### PR TITLE
feat: resolve SSM dynamic references

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -920,6 +920,18 @@ deploy. A deleted Stack releases its export names, leaving them free for the nex
 
 Exports are scoped per Account and Region, as they are on AWS. A Stack in one Region reads only the
 exports published in that Region.
+## Dynamic references
+
+A `{{resolve:...}}` dynamic reference reads a value from another service while a resource is being
+created. It is written into the template as ordinary text, so it can sit inside a longer string and
+inside `Fn::Sub`.
+
+`{{resolve:ssm:name}}` and `{{resolve:ssm:name:3}}` read a simulated SSM parameter. See
+[reading a parameter with a dynamic reference](../ssm/README.md#reading-a-parameter-with-a-dynamic-reference)
+for what they resolve to and what happens to one Parameter Store cannot answer.
+
+`{{resolve:ssm-secure:...}}` and `{{resolve:secretsmanager:...}}` are left in the template as
+written. Neither is resolved yet.
 
 ## Conditions
 

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -920,6 +920,7 @@ deploy. A deleted Stack releases its export names, leaving them free for the nex
 
 Exports are scoped per Account and Region, as they are on AWS. A Stack in one Region reads only the
 exports published in that Region.
+
 ## Dynamic references
 
 A `{{resolve:...}}` dynamic reference reads a value from another service while a resource is being
@@ -928,7 +929,7 @@ inside `Fn::Sub`.
 
 `{{resolve:ssm:name}}` and `{{resolve:ssm:name:3}}` read a simulated SSM parameter. See
 [reading a parameter with a dynamic reference](../ssm/README.md#reading-a-parameter-with-a-dynamic-reference)
-for what they resolve to and what happens to one Parameter Store cannot answer.
+for what they resolve to, and for what happens when Parameter Store cannot answer one.
 
 `{{resolve:ssm-secure:...}}` and `{{resolve:secretsmanager:...}}` are left in the template as
 written. Neither is resolved yet.

--- a/docs/services/ssm/README.md
+++ b/docs/services/ssm/README.md
@@ -818,6 +818,8 @@ Sim SSM currently supports:
 - The `AWS::SSM::Parameter` CloudFormation resource, including `Ref` and `Fn::GetAtt`
 - `{{resolve:ssm:...}}` dynamic references in CloudFormation resource properties, by version or by
   current value, embedded in a longer string and inside `Fn::Sub`
+- `StringList` parameters read through a dynamic reference as the comma-separated string `Fn::Split`
+  then splits
 - Parameter name validation, including hierarchy depth and the reserved `aws` and `ssm` prefixes
 - Authorization of every operation by simulated IAM, against the real IAM action and ARN
 - Calls made from inside a simulated Lambda handler, authorized as the function's execution role

--- a/docs/services/ssm/README.md
+++ b/docs/services/ssm/README.md
@@ -375,6 +375,86 @@ Resource: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/myapp/pro
 CDK does this for you. `ssm.StringParameter` with `grantRead(fn)` synthesises a template that deploys
 here without hand-editing.
 
+## Reading a parameter with a dynamic reference
+
+A template reads a parameter that already exists through a `{{resolve:ssm:...}}` dynamic reference.
+The reference is replaced with the parameter's value as the resource holding it is created.
+
+`{{resolve:ssm:name}}` reads the current version, and `{{resolve:ssm:name:3}}` reads version 3. A
+reference can sit inside a longer string, where only the reference itself is replaced.
+
+```typescript sim-ssm-dynamic-reference
+/**
+ * Reading an existing parameter from a template with a dynamic reference.
+ */
+
+import { GetParameterCommand, PutParameterCommand } from "@aws-sdk/client-ssm";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.ssm().putParameter(
+  new PutParameterCommand({
+    Name: "/myapp/prod/db-host",
+    Type: "String",
+    Value: "db.internal",
+  }),
+);
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "app-stack",
+  template: {
+    Resources: {
+      DbUrl: {
+        Type: "AWS::SSM::Parameter",
+        Properties: {
+          Name: "/myapp/prod/db-url",
+          Type: "String",
+          Value: "postgres://{{resolve:ssm:/myapp/prod/db-host}}:5432/app",
+        },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+const read = await simAws
+  .ssm()
+  .getParameter(new GetParameterCommand({ Name: "/myapp/prod/db-url" }));
+
+console.log(read.Parameter?.Value); // "postgres://db.internal:5432/app"
+```
+
+CDK emits one of these from `ssm.StringParameter.valueForStringParameter` when a version is given,
+and from `fromStringParameterAttributes` with `forceDynamicReference`.
+
+A reference inside `Fn::Sub` is read after the variables around it are substituted, so
+`!Sub "{{resolve:ssm:/myapp/${Environment}/db-host}}"` looks up the name the substitution produced.
+
+A `StringList` parameter resolves to the comma-separated string Parameter Store holds, which
+`Fn::Split` then splits.
+
+Real CloudFormation makes no dependency out of a dynamic reference, and neither does this. A
+parameter another resource of the same stack creates is only there in time when the template says
+`DependsOn`.
+
+`{{resolve:ssm-secure:...}}` and `{{resolve:secretsmanager:...}}` are left in the template as
+written. Neither is resolved yet.
+
+### A reference the simulation cannot answer
+
+Simulated CloudFormation deploys what it can. A reference naming a parameter that was never created
+resolves to `dummy-value-for-<name>`, and the stack carries on deploying. A template reading
+configuration a test does not care about is still worth deploying for everything else in it.
+
+The substitution is recorded on
+[`stack.ignoredProperties`](../cloudformation/README.md#properties-a-resource-was-created-without),
+naming the property that held the reference and why the value is a stand-in. A version the parameter
+never had, a `SecureString`, and a body that is not a name and an optional integer version are all
+recorded the same way.
+
 ## Reading configuration in a Lambda handler
 
 Function code that reads its configuration on cold start needs no special treatment. Any
@@ -736,6 +816,8 @@ Sim SSM currently supports:
 - `String`, `StringList` and `SecureString` parameter types
 - `SecureString` values encrypted through simulated KMS, decrypted only with `WithDecryption`
 - The `AWS::SSM::Parameter` CloudFormation resource, including `Ref` and `Fn::GetAtt`
+- `{{resolve:ssm:...}}` dynamic references in CloudFormation resource properties, by version or by
+  current value, embedded in a longer string and inside `Fn::Sub`
 - Parameter name validation, including hierarchy depth and the reserved `aws` and `ssm` prefixes
 - Authorization of every operation by simulated IAM, against the real IAM action and ARN
 - Calls made from inside a simulated Lambda handler, authorized as the function's execution role
@@ -780,9 +862,14 @@ Current documented limitations:
 - Every deployment of an `AWS::SSM::Parameter` is a create. A name another stack already used is
   refused. A stack update that changes `Value` deletes the parameter and creates it again, where
   real CloudFormation overwrites it in place, so the parameter's version starts from 1 again.
-- `{{resolve:ssm:...}}` dynamic references and the `AWS::SSM::Parameter::Value<String>` template
-  parameter type are absent. Those are CloudFormation engine features rather than Parameter Store
-  ones. Pass the name from `Ref` instead.
+- The `AWS::SSM::Parameter::Value<String>` template parameter type is absent. A `Ref` to a parameter
+  declared with it gives the name it was given, where real CloudFormation gives the value stored
+  under that name. Pass the name from `Ref` and read it with `GetParameter`.
+- `{{resolve:ssm-secure:...}}` dynamic references are absent. Reading a `SecureString` into a
+  template means decrypting it, which the CloudFormation engine has no route to yet.
+- A `{{resolve:ssm:...}}` reference naming a parameter, or a version, that simulated Parameter Store
+  has never held resolves to `dummy-value-for-<name>` and records the substitution. Real
+  CloudFormation fails the stack.
 - Public parameters under `/aws/service/...` do not exist, and names under the reserved `aws` and
   `ssm` prefixes are refused, as they are on real AWS.
 - The Parameters and Secrets Lambda extension HTTP endpoint is absent. Handler code has to use the

--- a/docs/services/ssm/sim-ssm-dynamic-reference.example.ts
+++ b/docs/services/ssm/sim-ssm-dynamic-reference.example.ts
@@ -1,0 +1,41 @@
+/**
+ * Reading an existing parameter from a template with a dynamic reference.
+ */
+
+import { GetParameterCommand, PutParameterCommand } from "@aws-sdk/client-ssm";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.ssm().putParameter(
+  new PutParameterCommand({
+    Name: "/myapp/prod/db-host",
+    Type: "String",
+    Value: "db.internal",
+  }),
+);
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "app-stack",
+  template: {
+    Resources: {
+      DbUrl: {
+        Type: "AWS::SSM::Parameter",
+        Properties: {
+          Name: "/myapp/prod/db-url",
+          Type: "String",
+          Value: "postgres://{{resolve:ssm:/myapp/prod/db-host}}:5432/app",
+        },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+const read = await simAws
+  .ssm()
+  .getParameter(new GetParameterCommand({ Name: "/myapp/prod/db-url" }));
+
+console.log(read.Parameter?.Value); // "postgres://db.internal:5432/app"

--- a/src/service/cloudformation/resource/resolve/property/sim-cfn-resource-property-resolver.ts
+++ b/src/service/cloudformation/resource/resolve/property/sim-cfn-resource-property-resolver.ts
@@ -7,11 +7,19 @@ import type {
 import type { SimCfnResourceResolveContext } from "../../sim-cfn-resource.type.js";
 import type { SimCfnPseudoParameters } from "../../../parameters/pseudo/sim-cfn-pseudo-parameters.js";
 import type { SimCfnExports } from "../../../export/sim-cfn-exports.js";
+import type { SimAwsAccountRegionScope } from "../../../../aws/sim-aws-account-region-scope.js";
+import {
+  makeSimCfnDynamicReferences,
+  type SimCfnDynamicReferences,
+} from "../../../template/dynamic/sim-cfn-dynamic-references.js";
+import type { SimCfnPropertyIgnorer } from "../../ignore/sim-cfn-ignored-property.type.js";
 
 interface SimCfnResourcePropertyResolverProperties {
   readonly parameters?: SimCfnParameters | undefined;
   readonly pseudoParameters?: SimCfnPseudoParameters | undefined;
   readonly exports?: SimCfnExports | undefined;
+  readonly accountRegionScope?: SimAwsAccountRegionScope | undefined;
+  readonly propertyIgnorer?: SimCfnPropertyIgnorer | undefined;
 }
 
 /**
@@ -31,11 +39,15 @@ export class SimCfnResourcePropertyResolver {
   private readonly parameters: SimCfnParameters | undefined;
   private readonly pseudoParameters: SimCfnPseudoParameters | undefined;
   private readonly exports: SimCfnExports | undefined;
+  private readonly accountRegionScope: SimAwsAccountRegionScope | undefined;
+  private readonly propertyIgnorer: SimCfnPropertyIgnorer | undefined;
 
   constructor(properties: SimCfnResourcePropertyResolverProperties = {}) {
     this.parameters = properties.parameters;
     this.pseudoParameters = properties.pseudoParameters;
     this.exports = properties.exports;
+    this.accountRegionScope = properties.accountRegionScope;
+    this.propertyIgnorer = properties.propertyIgnorer;
   }
 
   /**
@@ -57,6 +69,7 @@ export class SimCfnResourcePropertyResolver {
       parameters: this.parameters ?? new SimCfnParameters(),
       pseudoParameters: this.pseudoParameters,
       exports: this.exports,
+      dynamicReferences: this.dynamicReferences(context),
       resources: {
         has: (id): boolean => context.resources.has(id),
         refValue: (id): SimCfnTemplateValue => {
@@ -83,5 +96,28 @@ export class SimCfnResourcePropertyResolver {
     });
 
     return resolver.resolveRecord(properties);
+  }
+
+  /**
+   * The services answering this Resource's dynamic references.
+   *
+   * Absent where the caller has no simulation to read from, which is how the
+   * resolver is used on its own in tests. A reference then stays in the
+   * property as the template wrote it.
+   */
+  private dynamicReferences(
+    context: SimCfnResourceResolveContext,
+  ): SimCfnDynamicReferences | undefined {
+    const { simAws } = context;
+
+    if (simAws === undefined || this.accountRegionScope === undefined) {
+      return undefined;
+    }
+
+    return makeSimCfnDynamicReferences({
+      simAws,
+      accountRegionScope: this.accountRegionScope,
+      propertyIgnorer: this.propertyIgnorer,
+    });
   }
 }

--- a/src/service/cloudformation/resource/sim-cfn-resource-record.ts
+++ b/src/service/cloudformation/resource/sim-cfn-resource-record.ts
@@ -66,6 +66,8 @@ export abstract class SimCfnResourceRecord implements SimCfnPropertyIgnorer {
     this.propertyResolver = new SimCfnResourcePropertyResolver({
       parameters,
       exports,
+      accountRegionScope: this.accountRegionScope,
+      propertyIgnorer: this,
     });
     this.resourceLogicalIds = resourceLogicalIds;
   }

--- a/src/service/cloudformation/resource/sim-cfn-resource.type.ts
+++ b/src/service/cloudformation/resource/sim-cfn-resource.type.ts
@@ -49,6 +49,12 @@ export type SimCloudFormationResourceStatus =
  */
 export interface SimCfnResourceResolveContext {
   readonly resources: ReadonlyMap<string, SimCfnResource>;
+
+  /**
+   * The simulation the Stack is deploying into, for the values that come from
+   * another service rather than from the template. A dynamic reference is one.
+   */
+  readonly simAws?: SimAws | undefined;
 }
 
 export interface SimCloudFormationResourceCreateContext {

--- a/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-reference-resolvers.ts
+++ b/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-reference-resolvers.ts
@@ -1,0 +1,29 @@
+import type { SimAwsAccountRegionContainer } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimCfnDynamicReferenceResolver } from "./sim-cfn-dynamic-reference.type.js";
+
+/**
+ * How one simulated service hands over its dynamic reference resolver, given
+ * the Account and Region scope the Stack is deploying into.
+ */
+type SimCfnScopedDynamicReferenceResolver = (
+  scopedAws: SimAwsAccountRegionContainer,
+) => SimCfnDynamicReferenceResolver;
+
+/**
+ * The simulated service behind each `{{resolve:<service>:...}}` reference.
+ *
+ * The same shape as the Resource factory registry, for the same reason. A
+ * service name with no entry here leaves its references in the template as
+ * written, so a template using one this simulation has yet to implement still
+ * deploys everything else.
+ */
+export const simCfnDynamicReferenceResolvers: ReadonlyMap<
+  string,
+  SimCfnScopedDynamicReferenceResolver
+> = new Map([
+  [
+    "ssm",
+    (scopedAws): SimCfnDynamicReferenceResolver =>
+      scopedAws.ssm().cfnDynamicReferenceResolver(),
+  ],
+]);

--- a/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-reference-scan.ts
+++ b/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-reference-scan.ts
@@ -1,0 +1,61 @@
+import type { SimCfnDynamicReference } from "./sim-cfn-dynamic-reference.type.js";
+
+/**
+ * The opening of every dynamic reference, used to skip strings holding none.
+ */
+const dynamicReferenceOpening = "{{resolve:";
+
+/**
+ * One dynamic reference inside a larger string.
+ *
+ * The body runs to the first `}`, which is what stops a reference from eating
+ * the rest of the value it sits in. No segment of any reference CloudFormation
+ * documents may hold a brace, and a secret ARN's colons are left for the
+ * service reading the body to split.
+ */
+const dynamicReferencePattern = /\{\{resolve:([A-Za-z][\w-]*):([^{}]*)\}\}/g;
+
+/**
+ * What a caller answers each reference with.
+ *
+ * Answering `undefined` leaves the reference in the string as it was written,
+ * which is what happens for a service this simulation has no resolver for.
+ */
+type SimCfnDynamicReferenceSubstitution = (
+  reference: SimCfnDynamicReference,
+) => string | undefined;
+
+/**
+ * Whether a string holds anything worth scanning.
+ */
+export function hasSimCfnDynamicReference(text: string): boolean {
+  return text.includes(dynamicReferenceOpening);
+}
+
+/**
+ * Replace every dynamic reference in a string with what the caller answers.
+ *
+ * The text around each reference is untouched, so a value written as
+ * `prefix-{{resolve:ssm:name}}-suffix` keeps its prefix and suffix.
+ */
+export function substituteSimCfnDynamicReferences(
+  text: string,
+  substitute: SimCfnDynamicReferenceSubstitution,
+): string {
+  if (!hasSimCfnDynamicReference(text)) {
+    return text;
+  }
+
+  return text.replaceAll(
+    dynamicReferencePattern,
+    (matched, service: string, body: string) => {
+      const reference: SimCfnDynamicReference = {
+        text: matched,
+        service,
+        body,
+      };
+
+      return substitute(reference) ?? matched;
+    },
+  );
+}

--- a/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-reference.type.ts
+++ b/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-reference.type.ts
@@ -1,0 +1,43 @@
+/**
+ * One `{{resolve:service:...}}` dynamic reference found inside a template
+ * string.
+ *
+ * A dynamic reference is read out of a resolved string rather than parsed as
+ * its own node, because CloudFormation lets one sit inside a longer value.
+ * Only the span holding the reference is replaced, and the text around it is
+ * left as it was written.
+ */
+export interface SimCfnDynamicReference {
+  /** The whole reference as written, e.g. `{{resolve:ssm:/db/host:2}}`. */
+  readonly text: string;
+
+  /** The service the reference names, e.g. `ssm`. */
+  readonly service: string;
+
+  /** Everything after the service name, e.g. `/db/host:2`. */
+  readonly body: string;
+}
+
+/**
+ * What one service answers a dynamic reference with.
+ *
+ * A reference the service cannot answer still resolves to a value. Simulated
+ * CloudFormation deploys what it can, and a template naming parameters a test
+ * never created is one of the things it can mostly deploy. The stand-in value
+ * carries a reason, which the Resource records so a test asserting on that
+ * value can find out it was never read.
+ */
+export interface SimCfnDynamicReferenceResolution {
+  /** The value the reference is replaced with. */
+  readonly value: string;
+
+  /** Why the value is a stand-in, left out when the reference resolved. */
+  readonly reason?: string | undefined;
+}
+
+/**
+ * How one simulated service answers the dynamic references naming it.
+ */
+export interface SimCfnDynamicReferenceResolver {
+  resolve(reference: SimCfnDynamicReference): SimCfnDynamicReferenceResolution;
+}

--- a/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-references.ts
+++ b/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-references.ts
@@ -1,0 +1,91 @@
+import type { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimCfnPropertyIgnorer } from "../../resource/ignore/sim-cfn-ignored-property.type.js";
+import { currentSimCfnValuePath } from "../value/sim-cfn-value-path.js";
+import { simCfnDynamicReferenceResolvers } from "./sim-cfn-dynamic-reference-resolvers.js";
+import { substituteSimCfnDynamicReferences } from "./sim-cfn-dynamic-reference-scan.js";
+import type { SimCfnDynamicReferenceResolver } from "./sim-cfn-dynamic-reference.type.js";
+
+interface SimCfnDynamicReferencesProperties {
+  readonly resolvers: ReadonlyMap<string, SimCfnDynamicReferenceResolver>;
+  readonly propertyIgnorer?: SimCfnPropertyIgnorer | undefined;
+}
+
+/**
+ * The services a Stack's dynamic references are answered by.
+ *
+ * This sits on the resolve context so that a string node can substitute what
+ * it holds without knowing which simulated services exist. A service with no
+ * resolver here leaves its references in the template as written, which is
+ * what the ones this simulation has yet to implement do.
+ */
+export class SimCfnDynamicReferences {
+  private readonly resolvers: ReadonlyMap<
+    string,
+    SimCfnDynamicReferenceResolver
+  >;
+
+  private readonly propertyIgnorer: SimCfnPropertyIgnorer | undefined;
+
+  constructor(properties: SimCfnDynamicReferencesProperties) {
+    this.resolvers = properties.resolvers;
+    this.propertyIgnorer = properties.propertyIgnorer;
+  }
+
+  /**
+   * Replace every dynamic reference in a resolved string.
+   *
+   * A reference answered with a stand-in value is recorded against the
+   * property it sat on, so the Resource reports it the same way it reports a
+   * property its service could not act on.
+   */
+  substitute(text: string): string {
+    return substituteSimCfnDynamicReferences(text, (reference) => {
+      const resolver = this.resolvers.get(reference.service);
+
+      if (resolver === undefined) {
+        return;
+      }
+
+      const resolution = resolver.resolve(reference);
+
+      if (resolution.reason !== undefined) {
+        this.propertyIgnorer?.ignoreProperty(
+          currentSimCfnValuePath(),
+          resolution.reason,
+        );
+      }
+
+      return resolution.value;
+    });
+  }
+}
+
+interface MakeSimCfnDynamicReferencesProperties {
+  readonly simAws: SimAws;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly propertyIgnorer?: SimCfnPropertyIgnorer | undefined;
+}
+
+/**
+ * Build the dynamic reference resolvers for one Account and Region scope.
+ */
+export function makeSimCfnDynamicReferences(
+  properties: MakeSimCfnDynamicReferencesProperties,
+): SimCfnDynamicReferences {
+  const { simAws, accountRegionScope, propertyIgnorer } = properties;
+
+  const scopedAws = simAws.accountRegionScope(
+    accountRegionScope.accountId,
+    accountRegionScope.regionName,
+  );
+
+  return new SimCfnDynamicReferences({
+    propertyIgnorer,
+    resolvers: new Map(
+      simCfnDynamicReferenceResolvers
+        .entries()
+        .map(([service, resolver]) => [service, resolver(scopedAws)]),
+    ),
+  });
+}

--- a/src/service/cloudformation/template/node/fn/split/sim-cfn-fn-split.ts
+++ b/src/service/cloudformation/template/node/fn/split/sim-cfn-fn-split.ts
@@ -29,16 +29,21 @@ export class SimCfnFnSplit extends SimCfnNode {
    * before Resources exist, re-emits this function in template form for a
    * later resolution pass to finish.
    *
-   * A string still holding a dynamic reference is deferred the same way. The
-   * delimiters are inside the value Parameter Store has yet to answer with,
-   * which is the whole point of splitting a `StringList` parameter, so
-   * splitting now would cut up the reference instead.
+   * A string still holding a dynamic reference is deferred the same way, on
+   * the pass that has no service to read one with. The delimiters are inside
+   * the value that service has yet to answer with, which is the whole point of
+   * splitting a `StringList` parameter, so splitting now would cut up the
+   * reference. A reference left after the reading pass belongs to a service
+   * with no resolver, and is split as the plain text it stayed.
    */
   resolve(context: SimCfnResolveContext): SimCfnTemplateValue {
     const source = this.source.resolve(context);
 
     if (typeof source === "string") {
-      if (hasSimCfnDynamicReference(source)) {
+      if (
+        context.dynamicReferences === undefined &&
+        hasSimCfnDynamicReference(source)
+      ) {
         return { "Fn::Split": [this.delimiter, source] };
       }
 

--- a/src/service/cloudformation/template/node/fn/split/sim-cfn-fn-split.ts
+++ b/src/service/cloudformation/template/node/fn/split/sim-cfn-fn-split.ts
@@ -2,6 +2,7 @@ import { SimCfnNode } from "../../sim-cfn-node.js";
 import type { SimCfnResolveContext } from "../../../resolve/sim-cfn-resolve-context.js";
 import type { SimCfnTemplateValue } from "../../../value/sim-cfn-template-value.js";
 import { isSimCfnUnresolvedExpression } from "../../../value/sim-cfn-unresolved-expression.js";
+import { hasSimCfnDynamicReference } from "../../../dynamic/sim-cfn-dynamic-reference-scan.js";
 
 /**
  * Simulated CloudFormation `Fn::Split` intrinsic function.
@@ -27,11 +28,20 @@ export class SimCfnFnSplit extends SimCfnNode {
    * that is still an unresolved expression, such as an `Fn::GetAtt` read
    * before Resources exist, re-emits this function in template form for a
    * later resolution pass to finish.
+   *
+   * A string still holding a dynamic reference is deferred the same way. The
+   * delimiters are inside the value Parameter Store has yet to answer with,
+   * which is the whole point of splitting a `StringList` parameter, so
+   * splitting now would cut up the reference instead.
    */
   resolve(context: SimCfnResolveContext): SimCfnTemplateValue {
     const source = this.source.resolve(context);
 
     if (typeof source === "string") {
+      if (hasSimCfnDynamicReference(source)) {
+        return { "Fn::Split": [this.delimiter, source] };
+      }
+
       return source.split(this.delimiter);
     }
 

--- a/src/service/cloudformation/template/node/fn/sub/sim-cfn-fn-sub.ts
+++ b/src/service/cloudformation/template/node/fn/sub/sim-cfn-fn-sub.ts
@@ -57,9 +57,15 @@ export class SimCfnFnSub extends SimCfnNode {
       return this.unresolvedValue.toTemplateValue(resolvedVariables);
     }
 
-    return this.subTemplate.substitute(
+    const substituted = this.subTemplate.substitute(
       this.variableResolver.stringVariables(resolvedVariables),
     );
+
+    // A dynamic reference can name a parameter through a Sub variable, as in
+    // `{{resolve:ssm:/app/${Environment}/host}}`. Reading it before the
+    // variables are in would look up a name still holding `${...}`, so the
+    // reference is read from the finished string.
+    return context.dynamicReferences?.substitute(substituted) ?? substituted;
   }
 
   /**

--- a/src/service/cloudformation/template/node/sim-cfn-literal.ts
+++ b/src/service/cloudformation/template/node/sim-cfn-literal.ts
@@ -1,5 +1,6 @@
 import { SimCfnNode } from "./sim-cfn-node.js";
 import type { SimCfnTemplatePrimitiveValue } from "../value/sim-cfn-template-value.js";
+import type { SimCfnResolveContext } from "../resolve/sim-cfn-resolve-context.js";
 
 /**
  * A primitive CloudFormation template value (null, boolean, number, string).
@@ -10,9 +11,19 @@ export class SimCfnLiteral extends SimCfnNode {
   }
 
   /**
-   * Return the literal value unchanged.
+   * Return the literal value, with any dynamic reference in it substituted.
+   *
+   * A dynamic reference is written into the template as ordinary text, so this
+   * is where one is read. Substituting here rather than over the finished
+   * value keeps `Fn::Split` and the other functions reading a resolved string:
+   * splitting `{{resolve:ssm:name}}` on commas has to happen after Parameter
+   * Store has answered it.
    */
-  resolve(): SimCfnTemplatePrimitiveValue {
-    return this.value;
+  resolve(context: SimCfnResolveContext): SimCfnTemplatePrimitiveValue {
+    if (typeof this.value !== "string") {
+      return this.value;
+    }
+
+    return context.dynamicReferences?.substitute(this.value) ?? this.value;
   }
 }

--- a/src/service/cloudformation/template/resolve/sim-cfn-resolve-context.ts
+++ b/src/service/cloudformation/template/resolve/sim-cfn-resolve-context.ts
@@ -4,6 +4,7 @@ import type { SimCfnPseudoParameters } from "../../parameters/pseudo/sim-cfn-pse
 import type { SimCfnMappings } from "../mapping/sim-cfn-mappings.js";
 import type { SimCfnConditions } from "../condition/sim-cfn-conditions.js";
 import { SimCfnExports } from "../../export/sim-cfn-exports.js";
+import type { SimCfnDynamicReferences } from "../dynamic/sim-cfn-dynamic-references.js";
 
 interface SimCfnResolveContextProperties {
   readonly parameters: SimCfnParameters;
@@ -12,6 +13,7 @@ interface SimCfnResolveContextProperties {
   readonly mappings?: SimCfnMappings | undefined;
   readonly conditions?: SimCfnConditions | undefined;
   readonly exports?: SimCfnExports | undefined;
+  readonly dynamicReferences?: SimCfnDynamicReferences | undefined;
 }
 
 /**
@@ -32,6 +34,14 @@ export class SimCfnResolveContext {
    */
   public readonly exports: SimCfnExports;
 
+  /**
+   * The services answering `{{resolve:...}}` references in resolved strings.
+   *
+   * Absent on the template-wide pass, which runs before any Resource exists
+   * and so before a reference could be read as the Stack would read it.
+   */
+  public readonly dynamicReferences: SimCfnDynamicReferences | undefined;
+
   constructor(properties: SimCfnResolveContextProperties) {
     this.parameters = properties.parameters;
     this.resources = properties.resources;
@@ -39,5 +49,6 @@ export class SimCfnResolveContext {
     this.mappings = properties.mappings;
     this.conditions = properties.conditions;
     this.exports = properties.exports ?? new SimCfnExports();
+    this.dynamicReferences = properties.dynamicReferences;
   }
 }

--- a/src/service/cloudformation/template/value/sim-cfn-template-value-resolver.ts
+++ b/src/service/cloudformation/template/value/sim-cfn-template-value-resolver.ts
@@ -10,6 +10,7 @@ import { SimCfnResolveContext } from "../resolve/sim-cfn-resolve-context.js";
 import type { SimCfnMappings } from "../mapping/sim-cfn-mappings.js";
 import type { SimCfnConditions } from "../condition/sim-cfn-conditions.js";
 import type { SimCfnExports } from "../../export/sim-cfn-exports.js";
+import type { SimCfnDynamicReferences } from "../dynamic/sim-cfn-dynamic-references.js";
 import {
   resolveSimCfnValueAt,
   resolveSimCfnValueIn,
@@ -22,6 +23,7 @@ interface SimCfnTemplateValueResolverProperties {
   readonly mappings?: SimCfnMappings | undefined;
   readonly conditions?: SimCfnConditions | undefined;
   readonly exports?: SimCfnExports | undefined;
+  readonly dynamicReferences?: SimCfnDynamicReferences | undefined;
 }
 
 /**
@@ -38,6 +40,7 @@ export class SimCfnTemplateValueResolver {
       mappings: properties.mappings,
       conditions: properties.conditions,
       exports: properties.exports,
+      dynamicReferences: properties.dynamicReferences,
     });
   }
 

--- a/src/service/cloudformation/template/value/sim-cfn-value-path.ts
+++ b/src/service/cloudformation/template/value/sim-cfn-value-path.ts
@@ -15,6 +15,26 @@ interface SimCfnValuePath {
 const valuePaths = new WeakMap<Error, SimCfnValuePath>();
 
 /**
+ * Where resolution currently is, as the keys and list positions it descended
+ * through to get there.
+ *
+ * The failure path above is built on the way back up, which only a thrown
+ * error travels. Something noticed part way down and carried on, such as a
+ * dynamic reference resolved to a stand-in value, has nothing to throw and
+ * still has to say which property it happened on. Resolution is synchronous,
+ * so one stack pushed and popped by the same wrapper answers that.
+ */
+const currentPath: SimCfnValuePathSegment[] = [];
+
+/**
+ * The property path resolution is inside, written the way an ignored property
+ * records one, e.g. `Tags.0.Value`.
+ */
+export function currentSimCfnValuePath(): string {
+  return currentPath.map(String).join(".");
+}
+
+/**
  * Resolve a value, naming the key it sat under if it fails.
  *
  * A failure on its own says what was wrong with the expression but not which
@@ -29,10 +49,14 @@ export function resolveSimCfnValueAt<T>(
   segment: SimCfnValuePathSegment,
   resolve: () => T,
 ): T {
+  currentPath.push(segment);
+
   try {
     return resolve();
   } catch (error) {
     rethrowSimCfnValueAt(segment, error);
+  } finally {
+    currentPath.pop();
   }
 }
 

--- a/src/service/ssm/README.md
+++ b/src/service/ssm/README.md
@@ -148,7 +148,11 @@ There is no resource policy support, so cross-account access to a parameter cann
   as new ones are made.
 - Every deployment of an `AWS::SSM::Parameter` is a create, because sim CloudFormation has no stack
   updates. A name another stack already used is refused rather than overwritten.
-- There is no `{{resolve:ssm:...}}` support and no `AWS::SSM::Parameter::Value<String>` template
-  parameter type. Both are CloudFormation engine features rather than Parameter Store ones.
+- `{{resolve:ssm:...}}` dynamic references resolve here. `cfn/dynamic/` holds the resolver the
+  CloudFormation engine reaches through `SimSsm.cfnDynamicReferenceResolver()`. A reference this
+  store cannot answer resolves to a stand-in value and is recorded, which is the same best-effort
+  answer an unsupported property gets.
+- `{{resolve:ssm-secure:...}}` and the `AWS::SSM::Parameter::Value<String>` template parameter type
+  are still absent.
 
 The full list is in [docs/services/ssm](../../../docs/services/ssm/).

--- a/src/service/ssm/cfn/dynamic/sim-cfn-ssm-dynamic-reference-best-effort.iso.test.ts
+++ b/src/service/ssm/cfn/dynamic/sim-cfn-ssm-dynamic-reference-best-effort.iso.test.ts
@@ -1,0 +1,179 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCfnStack } from "../../../cloudformation/stack/sim-cfn-stack.js";
+
+const accountIdOneOnes = "111111111111";
+
+function simAwsInEuWest2(): SimAws {
+  return new SimAws({
+    defaultAccountId: accountIdOneOnes,
+    defaultRegionName: "eu-west-2",
+  });
+}
+
+async function deployReading(
+  simAws: SimAws,
+  value: string,
+): Promise<SimCfnStack> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "config-stack",
+    template: {
+      Resources: {
+        Read: {
+          Type: "AWS::SSM::Parameter",
+          Properties: { Name: "/myapp/read", Type: "String", Value: value },
+        },
+      },
+    },
+  });
+  await stack.waitForDeployComplete();
+
+  return stack;
+}
+
+function readValue(simAws: SimAws): string {
+  const parameter = simAws.ssm().findParameter("/myapp/read");
+  assertNonNullable(parameter, "the deployed parameter");
+
+  return parameter.currentVersion.value.value;
+}
+
+/**
+ * The one record the Stack made about a dynamic reference.
+ *
+ * A Resource can record properties of its own alongside this, such as a queue
+ * tag nothing simulated reads, so the reference is picked out by name.
+ */
+function dynamicReferenceRecord(stack: SimCfnStack): {
+  path: string;
+  reason: string;
+} {
+  const [ignored, ...rest] = stack.ignoredProperties.filter((property) =>
+    property.reason.includes("{{resolve:"),
+  );
+  assertNonNullable(ignored, "a recorded dynamic reference");
+  assertArrayLength(rest, 0, "no second recorded dynamic reference");
+
+  return { path: ignored.path, reason: ignored.reason };
+}
+
+describe("SSM CloudFormation dynamic references the simulation cannot answer", () => {
+  it("deploys with a stand-in value where the parameter is absent", async () => {
+    // Given nothing in Parameter Store.
+    const simAws = simAwsInEuWest2();
+
+    // When a template reads a parameter that was never created.
+    const stack = await deployReading(simAws, "{{resolve:ssm:/myapp/db-host}}");
+
+    // Then the Stack deploys and the Resource holds a stand-in value.
+    assertIdentical(stack.status, "CREATE_COMPLETE");
+    assertIdentical(readValue(simAws), "dummy-value-for-/myapp/db-host");
+
+    // And the substitution is recorded against the property that held it.
+    const ignored = dynamicReferenceRecord(stack);
+    assertIdentical(ignored.path, "Value");
+    assertStringIncludes(ignored.reason, "/myapp/db-host");
+    assertStringIncludes(ignored.reason, "stand-in value");
+  });
+
+  it("deploys with a stand-in value where the version is absent", async () => {
+    // Given a parameter with one version.
+    const simAws = simAwsInEuWest2();
+    await simAws.ssm().putParameter({
+      input: { Name: "/myapp/db-host", Type: "String", Value: "db.internal" },
+    });
+
+    // When a template names a version it has never had.
+    const stack = await deployReading(
+      simAws,
+      "{{resolve:ssm:/myapp/db-host:4}}",
+    );
+
+    // Then the Resource holds a stand-in value naming the missing version.
+    assertIdentical(readValue(simAws), "dummy-value-for-/myapp/db-host");
+    assertStringIncludes(dynamicReferenceRecord(stack).reason, "no version 4");
+  });
+
+  it("deploys with a stand-in value for a SecureString parameter", async () => {
+    // Given an encrypted parameter.
+    const simAws = simAwsInEuWest2();
+    await simAws.ssm().putParameter({
+      input: { Name: "/myapp/token", Type: "SecureString", Value: "s3cret" },
+    });
+
+    // When a plain ssm reference reads it.
+    const stack = await deployReading(simAws, "{{resolve:ssm:/myapp/token}}");
+
+    // Then the ciphertext stays put and the reference says why.
+    assertIdentical(readValue(simAws), "dummy-value-for-/myapp/token");
+    assertStringIncludes(dynamicReferenceRecord(stack).reason, "ssm-secure");
+  });
+
+  it("deploys with a stand-in value where the reference body is malformed", async () => {
+    // Given a reference whose version is not an integer.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed.
+    const stack = await deployReading(
+      simAws,
+      "{{resolve:ssm:/myapp/db-host:latest}}",
+    );
+
+    // Then it deploys, saying the body was not a name and a version.
+    assertIdentical(stack.status, "CREATE_COMPLETE");
+    assertStringIncludes(
+      dynamicReferenceRecord(stack).reason,
+      "integer version",
+    );
+  });
+
+  it("records the whole path to a reference nested in a property", async () => {
+    // Given a Stack tagging a queue with a parameter that does not exist.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "queue-stack",
+      template: {
+        Resources: {
+          Queue: {
+            Type: "AWS::SQS::Queue",
+            Properties: {
+              QueueName: "work",
+              Tags: [{ Key: "owner", Value: "{{resolve:ssm:/myapp/owner}}" }],
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the record names the list position the reference sat on.
+    assertIdentical(dynamicReferenceRecord(stack).path, "Tags.0.Value");
+  });
+
+  it("leaves a reference to a service with no resolver as it was written", async () => {
+    // Given a reference to a service this simulation does not resolve yet.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed.
+    const stack = await deployReading(
+      simAws,
+      "{{resolve:secretsmanager:MySecret:SecretString:password}}",
+    );
+
+    // Then the reference is untouched and nothing is recorded about it.
+    assertIdentical(
+      readValue(simAws),
+      "{{resolve:secretsmanager:MySecret:SecretString:password}}",
+    );
+    assertArrayLength(stack.ignoredProperties, 0);
+  });
+});

--- a/src/service/ssm/cfn/dynamic/sim-cfn-ssm-dynamic-reference-resolver.ts
+++ b/src/service/ssm/cfn/dynamic/sim-cfn-ssm-dynamic-reference-resolver.ts
@@ -1,0 +1,157 @@
+import type {
+  SimCfnDynamicReference,
+  SimCfnDynamicReferenceResolution,
+  SimCfnDynamicReferenceResolver,
+} from "../../../cloudformation/template/dynamic/sim-cfn-dynamic-reference.type.js";
+import { SimSsmParameterVersionNotFound } from "../../error/sim-ssm.error.js";
+import type { SimSsmParameter } from "../../parameter/sim-ssm-parameter.js";
+import type { SimSsm } from "../../sim-ssm.js";
+
+/** The characters CloudFormation documents a referenced parameter name as. */
+const ssmReferenceName = /^[a-zA-Z0-9_.\-/]+$/;
+
+/** The version selector, which CloudFormation documents as an integer. */
+const ssmReferenceVersion = /^\d+$/;
+
+/** A reference body read as the parameter name and the version after it. */
+interface SimCfnSsmReferenceBody {
+  readonly name: string;
+  readonly version: string | undefined;
+}
+
+/**
+ * Read a reference body as a parameter name and an optional version.
+ *
+ * A parameter name holds no colon, so the last one always opens the version.
+ */
+function parseSsmReferenceBody(
+  body: string,
+): SimCfnSsmReferenceBody | undefined {
+  const colon = body.lastIndexOf(":");
+
+  if (colon === -1) {
+    return ssmReferenceName.test(body)
+      ? { name: body, version: undefined }
+      : undefined;
+  }
+
+  const name = body.slice(0, colon);
+  const version = body.slice(colon + 1);
+
+  if (!ssmReferenceName.test(name) || !ssmReferenceVersion.test(version)) {
+    return undefined;
+  }
+
+  return { name, version };
+}
+
+interface SimCfnSsmDynamicReferenceResolverProperties {
+  readonly ssm: SimSsm;
+}
+
+/**
+ * Answers `{{resolve:ssm:...}}` references from the simulated Parameter Store.
+ *
+ * A reference is read as the caller deploying the Stack would read it, at the
+ * point the Resource holding it is created. Real CloudFormation makes no
+ * dependency out of a dynamic reference, so a parameter another Resource of
+ * the same Stack creates is only there in time if the template says
+ * `DependsOn`.
+ *
+ * Anything Parameter Store cannot answer becomes a stand-in value carrying a
+ * reason. A template naming parameters a test never created still deploys, and
+ * the Resource records what it was given instead.
+ */
+export class SimCfnSsmDynamicReferenceResolver implements SimCfnDynamicReferenceResolver {
+  private readonly ssm: SimSsm;
+
+  constructor(properties: SimCfnSsmDynamicReferenceResolverProperties) {
+    this.ssm = properties.ssm;
+  }
+
+  /**
+   * Resolve one reference to the parameter value it names.
+   */
+  resolve(reference: SimCfnDynamicReference): SimCfnDynamicReferenceResolution {
+    const parsed = parseSsmReferenceBody(reference.body);
+
+    if (parsed === undefined) {
+      return this.standIn(
+        reference,
+        reference.body,
+        `which is not the parameter name, optionally followed by an integer ` +
+          `version, that an ssm dynamic reference takes`,
+      );
+    }
+
+    const { name, version } = parsed;
+    const parameter = this.ssm.findParameter(name);
+
+    if (parameter === undefined) {
+      return this.standIn(
+        reference,
+        name,
+        `and simulated Parameter Store holds no parameter '${name}'`,
+      );
+    }
+
+    if (parameter.type.value === "SecureString") {
+      return this.standIn(
+        reference,
+        name,
+        `and '${name}' is a SecureString, which real CloudFormation reads ` +
+          `through an ssm-secure reference`,
+      );
+    }
+
+    return this.parameterValue(reference, parameter, name, version);
+  }
+
+  /**
+   * Read the version the reference selects, or the current one.
+   */
+  private parameterValue(
+    reference: SimCfnDynamicReference,
+    parameter: SimSsmParameter,
+    name: string,
+    version: string | undefined,
+  ): SimCfnDynamicReferenceResolution {
+    if (version === undefined) {
+      return { value: parameter.currentVersion.value.value };
+    }
+
+    try {
+      return { value: parameter.versionNumbered(Number(version)).value.value };
+    } catch (error) {
+      /* v8 ignore next 3 -- defensive: only a missing version reaches here */
+      if (!(error instanceof SimSsmParameterVersionNotFound)) {
+        throw error;
+      }
+
+      return this.standIn(
+        reference,
+        name,
+        `and '${name}' has no version ${version}`,
+      );
+    }
+  }
+
+  /**
+   * The value a reference Parameter Store could not answer resolves to.
+   *
+   * The shape follows CDK, which fills an unresolved context lookup with
+   * `dummy-value-for-<name>`. A test reading one back sees where it came from.
+   */
+  private standIn(
+    reference: SimCfnDynamicReference,
+    name: string,
+    reason: string,
+  ): SimCfnDynamicReferenceResolution {
+    return {
+      value: `dummy-value-for-${name}`,
+      reason:
+        `holds ${reference.text}, ${reason}, so the Resource is created ` +
+        `with a stand-in value`,
+    };
+  }
+}

--- a/src/service/ssm/cfn/dynamic/sim-cfn-ssm-dynamic-reference.iso.test.ts
+++ b/src/service/ssm/cfn/dynamic/sim-cfn-ssm-dynamic-reference.iso.test.ts
@@ -1,0 +1,149 @@
+import { assertIdentical, assertNonNullable } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCfnStack } from "../../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+const accountIdOneOnes = "111111111111";
+
+function simAwsInEuWest2(): SimAws {
+  return new SimAws({
+    defaultAccountId: accountIdOneOnes,
+    defaultRegionName: "eu-west-2",
+  });
+}
+
+/**
+ * Deploy one parameter holding the value under test, after seeding whatever
+ * the test needs Parameter Store to already hold.
+ */
+async function deployReading(
+  simAws: SimAws,
+  value: SimCfnTemplateValue,
+  parameters: Record<string, { Type: string; Default?: string }> = {},
+): Promise<SimCfnStack> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "config-stack",
+    template: {
+      Parameters: parameters,
+      Resources: {
+        Read: {
+          Type: "AWS::SSM::Parameter",
+          Properties: { Name: "/myapp/read", Type: "String", Value: value },
+        },
+      },
+    },
+  });
+  await stack.waitForDeployComplete();
+
+  return stack;
+}
+
+function readValue(simAws: SimAws): string {
+  const parameter = simAws.ssm().findParameter("/myapp/read");
+  assertNonNullable(parameter, "the deployed parameter");
+
+  return parameter.currentVersion.value.value;
+}
+
+describe("SSM CloudFormation dynamic references", () => {
+  it("resolves a reference to the current parameter value", async () => {
+    // Given a parameter holding a value.
+    const simAws = simAwsInEuWest2();
+    await simAws.ssm().putParameter({
+      input: { Name: "/myapp/db-host", Type: "String", Value: "db.internal" },
+    });
+
+    // When a template reads it through a dynamic reference.
+    await deployReading(simAws, "{{resolve:ssm:/myapp/db-host}}");
+
+    // Then the Resource is created with the parameter's value.
+    assertIdentical(readValue(simAws), "db.internal");
+  });
+
+  it("resolves a reference to the version it names", async () => {
+    // Given a parameter written twice.
+    const simAws = simAwsInEuWest2();
+    await simAws.ssm().putParameter({
+      input: {
+        Name: "/myapp/db-host",
+        Type: "String",
+        Value: "first.internal",
+      },
+    });
+    await simAws.ssm().putParameter({
+      input: {
+        Name: "/myapp/db-host",
+        Value: "second.internal",
+        Overwrite: true,
+      },
+    });
+
+    // When a template names the first version.
+    await deployReading(simAws, "{{resolve:ssm:/myapp/db-host:1}}");
+
+    // Then that version's value is read rather than the current one.
+    assertIdentical(readValue(simAws), "first.internal");
+  });
+
+  it("substitutes a reference sitting inside a longer string", async () => {
+    // Given a parameter holding a host name.
+    const simAws = simAwsInEuWest2();
+    await simAws.ssm().putParameter({
+      input: { Name: "/myapp/db-host", Type: "String", Value: "db.internal" },
+    });
+
+    // When a template wraps the reference in surrounding text.
+    await deployReading(
+      simAws,
+      "postgres://{{resolve:ssm:/myapp/db-host}}:5432/app",
+    );
+
+    // Then only the reference is replaced.
+    assertIdentical(readValue(simAws), "postgres://db.internal:5432/app");
+  });
+
+  it("resolves a reference whose name comes from an Fn::Sub variable", async () => {
+    // Given a parameter under an environment-specific path.
+    const simAws = simAwsInEuWest2();
+    await simAws.ssm().putParameter({
+      input: {
+        Name: "/myapp/prod/db-host",
+        Type: "String",
+        Value: "prod-db.internal",
+      },
+    });
+
+    // When the reference names it through an Fn::Sub variable.
+    await deployReading(
+      simAws,
+      // oxlint-disable-next-line no-template-curly-in-string -- Fn::Sub syntax, not a JavaScript template.
+      { "Fn::Sub": "{{resolve:ssm:/myapp/${Environment}/db-host}}" },
+      { Environment: { Type: "String", Default: "prod" } },
+    );
+
+    // Then the substituted name is what Parameter Store is asked for.
+    assertIdentical(readValue(simAws), "prod-db.internal");
+  });
+
+  it("hands a StringList parameter to Fn::Split as one comma-separated string", async () => {
+    // Given a StringList parameter.
+    const simAws = simAwsInEuWest2();
+    await simAws.ssm().putParameter({
+      input: {
+        Name: "/myapp/hosts",
+        Type: "StringList",
+        Value: "a.internal,b.internal",
+      },
+    });
+
+    // When a template splits the reference and selects from it.
+    await deployReading(simAws, {
+      "Fn::Select": [1, { "Fn::Split": [",", "{{resolve:ssm:/myapp/hosts}}"] }],
+    });
+
+    // Then the reference resolved before the split ran.
+    assertIdentical(readValue(simAws), "b.internal");
+  });
+});

--- a/src/service/ssm/sim-ssm.ts
+++ b/src/service/ssm/sim-ssm.ts
@@ -19,6 +19,7 @@ import { SimSsmGetParametersByPath } from "./command/parameter/sim-ssm-get-param
 import { SimSsmPutParameter } from "./command/parameter/sim-ssm-put-parameter.js";
 import type * as simSsmCommands from "./command/sim-ssm-command.types.js";
 import { SimSsmCfnResourceFactory } from "./cfn/sim-cfn-ssm-resource-factory.js";
+import { SimCfnSsmDynamicReferenceResolver } from "./cfn/dynamic/sim-cfn-ssm-dynamic-reference-resolver.js";
 import type { SimSsmParameter } from "./parameter/sim-ssm-parameter.js";
 import { SimSsmParameterEncryption } from "./parameter/sim-ssm-parameter-encryption.js";
 import type { SimSsmKmsCrypto } from "./parameter/sim-ssm-kms-crypto.js";
@@ -202,6 +203,13 @@ export class SimSsm {
    */
   cfnResourceFactory(): SimSsmCfnResourceFactory {
     return this.cfnFactory;
+  }
+
+  /**
+   * Get the resolver for `{{resolve:ssm:...}}` dynamic references.
+   */
+  cfnDynamicReferenceResolver(): SimCfnSsmDynamicReferenceResolver {
+    return new SimCfnSsmDynamicReferenceResolver({ ssm: this });
   }
 
   /**


### PR DESCRIPTION
A `{{resolve:ssm:...}}` reference in a Resource property now reads the simulated Parameter Store of the Stack's Account and Region while that Resource is created. A reference can sit inside a longer string, and one whose parameter name comes from an `Fn::Sub` variable is read after the substitution. `Fn::Split` defers over a string still holding a reference, so a `StringList` parameter is split on the value Parameter Store answered with. A reference the store cannot answer resolves to a stand-in value and is recorded on `stack.ignoredProperties`, keeping the rest of a template deployable when it names parameters a test never created.

Resolves #705


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for resolving CloudFormation SSM dynamic references from simulated Parameter Store values.
  - Supports current and versioned parameters, embedded strings, `Fn::Sub`, `StringList`, `Fn::Split`, and `Fn::Select`.
  - Missing or unsupported references remain usable through documented stand-in values and recorded reasons.

- **Documentation**
  - Added usage examples, behavior details, limitations, and a complete deployment example for SSM dynamic references.

- **Tests**
  - Added coverage for successful resolution, missing parameters, invalid versions, secure parameters, nested properties, and unsupported services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->