### PR TITLE
refactor: split the simulated S3 facade

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -733,17 +733,6 @@
       }
     },
     {
-      // A service facade is one delegation per operation the service supports,
-      // so it grows with the service rather than with any complexity of its
-      // own. Simulated S3 supports the most operations and passed 300 lines
-      // first. The facade is due a split between the AWS operations and the
-      // simulator-only controls, and this holds until then.
-      "files": ["src/service/s3/sim-s3.ts"],
-      "rules": {
-        "eslint/max-lines": ["error", 340]
-      }
-    },
-    {
       "files": ["scripts/**/*.mts"],
       "rules": {
         "eslint/no-await-in-loop": "off",

--- a/src/service/s3/README.md
+++ b/src/service/s3/README.md
@@ -11,7 +11,11 @@ familiar AWS SDK command shapes, CloudFormation resources, and local HTTP reques
 
 ## Entry points
 
-- `sim-s3.ts` is the main in-memory S3 service object for one account/region scope.
+- `sim-s3.ts` is the main in-memory S3 service object for one account/region scope. It holds the
+  simulator-only controls, the members with no AWS equivalent. The endpoint and website URLs, the
+  Bucket lookups, the filesystem mounts, `configureMaxKeysPerPage` and `close` are all here.
+- `sim-s3-operations.ts` holds the AWS operations, one delegation per SDK Command. `SimS3` extends
+  it. A caller reaches both kinds on the one service object.
 - `index.ts` exports the public S3 simulator API for `@kensio/yulin/s3`.
 - `sim-s3-global-registry.ts` records Bucket ownership across account/region scopes inside one
   simulated AWS instance.
@@ -33,7 +37,7 @@ and integration with other simulated services.
 
 ## Service and Bucket state model
 
-`SimS3` owns a local map of buckets:
+`SimS3` builds a local map of buckets and hands it to the collaborators it constructs:
 
 - the map contains only buckets in that `SimS3` instance's account/region scope
 - each Bucket is represented by `SimS3Bucket`
@@ -45,7 +49,7 @@ simulated AWS instance: it is still encapsulated state and can be freely recreat
 
 Bucket creation updates both places:
 
-1. the account/region-local `SimS3.buckets` map
+1. the account/region-local Bucket map
 2. the shared `SimS3GlobalRegistry`
 
 This lets direct SDK-style operations use local Bucket state while HTTP routing and cross-service
@@ -61,8 +65,8 @@ Each supported command has its own directory containing:
 - a handler that validates input and applies state changes
 - tests for expected simulator behaviour
 
-The main `SimS3` class delegates command execution to handlers rather than keeping command logic
-inline. For example, `SimS3.putObject()` calls `commands.objects.put()`, which creates a
+`SimS3Operations` delegates command execution to handlers rather than keeping command logic inline.
+For example, `SimS3.putObject()` calls `commands.objects.put()`, which creates a
 `PutObjectCommandHandler` with the Bucket map and background scheduler, then calls `handle()`.
 
 Supported command areas currently include:

--- a/src/service/s3/sim-s3-operations.ts
+++ b/src/service/s3/sim-s3-operations.ts
@@ -1,0 +1,174 @@
+import type * as simS3Commands from "./command/sim-s3-command.types.js";
+import type { SimS3RequestOptions } from "./command/sim-s3-request-options.js";
+import type { SimS3Commands } from "./sim-s3-commands.js";
+
+/**
+ * The AWS operations simulated S3 answers. One delegation per SDK Command,
+ * onto the handler in `SimS3Commands` that runs it.
+ *
+ * `SimS3` extends this. A caller reaches every operation on the one service
+ * object, alongside the simulator-only controls `SimS3` holds itself.
+ */
+export abstract class SimS3Operations {
+  protected constructor(protected readonly commands: SimS3Commands) {}
+
+  /** Handle a Create Bucket Command from the SDK. */
+  async createBucket(
+    command: simS3Commands.SimCreateBucketCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimCreateBucketCommandOutput> {
+    return await this.commands.buckets.create(command, options);
+  }
+
+  /** Handle a Head Bucket Command from the SDK. */
+  async headBucket(
+    command: simS3Commands.SimHeadBucketCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimHeadBucketCommandOutput> {
+    return await this.commands.buckets.head(command, options);
+  }
+
+  /** Handle a Head Object Command from the SDK. */
+  async headObject(
+    command: simS3Commands.SimHeadObjectCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimHeadObjectCommandOutput> {
+    return await this.commands.objects.head(command, options);
+  }
+
+  /** Handle a Delete Bucket Command from the SDK. */
+  async deleteBucket(
+    command: simS3Commands.SimDeleteBucketCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimDeleteBucketCommandOutput> {
+    return await this.commands.buckets.delete(command, options);
+  }
+
+  /** Handle a Put Bucket Policy Command from the SDK. */
+  async putBucketPolicy(
+    command: simS3Commands.SimPutBucketPolicyCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimPutBucketPolicyCommandOutput> {
+    return await this.commands.bucketPolicies.put(command, options);
+  }
+
+  /** Handle a Get Bucket Policy Command from the SDK. */
+  async getBucketPolicy(
+    command: simS3Commands.SimGetBucketPolicyCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimGetBucketPolicyCommandOutput> {
+    return await this.commands.bucketPolicies.get(command, options);
+  }
+
+  /** Handle a Delete Bucket Policy Command from the SDK. */
+  async deleteBucketPolicy(
+    command: simS3Commands.SimDeleteBucketPolicyCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimDeleteBucketPolicyCommandOutput> {
+    return await this.commands.bucketPolicies.delete(command, options);
+  }
+
+  /** Handle a Put Public Access Block Command from the SDK. */
+  async putPublicAccessBlock(
+    command: simS3Commands.SimPutPublicAccessBlockCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimPutPublicAccessBlockCommandOutput> {
+    return await this.commands.publicAccessBlocks.put(command, options);
+  }
+
+  /** Handle a Get Public Access Block Command from the SDK. */
+  async getPublicAccessBlock(
+    command: simS3Commands.SimGetPublicAccessBlockCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimGetPublicAccessBlockCommandOutput> {
+    return await this.commands.publicAccessBlocks.get(command, options);
+  }
+
+  /** Handle a Delete Public Access Block Command from the SDK. */
+  async deletePublicAccessBlock(
+    command: simS3Commands.SimDeletePublicAccessBlockCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimDeletePublicAccessBlockCommandOutput> {
+    return await this.commands.publicAccessBlocks.delete(command, options);
+  }
+
+  /** Handle a Put Bucket Website Command from the SDK. */
+  async putBucketWebsite(
+    command: simS3Commands.SimPutBucketWebsiteCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimPutBucketWebsiteCommandOutput> {
+    return await this.commands.buckets.putWebsite(command, options);
+  }
+
+  /** Handle a Put Bucket Notification Configuration Command from the SDK. */
+  async putBucketNotificationConfiguration(
+    command: simS3Commands.SimPutBucketNotificationConfigurationCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimPutBucketNotificationConfigurationCommandOutput> {
+    return await this.commands.notifications.put(command, options);
+  }
+
+  /** Handle a Get Bucket Notification Configuration Command from the SDK. */
+  async getBucketNotificationConfiguration(
+    command: simS3Commands.SimGetBucketNotificationConfigurationCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimGetBucketNotificationConfigurationCommandOutput> {
+    return await this.commands.notifications.get(command, options);
+  }
+
+  /** Handle a List Buckets Command from the SDK. */
+  async listBuckets(
+    command: simS3Commands.SimListBucketsCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimListBucketsCommandOutput> {
+    return await this.commands.buckets.list(command, options);
+  }
+
+  /** Handle a Put Object Command from the SDK. */
+  async putObject(
+    command: simS3Commands.SimPutObjectCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimPutObjectCommandOutput> {
+    return await this.commands.objects.put(command, options);
+  }
+
+  /** Handle a Get Object Command from the SDK. */
+  async getObject(
+    command: simS3Commands.SimGetObjectCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimGetObjectCommandOutput> {
+    return await this.commands.objects.get(command, options);
+  }
+
+  /** Handle a Delete Object Command from the SDK. */
+  async deleteObject(
+    command: simS3Commands.SimDeleteObjectCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimDeleteObjectCommandOutput> {
+    return await this.commands.objects.delete(command, options);
+  }
+
+  /** Handle a Delete Objects Command from the SDK. */
+  async deleteObjects(
+    command: simS3Commands.SimDeleteObjectsCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimDeleteObjectsCommandOutput> {
+    return await this.commands.objects.deleteMany(command, options);
+  }
+
+  /** Handle a List Objects Command from the SDK. */
+  async listObjects(
+    command: simS3Commands.SimListObjectsCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimListObjectsCommandOutput> {
+    return await this.commands.objects.list(command, options);
+  }
+
+  /** Handle a List Objects V2 Command from the SDK. */
+  async listObjectsV2(
+    command: simS3Commands.SimListObjectsV2Command,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimListObjectsV2CommandOutput> {
+    return await this.commands.objects.listV2(command, options);
+  }
+}

--- a/src/service/s3/sim-s3.ts
+++ b/src/service/s3/sim-s3.ts
@@ -1,5 +1,4 @@
 import type { SimS3Bucket, SimS3BucketName } from "./bucket/sim-s3-bucket.js";
-import type * as simS3Commands from "./command/sim-s3-command.types.js";
 import { SimS3GlobalRegistry } from "./sim-s3-global-registry.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { SimS3BucketAccess } from "./bucket/sim-s3-bucket-access.js";
@@ -7,9 +6,9 @@ import { SimS3CloudFormationResourceFactory } from "./cfn/sim-cfn-s3-resource-fa
 import type { SimCfnServiceResourceFactory } from "../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
 import { SimS3Commands, type SimS3Properties } from "./sim-s3-commands.js";
+import { SimS3Operations } from "./sim-s3-operations.js";
 import { SimS3SdkCommandRouter } from "./sdk/sim-s3-sdk-command-router.js";
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
-import type { SimS3RequestOptions } from "./command/sim-s3-request-options.js";
 import type { SimS3NotificationDeliveryFailure } from "./notification/sim-s3-notification-failures.js";
 import type { SimS3MountFilesystemOptions } from "./mount/sim-s3-mount.type.js";
 
@@ -17,11 +16,12 @@ import type { SimS3MountFilesystemOptions } from "./mount/sim-s3-mount.type.js";
  * Simulated S3. Handles SDK commands. Emulates AWS behaviour and state.
  * Scoped to an Account and Region, but has access to a global (as in
  * cross-region) registry of simulated S3 Buckets.
+ *
+ * This holds the simulator-only controls, the ones with no AWS equivalent.
+ * The AWS operations are on `SimS3Operations`, which this extends. A caller
+ * reaches both kinds on the one service object.
  */
-export class SimS3 {
-  private readonly buckets = new Map<SimS3BucketName, SimS3Bucket>();
-
-  private readonly commands: SimS3Commands;
+export class SimS3 extends SimS3Operations {
   private readonly bucketAccess: SimS3BucketAccess;
   private readonly cfnFactory = new SimS3CloudFormationResourceFactory(this);
   private readonly sdkRouter = new SimS3SdkCommandRouter(this);
@@ -31,178 +31,22 @@ export class SimS3 {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
       s3GlobalRegistry = new SimS3GlobalRegistry(),
     } = properties;
+    const buckets = new Map<SimS3BucketName, SimS3Bucket>();
 
-    this.commands = new SimS3Commands({
-      ...properties,
-      accountRegionScope,
-      s3GlobalRegistry,
-      buckets: this.buckets,
-    });
+    super(
+      new SimS3Commands({
+        ...properties,
+        accountRegionScope,
+        s3GlobalRegistry,
+        buckets,
+      }),
+    );
+
     this.bucketAccess = new SimS3BucketAccess({
-      buckets: this.buckets,
+      buckets,
       accountRegionScope,
       s3GlobalRegistry,
     });
-  }
-
-  /** Handle a Create Bucket Command from the SDK. */
-  async createBucket(
-    command: simS3Commands.SimCreateBucketCommand,
-    options?: SimS3RequestOptions,
-  ): Promise<simS3Commands.SimCreateBucketCommandOutput> {
-    return await this.commands.buckets.create(command, options);
-  }
-
-  /** Handle a Head Bucket Command from the SDK. */
-  async headBucket(
-    command: simS3Commands.SimHeadBucketCommand,
-    options?: SimS3RequestOptions,
-  ): Promise<simS3Commands.SimHeadBucketCommandOutput> {
-    return await this.commands.buckets.head(command, options);
-  }
-
-  /** Handle a Head Object Command from the SDK. */
-  async headObject(
-    command: simS3Commands.SimHeadObjectCommand,
-    options?: SimS3RequestOptions,
-  ): Promise<simS3Commands.SimHeadObjectCommandOutput> {
-    return await this.commands.objects.head(command, options);
-  }
-
-  /** Handle a Delete Bucket Command from the SDK. */
-  async deleteBucket(
-    command: simS3Commands.SimDeleteBucketCommand,
-    options?: SimS3RequestOptions,
-  ): Promise<simS3Commands.SimDeleteBucketCommandOutput> {
-    return await this.commands.buckets.delete(command, options);
-  }
-
-  /** Handle a Put Bucket Policy Command from the SDK. */
-  async putBucketPolicy(
-    command: simS3Commands.SimPutBucketPolicyCommand,
-    options?: SimS3RequestOptions,
-  ): Promise<simS3Commands.SimPutBucketPolicyCommandOutput> {
-    return await this.commands.bucketPolicies.put(command, options);
-  }
-
-  /** Handle a Get Bucket Policy Command from the SDK. */
-  async getBucketPolicy(
-    command: simS3Commands.SimGetBucketPolicyCommand,
-    options?: SimS3RequestOptions,
-  ): Promise<simS3Commands.SimGetBucketPolicyCommandOutput> {
-    return await this.commands.bucketPolicies.get(command, options);
-  }
-
-  /** Handle a Delete Bucket Policy Command from the SDK. */
-  async deleteBucketPolicy(
-    command: simS3Commands.SimDeleteBucketPolicyCommand,
-    options?: SimS3RequestOptions,
-  ): Promise<simS3Commands.SimDeleteBucketPolicyCommandOutput> {
-    return await this.commands.bucketPolicies.delete(command, options);
-  }
-
-  /** Handle a Put Public Access Block Command from the SDK. */
-  async putPublicAccessBlock(
-    command: simS3Commands.SimPutPublicAccessBlockCommand,
-    options?: SimS3RequestOptions,
-  ): Promise<simS3Commands.SimPutPublicAccessBlockCommandOutput> {
-    return await this.commands.publicAccessBlocks.put(command, options);
-  }
-
-  /** Handle a Get Public Access Block Command from the SDK. */
-  async getPublicAccessBlock(
-    command: simS3Commands.SimGetPublicAccessBlockCommand,
-    options?: SimS3RequestOptions,
-  ): Promise<simS3Commands.SimGetPublicAccessBlockCommandOutput> {
-    return await this.commands.publicAccessBlocks.get(command, options);
-  }
-
-  /** Handle a Delete Public Access Block Command from the SDK. */
-  async deletePublicAccessBlock(
-    command: simS3Commands.SimDeletePublicAccessBlockCommand,
-    options?: SimS3RequestOptions,
-  ): Promise<simS3Commands.SimDeletePublicAccessBlockCommandOutput> {
-    return await this.commands.publicAccessBlocks.delete(command, options);
-  }
-
-  /** Handle a Put Bucket Website Command from the SDK. */
-  async putBucketWebsite(
-    command: simS3Commands.SimPutBucketWebsiteCommand,
-    options?: SimS3RequestOptions,
-  ): Promise<simS3Commands.SimPutBucketWebsiteCommandOutput> {
-    return await this.commands.buckets.putWebsite(command, options);
-  }
-
-  /** Handle a Put Bucket Notification Configuration Command from the SDK. */
-  async putBucketNotificationConfiguration(
-    command: simS3Commands.SimPutBucketNotificationConfigurationCommand,
-    options?: SimS3RequestOptions,
-  ): Promise<simS3Commands.SimPutBucketNotificationConfigurationCommandOutput> {
-    return await this.commands.notifications.put(command, options);
-  }
-
-  /** Handle a Get Bucket Notification Configuration Command from the SDK. */
-  async getBucketNotificationConfiguration(
-    command: simS3Commands.SimGetBucketNotificationConfigurationCommand,
-    options?: SimS3RequestOptions,
-  ): Promise<simS3Commands.SimGetBucketNotificationConfigurationCommandOutput> {
-    return await this.commands.notifications.get(command, options);
-  }
-
-  /** Handle a List Buckets Command from the SDK. */
-  async listBuckets(
-    command: simS3Commands.SimListBucketsCommand,
-    options?: SimS3RequestOptions,
-  ): Promise<simS3Commands.SimListBucketsCommandOutput> {
-    return await this.commands.buckets.list(command, options);
-  }
-
-  /** Handle a Put Object Command from the SDK. */
-  async putObject(
-    command: simS3Commands.SimPutObjectCommand,
-    options?: SimS3RequestOptions,
-  ): Promise<simS3Commands.SimPutObjectCommandOutput> {
-    return await this.commands.objects.put(command, options);
-  }
-
-  /** Handle a Get Object Command from the SDK. */
-  async getObject(
-    command: simS3Commands.SimGetObjectCommand,
-    options?: SimS3RequestOptions,
-  ): Promise<simS3Commands.SimGetObjectCommandOutput> {
-    return await this.commands.objects.get(command, options);
-  }
-
-  /** Handle a Delete Object Command from the SDK. */
-  async deleteObject(
-    command: simS3Commands.SimDeleteObjectCommand,
-    options?: SimS3RequestOptions,
-  ): Promise<simS3Commands.SimDeleteObjectCommandOutput> {
-    return await this.commands.objects.delete(command, options);
-  }
-
-  /** Handle a Delete Objects Command from the SDK. */
-  async deleteObjects(
-    command: simS3Commands.SimDeleteObjectsCommand,
-    options?: SimS3RequestOptions,
-  ): Promise<simS3Commands.SimDeleteObjectsCommandOutput> {
-    return await this.commands.objects.deleteMany(command, options);
-  }
-
-  /** Handle a List Objects Command from the SDK. */
-  async listObjects(
-    command: simS3Commands.SimListObjectsCommand,
-    options?: SimS3RequestOptions,
-  ): Promise<simS3Commands.SimListObjectsCommandOutput> {
-    return await this.commands.objects.list(command, options);
-  }
-
-  /** Handle a List Objects V2 Command from the SDK. */
-  async listObjectsV2(
-    command: simS3Commands.SimListObjectsV2Command,
-    options?: SimS3RequestOptions,
-  ): Promise<simS3Commands.SimListObjectsV2CommandOutput> {
-    return await this.commands.objects.listV2(command, options);
   }
 
   /**


### PR DESCRIPTION
`sim-s3.ts` carried a `max-lines` exemption raising its limit from 300 to 340, added to land HeadObject and HeadBucket. The 20 AWS operation delegations now live on `SimS3Operations`, an abstract base holding the `SimS3Commands` they delegate to, and `SimS3` extends it. `SimS3` keeps its constructor and the simulator-only controls with no AWS equivalent, the endpoint URLs, the Bucket lookups, the filesystem mounts and `close`. Both files are well under 300 lines and the exemption is gone. Every member is still callable on `simAws.s3()` with the same signature, and both groups moved verbatim.

The base class takes the shape sim Cognito already uses. `SimS3` builds the Bucket map and the `SimS3Commands` as locals and passes them into `super()`, which settles the constructor ordering the issue raised without costing the facade a line per method.

Resolves https://github.com/KensioSoftware/yulin/issues/688

- [x] Conventional commit message, used as the title
- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`