### PR TITLE
feat: read a stack Output as a string

### DIFF
--- a/docs/services/acm/README.md
+++ b/docs/services/acm/README.md
@@ -629,7 +629,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
   },
 });
 
-const certificateArn = stack.outputs.get("CertificateArn")?.value;
+const certificateArn = stack.output("CertificateArn");
 if (typeof certificateArn !== "string")
   throw new Error("No CertificateArn Output");
 
@@ -643,7 +643,7 @@ const describeOutput = await simAws.acm().describeCertificate(
   }),
 );
 
-console.log(stack.outputs.get("CertificateStatus")?.value);
+console.log(stack.output("CertificateStatus"));
 console.log(listOutput.CertificateSummaryList?.[0]?.DomainName);
 console.log(describeOutput.Certificate?.Status);
 ```
@@ -701,7 +701,7 @@ await stack.waitForDeployComplete();
 
 // The hosted zone, the validation record and the issued certificate, from one
 // template deploy.
-console.log(stack.outputs.get("CertificateStatus")?.value); // ISSUED
+console.log(stack.output("CertificateStatus")); // ISSUED
 ```
 
 `HostedZoneId` accepts a `Ref` to an `AWS::Route53::HostedZone` in the same template, or the literal ID of a zone created outside the stack.

--- a/docs/services/acm/sim-acm-cloudformation-certificate.example.ts
+++ b/docs/services/acm/sim-acm-cloudformation-certificate.example.ts
@@ -51,7 +51,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
   },
 });
 
-const certificateArn = stack.outputs.get("CertificateArn")?.value;
+const certificateArn = stack.output("CertificateArn");
 if (typeof certificateArn !== "string")
   throw new Error("No CertificateArn Output");
 
@@ -65,6 +65,6 @@ const describeOutput = await simAws.acm().describeCertificate(
   }),
 );
 
-console.log(stack.outputs.get("CertificateStatus")?.value);
+console.log(stack.output("CertificateStatus"));
 console.log(listOutput.CertificateSummaryList?.[0]?.DomainName);
 console.log(describeOutput.Certificate?.Status);

--- a/docs/services/acm/sim-acm-cloudformation-dns-validation.example.ts
+++ b/docs/services/acm/sim-acm-cloudformation-dns-validation.example.ts
@@ -44,4 +44,4 @@ await stack.waitForDeployComplete();
 
 // The hosted zone, the validation record and the issued certificate, from one
 // template deploy.
-console.log(stack.outputs.get("CertificateStatus")?.value); // ISSUED
+console.log(stack.output("CertificateStatus")); // ISSUED

--- a/docs/services/apigatewayv2/README.md
+++ b/docs/services/apigatewayv2/README.md
@@ -1803,7 +1803,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
 await stack.waitForDeployComplete();
 
 // https://<api-id>.execute-api.us-east-1.amazonaws.com
-const apiEndpoint = stack.outputs.get("ApiEndpoint")?.value as string;
+const apiEndpoint = stack.output("ApiEndpoint");
 
 const srv = await serveSimAws({ simAws });
 

--- a/docs/services/apigatewayv2/sim-apigatewayv2-cloudformation.example.ts
+++ b/docs/services/apigatewayv2/sim-apigatewayv2-cloudformation.example.ts
@@ -100,7 +100,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
 await stack.waitForDeployComplete();
 
 // https://<api-id>.execute-api.us-east-1.amazonaws.com
-const apiEndpoint = stack.outputs.get("ApiEndpoint")?.value as string;
+const apiEndpoint = stack.output("ApiEndpoint");
 
 const srv = await serveSimAws({ simAws });
 

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -597,10 +597,10 @@ const stack = await simAws.cloudFormation().deployTemplate({
 
 await stack.waitForDeployComplete();
 
-console.log(stack.outputs.get("AlarmRef")?.value);
+console.log(stack.output("AlarmRef"));
 // "AlarmRule"
 
-console.log(stack.outputs.get("AlarmArn")?.value);
+console.log(stack.output("AlarmArn"));
 // "AlarmRule.Arn"
 
 for (const skipped of stack.skippedResources) {
@@ -1718,6 +1718,63 @@ different AWS-like scoping behaviour.
 An Account ID can always be written as a plain string, as above. Code that wants to name the type
 can get a `SimAwsAccountId` from `simAwsAccountId("111111111111")`, which refuses anything other than
 a 12-digit AWS Account ID.
+
+## Reading stack Outputs
+
+A deployed stack resolves its template `Outputs` once its resources exist. `stack.output(key)`
+answers one of them as a string.
+
+```typescript sim-cloudformation-stack-output
+/**
+ * Reading a resolved Stack Output as a string.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "output-stack",
+  template: {
+    Resources: {
+      SiteBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: {
+          BucketName: "output-site-bucket",
+        },
+      },
+    },
+    Outputs: {
+      SiteBucketName: {
+        Description: "The bucket the site is served from",
+        Value: {
+          Ref: "SiteBucket",
+        },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+const bucketName = stack.output("SiteBucketName");
+
+console.log(bucketName); // "output-site-bucket"
+```
+
+`output` throws where the template declares no such Output, naming the stack, the key asked for and
+the keys it does declare. It throws again where the Output resolved to something other than a
+string, since `DescribeStacks` types an `OutputValue` as a string and a template's Output `Value` is
+a string field.
+
+`stack.outputs` holds every resolved Output whole, keyed by name, and is where to go for the
+description, the export name, or a value that is not a string. Yulin resolves a few attributes as
+the lists and booleans they are, and `Fn::GetAtt` on `AWS::Route53::HostedZone` `NameServers` is the
+one that reaches an Output in these docs.
+
+```typescript
+const nameServers = stack.outputs.get("HostedZoneNameServers")?.value;
+```
 
 ## Inspecting stacks and resources
 

--- a/docs/services/cloudformation/sim-cloudformation-skipped-resource-values.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-skipped-resource-values.example.ts
@@ -23,10 +23,10 @@ const stack = await simAws.cloudFormation().deployTemplate({
 
 await stack.waitForDeployComplete();
 
-console.log(stack.outputs.get("AlarmRef")?.value);
+console.log(stack.output("AlarmRef"));
 // "AlarmRule"
 
-console.log(stack.outputs.get("AlarmArn")?.value);
+console.log(stack.output("AlarmArn"));
 // "AlarmRule.Arn"
 
 for (const skipped of stack.skippedResources) {

--- a/docs/services/cloudformation/sim-cloudformation-stack-output.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-stack-output.example.ts
@@ -1,0 +1,35 @@
+/**
+ * Reading a resolved Stack Output as a string.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "output-stack",
+  template: {
+    Resources: {
+      SiteBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: {
+          BucketName: "output-site-bucket",
+        },
+      },
+    },
+    Outputs: {
+      SiteBucketName: {
+        Description: "The bucket the site is served from",
+        Value: {
+          Ref: "SiteBucket",
+        },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+const bucketName = stack.output("SiteBucketName");
+
+console.log(bucketName); // "output-site-bucket"

--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -1073,8 +1073,7 @@ try {
     }),
   );
 
-  const domainName = stack.outputs.get("DistributionDomainName")
-    ?.value as string;
+  const domainName = stack.output("DistributionDomainName");
   const response = await fetch(srv.localUrl(`http://${domainName}/`));
 
   console.log(response.headers.get("cache-control"));
@@ -1255,7 +1254,7 @@ try {
     }),
   );
 
-  const siteHostname = stack.outputs.get("SiteHostname")?.value as string;
+  const siteHostname = stack.output("SiteHostname");
   const home = await fetch(srv.localUrl(`http://${siteHostname}/`));
 
   console.log(await home.text()); // <h1>Home</h1>
@@ -1436,7 +1435,7 @@ try {
 
   await stack.waitForDeployComplete();
 
-  const siteHostname = stack.outputs.get("SiteHostname")?.value as string;
+  const siteHostname = stack.output("SiteHostname");
   const greeting = await fetch(srv.localUrl(`http://${siteHostname}/greeting`));
 
   console.log(await greeting.text()); // Hello from behind CloudFront

--- a/docs/services/cloudfront/sim-cloudfront-function-url-origin-access-control.example.ts
+++ b/docs/services/cloudfront/sim-cloudfront-function-url-origin-access-control.example.ts
@@ -129,7 +129,7 @@ try {
 
   await stack.waitForDeployComplete();
 
-  const siteHostname = stack.outputs.get("SiteHostname")?.value as string;
+  const siteHostname = stack.output("SiteHostname");
   const greeting = await fetch(srv.localUrl(`http://${siteHostname}/greeting`));
 
   console.log(await greeting.text()); // Hello from behind CloudFront

--- a/docs/services/cloudfront/sim-cloudfront-origin-access-control.example.ts
+++ b/docs/services/cloudfront/sim-cloudfront-origin-access-control.example.ts
@@ -105,7 +105,7 @@ try {
     }),
   );
 
-  const siteHostname = stack.outputs.get("SiteHostname")?.value as string;
+  const siteHostname = stack.output("SiteHostname");
   const home = await fetch(srv.localUrl(`http://${siteHostname}/`));
 
   console.log(await home.text()); // <h1>Home</h1>

--- a/docs/services/cloudfront/sim-cloudfront-response-headers-policy.example.ts
+++ b/docs/services/cloudfront/sim-cloudfront-response-headers-policy.example.ts
@@ -100,8 +100,7 @@ try {
     }),
   );
 
-  const domainName = stack.outputs.get("DistributionDomainName")
-    ?.value as string;
+  const domainName = stack.output("DistributionDomainName");
   const response = await fetch(srv.localUrl(`http://${domainName}/`));
 
   console.log(response.headers.get("cache-control"));

--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -2765,11 +2765,11 @@ const stack = await simAws.cloudFormation().deployTemplate({
 });
 await stack.waitForDeployComplete();
 
-const userPoolId = stack.outputs.get("UserPoolId")?.value as string;
-const clientId = stack.outputs.get("ClientId")?.value as string;
+const userPoolId = stack.output("UserPoolId");
+const clientId = stack.output("ClientId");
 
 console.log(userPoolId); // "eu-west-2_aBcDeFgHi"
-console.log(stack.outputs.get("ProviderUrl")?.value);
+console.log(stack.output("ProviderUrl"));
 // "https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_aBcDeFgHi"
 
 // The deployed pool, client and group are what the test then works with.
@@ -2935,7 +2935,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
 });
 await stack.waitForDeployComplete();
 
-const userPoolId = stack.outputs.get("PoolId")?.value as string;
+const userPoolId = stack.output("PoolId");
 
 // The pool is named after the stack and the logical id, as the template named
 // neither it nor the client.

--- a/docs/services/cognito/sim-cognito-cdk-defaults.example.ts
+++ b/docs/services/cognito/sim-cognito-cdk-defaults.example.ts
@@ -53,7 +53,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
 });
 await stack.waitForDeployComplete();
 
-const userPoolId = stack.outputs.get("PoolId")?.value as string;
+const userPoolId = stack.output("PoolId");
 
 // The pool is named after the stack and the logical id, as the template named
 // neither it nor the client.

--- a/docs/services/cognito/sim-cognito-cloudformation.example.ts
+++ b/docs/services/cognito/sim-cognito-cloudformation.example.ts
@@ -50,11 +50,11 @@ const stack = await simAws.cloudFormation().deployTemplate({
 });
 await stack.waitForDeployComplete();
 
-const userPoolId = stack.outputs.get("UserPoolId")?.value as string;
-const clientId = stack.outputs.get("ClientId")?.value as string;
+const userPoolId = stack.output("UserPoolId");
+const clientId = stack.output("ClientId");
 
 console.log(userPoolId); // "eu-west-2_aBcDeFgHi"
-console.log(stack.outputs.get("ProviderUrl")?.value);
+console.log(stack.output("ProviderUrl"));
 // "https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_aBcDeFgHi"
 
 // The deployed pool, client and group are what the test then works with.

--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -3081,7 +3081,7 @@ await stack.waitForDeployComplete();
 await simAws.backgroundTasksComplete();
 
 // Ref resolves to the table name, so it works as a PutItem TableName.
-const tableName = stack.outputs.get("OrdersTableName")?.value as string;
+const tableName = stack.output("OrdersTableName");
 
 console.log(tableName);
 // "orders-stack-OrdersTable"
@@ -3092,7 +3092,7 @@ await simAws
     new PutItemCommand({ TableName: tableName, Item: { id: { S: "1" } } }),
   );
 
-console.log(stack.outputs.get("OrdersTableArn")?.value);
+console.log(stack.output("OrdersTableArn"));
 // "arn:aws:dynamodb:us-east-1:888888888888:table/orders-stack-OrdersTable"
 ```
 
@@ -3300,7 +3300,7 @@ await stack.waitForDeployComplete();
 await simAws.backgroundTasksComplete();
 
 // The Output holds the ARN of the stream the deployed table captures on.
-const streamArn = stack.outputs.get("OrdersStreamArn")?.value as string;
+const streamArn = stack.output("OrdersStreamArn");
 
 console.log(streamArn.includes("/stream/")); // true
 
@@ -3396,7 +3396,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
 await stack.waitForDeployComplete();
 await simAws.backgroundTasksComplete();
 
-const tableName = stack.outputs.get("OrdersTableName")?.value as string;
+const tableName = stack.output("OrdersTableName");
 
 console.log(tableName);
 // "orders"

--- a/docs/services/dynamodb/sim-dynamodb-cloudformation-global-table.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-cloudformation-global-table.example.ts
@@ -38,7 +38,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
 await stack.waitForDeployComplete();
 await simAws.backgroundTasksComplete();
 
-const tableName = stack.outputs.get("OrdersTableName")?.value as string;
+const tableName = stack.output("OrdersTableName");
 
 console.log(tableName);
 // "orders"

--- a/docs/services/dynamodb/sim-dynamodb-cloudformation-stream.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-cloudformation-stream.example.ts
@@ -42,7 +42,7 @@ await stack.waitForDeployComplete();
 await simAws.backgroundTasksComplete();
 
 // The Output holds the ARN of the stream the deployed table captures on.
-const streamArn = stack.outputs.get("OrdersStreamArn")?.value as string;
+const streamArn = stack.output("OrdersStreamArn");
 
 console.log(streamArn.includes("/stream/")); // true
 

--- a/docs/services/dynamodb/sim-dynamodb-cloudformation-table.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-cloudformation-table.example.ts
@@ -32,7 +32,7 @@ await stack.waitForDeployComplete();
 await simAws.backgroundTasksComplete();
 
 // Ref resolves to the table name, so it works as a PutItem TableName.
-const tableName = stack.outputs.get("OrdersTableName")?.value as string;
+const tableName = stack.output("OrdersTableName");
 
 console.log(tableName);
 // "orders-stack-OrdersTable"
@@ -43,5 +43,5 @@ await simAws
     new PutItemCommand({ TableName: tableName, Item: { id: { S: "1" } } }),
   );
 
-console.log(stack.outputs.get("OrdersTableArn")?.value);
+console.log(stack.output("OrdersTableArn"));
 // "arn:aws:dynamodb:us-east-1:888888888888:table/orders-stack-OrdersTable"

--- a/docs/services/ecr/README.md
+++ b/docs/services/ecr/README.md
@@ -196,7 +196,7 @@ const platformStack = await simAws.cloudFormation().deployTemplate({
 
 await platformStack.waitForDeployComplete();
 
-const repositoryUri = platformStack.outputs.get("RepositoryUri")?.value;
+const repositoryUri = platformStack.output("RepositoryUri");
 
 if (typeof repositoryUri !== "string") {
   throw new TypeError("No RepositoryUri Output");

--- a/docs/services/ecr/sim-ecr-cloudformation-repository.example.ts
+++ b/docs/services/ecr/sim-ecr-cloudformation-repository.example.ts
@@ -28,7 +28,7 @@ const platformStack = await simAws.cloudFormation().deployTemplate({
 
 await platformStack.waitForDeployComplete();
 
-const repositoryUri = platformStack.outputs.get("RepositoryUri")?.value;
+const repositoryUri = platformStack.output("RepositoryUri");
 
 if (typeof repositoryUri !== "string") {
   throw new TypeError("No RepositoryUri Output");

--- a/docs/services/ecs/README.md
+++ b/docs/services/ecs/README.md
@@ -1412,7 +1412,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
 
 await stack.waitForDeployComplete();
 
-console.log(stack.outputs.get("TaskDefinition")?.value);
+console.log(stack.output("TaskDefinition"));
 // "arn:aws:ecs:us-east-1:888888888888:task-definition/orders-worker:1"
 
 // Running a task from the deployed task definition runs the bound handler.
@@ -1585,9 +1585,9 @@ const stack = await simAws.cloudFormation().deployTemplate({
 await stack.waitForDeployComplete();
 await simAws.backgroundTasksComplete();
 
-console.log(stack.outputs.get("Service")?.value);
+console.log(stack.output("Service"));
 // "arn:aws:ecs:us-east-1:888888888888:service/orders/orders-worker"
-console.log(stack.outputs.get("ServiceName")?.value); // "orders-worker"
+console.log(stack.output("ServiceName")); // "orders-worker"
 
 const service = simAws.ecs().service("orders-worker", "orders");
 

--- a/docs/services/ecs/sim-ecs-cloudformation-service.example.ts
+++ b/docs/services/ecs/sim-ecs-cloudformation-service.example.ts
@@ -57,9 +57,9 @@ const stack = await simAws.cloudFormation().deployTemplate({
 await stack.waitForDeployComplete();
 await simAws.backgroundTasksComplete();
 
-console.log(stack.outputs.get("Service")?.value);
+console.log(stack.output("Service"));
 // "arn:aws:ecs:us-east-1:888888888888:service/orders/orders-worker"
-console.log(stack.outputs.get("ServiceName")?.value); // "orders-worker"
+console.log(stack.output("ServiceName")); // "orders-worker"
 
 const service = simAws.ecs().service("orders-worker", "orders");
 

--- a/docs/services/ecs/sim-ecs-cloudformation-task-definition.example.ts
+++ b/docs/services/ecs/sim-ecs-cloudformation-task-definition.example.ts
@@ -55,7 +55,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
 
 await stack.waitForDeployComplete();
 
-console.log(stack.outputs.get("TaskDefinition")?.value);
+console.log(stack.output("TaskDefinition"));
 // "arn:aws:ecs:us-east-1:888888888888:task-definition/orders-worker:1"
 
 // Running a task from the deployed task definition runs the bound handler.

--- a/docs/services/elbv2/README.md
+++ b/docs/services/elbv2/README.md
@@ -1528,10 +1528,10 @@ const stack = await simAws.cloudFormation().deployTemplate({
 await stack.waitForDeployComplete();
 await simAws.backgroundTasksComplete();
 
-const dnsName = stack.outputs.get("DnsName")?.value as string;
+const dnsName = stack.output("DnsName");
 
 console.log(dnsName); // "shop-alb-0000000001.us-east-1.elb.amazonaws.com"
-console.log(stack.outputs.get("FullName")?.value);
+console.log(stack.output("FullName"));
 // "app/shop-alb/0000000001"
 
 const claimed = await simElbV2Fetch(simAws, `http://${dnsName}/checkout/42`);
@@ -1623,7 +1623,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
 await stack.waitForDeployComplete();
 await simAws.backgroundTasksComplete();
 
-const listenerArn = stack.outputs.get("ListenerArn")?.value as string;
+const listenerArn = stack.output("ListenerArn");
 
 const described = await simAws
   .elbV2()

--- a/docs/services/elbv2/sim-elbv2-cloudformation-certificate.example.ts
+++ b/docs/services/elbv2/sim-elbv2-cloudformation-certificate.example.ts
@@ -70,7 +70,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
 await stack.waitForDeployComplete();
 await simAws.backgroundTasksComplete();
 
-const listenerArn = stack.outputs.get("ListenerArn")?.value as string;
+const listenerArn = stack.output("ListenerArn");
 
 const described = await simAws
   .elbV2()

--- a/docs/services/elbv2/sim-elbv2-cloudformation.example.ts
+++ b/docs/services/elbv2/sim-elbv2-cloudformation.example.ts
@@ -100,10 +100,10 @@ const stack = await simAws.cloudFormation().deployTemplate({
 await stack.waitForDeployComplete();
 await simAws.backgroundTasksComplete();
 
-const dnsName = stack.outputs.get("DnsName")?.value as string;
+const dnsName = stack.output("DnsName");
 
 console.log(dnsName); // "shop-alb-0000000001.us-east-1.elb.amazonaws.com"
-console.log(stack.outputs.get("FullName")?.value);
+console.log(stack.output("FullName"));
 // "app/shop-alb/0000000001"
 
 const claimed = await simElbV2Fetch(simAws, `http://${dnsName}/checkout/42`);

--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -745,8 +745,8 @@ const stack = await simAws.cloudFormation().deployTemplate({
 
 await stack.waitForDeployComplete();
 
-console.log(stack.outputs.get("RoleArn")?.value);
-console.log(stack.outputs.get("PolicyArn")?.value);
+console.log(stack.output("RoleArn"));
+console.log(stack.output("PolicyArn"));
 
 const roleOut = await simAws.iam().getRole(
   new GetRoleCommand({

--- a/docs/services/iam/sim-iam-cloudformation.example.ts
+++ b/docs/services/iam/sim-iam-cloudformation.example.ts
@@ -71,8 +71,8 @@ const stack = await simAws.cloudFormation().deployTemplate({
 
 await stack.waitForDeployComplete();
 
-console.log(stack.outputs.get("RoleArn")?.value);
-console.log(stack.outputs.get("PolicyArn")?.value);
+console.log(stack.output("RoleArn"));
+console.log(stack.output("PolicyArn"));
 
 const roleOut = await simAws.iam().getRole(
   new GetRoleCommand({

--- a/docs/services/kms/README.md
+++ b/docs/services/kms/README.md
@@ -569,7 +569,7 @@ const decrypted = await kms.decrypt(
 );
 
 console.log(Buffer.from(decrypted.Plaintext ?? []).toString("utf8")); // "hunter2"
-console.log(stack.outputs.get("KeyArn")?.value); // "arn:aws:kms:...:key/..."
+console.log(stack.output("KeyArn")); // "arn:aws:kms:...:key/..."
 ```
 
 A property asking for behaviour Yulin leaves out still deploys. The key is created without it, and

--- a/docs/services/kms/sim-kms-cloudformation-key.example.ts
+++ b/docs/services/kms/sim-kms-cloudformation-key.example.ts
@@ -46,4 +46,4 @@ const decrypted = await kms.decrypt(
 );
 
 console.log(Buffer.from(decrypted.Plaintext ?? []).toString("utf8")); // "hunter2"
-console.log(stack.outputs.get("KeyArn")?.value); // "arn:aws:kms:...:key/..."
+console.log(stack.output("KeyArn")); // "arn:aws:kms:...:key/..."

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -1968,8 +1968,8 @@ const stack = await simAws.cloudFormation().deployTemplate({
 });
 await stack.waitForDeployComplete();
 
-console.log(stack.outputs.get("FunctionName")?.value);
-console.log(stack.outputs.get("FunctionArn")?.value);
+console.log(stack.output("FunctionName"));
+console.log(stack.output("FunctionArn"));
 
 const output = await simAws.lambda().invoke(
   new InvokeCommand({
@@ -2193,7 +2193,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
 });
 await stack.waitForDeployComplete();
 
-const functionUrl = stack.outputs.get("GreeterFunctionUrl")?.value as string;
+const functionUrl = stack.output("GreeterFunctionUrl");
 const srv = await serveSimAws({ simAws });
 
 try {

--- a/docs/services/lambda/sim-lambda-cloudformation-function-url.example.ts
+++ b/docs/services/lambda/sim-lambda-cloudformation-function-url.example.ts
@@ -58,7 +58,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
 });
 await stack.waitForDeployComplete();
 
-const functionUrl = stack.outputs.get("GreeterFunctionUrl")?.value as string;
+const functionUrl = stack.output("GreeterFunctionUrl");
 const srv = await serveSimAws({ simAws });
 
 try {

--- a/docs/services/lambda/sim-lambda-cloudformation-function.example.ts
+++ b/docs/services/lambda/sim-lambda-cloudformation-function.example.ts
@@ -60,8 +60,8 @@ const stack = await simAws.cloudFormation().deployTemplate({
 });
 await stack.waitForDeployComplete();
 
-console.log(stack.outputs.get("FunctionName")?.value);
-console.log(stack.outputs.get("FunctionArn")?.value);
+console.log(stack.output("FunctionName"));
+console.log(stack.output("FunctionArn"));
 
 const output = await simAws.lambda().invoke(
   new InvokeCommand({

--- a/docs/services/route53/README.md
+++ b/docs/services/route53/README.md
@@ -1199,7 +1199,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
 });
 await stack.waitForDeployComplete();
 
-const hostedZoneId = stack.outputs.get("ZoneId")?.value;
+const hostedZoneId = stack.output("ZoneId");
 
 if (typeof hostedZoneId !== "string") {
   throw new TypeError("The stack did not output a hosted zone ID");
@@ -1264,7 +1264,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
 
 await stack.waitForDeployComplete();
 
-console.log(stack.outputs.get("HostedZoneId")?.value);
+console.log(stack.output("HostedZoneId"));
 console.log(stack.outputs.get("HostedZoneNameServers")?.value);
 ```
 

--- a/docs/services/route53/sim-route53-cloudformation-dnssec.example.ts
+++ b/docs/services/route53/sim-route53-cloudformation-dnssec.example.ts
@@ -45,7 +45,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
 });
 await stack.waitForDeployComplete();
 
-const hostedZoneId = stack.outputs.get("ZoneId")?.value;
+const hostedZoneId = stack.output("ZoneId");
 
 if (typeof hostedZoneId !== "string") {
   throw new TypeError("The stack did not output a hosted zone ID");

--- a/docs/services/route53/sim-route53-cloudformation-hosted-zone.example.ts
+++ b/docs/services/route53/sim-route53-cloudformation-hosted-zone.example.ts
@@ -37,5 +37,5 @@ const stack = await simAws.cloudFormation().deployTemplate({
 
 await stack.waitForDeployComplete();
 
-console.log(stack.outputs.get("HostedZoneId")?.value);
+console.log(stack.output("HostedZoneId"));
 console.log(stack.outputs.get("HostedZoneNameServers")?.value);

--- a/docs/services/secretsmanager/README.md
+++ b/docs/services/secretsmanager/README.md
@@ -420,7 +420,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
 await stack.waitForDeployComplete();
 
 // Ref resolves to the ARN including its suffix, so it works as a SecretId.
-const secretArn = stack.outputs.get("DbSecretArn")?.value as string;
+const secretArn = stack.output("DbSecretArn");
 
 const read = await simAws
   .secretsManager()

--- a/docs/services/secretsmanager/sim-secrets-manager-cloudformation-secret.example.ts
+++ b/docs/services/secretsmanager/sim-secrets-manager-cloudformation-secret.example.ts
@@ -38,7 +38,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
 await stack.waitForDeployComplete();
 
 // Ref resolves to the ARN including its suffix, so it works as a SecretId.
-const secretArn = stack.outputs.get("DbSecretArn")?.value as string;
+const secretArn = stack.output("DbSecretArn");
 
 const read = await simAws
   .secretsManager()

--- a/docs/services/sns/README.md
+++ b/docs/services/sns/README.md
@@ -1582,7 +1582,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
 });
 
 // Ref on a topic resolves to its ARN, so it works as a Publish TopicArn.
-const topicArn = stack.outputs.get("OrdersTopicArn")?.value as string;
+const topicArn = stack.output("OrdersTopicArn");
 
 await simAws
   .sns()
@@ -1591,7 +1591,7 @@ await simAws
 // Delivery happens after the publish is answered, as it does on real SNS.
 await simAws.backgroundTasksComplete();
 
-const QueueUrl = stack.outputs.get("FulfilmentQueueUrl")?.value as string;
+const QueueUrl = stack.output("FulfilmentQueueUrl");
 const { Messages } = await simAws
   .sqs()
   .receiveMessage(new ReceiveMessageCommand({ QueueUrl }));

--- a/docs/services/sns/sim-sns-cloudformation-topic.example.ts
+++ b/docs/services/sns/sim-sns-cloudformation-topic.example.ts
@@ -61,7 +61,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
 });
 
 // Ref on a topic resolves to its ARN, so it works as a Publish TopicArn.
-const topicArn = stack.outputs.get("OrdersTopicArn")?.value as string;
+const topicArn = stack.output("OrdersTopicArn");
 
 await simAws
   .sns()
@@ -70,7 +70,7 @@ await simAws
 // Delivery happens after the publish is answered, as it does on real SNS.
 await simAws.backgroundTasksComplete();
 
-const QueueUrl = stack.outputs.get("FulfilmentQueueUrl")?.value as string;
+const QueueUrl = stack.output("FulfilmentQueueUrl");
 const { Messages } = await simAws
   .sqs()
   .receiveMessage(new ReceiveMessageCommand({ QueueUrl }));

--- a/docs/services/sqs/README.md
+++ b/docs/services/sqs/README.md
@@ -1036,7 +1036,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
 await stack.waitForDeployComplete();
 
 // Ref resolves to the queue URL, so it works as a SendMessage QueueUrl.
-const queueUrl = stack.outputs.get("OrdersQueueUrl")?.value as string;
+const queueUrl = stack.output("OrdersQueueUrl");
 
 await simAws
   .sqs()
@@ -1044,7 +1044,7 @@ await simAws
     new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
   );
 
-console.log(stack.outputs.get("OrdersQueueArn")?.value);
+console.log(stack.output("OrdersQueueArn"));
 // "arn:aws:sqs:us-east-1:888888888888:orders"
 ```
 

--- a/docs/services/sqs/sim-sqs-cloudformation-queue.example.ts
+++ b/docs/services/sqs/sim-sqs-cloudformation-queue.example.ts
@@ -35,7 +35,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
 await stack.waitForDeployComplete();
 
 // Ref resolves to the queue URL, so it works as a SendMessage QueueUrl.
-const queueUrl = stack.outputs.get("OrdersQueueUrl")?.value as string;
+const queueUrl = stack.output("OrdersQueueUrl");
 
 await simAws
   .sqs()
@@ -43,5 +43,5 @@ await simAws
     new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
   );
 
-console.log(stack.outputs.get("OrdersQueueArn")?.value);
+console.log(stack.output("OrdersQueueArn"));
 // "arn:aws:sqs:us-east-1:888888888888:orders"

--- a/docs/services/ssm/README.md
+++ b/docs/services/ssm/README.md
@@ -351,7 +351,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
 await stack.waitForDeployComplete();
 
 // Ref resolves to the parameter name, so it works as a GetParameter Name.
-const parameterName = stack.outputs.get("DbHostParameter")?.value as string;
+const parameterName = stack.output("DbHostParameter");
 
 const read = await simAws
   .ssm()

--- a/docs/services/ssm/sim-ssm-cloudformation-parameter.example.ts
+++ b/docs/services/ssm/sim-ssm-cloudformation-parameter.example.ts
@@ -33,7 +33,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
 await stack.waitForDeployComplete();
 
 // Ref resolves to the parameter name, so it works as a GetParameter Name.
-const parameterName = stack.outputs.get("DbHostParameter")?.value as string;
+const parameterName = stack.output("DbHostParameter");
 
 const read = await simAws
   .ssm()

--- a/src/service/cloudformation/stack/output/sim-cfn-stack-output-lookup.ts
+++ b/src/service/cloudformation/stack/output/sim-cfn-stack-output-lookup.ts
@@ -1,0 +1,81 @@
+import type { SimCfnTemplateValue } from "../../template/value/sim-cfn-template-value.js";
+import type { SimCloudFormationStackName } from "../sim-cfn-stack.type.js";
+import type { SimCfnStackOutput } from "./sim-cfn-stack-output.js";
+
+interface SimCfnStackOutputLookupProperties {
+  readonly stackName: SimCloudFormationStackName;
+  readonly outputs: ReadonlyMap<string, SimCfnStackOutput>;
+}
+
+/**
+ * Reads one Stack Output as the string CloudFormation answers with.
+ *
+ * DescribeStacks types an OutputValue as a string, and a template's Output
+ * Value is a string field. A resolved Output holding anything else came from a
+ * template CloudFormation would itself refuse, and both that and an Output the
+ * template never declared are reported here. The Stack then answers one string
+ * per Output, and each caller is spared writing the same narrowing and the same
+ * failure message for itself.
+ */
+export class SimCfnStackOutputLookup {
+  private readonly stackName: SimCloudFormationStackName;
+  private readonly outputs: ReadonlyMap<string, SimCfnStackOutput>;
+
+  constructor(properties: SimCfnStackOutputLookupProperties) {
+    this.stackName = properties.stackName;
+    this.outputs = properties.outputs;
+  }
+
+  /**
+   * The string this Output resolved to.
+   *
+   * Throws where the template declares no such Output, and where the Output
+   * resolved to something a CloudFormation Output cannot hold.
+   */
+  value(outputKey: string): string {
+    const output = this.outputs.get(outputKey);
+
+    if (output === undefined) {
+      throw new TypeError(
+        `Sim CloudFormation Stack ${this.stackName} has no Output ${outputKey}. ` +
+          `It declares ${this.declaredOutputs()}.`,
+      );
+    }
+
+    if (typeof output.value !== "string") {
+      throw new TypeError(
+        `Sim CloudFormation Stack ${this.stackName} Output ${outputKey} resolved to ` +
+          `${describeValue(output.value)}. A CloudFormation Output is a string.`,
+      );
+    }
+
+    return output.value;
+  }
+
+  private declaredOutputs(): string {
+    const outputKeys = this.outputs.keys().toArray();
+
+    if (outputKeys.length === 0) {
+      return "no Outputs";
+    }
+
+    return outputKeys.join(", ");
+  }
+}
+
+/** What a resolved Output turned out to hold, for a failure to report. */
+function describeValue(value: SimCfnTemplateValue): string {
+  if (value === null) {
+    return "null";
+  }
+
+  if (Array.isArray(value)) {
+    return `a list (${JSON.stringify(value)})`;
+  }
+
+  if (typeof value === "object") {
+    return `a record (${JSON.stringify(value)})`;
+  }
+
+  return `a ${typeof value} (${JSON.stringify(value)})`;
+}

--- a/src/service/cloudformation/stack/output/sim-cfn-stack-output.iso.test.ts
+++ b/src/service/cloudformation/stack/output/sim-cfn-stack-output.iso.test.ts
@@ -1,0 +1,188 @@
+import { describe, it } from "vitest";
+
+/* oxlint-disable no-template-curly-in-string */
+import { assertIdentical, assertThrowsError } from "@kensio/smartass";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCfnStack } from "../sim-cfn-stack.js";
+import type { CfnTemplateBodyRecord } from "../../template/sim-cfn-template.js";
+import type { SimCfnTemplateValue } from "../../template/value/sim-cfn-template-value.js";
+import { SimCfnTemplate } from "../../template/sim-cfn-template.js";
+
+const stackName = "OutputAccessorStack";
+
+/** The `Outputs` section a test declares, by Output key. */
+type OutputTemplates = Record<string, SimCfnTemplateValue>;
+
+describe("reading one sim CloudFormation Stack Output", () => {
+  it("answers the Output as a string", async () => {
+    // Given a deployed Stack that declares an Output for its Bucket name
+    const stack = await deployedStack({
+      SiteBucketName: { Value: { Ref: "SiteBucket" } },
+    });
+
+    // When the Output is read by name
+    const bucketName: string = stack.output("SiteBucketName");
+
+    // Then it is the resolved value, already a string
+    assertIdentical(bucketName, "output-accessor-bucket");
+  });
+
+  it("answers an Output resolved through an intrinsic function", async () => {
+    // Given a deployed Stack whose Output resolves through Fn::Sub
+    const stack = await deployedStack({
+      BucketSummary: { Value: { "Fn::Sub": "bucket ${SiteBucket}" } },
+    });
+
+    // Then the accessor answers what the intrinsic resolved to
+    assertIdentical(
+      stack.output("BucketSummary"),
+      "bucket output-accessor-bucket",
+    );
+  });
+
+  it("answers the value the Stack holds after an update", async () => {
+    // Given a deployed Stack holding one Output value
+    const stack = await deployedStack({
+      SiteBucketName: { Value: "before-the-update" },
+    });
+
+    // When an update resolves that Output to something else
+    await stack.update(
+      new SimCfnTemplate({
+        stackName,
+        template: templateBody({
+          SiteBucketName: { Value: "after-the-update" },
+        }),
+      }),
+    );
+    await stack.waitForUpdateComplete();
+
+    // Then the accessor answers the value the update left behind
+    assertIdentical(stack.output("SiteBucketName"), "after-the-update");
+  });
+
+  it("reports the Stack and the Output the template never declared", async () => {
+    // Given a deployed Stack declaring one Output
+    const stack = await deployedStack({
+      SiteBucketName: { Value: { Ref: "SiteBucket" } },
+    });
+
+    // When another Output is asked for
+    const error = assertThrowsError(() => stack.output("SiteBucketArn"));
+
+    // Then the failure names the Stack, the Output, and what is there instead
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Stack OutputAccessorStack has no Output SiteBucketArn. " +
+        "It declares SiteBucketName.",
+    );
+  });
+
+  it("reports a Stack that declares no Outputs at all", async () => {
+    // Given a deployed Stack with no Outputs section
+    const stack = await deployedStack(undefined);
+
+    // When an Output is asked for
+    const error = assertThrowsError(() => stack.output("SiteBucketName"));
+
+    // Then the failure says the Stack declares none
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Stack OutputAccessorStack has no Output SiteBucketName. " +
+        "It declares no Outputs.",
+    );
+  });
+
+  it("reports an Output that resolved to a number", async () => {
+    // Given a Stack whose template puts a number where a string belongs
+    const stack = await deployedStack({ SitePort: { Value: 8080 } });
+
+    // When that Output is read as a string
+    const error = assertThrowsError(() => stack.output("SitePort"));
+
+    // Then the failure names the type it found and the value it held
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Stack OutputAccessorStack Output SitePort resolved to " +
+        "a number (8080). A CloudFormation Output is a string.",
+    );
+  });
+
+  it("reports an Output that resolved to a list", async () => {
+    // Given a Stack whose Output holds a list
+    const stack = await deployedStack({
+      SiteHosts: { Value: ["one.example.com", "two.example.com"] },
+    });
+
+    // When that Output is read as a string
+    const error = assertThrowsError(() => stack.output("SiteHosts"));
+
+    // Then the failure reports the list it found
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Stack OutputAccessorStack Output SiteHosts resolved to " +
+        'a list (["one.example.com","two.example.com"]). ' +
+        "A CloudFormation Output is a string.",
+    );
+  });
+
+  it("reports an Output that resolved to a record", async () => {
+    // Given a Stack whose Output holds a record
+    const stack = await deployedStack({
+      SiteTags: { Value: { Owner: "platform" } },
+    });
+
+    // When that Output is read as a string
+    const error = assertThrowsError(() => stack.output("SiteTags"));
+
+    // Then the failure reports the record it found
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Stack OutputAccessorStack Output SiteTags resolved to " +
+        'a record ({"Owner":"platform"}). A CloudFormation Output is a string.',
+    );
+  });
+
+  it("reports an Output that resolved to null", async () => {
+    // Given a Stack whose Output holds null
+    const stack = await deployedStack({ SiteOwner: { Value: null } });
+
+    // When that Output is read as a string
+    const error = assertThrowsError(() => stack.output("SiteOwner"));
+
+    // Then the failure reports the null it found
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Stack OutputAccessorStack Output SiteOwner resolved to " +
+        "null. A CloudFormation Output is a string.",
+    );
+  });
+});
+
+/** The template body a test deploys, with whatever Outputs it declares. */
+function templateBody(
+  outputs: OutputTemplates | undefined,
+): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      SiteBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: "output-accessor-bucket" },
+      },
+    },
+    ...(outputs !== undefined && { Outputs: outputs }),
+  };
+}
+
+/** A deployed Stack holding one Bucket and the Outputs a test declares. */
+async function deployedStack(
+  outputs: OutputTemplates | undefined,
+): Promise<SimCfnStack> {
+  const stack = await new SimAws()
+    .cloudFormation()
+    .deployTemplate({ stackName, template: templateBody(outputs) });
+
+  await stack.waitForDeployComplete();
+
+  return stack;
+}

--- a/src/service/cloudformation/stack/sim-cfn-stack.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack.ts
@@ -16,6 +16,7 @@ import { SimCfnStackResourceOperations } from "./sim-cfn-stack-resource-operatio
 import { SimCfnStackUpdateLifecycle } from "./update/sim-cfn-stack-update-lifecycle.js";
 import type { SimCfnStackOutput } from "./output/sim-cfn-stack-output.js";
 import { SimCfnStackOutputResolver } from "./output/sim-cfn-stack-output-resolver.js";
+import { SimCfnStackOutputLookup } from "./output/sim-cfn-stack-output-lookup.js";
 import { SimCfnStackResourceReport } from "./report/sim-cfn-stack-resource-report.js";
 import { SimCfnStackOperationStatus } from "./status/sim-cfn-stack-operation-status.js";
 import { validateSimCfnExecutableResourceBindings } from "../bind/validate/sim-cfn-exec-binding-validator.js";
@@ -226,6 +227,24 @@ export class SimCfnStack {
    */
   getResource(logicalId: string): SimCfnResource | undefined {
     return new SimCfnStackResourceLookup(this.resources).find(logicalId);
+  }
+
+  /**
+   * Get one Stack Output's resolved value, as the string it is.
+   *
+   * The `outputs` map holds every resolved Output whole, including its
+   * description and its export name, typed as the union a parsed template can
+   * hold. A caller after the value alone wants the string CloudFormation would
+   * have answered with, and this hands it over already narrowed.
+   *
+   * An Output the template never declared throws, as does one that resolved to
+   * something other than a string.
+   */
+  output(outputKey: string): string {
+    return new SimCfnStackOutputLookup({
+      stackName: this.stackName,
+      outputs: this.outputs,
+    }).value(outputKey);
   }
 
   /** Resources skipped because their sim implementation is not available. */


### PR DESCRIPTION
Every caller that read a Stack Output narrowed it for itself, and the cast appeared 38 times in Yulin's own documentation. `SimCfnStack.output(key)` now answers one Output as the string CloudFormation answers with, throwing where the template declares no such Output and where the Output resolved to something else. The `outputs` map is unchanged, and is still where the description, the export name and the values that are not strings live, including `Fn::GetAtt` on a Hosted Zone's `NameServers`.

Resolves #702