### PR TITLE
feat: serve the REST-JSON protocol for Lambda

### DIFF
--- a/docs/serve/README.md
+++ b/docs/serve/README.md
@@ -246,7 +246,7 @@ A request carrying no signature is anonymous and reaches nothing. In process an 
 
 ### Which services answer
 
-S3, STS, SNS, CloudFormation, and the services that speak the AWS JSON protocol. Those are DynamoDB, DynamoDB Streams, SQS, Cognito Identity Provider, EventBridge, ECS, SSM, ACM, CloudWatch, CloudWatch Logs, KMS, Secrets Manager and Rekognition.
+S3, STS, SNS, CloudFormation, Lambda, and the services that speak the AWS JSON protocol. Those are DynamoDB, DynamoDB Streams, SQS, Cognito Identity Provider, EventBridge, ECS, SSM, ACM, CloudWatch, CloudWatch Logs, KMS, Secrets Manager and Rekognition.
 
 A request to any other service is refused with `501 Not Implemented` and a body saying why. Every service is reachable in process through `SimAws` and through [SDK interception](../sdk/README.md), whether or not it answers here.
 
@@ -335,6 +335,49 @@ The four operations simulated CloudFormation implements are `CreateStack`, `Upda
 `DeleteStack` and `DescribeStacks`. A deployment starts in the background and the call is answered
 before the Resources exist, as real CloudFormation answers it. `describe-stacks` reports the status
 it reached, and `waitForStackDeployComplete` waits for it in process.
+
+### Lambda over the endpoint
+
+`aws lambda` and a `LambdaClient` reach simulated Lambda through the same endpoint URL:
+
+```bash
+export AWS_ENDPOINT_URL=http://localhost:8787
+aws lambda invoke --function-name orders --payload '{"id":1}' /tmp/out.json
+cat /tmp/out.json
+```
+
+The function runs in the process serving it, and what its handler returned is written to the file.
+A handler that throws answers `200` with `FunctionError` set to `Unhandled`, and the payload holds
+the error it threw. `--invocation-type Event` answers `202` and runs the handler on the background
+scheduler. A test that goes on to read what the function did waits on
+`simAws.backgroundTasksComplete()` first.
+
+A function created over the endpoint carries its code as a zip archive, which is the shape the
+`Code.ZipFile` member travels in over HTTP:
+
+```bash
+aws lambda create-function --function-name orders \
+  --role arn:aws:iam::888888888888:role/OrdersRole \
+  --handler index.handler --runtime nodejs22.x \
+  --zip-file fileb://orders.zip
+```
+
+The operations served are the sixteen simulated Lambda implements:
+
+- **Functions** — `CreateFunction`, `GetFunction`, `DeleteFunction`, `Invoke`
+- **Function URLs** — `CreateFunctionUrlConfig`, `GetFunctionUrlConfig`,
+  `UpdateFunctionUrlConfig`, `DeleteFunctionUrlConfig`, `ListFunctionUrlConfigs`
+- **Permissions** — `AddPermission`, `RemovePermission`, `GetPolicy`
+- **Event source mappings** — `CreateEventSourceMapping`, `GetEventSourceMapping`,
+  `ListEventSourceMappings`, `DeleteEventSourceMapping`
+
+Anything else is refused as `NotImplemented`, which an SDK raises under that name. The refusal names
+the path it arrived at. `aws lambda list-functions` reports that `GET /2015-03-31/functions` is
+unserved, and an unimplemented operation sharing a method with one that is served gets the same
+answer.
+
+Simulated Lambda also answers its own Function URL hostnames, covered above. That path is unchanged,
+and it is what a browser and a webhook reach.
 
 ## Stopping and restarting
 

--- a/src/serve/http/api/rest-json/sim-rest-json-endpoint.ts
+++ b/src/serve/http/api/rest-json/sim-rest-json-endpoint.ts
@@ -1,0 +1,106 @@
+import { SimSdkUnsupportedCommandError } from "../../../../sdk/error/sim-sdk.error.js";
+import { SimSdkCommandDispatcher } from "../../../../sdk/sim-sdk-command-dispatcher.js";
+import {
+  makeSimSdkWireClient,
+  makeSimSdkWireCommand,
+} from "../../../../sdk/wire/sim-sdk-wire-command.js";
+import type { SimAwsCaller } from "../../../../service/aws/caller/sim-aws-caller.js";
+import type { SimAws } from "../../../../service/aws/sim-aws.js";
+import { SimRestJsonInput } from "./sim-rest-json-input.js";
+import { readSimRestJsonRequest } from "./sim-rest-json-request.js";
+import { SimRestJsonProtocol } from "./sim-rest-json-response.js";
+import type {
+  SimRestJsonOutput,
+  SimRestJsonRoute,
+} from "./sim-rest-json-route.type.js";
+import { resolveSimRestJsonRoute } from "./sim-rest-json-routes.js";
+
+interface SimRestJsonApiEndpointProperties {
+  readonly simAws: SimAws;
+
+  /** The SDK service id the simulated service's Command router is under. */
+  readonly serviceId: string;
+
+  readonly routes: readonly SimRestJsonRoute[];
+}
+
+/**
+ * Serves one REST-JSON service to a client given an endpoint URL.
+ *
+ * REST-JSON names its operation in the method and the path rather than in a
+ * header, so the operation is resolved from the request before anything else.
+ * Both the routing and the JSON on either side of it are the protocol rather
+ * than the service, so every REST-JSON service is served by an instance of
+ * this, holding the routes it implements.
+ *
+ * An operation runs through the Command an SDK would have sent, so an HTTP
+ * caller reaches exactly the code an in-process caller does, and IAM
+ * authorizes it the same way.
+ */
+export class SimRestJsonApiEndpoint {
+  private readonly dispatcher: SimSdkCommandDispatcher;
+  private readonly serviceId: string;
+  private readonly routes: readonly SimRestJsonRoute[];
+  private readonly protocol = new SimRestJsonProtocol();
+
+  constructor(properties: SimRestJsonApiEndpointProperties) {
+    this.dispatcher = new SimSdkCommandDispatcher(properties.simAws);
+    this.serviceId = properties.serviceId;
+    this.routes = properties.routes;
+  }
+
+  /**
+   * Answer one REST-JSON request as the caller that signed it.
+   *
+   * A path no route serves is refused by name rather than answered by an
+   * operation that shares its method. Ignoring the difference would answer a
+   * question about one thing with a confident report about another, which is
+   * worse than saying so.
+   */
+  async handle(
+    request: Request,
+    body: Uint8Array,
+    caller: SimAwsCaller,
+    regionName: string,
+  ): Promise<Response> {
+    const restRequest = readSimRestJsonRequest(request, body);
+    const matched = resolveSimRestJsonRoute(this.routes, restRequest);
+    if (matched === undefined) {
+      return this.protocol.error(
+        501,
+        "NotImplemented",
+        `Simulated ${this.serviceId} does not serve ` +
+          `${restRequest.method} ${restRequest.path}`,
+      );
+    }
+
+    const { route } = matched;
+    try {
+      const input = route.input(
+        new SimRestJsonInput({
+          labels: matched.labels,
+          query: restRequest.query,
+          headers: restRequest.headers,
+          body: restRequest.body,
+        }),
+      );
+
+      const output = (await this.dispatcher.dispatch(
+        makeSimSdkWireCommand(route.commandName, input),
+        makeSimSdkWireClient(this.serviceId, regionName),
+        undefined,
+        caller,
+      )) as SimRestJsonOutput | undefined;
+
+      return route.output === undefined
+        ? this.protocol.response(output ?? {}, route.status ?? 200)
+        : route.output(output ?? {});
+    } catch (error) {
+      if (error instanceof SimSdkUnsupportedCommandError) {
+        return this.protocol.error(501, "NotImplemented", error.message);
+      }
+
+      return this.protocol.failure(error);
+    }
+  }
+}

--- a/src/serve/http/api/rest-json/sim-rest-json-input.ts
+++ b/src/serve/http/api/rest-json/sim-rest-json-input.ts
@@ -1,0 +1,65 @@
+import { readSimRestJsonBody } from "./sim-rest-json-request.js";
+
+interface SimRestJsonInputProperties {
+  readonly labels: ReadonlyMap<string, string>;
+  readonly query: URLSearchParams;
+  readonly headers: Headers;
+  readonly body: Uint8Array;
+}
+
+/**
+ * The four places a REST-JSON request states its input, behind one accessor.
+ *
+ * REST-JSON spreads one operation's members across a path, a query string,
+ * headers and a JSON body, and which member goes where is the operation's own
+ * business. An operation's route reads the members it has from wherever it put
+ * them, and this is what it reads them with.
+ */
+export class SimRestJsonInput {
+  readonly body: Uint8Array;
+
+  private readonly labels: ReadonlyMap<string, string>;
+  private readonly parameters: URLSearchParams;
+  private readonly headers: Headers;
+
+  constructor(properties: SimRestJsonInputProperties) {
+    this.labels = properties.labels;
+    this.parameters = properties.query;
+    this.headers = properties.headers;
+    this.body = properties.body;
+  }
+
+  /**
+   * A member the path stated, named by the route template that matched it.
+   */
+  label(name: string): string | undefined {
+    return this.labels.get(name);
+  }
+
+  /**
+   * A member the query string stated.
+   */
+  query(name: string): string | undefined {
+    return this.parameters.get(name) ?? undefined;
+  }
+
+  /**
+   * A member a header stated, matched however the client cased the name.
+   */
+  header(name: string): string | undefined {
+    return this.headers.get(name) ?? undefined;
+  }
+
+  /**
+   * The members the JSON body stated, which are the input shape as it is.
+   *
+   * The wire shape of a REST-JSON body is the Command input shape member for
+   * member, apart from the members JSON cannot carry: a blob travels base64
+   * encoded and a timestamp as epoch seconds. A route reading one of those
+   * decodes it itself, since only the operation's own schema says which
+   * members they are.
+   */
+  json(): Readonly<Record<string, unknown>> {
+    return readSimRestJsonBody(this.body);
+  }
+}

--- a/src/serve/http/api/rest-json/sim-rest-json-request.iso.test.ts
+++ b/src/serve/http/api/rest-json/sim-rest-json-request.iso.test.ts
@@ -1,0 +1,98 @@
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertObjectEquals,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  readSimRestJsonBody,
+  readSimRestJsonRequest,
+  simRestJsonPathSegments,
+} from "./sim-rest-json-request.js";
+
+/**
+ * Reading a REST-JSON request, which states its operation in a path and its
+ * input in a JSON body.
+ */
+describe("reading a REST-JSON request", () => {
+  it("takes the path apart into the segments a route is matched on", () => {
+    // Given a request naming an operation in its path
+    const request = new Request(
+      "http://localhost:1234/2015-03-31/functions/orders/invocations",
+      { method: "POST" },
+    );
+
+    // When it is read as the REST-JSON request it is
+    const read = readSimRestJsonRequest(request, Buffer.from("{}"));
+
+    // Then the method and the segments are both there to match on, and the
+    // path it arrived as is kept for naming one no route serves
+    assertIdentical(read.method, "POST");
+    assertIdentical(read.path, "/2015-03-31/functions/orders/invocations");
+    assertArrayEquals(read.segments, [
+      "2015-03-31",
+      "functions",
+      "orders",
+      "invocations",
+    ]);
+  });
+
+  it("decodes each segment on its own", () => {
+    // Given a path label carrying characters a URL encodes, as a function ARN
+    // does
+    const segments = simRestJsonPathSegments(
+      "/2015-03-31/functions/arn%3Aaws%3Alambda%3Aus-east-1%3A1%3Afunction%3Ao",
+    );
+
+    // Then the label arrived as the caller wrote it, in one segment
+    assertArrayEquals(segments, [
+      "2015-03-31",
+      "functions",
+      "arn:aws:lambda:us-east-1:1:function:o",
+    ]);
+  });
+
+  it("reads a path ending in a separator as the same path", () => {
+    // Given the two ways AWS writes the path of a collection operation
+    assertArrayEquals(
+      simRestJsonPathSegments("/2015-03-31/event-source-mappings"),
+      ["2015-03-31", "event-source-mappings"],
+    );
+    assertArrayEquals(
+      simRestJsonPathSegments("/2015-03-31/event-source-mappings/"),
+      ["2015-03-31", "event-source-mappings"],
+    );
+  });
+
+  it("reads an operation that sent no body as one taking no members", () => {
+    assertObjectEquals(readSimRestJsonBody(new Uint8Array()), {});
+  });
+
+  it("reads a body as the members it states", () => {
+    assertObjectEquals(
+      readSimRestJsonBody(Buffer.from('{"FunctionName":"orders"}')),
+      { FunctionName: "orders" },
+    );
+  });
+
+  it("refuses a body that states itself as JSON and is not", () => {
+    // Given a body that is not JSON at all
+    const error = assertThrowsError(() =>
+      readSimRestJsonBody(Buffer.from("not json")),
+    );
+
+    // Then it is refused under the name real AWS refuses it with
+    assertIdentical(error.name, "SerializationException");
+  });
+
+  it("refuses a body that is JSON but not an object", () => {
+    // Given a body holding a JSON value with no members to read
+    const error = assertThrowsError(() =>
+      readSimRestJsonBody(Buffer.from("[1, 2]")),
+    );
+
+    assertIdentical(error.name, "SerializationException");
+  });
+});

--- a/src/serve/http/api/rest-json/sim-rest-json-request.ts
+++ b/src/serve/http/api/rest-json/sim-rest-json-request.ts
@@ -1,0 +1,106 @@
+/**
+ * One AWS REST-JSON request, taken apart as far as the route table reads it.
+ *
+ * REST-JSON names its operation in the method and the path, as REST-XML does,
+ * and carries the rest of its input in a JSON body, in the query string and in
+ * headers. The path is split before anything is matched against it, because a
+ * route is a template of segments and matching one means comparing segments.
+ */
+export interface SimRestJsonRequest {
+  readonly method: string;
+
+  /** The path as it arrived, for naming one no route serves. */
+  readonly path: string;
+
+  /** The path split on its separators, each segment decoded. */
+  readonly segments: readonly string[];
+
+  readonly query: URLSearchParams;
+  readonly headers: Headers;
+  readonly body: Uint8Array;
+}
+
+/**
+ * A body that states itself as JSON and is not.
+ *
+ * Real AWS answers this as `SerializationException`, and an SDK raises it under
+ * that name rather than reporting whatever the parser happened to say.
+ */
+export class SimRestJsonSerializationError extends Error {
+  public override readonly name = "SerializationException";
+  public readonly $metadata = { httpStatusCode: 400 };
+}
+
+/**
+ * Read a request that arrived at the served AWS API endpoint as a REST-JSON
+ * request.
+ *
+ * A trailing separator is dropped, because AWS writes the path of a collection
+ * operation both ways: `CreateEventSourceMapping` is documented at
+ * `/2015-03-31/event-source-mappings/` and `CreateFunction` at
+ * `/2015-03-31/functions`. Neither names a segment after the last one, so
+ * neither is told from the other here.
+ */
+export function readSimRestJsonRequest(
+  request: Request,
+  body: Uint8Array,
+): SimRestJsonRequest {
+  const url = new URL(request.url);
+
+  return {
+    method: request.method,
+    path: url.pathname,
+    segments: simRestJsonPathSegments(url.pathname),
+    query: url.searchParams,
+    headers: request.headers,
+    body,
+  };
+}
+
+/**
+ * Split a path into the segments a route template is matched against.
+ *
+ * Each segment is decoded on its own. A label carrying a separator sends it
+ * encoded, so decoding the whole path at once would turn one segment into two
+ * and match the request against a template it does not belong to.
+ */
+export function simRestJsonPathSegments(path: string): readonly string[] {
+  return path
+    .split("/")
+    .filter((segment) => segment.length > 0)
+    .map((segment) => decodeURIComponent(segment));
+}
+
+/**
+ * Read a request body as the JSON object it states.
+ *
+ * An operation taking no body members sends none, which is the input `{}`.
+ * Anything that is not an object is a body this endpoint has no members to
+ * read out of, and is reported the same way an unparseable one is.
+ */
+export function readSimRestJsonBody(
+  body: Uint8Array,
+): Readonly<Record<string, unknown>> {
+  if (body.byteLength === 0) {
+    return {};
+  }
+
+  let value: unknown;
+  try {
+    value = JSON.parse(Buffer.from(body).toString("utf8")) as unknown;
+  } catch (error) {
+    throw new SimRestJsonSerializationError(
+      `Could not read the request body as JSON: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new SimRestJsonSerializationError(
+      "The request body is not a JSON object",
+    );
+  }
+
+  return value as Record<string, unknown>;
+}

--- a/src/serve/http/api/rest-json/sim-rest-json-response.ts
+++ b/src/serve/http/api/rest-json/sim-rest-json-response.ts
@@ -1,0 +1,62 @@
+import { simSdkWireErrorStatusCode } from "../../../../sdk/wire/sim-sdk-wire-response.js";
+import { simSdkWireJsonBody } from "../../../../sdk/wire/sim-sdk-wire-json.js";
+import type { SimRestJsonOutput } from "./sim-rest-json-route.type.js";
+
+const jsonContentType = { "content-type": "application/json" };
+
+/**
+ * Writes the responses of a REST-JSON service.
+ *
+ * A REST-JSON response is the operation's output as a JSON object, at the
+ * status the operation answers with. There is no envelope around it and no
+ * operation name in it, which is the whole of what separates this from the
+ * Query and REST-XML protocols on the way back.
+ */
+export class SimRestJsonProtocol {
+  /**
+   * Answer an operation with the members it produced.
+   *
+   * `$metadata` is dropped, since it is the SDK's record of the response
+   * rather than a member of it, and the SDK builds its own from what it
+   * receives. A status with no content answers with no body, as HTTP requires.
+   */
+  response(output: SimRestJsonOutput, status: number): Response {
+    if (status === 204) {
+      return new Response(null, { status });
+    }
+
+    const { $metadata: _metadata, ...members } = output;
+
+    return new Response(simSdkWireJsonBody(members), {
+      status,
+      headers: jsonContentType,
+    });
+  }
+
+  /**
+   * Refuse a request by name, in the shape an SDK reads an error out of.
+   *
+   * The name goes in the header the REST-JSON protocol reserves for it and in
+   * the body, because a client reads whichever it finds first.
+   */
+  error(status: number, code: string, message: string): Response {
+    return new Response(simSdkWireJsonBody({ __type: code, message }), {
+      status,
+      headers: { ...jsonContentType, "x-amzn-errortype": code },
+    });
+  }
+
+  /**
+   * Report what a simulated operation threw.
+   *
+   * A simulated service error already carries the AWS exception name and the
+   * status real AWS answers with, so an SDK raises it under the name a handler
+   * catching it in production would see.
+   */
+  failure(error: unknown): Response {
+    const code = error instanceof Error ? error.name : "InternalFailure";
+    const message = error instanceof Error ? error.message : String(error);
+
+    return this.error(simSdkWireErrorStatusCode(error), code, message);
+  }
+}

--- a/src/serve/http/api/rest-json/sim-rest-json-route.type.ts
+++ b/src/serve/http/api/rest-json/sim-rest-json-route.type.ts
@@ -1,0 +1,43 @@
+import type { SimRestJsonInput } from "./sim-rest-json-input.js";
+
+/**
+ * One simulated operation's output, as a route writes its response from.
+ */
+export type SimRestJsonOutput = Readonly<Record<string, unknown>>;
+
+/**
+ * One REST-JSON operation, and how to read its input out of a request.
+ *
+ * REST-JSON states its operation in the method and a path template, so a route
+ * is matched on those two and nothing else. A template segment written
+ * `{Name}` matches any one segment and hands it to the route under that name;
+ * every other segment matches itself and only itself.
+ */
+export interface SimRestJsonRoute {
+  readonly method: string;
+
+  /**
+   * The path template this operation is reached at, such as
+   * `/2015-03-31/functions/{FunctionName}/invocations`.
+   */
+  readonly path: string;
+
+  readonly commandName: string;
+
+  readonly input: (input: SimRestJsonInput) => Record<string, unknown>;
+
+  /**
+   * The status this operation answers with, which real AWS varies by
+   * operation rather than by outcome: a creation answers `201`, a removal
+   * `204` and a read `200`. Defaults to `200`.
+   */
+  readonly status?: number | undefined;
+
+  /**
+   * How to write the response, for an operation that answers with something
+   * other than its output as JSON. Lambda's `Invoke` is one: it answers with
+   * the function's own payload, and puts its output members in the status and
+   * in headers around it.
+   */
+  readonly output?: ((output: SimRestJsonOutput) => Response) | undefined;
+}

--- a/src/serve/http/api/rest-json/sim-rest-json-routes.iso.test.ts
+++ b/src/serve/http/api/rest-json/sim-rest-json-routes.iso.test.ts
@@ -1,0 +1,83 @@
+import { assertIdentical, assertUndefined } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { readSimRestJsonRequest } from "./sim-rest-json-request.js";
+import type { SimRestJsonRoute } from "./sim-rest-json-route.type.js";
+import { resolveSimRestJsonRoute } from "./sim-rest-json-routes.js";
+
+/**
+ * Which operation a REST-JSON request names, which the protocol states in the
+ * method and the path rather than in a header.
+ */
+describe("Resolving a REST-JSON operation from a request", () => {
+  const routes: readonly SimRestJsonRoute[] = [
+    {
+      method: "GET",
+      path: "/v1/widgets/{WidgetId}",
+      commandName: "GetWidgetCommand",
+      input: (input) => ({ WidgetId: input.label("WidgetId") }),
+    },
+    {
+      method: "POST",
+      path: "/v1/widgets/{WidgetId}/parts",
+      commandName: "AddPartCommand",
+      input: (input) => ({ WidgetId: input.label("WidgetId") }),
+    },
+    {
+      method: "POST",
+      path: "/v1/widgets",
+      commandName: "CreateWidgetCommand",
+      input: () => ({}),
+    },
+  ];
+
+  function match(method: string, path: string) {
+    const request = new Request(`http://localhost:1234${path}`, { method });
+
+    return resolveSimRestJsonRoute(
+      routes,
+      readSimRestJsonRequest(request, new Uint8Array()),
+    );
+  }
+
+  it("names the operation the method and the path state", () => {
+    assertIdentical(
+      match("GET", "/v1/widgets/w-1")?.route.commandName,
+      "GetWidgetCommand",
+    );
+    assertIdentical(
+      match("POST", "/v1/widgets")?.route.commandName,
+      "CreateWidgetCommand",
+    );
+    assertIdentical(
+      match("POST", "/v1/widgets/w-1/parts")?.route.commandName,
+      "AddPartCommand",
+    );
+  });
+
+  it("reads the labels a path stated out of it", () => {
+    assertIdentical(
+      match("GET", "/v1/widgets/w-1")?.labels.get("WidgetId"),
+      "w-1",
+    );
+  });
+
+  it("has no operation for a method the path is not served on", () => {
+    assertUndefined(match("DELETE", "/v1/widgets/w-1"));
+  });
+
+  it("has no operation for a path whose literal segments differ", () => {
+    // Given a path this table has nothing at, whose shape matches one it does
+    // Then it resolves to nothing rather than to the operation it resembles
+    assertUndefined(match("POST", "/v1/widgets/w-1/labels"));
+    assertUndefined(match("GET", "/v2/widgets/w-1"));
+  });
+
+  it("has no operation for a path with segments left over", () => {
+    // Given a longer path starting with one that is served
+    // Then a label stands for one segment rather than for the rest of the
+    // path, so the longer path is nobody's
+    assertUndefined(match("GET", "/v1/widgets/w-1/parts/p-1"));
+    assertUndefined(match("GET", "/v1/widgets"));
+  });
+});

--- a/src/serve/http/api/rest-json/sim-rest-json-routes.ts
+++ b/src/serve/http/api/rest-json/sim-rest-json-routes.ts
@@ -1,0 +1,77 @@
+import {
+  simRestJsonPathSegments,
+  type SimRestJsonRequest,
+} from "./sim-rest-json-request.js";
+import type { SimRestJsonRoute } from "./sim-rest-json-route.type.js";
+
+/**
+ * A request matched to the operation its path names, and the members that path
+ * stated along the way.
+ */
+export interface SimRestJsonMatch {
+  readonly route: SimRestJsonRoute;
+  readonly labels: ReadonlyMap<string, string>;
+}
+
+/**
+ * Find the operation a REST-JSON request names.
+ *
+ * A template matches a request only when it has the same number of segments
+ * and every literal segment is the segment the request sent. That is what
+ * keeps a path this endpoint has no operation for from being answered by one
+ * that happens to share its method: `GET /2015-03-31/functions/orders/aliases`
+ * has no route, and matches neither `GET /2015-03-31/functions/{FunctionName}`
+ * nor anything else, because a label stands for one segment rather than for
+ * the rest of the path.
+ *
+ * Returns undefined for a request matching no route, which is either an
+ * operation the simulated service has not implemented or one the real service
+ * does not have.
+ */
+export function resolveSimRestJsonRoute(
+  routes: readonly SimRestJsonRoute[],
+  request: SimRestJsonRequest,
+): SimRestJsonMatch | undefined {
+  for (const route of routes) {
+    if (route.method !== request.method) {
+      continue;
+    }
+
+    const labels = matchSimRestJsonPath(route.path, request.segments);
+    if (labels !== undefined) {
+      return { route, labels };
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Match one path template against the segments a request sent, and read the
+ * labels out of it.
+ */
+function matchSimRestJsonPath(
+  template: string,
+  segments: readonly string[],
+): ReadonlyMap<string, string> | undefined {
+  const expected = simRestJsonPathSegments(template);
+  if (expected.length !== segments.length) {
+    return undefined;
+  }
+
+  const labels = new Map<string, string>();
+  for (const [index, part] of expected.entries()) {
+    const segment = segments.at(index) ?? "";
+
+    if (part.startsWith("{") && part.endsWith("}")) {
+      labels.set(part.slice(1, -1), segment);
+      continue;
+    }
+
+    if (part !== segment) {
+      return undefined;
+    }
+  }
+
+  return labels;
+}

--- a/src/serve/http/api/sim-aws-api-protocols.ts
+++ b/src/serve/http/api/sim-aws-api-protocols.ts
@@ -1,6 +1,7 @@
 import type { SimAwsCaller } from "../../../service/aws/caller/sim-aws-caller.js";
 import type { SimAws } from "../../../service/aws/sim-aws.js";
 import { simCloudFormationApiEndpoint } from "../../../service/cloudformation/serve/sim-cloudformation-api.js";
+import { simLambdaApiEndpoint } from "../../../service/lambda/serve/api/sim-lambda-api.js";
 import { SimS3ApiEndpoint } from "../../../service/s3/serve/api/sim-s3-api.js";
 import { simSnsApiEndpoint } from "../../../service/sns/serve/sim-sns-api.js";
 import { simStsApiEndpoint } from "../../../service/sts/serve/sim-sts-api.js";
@@ -41,6 +42,7 @@ const simAwsProtocolEndpointFactories = new Map<
   ["sts", simStsApiEndpoint],
   ["sns", simSnsApiEndpoint],
   ["cloudformation", simCloudFormationApiEndpoint],
+  ["lambda", simLambdaApiEndpoint],
 ]);
 
 /**

--- a/src/service/lambda/serve/api/sim-lambda-api-event-source-routes.ts
+++ b/src/service/lambda/serve/api/sim-lambda-api-event-source-routes.ts
@@ -1,0 +1,65 @@
+import type { SimRestJsonInput } from "../../../../serve/http/api/rest-json/sim-rest-json-input.js";
+import type { SimRestJsonRoute } from "../../../../serve/http/api/rest-json/sim-rest-json-route.type.js";
+
+/**
+ * The event source mapping operations this endpoint serves.
+ *
+ * Creating and listing answer at the collection, and reading and deleting at
+ * one mapping's own UUID.
+ */
+export const simLambdaEventSourceApiRoutes: readonly SimRestJsonRoute[] = [
+  {
+    method: "POST",
+    path: "/2015-03-31/event-source-mappings",
+    commandName: "CreateEventSourceMappingCommand",
+    status: 202,
+    input: createEventSourceMappingInput,
+  },
+  {
+    method: "GET",
+    path: "/2015-03-31/event-source-mappings",
+    commandName: "ListEventSourceMappingsCommand",
+    input: (input) => ({
+      EventSourceArn: input.query("EventSourceArn"),
+      FunctionName: input.query("FunctionName"),
+    }),
+  },
+  {
+    method: "GET",
+    path: "/2015-03-31/event-source-mappings/{UUID}",
+    commandName: "GetEventSourceMappingCommand",
+    input: (input) => ({ UUID: input.label("UUID") }),
+  },
+  {
+    method: "DELETE",
+    path: "/2015-03-31/event-source-mappings/{UUID}",
+    commandName: "DeleteEventSourceMappingCommand",
+    status: 202,
+    input: (input) => ({ UUID: input.label("UUID") }),
+  },
+];
+
+/**
+ * Read a mapping to create, whose members are all in the body.
+ *
+ * Everything the request stated is passed on, including the members this
+ * simulation refuses, so a mapping asking for behaviour it does not have is
+ * refused here as it is in process rather than created without it.
+ *
+ * `StartingPositionTimestamp` is the one member that has to be turned back
+ * into what the simulation expects: JSON carries a timestamp as epoch seconds,
+ * and a starting position is compared against dates.
+ */
+function createEventSourceMappingInput(
+  input: SimRestJsonInput,
+): Record<string, unknown> {
+  const members = input.json();
+  const startingPosition = members["StartingPositionTimestamp"];
+
+  return typeof startingPosition === "number"
+    ? {
+        ...members,
+        StartingPositionTimestamp: new Date(startingPosition * 1000),
+      }
+    : { ...members };
+}

--- a/src/service/lambda/serve/api/sim-lambda-api-function-routes.ts
+++ b/src/service/lambda/serve/api/sim-lambda-api-function-routes.ts
@@ -1,0 +1,103 @@
+import { isRecord } from "../../../../util/type-guard/record.js";
+import type { SimRestJsonInput } from "../../../../serve/http/api/rest-json/sim-rest-json-input.js";
+import type { SimRestJsonRoute } from "../../../../serve/http/api/rest-json/sim-rest-json-route.type.js";
+import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
+import { simLambdaInvokeResponse } from "./sim-lambda-api-invoke-output.js";
+
+/**
+ * The invocation types real Lambda accepts, which it names in a header rather
+ * than in the body.
+ */
+const invocationTypes: readonly string[] = [
+  "RequestResponse",
+  "Event",
+  "DryRun",
+];
+
+/**
+ * The function operations this endpoint serves.
+ */
+export const simLambdaFunctionApiRoutes: readonly SimRestJsonRoute[] = [
+  {
+    method: "POST",
+    path: "/2015-03-31/functions",
+    commandName: "CreateFunctionCommand",
+    status: 201,
+    input: createFunctionInput,
+  },
+  {
+    method: "GET",
+    path: "/2015-03-31/functions/{FunctionName}",
+    commandName: "GetFunctionCommand",
+    input: (input) => ({ FunctionName: input.label("FunctionName") }),
+  },
+  {
+    method: "DELETE",
+    path: "/2015-03-31/functions/{FunctionName}",
+    commandName: "DeleteFunctionCommand",
+    input: (input) => ({ FunctionName: input.label("FunctionName") }),
+  },
+  {
+    method: "POST",
+    path: "/2015-03-31/functions/{FunctionName}/invocations",
+    commandName: "InvokeCommand",
+    input: invokeInput,
+    output: simLambdaInvokeResponse,
+  },
+];
+
+/**
+ * Read a CreateFunction request, whose members are all in the body.
+ *
+ * The one member JSON cannot carry as it is is the code, which travels base64
+ * encoded and reaches the simulation as the bytes of a zip.
+ */
+function createFunctionInput(input: SimRestJsonInput): Record<string, unknown> {
+  const members = input.json();
+  const code = members["Code"];
+
+  return isRecord(code)
+    ? { ...members, Code: functionCode(code) }
+    : { ...members };
+}
+
+function functionCode(code: Record<string, unknown>): Record<string, unknown> {
+  const zipFile = code["ZipFile"];
+
+  return typeof zipFile === "string"
+    ? { ...code, ZipFile: Buffer.from(zipFile, "base64") }
+    : code;
+}
+
+/**
+ * Read an Invoke request, which states its members in three different places.
+ *
+ * The body is the payload itself rather than a JSON object holding it, so it
+ * is passed on as the bytes that arrived. That is what lets `aws lambda
+ * invoke --payload` send a document the handler receives unchanged.
+ */
+function invokeInput(input: SimRestJsonInput): Record<string, unknown> {
+  return {
+    FunctionName: input.label("FunctionName"),
+    InvocationType: invocationType(input.header("x-amz-invocation-type")),
+    Qualifier: input.query("Qualifier"),
+    Payload: input.body,
+  };
+}
+
+/**
+ * Check the invocation type a request asked for.
+ *
+ * An unrecognised one is refused the way real Lambda refuses it, rather than
+ * passed on to a dispatcher that has nothing to do with it.
+ */
+function invocationType(value: string | undefined): string | undefined {
+  if (value !== undefined && !invocationTypes.includes(value)) {
+    throw new SimLambdaInvalidParameterValueException(
+      `Unrecognized invocation type ${value}. Valid invocation types are ` +
+        `${invocationTypes.join(", ")}.`,
+    );
+  }
+
+  return value;
+}

--- a/src/service/lambda/serve/api/sim-lambda-api-invoke-output.ts
+++ b/src/service/lambda/serve/api/sim-lambda-api-invoke-output.ts
@@ -1,0 +1,34 @@
+import type { SimRestJsonOutput } from "../../../../serve/http/api/rest-json/sim-rest-json-route.type.js";
+
+/**
+ * Write the response an Invoke answers with.
+ *
+ * Invoke is the one Lambda operation whose response is not its output as JSON.
+ * The body is the payload the function produced, and the output members are
+ * arranged around it: `StatusCode` is the HTTP status, and `FunctionError` and
+ * `ExecutedVersion` are headers. A handler that threw still answers `200` with
+ * a payload, and `X-Amz-Function-Error` is what tells a caller the difference.
+ */
+export function simLambdaInvokeResponse(output: SimRestJsonOutput): Response {
+  const status = output["StatusCode"];
+  const payload = output["Payload"];
+
+  return new Response(
+    status !== 204 && payload instanceof Uint8Array ? payload : null,
+    {
+      status: typeof status === "number" ? status : 200,
+      headers: {
+        "content-type": "application/json",
+        ...header("x-amz-function-error", output["FunctionError"]),
+        ...header("x-amz-executed-version", output["ExecutedVersion"]),
+      },
+    },
+  );
+}
+
+/**
+ * A header the output produced, left out when the output did not produce it.
+ */
+function header(name: string, value: unknown): Record<string, string> {
+  return typeof value === "string" ? { [name]: value } : {};
+}

--- a/src/service/lambda/serve/api/sim-lambda-api-permission-routes.ts
+++ b/src/service/lambda/serve/api/sim-lambda-api-permission-routes.ts
@@ -1,0 +1,37 @@
+import type { SimRestJsonRoute } from "../../../../serve/http/api/rest-json/sim-rest-json-route.type.js";
+
+/**
+ * The resource policy operations this endpoint serves.
+ *
+ * A statement is added and read at the function's `/policy`, and removed at
+ * that path with the statement id appended, so the removal is the one of the
+ * three that reads a second label out of the path.
+ */
+export const simLambdaPermissionApiRoutes: readonly SimRestJsonRoute[] = [
+  {
+    method: "POST",
+    path: "/2015-03-31/functions/{FunctionName}/policy",
+    commandName: "AddPermissionCommand",
+    status: 201,
+    input: (input) => ({
+      ...input.json(),
+      FunctionName: input.label("FunctionName"),
+    }),
+  },
+  {
+    method: "GET",
+    path: "/2015-03-31/functions/{FunctionName}/policy",
+    commandName: "GetPolicyCommand",
+    input: (input) => ({ FunctionName: input.label("FunctionName") }),
+  },
+  {
+    method: "DELETE",
+    path: "/2015-03-31/functions/{FunctionName}/policy/{StatementId}",
+    commandName: "RemovePermissionCommand",
+    status: 204,
+    input: (input) => ({
+      FunctionName: input.label("FunctionName"),
+      StatementId: input.label("StatementId"),
+    }),
+  },
+];

--- a/src/service/lambda/serve/api/sim-lambda-api-routes.iso.test.ts
+++ b/src/service/lambda/serve/api/sim-lambda-api-routes.iso.test.ts
@@ -1,0 +1,330 @@
+import {
+  assertIdentical,
+  assertObjectEquals,
+  assertObjectMatches,
+  assertThrowsError,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+
+import { SimRestJsonInput } from "../../../../serve/http/api/rest-json/sim-rest-json-input.js";
+import { readSimRestJsonRequest } from "../../../../serve/http/api/rest-json/sim-rest-json-request.js";
+import { resolveSimRestJsonRoute } from "../../../../serve/http/api/rest-json/sim-rest-json-routes.js";
+import { simLambdaApiRoutes } from "./sim-lambda-api-routes.js";
+
+interface RequestParts {
+  readonly body?: string;
+  readonly headers?: Record<string, string>;
+}
+
+/**
+ * Which Lambda operation a request names, which REST-JSON states in the method
+ * and the path rather than in a header.
+ */
+describe("Resolving a Lambda operation from a served request", () => {
+  function match(method: string, path: string, parts: RequestParts = {}) {
+    const request = new Request(`http://localhost:1234${path}`, {
+      method,
+      ...(parts.headers !== undefined && { headers: parts.headers }),
+    });
+    const body = Buffer.from(parts.body ?? "");
+
+    return {
+      matched: resolveSimRestJsonRoute(
+        simLambdaApiRoutes,
+        readSimRestJsonRequest(request, body),
+      ),
+      request,
+      body,
+    };
+  }
+
+  function command(
+    method: string,
+    path: string,
+    parts: RequestParts = {},
+  ): string | undefined {
+    return match(method, path, parts).matched?.route.commandName;
+  }
+
+  /**
+   * The input one of these routes reads out of a request it serves.
+   */
+  function input(
+    method: string,
+    path: string,
+    parts: RequestParts = {},
+  ): Record<string, unknown> {
+    const { matched, request, body } = match(method, path, parts);
+    assertDefined(matched, `a route for ${method} ${path}`);
+
+    return matched.route.input(
+      new SimRestJsonInput({
+        labels: matched.labels,
+        query: new URL(request.url).searchParams,
+        headers: request.headers,
+        body,
+      }),
+    );
+  }
+
+  it("routes the function operations", () => {
+    assertIdentical(
+      command("POST", "/2015-03-31/functions"),
+      "CreateFunctionCommand",
+    );
+    assertIdentical(
+      command("GET", "/2015-03-31/functions/orders"),
+      "GetFunctionCommand",
+    );
+    assertIdentical(
+      command("DELETE", "/2015-03-31/functions/orders"),
+      "DeleteFunctionCommand",
+    );
+    assertIdentical(
+      command("POST", "/2015-03-31/functions/orders/invocations"),
+      "InvokeCommand",
+    );
+  });
+
+  it("routes the Function URL configuration operations", () => {
+    const path = "/2021-10-31/functions/orders/url";
+
+    assertIdentical(command("POST", path), "CreateFunctionUrlConfigCommand");
+    assertIdentical(command("GET", path), "GetFunctionUrlConfigCommand");
+    assertIdentical(command("PUT", path), "UpdateFunctionUrlConfigCommand");
+    assertIdentical(command("DELETE", path), "DeleteFunctionUrlConfigCommand");
+    assertIdentical(
+      command("GET", "/2021-10-31/functions/orders/urls"),
+      "ListFunctionUrlConfigsCommand",
+    );
+  });
+
+  it("routes the resource policy operations", () => {
+    assertIdentical(
+      command("POST", "/2015-03-31/functions/orders/policy"),
+      "AddPermissionCommand",
+    );
+    assertIdentical(
+      command("GET", "/2015-03-31/functions/orders/policy"),
+      "GetPolicyCommand",
+    );
+    assertIdentical(
+      command("DELETE", "/2015-03-31/functions/orders/policy/AllowS3"),
+      "RemovePermissionCommand",
+    );
+  });
+
+  it("routes the event source mapping operations", () => {
+    assertIdentical(
+      command("POST", "/2015-03-31/event-source-mappings"),
+      "CreateEventSourceMappingCommand",
+    );
+    assertIdentical(
+      command("GET", "/2015-03-31/event-source-mappings"),
+      "ListEventSourceMappingsCommand",
+    );
+    assertIdentical(
+      command("GET", "/2015-03-31/event-source-mappings/a-uuid"),
+      "GetEventSourceMappingCommand",
+    );
+    assertIdentical(
+      command("DELETE", "/2015-03-31/event-source-mappings/a-uuid"),
+      "DeleteEventSourceMappingCommand",
+    );
+  });
+
+  it("has no operation for a path this endpoint does not serve", () => {
+    // Given the paths of Lambda operations this simulation has not
+    // implemented, each sharing its method with one it has
+    // Then none of them resolves to the operation beside it
+    assertUndefined(command("GET", "/2015-03-31/functions"));
+    assertUndefined(command("POST", "/2015-03-31/functions/orders/versions"));
+    assertUndefined(command("PUT", "/2015-03-31/functions/orders/code"));
+    assertUndefined(
+      command("GET", "/2015-03-31/functions/orders/configuration"),
+    );
+    assertUndefined(
+      command("GET", "/2015-03-31/functions/orders/aliases/live"),
+    );
+    assertUndefined(command("GET", "/2019-09-30/functions/orders/concurrency"));
+  });
+
+  it("reads the function or the mapping a path names", () => {
+    // Given the operations whose whole input is the resource in the path
+    // Then each reads it out of the label its template named
+    const named = { FunctionName: "orders" };
+
+    assertObjectEquals(input("GET", "/2015-03-31/functions/orders"), named);
+    assertObjectEquals(input("DELETE", "/2015-03-31/functions/orders"), named);
+    assertObjectEquals(
+      input("GET", "/2015-03-31/functions/orders/policy"),
+      named,
+    );
+    assertObjectEquals(input("GET", "/2021-10-31/functions/orders/url"), named);
+    assertObjectEquals(
+      input("DELETE", "/2021-10-31/functions/orders/url"),
+      named,
+    );
+    assertObjectEquals(
+      input("GET", "/2021-10-31/functions/orders/urls"),
+      named,
+    );
+
+    const mapping = { UUID: "a-uuid" };
+    assertObjectEquals(
+      input("GET", "/2015-03-31/event-source-mappings/a-uuid"),
+      mapping,
+    );
+    assertObjectEquals(
+      input("DELETE", "/2015-03-31/event-source-mappings/a-uuid"),
+      mapping,
+    );
+  });
+
+  it("reads a write from both the path and the body", () => {
+    // Given the operations naming their function in the path and stating what
+    // to write in the body
+    assertObjectEquals(
+      input("POST", "/2021-10-31/functions/orders/url", {
+        body: JSON.stringify({ AuthType: "NONE" }),
+      }),
+      { AuthType: "NONE", FunctionName: "orders" },
+    );
+    assertObjectEquals(
+      input("PUT", "/2021-10-31/functions/orders/url", {
+        body: JSON.stringify({ InvokeMode: "BUFFERED" }),
+      }),
+      { InvokeMode: "BUFFERED", FunctionName: "orders" },
+    );
+    assertObjectEquals(
+      input("POST", "/2015-03-31/functions/orders/policy", {
+        body: JSON.stringify({ StatementId: "AllowS3" }),
+      }),
+      { StatementId: "AllowS3", FunctionName: "orders" },
+    );
+  });
+
+  it("reads a permission removal, whose statement is a second label", () => {
+    assertObjectEquals(
+      input("DELETE", "/2015-03-31/functions/orders/policy/AllowS3"),
+      { FunctionName: "orders", StatementId: "AllowS3" },
+    );
+  });
+
+  it("reads an invoke from the path, a header, the query and the body", () => {
+    // Given an invocation naming its function in the path, its type in a
+    // header, its qualifier in the query string and its payload in the body
+    const read = input(
+      "POST",
+      "/2015-03-31/functions/orders/invocations?Qualifier=live",
+      {
+        headers: { "x-amz-invocation-type": "Event" },
+        body: '{"id":1}',
+      },
+    );
+
+    // Then every member came off the place REST-JSON puts it, and the payload
+    // is the bytes that arrived rather than anything read out of them
+    assertObjectMatches(read, {
+      FunctionName: "orders",
+      InvocationType: "Event",
+      Qualifier: "live",
+    });
+    assertIdentical(
+      Buffer.from(read["Payload"] as Uint8Array).toString(),
+      '{"id":1}',
+    );
+  });
+
+  it("refuses an invocation type real Lambda does not have", () => {
+    // Given a request asking to be invoked in a way there is no such thing as
+    const error = assertThrowsError(() =>
+      input("POST", "/2015-03-31/functions/orders/invocations", {
+        headers: { "x-amz-invocation-type": "Whenever" },
+      }),
+    );
+
+    // Then it is refused by name rather than dispatched to nothing
+    assertIdentical(error.name, "InvalidParameterValueException");
+  });
+
+  it("decodes the code a function is created with", () => {
+    // Given a creation carrying its zip the way JSON carries bytes
+    const zip = Buffer.from("PK pretend zip");
+    const read = input("POST", "/2015-03-31/functions", {
+      body: JSON.stringify({
+        FunctionName: "orders",
+        Code: { ZipFile: zip.toString("base64") },
+      }),
+    });
+
+    // Then the simulation is handed the bytes rather than the base64 of them
+    const code = read["Code"] as { ZipFile: Uint8Array };
+    assertIdentical(Buffer.from(code.ZipFile).toString(), zip.toString());
+  });
+
+  it("leaves code that is not a zip as it was stated", () => {
+    // Given a creation naming its code in S3 rather than carrying it
+    const read = input("POST", "/2015-03-31/functions", {
+      body: JSON.stringify({
+        FunctionName: "orders",
+        Code: { S3Bucket: "artifacts", S3Key: "orders.zip" },
+      }),
+    });
+
+    assertObjectEquals(read["Code"] as object, {
+      S3Bucket: "artifacts",
+      S3Key: "orders.zip",
+    });
+  });
+
+  it("reads a creation stating no code at all", () => {
+    const read = input("POST", "/2015-03-31/functions", {
+      body: JSON.stringify({ FunctionName: "orders" }),
+    });
+
+    assertObjectEquals(read, { FunctionName: "orders" });
+  });
+
+  it("reads a mapping's starting position back as a date", () => {
+    // Given a mapping to start reading from a moment, which JSON carries as
+    // epoch seconds
+    const read = input("POST", "/2015-03-31/event-source-mappings", {
+      body: JSON.stringify({
+        FunctionName: "orders",
+        StartingPosition: "AT_TIMESTAMP",
+        StartingPositionTimestamp: 1_770_000_000,
+      }),
+    });
+
+    // Then the simulation is handed the date it compares against
+    const started = read["StartingPositionTimestamp"] as Date;
+    assertIdentical(
+      started.toISOString(),
+      new Date(1_770_000_000_000).toISOString(),
+    );
+  });
+
+  it("reads a mapping stating no starting position", () => {
+    const read = input("POST", "/2015-03-31/event-source-mappings", {
+      body: JSON.stringify({ FunctionName: "orders", BatchSize: 10 }),
+    });
+
+    assertObjectEquals(read, { FunctionName: "orders", BatchSize: 10 });
+  });
+
+  it("reads a mapping listing's filters out of the query string", () => {
+    const read = input(
+      "GET",
+      "/2015-03-31/event-source-mappings?FunctionName=orders",
+    );
+
+    assertObjectEquals(read, {
+      EventSourceArn: undefined,
+      FunctionName: "orders",
+    });
+  });
+});

--- a/src/service/lambda/serve/api/sim-lambda-api-routes.ts
+++ b/src/service/lambda/serve/api/sim-lambda-api-routes.ts
@@ -1,0 +1,20 @@
+import type { SimRestJsonRoute } from "../../../../serve/http/api/rest-json/sim-rest-json-route.type.js";
+import { simLambdaEventSourceApiRoutes } from "./sim-lambda-api-event-source-routes.js";
+import { simLambdaFunctionApiRoutes } from "./sim-lambda-api-function-routes.js";
+import { simLambdaPermissionApiRoutes } from "./sim-lambda-api-permission-routes.js";
+import { simLambdaUrlApiRoutes } from "./sim-lambda-api-url-routes.js";
+
+/**
+ * The Lambda operations reachable through the served AWS API endpoint, which
+ * are the sixteen simulated Lambda implements.
+ *
+ * No two of these share a method and a path, so the order they are listed in
+ * decides nothing. A path that is not one of these is refused rather than
+ * matched against the nearest of them.
+ */
+export const simLambdaApiRoutes: readonly SimRestJsonRoute[] = [
+  ...simLambdaFunctionApiRoutes,
+  ...simLambdaUrlApiRoutes,
+  ...simLambdaPermissionApiRoutes,
+  ...simLambdaEventSourceApiRoutes,
+];

--- a/src/service/lambda/serve/api/sim-lambda-api-url-routes.ts
+++ b/src/service/lambda/serve/api/sim-lambda-api-url-routes.ts
@@ -1,0 +1,53 @@
+import type { SimRestJsonInput } from "../../../../serve/http/api/rest-json/sim-rest-json-input.js";
+import type { SimRestJsonRoute } from "../../../../serve/http/api/rest-json/sim-rest-json-route.type.js";
+
+/**
+ * The Function URL configuration operations this endpoint serves.
+ *
+ * These live under a later API version than the function operations do, which
+ * is how real Lambda dates the addition rather than anything a caller decides.
+ * A configuration is reached at `/url` and the listing at `/urls`, so the two
+ * are told apart by the last segment of the path.
+ */
+export const simLambdaUrlApiRoutes: readonly SimRestJsonRoute[] = [
+  {
+    method: "POST",
+    path: "/2021-10-31/functions/{FunctionName}/url",
+    commandName: "CreateFunctionUrlConfigCommand",
+    status: 201,
+    input: urlConfigInput,
+  },
+  {
+    method: "GET",
+    path: "/2021-10-31/functions/{FunctionName}/url",
+    commandName: "GetFunctionUrlConfigCommand",
+    input: (input) => ({ FunctionName: input.label("FunctionName") }),
+  },
+  {
+    method: "PUT",
+    path: "/2021-10-31/functions/{FunctionName}/url",
+    commandName: "UpdateFunctionUrlConfigCommand",
+    input: urlConfigInput,
+  },
+  {
+    method: "DELETE",
+    path: "/2021-10-31/functions/{FunctionName}/url",
+    commandName: "DeleteFunctionUrlConfigCommand",
+    status: 204,
+    input: (input) => ({ FunctionName: input.label("FunctionName") }),
+  },
+  {
+    method: "GET",
+    path: "/2021-10-31/functions/{FunctionName}/urls",
+    commandName: "ListFunctionUrlConfigsCommand",
+    input: (input) => ({ FunctionName: input.label("FunctionName") }),
+  },
+];
+
+/**
+ * Read a configuration write, which names its function in the path and states
+ * the configuration itself in the body.
+ */
+function urlConfigInput(input: SimRestJsonInput): Record<string, unknown> {
+  return { ...input.json(), FunctionName: input.label("FunctionName") };
+}

--- a/src/service/lambda/serve/api/sim-lambda-api.iso.test.ts
+++ b/src/service/lambda/serve/api/sim-lambda-api.iso.test.ts
@@ -1,0 +1,127 @@
+import {
+  assertIdentical,
+  assertObjectMatches,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  servedLambdaApi,
+  servedLambdaApiEndpoint,
+} from "../../../../../test/lambda/served-lambda-api.js";
+import { SimRestJsonApiEndpoint } from "../../../../serve/http/api/rest-json/sim-rest-json-endpoint.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+
+/**
+ * What the served Lambda endpoint does with a request, once the protocol has
+ * decided which operation it names.
+ */
+describe("Serving the simulated Lambda control plane", () => {
+  it("refuses a path it has no operation for, by name", async () => {
+    // Given a served simulation
+    const { send } = await servedLambdaApi();
+
+    // When a Lambda operation this simulation has not implemented is asked
+    // for, at a path that shares its method with one it has
+    const response = await send(
+      "POST",
+      "/2015-03-31/functions/orders/versions",
+    );
+
+    // Then it is refused rather than answered by the operation beside it, and
+    // the refusal names the path
+    assertIdentical(response.status, 501);
+    assertIdentical(response.headers.get("x-amzn-errortype"), "NotImplemented");
+    assertStringIncludes(
+      await response.text(),
+      "POST /2015-03-31/functions/orders/versions",
+    );
+  });
+
+  it("answers a dry run with the status and no payload", async () => {
+    // Given a served simulation
+    const { send } = await servedLambdaApi();
+
+    // When a function is invoked to check the caller may invoke it
+    const response = await send(
+      "POST",
+      "/2015-03-31/functions/orders/invocations",
+      { headers: { "x-amz-invocation-type": "DryRun" } },
+    );
+
+    // Then the status is the one Invoke reports for a dry run, and there is no
+    // payload to read, since nothing ran
+    assertIdentical(response.status, 204);
+    assertIdentical(await response.text(), "");
+  });
+
+  it("answers an invoke with the payload and the executed version", async () => {
+    // Given a served simulation
+    const { send } = await servedLambdaApi();
+
+    // When a function is invoked
+    const response = await send(
+      "POST",
+      "/2015-03-31/functions/orders/invocations",
+      { body: "{}" },
+    );
+
+    // Then the handler's result is the body, and the output members Invoke
+    // reports in headers are there
+    assertIdentical(response.status, 200);
+    assertIdentical(response.headers.get("x-amz-executed-version"), "$LATEST");
+    assertObjectMatches((await response.json()) as object, { ok: true });
+  });
+
+  it("reports a body that states itself as JSON and is not", async () => {
+    // Given a served simulation
+    const { send } = await servedLambdaApi();
+
+    // When a function creation carries something that is not JSON
+    const response = await send("POST", "/2015-03-31/functions", {
+      body: "not json at all",
+    });
+
+    // Then the refusal names the exception real AWS uses for it
+    assertIdentical(response.status, 400);
+    assertIdentical(
+      response.headers.get("x-amzn-errortype"),
+      "SerializationException",
+    );
+  });
+
+  it("reports a route naming an operation the simulation does not support", async () => {
+    // Given an endpoint whose table names a Command simulated Lambda has no
+    // handler for, which is what serving an operation ahead of implementing it
+    // would look like
+    const simAws = new SimAws();
+    const served = new SimRestJsonApiEndpoint({
+      simAws,
+      serviceId: "Lambda",
+      routes: [
+        {
+          method: "POST",
+          path: "/2015-03-31/functions/{FunctionName}/versions",
+          commandName: "PublishVersionCommand",
+          input: (input) => ({ FunctionName: input.label("FunctionName") }),
+        },
+      ],
+    });
+
+    // When it is asked for
+    const response = await served.handle(
+      new Request(
+        `${servedLambdaApiEndpoint}/2015-03-31/functions/orders/versions`,
+        { method: "POST" },
+      ),
+      new Uint8Array(),
+      { kind: "anonymous" },
+      simAws.defaultRegionName,
+    );
+
+    // Then the endpoint says so rather than answering with a server error
+    assertIdentical(response.status, 501);
+    assertIdentical(response.headers.get("x-amzn-errortype"), "NotImplemented");
+    assertStringIncludes(await response.text(), "PublishVersionCommand");
+  });
+});

--- a/src/service/lambda/serve/api/sim-lambda-api.loc.test.ts
+++ b/src/service/lambda/serve/api/sim-lambda-api.loc.test.ts
@@ -1,0 +1,291 @@
+import {
+  CreateAccessKeyCommand,
+  CreateUserCommand,
+  PutUserPolicyCommand,
+} from "@aws-sdk/client-iam";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+  CreateFunctionUrlConfigCommand,
+  DeleteFunctionCommand,
+  DeleteFunctionUrlConfigCommand,
+  GetFunctionCommand,
+  GetFunctionUrlConfigCommand,
+  GetPolicyCommand,
+  InvokeCommand,
+  LambdaClient,
+  ListEventSourceMappingsCommand,
+  ListFunctionUrlConfigsCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertArrayLength,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { afterAll, beforeAll, describe, it } from "vitest";
+
+import { SimAwsLocalServer } from "../../../../serve/index.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import { makeLambdaCodeZip } from "../../function/code/make-lambda-code-zip.js";
+
+/**
+ * Simulated Lambda reached the way a client outside the process reaches it: an
+ * endpoint URL, credentials, and no simulator in sight.
+ *
+ * Lambda speaks REST-JSON rather than the AWS JSON protocol most of the served
+ * services speak, so what these cover is whether an operation survives the
+ * round trip through a method, a path, a JSON body and, for an invoke, a
+ * payload carried as the body in both directions.
+ */
+describe("Serving the simulated Lambda control plane on an endpoint URL", () => {
+  const simAws = new SimAws();
+  const srv = new SimAwsLocalServer({ simAws });
+
+  let endpoint: string;
+  let client: LambdaClient;
+
+  beforeAll(async () => {
+    await srv.listen();
+    endpoint = `http://localhost:${srv.port}`;
+
+    const simIam = simAws.iam();
+    await simIam.createUser(new CreateUserCommand({ UserName: "Deployer" }));
+    await simIam.putUserPolicy(
+      new PutUserPolicyCommand({
+        UserName: "Deployer",
+        PolicyName: "Everything",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: { Effect: "Allow", Action: "*", Resource: "*" },
+        }),
+      }),
+    );
+    const created = await simIam.createAccessKey(
+      new CreateAccessKeyCommand({ UserName: "Deployer" }),
+    );
+
+    client = new LambdaClient({
+      region: simAws.defaultRegionName,
+      endpoint,
+      credentials: {
+        accessKeyId: created.AccessKey.AccessKeyId,
+        secretAccessKey: created.AccessKey.SecretAccessKey,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await srv.close();
+  });
+
+  /**
+   * A real zip archive, since a function created over the endpoint sends its
+   * code as base64 in a JSON body rather than handing over a handler the
+   * process already holds.
+   */
+  const echoCodeZip = makeLambdaCodeZip(
+    "exports.handler = async (event) => {\n" +
+      "  if (event.fail !== undefined) {\n" +
+      "    throw new Error(event.fail);\n" +
+      "  }\n" +
+      "  return { echoed: event };\n" +
+      "};",
+  );
+
+  /**
+   * Create a function over the endpoint, whose handler echoes what it was
+   * given, or throws when asked to.
+   */
+  async function createEchoFunction(functionName: string): Promise<void> {
+    await client.send(
+      new CreateFunctionCommand({
+        FunctionName: functionName,
+        Role: "arn:aws:iam::888888888888:role/EchoRole",
+        Handler: "index.handler",
+        Runtime: "nodejs22.x",
+        Code: { ZipFile: echoCodeZip },
+      }),
+    );
+  }
+
+  it("creates a function from a zip carried as JSON", async () => {
+    // Given nothing but an endpoint URL and credentials
+
+    // When a function is created over it
+    await createEchoFunction("orders");
+
+    // Then the simulation holds it, and reports it back over the same endpoint
+    const read = await client.send(
+      new GetFunctionCommand({ FunctionName: "orders" }),
+    );
+    assertDefined(read.Configuration, "a function configuration");
+    assertIdentical(read.Configuration.FunctionName, "orders");
+    assertIdentical(
+      read.Configuration.Role,
+      "arn:aws:iam::888888888888:role/EchoRole",
+    );
+  });
+
+  it("invokes a function and answers with its payload", async () => {
+    // Given a function reached over the endpoint
+    await createEchoFunction("invoiced");
+
+    // When it is invoked with a payload
+    const invoked = await client.send(
+      new InvokeCommand({
+        FunctionName: "invoiced",
+        Payload: JSON.stringify({ id: 1 }),
+      }),
+    );
+
+    // Then the handler ran, and its result came back as the payload
+    assertIdentical(invoked.StatusCode, 200);
+    assertUndefined(invoked.FunctionError);
+    assertDefined(invoked.Payload, "an invoke payload");
+    assertIdentical(
+      Buffer.from(invoked.Payload).toString(),
+      JSON.stringify({ echoed: { id: 1 } }),
+    );
+  });
+
+  it("reports a handler failure with the function error header", async () => {
+    // Given a function whose handler throws for this event
+    await createEchoFunction("failing");
+
+    // When it is invoked
+    const invoked = await client.send(
+      new InvokeCommand({
+        FunctionName: "failing",
+        Payload: JSON.stringify({ fail: "no stock" }),
+      }),
+    );
+
+    // Then the invocation succeeded and the failure is reported as one
+    assertIdentical(invoked.StatusCode, 200);
+    assertIdentical(invoked.FunctionError, "Unhandled");
+    assertDefined(invoked.Payload, "an invoke payload");
+    assertStringIncludes(Buffer.from(invoked.Payload).toString(), "no stock");
+  });
+
+  it("answers an asynchronous invocation before the handler runs", async () => {
+    // Given a function reached over the endpoint
+    await createEchoFunction("queued");
+
+    // When it is invoked without waiting for a result
+    const invoked = await client.send(
+      new InvokeCommand({
+        FunctionName: "queued",
+        InvocationType: "Event",
+        Payload: JSON.stringify({ id: 2 }),
+      }),
+    );
+
+    // Then the answer is the accepted status and nothing else
+    assertIdentical(invoked.StatusCode, 202);
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("raises a missing function under the name real Lambda gives it", async () => {
+    // Given no function of this name
+
+    // When one is invoked anyway
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await client.send(new InvokeCommand({ FunctionName: "absent" })),
+    );
+
+    // Then the SDK raised the exception rather than failing to read the answer
+    assertIdentical(error.name, "ResourceNotFoundException");
+    assertStringIncludes(error.message, "Function not found");
+  });
+
+  it("serves the resource policy operations", async () => {
+    // Given a function reached over the endpoint
+    await createEchoFunction("shared");
+
+    // When a statement is added to its policy
+    const added = await client.send(
+      new AddPermissionCommand({
+        FunctionName: "shared",
+        StatementId: "AllowS3",
+        Action: "lambda:InvokeFunction",
+        Principal: "s3.amazonaws.com",
+      }),
+    );
+
+    // Then the statement it assembled comes back, and the policy holds it
+    assertStringIncludes(added.Statement ?? "", "s3.amazonaws.com");
+
+    const policy = await client.send(
+      new GetPolicyCommand({ FunctionName: "shared" }),
+    );
+    assertStringIncludes(policy.Policy ?? "", "AllowS3");
+  });
+
+  it("serves the Function URL configuration operations", async () => {
+    // Given a function reached over the endpoint
+    await createEchoFunction("public");
+
+    // When a Function URL is configured for it
+    const created = await client.send(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "public",
+        AuthType: "NONE",
+      }),
+    );
+    assertStringIncludes(created.FunctionUrl ?? "", "lambda-url");
+
+    // Then it is read back at its own path, and at the listing beside it
+    const read = await client.send(
+      new GetFunctionUrlConfigCommand({ FunctionName: "public" }),
+    );
+    assertIdentical(read.AuthType, "NONE");
+
+    const listed = await client.send(
+      new ListFunctionUrlConfigsCommand({ FunctionName: "public" }),
+    );
+    assertArrayLength(listed.FunctionUrlConfigs ?? [], 1);
+
+    // And deleting it answers with the empty response real Lambda answers with
+    await client.send(
+      new DeleteFunctionUrlConfigCommand({ FunctionName: "public" }),
+    );
+    const gone = await client.send(
+      new ListFunctionUrlConfigsCommand({ FunctionName: "public" }),
+    );
+    assertArrayLength(gone.FunctionUrlConfigs ?? [], 0);
+  });
+
+  it("lists the event source mappings of a function", async () => {
+    // Given a function with no event source mapping
+    await createEchoFunction("unmapped");
+
+    // When its mappings are listed
+    const listed = await client.send(
+      new ListEventSourceMappingsCommand({ FunctionName: "unmapped" }),
+    );
+
+    // Then the listing is empty rather than absent
+    assertArrayLength(listed.EventSourceMappings ?? [], 0);
+  });
+
+  it("deletes a function", async () => {
+    // Given a function reached over the endpoint
+    await createEchoFunction("temporary");
+
+    // When it is deleted
+    await client.send(new DeleteFunctionCommand({ FunctionName: "temporary" }));
+
+    // Then it is gone
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await client.send(
+          new GetFunctionCommand({ FunctionName: "temporary" }),
+        ),
+    );
+    assertIdentical(error.name, "ResourceNotFoundException");
+  });
+});

--- a/src/service/lambda/serve/api/sim-lambda-api.ts
+++ b/src/service/lambda/serve/api/sim-lambda-api.ts
@@ -1,0 +1,23 @@
+import { SimRestJsonApiEndpoint } from "../../../../serve/http/api/rest-json/sim-rest-json-endpoint.js";
+import type { SimAws } from "../../../aws/sim-aws.js";
+import { simLambdaApiRoutes } from "./sim-lambda-api-routes.js";
+
+/**
+ * Serve the Lambda control plane to a client given an endpoint URL.
+ *
+ * This is what `aws lambda invoke` reaches, and what a container, a Python
+ * application or a shell script reaches. Invoking a simulated function over
+ * HTTP runs the same handler an in-process invoke runs, in the same
+ * environment, and IAM authorizes it the same way.
+ *
+ * The operations served are the ones simulated Lambda implements. Anything
+ * else is refused as `NotImplemented`, under that name rather than as an
+ * unparseable response.
+ */
+export function simLambdaApiEndpoint(simAws: SimAws): SimRestJsonApiEndpoint {
+  return new SimRestJsonApiEndpoint({
+    simAws,
+    serviceId: "Lambda",
+    routes: simLambdaApiRoutes,
+  });
+}

--- a/test/lambda/served-lambda-api.ts
+++ b/test/lambda/served-lambda-api.ts
@@ -1,0 +1,103 @@
+/**
+ * A simulated environment whose Lambda control plane is reached over the
+ * served AWS API endpoint, signed the way a real client signs.
+ *
+ * This lives under `test/` rather than beside the endpoint because it imports
+ * the real SigV4 signer, which is a devDependency, and because a module that
+ * both exports helpers and declares tests is not allowed.
+ */
+
+import {
+  CreateFunctionCommand,
+  type CreateFunctionCommandInput,
+} from "@aws-sdk/client-lambda";
+import { PutUserPolicyCommand } from "@aws-sdk/client-iam";
+
+import { SimAwsHttp } from "../../src/serve/http/sim-aws-http.js";
+import { SimAws } from "../../src/service/aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../src/service/lambda/function/code/lambda-zip-file-input.js";
+import {
+  signAwsRequest,
+  type SignAwsRequestCredentials,
+} from "../sigv4/sign-aws-request.js";
+import { createSigner } from "../sigv4/sim-signer.js";
+
+/**
+ * The endpoint URL a client would have been given. Nothing listens on it, since
+ * these requests are answered in the process that built the environment.
+ */
+export const servedLambdaApiEndpoint = "http://localhost:8787";
+
+export interface ServedRequestParts {
+  readonly body?: string;
+  readonly headers?: Record<string, string>;
+}
+
+export interface ServedLambdaApi {
+  readonly simAws: SimAws;
+
+  /** Send one signed request to the served Lambda control plane. */
+  readonly send: (
+    method: string,
+    path: string,
+    parts?: ServedRequestParts,
+  ) => Promise<Response>;
+}
+
+/**
+ * A simulation holding one function, reached by a caller allowed to do
+ * anything, so that what a test sees is the endpoint rather than a policy.
+ */
+export async function servedLambdaApi(
+  functionInput: Partial<CreateFunctionCommandInput> = {},
+): Promise<ServedLambdaApi> {
+  const simAws = new SimAws();
+  const credentials = await signingCredentials(simAws);
+  const http = new SimAwsHttp({ simAws });
+
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: "orders",
+      Role: "arn:aws:iam::888888888888:role/OrdersRole",
+      Code: { ZipFile: makeLambdaZipFileInput(() => ({ ok: true })) },
+      ...functionInput,
+    }),
+  );
+
+  return {
+    simAws,
+    send: async (method, path, parts = {}): Promise<Response> => {
+      const signed = await signAwsRequest({
+        url: `${servedLambdaApiEndpoint}${path}`,
+        credentials,
+        method,
+        service: "lambda",
+        region: simAws.defaultRegionName,
+        ...(parts.body !== undefined && { body: parts.body }),
+        ...(parts.headers !== undefined && { headers: parts.headers }),
+      });
+
+      return await http.handleRequest(signed.request);
+    },
+  };
+}
+
+async function signingCredentials(
+  simAws: SimAws,
+): Promise<SignAwsRequestCredentials> {
+  const simIam = simAws.iam();
+  const credentials = await createSigner(simIam, "Invoker");
+
+  await simIam.putUserPolicy(
+    new PutUserPolicyCommand({
+      UserName: "Invoker",
+      PolicyName: "Everything",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: { Effect: "Allow", Action: "*", Resource: "*" },
+      }),
+    }),
+  );
+
+  return credentials;
+}


### PR DESCRIPTION
`aws lambda invoke` against a served simulated environment was refused with `501 Not Implemented`, and so was any SDK client pointed at the endpoint. REST-JSON names its operation in the method and the path, and nothing at the endpoint read that, so a Lambda control-plane request fell through to the AWS JSON dispatcher and was refused for having no `x-amz-target`. A shared REST-JSON layer under `src/serve/http/api/rest-json/` now matches a request against a table of path templates and answers in JSON, and simulated Lambda registers the sixteen operations it implements. `Invoke` answers with the function's payload, its status and the `X-Amz-Function-Error` header a handler failure sets. A path with no route is refused by name rather than matched against the nearest operation sharing its method, which was the bug the S3 work shipped. API Gateway v2, SES v2 and EventBridge Scheduler each want a route table of their own on top of this.

Resolves https://github.com/KensioSoftware/yulin/issues/696

The route table was checked against botocore's own Lambda model, and every method, path and response status here is the one that model states. The endpoint was then driven with the real `aws` CLI: an invoke, a handler failure, a function created from a zip file, the policy and Function URL operations, and `list-functions`, `list-aliases` and `get-function-concurrency`, each of which is refused by name at the path it arrived at.

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`