### PR TITLE
feat: deploy every Stack in a cdk.out assembly

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -1109,6 +1109,95 @@ A template path with no file at it is refused with
 `No Sim CloudFormation template file at <path>`, naming the resolved path. A synthesized template
 is build output, and a checkout that has yet to synthesize one meets this on the first run.
 
+## Deploying a whole cloud assembly
+
+`deployCdkOut(...)` deploys the Stacks a `cdk.out` directory holds, each into the region its own
+environment names. The assembly's `manifest.json` is where that comes from, so an app synthesizing
+several Stacks across several regions needs no loop of its own and no region constants beside it.
+
+```typescript sim-cloudformation-cdk-out-assembly
+/**
+ * Deploying every Stack a synthesized CDK cloud assembly holds.
+ */
+
+import path from "node:path";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+const stacks = await simAws
+  .cloudFormation()
+  .deployCdkOut(path.join(process.cwd(), "cdk.out"));
+
+const siteStack = stacks.get("SiteStack");
+const dnsStack = stacks.get("DnsStack");
+
+console.log(siteStack?.getResource("SiteBucket")?.simResource);
+console.log(dnsStack?.getResource("SiteRecord")?.simResource);
+```
+
+A Stack synthesized with `env: { region: "us-east-1" }` deploys into simulated us-east-1, whatever
+region the call was made in. A Stack synthesized without `env` takes the region of the scope it was
+asked through, and every Stack takes that scope's Account.
+
+Stacks deploy in an order their manifest dependencies allow, so a Stack that consumes another
+Stack's export goes second. The deployed Stacks come back keyed by name, each one the same
+`SimCfnStack` `deployTemplateFile(...)` answers with.
+
+### Deploying part of an assembly
+
+Most apps synthesize Stacks a test has no use for, a deployment pipeline among them. `stackNames`
+picks the ones to deploy, naming each by Stack name or by CDK artifact ID.
+
+```typescript sim-cloudformation-cdk-out-stack-names
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+const stacks = await simAws.cloudFormation().deployCdkOut({
+  directoryPath: "cdk.out",
+  stackNames: ["SiteStack", "DnsStack"],
+});
+
+console.log(stacks.keys().toArray());
+```
+
+Naming a Stack the assembly lacks fails the call, listing the Stacks it does hold.
+
+### Bindings and transforms for one Stack
+
+A call naming a directory has no single template to attach bindings to, so `stackOptions` keys them
+by Stack. Each entry takes the `bindings`, `parameters` and `transform` that
+`deployTemplateFile(...)` takes for one template.
+
+```typescript sim-cloudformation-cdk-out-stack-options
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+const stacks = await simAws.cloudFormation().deployCdkOut({
+  directoryPath: "cdk.out",
+  stackNames: ["ApiStack"],
+  stackOptions: {
+    ApiStack: {
+      parameters: { Stage: "test" },
+      bindings: [
+        {
+          logicalId: "UploadFunction",
+          handler: (): { statusCode: number } => ({ statusCode: 200 }),
+        },
+      ],
+    },
+  },
+});
+
+console.log(stacks.get("ApiStack")?.stackName);
+```
+
+An options key matching no Stack being deployed fails the call, so a renamed Stack takes its
+bindings with it rather than quietly losing them.
+
 ## Editing a synthesized template before deploying it
 
 Sometimes a synthesized template needs a change before Yulin will deploy it, such as dropping a

--- a/docs/services/cloudformation/sim-cloudformation-cdk-out-assembly.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-cdk-out-assembly.example.ts
@@ -1,0 +1,19 @@
+/**
+ * Deploying every Stack a synthesized CDK cloud assembly holds.
+ */
+
+import path from "node:path";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+const stacks = await simAws
+  .cloudFormation()
+  .deployCdkOut(path.join(process.cwd(), "cdk.out"));
+
+const siteStack = stacks.get("SiteStack");
+const dnsStack = stacks.get("DnsStack");
+
+console.log(siteStack?.getResource("SiteBucket")?.simResource);
+console.log(dnsStack?.getResource("SiteRecord")?.simResource);

--- a/docs/services/cloudformation/sim-cloudformation-cdk-out-stack-names.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-cdk-out-stack-names.example.ts
@@ -1,0 +1,10 @@
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+const stacks = await simAws.cloudFormation().deployCdkOut({
+  directoryPath: "cdk.out",
+  stackNames: ["SiteStack", "DnsStack"],
+});
+
+console.log(stacks.keys().toArray());

--- a/docs/services/cloudformation/sim-cloudformation-cdk-out-stack-options.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-cdk-out-stack-options.example.ts
@@ -1,0 +1,21 @@
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+const stacks = await simAws.cloudFormation().deployCdkOut({
+  directoryPath: "cdk.out",
+  stackNames: ["ApiStack"],
+  stackOptions: {
+    ApiStack: {
+      parameters: { Stage: "test" },
+      bindings: [
+        {
+          logicalId: "UploadFunction",
+          handler: (): { statusCode: number } => ({ statusCode: 200 }),
+        },
+      ],
+    },
+  },
+});
+
+console.log(stacks.get("ApiStack")?.stackName);

--- a/src/service/cloudformation/cdk/sim-cdk-assembly-manifest-file.ts
+++ b/src/service/cloudformation/cdk/sim-cdk-assembly-manifest-file.ts
@@ -1,0 +1,66 @@
+import { readFile } from "node:fs/promises";
+import { jsonParse, type JSONString } from "../../../util/type-guard/json.js";
+import type { AwsRegionName } from "../../aws/sim-aws-region.js";
+
+/** The file a CDK cloud assembly describes itself in. */
+export const CDK_ASSEMBLY_MANIFEST_FILE_NAME = "manifest.json";
+
+/** What an environment-agnostic Stack carries in place of a region. */
+const CDK_UNKNOWN_REGION = "unknown-region";
+
+interface SimCdkAssemblyArtifact {
+  readonly type?: string | undefined;
+  readonly environment?: string | undefined;
+  readonly dependencies?: readonly string[] | undefined;
+  readonly properties?:
+    | {
+        readonly templateFile?: string | undefined;
+        readonly stackName?: string | undefined;
+      }
+    | undefined;
+}
+
+export type SimCdkAssemblyArtifacts = Record<string, SimCdkAssemblyArtifact>;
+
+interface SimCdkAssemblyManifest {
+  readonly artifacts?: SimCdkAssemblyArtifacts | undefined;
+}
+
+/**
+ * Read the artifacts a CDK cloud assembly's `manifest.json` holds.
+ *
+ * Reading it is what tells a caller that the directory they named is a cloud
+ * assembly at all, so the failure names the file rather than the directory.
+ */
+export async function readCdkAssemblyArtifacts(
+  manifestPath: string,
+): Promise<SimCdkAssemblyArtifacts> {
+  try {
+    // oxlint-disable-next-line security/detect-non-literal-fs-filename
+    const body = await readFile(manifestPath, "utf8");
+    const manifest = jsonParse(body as JSONString<SimCdkAssemblyManifest>);
+
+    return manifest.artifacts ?? {};
+  } catch (error) {
+    throw new Error(
+      `Could not read the CDK cloud assembly manifest at ${manifestPath}. A cloud assembly is what \`cdk synth\` writes, and it holds a manifest naming every Stack in it.`,
+      { cause: error },
+    );
+  }
+}
+
+/**
+ * Read the region out of a CDK environment such as `aws://111111111111/eu-west-2`.
+ *
+ * An environment-agnostic Stack carries `unknown-region`, and takes its region
+ * from whoever deploys it instead.
+ */
+export function cdkEnvironmentRegionName(
+  environment: string | undefined,
+): AwsRegionName | undefined {
+  const regionName = environment?.split("/").at(-1);
+
+  return regionName === CDK_UNKNOWN_REGION
+    ? undefined
+    : (regionName as AwsRegionName | undefined);
+}

--- a/src/service/cloudformation/cdk/sim-cdk-assembly-manifest.iso.test.ts
+++ b/src/service/cloudformation/cdk/sim-cdk-assembly-manifest.iso.test.ts
@@ -1,0 +1,92 @@
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertMapSize,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { TemporaryDirectory } from "../../../util/filesystem/temporary-directory.js";
+import { jsonStringify } from "../../../util/type-guard/json.js";
+
+describe("Reading a CDK cloud assembly manifest [iso]", () => {
+  it("falls back to the names CDK synthesizes by for an artifact carrying no properties", async () => {
+    // Given a manifest whose Stack artifact names neither its template file nor
+    // the Stack it deploys as.
+    const directory = new TemporaryDirectory();
+
+    await directory.writeFile(
+      ["cdk.out", "manifest.json"],
+      jsonStringify({
+        artifacts: {
+          SiteStack: { type: "aws:cloudformation:stack" },
+          SiteStackAssets: { type: "cdk:asset-manifest" },
+        },
+      }),
+    );
+    await directory.writeFile(
+      ["cdk.out", "SiteStack.template.json"],
+      jsonStringify({
+        Resources: {
+          SiteBucket: {
+            Type: "AWS::S3::Bucket",
+            Properties: { BucketName: "fallback-site-bucket" },
+          },
+        },
+      }),
+    );
+
+    // When the assembly is deployed.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+    const stacks = await simAws
+      .cloudFormation()
+      .deployCdkOut(directory.join("cdk.out"));
+
+    // Then the artifact ID named both the template file and the Stack, and the
+    // artifact that is not a Stack was left alone.
+    assertArrayEquals(stacks.keys().toArray(), ["SiteStack"]);
+    assertIdentical(stacks.get("SiteStack")?.stackName, "SiteStack");
+    assertNonNullable(simAws.s3().getSimBucketByName("fallback-site-bucket"));
+  });
+
+  it("deploys nothing from a manifest holding no artifacts at all", async () => {
+    // Given a cloud assembly a synth wrote nothing into.
+    const directory = new TemporaryDirectory();
+
+    await directory.writeFile(["cdk.out", "manifest.json"], jsonStringify({}));
+
+    // When it is deployed.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+    const stacks = await simAws
+      .cloudFormation()
+      .deployCdkOut(directory.join("cdk.out"));
+
+    // Then there was nothing in it to deploy.
+    assertMapSize(stacks, 0);
+  });
+
+  it("says the assembly holds no Stacks when one is named and there are none", async () => {
+    // Given the same empty cloud assembly.
+    const directory = new TemporaryDirectory();
+
+    await directory.writeFile(["cdk.out", "manifest.json"], jsonStringify({}));
+
+    // When a Stack is named in it.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().deployCdkOut({
+        directoryPath: directory.join("cdk.out"),
+        stackNames: ["SiteStack"],
+      }),
+    );
+
+    // Then the failure says there was nothing it could have been asked for.
+    assertStringIncludes(error.message, "holds no Stack named SiteStack");
+    assertStringIncludes(error.message, "It holds no Stacks at all.");
+  });
+});

--- a/src/service/cloudformation/cdk/sim-cdk-assembly-manifest.ts
+++ b/src/service/cloudformation/cdk/sim-cdk-assembly-manifest.ts
@@ -1,0 +1,60 @@
+import path from "node:path";
+import type { AwsRegionName } from "../../aws/sim-aws-region.js";
+import {
+  CDK_ASSEMBLY_MANIFEST_FILE_NAME,
+  cdkEnvironmentRegionName,
+  readCdkAssemblyArtifacts,
+} from "./sim-cdk-assembly-manifest-file.js";
+
+const CDK_STACK_ARTIFACT_TYPE = "aws:cloudformation:stack";
+
+/**
+ * One CloudFormation Stack artifact in a CDK cloud assembly.
+ */
+export interface SimCdkAssemblyStack {
+  /** The key the artifact is held under, which other artifacts depend on. */
+  readonly artifactId: string;
+
+  /** The name the Stack is deployed as. */
+  readonly stackName: string;
+
+  /** The absolute path to the synthesized template file. */
+  readonly templatePath: string;
+
+  /**
+   * The region the Stack's environment names, absent when it names none.
+   */
+  readonly regionName?: AwsRegionName | undefined;
+
+  /** The artifacts this one comes after, Stacks and assets alike. */
+  readonly dependencyArtifactIds: readonly string[];
+}
+
+/**
+ * Read the Stack artifacts a CDK cloud assembly holds.
+ *
+ * The manifest is the only file that knows about the set. Each Stack artifact
+ * carries the template file to deploy, the environment naming its region, and
+ * the artifacts it comes after.
+ */
+export async function loadCdkAssemblyStacks(
+  directoryPath: string,
+): Promise<readonly SimCdkAssemblyStack[]> {
+  const assemblyPath = path.resolve(directoryPath);
+  const artifacts = await readCdkAssemblyArtifacts(
+    path.join(assemblyPath, CDK_ASSEMBLY_MANIFEST_FILE_NAME),
+  );
+
+  return Object.entries(artifacts)
+    .filter(([, artifact]) => artifact.type === CDK_STACK_ARTIFACT_TYPE)
+    .map(([artifactId, artifact]) => ({
+      artifactId,
+      stackName: artifact.properties?.stackName ?? artifactId,
+      templatePath: path.join(
+        assemblyPath,
+        artifact.properties?.templateFile ?? `${artifactId}.template.json`,
+      ),
+      regionName: cdkEnvironmentRegionName(artifact.environment),
+      dependencyArtifactIds: artifact.dependencies ?? [],
+    }));
+}

--- a/src/service/cloudformation/cdk/sim-cdk-assembly-order.ts
+++ b/src/service/cloudformation/cdk/sim-cdk-assembly-order.ts
@@ -1,0 +1,82 @@
+import type { SimCdkAssemblyStack } from "./sim-cdk-assembly-manifest.js";
+
+/**
+ * Put Stack artifacts into an order their dependencies allow.
+ *
+ * A Stack comes after every Stack it depends on. Artifacts outside the given
+ * set are left where they are, so a selected subset is ordered among itself
+ * and an assets artifact orders nothing.
+ *
+ * Stacks that depend on nothing keep the order the manifest holds them in.
+ */
+export function orderCdkAssemblyStacks(
+  stacks: readonly SimCdkAssemblyStack[],
+): readonly SimCdkAssemblyStack[] {
+  const ordering = new SimCdkAssemblyStackOrdering(stacks);
+
+  for (const stack of stacks) {
+    ordering.place(stack, []);
+  }
+
+  return ordering.ordered;
+}
+
+class SimCdkAssemblyStackOrdering {
+  public readonly ordered: SimCdkAssemblyStack[] = [];
+
+  private readonly byArtifactId: Map<string, SimCdkAssemblyStack>;
+  private readonly placed = new Set<string>();
+  private readonly placing = new Set<string>();
+
+  constructor(stacks: readonly SimCdkAssemblyStack[]) {
+    this.byArtifactId = new Map(
+      stacks.map((stack) => [stack.artifactId, stack]),
+    );
+  }
+
+  place(stack: SimCdkAssemblyStack, trail: readonly string[]): void {
+    if (this.placed.has(stack.artifactId)) {
+      return;
+    }
+
+    this.assertNoCycle(stack, trail);
+    this.placing.add(stack.artifactId);
+
+    for (const dependency of this.dependenciesOf(stack)) {
+      this.place(dependency, [...trail, stack.artifactId]);
+    }
+
+    this.placing.delete(stack.artifactId);
+    this.placed.add(stack.artifactId);
+    this.ordered.push(stack);
+  }
+
+  private dependenciesOf(
+    stack: SimCdkAssemblyStack,
+  ): readonly SimCdkAssemblyStack[] {
+    return stack.dependencyArtifactIds
+      .map((artifactId) => this.byArtifactId.get(artifactId))
+      .filter(
+        (dependency): dependency is SimCdkAssemblyStack =>
+          dependency !== undefined,
+      );
+  }
+
+  private assertNoCycle(
+    stack: SimCdkAssemblyStack,
+    trail: readonly string[],
+  ): void {
+    if (!this.placing.has(stack.artifactId)) {
+      return;
+    }
+
+    const cycle = [
+      ...trail.slice(trail.indexOf(stack.artifactId)),
+      stack.artifactId,
+    ];
+
+    throw new Error(
+      `The CDK cloud assembly holds Stacks that depend on each other in a cycle, so there is no order to deploy them in: ${cycle.join(" -> ")}.`,
+    );
+  }
+}

--- a/src/service/cloudformation/cdk/sim-cdk-assembly-selection.ts
+++ b/src/service/cloudformation/cdk/sim-cdk-assembly-selection.ts
@@ -1,0 +1,60 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimCdkAssemblyStack } from "./sim-cdk-assembly-manifest.js";
+
+/**
+ * Pick the named Stack artifacts out of a CDK cloud assembly.
+ *
+ * A name matches the Stack name or the artifact ID, since a CDK app under a
+ * Stage deploys a Stack whose artifact ID is not what the Stack is called.
+ * Naming nothing takes every Stack in the assembly.
+ *
+ * Throws naming the Stacks the assembly does hold, which is what a caller who
+ * has just renamed one needs to see.
+ */
+export function selectCdkAssemblyStacks(properties: {
+  readonly stacks: readonly SimCdkAssemblyStack[];
+  readonly stackNames?: readonly string[] | undefined;
+  readonly directoryPath: string;
+}): readonly SimCdkAssemblyStack[] {
+  const { stacks, stackNames, directoryPath } = properties;
+
+  if (stackNames === undefined) {
+    return stacks;
+  }
+
+  const selected = new Set(
+    stackNames.map((stackName) =>
+      selectOne({ stacks, stackName, directoryPath }),
+    ),
+  );
+
+  return stacks.filter((stack) => selected.has(stack));
+}
+
+function selectOne(properties: {
+  readonly stacks: readonly SimCdkAssemblyStack[];
+  readonly stackName: string;
+  readonly directoryPath: string;
+}): SimCdkAssemblyStack {
+  const { stacks, stackName, directoryPath } = properties;
+
+  const selected = stacks.find(
+    (stack) => stack.stackName === stackName || stack.artifactId === stackName,
+  );
+
+  assertDefined(
+    selected,
+    `The CDK cloud assembly at ${directoryPath} holds no Stack named ${stackName}. ` +
+      `It holds ${stackNameList(stacks)}.`,
+  );
+
+  return selected;
+}
+
+function stackNameList(stacks: readonly SimCdkAssemblyStack[]): string {
+  if (stacks.length === 0) {
+    return "no Stacks at all";
+  }
+
+  return stacks.map((stack) => stack.stackName).join(", ");
+}

--- a/src/service/cloudformation/cdk/sim-cdk-cloud-assembly.factory.ts
+++ b/src/service/cloudformation/cdk/sim-cdk-cloud-assembly.factory.ts
@@ -1,0 +1,135 @@
+import { AsyncMappedFactory } from "@kensio/part-factory";
+import { TemporaryDirectory } from "../../../util/filesystem/temporary-directory.js";
+import { jsonStringify } from "../../../util/type-guard/json.js";
+import type { SimCfnTemplateValueRecord } from "../template/value/sim-cfn-template-value.js";
+
+/**
+ * One synthesized Stack in a cloud assembly a test writes.
+ */
+export interface SimCdkCloudAssemblyStackInput {
+  /** The key the manifest holds the artifact under. */
+  readonly artifactId: string;
+
+  /** The name the Stack deploys as, which defaults to the artifact ID. */
+  readonly stackName?: string | undefined;
+
+  /**
+   * The region the Stack's environment names.
+   *
+   * Left out, the Stack is environment-agnostic, the way `cdk synth` writes a
+   * Stack given no `env`.
+   */
+  readonly regionName?: string | undefined;
+
+  /** The artifact IDs the manifest says this Stack comes after. */
+  readonly dependencies?: readonly string[] | undefined;
+
+  /**
+   * The template's Resources, which default to one Bucket named after the
+   * artifact, so a test can find the Stack's work in the region it landed in.
+   */
+  readonly resources?: SimCfnTemplateValueRecord | undefined;
+
+  /** The template's Outputs, which a Stack sharing a value needs. */
+  readonly outputs?: SimCfnTemplateValueRecord | undefined;
+}
+
+export interface SimCdkCloudAssemblyInput {
+  readonly stacks: readonly SimCdkCloudAssemblyStackInput[];
+}
+
+/** The Bucket a Stack in a written assembly creates, unless it is given others. */
+export function assemblyStackBucketName(artifactId: string): string {
+  return `${artifactId.toLowerCase()}-bucket`;
+}
+
+/**
+ * Writes a synthesized CDK cloud assembly to a temporary directory.
+ *
+ * What comes back is the directory holding it, so the assembly itself is at
+ * `directory.join("cdk.out")`.
+ *
+ * ```typescript
+ * const directory = await simCdkCloudAssemblyFactory.make({
+ *   stacks: [
+ *     { artifactId: "SiteStack", regionName: "eu-west-2" },
+ *     { artifactId: "DnsStack", regionName: "us-east-1" },
+ *   ],
+ * });
+ * ```
+ */
+export const simCdkCloudAssemblyFactory = new AsyncMappedFactory<
+  SimCdkCloudAssemblyInput,
+  TemporaryDirectory
+>(
+  () => ({ stacks: [{ artifactId: "SiteStack", regionName: "eu-west-2" }] }),
+  async (input) => {
+    const directory = new TemporaryDirectory();
+
+    await directory.writeFile(
+      ["cdk.out", "manifest.json"],
+      jsonStringify(assemblyManifest(input.stacks)),
+    );
+
+    await Promise.all(
+      input.stacks.map(async (stack) =>
+        directory.writeFile(
+          ["cdk.out", templateFileName(stack)],
+          // JSON.stringify drops an undefined value, so a Stack given no
+          // Outputs writes a template with none rather than a null one.
+          jsonStringify({
+            Resources: stackResources(stack),
+            Outputs: stack.outputs,
+          }),
+        ),
+      ),
+    );
+
+    return directory;
+  },
+);
+
+function assemblyManifest(
+  stacks: readonly SimCdkCloudAssemblyStackInput[],
+): object {
+  return {
+    version: "54.0.0",
+    artifacts: Object.fromEntries(
+      stacks.map((stack) => [
+        stack.artifactId,
+        {
+          type: "aws:cloudformation:stack",
+          environment: `aws://111111111111/${stack.regionName ?? "unknown-region"}`,
+          displayName: stack.artifactId,
+          dependencies: [
+            ...(stack.dependencies ?? []),
+            `${stack.artifactId}.assets`,
+          ],
+          properties: {
+            templateFile: templateFileName(stack),
+            stackName: stack.stackName,
+          },
+        },
+      ]),
+    ),
+  };
+}
+
+function templateFileName(stack: SimCdkCloudAssemblyStackInput): string {
+  return `${stack.artifactId}.template.json`;
+}
+
+function stackResources(
+  stack: SimCdkCloudAssemblyStackInput,
+): SimCfnTemplateValueRecord {
+  return (
+    stack.resources ?? {
+      [`${stack.artifactId}Bucket`]: {
+        Type: "AWS::S3::Bucket",
+        Properties: {
+          BucketName: assemblyStackBucketName(stack.artifactId),
+        },
+      },
+    }
+  );
+}

--- a/src/service/cloudformation/deploy/sim-cfn-cdk-out-assembly-failures.iso.test.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-cdk-out-assembly-failures.iso.test.ts
@@ -1,0 +1,83 @@
+import { assertStringIncludes, assertThrowsErrorAsync } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simCdkCloudAssemblyFactory } from "../cdk/sim-cdk-cloud-assembly.factory.js";
+
+describe("Deploying a CDK cloud assembly that cannot be deployed [iso]", () => {
+  it("fails naming the manifest it looked for when the directory holds no cloud assembly", async () => {
+    // Given a directory that is not a cloud assembly, since the assembly is
+    // written in the `cdk.out` beneath it.
+    const directory = await simCdkCloudAssemblyFactory.make({
+      stacks: [{ artifactId: "SiteStack", regionName: "eu-west-2" }],
+    });
+
+    // When it is deployed.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().deployCdkOut(directory.path()),
+    );
+
+    // Then the failure names the file it expected to find.
+    assertStringIncludes(
+      error.message,
+      "Could not read the CDK cloud assembly manifest at",
+    );
+    assertStringIncludes(error.message, "manifest.json");
+  });
+
+  it("fails naming the Stacks the assembly does hold when asked for one it lacks", async () => {
+    // Given an assembly holding a Stack under a name a caller no longer uses.
+    const directory = await simCdkCloudAssemblyFactory.make({
+      stacks: [
+        { artifactId: "SiteStack", regionName: "eu-west-2" },
+        { artifactId: "DataStack", regionName: "eu-west-2" },
+      ],
+    });
+
+    // When the old name is asked for.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().deployCdkOut({
+        directoryPath: directory.join("cdk.out"),
+        stackNames: ["WebsiteStack"],
+      }),
+    );
+
+    // Then the failure says what it could have been asked for instead.
+    assertStringIncludes(error.message, "holds no Stack named WebsiteStack");
+    assertStringIncludes(error.message, "It holds SiteStack, DataStack.");
+  });
+
+  it("fails when the Stacks in the assembly depend on each other in a cycle", async () => {
+    // Given an assembly whose two Stacks each come after the other.
+    const directory = await simCdkCloudAssemblyFactory.make({
+      stacks: [
+        {
+          artifactId: "SiteStack",
+          regionName: "eu-west-2",
+          dependencies: ["DataStack"],
+        },
+        {
+          artifactId: "DataStack",
+          regionName: "eu-west-2",
+          dependencies: ["SiteStack"],
+        },
+      ],
+    });
+
+    // When the assembly is deployed.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().deployCdkOut(directory.join("cdk.out")),
+    );
+
+    // Then the failure names the cycle rather than deploying either of them.
+    assertStringIncludes(
+      error.message,
+      "there is no order to deploy them in: SiteStack -> DataStack -> SiteStack",
+    );
+  });
+});

--- a/src/service/cloudformation/deploy/sim-cfn-cdk-out-deployer.iso.test.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-cdk-out-deployer.iso.test.ts
@@ -1,0 +1,230 @@
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import {
+  assemblyStackBucketName,
+  simCdkCloudAssemblyFactory,
+} from "../cdk/sim-cdk-cloud-assembly.factory.js";
+
+describe("Deploying a CDK cloud assembly [iso]", () => {
+  it("deploys each Stack into the region its own environment names", async () => {
+    // Given a synthesized cloud assembly holding two Stacks in two regions.
+    const directory = await simCdkCloudAssemblyFactory.make({
+      stacks: [
+        { artifactId: "SiteStack", regionName: "eu-west-2" },
+        { artifactId: "DnsStack", regionName: "us-east-1" },
+      ],
+    });
+
+    // When the assembly directory is deployed.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+    const stacks = await simAws
+      .cloudFormation()
+      .deployCdkOut(directory.join("cdk.out"));
+
+    // Then each Stack's work landed in the region its environment names.
+    assertNonNullable(
+      simAws
+        .region("eu-west-2")
+        .s3()
+        .getSimBucketByName(assemblyStackBucketName("SiteStack")),
+    );
+    assertNonNullable(
+      simAws
+        .region("us-east-1")
+        .s3()
+        .getSimBucketByName(assemblyStackBucketName("DnsStack")),
+    );
+
+    // And nothing was deployed into the region the caller happened to be in.
+    assertUndefined(
+      simAws
+        .region("eu-west-2")
+        .s3()
+        .getSimBucketByName(assemblyStackBucketName("DnsStack")),
+    );
+
+    // And both Stacks came back by name.
+    assertArrayEquals(stacks.keys().toArray().toSorted(compareStackNames), [
+      "DnsStack",
+      "SiteStack",
+    ]);
+  });
+
+  it("deploys a Stack after the Stack the manifest says it depends on", async () => {
+    // Given an assembly holding a Stack ahead of the one it depends on.
+    const directory = await simCdkCloudAssemblyFactory.make({
+      stacks: [
+        {
+          artifactId: "SiteStack",
+          regionName: "eu-west-2",
+          dependencies: ["DataStack"],
+        },
+        { artifactId: "DataStack", regionName: "eu-west-2" },
+      ],
+    });
+
+    // When the assembly is deployed.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+    const stacks = await simAws
+      .cloudFormation()
+      .deployCdkOut(directory.join("cdk.out"));
+
+    // Then the dependency went first, whatever order the manifest holds them in.
+    assertArrayEquals(stacks.keys().toArray(), ["DataStack", "SiteStack"]);
+  });
+
+  it("deploys only the named Stacks, leaving the rest of the assembly alone", async () => {
+    // Given an assembly that also synthesizes a deployment pipeline no test wants.
+    const directory = await simCdkCloudAssemblyFactory.make({
+      stacks: [
+        { artifactId: "SiteStack", regionName: "eu-west-2" },
+        { artifactId: "PipelineStack", regionName: "eu-west-2" },
+      ],
+    });
+
+    // When only the site Stack is named.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+    const stacks = await simAws.cloudFormation().deployCdkOut({
+      directoryPath: directory.join("cdk.out"),
+      stackNames: ["SiteStack"],
+    });
+
+    // Then the pipeline Stack was never deployed.
+    assertArrayEquals(stacks.keys().toArray(), ["SiteStack"]);
+    assertUndefined(
+      simAws
+        .region("eu-west-2")
+        .s3()
+        .getSimBucketByName(assemblyStackBucketName("PipelineStack")),
+    );
+  });
+
+  it("deploys an environment-agnostic Stack into the region it is asked in", async () => {
+    // Given an assembly whose Stack was synthesized with no `env`.
+    const directory = await simCdkCloudAssemblyFactory.make({
+      stacks: [{ artifactId: "SiteStack" }],
+    });
+
+    // When it is deployed through a scope in a region of the caller's choosing.
+    const simAws = new SimAws();
+
+    await simAws
+      .region("ap-southeast-2")
+      .cloudFormation()
+      .deployCdkOut(directory.join("cdk.out"));
+
+    // Then that is the region it landed in.
+    assertNonNullable(
+      simAws
+        .region("ap-southeast-2")
+        .s3()
+        .getSimBucketByName(assemblyStackBucketName("SiteStack")),
+    );
+  });
+
+  it("answers with the same Stack a single-template deployment answers with", async () => {
+    // Given a deployed cloud assembly.
+    const directory = await simCdkCloudAssemblyFactory.make({
+      stacks: [{ artifactId: "SiteStack", regionName: "eu-west-2" }],
+    });
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+    // When the Stack is taken from what the deployment answered with.
+    const stacks = await simAws
+      .cloudFormation()
+      .deployCdkOut(directory.join("cdk.out"));
+    const stack = stacks.get("SiteStack");
+
+    // Then it is the Stack simulated CloudFormation holds under that name.
+    assertNonNullable(stack);
+    assertIdentical(stack.stackName, "SiteStack");
+    assertIdentical(stack, simAws.cloudFormation().getStackByName("SiteStack"));
+  });
+
+  it("deploys a Stack named by its CDK artifact ID when the Stack name differs", async () => {
+    // Given an assembly holding a Stack under a Stage, where the artifact ID
+    // and the Stack name are not the same.
+    const directory = await simCdkCloudAssemblyFactory.make({
+      stacks: [
+        {
+          artifactId: "ProdStageSiteStack",
+          stackName: "Prod-SiteStack",
+          regionName: "eu-west-2",
+        },
+      ],
+    });
+
+    // When it is named by its artifact ID.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+    const stacks = await simAws.cloudFormation().deployCdkOut({
+      directoryPath: directory.join("cdk.out"),
+      stackNames: ["ProdStageSiteStack"],
+    });
+
+    // Then it deployed under the name the manifest gives it.
+    assertArrayEquals(stacks.keys().toArray(), ["Prod-SiteStack"]);
+  });
+
+  it("deploys a Stack after the one whose export it imports", async () => {
+    // Given an assembly where a Stack shares a value with another, the way CDK
+    // emits an Export on the producer and an Fn::ImportValue on the consumer.
+    const directory = await simCdkCloudAssemblyFactory.make({
+      stacks: [
+        {
+          artifactId: "ConsumerStack",
+          regionName: "eu-west-2",
+          dependencies: ["ProducerStack"],
+          resources: {
+            ConsumerTopic: {
+              Type: "AWS::SNS::Topic",
+              Properties: {
+                TopicName: "consumer-topic",
+                DisplayName: { "Fn::ImportValue": "ProducerStack:BucketName" },
+              },
+            },
+          },
+        },
+        {
+          artifactId: "ProducerStack",
+          regionName: "eu-west-2",
+          outputs: {
+            BucketName: {
+              Value: { Ref: "ProducerStackBucket" },
+              Export: { Name: "ProducerStack:BucketName" },
+            },
+          },
+        },
+      ],
+    });
+
+    // When the assembly is deployed in one call.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+    const stacks = await simAws
+      .cloudFormation()
+      .deployCdkOut(directory.join("cdk.out"));
+
+    // Then the producer had published its export by the time the consumer
+    // imported it, so the import resolved to the value the producer exported.
+    assertIdentical(
+      stacks.get("ConsumerStack")?.resources.get("ConsumerTopic")?.properties[
+        "DisplayName"
+      ],
+      assemblyStackBucketName("ProducerStack"),
+    );
+  });
+});
+
+function compareStackNames(left: string, right: string): number {
+  return left.localeCompare(right);
+}

--- a/src/service/cloudformation/deploy/sim-cfn-cdk-out-deployer.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-cdk-out-deployer.ts
@@ -1,0 +1,65 @@
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimCfnStack } from "../stack/sim-cfn-stack.js";
+import { cdkOutOptionsFor } from "./sim-cfn-cdk-out-stack-options.js";
+import {
+  planCdkOutDeployment,
+  type SimCfnCdkOutPlan,
+  type SimCfnCdkOutPlannedStack,
+  type SimCloudFormationDeployCdkOutProperties,
+} from "./sim-cfn-cdk-out-plan.js";
+
+export type { SimCfnCdkOutStackOptions } from "./sim-cfn-cdk-out-stack-options.js";
+export type { SimCloudFormationDeployCdkOutProperties } from "./sim-cfn-cdk-out-plan.js";
+
+interface SimCfnCdkOutDeployerProperties {
+  readonly simAws: SimAws;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * Deploys the Stacks a CDK cloud assembly holds, each into its own region.
+ *
+ * The Account is the one this deployer was made in. Only the region moves,
+ * since that is what a synthesized environment names and what a caller
+ * otherwise has to keep a constant for.
+ */
+export class SimCfnCdkOutDeployer {
+  constructor(private readonly scope: SimCfnCdkOutDeployerProperties) {}
+
+  async deploy(
+    request: SimCloudFormationDeployCdkOutProperties | string,
+  ): Promise<ReadonlyMap<string, SimCfnStack>> {
+    const plan = await planCdkOutDeployment({
+      request,
+      defaultRegionName: this.scope.accountRegionScope.regionName,
+    });
+
+    const deployed = new Map<string, SimCfnStack>();
+
+    for (const stack of plan.stacks) {
+      // oxlint-disable-next-line no-await-in-loop -- one Stack at a time, since a later one may depend on an earlier one
+      const deployedStack = await this.deployStack(stack, plan);
+
+      deployed.set(stack.stackName, deployedStack);
+    }
+
+    return deployed;
+  }
+
+  private async deployStack(
+    stack: SimCfnCdkOutPlannedStack,
+    plan: SimCfnCdkOutPlan,
+  ): Promise<SimCfnStack> {
+    const { simAws, accountRegionScope } = this.scope;
+
+    return await simAws
+      .accountRegionScope(accountRegionScope.accountId, stack.regionName)
+      .cloudFormation()
+      .deployTemplateFile({
+        templatePath: stack.templatePath,
+        stackName: stack.stackName,
+        ...cdkOutOptionsFor(stack, plan.stackOptions),
+      });
+  }
+}

--- a/src/service/cloudformation/deploy/sim-cfn-cdk-out-plan.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-cdk-out-plan.ts
@@ -1,0 +1,83 @@
+import path from "node:path";
+import type { AwsRegionName } from "../../aws/sim-aws-region.js";
+import {
+  loadCdkAssemblyStacks,
+  type SimCdkAssemblyStack,
+} from "../cdk/sim-cdk-assembly-manifest.js";
+import { orderCdkAssemblyStacks } from "../cdk/sim-cdk-assembly-order.js";
+import { selectCdkAssemblyStacks } from "../cdk/sim-cdk-assembly-selection.js";
+import {
+  assertCdkOutOptionsAreDeployed,
+  type SimCfnCdkOutStackOptionsByName,
+} from "./sim-cfn-cdk-out-stack-options.js";
+
+export interface SimCloudFormationDeployCdkOutProperties {
+  /** The `cdk.out` directory to deploy, holding a `manifest.json`. */
+  readonly directoryPath: string;
+
+  /**
+   * The Stacks to deploy, named by Stack name or by CDK artifact ID.
+   *
+   * Every Stack in the assembly is deployed when this is left out, which is
+   * rarely what a test wants of an app that also synthesizes a deployment
+   * pipeline.
+   */
+  readonly stackNames?: readonly string[] | undefined;
+
+  /**
+   * Bindings, parameters and a transform for individual Stacks, keyed the same
+   * way `stackNames` names them.
+   */
+  readonly stackOptions?: SimCfnCdkOutStackOptionsByName | undefined;
+}
+
+/** A Stack to deploy, in the region it has been resolved into. */
+export interface SimCfnCdkOutPlannedStack extends SimCdkAssemblyStack {
+  readonly regionName: AwsRegionName;
+}
+
+export interface SimCfnCdkOutPlan {
+  readonly stacks: readonly SimCfnCdkOutPlannedStack[];
+  readonly stackOptions?: SimCfnCdkOutStackOptionsByName | undefined;
+}
+
+/**
+ * Work out which Stacks to deploy, in what order, and into which region.
+ *
+ * Everything a deployment decides from the cloud assembly is decided here, so
+ * an assembly that cannot be deployed says so before any Stack is created.
+ */
+export async function planCdkOutDeployment(properties: {
+  readonly request: SimCloudFormationDeployCdkOutProperties | string;
+  readonly defaultRegionName: AwsRegionName;
+}): Promise<SimCfnCdkOutPlan> {
+  const { directoryPath, stackNames, stackOptions } = cdkOutDeployment(
+    properties.request,
+  );
+
+  const selected = selectCdkAssemblyStacks({
+    stacks: await loadCdkAssemblyStacks(directoryPath),
+    stackNames,
+    directoryPath: path.resolve(directoryPath),
+  });
+
+  assertCdkOutOptionsAreDeployed(stackOptions, selected);
+
+  return {
+    stacks: orderCdkAssemblyStacks(selected).map((stack) => ({
+      ...stack,
+      regionName: stack.regionName ?? properties.defaultRegionName,
+    })),
+    stackOptions,
+  };
+}
+
+/**
+ * Normalize a cloud assembly deployment request, which may be the directory
+ * path on its own.
+ */
+function cdkOutDeployment(
+  request: SimCloudFormationDeployCdkOutProperties | string,
+): SimCloudFormationDeployCdkOutProperties {
+  return typeof request === "string" ? { directoryPath: request } : request;
+}

--- a/src/service/cloudformation/deploy/sim-cfn-cdk-out-stack-options.iso.test.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-cdk-out-stack-options.iso.test.ts
@@ -1,0 +1,161 @@
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import {
+  assemblyStackBucketName,
+  simCdkCloudAssemblyFactory,
+} from "../cdk/sim-cdk-cloud-assembly.factory.js";
+import type { SimCfnTemplateValueRecord } from "../template/value/sim-cfn-template-value.js";
+
+const assumeRolePolicyDocument = {
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Principal: { Service: "lambda.amazonaws.com" },
+      Action: "sts:AssumeRole",
+    },
+  ],
+};
+
+const functionStackResources: SimCfnTemplateValueRecord = {
+  GreeterRole: {
+    Type: "AWS::IAM::Role",
+    Properties: {
+      RoleName: "greeter-role",
+      AssumeRolePolicyDocument: assumeRolePolicyDocument,
+    },
+  },
+  GreeterFunction: {
+    Type: "AWS::Lambda::Function",
+    Properties: {
+      FunctionName: "greeter",
+      Role: { "Fn::GetAtt": ["GreeterRole", "Arn"] },
+      Code: { ZipFile: "exports.handler = async () => 'synthesized';" },
+      Handler: "index.handler",
+      Runtime: "nodejs22.x",
+    },
+  },
+};
+
+describe("Deploying a CDK cloud assembly with per-Stack options [iso]", () => {
+  it("binds a handler to the Stack the binding is keyed against", async () => {
+    // Given an assembly holding a Stack with a function in it, beside another.
+    const directory = await simCdkCloudAssemblyFactory.make({
+      stacks: [
+        {
+          artifactId: "ApiStack",
+          regionName: "eu-west-2",
+          resources: functionStackResources,
+        },
+        { artifactId: "SiteStack", regionName: "eu-west-2" },
+      ],
+    });
+
+    // When the assembly is deployed with a handler bound to that one Stack.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+    await simAws.cloudFormation().deployCdkOut({
+      directoryPath: directory.join("cdk.out"),
+      stackOptions: {
+        ApiStack: {
+          bindings: [
+            { logicalId: "GreeterFunction", handler: () => "bound in process" },
+          ],
+        },
+      },
+    });
+
+    // Then invoking the deployed function runs the bound handler.
+    const output = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "greeter" }));
+
+    assertNonNullable(output.Payload);
+    assertIdentical(
+      Buffer.from(output.Payload).toString(),
+      '"bound in process"',
+    );
+  });
+
+  it("transforms only the Stack the transform is keyed against", async () => {
+    // Given an assembly holding two Stacks that each create a Bucket.
+    const directory = await simCdkCloudAssemblyFactory.make({
+      stacks: [
+        { artifactId: "SiteStack", regionName: "eu-west-2" },
+        { artifactId: "DataStack", regionName: "eu-west-2" },
+      ],
+    });
+
+    // When one of them is deployed through a transform that renames its Bucket.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+    await simAws.cloudFormation().deployCdkOut({
+      directoryPath: directory.join("cdk.out"),
+      stackOptions: {
+        SiteStack: {
+          transform: (template) => ({
+            ...template,
+            Resources: {
+              SiteStackBucket: {
+                Type: "AWS::S3::Bucket",
+                Properties: { BucketName: "renamed-by-transform" },
+              },
+            },
+          }),
+        },
+      },
+    });
+
+    // Then that Stack deployed what the transform returned.
+    const s3 = simAws.region("eu-west-2").s3();
+
+    assertNonNullable(s3.getSimBucketByName("renamed-by-transform"));
+    assertUndefined(
+      s3.getSimBucketByName(assemblyStackBucketName("SiteStack")),
+    );
+
+    // And the Stack the transform was not keyed against deployed its own.
+    assertNonNullable(
+      s3.getSimBucketByName(assemblyStackBucketName("DataStack")),
+    );
+  });
+
+  it("fails when options name a Stack that is not being deployed", async () => {
+    // Given an assembly whose Stack has since been renamed.
+    const directory = await simCdkCloudAssemblyFactory.make({
+      stacks: [{ artifactId: "SiteStack", regionName: "eu-west-2" }],
+    });
+
+    // When options are keyed against the name it used to have.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().deployCdkOut({
+        directoryPath: directory.join("cdk.out"),
+        stackOptions: {
+          WebsiteStack: {
+            bindings: [{ logicalId: "Greeter", handler: () => "never runs" }],
+          },
+        },
+      }),
+    );
+
+    // Then the deployment says so rather than quietly losing the bindings.
+    assertStringIncludes(
+      error.message,
+      "Options were given for WebsiteStack, which no Stack being deployed is named.",
+    );
+    assertStringIncludes(
+      error.message,
+      "The Stacks being deployed are SiteStack.",
+    );
+  });
+});

--- a/src/service/cloudformation/deploy/sim-cfn-cdk-out-stack-options.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-cdk-out-stack-options.ts
@@ -1,0 +1,61 @@
+import type { SimCdkAssemblyStack } from "../cdk/sim-cdk-assembly-manifest.js";
+import type { SimCfnDeployBinding } from "../bind/sim-cfn-deploy-binding.js";
+import type { SimCfnTemplateFileTransform } from "./sim-cfn-template-file-transform.js";
+
+/**
+ * What one Stack in a cloud assembly is deployed with.
+ *
+ * These are the per-template options `deployTemplateFile` takes, for the one
+ * Stack they are keyed against.
+ */
+export interface SimCfnCdkOutStackOptions {
+  readonly parameters?: Record<string, string> | undefined;
+  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
+  readonly transform?: SimCfnTemplateFileTransform | undefined;
+}
+
+export type SimCfnCdkOutStackOptionsByName = Record<
+  string,
+  SimCfnCdkOutStackOptions
+>;
+
+/**
+ * The options a Stack is deployed with, keyed by Stack name or artifact ID.
+ */
+export function cdkOutOptionsFor(
+  stack: SimCdkAssemblyStack,
+  optionsByName: SimCfnCdkOutStackOptionsByName | undefined,
+): SimCfnCdkOutStackOptions {
+  return (
+    optionsByName?.[stack.stackName] ?? optionsByName?.[stack.artifactId] ?? {}
+  );
+}
+
+/**
+ * Refuse options keyed against a Stack that is not being deployed.
+ *
+ * A renamed Stack would otherwise take its bindings and its transform with it
+ * without saying anything, and the deployment that lost them looks like one
+ * that never had them.
+ */
+export function assertCdkOutOptionsAreDeployed(
+  optionsByName: SimCfnCdkOutStackOptionsByName | undefined,
+  deploying: readonly SimCdkAssemblyStack[],
+): void {
+  const names = new Set(
+    deploying.flatMap((stack) => [stack.stackName, stack.artifactId]),
+  );
+  const unmatched = Object.keys(optionsByName ?? {}).filter(
+    (name) => !names.has(name),
+  );
+
+  if (unmatched.length > 0) {
+    throw new Error(
+      `Options were given for ${unmatched.join(", ")}, which no Stack being deployed is named. The Stacks being deployed are ${stackNames(deploying)}.`,
+    );
+  }
+}
+
+function stackNames(stacks: readonly SimCdkAssemblyStack[]): string {
+  return stacks.map((stack) => stack.stackName).join(", ");
+}

--- a/src/service/cloudformation/deploy/sim-cfn-template-deployer.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-template-deployer.ts
@@ -14,6 +14,10 @@ import {
   type SimCloudFormationDeployTemplateFileProperties as SimCloudFormationDeployTemplateFileProperties,
 } from "./sim-cfn-template-file-loader.js";
 import { SimCfnTemplateFileUpdater } from "./sim-cfn-template-file-updater.js";
+import {
+  SimCfnCdkOutDeployer,
+  type SimCloudFormationDeployCdkOutProperties,
+} from "./sim-cfn-cdk-out-deployer.js";
 import { simCfnTemplateFileDeployment } from "./sim-cfn-template-file-deployment.js";
 import { SimCfnTemplateFileWatches } from "../watch/sim-cfn-template-file-watches.js";
 import type { SimCfnDeployBinding } from "../bind/sim-cfn-deploy-binding.js";
@@ -73,6 +77,7 @@ export class SimCloudFormationTemplateDeployer {
   private readonly exports: SimCfnExports | undefined;
   private readonly templateFileLoader = new SimCfnTemplateFileLoader();
   private readonly templateFileUpdater: SimCfnTemplateFileUpdater;
+  private readonly cdkOutDeployer: SimCfnCdkOutDeployer;
   private readonly watches: SimCfnTemplateFileWatches;
 
   constructor(properties: SimCloudFormationTemplateDeployerProperties) {
@@ -88,6 +93,10 @@ export class SimCloudFormationTemplateDeployer {
     });
     this.watches = new SimCfnTemplateFileWatches({
       updater: this.templateFileUpdater,
+    });
+    this.cdkOutDeployer = new SimCfnCdkOutDeployer({
+      simAws: this.simAws,
+      accountRegionScope: this.accountRegionScope,
     });
   }
 
@@ -128,6 +137,15 @@ export class SimCloudFormationTemplateDeployer {
     this.watches.watchIfAsked(deployment);
 
     return stack;
+  }
+
+  /**
+   * Deploy the Stacks a synthesized CDK cloud assembly holds.
+   */
+  async deployCdkOut(
+    properties: SimCloudFormationDeployCdkOutProperties | string,
+  ): Promise<ReadonlyMap<string, SimCfnStack>> {
+    return await this.cdkOutDeployer.deploy(properties);
   }
 
   /**

--- a/src/service/cloudformation/index.ts
+++ b/src/service/cloudformation/index.ts
@@ -1,6 +1,8 @@
 export { SimCloudFormation } from "./sim-cloudformation.js";
 export type { CfnTemplateBodyRecord } from "./template/sim-cfn-template.js";
 export type { SimCfnTemplateFileTransform } from "./deploy/sim-cfn-template-file-transform.js";
+export type { SimCloudFormationDeployCdkOutProperties } from "./deploy/sim-cfn-cdk-out-deployer.js";
+export type { SimCfnCdkOutStackOptions } from "./deploy/sim-cfn-cdk-out-stack-options.js";
 export type {
   SimCfnTemplateFileWatchOptions,
   SimCfnWatchReloadTarget,

--- a/src/service/cloudformation/sim-cloudformation.ts
+++ b/src/service/cloudformation/sim-cloudformation.ts
@@ -29,13 +29,12 @@ import type {
   SimUpdateStackCommandOutput,
 } from "./command/update-stack/update-stack.command.js";
 import { UpdateStackCommandHandler } from "./command/update-stack/update-stack.handler.js";
-import type { SimCdkOutContext } from "./cdk/sim-cdk-out-context.js";
 import {
   type SimCloudFormationCreateStackProperties as SimCloudFormationCreateStackProperties,
   SimCloudFormationTemplateDeployer,
 } from "./deploy/sim-cfn-template-deployer.js";
 import type { SimCloudFormationDeployTemplateFileProperties as SimCloudFormationDeployTemplateFileProperties } from "./deploy/sim-cfn-template-file-loader.js";
-import type { SimCfnDeployBinding } from "./bind/sim-cfn-deploy-binding.js";
+import type { SimCloudFormationDeployCdkOutProperties } from "./deploy/sim-cfn-cdk-out-deployer.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
 import { SimCfnExports } from "./export/sim-cfn-exports.js";
 import { SimCloudFormationSdkCommandRouter } from "./sdk/sim-cloudformation-sdk-command-router.js";
@@ -116,7 +115,14 @@ export class SimCloudFormation {
     options?: SimCloudFormationRequestOptions,
   ): Promise<SimCreateStackCommandOutput> {
     this.authorization.createStack(command.input.StackName, options?.caller);
-    return await this.createStackWithContext(command);
+
+    return await new CreateStackCommandHandler({
+      simAws: this.simAws,
+      accountRegionScope: this.accountRegionScope,
+      stacks: this.stacks,
+      background: this.background,
+      exports: this.exports,
+    }).handle(command);
   }
 
   /**
@@ -223,6 +229,16 @@ export class SimCloudFormation {
   }
 
   /**
+   * Convenience wrapper method to deploy the Stacks a synthesized CDK cloud
+   * assembly holds, each into the region its own environment names.
+   */
+  async deployCdkOut(
+    properties: SimCloudFormationDeployCdkOutProperties | string,
+  ): Promise<ReadonlyMap<string, SimCfnStack>> {
+    return await this.templateDeployer.deployCdkOut(properties);
+  }
+
+  /**
    * Convenience wrapper method to apply a synthesized CDK template file to the
    * simulated CloudFormation Stack it was deployed as.
    *
@@ -279,22 +295,5 @@ export class SimCloudFormation {
    */
   sdkCommandRouter(): SimSdkCommandRouter {
     return this.sdkRouter;
-  }
-
-  private async createStackWithContext(
-    command: SimCreateStackCommand,
-    cdkOutContext?: SimCdkOutContext,
-    bindings?: readonly SimCfnDeployBinding[],
-  ): Promise<SimCreateStackCommandOutput> {
-    const handler = new CreateStackCommandHandler({
-      simAws: this.simAws,
-      accountRegionScope: this.accountRegionScope,
-      stacks: this.stacks,
-      background: this.background,
-      cdkOutContext,
-      bindings,
-      exports: this.exports,
-    });
-    return await handler.handle(command);
   }
 }


### PR DESCRIPTION
Yulin deployed one template at a time. An app with more than one Stack orchestrated the set by hand, working out which templates to deploy, in what order, and which region each one belongs in. `deployCdkOut` reads the cloud assembly's own `manifest.json`, which is the file that knows about the set, and deploys the Stacks it finds. Each one goes into the region its `environment` names, in an order their manifest dependencies allow, and the deployed Stacks come back keyed by name. `stackNames` picks a subset, since a test rarely wants the deployment pipeline an app also synthesizes, and `stackOptions` carries bindings, parameters and a transform to individual Stacks.

Resolves https://github.com/KensioSoftware/yulin/issues/700

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`

Two things worth a reviewer's attention.

`SimCloudFormation` was at 295 of its 300 allowed lines, so the wrapper needed room. The private `createStackWithContext` took a `cdkOutContext` and a `bindings` argument that its one caller never passed, and it is now inlined into `createStack`. Nothing about that call changes.

The module split is finer than the feature needs. Both the deployer and the manifest reader scored over the FTA threshold of 50 as single files, and cyclomatic complexity turned out to be the term that moved the score, so the plan, the per-Stack options and the manifest file reading each became their own module.

The manifest reader was run against a real five-Stack CDK assembly across two regions, as well as against the written fixtures the tests use.
