### PR TITLE
fix: serve simulated CloudWatch over a port

### DIFF
--- a/docs/serve/README.md
+++ b/docs/serve/README.md
@@ -246,9 +246,11 @@ A request carrying no signature is anonymous and reaches nothing. In process an 
 
 ### Which services answer
 
-S3, STS, and the services that speak the AWS JSON protocol. Those are DynamoDB, DynamoDB Streams, SQS, Cognito Identity Provider, EventBridge, ECS, SSM, ACM, CloudWatch Logs, KMS, Secrets Manager and Rekognition.
+S3, STS, and the services that speak the AWS JSON protocol. Those are DynamoDB, DynamoDB Streams, SQS, Cognito Identity Provider, EventBridge, ECS, SSM, ACM, CloudWatch, CloudWatch Logs, KMS, Secrets Manager and Rekognition.
 
 A request to any other service is refused with `501 Not Implemented` and a body saying why. Every service is reachable in process through `SimAws` and through [SDK interception](../sdk/README.md), whether or not it answers here.
+
+CloudWatch's windowed reads, `GetMetricStatistics` and `GetMetricData`, are the exception among the operations those services implement. The JSON protocol carries a timestamp as epoch seconds, and the endpoint passes that number through as it arrives. The simulation is handed a number where it expects a date. Both reads answer in process and through SDK interception.
 
 ### Checking who the simulator thinks you are
 

--- a/src/sdk/wire/sim-sdk-wire-operation.ts
+++ b/src/sdk/wire/sim-sdk-wire-operation.ts
@@ -32,6 +32,7 @@ const jsonProtocolServiceIds: ReadonlyMap<string, string> = new Map([
   ["CertificateManager", "ACM"],
   ["DynamoDBStreams_20120810", "DynamoDB Streams"],
   ["DynamoDB_20120810", "DynamoDB"],
+  ["GraniteServiceVersion20100801", "CloudWatch"],
   ["Logs_20140328", "CloudWatch Logs"],
   ["RekognitionService", "Rekognition"],
   ["TrentService", "KMS"],

--- a/src/service/cloudwatch/serve/sim-cloudwatch-api.loc.test.ts
+++ b/src/service/cloudwatch/serve/sim-cloudwatch-api.loc.test.ts
@@ -1,0 +1,206 @@
+import {
+  CloudWatchClient,
+  DescribeAlarmsCommand,
+  DisableAlarmActionsCommand,
+  ListMetricsCommand,
+  PutMetricAlarmCommand,
+  PutMetricDataCommand,
+} from "@aws-sdk/client-cloudwatch";
+import {
+  CreateAccessKeyCommand,
+  CreateUserCommand,
+  PutUserPolicyCommand,
+} from "@aws-sdk/client-iam";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertObjectMatches,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { afterAll, beforeAll, describe, it } from "vitest";
+
+import { SimAwsLocalServer } from "../../../serve/index.js";
+import { SimAws } from "../../aws/sim-aws.js";
+
+interface AccessKey {
+  readonly accessKeyId: string;
+  readonly secretAccessKey: string;
+}
+
+/**
+ * Simulated CloudWatch reached over a port by a real `CloudWatchClient`.
+ *
+ * CloudWatch speaks the AWS JSON protocol under a service target of its own,
+ * `GraniteServiceVersion20100801`, and signs as `monitoring`. These cover
+ * whether a metric and an alarm written over the port come back out of the
+ * simulation holding them.
+ */
+describe("Serving simulated CloudWatch on an endpoint URL", () => {
+  const simAws = new SimAws();
+  const srv = new SimAwsLocalServer({ simAws });
+
+  let endpoint: string;
+  let client: CloudWatchClient;
+
+  beforeAll(async () => {
+    await srv.listen();
+    endpoint = `http://localhost:${srv.port}`;
+
+    client = cloudWatchClient(
+      await accessKeyFor("Widgets", {
+        Effect: "Allow",
+        Action: "cloudwatch:*",
+        Resource: "*",
+      }),
+    );
+  });
+
+  afterAll(async () => {
+    await srv.close();
+  });
+
+  it("publishes a metric a client reads back over the same endpoint", async () => {
+    // Given a real CloudWatch client holding an endpoint URL and credentials
+
+    // When it publishes an observation
+    await client.send(
+      new PutMetricDataCommand({
+        Namespace: "Orders",
+        MetricData: [
+          {
+            MetricName: "Failed",
+            Value: 3,
+            Unit: "Count",
+            Dimensions: [{ Name: "Channel", Value: "web" }],
+          },
+        ],
+      }),
+    );
+
+    // Then the metric it published is the one the endpoint lists
+    const listed = await client.send(
+      new ListMetricsCommand({ Namespace: "Orders" }),
+    );
+    const [metric] = listed.Metrics ?? [];
+    assertNonNullable(metric);
+    assertObjectMatches(metric, {
+      Namespace: "Orders",
+      MetricName: "Failed",
+      Dimensions: [{ Name: "Channel", Value: "web" }],
+    });
+  });
+
+  it("keeps an alarm a client wrote over the endpoint", async () => {
+    // Given an alarm written over the endpoint
+    await client.send(
+      new PutMetricAlarmCommand({
+        AlarmName: "FailedOrders",
+        Namespace: "Orders",
+        MetricName: "Failed",
+        Statistic: "Sum",
+        Period: 60,
+        EvaluationPeriods: 1,
+        Threshold: 5,
+        ComparisonOperator: "GreaterThanThreshold",
+      }),
+    );
+
+    // When the alarms are described
+    const described = await client.send(
+      new DescribeAlarmsCommand({ AlarmNames: ["FailedOrders"] }),
+    );
+
+    // Then the alarm comes back as it was written, waiting on its first
+    // evaluation
+    const [alarm] = described.MetricAlarms ?? [];
+    assertNonNullable(alarm);
+    assertObjectMatches(alarm, {
+      AlarmName: "FailedOrders",
+      Threshold: 5,
+      ComparisonOperator: "GreaterThanThreshold",
+      StateValue: "INSUFFICIENT_DATA",
+    });
+    assertIdentical(
+      alarm.AlarmArn,
+      `arn:aws:cloudwatch:${simAws.defaultRegionName}:` +
+        `${simAws.defaultAccountId}:alarm:FailedOrders`,
+    );
+  });
+
+  it("runs the request as the principal whose credentials signed it", async () => {
+    // Given a client signing as a User with no CloudWatch permission
+    const unprivileged = cloudWatchClient(
+      await accessKeyFor("Bystander", {
+        Effect: "Allow",
+        Action: "s3:GetObject",
+        Resource: "*",
+      }),
+    );
+
+    // When it asks what metrics there are
+    const error = await assertThrowsErrorAsync(
+      async () => await unprivileged.send(new ListMetricsCommand({})),
+    );
+
+    // Then simulated IAM refuses it, naming the User the signature belongs to
+    assertIdentical(error.name, "AccessDenied");
+    assertStringIncludes(error.message, "user/Bystander");
+    assertStringIncludes(error.message, "cloudwatch:ListMetrics");
+  });
+
+  it("refuses a CloudWatch operation it does not serve", async () => {
+    // When an operation simulated CloudWatch has no answer for is asked for
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await client.send(
+          new DisableAlarmActionsCommand({ AlarmNames: ["FailedOrders"] }),
+        ),
+    );
+
+    // Then the SDK raises it by name, rather than leaving the client to read a
+    // response it cannot parse
+    assertStringIncludes(error.message, "DisableAlarmActionsCommand");
+    assertStringIncludes(error.message, "Simulated CloudWatch");
+  });
+
+  function cloudWatchClient(credentials: AccessKey): CloudWatchClient {
+    return new CloudWatchClient({
+      region: simAws.defaultRegionName,
+      endpoint,
+      credentials,
+    });
+  }
+
+  /**
+   * An access key belonging to a new IAM User carrying one policy statement.
+   * A served request reaches nothing without one of these to sign with.
+   */
+  async function accessKeyFor(
+    username: string,
+    statement: object,
+  ): Promise<AccessKey> {
+    const simIam = simAws.iam();
+
+    await simIam.createUser(new CreateUserCommand({ UserName: username }));
+    await simIam.putUserPolicy(
+      new PutUserPolicyCommand({
+        UserName: username,
+        PolicyName: "Monitoring",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: statement,
+        }),
+      }),
+    );
+
+    const created = await simIam.createAccessKey(
+      new CreateAccessKeyCommand({ UserName: username }),
+    );
+
+    return {
+      accessKeyId: created.AccessKey.AccessKeyId,
+      secretAccessKey: created.AccessKey.SecretAccessKey,
+    };
+  }
+});

--- a/src/service/cloudwatch/serve/sim-cloudwatch-api.loc.test.ts
+++ b/src/service/cloudwatch/serve/sim-cloudwatch-api.loc.test.ts
@@ -158,8 +158,9 @@ describe("Serving simulated CloudWatch on an endpoint URL", () => {
         ),
     );
 
-    // Then the SDK raises it by name, rather than leaving the client to read a
-    // response it cannot parse
+    // Then the refusal comes back as an error the SDK raises under the name
+    // the endpoint gave it, naming the operation it turned down
+    assertIdentical(error.name, "SimSdkUnsupportedCommandError");
     assertStringIncludes(error.message, "DisableAlarmActionsCommand");
     assertStringIncludes(error.message, "Simulated CloudWatch");
   });


### PR DESCRIPTION
CloudWatch speaks the AWS JSON protocol under a service target of its own, `GraniteServiceVersion20100801`, and signs as `monitoring`. The served endpoint's service-target map missed it on both counts and refused every CloudWatch request with `501 Not Implemented`. One map entry puts the nine operations simulated CloudWatch routes within reach of `aws cloudwatch` and of any SDK client holding an endpoint URL. `GetMetricStatistics` and `GetMetricData` stay out of reach, because the JSON protocol carries their window as epoch seconds and the endpoint passes that number through as it arrives. Both still answer in process and through SDK interception, and the serve docs say so.

Resolves https://github.com/KensioSoftware/yulin/issues/684

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`

See https://www.conventionalcommits.org/en/v1.0.0/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CloudWatch support to the served AWS service list.
  * CloudWatch metric queries, including windowed reads, now work through HTTP serving and SDK interception.
  * CloudWatch operations support metric publication and listing, alarm persistence, and IAM-based authorization.

* **Documentation**
  * Documented CloudWatch support, supported metric queries, and timestamp behavior.

* **Bug Fixes**
  * Improved handling of CloudWatch service identification for SDK requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->