### PR TITLE
feat: simulate Rekognition face collections

### DIFF
--- a/docs/services/rekognition/README.md
+++ b/docs/services/rekognition/README.md
@@ -714,12 +714,59 @@ await simAws.backgroundTasksComplete();
 A handler that writes a moderated copy back into the Bucket that triggered it will notify itself for
 ever. Filter the notification configuration by prefix or suffix, as this one does.
 
+## Face collections
+
+A collection is what lets an application recognise the same person twice, where a detection answers what is in one image. Simulated Rekognition holds the collections themselves.
+
+```typescript sim-rekognition-collections
+/**
+ * Creating, listing and removing a Rekognition face collection.
+ */
+
+import {
+  CreateCollectionCommand,
+  DeleteCollectionCommand,
+  ListCollectionsCommand,
+} from "@aws-sdk/client-rekognition";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simRekognition = simAws.rekognition();
+
+const created = await simRekognition.createCollection(
+  new CreateCollectionCommand({ CollectionId: "staff" }),
+);
+
+console.log(created.CollectionArn);
+// arn:aws:rekognition:us-east-1:888888888888:collection/staff
+
+const listed = await simRekognition.listCollections(
+  new ListCollectionsCommand({}),
+);
+
+console.log(listed.CollectionIds); // ["staff"]
+console.log(listed.FaceModelVersions); // ["7.0"]
+
+await simRekognition.deleteCollection(
+  new DeleteCollectionCommand({ CollectionId: "staff" }),
+);
+```
+
+A collection belongs to one Account and Region, as it does on AWS, so a listing in another Region misses it. Creating one under a name already held raises `ResourceAlreadyExistsException`, and removing one that was never created raises `ResourceNotFoundException`.
+
+Every collection reports face model version 7.0. Real Rekognition stamps a collection with the version in force when it was created, and that version moves as AWS retrains. Nothing here recognises a face, so one fixed version is stated rather than a moving one invented.
+
 ## Permissions and errors
 
 Each detection is authorized as its own action against `*`, one of
 `rekognition:DetectModerationLabels`, `rekognition:DetectLabels` and `rekognition:DetectFaces`. Real
 Rekognition gives the detection operations no resource-level permissions, and a policy naming an ARN
-reaches nothing, here as on AWS. A denial throws `AccessDeniedException` with a 400 status, which is
+reaches nothing, here as on AWS.
+
+A collection is the other kind. It has an ARN, so `rekognition:CreateCollection` and
+`rekognition:DeleteCollection` authorize against that collection's ARN, and a policy naming one
+collection reaches only that collection. `rekognition:ListCollections` reads them all, so it
+authorizes against `*`. A denial throws `AccessDeniedException` with a 400 status, which is
 what real Rekognition answers with, where several other services use 403.
 
 The caller is authorized for the detection before the image is read. A caller without the Rekognition
@@ -780,12 +827,18 @@ Simulated Rekognition currently supports:
 - PNG and JPEG format detection from the image bytes
 - IAM authorization on `rekognition:DetectModerationLabels`, `rekognition:DetectLabels` and
   `rekognition:DetectFaces`, with the image read from S3 as the caller
+- `CreateCollectionCommand`, `ListCollectionsCommand` and `DeleteCollectionCommand`, scoped to one
+  Account and Region
+- IAM authorization on `rekognition:CreateCollection` and `rekognition:DeleteCollection` against the
+  collection's own ARN, and on `rekognition:ListCollections` against `*`
 - SDK interception of `RekognitionClient`, including from inside a simulated Lambda function
 
 ## Limitations
 
-- `DetectText`, `CompareFaces`, the face collection operations and the video operations are left
-  out. An intercepted client sending one of those Commands is refused by name.
+- `DetectText`, `CompareFaces` and the video operations are left out. An intercepted client sending
+  one of those Commands is refused by name.
+- A collection holds no faces. `IndexFaces`, `SearchFacesByImage`, `ListFaces` and `DeleteFaces` are
+  left out, so what a collection is here is its identity and its lifecycle.
 - A face detection reports the emotions that were declared and no others. Real `DetectFaces` returns
   all eight emotion types every time, with the ones it failed to see at a low confidence. Declare
   the emotions the code under test reads.

--- a/docs/services/rekognition/sim-rekognition-collections.example.ts
+++ b/docs/services/rekognition/sim-rekognition-collections.example.ts
@@ -1,0 +1,31 @@
+/**
+ * Creating, listing and removing a Rekognition face collection.
+ */
+
+import {
+  CreateCollectionCommand,
+  DeleteCollectionCommand,
+  ListCollectionsCommand,
+} from "@aws-sdk/client-rekognition";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simRekognition = simAws.rekognition();
+
+const created = await simRekognition.createCollection(
+  new CreateCollectionCommand({ CollectionId: "staff" }),
+);
+
+console.log(created.CollectionArn);
+// arn:aws:rekognition:us-east-1:888888888888:collection/staff
+
+const listed = await simRekognition.listCollections(
+  new ListCollectionsCommand({}),
+);
+
+console.log(listed.CollectionIds); // ["staff"]
+console.log(listed.FaceModelVersions); // ["7.0"]
+
+await simRekognition.deleteCollection(
+  new DeleteCollectionCommand({ CollectionId: "staff" }),
+);

--- a/src/service/aws/factory/sim-aws-account-region-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-account-region-service-builder.ts
@@ -174,6 +174,7 @@ export class SimAwsAccountRegionServiceBuilder {
    */
   createRekognition(scope: SimAwsAccountRegionContainer): SimRekognition {
     return new SimRekognition({
+      accountRegionScope: scope.accountRegionScope,
       iam: this.accountServices.createIam(scope),
       background: this.background,
       images: simAwsRekognitionImages(this.simAws, scope),

--- a/src/service/rekognition/README.md
+++ b/src/service/rekognition/README.md
@@ -23,7 +23,21 @@ the facade growing a result shape for each.
 
 The service is scoped to an account and region because its rules are: a detection made in one Region
 is answered by the rules registered in that Region, as a real Rekognition endpoint answers for the
-Region it belongs to.
+Region it belongs to. Face collections are scoped by that same instance. That is what leaves
+`collection/sim-rekognition-collections.ts` an ordinary map, with no scope to check per call.
+
+## The collection model
+
+`collection/` holds the face collections one Account and Region owns, and
+`command/collection/collection.handler.ts` holds the three operations that work on them. They share
+a store and an authorization shape, which is what makes them one handler and not three.
+
+A collection is the one Rekognition resource with an ARN, so those operations authorize against it
+where the detections authorize against `*`. That is why `SimRekognitionAuthorizer.authorize` takes an
+optional resource.
+
+Nothing is indexed into a collection yet, so what a collection is here is its identity, its ARN and
+its model version.
 
 ## The rule mechanism
 

--- a/src/service/rekognition/collection/sim-rekognition-collection.ts
+++ b/src/service/rekognition/collection/sim-rekognition-collection.ts
@@ -1,0 +1,29 @@
+import type { Brand } from "../../../util/brand.type.js";
+
+export type SimRekognitionCollectionId = Brand<
+  string,
+  "SimRekognitionCollectionId"
+>;
+
+/**
+ * The face model version every collection this simulation makes reports.
+ *
+ * Real Rekognition stamps a collection with the model version in force when it
+ * was created, and the version moves as AWS retrains. Nothing here recognises a
+ * face, so one fixed version is stated rather than a moving one invented.
+ */
+export const simRekognitionFaceModelVersion = "7.0";
+
+/**
+ * One simulated Rekognition face collection.
+ *
+ * A collection holds indexed faces in real Rekognition. This simulation has no
+ * faces to put in one yet, so what a collection is here is its identity, which
+ * is what the operations that create, list and remove it work with.
+ */
+export interface SimRekognitionCollection {
+  readonly collectionId: SimRekognitionCollectionId;
+  readonly arn: string;
+  readonly faceModelVersion: string;
+  readonly createdAt: Date;
+}

--- a/src/service/rekognition/collection/sim-rekognition-collections.ts
+++ b/src/service/rekognition/collection/sim-rekognition-collections.ts
@@ -1,0 +1,98 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import {
+  SimRekognitionResourceAlreadyExistsException,
+  SimRekognitionResourceNotFoundException,
+} from "../error/sim-rekognition.error.js";
+import {
+  simRekognitionFaceModelVersion,
+  type SimRekognitionCollection,
+  type SimRekognitionCollectionId,
+} from "./sim-rekognition-collection.js";
+
+interface SimRekognitionCollectionsProperties {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * The face collections one Account and Region holds.
+ *
+ * Real Rekognition scopes a collection to both, so a collection made in one
+ * Region is invisible from another. Simulated Rekognition is built per Account
+ * and Region already, which is what makes this an ordinary map rather than
+ * something that has to check a scope on every call.
+ */
+export class SimRekognitionCollections {
+  private readonly collections = new Map<
+    SimRekognitionCollectionId,
+    SimRekognitionCollection
+  >();
+
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimRekognitionCollectionsProperties) {
+    this.accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * The ARN a collection of this name would have, whether or not it exists.
+   *
+   * Authorization needs this before the collection does, since a policy naming
+   * a collection has to be evaluated for a request to create one.
+   */
+  arnFor(collectionId: string): string {
+    const { accountId, regionName } = this.accountRegionScope;
+
+    return `arn:aws:rekognition:${regionName}:${accountId}:collection/${collectionId}`;
+  }
+
+  /**
+   * Record a new collection.
+   *
+   * Throws when one of that name is already held, as real Rekognition does
+   * rather than answering with the collection that is there.
+   */
+  create(collectionId: string, createdAt: Date): SimRekognitionCollection {
+    const id = collectionId as SimRekognitionCollectionId;
+
+    if (this.collections.has(id)) {
+      throw new SimRekognitionResourceAlreadyExistsException(
+        `Rekognition collection ${collectionId} already exists`,
+      );
+    }
+
+    const collection: SimRekognitionCollection = {
+      collectionId: id,
+      arn: this.arnFor(collectionId),
+      faceModelVersion: simRekognitionFaceModelVersion,
+      createdAt,
+    };
+    this.collections.set(id, collection);
+
+    return collection;
+  }
+
+  /**
+   * Every collection held here, in the order they were created.
+   */
+  all(): readonly SimRekognitionCollection[] {
+    return this.collections.values().toArray();
+  }
+
+  /**
+   * Remove a collection, refusing one that was never created.
+   */
+  remove(collectionId: string): SimRekognitionCollection {
+    const id = collectionId as SimRekognitionCollectionId;
+    const collection = this.collections.get(id);
+
+    if (collection === undefined) {
+      throw new SimRekognitionResourceNotFoundException(
+        `Rekognition collection ${collectionId} does not exist`,
+      );
+    }
+
+    this.collections.delete(id);
+
+    return collection;
+  }
+}

--- a/src/service/rekognition/command/authorize/sim-rekognition-authorizer.ts
+++ b/src/service/rekognition/command/authorize/sim-rekognition-authorizer.ts
@@ -5,13 +5,16 @@ import { SimRekognitionAccessDeniedException } from "../../error/sim-rekognition
 import type { SimRekognitionRequestOptions } from "../sim-rekognition-request-options.js";
 
 /**
- * The resource every Rekognition detection authorizes against.
+ * The resource a Rekognition detection authorizes against.
  *
  * Real Rekognition gives the detection operations no resource-level
  * permissions, because the image is passed in rather than being a Rekognition
  * resource there is an ARN for. A policy allowing
  * `rekognition:DetectModerationLabels` has to use a resource of `*`, and one
  * naming an ARN reaches nothing, here as on AWS.
+ *
+ * A collection is the other kind. It has an ARN, and its operations authorize
+ * against that, so those pass one in.
  */
 const anyResource = "*";
 
@@ -37,15 +40,16 @@ export class SimRekognitionAuthorizer {
   }
 
   /**
-   * Ensure the caller may perform a detection action.
+   * Ensure the caller may perform an action, on a resource where there is one.
    */
   authorize(
     action: string,
     options: SimRekognitionRequestOptions = {},
+    resource: string = anyResource,
   ): SimAwsResolvedCaller {
     const decision = this.iam.authorize({
       action,
-      resource: anyResource,
+      resource,
       caller: options.caller,
     });
 

--- a/src/service/rekognition/command/collection/collection-id.ts
+++ b/src/service/rekognition/command/collection/collection-id.ts
@@ -1,0 +1,18 @@
+import { SimRekognitionInvalidParameterException } from "../../error/sim-rekognition.error.js";
+
+/**
+ * The collection a request named, refusing one that named none.
+ *
+ * Real Rekognition requires a CollectionId on every operation that works on
+ * one, and reports an omitted one as a malformed request rather than as a
+ * collection it could not find.
+ */
+export function requiredCollectionId(collectionId: string | undefined): string {
+  if (collectionId === undefined || collectionId.length === 0) {
+    throw new SimRekognitionInvalidParameterException(
+      "CollectionId is required",
+    );
+  }
+
+  return collectionId;
+}

--- a/src/service/rekognition/command/collection/collection.command.ts
+++ b/src/service/rekognition/command/collection/collection.command.ts
@@ -1,0 +1,62 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim Rekognition CreateCollection command.
+ */
+export interface SimCreateCollectionCommand {
+  readonly input: {
+    readonly CollectionId?: string | undefined;
+  };
+}
+
+/**
+ * Minimal structural sim Rekognition CreateCollection output.
+ */
+export interface SimCreateCollectionCommandOutput {
+  readonly StatusCode?: number;
+  readonly CollectionArn?: string;
+  readonly FaceModelVersion?: string;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Rekognition ListCollections command.
+ */
+export interface SimListCollectionsCommand {
+  readonly input?:
+    | {
+        readonly MaxResults?: number | undefined;
+        readonly NextToken?: string | undefined;
+      }
+    | undefined;
+}
+
+/**
+ * Minimal structural sim Rekognition ListCollections output.
+ *
+ * `FaceModelVersions` runs alongside `CollectionIds`, one entry per collection
+ * in the same order, which is how real Rekognition reports a version that can
+ * differ between collections.
+ */
+export interface SimListCollectionsCommandOutput {
+  readonly CollectionIds?: string[];
+  readonly FaceModelVersions?: string[];
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Rekognition DeleteCollection command.
+ */
+export interface SimDeleteCollectionCommand {
+  readonly input: {
+    readonly CollectionId?: string | undefined;
+  };
+}
+
+/**
+ * Minimal structural sim Rekognition DeleteCollection output.
+ */
+export interface SimDeleteCollectionCommandOutput {
+  readonly StatusCode?: number;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/rekognition/command/collection/collection.handler.ts
+++ b/src/service/rekognition/command/collection/collection.handler.ts
@@ -1,0 +1,115 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimRekognitionCollections } from "../../collection/sim-rekognition-collections.js";
+import { requiredCollectionId } from "./collection-id.js";
+import type { SimRekognitionAuthorizer } from "../authorize/sim-rekognition-authorizer.js";
+import type { SimRekognitionRequestOptions } from "../sim-rekognition-request-options.js";
+import type {
+  SimCreateCollectionCommand,
+  SimCreateCollectionCommandOutput,
+  SimDeleteCollectionCommand,
+  SimDeleteCollectionCommandOutput,
+  SimListCollectionsCommand,
+  SimListCollectionsCommandOutput,
+} from "./collection.command.js";
+
+interface SimRekognitionCollectionHandlerProperties {
+  readonly collections: SimRekognitionCollections;
+  readonly authorizer: SimRekognitionAuthorizer;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * The simulated Rekognition operations that work on a face collection.
+ *
+ * The three share a store and an authorization shape, so they are handled
+ * together rather than one class each. Unlike the detections, a collection has
+ * an ARN, so each authorizes against that rather than against a wildcard, and
+ * a policy naming one collection reaches only that collection.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/rekognition/command/CreateCollectionCommand/
+ */
+export class SimRekognitionCollectionHandler {
+  private readonly collections: SimRekognitionCollections;
+  private readonly authorizer: SimRekognitionAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: SimRekognitionCollectionHandlerProperties) {
+    this.collections = properties.collections;
+    this.authorizer = properties.authorizer;
+    this.background = properties.background;
+  }
+
+  /**
+   * Create a face collection.
+   */
+  async create(
+    command: SimCreateCollectionCommand,
+    options?: SimRekognitionRequestOptions,
+  ): Promise<SimCreateCollectionCommandOutput> {
+    const collectionId = requiredCollectionId(command.input.CollectionId);
+
+    this.authorizer.authorize(
+      "rekognition:CreateCollection",
+      options,
+      this.collections.arnFor(collectionId),
+    );
+
+    await this.background.sequence();
+
+    const collection = this.collections.create(
+      collectionId,
+      this.background.now(),
+    );
+
+    return {
+      StatusCode: 200,
+      CollectionArn: collection.arn,
+      FaceModelVersion: collection.faceModelVersion,
+      $metadata: {},
+    };
+  }
+
+  /**
+   * List the face collections this Account and Region holds.
+   */
+  async list(
+    _command: SimListCollectionsCommand,
+    options?: SimRekognitionRequestOptions,
+  ): Promise<SimListCollectionsCommandOutput> {
+    // A listing reads every collection, so it authorizes against all of them
+    // rather than against one, as real Rekognition does.
+    this.authorizer.authorize("rekognition:ListCollections", options);
+
+    await this.background.sequence();
+
+    const held = this.collections.all();
+
+    return {
+      CollectionIds: held.map((collection) => collection.collectionId),
+      FaceModelVersions: held.map((collection) => collection.faceModelVersion),
+      $metadata: {},
+    };
+  }
+
+  /**
+   * Remove a face collection.
+   */
+  async delete(
+    command: SimDeleteCollectionCommand,
+    options?: SimRekognitionRequestOptions,
+  ): Promise<SimDeleteCollectionCommandOutput> {
+    const collectionId = requiredCollectionId(command.input.CollectionId);
+
+    this.authorizer.authorize(
+      "rekognition:DeleteCollection",
+      options,
+      this.collections.arnFor(collectionId),
+    );
+
+    await this.background.sequence();
+
+    this.collections.remove(collectionId);
+
+    return { StatusCode: 200, $metadata: {} };
+  }
+}

--- a/src/service/rekognition/command/collection/collection.iso.test.ts
+++ b/src/service/rekognition/command/collection/collection.iso.test.ts
@@ -1,0 +1,182 @@
+import { CreateUserCommand, PutUserPolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateCollectionCommand,
+  DeleteCollectionCommand,
+  ListCollectionsCommand,
+} from "@aws-sdk/client-rekognition";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+
+/**
+ * Face collections, which are what lets an application recognise the same
+ * person twice rather than answer what is in one image.
+ *
+ * Nothing here indexes a face yet. What a collection is at this point is its
+ * identity, and these cover the lifecycle of that identity.
+ */
+describe("Simulated Rekognition face collections", () => {
+  it("creates a collection and lists it back with its ARN and model version", async () => {
+    // Given a simulation with no collections
+    const simAws = new SimAws();
+    const rekognition = simAws.rekognition();
+
+    // When one is created
+    const created = await rekognition.createCollection(
+      new CreateCollectionCommand({ CollectionId: "faces" }),
+    );
+
+    // Then it reports the ARN real Rekognition would issue
+    assertIdentical(
+      created.CollectionArn,
+      `arn:aws:rekognition:${simAws.defaultRegionName}:${simAws.defaultAccountId}:collection/faces`,
+    );
+    assertIdentical(created.StatusCode, 200);
+
+    // And the listing reports it alongside the model version it was made under
+    const listed = await rekognition.listCollections(
+      new ListCollectionsCommand({}),
+    );
+
+    assertArrayEquals(listed.CollectionIds ?? [], ["faces"]);
+    assertArrayEquals(listed.FaceModelVersions ?? [], [
+      created.FaceModelVersion ?? "",
+    ]);
+  });
+
+  it("holds collections per Account and Region", async () => {
+    // Given a collection created in one Region
+    const simAws = new SimAws();
+    await simAws
+      .rekognition()
+      .createCollection(new CreateCollectionCommand({ CollectionId: "faces" }));
+
+    // When another Region is asked
+    const elsewhere = await simAws
+      .accountRegionScope(undefined, "eu-west-2")
+      .rekognition()
+      .listCollections(new ListCollectionsCommand({}));
+
+    // Then it sees nothing, as real Rekognition scopes a collection to both
+    assertArrayEquals(elsewhere.CollectionIds ?? [], []);
+  });
+
+  it("refuses a second collection under a name it already holds", async () => {
+    // Given a collection that exists
+    const simAws = new SimAws();
+    const rekognition = simAws.rekognition();
+    await rekognition.createCollection(
+      new CreateCollectionCommand({ CollectionId: "faces" }),
+    );
+
+    // When the same name is created again
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await rekognition.createCollection(
+          new CreateCollectionCommand({ CollectionId: "faces" }),
+        ),
+    );
+
+    // Then it is refused rather than answered with the one that is there
+    assertIdentical(error.name, "ResourceAlreadyExistsException");
+  });
+
+  it("refuses to remove a collection that was never created", async () => {
+    // Given a simulation holding no collections
+    const simAws = new SimAws();
+
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws
+          .rekognition()
+          .deleteCollection(
+            new DeleteCollectionCommand({ CollectionId: "absent" }),
+          ),
+    );
+
+    assertIdentical(error.name, "ResourceNotFoundException");
+  });
+
+  it("stops listing a collection once it is removed", async () => {
+    // Given two collections
+    const simAws = new SimAws();
+    const rekognition = simAws.rekognition();
+    await rekognition.createCollection(
+      new CreateCollectionCommand({ CollectionId: "faces" }),
+    );
+    await rekognition.createCollection(
+      new CreateCollectionCommand({ CollectionId: "staff" }),
+    );
+
+    // When one is removed
+    const removed = await rekognition.deleteCollection(
+      new DeleteCollectionCommand({ CollectionId: "faces" }),
+    );
+
+    // Then only the other is left
+    assertIdentical(removed.StatusCode, 200);
+
+    const listed = await rekognition.listCollections(
+      new ListCollectionsCommand({}),
+    );
+    assertArrayEquals(listed.CollectionIds ?? [], ["staff"]);
+  });
+
+  it("authorizes each operation against the collection's own ARN", async () => {
+    // Given a caller allowed to work on one collection and no other
+    const simAws = new SimAws();
+    const accountId = simAws.defaultAccountId;
+    const regionName = simAws.defaultRegionName;
+
+    await simAws.iam().createUser(new CreateUserCommand({ UserName: "Faces" }));
+    await simAws.iam().putUserPolicy(
+      new PutUserPolicyCommand({
+        UserName: "Faces",
+        PolicyName: "OneCollection",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "rekognition:CreateCollection",
+            Resource: `arn:aws:rekognition:${regionName}:${accountId}:collection/allowed`,
+          },
+        }),
+      }),
+    );
+    const caller = {
+      kind: "arn" as const,
+      arn: `arn:aws:iam::${accountId}:user/Faces`,
+    };
+
+    // When it creates the collection it was named for
+    const created = await simAws
+      .rekognition()
+      .createCollection(
+        new CreateCollectionCommand({ CollectionId: "allowed" }),
+        { caller },
+      );
+
+    assertIdentical(created.StatusCode, 200);
+
+    // Then another collection is refused, which a wildcard resource could not
+    // have expressed
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws
+          .rekognition()
+          .createCollection(
+            new CreateCollectionCommand({ CollectionId: "denied" }),
+            { caller },
+          ),
+    );
+
+    assertIdentical(error.name, "AccessDeniedException");
+    assertStringIncludes(error.message, "rekognition:CreateCollection");
+  });
+});

--- a/src/service/rekognition/error/sim-rekognition.error.ts
+++ b/src/service/rekognition/error/sim-rekognition.error.ts
@@ -84,6 +84,34 @@ export class SimRekognitionAccessDeniedException extends SimRekognitionError {
 }
 
 /**
+ * Simulated Rekognition ResourceAlreadyExistsException error.
+ *
+ * Real Rekognition refuses a second collection under a name it already holds
+ * rather than answering with the one that is there.
+ */
+export class SimRekognitionResourceAlreadyExistsException extends SimRekognitionError {
+  public override readonly name = "ResourceAlreadyExistsException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated Rekognition ResourceNotFoundException error.
+ *
+ * Real Rekognition reports a collection it does not hold this way, whichever
+ * operation asked for it.
+ */
+export class SimRekognitionResourceNotFoundException extends SimRekognitionError {
+  public override readonly name = "ResourceNotFoundException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
  * Simulated Rekognition error for a request input this simulation does not
  * model.
  *

--- a/src/service/rekognition/sdk/sim-rekognition-sdk-command-router.ts
+++ b/src/service/rekognition/sdk/sim-rekognition-sdk-command-router.ts
@@ -3,6 +3,11 @@ import {
   type SimSdkCommandRoute,
   type SimSdkCommandRouter,
 } from "../../../sdk/index.js";
+import type {
+  SimCreateCollectionCommand,
+  SimDeleteCollectionCommand,
+  SimListCollectionsCommand,
+} from "../command/collection/collection.command.js";
 import type { SimDetectFacesCommand } from "../command/detect-faces/detect-faces.command.js";
 import type { SimDetectLabelsCommand } from "../command/detect-labels/detect-labels.command.js";
 import type { SimDetectModerationLabelsCommand } from "../command/detect-moderation-labels/detect-moderation-labels.command.js";
@@ -17,6 +22,30 @@ export class SimRekognitionSdkCommandRouter implements SimSdkCommandRouter {
 
   constructor(simRekognition: SimRekognition) {
     this.routes = new Map<string, SimSdkCommandRoute>([
+      [
+        "CreateCollectionCommand",
+        async (command, context): Promise<unknown> =>
+          await simRekognition.createCollection(
+            command as SimCreateCollectionCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListCollectionsCommand",
+        async (command, context): Promise<unknown> =>
+          await simRekognition.listCollections(
+            command as SimListCollectionsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteCollectionCommand",
+        async (command, context): Promise<unknown> =>
+          await simRekognition.deleteCollection(
+            command as SimDeleteCollectionCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
       [
         "DetectModerationLabelsCommand",
         async (command, context): Promise<unknown> =>

--- a/src/service/rekognition/sim-rekognition.ts
+++ b/src/service/rekognition/sim-rekognition.ts
@@ -3,6 +3,18 @@ import {
   BackgroundTasks,
 } from "../../util/background/background.js";
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
+import { SimRekognitionCollections } from "./collection/sim-rekognition-collections.js";
+import { SimRekognitionCollectionHandler } from "./command/collection/collection.handler.js";
+import type {
+  SimCreateCollectionCommand,
+  SimCreateCollectionCommandOutput,
+  SimDeleteCollectionCommand,
+  SimDeleteCollectionCommandOutput,
+  SimListCollectionsCommand,
+  SimListCollectionsCommandOutput,
+} from "./command/collection/collection.command.js";
 import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
@@ -34,6 +46,7 @@ import { SimRekognitionModeration } from "./moderation/sim-rekognition-moderatio
 import { SimRekognitionSdkCommandRouter } from "./sdk/sim-rekognition-sdk-command-router.js";
 
 interface SimRekognitionProperties {
+  readonly accountRegionScope?: SimAwsAccountRegionScope;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
   readonly images?: SimRekognitionImageObjects;
@@ -60,14 +73,26 @@ export class SimRekognition {
   private readonly detectLabelsCommand: DetectLabelsHandler;
   private readonly detectFacesCommand: DetectFacesHandler;
   private readonly sdkRouter = new SimRekognitionSdkCommandRouter(this);
+  private readonly collectionStore: SimRekognitionCollections;
+  private readonly collectionCommands: SimRekognitionCollectionHandler;
 
   constructor(properties: SimRekognitionProperties = {}) {
     const {
+      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
       iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
       images = new SimRekognitionUnreachableImageObjects(),
     } = properties;
     const authorizer = new SimRekognitionAuthorizer({ iam });
+
+    this.collectionStore = new SimRekognitionCollections({
+      accountRegionScope,
+    });
+    this.collectionCommands = new SimRekognitionCollectionHandler({
+      collections: this.collectionStore,
+      authorizer,
+      background,
+    });
 
     this.detectModerationLabelsCommand = new DetectModerationLabelsHandler({
       moderation: this.moderationRules,
@@ -89,6 +114,36 @@ export class SimRekognition {
       images,
       background,
     });
+  }
+
+  /**
+   * Handle a CreateCollectionCommand from the SDK.
+   */
+  async createCollection(
+    command: SimCreateCollectionCommand,
+    options?: SimRekognitionRequestOptions,
+  ): Promise<SimCreateCollectionCommandOutput> {
+    return await this.collectionCommands.create(command, options);
+  }
+
+  /**
+   * Handle a ListCollectionsCommand from the SDK.
+   */
+  async listCollections(
+    command: SimListCollectionsCommand,
+    options?: SimRekognitionRequestOptions,
+  ): Promise<SimListCollectionsCommandOutput> {
+    return await this.collectionCommands.list(command, options);
+  }
+
+  /**
+   * Handle a DeleteCollectionCommand from the SDK.
+   */
+  async deleteCollection(
+    command: SimDeleteCollectionCommand,
+    options?: SimRekognitionRequestOptions,
+  ): Promise<SimDeleteCollectionCommandOutput> {
+    return await this.collectionCommands.delete(command, options);
   }
 
   /**


### PR DESCRIPTION
A face collection can be created, listed and removed. That is the surface an application uses to recognise the same person twice, where a detection answers what is in one image.

Resolves https://github.com/KensioSoftware/yulin/issues/679

## Behaviour

Collections belong to one Account and Region, as they do on AWS, so a listing in another Region misses them. Simulated Rekognition is already built per Account and Region, which is what leaves the store an ordinary map with no scope to check per call.

Creating one under a name already held raises `ResourceAlreadyExistsException`. Removing one that was never created raises `ResourceNotFoundException`.

## Worth a reviewer's attention

**A collection is the one Rekognition resource with an ARN.** The detections have none, because the image is passed in rather than being a resource, so they authorize against `*`. `CreateCollection` and `DeleteCollection` authorize against the collection's own ARN, and a test covers a policy that names one collection allowing it and refusing another. `SimRekognitionAuthorizer.authorize` therefore takes an optional resource, defaulting to the wildcard the detections were already using.

**`SimRekognition` now takes its Account and Region scope.** It needed one to build a collection ARN, and it was the only per-scope service not receiving it.

**Every collection reports face model version 7.0.** Real Rekognition stamps a collection with the version in force when it was created, and that version moves as AWS retrains. Nothing here recognises a face, so one fixed version is stated rather than a moving one invented.

Verified against the real CLI as well as the SDK. `aws rekognition create-collection`, `list-collections` and `delete-collection` all answer over a served endpoint URL.

## Out of scope, as the issue set it

A collection holds no faces. `IndexFaces`, `SearchFacesByImage`, `ListFaces` and `DeleteFaces` are left out and want their own issue, since they are the reason a collection exists. `docs/services/rekognition` records that.

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`
