### PR TITLE
docs: plain prose in six more READMEs

### DIFF
--- a/docs/services/rekognition/README.md
+++ b/docs/services/rekognition/README.md
@@ -1,8 +1,8 @@
 # Simulated Rekognition
 
-Simulated Rekognition answers detection calls from results declared against images, so a test can
-say which image fails moderation or holds a cat without any image analysis happening. No recognition
-of any kind is performed on the bytes.
+Simulated Rekognition answers detection calls from results declared against images. A test can say
+which image fails moderation or holds a cat, with no image analysis happening. The bytes are never
+looked at.
 
 Rekognition-specific types are imported from the `@kensio/yulin/rekognition` subpath.
 
@@ -52,7 +52,7 @@ console.log(detected.ModerationLabels.map((label) => label.Name));
 console.log(detected.ModerationModelVersion); // "7.0"
 ```
 
-The image is read through simulated S3 as the caller making the detection, so the caller needs
+The image is read through simulated S3 as the caller making the detection. The caller needs
 `s3:GetObject` for it as well as `rekognition:DetectModerationLabels`.
 
 Image bytes go in as `Image.Bytes` instead, which needs no Bucket:
@@ -68,8 +68,8 @@ const detected = await simAws
 ## Detecting labels in an image
 
 `DetectLabels` answers with the objects, scenes and concepts an image is declared to hold. Each
-label carries the parents, aliases, categories and instances it was declared with, and nothing else:
-a label is reported as written.
+label carries the parents, aliases, categories and instances it was declared with, and no more. A
+label is reported as written.
 
 ```typescript sim-rekognition-detect-labels
 /**
@@ -131,14 +131,14 @@ console.log(detected.LabelModelVersion); // "3.0"
 Labels come back in descending order of confidence, which is the order real Rekognition reports them
 in. A declared instance with no confidence of its own takes its label's.
 
-An image no rule matches gets the built-in default result: the one `Mobile Phone` label from the
-example response in the AWS `DetectLabels` documentation, with the parent, alias, category and
-bounding box AWS documents it with. That is a real Rekognition response, but which labels an
+An image no rule matches gets the built-in default result. That is the one `Mobile Phone` label from
+the example response in the AWS `DetectLabels` documentation, with the parent, alias, category and
+bounding box AWS documents it with. It is a real Rekognition response, though which labels an
 unconfigured image gets is a simulator convention rather than what AWS would return for it.
 
-Nothing is filled in from a label name. Declaring `Cat` with no parents reports `Cat` with no
-parents, and declaring a `Pizza` nobody has heard of reports `Pizza`, because Yulin ships no general
-label ontology to check a name against or to expand one from.
+A label name fills in nothing of its own. Declaring `Cat` with no parents reports `Cat` with no
+parents, and declaring a `Pizza` nobody has heard of reports `Pizza`. Yulin ships no general label
+ontology to check a name against or to expand one from.
 
 ## Detecting faces in an image
 
@@ -201,7 +201,7 @@ console.log(detected.FaceDetails[0]?.Smile);
 ```
 
 Faces come back in the order they were declared. An attribute with no confidence of its own takes
-the face's, so a face detected at 99.4 is reported as smiling at 99.4. A face declared with no
+the face's, and a face detected at 99.4 is reported as smiling at 99.4. A face declared with no
 confidence at all is detected at the built-in one.
 
 An image with nobody in it is `{ faces: [] }`. Two built-in results cover the counting a test
@@ -219,19 +219,19 @@ faces.onName("incoming/landscape.png", simRekognitionNoFaces);
 faces.onName("incoming/crowd.png", simRekognitionSeveralFaces);
 ```
 
-An image no rule matches gets the built-in default result: the one face from the example response in
-the AWS `DetectFaces` documentation, with the attributes and all thirty landmarks AWS documents it
-with. That is a real Rekognition response, but which face an unconfigured image gets is a simulator
-convention rather than what AWS would return for it.
+An image no rule matches gets the built-in default result. That is the one face from the example
+response in the AWS `DetectFaces` documentation, with the attributes and all thirty landmarks AWS
+documents it with. It is a real Rekognition response, though which face an unconfigured image gets is
+a simulator convention rather than what AWS would return for it.
 
 ## Choosing the facial attributes
 
 `BoundingBox`, `Confidence`, `Pose`, `Quality` and `Landmarks` come back whatever a request asked
-for, which is the default subset AWS always returns. `ALL` adds the rest, and naming one attribute
-adds that one, so `["FACE_OCCLUDED"]` is the default subset with face occlusion on top.
+for, being the default subset AWS always returns. `ALL` adds the rest, and naming one attribute adds
+that one, so `["FACE_OCCLUDED"]` is the default subset with face occlusion on top.
 `["ALL", "DEFAULT"]` is the union the two describe together.
 
-Landmarks follow AWS too: five come back unless `ALL` was asked for, and every declared landmark
+Landmarks follow AWS too. Five come back unless `ALL` was asked for, and every declared landmark
 when it was.
 
 ```typescript sim-rekognition-face-attributes
@@ -292,23 +292,23 @@ console.log(
 // [ "eyeLeft", "eyeRight", "chinBottom" ]
 ```
 
-An attribute nothing was declared for is left out of the response rather than carried as an empty
-one, so a face declared with a bounding box and nothing else comes back as a bounding box and a
-confidence however many attributes the request asked for.
+An undeclared attribute is left out of the response, in place of coming back empty. A face declared
+with a bounding box and no more comes back as a bounding box and a confidence, however many
+attributes the request asked for.
 
 A declaration is checked where it is written. A bounding box or a landmark outside the image is
-refused, as is an age range that ends before it begins, an emotion Rekognition does not report, and
-a pair of landmarks that runs the wrong way across the face, such as an `eyeLeft` to the right of
-`eyeRight`. So is a result declaring more than a hundred faces, which is the most real Rekognition
-detects in one image. Landmarks are not required to sit inside the bounding box, because a real
-Rekognition face box routinely excludes the chin.
+refused, as is an age range that ends before it begins, an emotion Rekognition never reports, and a
+pair of landmarks that runs the wrong way across the face, such as an `eyeLeft` to the right of
+`eyeRight`. So is a result declaring more than a hundred faces, the most real Rekognition detects in
+one image. A landmark may sit outside the bounding box, because a real Rekognition face box routinely
+excludes the chin.
 
 ## Declaring results
 
 Results are declared per operation. `moderation()` holds the rules `DetectModerationLabels` answers
 from, `labels()` holds the rules `DetectLabels` answers from, and `faces()` holds the rules
-`DetectFaces` answers from. All three take the same three kinds of rule: an exact S3 object name, an
-exact content hash, or anything at all.
+`DetectFaces` answers from. All three take the same three kinds of rule, being an exact S3
+object name, an exact content hash, or anything at all.
 
 ```typescript sim-rekognition-moderation-rules
 /**
@@ -339,12 +339,12 @@ moderation.onHash(simRekognitionImageHash(fixture), {
 });
 ```
 
-A hash rule wins, then a name rule, then the default. Matching is exact, with no pattern syntax, so
-which rule applies never depends on how specific a pattern looks.
+A hash rule wins, then a name rule, then the default. Matching is exact, with no pattern syntax.
+Which rule applies never depends on how specific a pattern looks.
 
-A name is the `Name` in the request, which is the S3 object key. It is matched on its own rather
-than with the Bucket, so a rule for a key applies to that key in whichever Bucket the request names.
-An image passed as `Image.Bytes` has no name at all, so it consults hash rules and then the default.
+A name is the `Name` in the request, the S3 object key. It is matched on its own, with the Bucket
+left out, so a rule for a key applies to that key in whichever Bucket the request names. An image
+passed as `Image.Bytes` has no name at all, and consults hash rules and then the default.
 
 The hash is the sha256 digest of the image bytes as they were received, as lowercase hex.
 `simRekognitionImageHash` produces it from a fixture. Re-encoding an image between uploading it and
@@ -357,8 +357,8 @@ detection label at `97.53010559082031`.
 ## Sample images
 
 Simulated Rekognition ships with five images whose hashes are already declared. A test uploads one
-through its own code and gets a known answer without registering anything, which is what makes an
-application that generates its own object keys testable: nothing in the test has to know the key.
+through its own code and gets a known answer without registering anything. That is what makes an
+application generating its own object keys testable, since the test never has to know the key.
 
 | Image                                              | Format | Detected as                                       |
 | -------------------------------------------------- | ------ | ------------------------------------------------- |
@@ -405,12 +405,12 @@ console.log(detected.ModerationLabels.map((label) => label.Name));
 ```
 
 Each image is declared for the one operation it is named for. The moderation images say nothing
-about faces and the face images say nothing about moderation, so those detections answer from their
-own rules as they would for any other image.
+about faces and the face images say nothing about moderation. Those detections answer from their own
+rules as they would for any other image.
 
-The built-in rules are ordinary hash rules registered when the service is made, so declaring a rule
-for the same image replaces it. Note the precedence: a hash rule beats a name rule, so a sample
-image is overridden by hash rather than by the key it was uploaded under.
+The built-in rules are ordinary hash rules registered when the service is made, and declaring a rule
+for the same image replaces it. The precedence matters here. A hash rule beats a name rule, so a
+sample image is overridden by hash, and never by the key it was uploaded under.
 
 ```typescript
 const sample = simRekognitionSampleImages.flaggedByModeration();
@@ -421,13 +421,13 @@ simAws
   .onHash(simRekognitionImageHash(sample), { labels: [] });
 ```
 
-The images are real 16 by 16 PNG and JPEG files, 1,909 bytes in total, so the format check reads
-their magic bytes as it does for any other image. What they are pictures of decides nothing, since
-no image is looked at.
+The images are real 16 by 16 PNG and JPEG files, 1,909 bytes in total. The format check reads their
+magic bytes as it does for any other image. What they are pictures of decides nothing, since no
+image is looked at.
 
 ## Moderation labels come back with their parents
 
-A declared label expands to its whole chain in the version 7.0 moderation taxonomy, so handler code
+A declared label expands to its whole chain in the version 7.0 moderation taxonomy. Handler code
 that filters on the top-level category sees what it would see on AWS. Each label carries the
 `ParentName` and `TaxonomyLevel` real Rekognition reports.
 
@@ -465,21 +465,20 @@ console.log(detected.ModerationLabels);
 // ]
 ```
 
-Every label in one chain shares that chain's confidence, and `MinConfidence` filters whole chains,
-so a surviving label never names a parent that is not in the response. A label two chains share is
-reported once, at the higher of the two confidences.
+Every label in one chain shares that chain's confidence, and `MinConfidence` filters whole chains. A
+surviving label always names a parent the response carries. A label two chains share is reported
+once, at the higher of the two confidences.
 
-A label the taxonomy does not have is refused where it is declared rather than at detection time.
-That includes a version 6.1 name that version 7.0 dropped, such as `Drug Products`, which became
-`Products` under `Drugs & Tobacco`. Some names survived the move with a different place in the
-taxonomy: `Drinking` is still a label, but it now sits under `Alcohol Use` rather than directly
-under `Alcohol`.
+A label outside the taxonomy is refused where it is declared, ahead of detection time. That includes
+a version 6.1 name that version 7.0 dropped, such as `Drug Products`, which became `Products` under
+`Drugs & Tobacco`. Some names survived the move with a different place in the taxonomy. `Drinking`
+is still a label, and it now sits under `Alcohol Use` rather than directly under `Alcohol`.
 
 ## Filtering by confidence
 
-`MinConfidence` compares inclusively and defaults to what the operation defaults to on AWS: 50 for
-`DetectModerationLabels` and 55 for `DetectLabels`. An explicit `0` asks for every label rather than
-being read as unset.
+`MinConfidence` compares inclusively and defaults to what the operation defaults to on AWS, being 50
+for `DetectModerationLabels` and 55 for `DetectLabels`. An explicit `0` asks for every label, and is
+never read as unset.
 
 ```typescript sim-rekognition-min-confidence
 /**
@@ -517,12 +516,12 @@ console.log(strict.ModerationLabels.map((label) => label.Name));
 // [ "Violence", "Weapons" ]
 ```
 
-Confidences are float32 values, as real Rekognition confidences are, so a declared `99.4` comes back
-as `99.4000015258789`.
+Confidences are float32 values, as real Rekognition confidences are, and a declared `99.4` comes
+back as `99.4000015258789`.
 
 `DetectLabels` also takes a `MaxLabels`, which applies after the confidence filter and keeps the most
-confident labels of the ones that survived it. An explicit `0` asks for no labels rather than being
-read as unset.
+confident labels of the ones that survived it. An explicit `0` asks for no labels, and is never read
+as unset.
 
 ```typescript sim-rekognition-max-labels
 /**
@@ -563,13 +562,13 @@ console.log(detected.Labels.map((label) => label.Name)); // [ "Cat", "Grass" ]
 
 ## Moderating an upload
 
-An upload can moderate itself: a Bucket notification invokes a function, and the function moderates
+An upload can moderate itself. A Bucket notification invokes a function, and the function moderates
 the object the event names. The function calls Rekognition in the Account and Region it runs in, so
 the rules a test registers on `simAws.rekognition()` are the ones it finds.
 
 This is the flow the sample images exist for. The object goes in under a key the application
-generated, and the sample image's own hash rule decides the result, so nothing in the test names the
-key.
+generated, and the sample image's own hash rule decides the result, leaving the test with no key to
+name.
 
 ```typescript sim-rekognition-upload-pipeline
 /**
@@ -713,23 +712,22 @@ await simAws.backgroundTasksComplete();
 ```
 
 A handler that writes a moderated copy back into the Bucket that triggered it will notify itself for
-ever, so filter the notification configuration by prefix or suffix as this one does.
+ever. Filter the notification configuration by prefix or suffix, as this one does.
 
 ## Permissions and errors
 
-Each detection is authorized as its own action against `*`: `rekognition:DetectModerationLabels`,
-`rekognition:DetectLabels` and `rekognition:DetectFaces`. Real Rekognition gives the detection
-operations no resource-level
-permissions, so a policy naming an ARN reaches nothing, here as on AWS. A denial throws
-`AccessDeniedException` with a 400 status, which is what real Rekognition answers with rather than
-the 403 several other services use.
+Each detection is authorized as its own action against `*`, one of
+`rekognition:DetectModerationLabels`, `rekognition:DetectLabels` and `rekognition:DetectFaces`. Real
+Rekognition gives the detection operations no resource-level permissions, and a policy naming an ARN
+reaches nothing, here as on AWS. A denial throws `AccessDeniedException` with a 400 status, which is
+what real Rekognition answers with, where several other services use 403.
 
-The caller is authorized for the detection before the image is read, so a caller without the
-Rekognition permission is told about that rather than about an S3 object.
+The caller is authorized for the detection before the image is read. A caller without the Rekognition
+permission is told about that, and never about an S3 object.
 
 Every S3 problem becomes `InvalidS3ObjectException`, as it does on real Rekognition, whether the
 Bucket is missing, the object is missing, or the caller may not read it. The underlying simulator
-error is kept as the error's `cause`, so a missing `s3:GetObject` grant is still diagnosable:
+error is kept as the error's `cause`, leaving a missing `s3:GetObject` grant diagnosable:
 
 ```typescript
 try {
@@ -740,8 +738,8 @@ try {
 }
 ```
 
-Bytes that are not a PNG or a JPEG are refused with `InvalidImageFormatException`. The format comes
-from the leading bytes of the image, so a test that stores a placeholder string in a Bucket and
+Bytes that are neither a PNG nor a JPEG are refused with `InvalidImageFormatException`. The format
+comes from the leading bytes of the image. A test that stores a placeholder string in a Bucket and
 moderates it gets that error.
 
 ## Accounts and Regions
@@ -786,45 +784,46 @@ Simulated Rekognition currently supports:
 
 ## Limitations
 
-- `DetectText`, `CompareFaces`, the face collection operations and the video operations are not
-  simulated. An intercepted client sending one of those Commands is refused by name.
+- `DetectText`, `CompareFaces`, the face collection operations and the video operations are left
+  out. An intercepted client sending one of those Commands is refused by name.
 - A face detection reports the emotions that were declared and no others. Real `DetectFaces` returns
-  all eight emotion types every time, the ones it did not see at a low confidence. Declare the
-  emotions the code under test reads.
-- `OrientationCorrection` is not carried on a `DetectFaces` response, because AWS documents its
-  value as always null.
-- A declared bounding box has to sit inside the image. Real Rekognition can report a box that does
-  not, for a face at the image edge that is only partly visible. The check is kept because it
+  all eight emotion types every time, with the ones it failed to see at a low confidence. Declare
+  the emotions the code under test reads.
+- `OrientationCorrection` is left off a `DetectFaces` response, because AWS documents its value as
+  always null.
+- A declared bounding box has to sit inside the image. Real Rekognition can report one that spills
+  over, for a face at the image edge that is only partly visible. The check is kept because it
   catches a box written in pixels.
 - Landmark pairs that run across the face, such as `eyeLeft` and `eyeRight`, have to be declared in
   the order Rekognition reports them in. A face rolled past upright is the one case where that
-  ordering does not hold on AWS, and it cannot be declared here.
+  ordering breaks down on AWS, and it cannot be declared here.
 - Yulin ships no general label ontology, because AWS's is thousands of entries with no published
   enumerable table.
 - A declared label's `Parents` appear on that label alone. Real `DetectLabels` also returns each
   ancestor as a label in its own right, which needs the ontology above. Declare the ancestors as
   labels too when the code under test reads them that way.
-- A declared label name is not checked against anything, for the same reason. Refusing a real AWS
-  label because a Yulin list was missing it would be failing closed against Yulin's own gaps.
-- `DetectLabels` `Settings` filters and `IMAGE_PROPERTIES` are refused rather than ignored. Applying
-  no filters would answer with labels the caller asked to have left out, and image quality and
-  dominant colours would have to be invented by a simulation that looks at no images.
+- A declared label name goes unchecked, for the same reason. Refusing a real AWS label because a
+  Yulin list was missing it would be failing closed against Yulin's own gaps.
+- `DetectLabels` `Settings` filters and `IMAGE_PROPERTIES` are refused outright. Applying no filters
+  would answer with labels the caller asked to have left out, and image quality and dominant colours
+  would have to be invented by a simulation that looks at no images.
 - A custom moderation adapter named with `ProjectVersion`, and a human review loop named with
-  `HumanLoopConfig`, are both refused rather than ignored. Answering from the built-in model would
-  make an adapter look applied here and be applied in production.
+  `HumanLoopConfig`, are both refused outright. Answering from the built-in model would make an
+  adapter look applied here and be applied in production.
 - `ContentTypes` is always empty. Real Rekognition puts `Animated` or `Illustrated` there for
   content it identifies as such, which needs an image to look at.
-- Nothing looks at the image beyond its first few bytes. A PNG of a kitten declared as `Violence`
+- The image is read no further than its first few bytes. A PNG of a kitten declared as `Violence`
   comes back as `Violence`, and an image no rule matches gets the built-in `Mobile Phone` result.
 - The sample images are 16 by 16 pictures of coloured shapes, small enough to ship in the package.
-  They are not photographs of the things they are named for, because nothing decodes them.
+  They are drawings rather than photographs of the things they are named for, since nothing decodes
+  them.
 - The format comes from the image bytes and never from a stored content type. Simulated S3 keeps a
-  `ContentType` given to `PutObject` as a metadata key, and has none at all when the uploader did
-  not set one, so trusting it would make the same bytes detectable or not depending on how they were
+  `ContentType` given to `PutObject` as a metadata key, and has none at all when the uploader left
+  it out. Trusting it would make the same bytes detectable or not depending on how they were
   uploaded.
 - A `Version` on an `Image.S3Object` is refused, because simulated S3 has no object versions and
   would have answered with the current one.
 - There are no CloudFormation resource types for Rekognition, and Rekognition is not served over
   `serveSimAws`.
 - The moderation taxonomy is the published version 7.0 label list. A label from version 6.1 is
-  refused, since real Rekognition no longer returns one.
+  refused, since real Rekognition stopped returning one.

--- a/docs/services/route53/README.md
+++ b/docs/services/route53/README.md
@@ -57,9 +57,9 @@ becomes `example.test.`.
 Hosted Zone creation uses background tasks to move the zone to `INSYNC`. If your test needs final
 state, call `await simAws.backgroundTasksComplete()` before continuing.
 
-Hosted Zone IDs are accepted in any real Route53 shape: a `Z` prefix followed by uppercase
-alphanumerics, up to 32 characters. That means a real Hosted Zone ID copied out of an AWS account,
-such as `Z2FDTNDATAQYW2`, can be used in your test setup. An ID with no matching Hosted Zone gives
+Hosted Zone IDs are accepted in any real Route53 shape, being a `Z` prefix followed by uppercase
+alphanumerics, up to 32 characters. A real Hosted Zone ID copied out of an AWS account, such as
+`Z2FDTNDATAQYW2`, can therefore be used in your test setup. An ID with no matching Hosted Zone gives
 `NoSuchHostedZone`, while a malformed one gives `InvalidInput`. Commands also accept the
 `/hostedzone/Z...` form as well as the bare ID.
 
@@ -69,10 +69,10 @@ such as `Z2FDTNDATAQYW2`, can be used in your test setup. An ID with no matching
 from you. When something else already decided the ID, register the Hosted Zone as part of your test
 setup instead.
 
-The usual reason is a CDK app that looks its zone up with `HostedZone.fromLookup` rather than
+The usual reason is a CDK app that looks its zone up with `HostedZone.fromLookup` instead of
 creating it. That bakes the real Hosted Zone ID into the synthesized template, and every
-`AWS::Route53::RecordSet` in the template names that ID. Registering the zone first means the
-template deploys as it is, with no rewriting.
+`AWS::Route53::RecordSet` in the template names that ID. Registering the zone first lets the
+template deploy as it is, with no rewriting.
 
 ```typescript sim-route53-register-hosted-zone
 /**
@@ -121,22 +121,23 @@ already existing rather than created.
 
 `registerHostedZone` takes the same optional `config` as `CreateHostedZoneCommand`, and accepts the
 `/hostedzone/Z...` form of the ID. An ID that another Hosted Zone already holds is refused with
-`HostedZoneAlreadyExists`, and one that is not a Route53 Hosted Zone ID with `InvalidInput`.
+`HostedZoneAlreadyExists`, and one that is no Route53 Hosted Zone ID at all with `InvalidInput`.
 
-### A zone a template names but does not create
+### A zone a template only names
 
 Registering the zone first is optional. An `AWS::Route53::RecordSet` naming a `HostedZoneId` that no
-Hosted Zone holds gets one registered under that ID as the record is created, so a template built
-with `HostedZone.fromLookup` deploys without being told separately about a zone it already describes.
+Hosted Zone holds gets one registered under that ID as the record is created. A template built with
+`HostedZone.fromLookup` therefore deploys without being told separately about a zone it already
+describes.
 
-The template does not carry the zone's name, only its ID, so the name is inferred from the records.
-The first record to name the zone names it, and a record above that name widens it. A stack holding
+The template carries the zone's ID and no name, so the name is inferred from the records. The first
+record to name the zone names it, and a record above that name widens it. A stack holding
 `example.test` and `www.example.test` ends up with a zone called `example.test`. A stack holding only
 `www.example.test` ends up with a zone called `www.example.test`.
 
 Register the zone yourself when a test depends on its name, such as one listing zones by name, or
-when its name is not a suffix of any record the stack holds. A registered zone keeps the name it was
-given rather than inferring one, so its records are stored under the name you chose.
+when its name is a suffix of no record the stack holds. A registered zone keeps the name it was
+given, and its records are stored under the name you chose.
 
 ## Creating records
 
@@ -331,23 +332,22 @@ The stored alias value is normalized without the trailing dot.
 
 Sim Route53 stores ten record types: `A`, `AAAA`, `CAA`, `CNAME`, `MX`, `NS`, `PTR`, `SOA`, `SRV` and
 `TXT`. All ten can be created through `ChangeResourceRecordSetsCommand`, read back through
-`ListResourceRecordSetsCommand`, and declared as an `AWS::Route53::RecordSet`, so a zone that models
-a real one — mail records, certificate pinning, a service record — deploys as it stands.
+`ListResourceRecordSetsCommand`, and declared as an `AWS::Route53::RecordSet`. A zone that models a
+real one (mail records, certificate pinning, a service record) deploys as it stands.
 
-A type outside that list is not stored. `ChangeResourceRecordSetsCommand` rejects it, because the
-call asked for a record the simulator cannot keep. A template declaring one is treated more gently:
-the `AWS::Route53::RecordSet` is skipped and the rest of the stack deploys. See
+A type outside that list is refused by `ChangeResourceRecordSetsCommand`, because the call asked for
+a record the simulator cannot keep. A template declaring one is treated more gently. The
+`AWS::Route53::RecordSet` is skipped and the rest of the stack deploys. See
 [unsupported record types in a template](#unsupported-record-types-in-a-template).
 
-Simulated DNS answers queries for six of them: `A`, `AAAA`, `CNAME`, `TXT`, `NS` and `SOA`. `MX`,
-`SRV`, `CAA` and `PTR` are stored for a test to assert the presence and value of, not for a resolver
-to act on, so a DNS query for one is answered as no data. See
-[What is answered](#what-is-answered).
+Simulated DNS answers queries for six of them, being `A`, `AAAA`, `CNAME`, `TXT`, `NS` and `SOA`.
+`MX`, `SRV`, `CAA` and `PTR` are stored for a test to assert the presence and value of, and a DNS
+query for one is answered as no data. See [What is answered](#what-is-answered).
 
-Values of those four are stored exactly as written, along with `TXT`. Nothing takes an `MX`
-preference number or an `SRV` priority apart, so what you assert on is the string your stack
-declared. Values of the other types are hostnames or addresses, and are normalized like DNS names so
-they compare consistently.
+Values of those four are stored exactly as written, along with `TXT`. An `MX` preference number and
+an `SRV` priority are kept whole, so what you assert on is the string your stack declared. Values of
+the other types are hostnames or addresses, and are normalized like DNS names so they compare
+consistently.
 
 ```typescript sim-route53-mail-records
 /**
@@ -548,14 +548,14 @@ Paginate with `MaxItems`. When the listing is truncated, `IsTruncated` is `true`
 back as `StartRecordName` and `StartRecordType`. Marker names are normalised, so `www.example.test`
 and `WWW.EXAMPLE.TEST.` select the same starting point.
 
-Alias records are returned with an `AliasTarget` rather than `ResourceRecords`. The simulator stores
-an alias target as a record value plus an alias flag, so `AliasTarget.DNSName` is returned.
-`AliasTarget.HostedZoneId` is not part of the stored record and is not returned.
+Alias records are returned with an `AliasTarget` in place of `ResourceRecords`. The simulator stores
+an alias target as a record value plus an alias flag, and `AliasTarget.DNSName` is returned.
+`AliasTarget.HostedZoneId` is outside the stored record, and is left out.
 
 ## Inspecting hosted zones in a browser
 
-A served simulated AWS environment reports its Route53 state at `dns.sim-aws.localhost`, so you can
-see which hosted zones and records exist without writing code to read them back.
+A served simulated AWS environment reports its Route53 state at `dns.sim-aws.localhost`. You can see
+which hosted zones and records exist without writing code to read them back.
 
 ```typescript sim-route53-zone-summary
 /**
@@ -593,13 +593,13 @@ Hosted zones from every simulated Account appear, not just the default one, beca
 resolution is environment-wide even though the Route53 service object is Account-scoped.
 
 `dns.sim-aws.localhost` is where the summary is served, not a name it answers for. It is a built-in
-Yulin hostname, so it stays reachable whatever records your test creates, and it is unrelated to any
+Yulin hostname. It stays reachable whatever records your test creates, and it stands apart from any
 hosted zone you might name `dns`.
 
 ## Querying simulated records with dig
 
 A served simulated environment answers real DNS queries over UDP, on the same port number the HTTP
-server took on TCP. UDP and TCP port namespaces are separate, so one number covers both.
+server took on TCP. UDP and TCP port namespaces are separate, and one number covers both.
 
 ```typescript sim-route53-dns
 /**
@@ -664,8 +664,7 @@ The CNAME is followed and an address record is synthesised for the simulated S3 
 the address the local HTTP server listens on. A name that resolves to a simulated service therefore
 answers with somewhere you can actually make a request.
 
-Any DNS client works. Node's own resolver needs no extra dependency, which makes it convenient in
-tests:
+Any DNS client works. Node's own resolver needs no extra dependency, which suits a test:
 
 ```typescript sim-route53-dns-resolver
 /**
@@ -727,41 +726,41 @@ try {
 }
 ```
 
-A short timeout with a single try keeps a test failing quickly rather than
-hanging, should the record not be there.
+A short timeout with a single try keeps a test failing quickly, where a
+missing record would otherwise leave it hanging.
 
 ### Ports
 
-DNS binds the same port number as HTTP, but that is a convenience rather than a guarantee: if the
-number is already held on UDP by something else, DNS binds an ephemeral port instead. Read
-`srv.dnsPort` rather than assuming it matches `srv.port`.
+DNS binds the same port number as HTTP, as a convenience and not a guarantee. Where the number is
+already held on UDP by something else, DNS binds an ephemeral port instead. Read `srv.dnsPort`, and
+leave `srv.port` out of it.
 
-Nothing binds port 53, which would need root. To resolve simulated names system-wide without naming a
-port, point your resolver at the simulator yourself. On macOS, a file such as `/etc/resolver/test`
+Port 53 is left alone, since binding it would need root. To resolve simulated names system-wide
+without naming a port, point your resolver at the simulator yourself. On macOS, a file such as `/etc/resolver/test`
 containing `nameserver 127.0.0.1` and `port <dnsPort>` makes the whole `.test` TLD resolve through
 it. That is a change to your machine, so Yulin does not make it for you. With that in place, the HTTP
-server answers for those names too: see [Local hostname resolution](#local-hostname-resolution).
+server answers for those names too. See [Local hostname resolution](#local-hostname-resolution).
 
 ### What is answered
 
-- Six of the ten record types sim Route53 stores: `A`, `AAAA`, `CNAME`, `TXT`, `NS` and `SOA`. A
-  query for a stored type outside that list — `MX`, `SRV`, `CAA` or `PTR` — is answered as no data,
-  the same as a query type the simulator does not recognise at all. Those records exist to be
-  asserted on rather than resolved; what a browser reaching a simulated site needs is an address or
-  a CNAME. See [Record types](#record-types).
+- Six of the ten record types sim Route53 stores, being `A`, `AAAA`, `CNAME`, `TXT`, `NS` and
+  `SOA`. A query for a stored type outside that list (`MX`, `SRV`, `CAA` or `PTR`) is answered as no
+  data, the same as a query type the simulator has never heard of. Those records exist to be
+  asserted on. What a browser reaching a simulated site needs is an address or a CNAME. See
+  [Record types](#record-types).
 - CNAME chains are followed, so an `A` query on a name holding a CNAME returns the CNAME and the
   address it leads to together. Chains are bounded, and a cycle stops immediately.
 - Alias records are resolved to the address of whatever they point at, answered under the name that
-  holds the alias, which is how Route53 answers an alias. The alias record itself never appears.
+  holds the alias, as Route53 answers an alias. The alias record itself never appears.
 - A name in a zone holding no record of the queried type gives `NOERROR` with no answers, and a name
-  the zone does not hold gives `NXDOMAIN`. Both carry the zone `SOA` in the authority section, so a
-  resolver knows how long it may cache the negative answer. If the zone holds no `SOA` of its own,
-  one is synthesised.
-- A name held by no hosted zone is `REFUSED` rather than `NXDOMAIN`: the simulator answers only for
+  the zone lacks gives `NXDOMAIN`. Both carry the zone `SOA` in the authority section, so a resolver
+  knows how long it may cache the negative answer. Where the zone holds no `SOA` of its own, one is
+  synthesised.
+- A name held by no hosted zone is `REFUSED`, and never `NXDOMAIN`. The simulator answers only for
   the zones it holds, and cannot claim a name exists nowhere.
 - Zones from every simulated Account are answered, because DNS resolution is environment-wide.
 
-Not modelled: EDNS0, the `ANY` query type, DNS over TCP, more than one question per query, recursion,
+Left out are EDNS0, the `ANY` query type, DNS over TCP, more than one question per query, recursion,
 and DNSSEC. Answers are always authoritative.
 
 ## Local hostname resolution
@@ -779,9 +778,9 @@ The local server resolves the logical hostname `www.example.test` through sim Ro
 request to the simulated target named by the record.
 
 The suffix is optional. It exists so a client can reach the local server without the hostname
-resolving on the public internet, so it is only needed while nothing is resolving the name to the
-simulator. Once a resolver is pointed at the served DNS server, as under [Ports](#ports) above, the
-name resolves on its own and the request can be made under the hostname your application really
+resolving on the public internet, and it is only needed while the name resolves to the simulator
+nowhere else. Once a resolver is pointed at the served DNS server, as under [Ports](#ports) above,
+the name resolves on its own and the request can be made under the hostname your application really
 uses:
 
 ```text
@@ -789,17 +788,17 @@ http://www.example.test:<port>/
 ```
 
 Both forms reach the same simulated target. The suffix-free form is what makes an exact apex `Host`
-possible, so a CloudFront Function redirecting `example.test` to `www.example.test` can be exercised
-in a browser.
+possible. A CloudFront Function redirecting `example.test` to `www.example.test` can then be
+exercised in a browser.
 
 This is most useful with CloudFront aliases. You can create a CloudFront distribution, create a
 Route53 record pointing at the distribution hostname, then fetch through your application hostname.
 
 The hostname you fetch has to be one of the Distribution's alternate domain names, the same as it
-would be in real CloudFront, which refuses a `Host` it does not serve. So the record name goes in the
-Distribution's `Aliases` as well as in the Route53 record. Real CloudFront also wants an ACM
-certificate covering those names, described under
-[Viewer certificates](../cloudfront/README.md#viewer-certificates); it is left out here because this
+would be in real CloudFront, which refuses a `Host` outside the ones it serves. So the record name
+goes in the Distribution's `Aliases` as well as in the Route53 record. Real CloudFront also wants an
+ACM certificate covering those names, described under
+[Viewer certificates](../cloudfront/README.md#viewer-certificates). It is left out here because this
 request is served over plain HTTP on localhost.
 
 ```typescript sim-route53-cloudfront-localhost
@@ -948,7 +947,7 @@ the server to adapt it to the selected local port.
 ### What a name can resolve to
 
 A record chain ends when it reaches a hostname a simulated service owns. Those are recognised by
-their shape, so the value to point a record at is whatever the service reported:
+their shape, and the value to point a record at is whatever the service reported:
 
 | Hostname                                 | What it reaches                               |
 | ---------------------------------------- | --------------------------------------------- |
@@ -961,12 +960,12 @@ their shape, so the value to point a record at is whatever the service reported:
 | `cognito-idp.<region>`                   | the [Cognito](../cognito/) user pool endpoint |
 
 The hostnames the AWS SDK talks to are written without their `.amazonaws.com` or `.on.aws` tail,
-which is the same rewriting Yulin applies to an SDK endpoint. A load balancer's name keeps its whole
-domain, because nothing rewrites it: `DNSName` is what a record points at and what a client asks for.
+the same rewriting Yulin applies to an SDK endpoint. A load balancer's name keeps its whole domain,
+since it goes unrewritten. `DNSName` is what a record points at and what a client asks for.
 
-A name pointing at a load balancer resolves to it, so a request to that name reaches the load
-balancer's listeners and rules, and a `host-header` condition on a rule sees the name the request was
-made to rather than the load balancer's own:
+A name pointing at a load balancer resolves to it. A request to that name reaches the load balancer's
+listeners and rules, and a `host-header` condition on a rule sees the name the request was made to,
+in place of the load balancer's own:
 
 ```typescript sim-route53-elbv2-alias
 /**
@@ -1058,13 +1057,13 @@ try {
 ```
 
 A request served under the suffix reaches the listener on port 80, since the port such a request
-carries is the local server's rather than one a client chose. See
+carries is the local server's and never one a client chose. See
 [Simulated Elastic Load Balancing](../elbv2/) for what happens once the request is there.
 
 ## DNSSEC
 
 A Hosted Zone can be signed. Signing needs a key-signing key, and a key-signing key needs a KMS
-customer managed key: an enabled `ECC_NIST_P256` `SIGN_VERIFY` key, which is the only kind real
+customer managed key. That is an enabled `ECC_NIST_P256` `SIGN_VERIFY` key, the only kind real
 Route53 accepts.
 
 ```typescript sim-route53-dnssec
@@ -1124,28 +1123,28 @@ console.log(dnssec.Status?.ServeSignature); // "SIGNING"
 console.log(dnssec.KeySigningKeys?.[0]?.DSRecord);
 ```
 
-Nothing about the key-signing key is invented. Its `PublicKey` is the KMS key's own public key in
-the base64 form RFC 4034 defines, its `KeyTag` is computed by the RFC 4034 Appendix B algorithm, and
-its `DigestValue` is the SHA-256 delegation signer digest over the zone name and the DNSKEY. So a
-test can assert on the DS record it would hand to a registrar, and two zones on two keys get two
-different ones.
+Every part of the key-signing key is computed from the KMS key. Its `PublicKey` is that key's own
+public key in the base64 form RFC 4034 defines, its `KeyTag` comes from the RFC 4034 Appendix B
+algorithm, and its `DigestValue` is the SHA-256 delegation signer digest over the zone name and the
+DNSKEY. A test can assert on the DS record it would hand to a registrar, and two zones on two keys
+get two different ones.
 
-Adding a key-signing key does not start signing, and stopping signing leaves the keys in place, the
-same as on AWS. `ActivateKeySigningKey` and `DeactivateKeySigningKey` move a key between `ACTIVE`
-and `INACTIVE`; `DeleteKeySigningKey` refuses a key that is still active. `EnableHostedZoneDNSSEC`
-refuses a zone with no active key to sign with, and `DisableHostedZoneDNSSEC` refuses a zone that is
-not signed.
+Adding a key-signing key leaves signing off, and stopping signing leaves the keys in place, the same
+as on AWS. `ActivateKeySigningKey` and `DeactivateKeySigningKey` move a key between `ACTIVE` and
+`INACTIVE`. `DeleteKeySigningKey` refuses a key that is still active. `EnableHostedZoneDNSSEC`
+refuses a zone with no active key to sign with, and `DisableHostedZoneDNSSEC` refuses an unsigned
+zone.
 
-A KMS key that is symmetric, disabled, or not there at all is refused when the key-signing key is
-created, so a stack naming the wrong key fails here rather than on the deployment. A signed zone
-cannot be deleted either, for the reason real Route53 gives: the DS record at the parent would be
-left pointing at a zone that had gone.
+A KMS key that is symmetric, disabled, or absent altogether is refused when the key-signing key is
+created. A stack naming the wrong key fails here, ahead of the deployment. A signed zone cannot
+be deleted either, for the reason real Route53 gives. The DS record at the parent would be left
+pointing at a zone that had gone.
 
-The key's policy is not checked. Real Route53 needs the key to allow `kms:DescribeKey`,
+The key's policy goes unchecked. Real Route53 needs the key to allow `kms:DescribeKey`,
 `kms:GetPublicKey` and `kms:Sign` to the `dnssec-route53.amazonaws.com` service principal, and
 `kms:CreateGrant` conditioned on `kms:GrantIsForAWSResource`, which is what CDK's `KeySigningKey`
 construct adds for you. A key created here without those statements takes a key-signing key anyway,
-so a template that would fail on AWS for that reason deploys here.
+and a template that would fail on AWS for that reason deploys here.
 
 ### DNSSEC from CloudFormation
 
@@ -1214,9 +1213,9 @@ console.log(dnssec.Status?.ServeSignature); // "SIGNING"
 console.log(dnssec.KeySigningKeys?.[0]?.Status); // "ACTIVE"
 ```
 
-`Ref` on an `AWS::Route53::KeySigningKey` returns `<HostedZoneId>|<Name>`, which is what CDK reads
-as `keySigningKeyId`. `Ref` on an `AWS::Route53::DNSSEC` returns the hosted zone ID. Neither type
-has any `Fn::GetAtt` attributes, so one is refused rather than answered.
+`Ref` on an `AWS::Route53::KeySigningKey` returns `<HostedZoneId>|<Name>`, which CDK reads as
+`keySigningKeyId`. `Ref` on an `AWS::Route53::DNSSEC` returns the hosted zone ID. Neither type has
+any `Fn::GetAtt` attributes, and a `Fn::GetAtt` on one is refused.
 
 Tearing the stack down stops signing and takes the key-signing key with it, deactivating it first,
 because an active key cannot be deleted.
@@ -1316,13 +1315,13 @@ await simAws.backgroundTasksComplete();
 ```
 
 Record sets can use either `HostedZoneId` or `HostedZoneName`. `HostedZoneId` is usually the
-clearest option in templates because it can reference the zone resource directly.
+clearest option in templates, since it can reference the zone resource directly.
 
 ### Unsupported record types in a template
 
-A real DNS stack usually holds a few records that have nothing to do with what is being tested. When
-one of them declares a [record type](#record-types) sim Route53 does not store, the RecordSet is
-skipped and the rest of the stack deploys, the same way an unsupported resource type is. The skipped
+A real DNS stack usually holds a few records beside the point of what is being tested. When one of
+them declares a [record type](#record-types) sim Route53 leaves unstored, the RecordSet is skipped
+and the rest of the stack deploys, the same way an unsupported resource type is. The skipped
 RecordSet is in `stack.skippedResources` with a `skippedReason` naming the record type.
 
 ```typescript sim-route53-skipped-record-type
@@ -1385,12 +1384,11 @@ console.log(stack.getResource("DelegationSigner")?.skippedReason);
 ```
 
 Only the record type is treated this way. A RecordSet that makes no sense as a RecordSet still fails
-the stack, so a `Name` that is not a string, a `Type` that is not a string, or a negative `TTL` is
-refused. An unmodelled record type is a gap in the simulation; a malformed RecordSet is a broken
-template.
+the stack. A non-string `Name`, a non-string `Type`, or a negative `TTL` is refused. An unmodelled
+record type is a gap in the simulation, where a malformed RecordSet is a broken template.
 
-Tearing the stack down works with the skipped RecordSet in it. Nothing was created for it, so the
-teardown steps over it rather than asking Route53 to remove a record it never stored.
+Tearing the stack down works with the skipped RecordSet in it. Nothing was created for it, and the
+teardown steps over it without asking Route53 to remove a record it never stored.
 
 ## CDK integration
 
@@ -1445,7 +1443,7 @@ This lets local integration tests use the same CDK infrastructure shape as produ
 the test process local.
 
 A CDK app whose Hosted Zone comes from `HostedZone.fromLookup` names a real Hosted Zone ID
-throughout its template rather than creating the zone. The template deploys as it is: the zone is
+throughout its template, in place of creating the zone. The template deploys as it is. The zone is
 registered under that ID as the first RecordSet naming it is created, with its name inferred from the
 record names. Register it yourself with
 [Registering a Hosted Zone with a chosen ID](#registering-a-hosted-zone-with-a-chosen-id) when a test
@@ -1503,8 +1501,8 @@ await scopedRoute53.createHostedZone(
 );
 ```
 
-Each `SimAws` instance has its own isolated state, so you can create a fresh instance per test or
-share one across related local setup.
+Each `SimAws` instance has its own isolated state. Create a fresh instance per test, or share one
+across related local setup.
 
 ## Standalone SimRoute53
 
@@ -1531,7 +1529,7 @@ const hostedZoneCreation = await route53.createHostedZone(
 console.log(hostedZoneCreation.HostedZone?.Id);
 ```
 
-A standalone `SimRoute53` instance has its own isolated state and is not connected to a wider
+A standalone `SimRoute53` instance has its own isolated state, standing apart from any wider
 `SimAws` environment. Use `SimAws` when Route53 needs to resolve names to other simulated services.
 
 ## Available functionality
@@ -1561,7 +1559,7 @@ Sim Route53 currently supports:
 - The `AWS::Route53::KeySigningKey` and `AWS::Route53::DNSSEC` CloudFormation resources
 - CDK-created Route53 Hosted Zones and records in synthesized templates
 
-The simulator focuses on useful behaviour for tests and local development rather than full Route53
+The simulator focuses on useful behaviour for tests and local development, ahead of full Route53
 feature parity. Unsupported Route53 options may be ignored or may throw errors depending on whether
 the simulator needs them to model the requested behaviour.
 
@@ -1569,27 +1567,27 @@ the simulator needs them to model the requested behaviour.
 
 Where sim Route53 knowingly behaves differently from AWS:
 
-- **A RecordSet naming a Hosted Zone that does not exist creates one.** CloudFormation would refuse
-  with `NoSuchHostedZone`, because the ID names a zone in an account the simulation is not. Every
-  template built with `HostedZone.fromLookup` would then be undeployable here, so the zone is
+- **A RecordSet naming an absent Hosted Zone creates one.** CloudFormation would refuse with
+  `NoSuchHostedZone`, because the ID names a zone in an account the simulation is not. Every
+  template built with `HostedZone.fromLookup` would then be undeployable here. The zone is
   registered on demand instead. See
-  [A zone a template names but does not create](#a-zone-a-template-names-but-does-not-create).
-- **The name of such a zone is a guess.** Nothing in a synthesized template says what a looked-up
-  zone is called, so the name is inferred from the records that reference it and is only as specific
-  as they are. Register the zone yourself when a test depends on its name.
+  [A zone a template only names](#a-zone-a-template-only-names).
+- **The name of such a zone is a guess.** A synthesized template says nothing about what a
+  looked-up zone is called. The name is inferred from the records that reference it, and is only as
+  specific as they are. Register the zone yourself when a test depends on its name.
 - **A signed zone is signed on paper only.** No RRSIG records are produced, no DNSKEY records are
   added to the zone, and a query answered over UDP is unsigned whatever `GetDNSSEC` says. Signing is
-  observable through `GetDNSSEC`, which is where the key-signing keys and the DS record fields are.
-  Sim Route53 is not a general DNS server, and an RRSIG needs canonical RRset ordering and
-  wire-format signing that nothing here would read back.
-- **A key-signing key does not rotate, and a zone never reports trouble.** `ACTIVE` and `INACTIVE`
-  are the only key statuses, and `SIGNING` and `NOT_SIGNING` the only zone statuses. Real Route53
-  also has `DELETING`, `ACTION_NEEDED` and `INTERNAL_FAILURE`, which describe a key mid-operation or
-  a zone that needs attention, and nothing here produces either.
-- **A key-signing key's KMS key policy is not checked.** Real Route53 refuses a key that does not
-  admit the `dnssec-route53.amazonaws.com` service principal, and this does not, so a template
-  missing those statements deploys here and fails on AWS. Checking it would mean authorizing the
-  service principal against the key policy, which is its own piece of work.
+  observable through `GetDNSSEC`, which holds the key-signing keys and the DS record fields. Sim
+  Route53 is no general DNS server, and an RRSIG needs canonical RRset ordering and wire-format
+  signing that nothing here would read back.
+- **A key-signing key never rotates, and a zone never reports trouble.** `ACTIVE` and `INACTIVE` are
+  the only key statuses, and `SIGNING` and `NOT_SIGNING` the only zone statuses. Real Route53 also
+  has `DELETING`, `ACTION_NEEDED` and `INTERNAL_FAILURE`, which describe a key mid-operation or a
+  zone that needs attention, and neither is produced here.
+- **A key-signing key's KMS key policy goes unchecked.** Real Route53 refuses a key that leaves the
+  `dnssec-route53.amazonaws.com` service principal out, and this accepts one. A template missing
+  those statements deploys here and fails on AWS. Checking it would mean authorizing the service
+  principal against the key policy, which is its own piece of work.
 - **DNSSEC needs KMS wired to Route53.** A standalone `new SimRoute53()` has no simulated KMS to
   resolve a key ARN against, so `CreateKeySigningKey` refuses. Reach Route53 through `SimAws` when a
   test signs a zone.

--- a/docs/services/route53/README.md
+++ b/docs/services/route53/README.md
@@ -732,8 +732,8 @@ missing record would otherwise leave it hanging.
 ### Ports
 
 DNS binds the same port number as HTTP, as a convenience and not a guarantee. Where the number is
-already held on UDP by something else, DNS binds an ephemeral port instead. Read `srv.dnsPort`, and
-leave `srv.port` out of it.
+already held on UDP by something else, DNS binds an ephemeral port instead. Read `srv.dnsPort`, which
+may differ from `srv.port`.
 
 Port 53 is left alone, since binding it would need root. To resolve simulated names system-wide
 without naming a port, point your resolver at the simulator yourself. On macOS, a file such as `/etc/resolver/test`

--- a/docs/services/scheduler/README.md
+++ b/docs/services/scheduler/README.md
@@ -5,10 +5,10 @@ are held in memory and every operation is authorized by simulated IAM. Scheduler
 imported from the `@kensio/yulin/scheduler` subpath.
 
 Scheduler is a separate service from [EventBridge](../eventbridge/), not a corner of it. It has its
-own SDK client, its own ARN shape, and its own way of reaching a target: a schedule assumes an IAM
+own SDK client, its own ARN shape, and its own way of reaching a target. A schedule assumes an IAM
 execution role, where an EventBridge rule relies on a resource policy admitting a service principal.
-A project using Scheduler cannot be tested against simulated EventBridge rules instead, which is why
-this exists separately.
+A project using Scheduler cannot be tested against simulated EventBridge rules. That is why this
+exists separately.
 
 ## Creating a schedule
 
@@ -51,28 +51,29 @@ console.log(described.ScheduleExpression); // "cron(0 2 * * ? *)"
 
 `FlexibleTimeWindow` and `Target` are both required, as AWS requires them, and a target carries both
 an `Arn` and the `RoleArn` it is invoked as. A schedule ARN always names its group, even the
-`default` one, which is unlike an EventBridge rule ARN, where the bus appears only when it is not
-the default. An IAM policy naming a schedule needs the group in it or it matches nothing.
+`default` one. An EventBridge rule ARN differs, showing the bus only when it is not the default. An
+IAM policy naming a schedule needs the group in it, or it matches no schedule.
 
 ## Writing the schedule expression
 
 Three forms, and the same parser as an [EventBridge scheduled
 rule](../eventbridge/#rules-that-fire-on-a-schedule) with two differences:
 
-- `at(yyyy-mm-ddThh:mm:ss)` runs once, at that instant. There is no timezone on it: the timezone is a
-  separate setting on the schedule rather than part of the expression, so a trailing `Z` is refused.
+- `at(yyyy-mm-ddThh:mm:ss)` runs once, at that instant. The timezone is a separate setting on the
+  schedule, outside the expression, and a trailing `Z` is refused.
 - `rate(<value> <unit>)` runs from when the schedule was created. The unit is `minute`, `hour` or
-  `day`, and Scheduler does not insist it agrees with its value, so `rate(1 hours)` is an hour here
-  and a refusal on an EventBridge rule.
+  `day`, and Scheduler lets it disagree with its value. `rate(1 hours)` is an hour here and a
+  refusal on an EventBridge rule.
 - `cron(<six fields>)` names absolute instants in UTC. Minutes, hours, day-of-month, month,
   day-of-week and year, so every day at two in the morning is `cron(0 2 * * ? *)`. The day-of-month
-  and day-of-week fields cannot both say something: whichever is not deciding the day is written `?`.
+  and day-of-week fields cannot both say something. Whichever is not deciding the day is written
+  `?`.
 
 ## Firing a schedule
 
-A schedule fires on the simulation's clock, not the host's: advancing simulated time past a due
-instant invokes the target, and nothing happens otherwise. So a nightly job takes no time at all to
-test.
+A schedule fires on the simulation's clock. Advancing simulated time past a due
+instant invokes the target. Leave time alone and the target is never invoked. A nightly job takes no
+time at all to test.
 
 ```typescript sim-scheduler-firing
 /**
@@ -152,12 +153,12 @@ await simAws.clock().advanceBy({ hours: 3 });
 console.log(runs.length); // 3
 ```
 
-Firing is per due instant rather than per advance. Advancing an hour with a `rate(1 minute)` schedule
+Firing is per due instant. Advancing an hour with a `rate(1 minute)` schedule
 invokes the target sixty times, at sixty distinct simulated instants. `advanceBy(...)` returns once
-every one of those invocations has settled, so the next line can assert.
+every one of those invocations has settled, leaving the next line free to assert.
 
-A target with an `Input` receives that text; one without receives an empty JSON object, which is what
-AWS documents for a function with no payload. There is no envelope: a schedule has no event of its
+A target with an `Input` receives that text. One without receives an empty JSON object, which AWS
+documents for a function with no payload. There is no envelope, since a schedule has no event of its
 own to describe.
 
 ### The execution role
@@ -171,13 +172,12 @@ Two things therefore have to be right, and they are fixed in different places:
 
 - The role's **trust policy** has to let `scheduler.amazonaws.com` assume it. A role copied from an
   EventBridge rule trusts `events.amazonaws.com` and fails here.
-- A policy **on the role** has to allow the action on the target: `lambda:InvokeFunction`,
+- A policy **on the role** has to allow the action on the target, being `lambda:InvokeFunction`,
   `sqs:SendMessage`, `sns:Publish` or `ecs:RunTask`.
 
-When either is missing the target is not invoked and nothing is thrown, exactly as on AWS, where the
-failure goes to CloudWatch and nowhere the caller can see. `advanceBy(...)` still returns normally,
-so a test asserting on a failed invocation reads `deliveryFailures` rather than expecting the advance
-to reject:
+When either is missing the target goes uninvoked and no error is thrown, exactly as on AWS, where the
+failure goes to CloudWatch and nowhere the caller can see. `advanceBy(...)` still returns normally. A
+test asserting on a failed invocation reads `deliveryFailures`:
 
 ```typescript sim-scheduler-delivery-failures
 /**
@@ -232,22 +232,22 @@ console.log(failure?.message);
 ### One-time schedules and what happens after
 
 An `at(...)` schedule fires once and then stops. By default it stays in the Account afterwards, which
-surprises people who expected it to clean up: it keeps counting against the schedule quota and keeps
+surprises people who expected it to clean up. It keeps counting against the schedule quota and keeps
 turning up in listings. `ActionAfterCompletion: "DELETE"` is what removes it, and after that
 `GetSchedule` reports it gone.
 
-A schedule that is disabled when its only instant passes has not completed, because nothing was
-invoked, so it is still there afterwards whatever `ActionAfterCompletion` says.
+A schedule that is disabled when its only instant passes has not completed, since nothing was
+invoked. It is still there afterwards whatever `ActionAfterCompletion` says.
 
 `State: "DISABLED"` stops a recurring schedule firing while it is off, and an `UpdateSchedule`
-enabling it picks up from the next due instant rather than replaying what it missed. An update that
+enabling it picks up from the next due instant. What it missed is never replayed. An update that
 changes the expression reschedules from the new one.
 
 ## Running an ECS task on a schedule
 
-A target whose ARN names an ECS cluster runs a [simulated ECS](../ecs/) task instead of being
-invoked with a payload. That is the shape a nightly batch job usually has: a container that runs,
-does its work and stops, rather than a function or a queue.
+A target whose ARN names an ECS cluster runs a [simulated ECS](../ecs/) task, in place of being
+invoked with a payload. That is the shape a nightly batch job usually has. A container runs, does
+its work and stops.
 
 ```typescript sim-scheduler-ecs-target
 /**
@@ -352,16 +352,16 @@ const tasks = await ecs.listTasks(
 console.log(tasks.taskArns?.length); // 1
 ```
 
-The target ARN names the cluster, so an ARN naming anything else in ECS is refused when the schedule
+The target ARN names the cluster. An ARN naming anything else in ECS is refused when the schedule
 is created. `EcsParameters` names the task definition, as a family, a `family:revision` or a full
 ARN, and the same one `RunTask` would take.
 
-An ECS target's `Input` is the task's overrides rather than something the target receives, because a
-task has nowhere to receive a payload. A target with no `Input` runs the task with no overrides.
+An ECS target's `Input` is the task's overrides, since a task has nowhere to receive a payload. A
+target with no `Input` runs the task with no overrides.
 `EcsParameters` on a target whose ARN names anything else is refused, since it would do nothing.
 
-Which containers actually run is [simulated ECS](../ecs/)'s answer rather than the schedule's: a
-container with a binding runs its handler, and a container without one is recorded as not simulated.
+[Simulated ECS](../ecs/) decides which containers actually run. A container
+with a binding runs its handler, and a container without one is recorded as not simulated.
 A target naming a task definition with nothing bound therefore records a task that never started,
 and the schedule counts as invoked.
 
@@ -415,24 +415,22 @@ console.log(described.ScheduleExpression); // "rate(30 minutes)"
 console.log(described.Description); // undefined, and not by accident
 ```
 
-`UpdateSchedule` carries the whole of a schedule, so anything an earlier request set and this one
-leaves out is gone. That is real behaviour and a common surprise. The schedule has to exist:
-updating one that is not there is a `ResourceNotFoundException` rather than a create, which is
-another difference from EventBridge's `PutRule`.
+`UpdateSchedule` carries the whole of a schedule, and anything an earlier request set and this one
+leaves out is gone. That is real behaviour and a common surprise. The schedule has to exist.
+Updating one that is absent raises `ResourceNotFoundException`. EventBridge's `PutRule` creates it.
 
-`CreateSchedule` for a name that already exists is a `ConflictException` rather than a replacement,
-so a deployment running it twice fails the second time here as it does on AWS. `DeleteSchedule` for a
-schedule that is not there is a `ResourceNotFoundException`, where EventBridge's `DeleteRule`
-succeeds.
+`CreateSchedule` for a name that already exists raises `ConflictException`. A deployment running it
+twice fails the second time here as it does on AWS. `DeleteSchedule` for a schedule that is absent
+raises `ResourceNotFoundException`, where EventBridge's `DeleteRule` succeeds.
 
 ## Listing schedules
 
 `ListSchedules` reports the schedules of a group in creation order, narrowed by `NamePrefix` and
 `State` and paged by `MaxResults` and `NextToken`.
 
-A listing carries less than a describe, as it does on AWS: the target's ARN and nothing else about
-the target, and no expression at all. Code reading `ScheduleExpression` off a listing gets
-`undefined` from AWS, so it gets `undefined` here too.
+A listing carries less than a describe, as it does on AWS. It has the target's ARN and no more of the target,
+and no expression at all. Code reading `ScheduleExpression` off a listing gets
+`undefined` from AWS, and gets `undefined` here too.
 
 ## Permissions
 
@@ -497,17 +495,17 @@ const created = await simAws.scheduler().createSchedule(
 console.log(created.ScheduleArn !== undefined); // true
 ```
 
-`ListSchedules` names no schedule, so IAM evaluates it against `*` and only a policy whose `Resource`
+`ListSchedules` names no schedule. IAM evaluates it against `*`, and only a policy whose `Resource`
 is `*` allows it. A policy naming a schedule ARN allows no listing, here as on AWS.
 
 That is the caller's own permission to manage schedules, and it is a separate question from whether a
-schedule's execution role may invoke its target. The second is asked when the schedule fires, against
-the `RoleArn` on the target rather than against whoever created the schedule.
+schedule's execution role may invoke its target. The second is asked when the schedule fires,
+against the `RoleArn` on the target.
 
 ## Deploying from a CloudFormation template
 
-`AWS::Scheduler::Schedule` deploys through [simulated CloudFormation](../cloudformation/), so a stack
-that declares its schedules rather than calling the SDK can be exercised end to end. Everything the
+`AWS::Scheduler::Schedule` deploys through [simulated CloudFormation](../cloudformation/). A stack
+that declares its schedules can be exercised end to end, with no SDK calls of its own. Everything the
 Resource carries lines up with `CreateSchedule`, and a target ARN or execution role resolved by
 `Fn::GetAtt` from the same template works as it would in a real deployment.
 
@@ -603,12 +601,12 @@ console.log(simAws.scheduler().deliveryFailures.length); // 0
 ```
 
 `Ref` returns the schedule's **name** and `Fn::GetAtt ... Arn` its ARN, which carries the schedule
-group as it always does. A schedule the template does not name gets one generated from the stack name
-and the logical ID.
+group as it always does. A schedule the template leaves unnamed gets one generated from the stack
+name and the logical ID.
 
-A property this simulation does not model is refused at deploy time naming the Resource, rather than
-deploying a schedule that behaves differently from the one that was declared. Tearing the stack down
-removes the schedules it created, so nothing fires afterwards.
+A property this simulation leaves out is refused at deploy time, naming the Resource. Deploying a
+schedule that behaves differently from the one declared would be worse. Tearing the stack down
+removes the schedules it created, and no schedule fires afterwards.
 
 ## Available functionality
 
@@ -628,38 +626,39 @@ removes the schedules it created, so nothing fires afterwards.
 
 ## Limitations
 
-- A schedule only fires while a test advances the simulation's clock. Nothing runs on the host's
-  clock, so a simulation left alone in real time fires nothing however long it is left.
-- Firing is exact and exactly once. Real Scheduler invokes within a minute of the due time and does
-  not promise a single invocation.
-- An invocation is attempted once. There is no retry and no dead letter queue, so a target that
-  throws is a recorded failure rather than a redelivery. A failed invocation never rejects
-  `advanceBy(...)`; it is read from `deliveryFailures`.
-- Schedule groups are not a manageable resource. Every schedule is in `default`, and a `GroupName`
-  naming any other group is refused rather than quietly put in `default`, where its ARN would name a
-  group it is not in.
+- A schedule only fires while a test advances the simulation's clock. The host's clock drives none
+  of it, and a simulation left alone in real time never fires however long it is left.
+- Firing is exact and exactly once. Real Scheduler invokes within a minute of the due time, and its
+  promise is at-least-once.
+- An invocation is attempted once. There is no retry and no dead letter queue. A target that throws
+  is recorded as a failure, and never redelivered. A failed invocation never rejects
+  `advanceBy(...)`, and is read from `deliveryFailures`.
+- Schedule groups are absent as a manageable resource. Every schedule is in `default`, and a
+  `GroupName` naming any other group is refused. Putting it quietly in `default` would give it an
+  ARN naming the wrong group.
 - `FlexibleTimeWindow` with `Mode: "FLEXIBLE"` is refused. Real Scheduler invokes the target at an
   unpredictable moment inside the window, and firing at the exact due time instead would let a test
-  rely on timing AWS does not promise.
-- `ScheduleExpressionTimezone` other than `UTC` is refused rather than ignored, since running a
-  schedule in the wrong zone fires it at the wrong hour.
-- `StartDate` and `EndDate` are refused rather than ignored.
+  rely on timing AWS leaves unpromised.
+- `ScheduleExpressionTimezone` other than `UTC` is refused outright, since running a schedule in the
+  wrong zone fires it at the wrong hour.
+- `StartDate` and `EndDate` are refused outright.
 - Targets are Lambda, SQS, SNS and ECS. The universal target
   (`arn:aws:scheduler:::aws-sdk:<service>:<action>`) and every other target service are refused when
-  the schedule is created rather than when it first falls due.
+  the schedule is created, ahead of the first due instant.
 - A target `DeadLetterConfig`, `RetryPolicy`, `EventBridgeParameters`, `KinesisParameters`,
-  `SageMakerPipelineParameters` and `SqsParameters` are refused rather than dropped, as is
-  `EcsParameters` on a target whose ARN does not name an ECS cluster.
+  `SageMakerPipelineParameters` and `SqsParameters` are refused outright, as is `EcsParameters` on a
+  target whose ARN names something other than an ECS cluster.
 - An ECS target's `EcsParameters` takes `TaskDefinitionArn` and `TaskCount`, and takes and ignores
   `LaunchType`, `PlatformVersion`, `NetworkConfiguration` and `CapacityProviderStrategy`, since
   there is no placement and no network here for them to apply to. Anything else it can carry, such
-  as `Group`, `Tags` or `PropagateTags`, is refused rather than dropped.
-- An ECS target's `Input` is read as the task's overrides rather than as text the target receives,
-  so a `containerOverrides` list is how a schedule sets a container's environment. An `Input` that
-  is not a JSON object is refused on an ECS target, where every other target type takes any text.
+  as `Group`, `Tags` or `PropagateTags`, is refused outright.
+- An ECS target's `Input` is read as the task's overrides. A `containerOverrides` list is how a
+  schedule sets a container's environment. An `Input` that is anything but a JSON object is refused
+  on an ECS target, where every other target type takes any text.
 - A `TaskCount` above one runs that many simulated tasks, and a bound container handler runs once
   for each of them, in this process and one after another.
-- `KmsKeyArn` is refused, and `ClientToken` is accepted and ignored: nothing here retries, so there is
-  no request for it to make idempotent.
-- `AWS::Scheduler::ScheduleGroup` is not simulated as a CloudFormation resource type.
-  `AWS::Scheduler::Schedule` is: see [deploying from a template](#deploying-from-a-cloudformation-template).
+- `KmsKeyArn` is refused, and `ClientToken` is accepted and ignored. Nothing here retries, so it has
+  no request to make idempotent.
+- `AWS::Scheduler::ScheduleGroup` is absent as a CloudFormation resource type.
+  `AWS::Scheduler::Schedule` is there, under
+  [deploying from a template](#deploying-from-a-cloudformation-template).

--- a/docs/services/secretsmanager/README.md
+++ b/docs/services/secretsmanager/README.md
@@ -273,9 +273,9 @@ label. A version that has lost every label is on its way out of existence, and i
 
 ## Deletion and the recovery window
 
-`DeleteSecret` schedules deletion after a recovery window of 7 to 30 days, defaulting to 30, rather
-than deleting anything itself. During that window the secret is still there. It can be described and
-restored, it refuses to be read or written, and it still holds its name.
+`DeleteSecret` schedules deletion for later. The recovery window is 7 to 30 days, defaulting to 30.
+During that window the secret is still there. It can be described and restored, it refuses to be
+read or written, and it still holds its name.
 
 Holding the name is what a redeployed stack hits. Advancing the simulated clock past the window frees
 it.

--- a/docs/services/secretsmanager/README.md
+++ b/docs/services/secretsmanager/README.md
@@ -46,7 +46,7 @@ on read.
 ## Encryption and KMS permissions
 
 Every version is encrypted through simulated KMS when it is written and decrypted when
-`GetSecretValue` reads it. There is no flag for reading a secret without decrypting it: the read
+`GetSecretValue` reads it. There is no flag for reading a secret without decrypting it. The read
 either returns the plaintext or fails.
 
 A secret naming no `KmsKeyId` uses the `aws/secretsmanager` AWS managed key, which asks the caller
@@ -56,8 +56,8 @@ the account's principals to use it through Secrets Manager. A Lambda role grante
 
 Pass `KmsKeyId` to encrypt under a customer managed key instead, and the caller's own permissions on
 that key start to matter. Secrets Manager uses envelope encryption, asking KMS for a data key per
-version, so a write needs `kms:GenerateDataKey` and a read needs `kms:Decrypt`. A role granted the
-secret but not the key fails here rather than in a deployment.
+version. A write needs `kms:GenerateDataKey` and a read needs `kms:Decrypt`. A role granted the
+secret but not the key fails here, ahead of a deployment.
 
 ```typescript sim-secrets-manager-customer-key
 /**
@@ -132,19 +132,19 @@ try {
 ```
 
 Each version is bound to its own secret ARN and version id as the KMS encryption context, as real
-Secrets Manager binds them. A `KmsKeyId` naming a key that does not exist, is disabled, or is pending
-deletion fails with `EncryptionFailure` when a value is written under it, and a version whose key has
-since become unusable fails with `DecryptionFailure` when it is read.
+Secrets Manager binds them. A `KmsKeyId` naming a key that is absent, disabled, or pending deletion
+fails with `EncryptionFailure` when a value is written under it, and a version whose key has since
+become unusable fails with `DecryptionFailure` when it is read.
 
 Changing `KmsKeyId` applies to versions written afterwards. The versions already written keep the key
-they were made with and stay readable, which is what real AWS does too.
+they were made with and stay readable, as they do on real AWS.
 
 ## Secret ARNs and IAM policies
 
-Real Secrets Manager appends a hyphen and six random characters to the secret name in its ARN, so a
-secret named `db-creds` gets an ARN ending `:secret:db-creds-AbCdEf`. Sim Secrets Manager does the
-same. A policy naming the bare ARN therefore matches nothing, and a policy has to end in `-??????` or
-a wildcard.
+Real Secrets Manager appends a hyphen and six random characters to the secret name in its ARN. A
+secret named `db-creds` gets an ARN ending `:secret:db-creds-AbCdEf`, and sim Secrets Manager does
+the same. A policy naming the bare ARN therefore matches nothing, and a policy has to end in
+`-??????` or a wildcard.
 
 ```typescript sim-secrets-manager-iam-policy
 /**
@@ -208,22 +208,23 @@ const read = await simAws
 console.log(read.SecretString); // "hunter2"
 ```
 
-`ListSecrets` is the exception: real Secrets Manager gives it no resource-level permissions, so a
+`ListSecrets` is the exception. Real Secrets Manager gives it no resource-level permissions, and a
 policy allowing it has to use a resource of `*`. A policy naming individual secret ARNs grants
 nothing, here as there.
 
 ## Naming a secret
 
-Every operation takes its target as a `SecretId`, and any of the three forms real Secrets Manager
-accepts will do: the friendly name, the full ARN including the suffix, or the partial ARN without it.
+Every operation takes its target as a `SecretId`, in any of the three forms real Secrets Manager
+accepts. Those are the friendly name, the full ARN including the suffix, and the partial ARN without
+it.
 
-An ARN naming another account or region resolves to nothing, rather than having its name read out and
-looked up locally. A foreign ARN cannot reach a secret that happens to share a name.
+An ARN naming another account or region resolves to no secret at all. Its name is never read out and
+looked up locally, and a foreign ARN cannot reach a secret that happens to share a name.
 
 ## Versions and staging labels
 
-Every write creates a version rather than replacing one. `AWSCURRENT` names the version a plain read
-returns, and writing a new current version demotes the previous one to `AWSPREVIOUS`.
+Every write creates a version, leaving the earlier ones in place. `AWSCURRENT` names the version a
+plain read returns, and writing a new current version demotes the previous one to `AWSPREVIOUS`.
 
 ```typescript sim-secrets-manager-staging-labels
 /**
@@ -264,17 +265,17 @@ console.log(previous.SecretString); // "old-key"
 ```
 
 A `ClientRequestToken` becomes the version id, as it does on real AWS. Repeating a write with the
-same token and the same value is ignored, which makes a retry safe. The same token with a different
+same token and the same value is ignored, so a retry is safe. The same token with a different
 value is refused, because a version's value never changes once written.
 
-`DescribeSecret` reports `VersionIdsToStages`, which lists only the versions still carrying a staging
-label. A version that has lost every label is on its way out of existence, so it is left out.
+`DescribeSecret` reports `VersionIdsToStages`. That lists only the versions still carrying a staging
+label. A version that has lost every label is on its way out of existence, and is left out.
 
 ## Deletion and the recovery window
 
-`DeleteSecret` does not delete. It schedules deletion after a recovery window of 7 to 30 days,
-defaulting to 30. During that window the secret is still there: it can be described and restored, it
-refuses to be read or written, and it still holds its name.
+`DeleteSecret` schedules deletion after a recovery window of 7 to 30 days, defaulting to 30, rather
+than deleting anything itself. During that window the secret is still there. It can be described and
+restored, it refuses to be read or written, and it still holds its name.
 
 Holding the name is what a redeployed stack hits. Advancing the simulated clock past the window frees
 it.
@@ -330,7 +331,7 @@ See [simulated time](../../time/ "Simulated time docs") for what else the clock 
 ## Scoping
 
 Secrets belong to an account and a region, as they do on real AWS. A secret name is unique within one
-account and region and nowhere wider, so the same name can be used in two regions for two different
+account and region and nowhere wider. The same name can be used in two regions for two different
 secrets.
 
 ```typescript sim-secrets-manager-scoping
@@ -434,21 +435,21 @@ console.log(credentials.username); // "app"
 console.log(credentials.password?.length); // 24
 ```
 
-Generated passwords are random, so a test reads the value back out of the simulation the way a
-deployed application does rather than predicting it.
+Generated passwords are random. A test reads the value back out of the simulation the way a deployed
+application does.
 
-`SecretStringTemplate` and `GenerateStringKey` go together: the generated password is added to the
+`SecretStringTemplate` and `GenerateStringKey` go together. The generated password is added to the
 template's JSON object under that key. Without them, the whole secret value is the generated
-password. That is what an empty `GenerateSecretString: {}` produces, which is the property CDK
+password. That is what an empty `GenerateSecretString: {}` produces, and it is the property CDK
 synthesises for a `secretsmanager.Secret` with no options.
 
-The other generation options behave as they do on real AWS: `PasswordLength` (32 by default),
+The other generation options behave as they do on real AWS, being `PasswordLength` (32 by default),
 `ExcludeCharacters`, `ExcludeUppercase`, `ExcludeLowercase`, `ExcludeNumbers`, `ExcludePunctuation`,
-`IncludeSpace`, and `RequireEachIncludedType`. The last is on unless turned off, so a generated
+`IncludeSpace`, and `RequireEachIncludedType`. The last is on unless turned off, and a generated
 password carries one of every character type it was not told to exclude.
 
 A secret with no `Name` is named after its logical ID. Real CloudFormation names it after the stack
-and appends its own random characters, so a template cannot rely on the exact generated name either
+and appends its own random characters. A template cannot rely on the exact generated name either
 way.
 
 ## Inside a simulated Lambda handler
@@ -459,8 +460,8 @@ has to be allowed to, by that role's policy, the same as on real AWS. See
 [simulated Lambda](../lambda/ "Simulated Lambda docs") for how function code and execution roles
 work.
 
-The same applies to `SimSdk` interception: intercepting `SecretsManagerClient` routes ordinary SDK
-code into the simulation with nothing touching the network. See
+The same applies to `SimSdk` interception. Intercepting `SecretsManagerClient` routes ordinary SDK
+code into the simulation, served in process. See
 [AWS SDK interception](../../sdk/ "Simulated AWS SDK docs").
 
 ## Available functionality
@@ -486,48 +487,47 @@ Sim Secrets Manager currently supports:
 Current documented limitations:
 
 - A `KmsKeyId` is checked when a version is written under it, not when it is set on its own. An
-  `UpdateSecret` changing only the key accepts a key that does not exist, and the next write of a
-  value fails.
-- A secret name ending in a hyphen and six alphanumeric characters is refused, which is stricter than
-  AWS. Real AWS only advises against such names, because they cannot be told apart from an ARN's
+  `UpdateSecret` changing only the key accepts a key that is absent, and the next write of a value
+  fails.
+- A secret name ending in a hyphen and six alphanumeric characters is refused. That is stricter than
+  AWS, which only advises against such names, because they cannot be told apart from an ARN's
   resource part when a partial ARN is resolved. This rules out ordinary-looking names such as
   `app-secret` and `prod-config`, since `secret` and `config` are six characters. Name them
   `app-credentials` or `prod-settings` instead.
-- `RotateSecret`, `CancelRotateSecret` and the rotation Lambda protocol are not simulated.
+- `RotateSecret`, `CancelRotateSecret` and the rotation Lambda protocol are left out.
   `DescribeSecret` always reports `RotationEnabled` as `false`.
 - `AWS::SecretsManager::Secret` supports `Name`, `Description`, `KmsKeyId`, `SecretString`,
   `GenerateSecretString` and `Tags`. `ReplicaRegions` is ignored. The other resource types
-  (`SecretTargetAttachment`, `RotationSchedule` and `ResourcePolicy`) are reported as unsupported and
-  skipped rather than deployed.
+  (`SecretTargetAttachment`, `RotationSchedule` and `ResourcePolicy`) are reported as unsupported
+  and skipped.
 - A template declaring neither `SecretString` nor `GenerateSecretString` is refused, which is
   stricter than real CloudFormation. Real CloudFormation creates an empty secret in that case, and a
-  secret with no version is not simulated.
-- `ExcludeCharacters` that removes every character of an included type is refused rather than
-  generating a password missing a type it was told to include.
-- `{{resolve:secretsmanager:...}}` dynamic references are not supported. That is a CloudFormation
-  engine feature rather than a Secrets Manager one; pass the ARN from `Ref` instead.
+  secret with no version is outside this simulation.
+- `ExcludeCharacters` that removes every character of an included type is refused. Generating a
+  password missing a type it was told to include would be worse.
+- `{{resolve:secretsmanager:...}}` dynamic references are absent. That is a CloudFormation engine
+  feature rather than a Secrets Manager one. Pass the ARN from `Ref` instead.
 - Resource policies (`PutResourcePolicy`, `GetResourcePolicy`, `DeleteResourcePolicy`,
-  `ValidateResourcePolicy`) are not simulated, so cross-account access to a secret cannot be granted.
-- Replica regions are not simulated. `AddReplicaRegions`, `ReplicateSecretToRegions` and
-  `RemoveRegionsFromReplication` do nothing, and `ReplicationStatus` is not reported.
-- `BatchGetSecretValue` is not supported, and neither is the Parameters and Secrets Lambda Extension
-  HTTP endpoint.
-- `ListSecrets` refuses `Filters`, `SortOrder` and `SortBy` rather than ignoring them, since quietly
-  returning an unfiltered or differently ordered list would be worse. Secrets are listed in creation
-  order, with `MaxResults` and `NextToken` paging over them. A `NextToken` this simulation did not
-  issue, including one whose offset is past the end of the list, is refused rather than answered with
-  an empty page.
+  `ValidateResourcePolicy`) are left out, and cross-account access to a secret cannot be granted.
+- Replica regions are left out. `AddReplicaRegions`, `ReplicateSecretToRegions` and
+  `RemoveRegionsFromReplication` do nothing, and `ReplicationStatus` goes unreported.
+- `BatchGetSecretValue` is absent, as is the Parameters and Secrets Lambda Extension HTTP endpoint.
+- `ListSecrets` refuses `Filters`, `SortOrder` and `SortBy` outright, since quietly returning an
+  unfiltered or differently ordered list would be worse. Secrets are listed in creation order, with
+  `MaxResults` and `NextToken` paging over them. A `NextToken` this simulation did not issue,
+  including one whose offset is past the end of the list, is refused rather than answered with an
+  empty page.
 - Tags are stored and reported by `DescribeSecret` and `ListSecrets`, but `TagResource` and
-  `UntagResource` are not supported, and the `secretsmanager:ResourceTag` and `aws:ResourceTag`
-  condition keys are not derived.
+  `UntagResource` are absent, and the `secretsmanager:ResourceTag` and `aws:ResourceTag` condition
+  keys are left underived.
 - Other Secrets Manager condition keys, such as `secretsmanager:SecretId` and
-  `secretsmanager:VersionStage`, are not derived either, so a policy relying on them will not match.
+  `secretsmanager:VersionStage`, are left underived too, and a policy relying on them fails to match.
   Ordinary condition operators on values sim IAM does supply work as usual.
 - A version that loses every staging label is kept indefinitely and stays readable by version id,
-  rather than being removed as real Secrets Manager removes it after about a day. It is left out of
-  `VersionIdsToStages` either way.
-- `LastAccessedDate`, `LastRotatedDate`, `NextRotationDate`, `OwningService` and `PrimaryRegion` are
-  not reported.
-- Secret values live in process memory for the lifetime of the `SimAws` instance. That is not a
-  security boundary: anything sharing the process can reach them.
+  where real Secrets Manager removes it after about a day. It is left out of `VersionIdsToStages`
+  either way.
+- `LastAccessedDate`, `LastRotatedDate`, `NextRotationDate`, `OwningService` and `PrimaryRegion` go
+  unreported.
+- Secret values live in process memory for the lifetime of the `SimAws` instance. Anything sharing
+  the process can reach them.
 - Secrets Manager is not served as an HTTP API by `serveSimAws`.

--- a/docs/services/ses/README.md
+++ b/docs/services/ses/README.md
@@ -2,12 +2,12 @@
 
 Yulin includes a simulated Amazon SES for tests and local development, through the SES v2 API. It
 holds email identities, applies the sandbox rules, and keeps a record of every message it would have
-sent, so a test can assert that signing someone up produced a welcome email addressed to them,
-without an AWS account and without a mailbox to read.
+sent. A test can assert that signing someone up produced a welcome email addressed to them, without
+an AWS account and without a mailbox to read.
 
-There is no delivery to simulate. A message SES accepts leaves AWS for a mail system, so the whole
-of the observable AWS behaviour is whether SES would have accepted the message and what it would
-have sent. That is what makes this service small and what makes it useful.
+There is no delivery to simulate. A message SES accepts leaves AWS for a mail system. The whole of
+the observable AWS behaviour is whether SES would have accepted the message and what it would have
+sent. That is what makes this service small and what makes it useful.
 
 SES specific types are imported from the `@kensio/yulin/ses` subpath.
 
@@ -52,19 +52,18 @@ const [email] = ses.sentEmails();
 console.log(email?.subject, email?.destination.toAddresses[0]);
 ```
 
-Messages come back in the order they were sent, so the first message of a flow is the first one
-read. The three recipient lists stay apart, so a test asserting a bcc was a bcc still can, and
-`recipients` gathers all three when it does not matter which was which.
+Messages come back in the order they were sent, and the first message of a flow is the first one
+read. The three recipient lists stay apart, leaving a test free to assert that a bcc was a bcc.
+`recipients` gathers all three where it makes no difference which was which.
 
 `body` keeps `text` and `html` apart too. A message sent with only an HTML body reports `undefined`
-for its text rather than handing back the markup.
+for its text, and never the markup.
 
 ## Verifying identities
 
 Real SES verifies an email address by emailing it a link and a domain by looking for DNS records.
 Neither can happen inside a test process, so verification here is the simulator's own operation
-rather than an API call. `verifyIdentity` performs it, creating the identity if it is not already
-there.
+instead of an API call. `verifyIdentity` performs it, creating the identity where one is absent.
 
 Everything else about identities is the ordinary SES API. `CreateEmailIdentity` starts one, and it
 starts unverified, exactly as a real one does:
@@ -109,29 +108,28 @@ const verified = await ses.getEmailIdentity(
 console.log(verified.VerificationStatus, verified.VerifiedForSendingStatus);
 ```
 
-Whether an identity is an address or a domain follows from whether the name has an `@` in it, which
-is how SES itself decides: there is no parameter saying which is meant.
+Whether an identity is an address or a domain follows from whether the name has an `@` in it. That
+is how SES itself decides, with no parameter saying which is meant.
 
-A verified domain covers every address at it, which is the whole reason domain identities exist. It
-does not cover a subdomain: `example.com` does nothing for `orders@mail.example.com`, here or on
-real SES. Domains match without regard to case; the local part of an address does not, per RFC 5321,
-so `Sales@example.com` and `sales@example.com` are two identities.
+A verified domain covers every address at it, the whole reason domain identities exist. Its
+subdomains are a separate matter, and `example.com` leaves `orders@mail.example.com` uncovered, here
+or on real SES. Domains match without regard to case. The local part of an address is
+case-sensitive, per RFC 5321, so `Sales@example.com` and `sales@example.com` are two identities.
 
-`unverify()` on an identity puts it back to `PENDING`, which is what a real one does when the
-records that proved it stop resolving. That gives a test somewhere to go when it wants to see
-sending fail after it once worked.
+`unverify()` on an identity puts it back to `PENDING`, as a real one goes when the records that
+proved it stop resolving. That gives a test somewhere to go when it wants to see sending fail after
+it once worked.
 
 ## Email templates
 
-The assertion a test usually wants is not "the email said this prose", which changes whenever
-someone rewords it. It is "the welcome email went to this address, from this template, with these
-substitutions". Storing the template in SES and sending from it by name is what makes that
-assertion possible.
+The assertion a test usually wants is "the welcome email went to this address, from this template,
+with these substitutions". Asserting on the prose instead breaks whenever someone rewords it.
+Storing the template in SES and sending from it by name is what makes the better assertion possible.
 
 Templates are managed with `CreateEmailTemplate`, `GetEmailTemplate`, `UpdateEmailTemplate`,
 `ListEmailTemplates` and `DeleteEmailTemplate`. A send carrying `Content.Template` renders the
-stored wording against the JSON in `TemplateData`, and the recorded send carries the template name
-and the parsed data alongside the rendered result, so a test can assert on either.
+stored wording against the JSON in `TemplateData`. The recorded send carries the template name and
+the parsed data alongside the rendered result, leaving a test free to assert on either.
 
 ```typescript sim-ses-templates
 /**
@@ -177,26 +175,24 @@ const [email] = ses.sentEmails();
 console.log(email?.templateName, email?.templateData, email?.subject);
 ```
 
-A message written out in full reports `undefined` for both, so a test can tell the two kinds of send
-apart.
+A message written out in full reports `undefined` for both, leaving a test able to tell the two
+kinds of send apart.
 
 ### What the substitution does
 
-Real SES renders templates with Handlebars, and this simulator renders the substitution part of it:
-`{{name}}`, and dotted paths like `{{order.id}}`.
+Real SES renders templates with Handlebars, and this simulator renders the substitution part of it,
+being `{{name}}` and dotted paths like `{{order.id}}`.
 
-A placeholder naming something the data does not have renders as an empty string rather than
-failing. That is what real SES does, and it is much the commonest surprise in an SES template: the
-message goes out with a hole in it and nothing reports a problem. Asserting on the rendered body is
-how that gets caught.
+A placeholder naming something the data lacks renders as an empty string. That is what real SES
+does, and it is much the commonest surprise in an SES template. The message goes out with a hole in
+it and nothing reports a problem. Asserting on the rendered body is how that gets caught.
 
-`{{name}}` HTML-escapes its value and `{{{name}}}` does not, again following Handlebars. The
-escaping applies to the text part as well as the HTML one, because Handlebars renders a string
-without knowing what it is for, so a plain text email carrying an ampersand comes out with
-`&amp;` in it.
+`{{name}}` HTML-escapes its value where `{{{name}}}` leaves it alone, again following Handlebars.
+The escaping applies to the text part as well as the HTML one, because Handlebars renders a string
+without knowing what it is for. A plain text email carrying an ampersand comes out with `&amp;` in
+it.
 
-Everything else Handlebars can do is refused where the template is written, rather than left in
-place:
+Everything else Handlebars can do is refused where the template is written:
 
 ```typescript sim-ses-template-refusals
 /**
@@ -227,24 +223,23 @@ try {
 }
 ```
 
-Refusing at the template rather than at the send is deliberate: it fails where the mistake is
-written, and a template surviving into a sent message with `{{#if premium}}` still in it would make
-a test pass on a message no real SES would produce.
+Refusing at the template is deliberate. It fails where the mistake is written, and a template
+surviving into a sent message with `{{#if premium}}` still in it would make a test pass on a message
+no real SES would produce.
 
-`TemplateData` is checked only when a send carries it: malformed JSON, or JSON that is not an
-object, is refused. A send with no `TemplateData` at all is accepted and renders every placeholder
-empty, which is how real SES treats it.
+`TemplateData` is checked only when a send carries it. Malformed JSON, or JSON that is anything but
+an object, is refused. A send with no `TemplateData` at all is accepted and renders every
+placeholder empty, as real SES treats it.
 
 A send may name a stored template or write its wording out in `TemplateContent`, but not both.
-Naming both is refused, because which of them real SES renders is not something this simulator
-knows, and recording the message under a template it was not rendered from would be worse than
-failing.
+Naming both is refused. Which of them real SES renders is beyond what this simulator knows, and
+recording the message under a template it was not rendered from would be worse than failing.
 
 ## Deploying identities and templates with CloudFormation
 
-`AWS::SES::EmailIdentity` and `AWS::SES::Template` deploy into simulated SES, so a project that
-declares them in CDK or CloudFormation can deploy the same template its application deploys rather
-than creating them by hand in test setup.
+`AWS::SES::EmailIdentity` and `AWS::SES::Template` deploy into simulated SES. A project that
+declares them in CDK or CloudFormation can deploy the same template its application deploys, with no
+hand-written test setup.
 
 ```typescript sim-ses-cloudformation
 /**
@@ -300,12 +295,12 @@ await ses.sendEmail(
 console.log(ses.sentEmails()[0]?.subject);
 ```
 
-An identity deploys **unverified**. That is what a real deploy leaves behind: the confirmation link
-or the DKIM records still have to be dealt with out of band. Verify it afterwards with
-`verifyIdentity`, in that order: verifying first and deploying second fails the deploy, because
+An identity deploys **unverified**. That is what a real deploy leaves behind, with the confirmation
+link or the DKIM records still to be dealt with out of band. Verify it afterwards with
+`verifyIdentity`, in that order. Verifying first and deploying second fails the deploy, because
 CloudFormation is creating an identity that is already there.
 
-`Ref` on an identity returns the address or domain itself, which is directly usable as a
+`Ref` on an identity returns the address or domain itself, directly usable as a
 `FromEmailAddress`. `Ref` on a template, and its `Id` attribute, both return the template name.
 
 Deleting the stack removes both.
@@ -313,41 +308,41 @@ Deleting the stack removes both.
 ### DKIM tokens
 
 `Fn::GetAtt` on an identity reads the six DKIM token attributes, and this simulator answers them
-with tokens it made up. They are derived from the identity's own name, so they are the same on every
-run, and they are not real: nothing here signs a message.
+with tokens it made up. They are derived from the identity's own name, and come out the same on every
+run. They are invented, and no message here is signed.
 
 They exist because `ses.Identity.publicHostedZone()` in CDK emits three `AWS::Route53::RecordSet`
 Resources reading exactly these attributes. Refusing them would take an ordinary CDK stack down over
-records nothing in this simulation reads, so the stack deploys with records of the right shape
-pointing at nothing.
+records this simulation never reads. The stack deploys with records of the right shape and no
+target.
 
 ### What an identity Resource is deployed without
 
 `EmailIdentity` is the only property acted on. `DkimAttributes`, `DkimSigningAttributes`,
 `MailFromAttributes`, `FeedbackAttributes`, `ConfigurationSetAttributes` and `Tags` are recorded as
-ignored and the identity is created without them, because an identity without any of them still does
-the one thing an identity does here: exist to be verified, and let a send from it through.
+ignored and the identity is created without them. An identity lacking all of them still does the one
+thing an identity does here. It exists, it is verified, and it lets a send from it through.
 
-`stack.ignoredProperties` is where they are reported, each with the reason it was not acted on, so
-nothing is dropped in silence.
+`stack.ignoredProperties` is where they are reported, each with the reason it was left alone. None
+is dropped in silence.
 
 The SDK path is stricter on purpose. `CreateEmailIdentity` refuses `DkimSigningAttributes` outright,
-because a caller reaching for it directly is asking for that behaviour and should be told it is not
-there. A template is a whole document, and one property in it should not sink the deploy.
+because a caller reaching for it directly is asking for that behaviour and deserves to hear it is
+absent. A template is a whole document, and one property in it should leave the deploy standing.
 
 A template Resource has no such list, because everything `AWS::SES::Template` can usefully say is
-wording and all of it is acted on. Anything else it says is still reported, at both levels: a
-property beside `Template`, and a part inside it that is not one of the four. In practice that
-catches a misspelling, which is worth catching, since `TextPart` written `Textpart` would otherwise
-send a message with no body and nothing to explain it.
+wording and all of it is acted on. Anything else it says is still reported, at both levels. That
+covers a property beside `Template`, and a part inside it that is none of the four. In practice it
+catches a misspelling. `TextPart` written `Textpart` would otherwise send a message with no body and
+no explanation for it.
 
-A template carrying Handlebars this simulator does not render is a different matter, and fails the
-deploy rather than sitting in the stack waiting to fail at the first send.
+A template carrying Handlebars this simulator leaves unrendered is a different matter, and fails the
+deploy where it would otherwise sit in the stack waiting to fail at the first send.
 
 ## The sandbox
 
 An account starts in the SES sandbox, where **both** the sender and every recipient have to be
-verified. That is the state most tests should be written against: it is the configuration that
+verified. That is the state most tests should be written against. It is the configuration that
 refuses to mail an address nobody verified, and catching that refusal in a test is much better than
 catching it in an account.
 
@@ -404,23 +399,23 @@ await ses.sendEmail(message);
 console.log(ses.sentEmails().length);
 ```
 
-A rejection names every identity that failed the check in one message, the way real SES does, so a
-caller finds out everything it has to verify from one failure rather than several:
+A rejection names every identity that failed the check in one message, the way real SES does. A
+caller finds out everything it has to verify from one failure:
 
 ```text
 Email address is not verified. The following identities failed the check in region US-EAST-1: someone@example.org
 ```
 
-Real SES treats `ProductionAccessEnabled` as a request that a human at AWS then reviews, so an
-account does not leave the sandbox the moment the call returns. Granting it immediately is a
-deliberate divergence: the alternative is a simulator no test can get out of the sandbox in, and
-waiting for a review is not behaviour a test can assert on anyway.
+Real SES treats `ProductionAccessEnabled` as a request that a human at AWS then reviews, and an
+account stays in the sandbox until that review lands. Granting it immediately is a deliberate
+divergence. The alternative is a simulator no test can get out of the sandbox in, and waiting for a
+review is beyond what a test can assert on anyway.
 
 ## Permissions
 
 Every command authorizes through simulated IAM. A send authorizes against the identity being sent
-**from**; recipients never enter into it, which is worth knowing when a policy looks like it should
-cover a send and does not.
+**from**, and recipients never enter into it. That is worth knowing when a policy looks like it
+should cover a send and fails to.
 
 ```typescript sim-ses-permissions
 /**
@@ -498,17 +493,17 @@ send from any address at the domain, unless that address is an identity in its o
 case the send authorizes against `identity/hello@example.com` instead.
 
 `ses:ListEmailIdentities`, `ses:GetAccount` and `ses:PutAccountDetails` have no resource type at all
-on real SES, so only a policy written against `*` allows them. A policy scoped to identity ARNs
-allows none of the three, not even one written against `identity/*`, which is the intuitive reading
-and the wrong one.
+on real SES, and only a policy written against `*` allows them. A policy scoped to identity ARNs
+allows none of the three. Not even one written against `identity/*`, the intuitive reading and the
+wrong one.
 
 IAM is evaluated before the identity check, as it is on real AWS. A caller with no permission is
-refused whether or not its identities are verified, which means the error a test sees says which of
-the two is wrong.
+refused whether or not its identities are verified. The error a test sees says which of the two is
+wrong.
 
 ## SDK interception
 
-An intercepted `SESv2Client` reaches simulated SES with nothing touching the network:
+An intercepted `SESv2Client` reaches simulated SES, served in process:
 
 ```typescript sim-ses-sdk-interception
 /**
@@ -575,9 +570,9 @@ console.log(
 );
 ```
 
-The quota figures are the real sandbox and production ones, and neither is enforced. `SentLast24Hours`
-counts what was actually sent, on the simulated clock, so a test that moves time forward past the
-window sees the count fall the way an account's would.
+The quota figures are the real sandbox and production ones, and both are reported without being
+enforced. `SentLast24Hours` counts what was actually sent, on the simulated clock. A test that moves
+time forward past the window sees the count fall the way an account's would.
 
 ## Simulated commands
 
@@ -596,7 +591,7 @@ window sees the count fall the way an account's would.
 | `GetAccount`          |                                                                                            |
 | `PutAccountDetails`   | `MailType` and `WebsiteURL` are required, as on real SES.                                  |
 
-Anything else refuses on send with `SimSdkUnsupportedCommandError` rather than misbehaving quietly.
+Anything else refuses on send with `SimSdkUnsupportedCommandError`.
 
 ## Divergences and limitations
 
@@ -605,20 +600,20 @@ Anything else refuses on send with `SimSdkUnsupportedCommandError` rather than m
   record.
 - **Production access is granted on request.** Real SES has a human review it first.
 - **Send quotas are reported, not enforced.** A send past the daily figure still succeeds, and
-  nothing here takes real time to respect a per-second rate.
+  a per-second rate would cost real time to respect.
 - **`Content.Raw` is refused by name.** A raw MIME message would have to be parsed to say anything
   about its subject or body.
 - **Only Handlebars substitution is rendered.** Block helpers, partials and comments are refused at
   the template. Template data holding an object where the template wants a value is refused too,
-  rather than rendering `[object Object]` the way real Handlebars would.
-- **`SendBulkEmail` is not simulated**, so there is no per-recipient replacement data.
+  where real Handlebars would render `[object Object]`.
+- **`SendBulkEmail` is absent**, along with its per-recipient replacement data.
 - **Nothing is delivered, and nothing bounces.** There are no bounce or complaint events, no
   suppression list, no configuration sets and no event destinations. A configuration set named on a
-  send is kept on the record so a test can assert the right one was used, and does nothing else.
+  send is kept on the record so a test can assert the right one was used, and goes no further.
 - **DKIM tokens on `AWS::SES::EmailIdentity` are made up.** They are stable per identity so a test
-  can assert on them, and they prove nothing.
+  can assert on them, and they prove no ownership of anything.
 - **Only `AWS::SES::EmailIdentity` and `AWS::SES::Template` deploy.** `AWS::SES::ConfigurationSet`,
-  `AWS::SES::ContactList`, `AWS::SES::ReceiptRule` and the rest are not simulated.
-- **SES v2 only.** The older `@aws-sdk/client-ses` API is not simulated.
-- **DKIM, MAIL FROM domains and sending authorization policies are not simulated.** An identity
-  created with `DkimSigningAttributes` is refused rather than reported as configured.
+  `AWS::SES::ContactList`, `AWS::SES::ReceiptRule` and the rest are left out.
+- **SES v2 only.** The older `@aws-sdk/client-ses` API is absent.
+- **DKIM, MAIL FROM domains and sending authorization policies are left out.** An identity created
+  with `DkimSigningAttributes` is refused, and never reported as configured.

--- a/docs/services/ssm/README.md
+++ b/docs/services/ssm/README.md
@@ -4,7 +4,7 @@ Yulin includes a simulated AWS Systems Manager Parameter Store for tests and loc
 Parameters are stored in memory, versioned on every write, and every operation is authorized by
 simulated IAM.
 
-Only Parameter Store is simulated. Nothing else in Systems Manager is.
+Only Parameter Store is simulated.
 
 SSM-specific types are imported from the `@kensio/yulin/ssm` subpath.
 
@@ -111,11 +111,11 @@ console.log(read.Parameter?.Value); // "db.internal"
 ```
 
 `DescribeParameters` is the exception. Real Parameter Store gives that action no resource-level
-permissions, so it authorizes against `*` here, and a policy naming individual parameter ARNs grants
+permissions. It authorizes against `*` here, and a policy naming individual parameter ARNs grants
 nothing.
 
 `GetParametersByPath` authorizes against the path rather than against each parameter it returns.
-Access to a path is access to everything under it, so a recursive listing of `/myapp` returns
+Access to a path is access to everything under it. A recursive listing of `/myapp` returns
 `/myapp/prod/db-host` even where a policy explicitly denies that parameter.
 
 ## Versions
@@ -220,7 +220,7 @@ A page holds ten parameters, as it does on real AWS. Follow `NextToken` to read 
 ## Reading several parameters at once
 
 `GetParameters` takes up to ten names. A name that resolves to nothing comes back in
-`InvalidParameters` rather than failing the request, which is what makes a typo easy to miss.
+`InvalidParameters`, leaving the request to succeed. That is what makes a typo easy to miss.
 
 ```typescript sim-ssm-get-parameters-batch
 /**
@@ -253,12 +253,12 @@ console.log(read.Parameters?.map((parameter) => parameter.Name));
 console.log(read.InvalidParameters); // [ "/myapp/prod/db-hostt" ]
 ```
 
-`GetParameters` still authorizes each name, so one name the caller may not read fails the whole
+`GetParameters` still authorizes each name. One name the caller may not read fails the whole
 request.
 
 ## String lists
 
-A `StringList` value is one comma-separated string, on read as well as on write. It is not returned
+A `StringList` value comes back as one comma-separated string, on read as well as on write, never
 as an array.
 
 ```typescript sim-ssm-string-list
@@ -302,17 +302,17 @@ deployment failure a passing test would have hidden. A name:
 - may not contain spaces between characters, though surrounding spaces are stripped
 - may not make an ARN longer than 1011 characters, counting the ARN prefix for the account and region
 
-A `String` or `StringList` value holds at most 4KB, which is the standard tier limit. This is the one
-people hit, usually by putting a whole JSON configuration blob in one parameter.
+A `String` or `StringList` value holds at most 4KB, the standard tier limit. This is the one people
+hit, usually by putting a whole JSON configuration blob in one parameter.
 
 ## Deploying a parameter from CloudFormation
 
 Simulated CloudFormation creates a parameter from an `AWS::SSM::Parameter` resource, in the stack's
-account and region. The parameter is written through `PutParameter`, so a template-created parameter
-is the same thing an SDK caller would get: the same name validation, the same ARN, version 1.
+account and region. The parameter is written through `PutParameter`. A template-created parameter is
+the same thing an SDK caller would get, with the same name validation, the same ARN, and version 1.
 
-`Ref` on the resource gives the parameter name rather than its ARN, as it does on real AWS, so it can
-be handed straight to `GetParameter`. `Fn::GetAtt … Type` and `Fn::GetAtt … Value` give those
+`Ref` on the resource gives the parameter name, as it does on real AWS, and it can be handed straight
+to `GetParameter`. `Fn::GetAtt … Type` and `Fn::GetAtt … Value` give those
 properties.
 
 ```typescript sim-ssm-cloudformation-parameter
@@ -362,7 +362,7 @@ console.log(read.Parameter?.Version); // 1
 ```
 
 A parameter with no `Name` is named after its logical ID. Real CloudFormation generates a name from
-the stack name and its own random characters, so a template cannot rely on the exact generated name
+the stack name and its own random characters. A template cannot rely on the exact generated name
 either way.
 
 An IAM policy granting access to a template-created parameter needs the ARN rather than the `Ref`.
@@ -379,7 +379,7 @@ here without hand-editing.
 
 Function code that reads its configuration on cold start needs no special treatment. Any
 `@aws-sdk/client-ssm` client the handler creates is intercepted and dispatched with the function's
-execution role as the caller, so the role's policy decides whether the read succeeds.
+execution role as the caller. The role's policy decides whether the read succeeds.
 
 ```typescript sim-ssm-lambda-handler-config
 /**
@@ -518,10 +518,10 @@ console.log(read.Parameter?.ARN);
 
 A `SecureString` value is encrypted through simulated KMS, under the `aws/ssm` AWS managed key unless
 the request names a key of its own. Simulated KMS creates that managed key the first time something
-asks for it, so nothing has to set it up.
+asks for it, with no setup needed.
 
 A read returns the ciphertext unless it asks for decryption. This is the mistake that is easy to make
-and hard to see: a handler that forgets `WithDecryption` parses a base64 blob as if it were a
+and hard to see. A handler that forgets `WithDecryption` parses a base64 blob as if it were a
 password.
 
 ```typescript sim-ssm-secure-string
@@ -560,22 +560,22 @@ const decrypted = await ssm.getParameter(
 console.log(decrypted.Parameter?.Value); // "hunter2"
 ```
 
-`WithDecryption` on a `String` or `StringList` parameter is ignored rather than refused, as real
-Parameter Store ignores it.
+`WithDecryption` on a `String` or `StringList` parameter is ignored, as real Parameter Store ignores
+it.
 
-Pass `KeyId` to encrypt under a customer managed key instead. A `KeyId` naming a key that does not
-exist, is disabled, or is pending deletion fails with `InvalidKeyId`, which is how real Parameter
-Store reports every KMS key problem.
+Pass `KeyId` to encrypt under a customer managed key instead. A `KeyId` naming a key that is absent,
+disabled, or pending deletion fails with `InvalidKeyId`. That is how real Parameter Store reports
+every KMS key problem.
 
 Each value is bound to its own parameter's ARN as the KMS encryption context, under the
-`PARAMETER_ARN` key, so a ciphertext lifted out of one parameter cannot be decrypted as another.
+`PARAMETER_ARN` key. A ciphertext lifted out of one parameter cannot be decrypted as another.
 
 ### A customer managed key needs its own permission
 
 Encrypting and decrypting go to simulated KMS as the caller, not as the service. Under a customer
 managed key a write needs `kms:Encrypt` on the key on top of `ssm:PutParameter` on the parameter, and
 a decrypting read needs `kms:Decrypt` on top of `ssm:GetParameter`. A role granted one and not the
-other fails here rather than in a deployment.
+other fails here, ahead of a deployment.
 
 ```typescript sim-ssm-secure-string-permissions
 /**
@@ -745,49 +745,48 @@ Sim SSM currently supports:
 Current documented limitations:
 
 - Only standard tier `SecureString` encryption is simulated, which encrypts under the KMS key
-  directly. The advanced tier's envelope encryption through the AWS Encryption SDK is not, so
+  directly. The advanced tier's envelope encryption through the AWS Encryption SDK is left out, and
   `kms:GenerateDataKey` is never needed.
-- Parameter labels are not simulated. `LabelParameterVersion` is not implemented, so nothing can
-  create a label, and a `name:label` selector is refused with an error saying so.
-- `GetParameterHistory` is not simulated, though earlier versions stay readable by number.
-- The advanced tier is not simulated. `Tier: Advanced` and `Tier: Intelligent-Tiering` are refused,
-  and every parameter reports `Tier: Standard` with the 4KB standard tier value limit.
-- Parameter policies (expiration and notification) are not simulated. `Policies` is refused, and
+- Parameter labels are left out. `LabelParameterVersion` is unimplemented, so a label can never be
+  created, and a `name:label` selector is refused with an error saying so.
+- `GetParameterHistory` is absent, though earlier versions stay readable by number.
+- The advanced tier is left out. `Tier: Advanced` and `Tier: Intelligent-Tiering` are refused, and
+  every parameter reports `Tier: Standard` with the 4KB standard tier value limit.
+- Parameter policies (expiration and notification) are left out. `Policies` is refused, and
   `DescribeParameters` always reports an empty `Policies` list.
-- Tags are not simulated. `Tags` on `PutParameter` is refused, and `AddTagsToResource`,
-  `RemoveTagsFromResource` and `ListTagsForResource` are not supported.
-- `AllowedPattern` is refused rather than ignored, because a value it was meant to reject would
-  otherwise be stored without complaint.
+- Tags are left out. `Tags` on `PutParameter` is refused, and `AddTagsToResource`,
+  `RemoveTagsFromResource` and `ListTagsForResource` are absent.
+- `AllowedPattern` is refused outright. Ignoring it would store a value it was meant to reject,
+  without complaint.
 - `KeyId` on a `String` or `StringList` parameter is refused, since nothing would encrypt a value
   stored in the clear.
 - `DataType` other than `text` is refused. Real Parameter Store validates an `aws:ec2:image` value
   against EC2, which this simulation cannot do.
-- Filters are refused rather than ignored. `GetParametersByPath` refuses `ParameterFilters`, and
+- Filters are refused outright. `GetParametersByPath` refuses `ParameterFilters`, and
   `DescribeParameters` refuses `Filters` and `ParameterFilters`. Parameters are listed in name order.
 - `DescribeParameters` refuses `Shared`. Parameters cannot be shared between simulated accounts, and
   there is no resource policy support, so cross-account access to a parameter cannot be granted.
 - Every version is kept. Real Parameter Store keeps the hundred most recent versions and deletes the
   oldest as new ones are made, which can fail with `ParameterMaxVersionLimitExceeded`.
 - There is no per-account parameter count limit, so `ParameterLimitExceeded` never happens.
-- Deletion is immediate. Real Parameter Store asks for thirty seconds before a deleted name is reused;
-  here the name is free straight away.
+- Deletion is immediate. Real Parameter Store asks for thirty seconds before a deleted name is
+  reused, where here the name is free straight away.
 - `AWS::SSM::Parameter` supports `Name`, `Type`, `Value`, `Description` and `Tier`. `AllowedPattern`,
   `DataType`, `Policies` and `Tags` reach `PutParameter`, which refuses them for the reasons above.
-  `Type: SecureString` is refused, as real CloudFormation refuses it for this resource type: the
+  `Type: SecureString` is refused, as real CloudFormation refuses it for this resource type. The
   plaintext value would sit in the template.
 - The other `AWS::SSM::*` resource types (`Document`, `Association`, `MaintenanceWindow`,
-  `PatchBaseline`, `ResourceDataSync` and the rest) are reported as unsupported and skipped rather
-  than deployed.
-- Every deployment of an `AWS::SSM::Parameter` is a create, so a name another stack already used is
+  `PatchBaseline`, `ResourceDataSync` and the rest) are reported as unsupported and skipped.
+- Every deployment of an `AWS::SSM::Parameter` is a create. A name another stack already used is
   refused. A stack update that changes `Value` deletes the parameter and creates it again, where
   real CloudFormation overwrites it in place, so the parameter's version starts from 1 again.
 - `{{resolve:ssm:...}}` dynamic references and the `AWS::SSM::Parameter::Value<String>` template
-  parameter type are not supported. Those are CloudFormation engine features rather than Parameter
-  Store ones; pass the name from `Ref` instead.
+  parameter type are absent. Those are CloudFormation engine features rather than Parameter Store
+  ones. Pass the name from `Ref` instead.
 - Public parameters under `/aws/service/...` do not exist, and names under the reserved `aws` and
   `ssm` prefixes are refused, as they are on real AWS.
-- The Parameters and Secrets Lambda extension HTTP endpoint is not simulated. Handler code has to use
-  the SDK.
-- Nothing else in Systems Manager is simulated: Run Command, Session Manager, Patch Manager, State
-  Manager, Automation, inventory and maintenance windows are all absent.
+- The Parameters and Secrets Lambda extension HTTP endpoint is absent. Handler code has to use the
+  SDK.
+- Systems Manager is otherwise left out. Run Command, Session Manager, Patch Manager, State Manager,
+  Automation, inventory and maintenance windows are all absent.
 - SSM is not served as an HTTP API by `serveSimAws`.

--- a/docs/services/ssm/README.md
+++ b/docs/services/ssm/README.md
@@ -220,7 +220,7 @@ A page holds ten parameters, as it does on real AWS. Follow `NextToken` to read 
 ## Reading several parameters at once
 
 `GetParameters` takes up to ten names. A name that resolves to nothing comes back in
-`InvalidParameters`, leaving the request to succeed. That is what makes a typo easy to miss.
+`InvalidParameters`, and the request still succeeds. That is what makes a typo easy to miss.
 
 ```typescript sim-ssm-get-parameters-batch
 /**


### PR DESCRIPTION
Rewrites the sim Rekognition, Route53, Scheduler, Secrets Manager, SES and SSM Parameter Store docs against the technical-prose-style and avoid-ai-writing skills, cutting significance tails, contrastive definitions, negation framing and appositive tails, and splitting the semicolons, em dashes and mid-sentence colons the house rules ban. Only prose changed, with the extracted examples untouched. One Route53 heading moved out of negation framing, and both links to its anchor follow it.

`pnpm run check` passes, and `prose-check` reports every file in this batch clean. Branched from `main` rather than from #656, since the two batches touch different files. Still to do in a final batch: Lambda, S3, SNS and SQS.