### PR TITLE
feat: fan out an SNS message to a phone number

### DIFF
--- a/docs/services/sns/README.md
+++ b/docs/services/sns/README.md
@@ -5,9 +5,10 @@ every operation is authorized by simulated IAM.
 
 Standard topics only. SNS-specific types are imported from the `@kensio/yulin/sns` subpath.
 
-A message published to a topic is delivered to every queue subscribed to it, and invokes every Lambda
-function subscribed to it. Other subscription protocols are not simulated. A message published to a
-phone number is recorded as an SMS a test can assert on.
+A message published to a topic is delivered to every queue subscribed to it, invokes every Lambda
+function subscribed to it, and is recorded as an SMS for every phone number subscribed to it. Other
+subscription protocols are not simulated. A message published straight to a phone number is recorded
+as an SMS a test can assert on.
 
 ## Creating a topic and publishing to it
 
@@ -205,7 +206,8 @@ console.log(published.Failed?.[0]?.Code); // "InvalidParameterValueException"
 
 A `Publish` that names a `PhoneNumber` sends an SMS to that number. The message stays inside the
 simulation. Simulated SNS records what it would have texted, and `sentSmsMessages()` on the service
-reads the records back, oldest first.
+reads the records back, oldest first. A topic texts a number as well, under
+[texting a subscribed number](#texting-a-subscribed-number).
 
 ```typescript sim-sns-sms
 /**
@@ -292,9 +294,10 @@ published in `eu-west-2` is invisible from `us-east-1`.
 
 ## Subscriptions
 
-`Subscribe` with the `sqs` protocol and a queue ARN, or the `lambda` protocol and a function ARN,
-answers with a subscription ARN straight away. There is no confirmation step for either protocol, as
-there is none on real SNS: the subscription is confirmed the moment it exists.
+`Subscribe` with the `sqs` protocol and a queue ARN, the `lambda` protocol and a function ARN, or the
+`sms` protocol and a phone number, answers with a subscription ARN straight away. There is no
+confirmation step for any of the three, as there is none on real SNS. The subscription is confirmed
+the moment it exists.
 
 ```typescript sim-sns-subscriptions
 /**
@@ -365,10 +368,11 @@ A subscription ARN is the topic's ARN with an opaque id on the end. That is the 
 subscription: `Unsubscribe`, `GetSubscriptionAttributes` and `SetSubscriptionAttributes` all name one
 by it.
 
-The endpoint has to be an ARN of the kind the protocol implies, and it is checked when the
-subscription is made: a queue ARN over the `lambda` protocol is refused, as it is on real SNS. A
-qualified function ARN naming a version or an alias is refused too, since simulated Lambda has
-neither and subscribing `$LATEST` instead would be a different function from the one asked for.
+The endpoint has to be what the protocol implies, and it is checked when the subscription is made. A
+queue ARN over the `lambda` protocol is refused, as it is on real SNS, and so is an `sms` endpoint
+outside E.164. A qualified function ARN naming a version or an alias is refused too, since simulated
+Lambda has neither and subscribing `$LATEST` instead would be a different function from the one asked
+for.
 
 Subscribing the same endpoint to the same topic twice answers with the subscription that is already
 there rather than making a second one, as real SNS does. The attributes the repeated request carries
@@ -388,11 +392,11 @@ topic recreated under the same name starts with none.
 
 `GetTopicAttributes` counts the topic's subscriptions in `SubscriptionsConfirmed`, and counts the
 ones that have been unsubscribed in `SubscriptionsDeleted`. `SubscriptionsPending` is always zero,
-because neither protocol simulated needs a confirmation.
+because no protocol simulated needs a confirmation.
 
-Only the `sqs` and `lambda` protocols are simulated. Every other protocol real SNS has is refused by
-name at `Subscribe` time with the reason it is missing, rather than creating a subscription that
-would never be delivered to.
+Only the `sqs`, `lambda` and `sms` protocols are simulated. Every other protocol real SNS has is
+refused by name at `Subscribe` time with the reason it is missing, rather than creating a
+subscription that would never be delivered to.
 
 ## Delivering to a queue
 
@@ -668,6 +672,84 @@ envelope leaves both out.
 
 `RawMessageDelivery` has no effect on a `lambda` subscription. Real SNS treats it as an SQS and HTTP
 setting, so a function is invoked with the whole event whether it is set or not.
+
+## Texting a subscribed number
+
+Subscribing a phone number with the `sms` protocol records one SMS per published message the
+subscription accepts. The records are the ones `sentSmsMessages()` reads back, alongside those a
+publish straight to a `PhoneNumber` leaves.
+
+```typescript sim-sns-sms-subscription
+/**
+ * Fanning a published message out to a subscribed phone number.
+ */
+
+import {
+  CreateTopicCommand,
+  PublishCommand,
+  SubscribeCommand,
+} from "@aws-sdk/client-sns";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const sns = simAws.sns();
+
+const { TopicArn } = await sns.createTopic(
+  new CreateTopicCommand({ Name: "alerts" }),
+);
+
+// An sms subscription needs no confirmation either, so the ARN comes back at
+// once.
+const { SubscriptionArn } = await sns.subscribe(
+  new SubscribeCommand({
+    TopicArn,
+    Protocol: "sms",
+    Endpoint: "+15550100",
+    Attributes: { FilterPolicy: JSON.stringify({ severity: ["high"] }) },
+  }),
+);
+
+await sns.publish(
+  new PublishCommand({
+    TopicArn,
+    Subject: "Disk usage",
+    Message: "Disk full",
+    MessageAttributes: {
+      severity: { DataType: "String", StringValue: "high" },
+    },
+  }),
+);
+
+// A topic delivers after the publish has been answered, as it does on real
+// SNS.
+await simAws.backgroundTasksComplete();
+
+const [sms] = sns.sentSmsMessages();
+
+console.log(sms?.phoneNumber); // "+15550100"
+console.log(sms?.message); // "Disk full"
+console.log(sms?.topicArn === TopicArn); // true
+console.log(sms?.subscriptionArn === SubscriptionArn); // true
+console.log(sms?.suppressed); // false
+```
+
+The recorded body is the message as it was published. A handset receives the text on its own, so the
+SNS envelope a queue receives and the `Subject` an email carries are both left off.
+
+Each record names the topic and the subscription that produced it, in `topicArn` and
+`subscriptionArn`. A record from a publish straight to a phone number leaves both undefined. That is
+how a test tells one kind of send from the other. The `messageId` is the one the publish was answered
+with, so every SMS one publish fanned out carries it.
+
+A filter policy applies to an `sms` subscription the way it applies to any other. The number receives
+the messages its own policy accepts, and the rest of the topic's subscriptions are unaffected.
+
+A subscribed number on the opt-out list has its message recorded as `suppressed`, and the publish
+still succeeds. The topic's other subscriptions receive theirs. `optOutPhoneNumber` on the service is
+what puts a number on the list, under [sending an SMS](#sending-an-sms).
+
+`Unsubscribe` stops the texting. A message published afterwards leaves no record for that number.
 
 ## Filtering what a subscription receives
 
@@ -1428,8 +1510,8 @@ an SDK caller would get: the same name validation, the same attributes, the same
 `Publish` or `Subscribe`. `Fn::GetAtt … TopicArn` gives the same string, and `Fn::GetAtt … TopicName`
 gives the name without the account and region around it.
 
-`AWS::SNS::Subscription` subscribes through `Subscribe`, so its `Protocol` has to be one of the two
-simulated and its `Endpoint` has to be an ARN that protocol can reach. `RawMessageDelivery`,
+`AWS::SNS::Subscription` subscribes through `Subscribe`, so its `Protocol` has to be one of the three
+simulated and its `Endpoint` has to be something that protocol can reach. `RawMessageDelivery`,
 `FilterPolicy` and `FilterPolicyScope` are carried through as subscription attributes, so a filter
 policy written in a template is read exactly as one set through the SDK. The policy is an object in
 the template where the API takes a JSON string; the conversion happens on the way in. `Ref` on the
@@ -1600,7 +1682,7 @@ Sim SNS currently supports:
 - The phone number opt-out list, with `CheckIfPhoneNumberIsOptedOutCommand`,
   `ListPhoneNumbersOptedOutCommand` and `OptInPhoneNumberCommand`, and `optOutPhoneNumber()` standing
   in for a recipient replying STOP
-- `SubscribeCommand` over the `sqs` and `lambda` protocols, confirmed at once, and
+- `SubscribeCommand` over the `sqs`, `lambda` and `sms` protocols, confirmed at once, and
   `UnsubscribeCommand`
 - `ListSubscriptionsCommand` and `ListSubscriptionsByTopicCommand`, paged at a hundred subscriptions
   with a `NextToken`
@@ -1612,6 +1694,8 @@ Sim SNS currently supports:
   another region, authorized by that queue's own policy on every message
 - Invocation of every subscribed Lambda function, including a function in another account or another
   region, authorized by that function's own resource policy on every message
+- An SMS recorded for every subscribed phone number, carrying the topic ARN and the subscription ARN
+  that produced it, and marked `suppressed` for a number on the opt-out list
 - The SNS envelope, with a real RSA signature a verifier can check against the certificate the
   message names, and `RawMessageDelivery` for the published message on its own
 - The SNS Lambda event, with one `Records` entry per published message and the message attributes in
@@ -1631,9 +1715,9 @@ Sim SNS currently supports:
 
 Current documented limitations:
 
-- Only the `sqs` and `lambda` subscription protocols are simulated, so a queue and a function are the
-  only things a topic can deliver to. `http`, `https`, `email`, `email-json`, `sms`, `application`
-  and `firehose` are refused at `Subscribe` time.
+- Only the `sqs`, `lambda` and `sms` subscription protocols are simulated, so a queue, a function and
+  a phone number are the only things a topic can deliver to. `http`, `https`, `email`, `email-json`,
+  `application` and `firehose` are refused at `Subscribe` time.
 - A subscribed function is invoked with `Subject: null` and `MessageAttributes: {}` where the publish
   had neither, which is what real SNS sends. The envelope a queue receives leaves both fields out.
 - `RawMessageDelivery` is accepted on a `lambda` subscription and has no effect on it, as it has none
@@ -1653,8 +1737,8 @@ Current documented limitations:
 - Delivery retry policies, subscription dead-letter queues and delivery status logging are not
   simulated, so a message an endpoint would not take is delivered once and recorded as a failure
   rather than retried.
-- `ConfirmSubscription` is not supported. Neither protocol simulated needs a confirmation, so there
-  is no confirmation token to confirm.
+- `ConfirmSubscription` is not supported. No protocol simulated needs a confirmation, so there is no
+  confirmation token to confirm.
 - The `cidr` filter policy operator is not simulated. A policy holding one is refused when it is set,
   naming the operator, rather than accepted and then matching nothing.
 - A filter policy is reported back as the string it was set with. Real SNS re-serialises the
@@ -1721,8 +1805,7 @@ Current documented limitations:
 - Delivery status logging writes to CloudWatch Logs, which is not simulated, so the feedback role and
   sample rate attributes are refused.
 - Platform applications and endpoints, and subscribing over `http`, `https`, `email`, `email-json`,
-  `sms`, `application` and `firehose`, are not supported. An SMS is reached by publishing to a phone
-  number, not yet by subscribing one to a topic.
+  `application` and `firehose`, are not supported.
 - SNS condition keys such as `sns:Endpoint` and `sns:Protocol` are not derived, so a policy relying on
   them will not match. Ordinary condition operators on values sim IAM does supply work as usual.
 - `FifoTopic: false` in a template fails the resource rather than deploying a standard topic. It is

--- a/docs/services/sns/sim-sns-sms-subscription.example.ts
+++ b/docs/services/sns/sim-sns-sms-subscription.example.ts
@@ -1,0 +1,52 @@
+/**
+ * Fanning a published message out to a subscribed phone number.
+ */
+
+import {
+  CreateTopicCommand,
+  PublishCommand,
+  SubscribeCommand,
+} from "@aws-sdk/client-sns";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const sns = simAws.sns();
+
+const { TopicArn } = await sns.createTopic(
+  new CreateTopicCommand({ Name: "alerts" }),
+);
+
+// An sms subscription needs no confirmation either, so the ARN comes back at
+// once.
+const { SubscriptionArn } = await sns.subscribe(
+  new SubscribeCommand({
+    TopicArn,
+    Protocol: "sms",
+    Endpoint: "+15550100",
+    Attributes: { FilterPolicy: JSON.stringify({ severity: ["high"] }) },
+  }),
+);
+
+await sns.publish(
+  new PublishCommand({
+    TopicArn,
+    Subject: "Disk usage",
+    Message: "Disk full",
+    MessageAttributes: {
+      severity: { DataType: "String", StringValue: "high" },
+    },
+  }),
+);
+
+// A topic delivers after the publish has been answered, as it does on real
+// SNS.
+await simAws.backgroundTasksComplete();
+
+const [sms] = sns.sentSmsMessages();
+
+console.log(sms?.phoneNumber); // "+15550100"
+console.log(sms?.message); // "Disk full"
+console.log(sms?.topicArn === TopicArn); // true
+console.log(sms?.subscriptionArn === SubscriptionArn); // true
+console.log(sms?.suppressed); // false

--- a/src/service/aws/factory/sim-aws-account-region-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-account-region-service-builder.ts
@@ -28,7 +28,7 @@ import { simAwsEcsCollaborators } from "./sim-aws-ecs-collaborators.js";
 import { simAwsLambdaCollaborators } from "./sim-aws-lambda-collaborators.js";
 import { simAwsS3NotificationDestinations } from "./sim-aws-s3-notification-destinations.js";
 import { SimSns } from "../../sns/index.js";
-import { SimAwsSnsDeliveryEndpoints } from "../../sns/delivery/sim-aws-sns-delivery-endpoints.js";
+import { simAwsSnsDeliveryEndpoints } from "../../sns/delivery/sim-aws-sns-delivery-endpoints.js";
 import { SimSts } from "../../sts/sim-sts.js";
 import type { SimAwsAccountServiceCache } from "./sim-aws-account-service-cache.js";
 import type { SimAwsScopedServiceProperties } from "./sim-aws-scoped-service-properties.js";
@@ -210,7 +210,7 @@ export class SimAwsAccountRegionServiceBuilder {
    * and are resolved on delivery rather than here.
    */
   createSns(scope: SimAwsAccountRegionContainer): SimSns {
-    const endpoints = new SimAwsSnsDeliveryEndpoints({ simAws: this.simAws });
+    const endpoints = simAwsSnsDeliveryEndpoints({ simAws: this.simAws });
 
     return new SimSns({ ...this.scoped(scope), deliveryEndpoints: endpoints });
   }

--- a/src/service/sns/README.md
+++ b/src/service/sns/README.md
@@ -59,13 +59,15 @@ Subscription state lives under `subscription/`.
 
 `SimSnsSubscription` is the stored resource: its ARN, the topic it belongs to, its protocol, its
 endpoint, the Account owning it, and its attributes. The endpoint is held as a
-`SimSnsSubscriptionEndpoint` rather than as a string, because a delivery reaches the Account and
-Region that ARN names rather than the topic's. Which kind of ARN it has to be is the protocol's
-question, answered by `requireSimSnsSubscriptionEndpoint`: `SimSnsQueueEndpointArn` for `sqs`, and
-`SimSnsFunctionEndpointArn` for `lambda`. Reading a function ARN is Lambda's own business, so those
-parts come from `parseSimLambdaFunctionArn`; what SNS adds is what an unreadable one means to a
-`Subscribe` request. A qualified function ARN naming a version or an alias is refused, since
-simulated Lambda has neither and delivering to `$LATEST` instead would be the wrong function.
+`SimSnsSubscriptionEndpoint` rather than as a string, because a delivery over an ARN endpoint reaches
+the Account and Region that ARN names rather than the topic's. What the endpoint has to be is the
+protocol's question, answered by `requireSimSnsSubscriptionEndpoint`: `SimSnsQueueEndpointArn` for
+`sqs`, `SimSnsFunctionEndpointArn` for `lambda`, and `SimSnsPhoneNumber` for `sms`. The Account and
+the Region are optional on the endpoint, since an `sms` endpoint is a phone number. Reading a function
+ARN is Lambda's own business, so those parts come from `parseSimLambdaFunctionArn`; what SNS adds is
+what an unreadable one means to a `Subscribe` request. A qualified function ARN naming a version or
+an alias is refused, since simulated Lambda has neither and delivering to `$LATEST` instead would be
+the wrong function.
 
 Nothing checks that the endpoint queue or function exists when a subscription is created, because
 real SNS does not either: a subscription to something that is not there is created, and fails when
@@ -77,11 +79,12 @@ delivery.
 and `parseSnsSubscriptionArn` reads one. Counting the colon separated parts is what tells a
 subscription ARN from a topic ARN, since neither has a resource type separator.
 
-`SimSnsSubscriptionProtocol` holds the two protocols delivery is simulated over, `sqs` and `lambda`.
-Neither needs a confirmation, which is why `ConfirmSubscription` is not implemented. Every other
+`SimSnsSubscriptionProtocol` holds the three protocols delivery is simulated over, `sqs`, `lambda`
+and `sms`. None needs a confirmation, so `ConfirmSubscription` is not implemented. Every other
 protocol real SNS has is refused by name with the reason it is missing, rather than accepted as a
 subscription that would never be delivered to. A protocol real SNS does not have at all is refused
-the way real SNS refuses one.
+the way real SNS refuses one. `SimSnsOutwardProtocol` is the subset whose delivery leaves simulated
+SNS, and the endpoints supplied from outside cover those.
 
 `SimSnsSubscriptionAttributes` holds `RawMessageDelivery`, the subscription's filter policy and the
 scope that policy is read under, and `SimSnsSubscriptionAttributeNames` is where the refusal of the
@@ -243,7 +246,21 @@ what a destination is asked before it takes a message and what it is handed both
 a second protocol adds a second implementation rather than a branch in an existing one.
 `SimSnsProtocolDeliveryEndpoints` picks between them by the subscription's protocol, holding them in
 a record keyed by the protocol union so that adding a protocol without somewhere to deliver fails to
-compile. `SimAwsSnsDeliveryEndpoints` is that set for one simulated AWS instance.
+compile.
+
+The record is assembled in two halves. `simAwsSnsDeliveryEndpoints` is the outward half for one
+simulated AWS instance, covering the protocols that reach another simulated service, and it is handed
+to `SimSns` from outside because a queue or a function is only reachable through `SimAws`.
+`simSnsNoDeliveryEndpoints` is the outward half of a `SimSns` built on its own, which refuses every
+delivery and records the refusal as a delivery failure. `SimSnsCommands` fills in `sms` itself, with
+`SimSnsDeliverySms`, since an SMS reaches nothing outside simulated SNS. That is also why a
+standalone `SimSns` still texts a subscribed number.
+
+`SimSnsDeliverySms` records the message on the same `SimSnsSentSmsStore` a publish to a phone number
+records on, so `sentSmsMessages()` reads both. It keeps the published message's own id, the topic ARN
+and the subscription ARN, and asks the opt-out list whether the message would have arrived. The body
+is the message as it was published. A handset receives the text on its own, and the envelope and the
+subject belong to the protocols that carry them.
 
 `SimAwsSnsDeliveryQueues` and `SimAwsSnsDeliveryFunctions` resolve the endpoint when a message is
 delivered, never when they are built, for the same reason S3's notification destinations do it that
@@ -421,9 +438,9 @@ here, it does not make another Account's topics reachable through this one.
 
 ## Divergences worth knowing
 
-- Only the `sqs` and `lambda` subscription protocols are simulated, so a queue and a function are the
-  only things a topic delivers to. `ConfirmSubscription` is not implemented, since neither protocol
-  needs a confirmation.
+- Only the `sqs`, `lambda` and `sms` subscription protocols are simulated, so a queue, a function and
+  a phone number are the only things a topic delivers to. `ConfirmSubscription` is not implemented,
+  since no protocol needs a confirmation.
 - A Lambda event carries `Subject: null` and `MessageAttributes: {}` where there is nothing to put in
   either, which is what real SNS sends. The envelope a queue receives leaves both fields out instead.
 - `RawMessageDelivery` is accepted on a `lambda` subscription and has no effect on it, as it has none
@@ -458,8 +475,8 @@ here, it does not make another Account's topics reachable through this one.
   set, since the scope only says how a policy is read.
 - `GetTopicAttributes` reports `TopicArn`, `Owner`, `DisplayName`, the three subscription counts and
   `Policy` when one is set. `EffectiveDeliveryPolicy` and `DeliveryPolicy` are left out, since
-  delivery retry policies are not simulated. `SubscriptionsPending` is always zero, because the one
-  protocol simulated needs no confirmation.
+  delivery retry policies are not simulated. `SubscriptionsPending` is always zero, because no
+  protocol simulated needs a confirmation.
 - Tags, data protection policies and encryption are refused rather than ignored, whether by
   `CreateTopic` or by `SetTopicAttributes`.
 - `MessageStructure` is refused, because a `json` structure picks a different body per protocol and

--- a/src/service/sns/cfn/sim-cfn-sns-sms-subscription.iso.test.ts
+++ b/src/service/sns/cfn/sim-cfn-sns-sms-subscription.iso.test.ts
@@ -1,0 +1,93 @@
+import { PublishCommand } from "@aws-sdk/client-sns";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnTemplateValue } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+const onCall = "+15550100";
+
+const ordersTopicArn = "arn:aws:sns:us-east-1:888888888888:orders";
+
+/**
+ * Deploy a template holding the Resources, then publish one alert to the topic
+ * it created.
+ */
+async function deployAndAlert(
+  resources: Record<string, SimCfnTemplateValue>,
+): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simAws.cloudFormation().deployTemplate({
+    stackName: "alerts-stack",
+    template: { Resources: resources },
+  });
+
+  await simAws.sns().publish(
+    new PublishCommand({
+      TopicArn: ordersTopicArn,
+      Message: "Disk full",
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+
+  return simAws;
+}
+
+describe("SNS CloudFormation sms Subscription deployment", () => {
+  it("texts the number an AWS::SNS::Subscription names", async () => {
+    // Given a template subscribing a phone number to a topic as its own
+    // Resource, the way CDK emits a subscription.
+    const simAws = await deployAndAlert({
+      OrdersTopic: {
+        Type: "AWS::SNS::Topic",
+        Properties: { TopicName: "orders" },
+      },
+      OnCallSubscription: {
+        Type: "AWS::SNS::Subscription",
+        Properties: {
+          TopicArn: { Ref: "OrdersTopic" },
+          Protocol: "sms",
+          Endpoint: onCall,
+        },
+      },
+    });
+
+    // Then the published message was texted to it, naming the subscription the
+    // template created.
+    const [sms] = simAws.sns().sentSmsMessages();
+    const [subscription] = simAws.sns().topicSubscriptions("orders");
+
+    assertNonNullable(sms);
+    assertNonNullable(subscription);
+    assertIdentical(sms.phoneNumber, onCall);
+    assertIdentical(sms.message, "Disk full");
+    assertIdentical(sms.subscriptionArn, subscription.arn.value);
+  });
+
+  it("texts the number a topic subscribes inline", async () => {
+    // Given a template using the Subscription property of the topic rather
+    // than a Resource of its own.
+    const simAws = await deployAndAlert({
+      OrdersTopic: {
+        Type: "AWS::SNS::Topic",
+        Properties: {
+          TopicName: "orders",
+          Subscription: [{ Protocol: "sms", Endpoint: onCall }],
+        },
+      },
+    });
+
+    // Then the inline subscription is there and was texted.
+    assertArrayLength(simAws.sns().topicSubscriptions("orders"), 1);
+
+    const [sms] = simAws.sns().sentSmsMessages();
+
+    assertIdentical(sms?.phoneNumber, onCall);
+    assertIdentical(sms.topicArn, ordersTopicArn);
+  });
+});

--- a/src/service/sns/cfn/sim-cfn-sns-validation.iso.test.ts
+++ b/src/service/sns/cfn/sim-cfn-sns-validation.iso.test.ts
@@ -220,7 +220,7 @@ describe("AWS::SNS::Subscription validation", () => {
 
   it("leaves an absent Endpoint to Subscribe to refuse", async () => {
     // Given a subscription with no Endpoint. Real CloudFormation leaves the
-    // property optional, because a protocol such as sms carries the
+    // property optional, because a protocol such as application carries the
     // destination elsewhere, so the refusal belongs to the protocol.
     const error = await deploySubscription({ Protocol: "sqs" });
 
@@ -229,6 +229,22 @@ describe("AWS::SNS::Subscription validation", () => {
       "Invalid AWS::SNS::Subscription Resource FulfilmentSubscription",
     );
     assertStringIncludes(error.message, "Endpoint");
+  });
+
+  it("fails an sms subscription whose Endpoint is not a phone number", async () => {
+    // Given a template texting something that is not an E.164 number.
+    const error = await deploySubscription({
+      Protocol: "sms",
+      Endpoint: "555-0100",
+    });
+
+    // Then the Resource is invalid rather than deployed as a subscription that
+    // would text nobody.
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::SNS::Subscription Resource FulfilmentSubscription",
+    );
+    assertStringIncludes(error.message, "is not an E.164 phone number");
   });
 
   it("fails a subscription whose Endpoint is not a string", async () => {

--- a/src/service/sns/cfn/subscription/sim-cfn-sns-subscription-properties.ts
+++ b/src/service/sns/cfn/subscription/sim-cfn-sns-subscription-properties.ts
@@ -56,9 +56,10 @@ export class SimCfnSnsSubscriptionProperties {
   /**
    * What the subscription delivers to.
    *
-   * Real CloudFormation leaves it optional, because a protocol such as `sms`
-   * carries the destination elsewhere. Neither protocol simulated here is one
-   * of those, so an absent endpoint is refused by Subscribe rather than here.
+   * Real CloudFormation leaves it optional, because a protocol such as
+   * `application` carries the destination elsewhere. No protocol simulated here
+   * is one of those, so an absent endpoint is refused by Subscribe rather than
+   * here.
    */
   private endpoint(): string | undefined {
     const endpoint = this.properties.get(subscriptionEndpointPropertyName);

--- a/src/service/sns/cfn/subscription/sim-cfn-sns-subscription-property-names.ts
+++ b/src/service/sns/cfn/subscription/sim-cfn-sns-subscription-property-names.ts
@@ -9,8 +9,8 @@ export const subscriptionTopicArnPropertyName = "TopicArn";
 export const subscriptionProtocolPropertyName = "Protocol";
 
 /**
- * What the subscription is delivered to, which is a queue ARN or a function
- * ARN for the two protocols simulated.
+ * What the subscription is delivered to, which is a queue ARN, a function ARN
+ * or a phone number for the three protocols simulated.
  */
 export const subscriptionEndpointPropertyName = "Endpoint";
 

--- a/src/service/sns/command/sim-sns-commands.ts
+++ b/src/service/sns/command/sim-sns-commands.ts
@@ -1,9 +1,13 @@
 import type { BackgroundScheduler } from "../../../util/background/background.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
-import type { SimSnsDeliveryEndpoints } from "../delivery/sim-sns-delivery.js";
 import { SimSnsDeliveryRequests } from "../delivery/sim-sns-delivery-request.js";
 import { SimSnsFanOut } from "../delivery/sim-sns-fan-out.js";
+import {
+  type SimSnsOutwardDeliveryEndpoints,
+  SimSnsProtocolDeliveryEndpoints,
+} from "../delivery/sim-sns-protocol-delivery-endpoints.js";
+import { SimSnsDeliverySms } from "../delivery/sms/sim-sns-delivery-sms.js";
 import { SimSnsMessageSigner } from "../signature/sim-sns-message-signer.js";
 import type { SimSnsSubscriptionStore } from "../subscription/sim-sns-subscription-store.js";
 import type { SimSnsTopicStore } from "../topic/sim-sns-topic-store.js";
@@ -28,7 +32,7 @@ interface SimSnsCommandsProperties {
   readonly subscriptions: SimSnsSubscriptionStore;
   readonly iam: SimIamInterServiceAuthZ;
   readonly background: BackgroundScheduler;
-  readonly deliveryEndpoints: SimSnsDeliveryEndpoints;
+  readonly deliveryEndpoints: SimSnsOutwardDeliveryEndpoints;
   readonly accountRegionScope: SimAwsAccountRegionScope;
 }
 
@@ -75,7 +79,18 @@ export class SimSnsCommands {
     this.signer = new SimSnsMessageSigner({ accountRegionScope });
     this.fanOut = new SimSnsFanOut({
       subscriptions,
-      endpoints: properties.deliveryEndpoints,
+      // The protocols reaching another service are supplied from outside, and
+      // the one that reaches nothing is filled in here, where the store it
+      // records on lives.
+      endpoints: new SimSnsProtocolDeliveryEndpoints({
+        byProtocol: {
+          ...properties.deliveryEndpoints,
+          sms: new SimSnsDeliverySms({
+            optOutList: this.optOutList,
+            sent: this.sentSms,
+          }),
+        },
+      }),
       requests: new SimSnsDeliveryRequests({
         signer: this.signer,
         accountRegionScope,

--- a/src/service/sns/command/subscription/sim-sns-subscribe-validation.iso.test.ts
+++ b/src/service/sns/command/subscription/sim-sns-subscribe-validation.iso.test.ts
@@ -2,7 +2,9 @@ import { assertInstanceOf, assertStringIncludes } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import {
   endpointRefusal,
+  phoneNumberRefusal,
   protocolRefusal,
+  simSnsEndpointsThatAreNotPhoneNumbers,
   simSnsEndpointsThatAreNotQueues,
   simSnsUnsimulatedProtocols,
 } from "../../../../../test/sns/subscription-fixture.js";
@@ -65,6 +67,24 @@ describe("SNS Subscribe validation", () => {
     for (const error of refusals) {
       assertInstanceOf(error, SimSnsInvalidParameterException);
       assertStringIncludes(error.message, "is not an SQS queue ARN");
+    }
+  });
+
+  it("refuses an endpoint that is not an E.164 phone number", async () => {
+    // Given a topic.
+    // When the sms protocol is given something else as its endpoint, including
+    // no endpoint at all.
+    const refusals = await Promise.all(
+      [...simSnsEndpointsThatAreNotPhoneNumbers, undefined].map(
+        async (endpoint) => phoneNumberRefusal(endpoint),
+      ),
+    );
+
+    // Then each is refused, since an sms subscription texts a phone number and
+    // real SNS takes those in E.164 only.
+    for (const error of refusals) {
+      assertInstanceOf(error, SimSnsInvalidParameterException);
+      assertStringIncludes(error.message, "is not an E.164 phone number");
     }
   });
 

--- a/src/service/sns/command/subscription/sim-sns-subscribe.iso.test.ts
+++ b/src/service/sns/command/subscription/sim-sns-subscribe.iso.test.ts
@@ -81,6 +81,42 @@ describe("SNS Subscribe", () => {
     });
   });
 
+  it("confirms an sms subscription at once and reports the number", async () => {
+    // Given a topic.
+    const { simAws, topicArn } = await simAwsWithTopic();
+
+    // When a phone number is subscribed to it.
+    const subscribed = await simAws.sns().subscribe(
+      new SubscribeCommand({
+        TopicArn: topicArn,
+        Protocol: "sms",
+        Endpoint: "+15550100",
+      }),
+    );
+
+    // Then the answer is a subscription ARN, as it is for a queue: the number
+    // is the endpoint, so real SNS has nothing to confirm either.
+    assertNonNullable(subscribed.SubscriptionArn);
+    assertStringIncludes(
+      subscribed.SubscriptionArn,
+      `${simSnsOrdersTopicArn}:`,
+    );
+
+    // And the subscription reports where it texts.
+    const read = await simAws.sns().getSubscriptionAttributes(
+      new GetSubscriptionAttributesCommand({
+        SubscriptionArn: subscribed.SubscriptionArn,
+      }),
+    );
+
+    assertNonNullable(read.Attributes);
+    assertObjectMatches(read.Attributes, {
+      Protocol: "sms",
+      Endpoint: "+15550100",
+      PendingConfirmation: "false",
+    });
+  });
+
   it("takes RawMessageDelivery on the Subscribe request", async () => {
     // Given a topic.
     const { simAws, topicArn } = await simAwsWithTopic();

--- a/src/service/sns/delivery/sim-aws-sns-delivery-endpoints.ts
+++ b/src/service/sns/delivery/sim-aws-sns-delivery-endpoints.ts
@@ -1,6 +1,6 @@
 import type { SimAws } from "../../aws/sim-aws.js";
 import { SimAwsSnsDeliveryFunctions } from "./lambda/sim-aws-sns-delivery-functions.js";
-import { SimSnsProtocolDeliveryEndpoints } from "./sim-sns-protocol-delivery-endpoints.js";
+import type { SimSnsOutwardDeliveryEndpoints } from "./sim-sns-protocol-delivery-endpoints.js";
 import { SimAwsSnsDeliveryQueues } from "./sqs/sim-aws-sns-delivery-queues.js";
 
 interface SimAwsSnsDeliveryEndpointsProperties {
@@ -8,19 +8,18 @@ interface SimAwsSnsDeliveryEndpointsProperties {
 }
 
 /**
- * Everywhere the topics of one simulated AWS instance can deliver.
+ * Everywhere outside itself the topics of one simulated AWS instance deliver.
  *
  * Which protocols are simulated is a fact about simulated SNS rather than about
  * the service builder that hands it its endpoints, so the set is assembled
- * here.
+ * here. The `sms` protocol is not one of them: an SMS never leaves simulated
+ * SNS, which fills that one in itself.
  */
-export class SimAwsSnsDeliveryEndpoints extends SimSnsProtocolDeliveryEndpoints {
-  constructor(properties: SimAwsSnsDeliveryEndpointsProperties) {
-    super({
-      byProtocol: {
-        sqs: new SimAwsSnsDeliveryQueues(properties),
-        lambda: new SimAwsSnsDeliveryFunctions(properties),
-      },
-    });
-  }
+export function simAwsSnsDeliveryEndpoints(
+  properties: SimAwsSnsDeliveryEndpointsProperties,
+): SimSnsOutwardDeliveryEndpoints {
+  return {
+    sqs: new SimAwsSnsDeliveryQueues(properties),
+    lambda: new SimAwsSnsDeliveryFunctions(properties),
+  };
 }

--- a/src/service/sns/delivery/sim-sns-no-delivery-endpoints.ts
+++ b/src/service/sns/delivery/sim-sns-no-delivery-endpoints.ts
@@ -3,9 +3,10 @@ import type {
   SimSnsDeliveryEndpoints,
   SimSnsDeliveryRequest,
 } from "./sim-sns-delivery.js";
+import type { SimSnsOutwardDeliveryEndpoints } from "./sim-sns-protocol-delivery-endpoints.js";
 
 /**
- * The endpoints a simulated SNS built on its own can reach, which is none.
+ * A protocol whose destination a simulated SNS built on its own cannot reach.
  *
  * A standalone SimSns has no other simulated services to reach, and owns its
  * own background scheduler, so nothing could wait for a delivery it made even
@@ -13,7 +14,7 @@ import type {
  * nothing but SNS: it is delivery that is refused, and the refusal is recorded
  * as a delivery failure like any other.
  */
-export class SimSnsNoDeliveryEndpoints implements SimSnsDeliveryEndpoints {
+class SimSnsUnreachableEndpoint implements SimSnsDeliveryEndpoints {
   /**
    * Refuse every delivery, explaining how to get one.
    */
@@ -26,4 +27,17 @@ export class SimSnsNoDeliveryEndpoints implements SimSnsDeliveryEndpoints {
         "queue or a function.",
     );
   }
+}
+
+/**
+ * The endpoints outside itself a simulated SNS built on its own can reach,
+ * which is none.
+ *
+ * An `sms` subscription is unaffected, since simulated SNS records those itself
+ * rather than reaching anything.
+ */
+export function simSnsNoDeliveryEndpoints(): SimSnsOutwardDeliveryEndpoints {
+  const unreachable = new SimSnsUnreachableEndpoint();
+
+  return { sqs: unreachable, lambda: unreachable };
 }

--- a/src/service/sns/delivery/sim-sns-protocol-delivery-endpoints.ts
+++ b/src/service/sns/delivery/sim-sns-protocol-delivery-endpoints.ts
@@ -1,4 +1,7 @@
-import type { SimSnsSubscriptionProtocol } from "../subscription/sim-sns-subscription-protocol.js";
+import type {
+  SimSnsOutwardProtocol,
+  SimSnsSubscriptionProtocol,
+} from "../subscription/sim-sns-subscription-protocol.js";
 import type {
   SimSnsDeliveryEndpoints,
   SimSnsDeliveryRequest,
@@ -13,6 +16,18 @@ import type {
  */
 type SimSnsEndpointsByProtocol = Readonly<
   Record<SimSnsSubscriptionProtocol, SimSnsDeliveryEndpoints>
+>;
+
+/**
+ * The endpoints a simulated SNS is handed from outside.
+ *
+ * These are the protocols delivering to another simulated service, which is
+ * only reachable through `SimAws`. Simulated SNS fills in the rest itself: an
+ * SMS is recorded here rather than delivered anywhere, so nothing outside has
+ * anything to supply for it.
+ */
+export type SimSnsOutwardDeliveryEndpoints = Readonly<
+  Record<SimSnsOutwardProtocol, SimSnsDeliveryEndpoints>
 >;
 
 interface SimSnsProtocolDeliveryEndpointsProperties {

--- a/src/service/sns/delivery/sms/sim-sns-delivery-sms.ts
+++ b/src/service/sns/delivery/sms/sim-sns-delivery-sms.ts
@@ -1,0 +1,65 @@
+import type { SimSnsOptOutList } from "../../sms/sim-sns-opt-out-list.js";
+import { SimSnsPhoneNumber } from "../../sms/sim-sns-phone-number.js";
+import { SimSnsSentSmsMessage } from "../../sms/sim-sns-sent-sms-message.js";
+import type { SimSnsSentSmsStore } from "../../sms/sim-sns-sent-sms-store.js";
+import type {
+  SimSnsDeliveryEndpoints,
+  SimSnsDeliveryRequest,
+} from "../sim-sns-delivery.js";
+
+interface SimSnsDeliverySmsProperties {
+  readonly optOutList: SimSnsOptOutList;
+  readonly sent: SimSnsSentSmsStore;
+}
+
+/**
+ * The phone numbers a topic delivers to, which are simulated SNS's own.
+ *
+ * A queue or a function is another simulated service, so where those deliver is
+ * handed to simulated SNS from outside. An SMS reaches no service at all: it is
+ * recorded on the same store a publish straight to a phone number records on,
+ * so a test reads both through `sentSmsMessages()`.
+ */
+export class SimSnsDeliverySms implements SimSnsDeliveryEndpoints {
+  private readonly optOutList: SimSnsOptOutList;
+  private readonly sent: SimSnsSentSmsStore;
+
+  constructor(properties: SimSnsDeliverySmsProperties) {
+    this.optOutList = properties.optOutList;
+    this.sent = properties.sent;
+  }
+
+  /**
+   * Record one message as an SMS to the number its subscription names.
+   *
+   * The body is the message as it was published. The envelope and the subject
+   * are left off, because a handset receives the text and nothing else: real
+   * SNS sends the envelope to a queue and puts a subject on an email.
+   *
+   * A subscriber on the opt-out list is recorded as suppressed rather than
+   * refused, which is what a publish straight to an opted-out number does. The
+   * publish succeeds and the topic's other subscriptions receive theirs.
+   */
+  deliver(request: SimSnsDeliveryRequest): Promise<void> {
+    const phoneNumber = SimSnsPhoneNumber.of(
+      request.subscription.endpoint.value,
+    );
+
+    this.sent.add(
+      new SimSnsSentSmsMessage({
+        // The published message's id, so every SMS one publish fanned out is
+        // recorded under the id the publisher was answered with.
+        messageId: request.message.messageId,
+        phoneNumber: phoneNumber.value,
+        message: request.message.body.value,
+        attributes: request.message.attributes,
+        suppressed: this.optOutList.isOptedOut(phoneNumber),
+        sentDate: request.message.publishedAt,
+        topicArn: request.subscription.topicArn,
+        subscriptionArn: request.subscription.arn.value,
+      }),
+    );
+
+    return Promise.resolve();
+  }
+}

--- a/src/service/sns/delivery/sms/sim-sns-sms-fan-out.iso.test.ts
+++ b/src/service/sns/delivery/sms/sim-sns-sms-fan-out.iso.test.ts
@@ -1,0 +1,194 @@
+import { PublishCommand, UnsubscribeCommand } from "@aws-sdk/client-sns";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  simSnsDeliveredMessage,
+  simSnsSubscribedQueue,
+  simSnsTextedMessages,
+  subscribePhoneNumber,
+} from "../../../../../test/sns/subscription-fixture.js";
+import { simAwsWithTopic } from "../../../../../test/sns/topic-fixture.js";
+
+/** The numbers the topic texts here. */
+const onCall = "+15550100";
+
+const escalation = "+15550111";
+
+describe("SNS fan-out to a phone number", () => {
+  it("records what a published message would have texted", async () => {
+    // Given a topic with a phone number subscribed to it.
+    const { simAws, topicArn } = await simAwsWithTopic();
+    const subscriptionArn = await subscribePhoneNumber(
+      simAws,
+      topicArn,
+      onCall,
+    );
+
+    // When a message is published to the topic.
+    const published = await simAws.sns().publish(
+      new PublishCommand({
+        TopicArn: topicArn,
+        Subject: "Disk usage",
+        Message: "Disk full",
+      }),
+    );
+
+    // Then the SMS is on the record, naming the topic and the subscription
+    // that produced it. The body is the message as it was published: a handset
+    // receives the text on its own, so the envelope a queue receives and the
+    // subject an email carries are both left off.
+    const [sms] = await simSnsTextedMessages(simAws);
+
+    assertNonNullable(sms);
+    assertIdentical(sms.phoneNumber, onCall);
+    assertIdentical(sms.message, "Disk full");
+    assertIdentical(sms.topicArn, topicArn);
+    assertIdentical(sms.subscriptionArn, subscriptionArn);
+    assertIdentical(sms.messageId, published.MessageId);
+    assertFalse(sms.suppressed);
+  });
+
+  it("texts every number subscribed to the topic", async () => {
+    // Given a topic with two phone numbers subscribed to it.
+    const { simAws, topicArn } = await simAwsWithTopic();
+
+    await subscribePhoneNumber(simAws, topicArn, onCall);
+    await subscribePhoneNumber(simAws, topicArn, escalation);
+
+    // When one message is published.
+    await simAws
+      .sns()
+      .publish(
+        new PublishCommand({ TopicArn: topicArn, Message: "Disk full" }),
+      );
+
+    // Then both numbers were texted, which is what a topic is for.
+    const texted = await simSnsTextedMessages(simAws);
+
+    assertArrayLength(texted, 2);
+    assertIdentical(texted[0].phoneNumber, onCall);
+    assertIdentical(texted[1].phoneNumber, escalation);
+  });
+
+  it("texts a number alongside a queue taking the same message", async () => {
+    // Given a topic notifying both a queue and a phone number, which is the
+    // shape an alerting path has.
+    const { simAws, topicArn } = await simAwsWithTopic();
+    const { queueUrl } = await simSnsSubscribedQueue(
+      simAws,
+      "alerts",
+      topicArn,
+    );
+
+    await subscribePhoneNumber(simAws, topicArn, onCall);
+
+    // When one message is published.
+    await simAws
+      .sns()
+      .publish(
+        new PublishCommand({ TopicArn: topicArn, Message: "Disk full" }),
+      );
+
+    // Then the queue received the envelope and the number was texted the
+    // message on its own.
+    const body = await simSnsDeliveredMessage(simAws, queueUrl);
+
+    assertNonNullable(body);
+    assertIdentical(
+      (JSON.parse(body) as Record<string, unknown>)["Message"],
+      "Disk full",
+    );
+
+    const [sms] = await simSnsTextedMessages(simAws);
+
+    assertIdentical(sms?.message, "Disk full");
+  });
+
+  it("leaves out a number whose filter policy does not want the message", async () => {
+    // Given a topic with one number taking every alert and one taking only the
+    // high severity ones.
+    const { simAws, topicArn } = await simAwsWithTopic();
+
+    await subscribePhoneNumber(simAws, topicArn, onCall);
+    await subscribePhoneNumber(simAws, topicArn, escalation, {
+      FilterPolicy: JSON.stringify({ severity: ["high"] }),
+    });
+
+    // When a message the second one's policy excludes is published.
+    await simAws.sns().publish(
+      new PublishCommand({
+        TopicArn: topicArn,
+        Message: "Disk filling up",
+        MessageAttributes: {
+          severity: { DataType: "String", StringValue: "low" },
+        },
+      }),
+    );
+
+    // Then only the number that wanted it was texted, and the other
+    // subscription's policy had nothing to do with that.
+    const texted = await simSnsTextedMessages(simAws);
+
+    assertArrayLength(texted, 1);
+    assertIdentical(texted[0].phoneNumber, onCall);
+  });
+
+  it("suppresses the SMS to an opted-out number and texts the others", async () => {
+    // Given a topic with two numbers subscribed, one of which has replied
+    // STOP.
+    const { simAws, topicArn } = await simAwsWithTopic();
+
+    await subscribePhoneNumber(simAws, topicArn, onCall);
+    await subscribePhoneNumber(simAws, topicArn, escalation);
+    simAws.sns().optOutPhoneNumber(escalation);
+
+    // When a message is published.
+    const published = await simAws
+      .sns()
+      .publish(
+        new PublishCommand({ TopicArn: topicArn, Message: "Disk full" }),
+      );
+
+    // Then the publish succeeded, as it does on real SNS, the opted-out number
+    // has a record saying nothing arrived, and the other number was texted.
+    assertNonNullable(published.MessageId);
+
+    const [first, second] = await simSnsTextedMessages(simAws);
+
+    assertFalse(first?.suppressed);
+    assertIdentical(second?.phoneNumber, escalation);
+    assertTrue(second.suppressed);
+  });
+
+  it("stops texting once the subscription is gone", async () => {
+    // Given a topic with a subscribed number that is then unsubscribed.
+    const { simAws, topicArn } = await simAwsWithTopic();
+    const subscriptionArn = await subscribePhoneNumber(
+      simAws,
+      topicArn,
+      onCall,
+    );
+
+    await simAws
+      .sns()
+      .unsubscribe(
+        new UnsubscribeCommand({ SubscriptionArn: subscriptionArn }),
+      );
+
+    // When a message is published.
+    await simAws
+      .sns()
+      .publish(
+        new PublishCommand({ TopicArn: topicArn, Message: "Disk full" }),
+      );
+
+    // Then nothing was texted.
+    assertArrayLength(await simSnsTextedMessages(simAws), 0);
+  });
+});

--- a/src/service/sns/index.ts
+++ b/src/service/sns/index.ts
@@ -29,6 +29,8 @@ export {
 } from "./subscription/sim-sns-subscription-attributes.js";
 export {
   simSnsLambdaProtocol,
+  type SimSnsOutwardProtocol,
+  simSnsSmsProtocol,
   simSnsSqsProtocol,
   type SimSnsSubscriptionProtocol,
 } from "./subscription/sim-sns-subscription-protocol.js";
@@ -66,6 +68,7 @@ export {
   type SimSnsDeliveryRequest,
   simSnsServicePrincipal,
 } from "./delivery/sim-sns-delivery.js";
+export type { SimSnsOutwardDeliveryEndpoints } from "./delivery/sim-sns-protocol-delivery-endpoints.js";
 export { SimSnsEnvelope } from "./delivery/sim-sns-envelope.js";
 export {
   SimSnsNotification,

--- a/src/service/sns/sim-sns.ts
+++ b/src/service/sns/sim-sns.ts
@@ -9,9 +9,9 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
-import type { SimSnsDeliveryEndpoints } from "./delivery/sim-sns-delivery.js";
 import type { SimSnsDeliveryFailure } from "./delivery/sim-sns-delivery-failures.js";
-import { SimSnsNoDeliveryEndpoints } from "./delivery/sim-sns-no-delivery-endpoints.js";
+import { simSnsNoDeliveryEndpoints } from "./delivery/sim-sns-no-delivery-endpoints.js";
+import type { SimSnsOutwardDeliveryEndpoints } from "./delivery/sim-sns-protocol-delivery-endpoints.js";
 import type * as simSnsCommands from "./command/sim-sns-command.types.js";
 import { SimSnsCommands } from "./command/sim-sns-commands.js";
 import type { SimSnsRequestOptions } from "./command/sim-sns-request-options.js";
@@ -29,12 +29,13 @@ interface SimSnsProperties {
   readonly background?: BackgroundScheduler;
 
   /**
-   * Where this scope's subscriptions deliver to.
+   * Where this scope's subscriptions deliver to, outside simulated SNS itself.
    *
    * A SimSns built on its own has none, since a queue or a function in another
-   * simulated service is only reachable through SimAws.
+   * simulated service is only reachable through SimAws. An `sms` subscription
+   * needs nothing here, because simulated SNS records those itself.
    */
-  readonly deliveryEndpoints?: SimSnsDeliveryEndpoints;
+  readonly deliveryEndpoints?: SimSnsOutwardDeliveryEndpoints;
 }
 
 /**
@@ -57,7 +58,7 @@ export class SimSns extends SimSnsSms {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
       iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
-      deliveryEndpoints = new SimSnsNoDeliveryEndpoints(),
+      deliveryEndpoints = simSnsNoDeliveryEndpoints(),
     } = properties;
     const topics = new SimSnsTopicStore();
     const subscriptions = new SimSnsSubscriptionStore();

--- a/src/service/sns/sms/sim-sns-sent-sms-message.ts
+++ b/src/service/sns/sms/sim-sns-sent-sms-message.ts
@@ -11,6 +11,8 @@ interface SimSnsSentSmsMessageProperties {
   readonly attributes: SimSnsMessageAttributes;
   readonly suppressed: boolean;
   readonly sentDate: Date;
+  readonly topicArn?: string;
+  readonly subscriptionArn?: string;
 }
 
 /**
@@ -52,6 +54,18 @@ export class SimSnsSentSmsMessage {
 
   public readonly sentDate: Date;
 
+  /**
+   * The topic that fanned this one out, where a topic did.
+   *
+   * A publish naming a phone number reaches no topic, so both this and the
+   * subscription ARN are absent for one. A test asserting on the SMS a topic
+   * sent has them to assert on.
+   */
+  public readonly topicArn: string | undefined;
+
+  /** The `sms` subscription that took this message, where one did. */
+  public readonly subscriptionArn: string | undefined;
+
   constructor(properties: SimSnsSentSmsMessageProperties) {
     this.messageId = properties.messageId;
     this.phoneNumber = properties.phoneNumber;
@@ -59,6 +73,8 @@ export class SimSnsSentSmsMessage {
     this.attributes = properties.attributes;
     this.suppressed = properties.suppressed;
     this.sentDate = properties.sentDate;
+    this.topicArn = properties.topicArn;
+    this.subscriptionArn = properties.subscriptionArn;
   }
 
   /**

--- a/src/service/sns/subscription/sim-sns-subscription-endpoint.ts
+++ b/src/service/sns/subscription/sim-sns-subscription-endpoint.ts
@@ -1,9 +1,11 @@
 import type { SimAwsAccountId } from "../../aws/sim-aws-account-id.js";
 import type { AwsRegionName } from "../../aws/sim-aws-region.js";
+import { SimSnsPhoneNumber } from "../sms/sim-sns-phone-number.js";
 import { SimSnsFunctionEndpointArn } from "./sim-sns-function-endpoint-arn.js";
 import { SimSnsQueueEndpointArn } from "./sim-sns-queue-endpoint-arn.js";
 import {
   simSnsLambdaProtocol,
+  simSnsSmsProtocol,
   simSnsSqsProtocol,
   type SimSnsSubscriptionProtocol,
 } from "./sim-sns-subscription-protocol.js";
@@ -12,15 +14,16 @@ import {
  * Where a subscription delivers, whichever kind of endpoint its protocol
  * implies.
  *
- * Every protocol simulated names its endpoint by an ARN, and every delivery
- * needs the same three things from it: the ARN itself, and the Account and
- * Region to resolve the endpoint in. What kind of resource it is belongs to the
- * protocol's own endpoint type.
+ * The Account and Region are there for a protocol whose endpoint is an ARN,
+ * because a delivery resolves the endpoint in the scope that ARN gives rather
+ * than in the topic's. An `sms` endpoint is a phone number and names neither,
+ * which is why both are optional. What kind of resource an endpoint is belongs
+ * to the protocol's own endpoint type.
  */
 export interface SimSnsSubscriptionEndpoint {
   readonly value: string;
-  readonly regionName: AwsRegionName;
-  readonly accountId: SimAwsAccountId;
+  readonly regionName?: AwsRegionName;
+  readonly accountId?: SimAwsAccountId;
 }
 
 /**
@@ -28,7 +31,8 @@ export interface SimSnsSubscriptionEndpoint {
  *
  * The protocol decides what the endpoint has to be, so an SQS queue ARN over
  * the `lambda` protocol is refused here rather than at delivery time. Real SNS
- * validates the endpoint against the protocol at `Subscribe` time too.
+ * validates the endpoint against the protocol at `Subscribe` time too, which is
+ * where a phone number outside E.164 is refused.
  */
 export function requireSimSnsSubscriptionEndpoint(
   protocol: SimSnsSubscriptionProtocol,
@@ -40,6 +44,9 @@ export function requireSimSnsSubscriptionEndpoint(
     }
     case simSnsLambdaProtocol: {
       return SimSnsFunctionEndpointArn.parse(endpoint ?? "");
+    }
+    case simSnsSmsProtocol: {
+      return SimSnsPhoneNumber.of(endpoint);
     }
   }
 }

--- a/src/service/sns/subscription/sim-sns-subscription-protocol.ts
+++ b/src/service/sns/subscription/sim-sns-subscription-protocol.ts
@@ -23,11 +23,43 @@ export const simSnsSqsProtocol = "sqs";
 export const simSnsLambdaProtocol = "lambda";
 
 /**
+ * Delivery by texting a phone number.
+ *
+ * Real SNS confirms this one itself as well, since the number is the endpoint
+ * and there is nothing to confirm. The endpoint is an E.164 phone number rather
+ * than an ARN, and a message reaching it is recorded as a sent SMS rather than
+ * handed to a carrier.
+ */
+export const simSnsSmsProtocol = "sms";
+
+/**
  * A protocol a simulated subscription can be created with.
  */
 export type SimSnsSubscriptionProtocol =
   | typeof simSnsSqsProtocol
+  | typeof simSnsLambdaProtocol
+  | typeof simSnsSmsProtocol;
+
+/**
+ * The protocols whose delivery leaves simulated SNS.
+ *
+ * A queue and a function are other simulated services, only reachable through
+ * `SimAws`, so where they deliver is supplied to `SimSns` from outside. An SMS
+ * goes nowhere but simulated SNS's own record, which is why `sms` is not one of
+ * these.
+ */
+export type SimSnsOutwardProtocol =
+  | typeof simSnsSqsProtocol
   | typeof simSnsLambdaProtocol;
+
+/**
+ * Every protocol delivery is simulated over, in the order a refusal names them.
+ */
+const simulatedProtocols = [
+  simSnsSqsProtocol,
+  simSnsLambdaProtocol,
+  simSnsSmsProtocol,
+] as const;
 
 /**
  * The protocols real SNS has that this simulation does not deliver over.
@@ -42,7 +74,6 @@ const unsimulatedProtocols = new Map<string, string>([
   ["https", "Delivery over HTTPS would leave the simulation."],
   ["email", "Sending email is not simulated."],
   ["email-json", "Sending email is not simulated."],
-  ["sms", "Sending SMS is not simulated."],
   [
     "application",
     "Mobile application endpoints and push notifications are not simulated.",
@@ -63,8 +94,10 @@ const unsimulatedProtocols = new Map<string, string>([
 export function requireSimSnsProtocol(
   value: string | undefined,
 ): SimSnsSubscriptionProtocol {
-  if (value === simSnsSqsProtocol || value === simSnsLambdaProtocol) {
-    return value;
+  const simulated = simulatedProtocols.find((protocol) => protocol === value);
+
+  if (simulated !== undefined) {
+    return simulated;
   }
 
   const named = value ?? "(none)";
@@ -73,8 +106,8 @@ export function requireSimSnsProtocol(
   if (reason !== undefined) {
     throw new SimSnsUnsimulatedInputException(
       `The ${named} subscription protocol is not simulated. ${reason} ` +
-        `Subscribe with the ${simSnsSqsProtocol} or ` +
-        `${simSnsLambdaProtocol} protocol instead.`,
+        `Subscribe with the ${simSnsSqsProtocol}, ${simSnsLambdaProtocol} or ` +
+        `${simSnsSmsProtocol} protocol instead.`,
     );
   }
 

--- a/test/sns/subscription-fixture.ts
+++ b/test/sns/subscription-fixture.ts
@@ -18,6 +18,7 @@ import { assertNonNullable, assertThrowsErrorAsync } from "@kensio/smartass";
 
 import type { SimAws } from "../../src/service/aws/sim-aws.js";
 import type { AwsRegionName } from "../../src/service/aws/sim-aws-region.js";
+import type { SimSnsSentSmsMessage } from "../../src/service/sns/sms/sim-sns-sent-sms-message.js";
 import { simAwsWithTopic } from "./topic-fixture.js";
 
 /**
@@ -104,10 +105,61 @@ export const simSnsUnsimulatedProtocols = [
   "https",
   "email",
   "email-json",
-  "sms",
   "application",
   "firehose",
 ];
+
+/**
+ * Endpoints that are not an E.164 phone number, one of each way to not be one.
+ */
+export const simSnsEndpointsThatAreNotPhoneNumbers = [
+  "5550100",
+  "+0155501000",
+  "+1 555 0100",
+  "+1555010012345678",
+  "",
+];
+
+/**
+ * Subscribe a phone number to a topic, answering with the subscription ARN.
+ */
+export async function subscribePhoneNumber(
+  simAws: SimAws,
+  topicArn: string,
+  phoneNumber: string,
+  attributes?: Record<string, string>,
+): Promise<string> {
+  const subscribed = await simAws.sns().subscribe(
+    new SubscribeCommand({
+      TopicArn: topicArn,
+      Protocol: "sms",
+      Endpoint: phoneNumber,
+      ...(attributes !== undefined && { Attributes: attributes }),
+    }),
+  );
+
+  assertNonNullable(
+    subscribed.SubscriptionArn,
+    "Subscribe answered with an ARN",
+  );
+
+  return subscribed.SubscriptionArn;
+}
+
+/**
+ * Wait for delivery, then take the SMS messages one simulated SNS recorded.
+ *
+ * Delivery happens on the background scheduler, as it does on real SNS after
+ * the publish has been answered, so nothing has been texted until that work is
+ * done.
+ */
+export async function simSnsTextedMessages(
+  simAws: SimAws,
+): Promise<readonly SimSnsSentSmsMessage[]> {
+  await simAws.backgroundTasksComplete();
+
+  return simAws.sns().sentSmsMessages();
+}
 
 /**
  * Endpoints that are not an SQS queue ARN, one of each way to not be one.
@@ -232,4 +284,13 @@ export async function endpointRefusal(
   endpoint: string | undefined,
 ): Promise<Error> {
   return subscribeRefusal({ Protocol: "sqs", Endpoint: endpoint });
+}
+
+/**
+ * Subscribe an endpoint over the sms protocol, answering with what it threw.
+ */
+export async function phoneNumberRefusal(
+  endpoint: string | undefined,
+): Promise<Error> {
+  return subscribeRefusal({ Protocol: "sms", Endpoint: endpoint });
 }


### PR DESCRIPTION
Subscribe takes the sms protocol with an E.164 phone number as its endpoint, confirmed at once as the sqs and lambda protocols already are. A published message the subscription accepts is recorded on the store a publish to a phone number records on, carrying the topic ARN and the subscription ARN that produced it, and a subscriber on the opt-out list has its message recorded as suppressed while the topic's other subscriptions receive theirs. The recorded body is the message as it was published, with the envelope and the subject left off. The endpoints simulated SNS is handed from outside now cover only the protocols reaching another simulated service, and the sms endpoint is built inside the service next to the store it records on.

Resolves #647


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SNS SMS subscriptions and fan-out delivery to phone numbers.
  * Added support for E.164 phone-number endpoint validation.
  * SMS records now include message, topic, and subscription metadata.
  * Opted-out phone numbers are suppressed from delivery.
  * Added CloudFormation support and examples for SMS subscriptions.

* **Bug Fixes**
  * Unsubscribed phone numbers no longer receive messages.
  * Filter policies correctly exclude nonmatching SMS deliveries.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->