### PR TITLE
docs: plain prose in the last four READMEs

### DIFF
--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -14,8 +14,8 @@ instances can be routed into sim Lambda with
 
 The quickest way to a working function is to pass a real in-process handler function through the
 SDK-shaped `Code.ZipFile` input with `makeLambdaZipFileInput(...)`. The handler is an ordinary
-function in your Node.js process, so it can be stepped through in a debugger and can close over
-local state.
+function in your Node.js process. It can be stepped through in a debugger and can close over local
+state.
 
 ```typescript sim-lambda-create-and-invoke
 /**
@@ -67,25 +67,25 @@ console.log(fetched.Configuration.State);
 ```
 
 Creating a function requires an execution `Role` ARN, as on real AWS. A new function starts in the
-`Pending` state and becomes `Active` in the background; wait with
+`Pending` state and becomes `Active` in the background. Wait with
 `simAws.backgroundTasksComplete()` when a test asserts on the `Active` state.
 
 Handlers use the same signature as real Node.js Lambda handlers, `(event, context, callback)`. All
-the real completion styles work: returning a promise, returning a plain value, calling the callback,
-or the legacy context `done`/`fail`/`succeed` methods. Typed handlers written against the
-`aws-lambda` typings package can be passed in unchanged.
+the real completion styles work. Return a promise, return a plain value, call the callback, or use
+the legacy context `done`/`fail`/`succeed` methods. Typed handlers written against the `aws-lambda`
+typings package can be passed in unchanged.
 
-A handler that throws is reported AWS-style: the invocation output has `FunctionError:
-"Unhandled"` and the payload is an error document with `errorType`, `errorMessage`, and `trace`,
-rather than the invoke call itself throwing.
+A handler that throws is reported AWS-style. The invocation output has `FunctionError:
+"Unhandled"` and the payload is an error document with `errorType`, `errorMessage`, and `trace`.
+The invoke call itself returns normally.
 
 ## Zip-packaged code and the vm runtime
 
 Real Lambda receives function code as a zip archive. `makeLambdaCodeZip(...)` builds real zip
 bytes from a source string (which becomes a single `index.js` module) or from a files map keyed by
 archive path (like a bundled deployment package). The archive runs in a Node.js `vm` context with
-real cold-start semantics: the module is imported once, on first invocation, and module state
-stays warm across invocations.
+real cold-start semantics. The module is imported once, on first invocation, and module state stays
+warm across invocations.
 
 ```typescript sim-lambda-zip-code-vm-runtime
 /**
@@ -149,39 +149,37 @@ The vm runtime models the real Node.js runtime closely:
   (`AWS_REGION`, `AWS_LAMBDA_FUNCTION_NAME`, `AWS_LAMBDA_FUNCTION_MEMORY_SIZE`, ...).
 - The sandbox provides writable `process.stdout` and `process.stderr`, with its `console` built
   over them, as the real runtime does. See [What a handler prints](#what-a-handler-prints).
-- Import and handler problems surface as invocation errors rather than failing creation, with the
-  real runtime error types (`Runtime.ImportModuleError`, `Runtime.HandlerNotFound`,
-  `Runtime.UserCodeSyntaxError`, `Runtime.MalformedHandlerName`).
+- Import and handler problems surface as invocation errors, with the real runtime error types
+  (`Runtime.ImportModuleError`, `Runtime.HandlerNotFound`, `Runtime.UserCodeSyntaxError`,
+  `Runtime.MalformedHandlerName`). Creation succeeds either way.
 
-Code is CommonJS, as zipped `.js` files are on the real `nodejs` runtimes; ES module source
-(`export` syntax) is not supported yet and fails with a clear hint. `Code.ZipFile` bytes that are
-not a real zip archive are rejected at creation with the AWS-like
+Code is CommonJS, as zipped `.js` files are on the real `nodejs` runtimes. ES module source
+(`export` syntax) is unsupported so far, and fails with a clear hint. `Code.ZipFile` bytes that fail to
+unzip are rejected at creation with the AWS-like
 `InvalidParameterValueException: Could not unzip uploaded file`.
 
-The archives are real zip files, so they interoperate with real tooling in both directions: a zip
+The archives are real zip files, and they interoperate with real tooling in both directions. A zip
 built by any other tool works as `Code.ZipFile` input, and `makeLambdaCodeZip` output can be
 unzipped normally.
 
 ### What a handler prints
 
-The sandbox has writable standard streams, so `process.stdout.write(...)` and
+The sandbox has writable standard streams. `process.stdout.write(...)` and
 `process.stderr.write(...)` work inside a handler, and its `console` is built over them as the real
-runtime's is. A logging library that builds its own console rather than using the global one works
-too:
+runtime's is. A logging library that builds its own console over them works too:
 
 ```javascript
 const { Console } = require("node:console");
 const logger = new Console({ stdout: process.stdout, stderr: process.stderr });
 ```
 
-That is what AWS Lambda Powertools' `Logger` does, at module scope, so a bundled Powertools handler
-runs here. Its `Metrics` writes its embedded metric format document to standard output, so the
+That is what AWS Lambda Powertools' `Logger` does, at module scope, and a bundled Powertools handler
+runs here. Its `Metrics` writes its embedded metric format document to standard output, where the
 metrics a handler emitted can be read back the same way its log lines can.
 
 What a handler prints is recorded into the function's log group in
 [simulated CloudWatch Logs](../logs/ "Simulated CloudWatch Logs usage docs"), at
-`/aws/lambda/<function name>`, so a test asserts on it by searching that group rather than by
-capturing process output:
+`/aws/lambda/<function name>`. A test asserts on it by searching that group:
 
 ```typescript
 const found = await simAws.logs().filterLogEvents(
@@ -192,25 +190,24 @@ const found = await simAws.logs().filterLogEvents(
 );
 ```
 
-One line becomes one log event, as it does in an account, so a handler printing a multi-line object
-gets several events and a search for one of those lines finds it. EMF metric documents go to the
+One line becomes one log event, as it does in an account. A handler printing a multi-line object
+gets several events, and a search for one of those lines finds it. EMF metric documents go to the
 same place, since Powertools' `Metrics` writes them to standard output.
 
 Each invocation also reaches the matching host stream, standard output to standard output and
-standard error to standard error, which is where a test or a `pnpm run dev` session already sees
-output. That is a tee rather than a redirect: real Lambda sends output to CloudWatch Logs and
-nowhere else, but a test tool that swallowed it would make a failing test harder to debug than it is
-with none of this.
+standard error to standard error, where a test or a `pnpm run dev` session already sees output. That
+is a tee rather than a redirect. Real Lambda sends output to CloudWatch Logs and nowhere else, and a
+test tool that swallowed the output would make a failing test harder to debug than it is with none
+of this.
 
 `context.logGroupName` and `context.logStreamName` name the group and stream that were actually
 written to, and stream names use the real `YYYY/MM/DD/[$LATEST]<hash>` format. The hash identifies
-the execution environment rather than the request, so match the shape rather than the value.
+the execution environment rather than the request. Match the shape, and leave the value alone.
 
 Only zip-packaged code is recorded. A function backed by a handler function reference, including one
-bound to a container image, is an ordinary function closing over the test's own module scope: its
-`console.log` reaches the host console directly, and there is nothing to intercept without patching
-a global the whole test run shares. Capturing the host stream is still the way to assert on one of
-those.
+bound to a container image, is an ordinary function closing over the test's own module scope. Its
+`console.log` reaches the host console directly, and intercepting that would mean patching a global
+the whole test run shares. Capturing the host stream is still the way to assert on one of those.
 
 ## Function code from S3
 
@@ -271,17 +268,17 @@ await simAws.backgroundTasksComplete();
 
 S3 lookup failures are wrapped AWS-style, e.g. `Error occurred while GetObject. S3 Error Code:
 NoSuchKey. ...`. `S3ObjectVersion` is accepted but ignored, as sim S3 has no object versioning
-yet. A standalone `SimLambda` (constructed directly rather than through `SimAws`) has no sim S3 to
-fetch from; `SimAws`-created Lambda wires the same-scope sim S3 automatically, matching real
+yet. A standalone `SimLambda` (constructed directly, outside `SimAws`) has no sim S3 to
+fetch from. `SimAws`-created Lambda wires the same-scope sim S3 automatically, matching real
 Lambda's requirement for a same-region code bucket.
 
 ## The runtime-provided AWS SDK
 
 Like the real Lambda Node.js runtime, the simulated runtime provides AWS SDK v3 packages without
-them being bundled in the code archive: `require("@aws-sdk/client-s3")` (or any other `@aws-sdk/*`
-package installed in the host project) resolves to the real package with its clients routed into
+them being bundled in the code archive. `require("@aws-sdk/client-s3")`, or any other `@aws-sdk/*`
+package installed in the host project, resolves to the real package with its clients routed into
 the owning simulated AWS environment. Calls the function code makes run as the function's
-execution role, so simulated IAM authorizes them just like real Lambda execution roles.
+execution role, and simulated IAM authorizes them just like real Lambda execution roles.
 
 ```typescript sim-lambda-runtime-provided-sdk
 /**
@@ -381,36 +378,35 @@ the invocation reports the denial as an unhandled function error, just as a real
 denial surfaces inside the handler.
 
 A client constructed without a region defaults to the function's account and region scope, as the
-real runtime's `AWS_REGION` provides; an explicit region on the client wins. The archive always
-takes precedence: a package bundled under the archive's `node_modules/` is used as-is rather than
-being intercepted, and reaches the simulation through the transport below instead.
+real runtime's `AWS_REGION` provides. An explicit region on the client wins. The archive always
+takes precedence. A package bundled under the archive's `node_modules/` is used as it stands, and
+reaches the simulation through the transport below.
 
 ### Function code that bundles the SDK
 
-Some deployment packages inline the SDK rather than relying on the runtime to provide it, which is
-what CDK's `NodejsFunction` does when given `bundling: { externalModules: [] }`. There is then no
-`@aws-sdk/*` module left for the runtime to provide, so nothing to intercept.
+Some deployment packages inline the SDK rather than relying on the runtime to provide it. CDK's
+`NodejsFunction` does that when given `bundling: { externalModules: [] }`. There is then no
+`@aws-sdk/*` module left for the runtime to provide, and nothing to intercept.
 
 Those functions reach the simulation anyway. The runtime provides their HTTP transport, `node:http`
 and `node:https`, and a request addressed to an AWS API endpoint is answered from the same
 simulated services, as the same execution role, instead of going to the network. The execution
-role credentials are in the function's environment, as real Lambda puts them there, so the SDK
-resolves credentials without looking outside the sandbox rather than failing with
-`CredentialsProviderError`.
+role credentials are in the function's environment, as real Lambda puts them there. The SDK resolves
+credentials inside the sandbox, where it would otherwise fail with `CredentialsProviderError`.
 
 A serialized request states which operation it is and carries its input for the services using the
-AWS JSON protocol, which is what can be read back without the operation's schema:
+AWS JSON protocol. Those are the ones that can be read back without the operation's schema:
 
 ACM, CloudWatch Logs, Cognito Identity Provider, DynamoDB, DynamoDB Streams, ECS, EventBridge, KMS,
 Rekognition, Secrets Manager, SQS and SSM.
 
 A bundled call to any other simulated service, such as S3, SNS, SES or Lambda itself, fails with an
-error naming the service rather than reaching it. Leaving the SDK out of that archive puts it back
+error naming the service. Leaving the SDK out of that archive puts it back
 on the module interception path above, which every simulated service is reachable through.
 
-Values the JSON protocols encode travel in their encoded form: a binary attribute written through a
-bundled SDK is stored base64-encoded and decodes correctly when the same path reads it back, but an
-in-process intercepted client reading it sees the encoded string rather than the bytes.
+Values the JSON protocols encode travel in their encoded form. A binary attribute written through a
+bundled SDK is stored base64-encoded and decodes correctly when the same path reads it back, where
+an in-process intercepted client reading it sees the encoded string.
 
 Only service API endpoints are answered this way. A request to the endpoint of one resource, such
 as a Lambda Function URL or an API Gateway HTTP API, is an ordinary HTTP request rather than a
@@ -475,8 +471,8 @@ const dryRunOutput = await lambda.invoke(
 console.log(dryRunOutput.StatusCode);
 ```
 
-`Event` invocation handler errors are dropped, as sim Lambda does not simulate asynchronous
-retries or failure destinations yet.
+`Event` invocation handler errors are dropped. Asynchronous retries and failure destinations are
+left out so far.
 
 ## Triggering a function from an SQS queue
 
@@ -484,8 +480,8 @@ An event source mapping connects a [simulated queue](../sqs/ "Simulated SQS docs
 Messages sent to the queue are delivered to the handler as an SQS event, with the `Records` shape
 real Lambda uses.
 
-Polling runs on the simulation's background scheduler, so a test awaits
-`simAws.backgroundTasksComplete()` and then asserts, rather than sleeping.
+Polling runs on the simulation's background scheduler. A test awaits
+`simAws.backgroundTasksComplete()` and then asserts, without sleeping.
 
 `BatchSize` says how many messages one invocation may be given, and defaults to 10. The queue and
 the function have to be in the same account and region, as they do on real AWS.
@@ -588,14 +584,13 @@ Each record carries `messageId`, `receiptHandle`, `body`, `md5OfBody`, `messageA
 `ApproximateReceiveCount` and `ApproximateFirstReceiveTimestamp`. `SimLambdaSqsEvent` and
 `SimLambdaSqsEventRecord` are exported from `@kensio/yulin/lambda` for typing a handler, and are
 minimal structural equivalents of the `SQSEvent` and `SQSRecord` types from the `aws-lambda` typings
-package, so a handler already written against those can be passed in unchanged. `SenderId` is not
-reported, because a simulated caller has no user or role id to report it as.
+package, and a handler already written against those can be passed in unchanged. `SenderId` is left
+out, because a simulated caller has no user or role id to report it as.
 
-Creating the mapping checks two things real Lambda checks: that the queue exists, and that the
-function's execution role is allowed `sqs:ReceiveMessage`, `sqs:DeleteMessage` and
+Creating the mapping checks the two things real Lambda checks. The queue has to exist, and the
+function's execution role has to be allowed `sqs:ReceiveMessage`, `sqs:DeleteMessage` and
 `sqs:GetQueueAttributes` on it. A role missing one of them fails with
-`InvalidParameterValueException` naming the operation, rather than leaving a mapping that quietly
-delivers nothing.
+`InvalidParameterValueException` naming the operation, before the mapping exists.
 
 `GetEventSourceMappingCommand`, `ListEventSourceMappingsCommand` and
 `DeleteEventSourceMappingCommand` read and remove mappings. A mapping is `Creating` when the command
@@ -605,7 +600,7 @@ polling.
 ### When the handler fails
 
 A handler that returns normally has handled the batch, and the messages are deleted from the queue.
-A handler that throws returns the whole batch: the messages stay on the queue, hidden until their
+A handler that throws returns the whole batch. The messages stay on the queue, hidden until their
 visibility timeout lapses, and are delivered again after that. Advancing the simulation's clock is
 what brings them back:
 
@@ -617,15 +612,15 @@ A queue with a `RedrivePolicy` eventually gives up on a message the handler keep
 moves it to the dead-letter queue, exactly as it would for any other failing consumer. See
 [dead-letter queues](../sqs/#dead-letter-queues "Simulated SQS dead-letter queue docs").
 
-The handler error itself is not reported to whoever sent the message, as it is not on real AWS. What
+The handler error itself goes unreported to whoever sent the message, as it does on real AWS. What
 the sender sees is the message coming back.
 
 ### Reporting individual message failures
 
 A queue mapping created with `FunctionResponseTypes: ["ReportBatchItemFailures"]` takes the
-`batchItemFailures` list the handler returns: the message ids named in it go back to the queue, and
+`batchItemFailures` list the handler returns. The message ids named in it go back to the queue, and
 the rest of the batch is deleted. A stream mapping takes the same list and does something else with
-it, which is [reporting individual record failures](#reporting-individual-record-failures).
+it, under [reporting individual record failures](#reporting-individual-record-failures).
 
 ```typescript
 await simAws.lambda().createEventSourceMapping(
@@ -645,14 +640,14 @@ const handler = (event: SimLambdaSqsEvent) => ({
 ```
 
 A report naming an id that was not in the batch returns the whole batch, as real Lambda does with a
-report it cannot trust. So does an entry with no `itemIdentifier`. A handler that returns nothing,
+report it cannot trust. So does an entry with no `itemIdentifier`. A handler that returns no list,
 or an empty `batchItemFailures` list, has handled the whole batch.
 
 ### Making an SQS event without a queue
 
 A test of the handler on its own, with no queue and no mapping, still has to pass it a whole event.
-`lambdaSqsEventFactory` makes one, and `lambdaSqsEventRecordFactory` makes the records in it, so
-such a test says what the messages carry and nothing else:
+`lambdaSqsEventFactory` makes one, and `lambdaSqsEventRecordFactory` makes the records in it. Such a
+test then says what the messages carry and leaves the rest to the factory:
 
 ```typescript sim-lambda-sqs-event-factory
 /**
@@ -690,17 +685,17 @@ console.log(record.awsRegion);
 
 The default is the single-message batch a quiet queue delivers. Each record is completed as a
 delivered one is, including the message id, the receipt handle and the three system `attributes` a
-simulated mapping reports. Two fields a record repeats are computed from the rest: `md5OfBody` is
-the digest of the body given, which is what a handler checking the digest compares against, and
-`awsRegion` is the Region of the queue ARN given.
+simulated mapping reports. Two fields a record repeats are computed from the rest. `md5OfBody` is
+the digest of the body given, which a handler checking the digest compares against, and `awsRegion`
+is the Region of the queue ARN given.
 
-Reporting individual failures is worth testing against a made event too: the handler's
+Reporting individual failures can be tested against a made event too. The handler's
 `batchItemFailures` name `messageId` values, and those are the ids of the records the factory made.
 
 ### Event source mappings in templates
 
-`AWS::Lambda::EventSourceMapping` deploys the same thing, which is what CDK's
-`fn.addEventSource(new SqsEventSource(queue))` emits. `EventSourceArn` and `FunctionName` accept the
+`AWS::Lambda::EventSourceMapping` deploys the same thing, and CDK's
+`fn.addEventSource(new SqsEventSource(queue))` emits one. `EventSourceArn` and `FunctionName` accept the
 `Fn::GetAtt` and `Ref` values a template gives them, `Ref` on the mapping returns its UUID, and
 `Fn::GetAtt` exposes `Id` and `EventSourceMappingArn`. A queue mapping has no `StartingPosition`, and
 a template naming one is refused. The same Resource deploys a
@@ -717,7 +712,7 @@ what the stream still holds, so changes made before the mapping existed are deli
 reads only what the table changes from the moment the mapping starts reading. `AT_TIMESTAMP` is for
 a Kinesis stream and is refused by name.
 
-`BatchSize` says how many records one invocation may be given, and defaults to 100, which is what
+`BatchSize` says how many records one invocation may be given, and defaults to 100, the number
 CDK's `DynamoEventSource` also asks for. The table and the function have to be in the same account
 and region, as they do on real AWS.
 
@@ -874,33 +869,33 @@ Each record carries `eventID`, `eventName`, `eventVersion`, `eventSource`, `awsR
 `eventSourceARN` and a `dynamodb` body holding `Keys`, the images the stream's view type selects,
 `SequenceNumber`, `SizeBytes`, `StreamViewType` and `ApproximateCreationDateTime` as whole seconds
 since the epoch. A time to live removal also carries
-`userIdentity: { type: "Service", principalId: "dynamodb.amazonaws.com" }`, which is how a handler
-tells an expiry from a deletion the application asked for. The event lower-cases those two fields
+`userIdentity: { type: "Service", principalId: "dynamodb.amazonaws.com" }`. A handler tells an
+expiry from a deletion the application asked for by that. The event lower-cases those two fields
 where [the Streams API capitalizes them](../dynamodb/#reading-a-streams-records "Simulated DynamoDB Streams docs").
 
 `SimLambdaDynamoDbStreamEvent` and `SimLambdaDynamoDbStreamEventRecord` are exported from
 `@kensio/yulin/lambda` for typing a handler, and are minimal structural equivalents of the
 `DynamoDBStreamEvent` and `DynamoDBRecord` types from the `aws-lambda` typings package.
 
-A binary attribute reaches the handler as a base64 string rather than as bytes, which is what the
-event carries on AWS: it arrives as JSON, and JSON has no bytes. `Buffer.from(value.B, "base64")`
+A binary attribute reaches the handler as a base64 string, as it does on AWS. The event arrives as
+JSON, and JSON has no bytes. `Buffer.from(value.B, "base64")`
 therefore reads the same here as it does deployed. The
 [Streams API](../dynamodb/#reading-a-streams-records "Simulated DynamoDB Streams docs") hands out
-bytes for the same attribute, because its client decodes them. Nesting makes no difference: binary
-inside a list or a map is encoded too.
+bytes for the same attribute, because its client decodes them. Nesting makes no difference, and
+binary inside a list or a map is encoded too.
 
-Creating the mapping checks what real Lambda checks: that the stream exists, and that the function's
-execution role is allowed `dynamodb:DescribeStream`, `dynamodb:GetRecords` and
+Creating the mapping checks what real Lambda checks. The stream has to exist, and the function's
+execution role has to be allowed `dynamodb:DescribeStream`, `dynamodb:GetRecords` and
 `dynamodb:GetShardIterator` on it, plus `dynamodb:ListStreams` on `*`. Those four are what both the
 AWS managed policy and CDK's own grant give a stream consumer. A role missing one of them fails with
 `InvalidParameterValueException` naming the operation.
 
 ### When the handler fails
 
-A stream is not a queue, and the difference shows here. A queue hands a message out and hides it, so
-a batch the handler threw on is the queue's problem afterwards. A stream hands out a place, and the
-mapping is the only thing that remembers it, so a batch the handler threw on is read again from
-exactly where it was and nothing behind it is delivered until it is through. That is what blocking a
+A stream behaves differently from a queue here. A queue hands a message out and hides it, and a
+batch the handler threw on becomes the queue's problem afterwards. A stream hands out a place, and
+the mapping is the only thing that remembers it. A batch the handler threw on is read again from
+exactly where it was, and everything behind it waits until it is through. That is what blocking a
 shard means.
 
 Advancing the simulation's clock is what hands the batch over again:
@@ -910,14 +905,14 @@ await simAws.clock().advanceBy({ seconds: 30 });
 ```
 
 The batch is delivered again five times, after 1, 2, 4, 8 and 16 seconds, so six deliveries in all.
-Then it is discarded and the mapping carries on with the stream, which is what AWS does once a
-stream mapping's error handling has run out.
+Then it is discarded and the mapping carries on with the stream, as AWS does once a stream mapping's
+error handling has run out.
 
 Both the cadence and the number of attempts are simulator constraints rather than AWS behaviour. AWS
 documents no delay between attempts and retries until the records age out of the stream, a day
-later. A delay of zero here would fall due at the instant the clock already reads, so a handler that
-always throws would leave `advanceBy` with work falling due forever, and waiting out a simulated day
-is the same problem with more steps.
+later. A delay of zero here would fall due at the instant the clock already reads. A handler that
+always throws would then leave `advanceBy` with work falling due forever, and waiting out a
+simulated day is the same problem with more steps.
 
 ### Reporting individual record failures
 
@@ -943,30 +938,30 @@ const handler = (event: SimLambdaDynamoDbStreamEvent) => ({
 });
 ```
 
-What a stream does with that report is not what a queue does with it. A queue takes back the
-messages the report names and deletes the rest. A stream moves its checkpoint to the lowest sequence
+A stream reads that report differently from a queue. A queue takes back the messages the report
+names and deletes the rest. A stream moves its checkpoint to the lowest sequence
 number the report names and delivers everything from there again, including the records after it
 that the handler did handle. That is real AWS behaviour rather than a simulation artifact, and it is
 why a stream consumer has to be idempotent.
 
 So a report naming only the last record of a batch delivers that record again. A report naming the
-first record delivers the whole batch again. The redelivery is a retry like any other: it waits out
+first record delivers the whole batch again. The redelivery is a retry like any other. It waits out
 the same backoff, counts against the same five attempts, and what is left is discarded when they run
 out.
 
 A report naming a sequence number that was not in the batch delivers the whole batch again, as real
 Lambda does with a report it cannot trust. So does an entry with no `itemIdentifier`. A handler that
-returns nothing, or an empty `batchItemFailures` list, has handled the whole batch. A mapping
+returns no list, or an empty `batchItemFailures` list, has handled the whole batch. A mapping
 created without `FunctionResponseTypes` ignores a report entirely.
 
 ### Writing back to the source table
 
 A handler that writes into the table whose stream invoked it is delivered its own write, which
 writes again. Real Lambda runs that loop for as long as the account is willing to pay for it. The
-simulation refuses instead, with an error naming the function, the stream and the table, rather than
-going round until the test times out.
+simulation refuses instead, with an error naming the function, the stream and the table, before the
+test times out.
 
-The write itself succeeds; the refusal comes afterwards, from whatever is waiting for the simulation
+The write itself succeeds. The refusal comes afterwards, from whatever is waiting for the simulation
 to settle:
 
 ```typescript
@@ -975,7 +970,7 @@ await simAws.backgroundTasksComplete(); // throws SimLambdaStreamCascadeError
 
 Only the handler's own writes count. Items written at the same time by the test, or by anything else
 in the simulation, are an ordinary batch however many of them there are, because the guard tells them
-apart by where the write came from rather than by when it landed.
+apart by where the write came from, and never by when it landed.
 
 Writing the projection into a second table is what the guard is asking for, and is what a real
 aggregation or search index does anyway.
@@ -1023,23 +1018,25 @@ console.log(event.Records[0]?.dynamodb.StreamViewType);
 ```
 
 The default is the single-record batch one changed item produces. What a record says in more than
-one place is computed from the rest, so it is a record a stream could have delivered: an `INSERT`
-carries a new image, a `REMOVE` an old one and a `MODIFY` both, `StreamViewType` names the images
+one place is computed from the rest, and the result is a record a stream could have delivered. An
+`INSERT` carries a new image, a `REMOVE` an old one and a `MODIFY` both, `StreamViewType` names the
+images
 the record actually carries, and `awsRegion` is the Region of the stream ARN given. A record for a
 `KEYS_ONLY` stream is one with the images explicitly taken away, as in
 `make({ dynamodb: { NewImage: undefined, OldImage: undefined } })`.
 
-`SizeBytes` is a plausible default rather than a measurement of the images given, so a test
-asserting on it should say what it expects.
+`SizeBytes` is a plausible default, and measures nothing about the images given. A test asserting
+on it should say what it expects.
 
 ### Stream mappings in templates
 
 `AWS::Lambda::EventSourceMapping` deploys a stream mapping too. `EventSourceArn` takes the
 `Fn::GetAtt … StreamArn` of a
 [streamed table](../dynamodb/#deploying-a-table-with-a-stream "Simulated DynamoDB table stream in CloudFormation docs")
-in the same template, which is also what makes the mapping wait for the table. `StartingPosition` is
-required, as it is for an SDK caller, and the properties go to `CreateEventSourceMapping` unjudged,
-so a template that gets one wrong is refused in the words the command refuses it in.
+in the same template. That reference is also what makes the mapping wait for the table.
+`StartingPosition` is required, as it is for an SDK caller, and the properties go to
+`CreateEventSourceMapping` unjudged. A template that gets one wrong is refused in the words the
+command refuses it in.
 
 ```typescript sim-lambda-cloudformation-dynamodb-event-source
 /**
@@ -1154,16 +1151,17 @@ console.log(projected); // ["order-1"]
 
 CDK's `fn.addEventSource(new DynamoEventSource(table, { startingPosition }))` synthesises exactly
 this, and deploys without hand-editing. The grant CDK writes alongside it is an inline policy with
-the three stream actions on the stream ARN and `dynamodb:ListStreams` on every stream, which is what
+the three stream actions on the stream ARN and `dynamodb:ListStreams` on every stream, exactly what
 the mapping's execution-role check is looking for.
 
-The properties a non-default `DynamoEventSource` adds are refused by name: `FilterCriteria`,
-`ParallelizationFactor`, `BisectBatchOnFunctionError`, `TumblingWindowInSeconds` and
-`DestinationConfig`.
+The properties a non-default `DynamoEventSource` adds are refused by name. Those are
+`FilterCriteria`, `ParallelizationFactor`, `BisectBatchOnFunctionError`, `TumblingWindowInSeconds`
+and `DestinationConfig`.
 
 A hand-written template or a SAM application usually gives the function the AWS managed policy
-`AWSLambdaDynamoDBExecutionRole` instead. Simulated IAM does not model managed policy ARNs, so that
-role reaches the mapping with no stream permissions and the mapping is refused when it is created.
+`AWSLambdaDynamoDBExecutionRole` instead. Simulated IAM has no model for managed policy ARNs, so
+that role reaches the mapping with no stream permissions and the mapping is refused when it is
+created.
 Write the grant as an inline policy, as the example above and CDK both do.
 
 ## Function URLs
@@ -1240,14 +1238,14 @@ try {
 
 On localhost the endpoint hostname becomes
 `<url-id>.lambda-url.<region>.sim-aws.localhost:<port>`, dropping the `.on.aws` tail the way
-simulated S3 endpoints drop `.amazonaws.com`. Requests are routed by that hostname, so a Function
-URL created in a non-default account or region reaches the right function without any extra
+simulated S3 endpoints drop `.amazonaws.com`. Requests are routed by that hostname. A Function URL
+created in a non-default account or region reaches the right function without any extra
 configuration.
 
 ### The invocation event and the response
 
 The handler receives the API Gateway HTTP API payload format 2.0 event that real Function URLs
-send, which is the only format they use:
+send, the only format they use:
 
 ```json
 {
@@ -1275,15 +1273,14 @@ A handler can answer in either of the two shapes real Lambda accepts:
 - any other value, which becomes a `200` JSON response, as in
   `return { greeting: "hello" }`
 
-If the handler throws, the endpoint answers `502` with an AWS-like error document rather than the
-handler's error, which stays visible to the test as the thrown error would be through
-`InvokeCommand`.
+If the handler throws, the endpoint answers `502` with an AWS-like error document. The handler's
+error stays visible to the test, as the thrown error would be through `InvokeCommand`.
 
 ### Making an invocation event without a request
 
 A test of the handler on its own, with no endpoint serving it, still has to pass it a whole event.
-`lambdaFunctionUrlEventFactory` makes one, so such a test says what the request was and nothing
-else:
+`lambdaFunctionUrlEventFactory` makes one. Such a test then says what the request was and leaves the
+rest to the factory:
 
 ```typescript sim-lambda-function-url-event-factory
 /**
@@ -1333,9 +1330,9 @@ console.log(
 ```
 
 The defaults describe an anonymous `GET /` to a `NONE` auth Function URL, down to the headers AWS
-stamps on a proxied request, so a handler reading `host`, `x-forwarded-for` or `x-amzn-trace-id`
-finds what it would find on AWS. The fields a Function URL invocation never carries —
-`pathParameters` and `stageVariables` — are absent rather than empty, as they are in a served event.
+stamps on a proxied request. A handler reading `host`, `x-forwarded-for` or `x-amzn-trace-id` finds
+what it would find on AWS. The fields a Function URL invocation never carries (`pathParameters` and
+`stageVariables`) are absent, as they are in a served event.
 
 A real event says several things twice, and the factory computes its defaults from the overrides so
 that supplying either copy sets both:
@@ -1348,40 +1345,40 @@ that supplying either copy sets both:
 | the caller            | `requestContext.http.sourceIp` and `userAgent`, the `x-forwarded-for` and `user-agent` headers    |
 | the time              | `requestContext.timeEpoch` and the Common Log Format `requestContext.time`                        |
 
-So `make({ rawPath: "/user/status" })` is a request for `/user/status` in both places, rather than
-one for `/user/status` that the request context still calls `/`. Overriding both copies with
-different values is still allowed, for a test that wants an event no real invocation produces.
+So `make({ rawPath: "/user/status" })` is a request for `/user/status` in both places, and the
+request context follows the override. Overriding both copies with different values is still allowed,
+for a test that wants an event no real invocation produces.
 
 The same events go to a handler through
 [the API Gateway HTTP API](../apigatewayv2/ "Simulated API Gateway HTTP API usage docs") too, where
 the route key, the stage and the path parameters are the endpoint's rather than a Function URL's
-`$default`, so an event for one of those is this factory with those fields overridden.
+`$default`. An event for one of those is this factory with those fields overridden.
 
 ### Managing a Function URL
 
 `GetFunctionUrlConfigCommand` reads the configuration back, `UpdateFunctionUrlConfigCommand`
 changes the `AuthType` or `InvokeMode` while keeping the same endpoint, and
 `DeleteFunctionUrlConfigCommand` removes it, after which the hostname stops resolving and returns
-`404`. `ListFunctionUrlConfigsCommand` lists what a function has, which is either nothing or one
-configuration, since a function has at most one Function URL.
+`404`. `ListFunctionUrlConfigsCommand` lists what a function has, which is one configuration or
+none, since a function has at most one Function URL.
 
 ### IAM-authenticated Function URLs
 
 A URL created with `AuthType: "AWS_IAM"` invokes the function only for a caller allowed
 `lambda:InvokeFunctionUrl` on the function ARN, and answers `403` otherwise. That is a different
-action from `lambda:InvokeFunction`, which the Invoke API uses: real AWS separates the two so a
+action from `lambda:InvokeFunction`, which the Invoke API uses. Real AWS separates the two so a
 policy can grant the HTTP endpoint without granting the SDK operation, and a policy naming only one
-of them does not grant the other here either.
+of them grants only that one here as well.
 
 The caller comes from the request itself, through either a SigV4 signature or an `x-sim-aws-caller`
-header naming a principal directly. A request that offers neither is anonymous, owns no policies, and
-is refused. See [callers of HTTP requests](../iam/#callers-of-http-requests) in the IAM docs for how
+header naming a principal directly. A request that offers no caller at all is anonymous, owns no
+policies, and is refused. See [callers of HTTP requests](../iam/#callers-of-http-requests) in the IAM docs for how
 that resolution works and how to sign a served request.
 
 A grant conditioned on `AWS:SourceArn` or `AWS:SourceAccount` is evaluated against what the request
-says it is being made for, which is how a permission granting `cloudfront.amazonaws.com` names one
+says it is being made for. That is how a permission granting `cloudfront.amazonaws.com` names one
 Distribution. Sim CloudFront states that itself when it reaches a Function URL Origin through an
-origin access control, so a Function URL behind a Distribution runs for that Distribution and
+origin access control, and a Function URL behind a Distribution runs for that Distribution and
 refuses everything else. See
 [origin access controls](../cloudfront/README.md#origin-access-controls) in the CloudFront docs.
 
@@ -1396,14 +1393,15 @@ CloudFront docs.
 
 CloudFront is the exception to the two actions being separate. A request from
 `cloudfront.amazonaws.com` is authorized against `lambda:InvokeFunctionUrl` and
-`lambda:InvokeFunction`, and needs a grant for both, which is what real Lambda asks an origin access
+`lambda:InvokeFunction`, and needs a grant for both, exactly what real Lambda asks an origin access
 control for. A caller signing its own request still needs only `lambda:InvokeFunctionUrl`.
 
-An `AWS_IAM` invocation carries its caller into the event as
-`requestContext.authorizer.iam`, which is the part a handler reads. The `authorizer` block is absent
-for a `NONE` invocation, as it is on real AWS, and `requestContext.accountId` is the caller's Account
-rather than `anonymous`. The block is shared with simulated API Gateway HTTP APIs, whose JWT
-authorizers would fill a `jwt` member instead, so `iam` is optional on the type.
+An `AWS_IAM` invocation carries its caller into the event as `requestContext.authorizer.iam`, the
+part a handler reads. The `authorizer` block is absent for a `NONE` invocation, as it is on real
+AWS, and `requestContext.accountId` carries the caller's Account, where a `NONE` invocation reports
+`anonymous`. The block is
+shared with simulated API Gateway HTTP APIs, whose JWT authorizers would fill a `jwt` member
+instead, and `iam` is optional on the type.
 
 ```typescript sim-lambda-function-url-iam-auth
 /**
@@ -1500,15 +1498,15 @@ try {
 ## Resource-based policies
 
 A function's resource-based policy is the other half of Lambda authorization. An identity policy
-says what a principal may do; a resource policy says who may act on the function. Either one is
-enough to allow a call within the same Account. A principal from another Account needs both: the
-grant on the function, and an identity policy in its own Account allowing the action, which is how
-AWS decides a cross-Account request. See
+says what a principal may do, and a resource policy says who may act on the function. Either one is
+enough to allow a call within the same Account. A principal from another Account needs both, the
+grant on the function and an identity policy in its own Account allowing the action. That is how AWS
+decides a cross-Account request. See
 [Cross-Account requests](../iam/README.md#cross-account-requests).
 
 `AddPermissionCommand` grants a statement, `RemovePermissionCommand` revokes it by `StatementId`,
-and `GetPolicyCommand` returns the assembled document. `AddPermission` is a shorthand: Lambda expands
-its parts into one statement, so reading that statement back shows what the grant means:
+and `GetPolicyCommand` returns the assembled document. `AddPermission` is a shorthand. Lambda expands
+its parts into one statement, and reading that statement back shows what the grant means:
 
 ```typescript sim-lambda-add-permission
 /**
@@ -1554,32 +1552,32 @@ const policy = await simAws
 console.log(policy.Policy);
 ```
 
-`Principal` takes the same shorthand real Lambda does, and is expanded the same way: a 12-digit
+`Principal` takes the same shorthand real Lambda does, and is expanded the same way. A 12-digit
 Account id becomes `{"AWS": "arn:aws:iam::<id>:root"}`, an ARN becomes `{"AWS": "<arn>"}`, anything
 else is read as a service principal, and `*` stays `*`.
 
-`FunctionUrlAuthType` becomes a `lambda:FunctionUrlAuthType` condition, which is evaluated when a
-Function URL is invoked. That is what a Function URL grant conditions on in practice: a permission
-granted for `AWS_IAM` does not also open a URL later switched to `NONE`.
+`FunctionUrlAuthType` becomes a `lambda:FunctionUrlAuthType` condition, evaluated when a Function
+URL is invoked. That is what a Function URL grant conditions on in practice. A permission granted
+for `AWS_IAM` leaves a URL later switched to `NONE` closed.
 
 `SourceArn` becomes an `ArnLike` condition on `AWS:SourceArn`, and `SourceAccount` a `StringEquals`
 condition on `AWS:SourceAccount`. Both are evaluated when another simulated service invokes the
-function: a simulated API Gateway HTTP API invoking it through a Lambda proxy integration or as a
-`REQUEST` authorizer, a simulated S3 Bucket delivering an event notification, and a simulated
+function. That is a simulated API Gateway HTTP API invoking it through a Lambda proxy integration or
+as a `REQUEST` authorizer, a simulated S3 Bucket delivering an event notification, or a simulated
 Cognito user pool running a Lambda trigger. The source ARN is what that service is invoking the
-function for — the API, the Bucket or the user pool — and the source Account is that service's
+function for (the API, the Bucket or the user pool) and the source Account is that service's
 resource's own. See
 [Granting the API permission to invoke the function](../apigatewayv2/README.md#granting-the-api-permission-to-invoke-the-function)
 and [Lambda triggers](../cognito/README.md#lambda-triggers).
-A direct `Invoke`, a Function URL request and an SQS event source mapping supply neither, so a
-statement carrying one does not match them.
+A direct `Invoke`, a Function URL request and an SQS event source mapping supply no value for
+either, and a statement carrying one of them matches none of the three.
 
 `PrincipalOrgID` and `InvokedViaFunctionUrl` are written into the statement so `GetPolicy` reports
-the grant that was made, but nothing supplies a value for them at request time, so a statement
-carrying one of those never matches.
+the grant that was made. No value is supplied for them at request time, and a statement carrying one
+of those never matches.
 
-A function that has been granted nothing has no policy at all, which `GetPolicy` reports as a
-`ResourceNotFoundException` rather than as an empty document. Granting a `StatementId` that is
+A function with no grant on it has no policy at all. `GetPolicy` reports that as a
+`ResourceNotFoundException`, and never as an empty document. Granting a `StatementId` that is
 already in use is a `ResourceConflictException`, and removing one that was never granted is a
 `ResourceNotFoundException`, as on AWS.
 
@@ -1587,7 +1585,7 @@ already in use is a `ResourceConflictException`, and removing one that was never
 
 `AWS::Lambda::Permission` creates the same permission from a CloudFormation template, which matters
 because CDK emits one for every `grantInvoke` and `grantInvokeUrl` to a principal outside the
-stack's own Account. The Resource has no `StatementId` property: CloudFormation names the statement
+stack's own Account. The Resource has no `StatementId` property. CloudFormation names the statement
 after the logical ID, and so does this.
 
 ```json
@@ -1613,9 +1611,9 @@ A function can declare its own environment variables with `Environment.Variables
 Lambda. While the function runs, its code reads those variables from `process.env`, alongside the
 AWS-provided runtime variables (`AWS_REGION`, `AWS_LAMBDA_FUNCTION_NAME`, and the rest). Those
 include placeholder execution role credentials in `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and
-`AWS_SESSION_TOKEN`, which is where an AWS SDK in the function code finds credentials, as it does
-on real Lambda. Nothing authorizes against their values: a call from function code is attributed to
-the execution Role because the invocation is running as it.
+`AWS_SESSION_TOKEN`, where an AWS SDK in the function code finds credentials, as it does on real
+Lambda. Their values authorize nothing. A call from function code is attributed to the execution
+Role because the invocation is running as it.
 
 ```typescript sim-lambda-environment-variables
 /**
@@ -1663,7 +1661,7 @@ console.log(Buffer.from(invokeOutput.Payload).toString());
 ```
 
 Each function gets only the variables it declares. Variables that happen to be set in the process
-running your tests are not visible to it, so a function cannot accidentally pass because your
+running your tests stay invisible to it, and a function cannot accidentally pass because your
 shell or CI environment had the right variable set. Two functions declaring the same variable name
 with different values each see their own, including when their invocations overlap.
 
@@ -1671,21 +1669,21 @@ The same applies to zip-packaged code in the vm runtime and to functions deploye
 `AWS::Lambda::Function` template with an `Environment` property, including ones backed by an
 [executable binding](#executable-bindings).
 
-This is also how a function reaches something Yulin does not simulate, such as a Redis or a
+This is also how a function reaches something outside the simulation, such as a Redis or a
 Postgres. See [non-AWS dependencies](../../non-aws-dependencies/README.md).
 
 Variable names are validated as on real AWS. A name must match the Lambda name pattern
 `[a-zA-Z]([a-zA-Z0-9_])+`, meaning it starts with a letter, is at least two characters, and otherwise
-holds letters, digits and underscores. A name that does not match is rejected with
+holds letters, digits and underscores. A name breaking that pattern is rejected with
 `ValidationException`. The names Lambda reserves for the runtime (`AWS_REGION`,
 `AWS_LAMBDA_FUNCTION_NAME`, `LAMBDA_TASK_ROOT` and so on) cannot be declared, and are rejected with
-`InvalidParameterValueException`. As on AWS, the pattern is checked first, so a reserved name that
+`InvalidParameterValueException`. As on AWS, the pattern is checked first, and a reserved name that
 also breaks it, such as `_HANDLER`, is reported as the constraint violation.
 
 ### Read environment variables inside the handler
 
 A function backed by a real in-process handler behaves differently here. That handler is an ordinary
-function in your test process rather than code loaded into a sandbox, so it only gets the function's
+function in your test process rather than code loaded into a sandbox. It only gets the function's
 own `process.env` while it is actually running.
 
 That means a variable read at module scope is read too early:
@@ -1704,25 +1702,24 @@ export const handler = async () => {
 Moving the read inside the handler fixes it. Zip code in the vm runtime is unaffected, because it is
 imported at cold start, during an invocation.
 
-This often does not come up, because test suites commonly export the same variables they configure
-their functions with, and then a module-scope read gets the right value anyway. Sim Lambda warns on
-the console when that is not the case, in the two situations where the difference changes what your
-code sees:
+This rarely comes up, because test suites commonly export the same variables they configure their
+functions with, and then a module-scope read gets the right value anyway. Sim Lambda warns on the
+console in the two situations where the difference changes what your code sees:
 
 - a declared variable whose name the host process also sets, with a different value
 - two simulated functions declaring the same variable name with different values
 
 ## The time inside a handler
 
-A function runs on its simulation's clock, and so does the function code: `Date.now()` and
-`new Date()` inside a handler report simulated time rather than the host's. Freezing the clock
-gives an invocation a constant `Date.now()`, and advancing it changes what the next invocation
-reads. `context.getRemainingTimeInMillis()` counts down against the same clock, so a frozen clock
-leaves a handler with a constant budget rather than one draining in real time.
+A function runs on its simulation's clock, and so does the function code. `Date.now()` and
+`new Date()` inside a handler report simulated time. Freezing the clock gives an invocation a
+constant `Date.now()`, and advancing it changes what the next invocation reads.
+`context.getRemainingTimeInMillis()` counts down against the same clock. A frozen clock leaves a
+handler with a constant budget, where it would otherwise drain in real time.
 
 Zip code gets this from its own vm sandbox. A real in-process handler gets it from a substituted
 global `Date` that reports the invocation's clock while an invocation is running and the host clock
-otherwise, so a time read at module scope is read too early, exactly as it is for environment
+otherwise. A time read at module scope is therefore read too early, exactly as it is for environment
 variables. See [simulated time](../../time/README.md) for the whole picture, including where real
 AWS puts the time on the event.
 
@@ -1817,7 +1814,7 @@ For `AWS::Lambda::Function`, `Ref` returns the function name and `Fn::GetAtt` su
 Supported function properties:
 
 - `FunctionName` (defaults to the logical ID)
-- `Role` (typically a `Ref`/`Fn::GetAtt` to a same-stack `AWS::IAM::Role`; both resolve to the
+- `Role` (typically a `Ref`/`Fn::GetAtt` to a same-stack `AWS::IAM::Role`, both resolving to the
   role's ARN)
 - `Code` (inline `ZipFile` source string, or `S3Bucket`/`S3Key` fetched from same-scope sim S3)
 - `Handler`
@@ -1841,38 +1838,37 @@ Both shapes of staged asset are published. A handler directory is zipped on the 
 as `cdk-assets` zips it on the way to a real bucket. An asset that is already an archive, such as
 `Code.fromAsset("handler.zip")` or a bundler's archived output, is published as it stands.
 
-Asset code runs under the same rules as any other sim Lambda code: modules are evaluated as
+Asset code runs under the same rules as any other sim Lambda code. Modules are evaluated as
 CommonJS in a vm, so everything the handler imports has to be in the asset, and only Node.js
 runtimes are simulated.
 
-Two cases are skipped with a diagnostic rather than failing the stack:
+Two cases are skipped with a diagnostic, and the stack deploys around them:
 
 - A function declaring a non-Node.js `Runtime`, such as the Python provider function CDK
   synthesizes for `BucketDeployment`. Sim CloudFormation simulates that custom resource directly,
   so its provider never needs to run. Bind a real in-process handler to simulate a function whose
   runtime Yulin cannot run.
 - A CDK-shaped template deployed without its cloud assembly, such as a template object passed
-  inline to `deployTemplate`, where there is no asset to publish and the staging bucket does not
-  exist.
+  inline to `deployTemplate`, where there is no asset to publish and no staging bucket.
 
 ### Container image functions
 
-A function with `PackageType: Image` names a container image instead of code, which is what CDK's
-`DockerImageFunction` and `lambda.DockerImageCode` synthesize. Yulin never reads an image, so there
-is nothing for it to run. The Resource is skipped with a diagnostic naming the image, and the rest
-of the stack deploys.
+A function with `PackageType: Image` names a container image instead of code, as CDK's
+`DockerImageFunction` and `lambda.DockerImageCode` synthesize it. Yulin never reads an image, and
+has nothing to run. The Resource is skipped with a diagnostic naming the image, and the rest of the
+stack deploys.
 
 There are two ways to give that function a real in-process handler to run instead, and they suit
 different shapes of test:
 
-- Bind one to the function for this deploy, which is the same mechanism as
-  [executable bindings](#executable-bindings) and is shown below.
+- Bind one to the function for this deploy, the same mechanism as
+  [executable bindings](#executable-bindings) and shown below.
 - Register one as the image in a
-  [simulated ECR repository](../ecr/ "Simulated ECR usage docs"), which is a standing statement
-  about what that image is, made once and good for every stack that runs it, and for a function
-  created directly through `CreateFunction`.
+  [simulated ECR repository](../ecr/ "Simulated ECR usage docs"). That is a standing statement about
+  what the image is, made once and good for every stack that runs it, and for a function created
+  directly through `CreateFunction`.
 
-Either way the handler replaces the image, so the function is created and invoked like any other. A
+Either way the handler replaces the image, and the function is created and invoked like any other. A
 binding is looked at first, because it is about one deploy where a repository is about the image
 everywhere.
 
@@ -1951,13 +1947,14 @@ running that image without repeating the binding per stack. See
 [binding by container image repository](#binding-by-container-image-repository).
 
 The skip reason says what was looked for. An image whose repository no simulated ECR holds is
-reported apart from one whose repository holds no image, since those send you to different places:
-a repository name that does not agree with the template, or a handler that was never registered.
+reported apart from one whose repository holds no image, since those send you to different places.
+The first is a repository name disagreeing with the template, and the second a handler that was
+never registered.
 
 ## Function URLs in templates
 
-`AWS::Lambda::Url` creates a Function URL for a deployed function, which is what CDK's
-`Function.addFunctionUrl(...)` emits. `TargetFunctionArn` accepts either an `Fn::GetAtt` ARN or a
+`AWS::Lambda::Url` creates a Function URL for a deployed function, and CDK's
+`Function.addFunctionUrl(...)` emits one. `TargetFunctionArn` accepts either an `Fn::GetAtt` ARN or a
 `Ref` to the function, and `Fn::GetAtt` on the URL exposes `FunctionUrl` and `FunctionArn`.
 
 ```typescript sim-lambda-cloudformation-function-url
@@ -2033,10 +2030,10 @@ try {
 }
 ```
 
-CDK templates work the same way: synth the app, deploy the template file, and read
-`functionUrl.url` from the stack outputs. Note that CDK pairs a public Function URL with an
-`AWS::Lambda::Permission`, which is not simulated and is skipped with a diagnostic rather than
-failing the deployment.
+CDK templates work the same way. Synth the app, deploy the template file, and read
+`functionUrl.url` from the stack outputs. CDK pairs a public Function URL with an
+`AWS::Lambda::Permission`, which deploys alongside it as
+[permissions in templates](#permissions-in-templates) covers.
 
 ## Executable bindings
 
@@ -2098,19 +2095,19 @@ await simAws.backgroundTasksComplete();
 A binding can target the function by `logicalId` (which also matches a CDK construct ID from
 `aws:cdk:path` metadata), by `functionName`, by `arn`, by full `cdkPath`, or by `imageRepository`
 for a function packaged as a container image. A bound function may omit template `Code` and
-`Handler` entirely; unbound functions in the same template keep their template code on the vm path.
-A binding that does not resolve to any template resource fails the deploy with the unmatched target
+`Handler` entirely, and unbound functions in the same template keep their template code on the vm
+path. A binding that resolves to no template resource fails the deploy with the unmatched target
 named for diagnosis. Where two bindings could both back the same function, the one listed first is
 the one that backs it.
 
 ### Binding by container image repository
 
 `imageRepository` matches any function whose resolved `Code.ImageUri` names that repository. One
-binding covers every function running that image, in every stack deployed from the same `SimAws`,
-rather than naming a logical ID that belongs to one construct tree.
+binding covers every function running that image, in every stack deployed from the same `SimAws`.
+A logical ID belongs to one construct tree.
 
-The image tag is ignored on both sides of the match. No tag is stable enough to write into a test:
-a CDK image asset is tagged with the asset content hash, which changes whenever the image source
+The image tag is ignored on both sides of the match. No tag is stable enough to write into a test.
+A CDK image asset is tagged with the asset content hash, which changes whenever the image source
 does, and a pipeline-built image is usually tagged with a git sha or a build number passed in as a
 stack parameter. The registry host is part of the repository, so the account and region have to
 match too, and an `ImageUri` built by `Fn::Sub` or from a stack parameter is matched on what it
@@ -2176,7 +2173,7 @@ console.log(Buffer.from(output.Payload).toString());
 await simAws.backgroundTasksComplete();
 ```
 
-A function matched this way is created from the bound handler, so it never reaches the
+A function matched this way is created from the bound handler, and never reaches the
 [container image skip](#container-image-functions). Functions in the same template running an image
 from another repository are skipped as usual.
 
@@ -2237,92 +2234,91 @@ Current documented limitations:
 
 - Only `CreateFunctionCommand`, `GetFunctionCommand`, `InvokeCommand`, the permission commands
   (`AddPermissionCommand`, `RemovePermissionCommand`, `GetPolicyCommand`), the Function URL config
-  commands and the event source mapping commands are supported. There is no `UpdateFunctionCode`,
-  `DeleteFunction`, or function listing yet.
-- A cross-account grant is only half of what admits a call: the caller's own Account has to allow
+  commands and the event source mapping commands are supported. `UpdateFunctionCode`,
+  `DeleteFunction` and function listing are absent so far.
+- A cross-account grant is only half of what admits a call. The caller's own Account has to allow
   the action too, and its IAM has to be part of the same `SimAws` instance for its policies to be
-  found. A caller from an Account the simulation knows nothing about is denied.
+  found. A caller from an Account outside the simulation is denied.
 - `lambda:FunctionUrlAuthType`, `AWS:SourceArn` and `AWS:SourceAccount` are the only condition keys
   given a value at request time, the first when a Function URL is invoked and the other two when a
   simulated API Gateway HTTP API invokes the function. `PrincipalOrgID` and `InvokedViaFunctionUrl`
-  are written into the statement so `GetPolicy` reports the grant that was made, but nothing supplies
-  a value for them, so a statement carrying one never matches. Neither does a `SourceArn` or
+  are written into the statement so `GetPolicy` reports the grant that was made, and no value is
+  supplied for them, so a statement carrying one never matches. The same goes for a `SourceArn` or
   `SourceAccount` statement on a request from anything but an HTTP API.
-- `Qualifier`, `RevisionId` and `EventSourceToken` on the permission commands are not simulated,
-  as versions and aliases are not.
+- `Qualifier`, `RevisionId` and `EventSourceToken` on the permission commands are left out, along
+  with versions and aliases.
 - `requestContext.authorizer.iam` reports `accessKey` as empty, and `callerId` and `userId` as the
   caller ARN rather than the opaque unique id real AWS uses. `cognitoIdentity` and `principalOrgId`
   are always null.
-- The Function URL `Cors` configuration is not simulated, including OPTIONS preflight handling.
+- The Function URL `Cors` configuration is left out, including OPTIONS preflight handling.
 - `InvokeMode: "RESPONSE_STREAM"` is accepted and reported, but responses are always served
   buffered.
-- A function has at most one Function URL, and qualified (version or alias) Function URLs are not
-  simulated.
-- Function versions, aliases, and qualifiers are not simulated (`Version` is always `$LATEST`).
-- The vm runtime supports CommonJS function code only; ES module source (`.mjs` / `export`
-  syntax) is not supported yet.
+- A function has at most one Function URL, and qualified (version or alias) Function URLs are left
+  out.
+- Function versions, aliases, and qualifiers are left out (`Version` is always `$LATEST`).
+- The vm runtime supports CommonJS function code only. ES module source (`.mjs` / `export` syntax)
+  has yet to land.
 - Only zip-packaged code has its output recorded into a log group. A function backed by a handler
   function reference, including a container image binding, writes to the host console directly and
-  is not recorded, so a test asserting on its output still has to capture the host stream. See
+  goes unrecorded, so a test asserting on its output still has to capture the host stream. See
   [What a handler prints](#what-a-handler-prints).
-- Nothing writes the platform `START`, `END` and `REPORT` lines a real log stream carries, and
+- The platform `START`, `END` and `REPORT` lines a real log stream carries are left out, and
   execution environments are never recycled, so a function keeps one log stream for as long as it
   exists.
-- Container image functions are not run. Yulin never reads a container image, and stays Docker-free.
+- Container image functions are never run. Yulin never reads a container image, and stays
+  Docker-free.
   A function with `PackageType: Image` is skipped, or refused on `CreateFunction`, unless a real
-  in-process handler stands in for its image: one bound to it, or one registered in the
+  in-process handler stands in for its image, either one bound to it or one registered in the
   [simulated ECR](../ecr/ "Simulated ECR usage docs") repository the image URI names. See
   [Container image functions](#container-image-functions).
-- Lambda Layers are not simulated.
+- Lambda Layers are left out.
 - Environment variables declared with `Environment.Variables` reach a real in-process handler
   function only while it runs, so a variable read at module scope sees the host process value
   instead. See [Environment variables](#environment-variables).
-- `Timeout` is recorded but does not interrupt handler execution.
-- Timers inside a handler are host timers: `setTimeout` waits in real time, and advancing the
-  simulation's clock does not release a sleeping handler.
+- `Timeout` is recorded and never interrupts handler execution.
+- Timers inside a handler are host timers. `setTimeout` waits in real time, and advancing the
+  simulation's clock leaves a sleeping handler asleep.
 - A time read at module scope, like an environment variable read there, is read before any
   invocation and sees the host clock. See [The time inside a handler](#the-time-inside-a-handler).
-- `Event` invocations do not simulate retries or failure destinations; handler errors are dropped.
+- `Event` invocation retries and failure destinations are left out, and handler errors are dropped.
 - `Code.S3ObjectVersion` is accepted but ignored, as sim S3 has no object versioning yet.
 - SQS queues and DynamoDB streams are the only event sources. Kinesis, Kafka and DocumentDB sources
-  are refused rather than accepted and never delivered from, and so are `FilterCriteria`,
+  are refused outright, and so are `FilterCriteria`,
   `ScalingConfig`, `DestinationConfig`, `MaximumRetryAttempts`, `BisectBatchOnFunctionError`,
   `ParallelizationFactor`, `TumblingWindowInSeconds` and the other mapping inputs this simulation
   has no behaviour for.
-- A stream batch is delivered again five times, after 1, 2, 4, 8 and 16 seconds, and then
-  discarded. AWS
-  documents no delay between attempts and retries until the records age out. Both differences are
-  deliberate: a delay of zero falls due at the instant the clock already reads, so a handler that
-  always throws would leave `advanceBy` with work falling due forever. A batch item failure report
-  counts against the same five attempts, rather than starting them again for the records it rewound
-  to.
+- A stream batch is delivered again five times, after 1, 2, 4, 8 and 16 seconds, and then discarded.
+  AWS documents no delay between attempts and retries until the records age out. Both differences
+  are deliberate. A delay of zero falls due at the instant the clock already reads, and a handler
+  that always throws would leave `advanceBy` with work falling due forever. A batch item failure
+  report counts against the same five attempts, and never starts them again for the records it
+  rewound to.
 - A handler writing into the table whose stream invoked it is refused with
   `SimLambdaStreamCascadeError` rather than being delivered its own writes forever. Real Lambda runs
   that loop.
 - A shard iterator never expires, where a real one is good for 15 minutes.
-- `MaximumBatchingWindowInSeconds` is only simulated as 0: a partial batch is delivered as soon as
-  anything is on the event source, so a batching window would have nothing to wait for. A non-zero
-  value is refused, which also caps a queue mapping's `BatchSize` at 10. The documented rule that a
-  `BatchSize` above 10 needs a batching window is not enforced, because the same AWS documentation
+- `MaximumBatchingWindowInSeconds` is only simulated as 0. A partial batch is delivered as soon as
+  anything is on the event source, leaving a batching window nothing to wait for. A non-zero value
+  is refused, which also caps a queue mapping's `BatchSize` at 10. The documented rule that a
+  `BatchSize` above 10 needs a batching window goes unenforced, because the same AWS documentation
   gives a stream mapping `BatchSize` 100 and window 0 as simultaneous defaults, and CDK emits
   exactly that.
 - An execution role that gets its stream permissions from the AWS managed policy
-  `AWSLambdaDynamoDBExecutionRole` has none here, since simulated IAM does not model managed policy
-  ARNs, so the mapping is refused when it is created. A hand-written template and a SAM application
+  `AWSLambdaDynamoDBExecutionRole` has none here, since simulated IAM has no model for managed
+  policy ARNs, so the mapping is refused when it is created. A hand-written template and a SAM application
   usually attach that policy where CDK writes an inline one, so the two declaration paths differ.
   Write the grant inline to deploy either.
-- `UpdateEventSourceMapping` is not supported, so a mapping's batch size or enabled state is fixed
-  once it is created. `Enabled: false` at creation is simulated.
+- `UpdateEventSourceMapping` is absent, and a mapping's batch size or enabled state is fixed once it
+  is created. `Enabled: false` at creation is simulated.
 - One poll delivers one batch. Real Lambda runs several pollers at once and scales them with the
-  event source, so nothing here shows what concurrency does to ordering or to a downstream service.
-  A simulated stream has one shard and never splits, so a stream mapping has one thing to read
+  event source, and what that concurrency does to ordering or to a downstream service is invisible
+  here. A simulated stream has one shard and never splits, so a stream mapping has one thing to read
   either way.
 - CloudFormation resource types other than `AWS::Lambda::Function`, `AWS::Lambda::Url`,
   `AWS::Lambda::Permission` and `AWS::Lambda::EventSourceMapping` (`Version`, `Alias`, ...) are
   skipped with an "Unsupported" diagnostic.
-- The `vm` context is a namespacing convenience, not a security boundary: function code runs
+- The `vm` context is a namespacing convenience rather than a security boundary. Function code runs
   in-process with the same trust as the test suite itself. Do not run untrusted code through the
   simulator.
-- Only Function URLs are served over HTTP by `serveSimAws`; the Lambda control-plane API itself is
-  not served, so SDK commands go through `SimAws` or [SDK interception](../../sdk/) rather than
-  over the local server.
+- Only Function URLs are served over HTTP by `serveSimAws`. The Lambda control-plane API itself is
+  not served, and SDK commands go through `SimAws` or [SDK interception](../../sdk/) instead.

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -1562,15 +1562,17 @@ for `AWS_IAM` leaves a URL later switched to `NONE` closed.
 
 `SourceArn` becomes an `ArnLike` condition on `AWS:SourceArn`, and `SourceAccount` a `StringEquals`
 condition on `AWS:SourceAccount`. Both are evaluated when another simulated service invokes the
-function. That is a simulated API Gateway HTTP API invoking it through a Lambda proxy integration or
-as a `REQUEST` authorizer, a simulated S3 Bucket delivering an event notification, or a simulated
-Cognito user pool running a Lambda trigger. The source ARN is what that service is invoking the
-function for (the API, the Bucket or the user pool) and the source Account is that service's
-resource's own. See
+function on a resource's behalf, and every simulated service that does so supplies them. That covers
+a simulated API Gateway HTTP API invoking it through a Lambda proxy integration or as a `REQUEST`
+authorizer, a simulated S3 Bucket delivering an event notification, a simulated SNS topic delivering
+a message, a simulated Cognito user pool running a Lambda trigger, and an EventBridge or ELBv2
+target. The source ARN is what that service is invoking the function for, and the source Account is
+that service's resource's own. See
 [Granting the API permission to invoke the function](../apigatewayv2/README.md#granting-the-api-permission-to-invoke-the-function)
-and [Lambda triggers](../cognito/README.md#lambda-triggers).
-A direct `Invoke`, a Function URL request and an SQS event source mapping supply no value for
-either, and a statement carrying one of them matches none of the three.
+and [Lambda triggers](../cognito/README.md#lambda-triggers). A served Function URL request carries a
+source ARN when it says what it is being made for, which is how a CloudFront origin access control
+reaches one. A direct `Invoke` and an SQS event source mapping supply no value for either, and a
+statement carrying one matches no request of theirs.
 
 `PrincipalOrgID` and `InvokedViaFunctionUrl` are written into the statement so `GetPolicy` reports
 the grant that was made. No value is supplied for them at request time, and a statement carrying one
@@ -2240,11 +2242,12 @@ Current documented limitations:
   the action too, and its IAM has to be part of the same `SimAws` instance for its policies to be
   found. A caller from an Account outside the simulation is denied.
 - `lambda:FunctionUrlAuthType`, `AWS:SourceArn` and `AWS:SourceAccount` are the only condition keys
-  given a value at request time, the first when a Function URL is invoked and the other two when a
-  simulated API Gateway HTTP API invokes the function. `PrincipalOrgID` and `InvokedViaFunctionUrl`
-  are written into the statement so `GetPolicy` reports the grant that was made, and no value is
-  supplied for them, so a statement carrying one never matches. The same goes for a `SourceArn` or
-  `SourceAccount` statement on a request from anything but an HTTP API.
+  given a value at request time. The first is supplied when a Function URL is invoked, and the other
+  two when another simulated service invokes the function on a resource's behalf. See
+  [Resource-based policies](#resource-based-policies) for which paths those are.
+  `PrincipalOrgID` and `InvokedViaFunctionUrl` are written into the statement so `GetPolicy` reports
+  the grant that was made, and no value is supplied for them, so a statement carrying one never
+  matches.
 - `Qualifier`, `RevisionId` and `EventSourceToken` on the permission commands are left out, along
   with versions and aliases.
 - `requestContext.authorizer.iam` reports `accessKey` as empty, and `callerId` and `userId` as the

--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -107,8 +107,8 @@ await scopedS3.createBucket(
 Within one `SimAws` instance, Bucket names are globally registered across Accounts and Regions.
 Creating a Bucket with a name already used in another simulated Region or Account throws an error.
 
-Each `SimAws` instance has its own isolated state, so you can create a fresh `SimAws` instance per
-test or share one across all tests as you prefer.
+Each `SimAws` instance has its own isolated state. Create a fresh one per test or share one across
+all tests, as you prefer.
 
 ## Listing Buckets
 
@@ -192,14 +192,14 @@ Listings are sorted by key, and a page holds at most 1,000 keys, as in real S3. 
 is lowered to it, and the response reports the page size that was actually used. A `MaxKeys` of zero
 returns no keys and completes the listing, and a negative one is refused with `InvalidArgument`.
 
-A listing that found no keys has no `Contents` at all rather than an empty one, which is why the
-example reaches for `Contents ?? []`. `KeyCount` is the count either way.
+A listing that found no keys has no `Contents` at all, and the example reaches for `Contents ?? []`
+for that reason. `KeyCount` is the count either way.
 
 ### Walking a truncated listing
 
 A truncated response carries `NextContinuationToken`, which the next request passes as
-`ContinuationToken`. The token is opaque, as it is in real S3: pass it back unchanged rather than
-reading anything out of it, and simulated S3 refuses one it did not issue.
+`ContinuationToken`. The token is opaque, as it is in real S3. Pass it back unchanged, read nothing
+out of it, and simulated S3 refuses one it did not issue.
 
 ```typescript sim-s3-list-objects-v2-pagination
 /**
@@ -252,9 +252,9 @@ do {
 console.log(allKeys);
 ```
 
-Code that never names `MaxKeys` never continues a listing in a test small enough to be readable, so
+Code that never names `MaxKeys` never continues a listing in a test small enough to be readable, and
 its pagination goes unexercised. `configureMaxKeysPerPage` lowers the page size for a whole simulated
-S3 instead, which makes a Bucket of two Objects enough to make the caller walk a continuation:
+S3 instead. A Bucket of two Objects is then enough to make the caller walk a continuation:
 
 ```typescript sim-s3-list-page-size
 /**
@@ -346,15 +346,15 @@ for (const object of objectContentItems) {
 }
 ```
 
-The marker is exclusive and lexicographic, so a listing resumes after the key it names whether or not
+The marker is exclusive and lexicographic. A listing resumes after the key it names whether or not
 the Bucket still holds it.
 
 ## Object ETags
 
-Every Object has an ETag, which is the MD5 of its body in hex, quoted, as real S3 gives it for a
+Every Object has an ETag, the MD5 of its body in hex and quoted, as real S3 gives it for a
 single-part upload. `PutObject`, `GetObject`, both list operations and the S3 REST endpoint all
-report the same one, so a tool can compare what a Bucket holds against a local file without reading
-the Object back.
+report the same one. A tool can compare what a Bucket holds against a local file without reading the
+Object back.
 
 ```typescript sim-s3-object-etag
 /**
@@ -397,14 +397,14 @@ for (const object of listedObjects) {
 }
 ```
 
-An event notification record carries the same value unquoted, in its `eTag` field, which is how real
-S3 reports it there.
+An event notification record carries the same value unquoted, in its `eTag` field, as real S3
+reports it there.
 
 ## Deleting Objects
 
 Use `DeleteObjectCommand` to remove one Object, and `DeleteObjectsCommand` to remove several in one
-request. Both are authorized against `s3:DeleteObject` on the Object ARN, so a caller allowed to read
-a Bucket cannot empty it.
+request. Both are authorized against `s3:DeleteObject` on the Object ARN. A caller allowed to read a
+Bucket cannot empty it.
 
 ```typescript sim-s3-delete-object
 /**
@@ -465,8 +465,8 @@ for (const refused of refusedObjects) {
 }
 ```
 
-Deletion is idempotent, as it is in real S3. Deleting a key that is not in the Bucket succeeds, and
-`DeleteObjects` reports it among the keys it deleted. Deleting from a Bucket that does not exist
+Deletion is idempotent, as it is in real S3. Deleting a key the Bucket never held succeeds, and
+`DeleteObjects` reports it among the keys it deleted. Deleting from a Bucket that was never created
 raises `NoSuchBucket`.
 
 `DeleteObjects` authorizes each key on its own and carries on through the batch. A key the caller may
@@ -476,8 +476,8 @@ failures come back.
 
 ### Limitations
 
-- Object versioning is not simulated, so deletion removes the Object rather than writing a delete
-  marker, and neither `VersionId` nor `MFA` is read from the request.
+- Object versioning is left out. Deletion removes the Object rather than writing a delete marker,
+  and `VersionId` and `MFA` are both ignored on the request.
 - A request naming no Objects, or more than the thousand S3 accepts, is refused with `MalformedXML`
   before anything is deleted.
 - A Bucket using filesystem-backed storage refuses deletion. See
@@ -490,9 +490,9 @@ SNS topic when an Object is created or removed. The configuration is applied wit
 `PutBucketNotificationConfigurationCommand` and read back with
 `GetBucketNotificationConfigurationCommand`.
 
-The destination's own policy decides whether S3 may reach it: the function's resource policy, the
-queue's `Policy` attribute, or the topic's. That is checked when the configuration is applied, and
-again for every event, as real S3 does.
+The destination's own policy decides whether S3 may reach it. That is the function's resource
+policy, the queue's `Policy` attribute, or the topic's. It is checked when the configuration is
+applied, and again for every event, as real S3 does.
 
 ```typescript sim-s3-event-notifications
 /**
@@ -581,7 +581,7 @@ A configuration can filter on an object key prefix, a suffix, or both. Two confi
 an event type and whose filters could both match the same key are refused with `InvalidArgument`, as
 real S3 refuses them. Overlapping prefixes are fine when the suffixes do not overlap, so one function
 can take the `.jpg` files under a prefix while another takes the `.png` files under the same one.
-The rule applies across the destination groups, so a function and a queue that both want the same
+The rule applies across the destination groups. A function and a queue that both want the same
 event are refused as readily as two functions.
 
 `PutBucketNotificationConfigurationCommand` replaces the whole configuration rather than adding to
@@ -604,11 +604,11 @@ are the real IAM action names, and they do not match the API names.
 ### To an SQS queue
 
 A `QueueConfigurations` entry names a queue by ARN. The whole `Records` document arrives as one
-message body, so a consumer parses `record.body` to get at the event. Put a Lambda event source
+message body, and a consumer parses `record.body` to get at the event. Put a Lambda event source
 mapping on the queue and the chain runs end to end after one `backgroundTasksComplete()`.
 
 The queue's `Policy` attribute has to allow `sqs:SendMessage` for the `s3.amazonaws.com` service
-principal. S3 supplies `aws:SourceArn` and `aws:SourceAccount`, so the `ArnLike` condition CDK's
+principal. S3 supplies `aws:SourceArn` and `aws:SourceAccount`. The `ArnLike` condition CDK's
 `SqsDestination` writes and the `StringEquals aws:SourceAccount` guard AWS documents are both
 satisfied.
 
@@ -761,12 +761,12 @@ its own policy and its own Account's IAM are what admit the Bucket. A FIFO queue
 ### To an SNS topic
 
 A `TopicConfigurations` entry names a topic by ARN. The whole `Records` document is published as the
-SNS `Message`, with a `Subject` of `Amazon S3 Notification`, which is what real S3 publishes. A queue
-subscribed to the topic therefore has two envelopes to reach through: parse the message body for the
+SNS `Message`, with a `Subject` of `Amazon S3 Notification`, as real S3 publishes it. A queue
+subscribed to the topic therefore has two envelopes to reach through. Parse the message body for the
 SNS envelope, then parse its `Message` for the S3 event.
 
 The topic's `Policy` attribute has to allow `sns:Publish` for the `s3.amazonaws.com` service
-principal. S3 supplies `aws:SourceArn` and `aws:SourceAccount`, so the `ArnLike` condition CDK's
+principal. S3 supplies `aws:SourceArn` and `aws:SourceAccount`. The `ArnLike` condition CDK's
 `SnsDestination` writes and the `StringEquals aws:SourceAccount` guard AWS documents are both
 satisfied.
 
@@ -908,21 +908,21 @@ console.log(event.Records[0].s3.object.key); // "raw/cat.jpg"
 The topic has to be in the Bucket's Region, as real S3 requires. It can be in another Account, since
 its own policy and its own Account's IAM are what admit the Bucket. A FIFO topic is refused by name.
 
-The publish goes through the ordinary `Publish` path, so the topic's own subscriptions take it from
+The publish goes through the ordinary `Publish` path, and the topic's own subscriptions take it from
 there. That means a topic destination reaches everything the topic reaches, and a subscribed queue is
 two hops from the Object that was written. One `backgroundTasksComplete()` covers both.
 
 ### From a CloudFormation template
 
 The `NotificationConfiguration` property of `AWS::S3::Bucket` deploys through the same
-`PutBucketNotificationConfiguration` path, so a template and an SDK caller get identical validation.
-CloudFormation names the same configuration differently in several places: `LambdaConfigurations`
-rather than `LambdaFunctionConfigurations`, a single `Event` string rather than an `Events` list,
-`Function` rather than `LambdaFunctionArn`, `Queue` rather than `QueueArn`, `Topic` rather than
-`TopicArn`, and `Filter.S3Key.Rules` rather than `Filter.Key.FilterRules`. `QueueConfigurations` and
-`TopicConfigurations` are the names both spell the same way. Yulin reads the CloudFormation names and
-refuses the others, so a template using the SDK spelling fails the stack rather than deploying an
-unfiltered configuration.
+`PutBucketNotificationConfiguration` path, and a template and an SDK caller get identical validation.
+CloudFormation names the same configuration differently in several places. It writes
+`LambdaConfigurations` where the SDK writes `LambdaFunctionConfigurations`, a single `Event` string
+where the SDK takes an `Events` list, `Function` for `LambdaFunctionArn`, `Queue` for `QueueArn`,
+`Topic` for `TopicArn`, and `Filter.S3Key.Rules` for `Filter.Key.FilterRules`. `QueueConfigurations`
+and `TopicConfigurations` are the names both spell the same way. Yulin reads the CloudFormation names
+and refuses the others, so a template using the SDK spelling fails the stack. An unfiltered
+configuration would deploy otherwise.
 
 ```typescript sim-s3-cfn-event-notification
 /**
@@ -1010,32 +1010,32 @@ await simAws.backgroundTasksComplete();
 ```
 
 Two things in that template are there because real CloudFormation needs them, and simulated
-CloudFormation needs them for the same reasons. The Bucket names itself rather than letting
-CloudFormation name it, and the permission names the Bucket by ARN literal rather than by
-`Fn::GetAtt`. Written the other way round, the Bucket needs the function's ARN and the permission
-needs the Bucket's, which is a circular dependency. The `DependsOn` then puts the permission in place
-before S3 validates the destination the notification names.
+CloudFormation needs them for the same reasons. The Bucket names itself, where CloudFormation would
+otherwise name it, and the permission names the Bucket by ARN literal, where `Fn::GetAtt` would
+otherwise give it. Written the other way round, the Bucket needs the function's ARN and the
+permission needs the Bucket's, a circular dependency. The `DependsOn` then puts the permission in
+place before S3 validates the destination the notification names.
 
 S3 generates the configuration id, because CloudFormation has no property for stating one. Read it
 back with `GetBucketNotificationConfigurationCommand` if a test needs it.
 
 ### From a CDK app
 
-`bucket.addEventNotification(...)` deploys through simulated CloudFormation. CDK does not write the
-`AWS::S3::Bucket` `NotificationConfiguration` property for it. It writes a
-`Custom::S3BucketNotifications` resource carrying the same request
+`bucket.addEventNotification(...)` deploys through simulated CloudFormation. CDK writes a
+`Custom::S3BucketNotifications` resource for it rather than the `AWS::S3::Bucket`
+`NotificationConfiguration` property. The resource carries the same request
 `PutBucketNotificationConfigurationCommand` takes, alongside the `AWS::Lambda::Permission` that lets
 S3 invoke the function. Yulin applies that request through the same command path an SDK caller
-reaches, so a configuration is validated the same way whichever it arrives by.
+reaches, and a configuration is validated the same way whichever it arrives by.
 
 `SqsDestination` and `SnsDestination` write their entry into the same resource, alongside the
 `AWS::SQS::QueuePolicy` or `AWS::SNS::TopicPolicy` that grants S3 access. Both of those deploy, as
-does the `AWS::SNS::Topic` beside them, so a stack whose Bucket notifies a topic needs nothing set
-up by hand.
+does the `AWS::SNS::Topic` beside them. A stack whose Bucket notifies a topic needs nothing set up
+by hand.
 
 Deploy into an Account and Region matching the ones the CDK app synthesized for. The `SourceAccount`
-on the permission CDK writes beside the notification is a synth-time literal, so a stack deployed
-into another Account leaves S3 unable to validate the destination, and the stack fails.
+on the permission CDK writes beside the notification is a synth-time literal. A stack deployed into
+another Account leaves S3 unable to validate the destination, and the stack fails.
 
 ```typescript sim-s3-cdk-event-notification
 /**
@@ -1072,8 +1072,8 @@ is read and ignored.
 
 A resource carrying `Managed: false` is refused, and the stack fails. CDK writes it for a Bucket the
 app imported rather than declared. It asks S3 to merge the configuration with the configurations
-already on the Bucket instead of replacing them, and simulated S3 only replaces, so applying it as
-written would drop configurations that survive on real AWS. Declare the Bucket in the same stack to
+already on the Bucket, where simulated S3 only replaces, so applying it as written would drop
+configurations that survive on real AWS. Declare the Bucket in the same stack to
 get a managed notification configuration.
 
 ### What arrives at the destination
@@ -1081,17 +1081,17 @@ get a managed notification configuration.
 A function is invoked with the `Records` document real S3 sends. A queue gets the same document as
 one message body, and a topic gets it as the published `Message`. One event produces one record.
 
-Creation records carry the Object's `size` and its `eTag`, which is the MD5 of the bytes as it is for
-an Object real S3 stored in one part. Removal records carry neither, because the Object they describe
+Creation records carry the Object's `size` and its `eTag`, the MD5 of the bytes as it is for an
+Object real S3 stored in one part. Removal records leave both out, because the Object they describe
 is gone. Both carry a `sequencer`, which orders the events for one object key. The object key is
 form-URL-encoded, so `red flower.jpg` arrives as `red+flower.jpg`.
 
-`eventTime` comes from the simulation's clock, so a frozen clock produces a fixed timestamp.
+`eventTime` comes from the simulation's clock, and a frozen clock produces a fixed timestamp.
 
-The document is typed as `SimS3Event`, with `SimS3EventRecord` for one record, so a handler can be
-written against it. It is not assignable to the `aws-lambda` typings package's `S3Event`, and that
-is deliberate: that package declares `Records` mutable and requires `s3.object.size` and `eTag`,
-which a removal record does not carry. A handler typed against `S3Event` still receives this
+The document is typed as `SimS3Event`, with `SimS3EventRecord` for one record, and a handler can be
+written against it. Assigning it to the `aws-lambda` typings package's `S3Event` fails,
+deliberately. That package declares `Records` mutable and requires `s3.object.size` and `eTag`, which a
+removal record leaves out. A handler typed against `S3Event` still receives this
 document at runtime, and typing it as `SimS3Event` is what describes what actually arrives.
 
 ### Making an event notification without a Bucket
@@ -1133,20 +1133,20 @@ const objectRemovedFactory = new VariantFactory(s3NotificationEventFactory, {
 console.log(thumbnailKeys(objectRemovedFactory.make()));
 ```
 
-The default is the single record one Object event produces, which is all real S3 delivers to a
-function at once. What a record says in more than one place is computed from the rest: the Bucket
-ARN is the ARN of the Bucket named, and a removal carries no `size` and no `eTag` while a creation
-carries both. The key is carried as a record carries it, form-URL-encoded, so a key with a space in
-it goes in as `red+flower.jpg`.
+The default is the single record one Object event produces, all real S3 delivers to a function at
+once. What a record says in more than one place is computed from the rest. The Bucket ARN is the ARN
+of the Bucket named, and a removal carries no `size` and no `eTag` where a creation carries both.
+The key is carried as a record carries it, form-URL-encoded, and a key with a space in it goes in as
+`red+flower.jpg`.
 
 The [event factories page](../../factories/ "Test factories for AWS event shapes usage docs")
 covers what these have in common with the factories for the other event shapes.
 
 ### When delivery fails
 
-Real S3 tells the caller who wrote the Object nothing about a delivery, and neither does the
-simulator: a handler that throws does not fail the `PutObject` and does not reject
-`backgroundTasksComplete()`. The outcome is still readable:
+Real S3 tells the caller who wrote the Object nothing about a delivery, and the simulator says as
+little. A handler that throws leaves the `PutObject` successful and `backgroundTasksComplete()`
+resolved. The outcome is still readable:
 
 ```typescript
 for (const failure of simAws.s3().getNotificationDeliveryFailures()) {
@@ -1159,17 +1159,17 @@ destination that refused the event, because its resource policy no longer admits
 recorded without a warning.
 
 A handler that writes back into the Bucket that triggered it notifies itself forever, and in process
-there is nothing to slow it down. Filter the configuration by prefix or suffix so the handler's own
-writes do not match it. Without that, the simulation stops after a thousand deliveries and
+there is nothing to slow it down. Filter the configuration by prefix or suffix, so the handler's own
+writes fall outside it. Without that, the simulation stops after a thousand deliveries and
 `backgroundTasksComplete()` raises an error naming the Bucket.
 
 ### Limitations
 
 - A Lambda function, an SQS queue and an SNS topic are the destinations. EventBridge is refused by
   name.
-- A destination goes where the group it was declared in says, not where its ARN says: a queue ARN
-  under `LambdaFunctionConfigurations` is refused for not being a function ARN rather than delivered
-  to as a queue.
+- A destination goes where the group it was declared in says, and its ARN has no say. A queue ARN
+  under `LambdaFunctionConfigurations` is refused for failing to be a function ARN, and never
+  delivered to as a queue.
 - Only `s3:ObjectCreated:Put` and `s3:ObjectRemoved:Delete` are raised. `Copy`, `Post`,
   `CompleteMultipartUpload`, `DeleteMarkerCreated`, the `ObjectRestore:*`, `Replication:*`,
   `LifecycleExpiration:*` and `ObjectTagging:*` families, `LifecycleTransition`,
@@ -1181,28 +1181,30 @@ writes do not match it. Without that, the simulation stops after a thousand deli
   was made in this process, and the `responseElements` request ids are generated per event and match
   nothing.
 - `eventVersion` is the version the S3 event message structure page documents now. AWS increments the
-  minor version whenever it adds a field, so compare the major for equality rather than asserting on
-  the whole string.
-- `versionId` is absent from every record, which is what real S3 does for a Bucket without
-  versioning. Versioning is not simulated.
+  minor version whenever it adds a field, so compare the major for equality and leave the whole
+  string alone.
+- `versionId` is absent from every record, as it is on real S3 for a Bucket without versioning.
+  Versioning is left out.
 - A notification cannot be configured on a standalone `SimS3`. It has no other simulated services to
   notify, and no shared background scheduler for `backgroundTasksComplete()` to drain. Reach
   simulated S3 through `SimAws` instead.
 - An `EventBridgeConfiguration` in an `AWS::S3::Bucket` `NotificationConfiguration` is refused by
   name, as it is for an SDK caller.
-- `Managed: false` on a `Custom::S3BucketNotifications` resource is refused rather than approximated,
-  and an EventBridge destination in one is refused by name as it is for an SDK caller.
+- `Managed: false` on a `Custom::S3BucketNotifications` resource is refused outright, and an
+  EventBridge destination in one is refused by name as it is for an SDK caller.
 - A FIFO queue destination is refused by name, as real S3 refuses one. Simulated SQS has no FIFO
-  queues either, and neither does simulated SNS, so a FIFO topic destination is refused the same way.
-- The KMS key policy statement CDK's `SqsDestination` writes for an encrypted queue is not acted on.
-  Queue encryption is not simulated.
+  queues either, and simulated SNS has no FIFO topics, so a FIFO topic destination is refused the
+  same way.
+- The KMS key policy statement CDK's `SqsDestination` writes for an encrypted queue is ignored.
+  Queue encryption is left out.
 - A CDK `BucketDeployment` and `mountBucketFilesystem(...)` both replace the whole storage backend
-  rather than putting Objects, so neither raises anything, whereas real CDK `BucketDeployment` fires
-  one `ObjectCreated:Put` per file.
-- A function ARN naming a version or an alias is refused, since simulated Lambda has neither.
+  rather than putting Objects, and neither raises an event. Real CDK `BucketDeployment` fires one
+  `ObjectCreated:Put` per file.
+- A function ARN naming a version or an alias is refused, since simulated Lambda has no versions or
+  aliases.
 - A topic destination publishes with no message attributes, since real S3 publishes none. The only
   thing on the message besides the event document is the `Amazon S3 Notification` subject.
-- `s3:TestEvent` is not sent. Real S3 puts one on a queue or topic when a configuration naming it is
+- `s3:TestEvent` is left out. Real S3 puts one on a queue or topic when a configuration naming it is
   applied, carrying a flat `{Service, Event, Time, Bucket, RequestId, HostId}` document with no
   `Records` in it. Sending it here would make the simplest test two messages long and hand a
   consumer a body it cannot parse as an event. What the message exists to prove, that S3 may reach
@@ -1210,43 +1212,43 @@ writes do not match it. Without that, the simulation stops after a thousand deli
 
 ## Buckets from CloudFormation
 
-An `AWS::S3::Bucket` resource carries four properties simulated S3 acts on: `BucketName`,
+An `AWS::S3::Bucket` resource carries four properties simulated S3 acts on. Those are `BucketName`,
 `NotificationConfiguration`, `PublicAccessBlockConfiguration` and `WebsiteConfiguration`. Without
-`BucketName` the Bucket is named after the resource's logical id, lowercased, rather than the
-generated name real CloudFormation invents.
+`BucketName` the Bucket is named after the resource's logical id, lowercased, where real
+CloudFormation invents a generated name.
 
 Any other property is left out and recorded in
 [`stack.ignoredProperties`](../cloudformation/README.md#properties-a-resource-was-created-without),
-so the Bucket is created and the stack carries on. That matters because a Bucket deployed without the
-lifecycle rules, versioning or CORS configuration its template asked for looks configured and behaves
-as though it were not, and the failure that causes turns up somewhere else entirely. The record is
-where a test checks which of those it is standing on. A property name `AWS::S3::Bucket` does not have
-is recorded the same way, rather than a stack failing over a typo.
+and the Bucket is created and the stack carries on. That matters because a Bucket deployed without
+the lifecycle rules, versioning or CORS configuration its template asked for looks configured and
+behaves as though it were bare, and the failure that causes turns up somewhere else entirely. The
+record is where a test checks which of those it is standing on. A property name `AWS::S3::Bucket`
+never had is recorded the same way, and a typo leaves the stack standing.
 
-One of the four that is there but is not the shape it should be still fails the stack, rather than
-being read as absent, and so does a `BucketName` that is not a string: there is no Bucket to create
-under a name nothing else in the template refers to.
+One of the four given in the wrong shape still fails the stack, and so does a `BucketName` that is
+something other than a string. There is no Bucket to create under a name nothing else in the
+template refers to.
 
-`BucketEncryption` and `Tags` are read, ignored and not recorded, because nothing this simulator
-models can tell the difference: there is no simulated KMS, Object bytes are stored as they arrive,
-and no simulated service reads a Bucket tag. CDK puts both on almost every Bucket it synthesizes, and
+`BucketEncryption` and `Tags` are read, ignored and left out of the record, because nothing this
+simulator models can tell the difference. There is no simulated KMS, Object bytes are stored as they
+arrive, and no simulated service reads a Bucket tag. CDK puts both on almost every Bucket it synthesizes, and
 listing a difference no test could observe would only bury the ones that matter.
 
 ## Bucket policies
 
 A Bucket policy is a resource policy stored on the Bucket. Sim IAM evaluates it alongside the
-caller's identity policies whenever an Object command is authorized, so a policy can grant access to
-a principal that holds no identity policy at all, including an anonymous caller.
+caller's identity policies whenever an Object command is authorized. A policy can grant access to a
+principal that holds no identity policy at all, including an anonymous caller.
 
 Apply one with `PutBucketPolicyCommand`, read it back with `GetBucketPolicyCommand`, and remove it
 with `DeleteBucketPolicyCommand`. Each is authorized in its own right, against `s3:PutBucketPolicy`,
 `s3:GetBucketPolicy` and `s3:DeleteBucketPolicy`.
 
 In a CloudFormation template, a Bucket policy is a separate `AWS::S3::BucketPolicy` resource rather
-than a property of `AWS::S3::Bucket`. This is what CDK synthesizes for `bucket.grantRead(...)`,
-`grantPut(...)` and `addToResourcePolicy(...)`, so a template reaches it whether or not the app
+than a property of `AWS::S3::Bucket`. CDK synthesizes one for `bucket.grantRead(...)`,
+`grantPut(...)` and `addToResourcePolicy(...)`, and a template reaches it whether or not the app
 mentions a Bucket policy itself. Sim CloudFormation attaches it through the same `PutBucketPolicy`
-path an SDK call takes, so the document is validated and enforced identically either way.
+path an SDK call takes, and the document is validated and enforced identically either way.
 
 ```typescript sim-s3-bucket-policy
 /**
@@ -1334,17 +1336,17 @@ const policyOut = await simS3.getBucketPolicy(
 console.log(policyOut.Policy);
 ```
 
-`GetBucketPolicyCommand` throws `NoSuchBucketPolicy` when the Bucket exists but has no policy, which
-is how real S3 distinguishes that from a Bucket that does not exist. `DeleteBucketPolicyCommand`
-succeeds either way, matching S3's idempotent behaviour.
+`GetBucketPolicyCommand` throws `NoSuchBucketPolicy` when the Bucket exists but has no policy, as
+real S3 separates that from a missing Bucket. `DeleteBucketPolicyCommand` succeeds either way,
+matching S3's idempotent behaviour.
 
 A Bucket policy granting `Principal: "*"` is refused by default. See
 [Block Public Access](#block-public-access) below.
 
 ### Where a request came from
 
-A request can say what it is being made for, which is what a simulated service supplies when it
-reaches a Bucket on a resource's behalf. `sourceArn` and `sourceAccount` go alongside the caller and
+A request can say what it is being made for, and a simulated service supplies that when it reaches a
+Bucket on a resource's behalf. `sourceArn` and `sourceAccount` go alongside the caller and
 reach IAM as the `aws:SourceArn` and `aws:SourceAccount` condition keys:
 
 ```typescript
@@ -1358,18 +1360,18 @@ await simS3.getObject(
 ```
 
 That is the condition a Bucket policy granting a service principal usually carries, since a service
-principal is shared by every resource of that service. A request carrying neither leaves the key out
-rather than supplying an empty string, so a statement conditioned on it fails to match. Condition
-key names are matched case insensitively, so CDK's `AWS:SourceArn` spelling matches the same key.
+principal is shared by every resource of that service. A request carrying no such value leaves the
+key out entirely, and a statement conditioned on it fails to match. Condition key names are matched
+case insensitively, so CDK's `AWS:SourceArn` spelling matches the same key.
 
-Sim CloudFront supplies both when a Distribution's S3 Origin has an origin access control, which is
-[how it serves a private Bucket](../cloudfront/README.md#origin-access-controls).
+Sim CloudFront supplies both when a Distribution's S3 Origin has an origin access control, and that
+is [how it serves a private Bucket](../cloudfront/README.md#origin-access-controls).
 
 ## Block Public Access
 
 Real S3 turns on all four Block Public Access settings for every new Bucket, and `BlockPublicPolicy`
-makes `PutBucketPolicy` reject a policy that allows public access. Sim S3 does the same, so a Bucket
-starts closed and a public Bucket policy is refused with `AccessDenied` until the Bucket opts out:
+makes `PutBucketPolicy` reject a policy that allows public access. Sim S3 does the same. A Bucket
+starts closed, and a public Bucket policy is refused with `AccessDenied` until the Bucket opts out:
 
 ```typescript
 await simS3.putPublicAccessBlock(
@@ -1380,13 +1382,12 @@ await simS3.putPublicAccessBlock(
 );
 ```
 
-The configuration you supply replaces the previous one wholesale, so a setting you leave out of it
-is off rather than kept. That matches CDK: `BlockPublicAccess.BLOCK_ACLS` names only the two ACL
-settings, and pairing it with `publicReadAccess: true` is the usual way to build a public website
-Bucket.
+The configuration you supply replaces the previous one wholesale, and a setting you leave out of it
+is off. That matches CDK. `BlockPublicAccess.BLOCK_ACLS` names only the two ACL settings, and pairing
+it with `publicReadAccess: true` is the usual way to build a public website Bucket.
 
-`GetPublicAccessBlockCommand` reads the settings back and `DeletePublicAccessBlockCommand` removes
-them, which returns the Bucket to fully blocked rather than leaving it open. In a CloudFormation
+`GetPublicAccessBlockCommand` reads the settings back, and `DeletePublicAccessBlockCommand` removes
+them, which returns the Bucket to fully blocked. In a CloudFormation
 template the settings are the `PublicAccessBlockConfiguration` property of `AWS::S3::Bucket`, and a
 Stack whose `AWS::S3::BucketPolicy` is public without that opt-out fails to deploy, exactly as the
 real deployment would.
@@ -1404,25 +1405,25 @@ does in real S3. A `Service` principal is never a wildcard, and a `Deny` stateme
 
 ### Limitations
 
-Only `BlockPublicPolicy` changes behaviour. The other three settings are stored and reported but do
-nothing: `BlockPublicAcls` and `IgnorePublicAcls` govern ACLs, which are not modelled, and
+Only `BlockPublicPolicy` changes behaviour. The other three settings are stored and reported, and go
+no further. `BlockPublicAcls` and `IgnorePublicAcls` govern ACLs, which this simulator leaves out.
 `RestrictPublicBuckets` changes how an existing public policy is evaluated for cross-account callers
-rather than rejecting a write, which is not yet simulated.
+rather than rejecting a write, and that evaluation is absent so far.
 
-Anything the simulator cannot classify confidently counts as public and is refused, so it can be
-stricter than real S3. A `NotPrincipal` statement, a statement with no `Principal`, and a
+Anything the simulator cannot classify confidently counts as public and is refused, which makes it
+stricter than real S3 in places. A `NotPrincipal` statement, a statement with no `Principal`, and a
 `Condition` on `aws:SourceIp` all count as public here. Real S3 accepts a sufficiently narrow
-`aws:SourceIp` CIDR range as non-public; the simulator does not judge range breadth.
+`aws:SourceIp` CIDR range as non-public, where the simulator judges no range breadth at all.
 
 Account-level and organisation-level Block Public Access, access points, and `GetBucketPolicyStatus`
-are not simulated.
+are left out.
 
 The static website endpoint authorizes a request that names a principal as that principal, where a
 real S3 website endpoint supports only publicly readable content and authenticates nothing. The
-simulator is looser here, so a website reachable in a test as a named principal can be unreachable
-in the same way against real S3.
+simulator is looser here. A website reachable in a test as a named principal can be unreachable in
+the same way against real S3.
 
-Bucket ACLs and Object ownership settings are not modelled and are not planned. Object Ownership
+Bucket ACLs and Object ownership settings are left out, and stay that way by choice. Object Ownership
 defaults to Bucket owner enforced on new Buckets, which disables ACLs, and AWS recommends keeping
 them disabled in favour of policies.
 
@@ -1430,16 +1431,16 @@ them disabled in favour of policies.
 
 Configure Bucket website hosting with `PutBucketWebsiteCommand`.
 
-Website hosting settles which Object answers a request, not who may read it. A browser asking for a
-page is anonymous, and anonymous holds nothing unless a Bucket policy grants it, so a site with no
-Bucket policy answers `403` to every ordinary visitor, as it does on real S3. See
-[Block Public Access](#block-public-access) for the two commands a public site needs; the localhost
+Website hosting settles which Object answers a request. Who may read it is a separate question. A
+browser asking for a page is anonymous, and anonymous holds nothing unless a Bucket policy grants
+it. A site with no Bucket policy answers `403` to every ordinary visitor, as it does on real S3. See
+[Block Public Access](#block-public-access) for the two commands a public site needs. The localhost
 serving example below shows them in place. The examples in this section configure hosting without
-serving it, so they leave that out.
+serving it, and leave that out.
 
 A request that does name a principal, through a signature or the `x-sim-aws-caller` header, is
-authorized as that principal, so an identity policy granting `s3:GetObject` reaches the website
-endpoint too. Real S3 has no such thing: its website endpoint supports only publicly readable
+authorized as that principal, and an identity policy granting `s3:GetObject` reaches the website
+endpoint too. Real S3 has no such thing. Its website endpoint supports only publicly readable
 content and never authenticates a request. This is a deliberate simulator affordance, in keeping
 with the other simulated services that serve HTTP, and it means a website test driven as a named
 principal proves less than one driven as a browser would be.
@@ -1503,8 +1504,8 @@ With an index document configured:
 - `/docs/` resolves to `docs/index.html`
 - `/docs` redirects to `/docs/` when `docs/index.html` exists
 
-Static website hosting must be enabled before the sim Bucket can be served over HTTP. If it is not
-enabled, the localhost server returns `403`.
+Static website hosting must be enabled before the sim Bucket can be served over HTTP. The localhost
+server returns `403` until it is.
 
 ## Serve simulated S3 on localhost
 
@@ -1605,11 +1606,11 @@ server while preserving the simulated S3 website hostname.
 
 Sim S3 serves a REST API endpoint alongside the website endpoint, and it accepts presigned URLs
 built by the real AWS presigner, `getSignedUrl` from `@aws-sdk/s3-request-presigner`. Nothing about
-the signing is simulated: an `S3Client` is pointed at the simulated endpoint and signs as it would
+the signing is simulated. An `S3Client` is pointed at the simulated endpoint and signs as it would
 against real S3, and sim IAM verifies the signature it produced.
 
-Presigning is entirely client-side, so this works whether or not the URL is ever fetched over a real
-socket. Install the presigner alongside the SDK:
+Presigning is entirely client-side, and this works whether or not the URL is ever fetched over a
+real socket. Install the presigner alongside the SDK:
 
 ```bash
 npm install --save-dev @aws-sdk/s3-request-presigner
@@ -1703,13 +1704,13 @@ try {
 ```
 
 A presigned URL grants exactly what the principal who signed it holds. Sim IAM resolves that
-principal from the signature and authorizes `s3:GetObject` as them, so a user without permission
-cannot presign around it. Temporary credentials from an STS `AssumeRoleCommand` work the same way,
+principal from the signature and authorizes `s3:GetObject` as them. A user without permission cannot
+presign around it. Temporary credentials from an STS `AssumeRoleCommand` work the same way,
 carrying their session token in the URL.
 
-A request to the REST endpoint that neither presents a signature nor names a principal in the
+A request to the REST endpoint presenting no signature and naming no principal in the
 `x-sim-aws-caller` header is anonymous, and anonymous holds nothing unless a Bucket policy says
-otherwise. That header is always enabled and wins over a signature, so a request driven by hand can
+otherwise. That header is always enabled and wins over a signature, and a request driven by hand can
 be any principal without signing anything, exactly as it can against the other simulated services
 that serve HTTP. See
 [the sim IAM docs](../iam/README.md#what-the-simulator-reports-back) for the whole boundary.
@@ -1731,7 +1732,7 @@ const response = await fetch(url); // 403
 ### Uploads and checksums
 
 Presigned `PutObjectCommand` URLs work in the same way, with one thing to watch. The AWS SDK computes
-a checksum when it presigns, which is before there is a body to hash, and hoists it into the signed
+a checksum when it presigns, before there is a body to hash, and hoists it into the signed
 URL. Uploading anything else through that URL then fails against real S3, and fails here too, with
 `XAmzContentChecksumMismatch`. Build the client with
 `requestChecksumCalculation: "WHEN_REQUIRED"` to presign upload URLs that accept a body:
@@ -1748,13 +1749,13 @@ const s3Client = new S3Client({
 ### Limitations
 
 - `GET`, `HEAD`, `PUT` and `DELETE` of an Object are served over the REST endpoint. Bucket operations
-  and multipart uploads are not, and are refused with `501` rather than answered. `DeleteObjects` is
-  a `POST` to the Bucket, so it is available through the SDK but not over HTTP.
-- `createPresignedPost` and SigV4A presigning are not simulated.
+  and multipart uploads are refused with `501`. `DeleteObjects` is a `POST` to the Bucket, so it is
+  available through the SDK and unavailable over HTTP.
+- `createPresignedPost` and SigV4A presigning are left out.
 - Checksums are verified for CRC32, SHA1 and SHA256. An upload stating a CRC32C or CRC64NVME checksum
-  is refused rather than stored unchecked.
-- Responses carry the Object's `ETag` and `Last-Modified`, but no conditional request is honoured:
-  `If-None-Match` and `If-Modified-Since` are ignored and the Object is served in full.
+  is refused, and never stored unchecked.
+- Responses carry the Object's `ETag` and `Last-Modified`, and no conditional request is honoured.
+  `If-None-Match` and `If-Modified-Since` are ignored, and the Object is served in full.
 
 ## Error documents
 
@@ -1898,8 +1899,8 @@ await simS3.putBucketWebsite(
 );
 ```
 
-The first matching routing rule is used. A rule can match by `KeyPrefixEquals`,
-`HttpErrorCodeReturnedEquals`, both, or neither. Redirects support configured host, protocol,
+The first matching routing rule is used. A rule can match by `KeyPrefixEquals`, by
+`HttpErrorCodeReturnedEquals`, by both, or by no condition at all. Redirects support configured host, protocol,
 replacement key, replacement key prefix, and redirect status code.
 
 ## Filesystem-backed Bucket storage
@@ -1937,8 +1938,8 @@ After mounting, Object reads and writes for that Bucket use the filesystem direc
 
 ### Reloading the browser when the directory changes
 
-The Bucket is reading the files, so a rebuild needs nothing copying into it. All that is left is
-telling the browser. Give the mount somewhere to reload and it watches the directory for you:
+The Bucket is reading the files, and a rebuild copies nothing into it. All that is left is telling
+the browser. Give the mount somewhere to reload and it watches the directory for you:
 
 ```typescript sim-s3-mount-reload
 /**
@@ -1961,8 +1962,8 @@ simAws.s3().mountBucketFilesystem("site", path.join(process.cwd(), "public"), {
 });
 ```
 
-A build writing a whole tree of files is one reload, not one per file: the writes are held until
-they stop arriving. `settleMs` is how long that wait is, in milliseconds, for a generator that
+A build writing a whole tree of files is one reload, and never one per file. The writes are held
+until they stop arriving. `settleMs` is how long that wait is, in milliseconds, for a generator that
 pauses part way through a build:
 
 ```typescript sim-s3-mount-reload-settle
@@ -1987,18 +1988,18 @@ simAws.s3().mountBucketFilesystem("site", path.join(process.cwd(), "dist"), {
 });
 ```
 
-Anything with a `reload()` method will do, so a test can watch a mount without serving anything.
+Anything with a `reload()` method will do, and a test can watch a mount without serving anything.
 
-The watch is recursive, and holds an open filesystem handle, which keeps the process alive. A dev
+The watch is recursive, and holds an open filesystem handle that keeps the process alive. A dev
 process wants exactly that. Anything with an end, such as a test, calls
 `simAws.s3().stopWatchingMountedDirectories()` when it is done.
 `simAws.s3().watchedMountedDirectories()` says which directories are being watched.
-[`simAws.close()`](../../serve/README.md#stopping-and-restarting) is the one that does not need
-naming a service or a scope: it lets go of the mounted directory watches along with everything else
-the environment is holding, and a served environment gets that from `srv.close()`.
+[`simAws.close()`](../../serve/README.md#stopping-and-restarting) is the one that names no service
+and no scope. It lets go of the mounted directory watches along with everything else the environment
+is holding, and a served environment gets that from `srv.close()`.
 
 Under [`yulin watch`](../../serve/README.md#restarting-on-a-file-change), a mount that reloads for
-itself is left alone by the supervisor: a rebuild reloads the page rather than restarting the
+itself is left alone by the supervisor. A rebuild reloads the page rather than restarting the
 process and taking every simulated Bucket, Table and Stack with it. A mount without a reload target
 is still reported to the supervisor as a directory to watch, and a change in it restarts the
 process.
@@ -2010,30 +2011,30 @@ Filesystem storage is somewhat restrictive to make it slightly safer:
 - The directory must not be the user's home directory
 - The path must not contain `..`
 - Object keys must not be absolute paths or contain `..`
-- Only files whose extension is on a cautious list are served; see below
+- Only files whose extension is on a cautious list are served (see below)
 - Symlinks are ignored when listing Objects
-- Deletion is refused rather than unlinking a real file
+- Deletion is refused, and never unlinks a real file
 
 `DeleteObject` against a filesystem-backed Bucket raises `NotImplemented`, and `DeleteObjects`
-reports the same code for every key. This is stricter than real S3, deliberately: the directory a
+reports the same code for every key. This is stricter than real S3, deliberately. The directory a
 Bucket is mounted on is an ordinary directory of yours, and removing files from it because a test
-called `DeleteObject` is not a reasonable default. Leave a Bucket on the default in-memory storage
+called `DeleteObject` would be a poor default. Leave a Bucket on the default in-memory storage
 when a test needs deletion to work.
 
 When reading files from filesystem-backed storage, Yulin infers common `content-type` metadata from
 file extensions such as `.html`, `.css`, `.js`, `.json`, `.png`, `.svg`, `.txt`, `.xml`, and common
-font and image formats. A served file whose extension is not one of those gets
-`application/octet-stream`, which is what S3 reports for an object whose type it was never told.
-That only comes up for an extension a mount named itself, below: no other file is served at all,
-with or without a type.
+font and image formats. A served file whose extension falls outside that set gets
+`application/octet-stream`, as S3 reports for an object whose type it was never told. That only
+comes up for an extension a mount named itself, below. No other file is served at all, with or
+without a type.
 
 ### Serving a file extension of your own
 
-A mounted Bucket only serves files whose extension is on a cautious list — the web's own types, and
-nothing else — so that pointing a Bucket at a directory cannot be talked into reading whatever else
-happens to be in it. A file with any other extension is not served, and a `GetObject` for it comes
-back as though the file were not there. That is the right default and the wrong answer for a site
-with a data file of its own, so a mount can name the extensions it needs:
+A mounted Bucket only serves files whose extension is on a cautious list (the web's own types, and
+nothing else) so that pointing a Bucket at a directory cannot be talked into reading whatever else
+happens to be in it. A file with any other extension goes unserved, and a `GetObject` for it comes
+back as though the file were absent. That is the right default and the wrong answer for a site with
+a data file of its own. A mount can name the extensions it needs:
 
 ```typescript sim-s3-mount-file-extensions
 /**
@@ -2061,7 +2062,7 @@ leading dot is optional. Everything not named is still refused.
 ### Metadata a file cannot carry
 
 A stored Object holds what S3 was told when it was written. A file holds its bytes and its name, so
-a mounted Bucket has only the extension to go on, and reports a `content-type` and nothing else.
+a mounted Bucket has only the extension to go on, and reports a `content-type` and no more.
 Anything a deployment would have set is either inherited from the deployment, below, or declared on
 the mount, for the Objects under a key prefix.
 
@@ -2092,16 +2093,16 @@ simAws.s3().mountBucketFilesystem("site", path.join(process.cwd(), "public"), {
 
 The fields are the ones a [`PutObjectCommand`](#object-system-metadata) sets, and every value is a
 string, including `Expires`. Every declaration whose prefix the key starts with applies, in the
-order they were given, so a later one wins where two name the same header. An empty prefix is every
+order they were given, and a later one wins where two name the same header. An empty prefix is every
 Object in the Bucket. A declared `ContentType` replaces the one guessed from the extension.
 
 ### Inheriting what the deployment set
 
-A mount usually does not need to declare any of that, because something in the same simulated account
-has already said it. A CDK [`BucketDeployment`](../cloudformation/README.md#cdk-s3-bucketdeployment)
+A mount rarely has to declare any of that, because something in the same simulated account has
+already said it. A CDK [`BucketDeployment`](../cloudformation/README.md#cdk-s3-bucketdeployment)
 sets these headers through its own `SystemMetadata`, and says so on the destination Bucket as well as
 setting them on the Objects it copies. Mounting a directory over that Bucket replaces the Objects and
-inherits what the Bucket was told about them, so the files on disk are served as the deployed ones
+inherits what the Bucket was told about them. The files on disk are then served as the deployed ones
 were:
 
 ```typescript sim-s3-mount-deployed-system-metadata
@@ -2128,17 +2129,17 @@ simAws
   .mountBucketFilesystem("site-bucket", path.join(process.cwd(), "public"));
 ```
 
-The order does not matter: a directory can be mounted into a Bucket before the Stack describing it is
+The order is free. A directory can be mounted into a Bucket before the Stack describing it is
 deployed, and the mount answers with whatever the Bucket has been told by the time an Object is read.
 
-What a deployment published is what it is sure of, so a file it copied is described exactly. A file a
-later build wrote is described by the rule the deployment would have published it under — its
-destination key prefix and its filters — as long as only one deployment claims it. Where two
+What a deployment published is what it is sure of, and a file it copied is described exactly. A file
+a later build wrote is described by the rule the deployment would have published it under (its
+destination key prefix and its filters) as long as only one deployment claims it. Where two
 deployments into one Bucket could both have published a file that neither did, nothing is inherited
-for it, because serving a page as another deployment's brotli breaks it in a way serving the file as
-it is on disk does not. Declare those on the mount.
+for it. Serving a page as another deployment's brotli breaks it, where serving the file as it is on
+disk leaves it readable. Declare those on the mount.
 
-Anything declared on the mount goes over the top of all of it, one header at a time, which is how a
+Anything declared on the mount goes over the top of all of it, one header at a time. That is how a
 mount answers differently on purpose. A deployed site caching its assets for a year is the usual
 reason:
 
@@ -2167,9 +2168,9 @@ simAws
   });
 ```
 
-Pages served with [live reload](../../serve/README.md) are already sent `no-store`, so an HTML
-document is never what a stale cache is holding on to. Assets a build rewrites in place are, which is
-what a declaration like this one is for.
+Pages served with [live reload](../../serve/README.md) are already sent `no-store`, and an HTML
+document is never what a stale cache is holding on to. Assets a build rewrites in place are, and a
+declaration like this one is what they need.
 
 ## Object system metadata
 
@@ -2178,10 +2179,10 @@ Sim S3 stores and returns `cache-control`, `content-disposition`, `content-encod
 `content-language`, `content-type` and `expires`, alongside a `content-length` describing the body
 being served.
 
-Every path that serves an Object goes through the same mapping, so the REST endpoint, the
+Every path that serves an Object goes through the same mapping. The REST endpoint, the
 [website endpoint](#static-website-hosting) and a CloudFront S3 Origin all report the same headers
-for it. `content-encoding` is the one that matters most: bytes served without it are bytes no client
-can decode, so an Object stored as brotli is only usable if the header comes back with it.
+for it. `content-encoding` is the one that matters most. Bytes served without it are bytes no client
+can decode, and an Object stored as brotli is only usable if the header comes back with it.
 
 `PutObjectCommand` sets them, one request field per header.
 
@@ -2224,9 +2225,9 @@ console.log(objectOut.Metadata?.["content-encoding"]); // br
 console.log(objectOut.Metadata?.["expires"]); // Sat, 02 Jan 2027 03:04:05 GMT
 ```
 
-A header the write says nothing about is left unset rather than stored empty, so a read does not
-report it. `Expires` is the one field that is not a string: the SDK takes a `Date`, which is stored
-as the HTTP date a read hands back.
+A header the write says nothing about is left unset, and never stored empty, so a read leaves it
+out. `Expires` is the one field that takes something other than a string. The SDK takes a `Date`,
+stored as the HTTP date a read hands back.
 
 A CDK BucketDeployment's `SystemMetadata` sets the same headers on every Object it copies. See
 [CDK S3 BucketDeployment](../cloudformation/README.md#cdk-s3-bucketdeployment). A
@@ -2262,8 +2263,8 @@ await simS3.putObject(
 );
 ```
 
-A standalone `SimS3` instance has its own isolated state and is not connected to a wider `SimAws`
-environment.
+A standalone `SimS3` instance has its own isolated state, with no wider `SimAws` environment behind
+it.
 
 ## Available functionality
 
@@ -2296,7 +2297,7 @@ Sim S3 currently supports:
   CDK `BucketDeployment` into the same Bucket published, alongside anything the mount declares for a
   key prefix itself
 
-The simulator focuses on useful behaviour for tests and local development rather than full S3 feature
+The simulator aims at useful behaviour for tests and local development, short of full S3 feature
 parity. Unsupported S3 options may be ignored or may throw errors depending on whether the simulator
 needs them to model the requested behaviour.
 
@@ -2304,26 +2305,25 @@ needs them to model the requested behaviour.
 
 These apply across the page. The sections above each list what is specific to them.
 
-- Object versioning is not simulated. There are no version ids, no delete markers and no
-  `VersionId` on any request or response.
-- Multipart uploads are not simulated. An Object is stored by one `PutObject`, so an ETag is always
-  the MD5 of the whole body and never carries the `-N` part-count suffix real S3 gives a multipart
-  Object.
-- A listing reports `StorageClass` as `STANDARD` for every Object. Storage classes themselves are not
-  simulated, so nothing can be stored in another one.
-- `Delimiter` and `CommonPrefixes` are not simulated, so a listing cannot be walked as a folder tree.
+- Object versioning is left out. There are no version ids, no delete markers and no `VersionId` on
+  any request or response.
+- Multipart uploads are left out. An Object is stored by one `PutObject`, and an ETag is always the
+  MD5 of the whole body, never carrying the `-N` part-count suffix real S3 gives a multipart Object.
+- A listing reports `StorageClass` as `STANDARD` for every Object. Storage classes themselves are
+  left out, and every Object is in that one.
+- `Delimiter` and `CommonPrefixes` are left out, and a listing cannot be walked as a folder tree.
   `EncodingType` is ignored, and keys come back unencoded.
-- Object tags, ACLs, lifecycle rules, replication and server-side encryption are not simulated.
+- Object tags, ACLs, lifecycle rules, replication and server-side encryption are left out.
 - A Bucket using filesystem-backed storage cannot delete Objects, and raises no event
-  notifications, because it swaps the whole storage backend rather than putting Objects.
+  notifications, because it swaps the whole storage backend in place of putting Objects.
 - `GetObjectCommand` returns system metadata through `Metadata`, under the header name it is stored
   as, rather than through the `ContentType`, `CacheControl` and other response fields real S3 uses.
   See [Object system metadata](#object-system-metadata).
-- `HeadObjectCommand` is not one of the Commands simulated S3 answers, so it is not routed by SDK
-  interception either. A `HEAD` over the S3 REST endpoint is served, answering with the Object's
-  headers and no body, which is what a presigned `HEAD` URL uses.
-- An upload over the S3 REST endpoint keeps its `content-type` and no other system metadata, so a
-  presigned `PUT` cannot set the rest. A `PutObjectCommand` through the SDK keeps all of them.
+- `HeadObjectCommand` is absent from the Commands simulated S3 answers, and SDK interception leaves
+  it alone. A `HEAD` over the S3 REST endpoint is served, answering with the Object's headers and no
+  body, as a presigned `HEAD` URL uses.
+- An upload over the S3 REST endpoint keeps its `content-type` and no other system metadata, leaving
+  a presigned `PUT` unable to set the rest. A `PutObjectCommand` through the SDK keeps all of them.
 - A presigned `GetObject` ignores the `response-content-type`, `response-cache-control` and other
   `response-*` parameters that override a response header in real S3. An Object is served with the
   system metadata it was written with.

--- a/docs/services/sns/README.md
+++ b/docs/services/sns/README.md
@@ -148,9 +148,10 @@ const published = await sns.publish(
 console.log(published.MessageId !== undefined); // true
 ```
 
-The name and data type rules are the real ones. A reserved `AWS.` or `Amazon.` prefix on a name, a
-data type outside `String`, `String.Array`, `Number` and `Binary`, or a value that disagrees with its
-data type is refused. A test finds any of those without going near AWS. The two reserved names real
+The name and data type rules are the real ones. A data type is `String`, `String.Array`, `Number` or
+`Binary`, and each takes a custom label after a dot, so `Number.int` is a number as far as the rules
+go. A reserved `AWS.` or `Amazon.` prefix on a name, a data type built on none of the four, or a
+value that disagrees with its data type is refused. A test finds any of those without going near AWS. The two reserved names real
 SNS defines for SMS, `AWS.SNS.SMS.SenderID` and `AWS.SNS.SMS.SMSType`, are the exception.
 [Sending an SMS](#sending-an-sms) covers those.
 
@@ -1209,8 +1210,9 @@ try {
 ## Topic policies
 
 A topic's `Policy` attribute is its resource policy, and simulated IAM evaluates it as one. It is
-what admits a caller that has no identity policy of its own. A principal from another account is one,
-and so is a service principal such as `s3.amazonaws.com`, which owns no identity policies anywhere.
+what admits a service principal such as `s3.amazonaws.com`, which owns no identity policies
+anywhere. It is also half of what admits a principal from another account, which needs an identity
+policy in its own account as well.
 
 The policy is set with `CreateTopic` or `SetTopicAttributes` and read back with `GetTopicAttributes`.
 

--- a/docs/services/sns/README.md
+++ b/docs/services/sns/README.md
@@ -6,8 +6,8 @@ every operation is authorized by simulated IAM.
 Standard topics only. SNS-specific types are imported from the `@kensio/yulin/sns` subpath.
 
 A message published to a topic is delivered to every queue subscribed to it, invokes every Lambda
-function subscribed to it, and is recorded as an SMS for every phone number subscribed to it. Other
-subscription protocols are not simulated. A message published straight to a phone number is recorded
+function subscribed to it, and is recorded as an SMS for every phone number subscribed to it. Only
+those three protocols are simulated. A message published straight to a phone number is recorded
 as an SMS a test can assert on.
 
 ## Creating a topic and publishing to it
@@ -41,18 +41,18 @@ const { MessageId } = await sns.publish(
 console.log(MessageId !== undefined); // true
 ```
 
-A topic ARN is `arn:aws:sns:<region>:<account-id>:<name>`. An SNS ARN has no resource type in it, so
-the topic name follows the account id directly, the same as an SQS queue ARN.
+A topic ARN is `arn:aws:sns:<region>:<account-id>:<name>`. An SNS ARN has no resource type in it.
+The topic name follows the account id directly, the same as an SQS queue ARN.
 
 `CreateTopic` is idempotent, as it is on real AWS. A second request for the same name returns the
-existing topic's ARN and leaves that topic alone, so the attributes the second request carries are
-not applied. That differs from SQS, which fails a repeated `CreateQueue` whose attributes differ.
+existing topic's ARN and leaves that topic alone, and the attributes the second request carries are
+ignored. SQS is stricter, and fails a repeated `CreateQueue` whose attributes differ.
 
 A topic name is up to 256 characters of alphanumerics, hyphens and underscores. Anything else is
 refused with `InvalidParameterException`, including a name ending in `.fifo`.
 
-`DeleteTopic` removes the topic and frees its name at once, so it can be recreated straight away.
-Deleting a topic that is not there succeeds, as it does on real SNS.
+`DeleteTopic` removes the topic and frees its name at once, and a topic can be recreated straight
+away. Deleting a topic that was never there succeeds, as it does on real SNS.
 
 ## Topic attributes
 
@@ -100,7 +100,7 @@ console.log(read.Attributes?.["SubscriptionsConfirmed"]); // "0"
 ```
 
 `DisplayName` is reported as an empty string for a topic that has never had one set, as real SNS
-reports it. The three subscription counts are reported as zero, which is what a topic with no
+reports it. The three subscription counts are reported as zero, the counts a topic with no
 subscriptions has.
 
 An attribute real SNS has and this simulation gives no behaviour to is refused by name rather than
@@ -148,14 +148,14 @@ const published = await sns.publish(
 console.log(published.MessageId !== undefined); // true
 ```
 
-The name and data type rules are the real ones. A name using a reserved `AWS.` or `Amazon.` prefix, a
-data type that is not `String`, `String.Array`, `Number` or `Binary`, or a value that does not match
-its data type is refused here rather than on AWS. The two reserved names real SNS defines for SMS,
-`AWS.SNS.SMS.SenderID` and `AWS.SNS.SMS.SMSType`, are the exception. [Sending an SMS](#sending-an-sms)
-covers those.
+The name and data type rules are the real ones. A reserved `AWS.` or `Amazon.` prefix on a name, a
+data type outside `String`, `String.Array`, `Number` and `Binary`, or a value that disagrees with its
+data type is refused. A test finds any of those without going near AWS. The two reserved names real
+SNS defines for SMS, `AWS.SNS.SMS.SenderID` and `AWS.SNS.SMS.SMSType`, are the exception.
+[Sending an SMS](#sending-an-sms) covers those.
 
-A `Subject` is UTF-8 text with no line breaks or control characters, of fewer than 100 characters,
-which is the contract real SNS states. A subject of exactly 100 characters is already too long. A
+A `Subject` is UTF-8 text with no line breaks or control characters, of fewer than 100 characters.
+That is the contract real SNS states. A subject of exactly 100 characters is already too long. A
 publish with no `Message`, or with one over the size limit, is refused with
 `InvalidParameterException`.
 
@@ -163,9 +163,9 @@ publish with no `Message`, or with one over the size limit, is refused with
 the rest of the batch goes through, as real SNS reports it. An empty batch, more than ten entries, a
 malformed entry id or two entries sharing an id fail the whole request.
 
-The size limit is the one thing a batch is not held to per entry. It covers the whole batch, so ten
-entries each just inside it are one batch far outside it, and a single entry over it fails the batch
-with `BatchRequestTooLongException` rather than being reported as the one entry that did not fit.
+The size limit is the one thing a batch is held to as a whole. Ten entries each just inside it are
+one batch far outside it, and a single entry over it fails the whole batch with
+`BatchRequestTooLongException`. The response singles out no entry.
 
 ```typescript sim-sns-publish-batch
 /**
@@ -276,7 +276,7 @@ well, since one of the two would otherwise win silently.
 Both are recorded, and the record reads them back as `senderId` and `smsType`. The other reserved SMS
 attributes are refused by name. `AWS.SNS.SMS.MaxPrice` caps what a message may cost, and
 `AWS.MM.SMS.OriginationNumber`, `AWS.MM.SMS.EntityId` and `AWS.MM.SMS.TemplateId` pick the routing
-and the registration it travels under. Each one changes a real send and would change nothing here.
+and the registration it travels under. Each one changes a real send. Here it would be inert.
 
 Real SNS puts a number on the opt-out list when the recipient replies STOP, and its API only takes
 numbers back off. Standing in for the handset is the simulator's job. `optOutPhoneNumber` on the
@@ -365,24 +365,24 @@ console.log(simAws.sns().topicSubscriptions("orders").length); // 0
 ```
 
 A subscription ARN is the topic's ARN with an opaque id on the end. That is the only handle on a
-subscription: `Unsubscribe`, `GetSubscriptionAttributes` and `SetSubscriptionAttributes` all name one
+subscription. `Unsubscribe`, `GetSubscriptionAttributes` and `SetSubscriptionAttributes` all name one
 by it.
 
 The endpoint has to be what the protocol implies, and it is checked when the subscription is made. A
 queue ARN over the `lambda` protocol is refused, as it is on real SNS, and so is an `sms` endpoint
 outside E.164. A qualified function ARN naming a version or an alias is refused too, since simulated
-Lambda has neither and subscribing `$LATEST` instead would be a different function from the one asked
-for.
+Lambda has no versions or aliases. Subscribing `$LATEST` in its place would be a different function
+from the one asked for.
 
 Subscribing the same endpoint to the same topic twice answers with the subscription that is already
-there rather than making a second one, as real SNS does. The attributes the repeated request carries
-are not applied to it, the same way a repeated `CreateTopic` leaves the existing topic alone. They
-are still validated, so a repeated request naming an attribute this simulation will not take is
-refused for it.
+there, as real SNS does. The attributes the repeated request carries are ignored, the same way a
+repeated `CreateTopic` leaves the existing topic alone. They are still validated, and a repeated
+request naming an attribute this simulation has no place for is still refused.
 
 `RawMessageDelivery` can be set on the `Subscribe` request or afterwards with
-`SetSubscriptionAttributes`, and its value is `"true"` or `"false"`. Anything else is refused, rather
-than being treated as false. The other two attributes with behaviour behind them are `FilterPolicy`
+`SetSubscriptionAttributes`, and its value is `"true"` or `"false"`. Anything else is refused.
+Reading it as false would silently change what the subscription delivers. The other two attributes with behaviour
+behind them are `FilterPolicy`
 and `FilterPolicyScope`, under
 [filtering what a subscription receives](#filtering-what-a-subscription-receives).
 
@@ -395,13 +395,13 @@ ones that have been unsubscribed in `SubscriptionsDeleted`. `SubscriptionsPendin
 because no protocol simulated needs a confirmation.
 
 Only the `sqs`, `lambda` and `sms` protocols are simulated. Every other protocol real SNS has is
-refused by name at `Subscribe` time with the reason it is missing, rather than creating a
-subscription that would never be delivered to.
+refused by name at `Subscribe` time, with the reason it is missing. The alternative would be a
+subscription that never delivers anything.
 
 ## Delivering to a queue
 
 Publishing to a topic delivers one message to each subscribed queue. That happens after the publish
-has been answered, as it does on real SNS, so a test waits for it with
+has been answered, as it does on real SNS. A test waits for it with
 `simAws.backgroundTasksComplete()` before receiving.
 
 ```typescript sim-sns-fan-out
@@ -493,14 +493,14 @@ for (const QueueUrl of [fulfilment, audit]) {
 The queue's policy is what allows the delivery. It has to admit `sns.amazonaws.com` for
 `sqs:SendMessage`, and the `aws:SourceArn` condition is what keeps one topic's grant from opening the
 queue to another. The policy is checked on every message rather than remembered from subscribe time,
-so a permission taken away afterwards stops delivery.
+and a permission taken away afterwards stops delivery.
 
-Nothing checks the queue at `Subscribe` time, because real SNS does not either. A subscription to a
-queue that does not exist, or to one whose policy says no, is created and fails when a message is
-delivered to it.
+The subscription is made without checking the queue, as it is on real SNS. A subscription to a queue
+that is absent, or to one whose policy says no, is created and fails when a message is delivered to
+it.
 
-A delivery that fails is not reported to the publisher, as it is not on real SNS: the publish is
-answered with a `MessageId` before anything is delivered. It is recorded instead, so a queue that is
+A failed delivery goes unreported to the publisher, as it does on real SNS. The publish is answered
+with a `MessageId` before anything is delivered. The failure is recorded instead, and a queue that is
 unexpectedly empty says why:
 
 ```typescript
@@ -512,13 +512,13 @@ console.log(failure?.wasRefused); // true when the queue policy said no
 ```
 
 A queue in another account or another region receives a message the same way. Real SNS delivers
-across both, which differs from simulated S3 event notifications: real S3 requires a destination
-queue to be in the bucket's region, and this does not.
+across both. Simulated S3 event notifications are stricter, since real S3 requires a destination
+queue to be in the bucket's region, where a topic delivers to a queue in any region.
 
 ## The message a queue receives
 
-By default the body is the SNS envelope, which is the JSON document real SNS wraps a published
-message in. A consumer reads the message out of it with `JSON.parse(body).Message`:
+By default the body is the SNS envelope, the JSON document real SNS wraps a published message in. A
+consumer reads the message out of it with `JSON.parse(body).Message`:
 
 ```json
 {
@@ -547,7 +547,7 @@ because a consumer written for one breaks on the other.
 
 Subscribing a function with the `lambda` protocol invokes it once per published message, with the SNS
 event shape. The function's resource policy has to allow `sns.amazonaws.com` to invoke it for the
-topic, which is what `AddPermission` grants:
+topic. `AddPermission` grants that:
 
 ```typescript sim-sns-lambda-delivery
 /**
@@ -623,12 +623,12 @@ await sns.publish(
 await simAws.backgroundTasksComplete();
 ```
 
-The permission is checked on every message rather than remembered from subscribe time, so one taken
-away afterwards stops delivery. Nothing checks the function at `Subscribe` time, as nothing checks
-the queue: a subscription to a function that does not exist, or to one whose policy says no, is
+The permission is checked on every message rather than remembered from subscribe time, and one taken
+away afterwards stops delivery. The subscription is made without checking the function, the same as a
+queue subscription. A subscription to a function that is absent, or to one whose policy says no, is
 created and fails when a message is delivered to it. Both failures are recorded on
 `simAws.sns().deliveryFailures` the same way a queue's are, and a handler that throws is recorded
-there too without stopping delivery to the topic's other subscriptions.
+there too. Delivery to the topic's other subscriptions carries on.
 
 A function in another account or another region is invoked the same way, on that account's own
 resource policy.
@@ -636,8 +636,8 @@ resource policy.
 ## The event a Lambda function receives
 
 `Records` always holds exactly one entry, even when the message came from a `PublishBatch`. Real SNS
-does not batch to Lambda: each published message is its own invocation, so a handler looping over
-`Records` sees one message per call.
+gives each published message its own invocation. A handler looping over `Records` sees one message
+per call.
 
 ```json
 {
@@ -664,14 +664,14 @@ does not batch to Lambda: each published message is its own invocation, so a han
 }
 ```
 
-Two fields are spelled differently from the envelope a queue receives, and the difference is real SNS
-behaviour worth writing a consumer against: the envelope has `SigningCertURL` and `UnsubscribeURL`,
-and the Lambda event has `SigningCertUrl` and `UnsubscribeUrl`. `Subject` and `MessageAttributes` are
-always present here as well, carrying `null` and `{}` when the publish had neither, where the
-envelope leaves both out.
+Two fields are spelled differently from the envelope a queue receives. The envelope has
+`SigningCertURL` and `UnsubscribeURL`, and the Lambda event has `SigningCertUrl` and
+`UnsubscribeUrl`. That is real SNS behaviour, and a consumer has to be written against it. `Subject`
+and `MessageAttributes` are always present here as well, carrying `null` and `{}` for a publish that
+omitted them, where the envelope leaves both out.
 
 `RawMessageDelivery` has no effect on a `lambda` subscription. Real SNS treats it as an SQS and HTTP
-setting, so a function is invoked with the whole event whether it is set or not.
+setting, and a function is invoked with the whole event whatever the value.
 
 ## Texting a subscribed number
 
@@ -734,7 +734,7 @@ console.log(sms?.subscriptionArn === SubscriptionArn); // true
 console.log(sms?.suppressed); // false
 ```
 
-The recorded body is the message as it was published. A handset receives the text on its own, so the
+The recorded body is the message as it was published. A handset receives the text on its own, and the
 SNS envelope a queue receives and the `Subject` an email carries are both left off.
 
 Each record names the topic and the subscription that produced it, in `topicArn` and
@@ -754,10 +754,10 @@ what puts a number on the list, under [sending an SMS](#sending-an-sms).
 ## Filtering what a subscription receives
 
 A subscription with a `FilterPolicy` receives only the messages its policy matches. Every other
-subscription of the topic is unaffected, so one subscriber filtering a message out has nothing to do
-with what another receives. It applies to a subscribed function as it does to a subscribed queue: the
-policy decides whether the message reaches the subscription at all, whatever the subscription
-delivers to.
+subscription of the topic is unaffected, and one subscriber filtering a message out leaves what
+another receives alone. A policy applies to a subscribed function as it does to a subscribed queue.
+It decides whether the message reaches the subscription at all, whatever the subscription delivers
+to.
 
 The policy is a JSON document of keys and the match conditions each one accepts. Separate keys are an
 and, and the list a key holds is an or.
@@ -856,7 +856,7 @@ console.log(delivered.Messages?.length); // 1
 console.log(filtered.Messages); // undefined
 ```
 
-By default a policy is matched against the message attributes of the publish, which is the
+By default a policy is matched against the message attributes of the publish, under the
 `MessageAttributes` scope. These are the operators:
 
 | Condition                               | Matches                                     |
@@ -874,17 +874,17 @@ By default a policy is matched against the message attributes of the publish, wh
 | `{"exists": true}`                      | the key being there, holding something      |
 | `{"exists": false}`                     | the key not being there                     |
 
-Only `{"exists": false}` matches a key the message does not carry. Every other operator needs a value
-to look at, including `anything-but`: there is nothing there to be anything but the excluded value.
+Only `{"exists": false}` matches a key the message leaves out. Every other operator needs a value to
+look at, `anything-but` included. An absent key holds no value to be anything but the excluded one.
 
-`{"exists": false}` also needs the message to carry something else, which is what real SNS states: a
+`{"exists": false}` also needs the message to carry some other key, which real SNS states as well. A
 publish with no message attributes at all matches no filter policy of the default scope, this one
-included. Under the `MessageBody` scope the same goes for a body holding no keys, so a body that is
-not JSON matches nothing whichever operator the policy uses.
+included. Under the `MessageBody` scope the same goes for a body holding no keys. A body that fails
+to parse as JSON matches no policy, whichever operator it uses.
 
-Numeric matching applies to the `Number` message attribute data type, as it does on real SNS, so
-digits published as a `String` are text. A `String.Array` attribute matches when any member of it
-does. A `Binary` attribute matches nothing, since filtering is on text.
+Numeric matching applies to the `Number` message attribute data type, as it does on real SNS. Digits
+published as a `String` are text. A `String.Array` attribute matches when any member of it does. A
+`Binary` attribute matches no condition, since filtering is on text.
 
 `$or` matches when either of two separate keys does, which the rest of a policy cannot say:
 
@@ -893,14 +893,14 @@ does. A `Binary` attribute matches nothing, since filtering is on text.
 ```
 
 Real SNS reads `$or` as an or only when it holds a list of at least two objects, none of which names
-a reserved keyword such as `numeric` or `prefix`. Anything else is an attribute named `$or` there, so
-the policy quietly stops being an or and matches nothing. Each of those is refused here when the
-policy is set instead.
+a reserved keyword such as `numeric` or `prefix`. Anything else is an attribute named `$or` there,
+and the policy quietly stops being an or, matching no message at all. Each of those is refused here
+when the policy is set.
 
 ### Filtering on the message body
 
 With `FilterPolicyScope` set to `MessageBody`, the policy is matched against the message body read as
-JSON. That is the scope that nests: a policy names a nested key by nesting itself.
+JSON. That is the scope that nests. A policy names a nested key by nesting itself.
 
 ```typescript sim-sns-filter-policy-body
 /**
@@ -985,30 +985,31 @@ const { Messages } = await sqs.receiveMessage(
 console.log(Messages?.length); // 1
 ```
 
-A body that is not JSON, or that is JSON without being an object, matches no policy of this scope. It
-is not an error: the body comes from whoever published, and the scope is the subscription's own
-business, so a publisher would otherwise fail on a subscription it knows nothing about. A key holding
-`null`, an object or an empty list holds no value to match, so it is a key `{"exists": false}`
-matches, as long as the body holds some other key.
+A body that fails to parse as JSON, or that parses to something other than an object, matches no
+policy of this scope. The result is a miss, and the publish still succeeds. The body comes from
+whoever published,
+the scope is the subscription's own business, and a publisher would otherwise fail on a subscription
+it knows nothing of. A key holding `null`, an object or an empty list holds no value to match, so it
+is a key `{"exists": false}` matches, as long as the body holds some other key.
 
 The two attributes can be set on `Subscribe` or afterwards with `SetSubscriptionAttributes`, and
 `GetSubscriptionAttributes` reports both once a policy is set. Setting `FilterPolicy` with no value
-takes the policy off, so the subscription receives everything again.
+takes the policy off, and the subscription receives everything again.
 
-A policy is read when it is set rather than when a message arrives. An operator real SNS does not
-have, a match condition naming two operators, a key holding no conditions, and a nested key under the
-`MessageAttributes` scope are all refused there. So is `cidr`, which is the one operator real SNS has
-that this does not.
+A policy is read when it is set rather than when a message arrives. An operator real SNS has never
+had, a match condition naming two operators, a key holding no conditions, and a nested key under the
+`MessageAttributes` scope are all refused there. So is `cidr`, the one real SNS operator missing
+here.
 
 ## Verifying a message signature
 
-The `Signature` in the envelope is a real RSA signature over the string real SNS signs: the signed
-fields in alphabetical order, each one its name and its value followed by a newline. Signature
-version `1` is SHA1withRSA, which is what real SNS signs with unless a topic opts into version 2.
+The `Signature` in the envelope is a real RSA signature over the string real SNS signs. That string
+is the signed fields in alphabetical order, each one its name and its value followed by a newline.
+Signature version `1` is SHA1withRSA, and real SNS signs with it unless a topic opts into version 2.
 
 The key pair belongs to the simulated SNS scope, as a real signing certificate belongs to a region.
-`SigningCertURL` names its certificate, and `simAws.sns().signingCertificate(url)` hands it over: the
-URL itself cannot be fetched, because simulated SNS is not served over HTTP.
+`SigningCertURL` names its certificate, and `simAws.sns().signingCertificate(url)` hands it over.
+Fetching the URL itself fails, since simulated SNS has no HTTP endpoint.
 
 ```typescript sim-sns-message-signature
 /**
@@ -1113,28 +1114,27 @@ console.log(envelope.SignatureVersion); // "1"
 console.log(verified); // true
 ```
 
-The message attributes are not signed, here or on real AWS, so changing one in flight leaves the
-signature valid.
+The message attributes stay out of the signature, here and on real AWS, and changing one in flight
+leaves the signature valid.
 
 ## IAM permissions
 
 Every operation is authorized against the topic's ARN, which carries the topic name with no resource
-type in front of it. Two details are worth knowing, because both are real SNS behaviour that a policy
-can get wrong:
+type in front of it. Three details of real SNS trip policies up:
 
-- `ListTopics` has no resource type at all, so it is authorized against `*` and only a policy whose
-  `Resource` is `*` allows it. A policy naming one topic grants no listing, and neither does one
-  naming `arn:aws:sns:<region>:<account-id>:*`.
+- `ListTopics` has no resource type at all. It is authorized against `*`, and only a policy whose
+  `Resource` is `*` allows it. A policy naming one topic grants no listing, and one naming
+  `arn:aws:sns:<region>:<account-id>:*` grants none either.
 - `Unsubscribe`, `ListSubscriptions`, `GetSubscriptionAttributes` and `SetSubscriptionAttributes`
-  have no resource type either, for the same reason: SNS has no subscription resource type for a
-  policy to name. They are authorized against `*`, so a topic policy cannot grant them and neither
-  can an identity policy naming the topic ARN. `Subscribe` and `ListSubscriptionsByTopic` do name a
-  topic, and are authorized against its ARN.
+  have no resource type either, for the same reason. SNS has no subscription resource type for a
+  policy to name. They are authorized against `*`, out of reach of a topic policy and of an identity
+  policy naming the topic ARN. `Subscribe` and `ListSubscriptionsByTopic` do name a topic, and are
+  authorized against its ARN.
 - `PublishBatch` is authorized as `sns:Publish`. There is no `sns:PublishBatch` action for a policy to
   name.
 
-A denial is `AuthorizationErrorException`, which is what real SNS answers with rather than the
-`AccessDenied` most other services use.
+A denial is `AuthorizationErrorException`, the error real SNS answers with. Most other services use
+`AccessDenied`.
 
 ```typescript sim-sns-iam-policy
 /**
@@ -1208,9 +1208,9 @@ try {
 
 ## Topic policies
 
-A topic's `Policy` attribute is its resource policy, and simulated IAM evaluates it as one. It is what
-admits a caller that has no identity policy of its own: a principal from another account, or a service
-principal such as `s3.amazonaws.com`, which owns no identity policies anywhere.
+A topic's `Policy` attribute is its resource policy, and simulated IAM evaluates it as one. It is
+what admits a caller that has no identity policy of its own. A principal from another account is one,
+and so is a service principal such as `s3.amazonaws.com`, which owns no identity policies anywhere.
 
 The policy is set with `CreateTopic` or `SetTopicAttributes` and read back with `GetTopicAttributes`.
 
@@ -1277,30 +1277,29 @@ try {
 ```
 
 `sourceArn` is what a request says it is being made on behalf of, and `sourceAccount` is the Account
-owning that resource, supplied as `aws:SourceAccount`. A request that does not carry one leaves the
-key out rather than supplying an empty string, so a statement conditioned on it does not match at
-all.
+owning that resource, supplied as `aws:SourceAccount`. A request that omits one leaves the key out
+entirely, and a statement conditioned on it matches nothing.
 
-A caller from another account needs both sides to allow the request, as it does on real AWS: the
-topic policy naming the principal, and that principal's own account allowing the action. Either one
-on its own is a denial.
+A caller from another account needs both sides to allow the request, as it does on real AWS. The
+topic policy has to name the principal, and that principal's own account has to allow the action.
+Either one on its own is a denial.
 
-The policy is validated when it is set, so a malformed document fails there rather than the first
-time something is authorized against it. It has to be a JSON policy document whose statements each
-carry an `Effect` of `Allow` or `Deny`, an `Action` or `NotAction`, and a `Resource` or `NotResource`.
-Anything else fails with `InvalidParameterException`.
+The policy is validated when it is set. A malformed document fails there, before anything has been
+authorized against it. It has to be a JSON policy document whose statements each carry an `Effect` of
+`Allow` or `Deny`, an `Action` or `NotAction`, and a `Resource` or `NotResource`. Anything else fails
+with `InvalidParameterException`.
 
 `GetTopicAttributes` reports `Policy` back as the string it was set with. Setting the attribute with
-no value takes the policy off the topic, which is the only way back to a topic without one.
+no value takes the policy off the topic, the only way back to a topic without one.
 
 ## Taking S3 Object events
 
 A simulated S3 Bucket can publish its event notifications to a topic. The topic then fans them out to
-its own subscribers, so one Bucket configuration reaches every queue subscribed to the topic.
+its own subscribers, and one Bucket configuration reaches every queue subscribed to the topic.
 
 Set up the topic policy first. S3 asks the topic whether it may publish when the notification
-configuration is applied, and asks again for every event, so a policy that does not admit
-`s3.amazonaws.com` for that Bucket refuses the configuration outright.
+configuration is applied, and asks again for every event. A policy that leaves `s3.amazonaws.com` out
+for that Bucket refuses the configuration outright.
 
 ```typescript sim-sns-s3-events
 /**
@@ -1439,12 +1438,12 @@ for (const QueueUrl of [thumbnails, audit]) {
 ```
 
 The published `Message` is the S3 `Records` document as text, and the `Subject` is
-`Amazon S3 Notification`, which is what real S3 publishes. A subscribed queue receiving the SNS
+`Amazon S3 Notification`. Those are what real S3 publishes. A subscribed queue receiving the SNS
 envelope therefore has two layers to parse. `RawMessageDelivery` on the subscription takes one of
 them away, leaving the S3 event document as the message body.
 
-The topic has to be in the Bucket's Region, as real S3 requires, which is stricter than a
-subscription: a topic delivers to a queue in any Region. The Accounts can differ on both hops.
+The topic has to be in the Bucket's Region, as real S3 requires. A subscription is looser, and a
+topic delivers to a queue in any Region. The Accounts can differ on both hops.
 
 See [simulated S3](../s3/README.md#event-notifications "Simulated S3 event notification docs") for the
 rest of the Bucket side, including the object key filters and what a record carries.
@@ -1452,8 +1451,7 @@ rest of the Bucket side, including the object key filters and what a record carr
 ## Scoping
 
 Topics belong to an account and a region, as they do on real AWS. A topic name is unique within one
-account and region and nowhere wider, so the same name can be used in two regions for two different
-topics.
+account and region and nowhere wider. The same name can name two different topics in two regions.
 
 ```typescript sim-sns-scoping
 /**
@@ -1486,8 +1484,8 @@ try {
 ```
 
 A topic ARN naming another account is refused the same way, rather than being answered by a local
-topic of the same name. A topic policy admits another account's principal to a topic here; it does
-not make another account's topics reachable through this one.
+topic of the same name. A topic policy admits another account's principal to a topic here, and leaves
+that account's own topics unreachable from this one.
 
 ## Inside a simulated Lambda handler
 
@@ -1496,27 +1494,27 @@ the function's execution role as the caller. A handler publishing to a topic the
 allowed to, by that role's policy, the same as on real AWS. See
 [simulated Lambda](../lambda/ "Simulated Lambda docs") for how function code and execution roles work.
 
-The same applies to `SimSdk` interception: intercepting `SNSClient` routes ordinary SDK code into the
-simulation with nothing touching the network. See
+`SimSdk` interception works the same way. Intercepting `SNSClient` routes ordinary SDK code into the
+simulation with nothing touching the network, covered under
 [AWS SDK interception](../../sdk/ "Simulated AWS SDK docs").
 
 ## Deploying a topic from CloudFormation
 
 Simulated CloudFormation creates a topic from an `AWS::SNS::Topic` resource, in the stack's account
-and region. The topic is created through `CreateTopic`, so a template-created topic is the same thing
-an SDK caller would get: the same name validation, the same attributes, the same ARN.
+and region. The topic is created through `CreateTopic`. A template-created topic gets the same name
+validation, the same attributes and the same ARN as one an SDK caller creates.
 
-`Ref` on the resource gives the topic ARN, as it does on real AWS, so it can be handed straight to
+`Ref` on the resource gives the topic ARN, as it does on real AWS, and it can be handed straight to
 `Publish` or `Subscribe`. `Fn::GetAtt … TopicArn` gives the same string, and `Fn::GetAtt … TopicName`
 gives the name without the account and region around it.
 
-`AWS::SNS::Subscription` subscribes through `Subscribe`, so its `Protocol` has to be one of the three
-simulated and its `Endpoint` has to be something that protocol can reach. `RawMessageDelivery`,
-`FilterPolicy` and `FilterPolicyScope` are carried through as subscription attributes, so a filter
+`AWS::SNS::Subscription` subscribes through `Subscribe`. Its `Protocol` has to be one of the three
+simulated, and its `Endpoint` has to be something that protocol can reach. `RawMessageDelivery`,
+`FilterPolicy` and `FilterPolicyScope` are carried through as subscription attributes, and a filter
 policy written in a template is read exactly as one set through the SDK. The policy is an object in
-the template where the API takes a JSON string; the conversion happens on the way in. `Ref` on the
-resource gives the subscription ARN, and `Fn::GetAtt … Arn` gives the same string, since the ARN is
-the resource's physical id.
+the template where the API takes a JSON string, and the conversion happens on the way in. `Ref` on
+the resource gives the subscription ARN, and `Fn::GetAtt … Arn` gives the same string, since the ARN
+is the resource's physical id.
 
 ```typescript sim-sns-cloudformation-topic
 /**
@@ -1599,16 +1597,16 @@ const { Messages } = await simAws
 console.log(Messages?.[0]?.Body); // "order-1"
 ```
 
-A topic with no `TopicName` is named from the stack name and the logical ID, so the topic above with
-its name left out would be `orders-stack-OrdersTopic`. Real CloudFormation adds random characters to
+A topic with no `TopicName` is named from the stack name and the logical ID. The topic above with its
+name left out would be `orders-stack-OrdersTopic`. Real CloudFormation adds random characters to
 that, which a template cannot predict either way. The generated name is trimmed to the 256 characters
 a topic name allows, ending in a hash of the untrimmed name so two long names that start the same
 stay apart.
 
-A topic can also declare its subscriptions inside itself, with the `Subscription` property, which is
+A topic can also declare its subscriptions inside itself, with the `Subscription` property. That is
 how a hand-written template usually writes them. Each entry is a `Protocol` and an `Endpoint`, and
 each goes through `Subscribe` the same way a separate resource does. A `Protocol` and an `Endpoint`
-are all real CloudFormation lets an entry carry, so an entry carrying anything else fails the
+are all real CloudFormation lets an entry carry, and an entry carrying anything else fails the
 resource. A filter policy or raw message delivery needs the separate resource.
 
 ```typescript
@@ -1629,7 +1627,7 @@ resource. A filter policy or raw message delivery needs the separate resource.
 `AWS::SNS::TopicPolicy` deploys the policy it names onto each topic in its `Topics` list, through
 `SetTopicAttributes`. A policy declared in a template is therefore validated and enforced exactly as
 one set through the SDK, and a document SNS would refuse fails the resource. `Topics` carries topic
-ARNs, which is what `Ref` on an `AWS::SNS::Topic` gives.
+ARNs, and `Ref` on an `AWS::SNS::Topic` gives one.
 
 ```typescript
 {
@@ -1656,12 +1654,12 @@ A property with no simulated behaviour fails the resource rather than being drop
 `SignatureVersion`, `TracingConfig`, `ArchivePolicy`, `DeliveryStatusLogging`, `DataProtectionPolicy`
 and `Tags` on a topic, and `DeliveryPolicy`, `RedrivePolicy`, `ReplayPolicy`, `SubscriptionRoleArn`
 and `Region` on a subscription. Most of them are refused by simulated SNS itself, since they are
-topic or subscription attributes of the same name, so the reason is the same one an SDK caller gets.
-A property the resource type does not have at all is refused too. The failure is worded as an invalid
-resource rather than an unsupported one, so the resource fails instead of being
-[skipped](../cloudformation/README.md#values-from-a-skipped-resource): a topic that cannot be created
-as the template asked for it would otherwise leave a stack that looks deployed with nothing
-publishing.
+topic or subscription attributes of the same name, and the reason is the same one an SDK caller gets.
+A property the resource type never had is refused too. The failure is worded as an invalid resource,
+which fails the resource where an unsupported one would be
+[skipped](../cloudformation/README.md#values-from-a-skipped-resource). A topic that cannot be created
+as the template asked for it would otherwise leave a stack that looks deployed with no publisher
+behind it.
 
 CDK works without hand-editing. `topic.addSubscription(new subscriptions.SqsSubscription(queue))`
 synthesises an `AWS::SNS::Subscription` alongside the `AWS::SQS::QueuePolicy` that authorizes the
@@ -1715,99 +1713,96 @@ Sim SNS currently supports:
 
 Current documented limitations:
 
-- Only the `sqs`, `lambda` and `sms` subscription protocols are simulated, so a queue, a function and
-  a phone number are the only things a topic can deliver to. `http`, `https`, `email`, `email-json`,
+- Only the `sqs`, `lambda` and `sms` subscription protocols are simulated. A queue, a function and a
+  phone number are the only things a topic can deliver to. `http`, `https`, `email`, `email-json`,
   `application` and `firehose` are refused at `Subscribe` time.
 - A subscribed function is invoked with `Subject: null` and `MessageAttributes: {}` where the publish
-  had neither, which is what real SNS sends. The envelope a queue receives leaves both fields out.
+  carried neither of them, as real SNS sends it. The envelope a queue receives leaves both fields
+  out.
 - `RawMessageDelivery` is accepted on a `lambda` subscription and has no effect on it, as it has none
   on real SNS.
 - A qualified function ARN naming a version or an alias is refused as a subscription endpoint.
   Simulated Lambda has no versions or aliases, so subscribing `$LATEST` instead would be a different
   function from the one named.
 - `SigningCertURL` and `UnsubscribeURL` name `sns.<region>.yulin.invalid` rather than
-  `sns.<region>.amazonaws.com`, and neither can be fetched: simulated SNS is not served over HTTP.
+  `sns.<region>.amazonaws.com`, and both are unfetchable, since simulated SNS has no HTTP endpoint.
   The certificate is handed out in process by `simAws.sns().signingCertificate(url)`. A real SNS
   signature verifier such as `sns-validator` hard-codes an `amazonaws.com` certificate host and
-  fetches the URL itself, so it cannot verify a simulated message as it stands. Verify with
-  `node:crypto` against the certificate the simulator hands over instead.
-- A delivery failure is not reported to the publisher, as it is not on real SNS. It is recorded on
+  fetches the URL itself, which leaves it unable to verify a simulated message as it stands. Verify
+  with `node:crypto` against the certificate the simulator hands over instead.
+- A delivery failure goes unreported to the publisher, as it does on real SNS. It is recorded on
   `simAws.sns().deliveryFailures`, and anything other than an endpoint policy refusal is also warned
   about once on the console.
-- Delivery retry policies, subscription dead-letter queues and delivery status logging are not
-  simulated, so a message an endpoint would not take is delivered once and recorded as a failure
-  rather than retried.
-- `ConfirmSubscription` is not supported. No protocol simulated needs a confirmation, so there is no
-  confirmation token to confirm.
-- The `cidr` filter policy operator is not simulated. A policy holding one is refused when it is set,
-  naming the operator, rather than accepted and then matching nothing.
+- Delivery retry policies, subscription dead-letter queues and delivery status logging are left out.
+  A message an endpoint refuses is delivered once and recorded as a failure, with no retry behind it.
+- `ConfirmSubscription` is absent. No protocol simulated needs a confirmation, so there is no token
+  to confirm.
+- The `cidr` filter policy operator is left out. A policy holding one is refused when it is set,
+  naming the operator. Accepting it would leave a policy that silently matches no message.
 - A filter policy is reported back as the string it was set with. Real SNS re-serialises the
-  document, so what comes back there is not byte for byte what went in.
+  document, so what comes back there differs from what went in.
 - A nested filter policy key is refused under the `MessageAttributes` scope, since message attributes
   are a flat set of names and such a policy could never match.
-- A message body that is not a JSON object matches no `MessageBody` filter policy, and is not an
-  error. A key holding `null`, an object or an empty list holds no value to match, so
-  `{"exists": false}` matches it, as long as the body holds some other key.
-- An `$or` real SNS would not read as one, because it holds fewer than two objects or names a
-  reserved keyword, is refused when the policy is set. Real SNS treats it as an attribute named
-  `$or` instead, which matches nothing.
-- Subscription delivery retry policies, subscription dead-letter queues and message replay are not
-  simulated, so `DeliveryPolicy`, `RedrivePolicy`, `SubscriptionRoleArn` and `ReplayPolicy` are
-  refused.
+- A message body that parses to something other than a JSON object matches no `MessageBody` filter
+  policy, and the publish still succeeds. A key holding `null`, an object or an empty list
+  holds no value to match, so `{"exists": false}` matches it, as long as the body holds some other
+  key.
+- An `$or` holding fewer than two objects, or naming a reserved keyword, is refused when the policy
+  is set. Real SNS reads it as an attribute named `$or`, which matches no message.
+- Subscription delivery retry policies, subscription dead-letter queues and message replay are left
+  out, and `DeliveryPolicy`, `RedrivePolicy`, `SubscriptionRoleArn` and `ReplayPolicy` are refused.
 - `GetSubscriptionAttributes` reports `SubscriptionArn`, `TopicArn`, `Protocol`, `Endpoint`, `Owner`,
   `ConfirmationWasAuthenticated`, `PendingConfirmation` and `RawMessageDelivery`, with `FilterPolicy`
   and `FilterPolicyScope` once a policy is set. `EffectiveDeliveryPolicy` is left out, since delivery
-  retry policies are not simulated.
+  retry policies are absent.
 - A queue whose name ends in `.fifo` is refused as a subscription endpoint. Only a FIFO topic
   delivers to a FIFO queue, and there are no FIFO topics here.
 - Standard topics only. A topic name ending in `.fifo` is refused, as are the `FifoTopic`,
   `FifoThroughputScope` and `ContentBasedDeduplication` attributes, and the `MessageGroupId` and
   `MessageDeduplicationId` publish inputs.
 - `MessageStructure` is refused. A `json` structure picks a different message body per protocol, and
-  picking one is not simulated, so it would be a body chosen by a rule that never ran.
-- Publishing to a `TargetArn` is refused. Mobile application endpoints and push notifications are not
-  simulated, so a publish reaches a topic or a phone number.
-- An SMS is recorded and never delivered, and nothing models what a carrier would do with one. There
-  is no message part splitting, no delivery receipt, no price and no throughput limit.
+  that picking is left out. Accepting it would mean a body chosen by a rule that never ran.
+- Publishing to a `TargetArn` is refused. Mobile application endpoints and push notifications are
+  left out, and a publish reaches a topic or a phone number.
+- An SMS is recorded and never delivered, and what a carrier would do with one is left out. There is
+  no message part splitting, no delivery receipt, no price and no throughput limit.
 - `AWS.SNS.SMS.MaxPrice`, `AWS.MM.SMS.OriginationNumber`, `AWS.MM.SMS.EntityId` and
   `AWS.MM.SMS.TemplateId` are refused rather than recorded. Each one changes what real SNS does with
-  a message, and accepting one that changed nothing would misrepresent the send.
+  a message, and accepting an inert copy of it would misrepresent the send.
 - `SetSMSAttributes` and `GetSMSAttributes`, which carry the account-wide SMS defaults and the spend
-  limit, are not supported.
-- The SMS sandbox is not simulated. Real SNS only texts verified destination numbers until an account
+  limit, are absent.
+- The SMS sandbox is left out. Real SNS only texts verified destination numbers until an account
   leaves it. Yulin is a sandbox already, so every number here is reachable without verifying it
   first.
-- The thirty day limit real SNS puts on opting one number back in is not simulated.
+- The thirty day limit real SNS puts on opting one number back in is absent.
 - Message attributes count against the 256 KB publish limit alongside the message body, as they do on
-  real SNS. The exact accounting AWS uses for one attribute is not documented, so this counts the
-  bytes of the attribute's name, its data type and its value, which is stricter than counting the
-  body alone.
-- A `Subject` is held to the contract real SNS states, which is UTF-8 text with no line breaks or
-  control characters and fewer than 100 characters. Older AWS documentation described it as ASCII
-  text beginning with a letter, number or punctuation mark. That wording is superseded, so a subject
+  real SNS. AWS documents no exact accounting for one attribute, so this counts the bytes of the
+  attribute's name, its data type and its value. That is stricter than counting the body alone.
+- A `Subject` is held to the contract real SNS states, UTF-8 text with no line breaks or control
+  characters and fewer than 100 characters. Older AWS documentation described it as ASCII text
+  beginning with a letter, number or punctuation mark. That wording is superseded, and a subject
   beginning with a space is accepted here.
 - `GetTopicAttributes` reports `TopicArn`, `Owner`, `DisplayName`, `SubscriptionsConfirmed`,
   `SubscriptionsPending`, `SubscriptionsDeleted` and `Policy` when one is set. `DeliveryPolicy` and
-  `EffectiveDeliveryPolicy` are left out, since delivery retry policies are not simulated.
+  `EffectiveDeliveryPolicy` are left out, since delivery retry policies are absent.
 - `GetTopicAttributes` reports the `Policy` string that was set. Real SNS re-serialises the document
-  and adds an `Id` and a `Sid`, so what comes back there is not byte for byte what went in.
+  and adds an `Id` and a `Sid`, so what comes back there differs from what went in.
 - A topic policy is set through the `Policy` attribute only. `AddPermission` and `RemovePermission`,
-  which are shorthands for writing one statement of it, are not supported.
-- Encryption is not simulated. `KmsMasterKeyId` is refused rather than applied, and message bodies are
-  held in process memory as they were published. That is not a security boundary: anything sharing the
-  process can reach them.
-- Tags are not simulated. `TagResource`, `UntagResource` and `ListTagsForResource` are not supported,
-  and `CreateTopic` refuses a `Tags` parameter rather than dropping it.
-- Data protection policies are not simulated. `PutDataProtectionPolicy` and
-  `GetDataProtectionPolicy` are not supported, and `CreateTopic` refuses a `DataProtectionPolicy`
-  rather than creating a topic that redacts nothing.
-- Message archiving and replay are not simulated, so `ArchivePolicy` is refused.
-- Delivery status logging writes to CloudWatch Logs, which is not simulated, so the feedback role and
-  sample rate attributes are refused.
+  shorthands for writing one statement of it, are absent.
+- Encryption is left out. `KmsMasterKeyId` is refused, and message bodies are held in process memory
+  as they were published. Anything sharing the process can read them.
+- Tags are left out. `TagResource`, `UntagResource` and `ListTagsForResource` are absent, and
+  `CreateTopic` refuses a `Tags` parameter rather than dropping it.
+- Data protection policies are left out. `PutDataProtectionPolicy` and `GetDataProtectionPolicy` are
+  absent, and `CreateTopic` refuses a `DataProtectionPolicy` rather than creating a topic that
+  redacts nothing.
+- Message archiving and replay are left out, and `ArchivePolicy` is refused.
+- Delivery status logging is left out, and the feedback role and sample rate attributes are refused.
+  Nothing here writes a delivery record to a simulated CloudWatch Logs group.
 - Platform applications and endpoints, and subscribing over `http`, `https`, `email`, `email-json`,
-  `application` and `firehose`, are not supported.
-- SNS condition keys such as `sns:Endpoint` and `sns:Protocol` are not derived, so a policy relying on
-  them will not match. Ordinary condition operators on values sim IAM does supply work as usual.
+  `application` and `firehose`, are absent.
+- SNS condition keys such as `sns:Endpoint` and `sns:Protocol` are left out, and a policy relying on
+  one matches nothing. Ordinary condition operators on values sim IAM does supply work as usual.
 - `FifoTopic: false` in a template fails the resource rather than deploying a standard topic. It is
   passed to `CreateTopic` as the attribute of the same name, which simulated SNS refuses by name
   whatever the value is. CDK leaves the property out for a standard topic, so this only reaches a

--- a/docs/services/sqs/README.md
+++ b/docs/services/sqs/README.md
@@ -48,7 +48,7 @@ await sqs.deleteMessage(
 ```
 
 A queue URL is `https://sqs.<region>.amazonaws.com/<account-id>/<name>`, and the ARN is
-`arn:aws:sqs:<region>:<account-id>:<name>`. An SQS ARN has no resource type in it, so the queue name
+`arn:aws:sqs:<region>:<account-id>:<name>`. An SQS ARN has no resource type in it. The queue name
 follows the account id directly.
 
 `CreateQueue` is idempotent, as it is on real AWS. A second request for the same name returns the
@@ -58,9 +58,9 @@ differ. A request naming no attributes always matches.
 ## Visibility timeouts
 
 A received message is hidden from other consumers for the queue's visibility timeout, 30 seconds by
-default. Nothing is scheduled to release it: the message records the instant it is hidden until, and it
-becomes receivable again once simulated time reaches that instant. Advancing the clock is therefore all
-a test needs to watch an undeleted message come back.
+default. The message records the instant it is hidden until. It becomes receivable again once
+simulated time reaches that instant. Advancing the clock is all a test needs to watch an undeleted
+message come back.
 
 ```typescript sim-sqs-visibility-timeout
 /**
@@ -112,20 +112,20 @@ console.log(again.Messages?.[0]?.Attributes?.["ApproximateReceiveCount"]); // "2
 ```
 
 A receive request can override the timeout for the messages it takes with `VisibilityTimeout`, and a
-consumer part way through a slow handler can ask for more time with `ChangeMessageVisibility`. The new
-timeout runs from the moment of the change rather than from the receive, as it does on real AWS, and
-a timeout of zero gives the message straight back to the queue.
+consumer part way through a slow handler can ask for more time with `ChangeMessageVisibility`. The
+new timeout runs from the moment of the change rather than from the receive, as it does on real AWS.
+A timeout of zero gives the message straight back to the queue.
 
-`ChangeMessageVisibility` on a message whose timeout has already lapsed fails with `MessageNotInflight`,
-which is what real SQS answers: there is no timeout left to change.
+`ChangeMessageVisibility` on a message whose timeout has already lapsed fails with
+`MessageNotInflight`. There is no timeout left to change, and real SQS answers the same way.
 
 See [simulated time](../../time/ "Simulated time docs") for what else the clock can do.
 
 ## Receipt handles
 
 Every receive issues a fresh receipt handle, and a delete has to use the handle from the most recent
-receive of that message. A handle from an earlier receive is accepted and deletes nothing, which is
-exactly what real SQS does with one.
+receive of that message. A handle from an earlier receive is accepted and deletes nothing. Real SQS
+treats a stale handle the same way.
 
 That is the failure a consumer slower than its visibility timeout hits. Its message went back on the
 queue, someone else took it, and its own delete quietly does nothing.
@@ -189,8 +189,8 @@ still the most recent one, so deleting with it works. A handle the queue never i
 
 A `RedrivePolicy` says where a message goes once a consumer has had enough attempts at it. Once a
 message has been received `maxReceiveCount` times without being deleted, the next lapse of its
-visibility timeout moves it to the queue named by `deadLetterTargetArn` rather than making it
-receivable again. Advancing the clock is what drives the move, as it drives the timeout itself.
+visibility timeout moves it to the queue named by `deadLetterTargetArn`. Advancing the clock drives
+the move, as it drives the timeout itself.
 
 ```typescript sim-sqs-dead-letter-queue
 /**
@@ -260,23 +260,23 @@ const dead = await sqs.receiveMessage(
 console.log(dead.Messages?.[0]?.Body); // "order-1"
 ```
 
-The message arrives with its `MessageId`, body and message attributes unchanged, so a test can
-identify it. `ApproximateNumberOfMessages` on both queues reflects the move. A message deleted before
-its attempts run out never gets there, and a message still inside its visibility timeout has not moved
+The message keeps its `MessageId`, body and message attributes, and a test can identify it by any of
+them. `ApproximateNumberOfMessages` on both queues reflects the move. A message deleted before its
+attempts run out never gets there, and a message still inside its visibility timeout has not moved
 yet, because the consumer holding it may still delete it.
 
 `SentTimestamp` is unchanged by the move, as it is on a real standard queue. The dead-letter queue's
-`MessageRetentionPeriod` therefore runs from when the message was first sent rather than restarting,
-which is why AWS suggests giving a dead-letter queue a longer retention period than the queue feeding
-it. `ApproximateReceiveCount` starts again from one, since a receive count counts receives from one
-queue and the message has not been received from this one yet. A moved message also reports
+`MessageRetentionPeriod` therefore runs from when the message was first sent. That is why AWS
+suggests giving a dead-letter queue a longer retention period than the queue feeding it.
+`ApproximateReceiveCount` starts again from one, since a receive count counts receives from one queue
+and the message has not been received from this one yet. A moved message also reports
 `DeadLetterQueueSourceArn`, naming the queue it came from.
 
-The policy is validated when it is set, whether by `CreateQueue` or `SetQueueAttributes`. It has to be
-a JSON object with both a `deadLetterTargetArn` and a `maxReceiveCount` between 1 and 1000, carried as
-a JSON number or as a string holding one. The `deadLetterTargetArn` has to name a queue that already
-exists in the same account and region, as real SQS requires, so a policy pointing at nothing fails
-there and then rather than quietly losing messages later. Anything else fails with
+The policy is validated when it is set, whether by `CreateQueue` or `SetQueueAttributes`. It has to
+be a JSON object with both a `deadLetterTargetArn` and a `maxReceiveCount` between 1 and 1000,
+carried as a JSON number or as a string holding one. The `deadLetterTargetArn` has to name a queue
+that already exists in the same account and region, as real SQS requires. A policy pointing at
+nothing fails there and then, before a message has been lost to it. Anything else fails with
 `InvalidParameterValue`.
 
 `GetQueueAttributes` reports `RedrivePolicy` back as the string it was set with.
@@ -325,14 +325,14 @@ const late = await sqs.receiveMessage(new ReceiveMessageCommand({ QueueUrl }));
 console.log(late.Messages?.[0]?.Body); // "order-1"
 ```
 
-`MessageRetentionPeriod` works on the same clock. A message on the queue longer than the retention
-period, four days by default, is gone rather than kept indefinitely.
+`MessageRetentionPeriod` works on the same clock. A message on the queue for longer than the
+retention period (four days by default) is gone.
 
 ## Message attributes
 
-Message attributes round-trip, and both digests are real: `MD5OfMessageBody` is an MD5 of the body, and
-`MD5OfMessageAttributes` uses the length-prefixed encoding real SQS digests attributes with. A consumer
-checking either against its own digest is checking something real.
+Message attributes round-trip, and both digests are computed. `MD5OfMessageBody` is an MD5 of the
+body, and `MD5OfMessageAttributes` uses the length-prefixed encoding real SQS digests attributes
+with. A consumer checking either against its own digest is checking a real MD5.
 
 A receive returns no attributes unless it names them, as on real AWS. `All` or `.*` selects every
 attribute, a bare name selects one, and a name ending in `.*` selects a prefix.
@@ -378,9 +378,9 @@ console.log(message?.MD5OfMessageAttributes === sent.MD5OfMessageAttributes); //
 console.log(message?.MD5OfBody === sent.MD5OfMessageBody); // true
 ```
 
-The name and data type rules are the real ones. A name using a reserved `AWS.` or `Amazon.` prefix, a
-data type that is not `String`, `Number` or `Binary`, or a value that does not match its data type is
-refused here rather than on AWS.
+The name and data type rules are the real ones. A reserved `AWS.` or `Amazon.` prefix on a name, a
+data type outside `String`, `Number` and `Binary`, or a value that disagrees with its data type is
+refused. A test finds any of those without going near AWS.
 
 The message system attributes are asked for separately, with `MessageSystemAttributeNames`, or with
 the discontinued `AttributeNames` that means the same thing. `SentTimestamp`,
@@ -389,7 +389,7 @@ the discontinued `AttributeNames` that means the same thing. `SentTimestamp`,
 ## Queue attributes
 
 `GetQueueAttributes` returns only the attributes a request names, as real SQS does, and `All` names
-every attribute this simulation holds. The defaults are the AWS ones: `VisibilityTimeout` 30,
+every attribute this simulation holds. The defaults are the AWS ones. `VisibilityTimeout` is 30,
 `DelaySeconds` 0, `MessageRetentionPeriod` 345600, `MaximumMessageSize` 262144 and
 `ReceiveMessageWaitTimeSeconds` 0.
 
@@ -440,24 +440,23 @@ console.log(read.Attributes?.["ApproximateNumberOfMessagesNotVisible"]); // "1"
 console.log(read.Attributes?.["QueueArn"]); // "arn:aws:sqs:us-east-1:888888888888:orders"
 ```
 
-The other two settable attributes are JSON documents: `RedrivePolicy`, covered under
-[dead-letter queues](#dead-letter-queues) above, and `Policy`, covered under
+The other two settable attributes are JSON documents. `RedrivePolicy` is covered under
+[dead-letter queues](#dead-letter-queues) above and `Policy` under
 [queue policies](#queue-policies) below. Both are reported back as the string they were set with.
 
 An attribute real SQS reports and this simulation does not model, `RedriveAllowPolicy` for one, is
-left out of a response rather than refused, since that is what real SQS does with an attribute a queue
-has no value for. Setting one is refused, because a queue that appeared to accept it would behave
-differently here than on AWS.
+left out of a response. Real SQS leaves out an attribute a queue has no value for in the same way.
+Setting one is refused, because a queue that appeared to accept it would behave differently here than
+on AWS.
 
 `PurgeQueue` deletes everything on a queue, hidden messages included.
 
 ## IAM permissions
 
 Every operation is authorized against the queue's ARN, which carries the queue name with no resource
-type in front of it. Two details are worth knowing, because both are real SQS behaviour that a policy
-can get wrong:
+type in front of it. Two details of real SQS trip policies up:
 
-- `ListQueues` has no resource type at all, so a policy allowing it names `*`. A policy naming one
+- `ListQueues` has no resource type at all. A policy allowing it names `*`. A policy naming one
   queue, or every queue in the Account and Region, grants no listing.
 - The batch operations are authorized as their singular action. There is no `sqs:SendMessageBatch`,
   `sqs:DeleteMessageBatch` or `sqs:ChangeMessageVisibilityBatch` action for a policy to name.
@@ -545,8 +544,8 @@ try {
 ## Queue policies
 
 A queue's `Policy` attribute is its resource policy, and simulated IAM evaluates it as one. It is
-what admits a caller that has no identity policy of its own: a principal from another account, or a
-service principal such as `s3.amazonaws.com`, which owns no identity policies anywhere.
+what admits a caller that has no identity policy of its own. A principal from another account is one,
+and so is a service principal such as `s3.amazonaws.com`, which owns no identity policies anywhere.
 
 The policy is set with `CreateQueue` or `SetQueueAttributes` and read back with
 `GetQueueAttributes`.
@@ -615,22 +614,21 @@ try {
 ```
 
 `sourceArn` is what a request says it is being made on behalf of, and `sourceAccount` is the Account
-owning that resource, supplied as `aws:SourceAccount`. A request that does not carry one leaves the
-key out rather than supplying an empty string, so a statement conditioned on it does not match at
-all.
+owning that resource, supplied as `aws:SourceAccount`. A request that omits one leaves the key out
+entirely, and a statement conditioned on it matches nothing.
 
-A simulated S3 Bucket notifying a queue supplies both, so the `ArnLike aws:SourceArn` condition CDK
+A simulated S3 Bucket notifying a queue supplies both. The `ArnLike aws:SourceArn` condition CDK
 writes and the `StringEquals aws:SourceAccount` guard AWS documents are each enough on their own.
 See [Event notifications](../s3/#event-notifications) on the S3 page for the whole chain.
 
-A caller from another account needs both sides to allow the request, as it does on real AWS: the
-queue policy naming the principal, and that principal's own account allowing the action. Either one
-on its own is a denial.
+A caller from another account needs both sides to allow the request, as it does on real AWS. The
+queue policy has to name the principal, and that principal's own account has to allow the action.
+Either one on its own is a denial.
 
-The policy is validated when it is set, by `CreateQueue` or `SetQueueAttributes`, so a malformed
-document fails there rather than the first time something is authorized against it. It has to be a
-JSON policy document whose statements each carry an `Effect` of `Allow` or `Deny`, an `Action` or
-`NotAction`, and a `Resource` or `NotResource`. Anything else fails with `InvalidAttributeValue`.
+The policy is validated when it is set, by `CreateQueue` or `SetQueueAttributes`. A malformed
+document fails there, before anything has been authorized against it. It has to be a JSON policy
+document whose statements each carry an `Effect` of `Allow` or `Deny`, an `Action` or `NotAction`,
+and a `Resource` or `NotResource`. Anything else fails with `InvalidAttributeValue`.
 
 `GetQueueAttributes` reports `Policy` back as the string it was set with.
 
@@ -678,9 +676,9 @@ console.log(sent.Failed?.[0]?.Code); // "InvalidParameterValue"
 
 ## Deleting a queue
 
-`DeleteQueue` removes the queue and everything on it. The name is not free straight away: real SQS
-holds a deleted queue's name for 60 seconds, and so does this. Advancing simulated time past it frees
-the name, which is what a redeployed stack depends on.
+`DeleteQueue` removes the queue and everything on it. Real SQS holds a deleted queue's name for 60
+seconds, and so does this. Advancing simulated time past the hold frees the name. A stack redeployed
+in the same test depends on that.
 
 ```typescript sim-sqs-delete-queue
 /**
@@ -719,8 +717,7 @@ console.log(recreated.QueueUrl === QueueUrl); // true
 ## Scoping
 
 Queues belong to an account and a region, as they do on real AWS. A queue name is unique within one
-account and region and nowhere wider, so the same name can be used in two regions for two different
-queues.
+account and region and nowhere wider. The same name can name two different queues in two regions.
 
 ```typescript sim-sqs-scoping
 /**
@@ -861,8 +858,8 @@ console.log(Buffer.from(invoked.Payload ?? []).toString("utf8")); // "\"order-1\
 ```
 
 See [simulated Lambda](../lambda/ "Simulated Lambda docs") for how function code and execution roles
-work. The same applies to `SimSdk` interception: intercepting `SQSClient` routes ordinary SDK code into
-the simulation with nothing touching the network. See
+work. `SimSdk` interception works the same way. Intercepting `SQSClient` routes ordinary SDK code
+into the simulation with nothing touching the network, covered under
 [AWS SDK interception](../../sdk/ "Simulated AWS SDK docs").
 
 ## Triggering a Lambda from a queue
@@ -871,7 +868,7 @@ A Lambda event source mapping delivers messages from a queue to a function witho
 `ReceiveMessage` itself. Messages sent to the queue arrive at the handler as an SQS event, in
 batches of up to `BatchSize`.
 
-Delivery runs on the simulation's background scheduler, so a test waits for it with
+Delivery runs on the simulation's background scheduler. A test waits for it with
 `simAws.backgroundTasksComplete()`.
 
 ```typescript sim-sqs-lambda-event-source
@@ -978,8 +975,8 @@ console.log(remaining.Messages); // undefined
 
 A handler that throws leaves the whole batch on the queue instead. The messages stay hidden until
 their visibility timeout lapses, come back after that, and eventually move to the dead-letter queue
-if the queue has a `RedrivePolicy`. That is the same path any other failing consumer takes, so
-advancing the clock is what drives it:
+if the queue has a `RedrivePolicy`. That is the path any other failing consumer takes, and advancing
+the clock is what drives it:
 
 ```typescript
 await simAws.clock().advanceBy({ seconds: 31 });
@@ -992,10 +989,10 @@ source mapping docs") for the event shape, partial batch failures, and the
 ## Deploying a queue from CloudFormation
 
 Simulated CloudFormation creates a queue from an `AWS::SQS::Queue` resource, in the stack's account
-and region. The queue is created through `CreateQueue`, so a template-created queue is the same thing
-an SDK caller would get: the same name validation, the same attribute ranges, the same ARN and URL.
+and region. The queue is created through `CreateQueue`. A template-created queue gets the same name
+validation, the same attribute ranges and the same ARN and URL as one an SDK caller creates.
 
-`Ref` on the resource gives the queue URL rather than its name or ARN, as it does on real AWS, so it
+`Ref` on the resource gives the queue URL rather than its name or ARN, as it does on real AWS, and it
 can be handed straight to `SendMessage`. `Fn::GetAtt … Arn`, `Fn::GetAtt … QueueName` and
 `Fn::GetAtt … QueueUrl` give those.
 
@@ -1051,30 +1048,30 @@ console.log(stack.outputs.get("OrdersQueueArn")?.value);
 
 The properties applied to the queue are `VisibilityTimeout`, `DelaySeconds`,
 `MessageRetentionPeriod`, `MaximumMessageSize` and `ReceiveMessageWaitTimeSeconds`. Each is passed to
-`CreateQueue`, so a value outside the range real SQS accepts fails the resource.
+`CreateQueue`, and a value outside the range real SQS accepts fails the resource.
 
-A queue with no `QueueName` is named from the stack name and the logical ID, so the queue above with
-its name left out would be `orders-stack-OrdersQueue`. Real CloudFormation adds random characters to
+A queue with no `QueueName` is named from the stack name and the logical ID. The queue above with its
+name left out would be `orders-stack-OrdersQueue`. Real CloudFormation adds random characters to
 that, which a template cannot predict either way. The generated name is trimmed to the 80 characters
 a queue name allows, ending in a hash of the untrimmed name so two long names that start the same
 stay apart.
 
 `FifoQueue: true` fails the resource. Only standard queues are simulated, and a FIFO queue is named
-`<name>.fifo`, which simulated SQS refuses to an SDK caller as well, so there is no queue to create
+`<name>.fifo`, a name simulated SQS refuses to an SDK caller as well. There is no queue to create
 under the name the template gave it.
 
-The properties with behaviour that is not simulated are a different case: the queue is created
-without them and each one is recorded in
-[`stack.ignoredProperties`](../cloudformation/README.md#properties-a-resource-was-created-without),
-so a stack full of queues still deploys. Those are `RedrivePolicy`, `RedriveAllowPolicy`,
+The properties this simulation has no behaviour for are a different case. The queue is created without
+them and each one is recorded in
+[`stack.ignoredProperties`](../cloudformation/README.md#properties-a-resource-was-created-without).
+A stack full of queues still deploys. Those properties are `RedrivePolicy`, `RedriveAllowPolicy`,
 `KmsMasterKeyId`, `KmsDataKeyReusePeriodSeconds`, `SqsManagedSseEnabled`,
 `ContentBasedDeduplication`, `DeduplicationScope`, `FifoThroughputLimit` and `Tags`. A property
-`AWS::SQS::Queue` does not have is recorded the same way.
+`AWS::SQS::Queue` never had is recorded the same way.
 
 `AWS::SQS::QueuePolicy` deploys the policy it names onto each queue in its `Queues` list, through
 `SetQueueAttributes`. A policy declared in a template is therefore validated and enforced exactly as
 one set through the SDK, and a document SQS would refuse fails the resource. `Queues` carries queue
-URLs, which is what `Ref` on an `AWS::SQS::Queue` gives.
+URLs, and `Ref` on an `AWS::SQS::Queue` gives one.
 
 ```typescript
 {
@@ -1133,53 +1130,54 @@ Current documented limitations:
 - Standard queues only. A queue name ending in `.fifo` is refused, as are `MessageGroupId`,
   `MessageDeduplicationId` and `ReceiveRequestAttemptId`.
 - Ordering and duplicates are stricter here than AWS promises. Messages come back oldest first, and a
-  message is handed out to one consumer at a time. Real standard queues make no ordering promise and
-  guarantee at-least-once delivery, so there a copy of a message can arrive twice and messages can
-  arrive out of order. Redelivery after a visibility timeout lapses is simulated, since that follows
-  from the timeout; a duplicate arriving on its own is not.
-- Long polling does not wait. `WaitTimeSeconds` and `ReceiveMessageWaitTimeSeconds` are accepted and
-  validated, and a receive returns at once. Nothing else is running in process that could send a
-  message during the wait, so waiting could only ever time out.
+  message is handed out to one consumer at a time. Real standard queues promise no ordering at all
+  and guarantee at-least-once delivery, so a copy of a message can arrive twice there and messages
+  can arrive out of order. Redelivery after a visibility timeout lapses is simulated, since that
+  follows from the timeout. A duplicate arriving on its own is left out.
+- Long polling answers at once. `WaitTimeSeconds` and `ReceiveMessageWaitTimeSeconds` are accepted
+  and validated, and a receive returns immediately. The whole simulation runs in the calling process,
+  where a wait could only ever time out.
 - `DeleteQueue` and `PurgeQueue` take effect immediately, where real SQS may take up to 60 seconds
   over either. The 60 second hold on a deleted queue's name is simulated, so recreating a queue
   straight after deleting it fails with `QueueDeletedRecently` until the clock moves on.
 - Dead-letter queues are simulated for standard queues only, and only the `RedrivePolicy` half of
   them. Setting `RedriveAllowPolicy` through the SQS API is refused, and on an `AWS::SQS::Queue` it
-  is recorded and the queue created without it, so a dead-letter queue cannot restrict which queues
-  may redrive to it either way. `ListDeadLetterSourceQueues` and the `StartMessageMoveTask` family for draining a
-  dead-letter queue back to its source are not supported, so a redriven message is moved back by a
-  test sending it again.
+  is recorded and the queue created without it. A dead-letter queue cannot restrict which queues may
+  redrive to it either way. `ListDeadLetterSourceQueues` and the `StartMessageMoveTask` family for
+  draining a dead-letter queue back to its source are absent. A test moves a redriven message back by
+  sending it again.
 - `ApproximateReceiveCount` starting again from one on a dead-letter queue is this simulation's
-  reading of SQS rather than something AWS documents. A receive count counts receives from one queue,
-  and the moved message has not been received from the dead-letter queue yet. `SentTimestamp` being
-  unchanged by the move is documented AWS behaviour, and is simulated as such.
-- The `RedrivePolicy` property on `AWS::SQS::Queue` is not simulated, so a dead-letter queue is
-  configured by an SDK call rather than by a template. The queue is created without the property and
-  the omission is recorded in `stack.ignoredProperties`.
+  reading of SQS, and AWS documents no answer either way. A receive count counts receives from one
+  queue, and the moved message has not been received from the dead-letter queue yet. `SentTimestamp`
+  being unchanged by the move is documented AWS behaviour, and is simulated as such.
+- The `RedrivePolicy` property on `AWS::SQS::Queue` is left out, and an SDK call is what configures a
+  dead-letter queue. The queue is created without the property and the omission is recorded in
+  `stack.ignoredProperties`.
 - A queue policy is set through the `Policy` attribute only. `AddPermission` and `RemovePermission`,
-  which are shorthands for writing one statement of it, are not supported.
+  shorthands for writing one statement of it, are absent.
 - `GetQueueAttributes` reports the `Policy` string that was set. Real SQS re-serialises the document
-  and adds an `Id` and a `Sid` to it, so what comes back there is not byte for byte what went in.
+  and adds an `Id` and a `Sid` to it, so what comes back there differs from what went in.
 - A request naming a `QueueOwnerAWSAccountId` other than the scope's own account is refused. A queue
-  policy admits another account's principal to a queue here; it does not make another account's
-  queues reachable through this one.
-- Encryption is not simulated. `KmsMasterKeyId`, `KmsDataKeyReusePeriodSeconds` and
-  `SqsManagedSseEnabled` are recorded rather than applied on an `AWS::SQS::Queue`, and message bodies
-  are held in process memory as they were sent. That is not a security boundary: anything sharing the process can reach them.
-- Tags are not simulated. `TagQueue`, `UntagQueue` and `ListQueueTags` are not supported, and
-  `CreateQueue` refuses a `tags` parameter rather than dropping it.
-- `SenderId` is not reported, because a simulated caller has no user or role id to report it as.
-  `AWSTraceHeader` is not reported either, and `MessageSystemAttributes` on a send are refused. Asking
-  for any of them is accepted, as real SQS accepts a request for an attribute a message has no value
-  for, and they are left out of the response.
-- SQS condition keys are not derived, so a policy relying on them will not match. Ordinary condition
+  policy admits another account's principal to a queue here, and leaves that account's own queues
+  unreachable from this one.
+- Encryption is left out. `KmsMasterKeyId`, `KmsDataKeyReusePeriodSeconds` and
+  `SqsManagedSseEnabled` are recorded on an `AWS::SQS::Queue` and applied to nothing, and message
+  bodies are held in process memory as they were sent. Anything sharing the process can read them.
+- Tags are left out. `TagQueue`, `UntagQueue` and `ListQueueTags` are absent, and `CreateQueue`
+  refuses a `tags` parameter rather than dropping it.
+- `SenderId` is left out, because a simulated caller has no user or role id to report it as.
+  `AWSTraceHeader` is left out too, and `MessageSystemAttributes` on a send are refused. Asking for
+  any of them is accepted, as real SQS accepts a request for an attribute a message has no value for,
+  and they are absent from the response.
+- SQS condition keys are left out, and a policy relying on one matches nothing. Ordinary condition
   operators on values sim IAM does supply work as usual.
-- `ChangeMessageVisibilityBatch` and the batch size limit (`BatchRequestTooLong`) are not supported.
+- `ChangeMessageVisibilityBatch` and the batch size limit (`BatchRequestTooLong`) are absent.
 - A Lambda event source mapping polls one batch at a time. Real Lambda runs several pollers at once
-  and scales them with the queue, so nothing here shows what that concurrency does to ordering. See
+  and scales them with the queue, and what that concurrency does to ordering is invisible here. See
   [simulated Lambda](../lambda/#triggering-a-function-from-an-sqs-queue "Simulated Lambda event
 source mapping docs") for the rest of the mapping limitations.
 - `AWS::SQS::Queue` and `AWS::SQS::QueuePolicy` are the SQS resource types CloudFormation creates.
-  Any other is skipped, and the queue properties this simulation has no behaviour for fail the
-  resource rather than being dropped.
+  Any other is reported as unsupported and skipped. A queue attribute outside the range real SQS
+  accepts fails the resource, and a property it has no behaviour for is recorded and the queue
+  created without it.
 - SQS is not served as an HTTP API by `serveSimAws`.

--- a/docs/services/sqs/README.md
+++ b/docs/services/sqs/README.md
@@ -125,7 +125,7 @@ See [simulated time](../../time/ "Simulated time docs") for what else the clock 
 
 Every receive issues a fresh receipt handle, and a delete has to use the handle from the most recent
 receive of that message. A handle from an earlier receive is accepted and deletes nothing. Real SQS
-treats a stale handle the same way.
+accepts one too, and promises only that the message might not be deleted.
 
 That is the failure a consumer slower than its visibility timeout hits. Its message went back on the
 queue, someone else took it, and its own delete quietly does nothing.
@@ -378,9 +378,10 @@ console.log(message?.MD5OfMessageAttributes === sent.MD5OfMessageAttributes); //
 console.log(message?.MD5OfBody === sent.MD5OfMessageBody); // true
 ```
 
-The name and data type rules are the real ones. A reserved `AWS.` or `Amazon.` prefix on a name, a
-data type outside `String`, `Number` and `Binary`, or a value that disagrees with its data type is
-refused. A test finds any of those without going near AWS.
+The name and data type rules are the real ones. A data type is `String`, `Number` or `Binary`, and
+each takes a custom label after a dot, so `Number.int` is a number as far as the rules go. A
+reserved `AWS.` or `Amazon.` prefix on a name, a data type built on none of the three, or a value
+that disagrees with its data type is refused. A test finds any of those without going near AWS.
 
 The message system attributes are asked for separately, with `MessageSystemAttributeNames`, or with
 the discontinued `AttributeNames` that means the same thing. `SentTimestamp`,
@@ -544,8 +545,9 @@ try {
 ## Queue policies
 
 A queue's `Policy` attribute is its resource policy, and simulated IAM evaluates it as one. It is
-what admits a caller that has no identity policy of its own. A principal from another account is one,
-and so is a service principal such as `s3.amazonaws.com`, which owns no identity policies anywhere.
+what admits a service principal such as `s3.amazonaws.com`, which owns no identity policies
+anywhere. It is also half of what admits a principal from another account, which needs an identity
+policy in its own account as well.
 
 The policy is set with `CreateQueue` or `SetQueueAttributes` and read back with
 `GetQueueAttributes`.
@@ -1066,7 +1068,7 @@ them and each one is recorded in
 A stack full of queues still deploys. Those properties are `RedrivePolicy`, `RedriveAllowPolicy`,
 `KmsMasterKeyId`, `KmsDataKeyReusePeriodSeconds`, `SqsManagedSseEnabled`,
 `ContentBasedDeduplication`, `DeduplicationScope`, `FifoThroughputLimit` and `Tags`. A property
-`AWS::SQS::Queue` never had is recorded the same way.
+outside the `AWS::SQS::Queue` schema is recorded the same way.
 
 `AWS::SQS::QueuePolicy` deploys the policy it names onto each queue in its `Queues` list, through
 `SetQueueAttributes`. A policy declared in a template is therefore validated and enforced exactly as
@@ -1138,7 +1140,7 @@ Current documented limitations:
   and validated, and a receive returns immediately. The whole simulation runs in the calling process,
   where a wait could only ever time out.
 - `DeleteQueue` and `PurgeQueue` take effect immediately, where real SQS may take up to 60 seconds
-  over either. The 60 second hold on a deleted queue's name is simulated, so recreating a queue
+  over either. The 60-second hold on a deleted queue's name is simulated, so recreating a queue
   straight after deleting it fails with `QueueDeletedRecently` until the clock moves on.
 - Dead-letter queues are simulated for standard queues only, and only the `RedrivePolicy` half of
   them. Setting `RedriveAllowPolicy` through the SQS API is refused, and on an `AWS::SQS::Queue` it


### PR DESCRIPTION
Brief, concise description of the change:

Rewrites the SQS, SNS, Lambda and S3 usage READMEs to plain technical prose, which finishes the sweep #645, #648, #650, #656 and #658 started. Every file in `docs/` is now under the prose checker's fail thresholds. Five stale claims were found while rewriting and are corrected here: the SQS limitations said a template property with no simulated behaviour fails the resource, where it is recorded and the queue created without it; the SNS IAM section promised two details and then listed three; the SNS delivery status logging limitation explained itself by CloudWatch Logs being unsimulated, which stopped being true when sim CloudWatch Logs landed; the Lambda page said the `AWS::Lambda::Permission` CDK writes beside a Function URL is skipped with a diagnostic, where it deploys, as the same page says forty lines earlier; and two hard-wrapped passages had lost their wrapping.

Prose only. Every fenced code block is byte-identical to `main`, checked programmatically, so nothing changes for the `*.example.ts` extraction. Headings, bullets, fences and tables all match too.

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified simulated Lambda behavior, including execution, errors, logging, retries, authorization, event sources, Function URLs, CloudFormation integration, and limitations.
  - Expanded S3 documentation covering listings, notifications, policies, websites, presigned URLs, metadata, integrations, and unsupported features.
  - Refined SNS guidance for publishing, subscriptions, filtering, delivery, authorization, integrations, and limitations.
  - Clarified SQS behavior for visibility, retention, dead-letter queues, authorization, integrations, validation, and queue lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->