### PR TITLE
feat: serve managed login pages for a password reset

### DIFF
--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -1779,8 +1779,8 @@ so does one that signed up on the page below.
 
 ### The pages managed login serves
 
-A served domain answers three pages, so a browser in a local development server completes a whole
-sign-up and sign-in without any of it being stubbed out.
+A served domain answers five pages, so a browser in a local development server completes a whole
+sign-up, password reset and sign-in without any of it being stubbed out.
 
 `GET /oauth2/authorize` naming no `identity_provider` answers HTML holding the sign-in form. The
 form has a username field, a password field, and the authorize parameters as hidden inputs, and it
@@ -1855,12 +1855,78 @@ console.log(callbackUrl.searchParams.get("state")); // "csrf-token"
 console.log(callbackUrl.searchParams.get("code") !== null); // true
 ```
 
-A refusal a person can do something about is shown on the form they posted. A wrong password comes
-back on the sign-in form and issues no code, and a password the pool's policy turns down comes back
-on the sign-up form. A refusal the application caused, such as a `redirect_uri` the app client never
-registered, is answered the way every other authorize refusal is.
+`/forgotPassword` is the other link from the sign-in page, and it is where a person who cannot get
+in goes. Its form asks who has forgotten the password, does what `ForgotPassword` does, and sends
+the browser to `/confirmForgotPassword`. That page takes the code and a new password, does what
+`ConfirmForgotPassword` does, and sends the browser back to `/oauth2/authorize` to sign in with the
+password it has just chosen. Both paths are the ones real managed login serves these two steps at.
 
-There is no styling and no script on any of the three. Matching what real managed login looks like
+```typescript sim-cognito-managed-login-reset
+/**
+ * Resetting a forgotten password through the served pages.
+ */
+
+import type { SimAws } from "@kensio/yulin";
+import { SimAwsHttp } from "@kensio/yulin/serve";
+
+declare const simAws: SimAws;
+declare const userPoolId: string;
+declare const clientId: string;
+
+const http = new SimAwsHttp({ simAws });
+const domain = "https://myapp-login.auth.eu-west-2.amazoncognito.com";
+const parameters = {
+  response_type: "code",
+  client_id: clientId,
+  redirect_uri: "https://www.example.com/user/callback",
+  scope: "openid email",
+  state: "csrf-token",
+};
+
+const posted = async (
+  path: string,
+  fields: Record<string, string>,
+): Promise<Response> =>
+  http.fetch(`${domain}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ ...parameters, ...fields }).toString(),
+  });
+
+// A confirmed user of the pool has forgotten its password.
+await posted("/forgotPassword", { username: "alice" });
+
+// The code the pool would have emailed is read off the pool, as a sign-up
+// code is.
+const pool = simAws.cognitoIdentityProvider().userPool(userPoolId);
+await posted("/confirmForgotPassword", {
+  username: "alice",
+  code: pool.confirmationCode("alice") ?? "",
+  password: "Ev3nBetter!",
+});
+
+// The user signs in with the new password and reaches the callback with a
+// code and the state the application began with.
+const signedIn = await posted("/oauth2/authorize", {
+  username: "alice",
+  password: "Ev3nBetter!",
+});
+const callbackUrl = new URL(signedIn.headers.get("location")!);
+console.log(callbackUrl.searchParams.get("state")); // "csrf-token"
+console.log(callbackUrl.searchParams.get("code") !== null); // true
+```
+
+A refusal a person can do something about is shown on the form they posted. A wrong password comes
+back on the sign-in form and issues no code, a password the pool's policy turns down comes back on
+the sign-up form or the new password form, and a wrong reset code comes back on the form that asked
+for it, leaving the password alone. A refusal the application caused, such as a `redirect_uri` the
+app client never registered, is answered the way every other authorize refusal is.
+
+What `/forgotPassword` shows for a username the pool lacks is the app client's
+`PreventUserExistenceErrors` decision. A client set to `ENABLED` sends the browser on to the code
+page either way, and one left on the `LEGACY` default says the user is not there.
+
+There is no styling and no script on any of the five. Matching what real managed login looks like
 would be work no test could tell apart from a bare form.
 
 ### Signing out
@@ -3647,8 +3713,9 @@ Sim Cognito currently supports:
   with PKCE and with a `refresh_token` grant
 - An authorize request naming no identity provider, signing one of the pool's own users in from a
   `username` and a `password` it carries
-- A served sign-in form at `/oauth2/authorize`, a sign-up form at `/signup` and a confirmation form
-  at `/confirm`, each carrying the authorize parameters through to the next
+- A served sign-in form at `/oauth2/authorize`, a sign-up form at `/signup`, a confirmation form at
+  `/confirm`, and the two password reset forms at `/forgotPassword` and `/confirmForgotPassword`,
+  each carrying the authorize parameters through to the next
 - The pool user a federated sign-in creates, named `<ProviderName>_<subject>`, in the
   `EXTERNAL_PROVIDER` status, carrying the `identities` attribute and claim and the attributes the
   provider's `AttributeMapping` named
@@ -3945,8 +4012,9 @@ Current documented limitations:
 - A hosted sign-in that real managed login would answer with a further page is refused. That is a
   user which has registered a second factor, and a user holding a temporary password. Both
   challenges are simulated at `InitiateAuth` and `AdminInitiateAuth`, which is where a test drives
-  them. No page asks for a reset code either. `ForgotPassword` and `ConfirmForgotPassword` are
-  simulated at the API, which is where a test drives a reset.
+  them. A user in `RESET_REQUIRED` is refused there as well, where real managed login prompts for a
+  new password at sign-in. The served reset pages are the ones a person reaches from the sign-in
+  form, and they start a reset rather than finishing one an administrator forced.
 - The implicit grant is refused, and so is the client credentials grant, which needs resource
   servers.
 - The served OpenID configuration names its `authorization_endpoint`, `token_endpoint` and

--- a/docs/services/cognito/sim-cognito-managed-login-reset.example.ts
+++ b/docs/services/cognito/sim-cognito-managed-login-reset.example.ts
@@ -1,0 +1,52 @@
+/**
+ * Resetting a forgotten password through the served pages.
+ */
+
+import type { SimAws } from "@kensio/yulin";
+import { SimAwsHttp } from "@kensio/yulin/serve";
+
+declare const simAws: SimAws;
+declare const userPoolId: string;
+declare const clientId: string;
+
+const http = new SimAwsHttp({ simAws });
+const domain = "https://myapp-login.auth.eu-west-2.amazoncognito.com";
+const parameters = {
+  response_type: "code",
+  client_id: clientId,
+  redirect_uri: "https://www.example.com/user/callback",
+  scope: "openid email",
+  state: "csrf-token",
+};
+
+const posted = async (
+  path: string,
+  fields: Record<string, string>,
+): Promise<Response> =>
+  http.fetch(`${domain}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ ...parameters, ...fields }).toString(),
+  });
+
+// A confirmed user of the pool has forgotten its password.
+await posted("/forgotPassword", { username: "alice" });
+
+// The code the pool would have emailed is read off the pool, as a sign-up
+// code is.
+const pool = simAws.cognitoIdentityProvider().userPool(userPoolId);
+await posted("/confirmForgotPassword", {
+  username: "alice",
+  code: pool.confirmationCode("alice") ?? "",
+  password: "Ev3nBetter!",
+});
+
+// The user signs in with the new password and reaches the callback with a
+// code and the state the application began with.
+const signedIn = await posted("/oauth2/authorize", {
+  username: "alice",
+  password: "Ev3nBetter!",
+});
+const callbackUrl = new URL(signedIn.headers.get("location")!);
+console.log(callbackUrl.searchParams.get("state")); // "csrf-token"
+console.log(callbackUrl.searchParams.get("code") !== null); // true

--- a/src/service/cognito/README.md
+++ b/src/service/cognito/README.md
@@ -442,11 +442,14 @@ client reaches the simulator through `SimSdk`.
 
 `serve/page/` under it is the managed login pages. `SimCognitoPageMarkup` is the HTML they are built
 from, `SimCognitoPageForm` is one request read as the form it fetched or posted, and
-`SimCognitoManagedLogin` is what `SimCognitoDomainEndpoints` hands a page request to. The three
-pages are `SimCognitoSignInPage`, `SimCognitoSignUpPage` and `SimCognitoConfirmPage`, and the last
-two call `SignUp`, `ConfirmSignUp` and `ResendConfirmationCode` as an application would. A refusal a
-person can act on is rendered back onto the form they posted, and one the application caused is
-answered as any other authorize refusal is.
+`SimCognitoManagedLogin` is what `SimCognitoDomainEndpoints` hands a page request to. The five pages
+are `SimCognitoSignInPage`, `SimCognitoSignUpPage`, `SimCognitoConfirmPage`,
+`SimCognitoForgotPasswordPage` and `SimCognitoResetPasswordPage`, and the last four call `SignUp`,
+`ConfirmSignUp`, `ResendConfirmationCode`, `ForgotPassword` and `ConfirmForgotPassword` as an
+application would. `simCognitoPagePaths` is the set `SimCognitoDomainEndpoints` routes by, and the
+sign-in form is absent from it because the authorize endpoint is what answers with that one. A
+refusal a person can act on is rendered back onto the form they posted, and one the application
+caused is answered as any other authorize refusal is.
 
 `/<userPoolId>/messages` is served alongside them, and real Cognito has no such endpoint. It is the
 serving side of `SimCognitoUserPool.sentMessages`, so a browser or a curl can read what a pool would

--- a/src/service/cognito/serve/page/sim-cognito-forgot-password-page.ts
+++ b/src/service/cognito/serve/page/sim-cognito-forgot-password-page.ts
@@ -1,0 +1,73 @@
+import { SimCognitoPageForm } from "./sim-cognito-page-form.js";
+import { SimCognitoPageMarkup } from "./sim-cognito-page-markup.js";
+import {
+  simCognitoAuthorizePath,
+  simCognitoForgotPasswordPath,
+  simCognitoResetPasswordPath,
+} from "./sim-cognito-page-paths.js";
+
+/**
+ * The form that starts a password reset, reached from a link on the sign-in
+ * page.
+ *
+ * It asks who has forgotten the password and posts that to `ForgotPassword`,
+ * which is what an application with its own sign-in screens calls. The browser
+ * goes on to the page that takes the code.
+ *
+ * What an unknown user sees is the app client's `PreventUserExistenceErrors`
+ * decision. A client that hides existence sends the browser to the next page
+ * either way, and one on the `LEGACY` default says the user is not there.
+ */
+export class SimCognitoForgotPasswordPage {
+  private readonly markup = new SimCognitoPageMarkup();
+
+  /**
+   * The page, or the reset its form has just started.
+   */
+  async handle(form: SimCognitoPageForm): Promise<Response> {
+    if (!form.isPosted) {
+      return this.render(form);
+    }
+
+    try {
+      await form.cognito.forgotPassword({
+        input: {
+          ClientId: form.clientId,
+          Username: form.username,
+          ...form.secretHash(),
+        },
+      });
+    } catch (error) {
+      return this.render(form, SimCognitoPageForm.messageIn(error));
+    }
+
+    return this.markup.redirect(simCognitoResetPasswordPath, {
+      ...form.parameters,
+      username: form.username,
+    });
+  }
+
+  /**
+   * The page a browser is answered with, with a message where a reset has
+   * already been refused once.
+   */
+  private render(form: SimCognitoPageForm, message?: string): Response {
+    const { parameters } = form;
+    const body =
+      (message === undefined ? "" : this.markup.message(message)) +
+      this.markup.form(
+        simCognitoForgotPasswordPath,
+        this.markup.hidden(parameters) +
+          this.markup.field("username", "Username") +
+          this.markup.submit("reset", "Send a reset code"),
+      ) +
+      this.markup.link(
+        simCognitoResetPasswordPath,
+        parameters,
+        "I already have a code",
+      ) +
+      this.markup.link(simCognitoAuthorizePath, parameters, "Back to sign in");
+
+    return this.markup.page("Forgotten your password", body);
+  }
+}

--- a/src/service/cognito/serve/page/sim-cognito-managed-login.ts
+++ b/src/service/cognito/serve/page/sim-cognito-managed-login.ts
@@ -2,13 +2,17 @@ import { isSimCognitoManagedLoginRequired } from "../../error/sim-cognito-manage
 import { isSimCognitoOAuthError } from "../../error/sim-cognito-oauth.error.js";
 import type { SimCognitoDomainRequest } from "../sim-cognito-domain-request.js";
 import { SimCognitoConfirmPage } from "./sim-cognito-confirm-page.js";
+import { SimCognitoForgotPasswordPage } from "./sim-cognito-forgot-password-page.js";
 import { SimCognitoPageForm } from "./sim-cognito-page-form.js";
 import type { SimCognitoPageParameters } from "./sim-cognito-page-markup.js";
 import {
-  simCognitoConfirmPath,
+  simCognitoForgotPasswordPath,
   simCognitoIsLocalSignIn,
+  simCognitoPagePaths,
+  simCognitoResetPasswordPath,
   simCognitoSignUpPath,
 } from "./sim-cognito-page-paths.js";
+import { SimCognitoResetPasswordPage } from "./sim-cognito-reset-password-page.js";
 import { SimCognitoPageRequest } from "./sim-cognito-page-request.js";
 import { SimCognitoSignInPage } from "./sim-cognito-sign-in-page.js";
 import { SimCognitoSignUpPage } from "./sim-cognito-sign-up-page.js";
@@ -17,37 +21,47 @@ import { SimCognitoSignUpPage } from "./sim-cognito-sign-up-page.js";
  * The pages simulated managed login serves.
  *
  * A person reaches the sign-in form at the authorize endpoint, the sign-up
- * form from a link on it, and the confirmation form from the sign-up it has
- * just made. Each form carries the authorize request's own parameters through
- * as hidden inputs, so the sign-in at the end of it reaches the app client's
- * callback URL the application asked for.
+ * form and the forgotten password form from links on it, and the confirmation
+ * and new password forms from the step before each. Each form carries the
+ * authorize request's own parameters through as hidden inputs, so the sign-in
+ * at the end of it reaches the app client's callback URL the application asked
+ * for.
  */
 export class SimCognitoManagedLogin {
   private readonly pageRequest = new SimCognitoPageRequest();
   private readonly signInPage = new SimCognitoSignInPage();
   private readonly signUpPage = new SimCognitoSignUpPage();
   private readonly confirmPage = new SimCognitoConfirmPage();
+  private readonly forgotPasswordPage = new SimCognitoForgotPasswordPage();
+  private readonly resetPasswordPage = new SimCognitoResetPasswordPage();
 
   /**
-   * Whether a path is one of the two pages served beside the OAuth endpoints.
+   * Whether a path is one of the pages served beside the OAuth endpoints.
    */
   static servesPage(pathname: string): boolean {
-    return (
-      pathname === simCognitoSignUpPath || pathname === simCognitoConfirmPath
-    );
+    return simCognitoPagePaths.has(pathname);
   }
 
   /**
-   * Answer the sign-up or confirmation page a request reached.
+   * Answer the page a request reached.
    */
   async handlePage(request: SimCognitoDomainRequest): Promise<Response> {
     const form = this.formIn(request);
 
-    if (request.url.pathname === simCognitoSignUpPath) {
-      return await this.signUpPage.handle(form);
+    switch (request.url.pathname) {
+      case simCognitoSignUpPath: {
+        return await this.signUpPage.handle(form);
+      }
+      case simCognitoForgotPasswordPath: {
+        return await this.forgotPasswordPage.handle(form);
+      }
+      case simCognitoResetPasswordPath: {
+        return await this.resetPasswordPage.handle(form);
+      }
+      default: {
+        return await this.confirmPage.handle(form);
+      }
     }
-
-    return await this.confirmPage.handle(form);
   }
 
   /**

--- a/src/service/cognito/serve/page/sim-cognito-page-paths.ts
+++ b/src/service/cognito/serve/page/sim-cognito-page-paths.ts
@@ -25,6 +25,32 @@ export const simCognitoSignUpPath = "/signup";
 export const simCognitoConfirmPath = "/confirm";
 
 /**
+ * The path the form asking who has forgotten a password is served at.
+ */
+export const simCognitoForgotPasswordPath = "/forgotPassword";
+
+/**
+ * The path the form taking the reset code and the new password is served at.
+ *
+ * Real managed login serves both halves of a reset at these two paths, and
+ * that is where an application's own links to them point.
+ */
+export const simCognitoResetPasswordPath = "/confirmForgotPassword";
+
+/**
+ * The pages served beside the OAuth endpoints.
+ *
+ * The sign-in form is not among them. It is what the authorize endpoint
+ * answers with, so it has no path of its own.
+ */
+export const simCognitoPagePaths: ReadonlySet<string> = new Set([
+  simCognitoSignUpPath,
+  simCognitoConfirmPath,
+  simCognitoForgotPasswordPath,
+  simCognitoResetPasswordPath,
+]);
+
+/**
  * The authorize parameters every page carries on to the next.
  *
  * A sign-up ends in a sign-in, and that sign-in has to reach the app client's

--- a/src/service/cognito/serve/page/sim-cognito-provider-links.ts
+++ b/src/service/cognito/serve/page/sim-cognito-provider-links.ts
@@ -1,0 +1,37 @@
+import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
+import type {
+  SimCognitoPageMarkup,
+  SimCognitoPageParameters,
+} from "./sim-cognito-page-markup.js";
+import { simCognitoAuthorizePath } from "./sim-cognito-page-paths.js";
+
+/**
+ * One link per identity provider this app client offers, each starting the
+ * federated sign-in the authorize endpoint already answers.
+ *
+ * A provider the client left out of its `SupportedIdentityProviders` is left
+ * off the page, because the authorize request the link would make is one that
+ * endpoint refuses.
+ */
+export function simCognitoProviderLinks(
+  markup: SimCognitoPageMarkup,
+  pool: SimCognitoUserPool,
+  parameters: SimCognitoPageParameters,
+): string {
+  const clientId = parameters["client_id"];
+  const client = clientId === undefined ? undefined : pool.findClient(clientId);
+
+  return pool.auth.identityProviders.all
+    .filter(
+      (provider) =>
+        client?.oauth.allowsIdentityProvider(provider.name) ?? false,
+    )
+    .map((provider) =>
+      markup.link(
+        simCognitoAuthorizePath,
+        { ...parameters, identity_provider: provider.name },
+        `Sign in with ${provider.name}`,
+      ),
+    )
+    .join("");
+}

--- a/src/service/cognito/serve/page/sim-cognito-reset-password-page.ts
+++ b/src/service/cognito/serve/page/sim-cognito-reset-password-page.ts
@@ -1,0 +1,79 @@
+import { SimCognitoPageForm } from "./sim-cognito-page-form.js";
+import { SimCognitoPageMarkup } from "./sim-cognito-page-markup.js";
+import {
+  simCognitoAuthorizePath,
+  simCognitoResetPasswordPath,
+} from "./sim-cognito-page-paths.js";
+
+/**
+ * The form that finishes a password reset, reached from the one that started
+ * it.
+ *
+ * It takes the code the pool issued and the password the person has chosen,
+ * and posts both to `ConfirmForgotPassword`. A wrong code and a password the
+ * pool's policy turns down are both shown on the form, which is where the
+ * person can do something about them.
+ *
+ * Nothing here delivers a code to anybody. The pool records the message it
+ * would have sent, and `SimCognitoUserPool.confirmationCode` is where a test
+ * reads it from, which is where a person would have read it out of an inbox.
+ */
+export class SimCognitoResetPasswordPage {
+  private readonly markup = new SimCognitoPageMarkup();
+
+  /**
+   * The page, or the reset its form has just finished.
+   */
+  async handle(form: SimCognitoPageForm): Promise<Response> {
+    if (!form.isPosted) {
+      return this.render(form);
+    }
+
+    try {
+      await form.cognito.confirmForgotPassword({
+        input: {
+          ClientId: form.clientId,
+          Username: form.username,
+          ConfirmationCode: form.field("code"),
+          Password: form.field("password"),
+          ...form.secretHash(),
+        },
+      });
+    } catch (error) {
+      return this.render(form, SimCognitoPageForm.messageIn(error));
+    }
+
+    // The user signs in with its new password at the endpoint the browser
+    // arrived on, which is where the grant it started carries on from.
+    return this.markup.redirect(simCognitoAuthorizePath, form.parameters);
+  }
+
+  /**
+   * The page a browser is answered with, with a message where a reset has
+   * already been refused once.
+   */
+  private render(form: SimCognitoPageForm, message?: string): Response {
+    const { parameters, username } = form;
+
+    // The page that started the reset names the user, and a browser that came
+    // here from a link instead has to say who it is.
+    const user =
+      username === ""
+        ? this.markup.field("username", "Username")
+        : this.markup.hidden({ username });
+
+    const body =
+      (message === undefined ? "" : this.markup.message(message)) +
+      this.markup.form(
+        simCognitoResetPasswordPath,
+        this.markup.hidden(parameters) +
+          user +
+          this.markup.field("code", "Reset code") +
+          this.markup.field("password", "New password", "password") +
+          this.markup.submit("reset", "Set the new password"),
+      ) +
+      this.markup.link(simCognitoAuthorizePath, parameters, "Back to sign in");
+
+    return this.markup.page("Choose a new password", body);
+  }
+}

--- a/src/service/cognito/serve/page/sim-cognito-sign-in-page.ts
+++ b/src/service/cognito/serve/page/sim-cognito-sign-in-page.ts
@@ -6,8 +6,19 @@ import {
 import {
   simCognitoAuthorizePath,
   simCognitoConfirmPath,
+  simCognitoForgotPasswordPath,
   simCognitoSignUpPath,
 } from "./sim-cognito-page-paths.js";
+import { simCognitoProviderLinks } from "./sim-cognito-provider-links.js";
+
+/**
+ * The other pages the sign-in form links to, in the order they are offered.
+ */
+const linkedPages: readonly (readonly [string, string])[] = [
+  [simCognitoSignUpPath, "Sign up"],
+  [simCognitoConfirmPath, "Confirm a sign-up"],
+  [simCognitoForgotPasswordPath, "Forgotten your password?"],
+];
 
 /**
  * The sign-in form managed login answers an authorize request with.
@@ -15,7 +26,8 @@ import {
  * The form posts back to the authorize endpoint, carrying the parameters the
  * browser arrived on as hidden inputs and the two fields the person filled in.
  * The pool's identity providers are links to the same endpoint with
- * `identity_provider` set, so both ways in are reachable from this one page.
+ * `identity_provider` set, so both ways in are reachable from this one page,
+ * and the other pages of the journey are links beside them.
  */
 export class SimCognitoSignInPage {
   private readonly markup = new SimCognitoPageMarkup();
@@ -38,41 +50,11 @@ export class SimCognitoSignInPage {
           this.markup.field("password", "Password", "password") +
           this.markup.submit("signIn", "Sign in"),
       ) +
-      this.providerLinks(pool, parameters) +
-      this.markup.link(simCognitoSignUpPath, parameters, "Sign up") +
-      this.markup.link(simCognitoConfirmPath, parameters, "Confirm a sign-up");
+      simCognitoProviderLinks(this.markup, pool, parameters) +
+      linkedPages
+        .map(([path, text]) => this.markup.link(path, parameters, text))
+        .join("");
 
     return this.markup.page("Sign in", body);
-  }
-
-  /**
-   * One link per identity provider this app client offers, each starting the
-   * federated sign-in the same endpoint already answers.
-   *
-   * A provider the client left out of its `SupportedIdentityProviders` is left
-   * off the page, because the authorize request the link would make is one
-   * that endpoint refuses.
-   */
-  private providerLinks(
-    pool: SimCognitoUserPool,
-    parameters: SimCognitoPageParameters,
-  ): string {
-    const clientId = parameters["client_id"];
-    const client =
-      clientId === undefined ? undefined : pool.findClient(clientId);
-
-    return pool.auth.identityProviders.all
-      .filter(
-        (provider) =>
-          client?.oauth.allowsIdentityProvider(provider.name) ?? false,
-      )
-      .map((provider) =>
-        this.markup.link(
-          simCognitoAuthorizePath,
-          { ...parameters, identity_provider: provider.name },
-          `Sign in with ${provider.name}`,
-        ),
-      )
-      .join("");
   }
 }

--- a/src/service/cognito/serve/sim-cognito-page-password-reset.iso.test.ts
+++ b/src/service/cognito/serve/sim-cognito-page-password-reset.iso.test.ts
@@ -1,0 +1,287 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  simCognitoHosted,
+  simCognitoLocalPassword,
+  simCognitoLocalUser,
+  simCognitoLocalUsername,
+  type SimCognitoHostedSetUp,
+} from "../../../../test/cognito/federation-fixture.js";
+import {
+  simCognitoAuthorizeParameters,
+  simCognitoGetPage,
+  simCognitoPostForm,
+  simCognitoRedirectedTo,
+} from "../../../../test/cognito/managed-login-fixture.js";
+
+const newPassword = "Ev3nBetter!";
+
+/**
+ * A pool that can send a reset code, holding one confirmed user.
+ */
+async function simCognitoResettable(
+  preventUserExistenceErrors?: "ENABLED" | "LEGACY",
+): Promise<SimCognitoHostedSetUp> {
+  const setUp = await simCognitoHosted({
+    autoVerifiedAttributes: ["email"],
+    ...(preventUserExistenceErrors !== undefined && {
+      preventUserExistenceErrors,
+    }),
+  });
+
+  await simCognitoLocalUser(setUp);
+
+  return setUp;
+}
+
+function resetCodeIn(setUp: SimCognitoHostedSetUp): string {
+  const code = setUp.cognito
+    .userPool(setUp.userPoolId)
+    .confirmationCode(simCognitoLocalUsername);
+
+  assertNonNullable(code);
+
+  return code;
+}
+
+describe("Resetting a password through the pages a sim Cognito domain serves", () => {
+  it("resets a forgotten password and signs in with the new one", async () => {
+    // Given a user of the pool that has forgotten its password.
+    const setUp = await simCognitoResettable();
+    const parameters = simCognitoAuthorizeParameters(setUp);
+
+    // When the sign-in page is fetched, it offers the way out.
+    const signInPage = await simCognitoGetPage(
+      setUp,
+      "/oauth2/authorize",
+      parameters,
+    );
+
+    assertStringIncludes(await signInPage.text(), "/forgotPassword?");
+
+    // And the forgotten password form is posted with the username.
+    const asked = await simCognitoPostForm(setUp, "/forgotPassword", {
+      ...parameters,
+      username: simCognitoLocalUsername,
+    });
+
+    // Then the browser is sent on to the page that takes the code.
+    assertIdentical(asked.status, 303);
+    assertIdentical(
+      simCognitoRedirectedTo(asked).pathname,
+      "/confirmForgotPassword",
+    );
+
+    // And posting the code the pool issued with a new password sets it.
+    const reset = await simCognitoPostForm(setUp, "/confirmForgotPassword", {
+      ...parameters,
+      username: simCognitoLocalUsername,
+      code: resetCodeIn(setUp),
+      password: newPassword,
+    });
+
+    assertIdentical(reset.status, 303);
+    assertIdentical(
+      simCognitoRedirectedTo(reset).pathname,
+      "/oauth2/authorize",
+    );
+
+    // And that user then signs in with the new password and reaches the
+    // callback with a code and the state the application began with.
+    const signedIn = await simCognitoPostForm(setUp, "/oauth2/authorize", {
+      ...parameters,
+      username: simCognitoLocalUsername,
+      password: newPassword,
+    });
+
+    assertIdentical(signedIn.status, 302);
+
+    const callback = simCognitoRedirectedTo(signedIn);
+
+    assertNonNullable(callback.searchParams.get("code"));
+    assertIdentical(callback.searchParams.get("state"), "csrf-token");
+  });
+
+  it("stops the old password working once the reset is through", async () => {
+    // Given a user that has reset its password through the pages.
+    const setUp = await simCognitoResettable();
+    const parameters = simCognitoAuthorizeParameters(setUp);
+
+    await simCognitoPostForm(setUp, "/forgotPassword", {
+      ...parameters,
+      username: simCognitoLocalUsername,
+    });
+    await simCognitoPostForm(setUp, "/confirmForgotPassword", {
+      ...parameters,
+      username: simCognitoLocalUsername,
+      code: resetCodeIn(setUp),
+      password: newPassword,
+    });
+
+    // When it signs in with the password it had before.
+    const refused = await simCognitoPostForm(setUp, "/oauth2/authorize", {
+      ...parameters,
+      username: simCognitoLocalUsername,
+      password: simCognitoLocalPassword,
+    });
+
+    // Then the sign-in form comes back saying so.
+    assertIdentical(refused.status, 200);
+    assertStringIncludes(
+      await refused.text(),
+      "Incorrect username or password",
+    );
+  });
+
+  it("shows a wrong code on the form and changes no password", async () => {
+    // Given a user waiting to answer with a reset code.
+    const setUp = await simCognitoResettable();
+    const parameters = simCognitoAuthorizeParameters(setUp);
+
+    await simCognitoPostForm(setUp, "/forgotPassword", {
+      ...parameters,
+      username: simCognitoLocalUsername,
+    });
+
+    // When the form is posted with a code the pool never issued.
+    const refused = await simCognitoPostForm(setUp, "/confirmForgotPassword", {
+      ...parameters,
+      username: simCognitoLocalUsername,
+      code: "000000",
+      password: newPassword,
+    });
+
+    // Then the form comes back with the refusal, and the old password still
+    // signs the user in.
+    assertIdentical(refused.status, 200);
+    assertStringIncludes(await refused.text(), "Invalid verification code");
+
+    const signedIn = await simCognitoPostForm(setUp, "/oauth2/authorize", {
+      ...parameters,
+      username: simCognitoLocalUsername,
+      password: simCognitoLocalPassword,
+    });
+
+    assertIdentical(signedIn.status, 302);
+  });
+
+  it("shows a password the pool's policy turns down on the form", async () => {
+    // Given a user waiting to answer with a reset code.
+    const setUp = await simCognitoResettable();
+    const parameters = simCognitoAuthorizeParameters(setUp);
+
+    await simCognitoPostForm(setUp, "/forgotPassword", {
+      ...parameters,
+      username: simCognitoLocalUsername,
+    });
+
+    // When the form is posted with a password the policy refuses.
+    const refused = await simCognitoPostForm(setUp, "/confirmForgotPassword", {
+      ...parameters,
+      username: simCognitoLocalUsername,
+      code: resetCodeIn(setUp),
+      password: "short",
+    });
+
+    // Then the form comes back with the rule the password broke.
+    assertIdentical(refused.status, 200);
+    assertStringIncludes(await refused.text(), "Password not long enough");
+  });
+
+  it("hides an unknown user where the app client asks it to", async () => {
+    // Given an app client with PreventUserExistenceErrors enabled.
+    const setUp = await simCognitoResettable("ENABLED");
+    const parameters = simCognitoAuthorizeParameters(setUp);
+
+    // When the forgotten password form names a user the pool does not hold.
+    const asked = await simCognitoPostForm(setUp, "/forgotPassword", {
+      ...parameters,
+      username: "mallory",
+    });
+
+    // Then the browser goes on to the code page, as it does for a user that
+    // is really there.
+    assertIdentical(asked.status, 303);
+    assertIdentical(
+      simCognitoRedirectedTo(asked).pathname,
+      "/confirmForgotPassword",
+    );
+  });
+
+  it("reports an unknown user where the app client leaks existence", async () => {
+    // Given an app client left on the LEGACY default.
+    const setUp = await simCognitoResettable();
+    const parameters = simCognitoAuthorizeParameters(setUp);
+
+    // When the forgotten password form names a user the pool does not hold.
+    const asked = await simCognitoPostForm(setUp, "/forgotPassword", {
+      ...parameters,
+      username: "mallory",
+    });
+
+    // Then the form comes back saying so, as real Cognito does under that
+    // setting.
+    assertIdentical(asked.status, 200);
+    assertStringIncludes(await asked.text(), "User does not exist");
+  });
+
+  it("asks who has forgotten the password before anything is posted", async () => {
+    // Given a pool with a hosted domain.
+    const setUp = await simCognitoResettable();
+    const parameters = simCognitoAuthorizeParameters(setUp);
+
+    // When each of the two forms is fetched.
+    const asking = await simCognitoGetPage(
+      setUp,
+      "/forgotPassword",
+      parameters,
+    );
+    const resetting = await simCognitoGetPage(
+      setUp,
+      "/confirmForgotPassword",
+      parameters,
+    );
+
+    // Then each asks for what it needs, and carries the grant's own state on
+    // to the next step.
+    const askingBody = await asking.text();
+
+    assertIdentical(asking.status, 200);
+    assertStringIncludes(askingBody, 'name="username"');
+    assertStringIncludes(askingBody, 'value="csrf-token"');
+
+    const resettingBody = await resetting.text();
+
+    assertIdentical(resetting.status, 200);
+    assertStringIncludes(resettingBody, 'name="code"');
+    assertStringIncludes(resettingBody, 'name="password"');
+    assertStringIncludes(resettingBody, 'value="csrf-token"');
+  });
+
+  it("refuses a reset for a pool with nowhere to send a code", async () => {
+    // Given a pool that verifies nothing, so it has no address to write to.
+    const setUp = await simCognitoHosted();
+
+    await simCognitoLocalUser(setUp);
+
+    const parameters = simCognitoAuthorizeParameters(setUp);
+
+    // When the forgotten password form is posted.
+    const refused = await simCognitoPostForm(setUp, "/forgotPassword", {
+      ...parameters,
+      username: simCognitoLocalUsername,
+    });
+
+    // Then the form comes back with what real Cognito refuses this with.
+    assertIdentical(refused.status, 200);
+    assertStringIncludes(
+      await refused.text(),
+      "no registered/verified email or phone_number",
+    );
+  });
+});

--- a/test/cognito/federation-fixture.ts
+++ b/test/cognito/federation-fixture.ts
@@ -11,8 +11,10 @@
 
 import type {
   AttributeType,
+  PreventUserExistenceErrorTypes,
   SchemaAttributeType,
   UserPoolMfaType,
+  VerifiedAttributeType,
 } from "@aws-sdk/client-cognito-identity-provider";
 import {
   AdminCreateUserCommand,
@@ -83,6 +85,15 @@ export interface SimCognitoHostedSetUpOptions {
 
   /** The pool's `Schema`, which is the standard attributes by default. */
   readonly schema?: SchemaAttributeType[];
+
+  /**
+   * The attributes the pool verifies automatically, none by default. A pool
+   * with none has nowhere to send a password reset code.
+   */
+  readonly autoVerifiedAttributes?: readonly VerifiedAttributeType[];
+
+  /** What the app client does about a username the pool lacks. */
+  readonly preventUserExistenceErrors?: PreventUserExistenceErrorTypes;
 }
 
 /**
@@ -129,6 +140,9 @@ export async function simCognitoHosted(
         MfaConfiguration: options.mfaConfiguration,
       }),
       ...(options.schema !== undefined && { Schema: options.schema }),
+      ...(options.autoVerifiedAttributes !== undefined && {
+        AutoVerifiedAttributes: [...options.autoVerifiedAttributes],
+      }),
     }),
   );
   assertNonNullable(pool.UserPool?.Id);
@@ -162,6 +176,7 @@ export async function simCognitoHosted(
       CallbackURLs: [simCognitoCallbackUrl],
       LogoutURLs: [simCognitoLogoutUrl],
       SupportedIdentityProviders: [...identityProviders],
+      PreventUserExistenceErrors: options.preventUserExistenceErrors,
     }),
   );
   assertNonNullable(client.UserPoolClient?.ClientId);


### PR DESCRIPTION
A person who cannot sign in follows a link from the served sign-in form to `/forgotPassword`, which asks who they are and calls `ForgotPassword`, and then to `/confirmForgotPassword`, which takes the code the pool issued and a new password and calls `ConfirmForgotPassword`. Both are the paths real managed login serves these steps at, both carry the authorize parameters through as hidden inputs, and the last step sends the browser back to the authorize endpoint, so a sign-in with the new password reaches the app client's callback URL with a code and the state the application began with. A wrong code and a password the pool's policy turns down come back on the form, and what an unknown username sees is the app client's `PreventUserExistenceErrors` decision.

Resolves #665