### PR TITLE
fix: record when a simulated S3 Bucket was created

### DIFF
--- a/docs/serve/README.md
+++ b/docs/serve/README.md
@@ -799,6 +799,5 @@ it is without watch mode.
 - The IDE run configurations for attaching a debugger to a watched process are not documented yet.
 - The served AWS service API covers S3, STS and the AWS JSON protocol services. A service speaking REST-JSON, or Query other than STS, is refused with `501 Not Implemented`.
 - `GetCallerIdentity` is the only STS operation served. `AssumeRole` over a port would mean the temporary credentials it issues have to sign the calls that follow, which is its own piece of work.
-- `aws s3 ls` with no Bucket fails, because simulated S3 records no creation date for a Bucket and the CLI reads one from every entry. `aws s3api list-buckets` and `aws s3 ls s3://bucket/` both work.
 - Simulated S3 implements no `HeadObject` or `HeadBucket`, so both are refused. `aws s3 cp` reads an Object with `HeadObject` before copying it, which puts that out of reach too.
 - A served AWS API request is routed by its SigV4 credential scope. An unsigned one reaches nothing, whatever endpoint URL it used.

--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -112,7 +112,7 @@ all tests, as you prefer.
 
 ## Listing Buckets
 
-Use `ListBucketsCommand` to inspect Buckets in the selected simulated S3 scope.
+Use `ListBucketsCommand` to inspect Buckets in the selected simulated S3 scope. Each Bucket reports the instant it was created, taken from [simulated time](../../time/README.md) rather than the host clock.
 
 ```typescript sim-s3-list-buckets
 /**
@@ -134,6 +134,7 @@ await simS3.createBucket(
 const listBucketsOutput = await simS3.listBuckets(new ListBucketsCommand());
 
 console.log(listBucketsOutput.Buckets?.map((bucket) => bucket.Name));
+console.log(listBucketsOutput.Buckets?.[0]?.CreationDate);
 ```
 
 ## Listing Objects

--- a/docs/services/s3/sim-s3-list-buckets.example.ts
+++ b/docs/services/s3/sim-s3-list-buckets.example.ts
@@ -17,3 +17,4 @@ await simS3.createBucket(
 const listBucketsOutput = await simS3.listBuckets(new ListBucketsCommand());
 
 console.log(listBucketsOutput.Buckets?.map((bucket) => bucket.Name));
+console.log(listBucketsOutput.Buckets?.[0]?.CreationDate);

--- a/src/service/s3/bucket/sim-s3-bucket.ts
+++ b/src/service/s3/bucket/sim-s3-bucket.ts
@@ -1,3 +1,4 @@
+import { BackgroundTasks } from "../../../util/background/background.js";
 import type { Brand } from "../../../util/brand.type.js";
 import type { SimS3BucketStorage } from "../storage/s3-bucket-storage.js";
 import type { SimS3Object } from "../object/s3-object.js";
@@ -22,6 +23,13 @@ interface SimS3BucketProperties {
   readonly policy?: SimIamPolicyDocument | undefined;
   readonly publicAccessBlock?: SimS3PublicAccessBlock;
   readonly notifications?: SimS3NotificationConfiguration;
+  /**
+   * When the Bucket came into being, in simulated time.
+   *
+   * Real S3 reports this on every Bucket a listing returns, and the `aws` CLI
+   * reads it from each entry, so a Bucket without one cannot be listed.
+   */
+  readonly creationDate?: Date;
 }
 
 /**
@@ -29,6 +37,7 @@ interface SimS3BucketProperties {
  */
 export class SimS3Bucket {
   public readonly bucketName: SimS3BucketName;
+  public readonly creationDate: Date;
 
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly systemMetadata = new SimS3BucketSystemMetadata();
@@ -47,6 +56,7 @@ export class SimS3Bucket {
       policy,
       publicAccessBlock = SimS3PublicAccessBlock.blockingAll(),
       notifications = SimS3NotificationConfiguration.empty(),
+      creationDate = new BackgroundTasks().now(),
     } = properties;
 
     validateS3BucketName(bucketName);
@@ -58,6 +68,7 @@ export class SimS3Bucket {
     this.policy = policy;
     this.publicAccessBlock = publicAccessBlock;
     this.notifications = notifications;
+    this.creationDate = creationDate;
   }
 
   /**

--- a/src/service/s3/command/create-bucket/create-bucket.handler.ts
+++ b/src/service/s3/command/create-bucket/create-bucket.handler.ts
@@ -103,6 +103,7 @@ export class CreateBucketCommandHandler implements CommandHandler<
     const bucket = new SimS3Bucket({
       bucketName,
       accountRegionScope: this.accountRegionScope,
+      creationDate: this.background.now(),
     });
     this.buckets.set(bucketName, bucket);
     this.s3GlobalRegistry.registerBucket(bucketName, this.accountRegionScope);

--- a/src/service/s3/command/list-buckets/list-buckets-creation-date.iso.test.ts
+++ b/src/service/s3/command/list-buckets/list-buckets-creation-date.iso.test.ts
@@ -1,0 +1,67 @@
+import { CreateBucketCommand, ListBucketsCommand } from "@aws-sdk/client-s3";
+import { assertArrayLength, assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimFixedClock } from "../../../../util/clock/sim-clock.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+
+/**
+ * When a listing says a Bucket was created.
+ *
+ * Real S3 states this on every Bucket it lists, and the `aws` CLI reads it
+ * from each entry, so a Bucket without one cannot be listed at all.
+ */
+describe("Simulated S3 Bucket creation dates", () => {
+  it("records the instant simulated time was at, rather than the host clock's", async () => {
+    // Given a simulation whose clock is stopped somewhere the host clock is not
+    const instant = new Date("2026-07-26T09:00:00.000Z");
+    const simAws = new SimAws({ clock: new SimFixedClock(instant) });
+
+    // When a Bucket is created and then listed
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "widgets" }));
+    const listed = await simAws.s3().listBuckets(new ListBucketsCommand({}));
+
+    // Then the listing reports the simulation's instant
+    assertDefined(listed.Buckets, "the listed Buckets");
+    assertArrayLength(listed.Buckets, 1);
+    const [listedBucket] = listed.Buckets;
+    assertDefined(listedBucket, "the listed Bucket");
+    assertIdentical(
+      listedBucket.CreationDate?.toISOString(),
+      instant.toISOString(),
+    );
+  });
+
+  it("keeps the instant each Bucket was created at as the clock moves", async () => {
+    // Given a simulation whose clock moves between two Bucket creations
+    const simAws = new SimAws({
+      clock: new SimFixedClock(new Date("2026-07-26T09:00:00.000Z")),
+    });
+
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "first" }));
+    await simAws.clock().advanceBy({ hours: 3 });
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "second" }));
+
+    // When both are listed
+    const listed = await simAws.s3().listBuckets(new ListBucketsCommand({}));
+
+    // Then each reports when it was made rather than when the listing ran
+    assertDefined(listed.Buckets, "the listed Buckets");
+    const dates = new Map(
+      listed.Buckets.map((bucket) => [
+        bucket.Name,
+        bucket.CreationDate?.toISOString(),
+      ]),
+    );
+
+    assertIdentical(dates.get("first"), "2026-07-26T09:00:00.000Z");
+    assertIdentical(dates.get("second"), "2026-07-26T12:00:00.000Z");
+  });
+});

--- a/src/service/s3/command/list-buckets/list-buckets-page-builder.ts
+++ b/src/service/s3/command/list-buckets/list-buckets-page-builder.ts
@@ -53,6 +53,7 @@ export class ListBucketsPageBuilder {
     return {
       Buckets: page.map((bucket) => ({
         Name: bucket.bucketName,
+        CreationDate: bucket.creationDate,
       })),
       ContinuationToken: this.nextContinuationToken(
         page,

--- a/src/service/s3/command/list-buckets/list-buckets.command.ts
+++ b/src/service/s3/command/list-buckets/list-buckets.command.ts
@@ -31,4 +31,5 @@ export interface SimListBucketsCommandOutput {
  */
 export interface SimS3BucketSummary {
   readonly Name?: string | undefined;
+  readonly CreationDate?: Date | undefined;
 }

--- a/src/service/s3/serve/api/sim-s3-api-listing.ts
+++ b/src/service/s3/serve/api/sim-s3-api-listing.ts
@@ -4,6 +4,11 @@ import {
   xmlValue,
 } from "../../../../util/xml/xml-writer.js";
 
+interface BucketSummary {
+  readonly Name?: string | undefined;
+  readonly CreationDate?: Date | undefined;
+}
+
 interface ObjectSummary {
   readonly Key?: string | undefined;
   readonly Size?: number | undefined;
@@ -27,9 +32,7 @@ interface ListObjectsOutput {
 }
 
 interface ListBucketsOutput {
-  readonly Buckets?:
-    | readonly { readonly Name?: string | undefined }[]
-    | undefined;
+  readonly Buckets?: readonly BucketSummary[] | undefined;
   readonly ContinuationToken?: string | undefined;
   readonly Prefix?: string | undefined;
 }
@@ -39,7 +42,13 @@ interface ListBucketsOutput {
  */
 export function simS3ListBucketsXml(output: ListBucketsOutput): string {
   const buckets = (output.Buckets ?? [])
-    .map((bucket) => xmlElement("Bucket", xmlValue("Name", bucket.Name)))
+    .map((bucket) =>
+      xmlElement(
+        "Bucket",
+        xmlValue("Name", bucket.Name) +
+          xmlValue("CreationDate", bucket.CreationDate),
+      ),
+    )
     .join("");
 
   return xmlDocument(


### PR DESCRIPTION
Real S3 states a creation date on every Bucket a listing returns, and the `aws` CLI reads one from each entry, so `aws s3 ls` failed outright against a simulation instead of printing a blank column. A Bucket now records when it came into being, and ListBuckets reports it.

Resolves https://github.com/KensioSoftware/yulin/issues/677

## The instant comes from simulated time

`SimS3` already takes the background scheduler that every other time-aware simulated service takes, so nothing new had to be threaded through. The one path that really creates a Bucket passes `background.now()`, which means a test that freezes or moves the clock sees the listing it expects rather than whatever the host clock said.

Two tests cover that. One asserts the recorded instant against a `SimFixedClock` the host clock is nowhere near. The other advances the clock between two Buckets and checks each keeps its own instant.

## Worth a reviewer's attention

`SimS3Bucket` takes `creationDate` as an optional property defaulting to `new BackgroundTasks().now()`, the way it already defaults `storage`, `website` and the rest of its collaborators. That keeps the twenty-odd direct constructions in tests untouched. The one production caller passes the scheduler's instant explicitly, so the default never applies to a Bucket a caller actually created.

Verified with the real CLI. `aws s3 ls` lists both Buckets with their dates, and `aws s3api list-buckets` reports `CreationDate` on each.

## Follows on from

The gap surfaced while serving the S3 REST API in #676, where it was the one thing keeping `aws s3 ls` from working. `docs/serve` loses that limitation here.

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`
