### PR TITLE
feat: find a Stack Resource by CDK construct ID

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -1756,6 +1756,51 @@ console.log(bucketResource?.simResource);
 This is useful in tests when you want to assert that a specific template resource created the
 expected simulated service resource.
 
+### Looking a Resource up by CDK construct ID
+
+`getResource` takes the CDK construct ID as well as the synthesized logical ID. A construct named
+`UploadsBucket` synthesizes as `UploadsBucket9F8E7D6C`, and either name answers with that Resource.
+The construct ID is the identifier a [binding](#lambda-function-bindings) takes. A test that bound a
+handler by construct ID can ask the Stack what it bound, without reading the synthesized template
+for the hash.
+
+```typescript sim-cloudformation-construct-id-resource
+/**
+ * Finding a synthesized Resource by the CDK construct ID it came from.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "construct-id-stack",
+  template: {
+    Resources: {
+      // As CDK synthesizes it, with a hash on the logical ID and the construct
+      // path in Metadata.
+      UploadsBucket9F8E7D6C: {
+        Type: "AWS::S3::Bucket",
+        Metadata: {
+          "aws:cdk:path": "UploadsStack/UploadsBucket/Resource",
+        },
+        Properties: {
+          BucketName: "construct-id-uploads",
+        },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+console.log(stack.getResource("UploadsBucket")?.logicalId);
+// "UploadsBucket9F8E7D6C"
+```
+
+A logical ID that matches exactly is answered first. A template naming its own Resources resolves
+the way it always has. An identifier no Resource carries either way answers `undefined`.
+
 `stack.skippedResources` lists the Resources the deployment did not create. Each one carries a
 `skippedReason` saying why that Resource was skipped. A test that expected a resource to exist can
 find out why it is missing.

--- a/docs/services/cloudformation/sim-cloudformation-construct-id-resource.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-construct-id-resource.example.ts
@@ -1,0 +1,31 @@
+/**
+ * Finding a synthesized Resource by the CDK construct ID it came from.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "construct-id-stack",
+  template: {
+    Resources: {
+      // As CDK synthesizes it, with a hash on the logical ID and the construct
+      // path in Metadata.
+      UploadsBucket9F8E7D6C: {
+        Type: "AWS::S3::Bucket",
+        Metadata: {
+          "aws:cdk:path": "UploadsStack/UploadsBucket/Resource",
+        },
+        Properties: {
+          BucketName: "construct-id-uploads",
+        },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+console.log(stack.getResource("UploadsBucket")?.logicalId);
+// "UploadsBucket9F8E7D6C"

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -2275,6 +2275,67 @@ path. A binding that resolves to no template resource fails the deploy with the 
 named for diagnosis. Where two bindings could both back the same function, the one listed first is
 the one that backs it.
 
+### Invoking a function bound by construct ID
+
+A CDK function usually leaves `FunctionName` out of the template, and sim Lambda creates it under
+the synthesized logical ID. `stack.getResource` takes the construct ID the binding named. The
+Resource it answers with carries that logical ID, and it is the name to invoke. The hash CDK
+generated stays out of the test.
+
+```typescript sim-lambda-construct-id-invoke
+/**
+ * Invoking a Lambda function bound by its CDK construct ID.
+ */
+
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "uploads-stack",
+  template: {
+    Resources: {
+      UploadFunction8A7B6C5D: {
+        Type: "AWS::Lambda::Function",
+        Metadata: {
+          "aws:cdk:path": "UploadsStack/UploadFunction/Resource",
+        },
+        Properties: {
+          Role: "arn:aws:iam::111111111111:role/UploadFunctionRole",
+        },
+      },
+    },
+  },
+  bindings: [
+    {
+      logicalId: "UploadFunction",
+      handler: (event: { key: string }): string => `stored ${event.key}`,
+    },
+  ],
+});
+
+const upload = stack.getResource("UploadFunction");
+if (upload === undefined) throw new Error("No UploadFunction Resource");
+
+const output = await simAws.lambda().invoke(
+  new InvokeCommand({
+    FunctionName: upload.logicalId,
+    Payload: JSON.stringify({ key: "receipt.pdf" }),
+  }),
+);
+
+if (output.Payload === undefined) throw new Error("No invoke Payload");
+console.log(Buffer.from(output.Payload).toString());
+// "stored receipt.pdf"
+
+await simAws.backgroundTasksComplete();
+```
+
+A function with a `FunctionName` in the template is invoked by that name. The caller wrote it and
+already holds it.
+
 ### Binding by container image repository
 
 `imageRepository` matches any function whose resolved `Code.ImageUri` names that repository. One

--- a/docs/services/lambda/sim-lambda-construct-id-invoke.example.ts
+++ b/docs/services/lambda/sim-lambda-construct-id-invoke.example.ts
@@ -1,0 +1,48 @@
+/**
+ * Invoking a Lambda function bound by its CDK construct ID.
+ */
+
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "uploads-stack",
+  template: {
+    Resources: {
+      UploadFunction8A7B6C5D: {
+        Type: "AWS::Lambda::Function",
+        Metadata: {
+          "aws:cdk:path": "UploadsStack/UploadFunction/Resource",
+        },
+        Properties: {
+          Role: "arn:aws:iam::111111111111:role/UploadFunctionRole",
+        },
+      },
+    },
+  },
+  bindings: [
+    {
+      logicalId: "UploadFunction",
+      handler: (event: { key: string }): string => `stored ${event.key}`,
+    },
+  ],
+});
+
+const upload = stack.getResource("UploadFunction");
+if (upload === undefined) throw new Error("No UploadFunction Resource");
+
+const output = await simAws.lambda().invoke(
+  new InvokeCommand({
+    FunctionName: upload.logicalId,
+    Payload: JSON.stringify({ key: "receipt.pdf" }),
+  }),
+);
+
+if (output.Payload === undefined) throw new Error("No invoke Payload");
+console.log(Buffer.from(output.Payload).toString());
+// "stored receipt.pdf"
+
+await simAws.backgroundTasksComplete();

--- a/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-asset-code.loc.test.ts
+++ b/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-asset-code.loc.test.ts
@@ -87,7 +87,9 @@ app.synth();
     await simAws.backgroundTasksComplete();
 
     // Then the function is deployed rather than skipped, with its asset code.
-    const functionResource = stack.getResource("AssetFunctionA633A7D1");
+    // The Stack answers for the construct ID, so the hash CDK synthesized on
+    // to the logical ID is not written down here to go stale.
+    const functionResource = stack.getResource("AssetFunction");
     assertNonNullable(functionResource);
     assertUndefined(functionResource.skippedReason);
 

--- a/src/service/cloudformation/stack/resource-map/sim-cfn-stack-resource-lookup.iso.test.ts
+++ b/src/service/cloudformation/stack/resource-map/sim-cfn-stack-resource-lookup.iso.test.ts
@@ -1,0 +1,96 @@
+import { assertIdentical, assertUndefined } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+
+describe("SimCfnStackResourceLookup", () => {
+  it("answers a hashed Resource by the construct ID it was synthesized from", async () => {
+    // Given a Stack deployed from a CDK-synthesized template, whose logical ID
+    // carries a hash a caller has no way to know.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "cdk-lookup-stack",
+      template: {
+        Resources: {
+          UploadsBucket9F8E7D6C: {
+            Type: "AWS::S3::Bucket",
+            Metadata: {
+              "aws:cdk:path": "TestStack/UploadsBucket/Resource",
+            },
+            Properties: {
+              BucketName: "cdk-lookup-uploads",
+            },
+          },
+        },
+      },
+    });
+
+    // When the Stack is asked for the Resource by construct ID.
+    const resource = stack.getResource("UploadsBucket");
+
+    // Then it answers the hashed Resource that construct synthesized.
+    assertIdentical(resource?.logicalId, "UploadsBucket9F8E7D6C");
+    assertIdentical(resource.properties["BucketName"], "cdk-lookup-uploads");
+  });
+
+  it("prefers a Resource whose logical ID matches exactly", async () => {
+    // Given a Stack holding both a Resource named as the identifier asked for
+    // and a hashed one whose construct ID is the same name.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "ambiguous-lookup-stack",
+      template: {
+        Resources: {
+          UploadsBucket: {
+            Type: "AWS::S3::Bucket",
+            Properties: {
+              BucketName: "named-by-logical-id",
+            },
+          },
+          UploadsBucket9F8E7D6C: {
+            Type: "AWS::S3::Bucket",
+            Metadata: {
+              "aws:cdk:path": "TestStack/UploadsBucket/Resource",
+            },
+            Properties: {
+              BucketName: "named-by-construct-id",
+            },
+          },
+        },
+      },
+    });
+
+    // When the Stack is asked for that identifier.
+    const resource = stack.getResource("UploadsBucket");
+
+    // Then the logical ID answers. Everything that resolved before construct
+    // IDs were understood still resolves the same way.
+    assertIdentical(resource?.logicalId, "UploadsBucket");
+    assertIdentical(resource.properties["BucketName"], "named-by-logical-id");
+  });
+
+  it("answers nothing for an identifier no Resource carries", async () => {
+    // Given a Stack whose one Resource was synthesized under another construct.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "missing-lookup-stack",
+      template: {
+        Resources: {
+          UploadsBucket9F8E7D6C: {
+            Type: "AWS::S3::Bucket",
+            Metadata: {
+              "aws:cdk:path": "TestStack/UploadsBucket/Resource",
+            },
+            Properties: {
+              BucketName: "missing-lookup-uploads",
+            },
+          },
+        },
+      },
+    });
+
+    // When the Stack is asked for a construct that is not in it.
+    // Then it answers with nothing rather than the wrong Resource.
+    assertUndefined(stack.getResource("ReportsBucket"));
+  });
+});

--- a/src/service/cloudformation/stack/resource-map/sim-cfn-stack-resource-lookup.ts
+++ b/src/service/cloudformation/stack/resource-map/sim-cfn-stack-resource-lookup.ts
@@ -1,0 +1,43 @@
+import { SimCfnResourceCdkPath } from "../../bind/validate/sim-cfn-resource-cdk-path.js";
+import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
+
+/**
+ * Finds one Resource in a Stack by the identifier a caller has for it.
+ *
+ * A Stack keys its Resources by synthesized logical ID. That is the name a
+ * hand-written template gives them. CDK appends a hash to it, and the readable
+ * half is the construct ID that bindings already accept. Both names are
+ * answered here. A caller that bound a handler by construct ID can then ask the
+ * Stack what that binding matched, and never reads the synthesized template.
+ *
+ * An exact logical ID is answered first. A construct ID is looked for only once
+ * no Resource carries the identifier as its logical ID, and a template whose
+ * logical IDs read as construct names resolves the way it always has.
+ */
+export class SimCfnStackResourceLookup {
+  private readonly resources: ReadonlyMap<string, SimCfnResource>;
+
+  constructor(resources: ReadonlyMap<string, SimCfnResource>) {
+    this.resources = resources;
+  }
+
+  /**
+   * The Resource this identifier names, by logical ID or CDK construct ID.
+   *
+   * Two Resources in one Stack cannot share a construct ID, since CDK
+   * synthesizes a distinct logical ID per construct. The first match is the
+   * only one.
+   */
+  find(logicalId: string): SimCfnResource | undefined {
+    return this.resources.get(logicalId) ?? this.byConstructId(logicalId);
+  }
+
+  private byConstructId(constructId: string): SimCfnResource | undefined {
+    return this.resources
+      .values()
+      .find(
+        (resource) =>
+          new SimCfnResourceCdkPath(resource).constructId() === constructId,
+      );
+  }
+}

--- a/src/service/cloudformation/stack/sim-cfn-stack.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack.ts
@@ -1,7 +1,4 @@
-import type { SimAws } from "../../aws/sim-aws.js";
-import type { Brand } from "../../../util/brand.type.js";
 import type { BackgroundScheduler } from "../../../util/background/background.js";
-import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type { SimCfnResource } from "../resource/sim-cfn-resource.js";
 import type { SimCfnIgnoredProperty } from "../resource/ignore/sim-cfn-ignored-property.type.js";
 import type {
@@ -13,53 +10,21 @@ import {
   type SimCfnStackDeleteProperties,
 } from "./teardown/sim-cfn-stack-deletion-lifecycle.js";
 import { makeSimCfnStackResourceMap } from "./resource-map/sim-cfn-stack-resource-map.js";
+import { SimCfnStackResourceLookup } from "./resource-map/sim-cfn-stack-resource-lookup.js";
 import { SimCfnStackDeploymentLifecycle } from "./deploy/sim-cfn-stack-deployment-lifecycle.js";
 import { SimCfnStackResourceOperations } from "./sim-cfn-stack-resource-operations.js";
 import { SimCfnStackUpdateLifecycle } from "./update/sim-cfn-stack-update-lifecycle.js";
-import type { SimCdkOutContext } from "../cdk/sim-cdk-out-context.js";
-import type { SimCfnDeployBinding } from "../bind/sim-cfn-deploy-binding.js";
 import type { SimCfnStackOutput } from "./output/sim-cfn-stack-output.js";
 import { SimCfnStackOutputResolver } from "./output/sim-cfn-stack-output-resolver.js";
 import { SimCfnStackResourceReport } from "./report/sim-cfn-stack-resource-report.js";
 import { SimCfnStackOperationStatus } from "./status/sim-cfn-stack-operation-status.js";
 import { validateSimCfnExecutableResourceBindings } from "../bind/validate/sim-cfn-exec-binding-validator.js";
-
-export type SimCloudFormationStackName = Brand<
-  string,
-  "SimCloudFormationStackName"
->;
-
-export type SimCloudFormationStackStatus =
-  | "REVIEW_IN_PROGRESS"
-  | "CREATE_IN_PROGRESS"
-  | "CREATE_COMPLETE"
-  | "CREATE_FAILED"
-  | "UPDATE_IN_PROGRESS"
-  | "UPDATE_COMPLETE"
-  | "UPDATE_FAILED"
-  | "DELETE_IN_PROGRESS"
-  | "DELETE_COMPLETE"
-  | "DELETE_FAILED";
-
-export interface SimCfnStackUpdateProperties {
-  /**
-   * The CDK cloud assembly the new template was synthesized into, when it came
-   * from a template file that has been synthesized again. The Stack reads
-   * assets from it from then on, since the manifest it was deployed with
-   * describes the assembly the previous template came from.
-   */
-  readonly cdkOutContext?: SimCdkOutContext | undefined;
-}
-
-interface SimCloudFormationStackProperties {
-  readonly simAws: SimAws;
-  readonly accountRegionScope: SimAwsAccountRegionScope;
-  readonly background: BackgroundScheduler;
-  readonly stackName: SimCloudFormationStackName;
-  readonly template: SimCfnTemplate;
-  readonly cdkOutContext?: SimCdkOutContext | undefined;
-  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
-}
+import type {
+  SimCloudFormationStackProperties,
+  SimCloudFormationStackStatus,
+  SimCfnStackUpdateProperties,
+  SimCloudFormationStackName,
+} from "./sim-cfn-stack.type.js";
 
 /**
  * Lightweight simulated CloudFormation Stack.
@@ -251,9 +216,16 @@ export class SimCfnStack {
     await this.operations.deleteAll(this.resources);
   }
 
-  /** Get a Stack Resource by logical ID. */
+  /**
+   * Get a Stack Resource by logical ID, or by the CDK construct ID a
+   * synthesized logical ID was generated from.
+   *
+   * The construct ID is the identifier a binding takes. A caller that bound a
+   * handler by construct ID can ask the Stack what it bound, without holding
+   * the hash CDK appended.
+   */
   getResource(logicalId: string): SimCfnResource | undefined {
-    return this.resources.get(logicalId);
+    return new SimCfnStackResourceLookup(this.resources).find(logicalId);
   }
 
   /** Resources skipped because their sim implementation is not available. */
@@ -297,3 +269,9 @@ export class SimCfnStack {
     }).resolve();
   }
 }
+
+export {
+  type SimCfnStackUpdateProperties,
+  type SimCloudFormationStackName,
+  type SimCloudFormationStackStatus,
+} from "./sim-cfn-stack.type.js";

--- a/src/service/cloudformation/stack/sim-cfn-stack.type.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack.type.ts
@@ -1,0 +1,44 @@
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { Brand } from "../../../util/brand.type.js";
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimCfnTemplate } from "../template/sim-cfn-template.js";
+import type { SimCdkOutContext } from "../cdk/sim-cdk-out-context.js";
+import type { SimCfnDeployBinding } from "../bind/sim-cfn-deploy-binding.js";
+
+export type SimCloudFormationStackName = Brand<
+  string,
+  "SimCloudFormationStackName"
+>;
+
+export type SimCloudFormationStackStatus =
+  | "REVIEW_IN_PROGRESS"
+  | "CREATE_IN_PROGRESS"
+  | "CREATE_COMPLETE"
+  | "CREATE_FAILED"
+  | "UPDATE_IN_PROGRESS"
+  | "UPDATE_COMPLETE"
+  | "UPDATE_FAILED"
+  | "DELETE_IN_PROGRESS"
+  | "DELETE_COMPLETE"
+  | "DELETE_FAILED";
+
+export interface SimCfnStackUpdateProperties {
+  /**
+   * The CDK cloud assembly the new template was synthesized into, when it came
+   * from a template file that has been synthesized again. The Stack reads
+   * assets from it from then on, since the manifest it was deployed with
+   * describes the assembly the previous template came from.
+   */
+  readonly cdkOutContext?: SimCdkOutContext | undefined;
+}
+
+export interface SimCloudFormationStackProperties {
+  readonly simAws: SimAws;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly background: BackgroundScheduler;
+  readonly stackName: SimCloudFormationStackName;
+  readonly template: SimCfnTemplate;
+  readonly cdkOutContext?: SimCdkOutContext | undefined;
+  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
+}

--- a/src/service/lambda/cfn/sim-cfn-lambda-bindings.iso.test.ts
+++ b/src/service/lambda/cfn/sim-cfn-lambda-bindings.iso.test.ts
@@ -2,6 +2,7 @@ import { InvokeCommand } from "@aws-sdk/client-lambda";
 import {
   assertArrayLength,
   assertIdentical,
+  assertInstanceOf,
   assertNonNullable,
   assertStringIncludes,
   assertThrowsErrorAsync,
@@ -9,6 +10,7 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../aws/sim-aws.js";
+import { SimLambdaFunction } from "../function/sim-lambda-function.js";
 
 function parsePayload(payload: Uint8Array | undefined): unknown {
   assertNonNullable(payload);
@@ -161,7 +163,7 @@ describe("Lambda CloudFormation Function bindings", () => {
     const simAws = new SimAws();
 
     // When the template is deployed with the binding.
-    await simAws.cloudFormation().deployTemplate({
+    const stack = await simAws.cloudFormation().deployTemplate({
       stackName: "cdk-bound-stack",
       template: {
         Resources: {
@@ -188,11 +190,15 @@ describe("Lambda CloudFormation Function bindings", () => {
       ],
     });
 
-    // Then the bound handler backs the function created under the hashed
-    // logical ID.
+    // Then the Stack answers for the construct the binding named, and the
+    // bound handler backs the function it created, without the hash CDK
+    // appended being written down anywhere.
+    const reader = stack.getResource("ReaderFunction")?.simResource;
+    assertInstanceOf(reader, SimLambdaFunction);
+
     const output = await simAws
       .lambda()
-      .invoke(new InvokeCommand({ FunctionName: "ReaderFunction2A1B3C4D" }));
+      .invoke(new InvokeCommand({ FunctionName: reader.name }));
 
     assertIdentical(parsePayload(output.Payload), "bound via construct id");
 


### PR DESCRIPTION
`SimCfnStack.getResource` reads the construct ID out of `aws:cdk:path` metadata where no Resource carries the identifier as a synthesized logical ID, reusing the same `SimCfnResourceCdkPath` the binding matchers read. A caller that bound a handler by construct ID can now ask the Stack what that binding matched, and a Lambda function bound that way is invoked under the name the Stack answers with. An exact logical ID is still answered first, and everything that resolved before resolves the same way. Two tests that had a CDK hash written into them ask for the construct ID now, one of them against a template a real `cdk synth` produced.

Resolves #691