### PR TITLE
feat: serve the Cognito JWKS to a sim Lambda

### DIFF
--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -3059,6 +3059,11 @@ client that discovers the document can go on to fetch the keys it points at. The
 real `https://cognito-idp.<region>.amazonaws.com/<userPoolId>` in `iss`, what a verifier built from
 a pool id checks against. The two disagree here where they agree on real Cognito.
 
+A [simulated Lambda](../lambda/#verifying-a-cognito-token-in-a-handler "Simulated Lambda usage docs")
+reads both documents at the real regional endpoint, with no local server and no URL rewriting. A
+`CognitoJwtVerifier` inside a handler fetches the pool's JWKS for itself and verifies the token,
+which is the verifier setup the deployed code already has.
+
 ## Intercepting the SDK client
 
 Code that builds its own `CognitoIdentityProviderClient` needs no changes. Intercepting the client

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -418,14 +418,19 @@ A request from a handler to a hostname the simulation serves is answered by the 
 never leaves the process. `fetch`, `node:http` and `node:https` all reach it, so it makes no
 difference which client the handler was written with.
 
-Two kinds of hostname are served. The AWS service API endpoints are answered as Commands, which is
-what the section above covers. Everything simulated Route53 resolves is answered over the same
-in-process HTTP entry point a browser on localhost reaches, which covers a
+Two kinds of hostname are served. Everything simulated Route53 resolves is answered over the same
+in-process HTTP entry point a browser on localhost reaches. That covers a
 [Cognito user pool domain](../cognito/ "Simulated Cognito usage docs") in both of its forms
 (`<prefix>.auth.<region>.amazoncognito.com` and a custom domain such as `auth.example.com`), an
 [API Gateway HTTP API](../apigatewayv2/ "Simulated API Gateway usage docs"), a
 [load balancer](../elbv2/ "Simulated ELBv2 usage docs") and anything a hosted-zone record points at
 one of those.
+
+The AWS service API endpoints are the other kind, and a request to one is read for what it carries.
+A serialized Command goes to the simulated operation it names (the section above). A request
+carrying no operation header and no signature is an ordinary HTTP request, and the endpoint serves
+it the way the local hostname does. That is how a pool's JWKS is read at
+`cognito-idp.<region>.amazonaws.com` by a client holding no credentials.
 
 A hostname the simulation serves nothing at goes where it was addressed. A handler calling a
 payment API or a webhook reaches the network as it always did.
@@ -507,6 +512,78 @@ makes while it is being imported going to the network.
 
 A response comes back from the simulation as it was answered. A redirect arrives as the `302` it
 is, where the host `fetch` would have followed it.
+
+### Verifying a Cognito token in a handler
+
+An API that takes a bearer token verifies it against the keys the pool publishes.
+`CognitoJwtVerifier` from `aws-jwt-verify` builds the JWKS URL from the pool id
+(`https://cognito-idp.<region>.amazonaws.com/<userPoolId>/.well-known/jwks.json`) and accepts no
+other, and fetches it with `node:https` the first time it verifies anything. Both of those are the
+simulation's to answer inside a handler, so the verifier in the deployed code verifies a simulated
+pool's token with no cache primed and no setup around it:
+
+```typescript sim-lambda-verify-cognito-token
+/**
+ * A simulated Lambda verifying a Cognito access token, with a verifier that
+ * goes and fetches the pool's JWKS for itself.
+ */
+
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import { CognitoJwtVerifier } from "aws-jwt-verify";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+// The pool the API trusts, the app client its tokens are issued to, and the
+// token a caller presented.
+declare const userPoolId: string;
+declare const clientId: string;
+declare const accessToken: string;
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "api",
+    Role: "arn:aws:iam::111111111111:role/ApiRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput(async (event: { token: string }) => {
+        const verifier = CognitoJwtVerifier.create({
+          userPoolId,
+          tokenUse: "access",
+          clientId,
+        });
+
+        return await verifier.verify(event.token);
+      }),
+    },
+  }),
+);
+
+const output = await simAws.lambda().invoke(
+  new InvokeCommand({
+    FunctionName: "api",
+    Payload: JSON.stringify({ token: accessToken }),
+  }),
+);
+
+if (output.Payload === undefined) throw new Error("No invoke Payload");
+
+// The claims of the access token, read by the verifier the API ships with.
+console.log(Buffer.from(output.Payload).toString());
+
+await simAws.backgroundTasksComplete();
+```
+
+The pool's OpenID configuration is served at the same endpoint, at
+`/<userPoolId>/.well-known/openid-configuration`. Its `issuer` and `jwks_uri` name the local
+hostname the simulation answered on, and a handler that discovered the document can fetch the keys
+it points at. See
+[serving a pool's JWKS](../cognito/#serving-a-pools-jwks-on-localhost "Simulated Cognito usage docs").
+
+A Command the same function sends still reaches simulated Cognito. An SDK bundled into the
+deployment package addresses `cognito-idp.<region>.amazonaws.com` as well, and its requests carry
+the operation header that says so.
 
 ## Invocation types
 
@@ -2316,7 +2393,8 @@ Sim Lambda currently supports:
 - Runtime-provided `@aws-sdk/*` packages inside function code, routed into the owning simulated AWS
   environment
 - `fetch`, `node:http` and `node:https` requests from function code, answered by the simulation for
-  every hostname it serves, including a Cognito user pool domain's OAuth endpoints
+  every hostname it serves, including a Cognito user pool domain's OAuth endpoints and the JWKS a
+  token verifier fetches from the regional Cognito endpoint
 - Execution roles, evaluated against simulated IAM
 - IAM authorization of the Lambda commands themselves (`lambda:CreateFunction`,
   `lambda:GetFunction`, `lambda:InvokeFunction`, and the Function URL config actions)
@@ -2385,6 +2463,9 @@ Current documented limitations:
   issues for one resource, a Lambda Function URL and an API Gateway HTTP API, resolve under the
   hostnames the simulator serves them on. A request to the AWS form of one of those reaches the
   network.
+- An unsigned request to a service API endpoint is served over HTTP when the simulation serves that
+  endpoint, which today means Cognito's regional endpoint and the S3 endpoints. Anywhere else it is
+  read as a Command and refused as one.
 - `Timeout` is recorded and never interrupts handler execution.
 - Timers inside a handler are host timers. `setTimeout` waits in real time, and advancing the
   simulation's clock leaves a sleeping handler asleep.

--- a/docs/services/lambda/sim-lambda-verify-cognito-token.example.ts
+++ b/docs/services/lambda/sim-lambda-verify-cognito-token.example.ts
@@ -1,0 +1,50 @@
+/**
+ * A simulated Lambda verifying a Cognito access token, with a verifier that
+ * goes and fetches the pool's JWKS for itself.
+ */
+
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import { CognitoJwtVerifier } from "aws-jwt-verify";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+// The pool the API trusts, the app client its tokens are issued to, and the
+// token a caller presented.
+declare const userPoolId: string;
+declare const clientId: string;
+declare const accessToken: string;
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "api",
+    Role: "arn:aws:iam::111111111111:role/ApiRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput(async (event: { token: string }) => {
+        const verifier = CognitoJwtVerifier.create({
+          userPoolId,
+          tokenUse: "access",
+          clientId,
+        });
+
+        return await verifier.verify(event.token);
+      }),
+    },
+  }),
+);
+
+const output = await simAws.lambda().invoke(
+  new InvokeCommand({
+    FunctionName: "api",
+    Payload: JSON.stringify({ token: accessToken }),
+  }),
+);
+
+if (output.Payload === undefined) throw new Error("No invoke Payload");
+
+// The claims of the access token, read by the verifier the API ships with.
+console.log(Buffer.from(output.Payload).toString());
+
+await simAws.backgroundTasksComplete();

--- a/src/sdk/wire/sim-sdk-wire-operation.ts
+++ b/src/sdk/wire/sim-sdk-wire-operation.ts
@@ -39,6 +39,16 @@ const jsonProtocolServiceIds: ReadonlyMap<string, string> = new Map([
 ]);
 
 /**
+ * The part of a wire request the two readers below need.
+ *
+ * An AWS API request says which operation it is and what it was signed for in
+ * its headers, so neither question needs the body. That leaves both of them
+ * answerable for a request whose body has not been read, which is what a
+ * client holding an outgoing request has.
+ */
+type SimSdkWireRequestHeaders = Pick<SimSdkWireRequest, "headers">;
+
+/**
  * Which simulated service operation a wire request is asking for.
  */
 export interface SimSdkWireOperation {
@@ -56,7 +66,7 @@ export interface SimSdkWireOperation {
  * neither can be answered from the simulation.
  */
 export function readSimSdkWireOperation(
-  request: SimSdkWireRequest,
+  request: SimSdkWireRequestHeaders,
 ): SimSdkWireOperation | undefined {
   // oxlint-disable-next-line security/detect-object-injection -- this module's own fixed header name.
   const target = request.headers[operationHeaderName];
@@ -97,7 +107,7 @@ export interface SimSdkWireCredentialScope {
  * an unsupported request can still say which service it was for.
  */
 export function readSimSdkWireCredentialScope(
-  request: SimSdkWireRequest,
+  request: SimSdkWireRequestHeaders,
 ): SimSdkWireCredentialScope | undefined {
   const authorization = request.headers["authorization"];
   const credential = /Credential=[^/]*\/(?<scope>[^,\s]+)/.exec(

--- a/src/service/cognito/README.md
+++ b/src/service/cognito/README.md
@@ -440,6 +440,11 @@ serving layer dispatches to, `SimCognitoOpenIdConfiguration` builds the discover
 `SimCognitoEndpointResponse` builds the responses. The Cognito API itself is not served: an SDK
 client reaches the simulator through `SimSdk`.
 
+The same two documents answer a simulated Lambda that asks for them at
+`cognito-idp.<region>.amazonaws.com`, which is the URL `CognitoJwtVerifier` builds from a pool id.
+Sim Lambda's outbound HTTP rewrites that endpoint to the local hostname and routes the request here
+(see `src/service/lambda/README.md`).
+
 `serve/page/` under it is the managed login pages. `SimCognitoPageMarkup` is the HTML they are built
 from, `SimCognitoPageForm` is one request read as the form it fetched or posted, and
 `SimCognitoManagedLogin` is what `SimCognitoDomainEndpoints` hands a page request to. The three

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -288,9 +288,18 @@ gives its functions, and it answers for two kinds of hostname. A hostname simula
 resolves goes through `SimAwsHttp`, the same in-process entry point a request arriving on localhost
 takes, which is what makes a Cognito user pool domain, an HTTP API and a load balancer all reachable
 without Lambda knowing which of them it is. An AWS service API endpoint goes to
-`SimSdkWireDispatcher` (`SimLambdaAwsApiOutbound`), because that request carries a serialized
+`SimSdkWireDispatcher` (`SimLambdaAwsApiOutbound`) for the requests that carry a serialized
 Command. Resolution is asked first, since a load balancer's own `.elb.amazonaws.com` name ends in a
 service API suffix while naming something served over HTTP.
+
+A service API endpoint also serves documents over plain HTTP, and a user pool's JWKS is the one a
+handler asks for. `isSimAwsApiRequest` is the test that separates the two, on the operation header
+of the AWS JSON protocol and the SigV4 credential scope, since a client fetching a published
+document carries neither. What is left goes to `SimAwsHttp` under the local hostname
+`SimAwsLocalUrl` rewrites the endpoint to, which is the name simulated Route53 knows it by. An
+endpoint nothing resolves for falls back to the wire dispatcher. A request that cannot be routed is
+then refused with `SimSdkUnbridgedWireRequestError`, in place of a 501 naming a local hostname
+nobody asked for.
 
 The factory is a module of its own for the reason `makeSimCfCustomOriginDispatcher` is: `SimAwsHttp`
 reaches every simulated service, and the service that reaches it back is wired from

--- a/src/service/lambda/function/outbound/sim-lambda-aws-api-outbound.iso.test.ts
+++ b/src/service/lambda/function/outbound/sim-lambda-aws-api-outbound.iso.test.ts
@@ -9,9 +9,22 @@ import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
 import {
+  isSimAwsApiRequest,
   isSimAwsEndpointHostname,
   SimLambdaAwsApiOutbound,
 } from "./sim-lambda-aws-api-outbound.js";
+
+/**
+ * The credential scope of a request signed for a service, as the Authorization
+ * header carries it.
+ */
+function signedFor(signingName: string): string {
+  return (
+    `AWS4-HMAC-SHA256 Credential=ASIAEXAMPLE/20260818/eu-west-2/` +
+    `${signingName}/aws4_request, SignedHeaders=host;x-amz-date, ` +
+    "Signature=0000000000000000000000000000000000000000000000000000000000000000"
+  );
+}
 
 /**
  * A simulated table holding one order.
@@ -63,6 +76,37 @@ describe("The AWS service API a sim Lambda's requests reach", () => {
     assertFalse(
       isSimAwsEndpointHostname("abc123.execute-api.eu-west-2.amazonaws.com"),
     );
+  });
+
+  it("tells an API call apart from a document published at the same endpoint", () => {
+    // Given a serialized Command, which says which operation it is.
+    const command = new Request(
+      "https://cognito-idp.eu-west-2.amazonaws.com/",
+      {
+        method: "POST",
+        headers: {
+          "x-amz-target": "AWSCognitoIdentityProviderService.GetUser",
+        },
+      },
+    );
+
+    // And a signed request naming an operation nowhere, since only an SDK
+    // holds credentials to sign with.
+    const signed = new Request(
+      "https://data.s3.eu-west-2.amazonaws.com/greeting.txt",
+      { headers: { authorization: signedFor("s3") } },
+    );
+
+    // And a JWKS fetch, which a token verifier makes holding neither.
+    const published = new Request(
+      "https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_aBcDeFgHi/.well-known/jwks.json",
+    );
+
+    // Then the two an SDK sent are API calls and the published document is
+    // not.
+    assertTrue(isSimAwsApiRequest(command));
+    assertTrue(isSimAwsApiRequest(signed));
+    assertFalse(isSimAwsApiRequest(published));
   });
 
   it("answers a Command an SDK addressed to a service endpoint", async () => {

--- a/src/service/lambda/function/outbound/sim-lambda-aws-api-outbound.ts
+++ b/src/service/lambda/function/outbound/sim-lambda-aws-api-outbound.ts
@@ -1,4 +1,8 @@
 import { SimSdkWireDispatcher } from "../../../../sdk/wire/sim-sdk-wire-dispatcher.js";
+import {
+  readSimSdkWireCredentialScope,
+  readSimSdkWireOperation,
+} from "../../../../sdk/wire/sim-sdk-wire-operation.js";
 import type { AwsRegionName } from "../../../aws/sim-aws-region.js";
 import type { SimAws } from "../../../aws/sim-aws.js";
 import type { SimLambdaOutboundHttp } from "./sim-lambda-outbound-http.js";
@@ -46,6 +50,26 @@ export function isSimAwsEndpointHostname(hostname: string): boolean {
   }
 
   return awsEndpointSuffixes.some((suffix) => name.endsWith(suffix));
+}
+
+/**
+ * Whether a request to an AWS service API endpoint is an API call, or an
+ * ordinary HTTP request to the same hostname.
+ *
+ * A service API endpoint answers both. What an SDK sends carries the operation
+ * header of the AWS JSON protocol, or the SigV4 credentials it was signed
+ * with, or both, and the wire dispatcher answers it. A token verifier fetching
+ * from the same hostname carries neither, because it holds nothing to sign
+ * with. A user pool publishes its JWKS and its OpenID configuration to whoever
+ * asks, and both are read over plain HTTP.
+ */
+export function isSimAwsApiRequest(request: Request): boolean {
+  const wireRequest = { headers: Object.fromEntries(request.headers) };
+
+  return (
+    readSimSdkWireOperation(wireRequest) !== undefined ||
+    readSimSdkWireCredentialScope(wireRequest) !== undefined
+  );
 }
 
 interface SimLambdaAwsApiOutboundProperties {

--- a/src/service/lambda/function/outbound/sim-lambda-jwks-verify.iso.test.ts
+++ b/src/service/lambda/function/outbound/sim-lambda-jwks-verify.iso.test.ts
@@ -1,0 +1,258 @@
+import https from "node:https";
+import {
+  CognitoIdentityProviderClient,
+  GetUserCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertObjectEquals,
+  assertUndefined,
+} from "@kensio/smartass";
+import { CognitoJwtVerifier } from "aws-jwt-verify";
+import { describe, it } from "vitest";
+
+import {
+  simCognitoSignedIn,
+  type SimCognitoSignedInSetUp,
+} from "../../../../../test/cognito/signed-in-fixture.js";
+import type { SimLambdaHandler } from "../sim-lambda-handler.type.js";
+
+/**
+ * The template an API declares its request-handling function by.
+ *
+ * The execution role is in the simulation's default Account, which is where
+ * the pool is, so an SDK Command the function sends reaches that pool. The
+ * function declares a variable of its own because an in-process handler is
+ * given the runtime environment only when it declares one, and an SDK bundled
+ * into function code reads its Region and its credentials from there.
+ */
+const apiFunctionTemplate = {
+  Resources: {
+    ApiFunction: {
+      Type: "AWS::Lambda::Function",
+      Properties: {
+        FunctionName: "api",
+        Role: "arn:aws:iam::888888888888:role/ApiRole",
+        Handler: "index.handler",
+        Runtime: "nodejs22.x",
+        Code: { ZipFile: "exports.handler = async () => 'api';" },
+        Environment: { Variables: { APP_NAME: "myapp" } },
+      },
+    },
+  },
+};
+
+/**
+ * What the handlers here answer a request with, which is what the function
+ * read at the endpoint it asked.
+ */
+interface FetchedDocument {
+  readonly status: number;
+  readonly body: unknown;
+}
+
+/**
+ * The event the handlers are invoked with.
+ */
+interface VerifyEvent {
+  readonly url?: string;
+  readonly userPoolId?: string;
+  readonly clientId?: string;
+  readonly accessToken?: string;
+}
+
+/**
+ * The regional Cognito endpoint a pool's public documents are published at,
+ * which is the hostname a handler names and the only one a verifier builds.
+ */
+function regionalEndpointUrl(userPoolId: string, document: string): string {
+  return `https://cognito-idp.eu-west-2.amazonaws.com/${userPoolId}/.well-known/${document}`;
+}
+
+/**
+ * A handler that reads a published document with `fetch`, as a Node.js handler
+ * doing this is written today.
+ */
+const fetchingHandler: SimLambdaHandler = async (
+  event: VerifyEvent,
+): Promise<FetchedDocument> => {
+  const response = await fetch(String(event.url));
+
+  return { status: response.status, body: await response.json() };
+};
+
+/**
+ * A handler that reads the same document through `node:https`, which is the
+ * client `aws-jwt-verify` fetches a JWKS with.
+ */
+const httpsHandler: SimLambdaHandler = async (
+  event: VerifyEvent,
+): Promise<FetchedDocument> =>
+  await new Promise((resolve, reject) => {
+    const request = https.request(String(event.url), (response) => {
+      const chunks: Buffer[] = [];
+
+      response.on("data", (chunk: Buffer) => {
+        chunks.push(chunk);
+      });
+      response.on("end", () => {
+        resolve({
+          status: response.statusCode ?? 0,
+          body: JSON.parse(Buffer.concat(chunks).toString()) as unknown,
+        });
+      });
+    });
+
+    request.on("error", reject);
+    request.end();
+  });
+
+/**
+ * Deploy the function with a handler bound to it.
+ */
+async function deployApi(
+  setUp: SimCognitoSignedInSetUp,
+  handler: SimLambdaHandler,
+): Promise<void> {
+  const stack = await setUp.simAws.cloudFormation().deployTemplate({
+    stackName: "api-stack",
+    template: apiFunctionTemplate,
+    bindings: [{ functionName: "api", handler }],
+  });
+
+  await stack.waitForDeployComplete();
+}
+
+/**
+ * Invoke the deployed function and read what it answered with.
+ */
+async function invokedWith(
+  setUp: SimCognitoSignedInSetUp,
+  event: VerifyEvent,
+): Promise<unknown> {
+  const output = await setUp.simAws.lambda().invoke(
+    new InvokeCommand({
+      FunctionName: "api",
+      Payload: JSON.stringify(event),
+    }),
+  );
+
+  assertUndefined(output.FunctionError);
+  assertNonNullable(output.Payload);
+
+  const answer = JSON.parse(Buffer.from(output.Payload).toString()) as unknown;
+
+  await setUp.simAws.backgroundTasksComplete();
+
+  return answer;
+}
+
+describe("A sim Lambda verifying a Cognito token", () => {
+  it("fetches the pool's JWKS from the regional endpoint", async () => {
+    // Given a pool with a signed-in user, and a function that fetches keys.
+    const setUp = await simCognitoSignedIn();
+    await deployApi(setUp, fetchingHandler);
+
+    // When the handler asks for the pool's JWKS where real Cognito publishes
+    // it, which is the only URL a verifier built from a pool id will ask.
+    const read = (await invokedWith(setUp, {
+      url: regionalEndpointUrl(setUp.userPoolId, "jwks.json"),
+    })) as FetchedDocument;
+
+    // Then the simulated pool answered with the keys it signs its tokens with.
+    assertIdentical(read.status, 200);
+    assertObjectEquals(
+      read.body,
+      setUp.cognito.userPool(setUp.userPoolId).jwks(),
+    );
+  });
+
+  it("fetches the same JWKS through node:https", async () => {
+    // Given the same pool, and a handler written without the Fetch API.
+    const setUp = await simCognitoSignedIn();
+    await deployApi(setUp, httpsHandler);
+
+    // When it reads the JWKS.
+    const read = (await invokedWith(setUp, {
+      url: regionalEndpointUrl(setUp.userPoolId, "jwks.json"),
+    })) as FetchedDocument;
+
+    // Then the same document is served whichever client asked for it.
+    assertIdentical(read.status, 200);
+    assertObjectEquals(
+      read.body,
+      setUp.cognito.userPool(setUp.userPoolId).jwks(),
+    );
+  });
+
+  it("fetches the pool's OpenID configuration", async () => {
+    // Given the same pool and a function that fetches documents.
+    const setUp = await simCognitoSignedIn();
+    await deployApi(setUp, fetchingHandler);
+
+    // When the handler asks for the discovery document.
+    const read = (await invokedWith(setUp, {
+      url: regionalEndpointUrl(setUp.userPoolId, "openid-configuration"),
+    })) as FetchedDocument;
+    const { jwks_uri: jwksUri } = read.body as { jwks_uri: string };
+
+    // Then the JWKS URI it advertises is one the same handler can go on to
+    // fetch, which is the whole point of discovering it.
+    assertIdentical(read.status, 200);
+    const discovered = (await invokedWith(setUp, {
+      url: jwksUri,
+    })) as FetchedDocument;
+    assertIdentical(discovered.status, 200);
+  });
+
+  it("verifies a token with a verifier that fetches its own keys", async () => {
+    // Given a function verifying tokens the way an application does, with a
+    // verifier configured with nothing but the pool and the client it trusts.
+    const setUp = await simCognitoSignedIn();
+    await deployApi(setUp, async (event: VerifyEvent): Promise<unknown> => {
+      const verifier = CognitoJwtVerifier.create({
+        userPoolId: String(event.userPoolId),
+        tokenUse: "access",
+        clientId: String(event.clientId),
+      });
+
+      return await verifier.verify(String(event.accessToken));
+    });
+
+    // When it verifies the access token the user signed in with.
+    const payload = (await invokedWith(setUp, {
+      userPoolId: setUp.userPoolId,
+      clientId: setUp.clientId,
+      accessToken: setUp.accessToken,
+    })) as { username: string };
+
+    // Then the verifier fetched the pool's keys for itself and the token
+    // verified against them, with nothing handed to it by the test.
+    assertIdentical(payload.username, "alice");
+  });
+
+  it("still reaches simulated Cognito for a Command the same function sends", async () => {
+    // Given a function that also calls the Cognito API, with an SDK client of
+    // its own rather than one the simulator intercepted.
+    const setUp = await simCognitoSignedIn();
+    await deployApi(setUp, async (event: VerifyEvent): Promise<unknown> => {
+      const cognito = new CognitoIdentityProviderClient({});
+      const output = await cognito.send(
+        new GetUserCommand({ AccessToken: String(event.accessToken) }),
+      );
+
+      return { username: output.Username };
+    });
+
+    // When it reads the user the token belongs to.
+    const user = (await invokedWith(setUp, {
+      accessToken: setUp.accessToken,
+    })) as { username: string };
+
+    // Then that Command reached the simulated pool, at the hostname the
+    // documents above are served from.
+    assertIdentical(user.username, "alice");
+  });
+});

--- a/src/service/lambda/function/outbound/sim-lambda-outbound-http.factory.ts
+++ b/src/service/lambda/function/outbound/sim-lambda-outbound-http.factory.ts
@@ -1,8 +1,32 @@
 import { SimAwsHttp } from "../../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../../serve/http/url/sim-aws-local-url.js";
 import type { AwsRegionName } from "../../../aws/sim-aws-region.js";
 import type { SimAws } from "../../../aws/sim-aws.js";
-import { SimLambdaAwsApiOutbound } from "./sim-lambda-aws-api-outbound.js";
+import {
+  isSimAwsApiRequest,
+  SimLambdaAwsApiOutbound,
+} from "./sim-lambda-aws-api-outbound.js";
 import type { SimLambdaOutboundHttp } from "./sim-lambda-outbound-http.js";
+
+/**
+ * Ask for a request at a URL, which is the request itself where that is where
+ * it was already addressed.
+ *
+ * The body is read here because a request being asked for somewhere else has
+ * to be built again, and there is nothing streaming through this: what arrives
+ * is a request a client has finished writing.
+ */
+async function requestAt(url: URL, request: Request): Promise<Request> {
+  if (url.href === request.url) {
+    return request;
+  }
+
+  return new Request(url, {
+    method: request.method,
+    headers: request.headers,
+    body: request.body === null ? null : await request.arrayBuffer(),
+  });
+}
 
 interface SimLambdaOutboundHttpProperties {
   readonly simAws: SimAws;
@@ -19,8 +43,12 @@ interface SimLambdaOutboundHttpProperties {
  * load balancer without knowing which of them it is, exactly as it answers a
  * browser.
  *
- * An AWS service API endpoint is answered as a Command, because that is what
- * one carries. That comes second because a resolved hostname is the more
+ * An AWS service API endpoint is answered as a Command when it carries one,
+ * and over HTTP when it does not. A user pool's JWKS is published at the
+ * regional Cognito endpoint and fetched by a verifier holding no credentials,
+ * so a hostname alone does not say which of the two a request is.
+ *
+ * A resolved hostname is answered before either, because it is the more
  * specific answer. A load balancer's own `.elb.amazonaws.com` name and a
  * custom domain below an AWS one both end in a service API suffix, and both
  * name something the simulation is serving over HTTP.
@@ -47,15 +75,45 @@ class SimAwsLambdaOutboundHttp implements SimLambdaOutboundHttp {
    * Answer a request from the simulation.
    */
   async fetch(request: Request): Promise<Response> {
-    const { hostname } = new URL(request.url);
+    const served = this.servedUrl(request);
 
-    if (!this.resolves(hostname)) {
+    if (served === undefined) {
       return await this.awsApi.fetch(request);
     }
 
     this.http ??= new SimAwsHttp({ simAws: this.simAws });
 
-    return await this.http.handleRequest(request);
+    return await this.http.handleRequest(await requestAt(served, request));
+  }
+
+  /**
+   * Where the simulation serves a request over HTTP, or nothing for one it
+   * answers as a Command.
+   *
+   * A hostname simulated Route53 resolves is served as it was asked for. An
+   * AWS service API endpoint is served at the local hostname it rewrites to,
+   * since that is the name simulated Route53 knows the endpoint by, and only
+   * for a request that is not an API call.
+   *
+   * Everything else is the wire dispatcher's, including an endpoint the
+   * simulation serves nothing at, so that a request it cannot route is refused
+   * with the explanation that dispatcher gives rather than with a 501 naming a
+   * hostname nobody asked for.
+   */
+  private servedUrl(request: Request): URL | undefined {
+    const url = new URL(request.url);
+
+    if (this.resolves(url.hostname)) {
+      return url;
+    }
+
+    if (isSimAwsApiRequest(request)) {
+      return undefined;
+    }
+
+    const localUrl = new SimAwsLocalUrl({ input: url }).toURL();
+
+    return this.resolves(localUrl.hostname) ? localUrl : undefined;
   }
 
   /**

--- a/src/service/lambda/function/outbound/sim-lambda-outbound-http.iso.test.ts
+++ b/src/service/lambda/function/outbound/sim-lambda-outbound-http.iso.test.ts
@@ -1,4 +1,10 @@
-import { assertFalse, assertIdentical, assertTrue } from "@kensio/smartass";
+import {
+  assertFalse,
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
 import { describe, it } from "vitest";
 
 import { simCognitoHosted } from "../../../../../test/cognito/federation-fixture.js";
@@ -49,6 +55,65 @@ describe("What a simulated environment answers its functions for", () => {
       ((await response.json()) as { error: string }).error,
       "invalid_client",
     );
+  });
+
+  it("serves a document an AWS service API endpoint publishes", async () => {
+    // Given a simulation with a user pool.
+    const setUp = await simCognitoHosted();
+    const outbound = makeSimLambdaOutboundHttp({ simAws: setUp.simAws });
+
+    // When a request arrives for the pool's JWKS at the regional Cognito
+    // endpoint, carrying no Command and nothing to sign it with.
+    const response = await outbound.fetch(
+      new Request(
+        `https://cognito-idp.eu-west-2.amazonaws.com/${setUp.userPoolId}/.well-known/jwks.json`,
+      ),
+    );
+
+    // Then the pool published it, as it publishes it to a browser.
+    assertIdentical(response.status, 200);
+  });
+
+  it("leaves a signed request to a service endpoint to be routed as a Command", async () => {
+    // Given a simulation, and a signed request to a service whose endpoint it
+    // does serve over HTTP.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    const outbound = makeSimLambdaOutboundHttp({ simAws });
+
+    // When it arrives.
+    const error = await assertThrowsErrorAsync(async () =>
+      outbound.fetch(
+        new Request("https://data.s3.eu-west-2.amazonaws.com/greeting.txt", {
+          headers: {
+            authorization:
+              "AWS4-HMAC-SHA256 Credential=ASIAEXAMPLE/20260818/eu-west-2/" +
+              "s3/aws4_request, SignedHeaders=host, Signature=00",
+          },
+        }),
+      ),
+    );
+
+    // Then it was read as the AWS API request it is, and refused as one, so
+    // that a bundled SDK is told what to do about the protocol its requests
+    // cannot be routed back from.
+    assertStringIncludes(error.message, "request to s3");
+    assertStringIncludes(error.message, "AWS JSON protocol");
+  });
+
+  it("refuses an endpoint it serves nothing at with what a Command would say", async () => {
+    // Given a simulation, and an unsigned request to a service endpoint
+    // nothing in it answers for.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    const outbound = makeSimLambdaOutboundHttp({ simAws });
+
+    // When it arrives.
+    const error = await assertThrowsErrorAsync(async () =>
+      outbound.fetch(new Request("https://sts.eu-west-2.amazonaws.com/")),
+    );
+
+    // Then the refusal names the endpoint and says why, rather than reporting
+    // a local hostname the request never named.
+    assertStringIncludes(error.message, "sts.eu-west-2.amazonaws.com");
   });
 
   it("prefers a hostname it resolves to the AWS suffix that hostname ends with", async () => {


### PR DESCRIPTION
A simulated Lambda fetching a user pool's JWKS or its OpenID configuration at
`cognito-idp.<region>.amazonaws.com` is now answered by the simulation. That is
the URL `CognitoJwtVerifier` builds from a pool id and the only one it accepts,
and a verifier in handler code verifies a simulated token with no cache primed
and no fetcher of its own. Requests to a service API endpoint are routed by what
they carry. One with the AWS JSON protocol operation header or a SigV4 signature
goes to the wire dispatcher as before. One with neither is served over HTTP at
the local hostname the endpoint rewrites to. An endpoint the simulation serves
nothing at falls back to the dispatcher and its refusal, keeping the explanation
a bundled SDK gets for a protocol nothing can route back.

Resolves #668