### PR TITLE
feat: serve the managed login pages

### DIFF
--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -1634,7 +1634,94 @@ challenge. `InitiateAuth` issues the MFA challenge and the new password challeng
 `AdminSetUserPassword` gives a user a permanent password.
 
 Users sign themselves up through `SignUp` and `ConfirmSignUp`, which are covered under
-[Signing up](#signing-up). A user confirmed that way signs in here with the password it chose.
+[Signing up](#signing-up). A user confirmed that way signs in here with the password it chose, and
+so does one that signed up on the page below.
+
+### The pages managed login serves
+
+A served domain answers three pages, so a browser in a local development server completes a whole
+sign-up and sign-in without any of it being stubbed out.
+
+`GET /oauth2/authorize` naming no `identity_provider` answers HTML holding the sign-in form. The
+form has a username field, a password field, and the authorize parameters as hidden inputs, and it
+posts back to `/oauth2/authorize`. The pool's identity providers are links to the same endpoint with
+`identity_provider` set, so both ways in are on the one page. Posting the form redirects to the app
+client's callback URL with the code and the `state`, honouring a `code_challenge` the request
+carried.
+
+`/signup` is a link from that page. Its form asks for a username, a password and the attributes the
+pool needs, which are the ones its `Schema` made required and the ones its `AutoVerifiedAttributes`
+names. Posting it does what `SignUp` does and sends the browser to `/confirm`.
+
+`/confirm` asks for the code, does what `ConfirmSignUp` does with it, and sends the browser back to
+`/oauth2/authorize` to sign in. Its second button is `ResendConfirmationCode`. Nothing delivers a
+code to anybody, so a test reads it off the pool the way it does for any other sign-up:
+
+```typescript sim-cognito-managed-login-pages
+/**
+ * Signing up, confirming and signing in through the served pages.
+ */
+
+import type { SimAws } from "@kensio/yulin";
+import { SimAwsHttp } from "@kensio/yulin/serve";
+
+declare const simAws: SimAws;
+declare const userPoolId: string;
+declare const clientId: string;
+
+const http = new SimAwsHttp({ simAws });
+const domain = "https://myapp-login.auth.eu-west-2.amazoncognito.com";
+const parameters = {
+  response_type: "code",
+  client_id: clientId,
+  redirect_uri: "https://www.example.com/user/callback",
+  scope: "openid email",
+  state: "csrf-token",
+};
+
+const posted = async (
+  path: string,
+  fields: Record<string, string>,
+): Promise<Response> =>
+  http.fetch(`${domain}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ ...parameters, ...fields }).toString(),
+  });
+
+// The sign-in page is what the authorize endpoint answers a browser with.
+const signInPage = await http.fetch(
+  `${domain}/oauth2/authorize?${new URLSearchParams(parameters).toString()}`,
+);
+console.log(signInPage.headers.get("content-type")); // "text/html; charset=utf-8"
+
+// The sign-up form creates the user, unconfirmed.
+await posted("/signup", { username: "alice", password: "Sup3rSecret!" });
+
+// The code the pool would have emailed is read off the pool.
+const pool = simAws.cognitoIdentityProvider().userPool(userPoolId);
+await posted("/confirm", {
+  username: "alice",
+  code: pool.confirmationCode("alice") ?? "",
+});
+
+// That same user then signs in and reaches the callback with a code.
+const signedIn = await posted("/oauth2/authorize", {
+  username: "alice",
+  password: "Sup3rSecret!",
+});
+const callbackUrl = new URL(signedIn.headers.get("location")!);
+console.log(callbackUrl.searchParams.get("state")); // "csrf-token"
+console.log(callbackUrl.searchParams.get("code") !== null); // true
+```
+
+A refusal a person can do something about is shown on the form they posted. A wrong password comes
+back on the sign-in form and issues no code, and a password the pool's policy turns down comes back
+on the sign-up form. A refusal the application caused, such as a `redirect_uri` the app client never
+registered, is answered the way every other authorize refusal is.
+
+There is no styling and no script on any of the three. Matching what real managed login looks like
+would be work no test could tell apart from a bare form.
 
 ### Signing out
 
@@ -3414,6 +3501,8 @@ Sim Cognito currently supports:
   with PKCE and with a `refresh_token` grant
 - An authorize request naming no identity provider, signing one of the pool's own users in from a
   `username` and a `password` it carries
+- A served sign-in form at `/oauth2/authorize`, a sign-up form at `/signup` and a confirmation form
+  at `/confirm`, each carrying the authorize parameters through to the next
 - The pool user a federated sign-in creates, named `<ProviderName>_<subject>`, in the
   `EXTERNAL_PROVIDER` status, carrying the `identities` attribute and claim and the attributes the
   provider's `AttributeMapping` named
@@ -3683,12 +3772,15 @@ Current documented limitations:
 - A pool's schema is settled when the pool is created. `AddCustomAttributes` is unimplemented, and
   an `UpdateUserPool` request carrying a `Schema` is refused, because real `UpdateUserPool` has no
   such input.
-- Managed login's pages are outside the simulation. The sign-in behind them is inside it. An
-  authorize request naming no `identity_provider`, or naming `COGNITO`, signs one of the pool's own
-  users in from the `username` and `password` it carries, and answers with the code real managed
-  login answers with. Nothing here draws the form those two fields came from, and
-  `AWS::Cognito::ManagedLoginBranding` is an unsupported resource type. `/login`, `/signup`,
-  `/oauth2/userInfo`, `/oauth2/revoke`, `/oauth2/idpresponse` and the SAML endpoints go unserved.
+- The managed login pages are bare forms with no styling and no script, and
+  `AWS::Cognito::ManagedLoginBranding` is an unsupported resource type. They are also at paths of
+  this simulation's own: real managed login serves its sign-in form at `/login` and confirms a
+  sign-up within `/signup`, where here the authorize endpoint answers with the form itself and
+  `/confirm` is a page. `/oauth2/userInfo`, `/oauth2/revoke`, `/oauth2/idpresponse` and the SAML
+  endpoints go unserved.
+- The pages hold no session and set no cookie, so each of them carries the authorize parameters in
+  hidden inputs instead. Real managed login keeps a session cookie, which is what signs a returning
+  browser straight back in without the form.
 - A hosted sign-in that real managed login would answer with a further page is refused. That is a
   user which has registered a second factor, and a user holding a temporary password. Both
   challenges are simulated at `InitiateAuth` and `AdminInitiateAuth`, which is where a test drives

--- a/docs/services/cognito/sim-cognito-managed-login-pages.example.ts
+++ b/docs/services/cognito/sim-cognito-managed-login-pages.example.ts
@@ -1,0 +1,55 @@
+/**
+ * Signing up, confirming and signing in through the served pages.
+ */
+
+import type { SimAws } from "@kensio/yulin";
+import { SimAwsHttp } from "@kensio/yulin/serve";
+
+declare const simAws: SimAws;
+declare const userPoolId: string;
+declare const clientId: string;
+
+const http = new SimAwsHttp({ simAws });
+const domain = "https://myapp-login.auth.eu-west-2.amazoncognito.com";
+const parameters = {
+  response_type: "code",
+  client_id: clientId,
+  redirect_uri: "https://www.example.com/user/callback",
+  scope: "openid email",
+  state: "csrf-token",
+};
+
+const posted = async (
+  path: string,
+  fields: Record<string, string>,
+): Promise<Response> =>
+  http.fetch(`${domain}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ ...parameters, ...fields }).toString(),
+  });
+
+// The sign-in page is what the authorize endpoint answers a browser with.
+const signInPage = await http.fetch(
+  `${domain}/oauth2/authorize?${new URLSearchParams(parameters).toString()}`,
+);
+console.log(signInPage.headers.get("content-type")); // "text/html; charset=utf-8"
+
+// The sign-up form creates the user, unconfirmed.
+await posted("/signup", { username: "alice", password: "Sup3rSecret!" });
+
+// The code the pool would have emailed is read off the pool.
+const pool = simAws.cognitoIdentityProvider().userPool(userPoolId);
+await posted("/confirm", {
+  username: "alice",
+  code: pool.confirmationCode("alice") ?? "",
+});
+
+// That same user then signs in and reaches the callback with a code.
+const signedIn = await posted("/oauth2/authorize", {
+  username: "alice",
+  password: "Sup3rSecret!",
+});
+const callbackUrl = new URL(signedIn.headers.get("location")!);
+console.log(callbackUrl.searchParams.get("state")); // "csrf-token"
+console.log(callbackUrl.searchParams.get("code") !== null); // true

--- a/src/service/cognito/README.md
+++ b/src/service/cognito/README.md
@@ -248,8 +248,9 @@ two shapes real Cognito reports it in.
 
 ## Hosted endpoints
 
-`command/hosted/` holds the three endpoints a domain serves, and `serve/sim-cognito-domain-controller.ts`
-is the HTTP side of them. They are not SDK commands and authorize no IAM caller: a browser and an
+`command/hosted/` holds the three endpoints a domain serves, `serve/page/` holds the pages managed
+login answers a browser with, and `serve/sim-cognito-domain-controller.ts` is the HTTP side of both.
+They are not SDK commands and authorize no IAM caller: a browser and an
 application's own server hold no AWS credentials, in the same way an `InitiateAuth` caller holds
 none. What the token endpoint authenticates instead is the app client: one with a secret presents
 it, in a basic authorization header or in the body, and a public client presents its client id and
@@ -259,7 +260,9 @@ binds the grant with PKCE.
 application. `SimCognitoHostedSignIn` is what decides which of the two sign-ins a request asked
 for. One naming an identity provider goes through `SimCognitoFederatedSignIn`, and one naming none
 goes through `SimCognitoHostedPasswordSignIn`, which checks the `username` and `password` the
-request carried with the checks `InitiateAuth` makes. `SimCognitoTokenEndpoint` exchanges the code,
+request carried with the checks `InitiateAuth` makes. A request carrying none is refused with
+`SimCognitoManagedLoginRequired`, which is the one refusal the serving layer answers with a page
+rather than with an error. `SimCognitoTokenEndpoint` exchanges the code,
 through the pool's own token issuer rather than anything of its own, so a hosted sign-in and an API
 sign-in issue the same tokens and run the same `PreTokenGeneration` trigger.
 
@@ -426,6 +429,14 @@ serves without any authentication: `/<userPoolId>/.well-known/jwks.json` and
 serving layer dispatches to, `SimCognitoOpenIdConfiguration` builds the discovery document, and
 `SimCognitoEndpointResponse` builds the responses. The Cognito API itself is not served: an SDK
 client reaches the simulator through `SimSdk`.
+
+`serve/page/` under it is the managed login pages. `SimCognitoPageMarkup` is the HTML they are built
+from, `SimCognitoPageForm` is one request read as the form it fetched or posted, and
+`SimCognitoManagedLogin` is what `SimCognitoDomainEndpoints` hands a page request to. The three
+pages are `SimCognitoSignInPage`, `SimCognitoSignUpPage` and `SimCognitoConfirmPage`, and the last
+two call `SignUp`, `ConfirmSignUp` and `ResendConfirmationCode` as an application would. A refusal a
+person can act on is rendered back onto the form they posted, and one the application caused is
+answered as any other authorize refusal is.
 
 `/<userPoolId>/messages` is served alongside them, and real Cognito has no such endpoint. It is the
 serving side of `SimCognitoUserPool.sentMessages`, so a browser or a curl can read what a pool would
@@ -629,13 +640,13 @@ resource, here or on real AWS.
   developer credentials, and nothing here tells one caller from another that way.
 - Users are resolved by username only, and real Cognito also accepts a `sub` there.
 - `AdminListGroupsForUser` sorts by precedence. Real Cognito does not document an order for it.
-- Managed login's pages are not simulated, and the local sign-in behind them is. An authorize
-  request naming no identity provider, or naming `COGNITO`, signs a pool user in from a `username`
-  and a `password` passed beside the other parameters. Nothing draws the form they came from. A
-  sign-in managed login would answer with a second page, which is a user owing a second factor and
-  a user holding a temporary password, is refused instead. The implicit and client credentials
-  grants are refused too, and `/login`, `/signup`, `/oauth2/userInfo`, `/oauth2/revoke` and the SAML
-  endpoints are not served.
+- The managed login pages are bare forms at paths of this simulation's own. The authorize endpoint
+  answers with the sign-in form where real managed login redirects to `/login`, and `/confirm` is a
+  page where real managed login confirms within `/signup`. They hold no session and set no cookie,
+  and carry the authorize parameters in hidden inputs instead. A sign-in managed login would answer
+  with a second page, which is a user owing a second factor and a user holding a temporary
+  password, is refused. The implicit and client credentials grants are refused too, and
+  `/oauth2/userInfo`, `/oauth2/revoke` and the SAML endpoints are not served.
 - A simulated identity provider signs in the user `signInAs` put there, and calls nothing. A
   provider nobody is signed in at refuses the authorize request rather than inventing one.
 - A custom domain answers on its own hostname with no Route53 record, where real AWS needs an alias

--- a/src/service/cognito/command/hosted/sim-cognito-hosted-password-sign-in.ts
+++ b/src/service/cognito/command/hosted/sim-cognito-hosted-password-sign-in.ts
@@ -1,5 +1,5 @@
 import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
-import { SimCognitoOAuthError } from "../../error/sim-cognito-oauth.error.js";
+import { SimCognitoManagedLoginRequired } from "../../error/sim-cognito-managed-login.error.js";
 import {
   requireSimCognitoConfirmed,
   requireSimCognitoSignIn,
@@ -57,9 +57,8 @@ export class SimCognitoHostedPasswordSignIn {
    * The username and password the request carried.
    *
    * A request carrying neither, and naming no identity provider, is one a
-   * browser would have been shown the sign-in page for. Calling
-   * `hostedAuthorize` directly skips that page, so this says what to pass
-   * instead.
+   * browser is shown the sign-in page for. The serving layer is what answers
+   * with that page, from this refusal.
    */
   private requiredCredentials(
     input: SimCognitoAuthorizeInput,
@@ -72,14 +71,7 @@ export class SimCognitoHostedPasswordSignIn {
       password === undefined ||
       password === ""
     ) {
-      throw new SimCognitoOAuthError({
-        code: "invalid_request",
-        description:
-          "This request names no identity provider, so it signs in one of " +
-          "the pool's own users and needs a username and a password. Pass " +
-          "both, or name an identity_provider to sign in through.",
-        redirectable: false,
-      });
+      throw new SimCognitoManagedLoginRequired();
     }
 
     return { username, password };

--- a/src/service/cognito/error/sim-cognito-managed-login.error.ts
+++ b/src/service/cognito/error/sim-cognito-managed-login.error.ts
@@ -1,0 +1,36 @@
+import { SimCognitoOAuthError } from "./sim-cognito-oauth.error.js";
+
+/**
+ * An authorize request that a person still has to fill a form in for.
+ *
+ * Real Cognito answers this request with managed login's sign-in form. The
+ * serving layer answers it with the simulation's own form, and a caller
+ * reaching `hostedAuthorize` without going through HTTP is answered with this
+ * refusal, which says which two fields the form would have posted.
+ *
+ * It is an OAuth error so that every other caller treats it as one. The
+ * serving layer is the only thing that tells it apart, because the serving
+ * layer is the only thing that can answer with a page.
+ */
+export class SimCognitoManagedLoginRequired extends SimCognitoOAuthError {
+  constructor() {
+    super({
+      code: "invalid_request",
+      description:
+        "This request names no identity provider, so it signs in one of " +
+        "the pool's own users and needs a username and a password. Pass " +
+        "both, or name an identity_provider to sign in through.",
+      redirectable: false,
+    });
+  }
+}
+
+/**
+ * Whether an authorize request was one managed login would have answered with
+ * its sign-in form.
+ */
+export function isSimCognitoManagedLoginRequired(
+  error: unknown,
+): error is SimCognitoManagedLoginRequired {
+  return error instanceof SimCognitoManagedLoginRequired;
+}

--- a/src/service/cognito/serve/page/sim-cognito-confirm-page.ts
+++ b/src/service/cognito/serve/page/sim-cognito-confirm-page.ts
@@ -81,15 +81,24 @@ export class SimCognitoConfirmPage {
    * has already been refused once or a fresh code has just been sent.
    */
   private render(form: SimCognitoPageForm, message?: string): Response {
-    const { parameters } = form;
+    const { parameters, username } = form;
+
+    // The sign-up that has just been made names the user, and a browser that
+    // came here from the sign-in page instead has to say who it is.
+    const user =
+      username === ""
+        ? this.markup.field("username", "Username")
+        : this.markup.hidden({ username });
+
     const body =
       (message === undefined ? "" : this.markup.message(message)) +
       this.markup.form(
         simCognitoConfirmPath,
-        this.markup.hidden({ ...parameters, username: form.username }) +
+        this.markup.hidden(parameters) +
+          user +
           this.markup.field("code", "Confirmation code") +
           this.markup.submit("confirm", "Confirm") +
-          this.markup.submit(resendField, "Send another code"),
+          this.markup.submit(resendField, "Send another code", true),
       ) +
       this.markup.link(simCognitoAuthorizePath, parameters, "Back to sign in");
 

--- a/src/service/cognito/serve/page/sim-cognito-confirm-page.ts
+++ b/src/service/cognito/serve/page/sim-cognito-confirm-page.ts
@@ -1,0 +1,98 @@
+import { SimCognitoPageForm } from "./sim-cognito-page-form.js";
+import { SimCognitoPageMarkup } from "./sim-cognito-page-markup.js";
+import {
+  simCognitoAuthorizePath,
+  simCognitoConfirmPath,
+} from "./sim-cognito-page-paths.js";
+
+/**
+ * The name of the button that asks for another confirmation code.
+ *
+ * The form has two submit buttons, and this is what tells the post which one
+ * was pressed.
+ */
+const resendField = "resend";
+
+/**
+ * The confirmation form, reached from the sign-up that has just been made.
+ *
+ * It takes the code the pool issued and confirms the sign-up with it, which is
+ * `ConfirmSignUp`. The second button is `ResendConfirmationCode`, and the code
+ * the user was holding stops working when it is pressed.
+ *
+ * Nothing here delivers a code to anybody. The pool records the message it
+ * would have sent, and `SimCognitoUserPool.confirmationCode` is where a test
+ * reads it from, which is where a person would have read it out of an inbox.
+ */
+export class SimCognitoConfirmPage {
+  private readonly markup = new SimCognitoPageMarkup();
+
+  /**
+   * The page, or one of the two operations its form has just posted.
+   */
+  async handle(form: SimCognitoPageForm): Promise<Response> {
+    if (!form.isPosted) {
+      return this.render(form);
+    }
+
+    if (form.field(resendField) !== undefined) {
+      return await this.resend(form);
+    }
+
+    try {
+      await form.cognito.confirmSignUp({
+        input: {
+          ClientId: form.clientId,
+          Username: form.username,
+          ConfirmationCode: form.field("code"),
+          ...form.secretHash(),
+        },
+      });
+    } catch (error) {
+      return this.render(form, SimCognitoPageForm.messageIn(error));
+    }
+
+    // The confirmed user signs in at the endpoint the browser arrived on,
+    // which is where the grant it started carries on from.
+    return this.markup.redirect(simCognitoAuthorizePath, form.parameters);
+  }
+
+  /**
+   * Issue a fresh confirmation code, and ask for it again.
+   */
+  private async resend(form: SimCognitoPageForm): Promise<Response> {
+    try {
+      await form.cognito.resendConfirmationCode({
+        input: {
+          ClientId: form.clientId,
+          Username: form.username,
+          ...form.secretHash(),
+        },
+      });
+    } catch (error) {
+      return this.render(form, SimCognitoPageForm.messageIn(error));
+    }
+
+    return this.render(form, "Another code has been sent.");
+  }
+
+  /**
+   * The page a browser is answered with, with a message where a confirmation
+   * has already been refused once or a fresh code has just been sent.
+   */
+  private render(form: SimCognitoPageForm, message?: string): Response {
+    const { parameters } = form;
+    const body =
+      (message === undefined ? "" : this.markup.message(message)) +
+      this.markup.form(
+        simCognitoConfirmPath,
+        this.markup.hidden({ ...parameters, username: form.username }) +
+          this.markup.field("code", "Confirmation code") +
+          this.markup.submit("confirm", "Confirm") +
+          this.markup.submit(resendField, "Send another code"),
+      ) +
+      this.markup.link(simCognitoAuthorizePath, parameters, "Back to sign in");
+
+    return this.markup.page("Confirm your sign-up", body);
+  }
+}

--- a/src/service/cognito/serve/page/sim-cognito-managed-login.ts
+++ b/src/service/cognito/serve/page/sim-cognito-managed-login.ts
@@ -1,0 +1,89 @@
+import { isSimCognitoManagedLoginRequired } from "../../error/sim-cognito-managed-login.error.js";
+import { isSimCognitoOAuthError } from "../../error/sim-cognito-oauth.error.js";
+import type { SimCognitoDomainRequest } from "../sim-cognito-domain-request.js";
+import { SimCognitoConfirmPage } from "./sim-cognito-confirm-page.js";
+import { SimCognitoPageForm } from "./sim-cognito-page-form.js";
+import type { SimCognitoPageParameters } from "./sim-cognito-page-markup.js";
+import {
+  simCognitoConfirmPath,
+  simCognitoIsLocalSignIn,
+  simCognitoSignUpPath,
+} from "./sim-cognito-page-paths.js";
+import { SimCognitoPageRequest } from "./sim-cognito-page-request.js";
+import { SimCognitoSignInPage } from "./sim-cognito-sign-in-page.js";
+import { SimCognitoSignUpPage } from "./sim-cognito-sign-up-page.js";
+
+/**
+ * The pages simulated managed login serves.
+ *
+ * A person reaches the sign-in form at the authorize endpoint, the sign-up
+ * form from a link on it, and the confirmation form from the sign-up it has
+ * just made. Each form carries the authorize request's own parameters through
+ * as hidden inputs, so the sign-in at the end of it reaches the app client's
+ * callback URL the application asked for.
+ */
+export class SimCognitoManagedLogin {
+  private readonly pageRequest = new SimCognitoPageRequest();
+  private readonly signInPage = new SimCognitoSignInPage();
+  private readonly signUpPage = new SimCognitoSignUpPage();
+  private readonly confirmPage = new SimCognitoConfirmPage();
+
+  /**
+   * Whether a path is one of the two pages served beside the OAuth endpoints.
+   */
+  static servesPage(pathname: string): boolean {
+    return (
+      pathname === simCognitoSignUpPath || pathname === simCognitoConfirmPath
+    );
+  }
+
+  /**
+   * Answer the sign-up or confirmation page a request reached.
+   */
+  async handlePage(request: SimCognitoDomainRequest): Promise<Response> {
+    const form = this.formIn(request);
+
+    if (request.url.pathname === simCognitoSignUpPath) {
+      return await this.signUpPage.handle(form);
+    }
+
+    return await this.confirmPage.handle(form);
+  }
+
+  /**
+   * Answer a refused authorize request on the sign-in form, where the form is
+   * what real managed login would have answered with.
+   *
+   * A request carrying no credentials gets the empty form. One the person
+   * filled in wrongly gets it back with the refusal on it, because a wrong
+   * password is theirs to correct rather than the application's to be told
+   * about. Every other refusal belongs to the application, and nothing here
+   * answers it.
+   */
+  refusedSignIn(
+    request: SimCognitoDomainRequest,
+    parameters: SimCognitoPageParameters,
+    error: unknown,
+  ): Response | undefined {
+    if (isSimCognitoManagedLoginRequired(error)) {
+      return this.signInPage.render(request.pool, parameters);
+    }
+
+    if (isSimCognitoOAuthError(error) || !simCognitoIsLocalSignIn(parameters)) {
+      return undefined;
+    }
+
+    return this.signInPage.render(
+      request.pool,
+      parameters,
+      SimCognitoPageForm.messageIn(error),
+    );
+  }
+
+  private formIn(request: SimCognitoDomainRequest): SimCognitoPageForm {
+    return new SimCognitoPageForm(
+      request,
+      this.pageRequest.values(request.serviceRequest, request.url),
+    );
+  }
+}

--- a/src/service/cognito/serve/page/sim-cognito-page-form.ts
+++ b/src/service/cognito/serve/page/sim-cognito-page-form.ts
@@ -1,0 +1,96 @@
+import { simCognitoSecretHash } from "../../user-pool/auth/sim-cognito-secret-hash.js";
+import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
+import type { SimCognitoDomainRequest } from "../sim-cognito-domain-request.js";
+import type { SimCognitoPageParameters } from "./sim-cognito-page-markup.js";
+import { simCognitoCarriedParameters } from "./sim-cognito-page-paths.js";
+
+/**
+ * One request to a page, read as the form it fetched or posted.
+ *
+ * A page is reached with a query string and posted back with a form encoded
+ * body, and both are name and value pairs. Which of the two a value came from
+ * changes nothing about what the page does with it, so a form holds them the
+ * same way and holds the method beside them.
+ */
+export class SimCognitoPageForm {
+  /** The authorize parameters this page carries on to the next one. */
+  public readonly parameters: SimCognitoPageParameters;
+
+  private readonly request: SimCognitoDomainRequest;
+  private readonly fields: SimCognitoPageParameters;
+
+  constructor(
+    request: SimCognitoDomainRequest,
+    values: SimCognitoPageParameters,
+  ) {
+    this.request = request;
+    this.fields = values;
+    this.parameters = simCognitoCarriedParameters(values);
+  }
+
+  /**
+   * The message a refusal is shown on the page as.
+   */
+  static messageIn(error: unknown): string {
+    if (error instanceof Error) {
+      return error.message;
+    }
+
+    return "The request was refused";
+  }
+
+  /** The pool this page belongs to. */
+  get pool(): SimCognitoUserPool {
+    return this.request.pool;
+  }
+
+  /** The simulated Cognito scope the operations behind the pages run in. */
+  get cognito(): SimCognitoDomainRequest["cognito"] {
+    return this.request.cognito;
+  }
+
+  /** Whether the form was posted rather than fetched. */
+  get isPosted(): boolean {
+    return this.request.serviceRequest.request.method === "POST";
+  }
+
+  /** The app client the grant this page belongs to was started by. */
+  get clientId(): string | undefined {
+    return this.parameters["client_id"];
+  }
+
+  /** The user this page is about, which is empty until a form named one. */
+  get username(): string {
+    return this.fields["username"] ?? "";
+  }
+
+  /**
+   * One field the form asked for.
+   */
+  field(name: string): string | undefined {
+    return Object.entries(this.fields).find(([key]) => key === name)?.[1];
+  }
+
+  /**
+   * The `SecretHash` a client with a secret needs, and nothing for one
+   * without.
+   *
+   * Managed login computes this on the server rather than asking the browser
+   * for a secret, and so does this.
+   */
+  secretHash(): { SecretHash?: string } {
+    const { clientId, username } = this;
+    const secret =
+      clientId === undefined
+        ? undefined
+        : this.pool.findClient(clientId)?.secret;
+
+    // This asks whether the app client has a secret at all, and compares none.
+    // oxlint-disable-next-line security/detect-possible-timing-attacks
+    if (secret === undefined || clientId === undefined) {
+      return {};
+    }
+
+    return { SecretHash: simCognitoSecretHash(username, clientId, secret) };
+  }
+}

--- a/src/service/cognito/serve/page/sim-cognito-page-markup.ts
+++ b/src/service/cognito/serve/page/sim-cognito-page-markup.ts
@@ -1,0 +1,139 @@
+/**
+ * The parameters a managed login page carries from one step to the next.
+ *
+ * They are the authorize request's own query string, held as hidden inputs so
+ * that the sign-in at the end of a sign-up reaches the app client's callback
+ * URL with the `state` the application started with.
+ */
+export type SimCognitoPageParameters = Readonly<Record<string, string>>;
+
+const escapes = new Map([
+  ["&", "&amp;"],
+  ["<", "&lt;"],
+  [">", "&gt;"],
+  ['"', "&quot;"],
+  ["'", "&#39;"],
+]);
+
+/**
+ * The HTML the simulated managed login pages are built from.
+ *
+ * There is no styling and there is no script. The pages exist so that a
+ * browser in a local development server can complete a sign-up and a sign-in,
+ * and so that a test can post the same forms. Matching what real managed login
+ * looks like would be work no test could tell apart from this.
+ *
+ * Every value that reaches the page goes through `escaped`. A `state` is
+ * whatever the application put in it, and it is written back into a hidden
+ * input, so it is the one piece of this that a page could otherwise be broken
+ * with.
+ */
+export class SimCognitoPageMarkup {
+  /**
+   * One page, answered as HTML.
+   */
+  page(title: string, body: string): Response {
+    const html =
+      `<!doctype html>\n<html lang="en">\n<head>\n` +
+      `<meta charset="utf-8">\n<title>${this.escaped(title)}</title>\n` +
+      `</head>\n<body>\n<h1>${this.escaped(title)}</h1>\n${body}\n` +
+      `</body>\n</html>\n`;
+
+    return new Response(html, {
+      status: 200,
+      headers: {
+        "content-type": "text/html; charset=utf-8",
+        "cache-control": "no-store",
+      },
+    });
+  }
+
+  /**
+   * Send the browser on to the next page of the flow.
+   *
+   * A form post is answered with a 303 so that the browser follows it with a
+   * GET, which is what stops a reload posting the form a second time.
+   */
+  redirect(path: string, parameters: SimCognitoPageParameters): Response {
+    const query = new URLSearchParams(parameters).toString();
+
+    return new Response(undefined, {
+      status: 303,
+      headers: { location: `${path}?${query}`, "cache-control": "no-store" },
+    });
+  }
+
+  /**
+   * A form posting back to the path it was served from.
+   */
+  form(action: string, body: string): string {
+    return `<form method="post" action="${this.escaped(action)}">\n${body}</form>\n`;
+  }
+
+  /**
+   * One labelled input, with the label naming the field it is for.
+   */
+  field(name: string, label: string, type = "text"): string {
+    const escapedName = this.escaped(name);
+
+    return (
+      `<p><label for="${escapedName}">${this.escaped(label)}</label>\n` +
+      `<input id="${escapedName}" name="${escapedName}" ` +
+      `type="${this.escaped(type)}" required></p>\n`
+    );
+  }
+
+  /**
+   * The parameters this page carries on to the next one.
+   */
+  hidden(parameters: SimCognitoPageParameters): string {
+    return Object.entries(parameters)
+      .map(
+        ([name, value]) =>
+          `<input type="hidden" name="${this.escaped(name)}" ` +
+          `value="${this.escaped(value)}">\n`,
+      )
+      .join("");
+  }
+
+  /**
+   * A link to another page of the flow, carrying the same parameters.
+   */
+  link(
+    path: string,
+    parameters: SimCognitoPageParameters,
+    text: string,
+  ): string {
+    const query = new URLSearchParams(parameters).toString();
+
+    return `<p><a href="${this.escaped(`${path}?${query}`)}">${this.escaped(text)}</a></p>\n`;
+  }
+
+  /**
+   * What went wrong with the form that was just posted.
+   */
+  message(text: string): string {
+    return `<p class="message">${this.escaped(text)}</p>\n`;
+  }
+
+  /**
+   * A submit button, named so that a form with two of them says which was
+   * pressed.
+   */
+  submit(name: string, label: string): string {
+    return (
+      `<p><button type="submit" name="${this.escaped(name)}" ` +
+      `value="${this.escaped(name)}">${this.escaped(label)}</button></p>\n`
+    );
+  }
+
+  /**
+   * A value written into HTML, with the five characters that would otherwise
+   * change what the page means replaced.
+   */
+  escaped(value: string): string {
+    return value.replaceAll(/[&<>"']/gu, (character) => {
+      return escapes.get(character) ?? character;
+    });
+  }
+}

--- a/src/service/cognito/serve/page/sim-cognito-page-markup.ts
+++ b/src/service/cognito/serve/page/sim-cognito-page-markup.ts
@@ -119,11 +119,16 @@ export class SimCognitoPageMarkup {
   /**
    * A submit button, named so that a form with two of them says which was
    * pressed.
+   *
+   * A button that asks the form to do something other than what its fields
+   * were filled in for skips the browser's own validation, so an empty
+   * required field does not stop it.
    */
-  submit(name: string, label: string): string {
+  submit(name: string, label: string, skipValidation = false): string {
     return (
       `<p><button type="submit" name="${this.escaped(name)}" ` +
-      `value="${this.escaped(name)}">${this.escaped(label)}</button></p>\n`
+      `value="${this.escaped(name)}"${skipValidation ? " formnovalidate" : ""}>` +
+      `${this.escaped(label)}</button></p>\n`
     );
   }
 

--- a/src/service/cognito/serve/page/sim-cognito-page-paths.ts
+++ b/src/service/cognito/serve/page/sim-cognito-page-paths.ts
@@ -1,0 +1,72 @@
+import type { SimCognitoPageParameters } from "./sim-cognito-page-markup.js";
+
+/**
+ * The path the sign-in form is served at and posts back to.
+ *
+ * Real managed login serves its form at `/login` and sends the browser there
+ * from `/oauth2/authorize`. Here the authorize endpoint answers with the form
+ * itself, so an application's own authorize URL is the whole of what a test
+ * has to know.
+ */
+export const simCognitoAuthorizePath = "/oauth2/authorize";
+
+/**
+ * The path the sign-up form is served at.
+ */
+export const simCognitoSignUpPath = "/signup";
+
+/**
+ * The path the confirmation form is served at.
+ *
+ * Real managed login confirms a sign-up on a page of `/signup` rather than at
+ * a path of its own. This one is separate so that a browser can come back to
+ * it with the code, and a test can reach it without replaying the sign-up.
+ */
+export const simCognitoConfirmPath = "/confirm";
+
+/**
+ * The authorize parameters every page carries on to the next.
+ *
+ * A sign-up ends in a sign-in, and that sign-in has to reach the app client's
+ * callback URL with the `state` the application started with, so these travel
+ * through each form as hidden inputs.
+ */
+const carriedNames = new Set([
+  "response_type",
+  "client_id",
+  "redirect_uri",
+  "state",
+  "scope",
+  "code_challenge",
+  "code_challenge_method",
+]);
+
+/**
+ * Whether a request signs in one of the pool's own users.
+ *
+ * A request naming no identity provider, or naming `COGNITO`, is the one
+ * managed login answers with its own form, so a refusal from it is shown on
+ * that form. One naming an external provider has no form to be shown on.
+ */
+export function simCognitoIsLocalSignIn(
+  values: SimCognitoPageParameters,
+): boolean {
+  const named = values["identity_provider"] ?? values["idp_identifier"];
+
+  return named === undefined || named === "COGNITO";
+}
+
+/**
+ * The authorize parameters out of everything a request carried.
+ *
+ * A form post arrives holding these and the fields the form asked for, and a
+ * page passes on only these, so nothing a person typed becomes part of the
+ * next request's authorize parameters.
+ */
+export function simCognitoCarriedParameters(
+  values: SimCognitoPageParameters,
+): SimCognitoPageParameters {
+  return Object.fromEntries(
+    Object.entries(values).filter(([name]) => carriedNames.has(name)),
+  );
+}

--- a/src/service/cognito/serve/page/sim-cognito-page-request.ts
+++ b/src/service/cognito/serve/page/sim-cognito-page-request.ts
@@ -1,0 +1,38 @@
+import type { SimAwsServiceRequest } from "../../../../serve/controller/sim-service-controller.js";
+import type { SimCognitoPageParameters } from "./sim-cognito-page-markup.js";
+
+/**
+ * What a request to a managed login page carried.
+ *
+ * A page is reached with a query string and posted back with a form encoded
+ * body, and both are name and value pairs, so they are read into the same
+ * record. Which of them a value came from changes nothing about what the page
+ * does with it.
+ */
+export class SimCognitoPageRequest {
+  /**
+   * The values a request carried, from its body where it has one and from its
+   * query string where it has not.
+   */
+  values(
+    serviceRequest: SimAwsServiceRequest,
+    url: URL,
+  ): SimCognitoPageParameters {
+    if (serviceRequest.request.method === "GET") {
+      return Object.fromEntries(url.searchParams);
+    }
+
+    return Object.fromEntries(new URLSearchParams(this.body(serviceRequest)));
+  }
+
+  /**
+   * The body as it arrived, which the serving layer buffered.
+   */
+  private body(serviceRequest: SimAwsServiceRequest): string {
+    if (serviceRequest.body === undefined) {
+      return "";
+    }
+
+    return Buffer.from(serviceRequest.body).toString("utf8");
+  }
+}

--- a/src/service/cognito/serve/page/sim-cognito-sign-in-page.ts
+++ b/src/service/cognito/serve/page/sim-cognito-sign-in-page.ts
@@ -1,0 +1,66 @@
+import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
+import {
+  SimCognitoPageMarkup,
+  type SimCognitoPageParameters,
+} from "./sim-cognito-page-markup.js";
+import {
+  simCognitoAuthorizePath,
+  simCognitoConfirmPath,
+  simCognitoSignUpPath,
+} from "./sim-cognito-page-paths.js";
+
+/**
+ * The sign-in form managed login answers an authorize request with.
+ *
+ * The form posts back to the authorize endpoint, carrying the parameters the
+ * browser arrived on as hidden inputs and the two fields the person filled in.
+ * The pool's identity providers are links to the same endpoint with
+ * `identity_provider` set, so both ways in are reachable from this one page.
+ */
+export class SimCognitoSignInPage {
+  private readonly markup = new SimCognitoPageMarkup();
+
+  /**
+   * The page a browser is answered with, with a message where a sign-in has
+   * already been refused once.
+   */
+  render(
+    pool: SimCognitoUserPool,
+    parameters: SimCognitoPageParameters,
+    message?: string,
+  ): Response {
+    const body =
+      (message === undefined ? "" : this.markup.message(message)) +
+      this.markup.form(
+        simCognitoAuthorizePath,
+        this.markup.hidden(parameters) +
+          this.markup.field("username", "Username") +
+          this.markup.field("password", "Password", "password") +
+          this.markup.submit("signIn", "Sign in"),
+      ) +
+      this.providerLinks(pool, parameters) +
+      this.markup.link(simCognitoSignUpPath, parameters, "Sign up") +
+      this.markup.link(simCognitoConfirmPath, parameters, "Confirm a sign-up");
+
+    return this.markup.page("Sign in", body);
+  }
+
+  /**
+   * One link per identity provider the pool has, each starting the federated
+   * sign-in this endpoint already answers.
+   */
+  private providerLinks(
+    pool: SimCognitoUserPool,
+    parameters: SimCognitoPageParameters,
+  ): string {
+    return pool.auth.identityProviders.all
+      .map((provider) =>
+        this.markup.link(
+          simCognitoAuthorizePath,
+          { ...parameters, identity_provider: provider.name },
+          `Sign in with ${provider.name}`,
+        ),
+      )
+      .join("");
+  }
+}

--- a/src/service/cognito/serve/page/sim-cognito-sign-in-page.ts
+++ b/src/service/cognito/serve/page/sim-cognito-sign-in-page.ts
@@ -46,14 +46,26 @@ export class SimCognitoSignInPage {
   }
 
   /**
-   * One link per identity provider the pool has, each starting the federated
-   * sign-in this endpoint already answers.
+   * One link per identity provider this app client offers, each starting the
+   * federated sign-in the same endpoint already answers.
+   *
+   * A provider the client left out of its `SupportedIdentityProviders` is left
+   * off the page, because the authorize request the link would make is one
+   * that endpoint refuses.
    */
   private providerLinks(
     pool: SimCognitoUserPool,
     parameters: SimCognitoPageParameters,
   ): string {
+    const clientId = parameters["client_id"];
+    const client =
+      clientId === undefined ? undefined : pool.findClient(clientId);
+
     return pool.auth.identityProviders.all
+      .filter(
+        (provider) =>
+          client?.oauth.allowsIdentityProvider(provider.name) ?? false,
+      )
       .map((provider) =>
         this.markup.link(
           simCognitoAuthorizePath,

--- a/src/service/cognito/serve/page/sim-cognito-sign-up-page.ts
+++ b/src/service/cognito/serve/page/sim-cognito-sign-up-page.ts
@@ -1,0 +1,106 @@
+import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
+import type { SimCognitoAttributeType } from "../../user-pool/user/sim-cognito-user-attributes.js";
+import { SimCognitoPageForm } from "./sim-cognito-page-form.js";
+import { SimCognitoPageMarkup } from "./sim-cognito-page-markup.js";
+import {
+  simCognitoAuthorizePath,
+  simCognitoConfirmPath,
+  simCognitoSignUpPath,
+} from "./sim-cognito-page-paths.js";
+
+/**
+ * The sign-up form, reached from a link on the sign-in page.
+ *
+ * The form asks for a username, a password and the attributes the pool needs
+ * of a new user. Those are the ones its `Schema` made required, and the ones
+ * its `AutoVerifiedAttributes` names, because the second is where the
+ * confirmation code would have been delivered.
+ *
+ * Posting it is `SignUp`, called as an application calls it. A refusal is
+ * shown on the form, which is what managed login does with a password the
+ * pool's policy turns down.
+ */
+export class SimCognitoSignUpPage {
+  private readonly markup = new SimCognitoPageMarkup();
+
+  /**
+   * The attributes this pool's sign-up form asks for.
+   */
+  static attributeNames(pool: SimCognitoUserPool): readonly string[] {
+    const { schema, autoVerifiedAttributes, usernameAttributes } =
+      pool.settings;
+    const asked = new Set([
+      ...schema.requiredNames,
+      ...autoVerifiedAttributes.names,
+    ]);
+
+    // A pool signing users in by an address takes that address as the
+    // username, so asking for it again would be asking the same question
+    // twice.
+    return [...asked.difference(new Set(usernameAttributes.names))];
+  }
+
+  /**
+   * The attributes the form asked for, as `SignUp` takes them.
+   */
+  private static attributesIn(
+    form: SimCognitoPageForm,
+  ): SimCognitoAttributeType[] {
+    return this.attributeNames(form.pool)
+      .map((name) => ({ Name: name, Value: form.field(name) }))
+      .filter((attribute) => (attribute.Value ?? "") !== "");
+  }
+
+  /**
+   * The page, or the sign-up its form has just posted.
+   */
+  async handle(form: SimCognitoPageForm): Promise<Response> {
+    if (!form.isPosted) {
+      return this.render(form);
+    }
+
+    try {
+      await form.cognito.signUp({
+        input: {
+          ClientId: form.clientId,
+          Username: form.username,
+          Password: form.field("password"),
+          UserAttributes: SimCognitoSignUpPage.attributesIn(form),
+          ...form.secretHash(),
+        },
+      });
+    } catch (error) {
+      return this.render(form, SimCognitoPageForm.messageIn(error));
+    }
+
+    return this.markup.redirect(simCognitoConfirmPath, {
+      ...form.parameters,
+      username: form.username,
+    });
+  }
+
+  /**
+   * The page a browser is answered with, with a message where a sign-up has
+   * already been refused once.
+   */
+  private render(form: SimCognitoPageForm, message?: string): Response {
+    const { parameters } = form;
+    const attributes = SimCognitoSignUpPage.attributeNames(form.pool)
+      .map((name) => this.markup.field(name, name))
+      .join("");
+
+    const body =
+      (message === undefined ? "" : this.markup.message(message)) +
+      this.markup.form(
+        simCognitoSignUpPath,
+        this.markup.hidden(parameters) +
+          this.markup.field("username", "Username") +
+          this.markup.field("password", "Password", "password") +
+          attributes +
+          this.markup.submit("signUp", "Sign up"),
+      ) +
+      this.markup.link(simCognitoAuthorizePath, parameters, "Back to sign in");
+
+    return this.markup.page("Sign up", body);
+  }
+}

--- a/src/service/cognito/serve/sim-cognito-authorize-refusals.iso.test.ts
+++ b/src/service/cognito/serve/sim-cognito-authorize-refusals.iso.test.ts
@@ -217,7 +217,7 @@ describe("Refusals from a sim Cognito authorize endpoint", () => {
     );
   });
 
-  it("refuses a local sign-in that carries no credentials", async () => {
+  it("answers a local sign-in that carries no credentials with the form", async () => {
     // Given a pool with a domain.
     const setUp = await simCognitoHosted();
     const { identity_provider: unused, ...withoutProvider } =
@@ -226,13 +226,9 @@ describe("Refusals from a sim Cognito authorize endpoint", () => {
     // When an authorize request names no identity provider and no user.
     const response = await authorize(setUp, withoutProvider);
 
-    // Then it says which two fields a sign-in by one of the pool's own users
-    // needs.
-    assertIdentical(response.status, 400);
-    assertStringIncludes(
-      await refusedBody(response),
-      "needs a username and a password",
-    );
+    // Then the browser is asked who is signing in, rather than being refused.
+    assertIdentical(response.status, 200);
+    assertStringIncludes(await response.text(), 'name="password"');
     assertIdentical(unused, "Google");
   });
 
@@ -291,17 +287,19 @@ describe("Refusals from a sim Cognito authorize endpoint", () => {
     const http = new SimAwsHttp({ simAws: setUp.simAws });
 
     // When a path the domain does not serve is requested, and the authorize
-    // endpoint is posted to.
+    // endpoint is asked for with a method it does not take.
     const missing = await http.fetch(hostedUrl("/oauth2/userInfo", {}));
-    const posted = await http.fetch(
+    const deleted = await http.fetch(
       hostedUrl("/oauth2/authorize", authorizeParameters(setUp)),
-      { method: "POST" },
+      { method: "DELETE" },
     );
 
-    // Then each is refused, saying what the domain does serve.
+    // Then each is refused, saying what the domain does serve. The authorize
+    // endpoint takes the post of the sign-in form it serves as well as the
+    // get an application sends the browser on.
     assertIdentical(missing.status, 404);
     assertStringIncludes(await refusedBody(missing), "/oauth2/authorize");
-    assertIdentical(posted.status, 405);
-    assertIdentical(posted.headers.get("allow"), "GET");
+    assertIdentical(deleted.status, 405);
+    assertIdentical(deleted.headers.get("allow"), "GET, POST");
   });
 });

--- a/src/service/cognito/serve/sim-cognito-domain-endpoints.ts
+++ b/src/service/cognito/serve/sim-cognito-domain-endpoints.ts
@@ -1,38 +1,38 @@
-import type { SimAwsServiceRequest } from "../../../serve/controller/sim-service-controller.js";
-import type { SimCognitoIdentityProvider } from "../sim-cognito-identity-provider.js";
-import type { SimCognitoUserPool } from "../user-pool/sim-cognito-user-pool.js";
+import { SimCognitoManagedLogin } from "./page/sim-cognito-managed-login.js";
+import type { SimCognitoPageParameters } from "./page/sim-cognito-page-markup.js";
+import { simCognitoAuthorizePath } from "./page/sim-cognito-page-paths.js";
+import { SimCognitoPageRequest } from "./page/sim-cognito-page-request.js";
+import type { SimCognitoDomainRequest } from "./sim-cognito-domain-request.js";
 import { SimCognitoOAuthResponse } from "./sim-cognito-oauth-response.js";
 import { SimCognitoTokenRequest } from "./sim-cognito-token-request.js";
 
 /**
- * The paths a hosted domain serves.
+ * The remaining paths a hosted domain serves.
  */
-const authorizePath = "/oauth2/authorize";
 const tokenPath = "/oauth2/token";
 const logoutPath = "/logout";
 
 /**
- * One request to a hosted domain, and what answers it.
+ * The methods a page takes, which is both of them, because a form is fetched
+ * and then posted back.
  */
-export interface SimCognitoDomainRequest {
-  readonly pool: SimCognitoUserPool;
+const pageMethods = "GET, POST";
 
-  /** The simulated Cognito scope the pool belongs to. */
-  readonly cognito: SimCognitoIdentityProvider;
-  readonly serviceRequest: SimAwsServiceRequest;
-  readonly url: URL;
-}
+export type { SimCognitoDomainRequest } from "./sim-cognito-domain-request.js";
 
 /**
- * The three endpoints a pool's hosted domain serves.
+ * The endpoints and pages a pool's hosted domain serves.
  *
- * Each takes one HTTP method and one only, as real Cognito's do, and turns
- * what the simulation answered into the redirect or the JSON body a browser or
- * an application's own server reads.
+ * The token and logout endpoints take one HTTP method each, as real Cognito's
+ * do. The authorize endpoint takes the post of the sign-in form it serves as
+ * well as the get an application sends the browser on, and so do the two pages
+ * reached from that form.
  */
 export class SimCognitoDomainEndpoints {
   private readonly response = new SimCognitoOAuthResponse();
   private readonly tokenRequest = new SimCognitoTokenRequest();
+  private readonly pageRequest = new SimCognitoPageRequest();
+  private readonly pages = new SimCognitoManagedLogin();
 
   /**
    * Answer a request that reached the domain's hostname.
@@ -40,7 +40,7 @@ export class SimCognitoDomainEndpoints {
   async handleRequest(request: SimCognitoDomainRequest): Promise<Response> {
     const { pathname } = request.url;
 
-    if (pathname === authorizePath) {
+    if (pathname === simCognitoAuthorizePath) {
       return await this.authorize(request);
     }
 
@@ -52,29 +52,56 @@ export class SimCognitoDomainEndpoints {
       return await this.logout(request);
     }
 
+    if (SimCognitoManagedLogin.servesPage(pathname)) {
+      return await this.answered(request, pageMethods, async () =>
+        this.pages.handlePage(request),
+      );
+    }
+
     return this.response.noSuchEndpoint(pathname);
   }
 
   /**
-   * Sign a user in through an identity provider and send the browser back to
-   * the application with a code.
+   * Sign a user in and send the browser back to the application with a code,
+   * or serve the form that asks who is signing in.
+   *
+   * A get carrying credentials and a post of the sign-in form are the same
+   * request to the simulation. Both name the user and its password, and the
+   * only difference is where those two were read from.
    */
   private async authorize(request: SimCognitoDomainRequest): Promise<Response> {
-    const parameters = Object.fromEntries(request.url.searchParams);
+    return await this.answered(request, pageMethods, async () => {
+      const parameters = this.pageRequest.values(
+        request.serviceRequest,
+        request.url,
+      );
 
-    return await this.answered(request, "GET", async () => {
       try {
         return this.response.redirect(
           await request.cognito.hostedAuthorize(request.pool, parameters),
         );
       } catch (error) {
-        return this.response.refusedRedirect(
-          error,
-          parameters["redirect_uri"],
-          parameters["state"],
-        );
+        return this.refused(request, parameters, error);
       }
     });
+  }
+
+  /**
+   * Answer a refused sign-in, on the form or at the application.
+   */
+  private refused(
+    request: SimCognitoDomainRequest,
+    parameters: SimCognitoPageParameters,
+    error: unknown,
+  ): Response {
+    return (
+      this.pages.refusedSignIn(request, parameters, error) ??
+      this.response.refusedRedirect(
+        error,
+        parameters["redirect_uri"],
+        parameters["state"],
+      )
+    );
   }
 
   /**
@@ -113,20 +140,17 @@ export class SimCognitoDomainEndpoints {
   }
 
   /**
-   * Answer a request that used the method its endpoint takes.
-   *
-   * Each endpoint takes one method and one only, as real Cognito's do, so what
-   * is left to say about any other is which one it was.
+   * Answer a request that used a method its endpoint takes.
    */
   private async answered(
     request: SimCognitoDomainRequest,
-    method: string,
+    allowed: string,
     answer: () => Promise<Response>,
   ): Promise<Response> {
     const requested = request.serviceRequest.request.method;
 
-    if (requested !== method) {
-      return this.response.notAllowed(requested, method);
+    if (!allowed.split(", ").includes(requested)) {
+      return this.response.notAllowed(requested, allowed);
     }
 
     return await answer();

--- a/src/service/cognito/serve/sim-cognito-domain-request.ts
+++ b/src/service/cognito/serve/sim-cognito-domain-request.ts
@@ -1,0 +1,15 @@
+import type { SimAwsServiceRequest } from "../../../serve/controller/sim-service-controller.js";
+import type { SimCognitoIdentityProvider } from "../sim-cognito-identity-provider.js";
+import type { SimCognitoUserPool } from "../user-pool/sim-cognito-user-pool.js";
+
+/**
+ * One request to a hosted domain, and what answers it.
+ */
+export interface SimCognitoDomainRequest {
+  readonly pool: SimCognitoUserPool;
+
+  /** The simulated Cognito scope the pool belongs to. */
+  readonly cognito: SimCognitoIdentityProvider;
+  readonly serviceRequest: SimAwsServiceRequest;
+  readonly url: URL;
+}

--- a/src/service/cognito/serve/sim-cognito-managed-login.iso.test.ts
+++ b/src/service/cognito/serve/sim-cognito-managed-login.iso.test.ts
@@ -1,0 +1,181 @@
+import { createHash } from "node:crypto";
+
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertStringNotIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  simCognitoCallbackUrl,
+  simCognitoHosted,
+  simCognitoLocalPassword,
+  simCognitoLocalUser,
+  simCognitoLocalUsername,
+} from "../../../../test/cognito/federation-fixture.js";
+import {
+  simCognitoAuthorizeParameters,
+  simCognitoGetPage,
+  simCognitoPostForm,
+  simCognitoRedirectedTo,
+} from "../../../../test/cognito/managed-login-fixture.js";
+
+describe("The pages a sim Cognito hosted domain serves", () => {
+  it("answers an authorize request with a sign-in form and its parameters", async () => {
+    // Given a pool with a hosted domain and a Google provider.
+    const setUp = await simCognitoHosted();
+
+    // When the browser is sent to the authorize endpoint naming no provider.
+    const response = await simCognitoGetPage(
+      setUp,
+      "/oauth2/authorize",
+      simCognitoAuthorizeParameters(setUp),
+    );
+
+    // Then it is answered with the form, carrying the parameters the request
+    // arrived on so that the post of it grants what the application asked for.
+    assertIdentical(response.status, 200);
+    assertIdentical(
+      response.headers.get("content-type"),
+      "text/html; charset=utf-8",
+    );
+
+    const page = await response.text();
+    assertStringIncludes(page, 'name="username"');
+    assertStringIncludes(page, 'name="password"');
+    assertStringIncludes(page, `value="${setUp.clientId}"`);
+    assertStringIncludes(page, 'name="state" value="csrf-token"');
+
+    // And the pool's identity provider is a link to the same endpoint, so both
+    // ways in are reachable from the one page.
+    assertStringIncludes(page, "identity_provider=Google");
+  });
+
+  it("signs a user in when the form is posted", async () => {
+    // Given a pool holding a confirmed user of its own.
+    const setUp = await simCognitoHosted();
+    await simCognitoLocalUser(setUp);
+
+    // When the sign-in form is posted.
+    const response = await simCognitoPostForm(setUp, "/oauth2/authorize", {
+      ...simCognitoAuthorizeParameters(setUp),
+      username: simCognitoLocalUsername,
+      password: simCognitoLocalPassword,
+    });
+
+    // Then the browser goes to the app client's callback URL with a code and
+    // the state the grant started with.
+    assertIdentical(response.status, 302);
+
+    const callback = simCognitoRedirectedTo(response);
+    assertIdentical(callback.origin + callback.pathname, simCognitoCallbackUrl);
+    assertIdentical(callback.searchParams.get("state"), "csrf-token");
+    assertNonNullable(callback.searchParams.get("code"));
+  });
+
+  it("honours a PKCE challenge the form carried", async () => {
+    // Given a pool holding a confirmed user of its own, and an authorize
+    // request that bound its grant to a verifier.
+    const setUp = await simCognitoHosted();
+    await simCognitoLocalUser(setUp);
+    const challenge = {
+      code_challenge: createHash("sha256")
+        .update("a-code-verifier-of-a-perfectly-reasonable-length")
+        .digest("base64url"),
+      code_challenge_method: "S256",
+    };
+
+    // When the form served for it is posted back.
+    const served = await simCognitoGetPage(setUp, "/oauth2/authorize", {
+      ...simCognitoAuthorizeParameters(setUp),
+      ...challenge,
+    });
+    assertStringIncludes(await served.text(), challenge.code_challenge);
+
+    const response = await simCognitoPostForm(setUp, "/oauth2/authorize", {
+      ...simCognitoAuthorizeParameters(setUp),
+      ...challenge,
+      username: simCognitoLocalUsername,
+      password: simCognitoLocalPassword,
+    });
+
+    // Then the code it hands back only exchanges with the matching verifier.
+    const code = simCognitoRedirectedTo(response).searchParams.get("code");
+    assertNonNullable(code);
+
+    const withoutVerifier = await simCognitoPostForm(setUp, "/oauth2/token", {
+      grant_type: "authorization_code",
+      client_id: setUp.clientId,
+      code,
+      redirect_uri: simCognitoCallbackUrl,
+    });
+
+    assertIdentical(withoutVerifier.status, 400);
+  });
+
+  it("shows a wrong password on the form and issues no code", async () => {
+    // Given a pool holding a confirmed user of its own.
+    const setUp = await simCognitoHosted();
+    await simCognitoLocalUser(setUp);
+
+    // When the form is posted with the wrong password.
+    const response = await simCognitoPostForm(setUp, "/oauth2/authorize", {
+      ...simCognitoAuthorizeParameters(setUp),
+      username: simCognitoLocalUsername,
+      password: "not-the-password",
+    });
+
+    // Then the form comes back saying so, with nowhere for a browser to take
+    // a code from.
+    assertIdentical(response.status, 200);
+    assertStringIncludes(
+      await response.text(),
+      "Incorrect username or password",
+    );
+    assertIdentical(response.headers.get("location"), null);
+  });
+
+  it("serves all three pages through a custom domain", async () => {
+    // Given a pool served on a custom domain.
+    const host = "auth.example.com";
+    const setUp = await simCognitoHosted({ domain: host });
+    const parameters = simCognitoAuthorizeParameters(setUp);
+
+    // When each page is fetched at that hostname.
+    const pages = await Promise.all(
+      ["/oauth2/authorize", "/signup", "/confirm"].map(async (path) =>
+        simCognitoGetPage(setUp, path, parameters, host),
+      ),
+    );
+
+    // Then each answers, so a browser in a local development server completes
+    // the whole flow on the hostname the application already uses.
+    for (const page of pages) {
+      assertIdentical(page.status, 200);
+      assertIdentical(
+        page.headers.get("content-type"),
+        "text/html; charset=utf-8",
+      );
+    }
+  });
+
+  it("writes a state back into the form without letting it change the page", async () => {
+    // Given a pool with a hosted domain, and an application whose state holds
+    // the characters that would otherwise end an attribute.
+    const setUp = await simCognitoHosted();
+
+    // When the sign-in form is served for it.
+    const response = await simCognitoGetPage(setUp, "/oauth2/authorize", {
+      ...simCognitoAuthorizeParameters(setUp),
+      state: '"><script>alert(1)</script>',
+    });
+
+    // Then the state is written back escaped, so the form still holds it and
+    // the page still means what it meant.
+    const page = await response.text();
+    assertStringIncludes(page, "&quot;&gt;&lt;script&gt;");
+    assertStringNotIncludes(page, "<script>");
+  });
+});

--- a/src/service/cognito/serve/sim-cognito-managed-login.iso.test.ts
+++ b/src/service/cognito/serve/sim-cognito-managed-login.iso.test.ts
@@ -178,4 +178,21 @@ describe("The pages a sim Cognito hosted domain serves", () => {
     assertStringIncludes(page, "&quot;&gt;&lt;script&gt;");
     assertStringNotIncludes(page, "<script>");
   });
+
+  it("offers only the providers the app client supports", async () => {
+    // Given an app client offering the pool's own users and nothing else,
+    // over a pool that has a Google provider.
+    const setUp = await simCognitoHosted({ identityProviders: ["COGNITO"] });
+
+    // When the sign-in form is served.
+    const response = await simCognitoGetPage(
+      setUp,
+      "/oauth2/authorize",
+      simCognitoAuthorizeParameters(setUp),
+    );
+
+    // Then Google is left off it, because the request that link would make is
+    // one the authorize endpoint refuses.
+    assertStringNotIncludes(await response.text(), "identity_provider=Google");
+  });
 });

--- a/src/service/cognito/serve/sim-cognito-page-sign-up.iso.test.ts
+++ b/src/service/cognito/serve/sim-cognito-page-sign-up.iso.test.ts
@@ -148,4 +148,21 @@ describe("Signing up through the pages a sim Cognito domain serves", () => {
       "someone@example.com",
     );
   });
+
+  it("asks who is confirming when the page was reached from sign-in", async () => {
+    // Given a browser that followed the confirmation link on the sign-in page,
+    // which names nobody.
+    const setUp = await simCognitoHosted();
+
+    // When that page is fetched.
+    const response = await simCognitoGetPage(
+      setUp,
+      "/confirm",
+      simCognitoAuthorizeParameters(setUp),
+    );
+
+    // Then it asks for the username as well as the code, rather than holding
+    // an empty one nothing can fill in.
+    assertStringIncludes(await response.text(), 'id="username"');
+  });
 });

--- a/src/service/cognito/serve/sim-cognito-page-sign-up.iso.test.ts
+++ b/src/service/cognito/serve/sim-cognito-page-sign-up.iso.test.ts
@@ -1,0 +1,151 @@
+import {
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  simCognitoHosted,
+  simCognitoLocalPassword,
+  simCognitoLocalUsername,
+} from "../../../../test/cognito/federation-fixture.js";
+import {
+  simCognitoAuthorizeParameters,
+  simCognitoGetPage,
+  simCognitoPostForm,
+  simCognitoRedirectedTo,
+} from "../../../../test/cognito/managed-login-fixture.js";
+
+describe("Signing up through the pages a sim Cognito domain serves", () => {
+  it("signs up, confirms and then signs in, all through the pages", async () => {
+    // Given a pool with a hosted domain and nobody in it.
+    const setUp = await simCognitoHosted();
+    const parameters = simCognitoAuthorizeParameters(setUp);
+    const pool = setUp.cognito.userPool(setUp.userPoolId);
+
+    // When the sign-up form is fetched and posted.
+    const form = await simCognitoGetPage(setUp, "/signup", parameters);
+    assertIdentical(form.status, 200);
+    assertStringIncludes(await form.text(), 'name="username"');
+
+    const signedUp = await simCognitoPostForm(setUp, "/signup", {
+      ...parameters,
+      username: simCognitoLocalUsername,
+      password: simCognitoLocalPassword,
+    });
+
+    // Then the user is in the pool unconfirmed, and the browser is sent on to
+    // the page that asks for the code.
+    assertIdentical(signedUp.status, 303);
+    assertIdentical(simCognitoRedirectedTo(signedUp).pathname, "/confirm");
+    assertTrue(
+      pool.requireUser(simCognitoLocalUsername as never).status.isUnconfirmed,
+    );
+
+    // And posting the code the pool issued confirms the sign-up.
+    const code = pool.confirmationCode(simCognitoLocalUsername);
+    assertNonNullable(code);
+
+    const confirmed = await simCognitoPostForm(setUp, "/confirm", {
+      ...parameters,
+      username: simCognitoLocalUsername,
+      code,
+    });
+
+    assertIdentical(confirmed.status, 303);
+    assertIdentical(
+      simCognitoRedirectedTo(confirmed).pathname,
+      "/oauth2/authorize",
+    );
+
+    // And that same user then signs in and reaches the callback with a code.
+    const signedIn = await simCognitoPostForm(setUp, "/oauth2/authorize", {
+      ...parameters,
+      username: simCognitoLocalUsername,
+      password: simCognitoLocalPassword,
+    });
+
+    assertIdentical(signedIn.status, 302);
+    assertNonNullable(
+      simCognitoRedirectedTo(signedIn).searchParams.get("code"),
+    );
+  });
+
+  it("asks the pool for another confirmation code", async () => {
+    // Given a user that signed itself up through the page.
+    const setUp = await simCognitoHosted();
+    const parameters = simCognitoAuthorizeParameters(setUp);
+    const pool = setUp.cognito.userPool(setUp.userPoolId);
+
+    await simCognitoPostForm(setUp, "/signup", {
+      ...parameters,
+      username: simCognitoLocalUsername,
+      password: simCognitoLocalPassword,
+    });
+    const first = pool.confirmationCode(simCognitoLocalUsername);
+
+    // When the resend button is pressed.
+    const response = await simCognitoPostForm(setUp, "/confirm", {
+      ...parameters,
+      username: simCognitoLocalUsername,
+      resend: "resend",
+    });
+
+    // Then the pool has issued a fresh code, and the page asks for it.
+    assertIdentical(response.status, 200);
+    assertStringIncludes(await response.text(), "Another code has been sent");
+
+    const second = pool.confirmationCode(simCognitoLocalUsername);
+    assertNonNullable(second);
+    assertFalse(second === first);
+  });
+
+  it("shows a refused sign-up on the form", async () => {
+    // Given a pool with the default password policy.
+    const setUp = await simCognitoHosted();
+
+    // When the sign-up form is posted with a password the policy turns down.
+    const response = await simCognitoPostForm(setUp, "/signup", {
+      ...simCognitoAuthorizeParameters(setUp),
+      username: simCognitoLocalUsername,
+      password: "short",
+    });
+
+    // Then the form comes back saying why, and the pool gained no user.
+    assertIdentical(response.status, 200);
+    assertStringIncludes(await response.text(), "Password did not conform");
+    assertIdentical(setUp.cognito.userPool(setUp.userPoolId).userCount, 0);
+  });
+
+  it("asks a sign-up for the attributes the pool requires", async () => {
+    // Given a pool that requires an email address of every user.
+    const setUp = await simCognitoHosted({
+      schema: [{ Name: "email", Required: true, AttributeDataType: "String" }],
+    });
+    const parameters = simCognitoAuthorizeParameters(setUp);
+
+    // When the sign-up form is fetched and posted with one.
+    const form = await simCognitoGetPage(setUp, "/signup", parameters);
+    assertStringIncludes(await form.text(), 'name="email"');
+
+    const signedUp = await simCognitoPostForm(setUp, "/signup", {
+      ...parameters,
+      username: simCognitoLocalUsername,
+      password: simCognitoLocalPassword,
+      email: "someone@example.com",
+    });
+
+    // Then the user carries it.
+    assertIdentical(signedUp.status, 303);
+    assertIdentical(
+      setUp.cognito
+        .userPool(setUp.userPoolId)
+        .requireUser(simCognitoLocalUsername as never)
+        .attributeValues.get("email"),
+      "someone@example.com",
+    );
+  });
+});

--- a/test/cognito/federation-fixture.ts
+++ b/test/cognito/federation-fixture.ts
@@ -11,6 +11,7 @@
 
 import type {
   AttributeType,
+  SchemaAttributeType,
   UserPoolMfaType,
 } from "@aws-sdk/client-cognito-identity-provider";
 import {
@@ -72,6 +73,9 @@ export interface SimCognitoHostedSetUpOptions {
 
   /** What the pool asks of a second factor, `OFF` by default. */
   readonly mfaConfiguration?: UserPoolMfaType;
+
+  /** The pool's `Schema`, which is the standard attributes by default. */
+  readonly schema?: SchemaAttributeType[];
 }
 
 /**
@@ -117,6 +121,7 @@ export async function simCognitoHosted(
       ...(options.mfaConfiguration !== undefined && {
         MfaConfiguration: options.mfaConfiguration,
       }),
+      ...(options.schema !== undefined && { Schema: options.schema }),
     }),
   );
   assertNonNullable(pool.UserPool?.Id);

--- a/test/cognito/managed-login-fixture.ts
+++ b/test/cognito/managed-login-fixture.ts
@@ -1,0 +1,91 @@
+/**
+ * The requests the managed login page tests share: the authorize parameters an
+ * application starts a grant with, and the fetching and posting of a form.
+ *
+ * It lives under `test/` for the same reasons as `test/cognito/cfn-deploy.ts`:
+ * a test file cannot export helpers alongside its own `describe` calls, and
+ * `test/**` is type-checked with everything else and excluded from the
+ * published build.
+ */
+
+import { assertNonNullable } from "@kensio/smartass";
+
+import { SimAwsHttp } from "../../src/serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../src/serve/http/url/sim-aws-local-url.js";
+import {
+  simCognitoCallbackUrl,
+  simCognitoDomainHost,
+  type SimCognitoHostedSetUp,
+} from "./federation-fixture.js";
+
+/**
+ * The parameters an application starts an authorization code grant with.
+ */
+export function simCognitoAuthorizeParameters(
+  setUp: SimCognitoHostedSetUp,
+): Record<string, string> {
+  return {
+    response_type: "code",
+    client_id: setUp.clientId,
+    redirect_uri: simCognitoCallbackUrl,
+    scope: "openid email",
+    state: "csrf-token",
+  };
+}
+
+/**
+ * A URL on a hosted domain, as the localhost server rewrites it.
+ */
+export function simCognitoPageUrl(
+  path: string,
+  parameters: Record<string, string> = {},
+  host: string = simCognitoDomainHost,
+): string {
+  const query = new URLSearchParams(parameters).toString();
+
+  return new SimAwsLocalUrl({
+    input: `https://${host}${path}${query === "" ? "" : `?${query}`}`,
+  }).toString();
+}
+
+/**
+ * Fetch a page the way a browser follows a link to one.
+ */
+export async function simCognitoGetPage(
+  setUp: SimCognitoHostedSetUp,
+  path: string,
+  parameters: Record<string, string> = {},
+  host?: string,
+): Promise<Response> {
+  return await new SimAwsHttp({ simAws: setUp.simAws }).fetch(
+    simCognitoPageUrl(path, parameters, host),
+  );
+}
+
+/**
+ * Post a form the way a browser posts one.
+ */
+export async function simCognitoPostForm(
+  setUp: SimCognitoHostedSetUp,
+  path: string,
+  fields: Record<string, string>,
+): Promise<Response> {
+  return await new SimAwsHttp({ simAws: setUp.simAws }).fetch(
+    simCognitoPageUrl(path),
+    {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams(fields).toString(),
+    },
+  );
+}
+
+/**
+ * Where a redirect sent the browser.
+ */
+export function simCognitoRedirectedTo(response: Response): URL {
+  const location = response.headers.get("location");
+  assertNonNullable(location);
+
+  return new URL(location, `https://${simCognitoDomainHost}`);
+}


### PR DESCRIPTION
A pool's hosted domain answers a browser with three forms. The authorize endpoint serves the sign-in form where the request names no identity provider, and posting it back signs the user in and redirects to the app client's callback URL with the code and the state, honouring PKCE where the request carried a challenge. `/signup` asks for a username, a password and the attributes the pool needs, and does what `SignUp` does. `/confirm` takes the code the pool issued, does what `ConfirmSignUp` does, and its second button is `ResendConfirmationCode`. Each form carries the authorize parameters through as hidden inputs, so the sign-in at the end of a sign-up reaches the callback the application asked for. A refusal a person can act on comes back on the form they posted, and one the application caused is answered as any other authorize refusal is. There is no styling and no script: matching real managed login would be work no test could tell apart from a bare form.

This is the second half of #652, stacked on https://github.com/KensioSoftware/yulin/pull/655, which is the in-process sign-in these pages post to. Retarget it to main once that one lands.

Resolves #652
