### PR TITLE
feat: read SSM parameter value types

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -460,6 +460,12 @@ console.log(
 
 A parameter with no supplied value takes the template default, when the template has one.
 
+A parameter's `Type` is read for the `AWS::SSM::Parameter::Value<...>` types, which hold a Parameter
+Store name and resolve to the value stored under it. See
+[reading a parameter through a template Parameter](../ssm/README.md#reading-a-parameter-through-a-template-parameter).
+Every other type is accepted and its value used as written, with no validation of the value against
+the type.
+
 ## Intrinsic functions
 
 Sim CloudFormation supports common intrinsic functions used by supported resources.
@@ -2193,6 +2199,10 @@ for (const ignored of stack.ignoredProperties) {
   //  are not simulated, ..."
 }
 ```
+
+A template parameter that resolved to a stand-in value is recorded in the same list, with the
+parameter name as the `logicalId`, its declared `Type` as the `resourceType`, and a `path` of
+`Parameters.<parameter name>`. Only the `AWS::SSM::Parameter::Value<...>` types can produce one.
 
 Each entry names the `logicalId` and `resourceType` of the Resource, the `path` to the property, and
 a `reason`. The path is the whole way down, and a setting on one entry of a list says which entry it

--- a/docs/services/ssm/README.md
+++ b/docs/services/ssm/README.md
@@ -455,6 +455,84 @@ naming the property that held the reference and why the value is a stand-in. A v
 never had, a `SecureString`, and a body that is not a name and an optional integer version are all
 recorded the same way.
 
+## Reading a parameter through a template Parameter
+
+A template `Parameters` entry declared as `AWS::SSM::Parameter::Value<String>` is given a parameter
+name, and `Ref` on it gives the value held under that name in the stack's account and region. The
+name comes from the value passed to `CreateStack`, and from the template `Default` when no value is
+passed.
+
+```typescript sim-ssm-template-parameter-value
+/**
+ * Reading configuration into a template through a Parameter Store value type.
+ */
+
+import { PutParameterCommand } from "@aws-sdk/client-ssm";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.ssm().putParameter(
+  new PutParameterCommand({
+    Name: "/myapp/prod/uploads-bucket",
+    Type: "String",
+    Value: "myapp-prod-uploads",
+  }),
+);
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "app-stack",
+  template: {
+    Parameters: {
+      UploadsBucketName: {
+        Type: "AWS::SSM::Parameter::Value<String>",
+        Default: "/myapp/prod/uploads-bucket",
+      },
+    },
+    Resources: {
+      UploadsBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: { Ref: "UploadsBucketName" } },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+// The Bucket was created under the name the parameter holds.
+console.log(simAws.s3().getSimBucketByName("myapp-prod-uploads")?.bucketName);
+// "myapp-prod-uploads"
+```
+
+CDK emits this Parameter from `ssm.StringParameter.valueForStringParameter(scope, name)` called
+without a version, carrying the name as the `Default`.
+
+`AWS::SSM::Parameter::Value<List<String>>` resolves to the stored comma-separated string split into
+a list, which `Fn::Select` then reads by index. `AWS::SSM::Parameter::Value<CommaDelimitedList>`
+resolves the same way. `ssm.StringListParameter.fromListParameterAttributes` without a version emits
+the first of the two.
+
+The `Parameters` section is read before any resource is created, as it is on real AWS. A name a
+resource of the same stack goes on to create is never there in time, whatever the template says
+about `DependsOn`.
+
+The stored value goes unchecked against the inner type. A name held against something other than an
+image ID resolves under `AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>`, where real CloudFormation
+refuses the stack.
+
+### A name the simulation cannot answer
+
+The same best-effort answer a dynamic reference gets. A name Parameter Store has never held resolves
+to `dummy-value-for-<name>`, and the stack carries on deploying. A `SecureString` resolves that way
+too, since real CloudFormation refuses to read one into a template Parameter.
+
+The substitution is recorded on
+[`stack.ignoredProperties`](../cloudformation/README.md#properties-a-resource-was-created-without).
+The `logicalId` names the template Parameter, the `resourceType` gives its declared type, and the
+`path` is `Parameters.<parameter name>`.
+
 ## Reading configuration in a Lambda handler
 
 Function code that reads its configuration on cold start needs no special treatment. Any
@@ -820,6 +898,9 @@ Sim SSM currently supports:
   current value, embedded in a longer string and inside `Fn::Sub`
 - `StringList` parameters read through a dynamic reference as the comma-separated string `Fn::Split`
   then splits
+- `AWS::SSM::Parameter::Value<String>` template parameters, resolving `Ref` to the stored value
+- `AWS::SSM::Parameter::Value<List<String>>` and `<CommaDelimitedList>` template parameters,
+  resolving `Ref` to the stored string split into a list
 - Parameter name validation, including hierarchy depth and the reserved `aws` and `ssm` prefixes
 - Authorization of every operation by simulated IAM, against the real IAM action and ARN
 - Calls made from inside a simulated Lambda handler, authorized as the function's execution role
@@ -864,14 +945,17 @@ Current documented limitations:
 - Every deployment of an `AWS::SSM::Parameter` is a create. A name another stack already used is
   refused. A stack update that changes `Value` deletes the parameter and creates it again, where
   real CloudFormation overwrites it in place, so the parameter's version starts from 1 again.
-- The `AWS::SSM::Parameter::Value<String>` template parameter type is absent. A `Ref` to a parameter
-  declared with it gives the name it was given, where real CloudFormation gives the value stored
-  under that name. Pass the name from `Ref` and read it with `GetParameter`.
+- A template parameter typed as `AWS::SSM::Parameter::Value<...>` is read once, while the
+  `Parameters` section is. Real CloudFormation does the same, so a name that only exists once the
+  stack has deployed resolves to a stand-in value here and fails the stack there.
+- The value a template parameter resolves to goes unvalidated against the inner type. The
+  `AWS::EC2::*` and `AWS::Route53::HostedZone::Id` inner types name EC2 and Route53 resources, which
+  this simulation holds none of.
 - `{{resolve:ssm-secure:...}}` dynamic references are absent. Reading a `SecureString` into a
   template means decrypting it, which the CloudFormation engine has no route to yet.
 - A `{{resolve:ssm:...}}` reference naming a parameter, or a version, that simulated Parameter Store
   has never held resolves to `dummy-value-for-<name>` and records the substitution. Real
-  CloudFormation fails the stack.
+  CloudFormation fails the stack. A template parameter naming one gets the same stand-in value.
 - Public parameters under `/aws/service/...` do not exist, and names under the reserved `aws` and
   `ssm` prefixes are refused, as they are on real AWS.
 - The Parameters and Secrets Lambda extension HTTP endpoint is absent. Handler code has to use the

--- a/docs/services/ssm/sim-ssm-template-parameter-value.example.ts
+++ b/docs/services/ssm/sim-ssm-template-parameter-value.example.ts
@@ -1,0 +1,41 @@
+/**
+ * Reading configuration into a template through a Parameter Store value type.
+ */
+
+import { PutParameterCommand } from "@aws-sdk/client-ssm";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.ssm().putParameter(
+  new PutParameterCommand({
+    Name: "/myapp/prod/uploads-bucket",
+    Type: "String",
+    Value: "myapp-prod-uploads",
+  }),
+);
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "app-stack",
+  template: {
+    Parameters: {
+      UploadsBucketName: {
+        Type: "AWS::SSM::Parameter::Value<String>",
+        Default: "/myapp/prod/uploads-bucket",
+      },
+    },
+    Resources: {
+      UploadsBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: { Ref: "UploadsBucketName" } },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+// The Bucket was created under the name the parameter holds.
+console.log(simAws.s3().getSimBucketByName("myapp-prod-uploads")?.bucketName);
+// "myapp-prod-uploads"

--- a/src/service/cloudformation/README.md
+++ b/src/service/cloudformation/README.md
@@ -238,6 +238,13 @@ resource creation time.
 - template `Parameters` definitions
 - parameter values supplied to `CreateStack`
 - default values from the template
+- values read from simulated Parameter Store for the `AWS::SSM::Parameter::Value<...>` types
+
+A Parameter Store value type is given a parameter name by whichever of the supplied value and the
+default it takes. `store/` reads that name through the `SimCfnParameterStoreReader` a simulated
+service implements, and records a name the store cannot answer as an ignored property of the
+Parameter. A `SimCfnParameters` built with no store, as a template resolved outside a simulation is,
+leaves such a Parameter holding the name it was given.
 
 Parameter resolution happens before runtime `SimCfnResource` objects are created. This means
 resource templates in the stack resource map already have parameter-derived values substituted where

--- a/src/service/cloudformation/command/create-stack/create-stack.handler.ts
+++ b/src/service/cloudformation/command/create-stack/create-stack.handler.ts
@@ -20,6 +20,7 @@ import {
   SimCfnTemplate,
 } from "../../template/sim-cfn-template.js";
 import { SimCfnParameters } from "../../parameters/sim-cfn-parameters.js";
+import { makeSimCfnParameterStore } from "../../parameters/store/sim-cfn-parameter-store.js";
 import type { JSONString } from "../../../../util/type-guard/json.js";
 import type { SimCdkOutContext } from "../../cdk/sim-cdk-out-context.js";
 import type { SimCfnDeployBinding } from "../../bind/sim-cfn-deploy-binding.js";
@@ -97,13 +98,19 @@ export class CreateStackCommandHandler implements CommandHandler<
       );
     }
 
+    const parameters = SimCfnParameters.fromInput(command.input, {
+      stackName,
+      parameterStore: makeSimCfnParameterStore({
+        simAws: this.simAws,
+        accountRegionScope: this.accountRegionScope,
+      }),
+    });
+
     const template = SimCfnTemplate.fromJson(
       command.input.TemplateBody as JSONString<CfnTemplateBodyRecord>,
       {
         stackName,
-        parameters: SimCfnParameters.fromInput(command.input, {
-          stackName,
-        }),
+        parameters,
         accountRegionScope: this.accountRegionScope,
         exports: this.exports,
       },

--- a/src/service/cloudformation/command/update-stack/update-stack.handler.ts
+++ b/src/service/cloudformation/command/update-stack/update-stack.handler.ts
@@ -5,6 +5,7 @@ import type {
   BackgroundScheduler,
 } from "../../../../util/background/background.js";
 import type { JSONString } from "../../../../util/type-guard/json.js";
+import type { SimAws } from "../../../aws/sim-aws.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import type { SimCdkOutContext } from "../../cdk/sim-cdk-out-context.js";
 import type {
@@ -16,6 +17,7 @@ import {
   SimCfnTemplate,
 } from "../../template/sim-cfn-template.js";
 import { SimCfnParameters } from "../../parameters/sim-cfn-parameters.js";
+import { makeSimCfnParameterStore } from "../../parameters/store/sim-cfn-parameter-store.js";
 import { SimCloudFormationValidationError } from "../../error/sim-cloudformation.error.js";
 import type { SimCfnExports } from "../../export/sim-cfn-exports.js";
 import type {
@@ -24,6 +26,7 @@ import type {
 } from "./update-stack.command.js";
 
 interface UpdateStackCommandHandlerProperties {
+  readonly simAws: SimAws;
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly stacks: Map<SimCloudFormationStackName, SimCfnStack>;
   readonly background: BackgroundScheduler & BackgroundCompleter;
@@ -47,6 +50,7 @@ export class UpdateStackCommandHandler implements CommandHandler<
   SimUpdateStackCommand,
   SimUpdateStackCommandOutput
 > {
+  private readonly simAws: SimAws;
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly stacks: Map<SimCloudFormationStackName, SimCfnStack>;
   private readonly background: BackgroundScheduler & BackgroundCompleter;
@@ -54,6 +58,7 @@ export class UpdateStackCommandHandler implements CommandHandler<
   private readonly exports: SimCfnExports | undefined;
 
   constructor(properties: UpdateStackCommandHandlerProperties) {
+    this.simAws = properties.simAws;
     this.accountRegionScope = properties.accountRegionScope;
     this.stacks = properties.stacks;
     this.background = properties.background;
@@ -96,12 +101,20 @@ export class UpdateStackCommandHandler implements CommandHandler<
       );
     }
 
+    const parameters = SimCfnParameters.fromInput(command.input, {
+      stackName,
+      parameterStore: makeSimCfnParameterStore({
+        simAws: this.simAws,
+        accountRegionScope: this.accountRegionScope,
+      }),
+    });
+
     await stack.update(
       SimCfnTemplate.fromJson(
         command.input.TemplateBody as JSONString<CfnTemplateBodyRecord>,
         {
           stackName,
-          parameters: SimCfnParameters.fromInput(command.input, { stackName }),
+          parameters,
           accountRegionScope: this.accountRegionScope,
           exports: this.exports,
         },

--- a/src/service/cloudformation/deploy/sim-cfn-template-deployer.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-template-deployer.ts
@@ -87,6 +87,7 @@ export class SimCloudFormationTemplateDeployer {
     this.background = properties.background;
     this.exports = properties.exports;
     this.templateFileUpdater = new SimCfnTemplateFileUpdater({
+      simAws: this.simAws,
       accountRegionScope: this.accountRegionScope,
       stacks: this.stacks,
       background: this.background,

--- a/src/service/cloudformation/deploy/sim-cfn-template-file-updater.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-template-file-updater.ts
@@ -8,6 +8,7 @@ import {
   SimCfnTemplateFileLoader,
   type SimCloudFormationDeployTemplateFileProperties,
 } from "./sim-cfn-template-file-loader.js";
+import type { SimAws } from "../../aws/sim-aws.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type {
   BackgroundCompleter,
@@ -29,6 +30,7 @@ export interface SimCfnTemplateFileUpdating {
 }
 
 interface SimCfnTemplateFileUpdaterProperties {
+  readonly simAws: SimAws;
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly stacks: Map<SimCloudFormationStackName, SimCfnStack>;
   readonly background: BackgroundScheduler & BackgroundCompleter;
@@ -47,12 +49,14 @@ interface SimCfnTemplateFileUpdaterProperties {
  * re-synthesis rewrites beside the template.
  */
 export class SimCfnTemplateFileUpdater implements SimCfnTemplateFileUpdating {
+  private readonly simAws: SimAws;
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly stacks: Map<SimCloudFormationStackName, SimCfnStack>;
   private readonly background: BackgroundScheduler & BackgroundCompleter;
   private readonly templateFileLoader = new SimCfnTemplateFileLoader();
 
   constructor(properties: SimCfnTemplateFileUpdaterProperties) {
+    this.simAws = properties.simAws;
     this.accountRegionScope = properties.accountRegionScope;
     this.stacks = properties.stacks;
     this.background = properties.background;
@@ -71,6 +75,7 @@ export class SimCfnTemplateFileUpdater implements SimCfnTemplateFileUpdating {
   ): Promise<SimCfnStack> {
     const loaded = await this.templateFileLoader.load(properties);
     const handler = new UpdateStackCommandHandler({
+      simAws: this.simAws,
       accountRegionScope: this.accountRegionScope,
       stacks: this.stacks,
       background: this.background,

--- a/src/service/cloudformation/parameters/sim-cfn-parameter-definitions.ts
+++ b/src/service/cloudformation/parameters/sim-cfn-parameter-definitions.ts
@@ -1,0 +1,32 @@
+import { isRecord } from "../../../util/type-guard/record.js";
+import type {
+  SimCfnParameterDefinition,
+  SimCfnParametersContext,
+} from "./sim-cfn-parameters.type.js";
+
+/**
+ * Read a template `Parameters` section into the definitions of one Stack.
+ *
+ * An entry that is not an object is refused by name. There is nothing a value
+ * expression could read from a definition with no fields, and the template that
+ * wrote one has a shape CloudFormation would refuse too.
+ */
+export function simCfnParameterDefinitions(
+  properties: SimCfnParametersContext,
+): ReadonlyMap<string, SimCfnParameterDefinition> {
+  const definitions = new Map<string, SimCfnParameterDefinition>();
+  const stackName = properties.stackName ?? "unknown";
+  const declared = Object.entries(properties.definitions ?? {});
+
+  for (const [parameterName, definition] of declared) {
+    if (!isRecord(definition)) {
+      throw new Error(
+        `Sim CloudFormation Stack ${stackName} parameter ${parameterName} definition must be an object`,
+      );
+    }
+
+    definitions.set(parameterName, definition);
+  }
+
+  return definitions;
+}

--- a/src/service/cloudformation/parameters/sim-cfn-parameter-input-values.ts
+++ b/src/service/cloudformation/parameters/sim-cfn-parameter-input-values.ts
@@ -1,0 +1,28 @@
+import type {
+  SimCloudFormationParameterInput,
+  SimCloudFormationParameterValues,
+} from "./sim-cfn-parameters.type.js";
+
+/**
+ * Read the Parameter values a CloudFormation command input carries.
+ *
+ * AWS command inputs carry Parameters as an array of key/value objects, while
+ * the Parameters wrapper keys values by Parameter name. An entry missing either
+ * half is left out, having no usable runtime value to contribute.
+ */
+export function simCfnParameterInputValues(
+  input: SimCloudFormationParameterInput,
+): SimCloudFormationParameterValues {
+  const values = new Map<string, string>();
+  const inputParameters = input.Parameters ?? [];
+
+  for (const parameter of inputParameters) {
+    const { ParameterKey: key, ParameterValue: value } = parameter;
+
+    if (key !== undefined && value !== undefined) {
+      values.set(key, value);
+    }
+  }
+
+  return Object.fromEntries(values);
+}

--- a/src/service/cloudformation/parameters/sim-cfn-parameter-values.ts
+++ b/src/service/cloudformation/parameters/sim-cfn-parameter-values.ts
@@ -1,0 +1,65 @@
+import type { SimCfnIgnoredProperty } from "../resource/ignore/sim-cfn-ignored-property.type.js";
+import { SimCfnParameterStoreValues } from "./store/sim-cfn-parameter-store-values.js";
+import type { SimCfnParameterStoreReader } from "./store/sim-cfn-parameter-store.type.js";
+import type {
+  SimCfnParameterDefinition,
+  SimCloudFormationParameterValue,
+  SimCloudFormationParameterValues,
+} from "./sim-cfn-parameters.type.js";
+
+interface SimCfnParameterValuesProperties {
+  readonly definitions: ReadonlyMap<string, SimCfnParameterDefinition>;
+  readonly supplied: SimCloudFormationParameterValues;
+  readonly store?: SimCfnParameterStoreReader | undefined;
+}
+
+/**
+ * The runtime value of every Parameter a Stack was created with.
+ *
+ * Worked out in the order CloudFormation works them out. A value supplied to
+ * the command wins over a template `Default`, and a Parameter declared as a
+ * Parameter Store value type reads whichever of the two it ended up with as the
+ * name to read.
+ */
+export class SimCfnParameterValues {
+  private readonly values: Map<string, SimCloudFormationParameterValue>;
+  private readonly storeValues: SimCfnParameterStoreValues;
+
+  constructor(properties: SimCfnParameterValuesProperties) {
+    const { definitions, supplied, store } = properties;
+
+    this.storeValues = new SimCfnParameterStoreValues({ store });
+    this.values = new Map(Object.entries(supplied));
+
+    this.recordDefaults(definitions);
+    this.storeValues.applyTo(this.values, definitions);
+  }
+
+  /** Every Parameter that resolved to a stand-in value. */
+  public get ignoredProperties(): readonly SimCfnIgnoredProperty[] {
+    return this.storeValues.ignoredProperties;
+  }
+
+  /**
+   * The value of one Parameter, or undefined for a Parameter with no value.
+   */
+  get(parameterName: string): SimCloudFormationParameterValue | undefined {
+    return this.values.get(parameterName);
+  }
+
+  /**
+   * Fill in each Parameter that was supplied no value and declares a string
+   * `Default`.
+   */
+  private recordDefaults(
+    definitions: ReadonlyMap<string, SimCfnParameterDefinition>,
+  ): void {
+    for (const [parameterName, definition] of definitions) {
+      const defaultValue = definition.Default;
+
+      if (typeof defaultValue === "string" && !this.values.has(parameterName)) {
+        this.values.set(parameterName, defaultValue);
+      }
+    }
+  }
+}

--- a/src/service/cloudformation/parameters/sim-cfn-parameters.ts
+++ b/src/service/cloudformation/parameters/sim-cfn-parameters.ts
@@ -1,6 +1,10 @@
-import { isRecord } from "../../../util/type-guard/record.js";
+import { simCfnParameterDefinitions } from "./sim-cfn-parameter-definitions.js";
+import { simCfnParameterInputValues } from "./sim-cfn-parameter-input-values.js";
+import { SimCfnParameterValues } from "./sim-cfn-parameter-values.js";
+import type { SimCfnIgnoredProperty } from "../resource/ignore/sim-cfn-ignored-property.type.js";
 import type {
   SimCfnParameterDefinition,
+  SimCfnParametersContext,
   SimCfnParametersProperties as SimCfnParametersProperties,
   SimCloudFormationParameterInput,
   SimCloudFormationParameterValue,
@@ -14,53 +18,36 @@ import { assertDefined } from "../../../util/type-guard/defined.js";
  * This class keeps the template Parameter definitions and the runtime Parameter
  * values together. Values supplied by command input take precedence, then any
  * missing values are filled from string defaults in the template definitions.
+ *
+ * A Parameter declared as an `AWS::SSM::Parameter::Value<...>` type is given a
+ * parameter name either way, and the value it resolves to is the one simulated
+ * Parameter Store holds under that name.
  */
 export class SimCfnParameters {
-  private readonly definitions = new Map<string, SimCfnParameterDefinition>();
-  private readonly values = new Map<string, SimCloudFormationParameterValue>();
-  private readonly stackName: string | undefined;
+  private readonly definitions: ReadonlyMap<string, SimCfnParameterDefinition>;
+  private readonly values: SimCfnParameterValues;
+  private readonly properties: SimCfnParametersProperties;
 
   constructor(properties: SimCfnParametersProperties = {}) {
-    const { definitions, values = {}, stackName } = properties;
-
-    this.stackName = stackName;
-
-    this.recordDefinitions(definitions);
-    this.recordValues(values);
-    this.recordDefaultValues();
+    this.properties = properties;
+    this.definitions = simCfnParameterDefinitions(properties);
+    this.values = new SimCfnParameterValues({
+      definitions: this.definitions,
+      supplied: properties.values ?? {},
+      store: properties.parameterStore,
+    });
   }
 
   /**
    * Create Parameters from a CloudFormation command-like input object.
-   *
-   * AWS command inputs carry Parameters as an array of key/value objects, while
-   * this wrapper stores values in a map keyed by Parameter name. Incomplete
-   * array entries are ignored because they cannot contribute a usable runtime value.
    */
   static fromInput(
     input: SimCloudFormationParameterInput,
-    properties: Pick<
-      SimCfnParametersProperties,
-      "definitions" | "stackName"
-    > = {},
+    properties: SimCfnParametersContext = {},
   ): SimCfnParameters {
-    const values: SimCloudFormationParameterValues = {};
-
-    const inputParameters = input.Parameters ?? [];
-    for (const parameter of inputParameters) {
-      if (
-        parameter.ParameterKey === undefined ||
-        parameter.ParameterValue === undefined
-      ) {
-        continue;
-      }
-
-      values[parameter.ParameterKey] = parameter.ParameterValue;
-    }
-
     return new SimCfnParameters({
       ...properties,
-      values,
+      values: simCfnParameterInputValues(input),
     });
   }
 
@@ -73,10 +60,7 @@ export class SimCfnParameters {
    */
   static fromValues(
     values: SimCloudFormationParameterValues,
-    properties: Pick<
-      SimCfnParametersProperties,
-      "definitions" | "stackName"
-    > = {},
+    properties: SimCfnParametersContext = {},
   ): SimCfnParameters {
     return new SimCfnParameters({
       ...properties,
@@ -95,11 +79,7 @@ export class SimCfnParameters {
   withDefinitions(
     definitions: Record<string, SimCfnParameterDefinition> | undefined,
   ): SimCfnParameters {
-    return new SimCfnParameters({
-      definitions,
-      values: Object.fromEntries(this.values),
-      stackName: this.stackName,
-    });
+    return new SimCfnParameters({ ...this.properties, definitions });
   }
 
   /**
@@ -115,62 +95,29 @@ export class SimCfnParameters {
   /**
    * Resolve the runtime value for a declared or referenced Parameter.
    *
-   * The returned value may have come from command input or from a string
-   * Default in the template definition. Missing values are treated as
-   * template/runtime errors because a Ref to a Parameter must resolve to a
-   * concrete value.
+   * The returned value may have come from command input, from a string Default
+   * in the template definition, or from simulated Parameter Store. Missing
+   * values are treated as template/runtime errors because a Ref to a Parameter
+   * must resolve to a concrete value.
    */
   value(parameterName: string): SimCloudFormationParameterValue {
     const value = this.values.get(parameterName);
     assertDefined(
       value,
-      `Sim CloudFormation Stack ${this.stackNameLabel()} parameter ${parameterName} is missing a value`,
+      `Sim CloudFormation Stack ${this.properties.stackName ?? "unknown"} parameter ${parameterName} is missing a value`,
     );
 
     return value;
   }
 
-  private recordDefinitions(
-    definitions: Record<string, SimCfnParameterDefinition> | undefined,
-  ): void {
-    if (definitions === undefined) {
-      return;
-    }
-
-    for (const [parameterName, parameterDefinition] of Object.entries(
-      definitions,
-    )) {
-      if (!isRecord(parameterDefinition)) {
-        throw new Error(
-          `Sim CloudFormation Stack ${this.stackNameLabel()} parameter ${parameterName} definition must be an object`,
-        );
-      }
-
-      this.definitions.set(parameterName, parameterDefinition);
-    }
-  }
-
-  private recordValues(values: SimCloudFormationParameterValues): void {
-    for (const [parameterName, parameterValue] of Object.entries(values)) {
-      this.values.set(parameterName, parameterValue);
-    }
-  }
-
-  private recordDefaultValues(): void {
-    for (const [parameterName, parameterDefinition] of this.definitions) {
-      if (this.values.has(parameterName)) {
-        continue;
-      }
-
-      const defaultValue = parameterDefinition.Default;
-
-      if (typeof defaultValue === "string") {
-        this.values.set(parameterName, defaultValue);
-      }
-    }
-  }
-
-  private stackNameLabel(): string {
-    return this.stackName ?? "unknown";
+  /**
+   * Every Parameter that resolved to a stand-in value, and why.
+   *
+   * A Stack reports these alongside the properties its Resources were created
+   * without, since a Parameter holding a stand-in leaves every Resource that
+   * reads it configured with a value the template never asked for.
+   */
+  public get ignoredProperties(): readonly SimCfnIgnoredProperty[] {
+    return this.values.ignoredProperties;
   }
 }

--- a/src/service/cloudformation/parameters/sim-cfn-parameters.type.ts
+++ b/src/service/cloudformation/parameters/sim-cfn-parameters.type.ts
@@ -1,21 +1,22 @@
 import type { SimCfnTemplateValue } from "../template/value/sim-cfn-template-value.js";
+import type { SimCfnParameterStoreReader } from "./store/sim-cfn-parameter-store.type.js";
 
 /**
- * Runtime value for a CloudFormation Parameter after command input and template
- * defaults have been applied.
+ * Runtime value for a CloudFormation Parameter after command input, template
+ * defaults and Parameter Store reads have been applied.
  *
- * The simulator currently supports string Parameter values because AWS
- * CloudFormation command inputs provide ParameterValue as a string.
+ * A Parameter is given its value as a string, because AWS CloudFormation
+ * command inputs provide ParameterValue as one. A Parameter declared as
+ * `AWS::SSM::Parameter::Value<List<String>>` is given a parameter name and
+ * resolves to the stored value split into a list, so a resolved value can be
+ * either.
  */
-export type SimCloudFormationParameterValue = string;
+export type SimCloudFormationParameterValue = string | string[];
 
 /**
- * Normalized Parameter values keyed by CloudFormation Parameter name.
+ * The Parameter values a command supplied, keyed by Parameter name.
  */
-export type SimCloudFormationParameterValues = Record<
-  string,
-  SimCloudFormationParameterValue
->;
+export type SimCloudFormationParameterValues = Record<string, string>;
 
 /**
  * Minimal structural shape accepted from CloudFormation command inputs.
@@ -43,15 +44,37 @@ export interface SimCfnParametersProperties {
   readonly definitions?: Record<string, SimCfnParameterDefinition> | undefined;
   readonly values?: SimCloudFormationParameterValues | undefined;
   readonly stackName?: string | undefined;
+
+  /**
+   * The simulated Parameter Store that a Parameter typed as one of its values
+   * is read from.
+   *
+   * Absent where a template is resolved outside a simulation, which leaves
+   * such a Parameter resolving to the name it was given.
+   */
+  readonly parameterStore?: SimCfnParameterStoreReader | undefined;
 }
+
+/**
+ * What a Parameters wrapper is given about the Stack it belongs to.
+ *
+ * Everything but the values. A caller with command input to normalize passes
+ * the values separately, and a caller reading a template Parameters section has
+ * none to pass at all.
+ */
+export type SimCfnParametersContext = Pick<
+  SimCfnParametersProperties,
+  "definitions" | "stackName" | "parameterStore"
+>;
 
 /**
  * Minimal CloudFormation template Parameter definition understood by the
  * simulator.
  *
  * Most fields are recorded for structural typing/documentation. Runtime
- * behavior currently only applies string Default values when a command does not
- * provide an explicit Parameter value.
+ * behavior applies string Default values when a command does not provide an
+ * explicit Parameter value, and reads an `AWS::SSM::Parameter::Value<...>`
+ * Type from simulated Parameter Store.
  */
 export interface SimCfnParameterDefinition {
   readonly Type?: string | undefined;

--- a/src/service/cloudformation/parameters/store/sim-cfn-parameter-store-value-type.iso.test.ts
+++ b/src/service/cloudformation/parameters/store/sim-cfn-parameter-store-value-type.iso.test.ts
@@ -1,0 +1,82 @@
+import { assertFalse, assertTrue, assertUndefined } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simCfnParameterStoreValueType } from "./sim-cfn-parameter-store-value-type.js";
+
+describe("simCfnParameterStoreValueType", () => {
+  it("reads a String value type as one value", () => {
+    // Given the type CDK emits for a parameter read without a version.
+    const declaredType = "AWS::SSM::Parameter::Value<String>";
+
+    // When the type is read.
+    const valueType = simCfnParameterStoreValueType(declaredType);
+
+    // Then the value it names is a single string.
+    assertFalse(valueType?.list);
+  });
+
+  it("reads a List value type as a list", () => {
+    // Given the type a StringList parameter is read through.
+    const declaredType = "AWS::SSM::Parameter::Value<List<String>>";
+
+    // When the type is read.
+    const valueType = simCfnParameterStoreValueType(declaredType);
+
+    // Then the stored value is to be split into a list.
+    assertTrue(valueType?.list);
+  });
+
+  it("reads a CommaDelimitedList value type as a list", () => {
+    // Given the other list form CloudFormation accepts.
+    const declaredType = "AWS::SSM::Parameter::Value<CommaDelimitedList>";
+
+    // When the type is read.
+    const valueType = simCfnParameterStoreValueType(declaredType);
+
+    // Then it names a list too.
+    assertTrue(valueType?.list);
+  });
+
+  it("reads an EC2 value type as one value", () => {
+    // Given a value type naming an EC2 resource, which simulated Parameter
+    // Store can hold the identifier of without simulating the resource.
+    const declaredType = "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>";
+
+    // When the type is read.
+    const valueType = simCfnParameterStoreValueType(declaredType);
+
+    // Then it is read as the string it is, unvalidated.
+    assertFalse(valueType?.list);
+  });
+
+  it("reads a type holding its own value as no value type", () => {
+    // Given a Parameter whose value is in the template.
+    const declaredType = "CommaDelimitedList";
+
+    // When the type is read.
+    const valueType = simCfnParameterStoreValueType(declaredType);
+
+    // Then nothing is read from Parameter Store for it.
+    assertUndefined(valueType);
+  });
+
+  it("reads an unclosed value type as no value type", () => {
+    // Given a type that names no inner type at all.
+    const declaredType = "AWS::SSM::Parameter::Value<String";
+
+    // When the type is read.
+    const valueType = simCfnParameterStoreValueType(declaredType);
+
+    // Then it is left alone rather than guessed at.
+    assertUndefined(valueType);
+  });
+
+  it("reads a Parameter with no type as no value type", () => {
+    // Given a Parameter definition declaring no Type.
+    // When the missing type is read.
+    const valueType = simCfnParameterStoreValueType(undefined);
+
+    // Then nothing is read from Parameter Store for it.
+    assertUndefined(valueType);
+  });
+});

--- a/src/service/cloudformation/parameters/store/sim-cfn-parameter-store-value-type.ts
+++ b/src/service/cloudformation/parameters/store/sim-cfn-parameter-store-value-type.ts
@@ -1,0 +1,39 @@
+/** The Parameter type that holds a Parameter Store name. */
+const parameterStoreValuePrefix = "AWS::SSM::Parameter::Value<";
+
+/**
+ * A template Parameter type that names a value in Parameter Store.
+ *
+ * The inner type decides the shape the stored value takes, and nothing else.
+ * The value is not checked against it: a name pointing at something other than
+ * an image ID resolves as the string it is, where real CloudFormation would
+ * refuse the Stack.
+ */
+export interface SimCfnParameterStoreValueType {
+  /** Whether the stored value is split into a list of strings. */
+  readonly list: boolean;
+}
+
+/**
+ * Read a declared Parameter `Type` as a Parameter Store value type.
+ *
+ * Undefined for every other type, including the `String` and
+ * `CommaDelimitedList` types that hold their value in the template itself.
+ */
+export function simCfnParameterStoreValueType(
+  declaredType: string | undefined,
+): SimCfnParameterStoreValueType | undefined {
+  if (
+    declaredType === undefined ||
+    !declaredType.startsWith(parameterStoreValuePrefix) ||
+    !declaredType.endsWith(">")
+  ) {
+    return undefined;
+  }
+
+  const innerType = declaredType.slice(parameterStoreValuePrefix.length, -1);
+
+  return {
+    list: innerType === "CommaDelimitedList" || innerType.startsWith("List<"),
+  };
+}

--- a/src/service/cloudformation/parameters/store/sim-cfn-parameter-store-values.iso.test.ts
+++ b/src/service/cloudformation/parameters/store/sim-cfn-parameter-store-values.iso.test.ts
@@ -1,0 +1,39 @@
+import { assertArrayLength, assertObjectMatches } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimCfnTemplate } from "../../template/sim-cfn-template.js";
+
+describe("Parameter Store values outside a simulation", () => {
+  it("leaves a Parameter holding the name it was given", () => {
+    // Given a template resolved with no simulated Parameter Store behind it.
+    const template = new SimCfnTemplate({
+      stackName: "TestStack",
+      template: {
+        Parameters: {
+          BucketNameParameter: {
+            Type: "AWS::SSM::Parameter::Value<String>",
+            Default: "/myapp/bucket-name",
+          },
+        },
+        Resources: {
+          TestBucket: {
+            Type: "AWS::S3::Bucket",
+            Properties: { BucketName: { Ref: "BucketNameParameter" } },
+          },
+        },
+      },
+    });
+
+    // When the Resource templates are read.
+    const resourceTemplates = template.resourceTemplates();
+
+    // Then the Ref resolved to the name, there being nothing to read it from.
+    assertObjectMatches(resourceTemplates[0]?.template, {
+      Type: "AWS::S3::Bucket",
+      Properties: { BucketName: "/myapp/bucket-name" },
+    });
+
+    // And nothing is recorded, since no substitution was made.
+    assertArrayLength(template.parameters.ignoredProperties, 0);
+  });
+});

--- a/src/service/cloudformation/parameters/store/sim-cfn-parameter-store-values.ts
+++ b/src/service/cloudformation/parameters/store/sim-cfn-parameter-store-values.ts
@@ -1,0 +1,113 @@
+import { SimCfnIgnoredProperties } from "../../resource/ignore/sim-cfn-ignored-properties.js";
+import type { SimCfnIgnoredProperty } from "../../resource/ignore/sim-cfn-ignored-property.type.js";
+import type {
+  SimCfnParameterDefinition,
+  SimCloudFormationParameterValue,
+} from "../sim-cfn-parameters.type.js";
+import type { SimCfnParameterStoreReader } from "./sim-cfn-parameter-store.type.js";
+import {
+  simCfnParameterStoreValueType,
+  type SimCfnParameterStoreValueType,
+} from "./sim-cfn-parameter-store-value-type.js";
+
+interface SimCfnParameterStoreValuesProperties {
+  readonly store?: SimCfnParameterStoreReader | undefined;
+}
+
+/** What one Parameter was given, and the value type it was declared as. */
+interface SimCfnParameterStoreName {
+  readonly parameterName: string;
+  readonly definition: SimCfnParameterDefinition;
+  readonly name: string;
+  readonly valueType: SimCfnParameterStoreValueType;
+}
+
+/**
+ * The template Parameters whose value comes from Parameter Store.
+ *
+ * A Parameter declared as `AWS::SSM::Parameter::Value<String>` is given a
+ * parameter name, and resolves to the value held under it. A `List<...>` inner
+ * type resolves to the stored string split on commas, which is the shape
+ * `Fn::Select` and the other list functions take.
+ *
+ * A name the store cannot answer resolves to a stand-in value, and the
+ * substitution is recorded here for the Stack to report. The record is what
+ * makes the stand-in findable. A Parameter holding one leaves every Resource
+ * that read it configured with a value the template never asked for.
+ */
+export class SimCfnParameterStoreValues {
+  private readonly store: SimCfnParameterStoreReader | undefined;
+  private readonly ignored = new SimCfnIgnoredProperties();
+
+  constructor(properties: SimCfnParameterStoreValuesProperties = {}) {
+    this.store = properties.store;
+  }
+
+  /** Every Parameter that resolved to a stand-in value. */
+  public get ignoredProperties(): readonly SimCfnIgnoredProperty[] {
+    return this.ignored.all;
+  }
+
+  /**
+   * Replace the name each Parameter Store value type Parameter was given with
+   * the value the store holds under it.
+   *
+   * Nothing is replaced where there is no store to read. A Parameters wrapper
+   * built outside a simulation has no Parameter Store behind it, and the name
+   * it was given stands as its value.
+   */
+  applyTo(
+    values: Map<string, SimCloudFormationParameterValue>,
+    definitions: ReadonlyMap<string, SimCfnParameterDefinition>,
+  ): void {
+    const store = this.store;
+
+    if (store === undefined) {
+      return;
+    }
+
+    for (const named of this.named(values, definitions)) {
+      values.set(named.parameterName, this.read(store, named));
+    }
+  }
+
+  /**
+   * The Parameters that name a Parameter Store value, and what they name.
+   *
+   * A Parameter with no value at all is left out. A `Ref` to one is refused
+   * where it is read, as a Parameter of any other type with no value is.
+   */
+  private *named(
+    values: ReadonlyMap<string, SimCloudFormationParameterValue>,
+    definitions: ReadonlyMap<string, SimCfnParameterDefinition>,
+  ): Generator<SimCfnParameterStoreName> {
+    for (const [parameterName, definition] of definitions) {
+      const name = values.get(parameterName);
+      const valueType = simCfnParameterStoreValueType(definition.Type);
+
+      if (valueType !== undefined && typeof name === "string") {
+        yield { parameterName, definition, name, valueType };
+      }
+    }
+  }
+
+  /**
+   * Read the value one Parameter's name is held against.
+   */
+  private read(
+    store: SimCfnParameterStoreReader,
+    named: SimCfnParameterStoreName,
+  ): SimCloudFormationParameterValue {
+    const read = store.read(named.name);
+
+    if (read.reason !== undefined) {
+      this.ignored.record(
+        { logicalId: named.parameterName, type: named.definition.Type },
+        `Parameters.${named.parameterName}`,
+        read.reason,
+      );
+    }
+
+    return named.valueType.list ? read.value.split(",") : read.value;
+  }
+}

--- a/src/service/cloudformation/parameters/store/sim-cfn-parameter-store.ts
+++ b/src/service/cloudformation/parameters/store/sim-cfn-parameter-store.ts
@@ -1,0 +1,29 @@
+import type { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimCfnParameterStoreReader } from "./sim-cfn-parameter-store.type.js";
+
+interface MakeSimCfnParameterStoreProperties {
+  readonly simAws: SimAws;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * The simulated Parameter Store a Stack's typed Parameters are read from.
+ *
+ * One Account and Region, the Stack's own, as real CloudFormation reads them.
+ * A Parameter naming configuration held in another Region is a Parameter this
+ * store cannot answer.
+ */
+export function makeSimCfnParameterStore(
+  properties: MakeSimCfnParameterStoreProperties,
+): SimCfnParameterStoreReader {
+  const { simAws, accountRegionScope } = properties;
+
+  return simAws
+    .accountRegionScope(
+      accountRegionScope.accountId,
+      accountRegionScope.regionName,
+    )
+    .ssm()
+    .cfnParameterValueReader();
+}

--- a/src/service/cloudformation/parameters/store/sim-cfn-parameter-store.type.ts
+++ b/src/service/cloudformation/parameters/store/sim-cfn-parameter-store.type.ts
@@ -1,0 +1,29 @@
+/**
+ * What a simulated Parameter Store answered a template Parameter with.
+ *
+ * A reason is set only where the store could not answer the name, in which
+ * case the value is a stand-in. Simulated CloudFormation deploys what it can,
+ * so a Parameter naming configuration a test never created still resolves to
+ * something, and the reason is what the Stack records about it.
+ */
+export interface SimCfnParameterStoreValue {
+  /** The value held under the name, or a stand-in where none is held. */
+  readonly value: string;
+
+  /** Why the value is a stand-in rather than a stored one. */
+  readonly reason?: string | undefined;
+}
+
+/**
+ * The simulated Parameter Store that a template Parameter's name is read from.
+ *
+ * Declared here so that the CloudFormation engine can resolve an
+ * `AWS::SSM::Parameter::Value<...>` Parameter without importing simulated SSM,
+ * the same way it reaches a dynamic reference resolver.
+ */
+export interface SimCfnParameterStoreReader {
+  /**
+   * Read the current value held under one parameter name.
+   */
+  read(name: string): SimCfnParameterStoreValue;
+}

--- a/src/service/cloudformation/sim-cloudformation.ts
+++ b/src/service/cloudformation/sim-cloudformation.ts
@@ -149,6 +149,7 @@ export class SimCloudFormation {
   ): Promise<SimUpdateStackCommandOutput> {
     this.authorization.updateStack(command.input.StackName, options?.caller);
     const handler = new UpdateStackCommandHandler({
+      simAws: this.simAws,
       accountRegionScope: this.accountRegionScope,
       stacks: this.stacks,
       background: this.background,

--- a/src/service/cloudformation/stack/report/sim-cfn-stack-resource-report.ts
+++ b/src/service/cloudformation/stack/report/sim-cfn-stack-resource-report.ts
@@ -1,20 +1,27 @@
 import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
 import type { SimCfnIgnoredProperty } from "../../resource/ignore/sim-cfn-ignored-property.type.js";
+import type { SimCfnTemplate } from "../../template/sim-cfn-template.js";
 
 /**
  * What a Stack's Resources say happened to them.
  *
- * Everything here is read off the Resources rather than collected while the
- * Stack ran, so the Stack and its Resources cannot disagree, and a Stack whose
- * Resources changed under an update reports the Resources it holds now.
+ * Everything here is read off the Resources and the template rather than
+ * collected while the Stack ran, so the Stack and its Resources cannot
+ * disagree, and a Stack whose Resources changed under an update reports the
+ * Resources it holds now.
  *
  * It does not create, delete, or order Resources.
  */
 export class SimCfnStackResourceReport {
   private readonly resources: ReadonlyMap<string, SimCfnResource>;
+  private readonly template: SimCfnTemplate | undefined;
 
-  constructor(resources: ReadonlyMap<string, SimCfnResource>) {
+  constructor(
+    resources: ReadonlyMap<string, SimCfnResource>,
+    template?: SimCfnTemplate,
+  ) {
     this.resources = resources;
+    this.template = template;
   }
 
   /**
@@ -54,13 +61,16 @@ export class SimCfnStackResourceReport {
   }
 
   /**
-   * Every property a Resource was created without acting on.
+   * Every property a Resource was created without acting on, and every template
+   * Parameter that resolved to a stand-in value.
    */
   public get ignoredProperties(): readonly SimCfnIgnoredProperty[] {
-    return this.resources
-      .values()
-      .flatMap((resource) => resource.ignoredProperties)
-      .toArray();
+    return [
+      ...(this.template?.parameters.ignoredProperties ?? []),
+      ...this.resources
+        .values()
+        .flatMap((resource) => resource.ignoredProperties),
+    ];
   }
 
   private matching(

--- a/src/service/cloudformation/stack/sim-cfn-stack.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack.ts
@@ -271,13 +271,13 @@ export class SimCfnStack {
     return this.report.retained;
   }
 
-  /** Every property a Resource was created without acting on. */
+  /** Every property or Parameter that did not reach simulated AWS as written. */
   public get ignoredProperties(): readonly SimCfnIgnoredProperty[] {
     return this.report.ignoredProperties;
   }
 
   private get report(): SimCfnStackResourceReport {
-    return new SimCfnStackResourceReport(this.resources);
+    return new SimCfnStackResourceReport(this.resources, this.cfnTemplate);
   }
 
   private async createResources(): Promise<void> {

--- a/src/service/ssm/README.md
+++ b/src/service/ssm/README.md
@@ -152,7 +152,10 @@ There is no resource policy support, so cross-account access to a parameter cann
   CloudFormation engine reaches through `SimSsm.cfnDynamicReferenceResolver()`. A reference this
   store cannot answer resolves to a stand-in value and is recorded, which is the same best-effort
   answer an unsupported property gets.
-- `{{resolve:ssm-secure:...}}` and the `AWS::SSM::Parameter::Value<String>` template parameter type
-  are still absent.
+- An `AWS::SSM::Parameter::Value<...>` template parameter is read here too.
+  `cfn/parameter/sim-cfn-ssm-parameter-value-reader.ts` holds the reader the CloudFormation engine
+  reaches through `SimSsm.cfnParameterValueReader()`, and a name this store cannot answer gets the
+  same recorded stand-in value a dynamic reference does.
+- `{{resolve:ssm-secure:...}}` is still absent.
 
 The full list is in [docs/services/ssm](../../../docs/services/ssm/).

--- a/src/service/ssm/cfn/parameter/sim-cfn-ssm-parameter-value-best-effort.iso.test.ts
+++ b/src/service/ssm/cfn/parameter/sim-cfn-ssm-parameter-value-best-effort.iso.test.ts
@@ -1,0 +1,133 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCfnIgnoredProperty } from "../../../cloudformation/resource/ignore/sim-cfn-ignored-property.type.js";
+import type { SimCfnStack } from "../../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+const accountIdOneOnes = "111111111111";
+
+function simAwsInEuWest2(): SimAws {
+  return new SimAws({
+    defaultAccountId: accountIdOneOnes,
+    defaultRegionName: "eu-west-2",
+  });
+}
+
+async function deployReading(properties: {
+  readonly simAws: SimAws;
+  readonly type: string;
+  readonly name: string;
+  readonly value: SimCfnTemplateValue;
+}): Promise<SimCfnStack> {
+  const stack = await properties.simAws.cloudFormation().deployTemplate({
+    stackName: "config-stack",
+    template: {
+      Parameters: {
+        DbHostParameter: { Type: properties.type, Default: properties.name },
+      },
+      Resources: {
+        Read: {
+          Type: "AWS::SSM::Parameter",
+          Properties: {
+            Name: "/myapp/read",
+            Type: "String",
+            Value: properties.value,
+          },
+        },
+      },
+    },
+  });
+  await stack.waitForDeployComplete();
+
+  return stack;
+}
+
+function readValue(simAws: SimAws): string {
+  const parameter = simAws.ssm().findParameter("/myapp/read");
+  assertNonNullable(parameter, "the deployed parameter");
+
+  return parameter.currentVersion.value.value;
+}
+
+/**
+ * The one record the Stack made about a template Parameter.
+ */
+function parameterRecord(stack: SimCfnStack): SimCfnIgnoredProperty {
+  const [ignored, ...rest] = stack.ignoredProperties;
+  assertNonNullable(ignored, "a recorded template Parameter");
+  assertArrayLength(rest, 0, "no second record");
+
+  return ignored;
+}
+
+describe("SSM CloudFormation Parameter::Value names the store cannot answer", () => {
+  it("deploys with a stand-in value where the parameter is absent", async () => {
+    // Given nothing in Parameter Store.
+    const simAws = simAwsInEuWest2();
+
+    // When a template Parameter names a parameter that was never created.
+    const stack = await deployReading({
+      simAws,
+      type: "AWS::SSM::Parameter::Value<String>",
+      name: "/myapp/db-host",
+      value: { Ref: "DbHostParameter" },
+    });
+
+    // Then the Stack deploys and the Resource holds a stand-in value.
+    assertIdentical(stack.status, "CREATE_COMPLETE");
+    assertIdentical(readValue(simAws), "dummy-value-for-/myapp/db-host");
+
+    // And the substitution names the Parameter, its type and the name.
+    const ignored = parameterRecord(stack);
+    assertIdentical(ignored.logicalId, "DbHostParameter");
+    assertIdentical(ignored.resourceType, "AWS::SSM::Parameter::Value<String>");
+    assertIdentical(ignored.path, "Parameters.DbHostParameter");
+    assertStringIncludes(ignored.reason, "/myapp/db-host");
+    assertStringIncludes(ignored.reason, "stand-in value");
+  });
+
+  it("deploys with a stand-in value for a SecureString parameter", async () => {
+    // Given an encrypted parameter, which real CloudFormation refuses to read
+    // into a template Parameter.
+    const simAws = simAwsInEuWest2();
+    await simAws.ssm().putParameter({
+      input: { Name: "/myapp/token", Type: "SecureString", Value: "s3cret" },
+    });
+
+    // When a template Parameter names it.
+    const stack = await deployReading({
+      simAws,
+      type: "AWS::SSM::Parameter::Value<String>",
+      name: "/myapp/token",
+      value: { Ref: "DbHostParameter" },
+    });
+
+    // Then the ciphertext stays put and the record says why.
+    assertIdentical(readValue(simAws), "dummy-value-for-/myapp/token");
+    assertStringIncludes(parameterRecord(stack).reason, "SecureString");
+  });
+
+  it("deploys a list Parameter with a stand-in list", async () => {
+    // Given nothing in Parameter Store.
+    const simAws = simAwsInEuWest2();
+
+    // When a list-typed Parameter names a parameter that is not there.
+    const stack = await deployReading({
+      simAws,
+      type: "AWS::SSM::Parameter::Value<List<String>>",
+      name: "/myapp/db-hosts",
+      value: { "Fn::Select": [0, { Ref: "DbHostParameter" }] },
+    });
+
+    // Then the stand-in is a list of one, so the list functions still read it.
+    assertIdentical(readValue(simAws), "dummy-value-for-/myapp/db-hosts");
+    assertStringIncludes(parameterRecord(stack).reason, "/myapp/db-hosts");
+  });
+});

--- a/src/service/ssm/cfn/parameter/sim-cfn-ssm-parameter-value-reader.ts
+++ b/src/service/ssm/cfn/parameter/sim-cfn-ssm-parameter-value-reader.ts
@@ -1,0 +1,70 @@
+import type {
+  SimCfnParameterStoreReader,
+  SimCfnParameterStoreValue,
+} from "../../../cloudformation/parameters/store/sim-cfn-parameter-store.type.js";
+import type { SimSsm } from "../../sim-ssm.js";
+
+interface SimCfnSsmParameterValueReaderProperties {
+  readonly ssm: SimSsm;
+}
+
+/**
+ * Answers an `AWS::SSM::Parameter::Value<...>` template Parameter from the
+ * simulated Parameter Store.
+ *
+ * The Parameter is given a parameter name and resolves to the current value
+ * held under it, as real CloudFormation resolves one while it reads the
+ * template's `Parameters` section. Nothing in the Stack has been created at
+ * that point, so a name another Resource of the same Stack goes on to create
+ * is a name this cannot answer.
+ *
+ * A name with nothing behind it becomes a stand-in value carrying a reason,
+ * which the Stack records. A template reading configuration a test never
+ * created still deploys everything else in it.
+ */
+export class SimCfnSsmParameterValueReader implements SimCfnParameterStoreReader {
+  private readonly ssm: SimSsm;
+
+  constructor(properties: SimCfnSsmParameterValueReaderProperties) {
+    this.ssm = properties.ssm;
+  }
+
+  /**
+   * Read the current value of one parameter.
+   */
+  read(name: string): SimCfnParameterStoreValue {
+    const parameter = this.ssm.findParameter(name);
+
+    if (parameter === undefined) {
+      return this.standIn(
+        name,
+        `which simulated Parameter Store holds no parameter of`,
+      );
+    }
+
+    if (parameter.type.value === "SecureString") {
+      return this.standIn(
+        name,
+        `which is a SecureString, a type real CloudFormation refuses to read ` +
+          `into a template Parameter`,
+      );
+    }
+
+    return { value: parameter.currentVersion.value.value };
+  }
+
+  /**
+   * The value a name Parameter Store could not answer resolves to.
+   *
+   * The shape follows the one a dynamic reference stands in with, so a test
+   * reading either back sees where the value came from.
+   */
+  private standIn(name: string, reason: string): SimCfnParameterStoreValue {
+    return {
+      value: `dummy-value-for-${name}`,
+      reason:
+        `names the Parameter Store parameter '${name}', ${reason}, so the ` +
+        `Parameter resolves to a stand-in value`,
+    };
+  }
+}

--- a/src/service/ssm/cfn/parameter/sim-cfn-ssm-parameter-value-type.iso.test.ts
+++ b/src/service/ssm/cfn/parameter/sim-cfn-ssm-parameter-value-type.iso.test.ts
@@ -1,0 +1,258 @@
+import { assertIdentical, assertNonNullable } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { jsonStringify } from "../../../../util/type-guard/json.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCfnStack } from "../../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+const accountIdOneOnes = "111111111111";
+
+function simAwsInEuWest2(): SimAws {
+  return new SimAws({
+    defaultAccountId: accountIdOneOnes,
+    defaultRegionName: "eu-west-2",
+  });
+}
+
+/**
+ * Deploy one parameter holding whatever the Parameter under test resolves to.
+ *
+ * The template Parameters are given as they would be written, so each test
+ * says which value type it is declaring and what name it is given.
+ */
+async function deployReading(properties: {
+  readonly simAws: SimAws;
+  readonly parameters: Record<string, { Type: string; Default?: string }>;
+  readonly value: SimCfnTemplateValue;
+  readonly names?: Record<string, string> | undefined;
+}): Promise<SimCfnStack> {
+  const stack = await properties.simAws.cloudFormation().deployTemplate({
+    stackName: "config-stack",
+    template: {
+      Parameters: properties.parameters,
+      Resources: {
+        Read: {
+          Type: "AWS::SSM::Parameter",
+          Properties: {
+            Name: "/myapp/read",
+            Type: "String",
+            Value: properties.value,
+          },
+        },
+      },
+    },
+    parameters: properties.names,
+  });
+  await stack.waitForDeployComplete();
+
+  return stack;
+}
+
+function readValue(simAws: SimAws): string {
+  const parameter = simAws.ssm().findParameter("/myapp/read");
+  assertNonNullable(parameter, "the deployed parameter");
+
+  return parameter.currentVersion.value.value;
+}
+
+async function putParameter(
+  simAws: SimAws,
+  name: string,
+  value: string,
+  type = "String",
+): Promise<void> {
+  await simAws.ssm().putParameter({
+    input: { Name: name, Type: type, Value: value },
+  });
+}
+
+/**
+ * The template the update test deploys and then changes, named after whichever
+ * Parameter Store parameter it is reading.
+ */
+function templateNaming(parameterStoreName: string): {
+  Parameters: Record<string, { Type: string; Default: string }>;
+  Resources: Record<string, SimCfnTemplateValue>;
+} {
+  return {
+    Parameters: {
+      DbHostParameter: {
+        Type: "AWS::SSM::Parameter::Value<String>",
+        Default: parameterStoreName,
+      },
+    },
+    Resources: {
+      Read: {
+        Type: "AWS::SSM::Parameter",
+        Properties: {
+          Name: "/myapp/read",
+          Type: "String",
+          Value: { Ref: "DbHostParameter" },
+        },
+      },
+    },
+  };
+}
+
+describe("SSM CloudFormation Parameter::Value template Parameters", () => {
+  it("resolves a Ref to the value the named parameter holds", async () => {
+    // Given a parameter holding a value.
+    const simAws = simAwsInEuWest2();
+    await putParameter(simAws, "/myapp/db-host", "db.internal");
+
+    // When a template Parameter typed as a Parameter Store value names it.
+    await deployReading({
+      simAws,
+      parameters: {
+        DbHostParameter: {
+          Type: "AWS::SSM::Parameter::Value<String>",
+          Default: "/myapp/db-host",
+        },
+      },
+      value: { Ref: "DbHostParameter" },
+    });
+
+    // Then the Ref resolves to the stored value rather than the name.
+    assertIdentical(readValue(simAws), "db.internal");
+  });
+
+  it("resolves to the value the parameter holds now", async () => {
+    // Given a parameter that has been overwritten.
+    const simAws = simAwsInEuWest2();
+    await putParameter(simAws, "/myapp/db-host", "first.internal");
+    await simAws.ssm().putParameter({
+      input: {
+        Name: "/myapp/db-host",
+        Value: "second.internal",
+        Overwrite: true,
+      },
+    });
+
+    // When a template Parameter names it.
+    await deployReading({
+      simAws,
+      parameters: {
+        DbHostParameter: {
+          Type: "AWS::SSM::Parameter::Value<String>",
+          Default: "/myapp/db-host",
+        },
+      },
+      value: { Ref: "DbHostParameter" },
+    });
+
+    // Then the current version is the one read.
+    assertIdentical(readValue(simAws), "second.internal");
+  });
+
+  it("prefers a name given to CreateStack over the template default", async () => {
+    // Given two parameters, one of them named by the template default.
+    const simAws = simAwsInEuWest2();
+    await putParameter(simAws, "/myapp/db-host", "default.internal");
+    await putParameter(simAws, "/myapp/staging/db-host", "staging.internal");
+
+    // When the Stack is created with the other name as the Parameter value.
+    await deployReading({
+      simAws,
+      parameters: {
+        DbHostParameter: {
+          Type: "AWS::SSM::Parameter::Value<String>",
+          Default: "/myapp/db-host",
+        },
+      },
+      value: { Ref: "DbHostParameter" },
+      names: { DbHostParameter: "/myapp/staging/db-host" },
+    });
+
+    // Then the value read is the one the supplied name holds.
+    assertIdentical(readValue(simAws), "staging.internal");
+  });
+
+  it("resolves a List value type to the stored list", async () => {
+    // Given a StringList parameter holding two hosts.
+    const simAws = simAwsInEuWest2();
+    await putParameter(
+      simAws,
+      "/myapp/db-hosts",
+      "first.internal,second.internal",
+      "StringList",
+    );
+
+    // When a list-typed Parameter names it and Fn::Select reads one entry.
+    await deployReading({
+      simAws,
+      parameters: {
+        DbHostsParameter: {
+          Type: "AWS::SSM::Parameter::Value<List<String>>",
+          Default: "/myapp/db-hosts",
+        },
+      },
+      value: { "Fn::Select": [1, { Ref: "DbHostsParameter" }] },
+    });
+
+    // Then the stored string was split into a list to select from.
+    assertIdentical(readValue(simAws), "second.internal");
+  });
+
+  it("resolves a CommaDelimitedList value type to the stored list", async () => {
+    // Given a parameter holding a comma-separated string.
+    const simAws = simAwsInEuWest2();
+    await putParameter(simAws, "/myapp/regions", "eu-west-2,us-east-1");
+
+    // When a CommaDelimitedList-typed Parameter names it.
+    await deployReading({
+      simAws,
+      parameters: {
+        RegionsParameter: {
+          Type: "AWS::SSM::Parameter::Value<CommaDelimitedList>",
+          Default: "/myapp/regions",
+        },
+      },
+      value: { "Fn::Select": [0, { Ref: "RegionsParameter" }] },
+    });
+
+    // Then that string was split the same way.
+    assertIdentical(readValue(simAws), "eu-west-2");
+  });
+
+  it("reads Parameter Store again for a changed template", async () => {
+    // Given a deployed Stack whose Parameter named one of two parameters.
+    const simAws = simAwsInEuWest2();
+    await putParameter(simAws, "/myapp/db-host", "db.internal");
+    await putParameter(simAws, "/myapp/replica-host", "replica.internal");
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "config-stack",
+      template: templateNaming("/myapp/db-host"),
+    });
+
+    // When an update names the other one.
+    await simAws.cloudFormation().updateStack({
+      input: {
+        StackName: "config-stack",
+        TemplateBody: jsonStringify(templateNaming("/myapp/replica-host")),
+      },
+    });
+    await stack.waitForUpdateComplete();
+
+    // Then the Resource holds the value the new name is held against.
+    assertIdentical(readValue(simAws), "replica.internal");
+  });
+
+  it("leaves a Parameter of another type holding the value it was given", async () => {
+    // Given a parameter whose name a plain String Parameter carries.
+    const simAws = simAwsInEuWest2();
+    await putParameter(simAws, "/myapp/db-host", "db.internal");
+
+    // When the template Parameter is not a Parameter Store value type.
+    await deployReading({
+      simAws,
+      parameters: {
+        DbHostName: { Type: "String", Default: "/myapp/db-host" },
+      },
+      value: { Ref: "DbHostName" },
+    });
+
+    // Then nothing is read, and the Ref resolves to the name as written.
+    assertIdentical(readValue(simAws), "/myapp/db-host");
+  });
+});

--- a/src/service/ssm/sim-ssm.ts
+++ b/src/service/ssm/sim-ssm.ts
@@ -20,6 +20,7 @@ import { SimSsmPutParameter } from "./command/parameter/sim-ssm-put-parameter.js
 import type * as simSsmCommands from "./command/sim-ssm-command.types.js";
 import { SimSsmCfnResourceFactory } from "./cfn/sim-cfn-ssm-resource-factory.js";
 import { SimCfnSsmDynamicReferenceResolver } from "./cfn/dynamic/sim-cfn-ssm-dynamic-reference-resolver.js";
+import { SimCfnSsmParameterValueReader } from "./cfn/parameter/sim-cfn-ssm-parameter-value-reader.js";
 import type { SimSsmParameter } from "./parameter/sim-ssm-parameter.js";
 import { SimSsmParameterEncryption } from "./parameter/sim-ssm-parameter-encryption.js";
 import type { SimSsmKmsCrypto } from "./parameter/sim-ssm-kms-crypto.js";
@@ -210,6 +211,13 @@ export class SimSsm {
    */
   cfnDynamicReferenceResolver(): SimCfnSsmDynamicReferenceResolver {
     return new SimCfnSsmDynamicReferenceResolver({ ssm: this });
+  }
+
+  /**
+   * Get the reader for `AWS::SSM::Parameter::Value<...>` template Parameters.
+   */
+  cfnParameterValueReader(): SimCfnSsmParameterValueReader {
+    return new SimCfnSsmParameterValueReader({ ssm: this });
   }
 
   /**


### PR DESCRIPTION
A template Parameter declared as `AWS::SSM::Parameter::Value<String>` now resolves `Ref` to the value simulated Parameter Store holds under the name it was given, taking that name from a CreateStack parameter value ahead of the template `Default`. A `List<...>` or `CommaDelimitedList` inner type resolves to the stored comma-separated string split into a list, which `Fn::Select` reads by index. A name the store cannot answer, and a `SecureString` that real CloudFormation refuses to read into a template Parameter, resolve to a stand-in value recorded on `stack.ignoredProperties` under the Parameter that named it, so a template reading configuration a test never created still deploys. Working out the values moved out of `SimCfnParameters` into collaborators of its own, to keep the file under the FTA threshold that reading the store would otherwise have pushed it past.

Resolves #706
