### PR TITLE
docs: plain prose in six more READMEs

### DIFF
--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -10,8 +10,8 @@ tests.
 ## How it works
 
 `SimSdk` replaces the `send` method of an intercepted SDK client. Each sent Command is routed by
-name to the matching operation of a simulated AWS service, and the result is returned to the
-caller as a normal SDK response. Nothing touches the network.
+name to the matching operation of a simulated AWS service, and the result comes back to the caller
+as a normal SDK response. Every Command is served in process.
 
 Every `SimSdk` owns a simulated AWS environment. You can let it create its own, or give it an
 existing one to share:
@@ -62,25 +62,25 @@ You can intercept a client class or a client instance:
 
 - **A class** (`simSdk.intercept(S3Client)`) intercepts every instance of it, including instances
   the code under test constructs later. This is the most common choice.
-- **An instance** (`simSdk.intercept(s3Client)`) intercepts only that instance, which is useful
-  when a specific client should hit the simulator while others are handled differently.
+- **An instance** (`simSdk.intercept(s3Client)`) intercepts only that instance. Use it when one
+  client should hit the simulator and the others are handled some other way.
 
-A client can only have one interception at a time: intercepting an already-intercepted client
-throws a diagnostic error rather than silently replacing the existing interception.
+A client can only have one interception at a time. Intercepting an already-intercepted client
+throws a diagnostic error, and the existing interception stays in place.
 
 ## Account and Region scope
 
-The simulated Account and Region scope is resolved for each sent Command, never fixed per client:
+Each sent Command resolves its own simulated Account and Region scope:
 
 1. The **Region** comes from the sending client's own configuration, such as
    `new S3Client({ region: "eu-west-2" })`, falling back to the simulation default.
 2. The **Account** comes from the ambient `simAws.runAs(...)` caller when one is set, falling back
    to the simulation default Account.
 
-The resolved caller is passed through to the simulated service, so simulated
-[IAM](../services/iam/) authorization applies to it exactly as for direct sim service use: a
-caller without permission for a Command is denied, like real AWS. When no caller can be
-identified, Commands run as the simulation's default Account root.
+The resolved caller reaches the simulated service, and simulated [IAM](../services/iam/)
+authorization applies to it exactly as it does for direct sim service use. A caller without
+permission for a Command is denied, as on real AWS. Where no caller can be identified, Commands run
+as the simulation's default Account root.
 
 `runAs` runs a function with an ambient simulated caller, such as an IAM Role. Commands sent during
 the run are attributed to that caller, with no changes to the client or the code under test:
@@ -151,17 +151,17 @@ await simAws.runAs(
 simSdk.restoreAll();
 ```
 
-The ambient caller is scoped to its own `SimAws` instance, so separate simulations in the same
-process never observe each other's callers.
+The ambient caller belongs to its own `SimAws` instance. Separate simulations in the same process
+each keep their own.
 
 ## Restoring interception
 
 Restoring puts back the client's real SDK `send`:
 
-- `interception.restore()` restores one interception; `simSdk.intercept(...)` returns the handle.
+- `interception.restore()` restores one interception. `simSdk.intercept(...)` returns the handle.
 - `simSdk.restoreAll()` restores everything intercepted through that `SimSdk`.
-- `SimSdk` and interception handles are disposable, so `using simSdk = new SimSdk();` restores
-  automatically at the end of the scope, which is convenient in tests.
+- `SimSdk` and interception handles are disposable. `using simSdk = new SimSdk();` restores
+  automatically at the end of the scope.
 
 ## Choosing Commands to intercept
 
@@ -172,10 +172,10 @@ throw a diagnostic error.
 
 ## The DynamoDB document client
 
-`@aws-sdk/lib-dynamodb` lets application code write `{ id: "a", count: 1 }` rather than
-`{ id: { S: "a" }, count: { N: "1" } }`. Intercept the document client and its Commands reach
-simulated DynamoDB with the values converted, so code written against it needs no changes to run
-against the simulator.
+`@aws-sdk/lib-dynamodb` takes plain JavaScript values. Application code writes
+`{ id: "a", count: 1 }` where the base client wants `{ id: { S: "a" }, count: { N: "1" } }`.
+Intercept the document client and its Commands reach simulated DynamoDB with the values already
+converted. Code written against the document client runs against the simulator unchanged.
 
 ```typescript sim-sdk-document-client
 /**
@@ -228,17 +228,16 @@ console.log(read.Item?.["total"]); // 42
 console.log(read.Item?.["paid"]); // true
 ```
 
-`DynamoDBDocumentClient.from(client)` builds a separate object rather than wrapping the client in
-place, and that object is not an instance of `DynamoDBClient`. Intercepting the base client
-therefore does nothing for Commands sent through the document client. Intercept the document
-client. Both can be intercepted at once, and they reach the same simulated tables, since the
-document client shares the base client's config and so resolves the same Account and Region.
+`DynamoDBDocumentClient.from(client)` builds a separate object of its own class. Intercepting the
+base client therefore leaves Commands sent through the document client alone. Intercept the
+document client. Both can be intercepted at once, and they reach
+the same simulated tables, since the document client shares the base client's config and so
+resolves the same Account and Region.
 
 The real document client converts values in middleware, which runs inside the `send` that
 interception replaces. So the conversion happens at the interception boundary instead, using the
-option defaults `lib-dynamodb` sets rather than the `util-dynamodb` ones. Which native types map to
-which descriptors is in
-[the sim DynamoDB docs](../services/dynamodb/README.md#the-document-client).
+option defaults `lib-dynamodb` sets (not the `util-dynamodb` ones). Which native types map to which
+descriptors is in [the sim DynamoDB docs](../services/dynamodb/README.md#the-document-client).
 
 ## Supported services and Commands
 
@@ -248,7 +247,7 @@ EventBridge, EventBridge Scheduler, IAM, KMS, Lambda, Rekognition, Route53, S3, 
 SES, SNS, SQS, SSM and STS. Each service's own docs under
 [docs/services](../services/) list the Commands it simulates.
 
-Both kinds of gap are refused on send rather than misbehaving silently, with a different error each:
+A gap in that coverage is refused on send, with a different error for each kind:
 
 - A Command the simulated service doesn't support throws `SimSdkUnsupportedCommandError`, naming the
   Command and listing the Commands that service does support.
@@ -258,14 +257,14 @@ Both kinds of gap are refused on send rather than misbehaving silently, with a d
 ## Limitations
 
 - Only `client.send(command)` is intercepted. SDK utilities that bypass `send`, such as
-  `getSignedUrl`, see nothing of interception. Paginators and waiters go through `send`, so they
-  work. Presigning needs no interception: point the client at the simulated endpoint instead, as
+  `getSignedUrl`, run against real AWS. Paginators and waiters go through `send`, so they work. Presigning works without interception. Point the client at the simulated endpoint, as
   [the sim S3 presigned URL docs](../services/s3/README.md#presigned-urls) show.
 - Simulated errors carry SDK-shaped `name` and `$metadata`, but are not instances of the real SDK
-  exception classes: match errors with `error.name`, not `instanceof`.
-- The callback form of `send(command, callback)` is not supported; use the promise form.
+  exception classes. Match an error by its `error.name`. An `instanceof` check against the SDK class
+  fails.
+- The callback form of `send(command, callback)` is not supported. Use the promise form.
 - The translate config a document client is built with,
-  `DynamoDBDocumentClient.from(client, { marshallOptions, unmarshallOptions })`, is not read. The
-  conversion always uses the defaults, so `removeUndefinedValues: true` in particular does not
-  apply: an `undefined` attribute is refused here where AWS would have dropped it. The refusal names
+  `DynamoDBDocumentClient.from(client, { marshallOptions, unmarshallOptions })`, is ignored. The
+  conversion always uses the defaults. `removeUndefinedValues: true` in particular has no effect
+  here, and an `undefined` attribute is refused where AWS would have dropped it. The refusal names
   the attribute and says so.

--- a/docs/services/acm/README.md
+++ b/docs/services/acm/README.md
@@ -388,7 +388,7 @@ needs:
 | `simAws.acm().autoIssueCertificates()` | Never requires validation. Use this when a hosted zone exists for unrelated reasons and you don't care about certificates. |
 | `simAws.acm().requireDnsValidation()`  | Always requires DNS validation. Use this to exercise the validation path without creating a hosted zone first.             |
 
-A standalone `new SimAcm()` instance has no simulated Route53, so it always issues certificates
+A standalone `new SimAcm()` instance has no simulated Route53, and always issues certificates
 immediately. Calling `requireDnsValidation()` on one throws, because nothing can publish the record
 it would then wait for.
 
@@ -510,7 +510,7 @@ await acm.requestCertificate(
 ## Scope certificates to an account and region
 
 Use `SimAws` scopes to create ACM certificates in different simulated accounts and regions. ACM
-state is scoped to the selected account and region — certificates requested in one scope don't
+state is scoped to the selected account and region. Certificates requested in one scope don't
 appear in another.
 
 ```typescript sim-acm-account-region-scoping
@@ -650,9 +650,9 @@ console.log(describeOutput.Certificate?.Status);
 
 ### Validate a certificate from the template
 
-Give a `DomainValidationOptions` entry a `HostedZoneId` and simulated CloudFormation publishes the validation record itself, the same way real CloudFormation does. This is what CDK emits for `CertificateValidation.fromDns(zone)`, so a CDK-synthesized template works without changes.
+Give a `DomainValidationOptions` entry a `HostedZoneId` and simulated CloudFormation publishes the validation record itself, the same way real CloudFormation does. This is what CDK emits for `CertificateValidation.fromDns(zone)`. A CDK-synthesized template works without changes.
 
-A certificate resource is not complete until the certificate is issued — anything depending on the certificate is created after it exists, as in real CloudFormation.
+A certificate resource is only complete once the certificate is issued. Anything depending on the certificate is created after it exists, as in real CloudFormation.
 
 ```typescript sim-acm-cloudformation-dns-validation
 /**
@@ -708,7 +708,7 @@ console.log(stack.outputs.get("CertificateStatus")?.value); // ISSUED
 
 A `HostedZoneId` that names a hosted zone the simulator doesn't hold is skipped rather than failing. Route53 is often managed by another team or another tool. The certificate then follows the usual rule from [Validate a certificate against simulated Route53](#validate-a-certificate-against-simulated-route53): with nothing authoritative for its domain, it's issued without validation.
 
-If a hosted zone covers the domain but the validation record never appears, the stack fails rather than hanging. Real CloudFormation sits in `CREATE_IN_PROGRESS` for hours before timing out — that's not useful in a test, so the resource fails immediately and names the record it waited for.
+If a hosted zone covers the domain but the validation record never appears, the stack fails rather than hanging. Real CloudFormation sits in `CREATE_IN_PROGRESS` for hours before timing out, which is of little use in a test. The resource fails immediately and names the record it waited for.
 
 ## Available functionality
 

--- a/docs/services/apigatewayv2/README.md
+++ b/docs/services/apigatewayv2/README.md
@@ -51,8 +51,8 @@ and only the id tells them apart.
 
 ## Routing requests to a Lambda function
 
-An API needs three more resources before it serves anything: an integration naming the function, a
-route pointing at that integration, and a stage to serve it from. The function also has to allow API
+An API needs three more resources before it serves anything. Those are an integration naming the
+function, a route pointing at that integration, and a stage to serve it from. The function also has to allow API
 Gateway to invoke it. That grant is a permission on the function, not on the API. See
 [Granting the API permission to invoke the function](#granting-the-api-permission-to-invoke-the-function).
 Once all of that exists, `serveSimAws` answers requests to the generated endpoint by invoking the
@@ -252,8 +252,8 @@ from the routes `GET /pets/dog/1`, `GET /pets/dog/{id}`, `GET /pets/{proxy+}`, `
 `$default`.
 
 Rule 1 is documented by AWS, as is the literal-beating-parameter part of rule 3. Three things here
-are observed rather than documented: rule 2, the longest-literal-prefix part of rule 3, and the
-placement of the method comparison above the path comparison. Each is marked in the code next to the
+are observed rather than documented. They are rule 2, the longest-literal-prefix part of rule 3, and
+the placement of the method comparison above the path comparison. Each is marked in the code next to the
 rule it governs.
 
 A request whose path matches a route with a different method matches no route at all. An API with no
@@ -571,8 +571,8 @@ or carrying a claim that fails is answered with a 401, `{"message":"Unauthorized
 undisclosed, here and on real API Gateway. A mismatched audience is the exception. That one carries
 `error_description="the token does not have a valid audience"`, the one description AWS publishes.
 
-The claims are checked in the order AWS documents: the issuer, then the audience, then `exp`, `nbf`
-and `iat`. There is no allowance for clock skew, and every timestamp comes from the simulation's
+The claims are checked in the order AWS documents. The issuer comes first, then the audience, then
+`exp`, `nbf` and `iat`. There is no allowance for clock skew, and every timestamp comes from the simulation's
 clock. `simAws.clock().advanceBy(...)` expires a token that was accepted a moment before.
 
 ### Identity source
@@ -1318,7 +1318,7 @@ console.log(ordersHandler(order));
 ```
 
 The defaults describe an unauthorized `GET /` reaching the API's default stage, down to the headers
-API Gateway sets itself. The route key and the request agree whichever a test gives: an event for
+API Gateway sets itself. The route key and the request agree whichever a test gives. An event for
 `rawPath: "/orders"` is one for the `GET /orders` route, and an event for `routeKey: "POST /orders"`
 is a POST to `/orders`. A route key whose path is a template captures nothing on its own. An event for
 a parameterised route says the concrete path and its `pathParameters` itself, as above.

--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -247,7 +247,7 @@ request for `/blog/` is passed to the Origin as it arrived, even where that fold
 `index.html`. That is where CloudFront differs from an S3 website index document. The substituted
 path is what the rest of request handling sees, and a Cache Behavior pattern and a `viewer-request`
 CloudFront Function both act on the object being served. The value names an object at the Origin. It may be a
-path such as `public/index.html`, and it must begin with something other than a forward slash. Sim CloudFront refuses one that does with `InvalidDefaultRootObject`. The alternative would
+path such as `public/index.html`, and it must not begin with a forward slash. Sim CloudFront refuses one that does with `InvalidDefaultRootObject`. The alternative would
 be a Distribution that answers its own root with a 403.
 
 A custom error response replaces the Origin's response when its status matches `ErrorCode`. The
@@ -566,7 +566,7 @@ sends a request for `/things` on to `/v1/things`.
 
 Three things follow from the request never leaving the process:
 
-- A domain the simulation has no match for fails with an error naming the Origin and the
+- A domain unknown to the simulation fails with an error naming the Origin and the
   domain. No real request is made to it, and external HTTP Origins are unsupported.
 - The settings inside `CustomOriginConfig` describe how CloudFront connects over the network. The
   protocol policy, ports, SSL protocols and timeouts are accepted and ignored.

--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -6,8 +6,8 @@ Sim CloudFront can be used directly through `SimAws`, and it can also be served 
 alongside other simulated AWS services, so application code can make HTTP requests through a
 CloudFront-like layer without talking to real AWS.
 
-`SimCloudFront` can also be instantiated on its own, in which case it has its own isolated state that
-is not connected to a wider simulated AWS environment.
+`SimCloudFront` can also be instantiated on its own, in which case it has its own isolated state,
+standing apart from any wider simulated AWS environment.
 
 ## Basic Distribution setup
 
@@ -95,33 +95,33 @@ console.log(distributionCreation.Distribution?.DomainName);
 
 ## What an S3 Origin can read
 
-An S3 Origin reads its Bucket through the ordinary GetObject command, so the Bucket policy decides
-what the Distribution can serve. An Origin with no origin access control reads anonymously, which is
-the unsigned request real CloudFront sends to the S3 REST endpoint, so an Object has to be publicly
-readable for the Distribution to serve it. A Bucket with no policy answers 403 for every Object.
+An S3 Origin reads its Bucket through the ordinary GetObject command. The Bucket policy decides what
+the Distribution can serve. An Origin with no origin access control reads anonymously, the unsigned
+request real CloudFront sends to the S3 REST endpoint. An Object has to be publicly readable for the
+Distribution to serve it, and a Bucket with no policy answers 403 for every Object.
 
-An Origin that does have an origin access control reads as the CloudFront service principal instead,
-so the Bucket stays private and its policy names the Distribution. See
+An Origin that does have an origin access control reads as the CloudFront service principal. The
+Bucket stays private and its policy names the Distribution. See
 [Origin access controls](#origin-access-controls) for the Bucket policy that takes.
 
-That is the two commands in the example above: `PutPublicAccessBlockCommand` to opt out of the block
-on public Bucket policies, then `PutBucketPolicyCommand` granting `s3:GetObject` to `Principal: "*"`.
-The same pair is what a static website Bucket needs, and it is what CDK's `publicReadAccess: true`
-generates.
+That is what the two commands in the example above do. `PutPublicAccessBlockCommand` opts out of the
+block on public Bucket policies, then `PutBucketPolicyCommand` grants `s3:GetObject` to
+`Principal: "*"`. The same pair is what a static website Bucket needs, and it is what CDK's
+`publicReadAccess: true` generates.
 
-A denied read reaches the viewer as a 403 from the Origin, so a Distribution's custom error response
-for 403 replaces it. That is what makes the usual single-page-app setup, rewriting 403 to
-`/index.html`, behave here as it does in AWS.
+A denied read reaches the viewer as a 403 from the Origin, and a Distribution's custom error
+response for 403 replaces it. The usual single-page-app setup, rewriting 403 to `/index.html`,
+behaves here as it does in AWS.
 
-`S3OriginConfig.OriginAccessIdentity` is refused rather than read as anonymous. Leave it empty, as
-CloudFront itself writes it for an Origin that signs nothing.
+`S3OriginConfig.OriginAccessIdentity` is refused. Leave it empty, as CloudFront itself writes it for
+an Origin that signs nothing.
 
-## Static sites: default root object and error pages
+## Static sites, default root objects and error pages
 
-A static site behind CloudFront usually leans on two Distribution settings: `DefaultRootObject`, so
-a request for the site root returns the home page, and `CustomErrorResponses`, so a URL that matches
-no object returns the site's own error page rather than the Origin's. Sim CloudFront applies both,
-so a test can assert what a visitor would actually see.
+A static site behind CloudFront usually leans on two Distribution settings. `DefaultRootObject`
+makes a request for the site root return the home page. `CustomErrorResponses` makes a URL that
+matches no object return the site's own error page in place of the Origin's. Sim CloudFront applies
+both, and a test can assert what a visitor would actually see.
 
 ```typescript sim-cloudfront-static-site
 /**
@@ -244,25 +244,24 @@ try {
 
 The default root object stands in for a request to the root of the Distribution and nothing else. A
 request for `/blog/` is passed to the Origin as it arrived, even where that folder holds its own
-`index.html`, which is where CloudFront differs from an S3 website index document. The substituted
-path is what the rest of request handling sees, so a Cache Behavior pattern and a `viewer-request`
-CloudFront Function both act on the object being served rather than on the root. The value names an
-object at the Origin, so it may be a path such as `public/index.html` but must not begin with a
-forward slash: sim CloudFront refuses one that does with `InvalidDefaultRootObject`, rather than
-creating a Distribution that answers its own root with a 403.
+`index.html`. That is where CloudFront differs from an S3 website index document. The substituted
+path is what the rest of request handling sees, and a Cache Behavior pattern and a `viewer-request`
+CloudFront Function both act on the object being served. The value names an object at the Origin. It may be a
+path such as `public/index.html`, and it must begin with something other than a forward slash. Sim CloudFront refuses one that does with `InvalidDefaultRootObject`. The alternative would
+be a Distribution that answers its own root with a 403.
 
-A custom error response replaces the Origin's response when its status matches `ErrorCode`, which is
-one of the codes CloudFront supports: 400, 403, 404, 405, 414, 416, 500, 501, 502, 503 and 504. The
-response page is fetched as a request in its own right, so the Cache Behavior matching
-`ResponsePagePath` chooses which Origin it comes from, and error pages can live somewhere other than
-the content that failed. `ResponseCode` is the status the viewer sees, which is how a single-page
-app serves its shell with a 200 for a URL the Bucket has no object for. It is one of the same error
-codes or 200, the set CloudFront allows. Where the response page is itself missing, the viewer gets
-the status from fetching it, as in CloudFront.
+A custom error response replaces the Origin's response when its status matches `ErrorCode`. The
+codes CloudFront supports are 400, 403, 404, 405, 414, 416, 500, 501, 502, 503 and 504. The response
+page is fetched as a request in its own right, and the Cache Behavior matching `ResponsePagePath`
+chooses which Origin it comes from. Error pages can live somewhere other than the content that
+failed. `ResponseCode` is the status the viewer sees. That is how a single-page app serves its shell
+with a 200 for a URL the Bucket has no object for. It is one of the same error codes or 200, the set
+CloudFront allows. Where the response page is itself missing, the viewer gets the status from
+fetching it, as in CloudFront.
 
-Custom error responses are applied before a `viewer-response` CloudFront Function runs, so the
-function sees the response the viewer is about to get. `ErrorCachingMinTTL` is accepted and ignored,
-along with a rule that sets nothing else, because sim CloudFront has no cache to apply it to.
+Custom error responses are applied before a `viewer-response` CloudFront Function runs. The function
+sees the response the viewer is about to get. `ErrorCachingMinTTL` is accepted and ignored, along
+with a rule that sets nothing else, since sim CloudFront has no cache to apply it to.
 
 ## Serve simulated CloudFront on localhost
 
@@ -373,16 +372,16 @@ The Distribution domain is adapted through `server.localUrl(...)` so that the re
 local Yulin server while preserving the simulated CloudFront hostname.
 
 A test that needs no browser can skip the port. `SimAwsHttp` answers the same requests in the
-process, with no server listening and nothing to adapt the URL for, and an alternate domain name a
-simulated Route53 answers for is requested by its own name: `simAwsHttp.fetch("https://cdn.example.test/")`
-reaches the Distribution behind it. See
+process, with no server listening and no URL to adapt. An alternate domain name a simulated Route53
+answers for is requested by its own name, and `simAwsHttp.fetch("https://cdn.example.test/")` reaches
+the Distribution behind it. See
 [requests without a port](../../serve/#requests-without-a-port "Requests without a port docs").
 
 ## Custom Origins
 
-An Origin with a `CustomOriginConfig` is one CloudFront reaches over HTTP rather than as an S3
+An Origin with a `CustomOriginConfig` is one CloudFront reaches over HTTP, in place of reading an S3
 Bucket. Sim CloudFront resolves its `DomainName` in the simulated environment and serves the request
-in process, so a Distribution can front a simulated HTTP API endpoint
+in process. A Distribution can front a simulated HTTP API endpoint
 (`<api-id>.execute-api.<region>.amazonaws.com`), a simulated Lambda Function URL
 (`<url-id>.lambda-url.<region>.on.aws`), or anything a simulated Route53 record points at one of
 those.
@@ -558,19 +557,19 @@ try {
 }
 ```
 
-The Origin domain is resolved when a request is served rather than when the Distribution is created,
-so the Distribution and the service behind its Origin can be created in either order, whichever way
-round a CloudFormation template happens to declare them.
+The Origin domain is resolved when a request is served, and the Distribution and the service behind
+its Origin can be created in either order, whichever way round a CloudFormation template happens to
+declare them.
 
-`OriginPath` is prefixed to the request path, as it is for an S3 Origin, so an Origin path of `/v1`
+`OriginPath` is prefixed to the request path, as it is for an S3 Origin. An Origin path of `/v1`
 sends a request for `/things` on to `/v1/things`.
 
-A few things follow from the request never leaving the process:
+Three things follow from the request never leaving the process:
 
-- A domain that names nothing in the simulation fails with an error naming the Origin and the
-  domain, rather than a real request being made to it. External HTTP Origins are not supported.
-- The settings inside `CustomOriginConfig` describe how CloudFront connects over the network, so
-  the protocol policy, ports, SSL protocols and timeouts are accepted and ignored.
+- A domain the simulation has no match for fails with an error naming the Origin and the
+  domain. No real request is made to it, and external HTTP Origins are unsupported.
+- The settings inside `CustomOriginConfig` describe how CloudFront connects over the network. The
+  protocol policy, ports, SSL protocols and timeouts are accepted and ignored.
 - The Origin is reached anonymously unless it has an origin access control, as CloudFront reaches an
   Origin it has nothing to sign for. A Function URL or an HTTP API route authorizing with `AWS_IAM`
   therefore refuses the request. [Origin access controls](#origin-access-controls) covers the
@@ -579,13 +578,13 @@ A few things follow from the request never leaving the process:
 ## Viewer certificates
 
 A Distribution with alternate domain names needs an ACM certificate, and CloudFront accepts only
-certain ones. Sim CloudFront applies the same rules, so a Distribution that real CloudFront would
+certain ones. Sim CloudFront applies the same rules. A Distribution that real CloudFront would
 reject at deploy time is rejected here first, with `InvalidViewerCertificate`:
 
-- the certificate must be in `us-east-1`, wherever the rest of your infrastructure lives;
-- the certificate must exist and be `ISSUED`;
+- the certificate must be in `us-east-1`, wherever the rest of your infrastructure lives
+- the certificate must exist and be `ISSUED`
 - every alternate domain name must be covered by the certificate's domain name or one of its subject
-  alternative names, with a wildcard covering exactly one label.
+  alternative names, with a wildcard covering exactly one label
 
 The `us-east-1` rule is easy to miss, because nothing else in a stack cares about it. A Distribution
 in `eu-west-2` with a certificate alongside it looks fine until CloudFront refuses it.
@@ -641,25 +640,25 @@ try {
 
 The CloudFront API and CloudFormation capitalise this field differently, and sim CloudFront accepts
 both. SDK calls use `ACMCertificateArn` and `SSLSupportMethod`, as above.
-`AWS::CloudFront::Distribution` uses `AcmCertificateArn` and `SslSupportMethod`, so a template or
-CDK app works without changes.
+`AWS::CloudFront::Distribution` uses `AcmCertificateArn` and `SslSupportMethod`. A template or CDK
+app works without changes.
 
-A Distribution using `CloudFrontDefaultCertificate` needs no ACM certificate and is not checked. A
-standalone `new SimCloudFront()` has no sim ACM to check against, so it does not check either.
+A Distribution using `CloudFrontDefaultCertificate` needs no ACM certificate, and it goes
+unchecked. A standalone `new SimCloudFront()` has no sim ACM to check against, and skips the check
+as well.
 
 ## Disabling and deleting a Distribution
 
-`DeleteDistributionCommand` removes a Distribution. CloudFront will not delete one that is still
-serving, so the sequence is `UpdateDistributionCommand` with `Enabled: false` first, then the
-deletion. Deleting an enabled Distribution answers `DistributionNotDisabled`, as it does in AWS.
+`DeleteDistributionCommand` removes a Distribution. CloudFront will only delete one that has stopped
+serving. The sequence is `UpdateDistributionCommand` with `Enabled: false` first, then the deletion. Deleting an enabled Distribution answers `DistributionNotDisabled`, as it does in AWS.
 
-`UpdateDistributionCommand` takes a whole `DistributionConfig` rather than a patch, so the update is
-applied as a replacement. Anything left out of the new config is dropped, including alternate domain
-names and the default root object. Read the Distribution first, change the field you want, and send
-the config back.
+`UpdateDistributionCommand` takes a whole `DistributionConfig`, and applies the update as a
+replacement. Anything left out of the new config is dropped, including alternate domain names and
+the default root object. Read the Distribution first, change the field you want, and send the config
+back.
 
 Once the Distribution is deleted, a request to its CloudFront domain or any of its alternate domain
-names no longer resolves to it, and those alternate domain names are free for another Distribution.
+names stops resolving to it, and those alternate domain names are free for another Distribution.
 
 ```typescript sim-cloudfront-delete-distribution
 /**
@@ -745,8 +744,8 @@ try {
 ```
 
 `DeleteFunctionCommand` removes a CloudFront Function by name, and answers `NoSuchFunctionExists`
-when the name matches nothing. A cache Behavior still pointing at a deleted Function finds nothing
-and runs no Function code.
+when the name matches nothing. A cache Behavior still pointing at a deleted Function runs no
+Function code.
 
 ## Simulated CloudFront Functions
 
@@ -754,12 +753,12 @@ The sim CloudFront supports `viewer-request` and `viewer-response` CloudFront Fu
 
 Use `makeCffFunctionCodeInput` to pass a JavaScript handler function to `CreateFunctionCommand`.
 
-The `host` header a function sees is the hostname the request was made to CloudFront with: the
-Distribution domain name, or one of its alternate domain names. Requests served on localhost arrive
+The `host` header a function sees is the hostname the request was made to CloudFront with, being the
+Distribution domain name or one of its alternate domain names. Requests served on localhost arrive
 with a Yulin-local host such as `distro123.cloudfront.net.sim-aws.localhost:52341`, and the local
-suffix and port are dropped before the function runs, so a function building a URL from
-`event.request.headers.host.value` behaves as it would on AWS. As on AWS, `host` is read-only: a
-host a function writes is discarded rather than sent on to the Origin.
+suffix and port are dropped before the function runs. A function building a URL from
+`event.request.headers.host.value` behaves as it would on AWS. As on AWS, `host` is read-only, and a
+host a function writes is discarded before the Origin sees it.
 
 ```typescript sim-cloudfront-function
 /**
@@ -960,9 +959,9 @@ export function handler(event) {
 }
 ```
 
-CloudFront Functions run JS2, which is ECMAScript 5.1 plus a named subset of ES 6 to 12, so it
-refuses constructs ordinary JavaScript allows. Yulin publishes ESLint and Oxlint configs that report
-those refusals in the editor rather than at publication. See
+CloudFront Functions run JS2, ECMAScript 5.1 plus a named subset of ES 6 to 12. It refuses
+constructs ordinary JavaScript allows. Yulin publishes ESLint and Oxlint configs that report those
+refusals in the editor, ahead of publication. See
 [Linting CloudFront Functions JS2](../../lint/ "CloudFront Functions JS2 lint config usage docs").
 
 ## Response headers policies
@@ -1086,9 +1085,9 @@ try {
 
 Each header in `CustomHeadersConfig` carries an `Override` boolean. With it set, the policy's value
 replaces one the Origin sent. Without it, the Origin's value is kept and the policy's is dropped. A
-header the Origin did not send is added either way.
+header the Origin left out is added either way.
 
-`RemoveHeadersConfig` takes headers away, and is applied before the added ones, so a header named in
+`RemoveHeadersConfig` takes headers away, and is applied before the added ones. A header named in
 both sections ends up present with the policy's value.
 
 The policy is applied after a custom error response is fetched and before a `viewer-response`
@@ -1096,60 +1095,57 @@ CloudFront Function runs, as CloudFront does. An error page carries the policy's
 function sees them in `event.response.headers` and can change them.
 
 `SecurityHeadersConfig` is what CDK's `ResponseHeadersPolicy` construct synthesizes from
-`securityHeadersBehavior`, and every one of its sections is modelled: `ContentSecurityPolicy`,
+`securityHeadersBehavior`, and every one of its sections is modelled. `ContentSecurityPolicy`,
 `ContentTypeOptions`, `FrameOptions`, `ReferrerPolicy`, `StrictTransportSecurity` and `XSSProtection`
 each become the header CloudFront documents for it, honouring the section's own `Override` the same
 way a `CustomHeadersConfig` item does.
 
 `ServerTimingHeadersConfig` adds a `Server-Timing` header once `Enabled` is true. `SamplingRate` is
-not honoured: this simulation always adds the header rather than sampling a share of responses, so a
-test asserting on it does not depend on chance, and the header's value is a fixed placeholder rather
-than real Origin timing.
+ignored. This simulation adds the header to every response. A test asserting on it never depends on
+chance, and the header's value is a fixed placeholder in place of real Origin timing.
 
 `CorsConfig` is what CDK's `corsBehavior` synthesizes. CloudFront reflects the viewer request's
-`Origin` header against `AccessControlAllowOrigins` rather than sending the list itself: a request
+`Origin` header against `AccessControlAllowOrigins`, in place of sending the list itself. A request
 naming an Origin the list allows gets the CORS headers the section configures, with the response
-varying on `Origin` unless the list contains `*`; a request naming one it does not allow gets none of
-them, the same as CloudFront sending none rather than a mismatched one. `AccessControlAllowMethods`
-of `["ALL"]` expands to CloudFront's full method list, and `AccessControlAllowCredentials: false`
-leaves `Access-Control-Allow-Credentials` off entirely, since a header naming `false` means the same
-as its absence to a browser.
+varying on `Origin` unless the list contains `*`. A request naming one the list omits gets none of
+them, matching CloudFront, which sends none in preference to a mismatched one.
+`AccessControlAllowMethods` of `["ALL"]` expands to CloudFront's full method list, and
+`AccessControlAllowCredentials: false` leaves `Access-Control-Allow-Credentials` off entirely, since
+a header naming `false` means the same as its absence to a browser.
 
 An allow-list entry may use the wildcard on its own, meaning every Origin, or as the leftmost
 subdomain, so `*.example.org` matches `https://site.example.org`. It stands for exactly one label, as
-a wildcard certificate does, so it does not match `https://deep.site.example.org`, and an entry
-naming no scheme matches the host whichever scheme the request used. CloudFront allows the wildcard
-nowhere else, and an entry placing one elsewhere — `example.*`, `test.*.example.org`,
-`*test.example.org`, `exa*mple.org` — fails the stack rather than silently matching nothing.
+a wildcard certificate does, and it leaves `https://deep.site.example.org` unmatched. An entry naming
+no scheme matches the host whichever scheme the request used. CloudFront allows the wildcard nowhere
+else, and an entry placing one elsewhere (`example.*`, `test.*.example.org`, `*test.example.org`,
+`exa*mple.org`) fails the stack.
 
-`OriginOverride` decides the whole CORS section rather than one header at a time, unlike the
-`Override` on a custom or security header. Without it, an Origin response carrying any CORS header at
-all — whether or not the policy names that header — keeps every header the section would have set off
-the response.
+`OriginOverride` decides the whole CORS section at once, where the `Override` on a custom or security
+header decides one header. Without it, an Origin response carrying any CORS header at all, named by
+the policy or otherwise, keeps every header the section would have set off the response.
 
-A Behavior's `ResponseHeadersPolicyId` is checked when the Distribution is created or updated: naming
-a policy this simulation did not create, whether mistyped or a CloudFront managed policy ID, fails the
-Stack there rather than deploying successfully and only failing the first request that reaches the
-Behavior.
+A Behavior's `ResponseHeadersPolicyId` is checked when the Distribution is created or updated. Naming
+a policy this simulation did not create, whether mistyped or a CloudFront managed policy ID, fails
+the Stack there. The alternative would be a successful deploy that fails the first request reaching
+the Behavior.
 
 ## Origin access controls
 
-An origin access control is how a Distribution authenticates to a private Origin, so that the Origin
-admits the Distribution and nothing else. Declare one as
-`AWS::CloudFront::OriginAccessControl` and point an Origin's `OriginAccessControlId` at it with a
-`Ref`, which is what CDK's `S3BucketOrigin.withOriginAccessControl` synthesizes.
+An origin access control is how a Distribution authenticates to a private Origin. The Origin then
+admits the Distribution and nothing else. Declare one as `AWS::CloudFront::OriginAccessControl` and
+point an Origin's `OriginAccessControlId` at it with a `Ref`, which is what CDK's
+`S3BucketOrigin.withOriginAccessControl` synthesizes.
 
 An `OriginAccessControlOriginType` of `s3` signs for an S3 Bucket Origin, and one of `lambda` signs
-for a Lambda Function URL Origin. The origin type has to match the Origin it is attached to: an `s3`
+for a Lambda Function URL Origin. The origin type has to match the Origin it is attached to. An `s3`
 origin access control on a custom Origin, or a `lambda` one on an S3 Origin, fails the Stack when
 the Distribution is created, as CloudFront refuses it.
 
 An S3 Origin whose origin access control signs reads its Bucket as the `cloudfront.amazonaws.com`
 service principal, carrying the Distribution's ARN as `aws:SourceArn`. The Bucket policy is then the
-whole decision, so the Bucket needs a statement granting `s3:GetObject` to that principal,
-conditioned on the Distribution allowed to read it. That is the policy CDK writes. A condition
-naming a different Distribution, or an Origin that was never given an origin access control,
-answers 403 rather than serving.
+whole decision. The Bucket needs a statement granting `s3:GetObject` to that principal, conditioned
+on the Distribution allowed to read it. That is the policy CDK writes. A condition naming a different
+Distribution, or an Origin that was never given an origin access control, answers 403.
 
 ```typescript sim-cloudfront-origin-access-control
 /**
@@ -1268,10 +1264,10 @@ try {
 }
 ```
 
-The Bucket policy names the Distribution's ARN, so it is created after the Distribution: the `Ref`
-inside `Fn::Join` is the dependency CloudFormation orders the Stack by. Nothing about the read is
-settled when the Distribution is created, because the policy deciding it does not exist yet. The
-Origin works out who it is reading as per request instead.
+The Bucket policy names the Distribution's ARN, and is created after the Distribution. The `Ref`
+inside `Fn::Join` is the dependency CloudFormation orders the Stack by. The read is settled per
+request, because the policy deciding it comes into existence after the Distribution does. The Origin
+works out who it is reading as each time.
 
 ### A Lambda Function URL Origin
 
@@ -1284,8 +1280,8 @@ CloudFront without leaving the Function URL open to anyone who finds its endpoin
 Both permissions are needed. One grants `lambda:InvokeFunctionUrl` and the other
 `lambda:InvokeFunction`, to the same principal with the same `SourceArn`, as
 [Restrict access to an AWS Lambda function URL origin](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-lambda.html)
-sets out. CDK's `FunctionUrlOrigin.withOriginAccessControl` writes only the first, so a CDK app has
-to add the second itself:
+sets out. CDK's `FunctionUrlOrigin.withOriginAccessControl` writes only the first. A CDK app has to
+add the second itself:
 
 ```typescript
 greeterFunction.addPermission("InvokeFunctionFromCloudFront", {
@@ -1305,8 +1301,8 @@ greeterFunction.addPermission("InvokeFunctionFromCloudFront", {
 The Origin request is made as the `cloudfront.amazonaws.com` service principal carrying the
 Distribution's ARN, the same pair an S3 Origin read carries, and the function's resource policy is
 the whole decision. A Stack missing either permission, or with one naming a different Distribution,
-deploys and then answers 403 through the Distribution, which is what the real deployment does. The
-function is never invoked, so it writes no logs to look at either.
+deploys and then answers 403 through the Distribution, as the real deployment does. The function is
+never invoked, and writes no logs to look at either.
 
 ```typescript sim-cloudfront-function-url-origin-access-control
 /**
@@ -1450,25 +1446,25 @@ try {
 ```
 
 The Function URL is reachable directly as well, on its own endpoint, and it refuses a request that
-arrives there without the permission the Distribution has. That is the point of the auth type: the
+arrives there without the permission the Distribution has. That is the point of the auth type. The
 endpoint exists, and only the Distribution may use it.
 
 `SigningBehavior` takes any of `always`, `never` and `no-override`. `always` and `no-override` both
 sign, since nothing here sends a pre-signed viewer request to an Origin for `no-override` to pass
-through. `never` turns the origin access control off without removing it, so the Origin is reached
-anonymously, as an Origin with no origin access control is. An S3 Origin then needs a Bucket policy
-allowing that, and an `AWS_IAM` Function URL refuses the request outright.
+through. `never` turns the origin access control off while leaving it in place, and the Origin is
+reached anonymously, as an Origin with no origin access control is. An S3 Origin then needs a Bucket
+policy allowing that, and an `AWS_IAM` Function URL refuses the request outright.
 
 `Ref` and `Fn::GetAtt` on `Id` both return the ID, so either resolves an Origin's
 `OriginAccessControlId`. An Origin naming an ID no origin access control holds is refused with
-`InvalidOriginAccessControl` when the Distribution is created, rather than created without one.
-Tearing the Stack down removes the origin access control, and its name is free again.
+`InvalidOriginAccessControl` when the Distribution is created. Tearing the Stack down removes the
+origin access control, and its name is free again.
 
 `OriginAccessControlOriginType` must be `s3` or `lambda`, and `SigningProtocol` must be `sigv4`. Any
 other value fails the Stack by name.
 
-There is no `CreateOriginAccessControl` command here, so a CloudFormation template is the only way
-to make one.
+A CloudFormation template is the only way to make one. There is no `CreateOriginAccessControl`
+command here.
 
 #### Posting to a Function URL Origin
 
@@ -1506,15 +1502,15 @@ missing the header fails in a test as well as on the deployment.
 
 ## Key value stores
 
-A key value store holds data a CloudFront Function reads at request time, so a redirect table or a
-feature flag does not have to be baked into the Function's code.
+A key value store holds data a CloudFront Function reads at request time. A redirect table or a
+feature flag can live there instead of being baked into the Function's code.
 
 AWS splits this across two SDK clients, and so does the simulator. The CloudFront client owns the
-store: `CreateKeyValueStoreCommand`, `DescribeKeyValueStoreCommand`, `ListKeyValueStoresCommand`,
-`UpdateKeyValueStoreCommand` and `DeleteKeyValueStoreCommand`, all addressing a store by name. The
-key value store client owns the data: `GetKeyCommand`, `PutKeyCommand`, `DeleteKeyCommand`,
-`ListKeysCommand`, `UpdateKeysCommand` and its own `DescribeKeyValueStoreCommand`, all addressing a
-store by ARN.
+store, through `CreateKeyValueStoreCommand`, `DescribeKeyValueStoreCommand`,
+`ListKeyValueStoresCommand`, `UpdateKeyValueStoreCommand` and `DeleteKeyValueStoreCommand`, all
+addressing a store by name. The key value store client owns the data, through `GetKeyCommand`,
+`PutKeyCommand`, `DeleteKeyCommand`, `ListKeysCommand`, `UpdateKeysCommand` and its own
+`DescribeKeyValueStoreCommand`, all addressing a store by ARN.
 
 Both clients are intercepted by `SimSdk`. Used directly, they are `simAws.cloudFront().keyValueStores()`
 and `simAws.cloudFrontKeyValueStore()`.
@@ -1581,26 +1577,26 @@ CloudFront. `await simAws.backgroundTasksComplete()` waits for that.
 
 ### ETags
 
-Unlike the Distribution and Function commands, the key value store commands do check `IfMatch`. Both
-APIs require it on every write and CloudFront refuses a stale one, which is what stops two writers
-overwriting each other. A write carrying an ETag that is not current is refused with
-`PreconditionFailed`, so a caller has to thread the ETag through the way it does against CloudFront.
-Each write returns the new ETag for the next one.
+The key value store commands do check `IfMatch`, where the Distribution and Function commands ignore
+it. Both APIs require it on every write and CloudFront refuses a stale one, which is what stops two
+writers overwriting each other. A write carrying a stale ETag is refused with `PreconditionFailed`,
+and a caller has to thread the ETag through the way it does against CloudFront. Each write returns
+the new ETag for the next one.
 
 A store has two ETags and they are not interchangeable, as in AWS. Each `DescribeKeyValueStore`
-returns its own: the CloudFront client's versions the store's configuration, and the key value store
-client's versions the keys. Writing a key does not move the configuration's ETag, and changing the
-comment does not move the keys'. A write carrying the other API's ETag is refused, and the message
-says which of the two it wanted.
+returns its own. The CloudFront client's versions the store's configuration, and the key value store
+client's versions the keys. Writing a key leaves the configuration's ETag where it was, and changing
+the comment leaves the keys' where it was. A write carrying the other API's ETag is refused, and the
+message says which of the two it wanted.
 
 ### Reading a store from a CloudFront Function
 
 A Function reads its store through `cf`, which it gets from `import cf from "cloudfront"`. That is
 the one import JS 2.0 has. `cf.kvs()` opens the store the Function is associated with, and its
-`get`, `exists` and `meta` are all promises, so a Function that reads a store is async.
+`get`, `exists` and `meta` are all promises. A Function that reads a store is async.
 
 A Function names the store it may read with `KeyValueStoreAssociations` on its `FunctionConfig`.
-CloudFront takes at most one, and only on `cloudfront-js-2.0`: an association on the 1.0 runtime is
+CloudFront takes at most one, and only on `cloudfront-js-2.0`. An association on the 1.0 runtime is
 refused, because that runtime has no `cf` to reach a store through.
 
 ```typescript sim-cloudfront-function-key-value-store
@@ -1688,21 +1684,20 @@ console.log((redirected as Response).headers.get("location")); // /new-page
 ```
 
 `get` reads a string by default, and takes `{ format: "json" }` to parse the stored string or
-`{ format: "bytes" }` for its UTF-8 bytes. A key that is not stored rejects, so a Function that
-wants a default checks `exists` first, as the example does.
+`{ format: "bytes" }` for its UTF-8 bytes. A missing key rejects. A Function that wants a default checks
+`exists` first, as the example does.
 
-A Function written as a function reference rather than as source has no import to write, so it reads
-`cf` as a global. Importing `@kensio/yulin/cloudfront/globals` gives that global a type, along with
-the CloudFront Function event types. Each invocation gets its own `cf` through Node.js asynchronous
-context, so two Functions associated with different stores read their own even when they run at the
-same time.
+A Function written as a function reference has no import to write, and reads `cf` as a global.
+Importing `@kensio/yulin/cloudfront/globals` gives that global a type, along with the CloudFront
+Function event types. Each invocation gets its own `cf` through Node.js asynchronous context, and two
+Functions associated with different stores read their own even when they run at the same time.
 
 ### From CloudFormation
 
 `AWS::CloudFront::KeyValueStore` creates a store, and a Function associates one with
-`FunctionConfig.KeyValueStoreAssociations`. CloudFormation takes a plain array there rather than the
-`Quantity` and `Items` pair the SDK uses, and `Ref` on a key value store is its ARN, so the two fit
-together directly:
+`FunctionConfig.KeyValueStoreAssociations`. CloudFormation takes a plain array there, where the SDK
+takes a `Quantity` and `Items` pair. `Ref` on a key value store is its ARN, and the two fit together
+directly:
 
 ```yaml
 Redirects:
@@ -1726,12 +1721,12 @@ RedirectFunction:
 `Fn::GetAtt` supports `Arn`, `Id` and `Status`. Deleting the Stack deletes the store, after the
 Functions holding it have gone.
 
-CDK's `cloudfront.KeyValueStore` and the `keyValueStore` prop on `cloudfront.Function` both deploy,
-so a CDK stack needs no hand-editing.
+CDK's `cloudfront.KeyValueStore` and the `keyValueStore` prop on `cloudfront.Function` both deploy.
+A CDK stack needs no hand-editing.
 
-`cf.kvs()` refuses when the Function is associated with no store, and refuses an ID that is not the
-associated store's. Neither hands back an empty store, which would let a Function that lost its
-association run to completion and quietly take every default.
+`cf.kvs()` refuses when the Function is associated with no store, and refuses an ID belonging to some
+other store. Handing back an empty store would let a Function that lost its association run to
+completion and quietly take every default.
 
 ## Available functionality
 
@@ -1750,11 +1745,11 @@ Sim CloudFront currently supports:
 - CloudFront Functions reading an associated key value store through `cf.kvs()`
 - `AWS::CloudFront::ResponseHeadersPolicy`, for headers a cache Behavior sets on every response
 - `AWS::CloudFront::KeyValueStore`, and `KeyValueStoreAssociations` on `AWS::CloudFront::Function`
-- `AWS::CloudFront::OriginAccessControl`, so an Origin reads a private Bucket as CloudFront
+- `AWS::CloudFront::OriginAccessControl`, letting an Origin read a private Bucket as CloudFront
 - Viewer certificates from sim ACM, including CloudFront's `us-east-1` requirement
 - Serving simulated CloudFront traffic on localhost with `serveSimAws`
 
-The simulator focuses on useful behaviour for tests and local development rather than full CloudFront
+The simulator focuses on useful behaviour for tests and local development, ahead of full CloudFront
 feature parity. Unsupported CloudFront options may be ignored or may throw errors depending on
 whether the simulator needs them to model the requested behaviour safely.
 
@@ -1763,83 +1758,81 @@ whether the simulator needs them to model the requested behaviour safely.
 Where sim CloudFront knowingly behaves differently from AWS:
 
 - **An S3 Origin with no origin access control reads its Bucket anonymously.** That is the unsigned
-  request real CloudFront sends to the S3 REST endpoint without one, so the Bucket policy has to
-  make an Object publicly readable for the Distribution to serve it. A legacy
-  `S3OriginConfig.OriginAccessIdentity` is refused by name rather than read as anonymous: it signs
-  the Origin request as a CloudFront canonical user nothing here models, so a Bucket policy written
-  for one would deny the read and say nothing about why.
-- **A signed Origin request is not really signed.** An Origin whose origin access control signs
+  request real CloudFront sends to the S3 REST endpoint without one. The Bucket policy has to make
+  an Object publicly readable for the Distribution to serve it. A legacy
+  `S3OriginConfig.OriginAccessIdentity` is refused by name. It signs the Origin request as a
+  CloudFront canonical user nothing here models, and a Bucket policy written for one would deny the
+  read in silence.
+- **A signed Origin request carries no signature.** An Origin whose origin access control signs
   reaches the Origin as the `cloudfront.amazonaws.com` service principal carrying the Distribution's
-  ARN, which is what the Bucket policy or the function's resource policy is evaluated against, but
-  no SigV4 signature is computed or checked. A Function URL Origin is told who the request is from
-  at the simulated HTTP boundary instead, the same way anything else calling into simulated AWS in
-  process says who it is. Nothing else here signs a simulated request either, so a test cannot
-  assert anything about the signature itself. The payload hash is the one part of a signature that
+  ARN. That pair is what the Bucket policy or the function's resource policy is evaluated against,
+  and no SigV4 signature is computed or checked. A Function URL Origin is told who the request is
+  from at the simulated HTTP boundary, the same way anything else calling into simulated AWS in
+  process says who it is. No other simulated request is signed here either, and the signature
+  itself is beyond what a test can assert on. The payload hash is the one part of a signature that
   is stated and checked, because a Function URL turns a POST away over it. See
   [posting to a Function URL Origin](#posting-to-a-function-url-origin).
 - **An origin access control signs for an S3 or Lambda Function URL Origin only.** CloudFront also
-  signs for MediaStore and MediaPackage V2 Origins, and neither is modelled. An
+  signs for MediaStore and MediaPackage V2 Origins, and both are left out. An
   `OriginAccessControlOriginType` other than `s3` or `lambda`, or a `SigningProtocol` other than
-  `sigv4`, fails the Stack by naming the value rather than deploying and behaving like one of the
-  two.
-- **An origin access control name is unique, but nothing else about it is checked.** A second one
+  `sigv4`, fails the Stack by naming the value. Neither is quietly treated as one of the two.
+- **An origin access control name is unique, and that is the whole of the checking.** A second one
   claiming a name is refused with `OriginAccessControlAlreadyExists`, as CloudFront refuses one.
-- **There is no command surface for an origin access control.** `CreateOriginAccessControl` and its
-  siblings are not simulated, so `AWS::CloudFront::OriginAccessControl` is the only way to make one.
+- **An origin access control has no command surface.** `CreateOriginAccessControl` and its siblings
+  are absent, and `AWS::CloudFront::OriginAccessControl` is the only way to make one.
 - **A list's `Quantity` is only checked when it is there.** Every CloudFront list carries a count
   alongside its items, and a `Quantity` that disagrees with `Items` is refused with
-  `InconsistentQuantities`, as CloudFront refuses it. A list arriving as a plain array has no count
-  to disagree with, which is the CloudFormation shape, so a template is not checked this way. Nor is
-  a hand-written `{ Items: [...] }` with the count left out: the AWS SDK types make omitting
-  `Quantity` a compile error, so what arrives without one is not the mistake this catches.
-- **`IfMatch` ETags are not checked on a Distribution or a Function.**
-  `UpdateDistributionCommand`, `DeleteDistributionCommand` and `DeleteFunctionCommand` all accept
-  `IfMatch` and ignore it, so neither `PreconditionFailed` nor `InvalidIfMatchVersion` is returned
-  for those. A stale ETag there is a retry rather than a design mistake. The key value store
-  commands are the exception and do check it, because the data API is built around it: two writers
-  racing on one store is the case it exists to catch.
+  `InconsistentQuantities`, as CloudFront refuses it. A list arriving as a plain array, which is the
+  CloudFormation shape, has no count to disagree with, and a template goes unchecked this way. So
+  does a hand-written `{ Items: [...] }` with the count left out. The AWS SDK types make omitting
+  `Quantity` a compile error, so what arrives without one is a different mistake from the one this
+  catches.
+- **`IfMatch` ETags are ignored on a Distribution or a Function.** `UpdateDistributionCommand`,
+  `DeleteDistributionCommand` and `DeleteFunctionCommand` all accept `IfMatch` and ignore it,
+  leaving both `PreconditionFailed` and `InvalidIfMatchVersion` unused there. A stale ETag there
+  costs a retry. The key value store commands are the exception and do check it, because the data
+  API is built around it, and two writers racing on one store is the case it exists to catch.
 - **A key value store has no size quota.** CloudFront caps a store's total size and the length of a
   single key and value, and refuses a write that would exceed either. Nothing here counts against a
-  quota, so `TotalSizeInBytes` is reported but never enforced. A test cannot find out that its data
-  would be too large for a real store.
-- **A key value store association cannot be changed after the Function is created.** There is no
-  `UpdateFunction` here, so the store a Function reads is the one it was created with. Delete the
+  quota, and `TotalSizeInBytes` is reported without being enforced. A test can find out nothing
+  about whether its data would be too large for a real store.
+- **A key value store association is fixed once the Function is created.** There is no
+  `UpdateFunction` here, and the store a Function reads is the one it was created with. Delete the
   Function and create it again to change it.
-- **`ImportSource` is not supported.** `CreateKeyValueStoreCommand` ignores it, and
-  `AWS::CloudFront::KeyValueStore` refuses a Resource carrying one rather than deploying a store that
-  came up empty. Nothing here reads an S3 Object as key data, and a test passing against no data the
-  deploy would have seeded is the failure worth avoiding. Write the keys with `PutKey` or
-  `UpdateKeys` instead.
+- **`ImportSource` is unsupported.** `CreateKeyValueStoreCommand` ignores it, and
+  `AWS::CloudFront::KeyValueStore` refuses a Resource carrying one. Nothing here reads an S3 Object
+  as key data, and deploying an empty store would let a test pass against data the deploy should
+  have seeded. Write the keys with `PutKey` or `UpdateKeys`.
 - **A `Status` Output holds the status at deploy time.** CloudFormation Outputs are resolved once,
   while a new store is still `PROVISIONING`, so `Fn::GetAtt` on `Status` in an Output reads
   `PROVISIONING` even though the store goes on to become `READY`. Read the store itself for its
   current status.
-- **Key listing is not paginated.** `ListKeysCommand` and `ListKeyValueStoresCommand` answer with
-  everything and never set a `NextToken` or `NextMarker`, so a test cannot exercise a paging loop.
-- **A deletion does not wait for the disable to deploy.** Real CloudFront needs the disabled
-  Distribution to reach `Deployed` before it accepts the deletion. Here, `Enabled: false` is enough.
+- **Key listing is unpaginated.** `ListKeysCommand` and `ListKeyValueStoresCommand` answer with
+  everything and never set a `NextToken` or `NextMarker`, leaving a test with no paging loop to
+  exercise.
+- **A deletion goes ahead without waiting for the disable to deploy.** Real CloudFront needs the
+  disabled Distribution to reach `Deployed` before it accepts the deletion. Here, `Enabled: false`
+  is enough.
 - **A disabled Distribution still serves requests.** Real CloudFront answers a disabled Distribution
   with a 403. Only deleting a Distribution stops it serving here.
-- **`DeleteFunctionCommand` never answers `FunctionInUse`.** Nothing tells a CloudFront Function that
-  a cache Behavior has taken it up, so every Function is deletable. A Behavior left pointing at a
+- **`DeleteFunctionCommand` never answers `FunctionInUse`.** A CloudFront Function is never told
+  that a cache Behavior has taken it up, and every Function is deletable. A Behavior left pointing at a
   deleted Function runs no Function code.
-- **A response headers policy name is unique, but nothing else about it is checked.** A second
+- **A response headers policy name is unique, and that is the whole of the checking.** A second
   policy claiming a name is refused with `ResponseHeadersPolicyAlreadyExists`, as CloudFront refuses
   one. The header names and values themselves are stored as written.
-- **There is no command surface for a response headers policy.** `CreateResponseHeadersPolicy` and
-  its siblings are not simulated, so `AWS::CloudFront::ResponseHeadersPolicy` is the only way to make
-  one.
-- **`ServerTimingHeadersConfig` always adds the header once enabled, rather than sampling.**
-  `SamplingRate` decides what share of real responses carry `Server-Timing`; this simulation adds it
-  to every response once `Enabled` is true, so a test asserting on it does not depend on chance. The
-  header's value is a fixed placeholder rather than real timing data, since nothing here measures an
-  Origin fetch the way CloudFront's edge does.
-- **A managed policy ID is not found.** CloudFront's managed policies belong to AWS rather than to a
-  template, so nothing here creates them. A Behavior naming one is refused with
-  `InvalidResponseHeadersPolicyId` when the Distribution is created or updated, the same as real
-  CloudFront refuses one at that point, rather than deploying successfully and only failing the first
-  request that reaches the Behavior.
-- **`CachePolicyId` and `OriginRequestPolicyId` are accepted and ignored.** Sim CloudFront does not
-  model edge caching, so a Behavior's cache policy — including an AWS managed policy such as
-  `CachingOptimized` — is neither validated nor applied to TTLs or the cache key. Every request
-  reaches the Origin regardless of what the policy would have cached on real CloudFront.
+- **A response headers policy has no command surface.** `CreateResponseHeadersPolicy` and its
+  siblings are absent, and `AWS::CloudFront::ResponseHeadersPolicy` is the only way to make one.
+- **`ServerTimingHeadersConfig` always adds the header once enabled.** `SamplingRate` decides what
+  share of real responses carry `Server-Timing`. This simulation adds it to every response once
+  `Enabled` is true. A test asserting on it never depends on chance. The header's value is a
+  fixed placeholder, since nothing here measures an Origin fetch the way CloudFront's edge does.
+- **A managed policy ID is unknown here.** CloudFront's managed policies belong to AWS, and this
+  simulation creates none of them. A Behavior naming one is refused with
+  `InvalidResponseHeadersPolicyId` when the Distribution is created or updated, the same point real
+  CloudFront refuses one at. The alternative would be a successful deploy that fails the first
+  request reaching the Behavior.
+- **`CachePolicyId` and `OriginRequestPolicyId` are accepted and ignored.** Sim CloudFront models no
+  edge caching. A Behavior's cache policy, including an AWS managed policy such as
+  `CachingOptimized`, is left unvalidated and unapplied to TTLs and the cache key. Every request
+  reaches the Origin, whatever the policy would have cached on real CloudFront.

--- a/docs/services/cloudwatch/README.md
+++ b/docs/services/cloudwatch/README.md
@@ -1,7 +1,7 @@
 # Simulated CloudWatch metrics and alarms
 
 Yulin includes a simulated Amazon CloudWatch for tests and local development. It holds custom
-metrics: the datapoints `PutMetricData` publishes, and the statistics `GetMetricStatistics` and
+metrics, being the datapoints `PutMetricData` publishes and the statistics `GetMetricStatistics` and
 `GetMetricData` read back from them, without an AWS account. It also holds alarms over those
 metrics, which evaluate on the simulation's clock and notify an SNS topic when they change state.
 
@@ -69,23 +69,23 @@ A datum may state its values as a plain `Value`, as a `StatisticValues` summary,
 matching `Counts`. All three answer the same statistics, and a metric published one way reads back
 like a metric published another.
 
-Values are checked the way real CloudWatch checks them: within -2^360 to 2^360, never `NaN` or an
-infinity, at most 150 unique values in one datum, and `Counts` only alongside the `Values` it
-counts. `Unit` is the closed `StandardUnit` set, not free text, on the way in and on the way out. A
-query naming a unit CloudWatch lacks fails here as it would in an account.
+Values are checked the way real CloudWatch checks them. A value sits within -2^360 to 2^360, is
+never `NaN` or an infinity, runs to at most 150 unique values in one datum, and carries `Counts`
+only alongside the `Values` it counts. `Unit` is the closed `StandardUnit` set on the way in and on
+the way out. A query naming a unit CloudWatch lacks fails here as it would in an account.
 
 ## Metrics are identified by their dimensions
 
 Real CloudWatch leaves a custom metric unrolled across its dimensions, and so does this. The same
-metric name published under two channels is two metrics, and a read naming no dimensions reaches the
-metric that was published with none, not the total of all of them.
+metric name published under two channels is two metrics. A read naming no dimensions reaches the
+metric that was published with none, leaving the rest of them out of the total.
 
 That is the behaviour teams most often get wrong, and it is worth a test of its own. A dashboard
 query written against a metric name alone finds nothing at all if every publish carried a dimension.
 
 ## Metrics and simulated time
 
-A datum carrying no `Timestamp` is stamped from the simulation's clock, not the host's. A test with
+A datum carrying no `Timestamp` is stamped from the simulation's clock. A test with
 a frozen clock therefore gets timestamps it can assert on exactly, and one that moves time on gets
 datapoints in the period it moved to:
 

--- a/docs/services/cloudwatch/README.md
+++ b/docs/services/cloudwatch/README.md
@@ -1,8 +1,8 @@
 # Simulated CloudWatch metrics and alarms
 
 Yulin includes a simulated Amazon CloudWatch for tests and local development. It holds custom
-metrics, being the datapoints `PutMetricData` publishes and the statistics `GetMetricStatistics` and
-`GetMetricData` read back from them, without an AWS account. It also holds alarms over those
+metrics. Those are the datapoints `PutMetricData` publishes, and the statistics
+`GetMetricStatistics` and `GetMetricData` read back from them, without an AWS account. It also holds alarms over those
 metrics, which evaluate on the simulation's clock and notify an SNS topic when they change state.
 
 Code that publishes a business metric is code teams already have, and until now the only way to test
@@ -77,8 +77,8 @@ the way out. A query naming a unit CloudWatch lacks fails here as it would in an
 ## Metrics are identified by their dimensions
 
 Real CloudWatch leaves a custom metric unrolled across its dimensions, and so does this. The same
-metric name published under two channels is two metrics. A read naming no dimensions reaches the
-metric that was published with none, leaving the rest of them out of the total.
+metric name published under two channels is two metrics. A read naming no dimensions reaches only the
+metric that was published with none, and never aggregates across the others.
 
 That is the behaviour teams most often get wrong, and it is worth a test of its own. A dashboard
 query written against a metric name alone finds nothing at all if every publish carried a dimension.

--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -3646,7 +3646,7 @@ Current documented limitations:
 - A sign-in by a user of an `ON` pool that has registered no factor is refused, because real Cognito
   answers that one with the `MFA_SETUP` challenge, which registers a factor mid-sign-in and is
   outside the simulation. A user with both factors enabled and neither preferred is refused for the
-  same kind of reason, real Cognito answering that with `SELECT_MFA_TYPE`.
+  same kind of reason. Real Cognito answers that with `SELECT_MFA_TYPE`.
 - An MFA code is texted to the user's `phone_number` whatever the pool's `AutoVerifiedAttributes`
   say, and the pool records it as a message with an occasion of `Authentication`, where a test reads
   it from. Real Cognito delivers it and reports it to nobody.
@@ -3672,7 +3672,7 @@ Current documented limitations:
   `USER_AUTH` flow, itself refused as a flow of its own.
 - `AssociateSoftwareToken` and `VerifySoftwareToken` take an `AccessToken` and refuse a `Session`,
   because the `MFA_SETUP` challenge that would issue one is outside the simulation. A
-  `FriendlyDeviceName` is refused for the same kind of reason, device tracking being outside the
+  `FriendlyDeviceName` is refused for the same kind of reason. Device tracking is outside the
   simulation.
 - `UpdateUserPool` replaces a pool's settings rather than merging into them, as real Cognito does. A
   setting the request leaves out goes back to the default `CreateUserPool` would have given it. It

--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -3774,7 +3774,7 @@ Current documented limitations:
   such input.
 - The managed login pages are bare forms with no styling and no script, and
   `AWS::Cognito::ManagedLoginBranding` is an unsupported resource type. They are also at paths of
-  this simulation's own: real managed login serves its sign-in form at `/login` and confirms a
+  this simulation's own. Real managed login serves its sign-in form at `/login` and confirms a
   sign-up within `/signup`, where here the authorize endpoint answers with the form itself and
   `/confirm` is a page. `/oauth2/userInfo`, `/oauth2/revoke`, `/oauth2/idpresponse` and the SAML
   endpoints go unserved.

--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -53,7 +53,7 @@ Two pools may share a name. Only the id identifies one.
 
 ## Password policy
 
-A pool created without a `Policies` of its own gets the real default: eight characters, with an
+A pool created without a `Policies` of its own gets the real default of eight characters, with an
 uppercase letter, a lowercase letter, a number and a symbol each required. A request setting some of
 those keeps the defaults for the rest.
 
@@ -504,7 +504,7 @@ Nothing here delivers an email or a text message. A pool records what it would h
 and `sentMessages` on the pool object hands the record over. Each message carries the recipient, the
 medium, the subject, the body and the occasion it was sent on.
 
-A message is recorded on three occasions: a `SignUp`, a `ResendConfirmationCode`, and an
+A message is recorded on three occasions. Those are a `SignUp`, a `ResendConfirmationCode`, and an
 `AdminCreateUser` that did not ask for `MessageAction: SUPPRESS`. The verification wording is the
 pool's own, and `{####}` is replaced with the code the user was issued. A sign-up a `PreSignUp`
 handler auto-confirmed records none. That user has no code to answer with, and real Cognito sends it
@@ -580,7 +580,7 @@ code` and `Your verification code is {####}` for a verification message, and `Yo
 password` and `Your username is {username} and temporary password is {####}.` for an invitation.
 `EmailVerificationMessage`, `EmailVerificationSubject`, `SmsVerificationMessage` and
 `VerificationMessageTemplate` are all read, at whatever wording a request sets, held to the two
-rules real Cognito holds them to: a message carries `{####}`, and runs to 20,000 characters for an
+rules real Cognito holds them to. A message carries `{####}`, and runs to 20,000 characters for an
 email and the 140 an SMS carries.
 
 This is Cognito's own delivery record, not a simulated SES. Real Cognito with the default
@@ -2298,7 +2298,7 @@ A response naming something this simulation would have to drop is refused with
 `iat`, `exp` and `auth_time` come from the simulation's clock, not the host's, and the tokens
 last the hour a pool's tokens last unless the app client says otherwise.
 
-That makes an expired token something a test can produce: sign the user in with the simulated clock
+That makes an expired token something a test can produce. Sign the user in with the simulated clock
 set far enough in the past, and the token a verifier gets is already expired.
 
 ```typescript sim-cognito-expired-token
@@ -2452,7 +2452,7 @@ ARNs grants nothing.
 
 The client-side operations are the other exception. `InitiateAuth`, `RespondToAuthChallenge` and
 `GlobalSignOut` authorize against no resource at all, because real Cognito evaluates no IAM policy
-for them: they are what an application calls on behalf of a user, holding no AWS credentials. A
+for them. They are what an application calls on behalf of a user, holding no AWS credentials. A
 `caller` goes unread on those three, and the tokens or the app client id are what authorizes them.
 
 That is the difference the two sign-in paths make to a policy. Code calling `AdminInitiateAuth`
@@ -3190,7 +3190,7 @@ The `SecretCode` is a real RFC 6238 shared secret. An authenticator app or any T
 it produces the codes `VerifySoftwareToken` accepts, and a code from another secret is refused with
 `EnableSoftwareTokenMFAException`. A test that would rather not compute one reads the code the
 user's app would be showing off the pool, through `SimCognitoUserPool.softwareTokenCode`, in the way
-it reads a sign-up confirmation code: real Cognito reports neither to anyone, and nothing here is
+it reads a sign-up confirmation code. Real Cognito reports neither to anyone, and nothing here is
 holding the user's phone.
 
 Verifying a token registers it and leaves it disabled. `SetUserMFAPreference` is what turns a factor
@@ -3306,7 +3306,7 @@ console.log(user.PreferredMfaSetting); // "SOFTWARE_TOKEN_MFA"
 
 A sign-in by a user that has registered a factor is answered with `SMS_MFA` or `SOFTWARE_TOKEN_MFA`
 and a `Session` in place of tokens, on `InitiateAuth` and `AdminInitiateAuth` alike, and after
-a `NEW_PASSWORD_REQUIRED` response as well: one challenge follows the other. The code goes back
+a `NEW_PASSWORD_REQUIRED` response as well, one challenge following the other. The code goes back
 through `RespondToAuthChallenge` or `AdminRespondToAuthChallenge` as `SMS_MFA_CODE` or
 `SOFTWARE_TOKEN_MFA_CODE`, and that request is what hands out the tokens.
 
@@ -3333,7 +3333,7 @@ was challenged. `PreTokenGeneration` runs there too, reporting
 before this one. Which source real Cognito reports for that pair of challenges was not checked
 against a live account.
 
-A user with both factors enabled and neither preferred is refused: real Cognito answers that
+A user with both factors enabled and neither preferred is refused. Real Cognito answers that
 sign-in with `SELECT_MFA_TYPE`, a challenge of its own. `SetUserMFAPreference` naming one
 of them as `PreferredMfa` is what settles it.
 
@@ -3576,11 +3576,11 @@ Current documented limitations:
 - No message is ever delivered. A pool records what it would have sent and `sentMessages` reads it
   back, which real Cognito reports to nobody. Nothing leaves the simulation, and no
   `CodeDeliveryDetails` is reported by `SignUp` or `ResendConfirmationCode`.
-- A message is recorded on three occasions: `SignUp`, `ResendConfirmationCode` and
+- A message is recorded on three occasions, being `SignUp`, `ResendConfirmationCode` and
   `AdminCreateUser`. Password reset, MFA and the account-taken-over notices are occasions real
   Cognito sends on and this simulation never reaches.
 - A verification message is recorded only for an attribute the pool verifies automatically. A pool
-  with no `AutoVerifiedAttributes` records none, and only for a user that has to confirm: one a
+  with no `AutoVerifiedAttributes` records none, and only for a user that has to confirm. One a
   `PreSignUp` handler auto-confirmed is sent nothing, as on real Cognito. An invitation is recorded
   whatever the pool verifies, and both are recorded only where the user has an `email` or a
   `phone_number` to be reached at.
@@ -3646,7 +3646,7 @@ Current documented limitations:
 - A sign-in by a user of an `ON` pool that has registered no factor is refused, because real Cognito
   answers that one with the `MFA_SETUP` challenge, which registers a factor mid-sign-in and is
   outside the simulation. A user with both factors enabled and neither preferred is refused for the
-  same kind of reason: real Cognito answers that with `SELECT_MFA_TYPE`.
+  same kind of reason, real Cognito answering that with `SELECT_MFA_TYPE`.
 - An MFA code is texted to the user's `phone_number` whatever the pool's `AutoVerifiedAttributes`
   say, and the pool records it as a message with an occasion of `Authentication`, where a test reads
   it from. Real Cognito delivers it and reports it to nobody.
@@ -3654,8 +3654,8 @@ Current documented limitations:
   because no device is remembered here.
 - A user's software token secret is a real RFC 6238 shared secret, and the pool reports the code the
   user's authenticator app would be showing through `SimCognitoUserPool.softwareTokenCode`. Real
-  Cognito reports that to nobody: the code is on the user's own device, in the way a confirmation
-  code is in the user's own inbox.
+  Cognito reports that to nobody, because the code is on the user's own device, in the way a
+  confirmation code is in the user's own inbox.
 - `VerifySoftwareToken` registers a token and enables nothing, so `SetUserMFAPreference` is what
   turns a factor on. Whether real Cognito also activates a TOTP factor on verification alone was not
   checked against a live account.
@@ -3672,7 +3672,7 @@ Current documented limitations:
   `USER_AUTH` flow, itself refused as a flow of its own.
 - `AssociateSoftwareToken` and `VerifySoftwareToken` take an `AccessToken` and refuse a `Session`,
   because the `MFA_SETUP` challenge that would issue one is outside the simulation. A
-  `FriendlyDeviceName` is refused for the same kind of reason: device tracking is outside the
+  `FriendlyDeviceName` is refused for the same kind of reason, device tracking being outside the
   simulation.
 - `UpdateUserPool` replaces a pool's settings rather than merging into them, as real Cognito does. A
   setting the request leaves out goes back to the default `CreateUserPool` would have given it. It
@@ -3685,7 +3685,7 @@ Current documented limitations:
   in the same words.
 - `UpdateUserPoolClient` replaces an app client's settings the same way. A setting the request
   leaves out goes back to the default `CreateUserPoolClient` would have given it. `ClientName` is
-  the exception: a client has to have a name and there is no default to reset to, and an update that
+  the exception. A client has to have a name and there is no default to reset to, so an update that
   names none keeps the one the client has.
 - An update leaves the client's secret alone. `UpdateUserPoolClient` has no `GenerateSecret` input
   on real Cognito, and a client created without a secret never gains one.
@@ -3696,7 +3696,7 @@ Current documented limitations:
   refused when the pool is created or updated, naming the trigger, because a pool that accepted one
   would never call the function the template named. The custom challenge triggers would need a
   challenge loop this simulation lacks, and the migration and federation triggers have no external
-  directory to reach: a simulated identity provider answers with the user `signInAs` put there,
+  directory to reach. A simulated identity provider answers with the user `signInAs` put there,
   beyond the reach of a trigger.
 - `AdminCreateUser` leaves `PostConfirmation` unfired, here and on real Cognito. It is the tempting
   place to hang the trigger and the wrong one. A project relying on it would pass here and write no
@@ -3757,8 +3757,8 @@ Current documented limitations:
   way of naming the user, and that is unmodelled.
 - A `UsernameAttributes` pool resolves the address for its admin operations and its sign-ins, and
   refuses a second user holding an address another user already signs in by.
-- Unsimulated `CreateUserPoolClient` inputs are refused the same way: a `ClientSecret` of your own,
-  `AnalyticsConfiguration`, `AuthSessionValidity`, `EnablePropagateAdditionalUserContextData`,
+- Unsimulated `CreateUserPoolClient` inputs are refused the same way. They are a `ClientSecret` of
+  your own, `AnalyticsConfiguration`, `AuthSessionValidity`, `EnablePropagateAdditionalUserContextData`,
   `RefreshTokenRotation`, `ReadAttributes`, `WriteAttributes`, and an `EnableTokenRevocation` of
   `false`. `UpdateUserPoolClient` refuses the same inputs, in the same words.
 - The OAuth settings need `AllowedOAuthFlowsUserPoolClient` to be true before they can be set, as
@@ -3766,8 +3766,8 @@ Current documented limitations:
   browser, and `client_credentials` needs the resource servers that define its scopes, so both are
   refused. `AllowedOAuthScopes` takes the system scopes, and a custom scope is refused for the same
   reason.
-- Unsimulated authentication inputs are refused the same way: `AnalyticsMetadata` on all four
-  operations, `ContextData` on the admin ones, `UserContextData` on the client ones, and a `Session`
+- Unsimulated authentication inputs are refused the same way. They are `AnalyticsMetadata` on all
+  four operations, `ContextData` on the admin ones, `UserContextData` on the client ones, and a `Session`
   on `InitiateAuth` or `AdminInitiateAuth`, which continues a flow neither of them starts.
 - A pool's schema is settled when the pool is created. `AddCustomAttributes` is unimplemented, and
   an `UpdateUserPool` request carrying a `Schema` is refused, because real `UpdateUserPool` has no
@@ -3792,7 +3792,7 @@ Current documented limitations:
   `end_session_endpoint` once the pool has a domain, at that domain's local hostname. It carries no
   `userinfo_endpoint`, where real Cognito names one.
 - Nothing calls an external identity provider. A provider's `ProviderDetails` are recorded and
-  validated for presence, and never used: the user a simulated provider signs in is the one
+  validated for presence, and never used. The user a simulated provider signs in is the one
   `signInAs` put there. That accessor is a divergence for the same reason `confirmationCode` is one.
 - A custom domain answers on its own hostname with no Route53 record of its own, where real AWS
   needs an alias record to the CloudFront distribution Cognito creates. The distribution name a

--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -65,13 +65,14 @@ console.log(decision.isAllowed);
 `CreateRoleCommand` validates the trust policy document and stores the Role with an AWS-shaped ARN,
 Role ID, and creation date. Roles can be inspected with `GetRoleCommand` and `ListRolesCommand`.
 
-A trust policy alone grants no permissions: a Role with no inline or attached policies is implicitly
+A trust policy alone grants no permissions. A Role with no inline or attached policies is implicitly
 denied for every action.
 
 ## Authorization decisions
 
-`authorize(...)` returns a decision object rather than throwing, so tests can assert on exactly why
-a request was allowed or denied. The decision models the common IAM evaluation rules:
+`authorize(...)` returns a decision object. A denied request comes back as a decision too, and a
+test can assert on exactly why it was allowed or denied. The decision models the common IAM
+evaluation rules:
 
 - A matching explicit `Deny` statement in any evaluated policy wins
 - Otherwise, within one Account, a matching `Allow` in an identity policy or resource policy allows
@@ -84,14 +85,14 @@ The decision exposes `value` (`"Allow"`, `"ExplicitDeny"`, or `"ImplicitDeny"`),
 flags `isAllowed`, `isDenied`, `isExplicitDeny`, and `isImplicitDeny`, the matching
 `allowStatements` and `explicitDenyStatements`, and the resolved `caller` for diagnostics. The
 matching Allows are also available per side as `identityAllowStatements` and
-`resourceAllowStatements`, which is what a cross-Account denial is best read from.
+`resourceAllowStatements`. A cross-Account denial is best read from those.
 
 If the caller is omitted, authorization defaults to the root principal of the Account owning the
-sim IAM instance, which is allowed within its own Account. An explicit `{ kind: "anonymous" }`
-caller suppresses that fallback and is evaluated without identity policies.
+sim IAM instance. That principal is allowed within its own Account. An explicit
+`{ kind: "anonymous" }` caller suppresses the fallback and is evaluated without identity policies.
 
-Resource policies are not stored in IAM. They are supplied with the authorization request by the
-service that owns the target resource, such as an S3 Bucket policy.
+Resource policies live with the service that owns the target resource, such as an S3 Bucket policy,
+and are supplied with the authorization request.
 
 ```typescript sim-iam-authorization-decisions
 /**
@@ -208,7 +209,7 @@ console.log(policyCreation.Policy.Arn);
 console.log(decision.isAllowed);
 ```
 
-Policy paths are normalised into the Policy ARN, so a Policy named `ReadOnlyReports` with path
+Policy paths are normalised into the Policy ARN. A Policy named `ReadOnlyReports` with path
 `/service-role/` gets the ARN `arn:aws:iam::123456789012:policy/service-role/ReadOnlyReports`.
 Creating a duplicate Policy name in the same path throws an error, while the same name in different
 paths is allowed. Stored Policies can be inspected with `GetPolicyCommand` and
@@ -222,8 +223,8 @@ Policy statements can carry `Condition` blocks. Sim IAM currently supports the `
 
 `ArnLike` and `ArnEquals` behave identically, as AWS documents them doing. Both compare the six
 colon-delimited components of an ARN separately, and both accept `*` and `?` wildcards in any of
-them. A wildcard stays inside the component it is written in, so `arn:aws:s3:*` matches nothing: a
-pattern needs as many components as the ARN it is matched against.
+them. A wildcard stays inside the component it is written in. `arn:aws:s3:*` matches nothing,
+because a pattern needs as many components as the ARN it is matched against.
 
 Condition context values are supplied by the service handling the simulated request, such as S3
 object tags. Sim IAM automatically derives global values it can work out itself, such as
@@ -287,15 +288,15 @@ const decision = simIam.authorize({
 console.log(decision.isAllowed);
 ```
 
-A condition that references a context key with no supplied value simply does not match, leaving the
+A condition that references a context key with no supplied value fails to match, leaving the
 request implicitly denied unless another statement allows it.
 
 ## Users and access keys
 
 Create Users with `CreateUserCommand`, give them inline policies with `PutUserPolicyCommand`, and
 issue access keys with `CreateAccessKeyCommand`. Access keys are registered with the Account's
-credential registry, so credentials can be supplied as the caller of an authorization attempt and
-are authenticated before policy evaluation.
+credential registry. Credentials can then be supplied as the caller of an authorization attempt,
+and are authenticated before policy evaluation.
 
 ```typescript sim-iam-user-access-key
 /**
@@ -447,17 +448,16 @@ works the caller out from the request itself, in a fixed order:
 
 1. An `x-sim-aws-caller` header naming the principal directly.
 2. An `Authorization: AWS4-HMAC-SHA256` header, verified as a SigV4 signature.
-3. Neither, giving **anonymous**.
+3. Failing both, **anonymous**.
 
-Sim IAM treats an omitted in-process caller as the Account root with unrestricted access, which is a
+Sim IAM treats an omitted in-process caller as the Account root with unrestricted access, a
 convenience inside a test. Over HTTP the same default would make every unauthenticated request an
-administrator, so a served request that says nothing about who sent it is anonymous instead, and
-never the Account root.
+administrator. A served request that says nothing about who sent it is anonymous.
 
 ### Naming the caller directly
 
 `x-sim-aws-caller` names the principal outright. It is the path for local development and for
-tooling that will not sign requests: a curl one-liner can be a Role without holding any credentials.
+tooling that will not sign requests. A curl one-liner can be a Role without holding any credentials.
 
 ```bash
 curl -H 'x-sim-aws-caller: arn:aws:iam::111111111111:role/Reporter' \
@@ -472,10 +472,11 @@ The value is one of three forms:
 | `service:<name>` | An AWS service principal, such as `service:s3.amazonaws.com` |
 | `anonymous`      | Explicitly anonymous                                         |
 
-The header is always enabled and not configurable, and it takes precedence over a valid signature. It
-does not check that the ARN exists, since naming a principal is not claiming it was created, exactly
-as `runAs` behaves. It is stripped before the request reaches the simulated service, so a Lambda
-handler echoing `event.headers` never sees simulator control metadata.
+The header is always enabled and not configurable, and it takes precedence over a valid signature.
+The ARN it names is taken as given, since naming a principal is a separate thing from claiming it
+was created, exactly as `runAs` behaves. The header is stripped before the request reaches the
+simulated service. A Lambda handler echoing `event.headers` sees none of the simulator's control
+metadata.
 
 ```typescript sim-iam-served-request-caller
 /**
@@ -543,12 +544,12 @@ curl -H 'x-sim-aws-caller: service:cloudfront.amazonaws.com' \
   http://abc123.lambda-url.us-east-1.sim-aws.localhost:4566/
 ```
 
-A request that states neither has no source at all, rather than an empty one, so a statement
-conditioned on either key does not match instead of matching an empty string. Both headers are
-stripped before the request reaches the simulated service, as the caller header is.
+A request that supplies neither header leaves both condition keys unset, and an unset key is a
+different thing from an empty one. A statement conditioned on either key fails to match. Both
+headers are stripped before the request reaches the simulated service, as the caller header is.
 
 Sim CloudFront sends these itself when a Distribution reaches a custom Origin through an origin
-access control, which is what an `AWS_IAM` Lambda Function URL behind CloudFront is admitted by.
+access control. That is how an `AWS_IAM` Lambda Function URL behind CloudFront is admitted.
 Simulated Lambda Function URLs are the only endpoint evaluating them so far.
 
 ### Signed requests
@@ -556,25 +557,25 @@ Simulated Lambda Function URLs are the only endpoint evaluating them so far.
 A request signed with credentials from `CreateAccessKeyCommand` or from an STS `AssumeRoleCommand`
 session is verified as a SigV4 signature and resolves to the signing principal, with the same
 identity `resolveCredentials` returns in process. For an assumed-role session that means the
-request is attributed to the session while its permissions come from the Role behind it, so a
-policy on the Role applies to a request the session signed.
+request is attributed to the session while its permissions come from the Role behind it. A policy
+on the Role applies to a request the session signed.
 
-Sign the URL you actually call. Serving rewrites AWS endpoint hostnames to local ones, so a Function
-URL is served at `<url-id>.lambda-url.<region>.sim-aws.localhost:<port>`. The `host` header is part of
-what a signature covers, so a signature made against the real AWS hostname will not verify against
-the local one.
+Sign the URL you actually call. Serving rewrites AWS endpoint hostnames to local ones, and a
+Function URL is served at `<url-id>.lambda-url.<region>.sim-aws.localhost:<port>`. The `host` header
+is part of what a signature covers. A signature made against the real AWS hostname fails against the
+local one.
 
 A signature whose credential scope names a different service or Region than the endpoint it reached
-is refused before anything else is checked, and says so. The scope feeds the signing key, so without
-that check the only symptom would be a signature mismatch with nothing to act on.
+is refused before anything else is checked, and says so. The scope feeds the signing key. Without
+that check the only symptom would be a bare signature mismatch.
 
 ### Presigned URLs
 
-A URL carrying its signature in query parameters is verified the same way: `X-Amz-Algorithm` in the
-query is what marks it, and the access key, credential scope, signed headers and signature are read
-from there instead of from an `Authorization` header. A presigned URL also states its own lifetime
-in `X-Amz-Expires`, and that _is_ enforced, against simulated time, so a frozen clock keeps a URL
-usable and advancing past the window refuses it with `AccessDenied` and `Request has expired`.
+A URL carrying its signature in query parameters is verified the same way. `X-Amz-Algorithm` in the
+query is what marks it, and the access key, credential scope, signed headers and signature all come
+from the query string. A presigned URL also states its own lifetime in `X-Amz-Expires`, and that
+_is_ enforced, against simulated time. A frozen clock keeps a URL usable, and advancing past the
+window refuses it with `AccessDenied` and `Request has expired`.
 
 URLs built by the real presigner, `getSignedUrl` from `@aws-sdk/s3-request-presigner`, verify here
 without anything simulator-specific. See
@@ -593,11 +594,11 @@ request was accepted:
 | `x-sim-aws-error`        | Absent                                                                                   | The AWS error code, such as `SignatureDoesNotMatch` |
 | `x-sim-aws-error-detail` | Absent                                                                                   | What the simulator can say about why                |
 
-A refused request is answered as real AWS answers it: `403` with `{"Message":"Forbidden"}` for a
-rejected signature, and `400` for a signature too incomplete to parse or an `x-sim-aws-caller`
-value that names no principal form. Real AWS has nowhere in that body to explain itself and neither
-does this, which is why the detail goes in `x-sim-aws-error-detail` where it changes nothing for a
-client parsing the response.
+A refused request is answered as real AWS answers it. A rejected signature gets `403` with
+`{"Message":"Forbidden"}`. A signature too incomplete to parse, or an `x-sim-aws-caller` value that
+names no principal form, gets `400`. Real AWS has nowhere in that body to explain itself, and this
+follows it. The detail goes in `x-sim-aws-error-detail`, out of the way of a client parsing the
+response.
 
 ## Authorizing other simulated services
 
@@ -659,16 +660,16 @@ await simRoute53.createHostedZone(
 
 A denied action throws an AWS-like access-denied error with a `403` status code and the attempted
 action, resource, and caller for diagnostics, before the service mutates any state. Omitting the
-caller defaults to the Account root, which is allowed within its own Account, so existing tests
-that never mention IAM keep working.
+caller defaults to the Account root. The Account root is allowed within its own Account, and a test
+that never mentions IAM keeps working.
 
 ## CloudFormation Roles and Managed Policies
 
 Sim CloudFormation can create IAM resources from `AWS::IAM::Role`, `AWS::IAM::ManagedPolicy`, and
 `AWS::IAM::Policy`. An `AWS::IAM::Policy` puts its document onto each Role named in `Roles` as an
 inline policy. That is the shape CDK grants such as `bucket.grantRead(fn)` synthesize as a
-"DefaultPolicy" resource. IAM Users and Groups are not simulated as policy principals, so naming them
-fails creation rather than silently dropping the grant.
+"DefaultPolicy" resource. IAM Users and Groups are not simulated as policy principals. Naming one
+fails the creation outright.
 
 ```typescript sim-iam-cloudformation
 /**
@@ -763,7 +764,7 @@ Role's inline policies.
 
 ## Accounts
 
-IAM is account-scoped in AWS, and sim IAM matches that: every Region scope of the same simulated
+IAM is account-scoped in AWS, and sim IAM matches that. Every Region scope of the same simulated
 Account shares one IAM state, while different Accounts are fully isolated from each other.
 
 ```typescript sim-iam-account-scoping
@@ -790,7 +791,7 @@ console.log(firstUserOutput.User.Arn);
 console.log(secondUserOutput.User.Arn);
 ```
 
-Principals from one Account get no implicit access to another Account's resources: authorizing a
+Principals from one Account get no implicit access to another Account's resources. Authorizing a
 caller from a different simulated Account results in an implicit deny unless both Accounts allow the
 request.
 
@@ -804,8 +805,8 @@ Accounts, as it is on AWS:
 - The caller's Account must allow it through an identity policy on that principal
 
 Either one on its own is denied. A resource policy naming another Account's principal delegates to
-that Account rather than granting on its behalf, and an Account cannot grant its own principals
-access to somebody else's resource. An explicit `Deny` on either side denies. Callers with no
+that Account, and an Account cannot grant its own principals access to somebody else's resource. An
+explicit `Deny` on either side denies. Callers with no
 identity side, such as a service principal or an anonymous request, are unaffected, and are still
 allowed by a resource policy alone.
 
@@ -886,15 +887,15 @@ await partnerIam.putRolePolicy(
 console.log(simAws.account("111111111111").iam().authorize(request).isAllowed);
 ```
 
-The caller's Account is resolved from the principal ARN, so it has to be an Account of the same
-`SimAws` instance for its policies to count. An Account the simulation was never told about grants
-nothing, which is also what a principal ARN that was never given any permissions means on AWS.
+The caller's Account is resolved from the principal ARN. For its policies to count, that Account has
+to belong to the same `SimAws` instance. An Account the simulation was never told about grants
+nothing. On AWS, a principal ARN that was never given any permissions comes out the same way.
 
-A standalone `SimIam` has no simulation around it and so no other Account to ask: a principal whose
+A standalone `SimIam` has no simulation around it, and so no other Account to ask. A principal whose
 ARN belongs to another Account is always denied, however permissive the resource policy. Anonymous
-and service-principal callers are not affected, since they have no Account either way, so a resource
-policy still allows them. The Account ID is available as `simIam.accountId`, which is what a test
-naming its own principals should build their ARNs from.
+and service-principal callers carry on as before, since they have no Account either way, and a
+resource policy still allows them. The Account ID is available as `simIam.accountId`. A test naming
+its own principals should build their ARNs from that.
 
 ## Standalone SimIam
 
@@ -927,8 +928,8 @@ const roleCreation = await simIam.createRole(
 console.log(roleCreation.Role.Arn);
 ```
 
-A standalone `SimIam` instance has its own isolated state, scoped to a generated Account ID, and is
-not connected to a wider `SimAws` environment. Other services instantiated standalone, such as
+A standalone `SimIam` instance has its own isolated state, scoped to a generated Account ID, and
+stands apart from any wider `SimAws` environment. Other services instantiated standalone, such as
 `new SimRoute53()`, fall back to allow-all authorization. Connect services through a shared `SimAws`
 instance when a test should exercise real IAM enforcement.
 
@@ -958,23 +959,21 @@ them to model the requested behaviour.
 
 ## Limitations
 
-Sim IAM models the policy behaviour that multi-service tests most commonly need, rather than the
-full IAM feature set. Notable gaps:
+Sim IAM models the policy behaviour that multi-service tests most commonly need. Notable gaps:
 
 - Permissions boundaries, session policies, and service control policies are not evaluated
-- Managed Policies have a single version; policy version commands are not supported
+- Managed Policies have a single version, and the policy version commands are absent
 - Deleting and detaching resources (Roles, Users, Policies, access keys) is not yet supported
-- Only the condition operators listed above are supported; a statement using an unsupported
-  operator fails closed and does not match, rather than silently allowing
-- Signature age is deliberately not enforced: `X-Amz-Date` must be present, well formed, and agree
-  with the credential scope date, but is never compared to a clock, so a client stamping real time
-  is not locked out of a simulation keeping a different one. Session expiry _is_ enforced, against
+- Only the condition operators listed above are supported. A statement using any other operator
+  fails closed, matching no request
+- Signature age is deliberately not enforced. `X-Amz-Date` must be present, well formed, and agree
+  with the credential scope date, but is never compared to a clock. A client stamping real time can
+  therefore reach a simulation keeping a different one. Session expiry _is_ enforced, against
   simulated time
 - S3 `aws-chunked` streaming signatures and SigV4A are not verified. Presigned query-string
   authentication is verified, for the `AWS4-HMAC-SHA256` algorithm only
 - The resolved caller is evaluated by Lambda Function URLs with `AuthType: "AWS_IAM"` and by the S3
-  REST endpoint, but not yet by the other services that serve HTTP: website-endpoint S3 responses
+  REST endpoint, but not yet by the other services that serve HTTP. Website-endpoint S3 responses
   and CloudFront responses perform no authorization
 - The identity side of a cross-Account request comes from the caller's Account in the same `SimAws`
-  instance. A caller whose Account is not part of the simulation is denied rather than assumed to be
-  permitted
+  instance. A caller whose Account is absent from the simulation is denied

--- a/docs/services/kms/README.md
+++ b/docs/services/kms/README.md
@@ -3,14 +3,15 @@
 Yulin includes a simulated AWS Key Management Service (KMS) for tests and local development.
 
 Encryption is real. Each simulated key holds AES-256 key material and the operations run through
-Node.js's own `crypto`, so a ciphertext cannot be read without its key, and a decryption with the
-wrong encryption context fails.
+Node.js's own `crypto`. A ciphertext can only be read with its key, and a decryption with the wrong
+encryption context fails.
 
 KMS-specific types are imported from the `@kensio/yulin/kms` subpath.
 
 ## Encrypting and decrypting
 
-Create a key and use it. `Decrypt` needs no `KeyId` for a symmetric key, because the ciphertext already names the key that produced it.
+Create a key and use it. `Decrypt` needs no `KeyId` for a symmetric key, because the ciphertext
+already names the key that produced it.
 
 ```typescript sim-kms-encrypt-decrypt
 /**
@@ -46,13 +47,13 @@ const decrypted = await kms.decrypt(
 console.log(Buffer.from(decrypted.Plaintext ?? []).toString("utf8")); // "hunter2"
 ```
 
-The ciphertext blob is opaque. Nothing outside the simulator should try to read it. It is not
-portable to real AWS, or between two `SimAws` instances.
+The ciphertext blob is opaque. Only the `SimAws` instance that produced it can read it. Real AWS and
+any second `SimAws` instance both reject it.
 
 ## Encryption context
 
-An encryption context is non-secret key/value data bound to a ciphertext. Supplying a different one
-on decryption fails, which ties a ciphertext to the thing it belongs to.
+An encryption context is non-secret key/value data bound to a ciphertext. Decryption with a
+different context fails. That ties a ciphertext to the thing it belongs to.
 
 ```typescript sim-kms-encryption-context
 /**
@@ -95,13 +96,13 @@ try {
 }
 ```
 
-The context is an unordered map, so the same pairs written in a different order still decrypt.
+The context is an unordered map. The same pairs written in a different order still decrypt.
 
 ## Envelope encryption
 
-`Encrypt` takes at most 4096 bytes, which is the limit that makes envelope encryption necessary.
-`GenerateDataKey` returns a data key twice: once in the clear, to encrypt your data with, and once
-encrypted under the KMS key, to store alongside it.
+`Encrypt` takes at most 4096 bytes. That limit is what makes envelope encryption necessary.
+`GenerateDataKey` returns a data key twice, once in the clear to encrypt your data with, and once
+encrypted under the KMS key to store alongside it.
 
 ```typescript sim-kms-generate-data-key
 /**
@@ -188,16 +189,16 @@ const verified = await kms.verify(
 console.log(verified.SignatureValid); // true
 ```
 
-`Verify` fails with `KMSInvalidSignatureException` when a signature does not check out, rather than
-answering `SignatureValid: false`. That is what real KMS does.
+`Verify` raises `KMSInvalidSignatureException` for a signature that fails to check out. Real KMS
+does the same, in place of answering `SignatureValid: false`.
 
 The key specs simulated are `ECC_NIST_P256`, `ECC_NIST_P384`, `ECC_NIST_P521`, `ECC_SECG_P256K1`,
 `RSA_2048`, `RSA_3072` and `RSA_4096`. Each ECC spec offers the one ECDSA algorithm paired with its
-curve; each RSA spec offers all six RSASSA algorithms. A signing algorithm the key spec does not
-offer is refused. So is `Sign` against an encryption key, and `Encrypt` against a signing key.
+curve. Each RSA spec offers all six RSASSA algorithms. A signing algorithm the key spec leaves out
+is refused. So is `Sign` against an encryption key, and `Encrypt` against a signing key.
 
-`DescribeKey` reports the key's own spec, usage and algorithms, so code that branches on them
-branches the same way it would on AWS.
+`DescribeKey` reports the key's own spec, usage and algorithms. Code that branches on them branches
+the same way it would on AWS.
 
 ### Verifying outside KMS
 
@@ -260,14 +261,14 @@ both matching what KMS produces. `GetPublicKey` against a symmetric key is
 
 ## Key policies and IAM
 
-Every KMS key has a policy, and it cannot be removed. An IAM policy granting `kms:Decrypt` reaches
-nothing unless the key's own policy admits the caller. How it admits them decides what else is
+Every KMS key has a policy, and it cannot be removed. An IAM policy granting `kms:Decrypt` only
+takes effect where the key's own policy admits the caller. How it admits them decides what else is
 needed:
 
-- A statement naming the caller grants access outright, so a role with no permissions of its own can
+- A statement naming the caller grants access outright. A role with no permissions of its own can
   still use the key.
-- A statement naming the account root, which is what the default key policy contains, only delegates
-  to that account's IAM. The caller still needs an identity policy allowing the action.
+- A statement naming the account root only delegates to that account's IAM. The caller still needs
+  an identity policy allowing the action. The default key policy is of this kind.
 
 ```typescript sim-kms-key-policy
 /**
@@ -342,20 +343,20 @@ on real KMS.
 ## AWS managed keys and `kms:ViaService`
 
 An alias beginning `alias/aws/` names an AWS managed key, and the key is created the first time
-something references it. Such a key gets the policy real AWS gives it, which is not the customer
-default:
+something references it. Such a key gets the policy real AWS gives it, which differs from the
+customer default:
 
 - Use of the key is allowed to any principal in the owning account, but only when `kms:ViaService`
   names the service that owns the key, such as `ssm.us-east-1.amazonaws.com` for `aws/ssm`.
-- The account root is allowed to read the key's metadata, and nothing more. Nothing about using the
-  key is delegated to IAM.
+- The account root is allowed to read the key's metadata. That is the whole of what this policy
+  delegates to IAM.
 
 That is why a role holding only `ssm:GetParameter` reads a decrypted `SecureString` under `aws/ssm`,
 and why a role holding `kms:Decrypt` on that key still cannot use it by calling KMS itself.
 
 `kms:ViaService` is set by the service making the call on the caller's behalf. Sim SSM does this for
 `SecureString` parameters. Code calling simulated KMS directly sets it with the `viaService` request
-option, naming the service on its own rather than as an endpoint, since the region is the key's.
+option, naming the service on its own (`ssm`), since the region is the key's.
 
 ```typescript sim-kms-aws-managed-key
 /**
@@ -403,15 +404,15 @@ console.log(policy.Policy); // the via-service-scoped policy
 
 A key policy of your own can use `kms:ViaService` too, with the ordinary condition operators, and it
 matches for requests carrying the option. A request that names no service has no value for the key,
-so a condition on it does not match.
+and a condition on it stays unmatched.
 
 ## Naming a key
 
-Every operation takes its target as a `KeyId`, and any of the four forms real KMS accepts will do: a
-key ID, a key ARN, an alias name such as `alias/app-key`, or an alias ARN.
+Every operation takes its target as a `KeyId`, in any of the four forms real KMS accepts. Those are
+a key ID, a key ARN, an alias name such as `alias/app-key`, and an alias ARN.
 
-A key ARN or alias ARN naming another account or region resolves to nothing, rather than having its
-identifier read out and looked up locally. A foreign ARN cannot reach a key that happens to share an
+A key ARN or alias ARN naming another account or region resolves to no key at all. Its identifier is
+never read out and looked up locally. A foreign ARN cannot reach a key that happens to share an
 identifier.
 
 Aliases beginning `alias/aws/` are reserved for AWS managed keys. `CreateAlias` refuses to create
@@ -461,16 +462,15 @@ console.log(managed.KeyMetadata?.KeyManager); // "AWS"
 
 ## Key state and deletion
 
-A key can be disabled, which leaves it present but unusable, and re-enabled later.
+A key can be disabled and re-enabled later. A disabled key stays present, and refuses to be used.
 
 Deletion is never immediate. `ScheduleKeyDeletion` sets a recovery window of 7 to 30 days, defaulting
 to 30. During that window the key refuses to be used but can still be recovered with
-`CancelKeyDeletion`. Cancelling leaves the key disabled rather than enabled, so re-enabling it is a
-separate step.
+`CancelKeyDeletion`. Cancelling leaves the key disabled. Re-enabling it is a separate step.
 
 A disabled key fails cryptographic operations with `DisabledException`. A key pending deletion fails
-with `KMSInvalidStateException`. The two are distinct: one means the key can be enabled again, the
-other means it is on its way out.
+with `KMSInvalidStateException`. The two are distinct. One means the key can be enabled again, the
+other that it is on its way out.
 
 ## Scoping
 
@@ -511,14 +511,14 @@ try {
 
 Simulated CloudFormation creates a key from an `AWS::KMS::Key` resource and points an
 `AWS::KMS::Alias` at it, in the stack's account and region. The key comes out of the same `CreateKey`
-path an SDK caller uses, so it has real key material. A `KeyPolicy` the template declares becomes the
-key policy. Omitting `KeyPolicy` gets the default root-delegation policy, as `CreateKey` with no
+path an SDK caller uses, with real key material. A `KeyPolicy` the template declares becomes the key
+policy. Omitting `KeyPolicy` gets the default root-delegation policy, as `CreateKey` with no
 `Policy` does.
 
-`Ref` on the key gives its key ID rather than its ARN, as on real AWS, and `Fn::GetAtt` gives `Arn`
-or `KeyId`. `Ref` on the alias gives the alias name, such as `alias/app-key`, which is itself usable
-as a `KeyId`. So a property wanting a key ID takes the `Ref`, while an IAM policy resource wanting
-the key needs `Fn::GetAtt … Arn`.
+`Ref` on the key gives its key ID, as on real AWS, and `Fn::GetAtt` gives `Arn` or `KeyId`. `Ref` on
+the alias gives the alias name, such as `alias/app-key`, and an alias name is itself usable as a
+`KeyId`. So a property wanting a key ID takes the `Ref`, while an IAM policy resource wanting the
+key needs `Fn::GetAtt … Arn`.
 
 ```typescript sim-kms-cloudformation-key
 /**
@@ -572,16 +572,17 @@ console.log(Buffer.from(decrypted.Plaintext ?? []).toString("utf8")); // "hunter
 console.log(stack.outputs.get("KeyArn")?.value); // "arn:aws:kms:...:key/..."
 ```
 
-Properties asking for behaviour that is not simulated do not stop the key being created. The key is
-created without them and each one is recorded in
-[`stack.ignoredProperties`](../cloudformation/README.md#properties-a-resource-was-created-without),
-so a template deploys and the record says what the key does not do. `EnableKeyRotation`,
-`RotationPeriodInDays`, `MultiRegion` and `Tags` are all recorded that way: the key encrypts and
-decrypts, its material never rotates, it exists in one region, and nothing reads its tags. A `KeySpec`
-or `KeyUsage` pair simulated KMS does not model, or an `Origin` other than `AWS_KMS`, is still
-refused by `CreateKey` in the same terms it refuses an SDK caller, because there is no key to
-create at all.
-`Enabled: false` is supported, and deploys a key that is disabled from the moment it exists.
+A property asking for behaviour Yulin leaves out still deploys. The key is created without it, and
+the property is recorded in
+[`stack.ignoredProperties`](../cloudformation/README.md#properties-a-resource-was-created-without).
+The template deploys, and the record says what the key leaves out. `EnableKeyRotation`,
+`RotationPeriodInDays`, `MultiRegion` and `Tags` are all recorded that way. The key encrypts and
+decrypts, its material stays as it was, it exists in one region, and its tags go unread.
+
+A `KeySpec` or `KeyUsage` pair simulated KMS has no model for, or an `Origin` other than `AWS_KMS`,
+is refused by `CreateKey` in the same terms it refuses an SDK caller, since there is no key to
+create at all. `Enabled: false` is supported, and deploys a key that is disabled from the moment it
+exists.
 
 ## Inside a simulated Lambda handler
 
@@ -611,47 +612,48 @@ Sim KMS currently supports:
 
 Current documented limitations:
 
-- Only encryption with a symmetric key and signing with an asymmetric key are simulated. Asymmetric
-  encryption (`RSAES_OAEP_SHA_1` and `RSAES_OAEP_SHA_256`), HMAC keys and `GENERATE_VERIFY_MAC`,
-  key agreement and `DeriveSharedSecret`, the `SM2` key spec, and `ReEncrypt` are not. An RSA key
-  asked for with `KeyUsage: ENCRYPT_DECRYPT` is refused, which real KMS allows.
-- `Sign` and `Verify` take a `MessageType` of `RAW` only. A `DIGEST` message is refused, because
-  Node cannot sign a digest that has already been computed: `crypto.sign` with no algorithm hashes
-  what it is given rather than signing it, so the signature would not be the one real KMS makes and
-  would not verify against the message anywhere outside the simulator.
-- Generating an RSA key pair is real key generation, so an `RSA_4096` key costs a second or so of
-  test time. The ECC specs are effectively free.
-- Imported key material and custom key stores are not simulated; `Origin` other than `AWS_KMS` is
+- Only encryption with a symmetric key and signing with an asymmetric key are simulated. Left out
+  are asymmetric encryption (`RSAES_OAEP_SHA_1` and `RSAES_OAEP_SHA_256`), HMAC keys and
+  `GENERATE_VERIFY_MAC`, key agreement and `DeriveSharedSecret`, the `SM2` key spec, and
+  `ReEncrypt`. An RSA key asked for with `KeyUsage: ENCRYPT_DECRYPT` is refused, which real KMS
+  allows.
+- `Sign` and `Verify` take a `MessageType` of `RAW` only. A `DIGEST` message is refused. Node cannot
+  sign a digest that has already been computed, because `crypto.sign` with no algorithm hashes what
+  it is given. The resulting signature would differ from the one real KMS makes, and would fail to
+  verify against the message anywhere outside the simulator.
+- Generating an RSA key pair is real key generation. An `RSA_4096` key costs a second or so of test
+  time. The ECC specs are effectively free.
+- Imported key material and custom key stores are left out. `Origin` other than `AWS_KMS` is
   refused.
-- Grants (`CreateGrant` and friends) are not simulated.
-- Automatic key rotation is not simulated. An `AWS::KMS::Key` declaring `EnableKeyRotation` or
+- Grants (`CreateGrant` and friends) are left out.
+- Key material stays as it was created. An `AWS::KMS::Key` declaring `EnableKeyRotation` or
   `RotationPeriodInDays` is created without it, and the property is recorded in
   `stack.ignoredProperties`.
-- Multi-Region keys are not simulated. An `AWS::KMS::Key` declaring `MultiRegion: true` is created as
-  a key in one region, and the property is recorded.
+- A Multi-Region key comes out as an ordinary key in one region. An `AWS::KMS::Key` declaring
+  `MultiRegion: true` deploys that way, and the property is recorded.
 - `AWS::KMS::Key` accepts but ignores `PendingWindowInDays` and `BypassPolicyLockoutSafetyCheck`.
-  Neither has anything to act on: a stack teardown schedules the key for deletion with the default
-  window, and simulated KMS applies no policy lockout safety check to bypass.
+  Both are inert here. A stack teardown schedules the key for deletion with the default window, and
+  simulated KMS applies no policy lockout safety check to bypass.
 - An `AWS::KMS::Alias` retargeted by a stack update is deleted and created again pointing at the new
   key, because a stack update replaces a changed resource and simulated KMS has no `UpdateAlias`.
-- `AWS::KMS::Grant` and `AWS::KMS::ReplicaKey` are not supported; a template declaring one is
-  refused.
+- A template declaring `AWS::KMS::Grant` or `AWS::KMS::ReplicaKey` is refused.
 - A key pending deletion stays in that state indefinitely. Advancing the simulated clock past the
-  recovery window does not delete it, so the key ID stays taken.
-- `UpdateAlias` is not supported. An alias is retargeted by deleting it and creating it again.
-- Tags, `ListResourceTags` and the `aws:ResourceTag` condition key are not simulated. An
-  `AWS::KMS::Key` declaring `Tags` deploys with the tags dropped and the property recorded, so a
-  policy condition written around one matches nothing here and matches on AWS.
-- `kms:EncryptionContext:*` and other KMS-specific condition keys beyond `kms:ViaService` and
-  `kms:CallerAccount` are not derived, so a policy relying on them will not match. Ordinary condition
-  operators on values sim IAM does supply work as usual.
-- The service an AWS managed key belongs to is taken from its alias, so `alias/aws/ebs` is scoped to
+  recovery window leaves it there, and the key ID stays taken.
+- `UpdateAlias` is absent. An alias is retargeted by deleting it and creating it again.
+- Tags, `ListResourceTags` and the `aws:ResourceTag` condition key are left out. An
+  `AWS::KMS::Key` declaring `Tags` deploys with the tags dropped and the property recorded. A policy
+  condition written around one fails to match here, where on AWS it would match.
+- `kms:ViaService` and `kms:CallerAccount` are the KMS-specific condition keys derived. A policy
+  relying on `kms:EncryptionContext:*` or any other one fails to match. Ordinary condition operators
+  on values sim IAM does supply work as usual.
+- The service an AWS managed key belongs to is taken from its alias. `alias/aws/ebs` is scoped to
   `ebs.<region>.amazonaws.com`. Real AWS scopes that one to EC2. The two agree for every service
   Yulin simulates.
-- Key material lives in process memory for the lifetime of the `SimAws` instance. That is not a
-  security boundary: anything sharing the process can reach it.
+- Key material lives in process memory for the lifetime of the `SimAws` instance. Anything sharing
+  the process can reach it.
 - Sim SSM encrypts `SecureString` parameters with simulated keys, checking `kms:Encrypt` and
   `kms:Decrypt`, and sim Secrets Manager encrypts every secret version, checking
-  `kms:GenerateDataKey` and `kms:Decrypt`. No other simulated service uses simulated keys: sim S3,
-  sim DynamoDB and sim Lambda environment variables do not, and do not check `kms:Decrypt`.
+  `kms:GenerateDataKey` and `kms:Decrypt`. No other simulated service uses simulated keys. Sim S3,
+  sim DynamoDB and sim Lambda environment variables leave them alone, and skip the `kms:Decrypt`
+  check.
 - KMS is not served as an HTTP API by `serveSimAws`.

--- a/docs/services/logs/README.md
+++ b/docs/services/logs/README.md
@@ -1,20 +1,20 @@
 # Simulated CloudWatch Logs
 
 Yulin includes a simulated Amazon CloudWatch Logs for tests and local development. It holds log
-groups, the streams inside them and the events written to those streams, so a test can put log
-events and read them back with `GetLogEvents` or search them with `FilterLogEvents` without an AWS
+groups, the streams inside them and the events written to those streams. A test can put log events
+and read them back with `GetLogEvents`, or search them with `FilterLogEvents`, without an AWS
 account.
 
-That is what this service is for: making log data addressable. Code that writes to CloudWatch Logs
-is code teams already have, and until now a test could only observe it by capturing process output.
+The point of it is to make log data addressable. Code that writes to CloudWatch Logs is code teams
+already have, and the alternative for a test is capturing process output.
 
 CloudWatch Logs specific types are imported from the `@kensio/yulin/logs` subpath.
 
 ## Writing and searching log events
 
 A log group holds streams, a stream holds events, and `FilterLogEvents` searches across every
-stream in a group. That last part is what makes an assertion practical: the test names the group,
-not the stream, so it does not need to know which execution environment wrote the line.
+stream in a group. A test can therefore name the group and leave the stream out, without knowing
+which execution environment wrote the line.
 
 ```typescript sim-logs-write-and-search
 /**
@@ -66,13 +66,13 @@ const found = await logs.filterLogEvents(
 console.log(found.events?.length, found.events?.[0]?.logStreamName);
 ```
 
-Neither the group nor the stream is created on the way. Real CloudWatch Logs refuses a write to
-either one that is not there, which is what makes a missing `logs:CreateLogStream` permission show
-up as a failure rather than as logs that quietly never appear.
+A write needs both the group and the stream to exist already. Real CloudWatch Logs refuses a write
+to either one that is absent. A missing `logs:CreateLogStream` permission therefore shows up as a failure, where
+otherwise the logs would quietly never appear.
 
 ## Filter patterns
 
-The plain text filter pattern syntax is supported: terms are matched as case sensitive substrings,
+The plain text filter pattern syntax is supported. Terms are matched as case sensitive substrings,
 every unprefixed term must appear, a `-` prefix excludes a term, a `?` prefix makes a term one of a
 set of alternatives, and a quoted phrase matches with its spaces intact.
 
@@ -86,26 +86,25 @@ set of alternatives, and a quoted phrase matches with its spaces intact.
 
 An omitted or empty pattern matches everything.
 
-The structured pattern syntaxes are refused rather than approximated. A JSON property pattern
-(`{ $.level = "ERROR" }`), a space delimited field pattern (`[level=ERROR, message]`) and a regular
-expression term (`%ERROR|WARN%`) each raise `SimLogsUnsupportedOperationException`. That is
-deliberate: a pattern quietly treated as matching everything would turn an assertion about one log
-line into an assertion about any log line at all, and the test would keep passing while testing
-nothing.
+The structured pattern syntaxes are refused. A JSON property pattern (`{ $.level = "ERROR" }`), a
+space delimited field pattern (`[level=ERROR, message]`) and a regular expression term
+(`%ERROR|WARN%`) each raise `SimLogsUnsupportedOperationException`. Approximating one would be
+worse. A pattern quietly treated as matching everything would turn an assertion about one log line
+into an assertion about any log line at all, and the test would keep passing while testing nothing.
 
 ## Reading one stream
 
 `GetLogEvents` reads a single stream and pages in both directions. With no token it answers with
-the newest events, as real CloudWatch Logs does; `startFromHead` starts at the oldest instead.
-Following `nextForwardToken` walks towards newer events, and reaching the end gives the same token
-back rather than nothing, so a caller polling a stream keeps it and asks again.
+the newest events, as real CloudWatch Logs does. `startFromHead` starts at the oldest. Following
+`nextForwardToken` walks towards newer events, and reaching the end gives the same token back. A
+caller polling a stream keeps it and asks again.
 
-Both readers narrow to a half open time window: an event whose timestamp equals `startTime` is
-included, and one whose timestamp equals `endTime` is not.
+Both readers narrow to a half open time window. An event whose timestamp equals `startTime` is
+included, and one whose timestamp equals `endTime` is left out.
 
 A token is an offset into the events the request selected, so keep `startTime` and `endTime` the
-same across a walk. Changing the window part-way through means the offset is counted against a
-different set of events, and the page you get back will not be the one you expected.
+same across a walk. Changing the window part-way through counts the offset against a different set
+of events, and the page comes back as a different page.
 
 ```typescript sim-logs-read-a-stream
 /**
@@ -167,13 +166,13 @@ console.log(read);
 
 ## Retention
 
-Retention is held as a property to assert on. Nothing expires here: a test would have to move the
-clock by months to see an event go, and what teams get wrong about retention is the value they
-deployed rather than the deletion that eventually follows from it. A log group with no retention
-keeps its events forever, which is the AWS default.
+Retention is held as a property to assert on. Events stay where they are, and seeing one go would
+mean moving the clock by months. What teams get wrong about retention is the value they deployed,
+ahead of the deletion that eventually follows from it. A log group with no retention keeps its
+events forever, the AWS default.
 
-The set of accepted values is fixed rather than a range, so a reasonable-looking
-`retentionInDays: 10` is refused here exactly as it is by an account.
+The accepted values are a fixed set. A reasonable-looking `retentionInDays: 10` is refused here
+exactly as it is by an account.
 
 ```typescript sim-logs-retention
 /**
@@ -211,9 +210,8 @@ console.log(
 
 ## Lambda handler output
 
-A zip-packaged Lambda function's output is recorded into `/aws/lambda/<function name>` as it runs,
-so a test can assert on what a handler logged by searching its log group rather than by capturing
-process output.
+A zip-packaged Lambda function's output is recorded into `/aws/lambda/<function name>` as it runs.
+A test can then assert on what a handler logged by searching its log group.
 
 ```typescript sim-logs-lambda-output
 /**
@@ -258,23 +256,23 @@ console.log(found.events?.[0]?.message);
 ```
 
 The output still reaches the terminal as well. Real Lambda sends it to CloudWatch Logs and nowhere
-else, but a test tool that swallowed it would make a failing test harder to debug than it is with
-none of this, so recording is a tee rather than a redirect.
+else, but a test tool that swallowed it would make a failing test harder to debug. Recording is a
+tee.
 
 Each invocation's `context.logGroupName` and `context.logStreamName` name the group and stream that
-were actually written to. Stream names use the real `YYYY/MM/DD/[$LATEST]<hash>` format, and the
-hash identifies the execution environment rather than the request, so a test should match the shape
-rather than the value.
+were actually written to. Stream names use the real `YYYY/MM/DD/[$LATEST]<hash>` format. The hash
+identifies the execution environment, and one environment serves more than one request. Match the
+shape in a test, and leave the value alone.
 
-Nothing is authorized on this path. A real function needs `logs:CreateLogGroup` and
+Writing on this path is unconditional. A real function needs `logs:CreateLogGroup` and
 `logs:PutLogEvents` on its execution Role, and one without them produces no logs at all, in silence.
-Simulating that would mean nearly every function in a test logged nothing with no failure to explain
-why, so writing here is unconditional.
+Simulating that would leave nearly every function in a test logging nothing, with no failure to
+explain why.
 
 ## Declaring a log group in a template
 
-`AWS::Logs::LogGroup` is deployed by simulated CloudFormation, so a test can assert on the retention
-a stack gave a group rather than reading it off the template.
+`AWS::Logs::LogGroup` is deployed by simulated CloudFormation. A test can then assert on the
+retention a stack gave a group.
 
 ```yaml
 OrdersLogs:
@@ -284,32 +282,29 @@ OrdersLogs:
     RetentionInDays: 14
 ```
 
-`Ref` resolves to the log group name and `Fn::GetAtt Arn` to the ARN with its trailing `:*`, which is
-the form a policy has to name, so a template granting a function permission on its own log group
-gets a resource that reaches the streams inside it.
+`Ref` resolves to the log group name, and `Fn::GetAtt Arn` to the ARN with its trailing `:*`. That is
+the form a policy has to name. A template granting a function permission on its own log group gets a
+resource that reaches the streams inside it.
 
 `LogGroupName` and `RetentionInDays` are the two properties acted on. A `RetentionInDays` outside the
-set AWS accepts fails the deploy, which is the point: it would otherwise only be found on a real one.
-Everything else is recorded as an ignored property rather than refused, so a reader can see what a
-deployed group is not doing without a whole stack failing over a property that changes nothing about
-what the test asserts.
+set AWS accepts fails the deploy, where otherwise it would only be found on a real one. Everything
+else is recorded as an ignored property. A reader can see what a deployed group leaves out, and the
+stack still deploys.
 
-Two divergences are worth knowing about:
+Two divergences to know about:
 
-- **A group that already exists is taken over rather than refused.** Real CloudFormation fails a
-  deploy that declares a log group already in the account. That is a genuine misconfiguration there
-  and pure noise here, where a Lambda function that logged during test setup has already created
-  `/aws/lambda/orders`.
-- **An update replaces the group rather than changing it in place.** Simulated CloudFormation has no
-  in-place update at all: any resource whose template entry changed is deleted and created again. The
-  retention ends up correct, but the events the group held are gone, where a real update to
-  `RetentionInDays` keeps them.
+- **A group that already exists is taken over.** Real CloudFormation fails a deploy that declares a
+  log group already in the account. That is a genuine misconfiguration there and pure noise here,
+  where a Lambda function that logged during test setup has already created `/aws/lambda/orders`.
+- **An update replaces the group.** Simulated CloudFormation has no in-place update at all. Any
+  resource whose template entry changed is deleted and created again. The retention ends up correct,
+  but the events the group held are gone, where a real update to `RetentionInDays` keeps them.
 
 ## Subscription filters
 
-A subscription filter delivers the events matching its pattern to a Lambda function, so the code a
-team wrote to forward log lines to an error tracker or a metrics sink can be tested against the
-handler it forwards from.
+A subscription filter delivers the events matching its pattern to a Lambda function. Code written to
+forward log lines to an error tracker or a metrics sink can be tested against the handler it
+forwards from.
 
 ```typescript sim-logs-subscription-filter
 /**
@@ -406,38 +401,38 @@ await simAws.backgroundTasksComplete();
 console.log(received);
 ```
 
-The payload is the real one: an `awslogs.data` field holding the base64 of a gzipped JSON document
+The payload is the real one. An `awslogs.data` field holds the base64 of a gzipped JSON document
 with `messageType`, `owner`, `logGroup`, `logStream`, `subscriptionFilters` and `logEvents`. A
 handler written against a real subscription decodes it unchanged.
 
-A few things are worth knowing:
+The behaviour in detail:
 
-- **Delivery is asynchronous.** `PutLogEvents` is answered before anything is delivered, so a test
-  waits with `await simAws.backgroundTasksComplete()`. A destination that throws does not fail the
-  write that triggered it.
-- **A failed delivery is kept.** Real CloudWatch Logs tells nobody when a delivery fails; it becomes
-  a metric nobody is watching. `simAws.logs().subscriptionFailures` holds them, so a test can find
-  out that the subscription it set up never reached anything.
-- **The destination is checked when the filter is put.** A function that has not granted
+- **Delivery is asynchronous.** `PutLogEvents` is answered before anything is delivered. A test
+  waits with `await simAws.backgroundTasksComplete()`. A destination that throws leaves the write
+  that triggered it alone.
+- **A failed delivery is kept.** Real CloudWatch Logs tells nobody when a delivery fails, and it
+  becomes a metric nobody is watching. `simAws.logs().subscriptionFailures` holds them. A test can
+  find out that the subscription it set up never reached anything.
+- **The destination is checked when the filter is put.** A function that has yet to grant
   `logs.<region>.amazonaws.com` permission to invoke it fails `PutSubscriptionFilter`, as it does in
-  an account, rather than leaving a filter that silently drops every event. The resource policy is
-  consulted again on every delivery, so a permission removed later stops delivery too.
+  an account. The alternative would be a filter that silently drops every event. The resource policy
+  is consulted again on every delivery, and a permission removed later stops delivery too.
 - **What a Lambda function logged is delivered as well.** A subscription on `/aws/lambda/orders`
-  picks up what that function wrote, so a forwarder can be tested against a real handler's output.
+  picks up what that function wrote. A forwarder can be tested against a real handler's output.
 - **Lambda is the only destination.** Kinesis, Firehose and cross-account destinations are refused
-  rather than accepted and never delivered to.
-- **Two filters per log group**, which is the current AWS account default.
+  outright.
+- **Two filters per log group**, the current AWS account default.
 
 ## Permissions
 
 Every operation goes through simulated IAM. An operation on a named log group authorizes against
-that group's ARN with the trailing `:*`, which is the form CloudWatch Logs policies are written in:
-granting `logs:PutLogEvents` on a group grants it on the streams inside, and the wildcard is what
-covers them. A policy naming `log-group:/aws/lambda/orders` without it reaches nothing here, exactly
-as it reaches nothing on real AWS.
+that group's ARN with the trailing `:*`. That is the form CloudWatch Logs policies are written in.
+Granting `logs:PutLogEvents` on a group grants it on the streams inside, and the wildcard is what
+covers them. A policy naming `log-group:/aws/lambda/orders` without it reaches no stream here,
+exactly as on real AWS.
 
-`DescribeLogGroups` names no particular group, so it authorizes against every log group in the
-account and region. A policy scoped to one group cannot describe them all.
+`DescribeLogGroups` names no particular group. It authorizes against every log group in the account
+and region, and a policy scoped to one group cannot describe them all.
 
 ```typescript sim-logs-permissions
 /**
@@ -510,7 +505,7 @@ console.log(simAws.logs().findLogGroup(logGroupName)?.logGroupArn);
 ## Through an intercepted SDK client
 
 Application code that constructs its own `CloudWatchLogsClient` reaches the simulator through SDK
-interception, with nothing to change in the code under test.
+interception, with the code under test unchanged.
 
 ```typescript sim-logs-sdk-interception
 /**
@@ -540,19 +535,19 @@ const described = await client.send(new DescribeLogGroupsCommand({}));
 console.log(described.logGroups?.[0]?.logGroupArn);
 ```
 
-## What is not simulated
+## Limitations
 
-- **Nothing expires.** Retention is stored and reported, never acted on.
+- **Events never expire.** Retention is stored and reported, never acted on.
 - **Metric filters.** Absent, so `metricFilterCount` is always zero.
-- **Subscription filter destinations other than Lambda**, and `Distribution`, which is accepted and
-  reported but changes nothing because there are no shards to spread across.
+- **Subscription filter destinations other than Lambda**, and `Distribution`. `Distribution` is
+  accepted and reported, and with no shards to spread across it has no effect.
 - **`AWS::Logs::SubscriptionFilter` and `AWS::Logs::MetricFilter`.** `AWS::Logs::LogGroup` is the
-  only CloudFormation resource type here; the others are recorded as gaps.
+  only CloudFormation resource type here, and the others are recorded as gaps.
 - **Logs Insights, export tasks, tags, encryption and data protection policies.** Absent. Tags and
-  `kmsKeyId` on `CreateLogGroup` are refused rather than dropped, so nothing looks set here and
-  behaves differently in an account.
-- **Per-stream `storedBytes`.** Always zero, which matches real CloudWatch Logs: it stopped
-  reporting the figure per stream in 2019. `DescribeLogGroups` reports the bytes a group holds.
+  `kmsKeyId` on `CreateLogGroup` are refused outright. A property cannot look set here and behave
+  differently in an account.
+- **Per-stream `storedBytes`.** Always zero, matching real CloudWatch Logs, which stopped reporting
+  the figure per stream in 2019. `DescribeLogGroups` reports the bytes a group holds.
 - **Log capture from anything but zip-packaged Lambda code.** A function backed by a handler
   function reference, including a container image binding, writes to the host console directly and
   is not recorded. See the Lambda docs for why.

--- a/docs/services/sts/README.md
+++ b/docs/services/sts/README.md
@@ -3,9 +3,9 @@
 Yulin includes a simulated STS (Security Token Service) for tests and local development.
 
 Sim STS is used through `SimAws` as `simAws.sts()`, scoped to the Account making the assume request.
-It simulates assuming IAM Roles: it evaluates the request against [simulated IAM](../iam/) policies
-and issues temporary session credentials that the rest of the simulated environment authenticates
-like real AWS credentials.
+It simulates assuming IAM Roles. An assume request is evaluated against
+[simulated IAM](../iam/) policies, and a request that passes issues temporary session credentials
+that the rest of the simulated environment authenticates like real AWS credentials.
 
 ## Basic usage
 
@@ -50,23 +50,23 @@ console.log(assumeRoleOutput.Credentials?.AccessKeyId);
 console.log(assumeRoleOutput.Credentials?.Expiration);
 ```
 
-The output matches the AWS shape: `AssumedRoleUser.Arn` is the session ARN, such as
+The output matches the AWS shape. `AssumedRoleUser.Arn` is the session ARN, such as
 `arn:aws:sts::123456789012:assumed-role/TargetRole/test-session`, and `Credentials` carries the
 temporary `AccessKeyId`, `SecretAccessKey`, `SessionToken`, and `Expiration`.
 
-The issued credentials are registered with the target Account's sim IAM, so they can authenticate
-later simulated requests, for example as the `caller` of an IAM authorization attempt, where identity
+The issued credentials are registered with the target Account's sim IAM. They authenticate later
+simulated requests, for example as the `caller` of an IAM authorization attempt, where identity
 policies come from the underlying Role. See [the sim IAM docs](../iam/#sts-assumerole-sessions) for a
 full example. Credentials missing their session token, or used after `Expiration`, are rejected with
 an AWS-like invalid-credentials error.
 
-`DurationSeconds` controls the session lifetime and defaults to 3600 seconds (one hour); it must be
+`DurationSeconds` controls the session lifetime and defaults to 3600 seconds (one hour). It must be
 a positive integer.
 
 ## Role-to-Role assumption
 
-Pass a caller to assume a Role as a specific principal instead of the Account root. As in real AWS,
-both sides of the request are then evaluated:
+Pass a caller to assume a Role as a specific principal. As in real AWS, both sides of the request
+are then evaluated:
 
 - The target Role's trust policy must allow the caller to perform `sts:AssumeRole`
 - A non-root caller also needs an identity policy allowing `sts:AssumeRole` on the target Role's
@@ -149,7 +149,7 @@ trust policy does not cover the caller, the caller has no identity policy allowi
 or an explicit `Deny` matches. The error has a `403` status code and names the `sts:AssumeRole`
 action and the target Role ARN. No session is created.
 
-Cross-Account assumption works the same way: create the source and target Roles in different
+Cross-Account assumption works the same way. Create the source and target Roles in different
 simulated Accounts of the same `SimAws` instance, and call `assumeRole` on the source Account's
 `sts()`. The issued session belongs to the target Role's Account.
 
@@ -200,7 +200,7 @@ const assumeRoleOutput = await account.sts().assumeRole(
 console.log(assumeRoleOutput.AssumedRoleUser?.Arn);
 ```
 
-An omitted or mismatched `ExternalId` leaves the trust-policy condition unmatched, so the assume
+An omitted or mismatched `ExternalId` leaves the trust-policy condition unmatched. The assume
 request is denied.
 
 ## Available functionality
@@ -222,7 +222,7 @@ them to model the requested behaviour.
 
 ## Limitations
 
-Sim STS models Role assumption rather than the full STS API. Notable gaps:
+Sim STS models Role assumption. Notable gaps:
 
 - `AssumeRoleCommand` is the only supported command. There is no `GetCallerIdentity`, federation, or
   web-identity support


### PR DESCRIPTION
Rewrites the sim CloudFront, IAM, KMS, CloudWatch Logs, STS and SDK interception docs against the technical-prose-style and avoid-ai-writing skills, cutting significance tails, contrastive definitions, negation framing and appositive tails, and splitting the semicolons and mid-sentence colons the house rules ban. Also clears the near-misses the earlier batches left behind in the ACM, API Gateway, CloudWatch and Cognito docs, so every README rewritten so far passes the checker. Only prose changed, with the extracted examples untouched. Two headings moved, the CloudWatch Logs one out of negation framing and the CloudFront one off a mid-sentence colon. Nothing links to either anchor.

`pnpm run check` passes, and `prose-check` reports every file in this batch clean. Still to do in a later batch: Lambda, S3, SNS, Route53, SQS, Rekognition, Scheduler, Secrets Manager, SES and SSM.