### PR TITLE
feat: simulate publishing an SMS to a phone number

### DIFF
--- a/docs/services/sns/README.md
+++ b/docs/services/sns/README.md
@@ -149,7 +149,9 @@ console.log(published.MessageId !== undefined); // true
 
 The name and data type rules are the real ones. A name using a reserved `AWS.` or `Amazon.` prefix, a
 data type that is not `String`, `String.Array`, `Number` or `Binary`, or a value that does not match
-its data type is refused here rather than on AWS.
+its data type is refused here rather than on AWS. The two reserved names real SNS defines for SMS,
+`AWS.SNS.SMS.SenderID` and `AWS.SNS.SMS.SMSType`, are the exception. [Sending an SMS](#sending-an-sms)
+covers those.
 
 A `Subject` is UTF-8 text with no line breaks or control characters, of fewer than 100 characters,
 which is the contract real SNS states. A subject of exactly 100 characters is already too long. A
@@ -271,7 +273,7 @@ well, since one of the two would otherwise win silently.
 `AWS.SNS.SMS.SenderID` and `AWS.SNS.SMS.SMSType` are the two reserved attributes a publish may carry.
 Both are recorded, and the record reads them back as `senderId` and `smsType`. The other reserved SMS
 attributes are refused by name. `AWS.SNS.SMS.MaxPrice` caps what a message may cost, and
-`AWS.MM.SMS.OriginationNumber`, `AWS.SNS.SMS.EntityId` and `AWS.SNS.SMS.TemplateId` pick the routing
+`AWS.MM.SMS.OriginationNumber`, `AWS.MM.SMS.EntityId` and `AWS.MM.SMS.TemplateId` pick the routing
 and the registration it travels under. Each one changes a real send and would change nothing here.
 
 Real SNS puts a number on the opt-out list when the recipient replies STOP, and its API only takes
@@ -1683,8 +1685,8 @@ Current documented limitations:
   simulated, so a publish reaches a topic or a phone number.
 - An SMS is recorded and never delivered, and nothing models what a carrier would do with one. There
   is no message part splitting, no delivery receipt, no price and no throughput limit.
-- `AWS.SNS.SMS.MaxPrice`, `AWS.MM.SMS.OriginationNumber`, `AWS.SNS.SMS.EntityId` and
-  `AWS.SNS.SMS.TemplateId` are refused rather than recorded. Each one changes what real SNS does with
+- `AWS.SNS.SMS.MaxPrice`, `AWS.MM.SMS.OriginationNumber`, `AWS.MM.SMS.EntityId` and
+  `AWS.MM.SMS.TemplateId` are refused rather than recorded. Each one changes what real SNS does with
   a message, and accepting one that changed nothing would misrepresent the send.
 - `SetSMSAttributes` and `GetSMSAttributes`, which carry the account-wide SMS defaults and the spend
   limit, are not supported.

--- a/docs/services/sns/README.md
+++ b/docs/services/sns/README.md
@@ -6,7 +6,8 @@ every operation is authorized by simulated IAM.
 Standard topics only. SNS-specific types are imported from the `@kensio/yulin/sns` subpath.
 
 A message published to a topic is delivered to every queue subscribed to it, and invokes every Lambda
-function subscribed to it. Other subscription protocols are not simulated.
+function subscribed to it. Other subscription protocols are not simulated. A message published to a
+phone number is recorded as an SMS a test can assert on.
 
 ## Creating a topic and publishing to it
 
@@ -197,6 +198,95 @@ const published = await sns.publishBatch(
 console.log(published.Successful?.map((entry) => entry.Id)); // ["one"]
 console.log(published.Failed?.[0]?.Code); // "InvalidParameterValueException"
 ```
+
+## Sending an SMS
+
+A `Publish` that names a `PhoneNumber` sends an SMS to that number. The message stays inside the
+simulation. Simulated SNS records what it would have texted, and `sentSmsMessages()` on the service
+reads the records back, oldest first.
+
+```typescript sim-sns-sms
+/**
+ * Publishing an SMS to a phone number and reading the record back.
+ */
+
+import {
+  CheckIfPhoneNumberIsOptedOutCommand,
+  PublishCommand,
+} from "@aws-sdk/client-sns";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const sns = simAws.sns();
+
+const { MessageId } = await sns.publish(
+  new PublishCommand({
+    PhoneNumber: "+15550100",
+    Message: "Your code is 123456",
+    MessageAttributes: {
+      "AWS.SNS.SMS.SenderID": { DataType: "String", StringValue: "Orders" },
+      "AWS.SNS.SMS.SMSType": {
+        DataType: "String",
+        StringValue: "Transactional",
+      },
+    },
+  }),
+);
+
+const [sent] = sns.sentSmsMessages();
+
+console.log(sent?.phoneNumber); // "+15550100"
+console.log(sent?.message); // "Your code is 123456"
+console.log(sent?.senderId); // "Orders"
+console.log(sent?.suppressed); // false
+console.log(sent?.messageId === MessageId); // true
+
+// On real SNS a recipient opts out by replying STOP. Nothing in a test process
+// can reply, so the simulator does it.
+sns.optOutPhoneNumber("+15550100");
+
+await sns.publish(
+  new PublishCommand({
+    PhoneNumber: "+15550100",
+    Message: "Your code is 654321",
+  }),
+);
+
+const [, stopped] = sns.sentSmsMessages();
+
+console.log(stopped?.suppressed); // true
+
+const { isOptedOut } = await sns.checkIfPhoneNumberIsOptedOut(
+  new CheckIfPhoneNumberIsOptedOutCommand({ phoneNumber: "+15550100" }),
+);
+
+console.log(isOptedOut); // true
+```
+
+The number is E.164, a plus sign followed by up to fifteen digits. Anything else is refused with
+`InvalidParameterException`. A publish naming both a `TopicArn` and a `PhoneNumber` is refused as
+well, since one of the two would otherwise win silently.
+
+`AWS.SNS.SMS.SenderID` and `AWS.SNS.SMS.SMSType` are the two reserved attributes a publish may carry.
+Both are recorded, and the record reads them back as `senderId` and `smsType`. The other reserved SMS
+attributes are refused by name. `AWS.SNS.SMS.MaxPrice` caps what a message may cost, and
+`AWS.MM.SMS.OriginationNumber`, `AWS.SNS.SMS.EntityId` and `AWS.SNS.SMS.TemplateId` pick the routing
+and the registration it travels under. Each one changes a real send and would change nothing here.
+
+Real SNS puts a number on the opt-out list when the recipient replies STOP, and its API only takes
+numbers back off. Standing in for the handset is the simulator's job. `optOutPhoneNumber` on the
+service is what puts a number on the list, the same kind of accessor as `verifyIdentity` on simulated
+SES.
+
+A publish to a number on the list succeeds and answers with a `MessageId`, as it does on real SNS.
+The record for that message says `suppressed`. A test can then tell a message that would have arrived
+from one the opt-out list stopped. `CheckIfPhoneNumberIsOptedOutCommand` and
+`ListPhoneNumbersOptedOutCommand` read the list, and `OptInPhoneNumberCommand` takes a number back
+off it. Real SNS allows an opt-in once every thirty days per number, and that limit is absent here.
+
+The records and the opt-out list belong to one account and region, the way topics do. A message
+published in `eu-west-2` is invisible from `us-east-1`.
 
 ## Subscriptions
 
@@ -1503,6 +1593,11 @@ Sim SNS currently supports:
 - `GetTopicAttributesCommand` and `SetTopicAttributesCommand`, for `DisplayName` and `Policy`
 - `PublishCommand` and `PublishBatchCommand`, with message attributes, a subject and the 256 KB size
   limit
+- `PublishCommand` to a `PhoneNumber`, recorded as an SMS that `sentSmsMessages()` reads back, with
+  the `AWS.SNS.SMS.SenderID` and `AWS.SNS.SMS.SMSType` attributes
+- The phone number opt-out list, with `CheckIfPhoneNumberIsOptedOutCommand`,
+  `ListPhoneNumbersOptedOutCommand` and `OptInPhoneNumberCommand`, and `optOutPhoneNumber()` standing
+  in for a recipient replying STOP
 - `SubscribeCommand` over the `sqs` and `lambda` protocols, confirmed at once, and
   `UnsubscribeCommand`
 - `ListSubscriptionsCommand` and `ListSubscriptionsByTopicCommand`, paged at a hundred subscriptions
@@ -1584,8 +1679,19 @@ Current documented limitations:
   `MessageDeduplicationId` publish inputs.
 - `MessageStructure` is refused. A `json` structure picks a different message body per protocol, and
   picking one is not simulated, so it would be a body chosen by a rule that never ran.
-- Publishing to a `TargetArn` or a `PhoneNumber` is refused. Mobile application endpoints and SMS are
-  not simulated, so only a `TopicArn` can be published to.
+- Publishing to a `TargetArn` is refused. Mobile application endpoints and push notifications are not
+  simulated, so a publish reaches a topic or a phone number.
+- An SMS is recorded and never delivered, and nothing models what a carrier would do with one. There
+  is no message part splitting, no delivery receipt, no price and no throughput limit.
+- `AWS.SNS.SMS.MaxPrice`, `AWS.MM.SMS.OriginationNumber`, `AWS.SNS.SMS.EntityId` and
+  `AWS.SNS.SMS.TemplateId` are refused rather than recorded. Each one changes what real SNS does with
+  a message, and accepting one that changed nothing would misrepresent the send.
+- `SetSMSAttributes` and `GetSMSAttributes`, which carry the account-wide SMS defaults and the spend
+  limit, are not supported.
+- The SMS sandbox is not simulated. Real SNS only texts verified destination numbers until an account
+  leaves it. Yulin is a sandbox already, so every number here is reachable without verifying it
+  first.
+- The thirty day limit real SNS puts on opting one number back in is not simulated.
 - Message attributes count against the 256 KB publish limit alongside the message body, as they do on
   real SNS. The exact accounting AWS uses for one attribute is not documented, so this counts the
   bytes of the attribute's name, its data type and its value, which is stricter than counting the
@@ -1612,8 +1718,9 @@ Current documented limitations:
 - Message archiving and replay are not simulated, so `ArchivePolicy` is refused.
 - Delivery status logging writes to CloudWatch Logs, which is not simulated, so the feedback role and
   sample rate attributes are refused.
-- Platform applications and endpoints, subscribing over `http`, `https`, `email`, `email-json`,
-  `sms`, `application` and `firehose`, and SMS sandbox and opt-out management are not planned.
+- Platform applications and endpoints, and subscribing over `http`, `https`, `email`, `email-json`,
+  `sms`, `application` and `firehose`, are not supported. An SMS is reached by publishing to a phone
+  number, not yet by subscribing one to a topic.
 - SNS condition keys such as `sns:Endpoint` and `sns:Protocol` are not derived, so a policy relying on
   them will not match. Ordinary condition operators on values sim IAM does supply work as usual.
 - `FifoTopic: false` in a template fails the resource rather than deploying a standard topic. It is

--- a/docs/services/sns/sim-sns-sms.example.ts
+++ b/docs/services/sns/sim-sns-sms.example.ts
@@ -1,0 +1,56 @@
+/**
+ * Publishing an SMS to a phone number and reading the record back.
+ */
+
+import {
+  CheckIfPhoneNumberIsOptedOutCommand,
+  PublishCommand,
+} from "@aws-sdk/client-sns";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const sns = simAws.sns();
+
+const { MessageId } = await sns.publish(
+  new PublishCommand({
+    PhoneNumber: "+15550100",
+    Message: "Your code is 123456",
+    MessageAttributes: {
+      "AWS.SNS.SMS.SenderID": { DataType: "String", StringValue: "Orders" },
+      "AWS.SNS.SMS.SMSType": {
+        DataType: "String",
+        StringValue: "Transactional",
+      },
+    },
+  }),
+);
+
+const [sent] = sns.sentSmsMessages();
+
+console.log(sent?.phoneNumber); // "+15550100"
+console.log(sent?.message); // "Your code is 123456"
+console.log(sent?.senderId); // "Orders"
+console.log(sent?.suppressed); // false
+console.log(sent?.messageId === MessageId); // true
+
+// On real SNS a recipient opts out by replying STOP. Nothing in a test process
+// can reply, so the simulator does it.
+sns.optOutPhoneNumber("+15550100");
+
+await sns.publish(
+  new PublishCommand({
+    PhoneNumber: "+15550100",
+    Message: "Your code is 654321",
+  }),
+);
+
+const [, stopped] = sns.sentSmsMessages();
+
+console.log(stopped?.suppressed); // true
+
+const { isOptedOut } = await sns.checkIfPhoneNumberIsOptedOut(
+  new CheckIfPhoneNumberIsOptedOutCommand({ phoneNumber: "+15550100" }),
+);
+
+console.log(isOptedOut); // true

--- a/src/service/sns/README.md
+++ b/src/service/sns/README.md
@@ -179,6 +179,35 @@ whichever form it arrived in, because the data type already says which form that
 a `Binary` type carries bytes and any other carries text. There is no digest here, unlike simulated
 SQS, because a real SNS publish response carries no digest for a caller to check.
 
+## SMS
+
+SMS state lives under `sms/`, and the commands that reach it under `command/sms/` and
+`command/publish/sim-sns-publish-sms.ts`.
+
+`SimSnsPublishSms` is the half of `Publish` that reaches no topic. It authorizes `sns:Publish`
+against `*`, since there is no topic in the request for a policy to name, reads the message through
+the same `SimSnsPublishedMessage` a topic publish goes through, and records the result.
+
+`SimSnsSentSmsMessage` is one SMS this scope would have sent. Delivery stops at the simulator
+boundary, and the record is the whole of the feature. It carries a phone number, a body, the message
+attributes, an instant, and whether the opt-out list stopped it. Simulated SNS holds these itself,
+the way a simulated Cognito user pool holds the messages it would have texted. A simulated SMS
+service would put one record where two senders need their own.
+
+`SimSnsOptOutList` holds the numbers this scope will send nothing to. Real SNS has no API for putting
+one on, because the recipient does it by replying STOP, so `SimSns.optOutPhoneNumber` stands in for
+the handset. That is the same divergence, and the same reason for it, as `verifyIdentity` on
+simulated SES. A publish to a number on the list is accepted and answered with a message id, as it is
+on real SNS, and the record carries `suppressed` so that a test can tell the two apart.
+
+`SimSnsPhoneNumber` holds the E.164 check in one place. A number reaching the opt-out list or a
+record has been through it already.
+
+The reserved `AWS.SNS.SMS.` attribute names are listed in `message/sim-sns-sms-attributes.ts`, next
+to the general attribute name rules that would otherwise refuse every one of them for its reserved
+prefix. `SenderID` and `SMSType` are recorded. The rest are refused by name, because each changes
+what real SNS does with a message, and none of that behaviour exists here.
+
 ## Delivery
 
 Delivery lives under `delivery/`, and the signing that goes with it under `signature/`.
@@ -435,7 +464,11 @@ here, it does not make another Account's topics reachable through this one.
   `CreateTopic` or by `SetTopicAttributes`.
 - `MessageStructure` is refused, because a `json` structure picks a different body per protocol and
   picking one is not simulated.
-- Publishing to a `TargetArn` or a `PhoneNumber` is refused. Only topics are simulated.
+- Publishing to a `TargetArn` is refused, since mobile application endpoints are not simulated. A
+  publish reaches a topic or a phone number, and one naming both is refused.
+- An SMS is recorded and never delivered. Message part splitting, delivery receipts, pricing and
+  throughput limits are all absent, and so is the SMS sandbox. `AWS.SNS.SMS.MaxPrice` and the other
+  reserved attributes with behaviour behind them are refused rather than recorded.
 - `AddPermission` and `RemovePermission`, which are shorthands for writing one statement of the topic
   policy, are not implemented. The policy is set through the `Policy` attribute only.
 - A CloudFormation property with no simulated behaviour fails the Resource rather than being recorded

--- a/src/service/sns/command/publish/sim-sns-publish-commands.ts
+++ b/src/service/sns/command/publish/sim-sns-publish-commands.ts
@@ -12,10 +12,7 @@ import {
   requireSnsBatchEntries,
   runSnsBatch,
 } from "./sim-sns-batch-entries.js";
-import {
-  refuseUnsimulatedPublishTarget,
-  simSnsPublishedMessageInput,
-} from "./sim-sns-publish-input.js";
+import { simSnsPublishedMessageInput } from "./sim-sns-publish-input.js";
 import type {
   SimPublishBatchCommand,
   SimPublishBatchCommandOutput,
@@ -39,6 +36,9 @@ interface SimSnsPublishCommandsProperties {
 
 /**
  * The commands that publish messages to a topic.
+ *
+ * A publish reaches this once `SimSnsPublishDispatch` has decided it names a
+ * topic. Publishing to a phone number never arrives here.
  *
  * A topic keeps nothing a publish sends it. Real SNS hands a message to the
  * topic's subscriptions and forgets it, so a topic with no subscriptions
@@ -64,8 +64,6 @@ export class SimSnsPublishCommands {
     command: SimPublishCommand,
     options?: SimSnsRequestOptions,
   ): SimPublishCommandOutput {
-    refuseUnsimulatedPublishTarget(command.input);
-
     // The topic has to be there and the caller has to be allowed to publish to
     // it before anything is read out of the message.
     const topic = this.access.requireByArn(

--- a/src/service/sns/command/publish/sim-sns-publish-dispatch.ts
+++ b/src/service/sns/command/publish/sim-sns-publish-dispatch.ts
@@ -1,0 +1,67 @@
+import type { SimSnsRequestOptions } from "../sim-sns-request-options.js";
+import type { SimSnsPublishCommands } from "./sim-sns-publish-commands.js";
+import { refuseUnsimulatedPublishTarget } from "./sim-sns-publish-input.js";
+import type { SimSnsPublishSms } from "./sim-sns-publish-sms.js";
+import type {
+  SimPublishBatchCommand,
+  SimPublishBatchCommandOutput,
+  SimPublishCommand,
+  SimPublishCommandOutput,
+} from "./publish.command.js";
+
+interface SimSnsPublishDispatchProperties {
+  readonly topic: SimSnsPublishCommands;
+  readonly sms: SimSnsPublishSms;
+}
+
+/**
+ * Which of the two publishes a `Publish` request is.
+ *
+ * One SDK command name covers two operations that share a message and nothing
+ * else. A publish to a topic goes to the topic's subscriptions. A publish to a
+ * phone number reaches no topic, no subscription and no delivery endpoint, and
+ * is recorded as an SMS. Each has its own handler, and this is what reads the
+ * request to decide.
+ *
+ * The target refusals belong here, ahead of the decision, so that a request
+ * naming an unsimulated target is refused whichever way it would otherwise
+ * have gone.
+ *
+ * `PublishBatch` is only ever a topic publish, since the SNS API gives a batch
+ * entry no phone number field.
+ */
+export class SimSnsPublishDispatch {
+  private readonly topic: SimSnsPublishCommands;
+  private readonly sms: SimSnsPublishSms;
+
+  constructor(properties: SimSnsPublishDispatchProperties) {
+    this.topic = properties.topic;
+    this.sms = properties.sms;
+  }
+
+  /**
+   * Publish one message to a topic or to a phone number.
+   */
+  publish(
+    command: SimPublishCommand,
+    options?: SimSnsRequestOptions,
+  ): SimPublishCommandOutput {
+    refuseUnsimulatedPublishTarget(command.input);
+
+    if (command.input.PhoneNumber === undefined) {
+      return this.topic.publish(command, options);
+    }
+
+    return this.sms.publish(command.input, options);
+  }
+
+  /**
+   * Publish up to ten messages to a topic at once.
+   */
+  publishBatch(
+    command: SimPublishBatchCommand,
+    options?: SimSnsRequestOptions,
+  ): SimPublishBatchCommandOutput {
+    return this.topic.publishBatch(command, options);
+  }
+}

--- a/src/service/sns/command/publish/sim-sns-publish-input.ts
+++ b/src/service/sns/command/publish/sim-sns-publish-input.ts
@@ -1,4 +1,7 @@
-import { SimSnsUnsimulatedInputException } from "../../error/sim-sns.error.js";
+import {
+  SimSnsInvalidParameterException,
+  SimSnsUnsimulatedInputException,
+} from "../../error/sim-sns.error.js";
 import { SimSnsMessageAttributes } from "../../message/sim-sns-message-attributes.js";
 import type { SimSnsPublishedMessageInput } from "../../message/sim-sns-published-message.js";
 import type {
@@ -7,10 +10,10 @@ import type {
 } from "./publish.command.js";
 
 /**
- * Refuse a publish to somewhere other than a topic.
+ * Refuse a publish to somewhere other than a topic or a phone number.
  *
- * Real SNS publishes to a topic, to a mobile application endpoint, or to a
- * phone number. Only the topic is simulated, so the other two are refused
+ * Real SNS publishes to a topic, to a phone number, or to a mobile application
+ * endpoint. The endpoint is the one that is not simulated, so it is refused
  * rather than answered with a message id for a message that reached nothing.
  */
 export function refuseUnsimulatedPublishTarget(
@@ -19,14 +22,14 @@ export function refuseUnsimulatedPublishTarget(
   if (input.TargetArn !== undefined) {
     throw new SimSnsUnsimulatedInputException(
       "TargetArn publishes to a mobile application endpoint, which simulated " +
-        "SNS does not support. Publish to a TopicArn instead.",
+        "SNS does not support. Publish to a TopicArn or a PhoneNumber instead.",
     );
   }
 
-  if (input.PhoneNumber !== undefined) {
-    throw new SimSnsUnsimulatedInputException(
-      "PhoneNumber publishes an SMS message, which simulated SNS does not " +
-        "support. Publish to a TopicArn instead.",
+  if (input.TopicArn !== undefined && input.PhoneNumber !== undefined) {
+    throw new SimSnsInvalidParameterException(
+      "Invalid parameter: A publish names a TopicArn or a PhoneNumber, and " +
+        "this one names both",
     );
   }
 }

--- a/src/service/sns/command/publish/sim-sns-publish-sms-refusals.iso.test.ts
+++ b/src/service/sns/command/publish/sim-sns-publish-sms-refusals.iso.test.ts
@@ -49,7 +49,7 @@ describe("SNS publish to a phone number refusals", () => {
       [
         "AWS.SNS.SMS.MaxPrice",
         "AWS.MM.SMS.OriginationNumber",
-        "AWS.SNS.SMS.EntityId",
+        "AWS.MM.SMS.EntityId",
       ].map(async (attributeName) =>
         assertThrowsErrorAsync(async () => {
           await simAws.sns().publish(

--- a/src/service/sns/command/publish/sim-sns-publish-sms-refusals.iso.test.ts
+++ b/src/service/sns/command/publish/sim-sns-publish-sms-refusals.iso.test.ts
@@ -1,0 +1,74 @@
+import { PublishCommand } from "@aws-sdk/client-sns";
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimSnsInvalidParameterException,
+  SimSnsUnsimulatedInputException,
+} from "../../error/sim-sns.error.js";
+
+const phoneNumber = "+15550100";
+
+describe("SNS publish to a phone number refusals", () => {
+  it("refuses a phone number that is not in E.164 form", async () => {
+    // Given a simulated SNS.
+    const simAws = new SimAws();
+
+    // When each badly formatted number is published to.
+    const refusals = await Promise.all(
+      ["5550100", "+0555010", "+1555abc0100", "+1555010012345678"].map(
+        async (badNumber) =>
+          assertThrowsErrorAsync(async () => {
+            await simAws
+              .sns()
+              .publish(
+                new PublishCommand({ PhoneNumber: badNumber, Message: "hi" }),
+              );
+          }),
+      ),
+    );
+
+    // Then each is refused the way real SNS refuses a parameter it will not
+    // take, naming the parameter.
+    for (const error of refusals) {
+      assertInstanceOf(error, SimSnsInvalidParameterException);
+      assertStringIncludes(error.message, "PhoneNumber");
+    }
+  });
+
+  it("refuses the reserved SMS attributes it would act on and does not", async () => {
+    // Given a simulated SNS.
+    const simAws = new SimAws();
+
+    // When a publish carries one of the reserved attributes real SNS acts on.
+    const refusals = await Promise.all(
+      [
+        "AWS.SNS.SMS.MaxPrice",
+        "AWS.MM.SMS.OriginationNumber",
+        "AWS.SNS.SMS.EntityId",
+      ].map(async (attributeName) =>
+        assertThrowsErrorAsync(async () => {
+          await simAws.sns().publish(
+            new PublishCommand({
+              PhoneNumber: phoneNumber,
+              Message: "hi",
+              MessageAttributes: {
+                [attributeName]: { DataType: "String", StringValue: "0.50" },
+              },
+            }),
+          );
+        }),
+      ),
+    );
+
+    // Then each is refused, since a price cap that capped nothing would be one
+    // a test believed was applied.
+    for (const error of refusals) {
+      assertInstanceOf(error, SimSnsUnsimulatedInputException);
+    }
+  });
+});

--- a/src/service/sns/command/publish/sim-sns-publish-sms.iso.test.ts
+++ b/src/service/sns/command/publish/sim-sns-publish-sms.iso.test.ts
@@ -1,0 +1,173 @@
+import { OptInPhoneNumberCommand, PublishCommand } from "@aws-sdk/client-sns";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimFixedClock } from "../../../../util/clock/sim-clock.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+
+const sentAt = new Date("2026-08-17T09:00:00.000Z");
+
+/** The number every test here texts. */
+const phoneNumber = "+15550100";
+
+describe("SNS publish to a phone number", () => {
+  it("records the SMS it would have sent", async () => {
+    // Given a simulated SNS with a fixed clock.
+    const simAws = new SimAws({ clock: new SimFixedClock(sentAt) });
+
+    // When a message is published straight to a phone number.
+    const published = await simAws
+      .sns()
+      .publish(
+        new PublishCommand({ PhoneNumber: phoneNumber, Message: "code 12345" }),
+      );
+
+    // Then SNS answered with a message id, and kept what it would have texted.
+    const [sms] = simAws.sns().sentSmsMessages();
+
+    assertNonNullable(sms);
+    assertIdentical(sms.messageId, published.MessageId);
+    assertIdentical(sms.phoneNumber, phoneNumber);
+    assertIdentical(sms.message, "code 12345");
+    assertIdentical(sms.sentDate.getTime(), sentAt.getTime());
+    assertFalse(sms.suppressed);
+  });
+
+  it("records the sender id and the message type", async () => {
+    // Given a simulated SNS.
+    const simAws = new SimAws();
+
+    // When a message carries the SMS attributes real SNS reads.
+    await simAws.sns().publish(
+      new PublishCommand({
+        PhoneNumber: phoneNumber,
+        Message: "code 12345",
+        MessageAttributes: {
+          "AWS.SNS.SMS.SenderID": { DataType: "String", StringValue: "Orders" },
+          "AWS.SNS.SMS.SMSType": {
+            DataType: "String",
+            StringValue: "Transactional",
+          },
+        },
+      }),
+    );
+
+    // Then both are on the record, along with the attributes they came from.
+    const [sms] = simAws.sns().sentSmsMessages();
+
+    assertNonNullable(sms);
+    assertIdentical(sms.senderId, "Orders");
+    assertIdentical(sms.smsType, "Transactional");
+    assertArrayLength(sms.attributes.all, 2);
+  });
+
+  it("reports neither where the publish set neither", async () => {
+    // Given a simulated SNS.
+    const simAws = new SimAws();
+
+    // When a message carries no attributes.
+    await simAws
+      .sns()
+      .publish(
+        new PublishCommand({ PhoneNumber: phoneNumber, Message: "code 12345" }),
+      );
+
+    // Then the record reports nothing for either, so a test asserting on a
+    // sender id finds the absence rather than an empty string.
+    const [sms] = simAws.sns().sentSmsMessages();
+
+    assertNonNullable(sms);
+    assertUndefined(sms.senderId);
+    assertUndefined(sms.smsType);
+  });
+
+  it("keeps the messages in the order they were published", async () => {
+    // Given a simulated SNS.
+    const simAws = new SimAws();
+
+    // When two messages go to the same number.
+    await simAws
+      .sns()
+      .publish(
+        new PublishCommand({ PhoneNumber: phoneNumber, Message: "one" }),
+      );
+    await simAws
+      .sns()
+      .publish(
+        new PublishCommand({ PhoneNumber: phoneNumber, Message: "two" }),
+      );
+
+    // Then the first message of the flow is the first one recorded.
+    const [first, second] = simAws.sns().sentSmsMessages();
+
+    assertIdentical(first?.message, "one");
+    assertIdentical(second?.message, "two");
+  });
+
+  it("accepts a publish to an opted-out number and suppresses it", async () => {
+    // Given a number that has replied STOP.
+    const simAws = new SimAws();
+
+    simAws.sns().optOutPhoneNumber(phoneNumber);
+
+    // When a message is published to it.
+    const published = await simAws
+      .sns()
+      .publish(
+        new PublishCommand({ PhoneNumber: phoneNumber, Message: "code 12345" }),
+      );
+
+    // Then the publish succeeded the way real SNS succeeds, and the record
+    // says the opt-out list stopped the message.
+    assertNonNullable(published.MessageId);
+
+    const [sms] = simAws.sns().sentSmsMessages();
+
+    assertNonNullable(sms);
+    assertTrue(sms.suppressed);
+    assertIdentical(sms.messageId, published.MessageId);
+  });
+
+  it("sends again once the number is opted back in", async () => {
+    // Given a number that was opted out and then opted back in.
+    const simAws = new SimAws();
+
+    simAws.sns().optOutPhoneNumber(phoneNumber);
+    await simAws
+      .sns()
+      .optInPhoneNumber(new OptInPhoneNumberCommand({ phoneNumber }));
+
+    // When a message is published to it.
+    await simAws
+      .sns()
+      .publish(
+        new PublishCommand({ PhoneNumber: phoneNumber, Message: "code 12345" }),
+      );
+
+    // Then the message would have arrived.
+    const [sms] = simAws.sns().sentSmsMessages();
+
+    assertFalse(sms?.suppressed);
+  });
+
+  it("keeps the messages of one Region out of another", async () => {
+    // Given two Regions of one Account.
+    const simAws = new SimAws();
+    const london = simAws.region("eu-west-2").account().sns();
+
+    // When a message is published in one of them.
+    await london.publish(
+      new PublishCommand({ PhoneNumber: phoneNumber, Message: "code 12345" }),
+    );
+
+    // Then the other Region has no record of it.
+    assertArrayLength(london.sentSmsMessages(), 1);
+    assertArrayLength(simAws.sns().sentSmsMessages(), 0);
+  });
+});

--- a/src/service/sns/command/publish/sim-sns-publish-sms.ts
+++ b/src/service/sns/command/publish/sim-sns-publish-sms.ts
@@ -1,0 +1,87 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import {
+  assertSimSnsMessageWithinLimit,
+  SimSnsPublishedMessage,
+} from "../../message/sim-sns-published-message.js";
+import type { SimSnsOptOutList } from "../../sms/sim-sns-opt-out-list.js";
+import { SimSnsPhoneNumber } from "../../sms/sim-sns-phone-number.js";
+import { SimSnsSentSmsMessage } from "../../sms/sim-sns-sent-sms-message.js";
+import type { SimSnsSentSmsStore } from "../../sms/sim-sns-sent-sms-store.js";
+import type { SimSnsRequestOptions } from "../sim-sns-request-options.js";
+import type { SimSnsTopicAccess } from "../topic/sim-sns-topic-access.js";
+import { simSnsPublishedMessageInput } from "./sim-sns-publish-input.js";
+import type {
+  SimPublishCommandInput,
+  SimPublishCommandOutput,
+} from "./publish.command.js";
+
+/**
+ * Real SNS authorizes an SMS publish as `sns:Publish` against `*`, since there
+ * is no topic in the request for a policy to name.
+ */
+const publishAction = "sns:Publish";
+
+interface SimSnsPublishSmsProperties {
+  readonly access: SimSnsTopicAccess;
+  readonly clock: BackgroundScheduler;
+  readonly optOutList: SimSnsOptOutList;
+  readonly sent: SimSnsSentSmsStore;
+}
+
+/**
+ * Publishing straight to a phone number.
+ *
+ * This is the half of `Publish` that reaches no topic. Real SNS hands the
+ * message to a carrier and tells the publisher a message id, and the publisher
+ * hears nothing more about it. There is no carrier here to hand it to. The
+ * message is recorded, and the publisher gets the same message id it would
+ * have got on AWS.
+ */
+export class SimSnsPublishSms {
+  private readonly access: SimSnsTopicAccess;
+  private readonly clock: BackgroundScheduler;
+  private readonly optOutList: SimSnsOptOutList;
+  private readonly sent: SimSnsSentSmsStore;
+
+  constructor(properties: SimSnsPublishSmsProperties) {
+    this.access = properties.access;
+    this.clock = properties.clock;
+    this.optOutList = properties.optOutList;
+    this.sent = properties.sent;
+  }
+
+  /**
+   * Publish one SMS to a phone number.
+   *
+   * A number on the opt-out list still gets a message id, because that is what
+   * real SNS answers a publish it accepts and then delivers nowhere. The
+   * record says the opt-out list stopped it.
+   */
+  publish(
+    input: SimPublishCommandInput,
+    options?: SimSnsRequestOptions,
+  ): SimPublishCommandOutput {
+    this.access.authorizeAnyTopic(publishAction, options);
+
+    const phoneNumber = SimSnsPhoneNumber.of(input.PhoneNumber);
+    const message = SimSnsPublishedMessage.of(
+      simSnsPublishedMessageInput(input),
+      this.clock.now(),
+    );
+
+    assertSimSnsMessageWithinLimit(message.byteSize);
+
+    this.sent.add(
+      new SimSnsSentSmsMessage({
+        messageId: message.messageId,
+        phoneNumber: phoneNumber.value,
+        message: message.body.value,
+        attributes: message.attributes,
+        suppressed: this.optOutList.isOptedOut(phoneNumber),
+        sentDate: message.publishedAt,
+      }),
+    );
+
+    return { $metadata: {}, MessageId: message.messageId };
+  }
+}

--- a/src/service/sns/command/publish/sim-sns-unsimulated-publish.iso.test.ts
+++ b/src/service/sns/command/publish/sim-sns-unsimulated-publish.iso.test.ts
@@ -2,7 +2,10 @@ import { PublishCommand } from "@aws-sdk/client-sns";
 import { assertInstanceOf, assertThrowsErrorAsync } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { simAwsWithTopic } from "../../../../../test/sns/topic-fixture.js";
-import { SimSnsUnsimulatedInputException } from "../../error/sim-sns.error.js";
+import {
+  SimSnsInvalidParameterException,
+  SimSnsUnsimulatedInputException,
+} from "../../error/sim-sns.error.js";
 
 describe("SNS unsimulated publish input", () => {
   it("refuses the publish inputs that are not simulated", async () => {
@@ -13,7 +16,6 @@ describe("SNS unsimulated publish input", () => {
     const refusals = await Promise.all(
       [
         { TargetArn: "arn:aws:sns:us-east-1:888888888888:endpoint/APNS/app/1" },
-        { PhoneNumber: "+15550100" },
         { TopicArn: topicArn, MessageStructure: "json" },
         { TopicArn: topicArn, MessageGroupId: "orders" },
         { TopicArn: topicArn, MessageDeduplicationId: "order-1" },
@@ -31,5 +33,24 @@ describe("SNS unsimulated publish input", () => {
     for (const error of refusals) {
       assertInstanceOf(error, SimSnsUnsimulatedInputException);
     }
+  });
+
+  it("refuses a publish naming both a topic and a phone number", async () => {
+    // Given a topic.
+    const { simAws, topicArn } = await simAwsWithTopic();
+
+    // When a publish names both targets.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sns().publish(
+        new PublishCommand({
+          TopicArn: topicArn,
+          PhoneNumber: "+15550100",
+          Message: "order-1",
+        }),
+      );
+    });
+
+    // Then it is refused rather than one of the two silently winning.
+    assertInstanceOf(error, SimSnsInvalidParameterException);
   });
 });

--- a/src/service/sns/command/sim-sns-command.types.ts
+++ b/src/service/sns/command/sim-sns-command.types.ts
@@ -42,6 +42,17 @@ export type {
   SimUnsubscribeCommandOutput,
 } from "./subscription/subscription.command.js";
 export type {
+  SimCheckIfPhoneNumberIsOptedOutCommand,
+  SimCheckIfPhoneNumberIsOptedOutCommandInput,
+  SimCheckIfPhoneNumberIsOptedOutCommandOutput,
+  SimListPhoneNumbersOptedOutCommand,
+  SimListPhoneNumbersOptedOutCommandInput,
+  SimListPhoneNumbersOptedOutCommandOutput,
+  SimOptInPhoneNumberCommand,
+  SimOptInPhoneNumberCommandInput,
+  SimOptInPhoneNumberCommandOutput,
+} from "./sms/sms.command.js";
+export type {
   SimPublishBatchCommand,
   SimPublishBatchCommandInput,
   SimPublishBatchCommandOutput,

--- a/src/service/sns/command/sim-sns-commands.ts
+++ b/src/service/sns/command/sim-sns-commands.ts
@@ -7,8 +7,13 @@ import { SimSnsFanOut } from "../delivery/sim-sns-fan-out.js";
 import { SimSnsMessageSigner } from "../signature/sim-sns-message-signer.js";
 import type { SimSnsSubscriptionStore } from "../subscription/sim-sns-subscription-store.js";
 import type { SimSnsTopicStore } from "../topic/sim-sns-topic-store.js";
+import { SimSnsOptOutList } from "../sms/sim-sns-opt-out-list.js";
+import { SimSnsSentSmsStore } from "../sms/sim-sns-sent-sms-store.js";
 import { SimSnsAuthorizer } from "./authorize/sim-sns-authorizer.js";
 import { SimSnsPublishCommands } from "./publish/sim-sns-publish-commands.js";
+import { SimSnsPublishDispatch } from "./publish/sim-sns-publish-dispatch.js";
+import { SimSnsPublishSms } from "./publish/sim-sns-publish-sms.js";
+import { SimSnsOptOutCommands } from "./sms/sim-sns-opt-out-commands.js";
 import { SimSnsSubscriptionAccess } from "./subscription/sim-sns-subscription-access.js";
 import { SimSnsSubscriptionAttributeCommands } from "./subscription/sim-sns-subscription-attribute-commands.js";
 import { SimSnsSubscriptionCommands } from "./subscription/sim-sns-subscription-commands.js";
@@ -42,9 +47,16 @@ export class SimSnsCommands {
   public readonly subscriptions: SimSnsSubscriptionCommands;
   public readonly subscriptionListings: SimSnsSubscriptionListings;
   public readonly subscriptionAttributes: SimSnsSubscriptionAttributeCommands;
-  public readonly publish: SimSnsPublishCommands;
+  public readonly publish: SimSnsPublishDispatch;
+  public readonly optOut: SimSnsOptOutCommands;
   public readonly fanOut: SimSnsFanOut;
   public readonly signer: SimSnsMessageSigner;
+
+  /** Every SMS this scope would have sent, delivered or suppressed. */
+  public readonly sentSms = new SimSnsSentSmsStore();
+
+  /** The numbers this scope will send no SMS to. */
+  public readonly optOutList = new SimSnsOptOutList();
 
   constructor(properties: SimSnsCommandsProperties) {
     const { topics, subscriptions, accountRegionScope, background } =
@@ -92,10 +104,22 @@ export class SimSnsCommands {
     this.subscriptionAttributes = new SimSnsSubscriptionAttributeCommands({
       access: subscriptionAccess,
     });
-    this.publish = new SimSnsPublishCommands({
+    this.publish = new SimSnsPublishDispatch({
+      topic: new SimSnsPublishCommands({
+        access,
+        clock: background,
+        fanOut: this.fanOut,
+      }),
+      sms: new SimSnsPublishSms({
+        access,
+        clock: background,
+        optOutList: this.optOutList,
+        sent: this.sentSms,
+      }),
+    });
+    this.optOut = new SimSnsOptOutCommands({
       access,
-      clock: background,
-      fanOut: this.fanOut,
+      optOutList: this.optOutList,
     });
   }
 }

--- a/src/service/sns/command/sms/sim-sns-opt-out-commands.ts
+++ b/src/service/sns/command/sms/sim-sns-opt-out-commands.ts
@@ -1,0 +1,91 @@
+import type { SimSnsOptOutList } from "../../sms/sim-sns-opt-out-list.js";
+import { SimSnsPhoneNumber } from "../../sms/sim-sns-phone-number.js";
+import { SimSnsPage } from "../sim-sns-page.js";
+import type { SimSnsRequestOptions } from "../sim-sns-request-options.js";
+import type { SimSnsTopicAccess } from "../topic/sim-sns-topic-access.js";
+import type {
+  SimCheckIfPhoneNumberIsOptedOutCommand,
+  SimCheckIfPhoneNumberIsOptedOutCommandOutput,
+  SimListPhoneNumbersOptedOutCommand,
+  SimListPhoneNumbersOptedOutCommandOutput,
+  SimOptInPhoneNumberCommand,
+  SimOptInPhoneNumberCommandOutput,
+} from "./sms.command.js";
+
+interface SimSnsOptOutCommandsProperties {
+  readonly access: SimSnsTopicAccess;
+  readonly optOutList: SimSnsOptOutList;
+}
+
+/**
+ * The commands that read and unwind the phone number opt-out list.
+ *
+ * None of them names a topic, so each authorizes against `*` the way
+ * `ListTopics` does. A policy naming a topic ARN allows none of them, here as
+ * on AWS.
+ *
+ * There is no command for opting a number out. Real SNS puts a number on the
+ * list when the recipient replies STOP, and `SimSns.optOutPhoneNumber` stands
+ * in for the handset.
+ */
+export class SimSnsOptOutCommands {
+  private readonly access: SimSnsTopicAccess;
+  private readonly optOutList: SimSnsOptOutList;
+
+  constructor(properties: SimSnsOptOutCommandsProperties) {
+    this.access = properties.access;
+    this.optOutList = properties.optOutList;
+  }
+
+  /**
+   * Say whether a number is opted out of receiving SMS.
+   */
+  checkIfPhoneNumberIsOptedOut(
+    command: SimCheckIfPhoneNumberIsOptedOutCommand,
+    options?: SimSnsRequestOptions,
+  ): SimCheckIfPhoneNumberIsOptedOutCommandOutput {
+    this.access.authorizeAnyTopic("sns:CheckIfPhoneNumberIsOptedOut", options);
+
+    const phoneNumber = SimSnsPhoneNumber.of(command.input.phoneNumber);
+
+    return {
+      $metadata: {},
+      isOptedOut: this.optOutList.isOptedOut(phoneNumber),
+    };
+  }
+
+  /**
+   * List the opted-out numbers, in the order they were opted out.
+   */
+  listPhoneNumbersOptedOut(
+    command: SimListPhoneNumbersOptedOutCommand,
+    options?: SimSnsRequestOptions,
+  ): SimListPhoneNumbersOptedOutCommandOutput {
+    this.access.authorizeAnyTopic("sns:ListPhoneNumbersOptedOut", options);
+
+    const page = new SimSnsPage(this.optOutList.all, command.input.nextToken);
+
+    return {
+      $metadata: {},
+      phoneNumbers: page.items,
+      ...(page.nextToken !== undefined && { nextToken: page.nextToken }),
+    };
+  }
+
+  /**
+   * Take a number back off the opt-out list.
+   *
+   * A number that was never on it succeeds and changes nothing, as it does on
+   * real SNS.
+   */
+  optInPhoneNumber(
+    command: SimOptInPhoneNumberCommand,
+    options?: SimSnsRequestOptions,
+  ): SimOptInPhoneNumberCommandOutput {
+    this.access.authorizeAnyTopic("sns:OptInPhoneNumber", options);
+
+    this.optOutList.optIn(SimSnsPhoneNumber.of(command.input.phoneNumber));
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/sns/command/sms/sim-sns-opt-out-paging.iso.test.ts
+++ b/src/service/sns/command/sms/sim-sns-opt-out-paging.iso.test.ts
@@ -1,0 +1,29 @@
+import { ListPhoneNumbersOptedOutCommand } from "@aws-sdk/client-sns";
+import { assertArrayLength, assertUndefined } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+
+describe("SNS opt-out list paging", () => {
+  it("pages the listing at a hundred numbers", async () => {
+    // Given more opted-out numbers than one page holds.
+    const sns = new SimAws().sns();
+
+    for (let index = 0; index < 101; index++) {
+      sns.optOutPhoneNumber(`+1555${String(index).padStart(6, "0")}`);
+    }
+
+    // When the first page is read, and then the second.
+    const first = await sns.listPhoneNumbersOptedOut(
+      new ListPhoneNumbersOptedOutCommand({}),
+    );
+    const second = await sns.listPhoneNumbersOptedOut(
+      new ListPhoneNumbersOptedOutCommand({ nextToken: first.nextToken }),
+    );
+
+    // Then the first page carries a token to the second, and the second
+    // carries none, as real SNS pages its listings.
+    assertArrayLength(first.phoneNumbers ?? [], 100);
+    assertArrayLength(second.phoneNumbers ?? [], 1);
+    assertUndefined(second.nextToken);
+  });
+});

--- a/src/service/sns/command/sms/sim-sns-opt-out.iso.test.ts
+++ b/src/service/sns/command/sms/sim-sns-opt-out.iso.test.ts
@@ -1,0 +1,133 @@
+import {
+  CheckIfPhoneNumberIsOptedOutCommand,
+  ListPhoneNumbersOptedOutCommand,
+  OptInPhoneNumberCommand,
+  PublishCommand,
+} from "@aws-sdk/client-sns";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertFalse,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimSnsInvalidParameterException } from "../../error/sim-sns.error.js";
+
+const phoneNumber = "+15550100";
+const otherNumber = "+15550101";
+
+describe("SNS phone number opt-out list", () => {
+  it("reports a number the simulator opted out", async () => {
+    // Given a number that has replied STOP.
+    const sns = new SimAws().sns();
+
+    sns.optOutPhoneNumber(phoneNumber);
+
+    // When each number is checked.
+    const optedOut = await sns.checkIfPhoneNumberIsOptedOut(
+      new CheckIfPhoneNumberIsOptedOutCommand({ phoneNumber }),
+    );
+    const other = await sns.checkIfPhoneNumberIsOptedOut(
+      new CheckIfPhoneNumberIsOptedOutCommand({ phoneNumber: otherNumber }),
+    );
+
+    // Then only the one that replied STOP is opted out.
+    assertTrue(optedOut.isOptedOut);
+    assertFalse(other.isOptedOut);
+  });
+
+  it("lists the numbers in the order they were opted out", async () => {
+    // Given two numbers that have replied STOP.
+    const sns = new SimAws().sns();
+
+    sns.optOutPhoneNumber(otherNumber);
+    sns.optOutPhoneNumber(phoneNumber);
+
+    // When the list is read.
+    const listed = await sns.listPhoneNumbersOptedOut(
+      new ListPhoneNumbersOptedOutCommand({}),
+    );
+
+    // Then both are on it, oldest first, and one page holds them.
+    assertArrayEquals(listed.phoneNumbers ?? [], [otherNumber, phoneNumber]);
+    assertUndefined(listed.nextToken);
+  });
+
+  it("takes a number back off the list", async () => {
+    // Given a number on the opt-out list.
+    const sns = new SimAws().sns();
+
+    sns.optOutPhoneNumber(phoneNumber);
+
+    // When it is opted back in.
+    await sns.optInPhoneNumber(new OptInPhoneNumberCommand({ phoneNumber }));
+
+    // Then the list is empty again.
+    const listed = await sns.listPhoneNumbersOptedOut(
+      new ListPhoneNumbersOptedOutCommand({}),
+    );
+
+    assertArrayLength(listed.phoneNumbers ?? [], 0);
+  });
+
+  it("takes an opt-in for a number that was never opted out", async () => {
+    // Given a simulated SNS with an empty opt-out list.
+    const sns = new SimAws().sns();
+
+    // When a number that was never on the list is opted in.
+    await sns.optInPhoneNumber(new OptInPhoneNumberCommand({ phoneNumber }));
+
+    // Then it succeeds and changes nothing, as it does on real SNS.
+    const listed = await sns.listPhoneNumbersOptedOut(
+      new ListPhoneNumbersOptedOutCommand({}),
+    );
+
+    assertArrayLength(listed.phoneNumbers ?? [], 0);
+  });
+
+  it("refuses a phone number that is not in E.164 form", async () => {
+    // Given a simulated SNS.
+    const sns = new SimAws().sns();
+
+    // When a badly formatted number reaches either command that takes one.
+    const errors = await Promise.all([
+      assertThrowsErrorAsync(async () => {
+        await sns.checkIfPhoneNumberIsOptedOut(
+          new CheckIfPhoneNumberIsOptedOutCommand({ phoneNumber: "5550100" }),
+        );
+      }),
+      assertThrowsErrorAsync(async () => {
+        await sns.optInPhoneNumber(
+          new OptInPhoneNumberCommand({ phoneNumber: "5550100" }),
+        );
+      }),
+    ]);
+
+    // Then both are refused.
+    for (const error of errors) {
+      assertInstanceOf(error, SimSnsInvalidParameterException);
+    }
+  });
+
+  it("keeps one Region's opt-out list out of another", async () => {
+    // Given a number opted out in one Region.
+    const simAws = new SimAws();
+
+    simAws.region("eu-west-2").account().sns().optOutPhoneNumber(phoneNumber);
+
+    // When the other Region publishes to it.
+    await simAws
+      .sns()
+      .publish(new PublishCommand({ PhoneNumber: phoneNumber, Message: "hi" }));
+
+    // Then that Region delivered it, since the opt-out list is scoped the way
+    // topics are.
+    const [sms] = simAws.sns().sentSmsMessages();
+
+    assertFalse(sms?.suppressed);
+  });
+});

--- a/src/service/sns/command/sms/sim-sns-sms-iam.iso.test.ts
+++ b/src/service/sns/command/sms/sim-sns-sms-iam.iso.test.ts
@@ -1,0 +1,127 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CheckIfPhoneNumberIsOptedOutCommand,
+  ListPhoneNumbersOptedOutCommand,
+  OptInPhoneNumberCommand,
+  PublishCommand,
+} from "@aws-sdk/client-sns";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimSnsAuthorizationErrorException } from "../../error/sim-sns.error.js";
+
+const phoneNumber = "+15550100";
+
+/**
+ * A simulated AWS and a Role allowed only what one policy statement says.
+ */
+async function simAwsWithRole(
+  statement: object,
+): Promise<{ simAws: SimAws; caller: SimAwsCaller }> {
+  const simAws = new SimAws();
+  const role = await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "Texter",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { AWS: `arn:aws:iam::${simAws.defaultAccountId}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "Texter",
+      PolicyName: "TextPeople",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: statement,
+      }),
+    }),
+  );
+
+  return { simAws, caller: { kind: "arn", arn: role.Role.Arn } };
+}
+
+describe("SNS SMS IAM authorization", () => {
+  it("refuses a caller whose policy allows none of the SMS actions", async () => {
+    // Given a Role allowed to read a topic and nothing else.
+    const { simAws, caller } = await simAwsWithRole({
+      Effect: "Allow",
+      Action: "sns:GetTopicAttributes",
+      Resource: "*",
+    });
+    const sns = simAws.sns();
+
+    // When it reaches each command the SMS surface has.
+    const errors = await Promise.all([
+      assertThrowsErrorAsync(async () => {
+        await sns.publish(
+          new PublishCommand({ PhoneNumber: phoneNumber, Message: "hi" }),
+          { caller },
+        );
+      }),
+      assertThrowsErrorAsync(async () => {
+        await sns.checkIfPhoneNumberIsOptedOut(
+          new CheckIfPhoneNumberIsOptedOutCommand({ phoneNumber }),
+          { caller },
+        );
+      }),
+      assertThrowsErrorAsync(async () => {
+        await sns.listPhoneNumbersOptedOut(
+          new ListPhoneNumbersOptedOutCommand({}),
+          { caller },
+        );
+      }),
+      assertThrowsErrorAsync(async () => {
+        await sns.optInPhoneNumber(
+          new OptInPhoneNumberCommand({ phoneNumber }),
+          { caller },
+        );
+      }),
+    ]);
+
+    // Then each is refused, and the refused publish recorded nothing.
+    for (const error of errors) {
+      assertInstanceOf(error, SimSnsAuthorizationErrorException);
+    }
+
+    assertArrayLength(sns.sentSmsMessages(), 0);
+  });
+
+  it("admits a caller whose policy allows the SMS actions", async () => {
+    // Given a Role allowed them against every resource, which is the only
+    // resource these actions have.
+    const { simAws, caller } = await simAwsWithRole({
+      Effect: "Allow",
+      Action: ["sns:Publish", "sns:CheckIfPhoneNumberIsOptedOut"],
+      Resource: "*",
+    });
+    const sns = simAws.sns();
+
+    // When it publishes to a number and checks the opt-out list.
+    await sns.publish(
+      new PublishCommand({ PhoneNumber: phoneNumber, Message: "hi" }),
+      { caller },
+    );
+
+    const checked = await sns.checkIfPhoneNumberIsOptedOut(
+      new CheckIfPhoneNumberIsOptedOutCommand({ phoneNumber }),
+      { caller },
+    );
+
+    // Then the message was recorded and the check answered.
+    assertArrayLength(sns.sentSmsMessages(), 1);
+    assertFalse(checked.isOptedOut);
+  });
+});

--- a/src/service/sns/command/sms/sms.command.ts
+++ b/src/service/sns/command/sms/sms.command.ts
@@ -1,0 +1,58 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim SNS CheckIfPhoneNumberIsOptedOut command.
+ *
+ * The SMS operations name their fields in camel case, unlike every other SNS
+ * operation. That is how the SNS API has them, and the SDK carries it through.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sns/command/CheckIfPhoneNumberIsOptedOutCommand/
+ */
+export interface SimCheckIfPhoneNumberIsOptedOutCommand {
+  readonly input: SimCheckIfPhoneNumberIsOptedOutCommandInput;
+}
+
+export interface SimCheckIfPhoneNumberIsOptedOutCommandInput {
+  readonly phoneNumber?: string | undefined;
+}
+
+export interface SimCheckIfPhoneNumberIsOptedOutCommandOutput {
+  readonly isOptedOut?: boolean | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim SNS ListPhoneNumbersOptedOut command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sns/command/ListPhoneNumbersOptedOutCommand/
+ */
+export interface SimListPhoneNumbersOptedOutCommand {
+  readonly input: SimListPhoneNumbersOptedOutCommandInput;
+}
+
+export interface SimListPhoneNumbersOptedOutCommandInput {
+  readonly nextToken?: string | undefined;
+}
+
+export interface SimListPhoneNumbersOptedOutCommandOutput {
+  readonly phoneNumbers?: readonly string[] | undefined;
+  readonly nextToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim SNS OptInPhoneNumber command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sns/command/OptInPhoneNumberCommand/
+ */
+export interface SimOptInPhoneNumberCommand {
+  readonly input: SimOptInPhoneNumberCommandInput;
+}
+
+export interface SimOptInPhoneNumberCommandInput {
+  readonly phoneNumber?: string | undefined;
+}
+
+export interface SimOptInPhoneNumberCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/sns/index.ts
+++ b/src/service/sns/index.ts
@@ -44,6 +44,12 @@ export {
 } from "./filter/sim-sns-filter-policy-scope.js";
 export type { SimSnsFilterSubject } from "./filter/sim-sns-filter-subject.js";
 export { SimSnsFilterValue } from "./filter/sim-sns-filter-value.js";
+export { SimSnsPhoneNumber } from "./sms/sim-sns-phone-number.js";
+export { SimSnsSentSmsMessage } from "./sms/sim-sns-sent-sms-message.js";
+export {
+  simSnsSenderIdAttribute,
+  simSnsSmsTypeAttribute,
+} from "./message/sim-sns-sms-attributes.js";
 export { SimSnsMessageAttributes } from "./message/sim-sns-message-attributes.js";
 export type {
   SimSnsMessageAttributeInput,

--- a/src/service/sns/message/sim-sns-message-attribute-rules.ts
+++ b/src/service/sns/message/sim-sns-message-attribute-rules.ts
@@ -1,5 +1,12 @@
-import { SimSnsInvalidParameterValueException } from "../error/sim-sns.error.js";
+import {
+  SimSnsInvalidParameterValueException,
+  SimSnsUnsimulatedInputException,
+} from "../error/sim-sns.error.js";
 import type { SimSnsMessageAttributeValue } from "./sim-sns-message-attribute-value.js";
+import {
+  simSnsSmsAttributeNames,
+  simSnsUnsimulatedSmsAttributes,
+} from "./sim-sns-sms-attributes.js";
 
 const attributeNamePattern = /^[\w\-.]{1,256}$/;
 
@@ -39,6 +46,18 @@ export function assertUsableSnsAttributeName(name: string): void {
 
   if (name.startsWith(".") || name.endsWith(".") || name.includes("..")) {
     throw invalid;
+  }
+
+  if (simSnsSmsAttributeNames.has(name)) {
+    return;
+  }
+
+  const unsimulated = simSnsUnsimulatedSmsAttributes.get(name);
+
+  if (unsimulated !== undefined) {
+    throw new SimSnsUnsimulatedInputException(
+      `The ${name} message attribute is not simulated. ${unsimulated}`,
+    );
   }
 
   const lowerCased = name.toLowerCase();

--- a/src/service/sns/message/sim-sns-message-attributes.ts
+++ b/src/service/sns/message/sim-sns-message-attributes.ts
@@ -46,6 +46,17 @@ export class SimSnsMessageAttributes {
   }
 
   /**
+   * One attribute by name, where the message carries it.
+   *
+   * SMS is what needs this. Real SNS reads `AWS.SNS.SMS.SenderID` and
+   * `AWS.SNS.SMS.SMSType` out of the attributes of a publish to a phone
+   * number, so a recorded SMS reads them back the same way.
+   */
+  find(name: string): SimSnsMessageAttribute | undefined {
+    return this.attributes.find((attribute) => attribute.name === name);
+  }
+
+  /**
    * What these attributes contribute to the size of a publish.
    */
   get byteSize(): number {

--- a/src/service/sns/message/sim-sns-sms-attributes.ts
+++ b/src/service/sns/message/sim-sns-sms-attributes.ts
@@ -39,11 +39,11 @@ export const simSnsUnsimulatedSmsAttributes: ReadonlyMap<string, string> =
       "Origination numbers and phone pools are not simulated.",
     ],
     [
-      "AWS.SNS.SMS.EntityId",
+      "AWS.MM.SMS.EntityId",
       "The India DLT registration these identify is not simulated.",
     ],
     [
-      "AWS.SNS.SMS.TemplateId",
+      "AWS.MM.SMS.TemplateId",
       "The India DLT registration these identify is not simulated.",
     ],
   ]);

--- a/src/service/sns/message/sim-sns-sms-attributes.ts
+++ b/src/service/sns/message/sim-sns-sms-attributes.ts
@@ -1,0 +1,49 @@
+/**
+ * The message attribute carrying the name an SMS appears to come from.
+ */
+export const simSnsSenderIdAttribute = "AWS.SNS.SMS.SenderID";
+
+/**
+ * The message attribute saying whether an SMS is transactional or promotional.
+ */
+export const simSnsSmsTypeAttribute = "AWS.SNS.SMS.SMSType";
+
+/**
+ * The reserved SMS attributes a publish may carry here.
+ *
+ * Message attribute names beginning with `AWS.` are reserved, and real SNS
+ * refuses one a caller invents. These two are AWS's own, so real SNS takes
+ * them and so does this. Both are recorded on the SMS and read back from it.
+ */
+export const simSnsSmsAttributeNames: ReadonlySet<string> = new Set([
+  simSnsSenderIdAttribute,
+  simSnsSmsTypeAttribute,
+]);
+
+/**
+ * The reserved SMS attributes real SNS acts on and this simulation does not.
+ *
+ * Each is refused by name with the reason. An accepted `MaxPrice` that capped
+ * no spending would be a price cap a test believed was applied. That is the
+ * same reasoning that refuses `MessageGroupId` on a publish.
+ */
+export const simSnsUnsimulatedSmsAttributes: ReadonlyMap<string, string> =
+  new Map([
+    [
+      "AWS.SNS.SMS.MaxPrice",
+      "Per-message pricing is not simulated. Nothing here would hold a " +
+        "message to a price cap.",
+    ],
+    [
+      "AWS.MM.SMS.OriginationNumber",
+      "Origination numbers and phone pools are not simulated.",
+    ],
+    [
+      "AWS.SNS.SMS.EntityId",
+      "The India DLT registration these identify is not simulated.",
+    ],
+    [
+      "AWS.SNS.SMS.TemplateId",
+      "The India DLT registration these identify is not simulated.",
+    ],
+  ]);

--- a/src/service/sns/sdk/sim-sns-sdk-command-router.ts
+++ b/src/service/sns/sdk/sim-sns-sdk-command-router.ts
@@ -8,6 +8,11 @@ import type {
   SimPublishCommand,
 } from "../command/publish/publish.command.js";
 import type {
+  SimCheckIfPhoneNumberIsOptedOutCommand,
+  SimListPhoneNumbersOptedOutCommand,
+  SimOptInPhoneNumberCommand,
+} from "../command/sms/sms.command.js";
+import type {
   SimGetSubscriptionAttributesCommand,
   SimListSubscriptionsByTopicCommand,
   SimListSubscriptionsCommand,
@@ -133,6 +138,30 @@ export class SimSnsSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simSns.publishBatch(
             command as SimPublishBatchCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "CheckIfPhoneNumberIsOptedOutCommand",
+        async (command, context): Promise<unknown> =>
+          await simSns.checkIfPhoneNumberIsOptedOut(
+            command as SimCheckIfPhoneNumberIsOptedOutCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListPhoneNumbersOptedOutCommand",
+        async (command, context): Promise<unknown> =>
+          await simSns.listPhoneNumbersOptedOut(
+            command as SimListPhoneNumbersOptedOutCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "OptInPhoneNumberCommand",
+        async (command, context): Promise<unknown> =>
+          await simSns.optInPhoneNumber(
+            command as SimOptInPhoneNumberCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/sns/sdk/sim-sns-sdk-sms-routing.iso.test.ts
+++ b/src/service/sns/sdk/sim-sns-sdk-sms-routing.iso.test.ts
@@ -1,0 +1,55 @@
+import {
+  CheckIfPhoneNumberIsOptedOutCommand,
+  ListPhoneNumbersOptedOutCommand,
+  OptInPhoneNumberCommand,
+  PublishCommand,
+  SNSClient,
+} from "@aws-sdk/client-sns";
+import {
+  assertArrayEquals,
+  assertFalse,
+  assertNonNullable,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimSdk } from "../../../sdk/index.js";
+import { SimAws } from "../../aws/sim-aws.js";
+
+const phoneNumber = "+15550100";
+
+describe("SNS SDK SMS interception", () => {
+  it("routes every SMS Command through the intercepted client", async () => {
+    // Given an intercepted SNS SDK client, with one number opted out through
+    // the simulator the way a recipient replying STOP would.
+    const simAws = new SimAws();
+
+    using simSdk = new SimSdk({ simAws });
+    simSdk.intercept(SNSClient);
+
+    simAws.sns().optOutPhoneNumber(phoneNumber);
+
+    const client = new SNSClient({ region: "us-east-1" });
+
+    // When ordinary SDK code texts the number and reads the opt-out list.
+    const published = await client.send(
+      new PublishCommand({ PhoneNumber: phoneNumber, Message: "code 12345" }),
+    );
+    const checked = await client.send(
+      new CheckIfPhoneNumberIsOptedOutCommand({ phoneNumber }),
+    );
+    const listed = await client.send(new ListPhoneNumbersOptedOutCommand({}));
+
+    await client.send(new OptInPhoneNumberCommand({ phoneNumber }));
+
+    const afterOptIn = await client.send(
+      new CheckIfPhoneNumberIsOptedOutCommand({ phoneNumber }),
+    );
+
+    // Then each command reached the simulation with nothing touching the
+    // network.
+    assertNonNullable(published.MessageId);
+    assertTrue(checked.isOptedOut);
+    assertArrayEquals(listed.phoneNumbers ?? [], [phoneNumber]);
+    assertFalse(afterOptIn.isOptedOut);
+  });
+});

--- a/src/service/sns/sim-sns-sms.ts
+++ b/src/service/sns/sim-sns-sms.ts
@@ -1,0 +1,109 @@
+import type { BackgroundScheduler } from "../../util/background/background.js";
+import type * as simSnsCommands from "./command/sim-sns-command.types.js";
+import type { SimSnsCommands } from "./command/sim-sns-commands.js";
+import type { SimSnsRequestOptions } from "./command/sim-sns-request-options.js";
+import { SimSnsPhoneNumber } from "./sms/sim-sns-phone-number.js";
+import type { SimSnsSentSmsMessage } from "./sms/sim-sns-sent-sms-message.js";
+
+interface SimSnsSmsProperties {
+  readonly commands: SimSnsCommands;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * The SMS half of simulated SNS: publishing to a phone number, and the opt-out
+ * list that decides whether the message would have arrived.
+ *
+ * `SimSns` extends this, so a caller reaches these on the one service object
+ * alongside the topic operations. They are here because they are the operations
+ * that touch no topic at all.
+ */
+export abstract class SimSnsSms {
+  protected readonly commands: SimSnsCommands;
+  protected readonly background: BackgroundScheduler;
+
+  protected constructor(properties: SimSnsSmsProperties) {
+    this.commands = properties.commands;
+    this.background = properties.background;
+  }
+
+  /**
+   * Every SMS this simulated SNS would have sent, oldest first.
+   *
+   * Delivery stops at the simulator boundary, and this record is the whole of
+   * what an SMS is here. A message the opt-out list stopped is in the list
+   * too, marked suppressed.
+   *
+   * This is the simulator's own accessor. Real SNS tells a publisher nothing
+   * about what became of an SMS, and a test needs to know.
+   */
+  sentSmsMessages(): readonly SimSnsSentSmsMessage[] {
+    return this.commands.sentSms.all;
+  }
+
+  /**
+   * Stop sending SMS to a phone number, as a reply of STOP does on real SNS.
+   *
+   * Real SNS has no API for this, because the recipient does it from the
+   * handset. Standing in for the handset is the simulator's job, the same way
+   * verifying an SES identity is. `OptInPhoneNumber` reverses it.
+   */
+  optOutPhoneNumber(phoneNumber: string): void {
+    this.commands.optOutList.optOut(SimSnsPhoneNumber.of(phoneNumber));
+  }
+
+  /**
+   * Handle a Publish Command from the SDK.
+   */
+  async publish(
+    command: simSnsCommands.SimPublishCommand,
+    options?: SimSnsRequestOptions,
+  ): Promise<simSnsCommands.SimPublishCommandOutput> {
+    await this.background.sequence();
+    return this.commands.publish.publish(command, options);
+  }
+
+  /**
+   * Handle a PublishBatch Command from the SDK.
+   */
+  async publishBatch(
+    command: simSnsCommands.SimPublishBatchCommand,
+    options?: SimSnsRequestOptions,
+  ): Promise<simSnsCommands.SimPublishBatchCommandOutput> {
+    await this.background.sequence();
+    return this.commands.publish.publishBatch(command, options);
+  }
+
+  /**
+   * Handle a CheckIfPhoneNumberIsOptedOut Command from the SDK.
+   */
+  async checkIfPhoneNumberIsOptedOut(
+    command: simSnsCommands.SimCheckIfPhoneNumberIsOptedOutCommand,
+    options?: SimSnsRequestOptions,
+  ): Promise<simSnsCommands.SimCheckIfPhoneNumberIsOptedOutCommandOutput> {
+    await this.background.sequence();
+    return this.commands.optOut.checkIfPhoneNumberIsOptedOut(command, options);
+  }
+
+  /**
+   * Handle a ListPhoneNumbersOptedOut Command from the SDK.
+   */
+  async listPhoneNumbersOptedOut(
+    command: simSnsCommands.SimListPhoneNumbersOptedOutCommand,
+    options?: SimSnsRequestOptions,
+  ): Promise<simSnsCommands.SimListPhoneNumbersOptedOutCommandOutput> {
+    await this.background.sequence();
+    return this.commands.optOut.listPhoneNumbersOptedOut(command, options);
+  }
+
+  /**
+   * Handle an OptInPhoneNumber Command from the SDK.
+   */
+  async optInPhoneNumber(
+    command: simSnsCommands.SimOptInPhoneNumberCommand,
+    options?: SimSnsRequestOptions,
+  ): Promise<simSnsCommands.SimOptInPhoneNumberCommandOutput> {
+    await this.background.sequence();
+    return this.commands.optOut.optInPhoneNumber(command, options);
+  }
+}

--- a/src/service/sns/sim-sns.ts
+++ b/src/service/sns/sim-sns.ts
@@ -17,6 +17,7 @@ import { SimSnsCommands } from "./command/sim-sns-commands.js";
 import type { SimSnsRequestOptions } from "./command/sim-sns-request-options.js";
 import { SimSnsCfnResourceFactory } from "./cfn/sim-sns-cfn-resource-factory.js";
 import { SimSnsSdkCommandRouter } from "./sdk/sim-sns-sdk-command-router.js";
+import { SimSnsSms } from "./sim-sns-sms.js";
 import type { SimSnsSubscription } from "./subscription/sim-sns-subscription.js";
 import { SimSnsSubscriptionStore } from "./subscription/sim-sns-subscription-store.js";
 import type { SimSnsTopic } from "./topic/sim-sns-topic.js";
@@ -45,13 +46,11 @@ interface SimSnsProperties {
  *
  * Only standard topics are simulated. FIFO topics are not.
  */
-export class SimSns {
-  private readonly topics = new SimSnsTopicStore();
-  private readonly subscriptions = new SimSnsSubscriptionStore();
-  private readonly commands: SimSnsCommands;
-  private readonly background: BackgroundScheduler;
-  private readonly sdkRouter = new SimSnsSdkCommandRouter(this);
-  private readonly cfnFactory = new SimSnsCfnResourceFactory({ sns: this });
+export class SimSns extends SimSnsSms {
+  private readonly topics: SimSnsTopicStore;
+  private readonly subscriptions: SimSnsSubscriptionStore;
+  private readonly sdkRouter: SimSnsSdkCommandRouter;
+  private readonly cfnFactory: SimSnsCfnResourceFactory;
 
   constructor(properties: SimSnsProperties = {}) {
     const {
@@ -60,16 +59,25 @@ export class SimSns {
       background = new BackgroundTasks(),
       deliveryEndpoints = new SimSnsNoDeliveryEndpoints(),
     } = properties;
+    const topics = new SimSnsTopicStore();
+    const subscriptions = new SimSnsSubscriptionStore();
 
-    this.background = background;
-    this.commands = new SimSnsCommands({
-      topics: this.topics,
-      subscriptions: this.subscriptions,
-      iam,
+    super({
       background,
-      deliveryEndpoints,
-      accountRegionScope,
+      commands: new SimSnsCommands({
+        topics,
+        subscriptions,
+        iam,
+        background,
+        deliveryEndpoints,
+        accountRegionScope,
+      }),
     });
+
+    this.topics = topics;
+    this.subscriptions = subscriptions;
+    this.sdkRouter = new SimSnsSdkCommandRouter(this);
+    this.cfnFactory = new SimSnsCfnResourceFactory({ sns: this });
   }
 
   /**
@@ -254,28 +262,6 @@ export class SimSns {
       command,
       options,
     );
-  }
-
-  /**
-   * Handle a Publish Command from the SDK.
-   */
-  async publish(
-    command: simSnsCommands.SimPublishCommand,
-    options?: SimSnsRequestOptions,
-  ): Promise<simSnsCommands.SimPublishCommandOutput> {
-    await this.background.sequence();
-    return this.commands.publish.publish(command, options);
-  }
-
-  /**
-   * Handle a PublishBatch Command from the SDK.
-   */
-  async publishBatch(
-    command: simSnsCommands.SimPublishBatchCommand,
-    options?: SimSnsRequestOptions,
-  ): Promise<simSnsCommands.SimPublishBatchCommandOutput> {
-    await this.background.sequence();
-    return this.commands.publish.publishBatch(command, options);
   }
 
   /**

--- a/src/service/sns/sms/sim-sns-opt-out-list.ts
+++ b/src/service/sns/sms/sim-sns-opt-out-list.ts
@@ -1,0 +1,52 @@
+import type { SimSnsPhoneNumber } from "./sim-sns-phone-number.js";
+
+/**
+ * The phone numbers one simulated SNS scope will send no SMS to.
+ *
+ * Real SNS puts a number on this list when the recipient replies STOP, and the
+ * API only takes numbers back off it. `SimSns.optOutPhoneNumber` is what puts
+ * one on. That is a deliberate divergence, for the same reason SES identity
+ * verification is one. The act a recipient performs on a handset belongs to
+ * the simulator, since a test process has no handset to perform it on.
+ *
+ * Numbers are held in the order they were opted out.
+ * `ListPhoneNumbersOptedOut` reports them in that order.
+ */
+export class SimSnsOptOutList {
+  readonly #optedOut = new Set<string>();
+
+  /**
+   * Every opted-out number, in the order they were opted out.
+   */
+  get all(): readonly string[] {
+    return [...this.#optedOut];
+  }
+
+  /**
+   * Stop sending SMS to a number, as a reply of STOP does on real SNS.
+   *
+   * Opting out a number already on the list leaves it where it is, so its
+   * place in the listing stays put.
+   */
+  optOut(phoneNumber: SimSnsPhoneNumber): void {
+    this.#optedOut.add(phoneNumber.value);
+  }
+
+  /**
+   * Start sending SMS to a number again.
+   *
+   * Real SNS allows this once every thirty days per number and refuses a
+   * second attempt inside the window. That limit is absent here. A test can
+   * opt a number in as often as it needs to.
+   */
+  optIn(phoneNumber: SimSnsPhoneNumber): void {
+    this.#optedOut.delete(phoneNumber.value);
+  }
+
+  /**
+   * Whether SMS to this number would be stopped.
+   */
+  isOptedOut(phoneNumber: SimSnsPhoneNumber): boolean {
+    return this.#optedOut.has(phoneNumber.value);
+  }
+}

--- a/src/service/sns/sms/sim-sns-phone-number.ts
+++ b/src/service/sns/sms/sim-sns-phone-number.ts
@@ -1,0 +1,48 @@
+import { SimSnsInvalidParameterException } from "../error/sim-sns.error.js";
+
+/**
+ * E.164 form. A plus sign, a country code that never starts with zero, and
+ * fifteen digits at the most.
+ */
+const phoneNumberPattern = /^\+[1-9]\d{1,14}$/;
+
+/**
+ * What a missing phone number is called in the error naming it.
+ *
+ * This is the wording the subscription protocol check uses for the same case.
+ */
+const missingNumber = "(none)";
+
+/**
+ * A phone number simulated SNS will send an SMS to.
+ *
+ * Real SNS takes E.164 and refuses everything else, and the opt-out list is
+ * keyed by the same form. Holding it as a value keeps the check in one place.
+ * A number that reaches the opt-out list or a recorded SMS has been through it
+ * already.
+ */
+export class SimSnsPhoneNumber {
+  public readonly value: string;
+
+  private constructor(value: string) {
+    this.value = value;
+  }
+
+  /**
+   * Read the phone number a request names, refusing one real SNS would refuse.
+   *
+   * The wording real SNS uses varies by operation. This is one message for all
+   * of them, naming the parameter and the value the way the SNS errors here
+   * already do.
+   */
+  static of(value: string = missingNumber): SimSnsPhoneNumber {
+    if (!phoneNumberPattern.test(value)) {
+      throw new SimSnsInvalidParameterException(
+        `Invalid parameter: PhoneNumber Reason: ${value} is not an E.164 ` +
+          `phone number`,
+      );
+    }
+
+    return new this(value);
+  }
+}

--- a/src/service/sns/sms/sim-sns-sent-sms-message.ts
+++ b/src/service/sns/sms/sim-sns-sent-sms-message.ts
@@ -1,0 +1,80 @@
+import type { SimSnsMessageAttributes } from "../message/sim-sns-message-attributes.js";
+import {
+  simSnsSenderIdAttribute,
+  simSnsSmsTypeAttribute,
+} from "../message/sim-sns-sms-attributes.js";
+
+interface SimSnsSentSmsMessageProperties {
+  readonly messageId: string;
+  readonly phoneNumber: string;
+  readonly message: string;
+  readonly attributes: SimSnsMessageAttributes;
+  readonly suppressed: boolean;
+  readonly sentDate: Date;
+}
+
+/**
+ * One SMS a simulated SNS would have sent.
+ *
+ * Delivery stops at the simulator boundary, and this record is the whole of
+ * what an SMS is here. Simulated SNS keeps it itself, the way a simulated
+ * Cognito user pool keeps the verification and MFA messages it would have
+ * texted.
+ *
+ * There is no subject. Real SNS uses `Subject` for email and leaves it off an
+ * SMS. A publish that carries one to a phone number has it ignored.
+ */
+export class SimSnsSentSmsMessage {
+  public readonly messageId: string;
+
+  /** The E.164 number this would have gone to. */
+  public readonly phoneNumber: string;
+
+  /** The body, which arrives on a handset as the whole of the message. */
+  public readonly message: string;
+
+  /**
+   * The message attributes the publish carried, including the `AWS.SNS.SMS.`
+   * ones real SNS reads for the sender id, the message type and the price cap.
+   */
+  public readonly attributes: SimSnsMessageAttributes;
+
+  /**
+   * Whether the opt-out list stopped this one.
+   *
+   * A publish to an opted-out number succeeds and answers with a message id,
+   * and nothing arrives. The record is kept either way, and this flag tells
+   * the two apart. A test about a code reaching a handset asserts on a
+   * delivered message, and a test about the opt-out list has something to
+   * read.
+   */
+  public readonly suppressed: boolean;
+
+  public readonly sentDate: Date;
+
+  constructor(properties: SimSnsSentSmsMessageProperties) {
+    this.messageId = properties.messageId;
+    this.phoneNumber = properties.phoneNumber;
+    this.message = properties.message;
+    this.attributes = properties.attributes;
+    this.suppressed = properties.suppressed;
+    this.sentDate = properties.sentDate;
+  }
+
+  /**
+   * The name this SMS appears to come from, where the publish set one.
+   */
+  get senderId(): string | undefined {
+    return this.attributes.find(simSnsSenderIdAttribute)?.envelopeValue;
+  }
+
+  /**
+   * `Transactional` or `Promotional`, where the publish set one.
+   *
+   * Real SNS reads this to decide how it routes and prices a message. Routing
+   * and pricing are absent here, and the value is recorded and left alone.
+   */
+  get smsType(): string | undefined {
+    return this.attributes.find(simSnsSmsTypeAttribute)?.envelopeValue;
+  }
+}

--- a/src/service/sns/sms/sim-sns-sent-sms-store.ts
+++ b/src/service/sns/sms/sim-sns-sent-sms-store.ts
@@ -1,0 +1,31 @@
+import type { SimSnsSentSmsMessage } from "./sim-sns-sent-sms-message.js";
+
+/**
+ * The SMS messages one simulated SNS scope has accepted.
+ *
+ * They are kept in the order they were published, because the assertion a test
+ * usually wants is about the first message of a flow. A one-time code is sent
+ * once, and whatever else the flow texts afterwards is not what the test is
+ * looking at.
+ *
+ * Nothing here is ever discarded. Real SNS keeps no such record at all, so
+ * there is no retention behaviour to reproduce, and a test process is short
+ * enough that keeping every message costs nothing.
+ */
+export class SimSnsSentSmsStore {
+  readonly #sent: SimSnsSentSmsMessage[] = [];
+
+  /**
+   * Every SMS this scope has accepted, oldest first.
+   */
+  get all(): readonly SimSnsSentSmsMessage[] {
+    return [...this.#sent];
+  }
+
+  /**
+   * Keep an SMS simulated SNS has accepted.
+   */
+  add(message: SimSnsSentSmsMessage): void {
+    this.#sent.push(message);
+  }
+}


### PR DESCRIPTION
A `Publish` that names a `PhoneNumber` now records the SMS simulated SNS would have texted, where it used to be refused. `sentSmsMessages()` reads the records back, carrying the `AWS.SNS.SMS.SenderID` and `AWS.SNS.SMS.SMSType` attributes the publish set. The phone number opt-out list comes with it, because a publish to an opted-out number succeeds and delivers nothing. `optOutPhoneNumber` stands in for a recipient replying STOP, the record for a stopped message says suppressed, and `CheckIfPhoneNumberIsOptedOut`, `ListPhoneNumbersOptedOut` and `OptInPhoneNumber` are the API side of the same list. The SMS sandbox stays out, since Yulin is a sandbox already.

Resolves #646


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added simulated SNS SMS publishing to phone numbers, including message IDs, timestamps, sender metadata, and delivery records.
  - Added phone-number opt-out management: check status, list opted-out numbers, and opt in recipients.
  - Added suppression of messages sent to opted-out numbers, with region-scoped behavior.
  - Added validation for E.164 phone numbers and conflicting publish targets.
  - Added support for SDK-based SMS operations without network access.

- **Documentation**
  - Expanded SNS documentation and examples covering SMS publishing, attributes, limitations, validation, and opt-out workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->