### PR TITLE
feat: index faces into a Rekognition collection

### DIFF
--- a/docs/services/rekognition/README.md
+++ b/docs/services/rekognition/README.md
@@ -306,9 +306,10 @@ excludes the chin.
 ## Declaring results
 
 Results are declared per operation. `moderation()` holds the rules `DetectModerationLabels` answers
-from, `labels()` holds the rules `DetectLabels` answers from, and `faces()` holds the rules
-`DetectFaces` answers from. All three take the same three kinds of rule, being an exact S3
-object name, an exact content hash, or anything at all.
+from, `labels()` holds the rules `DetectLabels` answers from, `faces()` holds the rules
+`DetectFaces` answers from, and `faceMatches()` holds the rules `SearchFacesByImage` answers from.
+All four take the same three kinds of rule, being an exact S3 object name, an exact content hash, or
+anything at all.
 
 ```typescript sim-rekognition-moderation-rules
 /**
@@ -353,6 +354,60 @@ detecting on it changes the digest, so hash the exact bytes the test puts throug
 A label can be declared as a name on its own, or as a name with what is to be reported alongside it.
 A moderation label declared as a name reports at a confidence of `96.68000030517578`, and a
 detection label at `97.53010559082031`.
+
+`faceMatches()` declares people where the other three declare labels. A match names one indexed
+face, by the `ExternalImageId` it was indexed under or by the `FaceId` `IndexFaces` answered with,
+and says how alike the search reports it as.
+
+```typescript sim-rekognition-face-match-rules
+/**
+ * The two ways a rule names the face a search finds.
+ */
+
+import {
+  CreateCollectionCommand,
+  IndexFacesCommand,
+} from "@aws-sdk/client-rekognition";
+import { SimAws } from "@kensio/yulin";
+import { simRekognitionSampleImages } from "@kensio/yulin/rekognition";
+
+const simAws = new SimAws();
+const simRekognition = simAws.rekognition();
+const faceMatches = simRekognition.faceMatches();
+
+// Every image starts here, finding nobody.
+faceMatches.byDefault({ matches: [] });
+
+// By the id the indexing chose. A test can write this before the face exists.
+faceMatches.onName("door/visitor.jpg", {
+  matches: [{ externalImageId: "ada", similarity: 98.5 }],
+});
+
+// By the id IndexFaces answered with, for an application that keeps it.
+await simRekognition.createCollection(
+  new CreateCollectionCommand({ CollectionId: "staff" }),
+);
+
+const indexed = await simRekognition.indexFaces(
+  new IndexFacesCommand({
+    CollectionId: "staff",
+    Image: { Bytes: simRekognitionSampleImages.oneFace() },
+  }),
+);
+
+faceMatches.onName("door/courier.jpg", {
+  matches: indexed.FaceRecords.map((record) => ({
+    faceId: record.Face.FaceId,
+  })),
+});
+```
+
+An `externalImageId` rule can be written before anything is indexed. That suits a test whose own
+code registers the face. A `faceId` rule is written after the indexing that issued the id, and names
+one face exactly. Where the same external image id covers several faces, each one comes back as its
+own match. A match that states no similarity reports at `99.97222137451172`, the similarity in the
+AWS `SearchFacesByImage` example response. Declaring both kinds of id on one match, or neither, is
+refused where the rule is written.
 
 ## Sample images
 
@@ -716,7 +771,7 @@ ever. Filter the notification configuration by prefix or suffix, as this one doe
 
 ## Face collections
 
-A collection is what lets an application recognise the same person twice, where a detection answers what is in one image. Simulated Rekognition holds the collections themselves.
+A collection is what lets an application recognise the same person twice, where a detection answers what is in one image.
 
 ```typescript sim-rekognition-collections
 /**
@@ -756,6 +811,114 @@ A collection belongs to one Account and Region, as it does on AWS, so a listing 
 
 Every collection reports face model version 7.0. Real Rekognition stamps a collection with the version in force when it was created, and that version moves as AWS retrains. Nothing here recognises a face, so one fixed version is stated rather than a moving one invented.
 
+## Indexing faces and finding them again
+
+`IndexFaces` puts the faces an image holds into a collection. Which faces an image holds is what the
+`faces()` rules declare, the same rules `DetectFaces` answers from. An image with one declared face
+indexes one face, at the bounding box and the confidence that rule gave it, and an image no rule
+matches indexes the built-in default face.
+
+`SearchFacesByImage` answers from the `faceMatches()` rules. They say which indexed faces one image
+finds, and an image no rule matches finds nobody.
+
+```typescript sim-rekognition-face-indexing
+/**
+ * Indexing a face into a collection and recognising the same person later.
+ */
+
+import {
+  CreateCollectionCommand,
+  DeleteFacesCommand,
+  IndexFacesCommand,
+  ListFacesCommand,
+  SearchFacesByImageCommand,
+} from "@aws-sdk/client-rekognition";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+import { simRekognitionSampleImages } from "@kensio/yulin/rekognition";
+
+const simAws = new SimAws();
+const simRekognition = simAws.rekognition();
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "photos" }));
+await simAws.s3().putObject(
+  new PutObjectCommand({
+    Bucket: "photos",
+    Key: "staff/ada.jpg",
+    Body: simRekognitionSampleImages.oneFace(),
+  }),
+);
+await simAws.s3().putObject(
+  new PutObjectCommand({
+    Bucket: "photos",
+    Key: "door/visitor.jpg",
+    Body: simRekognitionSampleImages.oneFace(),
+  }),
+);
+
+await simRekognition.createCollection(
+  new CreateCollectionCommand({ CollectionId: "staff" }),
+);
+
+const indexed = await simRekognition.indexFaces(
+  new IndexFacesCommand({
+    CollectionId: "staff",
+    Image: { S3Object: { Bucket: "photos", Name: "staff/ada.jpg" } },
+    ExternalImageId: "ada",
+  }),
+);
+
+console.log(indexed.FaceRecords.map((record) => record.Face.ExternalImageId));
+// [ "ada" ]
+
+const listed = await simRekognition.listFaces(
+  new ListFacesCommand({ CollectionId: "staff" }),
+);
+
+console.log(listed.Faces.length); // 1
+
+// The visitor at the door is declared to be that member of staff.
+simRekognition
+  .faceMatches()
+  .onName("door/visitor.jpg", { matches: [{ externalImageId: "ada" }] });
+
+const found = await simRekognition.searchFacesByImage(
+  new SearchFacesByImageCommand({
+    CollectionId: "staff",
+    Image: { S3Object: { Bucket: "photos", Name: "door/visitor.jpg" } },
+  }),
+);
+
+console.log(found.FaceMatches.map((match) => match.Face.ExternalImageId));
+// [ "ada" ]
+
+const deleted = await simRekognition.deleteFaces(
+  new DeleteFacesCommand({
+    CollectionId: "staff",
+    FaceIds: listed.Faces.map((face) => face.FaceId),
+  }),
+);
+
+console.log(deleted.DeletedFaces.length); // 1
+```
+
+Each indexed face gets a `FaceId` of its own, and every face from one call shares an `ImageId`. Both
+are uuids, as they are on AWS. An application that stores a `FaceId` and looks it up later works
+here the way it works there.
+
+A declared match reaches the faces the searched collection holds. `DeleteFaces` removes one and the
+same rule then finds nobody. One rule covers both sides of a deletion. `DeletedFaces` reports the
+ids that were there, and an id the collection never held is left out of it.
+
+`FaceMatchThreshold` filters on the similarity the rule stated and defaults to 80, as it does on
+AWS. `MaxFaces` caps how many matches come back, most alike first. A search with an image the
+`faces()` rules give no face raises `InvalidParameterException`, as real Rekognition does when there
+is no face to search with.
+
+`ListFaces` reports the faces one collection holds, in the order they were indexed, and narrows to
+the ids a request names. `MaxResults` pages the listing and the `NextToken` in the response reaches
+the next page. A listing that asks for no page size comes back whole.
+
 ## Permissions and errors
 
 Each detection is authorized as its own action against `*`, one of
@@ -763,10 +926,13 @@ Each detection is authorized as its own action against `*`, one of
 Rekognition gives the detection operations no resource-level permissions, and a policy naming an ARN
 reaches nothing, here as on AWS.
 
-A collection is the other kind. It has an ARN, so `rekognition:CreateCollection` and
-`rekognition:DeleteCollection` authorize against that collection's ARN, and a policy naming one
-collection reaches only that collection. `rekognition:ListCollections` reads them all, so it
-authorizes against `*`. A denial throws `AccessDeniedException` with a 400 status, which is
+A collection is the other kind. It has an ARN, so `rekognition:CreateCollection`,
+`rekognition:DeleteCollection`, `rekognition:IndexFaces`, `rekognition:ListFaces`,
+`rekognition:SearchFacesByImage` and `rekognition:DeleteFaces` authorize against that collection's
+ARN, and a policy naming one collection reaches only that collection. `rekognition:ListCollections`
+reads them all, so it authorizes against `*`. Each face operation is authorized before the
+collection is looked up. A caller with no permission for a collection never learns whether it is
+there. A denial throws `AccessDeniedException` with a 400 status, which is
 what real Rekognition answers with, where several other services use 403.
 
 The caller is authorized for the detection before the image is read. A caller without the Rekognition
@@ -829,16 +995,36 @@ Simulated Rekognition currently supports:
   `rekognition:DetectFaces`, with the image read from S3 as the caller
 - `CreateCollectionCommand`, `ListCollectionsCommand` and `DeleteCollectionCommand`, scoped to one
   Account and Region
-- IAM authorization on `rekognition:CreateCollection` and `rekognition:DeleteCollection` against the
-  collection's own ARN, and on `rekognition:ListCollections` against `*`
+- `IndexFacesCommand`, `ListFacesCommand`, `SearchFacesByImageCommand` and `DeleteFacesCommand`,
+  with the faces put in a collection taken from the `faces()` rules for the image they came from
+- Face searches declared through `faceMatches()`, by the external image id a face was indexed under
+  or by the face id `IndexFaces` answered with, filtered by `FaceMatchThreshold` and capped by
+  `MaxFaces`
+- `ListFaces` narrowing to named face ids, and paging on `MaxResults` and `NextToken`
+- IAM authorization on `rekognition:CreateCollection`, `rekognition:DeleteCollection`,
+  `rekognition:IndexFaces`, `rekognition:ListFaces`, `rekognition:SearchFacesByImage` and
+  `rekognition:DeleteFaces` against the collection's own ARN, and on `rekognition:ListCollections`
+  against `*`
 - SDK interception of `RekognitionClient`, including from inside a simulated Lambda function
 
 ## Limitations
 
 - `DetectText`, `CompareFaces` and the video operations are left out. An intercepted client sending
   one of those Commands is refused by name.
-- A collection holds no faces. `IndexFaces`, `SearchFacesByImage`, `ListFaces` and `DeleteFaces` are
-  left out, so what a collection is here is its identity and its lifecycle.
+- `SearchFaces`, which searches by face id, and the `SearchUsers` and user association operations are
+  left out. An intercepted client sending one of those Commands is refused by name.
+- `QualityFilter` is refused on `IndexFaces` and `SearchFacesByImage`. Real Rekognition uses it to
+  drop faces it judges too blurry or too small. Nothing here judges an image. A filter set on the
+  request would drop faces on AWS and keep them here.
+- A `MaxFaces` on `IndexFaces` takes the faces in the order they were declared, and the rest come
+  back in `UnindexedFaces` as `EXCEEDS_MAX_FACES`. Real Rekognition indexes the largest.
+- A search reports the first face declared for the image as the one it searched with. Real
+  Rekognition uses the largest, and nothing here measures a face.
+- `UserId` is refused on `ListFaces` and `UnsuccessfulFaceDeletions` is always empty. A face is
+  never associated with a user here. A listing narrowed to one would answer with the whole
+  collection.
+- A `ListFaces` page with no `MaxResults` holds the whole collection. Real Rekognition pages at a
+  thousand faces. The two differ only for a collection larger than that.
 - A face detection reports the emotions that were declared and no others. Real `DetectFaces` returns
   all eight emotion types every time, with the ones it failed to see at a low confidence. Declare
   the emotions the code under test reads.

--- a/docs/services/rekognition/README.md
+++ b/docs/services/rekognition/README.md
@@ -378,7 +378,8 @@ const faceMatches = simRekognition.faceMatches();
 // Every image starts here, finding nobody.
 faceMatches.byDefault({ matches: [] });
 
-// By the id the indexing chose. A test can write this before the face exists.
+// By the external image id the indexing request gave the face. A test can
+// write this before anything is indexed.
 faceMatches.onName("door/visitor.jpg", {
   matches: [{ externalImageId: "ada", similarity: 98.5 }],
 });
@@ -908,7 +909,8 @@ here the way it works there.
 
 A declared match reaches the faces the searched collection holds. `DeleteFaces` removes one and the
 same rule then finds nobody. One rule covers both sides of a deletion. `DeletedFaces` reports the
-ids that were there, and an id the collection never held is left out of it.
+ids that were there, and an id the collection never held comes back in
+`UnsuccessfulFaceDeletions` as `FACE_NOT_FOUND`.
 
 `FaceMatchThreshold` filters on the similarity the rule stated and defaults to 80, as it does on
 AWS. `MaxFaces` caps how many matches come back, most alike first. A search with an image the
@@ -1020,9 +1022,9 @@ Simulated Rekognition currently supports:
   back in `UnindexedFaces` as `EXCEEDS_MAX_FACES`. Real Rekognition indexes the largest.
 - A search reports the first face declared for the image as the one it searched with. Real
   Rekognition uses the largest, and nothing here measures a face.
-- `UserId` is refused on `ListFaces` and `UnsuccessfulFaceDeletions` is always empty. A face is
-  never associated with a user here. A listing narrowed to one would answer with the whole
-  collection.
+- `UserId` is refused on `ListFaces`, and `UnsuccessfulFaceDeletions` never reports
+  `ASSOCIATED_TO_AN_EXISTING_USER`. A face is never associated with a user here. A listing narrowed
+  to one would answer with the whole collection.
 - A `ListFaces` page with no `MaxResults` holds the whole collection. Real Rekognition pages at a
   thousand faces. The two differ only for a collection larger than that.
 - A face detection reports the emotions that were declared and no others. Real `DetectFaces` returns

--- a/docs/services/rekognition/sim-rekognition-face-indexing.example.ts
+++ b/docs/services/rekognition/sim-rekognition-face-indexing.example.ts
@@ -1,0 +1,78 @@
+/**
+ * Indexing a face into a collection and recognising the same person later.
+ */
+
+import {
+  CreateCollectionCommand,
+  DeleteFacesCommand,
+  IndexFacesCommand,
+  ListFacesCommand,
+  SearchFacesByImageCommand,
+} from "@aws-sdk/client-rekognition";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+import { simRekognitionSampleImages } from "@kensio/yulin/rekognition";
+
+const simAws = new SimAws();
+const simRekognition = simAws.rekognition();
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "photos" }));
+await simAws.s3().putObject(
+  new PutObjectCommand({
+    Bucket: "photos",
+    Key: "staff/ada.jpg",
+    Body: simRekognitionSampleImages.oneFace(),
+  }),
+);
+await simAws.s3().putObject(
+  new PutObjectCommand({
+    Bucket: "photos",
+    Key: "door/visitor.jpg",
+    Body: simRekognitionSampleImages.oneFace(),
+  }),
+);
+
+await simRekognition.createCollection(
+  new CreateCollectionCommand({ CollectionId: "staff" }),
+);
+
+const indexed = await simRekognition.indexFaces(
+  new IndexFacesCommand({
+    CollectionId: "staff",
+    Image: { S3Object: { Bucket: "photos", Name: "staff/ada.jpg" } },
+    ExternalImageId: "ada",
+  }),
+);
+
+console.log(indexed.FaceRecords.map((record) => record.Face.ExternalImageId));
+// [ "ada" ]
+
+const listed = await simRekognition.listFaces(
+  new ListFacesCommand({ CollectionId: "staff" }),
+);
+
+console.log(listed.Faces.length); // 1
+
+// The visitor at the door is declared to be that member of staff.
+simRekognition
+  .faceMatches()
+  .onName("door/visitor.jpg", { matches: [{ externalImageId: "ada" }] });
+
+const found = await simRekognition.searchFacesByImage(
+  new SearchFacesByImageCommand({
+    CollectionId: "staff",
+    Image: { S3Object: { Bucket: "photos", Name: "door/visitor.jpg" } },
+  }),
+);
+
+console.log(found.FaceMatches.map((match) => match.Face.ExternalImageId));
+// [ "ada" ]
+
+const deleted = await simRekognition.deleteFaces(
+  new DeleteFacesCommand({
+    CollectionId: "staff",
+    FaceIds: listed.Faces.map((face) => face.FaceId),
+  }),
+);
+
+console.log(deleted.DeletedFaces.length); // 1

--- a/docs/services/rekognition/sim-rekognition-face-match-rules.example.ts
+++ b/docs/services/rekognition/sim-rekognition-face-match-rules.example.ts
@@ -1,0 +1,40 @@
+/**
+ * The two ways a rule names the face a search finds.
+ */
+
+import {
+  CreateCollectionCommand,
+  IndexFacesCommand,
+} from "@aws-sdk/client-rekognition";
+import { SimAws } from "@kensio/yulin";
+import { simRekognitionSampleImages } from "@kensio/yulin/rekognition";
+
+const simAws = new SimAws();
+const simRekognition = simAws.rekognition();
+const faceMatches = simRekognition.faceMatches();
+
+// Every image starts here, finding nobody.
+faceMatches.byDefault({ matches: [] });
+
+// By the id the indexing chose. A test can write this before the face exists.
+faceMatches.onName("door/visitor.jpg", {
+  matches: [{ externalImageId: "ada", similarity: 98.5 }],
+});
+
+// By the id IndexFaces answered with, for an application that keeps it.
+await simRekognition.createCollection(
+  new CreateCollectionCommand({ CollectionId: "staff" }),
+);
+
+const indexed = await simRekognition.indexFaces(
+  new IndexFacesCommand({
+    CollectionId: "staff",
+    Image: { Bytes: simRekognitionSampleImages.oneFace() },
+  }),
+);
+
+faceMatches.onName("door/courier.jpg", {
+  matches: indexed.FaceRecords.map((record) => ({
+    faceId: record.Face.FaceId,
+  })),
+});

--- a/docs/services/rekognition/sim-rekognition-face-match-rules.example.ts
+++ b/docs/services/rekognition/sim-rekognition-face-match-rules.example.ts
@@ -16,7 +16,8 @@ const faceMatches = simRekognition.faceMatches();
 // Every image starts here, finding nobody.
 faceMatches.byDefault({ matches: [] });
 
-// By the id the indexing chose. A test can write this before the face exists.
+// By the external image id the indexing request gave the face. A test can
+// write this before anything is indexed.
 faceMatches.onName("door/visitor.jpg", {
   matches: [{ externalImageId: "ada", similarity: 98.5 }],
 });

--- a/src/service/rekognition/README.md
+++ b/src/service/rekognition/README.md
@@ -2,7 +2,8 @@
 
 This directory contains the simulated Rekognition implementation. Three image detections are
 simulated, `DetectModerationLabels`, `DetectLabels` and `DetectFaces`, each for an image supplied as
-bytes or as an S3 object.
+bytes or as an S3 object, along with the face collections that hold indexed faces and the search
+that finds them again.
 
 The guiding decision here is that no image recognition happens. Rekognition is a service where the
 interesting behaviour is not the call but what the call returns, so the simulation maintains no
@@ -16,10 +17,10 @@ IAM decision, and the taxonomy a returned label belongs to.
 - `sim-rekognition.ts` is the service facade for one account/region scope.
 - `index.ts` exports the public Rekognition simulator API for `@kensio/yulin/rekognition`.
 
-`SimRekognition` owns a `SimRekognitionModeration`, a `SimRekognitionLabels` and a
-`SimRekognitionFaces`, which own the rules the three detections answer from. Rules are grouped per
-operation rather than hung off the facade, so an operation group is added beside the others without
-the facade growing a result shape for each.
+`SimRekognition` owns a `SimRekognitionModeration`, a `SimRekognitionLabels`, a
+`SimRekognitionFaces` and a `SimRekognitionFaceMatches`, which own the rules the operations answer
+from. Rules are grouped per operation rather than hung off the facade, so an operation group is
+added beside the others without the facade growing a result shape for each.
 
 The service is scoped to an account and region because its rules are: a detection made in one Region
 is answered by the rules registered in that Region, as a real Rekognition endpoint answers for the
@@ -28,16 +29,41 @@ Region it belongs to. Face collections are scoped by that same instance. That is
 
 ## The collection model
 
-`collection/` holds the face collections one Account and Region owns, and
-`command/collection/collection.handler.ts` holds the three operations that work on them. They share
-a store and an authorization shape, which is what makes them one handler and not three.
+`collection/` holds the face collections one Account and Region owns.
+`command/collection/collection.handler.ts` holds the three lifecycle operations and
+`command/face/face.handler.ts` holds the four that work on the faces inside one. Each group shares a
+store and an authorization shape, which is what makes each of them one handler.
 
 A collection is the one Rekognition resource with an ARN, so those operations authorize against it
 where the detections authorize against `*`. That is why `SimRekognitionAuthorizer.authorize` takes an
-optional resource.
+optional resource. Every face operation authorizes before it looks the collection up. A denial and
+a missing collection stay separate, and a caller with no permission for a collection never learns
+whether it is there.
 
-Nothing is indexed into a collection yet, so what a collection is here is its identity, its ARN and
-its model version.
+The faces live on the collection record, in `SimRekognitionCollectionFaces`. Removing a collection
+removes its faces with it, as it does on AWS.
+
+`SimRekognitionIndexedFace` keeps the `SimRekognitionDetectedFace` it was indexed from. A face
+indexed from an image and a face detected in that same image are then the same face, and `ListFaces`
+reports the bounding box and confidence the `faces()` rules declared, whatever
+`DetectionAttributes` the indexing asked for.
+
+## The face search model
+
+`match/` is the fourth rule set, and it answers `SearchFacesByImage`. The decision that matters
+lives here. Nothing in this simulation compares one face with another. Which indexed faces a search
+image finds is declared, the way every other Rekognition result here is.
+
+A declared match names one indexed face, by the `ExternalImageId` it was indexed under or by the
+`FaceId` `IndexFaces` answered with. Both are carried because each covers a case the other cannot. A
+test whose own code registers the face knows the external image id in advance and can write the rule
+before anything exists. An application that keeps the generated face id has no external image id to
+name, and writes the rule after the indexing that issued it. Declaring both on one match, or
+neither, is refused where the rule is written.
+
+`SimRekognitionFaceMatchRule` resolves the declaration and leaves the lookup for the search. The
+collection being searched decides which faces a rule reaches. A deleted face then stops being found
+with the rule unchanged, and one rule covers both sides of a deletion.
 
 ## The rule mechanism
 

--- a/src/service/rekognition/collection/sim-rekognition-collection-faces.ts
+++ b/src/service/rekognition/collection/sim-rekognition-collection-faces.ts
@@ -1,0 +1,71 @@
+import type { SimRekognitionIndexedFace } from "./sim-rekognition-indexed-face.js";
+
+/**
+ * The faces one collection holds.
+ *
+ * They are kept in the order they were indexed, which is the order a listing
+ * reports them in. Real Rekognition documents no order for `ListFaces`, so
+ * indexing order is a simulator convention rather than AWS behaviour.
+ */
+export class SimRekognitionCollectionFaces {
+  private readonly faces = new Map<string, SimRekognitionIndexedFace>();
+
+  /**
+   * Record a face against this collection.
+   */
+  index(face: SimRekognitionIndexedFace): void {
+    this.faces.set(face.faceId, face);
+  }
+
+  /**
+   * Every face held here.
+   */
+  all(): readonly SimRekognitionIndexedFace[] {
+    return this.faces.values().toArray();
+  }
+
+  /**
+   * The faces with these ids, leaving out any id this collection does not
+   * hold.
+   */
+  withIds(faceIds: readonly string[]): readonly SimRekognitionIndexedFace[] {
+    const wanted = new Set(faceIds);
+
+    return this.all().filter((face) => wanted.has(face.faceId));
+  }
+
+  /**
+   * The face with this id, when this collection holds it.
+   */
+  withFaceId(faceId: string): SimRekognitionIndexedFace | undefined {
+    return this.faces.get(faceId);
+  }
+
+  /**
+   * The faces indexed under this external image id.
+   *
+   * There can be several. Real Rekognition takes an `ExternalImageId` as a
+   * label the caller chose rather than as a key, so a photograph of the same
+   * person indexed twice leaves two faces under one id.
+   */
+  withExternalImageId(
+    externalImageId: string,
+  ): readonly SimRekognitionIndexedFace[] {
+    return this.all().filter(
+      (face) => face.externalImageId === externalImageId,
+    );
+  }
+
+  /**
+   * Remove the faces with these ids, answering with the ids that were held.
+   */
+  remove(faceIds: readonly string[]): readonly string[] {
+    const removed = this.withIds(faceIds).map((face) => face.faceId);
+
+    for (const faceId of removed) {
+      this.faces.delete(faceId);
+    }
+
+    return removed;
+  }
+}

--- a/src/service/rekognition/collection/sim-rekognition-collection-faces.ts
+++ b/src/service/rekognition/collection/sim-rekognition-collection-faces.ts
@@ -1,6 +1,14 @@
 import type { SimRekognitionIndexedFace } from "./sim-rekognition-indexed-face.js";
 
 /**
+ * What one removal reached, and what it asked for and did not find.
+ */
+export interface SimRekognitionFaceRemoval {
+  readonly removed: readonly string[];
+  readonly missing: readonly string[];
+}
+
+/**
  * The faces one collection holds.
  *
  * They are kept in the order they were indexed, which is the order a listing
@@ -57,15 +65,26 @@ export class SimRekognitionCollectionFaces {
   }
 
   /**
-   * Remove the faces with these ids, answering with the ids that were held.
+   * Remove the faces with these ids.
+   *
+   * An id this collection does not hold is reported back rather than dropped,
+   * because real Rekognition answers for every id a request named. A request
+   * naming the same id twice is one removal, since the second one would
+   * otherwise be reported as a face that could not be found.
    */
-  remove(faceIds: readonly string[]): readonly string[] {
-    const removed = this.withIds(faceIds).map((face) => face.faceId);
+  remove(faceIds: readonly string[]): SimRekognitionFaceRemoval {
+    const removed: string[] = [];
+    const missing: string[] = [];
+    const wanted = new Set(faceIds);
 
-    for (const faceId of removed) {
-      this.faces.delete(faceId);
+    for (const faceId of wanted) {
+      if (this.faces.delete(faceId)) {
+        removed.push(faceId);
+      } else {
+        missing.push(faceId);
+      }
     }
 
-    return removed;
+    return { removed, missing };
   }
 }

--- a/src/service/rekognition/collection/sim-rekognition-collection.ts
+++ b/src/service/rekognition/collection/sim-rekognition-collection.ts
@@ -1,4 +1,5 @@
 import type { Brand } from "../../../util/brand.type.js";
+import type { SimRekognitionCollectionFaces } from "./sim-rekognition-collection-faces.js";
 
 export type SimRekognitionCollectionId = Brand<
   string,
@@ -17,13 +18,14 @@ export const simRekognitionFaceModelVersion = "7.0";
 /**
  * One simulated Rekognition face collection.
  *
- * A collection holds indexed faces in real Rekognition. This simulation has no
- * faces to put in one yet, so what a collection is here is its identity, which
- * is what the operations that create, list and remove it work with.
+ * A collection is its identity and the faces indexed into it. The faces belong
+ * to the collection record rather than to a store of their own, so removing a
+ * collection removes the faces with it, as it does on AWS.
  */
 export interface SimRekognitionCollection {
   readonly collectionId: SimRekognitionCollectionId;
   readonly arn: string;
   readonly faceModelVersion: string;
   readonly createdAt: Date;
+  readonly faces: SimRekognitionCollectionFaces;
 }

--- a/src/service/rekognition/collection/sim-rekognition-collections.ts
+++ b/src/service/rekognition/collection/sim-rekognition-collections.ts
@@ -3,6 +3,7 @@ import {
   SimRekognitionResourceAlreadyExistsException,
   SimRekognitionResourceNotFoundException,
 } from "../error/sim-rekognition.error.js";
+import { SimRekognitionCollectionFaces } from "./sim-rekognition-collection-faces.js";
 import {
   simRekognitionFaceModelVersion,
   type SimRekognitionCollection,
@@ -65,8 +66,30 @@ export class SimRekognitionCollections {
       arn: this.arnFor(collectionId),
       faceModelVersion: simRekognitionFaceModelVersion,
       createdAt,
+      faces: new SimRekognitionCollectionFaces(),
     };
     this.collections.set(id, collection);
+
+    return collection;
+  }
+
+  /**
+   * The collection of this name, refusing one that was never created.
+   *
+   * Every operation that works on the faces in a collection needs this, and
+   * real Rekognition reports a collection it does not hold the same way
+   * whichever operation asked for it.
+   */
+  require(collectionId: string): SimRekognitionCollection {
+    const collection = this.collections.get(
+      collectionId as SimRekognitionCollectionId,
+    );
+
+    if (collection === undefined) {
+      throw new SimRekognitionResourceNotFoundException(
+        `Rekognition collection ${collectionId} does not exist`,
+      );
+    }
 
     return collection;
   }
@@ -82,16 +105,9 @@ export class SimRekognitionCollections {
    * Remove a collection, refusing one that was never created.
    */
   remove(collectionId: string): SimRekognitionCollection {
-    const id = collectionId as SimRekognitionCollectionId;
-    const collection = this.collections.get(id);
+    const collection = this.require(collectionId);
 
-    if (collection === undefined) {
-      throw new SimRekognitionResourceNotFoundException(
-        `Rekognition collection ${collectionId} does not exist`,
-      );
-    }
-
-    this.collections.delete(id);
+    this.collections.delete(collection.collectionId);
 
     return collection;
   }

--- a/src/service/rekognition/collection/sim-rekognition-indexed-face.ts
+++ b/src/service/rekognition/collection/sim-rekognition-indexed-face.ts
@@ -1,0 +1,74 @@
+import type {
+  SimRekognitionFaceOutput,
+  SimRekognitionFaceRecordOutput,
+} from "../command/face/face-output.js";
+import type { SimRekognitionFaceAttributes } from "../face/sim-rekognition-face-attributes.js";
+import type { SimRekognitionDetectedFace } from "../face/sim-rekognition-detected-face.js";
+
+interface SimRekognitionIndexedFaceProperties {
+  readonly faceId: string;
+  readonly imageId: string;
+  readonly externalImageId: string | undefined;
+  readonly faceModelVersion: string;
+  readonly detected: SimRekognitionDetectedFace;
+}
+
+/**
+ * One face indexed into a collection.
+ *
+ * The face it was indexed from is kept rather than a copy of the detail, so
+ * the bounding box and confidence a collection reports are the ones the
+ * `faces()` rules declared for the image it came from. A face indexed from an
+ * image and a face detected in that same image are then the same face.
+ */
+export class SimRekognitionIndexedFace {
+  public readonly faceId: string;
+  public readonly externalImageId: string | undefined;
+
+  private readonly imageId: string;
+  private readonly faceModelVersion: string;
+  private readonly detected: SimRekognitionDetectedFace;
+
+  constructor(properties: SimRekognitionIndexedFaceProperties) {
+    this.faceId = properties.faceId;
+    this.imageId = properties.imageId;
+    this.externalImageId = properties.externalImageId;
+    this.faceModelVersion = properties.faceModelVersion;
+    this.detected = properties.detected;
+  }
+
+  /**
+   * This face as a listing or a search match reports it.
+   *
+   * Real Rekognition keeps a face vector rather than the detail the indexing
+   * request asked for, so a face read back this way carries a bounding box
+   * and a confidence whatever `DetectionAttributes` the indexing asked for.
+   */
+  stored(): SimRekognitionFaceOutput {
+    const boundingBox = this.detected.boundingBox();
+
+    return {
+      FaceId: this.faceId,
+      ImageId: this.imageId,
+      ...(boundingBox !== undefined && { BoundingBox: boundingBox }),
+      ...(this.externalImageId !== undefined && {
+        ExternalImageId: this.externalImageId,
+      }),
+      Confidence: this.detected.confidence(),
+      IndexFacesModelVersion: this.faceModelVersion,
+    };
+  }
+
+  /**
+   * This face as the indexing that stored it reports it, with the detail that
+   * request asked for.
+   */
+  record(
+    attributes: SimRekognitionFaceAttributes,
+  ): SimRekognitionFaceRecordOutput {
+    return {
+      Face: this.stored(),
+      FaceDetail: this.detected.detailFor(attributes),
+    };
+  }
+}

--- a/src/service/rekognition/command/face/delete-faces-request.ts
+++ b/src/service/rekognition/command/face/delete-faces-request.ts
@@ -1,0 +1,25 @@
+import { requiredCollectionId } from "../collection/collection-id.js";
+import { SimRekognitionUnsimulatedInput } from "../sim-rekognition-unsimulated-input.js";
+import { requiredFaceIds } from "./face-ids.js";
+import type { SimDeleteFacesCommandInput } from "./face.command.js";
+
+const operation = "DeleteFaces";
+const acceptedInput = ["CollectionId", "FaceIds"];
+
+/**
+ * A DeleteFaces request, checked before anything acts on it.
+ */
+export class DeleteFacesRequest {
+  public readonly collectionId: string;
+  public readonly faceIds: readonly string[];
+
+  constructor(input: SimDeleteFacesCommandInput) {
+    new SimRekognitionUnsimulatedInput(operation).refuseUnaccepted(
+      input,
+      acceptedInput,
+    );
+
+    this.collectionId = requiredCollectionId(input.CollectionId);
+    this.faceIds = requiredFaceIds(input.FaceIds);
+  }
+}

--- a/src/service/rekognition/command/face/external-image-id.ts
+++ b/src/service/rekognition/command/face/external-image-id.ts
@@ -1,0 +1,36 @@
+import { SimRekognitionInvalidParameterException } from "../../error/sim-rekognition.error.js";
+
+/**
+ * The characters real Rekognition accepts in an ExternalImageId.
+ *
+ * https://docs.aws.amazon.com/rekognition/latest/APIReference/API_IndexFaces.html
+ */
+const accepted = /^[\w.\-:]+$/;
+
+const longest = 255;
+
+/**
+ * The external image id an indexing request chose, checked as AWS checks it.
+ *
+ * It is the id an application ties a face back to its own records with, so it
+ * is checked here rather than stored as given: an id real Rekognition would
+ * refuse would otherwise work in a test and fail in production.
+ */
+export function acceptedExternalImageId(
+  externalImageId: string | undefined,
+): string | undefined {
+  if (externalImageId === undefined) {
+    return undefined;
+  }
+
+  if (externalImageId.length > longest || !accepted.test(externalImageId)) {
+    throw new SimRekognitionInvalidParameterException(
+      `Request has invalid parameters: ExternalImageId of ` +
+        `'${externalImageId}' is not one Rekognition accepts, which is up ` +
+        `to ${String(longest)} letters, digits, underscores, hyphens, full ` +
+        `stops and colons`,
+    );
+  }
+
+  return externalImageId;
+}

--- a/src/service/rekognition/command/face/face-iam.iso.test.ts
+++ b/src/service/rekognition/command/face/face-iam.iso.test.ts
@@ -1,0 +1,189 @@
+import {
+  CreateCollectionCommand,
+  DeleteFacesCommand,
+  IndexFacesCommand,
+  ListFacesCommand,
+  SearchFacesByImageCommand,
+} from "@aws-sdk/client-rekognition";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { redPngBytes } from "../../../../../test/rekognition/image-fixture.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simIamRoleWithPolicyFactory } from "../../../iam/role/sim-iam-role-with-policy.factory.js";
+
+const faceActions = [
+  "rekognition:IndexFaces",
+  "rekognition:ListFaces",
+  "rekognition:SearchFacesByImage",
+  "rekognition:DeleteFaces",
+];
+
+/**
+ * The image is passed as bytes, so these tests are about the Rekognition
+ * decision alone. The S3 read a request naming an object makes is authorized
+ * separately, as the caller, and the detection tests cover that.
+ */
+const photo = { Bytes: redPngBytes };
+
+async function simAwsWithCollection(collectionId: string): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simAws
+    .rekognition()
+    .createCollection(
+      new CreateCollectionCommand({ CollectionId: collectionId }),
+    );
+
+  return simAws;
+}
+
+describe("Authorizing simulated Rekognition face operations", () => {
+  it("allows a caller whose policy names the collection it works on", async () => {
+    // Given a Role allowed the face operations on one collection
+    const simAws = await simAwsWithCollection("staff");
+    const role = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "FaceIndexer",
+        actions: faceActions,
+        resource: `arn:aws:rekognition:${simAws.defaultRegionName}:${simAws.defaultAccountId}:collection/staff`,
+      },
+      simAws,
+    );
+    const caller = { kind: "arn" as const, arn: role.Arn };
+
+    // When it indexes a face and lists the collection back
+    const indexed = await simAws
+      .rekognition()
+      .indexFaces(
+        new IndexFacesCommand({ CollectionId: "staff", Image: photo }),
+        { caller },
+      );
+    const listed = await simAws
+      .rekognition()
+      .listFaces(new ListFacesCommand({ CollectionId: "staff" }), { caller });
+
+    // Then both run
+    assertArrayLength(indexed.FaceRecords, 1);
+    assertArrayLength(listed.Faces, 1);
+  });
+
+  it("refuses a caller whose policy names another collection", async () => {
+    // Given a Role allowed the face operations on one collection only
+    const simAws = await simAwsWithCollection("visitors");
+    const role = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "StaffIndexer",
+        actions: faceActions,
+        resource: `arn:aws:rekognition:${simAws.defaultRegionName}:${simAws.defaultAccountId}:collection/staff`,
+      },
+      simAws,
+    );
+
+    // When it indexes into the collection it was not named for
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws
+          .rekognition()
+          .indexFaces(
+            new IndexFacesCommand({ CollectionId: "visitors", Image: photo }),
+            { caller: { kind: "arn", arn: role.Arn } },
+          ),
+    );
+
+    // Then it is refused, which a wildcard resource could not have expressed
+    assertIdentical(error.name, "AccessDeniedException");
+    assertStringIncludes(error.message, "rekognition:IndexFaces");
+  });
+
+  it("tells a caller with no permission nothing about the collection", async () => {
+    // Given a caller allowed nothing and a collection that was never created
+    const simAws = new SimAws();
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "Nobody", actions: [] },
+      simAws,
+    );
+
+    // When it lists a collection that does not exist
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws
+          .rekognition()
+          .listFaces(new ListFacesCommand({ CollectionId: "absent" }), {
+            caller: { kind: "arn", arn: role.Arn },
+          }),
+    );
+
+    // Then the denial comes first, so whether the collection is there is not
+    // something an unauthorized caller can find out
+    assertIdentical(error.name, "AccessDeniedException");
+  });
+});
+
+describe("Working on a simulated Rekognition collection that was never created", () => {
+  it("refuses to index a face into it", async () => {
+    const simAws = new SimAws();
+
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.rekognition().indexFaces(
+          new IndexFacesCommand({
+            CollectionId: "absent",
+            Image: { Bytes: redPngBytes },
+          }),
+        ),
+    );
+
+    assertIdentical(error.name, "ResourceNotFoundException");
+  });
+
+  it("refuses to list its faces", async () => {
+    const simAws = new SimAws();
+
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws
+          .rekognition()
+          .listFaces(new ListFacesCommand({ CollectionId: "absent" })),
+    );
+
+    assertIdentical(error.name, "ResourceNotFoundException");
+  });
+
+  it("refuses to search it", async () => {
+    const simAws = new SimAws();
+
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.rekognition().searchFacesByImage(
+          new SearchFacesByImageCommand({
+            CollectionId: "absent",
+            Image: { Bytes: redPngBytes },
+          }),
+        ),
+    );
+
+    assertIdentical(error.name, "ResourceNotFoundException");
+  });
+
+  it("refuses to remove faces from it", async () => {
+    const simAws = new SimAws();
+
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.rekognition().deleteFaces(
+          new DeleteFacesCommand({
+            CollectionId: "absent",
+            FaceIds: ["0a1b2c3d-4e5f-4a6b-8c9d-0e1f2a3b4c5d"],
+          }),
+        ),
+    );
+
+    assertIdentical(error.name, "ResourceNotFoundException");
+  });
+});

--- a/src/service/rekognition/command/face/face-ids.ts
+++ b/src/service/rekognition/command/face/face-ids.ts
@@ -1,0 +1,46 @@
+import { SimRekognitionInvalidParameterException } from "../../error/sim-rekognition.error.js";
+
+/**
+ * The most face ids real Rekognition takes in one request.
+ */
+const mostFaceIds = 4096;
+
+function refuseUnusable(faceIds: readonly string[]): void {
+  if (faceIds.length === 0 || faceIds.length > mostFaceIds) {
+    throw new SimRekognitionInvalidParameterException(
+      `Request has invalid parameters: FaceIds holds ` +
+        `${String(faceIds.length)} face ids, where Rekognition takes from 1 ` +
+        `to ${String(mostFaceIds)}`,
+    );
+  }
+}
+
+/**
+ * The face ids a request named, where naming none is the whole collection.
+ */
+export function selectedFaceIds(
+  faceIds: readonly string[] | undefined,
+): readonly string[] | undefined {
+  if (faceIds === undefined) {
+    return undefined;
+  }
+
+  refuseUnusable(faceIds);
+
+  return faceIds;
+}
+
+/**
+ * The face ids a request named, refusing one that named none.
+ */
+export function requiredFaceIds(
+  faceIds: readonly string[] | undefined,
+): readonly string[] {
+  if (faceIds === undefined) {
+    throw new SimRekognitionInvalidParameterException("FaceIds is required");
+  }
+
+  refuseUnusable(faceIds);
+
+  return faceIds;
+}

--- a/src/service/rekognition/command/face/face-ids.ts
+++ b/src/service/rekognition/command/face/face-ids.ts
@@ -5,6 +5,16 @@ import { SimRekognitionInvalidParameterException } from "../../error/sim-rekogni
  */
 const mostFaceIds = 4096;
 
+/**
+ * The shape of a face id, which is a lowercase uuid.
+ *
+ * Real Rekognition checks this before it looks a face up, so an id in another
+ * shape is a malformed request there. Checking it here keeps that a malformed
+ * request rather than a face the collection turns out not to hold.
+ */
+const faceIdShape =
+  /^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/u;
+
 function refuseUnusable(faceIds: readonly string[]): void {
   if (faceIds.length === 0 || faceIds.length > mostFaceIds) {
     throw new SimRekognitionInvalidParameterException(
@@ -12,6 +22,16 @@ function refuseUnusable(faceIds: readonly string[]): void {
         `${String(faceIds.length)} face ids, where Rekognition takes from 1 ` +
         `to ${String(mostFaceIds)}`,
     );
+  }
+
+  for (const faceId of faceIds) {
+    if (!faceIdShape.test(faceId)) {
+      throw new SimRekognitionInvalidParameterException(
+        `Request has invalid parameters: FaceIds holds '${faceId}', which is ` +
+          `not a Rekognition face id. A face id is the lowercase uuid ` +
+          `IndexFaces answered with.`,
+      );
+    }
   }
 }
 

--- a/src/service/rekognition/command/face/face-indexer.ts
+++ b/src/service/rekognition/command/face/face-indexer.ts
@@ -1,0 +1,85 @@
+import { randomUUID } from "node:crypto";
+
+import type { SimRekognitionCollection } from "../../collection/sim-rekognition-collection.js";
+import { SimRekognitionIndexedFace } from "../../collection/sim-rekognition-indexed-face.js";
+import type { SimRekognitionDetectedFace } from "../../face/sim-rekognition-detected-face.js";
+import type { SimRekognitionFaceDetection } from "../../face/sim-rekognition-face-detection.js";
+import type { SimIndexFacesCommandOutput } from "./face.command.js";
+import type { IndexFacesRequest } from "./index-faces-request.js";
+
+/**
+ * Why real Rekognition leaves a face out of a collection when the request
+ * asked for fewer faces than the image holds.
+ */
+const exceedsMaxFaces = "EXCEEDS_MAX_FACES";
+
+interface SimRekognitionFaceIndexerProperties {
+  readonly collection: SimRekognitionCollection;
+  readonly detection: SimRekognitionFaceDetection;
+  readonly request: IndexFacesRequest;
+}
+
+/**
+ * Records the faces one image holds against one collection.
+ *
+ * The faces are the ones the `faces()` rules declare for that image, so a face
+ * indexed from an image and a face detected in it are the same face, with the
+ * same bounding box and the same confidence. An image no rule matches indexes
+ * the built-in default face.
+ *
+ * Every face indexed from one image shares an `ImageId` and gets a `FaceId` of
+ * its own, as they do on AWS.
+ */
+export class SimRekognitionFaceIndexer {
+  private readonly collection: SimRekognitionCollection;
+  private readonly detection: SimRekognitionFaceDetection;
+  private readonly request: IndexFacesRequest;
+  private readonly imageId = randomUUID();
+
+  constructor(properties: SimRekognitionFaceIndexerProperties) {
+    this.collection = properties.collection;
+    this.detection = properties.detection;
+    this.request = properties.request;
+  }
+
+  /**
+   * Index the faces and report what was stored.
+   *
+   * Real Rekognition indexes the largest faces first and reports the rest as
+   * unindexed. Nothing here measures a face, so a `MaxFaces` takes them in the
+   * order they were declared.
+   */
+  index(): SimIndexFacesCommandOutput {
+    const detected = this.detection.detected();
+    const wanted = this.request.maxFaces ?? detected.length;
+    const { attributes } = this.request;
+
+    return {
+      FaceRecords: detected
+        .slice(0, wanted)
+        .map((face) => this.store(face).record(attributes)),
+      UnindexedFaces: detected.slice(wanted).map((face) => ({
+        Reasons: [exceedsMaxFaces],
+        FaceDetail: face.detailFor(attributes),
+      })),
+      FaceModelVersion: this.collection.faceModelVersion,
+      $metadata: {},
+    };
+  }
+
+  private store(
+    detected: SimRekognitionDetectedFace,
+  ): SimRekognitionIndexedFace {
+    const face = new SimRekognitionIndexedFace({
+      faceId: randomUUID(),
+      imageId: this.imageId,
+      externalImageId: this.request.externalImageId,
+      faceModelVersion: this.collection.faceModelVersion,
+      detected,
+    });
+
+    this.collection.faces.index(face);
+
+    return face;
+  }
+}

--- a/src/service/rekognition/command/face/face-indexing.iso.test.ts
+++ b/src/service/rekognition/command/face/face-indexing.iso.test.ts
@@ -1,0 +1,144 @@
+import {
+  CreateCollectionCommand,
+  IndexFacesCommand,
+  ListFacesCommand,
+} from "@aws-sdk/client-rekognition";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertSetSize,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { redPngBytes } from "../../../../../test/rekognition/image-fixture.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simRekognitionSeveralFaces } from "../../face/sim-rekognition-face-defaults.js";
+
+async function simAwsWithPhoto(objectName = "staff/ada.jpg"): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "photos" }));
+  await simAws.s3().putObject(
+    new PutObjectCommand({
+      Bucket: "photos",
+      Key: objectName,
+      Body: redPngBytes,
+    }),
+  );
+  await simAws
+    .rekognition()
+    .createCollection(new CreateCollectionCommand({ CollectionId: "staff" }));
+
+  return simAws;
+}
+
+function indexing(
+  objectName = "staff/ada.jpg",
+  externalImageId = "ada",
+): IndexFacesCommand {
+  return new IndexFacesCommand({
+    CollectionId: "staff",
+    Image: { S3Object: { Bucket: "photos", Name: objectName } },
+    ExternalImageId: externalImageId,
+  });
+}
+
+describe("Indexing faces into a simulated Rekognition collection", () => {
+  it("records the face an image holds and answers with what a caller reads", async () => {
+    // Given a photograph in a Bucket and an empty collection
+    const simAws = await simAwsWithPhoto();
+
+    // When it is indexed
+    const indexed = await simAws.rekognition().indexFaces(indexing());
+
+    // Then the face comes back with the identity a caller stores
+    assertArrayLength(indexed.FaceRecords, 1);
+
+    const [record] = indexed.FaceRecords;
+    assertNonNullable(record);
+    assertIdentical(record.Face.ExternalImageId, "ada");
+    assertIdentical(record.Face.IndexFacesModelVersion, "7.0");
+    assertNonNullable(record.Face.FaceId);
+    assertNonNullable(record.Face.ImageId);
+    assertNonNullable(record.Face.BoundingBox);
+    assertIdentical(indexed.FaceModelVersion, "7.0");
+    assertArrayLength(indexed.UnindexedFaces, 0);
+  });
+
+  it("indexes the faces the image is declared to hold, under one image id", async () => {
+    // Given an image declared to hold three faces
+    const simAws = await simAwsWithPhoto("staff/team.jpg");
+    simAws
+      .rekognition()
+      .faces()
+      .onName("staff/team.jpg", simRekognitionSeveralFaces);
+
+    // When it is indexed
+    const indexed = await simAws
+      .rekognition()
+      .indexFaces(indexing("staff/team.jpg"));
+
+    // Then each face is stored under its own id and the one image id they
+    // were all found in
+    assertArrayLength(indexed.FaceRecords, 3);
+
+    const faceIds = new Set(
+      indexed.FaceRecords.map((record) => record.Face.FaceId),
+    );
+    const imageIds = new Set(
+      indexed.FaceRecords.map((record) => record.Face.ImageId),
+    );
+
+    assertSetSize(faceIds, 3);
+    assertSetSize(imageIds, 1);
+  });
+
+  it("reports the faces a MaxFaces left out, and does not store them", async () => {
+    // Given an image declared to hold three faces
+    const simAws = await simAwsWithPhoto("staff/team.jpg");
+    const rekognition = simAws.rekognition();
+    rekognition.faces().onName("staff/team.jpg", simRekognitionSeveralFaces);
+
+    // When only one is asked for
+    const indexed = await rekognition.indexFaces(
+      new IndexFacesCommand({
+        CollectionId: "staff",
+        Image: { S3Object: { Bucket: "photos", Name: "staff/team.jpg" } },
+        MaxFaces: 1,
+      }),
+    );
+
+    // Then the other two are reported as unindexed rather than stored
+    assertArrayLength(indexed.FaceRecords, 1);
+    assertArrayLength(indexed.UnindexedFaces, 2);
+
+    const [unindexed] = indexed.UnindexedFaces;
+    assertNonNullable(unindexed);
+    assertArrayEquals(unindexed.Reasons, ["EXCEEDS_MAX_FACES"]);
+
+    const listed = await rekognition.listFaces(
+      new ListFacesCommand({ CollectionId: "staff" }),
+    );
+    assertArrayLength(listed.Faces, 1);
+  });
+
+  it("refuses an external image id real Rekognition would refuse", async () => {
+    // Given a photograph to index
+    const simAws = await simAwsWithPhoto();
+
+    // When it is indexed under an id holding a space
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws
+          .rekognition()
+          .indexFaces(indexing("staff/ada.jpg", "ada lovelace")),
+    );
+
+    // Then it is refused where AWS would refuse it rather than stored
+    assertIdentical(error.name, "InvalidParameterException");
+  });
+});

--- a/src/service/rekognition/command/face/face-limits.ts
+++ b/src/service/rekognition/command/face/face-limits.ts
@@ -1,0 +1,50 @@
+import { SimRekognitionInvalidParameterException } from "../../error/sim-rekognition.error.js";
+
+interface SimRekognitionFaceLimitProperties {
+  readonly most?: number;
+}
+
+/**
+ * A limit on the number of faces one request works with.
+ *
+ * There is no default. A request that left `MaxFaces` out gets every face, as
+ * it does on AWS, so an operation only has to say what the largest limit it
+ * accepts is. `SearchFacesByImage` has one and `IndexFaces` has none.
+ */
+export class SimRekognitionFaceLimit {
+  private readonly most: number | undefined;
+
+  constructor(properties: SimRekognitionFaceLimitProperties = {}) {
+    this.most = properties.most;
+  }
+
+  /**
+   * The limit a request asked for, if it asked for one.
+   */
+  of(requested: number | undefined): number | undefined {
+    if (requested === undefined) {
+      return undefined;
+    }
+
+    if (
+      !Number.isSafeInteger(requested) ||
+      requested < 1 ||
+      this.exceeded(requested)
+    ) {
+      throw new SimRekognitionInvalidParameterException(
+        `Request has invalid parameters: MaxFaces of ${String(requested)} ` +
+          `is not a whole number of faces from 1 ${this.upperBound()}`,
+      );
+    }
+
+    return requested;
+  }
+
+  private exceeded(requested: number): boolean {
+    return this.most !== undefined && requested > this.most;
+  }
+
+  private upperBound(): string {
+    return this.most === undefined ? "upwards" : `to ${String(this.most)}`;
+  }
+}

--- a/src/service/rekognition/command/face/face-listing.iso.test.ts
+++ b/src/service/rekognition/command/face/face-listing.iso.test.ts
@@ -1,0 +1,157 @@
+import {
+  CreateCollectionCommand,
+  DeleteFacesCommand,
+  IndexFacesCommand,
+  ListFacesCommand,
+} from "@aws-sdk/client-rekognition";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { redPngBytes } from "../../../../../test/rekognition/image-fixture.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simRekognitionSeveralFaces } from "../../face/sim-rekognition-face-defaults.js";
+
+async function simAwsWithPhoto(objectName = "staff/ada.jpg"): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "photos" }));
+  await simAws.s3().putObject(
+    new PutObjectCommand({
+      Bucket: "photos",
+      Key: objectName,
+      Body: redPngBytes,
+    }),
+  );
+  await simAws
+    .rekognition()
+    .createCollection(new CreateCollectionCommand({ CollectionId: "staff" }));
+
+  return simAws;
+}
+
+function indexing(
+  objectName = "staff/ada.jpg",
+  externalImageId = "ada",
+): IndexFacesCommand {
+  return new IndexFacesCommand({
+    CollectionId: "staff",
+    Image: { S3Object: { Bucket: "photos", Name: objectName } },
+    ExternalImageId: externalImageId,
+  });
+}
+
+describe("Reading and removing the faces of a simulated Rekognition collection", () => {
+  it("lists the faces of one collection and misses those of another", async () => {
+    // Given a face indexed into one of two collections
+    const simAws = await simAwsWithPhoto();
+    const rekognition = simAws.rekognition();
+    await rekognition.createCollection(
+      new CreateCollectionCommand({ CollectionId: "visitors" }),
+    );
+    const indexed = await rekognition.indexFaces(indexing());
+
+    // When each collection is listed
+    const staff = await rekognition.listFaces(
+      new ListFacesCommand({ CollectionId: "staff" }),
+    );
+    const visitors = await rekognition.listFaces(
+      new ListFacesCommand({ CollectionId: "visitors" }),
+    );
+
+    // Then the face is in the one it was indexed into and no other
+    assertArrayEquals(
+      staff.Faces.map((face) => face.FaceId),
+      indexed.FaceRecords.map((record) => record.Face.FaceId),
+    );
+    assertArrayLength(visitors.Faces, 0);
+  });
+
+  it("narrows a listing to the face ids it names", async () => {
+    // Given two indexed faces
+    const simAws = await simAwsWithPhoto();
+    const rekognition = simAws.rekognition();
+    const first = await rekognition.indexFaces(indexing());
+    await rekognition.indexFaces(indexing("staff/ada.jpg", "grace"));
+
+    const [wanted] = first.FaceRecords;
+    assertNonNullable(wanted);
+
+    // When one of them is asked for
+    const listed = await rekognition.listFaces(
+      new ListFacesCommand({
+        CollectionId: "staff",
+        FaceIds: [wanted.Face.FaceId],
+      }),
+    );
+
+    // Then it is the only one reported
+    assertArrayEquals(
+      listed.Faces.map((face) => face.ExternalImageId),
+      ["ada"],
+    );
+  });
+
+  it("pages a listing the request asked to have paged", async () => {
+    // Given three indexed faces
+    const simAws = await simAwsWithPhoto("staff/team.jpg");
+    const rekognition = simAws.rekognition();
+    rekognition.faces().onName("staff/team.jpg", simRekognitionSeveralFaces);
+    await rekognition.indexFaces(indexing("staff/team.jpg"));
+
+    // When two are asked for at a time
+    const first = await rekognition.listFaces(
+      new ListFacesCommand({ CollectionId: "staff", MaxResults: 2 }),
+    );
+
+    assertArrayLength(first.Faces, 2);
+    assertNonNullable(first.NextToken);
+
+    const second = await rekognition.listFaces(
+      new ListFacesCommand({
+        CollectionId: "staff",
+        MaxResults: 2,
+        NextToken: first.NextToken,
+      }),
+    );
+
+    // Then the rest come back and the listing ends
+    assertArrayLength(second.Faces, 1);
+    assertUndefined(second.NextToken);
+  });
+
+  it("removes faces by id and reports which were removed", async () => {
+    // Given two indexed faces
+    const simAws = await simAwsWithPhoto();
+    const rekognition = simAws.rekognition();
+    const first = await rekognition.indexFaces(indexing());
+    await rekognition.indexFaces(indexing("staff/ada.jpg", "grace"));
+
+    const [removing] = first.FaceRecords;
+    assertNonNullable(removing);
+
+    // When one is removed alongside an id the collection never held
+    const deleted = await rekognition.deleteFaces(
+      new DeleteFacesCommand({
+        CollectionId: "staff",
+        FaceIds: [removing.Face.FaceId, "3b0b5b0e-0000-4000-8000-000000000000"],
+      }),
+    );
+
+    // Then only the one that was there is reported as removed
+    assertArrayEquals(deleted.DeletedFaces, [removing.Face.FaceId]);
+
+    const listed = await rekognition.listFaces(
+      new ListFacesCommand({ CollectionId: "staff" }),
+    );
+    assertArrayEquals(
+      listed.Faces.map((face) => face.ExternalImageId),
+      ["grace"],
+    );
+  });
+});

--- a/src/service/rekognition/command/face/face-listing.iso.test.ts
+++ b/src/service/rekognition/command/face/face-listing.iso.test.ts
@@ -8,7 +8,9 @@ import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
 import {
   assertArrayEquals,
   assertArrayLength,
+  assertIdentical,
   assertNonNullable,
+  assertThrowsErrorAsync,
   assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
@@ -45,6 +47,8 @@ function indexing(
     ExternalImageId: externalImageId,
   });
 }
+
+const absentFaceId = "3b0b5b0e-0000-4000-8000-000000000000";
 
 describe("Reading and removing the faces of a simulated Rekognition collection", () => {
   it("lists the faces of one collection and misses those of another", async () => {
@@ -139,12 +143,18 @@ describe("Reading and removing the faces of a simulated Rekognition collection",
     const deleted = await rekognition.deleteFaces(
       new DeleteFacesCommand({
         CollectionId: "staff",
-        FaceIds: [removing.Face.FaceId, "3b0b5b0e-0000-4000-8000-000000000000"],
+        FaceIds: [removing.Face.FaceId, absentFaceId],
       }),
     );
 
-    // Then only the one that was there is reported as removed
+    // Then only the one that was there is reported as removed, and the other
+    // is answered for rather than dropped
     assertArrayEquals(deleted.DeletedFaces, [removing.Face.FaceId]);
+
+    const [unsuccessful] = deleted.UnsuccessfulFaceDeletions;
+    assertNonNullable(unsuccessful);
+    assertIdentical(unsuccessful.FaceId, absentFaceId);
+    assertArrayEquals(unsuccessful.Reasons, ["FACE_NOT_FOUND"]);
 
     const listed = await rekognition.listFaces(
       new ListFacesCommand({ CollectionId: "staff" }),
@@ -153,5 +163,25 @@ describe("Reading and removing the faces of a simulated Rekognition collection",
       listed.Faces.map((face) => face.ExternalImageId),
       ["grace"],
     );
+  });
+
+  it("refuses a face id that is not the shape Rekognition issues", async () => {
+    // Given a collection to remove a face from
+    const simAws = await simAwsWithPhoto();
+
+    // When a request names an id in another shape
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.rekognition().deleteFaces(
+          new DeleteFacesCommand({
+            CollectionId: "staff",
+            FaceIds: ["the-face-of-ada"],
+          }),
+        ),
+    );
+
+    // Then it is a malformed request, as it is on AWS, rather than a face the
+    // collection turns out not to hold
+    assertIdentical(error.name, "InvalidParameterException");
   });
 });

--- a/src/service/rekognition/command/face/face-listing.ts
+++ b/src/service/rekognition/command/face/face-listing.ts
@@ -1,0 +1,47 @@
+import type { SimRekognitionCollection } from "../../collection/sim-rekognition-collection.js";
+import type { SimListFacesCommandOutput } from "./face.command.js";
+import type { ListFacesRequest } from "./list-faces-request.js";
+import { SimRekognitionFacePage } from "./list-faces-page.js";
+
+interface SimRekognitionFaceListingProperties {
+  readonly collection: SimRekognitionCollection;
+  readonly request: ListFacesRequest;
+}
+
+/**
+ * Reads the faces one collection holds.
+ *
+ * A request naming no face ids lists the whole collection, and one naming
+ * some narrows the listing to those, leaving out any id the collection does
+ * not hold. Paging is applied after that, so a page is a page of what the
+ * request selected.
+ */
+export class SimRekognitionFaceListing {
+  private readonly collection: SimRekognitionCollection;
+  private readonly request: ListFacesRequest;
+
+  constructor(properties: SimRekognitionFaceListingProperties) {
+    this.collection = properties.collection;
+    this.request = properties.request;
+  }
+
+  /**
+   * The page of faces this request asked for.
+   */
+  list(): SimListFacesCommandOutput {
+    const { faceIds, maxResults, nextToken } = this.request;
+    const held = this.collection.faces;
+    const page = new SimRekognitionFacePage({
+      listed: faceIds === undefined ? held.all() : held.withIds(faceIds),
+      maxResults,
+      nextToken,
+    });
+
+    return {
+      Faces: page.faces.map((face) => face.stored()),
+      ...(page.nextToken !== undefined && { NextToken: page.nextToken }),
+      FaceModelVersion: this.collection.faceModelVersion,
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/rekognition/command/face/face-output.ts
+++ b/src/service/rekognition/command/face/face-output.ts
@@ -40,6 +40,26 @@ export interface SimRekognitionUnindexedFaceOutput {
 }
 
 /**
+ * Why real Rekognition could not delete a face a request named.
+ *
+ * The other reason it reports is `ASSOCIATED_TO_AN_EXISTING_USER`, which
+ * nothing here produces, since a face is never associated with a user.
+ */
+export const simRekognitionFaceNotFound = "FACE_NOT_FOUND";
+
+/**
+ * One face DeleteFaces did not remove, and why.
+ *
+ * `UserId` is left out, because nothing here associates a face with a user.
+ *
+ * https://docs.aws.amazon.com/rekognition/latest/APIReference/API_UnsuccessfulFaceDeletion.html
+ */
+export interface SimRekognitionUnsuccessfulFaceDeletionOutput {
+  readonly FaceId: string;
+  readonly Reasons: readonly string[];
+}
+
+/**
  * One face a search found, and how alike the search says it is.
  *
  * https://docs.aws.amazon.com/rekognition/latest/APIReference/API_FaceMatch.html

--- a/src/service/rekognition/command/face/face-output.ts
+++ b/src/service/rekognition/command/face/face-output.ts
@@ -1,0 +1,50 @@
+import type { SimRekognitionFaceDetailOutput } from "../detect-faces/detect-faces.command.js";
+import type { SimRekognitionBoundingBoxOutput } from "../../image/sim-rekognition-bounding-box.js";
+
+/**
+ * One face held in a collection.
+ *
+ * `UserId` is left out, because associating a face with a user is a layer
+ * above this one and nothing here creates a user.
+ *
+ * https://docs.aws.amazon.com/rekognition/latest/APIReference/API_Face.html
+ */
+export interface SimRekognitionFaceOutput {
+  readonly FaceId: string;
+  readonly ImageId: string;
+  readonly BoundingBox?: SimRekognitionBoundingBoxOutput;
+  readonly ExternalImageId?: string;
+  readonly Confidence: number;
+  readonly IndexFacesModelVersion: string;
+}
+
+/**
+ * One face IndexFaces put in a collection, with the detail it was indexed
+ * from.
+ *
+ * https://docs.aws.amazon.com/rekognition/latest/APIReference/API_FaceRecord.html
+ */
+export interface SimRekognitionFaceRecordOutput {
+  readonly Face: SimRekognitionFaceOutput;
+  readonly FaceDetail: SimRekognitionFaceDetailOutput;
+}
+
+/**
+ * One face IndexFaces left out of a collection, and why.
+ *
+ * https://docs.aws.amazon.com/rekognition/latest/APIReference/API_UnindexedFace.html
+ */
+export interface SimRekognitionUnindexedFaceOutput {
+  readonly Reasons: readonly string[];
+  readonly FaceDetail: SimRekognitionFaceDetailOutput;
+}
+
+/**
+ * One face a search found, and how alike the search says it is.
+ *
+ * https://docs.aws.amazon.com/rekognition/latest/APIReference/API_FaceMatch.html
+ */
+export interface SimRekognitionFaceMatchOutput {
+  readonly Similarity: number;
+  readonly Face: SimRekognitionFaceOutput;
+}

--- a/src/service/rekognition/command/face/face-search.iso.test.ts
+++ b/src/service/rekognition/command/face/face-search.iso.test.ts
@@ -1,0 +1,254 @@
+import {
+  CreateCollectionCommand,
+  DeleteFacesCommand,
+  IndexFacesCommand,
+  ListFacesCommand,
+  SearchFacesByImageCommand,
+} from "@aws-sdk/client-rekognition";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  bluePngBytes,
+  redPngBytes,
+} from "../../../../../test/rekognition/image-fixture.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simRekognitionNoFaces } from "../../face/sim-rekognition-face-defaults.js";
+
+const staffPhoto = "staff/ada.jpg";
+const visitorPhoto = "door/visitor.jpg";
+
+/**
+ * A simulation holding one collection with one face indexed under `ada`, and
+ * a second photograph to search with.
+ */
+async function simAwsWithIndexedFace(): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "photos" }));
+  await simAws.s3().putObject(
+    new PutObjectCommand({
+      Bucket: "photos",
+      Key: staffPhoto,
+      Body: redPngBytes,
+    }),
+  );
+  await simAws.s3().putObject(
+    new PutObjectCommand({
+      Bucket: "photos",
+      Key: visitorPhoto,
+      Body: bluePngBytes,
+    }),
+  );
+  await simAws
+    .rekognition()
+    .createCollection(new CreateCollectionCommand({ CollectionId: "staff" }));
+  await simAws.rekognition().indexFaces(
+    new IndexFacesCommand({
+      CollectionId: "staff",
+      Image: { S3Object: { Bucket: "photos", Name: staffPhoto } },
+      ExternalImageId: "ada",
+    }),
+  );
+
+  return simAws;
+}
+
+function searching(threshold?: number): SearchFacesByImageCommand {
+  return new SearchFacesByImageCommand({
+    CollectionId: "staff",
+    Image: { S3Object: { Bucket: "photos", Name: visitorPhoto } },
+    ...(threshold !== undefined && { FaceMatchThreshold: threshold }),
+  });
+}
+
+describe("Searching a simulated Rekognition collection by image", () => {
+  it("finds nobody until a rule says otherwise", async () => {
+    // Given a collection holding a face and no rule for the search image
+    const simAws = await simAwsWithIndexedFace();
+
+    // When it is searched
+    const found = await simAws.rekognition().searchFacesByImage(searching());
+
+    // Then nobody is found, rather than a match being invented
+    assertArrayLength(found.FaceMatches, 0);
+  });
+
+  it("finds the face a rule names by the id it was indexed under", async () => {
+    // Given a rule saying the visitor is the member of staff
+    const simAws = await simAwsWithIndexedFace();
+    simAws
+      .rekognition()
+      .faceMatches()
+      .onName(visitorPhoto, {
+        matches: [{ externalImageId: "ada", similarity: 98.5 }],
+      });
+
+    // When the collection is searched with the visitor's photograph
+    const found = await simAws.rekognition().searchFacesByImage(searching());
+
+    // Then the indexed face comes back at the similarity the rule stated
+    assertArrayLength(found.FaceMatches, 1);
+
+    const [match] = found.FaceMatches;
+    assertNonNullable(match);
+    assertIdentical(match.Face.ExternalImageId, "ada");
+    assertIdentical(match.Similarity, 98.5);
+  });
+
+  it("finds the face a rule names by the id IndexFaces answered with", async () => {
+    // Given a collection whose one face id is known
+    const simAws = await simAwsWithIndexedFace();
+    const rekognition = simAws.rekognition();
+    const listed = await rekognition.listFaces(
+      new ListFacesCommand({ CollectionId: "staff" }),
+    );
+    const [face] = listed.Faces;
+    assertNonNullable(face);
+
+    // When a rule names that face id
+    rekognition
+      .faceMatches()
+      .onName(visitorPhoto, { matches: [{ faceId: face.FaceId }] });
+
+    const found = await rekognition.searchFacesByImage(searching());
+
+    // Then the search finds it, at the similarity an undeclared one reports
+    assertArrayLength(found.FaceMatches, 1);
+
+    const [match] = found.FaceMatches;
+    assertNonNullable(match);
+    assertIdentical(match.Face.FaceId, face.FaceId);
+    assertIdentical(match.Similarity, 99.97222137451172);
+  });
+
+  it("leaves out a match the request was not confident enough for", async () => {
+    // Given a declared match at a middling similarity
+    const simAws = await simAwsWithIndexedFace();
+    simAws
+      .rekognition()
+      .faceMatches()
+      .onName(visitorPhoto, {
+        matches: [{ externalImageId: "ada", similarity: 72 }],
+      });
+
+    // When it is searched for at the default threshold and then below it
+    const strict = await simAws.rekognition().searchFacesByImage(searching());
+    const lenient = await simAws
+      .rekognition()
+      .searchFacesByImage(searching(70));
+
+    // Then the threshold decides, as it does on AWS
+    assertArrayLength(strict.FaceMatches, 0);
+    assertArrayLength(lenient.FaceMatches, 1);
+  });
+
+  it("stops finding a face once it is removed from the collection", async () => {
+    // Given a face a rule finds
+    const simAws = await simAwsWithIndexedFace();
+    const rekognition = simAws.rekognition();
+    rekognition
+      .faceMatches()
+      .onName(visitorPhoto, { matches: [{ externalImageId: "ada" }] });
+
+    const before = await rekognition.searchFacesByImage(searching());
+    const [match] = before.FaceMatches;
+    assertNonNullable(match);
+    assertNonNullable(match.Face.FaceId);
+
+    // When the face is deleted
+    await rekognition.deleteFaces(
+      new DeleteFacesCommand({
+        CollectionId: "staff",
+        FaceIds: [match.Face.FaceId],
+      }),
+    );
+
+    // Then the rule still says so and the search finds nobody
+    const after = await rekognition.searchFacesByImage(searching());
+    assertArrayLength(after.FaceMatches, 0);
+  });
+
+  it("reports the face it searched with, from the rules for that image", async () => {
+    // Given a search image declared to hold one face
+    const simAws = await simAwsWithIndexedFace();
+
+    // When the collection is searched
+    const found = await simAws.rekognition().searchFacesByImage(searching());
+
+    // Then the face the search was made with is reported alongside the matches
+    assertNonNullable(found.SearchedFaceBoundingBox);
+    assertIdentical(found.SearchedFaceConfidence, 99.99872589111328);
+  });
+
+  it("refuses a search with an image holding nobody", async () => {
+    // Given a search image declared to hold no faces
+    const simAws = await simAwsWithIndexedFace();
+    simAws.rekognition().faces().onName(visitorPhoto, simRekognitionNoFaces);
+
+    // When the collection is searched with it
+    const error = await assertThrowsErrorAsync(
+      async () => await simAws.rekognition().searchFacesByImage(searching()),
+    );
+
+    // Then it is refused, as real Rekognition refuses a search with nothing
+    // to search for
+    assertIdentical(error.name, "InvalidParameterException");
+  });
+
+  it("answers a search in every Region the rule was registered in", async () => {
+    // Given a rule and a collection in one Region
+    const simAws = await simAwsWithIndexedFace();
+    simAws
+      .rekognition()
+      .faceMatches()
+      .onName(visitorPhoto, { matches: [{ externalImageId: "ada" }] });
+
+    // When another Region is searched
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws
+          .accountRegionScope(undefined, "eu-west-2")
+          .rekognition()
+          .searchFacesByImage(searching()),
+    );
+
+    // Then it has no such collection, as a collection belongs to one Region
+    assertIdentical(error.name, "ResourceNotFoundException");
+  });
+
+  it("reports a face once when two matches name it", async () => {
+    // Given one face named twice over, by each kind of id
+    const simAws = await simAwsWithIndexedFace();
+    const rekognition = simAws.rekognition();
+    const listed = await rekognition.listFaces(
+      new ListFacesCommand({ CollectionId: "staff" }),
+    );
+    const [face] = listed.Faces;
+    assertNonNullable(face);
+
+    rekognition.faceMatches().onName(visitorPhoto, {
+      matches: [
+        { externalImageId: "ada", similarity: 91 },
+        { faceId: face.FaceId, similarity: 97 },
+      ],
+    });
+
+    // When the collection is searched
+    const found = await rekognition.searchFacesByImage(searching());
+
+    // Then it is one face in the collection and so one match in the response,
+    // reported at the most alike of the two
+    assertArrayEquals(
+      found.FaceMatches.map((match) => match.Similarity),
+      [97],
+    );
+  });
+});

--- a/src/service/rekognition/command/face/face-search.iso.test.ts
+++ b/src/service/rekognition/command/face/face-search.iso.test.ts
@@ -203,7 +203,7 @@ describe("Searching a simulated Rekognition collection by image", () => {
     assertIdentical(error.name, "InvalidParameterException");
   });
 
-  it("answers a search in every Region the rule was registered in", async () => {
+  it("misses a collection made in another Region", async () => {
     // Given a rule and a collection in one Region
     const simAws = await simAwsWithIndexedFace();
     simAws

--- a/src/service/rekognition/command/face/face-searcher.ts
+++ b/src/service/rekognition/command/face/face-searcher.ts
@@ -1,0 +1,64 @@
+import type { SimRekognitionCollection } from "../../collection/sim-rekognition-collection.js";
+import { SimRekognitionInvalidParameterException } from "../../error/sim-rekognition.error.js";
+import type { SimRekognitionFaceDetection } from "../../face/sim-rekognition-face-detection.js";
+import type { SimRekognitionFaceMatchResult } from "../../match/sim-rekognition-face-match-result.js";
+import type { SimSearchFacesByImageCommandOutput } from "./face.command.js";
+import type { SearchFacesByImageRequest } from "./search-faces-by-image-request.js";
+
+interface SimRekognitionFaceSearcherProperties {
+  readonly collection: SimRekognitionCollection;
+  readonly detection: SimRekognitionFaceDetection;
+  readonly declared: SimRekognitionFaceMatchResult;
+  readonly request: SearchFacesByImageRequest;
+}
+
+/**
+ * Searches one collection with one image.
+ *
+ * The face the search is made with is the first face the `faces()` rules
+ * declare for the image, which is the face a real search would have measured
+ * everything else against. Which faces it finds is what the `faceMatches()`
+ * rules declare, narrowed to the faces the collection actually holds.
+ */
+export class SimRekognitionFaceSearcher {
+  private readonly collection: SimRekognitionCollection;
+  private readonly detection: SimRekognitionFaceDetection;
+  private readonly declared: SimRekognitionFaceMatchResult;
+  private readonly request: SearchFacesByImageRequest;
+
+  constructor(properties: SimRekognitionFaceSearcherProperties) {
+    this.collection = properties.collection;
+    this.detection = properties.detection;
+    this.declared = properties.declared;
+    this.request = properties.request;
+  }
+
+  /**
+   * The matches this search reports.
+   */
+  search(): SimSearchFacesByImageCommandOutput {
+    const [searched] = this.detection.detected();
+
+    if (searched === undefined) {
+      throw new SimRekognitionInvalidParameterException(
+        "Request has invalid parameters: there are no faces in the image, " +
+          "and a search needs at least one to search with",
+      );
+    }
+
+    const boundingBox = searched.boundingBox();
+
+    return {
+      ...(boundingBox !== undefined && {
+        SearchedFaceBoundingBox: boundingBox,
+      }),
+      SearchedFaceConfidence: searched.confidence(),
+      FaceMatches: this.declared.matchesIn(this.collection.faces, {
+        threshold: this.request.threshold,
+        mostFaces: this.request.maxFaces,
+      }),
+      FaceModelVersion: this.collection.faceModelVersion,
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/rekognition/command/face/face.command.ts
+++ b/src/service/rekognition/command/face/face.command.ts
@@ -6,6 +6,7 @@ import type {
   SimRekognitionFaceOutput,
   SimRekognitionFaceRecordOutput,
   SimRekognitionUnindexedFaceOutput,
+  SimRekognitionUnsuccessfulFaceDeletionOutput,
 } from "./face-output.js";
 
 /**
@@ -110,11 +111,14 @@ export interface SimDeleteFacesCommandInput {
 /**
  * The DeleteFaces response.
  *
- * `UnsuccessfulFaceDeletions` is always empty. Real Rekognition reports a face
- * there when it is associated with a user, and nothing here associates one.
+ * A face id the collection does not hold comes back in
+ * `UnsuccessfulFaceDeletions` as `FACE_NOT_FOUND`, as it does on AWS. The other
+ * reason real Rekognition reports there is
+ * `ASSOCIATED_TO_AN_EXISTING_USER`, and nothing here associates a face with a
+ * user.
  */
 export interface SimDeleteFacesCommandOutput {
   readonly DeletedFaces: readonly string[];
-  readonly UnsuccessfulFaceDeletions: readonly string[];
+  readonly UnsuccessfulFaceDeletions: readonly SimRekognitionUnsuccessfulFaceDeletionOutput[];
   readonly $metadata: SimResponseMetadata;
 }

--- a/src/service/rekognition/command/face/face.command.ts
+++ b/src/service/rekognition/command/face/face.command.ts
@@ -1,0 +1,120 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimRekognitionBoundingBoxOutput } from "../../image/sim-rekognition-bounding-box.js";
+import type { SimRekognitionImageInput } from "../../image/sim-rekognition-image-input.js";
+import type {
+  SimRekognitionFaceMatchOutput,
+  SimRekognitionFaceOutput,
+  SimRekognitionFaceRecordOutput,
+  SimRekognitionUnindexedFaceOutput,
+} from "./face-output.js";
+
+/**
+ * Minimal structural sim Rekognition IndexFaces command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/rekognition/command/IndexFacesCommand/
+ */
+export interface SimIndexFacesCommand {
+  readonly input: SimIndexFacesCommandInput;
+}
+
+export interface SimIndexFacesCommandInput {
+  readonly CollectionId?: string | undefined;
+  readonly Image?: SimRekognitionImageInput | undefined;
+  readonly ExternalImageId?: string | undefined;
+  readonly DetectionAttributes?: readonly string[] | undefined;
+  readonly MaxFaces?: number | undefined;
+}
+
+/**
+ * The IndexFaces response.
+ *
+ * `OrientationCorrection` is not carried, for the reason it is left off a
+ * DetectFaces response: AWS documents its value as always null.
+ */
+export interface SimIndexFacesCommandOutput {
+  readonly FaceRecords: readonly SimRekognitionFaceRecordOutput[];
+  readonly UnindexedFaces: readonly SimRekognitionUnindexedFaceOutput[];
+  readonly FaceModelVersion: string;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Rekognition ListFaces command.
+ */
+export interface SimListFacesCommand {
+  readonly input: SimListFacesCommandInput;
+}
+
+export interface SimListFacesCommandInput {
+  readonly CollectionId?: string | undefined;
+  readonly FaceIds?: readonly string[] | undefined;
+  readonly MaxResults?: number | undefined;
+  readonly NextToken?: string | undefined;
+}
+
+/**
+ * The ListFaces response.
+ *
+ * A `NextToken` is carried only when the request set a `MaxResults` the
+ * collection is larger than, since a listing that asked for no page size comes
+ * back in one page.
+ */
+export interface SimListFacesCommandOutput {
+  readonly Faces: readonly SimRekognitionFaceOutput[];
+  readonly NextToken?: string;
+  readonly FaceModelVersion: string;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Rekognition SearchFacesByImage command.
+ */
+export interface SimSearchFacesByImageCommand {
+  readonly input: SimSearchFacesByImageCommandInput;
+}
+
+export interface SimSearchFacesByImageCommandInput {
+  readonly CollectionId?: string | undefined;
+  readonly Image?: SimRekognitionImageInput | undefined;
+  readonly FaceMatchThreshold?: number | undefined;
+  readonly MaxFaces?: number | undefined;
+}
+
+/**
+ * The SearchFacesByImage response.
+ *
+ * The searched face is the first face the `faces()` rules declare for the
+ * image, which is the face a real search would have measured everything else
+ * against.
+ */
+export interface SimSearchFacesByImageCommandOutput {
+  readonly SearchedFaceBoundingBox?: SimRekognitionBoundingBoxOutput;
+  readonly SearchedFaceConfidence: number;
+  readonly FaceMatches: readonly SimRekognitionFaceMatchOutput[];
+  readonly FaceModelVersion: string;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Rekognition DeleteFaces command.
+ */
+export interface SimDeleteFacesCommand {
+  readonly input: SimDeleteFacesCommandInput;
+}
+
+export interface SimDeleteFacesCommandInput {
+  readonly CollectionId?: string | undefined;
+  readonly FaceIds?: readonly string[] | undefined;
+}
+
+/**
+ * The DeleteFaces response.
+ *
+ * `UnsuccessfulFaceDeletions` is always empty. Real Rekognition reports a face
+ * there when it is associated with a user, and nothing here associates one.
+ */
+export interface SimDeleteFacesCommandOutput {
+  readonly DeletedFaces: readonly string[];
+  readonly UnsuccessfulFaceDeletions: readonly string[];
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/rekognition/command/face/face.handler.ts
+++ b/src/service/rekognition/command/face/face.handler.ts
@@ -1,0 +1,169 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimRekognitionCollection } from "../../collection/sim-rekognition-collection.js";
+import type { SimRekognitionCollections } from "../../collection/sim-rekognition-collections.js";
+import type { SimRekognitionFaces } from "../../face/sim-rekognition-faces.js";
+import type { SimRekognitionImageObjects } from "../../image/sim-rekognition-image-objects.js";
+import type { SimRekognitionFaceMatches } from "../../match/sim-rekognition-face-matches.js";
+import type { SimRekognitionAuthorizer } from "../authorize/sim-rekognition-authorizer.js";
+import type { SimRekognitionRequestOptions } from "../sim-rekognition-request-options.js";
+import { DeleteFacesRequest } from "./delete-faces-request.js";
+import { SimRekognitionFaceIndexer } from "./face-indexer.js";
+import { SimRekognitionFaceListing } from "./face-listing.js";
+import { SimRekognitionFaceSearcher } from "./face-searcher.js";
+import type {
+  SimDeleteFacesCommand,
+  SimDeleteFacesCommandOutput,
+  SimIndexFacesCommand,
+  SimIndexFacesCommandOutput,
+  SimListFacesCommand,
+  SimListFacesCommandOutput,
+  SimSearchFacesByImageCommand,
+  SimSearchFacesByImageCommandOutput,
+} from "./face.command.js";
+import { IndexFacesRequest } from "./index-faces-request.js";
+import { ListFacesRequest } from "./list-faces-request.js";
+import { SearchFacesByImageRequest } from "./search-faces-by-image-request.js";
+
+interface SimRekognitionFaceHandlerProperties {
+  readonly collections: SimRekognitionCollections;
+  readonly faces: SimRekognitionFaces;
+  readonly faceMatches: SimRekognitionFaceMatches;
+  readonly authorizer: SimRekognitionAuthorizer;
+  readonly images: SimRekognitionImageObjects;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * The simulated Rekognition operations that work on the faces in a collection.
+ *
+ * They are one handler for the reason the collection lifecycle operations are:
+ * they share a store and an authorization shape. Each authorizes against the
+ * collection's own ARN, and each does so before the collection is looked up,
+ * so a caller without the permission is told about that rather than about
+ * which collections exist.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/rekognition/command/IndexFacesCommand/
+ */
+export class SimRekognitionFaceHandler {
+  private readonly collections: SimRekognitionCollections;
+  private readonly faces: SimRekognitionFaces;
+  private readonly faceMatches: SimRekognitionFaceMatches;
+  private readonly authorizer: SimRekognitionAuthorizer;
+  private readonly images: SimRekognitionImageObjects;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: SimRekognitionFaceHandlerProperties) {
+    this.collections = properties.collections;
+    this.faces = properties.faces;
+    this.faceMatches = properties.faceMatches;
+    this.authorizer = properties.authorizer;
+    this.images = properties.images;
+    this.background = properties.background;
+  }
+
+  /**
+   * Index the faces an image is declared to hold into a collection.
+   */
+  async index(
+    command: SimIndexFacesCommand,
+    options: SimRekognitionRequestOptions = {},
+  ): Promise<SimIndexFacesCommandOutput> {
+    const request = new IndexFacesRequest(command.input);
+    const collection = await this.reach(
+      "rekognition:IndexFaces",
+      request.collectionId,
+      options,
+    );
+    const image = await request.image.read(this.images, options);
+
+    return new SimRekognitionFaceIndexer({
+      collection,
+      detection: this.faces.detectionFor(image),
+      request,
+    }).index();
+  }
+
+  /**
+   * List the faces one collection holds.
+   */
+  async list(
+    command: SimListFacesCommand,
+    options: SimRekognitionRequestOptions = {},
+  ): Promise<SimListFacesCommandOutput> {
+    const request = new ListFacesRequest(command.input);
+    const collection = await this.reach(
+      "rekognition:ListFaces",
+      request.collectionId,
+      options,
+    );
+
+    return new SimRekognitionFaceListing({ collection, request }).list();
+  }
+
+  /**
+   * Search a collection for the faces an image is declared to find.
+   */
+  async search(
+    command: SimSearchFacesByImageCommand,
+    options: SimRekognitionRequestOptions = {},
+  ): Promise<SimSearchFacesByImageCommandOutput> {
+    const request = new SearchFacesByImageRequest(command.input);
+    const collection = await this.reach(
+      "rekognition:SearchFacesByImage",
+      request.collectionId,
+      options,
+    );
+    const image = await request.image.read(this.images, options);
+
+    return new SimRekognitionFaceSearcher({
+      collection,
+      detection: this.faces.detectionFor(image),
+      declared: this.faceMatches.matchesFor(image),
+      request,
+    }).search();
+  }
+
+  /**
+   * Remove faces from a collection by id.
+   */
+  async delete(
+    command: SimDeleteFacesCommand,
+    options: SimRekognitionRequestOptions = {},
+  ): Promise<SimDeleteFacesCommandOutput> {
+    const request = new DeleteFacesRequest(command.input);
+    const collection = await this.reach(
+      "rekognition:DeleteFaces",
+      request.collectionId,
+      options,
+    );
+
+    return {
+      DeletedFaces: collection.faces.remove(request.faceIds),
+      UnsuccessfulFaceDeletions: [],
+      $metadata: {},
+    };
+  }
+
+  /**
+   * The collection an authorized request may work on.
+   *
+   * Authorizing before the collection is looked up is what keeps a denial and
+   * a missing collection separate: a caller with no permission for a
+   * collection never learns whether it is there.
+   */
+  private async reach(
+    action: string,
+    collectionId: string,
+    options: SimRekognitionRequestOptions,
+  ): Promise<SimRekognitionCollection> {
+    this.authorizer.authorize(
+      action,
+      options,
+      this.collections.arnFor(collectionId),
+    );
+
+    await this.background.sequence();
+
+    return this.collections.require(collectionId);
+  }
+}

--- a/src/service/rekognition/command/face/face.handler.ts
+++ b/src/service/rekognition/command/face/face.handler.ts
@@ -7,6 +7,7 @@ import type { SimRekognitionFaceMatches } from "../../match/sim-rekognition-face
 import type { SimRekognitionAuthorizer } from "../authorize/sim-rekognition-authorizer.js";
 import type { SimRekognitionRequestOptions } from "../sim-rekognition-request-options.js";
 import { DeleteFacesRequest } from "./delete-faces-request.js";
+import { simRekognitionFaceNotFound } from "./face-output.js";
 import { SimRekognitionFaceIndexer } from "./face-indexer.js";
 import { SimRekognitionFaceListing } from "./face-listing.js";
 import { SimRekognitionFaceSearcher } from "./face-searcher.js";
@@ -137,9 +138,14 @@ export class SimRekognitionFaceHandler {
       options,
     );
 
+    const removal = collection.faces.remove(request.faceIds);
+
     return {
-      DeletedFaces: collection.faces.remove(request.faceIds),
-      UnsuccessfulFaceDeletions: [],
+      DeletedFaces: removal.removed,
+      UnsuccessfulFaceDeletions: removal.missing.map((faceId) => ({
+        FaceId: faceId,
+        Reasons: [simRekognitionFaceNotFound],
+      })),
       $metadata: {},
     };
   }

--- a/src/service/rekognition/command/face/index-faces-request.ts
+++ b/src/service/rekognition/command/face/index-faces-request.ts
@@ -1,0 +1,52 @@
+import { SimRekognitionFaceAttributes } from "../../face/sim-rekognition-face-attributes.js";
+import {
+  type SimRekognitionImageRequest,
+  SimRekognitionImageRequests,
+} from "../../image/sim-rekognition-image-request.js";
+import { requiredCollectionId } from "../collection/collection-id.js";
+import { SimRekognitionUnsimulatedInput } from "../sim-rekognition-unsimulated-input.js";
+import { acceptedExternalImageId } from "./external-image-id.js";
+import { SimRekognitionFaceLimit } from "./face-limits.js";
+import type { SimIndexFacesCommandInput } from "./face.command.js";
+
+const operation = "IndexFaces";
+const acceptedInput = [
+  "CollectionId",
+  "Image",
+  "ExternalImageId",
+  "DetectionAttributes",
+  "MaxFaces",
+];
+
+const maxFaces = new SimRekognitionFaceLimit();
+
+/**
+ * An IndexFaces request, checked before anything acts on it.
+ *
+ * `QualityFilter` is refused with everything else this simulation does not
+ * model. Real Rekognition uses it to drop faces it judges too blurry or too
+ * small to index, and nothing here judges an image, so a request setting it
+ * would have faces dropped on AWS and kept here.
+ */
+export class IndexFacesRequest {
+  public readonly collectionId: string;
+  public readonly image: SimRekognitionImageRequest;
+  public readonly externalImageId: string | undefined;
+  public readonly attributes: SimRekognitionFaceAttributes;
+  public readonly maxFaces: number | undefined;
+
+  constructor(input: SimIndexFacesCommandInput) {
+    new SimRekognitionUnsimulatedInput(operation).refuseUnaccepted(
+      input,
+      acceptedInput,
+    );
+
+    this.collectionId = requiredCollectionId(input.CollectionId);
+    this.image = new SimRekognitionImageRequests(operation).parse(input.Image);
+    this.externalImageId = acceptedExternalImageId(input.ExternalImageId);
+    this.attributes = new SimRekognitionFaceAttributes(
+      input.DetectionAttributes,
+    );
+    this.maxFaces = maxFaces.of(input.MaxFaces);
+  }
+}

--- a/src/service/rekognition/command/face/list-faces-page.ts
+++ b/src/service/rekognition/command/face/list-faces-page.ts
@@ -1,0 +1,61 @@
+import { SimRekognitionInvalidParameterException } from "../../error/sim-rekognition.error.js";
+import type { SimRekognitionIndexedFace } from "../../collection/sim-rekognition-indexed-face.js";
+
+interface SimRekognitionFacePageProperties {
+  /** Every face the request selected, before paging. */
+  readonly listed: readonly SimRekognitionIndexedFace[];
+
+  readonly maxResults: number | undefined;
+  readonly nextToken: string | undefined;
+}
+
+function pageStartIndex(
+  nextToken: string | undefined,
+  listedCount: number,
+): number {
+  if (nextToken === undefined) {
+    return 0;
+  }
+
+  const startIndex = Number(nextToken);
+
+  if (
+    !Number.isSafeInteger(startIndex) ||
+    startIndex < 0 ||
+    startIndex >= listedCount ||
+    String(startIndex) !== nextToken
+  ) {
+    throw new SimRekognitionInvalidParameterException(
+      "Request has invalid parameters: NextToken is not a token this " +
+        "simulation issued",
+    );
+  }
+
+  return startIndex;
+}
+
+/**
+ * One page of a face listing, and the token that reaches the next one.
+ *
+ * The token is the offset of the next face, so it only means anything against
+ * the collection it was issued for. A token carried to a listing of a
+ * different collection reaches a different place, which is true of a real
+ * Rekognition token as well.
+ *
+ * A listing with no `MaxResults` comes back in one page. Real Rekognition
+ * pages a listing at a thousand faces by default, so the two differ only for a
+ * collection larger than that.
+ */
+export class SimRekognitionFacePage {
+  readonly faces: readonly SimRekognitionIndexedFace[];
+  readonly nextToken: string | undefined;
+
+  constructor(properties: SimRekognitionFacePageProperties) {
+    const { listed } = properties;
+    const startIndex = pageStartIndex(properties.nextToken, listed.length);
+    const nextIndex = startIndex + (properties.maxResults ?? listed.length);
+
+    this.faces = listed.slice(startIndex, nextIndex);
+    this.nextToken = nextIndex >= listed.length ? undefined : String(nextIndex);
+  }
+}

--- a/src/service/rekognition/command/face/list-faces-request.ts
+++ b/src/service/rekognition/command/face/list-faces-request.ts
@@ -1,0 +1,60 @@
+import { SimRekognitionInvalidParameterException } from "../../error/sim-rekognition.error.js";
+import { requiredCollectionId } from "../collection/collection-id.js";
+import { SimRekognitionUnsimulatedInput } from "../sim-rekognition-unsimulated-input.js";
+import { selectedFaceIds } from "./face-ids.js";
+import type { SimListFacesCommandInput } from "./face.command.js";
+
+const operation = "ListFaces";
+const acceptedInput = ["CollectionId", "FaceIds", "MaxResults", "NextToken"];
+
+/**
+ * The largest page real Rekognition returns.
+ */
+const mostResults = 4096;
+
+/**
+ * A ListFaces request, checked before anything acts on it.
+ *
+ * `UserId` is refused with everything else this simulation does not model.
+ * Nothing here associates a face with a user, so a listing narrowed to one
+ * would answer with every face in the collection.
+ */
+export class ListFacesRequest {
+  public readonly collectionId: string;
+  public readonly faceIds: readonly string[] | undefined;
+  public readonly maxResults: number | undefined;
+  public readonly nextToken: string | undefined;
+
+  constructor(input: SimListFacesCommandInput) {
+    new SimRekognitionUnsimulatedInput(operation).refuseUnaccepted(
+      input,
+      acceptedInput,
+    );
+
+    this.collectionId = requiredCollectionId(input.CollectionId);
+    this.faceIds = selectedFaceIds(input.FaceIds);
+    this.maxResults = ListFacesRequest.maxResultsOf(input.MaxResults);
+    this.nextToken = input.NextToken;
+  }
+
+  private static maxResultsOf(
+    requested: number | undefined,
+  ): number | undefined {
+    if (requested === undefined) {
+      return undefined;
+    }
+
+    if (
+      !Number.isSafeInteger(requested) ||
+      requested < 1 ||
+      requested > mostResults
+    ) {
+      throw new SimRekognitionInvalidParameterException(
+        `Request has invalid parameters: MaxResults of ${String(requested)} ` +
+          `is not a whole number of faces from 1 to ${String(mostResults)}`,
+      );
+    }
+
+    return requested;
+  }
+}

--- a/src/service/rekognition/command/face/search-faces-by-image-request.ts
+++ b/src/service/rekognition/command/face/search-faces-by-image-request.ts
@@ -1,0 +1,80 @@
+import { SimRekognitionInvalidParameterException } from "../../error/sim-rekognition.error.js";
+import {
+  type SimRekognitionImageRequest,
+  SimRekognitionImageRequests,
+} from "../../image/sim-rekognition-image-request.js";
+import { requiredCollectionId } from "../collection/collection-id.js";
+import { SimRekognitionUnsimulatedInput } from "../sim-rekognition-unsimulated-input.js";
+import { SimRekognitionFaceLimit } from "./face-limits.js";
+import type { SimSearchFacesByImageCommandInput } from "./face.command.js";
+
+const operation = "SearchFacesByImage";
+const acceptedInput = [
+  "CollectionId",
+  "Image",
+  "FaceMatchThreshold",
+  "MaxFaces",
+];
+
+/**
+ * The most faces real Rekognition returns from one search.
+ */
+const maxFaces = new SimRekognitionFaceLimit({ most: 4096 });
+
+/**
+ * How alike real Rekognition requires a face to be when a request does not
+ * say.
+ */
+const defaultThreshold = 80;
+
+/**
+ * A SearchFacesByImage request, checked before anything acts on it.
+ *
+ * `QualityFilter` is refused for the reason IndexFaces refuses it: nothing
+ * here judges an image, so a filter set on the request would drop the searched
+ * face on AWS and keep it here.
+ */
+export class SearchFacesByImageRequest {
+  public readonly collectionId: string;
+  public readonly image: SimRekognitionImageRequest;
+  public readonly threshold: number;
+  public readonly maxFaces: number | undefined;
+
+  constructor(input: SimSearchFacesByImageCommandInput) {
+    new SimRekognitionUnsimulatedInput(operation).refuseUnaccepted(
+      input,
+      acceptedInput,
+    );
+
+    this.collectionId = requiredCollectionId(input.CollectionId);
+    this.image = new SimRekognitionImageRequests(operation).parse(input.Image);
+    this.threshold = SearchFacesByImageRequest.thresholdOf(
+      input.FaceMatchThreshold,
+    );
+    this.maxFaces = maxFaces.of(input.MaxFaces);
+  }
+
+  /**
+   * How alike this search requires a face to be.
+   *
+   * The default applies only when the request left it out, so an explicit `0`
+   * asks for every declared match rather than being promoted to 80.
+   */
+  private static thresholdOf(requested: number | undefined): number {
+    if (requested === undefined) {
+      return defaultThreshold;
+    }
+
+    // A NaN is refused rather than compared against, as it is everywhere else
+    // a confidence is: every comparison with one is false, so it would filter
+    // every match out and look like a search that found nobody.
+    if (!Number.isFinite(requested) || requested < 0 || requested > 100) {
+      throw new SimRekognitionInvalidParameterException(
+        `Request has invalid parameters: FaceMatchThreshold of ` +
+          `${String(requested)} is not a percentage from 0 to 100`,
+      );
+    }
+
+    return requested;
+  }
+}

--- a/src/service/rekognition/command/sim-rekognition-detection-handlers.ts
+++ b/src/service/rekognition/command/sim-rekognition-detection-handlers.ts
@@ -1,0 +1,54 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimRekognitionFaces } from "../face/sim-rekognition-faces.js";
+import type { SimRekognitionImageObjects } from "../image/sim-rekognition-image-objects.js";
+import type { SimRekognitionLabels } from "../label/sim-rekognition-labels.js";
+import type { SimRekognitionModeration } from "../moderation/sim-rekognition-moderation.js";
+import type { SimRekognitionAuthorizer } from "./authorize/sim-rekognition-authorizer.js";
+import { DetectFacesHandler } from "./detect-faces/detect-faces.handler.js";
+import { DetectLabelsHandler } from "./detect-labels/detect-labels.handler.js";
+import { DetectModerationLabelsHandler } from "./detect-moderation-labels/detect-moderation-labels.handler.js";
+
+interface SimRekognitionDetectionHandlersProperties {
+  readonly moderation: SimRekognitionModeration;
+  readonly labels: SimRekognitionLabels;
+  readonly faces: SimRekognitionFaces;
+  readonly authorizer: SimRekognitionAuthorizer;
+  readonly images: SimRekognitionImageObjects;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * The three operations that answer what is in one image.
+ *
+ * They differ only in the rules they read, so they are built together and the
+ * facade holds one of these rather than three handlers and the same four
+ * collaborators three times over.
+ */
+export class SimRekognitionDetectionHandlers {
+  public readonly moderationLabels: DetectModerationLabelsHandler;
+  public readonly labels: DetectLabelsHandler;
+  public readonly faces: DetectFacesHandler;
+
+  constructor(properties: SimRekognitionDetectionHandlersProperties) {
+    const { authorizer, images, background } = properties;
+
+    this.moderationLabels = new DetectModerationLabelsHandler({
+      moderation: properties.moderation,
+      authorizer,
+      images,
+      background,
+    });
+    this.labels = new DetectLabelsHandler({
+      labels: properties.labels,
+      authorizer,
+      images,
+      background,
+    });
+    this.faces = new DetectFacesHandler({
+      faces: properties.faces,
+      authorizer,
+      images,
+      background,
+    });
+  }
+}

--- a/src/service/rekognition/face/sim-rekognition-detected-face.ts
+++ b/src/service/rekognition/face/sim-rekognition-detected-face.ts
@@ -1,4 +1,5 @@
 import type { SimRekognitionFaceDetailOutput } from "../command/detect-faces/detect-faces.command.js";
+import type { SimRekognitionBoundingBoxOutput } from "../image/sim-rekognition-bounding-box.js";
 import { SimRekognitionDeclaredConfidence } from "../rule/sim-rekognition-declared-confidence.js";
 import { SimRekognitionFaceAgeAndGender } from "./sim-rekognition-face-age-and-gender.js";
 import type { SimRekognitionFaceAttributes } from "./sim-rekognition-face-attributes.js";
@@ -63,6 +64,20 @@ export class SimRekognitionDetectedFace {
       confidence,
       declared.eyeDirection,
     );
+  }
+
+  /**
+   * How sure the detection is that this is a face.
+   */
+  confidence(): number {
+    return this.frame.confidence;
+  }
+
+  /**
+   * Where this face is, when a box was declared for it.
+   */
+  boundingBox(): SimRekognitionBoundingBoxOutput | undefined {
+    return this.frame.boundingBox;
   }
 
   /**

--- a/src/service/rekognition/face/sim-rekognition-face-detection.ts
+++ b/src/service/rekognition/face/sim-rekognition-face-detection.ts
@@ -36,6 +36,17 @@ export class SimRekognitionFaceDetection {
   }
 
   /**
+   * The faces this result holds, in the order they were declared.
+   *
+   * Indexing works from these rather than from the details, because a face
+   * put in a collection is read back later at attributes the request that
+   * indexed it never asked for.
+   */
+  detected(): readonly SimRekognitionDetectedFace[] {
+    return this.faces;
+  }
+
+  /**
    * The face details to report for this result, as one request asked for
    * them.
    */

--- a/src/service/rekognition/face/sim-rekognition-face-frame.ts
+++ b/src/service/rekognition/face/sim-rekognition-face-frame.ts
@@ -81,7 +81,11 @@ export class SimRekognitionFaceFrame {
    */
   public readonly confidence: number;
 
-  private readonly boundingBox: SimRekognitionBoundingBoxOutput | undefined;
+  /**
+   * Where this face is, when a box was declared for it.
+   */
+  public readonly boundingBox: SimRekognitionBoundingBoxOutput | undefined;
+
   private readonly pose: SimRekognitionPoseOutput | undefined;
   private readonly quality: SimRekognitionImageQualityOutput | undefined;
 

--- a/src/service/rekognition/index.ts
+++ b/src/service/rekognition/index.ts
@@ -28,6 +28,11 @@ export {
   simRekognitionLandmarkNames,
   type SimRekognitionLandmarkName,
 } from "./face/sim-rekognition-landmark-name.js";
+export { SimRekognitionFaceMatches } from "./match/sim-rekognition-face-matches.js";
+export type {
+  SimRekognitionDeclaredFaceMatch,
+  SimRekognitionFaceMatchesResult,
+} from "./match/sim-rekognition-face-match-declaration.js";
 export type { SimRekognitionDeclaredBoundingBox } from "./image/sim-rekognition-bounding-box.js";
 export { SimRekognitionLabels } from "./label/sim-rekognition-labels.js";
 export type {
@@ -62,5 +67,7 @@ export {
   SimRekognitionInvalidImageFormatException,
   SimRekognitionInvalidParameterException,
   SimRekognitionInvalidS3ObjectException,
+  SimRekognitionResourceAlreadyExistsException,
+  SimRekognitionResourceNotFoundException,
   SimRekognitionUnsimulatedInputException,
 } from "./error/sim-rekognition.error.js";

--- a/src/service/rekognition/match/sim-rekognition-face-match-declaration.iso.test.ts
+++ b/src/service/rekognition/match/sim-rekognition-face-match-declaration.iso.test.ts
@@ -1,0 +1,72 @@
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimRekognitionDeclarationError } from "../error/sim-rekognition.error.js";
+import type { SimRekognitionDeclaredFaceMatch } from "./sim-rekognition-face-match-declaration.js";
+import type { SimRekognitionFaceMatches } from "./sim-rekognition-face-matches.js";
+
+function faceMatches(): SimRekognitionFaceMatches {
+  return new SimAws().rekognition().faceMatches();
+}
+
+function declarationError(match: SimRekognitionDeclaredFaceMatch): Error {
+  return assertThrowsError(() => {
+    faceMatches().byDefault({ matches: [match] });
+  });
+}
+
+describe("Declaring a simulated face search result", () => {
+  it("accepts a match naming the id a face was indexed under", () => {
+    // Given a simulated Rekognition
+    // When a rule says which indexed face an image finds
+    faceMatches().onName("door/visitor.jpg", {
+      matches: [{ externalImageId: "ada" }],
+    });
+
+    // Then it is accepted, and the similarity is left to the default
+  });
+
+  it("accepts a match naming the id IndexFaces answered with", () => {
+    faceMatches().onName("door/visitor.jpg", {
+      matches: [{ faceId: "0a1b2c3d-4e5f-4a6b-8c9d-0e1f2a3b4c5d" }],
+    });
+  });
+
+  it("refuses a match naming both kinds of id", () => {
+    // Given a match declared with a face id and an external image id
+    const error = declarationError({
+      faceId: "0a1b2c3d-4e5f-4a6b-8c9d-0e1f2a3b4c5d",
+      externalImageId: "ada",
+    });
+
+    // Then it is refused where it was written, since the two say different
+    // things about which faces the search finds
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "face match 1");
+    assertStringIncludes(error.message, "not both");
+  });
+
+  it("refuses a match naming no face at all", () => {
+    // Given a match declared with a similarity and nothing to apply it to
+    const error = declarationError({ similarity: 99 });
+
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(
+      error.message,
+      "either a faceId or an externalImageId",
+    );
+  });
+
+  it("refuses a similarity outside the range Rekognition reports", () => {
+    // Given a match declared as more alike than anything can be
+    const error = declarationError({ externalImageId: "ada", similarity: 120 });
+
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "percentage from 0 to 100");
+  });
+});

--- a/src/service/rekognition/match/sim-rekognition-face-match-declaration.ts
+++ b/src/service/rekognition/match/sim-rekognition-face-match-declaration.ts
@@ -1,0 +1,29 @@
+/**
+ * One face a search is declared to find, named the way the test that wrote the
+ * rule knows it by.
+ *
+ * A match names exactly one of the two. `externalImageId` is the id the
+ * indexing request chose, so a rule using it can be written before anything is
+ * indexed, which is what a test whose own code does the indexing needs.
+ * `faceId` is the id `IndexFaces` answered with, so a rule using it is written
+ * after that call and names one face and no other.
+ *
+ * The face still has to be in the collection being searched. A declaration
+ * naming a face that was never indexed, or one that has since been deleted,
+ * matches nothing rather than inventing a face for the response.
+ */
+export interface SimRekognitionDeclaredFaceMatch {
+  readonly faceId?: string | undefined;
+  readonly externalImageId?: string | undefined;
+  readonly similarity?: number | undefined;
+}
+
+/**
+ * What a face search answers with for an image.
+ *
+ * An image that finds nobody is `{ matches: [] }`, which is what every image
+ * answers with until a rule says otherwise.
+ */
+export interface SimRekognitionFaceMatchesResult {
+  readonly matches: readonly SimRekognitionDeclaredFaceMatch[];
+}

--- a/src/service/rekognition/match/sim-rekognition-face-match-result.ts
+++ b/src/service/rekognition/match/sim-rekognition-face-match-result.ts
@@ -1,0 +1,72 @@
+import type { SimRekognitionCollectionFaces } from "../collection/sim-rekognition-collection-faces.js";
+import type { SimRekognitionFaceMatchOutput } from "../command/face/face-output.js";
+import type { SimRekognitionFaceMatchesResult } from "./sim-rekognition-face-match-declaration.js";
+import { SimRekognitionFaceMatchRule } from "./sim-rekognition-face-match-rule.js";
+
+interface SimRekognitionFaceSearch {
+  readonly threshold: number;
+  readonly mostFaces: number | undefined;
+}
+
+/**
+ * Keep the most alike report of each face.
+ *
+ * A face declared twice, once by its face id and once by the external image id
+ * it shares with another, is one face in the collection and so one match in
+ * the response.
+ */
+function deduplicated(
+  matches: readonly SimRekognitionFaceMatchOutput[],
+): readonly SimRekognitionFaceMatchOutput[] {
+  const best = new Map<string, SimRekognitionFaceMatchOutput>();
+
+  for (const match of matches) {
+    const held = best.get(match.Face.FaceId);
+
+    if (held === undefined || match.Similarity > held.Similarity) {
+      best.set(match.Face.FaceId, match);
+    }
+  }
+
+  return best.values().toArray();
+}
+
+/**
+ * The face matches one rule answers with, resolved from its declaration.
+ *
+ * What the rule declares is which indexed faces a search image finds. Which of
+ * them a given search reports is decided per call, from the collection it
+ * searched and the threshold and limit it asked for.
+ */
+export class SimRekognitionFaceMatchResult {
+  private readonly rules: readonly SimRekognitionFaceMatchRule[];
+
+  constructor(result: SimRekognitionFaceMatchesResult) {
+    this.rules = result.matches.map(
+      (match, index) =>
+        new SimRekognitionFaceMatchRule(
+          `face match ${String(index + 1)}`,
+          match,
+        ),
+    );
+  }
+
+  /**
+   * The matches one search reports, most alike first, as real Rekognition
+   * orders them.
+   */
+  matchesIn(
+    faces: SimRekognitionCollectionFaces,
+    search: SimRekognitionFaceSearch,
+  ): readonly SimRekognitionFaceMatchOutput[] {
+    const found = deduplicated(
+      this.rules.flatMap((rule) => rule.matchesIn(faces)),
+    )
+      .filter((match) => match.Similarity >= search.threshold)
+      .toSorted((one, other) => other.Similarity - one.Similarity);
+
+    return search.mostFaces === undefined
+      ? found
+      : found.slice(0, search.mostFaces);
+  }
+}

--- a/src/service/rekognition/match/sim-rekognition-face-match-rule.ts
+++ b/src/service/rekognition/match/sim-rekognition-face-match-rule.ts
@@ -1,0 +1,95 @@
+import type { SimRekognitionCollectionFaces } from "../collection/sim-rekognition-collection-faces.js";
+import type { SimRekognitionIndexedFace } from "../collection/sim-rekognition-indexed-face.js";
+import type { SimRekognitionFaceMatchOutput } from "../command/face/face-output.js";
+import { SimRekognitionDeclarationError } from "../error/sim-rekognition.error.js";
+import { SimRekognitionDeclaredConfidence } from "../rule/sim-rekognition-declared-confidence.js";
+import type { SimRekognitionDeclaredFaceMatch } from "./sim-rekognition-face-match-declaration.js";
+
+/**
+ * How alike a match is reported as when the declaration says nothing.
+ *
+ * It is the similarity in the AWS SearchFacesByImage example response, so an
+ * undeclared one has the float32 tail a real match has, and sits above the
+ * default `FaceMatchThreshold` of 80 that a search applies to it.
+ */
+const matchSimilarity = new SimRekognitionDeclaredConfidence(99.97222137451172);
+
+interface SimRekognitionFaceMatchIdentifier {
+  readonly kind: "faceId" | "externalImageId";
+  readonly value: string;
+}
+
+function identifierOf(
+  subject: string,
+  declared: SimRekognitionDeclaredFaceMatch,
+): SimRekognitionFaceMatchIdentifier {
+  const { faceId, externalImageId } = declared;
+
+  if (faceId !== undefined && externalImageId !== undefined) {
+    throw new SimRekognitionDeclarationError(
+      `A face match declared for '${subject}' names both a faceId and an ` +
+        `externalImageId. A match names the one face id IndexFaces answered ` +
+        `with, or the external image id it was indexed under, and not both.`,
+    );
+  }
+
+  if (faceId !== undefined) {
+    return { kind: "faceId", value: faceId };
+  }
+
+  if (externalImageId !== undefined) {
+    return { kind: "externalImageId", value: externalImageId };
+  }
+
+  throw new SimRekognitionDeclarationError(
+    `A face match declared for '${subject}' names no face. A match needs ` +
+      `either a faceId or an externalImageId to say which indexed face a ` +
+      `search finds.`,
+  );
+}
+
+/**
+ * One declared face match, resolved from its declaration.
+ *
+ * The declaration is resolved when the rule is registered, so a similarity
+ * outside the range Rekognition reports, or a match naming both kinds of id at
+ * once, is refused where it was written. Which faces it reaches is resolved
+ * per search, because the collection being searched is what decides that.
+ */
+export class SimRekognitionFaceMatchRule {
+  private readonly identifier: SimRekognitionFaceMatchIdentifier;
+  private readonly similarity: number;
+
+  constructor(subject: string, declared: SimRekognitionDeclaredFaceMatch) {
+    this.identifier = identifierOf(subject, declared);
+    this.similarity = matchSimilarity.of(subject, declared.similarity);
+  }
+
+  /**
+   * What this rule finds in one collection.
+   *
+   * An external image id can name several faces, since real Rekognition takes
+   * one as a label the caller chose rather than as a key, so a photograph of
+   * the same person indexed twice is found twice.
+   */
+  matchesIn(
+    faces: SimRekognitionCollectionFaces,
+  ): readonly SimRekognitionFaceMatchOutput[] {
+    return this.facesIn(faces).map((face) => ({
+      Similarity: this.similarity,
+      Face: face.stored(),
+    }));
+  }
+
+  private facesIn(
+    faces: SimRekognitionCollectionFaces,
+  ): readonly SimRekognitionIndexedFace[] {
+    if (this.identifier.kind === "externalImageId") {
+      return faces.withExternalImageId(this.identifier.value);
+    }
+
+    const face = faces.withFaceId(this.identifier.value);
+
+    return face === undefined ? [] : [face];
+  }
+}

--- a/src/service/rekognition/match/sim-rekognition-face-matches.ts
+++ b/src/service/rekognition/match/sim-rekognition-face-matches.ts
@@ -1,0 +1,48 @@
+import type { SimRekognitionImage } from "../image/sim-rekognition-image.js";
+import { SimRekognitionResultRules } from "../rule/sim-rekognition-result-rules.js";
+import type { SimRekognitionFaceMatchesResult } from "./sim-rekognition-face-match-declaration.js";
+import { SimRekognitionFaceMatchResult } from "./sim-rekognition-face-match-result.js";
+
+/**
+ * The face search results simulated Rekognition answers with.
+ *
+ * Nothing here compares one face with another, so which indexed faces a search
+ * image finds is declared the same way every other Rekognition result is: by
+ * the name of the S3 object searched with, by the hash of its bytes, or as the
+ * answer for anything else. An image no rule matches finds nobody, because a
+ * search that invented a match would pass a test the application would fail.
+ */
+export class SimRekognitionFaceMatches {
+  private readonly rules =
+    new SimRekognitionResultRules<SimRekognitionFaceMatchResult>(
+      new SimRekognitionFaceMatchResult({ matches: [] }),
+    );
+
+  /**
+   * Answer with these matches for any image no other rule matches.
+   */
+  byDefault(result: SimRekognitionFaceMatchesResult): void {
+    this.rules.byDefault(new SimRekognitionFaceMatchResult(result));
+  }
+
+  /**
+   * Answer with these matches for the S3 object with this exact name.
+   */
+  onName(name: string, result: SimRekognitionFaceMatchesResult): void {
+    this.rules.onName(name, new SimRekognitionFaceMatchResult(result));
+  }
+
+  /**
+   * Answer with these matches for the image with this exact content hash.
+   */
+  onHash(hash: string, result: SimRekognitionFaceMatchesResult): void {
+    this.rules.onHash(hash, new SimRekognitionFaceMatchResult(result));
+  }
+
+  /**
+   * The matches declared for one search image.
+   */
+  matchesFor(image: SimRekognitionImage): SimRekognitionFaceMatchResult {
+    return this.rules.resultFor(image);
+  }
+}

--- a/src/service/rekognition/sdk/sim-rekognition-sdk-command-router.iso.test.ts
+++ b/src/service/rekognition/sdk/sim-rekognition-sdk-command-router.iso.test.ts
@@ -19,6 +19,10 @@ describe("SimRekognitionSdkCommandRouter", () => {
       "DetectModerationLabelsCommand",
       "DetectLabelsCommand",
       "DetectFacesCommand",
+      "IndexFacesCommand",
+      "ListFacesCommand",
+      "SearchFacesByImageCommand",
+      "DeleteFacesCommand",
     ]);
   });
 

--- a/src/service/rekognition/sdk/sim-rekognition-sdk-command-router.ts
+++ b/src/service/rekognition/sdk/sim-rekognition-sdk-command-router.ts
@@ -8,6 +8,12 @@ import type {
   SimDeleteCollectionCommand,
   SimListCollectionsCommand,
 } from "../command/collection/collection.command.js";
+import type {
+  SimDeleteFacesCommand,
+  SimIndexFacesCommand,
+  SimListFacesCommand,
+  SimSearchFacesByImageCommand,
+} from "../command/face/face.command.js";
 import type { SimDetectFacesCommand } from "../command/detect-faces/detect-faces.command.js";
 import type { SimDetectLabelsCommand } from "../command/detect-labels/detect-labels.command.js";
 import type { SimDetectModerationLabelsCommand } from "../command/detect-moderation-labels/detect-moderation-labels.command.js";
@@ -43,6 +49,38 @@ export class SimRekognitionSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simRekognition.deleteCollection(
             command as SimDeleteCollectionCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "IndexFacesCommand",
+        async (command, context): Promise<unknown> =>
+          await simRekognition.indexFaces(
+            command as SimIndexFacesCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListFacesCommand",
+        async (command, context): Promise<unknown> =>
+          await simRekognition.listFaces(
+            command as SimListFacesCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "SearchFacesByImageCommand",
+        async (command, context): Promise<unknown> =>
+          await simRekognition.searchFacesByImage(
+            command as SimSearchFacesByImageCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteFacesCommand",
+        async (command, context): Promise<unknown> =>
+          await simRekognition.deleteFaces(
+            command as SimDeleteFacesCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/rekognition/sdk/sim-rekognition-sdk-routing.iso.test.ts
+++ b/src/service/rekognition/sdk/sim-rekognition-sdk-routing.iso.test.ts
@@ -1,8 +1,11 @@
 import {
+  CreateCollectionCommand,
   DetectFacesCommand,
   DetectLabelsCommand,
   DetectModerationLabelsCommand,
+  IndexFacesCommand,
   RekognitionClient,
+  SearchFacesByImageCommand,
 } from "@aws-sdk/client-rekognition";
 import {
   assertArrayLength,
@@ -91,5 +94,41 @@ describe("Rekognition SDK interception", () => {
     // Then the declared result comes back, with nothing touching the network.
     assertArrayLength(detected.FaceDetails ?? [], 2);
     assertTrue(detected.FaceDetails?.[0]?.Smile?.Value);
+  });
+
+  it("routes an intercepted indexing and search to simulated Rekognition", async () => {
+    // Given an intercepted Rekognition SDK client, with a search declared to
+    // find the face an application indexes.
+    using simSdk = new SimSdk();
+    simSdk.intercept(RekognitionClient);
+    simSdk.simAws
+      .rekognition()
+      .faceMatches()
+      .byDefault({ matches: [{ externalImageId: "ada" }] });
+
+    const rekognition = new RekognitionClient({ region: "us-east-1" });
+
+    // When ordinary SDK code registers a face and later searches for it.
+    await rekognition.send(
+      new CreateCollectionCommand({ CollectionId: "staff" }),
+    );
+    await rekognition.send(
+      new IndexFacesCommand({
+        CollectionId: "staff",
+        Image: { Bytes: redPngBytes },
+        ExternalImageId: "ada",
+      }),
+    );
+    const found = await rekognition.send(
+      new SearchFacesByImageCommand({
+        CollectionId: "staff",
+        Image: { Bytes: redPngBytes },
+      }),
+    );
+
+    // Then it recognises the same person twice, with nothing touching the
+    // network.
+    assertArrayLength(found.FaceMatches ?? [], 1);
+    assertIdentical(found.FaceMatches?.[0]?.Face?.ExternalImageId, "ada");
   });
 });

--- a/src/service/rekognition/sim-rekognition.ts
+++ b/src/service/rekognition/sim-rekognition.ts
@@ -6,6 +6,17 @@ import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-route
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
 import { SimRekognitionCollections } from "./collection/sim-rekognition-collections.js";
+import { SimRekognitionFaceHandler } from "./command/face/face.handler.js";
+import type {
+  SimDeleteFacesCommand,
+  SimDeleteFacesCommandOutput,
+  SimIndexFacesCommand,
+  SimIndexFacesCommandOutput,
+  SimListFacesCommand,
+  SimListFacesCommandOutput,
+  SimSearchFacesByImageCommand,
+  SimSearchFacesByImageCommandOutput,
+} from "./command/face/face.command.js";
 import { SimRekognitionCollectionHandler } from "./command/collection/collection.handler.js";
 import type {
   SimCreateCollectionCommand,
@@ -20,21 +31,19 @@ import {
   type SimIamInterServiceAuthZ,
 } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimRekognitionAuthorizer } from "./command/authorize/sim-rekognition-authorizer.js";
-import { DetectFacesHandler } from "./command/detect-faces/detect-faces.handler.js";
 import type {
   SimDetectFacesCommand,
   SimDetectFacesCommandOutput,
 } from "./command/detect-faces/detect-faces.command.js";
-import { DetectLabelsHandler } from "./command/detect-labels/detect-labels.handler.js";
 import type {
   SimDetectLabelsCommand,
   SimDetectLabelsCommandOutput,
 } from "./command/detect-labels/detect-labels.command.js";
-import { DetectModerationLabelsHandler } from "./command/detect-moderation-labels/detect-moderation-labels.handler.js";
 import type {
   SimDetectModerationLabelsCommand,
   SimDetectModerationLabelsCommandOutput,
 } from "./command/detect-moderation-labels/detect-moderation-labels.command.js";
+import { SimRekognitionDetectionHandlers } from "./command/sim-rekognition-detection-handlers.js";
 import type { SimRekognitionRequestOptions } from "./command/sim-rekognition-request-options.js";
 import { SimRekognitionFaces } from "./face/sim-rekognition-faces.js";
 import {
@@ -42,6 +51,7 @@ import {
   SimRekognitionUnreachableImageObjects,
 } from "./image/sim-rekognition-image-objects.js";
 import { SimRekognitionLabels } from "./label/sim-rekognition-labels.js";
+import { SimRekognitionFaceMatches } from "./match/sim-rekognition-face-matches.js";
 import { SimRekognitionModeration } from "./moderation/sim-rekognition-moderation.js";
 import { SimRekognitionSdkCommandRouter } from "./sdk/sim-rekognition-sdk-command-router.js";
 
@@ -69,12 +79,12 @@ export class SimRekognition {
   private readonly moderationRules = new SimRekognitionModeration();
   private readonly labelRules = new SimRekognitionLabels();
   private readonly faceRules = new SimRekognitionFaces();
-  private readonly detectModerationLabelsCommand: DetectModerationLabelsHandler;
-  private readonly detectLabelsCommand: DetectLabelsHandler;
-  private readonly detectFacesCommand: DetectFacesHandler;
+  private readonly faceMatchRules = new SimRekognitionFaceMatches();
+  private readonly detections: SimRekognitionDetectionHandlers;
   private readonly sdkRouter = new SimRekognitionSdkCommandRouter(this);
   private readonly collectionStore: SimRekognitionCollections;
   private readonly collectionCommands: SimRekognitionCollectionHandler;
+  private readonly collectionFaceCommands: SimRekognitionFaceHandler;
 
   constructor(properties: SimRekognitionProperties = {}) {
     const {
@@ -94,21 +104,18 @@ export class SimRekognition {
       background,
     });
 
-    this.detectModerationLabelsCommand = new DetectModerationLabelsHandler({
+    this.collectionFaceCommands = new SimRekognitionFaceHandler({
+      collections: this.collectionStore,
+      faces: this.faceRules,
+      faceMatches: this.faceMatchRules,
+      authorizer,
+      images,
+      background,
+    });
+
+    this.detections = new SimRekognitionDetectionHandlers({
       moderation: this.moderationRules,
-      authorizer,
-      images,
-      background,
-    });
-
-    this.detectLabelsCommand = new DetectLabelsHandler({
       labels: this.labelRules,
-      authorizer,
-      images,
-      background,
-    });
-
-    this.detectFacesCommand = new DetectFacesHandler({
       faces: this.faceRules,
       authorizer,
       images,
@@ -144,6 +151,46 @@ export class SimRekognition {
     options?: SimRekognitionRequestOptions,
   ): Promise<SimDeleteCollectionCommandOutput> {
     return await this.collectionCommands.delete(command, options);
+  }
+
+  /**
+   * Handle an IndexFacesCommand from the SDK.
+   */
+  async indexFaces(
+    command: SimIndexFacesCommand,
+    options?: SimRekognitionRequestOptions,
+  ): Promise<SimIndexFacesCommandOutput> {
+    return await this.collectionFaceCommands.index(command, options);
+  }
+
+  /**
+   * Handle a ListFacesCommand from the SDK.
+   */
+  async listFaces(
+    command: SimListFacesCommand,
+    options?: SimRekognitionRequestOptions,
+  ): Promise<SimListFacesCommandOutput> {
+    return await this.collectionFaceCommands.list(command, options);
+  }
+
+  /**
+   * Handle a SearchFacesByImageCommand from the SDK.
+   */
+  async searchFacesByImage(
+    command: SimSearchFacesByImageCommand,
+    options?: SimRekognitionRequestOptions,
+  ): Promise<SimSearchFacesByImageCommandOutput> {
+    return await this.collectionFaceCommands.search(command, options);
+  }
+
+  /**
+   * Handle a DeleteFacesCommand from the SDK.
+   */
+  async deleteFaces(
+    command: SimDeleteFacesCommand,
+    options?: SimRekognitionRequestOptions,
+  ): Promise<SimDeleteFacesCommandOutput> {
+    return await this.collectionFaceCommands.delete(command, options);
   }
 
   /**
@@ -190,6 +237,22 @@ export class SimRekognition {
   }
 
   /**
+   * The face searches this simulated Rekognition answers with.
+   *
+   * A search finds nobody until a rule says which indexed faces the image it
+   * searched with finds:
+   *
+   * ```typescript
+   * simAws.rekognition().faceMatches().onName("door/visitor.jpg", {
+   *   matches: [{ externalImageId: "ada" }],
+   * });
+   * ```
+   */
+  faceMatches(): SimRekognitionFaceMatches {
+    return this.faceMatchRules;
+  }
+
+  /**
    * Handle a DetectModerationLabels Command from the SDK.
    *
    * Background sequencing happens inside the command rather than here,
@@ -200,7 +263,7 @@ export class SimRekognition {
     command: SimDetectModerationLabelsCommand,
     options?: SimRekognitionRequestOptions,
   ): Promise<SimDetectModerationLabelsCommandOutput> {
-    return await this.detectModerationLabelsCommand.handle(command, options);
+    return await this.detections.moderationLabels.handle(command, options);
   }
 
   /**
@@ -210,7 +273,7 @@ export class SimRekognition {
     command: SimDetectLabelsCommand,
     options?: SimRekognitionRequestOptions,
   ): Promise<SimDetectLabelsCommandOutput> {
-    return await this.detectLabelsCommand.handle(command, options);
+    return await this.detections.labels.handle(command, options);
   }
 
   /**
@@ -220,7 +283,7 @@ export class SimRekognition {
     command: SimDetectFacesCommand,
     options?: SimRekognitionRequestOptions,
   ): Promise<SimDetectFacesCommandOutput> {
-    return await this.detectFacesCommand.handle(command, options);
+    return await this.detections.faces.handle(command, options);
   }
 
   /**


### PR DESCRIPTION
Simulated Rekognition held collections and put no faces in them. `IndexFaces` records the faces an image is declared to hold, `ListFaces` reads them back, `SearchFacesByImage` finds them again and `DeleteFaces` removes them. The faces put in a collection come from the same `faces()` rules `DetectFaces` answers from, and which of them a search finds is declared through a fourth rule set, `faceMatches()`, by the external image id a face was indexed under or by the face id `IndexFaces` answered with. A declared match reaches the faces the searched collection holds, so a deleted face stops being found with the rule unchanged. Each operation authorizes against the collection's own ARN before looking the collection up, and raises `ResourceNotFoundException` for one that was never created.

Resolves https://github.com/KensioSoftware/yulin/issues/687

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added simulated Rekognition face collections with face indexing, listing, image search, and deletion.
  - Added pagination, face ID and external image ID filtering, similarity thresholds, and collection-scoped access control.
  - Added configurable face-match rules by image name or indexed face ID, including deduplication and ranking.
  - Added SDK support for the new face operations.

- **Documentation**
  - Expanded Rekognition documentation and added examples covering face indexing, searching, lifecycle management, and match configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->