### PR TITLE
feat: serve IAM and ELBv2 over the Query protocol

### DIFF
--- a/docs/serve/README.md
+++ b/docs/serve/README.md
@@ -246,7 +246,7 @@ A request carrying no signature is anonymous and reaches nothing. In process an 
 
 ### Which services answer
 
-S3, STS, SNS, CloudFormation, Lambda, and the services that speak the AWS JSON protocol. Those are DynamoDB, DynamoDB Streams, SQS, Cognito Identity Provider, EventBridge, ECS, SSM, ACM, CloudWatch, CloudWatch Logs, KMS, Secrets Manager and Rekognition.
+S3, STS, IAM, ELBv2, SNS, CloudFormation, Lambda, and the services that speak the AWS JSON protocol. Those are DynamoDB, DynamoDB Streams, SQS, Cognito Identity Provider, EventBridge, ECS, SSM, ACM, CloudWatch, CloudWatch Logs, KMS, Secrets Manager and Rekognition.
 
 A request to any other service is refused with `501 Not Implemented` and a body saying why. Every service is reachable in process through `SimAws` and through [SDK interception](../sdk/README.md), whether or not it answers here.
 
@@ -305,6 +305,65 @@ raises it.
 
 `AssumeRole` and `GetCallerIdentity` are the two operations simulated STS implements, and both are
 served. `AssumeRoleWithWebIdentity` and `GetSessionToken` are refused as `NotImplemented`.
+
+### IAM over the endpoint
+
+A served request runs as whoever signed it, and the credentials to sign one used to come from the
+process that built the simulation. `aws iam` closes that circle. A container or a shell script
+creates its own User over the endpoint, gives it a policy, asks for an access key and signs
+everything after that with what it was answered:
+
+```bash
+export AWS_ENDPOINT_URL=http://localhost:8787
+aws iam create-user --user-name widgets
+aws iam put-user-policy --user-name widgets --policy-name everything \
+  --policy-document '{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"*","Resource":"*"}}'
+aws iam create-access-key --user-name widgets
+```
+
+`create-access-key` answers with the secret, and nothing reports it again. The first request still
+has to be signed by somebody. The [example above](#pointing-an-aws-sdk-or-the-cli-at-the-simulation)
+builds one identity in process, and everything after it can be built over the port.
+
+The fifteen operations simulated IAM implements are:
+
+- **Users** — `CreateUser`, `CreateAccessKey`, `PutUserPolicy`
+- **Roles** — `CreateRole`, `GetRole`, `ListRoles`, `DeleteRole`, `AttachRolePolicy`,
+  `DetachRolePolicy`, `PutRolePolicy`, `DeleteRolePolicy`
+- **Managed policies** — `CreatePolicy`, `GetPolicy`, `ListPolicies`, `DeletePolicy`
+
+Anything else is refused as `NotImplemented`, which an SDK raises under that name.
+
+### ELBv2 over the endpoint
+
+`aws elbv2` builds an Application Load Balancer in the simulation over the same endpoint URL:
+
+```bash
+export AWS_ENDPOINT_URL=http://localhost:8787
+aws elbv2 create-load-balancer --name shop-alb --subnets subnet-1 subnet-2
+aws elbv2 create-target-group --name checkout-tg --target-type lambda
+aws elbv2 create-listener --load-balancer-arn <arn> --protocol HTTP --port 80 \
+  --default-actions Type=forward,TargetGroupArn=<arn>
+```
+
+A load balancer built this way is the same load balancer an in-process build produces. Its DNS name
+is served on the local port, and a request to it reaches the simulated Functions and ECS Services
+registered behind it.
+
+The twenty-two operations simulated ELBv2 implements are:
+
+- **Load balancers** — `CreateLoadBalancer`, `DescribeLoadBalancers`, `DeleteLoadBalancer`
+- **Target groups** — `CreateTargetGroup`, `DescribeTargetGroups`, `ModifyTargetGroup`,
+  `DeleteTargetGroup`
+- **Targets** — `RegisterTargets`, `DeregisterTargets`, `DescribeTargetHealth`
+- **Listeners** — `CreateListener`, `DescribeListeners`, `ModifyListener`, `DeleteListener`
+- **Listener certificates** — `AddListenerCertificates`, `RemoveListenerCertificates`,
+  `DescribeListenerCertificates`
+- **Rules** — `CreateRule`, `DescribeRules`, `ModifyRule`, `DeleteRule`, `SetRulePriorities`
+
+A rule matches on `host-header` and `path-pattern`, in either the plain `Values` form or the
+per-field configuration. A condition naming any other field is refused by name, as is an operation
+outside the list above.
 
 ### S3 over the endpoint
 

--- a/src/serve/http/api/sim-aws-api-protocols.ts
+++ b/src/serve/http/api/sim-aws-api-protocols.ts
@@ -1,6 +1,8 @@
 import type { SimAwsCaller } from "../../../service/aws/caller/sim-aws-caller.js";
 import type { SimAws } from "../../../service/aws/sim-aws.js";
 import { simCloudFormationApiEndpoint } from "../../../service/cloudformation/serve/sim-cloudformation-api.js";
+import { simElbV2ApiEndpoint } from "../../../service/elbv2/serve/api/sim-elbv2-api.js";
+import { simIamApiEndpoint } from "../../../service/iam/serve/sim-iam-api.js";
 import { simLambdaApiEndpoint } from "../../../service/lambda/serve/api/sim-lambda-api.js";
 import { SimS3ApiEndpoint } from "../../../service/s3/serve/api/sim-s3-api.js";
 import { simSnsApiEndpoint } from "../../../service/sns/serve/sim-sns-api.js";
@@ -43,6 +45,8 @@ const simAwsProtocolEndpointFactories = new Map<
   ["sns", simSnsApiEndpoint],
   ["cloudformation", simCloudFormationApiEndpoint],
   ["lambda", simLambdaApiEndpoint],
+  ["iam", simIamApiEndpoint],
+  ["elasticloadbalancing", simElbV2ApiEndpoint],
 ]);
 
 /**

--- a/src/service/elbv2/serve/api/sim-elbv2-api-routing.loc.test.ts
+++ b/src/service/elbv2/serve/api/sim-elbv2-api-routing.loc.test.ts
@@ -19,6 +19,7 @@ import {
   assertArrayLength,
   assertIdentical,
   assertNonNullable,
+  assertTrue,
 } from "@kensio/smartass";
 import { afterAll, beforeAll, describe, it } from "vitest";
 
@@ -190,7 +191,11 @@ describe("Serving simulated ELBv2 routing on an endpoint URL", () => {
     const remaining = await client.send(
       new DescribeListenerCertificatesCommand({ ListenerArn: listenerArn }),
     );
+    const [left] = remaining.Certificates ?? [];
     assertArrayLength(remaining.Certificates ?? [], 1);
+    assertNonNullable(left, "the certificate that was not removed");
+    assertIdentical(left.CertificateArn, defaultCertificateArn);
+    assertTrue(left.IsDefault ?? false);
   });
 
   it("writes rules on a listener in both condition forms", async () => {

--- a/src/service/elbv2/serve/api/sim-elbv2-api-routing.loc.test.ts
+++ b/src/service/elbv2/serve/api/sim-elbv2-api-routing.loc.test.ts
@@ -1,0 +1,320 @@
+import {
+  AddListenerCertificatesCommand,
+  CreateListenerCommand,
+  CreateRuleCommand,
+  DeleteListenerCommand,
+  DeleteRuleCommand,
+  DescribeListenerCertificatesCommand,
+  DescribeListenersCommand,
+  DescribeRulesCommand,
+  ElasticLoadBalancingV2Client,
+  ModifyListenerCommand,
+  ModifyRuleCommand,
+  RemoveListenerCertificatesCommand,
+  type RuleCondition,
+  SetRulePrioritiesCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+import {
+  assertArrayIncludes,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+} from "@kensio/smartass";
+import { afterAll, beforeAll, describe, it } from "vitest";
+
+import {
+  servedListener,
+  servedLoadBalancer,
+  servedTargetGroup,
+} from "../../../../../test/elbv2/served-elbv2-api.js";
+import { servedUserCredentials } from "../../../../../test/serve/served-credentials.js";
+import { SimAwsLocalServer } from "../../../../serve/index.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { createFixtureCertificate } from "../../sim-elbv2.fixture.js";
+
+/**
+ * The listeners, certificates and rules of a simulated load balancer, reached
+ * over a port by a real client.
+ *
+ * These are the deepest requests ELB takes. An action holds a forward
+ * configuration holding a list of target groups, and a condition holds its
+ * values in either of two forms. Query flattens all of it into one form
+ * encoding, and these cover what comes back out.
+ */
+describe("Serving simulated ELBv2 routing on an endpoint URL", () => {
+  const simAws = new SimAws();
+  const srv = new SimAwsLocalServer({ simAws });
+
+  let client: ElasticLoadBalancingV2Client;
+
+  beforeAll(async () => {
+    await srv.listen();
+
+    client = new ElasticLoadBalancingV2Client({
+      region: simAws.defaultRegionName,
+      endpoint: `http://localhost:${srv.port}`,
+      credentials: await servedUserCredentials(simAws, "Operator"),
+    });
+  });
+
+  afterAll(async () => {
+    await srv.close();
+  });
+
+  it("makes a listener, changes what it answers with and removes it", async () => {
+    // Given a listener forwarding to a target group, made over the endpoint
+    const loadBalancerArn = await servedLoadBalancer(client, "checkout-alb");
+    const targetGroupArn = await servedTargetGroup(client, "checkout-tg");
+    const listenerArn = await servedListener(
+      client,
+      loadBalancerArn,
+      targetGroupArn,
+    );
+
+    // When it is described and then changed to answer for itself
+    const described = await client.send(
+      new DescribeListenersCommand({ ListenerArns: [listenerArn] }),
+    );
+    const changed = await client.send(
+      new ModifyListenerCommand({
+        ListenerArn: listenerArn,
+        DefaultActions: [
+          {
+            Type: "fixed-response",
+            FixedResponseConfig: {
+              StatusCode: "503",
+              MessageBody: "closed for stocktaking",
+              ContentType: "text/plain",
+            },
+          },
+        ],
+      }),
+    );
+
+    // Then the nested forward configuration came back the way it went out
+    const [listener] = described.Listeners ?? [];
+    assertNonNullable(listener, "the listener just created");
+    assertIdentical(listener.Port, 80);
+    assertIdentical(listener.Protocol, "HTTP");
+
+    const [action] = listener.DefaultActions ?? [];
+    assertNonNullable(action, "the listener's default action");
+    assertIdentical(action.Type, "forward");
+    assertIdentical(action.Order, 1);
+
+    const [tuple] = action.ForwardConfig?.TargetGroups ?? [];
+    assertNonNullable(tuple, "the forwarded target group");
+    assertIdentical(tuple.TargetGroupArn, targetGroupArn);
+    assertIdentical(tuple.Weight, 1);
+
+    const [fixed] = changed.Listeners?.[0]?.DefaultActions ?? [];
+    assertNonNullable(fixed, "the changed default action");
+    assertIdentical(fixed.FixedResponseConfig?.StatusCode, "503");
+    assertIdentical(
+      fixed.FixedResponseConfig.MessageBody,
+      "closed for stocktaking",
+    );
+
+    // And deleting it leaves the load balancer with none
+    await client.send(new DeleteListenerCommand({ ListenerArn: listenerArn }));
+
+    const left = await client.send(
+      new DescribeListenersCommand({ LoadBalancerArn: loadBalancerArn }),
+    );
+    assertArrayLength(left.Listeners ?? [], 0);
+  });
+
+  it("adds a certificate to an HTTPS listener and takes it off", async () => {
+    // Given an HTTPS listener with one certificate, and another one issued
+    const loadBalancerArn = await servedLoadBalancer(client, "secure-alb");
+    const targetGroupArn = await servedTargetGroup(client, "secure-tg");
+    const defaultCertificateArn = await createFixtureCertificate(simAws);
+    const extraCertificateArn = await createFixtureCertificate(
+      simAws,
+      simAws.acm(),
+      "checkout.example.com",
+    );
+
+    const created = await client.send(
+      new CreateListenerCommand({
+        LoadBalancerArn: loadBalancerArn,
+        Protocol: "HTTPS",
+        Port: 443,
+        SslPolicy: "ELBSecurityPolicy-TLS13-1-2-2021-06",
+        Certificates: [{ CertificateArn: defaultCertificateArn }],
+        DefaultActions: [{ Type: "forward", TargetGroupArn: targetGroupArn }],
+      }),
+    );
+    const [listener] = created.Listeners ?? [];
+    assertNonNullable(listener, "the HTTPS listener just created");
+    assertIdentical(listener.SslPolicy, "ELBSecurityPolicy-TLS13-1-2-2021-06");
+
+    const listenerArn = listener.ListenerArn;
+    assertNonNullable(listenerArn, "the listener's ARN");
+
+    // When the second certificate is added over the endpoint
+    const added = await client.send(
+      new AddListenerCertificatesCommand({
+        ListenerArn: listenerArn,
+        Certificates: [{ CertificateArn: extraCertificateArn }],
+      }),
+    );
+
+    // Then the listener answers for both, and the default says which it is
+    assertArrayIncludes(
+      (added.Certificates ?? []).map((each) => each.CertificateArn),
+      extraCertificateArn,
+    );
+
+    const listed = await client.send(
+      new DescribeListenerCertificatesCommand({
+        ListenerArn: listenerArn,
+        PageSize: 10,
+      }),
+    );
+    const certificates = listed.Certificates ?? [];
+    assertArrayLength(certificates, 2);
+    assertIdentical(
+      certificates.find((each) => each.IsDefault === true)?.CertificateArn,
+      defaultCertificateArn,
+    );
+
+    // And removing the added one leaves the default behind
+    await client.send(
+      new RemoveListenerCertificatesCommand({
+        ListenerArn: listenerArn,
+        Certificates: [{ CertificateArn: extraCertificateArn }],
+      }),
+    );
+
+    const remaining = await client.send(
+      new DescribeListenerCertificatesCommand({ ListenerArn: listenerArn }),
+    );
+    assertArrayLength(remaining.Certificates ?? [], 1);
+  });
+
+  it("writes rules on a listener in both condition forms", async () => {
+    // Given a listener with two rules, each stating its values differently
+    const listenerArn = await ruledListener(client, "rules-alb", "rules-tg");
+    const hostRuleArn = await servedRule(client, listenerArn, 10, {
+      Field: "host-header",
+      Values: ["shop.example.com"],
+    });
+    const pathRuleArn = await servedRule(client, listenerArn, 20, {
+      Field: "path-pattern",
+      PathPatternConfig: { Values: ["/admin/*"] },
+    });
+
+    // When the listener's rules are described
+    const described = await client.send(
+      new DescribeRulesCommand({ ListenerArn: listenerArn, PageSize: 10 }),
+    );
+    const rules = described.Rules ?? [];
+
+    // Then both forms came back the way they went out
+    const hostRule = rules.find((each) => each.RuleArn === hostRuleArn);
+    assertNonNullable(hostRule, "the host-header rule");
+    assertIdentical(hostRule.Priority, "10");
+    assertArrayIncludes(
+      hostRule.Conditions?.[0]?.Values ?? [],
+      "shop.example.com",
+    );
+
+    const pathRule = rules.find((each) => each.RuleArn === pathRuleArn);
+    assertNonNullable(pathRule, "the path-pattern rule");
+    assertArrayIncludes(
+      pathRule.Conditions?.[0]?.PathPatternConfig?.Values ?? [],
+      "/admin/*",
+    );
+    assertIdentical(pathRule.Actions?.[0]?.RedirectConfig?.Path, "/staff");
+  });
+
+  it("changes a rule, reorders it and deletes another", async () => {
+    // Given two rules on a listener
+    const listenerArn = await ruledListener(client, "orders-alb", "orders-tg");
+    const firstRuleArn = await servedRule(client, listenerArn, 10, {
+      Field: "host-header",
+      Values: ["shop.example.com"],
+    });
+    const secondRuleArn = await servedRule(client, listenerArn, 20, {
+      Field: "path-pattern",
+      PathPatternConfig: { Values: ["/admin/*"] },
+    });
+
+    // When one is changed and moved, and the other is deleted
+    const changed = await client.send(
+      new ModifyRuleCommand({
+        RuleArn: firstRuleArn,
+        Conditions: [{ Field: "host-header", Values: ["orders.example.com"] }],
+        Actions: [
+          {
+            Type: "redirect",
+            RedirectConfig: { Path: "/orders", StatusCode: "HTTP_302" },
+          },
+        ],
+      }),
+    );
+    const reordered = await client.send(
+      new SetRulePrioritiesCommand({
+        RulePriorities: [{ RuleArn: firstRuleArn, Priority: 30 }],
+      }),
+    );
+    await client.send(new DeleteRuleCommand({ RuleArn: secondRuleArn }));
+
+    // Then the listener is left with the one rule, as it was changed
+    assertArrayIncludes(
+      changed.Rules?.[0]?.Conditions?.[0]?.Values ?? [],
+      "orders.example.com",
+    );
+    assertIdentical(reordered.Rules?.[0]?.Priority, "30");
+
+    const left = await client.send(
+      new DescribeRulesCommand({ RuleArns: [firstRuleArn] }),
+    );
+    assertArrayLength(left.Rules ?? [], 1);
+  });
+});
+
+/**
+ * A load balancer, target group and listener for rules to be written on.
+ */
+async function ruledListener(
+  client: ElasticLoadBalancingV2Client,
+  loadBalancerName: string,
+  targetGroupName: string,
+): Promise<string> {
+  const loadBalancerArn = await servedLoadBalancer(client, loadBalancerName);
+  const targetGroupArn = await servedTargetGroup(client, targetGroupName);
+
+  return await servedListener(client, loadBalancerArn, targetGroupArn);
+}
+
+/**
+ * Write one redirecting rule on a listener, answering with its ARN.
+ */
+async function servedRule(
+  client: ElasticLoadBalancingV2Client,
+  listenerArn: string,
+  priority: number,
+  condition: RuleCondition,
+): Promise<string> {
+  const created = await client.send(
+    new CreateRuleCommand({
+      ListenerArn: listenerArn,
+      Priority: priority,
+      Conditions: [condition],
+      Actions: [
+        {
+          Type: "redirect",
+          RedirectConfig: { Path: "/staff", StatusCode: "HTTP_301" },
+        },
+      ],
+      Tags: [{ Key: "team", Value: "shop" }],
+    }),
+  );
+
+  const arn = created.Rules?.[0]?.RuleArn;
+  assertNonNullable(arn, "CreateRule answered with an ARN");
+
+  return arn;
+}

--- a/src/service/elbv2/serve/api/sim-elbv2-api.loc.test.ts
+++ b/src/service/elbv2/serve/api/sim-elbv2-api.loc.test.ts
@@ -182,13 +182,22 @@ describe("Serving simulated ELBv2 on an endpoint URL", () => {
       }),
     );
 
-    const remaining = await client.send(
+    const asked = await client.send(
       new DescribeTargetHealthCommand({
         TargetGroupArn: targetGroupArn,
         Targets: [{ Id: "10.0.0.2", Port: 8081 }],
       }),
     );
+    assertArrayLength(asked.TargetHealthDescriptions ?? [], 1);
+
+    const remaining = await client.send(
+      new DescribeTargetHealthCommand({ TargetGroupArn: targetGroupArn }),
+    );
+    const [left] = remaining.TargetHealthDescriptions ?? [];
     assertArrayLength(remaining.TargetHealthDescriptions ?? [], 1);
+    assertNonNullable(left, "the target that was not deregistered");
+    assertIdentical(left.Target?.Id, "10.0.0.2");
+    assertIdentical(left.Target.Port, 8081);
   });
 
   it("refuses an ELBv2 operation it does not serve", async () => {

--- a/src/service/elbv2/serve/api/sim-elbv2-api.loc.test.ts
+++ b/src/service/elbv2/serve/api/sim-elbv2-api.loc.test.ts
@@ -1,0 +1,210 @@
+import {
+  DeleteLoadBalancerCommand,
+  DeleteTargetGroupCommand,
+  DeregisterTargetsCommand,
+  DescribeLoadBalancersCommand,
+  DescribeTargetGroupAttributesCommand,
+  DescribeTargetGroupsCommand,
+  DescribeTargetHealthCommand,
+  ElasticLoadBalancingV2Client,
+  ModifyTargetGroupCommand,
+  RegisterTargetsCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+import {
+  assertArrayIncludes,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { afterAll, beforeAll, describe, it } from "vitest";
+
+import {
+  servedLoadBalancer,
+  servedTargetGroup,
+} from "../../../../../test/elbv2/served-elbv2-api.js";
+import { servedUserCredentials } from "../../../../../test/serve/served-credentials.js";
+import { SimAwsLocalServer } from "../../../../serve/index.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+
+/**
+ * Simulated ELBv2 reached over a port by a real client, which is the shape a
+ * container provisioning its own routing has.
+ *
+ * ELB speaks the Query protocol, and its requests nest further than any other
+ * service that does. A health check matcher, a forward configuration and a
+ * rule condition all arrive flattened into one form encoding. What these cover
+ * is whether a request survives that and comes back out the same shape.
+ */
+describe("Serving simulated ELBv2 on an endpoint URL", () => {
+  const simAws = new SimAws();
+  const srv = new SimAwsLocalServer({ simAws });
+
+  let client: ElasticLoadBalancingV2Client;
+
+  beforeAll(async () => {
+    await srv.listen();
+
+    client = new ElasticLoadBalancingV2Client({
+      region: simAws.defaultRegionName,
+      endpoint: `http://localhost:${srv.port}`,
+      credentials: await servedUserCredentials(simAws, "Operator"),
+    });
+  });
+
+  afterAll(async () => {
+    await srv.close();
+  });
+
+  it("makes a load balancer, describes it and takes it away", async () => {
+    // Given a load balancer created over the endpoint
+    const loadBalancerArn = await servedLoadBalancer(client, "shop-alb");
+
+    // When it is described by name
+    const described = await client.send(
+      new DescribeLoadBalancersCommand({ Names: ["shop-alb"], PageSize: 10 }),
+    );
+
+    // Then the nested state and the timestamp arrived as what they are
+    const [loadBalancer] = described.LoadBalancers ?? [];
+    assertNonNullable(loadBalancer, "the load balancer just created");
+    assertIdentical(loadBalancer.LoadBalancerArn, loadBalancerArn);
+    assertIdentical(loadBalancer.State?.Code, "active");
+    assertIdentical(loadBalancer.Type, "application");
+    assertStringIncludes(loadBalancer.DNSName ?? "", "shop-alb");
+    assertNonNullable(loadBalancer.CreatedTime, "a creation time");
+
+    // And deleting it over the endpoint leaves nothing to describe
+    await client.send(
+      new DeleteLoadBalancerCommand({ LoadBalancerArn: loadBalancerArn }),
+    );
+
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await client.send(
+          new DescribeLoadBalancersCommand({
+            LoadBalancerArns: [loadBalancerArn],
+          }),
+        ),
+    );
+    assertIdentical(error.name, "LoadBalancerNotFoundException");
+  });
+
+  it("makes a target group, changes its health check and deletes it", async () => {
+    // Given a target group created over the endpoint with a health check
+    const targetGroupArn = await servedTargetGroup(client, "orders-tg");
+
+    // When it is described and its health check is changed
+    const described = await client.send(
+      new DescribeTargetGroupsCommand({ Names: ["orders-tg"] }),
+    );
+    const changed = await client.send(
+      new ModifyTargetGroupCommand({
+        TargetGroupArn: targetGroupArn,
+        HealthCheckPath: "/ready",
+        HealthCheckTimeoutSeconds: 4,
+        UnhealthyThresholdCount: 4,
+        Matcher: { HttpCode: "200" },
+      }),
+    );
+
+    // Then the settings survived as the numbers and the nested matcher they are
+    const [targetGroup] = described.TargetGroups ?? [];
+    assertNonNullable(targetGroup, "the target group just created");
+    assertIdentical(targetGroup.Port, 8080);
+    assertIdentical(targetGroup.HealthCheckIntervalSeconds, 15);
+    assertIdentical(targetGroup.HealthyThresholdCount, 3);
+    assertIdentical(targetGroup.Matcher?.HttpCode, "200-299");
+    assertTrue(targetGroup.HealthCheckEnabled ?? false);
+
+    const [modified] = changed.TargetGroups ?? [];
+    assertNonNullable(modified, "the changed target group");
+    assertIdentical(modified.HealthCheckPath, "/ready");
+    assertIdentical(modified.HealthCheckTimeoutSeconds, 4);
+    assertIdentical(modified.UnhealthyThresholdCount, 4);
+    assertIdentical(modified.Matcher?.HttpCode, "200");
+
+    // And it can be deleted over the same endpoint
+    await client.send(
+      new DeleteTargetGroupCommand({ TargetGroupArn: targetGroupArn }),
+    );
+
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await client.send(
+          new DescribeTargetGroupsCommand({
+            TargetGroupArns: [targetGroupArn],
+          }),
+        ),
+    );
+    assertIdentical(error.name, "TargetGroupNotFoundException");
+  });
+
+  it("registers targets, reports their health and deregisters them", async () => {
+    // Given a target group with two addresses registered over the endpoint
+    const targetGroupArn = await servedTargetGroup(client, "web-tg");
+
+    await client.send(
+      new RegisterTargetsCommand({
+        TargetGroupArn: targetGroupArn,
+        Targets: [
+          { Id: "10.0.0.1", Port: 8080 },
+          { Id: "10.0.0.2", Port: 8081 },
+        ],
+      }),
+    );
+
+    // When their health is asked about
+    const health = await client.send(
+      new DescribeTargetHealthCommand({ TargetGroupArn: targetGroupArn }),
+    );
+
+    // Then both are reported, each on the port it was registered on
+    const described = health.TargetHealthDescriptions ?? [];
+    assertArrayLength(described, 2);
+    assertArrayIncludes(
+      described.map((each) => each.Target?.Id),
+      "10.0.0.1",
+    );
+
+    const [first] = described;
+    assertNonNullable(first, "the first target");
+    assertIdentical(first.TargetHealth?.State, "healthy");
+    assertIdentical(first.Target?.Port, 8080);
+
+    // And deregistering one leaves the other
+    await client.send(
+      new DeregisterTargetsCommand({
+        TargetGroupArn: targetGroupArn,
+        Targets: [{ Id: "10.0.0.1", Port: 8080 }],
+      }),
+    );
+
+    const remaining = await client.send(
+      new DescribeTargetHealthCommand({
+        TargetGroupArn: targetGroupArn,
+        Targets: [{ Id: "10.0.0.2", Port: 8081 }],
+      }),
+    );
+    assertArrayLength(remaining.TargetHealthDescriptions ?? [], 1);
+  });
+
+  it("refuses an ELBv2 operation it does not serve", async () => {
+    // When an operation simulated ELBv2 has no answer for is asked for
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await client.send(
+          new DescribeTargetGroupAttributesCommand({
+            TargetGroupArn: "arn:aws:elasticloadbalancing:::targetgroup/none",
+          }),
+        ),
+    );
+
+    // Then it is refused by name, in the shape the Query protocol states an
+    // error, so an SDK raises it rather than failing to parse the response
+    assertIdentical(error.name, "NotImplemented");
+    assertStringIncludes(error.message, "DescribeTargetGroupAttributes");
+  });
+});

--- a/src/service/elbv2/serve/api/sim-elbv2-api.ts
+++ b/src/service/elbv2/serve/api/sim-elbv2-api.ts
@@ -1,0 +1,46 @@
+import type { SimAws } from "../../../aws/sim-aws.js";
+import { SimQueryApiEndpoint } from "../../../../serve/http/api/query/sim-query-endpoint.js";
+import type { SimQueryOperations } from "../../../../serve/http/api/query/sim-query-operation.js";
+import { simElbV2QueryListenerCertificateOperations } from "./sim-elbv2-query-listener-certificate-operations.js";
+import { simElbV2QueryListenerOperations } from "./sim-elbv2-query-listener-operations.js";
+import { simElbV2QueryLoadBalancerOperations } from "./sim-elbv2-query-load-balancer-operations.js";
+import { simElbV2QueryRuleOperations } from "./sim-elbv2-query-rule-operations.js";
+import { simElbV2QueryTargetGroupOperations } from "./sim-elbv2-query-target-group-operations.js";
+import { simElbV2QueryTargetOperations } from "./sim-elbv2-query-target-operations.js";
+
+/**
+ * The XML namespace real ELBv2 stamps on every response it sends.
+ */
+const elbV2Namespace =
+  "http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/";
+
+/**
+ * Serve the ELBv2 Query API to a client given an endpoint URL.
+ *
+ * A load balancer built over the endpoint answers requests the same way one
+ * built in process does, so a container that provisions its own routing and
+ * then calls through it reaches the same simulated functions.
+ *
+ * The operations served are the ones simulated ELBv2 implements. Anything else
+ * is refused as `NotImplemented`, under that name rather than as an
+ * unparseable response.
+ */
+export function simElbV2ApiEndpoint(simAws: SimAws): SimQueryApiEndpoint {
+  return new SimQueryApiEndpoint({
+    simAws,
+    serviceId: "Elastic Load Balancing v2",
+    namespace: elbV2Namespace,
+    operations: simElbV2QueryOperations(),
+  });
+}
+
+function simElbV2QueryOperations(): SimQueryOperations {
+  return new Map([
+    ...simElbV2QueryLoadBalancerOperations(),
+    ...simElbV2QueryTargetGroupOperations(),
+    ...simElbV2QueryTargetOperations(),
+    ...simElbV2QueryListenerOperations(),
+    ...simElbV2QueryListenerCertificateOperations(),
+    ...simElbV2QueryRuleOperations(),
+  ]);
+}

--- a/src/service/elbv2/serve/api/sim-elbv2-query-action.ts
+++ b/src/service/elbv2/serve/api/sim-elbv2-query-action.ts
@@ -1,0 +1,76 @@
+import type { SimQueryFields } from "../../../../serve/http/api/query/sim-query-request.js";
+import type { SimQueryOutput } from "../../../../serve/http/api/query/sim-query-result.js";
+import {
+  queryList,
+  queryMembers,
+} from "../../../../serve/http/api/query/sim-query-result.js";
+import { elbV2QueryNumber, elbV2QueryStated } from "./sim-elbv2-query-input.js";
+import { elbV2QueryStructure } from "./sim-elbv2-query-result.js";
+
+/**
+ * The members a redirect action states where it sends a client with.
+ */
+const redirectMembers = [
+  "Protocol",
+  "Port",
+  "Host",
+  "Path",
+  "Query",
+  "StatusCode",
+];
+
+/**
+ * Read the actions a listener or a rule was given.
+ *
+ * A listener names its own under `DefaultActions` and a rule under `Actions`,
+ * and both hold the same shape, so the field to read is passed in.
+ */
+export function elbV2QueryActions(
+  fields: SimQueryFields,
+  name: string,
+): readonly Record<string, unknown>[] | undefined {
+  return fields.list(name, (action) => ({
+    Type: action.text("Type"),
+    Order: elbV2QueryNumber(action, "Order"),
+    TargetGroupArn: action.text("TargetGroupArn"),
+    ForwardConfig: elbV2QueryStated({
+      TargetGroups: action.list("ForwardConfig.TargetGroups", (tuple) => ({
+        TargetGroupArn: tuple.text("TargetGroupArn"),
+        Weight: elbV2QueryNumber(tuple, "Weight"),
+      })),
+    }),
+    FixedResponseConfig: elbV2QueryStated({
+      MessageBody: action.text("FixedResponseConfig.MessageBody"),
+      StatusCode: action.text("FixedResponseConfig.StatusCode"),
+      ContentType: action.text("FixedResponseConfig.ContentType"),
+    }),
+    RedirectConfig: elbV2QueryStated(
+      Object.fromEntries(
+        redirectMembers.map((member) => [
+          member,
+          action.text(`RedirectConfig.${member}`),
+        ]),
+      ),
+    ),
+  }));
+}
+
+/**
+ * Write one action as ELB reports it back.
+ */
+export function elbV2QueryActionMembers(action: SimQueryOutput): string {
+  return (
+    queryMembers(action, ["Type", "Order", "TargetGroupArn"]) +
+    elbV2QueryStructure(action, "ForwardConfig", (forward) =>
+      queryList(forward, "TargetGroups", (tuple) =>
+        queryMembers(tuple, ["TargetGroupArn", "Weight"]),
+      ),
+    ) +
+    elbV2QueryStructure(action, "FixedResponseConfig", (fixed) =>
+      queryMembers(fixed, ["MessageBody", "StatusCode", "ContentType"]),
+    ) +
+    elbV2QueryStructure(action, "RedirectConfig", (redirect) =>
+      queryMembers(redirect, redirectMembers),
+    )
+  );
+}

--- a/src/service/elbv2/serve/api/sim-elbv2-query-certificate.ts
+++ b/src/service/elbv2/serve/api/sim-elbv2-query-certificate.ts
@@ -1,0 +1,30 @@
+import type { SimQueryFields } from "../../../../serve/http/api/query/sim-query-request.js";
+import type { SimQueryOutput } from "../../../../serve/http/api/query/sim-query-result.js";
+import {
+  queryList,
+  queryMembers,
+} from "../../../../serve/http/api/query/sim-query-result.js";
+
+/**
+ * Read the certificates a request names.
+ *
+ * A listener takes them when it is created or changed, and the listener
+ * certificate operations add and remove them one request at a time.
+ */
+export function elbV2QueryCertificates(
+  fields: SimQueryFields,
+): readonly Record<string, unknown>[] | undefined {
+  return fields.list("Certificates", (certificate) => ({
+    CertificateArn: certificate.text("CertificateArn"),
+    IsDefault: certificate.flag("IsDefault"),
+  }));
+}
+
+/**
+ * Write the certificates an operation answered with.
+ */
+export function elbV2QueryCertificateList(output: SimQueryOutput): string {
+  return queryList(output, "Certificates", (certificate) =>
+    queryMembers(certificate, ["CertificateArn", "IsDefault"]),
+  );
+}

--- a/src/service/elbv2/serve/api/sim-elbv2-query-condition.ts
+++ b/src/service/elbv2/serve/api/sim-elbv2-query-condition.ts
@@ -1,0 +1,57 @@
+import type { SimQueryFields } from "../../../../serve/http/api/query/sim-query-request.js";
+import type { SimQueryOutput } from "../../../../serve/http/api/query/sim-query-result.js";
+import {
+  queryMembers,
+  queryScalarList,
+} from "../../../../serve/http/api/query/sim-query-result.js";
+import { elbV2QueryStated, elbV2QueryValues } from "./sim-elbv2-query-input.js";
+import { elbV2QueryStructure } from "./sim-elbv2-query-result.js";
+
+/**
+ * The per-field configurations a condition states its values in.
+ *
+ * ELB takes a condition's values in two forms, a plain `Values` list and a
+ * configuration named after the field, and a rule written by a stack may use
+ * either. These are the two fields simulated ELBv2 matches on: a condition
+ * naming any other is refused by the simulation, whichever form it arrives in.
+ */
+const valueConfigs = ["HostHeaderConfig", "PathPatternConfig"];
+
+/**
+ * Read the conditions a rule matches a request with.
+ */
+export function elbV2QueryConditions(
+  fields: SimQueryFields,
+): readonly Record<string, unknown>[] | undefined {
+  return fields.list("Conditions", (condition) => ({
+    ...Object.fromEntries(
+      valueConfigs.map((config) => [
+        config,
+        elbV2QueryStated({
+          Values: elbV2QueryValues(condition, `${config}.Values`),
+        }),
+      ]),
+    ),
+    Field: condition.text("Field"),
+    Values: elbV2QueryValues(condition, "Values"),
+  }));
+}
+
+/**
+ * Write one condition as ELB reports it back.
+ */
+export function elbV2QueryConditionMembers(condition: SimQueryOutput): string {
+  const configs = valueConfigs
+    .map((config) =>
+      elbV2QueryStructure(condition, config, (values) =>
+        queryScalarList(values, "Values"),
+      ),
+    )
+    .join("");
+
+  return (
+    queryMembers(condition, ["Field"]) +
+    queryScalarList(condition, "Values") +
+    configs
+  );
+}

--- a/src/service/elbv2/serve/api/sim-elbv2-query-input.ts
+++ b/src/service/elbv2/serve/api/sim-elbv2-query-input.ts
@@ -1,0 +1,87 @@
+import type { SimQueryFields } from "../../../../serve/http/api/query/sim-query-request.js";
+
+/**
+ * Read a numeric member back out of the text Query carries it as.
+ *
+ * ELB takes numbers everywhere: a listener port, a rule priority, a health
+ * check interval, a page size. The simulation checks most of them are whole
+ * numbers in range and refuses what is not, so a string handed straight on
+ * would be refused as a number nobody sent.
+ */
+export function elbV2QueryNumber(
+  fields: SimQueryFields,
+  name: string,
+): number | undefined {
+  const value = fields.text(name);
+
+  return value === undefined ? undefined : Number(value);
+}
+
+/**
+ * Read the tags a create was asked to put on what it makes.
+ */
+export function elbV2QueryTags(
+  fields: SimQueryFields,
+): readonly Record<string, unknown>[] | undefined {
+  return fields.list("Tags", (tag) => ({
+    Key: tag.text("Key"),
+    Value: tag.text("Value"),
+  }));
+}
+
+/**
+ * Read the paging a describe was asked for.
+ *
+ * ELB pages with a `Marker` in and a `NextMarker` out, rather than with the
+ * `NextToken` most services use, and every describe takes the same two.
+ */
+export function elbV2QueryPagingInput(
+  fields: SimQueryFields,
+): Record<string, unknown> {
+  return {
+    Marker: fields.text("Marker"),
+    PageSize: elbV2QueryNumber(fields, "PageSize"),
+  };
+}
+
+/**
+ * Read a list of values rather than of structures.
+ *
+ * The Query layer reads a list by handing each member its own fields, which
+ * reaches the members of a structure. A list of plain values has none:
+ * `Subnets.member.1` is the value itself. So the subscripts are walked from
+ * one until the request stops stating them, which is the order every AWS
+ * client writes a list in.
+ */
+export function elbV2QueryValues(
+  fields: SimQueryFields,
+  name: string,
+): readonly string[] | undefined {
+  const values: string[] = [];
+  let value = fields.text(`${name}.member.1`);
+
+  while (value !== undefined) {
+    values.push(value);
+    value = fields.text(`${name}.member.${String(values.length + 1)}`);
+  }
+
+  return values.length === 0 ? undefined : values;
+}
+
+/**
+ * The members read out of a nested structure, or nothing when the request
+ * stated none of them.
+ *
+ * Query has no nesting on the wire, so a structure nobody sent and a structure
+ * whose every member was left out read the same way. The two are different
+ * requests: ELB reports a configuration back exactly as it was given one, and
+ * an empty structure would appear in every describe of a listener that never
+ * had one.
+ */
+export function elbV2QueryStated(
+  members: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  return Object.values(members).some((member) => member !== undefined)
+    ? members
+    : undefined;
+}

--- a/src/service/elbv2/serve/api/sim-elbv2-query-input.ts
+++ b/src/service/elbv2/serve/api/sim-elbv2-query-input.ts
@@ -50,8 +50,12 @@ export function elbV2QueryPagingInput(
  * The Query layer reads a list by handing each member its own fields, which
  * reaches the members of a structure. A list of plain values has none:
  * `Subnets.member.1` is the value itself. So the subscripts are walked from
- * one until the request stops stating them, which is the order every AWS
- * client writes a list in.
+ * one until the request stops stating them.
+ *
+ * That stops at a gap, where the Query layer's own list reader carries on. It
+ * makes no difference to a request anything sends, since every AWS client
+ * numbers a list from one without skipping, and it is the reason this belongs
+ * in `SimQueryFields` alongside that reader rather than here.
  */
 export function elbV2QueryValues(
   fields: SimQueryFields,

--- a/src/service/elbv2/serve/api/sim-elbv2-query-listener-certificate-operations.ts
+++ b/src/service/elbv2/serve/api/sim-elbv2-query-listener-certificate-operations.ts
@@ -1,0 +1,53 @@
+import type { SimQueryFields } from "../../../../serve/http/api/query/sim-query-request.js";
+import type { SimQueryOperations } from "../../../../serve/http/api/query/sim-query-operation.js";
+import {
+  elbV2QueryCertificateList,
+  elbV2QueryCertificates,
+} from "./sim-elbv2-query-certificate.js";
+import { elbV2QueryPagingInput } from "./sim-elbv2-query-input.js";
+import { elbV2QueryNextMarker } from "./sim-elbv2-query-result.js";
+
+/**
+ * The listener certificate operations simulated ELBv2 serves over the Query
+ * protocol.
+ *
+ * These are how a listener gets more than one certificate. The first one is
+ * the default and is given when the listener is created, and the rest are
+ * added here for the hosts a load balancer answers for beyond it.
+ */
+export function simElbV2QueryListenerCertificateOperations(): SimQueryOperations {
+  return new Map([
+    [
+      "AddListenerCertificates",
+      {
+        input: certificatesInput,
+        result: elbV2QueryCertificateList,
+      },
+    ],
+    [
+      "RemoveListenerCertificates",
+      {
+        input: certificatesInput,
+        result: (): string => "",
+      },
+    ],
+    [
+      "DescribeListenerCertificates",
+      {
+        input: (fields): Record<string, unknown> => ({
+          ...elbV2QueryPagingInput(fields),
+          ListenerArn: fields.text("ListenerArn"),
+        }),
+        result: (output): string =>
+          elbV2QueryCertificateList(output) + elbV2QueryNextMarker(output),
+      },
+    ],
+  ]);
+}
+
+function certificatesInput(fields: SimQueryFields): Record<string, unknown> {
+  return {
+    ListenerArn: fields.text("ListenerArn"),
+    Certificates: elbV2QueryCertificates(fields),
+  };
+}

--- a/src/service/elbv2/serve/api/sim-elbv2-query-listener-operations.ts
+++ b/src/service/elbv2/serve/api/sim-elbv2-query-listener-operations.ts
@@ -1,0 +1,101 @@
+import type { SimQueryOperations } from "../../../../serve/http/api/query/sim-query-operation.js";
+import type { SimQueryOutput } from "../../../../serve/http/api/query/sim-query-result.js";
+import {
+  queryList,
+  queryMembers,
+} from "../../../../serve/http/api/query/sim-query-result.js";
+import {
+  elbV2QueryActionMembers,
+  elbV2QueryActions,
+} from "./sim-elbv2-query-action.js";
+import {
+  elbV2QueryCertificateList,
+  elbV2QueryCertificates,
+} from "./sim-elbv2-query-certificate.js";
+import {
+  elbV2QueryNumber,
+  elbV2QueryPagingInput,
+  elbV2QueryTags,
+  elbV2QueryValues,
+} from "./sim-elbv2-query-input.js";
+import { elbV2QueryNextMarker } from "./sim-elbv2-query-result.js";
+
+/**
+ * The members ELB describes one listener with.
+ */
+const listenerMembers = [
+  "ListenerArn",
+  "LoadBalancerArn",
+  "Port",
+  "Protocol",
+  "SslPolicy",
+];
+
+/**
+ * The listener operations simulated ELBv2 serves over the Query protocol.
+ */
+export function simElbV2QueryListenerOperations(): SimQueryOperations {
+  return new Map([
+    [
+      "CreateListener",
+      {
+        input: (fields): Record<string, unknown> => ({
+          LoadBalancerArn: fields.text("LoadBalancerArn"),
+          Protocol: fields.text("Protocol"),
+          Port: elbV2QueryNumber(fields, "Port"),
+          SslPolicy: fields.text("SslPolicy"),
+          Certificates: elbV2QueryCertificates(fields),
+          DefaultActions: elbV2QueryActions(fields, "DefaultActions"),
+          Tags: elbV2QueryTags(fields),
+        }),
+        result: listenerListing,
+      },
+    ],
+    [
+      "DescribeListeners",
+      {
+        input: (fields): Record<string, unknown> => ({
+          ...elbV2QueryPagingInput(fields),
+          LoadBalancerArn: fields.text("LoadBalancerArn"),
+          ListenerArns: elbV2QueryValues(fields, "ListenerArns"),
+        }),
+        result: (output): string =>
+          listenerListing(output) + elbV2QueryNextMarker(output),
+      },
+    ],
+    [
+      "ModifyListener",
+      {
+        input: (fields): Record<string, unknown> => ({
+          ListenerArn: fields.text("ListenerArn"),
+          Protocol: fields.text("Protocol"),
+          Port: elbV2QueryNumber(fields, "Port"),
+          SslPolicy: fields.text("SslPolicy"),
+          Certificates: elbV2QueryCertificates(fields),
+          DefaultActions: elbV2QueryActions(fields, "DefaultActions"),
+        }),
+        result: listenerListing,
+      },
+    ],
+    [
+      "DeleteListener",
+      {
+        input: (fields): Record<string, unknown> => ({
+          ListenerArn: fields.text("ListenerArn"),
+        }),
+        result: (): string => "",
+      },
+    ],
+  ]);
+}
+
+function listenerListing(output: SimQueryOutput): string {
+  return queryList(
+    output,
+    "Listeners",
+    (listener) =>
+      queryMembers(listener, listenerMembers) +
+      elbV2QueryCertificateList(listener) +
+      queryList(listener, "DefaultActions", elbV2QueryActionMembers),
+  );
+}

--- a/src/service/elbv2/serve/api/sim-elbv2-query-load-balancer-operations.ts
+++ b/src/service/elbv2/serve/api/sim-elbv2-query-load-balancer-operations.ts
@@ -1,0 +1,89 @@
+import type { SimQueryOperations } from "../../../../serve/http/api/query/sim-query-operation.js";
+import type { SimQueryOutput } from "../../../../serve/http/api/query/sim-query-result.js";
+import {
+  queryList,
+  queryMembers,
+} from "../../../../serve/http/api/query/sim-query-result.js";
+import {
+  elbV2QueryPagingInput,
+  elbV2QueryTags,
+  elbV2QueryValues,
+} from "./sim-elbv2-query-input.js";
+import {
+  elbV2QueryNextMarker,
+  elbV2QueryStructure,
+} from "./sim-elbv2-query-result.js";
+
+/**
+ * The members ELB describes one load balancer with.
+ */
+const loadBalancerMembers = [
+  "LoadBalancerArn",
+  "LoadBalancerName",
+  "DNSName",
+  "CanonicalHostedZoneId",
+  "CreatedTime",
+  "Scheme",
+  "Type",
+  "IpAddressType",
+];
+
+/**
+ * The load balancer operations simulated ELBv2 serves over the Query protocol.
+ */
+export function simElbV2QueryLoadBalancerOperations(): SimQueryOperations {
+  return new Map([
+    [
+      "CreateLoadBalancer",
+      {
+        input: (fields): Record<string, unknown> => ({
+          Name: fields.text("Name"),
+          Scheme: fields.text("Scheme"),
+          Type: fields.text("Type"),
+          IpAddressType: fields.text("IpAddressType"),
+          Subnets: elbV2QueryValues(fields, "Subnets"),
+          SubnetMappings: fields.list("SubnetMappings", (mapping) => ({
+            SubnetId: mapping.text("SubnetId"),
+            AllocationId: mapping.text("AllocationId"),
+          })),
+          SecurityGroups: elbV2QueryValues(fields, "SecurityGroups"),
+          Tags: elbV2QueryTags(fields),
+        }),
+        result: loadBalancerListing,
+      },
+    ],
+    [
+      "DescribeLoadBalancers",
+      {
+        input: (fields): Record<string, unknown> => ({
+          ...elbV2QueryPagingInput(fields),
+          LoadBalancerArns: elbV2QueryValues(fields, "LoadBalancerArns"),
+          Names: elbV2QueryValues(fields, "Names"),
+        }),
+        result: (output): string =>
+          loadBalancerListing(output) + elbV2QueryNextMarker(output),
+      },
+    ],
+    [
+      "DeleteLoadBalancer",
+      {
+        input: (fields): Record<string, unknown> => ({
+          LoadBalancerArn: fields.text("LoadBalancerArn"),
+        }),
+        result: (): string => "",
+      },
+    ],
+  ]);
+}
+
+function loadBalancerListing(output: SimQueryOutput): string {
+  return queryList(
+    output,
+    "LoadBalancers",
+    (loadBalancer) =>
+      queryMembers(loadBalancer, loadBalancerMembers) +
+      elbV2QueryStructure(loadBalancer, "State", (state) =>
+        queryMembers(state, ["Code"]),
+      ),
+  );
+}

--- a/src/service/elbv2/serve/api/sim-elbv2-query-result.ts
+++ b/src/service/elbv2/serve/api/sim-elbv2-query-result.ts
@@ -1,0 +1,33 @@
+/* oxlint-disable security/detect-object-injection -- the member read here is
+   the one the operation's own result writer named, out of the output that
+   operation produced. */
+
+import type { SimQueryOutput } from "../../../../serve/http/api/query/sim-query-result.js";
+import { queryMembers } from "../../../../serve/http/api/query/sim-query-result.js";
+import { isRecord } from "../../../../util/type-guard/record.js";
+import { xmlElement } from "../../../../util/xml/xml-writer.js";
+
+/**
+ * Write one structure member, such as the `ForwardConfig` of an action or the
+ * `State` of a load balancer.
+ *
+ * ELB nests structures several deep, and the Query layer writes the members of
+ * a structure and the items of a list. A structure holding a structure is the
+ * shape left between them, so the caller passes what to write inside it.
+ */
+export function elbV2QueryStructure(
+  output: SimQueryOutput,
+  name: string,
+  write: (member: SimQueryOutput) => string,
+): string {
+  const member = output[name];
+
+  return isRecord(member) ? xmlElement(name, write(member)) : "";
+}
+
+/**
+ * Write where the next page of a describe starts, when there is one.
+ */
+export function elbV2QueryNextMarker(output: SimQueryOutput): string {
+  return queryMembers(output, ["NextMarker"]);
+}

--- a/src/service/elbv2/serve/api/sim-elbv2-query-rule-operations.ts
+++ b/src/service/elbv2/serve/api/sim-elbv2-query-rule-operations.ts
@@ -1,0 +1,97 @@
+import type { SimQueryOperations } from "../../../../serve/http/api/query/sim-query-operation.js";
+import type { SimQueryOutput } from "../../../../serve/http/api/query/sim-query-result.js";
+import {
+  queryList,
+  queryMembers,
+} from "../../../../serve/http/api/query/sim-query-result.js";
+import {
+  elbV2QueryActionMembers,
+  elbV2QueryActions,
+} from "./sim-elbv2-query-action.js";
+import {
+  elbV2QueryConditionMembers,
+  elbV2QueryConditions,
+} from "./sim-elbv2-query-condition.js";
+import {
+  elbV2QueryNumber,
+  elbV2QueryPagingInput,
+  elbV2QueryTags,
+  elbV2QueryValues,
+} from "./sim-elbv2-query-input.js";
+import { elbV2QueryNextMarker } from "./sim-elbv2-query-result.js";
+
+/**
+ * The rule operations simulated ELBv2 serves over the Query protocol.
+ */
+export function simElbV2QueryRuleOperations(): SimQueryOperations {
+  return new Map([
+    [
+      "CreateRule",
+      {
+        input: (fields): Record<string, unknown> => ({
+          ListenerArn: fields.text("ListenerArn"),
+          Priority: elbV2QueryNumber(fields, "Priority"),
+          Conditions: elbV2QueryConditions(fields),
+          Actions: elbV2QueryActions(fields, "Actions"),
+          Tags: elbV2QueryTags(fields),
+        }),
+        result: ruleListing,
+      },
+    ],
+    [
+      "DescribeRules",
+      {
+        input: (fields): Record<string, unknown> => ({
+          ...elbV2QueryPagingInput(fields),
+          ListenerArn: fields.text("ListenerArn"),
+          RuleArns: elbV2QueryValues(fields, "RuleArns"),
+        }),
+        result: (output): string =>
+          ruleListing(output) + elbV2QueryNextMarker(output),
+      },
+    ],
+    [
+      "ModifyRule",
+      {
+        input: (fields): Record<string, unknown> => ({
+          RuleArn: fields.text("RuleArn"),
+          Conditions: elbV2QueryConditions(fields),
+          Actions: elbV2QueryActions(fields, "Actions"),
+        }),
+        result: ruleListing,
+      },
+    ],
+    [
+      "DeleteRule",
+      {
+        input: (fields): Record<string, unknown> => ({
+          RuleArn: fields.text("RuleArn"),
+        }),
+        result: (): string => "",
+      },
+    ],
+    [
+      "SetRulePriorities",
+      {
+        input: (fields): Record<string, unknown> => ({
+          RulePriorities: fields.list("RulePriorities", (pair) => ({
+            RuleArn: pair.text("RuleArn"),
+            Priority: elbV2QueryNumber(pair, "Priority"),
+          })),
+        }),
+        result: ruleListing,
+      },
+    ],
+  ]);
+}
+
+function ruleListing(output: SimQueryOutput): string {
+  return queryList(
+    output,
+    "Rules",
+    (rule) =>
+      queryMembers(rule, ["RuleArn", "Priority", "IsDefault"]) +
+      queryList(rule, "Conditions", elbV2QueryConditionMembers) +
+      queryList(rule, "Actions", elbV2QueryActionMembers),
+  );
+}

--- a/src/service/elbv2/serve/api/sim-elbv2-query-target-group-operations.ts
+++ b/src/service/elbv2/serve/api/sim-elbv2-query-target-group-operations.ts
@@ -1,0 +1,151 @@
+import type { SimQueryFields } from "../../../../serve/http/api/query/sim-query-request.js";
+import type { SimQueryOperations } from "../../../../serve/http/api/query/sim-query-operation.js";
+import type { SimQueryOutput } from "../../../../serve/http/api/query/sim-query-result.js";
+import {
+  queryList,
+  queryMembers,
+  queryScalarList,
+} from "../../../../serve/http/api/query/sim-query-result.js";
+import {
+  elbV2QueryNumber,
+  elbV2QueryPagingInput,
+  elbV2QueryStated,
+  elbV2QueryTags,
+  elbV2QueryValues,
+} from "./sim-elbv2-query-input.js";
+import {
+  elbV2QueryNextMarker,
+  elbV2QueryStructure,
+} from "./sim-elbv2-query-result.js";
+
+/**
+ * The health check members a target group is created or changed with, and
+ * reports back.
+ */
+const healthCheckMembers = [
+  "HealthCheckEnabled",
+  "HealthCheckProtocol",
+  "HealthCheckPort",
+  "HealthCheckPath",
+  "HealthCheckIntervalSeconds",
+  "HealthCheckTimeoutSeconds",
+  "HealthyThresholdCount",
+  "UnhealthyThresholdCount",
+];
+
+/**
+ * The members ELB describes one target group with, beyond its health check.
+ */
+const targetGroupMembers = [
+  "TargetGroupArn",
+  "TargetGroupName",
+  "TargetType",
+  "Protocol",
+  "Port",
+  "VpcId",
+];
+
+/**
+ * The target group operations simulated ELBv2 serves over the Query protocol.
+ */
+export function simElbV2QueryTargetGroupOperations(): SimQueryOperations {
+  return new Map([
+    [
+      "CreateTargetGroup",
+      {
+        input: (fields): Record<string, unknown> => ({
+          ...healthCheckInput(fields),
+          Name: fields.text("Name"),
+          TargetType: fields.text("TargetType"),
+          Protocol: fields.text("Protocol"),
+          ProtocolVersion: fields.text("ProtocolVersion"),
+          Port: elbV2QueryNumber(fields, "Port"),
+          VpcId: fields.text("VpcId"),
+          IpAddressType: fields.text("IpAddressType"),
+          Tags: elbV2QueryTags(fields),
+        }),
+        result: targetGroupListing,
+      },
+    ],
+    [
+      "DescribeTargetGroups",
+      {
+        input: (fields): Record<string, unknown> => ({
+          ...elbV2QueryPagingInput(fields),
+          LoadBalancerArn: fields.text("LoadBalancerArn"),
+          TargetGroupArns: elbV2QueryValues(fields, "TargetGroupArns"),
+          Names: elbV2QueryValues(fields, "Names"),
+        }),
+        result: (output): string =>
+          targetGroupListing(output) + elbV2QueryNextMarker(output),
+      },
+    ],
+    [
+      "ModifyTargetGroup",
+      {
+        input: (fields): Record<string, unknown> => ({
+          ...healthCheckInput(fields),
+          TargetGroupArn: fields.text("TargetGroupArn"),
+        }),
+        result: targetGroupListing,
+      },
+    ],
+    [
+      "DeleteTargetGroup",
+      {
+        input: (fields): Record<string, unknown> => ({
+          TargetGroupArn: fields.text("TargetGroupArn"),
+        }),
+        result: (): string => "",
+      },
+    ],
+  ]);
+}
+
+/**
+ * Read the health check settings a create or a change carries.
+ *
+ * The intervals and the thresholds are counts, and a matcher is the one nested
+ * structure among them.
+ */
+function healthCheckInput(fields: SimQueryFields): Record<string, unknown> {
+  return {
+    HealthCheckEnabled: fields.flag("HealthCheckEnabled"),
+    HealthCheckProtocol: fields.text("HealthCheckProtocol"),
+    HealthCheckPort: fields.text("HealthCheckPort"),
+    HealthCheckPath: fields.text("HealthCheckPath"),
+    HealthCheckIntervalSeconds: elbV2QueryNumber(
+      fields,
+      "HealthCheckIntervalSeconds",
+    ),
+    HealthCheckTimeoutSeconds: elbV2QueryNumber(
+      fields,
+      "HealthCheckTimeoutSeconds",
+    ),
+    HealthyThresholdCount: elbV2QueryNumber(fields, "HealthyThresholdCount"),
+    UnhealthyThresholdCount: elbV2QueryNumber(
+      fields,
+      "UnhealthyThresholdCount",
+    ),
+    Matcher: elbV2QueryStated({
+      HttpCode: fields.text("Matcher.HttpCode"),
+      GrpcCode: fields.text("Matcher.GrpcCode"),
+    }),
+  };
+}
+
+function targetGroupListing(output: SimQueryOutput): string {
+  return queryList(
+    output,
+    "TargetGroups",
+    (targetGroup) =>
+      queryMembers(targetGroup, [
+        ...targetGroupMembers,
+        ...healthCheckMembers,
+      ]) +
+      elbV2QueryStructure(targetGroup, "Matcher", (matcher) =>
+        queryMembers(matcher, ["HttpCode", "GrpcCode"]),
+      ) +
+      queryScalarList(targetGroup, "LoadBalancerArns"),
+  );
+}

--- a/src/service/elbv2/serve/api/sim-elbv2-query-target-operations.ts
+++ b/src/service/elbv2/serve/api/sim-elbv2-query-target-operations.ts
@@ -1,0 +1,82 @@
+import type { SimQueryFields } from "../../../../serve/http/api/query/sim-query-request.js";
+import type { SimQueryOperations } from "../../../../serve/http/api/query/sim-query-operation.js";
+import type { SimQueryOutput } from "../../../../serve/http/api/query/sim-query-result.js";
+import {
+  queryList,
+  queryMembers,
+} from "../../../../serve/http/api/query/sim-query-result.js";
+import { elbV2QueryNumber } from "./sim-elbv2-query-input.js";
+import { elbV2QueryStructure } from "./sim-elbv2-query-result.js";
+
+/**
+ * The members ELB names one target with.
+ */
+const targetMembers = ["Id", "Port", "AvailabilityZone"];
+
+/**
+ * The target operations simulated ELBv2 serves over the Query protocol.
+ */
+export function simElbV2QueryTargetOperations(): SimQueryOperations {
+  return new Map([
+    [
+      "RegisterTargets",
+      {
+        input: targetsInput,
+        result: (): string => "",
+      },
+    ],
+    [
+      "DeregisterTargets",
+      {
+        input: targetsInput,
+        result: (): string => "",
+      },
+    ],
+    [
+      "DescribeTargetHealth",
+      {
+        input: targetsInput,
+        result: targetHealthResult,
+      },
+    ],
+  ]);
+}
+
+/**
+ * Write the health ELB reports each target is in.
+ *
+ * Every target here is healthy, since nothing makes a request to one to find
+ * out, so what this carries is the shape a caller reads a health check result
+ * out of rather than a verdict.
+ */
+function targetHealthResult(output: SimQueryOutput): string {
+  return queryList(
+    output,
+    "TargetHealthDescriptions",
+    (described) =>
+      elbV2QueryStructure(described, "Target", (target) =>
+        queryMembers(target, targetMembers),
+      ) +
+      elbV2QueryStructure(described, "TargetHealth", (health) =>
+        queryMembers(health, ["State", "Description"]),
+      ),
+  );
+}
+
+/**
+ * The input all three target operations share: a target group, and the targets
+ * in it the request is about.
+ *
+ * A describe that names none is asking about every target registered, which is
+ * why an omitted list stays omitted rather than becoming an empty one.
+ */
+function targetsInput(fields: SimQueryFields): Record<string, unknown> {
+  return {
+    TargetGroupArn: fields.text("TargetGroupArn"),
+    Targets: fields.list("Targets", (target) => ({
+      Id: target.text("Id"),
+      Port: elbV2QueryNumber(target, "Port"),
+      AvailabilityZone: target.text("AvailabilityZone"),
+    })),
+  };
+}

--- a/src/service/iam/serve/sim-iam-api.loc.test.ts
+++ b/src/service/iam/serve/sim-iam-api.loc.test.ts
@@ -1,0 +1,277 @@
+import {
+  AttachRolePolicyCommand,
+  CreateAccessKeyCommand,
+  CreatePolicyCommand,
+  CreateRoleCommand,
+  CreateUserCommand,
+  DeletePolicyCommand,
+  DeleteRoleCommand,
+  DeleteRolePolicyCommand,
+  DetachRolePolicyCommand,
+  GetPolicyCommand,
+  GetRoleCommand,
+  GetUserCommand,
+  IAMClient,
+  ListPoliciesCommand,
+  ListRolesCommand,
+  PutRolePolicyCommand,
+  PutUserPolicyCommand,
+} from "@aws-sdk/client-iam";
+import { GetCallerIdentityCommand, STSClient } from "@aws-sdk/client-sts";
+import {
+  assertArrayIncludes,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { afterAll, beforeAll, describe, it } from "vitest";
+
+import { servedUserCredentials } from "../../../../test/serve/served-credentials.js";
+import { SimAwsLocalServer } from "../../../serve/index.js";
+import { SimAws } from "../../aws/sim-aws.js";
+
+/**
+ * A policy admitting a principal to everything, which is what the User created
+ * over the endpoint is given before it signs anything of its own.
+ */
+const everythingPolicy = JSON.stringify({
+  Version: "2012-10-17",
+  Statement: { Effect: "Allow", Action: "*", Resource: "*" },
+});
+
+/**
+ * A trust policy naming Lambda, which is the shape a Role takes one in.
+ */
+const lambdaTrustPolicy = JSON.stringify({
+  Version: "2012-10-17",
+  Statement: {
+    Effect: "Allow",
+    Principal: { Service: "lambda.amazonaws.com" },
+    Action: "sts:AssumeRole",
+  },
+});
+
+/**
+ * Simulated IAM reached over a port by a real client.
+ *
+ * Every served request is authorized as the principal that signed it, and
+ * until IAM answered here a caller outside the process that built the
+ * simulation had no way to become one. What these cover is that a container or
+ * a shell script can set up its own identity over the endpoint and then go on
+ * to use it.
+ */
+describe("Serving simulated IAM on an endpoint URL", () => {
+  const simAws = new SimAws();
+  const srv = new SimAwsLocalServer({ simAws });
+
+  let endpoint: string;
+  let client: IAMClient;
+
+  beforeAll(async () => {
+    await srv.listen();
+    endpoint = `http://localhost:${srv.port}`;
+
+    client = new IAMClient({
+      region: simAws.defaultRegionName,
+      endpoint,
+      credentials: await servedUserCredentials(simAws, "Bootstrap"),
+    });
+  });
+
+  afterAll(async () => {
+    await srv.close();
+  });
+
+  it("makes a User whose own access key signs its later requests", async () => {
+    // Given a User created over the endpoint, admitted to everything
+    const created = await client.send(
+      new CreateUserCommand({ UserName: "Widgets", Path: "/service/" }),
+    );
+    const user = created.User;
+    assertNonNullable(user, "CreateUser answered with a User");
+    assertIdentical(user.Path, "/service/");
+
+    await client.send(
+      new PutUserPolicyCommand({
+        UserName: "Widgets",
+        PolicyName: "Everything",
+        PolicyDocument: everythingPolicy,
+      }),
+    );
+
+    // When it asks the same endpoint for an access key
+    const answered = await client.send(
+      new CreateAccessKeyCommand({ UserName: "Widgets" }),
+    );
+    const key = answered.AccessKey;
+    assertNonNullable(key, "CreateAccessKey answered with a key");
+    assertNonNullable(key.AccessKeyId, "the key's id");
+    assertNonNullable(key.SecretAccessKey, "the key's secret");
+    assertIdentical(key.Status, "Active");
+    assertIdentical(key.UserName, "Widgets");
+
+    // Then a later request signed with that key is the User it was made for,
+    // which is the whole reason for serving IAM
+    const sts = new STSClient({
+      region: simAws.defaultRegionName,
+      endpoint,
+      credentials: {
+        accessKeyId: key.AccessKeyId,
+        secretAccessKey: key.SecretAccessKey,
+      },
+    });
+    const identity = await sts.send(new GetCallerIdentityCommand({}));
+
+    assertIdentical(identity.Arn, user.Arn);
+    assertIdentical(identity.Account, simAws.defaultAccountId);
+  });
+
+  it("makes a Role, reads it back and lists it", async () => {
+    // Given a Role created over the endpoint with a trust policy
+    const created = await client.send(
+      new CreateRoleCommand({
+        RoleName: "Checkout",
+        Path: "/service-role/",
+        AssumeRolePolicyDocument: lambdaTrustPolicy,
+        Description: "The checkout function's Role",
+      }),
+    );
+    const role = created.Role;
+    assertNonNullable(role, "CreateRole answered with a Role");
+    assertIdentical(role.RoleName, "Checkout");
+    assertIdentical(role.Path, "/service-role/");
+    assertNonNullable(role.CreateDate, "a creation date");
+
+    // When it is read back and listed
+    const answered = await client.send(
+      new GetRoleCommand({ RoleName: "Checkout" }),
+    );
+    const listed = await client.send(
+      new ListRolesCommand({ PathPrefix: "/service-role/", MaxItems: 10 }),
+    );
+
+    // Then both describe the Role the envelope carried out
+    const read = answered.Role;
+    assertNonNullable(read, "GetRole answered with a Role");
+    assertIdentical(read.Arn, role.Arn);
+    assertIdentical(read.Description, "The checkout function's Role");
+    assertStringIncludes(
+      read.AssumeRolePolicyDocument ?? "",
+      "lambda.amazonaws.com",
+    );
+    assertArrayIncludes(
+      (listed.Roles ?? []).map((listedRole) => listedRole.RoleName),
+      "Checkout",
+    );
+  });
+
+  it("writes an inline policy on a Role and takes it off again", async () => {
+    // Given a Role created over the endpoint
+    await client.send(
+      new CreateRoleCommand({
+        RoleName: "Reporting",
+        AssumeRolePolicyDocument: lambdaTrustPolicy,
+      }),
+    );
+
+    // When an inline policy is written on it and then removed
+    await client.send(
+      new PutRolePolicyCommand({
+        RoleName: "Reporting",
+        PolicyName: "ReadOrders",
+        PolicyDocument: everythingPolicy,
+      }),
+    );
+    await client.send(
+      new DeleteRolePolicyCommand({
+        RoleName: "Reporting",
+        PolicyName: "ReadOrders",
+      }),
+    );
+
+    // Then the Role can be deleted, and it is gone for the next request
+    await client.send(new DeleteRoleCommand({ RoleName: "Reporting" }));
+
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await client.send(new GetRoleCommand({ RoleName: "Reporting" })),
+    );
+    assertIdentical(error.name, "NoSuchEntityException");
+  });
+
+  it("makes a managed policy, attaches it to a Role and detaches it", async () => {
+    // Given a managed policy and a Role, both made over the endpoint
+    const created = await client.send(
+      new CreatePolicyCommand({
+        PolicyName: "ReadEverything",
+        Path: "/reporting/",
+        PolicyDocument: everythingPolicy,
+        Description: "Everything, for reporting",
+      }),
+    );
+    const policy = created.Policy;
+    assertNonNullable(policy, "CreatePolicy answered with a Policy");
+
+    const policyArn = policy.Arn;
+    assertNonNullable(policyArn, "the policy's ARN");
+    assertIdentical(policy.AttachmentCount, 0);
+
+    await client.send(
+      new CreateRoleCommand({
+        RoleName: "Reader",
+        AssumeRolePolicyDocument: lambdaTrustPolicy,
+      }),
+    );
+
+    // When the policy is attached, read back, listed and detached
+    await client.send(
+      new AttachRolePolicyCommand({ RoleName: "Reader", PolicyArn: policyArn }),
+    );
+    const answered = await client.send(
+      new GetPolicyCommand({ PolicyArn: policyArn }),
+    );
+    const listed = await client.send(
+      new ListPoliciesCommand({ Scope: "Local", OnlyAttached: false }),
+    );
+    await client.send(
+      new DetachRolePolicyCommand({ RoleName: "Reader", PolicyArn: policyArn }),
+    );
+
+    // Then every member arrived as what it is, a count as a number, a flag as
+    // a boolean and a timestamp as a date
+    const read = answered.Policy;
+    assertNonNullable(read, "GetPolicy answered with a Policy");
+    assertIdentical(read.AttachmentCount, 0);
+    assertTrue(read.IsAttachable ?? false);
+    assertIdentical(read.Path, "/reporting/");
+    assertNonNullable(read.UpdateDate, "an update date");
+    assertArrayIncludes(
+      (listed.Policies ?? []).map((each) => each.Arn),
+      policyArn,
+    );
+
+    // And a detached policy can be deleted
+    await client.send(new DeletePolicyCommand({ PolicyArn: policyArn }));
+
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await client.send(new GetPolicyCommand({ PolicyArn: policyArn })),
+    );
+    assertIdentical(error.name, "NoSuchEntityException");
+  });
+
+  it("refuses an IAM operation it does not serve", async () => {
+    // When an operation simulated IAM has no answer for is asked for
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await client.send(new GetUserCommand({ UserName: "Widgets" })),
+    );
+
+    // Then it is refused by name, in the shape the Query protocol states an
+    // error, so an SDK raises it rather than failing to parse the response
+    assertIdentical(error.name, "NotImplemented");
+    assertStringIncludes(error.message, "GetUser");
+  });
+});

--- a/src/service/iam/serve/sim-iam-api.ts
+++ b/src/service/iam/serve/sim-iam-api.ts
@@ -1,0 +1,42 @@
+import type { SimAws } from "../../aws/sim-aws.js";
+import { SimQueryApiEndpoint } from "../../../serve/http/api/query/sim-query-endpoint.js";
+import type { SimQueryOperations } from "../../../serve/http/api/query/sim-query-operation.js";
+import { simIamQueryPolicyOperations } from "./sim-iam-query-policy-operations.js";
+import { simIamQueryRoleOperations } from "./sim-iam-query-role-operations.js";
+import { simIamQueryUserOperations } from "./sim-iam-query-user-operations.js";
+
+/**
+ * The XML namespace real IAM stamps on every response it sends.
+ */
+const iamNamespace = "https://iam.amazonaws.com/doc/2010-05-08/";
+
+/**
+ * Serve the IAM Query API to a client given an endpoint URL.
+ *
+ * Every served request is authorized as the principal that signed it, so until
+ * IAM answers here, a caller outside the process that built the simulation had
+ * no way to be anybody. Creating a User and asking for its access key are the
+ * two operations that break that circle: a container or a shell script sets
+ * itself up over the endpoint and then signs the rest of its requests with
+ * what it was answered.
+ *
+ * The operations served are the ones simulated IAM implements. Anything else
+ * is refused as `NotImplemented`, under that name rather than as an
+ * unparseable response.
+ */
+export function simIamApiEndpoint(simAws: SimAws): SimQueryApiEndpoint {
+  return new SimQueryApiEndpoint({
+    simAws,
+    serviceId: "IAM",
+    namespace: iamNamespace,
+    operations: simIamQueryOperations(),
+  });
+}
+
+function simIamQueryOperations(): SimQueryOperations {
+  return new Map([
+    ...simIamQueryUserOperations(),
+    ...simIamQueryRoleOperations(),
+    ...simIamQueryPolicyOperations(),
+  ]);
+}

--- a/src/service/iam/serve/sim-iam-query-entity.ts
+++ b/src/service/iam/serve/sim-iam-query-entity.ts
@@ -1,0 +1,29 @@
+/* oxlint-disable security/detect-object-injection -- the member read here is
+   the one the operation's own result writer named, out of the output that
+   operation produced. */
+
+import { queryMembers } from "../../../serve/http/api/query/sim-query-result.js";
+import type { SimQueryOutput } from "../../../serve/http/api/query/sim-query-result.js";
+import { isRecord } from "../../../util/type-guard/record.js";
+import { xmlElement } from "../../../util/xml/xml-writer.js";
+
+/**
+ * Write the one entity an IAM operation answers with, under the name it has.
+ *
+ * Every IAM create and get reports its subject as a structure rather than as
+ * loose members: `CreateUser` answers a `User`, `GetRole` a `Role`, and the
+ * same structures are what a listing repeats. The Query layer writes the
+ * members of a structure and the items of a list, and this is the one shape
+ * left between them.
+ */
+export function iamQueryEntity(
+  output: SimQueryOutput,
+  name: string,
+  members: readonly string[],
+): string {
+  const entity = output[name];
+
+  return isRecord(entity)
+    ? xmlElement(name, queryMembers(entity, members))
+    : "";
+}

--- a/src/service/iam/serve/sim-iam-query-listing.ts
+++ b/src/service/iam/serve/sim-iam-query-listing.ts
@@ -1,0 +1,31 @@
+import type { SimQueryFields } from "../../../serve/http/api/query/sim-query-request.js";
+import type { SimQueryOutput } from "../../../serve/http/api/query/sim-query-result.js";
+import { queryMembers } from "../../../serve/http/api/query/sim-query-result.js";
+
+/**
+ * Read the paging a listing was asked for.
+ *
+ * IAM pages every listing the same way, with a `Marker` naming where to resume
+ * and a `MaxItems` bounding the page. `MaxItems` arrives as text like every
+ * other Query field, and the simulation checks it is a whole number in range,
+ * so it is read back as a number here rather than handed on as a string it
+ * would refuse.
+ */
+export function iamQueryListingInput(
+  fields: SimQueryFields,
+): Record<string, unknown> {
+  const maxItems = fields.text("MaxItems");
+
+  return {
+    Marker: fields.text("Marker"),
+    MaxItems: maxItems === undefined ? undefined : Number(maxItems),
+  };
+}
+
+/**
+ * Write the paging a listing answered with, which says whether there is more
+ * to come and where the next page starts.
+ */
+export function iamQueryListingResult(output: SimQueryOutput): string {
+  return queryMembers(output, ["IsTruncated", "Marker"]);
+}

--- a/src/service/iam/serve/sim-iam-query-policy-operations.ts
+++ b/src/service/iam/serve/sim-iam-query-policy-operations.ts
@@ -1,0 +1,83 @@
+import type { SimQueryOperations } from "../../../serve/http/api/query/sim-query-operation.js";
+import {
+  queryList,
+  queryMembers,
+} from "../../../serve/http/api/query/sim-query-result.js";
+import { iamQueryEntity } from "./sim-iam-query-entity.js";
+import {
+  iamQueryListingInput,
+  iamQueryListingResult,
+} from "./sim-iam-query-listing.js";
+
+/**
+ * The members IAM describes one managed policy with.
+ */
+const policyMembers = [
+  "PolicyName",
+  "PolicyId",
+  "Arn",
+  "Path",
+  "DefaultVersionId",
+  "AttachmentCount",
+  "PermissionsBoundaryUsageCount",
+  "IsAttachable",
+  "Description",
+  "CreateDate",
+  "UpdateDate",
+];
+
+/**
+ * The managed policy operations simulated IAM serves over the Query protocol.
+ */
+export function simIamQueryPolicyOperations(): SimQueryOperations {
+  return new Map([
+    [
+      "CreatePolicy",
+      {
+        input: (fields): Record<string, unknown> => ({
+          PolicyName: fields.text("PolicyName"),
+          Path: fields.text("Path"),
+          PolicyDocument: fields.text("PolicyDocument"),
+          Description: fields.text("Description"),
+        }),
+        result: (output): string =>
+          iamQueryEntity(output, "Policy", policyMembers),
+      },
+    ],
+    [
+      "GetPolicy",
+      {
+        input: (fields): Record<string, unknown> => ({
+          PolicyArn: fields.text("PolicyArn"),
+        }),
+        result: (output): string =>
+          iamQueryEntity(output, "Policy", policyMembers),
+      },
+    ],
+    [
+      "ListPolicies",
+      {
+        input: (fields): Record<string, unknown> => ({
+          ...iamQueryListingInput(fields),
+          Scope: fields.text("Scope"),
+          OnlyAttached: fields.flag("OnlyAttached"),
+          PathPrefix: fields.text("PathPrefix"),
+          PolicyUsageFilter: fields.text("PolicyUsageFilter"),
+        }),
+        result: (output): string =>
+          queryList(output, "Policies", (policy) =>
+            queryMembers(policy, policyMembers),
+          ) + iamQueryListingResult(output),
+      },
+    ],
+    [
+      "DeletePolicy",
+      {
+        input: (fields): Record<string, unknown> => ({
+          PolicyArn: fields.text("PolicyArn"),
+        }),
+        result: (): string => "",
+      },
+    ],
+  ]);
+}

--- a/src/service/iam/serve/sim-iam-query-role-operations.ts
+++ b/src/service/iam/serve/sim-iam-query-role-operations.ts
@@ -1,0 +1,119 @@
+import type { SimQueryOperations } from "../../../serve/http/api/query/sim-query-operation.js";
+import {
+  queryList,
+  queryMembers,
+} from "../../../serve/http/api/query/sim-query-result.js";
+import { iamQueryEntity } from "./sim-iam-query-entity.js";
+import {
+  iamQueryListingInput,
+  iamQueryListingResult,
+} from "./sim-iam-query-listing.js";
+
+/**
+ * The members IAM describes one Role with.
+ */
+const roleMembers = [
+  "Path",
+  "RoleName",
+  "RoleId",
+  "Arn",
+  "CreateDate",
+  "AssumeRolePolicyDocument",
+  "Description",
+];
+
+/**
+ * The Role operations simulated IAM serves over the Query protocol.
+ *
+ * The policy operations that name a Role are here rather than with the managed
+ * policies, because an inline policy belongs to the Role it is written on and
+ * has no life of its own.
+ */
+export function simIamQueryRoleOperations(): SimQueryOperations {
+  return new Map([
+    [
+      "CreateRole",
+      {
+        input: (fields): Record<string, unknown> => ({
+          RoleName: fields.text("RoleName"),
+          Path: fields.text("Path"),
+          AssumeRolePolicyDocument: fields.text("AssumeRolePolicyDocument"),
+          Description: fields.text("Description"),
+        }),
+        result: (output): string => iamQueryEntity(output, "Role", roleMembers),
+      },
+    ],
+    [
+      "GetRole",
+      {
+        input: (fields): Record<string, unknown> => ({
+          RoleName: fields.text("RoleName"),
+        }),
+        result: (output): string => iamQueryEntity(output, "Role", roleMembers),
+      },
+    ],
+    [
+      "ListRoles",
+      {
+        input: (fields): Record<string, unknown> => ({
+          ...iamQueryListingInput(fields),
+          PathPrefix: fields.text("PathPrefix"),
+        }),
+        result: (output): string =>
+          queryList(output, "Roles", (role) =>
+            queryMembers(role, roleMembers),
+          ) + iamQueryListingResult(output),
+      },
+    ],
+    [
+      "DeleteRole",
+      {
+        input: (fields): Record<string, unknown> => ({
+          RoleName: fields.text("RoleName"),
+        }),
+        result: (): string => "",
+      },
+    ],
+    [
+      "AttachRolePolicy",
+      {
+        input: (fields): Record<string, unknown> => ({
+          RoleName: fields.text("RoleName"),
+          PolicyArn: fields.text("PolicyArn"),
+        }),
+        result: (): string => "",
+      },
+    ],
+    [
+      "DetachRolePolicy",
+      {
+        input: (fields): Record<string, unknown> => ({
+          RoleName: fields.text("RoleName"),
+          PolicyArn: fields.text("PolicyArn"),
+        }),
+        result: (): string => "",
+      },
+    ],
+    [
+      "PutRolePolicy",
+      {
+        input: (fields): Record<string, unknown> => ({
+          RoleName: fields.text("RoleName"),
+          PolicyName: fields.text("PolicyName"),
+          PolicyDocument: fields.text("PolicyDocument"),
+        }),
+        result: (): string => "",
+      },
+    ],
+    [
+      "DeleteRolePolicy",
+      {
+        input: (fields): Record<string, unknown> => ({
+          RoleName: fields.text("RoleName"),
+          PolicyName: fields.text("PolicyName"),
+        }),
+        result: (): string => "",
+      },
+    ],
+  ]);
+}

--- a/src/service/iam/serve/sim-iam-query-user-operations.ts
+++ b/src/service/iam/serve/sim-iam-query-user-operations.ts
@@ -1,0 +1,66 @@
+import type { SimQueryOperations } from "../../../serve/http/api/query/sim-query-operation.js";
+import { iamQueryEntity } from "./sim-iam-query-entity.js";
+
+/**
+ * The members IAM describes one User with.
+ */
+const userMembers = ["Path", "UserName", "UserId", "Arn", "CreateDate"];
+
+/**
+ * The members IAM describes one access key with.
+ *
+ * `SecretAccessKey` is among them because this is the one response that
+ * carries it. Real IAM answers a created key with its secret and never
+ * reports it again, and a caller that did not keep it has to make another.
+ */
+const accessKeyMembers = [
+  "UserName",
+  "AccessKeyId",
+  "Status",
+  "SecretAccessKey",
+  "CreateDate",
+];
+
+/**
+ * The User operations simulated IAM serves over the Query protocol.
+ *
+ * This is the pair that makes an endpoint usable from outside the process that
+ * built the simulation: a shell script or a container creates a User, gives it
+ * a policy and asks for an access key, and then signs its own requests with
+ * what it was answered.
+ */
+export function simIamQueryUserOperations(): SimQueryOperations {
+  return new Map([
+    [
+      "CreateUser",
+      {
+        input: (fields): Record<string, unknown> => ({
+          UserName: fields.text("UserName"),
+          Path: fields.text("Path"),
+        }),
+        result: (output): string => iamQueryEntity(output, "User", userMembers),
+      },
+    ],
+    [
+      "CreateAccessKey",
+      {
+        input: (fields): Record<string, unknown> => ({
+          UserName: fields.text("UserName"),
+        }),
+        result: (output): string =>
+          iamQueryEntity(output, "AccessKey", accessKeyMembers),
+      },
+    ],
+    [
+      "PutUserPolicy",
+      {
+        input: (fields): Record<string, unknown> => ({
+          UserName: fields.text("UserName"),
+          PolicyName: fields.text("PolicyName"),
+          PolicyDocument: fields.text("PolicyDocument"),
+        }),
+        result: (): string => "",
+      },
+    ],
+  ]);
+}

--- a/test/elbv2/served-elbv2-api.ts
+++ b/test/elbv2/served-elbv2-api.ts
@@ -1,0 +1,99 @@
+import {
+  CreateListenerCommand,
+  CreateLoadBalancerCommand,
+  CreateTargetGroupCommand,
+  type ElasticLoadBalancingV2Client,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+import { assertNonNullable } from "@kensio/smartass";
+
+/**
+ * The load balancer, target group and listener a served ELBv2 test builds
+ * before it can say anything about routing.
+ *
+ * These go through the endpoint rather than through `SimAws`, because what is
+ * being tested is the endpoint. They live under `test/` for the same reasons as
+ * `test/sns/topic-fixture.ts`.
+ */
+
+/**
+ * Make a load balancer over the endpoint, answering with its ARN.
+ */
+export async function servedLoadBalancer(
+  client: ElasticLoadBalancingV2Client,
+  name: string,
+): Promise<string> {
+  const created = await client.send(
+    new CreateLoadBalancerCommand({
+      Name: name,
+      Scheme: "internet-facing",
+      Subnets: ["subnet-1", "subnet-2"],
+      SubnetMappings: [{ SubnetId: "subnet-1", AllocationId: "eipalloc-1" }],
+      SecurityGroups: ["sg-1"],
+      Tags: [{ Key: "team", Value: "shop" }],
+    }),
+  );
+
+  const arn = created.LoadBalancers?.[0]?.LoadBalancerArn;
+  assertNonNullable(arn, "CreateLoadBalancer answered with an ARN");
+
+  return arn;
+}
+
+/**
+ * Make a target group holding addresses, answering with its ARN.
+ */
+export async function servedTargetGroup(
+  client: ElasticLoadBalancingV2Client,
+  name: string,
+): Promise<string> {
+  const created = await client.send(
+    new CreateTargetGroupCommand({
+      Name: name,
+      TargetType: "ip",
+      Protocol: "HTTP",
+      Port: 8080,
+      VpcId: "vpc-1",
+      HealthCheckEnabled: true,
+      HealthCheckPath: "/health",
+      HealthCheckIntervalSeconds: 15,
+      HealthyThresholdCount: 3,
+      Matcher: { HttpCode: "200-299" },
+    }),
+  );
+
+  const arn = created.TargetGroups?.[0]?.TargetGroupArn;
+  assertNonNullable(arn, "CreateTargetGroup answered with an ARN");
+
+  return arn;
+}
+
+/**
+ * Make a listener forwarding to a target group, answering with its ARN.
+ */
+export async function servedListener(
+  client: ElasticLoadBalancingV2Client,
+  loadBalancerArn: string,
+  targetGroupArn: string,
+): Promise<string> {
+  const created = await client.send(
+    new CreateListenerCommand({
+      LoadBalancerArn: loadBalancerArn,
+      Protocol: "HTTP",
+      Port: 80,
+      DefaultActions: [
+        {
+          Type: "forward",
+          Order: 1,
+          ForwardConfig: {
+            TargetGroups: [{ TargetGroupArn: targetGroupArn, Weight: 1 }],
+          },
+        },
+      ],
+    }),
+  );
+
+  const arn = created.Listeners?.[0]?.ListenerArn;
+  assertNonNullable(arn, "CreateListener answered with an ARN");
+
+  return arn;
+}

--- a/test/serve/served-credentials.ts
+++ b/test/serve/served-credentials.ts
@@ -1,0 +1,54 @@
+import {
+  CreateAccessKeyCommand,
+  CreateUserCommand,
+  PutUserPolicyCommand,
+} from "@aws-sdk/client-iam";
+import type { AwsCredentialIdentity } from "@smithy/types";
+
+import type { SimAws } from "../../src/service/aws/sim-aws.js";
+
+/**
+ * A policy admitting a principal to everything, which is what a test identity
+ * gets so that the operations under test are the ones being tested.
+ */
+const everythingPolicy = JSON.stringify({
+  Version: "2012-10-17",
+  Statement: { Effect: "Allow", Action: "*", Resource: "*" },
+});
+
+/**
+ * Make a simulated IAM User admitted to everything, and answer with the
+ * credentials that sign as it.
+ *
+ * A served request runs as whoever signed it. A test reaching an endpoint has
+ * to be somebody first, and this is where every served API test starts.
+ *
+ * This lives under `test/` for the same reasons as `test/sns/topic-fixture.ts`.
+ * eslint rejects a test file that exports helpers alongside its own `describe`
+ * calls, and everything here is type-checked with the rest, excluded from the
+ * published build, not collected as a suite, and not counted in coverage.
+ */
+export async function servedUserCredentials(
+  simAws: SimAws,
+  username: string,
+): Promise<AwsCredentialIdentity> {
+  const simIam = simAws.iam();
+
+  await simIam.createUser(new CreateUserCommand({ UserName: username }));
+  await simIam.putUserPolicy(
+    new PutUserPolicyCommand({
+      UserName: username,
+      PolicyName: "Everything",
+      PolicyDocument: everythingPolicy,
+    }),
+  );
+
+  const created = await simIam.createAccessKey(
+    new CreateAccessKeyCommand({ UserName: username }),
+  );
+
+  return {
+    accessKeyId: created.AccessKey.AccessKeyId,
+    secretAccessKey: created.AccessKey.SecretAccessKey,
+  };
+}


### PR DESCRIPTION
`aws iam` and `aws elbv2` were refused with 501 against a served simulated environment. IAM is the half that matters. Every served request is authorized as the principal that signed it, so setting up users, roles and policies had to happen in the Node process that built the simulation, and a container or a shell script could not create its own credentials. Simulated IAM now serves the fifteen operations it implements and simulated ELBv2 the twenty-two, both on the shared Query layer from #698, each with its own XML namespace and operations map and each registered under the signing name the CLI actually sends (`iam` and `elasticloadbalancing`, checked against captured SDK requests rather than assumed). An operation a service has not implemented is refused in the Query error shape, so an SDK raises it by name. The `.loc.test.ts` that closes the loop creates an IAM User over the endpoint, asks the same endpoint for an access key, and signs a later served request with what it was answered.

Resolves https://github.com/KensioSoftware/yulin/issues/697

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`

Two notes for review. The shared Query layer has no reader for a list of plain values and no writer for a nested structure, and both services need them, so each carries a small local helper (`elbV2QueryValues`, `elbV2QueryStructure`, `iamQueryEntity`). Lifting them into `src/serve/http/api/query/` is the obvious follow-up, and that directory was left alone here to stay out of the way of concurrent work. Separately, simulated IAM holds a policy's `AttachmentCount` at zero whatever is attached to it, which makes `ListPolicies --only-attached` answer with nothing. That is pre-existing and untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated IAM support for users, roles, access keys, inline policies, and managed policies.
  * Added simulated Elastic Load Balancing v2 support for load balancers, target groups, listeners, certificates, rules, routing, and target health.
  * Registered both services with the served AWS endpoint.
* **Documentation**
  * Added CLI usage guidance and supported-operation details for IAM and ELBv2.
* **Tests**
  * Added comprehensive integration coverage for IAM and ELBv2 workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->