### PR TITLE
fix: refuse an unsigned POST to a Function URL

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -1470,6 +1470,40 @@ other value fails the Stack by name.
 There is no `CreateOriginAccessControl` command here, so a CloudFormation template is the only way
 to make one.
 
+#### Posting to a Function URL Origin
+
+A POST or PUT through an origin access control has to carry the SHA-256 of its body in an
+`x-amz-content-sha256` header. CloudFront streams the viewer's body on to the Origin without
+buffering it, and has no hash of its own to sign with. It signs the hash the viewer declared, and
+`UNSIGNED-PAYLOAD` where the viewer declared none. Lambda supports no unsigned payload, and answers
+`403` with `The request signature we calculated does not match the signature you provided`. The
+handler never runs. The declared hash is checked against the body that arrived, and a digest of
+other bytes is refused the same way.
+
+A viewer computes the digest of what it is about to send, the way any SigV4 client does:
+
+```typescript
+const body = JSON.stringify({ email: "someone@example.com" });
+const response = await fetch(`http://${siteHostname}/sign-in`, {
+  method: "POST",
+  body,
+  headers: {
+    "content-type": "application/json",
+    "x-amz-content-sha256": createHash("sha256").update(body).digest("hex"),
+  },
+});
+```
+
+A GET or a HEAD is left alone. SigV4 hashes an empty payload for a request without a body, and
+CloudFront can sign one of those on its own. An origin access control with a `SigningBehavior` of
+`never` signs no Origin request, and states no payload hash for one. A POST through one reaches
+the Origin anonymously, as it did before.
+
+AWS documents the requirement on
+[Restrict access to an AWS Lambda function URL origin](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-lambda.html).
+A simulated Distribution refuses the request for the same reason a real one does. A form post
+missing the header fails in a test as well as on the deployment.
+
 ## Key value stores
 
 A key value store holds data a CloudFront Function reads at request time, so a redirect table or a
@@ -1740,7 +1774,9 @@ Where sim CloudFront knowingly behaves differently from AWS:
   no SigV4 signature is computed or checked. A Function URL Origin is told who the request is from
   at the simulated HTTP boundary instead, the same way anything else calling into simulated AWS in
   process says who it is. Nothing else here signs a simulated request either, so a test cannot
-  assert anything about the signature itself.
+  assert anything about the signature itself. The payload hash is the one part of a signature that
+  is stated and checked, because a Function URL turns a POST away over it. See
+  [posting to a Function URL Origin](#posting-to-a-function-url-origin).
 - **An origin access control signs for an S3 or Lambda Function URL Origin only.** CloudFront also
   signs for MediaStore and MediaPackage V2 Origins, and neither is modelled. An
   `OriginAccessControlOriginType` other than `s3` or `lambda`, or a `SigningProtocol` other than

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -1385,6 +1385,14 @@ origin access control, so a Function URL behind a Distribution runs for that Dis
 refuses everything else. See
 [origin access controls](../cloudfront/README.md#origin-access-controls) in the CloudFront docs.
 
+A request declaring what its body hashes to in an `x-amz-content-sha256` header is held to it. The
+header is checked against the bytes that arrived, and a request declaring `UNSIGNED-PAYLOAD` is
+refused with `403` and `The request signature we calculated does not match the signature you
+provided`, because Lambda supports no unsigned payload. A request that declares no hash is invoked as
+before. That is what makes a POST through a CloudFront origin access control need the viewer's own
+digest. See [posting to a Function URL Origin](../cloudfront/README.md#posting-to-a-function-url-origin)
+in the CloudFront docs.
+
 CloudFront is the exception to the two actions being separate. A request from
 `cloudfront.amazonaws.com` is authorized against `lambda:InvokeFunctionUrl` and
 `lambda:InvokeFunction`, and needs a grant for both, which is what real Lambda asks an origin access

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -1385,13 +1385,14 @@ origin access control, so a Function URL behind a Distribution runs for that Dis
 refuses everything else. See
 [origin access controls](../cloudfront/README.md#origin-access-controls) in the CloudFront docs.
 
-A request declaring what its body hashes to in an `x-amz-content-sha256` header is held to it. The
-header is checked against the bytes that arrived, and a request declaring `UNSIGNED-PAYLOAD` is
-refused with `403` and `The request signature we calculated does not match the signature you
-provided`, because Lambda supports no unsigned payload. A request that declares no hash is invoked as
-before. That is what makes a POST through a CloudFront origin access control need the viewer's own
-digest. See [posting to a Function URL Origin](../cloudfront/README.md#posting-to-a-function-url-origin)
-in the CloudFront docs.
+A request declaring what its body hashes to in an `x-amz-content-sha256` header is held to it,
+whichever method it used. The header is checked against the bytes that arrived, and a request
+declaring `UNSIGNED-PAYLOAD` is refused with `403` and `The request signature we calculated does not
+match the signature you provided`, because Lambda supports no unsigned payload. A request that
+declares no hash is invoked as before. That is what makes a POST through a CloudFront origin access
+control need the viewer's own digest. See
+[posting to a Function URL Origin](../cloudfront/README.md#posting-to-a-function-url-origin) in the
+CloudFront docs.
 
 CloudFront is the exception to the two actions being separate. A request from
 `cloudfront.amazonaws.com` is authorized against `lambda:InvokeFunctionUrl` and

--- a/src/service/cloudfront/origin/custom/sim-cf-custom-origin-oac.iso.test.ts
+++ b/src/service/cloudfront/origin/custom/sim-cf-custom-origin-oac.iso.test.ts
@@ -2,66 +2,19 @@ import {
   assertIdentical,
   assertObjectEquals,
   assertResponseStatus,
-  assertTypeString,
   describeResponse,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
-import { SimAwsServiceRequest } from "../../../../serve/controller/sim-service-controller.js";
-import { SimAwsLocalUrl } from "../../../../serve/http/url/sim-aws-local-url.js";
-import { SimAws } from "../../../aws/sim-aws.js";
-import type { CfnTemplateBodyRecord } from "../../../cloudformation/template/sim-cfn-template.js";
+import { fetchThroughDistribution } from "../../../../../test/cloudfront/function-url-distribution.js";
 import { simAwsCallerHeaderName } from "../../../iam/request/sim-aws-caller-header.js";
 import {
   simAwsSourceAccountHeaderName,
   simAwsSourceArnHeaderName,
 } from "../../../iam/request/sim-aws-request-source.js";
-import { SimCloudFrontServiceController } from "../../controller/sim-cloudfront-controller.js";
 import { simCfFunctionUrlOriginTemplateFactory } from "./sim-cf-function-url-origin-template.factory.js";
 
 const accountId = "888888888888";
-
-/**
- * Deploy the Stack and fetch a path through the Distribution it created.
- *
- * The viewer's headers are built from the deployed Distribution's ARN, so a
- * test about what a viewer may state can state the one thing that would work.
- */
-async function fetchThroughDistribution(
-  template: CfnTemplateBodyRecord,
-  viewerHeaders: (
-    distributionArn: string,
-  ) => Record<string, string> = () => ({}),
-): Promise<Response> {
-  const simAws = new SimAws();
-  const stack = await simAws
-    .cloudFormation()
-    .deployTemplate({ stackName: "site-stack", template });
-  await stack.waitForDeployComplete();
-
-  const domainName = stack.outputs.get("DistributionDomainName")?.value;
-  const distributionArn = stack.outputs.get("DistributionArn")?.value;
-  assertTypeString(domainName);
-  assertTypeString(distributionArn);
-
-  const url = new SimAwsLocalUrl({
-    input: `https://${domainName}/greeting`,
-  }).toString();
-  const request = new Request(url, {
-    headers: viewerHeaders(distributionArn),
-  });
-
-  // Straight to the CloudFront controller rather than through SimAwsHttp, so
-  // that the request arrives as written. The HTTP boundary strips the
-  // simulator's control headers, and a test about what a viewer can state to
-  // an Origin has to be able to send them.
-  return await new SimCloudFrontServiceController({ simAws }).handleRequest(
-    new SimAwsServiceRequest({
-      target: { service: "cloudFront", resourceName: "" },
-      request,
-    }),
-  );
-}
 
 describe("Simulated CloudFront custom Origin with an origin access control", () => {
   it("reaches an AWS_IAM Function URL as the CloudFront service principal", async () => {
@@ -144,9 +97,11 @@ describe("Simulated CloudFront custom Origin with an origin access control", () 
         originAccessControl: false,
       }),
       (distributionArn) => ({
-        [simAwsCallerHeaderName]: "service:cloudfront.amazonaws.com",
-        [simAwsSourceArnHeaderName]: distributionArn,
-        [simAwsSourceAccountHeaderName]: accountId,
+        headers: {
+          [simAwsCallerHeaderName]: "service:cloudfront.amazonaws.com",
+          [simAwsSourceArnHeaderName]: distributionArn,
+          [simAwsSourceAccountHeaderName]: accountId,
+        },
       }),
     );
 

--- a/src/service/cloudfront/origin/custom/sim-cf-custom-origin-payload-hash.iso.test.ts
+++ b/src/service/cloudfront/origin/custom/sim-cf-custom-origin-payload-hash.iso.test.ts
@@ -95,6 +95,24 @@ describe("Posting through a CloudFront origin access control", () => {
     assertIdentical(await response.text(), body);
   });
 
+  it("invokes the function for a PUT declaring the hash of its body", async () => {
+    // Given the same digest sent with the other method that carries a body
+    const body = faker.lorem.sentence();
+    const response = await fetchThroughDistribution(
+      simCfFunctionUrlOriginTemplateFactory.make({}),
+      () => ({
+        method: "PUT",
+        body,
+        headers: { [simIamSigV4ContentSha256Header]: sha256(body) },
+      }),
+    );
+
+    // Then it reaches the handler too, so declaring the hash is what a PUT
+    // takes rather than the method being turned away
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(await response.text(), body);
+  });
+
   it("invokes the function for an empty body declared as the empty hash", async () => {
     // Given a POST with no body at all, declaring the digest of no bytes
     const response = await fetchThroughDistribution(

--- a/src/service/cloudfront/origin/custom/sim-cf-custom-origin-payload-hash.iso.test.ts
+++ b/src/service/cloudfront/origin/custom/sim-cf-custom-origin-payload-hash.iso.test.ts
@@ -1,0 +1,154 @@
+import { createHash } from "node:crypto";
+
+import { faker } from "@faker-js/faker";
+import {
+  assertIdentical,
+  assertObjectEquals,
+  assertResponseStatus,
+  describeResponse,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { fetchThroughDistribution } from "../../../../../test/cloudfront/function-url-distribution.js";
+import { simIamSigV4ContentSha256Header } from "../../../iam/sigv4/canonical/sim-iam-sigv4-payload-hash.js";
+import {
+  simLambdaUrlForbiddenMessage,
+  simLambdaUrlSignatureMismatchMessage,
+} from "../../../lambda/serve/response/sim-lambda-url-error-response.js";
+import { simCfFunctionUrlOriginTemplateFactory } from "./sim-cf-function-url-origin-template.factory.js";
+
+/**
+ * The SHA-256 a client computes over the body it is about to send, which is
+ * the whole of what CloudFront asks of a viewer posting through an origin
+ * access control.
+ */
+function sha256(body: string): string {
+  return createHash("sha256").update(body).digest("hex");
+}
+
+describe("Posting through a CloudFront origin access control", () => {
+  it("refuses a POST that declares no payload hash", async () => {
+    // Given a viewer posting a form to a Function URL Origin without stating
+    // what the body hashes to, which is what a browser form post is
+    const response = await fetchThroughDistribution(
+      simCfFunctionUrlOriginTemplateFactory.make({}),
+      () => ({ method: "POST", body: faker.lorem.sentence() }),
+    );
+
+    // Then CloudFront had nothing to sign the body with, so the Function URL
+    // answers the signature mismatch real Lambda answers, and the handler
+    // never ran
+    assertResponseStatus(response, 403, await describeResponse(response));
+    assertObjectEquals(await response.json(), {
+      Message: simLambdaUrlSignatureMismatchMessage,
+    });
+  });
+
+  it("refuses a PUT that declares no payload hash", async () => {
+    // Given the other method AWS names, sent the same way
+    const response = await fetchThroughDistribution(
+      simCfFunctionUrlOriginTemplateFactory.make({}),
+      () => ({ method: "PUT", body: faker.lorem.sentence() }),
+    );
+
+    // Then it is refused for the same reason
+    assertResponseStatus(response, 403, await describeResponse(response));
+  });
+
+  it("refuses a POST declaring the hash of some other body", async () => {
+    // Given a viewer stating a digest of bytes other than the ones it sends,
+    // which is the only thing a signature over a declaration can catch
+    const response = await fetchThroughDistribution(
+      simCfFunctionUrlOriginTemplateFactory.make({}),
+      () => ({
+        method: "POST",
+        body: faker.lorem.sentence(),
+        headers: {
+          [simIamSigV4ContentSha256Header]: sha256(faker.lorem.paragraph()),
+        },
+      }),
+    );
+
+    // Then the body that arrived is not the body the request claims, so it is
+    // refused rather than passed on to the function
+    assertResponseStatus(response, 403, await describeResponse(response));
+    assertObjectEquals(await response.json(), {
+      Message: simLambdaUrlSignatureMismatchMessage,
+    });
+  });
+
+  it("invokes the function for a POST declaring the hash of its body", async () => {
+    // Given a viewer that computed the SHA-256 of the body it sends, as AWS
+    // documents a POST through an origin access control has to
+    const body = faker.lorem.sentence();
+    const response = await fetchThroughDistribution(
+      simCfFunctionUrlOriginTemplateFactory.make({}),
+      () => ({
+        method: "POST",
+        body,
+        headers: { [simIamSigV4ContentSha256Header]: sha256(body) },
+      }),
+    );
+
+    // Then the request reaches the handler, with the body it was posted
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(await response.text(), body);
+  });
+
+  it("invokes the function for an empty body declared as the empty hash", async () => {
+    // Given a POST with no body at all, declaring the digest of no bytes
+    const response = await fetchThroughDistribution(
+      simCfFunctionUrlOriginTemplateFactory.make({}),
+      () => ({
+        method: "POST",
+        body: "",
+        headers: { [simIamSigV4ContentSha256Header]: sha256("") },
+      }),
+    );
+
+    // Then it is admitted: an empty body is a body like any other, and this is
+    // the digest of it
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(await response.text(), "Hello from behind CloudFront");
+  });
+
+  it("leaves a GET alone", async () => {
+    // Given a viewer fetching a page, stating nothing about a body it does not
+    // have
+    const response = await fetchThroughDistribution(
+      simCfFunctionUrlOriginTemplateFactory.make({}),
+    );
+
+    // Then nothing is asked of it: SigV4 hashes an empty payload for a GET, so
+    // CloudFront can sign one without the viewer's help
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(await response.text(), "Hello from behind CloudFront");
+  });
+
+  it("leaves a HEAD alone", async () => {
+    // Given the other method that carries no body
+    const response = await fetchThroughDistribution(
+      simCfFunctionUrlOriginTemplateFactory.make({}),
+      () => ({ method: "HEAD" }),
+    );
+
+    // Then it reaches the Origin as a GET does
+    assertResponseStatus(response, 200, await describeResponse(response));
+  });
+
+  it("still reaches the Origin anonymously when the origin access control never signs", async () => {
+    // Given an origin access control turned off, and a POST stating no hash
+    const response = await fetchThroughDistribution(
+      simCfFunctionUrlOriginTemplateFactory.make({ signingBehavior: "never" }),
+      () => ({ method: "POST", body: faker.lorem.sentence() }),
+    );
+
+    // Then nothing signs the Origin request, so nothing declares a payload for
+    // it either: the `AWS_IAM` Function URL refuses it for being anonymous,
+    // which is what it did before any of this
+    assertResponseStatus(response, 403, await describeResponse(response));
+    assertObjectEquals(await response.json(), {
+      Message: simLambdaUrlForbiddenMessage,
+    });
+  });
+});

--- a/src/service/cloudfront/origin/custom/sim-cf-custom-origin-request.ts
+++ b/src/service/cloudfront/origin/custom/sim-cf-custom-origin-request.ts
@@ -6,8 +6,9 @@ interface SimCfCustomOriginRequestProperties {
   readonly originPath: string;
   readonly request: Request;
   /**
-   * Headers stating who the Origin request is from, which an Origin whose
-   * origin access control signs carries and an anonymous one does not.
+   * Headers stating who the Origin request is from and what its signature
+   * covers, which an Origin whose origin access control signs carries and an
+   * anonymous one does not.
    */
   readonly signingHeaders?: Readonly<Record<string, string>> | undefined;
 }

--- a/src/service/cloudfront/origin/custom/sim-cf-custom-origin-signer.ts
+++ b/src/service/cloudfront/origin/custom/sim-cf-custom-origin-signer.ts
@@ -6,10 +6,24 @@ import {
   simAwsSourceAccountHeaderName,
   simAwsSourceArnHeaderName,
 } from "../../../iam/request/sim-aws-request-source.js";
+import {
+  simIamSigV4ContentSha256Header,
+  simIamSigV4UnsignedPayload,
+} from "../../../iam/sigv4/canonical/sim-iam-sigv4-payload-hash.js";
 import { simCloudFrontDistributionArn } from "../../distribution/sim-cf-distribution-view.js";
 import type { SimCloudFrontOriginAccessControl } from "../../origin-access-control/sim-cf-origin-access-control.js";
 import { simCloudFrontServicePrincipal } from "../../sim-cloudfront-service-principal.js";
 import type { SimCloudFrontOriginRequest } from "../sim-cloudfront-request-response.js";
+
+/**
+ * The viewer methods CloudFront has a body to hash for.
+ *
+ * These are the two AWS names on the Function URL Origin documentation, and
+ * the two a viewer sends a body with in practice. Anything else is left alone
+ * rather than guessed at, since refusing a method real CloudFront lets through
+ * would be the more expensive mistake.
+ */
+const bodyCarryingMethods = new Set(["POST", "PUT"]);
 
 /**
  * Who a CloudFront custom Origin is reached as.
@@ -25,6 +39,9 @@ import type { SimCloudFrontOriginRequest } from "../sim-cloudfront-request-respo
  * the same way anything else calling into simulated AWS in process says who it
  * is.
  *
+ * The payload hash a real signature covers is stated as itself, since it is
+ * the one part of a signature an Origin turns a request away over.
+ *
  * Which Distribution the request belongs to is only known per request, so this
  * answers per fetch rather than when the Origin is built.
  */
@@ -38,8 +55,8 @@ export class SimCfCustomOriginSigner {
   }
 
   /**
-   * The headers stating who one Origin request is from, which are none when the
-   * Origin is reached anonymously.
+   * The headers stating who one Origin request is from and what its signature
+   * covers, which are none when the Origin is reached anonymously.
    */
   forRequest(request: SimCloudFrontOriginRequest): Record<string, string> {
     if (this.originAccessControl?.signs !== true) {
@@ -55,6 +72,33 @@ export class SimCfCustomOriginSigner {
         request.distribution,
       ),
       [simAwsSourceAccountHeaderName]: request.distribution.accountId,
+      ...payloadDeclaration(request.req),
     };
   }
+}
+
+/**
+ * What the signature says the Origin request body hashes to.
+ *
+ * CloudFront streams the viewer's body on to the Origin rather than buffering
+ * it, so it has no hash of its own to sign with. It signs the viewer's
+ * `x-amz-content-sha256` when the viewer sent one, and `UNSIGNED-PAYLOAD` when
+ * it did not. A Lambda Function URL does not accept an unsigned payload, so a
+ * POST or PUT that carried no hash through a signing origin access control is
+ * refused at the Origin, which is what real CloudFront and Lambda do with one.
+ *
+ * A viewer's own header travels with the rest of its headers, so nothing is
+ * stated for it here.
+ *
+ * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-lambda.html
+ */
+function payloadDeclaration(viewerRequest: Request): Record<string, string> {
+  if (
+    !bodyCarryingMethods.has(viewerRequest.method.toUpperCase()) ||
+    viewerRequest.headers.has(simIamSigV4ContentSha256Header)
+  ) {
+    return {};
+  }
+
+  return { [simIamSigV4ContentSha256Header]: simIamSigV4UnsignedPayload };
 }

--- a/src/service/cloudfront/origin/custom/sim-cf-function-url-origin-template.factory.ts
+++ b/src/service/cloudfront/origin/custom/sim-cf-function-url-origin-template.factory.ts
@@ -74,9 +74,12 @@ export const simCfFunctionUrlOriginTemplateFactory = new MappedFactory<
           FunctionName: "greeter",
           Role: { "Fn::GetAtt": ["GreeterRole", "Arn"] },
           Code: {
+            // The handler answers with whatever it was sent, so a test about a
+            // request with a body can see that the body reached it, and one
+            // about a request without stays as readable as it was.
             ZipFile:
-              "exports.handler = async () => " +
-              "({ statusCode: 200, body: 'Hello from behind CloudFront' });",
+              "exports.handler = async (event) => ({ statusCode: 200, " +
+              "body: event.body ?? 'Hello from behind CloudFront' });",
           },
           Handler: "index.handler",
           Runtime: "nodejs22.x",

--- a/src/service/iam/sigv4/canonical/sim-iam-sigv4-payload-hash.ts
+++ b/src/service/iam/sigv4/canonical/sim-iam-sigv4-payload-hash.ts
@@ -8,7 +8,15 @@ import {
 
 export const simIamSigV4UnsignedPayload = "UNSIGNED-PAYLOAD";
 
-const sha256Name = "x-amz-content-sha256";
+/**
+ * The header a signed request declares its payload hash in.
+ *
+ * Whoever builds a signed request states the hash here, and whoever receives
+ * one reads it from here, so the name is shared rather than written out again
+ * at each end.
+ */
+export const simIamSigV4ContentSha256Header = "x-amz-content-sha256";
+
 const sha256DigestPattern = /^[\da-f]{64}$/i;
 
 /**
@@ -37,7 +45,9 @@ export class SimIamSigV4PayloadDeclaration {
    * The declaration a header-signed request makes.
    */
   static fromHeaders(headers: Headers): SimIamSigV4PayloadDeclaration {
-    return new SimIamSigV4PayloadDeclaration(headers.get(sha256Name));
+    return new SimIamSigV4PayloadDeclaration(
+      headers.get(simIamSigV4ContentSha256Header),
+    );
   }
 
   /**
@@ -80,9 +90,10 @@ export class SimIamSigV4PayloadDeclaration {
 
     if (!sha256DigestPattern.test(declared)) {
       throw new SimIamSignatureDoesNotMatch(
-        `Signed ${sha256Name} declares ${declared}, which is neither a ` +
-          `SHA-256 digest nor ${simIamSigV4UnsignedPayload}. Chunked and ` +
-          `streaming payload signing is not simulated.`,
+        `Signed ${simIamSigV4ContentSha256Header} declares ${declared}, ` +
+          `which is neither a SHA-256 digest nor ` +
+          `${simIamSigV4UnsignedPayload}. Chunked and streaming payload ` +
+          `signing is not simulated.`,
       );
     }
 
@@ -91,7 +102,7 @@ export class SimIamSigV4PayloadDeclaration {
     if (received !== declared.toLowerCase()) {
       throw new SimIamSignatureDoesNotMatch(
         `Request body hashes to ${received}, not the ${declared} its signed ` +
-          `${sha256Name} declares`,
+          `${simIamSigV4ContentSha256Header} declares`,
       );
     }
 

--- a/src/service/lambda/serve/auth/sim-lambda-url-payload-hash.ts
+++ b/src/service/lambda/serve/auth/sim-lambda-url-payload-hash.ts
@@ -23,6 +23,12 @@ import { SimIamSigV4Error } from "../../../iam/sigv4/error/sim-iam-sigv4.error.j
  * signed the body it sent and left the header off has said nothing to
  * disagree with.
  *
+ * The method the request used makes no difference here. A declaration is a
+ * claim about the body, and SigV4 covers it for a GET as much as for a POST,
+ * so a GET carrying a digest of other bytes is refused as well. The method
+ * matters on the CloudFront side, which invents a declaration for a POST or a
+ * PUT alone.
+ *
  * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-lambda.html
  */
 export async function simLambdaUrlPayloadRefusal(

--- a/src/service/lambda/serve/auth/sim-lambda-url-payload-hash.ts
+++ b/src/service/lambda/serve/auth/sim-lambda-url-payload-hash.ts
@@ -1,0 +1,64 @@
+import {
+  simIamSigV4ContentSha256Header,
+  SimIamSigV4PayloadDeclaration,
+  simIamSigV4UnsignedPayload,
+} from "../../../iam/sigv4/canonical/sim-iam-sigv4-payload-hash.js";
+import { SimIamSigV4Error } from "../../../iam/sigv4/error/sim-iam-sigv4.error.js";
+
+/**
+ * Why a Function URL request's payload hash cannot be accepted, or nothing
+ * when it can.
+ *
+ * Lambda checks what a request declares its body hashes to before it looks at
+ * who is asking, and answers a request that fails the check with a signature
+ * mismatch. Two declarations fail it. One is a digest that disagrees with the
+ * bytes that arrived, which would otherwise let a signed request carry any body
+ * at all. The other is `UNSIGNED-PAYLOAD`, which Lambda refuses outright.
+ * CloudFront signs a POST or PUT with it when the viewer sent no hash, and that
+ * is why such a request through an origin access control never reaches the
+ * function.
+ *
+ * A request declaring nothing is not checked. The hash is an input to the
+ * signature rather than something a request has to state, so a caller that
+ * signed the body it sent and left the header off has said nothing to
+ * disagree with.
+ *
+ * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-lambda.html
+ */
+export async function simLambdaUrlPayloadRefusal(
+  request: Request,
+): Promise<string | undefined> {
+  if (!request.headers.has(simIamSigV4ContentSha256Header)) {
+    return undefined;
+  }
+
+  const declaration = SimIamSigV4PayloadDeclaration.fromHeaders(
+    request.headers,
+  );
+  // A clone, so the body is still there for the invocation event to read.
+  const body = new Uint8Array(await request.clone().arrayBuffer());
+  let declared: string;
+
+  try {
+    declared = declaration.hashFor(body);
+  } catch (error) {
+    if (error instanceof SimIamSigV4Error) {
+      return error.message;
+    }
+
+    /* v8 ignore next 2 -- a declaration is refused with nothing else */
+    throw error;
+  }
+
+  if (declared !== simIamSigV4UnsignedPayload) {
+    return undefined;
+  }
+
+  return (
+    `Signed ${simIamSigV4ContentSha256Header} declares ` +
+    `${simIamSigV4UnsignedPayload}, which Lambda does not support. A ` +
+    `${request.method} to a Function URL has to declare the SHA-256 of its ` +
+    `body, and one sent through a CloudFront origin access control declares ` +
+    `whatever the viewer request declared.`
+  );
+}

--- a/src/service/lambda/serve/response/sim-lambda-url-error-response.ts
+++ b/src/service/lambda/serve/response/sim-lambda-url-error-response.ts
@@ -1,3 +1,8 @@
+import {
+  simAwsErrorDetailHeaderName,
+  simAwsErrorHeaderName,
+} from "../../../../serve/http/response/sim-aws-response-hints.js";
+
 /**
  * What real Lambda says when it refuses a Function URL request.
  *
@@ -8,6 +13,18 @@
 export const simLambdaUrlForbiddenMessage =
   "Forbidden. For troubleshooting Function URL authorization issues, see: " +
   "https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html";
+
+/**
+ * What real Lambda says when a Function URL request does not verify.
+ *
+ * This is the answer a request that failed authentication gets, as opposed to
+ * one that was authenticated and then not allowed, and the wording is what
+ * anyone searching for the failure will have in front of them.
+ */
+export const simLambdaUrlSignatureMismatchMessage =
+  "The request signature we calculated does not match the signature you " +
+  "provided. Check your AWS Secret Access Key and signing method. Consult " +
+  "the service documentation for details.";
 
 /**
  * The error responses a Function URL endpoint returns itself, before or
@@ -30,6 +47,25 @@ export class SimLambdaUrlErrorResponse {
    */
   forbidden(): Response {
     return this.jsonResponse(403, simLambdaUrlForbiddenMessage);
+  }
+
+  /**
+   * The request does not carry a signature over the body it arrived with.
+   *
+   * Real Lambda says only that the signature did not match, which is faithful
+   * and impossible to act on, so what the simulator worked out goes in a hint
+   * header where it changes nothing for a client reading the body.
+   */
+  signatureDoesNotMatch(detail: string): Response {
+    const response = this.jsonResponse(
+      403,
+      simLambdaUrlSignatureMismatchMessage,
+    );
+
+    response.headers.set(simAwsErrorHeaderName, "SignatureDoesNotMatch");
+    response.headers.set(simAwsErrorDetailHeaderName, detail);
+
+    return response;
   }
 
   /**

--- a/src/service/lambda/serve/sim-lambda-controller.ts
+++ b/src/service/lambda/serve/sim-lambda-controller.ts
@@ -12,6 +12,7 @@ import {
   SimLambdaUrlRouter,
 } from "./sim-lambda-url-router.js";
 import { SimLambdaUrlAuthorizer } from "./auth/sim-lambda-url-authorizer.js";
+import { simLambdaUrlPayloadRefusal } from "./auth/sim-lambda-url-payload-hash.js";
 import type { SimAwsRequestCaller } from "../../iam/request/sim-aws-request-caller.js";
 
 interface SimLambdaServiceControllerProperties {
@@ -77,12 +78,26 @@ export class SimLambdaServiceController implements SimAwsServiceController {
    * What the request is being made on behalf of travels with it, so a
    * CloudFront Distribution reaching this URL through an origin access control
    * is judged against the Distribution the permission names.
+   *
+   * What the request declares its body hashes to is settled first, as real
+   * Lambda authenticates a request before it authorizes one. A POST or PUT
+   * arriving through an origin access control declares an unsigned payload
+   * unless the viewer sent a hash of its own, and Lambda takes no unsigned
+   * payload, so it is refused here rather than reaching the function.
    */
   private async invokeAuthenticated(
     route: SimLambdaFunctionUrlRoute,
     serviceRequest: SimAwsServiceRequest,
   ): Promise<Response> {
     const { caller } = serviceRequest;
+    const payloadRefusal = await simLambdaUrlPayloadRefusal(
+      serviceRequest.request,
+    );
+
+    if (payloadRefusal !== undefined) {
+      return this.errorResponse.signatureDoesNotMatch(payloadRefusal);
+    }
+
     const decision = new SimLambdaUrlAuthorizer({ iam: route.iam }).authorize({
       simFunction: route.simFunction,
       functionUrl: route.functionUrl,

--- a/src/service/lambda/serve/sim-lambda-url-payload-hash.iso.test.ts
+++ b/src/service/lambda/serve/sim-lambda-url-payload-hash.iso.test.ts
@@ -1,0 +1,200 @@
+import { createHash } from "node:crypto";
+
+import {
+  CreateFunctionCommand,
+  CreateFunctionUrlConfigCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  CreateAccessKeyCommand,
+  CreateUserCommand,
+  PutUserPolicyCommand,
+} from "@aws-sdk/client-iam";
+import { faker } from "@faker-js/faker";
+import { describe, expect, it } from "vitest";
+
+import { signAwsRequest } from "../../../../test/sigv4/sign-aws-request.js";
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simAwsCallerHeaderName } from "../../iam/request/sim-aws-caller-header.js";
+import { simIamPolicyDocumentFactory } from "../../iam/policy/sim-iam-policy-document.factory.js";
+import {
+  simIamSigV4ContentSha256Header,
+  simIamSigV4UnsignedPayload,
+} from "../../iam/sigv4/canonical/sim-iam-sigv4-payload-hash.js";
+import { makeLambdaZipFileInput } from "../function/code/lambda-zip-file-input.js";
+import { simLambdaUrlSignatureMismatchMessage } from "./response/sim-lambda-url-error-response.js";
+import type { SimLambdaFunctionUrlEvent } from "./event/sim-lambda-url-event.type.js";
+
+const accountId = "888888888888";
+const callerArn = `arn:aws:iam::${accountId}:user/Poster`;
+
+/**
+ * Function code echoing the body it was posted, so a test can tell an
+ * invocation from a refusal by what came back.
+ */
+const echoBodyCode = {
+  ZipFile: makeLambdaZipFileInput(
+    (event: SimLambdaFunctionUrlEvent) => event.body,
+  ),
+};
+
+function sha256(body: string): string {
+  return createHash("sha256").update(body).digest("hex");
+}
+
+/**
+ * An `AWS_IAM` Function URL a named caller is allowed to invoke.
+ */
+async function serveBodyEcho(simAws: SimAws): Promise<string> {
+  const created = await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: "poster",
+      Role: `arn:aws:iam::${accountId}:role/PosterRole`,
+      Code: echoBodyCode,
+    }),
+  );
+  const urlConfig = await simAws.lambda().createFunctionUrlConfig(
+    new CreateFunctionUrlConfigCommand({
+      FunctionName: "poster",
+      AuthType: "AWS_IAM",
+    }),
+  );
+
+  await simAws.iam().createUser(new CreateUserCommand({ UserName: "Poster" }));
+  await simAws.iam().putUserPolicy(
+    new PutUserPolicyCommand({
+      UserName: "Poster",
+      PolicyName: "InvokeUrl",
+      PolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: {
+          Action: "lambda:InvokeFunctionUrl",
+          Resource: created.FunctionArn,
+        },
+      }),
+    }),
+  );
+
+  return new SimAwsLocalUrl({ input: urlConfig.FunctionUrl }).toString();
+}
+
+describe("The payload hash an AWS_IAM Function URL request declares", () => {
+  it("invokes for a POST declaring the hash of its body", async () => {
+    // Given a Function URL and a caller allowed to invoke it
+    const simAws = new SimAws();
+    const url = await serveBodyEcho(simAws);
+    const body = faker.lorem.sentence();
+
+    // When it posts a body along with that body's digest
+    const response = await new SimAwsHttp({ simAws }).fetch(url, {
+      method: "POST",
+      body,
+      headers: {
+        [simAwsCallerHeaderName]: callerArn,
+        [simIamSigV4ContentSha256Header]: sha256(body),
+      },
+    });
+
+    // Then the function ran on the body that arrived
+    expect(response.status).toBe(200);
+    expect(await response.json()).toBe(body);
+  });
+
+  it("invokes for a POST declaring no payload hash at all", async () => {
+    // Given a Function URL and a caller allowed to invoke it
+    const simAws = new SimAws();
+    const url = await serveBodyEcho(simAws);
+    const body = faker.lorem.sentence();
+
+    // When it posts a body without declaring what it hashes to
+    const response = await new SimAwsHttp({ simAws }).fetch(url, {
+      method: "POST",
+      body,
+      headers: { [simAwsCallerHeaderName]: callerArn },
+    });
+
+    // Then nothing is refused: the hash is an input to a signature rather than
+    // something a request has to state, so there is no claim to disagree with
+    expect(response.status).toBe(200);
+  });
+
+  it("refuses a POST declaring the hash of some other body", async () => {
+    // Given a Function URL and a caller allowed to invoke it
+    const simAws = new SimAws();
+    const url = await serveBodyEcho(simAws);
+
+    // When it posts one body and declares the digest of another
+    const response = await new SimAwsHttp({ simAws }).fetch(url, {
+      method: "POST",
+      body: faker.lorem.sentence(),
+      headers: {
+        [simAwsCallerHeaderName]: callerArn,
+        [simIamSigV4ContentSha256Header]: sha256(faker.lorem.paragraph()),
+      },
+    });
+
+    // Then it is refused as a signature mismatch, since a declaration nothing
+    // checked would leave the body free to be replaced
+    expect(response.status).toBe(403);
+    expect(await response.json()).toStrictEqual({
+      Message: simLambdaUrlSignatureMismatchMessage,
+    });
+  });
+
+  it("refuses a POST declaring an unsigned payload", async () => {
+    // Given a Function URL and a caller allowed to invoke it
+    const simAws = new SimAws();
+    const url = await serveBodyEcho(simAws);
+
+    // When it posts a body it declines to cover, which is how CloudFront signs
+    // a POST the viewer sent no hash with
+    const response = await new SimAwsHttp({ simAws }).fetch(url, {
+      method: "POST",
+      body: faker.lorem.sentence(),
+      headers: {
+        [simAwsCallerHeaderName]: callerArn,
+        [simIamSigV4ContentSha256Header]: simIamSigV4UnsignedPayload,
+      },
+    });
+
+    // Then Lambda refuses it: it takes no unsigned payload, whoever sent it
+    expect(response.status).toBe(403);
+    expect(await response.json()).toStrictEqual({
+      Message: simLambdaUrlSignatureMismatchMessage,
+    });
+  });
+
+  it("refuses an unsigned payload on a request whose signature verifies", async () => {
+    // Given a Function URL, and an access key for the user allowed to invoke it
+    const simAws = new SimAws();
+    const url = await serveBodyEcho(simAws);
+    const key = await simAws
+      .iam()
+      .createAccessKey(new CreateAccessKeyCommand({ UserName: "Poster" }));
+
+    // When a real SigV4 client signs a POST declaring an unsigned payload,
+    // which the signature then covers correctly
+    const signed = await signAwsRequest({
+      url,
+      credentials: {
+        accessKeyId: key.AccessKey.AccessKeyId,
+        secretAccessKey: key.AccessKey.SecretAccessKey,
+      },
+      method: "POST",
+      body: faker.lorem.sentence(),
+      headers: {
+        [simIamSigV4ContentSha256Header]: simIamSigV4UnsignedPayload,
+      },
+    });
+    const response = await new SimAwsHttp({ simAws }).handleRequest(
+      signed.request,
+    );
+
+    // Then the signature is beside the point: the body it covers is nothing,
+    // and Lambda has no use for a request like that
+    expect(response.status).toBe(403);
+    expect(await response.json()).toStrictEqual({
+      Message: simLambdaUrlSignatureMismatchMessage,
+    });
+  });
+});

--- a/src/service/lambda/serve/sim-lambda-url-payload-hash.iso.test.ts
+++ b/src/service/lambda/serve/sim-lambda-url-payload-hash.iso.test.ts
@@ -164,6 +164,45 @@ describe("The payload hash an AWS_IAM Function URL request declares", () => {
     });
   });
 
+  it("invokes for a GET declaring the hash of no body", async () => {
+    // Given a Function URL and a caller allowed to invoke it
+    const simAws = new SimAws();
+    const url = await serveBodyEcho(simAws);
+
+    // When it fetches with the digest a SigV4 client computes for a request
+    // that carries no body
+    const response = await new SimAwsHttp({ simAws }).fetch(url, {
+      headers: {
+        [simAwsCallerHeaderName]: callerArn,
+        [simIamSigV4ContentSha256Header]: sha256(""),
+      },
+    });
+
+    // Then it is invoked, which is what an SDK-signed GET arrives as
+    expect(response.status).toBe(200);
+  });
+
+  it("refuses a GET declaring the hash of some body it does not carry", async () => {
+    // Given a Function URL and a caller allowed to invoke it
+    const simAws = new SimAws();
+    const url = await serveBodyEcho(simAws);
+
+    // When it fetches with a digest of bytes it never sent
+    const response = await new SimAwsHttp({ simAws }).fetch(url, {
+      headers: {
+        [simAwsCallerHeaderName]: callerArn,
+        [simIamSigV4ContentSha256Header]: sha256(faker.lorem.sentence()),
+      },
+    });
+
+    // Then the method makes no difference: a declaration is a claim about the
+    // body, and this one disagrees with the empty body that arrived
+    expect(response.status).toBe(403);
+    expect(await response.json()).toStrictEqual({
+      Message: simLambdaUrlSignatureMismatchMessage,
+    });
+  });
+
   it("refuses an unsigned payload on a request whose signature verifies", async () => {
     // Given a Function URL, and an access key for the user allowed to invoke it
     const simAws = new SimAws();

--- a/test/cloudfront/function-url-distribution.ts
+++ b/test/cloudfront/function-url-distribution.ts
@@ -1,0 +1,58 @@
+/**
+ * Deploying a Lambda Function URL behind a Distribution, and fetching through
+ * it, for tests about what such a Distribution admits.
+ *
+ * This lives under `test/` because two test files share it, and a file mixing
+ * exported helpers with top-level `describe` calls is rejected by lint anyway.
+ */
+
+import { assertTypeString } from "@kensio/smartass";
+
+import { SimAwsServiceRequest } from "../../src/serve/controller/sim-service-controller.js";
+import { SimAwsLocalUrl } from "../../src/serve/http/url/sim-aws-local-url.js";
+import { SimAws } from "../../src/service/aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../src/service/cloudformation/template/sim-cfn-template.js";
+import { SimCloudFrontServiceController } from "../../src/service/cloudfront/controller/sim-cloudfront-controller.js";
+
+/**
+ * How a test states the request the viewer makes.
+ *
+ * The deployed Distribution's ARN is passed in, so a test about what a viewer
+ * may state can state the one thing that would work.
+ */
+export type ViewerRequest = (distributionArn: string) => RequestInit;
+
+/**
+ * Deploy the Stack and fetch a path through the Distribution it created.
+ */
+export async function fetchThroughDistribution(
+  template: CfnTemplateBodyRecord,
+  viewerRequest: ViewerRequest = () => ({}),
+): Promise<Response> {
+  const simAws = new SimAws();
+  const stack = await simAws
+    .cloudFormation()
+    .deployTemplate({ stackName: "site-stack", template });
+  await stack.waitForDeployComplete();
+
+  const domainName = stack.outputs.get("DistributionDomainName")?.value;
+  const distributionArn = stack.outputs.get("DistributionArn")?.value;
+  assertTypeString(domainName);
+  assertTypeString(distributionArn);
+
+  const url = new SimAwsLocalUrl({
+    input: `https://${domainName}/greeting`,
+  }).toString();
+  const request = new Request(url, viewerRequest(distributionArn));
+
+  // Straight to the CloudFront controller rather than through SimAwsHttp, so
+  // that the request arrives as written. The HTTP boundary strips the
+  // simulator's control headers, and a test about what a viewer can state to
+  // an Origin has to be able to send them.
+  return await new SimCloudFrontServiceController({ simAws }).handleRequest(
+    new SimAwsServiceRequest({
+      target: { service: "cloudFront", resourceName: "" },
+      request,
+    }),
+  );
+}


### PR DESCRIPTION
A POST or PUT reaching a Lambda Function URL Origin through a signing origin access control now declares a payload hash, taking the viewer's `x-amz-content-sha256` where there is one and `UNSIGNED-PAYLOAD` where there is not. The Function URL holds the request to that declaration through `SimIamSigV4PayloadDeclaration.hashFor`, and answers 403 with the signature mismatch real Lambda answers when the declaration covers no body or disagrees with the bytes that arrived. A form post that passed here and answered 403 on the deployment now fails in the test. GET and HEAD are unchanged, as is an origin access control with a `SigningBehavior` of `never`.

Resolves #651

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added payload-hash validation for Lambda Function URL requests routed through CloudFront.
  - POST and PUT requests can now be verified against the exact request body.
  - Valid hashed requests forward successfully, including empty-body requests.
  - Request bodies are returned by sample function URL handlers when provided.

- **Bug Fixes**
  - Invalid, missing, or unsigned payload declarations now receive HTTP 403 responses without invoking the handler.
  - GET and HEAD behavior remains unchanged.

- **Documentation**
  - Documented payload-hash requirements and related limitations for CloudFront and Lambda Function URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->