### PR TITLE
feat: serve sts assume-role over an endpoint

### DIFF
--- a/docs/serve/README.md
+++ b/docs/serve/README.md
@@ -268,7 +268,43 @@ aws sts get-caller-identity
 
 An assumed-role session reports its own session ARN, as it does in real AWS, and its user id joins the Role's id to the session name. A caller with no identity is refused, since there is nothing to answer with.
 
-`GetCallerIdentity` is the only STS operation served. `AssumeRole` works in process and through SDK interception.
+### Assuming a Role over the endpoint
+
+`sts assume-role` answers with temporary credentials, and those credentials sign the requests that
+follow:
+
+```bash
+export AWS_ENDPOINT_URL=http://localhost:8787
+aws sts assume-role --role-arn arn:aws:iam::888888888888:role/Reader --role-session-name probe
+{
+    "Credentials": {
+        "AccessKeyId": "ASIAQ3JZQ6XKFPWLZ4TM",
+        "SecretAccessKey": "T4rBqYbLXKsJ0nZuV9dHc2Wm1PfAeR7gSjNyIvXo",
+        "SessionToken": "IQoJb3JpZ2luX2VjEHkaCXVzLWVhc3QtMSJHMEUCIQ",
+        "Expiration": "2026-08-18T21:00:00.000Z"
+    },
+    "AssumedRoleUser": {
+        "AssumedRoleId": "AROA5KQZH2XWNDLB7YTVR:probe",
+        "Arn": "arn:aws:sts::888888888888:assumed-role/Reader/probe"
+    }
+}
+```
+
+Hand the three credential values to an SDK client, or to `AWS_ACCESS_KEY_ID`,
+`AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN`, and the whole assume-then-work sequence runs
+against the endpoint URL. Simulated IAM authorizes each request against the Role behind the session,
+and `get-caller-identity` reports the session ARN above.
+
+`DurationSeconds` and `ExternalId` are read from the request as they are in process. The expiry is
+stamped from the simulation's own clock. `simAws.clock().advanceBy({ hours: 2 })` takes a session
+past it, and the credentials stop authenticating. An SDK refreshes an expired session by assuming
+again.
+
+A Role whose trust policy refuses the caller comes back as `AccessDenied`, under the name real STS
+raises it.
+
+`AssumeRole` and `GetCallerIdentity` are the two operations simulated STS implements, and both are
+served. `AssumeRoleWithWebIdentity` and `GetSessionToken` are refused as `NotImplemented`.
 
 ### S3 over the endpoint
 
@@ -840,5 +876,5 @@ it is without watch mode.
   again and local state stays the same as what tests and CI see.
 - The IDE run configurations for attaching a debugger to a watched process are not documented yet.
 - The served AWS service API covers S3, STS and the AWS JSON protocol services. A service speaking REST-JSON, or Query other than STS, is refused with `501 Not Implemented`.
-- `GetCallerIdentity` is the only STS operation served. `AssumeRole` over a port would mean the temporary credentials it issues have to sign the calls that follow, which is its own piece of work.
+- Simulated STS implements `AssumeRole` and `GetCallerIdentity`, and serves both. `AssumeRoleWithWebIdentity` and `GetSessionToken` are refused as `NotImplemented`.
 - A served AWS API request is routed by its SigV4 credential scope. An unsigned one reaches nothing, whatever endpoint URL it used.

--- a/src/serve/http/api/query/sim-query-request.iso.test.ts
+++ b/src/serve/http/api/query/sim-query-request.iso.test.ts
@@ -85,6 +85,19 @@ describe("reading a Query protocol request", () => {
     assertUndefined(fields.binary("Missing"));
   });
 
+  it("reads a number back out of its text", () => {
+    // Given a numeric member and some text that names no number at all
+    const fields = fieldsOf("DurationSeconds=900&Attempts=&Limit=some");
+
+    // When each is read as a number
+    // Then the numeric one arrived, and the other two are absent rather than
+    // NaN, so the simulated service sees a member nobody stated
+    assertIdentical(fields.number("DurationSeconds"), 900);
+    assertUndefined(fields.number("Attempts"));
+    assertUndefined(fields.number("Limit"));
+    assertUndefined(fields.number("Missing"));
+  });
+
   it("orders list members by their subscript rather than by field order", () => {
     // Given a list whose tenth member was written before its second
     const fields = fieldsOf(

--- a/src/serve/http/api/query/sim-query-request.ts
+++ b/src/serve/http/api/query/sim-query-request.ts
@@ -64,6 +64,24 @@ export class SimQueryFields {
   }
 
   /**
+   * One numeric member, which Query carries as its decimal text.
+   *
+   * Text that is not a number at all is nothing rather than NaN, so a
+   * simulated service sees a member the request never stated instead of a
+   * value it has to check.
+   */
+  number(name: string): number | undefined {
+    const value = this.text(name);
+    if (value === undefined || value.trim().length === 0) {
+      return undefined;
+    }
+
+    const parsed = Number(value);
+
+    return Number.isNaN(parsed) ? undefined : parsed;
+  }
+
+  /**
    * One blob member, which Query carries as base64 text.
    */
   binary(name: string): Uint8Array | undefined {

--- a/src/serve/http/api/query/sim-query-result.iso.test.ts
+++ b/src/serve/http/api/query/sim-query-result.iso.test.ts
@@ -7,6 +7,7 @@ import {
   queryMap,
   queryMembers,
   queryScalarList,
+  queryStructure,
 } from "./sim-query-result.js";
 
 /**
@@ -59,6 +60,39 @@ describe("writing a Query protocol response", () => {
     assertIdentical(
       written,
       "<OutputValue>[&quot;one&quot;,&quot;two&quot;]</OutputValue>",
+    );
+  });
+
+  it("nests the members of a structure inside it", () => {
+    // Given an output holding a structure, as an assumed-role session's
+    // credentials are
+    const output = {
+      Credentials: { AccessKeyId: "ASIAEXAMPLE", Expiration: new Date(0) },
+    };
+
+    // When the structure is written
+    const written = queryStructure(output, "Credentials", (credentials) =>
+      queryMembers(credentials, ["AccessKeyId", "Expiration"]),
+    );
+
+    // Then its members are inside it rather than alongside it
+    assertIdentical(
+      written,
+      "<Credentials><AccessKeyId>ASIAEXAMPLE</AccessKeyId>" +
+        "<Expiration>1970-01-01T00:00:00.000Z</Expiration></Credentials>",
+    );
+  });
+
+  it("writes nothing for a structure the operation left out", () => {
+    // Given an operation that answered without one of its structures, as a
+    // refused request does
+    const output = {};
+
+    // When it is written
+    // Then there is no element at all, rather than an empty one
+    assertIdentical(
+      queryStructure(output, "Credentials", () => ""),
+      "",
     );
   });
 

--- a/src/serve/http/api/query/sim-query-result.ts
+++ b/src/serve/http/api/query/sim-query-result.ts
@@ -25,6 +25,23 @@ export function queryMembers(
 }
 
 /**
+ * Write a structure member, whose own members Query nests inside it.
+ *
+ * A structure the operation did not produce writes nothing, the same way an
+ * absent scalar member does, so a caller reads its absence rather than an
+ * empty element.
+ */
+export function queryStructure(
+  value: SimQueryOutput,
+  name: string,
+  members: (structure: SimQueryOutput) => string,
+): string {
+  const structure = value[name];
+
+  return isRecord(structure) ? xmlElement(name, members(structure)) : "";
+}
+
+/**
  * Write a list member, whose items Query wraps one `member` element each.
  */
 export function queryList(

--- a/src/service/sts/serve/sim-sts-api-assume-role.loc.test.ts
+++ b/src/service/sts/serve/sim-sts-api-assume-role.loc.test.ts
@@ -1,0 +1,177 @@
+import {
+  CreateAccessKeyCommand,
+  CreateRoleCommand,
+  CreateUserCommand,
+} from "@aws-sdk/client-iam";
+import {
+  AssumeRoleCommand,
+  GetCallerIdentityCommand,
+  STSClient,
+} from "@aws-sdk/client-sts";
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { afterAll, beforeAll, describe, it } from "vitest";
+
+import { SimAwsLocalServer } from "../../../serve/index.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+
+/**
+ * Assuming a Role over a port, which is the shape most production code takes:
+ * a process assumes a Role and then does its work as the session.
+ *
+ * `AssumeRole` is the first served operation whose answer nests structures,
+ * and the credentials it hands back have to sign the requests that follow.
+ * Both are what these cover.
+ */
+describe("Assuming a Role over the STS endpoint", () => {
+  const simAws = new SimAws();
+  const srv = new SimAwsLocalServer({ simAws });
+
+  let endpoint: string;
+  let client: STSClient;
+  let accountId: string;
+  let userArn: string;
+
+  beforeAll(async () => {
+    await srv.listen();
+    endpoint = `http://localhost:${srv.port}`;
+    accountId = simAws.defaultAccountId;
+    userArn = `arn:aws:iam::${accountId}:user/Batch`;
+
+    const simIam = simAws.iam();
+    await simIam.createUser(new CreateUserCommand({ UserName: "Batch" }));
+    const created = await simIam.createAccessKey(
+      new CreateAccessKeyCommand({ UserName: "Batch" }),
+    );
+
+    client = new STSClient({
+      region: simAws.defaultRegionName,
+      endpoint,
+      credentials: {
+        accessKeyId: created.AccessKey.AccessKeyId,
+        secretAccessKey: created.AccessKey.SecretAccessKey,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await srv.close();
+  });
+
+  it("hands back credentials that sign the request the caller makes next", async () => {
+    // Given a Role this caller is trusted to assume
+    await createRole("Reader", userArn);
+
+    // When it is assumed over the endpoint
+    const assumed = await client.send(
+      new AssumeRoleCommand({
+        RoleArn: `arn:aws:iam::${accountId}:role/Reader`,
+        RoleSessionName: "nightly",
+      }),
+    );
+
+    // Then the session came back whole, in the two structures STS nests it in
+    const session = assumed.Credentials;
+    assertDefined(session, "the assumed session credentials");
+    assertDefined(session.AccessKeyId, "the session access key id");
+    assertDefined(session.SecretAccessKey, "the session secret");
+    assertDefined(session.SessionToken, "the session token");
+    assertStringIncludes(session.AccessKeyId, "ASIA");
+    const assumedRoleUser = assumed.AssumedRoleUser;
+    assertDefined(assumedRoleUser, "the assumed Role user");
+    assertDefined(assumedRoleUser.AssumedRoleId, "the assumed Role id");
+    assertIdentical(
+      assumedRoleUser.Arn,
+      `arn:aws:sts::${accountId}:assumed-role/Reader/nightly`,
+    );
+    assertStringIncludes(assumedRoleUser.AssumedRoleId, ":nightly");
+
+    // And the credentials it answered with sign a second served request, which
+    // simulated IAM authorizes against the Role behind the session
+    const sessionClient = new STSClient({
+      region: simAws.defaultRegionName,
+      endpoint,
+      credentials: {
+        accessKeyId: session.AccessKeyId,
+        secretAccessKey: session.SecretAccessKey,
+        sessionToken: session.SessionToken,
+      },
+    });
+    const identity = await sessionClient.send(new GetCallerIdentityCommand({}));
+
+    assertIdentical(identity.Arn, assumedRoleUser.Arn);
+  });
+
+  it("expires the session on simulated time rather than on the host clock", async () => {
+    // Given a simulation whose clock has been moved days away from this machine's
+    await createRole("Weekly", userArn);
+    await simAws.clock().advanceBy({ days: 3 });
+
+    // When a fifteen minute session is assumed over the endpoint
+    const assumed = await client.send(
+      new AssumeRoleCommand({
+        RoleArn: `arn:aws:iam::${accountId}:role/Weekly`,
+        RoleSessionName: "sweep",
+        DurationSeconds: 900,
+      }),
+    );
+
+    // Then the expiry the caller reads is fifteen minutes past simulated time,
+    // which is days past the host clock the SDK signed with
+    const expiration = assumed.Credentials?.Expiration;
+    assertDefined(expiration, "the session expiry");
+    assertIdentical(
+      expiration.getTime(),
+      simAws.clock().now().getTime() + 900_000,
+    );
+    assertTrue(expiration.getTime() > Date.now() + 2 * 24 * 60 * 60 * 1000);
+  });
+
+  it("refuses a caller the Role does not trust", async () => {
+    // Given a Role whose trust policy names somebody else
+    await createRole("Restricted", `arn:aws:iam::${accountId}:user/Somebody`);
+
+    // When this caller tries to assume it
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await client.send(
+          new AssumeRoleCommand({
+            RoleArn: `arn:aws:iam::${accountId}:role/Restricted`,
+            RoleSessionName: "nightly",
+          }),
+        ),
+    );
+
+    // Then it comes back as the error real STS raises, under the name a
+    // handler catching it in production would see
+    assertIdentical(error.name, "AccessDenied");
+    assertStringIncludes(error.message, "sts:AssumeRole");
+  });
+
+  /**
+   * A Role one principal is trusted to assume, and nobody else.
+   */
+  async function createRole(
+    roleName: string,
+    trustedArn: string,
+  ): Promise<void> {
+    await simAws.iam().createRole(
+      new CreateRoleCommand({
+        RoleName: roleName,
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { AWS: trustedArn },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+  }
+});

--- a/src/service/sts/serve/sim-sts-api.ts
+++ b/src/service/sts/serve/sim-sts-api.ts
@@ -1,7 +1,10 @@
 import type { SimAws } from "../../aws/sim-aws.js";
 import { SimQueryApiEndpoint } from "../../../serve/http/api/query/sim-query-endpoint.js";
 import type { SimQueryOperations } from "../../../serve/http/api/query/sim-query-operation.js";
-import { queryMembers } from "../../../serve/http/api/query/sim-query-result.js";
+import {
+  queryMembers,
+  queryStructure,
+} from "../../../serve/http/api/query/sim-query-result.js";
 
 /**
  * The XML namespace real STS stamps on every response it sends.
@@ -11,10 +14,10 @@ const stsNamespace = "https://sts.amazonaws.com/doc/2011-06-15/";
 /**
  * Serve the STS Query API to a client given an endpoint URL.
  *
- * `GetCallerIdentity` is the only operation simulated STS implements, and it
- * is the one a person reaches for to check that an endpoint and a set of
- * credentials are wired up as expected. `AssumeRole` is reachable in process
- * and through SDK interception.
+ * The two operations simulated STS implements are both served.
+ * `GetCallerIdentity` is the one a person reaches for to check that an
+ * endpoint and a set of credentials are wired up as expected, and `AssumeRole`
+ * hands back credentials that sign the requests the caller makes next.
  */
 export function simStsApiEndpoint(simAws: SimAws): SimQueryApiEndpoint {
   return new SimQueryApiEndpoint({
@@ -33,6 +36,29 @@ function simStsQueryOperations(): SimQueryOperations {
         input: (): Record<string, unknown> => ({}),
         result: (output): string =>
           queryMembers(output, ["UserId", "Account", "Arn"]),
+      },
+    ],
+    [
+      "AssumeRole",
+      {
+        input: (fields): Record<string, unknown> => ({
+          RoleArn: fields.text("RoleArn"),
+          RoleSessionName: fields.text("RoleSessionName"),
+          DurationSeconds: fields.number("DurationSeconds"),
+          ExternalId: fields.text("ExternalId"),
+        }),
+        result: (output): string =>
+          queryStructure(output, "Credentials", (credentials) =>
+            queryMembers(credentials, [
+              "AccessKeyId",
+              "SecretAccessKey",
+              "SessionToken",
+              "Expiration",
+            ]),
+          ) +
+          queryStructure(output, "AssumedRoleUser", (user) =>
+            queryMembers(user, ["Arn", "AssumedRoleId"]),
+          ),
       },
     ],
   ]);


### PR DESCRIPTION
Brief, concise description of the change:

The served STS endpoint answered `GetCallerIdentity` and refused every other Action, which left the shape most production code takes out of reach from outside the process. `AssumeRole` is now one more entry in the STS Query operations map, reading `RoleArn`, `RoleSessionName`, `DurationSeconds` and `ExternalId` off the form encoding and writing `Credentials` and `AssumedRoleUser` back. Both are structures, which the Query envelope had not had to carry before, so the shared result writer gains `queryStructure` alongside `queryMembers` and the list and map writers. The request reader gains `number()` for the same reason: `DurationSeconds` arrives as text and no Query service had wanted a number until now. The credentials come back with an expiry stamped from the simulation's own clock, and a Role whose trust policy refuses the caller answers `AccessDenied` in the Query error shape. A new `.loc.test.ts` assumes a Role over the endpoint and signs a second served request with the credentials it answers with.

Resolves https://github.com/KensioSoftware/yulin/issues/686

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`

See https://www.conventionalcommits.org/en/v1.0.0/