### PR TITLE
docs: correct the simulated SNS protocol comment

### DIFF
--- a/src/service/sns/subscription/sim-sns-subscription-protocol.ts
+++ b/src/service/sns/subscription/sim-sns-subscription-protocol.ts
@@ -53,7 +53,11 @@ export type SimSnsOutwardProtocol =
   | typeof simSnsLambdaProtocol;
 
 /**
- * Every protocol delivery is simulated over, as a set to read a request against.
+ * Every protocol delivery is simulated over.
+ *
+ * A Subscribe request's protocol is read against this set. The refusal for a
+ * protocol that is missing writes each of them out itself, so the order here
+ * changes nothing.
  */
 const simulatedProtocols = [
   simSnsSqsProtocol,

--- a/src/service/sns/subscription/sim-sns-subscription-protocol.ts
+++ b/src/service/sns/subscription/sim-sns-subscription-protocol.ts
@@ -53,7 +53,7 @@ export type SimSnsOutwardProtocol =
   | typeof simSnsLambdaProtocol;
 
 /**
- * Every protocol delivery is simulated over, in the order a refusal names them.
+ * Every protocol delivery is simulated over, as a set to read a request against.
  */
 const simulatedProtocols = [
   simSnsSqsProtocol,


### PR DESCRIPTION
The set of simulated subscription protocols is what a Subscribe request is read against. The refusal naming them writes each one out, so the order of the set has nothing to do with it. This corrects a comment that came in with the sms subscription protocol and described the set as ordered for that message.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that simulated protocol delivery is represented as a set rather than an ordered refusal sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->