### PR TITLE
docs: plain prose in seven more READMEs

### DIFF
--- a/docs/serve/README.md
+++ b/docs/serve/README.md
@@ -1,8 +1,8 @@
 # Serving simulated AWS on localhost
 
-Serving puts a simulated AWS environment behind a real port, so a browser, `curl` or an SDK client
-reaches it over HTTP. The same request path is available in the process with no port at all, which
-is what a test wants.
+Serving puts a simulated AWS environment behind a real port. A browser, `curl` or an SDK client then
+reaches it over HTTP. The same request path is also available in the process with no port at all,
+which is the form a test usually wants.
 
 ## Serving a port
 
@@ -27,8 +27,8 @@ await srv.close();
 Without a `port` the server takes whatever port is free, which changes on every run. Pin one when
 the URL needs to stay the same, such as when a browser is pointed at it.
 
-Simulated hostnames do not resolve to the port the server took, so a URL from a simulated service
-needs adapting before it can be fetched. `srv.localUrl(...)` does that:
+A URL from a simulated service points at a simulated hostname on its usual port, and needs adapting
+before it can be fetched. `srv.localUrl(...)` swaps in the port the server took:
 
 ```typescript sim-serve-local-url
 /**
@@ -54,8 +54,8 @@ await srv.close();
 
 ## Requests without a port
 
-`SimAwsHttp` is the same request path with nothing listening under it. It takes a Fetch API
-`Request` and answers with a `Response`, in the process that built the environment:
+`SimAwsHttp` is the same request path with no socket under it. It takes a Fetch API `Request` and
+answers with a `Response`, in the process that built the environment:
 
 ```typescript sim-serve-in-process-request
 /**
@@ -131,44 +131,44 @@ console.log(await response.text()); // <h1>Hello, world!</h1>
 `fetch(input, init)` takes what the global `fetch` takes. `handleRequest(request)` takes a `Request`
 that is already built, for a caller that is holding one.
 
-Nothing binds a port, so there is no URL to adapt. The website URL above is fetched as it is, where
-a served environment needs `srv.localUrl(...)` to add the port it took. A hostname a simulated
-Route53 answers for is requested by its own name, so a Distribution behind `www.example.com` is
-reached at `https://www.example.com/`. An `https` URL needs no certificate set up for it, since there
-is no connection to encrypt.
+With no port bound there is no URL to adapt. The website URL above is fetched as it is, where a
+served environment needs `srv.localUrl(...)` to add the port it took. A hostname a simulated Route53
+answers for is requested by its own name. A Distribution behind `www.example.com` is reached at
+`https://www.example.com/`. An `https` URL needs no certificate set up for it, since there is no
+connection to encrypt.
 
-There is nothing to close either, though `simAws.close()` still lets go of what the environment
+There is also no server to close, though `simAws.close()` still lets go of what the environment
 itself is holding, such as a watched template file. See
 [stopping and restarting](#stopping-and-restarting).
 
-Live reload sits either side of this interface rather than inside it, so a response from here never
-carries the injected script, even in a process that served one elsewhere with live reload on.
+Live reload sits either side of this interface, outside it. A response from here never carries the
+injected script, even in a process that served one elsewhere with live reload on.
 
 Which to reach for:
 
 - `SimAwsHttp` for tests, and for anything else in the same process. Test files that run in parallel
-  have no port to collide over, and nothing listens, so there is no teardown to get wrong and no
-  socket between the request and the service answering it.
-- `serveSimAws` for anything outside the process: a browser, `curl`, or an SDK client pointed at a
-  local endpoint.
+  have no port to collide over. With no socket listening there is no teardown to get wrong, and no
+  connection between the request and the service answering it.
+- `serveSimAws` for anything outside the process, such as a browser, `curl`, or an SDK client
+  pointed at a local endpoint.
 
-Both go through the same authentication, routing and service code, so a request answered one way is
+Both go through the same authentication, routing and service code. A request answered one way is
 answered the same way the other.
 
 ## Stopping and restarting
 
-`close()` stops serving and lets go of everything Yulin was holding, so the process can exit. That
-is the HTTP port, the DNS port and the connections the server is holding, and the simulated
-environment it was serving with them: the template files a deployment is
-[watching](../services/cloudformation/README.md#watching-a-template-file) and the directories a
-[mount](../services/s3/README.md#reloading-the-browser-when-the-directory-changes) is watching,
-in whichever Account and Region each of them lives in. One call, so a script that does not exit is
-not a hunt for the handle you missed.
+`close()` stops serving and lets go of everything Yulin was holding, leaving the process free to
+exit. That is the HTTP port, the DNS port and the connections the server is holding, along with the
+simulated environment it was serving with them. The environment covers the template files a
+deployment is [watching](../services/cloudformation/README.md#watching-a-template-file) and the
+directories a [mount](../services/s3/README.md#reloading-the-browser-when-the-directory-changes) is
+watching, in whichever Account and Region each of them lives in. One call covers all of it. A script
+that hangs on exit is not a hunt for the handle you missed.
 
-It returns a promise that settles once the last thing the server had to say has gone, so a script
-that means to exit rather than let the event loop empty has something to wait for. Yulin installs no
-signal handlers, since a library taking over process signals gets in the way of whatever else the
-process is doing. Call `close()` from your own handler:
+It returns a promise that settles once the last thing the server had to say has gone. A script that
+means to exit under its own steam has something to wait for. Yulin installs no signal handlers,
+since a library taking over process signals gets in the way of whatever else the process is doing.
+Call `close()` from your own handler:
 
 ```typescript sim-serve-shutdown
 /**
@@ -190,14 +190,12 @@ process.on("SIGTERM", () => {
 });
 ```
 
-Closing twice does nothing twice, and closing a server whose environment started nothing is not an
-error. What is closed is the handles that keep the process alive: every simulated Bucket, Table and
-Stack is where it was, and the environment goes on working, so a script that closes and carries on
-can.
+Closing twice is safe, and so is closing a server whose environment started nothing. What closes is
+the handles that keep the process alive. Every simulated Bucket, Table and Stack is where it was,
+and the environment goes on working. A script can close and carry on.
 
-An environment that is not being served has the same call on it. `simAws.close()` lets go of its
-template file watches and mounted directory watches, and a test with one of those has one line
-rather than a list:
+An unserved environment has the same call on it. `simAws.close()` lets go of its template file
+watches and mounted directory watches, and a test with one of those closes it in one line:
 
 ```typescript sim-serve-close-environment
 /**
@@ -219,8 +217,8 @@ await simAws.close();
 
 ### Asking for a signal handler
 
-The handler above is yours to write, which is the point: your script decides what a signal means and
-in what order things happen. A script that wants nothing more than the usual can say so instead, and
+The handler above is yours to write, and that is the point. Your script decides what a signal means
+and in what order things happen. A script that wants the usual behaviour can ask for it instead, and
 gets the same close on `SIGINT` and `SIGTERM`:
 
 ```typescript sim-serve-close-on-signal
@@ -245,23 +243,23 @@ const stopListening = srv.closeOnSignal();
 stopListening();
 ```
 
-Nothing is installed until that call, so the default stands: a process that never asks keeps its
-signals to itself. `closeOnSignal({ signals: ["SIGHUP"] })` names other signals. The handlers come
-off as the first one arrives, so a second Ctrl-C from someone who has waited long enough lands on
-Node's own default and ends the process. Nothing here exits the process either: closing lets go of
-what Yulin was holding, and a process with nothing else to do then exits on its own. `SimAws` has
-the same method, for an environment that is not served.
+The handler goes on at that call and no sooner. A process that never asks keeps its signals to
+itself. `closeOnSignal({ signals: ["SIGHUP"] })` names other signals. The handlers come off as the
+first one arrives, and a second Ctrl-C from someone who has waited long enough lands on Node's own
+default and ends the process. Closing never exits the process itself. It lets go of what Yulin was
+holding, and a process with no work left then exits on its own. `SimAws` has the same method, for an
+unserved environment.
 
 A restart usually overlaps the process it replaces. `listen` waits a couple of seconds for a pinned
-port that is still held, then throws `SimAwsLocalPortInUse` naming the port, which means something
-other than the outgoing process owns it.
+port that is still held, then throws `SimAwsLocalPortInUse` naming the port. By then something other
+than the outgoing process owns it.
 
 ## Live reload
 
 A page served from a simulated Bucket website, CloudFront distribution, Function URL or HTTP API has
-nothing but Yulin in its response path, so Yulin is the only thing that can tell the browser to
-reload. Turning `liveReload` on serves a reload channel and puts a small script into the HTML pages
-it serves to browsers:
+only Yulin in its response path. Yulin is the one thing that can tell the browser to reload. Turning
+`liveReload` on serves a reload channel and puts a small script into the HTML pages it serves to
+browsers:
 
 ```typescript sim-serve-live-reload
 /**
@@ -287,23 +285,22 @@ process.on("SIGTERM", () => {
 });
 ```
 
-It is off by default. With it off, no response differs by a byte from what it would otherwise be.
+It is off by default, and every response is then byte for byte what it would otherwise be.
 
 ### Reloading on a restart
 
 Local development means restarting the process, because a changed setup script or Lambda handler
-needs a fresh module graph. The script survives that on its own, with no supervisor process and
-nothing shared between the outgoing and incoming process.
+needs a fresh module graph. The script survives that on its own, with no supervisor process and no
+shared state between the outgoing and incoming process.
 
-The channel is Server-Sent Events rather than a WebSocket, so the browser reconnects by itself. Each
-process has a boot id and sends it to every page that connects. A page that reconnects and finds a
-different boot id knows it is showing output from a process that is no longer running, and reloads.
-A page that reconnects to the same boot id, which is what a blip on a still running process gives,
-does nothing.
+The channel is Server-Sent Events, and the browser reconnects by itself. Each process has a boot id
+and sends it to every page that connects. A page that reconnects and finds a different boot id knows
+it is showing output from a process that has gone, and reloads. A blip on a still running process
+hands back the same boot id, and the page carries on.
 
-`close()` sends a `reloading` event before the connections go, so a page knows the gap it is about to
-see is a restart rather than a server that has died. The page is not drawn over. It gets a
-`data-sim-aws-live-reload="reloading"` attribute on its `<html>` element, which it can style:
+`close()` sends a `reloading` event before the connections go. A page then reads the gap it is about
+to see as a restart, and not a server that has died. The page keeps its own appearance and gets a
+`data-sim-aws-live-reload="reloading"` attribute on its `<html>` element, ready to style:
 
 ```css
 html[data-sim-aws-live-reload="reloading"] {
@@ -311,14 +308,14 @@ html[data-sim-aws-live-reload="reloading"] {
 }
 ```
 
-The event has to reach the browser before the connection does, so `close()` sees the reload streams
-out before it destroys anything else the server was holding, and its promise settles once they have
-gone. A browser that has stopped answering is waited on for half a second and then dropped, so a page
-nobody is looking at cannot hold up a restart. Both ports are released before any of that waiting, so
-a replacement process can take them straight away either way.
+The event has to reach the browser before the connection goes. `close()` sees the reload streams out
+before it destroys anything else the server was holding, and its promise settles once they have
+gone. A browser that has stopped answering is waited on for half a second and then dropped. A page
+nobody is looking at cannot hold up a restart. Both ports are released before any of that waiting,
+and a replacement process can take them straight away either way.
 
-This works with no supervisor process involved, so a dev script started from an IDE debugger gets
-browser reload with the debugger attached throughout.
+None of this needs a supervisor process. A dev script started from an IDE debugger gets browser
+reload with the debugger attached throughout.
 
 ### Reloading without a restart
 
@@ -352,18 +349,18 @@ srv.reload();
 await srv.close();
 ```
 
-`reload()` throws when live reload is off, rather than quietly doing nothing.
+`reload()` throws when live reload is off.
 
-Rather than calling it yourself, hand the server to something that reloads for you: a
+You can also hand the server to something that reloads for you, either a
 [mounted directory](#reloading-when-a-build-changes-a-mounted-directory) or a
 [watched template file](#answering-a-change-instead-of-restarting), both as `{ reload: srv }`. A
-watched template file refuses a server it could never reload as it is handed over, rather than on
-the first change.
+watched template file refuses a server it could never reload as it is handed over, ahead of the
+first change.
 
 ### Reloading when a build changes a mounted directory
 
-A Bucket mounted on a local directory is already reading the files a site generator writes, so a
-rebuild needs nothing copying into it. Hand the mount the server and it watches the directory and
+A Bucket mounted on a local directory is already reading the files a site generator writes. A
+rebuild needs nothing copied into it. Hand the mount the server and it watches the directory and
 reloads for you once the writes stop:
 
 ```typescript sim-serve-mount-reload
@@ -395,16 +392,16 @@ for the `settleMs` override and for stopping the watch.
 
 ### What gets the script
 
-Yulin's own account of a request goes in headers and never in the body, so a response keeps the shape
+Yulin's own account of a request goes in headers and never in the body. A response keeps the shape
 the real service returns. Live reload breaks that rule on purpose, and only for a page a browser is
 about to render. A response gets the script only when all of this holds:
 
 - the response media type is `text/html` exactly
 - the request `accept` header asks for `text/html`
-- the request carries no SigV4 signature, in either an `authorization` header or
-  the query string of a presigned URL, and no `x-amz-*` header
+- the request carries no SigV4 signature, in either an `authorization` header or the query string of
+  a presigned URL, and no `x-amz-*` header
 - the response has no `content-encoding`
-- the response status is not 206, and the request is not a `HEAD`
+- the response status is other than 206, and the request is not a `HEAD`
 
 So an SDK `GetObject` for an HTML Object gets the stored bytes, byte for byte, while a browser
 looking at the same Object through a website endpoint gets the script.
@@ -413,13 +410,13 @@ An injected response carries `x-sim-aws-live-reload: injected`. Its `content-len
 and `etag` and `last-modified` are dropped, since the bytes are no longer the ones those headers
 describe. Its `cache-control` is set to `no-store`, replacing whatever the service said, because a
 page held in the browser cache is a page live reload cannot reach. The script goes in before
-`</body>`, or before `</html>` when there is no body element, or on the end when the HTML has
-neither.
+`</body>`, or before `</html>` when there is no body element, or on the end when the HTML has no
+such element.
 
 ### The reserved path
 
-The reload channel is served at `/__sim-aws/live-reload` on every hostname the server answers on, so
-a page can ask for it relative to wherever it was served from. While live reload is on, no simulated
+The reload channel is served at `/__sim-aws/live-reload` on every hostname the server answers on. A
+page can ask for it relative to wherever it was served from. While live reload is on, no simulated
 service can serve anything at that path.
 
 ## Restarting on a file change
@@ -432,19 +429,19 @@ yulin watch -- tsx dev.ts
 ```
 
 Everything after `--` is the command, run as written and restarted when something changes. The CLI
-does not import it, does not look for an exported setup function, and does not care whether the
+never imports it, never looks for an exported setup function, and takes no interest in whether the
 simulation was built from SDK commands, a CloudFormation template, or several `SimAws` instances at
 once. The only change to a dev script is turning `liveReload` on.
 
-A restart, rather than swapping code in place, is the deliberate choice. A Lambda handler is a
-function reference out of your own module graph, and a new process re-imports it with no module cache
-to defeat. It also keeps simulated state the same as what a fresh test run sees, since seeding is
-part of the setup script and runs again.
+Restarting is the deliberate choice, over swapping code in place. A Lambda handler is a function
+reference out of your own module graph, and a new process re-imports it with no module cache to
+defeat. It also keeps simulated state the same as what a fresh test run sees, since seeding is part
+of the setup script and runs again.
 
 ### What is watched
 
-The working directory, minus what nothing edits by hand: `node_modules`, `.git`, `dist`, `coverage`,
-CDK asset directories, and the working files an editor writes around a save.
+The working directory, minus the paths nobody edits by hand. Those are `node_modules`, `.git`,
+`dist`, `coverage`, CDK asset directories, and the working files an editor writes around a save.
 
 On top of that, Yulin names paths it is holding that the module graph never mentions. A directory
 given to `mountBucketFilesystem` and a template given to `deployTemplateFile` are reported to the
@@ -452,33 +449,33 @@ supervisor as they are registered, and watched from then on, without appearing i
 a file in a mounted directory or re-synthing a stack restarts the process.
 
 A path the process is watching itself is the exception, and is
-[left to the process reading it](#answering-a-change-instead-of-restarting): a template deployed
-with the `watch` option, and a directory mounted with somewhere to reload. So is any other path the
-process [says it is holding](#holding-a-path-yourself).
+[left to the process reading it](#answering-a-change-instead-of-restarting). That covers a template
+deployed with the `watch` option, and a directory mounted with somewhere to reload. So is any other
+path the process [says it is holding](#holding-a-path-yourself).
 
 ### One restart for a burst of writes
 
-A burst of writes is one restart. Saving one file is several filesystem events, so changes are held
-until they stop arriving before anything is restarted. The wait is 250ms by default, and a build
-writing hundreds of files is one restart rather than one per file.
+A burst of writes is one restart. Saving one file is several filesystem events, and changes are held
+until they stop arriving before anything is restarted. The wait is 250ms by default. A build writing
+hundreds of files gets one restart, however many files it wrote.
 
-The number is what a build needs rather than what a save needs. macOS hands a recursive watch its
-events in waves rather than one at a time: a build writing several thousand files was measured
-arriving as tens of waves up to 49ms apart, so a window anywhere near that turns one build into
-several restarts. A build that pauses between its own phases, as a tool that resolves before it
-writes does, pauses for longer than that again. 250ms clears the waves several times over and covers
-the shorter of those pauses, at the cost of 250ms before a plain save is acted on.
+The number is set by what a build needs, and a save pays for it. macOS hands a recursive watch its
+events in waves. A build writing several thousand files was measured arriving as tens of waves up to
+49ms apart, and a window anywhere near that turns one build into several restarts. A build that
+pauses between its own phases, as a tool that resolves before it writes does, pauses for longer than
+that again. 250ms clears the waves several times over and covers the shorter of those pauses, at the
+cost of 250ms before a plain save is acted on.
 
-A project whose build is unusual can say so, rather than moving the default:
+A project whose build is unusual can say so on the command line:
 
 ```bash
 yulin watch --settle=600 -- tsx dev.ts
 ```
 
-Writes that keep arriving push the wait back, so a build that never goes quiet would otherwise hold
-the restart off for as long as it ran. A burst is acted on after five seconds however much is still
+Writes that keep arriving push the wait back. A build that never goes quiet would otherwise hold the
+restart off for as long as it ran, so a burst is acted on after five seconds however much is still
 arriving, and the writes after that are a burst of their own. That is a backstop for a build that
-writes continuously for minutes, not something an ordinary build reaches.
+writes continuously for minutes. An ordinary build never reaches it.
 
 ### Holding a path yourself
 
@@ -517,23 +514,23 @@ watch(built, { recursive: true }, () => {
 
 A static site build writing into that directory then reloads the page, where the mount alone would
 have restarted the process and taken every simulated Bucket, Table and Stack with it. Holding a path
-beats having reported it: being told a path is answered in the process is more specific than being
-told it is worth watching, so it wins even though `mountBucketFilesystem` reported the same directory
-first.
+beats having reported it. Being told a path is answered in the process is more specific than being
+told it is worth watching, so holding wins even though `mountBucketFilesystem` reported the same
+directory first.
 
-A held path stays held only for the run that reported it. A run that exits leaves nothing holding
-the path, and the supervisor watches it again until its replacement says otherwise.
+A held path stays held only for the run that reported it. A run that exits releases the path, and
+the supervisor watches it again until its replacement says otherwise.
 
-`simWatch.onStopping(...)` is the other half, for a restart this process does not decide: it runs
-just before the supervisor kills the process, which is where live reload tells browsers a reload is
-coming so a page comes back on its own. A hand-written reload channel wants the same warning.
+`simWatch.onStopping(...)` is the other half, for a restart this process has no say in. It runs just
+before the supervisor kills the process. Live reload uses that moment to tell browsers a reload is
+coming, so a page comes back on its own. A hand-written reload channel wants the same warning.
 
-Both are best effort and need a supervisor. In a process `yulin watch` did not start, such as a test
-run or a script launched from an IDE debugger, they do nothing at all.
+Both are best effort and need a supervisor. In a process `yulin watch` never started, such as a test
+run or a script launched from an IDE debugger, both are no-ops.
 
 This is the general case, for a path nothing else knows about. A mounted directory is the one Yulin
-does know about: `mountBucketFilesystem` takes a reload target, holds the path itself and settles the
-writes, so the example above is written for you. See
+does know about. `mountBucketFilesystem` takes a reload target, holds the path itself and settles
+the writes, so the example above is written for you. See
 [reloading when a build changes a mounted directory](#reloading-when-a-build-changes-a-mounted-directory).
 
 ### Answering a change instead of restarting
@@ -560,23 +557,22 @@ await simAws.cloudFormation().deployTemplateFile({
 ```
 
 Re-synthing the stack then updates it in place and reloads the page. The reload waits for the update
-rather than the write, so the page comes back on the resources the new template asked for, and an
-update that failed reloads nothing. Whatever the change left alone keeps what it holds in simulated
-S3, DynamoDB and SQS, where a restart would have taken all of it. The process names the template as
-one it is answering itself, so the supervisor takes it off its own list rather than restarting for
-it. See
+and not the write. The page comes back on the resources the new template asked for, and an update
+that failed reloads nothing. Whatever the change left alone keeps what it holds in simulated S3,
+DynamoDB and SQS, where a restart would have taken all of it. The process names the template as one
+it is answering itself, and the supervisor takes it off its own list. See
 [watching a template file](../services/cloudformation/README.md#watching-a-template-file) for what
 an update does to the resources.
 
 A directory mounted with somewhere to reload is left alone the same way. The Bucket is reading the
-files either way, so a rebuild has nothing to redo: the browser is reloaded and everything else the
-process is holding stays where it is, rather than the whole simulated environment going for the sake
-of a page that changed. See
+files either way, and a rebuild has nothing to redo. The browser is reloaded, and everything else
+the process is holding stays where it is. A restart would have taken the whole simulated environment
+for the sake of a page that changed. See
 [reloading when a build changes a mounted directory](#reloading-when-a-build-changes-a-mounted-directory).
 
 A template synthesized against a real account sometimes needs adapting before Yulin will take it.
 `transform` is given the parsed template and answers with the one to deploy, on the deployment and
-again on every change, so the file the supervisor leaves alone is still the one in `cdk.out`:
+again on every change. The file the supervisor leaves alone is still the one in `cdk.out`:
 
 ```typescript sim-serve-transform-template
 /**
@@ -607,12 +603,12 @@ await simAws.cloudFormation().deployTemplateFile({
 });
 ```
 
-A transform that throws is reported the way a failed update is, so the process and the resources it
-is serving are left where they were. See
+A transform that throws is reported the way a failed update is. The process and the resources it is
+serving are left where they were. See
 [adapting a synthesized template](../services/cloudformation/README.md#adapting-a-synthesized-template-on-the-way-in).
 
-Both work with no supervisor at all, so a dev script started from an IDE debugger picks up a
-re-synth or a rebuild with the debugger attached throughout.
+Both work with no supervisor at all. A dev script started from an IDE debugger picks up a re-synth
+or a rebuild with the debugger attached throughout.
 
 ### When a run goes wrong
 
@@ -620,16 +616,15 @@ A setup script that throws leaves the watcher up. The error is on the terminal a
 the retry, with no watch to start over.
 
 Setup that writes into a watched path restarts the process, which writes again, which restarts it.
-That is refused rather than run: after a few restarts caused by the same file changing straight after
-startup, `yulin watch` stops and names the file. Write generated files outside the working directory,
-or into a directory the watch passes over.
+`yulin watch` refuses to run that loop. After a few restarts caused by the same file changing
+straight after startup, it stops and names the file. Write generated files outside the working
+directory, or into a directory the watch passes over.
 
 ### Debugging
 
-A process started by `yulin watch` can be debugged, but the debugger has to attach to that process
-rather than to the supervisor, which does nothing worth stepping through. Pass an inspector flag to
-the watch and it reaches each run through `NODE_OPTIONS`, so it works whether the command is `node`
-or something that spawns it:
+A process started by `yulin watch` can be debugged. Attach the debugger to that process, and not to
+the supervisor, which has nothing worth stepping through. Pass an inspector flag to the watch and it
+reaches each run through `NODE_OPTIONS`, whether the command is `node` or something that spawns it:
 
 ```bash
 yulin watch --inspect=9230 -- tsx dev.ts
@@ -637,11 +632,11 @@ yulin watch --inspect=9230 -- tsx dev.ts
 
 Each run binds the same inspector port, because the process it replaces has fully exited by the time
 the replacement starts. Attaching to that port with reconnect turned on in your IDE keeps a debugger
-across restarts. The exact run configuration differs between IDEs and is not documented here yet.
+across restarts. The exact run configuration differs between IDEs.
 
-Nothing about live reload needs the supervisor. A dev script launched straight from an IDE debugger
-still gets browser reload and still picks up a re-synthed template, and a handler edit is a manual
-restart as it is without watch mode.
+Live reload works without the supervisor. A dev script launched straight from an IDE debugger still
+gets browser reload and still picks up a re-synthed template. A handler edit is a manual restart, as
+it is without watch mode.
 
 ## Limitations
 
@@ -659,7 +654,7 @@ restart as it is without watch mode.
   change touches go with it. Only the resources the template left alone keep what they hold.
 - Lambda and CloudFront Function code is not swapped without a restart. A fresh process picks up an
   edited handler correctly, and an in-process swap would have to invalidate an ESM import subgraph
-  that the language does not expose.
+  that the language keeps private.
 - Simulated state is not carried across a restart. Seeding belongs in the setup script, so it runs
   again and local state stays the same as what tests and CI see.
 - The IDE run configurations for attaching a debugger to a watched process are not documented yet.

--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -4,7 +4,7 @@ Yulin includes a simulated DynamoDB for tests and local development. Tables are 
 every operation is authorized by simulated IAM.
 
 This page covers creating, describing, listing and deleting tables. What a request says is checked
-the way real DynamoDB checks it, so a table that can be created here is one that could be created on
+the way real DynamoDB checks it. A table that can be created here is one that could be created on
 AWS.
 
 DynamoDB-specific types are imported from the `@kensio/yulin/dynamodb` subpath.
@@ -45,8 +45,8 @@ await simAws.backgroundTasksComplete();
 A new table is `CREATING`, and activation is scheduled as background work. Call
 `simAws.backgroundTasksComplete()` when a test needs the table to be `ACTIVE`.
 
-The description carries back what the request asked for: the key schema, the attribute definitions,
-the table ARN, a table ID, and the billing and capacity the table was created with.
+The description carries back what the request asked for. That is the key schema, the attribute
+definitions, the table ARN, a table ID, and the billing and capacity the table was created with.
 
 ## Key schema and attribute definitions
 
@@ -55,16 +55,16 @@ The key schema holds one `HASH` element, optionally followed by one `RANGE` elem
 
 `AttributeDefinitions` and the key attributes have to name exactly the same attributes. An attribute
 defined that no key uses is a `ValidationException`, and so is a key attribute with no definition.
-DynamoDB is only schemaless about the attributes that are not keys.
+DynamoDB is only schemaless about the non-key attributes.
 
 A key attribute is one of `S`, `N` or `B`, and an item written to the table has to carry every key
 attribute as the type the table declared for it.
 
 ## Billing modes and throughput
 
-`BillingMode` defaults to `PROVISIONED`, which makes `ProvisionedThroughput` required with at least
-one read and one write capacity unit. A request that leaves both out asks for a provisioned table
-with nothing provisioned, and is refused.
+`BillingMode` defaults to `PROVISIONED`, making `ProvisionedThroughput` required with at least one
+read and one write capacity unit. A request that leaves both out asks for a provisioned table with
+no capacity, and is refused.
 
 `PAY_PER_REQUEST` refuses `ProvisionedThroughput`, since an on-demand table has no capacity to
 provision.
@@ -103,10 +103,10 @@ console.log(throughput?.WriteCapacityUnits); // 3
 await simAws.backgroundTasksComplete();
 ```
 
-An on-demand table reports `ReadCapacityUnits` and `WriteCapacityUnits` of 0, which is what real
-DynamoDB reports for one.
+An on-demand table reports `ReadCapacityUnits` and `WriteCapacityUnits` of 0, as real DynamoDB
+reports for one.
 
-`TableClass` is stored and reported, and changes nothing else: nothing bills a table here.
+`TableClass` is stored and reported, and changes nothing else, since no billing happens here.
 `DeletionProtectionEnabled` does change what the table does, and is covered under deleting a table.
 
 ## Global secondary indexes
@@ -169,17 +169,17 @@ await dynamoDb.putItem(
 
 `AttributeDefinitions` has to match the table key schema and every index key schema exactly, in both
 directions. Declaring an index without adding its key attribute definitions is a
-`ValidationException`, and so is defining an attribute no key uses. This is where `CreateTable` input
-most often goes wrong.
+`ValidationException`, and so is defining an attribute no key uses. This is where `CreateTable`
+input most often goes wrong.
 
-An index key schema takes the same shape the table's does: one `HASH` element, optionally followed by
-one `RANGE` element, with key attributes of `S`, `N` or `B`. Index names are unique within a table,
-and a table holds at most 20 indexes.
+An index key schema takes the same shape the table's does, with one `HASH` element, optionally
+followed by one `RANGE` element, and key attributes of `S`, `N` or `B`. Index names are unique
+within a table, and a table holds at most 20 indexes.
 
 `Projection` says which attributes the index carries. `ALL` is the whole item, `KEYS_ONLY` is the
 index keys plus the table keys, and `INCLUDE` adds 1 to 20 `NonKeyAttributes` to those. `INCLUDE`
-with no attributes named is refused, since it would add nothing to `KEYS_ONLY`, and attributes named
-under either of the other two types are refused as well.
+with no attributes named is refused, since it would add no attribute to `KEYS_ONLY`, and attributes
+named under either of the other two types are refused as well.
 
 A table projects at most 100 `NonKeyAttributes` across all of its indexes, as well as 20 in any one
 of them. An attribute projected into two indexes counts twice.
@@ -189,25 +189,25 @@ refuses one, since an on-demand index has no capacity to provision.
 
 The description reports each index with its `IndexName`, `IndexArn`, `KeySchema`, `Projection`,
 `ProvisionedThroughput` and `IndexStatus`. The index ARN is the table's own with the index named
-under it. An index status follows its table's, so it is `CREATING` on the `CreateTable` response and
-`ACTIVE` once the table is. A table that declared no index leaves `GlobalSecondaryIndexes` out of its
-description altogether.
+under it. An index status follows its table's. It is `CREATING` on the `CreateTable` response and
+`ACTIVE` once the table is. A table that declared no index leaves `GlobalSecondaryIndexes` out of
+its description altogether.
 
-An index is sparse, so an item missing any one of an index's key attributes is absent from that index
-rather than refused on the write. An index keyed on two attributes needs both. The one thing a write
-is held to on account of an index is the type: an item carrying an index key attribute as a type the
-index did not declare is a `ValidationException`, since the index could never hold it.
+An index is sparse. An item missing any one of an index's key attributes is absent from that index,
+and the write itself still succeeds. An index keyed on two attributes needs both. The one thing a
+write is held to on account of an index is the type. An item carrying an index key attribute as a
+type the index did not declare is a `ValidationException`, since the index could never hold it.
 
 ## Local secondary indexes
 
-`LocalSecondaryIndexes` on `CreateTable` gives an item collection a second sort key. The index shares
-the table's partition key, so an entry sits in the same partition as the item it indexes, and its
-sort key is some other attribute. That is what serves an access pattern such as "this customer's
+`LocalSecondaryIndexes` on `CreateTable` gives an item collection a second sort key. The index
+shares the table's partition key. An entry sits in the same partition as the item it indexes, and
+its sort key is some other attribute. That is what serves an access pattern such as "this customer's
 orders in date order" against a table keyed by customer and order id.
 
 `CreateTable` is the only place one can be declared. AWS has no call that adds, changes or removes a
-local secondary index afterwards, so a table created without one stays without it for the whole of
-its life.
+local secondary index afterwards. A table created without one stays without it for the whole of its
+life.
 
 ```typescript sim-dynamodb-local-secondary-index
 /**
@@ -312,26 +312,26 @@ const whole = await dynamoDb.query(
 console.log(whole.Items?.[0]?.["total"]?.N); // "42"
 ```
 
-The key schema is what a declaration is held to. The `HASH` element is the table's own partition key,
-and a `RANGE` element is required and names some other attribute. An index sorted by the attribute
-the table is already sorted by is refused, since it would repeat the order the table is in, and so is
-one keyed on a partition key of its own. A table with no sort key at all takes no local secondary
-index, because it holds one item per partition key and there is no collection for a second sort key
-to reorder.
+The key schema is what a declaration is held to. The `HASH` element is the table's own partition
+key, and a `RANGE` element is required and names some other attribute. An index sorted by the
+attribute the table is already sorted by is refused, since it would repeat the order the table is
+in, and so is one keyed on a partition key of its own. A table with no sort key at all takes no
+local secondary index, because it holds one item per partition key and there is no collection for a
+second sort key to reorder.
 
 A table holds at most 5 local secondary indexes. Index names are unique within a table across both
-kinds, so a local secondary index cannot take the name of a global one. `Projection` follows the same
-`ALL`, `KEYS_ONLY` and `INCLUDE` rules a global secondary index does, and the 100 `NonKeyAttributes`
-a table projects is counted across every index of both kinds.
+kinds, and a local secondary index cannot take the name of a global one. `Projection` follows the
+same `ALL`, `KEYS_ONLY` and `INCLUDE` rules a global secondary index does, and the 100
+`NonKeyAttributes` a table projects is counted across every index of both kinds.
 
 A per-index `ProvisionedThroughput` is refused. A local secondary index is read and written out of
-the table's own capacity, so there is nothing to provision for it, and real DynamoDB has no
+the table's own capacity. There is no capacity to provision for it, and real DynamoDB has no
 throughput field on a `LocalSecondaryIndex` at all.
 
 The description reports each index with its `IndexName`, `IndexArn`, `KeySchema` and `Projection`.
-There is no `IndexStatus` and no `ProvisionedThroughput`, since the index is built with the table and
-shares its capacity. A table that declared none leaves `LocalSecondaryIndexes` out of its description
-altogether.
+There is no `IndexStatus` and no `ProvisionedThroughput`, since the index is built with the table
+and shares its capacity. A table that declared none leaves `LocalSecondaryIndexes` out of its
+description altogether.
 
 ## Describing a table
 
@@ -342,11 +342,11 @@ The `TableName` parameter takes the table's name or its ARN.
 
 ## Listing tables
 
-`ListTables` returns table names in DynamoDB's order, which is by UTF-8 bytes. `Limit` takes a whole
+`ListTables` returns table names in DynamoDB's order, sorted by UTF-8 bytes. `Limit` takes a whole
 number from 1 to 100 and defaults to 100.
 
 `LastEvaluatedTableName` is the name to resume from, and it is absent on the last page. That is what
-lets a caller loop until it is gone rather than until a page comes back empty.
+lets a caller loop until it is gone, rather than until a page comes back empty.
 
 ```typescript sim-dynamodb-list-tables
 /**
@@ -390,8 +390,8 @@ console.log(names); // ["TableA", "TableB", "TableC"]
 await simAws.backgroundTasksComplete();
 ```
 
-A token naming a table that has since been deleted still works: a page resumes at the first name
-after the token rather than at a remembered position.
+A token naming a table that has since been deleted still works. A page resumes at the first name
+after the token.
 
 ## Updating a table
 
@@ -402,14 +402,14 @@ after the token rather than at a remembered position.
 - remove one global secondary index
 
 A request combining two of them is a `ValidationException`. `TableClass` and
-`DeletionProtectionEnabled` are not one of the three and can ride along with any of them, or stand on
+`DeletionProtectionEnabled` sit outside the three and can ride along with any of them, or stand on
 their own.
 
 The table goes to `UPDATING` at once and settles back to `ACTIVE` once the scheduled background work
-has run. It serves reads and writes throughout, since AWS does not take a table offline to update it.
-A second `UpdateTable` while one is in flight is a `ResourceInUseException`.
+has run. It serves reads and writes throughout, since AWS keeps a table online while updating it. A
+second `UpdateTable` while one is in flight is a `ResourceInUseException`.
 
-Adding an index is the change most likely to go wrong in a deployment, so it is worth writing a test
+Adding an index is the change most likely to go wrong in a deployment. It is worth writing a test
 against. The new index is on the table straight away with an `IndexStatus` of `CREATING` and
 `Backfilling` true, and cannot be read until it is `ACTIVE`. A `Query` or a `Scan` against it before
 then is refused with `Cannot read from backfilling global secondary index`, which is what real
@@ -514,13 +514,13 @@ console.log(described.Table?.GlobalSecondaryIndexes); // undefined
 ```
 
 Removing an index takes it out of `DescribeTable`, after which a read naming it gives
-`ResourceNotFoundException`. Deleting one the table does not have gives the same, since there is no
-such index either way.
+`ResourceNotFoundException`. Deleting one the table lacks gives the same, since there is no such
+index either way.
 
-A request carrying `ProvisionedThroughput` and no `BillingMode` reprovisions the table under the mode
-it already has, so setting capacity on an on-demand table is refused rather than quietly switching
-it. Switching to `PROVISIONED` has to state the capacity here, which real DynamoDB estimates instead;
-see Limitations.
+A request carrying `ProvisionedThroughput` and no `BillingMode` reprovisions the table under the
+mode it already has, so setting capacity on an on-demand table is refused, and never quietly
+switched. Switching to `PROVISIONED` has to state the capacity here, which real DynamoDB estimates
+instead. See Limitations.
 
 ## Deleting a table
 
@@ -530,7 +530,7 @@ gone.
 
 Real DynamoDB only deletes a table that is `ACTIVE`. One that is still `CREATING` or `UPDATING`
 answers `ResourceInUseException`, and one that has gone answers `ResourceNotFoundException`.
-Deleting a table that is already deleting is not an error.
+Deleting a table that is already deleting succeeds.
 
 A table created with `DeletionProtectionEnabled` refuses to be deleted at all, and stays as it was.
 
@@ -640,19 +640,19 @@ console.log(Tags); // [{ Key: "Environment", Value: "staging" }]
 ```
 
 `TagResource` and `UntagResource` answer with an empty body, so `ListTagsOfResource` is the only way
-to see what either did. Untagging a key that is not there is not an error: the request asks for a
-table without that key, and that is what it gets either way.
+to see what either did. Untagging a key that was never set succeeds. The request asks for a table
+without that key, and that is what it gets either way.
 
 The rules a tag is held to are DynamoDB's:
 
-- a key is 1 to 128 characters, and a value is 0 to 256, so a key with nothing to say about itself
-  is a tag with an empty value
-- both are written with letters, whitespace, digits and `+ - = . _ : /`, which is narrower than
-  the set some other AWS services take: there is no `@` in it
+- a key is 1 to 128 characters, and a value is 0 to 256, and a key with no value of its own is a tag
+  with an empty value
+- both are written with letters, whitespace, digits and `+ - = . _ : /`, narrower than the set some
+  other AWS services take, with no `@` in it
 - a key beginning `aws:` is refused, since that prefix is AWS's to assign
 - a resource holds 50 tags
 
-A request that breaks one of those is refused whole, so a call carrying one good tag and one bad one
+A request that breaks one of those is refused whole. A call carrying one good tag and one bad one
 leaves the table's tags exactly as they were.
 
 `ListTagsOfResource` pages with `NextToken`, and leaves the token off the last page:
@@ -674,18 +674,18 @@ do {
 } while (nextToken !== undefined);
 ```
 
-A page carries 25 tags. The API has no page size parameter, so that number is this simulator's
-rather than DynamoDB's: it is half of the 50 a resource holds, so an ordinarily tagged table lists
-in one page and a test that wants to see a `NextToken` can reach one with 26 tags.
+A page carries 25 tags. The API has no page size parameter. That number is this simulator's own
+choosing. It is half of the 50 a resource holds, which puts an ordinarily tagged table in one page
+and lets a test that wants to see a `NextToken` reach one with 26 tags.
 
-An `AWS::DynamoDB::Table` template property of `Tags` is deployed the same way, so a CDK app calling
-`Tags.of(stack).add("Environment", "test")` gets a tagged table.
+An `AWS::DynamoDB::Table` template property of `Tags` is deployed the same way, and a CDK app
+calling `Tags.of(stack).add("Environment", "test")` gets a tagged table.
 
 ## Writing items
 
 `PutItem` writes one item, replacing the whole item under its primary key rather than merging into
-it. The item is there by the time the call returns, so a write and the read that follows it need
-nothing in between.
+it. The item is there by the time the call returns. A write and the read that follows it need no
+step in between.
 
 ```typescript sim-dynamodb-put-item
 /**
@@ -740,8 +740,8 @@ anywhere else in the item.
 ## Reading and deleting items
 
 `GetItem` reads one item by its primary key, and `DeleteItem` removes one the same way. The `Key`
-both take is the whole primary key and nothing else. A missing key element, an attribute that is not
-part of the key, or a value whose type does not match the table's `AttributeDefinitions` is a
+both take is the whole primary key and nothing else. A missing key element, an attribute outside the
+key, or a value whose type fails to match the table's `AttributeDefinitions` is a
 `ValidationException` naming the attribute at fault.
 
 ```typescript sim-dynamodb-get-delete-item
@@ -807,16 +807,16 @@ const missing = await dynamoDb.getItem(
 console.log(missing.Item); // undefined
 ```
 
-A key that holds nothing comes back with no `Item` at all, rather than an empty one. That absence is
-how a caller tells a miss from an item carrying nothing but its key.
+A key that holds nothing comes back with no `Item` at all, and not an empty one. That absence is how
+a caller tells a miss from an item carrying nothing but its key.
 
-`ConsistentRead` is accepted whichever way it is set, and changes nothing. Every write has landed by
-the time the call that made it returns, so an eventually consistent read still answers with the
-latest write.
+`ConsistentRead` is accepted whichever way it is set, and has no effect. Every write has landed by
+the time the call that made it returns. An eventually consistent read still answers with the latest
+write.
 
-`DeleteItem` names a key rather than an item, so deleting a key that is already free succeeds and
-reports nothing removed. Its `ReturnValues` takes `NONE` and `ALL_OLD`, as `PutItem` does, and
-`ALL_OLD` answers with the item that was removed.
+`DeleteItem` names a key, never an item, so deleting a key that is already free succeeds and reports
+no removal. Its `ReturnValues` takes `NONE` and `ALL_OLD`, as `PutItem` does, and `ALL_OLD` answers
+with the item that was removed.
 
 Both take the table's name or its ARN, as the table commands do.
 
@@ -828,12 +828,12 @@ Each keyword appears at most once, and the actions inside a clause are separated
 
 A `SET` action is `path = operand`, where an operand is a value from `ExpressionAttributeValues`,
 another document path, or a call to `if_not_exists(path, operand)` or `list_append(one, other)`. Two
-operands can be joined by one `+` or `-`. An update expression carries no literals, so every constant
-arrives through `ExpressionAttributeValues`. A `REMOVE` action is a document path on its own, and
-removing an attribute that is not there succeeds without changing the item.
+operands can be joined by one `+` or `-`. An update expression carries no literals, so every
+constant arrives through `ExpressionAttributeValues`. A `REMOVE` action is a document path on its
+own, and removing an attribute that is absent succeeds without changing the item.
 
-Every action reads the item as it stood before the request, rather than the item being built. So
-this expression, against `{ a: 1, b: 2, c: 3 }`:
+Every action reads the item as it stood before the request, and never the item being built. So this
+expression, against an item of `{ a: 1, b: 2, c: 3 }`:
 
 ```text
 REMOVE a SET b = a, c = b
@@ -924,39 +924,39 @@ await dynamoDb.updateItem(
 );
 ```
 
-An assignment reading a document path the item does not have is a `ValidationException` rather than
-an assignment of nothing, as it is on AWS. `if_not_exists` is how an expression says what to assign
-when the attribute may be absent.
+An assignment reading a document path the item lacks is a `ValidationException`, as it is on AWS,
+and never an assignment of nothing. `if_not_exists` is how an expression says what to assign when
+the attribute may be absent.
 
 ### Counting and appending
 
 `SET count = count + :n` and `SET count = count - :n` work out a number. DynamoDB takes one operator
 between two operands, with no chaining and no brackets, so `:a + :b + :c` is refused. Arithmetic
-against an attribute that is not there is a `ValidationException`, which is why a counter is usually
+against an attribute that is absent is a `ValidationException`, which is why a counter is usually
 written `SET count = if_not_exists(count, :zero) + :one`.
 
-The arithmetic runs on the decimal digits an item holds rather than on JavaScript numbers. Adding 1
-to `9007199254740993` answers `9007199254740994` here, where an implementation going through a
-double answers `9007199254740992`. A total wider than the 38 significant digits DynamoDB carries is
-refused rather than rounded.
+The arithmetic runs on the decimal digits an item holds, never on JavaScript numbers. Adding 1 to
+`9007199254740993` answers `9007199254740994` here, where an implementation going through a double
+answers `9007199254740992`. A total wider than the 38 significant digits DynamoDB carries is
+refused, never rounded.
 
 `list_append(one, other)` puts two lists end to end in the order they were written, so
 `list_append(history, :entry)` appends and `list_append(:entry, history)` prepends.
 
-A `SET` at a list index past the end of the list appends rather than leaving a gap, and a `REMOVE`
-of a list element closes the list up. Every index an expression names is read against the stored
-item, so `REMOVE lines[0], lines[1]` takes away the first two elements rather than the first and
-the one that moved down into its place.
+A `SET` at a list index past the end of the list appends, and never leaves a gap, and a `REMOVE` of
+a list element closes the list up. Every index an expression names is read against the stored item,
+so `REMOVE lines[0], lines[1]` takes away the first two elements, and never the first and the one
+that moved down into its place.
 
 ### Adding to numbers and sets
 
 `ADD path :value` and `DELETE path :value` are written as a path and a value with nothing between
 them. Both work on a top-level attribute, as they do on AWS, and both take a value the request
-carries rather than a document path.
+carries, never a document path.
 
-`ADD` on a number adds mathematically. An attribute that is not there counts as zero, and a negative
+`ADD` on a number adds mathematically. An attribute that is absent counts as zero, and a negative
 value counts down. `ADD` on a set unions the value into the stored set, and creates the attribute
-when it is not there. The two sets have to be the same kind: adding a number set to a string set is
+when it is absent. The two sets have to be the same kind, and adding a number set to a string set is
 refused.
 
 AWS recommends `SET` over `ADD` for a number, and it is worth repeating here. A retried `ADD` counts
@@ -1039,13 +1039,13 @@ console.log(untagged.Attributes?.["tags"]?.SS); // [ "published" ]
 ```
 
 `DELETE` is set subtraction and nothing else. The value has to be a set of the kind the attribute
-holds, a member the set does not hold is not an error, and a subtraction that empties the set takes
-the attribute away with it, since DynamoDB has no empty set.
+holds, a member the set fails to hold is allowed, and a subtraction that empties the set takes the
+attribute away with it, since DynamoDB has no empty set.
 
 `ADD` and `DELETE` against a String, Binary, List or Map attribute are refused, as they are on AWS.
 
-Assigning into a map the item does not carry is a `ValidationException` too. `SET address.city = :c`
-needs an `address` map to write into, and an update does not make one on the way past.
+Assigning into a map the item lacks is a `ValidationException` too. `SET address.city = :c` needs an
+`address` map to write into, and an update never makes one on the way past.
 
 An update cannot move an item's primary key. Assigning to a key attribute, or removing one, is a
 `ValidationException` naming the attribute, since the request already names the item it works on
@@ -1066,9 +1066,10 @@ placeholder used by either counts as used.
 
 ## Conditional writes
 
-`PutItem`, `DeleteItem` and `UpdateItem` take a `ConditionExpression`, which is checked against
-whatever is stored under the key before anything changes. A condition that does not hold leaves the item exactly as it
-was and throws `ConditionalCheckFailedException`, with the name and message real DynamoDB uses.
+`PutItem`, `DeleteItem` and `UpdateItem` take a `ConditionExpression`, checked against whatever is
+stored under the key before anything changes. A condition that fails to hold leaves the item exactly
+as it was and throws `ConditionalCheckFailedException`, with the name and message real DynamoDB
+uses.
 
 That is how a write becomes an insert if absent, and how a version attribute becomes optimistic
 locking.
@@ -1143,41 +1144,41 @@ try {
 `ReturnValuesOnConditionCheckFailure` takes `NONE` and `ALL_OLD`. `ALL_OLD` puts the stored item on
 the exception as `Item`, and there is no `Item` when the key held nothing.
 
-The expression is read before the table is reached, so an expression DynamoDB would refuse is
+The expression is read before the table is reached, and an expression DynamoDB would refuse is
 refused whether or not the key holds anything.
 
 ### What a condition can say
 
-The comparators are `=`, `<>`, `<`, `<=`, `>` and `>=`. `BETWEEN` takes two bounds and counts both as
-inside. `IN` takes up to 100 operands. `AND`, `OR`, `NOT` and brackets combine them, with `NOT`
+The comparators are `=`, `<>`, `<`, `<=`, `>` and `>=`. `BETWEEN` takes two bounds and counts both
+as inside. `IN` takes up to 100 operands. `AND`, `OR`, `NOT` and brackets combine them, with `NOT`
 binding tighter than `AND` and `AND` tighter than `OR`. Keywords are read in any case, so `and`
 works as well as `AND`.
 
 The functions are `attribute_exists`, `attribute_not_exists`, `attribute_type`, `begins_with`,
 `contains` and `size`. Function names are read in lower case only, as they are on real AWS.
-`attribute_exists` is true for an attribute stored as `NULL`, since `NULL` is a value rather than an
-absent one. The first operand of every one of them names a path in the item, so a supplied value
-there is refused rather than compared. `size` is a number rather than a condition, so it goes beside a comparator: a string and
-binary measure in bytes, and a set, a list or a map in how many things it holds.
+`attribute_exists` is true for an attribute stored as `NULL`, since `NULL` is a value and not an
+absent one. The first operand of every one of them names a path in the item. A supplied value there
+is refused, never compared. `size` is a number and not a condition, so it goes beside a comparator.
+It measures a string or binary in bytes, and a set, a list or a map in how many things it holds.
 
-Strings compare by UTF-8 byte order, numbers compare by their digits rather than by what they round
-to, and binary compares as unsigned bytes.
+Strings compare by UTF-8 byte order, numbers compare by the digits they hold, and binary compares as
+unsigned bytes.
 
-A comparison between two different types is never an error. Equality works across types, so a string
-and a number are not equal: `=` is false and `<>` is true. Ordering does not, so `<`, `<=`, `>` and
-`>=` are all false between them, as they are for a path the item does not have. That is what real
-DynamoDB does, and it is what lets one condition guard items that do not all carry the same
+A comparison between two different types is never an error. Equality works across types, and a
+string and a number are unequal, with `=` false and `<>` true. Ordering fails across types, so `<`,
+`<=`, `>` and `>=` are all false between them, as they are for a path the item lacks. That is what
+real DynamoDB does, and it is what lets one condition guard items that do not all carry the same
 attributes.
 
-`ExpressionAttributeNames` and `ExpressionAttributeValues` have to agree exactly with the expression,
-in both directions: a placeholder the request does not define is a `ValidationException`, and so is
-an entry no expression uses.
+`ExpressionAttributeNames` and `ExpressionAttributeValues` have to agree exactly with the
+expression, in both directions. A placeholder the request leaves undefined is a
+`ValidationException`, and so is an entry no expression uses.
 
 ## Projecting attributes
 
-`GetItem` takes a `ProjectionExpression`, which is a comma-separated list of document paths. Only
-those paths come back. A path is an attribute name, then any number of `.attribute` dereferences and
-`[n]` list indexes: `address.city`, `lines[0].sku`.
+`GetItem` takes a `ProjectionExpression`, a comma-separated list of document paths. Only those paths
+come back. A path is an attribute name, then any number of `.attribute` dereferences and `[n]` list
+indexes, such as `address.city` or `lines[0].sku`.
 
 An attribute name that is a DynamoDB reserved word, or that has a character an expression cannot
 carry, is written as a `#name` placeholder and defined in `ExpressionAttributeNames`.
@@ -1241,25 +1242,25 @@ console.log(output.Item?.["lines"]?.L?.length);
 // 1
 ```
 
-A projected path the item does not have is left out. It is not an error, and it does not come back
-as a `NULL`, so an item with none of the projected paths answers with an `Item` holding nothing.
+A projected path the item lacks is left out. That is allowed, and it never comes back as a `NULL`.
+An item with none of the projected paths answers with an `Item` holding nothing.
 
 The placeholders and the expression have to agree exactly, in both directions. A `#name` the request
-does not define is a `ValidationException`, and so is an `ExpressionAttributeNames` entry no
+leaves undefined is a `ValidationException`, and so is an `ExpressionAttributeNames` entry no
 expression uses. The second is what a request hits after an expression is edited and the old
 placeholder is left behind.
 
-Two paths where one contains the other, such as `address, address.city`, are a `ValidationException`,
-as they are on real AWS: the pair does not say whether the whole map or one attribute of it was
-wanted. Naming one path twice counts the same way.
+Two paths where one contains the other, such as `address, address.city`, are a
+`ValidationException`, as they are on real AWS. The pair leaves it open whether the whole map or one
+attribute of it was wanted. Naming one path twice counts the same way.
 
-A document path goes at most 32 levels deep, which is as far as an item nests. A negative index, a
-fractional index and a path past that depth are each a `ValidationException` naming the path.
+A document path goes at most 32 levels deep, as far as an item nests. A negative index, a fractional
+index and a path past that depth are each a `ValidationException` naming the path.
 
 ## Querying an item collection
 
-A table with a sort key holds an item collection under each partition key: the items with that
-partition key, ordered by their sort key. `Query` reads one of those collections.
+A table with a sort key holds an item collection under each partition key, holding the items with
+that partition key, ordered by their sort key. `Query` reads one of those collections.
 
 `KeyConditionExpression` says which. It is one equality on the partition key, optionally joined by
 `AND` to one condition on the sort key. The sort key condition is `=`, `<`, `<=`, `>`, `>=`,
@@ -1338,13 +1339,13 @@ console.log(newestFirst.Items?.map((item) => item["orderId"]?.S));
 // [ "2027-01-02", "2026-03-01", "2026-01-14" ]
 ```
 
-The order is DynamoDB's rather than JavaScript's. A String sort key orders by its UTF-8 bytes, a
-Binary one as unsigned bytes, and a Number one by value however it was written, so `1E2` and `100`
-are one key rather than two and `9` sorts below `20`.
+The order is DynamoDB's and not JavaScript's. A String sort key orders by its UTF-8 bytes, a Binary
+one as unsigned bytes, and a Number one by value however it was written, so `1E2` and `100` are one
+key and not two, and `9` sorts below `20`.
 
 `begins_with` reads a prefix of a String or Binary sort key. Against a Number sort key it is a
-`ValidationException`, as it is on AWS: a number is stored as a value rather than as the digits it
-was written with, so it has no prefix.
+`ValidationException`, as it is on AWS. A number is stored as a value, never as the digits it was
+written with. It has no prefix.
 
 A query on a table with no sort key is allowed, and reads the one item under the partition key.
 
@@ -1353,20 +1354,20 @@ A query on a table with no sort key is allowed, and reads the one item under the
 The grammar is closed, and deliberately narrower than a `ConditionExpression`. Each of these is a
 `ValidationException` naming what was wrong:
 
-- a key condition that does not test the partition key for equality
+- a key condition that leaves the partition key untested for equality
 - a range operator or `begins_with` applied to the partition key
-- an operator or function a sort key condition does not take, such as `<>` or `contains`
-- an attribute that is not part of the table's primary key
+- an operator or function a sort key condition refuses, such as `<>` or `contains`
+- an attribute outside the table's primary key
 - `OR` or `NOT` anywhere
 - the same key attribute tested twice
 - a `BETWEEN` whose upper bound is below its lower bound, or whose bounds are different types
-- a value written into the expression rather than supplied through `ExpressionAttributeValues`
-- a value whose type is not the one the table declared for that key attribute, such as comparing an
-  `S` sort key against an `N`. A key attribute has one type, so the condition could never hold, and
-  an empty page would read as a collection that happens to hold nothing.
+- a value written into the expression, where `ExpressionAttributeValues` should supply it
+- a value whose type differs from the one the table declared for that key attribute, such as
+  comparing an `S` sort key against an `N`. A key attribute has one type, and the condition could
+  never hold, and an empty page would read as a collection that happens to hold nothing.
 
-An attribute name that is a DynamoDB reserved word is written as a `#name` placeholder and defined in
-`ExpressionAttributeNames`, as in any other expression.
+An attribute name that is a DynamoDB reserved word is written as a `#name` placeholder and defined
+in `ExpressionAttributeNames`, as in any other expression.
 
 ### Paging a collection
 
@@ -1436,20 +1437,19 @@ do {
 console.log(read); // [ "1", "2", "3" ]
 ```
 
-`LastEvaluatedKey` is left out only when the key range ran out inside the `Limit`. Reaching the limit
-on the last matching item still hands out a token, and the next call answers with an empty page and
-no token. That is what real DynamoDB does, since it cannot know the range is exhausted without
-looking past it, so a loop like the one above is the way to read a whole collection.
+`LastEvaluatedKey` is left out only when the key range ran out inside the `Limit`. Reaching the
+limit on the last matching item still hands out a token, and the next call answers with an empty
+page and no token. That is what real DynamoDB does, since it cannot know the range is exhausted
+without looking past it. A loop like the one above is the way to read a whole collection.
 
-A token still works when the item it names has since been deleted: it says where to resume rather
-than which position to return to. A token from a different partition key is refused, since it names
-a collection this query is not reading.
+A token still works when the item it names has since been deleted. It says where to resume. A token
+from a different partition key is refused, since it names a collection this query goes unreading.
 
 ## Reading a global secondary index
 
-`IndexName` on `Query` and `Scan` reads an index instead of the table. The key condition is held to
-the index key schema rather than the table's, which is the point: the index is how an access pattern
-the table key cannot serve gets served.
+`IndexName` on `Query` and `Scan` reads an index in place of the table. The key condition is held to
+the index key schema and not the table's, which is the point. The index is how an access pattern the
+table key cannot serve gets served.
 
 ```typescript sim-dynamodb-query-index
 /**
@@ -1525,55 +1525,56 @@ console.log(open.Items?.[0]?.["total"]?.N); // "42"
 console.log(open.Items?.[0]?.["note"]); // undefined
 ```
 
-The index is sparse. An item missing any of the index key attributes is not in the index, so a read
-of it simply does not find that item. Nothing about the write said so at the time.
+The index is sparse. An item missing any of the index key attributes stays out of the index. A read
+of it simply misses that item. The write itself said so at no point.
 
-An index key is not unique, so several items can share one. Items sharing an index key come back in
-no particular order, and `LastEvaluatedKey` carries the index key attributes together with the table
-key attributes, which is what names one of them exactly enough to resume after. An
+An index key can repeat, so several items can share one. Items sharing an index key come back in no
+particular order, and `LastEvaluatedKey` carries the index key attributes together with the table
+key attributes, and the two together name one of them exactly enough to resume after. An
 `ExclusiveStartKey` carrying only part of that is refused.
 
 A read answers with the attributes the index projects, so `Select` defaults to
-`ALL_PROJECTED_ATTRIBUTES` rather than `ALL_ATTRIBUTES`. Asking for more than the index carries is
-refused rather than quietly answered with less:
+`ALL_PROJECTED_ATTRIBUTES` in place of `ALL_ATTRIBUTES`. Asking for more than the index carries is
+refused outright:
 
-- `Select: ALL_ATTRIBUTES` against an index whose projection is not `ALL` is a `ValidationException`.
-- A `FilterExpression` naming an attribute the index does not project is refused too. The attribute
-  is not on the items the index holds, so the filter would drop all of them and the empty page would
+- `Select: ALL_ATTRIBUTES` against an index whose projection falls short of `ALL` is a
+  `ValidationException`.
+- A `FilterExpression` naming an attribute the index omits is refused too. The attribute is absent
+  from the items the index holds, and the filter would drop all of them and the empty page would
   read as a collection that happens to hold nothing.
 
-An `IndexName` the table does not have gives `ResourceNotFoundException` rather than reading the
-table. `ConsistentRead: true` against a global secondary index is a `ValidationException`, because a
-global secondary index is maintained asynchronously on AWS and cannot answer a strongly consistent
-read at all.
+An `IndexName` the table lacks gives `ResourceNotFoundException`. `ConsistentRead: true` against a
+global secondary index is a `ValidationException`, because a global secondary index is maintained
+asynchronously on AWS and cannot answer a strongly consistent read at all.
 
 `Scan` takes `IndexName` the same way, including in parallel segments, which divide by the index
 partition key rather than the table's.
 
 ## Reading a local secondary index
 
-`IndexName` reaches a local secondary index the same way, and the walk is the same walk: the index is
-sparse, the key condition is held to the index key schema, and `Scan` takes the index too. Two things
-differ, and both follow from the index sitting in the same partition as the item it indexes.
+`IndexName` reaches a local secondary index the same way, and the walk is the same walk. The index
+is sparse, the key condition is held to the index key schema, and `Scan` takes the index too. Two
+things differ, and both follow from the index sitting in the same partition as the item it indexes.
 
-`ConsistentRead: true` is answered rather than refused. The index is written with the item, in the
-same partition, so there is no window in which it lags behind the table.
+`ConsistentRead: true` is answered here. The index is written with the item, in the same partition.
+There is no window in which it lags behind the table.
 
-An attribute the index does not project is fetched from the base table rather than refused. So
-`Select: ALL_ATTRIBUTES` against a `KEYS_ONLY` index answers with whole items, and a
-`FilterExpression` may name any attribute of the item rather than only a projected one. Real DynamoDB
-charges the extra read capacity for that fetch. A read that asks for neither still answers with what
-the index projects, since `Select` defaults to `ALL_PROJECTED_ATTRIBUTES` on any index.
+An attribute the index omits is fetched from the base table, and never refused. So `Select:
+ALL_ATTRIBUTES` against a `KEYS_ONLY` index answers with whole items, and a `FilterExpression` may
+name any attribute of the item, and never only a projected one. Real DynamoDB charges the extra read
+capacity for that fetch. A read that asks for one of those anyway still answers with what the index
+projects, since `Select` defaults to `ALL_PROJECTED_ATTRIBUTES` on any index.
 
-`LastEvaluatedKey` carries three attributes: the table partition key, the index sort key and the
-table sort key. Two entries can share a whole index key, so the table sort key is what names one of
-them exactly enough to resume after. An `ExclusiveStartKey` missing any of the three is refused.
+`LastEvaluatedKey` carries three attributes, which are the table partition key, the index sort key
+and the table sort key. Two entries can share a whole index key. The table sort key is what names
+one of them exactly enough to resume after. An `ExclusiveStartKey` missing any of the three is
+refused.
 
 ## Scanning a table
 
-`Scan` reads every item in a table. It needs no key knowledge at all, which is what makes it the
+`Scan` reads every item in a table. It needs no key knowledge at all. That is what makes it the
 operation test setup and assertions reach for, and the wrong operation for most application access
-patterns: it reads the whole table however few items the caller wanted.
+patterns, since it reads the whole table however few items the caller wanted.
 
 ```typescript sim-dynamodb-scan
 /**
@@ -1641,17 +1642,17 @@ console.log(
 // [ "2026-01", "2026-02", "2026-03" ]
 ```
 
-The partition key values themselves come back in an arbitrary order. It is not the sorted order and
-not the order the items were written in. Real DynamoDB walks a table by the hash of the partition
-key, so a scan that came back globally sorted would be something no real table gives you, and a test
-leaning on one would pass here and fail against the service.
+The partition key values themselves come back in an arbitrary order. It is neither the sorted order
+nor the order the items were written in. Real DynamoDB walks a table by the hash of the partition
+key, and a scan that came back globally sorted would be something no real table gives you, and a
+test leaning on one would pass here and fail against the service.
 
-The order is arbitrary rather than varying. Two scans of an unchanged table read it the same way,
-which is what lets a token resume one.
+The order is arbitrary but fixed. Two scans of an unchanged table read it the same way, and that is
+what lets a token resume one.
 
 `Limit`, `LastEvaluatedKey` and `ExclusiveStartKey` page a scan the way they page a query, and the
-loop is the same one. `ConsistentRead` is accepted and changes nothing, since every simulated read is
-already the strongly consistent one.
+loop is the same one. `ConsistentRead` is accepted and changes nothing, since every simulated read
+is already the strongly consistent one.
 
 ### Scanning in parallel
 
@@ -1745,8 +1746,8 @@ in the same segment. That is what makes a segment a share of the table's partiti
 a share of its items, and it is why segments come out uneven. A segment holding nothing is ordinary,
 and dividing a table into more segments than it has partition key values leaves most of them empty.
 
-There is nothing to gain in speed here, since a simulated scan walks a map in memory. What a parallel
-scan gives a test is the caller's side of one: code that divides a table between workers can be run
+There is no speed to gain here, since a simulated scan walks a map in memory. What a parallel scan
+gives a test is the caller's side of one. Code that divides a table between workers can be run
 without a real table.
 
 Each segment pages on its own. `Limit` and `LastEvaluatedKey` work per segment, and the next request
@@ -1755,16 +1756,16 @@ segment is refused, since it names a place that segment's walk never reaches.
 
 These are the rules a request is held to, each a `ValidationException`:
 
-- `Segment` without `TotalSegments`, or `TotalSegments` without `Segment`. They are supplied together
-  or not at all, and a request naming neither reads the whole table.
-- a `Segment` at or above `TotalSegments`, or below zero. It is zero based, so the last segment of
-  four is `3`.
+- `Segment` without `TotalSegments`, or `TotalSegments` without `Segment`. They are supplied
+  together or not at all, and a request naming both as absent reads the whole table.
+- a `Segment` at or above `TotalSegments`, or below zero. It is zero based. The last segment of four
+  is `3`.
 - a `TotalSegments` outside 1 to 1000000. A `TotalSegments` of 1 is a sequential scan.
 - an `ExclusiveStartKey` belonging to another segment.
 
-`Segment` and `TotalSegments` are refused on `Query`, which is not a parallel operation and never had
-them. A query reads one item collection, which sits under one partition key and so inside one
-segment.
+`Segment` and `TotalSegments` are refused on `Query`, since it is a single-collection operation and
+never had them. A query reads one item collection, which sits under one partition key and so inside
+one segment.
 
 ## Filtering a read
 
@@ -1772,9 +1773,9 @@ segment.
 [conditional write](#conditional-writes) is guarded by, evaluated against each item the read
 reached.
 
-It runs after the read rather than during it, and that order is what the counts report. The walk is
-cut at the `Limit` first, and the filter then drops items from the page that came back.
-`ScannedCount` is how many items the read evaluated, and `Count` how many of those survived.
+It runs after the read, and that order is what the counts report. The walk is cut at the `Limit`
+first, and the filter then drops items from the page that came back. `ScannedCount` is how many
+items the read evaluated, and `Count` how many of those survived.
 
 ```typescript sim-dynamodb-query-filter
 /**
@@ -1872,35 +1873,36 @@ console.log(counted.ScannedCount); // 4
 console.log(counted.Items); // undefined
 ```
 
-A filter saves nothing. Every item it drops was read, so a filtered query is charged for what it
+A filter saves no capacity. Every item it drops was read. A filtered query is charged for what it
 threw away on AWS.
 
-A `Count` below the `Limit` therefore says nothing about whether the collection is exhausted. A page
-can even come back with no items at all and a `LastEvaluatedKey`, when the filter dropped every item
-on it. Loop until the token is gone rather than until a page looks short or empty.
+A `Count` below the `Limit` therefore leaves it open whether the collection is exhausted. A page can
+even come back with no items at all and a `LastEvaluatedKey`, when the filter dropped every item on
+it. Loop until the token is gone. A short or empty page proves nothing on its own.
 
-An item that does not have what the filter points at fails it. `status = :open` drops an item with no
-`status`, the same way a condition on a write does not hold for an attribute that is not there.
+An item that lacks what the filter points at fails it. `status = :open` drops an item with no
+`status`, the same way a condition on a write fails to hold for an attribute that is absent.
 
 ### What a filter may name
 
 A `Query` filter may not name a key attribute, and a `Scan` filter may name any attribute at all. A
-query has already narrowed the read by its `KeyConditionExpression`, so a filter on the partition key
-or the sort key is either that condition written twice or a condition the key condition should have
-carried. Real DynamoDB refuses it as a `ValidationException`, and so does this. A scan narrows
-nothing, so there a key attribute is an attribute like any other.
+query has already narrowed the read by its `KeyConditionExpression`, and a filter on the partition
+key or the sort key is either that condition written twice or a condition the key condition should
+have carried. Real DynamoDB refuses it as a `ValidationException`, and so does this. A scan narrows
+no read. There a key attribute is an attribute like any other.
 
 The rule is about where a path starts, so `details.customerId` is allowed on a query with a
-`customerId` partition key: it names an attribute of a map rather than the key. Writing the key
-attribute as an `ExpressionAttributeNames` placeholder does not get past it either.
+`customerId` partition key. It names an attribute of a map and not the key. Writing the key
+attribute as an `ExpressionAttributeNames` placeholder gets past it no more easily.
 
 The key condition and the filter share one set of placeholders. A `#name` or `:value` either of them
-uses counts as used, and one neither uses is refused the way an unused placeholder always is.
+uses counts as used, and one that goes unused by both is refused the way an unused placeholder
+always is.
 
 ### Counting and projecting with Select
 
-`Select` says which attributes a read answers with. A table read defaults to `ALL_ATTRIBUTES`, which
-is whole items.
+`Select` says which attributes a read answers with. A table read defaults to `ALL_ATTRIBUTES`,
+meaning whole items.
 
 `COUNT` answers with `Count` and `ScannedCount` and no `Items` at all, as at the end of the example
 above. It reads and filters the same items, and leaves them out of the response. `Limit` and
@@ -1914,8 +1916,8 @@ The other two values are held to the rules AWS holds them to, each a `Validation
 - `ALL_PROJECTED_ATTRIBUTES` without an `IndexName`. It asks for the attributes an index projects,
   and a table read has no index to project from.
 
-Projecting a `Query` or a `Scan` is not simulated, so `SPECIFIC_ATTRIBUTES` gets as far as the
-`ProjectionExpression` refusal rather than being accepted with nothing to project.
+Projecting a `Query` or a `Scan` is absent, so `SPECIFIC_ATTRIBUTES` gets as far as the
+`ProjectionExpression` refusal rather than being accepted with no attribute to project.
 
 ## Reading and writing items in batches
 
@@ -1996,23 +1998,23 @@ console.log(output.Item?.["total"]?.N); // "24.99"
 ```
 
 A put replaces the whole item under its key, exactly as `PutItem` does, and a delete names a key, so
-deleting a key that is already free succeeds. Neither answers with the item it wrote over: a batch
+deleting a key that is already free succeeds. Neither answers with the item it wrote over. A batch
 has no `ReturnValues`, and no `ConditionExpression` either. A conditional write is what `PutItem`,
 `DeleteItem` and `UpdateItem` are for.
 
-Six things take the whole batch down rather than one entry of it, leaving nothing written:
+Six things take the whole batch down rather than one entry of it, leaving no write behind:
 
-- a table that is not there
+- a table that is absent
 - key attributes that do not match the table's key schema
 - more than one operation on the same item of one table
 - one table named twice, once by its name and once by its ARN
 - more than 25 write requests, counted across every table the request names
 - an item over the 400 KB an item holds
 
-Real DynamoDB also refuses a request over 16 MB. That one is not simulated, for the reason under
+Real DynamoDB also refuses a request over 16 MB. That one is absent, for the reason under
 Limitations.
 
-The same key in two different tables is two items rather than one, so a batch may write both.
+The same key in two different tables is two items, never one. A batch may write both.
 
 A batch read asks each table for `Keys`, and for how to read them. `ConsistentRead` and
 `ProjectionExpression` are settled per table rather than per call, so one call can read the whole of
@@ -2091,19 +2093,19 @@ console.log(output.Responses["CustomersTable"]?.[0]?.["name"]?.S); // "Ada"
 console.log(output.UnprocessedKeys); // {}
 ```
 
-An item that is not there is absent from `Responses`, with nothing standing in for it, so what came
-back is what was there. A table that held none of the keys it was asked for is still in `Responses`,
-with an empty list. DynamoDB reads a batch in parallel and answers in no particular order, so a
-caller that needs to tell its items apart reads the key attributes off them rather than counting on
-where they are in the list.
+An item that was never written is left out of `Responses`, with no placeholder standing in for it,
+so what came back is what was there. A table that held none of the keys it was asked for is still in
+`Responses`, with an empty list. DynamoDB reads a batch in parallel and answers in no particular
+order, and a caller that needs to tell its items apart reads the key attributes off them rather than
+counting on where they are in the list.
 
 More than 100 keys in one call, counted across every table the request names, is a
 `ValidationException`. So is the same key twice for one table, and so is one table named twice, once
 by its name and once by its ARN.
 
 Both commands answer with the map of what they could not get to, `UnprocessedItems` for a write and
-`UnprocessedKeys` for a read. Both are always empty here, since nothing is throttled, but they are
-there rather than absent, so the retry loop real code is written around still terminates:
+`UnprocessedKeys` for a read. Both are always empty here, since no request is throttled, but they
+are there all the same. The retry loop real code is written around still terminates:
 
 ```typescript
 let unprocessed = {
@@ -2126,8 +2128,8 @@ while (Object.keys(unprocessed).length > 0) {
 them do, so two items that have to agree with each other can be written together.
 
 Each action carries exactly one of `Put`, `Update`, `Delete` and `ConditionCheck`, and names its own
-table. A `ConditionCheck` writes nothing: it is how a transaction says that an item it is not
-changing has to hold for the items it is changing to be written.
+table. A `ConditionCheck` writes nothing. It is how a transaction says that an item it is leaving
+alone has to hold for the items it is changing to be written.
 
 What a test usually wants to show is the failure. A transaction that succeeds looks the same as two
 separate writes, so what is worth asserting is that a failed condition on the second action left the
@@ -2238,24 +2240,25 @@ console.log(entry.Item); // undefined
 
 `CancellationReasons` lines up with `TransactItems`. There is one entry per action, in the same
 order, including the actions that would have gone through, which carry the code `None`. The codes
-have no `Exception` suffix, so a failed condition reads as `ConditionalCheckFailed` rather than as
-the `ConditionalCheckFailedException` a single `PutItem` throws.
+have no `Exception` suffix. A failed condition reads as `ConditionalCheckFailed`, never as the
+`ConditionalCheckFailedException` a single `PutItem` throws.
 
 An action that sets `ReturnValuesOnConditionCheckFailure` to `ALL_OLD` gets `Item` on its
-cancellation reason, holding the item as it was, so a retry needs no second read.
+cancellation reason, holding the item as it was, and a retry needs no second read.
 
-These refuse the request outright rather than cancelling it, with nothing written either way:
+These refuse the request outright rather than cancelling it, with no write either way:
 
 - more than 100 actions
-- an action carrying more than one of `Put`, `Update`, `Delete` and `ConditionCheck`, or none of them
+- an action carrying more than one of `Put`, `Update`, `Delete` and `ConditionCheck`, or none of
+  them
 - two actions on the same item of one table
-- a table that is not there, or a key that does not match its key schema
+- a table that is absent, or a key that fails to match its key schema
 - an update that would move the item's primary key
 - an item carrying a secondary index key attribute as a type the index did not declare
 - an update that would take the item past the 400 KB one item holds
 
-One table may be named as often as the transaction likes, which is the difference from a batch. What
-it may not do is touch one item twice.
+One table may be named as often as the transaction likes, and that is the difference from a batch.
+What it may not do is touch one item twice.
 
 ### Retrying a transaction
 
@@ -2264,7 +2267,7 @@ minutes succeeds without applying the writes again, and replaying it with differ
 `IdempotentParameterMismatchException`. Only a transaction that was applied is remembered, so
 retrying one that was cancelled runs it again.
 
-The ten minutes are measured on the simulated clock, so a test moves past the window rather than
+The ten minutes are measured on the simulated clock. A test moves past the window rather than
 waiting for it:
 
 ```typescript
@@ -2293,8 +2296,8 @@ await dynamoDb.transactWriteItems(new TransactWriteItemsCommand(withdrawal));
 
 ### Reading in a transaction
 
-`TransactGetItems` reads up to 100 items in one step, and is always strongly consistent, so there is
-no `ConsistentRead` to set. Each `Get` names its own table, and takes a `ProjectionExpression`.
+`TransactGetItems` reads up to 100 items in one step, and is always strongly consistent. There is no
+`ConsistentRead` to set. Each `Get` names its own table, and takes a `ProjectionExpression`.
 
 ```typescript sim-dynamodb-transact-get-items
 /**
@@ -2366,15 +2369,15 @@ altogether. Here the answers stay lined up with the Gets that asked for them.
 
 `UpdateTimeToLive` names the attribute a table expires items by, and `DescribeTimeToLive` reports
 it. The attribute holds epoch seconds in a Number. An item without it, or holding a String or
-anything else, never expires, and that is not an error. Nor does an item whose timestamp is more
-than five years in the past, which DynamoDB treats as a malformed value rather than as long overdue.
+anything else, never expires, and that is allowed. Nor does an item whose timestamp is more than
+five years in the past, which DynamoDB treats as a malformed value rather than as long overdue.
 
 Expiry runs on [the simulated clock](../../time/). Moving the clock forward is what deletes items
 whose time to live has run out, so one `advanceBy` expires a table's sessions alongside whatever
-else that advance causes elsewhere in the simulation. There is nothing else for a test to call.
+else that advance causes elsewhere in the simulation. That is the only call a test has.
 
 Deletion is not immediate. Real DynamoDB marks an item expired at its timestamp and deletes it
-typically within 48 hours, and reads keep returning it until then. That gap is simulated, so a test
+typically within 48 hours, and reads keep returning it until then. That gap is simulated, and a test
 can advance an hour past a session's expiry, see the session come back from `GetItem`, and find out
 that the code under test needs to cope with it.
 
@@ -2460,28 +2463,28 @@ console.log(collected.Item === undefined); // true
 ```
 
 `UpdateTimeToLive` moves the status to `ENABLING` and it settles on `ENABLED` once the background
-work has run, which is the sequence a table's own status goes through. Switching it off goes through
-`DISABLING` to `DISABLED`, and a `DISABLED` table reports no attribute name.
+work has run, following the sequence a table's own status goes through. Switching it off goes
+through `DISABLING` to `DISABLED`, and a `DISABLED` table reports no attribute name.
 
 An `UpdateTimeToLive` asking for the state the table is already in is a `ValidationException`, as it
 is on AWS, so code that has to be idempotent reads `DescribeTimeToLive` first. Changing the
 attribute an enabled table expires by means switching time to live off and then on again.
 
 DynamoDB also takes one `UpdateTimeToLive` per table per hour. That hour is measured on the
-simulated clock, so a second call inside it is a `ValidationException` and
-`simAws.clock().advanceBy({ hours: 1 })` is what lets the next one through.
+simulated clock. A second call inside it is a `ValidationException` and `simAws.clock().advanceBy({
+hours: 1 })` is what lets the next one through.
 
 Switching time to live on reaches the items already on the table, since their attributes were only
-inert while it was off. A removal already scheduled is checked again when it comes due, so an item
+inert while it was off. A removal already scheduled is checked again when it comes due. An item
 overwritten with a later timestamp, or one on a table whose time to live has since been switched
 off, stays where it is.
 
 ## Capturing changes with a stream
 
 A `StreamSpecification` on `CreateTable` gives a table a stream, and every change to an item is
-captured on it as a record: an `INSERT` for the first write of an item, a `MODIFY` for a write over
-one that was there, and a `REMOVE` for a deletion. `DescribeTable` reports the specification back
-along with `LatestStreamArn` and `LatestStreamLabel`.
+captured on it as a record. That is an `INSERT` for the first write of an item, a `MODIFY` for a
+write over one that was there, and a `REMOVE` for a deletion. `DescribeTable` reports the
+specification back along with `LatestStreamArn` and `LatestStreamLabel`.
 
 Which images a record carries is what `StreamViewType` chooses, and every record carries the keys of
 the item that changed whichever one it is:
@@ -2494,8 +2497,8 @@ the item that changed whichever one it is:
 | `NEW_AND_OLD_IMAGES` | keys, new image | keys, both images | keys, old image |
 
 A `REMOVE` under `NEW_IMAGE` and an `INSERT` under `OLD_IMAGE` are keys and nothing else, because
-neither has the image the view type asks for. The record is still written: it is how a reader learns
-that the change happened at all.
+the view type asks for an image the record lacks. The record is still written, since it is how a
+reader learns that the change happened at all.
 
 ```typescript sim-dynamodb-stream-specification
 /**
@@ -2561,20 +2564,18 @@ console.log(withoutStream.Table?.LatestStreamArn !== undefined); // true
 ```
 
 `UpdateTable` switches a stream on for a table that has none and off for one that has one. A
-`StreamViewType` belongs to the stream rather than to the table, so there is no changing it in
-place: switching the stream off and on again is what AWS makes an application do, and gives the
+`StreamViewType` belongs to the stream rather than to the table, and there is no changing it in
+place. Switching the stream off and on again is what AWS makes an application do, and gives the
 table a stream with a fresh label and ARN. Asking to switch on a stream that is already on, or off
-one that is not there, is a `ValidationException` either way.
+one that is absent, is a `ValidationException` either way.
 
-A time to live expiry is captured as a `REMOVE` carrying
-`userIdentity: { type: "Service", principalId: "dynamodb.amazonaws.com" }`, where a deletion the
-application asked for carries none. That is how a stream consumer tells an item it deleted from one
-DynamoDB collected.
+A time to live expiry is captured as a `REMOVE` carrying `userIdentity: { type: "Service",
+principalId: "dynamodb.amazonaws.com" }`, where a deletion the application asked for carries none.
+That is how a stream consumer tells an item it deleted from one DynamoDB collected.
 
-Nothing is captured for a write that never reached the item: a refused conditional write, a
+Nothing is captured for a write that never reached the item, such as a refused conditional write, a
 cancelled transaction, a delete of a key holding nothing, or a request the table refused. Deleting
-the table takes its items with it rather than removing them one at a time, so nothing is captured
-for that either.
+the table takes its items with it in one go. No record is captured for that either.
 
 ## Reading a stream's records
 
@@ -2659,10 +2660,10 @@ console.log(read.NextShardIterator !== undefined); // true
 
 A record carries `eventID`, `eventName`, `eventSource`, `awsRegion` and a `dynamodb` body holding
 `Keys`, the images the view type selects, `SequenceNumber`, `SizeBytes` and
-`ApproximateCreationDateTime`. A time to live removal carries
-`userIdentity: { PrincipalId: "dynamodb.amazonaws.com", Type: "Service" }`. The Streams API
-capitalizes those two fields where the Lambda event carries the same values as `principalId` and
-`type`, so a consumer written against one shape does not read the other.
+`ApproximateCreationDateTime`. A time to live removal carries `userIdentity: { PrincipalId:
+"dynamodb.amazonaws.com", Type: "Service" }`. The Streams API capitalizes those two fields where the
+Lambda event carries the same values as `principalId` and `type`. A consumer written against one
+shape fails to read the other.
 
 ### Where to start reading
 
@@ -2682,14 +2683,14 @@ to start.
 ### Polling with NextShardIterator
 
 `GetRecords` answers with the iterator to use for the next call. Reading a stream to the end and
-polling it is the same loop either way: pass each `NextShardIterator` to the following `GetRecords`.
+polling it is the same loop either way. Pass each `NextShardIterator` to the following `GetRecords`.
 
-One `GetRecords` hands back at most 1000 records, so a reader with more than that behind it stays
+One `GetRecords` hands back at most 1000 records, and a reader with more than that behind it stays
 behind until it polls again. `Limit` asks for fewer, and a `Limit` above 1000 is a
-`ValidationException` rather than being quietly reduced.
+`ValidationException`.
 
 An empty `Records` array alongside a `NextShardIterator` is the ordinary answer for a reader that
-has caught up, and means to look again rather than that anything is wrong. `NextShardIterator` is
+has caught up, and means to look again, and not that anything is wrong. `NextShardIterator` is
 absent only when the shard is closed and the reader has reached the end of it, which happens once
 the table has switched the stream off and everything on it has been read.
 
@@ -2698,24 +2699,24 @@ the table has switched the stream off and everything on it has been read.
 A stream keeps its records for 24 hours on the simulated clock, and the trim is applied when the
 stream is read. Reading from a position the stream no longer holds raises a
 `TrimmedDataAccessException`, whether the sequence number was named in a `GetShardIterator` call or
-carried in an iterator that was still good when it was handed out. `TRIM_HORIZON` never raises it:
-it means the oldest record still there, whatever has gone.
+carried in an iterator that was still good when it was handed out. `TRIM_HORIZON` never raises it,
+since it means the oldest record still there, whatever has gone.
 
 A stream stays listable and readable after its table switches it off, and after everything on it has
-been trimmed. A trimmed stream reads as empty rather than as missing.
+been trimmed. A trimmed stream reads as empty, never as missing.
 
 ### Delivering a stream to a Lambda function
 
 Most applications consume a stream by having a Lambda function run on it rather than by polling it
-themselves, which is a
-[Lambda event source mapping](../lambda/#triggering-a-function-from-a-dynamodb-stream "Simulated Lambda event source mapping docs"):
-create the mapping, write to the table, and the function is invoked with the changes. The
+themselves, and that is a
+[Lambda event source mapping](../lambda/#triggering-a-function-from-a-dynamodb-stream "Simulated Lambda event source mapping docs").
+Create the mapping, write to the table, and the function is invoked with the changes. The
 `GetRecords` loop above is still there for a consumer that wants to read a stream directly.
 
 ## Numbers
 
 A DynamoDB number carries up to 38 significant digits, where a JavaScript number carries about 15.
-Numbers are held here as the digits they were written with, so an identifier, a monetary amount or a
+Numbers are held here as the digits they were written with. An identifier, a monetary amount or a
 large counter comes back exactly as it went in.
 
 ```typescript sim-dynamodb-number-precision
@@ -2759,7 +2760,7 @@ const replaced = await dynamoDb.putItem(
 console.log(replaced.Attributes?.["count"]?.N); // "9007199254740993"
 ```
 
-The digits are normalised the way DynamoDB normalises them: leading and trailing zeros are trimmed,
+The digits are normalised the way DynamoDB normalises them. Leading and trailing zeros are trimmed,
 and an exponent is worked back into plain notation, so `1E5` and `100000.00` are the same number.
 That is what makes `{ N: "1" }` and `{ N: "1.0" }` the same key.
 
@@ -2769,15 +2770,15 @@ A number with more than 38 significant digits, or outside the range `1E-130` to
 ## Sets, lists and maps
 
 A set holds one kind of value, holds at least one, and holds each value once. Binary members compare
-by their bytes rather than by object identity, so two `Uint8Array` values holding the same bytes are
-one member and are refused as a duplicate.
+by their bytes, so two `Uint8Array` values holding the same bytes are one member and are refused as
+a duplicate.
 
 Lists and maps nest up to 32 levels, and one item is at most 400 KB counting its attribute names as
 well as its values. Both are `ValidationException` when exceeded.
 
 ## The document client
 
-`@aws-sdk/lib-dynamodb` takes plain JavaScript values in place of AttributeValues. Intercept a
+`@aws-sdk/lib-dynamodb` takes plain JavaScript values rather than AttributeValues. Intercept a
 `DynamoDBDocumentClient` and its Commands reach simulated DynamoDB with the values converted, so
 code written against the document client runs against the simulator unchanged.
 
@@ -2855,15 +2856,14 @@ console.log(tags.has("priority")); // true
 as `TransactWriteCommand`, is refused by name before anything tries to convert its values.
 
 Intercept the document client itself. `DynamoDBDocumentClient.from(client)` builds a separate object
-that is not an instance of `DynamoDBClient`, so intercepting the base client does nothing for
-Commands sent through the document one. See
-[the SDK docs](../../sdk/README.md#the-dynamodb-document-client).
+outside the `DynamoDBClient` class, so intercepting the base client leaves Commands sent through the
+document one untouched. See [the SDK docs](../../sdk/README.md#the-dynamodb-document-client).
 
 ### Querying and scanning through the document client
 
 `@aws-sdk/lib-dynamodb` names its `QueryCommand` and `ScanCommand` exactly as
 `@aws-sdk/client-dynamodb` does. Both are routed, and which one a request gets is decided by the
-Command it was sent with rather than by the name, so the two can be used on the same intercepted
+Command it was sent with rather than by the name. The two can be used on the same intercepted
 client.
 
 Expression values and `ExclusiveStartKey` are converted on the way in, and `Items` and
@@ -2961,23 +2961,24 @@ for await (const page of pages) {
 | `Array`                                           | `L`       | `Array`                     |
 | plain object, `Map`                               | `M`       | plain object                |
 
-A class instance is not converted. The real document client refuses one unless it was built with
-`convertClassInstanceToMap`, so an object with behaviour is not quietly flattened into attributes.
+A class instance goes unconverted. The real document client refuses one unless it was built with
+`convertClassInstanceToMap`, and an object with behaviour is never quietly flattened into
+attributes.
 
 ### Numbers through the document client
 
 A simulated table holds a number's digits exactly, but the document client converts to and from
-JavaScript numbers, and that is where digits are lost. It is the same loss AWS has, so a test that
+JavaScript numbers, and that is where digits are lost. It is the same loss AWS has. A test that
 passes here is telling you something true about the real thing.
 
-- Writing a `number` outside the safe integer range is refused rather than stored already rounded.
-  Write a `bigint`, or a `NumberValue` from `@aws-sdk/lib-dynamodb`, to keep the digits.
+- Writing a `number` outside the safe integer range is refused, never stored already rounded. Write
+  a `bigint`, or a `NumberValue` from `@aws-sdk/lib-dynamodb`, to keep the digits.
 - Reading a stored number outside the safe integer range gives a `bigint`.
 - Reading a stored decimal with more digits than a JavaScript number carries gives a rounded
-  `number`. The table still holds every digit; the rounding is the document client's. Read through
-  an ordinary `GetItemCommand` to see the stored digits.
-- Reading a stored number that is outside the safe integer range and is not whole is refused, since
-  there is nothing to answer with.
+  `number`. The table still holds every digit, and the rounding is the document client's. Read
+  through an ordinary `GetItemCommand` to see the stored digits.
+- Reading a stored number that is outside the safe integer range and carrying a fraction is refused,
+  since there is no value it could answer with.
 
 ## Table names and ARNs
 
@@ -3038,12 +3039,12 @@ Creating a name that is already taken in the same scope fails with `ResourceInUs
 ## Deploying a table from CloudFormation
 
 Simulated CloudFormation creates a table from an `AWS::DynamoDB::Table` resource, in the stack's
-account and region. The table is created through `CreateTable`, so a template-created table is the
-same thing an SDK caller would get: the same name validation, the same key schema and attribute
-definition rules, the same ARN.
+account and region. The table is created through `CreateTable`. A template-created table is the same
+thing an SDK caller would get, with the same name validation, the same key schema and attribute
+definition rules, and the same ARN.
 
-`Ref` on the resource gives the table name, as it does on real AWS, so it can be handed straight to
-`PutItem`. `Fn::GetAtt … Arn` gives the table ARN, which is what an IAM policy names it by.
+`Ref` on the resource gives the table name, as it does on real AWS, and it can be handed straight to
+`PutItem`. `Fn::GetAtt … Arn` gives the table ARN, and an IAM policy names it by that.
 
 ```typescript sim-dynamodb-cloudformation-table
 /**
@@ -3098,32 +3099,32 @@ console.log(stack.outputs.get("OrdersTableArn")?.value);
 The properties that are read are `TableName`, `KeySchema`, `AttributeDefinitions`, `BillingMode`,
 `ProvisionedThroughput`, `TableClass`, `DeletionProtectionEnabled`, `Tags`,
 `GlobalSecondaryIndexes`, `LocalSecondaryIndexes`, `StreamSpecification` and
-`TimeToLiveSpecification`. All but the last are passed to `CreateTable` rather than applied here, so
-a value the template gets wrong fails the same way it would for an SDK caller.
+`TimeToLiveSpecification`. All but the last are passed to `CreateTable`, never applied here. A value
+the template gets wrong fails the same way it would for an SDK caller.
 
 `TimeToLiveSpecification` is applied after the table is created, through `UpdateTimeToLive`. Real
 `CreateTable` has no parameter for it either, so real CloudFormation makes the table and then
-updates it. A specification the template got wrong is refused in the words `UpdateTimeToLive` refuses
-it in.
+updates it. A specification the template got wrong is refused in the words `UpdateTimeToLive`
+refuses it in.
 
-A table with no `TableName` is named after the stack and its logical ID, so the table above with its
+A table with no `TableName` is named after the stack and its logical ID. The table above with its
 name left out would be `orders-stack-OrdersTable`. Real CloudFormation adds random characters to
 that, which a template cannot predict either way. Two stacks deploying the same template get two
 differently named tables. The generated name is trimmed to the 255 characters a table name allows,
 ending in a hash of the untrimmed name so two long names that start the same stay apart.
 
 `Fn::GetAtt … StreamArn` gives the ARN of the stream the table's `StreamSpecification` gave it. On a
-table with no `StreamSpecification` it is refused by name, naming the table, since an invented stream
-ARN would read as a working stream to whatever the template handed it to. Real CloudFormation refuses
-the same template while validating it, where this refuses when the attribute is asked for.
+table with no `StreamSpecification` it is refused by name, naming the table, since an invented
+stream ARN would read as a working stream to whatever the template handed it to. Real CloudFormation
+refuses the same template while validating it, where this refuses when the attribute is asked for.
 
-A property with behaviour that is not simulated is left out and recorded in
+A property with behaviour that is absent is left out and recorded in
 [`stack.ignoredProperties`](../cloudformation/README.md#properties-a-resource-was-created-without),
-so the table is created and the rest of the stack still deploys: `KinesisStreamSpecification`,
-`SSESpecification`, `PointInTimeRecoverySpecification`, `ContributorInsightsSpecification`,
-`ImportSourceSpecification`, `ResourcePolicy`, `OnDemandThroughput` and `WarmThroughput`. A property
-`AWS::DynamoDB::Table` does not have is recorded the same way, rather than a stack failing over a
-typo or a property AWS added since this list was written.
+and the table is created and the rest of the stack still deploys. Those properties are
+`KinesisStreamSpecification`, `SSESpecification`, `PointInTimeRecoverySpecification`,
+`ContributorInsightsSpecification`, `ImportSourceSpecification`, `ResourcePolicy`,
+`OnDemandThroughput` and `WarmThroughput`. A property `AWS::DynamoDB::Table` lacks is recorded the
+same way, so a typo or a property AWS added since this list was written.
 
 `AWS::DynamoDB::GlobalTable` deploys a table as well, under
 [deploying a global table](#deploying-a-global-table-from-cloudformation).
@@ -3136,7 +3137,7 @@ the ARN `Fn::GetAtt` gives.
 
 `GlobalSecondaryIndexes` and `LocalSecondaryIndexes` are read off the resource and handed to
 `CreateTable` with the rest of the table. An index a template declared is the index an SDK caller
-would have got, so it is queried and scanned the same way.
+would have got. It is queried and scanned the same way.
 
 ```typescript sim-dynamodb-cloudformation-indexes
 /**
@@ -3232,27 +3233,27 @@ const byTotal = await simAws.dynamoDb().query(
 console.log(byTotal.Count); // 1
 ```
 
-Which properties an index entry may carry is decided here, and nothing else about an index is. A
+Which properties an index entry may carry is decided here, and no other part of an index is. A
 template declaring an index whose key attributes are missing from `AttributeDefinitions` fails that
-resource with the error the API gives for the same input. The same goes for the projection rules, the
-per-index throughput a provisioned table needs, and the rule that a local secondary index shares the
-table's partition key.
+resource with the error the API gives for the same input. The same goes for the projection rules,
+the per-index throughput a provisioned table needs, and the rule that a local secondary index shares
+the table's partition key.
 
 `ContributorInsightsSpecification`, `OnDemandThroughput` and `WarmThroughput` on a global secondary
-index are not simulated, so the index is created without them and the record names the index it was
-on, such as `GlobalSecondaryIndexes.0.WarmThroughput`. `LocalSecondaryIndexes` entries have
-`IndexName`, `KeySchema` and `Projection` and nothing else, so anything further on one is recorded
-the same way. A `ProvisionedThroughput` there still fails the resource, because an index entry goes
-to `CreateTable` as the template wrote it and real DynamoDB refuses capacity on a local index.
+index are absent. The index is created without them and the record names the index it was on, such
+as `GlobalSecondaryIndexes.0.WarmThroughput`. `LocalSecondaryIndexes` entries have `IndexName`,
+`KeySchema` and `Projection` alone, so anything further on one is recorded the same way. A
+`ProvisionedThroughput` there still fails the resource, because an index entry goes to `CreateTable`
+as the template wrote it and real DynamoDB refuses capacity on a local index.
 
-A CDK `Table` with `addGlobalSecondaryIndex` and `addLocalSecondaryIndex` synthesises a template that
-deploys here without hand-editing.
+A CDK `Table` with `addGlobalSecondaryIndex` and `addLocalSecondaryIndex` synthesises a template
+that deploys here without hand-editing.
 
 ## Deploying a table with a stream
 
 A `StreamSpecification` on the resource deploys a table with a stream, and `Fn::GetAtt … StreamArn`
 gives the stream's ARN. CloudFormation's `StreamSpecification` has no `StreamEnabled` field, unlike
-the SDK's: declaring the property is what asks for the stream, and `StreamViewType` is required.
+the SDK's. Declaring the property is what asks for the stream, and `StreamViewType` is required.
 
 ```typescript sim-dynamodb-cloudformation-stream
 /**
@@ -3332,23 +3333,23 @@ const read = await dynamoDbStreams.getRecords(
 console.log(read.Records?.[0]?.eventName); // "INSERT"
 ```
 
-The specification goes to `CreateTable` with the rest of the table, so a template naming a view type
-that does not exist, or naming none at all, is refused in the words `CreateTable` refuses an SDK
+The specification goes to `CreateTable` with the rest of the table, and a template naming a view
+type that is absent, or naming none at all, is refused in the words `CreateTable` refuses an SDK
 caller in.
 
-`StreamSpecification.ResourcePolicy` is a policy on the stream rather than on the table. It is not
-simulated, so the table is created without it and the whole property path is recorded in
+`StreamSpecification.ResourcePolicy` is a policy on the stream rather than on the table. It is
+absent. The table is created without it and the whole property path is recorded in
 [`stack.ignoredProperties`](../cloudformation/README.md#properties-a-resource-was-created-without).
 
 Changing `StreamViewType` in a deployed template is a different thing here to what it is on real
-CloudFormation, which replaces the table. `UpdateTable` refuses the change in place, so switching the
-stream off and on again is what gives a table a stream with a different view type.
+CloudFormation, which replaces the table. `UpdateTable` refuses the change in place, so switching
+the stream off and on again is what gives a table a stream with a different view type.
 
 ## Deploying a global table from CloudFormation
 
 An `AWS::DynamoDB::GlobalTable` naming one replica deploys an ordinary simulated table in that
 region, because with one replica that is what it is. It is turned into the `AWS::DynamoDB::Table` it
-is and created down the path above, so it is the same table with the same rules behind it.
+is and created down the path above. It is the same table with the same rules behind it.
 
 That is the resource CDK's `TableV2` synthesises for every table it makes, whether or not any
 replica regions were asked for, since it always appends the stack's own region. So a `TableV2` stack
@@ -3411,54 +3412,54 @@ await simAws
 `StreamArn` and `TableId`, which are the attributes the resource type documents. `TableId` is the
 one an ordinary table has no attribute for at all.
 
-The replica carries the settings an ordinary table carries itself: `TableClass`,
+The replica carries the settings an ordinary table carries itself. `TableClass`,
 `DeletionProtectionEnabled` and `Tags` are read off it rather than off the table. Everything else a
-global table states the same way an ordinary one does — `TableName`, `KeySchema`,
-`AttributeDefinitions`, `BillingMode`, `LocalSecondaryIndexes`, `StreamSpecification` and
-`TimeToLiveSpecification` — is handed on as it was written.
+global table states the same way an ordinary one does is handed on as it was written. That covers
+`TableName`, `KeySchema`, `AttributeDefinitions`, `BillingMode`, `LocalSecondaryIndexes`,
+`StreamSpecification` and `TimeToLiveSpecification`.
 
 Capacity is the one thing a global table splits in two. Writes are the table's, in
 `WriteProvisionedThroughputSettings`, since every replica takes the same writes, and reads belong to
 the replica, in `ReadProvisionedThroughputSettings`. With one replica there is one of each, and they
 go back together into the `ProvisionedThroughput` `CreateTable` takes. A global secondary index is
-split the same way: the table declares the index and provisions its writes, and the replica's
+split the same way. The table declares the index and provisions its writes, and the replica's
 `GlobalSecondaryIndexes` entry names that index and provisions its reads.
 
 A global table naming two or more replica regions is created as an ordinary table in the region the
 stack is deploying into, with `Replicas` recorded in
 [`stack.ignoredProperties`](../cloudformation/README.md#properties-a-resource-was-created-without)
-naming the regions. Replication genuinely is not simulated, so everything the table does within one
-region behaves as the template describes and nothing is copied to the others.
+naming the regions. Replication genuinely is absent, so everything the table does within one region
+behaves as the template describes and nothing is copied to the others.
 
 A global table with no `Replicas` at all fails the resource, since `Replicas` is required and real
-CloudFormation refuses that template too. So does one whose single replica names a region the stack
-is not deploying into, since the replica list has to include the region the table would be created
-in.
+CloudFormation refuses that template too. So does one whose single replica names a region outside
+the stack's own, since the replica list has to include the region the table would be created in.
 
-A property with behaviour that is not simulated skips the resource, in the same terms an
-`AWS::DynamoDB::Table` one does: `MultiRegionConsistency`, `SSESpecification`, `WarmThroughput` and
-`WriteOnDemandThroughputSettings` on the table, and `PointInTimeRecoverySpecification`,
-`KinesisStreamSpecification`, `ContributorInsightsSpecification`, `ResourcePolicy`,
-`SSESpecification` and `ReadOnDemandThroughputSettings` on the replica. Capacity that scales with
-load — `WriteCapacityAutoScalingSettings` and `ReadCapacityAutoScalingSettings` — skips the resource
-too, since nothing here scales it. A property `AWS::DynamoDB::GlobalTable` does not have fails the
-resource instead.
+A property with behaviour that is absent skips the resource, in the same terms an
+`AWS::DynamoDB::Table` one does. Those are `MultiRegionConsistency`, `SSESpecification`,
+`WarmThroughput` and `WriteOnDemandThroughputSettings` on the table, and
+`PointInTimeRecoverySpecification`, `KinesisStreamSpecification`,
+`ContributorInsightsSpecification`, `ResourcePolicy`, `SSESpecification` and
+`ReadOnDemandThroughputSettings` on the replica. Capacity that scales with load skips the resource
+too, since no process here scales it, namely `WriteCapacityAutoScalingSettings` and
+`ReadCapacityAutoScalingSettings`. A property `AWS::DynamoDB::GlobalTable` lacks fails the resource
+instead.
 
 ## IAM authorization
 
 `CreateTable` authorizes `dynamodb:CreateTable` against the ARN the table is about to have, before
-it looks the name up. A caller with no permission is denied whether or not the name is free, so an
+it looks the name up. A caller with no permission is denied whether or not the name is free, and an
 unauthorized caller cannot find out which names are taken.
 
 `DescribeTable`, `PutItem`, `GetItem`, `DeleteItem` and `UpdateItem` authorize against the table ARN
-in the same way, each against the `dynamodb:` action of its own name. `ListTables` names no table, so it
-authorizes against `*`.
+in the same way, each against the `dynamodb:` action of its own name. `ListTables` names no table.
+It authorizes against `*`.
 
 A transaction is authorized as the operations it is made of rather than as itself. Each action of a
 `TransactWriteItems` needs `dynamodb:PutItem`, `dynamodb:UpdateItem`, `dynamodb:DeleteItem` or
 `dynamodb:ConditionCheckItem` against the table it names, and each `Get` of a `TransactGetItems`
-needs `dynamodb:GetItem`. A caller refused any one of them is refused the whole transaction, so
-nothing is written.
+needs `dynamodb:GetItem`. A caller refused any one of them is refused the whole transaction. No item
+is written.
 
 ## Available functionality
 
@@ -3478,13 +3479,13 @@ nothing is written.
 - `ListTables`, ordered by UTF-8 bytes and paged with `Limit` and `ExclusiveStartTableName`.
 - `DeleteTable`, following the table status DynamoDB moves a deleted table through, and refusing a
   table that is protected from deletion.
-- `PutItem`, with the attribute value model behind it: numbers keep their digits, sets compare by
+- `PutItem`, with the attribute value model behind it. Numbers keep their digits, sets compare by
   value, and key attributes are checked against what the table declared. It takes a table name or
   ARN and authorizes before the lookup.
 - `GetItem`, answering with the item under a primary key, and with no `Item` at all when the key
   holds nothing.
-- `ProjectionExpression` on `GetItem`, with document paths, list indexing and `ExpressionAttributeNames`
-  placeholders.
+- `ProjectionExpression` on `GetItem`, with document paths, list indexing and
+  `ExpressionAttributeNames` placeholders.
 - `DeleteItem`, removing the item under a primary key and answering with it for `ALL_OLD`.
 - `UpdateItem`, with `SET`, `REMOVE`, `ADD` and `DELETE` update expressions, `if_not_exists`,
   `list_append`, decimal arithmetic, list element paths, upserting when the key holds nothing, and
@@ -3497,9 +3498,9 @@ nothing is written.
   what was read and `Count` what survived, and refused on a `Query` when it names a key attribute.
 - `Select` on `Query` and `Scan`, with `COUNT` answering with counts alone and the rules tying
   `SPECIFIC_ATTRIBUTES`, `ALL_PROJECTED_ATTRIBUTES` and a projection together.
-- `ConditionExpression` on `PutItem`, `DeleteItem` and `UpdateItem`, with the six comparators, `BETWEEN`, `IN`,
-  `AND`, `OR`, `NOT`, brackets, and the `attribute_exists`, `attribute_not_exists`, `attribute_type`,
-  `begins_with`, `contains` and `size` functions.
+- `ConditionExpression` on `PutItem`, `DeleteItem` and `UpdateItem`, with the six comparators,
+  `BETWEEN`, `IN`, `AND`, `OR`, `NOT`, brackets, and the `attribute_exists`, `attribute_not_exists`,
+  `attribute_type`, `begins_with`, `contains` and `size` functions.
 - `BatchWriteItem`, putting and deleting items across tables in one call, with the 25 request cap,
   the whole batch refusals, and an empty `UnprocessedItems`.
 - `BatchGetItem`, reading items across tables in one call, with `ConsistentRead` and
@@ -3509,8 +3510,8 @@ nothing is written.
   `ClientRequestToken` making a retry idempotent for ten simulated minutes.
 - `TransactGetItems`, reading up to 100 items in one step, with a positional `Responses` array in
   which a missing item is an entry with no `Item`.
-- `UpdateTable`, doing one of a billing and throughput change, one global secondary index creation or
-  one global secondary index deletion per call, with `TableClass` and `DeletionProtectionEnabled`
+- `UpdateTable`, doing one of a billing and throughput change, one global secondary index creation
+  or one global secondary index deletion per call, with `TableClass` and `DeletionProtectionEnabled`
   riding along. The table moves through `UPDATING` while serving reads and writes, a new index
   reports `Backfilling` and refuses reads until it is `ACTIVE`, and a second update in flight gives
   `ResourceInUseException`.
@@ -3538,7 +3539,7 @@ nothing is written.
   provisioned capacity for the table and for each global secondary index, and `Ref`, `Fn::GetAtt …
 Arn`, `Fn::GetAtt … StreamArn` and `Fn::GetAtt … TableId` answering. A CDK `TableV2` stack deploys
   through it without hand-editing.
-- SDK interception, so an intercepted `DynamoDBClient` or `DynamoDBStreamsClient` reaches the
+- SDK interception, and an intercepted `DynamoDBClient` or `DynamoDBStreamsClient` reaches the
   simulation.
 - The `@aws-sdk/lib-dynamodb` document client, with `PutCommand`, `GetCommand`, `DeleteCommand`,
   `UpdateCommand`, `QueryCommand`, `ScanCommand`, `BatchWriteCommand` and `BatchGetCommand`
@@ -3547,70 +3548,70 @@ Arn`, `Fn::GetAtt … StreamArn` and `Fn::GetAtt … TableId` answering. A CDK `
 
 ## Limitations
 
-- The document client's transaction and PartiQL Commands are not converted. PartiQL is an operation
-  this simulation does not have yet. The transactions are simulated as operations, so only the
-  document form of them is missing. Both are refused by name rather than half converted.
-- A document client's translate config is not read, so the marshalling options it was built with do
-  not apply. See [the SDK docs](../../sdk/README.md#limitations).
+- The document client's transaction and PartiQL Commands go unconverted. PartiQL is an operation
+  this simulation lacks yet. The transactions are simulated as operations, so only the document form
+  of them is missing. Both are refused by name, never half converted.
+- A document client's translate config goes unread. The marshalling options it was built with do not
+  apply. See [the SDK docs](../../sdk/README.md#limitations).
 - `Expected`, `ConditionalOperator`, `AttributeUpdates`, `KeyConditions`, `QueryFilter` and
-  `ScanFilter` are not converted for the document client, because simulated DynamoDB refuses all six
+  `ScanFilter` go unconverted for the document client, because simulated DynamoDB refuses all six
   anyway. A request carrying one is refused by the operation rather than by the conversion.
-- A read of a global secondary index answers with the attributes the index projects, and nothing
-  fills in the rest. Real DynamoDB does not either: it never reads the base table for an attribute a
-  global secondary index does not project, which is why `Select: ALL_ATTRIBUTES` against a partial
-  projection is refused rather than served. A local secondary index does fetch from the base table,
-  and that is simulated. `ProjectionExpression` is not simulated on `Query` or `Scan` either way, so
-  naming a non-projected attribute that way does not arise.
-- The 10 GB limit on one item collection is not modelled, and neither is
+- A read of a global secondary index answers with the attributes the index projects, and no fetch
+  fills in the rest. Real DynamoDB behaves the same way. It never reads the base table for an
+  attribute a global secondary index omits. That is why `Select: ALL_ATTRIBUTES` against a partial
+  projection is refused outright. A local secondary index does fetch from the base table, and that
+  is simulated. `ProjectionExpression` is absent on `Query` or `Scan` either way, so naming a
+  non-projected attribute that way never arises.
+- The 10 GB limit on one item collection is left out, along with
   `ItemCollectionSizeLimitExceededException`. A table with a local secondary index can hold as much
-  under one partition key here as memory allows, so a write real DynamoDB would refuse for the size
-  of the collection it lands in goes through. `ReturnItemCollectionMetrics` is refused by name, so a
+  under one partition key here as memory allows. A write real DynamoDB would refuse for the size of
+  the collection it lands in goes through. `ReturnItemCollectionMetrics` is refused by name, and a
   write cannot ask how large the collection it touched has grown either.
 - An index key is one attribute, or two. Real DynamoDB now takes more than that, and a key schema of
   more than two elements is refused here.
 - `ItemCount` and `IndexSizeBytes` are 0 for every index, the same way the table's own figures are.
-- Per-index `ProvisionedThroughput` is read, validated and reported, and enforces nothing. No read or
-  write against an index is throttled, since none against the table is either.
-- A local secondary index cannot be added to or removed from a table after it has been created, which
-  is AWS behaviour rather than a limitation here: `CreateTable` is the only call that declares one.
-  `UpdateTable` refuses a `LocalSecondaryIndexes` change by having no such parameter at all, as AWS
-  does.
+- Per-index `ProvisionedThroughput` is read, validated and reported, and enforces no limit. No read
+  or write against an index is throttled, since none against the table is either.
+- A local secondary index cannot be added to or removed from a table after it has been created, and
+  that is AWS behaviour rather than a limitation here. `CreateTable` is the only call that declares
+  one. `UpdateTable` refuses a `LocalSecondaryIndexes` change by having no such parameter at all, as
+  AWS does.
 - There is no backfill to run when `UpdateTable` adds an index, since which items an index holds is
   worked out when the index is read. The `CREATING` window is a status the background scheduler
-  advances rather than work being done, so the index answers for the items already on the table the
-  moment it goes `ACTIVE`. What a test observes matches AWS while the mechanism does not: nothing
-  here takes longer to add an index to a large table than to an empty one.
-- `Backfilling` is reported as true while a new index is `CREATING` and left out once it is `ACTIVE`.
-  Real DynamoDB has a second phase in which the index is still `CREATING` with `Backfilling` false,
-  which is the point after which it can no longer be deleted mid-build. That phase is not modelled,
-  so an index here can be deleted at any point before it is `ACTIVE`.
-- Changing the provisioned capacity of an existing global secondary index is refused rather than
-  applied. A per-index capacity is read and reported but enforces nothing, so changing one would move
-  a number nothing acts on.
+  advances rather than work being done. The index answers for the items already on the table the
+  moment it goes `ACTIVE`. What a test observes matches AWS while the mechanism differs. No
+  operation here takes longer to add an index to a large table than to an empty one.
+- `Backfilling` is reported as true while a new index is `CREATING` and left out once it is
+  `ACTIVE`. Real DynamoDB has a second phase in which the index is still `CREATING` with
+  `Backfilling` false. After that point it can no longer be deleted mid-build. That phase is left
+  out. An index here can be deleted at any point before it is `ACTIVE`.
+- Changing the provisioned capacity of an existing global secondary index is refused outright. A
+  per-index capacity is read and reported but enforces no limit, so changing one would move a number
+  with no effect.
 - Switching a table to `PROVISIONED` with `UpdateTable` has to state the capacity. Real DynamoDB
-  estimates it from the table's consumption over the previous half hour, and nothing here measures
-  consumption, so an estimate would be an invented number that a deployment then reads back.
-- An `AttributeDefinition` for an index that has since been deleted stays on the table. Nothing
-  removes a definition, so a table can report one that no key now uses, which `CreateTable` would
-  have refused on the way in.
-- Tagging is immediate. AWS documents `TagResource` and `UntagResource` as eventually consistent, so
-  a real `ListTagsOfResource` issued straight after one of them may answer with the previous tags or
-  with none. Here the change is there by the time the call returns, so a test cannot observe the
+  estimates it from the table's consumption over the previous half hour, and no measurement of
+  consumption happens here, and an estimate would be an invented number that a deployment then reads
+  back.
+- An `AttributeDefinition` for an index that has since been deleted stays on the table. No call
+  removes a definition. A table can report one that no key now uses, which `CreateTable` would have
+  refused on the way in.
+- Tagging is immediate. AWS documents `TagResource` and `UntagResource` as eventually consistent. A
+  real `ListTagsOfResource` issued straight after one of them may answer with the previous tags or
+  with none. Here the change is there by the time the call returns, and a test cannot observe the
   window a retry would be written for.
-- A `ListTagsOfResource` page carries 25 tags. The API has no page size parameter, so the number is
-  this simulator's choice rather than DynamoDB's, and a real page may hold a different number.
-- The 10 KB limit on the total size of a resource's tags is not enforced. The 50 tag count and the
-  key and value lengths are, and 50 tags of the greatest key and value length are over 10 KB, so a
-  set of tags real DynamoDB would refuse for its size is accepted here.
+- A `ListTagsOfResource` page carries 25 tags. The API has no page size parameter. The number is
+  this simulator's own choice rather than DynamoDB's, and a real page may hold a different number.
+- The 10 KB limit on the total size of a resource's tags goes unenforced. The 50 tag count and the
+  key and value lengths are, and 50 tags of the greatest key and value length are over 10 KB. A set
+  of tags real DynamoDB would refuse for its size is accepted here.
 - Exceeding the 50 tag limit is a `ValidationException`. Real DynamoDB documents
   `LimitExceededException` for `TagResource`, but describes it entirely in terms of how many table
   operations are running at once, which is a different thing from how many tags a table carries.
-- Tag based IAM condition keys are not simulated. `aws:RequestTag`, `aws:ResourceTag` and
-  `aws:TagKeys` are not evaluated, so a policy that allows tagging only under a particular key
-  allows all of it here.
-- Tables are the only taggable DynamoDB resource here. Backups and global table replicas are not
-  simulated, so an ARN naming one of those names nothing. Real DynamoDB also copies a table's tags
-  onto its secondary indexes, which have nothing to copy to yet.
+- Tag based IAM condition keys are absent. `aws:RequestTag`, `aws:ResourceTag` and `aws:TagKeys` go
+  unevaluated, and a policy that allows tagging only under a particular key allows all of it here.
+- Tables are the only taggable DynamoDB resource here. Backups and global table replicas are absent.
+  An ARN naming one of those resolves to no resource. Real DynamoDB also copies a table's tags onto
+  its secondary indexes, which have no target to copy to yet.
 - The time to live deletion window is a fixed 48 hours, where AWS promises only that an expired item
   is typically deleted within 48 hours. A simulation has to pick a point in that range, and this
   picks the far end, because that is the longest an expired item can still be readable and so is the
@@ -3619,164 +3620,165 @@ Arn`, `Fn::GetAtt … StreamArn` and `Fn::GetAtt … TableId` answering. A CDK `
   still there partway through the window, since real DynamoDB may well have collected it by then.
 - Time to live expiry is dispatched by moving the clock through `simAws.clock()`, not by real time
   elapsing. An item whose window goes by while a running-mode clock tracks the host stays where it
-  is until something moves the clock. A simulated DynamoDB constructed standalone as
-  `new SimDynamoDb()` has no clock control at all, so nothing there ever expires.
+  is until something moves the clock. A simulated DynamoDB constructed standalone as `new
+SimDynamoDb()` has no clock control at all. No item there ever expires.
 - A Lambda event source mapping is the only simulated service integration that consumes a stream.
-  Anything else reads one through the Streams API itself. A
-  Kinesis Data Streams destination is not simulated.
+  Anything else reads one through the Streams API itself. A Kinesis Data Streams destination is
+  absent.
 - `Fn::GetAtt … StreamArn` on a table with no `StreamSpecification` is refused when the attribute is
   asked for, where real CloudFormation refuses the template while validating it. The timing differs,
-  the outcome does not.
-- Changing a deployed table's `StreamViewType` is not the table replacement real CloudFormation
-  performs. The change goes through `UpdateTable`, which refuses a view type change in place.
+  and the outcome matches.
+- Changing a deployed table's `StreamViewType` falls short of the table replacement real
+  CloudFormation performs. The change goes through `UpdateTable`, which refuses a view type change
+  in place.
 - An `AWS::DynamoDB::GlobalTable` naming two or more replica regions is created as an ordinary table
   in the region the stack is deploying into, with `Replicas` recorded in `stack.ignoredProperties`.
-  Replication between regions is not simulated at all, so everything the table does within one region
-  behaves as the template describes and nothing is copied to the others. A replica list that does not
-  include the stack's own region is refused, as real CloudFormation refuses it.
+  Replication between regions is absent at all, so everything the table does within one region
+  behaves as the template describes and no data is copied to the others. A replica list that leaves
+  out the stack's own region is refused, as real CloudFormation refuses it.
 - A global table's per-replica settings cannot differ from the primary's, because there is only ever
-  one replica. Anything a second replica would have said differently is not reachable.
-- `WriteCapacityAutoScalingSettings` and `ReadCapacityAutoScalingSettings` are recorded rather than
-  applied, and the table is created at the `MinCapacity` each of them names, which is where
-  autoscaling starts it on AWS. Nothing here scales capacity afterwards.
+  one replica. Anything a second replica would have said differently cannot be reached.
+- `WriteCapacityAutoScalingSettings` and `ReadCapacityAutoScalingSettings` are recorded, never
+  applied, and the table is created at the `MinCapacity` each of them names, and that is where
+  autoscaling starts it on AWS. No process here scales capacity afterwards.
 - A shard iterator never expires. Real DynamoDB gives one 15 minutes and then answers
   `ExpiredIteratorException`, which a consumer handles by asking for another from the sequence
-  number it last checkpointed. Nothing here refuses an iterator for being old.
+  number it last checkpointed. No check here refuses an iterator for being old.
 - `DescribeStream` never reports a `LastEvaluatedShardId`, since a simulated stream has one shard
-  and a page of shards is always all of them. `ShardFilter` is refused by name rather than ignored,
-  since there is no shard lineage for it to walk.
+  and a page of shards is always all of them. `ShardFilter` is refused by name, never ignored, since
+  there is no shard lineage for it to walk.
 - A stream is never dropped once everything on it has been trimmed. Real DynamoDB eventually stops
   listing a disabled stream whose records have all aged out, where the ARN a test is holding goes on
   resolving here and reads as empty.
-- The two readers per shard throughput limit and the `DescribeStream` rate limit are not applied.
-  Both are throughput protections a single-process simulation cannot produce honestly.
-- The five year time to live eligibility rule counts 1825 days rather than five calendar years, so
+- The two readers per shard throughput limit and the `DescribeStream` rate limit go unapplied. Both
+  are throughput protections a single-process simulation cannot produce honestly.
+- The five year time to live eligibility rule counts 1825 days rather than five calendar years, and
   an item whose timestamp sits within a couple of days of the boundary may be treated differently
   here to how AWS treats it.
 - A stream has one shard, which never splits. AWS documents an open shard as corresponding to one
-  table partition, and a simulated table is always one partition, so this is accurate rather than a
-  shortcut. It does mean the records come out in one total order across every key, which is stronger
-  than the per-key order AWS guarantees. A consumer relying on it here would be relying on something
-  real DynamoDB does not promise.
+  table partition, and a simulated table is always one partition. This is accurate. It does mean the
+  records come out in one total order across every key, and that is stronger than the per-key order
+  AWS guarantees. A consumer relying on it here would be relying on something real DynamoDB leaves
+  unpromised.
 - Stream sequence numbers are a counter rendered at a fixed 21 digits, where real AWS varies the
   width between 21 and 40. That makes comparing them as text always agree with comparing them as
-  numbers, which is a divergence in a reader's favour. They are not derived from the clock, because
+  numbers, and that divergence is in a reader's favour. They are independent of the clock, because
   several items commonly change inside one millisecond and a clock cannot tell those apart.
 - A stream record's `SizeBytes` counts the text of each value, summed over the keys and every image
-  the record carries. That is the rule AWS's own published sample records follow, and it is not the
-  rule the 400 KB item limit uses, where a number costs about half its digits.
-- `KinesisStreamSpecification` is not simulated. A table's changes go to its own stream or nowhere.
-- Encryption at rest is not simulated. An `SSESpecification` with `Enabled` set on a
-  CloudFormation Resource is recorded rather than reported back against items held in the clear.
-  `Enabled: false` asks for the AWS owned key real DynamoDB uses by default, so it is accepted.
-- Table resource policies are not simulated. `ResourcePolicy` on a CloudFormation Resource is
-  recorded, so a table a policy was meant to keep callers out of is open here and closed on AWS.
-- `OnDemandThroughput` and `WarmThroughput` are recorded rather than applied. Nothing here applies a
+  the record carries. That is the rule AWS's own published sample records follow, and it differs
+  from the rule the 400 KB item limit uses, where a number costs about half its digits.
+- `KinesisStreamSpecification` is absent. A table's changes go to its own stream or nowhere.
+- Encryption at rest is absent. An `SSESpecification` with `Enabled` set on a CloudFormation
+  Resource is recorded, and items are still held in the clear. `Enabled: false` asks for the AWS
+  owned key real DynamoDB uses by default. It is accepted.
+- Table resource policies are absent. `ResourcePolicy` on a CloudFormation Resource is recorded, and
+  a table a policy was meant to keep callers out of is open here and closed on AWS.
+- `OnDemandThroughput` and `WarmThroughput` are recorded, never applied. No process here applies a
   request-unit maximum or pre-warms capacity.
 - `BillingModeSummary` and `TableClassSummary` are reported only when the request named a
-  `BillingMode` or a `TableClass`. Real DynamoDB reports the effective values whichever way the table
-  was created.
-- `ItemCount` and `TableSizeBytes` are always 0. Real DynamoDB updates both about every six hours, so
-  they lag behind the items there too.
+  `BillingMode` or a `TableClass`. Real DynamoDB reports the effective values whichever way the
+  table was created.
+- `ItemCount` and `TableSizeBytes` are always 0. Real DynamoDB updates both about every six hours.
+  They lag behind the items there too.
 - Deletion happens as soon as the background work runs, where real DynamoDB may take a while over a
-  large table. Nothing waits for a `DELETING` table to go, so a test that needs it gone calls
+  large table. No call waits for a `DELETING` table to go. A test that needs it gone calls
   `simAws.backgroundTasksComplete()`.
-- The segment a parallel scan puts an item in is not the segment real DynamoDB would put it in.
-  DynamoDB's partition key hash is unpublished, so a different one is used here. What matches is the
-  shape: whole item collections move together, and the segments come out uneven. A test asserting
-  which segment a given key lands in is asserting something about this simulator rather than about
-  DynamoDB.
-- A table ARN naming another Account or Region is refused rather than resolved to the local table of
-  that name. Cross-account table access needs a resource policy, which is not simulated.
-- A table in `UPDATING` refuses `DeleteTable` as well as a second `UpdateTable`, which is AWS
-  behaviour: a table has to be `ACTIVE` before either.
-- Nothing enforces capacity. A provisioned table's throughput is stored and reported, and no request
-  is ever throttled with `ProvisionedThroughputExceededException`.
+- The segment a parallel scan puts an item in differs from the segment real DynamoDB would put it
+  in. DynamoDB's partition key hash is unpublished, and a different one is used here. What matches
+  is the shape. Whole item collections move together, and the segments come out uneven. A test
+  asserting which segment a given key lands in is asserting something about this simulator in place
+  of about DynamoDB.
+- A table ARN naming another Account or Region is refused, never resolved to the local table of that
+  name. Cross-account table access needs a resource policy, and that is absent here.
+- A table in `UPDATING` refuses `DeleteTable` as well as a second `UpdateTable`, as AWS behaves,
+  since a table has to be `ACTIVE` before either.
+- No check enforces capacity. A provisioned table's throughput is stored and reported, and no
+  request is ever throttled with `ProvisionedThroughputExceededException`.
 - A query or scan page is never cut short by size. Real DynamoDB stops a page at 1 MB and hands out
-  a `LastEvaluatedKey`, which is not modelled here, so a page breaks only on a `Limit`. A test
-  reading a large collection or a large table with no `Limit` gets all of it in one page where a real
-  one would page.
-- Nothing here throttles or measures a query or a scan, so `ReturnConsumedCapacity` is refused unless
-  it names `NONE`, and a `Limit` is the only thing that ends a page early.
-- A key condition takes no brackets. `(customerId = :c) AND orderId > :o` is refused here, where real
-  DynamoDB accepts it. The shape of a key condition is fixed, so there is nothing for brackets to
-  group, and being stricter is the direction that fails safely: it is a puzzling refusal here rather
-  than a query that means something different on AWS.
-- `ProjectionExpression` is refused on `Query` and on `Scan`, since it changes which parts of an item
-  the operation answers with. `Select` covers the counted and the projected read in the meantime.
-- `UnprocessedItems` and `UnprocessedKeys` are always empty. Nothing here is throttled and no
-  response stops at a size, so the branch of a batch retry loop that resends what did not go through
-  is never taken against the simulator.
-- The 16 MB limit on a batch request is not enforced. Real DynamoDB counts the request as the JSON it
-  arrived as, which is larger than the items it carries, and that inflation is not modelled: a batch
-  of 25 items under 400 KB each is under 10 MB by the sizes counted here, so nothing this simulation
-  measures ever reaches 16 MB.
-- `TransactionConflictException` and `TransactionInProgressException` are not modelled. Every call
-  here is serialised in one process, so no transaction ever meets another one working on the same
-  item, and neither error is reachable.
-- Only `None` and `ConditionalCheckFailed` appear as cancellation codes. Nothing here is throttled
-  and no item collection is tracked, so `ProvisionedThroughputExceeded` and
+  a `LastEvaluatedKey`, which is left out here. A page breaks only on a `Limit`. A test reading a
+  large collection or a large table with no `Limit` gets all of it in one page where a real one
+  would page.
+- No part of this throttles or measures a query or a scan, so `ReturnConsumedCapacity` is refused
+  unless it names `NONE`, and a `Limit` is the only thing that ends a page early.
+- A key condition takes no brackets. `(customerId = :c) AND orderId > :o` is refused here, where
+  real DynamoDB accepts it. The shape of a key condition is fixed. There is no sub-expression for
+  brackets to group, and being stricter is the direction that fails safely. It is a puzzling refusal
+  here rather than a query that means something different on AWS.
+- `ProjectionExpression` is refused on `Query` and on `Scan`, since it changes which parts of an
+  item the operation answers with. `Select` covers the counted and the projected read in the
+  meantime.
+- `UnprocessedItems` and `UnprocessedKeys` are always empty. No request here is throttled and no
+  response stops at a size, and the branch of a batch retry loop that resends what did not go
+  through is never taken against the simulator.
+- The 16 MB limit on a batch request goes unenforced. Real DynamoDB counts the request as the JSON
+  it arrived as, and the JSON is larger than the items it carries. That inflation is left out. A
+  batch of 25 items under 400 KB each is under 10 MB by the sizes counted here. No measurement this
+  simulation takes ever reaches 16 MB.
+- `TransactionConflictException` and `TransactionInProgressException` are left out. Every call here
+  is serialised in one process. No transaction ever meets another one working on the same item, and
+  both errors are out of reach.
+- Only `None` and `ConditionalCheckFailed` appear as cancellation codes. No request here is
+  throttled and no item collection is tracked, so `ProvisionedThroughputExceeded` and
   `ItemCollectionSizeLimitExceeded` never happen, and input DynamoDB would report as a
   `ValidationError` per action is refused up front as a `ValidationException` for the whole request.
 - The 4 MB limit on a transactional write is counted from the items and keys the actions carry,
   rather than from the JSON the request arrived as, which is larger. A transaction near the limit
-  here is near the limit there, but the byte counts are not identical.
-- A `ClientRequestToken` is compared against the `TransactItems` as the JSON they arrived as, so a
+  here is near the limit there, but the byte counts differ.
+- A `ClientRequestToken` is compared against the `TransactItems` as the JSON they arrived as, and a
   retry that names the same actions in a different order reads as a different request and is refused
-  rather than replayed. A retry of the same call sends the same JSON, so this shows up only in a
-  test that rebuilds the request by hand.
+  in place of replayed. A retry of the same call sends the same JSON. This shows up only in a test
+  that rebuilds the request by hand.
 - AWS creates one table with secondary indexes at a time in an account and region, and refuses a
   `CreateTable` that overlaps another one. Simulated CloudFormation creates each batch of resources
-  whose dependencies are met at once, so a template holding two indexed tables with no `DependsOn`
-  between them deploys here and may not on AWS. That is the exact template shape that diverges: one
+  whose dependencies are met at once. A template holding two indexed tables with no `DependsOn`
+  between them deploys here and may not on AWS. That is the exact template shape that diverges. One
   indexed table, or several with `DependsOn` ordering them, behaves the same either way.
 - A CloudFormation stack reaches `CREATE_COMPLETE` while the table it created is still `CREATING`.
-  Real CloudFormation waits for the table to be `ACTIVE`, so a test reading the status after the
+  Real CloudFormation waits for the table to be `ACTIVE`, and a test reading the status after the
   stack deployed calls `simAws.backgroundTasksComplete()` first.
-- A CloudFormation stack update replaces a changed table rather than updating it in place, so the
-  items in it are lost where real CloudFormation would keep them for a property it can change
-  without replacement.
-- `ProjectionExpression` is simulated on `GetItem`, `BatchGetItem` and `TransactGetItems`. On `Query`
-  and `Scan` it is refused rather than ignored.
-- The legacy `AttributesToGet` is refused rather than ignored, since an item that came back whole
-  where part of it was asked for would hide an application reading an attribute it never requested.
-  `ProjectionExpression` replaced it, and real DynamoDB has built nothing on it since.
-- The 4 KB limit on an expression and the 255 byte limit on a placeholder are not enforced. Nothing
-  here is slower for a long expression, so an expression real DynamoDB would refuse for its size is
-  evaluated.
+- A CloudFormation stack update replaces a changed table rather than updating it in place. The items
+  in it are lost where real CloudFormation would keep them for a property it can change without
+  replacement.
+- `ProjectionExpression` is simulated on `GetItem`, `BatchGetItem` and `TransactGetItems`. On
+  `Query` and `Scan` it is refused, never ignored.
+- The legacy `AttributesToGet` is refused outright, since an item that came back whole where part of
+  it was asked for would hide an application reading an attribute it never requested.
+  `ProjectionExpression` replaced it, and real DynamoDB has built no feature on it since.
+- The 4 KB limit on an expression and the 255 byte limit on a placeholder go unenforced. No
+  operation here is slower for a long expression. An expression real DynamoDB would refuse for its
+  size is evaluated.
 - Reads are always strongly consistent. `ConsistentRead` is accepted either way and changes nothing,
-  whether a request sets it once for a read or per table for a batch read, so a test cannot observe a
-  stale read here the way it might against a real table.
+  whether a request sets it once for a read or per table for a batch read, and a test cannot observe
+  a stale read here the way it might against a real table.
 - Condition expressions are simulated on `PutItem`, `DeleteItem`, `UpdateItem` and the actions of
   `TransactWriteItems`, key conditions on `Query`, and filters on `Query` and `Scan`.
-- Two update actions cannot write to overlapping paths, so `ADD tags :added DELETE tags :gone` in one
-  expression is refused as it is on AWS. Taking members out of a set an expression also adds to is a
-  second update.
-- An update is applied in one go, so nothing here shows the concurrency an atomic counter is for. A
+- Two update actions cannot write to overlapping paths, so `ADD tags :added DELETE tags :gone` in
+  one expression is refused as it is on AWS. Taking members out of a set an expression also adds to
+  is a second update.
+- An update is applied in one go. No part of this shows the concurrency an atomic counter is for. A
   simulated `ADD` counts exactly once per call, where a real one is what makes two callers counting
   at the same time both count.
-- The legacy `AttributeUpdates` is refused rather than ignored, for the same reason `Expected` is.
-  `UpdateExpression` replaced it, and real DynamoDB has built nothing on it since.
-- A `REMOVE` whose path reaches through an attribute that is missing, or that is not a map, changes
-  nothing rather than being refused. `REMOVE` names a place rather than a value, so there was nothing
-  there to remove either way.
-- The legacy `Expected` and `ConditionalOperator` are refused rather than ignored, since an
-  expectation that is never evaluated would let a write or a delete through that DynamoDB would have
-  turned away. `ConditionExpression` replaced them, and real DynamoDB has built nothing on them
-  since.
-- The 4 KB limit on an expression and the 300 operator limit are not enforced. Nothing here is slower
-  for a long expression, so an expression real DynamoDB would refuse for its size is evaluated.
-- Capacity and item collection reporting are not simulated. `ReturnConsumedCapacity` and
+- The legacy `AttributeUpdates` is refused outright, for the same reason `Expected` is.
+  `UpdateExpression` replaced it, and real DynamoDB has built no feature on it since.
+- A `REMOVE` whose path reaches through an attribute that is missing, or that is something other
+  than a map, changes nothing rather than being refused. `REMOVE` names a place in the item. There
+  was nothing there to remove either way.
+- The legacy `Expected` and `ConditionalOperator` are refused outright, since an expectation that is
+  never evaluated would let a write or a delete through that DynamoDB would have turned away.
+  `ConditionExpression` replaced them, and real DynamoDB has built no feature on them since.
+- The 4 KB limit on an expression and the 300 operator limit go unenforced. No operation here is
+  slower for a long expression, and an expression real DynamoDB would refuse for its size is
+  evaluated.
+- Capacity and item collection reporting are absent. `ReturnConsumedCapacity` and
   `ReturnItemCollectionMetrics` are refused unless they name `NONE`.
-- A `Key` that does not match the table's key schema is refused with the attribute named. Real
-  DynamoDB answers `The provided key element does not match the schema` without saying which
+- A `Key` that fails to match the table's key schema is refused with the attribute named. Real
+  DynamoDB answers `The provided key element fails to match the schema` without saying which
   attribute was at fault.
-- A number comes back in plain decimal notation, whatever notation it was written in, so a request
+- A number comes back in plain decimal notation, whatever notation it was written in. A request
   carrying `1E5` reads back `100000`. The value is the one that was written either way, but the text
-  is not always character for character what real DynamoDB would answer with for a number at the
+  is only sometimes character for character what real DynamoDB would answer with for a number at the
   extremes of its range.
 - Item sizes follow the figures AWS documents for its 400 KB limit, which AWS itself describes as
-  approximate. An item near the limit here is near the limit there, but the byte counts are not
-  identical.
-- PartiQL is not simulated, and is not on the roadmap for this service.
-- DynamoDB is not served as an HTTP API by `serveSimAws`.
+  approximate. An item near the limit here is near the limit there, but the byte counts differ.
+- PartiQL is absent, and stays off the roadmap for this service.
+- `serveSimAws` serves no DynamoDB HTTP API.

--- a/docs/services/ecr/README.md
+++ b/docs/services/ecr/README.md
@@ -6,7 +6,8 @@ each repository holds images by tag, where a simulated image is a real in-proces
 That is what this service is for. A container image Lambda function cannot run here, because Yulin
 never reads an image, so something has to say what the code inside that image actually is. A
 repository is the natural place to say it. It is the stable name for the thing that holds the code,
-and it outlives any stack, any tag and any CDK construct ID.
+outliving any tag and any CDK construct ID, and a repository holding a registered handler outlives
+the stack that declared it too.
 
 ECR-specific types are imported from the `@kensio/yulin/ecr` subpath.
 
@@ -246,10 +247,9 @@ delete a repository that still holds images, which fails the stack unless the te
 `EmptyOnDelete`. Here the refusal is recorded and the teardown carries on, since what is being
 protected is a test's own registration.
 
-Every other property a repository can declare is about image content, so each one is recorded as an
-ignored property and the repository is created without it. That covers `ImageScanningConfiguration`,
-`ImageTagMutability`, `LifecyclePolicy`, `RepositoryPolicyText`, `EncryptionConfiguration`,
-`EmptyOnDelete` and `Tags`.
+Every other property a repository can declare is recorded as an ignored property, and the repository
+is created without it. That covers `ImageScanningConfiguration`, `ImageTagMutability`,
+`LifecyclePolicy`, `RepositoryPolicyText`, `EncryptionConfiguration`, `EmptyOnDelete` and `Tags`.
 
 ## Where a function's handler comes from
 
@@ -257,8 +257,8 @@ Two things can back a container image function, and a deploy is looked at in thi
 
 1. An [executable binding](../lambda/#executable-bindings) given to that deploy, including one
    naming the image repository. A binding is the more specific thing to have said, since it is about
-   one deploy. 2. The simulated ECR repository the function's `Code.ImageUri` names. That is a standing
-   statement
+   one deploy.
+2. The simulated ECR repository the function's `Code.ImageUri` names. That is a standing statement
    about what the image is, made once and good for every stack that runs it.
 
 A function with no binding and no registered image is skipped with a diagnostic, and the rest of the

--- a/docs/services/ecr/README.md
+++ b/docs/services/ecr/README.md
@@ -5,21 +5,21 @@ each repository holds images by tag, where a simulated image is a real in-proces
 
 That is what this service is for. A container image Lambda function cannot run here, because Yulin
 never reads an image, so something has to say what the code inside that image actually is. A
-repository is the natural place to say it: it is the stable name for the thing that holds the code,
+repository is the natural place to say it. It is the stable name for the thing that holds the code,
 and it outlives any stack, any tag and any CDK construct ID.
 
 ECR-specific types are imported from the `@kensio/yulin/ecr` subpath.
 
 ## What a simulated image is
 
-An image URI is only ever an identifier here. Nothing is pulled, nothing is inspected, and no layer,
+An image URI is only ever an identifier here. No image is pulled or inspected, and no layer,
 manifest, digest or scan finding exists. A simulated image is a handler function, registered against
 a repository and a tag.
 
-Registering one is a Yulin-native operation rather than a simulated `PutImage`, and it is named
-`simulateImage` so it cannot be mistaken for one. Real `PutImage` takes an image manifest for layers
-that were pushed over the Docker registry protocol, none of which happens in this process, so a
-simulated `PutImage` would be a command that took an argument nothing could produce.
+Registering one is a Yulin-native operation, named `simulateImage` to keep it clear of a simulated
+`PutImage`. Real `PutImage` takes an image manifest for layers that were pushed over the Docker
+registry protocol. None of that happens in this process, and a simulated `PutImage` would be a
+command taking an argument nothing could produce.
 
 ## Registering a handler as an image
 
@@ -81,13 +81,12 @@ console.log(Buffer.from(output.Payload).toString());
 await simAws.backgroundTasksComplete();
 ```
 
-Naming a repository is what creates it. There is nothing to declare first, because a repository
-holds nothing of its own beyond its images, so a test can name the repository its templates already
-point at.
+Naming a repository is what creates it. A repository holds only its images. There is no prior
+declaration to make, and a test can name the repository its templates already point at.
 
-The repository name is a name rather than a URI. The account, the region and the registry host
-around it come from the simulated ECR the repository belongs to, so `orders` and `platform/orders`
-are names and an image URI is not one. A name real ECR would refuse is refused here too.
+The repository takes a bare name such as `orders` or `platform/orders`, and never a full image URI.
+The account, the region and the registry host around it come from the simulated ECR the repository
+belongs to. A name real ECR would refuse is refused here too.
 
 ## How an image URI is matched
 
@@ -95,7 +94,7 @@ Resolving an image URI happens in two steps, and the tag means something differe
 
 Finding the repository ignores the tag. A function's `Code.ImageUri` is matched on the registry host
 and the repository name, with any tag or digest dropped, because no tag is stable enough to write
-into a test: a CDK image asset is tagged with the asset content hash, which changes whenever the
+into a test. A CDK image asset is tagged with the asset content hash, which changes whenever the
 image source does, and a pipeline-built image is usually tagged with a git sha or a build number
 passed in as a stack parameter. An `ImageUri` built by `Fn::Sub` or from a stack parameter is
 matched on what it resolves to.
@@ -103,12 +102,12 @@ matched on what it resolves to.
 Choosing the image in that repository does read the tag. A tag the repository holds selects exactly
 that image, and any other tag, or none at all, falls back to the image registered most recently.
 
-The registry host is part of the match, so the account and the region have to agree. A function can
+The registry host is part of the match, and the account and the region have to agree. A function can
 run an image from another account's repository, as it can on real AWS, and a same-named repository
 in another account is a different repository.
 
-So `orders:blue` runs the handler registered under `blue` where there is one, and the handler
-registered most recently where there is not. That is how a blue/green pair of images in one
+So `orders:blue` runs the handler registered under `blue` where the repository holds one, and the
+handler registered most recently otherwise. That is how a blue/green pair of images in one
 repository can back two functions differently, while a content hash tag nobody registered still
 finds something to run. Registering a tag again both replaces what it held and makes it the most
 recent registration.
@@ -153,16 +152,16 @@ await simAws.backgroundTasksComplete();
 ```
 
 A function created directly through `CreateFunction` resolves its image the same way a template
-function does, as the example above shows. A function whose image resolves to nothing is refused,
+function does, as the example above shows. A function whose image resolves to no handler is refused,
 the way real Lambda refuses a function whose image it cannot pull.
 
 ## Repositories in CloudFormation
 
 `AWS::ECR::Repository` creates a simulated repository. A template declares a repository and never an
-image, which is what real CloudFormation does too, so a deployed repository starts empty unless a
-handler has already been registered in it.
+image, as real CloudFormation does. A deployed repository starts empty unless a handler has already
+been registered in it.
 
-`Ref` returns the repository name, and `Fn::GetAtt` exposes `Arn` and `RepositoryUri`, so an
+`Ref` returns the repository name, and `Fn::GetAtt` exposes `Arn` and `RepositoryUri`. An
 application stack can build its function's `ImageUri` from the repository a platform stack declared.
 
 ```typescript sim-ecr-cloudformation-repository
@@ -236,21 +235,21 @@ console.log(Buffer.from(output.Payload).toString());
 await simAws.backgroundTasksComplete();
 ```
 
-A repository a handler is already registered in is adopted rather than replaced, so the order these
-happen in does not matter: the image exists before the stack that declares the repository, as it
-does in real life.
+A repository a handler is already registered in is adopted, and the order these happen in makes no
+difference. The image can exist before the stack that declares the repository, as it does in real
+life.
 
 Tearing the stack down removes the repository only where it holds no simulated image. One that does
 is left where it is, and the deletion is recorded as skipped, because the handler in it was
 registered outside any stack and is what every later deploy resolves to. Real ECR also refuses to
 delete a repository that still holds images, which fails the stack unless the template says
-`EmptyOnDelete`; the refusal is recorded rather than failing the teardown here, since what is being
+`EmptyOnDelete`. Here the refusal is recorded and the teardown carries on, since what is being
 protected is a test's own registration.
 
 Every other property a repository can declare is about image content, so each one is recorded as an
-ignored property and the repository is created without it. That covers
-`ImageScanningConfiguration`, `ImageTagMutability`, `LifecyclePolicy`, `RepositoryPolicyText`,
-`EncryptionConfiguration`, `EmptyOnDelete` and `Tags`.
+ignored property and the repository is created without it. That covers `ImageScanningConfiguration`,
+`ImageTagMutability`, `LifecyclePolicy`, `RepositoryPolicyText`, `EncryptionConfiguration`,
+`EmptyOnDelete` and `Tags`.
 
 ## Where a function's handler comes from
 
@@ -258,14 +257,13 @@ Two things can back a container image function, and a deploy is looked at in thi
 
 1. An [executable binding](../lambda/#executable-bindings) given to that deploy, including one
    naming the image repository. A binding is the more specific thing to have said, since it is about
-   one deploy.
-2. The simulated ECR repository the function's `Code.ImageUri` names, which is a standing statement
-   about what that image is, made once and good for every stack that runs it.
+   one deploy. 2. The simulated ECR repository the function's `Code.ImageUri` names. That is a standing
+   statement
+   about what the image is, made once and good for every stack that runs it.
 
-A function neither backs is skipped with a diagnostic, and the rest of the stack deploys. The reason
-distinguishes an image whose repository nothing holds from one whose repository holds no image,
-since those send you to different places: a name that is wrong, or a handler that was never
-registered.
+A function with no binding and no registered image is skipped with a diagnostic, and the rest of the
+stack deploys. The reason separates a missing repository from an empty one, since those send you to
+different places. One is a wrong name, and the other is a handler that was never registered.
 
 ## Available functionality
 
@@ -282,24 +280,23 @@ registered.
 
 Current documented limitations:
 
-- No image content, layer, digest, manifest or scan behaviour is simulated. Nothing is pulled,
-  nothing is inspected, and a repository holds handlers rather than artifacts.
+- No image content, layer, digest, manifest or scan behaviour is simulated. A repository holds
+  handlers, and no image is ever pulled or inspected.
 - There are no ECR SDK commands. `CreateRepository`, `DescribeRepositories`, `PutImage`,
-  `DescribeImages`, `BatchDeleteImage` and `GetAuthorizationToken` are not simulated. Registering an
+  `DescribeImages`, `BatchDeleteImage` and `GetAuthorizationToken` are all absent. Registering an
   image is a Yulin-native operation because real `PutImage` takes a manifest for layers pushed over
-  the Docker registry protocol, which does not happen in this process.
-- Nothing authorizes against a repository. There are no requests to authorize, so a repository
-  policy is not evaluated and simulated IAM is not consulted.
-- Lifecycle policies are not evaluated, so no simulated image ever expires, and tag mutability is
-  not enforced, so registering the same tag again replaces what it held.
+  the Docker registry protocol, and that protocol never runs in this process.
+- Nothing authorizes against a repository. With no requests to authorize, a repository policy goes
+  unread and simulated IAM stays out of it.
+- Lifecycle policies go unevaluated, and no simulated image ever expires. Tag mutability goes
+  unenforced, and registering the same tag again replaces what it held.
 - Naming a repository creates it. There is no `CreateRepository` to fail for a name already taken,
   and no way to ask whether a repository exists without making one, other than `hasRepository`.
-- A stack teardown records the deletion of a repository holding a simulated image rather than
-  failing, where real CloudFormation fails the stack unless the template says `EmptyOnDelete`. The
-  repository and its handler are left in place. `EmptyOnDelete` itself is not read.
+- A stack teardown records the deletion of a repository holding a simulated image and carries on,
+  where real CloudFormation fails the stack unless the template says `EmptyOnDelete`. The repository
+  and its handler are left in place, and `EmptyOnDelete` itself goes unread.
 - Nothing tracks which stack created a repository. A repository holding no simulated image is
   removed by the teardown of any stack that declared it, and made again by the next deploy.
-- Repository tags, registry policies, pull through cache rules, replication configuration and
-  ECR Public are not simulated.
-- ECR is not served as an HTTP API by `serveSimAws`, and there is nothing for a Docker client to
-  talk to.
+- Repository tags, registry policies, pull through cache rules, replication configuration and ECR
+  Public are not simulated.
+- ECR has no HTTP API under `serveSimAws`, and nothing for a Docker client to talk to.

--- a/docs/services/ecs/README.md
+++ b/docs/services/ecs/README.md
@@ -8,23 +8,24 @@ ECS-specific types are imported from the `@kensio/yulin/ecs` subpath.
 
 ## What Yulin does with a container image
 
-Yulin never looks inside a container image. It cannot: an image may hold a Go binary, nginx, Redis or
-anything else, and the only thing Yulin can run is JavaScript or TypeScript in its own process.
+Yulin never looks inside a container image, and it could not if it tried. An image may hold a Go
+binary, nginx, Redis or anything else, and the only thing Yulin can run is JavaScript or TypeScript
+in its own process.
 
 So an image URI is only ever an identifier. Nothing here reads it, pulls it, or runs anything from
 it. It is stored as declared, and it is what a container is matched on when a task runs, in the same
-way an image URI identifies a container image Lambda function. The rule that follows from it is that
-a container matched to a handler runs that handler, and a container with no match is recorded as not
-simulated rather than failing anything.
+way an image URI identifies a container image Lambda function. The rule that follows is that a
+container matched to a handler runs that handler, and a container with no match is recorded as not
+simulated while the rest of the task carries on.
 
 A realistic task definition holds an application container, a log router and an observability agent.
-Only the first of those is something Yulin could ever run, and all three are stored and reported back
-exactly as declared.
+Only the first of those is something Yulin could ever run, and all three are stored and reported
+back exactly as declared.
 
-Where this does not work is a sidecar the application depends on, such as a Redis or a database in
-the same task. Yulin does not simulate that. The connection details are ordinary environment
-variables, so point them at a real one you run yourself. See
-[non-AWS dependencies](../../non-aws-dependencies/README.md) for how that fits together.
+The case this leaves out is a sidecar the application depends on, such as a Redis or a database in
+the same task. Point its connection details, which are ordinary environment variables, at a real one
+you run yourself. See [non-AWS dependencies](../../non-aws-dependencies/README.md) for how that fits
+together.
 
 ## Registering a task definition
 
@@ -76,16 +77,16 @@ console.log(described.taskDefinition?.containerDefinitions?.[0]?.image);
 ```
 
 Container definitions are stored as declared, whatever the image is and whether or not Yulin could
-ever run it. That includes port mappings, environment variables and secrets: a `valueFrom` naming a
-Secrets Manager secret is held as the identifier it is, since nothing resolves it.
+ever run it. That covers port mappings, environment variables and secrets. A `valueFrom` naming a
+Secrets Manager secret is held as the identifier it is, and never resolved.
 
-A registration is refused rather than trimmed if it declares something this simulation does not hold.
-That way a declaration cannot go missing from the revision it made.
+A registration that declares something this simulation has no room for is refused outright, and
+never trimmed. That way a declaration cannot go missing from the revision it made.
 
 ## Revisions
 
 Each registration of a family takes the next revision number. Naming the family alone means its
-latest active revision, so it follows registrations as they are made.
+latest active revision, which follows registrations as they are made.
 
 ```typescript sim-ecs-task-definition-revisions
 /**
@@ -125,15 +126,15 @@ console.log(first.taskDefinition?.containerDefinitions?.[0]?.image);
 // "checkout:1"
 ```
 
-`DescribeTaskDefinition` takes all three forms ECS takes: a family, a `family:revision`, and a full
-task definition ARN. The ARN of a revision is
+`DescribeTaskDefinition` takes all three forms ECS takes, namely a family, a `family:revision`, and
+a full task definition ARN. The ARN of a revision is
 `arn:aws:ecs:<region>:<account>:task-definition/<family>:<revision>`.
 
 ## Deregistering a revision
 
-`DeregisterTaskDefinition` marks one revision `INACTIVE` without removing it. It stays describable by
-`family:revision` and by ARN, because something already holding either of those still needs to find
-out what it declared. What it stops being is the revision the family resolves to.
+`DeregisterTaskDefinition` marks one revision `INACTIVE` without removing it. It stays describable
+by `family:revision` and by ARN, because something already holding either of those still needs to
+find out what it declared. What it stops being is the revision the family resolves to.
 
 ```typescript sim-ecs-deregister-task-definition
 /**
@@ -185,9 +186,9 @@ revision 3.
 ## Listing task definitions
 
 `ListTaskDefinitions` reports revision ARNs and `ListTaskDefinitionFamilies` reports family names.
-Both take a `familyPrefix`. A `ListTaskDefinitions` request saying nothing about status gets the
-active revisions, while a `ListTaskDefinitionFamilies` request saying nothing gets both the active
-and the inactive families, which is how real ECS defaults each of them.
+Both take a `familyPrefix`. A `ListTaskDefinitions` request silent on status gets the active
+revisions, while a `ListTaskDefinitionFamilies` request silent on it gets both the active and the
+inactive families. That is how real ECS defaults each of them.
 
 ```typescript sim-ecs-list-task-definitions
 /**
@@ -280,14 +281,14 @@ console.log(listed.clusterArns?.[0]);
 Settings, configuration and tags are reported only where the request asked for them by name, as they
 are on real ECS. A request naming no cluster means the `default` cluster.
 
-`DeleteCluster` marks a cluster `INACTIVE`. It stays describable and drops out of `ListClusters`, and
-creating a cluster of the same name again makes a new active one, listed in the position it was
-created in. Unlike the operations that read a cluster, `DeleteCluster` needs one to be named: a
-request naming none is refused rather than taken as meaning the `default` cluster.
+`DeleteCluster` marks a cluster `INACTIVE`. It stays describable and drops out of `ListClusters`,
+and creating a cluster of the same name again makes a new active one, listed in the position it was
+created in. Unlike the operations that read a cluster, `DeleteCluster` needs one to be named. A
+request naming none is refused, and never read as meaning the `default` cluster.
 
 A cluster is named either by its short name or by its full ARN, and the two are interchangeable. An
-ARN belonging to another account or region names a different cluster, so `DescribeClusters` reports
-it as a `MISSING` failure and `DeleteCluster` refuses it.
+ARN belonging to another account or region names a different cluster. `DescribeClusters` reports it
+as a `MISSING` failure, and `DeleteCluster` refuses it.
 
 A cluster has to exist before a task can run in it, including the `default` one. Yulin creates no
 cluster on its own, so create the one the tasks run in.
@@ -361,17 +362,17 @@ console.log(described.tasks?.[0]?.containers?.[1]?.reason);
 // "Not simulated: no executable binding matches this container, ..."
 ```
 
-`RunTask` answers before the containers have run, with the task in `PROVISIONING`, which is what real
-ECS answers with. Waiting for the simulator's background work is what runs them.
+`RunTask` answers before the containers have run, with the task in `PROVISIONING`, as real ECS
+answers it. Waiting for the simulator's background work is what runs them.
 
-The log router in that task definition has no binding, so it never starts and says why. That is the
-ordinary shape of a real task definition: an application container Yulin can run, next to containers
-it never could.
+The log router in that task definition has no binding. It never starts, and says why. That is the
+ordinary shape of a real task definition, with an application container Yulin can run next to
+containers it never could.
 
 A handler that throws stops its container with an exit code of 1 and the error message as its
-reason. The `RunTask` call itself does not fail, because nothing is watching one by the time a real
-container fails either. A task definition where nothing at all is bound still creates the task, which
-stops with a `stopCode` of `TaskFailedToStart` saying that nothing ran.
+reason. The `RunTask` call itself still succeeds, because a real container fails with nobody
+watching the call either. A task definition where nothing at all is bound still creates the task.
+The task stops with a `stopCode` of `TaskFailedToStart` saying that nothing ran.
 
 ### Binding by image repository
 
@@ -424,13 +425,13 @@ await simAws.backgroundTasksComplete();
 console.log(started); // ["app"]
 ```
 
-The registry host is part of the repository, so a same-named repository in another account or region
-does not match. A binding naming the family and the container name beats one naming a repository
+The registry host is part of the repository, and a same-named repository in another account or
+region misses. A binding naming the family and the container name beats one naming a repository
 where both would match, and binding the same container again replaces what it runs.
 
-The other shape a binding can take is `http`, a fetch-style
-`(request: Request) => Response | Promise<Response>` for a service container behind a load balancer.
-It is called once for each request routed to the container, and is covered under
+The other shape a binding can take is `http`, a fetch-style `(request: Request) => Response |
+Promise<Response>` for a service container behind a load balancer. It is called once for each
+request routed to the container, and is covered under
 [serving requests behind a load balancer](#serving-requests-behind-a-load-balancer).
 
 ## What a container sees while it runs
@@ -438,7 +439,7 @@ It is called once for each request routed to the container, and is covered under
 The container definition's `environment` is visible through `process.env` for the length of the run,
 along with any `RunTask` container override and the region variables a real task agent sets. This
 works the same way it does for a sim Lambda function handler, through Node.js asynchronous context
-tracking, so a container that declares nothing reads the host environment untouched.
+tracking. A container that declares nothing reads the host environment untouched.
 
 ```typescript sim-ecs-run-task-environment
 /**
@@ -496,8 +497,8 @@ await simAws.backgroundTasksComplete();
 console.log(batchSizes); // ["10"]
 ```
 
-A variable read at module scope, as in `const size = process.env.BATCH_SIZE` at the top of a file, is
-read when the test imports that file rather than when the container runs, so it sees the host value.
+A variable read at module scope, as in `const size = process.env.BATCH_SIZE` at the top of a file,
+is read when the test imports that file and not when the container runs, and it sees the host value.
 Read inside the handler to get the container's own.
 
 ## The task role
@@ -586,15 +587,14 @@ await simAws.backgroundTasksComplete();
 ```
 
 Take the policy away and the same run stops the container with an exit code of 1, carrying the IAM
-denial as its reason. That is the test worth writing: a task role missing a permission fails in the
-test rather than in the deployment.
+denial as its reason. That is the test worth writing. A task role missing a permission fails in the
+test, ahead of the deployment.
 
 A `RunTask` request can override the role with `overrides.taskRoleArn`. A task definition declaring
-no task role runs its containers as nobody, so their AWS calls are denied: a real task without one
+no task role runs its containers as nobody, and their AWS calls are denied. A real task without one
 has no credentials of its own, and taking the identity of whoever called `RunTask` would let a test
-pass on permissions the deployed task has not got. The execution role is what a container's
-`secrets` are resolved as, and nothing else: there is no image to pull and no log driver to write
-to.
+pass on permissions the deployed task lacks. The execution role covers a container's `secrets`
+alone, since there is no image to pull and no log driver to write to.
 
 ## Container secrets
 
@@ -603,8 +603,8 @@ or simulated SSM Parameter Store according to what each `valueFrom` names, and t
 the container's environment alongside its declared `environment`. A handler reads them through
 `process.env` like anything else.
 
-They are read as the task definition's `executionRoleArn`, not its `taskRoleArn`, which is the
-split real ECS makes: the execution role is what the task agent pulls secrets with before a
+They are read as the task definition's `executionRoleArn` rather than its `taskRoleArn`. That is the
+split real ECS makes. The execution role is what the task agent pulls secrets with before a
 container starts, and the task role is what the running container's own AWS calls are attributed to.
 A role allowed one is not thereby allowed the other.
 
@@ -715,55 +715,56 @@ arn:aws:iam::111111111111:role/OrdersExecutionRole is not authorized to perform:
 secretsmanager:GetSecretValue on resource: arn:aws:secretsmanager:...
 ```
 
-The task stops with `TaskFailedToStart` and never reaches `RUNNING`, so the bound handler does not
-run. A secret that does not exist, a task definition declaring secrets with no `executionRoleArn`,
-and a JSON key the secret has not got each stop it the same way with their own reason.
+The task stops with `TaskFailedToStart`, never reaches `RUNNING`, and the bound handler stays unrun.
+A secret that was never created, a task definition declaring secrets with no `executionRoleArn`, and
+a JSON key the secret lacks each stop it the same way with their own reason.
 
 ## Running a task from a rule or a schedule
 
-A task does not have to be started by a `RunTask` call. A [simulated EventBridge](../eventbridge/)
-rule target and a [simulated Scheduler](../scheduler/) schedule target can both name an ECS cluster,
-and both then run a task here when the rule matches an event or the schedule falls due. That is the
-usual shape of a nightly batch job or an import kicked off by something happening.
+A `RunTask` call is one way to start a task, and there are two others. A
+[simulated EventBridge](../eventbridge/) rule target and a [simulated Scheduler](../scheduler/)
+schedule target can both name an ECS cluster, and both then run a task here when the rule matches an
+event or the schedule falls due. That is the usual shape of a nightly batch job or an import kicked
+off by something happening.
 
-Both go through `RunTask`, so a task started that way is the same task as one started by a caller:
-the same cluster and revision lookups, the same IAM decision against `ecs:RunTask`, and the same
-task state afterwards. What a target may ask for is not the same, though. `EcsParameters` takes and
+Both go through `RunTask`, and a task started that way is the same task as one started by a caller.
+That means the same cluster and revision lookups, the same IAM decision against `ecs:RunTask`, and
+the same task state afterwards. What a target may ask for differs, though. `EcsParameters` takes and
 ignores the launch type, platform version, network configuration and capacity provider strategy that
 `RunTask` refuses, since a target written for real AWS carries them and refusing one would make an
-otherwise workable target unusable. The other difference is who runs it. A rule or a
-schedule runs the task as the role on its target, so that role needs `ecs:RunTask` on the revision,
-and the task role inside the task definition is still what the containers' own AWS calls are
-attributed to.
+otherwise workable target unusable. The other difference is who runs it. A rule or a schedule runs
+the task as the role on its target, and that role needs `ecs:RunTask` on the revision. The task role
+inside the task definition is still what the containers' own AWS calls are attributed to.
 
-The container model applies unchanged: only a bound container runs, and a target naming a task
-definition with nothing bound records a task that never started rather than failing the rule or the
-schedule. Writing one of these targets is documented where the target is written, in
+The container model applies unchanged. Only a bound container runs, and a target naming a task
+definition with nothing bound records a task that never started, leaving the rule or the schedule
+itself successful. Writing one of these targets is documented where the target is written, in
 [running an ECS task](../eventbridge/#running-an-ecs-task) for a rule and
 [running an ECS task on a schedule](../scheduler/#running-an-ecs-task-on-a-schedule) for a schedule.
 
 ## Describing, listing and stopping tasks
 
 `DescribeTasks` reports a task by its id or its full ARN, with its containers, which of them ran and
-their exit codes. A task it cannot find is a `MISSING` failure entry rather than an error.
+their exit codes. A task it cannot find comes back as a `MISSING` failure entry, and never as an
+error.
 
-`ListTasks` filters on a desired status of `RUNNING` when a request says nothing, as real ECS does,
-so a task that has finished is only listed by asking for the stopped ones with
-`desiredStatus: "STOPPED"`. It also filters by `family`, `startedBy` and `launchType`.
+`ListTasks` filters on a desired status of `RUNNING` when a request says nothing, as real ECS does.
+A task that has finished is only listed by asking for the stopped ones with `desiredStatus:
+"STOPPED"`. It also filters by `family`, `startedBy` and `launchType`.
 
 `StopTask` sets the desired status to `STOPPED` and records the reason. A task whose containers have
-not started yet runs none of them, and one stopped part way through runs no more, so a test can stop
-a task between `RunTask` and the background work that runs it. A task that has already stopped is
-reported as it stands, keeping the reason it stopped for.
+yet to start runs none of them, and one stopped part way through runs no more. A test can therefore
+stop a task between `RunTask` and the background work that runs it. A task that has already stopped
+is reported as it stands, keeping the reason it stopped for.
 
 ## Services
 
-A task runs and stops. A service keeps tasks running, which is what a deployed application usually
-is: a named service in a cluster, running some number of tasks from a task definition.
+A task runs and stops. A service keeps tasks running, and that is what a deployed application
+usually is. It is a named service in a cluster, running some number of tasks from a task definition.
 
 `CreateService` creates one. Its tasks exist as soon as the request is answered and reach `RUNNING`
-on the simulation's background work, as real ECS brings a new service up, so the service reports the
-desired count it was given and a running count that catches up.
+on the simulation's background work, as real ECS brings a new service up. The service reports the
+desired count it was given, and a running count that catches up.
 
 ```typescript sim-ecs-create-service
 /**
@@ -832,35 +833,35 @@ async function handleOneRequest(): Promise<void> {
 }
 ```
 
-Each of those tasks is a task like any other: `ListTasks` returns its ARN, `DescribeTasks` describes
+Each of those tasks is a task like any other. `ListTasks` returns its ARN, `DescribeTasks` describes
 it, and its containers report which of them Yulin is simulating.
 
-### The desired count is state, not concurrency
+### What the desired count models
 
 A desired count of three does not mean three copies of your handler. Yulin runs in one Node.js
-process and there are no containers to copy, so the count is simulated as state: three tasks exist
-and are reported as running, while the handler bound to a container is called once per request or per
-poll, whenever something reaches it.
+process and there are no containers to copy, so the count is simulated as state. Three tasks exist
+and are reported as running, while the handler bound to a container is called once per request or
+per poll, whenever something reaches it.
 
-That is a deliberate divergence. What it means in practice is that a service is worth asserting on
-for its state — how many tasks it keeps, which revision they run — rather than for anything about
-running three things at once. A test that needs concurrency is a test about your own code, not about
-ECS.
+That is a deliberate divergence. In practice a service is worth asserting on for its state (how many
+tasks it keeps, which revision they run) and not for anything about running three things at once. A
+test that needs concurrency is a test about your own code.
 
 A container of a service that has come up is treated as running from that point, and what calls it
-is whatever reaches it: a queue it consumes, or a load balancer sending it a request. Both are
+is whatever reaches it, either a queue it consumes or a load balancer sending it a request. Both are
 covered below.
 
 ### Consuming a queue
 
-A worker container reads an SQS queue in a loop: receive a batch, handle it, delete it, go round
-again. A binding cannot do that. An endless loop in a single Node.js process blocks everything and
-never yields to the test running it, so nothing would ever get to assert on what the loop did.
+A worker container reads an SQS queue in a loop. It receives a batch, handles it, deletes it, and
+goes round again. A binding cannot do that. An endless loop in a single Node.js process blocks
+everything and never yields to the test running it, leaving the test no chance to assert on what the
+loop did.
 
-So Yulin runs the loop and the binding supplies its body. A container declares `consumes` instead of
-`run`, naming the queue and a handler for a batch of messages, and Yulin receives, hands the batch
-over, and deletes it when the handler returns. The bound thing is the body of the loop rather than
-the loop itself, which is the one divergence worth keeping in mind here.
+So Yulin runs the loop and the binding supplies its body. A container declares `consumes` in place
+of `run`, naming the queue and a handler for a batch of messages, and Yulin receives, hands the
+batch over, and deletes it when the handler returns. The bound thing is the body of the loop, and
+not the loop itself. That is the one divergence worth keeping in mind here.
 
 ```typescript sim-ecs-consume-queue
 /**
@@ -961,20 +962,20 @@ console.log(handled); // ["order-1"]
 
 The queue is named by the URL `CreateQueue` answered with, and it has to be in the same account and
 region as the service, as a real task's own queue is. A `batchSize` is how many messages the handler
-is given at once, up to the ten one SQS receive hands out; it defaults to ten. The handler may be
-async, and is awaited. A container that declares `consumes` declares no `run` handler, and binding
-one that declares both is refused.
+is given at once, up to the ten one SQS receive hands out, and it defaults to ten. The handler may
+be async, and is awaited. A container declares either `consumes` or `run`, and binding one that
+declares both is refused.
 
-The task role is not optional here, which is the part worth noticing before writing the first one.
-Polling is done as the task role, so a task definition with no `taskRoleArn` polls as nobody and its
-very first poll is denied. That is what a real worker container with no credentials would hit.
+The task role is required here. That is the part worth noticing before writing the first one.
+Polling is done as the task role, and a task definition with no `taskRoleArn` polls as nobody and
+has its very first poll denied. That is what a real worker container with no credentials would hit.
 
 #### Polling runs on the simulated clock
 
 Yulin never polls in the background of a test. A message that can be received now is delivered as
-soon as the simulation settles, so `await simAws.backgroundTasksComplete()` is enough for an
-ordinary send. Anything that has to wait — a message sent with `DelaySeconds`, or a batch coming back
-after its visibility timeout — waits on the simulated clock, so freezing time holds it and advancing
+soon as the simulation settles, and `await simAws.backgroundTasksComplete()` is enough for an
+ordinary send. Anything that has to wait (a message sent with `DelaySeconds`, or a batch coming back
+after its visibility timeout) waits on the simulated clock. Freezing time holds it, and advancing
 time delivers it.
 
 ```typescript sim-ecs-consume-queue-clock
@@ -1010,11 +1011,11 @@ console.log(handled.length); // 1, the clock got there and the poll happened
 
 #### What the handler returning and throwing mean
 
-A handler that returns has handled the batch, so Yulin deletes it. A handler that throws has not, so
-the whole batch is left on the queue: it stays hidden for the queue's visibility timeout and is
-handed over again when that runs out, which is what a real worker crashing part way through a batch
-does. A redrive policy therefore gives up on a message the handler keeps throwing on, exactly as it
-would for the deployed container.
+A handler that returns has handled the batch, and Yulin deletes it. A handler that throws leaves the
+whole batch on the queue. It stays hidden for the queue's visibility timeout and is handed over
+again when that runs out. That is what a real worker crashing part way through a batch does. A
+redrive policy therefore gives up on a message the handler keeps throwing on, exactly as it would
+for the deployed container.
 
 The error goes no further than the container. What the sender sees is the message coming back.
 
@@ -1022,9 +1023,9 @@ The error goes no further than the container. What the sender sees is the messag
 
 Receiving, deleting and reading the queue's visibility timeout are all made as the task definition's
 `taskRoleArn`, and so is anything the handler itself does. A task role without `sqs:ReceiveMessage`,
-`sqs:DeleteMessage` or `sqs:GetQueueAttributes` on the queue is refused, which surfaces from
-`backgroundTasksComplete()` rather than being quietly allowed. That is the point of it: a policy that
-would break the deployed worker breaks the test.
+`sqs:DeleteMessage` or `sqs:GetQueueAttributes` on the queue is refused, and the refusal surfaces
+from `backgroundTasksComplete()`. That is the point of it. A policy that would break the deployed
+worker breaks the test.
 
 A task definition with no `taskRoleArn` polls anonymously and is denied at its very first poll, as a
 real task with no credentials of its own would be.
@@ -1032,26 +1033,26 @@ real task with no credentials of its own would be.
 #### Polling starts and stops with the service
 
 Polling starts when the service's first task comes up and stops when the service is deleted, scaled
-to zero, or its `SimAws` is closed. A stopped poller leaves nothing watching the queue and nothing
-waiting on the clock, so a test that finishes with a consuming service leaves nothing behind it.
+to zero, or its `SimAws` is closed. A stopped poller releases both the queue watch and the clock
+wait. A test that finishes with a consuming service leaves nothing behind it.
 
-There is one poller per service and container, not one per task. A desired count of three is three
-simulated tasks reported as running, and the handler is still called once per poll, which is the same
-divergence the desired count already rests on. Three real containers would each run their own loop
-and share the queue between them, which comes to the same messages being handled once.
+There is one poller per service and container, and never one per task. A desired count of three is
+three simulated tasks reported as running, and the handler is still called once per poll, which is
+the same divergence the desired count already rests on. Three real containers would each run their
+own loop and share the queue between them, coming to the same messages being handled once.
 
-A consuming container is the one kind a `RunTask` task cannot run. It has no handler that ends, and a
-task has to end, so a task started from the same definition records the container as not simulated
+A consuming container is the one kind a `RunTask` task cannot run. It has no handler that ends, and
+a task has to end. A task started from the same definition records the container as not simulated,
 with a reason saying to create a service instead.
 
 ### Serving requests behind a load balancer
 
-A service container that answers HTTP requests declares `http` instead of `run` or `consumes`. The
-handler is fetch-style: it is given a `Request` and answers with a `Response`, which is the same
-shape a simulated load balancer already answers a served request with.
+A service container that answers HTTP requests declares `http` in place of `run` or `consumes`. The
+handler is fetch-style. It is given a `Request` and answers with a `Response`, the same shape a
+simulated load balancer already answers a served request with.
 
 What reaches it is a request routed through simulated [Elastic Load Balancing](../elbv2/). A service
-declares `loadBalancers` naming a target group, a container and a container port; creating the
+declares `loadBalancers` naming a target group, a container and a container port. Creating the
 service registers each of its tasks into that target group, and a request the load balancer forwards
 there reaches the bound container's handler.
 
@@ -1155,9 +1156,9 @@ consuming a queue or one run by `RunTask` does. So application code inside it bu
 from `process.env` and is authorized by simulated IAM against the role the task definition declared.
 
 The container sees the request the client made, with the headers a load balancer writes in front of
-a target: the `host` the client asked for, `x-forwarded-for`, `x-forwarded-proto`, `x-forwarded-port`
-and `x-amzn-trace-id`. The URL is the AWS-facing one, so `new URL(request.url)` reads the name the
-client asked for rather than a localhost one.
+a target. Those are the `host` the client asked for, `x-forwarded-for`, `x-forwarded-proto`,
+`x-forwarded-port` and `x-amzn-trace-id`. The URL is the AWS-facing one, and `new URL(request.url)`
+reads the name the client asked for and never a localhost one.
 
 #### Which container of a task answers
 
@@ -1165,17 +1166,17 @@ Real ECS sends the request to the container the registration names, on the port 
 diverges from that on purpose, and it is worth knowing why.
 
 A great many deployed services put a proxy container, usually nginx, on the port the service
-registers, with the application listening behind it. Yulin has nothing to run in place of that proxy:
-there is no image to run and nothing a test could bind to it. Routing strictly by name and port would
-therefore send every request to a container that does not exist here, and the service would answer
-nothing however carefully it was set up.
+registers, with the application listening behind it. Yulin has nothing to run in place of that
+proxy. There is no image to run and nothing a test could bind to it. Routing strictly by name and
+port would therefore send every request to a container that is absent here, and the service would
+answer no request at all, however carefully it was set up.
 
-So the request goes to a container that is bound:
+So the request goes to a container that is bound, chosen in this order:
 
-- the container the registration names, when that container is bound;
-- otherwise the bound container that declared the registration's `containerPort`, which is what
-  chooses between two containers that both answer;
-- otherwise the first bound container of the task.
+- the container the registration names, when that container is bound
+- otherwise the bound container that declared the registration's `containerPort`, which settles a
+  choice between two containers that both answer
+- otherwise the first bound container of the task
 
 ```typescript
 // A registration naming the proxy still reaches the application behind it.
@@ -1183,17 +1184,18 @@ loadBalancers: [{ targetGroupArn, containerName: "nginx", containerPort: 80 }];
 ```
 
 A target group whose service has no bound container at all is answered with a 503 by the load
-balancer, which is the honest answer: the tasks are registered and there is nothing behind them.
+balancer. That is the honest answer, since the tasks are registered and there is nothing behind
+them.
 
 `RunTask` cannot run a serving container, for the same reason it cannot run a consuming one. It has
-no handler that ends and no request to send it, so a task started from the same definition records
-the container as not simulated with a reason saying to create a service instead.
+no handler that ends and no request to send it. A task started from the same definition records the
+container as not simulated, with a reason saying to create a service instead.
 
 ### Updating and deleting a service
 
 `UpdateService` changes the desired count, the task definition, or both. A new count starts or stops
-tasks to reach it. A new revision moves the service onto it, which replaces every task the service is
-running: real ECS replaces them a few at a time under a deployment configuration, and Yulin replaces
+tasks to reach it. A new revision moves the service onto it and replaces every task the service is
+running. Real ECS replaces them a few at a time under a deployment configuration, and Yulin replaces
 them at once because nothing here takes any time to start.
 
 ```typescript sim-ecs-update-service
@@ -1269,7 +1271,7 @@ console.log(listed.taskArns?.length); // 4, all of them on the new revision
 ```
 
 `DeleteService` stops the service and its tasks. A service still scaled above zero is refused unless
-the request forces it, as real ECS refuses one, so scaling to zero first is the ordinary way round. A
+the request forces it, as real ECS refuses one. Scaling to zero first is the ordinary way round. A
 deleted service is still describable as `INACTIVE`, and its name is free to create again.
 
 ```typescript sim-ecs-delete-service
@@ -1331,21 +1333,21 @@ const described = await ecs.describeServices(
 console.log(described.services?.[0]?.runningCount); // 0
 ```
 
-Closing the simulated environment with `simAws.close()` stops the tasks of every service in it, and
-nothing is left scheduled either way: a service is kept as state rather than by a timer, so a test
-that finishes with a service running leaves nothing behind it.
+Closing the simulated environment with `simAws.close()` stops the tasks of every service in it. A
+service is kept as state, and nothing is left scheduled either way. A test that finishes with a
+service running leaves nothing behind it.
 
 ## Deploying ECS from CloudFormation
 
 `AWS::ECS::Cluster` creates a simulated cluster, `AWS::ECS::TaskDefinition` registers a simulated
-task definition revision, and `AWS::ECS::Service` creates a simulated service running it, so a test
-can start from the stack the application is actually defined in rather than from
-`RegisterTaskDefinition` and `CreateService` calls written for the test.
+task definition revision, and `AWS::ECS::Service` creates a simulated service running it. A test can
+start from the stack the application is actually defined in, without `RegisterTaskDefinition` and
+`CreateService` calls written for the test.
 
 `Ref` on a cluster returns the cluster name and `Fn::GetAtt` `Arn` returns its ARN. `Ref` on a task
-definition returns the task definition ARN, revision and all, which is also what `Fn::GetAtt`
-`TaskDefinitionArn` returns. Each deployment registers a new revision, as real CloudFormation does,
-because a revision is immutable and a changed one is a new revision of the same family.
+definition returns the task definition ARN, revision and all, and so does `Fn::GetAtt`
+`TaskDefinitionArn`. Each deployment registers a new revision, as real CloudFormation does, because
+a revision is immutable and a changed one is a new revision of the same family.
 
 Containers are stored as declared, whatever their image, and what makes one of them run is an
 executable binding supplied at deploy time, in the same `bindings` list a Lambda function handler is
@@ -1426,7 +1428,7 @@ console.log(processedOrders); // ["outstanding orders"]
 ```
 
 A binding can name the task definition Resource instead, which is what a CDK stack gives a test to
-name: the construct ID is accepted as well as the synthesized logical ID, and the container name can
+name. The construct ID is accepted as well as the synthesized logical ID, and the container name can
 be left out where the task definition declares one container. A binding naming an image repository
 matches any container running an image from it, whichever family declares it, which covers a tag
 that changes with every build.
@@ -1502,12 +1504,12 @@ console.log(simAws.ecs().taskDefinition("orders-worker").revision); // 1
 
 A binding that resolves to no Resource in the stack fails the deployment naming the binding, since
 the usual cause is a container renamed in the template and not in the test. A container with no
-binding is a different thing: the stack deploys, the container is stored as declared, and it is
-recorded as not simulated when a task runs, which is what lets a task definition holding a log
-router and an observability agent alongside the application deploy and run.
+binding is a different thing. The stack deploys, the container is stored as declared, and it is
+recorded as not simulated when a task runs. That is what lets a task definition holding a log router
+and an observability agent alongside the application deploy and run.
 
 A task definition's `TaskRoleArn` and `ExecutionRoleArn` resolve whether the template gives an ARN
-or a `Ref` to an `AWS::IAM::Role` of the same stack, so a container's AWS calls are authorized as
+or a `Ref` to an `AWS::IAM::Role` of the same stack, and a container's AWS calls are authorized as
 the role the stack deploys.
 
 ### Deploying a service
@@ -1519,9 +1521,9 @@ revision the deployment registered, or an ARN, or a family. A container bound at
 running once the stack has deployed, because the service names the task definition and is created
 after it.
 
-`Ref` on a service returns the service ARN, which is also what `Fn::GetAtt` `ServiceArn` returns,
-and `Fn::GetAtt` `Name` returns the service name. `simAws.ecs().service(name, cluster)` reads the
-simulated service itself, by name in a cluster or by its full ARN.
+`Ref` on a service returns the service ARN, and so does `Fn::GetAtt` `ServiceArn`. `Fn::GetAtt`
+`Name` returns the service name. `simAws.ecs().service(name, cluster)` reads the simulated service
+itself, by name in a cluster or by its full ARN.
 
 ```typescript sim-ecs-cloudformation-service
 /**
@@ -1600,30 +1602,30 @@ const listed = await simAws
 console.log(listed.taskArns?.length); // 2
 ```
 
-A service the template does not name is named after the stack and the logical ID, as a cluster and a
-family are, and a service declaring no `DesiredCount` keeps one task running, which is what real
-CloudFormation gives a new service.
+An unnamed service is named after the stack and the logical ID, as a cluster and a family are. A
+service declaring no `DesiredCount` keeps one task running, which is what real CloudFormation gives
+a new service.
 
-Updating the stack moves the service: a changed `DesiredCount` scales it, and a changed task
+Updating the stack moves the service. A changed `DesiredCount` scales it, and a changed task
 definition moves it onto the revision the update registered, replacing the tasks it was keeping.
 Tearing the stack down deletes the service, stopping its tasks and leaving it `INACTIVE`, whatever
 it was scaled to.
 
-`LoadBalancers` registers the service's tasks into the target group it names, so a template that
-declares a load balancer, a target group and a service deploys something that answers. The target
-group has to exist and hold addresses, or the deployment fails naming it, and what the template
-declared is readable on the simulated service:
+`LoadBalancers` registers the service's tasks into the target group it names. A template that
+declares a load balancer, a target group and a service therefore deploys something that answers. The
+target group has to exist and hold addresses, or the deployment fails naming it, and what the
+template declared is readable on the simulated service:
 
 ```typescript
 console.log(simAws.ecs().service("orders-worker", "orders").loadBalancers);
 ```
 
 Everything else the three Resource types declare is stored as declared, or recorded as ignored where
-this simulation has nothing to act on it with. `CapacityProviders`,
-`DefaultCapacityProviderStrategy` and `ServiceConnectDefaults` on a cluster, `InferenceAccelerators`
-and `EnableFaultInjection` on a task definition, and a service's `NetworkConfiguration`,
-`CapacityProviderStrategy`, `DeploymentConfiguration` and `ServiceRegistries` among the rest, are
-read and ignored rather than failing the stack, and each one is reported on the Resource:
+this simulation has no use for it. `CapacityProviders`, `DefaultCapacityProviderStrategy` and
+`ServiceConnectDefaults` on a cluster, `InferenceAccelerators` and `EnableFaultInjection` on a task
+definition, and a service's `NetworkConfiguration`, `CapacityProviderStrategy`,
+`DeploymentConfiguration` and `ServiceRegistries` among the rest, are read and ignored while the
+stack deploys, and each one is reported on the Resource:
 
 ```typescript
 console.log(stack.resources.get("OrdersCluster")?.ignoredProperties);
@@ -1634,12 +1636,12 @@ console.log(stack.resources.get("OrdersCluster")?.ignoredProperties);
 Every operation is authorized by simulated IAM against the real ECS action.
 
 Real ECS gives the task definition operations no resource type at all, and gives `CreateCluster`,
-`ListClusters` and `ListTasks` none either, so all of those authorize against `*`. A policy naming a
-task definition ARN grants none of them, here as on AWS. The operations that do take a resource are
-`DescribeClusters` and `DeleteCluster`, which take the cluster's ARN, `RunTask`, which takes the
-task definition revision it would run, `DescribeTasks` and `StopTask`, which take the task's ARN, and
-the service operations, which take the service's ARN. `CreateService` authorizes against the ARN the
-service is about to have, so a policy can name one service by name before it exists.
+`ListClusters` and `ListTasks` none either, and all of those authorize against `*`. A policy naming
+a task definition ARN grants none of them, here as on AWS. The operations that do take a resource
+are `DescribeClusters` and `DeleteCluster`, which take the cluster's ARN, `RunTask`, which takes the
+task definition revision it would run, `DescribeTasks` and `StopTask`, which take the task's ARN,
+and the service operations, which take the service's ARN. `CreateService` authorizes against the ARN
+the service is about to have, and a policy can therefore name one service by name before it exists.
 
 ```typescript sim-ecs-iam-policy
 /**
@@ -1783,7 +1785,8 @@ console.log(described.taskDefinition?.revision); // 1
 - `DescribeTaskDefinitionCommand`, taking a family, a `family:revision` or a full ARN
 - `ListTaskDefinitionsCommand` and `ListTaskDefinitionFamiliesCommand`, with prefix, status and
   paging
-- `CreateClusterCommand`, `DescribeClustersCommand`, `ListClustersCommand` and `DeleteClusterCommand`
+- `CreateClusterCommand`, `DescribeClustersCommand`, `ListClustersCommand` and
+  `DeleteClusterCommand`
 - `RunTaskCommand`, running the handlers bound to a task definition's containers, up to a `count` of
   ten tasks at a time
 - `DescribeTasksCommand`, `ListTasksCommand` and `StopTaskCommand`
@@ -1792,7 +1795,7 @@ console.log(described.taskDefinition?.revision); // 1
 - `CreateServiceCommand`, keeping a desired count of tasks running from a task definition
 - `UpdateServiceCommand`, changing the desired count, the task definition, or both
 - `DescribeServicesCommand` and `DeleteServiceCommand`, with the `force` a scaled-up service needs
-- `ListTasks` filtering by `serviceName`, so a service's tasks can be listed on their own
+- `ListTasks` filtering by `serviceName`, listing a service's tasks on their own
 - `bindContainer`, targeting a container by family and container name or by image repository
 - A container binding that `consumes` a simulated SQS queue, with Yulin driving the polling loop on
   the simulated clock while the service is running
@@ -1827,36 +1830,35 @@ console.log(described.taskDefinition?.revision); // 1
 
 Current documented limitations:
 
-- Image contents are never read. An image URI is an identifier and nothing else, so no image is
-  pulled, inspected or run, and a tag that does not exist on any registry is stored without
-  complaint.
-- A container definition field the `SimEcsContainerDefinitionType` shape does not name, such as
+- Image contents are never read. An image URI is an identifier and nothing more. No image is pulled,
+  inspected or run, and a tag no registry holds is stored without complaint.
+- A container definition field the `SimEcsContainerDefinitionType` shape leaves unnamed, such as
   `hostname` or `links`, is still stored and reported back. The shape names the fields the docs
   describe rather than every field ECS has, and it deliberately carries no index signature, since
   one would stop a real SDK command input being passed straight in.
 - `ListTaskDefinitions` refuses a `status` of `DELETE_IN_PROGRESS`, which real ECS accepts. Nothing
-  deletes a task definition here, so the answer would always be an empty listing, and refusing says
-  so rather than looking like a result.
-- Yulin creates no cluster on its own, including the `default` one, so a `RunTask` request naming no
-  cluster needs one to have been created. An AWS account often has a `default` cluster already,
+  deletes a task definition here, and the answer would always be an empty listing. Refusing says so,
+  where a result would look like an answer.
+- Yulin creates no cluster on its own, including the `default` one. A `RunTask` request naming no
+  cluster needs one to have been created already. An AWS account often has a `default` cluster,
   created the first time ECS was used from the console.
-- A container of a task definition with no `taskRoleArn` is denied every AWS call, rather than
-  running with whatever credentials a container instance role might have supplied.
-- Only a bound container runs. A container with no binding never starts and is reported with a reason
-  saying so, and a task where nothing is bound stops with `TaskFailedToStart`.
-- Containers run one after another in the order the task definition declares them, rather than
+- A container of a task definition with no `taskRoleArn` is denied every AWS call. It never falls
+  back to whatever credentials a container instance role might have supplied.
+- Only a bound container runs. A container with no binding never starts and is reported with a
+  reason saying so, and a task with no binding at all stops with `TaskFailedToStart`.
+- Containers run one after another in the order the task definition declares them, and never
   alongside each other. `dependsOn`, `essential`, health checks and `startTimeout` are stored and
   ignored.
 - `RunTask` refuses `networkConfiguration`, `capacityProviderStrategy`, `platformVersion`, `tags`,
   `placementConstraints`, `placementStrategy` and the rest of what it takes. There is no network and
   no capacity here for any of them to apply to.
 - A `RunTask` override may name `taskRoleArn` and a container's `environment`. A `command`, `cpu` or
-  `memory` override is refused, since Yulin never runs an image and nothing here has capacity.
+  `memory` override is refused, since Yulin never runs an image and has no capacity to allocate.
 - The execution role resolves container `secrets` and does nothing else. There is no image to pull
   and no log driver to write to.
 - A container secret can only come from simulated Secrets Manager or simulated SSM Parameter Store.
-  A `valueFrom` naming anything else stops the task rather than being ignored. Secret rotation is
-  not simulated, so a task always reads the version that is current when it starts.
+  A `valueFrom` naming anything else stops the task outright. Secret rotation is absent, and a task
+  always reads the version that is current when it starts.
 - A JSON key selector resolves only where the key holds a string. A key holding a number, a boolean
   or a nested object is refused, because an environment variable is text and real ECS does not
   document which text it would become.
@@ -1864,74 +1866,74 @@ Current documented limitations:
   either, but it reports the problem differently.
 - `secretOptions` on a `logConfiguration` are stored and never resolved. There is no log driver here
   for them to configure.
-- A task definition declaring `secrets` and no `executionRoleArn` fails when a task is run rather
-  than when the revision is registered. Real ECS refuses the registration.
+- A task definition declaring `secrets` and no `executionRoleArn` fails when a task is run, and not
+  when the revision is registered. Real ECS refuses the registration.
 - An EventBridge or Scheduler target's `EcsParameters` takes `TaskDefinitionArn` and `TaskCount`
   only, taking and ignoring the launch type, platform version, network configuration and capacity
-  provider strategy for the same reason `RunTask` refuses them: there is no placement and no network
-  here. A `TaskCount` above one runs that many simulated tasks, and a bound container handler runs
-  once for each of them, in this process and one after another.
-- A rule or schedule target's `Input` is read as the task's overrides rather than as a payload,
-  since a task has nowhere to receive one, so container environment variables are set with a
-  `containerOverrides` list naming the container.
-- A service's desired count is simulated as state rather than as concurrency. Three tasks exist and
-  are reported as running, and the handler bound to a container is called once per request or per
-  poll rather than once per task. Yulin runs in one Node.js process, so there is nothing to copy.
+  provider strategy for the same reason `RunTask` refuses them, which is that there is no placement
+  and no network here. A `TaskCount` above one runs that many simulated tasks, and a bound container
+  handler runs once for each of them, in this process and one after another.
+- A rule or schedule target's `Input` is read as the task's overrides, since a task has nowhere to
+  receive a payload. Container environment variables are set with a `containerOverrides` list naming
+  the container.
+- A service's desired count is simulated as state, and not as concurrency. Three tasks exist and are
+  reported as running, and the handler bound to a container is called once per request or per poll.
+  Yulin runs in one Node.js process, with nothing to copy.
 - A bound container of a service is treated as running and stays available until the service is
-  deleted or its `SimAws` is closed. What calls its handler is whatever reaches it: a queue it
-  consumes, or a request a load balancer routes to it.
-- A consuming container's loop is Yulin's rather than the container's. A binding supplies what
-  happens to a batch, and nothing tries to run a polling loop written inside your own container code,
+  deleted or its `SimAws` is closed. What calls its handler is whatever reaches it, either a queue
+  it consumes or a request a load balancer routes to it.
+- A consuming container's loop belongs to Yulin, and not to the container. A binding supplies what
+  happens to a batch, and a polling loop written inside your own container code is never run,
   because an endless loop in a single Node.js process never yields to the test running it.
 - A container can only consume a simulated SQS queue, in the same account and region as the service.
   Nothing else is a source, and a queue URL naming another scope reaches no queue.
-- Yulin polls once per service and container rather than once per task, so a desired count above one
-  does not hand a batch over more than once. It also polls in response to something rather than
-  continuously: a message arriving, a batch coming back, or a full batch suggesting there is more
+- Yulin polls once per service and container, and never once per task, and a desired count above one
+  hands a batch over exactly once. It also polls in response to something, and never continuously.
+  The triggers are a message arriving, a batch coming back, or a full batch suggesting there is more
   waiting.
-- Long polling is not simulated. A `WaitTimeSeconds` has nothing to mean when the queue says when
-  there is something to poll for, so there is nothing to set.
-- A consuming container handles a batch all or nothing. There is no partial batch response, which is
-  a Lambda event source feature rather than something a worker container has.
+- Long polling is absent. A `WaitTimeSeconds` is meaningless when the queue itself says when there
+  is something to poll for, and the setting is gone.
+- A consuming container handles a batch all or nothing. There is no partial batch response, since
+  that is a Lambda event source feature and not something a worker container has.
 - A consuming or serving container of a task started by `RunTask` records the same not-simulated
   reason an unbound container does. Neither has a handler that ends, and a run task has to end.
 - A service's tasks come up all at once and are replaced all at once. There are no deployments,
   deployment controllers, circuit breakers or rolling replacement, so `DescribeServices` reports no
   `deployments` and no `events`, and `UpdateService` refuses `forceNewDeployment`.
-- A service whose tasks fail to start does not start replacements for them. Real ECS keeps trying,
-  which would be an endless retry in a test rather than a result to assert on, so the service
-  reports the running count it actually has.
+- A service whose tasks fail to start never starts replacements for them. Real ECS keeps trying,
+  which in a test would be an endless retry with nothing to assert on. The service here reports the
+  running count it actually has.
 - A `loadBalancers` entry needs a `targetGroupArn`, a `containerName` and a `containerPort` between
   1 and 65535, and the target group has to be an `ip` one in the service's own account and region. A
-  `loadBalancerName`, which is the Classic Load Balancer form, is refused, and so is a target group
-  that is not there.
+  `loadBalancerName` is the Classic Load Balancer form, and is refused, as is a target group that
+  was never created.
 - Which container of a task a request reaches diverges from real ECS on purpose. Real ECS routes to
-  the container the registration names, on the port it names; here the request goes to a container
-  that is bound, which is the one the registration names where it is bound, otherwise the bound
+  the container the registration names, on the port it names. Here the request goes to a bound
+  container, which is the one the registration names where that one is bound, otherwise the bound
   container declaring the registration's port, otherwise the first bound one. The common real task
   puts an unsimulated proxy on the registered port, and routing strictly would reach a container
-  that does not exist here.
+  absent here.
 - A service registered into a target group with no bound container is answered with a 503 by the
   load balancer. The tasks are registered and there is nothing behind them.
 - A task is registered as a target as soon as the service starts it and deregistered as soon as it
   stops. There are no health checks, no target health states, no deregistration delay and no
-  connection draining, and the address a task is registered under is counted rather than taken from
-  a network interface that does not exist.
-- Requests are not shared between a service's tasks. The desired count is state rather than
-  concurrency, so a target group holding three targets calls one handler.
+  connection draining. The address a task is registered under is counted, since there is no network
+  interface to take one from.
+- Requests are never shared between a service's tasks. The desired count is state and not
+  concurrency, and a target group holding three targets calls one handler.
 - `CreateService` refuses `serviceRegistries`, `networkConfiguration`, `deploymentConfiguration`,
   `capacityProviderStrategy` and the rest of what it takes. There is no network or capacity here for
   any of them to apply to.
-- `UpdateService` changes the desired count and the task definition and nothing else, so a service's
-  load balancer registration stays as it was created. Its tasks are registered and deregistered as
-  the count changes.
-- `CreateService` refuses a `schedulingStrategy` of `DAEMON`, which places one task on each container
-  instance. There are no container instances here to place one on each of.
+- `UpdateService` changes the desired count and the task definition alone. A service's load balancer
+  registration stays as it was created, and its tasks are registered and deregistered as the count
+  changes.
+- `CreateService` refuses a `schedulingStrategy` of `DAEMON`, which places one task on each
+  container instance. There are no container instances here to place one on each of.
 - `CreateService` needs a `desiredCount`, as a replica service does on real ECS, and it can be zero.
 - A service's tasks are `startedBy` `ecs-svc/` and the service name. Real ECS uses `ecs-svc/` and a
   number, which would name nothing here.
-- Service autoscaling and service discovery are not simulated, and neither is `ListServices`.
-- `StartTask` is not simulated.
+- Service autoscaling, service discovery and `ListServices` are all absent.
+- `StartTask` is absent.
 - Closing a `SimAws` stops the tasks of every service in it. The services stay describable with the
   desired count they had, and their tasks are not brought back.
 - `DescribeTasks` refuses `include`, and a task carries no tags, so `RunTask` refuses `tags` too.
@@ -1939,15 +1941,15 @@ Current documented limitations:
   wanted either running or stopped, so the answer would always be an empty listing.
 - A stopped task is kept for as long as the simulation lasts. Real ECS stops reporting one about an
   hour after it stops.
-- A task reports no `cpu`, `memory`, `connectivity`, `attachments` or `availabilityZone`. There is no
-  capacity and no network here to report.
+- A task reports no `cpu`, `memory`, `connectivity`, `attachments` or `availabilityZone`. There is
+  no capacity and no network here to report.
 - A described task definition reports neither `compatibilities` nor `requiresAttributes`. Real ECS
   works both out from what the definition declares, which would mean reading a container
   definition's meaning.
-- `RegisterTaskDefinition` refuses a setting this simulation does not hold, rather than dropping it.
-  `inferenceAccelerators` and `enableFaultInjection` are refused for that reason.
-- Nothing is defaulted. A revision registered without `networkMode` describes without one, rather
-  than reporting the `bridge` real ECS would have chosen, because that value would be made up here.
+- `RegisterTaskDefinition` refuses a setting this simulation has no room for, and never drops one
+  silently. `inferenceAccelerators` and `enableFaultInjection` are refused for that reason.
+- Nothing is defaulted. A revision registered without `networkMode` describes without one, where
+  real ECS would have chosen `bridge`, because that value would be made up here.
 - `CreateCluster` refuses `capacityProviders`, `defaultCapacityProviderStrategy` and
   `serviceConnectDefaults`. There is no capacity and no service discovery here to attach them to.
 - `DescribeClusters` refuses `include` values of `ATTACHMENTS` and `STATISTICS`, and always reports
@@ -1955,27 +1957,27 @@ Current documented limitations:
   cluster holds.
 - `ListClusters` leaves out a deleted cluster, which is still describable by name or ARN as
   `INACTIVE`.
-- `CreateCluster` with a name an active cluster already has hands that cluster back rather than
-  raising, as real ECS does. The settings, configuration and tags on the second request are ignored.
+- `CreateCluster` with a name an active cluster already has hands that cluster back, as real ECS
+  does. The settings, configuration and tags on the second request are ignored.
 - Deleting a cluster is immediate, and never fails for a cluster still holding running tasks or
   active services, which real ECS refuses. The services in it go on reporting what they are keeping.
 - `DescribeClusters` reports zero services and zero tasks whatever the cluster holds.
   `DescribeServices` and `ListTasks` are what report those.
-- Task definition and cluster tags are stored and reported, but `TagResource`,
-  `UntagResource` and `ListTagsForResource` are not simulated.
-- A cluster, task definition or service the template does not name gets a name composed from the
-  stack name and the logical ID, without the random part real CloudFormation adds, so a test can
-  predict it. A stack deployed twice under different names therefore gets two different families.
-- A service that declares no `DesiredCount` keeps one task running, which is the default real
+- Task definition and cluster tags are stored and reported, but `TagResource`, `UntagResource` and
+  `ListTagsForResource` are absent.
+- An unnamed cluster, task definition or service gets a name composed from the stack name and the
+  logical ID, without the random part real CloudFormation adds, which makes it predictable in a
+  test. A stack deployed twice under different names therefore gets two different families.
+- A service that declares no `DesiredCount` keeps one task running. That is the default real
   CloudFormation documents for a new service. A `DesiredCount` written as the text of a number is
   taken as that number, since a String Parameter resolves to text, and anything else is refused
   naming the Resource and the property, a fraction of a task included.
-- An update replaces a task definition Resource rather than updating it in place, so it registers a
-  new revision and deregisters the one it replaced. The family accumulates revisions with only the
-  newest one `ACTIVE`, where real CloudFormation leaves the earlier revisions active.
-- An update replaces a service Resource as well, so a scaled or redeployed service is deleted and
-  created again rather than updated. Its tasks stop and new ones start, and its ARN is unchanged as
-  long as its name is, since a service ARN is its cluster and its name.
+- An update replaces a task definition Resource in full, registering a new revision and
+  deregistering the one it replaced. The family accumulates revisions with only the newest one
+  `ACTIVE`, where real CloudFormation leaves the earlier revisions active.
+- An update replaces a service Resource as well, and a scaled or redeployed service is deleted and
+  created again. Its tasks stop and new ones start, and its ARN is unchanged as long as its name is,
+  since a service ARN is its cluster and its name.
 - A stack teardown deletes its cluster, leaving it `INACTIVE`, deregisters the revision it
   registered, leaving that `INACTIVE`, and deletes its service, leaving that `INACTIVE` too. None of
   them is removed, and revision numbers are not freed. The service is deleted with force, because
@@ -1988,18 +1990,19 @@ Current documented limitations:
 - `CapacityProviders`, `DefaultCapacityProviderStrategy` and `ServiceConnectDefaults` on a cluster,
   `InferenceAccelerators` and `EnableFaultInjection` on a task definition, and everything a service
   declares beyond its cluster, task definition, count, launch type, scheduling strategy and load
-  balancers, are read and recorded as ignored rather than refused, where the equivalent SDK request
-  is refused. A stack that will not deploy is worth less to a test than a Resource without a
-  property nothing here acts on.
-- A deploy-time binding is checked against the template as the stack is built, so a family, a
-  container name or an image repository built from another Resource's attribute rather than written
-  as a string resolves to nothing and fails the deployment.
-- A `TaskRoleArn` or `ExecutionRoleArn` given as a `Ref` to a role resolves to the role name, which
-  is turned into the ARN that name would have at the default path. A role declaring a `Path` of its
-  own therefore resolves to an ARN without it. This is what an `AWS::Lambda::Function` `Role` already
-  does, so the two agree, and naming the role by `Fn::GetAtt` `Arn` gets the real ARN either way.
+  balancers, are read and recorded as ignored, where the equivalent SDK request is refused. A stack
+  that fails to deploy is worth less to a test than a Resource missing a property this simulation
+  has no use for.
+- A deploy-time binding is checked against the template as the stack is built. A family, a container
+  name or an image repository built from another Resource's attribute, in place of a plain string,
+  resolves to no target and fails the deployment.
+- A `TaskRoleArn` or `ExecutionRoleArn` given as a `Ref` to a role resolves to the role name, and
+  that name is turned into the ARN it would have at the default path. A role declaring a `Path` of
+  its own therefore resolves to an ARN without it. An `AWS::Lambda::Function` `Role` already behaves
+  this way, so the two agree, and naming the role by `Fn::GetAtt` `Arn` gets the real ARN either
+  way.
 - Cluster and family names are validated to the 255 letters, numbers, hyphens and underscores real
   ECS accepts, but error messages differ from the real ones.
-- Account-wide limits do not exist, so no request fails for having registered too many task
-  definitions or created too many clusters.
-- ECS is not served as an HTTP API by `serveSimAws`.
+- Account-wide limits are absent. No request fails for having registered too many task definitions
+  or created too many clusters.
+- `serveSimAws` serves no ECS HTTP API.

--- a/docs/services/ecs/README.md
+++ b/docs/services/ecs/README.md
@@ -963,8 +963,8 @@ console.log(handled); // ["order-1"]
 The queue is named by the URL `CreateQueue` answered with, and it has to be in the same account and
 region as the service, as a real task's own queue is. A `batchSize` is how many messages the handler
 is given at once, up to the ten one SQS receive hands out, and it defaults to ten. The handler may
-be async, and is awaited. A container declares either `consumes` or `run`, and binding one that
-declares both is refused.
+be async, and is awaited. A binding declares one of `run`, `consumes` and `http`. Where a binding
+carries more than one, `consumes` wins, then `http`, then `run`.
 
 The task role is required here. That is the part worth noticing before writing the first one.
 Polling is done as the task role, and a task definition with no `taskRoleArn` polls as nobody and
@@ -1613,7 +1613,7 @@ it was scaled to.
 
 `LoadBalancers` registers the service's tasks into the target group it names. A template that
 declares a load balancer, a target group and a service therefore deploys something that answers. The
-target group has to exist and hold addresses, or the deployment fails naming it, and what the
+target group has to exist and be an `ip` one, or the deployment fails naming it, and what the
 template declared is readable on the simulated service:
 
 ```typescript
@@ -1880,8 +1880,8 @@ Current documented limitations:
   reported as running, and the handler bound to a container is called once per request or per poll.
   Yulin runs in one Node.js process, with nothing to copy.
 - A bound container of a service is treated as running and stays available until the service is
-  deleted or its `SimAws` is closed. What calls its handler is whatever reaches it, either a queue
-  it consumes or a request a load balancer routes to it.
+  scaled to zero, deleted, or its `SimAws` is closed. What calls its handler is whatever reaches it,
+  either a queue it consumes or a request a load balancer routes to it.
 - A consuming container's loop belongs to Yulin, and not to the container. A binding supplies what
   happens to a batch, and a polling loop written inside your own container code is never run,
   because an endless loop in a single Node.js process never yields to the test running it.

--- a/docs/services/elbv2/README.md
+++ b/docs/services/elbv2/README.md
@@ -459,7 +459,7 @@ await elbV2.removeListenerCertificates(
 ```
 
 The default certificate cannot be removed this way. Replacing it is `ModifyListener`, as on real
-ELB, and trying to remove it is refused with that named.
+ELB, and trying to remove it is refused, naming it.
 
 ### Serving a request over HTTPS
 
@@ -1766,7 +1766,8 @@ console.log(created.LoadBalancers?.[0]?.DNSName);
 - `RegisterTargets`, `DeregisterTargets` and `DescribeTargetHealth`.
 - `CreateListener`, `DescribeListeners`, `ModifyListener` and `DeleteListener`, on HTTP and HTTPS.
 - An HTTPS listener's default certificate resolved against simulated ACM, refusing a missing one,
-  one short of `ISSUED`, and one outside the load balancer's own account and region.
+  one whose status falls short of `ISSUED`, and one outside the load balancer's own account and
+  region.
 - `AddListenerCertificates`, `RemoveListenerCertificates` and `DescribeListenerCertificates`, with
   the default certificate reported first and refused removal.
 - `CreateRule`, `DescribeRules`, `ModifyRule`, `DeleteRule` and `SetRulePriorities`, with priorities

--- a/docs/services/elbv2/README.md
+++ b/docs/services/elbv2/README.md
@@ -6,18 +6,17 @@ authorized by simulated IAM. ELBv2-specific types are imported from the `@kensio
 subpath.
 
 A load balancer created here has a DNS name of the shape real ELB issues, and a
-[Route53](../route53/) record pointing at that name resolves to it, so a request made to your own
+[Route53](../route53/) record pointing at that name resolves to it. A request made to your own
 hostname reaches the load balancer as it would deployed. A request is matched to a listener by port
 and then to one of that listener's rules, and a `forward` action sends it to a target group, where a
 registered [Lambda](../lambda/) function is invoked with the request and its response becomes the
 HTTP response.
 
 Only the application load balancer is simulated. A network or gateway load balancer routes below
-HTTP, which nothing here speaks, so `Type: "network"` is refused rather than created as an
-application load balancer in disguise.
+HTTP, which nothing here speaks, and `Type: "network"` is refused outright.
 
 No TLS is performed anywhere in this. An HTTPS listener holds a certificate and is checked against
-simulated ACM, and nothing is ever encrypted or handshaken. See
+simulated ACM, and everything travels in the clear. See
 [HTTPS listeners and certificates](#https-listeners-and-certificates) for what that leaves a test
 able to conclude.
 
@@ -66,17 +65,17 @@ console.log(described.LoadBalancers?.[0]?.State.Code); // "active"
 ```
 
 A load balancer is `active` as soon as it is created, where real ELB leaves one in `provisioning`
-for a few minutes first. A name is unique within one account and region, so the same name can be used in
-another region and the two do not see each other.
+for a few minutes first. A name is unique within one account and region. The same name can be used
+in another region, and the two stay separate.
 
-An internal load balancer's host name carries the `internal-` prefix real ELB gives it, which is also
+An internal load balancer's host name carries the `internal-` prefix real ELB gives it. That is also
 why a load balancer cannot be named starting with `internal-`.
 
 ## Target groups hold functions or addresses
 
-A target group names what it holds through its `TargetType`, and that decides the rest: how many
-targets it takes, what a target's `Id` has to look like, and whether the group carries a protocol and
-port at all.
+A target group names what it holds through its `TargetType`, and that decides the rest. It sets how
+many targets the group takes, what a target's `Id` has to look like, and whether the group carries a
+protocol and port at all.
 
 ```typescript sim-elbv2-lambda-target-group
 /**
@@ -124,7 +123,7 @@ console.log(health.TargetHealthDescriptions?.[0]?.TargetHealth.State);
 // "healthy"
 ```
 
-A `lambda` target group takes exactly one function, as real ELB does, so registering a second is
+A `lambda` target group takes exactly one function, as real ELB does, and registering a second is
 refused. An `ip` target group is what a container service registers itself as, takes many addresses,
 and requires the `Protocol` and `Port` its targets are reached on.
 
@@ -179,16 +178,15 @@ console.log(health.TargetHealthDescriptions?.length); // 1
 console.log(health.TargetHealthDescriptions?.[0]?.Target.Port); // 8080
 ```
 
-`TargetType: "instance"` is refused rather than accepted and ignored, because there are no EC2
-instances here for it to mean anything about: a group created as one would look configured and route
-nowhere. A request naming no target type at all is refused for the same reason, since real ELB
-defaults it to `instance`.
+`TargetType: "instance"` is refused outright, because there are no EC2 instances here for it to mean
+anything about. A group created as one would look configured and route nowhere. A request naming no
+target type at all is refused for the same reason, since real ELB defaults it to `instance`.
 
 ## Listeners and the rules on them
 
 A listener answers on a port and holds the default actions for a request no rule claims. Rules carry
-a priority, and that is what decides which of several matching rules claims a request, so two rules
-on one listener cannot hold the same priority.
+a priority, and that is what decides which of several matching rules claims a request. Two rules on
+one listener cannot hold the same priority.
 
 ```typescript sim-elbv2-listener-rules
 /**
@@ -263,26 +261,25 @@ console.log(rules.Rules?.map((rule) => rule.Priority)); // ["10", "default"]
 ```
 
 Conditions are `host-header` and `path-pattern`. What is checked when a rule is written is that it
-could match something: the field has to be one of those two, and it has to have values to compare
+could match something. The field has to be one of those two, and it has to have values to compare
 against. A forward action naming a target group that was never created is refused for the same
-reason. The other four condition fields real ELB has are refused, rather than stored and then never
-matched. [Matching a request against the rules](#matching-a-request-against-the-rules) covers how the
-values are compared.
+reason. The other four condition fields real ELB has are refused at write time, ahead of any
+request. [Matching a request against the rules](#matching-a-request-against-the-rules) covers how
+the values are compared.
 
 `ModifyRule` changes a rule's conditions and actions but not its priority, as on real ELB. Moving
-rules about is `SetRulePriorities`, which reorders a whole listener, and which judges a request
-against the order it would leave behind rather than the one it started from, so two rules can swap
-places in one request.
+rules about is `SetRulePriorities`, which reorders a whole listener. It judges a request against the
+order it would leave behind, and two rules can therefore swap places in one request.
 
 ## HTTPS listeners and certificates
 
 A listener on `HTTPS` carries a certificate from simulated ACM. The certificate has to be one that
-exists and has been issued, and one in the load balancer's own account and region, or the listener is
-refused with the reason. That refusal is the point of connecting the two simulations: a test can
-prove that a stack's certificate and its listener line up, rather than the stack finding out at
-deploy time.
+exists and has been issued, and one in the load balancer's own account and region, or the listener
+is refused with the reason. That refusal is the point of connecting the two simulations. A test can
+prove that a stack's certificate and its listener line up, ahead of the deploy that would otherwise
+find out.
 
-**No TLS is performed here.** Nothing is encrypted, no handshake happens, and no certificate is
+**No TLS is performed here.** Everything travels in the clear, with no handshake and no certificate
 presented to anything. What is simulated is the configuration relationship between a listener and a
 certificate, and the protocol a request is treated as having arrived on.
 
@@ -365,19 +362,19 @@ try {
 }
 ```
 
-A certificate that is still `PENDING_VALIDATION` is refused the same way, since a listener presenting
-one could serve nothing. That is what makes a test of the whole issuance path worth writing: the
-certificate has to have been validated for the listener that uses it to be created.
+A certificate that is still `PENDING_VALIDATION` is refused the same way, since a listener
+presenting one could serve nothing. That is what makes a test of the whole issuance path worth
+writing. The certificate has to have been validated for the listener that uses it to be created.
 
 An HTTPS listener with no certificate at all is refused, and so is a listener that names a
 certificate and speaks something other than HTTPS, which would otherwise look configured for HTTPS
 while answering plain HTTP. Moving a listener to HTTP without naming a certificate drops the ones it
-was carrying, since nothing would present them.
+was carrying, since only an HTTPS listener presents a certificate.
 
 ### The certificate list
 
-A listener's default certificate is the one `CreateListener` and `ModifyListener` name, and it is the
-one a described listener reports. The rest of the list is `AddListenerCertificates`,
+A listener's default certificate is the one `CreateListener` and `ModifyListener` name, and it is
+the one a described listener reports. The rest of the list is `AddListenerCertificates`,
 `RemoveListenerCertificates` and `DescribeListenerCertificates`, which are the certificates a real
 listener would choose between by the host name a client asked for.
 
@@ -461,25 +458,25 @@ await elbV2.removeListenerCertificates(
 );
 ```
 
-The default certificate cannot be removed this way. Replacing it is `ModifyListener`, as on real ELB,
-and trying to remove it is refused with that named.
+The default certificate cannot be removed this way. Replacing it is `ModifyListener`, as on real
+ELB, and trying to remove it is refused with that named.
 
 ### Serving a request over HTTPS
 
 A request to `https://<dns-name>/orders` reaches the listener on port 443, and from there it is the
-same request as any other: the same rules are evaluated in the same order, and the same target groups
-answer. The listener's protocol is what the target is told the request arrived on, so a function
-behind an HTTPS listener sees `x-forwarded-proto: https` and `x-forwarded-port: 443`.
+same request as any other. The same rules are evaluated in the same order, and the same target
+groups answer. The listener's protocol is what the target is told the request arrived on, and a
+function behind an HTTPS listener sees `x-forwarded-proto: https` and `x-forwarded-port: 443`.
 
-Because no TLS happens, the URL scheme is not checked against the listener it reaches. What decides
+Because no TLS happens, the URL scheme goes unchecked against the listener it reaches. What decides
 the listener is the port, and what decides the protocol in the event is the listener. A test can
 therefore conclude that a request treated as arriving over HTTPS is routed and forwarded the way the
-configuration says, and cannot conclude anything about certificates, ciphers or a handshake.
+configuration says. Certificates, ciphers and handshakes stay out of reach.
 
 ## Carrying a request to a Lambda function
 
 `simElbV2Fetch` sends a request to whichever load balancer its host name names, in process and
-without a socket. The port in the URL is the listener's, so `http://<dns-name>/orders` reaches the
+without a socket. The port in the URL is the listener's, and `http://<dns-name>/orders` reaches the
 listener on port 80.
 
 The listener then evaluates its rules, and the first one to claim the request says what happens to
@@ -586,19 +583,19 @@ A rule with more than one condition claims a request only when every one of them
 condition, a list of values is satisfied when any one of them matches.
 
 Both fields support the two wildcards real ELB has, `*` for zero or more characters and `?` for
-exactly one, and both compare the pattern against the whole value rather than looking for it inside
-one. That last part is the one worth knowing, because a pattern can read as though it covers
-something it does not:
+exactly one, and both compare the pattern against the whole value. Neither looks for the pattern
+inside a longer value. That last part is the one worth knowing, because a pattern can read as though
+it covers more than it does:
 
-- `/api/*` claims `/api/orders` and `/api/v1/orders`, and does not claim `/api`. The pattern has a
-  slash the bare path does not. Real ELB behaves the same way, which is why a rule meant to cover
-  both is written as `["/api", "/api/*"]`.
-- `*.example.com` claims `admin.example.com` and `a.b.example.com`, and does not claim
-  `example.com`, for the same reason.
+- `/api/*` claims `/api/orders` and `/api/v1/orders`, and leaves `/api` alone. The pattern has a
+  slash the bare path lacks. Real ELB behaves the same way, and a rule meant to cover both is
+  written as `["/api", "/api/*"]`.
+- `*.example.com` claims `admin.example.com` and `a.b.example.com`, and leaves `example.com` alone,
+  for the same reason.
 - `*` covers slashes and dots, so `/api/*` claims paths any number of segments deep.
 
 A path pattern is compared with regard to case and a host name without, as on real ELB. A path
-pattern is compared against the path alone, so a query string is not part of it.
+pattern is compared against the path alone, and a query string plays no part in it.
 
 ```typescript sim-elbv2-serve-listener-rules
 /**
@@ -704,17 +701,17 @@ const toWeb = await simElbV2Fetch(simAws, `http://${dnsName}/api`);
 console.log(await toWeb.text()); // "web"
 ```
 
-A `host-header` condition is matched against the request's Host header, falling back to the host name
-in the URL when the request carries none. On real AWS those are the same thing, since DNS is what
-brought the request to the load balancer. Here a request reaches one at its own DNS name, so sending
-a Host header is how a test says which name the client asked for. Any port in the header is left out
-of the comparison, since a condition value cannot carry one.
+A `host-header` condition is matched against the request's Host header, falling back to the host
+name in the URL when the request carries none. On real AWS those are the same thing, since DNS is
+what brought the request to the load balancer. Here a request reaches one at its own DNS name, so
+sending a Host header is how a test says which name the client asked for. Any port in the header is
+left out of the comparison, since a condition value cannot carry one.
 
 ### Answering without a target
 
 A `fixed-response` action answers with the status, content type and body it holds, and a `redirect`
-action answers with a status and a `Location`. Neither touches a target group, so a listener holding
-one serves with nothing registered behind it.
+action answers with a status and a `Location`. Neither touches a target group, and a listener
+holding one serves with nothing registered behind it.
 
 ```typescript sim-elbv2-serve-fixed-response
 /**
@@ -790,21 +787,21 @@ console.log(redirected.headers.get("location"));
 // "https://shop.example.com:443/orders"
 ```
 
-A redirect keeps the components it does not name, and the five reserved keywords put a component back
-where one is named: `#{protocol}`, `#{host}`, `#{port}`, `#{path}` and `#{query}`. `#{path}` comes
-without its leading slash, which is why a redirect keeping the path writes it as `/#{path}`, and
+A redirect keeps every component it leaves unnamed, and the five reserved keywords put a component
+back where one is named. They are `#{protocol}`, `#{host}`, `#{port}`, `#{path}` and `#{query}`.
+`#{path}` comes without its leading slash, and a redirect keeping the path writes it as `/#{path}`.
 `#{query}` comes without its leading question mark, which the load balancer adds. A redirect that
 changes none of the protocol, host, port or path is refused when it is written, since it would
 redirect to the request's own URI.
 
-The port is always in the `Location`, including when it is the protocol's own. A redirect to HTTPS on
-443 therefore answers with a `Location` ending `:443`, which is what real ELB sends.
+The port is always in the `Location`, including when it is the protocol's own. A redirect to HTTPS
+on 443 therefore answers with a `Location` ending `:443`, as real ELB sends it.
 
 ### The event and the response
 
-The event is ELB's own shape, not either API Gateway payload format. A handler can tell them apart by
-the request context: an ALB event has an `elb` block carrying the target group ARN, and nothing else
-in it.
+The event is ELB's own shape, distinct from both API Gateway payload formats. A handler can tell
+them apart by the request context. An ALB event's request context holds one `elb` block, carrying
+the target group ARN.
 
 ```typescript
 {
@@ -818,22 +815,22 @@ in it.
 }
 ```
 
-Every field is always there. A request with no query string carries an empty `queryStringParameters`
-rather than none, and one with no body carries an empty `body`. Cookies stay in the `cookie` header
-they arrived in rather than being lifted into a field of their own. Query string values arrive as
-they were sent, since real ELB does not decode percent escapes and leaves that to the function.
+Every field is always there. A request with no query string carries an empty
+`queryStringParameters`, and one with no body carries an empty `body`. Cookies stay in the `cookie`
+header they arrived in, and never move into a field of their own. Query string values arrive as they
+were sent, since real ELB leaves percent escapes for the function to decode.
 
 The load balancer writes `host`, `x-amzn-trace-id`, `x-forwarded-port` and `x-forwarded-proto`
-itself, so whatever a client sent under those names does not survive. `x-forwarded-for` is the
-exception: the client's address is appended to what the request already carried, which is what makes
-that header a chain of proxies.
+itself, and overwrites whatever a client sent under those names. `x-forwarded-for` is the exception.
+The client's address is appended to what the request already carried. That is what makes that header
+a chain of proxies.
 
 A body is passed through as text for `text/*`, `application/json`, `application/javascript` and
 `application/xml`, and base64 encoded otherwise, with `isBase64Encoded` saying which happened. A
 request carrying a `content-encoding` header is always base64. That list is shorter than API
-Gateway's: a form post is text to API Gateway and base64 to a load balancer. A body called text that
-is not valid UTF-8 fails the invocation rather than reaching the handler with replacement characters
-in it.
+Gateway's, and a form post is text to API Gateway and base64 to a load balancer. A body called text
+that turns out to be invalid UTF-8 fails the invocation, ahead of any handler seeing replacement
+characters.
 
 The response has to carry a `statusCode`. `statusDescription`, `headers`, `body` and
 `isBase64Encoded` are all optional, and a `statusDescription` of `200 OK` becomes the reason phrase
@@ -922,43 +919,41 @@ const malformed = await simElbV2Fetch(simAws, `http://${dnsName}/orders`);
 console.log(malformed.status); // 502
 ```
 
-A 503 means there was no target to send the request to, which is a target group with nothing
-registered in it.
+A 503 means there was no target to send the request to, such as an empty target group.
 
-A 502 means there was a target and it did not produce a response. A missing invoke permission, a
-function that is not there, a handler that threw, a result with no usable `statusCode`, and a
-response over 1 MB are all 502, as they are on real ELB, where the difference between them is only
-visible in the load balancer's own logs. The response limit is on the whole response document rather
-than on the body alone, so a base64 body counts at its encoded size.
+A 502 means there was a target and it failed to produce a response. A missing invoke permission, a
+function that was never created, a handler that threw, a result with no usable `statusCode`, and a
+response over 1 MB are all 502, as they are on real ELB, where the difference between them shows up
+only in the load balancer's own logs. The response limit is on the whole response document, and a
+base64 body counts at its encoded size.
 
-A request body over 1 MB is a 413, which is the limit on what real ELB sends to a Lambda target.
+A request body over 1 MB is a 413, the limit on what real ELB sends to a Lambda target.
 
 A host name no load balancer answers on, and a port no listener holds, both throw a
-`SimElbV2ConnectionRefusedError` rather than answering. Neither reaches a load balancer on real AWS
-either: one resolves to nothing and the other refuses the connection, so there is no status for
-either.
+`SimElbV2ConnectionRefusedError`. Neither reaches a load balancer on real AWS either. One resolves
+to nothing and the other refuses the connection, and there is no status for either.
 
 ### The invoke permission
 
 A load balancer invokes a Lambda function through the function's resource-based policy, exactly as
 real ELB does. The grant names `elasticloadbalancing.amazonaws.com` as the principal and the target
 group as the source ARN, and the load balancer supplies the target group's own Account as the source
-Account, so a policy written with the `aws:SourceAccount` condition the ELB documentation recommends
-matches.
+Account. A policy written with the `aws:SourceAccount` condition the ELB documentation recommends
+therefore matches.
 
 Forgetting the grant is a common way to end up with a load balancer that looks configured and serves
-nothing but 502s. Real ELB refuses to register a Lambda target at all until the permission is there;
-here the permission is checked when the request arrives instead, so a target group can be built in
-any order and a policy that is later removed stops the requests.
+nothing but 502s. Real ELB refuses to register a Lambda target at all until the permission is there.
+Here the permission is checked when the request arrives. A target group can be built in any order,
+and a policy that is later removed stops the requests.
 
 ## Carrying a request to an ECS service
 
 An `ip` target group is answered by the simulated [ECS](../ecs/) service registered into it. A
-service declares `loadBalancers` naming a target group, a container and a container port; each task
+service declares `loadBalancers` naming a target group, a container and a container port. Each task
 it keeps running is registered into that group as an address, and a request forwarded there reaches
 the handler bound to the service's container.
 
-That is the whole path an application takes: a client asks for a name, Route53 resolves it to the
+That is the whole path an application takes. A client asks for a name, Route53 resolves it to the
 load balancer, a rule picks the target group, and the container's own code answers. This is a stack
 deployed from a template, which is how one usually arrives.
 
@@ -1163,53 +1158,53 @@ const read = await client.fetch(url);
 console.log(await read.json()); // { item: "flat white" }
 ```
 
-The container's own AWS calls are authorized as the task role the task definition declared, so a
-policy that would break the deployed service breaks the test. Everything in the handler is ordinary
-application code: an SDK client, `process.env`, a route and a response.
+The container's own AWS calls are authorized as the task role the task definition declared. A policy
+that would break the deployed service breaks the test. Everything in the handler is ordinary
+application code, with an SDK client, `process.env`, a route and a response.
 
 ### What the container is given
 
 The request is the one the client made, with the headers a load balancer writes in front of a
-target: the `host` the client asked for, `x-forwarded-for`, `x-forwarded-proto`, `x-forwarded-port`
-and `x-amzn-trace-id`. Its URL is the AWS-facing one, carrying the listener's scheme and port, so a
-container reading `request.url` sees the name a client asked for rather than the localhost one a
-served request arrived at. A Lambda target behind the same listener gets the same values in its
-event, since both are written by the same rules.
+target. Those are the `host` the client asked for, `x-forwarded-for`, `x-forwarded-proto`,
+`x-forwarded-port` and `x-amzn-trace-id`. Its URL is the AWS-facing one, carrying the listener's
+scheme and port. A container reading `request.url` sees the name a client asked for, and never the
+localhost one a served request arrived at. A Lambda target behind the same listener gets the same
+values in its event, since both are written by the same rules.
 
-### Which container answers, and when nothing does
+### Which container answers, and what a 503 means
 
 Which container of a task a request reaches is a deliberate divergence, documented in full under
-[the ECS service docs](../ecs/#which-container-of-a-task-answers). Briefly: real ECS routes to the
+[the ECS service docs](../ecs/#which-container-of-a-task-answers). In short, real ECS routes to the
 container the registration names on the port it names, the common real task puts an unsimulated
-proxy on that port, so the request goes to a container that is bound instead.
+proxy on that port, and the request here goes to a container that is bound.
 
 Three things are all the same 503 real ELB answers when no target is in service:
 
-- a target group with nothing registered in it;
-- a target group whose registered service has no container bound to an HTTP handler;
-- an address registered by hand, since nothing in this simulation listens on an address and only an
-  ECS service registration puts something behind one.
+- a target group with nothing registered in it
+- a target group whose registered service has no container bound to an HTTP handler
+- an address registered by hand, since only an ECS service registration puts something behind an
+  address in this simulation
 
-A container whose handler throws is a 502, as a Lambda target that throws is, and so is one that
-answers with something that is not a `Response`. The error goes no further than the load balancer,
-which is where it goes on real AWS too.
+A container whose handler throws is a 502, as a Lambda target that throws is, and so is one
+answering with something other than a `Response`. The error goes no further than the load balancer,
+as it goes no further on real AWS.
 
 ## Reaching a load balancer by name
 
-A load balancer's DNS name resolves through simulated [Route53](../route53/), so a record pointing at
-it reaches its listeners and rules. An alias record is the usual way, and a CNAME below the apex
+A load balancer's DNS name resolves through simulated [Route53](../route53/), and a record pointing
+at it reaches its listeners and rules. An alias record is the usual way, and a CNAME below the apex
 works too, the same as on real AWS. The record's value is `DNSName` exactly as a describe reported
-it, with nothing to rewrite.
+it.
 
-A `host-header` condition then sees the name the request was made to, rather than the load balancer's
-own, so a rule on `api.example.test` claims a request that a Route53 record for `api.example.test`
-brought to the load balancer. Host-based routing and DNS agree, which is what makes a stack with one
-load balancer behind several names behave here as it does deployed.
+A `host-header` condition then sees the name the request was made to, and never the load balancer's
+own. A rule on `api.example.test` claims a request that a Route53 record for `api.example.test`
+brought to the load balancer. Host-based routing and DNS agree, and a stack with one load balancer
+behind several names behaves here as it does deployed.
 
-Under `serveSimAws` the same name is served over real localhost HTTP, and a DNS lookup for it answers
-with the address the local server listens on. A request made under the Yulin-local suffix reaches the
-listener on port 80, since the port such a request carries is the local server's rather than one a
-client chose.
+Under `serveSimAws` the same name is served over real localhost HTTP, and a DNS lookup for it
+answers with the address the local server listens on. A request made under the Yulin-local suffix
+reaches the listener on port 80, since the port such a request carries belongs to the local server
+and not to a client's choice.
 
 ```typescript sim-elbv2-route53-alias
 /**
@@ -1324,17 +1319,17 @@ try {
 }
 ```
 
-A name pointing at a load balancer that has since been deleted fails rather than answering: nothing
-holds that host name any more, and the failure names it. A DNS lookup for the name still answers,
-because the shape of a load balancer host name is what a lookup recognises, in the same way a lookup
-for a deleted bucket's website name does.
+A name pointing at a load balancer that has since been deleted fails. Nothing holds that host name
+any more, and the failure names it. A DNS lookup for the name still answers, because the shape of a
+load balancer host name is what a lookup recognises, in the same way a lookup for a deleted bucket's
+website name does.
 
 ## Deleting
 
 Deleting a load balancer takes its listeners and their rules with it, and leaves its target groups
-where they are, which is what real ELB does: a target group is a resource in its own right and a
-replacement load balancer's listeners forward to the same ones. A target group a listener or rule
-still forwards to cannot be deleted until it does not.
+where they are, as real ELB does. A target group is a resource in its own right, and a replacement
+load balancer's listeners forward to the same ones. A target group a listener or rule still forwards
+to cannot be deleted until that forward has gone.
 
 ```typescript sim-elbv2-delete-load-balancer
 /**
@@ -1413,12 +1408,12 @@ try {
 ## Deploying a load balancer from CloudFormation
 
 `AWS::ElasticLoadBalancingV2::LoadBalancer`, `TargetGroup`, `Listener` and `ListenerRule` create
-their simulated counterparts, so a test can start from the stack the routing is actually defined in.
-Each one goes through the same command an SDK caller would use, so a template's listener rule matches
-requests the way the same rule created by hand does, and a declaration real ELB would refuse fails
-the deployment rather than deploying as something else.
+their simulated counterparts, and a test can start from the stack the routing is actually defined
+in. Each one goes through the same command an SDK caller would use. A template's listener rule
+matches requests the way the same rule created by hand does, and a declaration real ELB would refuse
+fails the deployment.
 
-`Ref` returns the ARN of all four, which is what a listener's `LoadBalancerArn`, a rule's
+`Ref` returns the ARN of all four, and that is what a listener's `LoadBalancerArn`, a rule's
 `ListenerArn` and a forward action's `TargetGroupArn` each take. `Fn::GetAtt` answers with:
 
 - `DNSName`, `LoadBalancerArn`, `LoadBalancerName`, `LoadBalancerFullName` and
@@ -1426,9 +1421,9 @@ the deployment rather than deploying as something else.
 - `TargetGroupArn`, `TargetGroupName` and `TargetGroupFullName` on a target group
 - `ListenerArn` on a listener, and `RuleArn` and `IsDefault` on a rule
 
-A load balancer or target group the template does not name is named after the stack and the logical
-ID, trimmed to the 32 characters ELB allows. A target group declaring `Targets` has them registered
-as part of creating it, so the group routes as soon as the stack has deployed.
+An unnamed load balancer or target group is named after the stack and the logical ID, trimmed to the
+32 characters ELB allows. A target group declaring `Targets` has them registered as part of creating
+it, and the group routes as soon as the stack has deployed.
 
 ```typescript sim-elbv2-cloudformation
 /**
@@ -1550,11 +1545,10 @@ const unclaimed = await simElbV2Fetch(simAws, `http://${dnsName}/other`);
 console.log(unclaimed.status); // 404
 ```
 
-A listener's `Certificates` resolves against simulated [ACM](../acm/), so a stack that creates a
+A listener's `Certificates` resolves against simulated [ACM](../acm/), and a stack that creates a
 certificate and attaches it to an HTTPS listener works end to end. A certificate that was never
-issued, or that belongs to another account or region, fails the deployment rather than leaving a
-listener that could not serve. A `Fn::GetAtt` on `DNSName` is a name a Route53 alias in the same
-stack can point at and reach.
+issued, or that belongs to another account or region, fails the deployment outright. A `Fn::GetAtt`
+on `DNSName` is a name a Route53 alias in the same stack can point at and reach.
 
 ```typescript sim-elbv2-cloudformation-certificate
 /**
@@ -1645,23 +1639,23 @@ console.log(listener?.Certificates[0]?.CertificateArn);
 console.log(listener?.SslPolicy); // "ELBSecurityPolicy-2016-08"
 ```
 
-Properties Yulin has nothing to act on are read and left out rather than failing the stack. Subnets,
+Properties Yulin has no use for are read and left out, and the stack still deploys. Subnets,
 security groups, load balancer and target group attributes, listener attributes, mutual
-authentication and health check configuration are all in that group, and each one is recorded on the
-Resource so a reader can see what the deployed load balancer is not doing:
+authentication and health check configuration are all in that group. Each one is recorded on the
+Resource, where a reader can see which parts of the deployed load balancer are inert:
 
 ```typescript
 const ignored = stack.resources.get("ShopAlb")?.ignoredProperties;
 ```
 
-Tearing the stack down removes all four in reverse dependency order, so a rule comes down before its
+Tearing the stack down removes all four in reverse dependency order. A rule comes down before its
 listener, a listener before its load balancer, and a target group after everything forwarding to it.
 
 ## IAM authorization
 
 Every operation is authorized by simulated [IAM](../iam/) as the caller making it, against the
-`elasticloadbalancing:` action and the ARN of whatever it names. An operation naming nothing that
-exists yet, such as `CreateLoadBalancer` or a describe, is authorized against `*`, so only a policy
+`elasticloadbalancing:` action and the ARN of whatever it names. An operation that names no existing
+resource, such as `CreateLoadBalancer` or a describe, is authorized against `*`, and only a policy
 whose Resource is `*` allows it.
 
 ```typescript sim-elbv2-iam-policy
@@ -1771,8 +1765,8 @@ console.log(created.LoadBalancers?.[0]?.DNSName);
   `lambda` and `ip` target types.
 - `RegisterTargets`, `DeregisterTargets` and `DescribeTargetHealth`.
 - `CreateListener`, `DescribeListeners`, `ModifyListener` and `DeleteListener`, on HTTP and HTTPS.
-- An HTTPS listener's default certificate resolved against simulated ACM, refusing one that does not
-  exist, one that is not `ISSUED`, and one outside the load balancer's own account and region.
+- An HTTPS listener's default certificate resolved against simulated ACM, refusing a missing one,
+  one short of `ISSUED`, and one outside the load balancer's own account and region.
 - `AddListenerCertificates`, `RemoveListenerCertificates` and `DescribeListenerCertificates`, with
   the default certificate reported first and refused removal.
 - `CreateRule`, `DescribeRules`, `ModifyRule`, `DeleteRule` and `SetRulePriorities`, with priorities
@@ -1781,13 +1775,13 @@ console.log(created.LoadBalancers?.[0]?.DNSName);
   conditions. A condition is read through its own field's configuration, so one carrying another
   field's is refused.
 - Paged describes with `PageSize` and `Marker`.
-- Carrying a request through `simElbV2Fetch`: a listener matched by port, its rules evaluated in
-  priority order with the first match winning, and a fall through to the default action.
-- Resolving a load balancer's DNS name through sim Route53, so an alias record or a CNAME pointing at
-  it reaches its listeners and rules, and a `host-header` condition sees the name the request was
-  made to.
-- Serving a load balancer under `serveSimAws`, over real localhost HTTP and with a DNS lookup for the
-  name answering with the address the local server listens on.
+- Carrying a request through `simElbV2Fetch`, with a listener matched by port, its rules evaluated
+  in priority order with the first match winning, and a fall through to the default action.
+- Resolving a load balancer's DNS name through sim Route53, where an alias record or a CNAME
+  pointing at it reaches its listeners and rules, and a `host-header` condition sees the name the
+  request was made to.
+- Serving a load balancer under `serveSimAws`, over real localhost HTTP and with a DNS lookup for
+  the name answering with the address the local server listens on.
 - `host-header` and `path-pattern` matching with ELB's own wildcard semantics, and a rule claiming a
   request only when all of its conditions hold.
 - `forward` to a `lambda` target group, which invokes its function with an ALB-shaped event, and the
@@ -1807,54 +1801,52 @@ console.log(created.LoadBalancers?.[0]?.DNSName);
 ## Limitations
 
 - Only `host-header` and `path-pattern` conditions exist. The `http-header`, `http-request-method`,
-  `query-string` and `source-ip` fields real ELB has are refused when the rule is written, rather
-  than stored and then never matching, which would leave a rule that looks configured and claims
-  nothing. Regular expression condition values, which real ELB takes in `RegexValues`, are not
-  matched either.
+  `query-string` and `source-ip` fields real ELB has are refused when the rule is written. Storing
+  them would leave a rule that looks configured while claiming no request at all. Regular expression
+  condition values, which real ELB takes in `RegexValues`, go unmatched too.
 - A `host-header` condition is matched against the request's Host header, falling back to the host
   name in the URL. On real AWS those are the same thing, because DNS is what brought the request to
-  the load balancer. A request served under the Yulin-local suffix is matched against the name inside
-  that suffix, so `api.example.test.sim-aws.localhost` is matched as `api.example.test`.
-- A `ForwardConfig` naming several target groups by weight is refused when the request arrives rather
-  than answered with something else. Nothing here reads the weights, so which group takes a request
-  is not a question this can answer.
-- An `ip` target group is answered by the simulated ECS service registered into it, and by nothing
-  else. An address registered by hand is a 503, since nothing in this simulation listens on an
-  address for one to name.
-- Requests are not shared between the targets of a group. An ECS service's desired count is state
-  rather than concurrency, so a group holding three targets calls one container handler.
+  the load balancer. A request served under the Yulin-local suffix is matched against the name
+  inside that suffix, so `api.example.test.sim-aws.localhost` is matched as `api.example.test`.
+- A `ForwardConfig` naming several target groups by weight is refused when the request arrives.
+  Nothing here reads the weights, and which group takes a request is a question this cannot answer.
+- An `ip` target group is answered by the simulated ECS service registered into it, and by that
+  alone. An address registered by hand is a 503, since only an ECS service registration puts
+  something behind an address here.
+- Requests are never shared between the targets of a group. An ECS service's desired count is state
+  and not concurrency, and a group holding three targets calls one container handler.
 - Which container of an ECS task a request reaches diverges from real ECS on purpose, and is
   documented under [the ECS docs](../ecs/#which-container-of-a-task-answers).
-- A redirect is not checked against the listener it is on, so redirecting HTTPS to HTTP is accepted
-  where real ELB refuses it. Nothing here performs TLS, so the listener's protocol is not something a
-  request can be trusted to have arrived over.
-- No TLS is performed on an HTTPS listener. Nothing is encrypted, no handshake happens, and no
-  certificate is presented to a client. What a test can conclude is that a listener's certificate
-  exists, was issued, and is in the load balancer's account and region, and that a request treated as
-  arriving over HTTPS is routed and forwarded the way the configuration says. What it cannot conclude
-  is anything about a client trusting the certificate, about expiry, about protocol versions or
-  ciphers, or about a request having really arrived over a secure connection.
-- The URL scheme a request is written with is not checked against the listener it reaches. The port
+- A redirect goes unchecked against the listener it is on, and redirecting HTTPS to HTTP is accepted
+  where real ELB refuses it. Nothing here performs TLS, and the listener's protocol says nothing
+  about what a request really arrived over.
+- No TLS is performed on an HTTPS listener. Everything travels in the clear, with no handshake and
+  no certificate presented to a client. What a test can conclude is that a listener's certificate
+  exists, was issued, and is in the load balancer's account and region, and that a request treated
+  as arriving over HTTPS is routed and forwarded the way the configuration says. Out of reach are a
+  client trusting the certificate, expiry, protocol versions and ciphers, and whether a request
+  really arrived over a secure connection.
+- The URL scheme a request is written with goes unchecked against the listener it reaches. The port
   decides the listener, and the listener decides the protocol the event and the forwarding headers
-  report, so `http://<dns-name>:443/` reaching an HTTPS listener is served as an HTTPS request rather
-  than refused as a failed handshake.
-- SNI certificate selection by host name is not simulated. The certificates beyond the default are
-  held and reported, and nothing chooses between them when a request arrives, since there is no
-  handshake to choose in. The default certificate is the one every request is served under.
+  report. So `http://<dns-name>:443/` reaching an HTTPS listener is served as an HTTPS request,
+  where a real handshake would have failed.
+- SNI certificate selection by host name is absent. The certificates beyond the default are held and
+  reported, and nothing chooses between them when a request arrives, since there is no handshake to
+  choose in. The default certificate is the one every request is served under.
 - Security policies and cipher suites are accepted and ignored. A listener that names no `SslPolicy`
   is given the one real ELB defaults to, the value is reported back, and nothing acts on it.
 - `IsDefault` is ignored on `AddListenerCertificates`, as real ELB documents that it should not be
   set there. The default certificate is replaced with `ModifyListener`, which drops the certificate
-  that was the default rather than moving it into the rest of the list.
-- A certificate is only ever an ACM one. `ImportCertificate` and IAM server certificates are not
-  simulated, and neither is mutual TLS, so there is no trust store to give a listener.
-- The length limits real ELB puts on a fixed response's message body and a redirect's components are
-  not enforced. A condition value is held to ELB's own 128 characters.
+  that was the default instead of moving it into the rest of the list.
+- A certificate is only ever an ACM one. `ImportCertificate`, IAM server certificates and mutual TLS
+  are all absent, and there is no trust store to give a listener.
+- The length limits real ELB puts on a fixed response's message body and a redirect's components go
+  unenforced. A condition value is held to ELB's own 128 characters.
 - A request served under the Yulin-local suffix reaches the listener on port 80, or on 443 for an
-  `https:` URL. The port such a request carries is the local server's rather than one a client chose,
-  so it cannot say which listener it is for. To reach a listener on another port over localhost,
-  serve on that port and request the hostname without the suffix, which needs a resolver pointed at
-  the simulator as described in [Route53](../route53/README.md#ports).
+  `https:` URL. The port such a request carries belongs to the local server, and cannot say which
+  listener it is for. To reach a listener on another port over localhost, serve on that port and
+  request the hostname without the suffix, which needs a resolver pointed at the simulator as
+  described in [Route53](../route53/README.md#ports).
 - A DNS lookup for a name pointing at a load balancer that has been deleted still answers with the
   local server address, because a load balancer host name is recognised by its shape. The request
   that follows is the thing that fails, naming the host name nothing answers on.
@@ -1862,44 +1854,43 @@ console.log(created.LoadBalancers?.[0]?.DNSName);
   target is registered and refuses `RegisterTargets` without it. A target naming a function in
   another Account or Region is registered here and then answers 502, where real ELB refuses the
   registration.
-- Multi-value headers are not simulated. `lambda.multi_value_headers.enabled` cannot be set, since
-  target group attributes are not simulated, so the event and the accepted response always use the
+- Multi-value headers are absent. `lambda.multi_value_headers.enabled` cannot be set, because target
+  group attributes are absent too, and the event and the accepted response always use the
   single-value `headers` and `queryStringParameters` fields. A repeated query string key keeps its
   last value, as real ELB does with the attribute off, while repeated request headers arrive already
-  joined with commas rather than reduced to the last one.
-- Health check requests are never sent to a target, so neither a Lambda function nor a container will
-  see the `ELB-HealthChecker/2.0` request real ELB sends when health checks are enabled.
-- Network and gateway load balancers are not simulated. `Type: "network"` and `"gateway"` are
-  refused, as are the `TCP`, `TLS`, `UDP`, `TCP_UDP` and `GENEVE` protocols.
-- `TargetType: "instance"` and `"alb"` are refused rather than accepted and ignored, and a target
-  group naming no target type at all is refused rather than defaulted to `instance` as real ELB
-  defaults it.
-- Health checks are not performed. Health check settings are held and reported, and every registered
-  target is `healthy` however it is configured, so a test cannot watch a deployment come up.
-- A load balancer is `active` immediately rather than `provisioning` for the minutes real ELB takes,
-  and deregistration is immediate rather than draining connections first.
-- Subnets, security groups, availability zones and cross-zone configuration are accepted and left out
-  of a describe rather than modelled, and `AvailabilityZones` and `SecurityGroups` are therefore
-  absent from a described load balancer.
-- `CanonicalHostedZoneId` is one value everywhere rather than the real per-region one. Simulated
+  joined with commas.
+- Health check requests never reach a target. A Lambda function or a container here will never see
+  the `ELB-HealthChecker/2.0` request real ELB sends when health checks are enabled.
+- Network and gateway load balancers are absent. `Type: "network"` and `"gateway"` are refused, as
+  are the `TCP`, `TLS`, `UDP`, `TCP_UDP` and `GENEVE` protocols.
+- `TargetType: "instance"` and `"alb"` are refused outright, and so is a target group naming no
+  target type at all, where real ELB defaults it to `instance`.
+- Health checks never run. Health check settings are held and reported, and every registered target
+  is `healthy` however it is configured, so a test cannot watch a deployment come up.
+- A load balancer is `active` immediately, where real ELB spends minutes in `provisioning`, and
+  deregistration is immediate, where real ELB drains connections first.
+- Subnets, security groups, availability zones and cross-zone configuration are accepted and left
+  out of a describe, and `AvailabilityZones` and `SecurityGroups` are therefore absent from a
+  described load balancer.
+- `CanonicalHostedZoneId` is one value everywhere, where the real one varies by region. Simulated
   Route53 resolves an alias by looking its target up, so only the shape is load-bearing, and copying
   this value into a real template would be copying the wrong one.
-- ARN ids and DNS name suffixes count from one rather than being random, so a test can assert on an
-  ARN it did not capture. The shape is the one real ELB issues either way.
+- ARN ids and DNS name suffixes count from one, where real ones are random, and a test can therefore
+  assert on an ARN it never captured. The shape is the one real ELB issues either way.
 - `authenticate-oidc` and `authenticate-cognito` actions are refused. Nothing here performs that
   exchange, and treating one as a plain forward would quietly skip authentication. Since those are
   the only actions that may precede a routing action, a listener or rule takes exactly one action
   here and a longer list is refused.
-- Load balancer and target group attributes, access logs, and tags as a readable resource are not
-  simulated.
-- `AWS::ElasticLoadBalancingV2::TrustStore`, `TrustStoreRevocation` and `ListenerCertificate` are not
-  deployed, and a stack declaring one records it as unsupported and carries on. The first two have
-  nothing to attach to, since mutual TLS is not simulated, and a listener's additional certificates
-  are added with `AddListenerCertificates` instead.
-- `Fn::GetAtt` `SecurityGroups` on a load balancer and `LoadBalancerArns` on a target group are
-  refused rather than answered. Nothing places a simulated load balancer behind a security group, and
-  nothing records on a target group which load balancers forward to it, which `DescribeTargetGroups`
-  reads back out of the listeners instead.
-- Sim CloudFormation has no in-place resource update, so a changed load balancer, target group,
-  listener or rule is deleted and created again, and everything naming it is replaced too. A replaced
-  load balancer gets a new DNS name.
+- Load balancer and target group attributes, access logs, and tags as a readable resource are all
+  absent.
+- `AWS::ElasticLoadBalancingV2::TrustStore`, `TrustStoreRevocation` and `ListenerCertificate` are
+  never deployed, and a stack declaring one records it as unsupported and carries on. The first two
+  have nothing to attach to, with mutual TLS absent, and a listener's additional certificates are
+  added with `AddListenerCertificates`.
+- `Fn::GetAtt` `SecurityGroups` on a load balancer and `LoadBalancerArns` on a target group are both
+  refused. Nothing places a simulated load balancer behind a security group, and a target group
+  keeps no record of which load balancers forward to it, which `DescribeTargetGroups` reads back out
+  of the listeners instead.
+- Sim CloudFormation has no in-place resource update. A changed load balancer, target group,
+  listener or rule is deleted and created again, and everything naming it is replaced too. A
+  replaced load balancer gets a new DNS name.

--- a/docs/services/eventbridge/README.md
+++ b/docs/services/eventbridge/README.md
@@ -5,9 +5,8 @@ in memory and every operation is authorized by simulated IAM.
 
 Event buses, rules, targets and `PutEvents`. A rule can send matched events to a simulated Lambda
 function, SQS queue or SNS topic, run a simulated ECS task, or fire on a schedule when a test
-advances simulated time.
-[EventBridge Scheduler](../scheduler/) is a separate service with its own docs.
-EventBridge-specific types are imported from the `@kensio/yulin/eventbridge` subpath.
+advances simulated time. [EventBridge Scheduler](../scheduler/) is a separate service with its own
+docs. EventBridge-specific types are imported from the `@kensio/yulin/eventbridge` subpath.
 
 ## Putting an event onto a bus
 
@@ -40,16 +39,16 @@ console.log(output.Entries?.[0]?.EventId !== undefined); // true
 ```
 
 Every account and region has a `default` bus without one being created, and an entry that names no
-bus goes to it. A request carries between one and ten entries, and they are independent: each may
-name a different bus, and one that fails does not stop the others.
+bus goes to it. A request carries between one and ten entries, and they are independent. Each may
+name a different bus, and one that fails leaves the others alone.
 
 `Detail`, `DetailType` and `Source` are all optional in the API model, and all three are needed for
 EventBridge to take an entry. An entry missing one fails on its own, with the rest of the request
 going through. A request in which no entry carries all three fails outright.
 
-The size limit applies to the request rather than to any one entry: the entries together come to less
-than 1 MB, measured the way AWS measures them, where a `Time` counts as 14 bytes and `Source`,
-`DetailType`, `Detail` and each `Resources` entry count as the length of their UTF-8 forms.
+The size limit applies to the whole request. The entries together come to less than 1 MB, measured
+the way AWS measures them, where a `Time` counts as 14 bytes and `Source`, `DetailType`, `Detail`
+and each `Resources` entry count as the length of their UTF-8 forms.
 
 ## Creating an event bus
 
@@ -97,21 +96,21 @@ console.log(described.Name); // "orders"
 ```
 
 A bus ARN is `arn:aws:events:<region>:<account-id>:event-bus/<name>`. Unlike an SNS topic ARN it
-carries a resource type, so an IAM policy naming a bus has the `event-bus/` in it.
+carries a resource type. An IAM policy naming a bus has the `event-bus/` in it.
 
-A bus name is up to 256 characters of letters, numbers, full stops, hyphens and underscores. Creating
-one that already exists is refused with `ResourceAlreadyExistsException`, which includes `default`,
-since that bus is always there. That differs from SNS `CreateTopic`, which answers a repeated create
-with the existing topic.
+A bus name is up to 256 characters of letters, numbers, full stops, hyphens and underscores.
+Creating one that already exists is refused with `ResourceAlreadyExistsException`, which includes
+`default`, since that bus is always there. That differs from SNS `CreateTopic`, which answers a
+repeated create with the existing topic.
 
 `DescribeEventBus` takes a name or a bus ARN, and describes the default bus when the request names
-neither. `ListEventBuses` reports the default bus alongside the custom ones, narrowed by `NamePrefix`
-and paged by `Limit` and `NextToken`.
+neither. `ListEventBuses` reports the default bus alongside the custom ones, narrowed by
+`NamePrefix` and paged by `Limit` and `NextToken`.
 
-`DeleteEventBus` frees the name at once, so it can be reused straight away. Deleting a bus that is
-not there succeeds. The default bus cannot be deleted.
+`DeleteEventBus` frees the name at once, ready to be reused straight away. Deleting a bus that was
+never there succeeds. The default bus stays.
 
-## A bus that does not exist
+## Events put onto an unknown bus
 
 An event put onto a bus that was never created **succeeds**:
 
@@ -143,16 +142,16 @@ console.log(output.FailedEntryCount); // 0
 console.log(output.Entries?.[0]?.EventId !== undefined); // true
 ```
 
-This is real EventBridge behaviour rather than a gap. AWS answers 200, finds no rule to match the
+This is real EventBridge behaviour, and not a gap here. AWS answers 200, finds no rule to match the
 event against, and drops it, without counting the entry as failed. A mistyped bus name therefore
-looks exactly like a working call, which is worth knowing before it costs an afternoon, so the
-simulation reproduces it rather than being helpfully stricter.
+looks exactly like a working call. That is worth knowing before it costs an afternoon, and the
+simulation reproduces it faithfully.
 
 ## Inspecting what a bus received
 
-Real EventBridge keeps no events, so there is no API for reading them back. For tests,
-`eventsOn(...)` reports what a bus received, in arrival order. It is a simulator accessor rather than
-a simulated API: nothing an SDK command returns is built from it.
+Real EventBridge keeps no events, and there is no API for reading them back. For tests,
+`eventsOn(...)` reports what a bus received, in arrival order. It is a simulator accessor and not a
+simulated API. No SDK command builds its answer from it.
 
 ```typescript sim-event-bridge-inspecting-events
 /**
@@ -198,9 +197,9 @@ console.log(event?.toEnvelope());
 // }
 ```
 
-The envelope is the shape a rule matches against and a target receives. An entry that names no `Time`
-is stamped from the simulation's own clock, so a test with a fixed clock gets a predictable
-timestamp, and the timestamp is written to the second, as real EventBridge writes it.
+The envelope is the shape a rule matches against and a target receives. An entry that names no
+`Time` is stamped from the simulation's own clock, giving a test with a fixed clock a predictable
+timestamp. The timestamp is written to the second, as real EventBridge writes it.
 
 ## Matching events with rules
 
@@ -246,27 +245,27 @@ const [receipt] = events.receiptsOn("default");
 console.log(receipt?.matchedRuleNames); // ["large-orders"]
 ```
 
-A rule name is up to 64 characters, shorter than a bus name, and it is unique within one bus rather
-than within the account. A rule ARN on the default bus is `arn:aws:events:<region>:<account>:rule/<name>`,
-and a rule on a custom bus carries the bus as well: `rule/<bus>/<name>`.
+A rule name is up to 64 characters, shorter than a bus name, and it is unique within one bus and not
+within the account. A rule ARN on the default bus is
+`arn:aws:events:<region>:<account>:rule/<name>`, and a rule on a custom bus carries the bus as well,
+as `rule/<bus>/<name>`.
 
-`PutRule` creates and updates alike, and an update **replaces** the rule rather than merging into it.
-A second request that leaves out the description clears the description. That is real behaviour and a
-common surprise.
+`PutRule` creates and updates alike, and an update **replaces** the rule rather than merging into
+it. A second request that leaves out the description clears the description. That is real behaviour
+and a common surprise.
 
-`DisableRule` stops a rule matching, and `EnableRule` starts it again. A rule that was off does not
-replay what it missed. `DeleteRule` on a rule that is not there succeeds. Deleting a bus deletes its
-rules with it.
+`DisableRule` stops a rule matching, and `EnableRule` starts it again. A rule that was off picks up
+from the next event and leaves what it missed behind. `DeleteRule` on a rule that was never there
+succeeds. Deleting a bus deletes its rules with it.
 
-`receiptsOn(...)` is a simulator accessor rather than an API: it reports what a bus received and
-which rules each event matched, which is how a test asserts on routing before there are targets to
-watch.
+`receiptsOn(...)` is a simulator accessor. It reports what a bus received and which rules each event
+matched. A test can assert on routing before there are targets to watch.
 
 ## Event patterns
 
-A pattern has the same shape as the events it matches. Every key of a pattern has to match, which is
-an "and"; a field's conditions are written as a list, and any one matching is enough, which is an
-"or".
+A pattern has the same shape as the events it matches. Every key of a pattern has to match, making
+the keys an "and". A field's conditions are written as a list, and any one matching is enough,
+making the list an "or".
 
 Supported conditions:
 
@@ -280,21 +279,20 @@ Supported conditions:
 | Numeric, and ranges            | `"total": [{ "numeric": [">", 0, "<=", 5000] }]`       |
 | Field is or is not there       | `"refundId": [{ "exists": false }]`                    |
 
-Values are compared by type, so the string `"5"` in a pattern does not match the number `5` in an
+Values are compared by type. The string `"5"` in a pattern does not match the number `5` in an
 event. `null` and the empty string are values like any other. Where the event carries a list for a
-field, the pattern matches when the two lists overlap, which is how a pattern naming one ARN matches
-an event whose `resources` names several. `exists` is about the field rather than its members, so a
-field carrying an empty list still exists.
+field, the pattern matches when the two lists overlap, and a pattern naming one ARN then matches an
+event whose `resources` names several. `exists` is about the field and not its members, and a field
+carrying an empty list still exists.
 
-Anything else is refused at `PutRule` rather than quietly never matching. The `cidr`,
-`equals-ignore-case`, `wildcard` and `$or` operators are all refused by name, as are the nested forms
-of `anything-but` and the case-insensitive forms of `prefix` and `suffix`. A pattern that silently
-matched nothing would look like a pattern that was simply too specific, and the rule would go
-unnoticed until the deployment.
+Anything else is refused at `PutRule`. The `cidr`, `equals-ignore-case`, `wildcard` and `$or`
+operators are all refused by name, as are the nested forms of `anything-but` and the
+case-insensitive forms of `prefix` and `suffix`. A pattern that silently matched nothing would look
+like a pattern that was simply too specific, and the rule would go unnoticed until the deployment.
 
 ## Testing a pattern without a rule
 
-`TestEventPattern` answers whether one event matches one pattern, creating nothing:
+`TestEventPattern` answers whether one event matches one pattern, creating no rule:
 
 ```typescript sim-event-bridge-test-pattern
 /**
@@ -323,14 +321,14 @@ const { Result } = await simAws.eventBridge().testEventPattern(
 console.log(Result); // true
 ```
 
-This is the quickest way to find out why a rule is not firing, and a pattern this simulation cannot
+This is the quickest way to find out why a rule stays quiet, and a pattern this simulation cannot
 evaluate is refused here exactly as `PutRule` refuses it.
 
 ## Sending matched events to targets
 
 A rule sends every event it matches to each of its targets. A target is a simulated Lambda function,
-SQS queue or SNS topic, or an ECS cluster, where the rule runs a task rather than delivering
-anything: see [running an ECS task](#running-an-ecs-task).
+SQS queue or SNS topic, or an ECS cluster where the rule runs a task. See
+[running an ECS task](#running-an-ecs-task).
 
 ```typescript sim-event-bridge-targets
 /**
@@ -415,13 +413,12 @@ console.log(received.Messages?.length); // 1
 
 A queue or topic target receives the event as its message body, with no envelope around it. A Lambda
 target is invoked with the event as its payload. A target with an `Input` receives that fixed JSON
-instead of the event, which is what makes `Input` useful for a target that only needs to know
-something happened.
+in place of the event. That makes `Input` useful for a target that only needs to know something
+happened.
 
 A rule has at most five targets, and a target id is unique within one rule. `PutTargets` replaces a
-target of the same id rather than adding a second beside it. `RemoveTargets` reports an id the rule
-does not have as a failed entry rather than failing the request. Deleting a rule takes its targets
-with it.
+target of the same id, and never adds a second beside it. `RemoveTargets` reports an unknown id as a
+failed entry and lets the request itself succeed. Deleting a rule takes its targets with it.
 
 `ListTargetsByRule` reports a rule's targets, and `ListRuleNamesByTarget` reports the rules of a bus
 that send to one target ARN.
@@ -429,23 +426,23 @@ that send to one target ARN.
 ## What a target has to allow
 
 EventBridge reaches a queue, topic or function target as the `events.amazonaws.com` service
-principal, and the target's own resource policy is the whole of the decision. There is no execution
-role for those three: a rule `RoleArn` and a target `RoleArn` are both refused rather than
-simulated. An ECS target is the exception, because there is no resource policy on a task definition
-for a rule to be admitted by, and it carries a role of its own.
+principal, and the target's own resource policy is the whole of the decision. Those three have no
+execution role, and a rule `RoleArn` and a target `RoleArn` are both refused. An ECS target is the
+exception, because a task definition has no resource policy for a rule to be admitted by, and it
+carries a role of its own.
 
 - **A queue** needs `sqs:SendMessage` for `events.amazonaws.com` in its `Policy` attribute.
 - **A topic** needs `sns:Publish` for `events.amazonaws.com` in its `Policy` attribute.
 - **A function** needs an `AddPermission` grant of `lambda:InvokeFunction` to
   `events.amazonaws.com`.
 
-The policy is consulted on every delivery rather than when the target is added, so a permission taken
-away afterwards stops delivery. Real EventBridge does not check it at `PutTargets` time either.
+The policy is consulted on every delivery, and never when the target is added. A permission taken
+away afterwards stops delivery. Real EventBridge leaves it unchecked at `PutTargets` time too.
 
 A target may be in another account or region of the same simulation. It is the target's own account
-that decides, so the policy lives with the target and is evaluated by that account's IAM, as it is on
-real AWS. Both condition keys AWS documents for this work: `aws:SourceArn` carries the rule's ARN and
-`aws:SourceAccount` carries the account the rule belongs to.
+that decides. The policy lives with the target and is evaluated by that account's IAM, as it is on
+real AWS. Both condition keys AWS documents for this work. `aws:SourceArn` carries the rule's ARN
+and `aws:SourceAccount` carries the account the rule belongs to.
 
 ```typescript sim-event-bridge-cross-account
 /**
@@ -472,7 +469,7 @@ const queuePolicy = {
 console.log(JSON.stringify(queuePolicy).length > 0); // true
 ```
 
-An event delivered across accounts still names the account it was put in, not the target's.
+An event delivered across accounts still names the account it was put in, and never the target's.
 
 ## Running an ECS task
 
@@ -595,32 +592,31 @@ await simAws.backgroundTasksComplete();
 console.log(imported); // ["order-1"]
 ```
 
-The target ARN names the cluster, so an ARN naming anything else in ECS is refused when the target
-is added. `EcsParameters` names the task definition, as a family, a `family:revision` or a full ARN,
+The target ARN names the cluster. An ARN naming anything else in ECS is refused when the target is
+added. `EcsParameters` names the task definition, as a family, a `family:revision` or a full ARN,
 and the same one `RunTask` would take.
 
-An ECS target's `Input` is the task's overrides rather than something the target receives, because
-a task has nowhere to receive a payload. So container environment variables are set the way the CDK
-sets them, with a `containerOverrides` list naming the container. A target with no `Input` runs the
-task with no overrides: the matched event is not passed to the container in its place.
+An ECS target's `Input` is the task's overrides, because a task has nowhere to receive a payload. So
+container environment variables are set the way the CDK sets them, with a `containerOverrides` list
+naming the container. A target with no `Input` runs the task with no overrides, and the matched
+event never reaches the container.
 
 The role is the whole of the decision. It has to trust `events.amazonaws.com` in its
 `AssumeRolePolicyDocument`, and it has to be allowed `ecs:RunTask` on the task definition revision
-the target runs. A role that may not is a recorded delivery failure, in
-[deliveries that did not happen](#deliveries-that-did-not-happen), rather than an error the caller
-who put the event sees.
+the target runs. A role that may not becomes a recorded
+[delivery failure](#reading-back-a-failed-delivery), and the caller who put the event sees no error.
 
-Which containers actually run is [simulated ECS](../ecs/)'s answer rather than the rule's: a
+Which containers actually run is [simulated ECS](../ecs/)'s answer, and never the rule's. A
 container with a binding runs its handler, and a container without one is recorded as not simulated.
 A target naming a task definition with nothing bound therefore records a task that never started,
 and the rule counts as delivered.
 
 ## Rules that fire on a schedule
 
-A rule created with a `ScheduleExpression` instead of an event pattern fires on its own timing rather
-than in response to anything put onto a bus. That timing is the simulation's clock, not the host's:
-the rule fires when a test advances simulated time past a due instant, and never otherwise. So a
-schedule that takes an hour in production takes no time at all to test.
+A rule created with a `ScheduleExpression` in place of an event pattern fires on its own timing,
+independently of anything put onto a bus. That timing is the simulation's clock. The rule fires when
+a test advances simulated time past a due instant, and never otherwise. So a schedule that takes an
+hour in production takes no time at all to test.
 
 ```typescript sim-event-bridge-scheduled-rules
 /**
@@ -687,47 +683,47 @@ console.log(ranAt);
 // [ '2026-07-26T10:00:00Z', '2026-07-26T11:00:00Z', '2026-07-26T12:00:00Z' ]
 ```
 
-Firing is per due instant rather than per advance. Advancing an hour with a `rate(1 minute)` rule
+Firing is per due instant, and not per advance. Advancing an hour with a `rate(1 minute)` rule
 invokes the target sixty times, at sixty distinct simulated timestamps, because that is what an hour
 of that rule does. `advanceBy(...)` returns once every one of those firings and its deliveries have
-settled, so the next line can assert.
+settled, ready for the next line to assert.
 
-A scheduled event carries the standard envelope with `source: "aws.events"`,
-`detail-type: "Scheduled Event"` and an empty `detail`, and names the rule that fired in `resources`.
-Its `time` is the instant the rule fell due, not the instant the advance finished, which is the field
-AWS advises scheduled handler code to read instead of the clock.
+A scheduled event carries the standard envelope with `source: "aws.events"`, `detail-type:
+"Scheduled Event"` and an empty `detail`, and names the rule that fired in `resources`. Its `time`
+is the instant the rule fell due rather than the instant the advance finished. That is the field AWS
+advises scheduled handler code to read in place of the clock.
 
 ### Writing the schedule
 
-`rate(<value> <unit>)` runs from the moment the rule was created, so a `rate(1 day)` rule created at
+`rate(<value> <unit>)` runs from the moment the rule was created. A `rate(1 day)` rule created at
 half past nine falls due at half past nine. The unit is `minute`, `hour` or `day`, and has to agree
-with its value: `rate(1 hour)` and `rate(5 hours)` are the valid forms, and `rate(1 hours)` is
-refused as real EventBridge refuses it. There is no unit under a minute, which is the finest schedule
-AWS runs.
+with its value. `rate(1 hour)` and `rate(5 hours)` are the valid forms, and `rate(1 hours)` is
+refused as real EventBridge refuses it. A minute is the finest schedule AWS runs, and there is no
+unit below it.
 
-`cron(<six fields>)` names absolute instants in UTC. The six fields are minutes, hours, day-of-month,
-month, day-of-week and year, so the every-day-at-noon expression is `cron(0 12 * * ? *)`. A five-field
-expression, which is what Unix cron takes, is refused naming the six-field form. Day-of-week runs
-`1-7` or `SUN-SAT` with Sunday as one, unlike Unix cron, and the day-of-month and day-of-week fields
-cannot both say something: whichever is not deciding the day is written `?`.
+`cron(<six fields>)` names absolute instants in UTC. The six fields are minutes, hours,
+day-of-month, month, day-of-week and year, making the every-day-at-noon expression `cron(0 12 * * ?
+*)`. A five-field expression, the form Unix cron takes, is refused naming the six-field form.
+Day-of-week runs `1-7` or `SUN-SAT` with Sunday as one, unlike Unix cron. The day-of-month and
+day-of-week fields cannot both say something, and whichever one is standing aside is written `?`.
 
 A scheduled rule only works on the `default` bus, as it does on real AWS, and a `ScheduleExpression`
 on any other bus is refused.
 
 `DisableRule` stops a scheduled rule firing while it is off, and `EnableRule` picks up from the next
-due instant rather than replaying what was missed. `DeleteRule` stops it for good, and `PutRule`
-replacing a scheduled rule restarts the schedule from the replacement.
+due instant. What was missed while it was off stays missed. `DeleteRule` stops it for good, and
+`PutRule` replacing a scheduled rule restarts the schedule from the replacement.
 
-A rule with no target still fires, and what it produced can be read with `eventsOn(...)`, which is
+A rule with no target still fires, and what it produced can be read with `eventsOn(...)`. That is
 useful for asserting on the schedule itself before there is anything to deliver to.
 
 ## Deploying from a CloudFormation template
 
 `AWS::Events::EventBus` and `AWS::Events::Rule` deploy through
-[simulated CloudFormation](../cloudformation/), so a stack that declares its routing rather than
-calling the SDK can be exercised end to end. A rule carries its `EventPattern` or
-`ScheduleExpression`, its `State`, and its inline `Targets`, and a target ARN resolved by
-`Fn::GetAtt` from a function or queue in the same template works as it would in a real deployment.
+[simulated CloudFormation](../cloudformation/). A stack that declares its routing in a template can
+be exercised end to end. A rule carries its `EventPattern` or `ScheduleExpression`, its `State`, and
+its inline `Targets`, and a target ARN resolved by `Fn::GetAtt` from a function or queue in the same
+template works as it would in a real deployment.
 
 ```typescript sim-event-bridge-cloudformation
 /**
@@ -808,22 +804,21 @@ await simAws.backgroundTasksComplete();
 console.log(handled.length); // 1
 ```
 
-`Ref` returns the **name** of a bus or a rule, not its ARN, which is what AWS returns and what makes
-a bus `Ref` usable straight away as another resource's `EventBusName`. The ARN comes from
-`Fn::GetAtt ... Arn`, which is what an `AWS::Lambda::Permission` `SourceArn` needs. A rule the
-template does not name gets one generated from the stack name and the logical ID, as real
-CloudFormation generates one.
+`Ref` returns the **name** of a bus or a rule, and never its ARN. That is what AWS returns, and it
+makes a bus `Ref` usable straight away as another resource's `EventBusName`. The ARN comes from
+`Fn::GetAtt ... Arn`, which an `AWS::Lambda::Permission` `SourceArn` needs. An unnamed rule gets a
+name generated from the stack name and the logical ID, as real CloudFormation generates one.
 
-A target property this simulation does not model, such as `InputTransformer` or `InputPath`, is
-refused at deploy time naming the property and the Resource, rather than deploying a rule that sends
-the whole event where one field was asked for. Tearing the stack down removes the buses, rules and
-targets it created.
+A target property this simulation leaves out, such as `InputTransformer` or `InputPath`, is refused
+at deploy time naming the property and the Resource. The alternative is a rule that sends the whole
+event where one field was asked for. Tearing the stack down removes the buses, rules and targets it
+created.
 
-## Deliveries that did not happen
+## Reading back a failed delivery
 
-Real EventBridge tells the caller nothing about a failed delivery: a `PutEvents` that matched a rule
-whose target refuses the call still answers with an event id. A target that is unexpectedly empty is
-explained by `deliveryFailures` instead:
+Real EventBridge tells the caller nothing about a failed delivery. A `PutEvents` that matched a rule
+whose target refuses the call still answers with an event id. `deliveryFailures` explains a target
+that is unexpectedly empty:
 
 ```typescript sim-event-bridge-delivery-failures
 /**
@@ -879,7 +874,7 @@ no is a modelled outcome a test may be asking for on purpose.
 ## Permissions
 
 Every operation is authorized by simulated IAM against the bus ARN. `events:ListEventBuses` has no
-bus-level resource on real AWS, so it authorizes against `*` and a policy naming a bus does not allow
+bus-level resource on real AWS. It authorizes against `*`, and a policy naming a bus will not allow
 it.
 
 ```typescript sim-event-bridge-iam-policy
@@ -902,7 +897,7 @@ console.log(JSON.stringify(policy).length > 0); // true
 ```
 
 A caller refused by IAM gets `AccessDeniedException`. Permission is checked before the bus is looked
-up, so a caller who is not allowed to reach a bus is refused whether or not that bus exists.
+up, and a caller who may not reach a bus is refused whether or not that bus exists.
 
 ## Scoping
 
@@ -950,7 +945,7 @@ no permission for.
   `TaskCount` from `EcsParameters` and container overrides from the target's `Input`.
 - Targets in another account or region of the same simulation, admitted by the target's own resource
   policy on `aws:SourceArn` or `aws:SourceAccount`, as real EventBridge does.
-- A target's fixed `Input`, and `deliveryFailures` for deliveries that did not happen.
+- A target's fixed `Input`, and `deliveryFailures` for a delivery that failed.
 - The `default` bus in every account and region, without one being created.
 - Bus descriptions, creation timestamps from the simulation's clock, and prefix-narrowed paged
   listings.
@@ -961,52 +956,49 @@ no permission for.
 ## Limitations
 
 - Targets deliver to Lambda, SQS and SNS, and run a task in ECS. A target ARN naming any other
-  service is refused when the target is added rather than when an event first matches.
+  service is refused as the target is added, ahead of any matching event.
 - Target `InputPath` and `InputTransformer` are refused, as are dead letter queues and retry
-  policies. A delivery is attempted once. A target `RoleArn` is refused except on an ECS target,
-  which is the one target type that runs as a role rather than as the service principal.
+  policies. A delivery is attempted once. A target `RoleArn` is refused except on an ECS target.
+  That is the one target type that runs as a role, where the others run as the service principal.
 - An ECS target's `EcsParameters` takes `TaskDefinitionArn` and `TaskCount`, and takes and ignores
   `LaunchType`, `PlatformVersion`, `NetworkConfiguration` and `CapacityProviderStrategy`, since
   there is no placement and no network here for them to apply to. Anything else it can carry, such
-  as `Group`, `Tags` or `PropagateTags`, is refused rather than dropped.
-- An ECS target's `Input` is read as the task's overrides rather than as something the target
-  receives, so a `containerOverrides` list is how a rule sets a container's environment. A target
-  with no `Input` runs the task with no overrides, and the matched event is not passed on in its
-  place.
+  as `Group`, `Tags` or `PropagateTags`, is refused outright.
+- An ECS target's `Input` is read as the task's overrides, and a `containerOverrides` list is how a
+  rule sets a container's environment. A target with no `Input` runs the task with no overrides, and
+  the matched event never reaches the container.
 - A `TaskCount` above one runs that many simulated tasks, and a bound container handler runs once
   for each of them, in this process and one after another.
 - An ECS target is refused in a CloudFormation template. `AWS::Events::Rule` still refuses a target
-  `RoleArn` and `EcsParameters`, so an ECS target is written with `PutTargets`.
+  `RoleArn` and `EcsParameters`. Write an ECS target with `PutTargets`.
 - Numbers are compared after JSON parsing, so `300`, `300.0` and `3.0e2` are one value here. Real
   EventBridge compares the JSON token when matching an exact value, and so may tell those forms
-  apart. Use `numeric` to compare numbers, which is what it is for.
-- The `cidr`, `equals-ignore-case`, `wildcard` and `$or` pattern operators are refused rather than
-  evaluated, as are the nested forms of `anything-but` and the case-insensitive forms of `prefix`
-  and `suffix`.
+  apart. Use `numeric` to compare numbers. That is what it is for.
+- The `cidr`, `equals-ignore-case`, `wildcard` and `$or` pattern operators are refused at `PutRule`,
+  as are the nested forms of `anything-but` and the case-insensitive forms of `prefix` and `suffix`.
 - A rule needs an `EventPattern`, a `ScheduleExpression` or both. Real EventBridge takes a rule with
-  neither, which matches nothing and fires never, and that is refused here rather than created.
+  neither, which matches nothing and fires never. Here that rule is refused.
 - A scheduled rule only fires while a test advances the simulation's clock. Nothing runs on the
-  host's clock, so a simulation left alone in real time fires nothing.
-- `ScheduleExpressionTimezone` and the `L`, `W` and `#` cron wildcards are refused rather than
-  simulated. Everything is read in UTC.
+  host's clock, and a simulation left alone in real time fires nothing.
+- `ScheduleExpressionTimezone` and the `L`, `W` and `#` cron wildcards are refused. Everything is
+  read in UTC.
 - Firing is exact and exactly once. Real EventBridge may deliver a scheduled event a few seconds
   late, and may deliver it more than once.
-- EventBridge Scheduler is a separate service, simulated separately: see
+- EventBridge Scheduler is a separate service, simulated separately. See
   [simulated Scheduler](../scheduler/).
-- Rule tags, a rule `RoleArn`, managed rules and the
-  `ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS` state are refused rather than simulated.
+- Rule tags, a rule `RoleArn`, managed rules and the `ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS`
+  state are all refused.
 - Deleting an event bus deletes its rules, and deleting a rule deletes its targets. Real EventBridge
   refuses to delete either while it still has what hangs off it.
 - `AWS::Events::EventBusPolicy`, `AWS::Events::Archive`, `AWS::Events::Connection` and
-  `AWS::Events::ApiDestination` are not simulated as CloudFormation resource types.
-  `AWS::Events::EventBus` and `AWS::Events::Rule` are: see
+  `AWS::Events::ApiDestination` are absent as CloudFormation resource types. `AWS::Events::EventBus`
+  and `AWS::Events::Rule` are there. See
   [deploying from a template](#deploying-from-a-cloudformation-template).
-- Event bus resource policies are not simulated. `PutPermission`, `RemovePermission` and the bus
-  `Policy` attribute are all absent, so a caller from another account cannot be admitted to a bus,
-  which is stricter than real AWS.
-- Putting an event onto another account's or region's bus is refused rather than delivered.
-- Partner event buses and partner event sources are refused rather than simulated, as are event bus
-  tags, encryption with a customer managed key, dead letter queues, logging configuration and global
-  endpoints.
+- Event bus resource policies are absent. `PutPermission`, `RemovePermission` and the bus `Policy`
+  attribute are all missing, and a caller from another account cannot be admitted to a bus. That is
+  stricter than real AWS.
+- Putting an event onto another account's or region's bus is refused.
+- Partner event buses and partner event sources are refused, as are event bus tags, encryption with
+  a customer managed key, dead letter queues, logging configuration and global endpoints.
 - Archives, replay, schema registry and discovery, API destinations and connections are not
   simulated.

--- a/docs/services/eventbridge/README.md
+++ b/docs/services/eventbridge/README.md
@@ -615,8 +615,8 @@ and the rule counts as delivered.
 
 A rule created with a `ScheduleExpression` in place of an event pattern fires on its own timing,
 independently of anything put onto a bus. That timing is the simulation's clock. The rule fires when
-a test advances simulated time past a due instant, and never otherwise. So a schedule that takes an
-hour in production takes no time at all to test.
+a test advances simulated time to or past a due instant, and never otherwise. So a schedule that
+takes an hour in production takes no time at all to test.
 
 ```typescript sim-event-bridge-scheduled-rules
 /**
@@ -873,9 +873,10 @@ no is a modelled outcome a test may be asking for on purpose.
 
 ## Permissions
 
-Every operation is authorized by simulated IAM against the bus ARN. `events:ListEventBuses` has no
-bus-level resource on real AWS. It authorizes against `*`, and a policy naming a bus will not allow
-it.
+Most operations are authorized by simulated IAM against the bus ARN. The two that name no bus
+authorize against `*` instead, and a policy naming a bus will not allow either. Those are
+`events:ListEventBuses`, which has no bus-level resource on real AWS, and `events:TestEventPattern`,
+which reaches no bus at all.
 
 ```typescript sim-event-bridge-iam-policy
 /**

--- a/docs/time/README.md
+++ b/docs/time/README.md
@@ -4,22 +4,21 @@ Every timestamp a simulated AWS service produces comes from that simulation's ow
 clock can be moved. Time can be frozen, set to an instant, or advanced by a duration. Behaviour that
 depends on time passing, such as a temporary session expiring, can be tested without waiting for it.
 
-Nothing here replaces the clock for the whole process. Time belongs to a `SimAws` instance, so moving
-it never disturbs another simulation running in the same test file, the real clock, or any other code
-in the process.
+Time belongs to a `SimAws` instance. Moving it affects that instance only. The host clock, another
+simulation running in the same test file, and any other code in the process all carry on unchanged.
 
 ## Reading the time
 
-`simAws.now()` is what the simulation means by "now", which is not necessarily what the host clock
-means by it. It is also what stamps simulated resources: an IAM User's `CreateDate`, an
-`AssumeRole` session's `Expiration`, and so on.
+`simAws.now()` is what the simulation means by "now". The host clock may say something different. It
+also stamps simulated resources, such as an IAM User's `CreateDate` and an `AssumeRole` session's
+`Expiration`.
 
 By default a new `SimAws` runs in step with the real system clock.
 
 ## Starting at a known instant
 
 Pass a clock to start somewhere specific. `SimFixedClock` is the usual choice, since it reports one
-instant and does not move on its own:
+instant and stays there:
 
 ```typescript sim-clock-freeze-and-advance
 /**
@@ -48,26 +47,26 @@ console.log(simAws.now()); // 2026-07-26T11:30:00.000Z
 simAws.clock().resume();
 ```
 
-Simulated time is layered over whatever clock is supplied, so a simulation started at a fixed
-instant is still free to move from there. It also stays measured against that clock: resuming a
-simulation built on a `SimFixedClock` puts it back in running mode, but its time only moves when
-the clock underneath does, which a fixed clock never does. Leave the default real clock in place
-for a simulation whose time should pass by itself.
+Simulated time is layered over whatever clock is supplied. A simulation started at a fixed instant
+is still free to move from there, and it stays measured against that clock. Resuming a simulation
+built on a `SimFixedClock` puts it back in running mode, and its time then moves whenever the clock
+underneath moves. A fixed clock stays where it is. Leave the default real clock in place for a
+simulation whose time should pass by itself.
 
 ## Frozen and running
 
 There are two modes:
 
 - **Frozen**: simulated time only moves when something moves it. A frozen clock reports the same
-  instant however long the host takes, so a slow test cannot drift past the state it set up. This is
-  what a deterministic assertion wants.
+  instant however long the host takes, and a slow test holds the state it set up. This is what a
+  deterministic assertion wants.
 - **Running**: simulated time tracks the clock underneath, offset from it. On the default real clock
-  that means time passes by itself, which is what "jump forward an hour and carry on" wants.
+  time passes by itself. Use it to jump forward an hour and carry on.
 
 Moving time deliberately freezes it. `setTo(...)` and `advanceBy(...)` both leave the clock stopped
-where they put it, so a test that asked for a specific instant asserts on that instant rather than on
-that instant plus however long the assertion took. `resume()` is the way back to running, and it
-carries on from where the clock stopped rather than snapping back to the clock underneath.
+where they put it. A test that asked for a specific instant then asserts on that instant, however
+long the assertion takes. `resume()` is the way back to running, and it carries on from where the
+clock stopped.
 
 `simAws.clock().isFrozen` reports which mode the clock is in.
 
@@ -77,10 +76,10 @@ carries on from where the clock stopped rather than snapping back to the clock u
 `seconds` and `milliseconds`, which add together. Durations are never negative, since time passing
 only runs forwards. `setTo(...)` is the explicit way to move a clock back.
 
-Advancing does two things: it moves the clock, and it runs whatever the passage of time should have
-caused. Work scheduled for an instant inside the interval is dispatched in due order, each task
-running with the clock reading its own due time, and any further work it schedules settles before
-`advanceBy` returns. So a test can advance and then assert, with no additional waiting:
+Advancing moves the clock, and it runs whatever the passage of time should have caused. Work
+scheduled for an instant inside the interval is dispatched in due order, each task running with the
+clock reading its own due time, and any further work it schedules settles before `advanceBy`
+returns. So a test can advance and then assert, with no additional waiting:
 
 ```typescript sim-clock-session-expiry
 /**
@@ -137,27 +136,27 @@ try {
 }
 ```
 
-If work triggered by advancing fails, the failure is thrown from `advanceBy(...)` rather than lost
-in the background, and the clock is left at the point it failed rather than at the instant asked
-for. Anything still queued stays queued.
+Work triggered by advancing that fails throws from `advanceBy(...)`, where the caller can see it.
+The clock is left at the point it failed, and anything still queued stays queued.
 
 Delivery to a target is the exception, and deliberately so. An EventBridge rule or a Scheduler
-schedule that cannot reach its target records the failure instead of throwing, because real AWS
-reports a failed delivery to nobody and because one rejected delivery would otherwise fail an
-unrelated `advanceBy(...)` elsewhere in the same test. Those are read from
-`eventBridge().deliveryFailures` and `scheduler().deliveryFailures` rather than caught.
+schedule that cannot reach its target records the failure instead of throwing. Real AWS reports a
+failed delivery to nobody, and one rejected delivery would otherwise fail an unrelated
+`advanceBy(...)` elsewhere in the same test. Read the failures from `eventBridge().deliveryFailures`
+and `scheduler().deliveryFailures`.
 
-Several parts of the simulator schedule work on the clock, so advancing time does more than change
-what timestamps and expiry checks see. A scheduled EventBridge rule fires, an EventBridge Scheduler
+Several parts of the simulator schedule work on the clock. Advancing time does more than change what
+timestamps and expiry checks see. A scheduled EventBridge rule fires, an EventBridge Scheduler
 schedule invokes its target, a DynamoDB item passes its time to live, a Secrets Manager deletion
-falls due, and a Lambda event source mapping polls again. Each of those runs at its own due instant inside the interval, not all at once at the end.
+falls due, and a Lambda event source mapping polls again. Each of those runs at its own due instant
+inside the interval, in the order they fall due.
 
 ## Time inside a simulated Lambda handler
 
 A simulated Lambda function runs on its simulation's clock, and that reaches the JavaScript clock
 the function code itself reads. `Date.now()` and `new Date()` inside a handler report simulated
-time, so code stamping an expiry or building a date-partitioned key can be tested against a clock
-the test controls:
+time. Code stamping an expiry or building a date-partitioned key can be tested against a clock the
+test controls:
 
 ```typescript sim-clock-lambda-handler
 /**
@@ -201,27 +200,27 @@ console.log(Buffer.from(second.Payload!).toString()); // {"at":"2026-07-26T11:00
 How that is arranged depends on where the function code runs. One of the two touches a process
 global:
 
-- **Zip code** runs in a vm sandbox owning its own globals, so it is handed a `Date` bound to the
-  simulation's clock. Nothing outside the sandbox is affected.
+- **Zip code** runs in a vm sandbox owning its own globals, and is handed a `Date` bound to the
+  simulation's clock. The globals outside the sandbox are left alone.
 - **A real in-process handler function** is a closure over the module scope it was written in, and
-  reads the global `Date` like everything else in the test run. So the global is substituted for
-  one reporting the invocation's clock while an invocation is running, and the host clock
-  otherwise, tracked with `AsyncLocalStorage` so concurrent invocations of different simulations
-  stay apart. It is installed on the first in-process invocation and never removed, but with no
-  invocation running it behaves exactly as the host's own `Date` does.
+  reads the global `Date` like everything else in the test run. So the global is substituted for one
+  reporting the invocation's clock while an invocation is running, and the host clock otherwise,
+  tracked with `AsyncLocalStorage` so concurrent invocations of different simulations stay apart. It
+  is installed on the first in-process invocation and never removed, and with no invocation running
+  it behaves exactly as the host's own `Date` does.
 
 Only the current time comes from the clock. `new Date("2020-03-12")`, `Date.parse(...)`,
 `Date.UTC(...)` and `instanceof Date` all behave as they always did.
 
-One thing to watch: under a frozen clock `Date.now()` returns the same number for the whole
-invocation, so handler code that waits for it to change never finishes. `resume()` before invoking
-if the code under test polls the clock.
+Under a frozen clock `Date.now()` returns the same number for the whole invocation, and handler code
+that waits for it to change never finishes. Call `resume()` before invoking if the code under test
+polls the clock.
 
 ### Where real AWS gets the time
 
 Real Lambda has no current-time API. The context object carries no timestamp, only
-`getRemainingTimeInMillis()`, and no environment variable holds one, so handler code reading
-`new Date()` is reading the machine clock. What AWS does provide is the time on the event:
+`getRemainingTimeInMillis()`, and no environment variable holds one. Handler code reading `new
+Date()` is reading the machine clock. AWS does provide the time on the event:
 
 | Event source              | Field                                             |
 | ------------------------- | ------------------------------------------------- |
@@ -231,16 +230,15 @@ Real Lambda has no current-time API. The context object carries no timestamp, on
 | SNS                       | `Records[].Sns.Timestamp`                         |
 | SQS                       | `Records[].attributes.SentTimestamp`              |
 
-For a scheduled invocation AWS's advice is to use the event's `time` rather than the system clock,
+For a scheduled invocation AWS advises reading the event's `time` in preference to the system clock,
 because a retry or a delayed delivery runs later than the time the work was for. Simulated Lambda
-follows the same rule where it builds events: a Function URL request carries simulated time in
+follows the same rule where it builds events. A Function URL request carries simulated time in
 `requestContext.time` and `requestContext.timeEpoch`.
 
-An SQS event source mapping does the same: the `SentTimestamp` and
-`ApproximateFirstReceiveTimestamp` attributes on a delivered record are simulated time, so a handler
-reading the event's time reads the clock the test controls. See
-[simulated Lambda](../services/lambda/#triggering-a-function-from-an-sqs-queue "Simulated Lambda
-event source mapping docs").
+An SQS event source mapping does the same. The `SentTimestamp` and
+`ApproximateFirstReceiveTimestamp` attributes on a delivered record are simulated time, and a
+handler reading the event's time reads the clock the test controls. See
+[simulated Lambda](../services/lambda/#triggering-a-function-from-an-sqs-queue "Simulated Lambda event source mapping docs").
 
 Handler code that takes a clock as a dependency stays the most testable option, on real AWS and
 here, and needs none of the machinery above.
@@ -248,33 +246,32 @@ here, and needs none of the machinery above.
 ## Time over HTTP
 
 A simulation served over HTTP, through `serveSimAws` or `SimAwsHttp.fetch(...)`, stamps every
-response with simulated time in its `Date` header, as real AWS stamps every API response with
-server time. Advancing the clock changes what that header reports, so a client talking to the
-simulation sees the same "now" the simulation does without needing to know it is talking to a
-simulator.
+response with simulated time in its `Date` header, as real AWS stamps every API response with server
+time. Advancing the clock changes what that header reports. A client talking to the simulation sees
+the same "now" the simulation does, with no need to know it is talking to a simulator.
 
 ## Time and SDK interception
 
-A `SimSdk` owns a simulated AWS environment, available as `simSdk.simAws`, so intercepted SDK code
-runs on a clock a test can control: `await simSdk.simAws.clock().advanceBy({ hours: 1 })`.
+A `SimSdk` owns a simulated AWS environment, available as `simSdk.simAws`. Intercepted SDK code runs
+on a clock a test can control with `await simSdk.simAws.clock().advanceBy({ hours: 1 })`.
 
 ## Limitations
 
 - Advancing the clock is the only thing that fires a scheduled
   [EventBridge rule](../services/eventbridge/#rules-that-fire-on-a-schedule). Nothing runs on the
-  host's clock, so a simulation left alone in real time fires nothing however long it is left.
-- Advancing the clock is also the only thing that fires an [EventBridge Scheduler
-  schedule](../services/scheduler/#firing-a-schedule), including a one-time `at(...)` one.
+  host's clock. A simulation left alone in real time fires nothing however long it is left.
+- Advancing the clock is also the only thing that fires an
+  [EventBridge Scheduler schedule](../services/scheduler/#firing-a-schedule), including a one-time
+  `at(...)` one.
 - Only `SimAws` exposes time control. Services constructed standalone, such as `new SimS3()`, get
   their own real clock and no way to move it.
 - A `SimAws` constructed with a `background` scheduler of its own cannot control time, because that
-  scheduler brings its own clock. `simAws.clock()` throws a diagnostic error rather than silently
-  controlling nothing.
+  scheduler brings its own clock. `simAws.clock()` throws a diagnostic error saying so.
 - Simulated time reaches JavaScript's own clock inside a simulated Lambda invocation, and nowhere
   else. `Date.now()` and `new Date()` in code under test that is not running as a simulated Lambda
   function still report real time.
-- Timers are not simulated. `setTimeout` inside a handler is a host timer, so a sleeping handler
-  waits in real time and advancing the clock does not release it.
+- Timers are not simulated. `setTimeout` inside a handler is a host timer. A sleeping handler waits
+  in real time, and advancing the clock leaves it asleep.
 - A time already read cannot be reached. A handler module doing `const startedAt = Date.now()` at
   module scope read it when the test file imported the module, long before any invocation.
 - Advancing time does not re-evaluate simulated state that was already computed, such as an ACM

--- a/docs/time/README.md
+++ b/docs/time/README.md
@@ -78,8 +78,9 @@ only runs forwards. `setTo(...)` is the explicit way to move a clock back.
 
 Advancing moves the clock, and it runs whatever the passage of time should have caused. Work
 scheduled for an instant inside the interval is dispatched in due order, each task running with the
-clock reading its own due time, and any further work it schedules settles before `advanceBy`
-returns. So a test can advance and then assert, with no additional waiting:
+clock reading its own due time. Further work it schedules settles before `advanceBy` returns where
+that work is itself due by the new time, and stays queued where it falls later. So a test can
+advance and then assert, with no additional waiting:
 
 ```typescript sim-clock-session-expiry
 /**


### PR DESCRIPTION
Brief, concise description of the change:

Rewrote the prose in the serve and time pages and in the DynamoDB, ECR, ECS, ELBv2 and EventBridge
service READMEs, leaving every code example byte-identical and re-extraction of the
`docs/*.example.ts` files unchanged. All seven failed the prose checker on the measured sentence
shapes, and five carried marks the house rules ban. The rewrite splits consequence clauses into
their own sentences, promotes or deletes trailing "which is" remarks, replaces colon restatements
with full stops, and turns roundabout negation positive where the sentence was stating scope, while
keeping negation and the contrastive forms wherever the absence or the correction is the fact being
documented, as it is throughout the Limitations sections. Four headings framed by what a section
excludes are named for what they cover instead, and the one inbound link to a renamed anchor is
updated. All seven now score below the warn threshold on every pattern.

Two notes for review. The DynamoDB page had around 390 flagged sentences, so the bulk transforms
were scripted at paragraph level rather than edited one at a time; converting every `rather than` to
`and not` in one pass simply moved the tic onto the replacement, which is the displacement the style
skill warns about, so that was rebalanced afterwards and the roughly twenty spots where a mechanical
substitution read badly were fixed by hand. Separately, the touched paragraphs were reflowed to 100
columns with markdown links kept unbroken; bullet, heading and table counts are unchanged against
main in all seven files, and the five remaining lines over 100 characters in the DynamoDB page are
each a single unbreakable link that was already over.

- [x] Conventional commit message, used as the title

- [ ] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`

See https://www.conventionalcommits.org/en/v1.0.0/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified serving behavior, request handling, URL adaptation, reloads, shutdown, and debugging guidance.
  * Expanded ECR and ECS documentation covering resource lifecycles, image matching, integrations, failures, and limitations.
  * Detailed ELBv2 routing, certificates, redirects, integrations, deletion, and deployment behavior.
  * Clarified EventBridge buses, rules, targets, scheduling, authorization, delivery, and unsupported features.
  * Documented simulated-time isolation, scheduling, timestamps, failure handling, and integration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->