### PR TITLE
feat: serve the general AWS APIs on one endpoint

### DIFF
--- a/docs/serve/README.md
+++ b/docs/serve/README.md
@@ -155,6 +155,101 @@ Which to reach for:
 Both go through the same authentication, routing and service code. A request answered one way is
 answered the same way the other.
 
+## Pointing an AWS SDK or the CLI at the simulation
+
+A served environment answers the general AWS service APIs on the same port it serves everything else. Give any AWS SDK, in any language, the server's own URL as its endpoint and it reaches the simulation.
+
+```typescript sim-serve-aws-api-endpoint
+/**
+ * Reaching simulated DynamoDB with an ordinary SDK client over a port.
+ */
+
+import {
+  CreateTableCommand,
+  DynamoDBClient,
+  PutItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  CreateAccessKeyCommand,
+  CreateUserCommand,
+  PutUserPolicyCommand,
+} from "@aws-sdk/client-iam";
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+await simAws.dynamoDb().createTable(
+  new CreateTableCommand({
+    TableName: "widgets",
+    AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+    KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+
+// A served request is authorized as whoever signed it, so the client needs
+// credentials simulated IAM issued.
+const simIam = simAws.iam();
+await simIam.createUser(new CreateUserCommand({ UserName: "Widgets" }));
+await simIam.putUserPolicy(
+  new PutUserPolicyCommand({
+    UserName: "Widgets",
+    PolicyName: "WriteWidgets",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: { Effect: "Allow", Action: "dynamodb:*", Resource: "*" },
+    }),
+  }),
+);
+const created = await simIam.createAccessKey(
+  new CreateAccessKeyCommand({ UserName: "Widgets" }),
+);
+
+const srv = await serveSimAws({ simAws, port: 8787 });
+
+const client = new DynamoDBClient({
+  region: simAws.defaultRegionName,
+  endpoint: `http://localhost:${srv.port}`,
+  credentials: {
+    accessKeyId: created.AccessKey.AccessKeyId,
+    secretAccessKey: created.AccessKey.SecretAccessKey,
+  },
+});
+
+await client.send(
+  new PutItemCommand({
+    TableName: "widgets",
+    Item: { id: { S: "w1" } },
+  }),
+);
+
+await srv.close();
+```
+
+One endpoint URL covers every service. A client sends `Host: localhost:<port>` whichever service it is talking to, which leaves no hostname to route on. Routing is on the service and Region named in the request's SigV4 credential scope, and a client cannot change either without invalidating its signature.
+
+The same URL works for anything that speaks the AWS APIs, which includes the real `aws` CLI:
+
+```bash
+export AWS_ENDPOINT_URL=http://localhost:8787
+export AWS_ACCESS_KEY_ID=<key from simulated IAM>
+export AWS_SECRET_ACCESS_KEY=<secret from simulated IAM>
+aws dynamodb put-item --table-name widgets --item '{"id":{"S":"w1"}}'
+```
+
+### Who a served request is
+
+Whoever signed it. The endpoint verifies the signature against simulated IAM and runs the operation as the principal behind the access key. An IAM policy applies exactly as it does in process, and an assumed-role session is authorized against the Role behind it.
+
+A request carrying no signature is anonymous and reaches nothing. In process an omitted caller means "whoever owns this simulation", and over a port the same default would hand administrator rights to anyone who could reach it.
+
+### Which services answer
+
+The services that speak the AWS JSON protocol: DynamoDB, DynamoDB Streams, SQS, Cognito Identity Provider, EventBridge, ECS, SSM, ACM, CloudWatch Logs, KMS, Secrets Manager and Rekognition.
+
+A request to any other service is refused with `501 Not Implemented` and a body saying why. S3 and STS are the ones worth naming, since they speak REST-XML and Query. Simulated S3 still answers its own hostname-routed endpoints, covered above, and every service is reachable in process through `SimAws` and through [SDK interception](../sdk/README.md).
+
 ## Stopping and restarting
 
 `close()` stops serving and lets go of everything Yulin was holding, leaving the process free to
@@ -658,3 +753,5 @@ it is without watch mode.
 - Simulated state is not carried across a restart. Seeding belongs in the setup script, so it runs
   again and local state stays the same as what tests and CI see.
 - The IDE run configurations for attaching a debugger to a watched process are not documented yet.
+- The served AWS service API covers the AWS JSON protocol only. A service speaking REST-XML, REST-JSON or Query (S3 and STS among them) is refused with `501 Not Implemented`, because reading one of those requests back into an operation needs that operation's schema.
+- A served AWS API request is routed by its SigV4 credential scope. An unsigned one reaches nothing, whatever endpoint URL it used.

--- a/docs/serve/sim-serve-aws-api-endpoint.example.ts
+++ b/docs/serve/sim-serve-aws-api-endpoint.example.ts
@@ -1,0 +1,65 @@
+/**
+ * Reaching simulated DynamoDB with an ordinary SDK client over a port.
+ */
+
+import {
+  CreateTableCommand,
+  DynamoDBClient,
+  PutItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  CreateAccessKeyCommand,
+  CreateUserCommand,
+  PutUserPolicyCommand,
+} from "@aws-sdk/client-iam";
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+await simAws.dynamoDb().createTable(
+  new CreateTableCommand({
+    TableName: "widgets",
+    AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+    KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+
+// A served request is authorized as whoever signed it, so the client needs
+// credentials simulated IAM issued.
+const simIam = simAws.iam();
+await simIam.createUser(new CreateUserCommand({ UserName: "Widgets" }));
+await simIam.putUserPolicy(
+  new PutUserPolicyCommand({
+    UserName: "Widgets",
+    PolicyName: "WriteWidgets",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: { Effect: "Allow", Action: "dynamodb:*", Resource: "*" },
+    }),
+  }),
+);
+const created = await simIam.createAccessKey(
+  new CreateAccessKeyCommand({ UserName: "Widgets" }),
+);
+
+const srv = await serveSimAws({ simAws, port: 8787 });
+
+const client = new DynamoDBClient({
+  region: simAws.defaultRegionName,
+  endpoint: `http://localhost:${srv.port}`,
+  credentials: {
+    accessKeyId: created.AccessKey.AccessKeyId,
+    secretAccessKey: created.AccessKey.SecretAccessKey,
+  },
+});
+
+await client.send(
+  new PutItemCommand({
+    TableName: "widgets",
+    Item: { id: { S: "w1" } },
+  }),
+);
+
+await srv.close();

--- a/src/sdk/router/sim-sdk-caller-options.ts
+++ b/src/sdk/router/sim-sdk-caller-options.ts
@@ -1,4 +1,4 @@
-import type { SimAwsPrincipal } from "../../service/aws/caller/sim-aws-caller.js";
+import type { SimAwsCaller } from "../../service/aws/caller/sim-aws-caller.js";
 import type { SimSdkCommandContext } from "./sim-sdk-command-router.type.js";
 
 /**
@@ -8,7 +8,7 @@ import type { SimSdkCommandContext } from "./sim-sdk-command-router.type.js";
  * such as SimS3RequestOptions and SimDynamoDbRequestOptions.
  */
 export interface SimSdkCallerOptions {
-  readonly caller: SimAwsPrincipal;
+  readonly caller: SimAwsCaller;
 }
 
 /**

--- a/src/sdk/router/sim-sdk-command-router.type.ts
+++ b/src/sdk/router/sim-sdk-command-router.type.ts
@@ -1,4 +1,4 @@
-import type { SimAwsPrincipal } from "../../service/aws/caller/sim-aws-caller.js";
+import type { SimAwsCaller } from "../../service/aws/caller/sim-aws-caller.js";
 
 /**
  * Minimal structural SDK Command shape as received by interception.
@@ -17,8 +17,13 @@ export interface SimSdkCommandContext {
    * Routes pass it through to the simulated service operation so IAM
    * authorization applies to the caller rather than the Account root
    * default.
+   *
+   * A caller authenticated elsewhere, such as the SigV4 signature on a served
+   * request, arrives already resolved and carries the identity whose policies
+   * apply alongside the principal the request is attributed to. An assumed-role
+   * session needs that split, because its session ARN owns no policies.
    */
-  readonly caller?: SimAwsPrincipal | undefined;
+  readonly caller?: SimAwsCaller | undefined;
 }
 
 /**

--- a/src/sdk/sim-sdk-command-dispatcher.ts
+++ b/src/sdk/sim-sdk-command-dispatcher.ts
@@ -1,5 +1,8 @@
 import { SimAwsCallerResolver } from "../service/aws/caller/sim-aws-caller-resolver.js";
-import type { SimAwsPrincipal } from "../service/aws/caller/sim-aws-caller.js";
+import type {
+  SimAwsCaller,
+  SimAwsPrincipal,
+} from "../service/aws/caller/sim-aws-caller.js";
 import { simAwsRunAsContext } from "../service/aws/caller/sim-aws-run-as-context.js";
 import type { SimAws } from "../service/aws/sim-aws.js";
 import {
@@ -28,11 +31,17 @@ export class SimSdkCommandDispatcher {
 
   /**
    * Route one intercepted SDK Command to a simulated service operation.
+   *
+   * A caller authenticated somewhere else, such as by the SigV4 signature on a
+   * served request, is passed in and takes precedence over the ambient one. It
+   * carries the identity whose policies apply alongside the principal the
+   * request is attributed to, which the ambient caller has no way to express.
    */
   async dispatch(
     command: object,
     client: unknown,
     commandNames: ReadonlySet<string> | undefined,
+    authenticatedCaller?: SimAwsCaller,
   ): Promise<unknown> {
     const commandName = command.constructor.name;
     if (commandNames !== undefined && !commandNames.has(commandName)) {
@@ -43,7 +52,7 @@ export class SimSdkCommandDispatcher {
     }
 
     const serviceId = simSdkClientServiceId(client);
-    const caller = this.ambientCaller();
+    const caller = authenticatedCaller ?? this.ambientCaller();
     const accountId = callerAccountId(caller) ?? this.simAws.defaultAccountId;
     const regionName = await simSdkClientRegionName(
       client,
@@ -84,12 +93,19 @@ export class SimSdkCommandDispatcher {
 
 /**
  * Resolve the AWS Account a caller belongs to, when it identifies one.
+ *
+ * Bare credentials name no Account without the IAM registry that would
+ * authenticate them, so they resolve to none here and the default Account
+ * applies, as it does for a Command sent with no caller at all.
  */
-function callerAccountId(
-  caller: SimAwsPrincipal | undefined,
-): string | undefined {
-  if (caller === undefined) {
+function callerAccountId(caller: SimAwsCaller | undefined): string | undefined {
+  if (caller === undefined || caller.kind === "credentials") {
     return undefined;
   }
-  return new SimAwsCallerResolver().resolve(caller, caller).accountId;
+
+  // The default principal is unreachable: a resolved caller carries its own,
+  // and a bare principal is its own.
+  const anonymous: SimAwsPrincipal = { kind: "anonymous" };
+
+  return new SimAwsCallerResolver().resolve(caller, anonymous).accountId;
 }

--- a/src/sdk/wire/sim-sdk-wire-dispatcher.ts
+++ b/src/sdk/wire/sim-sdk-wire-dispatcher.ts
@@ -1,3 +1,4 @@
+import type { SimAwsCaller } from "../../service/aws/caller/sim-aws-caller.js";
 import type { AwsRegionName } from "../../service/aws/sim-aws-region.js";
 import type { SimAws } from "../../service/aws/sim-aws.js";
 import { SimSdkCommandDispatcher } from "../sim-sdk-command-dispatcher.js";
@@ -9,7 +10,6 @@ import { readSimSdkWireInput } from "./sim-sdk-wire-json.js";
 import {
   readSimSdkWireCredentialScope,
   readSimSdkWireOperation,
-  type SimSdkWireOperation,
 } from "./sim-sdk-wire-operation.js";
 import {
   simSdkWireErrorResponse,
@@ -56,44 +56,43 @@ export class SimSdkWireDispatcher {
    * it back into the exception the calling code expects to catch. Only a
    * request that cannot be routed at all is thrown, since there is no response
    * that would mean what happened.
+   *
+   * A caller is passed when something has already authenticated the request,
+   * as a served endpoint does by verifying its signature. Without one the
+   * ambient run-as caller applies, which is what a sim Lambda's outbound call
+   * relies on.
    */
-  async dispatch(request: SimSdkWireRequest): Promise<SimSdkWireResponse> {
+  async dispatch(
+    request: SimSdkWireRequest,
+    caller?: SimAwsCaller,
+  ): Promise<SimSdkWireResponse> {
     const operation = readSimSdkWireOperation(request);
     if (operation === undefined) {
       throw simSdkUnbridgedWireRequest(request);
     }
 
+    // The operation runs in the Region it was signed for or, unsigned, the
+    // Region of the code that sent it.
+    const scope = readSimSdkWireCredentialScope(request);
     const contentType = request.headers["content-type"];
+
     try {
-      return simSdkWireOutputResponse(
-        await this.route(request, operation),
-        contentType,
+      const output = await this.dispatcher.dispatch(
+        makeSimSdkWireCommand(
+          operation.commandName,
+          readSimSdkWireInput(request.body),
+        ),
+        makeSimSdkWireClient(
+          operation.serviceId,
+          scope?.regionName ?? this.regionName,
+        ),
+        undefined,
+        caller,
       );
+
+      return simSdkWireOutputResponse(output, contentType);
     } catch (error) {
       return simSdkWireErrorResponse(error, contentType);
     }
-  }
-
-  /**
-   * Route a request to the operation it names, in the Region it was signed
-   * for or, unsigned, the Region of the code that sent it.
-   */
-  private async route(
-    request: SimSdkWireRequest,
-    operation: SimSdkWireOperation,
-  ): Promise<unknown> {
-    const scope = readSimSdkWireCredentialScope(request);
-
-    return await this.dispatcher.dispatch(
-      makeSimSdkWireCommand(
-        operation.commandName,
-        readSimSdkWireInput(request.body),
-      ),
-      makeSimSdkWireClient(
-        operation.serviceId,
-        scope?.regionName ?? this.regionName,
-      ),
-      undefined,
-    );
   }
 }

--- a/src/serve/http/api/sim-aws-api-endpoint.loc.test.ts
+++ b/src/serve/http/api/sim-aws-api-endpoint.loc.test.ts
@@ -1,0 +1,285 @@
+import {
+  CreateTableCommand,
+  DynamoDBClient,
+  GetItemCommand,
+  ListTablesCommand,
+  PutItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  CreateAccessKeyCommand,
+  CreateRoleCommand,
+  CreateUserCommand,
+  PutRolePolicyCommand,
+  PutUserPolicyCommand,
+} from "@aws-sdk/client-iam";
+import { AssumeRoleCommand } from "@aws-sdk/client-sts";
+import {
+  CreateQueueCommand,
+  ListQueuesCommand,
+  SQSClient,
+} from "@aws-sdk/client-sqs";
+import { ListBucketsCommand, S3Client } from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { afterAll, beforeAll, describe, it } from "vitest";
+
+import { SimAwsLocalServer } from "../../index.js";
+import { SimAws } from "../../../service/aws/sim-aws.js";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+
+/**
+ * The general AWS service API over a real port, driven by real SDK clients
+ * given nothing but an endpoint URL and credentials.
+ *
+ * This is the shape a non-Node client gets: no simulator import, no hostname
+ * that says which service is being addressed, and an identity that has to come
+ * from the signature.
+ */
+describe("Serving the general AWS API on one endpoint", () => {
+  const simAws = new SimAws();
+  const srv = new SimAwsLocalServer({ simAws });
+
+  let endpoint: string;
+  let credentials: { accessKeyId: string; secretAccessKey: string };
+  let readOnlyCredentials: { accessKeyId: string; secretAccessKey: string };
+
+  beforeAll(async () => {
+    await simAws.dynamoDb().createTable(
+      new CreateTableCommand({
+        TableName: "widgets",
+        AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+        KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+        BillingMode: "PAY_PER_REQUEST",
+      }),
+    );
+    await simAws
+      .sqs()
+      .createQueue(new CreateQueueCommand({ QueueName: "jobs" }));
+
+    credentials = await accessKeyFor("Spike", {
+      Effect: "Allow",
+      Action: "*",
+      Resource: "*",
+    });
+    readOnlyCredentials = await accessKeyFor("ReadOnly", {
+      Effect: "Allow",
+      Action: "dynamodb:GetItem",
+      Resource: "*",
+    });
+
+    await srv.listen();
+    endpoint = `http://localhost:${srv.port}`;
+  });
+
+  afterAll(async () => {
+    await srv.close();
+  });
+
+  async function accessKeyFor(
+    username: string,
+    statement: object,
+  ): Promise<{ accessKeyId: string; secretAccessKey: string }> {
+    const simIam = simAws.iam();
+
+    await simIam.createUser(new CreateUserCommand({ UserName: username }));
+    await simIam.putUserPolicy(
+      new PutUserPolicyCommand({
+        UserName: username,
+        PolicyName: "Spike",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: statement,
+        }),
+      }),
+    );
+
+    const created = await simIam.createAccessKey(
+      new CreateAccessKeyCommand({ UserName: username }),
+    );
+
+    return {
+      accessKeyId: created.AccessKey.AccessKeyId,
+      secretAccessKey: created.AccessKey.SecretAccessKey,
+    };
+  }
+
+  function dynamoDbClient(withCredentials = credentials): DynamoDBClient {
+    return new DynamoDBClient({
+      region: simAws.defaultRegionName,
+      endpoint,
+      credentials: withCredentials,
+    });
+  }
+
+  it("round-trips an Item for a client given only an endpoint URL", async () => {
+    // Given a real DynamoDB client pointed at the local server
+    const client = dynamoDbClient();
+
+    // When it writes and reads an Item
+    await client.send(
+      new PutItemCommand({
+        TableName: "widgets",
+        Item: { id: { S: "w1" }, name: { S: "Widget one" } },
+      }),
+    );
+    const got = await client.send(
+      new GetItemCommand({ TableName: "widgets", Key: { id: { S: "w1" } } }),
+    );
+
+    // Then it reads back what it wrote
+    assertIdentical(got.Item?.["name"]?.S, "Widget one");
+  });
+
+  it("routes two services through the same endpoint URL", async () => {
+    // Given DynamoDB and SQS clients sharing one endpoint URL
+    const dynamoDb = dynamoDbClient();
+    const sqs = new SQSClient({
+      region: simAws.defaultRegionName,
+      endpoint,
+      credentials,
+    });
+
+    // When each lists its own resources
+    const tables = await dynamoDb.send(new ListTablesCommand({}));
+    const queues = await sqs.send(new ListQueuesCommand({}));
+
+    // Then the credential scope routed each to its own simulated service
+    assertIdentical(tables.TableNames?.[0], "widgets");
+    assertStringIncludes(queues.QueueUrls?.[0] ?? "", "jobs");
+  });
+
+  it("refuses an operation the signing principal has no permission for", async () => {
+    // Given a client signing as a principal allowed only to read
+    const client = dynamoDbClient(readOnlyCredentials);
+
+    // When it attempts a write
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await client.send(
+          new PutItemCommand({
+            TableName: "widgets",
+            Item: { id: { S: "denied" } },
+          }),
+        ),
+    );
+
+    // Then simulated IAM denied it, and the SDK surfaced the AWS error
+    assertStringIncludes(error.message, "not authorized to perform");
+    assertStringIncludes(error.message, "dynamodb:PutItem");
+  });
+
+  it("authorizes an assumed-role session against the Role behind it", async () => {
+    // Given a Role allowed to write, and a session assumed into it whose own
+    // session ARN owns no policies at all
+    const accountId = simAws.defaultAccountId;
+
+    await simAws.iam().createRole(
+      new CreateRoleCommand({
+        RoleName: "Writer",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+    await simAws.iam().putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "Writer",
+        PolicyName: "WriteWidgets",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "dynamodb:PutItem",
+            Resource: "*",
+          },
+        }),
+      }),
+    );
+
+    const assumed = await simAws.sts().assumeRole(
+      new AssumeRoleCommand({
+        RoleArn: `arn:aws:iam::${accountId}:role/Writer`,
+        RoleSessionName: "served",
+      }),
+    );
+
+    const session = assumed.Credentials;
+    assertDefined(session, "assumed session credentials");
+
+    // When the session signs a write against the served endpoint
+    const client = new DynamoDBClient({
+      region: simAws.defaultRegionName,
+      endpoint,
+      credentials: {
+        accessKeyId: session.AccessKeyId ?? "",
+        secretAccessKey: session.SecretAccessKey ?? "",
+        sessionToken: session.SessionToken ?? "",
+      },
+    });
+
+    await client.send(
+      new PutItemCommand({
+        TableName: "widgets",
+        Item: { id: { S: "by-session" } },
+      }),
+    );
+
+    // Then the Role's policy allowed it, which the session ARN alone could not
+    const written = await simAws.dynamoDb().getItem(
+      new GetItemCommand({
+        TableName: "widgets",
+        Key: { id: { S: "by-session" } },
+      }),
+    );
+
+    assertIdentical(written.Item?.["id"]?.S, "by-session");
+  });
+
+  it("refuses a protocol it cannot read without asking the client to retry", async () => {
+    // Given a request signed for S3, which speaks REST-XML rather than the
+    // AWS JSON protocol this endpoint reads
+    const client = new S3Client({
+      region: simAws.defaultRegionName,
+      endpoint,
+      credentials,
+      maxAttempts: 1,
+    });
+
+    // When it asks for something only the REST-XML protocol could express
+    const error = await assertThrowsErrorAsync(
+      async () => await client.send(new ListBucketsCommand({})),
+    );
+
+    // Then it is refused as unimplemented, which an SDK does not retry, and
+    // the reason travels with the refusal
+    assertIdentical(
+      (error as { $metadata?: { httpStatusCode?: number } }).$metadata
+        ?.httpStatusCode,
+      501,
+    );
+  });
+
+  it("serves an unsigned request nothing, rather than serving it as an administrator", async () => {
+    // Given a request carrying no signature at all
+    const response = await fetch(`${endpoint}/`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-amz-json-1.0",
+        "x-amz-target": "DynamoDB_20120810.ListTables",
+      },
+      body: "{}",
+    });
+
+    // Then the endpoint declines it, because an unsigned request names no
+    // service to route to
+    assertIdentical(response.status, 501);
+  });
+});

--- a/src/serve/http/api/sim-aws-api-endpoint.ts
+++ b/src/serve/http/api/sim-aws-api-endpoint.ts
@@ -1,0 +1,111 @@
+import { SimSdkUnbridgedWireRequestError } from "../../../sdk/error/sim-sdk.error.js";
+import { SimSdkWireDispatcher } from "../../../sdk/wire/sim-sdk-wire-dispatcher.js";
+import { readSimSdkWireCredentialScope } from "../../../sdk/wire/sim-sdk-wire-operation.js";
+import type { SimSdkWireRequest } from "../../../sdk/wire/sim-sdk-wire.types.js";
+import type { SimAws } from "../../../service/aws/sim-aws.js";
+import { SimAwsReceivedRequest } from "../request/sim-aws-received-request.js";
+
+interface SimAwsApiEndpointProperties {
+  readonly simAws: SimAws;
+}
+
+/**
+ * The general AWS service API, served on one endpoint.
+ *
+ * Every other served endpoint is routed by hostname, because every other
+ * served endpoint belongs to a resource that was issued a hostname. A client
+ * given `--endpoint-url` or `AWS_ENDPOINT_URL` sends `Host: localhost:<port>`
+ * for every service, so there is no hostname to route on. What the request
+ * does carry is its SigV4 credential scope, which names the service and the
+ * Region it was signed for, and a client cannot alter either without
+ * invalidating the signature.
+ *
+ * So this endpoint routes on the credential scope. One endpoint URL then
+ * serves every simulated service, which is the shape `--endpoint-url` wants.
+ */
+export class SimAwsApiEndpoint {
+  private readonly simAws: SimAws;
+  private readonly dispatcher: SimSdkWireDispatcher;
+
+  constructor(properties: SimAwsApiEndpointProperties) {
+    this.simAws = properties.simAws;
+    this.dispatcher = new SimSdkWireDispatcher(properties.simAws);
+  }
+
+  /**
+   * Answer an AWS service API request, or decline one that is not signed.
+   *
+   * An unsigned request says nothing about which service it is for, so it is
+   * declined rather than guessed at, and the caller falls back to whatever it
+   * does for a hostname the simulation serves nothing at.
+   */
+  async handle(request: Request): Promise<Response | undefined> {
+    const received = await SimAwsReceivedRequest.receive(request);
+    const wireRequest = simAwsApiWireRequest(request, received.body);
+
+    const scope = readSimSdkWireCredentialScope(wireRequest);
+    if (scope === undefined) {
+      return undefined;
+    }
+
+    const caller = this.simAws.resolveRequestCaller(request, {
+      body: received.body,
+      expectedScope: {
+        serviceName: scope.signingName,
+        regionName: scope.regionName,
+      },
+    });
+
+    let response;
+    try {
+      response = await this.dispatcher.dispatch(wireRequest, caller.toCaller());
+    } catch (error) {
+      if (error instanceof SimSdkUnbridgedWireRequestError) {
+        return simAwsUnservedProtocolResponse(error);
+      }
+
+      throw error;
+    }
+
+    return new Response(response.body.length === 0 ? null : response.body, {
+      status: response.statusCode,
+      headers: { ...response.headers },
+    });
+  }
+}
+
+/**
+ * Refuse a request whose protocol this endpoint cannot read.
+ *
+ * `501 Not Implemented` rather than a server error, because the two differ in
+ * a way the client acts on: an SDK retries a 500 and gives up on a 501. A
+ * request this endpoint will never understand is answered once, and the reason
+ * travels in the body for whoever reads the response.
+ */
+function simAwsUnservedProtocolResponse(error: Error): Response {
+  return new Response(`${error.message}\n`, {
+    status: 501,
+    headers: { "content-type": "text/plain; charset=utf-8" },
+  });
+}
+
+/**
+ * Read a received request as the AWS API request it is on the wire.
+ *
+ * The body is passed in already buffered, because SigV4 verification needs
+ * the same bytes and a request body can only be read once.
+ */
+function simAwsApiWireRequest(
+  request: Request,
+  body: Uint8Array | undefined,
+): SimSdkWireRequest {
+  const url = new URL(request.url);
+
+  return {
+    method: request.method,
+    hostname: url.hostname,
+    path: `${url.pathname}${url.search}`,
+    headers: Object.fromEntries(request.headers),
+    body: body ?? new Uint8Array(),
+  };
+}

--- a/src/serve/http/sim-aws-http.ts
+++ b/src/serve/http/sim-aws-http.ts
@@ -2,6 +2,7 @@ import { SimAwsServiceControllerContainer } from "../controller/container/sim-aw
 import { SimAws } from "../../service/aws/sim-aws.js";
 import type { SimAwsServiceTarget } from "../controller/sim-service-controller.js";
 import { isSimAwsRequestAuthFailure } from "../../service/iam/request/error/sim-aws-request-auth.error.js";
+import { SimAwsApiEndpoint } from "./api/sim-aws-api-endpoint.js";
 import { SimAwsRequestAuthenticator } from "./request/sim-aws-request-authenticator.js";
 import { SimAwsAuthFailureResponse } from "./response/sim-aws-auth-failure-response.js";
 import { SimAwsResponseHints } from "./response/sim-aws-response-hints.js";
@@ -17,6 +18,7 @@ export class SimAwsHttp {
   private readonly simAws: SimAws;
   private readonly controllers: SimAwsServiceControllerContainer;
   private readonly authenticator: SimAwsRequestAuthenticator;
+  private readonly apiEndpoint: SimAwsApiEndpoint;
   private readonly authFailureResponse = new SimAwsAuthFailureResponse();
   private readonly hints = new SimAwsResponseHints();
 
@@ -25,6 +27,7 @@ export class SimAwsHttp {
     this.simAws = simAws;
     this.controllers = new SimAwsServiceControllerContainer({ simAws });
     this.authenticator = new SimAwsRequestAuthenticator({ simAws });
+    this.apiEndpoint = new SimAwsApiEndpoint({ simAws });
   }
 
   /**
@@ -62,6 +65,13 @@ export class SimAwsHttp {
 
       const target = this.simAws.route53().resolveHttpHost(hostname);
       if (target === undefined) {
+        // A signed AWS API request names its service in its credential scope
+        // and needs no hostname to route on.
+        const apiResponse = await this.apiEndpoint.handle(request);
+        if (apiResponse !== undefined) {
+          return apiResponse;
+        }
+
         return new Response(`Unknown simulated AWS host ${hostname} \n`, {
           status: 501,
           headers: {

--- a/src/service/sts/command/assume-role/assume-role.handler.ts
+++ b/src/service/sts/command/assume-role/assume-role.handler.ts
@@ -14,7 +14,7 @@ import { SimStsAssumeRoleSessionCreator } from "../../assume/sim-sts-assume-role
 import { SimStsAssumeRoleRequestParser } from "../../assume/sim-sts-assume-role-request-parser.js";
 import { SimAwsCallerResolver } from "../../../aws/caller/sim-aws-caller-resolver.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
-import type { SimAwsPrincipal } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import { AssumeRoleAuthorizationCoordinator } from "../../auth-z/assume-role-auth-z-coordinator.js";
 
 interface AssumeRoleCommandHandlerProperties {
@@ -71,7 +71,7 @@ export class AssumeRoleCommandHandler implements CommandHandler<
   async handle(
     command: SimAssumeRoleCommand,
     options?: {
-      caller?: SimAwsPrincipal;
+      caller?: SimAwsCaller;
     },
   ): Promise<SimAssumeRoleCommandOutput> {
     const request = this.requestParser.parse(command);

--- a/src/service/sts/sim-sts.ts
+++ b/src/service/sts/sim-sts.ts
@@ -11,7 +11,7 @@ import { AssumeRoleCommandHandler } from "./command/assume-role/assume-role.hand
 import { SimIamRegistry } from "../iam/registry/sim-iam-registry.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
-import type { SimAwsPrincipal } from "../aws/caller/sim-aws-caller.js";
+import type { SimAwsCaller } from "../aws/caller/sim-aws-caller.js";
 import { SimStsSdkCommandRouter } from "./sdk/sim-sts-sdk-command-router.js";
 import type { SimSdkCommandRouter } from "../../sdk/index.js";
 
@@ -47,7 +47,7 @@ export class SimSts {
   async assumeRole(
     command: SimAssumeRoleCommand,
     options?: {
-      caller?: SimAwsPrincipal;
+      caller?: SimAwsCaller;
     },
   ): Promise<SimAssumeRoleCommandOutput> {
     const handler = new AssumeRoleCommandHandler({


### PR DESCRIPTION
A served environment now answers the general AWS service APIs on the port it already serves everything else on. Any AWS SDK in any language, and the real `aws` CLI, reach the simulation given nothing but an endpoint URL and credentials from simulated IAM. The twelve AWS JSON protocol services answer this way, including DynamoDB, SQS, Cognito Identity Provider, EventBridge, ECS, SSM, CloudWatch Logs, KMS and Secrets Manager.

Resolves https://github.com/KensioSoftware/yulin/issues/671

## How it routes

A client sends `Host: localhost:<port>` whichever service it is addressing, which leaves no hostname to route on. A request that resolves to no simulated host is routed instead by the service and Region named in its SigV4 credential scope, and a client cannot alter either without invalidating its signature. Hostname-routed endpoints are reached first and are untouched.

## Worth a reviewer's attention

The caller is resolved through the same boundary the hostname-routed endpoints use, then passed to the dispatcher rather than set as an ambient run-as principal. That is what carries `identityPolicyPrincipal`, so an assumed-role session is authorized against the Role behind it instead of a session ARN owning no policies. `sim-aws-api-endpoint.loc.test.ts` covers it, and the test fails if the caller goes through `runAs`.

Two type widenings fall out of that. `SimSdkCommandContext.caller` and `SimSdkCallerOptions.caller` move from `SimAwsPrincipal` to `SimAwsCaller`, which pulls in simulated STS's `assumeRole` options.

A service speaking REST-XML, REST-JSON or Query is refused with `501 Not Implemented`. The status matters, since an SDK retries a 500 and gives up on a 501. `aws s3api list-buckets` previously burned four retries before reporting a server error. Reading one of those requests back into an operation needs that operation's schema, and #673 and #674 cover the work.

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a shared local HTTP endpoint for simulated AWS APIs.
  - Supports signed AWS SDK and CLI requests with SigV4 service and Region routing.
  - Added IAM authentication, authorization, and assumed-role support.
  - Unsupported protocols return `501 Not Implemented`; unsigned requests are rejected.
- **Documentation**
  - Added setup guidance, supported services, limitations, and an executable DynamoDB example.
- **Tests**
  - Added integration coverage for DynamoDB, cross-service routing, IAM denials, assumed roles, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->