### PR TITLE
feat: sign a local user in at authorize

### DIFF
--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -1568,6 +1568,74 @@ An authorization code is single use and lasts five minutes on the simulated cloc
 endpoint also answers a `grant_type` of `refresh_token`, with the refresh token the grant handed
 out.
 
+### Signing a local user in
+
+An authorize request naming no `identity_provider` signs in one of the pool's own users. Real
+managed login answers that request with a form and takes an email address and a password from it.
+Here the two arrive as a `username` and a `password` beside the parameters the request already
+carries, and everything after them is the same grant. The app client needs `COGNITO` among its
+`SupportedIdentityProviders`, which is what real Cognito needs before managed login offers the form
+at all.
+
+```typescript sim-cognito-hosted-local-sign-in
+/**
+ * Signing one of a pool's own users in at the authorize endpoint.
+ */
+
+import type { SimAws } from "@kensio/yulin";
+
+declare const simAws: SimAws;
+declare const userPoolId: string;
+declare const clientId: string;
+
+const cognito = simAws.cognitoIdentityProvider();
+const pool = cognito.userPool(userPoolId);
+const callbackUrl = "https://www.example.com/user/callback";
+
+// The two fields managed login's form would have taken, passed with the
+// parameters the browser arrived on.
+const redirect = await cognito.hostedAuthorize(pool, {
+  response_type: "code",
+  client_id: clientId,
+  redirect_uri: callbackUrl,
+  scope: "openid email",
+  state: "csrf-token",
+  username: "alice",
+  password: "Sup3rSecret!",
+});
+
+const callback = new URL(redirect.location);
+console.log(callback.searchParams.get("state")); // "csrf-token"
+
+// The application's own server exchanges the code, as it does after a
+// federated sign-in.
+const tokens = await cognito.hostedToken(pool, {
+  grant_type: "authorization_code",
+  client_id: clientId,
+  code: callback.searchParams.get("code")!,
+  redirect_uri: callbackUrl,
+});
+
+console.log(tokens.token_type); // "Bearer"
+```
+
+The password is checked the way `InitiateAuth` checks it. A wrong password is a
+`NotAuthorizedException`, a user that has not confirmed its sign-up is a
+`UserNotConfirmedException`, and a username the pool does not hold depends on the app client's
+`PreventUserExistenceErrors`. None of the three issues a code.
+
+An `identity_provider` of `COGNITO` reaches the same place, which is where real managed login sends
+a request that skipped the provider choice.
+
+Two sign-ins real managed login answers with a further page are refused instead. A user that has
+registered a second factor is one, and a user holding a temporary password from `AdminCreateUser` is
+the other. Both say which page would have come next, and where the simulation does answer that
+challenge. `InitiateAuth` issues the MFA challenge and the new password challenge, and
+`AdminSetUserPassword` gives a user a permanent password.
+
+Users sign themselves up through `SignUp` and `ConfirmSignUp`, which are covered under
+[Signing up](#signing-up). A user confirmed that way signs in here with the password it chose.
+
 ### Signing out
 
 `GET /logout?client_id=...&logout_uri=...` redirects to the sign-out URL, once it has checked it is
@@ -3344,6 +3412,8 @@ Sim Cognito currently supports:
 - The `/oauth2/authorize`, `/oauth2/token` and `/logout` endpoints of a pool's domain, served on the
   domain's own hostname, for an authorization code grant through an external identity provider,
   with PKCE and with a `refresh_token` grant
+- An authorize request naming no identity provider, signing one of the pool's own users in from a
+  `username` and a `password` it carries
 - The pool user a federated sign-in creates, named `<ProviderName>_<subject>`, in the
   `EXTERNAL_PROVIDER` status, carrying the `identities` attribute and claim and the attributes the
   provider's `AttributeMapping` named
@@ -3613,12 +3683,17 @@ Current documented limitations:
 - A pool's schema is settled when the pool is created. `AddCustomAttributes` is unimplemented, and
   an `UpdateUserPool` request carrying a `Schema` is refused, because real `UpdateUserPool` has no
   such input.
-- Managed login and the classic hosted UI are pages a person fills in, and are outside the
-  simulation. An authorize request naming no `identity_provider`, or naming `COGNITO`, would reach
-  one of those pages on real Cognito and is refused here with a message saying so. The pool's own
-  users sign in through `InitiateAuth` and `AdminInitiateAuth`, which are simulated. `/login`,
-  `/signup`, `/oauth2/userInfo`, `/oauth2/revoke`, `/oauth2/idpresponse` and the SAML endpoints go
-  unserved.
+- Managed login's pages are outside the simulation. The sign-in behind them is inside it. An
+  authorize request naming no `identity_provider`, or naming `COGNITO`, signs one of the pool's own
+  users in from the `username` and `password` it carries, and answers with the code real managed
+  login answers with. Nothing here draws the form those two fields came from, and
+  `AWS::Cognito::ManagedLoginBranding` is an unsupported resource type. `/login`, `/signup`,
+  `/oauth2/userInfo`, `/oauth2/revoke`, `/oauth2/idpresponse` and the SAML endpoints go unserved.
+- A hosted sign-in that real managed login would answer with a further page is refused. That is a
+  user which has registered a second factor, and a user holding a temporary password. Both
+  challenges are simulated at `InitiateAuth` and `AdminInitiateAuth`, which is where a test drives
+  them. Password reset is unsimulated on either side, so `ForgotPassword` and
+  `ConfirmForgotPassword` are unimplemented and no page asks for a reset code.
 - The implicit grant is refused, and so is the client credentials grant, which needs resource
   servers.
 - The served OpenID configuration names its `authorization_endpoint`, `token_endpoint` and
@@ -3641,8 +3716,9 @@ Current documented limitations:
   local user, and signing in as it would hand the application someone else's account.
 - `AdminLinkProviderForUser` is unimplemented, and a federated user is never linked to a user that
   was already in the pool, and the `identities` it carries always names one provider.
-- The `PreAuthentication`, `PostAuthentication` and migrate user triggers do not fire on a federated
-  sign-in.
+- The `PreAuthentication`, `PostAuthentication` and migrate user triggers do not fire on a sign-in
+  at the hosted domain, federated or local. `PreTokenGeneration` does, at the token endpoint where
+  the claims are settled.
 - A domain reports no `S3Bucket` or `Version`, both of which name parts of the machinery real
   Cognito builds a domain out of. Its `Status` is `ACTIVE` as soon as it exists, where a real prefix
   domain takes a minute and a custom domain up to an hour.

--- a/docs/services/cognito/sim-cognito-hosted-local-sign-in.example.ts
+++ b/docs/services/cognito/sim-cognito-hosted-local-sign-in.example.ts
@@ -1,0 +1,39 @@
+/**
+ * Signing one of a pool's own users in at the authorize endpoint.
+ */
+
+import type { SimAws } from "@kensio/yulin";
+
+declare const simAws: SimAws;
+declare const userPoolId: string;
+declare const clientId: string;
+
+const cognito = simAws.cognitoIdentityProvider();
+const pool = cognito.userPool(userPoolId);
+const callbackUrl = "https://www.example.com/user/callback";
+
+// The two fields managed login's form would have taken, passed with the
+// parameters the browser arrived on.
+const redirect = await cognito.hostedAuthorize(pool, {
+  response_type: "code",
+  client_id: clientId,
+  redirect_uri: callbackUrl,
+  scope: "openid email",
+  state: "csrf-token",
+  username: "alice",
+  password: "Sup3rSecret!",
+});
+
+const callback = new URL(redirect.location);
+console.log(callback.searchParams.get("state")); // "csrf-token"
+
+// The application's own server exchanges the code, as it does after a
+// federated sign-in.
+const tokens = await cognito.hostedToken(pool, {
+  grant_type: "authorization_code",
+  client_id: clientId,
+  code: callback.searchParams.get("code")!,
+  redirect_uri: callbackUrl,
+});
+
+console.log(tokens.token_type); // "Bearer"

--- a/src/service/cognito/README.md
+++ b/src/service/cognito/README.md
@@ -6,7 +6,8 @@ which exchange a token for AWS credentials, are a separate service and are not s
 The pool, the app client, the users and groups in it, self-service sign-up, the second factors a
 user registers, the sign-in flows on both sides of the API, the domain and identity providers a
 federated sign-in runs through, the messages it would have sent, the tokens it issues and the
-authorizer are all here. SRP, managed login, password resets and device tracking are not.
+authorizer are all here. SRP, managed login's own pages, password resets and device tracking are
+not.
 
 ## Entry points
 
@@ -254,12 +255,13 @@ none. What the token endpoint authenticates instead is the app client: one with 
 it, in a basic authorization header or in the body, and a public client presents its client id and
 binds the grant with PKCE.
 
-`SimCognitoAuthorizeEndpoint` signs a user in through an identity provider and answers with the
-redirect back to the application. A request naming no provider would reach managed login on real
-Cognito, which is a page rather than anything an API answers, so it is refused with a message saying
-what to do instead. `SimCognitoTokenEndpoint` exchanges the code, through the pool's own token
-issuer rather than anything of its own, so a hosted sign-in and an API sign-in issue the same tokens
-and run the same `PreTokenGeneration` trigger.
+`SimCognitoAuthorizeEndpoint` signs a user in and answers with the redirect back to the
+application. `SimCognitoHostedSignIn` is what decides which of the two sign-ins a request asked
+for. One naming an identity provider goes through `SimCognitoFederatedSignIn`, and one naming none
+goes through `SimCognitoHostedPasswordSignIn`, which checks the `username` and `password` the
+request carried with the checks `InitiateAuth` makes. `SimCognitoTokenEndpoint` exchanges the code,
+through the pool's own token issuer rather than anything of its own, so a hosted sign-in and an API
+sign-in issue the same tokens and run the same `PreTokenGeneration` trigger.
 
 `SimCognitoOAuthError` is what both refuse with, because an OAuth error is a code and a description
 rather than an API exception. Whether a refusal can be redirected back to the application is part of
@@ -627,10 +629,13 @@ resource, here or on real AWS.
   developer credentials, and nothing here tells one caller from another that way.
 - Users are resolved by username only, and real Cognito also accepts a `sub` there.
 - `AdminListGroupsForUser` sorts by precedence. Real Cognito does not document an order for it.
-- Managed login and the classic hosted UI are not simulated. An authorize request naming no
-  identity provider, or naming `COGNITO`, is refused rather than answered with a page. The implicit
-  and client credentials grants are refused too, and `/login`, `/oauth2/userInfo`, `/oauth2/revoke`
-  and the SAML endpoints are not served.
+- Managed login's pages are not simulated, and the local sign-in behind them is. An authorize
+  request naming no identity provider, or naming `COGNITO`, signs a pool user in from a `username`
+  and a `password` passed beside the other parameters. Nothing draws the form they came from. A
+  sign-in managed login would answer with a second page, which is a user owing a second factor and
+  a user holding a temporary password, is refused instead. The implicit and client credentials
+  grants are refused too, and `/login`, `/signup`, `/oauth2/userInfo`, `/oauth2/revoke` and the SAML
+  endpoints are not served.
 - A simulated identity provider signs in the user `signInAs` put there, and calls nothing. A
   provider nobody is signed in at refuses the authorize request rather than inventing one.
 - A custom domain answers on its own hostname with no Route53 record, where real AWS needs an alias

--- a/src/service/cognito/command/hosted/hosted-auth.command.ts
+++ b/src/service/cognito/command/hosted/hosted-auth.command.ts
@@ -17,6 +17,17 @@ export interface SimCognitoAuthorizeInput {
   readonly idp_identifier?: string | undefined;
   readonly code_challenge?: string | undefined;
   readonly code_challenge_method?: string | undefined;
+
+  /**
+   * The username a pool's own user signs in with.
+   *
+   * Real Cognito takes these two from the managed login form rather than from
+   * the query string, and a request carrying them here is the form post the
+   * simulation's own sign-in page makes. Naming no identity provider and
+   * carrying these two is what tells a local sign-in from a federated one.
+   */
+  readonly username?: string | undefined;
+  readonly password?: string | undefined;
 }
 
 /**

--- a/src/service/cognito/command/hosted/sim-cognito-authorize-endpoint.ts
+++ b/src/service/cognito/command/hosted/sim-cognito-authorize-endpoint.ts
@@ -1,17 +1,17 @@
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import { SimCognitoAuthorizationCode } from "../../user-pool/auth/sim-cognito-authorization-code.js";
-import type { SimCognitoFederatedSignIn } from "../../user-pool/idp/sim-cognito-federated-sign-in.js";
 import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
 import { SimCognitoAuthorizeRequest } from "./sim-cognito-authorize-request.js";
 import { SimCognitoGrantedScopes } from "./sim-cognito-granted-scopes.js";
 import { SimCognitoHostedClient } from "./sim-cognito-hosted-client.js";
+import type { SimCognitoHostedSignIn } from "./sim-cognito-hosted-sign-in.js";
 import type {
   SimCognitoAuthorizeInput,
   SimCognitoHostedRedirect,
 } from "./hosted-auth.command.js";
 
 interface SimCognitoAuthorizeEndpointProperties {
-  readonly federatedSignIn: SimCognitoFederatedSignIn;
+  readonly signIn: SimCognitoHostedSignIn;
   readonly clock: SimClock;
 }
 
@@ -20,30 +20,31 @@ interface SimCognitoAuthorizeEndpointProperties {
  *
  * Real Cognito answers this request in one of two ways: it sends the browser
  * to an identity provider's sign-in page when the request names a provider,
- * and to managed login's own page when it does not. Only the first has an
- * equivalent here, because the second is a web page a person fills in, and a
- * simulation of a person filling it in would be a simulation of nothing.
+ * and to managed login's own form when it does not. Both end in the same
+ * place, which is the app client's callback URL carrying an authorization
+ * code, and both end there here.
  *
- * So a request naming a provider signs in the user that provider has been told
- * is signed in at it, and answers with the code real Cognito would answer
- * with. A request naming no provider, or naming the pool's own users, is
- * refused with a message saying so, rather than being answered with a page or
- * with a user nothing put there.
+ * A request naming a provider signs in the user that provider has been told is
+ * signed in at it. A request naming none signs in one of the pool's own users,
+ * with the username and password real managed login would have taken from its
+ * form. Nothing here draws the form: the serving layer is what answers a
+ * browser with a page, and a test calling this directly passes the two fields
+ * the form would have posted.
  */
 export class SimCognitoAuthorizeEndpoint {
-  private readonly federatedSignIn: SimCognitoFederatedSignIn;
+  private readonly signIn: SimCognitoHostedSignIn;
   private readonly clock: SimClock;
   private readonly hostedClient = new SimCognitoHostedClient();
   private readonly request = new SimCognitoAuthorizeRequest();
 
   constructor(properties: SimCognitoAuthorizeEndpointProperties) {
-    this.federatedSignIn = properties.federatedSignIn;
+    this.signIn = properties.signIn;
     this.clock = properties.clock;
   }
 
   /**
-   * Sign a user in through an identity provider, and send the browser back to
-   * the application with an authorization code.
+   * Sign a user in, and send the browser back to the application with an
+   * authorization code.
    */
   handle(
     pool: SimCognitoUserPool,
@@ -63,12 +64,7 @@ export class SimCognitoAuthorizeEndpoint {
     this.request.requireChallengeMethod(input);
 
     const scopes = new SimCognitoGrantedScopes(client, input.scope);
-    const provider = this.request.requiredProvider(pool, client, input);
-    const user = this.federatedSignIn.signIn({
-      pool,
-      provider,
-      now: this.clock.now(),
-    });
+    const user = this.signIn.signIn(pool, client, input);
 
     const code = new SimCognitoAuthorizationCode({
       username: user.username,

--- a/src/service/cognito/command/hosted/sim-cognito-authorize-request.ts
+++ b/src/service/cognito/command/hosted/sim-cognito-authorize-request.ts
@@ -17,8 +17,12 @@ const tokenResponseType = "token";
 
 /**
  * The provider name the pool's own users sign in under.
+ *
+ * Real Cognito takes this in an `identity_provider` to mean the local sign-in
+ * form rather than any external provider, and a request naming no provider at
+ * all reaches the same place once the person has chosen it.
  */
-const localProviderName = "COGNITO";
+const simCognitoLocalProviderName = "COGNITO";
 
 /**
  * What an authorize request asked for, once it has been checked.
@@ -98,29 +102,24 @@ export class SimCognitoAuthorizeRequest {
   }
 
   /**
-   * The identity provider this request signs the user in through.
+   * The identity provider this request signs the user in through, and nothing
+   * where it signs one of the pool's own users in.
    *
-   * A request naming none would reach managed login on real Cognito, which is
-   * a page rather than anything an API answers, so it is refused here with a
-   * message saying what to do instead.
+   * A request naming no provider, or naming `COGNITO`, is a local sign-in: on
+   * real Cognito it reaches managed login's own form, and here it carries the
+   * username and password that form would have posted.
    */
-  requiredProvider(
+  signInProvider(
     pool: SimCognitoUserPool,
     client: SimCognitoUserPoolClient,
     input: SimCognitoAuthorizeInput,
-  ): SimCognitoUserPoolIdentityProvider {
+  ): SimCognitoUserPoolIdentityProvider | undefined {
     const named = input.identity_provider ?? input.idp_identifier;
 
-    if (named === undefined || named === localProviderName) {
-      throw new SimCognitoOAuthError({
-        code: "invalid_request",
-        description:
-          "This request would reach managed login, which is a sign-in page " +
-          "rather than anything this simulation can answer. Name an " +
-          "identity_provider to sign in through, or sign the pool's own " +
-          "users in with InitiateAuth or AdminInitiateAuth.",
-        redirectable: false,
-      });
+    if (named === undefined || named === simCognitoLocalProviderName) {
+      this.requireSupportedProviderName(client, simCognitoLocalProviderName);
+
+      return undefined;
     }
 
     const providers = pool.auth.identityProviders;
@@ -134,20 +133,28 @@ export class SimCognitoAuthorizeRequest {
       });
     }
 
-    this.requireSupportedProvider(client, provider);
+    this.requireSupportedProviderName(client, provider.name);
 
     return provider;
   }
 
-  private requireSupportedProvider(
+  /**
+   * Refuse a provider the app client does not offer.
+   *
+   * `COGNITO` is checked the same way, because real Cognito treats it as one
+   * of the entries in `SupportedIdentityProviders`: a client without it there
+   * signs nobody in at the hosted domain with a password, however many local
+   * users the pool holds.
+   */
+  private requireSupportedProviderName(
     client: SimCognitoUserPoolClient,
-    provider: SimCognitoUserPoolIdentityProvider,
+    providerName: string,
   ): void {
-    if (!client.oauth.allowsIdentityProvider(provider.name)) {
+    if (!client.oauth.allowsIdentityProvider(providerName)) {
       throw new SimCognitoOAuthError({
         code: "unauthorized_client",
         description:
-          `App client ${client.id} does not support the ${provider.name} ` +
+          `App client ${client.id} does not support the ${providerName} ` +
           `identity provider: add it to the client's ` +
           `SupportedIdentityProviders`,
         redirectable: true,

--- a/src/service/cognito/command/hosted/sim-cognito-hosted-commands.ts
+++ b/src/service/cognito/command/hosted/sim-cognito-hosted-commands.ts
@@ -3,6 +3,7 @@ import { SimCognitoFederatedSignIn } from "../../user-pool/idp/sim-cognito-feder
 import type { SimCognitoTokenIssuer } from "../../user-pool/token/sim-cognito-token-issuer.js";
 import type { SimCognitoUserFactory } from "../../user-pool/user/sim-cognito-user-factory.js";
 import { SimCognitoAuthorizeEndpoint } from "./sim-cognito-authorize-endpoint.js";
+import { SimCognitoHostedSignIn } from "./sim-cognito-hosted-sign-in.js";
 import { SimCognitoLogoutEndpoint } from "./sim-cognito-logout-endpoint.js";
 import { SimCognitoTokenEndpoint } from "./sim-cognito-token-endpoint.js";
 
@@ -30,7 +31,10 @@ export class SimCognitoHostedCommands {
     const { tokenIssuer, userFactory, clock } = properties;
 
     this.authorize = new SimCognitoAuthorizeEndpoint({
-      federatedSignIn: new SimCognitoFederatedSignIn({ userFactory }),
+      signIn: new SimCognitoHostedSignIn({
+        federatedSignIn: new SimCognitoFederatedSignIn({ userFactory }),
+        clock,
+      }),
       clock,
     });
     this.token = new SimCognitoTokenEndpoint({ tokenIssuer, clock });

--- a/src/service/cognito/command/hosted/sim-cognito-hosted-password-sign-in.iso.test.ts
+++ b/src/service/cognito/command/hosted/sim-cognito-hosted-password-sign-in.iso.test.ts
@@ -1,0 +1,345 @@
+import { createHash } from "node:crypto";
+
+import {
+  AdminCreateUserCommand,
+  AdminSetUserMFAPreferenceCommand,
+  SignUpCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { CognitoJwtVerifier } from "aws-jwt-verify";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  SimCognitoInvalidParameterException,
+  SimCognitoNotAuthorizedException,
+  SimCognitoUserNotConfirmedException,
+  SimCognitoUserNotFoundException,
+} from "../../error/sim-cognito.error.js";
+import { SimCognitoOAuthError } from "../../error/sim-cognito-oauth.error.js";
+import {
+  simCognitoCallbackUrl,
+  simCognitoHosted,
+  simCognitoLocalPassword,
+  simCognitoLocalUser,
+  simCognitoLocalUsername,
+  type SimCognitoHostedSetUp,
+} from "../../../../../test/cognito/federation-fixture.js";
+
+/**
+ * The authorize parameters managed login's own form posts, which is what the
+ * request arrived with plus the two fields the person filled in.
+ */
+function signInInput(
+  setUp: SimCognitoHostedSetUp,
+  overrides: Record<string, string> = {},
+): Record<string, string> {
+  return {
+    response_type: "code",
+    client_id: setUp.clientId,
+    redirect_uri: simCognitoCallbackUrl,
+    scope: "openid email",
+    state: "csrf-token",
+    username: simCognitoLocalUsername,
+    password: simCognitoLocalPassword,
+    ...overrides,
+  };
+}
+
+/**
+ * The code a redirect carries, the way the browser hands it to the callback.
+ */
+function codeIn(location: string): string {
+  const code = new URL(location).searchParams.get("code");
+  assertNonNullable(code);
+
+  return code;
+}
+
+describe("Signing a local sim Cognito user in at the authorize endpoint", () => {
+  it("issues a code the token endpoint exchanges for tokens", async () => {
+    // Given a hosted domain over a pool holding a confirmed user of its own.
+    const setUp = await simCognitoHosted();
+    await simCognitoLocalUser(setUp);
+    const pool = setUp.cognito.userPool(setUp.userPoolId);
+
+    // When the username and password managed login would have taken reach the
+    // authorize endpoint.
+    const redirect = await setUp.cognito.hostedAuthorize(
+      pool,
+      signInInput(setUp),
+    );
+
+    // Then the browser goes back to the app client's callback URL with a code
+    // and the state the request was given.
+    const location = new URL(redirect.location);
+    assertIdentical(location.origin + location.pathname, simCognitoCallbackUrl);
+    assertIdentical(location.searchParams.get("state"), "csrf-token");
+    assertIdentical(redirect.username, simCognitoLocalUsername);
+
+    // And the application's own server exchanges that code for tokens.
+    const tokens = await setUp.cognito.hostedToken(pool, {
+      grant_type: "authorization_code",
+      client_id: setUp.clientId,
+      code: codeIn(redirect.location),
+      redirect_uri: simCognitoCallbackUrl,
+    });
+
+    assertIdentical(tokens.token_type, "Bearer");
+    assertNonNullable(tokens.access_token);
+    assertNonNullable(tokens.refresh_token);
+    assertNonNullable(tokens.id_token);
+
+    // And the id token verifies against the pool, naming the user that signed
+    // in rather than one a provider federated.
+    const verifier = CognitoJwtVerifier.create({
+      userPoolId: setUp.userPoolId,
+      tokenUse: "id",
+      clientId: setUp.clientId,
+    });
+    verifier.cacheJwks(pool.jwks());
+
+    const claims = await verifier.verify(tokens.id_token);
+    assertIdentical(claims["cognito:username"], simCognitoLocalUsername);
+    assertIdentical(claims["email"], `${simCognitoLocalUsername}@example.com`);
+  });
+
+  it("honours a PKCE challenge the sign-in carried", async () => {
+    // Given a hosted domain over a pool holding a confirmed user of its own.
+    const setUp = await simCognitoHosted();
+    await simCognitoLocalUser(setUp);
+    const pool = setUp.cognito.userPool(setUp.userPoolId);
+    const codeVerifier = "a-code-verifier-of-a-perfectly-reasonable-length";
+
+    // When the sign-in carries the challenge that verifier hashes to.
+    const redirect = await setUp.cognito.hostedAuthorize(
+      pool,
+      signInInput(setUp, {
+        code_challenge: createHash("sha256")
+          .update(codeVerifier)
+          .digest("base64url"),
+        code_challenge_method: "S256",
+      }),
+    );
+
+    // Then the verifier exchanges the code, and a request without it does not.
+    const code = codeIn(redirect.location);
+    assertInstanceOf(
+      await assertThrowsErrorAsync(async () => {
+        await setUp.cognito.hostedToken(pool, {
+          grant_type: "authorization_code",
+          client_id: setUp.clientId,
+          code,
+          redirect_uri: simCognitoCallbackUrl,
+        });
+      }),
+      SimCognitoOAuthError,
+    );
+
+    const retried = await setUp.cognito.hostedAuthorize(
+      pool,
+      signInInput(setUp, {
+        code_challenge: createHash("sha256")
+          .update(codeVerifier)
+          .digest("base64url"),
+        code_challenge_method: "S256",
+      }),
+    );
+    const tokens = await setUp.cognito.hostedToken(pool, {
+      grant_type: "authorization_code",
+      client_id: setUp.clientId,
+      code: codeIn(retried.location),
+      redirect_uri: simCognitoCallbackUrl,
+      code_verifier: codeVerifier,
+    });
+
+    assertNonNullable(tokens.access_token);
+  });
+
+  it("issues no code for a wrong password", async () => {
+    // Given a hosted domain over a pool holding a confirmed user of its own.
+    const setUp = await simCognitoHosted();
+    await simCognitoLocalUser(setUp);
+    const pool = setUp.cognito.userPool(setUp.userPoolId);
+
+    // When the sign-in carries the wrong password.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.hostedAuthorize(
+        pool,
+        signInInput(setUp, { password: "not-the-password" }),
+      );
+    });
+
+    assertInstanceOf(error, SimCognitoNotAuthorizedException);
+
+    // Then it is refused the way every other sign-in refuses one, with no
+    // redirect for a browser to follow and so no code to take from it.
+    assertStringIncludes(error.message, "Incorrect username or password");
+  });
+
+  it("refuses a user that has not confirmed its sign-up", async () => {
+    // Given a pool holding a user that signed itself up and stopped there.
+    const setUp = await simCognitoHosted();
+    const pool = setUp.cognito.userPool(setUp.userPoolId);
+
+    await setUp.cognito.signUp(
+      new SignUpCommand({
+        ClientId: setUp.clientId,
+        Username: simCognitoLocalUsername,
+        Password: simCognitoLocalPassword,
+        UserAttributes: [
+          { Name: "email", Value: `${simCognitoLocalUsername}@example.com` },
+        ],
+      }),
+    );
+
+    // When it signs in with the password it chose.
+    assertInstanceOf(
+      await assertThrowsErrorAsync(async () => {
+        await setUp.cognito.hostedAuthorize(pool, signInInput(setUp));
+      }),
+      SimCognitoUserNotConfirmedException,
+    );
+  });
+
+  it("refuses a user the pool does not have", async () => {
+    // Given a pool holding no users at all.
+    const setUp = await simCognitoHosted();
+    const pool = setUp.cognito.userPool(setUp.userPoolId);
+
+    // When a sign-in names one.
+    assertInstanceOf(
+      await assertThrowsErrorAsync(async () => {
+        await setUp.cognito.hostedAuthorize(
+          pool,
+          signInInput(setUp, { username: "nobody" }),
+        );
+      }),
+      // The app client is on the `LEGACY` default, which says the user is not
+      // there. One with `PreventUserExistenceErrors` of `ENABLED` refuses it
+      // as a wrong password instead, and does so here for the same reason it
+      // does at InitiateAuth: this is the check InitiateAuth makes.
+      SimCognitoUserNotFoundException,
+    );
+  });
+
+  it("says what to pass when the request carries no credentials", async () => {
+    // Given a hosted domain over a pool holding a confirmed user of its own.
+    const setUp = await simCognitoHosted();
+    await simCognitoLocalUser(setUp);
+    const pool = setUp.cognito.userPool(setUp.userPoolId);
+    const { username, password, ...withoutCredentials } = signInInput(setUp);
+
+    // When an authorize request names neither a provider nor a user.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.hostedAuthorize(pool, withoutCredentials);
+    });
+
+    assertInstanceOf(error, SimCognitoOAuthError);
+
+    // Then it says which two fields a local sign-in needs, because the page
+    // that asks a person for them belongs to the serving layer rather than to
+    // this endpoint.
+    assertStringIncludes(error.message, "needs a username and a password");
+    assertIdentical(username, simCognitoLocalUsername);
+    assertIdentical(password, simCognitoLocalPassword);
+  });
+
+  it("signs a local user in through an identity_provider of COGNITO", async () => {
+    // Given a hosted domain over a pool holding a confirmed user of its own.
+    const setUp = await simCognitoHosted();
+    await simCognitoLocalUser(setUp);
+    const pool = setUp.cognito.userPool(setUp.userPoolId);
+
+    // When the sign-in names the local provider, as a request that skipped the
+    // provider choice does.
+    const redirect = await setUp.cognito.hostedAuthorize(
+      pool,
+      signInInput(setUp, { identity_provider: "COGNITO" }),
+    );
+
+    // Then the same user signs in and the same code comes back.
+    assertIdentical(redirect.username, simCognitoLocalUsername);
+    assertNonNullable(codeIn(redirect.location));
+  });
+
+  it("refuses a client that does not support the pool's own users", async () => {
+    // Given an app client offering Google alone.
+    const setUp = await simCognitoHosted({ identityProviders: ["Google"] });
+    await simCognitoLocalUser(setUp);
+    const pool = setUp.cognito.userPool(setUp.userPoolId);
+
+    // When one of the pool's own users signs in through it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.hostedAuthorize(pool, signInInput(setUp));
+    });
+
+    assertInstanceOf(error, SimCognitoOAuthError);
+
+    // Then it is refused, because a client signs in only through the providers
+    // it lists, and COGNITO is one of those.
+    assertStringIncludes(
+      error.message,
+      "does not support the COGNITO identity provider",
+    );
+  });
+
+  it("refuses a user holding a temporary password", async () => {
+    // Given a user an admin created and set no permanent password on.
+    const setUp = await simCognitoHosted();
+    const pool = setUp.cognito.userPool(setUp.userPoolId);
+
+    await setUp.cognito.adminCreateUser(
+      new AdminCreateUserCommand({
+        UserPoolId: setUp.userPoolId,
+        Username: simCognitoLocalUsername,
+        TemporaryPassword: simCognitoLocalPassword,
+      }),
+    );
+
+    // When it signs in with that password.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.hostedAuthorize(pool, signInInput(setUp));
+    });
+
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+
+    // Then it says which page real managed login would have answered with.
+    assertStringIncludes(error.message, "asking for a new one");
+  });
+
+  it("refuses a user that owes a second factor", async () => {
+    // Given a pool that challenges the users which registered a factor, and a
+    // user registered for the one its phone number receives.
+    const setUp = await simCognitoHosted({ mfaConfiguration: "OPTIONAL" });
+    await simCognitoLocalUser(setUp, {
+      attributes: [{ Name: "phone_number", Value: "+441632960123" }],
+    });
+    const pool = setUp.cognito.userPool(setUp.userPoolId);
+
+    await setUp.cognito.adminSetUserMFAPreference(
+      new AdminSetUserMFAPreferenceCommand({
+        UserPoolId: setUp.userPoolId,
+        Username: simCognitoLocalUsername,
+        SMSMfaSettings: { Enabled: true, PreferredMfa: true },
+      }),
+    );
+
+    // When it signs in with the right password.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.hostedAuthorize(pool, signInInput(setUp));
+    });
+
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+
+    // Then it says which page real managed login would have answered with, and
+    // where the challenge this simulation does issue is answered.
+    assertStringIncludes(error.message, "SMS_MFA");
+    assertStringIncludes(error.message, "InitiateAuth");
+  });
+});

--- a/src/service/cognito/command/hosted/sim-cognito-hosted-password-sign-in.ts
+++ b/src/service/cognito/command/hosted/sim-cognito-hosted-password-sign-in.ts
@@ -1,0 +1,119 @@
+import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
+import { SimCognitoOAuthError } from "../../error/sim-cognito-oauth.error.js";
+import {
+  requireSimCognitoConfirmed,
+  requireSimCognitoSignIn,
+  requireSimCognitoSignInUser,
+} from "../../user-pool/auth/sim-cognito-sign-in.js";
+import type { SimCognitoUserPoolClient } from "../../user-pool/client/sim-cognito-user-pool-client.js";
+import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
+import type { SimCognitoUser } from "../../user-pool/user/sim-cognito-user.js";
+import { simCognitoChallengeFactor } from "../auth/sim-cognito-mfa-factor-choice.js";
+import type { SimCognitoAuthorizeInput } from "./hosted-auth.command.js";
+
+/**
+ * The credentials a local sign-in at the authorize endpoint carries.
+ */
+interface SimCognitoHostedCredentials {
+  readonly username: string;
+  readonly password: string;
+}
+
+/**
+ * Signing one of a pool's own users in at the authorize endpoint.
+ *
+ * Real managed login takes the username and the password from its form and
+ * checks them the way `InitiateAuth` checks them. The same user lookup, the
+ * same refusal for a wrong password, and the same one for an account nobody
+ * has confirmed. Those checks are called from here, so the two sign-ins stay
+ * the same sign-in.
+ *
+ * Managed login has two more answers, and both are pages. A user owing a
+ * second factor is asked for the code, and one holding a temporary password is
+ * asked for a new one. Neither page is simulated, and a sign-in that would
+ * reach one is refused here with a message saying which.
+ */
+export class SimCognitoHostedPasswordSignIn {
+  /**
+   * The user this request signs in, having checked its password.
+   */
+  signIn(
+    pool: SimCognitoUserPool,
+    client: SimCognitoUserPoolClient,
+    input: SimCognitoAuthorizeInput,
+  ): SimCognitoUser {
+    const { username, password } = this.requiredCredentials(input);
+    const user = requireSimCognitoSignInUser(pool, client, username);
+
+    requireSimCognitoSignIn(user, password);
+    requireSimCognitoConfirmed(user);
+
+    this.requireNoFurtherPage(pool, user);
+
+    return user;
+  }
+
+  /**
+   * The username and password the request carried.
+   *
+   * A request carrying neither, and naming no identity provider, is one a
+   * browser would have been shown the sign-in page for. Calling
+   * `hostedAuthorize` directly skips that page, so this says what to pass
+   * instead.
+   */
+  private requiredCredentials(
+    input: SimCognitoAuthorizeInput,
+  ): SimCognitoHostedCredentials {
+    const { username, password } = input;
+
+    if (
+      username === undefined ||
+      username === "" ||
+      password === undefined ||
+      password === ""
+    ) {
+      throw new SimCognitoOAuthError({
+        code: "invalid_request",
+        description:
+          "This request names no identity provider, so it signs in one of " +
+          "the pool's own users and needs a username and a password. Pass " +
+          "both, or name an identity_provider to sign in through.",
+        redirectable: false,
+      });
+    }
+
+    return { username, password };
+  }
+
+  /**
+   * Refuse a sign-in real managed login answers with a page of its own.
+   *
+   * `simCognitoChallengeFactor` refuses the second factors it cannot
+   * challenge for and answers with the ones it can, and neither is a code, so
+   * a user with a factor is refused here whichever it has.
+   */
+  private requireNoFurtherPage(
+    pool: SimCognitoUserPool,
+    user: SimCognitoUser,
+  ): void {
+    if (user.status.mustChangePassword) {
+      throw new SimCognitoInvalidParameterException(
+        `User ${user.username} holds a temporary password, so real managed ` +
+          `login would answer this sign-in with a page asking for a new one, ` +
+          `which is not simulated. Set a permanent password on the user with ` +
+          `AdminSetUserPassword.`,
+      );
+    }
+
+    const factor = simCognitoChallengeFactor(pool, user);
+
+    if (factor !== undefined) {
+      throw new SimCognitoInvalidParameterException(
+        `User ${user.username} is challenged for ${factor}, so real managed ` +
+          `login would answer this sign-in with a page asking for the code, ` +
+          `which is not simulated. Sign the user in with InitiateAuth, which ` +
+          `answers the challenge this simulation issues.`,
+      );
+    }
+  }
+}

--- a/src/service/cognito/command/hosted/sim-cognito-hosted-sign-in.ts
+++ b/src/service/cognito/command/hosted/sim-cognito-hosted-sign-in.ts
@@ -1,0 +1,55 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import type { SimCognitoUserPoolClient } from "../../user-pool/client/sim-cognito-user-pool-client.js";
+import type { SimCognitoFederatedSignIn } from "../../user-pool/idp/sim-cognito-federated-sign-in.js";
+import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
+import type { SimCognitoUser } from "../../user-pool/user/sim-cognito-user.js";
+import { SimCognitoAuthorizeRequest } from "./sim-cognito-authorize-request.js";
+import { SimCognitoHostedPasswordSignIn } from "./sim-cognito-hosted-password-sign-in.js";
+import type { SimCognitoAuthorizeInput } from "./hosted-auth.command.js";
+
+interface SimCognitoHostedSignInProperties {
+  readonly federatedSignIn: SimCognitoFederatedSignIn;
+  readonly clock: SimClock;
+}
+
+/**
+ * Which user an authorize request signs in.
+ *
+ * Real Cognito has two answers here. A request naming an identity provider
+ * goes to that provider's own sign-in page, and one naming none goes to
+ * managed login's form. The choice is made from the same parameter either way,
+ * so it is made in one place, and what comes back is the pool user the
+ * authorization code is issued for.
+ */
+export class SimCognitoHostedSignIn {
+  private readonly federatedSignIn: SimCognitoFederatedSignIn;
+  private readonly clock: SimClock;
+  private readonly request = new SimCognitoAuthorizeRequest();
+  private readonly passwordSignIn = new SimCognitoHostedPasswordSignIn();
+
+  constructor(properties: SimCognitoHostedSignInProperties) {
+    this.federatedSignIn = properties.federatedSignIn;
+    this.clock = properties.clock;
+  }
+
+  /**
+   * The user this request signs in, at a provider or in the pool itself.
+   */
+  signIn(
+    pool: SimCognitoUserPool,
+    client: SimCognitoUserPoolClient,
+    input: SimCognitoAuthorizeInput,
+  ): SimCognitoUser {
+    const provider = this.request.signInProvider(pool, client, input);
+
+    if (provider === undefined) {
+      return this.passwordSignIn.signIn(pool, client, input);
+    }
+
+    return this.federatedSignIn.signIn({
+      pool,
+      provider,
+      now: this.clock.now(),
+    });
+  }
+}

--- a/src/service/cognito/serve/sim-cognito-authorize-refusals.iso.test.ts
+++ b/src/service/cognito/serve/sim-cognito-authorize-refusals.iso.test.ts
@@ -217,21 +217,21 @@ describe("Refusals from a sim Cognito authorize endpoint", () => {
     );
   });
 
-  it("refuses a request that would reach managed login", async () => {
+  it("refuses a local sign-in that carries no credentials", async () => {
     // Given a pool with a domain.
     const setUp = await simCognitoHosted();
     const { identity_provider: unused, ...withoutProvider } =
       authorizeParameters(setUp);
 
-    // When an authorize request names no identity provider.
+    // When an authorize request names no identity provider and no user.
     const response = await authorize(setUp, withoutProvider);
 
-    // Then it says so, rather than answering with a sign-in page this
-    // simulation has no equivalent of.
+    // Then it says which two fields a sign-in by one of the pool's own users
+    // needs.
     assertIdentical(response.status, 400);
     assertStringIncludes(
       await refusedBody(response),
-      "This request would reach managed login",
+      "needs a username and a password",
     );
     assertIdentical(unused, "Google");
   });

--- a/test/cognito/federation-fixture.ts
+++ b/test/cognito/federation-fixture.ts
@@ -9,7 +9,13 @@
  * published build.
  */
 
+import type {
+  AttributeType,
+  UserPoolMfaType,
+} from "@aws-sdk/client-cognito-identity-provider";
 import {
+  AdminCreateUserCommand,
+  AdminSetUserPasswordCommand,
   CreateIdentityProviderCommand,
   CreateUserPoolClientCommand,
   CreateUserPoolCommand,
@@ -55,11 +61,38 @@ export interface SimCognitoHostedSetUpOptions {
   /** The scopes the app client allows, `openid` and `email` by default. */
   readonly scopes?: readonly string[];
 
-  /** The providers the app client supports, `Google` by default. */
+  /**
+   * The providers the app client supports, the pool's own users and `Google`
+   * by default.
+   */
   readonly identityProviders?: readonly string[];
 
   /** The domain the pool is created with, the prefix form by default. */
   readonly domain?: string;
+
+  /** What the pool asks of a second factor, `OFF` by default. */
+  readonly mfaConfiguration?: UserPoolMfaType;
+}
+
+/**
+ * The username the pool's own user in these tests holds.
+ */
+export const simCognitoLocalUsername = "alice";
+
+/**
+ * The password that user signs in with.
+ */
+export const simCognitoLocalPassword = "Sup3rSecret!";
+
+export interface SimCognitoLocalUserOptions {
+  /** The username the user holds, `alice` by default. */
+  readonly username?: string;
+
+  /** The password it signs in with. */
+  readonly password?: string;
+
+  /** The attributes it is created with, an email address by default. */
+  readonly attributes?: AttributeType[];
 }
 
 /**
@@ -72,14 +105,19 @@ export async function simCognitoHosted(
   const {
     generateSecret = false,
     scopes = ["openid", "email"],
-    identityProviders = ["Google"],
+    identityProviders = ["COGNITO", "Google"],
     domain = simCognitoDomainPrefix,
   } = options;
   const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
   const cognito = simAws.cognitoIdentityProvider();
 
   const pool = await cognito.createUserPool(
-    new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+    new CreateUserPoolCommand({
+      PoolName: "myapp-users",
+      ...(options.mfaConfiguration !== undefined && {
+        MfaConfiguration: options.mfaConfiguration,
+      }),
+    }),
   );
   assertNonNullable(pool.UserPool?.Id);
   const userPoolId = pool.UserPool.Id;
@@ -138,6 +176,40 @@ export async function simCognitoHosted(
     clientId: client.UserPoolClient.ClientId,
     clientSecret: client.UserPoolClient.ClientSecret,
   };
+}
+
+/**
+ * A confirmed user of the pool's own, holding a password it signs in with.
+ *
+ * An admin creates it and sets a permanent password on it, which is the
+ * shortest route to a user in `CONFIRMED`. The sign-up route to the same place
+ * is what the sign-up tests drive.
+ */
+export async function simCognitoLocalUser(
+  setUp: SimCognitoHostedSetUp,
+  options: SimCognitoLocalUserOptions = {},
+): Promise<void> {
+  const {
+    username = simCognitoLocalUsername,
+    password = simCognitoLocalPassword,
+    attributes = [{ Name: "email", Value: `${username}@example.com` }],
+  } = options;
+
+  await setUp.cognito.adminCreateUser(
+    new AdminCreateUserCommand({
+      UserPoolId: setUp.userPoolId,
+      Username: username,
+      UserAttributes: attributes,
+    }),
+  );
+  await setUp.cognito.adminSetUserPassword(
+    new AdminSetUserPasswordCommand({
+      UserPoolId: setUp.userPoolId,
+      Username: username,
+      Password: password,
+      Permanent: true,
+    }),
+  );
 }
 
 /**


### PR DESCRIPTION
`/oauth2/authorize` signs one of a pool's own users in where the request names no identity provider. The username and password real managed login takes from its form arrive beside the parameters the request already carries, and are checked with the checks `InitiateAuth` makes, so a wrong password, an unknown user and an unconfirmed account are refused the way they are refused everywhere else in this simulation. The app client needs `COGNITO` among its `SupportedIdentityProviders`, as it does on real Cognito. A sign-in real managed login would answer with a further page, which is a user owing a second factor and a user holding a temporary password, is refused with a message naming the page and where the simulation does issue that challenge.

This is the first half of #652. The three served pages, and the form posts behind them, follow in a second pull request. Splitting it keeps this one to the sign-in itself, which is what most tests will reach for and what involves no HTML at all.

Part of #652