### PR TITLE
feat: upload a simulated S3 Object in parts

### DIFF
--- a/docs/serve/README.md
+++ b/docs/serve/README.md
@@ -292,7 +292,7 @@ const client = new S3Client({
 });
 ```
 
-The operations served are the ones simulated S3 implements: `CreateBucket`, `DeleteBucket`, `HeadBucket`, `ListBuckets`, `ListObjects`, `ListObjectsV2`, `GetObject`, `HeadObject`, `PutObject`, `DeleteObject`, `DeleteObjects`, and the Bucket policy, website, Block Public Access and event notification configurations. `aws s3 cp` works in both directions. Anything else is refused as `NotImplemented`, which an SDK raises under that name rather than leaving a client to guess.
+The operations served are the ones simulated S3 implements: `CreateBucket`, `DeleteBucket`, `HeadBucket`, `ListBuckets`, `ListObjects`, `ListObjectsV2`, `GetObject`, `HeadObject`, `PutObject`, `DeleteObject`, `DeleteObjects`, the six multipart upload operations, and the Bucket policy, website, Block Public Access and event notification configurations. `aws s3 cp` works in both directions, and for a file above the CLI's 8MB multipart threshold. Anything else is refused as `NotImplemented`, which an SDK raises under that name rather than leaving a client to guess.
 
 Simulated S3 also answers its own Bucket hostnames, covered above. That path is unchanged, and it is what a presigned URL and a website visitor use.
 

--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -409,6 +409,134 @@ for (const object of listedObjects) {
 An event notification record carries the same value unquoted, in its `eTag` field, as real S3
 reports it there.
 
+An Object uploaded in parts gets a different form. See
+[Uploading an Object in parts](#uploading-an-object-in-parts).
+
+## Uploading an Object in parts
+
+`aws s3 cp` switches to a multipart upload above eight megabytes, and `@aws-sdk/lib-storage` uploads
+in parts whatever the size. Sim S3 answers the six operations that path is made of, over the SDK and
+over a served endpoint alike.
+
+```bash
+aws s3 cp ./big.bin s3://widgets/big.bin   # 12MB, multipart under the covers
+aws s3 ls s3://widgets/                    # reports the whole 12MB Object
+```
+
+An upload is started, the parts are sent under the id it issues, and completing it stores one
+Object. The parts can be sent in any order.
+
+```typescript sim-s3-multipart-upload
+/**
+ * Uploading a simulated S3 Object in parts.
+ */
+
+import {
+  CompleteMultipartUploadCommand,
+  CreateBucketCommand,
+  CreateMultipartUploadCommand,
+  GetObjectCommand,
+  UploadPartCommand,
+} from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simS3 = simAws.s3();
+
+await simS3.createBucket(new CreateBucketCommand({ Bucket: "uploads-bucket" }));
+
+const started = await simS3.createMultipartUpload(
+  new CreateMultipartUploadCommand({
+    Bucket: "uploads-bucket",
+    Key: "report.csv",
+    ContentType: "text/csv",
+  }),
+);
+
+const second = await simS3.uploadPart(
+  new UploadPartCommand({
+    Bucket: "uploads-bucket",
+    Key: "report.csv",
+    UploadId: started.UploadId,
+    PartNumber: 2,
+    Body: "2,two\n",
+  }),
+);
+
+const first = await simS3.uploadPart(
+  new UploadPartCommand({
+    Bucket: "uploads-bucket",
+    Key: "report.csv",
+    UploadId: started.UploadId,
+    PartNumber: 1,
+    Body: "id,name\n1,one\n",
+  }),
+);
+
+const completed = await simS3.completeMultipartUpload(
+  new CompleteMultipartUploadCommand({
+    Bucket: "uploads-bucket",
+    Key: "report.csv",
+    UploadId: started.UploadId,
+    MultipartUpload: {
+      Parts: [
+        { PartNumber: 1, ETag: first.ETag },
+        { PartNumber: 2, ETag: second.ETag },
+      ],
+    },
+  }),
+);
+
+// The parts joined in part-number order, whichever order they arrived in.
+console.log(completed.ETag);
+
+const objectOut = await simS3.getObject(
+  new GetObjectCommand({ Bucket: "uploads-bucket", Key: "report.csv" }),
+);
+
+console.log(objectOut.Body);
+```
+
+The completed Object is an ordinary one. Every operation that reads an Object reads it, and the
+system metadata the upload was started with (`ContentType` above) travels with it.
+
+### The multipart ETag
+
+Real S3 gives an Object uploaded in parts the ETag `<md5-of-the-part-md5s>-<partCount>`, and sim S3
+gives it the same. A tool comparing content hashes checks for that `-N` suffix before trusting an
+ETag. An Object assembled from parts therefore cannot report the MD5 of the joined bytes. The two
+are different values.
+
+`PutObject`, `GetObject`, `HeadObject` and both list operations all report the same one.
+
+### Abandoning an upload
+
+`AbortMultipartUploadCommand` discards the parts. Nothing was ever under the key, and the Bucket is
+left as the upload found it. An unfinished upload puts no Object anywhere, and its parts are
+invisible to a listing.
+
+`ListMultipartUploadsCommand` reports what a Bucket has in flight, and `ListPartsCommand` reports the
+parts stored against one upload. Both are how a cleanup finds an upload that stalled.
+
+### Event notifications
+
+A completed upload raises `s3:ObjectCreated:CompleteMultipartUpload`. A single-request upload raises
+`s3:ObjectCreated:Put`, and real S3 keeps the two apart. `s3:ObjectCreated:*` covers both. See
+[Event notifications](#event-notifications).
+
+### Limitations
+
+- `UploadPartCopy` is left out. It copies a byte range from another Object, and `CopyObject` is left
+  out too.
+- Parts are held in memory, whatever storage the Bucket uses. A Bucket backed by a mounted directory
+  writes whole files and has nowhere to put half of one.
+- Real S3 requires every part except the last to be at least five megabytes, and answers
+  `EntityTooSmall` for one that is not. Sim S3 takes a part of any size.
+- A listing of uploads or of parts comes back on one page. `MaxUploads`, `MaxParts`, the markers that
+  page them, and `Delimiter` are all left out.
+- An upload has no expiry, and nothing abandons one on its own. A lifecycle rule expiring incomplete
+  uploads is left out along with the rest of lifecycle configuration.
+
 ## Deleting Objects
 
 Use `DeleteObjectCommand` to remove one Object, and `DeleteObjectsCommand` to remove several in one
@@ -1179,11 +1307,12 @@ writes fall outside it. Without that, the simulation stops after a thousand deli
 - A destination goes where the group it was declared in says, and its ARN has no say. A queue ARN
   under `LambdaFunctionConfigurations` is refused for failing to be a function ARN, and never
   delivered to as a queue.
-- Only `s3:ObjectCreated:Put` and `s3:ObjectRemoved:Delete` are raised. `Copy`, `Post`,
-  `CompleteMultipartUpload`, `DeleteMarkerCreated`, the `ObjectRestore:*`, `Replication:*`,
-  `LifecycleExpiration:*` and `ObjectTagging:*` families, `LifecycleTransition`,
-  `IntelligentTiering`, `ObjectAcl:Put` and `ReducedRedundancyLostObject` are refused by name.
-  `s3:ObjectCreated:*` and `s3:ObjectRemoved:*` therefore expand to one member each.
+- Three event types are raised: `s3:ObjectCreated:Put`,
+  `s3:ObjectCreated:CompleteMultipartUpload` and `s3:ObjectRemoved:Delete`. `Copy`, `Post`,
+  `DeleteMarkerCreated`, the `ObjectRestore:*`, `Replication:*`, `LifecycleExpiration:*` and
+  `ObjectTagging:*` families, `LifecycleTransition`, `IntelligentTiering`, `ObjectAcl:Put` and
+  `ReducedRedundancyLostObject` are refused by name. `s3:ObjectCreated:*` expands to the two
+  creations and `s3:ObjectRemoved:*` to the one removal.
 - `userIdentity.principalId` carries the caller's ARN rather than the `AIDA...` unique id real S3
   puts there. Simulated IAM has no unique-id namespace to draw one from, and an ARN is what a test
   would assert on. `requestParameters.sourceIPAddress` is the loopback address, because the request
@@ -1757,9 +1886,11 @@ const s3Client = new S3Client({
 
 ### Limitations
 
-- `GET`, `HEAD`, `PUT` and `DELETE` of an Object are served over the REST endpoint. Bucket operations
-  and multipart uploads are refused with `501`. `DeleteObjects` is a `POST` to the Bucket, so it is
-  available through the SDK and unavailable over HTTP.
+- `GET`, `HEAD`, `PUT` and `DELETE` of an Object are served over a Bucket's own REST endpoint, which
+  is what a presigned URL addresses. Bucket operations and multipart uploads there are refused with
+  `501`. `DeleteObjects` is a `POST` to the Bucket, so it is available through the SDK and
+  unavailable over a presigned URL. The shared endpoint `serveSimAws` binds serves all of them. See
+  [Serve simulated S3 on localhost](#serve-simulated-s3-on-localhost).
 - `createPresignedPost` and SigV4A presigning are left out.
 - Checksums are verified for CRC32, SHA1 and SHA256. An upload stating a CRC32C or CRC64NVME checksum
   is refused, and never stored unchecked.
@@ -2282,6 +2413,9 @@ Sim S3 currently supports:
 - `CreateBucketCommand` and `ListBucketsCommand`
 - `PutObjectCommand`, `GetObjectCommand`, `ListObjectsV2Command` and `ListObjectsCommand`, with an
   ETag and a last-modified time on every Object
+- `CreateMultipartUploadCommand`, `UploadPartCommand`, `CompleteMultipartUploadCommand`,
+  `AbortMultipartUploadCommand`, `ListMultipartUploadsCommand` and `ListPartsCommand`, so `aws s3 cp`
+  and `@aws-sdk/lib-storage` can upload a file of real size
 - `DeleteObjectCommand` and `DeleteObjectsCommand`, authorized per Object by sim IAM
 - `PutBucketNotificationConfigurationCommand` and `GetBucketNotificationConfigurationCommand`, with
   Object events delivered to a simulated Lambda function, a simulated SQS queue or a simulated SNS
@@ -2293,7 +2427,8 @@ Sim S3 currently supports:
 - Block Public Access, on by default as in real S3, refusing a public Bucket policy unless the Bucket
   opts out with `PutPublicAccessBlockCommand` or `PublicAccessBlockConfiguration`
 - Serving static website requests on localhost with `serveSimAws`
-- Serving Object `GET`, `HEAD`, `PUT` and `DELETE` over the S3 REST endpoint, authorized by sim IAM
+- Serving Object `GET`, `HEAD`, `PUT` and `DELETE` over the S3 REST endpoint, authorized by sim IAM,
+  and the `?uploads` and `?uploadId` sub-resources a multipart upload is made of
 - Presigned URLs built by the real `@aws-sdk/s3-request-presigner`, with expiry in simulated time
 - Object system metadata set by a `PutObjectCommand` and returned on a read, over every endpoint
   that serves an Object
@@ -2316,8 +2451,6 @@ These apply across the page. The sections above each list what is specific to th
 
 - Object versioning is left out. There are no version ids, no delete markers and no `VersionId` on
   any request or response.
-- Multipart uploads are left out. An Object is stored by one `PutObject`, and an ETag is always the
-  MD5 of the whole body, never carrying the `-N` part-count suffix real S3 gives a multipart Object.
 - A listing reports `StorageClass` as `STANDARD` for every Object. Storage classes themselves are
   left out, and every Object is in that one.
 - `Delimiter` and `CommonPrefixes` are left out, and a listing cannot be walked as a folder tree.

--- a/docs/services/s3/sim-s3-multipart-upload.example.ts
+++ b/docs/services/s3/sim-s3-multipart-upload.example.ts
@@ -1,0 +1,68 @@
+/**
+ * Uploading a simulated S3 Object in parts.
+ */
+
+import {
+  CompleteMultipartUploadCommand,
+  CreateBucketCommand,
+  CreateMultipartUploadCommand,
+  GetObjectCommand,
+  UploadPartCommand,
+} from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simS3 = simAws.s3();
+
+await simS3.createBucket(new CreateBucketCommand({ Bucket: "uploads-bucket" }));
+
+const started = await simS3.createMultipartUpload(
+  new CreateMultipartUploadCommand({
+    Bucket: "uploads-bucket",
+    Key: "report.csv",
+    ContentType: "text/csv",
+  }),
+);
+
+const second = await simS3.uploadPart(
+  new UploadPartCommand({
+    Bucket: "uploads-bucket",
+    Key: "report.csv",
+    UploadId: started.UploadId,
+    PartNumber: 2,
+    Body: "2,two\n",
+  }),
+);
+
+const first = await simS3.uploadPart(
+  new UploadPartCommand({
+    Bucket: "uploads-bucket",
+    Key: "report.csv",
+    UploadId: started.UploadId,
+    PartNumber: 1,
+    Body: "id,name\n1,one\n",
+  }),
+);
+
+const completed = await simS3.completeMultipartUpload(
+  new CompleteMultipartUploadCommand({
+    Bucket: "uploads-bucket",
+    Key: "report.csv",
+    UploadId: started.UploadId,
+    MultipartUpload: {
+      Parts: [
+        { PartNumber: 1, ETag: first.ETag },
+        { PartNumber: 2, ETag: second.ETag },
+      ],
+    },
+  }),
+);
+
+// The parts joined in part-number order, whichever order they arrived in.
+console.log(completed.ETag);
+
+const objectOut = await simS3.getObject(
+  new GetObjectCommand({ Bucket: "uploads-bucket", Key: "report.csv" }),
+);
+
+console.log(objectOut.Body);

--- a/src/service/s3/README.md
+++ b/src/service/s3/README.md
@@ -230,19 +230,27 @@ Objects are represented as `SimS3Object` instances. In normal command flow,
 - `Uint8Array` body is converted with `Buffer.from`
 - other body types currently throw an error
 
-Metadata is stored separately from the object body. `PutObjectCommandHandler` combines:
+Metadata is stored separately from the object body. `object/s3-write-metadata.ts` combines:
 
 - `input.Metadata`
 - the system metadata request fields, mapped to their lowercase header names by
   `object/s3-system-metadata.ts`
 
+`PutObject` and `CreateMultipartUpload` both go through it, because both are the request that says
+what the Object is. `object/s3-write-body.ts` does the same for the body forms an upload can carry,
+which `PutObject` and `UploadPart` share.
+
 `GetObjectCommandHandler` returns object bodies as Node `Readable` streams and returns stored
 metadata through `Metadata`, alongside the Object's `ETag` and `LastModified`.
 
 `object/s3-object-etag.ts` computes an Object's ETag as the MD5 of its body and quotes it for a
-response. The digest is what `SimS3Object` holds, computed on demand and kept, because the two
-surfaces disagree about the quotes: an SDK response and an HTTP header carry them, and the `eTag` of
-an Object event notification record does not.
+response. The digest is what `SimS3Object` holds, computed on demand, because the two surfaces
+disagree about the quotes. An SDK response and an HTTP header carry them, and the `eTag` of an Object
+event notification record does not.
+
+An Object uploaded in parts is the exception. `simS3MultipartETag` builds
+`<md5-of-the-part-md5s>-<partCount>`, and the Object carries that value rather than computing one,
+because the part count is a fact about how the bytes arrived that the joined bytes do not record.
 
 `object/s3-system-metadata.ts` holds the list of headers S3 remembers about an Object, pairing the
 request field a write sets each one with against the lowercase key it is stored under. Both sides
@@ -479,6 +487,39 @@ A batch deletion is not all or nothing. `DeleteObjectsOutcome` turns a `SimIamAc
 `AccessDenied` entry and any other `SimS3Error` into an entry carrying its error name, while the rest
 of the batch is still deleted. Anything else is re-raised, so a bug in the simulation cannot arrive
 as a per-key AWS error.
+
+## Multipart uploads
+
+Sim S3 usage docs:
+[`../../../docs/services/s3/README.md#uploading-an-object-in-parts`](../../../docs/services/s3/README.md#uploading-an-object-in-parts)
+
+`upload/` holds the model. `SimS3MultipartUpload` is one upload in progress, holding its key, the
+system metadata it was started with, and its parts under their numbers. `SimS3MultipartUploads` is
+the collection a Bucket holds, reached through `bucket.getMultipartUploads()`. A Bucket keeps it
+beside its storage. The parts of an unfinished upload are not Objects. Nothing that lists or reads a
+Bucket can see them, and only completing the upload puts anything under a key. Parts stay in memory
+whatever storage the Bucket uses, since a mounted directory writes whole files.
+
+`upload/sim-s3-completed-upload.ts` turns a completion into the `SimS3Object` to store. It joins the
+parts the request names, in the order it names them, and refuses a completion it cannot honour in
+full. A part that was never uploaded is `SimS3InvalidPart`, an ETag other than the one it stored is
+the same, and a list that does not ascend is `SimS3InvalidPartOrder`. Assembling from whatever
+happened to arrive would store an Object silently missing its middle.
+
+`command/multipart/` holds what the six operations share. `SimS3MultipartAccess` is the preamble all
+of them run. It finds the Bucket or answers `SimS3NoSuchBucket`, sequences the request, authorizes
+it, and finds the upload or answers `SimS3NoSuchUpload`. `SimS3MultipartAuthorizer` authorizes every one of
+them as `PutObject` is authorized, against the Object ARN under `s3:PutObject`. A role written to let
+a caller put an Object therefore lets it put a large one. `ListMultipartUploads` names no Object and
+authorizes against the Bucket.
+
+The six handlers live in a directory each, as the other commands do:
+`create-multipart-upload/`, `upload-part/`, `complete-multipart-upload/`,
+`abort-multipart-upload/`, `list-multipart-uploads/` and `list-parts/`.
+
+Over the served endpoint, S3 states these six in the `?uploads` and `?uploadId` sub-resources.
+`serve/api/sim-s3-api-multipart-input.ts` reads their inputs and
+`serve/api/sim-s3-api-multipart-output.ts` builds their responses.
 
 ## Event notifications
 

--- a/src/service/s3/bucket/notification/sim-s3-notification-event.ts
+++ b/src/service/s3/bucket/notification/sim-s3-notification-event.ts
@@ -13,6 +13,7 @@ import { SIM_S3_UNSIMULATED_NOTIFICATION_EVENTS } from "./sim-s3-unsimulated-not
  */
 export const SIM_S3_NOTIFICATION_EVENTS = [
   "s3:ObjectCreated:Put",
+  "s3:ObjectCreated:CompleteMultipartUpload",
   "s3:ObjectRemoved:Delete",
 ] as const;
 
@@ -32,8 +33,15 @@ export type SimS3NotificationEvent =
  * why the wildcard never covered it.
  */
 const eventExpansions = new Map<string, readonly SimS3NotificationEvent[]>([
-  ["s3:ObjectCreated:*", ["s3:ObjectCreated:Put"]],
+  [
+    "s3:ObjectCreated:*",
+    ["s3:ObjectCreated:Put", "s3:ObjectCreated:CompleteMultipartUpload"],
+  ],
   ["s3:ObjectCreated:Put", ["s3:ObjectCreated:Put"]],
+  [
+    "s3:ObjectCreated:CompleteMultipartUpload",
+    ["s3:ObjectCreated:CompleteMultipartUpload"],
+  ],
   ["s3:ObjectRemoved:*", ["s3:ObjectRemoved:Delete"]],
   ["s3:ObjectRemoved:Delete", ["s3:ObjectRemoved:Delete"]],
 ]);

--- a/src/service/s3/bucket/notification/sim-s3-unsimulated-notification-events.ts
+++ b/src/service/s3/bucket/notification/sim-s3-unsimulated-notification-events.ts
@@ -17,7 +17,6 @@ export const SIM_S3_UNSIMULATED_NOTIFICATION_EVENTS: ReadonlySet<string> =
     "s3:LifecycleExpiration:DeleteMarkerCreated",
     "s3:LifecycleTransition",
     "s3:ObjectAcl:Put",
-    "s3:ObjectCreated:CompleteMultipartUpload",
     "s3:ObjectCreated:Copy",
     "s3:ObjectCreated:Post",
     "s3:ObjectRemoved:DeleteMarkerCreated",

--- a/src/service/s3/bucket/sim-s3-bucket.ts
+++ b/src/service/s3/bucket/sim-s3-bucket.ts
@@ -12,6 +12,7 @@ import { simS3BucketWebsiteUrl } from "./website/sim-s3-bucket-website-url.js";
 import { validateS3BucketName } from "./validate/validate-s3-bucket-name.js";
 import { simAwsAccountRegionScopeFactory } from "../../aws/sim-aws-account-region-scope.factory.js";
 import { SimS3BucketSystemMetadata } from "./sim-s3-bucket-system-metadata.js";
+import { SimS3MultipartUploads } from "../upload/sim-s3-multipart-uploads.js";
 
 export type SimS3BucketName = Brand<string, "SimS3BucketName">;
 
@@ -41,6 +42,7 @@ export class SimS3Bucket {
 
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly systemMetadata = new SimS3BucketSystemMetadata();
+  private readonly multipartUploads = new SimS3MultipartUploads();
   private storage: SimS3BucketStorage;
   private website: SimS3BucketWebsite;
   private policy: SimIamPolicyDocument | undefined;
@@ -103,6 +105,17 @@ export class SimS3Bucket {
    */
   async deleteObject(key: string): Promise<boolean> {
     return await this.storage.deleteObject(key);
+  }
+
+  /**
+   * The multipart uploads this Bucket has in progress.
+   *
+   * Kept apart from storage because the parts of an unfinished upload are not
+   * Objects: nothing that lists or reads a Bucket can see them, and only
+   * completing the upload puts anything under a key.
+   */
+  getMultipartUploads(): SimS3MultipartUploads {
+    return this.multipartUploads;
   }
 
   /**

--- a/src/service/s3/cfn/bucket/notification/sim-cfn-s3-bucket-notification-refusals.iso.test.ts
+++ b/src/service/s3/cfn/bucket/notification/sim-cfn-s3-bucket-notification-refusals.iso.test.ts
@@ -62,17 +62,14 @@ describe("AWS::S3::Bucket NotificationConfiguration refusals", () => {
     const error = await deployFailing(simAws, {
       LambdaConfigurations: [
         {
-          Event: "s3:ObjectCreated:CompleteMultipartUpload",
+          Event: "s3:ObjectRestore:Completed",
           Function: { "Fn::GetAtt": ["Handler", "Arn"] },
         },
       ],
     });
 
     // Then the Stack fails with the command's own refusal.
-    assertStringIncludes(
-      error.message,
-      "s3:ObjectCreated:CompleteMultipartUpload",
-    );
+    assertStringIncludes(error.message, "s3:ObjectRestore:Completed");
 
     // And the Bucket the Resource would have created is not left behind.
     const stack = simAws.cloudFormation().getStackByName("uploads-stack");

--- a/src/service/s3/command/abort-multipart-upload/abort-multipart-upload.command.ts
+++ b/src/service/s3/command/abort-multipart-upload/abort-multipart-upload.command.ts
@@ -1,0 +1,25 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim S3 AbortMultipartUpload command.
+ */
+export interface SimAbortMultipartUploadCommand {
+  readonly input: SimAbortMultipartUploadCommandInput;
+}
+
+/**
+ * Minimal structural sim S3 AbortMultipartUpload input.
+ */
+export interface SimAbortMultipartUploadCommandInput {
+  readonly Bucket?: string | undefined;
+  readonly Key?: string | undefined;
+  readonly UploadId?: string | undefined;
+}
+
+/**
+ * Minimal structural sim S3 AbortMultipartUpload output, which says nothing
+ * beyond having worked.
+ */
+export interface SimAbortMultipartUploadCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/s3/command/abort-multipart-upload/abort-multipart-upload.handler.ts
+++ b/src/service/s3/command/abort-multipart-upload/abort-multipart-upload.handler.ts
@@ -1,0 +1,52 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import {
+  SimS3MultipartAccess,
+  type SimS3MultipartAccessProperties,
+} from "../multipart/sim-s3-multipart-access.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
+import type {
+  SimAbortMultipartUploadCommand,
+  SimAbortMultipartUploadCommandOutput,
+} from "./abort-multipart-upload.command.js";
+
+/**
+ * Simulated S3 AbortMultipartUploadCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/s3/command/AbortMultipartUploadCommand/
+ */
+export class AbortMultipartUploadCommandHandler implements CommandHandler<
+  SimAbortMultipartUploadCommand,
+  SimAbortMultipartUploadCommandOutput
+> {
+  private readonly access: SimS3MultipartAccess;
+
+  constructor(properties: SimS3MultipartAccessProperties) {
+    this.access = new SimS3MultipartAccess(properties);
+  }
+
+  /**
+   * Give up on an upload, discarding every part stored against it.
+   *
+   * Nothing was under the key, so nothing is removed and no Object event is
+   * raised: an abandoned upload leaves the Bucket as it found it. An upload id
+   * S3 no longer holds is refused rather than treated as already gone, which is
+   * what real S3 does.
+   */
+  async handle(
+    command: SimAbortMultipartUploadCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimAbortMultipartUploadCommandOutput> {
+    const { Bucket, Key, UploadId } = command.input;
+    assertDefined(Bucket, "AbortMultipartUploadCommand.input.Bucket");
+    assertDefined(Key, "AbortMultipartUploadCommand.input.Key");
+    assertDefined(UploadId, "AbortMultipartUploadCommand.input.UploadId");
+
+    const { bucket } = await this.access.reach(Bucket, Key, options);
+    this.access.requireUpload(bucket, UploadId);
+
+    bucket.getMultipartUploads().discard(UploadId);
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/s3/command/complete-multipart-upload/complete-multipart-upload.command.ts
+++ b/src/service/s3/command/complete-multipart-upload/complete-multipart-upload.command.ts
@@ -1,0 +1,45 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim S3 CompleteMultipartUpload command.
+ */
+export interface SimCompleteMultipartUploadCommand {
+  readonly input: SimCompleteMultipartUploadCommandInput;
+}
+
+/**
+ * One part as a completion names it.
+ */
+export interface SimCompletedUploadPart {
+  readonly PartNumber?: number | undefined;
+  readonly ETag?: string | undefined;
+}
+
+/**
+ * Minimal structural sim S3 CompleteMultipartUpload input.
+ *
+ * The parts are named by the request rather than assumed by S3, so a client can
+ * finish an upload it sent a part of twice.
+ */
+export interface SimCompleteMultipartUploadCommandInput {
+  readonly Bucket?: string | undefined;
+  readonly Key?: string | undefined;
+  readonly UploadId?: string | undefined;
+  readonly MultipartUpload?:
+    | { readonly Parts?: readonly SimCompletedUploadPart[] | undefined }
+    | undefined;
+}
+
+/**
+ * Minimal structural sim S3 CompleteMultipartUpload output.
+ *
+ * `ETag` is the multipart form, `<md5-of-the-part-md5s>-<partCount>`, quoted as
+ * every ETag on the wire is.
+ */
+export interface SimCompleteMultipartUploadCommandOutput {
+  readonly Location?: string;
+  readonly Bucket?: string;
+  readonly Key?: string;
+  readonly ETag?: string;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/s3/command/complete-multipart-upload/complete-multipart-upload.handler.ts
+++ b/src/service/s3/command/complete-multipart-upload/complete-multipart-upload.handler.ts
@@ -1,0 +1,116 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import { simS3BucketUrl } from "../../bucket/sim-s3-endpoint-url.js";
+import { simS3QuotedETag } from "../../object/s3-object-etag.js";
+import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
+import type { SimS3ObjectNotifier } from "../../notification/sim-s3-object-notifier.js";
+import {
+  simS3CompletedUploadObject,
+  type SimS3NamedUploadPart,
+} from "../../upload/sim-s3-completed-upload.js";
+import {
+  SimS3MultipartAccess,
+  type SimS3MultipartAccessProperties,
+} from "../multipart/sim-s3-multipart-access.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
+import type {
+  SimCompleteMultipartUploadCommand,
+  SimCompleteMultipartUploadCommandOutput,
+  SimCompletedUploadPart,
+} from "./complete-multipart-upload.command.js";
+
+interface CompleteMultipartUploadHandlerProperties extends SimS3MultipartAccessProperties {
+  readonly notifications: SimS3ObjectNotifier;
+}
+
+/**
+ * Simulated S3 CompleteMultipartUploadCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/s3/command/CompleteMultipartUploadCommand/
+ */
+export class CompleteMultipartUploadCommandHandler implements CommandHandler<
+  SimCompleteMultipartUploadCommand,
+  SimCompleteMultipartUploadCommandOutput
+> {
+  private readonly access: SimS3MultipartAccess;
+  private readonly notifications: SimS3ObjectNotifier;
+
+  constructor(properties: CompleteMultipartUploadHandlerProperties) {
+    this.access = new SimS3MultipartAccess(properties);
+    this.notifications = properties.notifications;
+  }
+
+  /**
+   * Join the parts into one Object and put it under the upload's key.
+   *
+   * The upload is discarded whether or not it produced an Object, but only
+   * after the joining has succeeded: a completion S3 refused leaves the parts
+   * where they are, so the client can name them correctly and try again.
+   */
+  async handle(
+    command: SimCompleteMultipartUploadCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimCompleteMultipartUploadCommandOutput> {
+    const { Bucket, Key, UploadId } = command.input;
+    assertDefined(Bucket, "CompleteMultipartUploadCommand.input.Bucket");
+    assertDefined(Key, "CompleteMultipartUploadCommand.input.Key");
+    assertDefined(UploadId, "CompleteMultipartUploadCommand.input.UploadId");
+
+    const { bucket, caller } = await this.access.reach(Bucket, Key, options);
+    const upload = this.access.requireUpload(bucket, UploadId);
+
+    const object = simS3CompletedUploadObject({
+      upload,
+      parts: namedParts(command.input.MultipartUpload?.Parts ?? []),
+      completedAt: this.access.now(),
+    });
+
+    await bucket.putObject(object);
+    bucket.getMultipartUploads().discard(UploadId);
+
+    this.notifications.objectCreated({
+      bucket,
+      object,
+      caller,
+      eventName: "s3:ObjectCreated:CompleteMultipartUpload",
+    });
+
+    return {
+      Location: new URL(object.key, uploadedTo(bucket)).href,
+      Bucket: bucket.bucketName,
+      Key: object.key,
+      ETag: simS3QuotedETag(object.etag),
+      $metadata: {},
+    };
+  }
+}
+
+/**
+ * Where a completed Object can be read from, which real S3 answers with.
+ *
+ * The virtual-hosted URL of the simulated Bucket, so a caller that follows the
+ * Location reaches the Object it has just uploaded rather than an AWS hostname
+ * nothing in the simulation answers on.
+ */
+function uploadedTo(bucket: SimS3Bucket): URL {
+  return simS3BucketUrl(
+    bucket.bucketName,
+    bucket.getAccountRegionScope().regionName,
+  );
+}
+
+/**
+ * The parts a completion names, with the numbers it has to have stated.
+ */
+function namedParts(
+  parts: readonly SimCompletedUploadPart[],
+): readonly SimS3NamedUploadPart[] {
+  return parts.map((part, index) => {
+    assertDefined(
+      part.PartNumber,
+      `CompleteMultipartUploadCommand.input.MultipartUpload.Parts[${index}].PartNumber`,
+    );
+
+    return { partNumber: part.PartNumber, etag: part.ETag };
+  });
+}

--- a/src/service/s3/command/create-multipart-upload/create-multipart-upload.command.ts
+++ b/src/service/s3/command/create-multipart-upload/create-multipart-upload.command.ts
@@ -1,0 +1,32 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimS3ObjectWriteMetadata } from "../../object/s3-write-metadata.js";
+
+/**
+ * Minimal structural sim S3 CreateMultipartUpload command.
+ */
+export interface SimCreateMultipartUploadCommand {
+  readonly input: SimCreateMultipartUploadCommandInput;
+}
+
+/**
+ * Minimal structural sim S3 CreateMultipartUpload input.
+ *
+ * This is the request that says what the Object will be, so it carries the same
+ * metadata members a `PutObject` does. None of the Object's bytes arrive here.
+ */
+export interface SimCreateMultipartUploadCommandInput extends SimS3ObjectWriteMetadata {
+  readonly Bucket?: string | undefined;
+  readonly Key?: string | undefined;
+}
+
+/**
+ * Minimal structural sim S3 CreateMultipartUpload output.
+ *
+ * `UploadId` is what every later request in the upload names it by.
+ */
+export interface SimCreateMultipartUploadCommandOutput {
+  readonly Bucket?: string;
+  readonly Key?: string;
+  readonly UploadId?: string;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/s3/command/create-multipart-upload/create-multipart-upload.handler.ts
+++ b/src/service/s3/command/create-multipart-upload/create-multipart-upload.handler.ts
@@ -1,0 +1,58 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import { simS3WriteMetadata } from "../../object/s3-write-metadata.js";
+import {
+  SimS3MultipartAccess,
+  type SimS3MultipartAccessProperties,
+} from "../multipart/sim-s3-multipart-access.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
+import type {
+  SimCreateMultipartUploadCommand,
+  SimCreateMultipartUploadCommandOutput,
+} from "./create-multipart-upload.command.js";
+
+/**
+ * Simulated S3 CreateMultipartUploadCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/s3/command/CreateMultipartUploadCommand/
+ */
+export class CreateMultipartUploadCommandHandler implements CommandHandler<
+  SimCreateMultipartUploadCommand,
+  SimCreateMultipartUploadCommandOutput
+> {
+  private readonly access: SimS3MultipartAccess;
+
+  constructor(properties: SimS3MultipartAccessProperties) {
+    this.access = new SimS3MultipartAccess(properties);
+  }
+
+  /**
+   * Start an upload and issue the id its parts will be sent under.
+   *
+   * Nothing appears under the key until the upload is completed, so a Bucket
+   * looks the same after this as it did before.
+   */
+  async handle(
+    command: SimCreateMultipartUploadCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimCreateMultipartUploadCommandOutput> {
+    const { Bucket, Key } = command.input;
+    assertDefined(Bucket, "CreateMultipartUploadCommand.input.Bucket");
+    assertDefined(Key, "CreateMultipartUploadCommand.input.Key");
+
+    const { bucket } = await this.access.reach(Bucket, Key, options);
+
+    const upload = bucket.getMultipartUploads().start({
+      key: Key,
+      metadata: simS3WriteMetadata(command.input),
+      initiated: this.access.now(),
+    });
+
+    return {
+      Bucket: bucket.bucketName,
+      Key: upload.key,
+      UploadId: upload.uploadId,
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/s3/command/list-multipart-uploads/list-multipart-uploads.command.ts
+++ b/src/service/s3/command/list-multipart-uploads/list-multipart-uploads.command.ts
@@ -1,0 +1,37 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim S3 ListMultipartUploads command.
+ */
+export interface SimListMultipartUploadsCommand {
+  readonly input: SimListMultipartUploadsCommandInput;
+}
+
+/**
+ * Minimal structural sim S3 ListMultipartUploads input.
+ */
+export interface SimListMultipartUploadsCommandInput {
+  readonly Bucket?: string | undefined;
+  readonly Prefix?: string | undefined;
+}
+
+/**
+ * One upload in progress, as a listing describes it.
+ */
+export interface SimMultipartUploadSummary {
+  readonly Key?: string;
+  readonly UploadId?: string;
+  readonly Initiated?: Date;
+  readonly StorageClass?: string;
+}
+
+/**
+ * Minimal structural sim S3 ListMultipartUploads output.
+ */
+export interface SimListMultipartUploadsCommandOutput {
+  readonly Bucket?: string;
+  readonly Prefix?: string | undefined;
+  readonly Uploads?: SimMultipartUploadSummary[] | undefined;
+  readonly IsTruncated?: boolean;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/s3/command/list-multipart-uploads/list-multipart-uploads.handler.ts
+++ b/src/service/s3/command/list-multipart-uploads/list-multipart-uploads.handler.ts
@@ -1,0 +1,63 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import { simS3DefaultStorageClass } from "../../object/s3-object-summary.js";
+import {
+  SimS3MultipartAccess,
+  type SimS3MultipartAccessProperties,
+} from "../multipart/sim-s3-multipart-access.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
+import type {
+  SimListMultipartUploadsCommand,
+  SimListMultipartUploadsCommandOutput,
+} from "./list-multipart-uploads.command.js";
+
+/**
+ * Simulated S3 ListMultipartUploadsCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/s3/command/ListMultipartUploadsCommand/
+ */
+export class ListMultipartUploadsCommandHandler implements CommandHandler<
+  SimListMultipartUploadsCommand,
+  SimListMultipartUploadsCommandOutput
+> {
+  private readonly access: SimS3MultipartAccess;
+
+  constructor(properties: SimS3MultipartAccessProperties) {
+    this.access = new SimS3MultipartAccess(properties);
+  }
+
+  /**
+   * Report the uploads a Bucket has in progress.
+   *
+   * This is what tells an upload that stalled from one that never started, and
+   * what a cleanup walks to abort whatever is left holding parts. Every upload
+   * comes back on one page, because the simulator holds parts in memory and
+   * nothing is going to accumulate the thousand uploads real S3 pages at.
+   */
+  async handle(
+    command: SimListMultipartUploadsCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimListMultipartUploadsCommandOutput> {
+    const { Bucket, Prefix } = command.input;
+    assertDefined(Bucket, "ListMultipartUploadsCommand.input.Bucket");
+
+    const { bucket } = await this.access.reach(Bucket, undefined, options);
+    const uploads = bucket.getMultipartUploads().inProgress(Prefix);
+
+    return {
+      Bucket: bucket.bucketName,
+      Prefix,
+      Uploads:
+        uploads.length === 0
+          ? undefined
+          : uploads.map((upload) => ({
+              Key: upload.key,
+              UploadId: upload.uploadId,
+              Initiated: upload.initiated,
+              StorageClass: simS3DefaultStorageClass,
+            })),
+      IsTruncated: false,
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/s3/command/list-parts/list-parts.command.ts
+++ b/src/service/s3/command/list-parts/list-parts.command.ts
@@ -1,0 +1,40 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim S3 ListParts command.
+ */
+export interface SimListPartsCommand {
+  readonly input: SimListPartsCommandInput;
+}
+
+/**
+ * Minimal structural sim S3 ListParts input.
+ */
+export interface SimListPartsCommandInput {
+  readonly Bucket?: string | undefined;
+  readonly Key?: string | undefined;
+  readonly UploadId?: string | undefined;
+}
+
+/**
+ * One stored part, as a listing describes it.
+ */
+export interface SimUploadPartSummary {
+  readonly PartNumber?: number;
+  readonly ETag?: string;
+  readonly Size?: number;
+  readonly LastModified?: Date;
+}
+
+/**
+ * Minimal structural sim S3 ListParts output.
+ */
+export interface SimListPartsCommandOutput {
+  readonly Bucket?: string;
+  readonly Key?: string;
+  readonly UploadId?: string;
+  readonly Parts?: SimUploadPartSummary[] | undefined;
+  readonly StorageClass?: string;
+  readonly IsTruncated?: boolean;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/s3/command/list-parts/list-parts.handler.ts
+++ b/src/service/s3/command/list-parts/list-parts.handler.ts
@@ -1,0 +1,67 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import { simS3QuotedETag } from "../../object/s3-object-etag.js";
+import { simS3DefaultStorageClass } from "../../object/s3-object-summary.js";
+import {
+  SimS3MultipartAccess,
+  type SimS3MultipartAccessProperties,
+} from "../multipart/sim-s3-multipart-access.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
+import type {
+  SimListPartsCommand,
+  SimListPartsCommandOutput,
+} from "./list-parts.command.js";
+
+/**
+ * Simulated S3 ListPartsCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/s3/command/ListPartsCommand/
+ */
+export class ListPartsCommandHandler implements CommandHandler<
+  SimListPartsCommand,
+  SimListPartsCommandOutput
+> {
+  private readonly access: SimS3MultipartAccess;
+
+  constructor(properties: SimS3MultipartAccessProperties) {
+    this.access = new SimS3MultipartAccess(properties);
+  }
+
+  /**
+   * Report the parts stored against an upload so far.
+   *
+   * In part-number order rather than arrival order, which is how a client
+   * resuming an upload works out which parts it still owes. Every part comes
+   * back on one page, as with the upload listing.
+   */
+  async handle(
+    command: SimListPartsCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimListPartsCommandOutput> {
+    const { Bucket, Key, UploadId } = command.input;
+    assertDefined(Bucket, "ListPartsCommand.input.Bucket");
+    assertDefined(Key, "ListPartsCommand.input.Key");
+    assertDefined(UploadId, "ListPartsCommand.input.UploadId");
+
+    const { bucket } = await this.access.reach(Bucket, Key, options);
+    const parts = this.access.requireUpload(bucket, UploadId).storedParts();
+
+    return {
+      Bucket: bucket.bucketName,
+      Key,
+      UploadId,
+      Parts:
+        parts.length === 0
+          ? undefined
+          : parts.map((part) => ({
+              PartNumber: part.partNumber,
+              ETag: simS3QuotedETag(part.etag),
+              Size: part.body.length,
+              LastModified: part.lastModified,
+            })),
+      StorageClass: simS3DefaultStorageClass,
+      IsTruncated: false,
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/s3/command/multipart/sim-s3-multipart-access.ts
+++ b/src/service/s3/command/multipart/sim-s3-multipart-access.ts
@@ -1,0 +1,109 @@
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type {
+  SimS3Bucket,
+  SimS3BucketName,
+} from "../../bucket/sim-s3-bucket.js";
+import { SimS3NoSuchUpload } from "../../error/sim-s3.error.js";
+import type { SimS3MultipartUpload } from "../../upload/sim-s3-multipart-upload.js";
+import { requireSimS3Bucket } from "../require-sim-s3-bucket.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
+import { SimS3MultipartAuthorizer } from "./sim-s3-multipart-authorizer.js";
+
+export interface SimS3MultipartAccessProperties {
+  readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * A Bucket a multipart request has been authorized against.
+ */
+export interface SimS3AuthorizedBucket {
+  readonly bucket: SimS3Bucket;
+  readonly caller: SimAwsResolvedCaller;
+}
+
+/**
+ * Getting at a Bucket's multipart uploads, with permission.
+ *
+ * The six operations of a multipart upload share the whole of their preamble:
+ * find the Bucket or answer NoSuchBucket, let the background scheduler order
+ * the request, authorize it, and for the five that name an upload, find that or
+ * answer NoSuchUpload. Holding it here is what keeps the six handlers to the
+ * one thing each of them actually does.
+ */
+export class SimS3MultipartAccess {
+  private readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  private readonly authorizer: SimS3MultipartAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: SimS3MultipartAccessProperties) {
+    const {
+      buckets,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.buckets = buckets;
+    this.authorizer = new SimS3MultipartAuthorizer({ iam });
+    this.background = background;
+  }
+
+  /**
+   * The current time in this simulation, which dates an upload and its parts.
+   */
+  now(): Date {
+    return this.background.now();
+  }
+
+  /**
+   * Find and authorize the Bucket a multipart request names.
+   *
+   * The Bucket is looked up before authorization so a request against a Bucket
+   * that is not there keeps S3's error, and authorization happens before
+   * anything is stored so a denied request cannot leave a part behind. An
+   * omitted key is ListMultipartUploads, which names no Object.
+   */
+  async reach(
+    bucketName: string,
+    key: string | undefined,
+    options?: SimS3RequestOptions,
+  ): Promise<SimS3AuthorizedBucket> {
+    const bucket = requireSimS3Bucket(
+      this.buckets,
+      bucketName as SimS3BucketName,
+    );
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    return { bucket, caller: this.authorizer.authorize(bucket, key, options) };
+  }
+
+  /**
+   * The upload a request names, or S3's refusal to act on one it never issued.
+   *
+   * A completed or aborted upload is as unknown as an invented id, because real
+   * S3 keeps nothing about an upload that has stopped being one.
+   */
+  requireUpload(bucket: SimS3Bucket, uploadId: string): SimS3MultipartUpload {
+    const upload = bucket.getMultipartUploads().find(uploadId);
+
+    if (upload === undefined) {
+      throw new SimS3NoSuchUpload(
+        `Bucket ${bucket.bucketName} has no multipart upload ${uploadId} in ` +
+          `progress. An upload that has been completed or aborted is gone.`,
+      );
+    }
+
+    return upload;
+  }
+}

--- a/src/service/s3/command/multipart/sim-s3-multipart-authorizer.ts
+++ b/src/service/s3/command/multipart/sim-s3-multipart-authorizer.ts
@@ -1,0 +1,69 @@
+import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simS3BucketArn } from "../../bucket/sim-s3-bucket-arn.js";
+import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
+import { simS3BucketResourcePolicies } from "../authorize/sim-s3-bucket-resource-policies.js";
+import { simS3ConditionContext } from "../authorize/sim-s3-condition-context.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
+
+interface SimS3MultipartAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * Applies IAM authorization to the operations of a multipart upload.
+ *
+ * All six authorize the way PutObject does, against the ARN of the Object being
+ * uploaded, because that is the write they add up to: a role written to allow a
+ * caller to put an Object should let it put a large one without a second grant.
+ * Real S3 splits them across finer-grained actions, which is a distinction a
+ * caller that can already write the Object has no way to fail.
+ *
+ * ListMultipartUploads is the one that names no Object, and authorizes against
+ * the Bucket, since asking what a Bucket has in flight is a question about the
+ * Bucket.
+ */
+export class SimS3MultipartAuthorizer {
+  private static readonly action = "s3:PutObject";
+
+  private readonly iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: SimS3MultipartAuthorizerProperties) {
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Ensure the caller may carry out this part of an upload.
+   *
+   * The resolved caller is returned rather than discarded, because it is the
+   * only place in the request where the principal has been worked out, and the
+   * Object event notification a completed upload raises has to say who caused
+   * it.
+   */
+  authorize(
+    bucket: SimS3Bucket,
+    key: string | undefined,
+    options?: SimS3RequestOptions,
+  ): SimAwsResolvedCaller {
+    const bucketArn = simS3BucketArn(bucket.bucketName);
+    const resource = key === undefined ? bucketArn : `${bucketArn}/${key}`;
+    const decision = this.iam.authorize({
+      action: SimS3MultipartAuthorizer.action,
+      resource,
+      caller: options?.caller,
+      conditionContext: simS3ConditionContext(options),
+      resourcePolicies: simS3BucketResourcePolicies(bucket),
+    });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action: SimS3MultipartAuthorizer.action,
+        resource,
+      });
+    }
+
+    return decision.caller;
+  }
+}

--- a/src/service/s3/command/multipart/sim-s3-multipart-commands.ts
+++ b/src/service/s3/command/multipart/sim-s3-multipart-commands.ts
@@ -1,0 +1,98 @@
+import { AbortMultipartUploadCommandHandler } from "../abort-multipart-upload/abort-multipart-upload.handler.js";
+import { CompleteMultipartUploadCommandHandler } from "../complete-multipart-upload/complete-multipart-upload.handler.js";
+import { CreateMultipartUploadCommandHandler } from "../create-multipart-upload/create-multipart-upload.handler.js";
+import { ListMultipartUploadsCommandHandler } from "../list-multipart-uploads/list-multipart-uploads.handler.js";
+import { ListPartsCommandHandler } from "../list-parts/list-parts.handler.js";
+import type { SimS3BucketCommandState } from "../sim-s3-bucket-command-state.js";
+import type * as simS3Commands from "../sim-s3-command.types.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
+import { UploadPartCommandHandler } from "../upload-part/upload-part.handler.js";
+
+/**
+ * The multipart upload commands of one simulated S3 scope.
+ */
+export class SimS3MultipartCommands {
+  private readonly state: SimS3BucketCommandState;
+
+  constructor(state: SimS3BucketCommandState) {
+    this.state = state;
+  }
+
+  /**
+   * Start an upload and issue the id its parts are sent under.
+   */
+  async create(
+    command: simS3Commands.SimCreateMultipartUploadCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimCreateMultipartUploadCommandOutput> {
+    return await new CreateMultipartUploadCommandHandler(this.state).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Store one numbered part of an upload.
+   */
+  async uploadPart(
+    command: simS3Commands.SimUploadPartCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimUploadPartCommandOutput> {
+    return await new UploadPartCommandHandler(this.state).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Join the parts of an upload into one stored Object.
+   */
+  async complete(
+    command: simS3Commands.SimCompleteMultipartUploadCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimCompleteMultipartUploadCommandOutput> {
+    return await new CompleteMultipartUploadCommandHandler(this.state).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Give up on an upload, discarding its parts.
+   */
+  async abort(
+    command: simS3Commands.SimAbortMultipartUploadCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimAbortMultipartUploadCommandOutput> {
+    return await new AbortMultipartUploadCommandHandler(this.state).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * List the uploads a Bucket has in progress.
+   */
+  async list(
+    command: simS3Commands.SimListMultipartUploadsCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimListMultipartUploadsCommandOutput> {
+    return await new ListMultipartUploadsCommandHandler(this.state).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * List the parts stored against one upload.
+   */
+  async listParts(
+    command: simS3Commands.SimListPartsCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimListPartsCommandOutput> {
+    return await new ListPartsCommandHandler(this.state).handle(
+      command,
+      options,
+    );
+  }
+}

--- a/src/service/s3/command/multipart/sim-s3-multipart-refusals.iso.test.ts
+++ b/src/service/s3/command/multipart/sim-s3-multipart-refusals.iso.test.ts
@@ -1,0 +1,316 @@
+import {
+  AbortMultipartUploadCommand,
+  CompleteMultipartUploadCommand,
+  CreateBucketCommand,
+  CreateMultipartUploadCommand,
+  ListPartsCommand,
+  PutBucketPolicyCommand,
+  UploadPartCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimS3 } from "../../sim-s3.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+
+/**
+ * What simulated S3 refuses during a multipart upload.
+ *
+ * An upload that goes wrong should go wrong the way it does against AWS, so
+ * that retry and cleanup code written against these errors is exercised rather
+ * than merely compiled. The alternative is worse than an absent feature: an
+ * Object assembled from whichever parts happened to arrive is a confident
+ * wrong answer.
+ */
+describe("Simulated S3 multipart upload refusals", () => {
+  const bucketWith = async (bucketName: string): Promise<SimS3> => {
+    const simS3 = new SimAws().s3();
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+
+    return simS3;
+  };
+
+  const startedUpload = async (
+    simS3: SimS3,
+    bucketName: string,
+    key: string,
+  ): Promise<string> => {
+    const started = await simS3.createMultipartUpload(
+      new CreateMultipartUploadCommand({ Bucket: bucketName, Key: key }),
+    );
+    assertDefined(started.UploadId, "the issued upload id");
+
+    return started.UploadId;
+  };
+
+  it("refuses an upload id it never issued", async () => {
+    // Given a Bucket with no upload in progress.
+    const simS3 = await bucketWith("unknown-uploads");
+
+    // When an upload id nothing issued is completed.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simS3.completeMultipartUpload(
+          new CompleteMultipartUploadCommand({
+            Bucket: "unknown-uploads",
+            Key: "invented.bin",
+            UploadId: "not-an-upload",
+            MultipartUpload: { Parts: [{ PartNumber: 1 }] },
+          }),
+        ),
+    );
+
+    // Then S3's own error is raised, which is what a client retrying an upload
+    // it has lost track of reads to know it has to start again.
+    assertIdentical(error.name, "NoSuchUpload");
+  });
+
+  it("refuses an upload id that has already been used up", async () => {
+    // Given an upload that was aborted.
+    const simS3 = await bucketWith("spent-uploads");
+    const uploadId = await startedUpload(simS3, "spent-uploads", "gone.bin");
+    await simS3.abortMultipartUpload(
+      new AbortMultipartUploadCommand({
+        Bucket: "spent-uploads",
+        Key: "gone.bin",
+        UploadId: uploadId,
+      }),
+    );
+
+    // When its parts are listed.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simS3.listParts(
+          new ListPartsCommand({
+            Bucket: "spent-uploads",
+            Key: "gone.bin",
+            UploadId: uploadId,
+          }),
+        ),
+    );
+
+    // Then it is as unknown as an invented id: real S3 keeps nothing about an
+    // upload that has stopped being one.
+    assertIdentical(error.name, "NoSuchUpload");
+  });
+
+  it("refuses a completion naming a part that was never uploaded", async () => {
+    // Given an upload holding one part.
+    const simS3 = await bucketWith("missing-parts");
+    const uploadId = await startedUpload(simS3, "missing-parts", "gappy.bin");
+    await simS3.uploadPart(
+      new UploadPartCommand({
+        Bucket: "missing-parts",
+        Key: "gappy.bin",
+        UploadId: uploadId,
+        PartNumber: 1,
+        Body: "one",
+      }),
+    );
+
+    // When the completion names a second part that never arrived.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simS3.completeMultipartUpload(
+          new CompleteMultipartUploadCommand({
+            Bucket: "missing-parts",
+            Key: "gappy.bin",
+            UploadId: uploadId,
+            MultipartUpload: {
+              Parts: [{ PartNumber: 1 }, { PartNumber: 2 }],
+            },
+          }),
+        ),
+    );
+
+    // Then it is refused rather than assembled from what was there, which
+    // would have stored an Object silently missing its second half.
+    assertIdentical(error.name, "InvalidPart");
+    assertStringIncludes(error.message, "part 2");
+  });
+
+  it("refuses a completion naming an ETag other than the one it stored", async () => {
+    // Given an upload holding one part.
+    const simS3 = await bucketWith("wrong-etags");
+    const uploadId = await startedUpload(simS3, "wrong-etags", "one.bin");
+    await simS3.uploadPart(
+      new UploadPartCommand({
+        Bucket: "wrong-etags",
+        Key: "one.bin",
+        UploadId: uploadId,
+        PartNumber: 1,
+        Body: "content",
+      }),
+    );
+
+    // When the completion names it by an ETag it was not stored under.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simS3.completeMultipartUpload(
+          new CompleteMultipartUploadCommand({
+            Bucket: "wrong-etags",
+            Key: "one.bin",
+            UploadId: uploadId,
+            MultipartUpload: {
+              Parts: [
+                {
+                  PartNumber: 1,
+                  ETag: '"d41d8cd98f00b204e9800998ecf8427e"',
+                },
+              ],
+            },
+          }),
+        ),
+    );
+
+    // Then S3 says the client is naming a part other than the one it holds.
+    assertIdentical(error.name, "InvalidPart");
+  });
+
+  it("refuses a completion listing its parts out of order", async () => {
+    // Given an upload holding two parts, sent in either order.
+    const simS3 = await bucketWith("unordered");
+    const uploadId = await startedUpload(simS3, "unordered", "swapped.bin");
+
+    await Promise.all(
+      [1, 2].map(
+        async (partNumber) =>
+          await simS3.uploadPart(
+            new UploadPartCommand({
+              Bucket: "unordered",
+              Key: "swapped.bin",
+              UploadId: uploadId,
+              PartNumber: partNumber,
+              Body: `part ${partNumber}`,
+            }),
+          ),
+      ),
+    );
+
+    // When the completion lists them the other way round.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simS3.completeMultipartUpload(
+          new CompleteMultipartUploadCommand({
+            Bucket: "unordered",
+            Key: "swapped.bin",
+            UploadId: uploadId,
+            MultipartUpload: {
+              Parts: [{ PartNumber: 2 }, { PartNumber: 1 }],
+            },
+          }),
+        ),
+    );
+
+    // Then it is refused rather than sorted, as real S3 refuses it. Accepting
+    // it here would pass a test that fails against AWS.
+    assertIdentical(error.name, "InvalidPartOrder");
+  });
+
+  it("refuses a completion naming no parts at all", async () => {
+    // Given an upload in progress.
+    const simS3 = await bucketWith("empty-completions");
+    const uploadId = await startedUpload(
+      simS3,
+      "empty-completions",
+      "nothing.bin",
+    );
+
+    // When it is completed with an empty part list.
+    const empty = await assertThrowsErrorAsync(
+      async () =>
+        await simS3.completeMultipartUpload(
+          new CompleteMultipartUploadCommand({
+            Bucket: "empty-completions",
+            Key: "nothing.bin",
+            UploadId: uploadId,
+            MultipartUpload: { Parts: [] },
+          }),
+        ),
+    );
+
+    // Then S3 refuses the request document rather than storing an empty Object.
+    assertIdentical(empty.name, "MalformedXML");
+
+    // And a completion that leaves the part list out altogether is the same
+    // refusal, rather than S3 assuming every part it happens to hold.
+    const omitted = await assertThrowsErrorAsync(
+      async () =>
+        await simS3.completeMultipartUpload(
+          new CompleteMultipartUploadCommand({
+            Bucket: "empty-completions",
+            Key: "nothing.bin",
+            UploadId: uploadId,
+          }),
+        ),
+    );
+    assertIdentical(omitted.name, "MalformedXML");
+  });
+
+  it("refuses a Bucket that is not there before anything else", async () => {
+    // Given a simulated S3 with no Buckets.
+    const simS3 = new SimAws().s3();
+
+    // When an upload is started against a Bucket that does not exist.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simS3.createMultipartUpload(
+          new CreateMultipartUploadCommand({
+            Bucket: "absent",
+            Key: "one.bin",
+          }),
+        ),
+    );
+
+    // Then it is the missing-Bucket error, as every other Bucket-scoped
+    // operation answers with.
+    assertIdentical(error.name, "NoSuchBucket");
+  });
+
+  it("authorizes each operation the way PutObject is authorized", async () => {
+    // Given a Bucket whose policy denies writes to the key being uploaded, and
+    // a caller subject to it.
+    const simAws = new SimAws();
+    const simS3 = simAws.s3();
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "denied" }));
+    await simS3.putBucketPolicy(
+      new PutBucketPolicyCommand({
+        Bucket: "denied",
+        Policy: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Deny",
+              Principal: "*",
+              Action: "s3:PutObject",
+              Resource: "arn:aws:s3:::denied/locked.bin",
+            },
+          ],
+        }),
+      }),
+    );
+
+    // When an upload of that key is started.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simS3.createMultipartUpload(
+          new CreateMultipartUploadCommand({
+            Bucket: "denied",
+            Key: "locked.bin",
+          }),
+          { caller: { kind: "service", service: "cloudfront.amazonaws.com" } },
+        ),
+    );
+
+    // Then it is denied at the start rather than after the parts have been
+    // uploaded, on the Object ARN and under the action PutObject uses.
+    assertIdentical(error.name, "AccessDenied");
+    assertStringIncludes(error.message, "s3:PutObject");
+    assertStringIncludes(error.message, "arn:aws:s3:::denied/locked.bin");
+  });
+});

--- a/src/service/s3/command/multipart/sim-s3-multipart-upload.iso.test.ts
+++ b/src/service/s3/command/multipart/sim-s3-multipart-upload.iso.test.ts
@@ -1,0 +1,397 @@
+import type { Readable } from "node:stream";
+
+import {
+  AbortMultipartUploadCommand,
+  CompleteMultipartUploadCommand,
+  CreateBucketCommand,
+  CreateMultipartUploadCommand,
+  GetObjectCommand,
+  HeadObjectCommand,
+  ListMultipartUploadsCommand,
+  ListObjectsV2Command,
+  ListPartsCommand,
+  UploadPartCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertStringEndsWith,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import { simS3BodyToBuffer } from "../../storage/s3-body-buffer.js";
+import {
+  simS3MultipartETag,
+  simS3ObjectETag,
+  simS3QuotedETag,
+} from "../../object/s3-object-etag.js";
+import { SimS3 } from "../../sim-s3.js";
+
+/**
+ * Uploading a simulated S3 Object in parts.
+ *
+ * This is the path anything uploading a file of real size takes: the `aws` CLI
+ * above eight megabytes, and `@aws-sdk/lib-storage` whatever the size. What
+ * matters is that it ends in an ordinary Object, indistinguishable from one
+ * written in a single PutObject except for the ETag, which says how it arrived.
+ */
+describe("Simulated S3 multipart upload", () => {
+  const storedContent = async (body: Readable | undefined): Promise<string> => {
+    assertDefined(body, "the read Object body");
+
+    const buffer = await simS3BodyToBuffer(body);
+
+    return buffer.toString("utf8");
+  };
+
+  const bucketWith = async (bucketName: string): Promise<SimS3> => {
+    const simS3 = new SimS3();
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+
+    return simS3;
+  };
+
+  const startedUpload = async (
+    simS3: SimS3,
+    bucketName: string,
+    key: string,
+  ): Promise<string> => {
+    const started = await simS3.createMultipartUpload(
+      new CreateMultipartUploadCommand({
+        Bucket: bucketName,
+        Key: key,
+        ContentType: "application/octet-stream",
+      }),
+    );
+    assertDefined(started.UploadId, "the issued upload id");
+
+    return started.UploadId;
+  };
+
+  it("joins the parts in part-number order, whatever order they arrived in", async () => {
+    // Given an upload whose parts are sent last one first, as a client sending
+    // several at once routinely finishes them.
+    const simS3 = await bucketWith("parts");
+    const uploadId = await startedUpload(simS3, "parts", "joined.txt");
+
+    const second = await simS3.uploadPart(
+      new UploadPartCommand({
+        Bucket: "parts",
+        Key: "joined.txt",
+        UploadId: uploadId,
+        PartNumber: 2,
+        Body: "world",
+      }),
+    );
+    const first = await simS3.uploadPart(
+      new UploadPartCommand({
+        Bucket: "parts",
+        Key: "joined.txt",
+        UploadId: uploadId,
+        PartNumber: 1,
+        Body: "hello ",
+      }),
+    );
+
+    // When the upload is completed.
+    await simS3.completeMultipartUpload(
+      new CompleteMultipartUploadCommand({
+        Bucket: "parts",
+        Key: "joined.txt",
+        UploadId: uploadId,
+        MultipartUpload: {
+          Parts: [
+            { PartNumber: 1, ETag: first.ETag },
+            { PartNumber: 2, ETag: second.ETag },
+          ],
+        },
+      }),
+    );
+
+    // Then the Object holds the parts in the order they are numbered.
+    const read = await simS3.getObject(
+      new GetObjectCommand({ Bucket: "parts", Key: "joined.txt" }),
+    );
+    assertIdentical(await storedContent(read.Body), "hello world");
+  });
+
+  it("gives the completed Object the multipart ETag form", async () => {
+    // Given an upload sent as two parts.
+    const simS3 = await bucketWith("etags");
+    const uploadId = await startedUpload(simS3, "etags", "big.bin");
+
+    await Promise.all(
+      ["one", "two"].map(
+        async (content, index) =>
+          await simS3.uploadPart(
+            new UploadPartCommand({
+              Bucket: "etags",
+              Key: "big.bin",
+              UploadId: uploadId,
+              PartNumber: index + 1,
+              Body: content,
+            }),
+          ),
+      ),
+    );
+
+    // When it is completed.
+    const completed = await simS3.completeMultipartUpload(
+      new CompleteMultipartUploadCommand({
+        Bucket: "etags",
+        Key: "big.bin",
+        UploadId: uploadId,
+        MultipartUpload: {
+          Parts: [{ PartNumber: 1 }, { PartNumber: 2 }],
+        },
+      }),
+    );
+
+    // Then the ETag is `<md5-of-the-part-md5s>-<partCount>`, which is what a
+    // tool comparing content hashes checks for before trusting one, and every
+    // operation that reports an ETag agrees on it.
+    const partETags = ["one", "two"].map((content) =>
+      simS3ObjectETag(Buffer.from(content)),
+    );
+    const expected = simS3QuotedETag(simS3MultipartETag(partETags));
+    assertIdentical(completed.ETag, expected);
+    assertStringEndsWith(expected, '-2"');
+
+    const head = await simS3.headObject(
+      new HeadObjectCommand({ Bucket: "etags", Key: "big.bin" }),
+    );
+    assertIdentical(head.ETag, expected);
+
+    const listed = await simS3.listObjectsV2(
+      new ListObjectsV2Command({ Bucket: "etags" }),
+    );
+    assertIdentical(listed.Contents?.[0]?.ETag, expected);
+  });
+
+  it("keeps what the upload was started with on the finished Object", async () => {
+    // Given an upload started with the metadata describing the Object, which is
+    // where real S3 takes it: none of the bytes have arrived yet.
+    const simS3 = await bucketWith("metadata");
+    const started = await simS3.createMultipartUpload(
+      new CreateMultipartUploadCommand({
+        Bucket: "metadata",
+        Key: "page.html",
+        ContentType: "text/html",
+        CacheControl: "max-age=60",
+        Metadata: { author: "yulin" },
+      }),
+    );
+    await simS3.uploadPart(
+      new UploadPartCommand({
+        Bucket: "metadata",
+        Key: "page.html",
+        UploadId: started.UploadId,
+        PartNumber: 1,
+        Body: "<h1>Home</h1>",
+      }),
+    );
+
+    // When it is completed and read back.
+    await simS3.completeMultipartUpload(
+      new CompleteMultipartUploadCommand({
+        Bucket: "metadata",
+        Key: "page.html",
+        UploadId: started.UploadId,
+        MultipartUpload: { Parts: [{ PartNumber: 1 }] },
+      }),
+    );
+    const read = await simS3.getObject(
+      new GetObjectCommand({ Bucket: "metadata", Key: "page.html" }),
+    );
+
+    // Then the Object carries it, as one written by a PutObject would: the
+    // system metadata under the header names a read hands back, and the
+    // user-defined metadata as it was given.
+    assertDefined(read.Metadata, "the read Object metadata");
+    assertIdentical(read.Metadata["content-type"], "text/html");
+    assertIdentical(read.Metadata["cache-control"], "max-age=60");
+    assertIdentical(read.Metadata["author"], "yulin");
+  });
+
+  it("puts nothing under the key until the upload is completed", async () => {
+    // Given an upload with a part stored against it.
+    const simS3 = await bucketWith("in-flight");
+    const uploadId = await startedUpload(simS3, "in-flight", "pending.bin");
+    await simS3.uploadPart(
+      new UploadPartCommand({
+        Bucket: "in-flight",
+        Key: "pending.bin",
+        UploadId: uploadId,
+        PartNumber: 1,
+        Body: "partial",
+      }),
+    );
+
+    // When the Bucket is listed.
+    const listed = await simS3.listObjectsV2(
+      new ListObjectsV2Command({ Bucket: "in-flight" }),
+    );
+
+    // Then it holds nothing: a part is not an Object, and half an Object is
+    // not something a reader should ever be offered.
+    assertIdentical(listed.KeyCount, 0);
+  });
+
+  it("discards the parts when the upload is abandoned", async () => {
+    // Given an upload with a part stored against it.
+    const simS3 = await bucketWith("abandoned");
+    const uploadId = await startedUpload(simS3, "abandoned", "gone.bin");
+    await simS3.uploadPart(
+      new UploadPartCommand({
+        Bucket: "abandoned",
+        Key: "gone.bin",
+        UploadId: uploadId,
+        PartNumber: 1,
+        Body: "never finished",
+      }),
+    );
+
+    // When it is aborted.
+    await simS3.abortMultipartUpload(
+      new AbortMultipartUploadCommand({
+        Bucket: "abandoned",
+        Key: "gone.bin",
+        UploadId: uploadId,
+      }),
+    );
+
+    // Then nothing is left: no Object under the key, and no upload holding
+    // parts that nothing is ever going to finish.
+    const listed = await simS3.listObjectsV2(
+      new ListObjectsV2Command({ Bucket: "abandoned" }),
+    );
+    assertIdentical(listed.KeyCount, 0);
+
+    const inFlight = await simS3.listMultipartUploads(
+      new ListMultipartUploadsCommand({ Bucket: "abandoned" }),
+    );
+    assertUndefined(inFlight.Uploads);
+  });
+
+  it("reports what is in flight, and the parts one upload holds", async () => {
+    // Given two uploads in progress, one of them with two parts stored.
+    const simS3 = await bucketWith("in-progress");
+    const uploadId = await startedUpload(simS3, "in-progress", "a/one.bin");
+    await startedUpload(simS3, "in-progress", "b/two.bin");
+
+    await simS3.uploadPart(
+      new UploadPartCommand({
+        Bucket: "in-progress",
+        Key: "a/one.bin",
+        UploadId: uploadId,
+        PartNumber: 2,
+        Body: "second",
+      }),
+    );
+    await simS3.uploadPart(
+      new UploadPartCommand({
+        Bucket: "in-progress",
+        Key: "a/one.bin",
+        UploadId: uploadId,
+        PartNumber: 1,
+        Body: "first",
+      }),
+    );
+
+    // When the uploads and one upload's parts are listed.
+    const uploads = await simS3.listMultipartUploads(
+      new ListMultipartUploadsCommand({ Bucket: "in-progress" }),
+    );
+    const parts = await simS3.listParts(
+      new ListPartsCommand({
+        Bucket: "in-progress",
+        Key: "a/one.bin",
+        UploadId: uploadId,
+      }),
+    );
+
+    // Then both uploads are reported, keyed by what they will become.
+    assertNonNullable(uploads.Uploads);
+    assertArrayLength(uploads.Uploads, 2);
+    assertIdentical(uploads.Uploads[0].Key, "a/one.bin");
+    assertIdentical(uploads.Uploads[0].UploadId, uploadId);
+    assertFalse(uploads.IsTruncated);
+
+    // And the parts come back in part-number order with the size each holds,
+    // which is what a client resuming an upload works from.
+    assertNonNullable(parts.Parts);
+    assertArrayLength(parts.Parts, 2);
+    assertIdentical(parts.Parts[0].PartNumber, 1);
+    assertIdentical(parts.Parts[0].Size, 5);
+    assertIdentical(parts.Parts[1].PartNumber, 2);
+    assertIdentical(parts.Parts[1].Size, 6);
+  });
+
+  it("narrows a listing of uploads to a prefix", async () => {
+    // Given uploads in progress under two prefixes.
+    const simS3 = await bucketWith("prefixed");
+    await startedUpload(simS3, "prefixed", "images/one.png");
+    await startedUpload(simS3, "prefixed", "video/one.mp4");
+
+    // When the uploads under one prefix are listed.
+    const listed = await simS3.listMultipartUploads(
+      new ListMultipartUploadsCommand({
+        Bucket: "prefixed",
+        Prefix: "images/",
+      }),
+    );
+
+    // Then only that one comes back.
+    assertNonNullable(listed.Uploads);
+    assertArrayLength(listed.Uploads, 1);
+    assertIdentical(listed.Uploads[0].Key, "images/one.png");
+  });
+
+  it("takes the last part sent under a number, so a resend wins", async () => {
+    // Given a part sent twice, as a client unsure the first attempt arrived
+    // will do.
+    const simS3 = await bucketWith("resent");
+    const uploadId = await startedUpload(simS3, "resent", "retried.txt");
+
+    await simS3.uploadPart(
+      new UploadPartCommand({
+        Bucket: "resent",
+        Key: "retried.txt",
+        UploadId: uploadId,
+        PartNumber: 1,
+        Body: "first attempt",
+      }),
+    );
+    const resent = await simS3.uploadPart(
+      new UploadPartCommand({
+        Bucket: "resent",
+        Key: "retried.txt",
+        UploadId: uploadId,
+        PartNumber: 1,
+        Body: "second attempt",
+      }),
+    );
+
+    // When the upload is completed naming the ETag the resend answered with.
+    await simS3.completeMultipartUpload(
+      new CompleteMultipartUploadCommand({
+        Bucket: "resent",
+        Key: "retried.txt",
+        UploadId: uploadId,
+        MultipartUpload: {
+          Parts: [{ PartNumber: 1, ETag: resent.ETag }],
+        },
+      }),
+    );
+
+    // Then the Object holds what arrived last.
+    const read = await simS3.getObject(
+      new GetObjectCommand({ Bucket: "resent", Key: "retried.txt" }),
+    );
+    assertIdentical(await storedContent(read.Body), "second attempt");
+  });
+});

--- a/src/service/s3/command/put-object/put-object-builder.ts
+++ b/src/service/s3/command/put-object/put-object-builder.ts
@@ -1,5 +1,6 @@
-import { SimS3Object, SimS3ObjectMetadata } from "../../object/s3-object.js";
-import { simS3SystemMetadataHeaders } from "../../object/s3-system-metadata.js";
+import { SimS3Object } from "../../object/s3-object.js";
+import { simS3WriteBodyBuffer } from "../../object/s3-write-body.js";
+import { simS3WriteMetadata } from "../../object/s3-write-metadata.js";
 import type { SimPutObjectCommand } from "./put-object.command.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
@@ -16,11 +17,6 @@ interface PutObjectBuilderProperties {
  * representation and the simulation's storage representation. Keeping that
  * translation here prevents body-format and metadata-normalization rules from
  * increasing the command handler's control-flow complexity.
- *
- * The simulation currently supports the request body forms used by its S3
- * boundary: strings and Uint8Array values. Node.js Buffer values are also covered
- * because Buffer extends Uint8Array. Other SDK streaming body forms should be
- * added here when the simulation gains support for them.
  */
 export class PutObjectBuilder {
   private readonly clock: SimClock;
@@ -43,75 +39,9 @@ export class PutObjectBuilder {
     assertDefined(command.input.Key, "PutObjectCommand.input.Key");
     return new SimS3Object({
       key: command.input.Key,
-      body: this.toBuffer(command.input.Body),
-      metadata: new SimS3ObjectMetadata(this.toMetadata(command)),
+      body: simS3WriteBodyBuffer(command.input.Body, "PutObjectCommand"),
+      metadata: simS3WriteMetadata(command.input),
       lastModified: this.clock.now(),
     });
-  }
-
-  /**
-   * Convert SDK metadata fields to the string map stored by SimS3ObjectMetadata.
-   *
-   * User-defined metadata is retained as supplied. System metadata is read by
-   * the same list of headers a read returns, under the lowercase key that read
-   * looks the value up by, so a write and a read agree on what S3 remembers
-   * about an Object. An omitted header leaves its key absent rather than
-   * assigning an undefined value.
-   */
-  private toMetadata(command: SimPutObjectCommand): Record<string, string> {
-    const metadata: Record<string, string> = { ...command.input.Metadata };
-
-    for (const header of simS3SystemMetadataHeaders) {
-      const value = this.toMetadataValue(command.input[header.field]);
-
-      if (value !== undefined) {
-        metadata[header.name] = value;
-      }
-    }
-
-    return metadata;
-  }
-
-  /**
-   * Represent a system metadata value as the string S3 stores and returns.
-   *
-   * Only `Expires` arrives as a Date, which the SDK would otherwise format on
-   * the wire. It becomes the same HTTP date here so the read side has a header
-   * value to hand back rather than an object.
-   */
-  private toMetadataValue(
-    value: string | Date | undefined,
-  ): string | undefined {
-    if (value instanceof Date) {
-      return value.toUTCString();
-    }
-
-    return value;
-  }
-
-  /**
-   * Materialize a supported SDK request body as a Buffer for Bucket storage.
-   *
-   * An omitted body represents an empty S3 Object. Strings use Node.js's default
-   * UTF-8 encoding. Uint8Array input is copied into a Buffer so storage receives
-   * one consistent binary representation and does not depend on the caller's
-   * mutable typed-array instance.
-   */
-  private toBuffer(body: SimPutObjectCommand["input"]["Body"]): Buffer {
-    if (body === undefined) {
-      return Buffer.alloc(0);
-    }
-
-    if (typeof body === "string") {
-      return Buffer.from(body);
-    }
-
-    if (body instanceof Uint8Array) {
-      return Buffer.from(body);
-    }
-
-    throw new Error(
-      "PutObjectCommand.input.Body must be a string or Uint8Array",
-    );
   }
 }

--- a/src/service/s3/command/put-object/put-object.command.ts
+++ b/src/service/s3/command/put-object/put-object.command.ts
@@ -1,5 +1,6 @@
-import type { Readable } from "node:stream";
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimS3WriteBody } from "../../object/s3-write-body.js";
+import type { SimS3ObjectWriteMetadata } from "../../object/s3-write-metadata.js";
 
 /**
  * Minimal structural sim S3 PutObject command.
@@ -11,23 +12,14 @@ export interface SimPutObjectCommand {
 /**
  * Minimal structural sim S3 PutObject input.
  *
- * The fields below `Metadata` are the system metadata headers S3 remembers
- * about an Object and returns on a read. There is one for every entry in
- * `simS3SystemMetadataHeaders`, which is what the builder reads them by, so a
- * header added to that list without a field here fails to compile. `Expires` is
- * a `Date` because the SDK takes one and formats it as an HTTP date.
+ * The metadata members it carries are the ones every write that describes an
+ * Object carries, which is why they are declared once in
+ * `SimS3ObjectWriteMetadata` and shared with `CreateMultipartUpload`.
  */
-export interface SimPutObjectCommandInput {
+export interface SimPutObjectCommandInput extends SimS3ObjectWriteMetadata {
   readonly Bucket?: string | undefined;
   readonly Key?: string | undefined;
   readonly Body?: SimPutObjectBody;
-  readonly Metadata?: Record<string, string> | undefined;
-  readonly CacheControl?: string | undefined;
-  readonly ContentDisposition?: string | undefined;
-  readonly ContentEncoding?: string | undefined;
-  readonly ContentLanguage?: string | undefined;
-  readonly ContentType?: string | undefined;
-  readonly Expires?: Date | undefined;
 }
 
 /**
@@ -43,14 +35,5 @@ export interface SimPutObjectCommandOutput {
 
 /**
  * Minimal supported sim S3 PutObject body type.
- * This allows for different types that Body could be in the real SDK command,
- * even though we will just use Readable internally.
  */
-export type SimPutObjectBody =
-  | string
-  | Uint8Array
-  | Buffer
-  | Blob
-  | Readable
-  | ReadableStream<Uint8Array>
-  | undefined;
+export type SimPutObjectBody = SimS3WriteBody;

--- a/src/service/s3/command/put-object/put-object.handler.ts
+++ b/src/service/s3/command/put-object/put-object.handler.ts
@@ -97,7 +97,12 @@ export class PutObjectCommandHandler implements CommandHandler<
 
     // Every write path funnels through here, so this one call covers the SDK,
     // an intercepted SDK client and the REST endpoint alike.
-    this.notifications.objectCreated({ bucket, object, caller });
+    this.notifications.objectCreated({
+      bucket,
+      object,
+      caller,
+      eventName: "s3:ObjectCreated:Put",
+    });
 
     return {
       ETag: simS3QuotedETag(object.etag),

--- a/src/service/s3/command/sim-s3-command.types.ts
+++ b/src/service/s3/command/sim-s3-command.types.ts
@@ -88,3 +88,30 @@ export type {
   SimPutPublicAccessBlockCommand,
   SimPutPublicAccessBlockCommandOutput,
 } from "./put-public-access-block/put-public-access-block.command.js";
+export type {
+  SimAbortMultipartUploadCommand,
+  SimAbortMultipartUploadCommandOutput,
+} from "./abort-multipart-upload/abort-multipart-upload.command.js";
+export type {
+  SimCompleteMultipartUploadCommand,
+  SimCompleteMultipartUploadCommandOutput,
+  SimCompletedUploadPart,
+} from "./complete-multipart-upload/complete-multipart-upload.command.js";
+export type {
+  SimCreateMultipartUploadCommand,
+  SimCreateMultipartUploadCommandOutput,
+} from "./create-multipart-upload/create-multipart-upload.command.js";
+export type {
+  SimListMultipartUploadsCommand,
+  SimListMultipartUploadsCommandOutput,
+  SimMultipartUploadSummary,
+} from "./list-multipart-uploads/list-multipart-uploads.command.js";
+export type {
+  SimListPartsCommand,
+  SimListPartsCommandOutput,
+  SimUploadPartSummary,
+} from "./list-parts/list-parts.command.js";
+export type {
+  SimUploadPartCommand,
+  SimUploadPartCommandOutput,
+} from "./upload-part/upload-part.command.js";

--- a/src/service/s3/command/upload-part/upload-part.command.ts
+++ b/src/service/s3/command/upload-part/upload-part.command.ts
@@ -1,0 +1,34 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimS3WriteBody } from "../../object/s3-write-body.js";
+
+/**
+ * Minimal structural sim S3 UploadPart command.
+ */
+export interface SimUploadPartCommand {
+  readonly input: SimUploadPartCommandInput;
+}
+
+/**
+ * Minimal structural sim S3 UploadPart input.
+ *
+ * The body forms are the ones `PutObject` takes, because a part is bytes on
+ * their way to an Object and arrives the same way they do.
+ */
+export interface SimUploadPartCommandInput {
+  readonly Bucket?: string | undefined;
+  readonly Key?: string | undefined;
+  readonly UploadId?: string | undefined;
+  readonly PartNumber?: number | undefined;
+  readonly Body?: SimS3WriteBody;
+}
+
+/**
+ * Minimal structural sim S3 UploadPart output.
+ *
+ * `ETag` is the quoted MD5 of the part's own bytes, which the client sends back
+ * in the completion to say which part it means.
+ */
+export interface SimUploadPartCommandOutput {
+  readonly ETag?: string;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/s3/command/upload-part/upload-part.handler.ts
+++ b/src/service/s3/command/upload-part/upload-part.handler.ts
@@ -1,0 +1,58 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import { simS3QuotedETag } from "../../object/s3-object-etag.js";
+import {
+  SimS3MultipartAccess,
+  type SimS3MultipartAccessProperties,
+} from "../multipart/sim-s3-multipart-access.js";
+import { simS3WriteBodyBuffer } from "../../object/s3-write-body.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
+import type {
+  SimUploadPartCommand,
+  SimUploadPartCommandOutput,
+} from "./upload-part.command.js";
+
+/**
+ * Simulated S3 UploadPartCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/s3/command/UploadPartCommand/
+ */
+export class UploadPartCommandHandler implements CommandHandler<
+  SimUploadPartCommand,
+  SimUploadPartCommandOutput
+> {
+  private readonly access: SimS3MultipartAccess;
+
+  constructor(properties: SimS3MultipartAccessProperties) {
+    this.access = new SimS3MultipartAccess(properties);
+  }
+
+  /**
+   * Store one numbered part of an upload in progress.
+   *
+   * The parts of an upload can arrive in any order, and a client sending
+   * several at once routinely finishes a later one first, so this stores the
+   * part under its number and leaves the ordering to the completion.
+   */
+  async handle(
+    command: SimUploadPartCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimUploadPartCommandOutput> {
+    const { Bucket, Key, UploadId, PartNumber } = command.input;
+    assertDefined(Bucket, "UploadPartCommand.input.Bucket");
+    assertDefined(Key, "UploadPartCommand.input.Key");
+    assertDefined(UploadId, "UploadPartCommand.input.UploadId");
+    assertDefined(PartNumber, "UploadPartCommand.input.PartNumber");
+
+    const { bucket } = await this.access.reach(Bucket, Key, options);
+    const upload = this.access.requireUpload(bucket, UploadId);
+
+    const part = upload.putPart(
+      PartNumber,
+      simS3WriteBodyBuffer(command.input.Body, "UploadPartCommand"),
+      this.access.now(),
+    );
+
+    return { ETag: simS3QuotedETag(part.etag), $metadata: {} };
+  }
+}

--- a/src/service/s3/error/sim-s3.error.ts
+++ b/src/service/s3/error/sim-s3.error.ts
@@ -173,3 +173,49 @@ export class SimS3InvalidBucketName extends SimS3Error {
     super(message, { httpStatusCode: 400 });
   }
 }
+
+/**
+ * Simulated S3 NoSuchUpload error.
+ *
+ * What real S3 answers when a request names a multipart upload id it did not
+ * issue, or one belonging to an upload that has since been completed or
+ * aborted.
+ */
+export class SimS3NoSuchUpload extends SimS3Error {
+  public override readonly name = "NoSuchUpload";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 404 });
+  }
+}
+
+/**
+ * Simulated S3 InvalidPart error.
+ *
+ * A completion naming a part that was never uploaded, or naming an ETag other
+ * than the one that part was stored under. Real S3 refuses rather than
+ * assembling what it can, because a caller that lost a part should not end up
+ * with an Object silently missing its middle.
+ */
+export class SimS3InvalidPart extends SimS3Error {
+  public override readonly name = "InvalidPart";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated S3 InvalidPartOrder error.
+ *
+ * A completion listing its parts in an order other than ascending part number.
+ * The parts themselves can be uploaded in any order; it is the list in the
+ * completion request that real S3 requires to be sorted.
+ */
+export class SimS3InvalidPartOrder extends SimS3Error {
+  public override readonly name = "InvalidPartOrder";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}

--- a/src/service/s3/notification/event/sim-s3-object-event-builder.ts
+++ b/src/service/s3/notification/event/sim-s3-object-event-builder.ts
@@ -15,7 +15,21 @@ export interface SimS3ObjectCreatedInput {
   readonly bucket: SimS3Bucket;
   readonly object: SimS3Object;
   readonly caller: SimAwsResolvedCaller;
+  /**
+   * How the Object came to be there, which real S3 distinguishes: an Object
+   * assembled from parts arrives as `s3:ObjectCreated:CompleteMultipartUpload`
+   * rather than as a Put.
+   */
+  readonly eventName: SimS3ObjectCreatedEvent;
 }
+
+/**
+ * The ways an Object can be created that simulated S3 raises an event for.
+ */
+export type SimS3ObjectCreatedEvent = Extract<
+  SimS3NotificationEvent,
+  `s3:ObjectCreated:${string}`
+>;
 
 /**
  * An Object key a command has just removed.
@@ -66,7 +80,7 @@ export class SimS3ObjectEventBuilder {
   forCreated(input: SimS3ObjectCreatedInput): SimS3ObjectEvent {
     return this.build({
       bucket: input.bucket,
-      eventName: "s3:ObjectCreated:Put",
+      eventName: input.eventName,
       key: input.object.key,
       caller: input.caller,
       size: input.object.body.length,

--- a/src/service/s3/notification/sim-s3-multipart-notification.iso.test.ts
+++ b/src/service/s3/notification/sim-s3-multipart-notification.iso.test.ts
@@ -1,0 +1,225 @@
+import type { Event } from "@aws-sdk/client-s3";
+import {
+  CompleteMultipartUploadCommand,
+  CreateBucketCommand,
+  CreateMultipartUploadCommand,
+  PutBucketNotificationConfigurationCommand,
+  PutObjectCommand,
+  UploadPartCommand,
+} from "@aws-sdk/client-s3";
+import {
+  CreateQueueCommand,
+  GetQueueUrlCommand,
+  ReceiveMessageCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertStringEndsWith,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { simIamPolicyDocumentFactory } from "../../iam/policy/sim-iam-policy-document.factory.js";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+
+/**
+ * The part of the S3 event document these tests read out of a message body.
+ */
+interface S3EventDocument {
+  readonly Records: readonly [
+    {
+      readonly eventName: string;
+      readonly s3: {
+        readonly object: {
+          readonly key: string;
+          readonly size?: number;
+          readonly eTag?: string;
+        };
+      };
+    },
+  ];
+}
+
+/**
+ * What a Bucket says happened when an Object arrived in parts.
+ *
+ * Real S3 distinguishes how an Object came to be there, so an upload completed
+ * from parts raises `s3:ObjectCreated:CompleteMultipartUpload` rather than the
+ * Put a single-request upload raises. A consumer filtering on one of them is
+ * relying on that difference.
+ */
+describe("Notifying a queue of an Object uploaded in parts", () => {
+  const notifyingBucket = async (events: Event[]): Promise<SimAws> => {
+    const simAws = new SimAws();
+    const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:uploads`;
+    const created = await simAws
+      .sqs()
+      .createQueue(new CreateQueueCommand({ QueueName: "uploads" }));
+
+    await simAws.sqs().setQueueAttributes(
+      new SetQueueAttributesCommand({
+        QueueUrl: created.QueueUrl,
+        Attributes: {
+          Policy: simIamPolicyDocumentFactory.make({
+            Statement: {
+              Principal: { Service: "s3.amazonaws.com" },
+              Action: "sqs:SendMessage",
+              Resource: queueArn,
+            },
+          }),
+        },
+      }),
+    );
+
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {
+          QueueConfigurations: [
+            { Id: "arrivals", Events: events, QueueArn: queueArn },
+          ],
+        },
+      }),
+    );
+
+    return simAws;
+  };
+
+  const uploadInParts = async (simAws: SimAws): Promise<void> => {
+    const simS3 = simAws.s3();
+    const started = await simS3.createMultipartUpload(
+      new CreateMultipartUploadCommand({
+        Bucket: "uploads",
+        Key: "raw/film.mov",
+      }),
+    );
+    assertDefined(started.UploadId, "the issued upload id");
+
+    await simS3.uploadPart(
+      new UploadPartCommand({
+        Bucket: "uploads",
+        Key: "raw/film.mov",
+        UploadId: started.UploadId,
+        PartNumber: 1,
+        Body: "the first half",
+      }),
+    );
+    await simS3.uploadPart(
+      new UploadPartCommand({
+        Bucket: "uploads",
+        Key: "raw/film.mov",
+        UploadId: started.UploadId,
+        PartNumber: 2,
+        Body: "the second half",
+      }),
+    );
+    await simS3.completeMultipartUpload(
+      new CompleteMultipartUploadCommand({
+        Bucket: "uploads",
+        Key: "raw/film.mov",
+        UploadId: started.UploadId,
+        MultipartUpload: { Parts: [{ PartNumber: 1 }, { PartNumber: 2 }] },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+  };
+
+  const queuedEvents = async (simAws: SimAws): Promise<S3EventDocument[]> => {
+    const queue = await simAws
+      .sqs()
+      .getQueueUrl(new GetQueueUrlCommand({ QueueName: "uploads" }));
+    const received = await simAws.sqs().receiveMessage(
+      new ReceiveMessageCommand({
+        QueueUrl: queue.QueueUrl,
+        MaxNumberOfMessages: 10,
+      }),
+    );
+
+    return (received.Messages ?? []).map(
+      (message) => JSON.parse(message.Body) as S3EventDocument,
+    );
+  };
+
+  it("says the Object was completed from parts, not put", async () => {
+    // Given a Bucket notifying a queue of every kind of Object creation.
+    const simAws = await notifyingBucket(["s3:ObjectCreated:*"]);
+
+    // When an Object arrives in parts.
+    await uploadInParts(simAws);
+
+    // Then the event names the completion, and describes the Object it made:
+    // the whole size, and the ETag that says it arrived in two parts.
+    const events = await queuedEvents(simAws);
+    assertArrayLength(events, 1);
+
+    const [record] = events[0].Records;
+    assertIdentical(record.eventName, "ObjectCreated:CompleteMultipartUpload");
+
+    const { key, size, eTag } = record.s3.object;
+    assertIdentical(key, "raw/film.mov");
+    assertIdentical(size, 29);
+    assertDefined(eTag, "the created Object's ETag");
+    assertStringEndsWith(eTag, "-2");
+  });
+
+  it("leaves a consumer wanting only puts alone", async () => {
+    // Given a Bucket notifying a queue of single-request uploads only.
+    const simAws = await notifyingBucket(["s3:ObjectCreated:Put"]);
+
+    // When an Object arrives in parts, and another arrives in one request.
+    await uploadInParts(simAws);
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "raw/note.txt",
+        Body: "a note",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then only the put was notified, as real S3 distinguishes the two.
+    const events = await queuedEvents(simAws);
+    assertArrayLength(events, 1);
+    assertIdentical(events[0].Records[0].s3.object.key, "raw/note.txt");
+  });
+
+  it("refuses a configuration that would overlap the wildcard", async () => {
+    // Given a Bucket already notifying on every kind of Object creation.
+    const simAws = await notifyingBucket(["s3:ObjectCreated:*"]);
+    const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:uploads`;
+
+    // When a second configuration names one of the members the wildcard covers.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.s3().putBucketNotificationConfiguration(
+          new PutBucketNotificationConfigurationCommand({
+            Bucket: "uploads",
+            NotificationConfiguration: {
+              QueueConfigurations: [
+                {
+                  Id: "arrivals",
+                  Events: ["s3:ObjectCreated:*"],
+                  QueueArn: queueArn,
+                },
+                {
+                  Id: "completions",
+                  Events: ["s3:ObjectCreated:CompleteMultipartUpload"],
+                  QueueArn: queueArn,
+                },
+              ],
+            },
+          }),
+        ),
+    );
+
+    // Then it is refused, because the wildcard now expands to include it and
+    // real S3 has no rule for which of the two would win.
+    assertIdentical(error.name, "InvalidArgument");
+  });
+});

--- a/src/service/s3/notification/sim-s3-object-notifier.ts
+++ b/src/service/s3/notification/sim-s3-object-notifier.ts
@@ -48,12 +48,12 @@ export class SimS3ObjectNotifier {
   }
 
   /**
-   * Raise an Object creation.
+   * Raise an Object creation, as whichever kind of creation it was.
    */
   objectCreated(input: SimS3ObjectCreatedInput): void {
     this.schedule.matching(
       input.bucket,
-      "s3:ObjectCreated:Put",
+      input.eventName,
       input.object.key,
       () => this.events.forCreated(input),
     );

--- a/src/service/s3/object/s3-object-etag.iso.test.ts
+++ b/src/service/s3/object/s3-object-etag.iso.test.ts
@@ -1,11 +1,16 @@
 import { createHash } from "node:crypto";
 import {
   assertIdentical,
-  assertStringLength,
+  assertStringEndsWith,
   assertStringNotIncludes,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
-import { simS3ObjectETag, simS3QuotedETag } from "./s3-object-etag.js";
+import {
+  simS3MultipartETag,
+  simS3ObjectETag,
+  simS3QuotedETag,
+  simS3UnquotedETag,
+} from "./s3-object-etag.js";
 
 describe("simS3ObjectETag", () => {
   it("is the MD5 of the bytes, as real S3 gives it for a single-part upload", () => {
@@ -29,15 +34,66 @@ describe("simS3ObjectETag", () => {
     assertIdentical(etag, "d41d8cd98f00b204e9800998ecf8427e");
   });
 
-  it("carries no multipart part count, because nothing here uploads in parts", () => {
+  it("carries no part count, which is what says the Object arrived in one piece", () => {
     // Given content large enough that real S3 tooling might upload it in parts.
-    // When its ETag is computed.
+    // When its ETag is computed as a single-part upload.
     const etag = simS3ObjectETag(Buffer.alloc(16 * 1024 * 1024, 7));
 
-    // Then it is a plain digest with no `-N` suffix, since this simulation
-    // stores an Object in one piece however big it is.
+    // Then it is a plain digest with no `-N` suffix, which is the difference a
+    // tool comparing content hashes reads before trusting one.
     assertStringNotIncludes(etag, "-");
-    assertStringLength(etag, 32);
+  });
+});
+
+describe("simS3MultipartETag", () => {
+  it("hashes the part digests and counts the parts, as real S3 does", () => {
+    // Given the MD5s of two parts of an upload.
+    const first = simS3ObjectETag(Buffer.from("first part"));
+    const second = simS3ObjectETag(Buffer.from("second part"));
+
+    // When the completed Object's ETag is computed from them.
+    const etag = simS3MultipartETag([first, second]);
+
+    // Then it is the MD5 of the raw part digests, joined, with the part count
+    // after it: the value AWS itself would have answered with.
+    const digests = [first, second].map((digest) => Buffer.from(digest, "hex"));
+    const overParts = createHash("md5")
+      .update(Buffer.concat(digests))
+      .digest("hex");
+
+    assertIdentical(etag, `${overParts}-2`);
+  });
+
+  it("differs from the digest of the joined bytes", () => {
+    // Given content sent as two parts.
+    const first = Buffer.from("hello ");
+    const second = Buffer.from("world");
+
+    // When the multipart ETag is computed.
+    const etag = simS3MultipartETag([
+      simS3ObjectETag(first),
+      simS3ObjectETag(second),
+    ]);
+
+    // Then it says so, rather than reporting the MD5 of the whole content. A
+    // caller told the plain digest would compare it against its own file and
+    // conclude, wrongly, that the upload had gone astray.
+    assertStringEndsWith(etag, "-2");
+    assertStringNotIncludes(
+      etag,
+      simS3ObjectETag(Buffer.concat([first, second])),
+    );
+  });
+});
+
+describe("simS3UnquotedETag", () => {
+  it("takes the quotes off an ETag a client sent back", () => {
+    // Given the ETag an UploadPart response carried.
+    // When a completion names the part by it.
+    const digest = simS3UnquotedETag('"d41d8cd98f00b204e9800998ecf8427e"');
+
+    // Then it is comparable against the digest S3 stored.
+    assertIdentical(digest, "d41d8cd98f00b204e9800998ecf8427e");
   });
 });
 

--- a/src/service/s3/object/s3-object-etag.ts
+++ b/src/service/s3/object/s3-object-etag.ts
@@ -4,13 +4,29 @@ import { createHash } from "node:crypto";
  * The ETag real S3 gives an Object uploaded in one part.
  *
  * It is the MD5 of the bytes, in hex, and stays that under SSE-S3. An Object
- * uploaded in several parts gets `<md5-of-the-part-md5s>-<partCount>` instead,
- * which is why a tool comparing content hashes checks for the `-N` suffix
- * before trusting an ETag. Simulated S3 has no multipart upload, so an ETag
- * here never carries one.
+ * uploaded in several parts gets a different form, which `simS3MultipartETag`
+ * below builds.
  */
 export function simS3ObjectETag(body: Buffer): string {
   return createHash("md5").update(body).digest("hex");
+}
+
+/**
+ * The ETag real S3 gives an Object uploaded in parts.
+ *
+ * It is `<md5-of-the-part-md5s>-<partCount>`, where the digests being hashed
+ * are the raw bytes of each part's MD5 rather than their hex spellings. A tool
+ * comparing content hashes checks for the `-N` suffix before trusting an ETag,
+ * so an Object assembled from parts has to carry this rather than the MD5 of
+ * the joined bytes: the two are different values and only one of them is what
+ * AWS would have answered.
+ */
+export function simS3MultipartETag(partETags: readonly string[]): string {
+  const digests = Buffer.concat(
+    partETags.map((etag) => Buffer.from(etag, "hex")),
+  );
+
+  return `${createHash("md5").update(digests).digest("hex")}-${partETags.length}`;
 }
 
 /**
@@ -23,4 +39,14 @@ export function simS3ObjectETag(body: Buffer): string {
  */
 export function simS3QuotedETag(etag: string): string {
   return `"${etag}"`;
+}
+
+/**
+ * The digest a quoted ETag carries, for reading one a client sent back.
+ *
+ * A client returns the ETag it was given, quotes and all, and a comparison
+ * against the stored digest has to be against the same form.
+ */
+export function simS3UnquotedETag(etag: string): string {
+  return etag.replaceAll('"', "");
 }

--- a/src/service/s3/object/s3-object-summary.ts
+++ b/src/service/s3/object/s3-object-summary.ts
@@ -9,7 +9,7 @@ import type { SimS3Object } from "./s3-object.js";
  * listing that leaves it out reads as an Object of unknown class, which is a
  * different thing from a Standard one.
  */
-const defaultStorageClass = "STANDARD";
+export const simS3DefaultStorageClass = "STANDARD";
 
 /**
  * One Object as a listing describes it.
@@ -39,7 +39,7 @@ export function simS3ObjectSummary(object: SimS3Object): SimS3ObjectSummary {
     Size: object.body.length,
     ETag: simS3QuotedETag(object.etag),
     LastModified: object.lastModified,
-    StorageClass: defaultStorageClass,
+    StorageClass: simS3DefaultStorageClass,
   };
 }
 

--- a/src/service/s3/object/s3-object.ts
+++ b/src/service/s3/object/s3-object.ts
@@ -12,6 +12,11 @@ interface SimS3ObjectProperties {
   readonly body?: Buffer;
   readonly metadata?: SimS3ObjectMetadata;
   readonly lastModified?: Date;
+  /**
+   * The ETag S3 gave these bytes, for an Object whose ETag is not the MD5 of
+   * them. Only a multipart upload produces one.
+   */
+  readonly etag?: string;
 }
 
 /**
@@ -23,6 +28,7 @@ export class SimS3Object {
   public readonly metadata: SimS3ObjectMetadata;
 
   private readonly writtenAt: Date;
+  private readonly givenETag: string | undefined;
 
   constructor(properties: SimS3ObjectProperties = {}) {
     const {
@@ -36,6 +42,7 @@ export class SimS3Object {
     this.body = body;
     this.metadata = metadata;
     this.writtenAt = new Date(lastModified);
+    this.givenETag = properties.etag;
   }
 
   /**
@@ -62,8 +69,12 @@ export class SimS3Object {
    * be the stored value. It is computed on each read rather than kept, since a
    * Buffer can be written to in place and an ETag remembered from before that
    * would describe bytes the Bucket no longer holds.
+   *
+   * An Object uploaded in parts is the exception, and carries the ETag it was
+   * given. That form says how many parts the bytes arrived in, which nothing
+   * about the joined bytes records, so it cannot be recomputed from them.
    */
   get etag(): string {
-    return simS3ObjectETag(this.body);
+    return this.givenETag ?? simS3ObjectETag(this.body);
   }
 }

--- a/src/service/s3/object/s3-write-body.ts
+++ b/src/service/s3/object/s3-write-body.ts
@@ -1,0 +1,48 @@
+import type { Readable } from "node:stream";
+
+/**
+ * The request body forms a write can carry.
+ *
+ * This allows for the different types Body could be in the real SDK command,
+ * even though the simulation will just use a Buffer internally.
+ */
+export type SimS3WriteBody =
+  | string
+  | Uint8Array
+  | Buffer
+  | Blob
+  | Readable
+  | ReadableStream<Uint8Array>
+  | undefined;
+
+/**
+ * Materialize a supported SDK request body as the Buffer S3 stores.
+ *
+ * An omitted body represents an empty S3 Object, or an empty part of one.
+ * Strings use Node.js's default UTF-8 encoding. Uint8Array input is copied into
+ * a Buffer so storage receives one consistent binary representation and does
+ * not depend on the caller's mutable typed-array instance.
+ *
+ * The simulation supports the request body forms used by its S3 boundary:
+ * strings and Uint8Array values. Node.js Buffer values are also covered because
+ * Buffer extends Uint8Array. Other SDK streaming body forms should be added
+ * here when the simulation gains support for them.
+ */
+export function simS3WriteBodyBuffer(
+  body: SimS3WriteBody,
+  commandName: string,
+): Buffer {
+  if (body === undefined) {
+    return Buffer.alloc(0);
+  }
+
+  if (typeof body === "string") {
+    return Buffer.from(body);
+  }
+
+  if (body instanceof Uint8Array) {
+    return Buffer.from(body);
+  }
+
+  throw new Error(`${commandName}.input.Body must be a string or Uint8Array`);
+}

--- a/src/service/s3/object/s3-write-metadata.ts
+++ b/src/service/s3/object/s3-write-metadata.ts
@@ -1,0 +1,64 @@
+import { SimS3ObjectMetadata } from "./s3-object.js";
+import { simS3SystemMetadataHeaders } from "./s3-system-metadata.js";
+
+/**
+ * The metadata members of a request that says what an Object is.
+ *
+ * `PutObject` and `CreateMultipartUpload` both carry these, because both of
+ * them are the request that describes the Object rather than the one that
+ * delivers its bytes. The fields below `Metadata` are the system metadata
+ * headers S3 remembers about an Object and returns on a read. There is one for
+ * every entry in `simS3SystemMetadataHeaders`, which is what the conversion
+ * below reads them by, so a header added to that list without a field here
+ * fails to compile. `Expires` is a `Date` because the SDK takes one and formats
+ * it as an HTTP date.
+ */
+export interface SimS3ObjectWriteMetadata {
+  readonly Metadata?: Record<string, string> | undefined;
+  readonly CacheControl?: string | undefined;
+  readonly ContentDisposition?: string | undefined;
+  readonly ContentEncoding?: string | undefined;
+  readonly ContentLanguage?: string | undefined;
+  readonly ContentType?: string | undefined;
+  readonly Expires?: Date | undefined;
+}
+
+/**
+ * Convert the metadata members of a write into what an Object stores.
+ *
+ * User-defined metadata is retained as supplied. System metadata is read by
+ * the same list of headers a read returns, under the lowercase key that read
+ * looks the value up by, so a write and a read agree on what S3 remembers
+ * about an Object. An omitted header leaves its key absent rather than
+ * assigning an undefined value.
+ */
+export function simS3WriteMetadata(
+  input: SimS3ObjectWriteMetadata,
+): SimS3ObjectMetadata {
+  const metadata: Record<string, string> = { ...input.Metadata };
+
+  for (const header of simS3SystemMetadataHeaders) {
+    const value = metadataValue(input[header.field]);
+
+    if (value !== undefined) {
+      metadata[header.name] = value;
+    }
+  }
+
+  return new SimS3ObjectMetadata(metadata);
+}
+
+/**
+ * Represent a system metadata value as the string S3 stores and returns.
+ *
+ * Only `Expires` arrives as a Date, which the SDK would otherwise format on
+ * the wire. It becomes the same HTTP date here so the read side has a header
+ * value to hand back rather than an object.
+ */
+function metadataValue(value: string | Date | undefined): string | undefined {
+  if (value instanceof Date) {
+    return value.toUTCString();
+  }
+
+  return value;
+}

--- a/src/service/s3/sdk/sim-s3-sdk-command-router.iso.test.ts
+++ b/src/service/s3/sdk/sim-s3-sdk-command-router.iso.test.ts
@@ -273,7 +273,7 @@ describe("simulated S3 SDK Command routing", () => {
 
     const supported = router.supportedCommandNames();
 
-    assertArrayLength(supported, 20);
+    assertArrayLength(supported, 26);
     assertArrayIncludes(supported, "GetObjectCommand");
     assertArrayIncludes(supported, "ListObjectsV2Command");
     assertArrayIncludes(supported, "DeleteBucketCommand");
@@ -286,6 +286,12 @@ describe("simulated S3 SDK Command routing", () => {
     assertArrayIncludes(supported, "PutPublicAccessBlockCommand");
     assertArrayIncludes(supported, "HeadObjectCommand");
     assertArrayIncludes(supported, "HeadBucketCommand");
+    assertArrayIncludes(supported, "CreateMultipartUploadCommand");
+    assertArrayIncludes(supported, "UploadPartCommand");
+    assertArrayIncludes(supported, "CompleteMultipartUploadCommand");
+    assertArrayIncludes(supported, "AbortMultipartUploadCommand");
+    assertArrayIncludes(supported, "ListMultipartUploadsCommand");
+    assertArrayIncludes(supported, "ListPartsCommand");
     assertUndefined(router.route("GetBucketAclCommand"));
   });
 

--- a/src/service/s3/sdk/sim-s3-sdk-command-router.ts
+++ b/src/service/s3/sdk/sim-s3-sdk-command-router.ts
@@ -4,7 +4,13 @@ import type {
   SimSdkCommandRouter,
 } from "../../../sdk/index.js";
 import { simSdkCallerOptions, simSdkStreamBody } from "../../../sdk/index.js";
+import type { SimAbortMultipartUploadCommand } from "../command/abort-multipart-upload/abort-multipart-upload.command.js";
+import type { SimCompleteMultipartUploadCommand } from "../command/complete-multipart-upload/complete-multipart-upload.command.js";
 import type { SimCreateBucketCommand } from "../command/create-bucket/create-bucket.command.js";
+import type { SimCreateMultipartUploadCommand } from "../command/create-multipart-upload/create-multipart-upload.command.js";
+import type { SimListMultipartUploadsCommand } from "../command/list-multipart-uploads/list-multipart-uploads.command.js";
+import type { SimListPartsCommand } from "../command/list-parts/list-parts.command.js";
+import type { SimUploadPartCommand } from "../command/upload-part/upload-part.command.js";
 import type {
   SimGetObjectCommand,
   SimGetObjectCommandOutput,
@@ -195,6 +201,54 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simS3.putObject(
             command as SimPutObjectCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "CreateMultipartUploadCommand",
+        async (command, context): Promise<unknown> =>
+          await simS3.createMultipartUpload(
+            command as SimCreateMultipartUploadCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "UploadPartCommand",
+        async (command, context): Promise<unknown> =>
+          await simS3.uploadPart(
+            command as SimUploadPartCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "CompleteMultipartUploadCommand",
+        async (command, context): Promise<unknown> =>
+          await simS3.completeMultipartUpload(
+            command as SimCompleteMultipartUploadCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "AbortMultipartUploadCommand",
+        async (command, context): Promise<unknown> =>
+          await simS3.abortMultipartUpload(
+            command as SimAbortMultipartUploadCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListMultipartUploadsCommand",
+        async (command, context): Promise<unknown> =>
+          await simS3.listMultipartUploads(
+            command as SimListMultipartUploadsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListPartsCommand",
+        async (command, context): Promise<unknown> =>
+          await simS3.listParts(
+            command as SimListPartsCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/s3/serve/api/sim-s3-api-bucket-routes.ts
+++ b/src/service/s3/serve/api/sim-s3-api-bucket-routes.ts
@@ -11,6 +11,7 @@ import {
   listObjectsInput,
   listObjectsV2Input,
 } from "./sim-s3-api-input.js";
+import { listMultipartUploadsInput } from "./sim-s3-api-multipart-input.js";
 import type { SimS3ApiRoute } from "./sim-s3-api-route.type.js";
 
 /**
@@ -52,6 +53,13 @@ export const simS3BucketApiRoutes: readonly SimS3ApiRoute[] = [
     subResource: "notification",
     commandName: "GetBucketNotificationConfigurationCommand",
     input: bucketInput,
+  },
+  {
+    method: "GET",
+    target: "bucket",
+    subResource: "uploads",
+    commandName: "ListMultipartUploadsCommand",
+    input: listMultipartUploadsInput,
   },
   {
     method: "GET",

--- a/src/service/s3/serve/api/sim-s3-api-input.ts
+++ b/src/service/s3/serve/api/sim-s3-api-input.ts
@@ -31,10 +31,17 @@ export function bucketBodyInput<T>(
  * them.
  */
 export function putObjectInput(request: SimS3ApiRequest): object {
+  return { ...createMultipartUploadInput(request), Body: request.body };
+}
+
+/**
+ * The input of a request that describes an Object without carrying its bytes,
+ * which is what starting a multipart upload is.
+ */
+export function createMultipartUploadInput(request: SimS3ApiRequest): object {
   return {
     Bucket: request.bucketName,
     Key: request.objectKey,
-    Body: request.body,
     ...optional("ContentType", request.headers.get("content-type")),
     ...optional("CacheControl", request.headers.get("cache-control")),
     ...optional(

--- a/src/service/s3/serve/api/sim-s3-api-multipart-input.ts
+++ b/src/service/s3/serve/api/sim-s3-api-multipart-input.ts
@@ -1,0 +1,53 @@
+import { optional, optionalNumber } from "./sim-s3-api-input.js";
+import type { SimS3ApiRequest } from "./sim-s3-api-request.js";
+import { readSimS3CompletedUpload } from "./sim-s3-api-xml-read.js";
+
+/**
+ * Reading the multipart upload operations' inputs out of a request.
+ *
+ * S3 states which upload a request belongs to in the `uploadId` query
+ * parameter, and which part in `partNumber`, so all six read the query string
+ * where the single-part operations read only the path.
+ */
+
+/**
+ * The input of an operation naming one upload in progress.
+ */
+export function uploadInput(request: SimS3ApiRequest): object {
+  return {
+    Bucket: request.bucketName,
+    Key: request.objectKey,
+    UploadId: request.query.get("uploadId") ?? "",
+  };
+}
+
+/**
+ * The UploadPart input, which carries one part's bytes and its number.
+ */
+export function uploadPartInput(request: SimS3ApiRequest): object {
+  return {
+    ...uploadInput(request),
+    Body: request.body,
+    ...optionalNumber("PartNumber", request.query.get("partNumber")),
+  };
+}
+
+/**
+ * The CompleteMultipartUpload input, which names the parts to join in its body.
+ */
+export function completeMultipartUploadInput(request: SimS3ApiRequest): object {
+  return {
+    ...uploadInput(request),
+    MultipartUpload: readSimS3CompletedUpload(request.body),
+  };
+}
+
+/**
+ * The ListMultipartUploads input, which names a Bucket rather than an Object.
+ */
+export function listMultipartUploadsInput(request: SimS3ApiRequest): object {
+  return {
+    Bucket: request.bucketName,
+    ...optional("Prefix", request.query.get("prefix")),
+  };
+}

--- a/src/service/s3/serve/api/sim-s3-api-multipart-listing.ts
+++ b/src/service/s3/serve/api/sim-s3-api-multipart-listing.ts
@@ -1,0 +1,89 @@
+import {
+  xmlDocument,
+  xmlElement,
+  xmlValue,
+} from "../../../../util/xml/xml-writer.js";
+
+interface MultipartUploadSummary {
+  readonly Key?: string | undefined;
+  readonly UploadId?: string | undefined;
+  readonly Initiated?: Date | undefined;
+  readonly StorageClass?: string | undefined;
+}
+
+interface ListMultipartUploadsOutput {
+  readonly Bucket?: string | undefined;
+  readonly Prefix?: string | undefined;
+  readonly Uploads?: readonly MultipartUploadSummary[] | undefined;
+  readonly IsTruncated?: boolean | undefined;
+}
+
+interface UploadPartSummary {
+  readonly PartNumber?: number | undefined;
+  readonly ETag?: string | undefined;
+  readonly Size?: number | undefined;
+  readonly LastModified?: Date | undefined;
+}
+
+interface ListPartsOutput {
+  readonly Bucket?: string | undefined;
+  readonly Key?: string | undefined;
+  readonly UploadId?: string | undefined;
+  readonly Parts?: readonly UploadPartSummary[] | undefined;
+  readonly StorageClass?: string | undefined;
+  readonly IsTruncated?: boolean | undefined;
+}
+
+/**
+ * The document listing the uploads a Bucket has in progress.
+ */
+export function simS3ListUploadsXml(
+  output: ListMultipartUploadsOutput,
+): string {
+  const uploads = (output.Uploads ?? [])
+    .map((upload) =>
+      xmlElement(
+        "Upload",
+        xmlValue("Key", upload.Key) +
+          xmlValue("UploadId", upload.UploadId) +
+          xmlValue("Initiated", upload.Initiated) +
+          xmlValue("StorageClass", upload.StorageClass),
+      ),
+    )
+    .join("");
+
+  return xmlDocument(
+    "ListMultipartUploadsResult",
+    xmlValue("Bucket", output.Bucket) +
+      xmlValue("Prefix", output.Prefix) +
+      xmlValue("IsTruncated", output.IsTruncated ?? false) +
+      uploads,
+  );
+}
+
+/**
+ * The document listing the parts stored against one upload.
+ */
+export function simS3ListPartsXml(output: ListPartsOutput): string {
+  const parts = (output.Parts ?? [])
+    .map((part) =>
+      xmlElement(
+        "Part",
+        xmlValue("PartNumber", part.PartNumber) +
+          xmlValue("LastModified", part.LastModified) +
+          xmlValue("ETag", part.ETag) +
+          xmlValue("Size", part.Size),
+      ),
+    )
+    .join("");
+
+  return xmlDocument(
+    "ListPartsResult",
+    xmlValue("Bucket", output.Bucket) +
+      xmlValue("Key", output.Key) +
+      xmlValue("UploadId", output.UploadId) +
+      xmlValue("StorageClass", output.StorageClass) +
+      xmlValue("IsTruncated", output.IsTruncated ?? false) +
+      parts,
+  );
+}

--- a/src/service/s3/serve/api/sim-s3-api-multipart-output.ts
+++ b/src/service/s3/serve/api/sim-s3-api-multipart-output.ts
@@ -1,0 +1,94 @@
+import { xmlDocument, xmlValue } from "../../../../util/xml/xml-writer.js";
+import {
+  simS3ListPartsXml,
+  simS3ListUploadsXml,
+} from "./sim-s3-api-multipart-listing.js";
+
+interface CreateMultipartUploadOutput {
+  readonly Bucket?: string | undefined;
+  readonly Key?: string | undefined;
+  readonly UploadId?: string | undefined;
+}
+
+interface CompleteMultipartUploadOutput {
+  readonly Location?: string | undefined;
+  readonly Bucket?: string | undefined;
+  readonly Key?: string | undefined;
+  readonly ETag?: string | undefined;
+}
+
+/**
+ * The response one of the multipart upload operations answers with, or nothing
+ * when the operation is not one of them.
+ *
+ * Four of the six answer in an XML document. `UploadPart` answers with an ETag
+ * header and `AbortMultipartUpload` with a status alone, so those two are left
+ * to the paths that already build those responses.
+ */
+export function simS3MultipartResponse(
+  commandName: string,
+  output: Record<string, unknown>,
+): Response | undefined {
+  const document = multipartXml(commandName, output);
+
+  return document === undefined
+    ? undefined
+    : new Response(document, {
+        status: 200,
+        headers: { "content-type": "application/xml" },
+      });
+}
+
+/**
+ * The document one of them answers with, if it answers with one.
+ */
+function multipartXml(
+  commandName: string,
+  output: Record<string, unknown>,
+): string | undefined {
+  switch (commandName) {
+    case "CreateMultipartUploadCommand": {
+      return initiateUploadXml(output);
+    }
+    case "CompleteMultipartUploadCommand": {
+      return completedUploadXml(output);
+    }
+    case "ListMultipartUploadsCommand": {
+      return simS3ListUploadsXml(output);
+    }
+    case "ListPartsCommand": {
+      return simS3ListPartsXml(output);
+    }
+    default: {
+      return undefined;
+    }
+  }
+}
+
+/**
+ * The document a started upload answers with.
+ *
+ * S3 names it after the operation's older name, `InitiateMultipartUploadResult`,
+ * which is what an SDK still parses for.
+ */
+function initiateUploadXml(output: CreateMultipartUploadOutput): string {
+  return xmlDocument(
+    "InitiateMultipartUploadResult",
+    xmlValue("Bucket", output.Bucket) +
+      xmlValue("Key", output.Key) +
+      xmlValue("UploadId", output.UploadId),
+  );
+}
+
+/**
+ * The document a completed upload answers with.
+ */
+function completedUploadXml(output: CompleteMultipartUploadOutput): string {
+  return xmlDocument(
+    "CompleteMultipartUploadResult",
+    xmlValue("Location", output.Location) +
+      xmlValue("Bucket", output.Bucket) +
+      xmlValue("Key", output.Key) +
+      xmlValue("ETag", output.ETag),
+  );
+}

--- a/src/service/s3/serve/api/sim-s3-api-multipart.loc.test.ts
+++ b/src/service/s3/serve/api/sim-s3-api-multipart.loc.test.ts
@@ -1,0 +1,221 @@
+import {
+  CreateAccessKeyCommand,
+  CreateUserCommand,
+  PutUserPolicyCommand,
+} from "@aws-sdk/client-iam";
+import {
+  AbortMultipartUploadCommand,
+  CompleteMultipartUploadCommand,
+  CreateBucketCommand,
+  CreateMultipartUploadCommand,
+  GetObjectCommand,
+  ListMultipartUploadsCommand,
+  ListPartsCommand,
+  S3Client,
+  UploadPartCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertStringEndsWith,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { afterAll, beforeAll, describe, it } from "vitest";
+
+import { SimAwsLocalServer } from "../../../../serve/index.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+
+/**
+ * The multipart upload operations reached the way a client outside the process
+ * reaches them: an endpoint URL, credentials, and no simulator in sight.
+ *
+ * S3 states these six in a `?uploads` or `?uploadId` sub-resource on the same
+ * methods and paths the single-part operations use, and answers four of them in
+ * XML documents an SDK parses. What this covers is whether an upload survives
+ * that round trip.
+ */
+describe("Serving the simulated S3 multipart operations on an endpoint URL", () => {
+  const simAws = new SimAws();
+  const srv = new SimAwsLocalServer({ simAws });
+
+  let client: S3Client;
+
+  beforeAll(async () => {
+    await srv.listen();
+
+    const simIam = simAws.iam();
+    await simIam.createUser(new CreateUserCommand({ UserName: "Uploader" }));
+    await simIam.putUserPolicy(
+      new PutUserPolicyCommand({
+        UserName: "Uploader",
+        PolicyName: "Uploads",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: { Effect: "Allow", Action: "*", Resource: "*" },
+        }),
+      }),
+    );
+    const created = await simIam.createAccessKey(
+      new CreateAccessKeyCommand({ UserName: "Uploader" }),
+    );
+
+    client = new S3Client({
+      region: simAws.defaultRegionName,
+      endpoint: `http://localhost:${srv.port}`,
+      forcePathStyle: true,
+      credentials: {
+        accessKeyId: created.AccessKey.AccessKeyId,
+        secretAccessKey: created.AccessKey.SecretAccessKey,
+      },
+    });
+
+    await client.send(new CreateBucketCommand({ Bucket: "served-uploads" }));
+  });
+
+  afterAll(async () => {
+    await srv.close();
+  });
+
+  async function startUpload(key: string): Promise<string> {
+    const started = await client.send(
+      new CreateMultipartUploadCommand({ Bucket: "served-uploads", Key: key }),
+    );
+    assertDefined(started.UploadId, "the issued upload id");
+
+    return started.UploadId;
+  }
+
+  it("round-trips an upload sent in parts through the endpoint", async () => {
+    // Given an upload started and sent in two parts over HTTP
+    const uploadId = await startUpload("joined.txt");
+
+    const first = await client.send(
+      new UploadPartCommand({
+        Bucket: "served-uploads",
+        Key: "joined.txt",
+        UploadId: uploadId,
+        PartNumber: 1,
+        Body: "hello ",
+      }),
+    );
+    const second = await client.send(
+      new UploadPartCommand({
+        Bucket: "served-uploads",
+        Key: "joined.txt",
+        UploadId: uploadId,
+        PartNumber: 2,
+        Body: "world",
+      }),
+    );
+
+    // When the upload is completed
+    const completed = await client.send(
+      new CompleteMultipartUploadCommand({
+        Bucket: "served-uploads",
+        Key: "joined.txt",
+        UploadId: uploadId,
+        MultipartUpload: {
+          Parts: [
+            { PartNumber: 1, ETag: first.ETag },
+            { PartNumber: 2, ETag: second.ETag },
+          ],
+        },
+      }),
+    );
+
+    // Then the Object is readable, and its ETag says it arrived in two parts
+    assertStringEndsWith(completed.ETag ?? "", '-2"');
+    assertIdentical(completed.Key, "joined.txt");
+
+    const read = await client.send(
+      new GetObjectCommand({ Bucket: "served-uploads", Key: "joined.txt" }),
+    );
+    assertIdentical(await read.Body?.transformToString(), "hello world");
+  });
+
+  it("reports what is in flight, and what one upload holds", async () => {
+    // Given an upload with a part stored against it
+    const uploadId = await startUpload("listed.bin");
+    await client.send(
+      new UploadPartCommand({
+        Bucket: "served-uploads",
+        Key: "listed.bin",
+        UploadId: uploadId,
+        PartNumber: 1,
+        Body: "twelve chars",
+      }),
+    );
+
+    // When the uploads and their parts are listed
+    const uploads = await client.send(
+      new ListMultipartUploadsCommand({
+        Bucket: "served-uploads",
+        Prefix: "listed.bin",
+      }),
+    );
+    const parts = await client.send(
+      new ListPartsCommand({
+        Bucket: "served-uploads",
+        Key: "listed.bin",
+        UploadId: uploadId,
+      }),
+    );
+
+    // Then both listings survived their XML documents, sizes and all
+    assertDefined(uploads.Uploads, "the uploads in progress");
+    assertArrayLength(uploads.Uploads, 1);
+    assertIdentical(uploads.Uploads[0].UploadId, uploadId);
+
+    assertDefined(parts.Parts, "the stored parts");
+    assertArrayLength(parts.Parts, 1);
+    assertIdentical(parts.Parts[0].PartNumber, 1);
+    assertIdentical(parts.Parts[0].Size, 12);
+  });
+
+  it("abandons an upload, and then does not know it", async () => {
+    // Given an upload in progress
+    const uploadId = await startUpload("abandoned.bin");
+
+    // When it is aborted
+    const aborted = await client.send(
+      new AbortMultipartUploadCommand({
+        Bucket: "served-uploads",
+        Key: "abandoned.bin",
+        UploadId: uploadId,
+      }),
+    );
+
+    // Then it is gone, and asking about it again is the S3 error a client
+    // retrying an upload it has lost track of reads
+    assertIdentical(aborted.$metadata.httpStatusCode, 204);
+
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await client.send(
+          new ListPartsCommand({
+            Bucket: "served-uploads",
+            Key: "abandoned.bin",
+            UploadId: uploadId,
+          }),
+        ),
+    );
+    assertIdentical(error.name, "NoSuchUpload");
+  });
+
+  it("says a Bucket has nothing in flight rather than saying nothing", async () => {
+    // Given a Bucket with no upload in progress
+    await client.send(new CreateBucketCommand({ Bucket: "quiet-uploads" }));
+
+    // When its uploads are listed
+    const listed = await client.send(
+      new ListMultipartUploadsCommand({ Bucket: "quiet-uploads" }),
+    );
+
+    // Then the listing is empty rather than absent, which is what a caller
+    // reaching for `Uploads ?? []` gets from real S3 too
+    assertUndefined(listed.Uploads);
+    assertIdentical(listed.Bucket, "quiet-uploads");
+  });
+});

--- a/src/service/s3/serve/api/sim-s3-api-object-output.ts
+++ b/src/service/s3/serve/api/sim-s3-api-object-output.ts
@@ -1,0 +1,38 @@
+import { simS3ObjectResponseHeaders } from "../../object/s3-object-response-headers.js";
+
+/**
+ * Answer a read with the Object itself, headers and all.
+ */
+export async function simS3GetObjectResponse(
+  output: Record<string, unknown>,
+): Promise<Response> {
+  const body = await objectBodyBytes(output["Body"]);
+
+  return new Response(body, {
+    status: 200,
+    headers: simS3ObjectResponseHeaders({
+      metadata: output["Metadata"] as Record<string, string> | undefined,
+      bodyLength: body.length,
+      etag: output["ETag"] as string | undefined,
+      lastModified: output["LastModified"] as Date | undefined,
+    }),
+  });
+}
+
+/**
+ * Read a GetObject body into the bytes an HTTP response carries.
+ */
+async function objectBodyBytes(body: unknown): Promise<Buffer> {
+  /* v8 ignore if -- the loader always answers with a body */
+  if (body === undefined || body === null) {
+    return Buffer.alloc(0);
+  }
+
+  const chunks: Buffer[] = [];
+
+  for await (const chunk of body as AsyncIterable<Uint8Array>) {
+    chunks.push(Buffer.from(chunk));
+  }
+
+  return Buffer.concat(chunks);
+}

--- a/src/service/s3/serve/api/sim-s3-api-object-routes.ts
+++ b/src/service/s3/serve/api/sim-s3-api-object-routes.ts
@@ -1,4 +1,13 @@
-import { objectInput, putObjectInput } from "./sim-s3-api-input.js";
+import {
+  createMultipartUploadInput,
+  objectInput,
+  putObjectInput,
+} from "./sim-s3-api-input.js";
+import {
+  completeMultipartUploadInput,
+  uploadInput,
+  uploadPartInput,
+} from "./sim-s3-api-multipart-input.js";
 import type { SimS3ApiRoute } from "./sim-s3-api-route.type.js";
 
 /**
@@ -18,10 +27,45 @@ export const simS3ObjectApiRoutes: readonly SimS3ApiRoute[] = [
     input: objectInput,
   },
   {
+    method: "GET",
+    target: "object",
+    subResource: "uploadId",
+    commandName: "ListPartsCommand",
+    input: uploadInput,
+  },
+  {
+    method: "POST",
+    target: "object",
+    subResource: "uploads",
+    commandName: "CreateMultipartUploadCommand",
+    input: createMultipartUploadInput,
+  },
+  {
+    method: "POST",
+    target: "object",
+    subResource: "uploadId",
+    commandName: "CompleteMultipartUploadCommand",
+    input: completeMultipartUploadInput,
+  },
+  {
+    method: "PUT",
+    target: "object",
+    subResource: "uploadId",
+    commandName: "UploadPartCommand",
+    input: uploadPartInput,
+  },
+  {
     method: "PUT",
     target: "object",
     commandName: "PutObjectCommand",
     input: putObjectInput,
+  },
+  {
+    method: "DELETE",
+    target: "object",
+    subResource: "uploadId",
+    commandName: "AbortMultipartUploadCommand",
+    input: uploadInput,
   },
   {
     method: "DELETE",

--- a/src/service/s3/serve/api/sim-s3-api-output.ts
+++ b/src/service/s3/serve/api/sim-s3-api-output.ts
@@ -1,4 +1,3 @@
-import { simS3ObjectResponseHeaders } from "../../object/s3-object-response-headers.js";
 import {
   deleteResultXml,
   notificationConfigurationXml,
@@ -12,6 +11,8 @@ import {
   simS3ListBucketsXml,
   simS3ListObjectsXml,
 } from "./sim-s3-api-listing.js";
+import { simS3MultipartResponse } from "./sim-s3-api-multipart-output.js";
+import { simS3GetObjectResponse } from "./sim-s3-api-object-output.js";
 
 const xmlContentType = { "content-type": "application/xml" };
 
@@ -40,7 +41,7 @@ export async function simS3ApiResponse(
       return xml(simS3ListObjectsXml(value, 2));
     }
     case "GetObjectCommand": {
-      return await getObjectResponse(value);
+      return await simS3GetObjectResponse(value);
     }
     case "GetBucketPolicyCommand": {
       // A Bucket policy is a JSON document, and real S3 answers this one
@@ -67,7 +68,8 @@ export async function simS3ApiResponse(
     case "HeadBucketCommand": {
       return simS3HeadBucketResponse(value);
     }
-    case "PutObjectCommand": {
+    case "PutObjectCommand":
+    case "UploadPartCommand": {
       return new Response(undefined, {
         status: 200,
         headers: etagHeader(value["ETag"]),
@@ -77,8 +79,12 @@ export async function simS3ApiResponse(
       return new Response(undefined, { status: 200 });
     }
     default: {
-      // The writes and removals that answer with a status and nothing else.
-      return new Response(undefined, { status: emptyStatus(commandName) });
+      // The writes and removals that answer with a status and nothing else,
+      // and the multipart operations, which answer in documents of their own.
+      return (
+        simS3MultipartResponse(commandName, value) ??
+        new Response(undefined, { status: emptyStatus(commandName) })
+      );
     }
   }
 }
@@ -87,47 +93,14 @@ export async function simS3ApiResponse(
  * The status an operation with no response body answers with.
  *
  * Real S3 answers a removal `204 No Content` and a configuration write `200`,
- * and a client reads the difference, so the two are kept apart here.
+ * and a client reads the difference, so the two are kept apart here. Abandoning
+ * a multipart upload is a removal, whatever its name starts with.
  */
 function emptyStatus(commandName: string): number {
-  return commandName.startsWith("Delete") ? 204 : 200;
-}
-
-/**
- * Answer a read with the Object itself, headers and all.
- */
-async function getObjectResponse(
-  output: Record<string, unknown>,
-): Promise<Response> {
-  const body = await objectBodyBytes(output["Body"]);
-
-  return new Response(body, {
-    status: 200,
-    headers: simS3ObjectResponseHeaders({
-      metadata: output["Metadata"] as Record<string, string> | undefined,
-      bodyLength: body.length,
-      etag: output["ETag"] as string | undefined,
-      lastModified: output["LastModified"] as Date | undefined,
-    }),
-  });
-}
-
-/**
- * Read a GetObject body into the bytes an HTTP response carries.
- */
-async function objectBodyBytes(body: unknown): Promise<Buffer> {
-  /* v8 ignore if -- the loader always answers with a body */
-  if (body === undefined || body === null) {
-    return Buffer.alloc(0);
-  }
-
-  const chunks: Buffer[] = [];
-
-  for await (const chunk of body as AsyncIterable<Uint8Array>) {
-    chunks.push(Buffer.from(chunk));
-  }
-
-  return Buffer.concat(chunks);
+  return commandName === "AbortMultipartUploadCommand" ||
+    commandName.startsWith("Delete")
+    ? 204
+    : 200;
 }
 
 /**

--- a/src/service/s3/serve/api/sim-s3-api-routes.iso.test.ts
+++ b/src/service/s3/serve/api/sim-s3-api-routes.iso.test.ts
@@ -1,6 +1,7 @@
 import {
   assertIdentical,
   assertObjectEquals,
+  assertObjectMatches,
   assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
@@ -63,6 +64,84 @@ describe("Resolving an S3 REST operation from a request", () => {
     assertIdentical(route("POST", "/widgets?delete"), "DeleteObjectsCommand");
   });
 
+  it("routes the six operations of a multipart upload", () => {
+    // Given the requests an upload in parts is made of, which share their
+    // method and path with the single-part operations and are told apart by
+    // the `uploads` and `uploadId` sub-resources alone.
+    assertIdentical(
+      route("POST", "/widgets/big.bin?uploads"),
+      "CreateMultipartUploadCommand",
+    );
+    assertIdentical(
+      route("PUT", "/widgets/big.bin?uploadId=U1&partNumber=2"),
+      "UploadPartCommand",
+    );
+    assertIdentical(
+      route("POST", "/widgets/big.bin?uploadId=U1"),
+      "CompleteMultipartUploadCommand",
+    );
+    assertIdentical(
+      route("DELETE", "/widgets/big.bin?uploadId=U1"),
+      "AbortMultipartUploadCommand",
+    );
+    assertIdentical(
+      route("GET", "/widgets/big.bin?uploadId=U1"),
+      "ListPartsCommand",
+    );
+    assertIdentical(
+      route("GET", "/widgets?uploads"),
+      "ListMultipartUploadsCommand",
+    );
+
+    // And the single-part operations they share a method and path with are
+    // still reached by a request naming no sub-resource.
+    assertIdentical(route("PUT", "/widgets/big.bin"), "PutObjectCommand");
+    assertIdentical(route("GET", "/widgets/big.bin"), "GetObjectCommand");
+    assertIdentical(route("DELETE", "/widgets/big.bin"), "DeleteObjectCommand");
+  });
+
+  it("reads which part of which upload a request carries", () => {
+    // Given a part upload, whose bytes travel as the body and whose number and
+    // upload travel in the query string.
+    const read = input(
+      "PUT",
+      "/widgets/big.bin?uploadId=U1&partNumber=3",
+      "the third part",
+    ) as Record<string, unknown>;
+
+    assertObjectMatches(read, {
+      Bucket: "widgets",
+      Key: "big.bin",
+      UploadId: "U1",
+      PartNumber: 3,
+    });
+    assertIdentical(
+      Buffer.from(read["Body"] as Uint8Array).toString("utf8"),
+      "the third part",
+    );
+  });
+
+  it("reads the parts a completion names out of its XML body", () => {
+    // Given the document the `aws` CLI sends to finish an upload.
+    const body =
+      `<CompleteMultipartUpload xmlns="http://s3.amazonaws.com/doc/2006-03-01/">` +
+      `<Part><ETag>"aaa"</ETag><PartNumber>1</PartNumber></Part>` +
+      `<Part><ETag>"bbb"</ETag><PartNumber>2</PartNumber></Part>` +
+      `</CompleteMultipartUpload>`;
+
+    assertObjectEquals(input("POST", "/widgets/big.bin?uploadId=U1", body), {
+      Bucket: "widgets",
+      Key: "big.bin",
+      UploadId: "U1",
+      MultipartUpload: {
+        Parts: [
+          { PartNumber: 1, ETag: '"aaa"' },
+          { PartNumber: 2, ETag: '"bbb"' },
+        ],
+      },
+    });
+  });
+
   it("names no operation for a method S3 does not use here", () => {
     assertUndefined(route("PATCH", "/widgets"));
     assertUndefined(route("POST", "/widgets/one.txt"));
@@ -118,6 +197,8 @@ describe("Resolving an S3 REST operation from a request", () => {
 
     // And the ones it does serve are not mistaken for it
     assertUndefined(unserved("/widgets?policy"));
+    assertUndefined(unserved("/widgets?uploads"));
+    assertUndefined(unserved("/widgets/big.bin?uploadId=U1"));
   });
 
   it("reads a parameter left empty as a value rather than a sub-resource", () => {

--- a/src/service/s3/serve/api/sim-s3-api-routes.ts
+++ b/src/service/s3/serve/api/sim-s3-api-routes.ts
@@ -16,6 +16,8 @@ const servedSubResources: readonly string[] = [
   "publicAccessBlock",
   "notification",
   "delete",
+  "uploads",
+  "uploadId",
 ];
 
 /**
@@ -51,7 +53,6 @@ const knownSubResources: ReadonlySet<string> = new Set([
   "select",
   "tagging",
   "torrent",
-  "uploads",
   "versioning",
   "versions",
 ]);

--- a/src/service/s3/serve/api/sim-s3-api-xml-read.ts
+++ b/src/service/s3/serve/api/sim-s3-api-xml-read.ts
@@ -3,6 +3,7 @@ import {
   xmlBoolean,
   xmlChild,
   xmlChildren,
+  xmlNumber,
   xmlText,
 } from "../../../../util/xml/xml-document.js";
 
@@ -27,6 +28,23 @@ export function readSimS3DeleteRequest(body: string): object {
       ...defined("Key", xmlText(object, "Key")),
     })),
     ...defined("Quiet", quiet),
+  };
+}
+
+/**
+ * Read a CompleteMultipartUpload body, which names the parts to join.
+ *
+ * A part carries the ETag its upload answered with, quotes and all, and the
+ * number it was uploaded under.
+ */
+export function readSimS3CompletedUpload(body: Uint8Array): object {
+  const root = parseXmlDocument(Buffer.from(body).toString("utf8"));
+
+  return {
+    Parts: xmlChildren(root, "Part").map((part) => ({
+      ...defined("PartNumber", xmlNumber(part, "PartNumber")),
+      ...defined("ETag", xmlText(part, "ETag")),
+    })),
   };
 }
 

--- a/src/service/s3/serve/api/sim-s3-multipart-cli.loc.test.ts
+++ b/src/service/s3/serve/api/sim-s3-multipart-cli.loc.test.ts
@@ -1,0 +1,187 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import {
+  CreateAccessKeyCommand,
+  CreateUserCommand,
+  PutUserPolicyCommand,
+} from "@aws-sdk/client-iam";
+import {
+  CreateBucketCommand,
+  GetObjectCommand,
+  ListObjectsV2Command,
+} from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertStringEndsWith,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { afterAll, beforeAll, describe, it } from "vitest";
+
+import { SimAwsLocalServer } from "../../../../serve/index.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { TemporaryDirectory } from "../../../../util/filesystem/temporary-directory.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+
+const runFile = promisify(execFile);
+
+/**
+ * The `aws` CLI copying a file large enough that it switches to a multipart
+ * upload, against simulated S3 served on a localhost endpoint.
+ *
+ * The CLI switches above eight megabytes, sends the parts concurrently and
+ * finishes them in whatever order they complete, so this is the whole of the
+ * multipart path driven by a real client rather than by a test's idea of one.
+ * Nothing here knows the upload was in parts: `aws s3 cp` is asked for a file
+ * and `aws s3 ls` is asked what the Bucket holds.
+ */
+describe("Copying a large file into simulated S3 with the aws CLI", () => {
+  const simAws = new SimAws();
+  const srv = new SimAwsLocalServer({ simAws });
+  const simS3 = simAws.s3();
+
+  /** Comfortably above the CLI's 8MB multipart threshold. */
+  const fileSize = 12 * 1024 * 1024;
+
+  /**
+   * The byte the copied file holds at one offset.
+   *
+   * Every byte is derived from its own offset, so parts joined in the wrong
+   * order, or one part left out, changes what is read back.
+   */
+  const byteAt = (offset: number): number => (offset * 31) % 256;
+
+  const files = new TemporaryDirectory();
+  let filePath: string;
+  let cliEnvironment: NodeJS.ProcessEnv;
+
+  beforeAll(async () => {
+    await srv.listen();
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "widgets" }));
+
+    // Content the parts cannot be confused with each other by.
+    const content = Buffer.from(
+      Uint8Array.from({ length: fileSize }, (_unused, offset) =>
+        byteAt(offset),
+      ),
+    );
+
+    await files.writeFile("big.bin", content);
+    filePath = files.join("big.bin");
+
+    cliEnvironment = await credentialEnvironment();
+  });
+
+  afterAll(async () => {
+    await srv.close();
+  });
+
+  /**
+   * The environment an `aws` invocation runs with: a simulated IAM user's
+   * access key, and nothing of whatever real AWS configuration the machine
+   * running the test happens to have.
+   */
+  async function credentialEnvironment(): Promise<NodeJS.ProcessEnv> {
+    const simIam = simAws.iam();
+
+    await simIam.createUser(new CreateUserCommand({ UserName: "Copier" }));
+    await simIam.putUserPolicy(
+      new PutUserPolicyCommand({
+        UserName: "Copier",
+        PolicyName: "Copies",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: { Effect: "Allow", Action: "s3:*", Resource: "*" },
+        }),
+      }),
+    );
+    const created = await simIam.createAccessKey(
+      new CreateAccessKeyCommand({ UserName: "Copier" }),
+    );
+
+    const { AWS_PROFILE: _profile, ...environment } = process.env;
+
+    return {
+      ...environment,
+      AWS_ACCESS_KEY_ID: created.AccessKey.AccessKeyId,
+      AWS_SECRET_ACCESS_KEY: created.AccessKey.SecretAccessKey,
+      AWS_DEFAULT_REGION: simAws.defaultRegionName,
+      // Whatever real AWS configuration the machine running this happens to
+      // have is not this test's, so the CLI is pointed away from it.
+      AWS_CONFIG_FILE: files.join("aws-config"),
+      AWS_SHARED_CREDENTIALS_FILE: files.join("aws-credentials"),
+      AWS_EC2_METADATA_DISABLED: "true",
+    };
+  }
+
+  async function aws(...commandArguments: string[]): Promise<string> {
+    const { stdout } = await runFile(
+      "aws",
+      [...commandArguments, "--endpoint-url", `http://localhost:${srv.port}`],
+      { env: cliEnvironment, maxBuffer: 8 * 1024 * 1024 },
+    );
+
+    return stdout;
+  }
+
+  it("copies a file above the multipart threshold, and lists its whole size", async () => {
+    // Given a 12MB file, which the CLI will send as several parts
+    // When it is copied into the Bucket
+    await aws("s3", "cp", filePath, "s3://widgets/big.bin");
+
+    // Then the CLI reports one Object of the whole size, rather than the parts
+    // it happened to send
+    const listed = await aws("s3", "ls", "s3://widgets/");
+    assertStringIncludes(listed, `${fileSize} big.bin`);
+  });
+
+  it("stores the parts joined in order, byte for byte", async () => {
+    // Given the copied file
+    await aws("s3", "cp", filePath, "s3://widgets/checked.bin");
+
+    // When it is read back through the simulator
+    const read = await simS3.getObject(
+      new GetObjectCommand({ Bucket: "widgets", Key: "checked.bin" }),
+    );
+
+    // Then it is the file that was copied, which a part joined out of order or
+    // left out would not be
+    assertDefined(read.Body, "the stored Object body");
+    const stored = Buffer.concat(await Array.fromAsync(read.Body));
+    assertIdentical(stored.byteLength, fileSize);
+    assertIdentical(stored.at(0), byteAt(0));
+    assertIdentical(stored.at(9 * 1024 * 1024), byteAt(9 * 1024 * 1024));
+    assertIdentical(stored.at(fileSize - 1), byteAt(fileSize - 1));
+  });
+
+  it("gives the Object the multipart ETag, so a content-hash comparison holds", async () => {
+    // Given a file copied in parts
+    await aws("s3", "cp", filePath, "s3://widgets/etagged.bin");
+
+    // When the Bucket is listed
+    const listed = await simS3.listObjectsV2(
+      new ListObjectsV2Command({ Bucket: "widgets", Prefix: "etagged.bin" }),
+    );
+
+    // Then the ETag carries the part count, which is what tells a tool
+    // comparing content hashes that this one is not the MD5 of the file
+    const etag = listed.Contents?.[0]?.ETag;
+    assertDefined(etag, "the listed Object's ETag");
+    assertStringEndsWith(etag, '-2"');
+  });
+
+  it("copies the Object back out again", async () => {
+    // Given an Object uploaded in parts
+    await aws("s3", "cp", filePath, "s3://widgets/round-trip.bin");
+
+    // When it is copied back to a local file
+    const downloadPath = files.join("downloaded.bin");
+    await aws("s3", "cp", "s3://widgets/round-trip.bin", downloadPath);
+
+    // Then the CLI is satisfied with what it got, which is the point of the
+    // whole exercise: the simulated Bucket now holds a file of real size that
+    // ordinary tooling can put in and take out again
+    const listed = await aws("s3", "ls", "s3://widgets/round-trip.bin");
+    assertStringIncludes(listed, `${fileSize} round-trip.bin`);
+  });
+});

--- a/src/service/s3/sim-s3-commands.ts
+++ b/src/service/s3/sim-s3-commands.ts
@@ -10,6 +10,7 @@ import {
 import type { SimS3Bucket, SimS3BucketName } from "./bucket/sim-s3-bucket.js";
 import { SimS3BucketCommands } from "./command/bucket/sim-s3-bucket-commands.js";
 import { SimS3BucketPolicyCommands } from "./command/bucket-policy/sim-s3-bucket-policy-commands.js";
+import { SimS3MultipartCommands } from "./command/multipart/sim-s3-multipart-commands.js";
 import { SimS3NotificationCommands } from "./command/notification/sim-s3-notification-commands.js";
 import { SimS3ObjectCommands } from "./command/object/sim-s3-object-commands.js";
 import { SimS3PublicAccessBlockCommands } from "./command/public-access-block/sim-s3-public-access-block-commands.js";
@@ -62,6 +63,7 @@ export class SimS3Commands {
   public readonly publicAccessBlocks: SimS3PublicAccessBlockCommands;
   public readonly notifications: SimS3NotificationCommands;
   public readonly objects: SimS3ObjectCommands;
+  public readonly multipartUploads: SimS3MultipartCommands;
   public readonly objectNotifier: SimS3ObjectNotifier;
 
   constructor(properties: SimS3CommandsProperties) {
@@ -94,5 +96,6 @@ export class SimS3Commands {
     this.publicAccessBlocks = new SimS3PublicAccessBlockCommands(state);
     this.notifications = new SimS3NotificationCommands(state);
     this.objects = new SimS3ObjectCommands(state);
+    this.multipartUploads = new SimS3MultipartCommands(state);
   }
 }

--- a/src/service/s3/sim-s3-operations.ts
+++ b/src/service/s3/sim-s3-operations.ts
@@ -171,4 +171,52 @@ export abstract class SimS3Operations {
   ): Promise<simS3Commands.SimListObjectsV2CommandOutput> {
     return await this.commands.objects.listV2(command, options);
   }
+
+  /** Handle a Create Multipart Upload Command from the SDK. */
+  async createMultipartUpload(
+    command: simS3Commands.SimCreateMultipartUploadCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimCreateMultipartUploadCommandOutput> {
+    return await this.commands.multipartUploads.create(command, options);
+  }
+
+  /** Handle an Upload Part Command from the SDK. */
+  async uploadPart(
+    command: simS3Commands.SimUploadPartCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimUploadPartCommandOutput> {
+    return await this.commands.multipartUploads.uploadPart(command, options);
+  }
+
+  /** Handle a Complete Multipart Upload Command from the SDK. */
+  async completeMultipartUpload(
+    command: simS3Commands.SimCompleteMultipartUploadCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimCompleteMultipartUploadCommandOutput> {
+    return await this.commands.multipartUploads.complete(command, options);
+  }
+
+  /** Handle an Abort Multipart Upload Command from the SDK. */
+  async abortMultipartUpload(
+    command: simS3Commands.SimAbortMultipartUploadCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimAbortMultipartUploadCommandOutput> {
+    return await this.commands.multipartUploads.abort(command, options);
+  }
+
+  /** Handle a List Multipart Uploads Command from the SDK. */
+  async listMultipartUploads(
+    command: simS3Commands.SimListMultipartUploadsCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimListMultipartUploadsCommandOutput> {
+    return await this.commands.multipartUploads.list(command, options);
+  }
+
+  /** Handle a List Parts Command from the SDK. */
+  async listParts(
+    command: simS3Commands.SimListPartsCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimListPartsCommandOutput> {
+    return await this.commands.multipartUploads.listParts(command, options);
+  }
 }

--- a/src/service/s3/upload/sim-s3-completed-upload.ts
+++ b/src/service/s3/upload/sim-s3-completed-upload.ts
@@ -1,0 +1,117 @@
+import {
+  SimS3InvalidPart,
+  SimS3InvalidPartOrder,
+  SimS3MalformedXml,
+} from "../error/sim-s3.error.js";
+import { SimS3Object } from "../object/s3-object.js";
+import {
+  simS3MultipartETag,
+  simS3UnquotedETag,
+} from "../object/s3-object-etag.js";
+import type { SimS3MultipartUpload } from "./sim-s3-multipart-upload.js";
+
+/**
+ * One part as a completion request names it: the number it was uploaded under
+ * and the ETag that upload answered with.
+ */
+export interface SimS3NamedUploadPart {
+  readonly partNumber: number;
+  readonly etag?: string | undefined;
+}
+
+interface SimS3CompletedUploadProperties {
+  readonly upload: SimS3MultipartUpload;
+  readonly parts: readonly SimS3NamedUploadPart[];
+  readonly completedAt: Date;
+}
+
+/**
+ * Join the parts a completion names into the Object S3 stores.
+ *
+ * The completion names the parts rather than S3 assuming them, so a client can
+ * finish an upload it sent a part of twice, or abandon a part it decided not to
+ * use. Every part it names has to be one that was uploaded, because an Object
+ * assembled from the parts that happened to be there would be quietly missing
+ * whatever went astray.
+ *
+ * The result carries the multipart ETag rather than the MD5 of the joined
+ * bytes. See `simS3MultipartETag`.
+ */
+export function simS3CompletedUploadObject(
+  properties: SimS3CompletedUploadProperties,
+): SimS3Object {
+  const { upload, parts } = properties;
+
+  if (parts.length === 0) {
+    throw new SimS3MalformedXml(
+      `The completion of upload ${upload.uploadId} names no parts. S3 takes ` +
+        `the parts to join from the request rather than assuming every part ` +
+        `it holds.`,
+    );
+  }
+
+  assertAscending(parts);
+
+  const stored = parts.map((named) => storedPart(upload, named));
+
+  return new SimS3Object({
+    key: upload.key,
+    body: Buffer.concat(stored.map((part) => part.body)),
+    metadata: upload.metadata,
+    lastModified: properties.completedAt,
+    etag: simS3MultipartETag(stored.map((part) => part.etag)),
+  });
+}
+
+/**
+ * Refuse a completion listing its parts out of order.
+ *
+ * The parts themselves can be uploaded in any order, and `aws s3 cp` routinely
+ * finishes a later one first. It is the list in the completion request that
+ * real S3 requires to ascend, and it says so rather than sorting.
+ */
+function assertAscending(parts: readonly SimS3NamedUploadPart[]): void {
+  for (const [index, part] of parts.entries()) {
+    const previous = parts[index - 1];
+
+    if (previous !== undefined && previous.partNumber >= part.partNumber) {
+      throw new SimS3InvalidPartOrder(
+        `The parts of a completed multipart upload must be listed in ` +
+          `ascending part number order. Part ${part.partNumber} is listed ` +
+          `after part ${previous.partNumber}.`,
+      );
+    }
+  }
+}
+
+/**
+ * The stored part a completion names, or S3's refusal to complete without it.
+ *
+ * A completion carries the ETag each `UploadPart` answered with, so a mismatch
+ * means the client is naming a part other than the one S3 holds under that
+ * number.
+ */
+function storedPart(
+  upload: SimS3MultipartUpload,
+  named: SimS3NamedUploadPart,
+): { readonly body: Buffer; readonly etag: string } {
+  const stored = upload.getPart(named.partNumber);
+
+  if (stored === undefined) {
+    throw new SimS3InvalidPart(
+      `Upload ${upload.uploadId} has no part ${named.partNumber}.`,
+    );
+  }
+
+  const namedETag =
+    named.etag === undefined ? undefined : simS3UnquotedETag(named.etag);
+
+  if (namedETag !== undefined && namedETag !== stored.etag) {
+    throw new SimS3InvalidPart(
+      `Part ${named.partNumber} of upload ${upload.uploadId} was stored with ` +
+        `ETag ${stored.etag}, not the ${namedETag} the completion names.`,
+    );
+  }
+
+  return stored;
+}

--- a/src/service/s3/upload/sim-s3-multipart-upload.ts
+++ b/src/service/s3/upload/sim-s3-multipart-upload.ts
@@ -1,0 +1,98 @@
+import { createHash } from "node:crypto";
+
+import type { Brand } from "../../../util/brand.type.js";
+import type { SimS3ObjectMetadata } from "../object/s3-object.js";
+
+export type SimS3UploadId = Brand<string, "SimS3UploadId">;
+
+/**
+ * One numbered part of a multipart upload, as S3 holds it between the
+ * `UploadPart` that stored it and the `CompleteMultipartUpload` that joins it
+ * to the rest.
+ *
+ * The ETag is the MD5 of the part's own bytes, which is both what `UploadPart`
+ * answers with and what the completed Object's ETag is computed from.
+ */
+export class SimS3UploadPart {
+  public readonly partNumber: number;
+  public readonly body: Buffer;
+  public readonly etag: string;
+  public readonly lastModified: Date;
+
+  constructor(partNumber: number, body: Buffer, lastModified: Date) {
+    this.partNumber = partNumber;
+    this.body = body;
+    this.etag = createHash("md5").update(body).digest("hex");
+    this.lastModified = new Date(lastModified);
+  }
+}
+
+interface SimS3MultipartUploadProperties {
+  readonly uploadId: SimS3UploadId | string;
+  readonly key: string;
+  readonly metadata: SimS3ObjectMetadata;
+  readonly initiated: Date;
+}
+
+/**
+ * A simulated S3 multipart upload in progress.
+ *
+ * S3 keeps the parts of an upload apart from the Bucket's Objects until the
+ * upload is completed, which is why an unfinished upload is invisible to a
+ * listing and an abandoned one leaves nothing behind. This holds them the same
+ * way: a Bucket's Objects and its uploads in progress are separate collections,
+ * and only `CompleteMultipartUpload` moves anything between them.
+ *
+ * The system metadata is taken at `CreateMultipartUpload` rather than at
+ * completion, as real S3 takes it, because the request that says what the
+ * Object is arrives before any of its bytes do.
+ */
+export class SimS3MultipartUpload {
+  public readonly uploadId: SimS3UploadId;
+  public readonly key: string;
+  public readonly metadata: SimS3ObjectMetadata;
+  public readonly initiated: Date;
+
+  private readonly parts = new Map<number, SimS3UploadPart>();
+
+  constructor(properties: SimS3MultipartUploadProperties) {
+    this.uploadId = properties.uploadId as SimS3UploadId;
+    this.key = properties.key;
+    this.metadata = properties.metadata;
+    this.initiated = new Date(properties.initiated);
+  }
+
+  /**
+   * Store a numbered part, replacing whatever was under that number.
+   *
+   * Real S3 lets a client re-send a part it is not sure arrived, and the last
+   * one to arrive is the one the completed Object is built from.
+   */
+  putPart(partNumber: number, body: Buffer, at: Date): SimS3UploadPart {
+    const part = new SimS3UploadPart(partNumber, body, at);
+    this.parts.set(partNumber, part);
+
+    return part;
+  }
+
+  /**
+   * The part stored under a number, if one has been.
+   */
+  getPart(partNumber: number): SimS3UploadPart | undefined {
+    return this.parts.get(partNumber);
+  }
+
+  /**
+   * Every part stored so far, in part-number order.
+   *
+   * The order is the upload's rather than the arrival order kept by the Map,
+   * because part numbers are what a completed Object is assembled by and a
+   * client is free to send them in any order it likes.
+   */
+  storedParts(): readonly SimS3UploadPart[] {
+    return this.parts
+      .values()
+      .toArray()
+      .toSorted((one, other) => one.partNumber - other.partNumber);
+  }
+}

--- a/src/service/s3/upload/sim-s3-multipart-uploads.ts
+++ b/src/service/s3/upload/sim-s3-multipart-uploads.ts
@@ -1,0 +1,82 @@
+import { randomUUID } from "node:crypto";
+
+import type { SimS3ObjectMetadata } from "../object/s3-object.js";
+import {
+  SimS3MultipartUpload,
+  type SimS3UploadId,
+} from "./sim-s3-multipart-upload.js";
+
+interface SimS3StartUploadProperties {
+  readonly key: string;
+  readonly metadata: SimS3ObjectMetadata;
+  readonly initiated: Date;
+}
+
+/**
+ * The multipart uploads one Bucket has in progress.
+ *
+ * Uploads belong to a Bucket rather than to its storage, because they are not
+ * Objects yet: the parts live here until `CompleteMultipartUpload` joins them
+ * into one Object and hands that to storage. Held in memory whatever the
+ * Bucket's storage is, since a mounted directory writes whole files and has
+ * nowhere to put half of one.
+ */
+export class SimS3MultipartUploads {
+  private readonly uploads = new Map<string, SimS3MultipartUpload>();
+
+  /**
+   * Issue an upload id and start holding parts under it.
+   *
+   * The id is opaque to a client, which sends back whatever it was given, so a
+   * UUID does everything real S3's longer token does.
+   */
+  start(properties: SimS3StartUploadProperties): SimS3MultipartUpload {
+    const upload = new SimS3MultipartUpload({
+      uploadId: randomUUID(),
+      key: properties.key,
+      metadata: properties.metadata,
+      initiated: properties.initiated,
+    });
+
+    this.uploads.set(upload.uploadId, upload);
+
+    return upload;
+  }
+
+  /**
+   * The upload an id names, if this Bucket has one in progress under it.
+   */
+  find(uploadId: SimS3UploadId | string): SimS3MultipartUpload | undefined {
+    return this.uploads.get(uploadId);
+  }
+
+  /**
+   * Forget an upload and every part stored against it.
+   *
+   * Both the abort and the completion end here: real S3 keeps nothing about an
+   * upload once it has stopped being one, so a completed upload id is as
+   * unknown afterwards as an aborted one.
+   */
+  discard(uploadId: SimS3UploadId | string): void {
+    this.uploads.delete(uploadId);
+  }
+
+  /**
+   * The uploads in progress, in the order real S3 lists them.
+   *
+   * S3 orders a multipart upload listing by key, and by when the upload was
+   * started within one key, so two uploads to the same key come back oldest
+   * first.
+   */
+  inProgress(prefix?: string): readonly SimS3MultipartUpload[] {
+    return this.uploads
+      .values()
+      .filter((upload) => prefix === undefined || upload.key.startsWith(prefix))
+      .toArray()
+      .toSorted(
+        (one, other) =>
+          one.key.localeCompare(other.key) ||
+          one.initiated.getTime() - other.initiated.getTime(),
+      );
+  }
+}

--- a/src/util/xml/xml-document.ts
+++ b/src/util/xml/xml-document.ts
@@ -112,6 +112,24 @@ export function xmlBoolean(
   return text === undefined ? undefined : text === "true";
 }
 
+/**
+ * The number a named child states, if the element has one that is a number.
+ */
+export function xmlNumber(
+  element: XmlElement | undefined,
+  name: string,
+): number | undefined {
+  const text = xmlText(element, name);
+
+  if (text === undefined) {
+    return undefined;
+  }
+
+  const parsed = Number(text);
+
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
 const entities: ReadonlyMap<string, string> = new Map([
   ["amp", "&"],
   ["lt", "<"],


### PR DESCRIPTION
Brief, concise description of the change:

Simulated S3 answers the six multipart upload operations, so `aws s3 cp` works for a file above the CLI's 8MB threshold and `@aws-sdk/lib-storage` has something to upload to. A Bucket holds its uploads in progress beside its storage, since the parts of an unfinished upload are not Objects: an abandoned upload leaves the Bucket as it found it, and only completing one puts anything under a key. The completed Object carries the multipart ETag form, `<md5-of-the-part-md5s>-<partCount>`, which `s3-object-etag.ts` already documented and never produced. A completion naming a part that was never uploaded is refused rather than assembled from what is there, and a completed upload raises `s3:ObjectCreated:CompleteMultipartUpload`, which sim S3 could not raise before.

Resolves https://github.com/KensioSoftware/yulin/issues/695

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`