### PR TITLE
feat: serve the S3 REST API on an endpoint URL

### DIFF
--- a/docs/serve/README.md
+++ b/docs/serve/README.md
@@ -246,9 +246,35 @@ A request carrying no signature is anonymous and reaches nothing. In process an 
 
 ### Which services answer
 
-The services that speak the AWS JSON protocol: DynamoDB, DynamoDB Streams, SQS, Cognito Identity Provider, EventBridge, ECS, SSM, ACM, CloudWatch Logs, KMS, Secrets Manager and Rekognition.
+S3, and the services that speak the AWS JSON protocol. Those are DynamoDB, DynamoDB Streams, SQS, Cognito Identity Provider, EventBridge, ECS, SSM, ACM, CloudWatch Logs, KMS, Secrets Manager and Rekognition.
 
-A request to any other service is refused with `501 Not Implemented` and a body saying why. S3 and STS are the ones worth naming, since they speak REST-XML and Query. Simulated S3 still answers its own hostname-routed endpoints, covered above, and every service is reachable in process through `SimAws` and through [SDK interception](../sdk/README.md).
+A request to any other service is refused with `501 Not Implemented` and a body saying why. STS is the one worth naming, since it speaks the Query protocol. Every service is reachable in process through `SimAws` and through [SDK interception](../sdk/README.md), whether or not it answers here.
+
+### S3 over the endpoint
+
+`aws s3` and an `S3Client` reach simulated S3 through the same endpoint URL:
+
+```bash
+export AWS_ENDPOINT_URL=http://localhost:8787
+aws s3api create-bucket --bucket widgets
+aws s3api put-object --bucket widgets --key one.txt --body ./one.txt
+aws s3 ls s3://widgets/
+```
+
+An SDK client needs `forcePathStyle`, because a virtual-host request puts the Bucket in the hostname and this endpoint routes on the credential scope rather than the host:
+
+```typescript
+const client = new S3Client({
+  region: "us-east-1",
+  endpoint: `http://localhost:${srv.port}`,
+  forcePathStyle: true,
+  credentials,
+});
+```
+
+The operations served are the ones simulated S3 implements: `CreateBucket`, `DeleteBucket`, `ListBuckets`, `ListObjects`, `ListObjectsV2`, `GetObject`, `PutObject`, `DeleteObject`, `DeleteObjects`, and the Bucket policy, website, Block Public Access and event notification configurations. Anything else is refused as `NotImplemented`, which an SDK raises under that name rather than leaving a client to guess.
+
+Simulated S3 also answers its own Bucket hostnames, covered above. That path is unchanged, and it is what a presigned URL and a website visitor use.
 
 ## Stopping and restarting
 
@@ -753,5 +779,7 @@ it is without watch mode.
 - Simulated state is not carried across a restart. Seeding belongs in the setup script, so it runs
   again and local state stays the same as what tests and CI see.
 - The IDE run configurations for attaching a debugger to a watched process are not documented yet.
-- The served AWS service API covers the AWS JSON protocol only. A service speaking REST-XML, REST-JSON or Query (S3 and STS among them) is refused with `501 Not Implemented`, because reading one of those requests back into an operation needs that operation's schema.
+- The served AWS service API covers S3 and the AWS JSON protocol services. A service speaking REST-JSON or Query, STS among them, is refused with `501 Not Implemented`.
+- `aws s3 ls` with no Bucket fails, because simulated S3 records no creation date for a Bucket and the CLI reads one from every entry. `aws s3api list-buckets` and `aws s3 ls s3://bucket/` both work.
+- Simulated S3 implements no `HeadObject` or `HeadBucket`, so both are refused. `aws s3 cp` reads an Object with `HeadObject` before copying it, which puts that out of reach too.
 - A served AWS API request is routed by its SigV4 credential scope. An unsigned one reaches nothing, whatever endpoint URL it used.

--- a/src/serve/http/api/sim-aws-api-endpoint.loc.test.ts
+++ b/src/serve/http/api/sim-aws-api-endpoint.loc.test.ts
@@ -18,7 +18,7 @@ import {
   ListQueuesCommand,
   SQSClient,
 } from "@aws-sdk/client-sqs";
-import { ListBucketsCommand, S3Client } from "@aws-sdk/client-s3";
+import { GetCallerIdentityCommand, STSClient } from "@aws-sdk/client-sts";
 import {
   assertIdentical,
   assertStringIncludes,
@@ -244,18 +244,18 @@ describe("Serving the general AWS API on one endpoint", () => {
   });
 
   it("refuses a protocol it cannot read without asking the client to retry", async () => {
-    // Given a request signed for S3, which speaks REST-XML rather than the
-    // AWS JSON protocol this endpoint reads
-    const client = new S3Client({
+    // Given a request signed for STS, which speaks the Query protocol rather
+    // than the AWS JSON protocol this endpoint reads
+    const client = new STSClient({
       region: simAws.defaultRegionName,
       endpoint,
       credentials,
       maxAttempts: 1,
     });
 
-    // When it asks for something only the REST-XML protocol could express
+    // When it asks for something only the Query protocol could express
     const error = await assertThrowsErrorAsync(
-      async () => await client.send(new ListBucketsCommand({})),
+      async () => await client.send(new GetCallerIdentityCommand({})),
     );
 
     // Then it is refused as unimplemented, which an SDK does not retry, and

--- a/src/serve/http/api/sim-aws-api-endpoint.ts
+++ b/src/serve/http/api/sim-aws-api-endpoint.ts
@@ -3,11 +3,17 @@ import { SimSdkWireDispatcher } from "../../../sdk/wire/sim-sdk-wire-dispatcher.
 import { readSimSdkWireCredentialScope } from "../../../sdk/wire/sim-sdk-wire-operation.js";
 import type { SimSdkWireRequest } from "../../../sdk/wire/sim-sdk-wire.types.js";
 import type { SimAws } from "../../../service/aws/sim-aws.js";
+import { SimS3ApiEndpoint } from "../../../service/s3/serve/api/sim-s3-api.js";
 import { SimAwsReceivedRequest } from "../request/sim-aws-received-request.js";
 
 interface SimAwsApiEndpointProperties {
   readonly simAws: SimAws;
 }
+
+/**
+ * The SigV4 signing name S3 requests carry.
+ */
+const s3SigningName = "s3";
 
 /**
  * The general AWS service API, served on one endpoint.
@@ -22,14 +28,21 @@ interface SimAwsApiEndpointProperties {
  *
  * So this endpoint routes on the credential scope. One endpoint URL then
  * serves every simulated service, which is the shape `--endpoint-url` wants.
+ *
+ * The scope also says which protocol to read the request with. Most simulated
+ * services speak the AWS JSON protocol and name their operation in a header.
+ * S3 speaks REST-XML and names its operation in the method and path, so it is
+ * read by an endpoint of its own.
  */
 export class SimAwsApiEndpoint {
   private readonly simAws: SimAws;
   private readonly dispatcher: SimSdkWireDispatcher;
+  private readonly s3: SimS3ApiEndpoint;
 
   constructor(properties: SimAwsApiEndpointProperties) {
     this.simAws = properties.simAws;
     this.dispatcher = new SimSdkWireDispatcher(properties.simAws);
+    this.s3 = new SimS3ApiEndpoint({ simAws: properties.simAws });
   }
 
   /**
@@ -55,6 +68,17 @@ export class SimAwsApiEndpoint {
         regionName: scope.regionName,
       },
     });
+
+    // S3 is the one served service that states its operation in the method and
+    // path rather than in a header, so it is read by its own endpoint.
+    if (scope.signingName === s3SigningName) {
+      return await this.s3.handle(
+        request,
+        received.body ?? new Uint8Array(),
+        caller.toCaller(),
+        scope.regionName,
+      );
+    }
 
     let response;
     try {

--- a/src/service/s3/serve/api/sim-s3-api-bucket-routes.ts
+++ b/src/service/s3/serve/api/sim-s3-api-bucket-routes.ts
@@ -1,0 +1,141 @@
+import { readSimS3NotificationConfiguration } from "./sim-s3-api-notification-read.js";
+import {
+  readSimS3DeleteRequest,
+  readSimS3PublicAccessBlock,
+  readSimS3WebsiteConfiguration,
+} from "./sim-s3-api-xml-read.js";
+import {
+  bucketBodyInput,
+  bucketInput,
+  listBucketsInput,
+  listObjectsInput,
+  listObjectsV2Input,
+} from "./sim-s3-api-input.js";
+import type { SimS3ApiRoute } from "./sim-s3-api-route.type.js";
+
+/**
+ * The service-level and Bucket-level S3 operations this endpoint serves.
+ *
+ * A route naming a sub-resource is matched before the plain one for the same
+ * method and path, which is the only ordering that matters here.
+ */
+export const simS3BucketApiRoutes: readonly SimS3ApiRoute[] = [
+  {
+    method: "GET",
+    target: "service",
+    commandName: "ListBucketsCommand",
+    input: listBucketsInput,
+  },
+  {
+    method: "GET",
+    target: "bucket",
+    subResource: "policy",
+    commandName: "GetBucketPolicyCommand",
+    input: bucketInput,
+  },
+  {
+    method: "GET",
+    target: "bucket",
+    subResource: "publicAccessBlock",
+    commandName: "GetPublicAccessBlockCommand",
+    input: bucketInput,
+  },
+  {
+    method: "GET",
+    target: "bucket",
+    subResource: "notification",
+    commandName: "GetBucketNotificationConfigurationCommand",
+    input: bucketInput,
+  },
+  {
+    method: "GET",
+    target: "bucket",
+    matches: (query) => query.get("list-type") === "2",
+    commandName: "ListObjectsV2Command",
+    input: (request) => listObjectsV2Input(request),
+  },
+  {
+    method: "GET",
+    target: "bucket",
+    commandName: "ListObjectsCommand",
+    input: (request) => listObjectsInput(request),
+  },
+  {
+    method: "PUT",
+    target: "bucket",
+    subResource: "policy",
+    commandName: "PutBucketPolicyCommand",
+    // A Bucket policy is a JSON document, which travels as the body itself.
+    input: (request) => bucketBodyInput(request, "Policy", (body) => body),
+  },
+  {
+    method: "PUT",
+    target: "bucket",
+    subResource: "website",
+    commandName: "PutBucketWebsiteCommand",
+    input: (request) =>
+      bucketBodyInput(
+        request,
+        "WebsiteConfiguration",
+        readSimS3WebsiteConfiguration,
+      ),
+  },
+  {
+    method: "PUT",
+    target: "bucket",
+    subResource: "publicAccessBlock",
+    commandName: "PutPublicAccessBlockCommand",
+    input: (request) =>
+      bucketBodyInput(
+        request,
+        "PublicAccessBlockConfiguration",
+        readSimS3PublicAccessBlock,
+      ),
+  },
+  {
+    method: "PUT",
+    target: "bucket",
+    subResource: "notification",
+    commandName: "PutBucketNotificationConfigurationCommand",
+    input: (request) =>
+      bucketBodyInput(
+        request,
+        "NotificationConfiguration",
+        readSimS3NotificationConfiguration,
+      ),
+  },
+  {
+    method: "PUT",
+    target: "bucket",
+    commandName: "CreateBucketCommand",
+    input: bucketInput,
+  },
+  {
+    method: "POST",
+    target: "bucket",
+    subResource: "delete",
+    commandName: "DeleteObjectsCommand",
+    input: (request) =>
+      bucketBodyInput(request, "Delete", readSimS3DeleteRequest),
+  },
+  {
+    method: "DELETE",
+    target: "bucket",
+    subResource: "policy",
+    commandName: "DeleteBucketPolicyCommand",
+    input: bucketInput,
+  },
+  {
+    method: "DELETE",
+    target: "bucket",
+    subResource: "publicAccessBlock",
+    commandName: "DeletePublicAccessBlockCommand",
+    input: bucketInput,
+  },
+  {
+    method: "DELETE",
+    target: "bucket",
+    commandName: "DeleteBucketCommand",
+    input: bucketInput,
+  },
+];

--- a/src/service/s3/serve/api/sim-s3-api-configuration-output.ts
+++ b/src/service/s3/serve/api/sim-s3-api-configuration-output.ts
@@ -1,0 +1,135 @@
+import {
+  xmlDocument,
+  xmlElement,
+  xmlValue,
+} from "../../../../util/xml/xml-writer.js";
+
+/**
+ * Writing the S3 configuration documents and the removal result.
+ *
+ * These are the responses that are neither a listing nor an Object, and each
+ * one is the XML form of a configuration a Bucket holds.
+ */
+
+/**
+ * Write a Block Public Access configuration.
+ */
+export function publicAccessBlockXml(output: Record<string, unknown>): string {
+  const configuration = (output["PublicAccessBlockConfiguration"] ??
+    {}) as Record<string, boolean | undefined>;
+
+  return xmlDocument(
+    "PublicAccessBlockConfiguration",
+    xmlValue("BlockPublicAcls", configuration["BlockPublicAcls"]) +
+      xmlValue("IgnorePublicAcls", configuration["IgnorePublicAcls"]) +
+      xmlValue("BlockPublicPolicy", configuration["BlockPublicPolicy"]) +
+      xmlValue("RestrictPublicBuckets", configuration["RestrictPublicBuckets"]),
+  );
+}
+
+interface NotificationEntry {
+  readonly Id?: string | undefined;
+  readonly Events?: readonly string[] | undefined;
+  readonly LambdaFunctionArn?: string | undefined;
+  readonly QueueArn?: string | undefined;
+  readonly TopicArn?: string | undefined;
+}
+
+/**
+ * Write an event notification configuration.
+ */
+export function notificationConfigurationXml(
+  output: Record<string, unknown>,
+): string {
+  // Each destination kind is written the same way and differs only in which
+  // ARN element it carries, so the reader for that element is what varies.
+  const kinds: readonly {
+    readonly member: string;
+    readonly element: string;
+    readonly arnName: string;
+    readonly arn: (entry: NotificationEntry) => string | undefined;
+  }[] = [
+    {
+      member: "LambdaFunctionConfigurations",
+      element: "LambdaFunctionConfiguration",
+      arnName: "LambdaFunctionArn",
+      arn: (entry) => entry.LambdaFunctionArn,
+    },
+    {
+      member: "QueueConfigurations",
+      element: "QueueConfiguration",
+      arnName: "QueueArn",
+      arn: (entry) => entry.QueueArn,
+    },
+    {
+      member: "TopicConfigurations",
+      element: "TopicConfiguration",
+      arnName: "TopicArn",
+      arn: (entry) => entry.TopicArn,
+    },
+  ];
+
+  const content = kinds
+    .map((kind) =>
+      notificationEntries(output, kind.member)
+        .map((entry) =>
+          xmlElement(
+            kind.element,
+            xmlValue("Id", entry.Id) +
+              xmlValue(kind.arnName, kind.arn(entry)) +
+              (entry.Events ?? [])
+                .map((event) => xmlValue("Event", event))
+                .join(""),
+          ),
+        )
+        .join(""),
+    )
+    .join("");
+
+  return xmlDocument("NotificationConfiguration", content);
+}
+
+/**
+ * The configurations of one destination kind an output carries.
+ */
+function notificationEntries(
+  output: Record<string, unknown>,
+  member: string,
+): readonly NotificationEntry[] {
+  // oxlint-disable-next-line security/detect-object-injection -- this module's own fixed member names.
+  const entries = output[member];
+
+  return Array.isArray(entries) ? (entries as NotificationEntry[]) : [];
+}
+
+interface DeletedObject {
+  readonly Key?: string | undefined;
+}
+
+interface DeleteError {
+  readonly Key?: string | undefined;
+  readonly Code?: string | undefined;
+  readonly Message?: string | undefined;
+}
+
+/**
+ * Write the result of a multi-Object removal.
+ */
+export function deleteResultXml(output: Record<string, unknown>): string {
+  const deleted = ((output["Deleted"] ?? []) as readonly DeletedObject[])
+    .map((object) => xmlElement("Deleted", xmlValue("Key", object.Key)))
+    .join("");
+
+  const errors = ((output["Errors"] ?? []) as readonly DeleteError[])
+    .map((error) =>
+      xmlElement(
+        "Error",
+        xmlValue("Key", error.Key) +
+          xmlValue("Code", error.Code) +
+          xmlValue("Message", error.Message),
+      ),
+    )
+    .join("");
+
+  return xmlDocument("DeleteResult", deleted + errors);
+}

--- a/src/service/s3/serve/api/sim-s3-api-input.ts
+++ b/src/service/s3/serve/api/sim-s3-api-input.ts
@@ -1,0 +1,143 @@
+import type { SimS3ApiRequest } from "./sim-s3-api-request.js";
+
+/**
+ * The input of an operation naming only a Bucket, which most of them are.
+ */
+export function bucketInput(request: SimS3ApiRequest): object {
+  return { Bucket: request.bucketName };
+}
+
+/**
+ * The input of an operation naming one Object.
+ */
+export function objectInput(request: SimS3ApiRequest): object {
+  return { Bucket: request.bucketName, Key: request.objectKey };
+}
+
+/**
+ * The input of an operation that names a Bucket and reads its body into one
+ * member, which every configuration write does.
+ */
+export function bucketBodyInput<T>(
+  request: SimS3ApiRequest,
+  member: string,
+  read: (body: string) => T,
+): object {
+  return { Bucket: request.bucketName, [member]: read(utf8(request.body)) };
+}
+
+/**
+ * The input of an upload, which carries its bytes and the headers describing
+ * them.
+ */
+export function putObjectInput(request: SimS3ApiRequest): object {
+  return {
+    Bucket: request.bucketName,
+    Key: request.objectKey,
+    Body: request.body,
+    ...optional("ContentType", request.headers.get("content-type")),
+    ...optional("CacheControl", request.headers.get("cache-control")),
+    ...optional(
+      "ContentDisposition",
+      request.headers.get("content-disposition"),
+    ),
+    ...optional("ContentEncoding", request.headers.get("content-encoding")),
+    ...optional("ContentLanguage", request.headers.get("content-language")),
+    ...simS3UserMetadata(request.headers),
+  };
+}
+
+/**
+ * Reading the members of an S3 operation input out of a request.
+ *
+ * S3 spreads an input across the query string, the headers and the body, so
+ * each of these takes the one part of a request its operation reads.
+ */
+
+/**
+ * The ListBuckets input, which pages by continuation token.
+ */
+export function listBucketsInput(request: SimS3ApiRequest): object {
+  return {
+    ...optional("Prefix", request.query.get("prefix")),
+    ...optional("ContinuationToken", request.query.get("continuation-token")),
+    ...optionalNumber("MaxBuckets", request.query.get("max-buckets")),
+  };
+}
+
+/**
+ * The ListObjectsV2 input, which pages by continuation token.
+ */
+export function listObjectsV2Input(request: SimS3ApiRequest): object {
+  return {
+    Bucket: request.bucketName,
+    ...optional("Prefix", request.query.get("prefix")),
+    ...optional("ContinuationToken", request.query.get("continuation-token")),
+    ...optional("StartAfter", request.query.get("start-after")),
+    ...optionalNumber("MaxKeys", request.query.get("max-keys")),
+  };
+}
+
+/**
+ * The first ListObjects input, which pages by marker.
+ */
+export function listObjectsInput(request: SimS3ApiRequest): object {
+  return {
+    Bucket: request.bucketName,
+    ...optional("Prefix", request.query.get("prefix")),
+    ...optional("Marker", request.query.get("marker")),
+    ...optionalNumber("MaxKeys", request.query.get("max-keys")),
+  };
+}
+
+/**
+ * The user metadata an upload carried, which S3 sends as `x-amz-meta-` headers.
+ */
+export function simS3UserMetadata(headers: Headers): {
+  Metadata?: Record<string, string>;
+} {
+  const prefix = "x-amz-meta-";
+  const metadata: Record<string, string> = {};
+
+  for (const [name, value] of headers) {
+    if (name.toLowerCase().startsWith(prefix)) {
+      metadata[name.slice(prefix.length).toLowerCase()] = value;
+    }
+  }
+
+  return Object.keys(metadata).length === 0 ? {} : { Metadata: metadata };
+}
+
+/**
+ * Include a member only when the request stated it, since an operation treats
+ * an absent member and an empty one differently.
+ */
+export function optional(
+  name: string,
+  value: string | null,
+): Record<string, string> {
+  return value === null ? {} : { [name]: value };
+}
+
+/**
+ * The numeric form of the same, dropping a value that is not a number.
+ */
+export function optionalNumber(
+  name: string,
+  value: string | null,
+): Record<string, number> {
+  if (value === null) {
+    return {};
+  }
+
+  const parsed = Number(value);
+
+  return Number.isFinite(parsed) ? { [name]: parsed } : {};
+}
+
+/**
+ * Read a request body as the text it carries.
+ */
+export function utf8(body: Uint8Array): string {
+  return Buffer.from(body).toString("utf8");
+}

--- a/src/service/s3/serve/api/sim-s3-api-listing.ts
+++ b/src/service/s3/serve/api/sim-s3-api-listing.ts
@@ -1,0 +1,108 @@
+import {
+  xmlDocument,
+  xmlElement,
+  xmlValue,
+} from "../../../../util/xml/xml-writer.js";
+
+interface ObjectSummary {
+  readonly Key?: string | undefined;
+  readonly Size?: number | undefined;
+  readonly ETag?: string | undefined;
+  readonly LastModified?: Date | undefined;
+  readonly StorageClass?: string | undefined;
+}
+
+interface ListObjectsOutput {
+  readonly Contents?: readonly ObjectSummary[] | undefined;
+  readonly Name?: string | undefined;
+  readonly Prefix?: string | undefined;
+  readonly MaxKeys?: number | undefined;
+  readonly IsTruncated?: boolean | undefined;
+  readonly KeyCount?: number | undefined;
+  readonly ContinuationToken?: string | undefined;
+  readonly NextContinuationToken?: string | undefined;
+  readonly StartAfter?: string | undefined;
+  readonly Marker?: string | undefined;
+  readonly NextMarker?: string | undefined;
+}
+
+interface ListBucketsOutput {
+  readonly Buckets?:
+    | readonly { readonly Name?: string | undefined }[]
+    | undefined;
+  readonly ContinuationToken?: string | undefined;
+  readonly Prefix?: string | undefined;
+}
+
+/**
+ * Write a bucket listing as the document real S3 answers ListBuckets with.
+ */
+export function simS3ListBucketsXml(output: ListBucketsOutput): string {
+  const buckets = (output.Buckets ?? [])
+    .map((bucket) => xmlElement("Bucket", xmlValue("Name", bucket.Name)))
+    .join("");
+
+  return xmlDocument(
+    "ListAllMyBucketsResult",
+    xmlElement("Buckets", buckets) +
+      xmlValue("Prefix", output.Prefix) +
+      xmlValue("ContinuationToken", output.ContinuationToken),
+  );
+}
+
+/**
+ * Write an Object listing as the document real S3 answers with.
+ *
+ * Both listing versions answer in a `ListBucketResult`, and differ only in how
+ * they say where the next page starts. The version is passed in because the
+ * output alone cannot say which was asked for.
+ */
+export function simS3ListObjectsXml(
+  output: ListObjectsOutput,
+  version: 1 | 2,
+): string {
+  const contents = (output.Contents ?? []).map(objectSummaryXml).join("");
+
+  return xmlDocument(
+    "ListBucketResult",
+    xmlValue("Name", output.Name) +
+      xmlValue("Prefix", output.Prefix) +
+      xmlValue("MaxKeys", output.MaxKeys) +
+      xmlValue("IsTruncated", output.IsTruncated ?? false) +
+      pagingXml(output, version) +
+      contents,
+  );
+}
+
+/**
+ * The elements that say where a page started and where the next one does.
+ */
+function pagingXml(output: ListObjectsOutput, version: 1 | 2): string {
+  if (version === 2) {
+    return (
+      xmlValue("KeyCount", output.KeyCount) +
+      xmlValue("ContinuationToken", output.ContinuationToken) +
+      xmlValue("NextContinuationToken", output.NextContinuationToken) +
+      xmlValue("StartAfter", output.StartAfter)
+    );
+  }
+
+  return (
+    xmlValue("Marker", output.Marker) +
+    xmlValue("NextMarker", output.NextMarker)
+  );
+}
+
+/**
+ * One Object in a listing.
+ */
+function objectSummaryXml(summary: ObjectSummary): string {
+  return xmlElement(
+    "Contents",
+    xmlValue("Key", summary.Key) +
+      xmlValue("LastModified", summary.LastModified) +
+      xmlValue("ETag", summary.ETag) +
+      xmlValue("Size", summary.Size) +
+      xmlValue("StorageClass", summary.StorageClass ?? "STANDARD"),
+  );
+}

--- a/src/service/s3/serve/api/sim-s3-api-notification-read.ts
+++ b/src/service/s3/serve/api/sim-s3-api-notification-read.ts
@@ -1,0 +1,77 @@
+import {
+  xmlChild,
+  xmlChildren,
+  xmlText,
+  parseXmlDocument,
+  type XmlElement,
+} from "../../../../util/xml/xml-document.js";
+
+/**
+ * Read an event notification configuration.
+ *
+ * The three destinations differ only in which ARN element they carry, so they
+ * are read the same way and told apart by that element's name.
+ */
+export function readSimS3NotificationConfiguration(body: string): object {
+  const root = parseXmlDocument(body);
+
+  return {
+    ...destinations(root, "LambdaFunctionConfiguration", "LambdaFunctionArn"),
+    ...destinations(root, "QueueConfiguration", "QueueArn"),
+    ...destinations(root, "TopicConfiguration", "TopicArn"),
+    ...defined(
+      "EventBridgeConfiguration",
+      xmlChild(root, "EventBridgeConfiguration") === undefined ? undefined : {},
+    ),
+  };
+}
+
+/**
+ * Read every notification configuration of one destination kind.
+ */
+function destinations(
+  root: XmlElement | undefined,
+  elementName: string,
+  arnName: string,
+): Record<string, object[]> {
+  const configurations = xmlChildren(root, elementName).map(
+    (configuration) => ({
+      ...defined("Id", xmlText(configuration, "Id")),
+      ...defined(arnName, xmlText(configuration, arnName)),
+      Events: xmlChildren(configuration, "Event").map((event) =>
+        event.text.trim(),
+      ),
+      ...defined("Filter", readNotificationFilter(configuration)),
+    }),
+  );
+
+  return configurations.length === 0
+    ? {}
+    : { [`${elementName}s`]: configurations };
+}
+
+/**
+ * Read the key filter a notification configuration states, if it has one.
+ */
+function readNotificationFilter(configuration: XmlElement): object | undefined {
+  const key = xmlChild(xmlChild(configuration, "Filter"), "S3Key");
+  if (key === undefined) {
+    return undefined;
+  }
+
+  return {
+    Key: {
+      FilterRules: xmlChildren(key, "FilterRule").map((rule) => ({
+        ...defined("Name", xmlText(rule, "Name")),
+        ...defined("Value", xmlText(rule, "Value")),
+      })),
+    },
+  };
+}
+
+/**
+ * Include a member only when the document stated it.
+ */
+function defined<T>(name: string, value: T | undefined): Record<string, T> {
+  return value === undefined ? {} : { [name]: value };
+}

--- a/src/service/s3/serve/api/sim-s3-api-object-routes.ts
+++ b/src/service/s3/serve/api/sim-s3-api-object-routes.ts
@@ -1,0 +1,26 @@
+import { objectInput, putObjectInput } from "./sim-s3-api-input.js";
+import type { SimS3ApiRoute } from "./sim-s3-api-route.type.js";
+
+/**
+ * The Object-level S3 operations this endpoint serves.
+ */
+export const simS3ObjectApiRoutes: readonly SimS3ApiRoute[] = [
+  {
+    method: "GET",
+    target: "object",
+    commandName: "GetObjectCommand",
+    input: objectInput,
+  },
+  {
+    method: "PUT",
+    target: "object",
+    commandName: "PutObjectCommand",
+    input: putObjectInput,
+  },
+  {
+    method: "DELETE",
+    target: "object",
+    commandName: "DeleteObjectCommand",
+    input: objectInput,
+  },
+];

--- a/src/service/s3/serve/api/sim-s3-api-output.ts
+++ b/src/service/s3/serve/api/sim-s3-api-output.ts
@@ -1,0 +1,135 @@
+import { simS3ObjectResponseHeaders } from "../../object/s3-object-response-headers.js";
+import {
+  deleteResultXml,
+  notificationConfigurationXml,
+  publicAccessBlockXml,
+} from "./sim-s3-api-configuration-output.js";
+import {
+  simS3ListBucketsXml,
+  simS3ListObjectsXml,
+} from "./sim-s3-api-listing.js";
+
+const xmlContentType = { "content-type": "application/xml" };
+
+/**
+ * Build the HTTP response an S3 operation's output is sent as.
+ *
+ * S3 answers in three different ways and which one applies is a property of
+ * the operation rather than of its output: a listing answers in XML, a read
+ * answers with the Object itself, and a write answers with a status and
+ * headers alone.
+ */
+export async function simS3ApiResponse(
+  commandName: string,
+  output: unknown,
+): Promise<Response> {
+  const value = output as Record<string, unknown>;
+
+  switch (commandName) {
+    case "ListBucketsCommand": {
+      return xml(simS3ListBucketsXml(value));
+    }
+    case "ListObjectsCommand": {
+      return xml(simS3ListObjectsXml(value, 1));
+    }
+    case "ListObjectsV2Command": {
+      return xml(simS3ListObjectsXml(value, 2));
+    }
+    case "GetObjectCommand": {
+      return await getObjectResponse(value);
+    }
+    case "GetBucketPolicyCommand": {
+      // A Bucket policy is a JSON document, and real S3 answers this one
+      // operation with the document itself rather than wrapping it in XML.
+      const policy = value["Policy"];
+
+      return new Response(typeof policy === "string" ? policy : "", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    case "GetPublicAccessBlockCommand": {
+      return xml(publicAccessBlockXml(value));
+    }
+    case "GetBucketNotificationConfigurationCommand": {
+      return xml(notificationConfigurationXml(value));
+    }
+    case "DeleteObjectsCommand": {
+      return xml(deleteResultXml(value));
+    }
+    case "PutObjectCommand": {
+      return new Response(undefined, {
+        status: 200,
+        headers: etagHeader(value["ETag"]),
+      });
+    }
+    case "CreateBucketCommand": {
+      return new Response(undefined, { status: 200 });
+    }
+    default: {
+      // The writes and removals that answer with a status and nothing else.
+      return new Response(undefined, { status: emptyStatus(commandName) });
+    }
+  }
+}
+
+/**
+ * The status an operation with no response body answers with.
+ *
+ * Real S3 answers a removal `204 No Content` and a configuration write `200`,
+ * and a client reads the difference, so the two are kept apart here.
+ */
+function emptyStatus(commandName: string): number {
+  return commandName.startsWith("Delete") ? 204 : 200;
+}
+
+/**
+ * Answer a read with the Object itself, headers and all.
+ */
+async function getObjectResponse(
+  output: Record<string, unknown>,
+): Promise<Response> {
+  const body = await objectBodyBytes(output["Body"]);
+
+  return new Response(body, {
+    status: 200,
+    headers: simS3ObjectResponseHeaders({
+      metadata: output["Metadata"] as Record<string, string> | undefined,
+      bodyLength: body.length,
+      etag: output["ETag"] as string | undefined,
+      lastModified: output["LastModified"] as Date | undefined,
+    }),
+  });
+}
+
+/**
+ * Read a GetObject body into the bytes an HTTP response carries.
+ */
+async function objectBodyBytes(body: unknown): Promise<Buffer> {
+  /* v8 ignore if -- the loader always answers with a body */
+  if (body === undefined || body === null) {
+    return Buffer.alloc(0);
+  }
+
+  const chunks: Buffer[] = [];
+
+  for await (const chunk of body as AsyncIterable<Uint8Array>) {
+    chunks.push(Buffer.from(chunk));
+  }
+
+  return Buffer.concat(chunks);
+}
+
+/**
+ * The ETag header a write answers with, when the operation produced one.
+ */
+function etagHeader(etag: unknown): Record<string, string> {
+  return typeof etag === "string" ? { etag } : {};
+}
+
+/**
+ * An XML response, which is how S3 answers everything that is not an Object.
+ */
+function xml(body: string): Response {
+  return new Response(body, { status: 200, headers: xmlContentType });
+}

--- a/src/service/s3/serve/api/sim-s3-api-request.ts
+++ b/src/service/s3/serve/api/sim-s3-api-request.ts
@@ -1,0 +1,77 @@
+/**
+ * An S3 REST request as the route table reads it.
+ *
+ * The path has already been taken apart, because which operation a request
+ * names depends on how many path segments it has: no Bucket is a service-level
+ * operation, a Bucket alone is a Bucket-level one, and a Bucket with a key is
+ * an Object operation.
+ */
+export interface SimS3ApiRequest {
+  readonly method: string;
+  /** Empty for a service-level request, such as ListBuckets. */
+  readonly bucketName: string;
+  /** Empty for a service-level or Bucket-level request. */
+  readonly objectKey: string;
+  readonly query: URLSearchParams;
+  readonly headers: Headers;
+  readonly body: Uint8Array;
+}
+
+/**
+ * Read a request that arrived at the served AWS API endpoint as an S3 request.
+ *
+ * Only path-style addressing is read here. A virtual-host request names its
+ * Bucket in the hostname, and simulated Route 53 resolves that to the Bucket's
+ * own endpoint before this endpoint is ever reached, so a request that gets
+ * this far put its Bucket in the path.
+ */
+export function readSimS3ApiRequest(
+  request: Request,
+  body: Uint8Array,
+): SimS3ApiRequest {
+  const url = new URL(request.url);
+
+  // The first segment is the Bucket and everything after it is the key, which
+  // can itself contain slashes.
+  const path = url.pathname.replace(/^\//, "");
+  const separator = path.indexOf("/");
+
+  const bucketName = separator === -1 ? path : path.slice(0, separator);
+  const objectKey = separator === -1 ? "" : path.slice(separator + 1);
+
+  return {
+    method: request.method,
+    bucketName: decodeURIComponent(bucketName),
+    objectKey: decodeSimS3ObjectKey(objectKey),
+    query: url.searchParams,
+    headers: request.headers,
+    body,
+  };
+}
+
+/**
+ * Decode an Object key from the path it was sent in.
+ *
+ * Each segment is decoded on its own, because a key containing an encoded
+ * slash names one segment of the key rather than two, and decoding the whole
+ * path at once would lose that distinction.
+ */
+function decodeSimS3ObjectKey(path: string): string {
+  return path
+    .split("/")
+    .map((segment) => decodeURIComponent(segment))
+    .join("/");
+}
+
+/**
+ * Which level of the S3 API a request addressed, taken from its path.
+ */
+export function simS3ApiRequestTarget(
+  request: SimS3ApiRequest,
+): "service" | "bucket" | "object" {
+  if (request.bucketName.length === 0) {
+    return "service";
+  }
+
+  return request.objectKey.length === 0 ? "bucket" : "object";
+}

--- a/src/service/s3/serve/api/sim-s3-api-route.type.ts
+++ b/src/service/s3/serve/api/sim-s3-api-route.type.ts
@@ -1,0 +1,26 @@
+import type { SimS3ApiRequest } from "./sim-s3-api-request.js";
+
+/**
+ * One S3 REST operation, and how to read its input out of a request.
+ *
+ * S3 states its operation in the method, the shape of the path and a
+ * sub-resource in the query string, so a route is matched on those three and
+ * nothing else. Real S3 reads a request the same way, which is why `?policy`
+ * and `?website` on the same `PUT /{Bucket}` reach different operations.
+ */
+export interface SimS3ApiRoute {
+  readonly method: string;
+  readonly target: "service" | "bucket" | "object";
+  /**
+   * The query string that picks this operation out of the others sharing its
+   * method and path. Undefined matches a request naming no sub-resource at all.
+   */
+  readonly subResource?: string | undefined;
+  /**
+   * A further condition on the query string, for the operations that share a
+   * method, a path and a sub-resource with another. Only the two listings do.
+   */
+  readonly matches?: ((query: URLSearchParams) => boolean) | undefined;
+  readonly commandName: string;
+  readonly input: (request: SimS3ApiRequest) => object;
+}

--- a/src/service/s3/serve/api/sim-s3-api-routes.iso.test.ts
+++ b/src/service/s3/serve/api/sim-s3-api-routes.iso.test.ts
@@ -1,0 +1,127 @@
+import {
+  assertIdentical,
+  assertObjectEquals,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { readSimS3ApiRequest } from "./sim-s3-api-request.js";
+import {
+  resolveSimS3ApiRoute,
+  simS3UnservedSubResource,
+} from "./sim-s3-api-routes.js";
+
+/**
+ * Which S3 operation a request names, which S3 states in the method, the path
+ * and a query-string sub-resource rather than in a header.
+ */
+describe("Resolving an S3 REST operation from a request", () => {
+  function route(method: string, path: string, body = ""): string | undefined {
+    const request = new Request(`http://localhost:1234${path}`, { method });
+
+    return resolveSimS3ApiRoute(readSimS3ApiRequest(request, Buffer.from(body)))
+      ?.commandName;
+  }
+
+  function input(method: string, path: string, body = ""): object | undefined {
+    const request = new Request(`http://localhost:1234${path}`, { method });
+    const apiRequest = readSimS3ApiRequest(request, Buffer.from(body));
+
+    return resolveSimS3ApiRoute(apiRequest)?.input(apiRequest);
+  }
+
+  it("reads the path depth as the level the request addressed", () => {
+    assertIdentical(route("GET", "/"), "ListBucketsCommand");
+    assertIdentical(route("GET", "/widgets"), "ListObjectsCommand");
+    assertIdentical(route("GET", "/widgets/one.txt"), "GetObjectCommand");
+  });
+
+  it("tells the two Object listings apart by the version asked for", () => {
+    assertIdentical(
+      route("GET", "/widgets?list-type=2"),
+      "ListObjectsV2Command",
+    );
+    assertIdentical(route("GET", "/widgets"), "ListObjectsCommand");
+  });
+
+  it("routes a sub-resource to its own operation", () => {
+    assertIdentical(route("GET", "/widgets?policy"), "GetBucketPolicyCommand");
+    assertIdentical(route("PUT", "/widgets?policy"), "PutBucketPolicyCommand");
+    assertIdentical(
+      route("DELETE", "/widgets?policy"),
+      "DeleteBucketPolicyCommand",
+    );
+    assertIdentical(route("PUT", "/widgets"), "CreateBucketCommand");
+  });
+
+  it("routes a multi-Object removal, which is the one POST", () => {
+    assertIdentical(route("POST", "/widgets?delete"), "DeleteObjectsCommand");
+  });
+
+  it("names no operation for a method S3 does not use here", () => {
+    assertUndefined(route("HEAD", "/widgets/one.txt"));
+    assertUndefined(route("PATCH", "/widgets"));
+  });
+
+  it("reads a key that contains slashes as one key", () => {
+    assertObjectEquals(input("GET", "/widgets/nested/deeper/one.txt"), {
+      Bucket: "widgets",
+      Key: "nested/deeper/one.txt",
+    });
+  });
+
+  it("decodes a key each segment at a time", () => {
+    // Given a key whose own text contains a space and an encoded slash
+    assertObjectEquals(input("GET", "/widgets/a%20b/c%2Fd"), {
+      Bucket: "widgets",
+      Key: "a b/c/d",
+    });
+  });
+
+  it("reads listing parameters out of the query string", () => {
+    assertObjectEquals(
+      input("GET", "/widgets?list-type=2&prefix=a%2F&max-keys=10"),
+      { Bucket: "widgets", Prefix: "a/", MaxKeys: 10 },
+    );
+  });
+
+  it("leaves out a listing parameter the request did not state", () => {
+    // Given a listing asking for nothing but the Bucket
+    assertObjectEquals(input("GET", "/widgets?list-type=2"), {
+      Bucket: "widgets",
+    });
+  });
+
+  it("drops a numeric parameter that is not a number", () => {
+    assertObjectEquals(input("GET", "/widgets?list-type=2&max-keys=many"), {
+      Bucket: "widgets",
+    });
+  });
+
+  function unserved(path: string): string | undefined {
+    const request = new Request(`http://localhost:1234${path}`);
+
+    return simS3UnservedSubResource(
+      readSimS3ApiRequest(request, Buffer.alloc(0)),
+    );
+  }
+
+  it("names a sub-resource it does not serve, so it can be refused", () => {
+    // Given requests naming sub-resources this endpoint has no operation for
+    assertIdentical(unserved("/widgets?acl"), "acl");
+    assertIdentical(unserved("/widgets?versioning"), "versioning");
+
+    // And the ones it does serve are not mistaken for it
+    assertUndefined(unserved("/widgets?policy"));
+  });
+
+  it("reads a parameter left empty as a value rather than a sub-resource", () => {
+    // Given the listing the CLI sends, which states an empty prefix and
+    // delimiter. Reading either as a sub-resource would refuse `aws s3 ls`.
+    assertUndefined(unserved("/widgets?list-type=2&prefix=&delimiter=%2F"));
+    assertIdentical(
+      route("GET", "/widgets?list-type=2&prefix=&delimiter=%2F"),
+      "ListObjectsV2Command",
+    );
+  });
+});

--- a/src/service/s3/serve/api/sim-s3-api-routes.ts
+++ b/src/service/s3/serve/api/sim-s3-api-routes.ts
@@ -1,0 +1,107 @@
+import { simS3BucketApiRoutes } from "./sim-s3-api-bucket-routes.js";
+import { simS3ObjectApiRoutes } from "./sim-s3-api-object-routes.js";
+import {
+  simS3ApiRequestTarget,
+  type SimS3ApiRequest,
+} from "./sim-s3-api-request.js";
+import type { SimS3ApiRoute } from "./sim-s3-api-route.type.js";
+
+/**
+ * The sub-resources these routes serve, which are the ones simulated S3
+ * implements an operation for.
+ */
+const servedSubResources: readonly string[] = [
+  "policy",
+  "website",
+  "publicAccessBlock",
+  "notification",
+  "delete",
+];
+
+/**
+ * Every sub-resource S3 defines, served here or not.
+ *
+ * A sub-resource has to be recognised by name rather than by shape. Both the
+ * SDK and the CLI write one as `?acl=`, with an equals and nothing after it,
+ * which is exactly how the CLI also writes the empty `prefix=` it sends on
+ * every listing. Nothing in the query string separates the two, so the names
+ * are listed instead of guessed at.
+ */
+const knownSubResources: ReadonlySet<string> = new Set([
+  ...servedSubResources,
+  "accelerate",
+  "acl",
+  "analytics",
+  "cors",
+  "encryption",
+  "intelligent-tiering",
+  "inventory",
+  "legal-hold",
+  "lifecycle",
+  "location",
+  "logging",
+  "metrics",
+  "object-lock",
+  "ownershipControls",
+  "policyStatus",
+  "replication",
+  "requestPayment",
+  "restore",
+  "retention",
+  "select",
+  "tagging",
+  "torrent",
+  "uploads",
+  "versioning",
+  "versions",
+]);
+
+/**
+ * The S3 operations reachable through the served AWS API endpoint, which are
+ * the ones simulated S3 implements.
+ */
+export const simS3ApiRoutes: readonly SimS3ApiRoute[] = [
+  ...simS3BucketApiRoutes,
+  ...simS3ObjectApiRoutes,
+];
+
+/**
+ * The sub-resource a request names that this endpoint does not serve.
+ *
+ * A sub-resource separates one operation from another on the same method and
+ * path, so one that is not served has to be refused rather than ignored. An
+ * ignored `?acl` on `GET /{Bucket}` is an Object listing, which is a confident
+ * wrong answer to a question about permissions.
+ */
+export function simS3UnservedSubResource(
+  request: SimS3ApiRequest,
+): string | undefined {
+  for (const name of request.query.keys()) {
+    if (knownSubResources.has(name) && !servedSubResources.includes(name)) {
+      return name;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Find the S3 operation a request names.
+ *
+ * Returns undefined for a request matching no route, which is either an
+ * operation simulated S3 has not implemented or one real S3 does not have.
+ */
+export function resolveSimS3ApiRoute(
+  request: SimS3ApiRequest,
+): SimS3ApiRoute | undefined {
+  const target = simS3ApiRequestTarget(request);
+  const named = servedSubResources.find((name) => request.query.has(name));
+
+  return simS3ApiRoutes.find(
+    (route) =>
+      route.method === request.method &&
+      route.target === target &&
+      route.subResource === named &&
+      (route.matches?.(request.query) ?? true),
+  );
+}

--- a/src/service/s3/serve/api/sim-s3-api-xml-read.ts
+++ b/src/service/s3/serve/api/sim-s3-api-xml-read.ts
@@ -1,0 +1,89 @@
+import {
+  parseXmlDocument,
+  xmlBoolean,
+  xmlChild,
+  xmlChildren,
+  xmlText,
+} from "../../../../util/xml/xml-document.js";
+
+/**
+ * Read the S3 request bodies that arrive as XML.
+ *
+ * Real S3 takes these configurations as XML documents, which is why the
+ * operations that set them are the only ones here with a body to read. An
+ * absent or unreadable member comes back undefined, and the operation itself
+ * decides whether that is a refusal.
+ */
+
+/**
+ * Read a DeleteObjects body, which names the Objects to remove.
+ */
+export function readSimS3DeleteRequest(body: string): object {
+  const root = parseXmlDocument(body);
+  const quiet = xmlBoolean(root, "Quiet");
+
+  return {
+    Objects: xmlChildren(root, "Object").map((object) => ({
+      ...defined("Key", xmlText(object, "Key")),
+    })),
+    ...defined("Quiet", quiet),
+  };
+}
+
+/**
+ * Read a Block Public Access configuration.
+ */
+export function readSimS3PublicAccessBlock(body: string): object {
+  const root = parseXmlDocument(body);
+
+  return {
+    ...defined("BlockPublicAcls", xmlBoolean(root, "BlockPublicAcls")),
+    ...defined("IgnorePublicAcls", xmlBoolean(root, "IgnorePublicAcls")),
+    ...defined("BlockPublicPolicy", xmlBoolean(root, "BlockPublicPolicy")),
+    ...defined(
+      "RestrictPublicBuckets",
+      xmlBoolean(root, "RestrictPublicBuckets"),
+    ),
+  };
+}
+
+/**
+ * Read a website configuration.
+ */
+export function readSimS3WebsiteConfiguration(body: string): object {
+  const root = parseXmlDocument(body);
+  const index = xmlChild(root, "IndexDocument");
+  const error = xmlChild(root, "ErrorDocument");
+  const redirect = xmlChild(root, "RedirectAllRequestsTo");
+
+  return {
+    ...defined(
+      "IndexDocument",
+      index === undefined
+        ? undefined
+        : { ...defined("Suffix", xmlText(index, "Suffix")) },
+    ),
+    ...defined(
+      "ErrorDocument",
+      error === undefined
+        ? undefined
+        : { ...defined("Key", xmlText(error, "Key")) },
+    ),
+    ...defined(
+      "RedirectAllRequestsTo",
+      redirect === undefined
+        ? undefined
+        : {
+            ...defined("HostName", xmlText(redirect, "HostName")),
+            ...defined("Protocol", xmlText(redirect, "Protocol")),
+          },
+    ),
+  };
+}
+
+/**
+ * Include a member only when the document stated it.
+ */
+function defined<T>(name: string, value: T | undefined): Record<string, T> {
+  return value === undefined ? {} : { [name]: value };
+}

--- a/src/service/s3/serve/api/sim-s3-api.loc.test.ts
+++ b/src/service/s3/serve/api/sim-s3-api.loc.test.ts
@@ -1,0 +1,343 @@
+import {
+  CreateAccessKeyCommand,
+  CreateUserCommand,
+  PutUserPolicyCommand,
+} from "@aws-sdk/client-iam";
+import {
+  CreateBucketCommand,
+  GetBucketPolicyCommand,
+  PutBucketPolicyCommand,
+  HeadObjectCommand,
+  DeleteObjectCommand,
+  DeleteObjectsCommand,
+  GetBucketAclCommand,
+  GetObjectCommand,
+  GetPublicAccessBlockCommand,
+  ListBucketsCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+  PutPublicAccessBlockCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { afterAll, beforeAll, describe, it } from "vitest";
+
+import { SimAwsLocalServer } from "../../../../serve/index.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+
+/**
+ * Simulated S3 reached the way a client outside the process reaches it: an
+ * endpoint URL, credentials, and no simulator in sight.
+ *
+ * S3 speaks REST-XML rather than the AWS JSON protocol the other served
+ * services speak, so what these cover is whether an operation survives the
+ * round trip through a method, a path, a query string and an XML document.
+ */
+describe("Serving the simulated S3 REST API on an endpoint URL", () => {
+  const simAws = new SimAws();
+  const srv = new SimAwsLocalServer({ simAws });
+
+  let client: S3Client;
+  let readOnlyClient: S3Client;
+
+  beforeAll(async () => {
+    await srv.listen();
+
+    client = await s3ClientFor("Writer", {
+      Effect: "Allow",
+      Action: "*",
+      Resource: "*",
+    });
+    readOnlyClient = await s3ClientFor("Reader", {
+      Effect: "Allow",
+      Action: "s3:ListBucket",
+      Resource: "*",
+    });
+  });
+
+  afterAll(async () => {
+    await srv.close();
+  });
+
+  async function s3ClientFor(
+    username: string,
+    statement: object,
+  ): Promise<S3Client> {
+    const simIam = simAws.iam();
+
+    await simIam.createUser(new CreateUserCommand({ UserName: username }));
+    await simIam.putUserPolicy(
+      new PutUserPolicyCommand({
+        UserName: username,
+        PolicyName: "Served",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: statement,
+        }),
+      }),
+    );
+    const created = await simIam.createAccessKey(
+      new CreateAccessKeyCommand({ UserName: username }),
+    );
+
+    return new S3Client({
+      region: simAws.defaultRegionName,
+      endpoint: `http://localhost:${srv.port}`,
+      forcePathStyle: true,
+      credentials: {
+        accessKeyId: created.AccessKey.AccessKeyId,
+        secretAccessKey: created.AccessKey.SecretAccessKey,
+      },
+    });
+  }
+
+  it("creates a Bucket and lists it back", async () => {
+    // Given a Bucket created through the served endpoint
+    await client.send(new CreateBucketCommand({ Bucket: "listed-bucket" }));
+
+    // When the Buckets are listed
+    const listed = await client.send(new ListBucketsCommand({}));
+
+    // Then the new Bucket is among them
+    assertDefined(listed.Buckets, "the listed Buckets");
+    assertTrue(
+      listed.Buckets.some((bucket) => bucket.Name === "listed-bucket"),
+    );
+  });
+
+  it("round-trips an Object through the endpoint", async () => {
+    // Given an Object written through the served endpoint
+    await client.send(new CreateBucketCommand({ Bucket: "round-trip" }));
+    await client.send(
+      new PutObjectCommand({
+        Bucket: "round-trip",
+        Key: "nested/one.txt",
+        Body: "hello from HTTP",
+        ContentType: "text/plain",
+      }),
+    );
+
+    // When it is read back
+    const read = await client.send(
+      new GetObjectCommand({ Bucket: "round-trip", Key: "nested/one.txt" }),
+    );
+
+    // Then the body and its content type both survived the round trip
+    assertIdentical(await read.Body?.transformToString(), "hello from HTTP");
+    assertIdentical(read.ContentType, "text/plain");
+  });
+
+  it("lists Objects with their sizes, and filters by prefix", async () => {
+    // Given a Bucket holding Objects under two prefixes
+    await client.send(new CreateBucketCommand({ Bucket: "listing" }));
+    await client.send(
+      new PutObjectCommand({ Bucket: "listing", Key: "a/one", Body: "12345" }),
+    );
+    await client.send(
+      new PutObjectCommand({ Bucket: "listing", Key: "b/two", Body: "123" }),
+    );
+
+    // When the whole Bucket is listed
+    const all = await client.send(
+      new ListObjectsV2Command({ Bucket: "listing" }),
+    );
+
+    // Then every Object came back, with the size it was written with
+    assertIdentical(all.KeyCount, 2);
+
+    assertDefined(all.Contents, "the listed Objects");
+    const [firstListed] = all.Contents;
+    assertDefined(firstListed, "the first listed Object");
+    assertIdentical(firstListed.Key, "a/one");
+    assertIdentical(firstListed.Size, 5);
+
+    // And a prefix narrows the listing to the Objects under it
+    const prefixed = await client.send(
+      new ListObjectsV2Command({ Bucket: "listing", Prefix: "b/" }),
+    );
+
+    assertDefined(prefixed.Contents, "the Objects under the prefix");
+    assertArrayLength(prefixed.Contents, 1);
+
+    const [onlyPrefixed] = prefixed.Contents;
+    assertDefined(onlyPrefixed, "the only Object under the prefix");
+    assertIdentical(onlyPrefixed.Key, "b/two");
+  });
+
+  it("removes Objects one at a time and in a batch", async () => {
+    // Given a Bucket holding two Objects
+    await client.send(new CreateBucketCommand({ Bucket: "removals" }));
+    await client.send(
+      new PutObjectCommand({ Bucket: "removals", Key: "one", Body: "1" }),
+    );
+    await client.send(
+      new PutObjectCommand({ Bucket: "removals", Key: "two", Body: "2" }),
+    );
+
+    // When one is removed on its own and the other in a batch
+    await client.send(
+      new DeleteObjectCommand({ Bucket: "removals", Key: "one" }),
+    );
+    const batch = await client.send(
+      new DeleteObjectsCommand({
+        Bucket: "removals",
+        Delete: { Objects: [{ Key: "two" }] },
+      }),
+    );
+
+    // Then the batch reported what it removed, and the Bucket is empty
+    assertIdentical(batch.Deleted?.[0]?.Key, "two");
+
+    const remaining = await client.send(
+      new ListObjectsV2Command({ Bucket: "removals" }),
+    );
+
+    assertIdentical(remaining.KeyCount, 0);
+  });
+
+  it("round-trips a Block Public Access configuration", async () => {
+    // Given a Bucket with Block Public Access configured through the endpoint
+    await client.send(new CreateBucketCommand({ Bucket: "access-block" }));
+    await client.send(
+      new PutPublicAccessBlockCommand({
+        Bucket: "access-block",
+        PublicAccessBlockConfiguration: {
+          BlockPublicAcls: true,
+          RestrictPublicBuckets: false,
+        },
+      }),
+    );
+
+    // When the configuration is read back
+    const read = await client.send(
+      new GetPublicAccessBlockCommand({ Bucket: "access-block" }),
+    );
+
+    // Then the settings survived the XML document in both directions
+    const configuration = read.PublicAccessBlockConfiguration;
+    assertDefined(configuration, "the Block Public Access configuration");
+    assertTrue(configuration.BlockPublicAcls);
+    assertFalse(configuration.RestrictPublicBuckets);
+  });
+
+  it("round-trips a Bucket policy, which travels as JSON rather than XML", async () => {
+    // Given a Bucket with a policy set through the served endpoint. The
+    // principal is the Account rather than everyone, because Block Public
+    // Access refuses a public policy here exactly as it does in real S3.
+    await client.send(new CreateBucketCommand({ Bucket: "policied" }));
+
+    const policy = JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { AWS: `arn:aws:iam::${simAws.defaultAccountId}:root` },
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::policied/*",
+        },
+      ],
+    });
+
+    await client.send(
+      new PutBucketPolicyCommand({ Bucket: "policied", Policy: policy }),
+    );
+
+    // When it is read back
+    const read = await client.send(
+      new GetBucketPolicyCommand({ Bucket: "policied" }),
+    );
+
+    // Then the document survived, which the XML path never touches
+    assertDefined(read.Policy, "the Bucket policy");
+    assertIdentical(
+      JSON.parse(read.Policy).Statement[0].Action,
+      "s3:GetObject",
+    );
+  });
+
+  it("reports a missing Object as the S3 error the SDK expects", async () => {
+    // Given a Bucket with nothing under the key being asked for
+    await client.send(new CreateBucketCommand({ Bucket: "missing-keys" }));
+
+    // When an absent Object is read
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await client.send(
+          new GetObjectCommand({ Bucket: "missing-keys", Key: "absent" }),
+        ),
+    );
+
+    // Then the SDK raised it under the AWS error name rather than a parse
+    // failure, which is what reading the XML error shape buys
+    assertIdentical(error.name, "NoSuchKey");
+  });
+
+  it("refuses a caller the Bucket policy does not allow to write", async () => {
+    // Given a Bucket and a client allowed only to list
+    await client.send(new CreateBucketCommand({ Bucket: "read-only" }));
+
+    // When it attempts a write
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await readOnlyClient.send(
+          new PutObjectCommand({
+            Bucket: "read-only",
+            Key: "denied",
+            Body: "nope",
+          }),
+        ),
+    );
+
+    // Then simulated IAM denied it, in the S3 error shape
+    assertIdentical(error.name, "AccessDenied");
+    assertStringIncludes(error.message, "s3:PutObject");
+  });
+
+  it("refuses an operation whose method it has no route for", async () => {
+    // Given a Bucket holding an Object
+    await client.send(new CreateBucketCommand({ Bucket: "no-route" }));
+    await client.send(
+      new PutObjectCommand({ Bucket: "no-route", Key: "one", Body: "1" }),
+    );
+
+    // When a HEAD is asked for, which simulated S3 has no operation behind
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await client.send(
+          new HeadObjectCommand({ Bucket: "no-route", Key: "one" }),
+        ),
+    );
+
+    // Then it is refused rather than answered from a route meant for a
+    // different method
+    assertIdentical(
+      (error as { $metadata?: { httpStatusCode?: number } }).$metadata
+        ?.httpStatusCode,
+      501,
+    );
+  });
+
+  it("refuses a sub-resource it does not serve instead of answering something else", async () => {
+    // Given a Bucket that exists
+    await client.send(new CreateBucketCommand({ Bucket: "sub-resources" }));
+
+    // When an operation simulated S3 does not serve is asked for, which shares
+    // its method and path with the Object listing
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await client.send(new GetBucketAclCommand({ Bucket: "sub-resources" })),
+    );
+
+    // Then it is refused by name, rather than quietly answered with a listing
+    assertIdentical(error.name, "NotImplemented");
+    assertStringIncludes(error.message, "acl");
+  });
+});

--- a/src/service/s3/serve/api/sim-s3-api.ts
+++ b/src/service/s3/serve/api/sim-s3-api.ts
@@ -1,0 +1,93 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAws } from "../../../aws/sim-aws.js";
+import { SimSdkUnsupportedCommandError } from "../../../../sdk/error/sim-sdk.error.js";
+import { SimSdkCommandDispatcher } from "../../../../sdk/sim-sdk-command-dispatcher.js";
+import {
+  makeSimSdkWireClient,
+  makeSimSdkWireCommand,
+} from "../../../../sdk/wire/sim-sdk-wire-command.js";
+import { SimS3RestErrorResponse } from "../sim-s3-rest-error-response.js";
+import { simS3ApiResponse } from "./sim-s3-api-output.js";
+import { readSimS3ApiRequest } from "./sim-s3-api-request.js";
+import {
+  resolveSimS3ApiRoute,
+  simS3UnservedSubResource,
+} from "./sim-s3-api-routes.js";
+
+/**
+ * The SDK service id simulated S3's Command router is registered under.
+ */
+const s3ServiceId = "S3";
+
+interface SimS3ApiEndpointProperties {
+  readonly simAws: SimAws;
+}
+
+/**
+ * Serves the S3 REST API to a client given an endpoint URL.
+ *
+ * S3 states its operation in the method, the path and a query-string
+ * sub-resource rather than in a header, so the operation is resolved from the
+ * request before anything else. What happens after that is the same as for
+ * every other served AWS API request: the operation runs through the Command
+ * the SDK would have sent, so an HTTP caller reaches exactly the code an
+ * in-process caller does, and IAM authorizes it the same way.
+ */
+export class SimS3ApiEndpoint {
+  private readonly dispatcher: SimSdkCommandDispatcher;
+
+  constructor(properties: SimS3ApiEndpointProperties) {
+    this.dispatcher = new SimSdkCommandDispatcher(properties.simAws);
+  }
+
+  /**
+   * Answer one S3 REST request as the caller that signed it.
+   *
+   * The Region is the one the request was signed for, read from its credential
+   * scope, so it arrives as whatever the client wrote rather than as a Region
+   * the simulator has already recognised.
+   */
+  async handle(
+    request: Request,
+    body: Uint8Array,
+    caller: SimAwsCaller,
+    regionName: string,
+  ): Promise<Response> {
+    const apiRequest = readSimS3ApiRequest(request, body);
+    const errors = new SimS3RestErrorResponse({
+      bucketName: apiRequest.bucketName,
+      objectKey: apiRequest.objectKey,
+    });
+
+    const unserved = simS3UnservedSubResource(apiRequest);
+    if (unserved !== undefined) {
+      return errors.notImplemented(
+        `Simulated S3 does not serve the ${unserved} sub-resource`,
+      );
+    }
+
+    const route = resolveSimS3ApiRoute(apiRequest);
+    if (route === undefined) {
+      return errors.notImplemented(
+        `Simulated S3 does not serve ${apiRequest.method} ${new URL(request.url).pathname}`,
+      );
+    }
+
+    try {
+      const output = await this.dispatcher.dispatch(
+        makeSimSdkWireCommand(route.commandName, route.input(apiRequest)),
+        makeSimSdkWireClient(s3ServiceId, regionName),
+        undefined,
+        caller,
+      );
+
+      return await simS3ApiResponse(route.commandName, output);
+    } catch (error) {
+      if (error instanceof SimSdkUnsupportedCommandError) {
+        return errors.notImplemented(error.message);
+      }
+
+      return errors.build(error);
+    }
+  }
+}

--- a/src/service/s3/serve/sim-s3-rest-error-response.ts
+++ b/src/service/s3/serve/sim-s3-rest-error-response.ts
@@ -1,3 +1,4 @@
+import { escapeXmlText } from "../../../util/xml/xml-writer.js";
 import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
 import { SimS3Error } from "../error/sim-s3.error.js";
 import { SimS3ChecksumMismatch } from "../error/sim-s3-checksum.error.js";
@@ -51,14 +52,25 @@ export class SimS3RestErrorResponse {
     throw error;
   }
 
+  /**
+   * Refuse an operation simulated S3 does not serve.
+   *
+   * `NotImplemented` is the code real S3 answers with for an operation it does
+   * not recognise, so a client reads this as an S3 failure rather than as a
+   * broken endpoint.
+   */
+  notImplemented(message: string): Response {
+    return this.xml(501, "NotImplemented", message);
+  }
+
   private xml(status: number, code: string, message: string): Response {
     const body = [
       `<?xml version="1.0" encoding="UTF-8"?>`,
       `<Error>`,
-      `  <Code>${escapeXml(code)}</Code>`,
-      `  <Message>${escapeXml(message)}</Message>`,
-      `  <BucketName>${escapeXml(this.bucketName)}</BucketName>`,
-      `  <Key>${escapeXml(this.objectKey)}</Key>`,
+      `  <Code>${escapeXmlText(code)}</Code>`,
+      `  <Message>${escapeXmlText(message)}</Message>`,
+      `  <BucketName>${escapeXmlText(this.bucketName)}</BucketName>`,
+      `  <Key>${escapeXmlText(this.objectKey)}</Key>`,
       `</Error>`,
       ``,
     ].join("\n");
@@ -70,11 +82,4 @@ export class SimS3RestErrorResponse {
       },
     });
   }
-}
-
-function escapeXml(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;");
 }

--- a/src/util/xml/xml-document.iso.test.ts
+++ b/src/util/xml/xml-document.iso.test.ts
@@ -1,0 +1,111 @@
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  parseXmlDocument,
+  xmlBoolean,
+  xmlChild,
+  xmlChildren,
+  xmlText,
+} from "./xml-document.js";
+
+describe("Reading an XML document", () => {
+  it("reads nested elements and their text", () => {
+    // Given a document with an element inside an element
+    const root = parseXmlDocument(
+      "<Delete><Object><Key>one.txt</Key></Object></Delete>",
+    );
+
+    // Then each level is reachable by name
+    assertIdentical(root?.name, "Delete");
+    assertIdentical(xmlText(xmlChild(root, "Object"), "Key"), "one.txt");
+  });
+
+  it("keeps repeated elements in document order", () => {
+    // Given a document repeating one element
+    const root = parseXmlDocument(
+      "<Delete><Object><Key>a</Key></Object><Object><Key>b</Key></Object></Delete>",
+    );
+
+    // When every one of them is read
+    const objects = xmlChildren(root, "Object");
+
+    // Then they came back in the order they were written
+    assertArrayLength(objects, 2);
+    assertIdentical(xmlText(objects[0], "Key"), "a");
+    assertIdentical(xmlText(objects[1], "Key"), "b");
+  });
+
+  it("reads an element that closed itself as having no children", () => {
+    // Given a document with a self-closing element
+    const root = parseXmlDocument(
+      "<Configuration><EventBridge/><Id>one</Id></Configuration>",
+    );
+
+    // Then it is present and empty, and the element after it is a sibling
+    assertArrayLength(xmlChildren(root, "EventBridge"), 1);
+    assertIdentical(xmlText(root, "Id"), "one");
+  });
+
+  it("ignores the declaration, comments and attributes", () => {
+    // Given a document carrying all three
+    const root = parseXmlDocument(
+      `<?xml version="1.0"?><!-- a note --><Config xmlns="http://s3"><Id>one</Id></Config>`,
+    );
+
+    // Then the element tree is what is left
+    assertIdentical(root?.name, "Config");
+    assertIdentical(xmlText(root, "Id"), "one");
+  });
+
+  it("decodes the entities XML text carries", () => {
+    // Given text using named, decimal and hexadecimal references
+    const root = parseXmlDocument(
+      "<Key>a&amp;b &lt;c&gt; &quot;d&quot; &apos;e&apos; &#65; &#x42;</Key>",
+    );
+
+    // Then each one came back as the character it names
+    assertIdentical(root?.text.trim(), `a&b <c> "d" 'e' A B`);
+  });
+
+  it("leaves a reference naming no character as it was written", () => {
+    // Given a reference outside the range of a code point
+    const root = parseXmlDocument("<Key>&#x110000; &notAnEntity;</Key>");
+
+    // Then it survives rather than becoming a replacement character
+    assertIdentical(root?.text.trim(), "&#x110000; &notAnEntity;");
+  });
+
+  it("reads a boolean an element states", () => {
+    // Given a configuration stating two booleans
+    const root = parseXmlDocument(
+      "<Config><Quiet>true</Quiet><Block>false</Block></Config>",
+    );
+
+    // Then each reads back as the boolean it named, and an absent one is
+    // undefined rather than false
+    assertTrue(xmlBoolean(root, "Quiet"));
+    assertFalse(xmlBoolean(root, "Block"));
+    assertUndefined(xmlBoolean(root, "Missing"));
+  });
+
+  it("reads an empty document as no element at all", () => {
+    // Given a body with nothing in it
+    assertUndefined(parseXmlDocument(""));
+    assertUndefined(parseXmlDocument(" ".repeat(3)));
+  });
+
+  it("ignores a closing tag that closes nothing", () => {
+    // Given a malformed document, which a service answers for itself
+    const root = parseXmlDocument("</Stray><Config><Id>one</Id></Config>");
+
+    // Then what can be read is read, rather than the reader raising
+    assertIdentical(xmlText(root, "Id"), "one");
+  });
+});

--- a/src/util/xml/xml-document.ts
+++ b/src/util/xml/xml-document.ts
@@ -1,0 +1,149 @@
+/**
+ * One element of a parsed XML document.
+ *
+ * Attributes are dropped. The documents this reads are AWS request bodies,
+ * where every value a service reads travels as element text, and the only
+ * attribute any of them carries is the default namespace.
+ */
+export interface XmlElement {
+  readonly name: string;
+  /** The element's own text, with child element text left out. */
+  readonly text: string;
+  readonly children: readonly XmlElement[];
+}
+
+interface MutableXmlElement {
+  readonly name: string;
+  text: string;
+  readonly children: MutableXmlElement[];
+}
+
+// The attributes run greedily to the closing angle bracket, with no
+// alternation, so the pattern cannot backtrack. Whether the tag closed itself
+// is read off the end of that run rather than matched separately.
+const tagPattern =
+  /<(?<closing>\/)?(?<name>[A-Za-z_][\w.:-]*)(?<attributes>[^>]*)>/g;
+
+const prologPattern = /<\?[\s\S]*?\?>|<!--[\s\S]*?-->|<!\[CDATA\[[\s\S]*?]]>/g;
+
+/**
+ * Read an XML document as a tree of elements.
+ *
+ * This handles the shape AWS request bodies actually take, which is elements,
+ * text and nothing else. Returns undefined for a document with no element in
+ * it, which is what an empty body parses to.
+ *
+ * A closing tag that does not match the element it closes is ignored rather
+ * than raising, because a service reading a malformed body answers with its own
+ * error rather than a parser's.
+ */
+export function parseXmlDocument(source: string): XmlElement | undefined {
+  const document = source.replaceAll(prologPattern, "");
+  const stack: MutableXmlElement[] = [];
+  let root: MutableXmlElement | undefined;
+  let index = 0;
+
+  for (const match of document.matchAll(tagPattern)) {
+    const groups = match.groups ?? {};
+    const open = stack.at(-1);
+
+    if (open !== undefined) {
+      open.text += decodeXmlText(document.slice(index, match.index));
+    }
+    index = match.index + match[0].length;
+
+    if (groups["closing"] === "/") {
+      stack.pop();
+      continue;
+    }
+
+    const name = groups["name"] ?? "";
+    const element: MutableXmlElement = { name, text: "", children: [] };
+    open?.children.push(element);
+    root ??= element;
+
+    if (!(groups["attributes"] ?? "").trimEnd().endsWith("/")) {
+      stack.push(element);
+    }
+  }
+
+  return root;
+}
+
+/**
+ * The first child element of the given name, if the element has one.
+ */
+export function xmlChild(
+  element: XmlElement | undefined,
+  name: string,
+): XmlElement | undefined {
+  return element?.children.find((child) => child.name === name);
+}
+
+/**
+ * Every child element of the given name, in document order.
+ */
+export function xmlChildren(
+  element: XmlElement | undefined,
+  name: string,
+): readonly XmlElement[] {
+  return element?.children.filter((child) => child.name === name) ?? [];
+}
+
+/**
+ * The trimmed text of a named child, if the element has one.
+ */
+export function xmlText(
+  element: XmlElement | undefined,
+  name: string,
+): string | undefined {
+  return xmlChild(element, name)?.text.trim();
+}
+
+/**
+ * The boolean a named child states, if the element has one.
+ */
+export function xmlBoolean(
+  element: XmlElement | undefined,
+  name: string,
+): boolean | undefined {
+  const text = xmlText(element, name);
+
+  return text === undefined ? undefined : text === "true";
+}
+
+const entities: ReadonlyMap<string, string> = new Map([
+  ["amp", "&"],
+  ["lt", "<"],
+  ["gt", ">"],
+  ["quot", '"'],
+  ["apos", "'"],
+]);
+
+/**
+ * Decode the entities XML text carries.
+ */
+function decodeXmlText(text: string): string {
+  return text.replaceAll(
+    /&(#x?[\da-f]+|\w+);/gi,
+    (whole, reference: string) => {
+      if (reference.startsWith("#x") || reference.startsWith("#X")) {
+        return codePoint(Number.parseInt(reference.slice(2), 16), whole);
+      }
+      if (reference.startsWith("#")) {
+        return codePoint(Number(reference.slice(1)), whole);
+      }
+
+      return entities.get(reference.toLowerCase()) ?? whole;
+    },
+  );
+}
+
+/**
+ * A numeric character reference, left as written when it names no character.
+ */
+function codePoint(value: number, whole: string): string {
+  return Number.isFinite(value) && value >= 0 && value <= 0x10_ff_ff
+    ? String.fromCodePoint(value)
+    : whole;
+}

--- a/src/util/xml/xml-writer.iso.test.ts
+++ b/src/util/xml/xml-writer.iso.test.ts
@@ -1,0 +1,58 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  escapeXmlText,
+  xmlDocument,
+  xmlElement,
+  xmlValue,
+} from "./xml-writer.js";
+
+describe("Writing an XML document", () => {
+  it("wraps content in an element", () => {
+    assertIdentical(xmlElement("Key", "one.txt"), "<Key>one.txt</Key>");
+  });
+
+  it("writes no element for a value the output did not carry", () => {
+    // Given a member the operation left out, which differs from an empty one
+    assertIdentical(xmlValue("Prefix", undefined), "");
+    assertIdentical(xmlValue("Prefix", ""), "<Prefix></Prefix>");
+  });
+
+  it("writes a timestamp as the ISO 8601 an SDK parses back", () => {
+    const written = xmlValue("LastModified", new Date("2026-08-18T09:30:00Z"));
+
+    assertIdentical(
+      written,
+      "<LastModified>2026-08-18T09:30:00.000Z</LastModified>",
+    );
+  });
+
+  it("writes numbers and booleans as their text", () => {
+    assertIdentical(xmlValue("Size", 42), "<Size>42</Size>");
+    assertIdentical(
+      xmlValue("IsTruncated", false),
+      "<IsTruncated>false</IsTruncated>",
+    );
+  });
+
+  it("escapes what would otherwise be read as markup", () => {
+    // Given a key containing every character XML gives meaning to
+    const escaped = escapeXmlText(`a&b<c>d"e'f`);
+
+    assertIdentical(escaped, "a&amp;b&lt;c&gt;d&quot;e&apos;f");
+  });
+
+  it("escapes a value on the way into an element", () => {
+    assertIdentical(xmlValue("Key", "a&b"), "<Key>a&amp;b</Key>");
+  });
+
+  it("writes a document with the declaration AWS sends", () => {
+    const document = xmlDocument("Result", "<Id>one</Id>");
+
+    assertIdentical(
+      document,
+      `<?xml version="1.0" encoding="UTF-8"?><Result><Id>one</Id></Result>`,
+    );
+  });
+});

--- a/src/util/xml/xml-writer.ts
+++ b/src/util/xml/xml-writer.ts
@@ -1,0 +1,61 @@
+/**
+ * Writing the XML documents AWS REST services answer with.
+ *
+ * These build strings rather than a document tree, because an AWS response
+ * body is written once and never read back, and the element order is fixed by
+ * the shape being written.
+ */
+
+/**
+ * An element wrapping already-written content.
+ */
+export function xmlElement(name: string, content: string): string {
+  return `<${name}>${content}</${name}>`;
+}
+
+/**
+ * An element holding one value, or nothing at all when the value is absent.
+ *
+ * An omitted member and a member holding an empty string are different facts
+ * in an AWS response, so an absent value writes no element rather than an
+ * empty one.
+ */
+export function xmlValue(
+  name: string,
+  value: string | number | boolean | Date | undefined,
+): string {
+  return value === undefined ? "" : xmlElement(name, xmlContent(value));
+}
+
+/**
+ * A whole document, with the declaration real AWS services send.
+ */
+export function xmlDocument(rootName: string, content: string): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>${xmlElement(rootName, content)}`;
+}
+
+/**
+ * A value in the form XML text carries it.
+ *
+ * A timestamp travels as ISO 8601, which is what the REST protocols use and
+ * what an SDK parses a date back out of.
+ */
+function xmlContent(value: string | number | boolean | Date): string {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  return escapeXmlText(String(value));
+}
+
+/**
+ * Escape the characters that would otherwise be read as markup.
+ */
+export function escapeXmlText(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}


### PR DESCRIPTION
An `S3Client` or `aws s3` given a served environment's endpoint URL now reaches simulated S3, alongside the AWS JSON protocol services that already answered there.

Resolves https://github.com/KensioSoftware/yulin/issues/673

## How it reads a request

S3 states its operation in the method, the shape of the path and a query-string sub-resource. A request signed for `s3` therefore goes to a route table, where the JSON protocol services go to the wire dispatcher. Everything after that is the ordinary dispatch. The operation runs through the Command the SDK would have sent, and simulated IAM authorizes it exactly as it does in process. The 18 operations simulated S3 implements are the ones served.

## Worth a reviewer's attention

**The issue proposed a different approach, and it turned out to be unavailable.** #673 planned to drive this off the SDK's runtime operation schemas. Those exist and carry what a server needs. Reading them means importing `@aws-sdk/client-s3` and `@smithy/core` as runtime values, and every SDK reference in `src/` today is a type import. The feature exists to serve non-Node clients, so requiring the Node SDK in the host project inverts its own point. This is hand-written, over the bounded set of operations simulated S3 has.

**A sub-resource has to be recognised by name.** Both the SDK and the CLI write one as `?acl=`, with an equals and nothing after it, which is exactly how the CLI writes the empty `prefix=` it sends on every listing. Nothing in the query string separates the two, so `sim-s3-api-routes.ts` lists S3's sub-resource names. An earlier attempt to infer it broke `aws s3 ls`, and the loc test pins that case.

**An unserved sub-resource is refused.** `?acl` on `GET /{Bucket}` shares its method and path with the Object listing, so ignoring it answers a question about permissions with a list of keys.

Verified against the real `aws` CLI as well as the SDK: `s3api create-bucket`, `put-object`, `list-objects-v2`, `get-object`, `delete-objects`, `put-bucket-policy`, `put-public-access-block` and `aws s3 ls s3://bucket/` all work, and `get-bucket-acl` is refused by name.

## Known gaps, documented in `docs/serve`

- `aws s3 ls` with no Bucket fails, because simulated S3 records no creation date for a Bucket and the CLI reads one from every entry. `aws s3api list-buckets` and `aws s3 ls s3://bucket/` both work. Worth its own issue.
- Simulated S3 implements no `HeadObject` or `HeadBucket`, so both are refused. That puts `aws s3 cp` out of reach too.

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`
