### PR TITLE
feat: resolve Fn::ImportValue between Stacks

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -853,6 +853,74 @@ but a list all fail the deployment, as they are all templates AWS rejects. The e
 resource and the property path the value sat at, for example
 `Sim CloudFormation Resource LogsBucket value at Properties.BucketName`.
 
+### `Fn::ImportValue`
+
+`Fn::ImportValue` reads a value another Stack exported. A Stack exports one by giving an Output an
+`Export.Name`, and a Stack in the same Account and Region imports it by that name.
+
+CDK writes both halves on its own. Referencing a resource in another Stack of the same app puts an
+`Export` on the producer and an `Fn::ImportValue` on the consumer, with no opt-in.
+
+```typescript sim-cloudformation-fn-import-value
+/**
+ * Sharing a value between two simulated CloudFormation Stacks.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const cloudFormation = simAws.cloudFormation();
+
+await cloudFormation.deployTemplate({
+  stackName: "producer-stack",
+  template: {
+    Resources: {
+      Uploads: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: "shared-uploads" },
+      },
+    },
+    Outputs: {
+      UploadsBucket: {
+        Value: { Ref: "Uploads" },
+        Export: { Name: "producer-stack:UploadsBucket" },
+      },
+    },
+  },
+});
+
+const consumer = await cloudFormation.deployTemplate({
+  stackName: "consumer-stack",
+  template: {
+    Resources: {
+      UploadsTopic: {
+        Type: "AWS::SNS::Topic",
+        Properties: {
+          TopicName: "uploads-topic",
+          DisplayName: { "Fn::ImportValue": "producer-stack:UploadsBucket" },
+        },
+      },
+    },
+  },
+});
+
+await consumer.waitForDeployComplete();
+
+// shared-uploads, read from the export the producer Stack published
+console.log(consumer.resources.get("UploadsTopic")?.properties["DisplayName"]);
+```
+
+Deploy the producer first. An export is published once the producer's Outputs have resolved, which
+happens after its Resources have been created. A consumer deployed ahead of its producer has
+nothing to import.
+
+An import naming an export no Stack has published fails with `No export named <name> found`, the
+way CloudFormation refuses one. A Stack exporting a name another Stack already holds fails to
+deploy. A deleted Stack releases its export names, leaving them free for the next Stack.
+
+Exports are scoped per Account and Region, as they are on AWS. A Stack in one Region reads only the
+exports published in that Region.
+
 ## Conditions
 
 A template `Conditions` section names boolean expressions over the stack's parameter values. A

--- a/docs/services/cloudformation/sim-cloudformation-fn-import-value.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-fn-import-value.example.ts
@@ -1,0 +1,46 @@
+/**
+ * Sharing a value between two simulated CloudFormation Stacks.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const cloudFormation = simAws.cloudFormation();
+
+await cloudFormation.deployTemplate({
+  stackName: "producer-stack",
+  template: {
+    Resources: {
+      Uploads: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: "shared-uploads" },
+      },
+    },
+    Outputs: {
+      UploadsBucket: {
+        Value: { Ref: "Uploads" },
+        Export: { Name: "producer-stack:UploadsBucket" },
+      },
+    },
+  },
+});
+
+const consumer = await cloudFormation.deployTemplate({
+  stackName: "consumer-stack",
+  template: {
+    Resources: {
+      UploadsTopic: {
+        Type: "AWS::SNS::Topic",
+        Properties: {
+          TopicName: "uploads-topic",
+          DisplayName: { "Fn::ImportValue": "producer-stack:UploadsBucket" },
+        },
+      },
+    },
+  },
+});
+
+await consumer.waitForDeployComplete();
+
+// shared-uploads, read from the export the producer Stack published
+console.log(consumer.resources.get("UploadsTopic")?.properties["DisplayName"]);

--- a/src/service/cloudformation/README.md
+++ b/src/service/cloudformation/README.md
@@ -28,6 +28,8 @@ familiar CloudFormation/CDK outputs.
   template files.
 - `template/` contains template body validation, template value parsing, intrinsic-function nodes,
   condition evaluation, and value resolution.
+- `export/` contains the export names published in one Account and Region. An `Fn::ImportValue`
+  reads them.
 - `parameters/` contains parameter input/default handling.
 - `resource/` contains the runtime CloudFormation resource model, resource type parsing, dependency
   extraction, property resolution, and service factory resolution.
@@ -261,6 +263,7 @@ Supported intrinsic-function areas currently include:
 - `Fn::If`
 - `Fn::Split`
 - `Fn::Select`
+- `Fn::ImportValue`
 
 Resolution happens in two phases:
 
@@ -287,6 +290,22 @@ resource template, which also keeps the logical ID visible to implicit dependenc
 
 Most intrinsic functions resolve to a string. `Fn::Split` resolves to a list, and `Fn::Select`
 resolves to whatever the list entry it picks holds, which may be a list or an object.
+
+### Exports and Fn::ImportValue
+
+A `SimCloudFormation` holds one `SimCfnExports`. Exports are therefore scoped per Account and
+Region, the way CloudFormation scopes them.
+
+A Stack publishes to that registry once its Outputs have resolved, which happens after its
+Resources have been created. An `Fn::ImportValue` reads what is published there.
+
+Deployment order is the constraint a caller works with. Stacks go in one at a time, with a
+producer finishing before a consumer that imports from it starts. An import naming an export no
+Stack has published is refused with `No export named <name> found`. A Stack exporting a name
+another Stack already holds fails to deploy.
+
+A Stack releases its export names when it is torn down. The name is then free for the next Stack
+that wants it.
 
 ### Naming the value that failed
 
@@ -889,6 +908,7 @@ Useful areas:
   - `Fn::If`
   - `Fn::Split`
   - `Fn::Select`
+  - `Fn::ImportValue`
   - literal/list/object node resolution
 
 - `template/condition/*.iso.test.ts`

--- a/src/service/cloudformation/cdk/cross-stack/sim-cdk-cross-stack-export.loc.test.ts
+++ b/src/service/cloudformation/cdk/cross-stack/sim-cdk-cross-stack-export.loc.test.ts
@@ -1,0 +1,72 @@
+import { GetParameterCommand } from "@aws-sdk/client-ssm";
+import { assertIdentical, assertTypeString } from "@kensio/smartass";
+import path from "node:path";
+import { describe, it } from "vitest";
+
+/**
+ * Slower local integration test. Calls the real CDK CLI to synth the output
+ * template files to pass to sim CloudFormation, so the Export and the
+ * Fn::ImportValue under test are the ones CDK actually emits for a value
+ * shared between two Stacks of one app.
+ */
+import { SimAws } from "../../../aws/sim-aws.js";
+import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+
+const accountIdOneOnes = "111111111111";
+
+describe("Sim CDK cross-stack export local integration", () => {
+  it("deploys a consumer Stack that imports a producer Stack's Bucket name", async () => {
+    // Given one CDK app of two Stacks, where the consumer reads a Bucket the
+    // producer owns. Nothing here opts into an export: naming the Bucket from
+    // the other Stack is what makes CDK write one.
+    const cdkProject = new TestCdkProject();
+    await cdkProject.writeCdkAppFile(`
+import * as cdk from "aws-cdk-lib/core";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import * as ssm from "aws-cdk-lib/aws-ssm";
+
+const app = new cdk.App();
+const environment = { account: "111111111111", region: "eu-west-2" };
+
+const producer = new cdk.Stack(app, "ProducerStack", { env: environment });
+const uploads = new s3.Bucket(producer, "Uploads", {
+  bucketName: "cross-stack-uploads",
+});
+
+const consumer = new cdk.Stack(app, "ConsumerStack", { env: environment });
+new ssm.StringParameter(consumer, "UploadsBucketName", {
+  parameterName: "/myapp/uploads-bucket",
+  stringValue: uploads.bucketName,
+});
+
+app.synth();
+    `);
+
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When both synthesized templates are deployed into the same simulated
+    // Account and Region, producer first.
+    const simAws = new SimAws();
+    const scoped = simAws.account(accountIdOneOnes).region("eu-west-2");
+    const cloudFormation = scoped.cloudFormation();
+
+    await cloudFormation.deployTemplateFile(
+      path.join(cdkOutDirectory, "ProducerStack.template.json"),
+    );
+    await cloudFormation.deployTemplateFile(
+      path.join(cdkOutDirectory, "ConsumerStack.template.json"),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the consumer's Parameter holds the Bucket name the producer
+    // exported, resolved through the Fn::ImportValue CDK emitted.
+    const read = await scoped
+      .ssm()
+      .getParameter(new GetParameterCommand({ Name: "/myapp/uploads-bucket" }));
+
+    assertTypeString(read.Parameter?.Value);
+    assertIdentical(read.Parameter.Value, "cross-stack-uploads");
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/service/cloudformation/command/create-stack/create-stack.handler.ts
+++ b/src/service/cloudformation/command/create-stack/create-stack.handler.ts
@@ -23,6 +23,7 @@ import { SimCfnParameters } from "../../parameters/sim-cfn-parameters.js";
 import type { JSONString } from "../../../../util/type-guard/json.js";
 import type { SimCdkOutContext } from "../../cdk/sim-cdk-out-context.js";
 import type { SimCfnDeployBinding } from "../../bind/sim-cfn-deploy-binding.js";
+import type { SimCfnExports } from "../../export/sim-cfn-exports.js";
 
 interface CreateStackCommandHandlerProperties {
   readonly simAws: SimAws;
@@ -31,6 +32,7 @@ interface CreateStackCommandHandlerProperties {
   readonly background: BackgroundScheduler & BackgroundCompleter;
   readonly cdkOutContext?: SimCdkOutContext | undefined;
   readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
+  readonly exports?: SimCfnExports | undefined;
 }
 
 /**
@@ -48,6 +50,7 @@ export class CreateStackCommandHandler implements CommandHandler<
   private readonly background: BackgroundScheduler & BackgroundCompleter;
   private readonly cdkOutContext: SimCdkOutContext | undefined;
   private readonly bindings: readonly SimCfnDeployBinding[] | undefined;
+  private readonly exports: SimCfnExports | undefined;
 
   constructor(properties: CreateStackCommandHandlerProperties) {
     const {
@@ -57,6 +60,7 @@ export class CreateStackCommandHandler implements CommandHandler<
       background,
       cdkOutContext,
       bindings,
+      exports,
     } = properties;
 
     this.simAws = simAws;
@@ -65,6 +69,7 @@ export class CreateStackCommandHandler implements CommandHandler<
     this.background = background;
     this.cdkOutContext = cdkOutContext;
     this.bindings = bindings;
+    this.exports = exports;
   }
 
   /**
@@ -100,6 +105,7 @@ export class CreateStackCommandHandler implements CommandHandler<
           stackName,
         }),
         accountRegionScope: this.accountRegionScope,
+        exports: this.exports,
       },
     );
 
@@ -111,6 +117,7 @@ export class CreateStackCommandHandler implements CommandHandler<
       template,
       cdkOutContext: this.cdkOutContext,
       bindings: this.bindings,
+      exports: this.exports,
     });
 
     this.stacks.set(stack.stackName, stack);

--- a/src/service/cloudformation/command/update-stack/update-stack.handler.ts
+++ b/src/service/cloudformation/command/update-stack/update-stack.handler.ts
@@ -17,6 +17,7 @@ import {
 } from "../../template/sim-cfn-template.js";
 import { SimCfnParameters } from "../../parameters/sim-cfn-parameters.js";
 import { SimCloudFormationValidationError } from "../../error/sim-cloudformation.error.js";
+import type { SimCfnExports } from "../../export/sim-cfn-exports.js";
 import type {
   SimUpdateStackCommand,
   SimUpdateStackCommandOutput,
@@ -32,6 +33,9 @@ interface UpdateStackCommandHandlerProperties {
    * applied from a template file rather than from an SDK Command.
    */
   readonly cdkOutContext?: SimCdkOutContext | undefined;
+
+  /** The export names published in this Account and Region. */
+  readonly exports?: SimCfnExports | undefined;
 }
 
 /**
@@ -47,12 +51,14 @@ export class UpdateStackCommandHandler implements CommandHandler<
   private readonly stacks: Map<SimCloudFormationStackName, SimCfnStack>;
   private readonly background: BackgroundScheduler & BackgroundCompleter;
   private readonly cdkOutContext: SimCdkOutContext | undefined;
+  private readonly exports: SimCfnExports | undefined;
 
   constructor(properties: UpdateStackCommandHandlerProperties) {
     this.accountRegionScope = properties.accountRegionScope;
     this.stacks = properties.stacks;
     this.background = properties.background;
     this.cdkOutContext = properties.cdkOutContext;
+    this.exports = properties.exports;
   }
 
   /**
@@ -97,6 +103,7 @@ export class UpdateStackCommandHandler implements CommandHandler<
           stackName,
           parameters: SimCfnParameters.fromInput(command.input, { stackName }),
           accountRegionScope: this.accountRegionScope,
+          exports: this.exports,
         },
       ),
       { cdkOutContext: this.cdkOutContext },

--- a/src/service/cloudformation/deploy/sim-cfn-template-deployer.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-template-deployer.ts
@@ -26,6 +26,7 @@ import type {
 import type { SimCreateStackCommandOutput } from "../command/create-stack/create-stack.command.js";
 import { CreateStackCommandHandler } from "../command/create-stack/create-stack.handler.js";
 import { faker } from "@faker-js/faker";
+import type { SimCfnExports } from "../export/sim-cfn-exports.js";
 
 export interface SimCloudFormationCreateStackProperties {
   readonly stackName?: SimCloudFormationStackName | string;
@@ -51,6 +52,7 @@ interface SimCloudFormationTemplateDeployerProperties {
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly stacks: Map<SimCloudFormationStackName, SimCfnStack>;
   readonly background: BackgroundScheduler & BackgroundCompleter;
+  readonly exports?: SimCfnExports | undefined;
 }
 
 /**
@@ -68,6 +70,7 @@ export class SimCloudFormationTemplateDeployer {
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly stacks: Map<SimCloudFormationStackName, SimCfnStack>;
   private readonly background: BackgroundScheduler & BackgroundCompleter;
+  private readonly exports: SimCfnExports | undefined;
   private readonly templateFileLoader = new SimCfnTemplateFileLoader();
   private readonly templateFileUpdater: SimCfnTemplateFileUpdater;
   private readonly watches: SimCfnTemplateFileWatches;
@@ -77,6 +80,7 @@ export class SimCloudFormationTemplateDeployer {
     this.accountRegionScope = properties.accountRegionScope;
     this.stacks = properties.stacks;
     this.background = properties.background;
+    this.exports = properties.exports;
     this.templateFileUpdater = new SimCfnTemplateFileUpdater({
       accountRegionScope: this.accountRegionScope,
       stacks: this.stacks,
@@ -210,6 +214,7 @@ export class SimCloudFormationTemplateDeployer {
       background: this.background,
       cdkOutContext,
       bindings,
+      exports: this.exports,
     });
 
     return await handler.handle(command);

--- a/src/service/cloudformation/export/sim-cfn-exports.ts
+++ b/src/service/cloudformation/export/sim-cfn-exports.ts
@@ -1,0 +1,92 @@
+import { SimCloudFormationValidationError } from "../error/sim-cloudformation.error.js";
+import type { SimCfnTemplateValue } from "../template/value/sim-cfn-template-value.js";
+
+/** One value a Stack publishes under an export name. */
+export interface SimCfnExport {
+  readonly name: string;
+  readonly value: SimCfnTemplateValue;
+}
+
+interface SimCfnPublishedExport extends SimCfnExport {
+  readonly stackName: string;
+}
+
+/**
+ * The export names published by the Stacks in one Account and Region.
+ *
+ * CloudFormation scopes exports per Account and Region, and so does this. One
+ * of these belongs to a SimCloudFormation, which covers one Account and one
+ * Region. A Stack therefore reads the exports of the Stacks deployed alongside
+ * it and of no others.
+ *
+ * A Stack publishes here once its Outputs have resolved, which happens after
+ * its Resources have been created. An `Fn::ImportValue` therefore reads a
+ * producer that has already finished deploying.
+ */
+export class SimCfnExports {
+  private readonly published = new Map<string, SimCfnPublishedExport>();
+
+  /**
+   * The value published under an export name.
+   *
+   * A name no Stack has published is refused with the message CloudFormation
+   * refuses an import with.
+   */
+  value(name: string): SimCfnTemplateValue {
+    const published = this.published.get(name);
+
+    if (published === undefined) {
+      throw new SimCloudFormationValidationError(
+        `No export named ${name} found`,
+      );
+    }
+
+    return published.value;
+  }
+
+  /** The Stack that published an export name, if any Stack has. */
+  publisher(name: string): string | undefined {
+    return this.published.get(name)?.stackName;
+  }
+
+  /**
+   * Publish everything one Stack exports, replacing what it published before.
+   *
+   * An export name another Stack already holds is refused. CloudFormation
+   * reports that as a deployment failure. It arrives here the same way, since
+   * this runs inside the deployment and what it throws becomes the Stack's
+   * error.
+   */
+  publish(stackName: string, exports: readonly SimCfnExport[]): void {
+    this.assertUnclaimed(stackName, exports);
+    this.release(stackName);
+
+    for (const exported of exports) {
+      this.published.set(exported.name, { ...exported, stackName });
+    }
+  }
+
+  /** Drop everything a Stack published, once the Stack itself has gone. */
+  release(stackName: string): void {
+    for (const [name, published] of this.published) {
+      if (published.stackName === stackName) {
+        this.published.delete(name);
+      }
+    }
+  }
+
+  private assertUnclaimed(
+    stackName: string,
+    exports: readonly SimCfnExport[],
+  ): void {
+    for (const exported of exports) {
+      const publisher = this.publisher(exported.name);
+
+      if (publisher !== undefined && publisher !== stackName) {
+        throw new SimCloudFormationValidationError(
+          `Export with name ${exported.name} is already exported by stack ${publisher}`,
+        );
+      }
+    }
+  }
+}

--- a/src/service/cloudformation/export/sim-cfn-stack-exports.ts
+++ b/src/service/cloudformation/export/sim-cfn-stack-exports.ts
@@ -1,0 +1,34 @@
+import type { SimCfnStackOutput } from "../stack/output/sim-cfn-stack-output.js";
+import type { SimCfnExport } from "./sim-cfn-exports.js";
+
+/**
+ * The exports a Stack's resolved Outputs publish.
+ *
+ * An Output carries an export name only where the template gave it an
+ * `Export.Name`, and the rest of the Outputs are readable through
+ * DescribeStacks without being importable.
+ */
+export function simCfnStackExports(
+  outputs: ReadonlyMap<string, SimCfnStackOutput>,
+): SimCfnExport[] {
+  const exports: SimCfnExport[] = [];
+
+  for (const output of outputs.values()) {
+    const name = output.exportName;
+
+    if (name === undefined) {
+      continue;
+    }
+
+    if (typeof name !== "string") {
+      throw new TypeError(
+        `Sim CloudFormation Output ${output.outputKey} Export Name must ` +
+          `resolve to a string, got ${typeof name}`,
+      );
+    }
+
+    exports.push({ name, value: output.value });
+  }
+
+  return exports;
+}

--- a/src/service/cloudformation/export/sim-cfn-stack-import-value.iso.test.ts
+++ b/src/service/cloudformation/export/sim-cfn-stack-import-value.iso.test.ts
@@ -1,0 +1,170 @@
+import { describe, it } from "vitest";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../template/sim-cfn-template.js";
+
+const producerTemplate = (
+  exportName: string,
+  queueName: string,
+): CfnTemplateBodyRecord => ({
+  Resources: {
+    SharedQueue: {
+      Type: "AWS::SQS::Queue",
+      Properties: { QueueName: queueName },
+    },
+  },
+  Outputs: {
+    SharedQueueUrl: {
+      Value: { Ref: "SharedQueue" },
+      Export: { Name: exportName },
+    },
+  },
+});
+
+const consumerTemplate = (exportName: string): CfnTemplateBodyRecord => ({
+  Resources: {
+    Consumer: {
+      Type: "AWS::SNS::Topic",
+      Properties: {
+        TopicName: "consumer-topic",
+        DisplayName: { "Fn::ImportValue": exportName },
+      },
+    },
+  },
+});
+
+describe("Fn::ImportValue between simulated Stacks", () => {
+  it("resolves an import against an export another deployed Stack published", async () => {
+    // Given a producer Stack that exports its Queue URL.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+
+    const producer = await cloudFormation.deployTemplate({
+      stackName: "ProducerStack",
+      template: producerTemplate("ProducerStack:SharedQueueUrl", "shared"),
+    });
+    const exportedUrl = producer.outputs.get("SharedQueueUrl")?.value;
+
+    // When a second Stack imports that export name.
+    const consumer = await cloudFormation.deployTemplate({
+      stackName: "ConsumerStack",
+      template: consumerTemplate("ProducerStack:SharedQueueUrl"),
+    });
+
+    // Then the consumer's Resource was created holding the producer's value.
+    assertIdentical(consumer.lifecycle.status, "CREATE_COMPLETE");
+    assertIdentical(
+      consumer.resources.get("Consumer")?.properties["DisplayName"],
+      exportedUrl,
+    );
+  });
+
+  it("refuses an import naming an export no deployed Stack has published", async () => {
+    // Given a simulation with no Stack exporting anything.
+    const simAws = new SimAws();
+
+    // When a Stack imports a name nothing published.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().deployTemplate({
+        stackName: "ConsumerStack",
+        template: consumerTemplate("ProducerStack:SharedQueueUrl"),
+      }),
+    );
+
+    // Then it is refused the way CloudFormation refuses one, and no Stack is
+    // left behind under the name.
+    assertIdentical(error.name, "ValidationError");
+    assertStringIncludes(
+      error.message,
+      "No export named ProducerStack:SharedQueueUrl found",
+    );
+    assertUndefined(simAws.cloudFormation().getStackByName("ConsumerStack"));
+  });
+
+  it("refuses a Stack exporting a name another Stack already exports", async () => {
+    // Given a Stack that already exports a name.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+    await cloudFormation.deployTemplate({
+      stackName: "ProducerStack",
+      template: producerTemplate("SharedQueueUrl", "shared"),
+    });
+
+    // When a second Stack exports the same name.
+    const error = await assertThrowsErrorAsync(async () =>
+      cloudFormation.deployTemplate({
+        stackName: "RivalStack",
+        template: producerTemplate("SharedQueueUrl", "rival"),
+      }),
+    );
+
+    // Then that Stack fails to deploy, naming the Stack holding the export.
+    assertStringIncludes(
+      error.message,
+      "Export with name SharedQueueUrl is already exported by stack ProducerStack",
+    );
+
+    const rival = cloudFormation.getStackByName("RivalStack");
+    assertIdentical(rival?.status, "CREATE_FAILED");
+  });
+
+  it("refuses an Export Name that resolves to something other than a string", async () => {
+    // Given a Stack whose Export Name resolves to a list.
+    const simAws = new SimAws();
+
+    // When it deploys.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().deployTemplate({
+        stackName: "ProducerStack",
+        template: {
+          Resources: {
+            SharedQueue: { Type: "AWS::SQS::Queue", Properties: {} },
+          },
+          Outputs: {
+            SharedQueueUrl: {
+              Value: { Ref: "SharedQueue" },
+              Export: { Name: { "Fn::Split": [",", "one,two"] } },
+            },
+          },
+        },
+      }),
+    );
+
+    // Then the Export is refused rather than published under a name no import
+    // could ever spell.
+    assertStringIncludes(
+      error.message,
+      "Output SharedQueueUrl Export Name must resolve to a string, got object",
+    );
+  });
+
+  it("frees an export name once the Stack that published it is deleted", async () => {
+    // Given a deployed producer Stack holding an export name.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+    const producer = await cloudFormation.deployTemplate({
+      stackName: "ProducerStack",
+      template: producerTemplate("SharedQueueUrl", "shared"),
+    });
+
+    // When the producer is deleted.
+    await producer.delete();
+    await producer.waitForDeleteComplete();
+    await simAws.backgroundTasksComplete();
+
+    // Then another Stack can export the same name.
+    const replacement = await cloudFormation.deployTemplate({
+      stackName: "ReplacementStack",
+      template: producerTemplate("SharedQueueUrl", "replacement"),
+    });
+
+    assertIdentical(replacement.lifecycle.status, "CREATE_COMPLETE");
+    assertNonNullable(replacement.outputs.get("SharedQueueUrl")?.exportName);
+  });
+});

--- a/src/service/cloudformation/resource/resolve/property/sim-cfn-resource-property-resolver.ts
+++ b/src/service/cloudformation/resource/resolve/property/sim-cfn-resource-property-resolver.ts
@@ -6,10 +6,12 @@ import type {
 } from "../../../template/value/sim-cfn-template-value.js";
 import type { SimCfnResourceResolveContext } from "../../sim-cfn-resource.type.js";
 import type { SimCfnPseudoParameters } from "../../../parameters/pseudo/sim-cfn-pseudo-parameters.js";
+import type { SimCfnExports } from "../../../export/sim-cfn-exports.js";
 
 interface SimCfnResourcePropertyResolverProperties {
   readonly parameters?: SimCfnParameters | undefined;
   readonly pseudoParameters?: SimCfnPseudoParameters | undefined;
+  readonly exports?: SimCfnExports | undefined;
 }
 
 /**
@@ -28,10 +30,12 @@ interface SimCfnResourcePropertyResolverProperties {
 export class SimCfnResourcePropertyResolver {
   private readonly parameters: SimCfnParameters | undefined;
   private readonly pseudoParameters: SimCfnPseudoParameters | undefined;
+  private readonly exports: SimCfnExports | undefined;
 
   constructor(properties: SimCfnResourcePropertyResolverProperties = {}) {
     this.parameters = properties.parameters;
     this.pseudoParameters = properties.pseudoParameters;
+    this.exports = properties.exports;
   }
 
   /**
@@ -52,6 +56,7 @@ export class SimCfnResourcePropertyResolver {
     const resolver = new SimCfnTemplateValueResolver({
       parameters: this.parameters ?? new SimCfnParameters(),
       pseudoParameters: this.pseudoParameters,
+      exports: this.exports,
       resources: {
         has: (id): boolean => context.resources.has(id),
         refValue: (id): SimCfnTemplateValue => {

--- a/src/service/cloudformation/resource/sim-cfn-resource-record.ts
+++ b/src/service/cloudformation/resource/sim-cfn-resource-record.ts
@@ -55,6 +55,7 @@ export abstract class SimCfnResourceRecord implements SimCfnPropertyIgnorer {
       template = {},
       parameters,
       resourceLogicalIds = new Set(),
+      exports,
     } = properties;
 
     this.accountRegionScope = accountRegionScope;
@@ -62,7 +63,10 @@ export abstract class SimCfnResourceRecord implements SimCfnPropertyIgnorer {
     this.stackName = stackName;
     this.template = template;
     this.resourceTemplateReader = new SimCfnResourceTemplateReader(template);
-    this.propertyResolver = new SimCfnResourcePropertyResolver({ parameters });
+    this.propertyResolver = new SimCfnResourcePropertyResolver({
+      parameters,
+      exports,
+    });
     this.resourceLogicalIds = resourceLogicalIds;
   }
 

--- a/src/service/cloudformation/resource/sim-cfn-resource.type.ts
+++ b/src/service/cloudformation/resource/sim-cfn-resource.type.ts
@@ -7,6 +7,7 @@ import type { SimCfnParameters } from "../parameters/sim-cfn-parameters.js";
 import type { SimCdkOutContext } from "../cdk/sim-cdk-out-context.js";
 import type { SimCfnDeployBinding } from "../bind/sim-cfn-deploy-binding.js";
 import type { SimCfnResource } from "./sim-cfn-resource.js";
+import type { SimCfnExports } from "../export/sim-cfn-exports.js";
 
 export interface SimCloudFormationResourceProperties {
   readonly accountRegionScope?: SimAwsAccountRegionScope;
@@ -17,6 +18,7 @@ export interface SimCloudFormationResourceProperties {
   readonly cfnResourceFactory?: SimCfnServiceResourceFactory | undefined;
   readonly parameters?: SimCfnParameters | undefined;
   readonly resourceLogicalIds?: ReadonlySet<string> | undefined;
+  readonly exports?: SimCfnExports | undefined;
 }
 
 /**

--- a/src/service/cloudformation/sim-cloudformation.ts
+++ b/src/service/cloudformation/sim-cloudformation.ts
@@ -37,6 +37,7 @@ import {
 import type { SimCloudFormationDeployTemplateFileProperties as SimCloudFormationDeployTemplateFileProperties } from "./deploy/sim-cfn-template-file-loader.js";
 import type { SimCfnDeployBinding } from "./bind/sim-cfn-deploy-binding.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
+import { SimCfnExports } from "./export/sim-cfn-exports.js";
 import { SimCloudFormationSdkCommandRouter } from "./sdk/sim-cloudformation-sdk-command-router.js";
 import type { SimSdkCommandRouter } from "../../sdk/index.js";
 import type { SimAwsCaller } from "../aws/caller/sim-aws-caller.js";
@@ -69,6 +70,7 @@ export class SimCloudFormation {
   private readonly simAws: SimAws;
   private readonly background: BackgroundScheduler & BackgroundCompleter;
   private readonly stacks = new Map<SimCloudFormationStackName, SimCfnStack>();
+  private readonly exports = new SimCfnExports();
   private readonly templateDeployer: SimCloudFormationTemplateDeployer;
   private readonly sdkRouter = new SimCloudFormationSdkCommandRouter(this);
   private readonly authorization: SimCloudFormationAuthorization;
@@ -93,6 +95,7 @@ export class SimCloudFormation {
       accountRegionScope: this.accountRegionScope,
       stacks: this.stacks,
       background: this.background,
+      exports: this.exports,
     });
   }
 
@@ -143,6 +146,7 @@ export class SimCloudFormation {
       accountRegionScope: this.accountRegionScope,
       stacks: this.stacks,
       background: this.background,
+      exports: this.exports,
     });
     return await handler.handle(command);
   }
@@ -289,6 +293,7 @@ export class SimCloudFormation {
       background: this.background,
       cdkOutContext,
       bindings,
+      exports: this.exports,
     });
     return await handler.handle(command);
   }

--- a/src/service/cloudformation/stack/output/sim-cfn-stack-output-resolver.ts
+++ b/src/service/cloudformation/stack/output/sim-cfn-stack-output-resolver.ts
@@ -6,10 +6,12 @@ import type {
   SimCfnTemplateValueRecord,
 } from "../../template/value/sim-cfn-template-value.js";
 import type { SimCfnStackOutput } from "./sim-cfn-stack-output.js";
+import type { SimCfnExports } from "../../export/sim-cfn-exports.js";
 
 interface SimCfnStackOutputResolverProperties {
   readonly template: SimCfnTemplate;
   readonly resources: ReadonlyMap<string, SimCfnResource>;
+  readonly exports?: SimCfnExports | undefined;
 }
 
 /**
@@ -22,10 +24,12 @@ interface SimCfnStackOutputResolverProperties {
 export class SimCfnStackOutputResolver {
   private readonly template: SimCfnTemplate;
   private readonly resources: ReadonlyMap<string, SimCfnResource>;
+  private readonly exports: SimCfnExports | undefined;
 
   constructor(properties: SimCfnStackOutputResolverProperties) {
     this.template = properties.template;
     this.resources = properties.resources;
+    this.exports = properties.exports;
   }
 
   /**
@@ -72,6 +76,7 @@ export class SimCfnStackOutputResolver {
     const resolver = new SimCfnTemplateValueResolver({
       parameters: this.template.parameters,
       pseudoParameters: this.template.pseudoParameters(),
+      exports: this.exports,
       resources: {
         has: (id): boolean => this.resources.has(id),
         refValue: (id): SimCfnTemplateValue => {

--- a/src/service/cloudformation/stack/output/sim-cfn-stack-outputs.ts
+++ b/src/service/cloudformation/stack/output/sim-cfn-stack-outputs.ts
@@ -1,0 +1,54 @@
+import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
+import type { SimCfnTemplate } from "../../template/sim-cfn-template.js";
+import type { SimCfnExports } from "../../export/sim-cfn-exports.js";
+import { simCfnStackExports } from "../../export/sim-cfn-stack-exports.js";
+import type { SimCfnStackOutput } from "./sim-cfn-stack-output.js";
+import { SimCfnStackOutputResolver } from "./sim-cfn-stack-output-resolver.js";
+
+interface SimCfnStackOutputsProperties {
+  readonly stackName: string;
+  readonly exports?: SimCfnExports | undefined;
+}
+
+/**
+ * One Stack's Outputs, and the export names they publish.
+ *
+ * Resolving and publishing are the same step because an export carries a
+ * resolved Output value, which only exists once the Resources it reads have
+ * been created. Both a deployment and an update end by running this.
+ */
+export class SimCfnStackOutputs {
+  private readonly stackName: string;
+  private readonly exports: SimCfnExports | undefined;
+
+  constructor(properties: SimCfnStackOutputsProperties) {
+    this.stackName = properties.stackName;
+    this.exports = properties.exports;
+  }
+
+  /**
+   * Resolve the Stack's Outputs and publish the ones it exports.
+   *
+   * An export name another Stack already holds is refused, and the refusal
+   * fails the deployment or the update that ran this.
+   */
+  resolve(
+    template: SimCfnTemplate,
+    resources: ReadonlyMap<string, SimCfnResource>,
+  ): Map<string, SimCfnStackOutput> {
+    const outputs = new SimCfnStackOutputResolver({
+      template,
+      resources,
+      exports: this.exports,
+    }).resolve();
+
+    this.exports?.publish(this.stackName, simCfnStackExports(outputs));
+
+    return outputs;
+  }
+
+  /** Let go of the export names this Stack published, once it has gone. */
+  release(): void {
+    this.exports?.release(this.stackName);
+  }
+}

--- a/src/service/cloudformation/stack/resource-map/sim-cfn-stack-resource-map.ts
+++ b/src/service/cloudformation/stack/resource-map/sim-cfn-stack-resource-map.ts
@@ -34,6 +34,7 @@ export function makeSimCfnStackResourceMap(
         template: resourceTemplate.template,
         parameters: template.parameters,
         resourceLogicalIds,
+        exports: template.exports,
       }),
     );
   }

--- a/src/service/cloudformation/stack/sim-cfn-stack.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack.ts
@@ -15,7 +15,7 @@ import { SimCfnStackDeploymentLifecycle } from "./deploy/sim-cfn-stack-deploymen
 import { SimCfnStackResourceOperations } from "./sim-cfn-stack-resource-operations.js";
 import { SimCfnStackUpdateLifecycle } from "./update/sim-cfn-stack-update-lifecycle.js";
 import type { SimCfnStackOutput } from "./output/sim-cfn-stack-output.js";
-import { SimCfnStackOutputResolver } from "./output/sim-cfn-stack-output-resolver.js";
+import { SimCfnStackOutputs } from "./output/sim-cfn-stack-outputs.js";
 import { SimCfnStackOutputLookup } from "./output/sim-cfn-stack-output-lookup.js";
 import { SimCfnStackResourceReport } from "./report/sim-cfn-stack-resource-report.js";
 import { SimCfnStackOperationStatus } from "./status/sim-cfn-stack-operation-status.js";
@@ -54,6 +54,7 @@ export class SimCfnStack {
   private readonly background: BackgroundScheduler;
   private readonly operations: SimCfnStackResourceOperations;
   private readonly operationStatus: SimCfnStackOperationStatus;
+  private readonly stackOutputs: SimCfnStackOutputs;
   private cfnTemplate: SimCfnTemplate;
 
   constructor(properties: SimCloudFormationStackProperties) {
@@ -65,10 +66,12 @@ export class SimCfnStack {
       template,
       cdkOutContext,
       bindings,
+      exports,
     } = properties;
 
     this.background = background;
     this.stackName = stackName;
+    this.stackOutputs = new SimCfnStackOutputs({ stackName, exports });
     this.cfnTemplate = template;
     this.template = this.cfnTemplate.template;
     this.resources = makeSimCfnStackResourceMap({
@@ -215,6 +218,7 @@ export class SimCfnStack {
    */
   async teardown(): Promise<void> {
     await this.operations.deleteAll(this.resources);
+    this.stackOutputs.release();
   }
 
   /**
@@ -282,10 +286,7 @@ export class SimCfnStack {
   }
 
   private resolveOutputs(): void {
-    this.outputs = new SimCfnStackOutputResolver({
-      template: this.cfnTemplate,
-      resources: this.resources,
-    }).resolve();
+    this.outputs = this.stackOutputs.resolve(this.cfnTemplate, this.resources);
   }
 }
 

--- a/src/service/cloudformation/stack/sim-cfn-stack.type.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack.type.ts
@@ -5,6 +5,7 @@ import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-
 import type { SimCfnTemplate } from "../template/sim-cfn-template.js";
 import type { SimCdkOutContext } from "../cdk/sim-cdk-out-context.js";
 import type { SimCfnDeployBinding } from "../bind/sim-cfn-deploy-binding.js";
+import type { SimCfnExports } from "../export/sim-cfn-exports.js";
 
 export type SimCloudFormationStackName = Brand<
   string,
@@ -41,4 +42,11 @@ export interface SimCloudFormationStackProperties {
   readonly template: SimCfnTemplate;
   readonly cdkOutContext?: SimCdkOutContext | undefined;
   readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
+
+  /**
+   * The export names published in the Account and Region this Stack deploys
+   * into. This Stack publishes its own Outputs here and reads the ones its
+   * `Fn::ImportValue` expressions name.
+   */
+  readonly exports?: SimCfnExports | undefined;
 }

--- a/src/service/cloudformation/template/node/fn/import-value/sim-cfn-fn-import-value.iso.test.ts
+++ b/src/service/cloudformation/template/node/fn/import-value/sim-cfn-fn-import-value.iso.test.ts
@@ -1,0 +1,84 @@
+import { describe, it } from "vitest";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertObjectEquals,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { SimCfnFnImportValue as SimCfnFunctionImportValue } from "./sim-cfn-fn-import-value.js";
+import { SimCfnLiteral } from "../../sim-cfn-literal.js";
+import { SimCfnRef as SimCfnReference } from "../../sim-cfn-ref.js";
+import { SimCfnResolveContext } from "../../../resolve/sim-cfn-resolve-context.js";
+import { SimCfnParameters } from "../../../../parameters/sim-cfn-parameters.js";
+import { SimCfnExports } from "../../../../export/sim-cfn-exports.js";
+import { parseSimCfnNode } from "../../../parse/node/sim-cfn-node-parser.js";
+
+const contextWith = (exports: SimCfnExports): SimCfnResolveContext =>
+  new SimCfnResolveContext({ parameters: new SimCfnParameters(), exports });
+
+describe("SimCfnFnImportValue", () => {
+  it("resolves to the value published under the export name", () => {
+    // Given a published export.
+    const exports = new SimCfnExports();
+    exports.publish("ProducerStack", [
+      { name: "SharedQueueUrl", value: "https://example.invalid/queue" },
+    ]);
+
+    // When an import names it.
+    const resolved = new SimCfnFunctionImportValue(
+      new SimCfnLiteral("SharedQueueUrl"),
+    ).resolve(contextWith(exports));
+
+    // Then the published value comes back.
+    assertIdentical(resolved, "https://example.invalid/queue");
+  });
+
+  it("re-emits itself while the export name is an unresolved expression", () => {
+    // Given an import whose name is built from a Resource that has yet to
+    // exist, so the first resolution pass cannot finish it.
+    const importValue = new SimCfnFunctionImportValue(
+      new SimCfnReference("SomeResource"),
+    );
+
+    // When it resolves without that Resource.
+    const resolved = importValue.resolve(contextWith(new SimCfnExports()));
+
+    // Then it comes back in template form for a later pass to finish.
+    assertObjectEquals(resolved, {
+      "Fn::ImportValue": { Ref: "SomeResource" },
+    });
+  });
+
+  it("reports the names its export name references", () => {
+    const importValue = new SimCfnFunctionImportValue(
+      new SimCfnReference("EnvironmentName"),
+    );
+
+    assertArrayEquals(importValue.referencedNames(), ["EnvironmentName"]);
+  });
+
+  it("refuses an export name that resolves to something other than a string", () => {
+    const error = assertThrowsError(() => {
+      new SimCfnFunctionImportValue(new SimCfnLiteral(42)).resolve(
+        contextWith(new SimCfnExports()),
+      );
+    });
+
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Fn::ImportValue export name must resolve to a " +
+        "string, got number",
+    );
+  });
+
+  it("refuses a Fn::ImportValue written as a list", () => {
+    const error = assertThrowsError(() => {
+      parseSimCfnNode({ "Fn::ImportValue": ["SharedQueueUrl"] });
+    });
+
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Fn::ImportValue value must be an export name",
+    );
+  });
+});

--- a/src/service/cloudformation/template/node/fn/import-value/sim-cfn-fn-import-value.ts
+++ b/src/service/cloudformation/template/node/fn/import-value/sim-cfn-fn-import-value.ts
@@ -1,0 +1,54 @@
+import { SimCfnNode } from "../../sim-cfn-node.js";
+import type { SimCfnResolveContext } from "../../../resolve/sim-cfn-resolve-context.js";
+import type { SimCfnTemplateValue } from "../../../value/sim-cfn-template-value.js";
+import { isSimCfnUnresolvedExpression } from "../../../value/sim-cfn-unresolved-expression.js";
+
+/**
+ * Simulated CloudFormation `Fn::ImportValue` intrinsic function.
+ *
+ * Standard shape:
+ *
+ * {
+ *   "Fn::ImportValue": "ProducerStack:ExportsOutputRefSharedQueue"
+ * }
+ *
+ * CDK emits one of these on the consumer whenever a Stack reads a value from
+ * another Stack of the same app, paired with an Export on the producer.
+ */
+export class SimCfnFnImportValue extends SimCfnNode {
+  constructor(private readonly exportName: SimCfnNode) {
+    super();
+  }
+
+  /**
+   * Read the value the named export was published with.
+   *
+   * An export name that is still an unresolved expression re-emits this
+   * function in template form. A later resolution pass finishes it once the
+   * Resources the name is built from exist. A name that has resolved is looked
+   * up, and one no Stack has published is refused there.
+   */
+  resolve(context: SimCfnResolveContext): SimCfnTemplateValue {
+    const name = this.exportName.resolve(context);
+
+    if (isSimCfnUnresolvedExpression(name)) {
+      return { "Fn::ImportValue": name };
+    }
+
+    if (typeof name !== "string") {
+      throw new TypeError(
+        "Sim CloudFormation Fn::ImportValue export name must resolve to a " +
+          `string, got ${typeof name}`,
+      );
+    }
+
+    return context.exports.value(name);
+  }
+
+  /**
+   * Collect referenced names from the export name.
+   */
+  override referencedNames(): string[] {
+    return this.exportName.referencedNames();
+  }
+}

--- a/src/service/cloudformation/template/parse/fn/import-value/sim-cfn-fn-import-value-parser.ts
+++ b/src/service/cloudformation/template/parse/fn/import-value/sim-cfn-fn-import-value-parser.ts
@@ -1,0 +1,34 @@
+import { SimCfnFnImportValue as SimCfnFunctionImportValue } from "../../../node/fn/import-value/sim-cfn-fn-import-value.js";
+import type { SimCfnTemplateValue } from "../../../value/sim-cfn-template-value.js";
+import type { SimCfnValueParser } from "../../value/sim-cfn-value-parser.type.js";
+
+/**
+ * Parses CloudFormation Fn::ImportValue values.
+ *
+ * Fn::ImportValue has the shape:
+ *
+ * {
+ *   "Fn::ImportValue": "ProducerStack:ExportsOutputRefSharedQueue"
+ * }
+ *
+ * The export name goes through the recursive value parser, since a template
+ * often builds it from a Parameter with Fn::Sub or Fn::Join. Whether it
+ * resolves to a string, and whether anything has published it, are both
+ * resolution-time questions that belong to the node.
+ */
+export class SimCfnFnImportValueParser {
+  constructor(private readonly valueParser: SimCfnValueParser) {}
+
+  /**
+   * Parse and validate the value inside a Fn::ImportValue expression.
+   */
+  parse(value: SimCfnTemplateValue): SimCfnFunctionImportValue {
+    if (Array.isArray(value)) {
+      throw new TypeError(
+        "Sim CloudFormation Fn::ImportValue value must be an export name",
+      );
+    }
+
+    return new SimCfnFunctionImportValue(this.valueParser.parse(value));
+  }
+}

--- a/src/service/cloudformation/template/parse/fn/sim-cfn-function-parser.ts
+++ b/src/service/cloudformation/template/parse/fn/sim-cfn-function-parser.ts
@@ -1,13 +1,10 @@
 import type { SimCfnNode } from "../../node/sim-cfn-node.js";
 import type { SimCfnTemplateValue } from "../../value/sim-cfn-template-value.js";
-import { SimCfnFnGetAttParser as SimCfnFunctionGetAttParser } from "./get-att/sim-cfn-fn-get-att-parser.js";
-import { SimCfnFnJoinParser as SimCfnFunctionJoinParser } from "./join/sim-cfn-fn-join-parser.js";
 import type { SimCfnValueParser } from "../value/sim-cfn-value-parser.type.js";
-import { SimCfnFnSubParser as SimCfnFunctionSubParser } from "./sub/sim-cfn-fn-sub-parser.js";
-import { SimCfnFnFindInMapParser as SimCfnFunctionFindInMapParser } from "./find-in-map/sim-cfn-fn-find-in-map-parser.js";
-import { SimCfnFnIfParser as SimCfnFunctionIfParser } from "./if/sim-cfn-fn-if-parser.js";
-import { SimCfnFnSplitParser as SimCfnFunctionSplitParser } from "./split/sim-cfn-fn-split-parser.js";
-import { SimCfnFnSelectParser as SimCfnFunctionSelectParser } from "./select/sim-cfn-fn-select-parser.js";
+import {
+  makeSimCfnFunctionParsers,
+  type SimCfnFunctionValueParser,
+} from "./sim-cfn-function-parsers.js";
 import { assertDefined } from "../../../../../util/type-guard/defined.js";
 
 /**
@@ -20,27 +17,21 @@ import { assertDefined } from "../../../../../util/type-guard/defined.js";
  * - an object with a non-intrinsic first key but an Fn::* sibling is malformed;
  * - function-specific value validation belongs to function-specific parsers.
  *
+ * Which functions are supported, and what parses each one, is the table in
+ * sim-cfn-function-parsers.ts.
+ *
  * It does not parse arbitrary template values. SimCfnNodeParser owns the full
  * recursive tree parse and passes itself in as SimCfnValueParser for functions
  * that need child values parsed recursively.
  */
 export class SimCfnFunctionParser {
-  private readonly fnGetAttParser: SimCfnFunctionGetAttParser;
-  private readonly fnFindInMapParser: SimCfnFunctionFindInMapParser;
-  private readonly fnJoinParser: SimCfnFunctionJoinParser;
-  private readonly fnSubParser: SimCfnFunctionSubParser;
-  private readonly fnIfParser: SimCfnFunctionIfParser;
-  private readonly fnSplitParser: SimCfnFunctionSplitParser;
-  private readonly fnSelectParser: SimCfnFunctionSelectParser;
+  private readonly functionParsers: ReadonlyMap<
+    string,
+    SimCfnFunctionValueParser
+  >;
 
   constructor(valueParser: SimCfnValueParser) {
-    this.fnGetAttParser = new SimCfnFunctionGetAttParser();
-    this.fnFindInMapParser = new SimCfnFunctionFindInMapParser(valueParser);
-    this.fnJoinParser = new SimCfnFunctionJoinParser(valueParser);
-    this.fnSubParser = new SimCfnFunctionSubParser(valueParser);
-    this.fnIfParser = new SimCfnFunctionIfParser(valueParser);
-    this.fnSplitParser = new SimCfnFunctionSplitParser(valueParser);
-    this.fnSelectParser = new SimCfnFunctionSelectParser(valueParser);
+    this.functionParsers = makeSimCfnFunctionParsers(valueParser);
   }
 
   /**
@@ -74,32 +65,10 @@ export class SimCfnFunctionParser {
     functionName: string,
     value: SimCfnTemplateValue,
   ): SimCfnNode {
-    if (functionName === "Fn::Join") {
-      return this.fnJoinParser.parse(value);
-    }
+    const functionParser = this.functionParsers.get(functionName);
 
-    if (functionName === "Fn::Sub") {
-      return this.fnSubParser.parse(value);
-    }
-
-    if (functionName === "Fn::GetAtt") {
-      return this.fnGetAttParser.parse(value);
-    }
-
-    if (functionName === "Fn::FindInMap") {
-      return this.fnFindInMapParser.parse(value);
-    }
-
-    if (functionName === "Fn::If") {
-      return this.fnIfParser.parse(value);
-    }
-
-    if (functionName === "Fn::Split") {
-      return this.fnSplitParser.parse(value);
-    }
-
-    if (functionName === "Fn::Select") {
-      return this.fnSelectParser.parse(value);
+    if (functionParser !== undefined) {
+      return functionParser.parse(value);
     }
 
     throw new Error(

--- a/src/service/cloudformation/template/parse/fn/sim-cfn-function-parsers.ts
+++ b/src/service/cloudformation/template/parse/fn/sim-cfn-function-parsers.ts
@@ -1,0 +1,41 @@
+import type { SimCfnNode } from "../../node/sim-cfn-node.js";
+import type { SimCfnTemplateValue } from "../../value/sim-cfn-template-value.js";
+import type { SimCfnValueParser } from "../value/sim-cfn-value-parser.type.js";
+import { SimCfnFnGetAttParser as SimCfnFunctionGetAttParser } from "./get-att/sim-cfn-fn-get-att-parser.js";
+import { SimCfnFnJoinParser as SimCfnFunctionJoinParser } from "./join/sim-cfn-fn-join-parser.js";
+import { SimCfnFnSubParser as SimCfnFunctionSubParser } from "./sub/sim-cfn-fn-sub-parser.js";
+import { SimCfnFnFindInMapParser as SimCfnFunctionFindInMapParser } from "./find-in-map/sim-cfn-fn-find-in-map-parser.js";
+import { SimCfnFnIfParser as SimCfnFunctionIfParser } from "./if/sim-cfn-fn-if-parser.js";
+import { SimCfnFnSplitParser as SimCfnFunctionSplitParser } from "./split/sim-cfn-fn-split-parser.js";
+import { SimCfnFnSelectParser as SimCfnFunctionSelectParser } from "./select/sim-cfn-fn-select-parser.js";
+import { SimCfnFnImportValueParser as SimCfnFunctionImportValueParser } from "./import-value/sim-cfn-fn-import-value-parser.js";
+
+/** What every intrinsic function parser answers a function's value with. */
+export interface SimCfnFunctionValueParser {
+  parse(value: SimCfnTemplateValue): SimCfnNode;
+}
+
+/**
+ * The intrinsic functions this simulator parses, by the name a template
+ * writes them under.
+ *
+ * Each parser takes the recursive value parser where it has child values to
+ * parse. Fn::GetAtt takes none, since both of its arguments are names.
+ *
+ * This table is the list of supported functions. A name absent from it is
+ * refused by SimCfnFunctionParser rather than parsed as a plain object.
+ */
+export function makeSimCfnFunctionParsers(
+  valueParser: SimCfnValueParser,
+): ReadonlyMap<string, SimCfnFunctionValueParser> {
+  return new Map<string, SimCfnFunctionValueParser>([
+    ["Fn::Join", new SimCfnFunctionJoinParser(valueParser)],
+    ["Fn::Sub", new SimCfnFunctionSubParser(valueParser)],
+    ["Fn::GetAtt", new SimCfnFunctionGetAttParser()],
+    ["Fn::FindInMap", new SimCfnFunctionFindInMapParser(valueParser)],
+    ["Fn::If", new SimCfnFunctionIfParser(valueParser)],
+    ["Fn::Split", new SimCfnFunctionSplitParser(valueParser)],
+    ["Fn::Select", new SimCfnFunctionSelectParser(valueParser)],
+    ["Fn::ImportValue", new SimCfnFunctionImportValueParser(valueParser)],
+  ]);
+}

--- a/src/service/cloudformation/template/resolve/sim-cfn-resolve-context.ts
+++ b/src/service/cloudformation/template/resolve/sim-cfn-resolve-context.ts
@@ -3,6 +3,7 @@ import type { SimCfnResourceRefResolver as SimCfnResourceReferenceResolver } fro
 import type { SimCfnPseudoParameters } from "../../parameters/pseudo/sim-cfn-pseudo-parameters.js";
 import type { SimCfnMappings } from "../mapping/sim-cfn-mappings.js";
 import type { SimCfnConditions } from "../condition/sim-cfn-conditions.js";
+import { SimCfnExports } from "../../export/sim-cfn-exports.js";
 
 interface SimCfnResolveContextProperties {
   readonly parameters: SimCfnParameters;
@@ -10,6 +11,7 @@ interface SimCfnResolveContextProperties {
   readonly pseudoParameters?: SimCfnPseudoParameters | undefined;
   readonly mappings?: SimCfnMappings | undefined;
   readonly conditions?: SimCfnConditions | undefined;
+  readonly exports?: SimCfnExports | undefined;
 }
 
 /**
@@ -21,6 +23,14 @@ export class SimCfnResolveContext {
   public readonly pseudoParameters: SimCfnPseudoParameters | undefined;
   public readonly mappings: SimCfnMappings | undefined;
   public readonly conditions: SimCfnConditions | undefined;
+  /**
+   * The export names a Stack deployed here can import.
+   *
+   * An empty set stands in where a caller resolves a template outside a
+   * simulation. An `Fn::ImportValue` there fails the lookup and is refused by
+   * export name.
+   */
+  public readonly exports: SimCfnExports;
 
   constructor(properties: SimCfnResolveContextProperties) {
     this.parameters = properties.parameters;
@@ -28,5 +38,6 @@ export class SimCfnResolveContext {
     this.pseudoParameters = properties.pseudoParameters;
     this.mappings = properties.mappings;
     this.conditions = properties.conditions;
+    this.exports = properties.exports ?? new SimCfnExports();
   }
 }

--- a/src/service/cloudformation/template/sim-cfn-template.ts
+++ b/src/service/cloudformation/template/sim-cfn-template.ts
@@ -17,6 +17,7 @@ import type {
   SimCfnConditionsSection,
 } from "./condition/sim-cfn-conditions.js";
 import { SimCfnResourceConditions } from "./condition/sim-cfn-resource-conditions.js";
+import type { SimCfnExports } from "../export/sim-cfn-exports.js";
 
 /**
  * Parsed CloudFormation template body accepted by the simulator.
@@ -51,12 +52,14 @@ interface SimCfnTemplateProperties {
   readonly parameters?: SimCfnParameters | undefined;
   readonly stackName?: string | undefined;
   readonly accountRegionScope?: SimAwsAccountRegionScope | undefined;
+  readonly exports?: SimCfnExports | undefined;
 }
 
 interface SimCfnTemplateFromJsonProperties {
   readonly stackName?: string | undefined;
   readonly parameters?: SimCfnParameters | undefined;
   readonly accountRegionScope?: SimAwsAccountRegionScope | undefined;
+  readonly exports?: SimCfnExports | undefined;
 }
 
 /**
@@ -68,15 +71,19 @@ export class SimCfnTemplate {
   public readonly template: CfnTemplateBodyRecord;
   public readonly stackName: string | undefined;
   public readonly parameters: SimCfnParameters;
+  /** The export names a Stack deployed from this template can import. */
+  public readonly exports: SimCfnExports | undefined;
   private readonly accountRegionScope: SimAwsAccountRegionScope | undefined;
   private evaluatedConditions: SimCfnConditions | undefined;
 
   constructor(properties: SimCfnTemplateProperties) {
-    const { template, parameters, stackName, accountRegionScope } = properties;
+    const { template, parameters, stackName, accountRegionScope, exports } =
+      properties;
 
     this.template = template;
     this.stackName = stackName;
     this.accountRegionScope = accountRegionScope;
+    this.exports = exports;
 
     const validator = new SimCfnTemplateBodyValidator({ template, stackName });
     validator.validate();
@@ -111,6 +118,7 @@ export class SimCfnTemplate {
       parameters: properties.parameters,
       stackName: properties.stackName,
       accountRegionScope: properties.accountRegionScope,
+      exports: properties.exports,
     });
   }
 
@@ -197,6 +205,7 @@ export class SimCfnTemplate {
         parameters: this.parameters,
         pseudoParameters: this.pseudoParameters(),
         mappings: this.template.Mappings,
+        exports: this.exports,
       }),
     }).evaluate();
 
@@ -209,6 +218,7 @@ export class SimCfnTemplate {
       pseudoParameters: this.pseudoParameters(),
       mappings: this.template.Mappings,
       conditions: this.conditions(),
+      exports: this.exports,
     });
   }
 }

--- a/src/service/cloudformation/template/value/sim-cfn-template-value-resolver.ts
+++ b/src/service/cloudformation/template/value/sim-cfn-template-value-resolver.ts
@@ -9,6 +9,7 @@ import type { SimCfnPseudoParameters } from "../../parameters/pseudo/sim-cfn-pse
 import { SimCfnResolveContext } from "../resolve/sim-cfn-resolve-context.js";
 import type { SimCfnMappings } from "../mapping/sim-cfn-mappings.js";
 import type { SimCfnConditions } from "../condition/sim-cfn-conditions.js";
+import type { SimCfnExports } from "../../export/sim-cfn-exports.js";
 import {
   resolveSimCfnValueAt,
   resolveSimCfnValueIn,
@@ -20,6 +21,7 @@ interface SimCfnTemplateValueResolverProperties {
   readonly pseudoParameters?: SimCfnPseudoParameters | undefined;
   readonly mappings?: SimCfnMappings | undefined;
   readonly conditions?: SimCfnConditions | undefined;
+  readonly exports?: SimCfnExports | undefined;
 }
 
 /**
@@ -35,6 +37,7 @@ export class SimCfnTemplateValueResolver {
       pseudoParameters: properties.pseudoParameters,
       mappings: properties.mappings,
       conditions: properties.conditions,
+      exports: properties.exports,
     });
   }
 


### PR DESCRIPTION
A CDK app whose stacks share a value emits an `Export` on the producer and an `Fn::ImportValue` on the consumer, and Yulin refused any template carrying one. `Fn::ImportValue` now parses as an intrinsic function node and resolves against a `SimCfnExports` registry held by each `SimCloudFormation`, which scopes exports per Account and Region as AWS does. A Stack publishes to that registry once its Outputs have resolved, and releases what it published when it is torn down. An import naming an export no Stack has published is refused with CloudFormation's own message, and a Stack exporting a name another Stack already holds fails to deploy.

Resolves https://github.com/KensioSoftware/yulin/issues/703

Worth a reviewer's attention:

- The registry defaults to empty in `SimCfnResolveContext`, so a template resolved outside a simulation fails on the export name rather than on missing plumbing.
- Adding an eighth branch tipped `sim-cfn-function-parser.ts` over the FTA threshold. Swapping the if-chain for a lookup map dropped cyclo 13 to 6 but raised the score, since the file lost lines without losing tokens. Moving the table into `sim-cfn-function-parsers.ts` is what brought it down.
- Resolving Outputs and publishing exports moved into `SimCfnStackOutputs`, which kept `sim-cfn-stack.ts` under the line limit and stops the Stack knowing about `simCfnStackExports`.
- Two open questions from the issue are deliberately not answered here: deleting a producer while a consumer still imports from it, which CloudFormation blocks, and deploying a whole cloud assembly in one call.

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`
