### PR TITLE
docs: shorten long docs titles

### DIFF
--- a/docs/lint/README.md
+++ b/docs/lint/README.md
@@ -1,4 +1,4 @@
-# Linting CloudFront Functions JS2
+# Linting CFF JS2
 
 CloudFront Functions run JS2, ECMAScript 5.1 with a named subset of ES 6 to 12 on top, rather than
 a current JavaScript engine. A class or a `for...of` is a syntax error, and CloudFront refuses the

--- a/docs/serve/README.md
+++ b/docs/serve/README.md
@@ -1,4 +1,4 @@
-# Serving simulated AWS on localhost
+# Localhost server
 
 Serving puts a simulated AWS environment behind a real port. A browser, `curl` or an SDK client then
 reaches it over HTTP. The same request path is also available in the process with no port at all,

--- a/docs/services/cloudwatch/README.md
+++ b/docs/services/cloudwatch/README.md
@@ -1,4 +1,4 @@
-# Simulated CloudWatch metrics and alarms
+# Simulated CloudWatch Metrics
 
 Yulin includes a simulated Amazon CloudWatch for tests and local development. It holds custom
 metrics. Those are the datapoints `PutMetricData` publishes, and the statistics


### PR DESCRIPTION
Brief, concise description of the change:

<!-- CodeRabbit will fill in a more detailed description once this is open. -->

<!-- If there is an issue, link it here:
     Resolves https://github.com/KensioSoftware/yulin/issues/N -->

- [ ] Conventional commit message, used as the title

- [ ] Conventional branch name, like `feat/concise-description`
- [ ] Full check with `pnpm run check` passed
- [ ] Rebased off latest main
- [ ] User-facing behaviour is documented in `docs/`

See https://www.conventionalcommits.org/en/v1.0.0/

<!-- One exception to that spec: no `!` in the title and no `BREAKING CHANGE:`
     footer. Major versions are published by hand here, so the release run
     refuses one rather than shipping it. -->
