### PR TITLE
feat: create sim IAM Users from CloudFormation

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -2339,7 +2339,7 @@ The resource types it creates are:
 - `AWS::DynamoDB::Table` and `AWS::DynamoDB::GlobalTable`
 - `AWS::ECR::Repository`
 - `AWS::Events::EventBus` and `AWS::Events::Rule`, with the rule's inline `Targets`
-- `AWS::IAM::Role`, `AWS::IAM::ManagedPolicy` and `AWS::IAM::Policy`
+- `AWS::IAM::Role`, `AWS::IAM::User`, `AWS::IAM::ManagedPolicy` and `AWS::IAM::Policy`
 - `AWS::KMS::Key` and `AWS::KMS::Alias`
 - `AWS::Lambda::Function`, `AWS::Lambda::Url` and `AWS::Lambda::Permission`
 - `AWS::Logs::LogGroup`

--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -360,6 +360,14 @@ console.log(decision.caller.arn);
 Invalid credentials throw an AWS-like error before any policies are evaluated, with a diagnostic
 reason such as an unknown access key, a secret access key mismatch, or an expired session.
 
+`AttachUserPolicyCommand` attaches a managed Policy to a User by ARN, the way
+`AttachRolePolicyCommand` does for a Role. An ARN with no stored Policy behind it, such as an
+AWS-managed one, attaches and contributes no statements to a decision.
+
+`CreateLoginProfileCommand` gives a User a console password. The response describes the profile
+without the password, which is how real IAM behaves. See
+[CloudFormation Users](#users) for reading the password back out of the simulator.
+
 ## STS AssumeRole sessions
 
 Simulated STS issues temporary credentials for IAM Roles with `AssumeRoleCommand`. The assume
@@ -663,13 +671,13 @@ action, resource, and caller for diagnostics, before the service mutates any sta
 caller defaults to the Account root. The Account root is allowed within its own Account, and a test
 that never mentions IAM keeps working.
 
-## CloudFormation Roles and Managed Policies
+## CloudFormation IAM resources
 
-Sim CloudFormation can create IAM resources from `AWS::IAM::Role`, `AWS::IAM::ManagedPolicy`, and
-`AWS::IAM::Policy`. An `AWS::IAM::Policy` puts its document onto each Role named in `Roles` as an
-inline policy. That is the shape CDK grants such as `bucket.grantRead(fn)` synthesize as a
-"DefaultPolicy" resource. IAM Users and Groups are not simulated as policy principals. Naming one
-fails the creation outright.
+Sim CloudFormation can create IAM resources from `AWS::IAM::Role`, `AWS::IAM::User`,
+`AWS::IAM::ManagedPolicy`, and `AWS::IAM::Policy`. An `AWS::IAM::Policy` puts its document onto each
+Role named in `Roles` as an inline policy. That is the shape CDK grants such as
+`bucket.grantRead(fn)` synthesize as a "DefaultPolicy" resource. A `Users` or `Groups` property on
+an `AWS::IAM::Policy` fails the creation outright.
 
 ```typescript sim-iam-cloudformation
 /**
@@ -761,6 +769,103 @@ For `AWS::IAM::Role`, `Ref` returns the Role name and `Fn::GetAtt` supports `Arn
 `AWS::IAM::ManagedPolicy`, `Ref` returns the Policy ARN. Both resource types default their name to
 the logical ID when it is omitted, and inline `Policies` declared on a Role are stored as the
 Role's inline policies.
+
+### Users
+
+An `AWS::IAM::User` creates a User in the Stack's Account. `UserName` names it and falls back to the
+Resource logical ID. `Path`, the inline `Policies` list and `ManagedPolicyArns` work as they do on a
+Role, and both policy forms reach the authorization decision made for that User. `Ref` returns the
+User name and `Fn::GetAtt` supports `Arn` and `UserId`.
+
+`LoginProfile` gives the User a console password, the way real CloudFormation calls
+`CreateLoginProfile`. The profile records the password, its creation date and
+`PasswordResetRequired`. Real IAM never reads a password back, and neither does the simulator. A
+test asserting on the password reads the User record from `SimIam.users`.
+
+Group membership is a gap. A `Groups` entry fails the Resource. An empty list still deploys, and CDK
+leaves `Groups` out of the template for a User that belongs to no group.
+
+```typescript sim-iam-cloudformation-user
+/**
+ * Creating an IAM User through simulated CloudFormation.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "iam-user-stack",
+  template: {
+    Resources: {
+      ReportsReadPolicy: {
+        Type: "AWS::IAM::ManagedPolicy",
+        Properties: {
+          ManagedPolicyName: "ReportsReadPolicy",
+          PolicyDocument: {
+            Version: "2012-10-17",
+            Statement: {
+              Effect: "Allow",
+              Action: "s3:GetObject",
+              Resource: "arn:aws:s3:::reports-bucket/*",
+            },
+          },
+        },
+      },
+      ReportPublisher: {
+        Type: "AWS::IAM::User",
+        Properties: {
+          UserName: "ReportPublisher",
+          Path: "/application/",
+          ManagedPolicyArns: [{ Ref: "ReportsReadPolicy" }],
+          Policies: [
+            {
+              PolicyName: "WriteReports",
+              PolicyDocument: {
+                Version: "2012-10-17",
+                Statement: {
+                  Effect: "Allow",
+                  Action: "s3:PutObject",
+                  Resource: "arn:aws:s3:::reports-bucket/*",
+                },
+              },
+            },
+          ],
+          LoginProfile: {
+            Password: "initial-console-password",
+            PasswordResetRequired: true,
+          },
+        },
+      },
+    },
+    Outputs: {
+      UserArn: {
+        Value: {
+          "Fn::GetAtt": ["ReportPublisher", "Arn"],
+        },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+const simIam = simAws.iam();
+
+const decision = simIam.authorize({
+  action: "s3:PutObject",
+  resource: "arn:aws:s3:::reports-bucket/2026/summary.csv",
+  caller: { kind: "arn", arn: stack.output("UserArn") },
+});
+
+console.log(decision.isAllowed);
+
+const user = simIam.users
+  .values()
+  .find((each) => each.userName === "ReportPublisher");
+
+console.log(user?.loginProfile?.passwordResetRequired);
+```
 
 ## Accounts
 
@@ -942,7 +1047,8 @@ Sim IAM currently supports:
 - `PutRolePolicyCommand`, for inline Role policies
 - `CreatePolicyCommand`, `GetPolicyCommand` and `ListPoliciesCommand`, for managed Policies
 - `AttachRolePolicyCommand`
-- `CreateUserCommand` and `PutUserPolicyCommand`
+- `CreateUserCommand`, `PutUserPolicyCommand` and `AttachUserPolicyCommand`
+- `CreateLoginProfileCommand`, for a User's console password
 - `CreateAccessKeyCommand`, registering access keys for credential authentication
 - Allow/deny authorization decisions with `authorize(...)`, evaluating identity policies,
   service-supplied resource policies, and policy conditions with explicit-deny precedence
@@ -952,7 +1058,8 @@ Sim IAM currently supports:
   `x-sim-aws-source-arn` and `x-sim-aws-source-account`
 - Temporary Role sessions through simulated STS `AssumeRoleCommand`, evaluated against Role trust
   policies
-- The `AWS::IAM::Role`, `AWS::IAM::ManagedPolicy` and `AWS::IAM::Policy` CloudFormation resources
+- The `AWS::IAM::Role`, `AWS::IAM::User`, `AWS::IAM::ManagedPolicy` and `AWS::IAM::Policy`
+  CloudFormation resources
 
 Unsupported IAM options may be ignored or may throw errors depending on whether the simulator needs
 them to model the requested behaviour.
@@ -961,6 +1068,8 @@ them to model the requested behaviour.
 
 Sim IAM models the policy behaviour that multi-service tests most commonly need. Notable gaps:
 
+- Groups are absent. An `AWS::IAM::User` naming one fails, and an `AWS::IAM::Policy` naming one
+  fails too
 - Permissions boundaries, session policies, and service control policies are not evaluated
 - Managed Policies have a single version, and the policy version commands are absent
 - Deleting and detaching resources (Roles, Users, Policies, access keys) is not yet supported

--- a/docs/services/iam/sim-iam-cloudformation-user.example.ts
+++ b/docs/services/iam/sim-iam-cloudformation-user.example.ts
@@ -1,0 +1,79 @@
+/**
+ * Creating an IAM User through simulated CloudFormation.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "iam-user-stack",
+  template: {
+    Resources: {
+      ReportsReadPolicy: {
+        Type: "AWS::IAM::ManagedPolicy",
+        Properties: {
+          ManagedPolicyName: "ReportsReadPolicy",
+          PolicyDocument: {
+            Version: "2012-10-17",
+            Statement: {
+              Effect: "Allow",
+              Action: "s3:GetObject",
+              Resource: "arn:aws:s3:::reports-bucket/*",
+            },
+          },
+        },
+      },
+      ReportPublisher: {
+        Type: "AWS::IAM::User",
+        Properties: {
+          UserName: "ReportPublisher",
+          Path: "/application/",
+          ManagedPolicyArns: [{ Ref: "ReportsReadPolicy" }],
+          Policies: [
+            {
+              PolicyName: "WriteReports",
+              PolicyDocument: {
+                Version: "2012-10-17",
+                Statement: {
+                  Effect: "Allow",
+                  Action: "s3:PutObject",
+                  Resource: "arn:aws:s3:::reports-bucket/*",
+                },
+              },
+            },
+          ],
+          LoginProfile: {
+            Password: "initial-console-password",
+            PasswordResetRequired: true,
+          },
+        },
+      },
+    },
+    Outputs: {
+      UserArn: {
+        Value: {
+          "Fn::GetAtt": ["ReportPublisher", "Arn"],
+        },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+const simIam = simAws.iam();
+
+const decision = simIam.authorize({
+  action: "s3:PutObject",
+  resource: "arn:aws:s3:::reports-bucket/2026/summary.csv",
+  caller: { kind: "arn", arn: stack.output("UserArn") },
+});
+
+console.log(decision.isAllowed);
+
+const user = simIam.users
+  .values()
+  .find((each) => each.userName === "ReportPublisher");
+
+console.log(user?.loginProfile?.passwordResetRequired);

--- a/src/service/cloudformation/resource/cfn/iam/sim-iam-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/iam/sim-iam-cfn-value-adapter.ts
@@ -1,7 +1,9 @@
 import type { SimIamManagedPolicy } from "../../../../iam/policy/sim-iam-policy.js";
 import type { SimIamRole } from "../../../../iam/role/sim-iam-role.js";
+import type { SimIamUser } from "../../../../iam/user/sim-iam-user.js";
 import { SimIamManagedPolicyCfn } from "./sim-iam-managed-policy-cfn.js";
 import { SimIamRoleCfn } from "./sim-iam-role-cfn.js";
+import { SimIamUserCfn } from "./sim-iam-user-cfn.js";
 import type {
   SimCfnResourceValueAdapterProperties,
   SimCfnServiceValueAdapter,
@@ -21,6 +23,10 @@ export function iamValueAdapter(
 
   if (properties.type === "AWS::IAM::Role") {
     return new SimIamRoleCfn({ role: properties.simResource as SimIamRole });
+  }
+
+  if (properties.type === "AWS::IAM::User") {
+    return new SimIamUserCfn({ user: properties.simResource as SimIamUser });
   }
 
   return undefined;

--- a/src/service/cloudformation/resource/cfn/iam/sim-iam-user-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/iam/sim-iam-user-cfn.ts
@@ -1,0 +1,45 @@
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimIamUser } from "../../../../iam/user/sim-iam-user.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimIamUserCfnProperties {
+  readonly user: SimIamUser;
+}
+
+/**
+ * CloudFormation-facing behaviour for an AWS::IAM::User Resource.
+ *
+ * Keeps IAM user objects free of CloudFormation intrinsic-function concerns
+ * while exposing the correct Ref and Fn::GetAtt values.
+ */
+export class SimIamUserCfn implements SimCfnResourceValueAdapter {
+  private readonly user: SimIamUser;
+
+  constructor(properties: SimIamUserCfnProperties) {
+    this.user = properties.user;
+  }
+
+  /**
+   * CloudFormation Ref for AWS::IAM::User returns the user name.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.user.userName;
+  }
+
+  /**
+   * CloudFormation attributes for AWS::IAM::User.
+   *
+   * AWS::IAM::User supports Fn::GetAtt for Arn and UserId.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    if (attributeName === "Arn") {
+      return this.user.arn;
+    }
+
+    if (attributeName === "UserId") {
+      return this.user.userId;
+    }
+
+    return `${this.user.arn}.${attributeName}`;
+  }
+}

--- a/src/service/iam/cfn/role/sim-cfn-iam-role-properties-parser.ts
+++ b/src/service/iam/cfn/role/sim-cfn-iam-role-properties-parser.ts
@@ -1,16 +1,16 @@
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import {
-  SimCfnIamRolePoliciesParser,
-  type SimCfnIamRoleInlinePolicy,
-} from "./sim-cfn-iam-role-policies-parser.js";
+  SimCfnIamPoliciesParser,
+  type SimCfnIamInlinePolicy,
+} from "../sim-cfn-iam-policies-parser.js";
 
 export interface SimCfnIamRoleProperties {
   readonly roleName: string;
   readonly path: string | undefined;
   readonly description: string | undefined;
   readonly assumeRolePolicyDocument: string;
-  readonly inlinePolicies: readonly SimCfnIamRoleInlinePolicy[];
+  readonly inlinePolicies: readonly SimCfnIamInlinePolicy[];
   readonly managedPolicyArns: readonly string[];
 }
 
@@ -22,7 +22,9 @@ export interface SimCfnIamRoleProperties {
  * orchestrating IAM command calls.
  */
 export class SimCfnIamRolePropertiesParser {
-  private readonly policiesParser = new SimCfnIamRolePoliciesParser();
+  private readonly policiesParser = new SimCfnIamPoliciesParser({
+    resourceType: "AWS::IAM::Role",
+  });
 
   /**
    * Parse the resolved CloudFormation properties for an AWS::IAM::Role.

--- a/src/service/iam/cfn/sim-cfn-iam-policies-parser.ts
+++ b/src/service/iam/cfn/sim-cfn-iam-policies-parser.ts
@@ -1,26 +1,40 @@
-import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
-import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
 
-export interface SimCfnIamRoleInlinePolicy {
+export interface SimCfnIamInlinePolicy {
   readonly policyName: string;
   readonly policyDocument: string;
 }
 
+interface SimCfnIamPoliciesParserProperties {
+  /**
+   * The Resource type being parsed, for error messages.
+   */
+  readonly resourceType: string;
+}
+
 /**
- * Parses the AWS::IAM::Role policy collection properties: the inline `Policies`
- * list and the attached `ManagedPolicyArns` list.
+ * Parses the policy collection properties an IAM identity Resource carries:
+ * the inline `Policies` list and the attached `ManagedPolicyArns` list.
  *
- * These list-shaped properties carry the bulk of the Role property validation,
- * so grouping them here keeps the main Role props parser small.
+ * AWS::IAM::Role and AWS::IAM::User declare both in the same shape, and these
+ * list-shaped properties carry the bulk of the property validation, so
+ * grouping them here keeps each identity's own props parser small.
  */
-export class SimCfnIamRolePoliciesParser {
+export class SimCfnIamPoliciesParser {
+  private readonly resourceType: string;
+
+  constructor(properties: SimCfnIamPoliciesParserProperties) {
+    this.resourceType = properties.resourceType;
+  }
+
   /**
    * Parse the inline `Policies` property into normalised inline policies.
    */
   inlinePolicies(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
-  ): readonly SimCfnIamRoleInlinePolicy[] {
+  ): readonly SimCfnIamInlinePolicy[] {
     const policies = properties["Policies"];
 
     if (policies === undefined) {
@@ -29,7 +43,7 @@ export class SimCfnIamRolePoliciesParser {
 
     if (!Array.isArray(policies)) {
       throw new TypeError(
-        `Invalid AWS::IAM::Role ${resource.logicalId}: Policies must be an array`,
+        `Invalid ${this.resourceType} ${resource.logicalId}: Policies must be an array`,
       );
     }
 
@@ -51,14 +65,14 @@ export class SimCfnIamRolePoliciesParser {
 
     if (!Array.isArray(managedPolicyArns)) {
       throw new TypeError(
-        `Invalid AWS::IAM::Role ${resource.logicalId}: ManagedPolicyArns must be an array`,
+        `Invalid ${this.resourceType} ${resource.logicalId}: ManagedPolicyArns must be an array`,
       );
     }
 
     return managedPolicyArns.map((arn) => {
       if (typeof arn !== "string") {
         throw new TypeError(
-          `Invalid AWS::IAM::Role ${resource.logicalId}: each ManagedPolicyArns entry must be a string`,
+          `Invalid ${this.resourceType} ${resource.logicalId}: each ManagedPolicyArns entry must be a string`,
         );
       }
 
@@ -69,14 +83,14 @@ export class SimCfnIamRolePoliciesParser {
   private inlinePolicy(
     resource: SimCfnResource,
     policy: SimCfnTemplateValueRecord[string] | undefined,
-  ): SimCfnIamRoleInlinePolicy {
+  ): SimCfnIamInlinePolicy {
     if (
       typeof policy !== "object" ||
       policy === null ||
       Array.isArray(policy)
     ) {
       throw new TypeError(
-        `Invalid AWS::IAM::Role ${resource.logicalId}: each Policies entry must be an object`,
+        `Invalid ${this.resourceType} ${resource.logicalId}: each Policies entry must be an object`,
       );
     }
 
@@ -84,7 +98,7 @@ export class SimCfnIamRolePoliciesParser {
 
     if (typeof policyName !== "string") {
       throw new TypeError(
-        `Invalid AWS::IAM::Role ${resource.logicalId}: Policies entry PolicyName must be a string`,
+        `Invalid ${this.resourceType} ${resource.logicalId}: Policies entry PolicyName must be a string`,
       );
     }
 
@@ -96,7 +110,7 @@ export class SimCfnIamRolePoliciesParser {
       Array.isArray(policyDocument)
     ) {
       throw new TypeError(
-        `Invalid AWS::IAM::Role ${resource.logicalId}: Policies entry PolicyDocument must be an object`,
+        `Invalid ${this.resourceType} ${resource.logicalId}: Policies entry PolicyDocument must be an object`,
       );
     }
 

--- a/src/service/iam/cfn/sim-cfn-iam-resource-factory.ts
+++ b/src/service/iam/cfn/sim-cfn-iam-resource-factory.ts
@@ -7,6 +7,7 @@ import type { SimIam } from "../sim-iam.js";
 import { SimCfnIamManagedPolicyCreator } from "./managed-policy/sim-cfn-iam-managed-policy-creator.js";
 import { SimCfnIamPolicyCreator } from "./policy/sim-cfn-iam-policy-creator.js";
 import { SimCfnIamRoleCreator } from "./role/sim-cfn-iam-role-creator.js";
+import { SimCfnIamUserCreator } from "./user/sim-cfn-iam-user-creator.js";
 import { SimCfnIamResourceDeleter } from "./sim-cfn-iam-resource-deleter.js";
 import type { SimCloudFormationResourceDeleteContext } from "../../cloudformation/resource/sim-cfn-resource.type.js";
 
@@ -17,12 +18,14 @@ export class SimIamCloudFormationResourceFactory implements SimCfnServiceResourc
   private readonly managedPolicyCreator: SimCfnIamManagedPolicyCreator;
   private readonly policyCreator: SimCfnIamPolicyCreator;
   private readonly roleCreator: SimCfnIamRoleCreator;
+  private readonly userCreator: SimCfnIamUserCreator;
   private readonly deleter: SimCfnIamResourceDeleter;
 
   constructor(iam: SimIam) {
     this.managedPolicyCreator = new SimCfnIamManagedPolicyCreator({ iam });
     this.policyCreator = new SimCfnIamPolicyCreator({ iam });
     this.roleCreator = new SimCfnIamRoleCreator({ iam });
+    this.userCreator = new SimCfnIamUserCreator({ iam });
     this.deleter = new SimCfnIamResourceDeleter({ iam });
   }
 
@@ -50,6 +53,12 @@ export class SimIamCloudFormationResourceFactory implements SimCfnServiceResourc
       }
       case "Role": {
         return await this.roleCreator.create(
+          resource,
+          context.resolvedProperties ?? resource.properties,
+        );
+      }
+      case "User": {
+        return await this.userCreator.create(
           resource,
           context.resolvedProperties ?? resource.properties,
         );

--- a/src/service/iam/cfn/user/sim-cfn-iam-user-authz.iso.test.ts
+++ b/src/service/iam/cfn/user/sim-cfn-iam-user-authz.iso.test.ts
@@ -1,0 +1,208 @@
+import { GetObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+  assertBufferEqual,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { Readable } from "node:stream";
+import { describe, it } from "vitest";
+
+import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../error/sim-iam.error.js";
+import type { SimIamUser } from "../../user/sim-iam-user.js";
+import { simS3BodyToBuffer } from "../../../s3/storage/s3-body-buffer.js";
+
+/**
+ * End-to-end authorization test for a CloudFormation-created IAM User.
+ *
+ * Both permission paths a User declares in a template are exercised against
+ * real requests: the inline `Policies` list, and the Managed Policies named by
+ * `ManagedPolicyArns`. Each policy's resource ARN comes from another stack
+ * resource through Fn::GetAtt, so intrinsic resolution feeds the same IAM
+ * evaluation that decides an S3 request made as that User.
+ */
+describe("IAM CloudFormation User driven authorization", () => {
+  it("allows the User to read Objects only from the Bucket its inline policy names", async () => {
+    // Given a stack with two Buckets and a User whose inline policy grants read
+    // access scoped to one Bucket's CloudFormation Fn::GetAtt Arn.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws();
+    const scopedAws = simAws.account(accountId).region("eu-west-2");
+
+    const stack = await scopedAws.cloudFormation().deployTemplate({
+      stackName: "iam-user-authz-stack",
+      template: {
+        Resources: {
+          ReportsBucket: {
+            Type: "AWS::S3::Bucket",
+            Properties: {
+              BucketName: "reports-bucket",
+            },
+          },
+          OtherBucket: {
+            Type: "AWS::S3::Bucket",
+            Properties: {
+              BucketName: "other-bucket",
+            },
+          },
+          ReportsReaderUser: {
+            Type: "AWS::IAM::User",
+            Properties: {
+              UserName: "ReportsReaderUser",
+              Policies: [
+                {
+                  PolicyName: "ReadReports",
+                  PolicyDocument: {
+                    Version: "2012-10-17",
+                    Statement: [
+                      {
+                        Effect: "Allow",
+                        Action: "s3:GetObject",
+                        Resource: {
+                          "Fn::Join": [
+                            "",
+                            [{ "Fn::GetAtt": ["ReportsBucket", "Arn"] }, "/*"],
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    const simS3 = scopedAws.s3();
+
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "reports-bucket",
+        Key: "daily.json",
+        Body: '{"status":"complete"}',
+      }),
+    );
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "other-bucket",
+        Key: "secret.json",
+        Body: '{"visibility":"private"}',
+      }),
+    );
+
+    const userResource = stack.getResource("ReportsReaderUser");
+
+    assertNonNullable(userResource);
+
+    const user = userResource.simResource as SimIamUser;
+
+    // When the User reads an Object from the Bucket its inline policy names.
+    const output = await simS3.getObject(
+      new GetObjectCommand({ Bucket: "reports-bucket", Key: "daily.json" }),
+      { caller: { kind: "arn", arn: user.arn } },
+    );
+
+    // Then IAM allows it, using the CloudFormation-resolved Bucket ARN.
+    assertInstanceOf(output.Body, Readable);
+    assertBufferEqual(
+      await simS3BodyToBuffer(output.Body),
+      Buffer.from('{"status":"complete"}'),
+    );
+
+    // But the same User is denied access to the Bucket not named by the policy.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.getObject(
+        new GetObjectCommand({ Bucket: "other-bucket", Key: "secret.json" }),
+        { caller: { kind: "arn", arn: user.arn } },
+      ),
+    );
+
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "s3:GetObject");
+    assertIdentical(error.resource, "arn:aws:s3:::other-bucket/secret.json");
+  });
+
+  it("grants access through a stack Managed Policy referenced by ManagedPolicyArns", async () => {
+    // Given a stack with a Bucket, a Managed Policy scoped to that Bucket, and a
+    // User that attaches the Managed Policy through ManagedPolicyArns.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws();
+    const scopedAws = simAws.account(accountId).region("eu-west-2");
+
+    const stack = await scopedAws.cloudFormation().deployTemplate({
+      stackName: "iam-user-managed-policy-authz-stack",
+      template: {
+        Resources: {
+          ReportsBucket: {
+            Type: "AWS::S3::Bucket",
+            Properties: {
+              BucketName: "reports-bucket",
+            },
+          },
+          ReportsReadPolicy: {
+            Type: "AWS::IAM::ManagedPolicy",
+            Properties: {
+              ManagedPolicyName: "ReportsReadPolicy",
+              PolicyDocument: {
+                Version: "2012-10-17",
+                Statement: [
+                  {
+                    Effect: "Allow",
+                    Action: "s3:GetObject",
+                    Resource: {
+                      "Fn::Join": [
+                        "",
+                        [{ "Fn::GetAtt": ["ReportsBucket", "Arn"] }, "/*"],
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          },
+          ReportsReaderUser: {
+            Type: "AWS::IAM::User",
+            Properties: {
+              UserName: "ReportsReaderUser",
+              ManagedPolicyArns: [{ Ref: "ReportsReadPolicy" }],
+            },
+          },
+        },
+      },
+    });
+
+    const simS3 = scopedAws.s3();
+
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "reports-bucket",
+        Key: "daily.json",
+        Body: '{"status":"complete"}',
+      }),
+    );
+
+    const userResource = stack.getResource("ReportsReaderUser");
+
+    assertNonNullable(userResource);
+
+    const user = userResource.simResource as SimIamUser;
+
+    // When the User reads an Object from the Bucket its attached policy names.
+    const output = await simS3.getObject(
+      new GetObjectCommand({ Bucket: "reports-bucket", Key: "daily.json" }),
+      { caller: { kind: "arn", arn: user.arn } },
+    );
+
+    // Then the CloudFormation-attached Managed Policy grants access.
+    assertInstanceOf(output.Body, Readable);
+    assertBufferEqual(
+      await simS3BodyToBuffer(output.Body),
+      Buffer.from('{"status":"complete"}'),
+    );
+  });
+});

--- a/src/service/iam/cfn/user/sim-cfn-iam-user-creator.ts
+++ b/src/service/iam/cfn/user/sim-cfn-iam-user-creator.ts
@@ -1,0 +1,109 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimIam } from "../../sim-iam.js";
+import type { SimIamUser, SimIamUsername } from "../../user/sim-iam-user.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import {
+  SimCfnIamUserPropertiesParser,
+  type SimCfnIamUserProperties,
+} from "./sim-cfn-iam-user-properties-parser.js";
+
+interface SimCfnIamUserCreatorProperties {
+  readonly iam: SimIam;
+}
+
+/**
+ * Creates simulated IAM Users from CloudFormation Resources.
+ */
+export class SimCfnIamUserCreator {
+  private readonly iam: SimIam;
+  private readonly propsParser = new SimCfnIamUserPropertiesParser();
+
+  constructor(properties: SimCfnIamUserCreatorProperties) {
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Create a simulated User from an AWS::IAM::User Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimIamUser> {
+    const userProperties = this.propsParser.parse(resource, properties);
+
+    await this.iam.createUser({
+      input: {
+        UserName: userProperties.userName,
+        Path: userProperties.path,
+      },
+    });
+
+    await Promise.all([
+      this.putInlinePolicies(userProperties),
+      this.attachManagedPolicies(userProperties),
+      this.createLoginProfile(userProperties),
+    ]);
+
+    const user = this.iam.users.get(userProperties.userName as SimIamUsername);
+    assertDefined(
+      user,
+      `Sim IAM User ${userProperties.userName} after CloudFormation creation`,
+    );
+
+    return user;
+  }
+
+  private async putInlinePolicies(
+    userProperties: SimCfnIamUserProperties,
+  ): Promise<void> {
+    await Promise.all(
+      userProperties.inlinePolicies.map(async (inlinePolicy) =>
+        this.iam.putUserPolicy({
+          input: {
+            UserName: userProperties.userName,
+            PolicyName: inlinePolicy.policyName,
+            PolicyDocument: inlinePolicy.policyDocument,
+          },
+        }),
+      ),
+    );
+  }
+
+  private async attachManagedPolicies(
+    userProperties: SimCfnIamUserProperties,
+  ): Promise<void> {
+    await Promise.all(
+      userProperties.managedPolicyArns.map(async (policyArn) =>
+        this.iam.attachUserPolicy({
+          input: {
+            UserName: userProperties.userName,
+            PolicyArn: policyArn,
+          },
+        }),
+      ),
+    );
+  }
+
+  /**
+   * Give the User a console password, the way real CloudFormation calls
+   * CreateLoginProfile for a `LoginProfile` property.
+   */
+  private async createLoginProfile(
+    userProperties: SimCfnIamUserProperties,
+  ): Promise<void> {
+    const { loginProfile } = userProperties;
+
+    if (loginProfile === undefined) {
+      return;
+    }
+
+    await this.iam.createLoginProfile({
+      input: {
+        UserName: userProperties.userName,
+        Password: loginProfile.password,
+        PasswordResetRequired: loginProfile.passwordResetRequired,
+      },
+    });
+  }
+}

--- a/src/service/iam/cfn/user/sim-cfn-iam-user-properties-parser.ts
+++ b/src/service/iam/cfn/user/sim-cfn-iam-user-properties-parser.ts
@@ -1,0 +1,149 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import {
+  SimCfnIamPoliciesParser,
+  type SimCfnIamInlinePolicy,
+} from "../sim-cfn-iam-policies-parser.js";
+
+export interface SimCfnIamUserLoginProfile {
+  readonly password: string;
+  readonly passwordResetRequired: boolean;
+}
+
+export interface SimCfnIamUserProperties {
+  readonly userName: string;
+  readonly path: string | undefined;
+  readonly inlinePolicies: readonly SimCfnIamInlinePolicy[];
+  readonly managedPolicyArns: readonly string[];
+  readonly loginProfile: SimCfnIamUserLoginProfile | undefined;
+}
+
+const resourceType = "AWS::IAM::User";
+
+/**
+ * Parses and validates AWS::IAM::User CloudFormation properties into the shape
+ * the sim IAM User creator needs.
+ *
+ * Keeping the property-shape validation here keeps the creator focused on
+ * orchestrating IAM command calls.
+ */
+export class SimCfnIamUserPropertiesParser {
+  private readonly policiesParser = new SimCfnIamPoliciesParser({
+    resourceType,
+  });
+
+  /**
+   * Parse the resolved CloudFormation properties for an AWS::IAM::User.
+   */
+  parse(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): SimCfnIamUserProperties {
+    this.rejectGroups(resource, properties);
+
+    return {
+      userName:
+        this.optionalString(resource, properties["UserName"], "UserName") ??
+        resource.logicalId,
+      path: this.optionalString(resource, properties["Path"], "Path"),
+      inlinePolicies: this.policiesParser.inlinePolicies(resource, properties),
+      managedPolicyArns: this.policiesParser.managedPolicyArns(
+        resource,
+        properties,
+      ),
+      loginProfile: this.loginProfile(resource, properties),
+    };
+  }
+
+  /**
+   * Group membership is not simulated, and silently dropping it would be
+   * misleading, so naming a Group fails the Resource. CDK leaves `Groups` out
+   * of the template altogether for a User in no group, so an empty list still
+   * deploys.
+   */
+  private rejectGroups(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): void {
+    const groups = properties["Groups"];
+
+    if (groups === undefined) {
+      return;
+    }
+
+    if (!Array.isArray(groups)) {
+      throw new TypeError(
+        `Invalid ${resourceType} ${resource.logicalId}: Groups must be an array`,
+      );
+    }
+
+    if (groups.length > 0) {
+      throw new TypeError(
+        `Invalid ${resourceType} ${resource.logicalId}: Groups are not simulated`,
+      );
+    }
+  }
+
+  private loginProfile(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): SimCfnIamUserLoginProfile | undefined {
+    const loginProfile = properties["LoginProfile"];
+
+    if (loginProfile === undefined) {
+      return undefined;
+    }
+
+    if (
+      typeof loginProfile !== "object" ||
+      loginProfile === null ||
+      Array.isArray(loginProfile)
+    ) {
+      throw new TypeError(
+        `Invalid ${resourceType} ${resource.logicalId}: LoginProfile must be an object`,
+      );
+    }
+
+    const password = loginProfile["Password"];
+
+    if (typeof password !== "string") {
+      throw new TypeError(
+        `Invalid ${resourceType} ${resource.logicalId}: LoginProfile Password must be a string`,
+      );
+    }
+
+    const passwordResetRequired = loginProfile["PasswordResetRequired"];
+
+    if (
+      passwordResetRequired !== undefined &&
+      typeof passwordResetRequired !== "boolean"
+    ) {
+      throw new TypeError(
+        `Invalid ${resourceType} ${resource.logicalId}: LoginProfile PasswordResetRequired must be a boolean`,
+      );
+    }
+
+    return {
+      password,
+      passwordResetRequired: passwordResetRequired ?? false,
+    };
+  }
+
+  private optionalString(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValueRecord[string] | undefined,
+    label: string,
+  ): string | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value !== "string") {
+      throw new TypeError(
+        `Invalid ${resourceType} ${resource.logicalId}: ${label} must be a string`,
+      );
+    }
+
+    return value;
+  }
+}

--- a/src/service/iam/cfn/user/sim-cfn-iam-user-validation.iso.test.ts
+++ b/src/service/iam/cfn/user/sim-cfn-iam-user-validation.iso.test.ts
@@ -1,0 +1,130 @@
+import {
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimIamUser } from "../../user/sim-iam-user.js";
+
+async function deployUser(
+  properties: SimCfnTemplateValueRecord,
+): Promise<SimIamUser | undefined> {
+  const simAws = new SimAws();
+
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "iam-user-validation-stack",
+    template: {
+      Resources: {
+        ValidatedUser: {
+          Type: "AWS::IAM::User",
+          Properties: properties,
+        },
+      },
+    },
+  });
+
+  return stack.getResource("ValidatedUser")?.simResource as
+    | SimIamUser
+    | undefined;
+}
+
+describe("IAM CloudFormation User validation", () => {
+  it("fails the Resource for a Group membership", async () => {
+    const error = await assertThrowsErrorAsync(async () =>
+      deployUser({ UserName: "GroupedUser", Groups: ["Administrators"] }),
+    );
+
+    assertInstanceOf(error, TypeError);
+    assertStringIncludes(error.message, "Groups are not simulated");
+  });
+
+  it("creates a User declaring no Group membership", async () => {
+    // CDK leaves Groups out of the template for a User in no group, but an
+    // empty list gives up nothing, so it still deploys.
+    const user = await deployUser({ UserName: "UngroupedUser", Groups: [] });
+
+    assertNonNullable(user);
+  });
+
+  it("rejects a non-array Groups", async () => {
+    const error = await assertThrowsErrorAsync(async () =>
+      deployUser({ UserName: "GroupedUser", Groups: "Administrators" }),
+    );
+
+    assertInstanceOf(error, TypeError);
+  });
+
+  it("rejects a non-string UserName", async () => {
+    const error = await assertThrowsErrorAsync(async () =>
+      deployUser({ UserName: 42 }),
+    );
+
+    assertInstanceOf(error, TypeError);
+  });
+
+  it("rejects a non-string Path", async () => {
+    const error = await assertThrowsErrorAsync(async () =>
+      deployUser({ UserName: "InvalidUser", Path: 42 }),
+    );
+
+    assertInstanceOf(error, TypeError);
+  });
+
+  it("rejects a non-object LoginProfile", async () => {
+    const error = await assertThrowsErrorAsync(async () =>
+      deployUser({ UserName: "InvalidUser", LoginProfile: "password" }),
+    );
+
+    assertInstanceOf(error, TypeError);
+  });
+
+  it("rejects a LoginProfile without a string Password", async () => {
+    const error = await assertThrowsErrorAsync(async () =>
+      deployUser({
+        UserName: "InvalidUser",
+        LoginProfile: { PasswordResetRequired: true },
+      }),
+    );
+
+    assertInstanceOf(error, TypeError);
+  });
+
+  it("rejects a non-boolean PasswordResetRequired", async () => {
+    const error = await assertThrowsErrorAsync(async () =>
+      deployUser({
+        UserName: "InvalidUser",
+        LoginProfile: {
+          Password: "initial-console-password",
+          PasswordResetRequired: "yes",
+        },
+      }),
+    );
+
+    assertInstanceOf(error, TypeError);
+  });
+
+  it("rejects a non-array Policies", async () => {
+    const error = await assertThrowsErrorAsync(async () =>
+      deployUser({ UserName: "InvalidUser", Policies: "ReadReports" }),
+    );
+
+    assertInstanceOf(error, TypeError);
+    assertStringIncludes(error.message, "AWS::IAM::User");
+  });
+
+  it("rejects a non-array ManagedPolicyArns", async () => {
+    const error = await assertThrowsErrorAsync(async () =>
+      deployUser({
+        UserName: "InvalidUser",
+        ManagedPolicyArns: "arn:aws:iam::aws:policy/ReadOnlyAccess",
+      }),
+    );
+
+    assertInstanceOf(error, TypeError);
+    assertStringIncludes(error.message, "AWS::IAM::User");
+  });
+});

--- a/src/service/iam/cfn/user/sim-cfn-iam-user.iso.test.ts
+++ b/src/service/iam/cfn/user/sim-cfn-iam-user.iso.test.ts
@@ -1,0 +1,324 @@
+import {
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertTypeString,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimIamUser } from "../../user/sim-iam-user.js";
+
+describe("IAM CloudFormation User", () => {
+  it("creates an IAM User from AWS::IAM::User", async () => {
+    // Given a CloudFormation template declaring an IAM User.
+    const simAws = new SimAws();
+
+    // When the template is deployed through sim CloudFormation.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "iam-user-stack",
+      template: {
+        Resources: {
+          ApplicationUser: {
+            Type: "AWS::IAM::User",
+            Properties: {
+              UserName: "ReportPublisher",
+              Path: "/application/",
+            },
+          },
+        },
+      },
+    });
+
+    // Then the CloudFormation Resource is backed by a simulated User.
+    const resource = stack.getResource("ApplicationUser");
+
+    assertNonNullable(resource);
+    assertIdentical(resource.status, "CREATE_COMPLETE");
+
+    const user = resource.simResource as SimIamUser | undefined;
+
+    assertNonNullable(user);
+    assertIdentical(user.userName, "ReportPublisher");
+    assertIdentical(user.path, "/application/");
+    assertIdentical(
+      user.arn,
+      `arn:aws:iam::${simAws.iam().accountId}:user/application/ReportPublisher`,
+    );
+    assertIdentical(simAws.iam().users.get(user.userName), user);
+  });
+
+  it("defaults UserName to the logical ID and Path to the root", async () => {
+    // Given a CloudFormation template with a User that omits its name and path.
+    const simAws = new SimAws();
+
+    // When the template is deployed through sim CloudFormation.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "iam-user-default-stack",
+      template: {
+        Resources: {
+          DefaultNamedUser: {
+            Type: "AWS::IAM::User",
+            Properties: {},
+          },
+        },
+      },
+    });
+
+    // Then the User uses the logical ID as its name and the root path.
+    const resource = stack.getResource("DefaultNamedUser");
+
+    assertNonNullable(resource);
+
+    const user = simAws.iam().users.get(resource.refValue as never);
+
+    assertNonNullable(user);
+    assertIdentical(user.userName, "DefaultNamedUser");
+    assertIdentical(user.path, "/");
+  });
+
+  it("stores inline Policies declared on the User", async () => {
+    // Given a CloudFormation template with a User carrying inline Policies.
+    const simAws = new SimAws();
+
+    // When the template is deployed through sim CloudFormation.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "iam-user-inline-policy-stack",
+      template: {
+        Resources: {
+          InlinePolicyUser: {
+            Type: "AWS::IAM::User",
+            Properties: {
+              UserName: "InlinePolicyUser",
+              Policies: [
+                {
+                  PolicyName: "ReadReports",
+                  PolicyDocument: {
+                    Version: "2012-10-17",
+                    Statement: [
+                      {
+                        Effect: "Allow",
+                        Action: "s3:GetObject",
+                        Resource: "arn:aws:s3:::reports-bucket/*",
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    // Then the inline policy is stored on the created User.
+    const resource = stack.getResource("InlinePolicyUser");
+
+    assertNonNullable(resource);
+
+    const user = resource.simResource as SimIamUser | undefined;
+
+    assertNonNullable(user);
+
+    const inlinePolicy = user.inlinePolicies.get("ReadReports");
+
+    assertTypeString(inlinePolicy);
+    assertIdentical(
+      inlinePolicy,
+      JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Action: "s3:GetObject",
+            Resource: "arn:aws:s3:::reports-bucket/*",
+          },
+        ],
+      }),
+    );
+  });
+
+  it("gives the User a login profile from LoginProfile", async () => {
+    // Given a CloudFormation template with a User carrying a LoginProfile.
+    const simAws = new SimAws();
+
+    // When the template is deployed through sim CloudFormation.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "iam-user-login-profile-stack",
+      template: {
+        Resources: {
+          ConsoleUser: {
+            Type: "AWS::IAM::User",
+            Properties: {
+              UserName: "ConsoleUser",
+              LoginProfile: {
+                Password: "initial-console-password",
+                PasswordResetRequired: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    // Then the User holds the password, which no command reports back.
+    const resource = stack.getResource("ConsoleUser");
+
+    assertNonNullable(resource);
+
+    const user = resource.simResource as SimIamUser | undefined;
+
+    assertNonNullable(user?.loginProfile);
+    assertIdentical(user.loginProfile.password, "initial-console-password");
+    assertTrue(user.loginProfile.passwordResetRequired);
+  });
+
+  it("defaults PasswordResetRequired on a LoginProfile", async () => {
+    // Given a template whose LoginProfile carries only a password.
+    const simAws = new SimAws();
+
+    // When the template is deployed through sim CloudFormation.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "iam-user-login-profile-default-stack",
+      template: {
+        Resources: {
+          ConsoleUser: {
+            Type: "AWS::IAM::User",
+            Properties: {
+              LoginProfile: {
+                Password: "initial-console-password",
+              },
+            },
+          },
+        },
+      },
+    });
+
+    // Then the User is not asked to change the password at sign-in.
+    const resource = stack.getResource("ConsoleUser");
+
+    assertNonNullable(resource);
+
+    const user = resource.simResource as SimIamUser | undefined;
+
+    assertNonNullable(user?.loginProfile);
+    assertFalse(user.loginProfile.passwordResetRequired);
+  });
+
+  it("uses the User name for Ref and exposes Arn and UserId via Fn::GetAtt", async () => {
+    // Given a template with a User, a dependent resource, and Outputs that
+    // exercise Ref and Fn::GetAtt resolution.
+    const simAws = new SimAws();
+
+    // When the template is deployed through sim CloudFormation.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "iam-user-ref-stack",
+      template: {
+        Resources: {
+          OutputUser: {
+            Type: "AWS::IAM::User",
+            Properties: {
+              UserName: "OutputUser",
+            },
+          },
+          WaitHandle: {
+            Type: "AWS::CloudFormation::WaitConditionHandle",
+            Properties: {
+              UserName: {
+                Ref: "OutputUser",
+              },
+              UserArn: {
+                "Fn::GetAtt": ["OutputUser", "Arn"],
+              },
+              UserId: {
+                "Fn::GetAtt": ["OutputUser", "UserId"],
+              },
+            },
+          },
+        },
+        Outputs: {
+          UserName: {
+            Value: {
+              Ref: "OutputUser",
+            },
+          },
+          UserArn: {
+            Value: {
+              "Fn::GetAtt": ["OutputUser", "Arn"],
+            },
+          },
+          UserId: {
+            Value: {
+              "Fn::GetAtt": ["OutputUser", "UserId"],
+            },
+          },
+        },
+      },
+    });
+
+    // Then Ref returns the User name and Fn::GetAtt returns Arn and UserId.
+    const userResource = stack.getResource("OutputUser");
+    const waitHandleResource = stack.getResource("WaitHandle");
+
+    assertNonNullable(userResource);
+    assertNonNullable(waitHandleResource);
+
+    const user = userResource.simResource as SimIamUser;
+
+    assertIdentical(userResource.refValue, "OutputUser");
+
+    const resolvedWaitHandleProperties =
+      await waitHandleResource.resolvedProperties({
+        resources: stack.resources,
+      });
+
+    assertIdentical(resolvedWaitHandleProperties["UserName"], "OutputUser");
+    assertIdentical(resolvedWaitHandleProperties["UserArn"], user.arn);
+    assertIdentical(resolvedWaitHandleProperties["UserId"], user.userId);
+
+    assertIdentical(stack.outputs.get("UserName")?.value, "OutputUser");
+    assertIdentical(stack.outputs.get("UserArn")?.value, user.arn);
+    assertIdentical(stack.outputs.get("UserId")?.value, user.userId);
+  });
+
+  it("falls back to an ARN-derived value for unsupported Fn::GetAtt attributes", async () => {
+    // Given a template that reads an attribute AWS::IAM::User does not expose
+    // via Fn::GetAtt.
+    const simAws = new SimAws();
+
+    // When the template is deployed through sim CloudFormation.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "iam-user-unsupported-attribute-stack",
+      template: {
+        Resources: {
+          AttributeUser: {
+            Type: "AWS::IAM::User",
+            Properties: {
+              UserName: "AttributeUser",
+            },
+          },
+        },
+        Outputs: {
+          UnsupportedAttribute: {
+            Value: {
+              "Fn::GetAtt": ["AttributeUser", "Path"],
+            },
+          },
+        },
+      },
+    });
+
+    // Then the fallback attribute value is derived from the User ARN.
+    const resource = stack.getResource("AttributeUser");
+
+    assertNonNullable(resource);
+
+    const user = resource.simResource as SimIamUser;
+
+    assertIdentical(
+      stack.outputs.get("UnsupportedAttribute")?.value,
+      `${user.arn}.Path`,
+    );
+  });
+});

--- a/src/service/iam/command/sim-iam-command.types.ts
+++ b/src/service/iam/command/sim-iam-command.types.ts
@@ -58,9 +58,17 @@ export type {
   SimListRolesCommandOutput,
 } from "./role/list-roles/list-roles.command.js";
 export type {
+  SimAttachUserPolicyCommand,
+  SimAttachUserPolicyCommandOutput,
+} from "./user/attach-user-policy/attach-user-policy.command.js";
+export type {
   SimCreateAccessKeyCommand,
   SimCreateAccessKeyCommandOutput,
 } from "./user/create-access-key/create-access-key.command.js";
+export type {
+  SimCreateLoginProfileCommand,
+  SimCreateLoginProfileCommandOutput,
+} from "./user/create-login-profile/create-login-profile.command.js";
 export type {
   SimCreateUserCommand,
   SimCreateUserCommandOutput,

--- a/src/service/iam/command/user/attach-user-policy/attach-user-policy.command.ts
+++ b/src/service/iam/command/user/attach-user-policy/attach-user-policy.command.ts
@@ -1,0 +1,10 @@
+export interface SimAttachUserPolicyCommandInput {
+  readonly UserName?: string | undefined;
+  readonly PolicyArn?: string | undefined;
+}
+
+export interface SimAttachUserPolicyCommand {
+  readonly input: SimAttachUserPolicyCommandInput;
+}
+
+export type SimAttachUserPolicyCommandOutput = Record<string, never>;

--- a/src/service/iam/command/user/attach-user-policy/attach-user-policy.handler.ts
+++ b/src/service/iam/command/user/attach-user-policy/attach-user-policy.handler.ts
@@ -1,0 +1,73 @@
+import type { CommandHandler } from "../../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../../util/background/background.js";
+import type { SimArn } from "../../../../aws/arn.js";
+import { SimIamNoSuchEntity } from "../../../error/sim-iam.error.js";
+import type { SimIamUser, SimIamUsername } from "../../../user/sim-iam-user.js";
+import type {
+  SimAttachUserPolicyCommand,
+  SimAttachUserPolicyCommandOutput,
+} from "./attach-user-policy.command.js";
+
+interface AttachUserPolicyCommandHandlerProperties {
+  readonly users: Map<SimIamUsername, SimIamUser>;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * IAM AttachUserPolicyCommand handler.
+ *
+ * The user-side counterpart of AttachRolePolicy: the attachment records a
+ * managed policy ARN on the user, and authorization resolves the referenced
+ * policy from the account policy store when it evaluates a request. An ARN
+ * with no stored policy behind it, such as an AWS-managed one, attaches and
+ * contributes no statements.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/iam/command/AttachUserPolicyCommand/
+ */
+export class AttachUserPolicyCommandHandler implements CommandHandler<
+  SimAttachUserPolicyCommand,
+  SimAttachUserPolicyCommandOutput
+> {
+  private readonly users: Map<SimIamUsername, SimIamUser>;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: AttachUserPolicyCommandHandlerProperties) {
+    const { users, background = new BackgroundTasks() } = properties;
+
+    this.users = users;
+    this.background = background;
+  }
+
+  /**
+   * Handle an AttachUserPolicyCommand from the SDK.
+   */
+  async handle(
+    command: SimAttachUserPolicyCommand,
+  ): Promise<SimAttachUserPolicyCommandOutput> {
+    const username = command.input.UserName as SimIamUsername | undefined;
+    if (username === undefined || username.length === 0) {
+      throw new Error("UserName is required");
+    }
+
+    const policyArn = command.input.PolicyArn as SimArn | undefined;
+    if (policyArn === undefined || policyArn.length === 0) {
+      throw new Error("PolicyArn is required");
+    }
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    const user = this.users.get(username);
+
+    if (user === undefined) {
+      throw new SimIamNoSuchEntity(`No IAM User with name ${username}`);
+    }
+
+    user.attachedPolicyArns.add(policyArn);
+
+    return {};
+  }
+}

--- a/src/service/iam/command/user/attach-user-policy/attach-user-policy.iso.test.ts
+++ b/src/service/iam/command/user/attach-user-policy/attach-user-policy.iso.test.ts
@@ -1,0 +1,134 @@
+import {
+  AttachUserPolicyCommand,
+  CreatePolicyCommand,
+  CreateUserCommand,
+} from "@aws-sdk/client-iam";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { makeSimAwsAccountId } from "../../../../aws/sim-aws-account.js";
+import { SimAws } from "../../../../aws/sim-aws.js";
+import { SimIamNoSuchEntity } from "../../../error/sim-iam.error.js";
+
+describe("IAM AttachUserPolicyCommand", () => {
+  it("grants a User the permissions of an attached Managed Policy", async () => {
+    // Given a User and a Managed Policy allowing an action.
+    const simAws = new SimAws();
+    const simIam = simAws.account(makeSimAwsAccountId()).iam();
+    const userCreation = await simIam.createUser(
+      new CreateUserCommand({ UserName: "ApplicationUser" }),
+    );
+    const policyCreation = await simIam.createPolicy(
+      new CreatePolicyCommand({
+        PolicyName: "ReadAssets",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "s3:GetObject",
+            Resource: "arn:aws:s3:::assets-bucket/*",
+          },
+        }),
+      }),
+    );
+
+    // When the Managed Policy is attached to the User.
+    await simIam.attachUserPolicy(
+      new AttachUserPolicyCommand({
+        UserName: "ApplicationUser",
+        PolicyArn: policyCreation.Policy.Arn,
+      }),
+    );
+
+    // Then the User is allowed the action the Policy names.
+    const decision = simIam.authorize({
+      caller: { kind: "arn", arn: userCreation.User.Arn },
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::assets-bucket/logo.svg",
+    });
+
+    assertTrue(decision.isAllowed);
+  });
+
+  it("attaches a Policy ARN with no stored Policy behind it", async () => {
+    // Given a User and an AWS-managed Policy ARN the simulation does not hold.
+    const simAws = new SimAws();
+    const simIam = simAws.account(makeSimAwsAccountId()).iam();
+    const userCreation = await simIam.createUser(
+      new CreateUserCommand({ UserName: "ApplicationUser" }),
+    );
+
+    // When that ARN is attached to the User.
+    await simIam.attachUserPolicy(
+      new AttachUserPolicyCommand({
+        UserName: "ApplicationUser",
+        PolicyArn: "arn:aws:iam::aws:policy/ReadOnlyAccess",
+      }),
+    );
+
+    // Then the attachment is recorded and contributes no statements.
+    const user = simIam.users.get("ApplicationUser" as never);
+
+    assertTrue(
+      user?.attachedPolicyArns.has("arn:aws:iam::aws:policy/ReadOnlyAccess"),
+    );
+
+    const decision = simIam.authorize({
+      caller: { kind: "arn", arn: userCreation.User.Arn },
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::assets-bucket/logo.svg",
+    });
+
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("throws when the IAM User does not exist", async () => {
+    const simAws = new SimAws();
+    const simIam = simAws.iam();
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simIam.attachUserPolicy(
+        new AttachUserPolicyCommand({
+          UserName: "MissingUser",
+          PolicyArn: "arn:aws:iam::aws:policy/ReadOnlyAccess",
+        }),
+      ),
+    );
+
+    assertInstanceOf(error, SimIamNoSuchEntity);
+    assertIdentical(error.message, "No IAM User with name MissingUser");
+  });
+
+  it("requires a UserName and a PolicyArn", async () => {
+    const simAws = new SimAws();
+    const simIam = simAws.iam();
+    await simIam.createUser(new CreateUserCommand({ UserName: "SomeUser" }));
+
+    const missingUsername = await assertThrowsErrorAsync(async () =>
+      simIam.attachUserPolicy(
+        new AttachUserPolicyCommand({
+          UserName: undefined,
+          PolicyArn: "arn:aws:iam::aws:policy/ReadOnlyAccess",
+        }),
+      ),
+    );
+
+    assertIdentical(missingUsername.message, "UserName is required");
+
+    const missingPolicyArn = await assertThrowsErrorAsync(async () =>
+      simIam.attachUserPolicy(
+        new AttachUserPolicyCommand({
+          UserName: "SomeUser",
+          PolicyArn: undefined,
+        }),
+      ),
+    );
+
+    assertIdentical(missingPolicyArn.message, "PolicyArn is required");
+  });
+});

--- a/src/service/iam/command/user/create-login-profile/create-login-profile.command.ts
+++ b/src/service/iam/command/user/create-login-profile/create-login-profile.command.ts
@@ -1,0 +1,17 @@
+export interface SimCreateLoginProfileCommandInput {
+  readonly UserName?: string | undefined;
+  readonly Password?: string | undefined;
+  readonly PasswordResetRequired?: boolean | undefined;
+}
+
+export interface SimCreateLoginProfileCommand {
+  readonly input: SimCreateLoginProfileCommandInput;
+}
+
+export interface SimCreateLoginProfileCommandOutput {
+  readonly LoginProfile: {
+    readonly UserName: string;
+    readonly CreateDate: Date;
+    readonly PasswordResetRequired: boolean;
+  };
+}

--- a/src/service/iam/command/user/create-login-profile/create-login-profile.handler.ts
+++ b/src/service/iam/command/user/create-login-profile/create-login-profile.handler.ts
@@ -1,0 +1,93 @@
+import type { CommandHandler } from "../../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../../util/background/background.js";
+import {
+  SimIamEntityAlreadyExists,
+  SimIamNoSuchEntity,
+} from "../../../error/sim-iam.error.js";
+import type { SimIamUser, SimIamUsername } from "../../../user/sim-iam-user.js";
+import type {
+  SimCreateLoginProfileCommand,
+  SimCreateLoginProfileCommandOutput,
+} from "./create-login-profile.command.js";
+
+interface CreateLoginProfileCommandHandlerProperties {
+  readonly users: Map<SimIamUsername, SimIamUser>;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * IAM CreateLoginProfileCommand handler.
+ *
+ * A login profile is the console password of a user. The response describes
+ * the profile without the password, which is how real IAM behaves: a password
+ * goes in and is never read back out. A test asserting on one reads it from
+ * the user record in `SimIam.users`.
+ *
+ * No password policy is applied. Real IAM validates the password against the
+ * account password policy, which the simulator does not model.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/iam/command/CreateLoginProfileCommand/
+ */
+export class CreateLoginProfileCommandHandler implements CommandHandler<
+  SimCreateLoginProfileCommand,
+  SimCreateLoginProfileCommandOutput
+> {
+  private readonly users: Map<SimIamUsername, SimIamUser>;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: CreateLoginProfileCommandHandlerProperties) {
+    const { users, background = new BackgroundTasks() } = properties;
+
+    this.users = users;
+    this.background = background;
+  }
+
+  /**
+   * Handle a CreateLoginProfileCommand from the SDK.
+   */
+  async handle(
+    command: SimCreateLoginProfileCommand,
+  ): Promise<SimCreateLoginProfileCommandOutput> {
+    const username = command.input.UserName as SimIamUsername | undefined;
+    if (username === undefined || username.length === 0) {
+      throw new Error("UserName is required");
+    }
+
+    const password = command.input.Password;
+    if (password === undefined || password.length === 0) {
+      throw new Error("Password is required");
+    }
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    const user = this.users.get(username);
+
+    if (user === undefined) {
+      throw new SimIamNoSuchEntity(`No IAM User with name ${username}`);
+    }
+
+    if (user.loginProfile !== undefined) {
+      throw new SimIamEntityAlreadyExists(
+        `Sim IAM User ${username} already has a login profile`,
+      );
+    }
+
+    user.loginProfile = {
+      password,
+      createDate: this.background.now(),
+      passwordResetRequired: command.input.PasswordResetRequired ?? false,
+    };
+
+    return {
+      LoginProfile: {
+        UserName: user.userName,
+        CreateDate: user.loginProfile.createDate,
+        PasswordResetRequired: user.loginProfile.passwordResetRequired,
+      },
+    };
+  }
+}

--- a/src/service/iam/command/user/create-login-profile/create-login-profile.iso.test.ts
+++ b/src/service/iam/command/user/create-login-profile/create-login-profile.iso.test.ts
@@ -1,0 +1,140 @@
+import {
+  CreateLoginProfileCommand,
+  CreateUserCommand,
+} from "@aws-sdk/client-iam";
+import {
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { makeSimAwsAccountId } from "../../../../aws/sim-aws-account.js";
+import { SimAws } from "../../../../aws/sim-aws.js";
+import {
+  SimIamEntityAlreadyExists,
+  SimIamNoSuchEntity,
+} from "../../../error/sim-iam.error.js";
+import type { SimIamUsername } from "../../../user/sim-iam-user.js";
+
+describe("IAM CreateLoginProfileCommand", () => {
+  it("gives a User a console password without reporting it back", async () => {
+    // Given an IAM User.
+    const simAws = new SimAws();
+    const simIam = simAws.account(makeSimAwsAccountId()).iam();
+    await simIam.createUser(new CreateUserCommand({ UserName: "ConsoleUser" }));
+
+    // When the User is given a login profile.
+    const profileCreation = await simIam.createLoginProfile(
+      new CreateLoginProfileCommand({
+        UserName: "ConsoleUser",
+        Password: "initial-console-password",
+        PasswordResetRequired: true,
+      }),
+    );
+
+    // Then the response describes the profile without the password.
+    assertIdentical(profileCreation.LoginProfile.UserName, "ConsoleUser");
+    assertTrue(profileCreation.LoginProfile.PasswordResetRequired);
+    assertInstanceOf(profileCreation.LoginProfile.CreateDate, Date);
+
+    // And the password itself is only reachable through the User record.
+    const user = simIam.users.get("ConsoleUser" as SimIamUsername);
+
+    assertNonNullable(user?.loginProfile);
+    assertIdentical(user.loginProfile.password, "initial-console-password");
+    assertTrue(user.loginProfile.passwordResetRequired);
+  });
+
+  it("defaults PasswordResetRequired to false", async () => {
+    // Given an IAM User.
+    const simAws = new SimAws();
+    const simIam = simAws.account(makeSimAwsAccountId()).iam();
+    await simIam.createUser(new CreateUserCommand({ UserName: "ConsoleUser" }));
+
+    // When a login profile is created without PasswordResetRequired.
+    const profileCreation = await simIam.createLoginProfile(
+      new CreateLoginProfileCommand({
+        UserName: "ConsoleUser",
+        Password: "initial-console-password",
+      }),
+    );
+
+    // Then the User is not asked to change the password at sign-in.
+    assertFalse(profileCreation.LoginProfile.PasswordResetRequired);
+  });
+
+  it("refuses a second login profile for the same User", async () => {
+    // Given a User that already has a login profile.
+    const simAws = new SimAws();
+    const simIam = simAws.account(makeSimAwsAccountId()).iam();
+    await simIam.createUser(new CreateUserCommand({ UserName: "ConsoleUser" }));
+    await simIam.createLoginProfile(
+      new CreateLoginProfileCommand({
+        UserName: "ConsoleUser",
+        Password: "initial-console-password",
+      }),
+    );
+
+    // When another login profile is created for it.
+    const error = await assertThrowsErrorAsync(async () =>
+      simIam.createLoginProfile(
+        new CreateLoginProfileCommand({
+          UserName: "ConsoleUser",
+          Password: "another-console-password",
+        }),
+      ),
+    );
+
+    // Then IAM refuses, as it does for any entity that already exists.
+    assertInstanceOf(error, SimIamEntityAlreadyExists);
+  });
+
+  it("throws when the IAM User does not exist", async () => {
+    const simAws = new SimAws();
+    const simIam = simAws.iam();
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simIam.createLoginProfile(
+        new CreateLoginProfileCommand({
+          UserName: "MissingUser",
+          Password: "initial-console-password",
+        }),
+      ),
+    );
+
+    assertInstanceOf(error, SimIamNoSuchEntity);
+    assertIdentical(error.message, "No IAM User with name MissingUser");
+  });
+
+  it("requires a UserName and a Password", async () => {
+    const simAws = new SimAws();
+    const simIam = simAws.iam();
+    await simIam.createUser(new CreateUserCommand({ UserName: "ConsoleUser" }));
+
+    const missingUsername = await assertThrowsErrorAsync(async () =>
+      simIam.createLoginProfile(
+        new CreateLoginProfileCommand({
+          UserName: undefined,
+          Password: "console-password",
+        }),
+      ),
+    );
+
+    assertIdentical(missingUsername.message, "UserName is required");
+
+    const missingPassword = await assertThrowsErrorAsync(async () =>
+      simIam.createLoginProfile(
+        new CreateLoginProfileCommand({
+          UserName: "ConsoleUser",
+          Password: undefined,
+        }),
+      ),
+    );
+
+    assertIdentical(missingPassword.message, "Password is required");
+  });
+});

--- a/src/service/iam/command/user/create-user/create-user-record-factory.ts
+++ b/src/service/iam/command/user/create-user/create-user-record-factory.ts
@@ -32,6 +32,7 @@ export class CreateUserRecordFactory {
       accessKeys: new Map(),
       inlinePolicies: new Map(),
       attachedPolicyArns: new Set(),
+      loginProfile: undefined,
     };
   }
 

--- a/src/service/iam/command/user/sim-iam-user-command-handlers.ts
+++ b/src/service/iam/command/user/sim-iam-user-command-handlers.ts
@@ -10,6 +10,16 @@ import type {
   SimCreateAccessKeyCommand,
   SimCreateAccessKeyCommandOutput,
 } from "./create-access-key/create-access-key.command.js";
+import { AttachUserPolicyCommandHandler } from "./attach-user-policy/attach-user-policy.handler.js";
+import type {
+  SimAttachUserPolicyCommand,
+  SimAttachUserPolicyCommandOutput,
+} from "./attach-user-policy/attach-user-policy.command.js";
+import { CreateLoginProfileCommandHandler } from "./create-login-profile/create-login-profile.handler.js";
+import type {
+  SimCreateLoginProfileCommand,
+  SimCreateLoginProfileCommandOutput,
+} from "./create-login-profile/create-login-profile.command.js";
 import { CreateUserCommandHandler } from "./create-user/create-user.handler.js";
 import type {
   SimCreateUserCommand,
@@ -72,6 +82,44 @@ export class SimIamUserCommandHandlers {
     );
     const handler = new CreateUserCommandHandler({
       accountId: this.accountId,
+      users: this.users,
+      background: this.background,
+    });
+    return await handler.handle(command);
+  }
+
+  /**
+   * Handle an AttachUserPolicy command from the SDK.
+   */
+  async attachUserPolicy(
+    command: SimAttachUserPolicyCommand,
+    options?: SimIamRequestOptions,
+  ): Promise<SimAttachUserPolicyCommandOutput> {
+    this.authorizer.authorize(
+      "iam:AttachUserPolicy",
+      this.userArn(command.input.UserName),
+      options?.caller,
+    );
+    const handler = new AttachUserPolicyCommandHandler({
+      users: this.users,
+      background: this.background,
+    });
+    return await handler.handle(command);
+  }
+
+  /**
+   * Handle a CreateLoginProfile command from the SDK.
+   */
+  async createLoginProfile(
+    command: SimCreateLoginProfileCommand,
+    options?: SimIamRequestOptions,
+  ): Promise<SimCreateLoginProfileCommandOutput> {
+    this.authorizer.authorize(
+      "iam:CreateLoginProfile",
+      this.userArn(command.input.UserName),
+      options?.caller,
+    );
+    const handler = new CreateLoginProfileCommandHandler({
       users: this.users,
       background: this.background,
     });

--- a/src/service/iam/sdk/sim-iam-sdk-command-router.iso.test.ts
+++ b/src/service/iam/sdk/sim-iam-sdk-command-router.iso.test.ts
@@ -1,7 +1,9 @@
 import { describe, it } from "vitest";
 import {
   AttachRolePolicyCommand,
+  AttachUserPolicyCommand,
   CreateAccessKeyCommand,
+  CreateLoginProfileCommand,
   CreatePolicyCommand,
   CreateRoleCommand,
   CreateUserCommand,
@@ -192,6 +194,32 @@ describe("simulated IAM SDK Command routing", () => {
         PolicyName: "inline-user-policy",
         PolicyDocument: allowAllPolicyDocument,
       }),
+    );
+
+    const policyCreation = await client.send(
+      new CreatePolicyCommand({
+        PolicyName: "intercept-user-policy",
+        PolicyDocument: allowAllPolicyDocument,
+      }),
+    );
+    assertNonNullable(policyCreation.Policy?.Arn);
+
+    await client.send(
+      new AttachUserPolicyCommand({
+        UserName: "InterceptUser",
+        PolicyArn: policyCreation.Policy.Arn,
+      }),
+    );
+
+    const loginProfileCreation = await client.send(
+      new CreateLoginProfileCommand({
+        UserName: "InterceptUser",
+        Password: "initial-console-password",
+      }),
+    );
+    assertIdentical(
+      loginProfileCreation.LoginProfile?.UserName,
+      "InterceptUser",
     );
 
     const accessKeyCreation = await client.send(

--- a/src/service/iam/sdk/sim-iam-sdk-command-router.ts
+++ b/src/service/iam/sdk/sim-iam-sdk-command-router.ts
@@ -16,7 +16,9 @@ import type { SimAttachRolePolicyCommand } from "../command/role/attach-role-pol
 import type { SimCreateRoleCommand } from "../command/role/create-role/create-role.command.js";
 import type { SimGetRoleCommand } from "../command/role/get-role/get-role.command.js";
 import type { SimListRolesCommand } from "../command/role/list-roles/list-roles.command.js";
+import type { SimAttachUserPolicyCommand } from "../command/user/attach-user-policy/attach-user-policy.command.js";
 import type { SimCreateAccessKeyCommand } from "../command/user/create-access-key/create-access-key.command.js";
+import type { SimCreateLoginProfileCommand } from "../command/user/create-login-profile/create-login-profile.command.js";
 import type { SimCreateUserCommand } from "../command/user/create-user/create-user.command.js";
 import type { SimIam } from "../sim-iam.js";
 
@@ -33,6 +35,14 @@ export class SimIamSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simIam.attachRolePolicy(
             command as SimAttachRolePolicyCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "AttachUserPolicyCommand",
+        async (command, context): Promise<unknown> =>
+          await simIam.attachUserPolicy(
+            command as SimAttachUserPolicyCommand,
             simSdkCallerOptions(context),
           ),
       ],
@@ -73,6 +83,14 @@ export class SimIamSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simIam.createAccessKey(
             command as SimCreateAccessKeyCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "CreateLoginProfileCommand",
+        async (command, context): Promise<unknown> =>
+          await simIam.createLoginProfile(
+            command as SimCreateLoginProfileCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/iam/sim-iam.ts
+++ b/src/service/iam/sim-iam.ts
@@ -245,6 +245,26 @@ export class SimIam
   }
 
   /**
+   * Handle an IAM AttachUserPolicy command.
+   */
+  async attachUserPolicy(
+    command: simIamCommands.SimAttachUserPolicyCommand,
+    options?: SimIamRequestOptions,
+  ): Promise<simIamCommands.SimAttachUserPolicyCommandOutput> {
+    return await this.commands.users.attachUserPolicy(command, options);
+  }
+
+  /**
+   * Handle an IAM CreateLoginProfile command.
+   */
+  async createLoginProfile(
+    command: simIamCommands.SimCreateLoginProfileCommand,
+    options?: SimIamRequestOptions,
+  ): Promise<simIamCommands.SimCreateLoginProfileCommandOutput> {
+    return await this.commands.users.createLoginProfile(command, options);
+  }
+
+  /**
    * Handle an IAM CreateAccessKey command.
    */
   async createAccessKey(

--- a/src/service/iam/user/sim-iam-user-login-profile.ts
+++ b/src/service/iam/user/sim-iam-user-login-profile.ts
@@ -1,0 +1,13 @@
+/**
+ * The console sign-in profile of a simulated IAM User.
+ *
+ * Real IAM never reads a password back. `CreateLoginProfile` takes one and
+ * `GetLoginProfile` answers without it, so the password kept here is only
+ * reachable through the simulator's own `SimIam.users`, which is where a test
+ * asserting on it has to look.
+ */
+export interface SimIamUserLoginProfile {
+  readonly password: string;
+  readonly createDate: Date;
+  readonly passwordResetRequired: boolean;
+}

--- a/src/service/iam/user/sim-iam-user.ts
+++ b/src/service/iam/user/sim-iam-user.ts
@@ -4,6 +4,7 @@ import type { SimArn } from "../../aws/arn.js";
 import type { SimIamAccessKey } from "../credential/sim-iam-access-key.js";
 import type { SimIamPolicyDocument } from "../policy/sim-iam-policy.js";
 import type { SimIamPrincipal } from "../principal/sim-iam-principal.js";
+import type { SimIamUserLoginProfile } from "./sim-iam-user-login-profile.js";
 
 export type SimIamUsername = Brand<string, "SimIamUsername">;
 export type SimIamUserId = Brand<string, "SimIamUserId">;
@@ -32,4 +33,12 @@ export interface SimIamUser extends SimIamPrincipal {
    * Managed identity policies attached to the user.
    */
   readonly attachedPolicyArns: Set<SimArn>;
+
+  /**
+   * The console sign-in profile, once the user has been given one.
+   *
+   * Mutable because a login profile is created after the user itself, by
+   * `CreateLoginProfile` or by an `AWS::IAM::User` carrying a `LoginProfile`.
+   */
+  loginProfile: SimIamUserLoginProfile | undefined;
 }


### PR DESCRIPTION
An `AWS::IAM::User` Resource now creates a User in the Stack Account's simulated IAM, where it was stepped over as unsupported. `UserName` names the User and falls back to the Resource logical ID, `Path` and inline `Policies` follow the Role creator, and `ManagedPolicyArns` attaches managed Policies through a new `AttachUserPolicy` command. `Ref` resolves to the User name and `Fn::GetAtt` to `Arn` and `UserId`. A `LoginProfile` gives the User a console password through a new `CreateLoginProfile` command, which answers without the password the way real IAM does, leaving `SimIam.users` as the only way to read one back. Group membership has no simulation behind it, so a `Groups` entry fails the Resource while an empty list still deploys, which is what CDK synthesizes for a User in no group.

Resolves #721