### PR TITLE
feat: refuse a missing template file

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -1037,6 +1037,10 @@ await stack.waitForDeployComplete();
 This is useful for local integration tests where you want CDK to produce the template, then Yulin to
 create the simulated resources from that synthesized output template.
 
+A template path with no file at it is refused with
+`No Sim CloudFormation template file at <path>`, naming the resolved path. A synthesized template
+is build output, and a checkout that has yet to synthesize one meets this on the first run.
+
 ## Editing a synthesized template before deploying it
 
 Sometimes a synthesized template needs a change before Yulin will deploy it, such as dropping a

--- a/src/service/cloudformation/deploy/sim-cfn-template-file-loader.iso.test.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-template-file-loader.iso.test.ts
@@ -243,6 +243,46 @@ describe("SimCfnTemplateFileLoader", () => {
     );
   });
 
+  it("refuses a template path with no file at it, naming the path", async () => {
+    // Given a directory with no synthesized template in it, as a checkout that
+    // has yet to synthesize one has.
+    const temporaryDirectory = new TemporaryDirectory();
+    await temporaryDirectory.resolvePath();
+    const templatePath = temporaryDirectory.join("MissingStack.template.json");
+
+    // When the template file is loaded.
+    const fileLoader = new SimCfnTemplateFileLoader();
+    const error = await assertThrowsErrorAsync(async () => {
+      await fileLoader.load(templatePath);
+    });
+
+    // Then the refusal names the resolved path and what was expected there,
+    // keeping the filesystem error that found it missing.
+    assertIdentical(
+      error.message,
+      `No Sim CloudFormation template file at ${path.resolve(templatePath)}`,
+    );
+    assertIdentical((error.cause as NodeJS.ErrnoException).code, "ENOENT");
+  });
+
+  it("reports the parse failure for a template file holding invalid JSON", async () => {
+    // Given a template file that is there and holds something other than JSON.
+    const temporaryDirectory = new TemporaryDirectory();
+    const templatePath = "BrokenStack.template.json";
+
+    await temporaryDirectory.writeFile(templatePath, "{ Resources: ");
+
+    // When the template file is loaded.
+    const fileLoader = new SimCfnTemplateFileLoader();
+    const error = await assertThrowsErrorAsync(async () => {
+      await fileLoader.load(temporaryDirectory.join(templatePath));
+    });
+
+    // Then the parse failure is what comes back, leaving the missing-file
+    // refusal for a path with no file at it.
+    assertStringIncludes(error.message, "JSON");
+  });
+
   it("loads a non-CDK template filename without requiring an assets manifest", async () => {
     // Given a template file whose name does not follow the CDK template naming convention.
     const temporaryDirectory = new TemporaryDirectory();

--- a/src/service/cloudformation/deploy/sim-cfn-template-file-loader.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-template-file-loader.ts
@@ -1,8 +1,7 @@
-import { readFile } from "node:fs/promises";
 import path from "node:path";
 import type { SimCloudFormationStackName } from "../stack/sim-cfn-stack.js";
 import type { CfnTemplateBodyRecord } from "../template/sim-cfn-template.js";
-import { jsonParse, type JSONString } from "../../../util/type-guard/json.js";
+import { jsonParse } from "../../../util/type-guard/json.js";
 import {
   loadSiblingCdkAssetsManifest,
   type SimCdkOutContext,
@@ -15,6 +14,7 @@ import {
   transformedTemplate,
   type SimCfnTemplateFileTransform,
 } from "./sim-cfn-template-file-transform.js";
+import { readTemplateFile } from "./sim-cfn-template-file-read.js";
 
 export interface SimCloudFormationDeployTemplateFileProperties {
   readonly templatePath: string;
@@ -82,10 +82,8 @@ export class SimCfnTemplateFileLoader {
     // watch mode.
     simWatch.reportPath(templatePath);
 
-    // oxlint-disable-next-line security/detect-non-literal-fs-filename
-    const templateBody = await readFile(templatePath, "utf8");
     const template = transformedTemplate(
-      jsonParse(templateBody as JSONString<CfnTemplateBodyRecord>),
+      jsonParse(await readTemplateFile(templatePath)),
       deployment.transform,
     );
     // Read from the path rather than the template, so what a transform did to

--- a/src/service/cloudformation/deploy/sim-cfn-template-file-read.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-template-file-read.ts
@@ -1,0 +1,38 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import type { JSONString } from "../../../util/type-guard/json.js";
+import type { CfnTemplateBodyRecord } from "../template/sim-cfn-template.js";
+
+/**
+ * Read the synthesized template file a deployment names.
+ *
+ * A path with no file at it is refused by naming the resolved path and what
+ * was expected there. A template under `cdk.out` is build output that a fresh
+ * checkout has yet to write, and the filesystem error for it says only that
+ * the path failed to open, which is what leaves callers writing their own
+ * guard in front of the deployment.
+ */
+export async function readTemplateFile(
+  templatePath: string,
+): Promise<JSONString<CfnTemplateBodyRecord>> {
+  try {
+    // oxlint-disable-next-line security/detect-non-literal-fs-filename
+    const templateBody = await readFile(templatePath, "utf8");
+
+    return templateBody as JSONString<CfnTemplateBodyRecord>;
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      throw new Error(
+        `No Sim CloudFormation template file at ${path.resolve(templatePath)}`,
+        { cause: error },
+      );
+    }
+
+    /* v8 ignore next */
+    throw error;
+  }
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}

--- a/src/service/cloudformation/deploy/sim-cfn-template-file-updater.iso.test.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-template-file-updater.iso.test.ts
@@ -1,7 +1,9 @@
+import { rm } from "node:fs/promises";
 import { buffer } from "node:stream/consumers";
 import {
   assertIdentical,
   assertNonNullable,
+  assertStringIncludes,
   assertThrowsErrorAsync,
   assertUndefined,
 } from "@kensio/smartass";
@@ -67,6 +69,39 @@ describe("updating a Stack from its template file", () => {
       await simAws.cloudFormation().updateTemplateFile(templatePath);
     });
     assertIdentical(error.message, "No updates are to be performed.");
+  });
+
+  it("refuses a template file that has been deleted, leaving the Resources serving", async () => {
+    // Given a Stack deployed from a template file, holding an Object
+    const { simAws, templatePath } = await deployedFrom({
+      Resources: { Site: bucketResource("site-content") },
+    });
+
+    await simAws.s3().putObject({
+      input: {
+        Bucket: "site-content",
+        Key: "index.html",
+        Body: "<h1>Hello</h1>",
+      },
+    });
+
+    // When the template file goes away, as a cleaned `cdk.out` takes it
+    await rm(templatePath);
+
+    // Then the update is refused by naming the path
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().updateTemplateFile(templatePath);
+    });
+    assertStringIncludes(
+      error.message,
+      "No Sim CloudFormation template file at",
+    );
+
+    // And the Resources the last template deployed carry on serving
+    assertIdentical(
+      await objectBody(simAws, "site-content", "index.html"),
+      "<h1>Hello</h1>",
+    );
   });
 
   it("reads the assets manifest the template was synthesized with", async () => {


### PR DESCRIPTION
Brief, concise description of the change:

Deploying a template path with no file at it failed with the raw Node filesystem error, which named the path and left the reader to work out what Yulin wanted there. Consumers covered it themselves, with an `existsSync` guard in front of the deployment. `readTemplateFile` now maps `ENOENT` to `No Sim CloudFormation template file at <resolved path>`, keeping the filesystem error as its `cause`, and every other error goes through untouched. Both the deployment and the watched re-read go through `SimCfnTemplateFileLoader.load()`, and a template deleted while watched reports the same refusal and leaves the deployed Resources serving.

The message names the path and stops there. Yulin takes any template path, and a message naming `cdk synth` would tie it to one way of producing a template, which the issue raised as the open question.

Resolves https://github.com/KensioSoftware/yulin/issues/699

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [ ] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`
