### PR TITLE
docs: plain prose in four more READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ npm i -D @kensio/yulin
 
 ### Intercept AWS SDK clients
 
-If your code uses the AWS SDK, you can intercept AWS SDK clients and route their Commands to
-simulated AWS services. Your implementation code uses the SDK as normal and never needs to know that
-it's dealing with a simulator behind the scenes:
+If your code uses the AWS SDK, you can intercept its clients and route their Commands to simulated
+AWS services. Your implementation code uses the SDK as normal and never needs to know a simulator is
+answering:
 
 ```typescript
 import {
@@ -90,9 +90,9 @@ simSdk.restoreAll(); // Or `using simSdk = new SimSdk();` to restore on scope ex
 ```
 
 You can intercept a client class, as above, or a single client instance. The simulated Account and
-Region scope is resolved per send: the Region comes from the sending client's configuration, and
-the Account from the ambient `simAws.runAs(...)` caller when one is set, falling back to the
-simulation defaults.
+Region scope is resolved per send. The Region comes from the sending client's configuration, and the
+Account from the ambient `simAws.runAs(...)` caller when one is set, falling back to the simulation
+defaults.
 
 Each `SimSdk` owns its own isolated simulated AWS, available as `simSdk.simAws` when a test needs
 to seed or inspect simulated state directly. To share state with an existing simulation, wrap it
@@ -130,8 +130,8 @@ await simAws.region("eu-west-2").dynamoDb().createTable({ ... });
 await simAws.account("111111111111").region("eu-west-2").dynamoDb().createTable({ ... });
 ```
 
-AWS state is simulated internally, so you can test realistic interactions with multiple AWS
-services.
+AWS state is simulated internally. A test can drive realistic interactions across several AWS
+services at once.
 
 An Account ID is a plain string wherever one is accepted. Code that wants to name the type can get a
 `SimAwsAccountId` from `simAwsAccountId(...)`, which refuses anything that is not a 12-digit AWS
@@ -144,8 +144,8 @@ const accountId = simAwsAccountId("111111111111");
 const someOtherAccountId = makeSimAwsAccountId();
 ```
 
-Each instance of `SimAws` is cheap and encapsulated so you can create them wherever you need them.
-It's fine to create a new instance of `SimAws` in every test case or in shared test setup.
+Each instance of `SimAws` is cheap and encapsulated. Make one wherever you need it, in every test
+case or in shared test setup, whichever suits.
 
 If you prefer, you can also instantiate simulated services individually:
 
@@ -209,7 +209,7 @@ const res = await fetch(new URL("/foo/", bucketWebsiteUrl));
 #### Send requests without a port
 
 A test usually wants the same requests with nothing listening. `SimAwsHttp` answers a Fetch API
-`Request` with a `Response` in process, so there is no port for parallel test files to collide over,
+`Request` with a `Response` in process. There is no port for parallel test files to collide over,
 and no server to start or tear down:
 
 ```typescript
@@ -224,24 +224,24 @@ const simAwsHttp = new SimAwsHttp({ simAws });
 const response = await simAwsHttp.fetch("https://www.example.com/");
 ```
 
-Nothing binds a port, so a URL a simulated service gives out is fetched as it is, with no
-`localUrl(...)` adapting, and a hostname a simulated Route53 answers for is requested by its own
-name. Both routes go through the same authentication, routing and service code, so `serveSimAws` is
-what you want only when the request comes from outside the process. See the
-[serving docs](./docs/serve "Serving simulated AWS on localhost docs") for which to reach for.
+A URL a simulated service gives out is fetched as it is, with no `localUrl(...)` adapting, and a
+hostname a simulated Route53 answers for is requested by its own name. Both routes go through the
+same authentication, routing and service code. Reach for `serveSimAws` when the request comes from
+outside the process. See the
+[serving docs](./docs/serve "Serving simulated AWS on localhost docs") for how to choose.
 
 #### Restarting a served environment
 
-A served environment takes an available port by default, so the URL changes every time the process
+A served environment takes an available port by default. The URL changes every time the process
 starts. Pin a port to keep the URL the same across restarts:
 
 ```typescript
 const srv = await serveSimAws({ simAws, port: 4599 });
 ```
 
-Closing the server ends the connections it is holding, so the process can exit rather than being
-kept alive by a browser tab. Yulin does not install signal handlers, so call `close()` from your
-own:
+Closing the server ends the connections it is holding, and the process can then exit. An open
+browser tab would otherwise keep it alive. Yulin installs no signal handlers, so call `close()` from
+your own:
 
 ```typescript
 process.on("SIGTERM", () => {
@@ -250,12 +250,12 @@ process.on("SIGTERM", () => {
 ```
 
 A restart usually overlaps the process it is replacing. `listen` waits a couple of seconds for a
-pinned port that is still held, then throws `SimAwsLocalPortInUse` naming the port, which means
-something other than the outgoing process owns it.
+pinned port that is still held, then throws `SimAwsLocalPortInUse` naming the port. Something other
+than the outgoing process owns it by then.
 
 #### Reload the browser on a restart
 
-Yulin is the only thing in the response path of a page it serves, so it can tell the browser to
+Yulin is the only thing in the response path of a page it serves, and it can tell the browser to
 reload. Turning `liveReload` on puts a small script into the HTML pages served to browsers, and the
 page reloads itself when the process restarts:
 
@@ -273,16 +273,15 @@ the page refreshed:
 yulin watch -- tsx dev.ts
 ```
 
-It watches the working directory, plus the paths Yulin is holding that a module graph never mentions:
-a directory mounted into a Bucket, and a synthesized template. See the
+It watches the working directory. It also watches the paths Yulin is holding that a module graph
+never mentions, a directory mounted into a Bucket and a synthesized template. See the
 [serving docs](./docs/serve "Serving simulated AWS on localhost docs") for what gets the script, what
 is watched, and what is not.
 
 #### Update a stack when its template changes
 
-A synthesized template is data rather than code, so a change to one does not need the process
-restarted. Deploy it with `watch` and Yulin applies the file again whenever it changes, updating the
-stack in place:
+A synthesized template is data, and a change to one needs no restart. Deploy it with `watch` and
+Yulin applies the file again whenever it changes, updating the stack in place:
 
 ```typescript
 await simAws.cloudFormation().deployTemplateFile({
@@ -296,8 +295,8 @@ await simAws.cloudFormation().deployTemplateFile({
 ```
 
 Resources the change left alone keep what they hold, so simulated S3, DynamoDB and SQS survive a
-`cdk synth`. Under `yulin watch` the template is left to the process watching it rather than being a
-reason to restart. See the
+`cdk synth`. Under `yulin watch` the template is left to the process watching it, and never triggers
+a restart. See the
 [CloudFormation docs](./docs/services/cloudformation "Simulated CloudFormation docs") for what an
 update does to each resource.
 
@@ -328,37 +327,36 @@ await simAws.clock().advanceBy({ minutes: 20 });
 // Those session credentials have now expired.
 ```
 
-Advancing runs whatever falls due during the interval and returns once the simulation has settled,
-so the next line can assert. Time belongs to the `SimAws` instance, so moving it never disturbs
-another simulation, or the real clock. See the
+Advancing runs whatever falls due during the interval and returns once the simulation has settled.
+The next line can assert. Time belongs to the `SimAws` instance, so moving it never disturbs another
+simulation, or the real clock. See the
 [simulated time docs](./docs/time "Simulated time docs") for full usage.
 
-## What is yulin?
+## What is Yulin?
 
-TLDR: yulin is an AWS simulator for testing Node.js applications.
+TLDR: Yulin is an AWS simulator for testing Node.js applications.
 
-The simulation is not only local to the machine, but in the same single process
-with the test and application under test. No network or external i/o is
-involved. This is what "isolated" refers to.
+The simulation runs in the same single process as the test and the application
+under test, and not just on the same machine. No network or external i/o is
+involved. That is what "isolated" refers to.
 
 This "isolated system" approach to testing has a few advantages:
 
 - Tests run fast as everything is in memory with no real networking.
-- Test set-up is fast and uncomplicated, as there are no containers or extra
+- Test set-up is quick and uncomplicated, as there are no containers or extra
   dependencies to manage.
 - It's straightforward to use multiple other mocks and simulators alongside
-  yulin, such as [nock](https://github.com/nock/nock), as yulin makes no
+  Yulin, such as [nock](https://github.com/nock/nock), as Yulin makes no
   assumptions about the environment.
-- You can control everything in each isolated test process, such as controlling
-  the current time, even when multiple different AWS services are simulated.
+- You can control everything in each isolated test process, including the
+  current time, even when multiple different AWS services are simulated.
 - One test can cover **meaningful system behaviour** across multiple AWS
   services and applications, such as Lambdas sending events to SQS queues to be
   picked up by other Lambdas, or DynamoDB streams triggering Lambdas.
 
-That last point is the most important. The motivation behind yulin is to enable
-efficient tests that cover the logical behaviour of a system. That is in
-contrast to less valuable microscopic unit tests with fiddly mocks and brittle
-assertions. The goal of yulin is to allow you to test system behaviours that are
+That last point matters most. Yulin exists to make efficient tests that cover
+the logical behaviour of a system, in contrast to microscopic unit tests with
+fiddly mocks and brittle assertions. The behaviours worth testing are the ones
 meaningful to users and stakeholders.
 
 ## What's in a name?

--- a/docs/factories/README.md
+++ b/docs/factories/README.md
@@ -1,16 +1,16 @@
 # Event factories
 
 A handler is invoked with an event, and a test of a handler has to produce one. The events AWS
-delivers are large, most of each one is fields the handler never reads, and the two or three that
-the test is actually about are buried in them. Written out by hand, that literal is copied between
-files and drifts.
+delivers are large, most of each one is fields the handler never reads, and the two or three the
+test is about are buried in them. Written out by hand, that literal is copied between files and
+drifts.
 
-Yulin exports [`@kensio/part-factory`](https://partfactory.dev/) factories for those event shapes,
-so a test says what the request or the message was and nothing else. They are ordinary factories,
-made in-process, and need no `SimAws` instance and no simulated service running: a handler test that
-does not want a simulator is exactly who they are for. A test that does want one — a Function URL
-served over HTTP, a queue with a real event source mapping — gets its events from the simulator
-instead, and these factories make the same shapes that simulator delivers.
+Yulin exports [`@kensio/part-factory`](https://partfactory.dev/) factories for those event shapes. A
+test made with one says what the request or the message was and leaves the rest of the event alone.
+They are ordinary factories, made in-process, and they need no `SimAws` instance and no simulated
+service running. A handler test that runs without a simulator is who they are for. A test that does want
+one (a Function URL served over HTTP, a queue with a real event source mapping) gets its events from
+the simulator, and these factories make the same shapes that simulator delivers.
 
 ## What is exported
 
@@ -23,12 +23,12 @@ instead, and these factories make the same shapes that simulator delivers.
 | `s3NotificationEventFactory`, `s3NotificationEventRecordFactory`              | `@kensio/yulin/s3`           | An S3 event notification            |
 | `cloudFrontViewerRequestEventFactory`, `cloudFrontViewerResponseEventFactory` | `@kensio/yulin/cloudfront`   | A CloudFront Functions event        |
 
-Each service's own documentation covers what its events mean; this page is about how the factories
+Each service's own documentation covers what its events mean. This page is about how the factories
 are shaped and what they have in common.
 
 ## One factory per shape, and one per record
 
-An event that carries a list of records has two factories: one for a record and one for the event
+An event that carries a list of records has two factories, one for a record and one for the event
 around it. The record factory makes one record, and the event factory completes as many records as
 the test asks for.
 
@@ -68,17 +68,17 @@ const event = lambdaSqsEventFactory.make({
 console.log(ordersHandler(event));
 ```
 
-Passing partial records like that is the reason the event factory exists rather than the event being
-one more `DynamicFactory`. Overrides are merged onto defaults, and merging replaces a list whole
-rather than element by element, so partial records passed to a plain factory would reach the handler
-as the only thing in those records — typed as complete ones, and missing every field the handler
-reads.
+The event factory exists so a test can pass partial records like that. A `DynamicFactory` whose
+defaults hold one record would not manage it. Overrides are merged onto defaults, and merging
+replaces a list whole rather than element by element. A partial record passed that way would reach
+the handler as the only thing in those records, typed as a complete one and missing every field the
+handler reads.
 
 ## Named variations
 
-Every factory here is an `ItemFactory`, so a variation with a name is a `VariantFactory` around it,
-the same as for any other `part-factory` factory. That is usually the tidiest way to describe the
-kind of request or message one application receives:
+Every factory here is an `ItemFactory`. A variation with a name is a `VariantFactory` around it, the
+same as for any other `part-factory` factory. That is usually the tidiest way to describe the kind
+of request or message one application receives:
 
 ```typescript factories-variants
 /**
@@ -121,12 +121,12 @@ console.log(
 ## Events that agree with themselves
 
 A real AWS event says the same thing in more than one field, and those copies are where a
-hand-written literal goes wrong: a request for `/user/status` whose request context still says `/`,
-an SQS record whose digest is of a different body, a DynamoDB record that reports an insert and
-carries an old image.
+hand-written literal goes wrong. It asks for `/user/status` and leaves the request context saying
+`/`, or gives an SQS record the digest of some other body, or reports a DynamoDB insert on a record
+that carries an old image.
 
-Each factory's defaults are computed from the overrides, so supplying either copy settles the
-other. What that covers is listed in each factory's own documentation, and in outline it is:
+Each factory's defaults are computed from the overrides, so supplying either copy settles the other.
+What that covers is listed in each factory's own documentation, and in outline it is:
 
 - **Function URL and HTTP API events** — the path, the query, the route key, the endpoint's id,
   hostname and `host` header, the caller's user agent and address, and the invocation time
@@ -137,4 +137,4 @@ other. What that covers is listed in each factory's own documentation, and in ou
   have a size and an eTag
 
 Overriding both copies of one of those with different values is still allowed. A test that wants an
-event no real invocation would produce is entitled to one; it just has to ask for it twice.
+event no real invocation would produce is entitled to one. It just has to ask for it twice.

--- a/docs/lint/README.md
+++ b/docs/lint/README.md
@@ -1,23 +1,23 @@
 # Linting CloudFront Functions JS2
 
-CloudFront Functions run JS2, which is ECMAScript 5.1 plus a named subset of ES 6 to 12 rather than a
-current JavaScript engine. Code using a class, `for...of` or `fetch` is refused when the Function is
-published, which is a long way from where it was written. Yulin publishes lint configs that refuse
-the same things in the editor.
+CloudFront Functions run JS2, ECMAScript 5.1 with a named subset of ES 6 to 12 on top, rather than
+a current JavaScript engine. Code using a class, `for...of` or `fetch` is refused when
+the Function is published, a long way from where it was written. Yulin publishes lint configs that
+refuse the same things in the editor.
 
-The configs apply to `**/*.cff.js` files, which is the naming
+The configs apply to `**/*.cff.js` files. That is the naming
 [sim CloudFront](../services/cloudfront/ "Simulated CloudFront usage docs") already uses for
 CloudFront Function source.
 
 Every restriction comes from the runtime's
 [own feature list](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/functions-javascript-runtime-20.html),
-which is an allow-list: anything it does not name is unsupported. Nothing here is house style. A rule
+an allow-list, and anything outside it is unsupported. None of it is house style. A rule
 banning syntax JS2 accepts would send you away from code that works.
 
 ## Setting it up with ESLint
 
 `@kensio/yulin/eslint` exports a flat config to spread into your own. It restricts itself to
-`**/*.cff.js`, so the rest of your config still applies everywhere else.
+`**/*.cff.js`. The rest of your config still applies everywhere else.
 
 ```typescript cff-js2-eslint-config
 /**
@@ -37,18 +37,18 @@ export default defineConfig(
 );
 ```
 
-It goes after any config whose rules it needs to turn off, which is a short list. `const`, `let`,
-template literals, arrow functions, rest parameters and `async`/`await` all work in JS2, so the
+It goes after any config whose rules it needs to turn off. That is a short list. `const`, `let`,
+template literals, arrow functions, rest parameters and `async`/`await` all work in JS2, and the
 rules asking for them stay on. Only `object-shorthand` is switched off, because shorthand property
-names are ES 6 literal syntax the runtime does not have.
+names are ES 6 literal syntax the runtime lacks.
 
 `eslint` and `typescript-eslint` are optional peer dependencies, needed only if you use this export.
 
 ## Setting it up with Oxlint
 
 `@kensio/yulin/oxlint` ships the same rules as an Oxlint config fragment to extend. The rules
-themselves are one plugin loaded by both linters, so the two configs report the same things in the
-same places.
+themselves are one plugin loaded by both linters. The two configs report the same things in the same
+places.
 
 ```json
 {
@@ -61,9 +61,9 @@ same places.
 }
 ```
 
-Oxlint's `extends` takes a file path rather than a package name, so the path into `node_modules` is
-written out. The fragment brings its own `overrides` entry scoped to `**/*.cff.js` and the JS plugin
-the rules live in, and leaves every other file to your own rules.
+Oxlint's `extends` takes a file path rather than a package name. The path into `node_modules` is
+written out in full. The fragment brings its own `overrides` entry scoped to `**/*.cff.js` and the
+JS plugin the rules live in, and leaves every other file to your own rules.
 
 The plugin is loaded through Oxlint's JS plugin support, which needs Oxlint 1.77 or later.
 
@@ -83,17 +83,16 @@ Each restriction is its own rule, under the `cff-js2` name in both linters.
 | `cff-js2/no-for-of`             | `for...of`, in favour of an index-based loop             |
 | `cff-js2/no-unavailable-global` | Globals the runtime does not have, such as `fetch`       |
 
-`cff-js2/no-unavailable-global` covers `fetch`, `XMLHttpRequest` and `WebSocket`, which need a
-network the runtime does not have; `process`, which needs Node.js; and `setTimeout`, `setInterval`,
-`setImmediate` and `clearTimeout`, which need an event loop a Function does not get. It resolves
-names through scope rather than matching them as text, so a local variable named `fetch` and a
-property named `event.fetch` are both left alone. Each report says why the global is missing, because
-`fetch` being absent for want of a network and `setTimeout` for want of an event loop call for
-different rewrites.
+`cff-js2/no-unavailable-global` covers three groups. `fetch`, `XMLHttpRequest` and `WebSocket` need
+a network the runtime lacks. `process` needs Node.js. `setTimeout`, `setInterval`, `setImmediate`
+and `clearTimeout` need an event loop a Function never gets. The rule resolves names through scope
+rather than matching them as text, and a local variable named `fetch` or a property named
+`event.fetch` is left alone. Each report says why the global is missing, because `fetch` being
+absent for want of a network and `setTimeout` for want of an event loop call for different rewrites.
 
 Alongside these, both configs turn on `no-eval`, `no-new-func` and `no-implied-eval`, which the
-runtime refuses outright, and set `no-unused-vars` to leave `handler` alone, since it is the entry
-point CloudFront calls rather than something the file itself uses.
+runtime refuses outright. They also set `no-unused-vars` to leave `handler` alone, since it is the
+entry point CloudFront calls.
 
 ## What is not reported
 
@@ -105,13 +104,13 @@ These all work in JS2 and no rule here objects to them:
 - `async` and `await`
 - `Promise`, including `all`, `allSettled`, `any` and `race`
 - `Buffer`, and `require` of `querystring`, `crypto` or `buffer`
-- `import cf from "cloudfront"`, which is how a Function reaches `cf.kvs()` and
+- `import cf from "cloudfront"`, which a Function needs for `cf.kvs()` and
   `cf.updateRequestOrigin()`
 - `String.prototype.replaceAll`, `atob`, `btoa` and numeric separators
 
 ## Turning one restriction off
 
-Rules are individual, so a restriction you disagree with can be switched off on its own. In ESLint:
+Rules are individual. A restriction you disagree with can be switched off on its own. In ESLint:
 
 ```typescript cff-js2-eslint-relax
 /**
@@ -154,7 +153,7 @@ In Oxlint, the same thing goes in an `overrides` entry after the `extends`:
 - An Oxlint config fragment at `dist/config/oxlint/cffjs2.oxlintrc.json`, with the object it is
   generated from exported as `cloudFrontFunctionsJs2Oxlint` from `@kensio/yulin/oxlint`
 - Nine `cff-js2` rules, one per restriction, shared by both linters
-- Scoping to `**/*.cff.js`, so a repository's own rules are untouched elsewhere
+- Scoping to `**/*.cff.js`, leaving a repository's own rules untouched elsewhere
 
 ## Limitations
 
@@ -162,18 +161,18 @@ Where the configs knowingly stop short:
 
 - **`async` arguments and closures are not checked.** JS2 supports `async` and `await`, but not
   `async` arguments or closures, and `await` only inside an `async` function. Where the runtime's
-  wording stops short of saying exactly which forms those are, no rule guesses at it, so a Function
-  can pass the lint and still be refused for one.
+  wording stops short of saying exactly which forms those are, no rule guesses at it. A Function can
+  pass the lint and still be refused for one.
 - **The list of unavailable globals is the useful part of one, not all of it.** It names what test
-  code and Node habits reach for. A global outside that list is not reported, even if JS2 lacks it.
+  code and Node habits reach for. A global outside that list goes unreported, even if JS2 lacks it.
 - **The rules are syntactic.** Nothing here knows CloudFront's size limit on Function code or its CPU
-  budget, so a Function that passes the lint can still be refused at publication for being too large
-  or too slow. Nothing checks which methods of a supported built-in you call either, and the runtime
+  budget. A Function that passes the lint can still be refused at publication for being too large or
+  too slow. No rule checks which methods of a supported built-in you call either, and the runtime
   supports only some of them.
 - **Only the `cff-js2` rules are shared between the linters.** ESLint and Oxlint each bring their own
   built-in rules, and their own defaults for which are on. A `.cff.js` file linted by both may pick
-  up findings from one that the other does not have.
+  up findings from one that the other lacks.
 - **Oxlint's JS plugin support is in alpha.** It is what loads these rules into Oxlint, and its API
   is still moving upstream.
-- **The Oxlint fragment is extended by path.** Oxlint does not resolve a package name in `extends`,
-  so the path into `node_modules` is written out and depends on your installer's layout.
+- **The Oxlint fragment is extended by path.** Oxlint has no package-name resolution in `extends`.
+  The written-out path into `node_modules` depends on your installer's layout.

--- a/docs/lint/README.md
+++ b/docs/lint/README.md
@@ -1,9 +1,10 @@
 # Linting CloudFront Functions JS2
 
 CloudFront Functions run JS2, ECMAScript 5.1 with a named subset of ES 6 to 12 on top, rather than
-a current JavaScript engine. Code using a class, `for...of` or `fetch` is refused when
-the Function is published, a long way from where it was written. Yulin publishes lint configs that
-refuse the same things in the editor.
+a current JavaScript engine. A class or a `for...of` is a syntax error, and CloudFront refuses the
+code when you upload it. A call to `fetch` parses, and then fails at the edge, where that global is
+absent and there is no network to reach. Both are a long way from where the code was written, and
+Yulin publishes lint configs that refuse the same things in the editor.
 
 The configs apply to `**/*.cff.js` files. That is the naming
 [sim CloudFront](../services/cloudfront/ "Simulated CloudFront usage docs") already uses for

--- a/docs/non-aws-dependencies/README.md
+++ b/docs/non-aws-dependencies/README.md
@@ -12,9 +12,9 @@ Simulated AWS services are handled by Yulin. A DynamoDB call reaches an in-memor
 call reaches an in-memory bucket, with no network involved. [AWS SDK interception](../sdk/README.md)
 is how an ordinary SDK client in the code under test gets there.
 
-Everything else is yours to provide, and connects the way it normally would. Yulin does not
-simulate it, does not intercept it, and knows nothing about it. Code that opens a Redis connection
-opens a real one, to whatever address it was given.
+Everything else is yours to provide, and connects the way it normally would. Yulin leaves it alone
+entirely, with no simulation and no interception. Code that opens a Redis connection opens a real
+one, to whatever address it was given.
 
 ## Pointing the code at your own dependency
 
@@ -22,7 +22,7 @@ A deployed Lambda function or ECS container reads its connection details from en
 The simulated ones do the same. A function's `Environment.Variables` and a container definition's
 `environment` are visible through `process.env` while the code runs, so pointing the application
 somewhere else means setting the value it already reads. No Yulin feature is involved, and the code
-under test does not change.
+under test stays as it is.
 
 ```typescript non-aws-dependency-lambda
 /**
@@ -81,8 +81,8 @@ The worked example below runs one simulated ECS container that writes to a simul
 and reads from a cache of its own. The two categories sit next to each other in the same handler and
 are configured the same way, through the container definition's `environment`.
 
-The cache here is a stand-in defined by the example, so nothing has to be running for it to work. A
-real client built from `CACHE_URL` would go in the same place.
+The cache here is a stand-in defined by the example, and it works with no server running. A real
+client built from `CACHE_URL` would go in the same place.
 
 ```typescript non-aws-dependency-ecs
 /**
@@ -220,14 +220,14 @@ console.log(stored.Item?.["rate"]?.S); // "1.27"
 ```
 
 The DynamoDB write is authorized as the task role, in the same way it would be in a deployment. The
-cache read is not authorized by anything, because IAM has nothing to do with it.
+cache read passes through no authorization at all, because IAM has no part in it.
 
 ## Sidecar containers are not started
 
 A task definition sometimes declares the dependency itself as a second container, such as a Redis
-running next to the application in the same task. Yulin does not start it. It never looks inside a
-container image, and the only thing it can run is JavaScript or TypeScript in its own process, so
-there is nothing it could do with an image holding a Redis server.
+running next to the application in the same task. Yulin never looks inside a container image, and
+the only thing it can run is JavaScript or TypeScript in its own process. An image holding a Redis
+server is beyond it.
 
 The container is stored and reported back as declared, and it is recorded as not simulated when the
 task runs, with a reason saying so. An application expecting it has to be given something else to
@@ -238,8 +238,8 @@ run yourself or a stand-in, in the same way as for any other dependency of your 
 
 Handler code gets the function's or the container's variables while it runs, and reads the host
 process environment otherwise. A read at module scope, as in `const url = process.env.CACHE_URL` at
-the top of a file, happens when the test imports that file rather than when the code runs, so it
-sees the host value.
+the top of a file, happens when the test imports that file rather than when the code runs. It sees
+the host value.
 
 That matters here because a connection is often built at module scope. Read inside the handler, or
 build the client there, to get the configured value. Sim Lambda warns on the console when the
@@ -251,8 +251,8 @@ page. Zip code running in the vm runtime is unaffected, because it is imported d
 
 Current documented limitations:
 
-- Nothing outside the simulated AWS services is simulated or started. Anything else the code talks
-  to is yours to run and to tear down.
+- Everything outside the simulated AWS services is yours to run and to tear down. Yulin starts none
+  of it.
 - A dependency declared as a sidecar container in an ECS task definition is not started, because
   Yulin never runs a container image.
 - A connection built at module scope reads the host environment rather than the function's or the


### PR DESCRIPTION
Rewrites the prose in the top-level README and the factories, lint and non-AWS dependency doc pages.
Every code example is byte-identical, and `pnpm examples:check` re-extracts the `docs/*.example.ts`
files with no change. All four failed the prose checker on the measured sentence shapes, and three
carried banned marks. All four now score below the warn threshold on every pattern.

Worth a look from a reviewer:

- `docs/non-aws-dependencies/README.md` is a page about what Yulin declines to do, and the checker's
  negation rule fits it badly. Several conversions there are near-cosmetic, such as `nothing has to
  be running` becoming `it works with no server running`. The genuine absences are kept, including
  the `Sidecar containers are not started` heading and the sidecar and module-scope limitation
  bullets. The most rhetorically deliberate sentence in that file, `does not simulate it, does not
  intercept it, and knows nothing about it`, is now `leaves it alone entirely, with no simulation and
  no interception`. That one is worth a second opinion.
- The main README spelled the name lowercase in the `What is yulin?` section and capitalised it
  everywhere else. Prose is now `Yulin` throughout, with `yulin watch` and `@kensio/yulin` left
  alone. The GitHub anchor is unaffected by the heading change.
- Two edits drop a clause rather than reshaping it. `docs/lint` no longer says `handler` is the entry
  point CloudFront calls `rather than something the file itself uses`, and its sidecar paragraph no
  longer restates the heading before giving the reason.
- `docs/lint` keeps three `rather than` contrasts, each correcting a belief a reader would hold. JS2
  is not a current engine, scope resolution is not text matching, and Oxlint's `extends` wants a path
  and not a package name. That leaves the file at warn on that pattern, which is the top of the human
  range rather than outside it.

Two things noticed and left alone, both outside a prose rewrite. Nothing links to `docs/lint/` from
the main README's feature docs list. The Development section says "Install pnpm" above a `pnpm i`
that installs project dependencies.

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Yulin’s in-process, network-free isolation model and testing behavior.
  * Expanded guidance on AWS SDK interception, simulated state, instance isolation, server restarts, live reload, template watching, and simulated time.
  * Improved factory documentation covering partial records, named variations, defaults, and conflicting field overrides.
  * Clarified CloudFront Functions linting rules, runtime restrictions, configuration, and limitations.
  * Documented the behavior and limitations of non-AWS dependencies and user-provided services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->