### PR TITLE
fix: attach a CFN Managed Policy to its Roles

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -2368,6 +2368,12 @@ Each service's own docs describe what its resource types support.
   `stack.inertResources` instead, and are listed under
   [resources deliberately left out](#resources-deliberately-left-out). Read both when accounting for
   every resource in a template.
+- `AWS::IAM::ManagedPolicy` is created from `ManagedPolicyName`, `Path`, `Description`,
+  `PolicyDocument` and `Roles`. Every `Roles` entry names a Role in the Stack's Account, and the
+  created policy is attached to each of them. An entry naming no simulated Role fails the resource,
+  as an `AWS::IAM::Policy` naming one does. `Users` and `Groups` fail the resource, because neither
+  can hold a managed policy attachment in the simulation. Deleting the stack takes the policy off
+  the Roles still carrying it before deleting the policy itself.
 - `AWS::Logs::LogGroup` is created, including the one CDK writes for a custom resource provider. That
   one is left empty, because the provider is never invoked. A log group a stack declares for a
   Lambda function is the same group that function writes to, and a group already there is taken over

--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -671,6 +671,11 @@ inline policy. That is the shape CDK grants such as `bucket.grantRead(fn)` synth
 "DefaultPolicy" resource. IAM Users and Groups are not simulated as policy principals. Naming one
 fails the creation outright.
 
+An `AWS::IAM::ManagedPolicy` also carries `Roles`, and attaches itself to each Role it names as it
+is created (the attachment `AttachRolePolicy` records). A name no simulated Role in the Account
+answers to fails the resource. Deleting the stack takes the policy back off the Roles still
+carrying it, and then deletes the policy.
+
 ```typescript sim-iam-cloudformation
 /**
  * Creating IAM resources through simulated CloudFormation.
@@ -717,6 +722,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
         Type: "AWS::IAM::ManagedPolicy",
         Properties: {
           ManagedPolicyName: "ReadOnlyAccess",
+          Roles: [{ Ref: "ServiceRole" }],
           PolicyDocument: {
             Version: "2012-10-17",
             Statement: {
@@ -760,7 +766,8 @@ console.log(roleOut.Role.Arn);
 For `AWS::IAM::Role`, `Ref` returns the Role name and `Fn::GetAtt` supports `Arn` and `RoleId`. For
 `AWS::IAM::ManagedPolicy`, `Ref` returns the Policy ARN. Both resource types default their name to
 the logical ID when it is omitted, and inline `Policies` declared on a Role are stored as the
-Role's inline policies.
+Role's inline policies. The `ReadOnlyAccess` policy above is attached to `LambdaExecutionRole`.
+Authorization for that Role reads the policy document the template gave it.
 
 ## Accounts
 

--- a/docs/services/iam/sim-iam-cloudformation.example.ts
+++ b/docs/services/iam/sim-iam-cloudformation.example.ts
@@ -43,6 +43,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
         Type: "AWS::IAM::ManagedPolicy",
         Properties: {
           ManagedPolicyName: "ReadOnlyAccess",
+          Roles: [{ Ref: "ServiceRole" }],
           PolicyDocument: {
             Version: "2012-10-17",
             Statement: {

--- a/src/service/iam/cfn/managed-policy/sim-cfn-iam-managed-policy-attacher.ts
+++ b/src/service/iam/cfn/managed-policy/sim-cfn-iam-managed-policy-attacher.ts
@@ -1,0 +1,108 @@
+import type { SimArn } from "../../../aws/arn.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimIam } from "../../sim-iam.js";
+import type { SimIamRoleName } from "../../role/sim-iam-role.js";
+import { SimIamNoSuchEntity } from "../../error/sim-iam.error.js";
+
+interface SimCfnIamManagedPolicyAttacherProperties {
+  readonly iam: SimIam;
+}
+
+/**
+ * Attaches a CloudFormation-created Managed Policy to the principals its
+ * Resource names.
+ *
+ * `Roles` names the Roles the policy is attached to as it is created, which is
+ * the attachment AttachRolePolicy records. `Users` and `Groups` name
+ * principals with nowhere to hold a managed policy attachment here, and both
+ * fail the Resource. Dropping the grant a template asked for without saying so
+ * would be misleading.
+ */
+export class SimCfnIamManagedPolicyAttacher {
+  private readonly iam: SimIam;
+
+  constructor(properties: SimCfnIamManagedPolicyAttacherProperties) {
+    this.iam = properties.iam;
+  }
+
+  /**
+   * The Roles an AWS::IAM::ManagedPolicy Resource attaches itself to. Role
+   * Refs are resolved to Role names before creation, so entries arrive as
+   * plain strings.
+   *
+   * A name no simulated Role answers to fails the Resource before the policy
+   * is created. Checking afterwards would leave a policy behind with nothing
+   * attached to it.
+   */
+  roleNames(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): readonly SimIamRoleName[] {
+    this.rejectUnsimulatedPrincipals(resource, properties);
+
+    const roles = properties["Roles"];
+
+    if (roles === undefined) {
+      return [];
+    }
+
+    if (!Array.isArray(roles)) {
+      throw new TypeError(
+        `Invalid AWS::IAM::ManagedPolicy ${resource.logicalId}: Roles must be an array`,
+      );
+    }
+
+    return roles.map((roleName) => this.roleName(resource, roleName));
+  }
+
+  /**
+   * Attach the created Managed Policy to each of the Roles.
+   */
+  async attach(
+    policyArn: SimArn,
+    roleNames: readonly SimIamRoleName[],
+  ): Promise<void> {
+    await Promise.all(
+      roleNames.map(async (roleName) =>
+        this.iam.attachRolePolicy({
+          input: { RoleName: roleName, PolicyArn: policyArn },
+        }),
+      ),
+    );
+  }
+
+  private roleName(
+    resource: SimCfnResource,
+    roleName: unknown,
+  ): SimIamRoleName {
+    if (typeof roleName !== "string") {
+      throw new TypeError(
+        `Invalid AWS::IAM::ManagedPolicy ${resource.logicalId}: Roles entries must be strings`,
+      );
+    }
+
+    const simRoleName = roleName as SimIamRoleName;
+
+    if (!this.iam.roles.has(simRoleName)) {
+      throw new SimIamNoSuchEntity(`No IAM Role with name ${roleName}`);
+    }
+
+    return simRoleName;
+  }
+
+  private rejectUnsimulatedPrincipals(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): void {
+    for (const principalProperty of ["Users", "Groups"]) {
+      // oxlint-disable-next-line security/detect-object-injection -- fixed property names.
+      if (properties[principalProperty] !== undefined) {
+        throw new TypeError(
+          `Invalid AWS::IAM::ManagedPolicy ${resource.logicalId}: ` +
+            `${principalProperty} are not simulated`,
+        );
+      }
+    }
+  }
+}

--- a/src/service/iam/cfn/managed-policy/sim-cfn-iam-managed-policy-attachment.iso.test.ts
+++ b/src/service/iam/cfn/managed-policy/sim-cfn-iam-managed-policy-attachment.iso.test.ts
@@ -1,0 +1,143 @@
+import { GetObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+  assertBufferEqual,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { Readable } from "node:stream";
+import { describe, it } from "vitest";
+
+import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { makeAwsRegionName } from "../../../aws/sim-aws-region.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../error/sim-iam.error.js";
+import type { SimIamManagedPolicy } from "../../policy/sim-iam-policy.js";
+import type { SimIamRole } from "../../role/sim-iam-role.js";
+import { simS3BodyToBuffer } from "../../../s3/storage/s3-body-buffer.js";
+
+/**
+ * The `Roles` property of an AWS::IAM::ManagedPolicy names the Roles the
+ * created policy is attached to, and the attachment is what carries the policy
+ * into an authorization decision made for one of those Roles.
+ */
+describe("IAM CloudFormation ManagedPolicy Role attachment", () => {
+  it("attaches a stack Managed Policy to the Role its Roles property names", async () => {
+    // Given a stack whose Role and Managed Policy are declared together, with
+    // the policy naming the Role in its Roles property.
+    const accountId = makeSimAwsAccountId();
+    const region = makeAwsRegionName();
+    const simAws = new SimAws();
+    const scopedAws = simAws.account(accountId).region(region);
+
+    const stack = await scopedAws.cloudFormation().deployTemplate({
+      stackName: "attached-managed-policy-stack",
+      template: {
+        Resources: {
+          ArchiveBucket: {
+            Type: "AWS::S3::Bucket",
+            Properties: { BucketName: "archive-bucket" },
+          },
+          ClosedBucket: {
+            Type: "AWS::S3::Bucket",
+            Properties: { BucketName: "closed-bucket" },
+          },
+          ArchiveReaderRole: {
+            Type: "AWS::IAM::Role",
+            Properties: {
+              RoleName: "ArchiveReader",
+              AssumeRolePolicyDocument: {
+                Version: "2012-10-17",
+                Statement: {
+                  Effect: "Allow",
+                  Principal: { Service: "lambda.amazonaws.com" },
+                  Action: "sts:AssumeRole",
+                },
+              },
+            },
+          },
+          ArchiveReadPolicy: {
+            Type: "AWS::IAM::ManagedPolicy",
+            Properties: {
+              ManagedPolicyName: "ArchiveReadPolicy",
+              Roles: [{ Ref: "ArchiveReaderRole" }],
+              PolicyDocument: {
+                Version: "2012-10-17",
+                Statement: [
+                  {
+                    Effect: "Allow",
+                    Action: "s3:GetObject",
+                    Resource: {
+                      "Fn::Join": [
+                        "",
+                        [{ "Fn::GetAtt": ["ArchiveBucket", "Arn"] }, "/*"],
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const simS3 = scopedAws.s3();
+
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "archive-bucket",
+        Key: "ledger.json",
+        Body: '{"entries":3}',
+      }),
+    );
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "closed-bucket",
+        Key: "ledger.json",
+        Body: '{"entries":0}',
+      }),
+    );
+
+    // Then the Stack attached the policy to the Role it named.
+    const policyResource = stack.getResource("ArchiveReadPolicy");
+    const roleResource = stack.getResource("ArchiveReaderRole");
+
+    assertNonNullable(policyResource);
+    assertNonNullable(roleResource);
+
+    const policy = policyResource.simResource as SimIamManagedPolicy;
+    const role = roleResource.simResource as SimIamRole;
+
+    assertTrue(role.attachedPolicyArns.has(policy.arn));
+
+    // When the Role reads an Object from the Bucket the attached policy names.
+    const roleArn = `arn:aws:iam::${accountId}:role/ArchiveReader`;
+
+    const output = await simS3.getObject(
+      new GetObjectCommand({ Bucket: "archive-bucket", Key: "ledger.json" }),
+      { caller: { kind: "arn", arn: roleArn } },
+    );
+
+    // Then IAM allows it on the strength of the attachment the Stack made.
+    assertInstanceOf(output.Body, Readable);
+    assertBufferEqual(
+      await simS3BodyToBuffer(output.Body),
+      Buffer.from('{"entries":3}'),
+    );
+
+    // But the same Role is denied the Bucket the policy does not name.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.getObject(
+        new GetObjectCommand({ Bucket: "closed-bucket", Key: "ledger.json" }),
+        { caller: { kind: "arn", arn: roleArn } },
+      ),
+    );
+
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "s3:GetObject");
+    assertIdentical(error.resource, "arn:aws:s3:::closed-bucket/ledger.json");
+  });
+});

--- a/src/service/iam/cfn/managed-policy/sim-cfn-iam-managed-policy-creator.ts
+++ b/src/service/iam/cfn/managed-policy/sim-cfn-iam-managed-policy-creator.ts
@@ -2,6 +2,7 @@ import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-re
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimIam } from "../../sim-iam.js";
 import type { SimIamManagedPolicy } from "../../policy/sim-iam-policy.js";
+import { SimCfnIamManagedPolicyAttacher } from "./sim-cfn-iam-managed-policy-attacher.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
 
 interface SimCfnIamManagedPolicyCreatorProperties {
@@ -13,9 +14,11 @@ interface SimCfnIamManagedPolicyCreatorProperties {
  */
 export class SimCfnIamManagedPolicyCreator {
   private readonly iam: SimIam;
+  private readonly attacher: SimCfnIamManagedPolicyAttacher;
 
   constructor(properties: SimCfnIamManagedPolicyCreatorProperties) {
     this.iam = properties.iam;
+    this.attacher = new SimCfnIamManagedPolicyAttacher({ iam: properties.iam });
   }
 
   /**
@@ -25,6 +28,7 @@ export class SimCfnIamManagedPolicyCreator {
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
   ): Promise<SimIamManagedPolicy> {
+    const roleNames = this.attacher.roleNames(resource, properties);
     const policyName = this.managedPolicyName(resource, properties);
     const path = this.path(resource, properties);
     const description = this.description(resource, properties);
@@ -44,6 +48,8 @@ export class SimCfnIamManagedPolicyCreator {
       policy,
       `Sim IAM Managed Policy ${policyCreation.Policy.Arn} after CloudFormation creation`,
     );
+
+    await this.attacher.attach(policy.arn, roleNames);
 
     return policy;
   }

--- a/src/service/iam/cfn/managed-policy/sim-cfn-iam-managed-policy-validation.iso.test.ts
+++ b/src/service/iam/cfn/managed-policy/sim-cfn-iam-managed-policy-validation.iso.test.ts
@@ -1,7 +1,23 @@
-import { assertInstanceOf, assertThrowsErrorAsync } from "@kensio/smartass";
+import {
+  assertArrayLength,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamNoSuchEntity } from "../../error/sim-iam.error.js";
+
+const readObjectsDocument = {
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Action: "s3:GetObject",
+      Resource: "*",
+    },
+  ],
+};
 
 describe("IAM CloudFormation ManagedPolicy validation", () => {
   it("requires a PolicyDocument", async () => {
@@ -131,5 +147,169 @@ describe("IAM CloudFormation ManagedPolicy validation", () => {
     });
 
     assertInstanceOf(error, TypeError);
+  });
+
+  it("rejects a Users entry", async () => {
+    // Given a CloudFormation template attaching a Managed Policy to a User.
+    const simAws = new SimAws();
+
+    // When / then deploying the template throws.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "iam-managed-policy-users-stack",
+        template: {
+          Resources: {
+            UserPolicy: {
+              Type: "AWS::IAM::ManagedPolicy",
+              Properties: {
+                ManagedPolicyName: "UserPolicy",
+                Users: ["reporting-user"],
+                PolicyDocument: readObjectsDocument,
+              },
+            },
+          },
+        },
+      });
+    });
+
+    assertInstanceOf(error, TypeError);
+  });
+
+  it("rejects a Groups entry", async () => {
+    // Given a CloudFormation template attaching a Managed Policy to a Group.
+    const simAws = new SimAws();
+
+    // When / then deploying the template throws.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "iam-managed-policy-groups-stack",
+        template: {
+          Resources: {
+            GroupPolicy: {
+              Type: "AWS::IAM::ManagedPolicy",
+              Properties: {
+                ManagedPolicyName: "GroupPolicy",
+                Groups: ["reporting-group"],
+                PolicyDocument: readObjectsDocument,
+              },
+            },
+          },
+        },
+      });
+    });
+
+    assertInstanceOf(error, TypeError);
+  });
+
+  it("rejects a non-array Roles", async () => {
+    // Given a CloudFormation template whose Roles is a bare string.
+    const simAws = new SimAws();
+
+    // When / then deploying the template throws.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "iam-managed-policy-roles-scalar-stack",
+        template: {
+          Resources: {
+            ScalarRolesPolicy: {
+              Type: "AWS::IAM::ManagedPolicy",
+              Properties: {
+                ManagedPolicyName: "ScalarRolesPolicy",
+                Roles: "reporting-role",
+                PolicyDocument: readObjectsDocument,
+              },
+            },
+          },
+        },
+      });
+    });
+
+    assertInstanceOf(error, TypeError);
+  });
+
+  it("rejects a non-string Roles entry", async () => {
+    // Given a CloudFormation template whose Roles entry is a number.
+    const simAws = new SimAws();
+
+    // When / then deploying the template throws.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "iam-managed-policy-roles-entry-stack",
+        template: {
+          Resources: {
+            NumericRolesPolicy: {
+              Type: "AWS::IAM::ManagedPolicy",
+              Properties: {
+                ManagedPolicyName: "NumericRolesPolicy",
+                Roles: [42],
+                PolicyDocument: readObjectsDocument,
+              },
+            },
+          },
+        },
+      });
+    });
+
+    assertInstanceOf(error, TypeError);
+  });
+
+  it("rejects a Roles entry naming no simulated Role", async () => {
+    // Given a CloudFormation template naming a Role that was never created.
+    const simAws = new SimAws();
+
+    // When / then deploying the template throws.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "iam-managed-policy-missing-role-stack",
+        template: {
+          Resources: {
+            MissingRolePolicy: {
+              Type: "AWS::IAM::ManagedPolicy",
+              Properties: {
+                ManagedPolicyName: "MissingRolePolicy",
+                Roles: ["absent-role"],
+                PolicyDocument: readObjectsDocument,
+              },
+            },
+          },
+        },
+      });
+    });
+
+    assertInstanceOf(error, SimIamNoSuchEntity);
+  });
+
+  it("leaves no Managed Policy behind when a Roles entry fails the Resource", async () => {
+    // Given a CloudFormation template naming a Role that was never created.
+    const simAws = new SimAws();
+
+    // When deploying the template throws.
+    await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "iam-managed-policy-no-orphan-stack",
+        template: {
+          Resources: {
+            OrphanCheckPolicy: {
+              Type: "AWS::IAM::ManagedPolicy",
+              Properties: {
+                ManagedPolicyName: "OrphanCheckPolicy",
+                Roles: ["absent-role"],
+                PolicyDocument: readObjectsDocument,
+              },
+            },
+          },
+        },
+      });
+    });
+
+    // Then the Managed Policy the Resource would have created is not there.
+    const listOutput = await simAws.iam().listPolicies({ input: {} });
+
+    assertArrayLength(
+      listOutput.Policies.filter(
+        (policy) => policy.PolicyName === "OrphanCheckPolicy",
+      ),
+      0,
+    );
   });
 });

--- a/src/service/iam/cfn/sim-cfn-iam-resource-deleter.ts
+++ b/src/service/iam/cfn/sim-cfn-iam-resource-deleter.ts
@@ -1,3 +1,4 @@
+import type { SimArn } from "../../aws/arn.js";
 import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimIam } from "../sim-iam.js";
@@ -57,7 +58,30 @@ export class SimCfnIamResourceDeleter {
       `sim IAM Managed Policy for CloudFormation Resource ${resource.logicalId}`,
     );
 
+    await this.detachManagedPolicy(policy.arn);
     await this.iam.deletePolicy({ input: { PolicyArn: policy.arn } });
+  }
+
+  /**
+   * Take the Managed Policy off every Role still carrying it.
+   *
+   * DeletePolicy refuses a policy anything is attached to, and an
+   * AWS::IAM::ManagedPolicy attaches itself to the Roles its `Roles` property
+   * names. A Role the same Stack created gives the policy up as its own
+   * Resource is deleted. A Role declared outside the Stack keeps it. This
+   * clears whatever attachments are left either way.
+   */
+  private async detachManagedPolicy(policyArn: SimArn): Promise<void> {
+    await Promise.all(
+      this.iam.roles
+        .values()
+        .filter((role) => role.attachedPolicyArns.has(policyArn))
+        .map(async (role) =>
+          this.iam.detachRolePolicy({
+            input: { RoleName: role.roleName, PolicyArn: policyArn },
+          }),
+        ),
+    );
   }
 
   /**

--- a/src/service/iam/cfn/sim-cfn-iam-teardown.iso.test.ts
+++ b/src/service/iam/cfn/sim-cfn-iam-teardown.iso.test.ts
@@ -133,4 +133,92 @@ describe("IAM CloudFormation Resource teardown", () => {
       "DELETE_COMPLETE",
     );
   });
+
+  it("deletes a Managed Policy the Stack attached to a Role it also created", async () => {
+    // Given a Stack whose Managed Policy names the Role the Stack created, so
+    // the policy is attached the moment it exists. IAM refuses DeletePolicy
+    // while an attachment is live.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "attached-policy-stack",
+      template: {
+        Resources: {
+          WorkerRole: {
+            Type: "AWS::IAM::Role",
+            Properties: {
+              RoleName: "worker-role",
+              AssumeRolePolicyDocument: assumeRolePolicyDocument,
+            },
+          },
+          WorkerReadPolicy: {
+            Type: "AWS::IAM::ManagedPolicy",
+            Properties: {
+              ManagedPolicyName: "worker-read",
+              Roles: [{ Ref: "WorkerRole" }],
+              PolicyDocument: readObjectsDocument,
+            },
+          },
+        },
+      },
+    });
+
+    const role = stack.resources.get("WorkerRole")?.simResource as
+      | SimIamRole
+      | undefined;
+    assertSetSize(role?.attachedPolicyArns, 1);
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then both the Managed Policy and the Role it was attached to are gone.
+    assertIdentical(
+      stack.resources.get("WorkerReadPolicy")?.status,
+      "DELETE_COMPLETE",
+    );
+    assertUndefined(simAws.iam().roles.get(role.roleName));
+    assertMapSize(simAws.iam().policies, 0);
+  });
+
+  it("takes a Managed Policy off a Role that outlives the Stack", async () => {
+    // Given a Role declared outside the Stack, so nothing else takes the
+    // Managed Policy off it as the Stack is torn down.
+    const simAws = new SimAws();
+    await simAws.iam().createRole({
+      input: {
+        RoleName: "standing-worker",
+        AssumeRolePolicyDocument: JSON.stringify(assumeRolePolicyDocument),
+      },
+    });
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "standing-role-policy-stack",
+      template: {
+        Resources: {
+          StandingReadPolicy: {
+            Type: "AWS::IAM::ManagedPolicy",
+            Properties: {
+              ManagedPolicyName: "standing-read",
+              Roles: ["standing-worker"],
+              PolicyDocument: readObjectsDocument,
+            },
+          },
+        },
+      },
+    });
+
+    const role = simAws.iam().roles.get("standing-worker" as never);
+    assertSetSize(role?.attachedPolicyArns, 1);
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then the attachment is off the Role, which is still there, and the
+    // Managed Policy is deleted.
+    assertSetSize(role.attachedPolicyArns, 0);
+    assertIdentical(
+      stack.resources.get("StandingReadPolicy")?.status,
+      "DELETE_COMPLETE",
+    );
+    assertMapSize(simAws.iam().policies, 0);
+  });
 });


### PR DESCRIPTION
`AWS::IAM::ManagedPolicy` carries `Roles`, `Users` and `Groups`. The creator read none of them, and a Stack reached `CREATE_COMPLETE` with the policy attached to nobody while sim IAM went on denying what the template granted. Each `Roles` entry now names a Role in the Stack Account, and the created policy is attached to it with `AttachRolePolicy`. An entry naming no simulated Role fails the Resource, as one does under `AWS::IAM::Policy`, and a `Users` or `Groups` entry fails it as well. `DeletePolicy` refuses a policy with a live attachment, so Stack teardown takes the policy off every Role still carrying it before deleting it.

Resolves #724