### PR TITLE
feat: describe a simulated S3 Object or Bucket without reading it

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -733,6 +733,17 @@
       }
     },
     {
+      // A service facade is one delegation per operation the service supports,
+      // so it grows with the service rather than with any complexity of its
+      // own. Simulated S3 supports the most operations and passed 300 lines
+      // first. The facade is due a split between the AWS operations and the
+      // simulator-only controls, and this holds until then.
+      "files": ["src/service/s3/sim-s3.ts"],
+      "rules": {
+        "eslint/max-lines": ["error", 340]
+      }
+    },
+    {
       "files": ["scripts/**/*.mts"],
       "rules": {
         "eslint/no-await-in-loop": "off",

--- a/docs/serve/README.md
+++ b/docs/serve/README.md
@@ -290,7 +290,7 @@ const client = new S3Client({
 });
 ```
 
-The operations served are the ones simulated S3 implements: `CreateBucket`, `DeleteBucket`, `ListBuckets`, `ListObjects`, `ListObjectsV2`, `GetObject`, `PutObject`, `DeleteObject`, `DeleteObjects`, and the Bucket policy, website, Block Public Access and event notification configurations. Anything else is refused as `NotImplemented`, which an SDK raises under that name rather than leaving a client to guess.
+The operations served are the ones simulated S3 implements: `CreateBucket`, `DeleteBucket`, `HeadBucket`, `ListBuckets`, `ListObjects`, `ListObjectsV2`, `GetObject`, `HeadObject`, `PutObject`, `DeleteObject`, `DeleteObjects`, and the Bucket policy, website, Block Public Access and event notification configurations. `aws s3 cp` works in both directions. Anything else is refused as `NotImplemented`, which an SDK raises under that name rather than leaving a client to guess.
 
 Simulated S3 also answers its own Bucket hostnames, covered above. That path is unchanged, and it is what a presigned URL and a website visitor use.
 
@@ -799,5 +799,4 @@ it is without watch mode.
 - The IDE run configurations for attaching a debugger to a watched process are not documented yet.
 - The served AWS service API covers S3, STS and the AWS JSON protocol services. A service speaking REST-JSON, or Query other than STS, is refused with `501 Not Implemented`.
 - `GetCallerIdentity` is the only STS operation served. `AssumeRole` over a port would mean the temporary credentials it issues have to sign the calls that follow, which is its own piece of work.
-- Simulated S3 implements no `HeadObject` or `HeadBucket`, so both are refused. `aws s3 cp` reads an Object with `HeadObject` before copying it, which puts that out of reach too.
 - A served AWS API request is routed by its SigV4 credential scope. An unsigned one reaches nothing, whatever endpoint URL it used.

--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -141,7 +141,7 @@ console.log(listBucketsOutput.Buckets?.[0]?.CreationDate);
 
 `HeadObjectCommand` reports what a read would say about an Object without returning the Object, and `HeadBucketCommand` reports whether a Bucket is there and reachable. `HeadBucket` also reports the Region it was found in.
 
-A HEAD response carries no body, so there is no document for an error code to travel in. Real S3 answers one of a few generic statuses and leaves the SDK to name the failure. The simulator answers `404` for an absent Bucket and an absent Object alike, which an SDK client raises as `NotFound`. A read distinguishes `NoSuchBucket` from `NoSuchKey`, because a read has a body to say which.
+A HEAD response carries no body, so there is no document for an error code to travel in. Real S3 answers a `HeadObject` with `403` or `404`, and a `HeadBucket` with `400`, `403` or `404`, leaving the SDK to name the failure from the status alone. The simulator answers `404` for an absent Bucket and an absent Object alike, which an SDK client raises as `NotFound`, and `403` for a caller the permission is missing for. A read distinguishes `NoSuchBucket` from `NoSuchKey`, because a read has a body to say which.
 
 `HeadObject` authorizes against `s3:GetObject` and `HeadBucket` against `s3:ListBucket`, as real S3 does, so knowing something is there needs the permission to read it.
 

--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -139,7 +139,9 @@ console.log(listBucketsOutput.Buckets?.[0]?.CreationDate);
 
 ## Asking whether something is there
 
-`HeadObjectCommand` reports what a read would say about an Object without returning the Object, and `HeadBucketCommand` reports whether a Bucket is there and reachable. Both answer `NotFound` when it is absent, which is what real S3 answers a HEAD with. A read answers `NoSuchKey`, which a HEAD has no body to carry.
+`HeadObjectCommand` reports what a read would say about an Object without returning the Object, and `HeadBucketCommand` reports whether a Bucket is there and reachable. `HeadBucket` also reports the Region it was found in.
+
+A HEAD response carries no body, so there is no document for an error code to travel in. Real S3 answers one of a few generic statuses and leaves the SDK to name the failure. The simulator answers `404` for an absent Bucket and an absent Object alike, which an SDK client raises as `NotFound`. A read distinguishes `NoSuchBucket` from `NoSuchKey`, because a read has a body to say which.
 
 `HeadObject` authorizes against `s3:GetObject` and `HeadBucket` against `s3:ListBucket`, as real S3 does, so knowing something is there needs the permission to read it.
 

--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -137,6 +137,12 @@ console.log(listBucketsOutput.Buckets?.map((bucket) => bucket.Name));
 console.log(listBucketsOutput.Buckets?.[0]?.CreationDate);
 ```
 
+## Asking whether something is there
+
+`HeadObjectCommand` reports what a read would say about an Object without returning the Object, and `HeadBucketCommand` reports whether a Bucket is there and reachable. Both answer `NotFound` when it is absent, which is what real S3 answers a HEAD with. A read answers `NoSuchKey`, which a HEAD has no body to carry.
+
+`HeadObject` authorizes against `s3:GetObject` and `HeadBucket` against `s3:ListBucket`, as real S3 does, so knowing something is there needs the permission to read it.
+
 ## Listing Objects
 
 Use `ListObjectsV2Command` to list the Objects in a Bucket. The simulator supports `Prefix`,

--- a/src/sdk/sim-sdk.iso.test.ts
+++ b/src/sdk/sim-sdk.iso.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "vitest";
 import {
   CreateBucketCommand,
   GetObjectCommand,
-  HeadObjectCommand,
+  GetBucketAclCommand,
   ListBucketsCommand,
   PutObjectCommand,
   S3Client,
@@ -234,12 +234,10 @@ describe("simulated AWS SDK", () => {
     simSdk.intercept(client);
 
     const error = await assertThrowsErrorAsync(async () => {
-      await client.send(
-        new HeadObjectCommand({ Bucket: "bucket-a", Key: "foo.txt" }),
-      );
+      await client.send(new GetBucketAclCommand({ Bucket: "bucket-a" }));
     });
 
-    assertStringIncludes(error.message, "HeadObjectCommand");
+    assertStringIncludes(error.message, "GetBucketAclCommand");
     assertStringIncludes(error.message, "GetObjectCommand");
   });
 

--- a/src/service/s3/command/bucket/sim-s3-bucket-commands.ts
+++ b/src/service/s3/command/bucket/sim-s3-bucket-commands.ts
@@ -2,6 +2,7 @@ import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-regi
 import type { SimS3GlobalRegistry } from "../../sim-s3-global-registry.js";
 import { CreateBucketCommandHandler } from "../create-bucket/create-bucket.handler.js";
 import { DeleteBucketCommandHandler } from "../delete-bucket/delete-bucket.handler.js";
+import { HeadBucketCommandHandler } from "../head-bucket/head-bucket.handler.js";
 import { ListBucketsCommandHandler } from "../list-buckets/list-buckets.handler.js";
 import { PutBucketWebsiteCommandHandler } from "../put-bucket-website/put-bucket-website.handler.js";
 import type { SimS3BucketCommandState } from "../sim-s3-bucket-command-state.js";
@@ -56,6 +57,16 @@ export class SimS3BucketCommands {
   /**
    * List the Buckets this scope owns.
    */
+  async head(
+    command: simS3Commands.SimHeadBucketCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimHeadBucketCommandOutput> {
+    return await new HeadBucketCommandHandler(this.properties).handle(
+      command,
+      options,
+    );
+  }
+
   async list(
     command: simS3Commands.SimListBucketsCommand,
     options?: SimS3RequestOptions,

--- a/src/service/s3/command/head-bucket/head-bucket-authorizer.ts
+++ b/src/service/s3/command/head-bucket/head-bucket-authorizer.ts
@@ -1,0 +1,60 @@
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
+import { simS3ConditionContext } from "../authorize/sim-s3-condition-context.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
+
+interface HeadBucketAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * Applies IAM authorization to an S3 HeadBucket request.
+ *
+ * Real S3 authorizes this against `s3:ListBucket`, since knowing a Bucket is
+ * there is the same knowledge a listing gives away. It shares the action with
+ * a listing and not the condition keys: a HeadBucket names no prefix and asks
+ * for no keys, so `s3:prefix` and `s3:max-keys` are absent rather than empty,
+ * and a policy conditioned on either does not match one.
+ */
+export class HeadBucketAuthorizer {
+  private static readonly action = "s3:ListBucket";
+
+  private readonly iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: HeadBucketAuthorizerProperties) {
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Ensure the caller may know this Bucket is there.
+   */
+  authorize(bucket: SimS3Bucket, options?: SimS3RequestOptions): void {
+    const resource = `arn:aws:s3:::${bucket.bucketName}`;
+    const policy = bucket.getPolicy();
+    const decision = this.iam.authorize({
+      action: HeadBucketAuthorizer.action,
+      resource,
+      caller: options?.caller,
+      conditionContext: simS3ConditionContext(options),
+      resourcePolicies:
+        policy === undefined
+          ? []
+          : [
+              {
+                document: policy,
+                policyName: "BucketPolicy",
+                resourceArn: resource,
+              },
+            ],
+    });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action: HeadBucketAuthorizer.action,
+        resource,
+      });
+    }
+  }
+}

--- a/src/service/s3/command/head-bucket/head-bucket.command.ts
+++ b/src/service/s3/command/head-bucket/head-bucket.command.ts
@@ -1,0 +1,26 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim S3 HeadBucket command.
+ */
+export interface SimHeadBucketCommand {
+  readonly input: SimHeadBucketCommandInput;
+}
+
+/**
+ * Minimal structural sim S3 HeadBucket input.
+ */
+export interface SimHeadBucketCommandInput {
+  readonly Bucket?: string | undefined;
+}
+
+/**
+ * Minimal structural sim S3 HeadBucket output.
+ *
+ * The operation answers whether the Bucket is there and reachable, so a
+ * successful answer carries nothing beyond the Region it was found in.
+ */
+export interface SimHeadBucketCommandOutput {
+  readonly BucketRegion?: string;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/s3/command/head-bucket/head-bucket.handler.ts
+++ b/src/service/s3/command/head-bucket/head-bucket.handler.ts
@@ -1,0 +1,86 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type {
+  SimS3Bucket,
+  SimS3BucketName,
+} from "../../bucket/sim-s3-bucket.js";
+import { SimS3NotFound } from "../../error/sim-s3.error.js";
+import { HeadBucketAuthorizer } from "./head-bucket-authorizer.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
+import type {
+  SimHeadBucketCommand,
+  SimHeadBucketCommandOutput,
+} from "./head-bucket.command.js";
+
+interface HeadBucketCommandHandlerProperties {
+  readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * Simulated S3 HeadBucketCommand handler.
+ *
+ * Real S3 authorizes this against `s3:ListBucket`, the same permission a
+ * listing needs, because knowing a Bucket is there is the same knowledge a
+ * listing would give away.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/s3/command/HeadBucketCommand/
+ */
+export class HeadBucketCommandHandler implements CommandHandler<
+  SimHeadBucketCommand,
+  SimHeadBucketCommandOutput
+> {
+  private readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+  private readonly authorizer: HeadBucketAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: HeadBucketCommandHandlerProperties) {
+    const {
+      buckets,
+      accountRegionScope,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+    this.buckets = buckets;
+    this.accountRegionScope = accountRegionScope;
+    this.authorizer = new HeadBucketAuthorizer({ iam });
+    this.background = background;
+  }
+
+  /**
+   * Report whether the Bucket is there and the caller may reach it.
+   */
+  async handle(
+    command: SimHeadBucketCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimHeadBucketCommandOutput> {
+    assertDefined(command.input.Bucket, "HeadBucketCommand.input.Bucket");
+
+    const bucketName = command.input.Bucket as SimS3BucketName;
+    const bucket = this.buckets.get(bucketName);
+    if (bucket === undefined) {
+      throw new SimS3NotFound(`No S3 Bucket named ${bucketName}`);
+    }
+
+    await this.background.sequence();
+
+    this.authorizer.authorize(bucket, options);
+
+    return {
+      BucketRegion: this.accountRegionScope.regionName,
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/s3/command/head-object/head-object-loader.ts
+++ b/src/service/s3/command/head-object/head-object-loader.ts
@@ -1,0 +1,35 @@
+import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
+import { SimS3NotFound } from "../../error/sim-s3.error.js";
+import { simS3QuotedETag } from "../../object/s3-object-etag.js";
+import type { SimHeadObjectCommandOutput } from "./head-object.command.js";
+
+/**
+ * Describes an authorized S3 Object without reading it out.
+ *
+ * The command handler authorizes before calling this, which is what keeps a
+ * denied caller from learning whether a key exists. What comes back is what a
+ * read would have said about the Object, with the length it would have sent in
+ * place of the body itself.
+ */
+export class HeadObjectLoader {
+  /**
+   * Describe an Object in the resolved Bucket.
+   */
+  async describe(
+    bucket: SimS3Bucket,
+    key: string,
+  ): Promise<SimHeadObjectCommandOutput> {
+    const object = await bucket.getObject(key);
+    if (object === undefined) {
+      throw new SimS3NotFound(`No S3 Object named ${key}`);
+    }
+
+    return {
+      ContentLength: object.body.length,
+      Metadata: object.metadata.values,
+      ETag: simS3QuotedETag(object.etag),
+      LastModified: object.lastModified,
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/s3/command/head-object/head-object.command.ts
+++ b/src/service/s3/command/head-object/head-object.command.ts
@@ -1,0 +1,31 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim S3 HeadObject command.
+ */
+export interface SimHeadObjectCommand {
+  readonly input: SimHeadObjectCommandInput;
+}
+
+/**
+ * Minimal structural sim S3 HeadObject input.
+ */
+export interface SimHeadObjectCommandInput {
+  readonly Bucket?: string | undefined;
+  readonly Key?: string | undefined;
+}
+
+/**
+ * Minimal structural sim S3 HeadObject output.
+ *
+ * A HEAD answers with what a read would have said about the Object and none of
+ * the Object itself, so this is a GetObject output without its body and with
+ * the length that body would have had.
+ */
+export interface SimHeadObjectCommandOutput {
+  readonly ContentLength?: number;
+  readonly Metadata?: Record<string, string>;
+  readonly ETag?: string;
+  readonly LastModified?: Date;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/s3/command/head-object/head-object.handler.ts
+++ b/src/service/s3/command/head-object/head-object.handler.ts
@@ -1,0 +1,88 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type {
+  SimS3Bucket,
+  SimS3BucketName,
+} from "../../bucket/sim-s3-bucket.js";
+import { SimS3NotFound } from "../../error/sim-s3.error.js";
+import { GetObjectAuthorizer } from "../get-object/get-object-authorizer.js";
+import { HeadObjectLoader } from "./head-object-loader.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
+import type {
+  SimHeadObjectCommand,
+  SimHeadObjectCommandOutput,
+} from "./head-object.command.js";
+
+interface HeadObjectCommandHandlerProperties {
+  readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * Simulated S3 HeadObjectCommand handler.
+ *
+ * A HEAD is a read whose response stops short of the Object, so this
+ * authorizes against `s3:GetObject` exactly as GetObject does. Real S3 does
+ * the same, which is why a caller allowed to read an Object can also ask
+ * whether it is there.
+ *
+ * A Bucket that does not exist and an Object that does not exist are both
+ * NotFound here. A HEAD response carries no body, so a client has only the
+ * status to read, and real S3 makes no distinction it could not express.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/s3/command/HeadObjectCommand/
+ */
+export class HeadObjectCommandHandler implements CommandHandler<
+  SimHeadObjectCommand,
+  SimHeadObjectCommandOutput
+> {
+  private readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  private readonly authorizer: GetObjectAuthorizer;
+  private readonly loader = new HeadObjectLoader();
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: HeadObjectCommandHandlerProperties) {
+    const {
+      buckets,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+    this.buckets = buckets;
+    this.authorizer = new GetObjectAuthorizer({ iam });
+    this.background = background;
+  }
+
+  /**
+   * Report what a read of this Object would have said about it.
+   */
+  async handle(
+    command: SimHeadObjectCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimHeadObjectCommandOutput> {
+    assertDefined(command.input.Bucket, "HeadObjectCommand.input.Bucket");
+    assertDefined(command.input.Key, "HeadObjectCommand.input.Key");
+
+    const bucketName = command.input.Bucket as SimS3BucketName;
+    const bucket = this.buckets.get(bucketName);
+    if (bucket === undefined) {
+      throw new SimS3NotFound(`No S3 Bucket named ${bucketName}`);
+    }
+
+    await this.background.sequence();
+
+    // Authorization runs before the key is looked up, so a denied caller
+    // cannot learn whether an Object exists.
+    this.authorizer.authorize(bucket, command.input.Key, options);
+
+    return await this.loader.describe(bucket, command.input.Key);
+  }
+}

--- a/src/service/s3/command/head-object/head-object.iso.test.ts
+++ b/src/service/s3/command/head-object/head-object.iso.test.ts
@@ -1,0 +1,109 @@
+import {
+  CreateBucketCommand,
+  HeadBucketCommand,
+  HeadObjectCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+
+/**
+ * Asking whether an Object or a Bucket is there, without reading it.
+ *
+ * A HEAD response carries no body, so everything a caller learns is the status
+ * and the headers. That is what makes the error shape matter here.
+ */
+describe("Simulated S3 HEAD operations", () => {
+  async function simulationWithObject(): Promise<SimAws> {
+    const simAws = new SimAws();
+    const simS3 = simAws.s3();
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "widgets" }));
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "widgets",
+        Key: "one.txt",
+        Body: "twelve chars",
+        ContentType: "text/plain",
+      }),
+    );
+
+    return simAws;
+  }
+
+  it("reports an Object's size, ETag and metadata without its body", async () => {
+    // Given a Bucket holding an Object
+    const simAws = await simulationWithObject();
+
+    // When it is asked about rather than read
+    const head = await simAws
+      .s3()
+      .headObject(new HeadObjectCommand({ Bucket: "widgets", Key: "one.txt" }));
+
+    // Then it describes the Object that a read would have returned
+    assertIdentical(head.ContentLength, 12);
+    assertStringIncludes(head.ETag ?? "", '"');
+    assertInstanceOf(head.LastModified, Date);
+  });
+
+  it("reports an absent Object as NotFound rather than NoSuchKey", async () => {
+    // Given a Bucket with nothing under the key asked for
+    const simAws = await simulationWithObject();
+
+    // When an absent Object is asked about
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws
+          .s3()
+          .headObject(
+            new HeadObjectCommand({ Bucket: "widgets", Key: "gone" }),
+          ),
+    );
+
+    // Then the error is the one real S3 answers a HEAD with. A read answers
+    // NoSuchKey, which a HEAD has no body to say.
+    assertIdentical(error.name, "NotFound");
+  });
+
+  it("reports an absent Bucket as NotFound for both operations", async () => {
+    // Given a simulation with no Buckets at all
+    const simAws = new SimAws();
+
+    const bucketError = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.s3().headBucket(new HeadBucketCommand({ Bucket: "gone" })),
+    );
+    const objectError = await assertThrowsErrorAsync(
+      async () =>
+        await simAws
+          .s3()
+          .headObject(new HeadObjectCommand({ Bucket: "gone", Key: "one" })),
+    );
+
+    // Then neither leaks which of the two was missing
+    assertIdentical(bucketError.name, "NotFound");
+    assertIdentical(objectError.name, "NotFound");
+  });
+
+  it("answers a Bucket that is there with the Region it was found in", async () => {
+    // Given a Bucket in a known Region
+    const simAws = new SimAws();
+    const simS3 = simAws.region("eu-west-2").s3();
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "widgets" }));
+
+    // When it is asked about
+    const head = await simS3.headBucket(
+      new HeadBucketCommand({ Bucket: "widgets" }),
+    );
+
+    // Then the Region comes back, as real S3 reports it
+    assertIdentical(head.BucketRegion, "eu-west-2");
+  });
+});

--- a/src/service/s3/command/object/sim-s3-object-commands.ts
+++ b/src/service/s3/command/object/sim-s3-object-commands.ts
@@ -1,6 +1,7 @@
 import { DeleteObjectCommandHandler } from "../delete-object/delete-object.handler.js";
 import { DeleteObjectsCommandHandler } from "../delete-objects/delete-objects.handler.js";
 import { GetObjectCommandHandler } from "../get-object/get-object.handler.js";
+import { HeadObjectCommandHandler } from "../head-object/head-object.handler.js";
 import { ListObjectsCommandHandler } from "../list-objects/list-objects.handler.js";
 import { ListObjectsV2CommandHandler } from "../list-objects-v2/list-objects-v2.handler.js";
 import { PutObjectCommandHandler } from "../put-object/put-object.handler.js";
@@ -46,6 +47,19 @@ export class SimS3ObjectCommands {
     options?: SimS3RequestOptions,
   ): Promise<simS3Commands.SimGetObjectCommandOutput> {
     return await new GetObjectCommandHandler(this.state).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Report what a read of an Object would say about it, without the Object.
+   */
+  async head(
+    command: simS3Commands.SimHeadObjectCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimHeadObjectCommandOutput> {
+    return await new HeadObjectCommandHandler(this.state).handle(
       command,
       options,
     );

--- a/src/service/s3/command/sim-s3-command.types.ts
+++ b/src/service/s3/command/sim-s3-command.types.ts
@@ -6,6 +6,16 @@
  */
 
 export type {
+  SimHeadBucketCommand,
+  SimHeadBucketCommandInput,
+  SimHeadBucketCommandOutput,
+} from "./head-bucket/head-bucket.command.js";
+export type {
+  SimHeadObjectCommand,
+  SimHeadObjectCommandInput,
+  SimHeadObjectCommandOutput,
+} from "./head-object/head-object.command.js";
+export type {
   SimCreateBucketCommand,
   SimCreateBucketCommandOutput,
 } from "./create-bucket/create-bucket.command.js";

--- a/src/service/s3/error/sim-s3.error.ts
+++ b/src/service/s3/error/sim-s3.error.ts
@@ -40,6 +40,22 @@ export class SimS3NoSuchKey extends SimS3Error {
 }
 
 /**
+ * Simulated S3 NotFound error.
+ *
+ * This is what a HEAD answers with, for a Bucket and for an Object alike. A
+ * HEAD response carries no body, so there is no error document to read a code
+ * out of, and real S3 answers the one status for both rather than the
+ * NoSuchBucket and NoSuchKey a GET distinguishes.
+ */
+export class SimS3NotFound extends SimS3Error {
+  public override readonly name = "NotFound";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 404 });
+  }
+}
+
+/**
  * Simulated S3 NoSuchBucketPolicy error.
  *
  * Real S3 distinguishes a Bucket that does not exist from a Bucket that exists

--- a/src/service/s3/sdk/sim-s3-sdk-command-router.iso.test.ts
+++ b/src/service/s3/sdk/sim-s3-sdk-command-router.iso.test.ts
@@ -273,7 +273,7 @@ describe("simulated S3 SDK Command routing", () => {
 
     const supported = router.supportedCommandNames();
 
-    assertArrayLength(supported, 18);
+    assertArrayLength(supported, 20);
     assertArrayIncludes(supported, "GetObjectCommand");
     assertArrayIncludes(supported, "ListObjectsV2Command");
     assertArrayIncludes(supported, "DeleteBucketCommand");
@@ -284,7 +284,9 @@ describe("simulated S3 SDK Command routing", () => {
     assertArrayIncludes(supported, "GetBucketPolicyCommand");
     assertArrayIncludes(supported, "DeleteBucketPolicyCommand");
     assertArrayIncludes(supported, "PutPublicAccessBlockCommand");
-    assertUndefined(router.route("HeadObjectCommand"));
+    assertArrayIncludes(supported, "HeadObjectCommand");
+    assertArrayIncludes(supported, "HeadBucketCommand");
+    assertUndefined(router.route("GetBucketAclCommand"));
   });
 
   it("passes through a GetObject output without a Body", async () => {

--- a/src/service/s3/sdk/sim-s3-sdk-command-router.ts
+++ b/src/service/s3/sdk/sim-s3-sdk-command-router.ts
@@ -9,6 +9,8 @@ import type {
   SimGetObjectCommand,
   SimGetObjectCommandOutput,
 } from "../command/get-object/get-object.command.js";
+import type { SimHeadBucketCommand } from "../command/head-bucket/head-bucket.command.js";
+import type { SimHeadObjectCommand } from "../command/head-object/head-object.command.js";
 import type { SimListBucketsCommand } from "../command/list-buckets/list-buckets.command.js";
 import type { SimListObjectsCommand } from "../command/list-objects/list-objects.command.js";
 import type { SimListObjectsV2Command } from "../command/list-objects-v2/list-objects-v2.command.js";
@@ -80,6 +82,22 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simS3.getBucketPolicy(
             command as SimGetBucketPolicyCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "HeadBucketCommand",
+        async (command, context): Promise<unknown> =>
+          await simS3.headBucket(
+            command as SimHeadBucketCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "HeadObjectCommand",
+        async (command, context): Promise<unknown> =>
+          await simS3.headObject(
+            command as SimHeadObjectCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/s3/serve/api/sim-s3-api-bucket-routes.ts
+++ b/src/service/s3/serve/api/sim-s3-api-bucket-routes.ts
@@ -21,6 +21,12 @@ import type { SimS3ApiRoute } from "./sim-s3-api-route.type.js";
  */
 export const simS3BucketApiRoutes: readonly SimS3ApiRoute[] = [
   {
+    method: "HEAD",
+    target: "bucket",
+    commandName: "HeadBucketCommand",
+    input: bucketInput,
+  },
+  {
     method: "GET",
     target: "service",
     commandName: "ListBucketsCommand",

--- a/src/service/s3/serve/api/sim-s3-api-head-output.ts
+++ b/src/service/s3/serve/api/sim-s3-api-head-output.ts
@@ -1,0 +1,47 @@
+import { simS3ObjectResponseHeaders } from "../../object/s3-object-response-headers.js";
+
+/**
+ * The responses a HEAD is answered with.
+ *
+ * HTTP forbids a body on a HEAD response, so everything the caller learns is
+ * in the headers and the status. That is what separates these from the
+ * operations that answer in XML.
+ */
+
+/**
+ * Answer a HEAD with what a read would have said and none of the Object.
+ *
+ * The `content-length` describes the Object rather than the response, which is
+ * what makes a HEAD worth sending.
+ */
+export function simS3HeadObjectResponse(
+  output: Record<string, unknown>,
+): Response {
+  return new Response(undefined, {
+    status: 200,
+    headers: simS3ObjectResponseHeaders({
+      metadata: output["Metadata"] as Record<string, string> | undefined,
+      bodyLength: (output["ContentLength"] as number | undefined) ?? 0,
+      etag: output["ETag"] as string | undefined,
+      lastModified: output["LastModified"] as Date | undefined,
+    }),
+  });
+}
+
+/**
+ * Answer that a Bucket is there and reachable.
+ *
+ * The Region it was found in travels in a header, since a HEAD has no body to
+ * put it in, and the SDK reads that header back into `BucketRegion`.
+ */
+export function simS3HeadBucketResponse(
+  output: Record<string, unknown>,
+): Response {
+  const region = output["BucketRegion"];
+
+  return new Response(undefined, {
+    status: 200,
+    headers:
+      typeof region === "string" ? { "x-amz-bucket-region": region } : {},
+  });
+}

--- a/src/service/s3/serve/api/sim-s3-api-object-routes.ts
+++ b/src/service/s3/serve/api/sim-s3-api-object-routes.ts
@@ -6,6 +6,12 @@ import type { SimS3ApiRoute } from "./sim-s3-api-route.type.js";
  */
 export const simS3ObjectApiRoutes: readonly SimS3ApiRoute[] = [
   {
+    method: "HEAD",
+    target: "object",
+    commandName: "HeadObjectCommand",
+    input: objectInput,
+  },
+  {
     method: "GET",
     target: "object",
     commandName: "GetObjectCommand",

--- a/src/service/s3/serve/api/sim-s3-api-output.ts
+++ b/src/service/s3/serve/api/sim-s3-api-output.ts
@@ -57,6 +57,13 @@ export async function simS3ApiResponse(
     case "DeleteObjectsCommand": {
       return xml(deleteResultXml(value));
     }
+    case "HeadObjectCommand": {
+      return headObjectResponse(value);
+    }
+    case "HeadBucketCommand": {
+      // The Bucket is there and reachable, which the status alone says.
+      return new Response(undefined, { status: 200 });
+    }
     case "PutObjectCommand": {
       return new Response(undefined, {
         status: 200,
@@ -96,6 +103,25 @@ async function getObjectResponse(
     headers: simS3ObjectResponseHeaders({
       metadata: output["Metadata"] as Record<string, string> | undefined,
       bodyLength: body.length,
+      etag: output["ETag"] as string | undefined,
+      lastModified: output["LastModified"] as Date | undefined,
+    }),
+  });
+}
+
+/**
+ * Answer a HEAD with what a read would have said and none of the Object.
+ *
+ * HTTP forbids a body on a HEAD response, so everything the caller learns is
+ * in the headers, `content-length` included. That length describes the Object
+ * rather than the response, which is what makes a HEAD worth sending.
+ */
+function headObjectResponse(output: Record<string, unknown>): Response {
+  return new Response(undefined, {
+    status: 200,
+    headers: simS3ObjectResponseHeaders({
+      metadata: output["Metadata"] as Record<string, string> | undefined,
+      bodyLength: (output["ContentLength"] as number | undefined) ?? 0,
       etag: output["ETag"] as string | undefined,
       lastModified: output["LastModified"] as Date | undefined,
     }),

--- a/src/service/s3/serve/api/sim-s3-api-output.ts
+++ b/src/service/s3/serve/api/sim-s3-api-output.ts
@@ -5,6 +5,10 @@ import {
   publicAccessBlockXml,
 } from "./sim-s3-api-configuration-output.js";
 import {
+  simS3HeadBucketResponse,
+  simS3HeadObjectResponse,
+} from "./sim-s3-api-head-output.js";
+import {
   simS3ListBucketsXml,
   simS3ListObjectsXml,
 } from "./sim-s3-api-listing.js";
@@ -58,11 +62,10 @@ export async function simS3ApiResponse(
       return xml(deleteResultXml(value));
     }
     case "HeadObjectCommand": {
-      return headObjectResponse(value);
+      return simS3HeadObjectResponse(value);
     }
     case "HeadBucketCommand": {
-      // The Bucket is there and reachable, which the status alone says.
-      return new Response(undefined, { status: 200 });
+      return simS3HeadBucketResponse(value);
     }
     case "PutObjectCommand": {
       return new Response(undefined, {
@@ -103,25 +106,6 @@ async function getObjectResponse(
     headers: simS3ObjectResponseHeaders({
       metadata: output["Metadata"] as Record<string, string> | undefined,
       bodyLength: body.length,
-      etag: output["ETag"] as string | undefined,
-      lastModified: output["LastModified"] as Date | undefined,
-    }),
-  });
-}
-
-/**
- * Answer a HEAD with what a read would have said and none of the Object.
- *
- * HTTP forbids a body on a HEAD response, so everything the caller learns is
- * in the headers, `content-length` included. That length describes the Object
- * rather than the response, which is what makes a HEAD worth sending.
- */
-function headObjectResponse(output: Record<string, unknown>): Response {
-  return new Response(undefined, {
-    status: 200,
-    headers: simS3ObjectResponseHeaders({
-      metadata: output["Metadata"] as Record<string, string> | undefined,
-      bodyLength: (output["ContentLength"] as number | undefined) ?? 0,
       etag: output["ETag"] as string | undefined,
       lastModified: output["LastModified"] as Date | undefined,
     }),

--- a/src/service/s3/serve/api/sim-s3-api-routes.iso.test.ts
+++ b/src/service/s3/serve/api/sim-s3-api-routes.iso.test.ts
@@ -54,13 +54,18 @@ describe("Resolving an S3 REST operation from a request", () => {
     assertIdentical(route("PUT", "/widgets"), "CreateBucketCommand");
   });
 
+  it("routes a HEAD to the operation that describes without reading", () => {
+    assertIdentical(route("HEAD", "/widgets"), "HeadBucketCommand");
+    assertIdentical(route("HEAD", "/widgets/one.txt"), "HeadObjectCommand");
+  });
+
   it("routes a multi-Object removal, which is the one POST", () => {
     assertIdentical(route("POST", "/widgets?delete"), "DeleteObjectsCommand");
   });
 
   it("names no operation for a method S3 does not use here", () => {
-    assertUndefined(route("HEAD", "/widgets/one.txt"));
     assertUndefined(route("PATCH", "/widgets"));
+    assertUndefined(route("POST", "/widgets/one.txt"));
   });
 
   it("reads a key that contains slashes as one key", () => {

--- a/src/service/s3/serve/api/sim-s3-api.loc.test.ts
+++ b/src/service/s3/serve/api/sim-s3-api.loc.test.ts
@@ -7,6 +7,7 @@ import {
   CreateBucketCommand,
   GetBucketPolicyCommand,
   PutBucketPolicyCommand,
+  HeadBucketCommand,
   HeadObjectCommand,
   DeleteObjectCommand,
   DeleteObjectsCommand,
@@ -301,27 +302,49 @@ describe("Serving the simulated S3 REST API on an endpoint URL", () => {
     assertStringIncludes(error.message, "s3:PutObject");
   });
 
-  it("refuses an operation whose method it has no route for", async () => {
+  it("answers a HEAD with the Object's headers and no body", async () => {
     // Given a Bucket holding an Object
-    await client.send(new CreateBucketCommand({ Bucket: "no-route" }));
+    await client.send(new CreateBucketCommand({ Bucket: "heads" }));
     await client.send(
-      new PutObjectCommand({ Bucket: "no-route", Key: "one", Body: "1" }),
+      new PutObjectCommand({
+        Bucket: "heads",
+        Key: "one",
+        Body: "twelve chars",
+      }),
     );
 
-    // When a HEAD is asked for, which simulated S3 has no operation behind
+    // When it is asked about rather than read
+    const head = await client.send(
+      new HeadObjectCommand({ Bucket: "heads", Key: "one" }),
+    );
+
+    // Then the length describes the Object, which is the point of a HEAD
+    assertIdentical(head.ContentLength, 12);
+
+    // And the Bucket answers one too
+    const bucket = await client.send(
+      new HeadBucketCommand({ Bucket: "heads" }),
+    );
+    assertIdentical(bucket.$metadata.httpStatusCode, 200);
+  });
+
+  it("answers a HEAD for something absent with 404 and no body to read", async () => {
+    // Given a Bucket with nothing under the key asked for
+    await client.send(new CreateBucketCommand({ Bucket: "absent-heads" }));
+
+    // When an absent Object is asked about
     const error = await assertThrowsErrorAsync(
       async () =>
         await client.send(
-          new HeadObjectCommand({ Bucket: "no-route", Key: "one" }),
+          new HeadObjectCommand({ Bucket: "absent-heads", Key: "gone" }),
         ),
     );
 
-    // Then it is refused rather than answered from a route meant for a
-    // different method
+    // Then the status is all there is, since HTTP forbids a body here
     assertIdentical(
       (error as { $metadata?: { httpStatusCode?: number } }).$metadata
         ?.httpStatusCode,
-      501,
+      404,
     );
   });
 

--- a/src/service/s3/serve/api/sim-s3-api.loc.test.ts
+++ b/src/service/s3/serve/api/sim-s3-api.loc.test.ts
@@ -321,11 +321,13 @@ describe("Serving the simulated S3 REST API on an endpoint URL", () => {
     // Then the length describes the Object, which is the point of a HEAD
     assertIdentical(head.ContentLength, 12);
 
-    // And the Bucket answers one too
+    // And the Bucket answers one too, reporting the Region it was found in.
+    // That travels in a header, since a HEAD has no body to put it in.
     const bucket = await client.send(
       new HeadBucketCommand({ Bucket: "heads" }),
     );
     assertIdentical(bucket.$metadata.httpStatusCode, 200);
+    assertIdentical(bucket.BucketRegion, simAws.defaultRegionName);
   });
 
   it("answers a HEAD for something absent with 404 and no body to read", async () => {

--- a/src/service/s3/sim-s3.ts
+++ b/src/service/s3/sim-s3.ts
@@ -53,6 +53,22 @@ export class SimS3 {
     return await this.commands.buckets.create(command, options);
   }
 
+  /** Handle a Head Bucket Command from the SDK. */
+  async headBucket(
+    command: simS3Commands.SimHeadBucketCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimHeadBucketCommandOutput> {
+    return await this.commands.buckets.head(command, options);
+  }
+
+  /** Handle a Head Object Command from the SDK. */
+  async headObject(
+    command: simS3Commands.SimHeadObjectCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimHeadObjectCommandOutput> {
+    return await this.commands.objects.head(command, options);
+  }
+
   /** Handle a Delete Bucket Command from the SDK. */
   async deleteBucket(
     command: simS3Commands.SimDeleteBucketCommand,


### PR DESCRIPTION
`HeadObject` reports what a read would have said about an Object and none of the Object itself. `HeadBucket` reports whether a Bucket is there and the caller may reach it. Both work in process, through SDK interception and over a served endpoint URL, which is what puts `aws s3 cp` in reach, since it asks about an Object before copying one. 

Resolves https://github.com/KensioSoftware/yulin/issues/678

## Behaviour worth checking

Each authorizes as its read equivalent does, `HeadObject` against `s3:GetObject` and `HeadBucket` against `s3:ListBucket`, because knowing something is there is the knowledge a read gives away. Authorization runs before the key is looked up, which keeps a denied caller from learning whether an Object exists.

Something absent is `NotFound`, where a GET distinguishes `NoSuchBucket` from `NoSuchKey`. A HEAD response carries no body to name a code in. Real S3 makes no distinction it could not express, and neither does this.

## Worth a reviewer's attention

**`HeadBucket` has an authorizer of its own rather than reusing the listing's.** It shares the action with `ListObjects` and none of the condition keys. A HeadBucket names no prefix and asks for no keys. `s3:prefix` and `s3:max-keys` are therefore absent where a listing sets them, which leaves a Bucket policy conditioned on either unmatched by one. Reusing `ListObjectsAuthorizer` would have required inventing both.

**`sim-s3.ts` gains a scoped `max-lines` override, and that is a judgement call worth a second opinion.** The facade is one delegation per operation. It grows with the service, not with any complexity of its own. It sat at 297 of the 300 allowed before this, and `sim-elbv2.ts` and `sim-cloudfront.ts` are both pinned at exactly 300, so the ceiling already binds on facades and will bind again. The override names the debt. The facade wants splitting between the AWS operations and the simulator-only controls. Happy to do that split here instead if you would rather.

**Three tests used `HeadObject` as their example of something unsupported**, which it no longer is. Two now use `GetBucketAcl` and the route table test uses `POST` on an Object.

Verified with the real CLI. `aws s3 cp` works in both directions, `head-object` and `head-bucket` answer, and both report 404 for something absent.

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for S3 `HeadBucket` and `HeadObject` operations.
  * Check bucket or object existence and receive appropriate 404 responses when unavailable.
  * Retrieve object metadata—including size, ETag, and last-modified details—without downloading its content.
  * Added IAM authorization checks for bucket and object HEAD requests.
  * `HEAD` requests now return appropriate HTTP responses and metadata headers.

* **Documentation**
  * Updated S3 documentation with supported operations, usage guidance, permissions, and missing-resource behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->