### PR TITLE
feat: reset a forgotten password in sim Cognito

### DIFF
--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -498,15 +498,149 @@ with `NotAuthorizedException`, as a real one does. That value is what a CDK `Use
 `selfSignUpEnabled` emits. A project testing its registration flow gets the same answer here that
 the deployed pool would give. A pool created without the setting allows sign-up, the AWS default.
 
+## Resetting a forgotten password
+
+A user that cannot get in asks for a code with `ForgotPassword` and sets a new password with
+`ConfirmForgotPassword`. Both name an app client, and neither is authorized by an IAM policy. They
+are the pair an application calls when it has built its own sign-in screens.
+
+The code goes to the same place a sign-up code goes, and is read back the same way, through
+`confirmationCode` on the pool object. `ForgotPassword` answers with `CodeDeliveryDetails` naming
+the medium and a masked destination, which an application prints to say where the user should go
+and look.
+
+```typescript sim-cognito-forgot-password
+/**
+ * Resetting a forgotten password with the code the pool issued.
+ */
+
+import {
+  ConfirmForgotPasswordCommand,
+  ConfirmSignUpCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  ForgotPasswordCommand,
+  InitiateAuthCommand,
+  SignUpCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const cognito = simAws.cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({
+    PoolName: "myapp-users",
+    AutoVerifiedAttributes: ["email"],
+  }),
+);
+const userPoolId = pool.UserPool!.Id!;
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: userPoolId,
+    ClientName: "web",
+    ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH"],
+  }),
+);
+const clientId = appClient.UserPoolClient!.ClientId!;
+
+await cognito.signUp(
+  new SignUpCommand({
+    ClientId: clientId,
+    Username: "alice",
+    Password: "Sup3rSecret!",
+    UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+  }),
+);
+await cognito.confirmSignUp(
+  new ConfirmSignUpCommand({
+    ClientId: clientId,
+    Username: "alice",
+    ConfirmationCode: cognito.userPool(userPoolId).confirmationCode("alice"),
+  }),
+);
+
+// The user has forgotten the password it chose at sign-up.
+const asked = await cognito.forgotPassword(
+  new ForgotPasswordCommand({ ClientId: clientId, Username: "alice" }),
+);
+
+console.log(asked.CodeDeliveryDetails?.DeliveryMedium); // "EMAIL"
+console.log(asked.CodeDeliveryDetails?.Destination); // "a***@e***.com"
+
+// Real Cognito sends this to the user and never reports it, as with a sign-up
+// code. The pool hands it over instead.
+const code = cognito.userPool(userPoolId).confirmationCode("alice");
+
+await cognito.confirmForgotPassword(
+  new ConfirmForgotPasswordCommand({
+    ClientId: clientId,
+    Username: "alice",
+    ConfirmationCode: code,
+    Password: "Ev3nBetter!",
+  }),
+);
+
+// The user is CONFIRMED, and the new password is the one that signs it in.
+const signedIn = await cognito.initiateAuth(
+  new InitiateAuthCommand({
+    ClientId: clientId,
+    AuthFlow: "USER_PASSWORD_AUTH",
+    AuthParameters: { USERNAME: "alice", PASSWORD: "Ev3nBetter!" },
+  }),
+);
+
+console.log(signedIn.AuthenticationResult?.AccessToken !== undefined); // true
+```
+
+The user reaches `CONFIRMED` once the reset lands, which also confirms one that never confirmed its
+sign-up. The password it had before stops working.
+
+A wrong code is refused with `CodeMismatchException`, and the user keeps the code it was issued for
+a second attempt. A spent code is refused with `ExpiredCodeException`. That is what real Cognito
+calls a code it will no longer take. The new password is held to the pool's password policy, and one the policy refuses raises
+`InvalidPasswordException` (the same refusal `AdminSetUserPassword` gives).
+
+Asking twice issues a second code and the first one stops working, the way `ResendConfirmationCode`
+replaces a sign-up code.
+
+`ForgotPassword` sends its code to an attribute the pool verifies automatically, preferring `email`
+over `phone_number`. A user the pool can reach at neither is refused with
+`InvalidParameterException`, in the words real Cognito refuses with. A user still holding a
+temporary password is refused with `NotAuthorizedException` and belongs at the
+`NEW_PASSWORD_REQUIRED` challenge.
+
+An app client's `PreventUserExistenceErrors` decides what a reset naming an unknown user gets. A
+client left on the `LEGACY` default answers `UserNotFoundException`. A client set to `ENABLED`
+answers as though a code had gone out, with a made-up destination. That closes the operation as a
+way of finding out who has an account.
+
+An app client created with a secret has its `SECRET_HASH` checked on both operations, computed over
+the username and the client id the way the sign-in operations compute it.
+
+### Resetting a password as an administrator
+
+`AdminResetUserPassword` takes a user's password away and leaves it in `RESET_REQUIRED`. It names
+the pool and the user, and is authorized by IAM the way the other admin operations are. From there
+the user is refused at sign-in with `PasswordResetRequiredException` until it answers
+`ConfirmForgotPassword` with the code the reset issued. The pool records the message carrying that
+code, under the `ForgotPassword` occasion.
+
+A federated user has no password in the pool, and both the user's own reset and the administrator's
+are refused for one.
+
 ## Messages a pool would have sent
 
 Nothing here delivers an email or a text message. A pool records what it would have sent instead,
 and `sentMessages` on the pool object hands the record over. Each message carries the recipient, the
 medium, the subject, the body and the occasion it was sent on.
 
-A message is recorded on three occasions. Those are a `SignUp`, a `ResendConfirmationCode`, and an
-`AdminCreateUser` that did not ask for `MessageAction: SUPPRESS`. The verification wording is the
-pool's own, and `{####}` is replaced with the code the user was issued. A sign-up a `PreSignUp`
+A message is recorded on five occasions. Those are a `SignUp`, a `ResendConfirmationCode`, an
+`AdminCreateUser` that did not ask for `MessageAction: SUPPRESS`, an MFA code sent by text message,
+and a password reset the user or an administrator started. The verification wording is the pool's
+own, and `{####}` is replaced with the code the user was issued. A sign-up a `PreSignUp`
 handler auto-confirmed records none. That user has no code to answer with, and real Cognito sends it
 nothing.
 
@@ -595,8 +729,9 @@ handler writes into `response.emailSubject`, `response.emailMessage` and `respon
 replaces the pool's own wording. The handler writes `request.codeParameter` into its message where
 the code belongs, as it does on real Cognito, and the code goes in afterwards.
 
-`triggerSource` names the occasion: `CustomMessage_SignUp`, `CustomMessage_ResendCode` or
-`CustomMessage_AdminCreateUser`. The invitation carries `request.usernameParameter` as well.
+`triggerSource` names the occasion: `CustomMessage_SignUp`, `CustomMessage_ResendCode`,
+`CustomMessage_AdminCreateUser`, `CustomMessage_Authentication` or `CustomMessage_ForgotPassword`.
+The invitation carries `request.usernameParameter` as well.
 
 ```typescript sim-cognito-custom-message
 /**
@@ -1740,19 +1875,22 @@ that only the matching `code_verifier` exchanges. `plain` is refused, as it is b
 A pool created with a `LambdaConfig` runs the functions it names as part of a sign-up, a sign-in or
 a message. Each one is given the real event and has to return it, changed or not.
 
-| Trigger              | Fires                                                                  | `triggerSource`                        |
-| -------------------- | ---------------------------------------------------------------------- | -------------------------------------- |
-| `PreSignUp`          | `SignUp`, before the pool takes the new user                           | `PreSignUp_SignUp`                     |
-| `PreSignUp`          | `AdminCreateUser`, before the pool takes the new user                  | `PreSignUp_AdminCreateUser`            |
-| `PostConfirmation`   | `ConfirmSignUp` and `AdminConfirmSignUp`, once the user is `CONFIRMED` | `PostConfirmation_ConfirmSignUp`       |
-| `PreAuthentication`  | a sign-in, once the user is known and before its password is checked   | `PreAuthentication_Authentication`     |
-| `PreTokenGeneration` | a sign-in, where the claims of its tokens are settled                  | `TokenGeneration_Authentication`       |
-| `PreTokenGeneration` | the sign-in that finishes by answering the new password challenge      | `TokenGeneration_NewPasswordChallenge` |
-| `PreTokenGeneration` | a `REFRESH_TOKEN_AUTH` refresh, over the tokens it reissues            | `TokenGeneration_RefreshTokens`        |
-| `PostAuthentication` | a sign-in, once the tokens have been issued                            | `PostAuthentication_Authentication`    |
-| `CustomMessage`      | `SignUp`, before the verification message is recorded                  | `CustomMessage_SignUp`                 |
-| `CustomMessage`      | `ResendConfirmationCode`, before the message is recorded               | `CustomMessage_ResendCode`             |
-| `CustomMessage`      | `AdminCreateUser`, before the invitation is recorded                   | `CustomMessage_AdminCreateUser`        |
+| Trigger              | Fires                                                                         | `triggerSource`                          |
+| -------------------- | ----------------------------------------------------------------------------- | ---------------------------------------- |
+| `PreSignUp`          | `SignUp`, before the pool takes the new user                                  | `PreSignUp_SignUp`                       |
+| `PreSignUp`          | `AdminCreateUser`, before the pool takes the new user                         | `PreSignUp_AdminCreateUser`              |
+| `PostConfirmation`   | `ConfirmSignUp` and `AdminConfirmSignUp`, once the user is `CONFIRMED`        | `PostConfirmation_ConfirmSignUp`         |
+| `PostConfirmation`   | `ConfirmForgotPassword`, once the reset has confirmed the user                | `PostConfirmation_ConfirmForgotPassword` |
+| `PreAuthentication`  | a sign-in, once the user is known and before its password is checked          | `PreAuthentication_Authentication`       |
+| `PreTokenGeneration` | a sign-in, where the claims of its tokens are settled                         | `TokenGeneration_Authentication`         |
+| `PreTokenGeneration` | the sign-in that finishes by answering the new password challenge             | `TokenGeneration_NewPasswordChallenge`   |
+| `PreTokenGeneration` | a `REFRESH_TOKEN_AUTH` refresh, over the tokens it reissues                   | `TokenGeneration_RefreshTokens`          |
+| `PostAuthentication` | a sign-in, once the tokens have been issued                                   | `PostAuthentication_Authentication`      |
+| `CustomMessage`      | `SignUp`, before the verification message is recorded                         | `CustomMessage_SignUp`                   |
+| `CustomMessage`      | `ResendConfirmationCode`, before the message is recorded                      | `CustomMessage_ResendCode`               |
+| `CustomMessage`      | `AdminCreateUser`, before the invitation is recorded                          | `CustomMessage_AdminCreateUser`          |
+| `CustomMessage`      | an MFA code, before the text message is recorded                              | `CustomMessage_Authentication`           |
+| `CustomMessage`      | `ForgotPassword` and `AdminResetUserPassword`, before the message is recorded | `CustomMessage_ForgotPassword`           |
 
 `CustomMessage` is the one whose response is read for more than a flag, and it is covered in
 [The CustomMessage trigger](#the-custommessage-trigger) above. The rest are here.
@@ -2665,10 +2803,10 @@ for anything, and a client created with `disableOAuth` emits two on `AWS::Cognit
 Most of them are simulated: `AdminCreateUserConfig` decides whether `SignUp` works against the pool,
 and the four verification wording properties are what a recorded message says.
 
-`AccountRecoverySetting` is the exception. There is no `ForgotPassword` here, so no recovery is ever
-started and no mechanism is ever chosen. The pool records the mechanisms it was asked for
-and `DescribeUserPool` reports them back, so what a template declared stays visible. The two app
-client properties are accepted at one value each instead.
+`AccountRecoverySetting` is the exception. `ForgotPassword` sends its code to an attribute the pool
+verifies automatically, so the mechanisms a pool ranked decide nothing here. The pool records the
+mechanisms it was asked for and `DescribeUserPool` reports them back, so what a template declared
+stays visible. The two app client properties are accepted at one value each instead.
 
 ```typescript sim-cognito-cdk-defaults
 /**
@@ -3455,6 +3593,9 @@ Sim Cognito currently supports:
 - `SignUpCommand`, `ConfirmSignUpCommand` and `ResendConfirmationCodeCommand`, authorized by no IAM
   policy as they are on real Cognito, and `AdminConfirmSignUpCommand`, authorized like the other
   admin operations
+- `ForgotPasswordCommand` and `ConfirmForgotPasswordCommand`, authorized by no IAM policy either,
+  with the reset code read back off the pool and the masked `CodeDeliveryDetails` reported, and
+  `AdminResetUserPasswordCommand`, which leaves a user in `RESET_REQUIRED`
 - The `PreSignUp` and `PostConfirmation` Lambda triggers, with `autoConfirmUser`, `autoVerifyEmail`
   and `autoVerifyPhone` applied, and with the `ValidationData` and `ClientMetadata` a request
   carries reaching the handler
@@ -3515,7 +3656,8 @@ Sim Cognito currently supports:
 - Pool ids in the real `<region>_<nine characters>` form, and pool ARNs built from them
 - The real default password policy, applied to the passwords users are given
 - The real user status lifecycle, in which an admin-created user stays in `FORCE_CHANGE_PASSWORD`
-  until it has a permanent password, and a signed-up user stays in `UNCONFIRMED` until it confirms
+  until it has a permanent password, a signed-up user stays in `UNCONFIRMED` until it confirms, and
+  a user an administrator reset stays in `RESET_REQUIRED` until it sets a password of its own
 - Group membership, and the precedence order the `cognito:groups` claim uses
 - App client authentication flows, token lifetimes, generated client secrets and
   `PreventUserExistenceErrors`
@@ -3567,18 +3709,30 @@ Current documented limitations:
   Those are the two Cognito can send a code to.
 - `ConfirmSignUp` and `ResendConfirmationCode` report a user the pool lacks whatever the app
   client's `PreventUserExistenceErrors` says. That setting is honoured for sign-in only.
-- Password reset is outside the simulation. `ForgotPassword`, `ConfirmForgotPassword` and
-  `ChangePassword` are unimplemented, leaving the `RESET_REQUIRED` status unreachable.
+- A reset code never expires either, where a real one lasts an hour. A second `ForgotPassword`
+  replaces it, and answering with it spends it. A spent code is refused with `ExpiredCodeException`.
+  That is what real Cognito calls a code it will no longer take.
+- `ForgotPassword` sends its code to an attribute the pool verifies automatically, and refuses a
+  user the pool can reach at neither `email` nor `phone_number`. Real Cognito chooses by the pool's
+  `AccountRecoverySetting`, which is recorded here and read by nothing, so a pool that recovers by
+  email alone behaves here exactly as one that recovers by phone number would.
+- The destination `ForgotPassword` reports is masked in real Cognito's shape rather than in a shape
+  read back from a live account. Assert that a destination came back and which medium carried it.
+- `ChangePassword` is unimplemented. It is the signed-in user replacing a password it still knows,
+  and it belongs to a different flow.
 - Unsimulated sign-up inputs are refused rather than ignored: `AnalyticsMetadata` and
-  `UserContextData` on the three client-side operations, and `ForceAliasCreation` and `Session` on
-  `ConfirmSignUp`. `ClientMetadata` is absent from that list, because each reaches a trigger that
-  runs here.
+  `UserContextData` on the three client-side operations and on the two password reset ones, and
+  `ForceAliasCreation` and `Session` on `ConfirmSignUp`. `ClientMetadata` is absent from that list,
+  because each reaches a trigger that runs here.
 - No message is ever delivered. A pool records what it would have sent and `sentMessages` reads it
   back, which real Cognito reports to nobody. Nothing leaves the simulation, and no
-  `CodeDeliveryDetails` is reported by `SignUp` or `ResendConfirmationCode`.
-- A message is recorded on three occasions, being `SignUp`, `ResendConfirmationCode` and
-  `AdminCreateUser`. Password reset, MFA and the account-taken-over notices are occasions real
-  Cognito sends on and this simulation never reaches.
+  `CodeDeliveryDetails` is reported by `SignUp` or `ResendConfirmationCode`. `ForgotPassword`
+  reports one, as real Cognito does.
+- A message is recorded on five occasions, being `SignUp`, `ResendConfirmationCode`,
+  `AdminCreateUser`, `Authentication` (an MFA code sent by text message) and `ForgotPassword`, which
+  covers the reset an administrator starts as well as the one the user asks for. Attribute
+  verification and the account-taken-over notices are occasions real Cognito sends on and this
+  simulation never reaches.
 - A verification message is recorded only for an attribute the pool verifies automatically. A pool
   with no `AutoVerifiedAttributes` records none, and only for a user that has to confirm. One a
   `PreSignUp` handler auto-confirmed is sent nothing, as on real Cognito. An invitation is recorded
@@ -3701,8 +3855,9 @@ Current documented limitations:
 - `AdminCreateUser` leaves `PostConfirmation` unfired, here and on real Cognito. It is the tempting
   place to hang the trigger and the wrong one. A project relying on it would pass here and write no
   record in production.
-- `PostConfirmation_ConfirmForgotPassword` goes unreached, because password reset is outside the
-  simulation. `PostConfirmation_ConfirmSignUp` is the only source the trigger reports.
+- `PostConfirmation` reports two sources, being `PostConfirmation_ConfirmSignUp` and
+  `PostConfirmation_ConfirmForgotPassword`. A handler that hangs a profile record off the first
+  confirmation sees the second one too.
 - A `PreSignUp` handler asking to verify an attribute the sign-up did not carry refuses the sign-up
   with `InvalidParameterException`. Real Cognito refuses it too, and what it names the error has not
   been checked against a live account.
@@ -3735,18 +3890,18 @@ Current documented limitations:
   `AdminRespondToAuthChallenge` alone, as it does on real Cognito. A refresh accepts one and it
   reaches nothing.
 - A `CustomMessage` event reports `CLIENT_ID_NOT_APPLICABLE` as its `callerContext.clientId` for an
-  `AdminCreateUser`, as real Cognito does for an admin operation, and names the app client for the
-  two occasions that come through one.
+  `AdminCreateUser` and an `AdminResetUserPassword`, as real Cognito does for an admin operation,
+  and names the app client for the occasions that come through one.
 - Unsimulated `CreateUserPool` inputs are refused, never ignored: `AliasAttributes`,
   `UsernameConfiguration`, `UserAttributeUpdateSettings`, `DeviceConfiguration`, `UserPoolAddOns`,
   `KeyConfiguration`, `IssuerConfiguration`, `UserPoolTags`, the email and SMS configurations, an
   `SmsAuthenticationMessage`, a `UserPoolTier` other than `ESSENTIALS`, a `SignInPolicy`, and a
   `PasswordHistorySize`.
 - `AccountRecoverySetting` is recorded and reported back by `DescribeUserPool`, and no code reads
-  it, because there is no `ForgotPassword`. Any mechanisms Cognito has are accepted, in any order,
-  and a setting outside the shape Cognito states is refused. A pool that recovers by email alone
-  therefore behaves here exactly as one that recovers by phone number would, which only shows in a
-  recovery neither of them can start.
+  it. Any mechanisms Cognito has are accepted, in any order, and a setting outside the shape Cognito
+  states is refused. `ForgotPassword` picks its destination from the pool's `AutoVerifiedAttributes`
+  (`email` before `phone_number`), so a pool that recovers by email alone behaves here exactly as
+  one that recovers by phone number would.
 - `AdminCreateUserConfig.AllowAdminCreateUserOnly` is acted on, and the two keys beside it are
   refused. `InviteMessageTemplate` is the wording of the invitation, and a pool cannot set its own
   yet, leaving an invitation recorded at Cognito's default wording. `UnusedAccountValidityDays`
@@ -3784,8 +3939,8 @@ Current documented limitations:
 - A hosted sign-in that real managed login would answer with a further page is refused. That is a
   user which has registered a second factor, and a user holding a temporary password. Both
   challenges are simulated at `InitiateAuth` and `AdminInitiateAuth`, which is where a test drives
-  them. Password reset is unsimulated on either side, so `ForgotPassword` and
-  `ConfirmForgotPassword` are unimplemented and no page asks for a reset code.
+  them. No page asks for a reset code either. `ForgotPassword` and `ConfirmForgotPassword` are
+  simulated at the API, which is where a test drives a reset.
 - The implicit grant is refused, and so is the client credentials grant, which needs resource
   servers.
 - The served OpenID configuration names its `authorization_endpoint`, `token_endpoint` and

--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -3708,7 +3708,8 @@ Current documented limitations:
 - `AutoVerifiedAttributes` is accepted at `email` and `phone_number`, and anything else is refused.
   Those are the two Cognito can send a code to.
 - `ConfirmSignUp` and `ResendConfirmationCode` report a user the pool lacks whatever the app
-  client's `PreventUserExistenceErrors` says. That setting is honoured for sign-in only.
+  client's `PreventUserExistenceErrors` says. The sign-ins and the two password reset operations
+  honour the setting.
 - A reset code never expires either, where a real one lasts an hour. A second `ForgotPassword`
   replaces it, and answering with it spends it. A spent code is refused with `ExpiredCodeException`.
   That is what real Cognito calls a code it will no longer take.

--- a/docs/services/cognito/sim-cognito-forgot-password.example.ts
+++ b/docs/services/cognito/sim-cognito-forgot-password.example.ts
@@ -1,0 +1,83 @@
+/**
+ * Resetting a forgotten password with the code the pool issued.
+ */
+
+import {
+  ConfirmForgotPasswordCommand,
+  ConfirmSignUpCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  ForgotPasswordCommand,
+  InitiateAuthCommand,
+  SignUpCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const cognito = simAws.cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({
+    PoolName: "myapp-users",
+    AutoVerifiedAttributes: ["email"],
+  }),
+);
+const userPoolId = pool.UserPool!.Id!;
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: userPoolId,
+    ClientName: "web",
+    ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH"],
+  }),
+);
+const clientId = appClient.UserPoolClient!.ClientId!;
+
+await cognito.signUp(
+  new SignUpCommand({
+    ClientId: clientId,
+    Username: "alice",
+    Password: "Sup3rSecret!",
+    UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+  }),
+);
+await cognito.confirmSignUp(
+  new ConfirmSignUpCommand({
+    ClientId: clientId,
+    Username: "alice",
+    ConfirmationCode: cognito.userPool(userPoolId).confirmationCode("alice"),
+  }),
+);
+
+// The user has forgotten the password it chose at sign-up.
+const asked = await cognito.forgotPassword(
+  new ForgotPasswordCommand({ ClientId: clientId, Username: "alice" }),
+);
+
+console.log(asked.CodeDeliveryDetails?.DeliveryMedium); // "EMAIL"
+console.log(asked.CodeDeliveryDetails?.Destination); // "a***@e***.com"
+
+// Real Cognito sends this to the user and never reports it, as with a sign-up
+// code. The pool hands it over instead.
+const code = cognito.userPool(userPoolId).confirmationCode("alice");
+
+await cognito.confirmForgotPassword(
+  new ConfirmForgotPasswordCommand({
+    ClientId: clientId,
+    Username: "alice",
+    ConfirmationCode: code,
+    Password: "Ev3nBetter!",
+  }),
+);
+
+// The user is CONFIRMED, and the new password is the one that signs it in.
+const signedIn = await cognito.initiateAuth(
+  new InitiateAuthCommand({
+    ClientId: clientId,
+    AuthFlow: "USER_PASSWORD_AUTH",
+    AuthParameters: { USERNAME: "alice", PASSWORD: "Ev3nBetter!" },
+  }),
+);
+
+console.log(signedIn.AuthenticationResult?.AccessToken !== undefined); // true

--- a/src/service/cognito/README.md
+++ b/src/service/cognito/README.md
@@ -5,9 +5,9 @@ which exchange a token for AWS credentials, are a separate service and are not s
 
 The pool, the app client, the users and groups in it, self-service sign-up, the second factors a
 user registers, the sign-in flows on both sides of the API, the domain and identity providers a
-federated sign-in runs through, the messages it would have sent, the tokens it issues and the
-authorizer are all here. SRP, managed login's own pages, password resets and device tracking are
-not.
+federated sign-in runs through, the password reset a user goes through when it cannot sign in, the
+messages it would have sent, the tokens it issues and the authorizer are all here. SRP, managed
+login's own pages and device tracking are not.
 
 ## Entry points
 
@@ -80,8 +80,8 @@ ARN of its own.
 `SimCognitoPasswordPolicy` applies the defaults real Cognito applies when a request says nothing:
 eight characters, with an uppercase letter, a lowercase letter, a number and a symbol each required.
 `SimCognitoPasswordCheck` is what applies it to a password. The two are separate because the policy
-is part of the pool's state and the checking is not, and because both `AdminCreateUser` and
-`AdminSetUserPassword` need the same check.
+is part of the pool's state and the checking is not, and because `AdminCreateUser`,
+`AdminSetUserPassword` and `ConfirmForgotPassword` all need the same check.
 
 `SimCognitoExplicitAuthFlows` validates the authentication flows an app client supports. The values
 are checked rather than stored as written, because a typo in a flow name would otherwise turn into a
@@ -134,11 +134,19 @@ against the pool's policy when it is set, and held as a `SimCognitoUserPassword`
 whether a candidate matches and exposes nothing, the same modelling choice simulated KMS key
 material makes.
 
-`SimCognitoUserStatus` holds the three statuses this simulation can reach, and the transitions
-between them. `AdminCreateUser` leaves a user in `FORCE_CHANGE_PASSWORD`, and only a permanent
-password reaches `CONFIRMED`. `SignUp` leaves a user in `UNCONFIRMED`, and `ConfirmSignUp`,
-`AdminConfirmSignUp` or a permanent password reaches `CONFIRMED` from there. The rest of the real
-statuses belong to password resets and federation, neither of which is simulated.
+`SimCognitoUserStatus` holds the statuses this simulation can reach, and the transitions between
+them. `AdminCreateUser` leaves a user in `FORCE_CHANGE_PASSWORD`, and only a permanent password
+reaches `CONFIRMED`. `SignUp` leaves a user in `UNCONFIRMED`, and `ConfirmSignUp`,
+`AdminConfirmSignUp` or a permanent password reaches `CONFIRMED` from there.
+`AdminResetUserPassword` leaves a user in `RESET_REQUIRED`, and `ConfirmForgotPassword` is the way
+out. `ARCHIVED`, `COMPROMISED` and `UNKNOWN` belong to threat protection and to retired accounts. Neither
+is simulated.
+
+`SimCognitoUserPasswordReset` under `user-pool/user/` is the reset one user can go through. It
+issues the code, checks the code and moves the user, working through callbacks the user hands it,
+the way `SimCognitoUserMfa` does. The code it issues is the one `SimCognitoUserConfirmation` holds,
+because a user has one code outstanding at a time and a reset code and a sign-up code are the same
+six digits.
 
 `SimCognitoUserMfa` under `user-pool/user/mfa/` is the second factors one user has registered: the
 software token secret it is registering, the one it has registered, which factors are enabled and
@@ -153,9 +161,10 @@ authenticator library handed the `SecretCode` produces codes this accepts, and a
 registration is refused. A code either side of the current thirty-second step is accepted, which is
 what stops a code computed a moment before the request being refused for crossing a step boundary.
 
-`SimCognitoConfirmationCode` is the six-digit code a signed-up user is issued. A user gets one when
-it is constructed `UNCONFIRMED`, spends it when it leaves that status, and `ResendConfirmationCode`
-replaces it with another rather than sending the same one again. The code is readable, through
+`SimCognitoConfirmationCode` is the six-digit code a user is issued. A user gets one when it is
+constructed `UNCONFIRMED` and when it is moved to `RESET_REQUIRED`, spends it when it leaves that
+status, and `ResendConfirmationCode` and `ForgotPassword` each replace it with another rather than
+sending the same one again. The code is readable, through
 `SimCognitoUserPool.confirmationCode`, which real Cognito never allows: nothing here delivers a
 message, so a test would otherwise have nowhere to read it from. That accessor is the one place this
 simulation knowingly tells a caller something real Cognito would not.
@@ -408,9 +417,10 @@ its request set.
 
 `AccountRecoverySetting` is read rather than compared. `SimCfnCognitoAccountRecovery` parses the
 template's mechanisms and `SimCognitoAccountRecovery` holds them on the pool, refusing a setting
-outside the shape Cognito states for it. Nothing reads them back out: there is no `ForgotPassword` here, so the
-refusal that would have to choose a mechanism has nowhere to live yet, and the pool records what it
-was asked for so a described pool reports it.
+outside the shape Cognito states for it. Nothing reads them back out. `ForgotPassword` picks its
+destination from the pool's `AutoVerifiedAttributes` (the address a sign-up code goes to), leaving
+the mechanisms a pool ranked with nothing to decide. The pool records what it was asked for, and a
+described pool reports it.
 
 `UserPoolName` and `ClientName` are both optional, and a CDK `UserPool` construct emits neither,
 while both creation Commands require a name. `SimCfnCognitoGeneratedName` generates one from the
@@ -588,8 +598,9 @@ command instances.
   actions no resource-level permissions, so a policy naming individual pool ARNs grants nothing.
 
 `InitiateAuth`, `RespondToAuthChallenge`, `GlobalSignOut`, `SignUp`, `ConfirmSignUp`,
-`ResendConfirmationCode`, `GetUser`, `AssociateSoftwareToken`, `VerifySoftwareToken` and
-`SetUserMFAPreference` authorize nothing, and read no caller. What the last four and `GlobalSignOut`
+`ResendConfirmationCode`, `ForgotPassword`, `ConfirmForgotPassword`, `GetUser`,
+`AssociateSoftwareToken`, `VerifySoftwareToken` and `SetUserMFAPreference` authorize nothing, and
+read no caller. What the last four and `GlobalSignOut`
 do check is the access token's own scope, in `requireSimCognitoSelfService`: real Cognito refuses an
 operation a user performs on itself unless the token carries
 `aws.cognito.signin.user.admin`, which a hosted sign-in has only where the app client asked for it. Real Cognito evaluates no IAM policy
@@ -614,8 +625,14 @@ resource, here or on real AWS.
   record and the wrong one.
 - A confirmation code never expires, where a real one lasts 24 hours. `ResendConfirmationCode` is
   what replaces one.
-- `ForgotPassword`, `ConfirmForgotPassword` and `ChangePassword` are not implemented, so
-  `RESET_REQUIRED` is a status no user here reaches.
+- A reset code never expires either, where a real one lasts an hour. A second `ForgotPassword`
+  replaces it, and answering with it spends it. A spent code is refused as `ExpiredCodeException`.
+  That is what real Cognito calls one.
+- `ForgotPassword` sends its code to an attribute the pool verifies automatically, and refuses a
+  user with none. Real Cognito chooses by the pool's `AccountRecoverySetting`, which is held here
+  and read by nothing.
+- `ChangePassword` is not implemented. It is the signed-in user replacing a password it still
+  knows, which is a different flow from the reset.
 - A client-side sign-up operation naming a user the pool does not hold reports it, whatever the app
   client's `PreventUserExistenceErrors` says. That setting is honoured for sign-in only.
 - Every unsimulated `CreateUserPool`, `UpdateUserPool`, `CreateUserPoolClient` and

--- a/src/service/cognito/README.md
+++ b/src/service/cognito/README.md
@@ -634,7 +634,8 @@ resource, here or on real AWS.
 - `ChangePassword` is not implemented. It is the signed-in user replacing a password it still
   knows, which is a different flow from the reset.
 - A client-side sign-up operation naming a user the pool does not hold reports it, whatever the app
-  client's `PreventUserExistenceErrors` says. That setting is honoured for sign-in only.
+  client's `PreventUserExistenceErrors` says. The sign-ins and the two password reset operations
+  honour the setting.
 - Every unsimulated `CreateUserPool`, `UpdateUserPool`, `CreateUserPoolClient` and
   `UpdateUserPoolClient` input is refused rather than ignored.
 - A pool created with `UsernameAttributes` stores a generated UUID as each user's username and

--- a/src/service/cognito/command/auth/sim-cognito-password-sign-in.ts
+++ b/src/service/cognito/command/auth/sim-cognito-password-sign-in.ts
@@ -1,5 +1,6 @@
 import {
   requireSimCognitoConfirmed,
+  requireSimCognitoPasswordSet,
   requireSimCognitoSignIn,
   requireSimCognitoSignInUser,
 } from "../../user-pool/auth/sim-cognito-sign-in.js";
@@ -86,6 +87,7 @@ export class SimCognitoPasswordSignIn {
 
     requireSimCognitoSignIn(user, parameters.require("PASSWORD"));
     requireSimCognitoConfirmed(user);
+    requireSimCognitoPasswordSet(user);
 
     if (user.status.mustChangePassword) {
       return this.challenge.issue({ pool, clientId: client.id, user });

--- a/src/service/cognito/command/authorize/sim-cognito-user-iam.iso.test.ts
+++ b/src/service/cognito/command/authorize/sim-cognito-user-iam.iso.test.ts
@@ -3,6 +3,7 @@ import {
   AdminInitiateAuthCommand,
   AdminGetUserCommand,
   AdminSetUserMFAPreferenceCommand,
+  AdminResetUserPasswordCommand,
   AdminSetUserPasswordCommand,
   CreateUserPoolCommand,
   ListUsersCommand,
@@ -187,6 +188,59 @@ describe("sim Cognito user IAM authorization", () => {
 
     // Then it is denied.
     assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("denies resetting a user's password without the permission", async () => {
+    // Given a Role allowed to read users but not to reset their passwords.
+    const { simAws, caller, userPoolId } = await simCognitoWithRole({
+      Effect: "Allow",
+      Action: "cognito-idp:AdminGetUser",
+      Resource: userPoolArn("*"),
+    });
+
+    // When that Role resets a user's password.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cognitoIdentityProvider().adminResetUserPassword(
+        new AdminResetUserPasswordCommand({
+          UserPoolId: userPoolId,
+          Username: "alice",
+        }),
+        { caller },
+      );
+    });
+
+    // Then it is denied: the reset has an IAM action of its own.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("allows resetting a user's password with the permission", async () => {
+    // Given a Role allowed to reset passwords and read users.
+    const { simAws, caller, userPoolId } = await simCognitoWithRole({
+      Effect: "Allow",
+      Action: [
+        "cognito-idp:AdminGetUser",
+        "cognito-idp:AdminResetUserPassword",
+      ],
+      Resource: userPoolArn("*"),
+    });
+    const cognito = simAws.cognitoIdentityProvider();
+
+    // When that Role resets a user's password.
+    await cognito.adminResetUserPassword(
+      new AdminResetUserPasswordCommand({
+        UserPoolId: userPoolId,
+        Username: "alice",
+      }),
+      { caller },
+    );
+
+    // Then the user is waiting to set another one.
+    const read = await cognito.adminGetUser(
+      new AdminGetUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+      { caller },
+    );
+
+    assertIdentical(read.UserStatus, "RESET_REQUIRED");
   });
 
   it("denies setting a user's MFA preference without the permission", async () => {

--- a/src/service/cognito/command/hosted/sim-cognito-hosted-password-sign-in.ts
+++ b/src/service/cognito/command/hosted/sim-cognito-hosted-password-sign-in.ts
@@ -2,6 +2,7 @@ import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.err
 import { SimCognitoManagedLoginRequired } from "../../error/sim-cognito-managed-login.error.js";
 import {
   requireSimCognitoConfirmed,
+  requireSimCognitoPasswordSet,
   requireSimCognitoSignIn,
   requireSimCognitoSignInUser,
 } from "../../user-pool/auth/sim-cognito-sign-in.js";
@@ -47,6 +48,7 @@ export class SimCognitoHostedPasswordSignIn {
 
     requireSimCognitoSignIn(user, password);
     requireSimCognitoConfirmed(user);
+    requireSimCognitoPasswordSet(user);
 
     this.requireNoFurtherPage(pool, user);
 

--- a/src/service/cognito/command/sim-cognito-command.types.ts
+++ b/src/service/cognito/command/sim-cognito-command.types.ts
@@ -53,6 +53,18 @@ export type {
   SimListUserPoolClientsCommandOutput,
 } from "./client/list-user-pool-clients.command.js";
 export type {
+  SimAdminResetUserPasswordCommand,
+  SimAdminResetUserPasswordCommandInput,
+  SimAdminResetUserPasswordCommandOutput,
+  SimCognitoCodeDeliveryDetailsType,
+  SimCognitoPasswordResetCommandInput,
+  SimConfirmForgotPasswordCommand,
+  SimConfirmForgotPasswordCommandInput,
+  SimConfirmForgotPasswordCommandOutput,
+  SimForgotPasswordCommand,
+  SimForgotPasswordCommandOutput,
+} from "./user/password-reset.command.js";
+export type {
   SimAdminCreateUserCommand,
   SimAdminCreateUserCommandInput,
   SimAdminCreateUserCommandOutput,

--- a/src/service/cognito/command/sim-cognito-commands.ts
+++ b/src/service/cognito/command/sim-cognito-commands.ts
@@ -23,6 +23,7 @@ import { SimCognitoGroupMembershipCommands } from "./group/sim-cognito-group-mem
 import { SimCognitoListGroups } from "./group/sim-cognito-list-groups.js";
 import { SimCognitoUserPoolClientCommands } from "./client/sim-cognito-user-pool-client-commands.js";
 import { SimCognitoListUsers } from "./user/sim-cognito-list-users.js";
+import { SimCognitoPasswordResetCommands } from "./user/sim-cognito-password-reset-commands.js";
 import { SimCognitoSignUpCommands } from "./user/sim-cognito-sign-up-commands.js";
 import { SimCognitoTokenUser } from "./user/sim-cognito-token-user.js";
 import { SimCognitoUserCommands } from "./user/sim-cognito-user-commands.js";
@@ -58,6 +59,7 @@ export class SimCognitoCommands {
   public readonly users: SimCognitoUserCommands;
   public readonly userMfa: SimCognitoUserMfaCommands;
   public readonly signUp: SimCognitoSignUpCommands;
+  public readonly passwordReset: SimCognitoPasswordResetCommands;
   public readonly userUpdates: SimCognitoUserUpdateCommands;
   public readonly listUsers: SimCognitoListUsers;
   public readonly groups: SimCognitoGroupCommands;
@@ -123,6 +125,12 @@ export class SimCognitoCommands {
       authResolver,
       resolver,
       userFactory,
+      triggers,
+      messenger,
+    });
+    this.passwordReset = new SimCognitoPasswordResetCommands({
+      authResolver,
+      resolver,
       triggers,
       messenger,
     });

--- a/src/service/cognito/command/user/password-reset.command.ts
+++ b/src/service/cognito/command/user/password-reset.command.ts
@@ -1,0 +1,89 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimCognitoCodeDeliveryDetailsType } from "../../user-pool/message/sim-cognito-code-delivery.js";
+
+export type { SimCognitoCodeDeliveryDetailsType } from "../../user-pool/message/sim-cognito-code-delivery.js";
+
+/**
+ * What both client-side password reset operations name: the app client, and
+ * the user resetting.
+ *
+ * There is no `UserPoolId` in either of them. These are what a browser or
+ * mobile app calls on behalf of someone who cannot sign in, so an app client
+ * id is all they carry, as on real Cognito. `SecretHash` is what a client
+ * created with a secret has to send.
+ */
+export interface SimCognitoPasswordResetCommandInput {
+  readonly ClientId?: string | undefined;
+  readonly Username?: string | undefined;
+  readonly SecretHash?: string | undefined;
+  readonly ClientMetadata?: Readonly<Record<string, string>> | undefined;
+  readonly AnalyticsMetadata?: object | undefined;
+  readonly UserContextData?: object | undefined;
+}
+
+/**
+ * Minimal structural sim Cognito ForgotPassword command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cognito-identity-provider/command/ForgotPasswordCommand/
+ */
+export interface SimForgotPasswordCommand {
+  readonly input: SimCognitoPasswordResetCommandInput;
+}
+
+/**
+ * Where the pool sent the reset code.
+ *
+ * The destination is masked, as real Cognito masks it. The code itself is read
+ * back off the pool, because nothing here delivers the message carrying it.
+ */
+export interface SimForgotPasswordCommandOutput {
+  readonly CodeDeliveryDetails?: SimCognitoCodeDeliveryDetailsType | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * The ConfirmForgotPassword inputs this simulation reads, and the ones it
+ * refuses.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cognito-identity-provider/command/ConfirmForgotPasswordCommand/
+ */
+export interface SimConfirmForgotPasswordCommandInput extends SimCognitoPasswordResetCommandInput {
+  readonly ConfirmationCode?: string | undefined;
+  readonly Password?: string | undefined;
+}
+
+/**
+ * Minimal structural sim Cognito ConfirmForgotPassword command.
+ */
+export interface SimConfirmForgotPasswordCommand {
+  readonly input: SimConfirmForgotPasswordCommandInput;
+}
+
+export interface SimConfirmForgotPasswordCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * The AdminResetUserPassword inputs, which are all simulated.
+ *
+ * This is the administrative side of a reset, so it names the pool and the
+ * user rather than an app client.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cognito-identity-provider/command/AdminResetUserPasswordCommand/
+ */
+export interface SimAdminResetUserPasswordCommandInput {
+  readonly UserPoolId?: string | undefined;
+  readonly Username?: string | undefined;
+  readonly ClientMetadata?: Readonly<Record<string, string>> | undefined;
+}
+
+/**
+ * Minimal structural sim Cognito AdminResetUserPassword command.
+ */
+export interface SimAdminResetUserPasswordCommand {
+  readonly input: SimAdminResetUserPasswordCommandInput;
+}
+
+export interface SimAdminResetUserPasswordCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/cognito/command/user/sim-cognito-admin-reset-user-password.iso.test.ts
+++ b/src/service/cognito/command/user/sim-cognito-admin-reset-user-password.iso.test.ts
@@ -1,0 +1,169 @@
+import {
+  AdminCreateUserCommand,
+  AdminGetUserCommand,
+  AdminResetUserPasswordCommand,
+  AdminSetUserPasswordCommand,
+  ConfirmForgotPasswordCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  InitiateAuthCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimCognitoPasswordResetRequiredException } from "../../error/sim-cognito.error.js";
+import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
+
+const password = "Sup3rSecret!";
+const newPassword = "Ev3nBetter!";
+
+interface SimCognitoWithSignedInUser {
+  readonly cognito: SimCognitoIdentityProvider;
+  readonly userPoolId: string;
+  readonly clientId: string;
+}
+
+/**
+ * A pool holding one user with a permanent password of its own.
+ */
+async function simCognitoWithSignedInUser(): Promise<SimCognitoWithSignedInUser> {
+  const cognito = new SimAws().cognitoIdentityProvider();
+  const pool = await cognito.createUserPool(
+    new CreateUserPoolCommand({
+      PoolName: "myapp-users",
+      AutoVerifiedAttributes: ["email"],
+    }),
+  );
+
+  assertNonNullable(pool.UserPool?.Id);
+
+  const userPoolId = pool.UserPool.Id;
+  const client = await cognito.createUserPoolClient(
+    new CreateUserPoolClientCommand({
+      UserPoolId: userPoolId,
+      ClientName: "web",
+      ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH"],
+    }),
+  );
+
+  assertNonNullable(client.UserPoolClient?.ClientId);
+
+  await cognito.adminCreateUser(
+    new AdminCreateUserCommand({
+      UserPoolId: userPoolId,
+      Username: "alice",
+      UserAttributes: [
+        { Name: "email", Value: "alice@example.com" },
+        { Name: "email_verified", Value: "true" },
+      ],
+    }),
+  );
+  await cognito.adminSetUserPassword(
+    new AdminSetUserPasswordCommand({
+      UserPoolId: userPoolId,
+      Username: "alice",
+      Password: password,
+      Permanent: true,
+    }),
+  );
+
+  return { cognito, userPoolId, clientId: client.UserPoolClient.ClientId };
+}
+
+async function signIn(
+  cognito: SimCognitoIdentityProvider,
+  clientId: string,
+  candidate: string,
+): Promise<string | undefined> {
+  const signedIn = await cognito.initiateAuth(
+    new InitiateAuthCommand({
+      ClientId: clientId,
+      AuthFlow: "USER_PASSWORD_AUTH",
+      AuthParameters: { USERNAME: "alice", PASSWORD: candidate },
+    }),
+  );
+
+  return signedIn.AuthenticationResult?.AccessToken;
+}
+
+describe("sim Cognito administrative password reset", () => {
+  it("leaves the user in RESET_REQUIRED and refuses its sign-in", async () => {
+    // Given a user signing in with a password of its own.
+    const { cognito, userPoolId, clientId } =
+      await simCognitoWithSignedInUser();
+
+    assertNonNullable(await signIn(cognito, clientId, password));
+
+    // When an administrator resets its password.
+    await cognito.adminResetUserPassword(
+      new AdminResetUserPasswordCommand({
+        UserPoolId: userPoolId,
+        Username: "alice",
+      }),
+    );
+
+    // Then the status says what is missing, and so does the sign-in it now
+    // gets refused with.
+    const read = await cognito.adminGetUser(
+      new AdminGetUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+
+    assertIdentical(read.UserStatus, "RESET_REQUIRED");
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await signIn(cognito, clientId, password);
+    });
+
+    assertInstanceOf(error, SimCognitoPasswordResetRequiredException);
+    assertStringIncludes(error.message, "Password reset required");
+  });
+
+  it("sends the code the user sets its next password with", async () => {
+    // Given a user whose password an administrator has reset.
+    const { cognito, userPoolId, clientId } =
+      await simCognitoWithSignedInUser();
+
+    await cognito.adminResetUserPassword(
+      new AdminResetUserPasswordCommand({
+        UserPoolId: userPoolId,
+        Username: "alice",
+      }),
+    );
+
+    // When it answers with the code the pool would have sent it.
+    const messages = cognito.userPool(userPoolId).sentMessages();
+    const message = messages.at(-1);
+    const code = cognito.userPool(userPoolId).confirmationCode("alice");
+
+    assertNonNullable(code);
+
+    await cognito.confirmForgotPassword(
+      new ConfirmForgotPasswordCommand({
+        ClientId: clientId,
+        Username: "alice",
+        ConfirmationCode: code,
+        Password: newPassword,
+      }),
+    );
+
+    // Then the last message the pool would have sent carried that code, after
+    // the invitation the user was created with, and the user is confirmed and
+    // signing in again with the password it chose.
+    assertNonNullable(message);
+    assertIdentical(message.occasion, "ForgotPassword");
+    assertStringIncludes(message.body, code);
+
+    const read = await cognito.adminGetUser(
+      new AdminGetUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+
+    assertIdentical(read.UserStatus, "CONFIRMED");
+    assertNonNullable(await signIn(cognito, clientId, newPassword));
+  });
+});

--- a/src/service/cognito/command/user/sim-cognito-forgot-password-refusals.iso.test.ts
+++ b/src/service/cognito/command/user/sim-cognito-forgot-password-refusals.iso.test.ts
@@ -1,0 +1,195 @@
+import {
+  AdminCreateUserCommand,
+  ConfirmForgotPasswordCommand,
+  ForgotPasswordCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  makeResetPool,
+  newResetPassword,
+  resetCodeIn,
+  resetPassword,
+  resetUsername,
+  simCognitoResetSecretHash,
+} from "../../../../../test/cognito/password-reset-fixture.js";
+import {
+  SimCognitoCodeMismatchException,
+  SimCognitoInvalidParameterException,
+  SimCognitoNotAuthorizedException,
+  SimCognitoUserNotFoundException,
+} from "../../error/sim-cognito.error.js";
+
+describe("sim Cognito forgotten password refusals", () => {
+  it("reports an unknown user to an app client that leaks existence", async () => {
+    // Given an app client left on the LEGACY default.
+    const pool = await makeResetPool();
+
+    // When a reset names a user the pool does not hold.
+    const error = await assertThrowsErrorAsync(async () => {
+      await pool.cognito.forgotPassword(
+        new ForgotPasswordCommand({
+          ClientId: pool.clientId,
+          Username: "mallory",
+        }),
+      );
+    });
+
+    // Then it says so, as real Cognito does under that setting.
+    assertInstanceOf(error, SimCognitoUserNotFoundException);
+  });
+
+  it("hides an unknown user from an app client that prevents the error", async () => {
+    // Given an app client with PreventUserExistenceErrors enabled.
+    const pool = await makeResetPool({ preventUserExistenceErrors: "ENABLED" });
+
+    // When a reset names a user the pool does not hold.
+    const asked = await pool.cognito.forgotPassword(
+      new ForgotPasswordCommand({
+        ClientId: pool.clientId,
+        Username: "mallory",
+      }),
+    );
+
+    // Then it answers as though a code had gone out, so nothing about the
+    // response says whether the account exists.
+    assertNonNullable(asked.CodeDeliveryDetails);
+    assertIdentical(asked.CodeDeliveryDetails.DeliveryMedium, "EMAIL");
+    assertNonNullable(asked.CodeDeliveryDetails.Destination);
+  });
+
+  it("answers a confirmation for an unknown user as a wrong code", async () => {
+    // Given an app client with PreventUserExistenceErrors enabled.
+    const pool = await makeResetPool({ preventUserExistenceErrors: "ENABLED" });
+
+    // When a confirmation names a user the pool does not hold.
+    const error = await assertThrowsErrorAsync(async () => {
+      await pool.cognito.confirmForgotPassword(
+        new ConfirmForgotPasswordCommand({
+          ClientId: pool.clientId,
+          Username: "mallory",
+          ConfirmationCode: "000000",
+          Password: newResetPassword,
+        }),
+      );
+    });
+
+    // Then the refusal is the one a wrong code gets, which says nothing about
+    // whether the account exists.
+    assertInstanceOf(error, SimCognitoCodeMismatchException);
+  });
+
+  it("refuses a user the pool has nowhere to send a code to", async () => {
+    // Given a pool that verifies nothing, so no address is one it writes to.
+    const pool = await makeResetPool({ autoVerifiedAttributes: [] });
+
+    // When that user asks to reset its password.
+    const error = await assertThrowsErrorAsync(async () => {
+      await pool.cognito.forgotPassword(
+        new ForgotPasswordCommand({
+          ClientId: pool.clientId,
+          Username: resetUsername,
+        }),
+      );
+    });
+
+    // Then it is refused in the words real Cognito refuses with.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "no registered/verified email");
+  });
+
+  it("refuses a user that has still to replace a temporary password", async () => {
+    // Given a user an administrator created and never gave a password of its
+    // own.
+    const pool = await makeResetPool();
+
+    await pool.cognito.adminCreateUser(
+      new AdminCreateUserCommand({
+        UserPoolId: pool.userPoolId,
+        Username: "bob",
+        TemporaryPassword: resetPassword,
+        UserAttributes: [{ Name: "email", Value: "bob@example.com" }],
+      }),
+    );
+
+    // When that user asks to reset its password.
+    const error = await assertThrowsErrorAsync(async () => {
+      await pool.cognito.forgotPassword(
+        new ForgotPasswordCommand({ ClientId: pool.clientId, Username: "bob" }),
+      );
+    });
+
+    // Then it is sent to the new password challenge instead, as real Cognito
+    // sends it.
+    assertInstanceOf(error, SimCognitoNotAuthorizedException);
+    assertStringIncludes(
+      error.message,
+      "User password cannot be reset in the current state.",
+    );
+  });
+
+  it("wants a SECRET_HASH from an app client with a secret", async () => {
+    // Given a pool whose app client was created with a secret.
+    const pool = await makeResetPool({ generateSecret: true });
+
+    assertNonNullable(pool.clientSecret);
+
+    // When a reset arrives without one.
+    const error = await assertThrowsErrorAsync(async () => {
+      await pool.cognito.forgotPassword(
+        new ForgotPasswordCommand({
+          ClientId: pool.clientId,
+          Username: resetUsername,
+        }),
+      );
+    });
+
+    // Then both operations are refused until the hash the SDKs compute gets
+    // in.
+    assertInstanceOf(error, SimCognitoNotAuthorizedException);
+    assertStringIncludes(error.message, "Unable to verify secret hash");
+
+    const secretHash = simCognitoResetSecretHash(
+      pool.clientId,
+      pool.clientSecret,
+    );
+
+    await pool.cognito.forgotPassword(
+      new ForgotPasswordCommand({
+        ClientId: pool.clientId,
+        Username: resetUsername,
+        SecretHash: secretHash,
+      }),
+    );
+
+    const unhashed = await assertThrowsErrorAsync(async () => {
+      await pool.cognito.confirmForgotPassword(
+        new ConfirmForgotPasswordCommand({
+          ClientId: pool.clientId,
+          Username: resetUsername,
+          ConfirmationCode: resetCodeIn(pool),
+          Password: newResetPassword,
+        }),
+      );
+    });
+
+    assertInstanceOf(unhashed, SimCognitoNotAuthorizedException);
+    assertStringIncludes(unhashed.message, "Unable to verify secret hash");
+
+    await pool.cognito.confirmForgotPassword(
+      new ConfirmForgotPasswordCommand({
+        ClientId: pool.clientId,
+        Username: resetUsername,
+        ConfirmationCode: resetCodeIn(pool),
+        Password: newResetPassword,
+        SecretHash: secretHash,
+      }),
+    );
+  });
+});

--- a/src/service/cognito/command/user/sim-cognito-forgot-password.iso.test.ts
+++ b/src/service/cognito/command/user/sim-cognito-forgot-password.iso.test.ts
@@ -1,0 +1,181 @@
+import {
+  AdminGetUserCommand,
+  ConfirmForgotPasswordCommand,
+  ForgotPasswordCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  makeResetPool,
+  newResetPassword,
+  resetCodeIn,
+  resetPassword,
+  resetUsername,
+  signResetUserIn,
+  type SimCognitoResetPool,
+} from "../../../../../test/cognito/password-reset-fixture.js";
+import {
+  SimCognitoCodeMismatchException,
+  SimCognitoExpiredCodeException,
+  SimCognitoInvalidPasswordException,
+  SimCognitoNotAuthorizedException,
+} from "../../error/sim-cognito.error.js";
+
+async function askToReset(pool: SimCognitoResetPool): Promise<void> {
+  await pool.cognito.forgotPassword(
+    new ForgotPasswordCommand({
+      ClientId: pool.clientId,
+      Username: resetUsername,
+    }),
+  );
+}
+
+async function resetWith(
+  pool: SimCognitoResetPool,
+  code: string | undefined,
+  password: string,
+): Promise<void> {
+  await pool.cognito.confirmForgotPassword(
+    new ConfirmForgotPasswordCommand({
+      ClientId: pool.clientId,
+      Username: resetUsername,
+      ConfirmationCode: code,
+      Password: password,
+    }),
+  );
+}
+
+async function statusOf(
+  pool: SimCognitoResetPool,
+): Promise<string | undefined> {
+  const read = await pool.cognito.adminGetUser(
+    new AdminGetUserCommand({
+      UserPoolId: pool.userPoolId,
+      Username: resetUsername,
+    }),
+  );
+
+  return read.UserStatus;
+}
+
+describe("sim Cognito forgotten password reset", () => {
+  it("resets a forgotten password and signs in with the new one", async () => {
+    // Given a confirmed user that has forgotten its password.
+    const pool = await makeResetPool();
+
+    // When it asks for a code and answers with a password of its own.
+    const asked = await pool.cognito.forgotPassword(
+      new ForgotPasswordCommand({
+        ClientId: pool.clientId,
+        Username: resetUsername,
+      }),
+    );
+
+    await resetWith(pool, resetCodeIn(pool), newResetPassword);
+
+    // Then the pool said where the code went, without saying the address in
+    // full, and the new password is the one that signs in.
+    assertNonNullable(asked.CodeDeliveryDetails);
+    assertIdentical(asked.CodeDeliveryDetails.DeliveryMedium, "EMAIL");
+    assertIdentical(asked.CodeDeliveryDetails.AttributeName, "email");
+    assertIdentical(asked.CodeDeliveryDetails.Destination, "a***@e***.com");
+    assertIdentical(await statusOf(pool), "CONFIRMED");
+    assertNonNullable(await signResetUserIn(pool, newResetPassword));
+  });
+
+  it("stops the old password working once the new one is set", async () => {
+    // Given a user that has reset its password.
+    const pool = await makeResetPool();
+
+    await askToReset(pool);
+    await resetWith(pool, resetCodeIn(pool), newResetPassword);
+
+    // When it tries the password it had before.
+    const error = await assertThrowsErrorAsync(async () => {
+      await signResetUserIn(pool, resetPassword);
+    });
+
+    // Then it is refused as any other wrong password is.
+    assertInstanceOf(error, SimCognitoNotAuthorizedException);
+    assertStringIncludes(error.message, "Incorrect username or password.");
+  });
+
+  it("refuses a code that is not the one it issued", async () => {
+    // Given a user waiting to answer with a reset code.
+    const pool = await makeResetPool();
+
+    await askToReset(pool);
+
+    // When it answers with a code the pool never issued.
+    const error = await assertThrowsErrorAsync(async () => {
+      await resetWith(pool, "000000", newResetPassword);
+    });
+
+    // Then nothing is reset, and the old password still signs it in.
+    assertInstanceOf(error, SimCognitoCodeMismatchException);
+    assertNonNullable(await signResetUserIn(pool, resetPassword));
+  });
+
+  it("issues a second code and forgets the first", async () => {
+    // Given a user that has asked to reset twice.
+    const pool = await makeResetPool();
+
+    await askToReset(pool);
+
+    const first = resetCodeIn(pool);
+
+    await askToReset(pool);
+
+    // When it answers with the code it was sent first.
+    const error = await assertThrowsErrorAsync(async () => {
+      await resetWith(pool, first, newResetPassword);
+    });
+
+    // Then that one is refused, and the code it was sent second works.
+    assertInstanceOf(error, SimCognitoCodeMismatchException);
+    await resetWith(pool, resetCodeIn(pool), newResetPassword);
+    assertNonNullable(await signResetUserIn(pool, newResetPassword));
+  });
+
+  it("spends the code, so it resets nothing twice", async () => {
+    // Given a user that has already reset with the code it was sent.
+    const pool = await makeResetPool();
+
+    await askToReset(pool);
+
+    const code = resetCodeIn(pool);
+
+    await resetWith(pool, code, newResetPassword);
+
+    // When the same code is used again.
+    const error = await assertThrowsErrorAsync(async () => {
+      await resetWith(pool, code, "Third0ne!");
+    });
+
+    // Then it is refused as expired, which is what real Cognito calls a code
+    // it will no longer take.
+    assertInstanceOf(error, SimCognitoExpiredCodeException);
+  });
+
+  it("holds a new password to the pool's password policy", async () => {
+    // Given a user waiting to answer with a reset code.
+    const pool = await makeResetPool();
+
+    await askToReset(pool);
+
+    // When it chooses a password the pool's policy refuses.
+    const error = await assertThrowsErrorAsync(async () => {
+      await resetWith(pool, resetCodeIn(pool), "short");
+    });
+
+    // Then it is refused with the rule it broke.
+    assertInstanceOf(error, SimCognitoInvalidPasswordException);
+    assertStringIncludes(error.message, "Password not long enough");
+  });
+});

--- a/src/service/cognito/command/user/sim-cognito-password-reset-commands.ts
+++ b/src/service/cognito/command/user/sim-cognito-password-reset-commands.ts
@@ -1,0 +1,193 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { requireSimCognitoSecretHash } from "../../user-pool/auth/sim-cognito-secret-hash.js";
+import {
+  simCognitoCodeDelivery,
+  simCognitoHiddenCodeDelivery,
+} from "../../user-pool/message/sim-cognito-code-delivery.js";
+import type { SimCognitoPoolMessenger } from "../../user-pool/message/sim-cognito-pool-messenger.js";
+import { SimCognitoPasswordCheck } from "../../user-pool/sim-cognito-password-check.js";
+import { SimCognitoTriggerOccasion } from "../../user-pool/trigger/sim-cognito-trigger-occasion.js";
+import type { SimCognitoUserPoolTriggers } from "../../user-pool/trigger/sim-cognito-user-pool-triggers.js";
+import { requireSimCognitoUsername } from "../../user-pool/user/sim-cognito-username.js";
+import type { SimCognitoAuthResolver } from "../auth/sim-cognito-auth-resolver.js";
+import type { SimCognitoRequestResolver } from "../sim-cognito-request-resolver.js";
+import {
+  findSimCognitoResettingUser,
+  requireSimCognitoResetDelivery,
+  requireSimCognitoResettingUser,
+} from "./sim-cognito-resetting-user.js";
+import { SimCognitoUnsimulatedPasswordResetOptions } from "./sim-cognito-unsimulated-password-reset-options.js";
+import type {
+  SimAdminResetUserPasswordCommand,
+  SimAdminResetUserPasswordCommandOutput,
+  SimConfirmForgotPasswordCommand,
+  SimConfirmForgotPasswordCommandOutput,
+  SimForgotPasswordCommand,
+  SimForgotPasswordCommandOutput,
+} from "./password-reset.command.js";
+
+interface SimCognitoPasswordResetCommandsProperties {
+  readonly authResolver: SimCognitoAuthResolver;
+  readonly resolver: SimCognitoRequestResolver;
+  readonly triggers: SimCognitoUserPoolTriggers;
+  readonly messenger: SimCognitoPoolMessenger;
+}
+
+interface SimCognitoCommandOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The commands a user resets a forgotten password with, and the one an
+ * administrator resets it for them with.
+ *
+ * The first two are what a browser or mobile app calls for someone who cannot
+ * sign in, so no IAM permission is involved and no caller is read: the app
+ * client id is what finds the pool, as it does for sign-up and sign-in.
+ * `AdminResetUserPassword` authorizes against the pool's ARN the way every
+ * other admin operation does.
+ *
+ * Nothing here delivers the code. It is issued and held on the user,
+ * `SimCognitoUserPool.confirmationCode` is where a test reads it from, and the
+ * message the pool would have sent it in is recorded on the pool.
+ */
+export class SimCognitoPasswordResetCommands {
+  private readonly authResolver: SimCognitoAuthResolver;
+  private readonly resolver: SimCognitoRequestResolver;
+  private readonly triggers: SimCognitoUserPoolTriggers;
+  private readonly messenger: SimCognitoPoolMessenger;
+  private readonly unsimulatedOptions =
+    new SimCognitoUnsimulatedPasswordResetOptions();
+
+  constructor(properties: SimCognitoPasswordResetCommandsProperties) {
+    this.authResolver = properties.authResolver;
+    this.resolver = properties.resolver;
+    this.triggers = properties.triggers;
+    this.messenger = properties.messenger;
+  }
+
+  /**
+   * Start a password reset, and answer with where the code went.
+   *
+   * The user keeps the password it has and stays where it is, because asking
+   * to reset is not resetting: `ConfirmForgotPassword` is what changes
+   * anything. A second request issues a second code and forgets the first.
+   *
+   * A pool with nowhere to send the code refuses, in the words real Cognito
+   * refuses with, rather than answering as though a message had gone out. The
+   * code goes to an attribute the pool verifies automatically, which is the
+   * same address a sign-up code goes to.
+   */
+  async forgotPassword(
+    command: SimForgotPasswordCommand,
+  ): Promise<SimForgotPasswordCommandOutput> {
+    const { input } = command;
+    const { pool, client } = this.authResolver.client(input.ClientId);
+
+    this.unsimulatedOptions.refuseInForgot(input);
+
+    const username = requireSimCognitoUsername(input.Username);
+
+    requireSimCognitoSecretHash(username, client, input.SecretHash);
+
+    const user = findSimCognitoResettingUser(pool, client, username);
+
+    if (user === undefined) {
+      return {
+        $metadata: {},
+        CodeDeliveryDetails: simCognitoHiddenCodeDelivery(username),
+      };
+    }
+
+    user.status.requireSelfResettable();
+
+    const delivery = requireSimCognitoResetDelivery(pool, user);
+
+    user.passwordReset.start();
+
+    await this.messenger.send({
+      pool,
+      user,
+      client,
+      occasion: "ForgotPassword",
+      code: user.confirmationCode,
+      clientMetadata: input.ClientMetadata,
+    });
+
+    return {
+      $metadata: {},
+      CodeDeliveryDetails: simCognitoCodeDelivery(delivery),
+    };
+  }
+
+  /**
+   * Finish a password reset with the code the pool issued.
+   *
+   * The user reaches `CONFIRMED` and signs in with the password it chose from
+   * then on. The password is checked against the pool's policy first, as every
+   * other password is, and the code is spent whether or not the user had one
+   * outstanding: a second attempt with the same code is refused.
+   *
+   * The pool's `PostConfirmation` trigger runs last, reporting
+   * `PostConfirmation_ConfirmForgotPassword`, so a handler that fires on a
+   * sign-up being confirmed can tell this occasion from that one.
+   */
+  async confirmForgotPassword(
+    command: SimConfirmForgotPasswordCommand,
+  ): Promise<SimConfirmForgotPasswordCommandOutput> {
+    const { input } = command;
+    const { pool, client } = this.authResolver.client(input.ClientId);
+
+    this.unsimulatedOptions.refuseInConfirm(input);
+
+    const username = requireSimCognitoUsername(input.Username);
+
+    requireSimCognitoSecretHash(username, client, input.SecretHash);
+
+    const user = requireSimCognitoResettingUser(pool, client, username);
+    const password = new SimCognitoPasswordCheck(
+      pool.settings.passwordPolicy,
+    ).require("Password", input.Password);
+
+    user.passwordReset.confirm(input.ConfirmationCode, password);
+
+    await this.triggers.postConfirmation(
+      SimCognitoTriggerOccasion.confirmForgotPassword,
+      { pool, client, user, clientMetadata: input.ClientMetadata },
+    );
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * Take a user's password away, leaving it in `RESET_REQUIRED`.
+   *
+   * The user cannot sign in until it sets another one, which is what the
+   * status is for, and the pool records the message carrying the code it sets
+   * that one with. A user the pool has nowhere to write to is still reset, and
+   * simply gets no message: the status change is what this operation is for.
+   */
+  async adminResetUserPassword(
+    command: SimAdminResetUserPasswordCommand,
+    options?: SimCognitoCommandOptions,
+  ): Promise<SimAdminResetUserPasswordCommandOutput> {
+    const { input } = command;
+    const { pool, user } = this.resolver.poolUser(
+      "cognito-idp:AdminResetUserPassword",
+      input,
+      options,
+    );
+
+    user.passwordReset.require();
+
+    await this.messenger.send({
+      pool,
+      user,
+      occasion: "ForgotPassword",
+      code: user.confirmationCode,
+      clientMetadata: input.ClientMetadata,
+    });
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/cognito/command/user/sim-cognito-resetting-user.ts
+++ b/src/service/cognito/command/user/sim-cognito-resetting-user.ts
@@ -1,0 +1,89 @@
+import {
+  SimCognitoCodeMismatchException,
+  SimCognitoInvalidParameterException,
+  SimCognitoUserNotFoundException,
+} from "../../error/sim-cognito.error.js";
+import type { SimCognitoUserPoolClient } from "../../user-pool/client/sim-cognito-user-pool-client.js";
+import { SimCognitoMessageDelivery } from "../../user-pool/message/sim-cognito-message-delivery.js";
+import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
+import type { SimCognitoUser } from "../../user-pool/user/sim-cognito-user.js";
+
+/**
+ * Find the user a `ForgotPassword` names, or answer with nothing where the app
+ * client hides that it is missing.
+ *
+ * A client on the `LEGACY` default says the user does not exist. One with
+ * `PreventUserExistenceErrors` of `ENABLED` leaves the caller to answer as
+ * though a code had gone out, which is what stops the operation being used to
+ * find out who has an account.
+ */
+export function findSimCognitoResettingUser(
+  pool: SimCognitoUserPool,
+  client: SimCognitoUserPoolClient,
+  username: string,
+): SimCognitoUser | undefined {
+  const user = pool.findUser(username);
+
+  if (user !== undefined) {
+    return user;
+  }
+
+  if (client.preventUserExistenceErrors.hidesUserExistence) {
+    return undefined;
+  }
+
+  throw new SimCognitoUserNotFoundException("User does not exist.");
+}
+
+/**
+ * Resolve the user a `ConfirmForgotPassword` names, as the app client reports
+ * one that is not there.
+ *
+ * A client hiding user existence answers with the same code mismatch a wrong
+ * code gets. Saying the user is missing would be the leak the setting exists
+ * to close.
+ */
+export function requireSimCognitoResettingUser(
+  pool: SimCognitoUserPool,
+  client: SimCognitoUserPoolClient,
+  username: string,
+): SimCognitoUser {
+  const user = findSimCognitoResettingUser(pool, client, username);
+
+  if (user === undefined) {
+    throw new SimCognitoCodeMismatchException(
+      "Invalid verification code provided, please try again.",
+    );
+  }
+
+  return user;
+}
+
+/**
+ * Where a reset code would go, or a refusal where the pool has nowhere to send
+ * one.
+ *
+ * The code goes to an attribute the pool verifies automatically, which is the
+ * address a sign-up code goes to. Real Cognito chooses by the pool's
+ * `AccountRecoverySetting` and refuses a user it can reach at neither address
+ * in these words.
+ */
+export function requireSimCognitoResetDelivery(
+  pool: SimCognitoUserPool,
+  user: SimCognitoUser,
+): SimCognitoMessageDelivery {
+  const delivery = SimCognitoMessageDelivery.forOccasion(
+    pool,
+    user,
+    "ForgotPassword",
+  );
+
+  if (delivery === undefined) {
+    throw new SimCognitoInvalidParameterException(
+      `Cannot reset password for the user as there is no ` +
+        `registered/verified email or phone_number`,
+    );
+  }
+
+  return delivery;
+}

--- a/src/service/cognito/command/user/sim-cognito-sign-up-commands.ts
+++ b/src/service/cognito/command/user/sim-cognito-sign-up-commands.ts
@@ -133,12 +133,15 @@ export class SimCognitoSignUpCommands {
 
     if (preSignUp.autoConfirmUser) {
       user.confirm();
-      await this.triggers.postConfirmation({
-        pool,
-        client,
-        user,
-        clientMetadata: input.ClientMetadata,
-      });
+      await this.triggers.postConfirmation(
+        SimCognitoTriggerOccasion.confirmSignUp,
+        {
+          pool,
+          client,
+          user,
+          clientMetadata: input.ClientMetadata,
+        },
+      );
     } else {
       await this.messenger.send({
         pool,
@@ -178,12 +181,15 @@ export class SimCognitoSignUpCommands {
     user.confirmSignUp(input.ConfirmationCode);
     user.verifyAttributes(pool.settings.autoVerifiedAttributes.names);
 
-    await this.triggers.postConfirmation({
-      pool,
-      client,
-      user,
-      clientMetadata: input.ClientMetadata,
-    });
+    await this.triggers.postConfirmation(
+      SimCognitoTriggerOccasion.confirmSignUp,
+      {
+        pool,
+        client,
+        user,
+        clientMetadata: input.ClientMetadata,
+      },
+    );
 
     return { $metadata: {} };
   }
@@ -248,11 +254,14 @@ export class SimCognitoSignUpCommands {
 
     user.confirm();
 
-    await this.triggers.postConfirmation({
-      pool,
-      user,
-      clientMetadata: input.ClientMetadata,
-    });
+    await this.triggers.postConfirmation(
+      SimCognitoTriggerOccasion.confirmSignUp,
+      {
+        pool,
+        user,
+        clientMetadata: input.ClientMetadata,
+      },
+    );
 
     return { $metadata: {} };
   }

--- a/src/service/cognito/command/user/sim-cognito-unsimulated-password-reset-options.ts
+++ b/src/service/cognito/command/user/sim-cognito-unsimulated-password-reset-options.ts
@@ -1,0 +1,55 @@
+import { SimCognitoUnsimulatedInput } from "../sim-cognito-unsimulated-input.js";
+import type { SimCognitoPasswordResetCommandInput } from "./password-reset.command.js";
+
+/**
+ * Refuses the password reset inputs this simulation does not model.
+ *
+ * Both client-side operations carry the analytics and device context a real
+ * app sends, and none of that is simulated, so an input asking for any of it
+ * is refused rather than dropped.
+ *
+ * `ClientMetadata` is not among them. It exists to reach a Lambda trigger, and
+ * the custom message and post confirmation triggers both run here, so the data
+ * reaches the handler instead of being refused.
+ */
+export class SimCognitoUnsimulatedPasswordResetOptions {
+  private readonly forgotInput = new SimCognitoUnsimulatedInput(
+    "ForgotPassword",
+  );
+  private readonly confirmInput = new SimCognitoUnsimulatedInput(
+    "ConfirmForgotPassword",
+  );
+
+  /**
+   * Refuse a `ForgotPassword` request this simulation cannot honour.
+   */
+  refuseInForgot(input: SimCognitoPasswordResetCommandInput): void {
+    this.refuseAppContext(this.forgotInput, input);
+  }
+
+  /**
+   * Refuse a `ConfirmForgotPassword` request this simulation cannot honour.
+   */
+  refuseInConfirm(input: SimCognitoPasswordResetCommandInput): void {
+    this.refuseAppContext(this.confirmInput, input);
+  }
+
+  /**
+   * Refuse the two inputs both operations share.
+   */
+  private refuseAppContext(
+    unsimulated: SimCognitoUnsimulatedInput,
+    input: SimCognitoPasswordResetCommandInput,
+  ): void {
+    unsimulated.refuse(
+      "AnalyticsMetadata",
+      input.AnalyticsMetadata,
+      "recording the request against a Pinpoint analytics endpoint",
+    );
+    unsimulated.refuse(
+      "UserContextData",
+      input.UserContextData,
+      "the device data threat protection judges a request by",
+    );
+  }
+}

--- a/src/service/cognito/error/sim-cognito.error.ts
+++ b/src/service/cognito/error/sim-cognito.error.ts
@@ -203,3 +203,34 @@ export class SimCognitoSoftwareTokenMfaNotFoundException extends SimCognitoError
     super(message, { httpStatusCode: 400 });
   }
 }
+
+/**
+ * Simulated Cognito ExpiredCodeException error.
+ *
+ * Real Cognito reports a code it will no longer take this way, whether the
+ * code was spent or its lifetime ran out. Only the first of those happens
+ * here, because nothing ages a code out.
+ */
+export class SimCognitoExpiredCodeException extends SimCognitoError {
+  public override readonly name = "ExpiredCodeException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated Cognito PasswordResetRequiredException error.
+ *
+ * Real Cognito reports a sign-in by a user whose password an administrator
+ * reset this way. The password was right: what is missing is the reset, so an
+ * application knows to send the user to `ConfirmForgotPassword` rather than
+ * back to the password field.
+ */
+export class SimCognitoPasswordResetRequiredException extends SimCognitoError {
+  public override readonly name = "PasswordResetRequiredException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}

--- a/src/service/cognito/index.ts
+++ b/src/service/cognito/index.ts
@@ -50,6 +50,7 @@ export { SimCognitoFederation } from "./sim-cognito-federation.js";
 export { SimCognitoAuthentication } from "./sim-cognito-authentication.js";
 export { SimCognitoUser } from "./user-pool/user/sim-cognito-user.js";
 export { SimCognitoConfirmationCode } from "./user-pool/user/sim-cognito-confirmation-code.js";
+export { SimCognitoUserPasswordReset } from "./user-pool/user/sim-cognito-user-password-reset.js";
 export type { SimCognitoUsername } from "./user-pool/user/sim-cognito-username.js";
 export {
   SimCognitoUserStatus,
@@ -143,10 +144,12 @@ export {
   SimCognitoDuplicateProviderException,
   SimCognitoEnableSoftwareTokenMfaException,
   SimCognitoError,
+  SimCognitoExpiredCodeException,
   SimCognitoGroupExistsException,
   SimCognitoInvalidParameterException,
   SimCognitoInvalidPasswordException,
   SimCognitoNotAuthorizedException,
+  SimCognitoPasswordResetRequiredException,
   SimCognitoResourceNotFoundException,
   SimCognitoSoftwareTokenMfaNotFoundException,
   SimCognitoUsernameExistsException,

--- a/src/service/cognito/sdk/sim-cognito-sdk-directory-routes.ts
+++ b/src/service/cognito/sdk/sim-cognito-sdk-directory-routes.ts
@@ -17,6 +17,11 @@ import type {
 } from "../command/group/group.command.js";
 import type { SimListUsersCommand } from "../command/user/list-users.command.js";
 import type {
+  SimAdminResetUserPasswordCommand,
+  SimConfirmForgotPasswordCommand,
+  SimForgotPasswordCommand,
+} from "../command/user/password-reset.command.js";
+import type {
   SimAdminConfirmSignUpCommand,
   SimConfirmSignUpCommand,
   SimResendConfirmationCodeCommand,
@@ -43,11 +48,12 @@ import type { SimCognitoIdentityProvider } from "../sim-cognito-identity-provide
 /**
  * The SDK Command routes for the users and groups in a pool.
  *
- * The three sign-up routes read no caller from the SDK context, because real
- * Cognito authorizes them with no IAM policy: they are what an application
- * calls on behalf of someone signing themselves up, holding no AWS credentials
- * at all. `AdminConfirmSignUp` is the admin side of the same thing, and does
- * read one.
+ * The three sign-up routes and the two password reset ones read no caller from
+ * the SDK context, because real Cognito authorizes them with no IAM policy:
+ * they are what an application calls on behalf of someone signing themselves
+ * up or unable to sign in, holding no AWS credentials at all.
+ * `AdminConfirmSignUp` and `AdminResetUserPassword` are the admin sides of the
+ * same two things, and do read one.
  */
 export function simCognitoSdkDirectoryRoutes(
   simCognito: SimCognitoIdentityProvider,
@@ -75,6 +81,26 @@ export function simCognitoSdkDirectoryRoutes(
       async (command, context): Promise<unknown> =>
         await simCognito.adminConfirmSignUp(
           command as SimAdminConfirmSignUpCommand,
+          simSdkCallerOptions(context),
+        ),
+    ],
+    [
+      "ForgotPasswordCommand",
+      async (command): Promise<unknown> =>
+        await simCognito.forgotPassword(command as SimForgotPasswordCommand),
+    ],
+    [
+      "ConfirmForgotPasswordCommand",
+      async (command): Promise<unknown> =>
+        await simCognito.confirmForgotPassword(
+          command as SimConfirmForgotPasswordCommand,
+        ),
+    ],
+    [
+      "AdminResetUserPasswordCommand",
+      async (command, context): Promise<unknown> =>
+        await simCognito.adminResetUserPassword(
+          command as SimAdminResetUserPasswordCommand,
           simSdkCallerOptions(context),
         ),
     ],

--- a/src/service/cognito/sdk/sim-cognito-sdk-user-routing.iso.test.ts
+++ b/src/service/cognito/sdk/sim-cognito-sdk-user-routing.iso.test.ts
@@ -5,14 +5,17 @@ import {
   AdminDisableUserCommand,
   AdminEnableUserCommand,
   AdminGetUserCommand,
+  AdminResetUserPasswordCommand,
   AdminSetUserMFAPreferenceCommand,
   AdminSetUserPasswordCommand,
   AdminUpdateUserAttributesCommand,
   AssociateSoftwareTokenCommand,
   CognitoIdentityProviderClient,
+  ConfirmForgotPasswordCommand,
   ConfirmSignUpCommand,
   CreateUserPoolClientCommand,
   CreateUserPoolCommand,
+  ForgotPasswordCommand,
   GetUserCommand,
   InitiateAuthCommand,
   ListUsersCommand,
@@ -172,6 +175,86 @@ describe("Cognito user SDK interception", () => {
           attribute.Name === "email_verified" && attribute.Value === "true",
       ),
     );
+  });
+
+  it("routes every password reset Command through the intercepted client", async () => {
+    // Given an intercepted Cognito SDK client with a confirmed user.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    using simSdk = new SimSdk({ simAws });
+    simSdk.intercept(CognitoIdentityProviderClient);
+
+    const client = new CognitoIdentityProviderClient({ region: "eu-west-2" });
+    const pool = await client.send(
+      new CreateUserPoolCommand({
+        PoolName: "myapp-users",
+        AutoVerifiedAttributes: ["email"],
+      }),
+    );
+    const userPoolId = pool.UserPool?.Id;
+    assertTypeString(userPoolId);
+
+    const appClient = await client.send(
+      new CreateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientName: "web",
+        ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH"],
+      }),
+    );
+
+    await client.send(
+      new AdminCreateUserCommand({
+        UserPoolId: userPoolId,
+        Username: "alice",
+        UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+      }),
+    );
+    await client.send(
+      new AdminSetUserPasswordCommand({
+        UserPoolId: userPoolId,
+        Username: "alice",
+        Password: "Sup3rSecret!",
+        Permanent: true,
+      }),
+    );
+
+    // When ordinary SDK code takes a user through a password reset.
+    await client.send(
+      new AdminResetUserPasswordCommand({
+        UserPoolId: userPoolId,
+        Username: "alice",
+      }),
+    );
+
+    const reset = await client.send(
+      new AdminGetUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+    const asked = await client.send(
+      new ForgotPasswordCommand({
+        ClientId: appClient.UserPoolClient?.ClientId,
+        Username: "alice",
+      }),
+    );
+
+    await client.send(
+      new ConfirmForgotPasswordCommand({
+        ClientId: appClient.UserPoolClient?.ClientId,
+        Username: "alice",
+        ConfirmationCode: simAws
+          .cognitoIdentityProvider()
+          .userPool(userPoolId)
+          .confirmationCode("alice"),
+        Password: "Ev3nBetter!",
+      }),
+    );
+
+    const confirmed = await client.send(
+      new AdminGetUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+
+    // Then each Command reached simulated Cognito.
+    assertIdentical(reset.UserStatus, "RESET_REQUIRED");
+    assertIdentical(asked.CodeDeliveryDetails?.DeliveryMedium, "EMAIL");
+    assertIdentical(confirmed.UserStatus, "CONFIRMED");
   });
 
   it("routes every MFA registration Command through the intercepted client", async () => {

--- a/src/service/cognito/sim-cognito-user-directory.ts
+++ b/src/service/cognito/sim-cognito-user-directory.ts
@@ -82,6 +82,41 @@ export abstract class SimCognitoUserDirectory extends SimCognitoUserFactors {
   }
 
   /**
+   * Handle a ForgotPassword Command from the SDK.
+   *
+   * No caller is read, because real Cognito authorizes this operation with no
+   * IAM policy at all: it is what an application calls for someone who cannot
+   * sign in and holds no AWS credentials.
+   */
+  async forgotPassword(
+    command: simCognitoCommands.SimForgotPasswordCommand,
+  ): Promise<simCognitoCommands.SimForgotPasswordCommandOutput> {
+    await this.background.sequence();
+    return this.commands.passwordReset.forgotPassword(command);
+  }
+
+  /**
+   * Handle a ConfirmForgotPassword Command from the SDK.
+   */
+  async confirmForgotPassword(
+    command: simCognitoCommands.SimConfirmForgotPasswordCommand,
+  ): Promise<simCognitoCommands.SimConfirmForgotPasswordCommandOutput> {
+    await this.background.sequence();
+    return this.commands.passwordReset.confirmForgotPassword(command);
+  }
+
+  /**
+   * Handle an AdminResetUserPassword Command from the SDK.
+   */
+  async adminResetUserPassword(
+    command: simCognitoCommands.SimAdminResetUserPasswordCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimAdminResetUserPasswordCommandOutput> {
+    await this.background.sequence();
+    return this.commands.passwordReset.adminResetUserPassword(command, options);
+  }
+
+  /**
    * Handle an AdminGetUser Command from the SDK.
    */
   async adminGetUser(

--- a/src/service/cognito/user-pool/auth/sim-cognito-sign-in.ts
+++ b/src/service/cognito/user-pool/auth/sim-cognito-sign-in.ts
@@ -1,5 +1,6 @@
 import {
   SimCognitoNotAuthorizedException,
+  SimCognitoPasswordResetRequiredException,
   SimCognitoUserNotConfirmedException,
 } from "../../error/sim-cognito.error.js";
 import type { SimCognitoUserPoolClient } from "../client/sim-cognito-user-pool-client.js";
@@ -61,6 +62,22 @@ export function requireSimCognitoEnabled(user: SimCognitoUser): void {
 export function requireSimCognitoConfirmed(user: SimCognitoUser): void {
   if (user.status.isUnconfirmed) {
     throw new SimCognitoUserNotConfirmedException("User is not confirmed.");
+  }
+}
+
+/**
+ * Refuse a sign-in by a user whose password an administrator has reset.
+ *
+ * This is checked alongside the confirmation, and for the same reason: the
+ * user is told what is actually missing, so an application can send it to
+ * `ConfirmForgotPassword` with the code the reset issued rather than back to
+ * the password field.
+ */
+export function requireSimCognitoPasswordSet(user: SimCognitoUser): void {
+  if (user.status.mustResetPassword) {
+    throw new SimCognitoPasswordResetRequiredException(
+      "Password reset required for the user.",
+    );
   }
 }
 

--- a/src/service/cognito/user-pool/idp/sim-cognito-federated-identity.ts
+++ b/src/service/cognito/user-pool/idp/sim-cognito-federated-identity.ts
@@ -1,3 +1,5 @@
+import type { SimCognitoAttributeType } from "../user/sim-cognito-user-attributes.js";
+
 /**
  * One entry of a user's `identities`, in the shape an id token carries it.
  *
@@ -82,5 +84,17 @@ export class SimCognitoFederatedIdentity {
    */
   toAttributeValue(): string {
     return JSON.stringify([this.toClaim()]);
+  }
+
+  /**
+   * The `identities` attribute a federated user reports, as the one entry a
+   * described user carries it in.
+   *
+   * A local user has no such attribute at all, so this is a list rather than a
+   * single attribute: the user spreads whichever it has into the attributes it
+   * reports.
+   */
+  attributes(): readonly SimCognitoAttributeType[] {
+    return [{ Name: "identities", Value: this.toAttributeValue() }];
   }
 }

--- a/src/service/cognito/user-pool/message/sim-cognito-code-delivery.ts
+++ b/src/service/cognito/user-pool/message/sim-cognito-code-delivery.ts
@@ -1,0 +1,113 @@
+import type { SimCognitoMessageDelivery } from "./sim-cognito-message-delivery.js";
+import type { SimCognitoMessageMedium } from "./sim-cognito-sent-message.js";
+
+/**
+ * Where a pool sent a code, as the operation that sent it reports it back.
+ *
+ * https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CodeDeliveryDetailsType.html
+ */
+export interface SimCognitoCodeDeliveryDetailsType {
+  readonly Destination?: string | undefined;
+  readonly DeliveryMedium?: string | undefined;
+  readonly AttributeName?: string | undefined;
+}
+
+/**
+ * How many characters of a phone number Cognito leaves showing.
+ */
+const shownDigits = 4;
+
+/**
+ * The attribute each medium is reached by, which is what a response names.
+ */
+const attributeNames: Readonly<Record<SimCognitoMessageMedium, string>> = {
+  EMAIL: "email",
+  SMS: "phone_number",
+};
+
+/**
+ * The details a pool answers with for a message it has just sent.
+ *
+ * Real Cognito reports where a code went without reporting the address it went
+ * to, so the destination is masked. That masking is what makes the response
+ * safe to show a browser: an application prints it to say which address to go
+ * and look at, and someone who guessed the username learns nothing from it.
+ *
+ * The masked shape here follows real Cognito's rather than being read back
+ * from a live account, so assert that a destination came back and which
+ * medium carried it rather than on the mask itself.
+ */
+export function simCognitoCodeDelivery(
+  delivery: SimCognitoMessageDelivery,
+): SimCognitoCodeDeliveryDetailsType {
+  return {
+    Destination: simCognitoMaskedDestination(
+      delivery.recipient,
+      delivery.medium,
+    ),
+    DeliveryMedium: delivery.medium,
+    AttributeName: attributeNames[delivery.medium],
+  };
+}
+
+/**
+ * The details a pool answers a reset for a user it does not hold with.
+ *
+ * An app client with `PreventUserExistenceErrors` of `ENABLED` answers a
+ * `ForgotPassword` naming an unknown user as though a code had gone out, which
+ * is what stops the operation being used to find out who has an account. Real
+ * Cognito makes up a destination for it, and so does this: there is no address
+ * behind it, so the username the request supplied is what gets masked.
+ */
+export function simCognitoHiddenCodeDelivery(
+  username: string,
+): SimCognitoCodeDeliveryDetailsType {
+  return {
+    Destination: simCognitoMaskedDestination(username, "EMAIL"),
+    DeliveryMedium: "EMAIL",
+    AttributeName: attributeNames.EMAIL,
+  };
+}
+
+/**
+ * One address with all but its first character and its last dotted part
+ * hidden, which is how Cognito writes an address it will not report.
+ *
+ * A phone number keeps its last four digits instead, because that is the part
+ * a person recognises their own number by.
+ */
+export function simCognitoMaskedDestination(
+  recipient: string,
+  medium: SimCognitoMessageMedium,
+): string {
+  if (medium === "SMS") {
+    return maskedNumber(recipient);
+  }
+
+  return maskedAddress(recipient);
+}
+
+function maskedNumber(number: string): string {
+  const shown = number.slice(-shownDigits);
+
+  return `${"*".repeat(Math.max(number.length - shownDigits, 0))}${shown}`;
+}
+
+function maskedAddress(address: string): string {
+  const at = address.indexOf("@");
+
+  if (at === -1) {
+    return maskedPart(address);
+  }
+
+  const domain = address.slice(at + 1);
+  const dot = domain.indexOf(".");
+  const host = dot === -1 ? domain : domain.slice(0, dot);
+  const tail = dot === -1 ? "" : domain.slice(dot);
+
+  return `${maskedPart(address.slice(0, at))}@${maskedPart(host)}${tail}`;
+}
+
+function maskedPart(part: string): string {
+  return `${part.slice(0, 1)}***`;
+}

--- a/src/service/cognito/user-pool/message/sim-cognito-message-occasion.ts
+++ b/src/service/cognito/user-pool/message/sim-cognito-message-occasion.ts
@@ -1,11 +1,15 @@
 /**
  * What made a simulated user pool send a message.
  *
- * These are the four occasions this simulation reaches: a user signing itself
- * up, that user asking for another code, an administrator creating a user, and
- * a sign-in being challenged for a code sent by text message. Real Cognito
- * sends on more of them, a password reset among them, which is not simulated
- * here.
+ * These are the five occasions this simulation reaches: a user signing itself
+ * up, that user asking for another code, an administrator creating a user, a
+ * sign-in being challenged for a code sent by text message, and a password
+ * being reset. Real Cognito sends on more of them, an attribute being verified
+ * among them, which is not simulated here.
+ *
+ * `ForgotPassword` covers the reset an administrator starts as well as the one
+ * the user asks for, because real Cognito sends both under the one
+ * `CustomMessage_ForgotPassword` trigger source.
  *
  * `SimCognitoTriggerOccasion.customMessage` turns one of these into the
  * occasion the `CustomMessage` trigger fires for.
@@ -14,4 +18,5 @@ export type SimCognitoMessageOccasion =
   | "SignUp"
   | "ResendCode"
   | "AdminCreateUser"
-  | "Authentication";
+  | "Authentication"
+  | "ForgotPassword";

--- a/src/service/cognito/user-pool/message/sim-cognito-pool-messenger.ts
+++ b/src/service/cognito/user-pool/message/sim-cognito-pool-messenger.ts
@@ -60,9 +60,13 @@ export class SimCognitoPoolMessenger {
    * `CustomMessage` trigger first so that a handler can write its own.
    *
    * A pool with nowhere to write to sends nothing, as one does on real
-   * Cognito, rather than recording a message addressed to no one.
+   * Cognito, rather than recording a message addressed to no one. Where a
+   * message did go out, the answer says where, because an operation reporting
+   * `CodeDeliveryDetails` has nowhere else to read that from.
    */
-  async send(request: SimCognitoMessageRequest): Promise<void> {
+  async send(
+    request: SimCognitoMessageRequest,
+  ): Promise<SimCognitoMessageDelivery | undefined> {
     const delivery = SimCognitoMessageDelivery.forOccasion(
       request.pool,
       request.user,
@@ -70,7 +74,7 @@ export class SimCognitoPoolMessenger {
     );
 
     if (delivery === undefined) {
-      return;
+      return undefined;
     }
 
     const { medium } = delivery;
@@ -106,5 +110,7 @@ export class SimCognitoPoolMessenger {
         sentDate: this.clock.now(),
       }),
     );
+
+    return delivery;
   }
 }

--- a/src/service/cognito/user-pool/trigger/sim-cognito-password-reset-triggers.iso.test.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-password-reset-triggers.iso.test.ts
@@ -1,0 +1,153 @@
+import {
+  ConfirmForgotPasswordCommand,
+  ForgotPasswordCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertObjectMatches,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  confirmTriggerSignUp,
+  makeTriggerPool,
+  signUpTriggerUser,
+  triggerFunctionArn,
+  triggerUsername,
+  type SimCognitoTriggerPool,
+} from "../../../../../test/cognito/trigger-fixture.js";
+import { recordingTriggerHandler } from "../../../../../test/cognito/trigger-handler-fixture.js";
+
+const newPassword = "Ev3nBetter!";
+
+/**
+ * The parts of a `CustomMessage` event a handler here reads.
+ */
+interface CustomMessageEvent {
+  readonly request: { readonly codeParameter: string };
+}
+
+/**
+ * Write a reset message of the handler's own, with the code placeholder where
+ * the code belongs.
+ */
+function writingHandler(event: unknown): unknown {
+  const { request } = event as CustomMessageEvent;
+
+  return {
+    ...(event as object),
+    response: {
+      emailSubject: "Reset your Acme password",
+      emailMessage: `Your Acme reset code is ${request.codeParameter}`,
+    },
+  };
+}
+
+function codeIn(pool: SimCognitoTriggerPool): string {
+  const code = pool.cognito
+    .userPool(pool.userPoolId)
+    .confirmationCode(triggerUsername);
+
+  assertNonNullable(code);
+
+  return code;
+}
+
+/**
+ * Sign the fixture's user up, confirm it, and ask to reset its password.
+ */
+async function askToReset(pool: SimCognitoTriggerPool): Promise<void> {
+  await signUpTriggerUser(pool);
+  await confirmTriggerSignUp(pool);
+  await pool.cognito.forgotPassword(
+    new ForgotPasswordCommand({
+      ClientId: pool.clientId,
+      Username: triggerUsername,
+    }),
+  );
+}
+
+describe("sim Cognito password reset triggers", () => {
+  it("writes the reset message from the CustomMessage handler", async () => {
+    // Given a pool whose CustomMessage trigger writes its own wording.
+    const pool = await makeTriggerPool({
+      triggers: { CustomMessage: triggerFunctionArn },
+      autoVerifiedAttributes: ["email"],
+      handler: writingHandler,
+    });
+
+    // When a user asks to reset its password.
+    await askToReset(pool);
+
+    // Then the pool recorded the handler's wording, carrying the reset code.
+    const message = pool.cognito
+      .userPool(pool.userPoolId)
+      .sentMessages()
+      .at(-1);
+
+    assertNonNullable(message);
+    assertIdentical(message.occasion, "ForgotPassword");
+    assertIdentical(message.subject, "Reset your Acme password");
+    assertStringIncludes(message.body, codeIn(pool));
+  });
+
+  it("tells the CustomMessage handler a reset from a sign-up", async () => {
+    // Given a pool whose CustomMessage trigger records what it is given.
+    const events: unknown[] = [];
+    const pool = await makeTriggerPool({
+      triggers: { CustomMessage: triggerFunctionArn },
+      autoVerifiedAttributes: ["email"],
+      handler: recordingTriggerHandler(events),
+    });
+
+    // When a user signs up, confirms and then asks to reset its password.
+    await askToReset(pool);
+
+    // Then the reset carries the source real Cognito gives it, which is what a
+    // handler customising one message and not another branches on.
+    assertObjectMatches(events.at(-1), {
+      userPoolId: pool.userPoolId,
+      userName: triggerUsername,
+      triggerSource: "CustomMessage_ForgotPassword",
+      callerContext: { clientId: pool.clientId },
+    });
+  });
+
+  it("runs PostConfirmation once the reset is confirmed", async () => {
+    // Given a pool whose PostConfirmation trigger records what it is given.
+    const events: unknown[] = [];
+    const pool = await makeTriggerPool({
+      triggers: { PostConfirmation: triggerFunctionArn },
+      autoVerifiedAttributes: ["email"],
+      handler: recordingTriggerHandler(events),
+    });
+
+    await askToReset(pool);
+
+    // When the user answers with the code and a password of its own.
+    await pool.cognito.confirmForgotPassword(
+      new ConfirmForgotPasswordCommand({
+        ClientId: pool.clientId,
+        Username: triggerUsername,
+        ConfirmationCode: codeIn(pool),
+        Password: newPassword,
+        ClientMetadata: { source: "web" },
+      }),
+    );
+
+    // Then the trigger ran again, under the source of its own real Cognito
+    // gives a reset, so a handler can tell it from the sign-up it also saw.
+    assertArrayLength(events, 2);
+    assertObjectMatches(events.at(-1), {
+      userPoolId: pool.userPoolId,
+      userName: triggerUsername,
+      triggerSource: "PostConfirmation_ConfirmForgotPassword",
+      callerContext: { clientId: pool.clientId },
+      request: { clientMetadata: { source: "web" } },
+      response: {},
+    });
+  });
+});

--- a/src/service/cognito/user-pool/trigger/sim-cognito-trigger-occasion.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-trigger-occasion.ts
@@ -47,6 +47,18 @@ export class SimCognitoTriggerOccasion {
   );
 
   /**
+   * A user reaching `CONFIRMED` by finishing a password reset.
+   *
+   * Real Cognito runs `PostConfirmation` for `ConfirmForgotPassword` as well
+   * as for a sign-up, under a source of its own, so a handler that creates a
+   * profile record on first confirmation can tell the two apart.
+   */
+  public static readonly confirmForgotPassword = new SimCognitoTriggerOccasion(
+    "PostConfirmation",
+    "PostConfirmation_ConfirmForgotPassword",
+  );
+
+  /**
    * A sign-in, before the user's password is checked.
    */
   public static readonly preAuthentication = new SimCognitoTriggerOccasion(
@@ -120,6 +132,18 @@ export class SimCognitoTriggerOccasion {
     );
 
   /**
+   * The code a user resetting a forgotten password is sent.
+   *
+   * `AdminResetUserPassword` reports this source too, because real Cognito has
+   * none of its own for the reset an administrator starts.
+   */
+  public static readonly customMessageForgotPassword =
+    new SimCognitoTriggerOccasion(
+      "CustomMessage",
+      "CustomMessage_ForgotPassword",
+    );
+
+  /**
    * The code a sign-in challenged for a second factor is sent.
    */
   public static readonly customMessageAuthentication =
@@ -158,6 +182,9 @@ export class SimCognitoTriggerOccasion {
       }
       case "Authentication": {
         return this.customMessageAuthentication;
+      }
+      case "ForgotPassword": {
+        return this.customMessageForgotPassword;
       }
     }
   }

--- a/src/service/cognito/user-pool/trigger/sim-cognito-user-pool-triggers.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-user-pool-triggers.ts
@@ -55,9 +55,15 @@ export class SimCognitoUserPoolTriggers {
    * request without undoing the confirmation: the user stays confirmed, exactly
    * as on real Cognito. `AdminCreateUser` never reaches here, as it never
    * reaches it on real Cognito.
+   *
+   * The occasion is what tells a sign-up being confirmed from a password being
+   * reset, which real Cognito reports as two sources of the one trigger.
    */
-  async postConfirmation(context: SimCognitoTriggerContext): Promise<void> {
-    await this.invocation.run(SimCognitoTriggerOccasion.confirmSignUp, context);
+  async postConfirmation(
+    occasion: SimCognitoTriggerOccasion,
+    context: SimCognitoTriggerContext,
+  ): Promise<void> {
+    await this.invocation.run(occasion, context);
   }
 
   /**

--- a/src/service/cognito/user-pool/user/sim-cognito-user-confirmation.ts
+++ b/src/service/cognito/user-pool/user/sim-cognito-user-confirmation.ts
@@ -1,14 +1,19 @@
-import { SimCognitoCodeMismatchException } from "../../error/sim-cognito.error.js";
+import {
+  SimCognitoCodeMismatchException,
+  SimCognitoExpiredCodeException,
+} from "../../error/sim-cognito.error.js";
 import { SimCognitoConfirmationCode } from "./sim-cognito-confirmation-code.js";
 import type { SimCognitoUserStatus } from "./sim-cognito-user-status.js";
 
 /**
- * The confirmation one user has outstanding.
+ * The code one user has outstanding.
  *
- * A user that signed itself up holds a code until it confirms, and a user that
- * did not holds none. Keeping the code and what it answers together is the
- * same modelling choice `SimCognitoUserPassword` makes: the user asks whether
- * a candidate is right, rather than reading the value out to compare it.
+ * A user that signed itself up holds one until it confirms, a user that asked
+ * to reset a forgotten password holds one until it sets the new one, and a
+ * user doing neither holds none. Keeping the code and what it answers together
+ * is the same modelling choice `SimCognitoUserPassword` makes: the user asks
+ * whether a candidate is right, rather than reading the value out to compare
+ * it.
  *
  * The value is readable, unlike a password, because nothing here delivers the
  * message that would carry it.
@@ -38,19 +43,31 @@ export class SimCognitoUserConfirmation {
    * Follow the user to a status.
    *
    * A user waiting to be confirmed holds a code, and one that has left
-   * `UNCONFIRMED` has spent it: a code confirms one sign-up and no more.
+   * `UNCONFIRMED` has spent it: a code confirms one sign-up and no more. A
+   * user an administrator has sent to `RESET_REQUIRED` is issued its code
+   * after the move, because the code is what the reset is answered with.
    */
   settle(status: SimCognitoUserStatus): void {
-    this.#code = status.isUnconfirmed
+    this.#code = status.holdsCode
       ? SimCognitoConfirmationCode.issue()
       : undefined;
   }
 
   /**
    * Refuse a candidate that is not the code outstanding.
+   *
+   * A user holding no code at all is refused as having an expired one, which
+   * is what real Cognito answers a code that has already been spent with.
+   * Nothing here ages a code out, so that is the only way to reach it.
    */
   require(candidate: string | undefined): void {
-    if (this.#code?.matches(candidate) !== true) {
+    if (this.#code === undefined) {
+      throw new SimCognitoExpiredCodeException(
+        "Invalid code provided, please request a code again.",
+      );
+    }
+
+    if (!this.#code.matches(candidate)) {
       throw new SimCognitoCodeMismatchException(
         "Invalid verification code provided, please try again.",
       );

--- a/src/service/cognito/user-pool/user/sim-cognito-user-password-reset.ts
+++ b/src/service/cognito/user-pool/user/sim-cognito-user-password-reset.ts
@@ -1,0 +1,87 @@
+import type { SimCognitoUserConfirmation } from "./sim-cognito-user-confirmation.js";
+import { SimCognitoUserStatus } from "./sim-cognito-user-status.js";
+
+interface SimCognitoUserPasswordResetProperties {
+  /** The code the user has outstanding, which a reset issues and spends. */
+  readonly confirmation: SimCognitoUserConfirmation;
+
+  /** Where the user is now, which decides whether it can reset at all. */
+  readonly status: () => SimCognitoUserStatus;
+
+  /** Move the user to a status. */
+  readonly moved: (status: SimCognitoUserStatus) => void;
+
+  /** Give the user a permanent password of its own. */
+  readonly chosen: (password: string) => void;
+
+  /** Note that the user changed without moving to another status. */
+  readonly changed: () => void;
+}
+
+/**
+ * The password reset one simulated user can go through.
+ *
+ * A reset is two operations apart: the user asks for one and is sent a code,
+ * then answers with that code and a password of its own. An administrator
+ * starts a third way, by taking the password away and leaving the user in
+ * `RESET_REQUIRED` holding the same kind of code.
+ *
+ * The code is the one `SimCognitoUserConfirmation` holds, because a user has
+ * one thing outstanding at a time and a reset code and a sign-up code are the
+ * same six digits sent the same way. A test reads it back off the pool for the
+ * same reason it reads a sign-up code back: nothing here delivers a message.
+ */
+export class SimCognitoUserPasswordReset {
+  private readonly confirmation: SimCognitoUserConfirmation;
+  private readonly status: () => SimCognitoUserStatus;
+  private readonly moved: (status: SimCognitoUserStatus) => void;
+  private readonly chosen: (password: string) => void;
+  private readonly changed: () => void;
+
+  constructor(properties: SimCognitoUserPasswordResetProperties) {
+    this.confirmation = properties.confirmation;
+    this.status = properties.status;
+    this.moved = properties.moved;
+    this.chosen = properties.chosen;
+    this.changed = properties.changed;
+  }
+
+  /**
+   * Start a reset, issuing the code that finishes it.
+   *
+   * The user stays where it is: real Cognito moves nobody on for asking, and
+   * the password it has goes on working until the reset is confirmed. Asking
+   * twice issues a second code and forgets the first, as a resent sign-up code
+   * does.
+   */
+  start(): void {
+    this.status().requireSelfResettable();
+    this.confirmation.issue();
+    this.changed();
+  }
+
+  /**
+   * Finish a reset with the code that started it.
+   *
+   * The user reaches `CONFIRMED`, which takes it out of `RESET_REQUIRED` and
+   * confirms one that never confirmed its sign-up, as real Cognito does. The
+   * old password stops working, and so does the code.
+   */
+  confirm(code: string | undefined, password: string): void {
+    this.status().requireSelfResettable();
+    this.confirmation.require(code);
+    this.chosen(password);
+  }
+
+  /**
+   * Take the user's password away, and issue the code it sets another with.
+   *
+   * This is `AdminResetUserPassword`. The user is refused at sign-in until it
+   * answers `ConfirmForgotPassword`, which is the whole of what
+   * `RESET_REQUIRED` is for.
+   */
+  require(): void {
+    this.status().requireResettable();
+    this.moved(SimCognitoUserStatus.resetRequired);
+  }
+}

--- a/src/service/cognito/user-pool/user/sim-cognito-user-status.ts
+++ b/src/service/cognito/user-pool/user/sim-cognito-user-status.ts
@@ -7,21 +7,24 @@ export type SimCognitoUserStatusValue =
   | "UNCONFIRMED"
   | "FORCE_CHANGE_PASSWORD"
   | "CONFIRMED"
+  | "RESET_REQUIRED"
   | "EXTERNAL_PROVIDER";
 
 /**
  * The status of one simulated user.
  *
- * Only the three statuses this simulation can reach are modelled. A user
- * created by `AdminCreateUser` starts in `FORCE_CHANGE_PASSWORD`, which is what
- * stops it signing in normally on real Cognito, and reaches `CONFIRMED` when an
- * admin sets a permanent password on it. A user that signed itself up with
- * `SignUp` starts in `UNCONFIRMED`, which is what stops that one signing in,
- * and reaches `CONFIRMED` through `ConfirmSignUp` or `AdminConfirmSignUp`. A
- * user the pool created for a federated sign-in is `EXTERNAL_PROVIDER` and
- * stays there, because its password is at the provider rather than in the
- * pool. `RESET_REQUIRED` and the rest belong to password resets, which are not
- * simulated.
+ * Only the statuses this simulation can reach are modelled. A user created by
+ * `AdminCreateUser` starts in `FORCE_CHANGE_PASSWORD`, which is what stops it
+ * signing in normally on real Cognito, and reaches `CONFIRMED` when an admin
+ * sets a permanent password on it. A user that signed itself up with `SignUp`
+ * starts in `UNCONFIRMED`, which is what stops that one signing in, and
+ * reaches `CONFIRMED` through `ConfirmSignUp` or `AdminConfirmSignUp`. A user
+ * an admin sent to `AdminResetUserPassword` is `RESET_REQUIRED` until it sets
+ * a password of its own again. A user the pool created for a federated sign-in
+ * is `EXTERNAL_PROVIDER` and stays there, because its password is at the
+ * provider rather than in the pool. `ARCHIVED`, `COMPROMISED` and `UNKNOWN`
+ * belong to threat protection and to accounts Cognito has retired, neither of
+ * which is simulated.
  */
 export class SimCognitoUserStatus {
   /**
@@ -40,6 +43,17 @@ export class SimCognitoUserStatus {
    * The status a user with a password of its own reaches.
    */
   public static readonly confirmed = new SimCognitoUserStatus("CONFIRMED");
+
+  /**
+   * The status a user whose password an administrator reset waits in.
+   *
+   * The user cannot sign in from here. It has a code to answer
+   * `ConfirmForgotPassword` with, and setting a password that way is what
+   * takes it back to `CONFIRMED`.
+   */
+  public static readonly resetRequired = new SimCognitoUserStatus(
+    "RESET_REQUIRED",
+  );
 
   /**
    * The status a user created by a federated sign-in stays in.
@@ -88,6 +102,18 @@ export class SimCognitoUserStatus {
   }
 
   /**
+   * Whether the user has to set a password of its own before it can sign in.
+   *
+   * This is what turns an authentication into `PasswordResetRequiredException`
+   * rather than into tokens, and it is the whole point of the status: an
+   * administrator has taken the user's password away, and only the user can
+   * choose the next one.
+   */
+  get mustResetPassword(): boolean {
+    return this.value === "RESET_REQUIRED";
+  }
+
+  /**
    * Whether the user has still to confirm the sign-up it made.
    *
    * This is what turns an authentication into `UserNotConfirmedException`,
@@ -95,6 +121,18 @@ export class SimCognitoUserStatus {
    */
   get isUnconfirmed(): boolean {
     return this.value === "UNCONFIRMED";
+  }
+
+  /**
+   * Whether a user in this status is holding a code it has still to answer
+   * with.
+   *
+   * A user waiting to confirm its sign-up holds the code its pool issued, and
+   * one an administrator has reset holds the code it sets a new password with.
+   * Nothing else has anything outstanding.
+   */
+  get holdsCode(): boolean {
+    return this.isUnconfirmed || this.mustResetPassword;
   }
 
   /**
@@ -108,6 +146,38 @@ export class SimCognitoUserStatus {
     if (!this.isUnconfirmed) {
       throw new SimCognitoNotAuthorizedException(
         `User cannot be confirmed. Current status is ${this.value}`,
+      );
+    }
+  }
+
+  /**
+   * Refuse a `ForgotPassword` or `ConfirmForgotPassword` for a user that
+   * cannot reset its own password.
+   *
+   * A user still on a temporary password is refused here and not by
+   * `AdminResetUserPassword`: it has the `NEW_PASSWORD_REQUIRED` challenge to
+   * answer, so real Cognito sends it to that rather than to a reset code.
+   */
+  requireSelfResettable(): void {
+    this.requireResettable();
+
+    if (this.mustChangePassword) {
+      throw new SimCognitoNotAuthorizedException(
+        "User password cannot be reset in the current state.",
+      );
+    }
+  }
+
+  /**
+   * Refuse a password reset for a user that has no password in this pool.
+   *
+   * A federated user signs in at its provider, so there is nothing here to
+   * reset and nothing a code could set, whoever asked for the reset.
+   */
+  requireResettable(): void {
+    if (this.value === "EXTERNAL_PROVIDER") {
+      throw new SimCognitoNotAuthorizedException(
+        "User password cannot be reset in the current state.",
       );
     }
   }

--- a/src/service/cognito/user-pool/user/sim-cognito-user.ts
+++ b/src/service/cognito/user-pool/user/sim-cognito-user.ts
@@ -2,6 +2,7 @@ import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import type { SimCognitoFederatedIdentity } from "../idp/sim-cognito-federated-identity.js";
 import { SimCognitoUserMfa } from "./mfa/sim-cognito-user-mfa.js";
 import { SimCognitoUserConfirmation } from "./sim-cognito-user-confirmation.js";
+import { SimCognitoUserPasswordReset } from "./sim-cognito-user-password-reset.js";
 import type {
   SimCognitoAttributeType,
   SimCognitoUserAttributes,
@@ -52,6 +53,7 @@ export class SimCognitoUser {
   private readonly userAttributes: SimCognitoUserAttributes;
   private readonly confirmation: SimCognitoUserConfirmation;
   private readonly userMfa: SimCognitoUserMfa;
+  private readonly reset: SimCognitoUserPasswordReset;
   private readonly federatedIdentity: SimCognitoFederatedIdentity | undefined;
   private userStatus: SimCognitoUserStatus;
   private userPassword: SimCognitoUserPassword | undefined;
@@ -72,6 +74,19 @@ export class SimCognitoUser {
     this.modifiedDate = this.creationDate;
     this.userMfa = new SimCognitoUserMfa({
       attributes: this.userAttributes.values,
+      changed: (): void => {
+        this.touch();
+      },
+    });
+    this.reset = new SimCognitoUserPasswordReset({
+      confirmation: this.confirmation,
+      status: (): SimCognitoUserStatus => this.userStatus,
+      moved: (status): void => {
+        this.moveTo(status);
+      },
+      chosen: (password): void => {
+        this.setPassword(password, true);
+      },
       changed: (): void => {
         this.touch();
       },
@@ -113,7 +128,7 @@ export class SimCognitoUser {
   get attributes(): readonly SimCognitoAttributeType[] {
     return [
       { Name: "sub", Value: this.sub },
-      ...this.identityAttribute(),
+      ...(this.federatedIdentity?.attributes() ?? []),
       ...this.userAttributes.entries,
     ];
   }
@@ -140,12 +155,13 @@ export class SimCognitoUser {
   }
 
   /**
-   * The confirmation code this user has outstanding, if it has one.
+   * The code this user has outstanding, if it has one.
    *
    * Real Cognito sends the code to the user and never reports it back. Nothing
    * here delivers a message, so a test reads the code from the pool instead,
-   * which is the divergence that makes a sign-up flow testable at all. A
-   * confirmed user has none: a code is single use, and confirming spends it.
+   * which is the divergence that makes a sign-up flow testable at all. A user
+   * with nothing outstanding has none: a code settles one sign-up or one
+   * password reset, and settling it spends it.
    */
   get confirmationCode(): string | undefined {
     return this.confirmation.code;
@@ -158,6 +174,14 @@ export class SimCognitoUser {
    */
   get mfa(): SimCognitoUserMfa {
     return this.userMfa;
+  }
+
+  /**
+   * The password reset this user can go through, which is what a forgotten
+   * password is replaced by and what an administrator can force.
+   */
+  get passwordReset(): SimCognitoUserPasswordReset {
+    return this.reset;
   }
 
   /**
@@ -256,30 +280,16 @@ export class SimCognitoUser {
   }
 
   /**
-   * Move the user to a status, and let its confirmation follow.
+   * Move the user to a status, and let the code it holds follow.
    *
-   * A code confirms one sign-up and no more, so it goes as soon as the user
-   * leaves `UNCONFIRMED`, whether it was `ConfirmSignUp` or an admin setting a
-   * permanent password that took it there.
+   * A code settles one thing and no more, so it goes as soon as the user
+   * leaves the status that issued it, and a user an administrator has sent to
+   * `RESET_REQUIRED` is issued the one it resets with on the way in.
    */
   private moveTo(status: SimCognitoUserStatus): void {
     this.userStatus = status;
     this.confirmation.settle(status);
     this.touch();
-  }
-
-  /**
-   * The `identities` attribute a federated user reports, which a local user
-   * does not have at all.
-   */
-  private identityAttribute(): readonly SimCognitoAttributeType[] {
-    if (this.federatedIdentity === undefined) {
-      return [];
-    }
-
-    return [
-      { Name: "identities", Value: this.federatedIdentity.toAttributeValue() },
-    ];
   }
 
   private touch(): void {

--- a/test/cognito/password-reset-fixture.ts
+++ b/test/cognito/password-reset-fixture.ts
@@ -1,0 +1,167 @@
+/**
+ * A pool holding one confirmed user with a password of its own, which is where
+ * a password reset test starts from.
+ *
+ * This lives under `test/` because the lint rules reject a test file exporting
+ * helpers alongside its own `describe` calls, and the reset suites all want the
+ * same pool.
+ */
+
+import { createHmac } from "node:crypto";
+import {
+  ConfirmSignUpCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  InitiateAuthCommand,
+  SignUpCommand,
+  type PreventUserExistenceErrorTypes,
+  type VerifiedAttributeType,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { assertNonNullable } from "@kensio/smartass";
+
+import { SimAws } from "../../src/service/aws/sim-aws.js";
+import type { SimCognitoIdentityProvider } from "../../src/service/cognito/index.js";
+
+/** The user every password reset suite signs up. */
+export const resetUsername = "alice";
+
+/** The password that user chooses at sign-up. */
+export const resetPassword = "Sup3rSecret!";
+
+/** The password it chooses when it resets. */
+export const newResetPassword = "Ev3nBetter!";
+
+/**
+ * What a test asks for when it wants a pool to reset a password in.
+ */
+export interface SimCognitoResetPoolInput {
+  /** What the app client is created with, `LEGACY` by default. */
+  readonly preventUserExistenceErrors?: PreventUserExistenceErrorTypes;
+
+  /** Whether the app client is created with a secret. */
+  readonly generateSecret?: boolean;
+
+  /**
+   * The `AutoVerifiedAttributes` the pool is created with, `email` by default.
+   * A pool created with none has nowhere to send a reset code.
+   */
+  readonly autoVerifiedAttributes?: readonly VerifiedAttributeType[];
+}
+
+/**
+ * A pool whose one user has signed itself up, confirmed, and can sign in.
+ */
+export interface SimCognitoResetPool {
+  readonly cognito: SimCognitoIdentityProvider;
+  readonly userPoolId: string;
+  readonly clientId: string;
+
+  /** The client secret, for a pool asked for an app client with one. */
+  readonly clientSecret: string | undefined;
+}
+
+/**
+ * Build the pool and take its user through sign-up and confirmation.
+ */
+export async function makeResetPool(
+  input: SimCognitoResetPoolInput = {},
+): Promise<SimCognitoResetPool> {
+  const cognito = new SimAws().cognitoIdentityProvider();
+  const pool = await cognito.createUserPool(
+    new CreateUserPoolCommand({
+      PoolName: "myapp-users",
+      AutoVerifiedAttributes: [...(input.autoVerifiedAttributes ?? ["email"])],
+    }),
+  );
+
+  assertNonNullable(pool.UserPool?.Id, "CreateUserPool answered with a pool");
+
+  const userPoolId = pool.UserPool.Id;
+  const client = await cognito.createUserPoolClient(
+    new CreateUserPoolClientCommand({
+      UserPoolId: userPoolId,
+      ClientName: "web",
+      ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH"],
+      PreventUserExistenceErrors: input.preventUserExistenceErrors,
+      GenerateSecret: input.generateSecret,
+    }),
+  );
+
+  assertNonNullable(
+    client.UserPoolClient?.ClientId,
+    "CreateUserPoolClient answered with a client id",
+  );
+
+  const clientId = client.UserPoolClient.ClientId;
+  const clientSecret = client.UserPoolClient.ClientSecret;
+  const secretHash =
+    clientSecret === undefined
+      ? undefined
+      : simCognitoResetSecretHash(clientId, clientSecret);
+
+  await cognito.signUp(
+    new SignUpCommand({
+      ClientId: clientId,
+      Username: resetUsername,
+      Password: resetPassword,
+      SecretHash: secretHash,
+      UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+    }),
+  );
+  await cognito.confirmSignUp(
+    new ConfirmSignUpCommand({
+      ClientId: clientId,
+      Username: resetUsername,
+      SecretHash: secretHash,
+      ConfirmationCode: cognito
+        .userPool(userPoolId)
+        .confirmationCode(resetUsername),
+    }),
+  );
+
+  return { cognito, userPoolId, clientId, clientSecret };
+}
+
+/**
+ * The `SECRET_HASH` the AWS SDKs compute for the fixture's user.
+ */
+export function simCognitoResetSecretHash(
+  clientId: string,
+  clientSecret: string,
+): string {
+  return createHmac("sha256", clientSecret)
+    .update(`${resetUsername}${clientId}`)
+    .digest("base64");
+}
+
+/**
+ * The code the pool issued the fixture's user, which real Cognito would have
+ * sent it.
+ */
+export function resetCodeIn(pool: SimCognitoResetPool): string {
+  const code = pool.cognito
+    .userPool(pool.userPoolId)
+    .confirmationCode(resetUsername);
+
+  assertNonNullable(code, "The pool issued the user a code");
+
+  return code;
+}
+
+/**
+ * Sign the fixture's user in, answering with the access token it was issued.
+ */
+export async function signResetUserIn(
+  pool: SimCognitoResetPool,
+  candidate: string,
+): Promise<string | undefined> {
+  const signedIn = await pool.cognito.initiateAuth(
+    new InitiateAuthCommand({
+      ClientId: pool.clientId,
+      AuthFlow: "USER_PASSWORD_AUTH",
+      AuthParameters: { USERNAME: resetUsername, PASSWORD: candidate },
+    }),
+  );
+
+  return signedIn.AuthenticationResult?.AccessToken;
+}


### PR DESCRIPTION
`ForgotPassword` issues a reset code, `ConfirmForgotPassword` spends it on a new password, and `AdminResetUserPassword` takes a password away and leaves the user in `RESET_REQUIRED`, where a sign-in is refused with `PasswordResetRequiredException`. The code is the one a user already holds for a sign-up, so a test reads it back through `SimCognitoUserPool.confirmationCode`, and the pool records the message it would have carried under a new `ForgotPassword` occasion. `ForgotPassword` reports masked `CodeDeliveryDetails` for the attribute the pool verifies automatically and refuses a user it can reach at neither address, an app client's `PreventUserExistenceErrors` decides what an unknown user gets, and the `CustomMessage` and `PostConfirmation` triggers gain the two sources real Cognito reports for a reset.

Resolves #664

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added self-service password recovery with forgot-password, confirmation-code, and password-reset flows.
  - Added administrator-initiated password resets, including `RESET_REQUIRED` status handling.
  - Added masked code-delivery details for email and phone destinations.
  - Added password-reset support to SDK routes and custom-message/PostConfirmation triggers.

- **Bug Fixes**
  - Users without permanent passwords can no longer sign in before completing the required reset.

- **Documentation**
  - Expanded Cognito documentation with password-recovery behavior, limitations, delivery rules, and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->