### PR TITLE
feat: resolve Secrets Manager dynamic references

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -931,8 +931,12 @@ inside `Fn::Sub`.
 [reading a parameter with a dynamic reference](../ssm/README.md#reading-a-parameter-with-a-dynamic-reference)
 for what they resolve to, and for what happens when Parameter Store cannot answer one.
 
-`{{resolve:ssm-secure:...}}` and `{{resolve:secretsmanager:...}}` are left in the template as
-written. Neither is resolved yet.
+`{{resolve:secretsmanager:secret-id:secret-string:json-key:version-stage:version-id}}` reads a
+simulated secret. See
+[reading a secret with a dynamic reference](../secretsmanager/README.md#reading-a-secret-with-a-dynamic-reference)
+for the segments and for what a reference Secrets Manager cannot answer resolves to.
+
+`{{resolve:ssm-secure:...}}` is left in the template as written, and is not resolved yet.
 
 ## Conditions
 

--- a/docs/services/secretsmanager/README.md
+++ b/docs/services/secretsmanager/README.md
@@ -438,6 +438,135 @@ console.log(credentials.password?.length); // 24
 Generated passwords are random. A test reads the value back out of the simulation the way a deployed
 application does.
 
+## Reading a secret with a dynamic reference
+
+A template reads a secret that already exists through a `{{resolve:secretsmanager:...}}` dynamic
+reference. The reference is replaced with the secret's value as the resource holding it is created.
+CDK emits one from `SecretValue.secretsManager`.
+
+The whole form is
+`{{resolve:secretsmanager:secret-id:secret-string:json-key:version-stage:version-id}}`. Only the
+secret id is required, and it takes a friendly name, a full ARN or a partial ARN. Every segment
+after it can be left empty, so `{{resolve:secretsmanager:db-credentials::::}}` reads what
+`{{resolve:secretsmanager:db-credentials}}` reads.
+
+- `secret-string` accepts `SecretString` and refuses anything else. (AWS documents the segment as
+  the field to read, and `SecretString` is the only field a dynamic reference has ever read.)
+- `json-key` names one key of a secret holding a JSON object. Omitting it reads the whole secret
+  string.
+- `version-stage` and `version-id` select a version, defaulting to `AWSCURRENT`. A reference carries
+  one or the other, and giving both is refused.
+
+```typescript sim-secrets-manager-dynamic-reference
+/**
+ * A CloudFormation template reading a secret into a Lambda function's
+ * environment.
+ */
+
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import { CreateSecretCommand } from "@aws-sdk/client-secrets-manager";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.secretsManager().createSecret(
+  new CreateSecretCommand({
+    Name: "db-credentials",
+    SecretString: JSON.stringify({ username: "app", password: "hunter2" }),
+  }),
+);
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "api-stack",
+  template: {
+    Resources: {
+      ApiRole: {
+        Type: "AWS::IAM::Role",
+        Properties: {
+          RoleName: "ApiRole",
+          AssumeRolePolicyDocument: {
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Principal: { Service: "lambda.amazonaws.com" },
+                Action: "sts:AssumeRole",
+              },
+            ],
+          },
+        },
+      },
+      ApiFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "api",
+          Role: { "Fn::GetAtt": ["ApiRole", "Arn"] },
+          Handler: "index.handler",
+          Runtime: "nodejs20.x",
+          Environment: {
+            Variables: {
+              DB_USERNAME:
+                "{{resolve:secretsmanager:db-credentials:SecretString:username}}",
+              DB_PASSWORD:
+                "{{resolve:secretsmanager:db-credentials:SecretString:password}}",
+            },
+          },
+          Code: {
+            ZipFile: "exports.handler = async () => process.env.DB_USERNAME;",
+          },
+        },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+// The function was created holding the values the references resolved to.
+const output = await simAws
+  .lambda()
+  .invoke(new InvokeCommand({ FunctionName: "api" }));
+
+const username = JSON.parse(
+  Buffer.from(output.Payload ?? []).toString(),
+) as string;
+
+console.log(username); // "app"
+
+await simAws.backgroundTasksComplete();
+```
+
+A reference can sit inside a longer string, where only the reference itself is replaced. One written
+inside `Fn::Sub` is read after the variables around it are substituted.
+
+A full ARN naming another account is read from that account's simulated Secrets Manager, as real
+CloudFormation reads it. A friendly name and a partial ARN both name a secret in the stack's own
+account and region.
+
+The value is decrypted through simulated KMS on the way out, the same as `GetSecretValue` decrypts
+it. A secret under a customer managed key that the simulation cannot decrypt resolves to a stand-in
+value.
+
+Real CloudFormation makes no dependency out of a dynamic reference, and neither does this. A secret
+another resource of the same stack creates is only there in time when the template says `DependsOn`.
+
+Resource properties are reported as they resolved, including this one. Real CloudFormation keeps a
+resolved secret out of its own logs and events, and sim CloudFormation has no such protection.
+
+### A reference the simulation cannot answer
+
+Simulated CloudFormation deploys what it can. A reference naming a secret that was never created
+resolves to `dummy-value-for-<secret-id>`, and the stack carries on deploying. A template reading a
+secret a test does not care about is still worth deploying for everything else in it.
+
+The substitution is recorded on
+[`stack.ignoredProperties`](../cloudformation/README.md#properties-a-resource-was-created-without),
+naming the property that held the reference and why the value is a stand-in. A `json-key` the secret
+has no value for, a version stage no version carries, a `secret-string` segment other than
+`SecretString`, and a reference naming both a version stage and a version id are all recorded the
+same way.
+
 `SecretStringTemplate` and `GenerateStringKey` go together. The generated password is added to the
 template's JSON object under that key. Without them, the whole secret value is the generated
 password. That is what an empty `GenerateSecretString: {}` produces, and it is the property CDK
@@ -481,6 +610,9 @@ Sim Secrets Manager currently supports:
   managed key
 - Calls made from inside a simulated Lambda handler, authorized as the function's execution role
 - The `AWS::SecretsManager::Secret` CloudFormation resource, including `GenerateSecretString`
+- `{{resolve:secretsmanager:...}}` dynamic references in CloudFormation resource properties, by
+  JSON key, by staging label and by version id
+- A dynamic reference carrying a full ARN reading the account that ARN names
 
 ## Limitations
 
@@ -505,8 +637,10 @@ Current documented limitations:
   secret with no version is outside this simulation.
 - `ExcludeCharacters` that removes every character of an included type is refused. Generating a
   password missing a type it was told to include would be worse.
-- `{{resolve:secretsmanager:...}}` dynamic references are absent. That is a CloudFormation engine
-  feature rather than a Secrets Manager one. Pass the ARN from `Ref` instead.
+- A `{{resolve:secretsmanager:...}}` dynamic reference resolves to a marker while the rest of the
+  resource's properties resolve around it, and the value replaces the marker once Secrets Manager
+  has answered. An intrinsic function reading the string in between, such as an `Fn::Split` over a
+  reference, sees the marker.
 - Resource policies (`PutResourcePolicy`, `GetResourcePolicy`, `DeleteResourcePolicy`,
   `ValidateResourcePolicy`) are left out, and cross-account access to a secret cannot be granted.
 - Replica regions are left out. `AddReplicaRegions`, `ReplicateSecretToRegions` and

--- a/docs/services/secretsmanager/sim-secrets-manager-dynamic-reference.example.ts
+++ b/docs/services/secretsmanager/sim-secrets-manager-dynamic-reference.example.ts
@@ -1,0 +1,77 @@
+/**
+ * A CloudFormation template reading a secret into a Lambda function's
+ * environment.
+ */
+
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import { CreateSecretCommand } from "@aws-sdk/client-secrets-manager";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.secretsManager().createSecret(
+  new CreateSecretCommand({
+    Name: "db-credentials",
+    SecretString: JSON.stringify({ username: "app", password: "hunter2" }),
+  }),
+);
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "api-stack",
+  template: {
+    Resources: {
+      ApiRole: {
+        Type: "AWS::IAM::Role",
+        Properties: {
+          RoleName: "ApiRole",
+          AssumeRolePolicyDocument: {
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Principal: { Service: "lambda.amazonaws.com" },
+                Action: "sts:AssumeRole",
+              },
+            ],
+          },
+        },
+      },
+      ApiFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "api",
+          Role: { "Fn::GetAtt": ["ApiRole", "Arn"] },
+          Handler: "index.handler",
+          Runtime: "nodejs20.x",
+          Environment: {
+            Variables: {
+              DB_USERNAME:
+                "{{resolve:secretsmanager:db-credentials:SecretString:username}}",
+              DB_PASSWORD:
+                "{{resolve:secretsmanager:db-credentials:SecretString:password}}",
+            },
+          },
+          Code: {
+            ZipFile: "exports.handler = async () => process.env.DB_USERNAME;",
+          },
+        },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+// The function was created holding the values the references resolved to.
+const output = await simAws
+  .lambda()
+  .invoke(new InvokeCommand({ FunctionName: "api" }));
+
+const username = JSON.parse(
+  Buffer.from(output.Payload ?? []).toString(),
+) as string;
+
+console.log(username); // "app"
+
+await simAws.backgroundTasksComplete();

--- a/src/service/cloudformation/resource/create/sim-cfn-resource-creator.ts
+++ b/src/service/cloudformation/resource/create/sim-cfn-resource-creator.ts
@@ -62,7 +62,7 @@ export class SimCfnResourceCreator<T extends object = object> {
 
     const resolvedContext: SimCloudFormationResourceCreateContext = {
       ...context,
-      resolvedProperties: this.resource.resolvedProperties(context),
+      resolvedProperties: await this.resource.resolvedProperties(context),
     };
 
     return await factory.create(

--- a/src/service/cloudformation/resource/delete/sim-cfn-resource-deleter.ts
+++ b/src/service/cloudformation/resource/delete/sim-cfn-resource-deleter.ts
@@ -63,7 +63,7 @@ export class SimCfnResourceDeleter<T extends object = object> {
 
     await factory.delete(resourceType.resourceTypeName, this.resource, {
       ...context,
-      resolvedProperties: this.resource.resolvedProperties(context),
+      resolvedProperties: await this.resource.resolvedProperties(context),
     });
   }
 }

--- a/src/service/cloudformation/resource/resolve/property/sim-cfn-resource-property-resolver.ts
+++ b/src/service/cloudformation/resource/resolve/property/sim-cfn-resource-property-resolver.ts
@@ -8,10 +8,8 @@ import type { SimCfnResourceResolveContext } from "../../sim-cfn-resource.type.j
 import type { SimCfnPseudoParameters } from "../../../parameters/pseudo/sim-cfn-pseudo-parameters.js";
 import type { SimCfnExports } from "../../../export/sim-cfn-exports.js";
 import type { SimAwsAccountRegionScope } from "../../../../aws/sim-aws-account-region-scope.js";
-import {
-  makeSimCfnDynamicReferences,
-  type SimCfnDynamicReferences,
-} from "../../../template/dynamic/sim-cfn-dynamic-references.js";
+import { makeSimCfnDynamicReferences } from "../../../template/dynamic/make-sim-cfn-dynamic-references.js";
+import type { SimCfnDynamicReferences } from "../../../template/dynamic/sim-cfn-dynamic-references.js";
 import type { SimCfnPropertyIgnorer } from "../../ignore/sim-cfn-ignored-property.type.js";
 
 interface SimCfnResourcePropertyResolverProperties {
@@ -57,19 +55,25 @@ export class SimCfnResourcePropertyResolver {
    * {@link SimCfnTemplateValueResolver}. If no Parameters are available, an empty
    * Parameter resolver is used so Resource Refs can still resolve.
    *
+   * Resolution itself is synchronous, and the awaiting happens around it. A
+   * dynamic reference naming a service that has to be waited on resolves to a
+   * marker while the properties resolve, and the values replace the markers
+   * here.
+   *
    * Resource Refs are read from the creation context. If a referenced Resource
    * is unexpectedly absent, the Ref is preserved as `{ Ref: logicalId }` rather
    * than being converted to an invalid value.
    */
-  resolve(
+  async resolve(
     properties: SimCfnTemplateValueRecord,
     context: SimCfnResourceResolveContext,
-  ): SimCfnTemplateValueRecord {
+  ): Promise<SimCfnTemplateValueRecord> {
+    const dynamicReferences = this.dynamicReferences(context);
     const resolver = new SimCfnTemplateValueResolver({
       parameters: this.parameters ?? new SimCfnParameters(),
       pseudoParameters: this.pseudoParameters,
       exports: this.exports,
-      dynamicReferences: this.dynamicReferences(context),
+      dynamicReferences,
       resources: {
         has: (id): boolean => context.resources.has(id),
         refValue: (id): SimCfnTemplateValue => {
@@ -95,7 +99,13 @@ export class SimCfnResourcePropertyResolver {
       },
     });
 
-    return resolver.resolveRecord(properties);
+    const resolved = resolver.resolveRecord(properties);
+
+    if (dynamicReferences === undefined) {
+      return resolved;
+    }
+
+    return await dynamicReferences.settle(resolved);
   }
 
   /**

--- a/src/service/cloudformation/resource/sim-cfn-resource-record.ts
+++ b/src/service/cloudformation/resource/sim-cfn-resource-record.ts
@@ -173,11 +173,16 @@ export abstract class SimCfnResourceRecord implements SimCfnPropertyIgnorer {
    * CREATE_COMPLETE, and by the deletion operation while everything this
    * Resource names is still there, so referenced Resources have valid Ref
    * values either way.
+   *
+   * This is awaited for the sake of the dynamic references a property can
+   * hold. A `{{resolve:secretsmanager:...}}` reference decrypts the secret it
+   * names through simulated KMS, and the properties are finished once it
+   * has.
    */
-  resolvedProperties(
+  async resolvedProperties(
     context: SimCfnResourceResolveContext,
-  ): SimCfnTemplateValueRecord {
-    return this.propertyResolver.resolve(this.properties, context);
+  ): Promise<SimCfnTemplateValueRecord> {
+    return await this.propertyResolver.resolve(this.properties, context);
   }
 
   /**

--- a/src/service/cloudformation/template/dynamic/make-sim-cfn-dynamic-references.ts
+++ b/src/service/cloudformation/template/dynamic/make-sim-cfn-dynamic-references.ts
@@ -1,0 +1,37 @@
+import type { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimCfnPropertyIgnorer } from "../../resource/ignore/sim-cfn-ignored-property.type.js";
+import { SimCfnDynamicReferences } from "./sim-cfn-dynamic-references.js";
+import { simCfnDynamicReferenceResolvers } from "./sim-cfn-dynamic-reference-resolvers.js";
+
+interface MakeSimCfnDynamicReferencesProperties {
+  readonly simAws: SimAws;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly propertyIgnorer?: SimCfnPropertyIgnorer | undefined;
+}
+
+/**
+ * Build the dynamic reference resolvers for one Account and Region scope.
+ */
+export function makeSimCfnDynamicReferences(
+  properties: MakeSimCfnDynamicReferencesProperties,
+): SimCfnDynamicReferences {
+  const { simAws, accountRegionScope, propertyIgnorer } = properties;
+
+  const scopedAws = simAws.accountRegionScope(
+    accountRegionScope.accountId,
+    accountRegionScope.regionName,
+  );
+
+  return new SimCfnDynamicReferences({
+    propertyIgnorer,
+    resolvers: new Map(
+      simCfnDynamicReferenceResolvers
+        .entries()
+        .map(([service, resolver]) => [
+          service,
+          resolver({ simAws, scopedAws }),
+        ]),
+    ),
+  });
+}

--- a/src/service/cloudformation/template/dynamic/sim-cfn-awaited-dynamic-references.ts
+++ b/src/service/cloudformation/template/dynamic/sim-cfn-awaited-dynamic-references.ts
@@ -1,0 +1,63 @@
+import { simCfnDynamicReferencePlaceholder } from "./sim-cfn-dynamic-reference-placeholder.js";
+import type { SimCfnDynamicReferenceResolution } from "./sim-cfn-dynamic-reference.type.js";
+
+/**
+ * One reference, once the service reading it has answered.
+ *
+ * The property the reference sat on is carried here rather than looked up
+ * later. The path is only knowable while resolution is inside that property,
+ * and by the time the service answers, resolution has moved on.
+ */
+export interface SimCfnSettledDynamicReference {
+  readonly placeholder: string;
+  readonly path: string;
+  readonly resolution: SimCfnDynamicReferenceResolution;
+}
+
+interface SimCfnAwaitedDynamicReference {
+  readonly placeholder: string;
+  readonly path: string;
+  readonly resolution: Promise<SimCfnDynamicReferenceResolution>;
+}
+
+/**
+ * The references of one property resolution that a service is still reading.
+ *
+ * Each one is held behind a marker while the properties resolve around it. The
+ * markers come back in the order the properties were resolved in, so a
+ * template holding two references records them in the order it wrote them.
+ */
+export class SimCfnAwaitedDynamicReferences {
+  private readonly awaited: SimCfnAwaitedDynamicReference[] = [];
+
+  /** Whether every reference was answered as the properties resolved. */
+  get isEmpty(): boolean {
+    return this.awaited.length === 0;
+  }
+
+  /**
+   * Hold one reference, and take the marker standing in for it.
+   */
+  hold(
+    resolution: Promise<SimCfnDynamicReferenceResolution>,
+    path: string,
+  ): string {
+    const placeholder = simCfnDynamicReferencePlaceholder(this.awaited.length);
+
+    this.awaited.push({ placeholder, path, resolution });
+
+    return placeholder;
+  }
+
+  /**
+   * Wait for every service to answer.
+   */
+  async settled(): Promise<readonly SimCfnSettledDynamicReference[]> {
+    return await Promise.all(
+      this.awaited.map(async (reference) => ({
+        ...reference,
+        resolution: await reference.resolution,
+      })),
+    );
+  }
+}

--- a/src/service/cloudformation/template/dynamic/sim-cfn-awaited-dynamic-references.ts
+++ b/src/service/cloudformation/template/dynamic/sim-cfn-awaited-dynamic-references.ts
@@ -1,4 +1,7 @@
-import { simCfnDynamicReferencePlaceholder } from "./sim-cfn-dynamic-reference-placeholder.js";
+import {
+  simCfnDynamicReferenceMarking,
+  simCfnDynamicReferencePlaceholder,
+} from "./sim-cfn-dynamic-reference-placeholder.js";
 import type { SimCfnDynamicReferenceResolution } from "./sim-cfn-dynamic-reference.type.js";
 
 /**
@@ -30,6 +33,15 @@ interface SimCfnAwaitedDynamicReference {
 export class SimCfnAwaitedDynamicReferences {
   private readonly awaited: SimCfnAwaitedDynamicReference[] = [];
 
+  /**
+   * What this resolution's markers are marked with.
+   *
+   * A marker is text in a resolved property until the service answers, so it
+   * has to be one nothing else can produce. A property that was written to
+   * look like a marker misses this marking and is left as it was written.
+   */
+  private readonly marking = simCfnDynamicReferenceMarking();
+
   /** Whether every reference was answered as the properties resolved. */
   get isEmpty(): boolean {
     return this.awaited.length === 0;
@@ -42,7 +54,10 @@ export class SimCfnAwaitedDynamicReferences {
     resolution: Promise<SimCfnDynamicReferenceResolution>,
     path: string,
   ): string {
-    const placeholder = simCfnDynamicReferencePlaceholder(this.awaited.length);
+    const placeholder = simCfnDynamicReferencePlaceholder(
+      this.marking,
+      this.awaited.length,
+    );
 
     this.awaited.push({ placeholder, path, resolution });
 

--- a/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-reference-placeholder.ts
+++ b/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-reference-placeholder.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import type {
   SimCfnTemplateValue,
   SimCfnTemplateValueRecord,
@@ -12,18 +13,34 @@ import type {
  * template resolves, and the value replaces it once the service has answered.
  *
  * The marker is wrapped in a private use character (one nothing in a
- * CloudFormation template holds), so no value a template wrote can be mistaken
- * for one. While it is in flight the marker is opaque text, which is what an
- * intrinsic function reading the string around it sees. An `Fn::Split` over a
- * value the service has yet to answer with splits the marker.
+ * CloudFormation template holds) and carries random bytes of its own. A
+ * property holding text a template author wrote is therefore left alone, even
+ * where that text was written to look like a marker. While it is in flight the
+ * marker is opaque text, which is what an intrinsic function reading the
+ * string around it sees. An `Fn::Split` over a value the service has yet to
+ * answer with splits the marker.
  */
-const placeholderPattern = /\u{E000}dynamic-reference-\d+\u{E000}/gu;
+const placeholderPattern = /\u{E000}dynamic-reference-[\da-f]+-\d+\u{E000}/gu;
+
+/** How many random bytes each resolution's markers are marked with. */
+const markingLength = 8;
+
+/**
+ * What one resolution's markers are marked with, so that no other resolution
+ * and nothing a template wrote produces the same marker.
+ */
+export function simCfnDynamicReferenceMarking(): string {
+  return randomBytes(markingLength).toString("hex");
+}
 
 /**
  * The marker standing in for the reference at this position in a resolution.
  */
-export function simCfnDynamicReferencePlaceholder(position: number): string {
-  return `\u{E000}dynamic-reference-${String(position)}\u{E000}`;
+export function simCfnDynamicReferencePlaceholder(
+  marking: string,
+  position: number,
+): string {
+  return `\u{E000}dynamic-reference-${marking}-${String(position)}\u{E000}`;
 }
 
 /**

--- a/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-reference-placeholder.ts
+++ b/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-reference-placeholder.ts
@@ -1,0 +1,74 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../value/sim-cfn-template-value.js";
+
+/**
+ * What stands in a resolved string for a reference still being read.
+ *
+ * Property resolution is synchronous, and a service such as Secrets Manager
+ * cannot answer a reference without being waited on. The substitution
+ * therefore happens in two steps. A marker goes into the string while the
+ * template resolves, and the value replaces it once the service has answered.
+ *
+ * The marker is wrapped in a private use character (one nothing in a
+ * CloudFormation template holds), so no value a template wrote can be mistaken
+ * for one. While it is in flight the marker is opaque text, which is what an
+ * intrinsic function reading the string around it sees. An `Fn::Split` over a
+ * value the service has yet to answer with splits the marker.
+ */
+const placeholderPattern = /\u{E000}dynamic-reference-\d+\u{E000}/gu;
+
+/**
+ * The marker standing in for the reference at this position in a resolution.
+ */
+export function simCfnDynamicReferencePlaceholder(position: number): string {
+  return `\u{E000}dynamic-reference-${String(position)}\u{E000}`;
+}
+
+/**
+ * Replace every marker in a resolved template object with the value the
+ * service answered with.
+ *
+ * A marker sits inside a string rather than being one, since a reference can
+ * be written into the middle of a longer value, so each string is rewritten
+ * rather than swapped. The rewrite goes through a function so that a value
+ * holding `$&` or `$1` arrives as it was written.
+ */
+export function fillSimCfnDynamicReferencePlaceholders(
+  properties: SimCfnTemplateValueRecord,
+  values: ReadonlyMap<string, string>,
+): SimCfnTemplateValueRecord {
+  return filledRecord(properties, values);
+}
+
+function filled(
+  value: SimCfnTemplateValue,
+  values: ReadonlyMap<string, string>,
+): SimCfnTemplateValue {
+  if (typeof value === "string") {
+    return value.replaceAll(
+      placeholderPattern,
+      (marker) => values.get(marker) ?? marker,
+    );
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => filled(entry, values));
+  }
+
+  if (value !== null && typeof value === "object") {
+    return filledRecord(value, values);
+  }
+
+  return value;
+}
+
+function filledRecord(
+  record: SimCfnTemplateValueRecord,
+  values: ReadonlyMap<string, string>,
+): SimCfnTemplateValueRecord {
+  return Object.fromEntries(
+    Object.entries(record).map(([key, value]) => [key, filled(value, values)]),
+  );
+}

--- a/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-reference-resolvers.ts
+++ b/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-reference-resolvers.ts
@@ -1,12 +1,27 @@
+import type { SimAws } from "../../../aws/sim-aws.js";
 import type { SimAwsAccountRegionContainer } from "../../../aws/sim-aws-account-region-scope.js";
+import { SimCfnSecretsManagerDynamicReferenceResolver } from "../../../secretsmanager/cfn/dynamic/sim-cfn-secrets-manager-dynamic-reference-resolver.js";
 import type { SimCfnDynamicReferenceResolver } from "./sim-cfn-dynamic-reference.type.js";
 
 /**
+ * The simulation a dynamic reference resolver is built against.
+ *
+ * A reference reads the Stack's own Account and Region, which is what
+ * `scopedAws` is. The whole simulation comes with it because a reference can
+ * name another Account. A `secretsmanager` reference carrying a secret ARN
+ * reads the Account that ARN names, as real CloudFormation does.
+ */
+interface SimCfnDynamicReferenceSimulation {
+  readonly simAws: SimAws;
+  readonly scopedAws: SimAwsAccountRegionContainer;
+}
+
+/**
  * How one simulated service hands over its dynamic reference resolver, given
- * the Account and Region scope the Stack is deploying into.
+ * the simulation the Stack is deploying into.
  */
 type SimCfnScopedDynamicReferenceResolver = (
-  scopedAws: SimAwsAccountRegionContainer,
+  simulation: SimCfnDynamicReferenceSimulation,
 ) => SimCfnDynamicReferenceResolver;
 
 /**
@@ -23,7 +38,18 @@ export const simCfnDynamicReferenceResolvers: ReadonlyMap<
 > = new Map([
   [
     "ssm",
-    (scopedAws): SimCfnDynamicReferenceResolver =>
+    ({ scopedAws }): SimCfnDynamicReferenceResolver =>
       scopedAws.ssm().cfnDynamicReferenceResolver(),
+  ],
+  [
+    "secretsmanager",
+    ({ simAws, scopedAws }): SimCfnDynamicReferenceResolver =>
+      new SimCfnSecretsManagerDynamicReferenceResolver({
+        secretsManager: scopedAws.secretsManager(),
+        secretsManagerIn: (scope) =>
+          simAws
+            .accountRegionScope(scope.accountId, scope.regionName)
+            .secretsManager(),
+      }),
   ],
 ]);

--- a/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-reference.type.ts
+++ b/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-reference.type.ts
@@ -37,7 +37,17 @@ export interface SimCfnDynamicReferenceResolution {
 
 /**
  * How one simulated service answers the dynamic references naming it.
+ *
+ * A service that cannot answer without being waited on returns a promise, as
+ * Secrets Manager does (reading a secret decrypts it through simulated KMS).
+ * Property resolution stays synchronous either way. A promised answer is
+ * substituted once the Resource's properties have resolved around it, so the
+ * resolver is free to await whatever answering takes.
  */
 export interface SimCfnDynamicReferenceResolver {
-  resolve(reference: SimCfnDynamicReference): SimCfnDynamicReferenceResolution;
+  resolve(
+    reference: SimCfnDynamicReference,
+  ):
+    | SimCfnDynamicReferenceResolution
+    | Promise<SimCfnDynamicReferenceResolution>;
 }

--- a/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-references.ts
+++ b/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-references.ts
@@ -1,10 +1,13 @@
-import type { SimAws } from "../../../aws/sim-aws.js";
-import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import type { SimCfnPropertyIgnorer } from "../../resource/ignore/sim-cfn-ignored-property.type.js";
+import type { SimCfnTemplateValueRecord } from "../value/sim-cfn-template-value.js";
 import { currentSimCfnValuePath } from "../value/sim-cfn-value-path.js";
-import { simCfnDynamicReferenceResolvers } from "./sim-cfn-dynamic-reference-resolvers.js";
+import { SimCfnAwaitedDynamicReferences } from "./sim-cfn-awaited-dynamic-references.js";
+import { fillSimCfnDynamicReferencePlaceholders } from "./sim-cfn-dynamic-reference-placeholder.js";
 import { substituteSimCfnDynamicReferences } from "./sim-cfn-dynamic-reference-scan.js";
-import type { SimCfnDynamicReferenceResolver } from "./sim-cfn-dynamic-reference.type.js";
+import type {
+  SimCfnDynamicReferenceResolution,
+  SimCfnDynamicReferenceResolver,
+} from "./sim-cfn-dynamic-reference.type.js";
 
 interface SimCfnDynamicReferencesProperties {
   readonly resolvers: ReadonlyMap<string, SimCfnDynamicReferenceResolver>;
@@ -18,6 +21,10 @@ interface SimCfnDynamicReferencesProperties {
  * it holds without knowing which simulated services exist. A service with no
  * resolver here leaves its references in the template as written, which is
  * what the ones this simulation has yet to implement do.
+ *
+ * One of these belongs to a single Resource's property resolution. That is
+ * what lets it hold the references still being read. `substitute` runs while
+ * the properties resolve, and `settle` finishes them afterwards.
  */
 export class SimCfnDynamicReferences {
   private readonly resolvers: ReadonlyMap<
@@ -27,6 +34,8 @@ export class SimCfnDynamicReferences {
 
   private readonly propertyIgnorer: SimCfnPropertyIgnorer | undefined;
 
+  private readonly awaited = new SimCfnAwaitedDynamicReferences();
+
   constructor(properties: SimCfnDynamicReferencesProperties) {
     this.resolvers = properties.resolvers;
     this.propertyIgnorer = properties.propertyIgnorer;
@@ -35,9 +44,9 @@ export class SimCfnDynamicReferences {
   /**
    * Replace every dynamic reference in a resolved string.
    *
-   * A reference answered with a stand-in value is recorded against the
-   * property it sat on, so the Resource reports it the same way it reports a
-   * property its service could not act on.
+   * A service answering at once is substituted here. One answering with a
+   * promise leaves a marker behind for `settle` to replace, so that resolution
+   * stays synchronous around a service that has to be waited on.
    */
   substitute(text: string): string {
     return substituteSimCfnDynamicReferences(text, (reference) => {
@@ -49,43 +58,55 @@ export class SimCfnDynamicReferences {
 
       const resolution = resolver.resolve(reference);
 
-      if (resolution.reason !== undefined) {
-        this.propertyIgnorer?.ignoreProperty(
-          currentSimCfnValuePath(),
-          resolution.reason,
-        );
+      if (resolution instanceof Promise) {
+        return this.awaited.hold(resolution, currentSimCfnValuePath());
       }
 
-      return resolution.value;
+      return this.answer(resolution, currentSimCfnValuePath());
     });
   }
-}
 
-interface MakeSimCfnDynamicReferencesProperties {
-  readonly simAws: SimAws;
-  readonly accountRegionScope: SimAwsAccountRegionScope;
-  readonly propertyIgnorer?: SimCfnPropertyIgnorer | undefined;
-}
+  /**
+   * Finish the references a service had to be waited on to answer.
+   *
+   * The resolved properties are handed back with every marker replaced. They
+   * come back untouched where nothing was waited on, which is every Resource
+   * whose properties name only services answering at once.
+   */
+  async settle(
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimCfnTemplateValueRecord> {
+    if (this.awaited.isEmpty) {
+      return properties;
+    }
 
-/**
- * Build the dynamic reference resolvers for one Account and Region scope.
- */
-export function makeSimCfnDynamicReferences(
-  properties: MakeSimCfnDynamicReferencesProperties,
-): SimCfnDynamicReferences {
-  const { simAws, accountRegionScope, propertyIgnorer } = properties;
+    const settled = await this.awaited.settled();
 
-  const scopedAws = simAws.accountRegionScope(
-    accountRegionScope.accountId,
-    accountRegionScope.regionName,
-  );
+    const values = new Map(
+      settled.map((reference) => [
+        reference.placeholder,
+        this.answer(reference.resolution, reference.path),
+      ]),
+    );
 
-  return new SimCfnDynamicReferences({
-    propertyIgnorer,
-    resolvers: new Map(
-      simCfnDynamicReferenceResolvers
-        .entries()
-        .map(([service, resolver]) => [service, resolver(scopedAws)]),
-    ),
-  });
+    return fillSimCfnDynamicReferencePlaceholders(properties, values);
+  }
+
+  /**
+   * The value one reference resolved to.
+   *
+   * A reference answered with a stand-in value is recorded against the
+   * property it sat on, so the Resource reports it the same way it reports a
+   * property its service could not act on.
+   */
+  private answer(
+    resolution: SimCfnDynamicReferenceResolution,
+    path: string,
+  ): string {
+    if (resolution.reason !== undefined) {
+      this.propertyIgnorer?.ignoreProperty(path, resolution.reason);
+    }
+
+    return resolution.value;
+  }
 }

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro.iso.test.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro.iso.test.ts
@@ -145,9 +145,10 @@ describe("CloudFront CloudFormation Distribution", () => {
 
     assertTypeString(distributionId);
 
-    const resolvedWaitHandleProperties = waitHandleResource.resolvedProperties({
-      resources: stack.resources,
-    });
+    const resolvedWaitHandleProperties =
+      await waitHandleResource.resolvedProperties({
+        resources: stack.resources,
+      });
 
     assertIdentical(
       resolvedWaitHandleProperties["DistributionId"],

--- a/src/service/iam/cfn/managed-policy/sim-cfn-iam-managed-policy.iso.test.ts
+++ b/src/service/iam/cfn/managed-policy/sim-cfn-iam-managed-policy.iso.test.ts
@@ -221,9 +221,10 @@ describe("IAM CloudFormation ManagedPolicy", () => {
       `arn:aws:iam::${simAws.defaultAccountId}:policy/OutputPolicy`,
     );
 
-    const resolvedWaitHandleProperties = waitHandleResource.resolvedProperties({
-      resources: stack.resources,
-    });
+    const resolvedWaitHandleProperties =
+      await waitHandleResource.resolvedProperties({
+        resources: stack.resources,
+      });
 
     assertIdentical(resolvedWaitHandleProperties["PolicyArn"], policyArn);
     assertIdentical(stack.outputs.get("PolicyArn")?.value, policyArn);

--- a/src/service/iam/cfn/role/sim-cfn-iam-role.iso.test.ts
+++ b/src/service/iam/cfn/role/sim-cfn-iam-role.iso.test.ts
@@ -277,9 +277,10 @@ describe("IAM CloudFormation Role", () => {
 
     assertIdentical(roleResource.refValue, "OutputRole");
 
-    const resolvedWaitHandleProperties = waitHandleResource.resolvedProperties({
-      resources: stack.resources,
-    });
+    const resolvedWaitHandleProperties =
+      await waitHandleResource.resolvedProperties({
+        resources: stack.resources,
+      });
 
     assertIdentical(resolvedWaitHandleProperties["RoleName"], "OutputRole");
     assertIdentical(resolvedWaitHandleProperties["RoleArn"], role.arn);

--- a/src/service/lambda/cfn/sim-cfn-lambda-deploy.iso.test.ts
+++ b/src/service/lambda/cfn/sim-cfn-lambda-deploy.iso.test.ts
@@ -225,9 +225,10 @@ describe("Lambda CloudFormation Function deployment", () => {
 
     assertIdentical(functionResource.refValue, "output-function");
 
-    const resolvedWaitHandleProperties = waitHandleResource.resolvedProperties({
-      resources: stack.resources,
-    });
+    const resolvedWaitHandleProperties =
+      await waitHandleResource.resolvedProperties({
+        resources: stack.resources,
+      });
 
     assertIdentical(
       resolvedWaitHandleProperties["FunctionName"],

--- a/src/service/route53/cfn/hosted-zone/sim-cfn-route53-zone.iso.test.ts
+++ b/src/service/route53/cfn/hosted-zone/sim-cfn-route53-zone.iso.test.ts
@@ -218,9 +218,10 @@ describe("Route53 CloudFormation HostedZone", () => {
 
     assertTypeString(hostedZoneId);
 
-    const resolvedWaitHandleProperties = waitHandleResource.resolvedProperties({
-      resources: stack.resources,
-    });
+    const resolvedWaitHandleProperties =
+      await waitHandleResource.resolvedProperties({
+        resources: stack.resources,
+      });
 
     assertIdentical(resolvedWaitHandleProperties["HostedZoneId"], hostedZoneId);
     assertIdentical(

--- a/src/service/secretsmanager/README.md
+++ b/src/service/secretsmanager/README.md
@@ -141,6 +141,17 @@ generated value reads it back out of the simulation, as a deployed application d
 carries the random suffix, which is what makes a `Ref` into an IAM policy resource behave here the
 way it does on real AWS.
 
+`cfn/dynamic/` answers `{{resolve:secretsmanager:...}}` references. The resolver reads through the
+ordinary `GetSecretValue` command. The version is decrypted through KMS as any other read decrypts
+it, and the answer comes back as a promise. That promise is why a CloudFormation dynamic reference
+resolver may return one at all. A reference resolves to a marker while a resource's properties
+resolve around it, and the value replaces the marker afterwards.
+
+`sim-cfn-secrets-manager-reference-body.ts` reads a reference body by shape, because splitting on
+every colon over-splits it. A secret ARN carries six colons of its own and the four segments after
+the secret id carry none. An ARN is therefore taken as seven parts, and whatever is left is the
+segments.
+
 ## Divergences worth knowing
 
 - A `KmsKeyId` is checked when a version is written under it, not when it is set on its own. An
@@ -155,5 +166,7 @@ way it does on real AWS.
   and refusing is the fail-closed reading.
 - `ExcludeCharacters` that empties an included character type is refused rather than generating a
   password quietly missing a type it was told to include.
+- A `{{resolve:secretsmanager:...}}` reference is a marker in the resolved string until Secrets
+  Manager answers. An `Fn::Split` over one splits the marker.
 
 The full list is in [docs/services/secretsmanager](../../../docs/services/secretsmanager/).

--- a/src/service/secretsmanager/cfn/dynamic/sim-cfn-secrets-manager-dynamic-reference-best-effort.iso.test.ts
+++ b/src/service/secretsmanager/cfn/dynamic/sim-cfn-secrets-manager-dynamic-reference-best-effort.iso.test.ts
@@ -1,0 +1,265 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCfnStack } from "../../../cloudformation/stack/sim-cfn-stack.js";
+
+const accountIdOneOnes = "111111111111";
+
+function simAwsInEuWest2(): SimAws {
+  return new SimAws({
+    defaultAccountId: accountIdOneOnes,
+    defaultRegionName: "eu-west-2",
+  });
+}
+
+async function deployReading(
+  simAws: SimAws,
+  value: string,
+): Promise<SimCfnStack> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "config-stack",
+    template: {
+      Resources: {
+        Read: {
+          Type: "AWS::SSM::Parameter",
+          Properties: { Name: "/myapp/read", Type: "String", Value: value },
+        },
+      },
+    },
+  });
+  await stack.waitForDeployComplete();
+
+  return stack;
+}
+
+function readValue(simAws: SimAws): string {
+  const parameter = simAws.ssm().findParameter("/myapp/read");
+  assertNonNullable(parameter, "the deployed parameter");
+
+  return parameter.currentVersion.value.value;
+}
+
+/**
+ * The one record the Stack made about a dynamic reference.
+ *
+ * A Resource can record properties of its own alongside this, so the reference
+ * is picked out by what its reason quotes.
+ */
+function dynamicReferenceRecord(stack: SimCfnStack): {
+  path: string;
+  reason: string;
+} {
+  const [ignored, ...rest] = stack.ignoredProperties.filter((property) =>
+    property.reason.includes("{{resolve:"),
+  );
+  assertNonNullable(ignored, "a recorded dynamic reference");
+  assertArrayLength(rest, 0, "no second recorded dynamic reference");
+
+  return { path: ignored.path, reason: ignored.reason };
+}
+
+/**
+ * Seed a secret holding a database username and password.
+ */
+async function createCredentials(simAws: SimAws): Promise<void> {
+  await simAws.secretsManager().createSecret({
+    input: {
+      Name: "db-credentials",
+      SecretString: JSON.stringify({ username: "app", password: "hunter2" }),
+    },
+  });
+}
+
+describe("Secrets Manager CloudFormation dynamic references the simulation cannot answer", () => {
+  it("deploys with a stand-in value where the secret is absent", async () => {
+    // Given nothing in Secrets Manager.
+    const simAws = simAwsInEuWest2();
+
+    // When a template reads a secret that was never created.
+    const stack = await deployReading(
+      simAws,
+      "{{resolve:secretsmanager:db-credentials:SecretString:password}}",
+    );
+
+    // Then the Stack deploys and the Resource holds a stand-in value.
+    assertIdentical(stack.status, "CREATE_COMPLETE");
+    assertIdentical(readValue(simAws), "dummy-value-for-db-credentials");
+
+    // And the substitution is recorded against the property that held it.
+    const ignored = dynamicReferenceRecord(stack);
+    assertIdentical(ignored.path, "Value");
+    assertStringIncludes(ignored.reason, "db-credentials");
+    assertStringIncludes(ignored.reason, "stand-in value");
+  });
+
+  it("deploys with a stand-in value where the secret lacks the json key", async () => {
+    // Given a JSON secret with no port in it.
+    const simAws = simAwsInEuWest2();
+    await createCredentials(simAws);
+
+    // When a template names a key the secret does not hold.
+    const stack = await deployReading(
+      simAws,
+      "{{resolve:secretsmanager:db-credentials:SecretString:port}}",
+    );
+
+    // Then the Resource holds a stand-in value naming the missing key.
+    assertIdentical(readValue(simAws), "dummy-value-for-db-credentials");
+    assertStringIncludes(dynamicReferenceRecord(stack).reason, "no 'port' key");
+  });
+
+  it("deploys with a stand-in value where a json key names a plain secret", async () => {
+    // Given a secret holding a plain string rather than JSON.
+    const simAws = simAwsInEuWest2();
+    await simAws
+      .secretsManager()
+      .createSecret({ input: { Name: "api-key", SecretString: "hunter2" } });
+
+    // When a template names a key of it.
+    const stack = await deployReading(
+      simAws,
+      "{{resolve:secretsmanager:api-key:SecretString:password}}",
+    );
+
+    // Then the reference says the secret is not a JSON object.
+    assertIdentical(readValue(simAws), "dummy-value-for-api-key");
+    assertStringIncludes(
+      dynamicReferenceRecord(stack).reason,
+      "does not hold a JSON object",
+    );
+  });
+
+  it("deploys with a stand-in value where a json key names a JSON list", async () => {
+    // Given a secret holding JSON that is not an object.
+    const simAws = simAwsInEuWest2();
+    await simAws.secretsManager().createSecret({
+      input: { Name: "api-keys", SecretString: JSON.stringify(["hunter2"]) },
+    });
+
+    // When a template names a key of it.
+    const stack = await deployReading(
+      simAws,
+      "{{resolve:secretsmanager:api-keys:SecretString:password}}",
+    );
+
+    // Then the reference says the secret is not a JSON object.
+    assertIdentical(readValue(simAws), "dummy-value-for-api-keys");
+    assertStringIncludes(
+      dynamicReferenceRecord(stack).reason,
+      "does not hold a JSON object",
+    );
+  });
+
+  it("deploys with a stand-in value where both version selectors are given", async () => {
+    // Given a secret a template could have read.
+    const simAws = simAwsInEuWest2();
+    await createCredentials(simAws);
+
+    // When the reference names a staging label and a version id.
+    const stack = await deployReading(
+      simAws,
+      "{{resolve:secretsmanager:db-credentials:SecretString::AWSCURRENT:4a1b}}",
+    );
+
+    // Then it deploys, saying a reference takes one or the other.
+    assertIdentical(stack.status, "CREATE_COMPLETE");
+    assertStringIncludes(
+      dynamicReferenceRecord(stack).reason,
+      "one or the other",
+    );
+  });
+
+  it("deploys with a stand-in value where the secret-string segment is something else", async () => {
+    // Given a secret a template could have read.
+    const simAws = simAwsInEuWest2();
+    await createCredentials(simAws);
+
+    // When the reference names SecretBinary in its second segment.
+    const stack = await deployReading(
+      simAws,
+      "{{resolve:secretsmanager:db-credentials:SecretBinary:password}}",
+    );
+
+    // Then it deploys, saying only SecretString is read.
+    assertStringIncludes(
+      dynamicReferenceRecord(stack).reason,
+      "reads SecretString only",
+    );
+  });
+
+  it("deploys with a stand-in value where the staging label is absent", async () => {
+    // Given a secret written once, so nothing is AWSPREVIOUS yet.
+    const simAws = simAwsInEuWest2();
+    await createCredentials(simAws);
+
+    // When a template names the previous version.
+    const stack = await deployReading(
+      simAws,
+      "{{resolve:secretsmanager:db-credentials:SecretString::AWSPREVIOUS}}",
+    );
+
+    // Then the reference says Secrets Manager could not read it.
+    assertIdentical(readValue(simAws), "dummy-value-for-db-credentials");
+    assertStringIncludes(
+      dynamicReferenceRecord(stack).reason,
+      "could not read it",
+    );
+  });
+
+  it("deploys with a stand-in value where an ARN names an Account with no such secret", async () => {
+    // Given a secret at home and an ARN naming another Account.
+    const simAws = simAwsInEuWest2();
+    await createCredentials(simAws);
+    const foreignArn =
+      "arn:aws:secretsmanager:eu-west-2:222222222222:secret:db-credentials-AbCdEf";
+
+    // When a template reads that ARN.
+    const stack = await deployReading(
+      simAws,
+      `{{resolve:secretsmanager:${foreignArn}:SecretString:password}}`,
+    );
+
+    // Then the secret of the same name at home is not read in its place.
+    assertIdentical(readValue(simAws), `dummy-value-for-${foreignArn}`);
+    assertStringIncludes(
+      dynamicReferenceRecord(stack).reason,
+      "could not read it",
+    );
+  });
+
+  it("records the whole path to a reference nested in a property", async () => {
+    // Given a Stack tagging a queue with a secret that does not exist.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "queue-stack",
+      template: {
+        Resources: {
+          Queue: {
+            Type: "AWS::SQS::Queue",
+            Properties: {
+              QueueName: "work",
+              Tags: [
+                {
+                  Key: "owner",
+                  Value: "{{resolve:secretsmanager:owner-tag}}",
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the record names the list position the reference sat on.
+    assertIdentical(dynamicReferenceRecord(stack).path, "Tags.0.Value");
+  });
+});

--- a/src/service/secretsmanager/cfn/dynamic/sim-cfn-secrets-manager-dynamic-reference-best-effort.iso.test.ts
+++ b/src/service/secretsmanager/cfn/dynamic/sim-cfn-secrets-manager-dynamic-reference-best-effort.iso.test.ts
@@ -233,6 +233,99 @@ describe("Secrets Manager CloudFormation dynamic references the simulation canno
     );
   });
 
+  it("deploys with a stand-in value where the body names no secret", async () => {
+    // Given a reference whose body is empty.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed.
+    const stack = await deployReading(simAws, "{{resolve:secretsmanager:}}");
+
+    // Then it deploys, saying the reference names no secret.
+    assertIdentical(stack.status, "CREATE_COMPLETE");
+    assertStringIncludes(
+      dynamicReferenceRecord(stack).reason,
+      "which names no secret",
+    );
+  });
+
+  it("deploys with a stand-in value where the body has more segments than a reference takes", async () => {
+    // Given a secret a template could have read.
+    const simAws = simAwsInEuWest2();
+    await createCredentials(simAws);
+
+    // When the reference carries a sixth segment.
+    const stack = await deployReading(
+      simAws,
+      "{{resolve:secretsmanager:db-credentials:SecretString:password:::}}",
+    );
+
+    // Then it deploys, saying the body has more than a reference takes.
+    assertStringIncludes(
+      dynamicReferenceRecord(stack).reason,
+      "more than the secret id",
+    );
+  });
+
+  it("deploys with a stand-in value for a secret holding binary", async () => {
+    // Given a secret holding bytes.
+    const simAws = simAwsInEuWest2();
+    await simAws.secretsManager().createSecret({
+      input: {
+        Name: "api-token",
+        SecretBinary: Uint8Array.from([1, 2, 3]),
+      },
+    });
+
+    // When a template reads it.
+    const stack = await deployReading(
+      simAws,
+      "{{resolve:secretsmanager:api-token}}",
+    );
+
+    // Then the reference says a binary value cannot be read this way.
+    assertIdentical(readValue(simAws), "dummy-value-for-api-token");
+    assertStringIncludes(
+      dynamicReferenceRecord(stack).reason,
+      "holds a binary value",
+    );
+  });
+
+  it("deploys with a stand-in value where the ARN is malformed", async () => {
+    // Given a secret at home and something ARN-shaped naming no account.
+    const simAws = simAwsInEuWest2();
+    await createCredentials(simAws);
+
+    // When a template reads a body that starts like an ARN.
+    const stack = await deployReading(
+      simAws,
+      "{{resolve:secretsmanager:arn:aws:secretsmanager:eu-west-2}}",
+    );
+
+    // Then the local Secrets Manager is asked, and it refuses the ARN.
+    assertStringIncludes(
+      dynamicReferenceRecord(stack).reason,
+      "could not read it",
+    );
+  });
+
+  it("deploys with a stand-in value where the ARN names no valid account", async () => {
+    // Given an ARN of the right shape carrying something that is no account.
+    const simAws = simAwsInEuWest2();
+    await createCredentials(simAws);
+
+    // When a template reads it.
+    const stack = await deployReading(
+      simAws,
+      "{{resolve:secretsmanager:arn:aws:secretsmanager:eu-west-2:nobody:secret:db-credentials-AbCdEf}}",
+    );
+
+    // Then no account is read from it, and the ARN is refused at home.
+    assertStringIncludes(
+      dynamicReferenceRecord(stack).reason,
+      "could not read it",
+    );
+  });
+
   it("records the whole path to a reference nested in a property", async () => {
     // Given a Stack tagging a queue with a secret that does not exist.
     const simAws = simAwsInEuWest2();

--- a/src/service/secretsmanager/cfn/dynamic/sim-cfn-secrets-manager-dynamic-reference-resolver.ts
+++ b/src/service/secretsmanager/cfn/dynamic/sim-cfn-secrets-manager-dynamic-reference-resolver.ts
@@ -74,15 +74,16 @@ export class SimCfnSecretsManagerDynamicReferenceResolver implements SimCfnDynam
         return this.standIn(reference, secretId, error.message);
       }
 
-      if (error instanceof SimSecretsManagerError) {
-        return this.standIn(
-          reference,
-          secretId,
-          `and simulated Secrets Manager could not read it: ${error.message}`,
-        );
+      /* v8 ignore next 3 -- defensive: only Secrets Manager reaches here */
+      if (!(error instanceof SimSecretsManagerError)) {
+        throw error;
       }
 
-      throw error;
+      return this.standIn(
+        reference,
+        secretId,
+        `and simulated Secrets Manager could not read it (${error.message})`,
+      );
     }
   }
 

--- a/src/service/secretsmanager/cfn/dynamic/sim-cfn-secrets-manager-dynamic-reference-resolver.ts
+++ b/src/service/secretsmanager/cfn/dynamic/sim-cfn-secrets-manager-dynamic-reference-resolver.ts
@@ -1,0 +1,142 @@
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type {
+  SimCfnDynamicReference,
+  SimCfnDynamicReferenceResolution,
+  SimCfnDynamicReferenceResolver,
+} from "../../../cloudformation/template/dynamic/sim-cfn-dynamic-reference.type.js";
+import { SimSecretsManagerError } from "../../error/sim-secrets-manager.error.js";
+import type { SimSecretsManager } from "../../sim-secrets-manager.js";
+import { simCfnSecretsManagerJsonKeyValue } from "./sim-cfn-secrets-manager-json-key.js";
+import {
+  parseSimCfnSecretsManagerReference,
+  type SimCfnSecretsManagerReference,
+  SimCfnSecretsManagerReferenceProblem,
+} from "./sim-cfn-secrets-manager-reference-body.js";
+
+interface SimCfnSecretsManagerDynamicReferenceResolverProperties {
+  /** Secrets Manager for the Account and Region the Stack deploys into. */
+  readonly secretsManager: SimSecretsManager;
+
+  /** Secrets Manager for another Account and Region, which a full ARN names. */
+  readonly secretsManagerIn: (
+    scope: SimAwsAccountRegionScope,
+  ) => SimSecretsManager;
+}
+
+/**
+ * Answers `{{resolve:secretsmanager:...}}` references from simulated Secrets
+ * Manager.
+ *
+ * The secret is read as the caller deploying the Stack would read it, at the
+ * point the Resource holding the reference is created. Real CloudFormation
+ * makes no dependency out of a dynamic reference, so a secret another Resource
+ * of the same Stack creates is only there in time if the template says
+ * `DependsOn`.
+ *
+ * Reading goes through the ordinary GetSecretValue command, which decrypts the
+ * version through simulated KMS, so the answer comes back as a promise. That
+ * is what the CloudFormation engine waits on around its otherwise synchronous
+ * property resolution.
+ *
+ * Anything Secrets Manager cannot answer becomes a stand-in value carrying a
+ * reason. A template naming secrets a test never created still deploys, and
+ * the Resource records what it was given instead.
+ */
+export class SimCfnSecretsManagerDynamicReferenceResolver implements SimCfnDynamicReferenceResolver {
+  private readonly secretsManager: SimSecretsManager;
+
+  private readonly secretsManagerIn: (
+    scope: SimAwsAccountRegionScope,
+  ) => SimSecretsManager;
+
+  constructor(
+    properties: SimCfnSecretsManagerDynamicReferenceResolverProperties,
+  ) {
+    this.secretsManager = properties.secretsManager;
+    this.secretsManagerIn = properties.secretsManagerIn;
+  }
+
+  /**
+   * Resolve one reference to the secret value it names.
+   */
+  async resolve(
+    reference: SimCfnDynamicReference,
+  ): Promise<SimCfnDynamicReferenceResolution> {
+    let secretId = reference.body;
+
+    try {
+      const parsed = parseSimCfnSecretsManagerReference(reference.body);
+      secretId = parsed.secretId;
+
+      return { value: await this.read(parsed) };
+    } catch (error) {
+      if (error instanceof SimCfnSecretsManagerReferenceProblem) {
+        return this.standIn(reference, secretId, error.message);
+      }
+
+      if (error instanceof SimSecretsManagerError) {
+        return this.standIn(
+          reference,
+          secretId,
+          `and simulated Secrets Manager could not read it: ${error.message}`,
+        );
+      }
+
+      throw error;
+    }
+  }
+
+  /**
+   * Read the version the reference selects, or the current one.
+   */
+  private async read(
+    reference: SimCfnSecretsManagerReference,
+  ): Promise<string> {
+    const { secretId, scope, jsonKey, versionStage, versionId } = reference;
+    const secretsManager =
+      scope === undefined ? this.secretsManager : this.secretsManagerIn(scope);
+
+    const read = await secretsManager.getSecretValue({
+      input: {
+        SecretId: secretId,
+        VersionStage: versionStage,
+        VersionId: versionId,
+      },
+    });
+
+    const secretString = read.SecretString;
+
+    if (secretString === undefined) {
+      throw new SimCfnSecretsManagerReferenceProblem(
+        `and '${secretId}' holds a binary value, which a dynamic reference ` +
+          `cannot read`,
+      );
+    }
+
+    if (jsonKey === undefined) {
+      return secretString;
+    }
+
+    return simCfnSecretsManagerJsonKeyValue(secretString, secretId, jsonKey);
+  }
+
+  /**
+   * The value a reference Secrets Manager could not answer resolves to.
+   *
+   * The shape follows the `ssm` references beside it, and CDK before them,
+   * which fills an unresolved context lookup with `dummy-value-for-<name>`. A
+   * test reading one back sees where it came from.
+   */
+  private standIn(
+    reference: SimCfnDynamicReference,
+    secretId: string,
+    reason: string,
+  ): SimCfnDynamicReferenceResolution {
+    return {
+      value: `dummy-value-for-${secretId}`,
+      reason:
+        `holds ${reference.text}, ${reason}, so the Resource is created ` +
+        `with a stand-in value`,
+    };
+  }
+}

--- a/src/service/secretsmanager/cfn/dynamic/sim-cfn-secrets-manager-dynamic-reference.iso.test.ts
+++ b/src/service/secretsmanager/cfn/dynamic/sim-cfn-secrets-manager-dynamic-reference.iso.test.ts
@@ -1,0 +1,259 @@
+import { assertIdentical, assertNonNullable } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+const accountIdOneOnes = "111111111111";
+const accountIdTwoTwos = "222222222222";
+
+function simAwsInEuWest2(): SimAws {
+  return new SimAws({
+    defaultAccountId: accountIdOneOnes,
+    defaultRegionName: "eu-west-2",
+  });
+}
+
+/**
+ * Deploy one parameter holding the value under test, so that whatever the
+ * reference resolved to can be read back out of the simulation.
+ */
+async function deployReading(
+  simAws: SimAws,
+  value: SimCfnTemplateValue,
+): Promise<void> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "config-stack",
+    template: {
+      Resources: {
+        Read: {
+          Type: "AWS::SSM::Parameter",
+          Properties: { Name: "/myapp/read", Type: "String", Value: value },
+        },
+      },
+    },
+  });
+  await stack.waitForDeployComplete();
+}
+
+function readValue(simAws: SimAws): string {
+  const parameter = simAws.ssm().findParameter("/myapp/read");
+  assertNonNullable(parameter, "the deployed parameter");
+
+  return parameter.currentVersion.value.value;
+}
+
+describe("Secrets Manager CloudFormation dynamic references", () => {
+  it("resolves a reference to the whole current secret string", async () => {
+    // Given a secret holding a plain string.
+    const simAws = simAwsInEuWest2();
+    await simAws
+      .secretsManager()
+      .createSecret({ input: { Name: "api-key", SecretString: "hunter2" } });
+
+    // When a template reads it through a dynamic reference.
+    await deployReading(simAws, "{{resolve:secretsmanager:api-key}}");
+
+    // Then the Resource is created with the secret's value.
+    assertIdentical(readValue(simAws), "hunter2");
+  });
+
+  it("resolves a json-key segment to that key of a JSON secret", async () => {
+    // Given a secret holding a JSON object.
+    const simAws = simAwsInEuWest2();
+    await simAws.secretsManager().createSecret({
+      input: {
+        Name: "db-credentials",
+        SecretString: JSON.stringify({ username: "app", password: "hunter2" }),
+      },
+    });
+
+    // When a template names one of its keys.
+    await deployReading(
+      simAws,
+      "{{resolve:secretsmanager:db-credentials:SecretString:password}}",
+    );
+
+    // Then only that key's value is read.
+    assertIdentical(readValue(simAws), "hunter2");
+  });
+
+  it("resolves a json-key holding a number to that number as text", async () => {
+    // Given a secret whose JSON holds a number.
+    const simAws = simAwsInEuWest2();
+    await simAws.secretsManager().createSecret({
+      input: {
+        Name: "db-credentials",
+        SecretString: JSON.stringify({ password: "hunter2", port: 5432 }),
+      },
+    });
+
+    // When a template names the key holding it.
+    await deployReading(
+      simAws,
+      "{{resolve:secretsmanager:db-credentials:SecretString:port}}",
+    );
+
+    // Then the value arrives as the text a template property holds.
+    assertIdentical(readValue(simAws), "5432");
+  });
+
+  it("reads the same value from a body whose trailing segments are empty", async () => {
+    // Given a secret holding a plain string.
+    const simAws = simAwsInEuWest2();
+    await simAws
+      .secretsManager()
+      .createSecret({ input: { Name: "api-key", SecretString: "hunter2" } });
+
+    // When a template writes every optional segment as empty.
+    await deployReading(simAws, "{{resolve:secretsmanager:api-key::::}}");
+
+    // Then it means what naming the secret alone means.
+    assertIdentical(readValue(simAws), "hunter2");
+  });
+
+  it("resolves a version-stage segment to the version carrying that label", async () => {
+    // Given a secret written twice, so an earlier version is AWSPREVIOUS.
+    const simAws = simAwsInEuWest2();
+    const secretsManager = simAws.secretsManager();
+    await secretsManager.createSecret({
+      input: { Name: "api-key", SecretString: "old-key" },
+    });
+    await secretsManager.putSecretValue({
+      input: { SecretId: "api-key", SecretString: "new-key" },
+    });
+
+    // When a template names the previous staging label.
+    await deployReading(
+      simAws,
+      "{{resolve:secretsmanager:api-key:SecretString::AWSPREVIOUS}}",
+    );
+
+    // Then that version's value is read rather than the current one.
+    assertIdentical(readValue(simAws), "old-key");
+  });
+
+  it("resolves a version-id segment to the version it names", async () => {
+    // Given a secret whose first version has a known id.
+    const simAws = simAwsInEuWest2();
+    const secretsManager = simAws.secretsManager();
+    const created = await secretsManager.createSecret({
+      input: { Name: "api-key", SecretString: "old-key" },
+    });
+    await secretsManager.putSecretValue({
+      input: { SecretId: "api-key", SecretString: "new-key" },
+    });
+
+    // When a template names that version id in the last segment.
+    await deployReading(
+      simAws,
+      `{{resolve:secretsmanager:api-key:SecretString:::${String(created.VersionId)}}}`,
+    );
+
+    // Then the version named is read rather than the current one.
+    assertIdentical(readValue(simAws), "old-key");
+  });
+
+  it("reads the Account a full secret ARN names", async () => {
+    // Given a secret in another Account, and one of the same name at home.
+    const simAws = simAwsInEuWest2();
+    await simAws
+      .secretsManager()
+      .createSecret({ input: { Name: "api-key", SecretString: "home-key" } });
+
+    const foreign = await simAws
+      .account(accountIdTwoTwos)
+      .region("eu-west-2")
+      .secretsManager()
+      .createSecret({
+        input: { Name: "api-key", SecretString: "foreign-key" },
+      });
+
+    // When a template reads the other Account's secret by its full ARN.
+    await deployReading(
+      simAws,
+      `{{resolve:secretsmanager:${String(foreign.ARN)}}}`,
+    );
+
+    // Then the value comes from the Account the ARN names.
+    assertIdentical(readValue(simAws), "foreign-key");
+  });
+
+  it("substitutes a reference sitting inside a longer string", async () => {
+    // Given a secret holding a database password.
+    const simAws = simAwsInEuWest2();
+    await simAws.secretsManager().createSecret({
+      input: { Name: "db-password", SecretString: "hunter2" },
+    });
+
+    // When a template wraps the reference in surrounding text.
+    await deployReading(
+      simAws,
+      "postgres://app:{{resolve:secretsmanager:db-password}}@db.internal/app",
+    );
+
+    // Then only the reference is replaced.
+    assertIdentical(
+      readValue(simAws),
+      "postgres://app:hunter2@db.internal/app",
+    );
+  });
+
+  it("resolves two references in one Resource", async () => {
+    // Given a secret holding a username and a password.
+    const simAws = simAwsInEuWest2();
+    await simAws.secretsManager().createSecret({
+      input: {
+        Name: "db-credentials",
+        SecretString: JSON.stringify({ username: "app", password: "hunter2" }),
+      },
+    });
+
+    // When a template reads both keys into one value.
+    await deployReading(simAws, {
+      "Fn::Join": [
+        ":",
+        [
+          "{{resolve:secretsmanager:db-credentials:SecretString:username}}",
+          "{{resolve:secretsmanager:db-credentials:SecretString:password}}",
+        ],
+      ],
+    });
+
+    // Then each reference is replaced with its own key's value.
+    assertIdentical(readValue(simAws), "app:hunter2");
+  });
+
+  it("resolves a reference whose secret name comes from an Fn::Sub variable", async () => {
+    // Given a secret under an environment-specific name.
+    const simAws = simAwsInEuWest2();
+    await simAws.secretsManager().createSecret({
+      input: { Name: "prod-api-key", SecretString: "hunter2" },
+    });
+
+    // When the reference names it through an Fn::Sub variable.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "config-stack",
+      template: {
+        Parameters: { Environment: { Type: "String", Default: "prod" } },
+        Resources: {
+          Read: {
+            Type: "AWS::SSM::Parameter",
+            Properties: {
+              Name: "/myapp/read",
+              Type: "String",
+              Value: {
+                // oxlint-disable-next-line no-template-curly-in-string -- Fn::Sub syntax, not a JavaScript template.
+                "Fn::Sub": "{{resolve:secretsmanager:${Environment}-api-key}}",
+              },
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the substituted name is what Secrets Manager is asked for.
+    assertIdentical(readValue(simAws), "hunter2");
+  });
+});

--- a/src/service/secretsmanager/cfn/dynamic/sim-cfn-secrets-manager-dynamic-reference.iso.test.ts
+++ b/src/service/secretsmanager/cfn/dynamic/sim-cfn-secrets-manager-dynamic-reference.iso.test.ts
@@ -224,6 +224,41 @@ describe("Secrets Manager CloudFormation dynamic references", () => {
     assertIdentical(readValue(simAws), "app:hunter2");
   });
 
+  it("leaves a property written to look like a substitution marker alone", async () => {
+    // Given a secret, and a template writing marker-shaped text of its own.
+    const simAws = simAwsInEuWest2();
+    await simAws
+      .secretsManager()
+      .createSecret({ input: { Name: "api-key", SecretString: "hunter2" } });
+
+    const markerShaped = "\u{E000}dynamic-reference-0\u{E000}";
+
+    // When both sit in the same Resource.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "config-stack",
+      template: {
+        Resources: {
+          Read: {
+            Type: "AWS::SSM::Parameter",
+            Properties: {
+              Name: "/myapp/read",
+              Type: "String",
+              Value: "{{resolve:secretsmanager:api-key}}",
+              Description: markerShaped,
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the secret reaches its own property and nothing else.
+    const parameter = simAws.ssm().findParameter("/myapp/read");
+    assertNonNullable(parameter, "the deployed parameter");
+    assertIdentical(parameter.currentVersion.value.value, "hunter2");
+    assertIdentical(parameter.currentVersion.description, markerShaped);
+  });
+
   it("resolves a reference whose secret name comes from an Fn::Sub variable", async () => {
     // Given a secret under an environment-specific name.
     const simAws = simAwsInEuWest2();

--- a/src/service/secretsmanager/cfn/dynamic/sim-cfn-secrets-manager-json-key.ts
+++ b/src/service/secretsmanager/cfn/dynamic/sim-cfn-secrets-manager-json-key.ts
@@ -1,0 +1,55 @@
+import { SimCfnSecretsManagerReferenceProblem } from "./sim-cfn-secrets-manager-reference-body.js";
+
+/**
+ * One key of a secret holding a JSON object.
+ *
+ * Real CloudFormation refuses a key the secret has no value for. A template
+ * naming a key that has since been renamed fails, where substituting nothing
+ * would have deployed an empty password.
+ */
+export function simCfnSecretsManagerJsonKeyValue(
+  secretString: string,
+  secretId: string,
+  jsonKey: string,
+): string {
+  const parsed = jsonObject(secretString);
+
+  if (parsed === undefined) {
+    throw new SimCfnSecretsManagerReferenceProblem(
+      `and '${secretId}' does not hold a JSON object, so it has no ` +
+        `'${jsonKey}' key`,
+    );
+  }
+
+  const value = parsed.get(jsonKey);
+
+  if (value === undefined) {
+    throw new SimCfnSecretsManagerReferenceProblem(
+      `and '${secretId}' holds no '${jsonKey}' key`,
+    );
+  }
+
+  return typeof value === "string" ? value : JSON.stringify(value);
+}
+
+/**
+ * The secret value read as a JSON object, or nothing where it is not one.
+ *
+ * The keys come back as a map so that a secret naming one of them `__proto__`
+ * reads that key of the secret.
+ */
+function jsonObject(secretString: string): Map<string, unknown> | undefined {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(secretString);
+  } catch {
+    return undefined;
+  }
+
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return undefined;
+  }
+
+  return new Map(Object.entries(parsed));
+}

--- a/src/service/secretsmanager/cfn/dynamic/sim-cfn-secrets-manager-reference-body.ts
+++ b/src/service/secretsmanager/cfn/dynamic/sim-cfn-secrets-manager-reference-body.ts
@@ -1,0 +1,141 @@
+import { isSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { AwsRegionName } from "../../../aws/sim-aws-region.js";
+
+/** How a secret ARN starts, and how many colon-separated parts it has. */
+const arnPrefix = "arn:";
+const arnPartCount = 7;
+
+/** The only secret field a dynamic reference can name. */
+const secretStringField = "SecretString";
+
+/** The segments a reference takes after the secret id. */
+const referenceSegmentCount = 4;
+
+/**
+ * What a reference body could not be read as.
+ *
+ * The message is the middle of the sentence a stand-in value is recorded with,
+ * so it reads as a clause rather than as a sentence of its own.
+ */
+export class SimCfnSecretsManagerReferenceProblem extends Error {
+  public override readonly name = "SimCfnSecretsManagerReferenceProblem";
+}
+
+/**
+ * A reference body read as the five segments CloudFormation documents.
+ */
+export interface SimCfnSecretsManagerReference {
+  /** The secret's friendly name, full ARN or partial ARN. */
+  readonly secretId: string;
+
+  /** The Account and Region a full ARN names, where the body carries one. */
+  readonly scope: SimAwsAccountRegionScope | undefined;
+
+  /** The key of a JSON secret to read, where the body names one. */
+  readonly jsonKey: string | undefined;
+
+  /** The staging label to read, defaulting to AWSCURRENT further down. */
+  readonly versionStage: string | undefined;
+
+  /** The version id to read, which cannot be given alongside a stage. */
+  readonly versionId: string | undefined;
+}
+
+/**
+ * Read a `{{resolve:secretsmanager:...}}` body as its segments.
+ *
+ * CloudFormation documents the body as
+ * `secret-id:secret-string:json-key:version-stage:version-id`, of which only
+ * the secret id is required. A trailing segment left empty means the same as
+ * one left out, so `MySecret::::` and `MySecret` name the same value.
+ *
+ * The secret id is taken first and by shape rather than by splitting the whole
+ * body, because a secret ARN holds colons of its own. An ARN has seven parts,
+ * and the segments after the secret id have none, so splitting from the left
+ * over-splits every reference carrying one.
+ */
+export function parseSimCfnSecretsManagerReference(
+  body: string,
+): SimCfnSecretsManagerReference {
+  const parts = body.split(":");
+  const idPartCount = body.startsWith(arnPrefix) ? arnPartCount : 1;
+  const secretId = parts.slice(0, idPartCount).join(":");
+
+  if (secretId === "") {
+    return refuse("which names no secret");
+  }
+
+  const segments = parts.slice(idPartCount);
+
+  if (segments.length > referenceSegmentCount) {
+    return refuse(
+      `whose body has more than the secret id, secret-string, json-key, ` +
+        `version-stage and version-id a secretsmanager dynamic reference takes`,
+    );
+  }
+
+  const [secretString, jsonKey, versionStage, versionId] = segments.map(given);
+
+  if (secretString !== undefined && secretString !== secretStringField) {
+    return refuse(
+      `whose secret-string segment is '${secretString}', where a ` +
+        `secretsmanager dynamic reference reads ${secretStringField} only`,
+    );
+  }
+
+  if (versionStage !== undefined && versionId !== undefined) {
+    return refuse(
+      `which names both a version stage and a version id, where a ` +
+        `secretsmanager dynamic reference takes one or the other`,
+    );
+  }
+
+  return {
+    secretId,
+    scope: referenceScope(secretId),
+    jsonKey,
+    versionStage,
+    versionId,
+  };
+}
+
+/**
+ * The Account and Region a secret ARN names, for a reference reading another
+ * Account's simulated Secrets Manager.
+ *
+ * Nothing comes back for a friendly name or a partial ARN, which name a secret
+ * in the Stack's own Account and Region.
+ */
+function referenceScope(
+  secretId: string,
+): SimAwsAccountRegionScope | undefined {
+  if (!secretId.startsWith(arnPrefix)) {
+    return undefined;
+  }
+
+  const parts = secretId.split(":");
+
+  if (parts.length !== arnPartCount) {
+    return undefined;
+  }
+
+  const [regionName, accountId] = parts.slice(3);
+
+  if (regionName === undefined || !isSimAwsAccountId(accountId)) {
+    return undefined;
+  }
+
+  return { accountId, regionName: regionName as AwsRegionName };
+}
+
+/**
+ * A segment that was left out and one left empty mean the same thing.
+ */
+function given(segment: string | undefined): string | undefined {
+  return segment === undefined || segment === "" ? undefined : segment;
+}
+
+function refuse(problem: string): never {
+  throw new SimCfnSecretsManagerReferenceProblem(problem);
+}

--- a/src/service/ssm/cfn/dynamic/sim-cfn-ssm-dynamic-reference-best-effort.iso.test.ts
+++ b/src/service/ssm/cfn/dynamic/sim-cfn-ssm-dynamic-reference-best-effort.iso.test.ts
@@ -166,14 +166,11 @@ describe("SSM CloudFormation dynamic references the simulation cannot answer", (
     // When the template is deployed.
     const stack = await deployReading(
       simAws,
-      "{{resolve:secretsmanager:MySecret:SecretString:password}}",
+      "{{resolve:ssm-secure:/myapp/token}}",
     );
 
     // Then the reference is untouched and nothing is recorded about it.
-    assertIdentical(
-      readValue(simAws),
-      "{{resolve:secretsmanager:MySecret:SecretString:password}}",
-    );
+    assertIdentical(readValue(simAws), "{{resolve:ssm-secure:/myapp/token}}");
     assertArrayLength(stack.ignoredProperties, 0);
   });
 });


### PR DESCRIPTION
A `{{resolve:secretsmanager:...}}` reference in a Resource property now reads the simulated Secrets Manager of the Stack's Account and Region while that Resource is created. The whole documented form is read, so a `json-key` segment takes one key of a JSON secret and a `version-stage` or `version-id` segment selects a version, with the empty trailing segments AWS allows meaning the same as leaving them out. A secret ARN naming another Account is read from that Account. Reading a secret decrypts it through simulated KMS, which cannot be done synchronously, so a resolver may now answer with a promise. Such a reference resolves to a marker while the Resource's other properties resolve around it, and the value replaces the marker before the Resource is created. A reference Secrets Manager cannot answer resolves to a stand-in value and is recorded on `stack.ignoredProperties`, keeping the rest of a template deployable.

Resolves #708


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resolving CloudFormation Secrets Manager dynamic references, including secret values, JSON keys, version selectors, and cross-account references.
  * Added fallback handling and diagnostics when references cannot be resolved.
  * Secret values can now be resolved asynchronously during CloudFormation resource deployment.

* **Documentation**
  * Expanded guidance and examples for Secrets Manager dynamic references.
  * Clarified that SSM SecureString references remain unresolved.

* **Bug Fixes**
  * Corrected CloudFormation resource property resolution to apply dynamic-reference values before resource creation, updates, and deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->