### PR TITLE
feat: answer sts get-caller-identity from the simulation

### DIFF
--- a/docs/serve/README.md
+++ b/docs/serve/README.md
@@ -246,9 +246,27 @@ A request carrying no signature is anonymous and reaches nothing. In process an 
 
 ### Which services answer
 
-S3, and the services that speak the AWS JSON protocol. Those are DynamoDB, DynamoDB Streams, SQS, Cognito Identity Provider, EventBridge, ECS, SSM, ACM, CloudWatch Logs, KMS, Secrets Manager and Rekognition.
+S3, STS, and the services that speak the AWS JSON protocol. Those are DynamoDB, DynamoDB Streams, SQS, Cognito Identity Provider, EventBridge, ECS, SSM, ACM, CloudWatch Logs, KMS, Secrets Manager and Rekognition.
 
-A request to any other service is refused with `501 Not Implemented` and a body saying why. STS is the one worth naming, since it speaks the Query protocol. Every service is reachable in process through `SimAws` and through [SDK interception](../sdk/README.md), whether or not it answers here.
+A request to any other service is refused with `501 Not Implemented` and a body saying why. Every service is reachable in process through `SimAws` and through [SDK interception](../sdk/README.md), whether or not it answers here.
+
+### Checking who the simulator thinks you are
+
+`sts get-caller-identity` reports the principal behind the credentials that signed the request, which is the quickest way to confirm an endpoint and a set of credentials are wired up as expected:
+
+```bash
+export AWS_ENDPOINT_URL=http://localhost:8787
+aws sts get-caller-identity
+{
+    "UserId": "AIDAM7J2TJYHV8BHEVIO",
+    "Account": "888888888888",
+    "Arn": "arn:aws:iam::888888888888:user/Widgets"
+}
+```
+
+An assumed-role session reports its own session ARN, as it does in real AWS, and its user id joins the Role's id to the session name. A caller with no identity is refused, since there is nothing to answer with.
+
+`GetCallerIdentity` is the only STS operation served. `AssumeRole` works in process and through SDK interception.
 
 ### S3 over the endpoint
 
@@ -779,7 +797,8 @@ it is without watch mode.
 - Simulated state is not carried across a restart. Seeding belongs in the setup script, so it runs
   again and local state stays the same as what tests and CI see.
 - The IDE run configurations for attaching a debugger to a watched process are not documented yet.
-- The served AWS service API covers S3 and the AWS JSON protocol services. A service speaking REST-JSON or Query, STS among them, is refused with `501 Not Implemented`.
+- The served AWS service API covers S3, STS and the AWS JSON protocol services. A service speaking REST-JSON, or Query other than STS, is refused with `501 Not Implemented`.
+- `GetCallerIdentity` is the only STS operation served. `AssumeRole` over a port would mean the temporary credentials it issues have to sign the calls that follow, which is its own piece of work.
 - `aws s3 ls` with no Bucket fails, because simulated S3 records no creation date for a Bucket and the CLI reads one from every entry. `aws s3api list-buckets` and `aws s3 ls s3://bucket/` both work.
 - Simulated S3 implements no `HeadObject` or `HeadBucket`, so both are refused. `aws s3 cp` reads an Object with `HeadObject` before copying it, which puts that out of reach too.
 - A served AWS API request is routed by its SigV4 credential scope. An unsigned one reaches nothing, whatever endpoint URL it used.

--- a/src/serve/http/api/sim-aws-api-endpoint.loc.test.ts
+++ b/src/serve/http/api/sim-aws-api-endpoint.loc.test.ts
@@ -18,7 +18,7 @@ import {
   ListQueuesCommand,
   SQSClient,
 } from "@aws-sdk/client-sqs";
-import { GetCallerIdentityCommand, STSClient } from "@aws-sdk/client-sts";
+import { LambdaClient, ListFunctionsCommand } from "@aws-sdk/client-lambda";
 import {
   assertIdentical,
   assertStringIncludes,
@@ -244,18 +244,18 @@ describe("Serving the general AWS API on one endpoint", () => {
   });
 
   it("refuses a protocol it cannot read without asking the client to retry", async () => {
-    // Given a request signed for STS, which speaks the Query protocol rather
-    // than the AWS JSON protocol this endpoint reads
-    const client = new STSClient({
+    // Given a request signed for the Lambda control plane, which speaks
+    // REST-JSON rather than any protocol this endpoint reads
+    const client = new LambdaClient({
       region: simAws.defaultRegionName,
       endpoint,
       credentials,
       maxAttempts: 1,
     });
 
-    // When it asks for something only the Query protocol could express
+    // When it asks for something only REST-JSON could express
     const error = await assertThrowsErrorAsync(
-      async () => await client.send(new GetCallerIdentityCommand({})),
+      async () => await client.send(new ListFunctionsCommand({})),
     );
 
     // Then it is refused as unimplemented, which an SDK does not retry, and

--- a/src/serve/http/api/sim-aws-api-endpoint.ts
+++ b/src/serve/http/api/sim-aws-api-endpoint.ts
@@ -4,6 +4,7 @@ import { readSimSdkWireCredentialScope } from "../../../sdk/wire/sim-sdk-wire-op
 import type { SimSdkWireRequest } from "../../../sdk/wire/sim-sdk-wire.types.js";
 import type { SimAws } from "../../../service/aws/sim-aws.js";
 import { SimS3ApiEndpoint } from "../../../service/s3/serve/api/sim-s3-api.js";
+import { SimStsApiEndpoint } from "../../../service/sts/serve/sim-sts-api.js";
 import { SimAwsReceivedRequest } from "../request/sim-aws-received-request.js";
 
 interface SimAwsApiEndpointProperties {
@@ -11,9 +12,11 @@ interface SimAwsApiEndpointProperties {
 }
 
 /**
- * The SigV4 signing name S3 requests carry.
+ * The SigV4 signing names of the services whose protocol is read by an
+ * endpoint of its own rather than by the AWS JSON protocol dispatcher.
  */
 const s3SigningName = "s3";
+const stsSigningName = "sts";
 
 /**
  * The general AWS service API, served on one endpoint.
@@ -31,18 +34,20 @@ const s3SigningName = "s3";
  *
  * The scope also says which protocol to read the request with. Most simulated
  * services speak the AWS JSON protocol and name their operation in a header.
- * S3 speaks REST-XML and names its operation in the method and path, so it is
- * read by an endpoint of its own.
+ * S3 speaks REST-XML and STS speaks Query, and each names its operation
+ * somewhere else, so each is read by an endpoint of its own.
  */
 export class SimAwsApiEndpoint {
   private readonly simAws: SimAws;
   private readonly dispatcher: SimSdkWireDispatcher;
   private readonly s3: SimS3ApiEndpoint;
+  private readonly sts: SimStsApiEndpoint;
 
   constructor(properties: SimAwsApiEndpointProperties) {
     this.simAws = properties.simAws;
     this.dispatcher = new SimSdkWireDispatcher(properties.simAws);
     this.s3 = new SimS3ApiEndpoint({ simAws: properties.simAws });
+    this.sts = new SimStsApiEndpoint({ simAws: properties.simAws });
   }
 
   /**
@@ -69,12 +74,24 @@ export class SimAwsApiEndpoint {
       },
     });
 
-    // S3 is the one served service that states its operation in the method and
-    // path rather than in a header, so it is read by its own endpoint.
+    // S3 states its operation in the method and path, and STS in a
+    // form-encoded field, so neither can be read by the header the AWS JSON
+    // protocol names its operation in.
+    const body = received.body ?? new Uint8Array();
+
     if (scope.signingName === s3SigningName) {
       return await this.s3.handle(
         request,
-        received.body ?? new Uint8Array(),
+        body,
+        caller.toCaller(),
+        scope.regionName,
+      );
+    }
+
+    if (scope.signingName === stsSigningName) {
+      return await this.sts.handle(
+        request,
+        body,
         caller.toCaller(),
         scope.regionName,
       );

--- a/src/service/iam/sim-iam.ts
+++ b/src/service/iam/sim-iam.ts
@@ -2,6 +2,7 @@ import type { SimArn } from "../aws/arn.js";
 import type { SimAwsAccountId } from "../aws/sim-aws-account.js";
 import type { SimIamManagedPolicy } from "./policy/sim-iam-policy.js";
 import type { SimIamRole, SimIamRoleName } from "./role/sim-iam-role.js";
+import type { SimIamUser, SimIamUsername } from "./user/sim-iam-user.js";
 import type { SimIamAuthorizationInput } from "./authorize/context/sim-iam-auth-z-context-builder.js";
 import type { SimIamPolicyDecision } from "./authorize/sim-iam-decision.js";
 import type * as simIamCommands from "./command/sim-iam-command.types.js";
@@ -51,6 +52,15 @@ export class SimIam
 
   public readonly policies: Map<SimArn, SimIamManagedPolicy>;
   public readonly roles: Map<SimIamRoleName, SimIamRole>;
+  /**
+   * The Users this Account holds, by name.
+   *
+   * Exposed for the simulated services that report on a principal rather than
+   * authorize one, such as STS answering GetCallerIdentity with a User's own
+   * id.
+   * @internal
+   */
+  public readonly users: Map<SimIamUsername, SimIamUser>;
 
   private readonly cfnFactory: SimCfnServiceResourceFactory;
   private readonly commands: SimIamCommandHandlers;
@@ -63,6 +73,7 @@ export class SimIam
     this.accountId = parts.accountId;
     this.policies = parts.policies;
     this.roles = parts.roles;
+    this.users = parts.users;
     this.credentials = parts.credentials;
     this.sessionManager = parts.sessionManager;
     this.accountAuthZ = parts.accountAuthZ;

--- a/src/service/sts/command/get-caller-identity/get-caller-identity.command.ts
+++ b/src/service/sts/command/get-caller-identity/get-caller-identity.command.ts
@@ -1,0 +1,21 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim STS GetCallerIdentity command.
+ *
+ * The operation takes no input. Everything it answers with comes from who the
+ * request was made by.
+ */
+export interface SimGetCallerIdentityCommand {
+  readonly input?: Record<string, never> | undefined;
+}
+
+/**
+ * Minimal structural sim STS GetCallerIdentity output.
+ */
+export interface SimGetCallerIdentityCommandOutput {
+  readonly UserId?: string | undefined;
+  readonly Account?: string | undefined;
+  readonly Arn?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/sts/command/get-caller-identity/get-caller-identity.handler.ts
+++ b/src/service/sts/command/get-caller-identity/get-caller-identity.handler.ts
@@ -1,0 +1,77 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import { SimAwsCallerResolver } from "../../../aws/caller/sim-aws-caller-resolver.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { makeSimAwsAccountRootPrincipal } from "../../../aws/caller/sim-aws-account-root-principal.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import type { SimIamAccountResolver } from "../../../iam/registry/sim-iam-account-resolver.js";
+import type {
+  SimGetCallerIdentityCommand,
+  SimGetCallerIdentityCommandOutput,
+} from "./get-caller-identity.command.js";
+import { simStsCallerUserId } from "./sim-sts-caller-user-id.js";
+
+interface GetCallerIdentityCommandHandlerProperties {
+  readonly sourceAccountId: SimAwsAccountId;
+  readonly iamResolver: SimIamAccountResolver;
+}
+
+/**
+ * Simulated STS GetCallerIdentity handler.
+ *
+ * The operation reports who the simulator decided the caller is. Real STS
+ * needs no permission for it, which is what makes it the call people reach for
+ * to check that credentials and an endpoint are wired up correctly, so this
+ * authorizes nothing either.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sts/command/GetCallerIdentityCommand/
+ */
+export class GetCallerIdentityCommandHandler implements CommandHandler<
+  SimGetCallerIdentityCommand,
+  SimGetCallerIdentityCommandOutput
+> {
+  private readonly callerResolver = new SimAwsCallerResolver();
+  private readonly sourceAccountId: SimAwsAccountId;
+  private readonly iamResolver: SimIamAccountResolver;
+
+  constructor(properties: GetCallerIdentityCommandHandlerProperties) {
+    this.sourceAccountId = properties.sourceAccountId;
+    this.iamResolver = properties.iamResolver;
+  }
+
+  /**
+   * Report the identity behind this request.
+   *
+   * A caller with no identity has none to report. Real STS answers an
+   * unsigned request by refusing the signature, and the simulator reaches the
+   * same place by way of the anonymous principal a served request resolves to.
+   */
+  // oxlint-disable-next-line require-await -- the handler contract is asynchronous
+  async handle(
+    _command: SimGetCallerIdentityCommand,
+    options?: { caller?: SimAwsCaller },
+  ): Promise<SimGetCallerIdentityCommandOutput> {
+    const caller = this.callerResolver.resolve(
+      options?.caller,
+      makeSimAwsAccountRootPrincipal(this.sourceAccountId),
+    );
+
+    if (caller.principal.kind !== "arn") {
+      throw new SimIamAccessDenied({
+        principal: caller.principal,
+        action: "sts:GetCallerIdentity",
+        resource: "*",
+      });
+    }
+
+    const accountId = (caller.accountId ??
+      this.sourceAccountId) as SimAwsAccountId;
+
+    return {
+      Arn: caller.arn,
+      Account: accountId,
+      ...simStsCallerUserId(caller.arn, accountId, this.iamResolver),
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/sts/command/get-caller-identity/get-caller-identity.iso.test.ts
+++ b/src/service/sts/command/get-caller-identity/get-caller-identity.iso.test.ts
@@ -50,6 +50,30 @@ describe("Simulated STS GetCallerIdentity", () => {
     assertIdentical(identity.UserId, created.User.UserId);
   });
 
+  it("reports a User held at a path, whose ARN carries the path before the name", async () => {
+    // Given a User created under a path, which real IAM allows and which puts
+    // the path into the User's own ARN
+    const simAws = new SimAws();
+    const accountId = simAws.defaultAccountId;
+    const created = await simAws
+      .iam()
+      .createUser(
+        new CreateUserCommand({ UserName: "Widgets", Path: "/engineering/" }),
+      );
+
+    const arn = created.User.Arn;
+    assertIdentical(arn, `arn:aws:iam::${accountId}:user/engineering/Widgets`);
+
+    // When that User asks who it is
+    const identity = await simAws
+      .sts()
+      .getCallerIdentity({}, { caller: { kind: "arn", arn } });
+
+    // Then the name was read from the end of the ARN rather than the start,
+    // so the User was found and reported with its own id
+    assertIdentical(identity.UserId, created.User.UserId);
+  });
+
   it("reports the Account id as the user id for the Account root", async () => {
     // Given the Account root asking who it is
     const simAws = new SimAws();

--- a/src/service/sts/command/get-caller-identity/get-caller-identity.iso.test.ts
+++ b/src/service/sts/command/get-caller-identity/get-caller-identity.iso.test.ts
@@ -1,0 +1,180 @@
+import {
+  CreateAccessKeyCommand,
+  CreateRoleCommand,
+  CreateUserCommand,
+} from "@aws-sdk/client-iam";
+import { AssumeRoleCommand } from "@aws-sdk/client-sts";
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertStringStartsWith,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+
+/**
+ * Who simulated STS says a caller is.
+ *
+ * The operation needs no permission in real AWS, which is what makes it the
+ * call people reach for to check that credentials are wired up correctly, so
+ * what these cover is whether the answer is faithful rather than whether it is
+ * allowed.
+ */
+describe("Simulated STS GetCallerIdentity", () => {
+  it("reports an IAM User by ARN, Account and its own id", async () => {
+    // Given a User that simulated IAM issued an id to
+    const simAws = new SimAws();
+    const accountId = simAws.defaultAccountId;
+    const created = await simAws
+      .iam()
+      .createUser(new CreateUserCommand({ UserName: "Widgets" }));
+
+    // When that User asks who it is
+    const identity = await simAws.sts().getCallerIdentity(
+      {},
+      {
+        caller: {
+          kind: "arn",
+          arn: `arn:aws:iam::${accountId}:user/Widgets`,
+        },
+      },
+    );
+
+    // Then all three members describe the User that asked
+    assertIdentical(identity.Arn, `arn:aws:iam::${accountId}:user/Widgets`);
+    assertIdentical(identity.Account, accountId);
+    assertIdentical(identity.UserId, created.User.UserId);
+  });
+
+  it("reports the Account id as the user id for the Account root", async () => {
+    // Given the Account root asking who it is
+    const simAws = new SimAws();
+    const accountId = simAws.defaultAccountId;
+
+    const identity = await simAws
+      .sts()
+      .getCallerIdentity(
+        {},
+        { caller: { kind: "arn", arn: `arn:aws:iam::${accountId}:root` } },
+      );
+
+    // Then the user id is the Account, which is what real STS answers
+    assertIdentical(identity.UserId, accountId);
+  });
+
+  it("reports an assumed-role session by its session ARN and the Role's id", async () => {
+    // Given a session assumed into a Role
+    const simAws = new SimAws();
+    const accountId = simAws.defaultAccountId;
+    const role = await simAws.iam().createRole(
+      new CreateRoleCommand({
+        RoleName: "Reader",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+    const assumed = await simAws.sts().assumeRole(
+      new AssumeRoleCommand({
+        RoleArn: `arn:aws:iam::${accountId}:role/Reader`,
+        RoleSessionName: "nightly",
+      }),
+    );
+
+    const sessionArn = assumed.AssumedRoleUser?.Arn;
+    assertDefined(sessionArn, "the assumed-role session ARN");
+
+    // When the session asks who it is
+    const identity = await simAws
+      .sts()
+      .getCallerIdentity({}, { caller: { kind: "arn", arn: sessionArn } });
+
+    // Then it is the session that answers, joined to the Role behind it
+    assertIdentical(
+      identity.Arn,
+      `arn:aws:sts::${accountId}:assumed-role/Reader/nightly`,
+    );
+    assertIdentical(identity.UserId, `${role.Role.RoleId}:nightly`);
+  });
+
+  it("states no user id for a principal nothing created", async () => {
+    // Given an ARN naming a User that was never created
+    const simAws = new SimAws();
+    const accountId = simAws.defaultAccountId;
+
+    const identity = await simAws.sts().getCallerIdentity(
+      {},
+      {
+        caller: { kind: "arn", arn: `arn:aws:iam::${accountId}:user/Ghost` },
+      },
+    );
+
+    // Then the ARN is reported as asked and no id is invented for it
+    assertIdentical(identity.Arn, `arn:aws:iam::${accountId}:user/Ghost`);
+    assertUndefined(identity.UserId);
+  });
+
+  it("refuses a caller with no identity to report", async () => {
+    // Given an anonymous caller
+    const simAws = new SimAws();
+
+    // When it asks who it is
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws
+          .sts()
+          .getCallerIdentity({}, { caller: { kind: "anonymous" } }),
+    );
+
+    // Then it is refused, because there is nothing to answer with
+    assertStringIncludes(error.message, "sts:GetCallerIdentity");
+  });
+
+  it("answers the Account that owns the caller, not the one it was asked through", async () => {
+    // Given a caller from another Account asking through this one
+    const simAws = new SimAws();
+
+    const identity = await simAws.sts().getCallerIdentity(
+      {},
+      {
+        caller: { kind: "arn", arn: "arn:aws:iam::111111111111:user/Other" },
+      },
+    );
+
+    // Then the Account is read from the caller's own ARN
+    assertIdentical(identity.Account, "111111111111");
+  });
+
+  it("issues a user id shaped the way AWS shapes one", async () => {
+    // Given a User simulated IAM created
+    const simAws = new SimAws();
+    await simAws
+      .iam()
+      .createUser(new CreateUserCommand({ UserName: "Shaped" }));
+    await simAws
+      .iam()
+      .createAccessKey(new CreateAccessKeyCommand({ UserName: "Shaped" }));
+
+    const identity = await simAws.sts().getCallerIdentity(
+      {},
+      {
+        caller: {
+          kind: "arn",
+          arn: `arn:aws:iam::${simAws.defaultAccountId}:user/Shaped`,
+        },
+      },
+    );
+
+    // Then the id starts the way an AWS user id does
+    assertStringStartsWith(identity.UserId, "AIDA");
+  });
+});

--- a/src/service/sts/command/get-caller-identity/sim-sts-caller-user-id.ts
+++ b/src/service/sts/command/get-caller-identity/sim-sts-caller-user-id.ts
@@ -1,0 +1,52 @@
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import type { SimIamAccountResolver } from "../../../iam/registry/sim-iam-account-resolver.js";
+import type { SimIamRoleName } from "../../../iam/role/sim-iam-role.js";
+import type { SimIamUsername } from "../../../iam/user/sim-iam-user.js";
+
+/**
+ * The unique id STS reports for a caller, which differs by what the caller is.
+ *
+ * Real STS answers the Account id for the Account root, the user's own id for
+ * an IAM user, and the Role's id joined to the session name for an
+ * assumed-role session. Each one is looked up rather than invented, so a
+ * caller with no simulated record behind it gets no id at all instead of a
+ * plausible-looking one.
+ */
+export function simStsCallerUserId(
+  arn: string | undefined,
+  accountId: SimAwsAccountId,
+  iamResolver: SimIamAccountResolver,
+): { UserId?: string } {
+  if (arn === undefined) {
+    return {};
+  }
+
+  const resource = arn.split(":").slice(5).join(":");
+
+  if (resource === "root") {
+    return { UserId: accountId };
+  }
+
+  const iam = iamResolver.findIamForAccount(accountId);
+  if (iam === undefined) {
+    return {};
+  }
+
+  const [kind, name, sessionName] = resource.split("/", 3);
+
+  if (kind === "user" && name !== undefined) {
+    const userId = iam.users.get(name as SimIamUsername)?.userId;
+
+    return userId === undefined ? {} : { UserId: userId };
+  }
+
+  if (kind === "assumed-role" && name !== undefined) {
+    const roleId = iam.roles.get(name as SimIamRoleName)?.roleId;
+
+    return roleId === undefined
+      ? {}
+      : { UserId: `${roleId}:${sessionName ?? ""}` };
+  }
+
+  return {};
+}

--- a/src/service/sts/command/get-caller-identity/sim-sts-caller-user-id.ts
+++ b/src/service/sts/command/get-caller-identity/sim-sts-caller-user-id.ts
@@ -32,16 +32,30 @@ export function simStsCallerUserId(
     return {};
   }
 
-  const [kind, name, sessionName] = resource.split("/", 3);
+  const [kind, ...segments] = resource.split("/");
 
-  if (kind === "user" && name !== undefined) {
-    const userId = iam.users.get(name as SimIamUsername)?.userId;
+  if (kind === "user") {
+    // A User ARN carries the User's path before its name, so the name is the
+    // last segment rather than the first. `user/engineering/Widgets` is the
+    // User `Widgets` at path `/engineering/`, and simulated IAM keys Users by
+    // name alone.
+    const username = segments.at(-1);
+    const userId =
+      username === undefined
+        ? undefined
+        : iam.users.get(username as SimIamUsername)?.userId;
 
     return userId === undefined ? {} : { UserId: userId };
   }
 
-  if (kind === "assumed-role" && name !== undefined) {
-    const roleId = iam.roles.get(name as SimIamRoleName)?.roleId;
+  if (kind === "assumed-role") {
+    // A session ARN names the Role and then the session, and carries no path,
+    // which is why these two are read by position.
+    const [roleName, sessionName] = segments;
+    const roleId =
+      roleName === undefined
+        ? undefined
+        : iam.roles.get(roleName as SimIamRoleName)?.roleId;
 
     return roleId === undefined
       ? {}

--- a/src/service/sts/sdk/sim-sts-sdk-command-router.iso.test.ts
+++ b/src/service/sts/sdk/sim-sts-sdk-command-router.iso.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "vitest";
 import { CreateRoleCommand } from "@aws-sdk/client-iam";
 import {
   AssumeRoleCommand,
-  GetCallerIdentityCommand,
+  GetSessionTokenCommand,
   STSClient,
 } from "@aws-sdk/client-sts";
 import {
@@ -72,10 +72,10 @@ describe("simulated STS SDK Command routing", () => {
     simSdk.intercept(client);
 
     const error = await assertThrowsErrorAsync(async () => {
-      await client.send(new GetCallerIdentityCommand({}));
+      await client.send(new GetSessionTokenCommand({}));
     });
 
-    assertStringIncludes(error.message, "GetCallerIdentityCommand");
+    assertStringIncludes(error.message, "GetSessionTokenCommand");
     assertStringIncludes(error.message, "AssumeRoleCommand");
   });
 });

--- a/src/service/sts/sdk/sim-sts-sdk-command-router.ts
+++ b/src/service/sts/sdk/sim-sts-sdk-command-router.ts
@@ -4,6 +4,7 @@ import {
   type SimSdkCommandRouter,
 } from "../../../sdk/index.js";
 import type { SimAssumeRoleCommand } from "../command/assume-role/assume-role.command.js";
+import type { SimGetCallerIdentityCommand } from "../command/get-caller-identity/get-caller-identity.command.js";
 import type { SimSts } from "../sim-sts.js";
 
 /**
@@ -14,6 +15,14 @@ export class SimStsSdkCommandRouter implements SimSdkCommandRouter {
 
   constructor(simSts: SimSts) {
     this.routes = new Map<string, SimSdkCommandRoute>([
+      [
+        "GetCallerIdentityCommand",
+        async (command, context): Promise<unknown> =>
+          await simSts.getCallerIdentity(
+            command as SimGetCallerIdentityCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
       [
         "AssumeRoleCommand",
         async (command, context): Promise<unknown> =>

--- a/src/service/sts/serve/sim-sts-api.loc.test.ts
+++ b/src/service/sts/serve/sim-sts-api.loc.test.ts
@@ -1,0 +1,181 @@
+import {
+  CreateAccessKeyCommand,
+  CreateRoleCommand,
+  CreateUserCommand,
+} from "@aws-sdk/client-iam";
+import {
+  AssumeRoleCommand,
+  GetCallerIdentityCommand,
+  GetSessionTokenCommand,
+  STSClient,
+} from "@aws-sdk/client-sts";
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { afterAll, beforeAll, describe, it } from "vitest";
+
+import { SimAwsLocalServer } from "../../../serve/index.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+
+/**
+ * Simulated STS reached over a port, which is the first call a person makes to
+ * check that credentials and an endpoint are wired up correctly.
+ *
+ * STS speaks the Query protocol, so what these cover is whether an operation
+ * survives a form-encoded request and an XML envelope.
+ */
+describe("Serving simulated STS on an endpoint URL", () => {
+  const simAws = new SimAws();
+  const srv = new SimAwsLocalServer({ simAws });
+
+  let endpoint: string;
+  let client: STSClient;
+  let accountId: string;
+
+  beforeAll(async () => {
+    await srv.listen();
+    endpoint = `http://localhost:${srv.port}`;
+    accountId = simAws.defaultAccountId;
+
+    const simIam = simAws.iam();
+    await simIam.createUser(new CreateUserCommand({ UserName: "Widgets" }));
+    const created = await simIam.createAccessKey(
+      new CreateAccessKeyCommand({ UserName: "Widgets" }),
+    );
+
+    client = new STSClient({
+      region: simAws.defaultRegionName,
+      endpoint,
+      credentials: {
+        accessKeyId: created.AccessKey.AccessKeyId,
+        secretAccessKey: created.AccessKey.SecretAccessKey,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await srv.close();
+  });
+
+  it("reports the principal whose credentials signed the request", async () => {
+    // Given a client signing as an IAM User
+
+    // When it asks who the simulator thinks it is
+    const identity = await client.send(new GetCallerIdentityCommand({}));
+
+    // Then the answer describes that User, read out of the signature alone
+    assertIdentical(identity.Arn, `arn:aws:iam::${accountId}:user/Widgets`);
+    assertIdentical(identity.Account, accountId);
+    assertStringIncludes(identity.UserId ?? "", "AIDA");
+  });
+
+  it("reports an assumed-role session as the session", async () => {
+    // Given a session assumed into a Role, signing with its own credentials
+    await simAws.iam().createRole(
+      new CreateRoleCommand({
+        RoleName: "Nightly",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+    const assumed = await simAws.sts().assumeRole(
+      new AssumeRoleCommand({
+        RoleArn: `arn:aws:iam::${accountId}:role/Nightly`,
+        RoleSessionName: "batch",
+      }),
+    );
+    const session = assumed.Credentials;
+    assertDefined(session, "the assumed session credentials");
+    assertDefined(session.AccessKeyId, "the session access key id");
+    assertDefined(session.SecretAccessKey, "the session secret");
+    assertDefined(session.SessionToken, "the session token");
+
+    const sessionClient = new STSClient({
+      region: simAws.defaultRegionName,
+      endpoint,
+      credentials: {
+        accessKeyId: session.AccessKeyId,
+        secretAccessKey: session.SecretAccessKey,
+        sessionToken: session.SessionToken,
+      },
+    });
+
+    // When the session asks who it is
+    const identity = await sessionClient.send(new GetCallerIdentityCommand({}));
+
+    // Then it is the session that answers, rather than the Role behind it
+    assertIdentical(
+      identity.Arn,
+      `arn:aws:sts::${accountId}:assumed-role/Nightly/batch`,
+    );
+  });
+
+  it("refuses an STS operation it does not serve", async () => {
+    // When an operation simulated STS has no answer for is asked for
+    const error = await assertThrowsErrorAsync(
+      async () => await client.send(new GetSessionTokenCommand({})),
+    );
+
+    // Then it is refused by name, in the shape the Query protocol states an
+    // error, so the SDK raises it rather than failing to parse the response
+    assertIdentical(error.name, "NotImplemented");
+    assertStringIncludes(error.message, "GetSessionToken");
+  });
+
+  it("refuses a signed request that names itself anonymous", async () => {
+    // Given a request signed for STS whose caller header overrides the
+    // identity the signature carries, which is the local-development path
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        "x-sim-aws-caller": "anonymous",
+        authorization: signedStsAuthorization(),
+      },
+      body: "Action=GetCallerIdentity&Version=2011-06-15",
+    });
+
+    // Then it is refused, because a caller with no identity has none to report
+    assertIdentical(response.status, 403);
+    assertStringIncludes(await response.text(), "AccessDenied");
+  });
+
+  it("refuses a request naming no operation at all", async () => {
+    // Given a Query request with no Action field
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        "x-sim-aws-caller": `arn:aws:iam::${accountId}:user/Widgets`,
+        authorization: signedStsAuthorization(),
+      },
+      body: "Version=2011-06-15",
+    });
+
+    // Then it is refused as stating no operation
+    assertIdentical(response.status, 400);
+    assertStringIncludes(await response.text(), "MissingAction");
+  });
+
+  /**
+   * An Authorization header scoped to STS, which is what routes a request to
+   * this endpoint. The signature itself is never verified in these two,
+   * because the caller header they also send wins over it.
+   */
+  function signedStsAuthorization(): string {
+    return (
+      "AWS4-HMAC-SHA256 " +
+      `Credential=AKIAEXAMPLE/20260818/${simAws.defaultRegionName}/sts/aws4_request, ` +
+      "SignedHeaders=host, Signature=0"
+    );
+  }
+});

--- a/src/service/sts/serve/sim-sts-api.ts
+++ b/src/service/sts/serve/sim-sts-api.ts
@@ -1,0 +1,98 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
+import { SimSdkCommandDispatcher } from "../../../sdk/sim-sdk-command-dispatcher.js";
+import {
+  makeSimSdkWireClient,
+  makeSimSdkWireCommand,
+} from "../../../sdk/wire/sim-sdk-wire-command.js";
+import { xmlValue } from "../../../util/xml/xml-writer.js";
+import type { SimGetCallerIdentityCommandOutput } from "../command/get-caller-identity/get-caller-identity.command.js";
+import { readSimStsQueryRequest } from "./sim-sts-query-request.js";
+import {
+  simStsQueryErrorResponse,
+  simStsQueryResponse,
+} from "./sim-sts-query-response.js";
+
+/**
+ * The SDK service id simulated STS's Command router is registered under.
+ */
+const stsServiceId = "STS";
+
+interface SimStsApiEndpointProperties {
+  readonly simAws: SimAws;
+}
+
+/**
+ * Serves the STS API to a client given an endpoint URL.
+ *
+ * STS speaks the Query protocol, which names its operation in a form-encoded
+ * `Action` field rather than in a header or a path. The operation is resolved
+ * from that field and answered from the simulation, as the other served
+ * protocols are, so an HTTP caller reaches the same code an in-process caller
+ * does.
+ */
+export class SimStsApiEndpoint {
+  private readonly dispatcher: SimSdkCommandDispatcher;
+
+  constructor(properties: SimStsApiEndpointProperties) {
+    this.dispatcher = new SimSdkCommandDispatcher(properties.simAws);
+  }
+
+  /**
+   * Answer one STS Query request as the caller that signed it.
+   */
+  async handle(
+    request: Request,
+    body: Uint8Array,
+    caller: SimAwsCaller,
+    regionName: string,
+  ): Promise<Response> {
+    const query = readSimStsQueryRequest(request, body);
+    if (query === undefined) {
+      return simStsQueryErrorResponse(
+        400,
+        "MissingAction",
+        "The request is missing an Action field, which every AWS Query protocol request states.",
+      );
+    }
+
+    if (query.action !== "GetCallerIdentity") {
+      return simStsQueryErrorResponse(
+        501,
+        "NotImplemented",
+        `Simulated STS does not serve ${query.action}`,
+      );
+    }
+
+    try {
+      const identity = (await this.dispatcher.dispatch(
+        makeSimSdkWireCommand(`${query.action}Command`, {}),
+        makeSimSdkWireClient(stsServiceId, regionName),
+        undefined,
+        caller,
+      )) as SimGetCallerIdentityCommandOutput;
+
+      return simStsQueryResponse(query.action, callerIdentityResult(identity));
+    } catch (error) {
+      if (error instanceof SimIamAccessDenied) {
+        return simStsQueryErrorResponse(403, "AccessDenied", error.message);
+      }
+
+      throw error;
+    }
+  }
+}
+
+/**
+ * Write the members GetCallerIdentity answers with.
+ */
+function callerIdentityResult(
+  identity: SimGetCallerIdentityCommandOutput,
+): string {
+  return (
+    xmlValue("UserId", identity.UserId) +
+    xmlValue("Account", identity.Account) +
+    xmlValue("Arn", identity.Arn)
+  );
+}

--- a/src/service/sts/serve/sim-sts-query-request.ts
+++ b/src/service/sts/serve/sim-sts-query-request.ts
@@ -1,0 +1,44 @@
+/**
+ * One AWS Query protocol request, as the form encoding carries it.
+ *
+ * Query is the oldest of the AWS protocols. It states the operation in an
+ * `Action` field and its input in the same form encoding, either in the body
+ * of a POST or in the query string of a GET.
+ */
+export interface SimStsQueryRequest {
+  readonly action: string;
+  readonly fields: URLSearchParams;
+}
+
+/**
+ * Read a request as the Query protocol operation it names.
+ *
+ * Returns undefined when no `Action` is stated, which is what separates a
+ * Query request from anything else that reached the endpoint.
+ */
+export function readSimStsQueryRequest(
+  request: Request,
+  body: Uint8Array,
+): SimStsQueryRequest | undefined {
+  const fields = queryFields(request, body);
+  const action = fields.get("Action");
+
+  return action === null || action.length === 0
+    ? undefined
+    : { action, fields };
+}
+
+/**
+ * The form-encoded fields a request carried, wherever it put them.
+ *
+ * A POST carries them in the body and a GET in the query string, and the
+ * `aws` CLI sends a POST while a browser or a hand-written GET sends the
+ * other. Both are read so that neither has to be the supported one.
+ */
+function queryFields(request: Request, body: Uint8Array): URLSearchParams {
+  if (body.byteLength > 0) {
+    return new URLSearchParams(Buffer.from(body).toString("utf8"));
+  }
+
+  return new URL(request.url).searchParams;
+}

--- a/src/service/sts/serve/sim-sts-query-response.ts
+++ b/src/service/sts/serve/sim-sts-query-response.ts
@@ -1,0 +1,64 @@
+import {
+  escapeXmlText,
+  xmlElement,
+  xmlValue,
+} from "../../../util/xml/xml-writer.js";
+
+/**
+ * The XML namespace real STS stamps on every response it sends.
+ */
+const stsNamespace = "https://sts.amazonaws.com/doc/2011-06-15/";
+
+/**
+ * Write a Query protocol response, which wraps a result in an envelope named
+ * after the operation.
+ *
+ * Every Query response has this shape: `<XResponse><XResult>...</XResult>` and
+ * a `ResponseMetadata` holding the request id. An SDK reads the operation's
+ * output out of the inner element, so the envelope has to carry the operation
+ * name rather than a generic one.
+ */
+export function simStsQueryResponse(action: string, result: string): Response {
+  const metadata = xmlElement(
+    "ResponseMetadata",
+    xmlValue("RequestId", simStsRequestId()),
+  );
+  const envelope = `${xmlElement(`${action}Result`, result)}${metadata}`;
+  const body = `<?xml version="1.0" encoding="UTF-8"?><${action}Response xmlns="${escapeXmlText(stsNamespace)}">${envelope}</${action}Response>`;
+
+  return new Response(body, {
+    status: 200,
+    headers: { "content-type": "text/xml" },
+  });
+}
+
+/**
+ * Write a Query protocol failure, which an SDK reads the error name out of.
+ */
+export function simStsQueryErrorResponse(
+  status: number,
+  code: string,
+  message: string,
+): Response {
+  const error = xmlElement(
+    "Error",
+    `${xmlValue("Type", "Sender")}${xmlValue("Code", code)}${xmlValue("Message", message)}`,
+  );
+  const envelope = xmlElement(
+    "ErrorResponse",
+    `${error}${xmlValue("RequestId", simStsRequestId())}`,
+  );
+  const body = `<?xml version="1.0" encoding="UTF-8"?>${envelope}`;
+
+  return new Response(body, {
+    status,
+    headers: { "content-type": "text/xml" },
+  });
+}
+
+/**
+ * A request id, which every Query response carries and nothing reads back.
+ */
+function simStsRequestId(): string {
+  return "00000000-0000-0000-0000-000000000000";
+}

--- a/src/service/sts/sim-sts.ts
+++ b/src/service/sts/sim-sts.ts
@@ -8,6 +8,11 @@ import type {
   SimAssumeRoleCommandOutput,
 } from "./command/assume-role/assume-role.command.js";
 import { AssumeRoleCommandHandler } from "./command/assume-role/assume-role.handler.js";
+import type {
+  SimGetCallerIdentityCommand,
+  SimGetCallerIdentityCommandOutput,
+} from "./command/get-caller-identity/get-caller-identity.command.js";
+import { GetCallerIdentityCommandHandler } from "./command/get-caller-identity/get-caller-identity.handler.js";
 import { SimIamRegistry } from "../iam/registry/sim-iam-registry.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
@@ -55,6 +60,23 @@ export class SimSts {
       iamResolver: this.iamResolver,
       background: this.background,
     });
+    return await handler.handle(command, options);
+  }
+
+  /**
+   * Handle a GetCallerIdentityCommand from the SDK.
+   */
+  async getCallerIdentity(
+    command: SimGetCallerIdentityCommand,
+    options?: {
+      caller?: SimAwsCaller;
+    },
+  ): Promise<SimGetCallerIdentityCommandOutput> {
+    const handler = new GetCallerIdentityCommandHandler({
+      sourceAccountId: this.accountRegionScope.accountId,
+      iamResolver: this.iamResolver,
+    });
+
     return await handler.handle(command, options);
   }
 


### PR DESCRIPTION
`aws sts get-caller-identity` against a served simulated environment now reports the principal whose credentials signed the request. That is the first call a person makes to check an endpoint and a set of credentials are wired up as they expect, and it needed two things that were both missing.

Resolves https://github.com/KensioSoftware/yulin/issues/674

## Simulated STS gains GetCallerIdentity

Reachable in process and through SDK interception as well as over HTTP. It answers the caller's ARN, the Account that ARN names, and the unique id STS reports for it. That id is the Account id for the root, the User's own id for an IAM User, and the Role's id joined to the session name for an assumed-role session.

Each id is looked up rather than invented. A principal with no simulated record behind it gets no id at all. The operation authorizes nothing, matching real STS, which is what makes it usable for checking credentials that have no permissions yet.

## The served endpoint gains the Query protocol

Query states its operation in a form-encoded `Action` field and answers in an XML envelope named after that operation. A refusal is written in the same shape, which is what lets an SDK raise it by name instead of failing to parse the response.

## Worth a reviewer's attention

**The issue's implementation notes are out of date, in the same way #673's were.** They describe reading a Query request from the SDK's operation schemas. #673 landed hand-written instead, for the runtime-dependency reason recorded there. This reuses that PR's XML writer and hand-reads the form encoding. There is no form-encoding parser to write, since `URLSearchParams` is the form encoding.

**Simulated IAM gains one `@internal` accessor.** `SimIam.users` is now exposed the way `SimIam.roles` already was, so STS can read a User's own id without a new public IAM operation.

**Two existing tests used STS as their example of something unsupported**, which it no longer is. The STS router test now uses `GetSessionToken`, and the endpoint's unreadable-protocol test now uses the Lambda control plane, which speaks REST-JSON.

Verified against the real CLI. `aws sts get-caller-identity` answers, `aws sts get-session-token` is refused as `NotImplemented`, and the same unprivileged user gets `AccessDenied` from S3 and DynamoDB, which confirms the operation needs no permission of its own.

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added STS support to the simulated AWS API.
  * Added `GetCallerIdentity`, including IAM user, root, and assumed-role identity details.
  * Added HTTP Query protocol support with AWS-compatible XML responses and error handling.
  * Documented STS availability and unsupported-operation behavior.

* **Bug Fixes**
  * Improved rejection handling for unsupported protocols and STS operations.

* **Tests**
  * Added coverage for caller identity scenarios, authorization, anonymous access, invalid requests, and endpoint integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->