### PR TITLE
fix: read a Range on a simulated S3 GetObject

### DIFF
--- a/docs/serve/README.md
+++ b/docs/serve/README.md
@@ -387,7 +387,7 @@ const client = new S3Client({
 });
 ```
 
-The operations served are the ones simulated S3 implements: `CreateBucket`, `DeleteBucket`, `HeadBucket`, `ListBuckets`, `ListObjects`, `ListObjectsV2`, `GetObject`, `HeadObject`, `PutObject`, `DeleteObject`, `DeleteObjects`, the six multipart upload operations, and the Bucket policy, website, Block Public Access and event notification configurations. `aws s3 cp` works in both directions, and for a file above the CLI's 8MB multipart threshold. Anything else is refused as `NotImplemented`, which an SDK raises under that name rather than leaving a client to guess.
+The operations served are the ones simulated S3 implements: `CreateBucket`, `DeleteBucket`, `HeadBucket`, `ListBuckets`, `ListObjects`, `ListObjectsV2`, `GetObject`, `HeadObject`, `PutObject`, `DeleteObject`, `DeleteObjects`, the six multipart upload operations, and the Bucket policy, website, Block Public Access and event notification configurations. `aws s3 cp` works in both directions, and for a file above the CLI's 8MB multipart threshold. A `GetObject` carrying a `Range` is answered `206 Partial Content` with the bytes it asked for, and that is how the CLI takes a large file back out. Anything else is refused as `NotImplemented`, which an SDK raises under that name rather than leaving a client to guess.
 
 Simulated S3 also answers its own Bucket hostnames, covered above. That path is unchanged, and it is what a presigned URL and a website visitor use.
 

--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -537,6 +537,82 @@ A completed upload raises `s3:ObjectCreated:CompleteMultipartUpload`. A single-r
 - An upload has no expiry, and nothing abandons one on its own. A lifecycle rule expiring incomplete
   uploads is left out along with the rest of lifecycle configuration.
 
+## Reading part of an Object
+
+`GetObjectCommand` takes a `Range` and answers with the bytes it names. A client downloading a large
+Object asks for its pieces at once and writes each response at the offset it asked for. `aws s3 cp`
+downloads that way above eight megabytes.
+
+```typescript sim-s3-ranged-read
+/**
+ * Reading part of a simulated S3 Object.
+ */
+
+import {
+  CreateBucketCommand,
+  GetObjectCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simS3 = simAws.s3();
+
+await simS3.createBucket(new CreateBucketCommand({ Bucket: "reports-bucket" }));
+
+await simS3.putObject(
+  new PutObjectCommand({
+    Bucket: "reports-bucket",
+    Key: "quarter.csv",
+    Body: "region,revenue\neu-west-2,1200\n",
+  }),
+);
+
+const header = await simS3.getObject(
+  new GetObjectCommand({
+    Bucket: "reports-bucket",
+    Key: "quarter.csv",
+    Range: "bytes=0-13",
+  }),
+);
+
+// The first fourteen bytes, which are "region,revenue".
+console.log(header.Body);
+// 14
+console.log(header.ContentLength);
+// "bytes 0-13/30"
+console.log(header.ContentRange);
+```
+
+`ContentLength` counts the bytes being sent, and `ContentRange` says which bytes of the Object they
+are, in the `bytes <start>-<end>/<size>` form real S3 answers with. The `ETag` is the whole Object's.
+A client reading an Object in pieces compares it across them to see whether the Object changed
+underneath it.
+
+Three forms are read:
+
+- `bytes=0-499` takes the first five hundred bytes.
+- `bytes=500-` takes everything from byte 500 to the end.
+- `bytes=-500` takes the last five hundred bytes.
+
+A range running past the end of the Object stops at the last byte, and a client that guessed the
+size gets what there is. A range starting past the end raises `InvalidRange`, under the name and the
+416 status real S3 gives it. A `Range` sim S3 cannot read (several ranges at once, or a unit other
+than bytes) is ignored, and the whole Object comes back under a `200`.
+
+Over a served endpoint, a ranged read answers `206 Partial Content` with a `content-range` header.
+Both the S3 REST endpoint and an endpoint URL a client is pointed at answer the same way. See
+[Serve simulated S3 on localhost](#serve-simulated-s3-on-localhost).
+
+### Limitations
+
+- `Range` on `HeadObject` is left out. A HEAD describes the whole Object however it is asked about,
+  over the SDK and over a served endpoint alike.
+- `If-Range` is left out. A ranged read is answered without comparing the Object against the entity
+  tag or the date the client held.
+- `PartNumber` is left out. A read names the bytes it wants, and the part they were uploaded in is
+  not something it can ask for.
+
 ## Deleting Objects
 
 Use `DeleteObjectCommand` to remove one Object, and `DeleteObjectsCommand` to remove several in one
@@ -2416,6 +2492,8 @@ Sim S3 currently supports:
 - `CreateMultipartUploadCommand`, `UploadPartCommand`, `CompleteMultipartUploadCommand`,
   `AbortMultipartUploadCommand`, `ListMultipartUploadsCommand` and `ListPartsCommand`, so `aws s3 cp`
   and `@aws-sdk/lib-storage` can upload a file of real size
+- `Range` on `GetObjectCommand`, answering with the bytes asked for and `206 Partial Content` over a
+  served endpoint, so `aws s3 cp` downloads a file of real size unchanged
 - `DeleteObjectCommand` and `DeleteObjectsCommand`, authorized per Object by sim IAM
 - `PutBucketNotificationConfigurationCommand` and `GetBucketNotificationConfigurationCommand`, with
   Object events delivered to a simulated Lambda function, a simulated SQS queue or a simulated SNS

--- a/docs/services/s3/sim-s3-ranged-read.example.ts
+++ b/docs/services/s3/sim-s3-ranged-read.example.ts
@@ -1,0 +1,38 @@
+/**
+ * Reading part of a simulated S3 Object.
+ */
+
+import {
+  CreateBucketCommand,
+  GetObjectCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simS3 = simAws.s3();
+
+await simS3.createBucket(new CreateBucketCommand({ Bucket: "reports-bucket" }));
+
+await simS3.putObject(
+  new PutObjectCommand({
+    Bucket: "reports-bucket",
+    Key: "quarter.csv",
+    Body: "region,revenue\neu-west-2,1200\n",
+  }),
+);
+
+const header = await simS3.getObject(
+  new GetObjectCommand({
+    Bucket: "reports-bucket",
+    Key: "quarter.csv",
+    Range: "bytes=0-13",
+  }),
+);
+
+// The first fourteen bytes, which are "region,revenue".
+console.log(header.Body);
+// 14
+console.log(header.ContentLength);
+// "bytes 0-13/30"
+console.log(header.ContentRange);

--- a/src/service/s3/README.md
+++ b/src/service/s3/README.md
@@ -411,7 +411,19 @@ never the thing caching holds on to.
 4. sequences background work
 5. gets the object from Bucket storage
 6. throws `SimS3NoSuchKey` if absent
-7. returns a readable body stream, metadata, `ETag`, `LastModified`, and `$metadata`
+7. resolves any stated `Range` against the size of the stored body
+8. returns a readable body stream, metadata, `ETag`, `LastModified`, `ContentLength` and
+   `$metadata`, with a `ContentRange` for a read that asked for part of the Object
+
+`simS3ReadObjectRange` in `object/s3-object-range.ts` reads the header. The three forms are
+`bytes=<start>-<end>`, `bytes=<start>-` and `bytes=-<suffix>`, and an end past the last byte is
+clamped to it. `undefined` comes back for a read that stated no range and for one whose header S3
+answers as though it had never been sent (several ranges at once, a unit other than bytes, an end
+before its start). A start past the last byte, a suffix of zero and any range of an empty Object
+each throw `SimS3InvalidRange`.
+
+The `ETag` is the whole Object's either way. Real S3 identifies the Object a slice came from, and a
+client reading in pieces compares the value across them.
 
 ### ListObjects
 
@@ -704,6 +716,8 @@ Bucket, or path style, where the first path segment does. `SimS3BucketLocator` t
 - a `DELETE` answers `204 No Content` whether or not the Object was there, as real S3 does
 - `DeleteObjects` is a `POST` to the Bucket rather than an Object request, so it is reachable through
   the SDK but not over this endpoint
+- a `GET` carrying a `Range` is answered `206 Partial Content` with a `content-range` header, and a
+  `HEAD` describes the whole Object however it is asked about, matching `HeadObjectCommandHandler`
 - it checks any `x-amz-checksum-*` an upload states before storing anything, through
   `SimS3UploadChecksum`
 - failures become the XML error document real S3 answers with, through `SimS3RestErrorResponse`,
@@ -790,6 +804,7 @@ Handlers throw AWS-like errors for supported failure cases, including:
 - no such key
 - no such Bucket policy
 - access denied, for S3's own refusals such as Block Public Access
+- invalid range, for a read whose `Range` names bytes the Object does not hold
 - Bucket already exists
 - Bucket already owned by you
 - invalid argument, for a notification configuration with overlapping filters, a repeated

--- a/src/service/s3/command/get-object/get-object-loader.ts
+++ b/src/service/s3/command/get-object/get-object-loader.ts
@@ -2,6 +2,10 @@ import { Readable } from "node:stream";
 import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
 import { SimS3NoSuchKey } from "../../error/sim-s3.error.js";
 import { simS3QuotedETag } from "../../object/s3-object-etag.js";
+import {
+  simS3ContentRange,
+  simS3ReadObjectRange,
+} from "../../object/s3-object-range.js";
 import type { SimGetObjectCommandOutput } from "./get-object.command.js";
 
 /**
@@ -15,7 +19,8 @@ import type { SimGetObjectCommandOutput } from "./get-object.command.js";
  * response is a representation of the stored Object:
  *
  * - a missing storage entry becomes the S3 NoSuchKey error;
- * - the stored Buffer becomes the readable response body;
+ * - the stored Buffer, or the part of it the read asked for, becomes the
+ *   readable response body;
  * - stored metadata becomes SDK response metadata;
  * - the Object's content hash and write time become its ETag and LastModified.
  *
@@ -24,22 +29,38 @@ import type { SimGetObjectCommandOutput } from "./get-object.command.js";
  */
 export class GetObjectLoader {
   /**
-   * Read an Object from the resolved Bucket and build its SDK command output.
+   * Read an Object, or the range of it that was asked for, from the resolved
+   * Bucket, and build its SDK command output.
    */
   async load(
     bucket: SimS3Bucket,
     key: string,
+    rangeHeader?: string,
   ): Promise<SimGetObjectCommandOutput> {
     const object = await bucket.getObject(key);
     if (object === undefined) {
       throw new SimS3NoSuchKey(`No S3 Object named ${key}`);
     }
 
+    const size = object.body.length;
+    const range = simS3ReadObjectRange(rangeHeader, size);
+    const body =
+      range === undefined
+        ? object.body
+        : object.body.subarray(range.start, range.end + 1);
+
     return {
-      Body: Readable.from([object.body]),
+      Body: Readable.from([body]),
       Metadata: object.metadata.values,
+      // The ETag identifies the Object rather than the bytes being sent. A
+      // client reading it in pieces compares the value across them to see
+      // whether the Object changed underneath it.
       ETag: simS3QuotedETag(object.etag),
       LastModified: object.lastModified,
+      ContentLength: body.length,
+      ...(range !== undefined && {
+        ContentRange: simS3ContentRange(range, size),
+      }),
       $metadata: {},
     };
   }

--- a/src/service/s3/command/get-object/get-object-range.iso.test.ts
+++ b/src/service/s3/command/get-object/get-object-range.iso.test.ts
@@ -1,0 +1,278 @@
+import type { Readable } from "node:stream";
+
+import {
+  CreateBucketCommand,
+  GetObjectCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import { simS3BodyToBuffer } from "../../storage/s3-body-buffer.js";
+import { SimS3 } from "../../sim-s3.js";
+
+/**
+ * Reading part of a simulated S3 Object.
+ *
+ * This is the path anything downloading a file of real size takes: the `aws`
+ * CLI above eight megabytes asks for the parts at once and joins them by the
+ * offsets it asked for, so an answer carrying more bytes than the request asked
+ * for writes a file that is neither the right size nor the right content.
+ */
+describe("Simulated S3 GetObject with a Range", () => {
+  /** The digits, so the offset of every byte is the byte itself. */
+  const content = "0123456789";
+
+  const bucketHolding = async (body: string): Promise<SimS3> => {
+    const simS3 = new SimS3();
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "widgets" }));
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "widgets",
+        Key: "digits.txt",
+        Body: body,
+      }),
+    );
+
+    return simS3;
+  };
+
+  const readContent = async (body: Readable | undefined): Promise<string> => {
+    assertDefined(body, "the read Object body");
+
+    const buffer = await simS3BodyToBuffer(body);
+
+    return buffer.toString("utf8");
+  };
+
+  const readWholeObject = async (
+    simS3: SimS3,
+    header: string,
+  ): Promise<{ body: string; contentRange: string | undefined }> => {
+    const read = await simS3.getObject(
+      new GetObjectCommand({
+        Bucket: "widgets",
+        Key: "digits.txt",
+        Range: header,
+      }),
+    );
+
+    return {
+      body: await readContent(read.Body),
+      contentRange: read.ContentRange,
+    };
+  };
+
+  it("answers a start and end with the bytes between them", async () => {
+    // Given an Object of known bytes
+    const simS3 = await bucketHolding(content);
+
+    // When bytes two to five are asked for
+    const read = await simS3.getObject(
+      new GetObjectCommand({
+        Bucket: "widgets",
+        Key: "digits.txt",
+        Range: "bytes=2-5",
+      }),
+    );
+
+    // Then those bytes come back, described by where in the Object they are
+    assertIdentical(await readContent(read.Body), "2345");
+    assertIdentical(read.ContentLength, 4);
+    assertIdentical(read.ContentRange, "bytes 2-5/10");
+  });
+
+  it("answers a start alone with the rest of the Object", async () => {
+    // Given an Object of known bytes
+    const simS3 = await bucketHolding(content);
+
+    // When everything from byte six is asked for
+    const read = await simS3.getObject(
+      new GetObjectCommand({
+        Bucket: "widgets",
+        Key: "digits.txt",
+        Range: "bytes=6-",
+      }),
+    );
+
+    // Then the read runs to the end of the Object
+    assertIdentical(await readContent(read.Body), "6789");
+    assertIdentical(read.ContentRange, "bytes 6-9/10");
+  });
+
+  it("answers a suffix with the last bytes of the Object", async () => {
+    // Given an Object of known bytes
+    const simS3 = await bucketHolding(content);
+
+    // When the last three bytes are asked for, without saying where they start
+    const read = await simS3.getObject(
+      new GetObjectCommand({
+        Bucket: "widgets",
+        Key: "digits.txt",
+        Range: "bytes=-3",
+      }),
+    );
+
+    // Then the suffix is resolved against the size the Object turned out to be
+    assertIdentical(await readContent(read.Body), "789");
+    assertIdentical(read.ContentRange, "bytes 7-9/10");
+  });
+
+  it("stops a range that runs past the end at the last byte", async () => {
+    // Given an Object of known bytes
+    const simS3 = await bucketHolding(content);
+
+    // When more bytes are asked for than the Object holds
+    const read = await simS3.getObject(
+      new GetObjectCommand({
+        Bucket: "widgets",
+        Key: "digits.txt",
+        Range: "bytes=6-99",
+      }),
+    );
+
+    // Then what there is comes back, which is what a client reading a file
+    // whose size it guessed at depends on
+    assertIdentical(await readContent(read.Body), "6789");
+    assertIdentical(read.ContentRange, "bytes 6-9/10");
+  });
+
+  it("answers a suffix longer than the Object with the whole of it", async () => {
+    // Given an Object of known bytes
+    const simS3 = await bucketHolding(content);
+
+    // When a suffix longer than the Object is asked for
+    const read = await simS3.getObject(
+      new GetObjectCommand({
+        Bucket: "widgets",
+        Key: "digits.txt",
+        Range: "bytes=-40",
+      }),
+    );
+
+    // Then the whole Object comes back, still as a partial read
+    assertIdentical(await readContent(read.Body), content);
+    assertIdentical(read.ContentRange, "bytes 0-9/10");
+  });
+
+  it("refuses a range starting past the end of the Object", async () => {
+    // Given an Object of known bytes
+    const simS3 = await bucketHolding(content);
+
+    // When a range beyond the last byte is asked for
+    const error = await assertThrowsErrorAsync(async () => {
+      await simS3.getObject(
+        new GetObjectCommand({
+          Bucket: "widgets",
+          Key: "digits.txt",
+          Range: "bytes=10-12",
+        }),
+      );
+    });
+
+    // Then it is refused under the name real S3 refuses it by, rather than
+    // answered with no bytes
+    assertIdentical(error.name, "InvalidRange");
+  });
+
+  it("refuses a suffix of no bytes", async () => {
+    // Given an Object of known bytes
+    const simS3 = await bucketHolding(content);
+
+    // When the last nothing bytes are asked for
+    const error = await assertThrowsErrorAsync(async () => {
+      await simS3.getObject(
+        new GetObjectCommand({
+          Bucket: "widgets",
+          Key: "digits.txt",
+          Range: "bytes=-0",
+        }),
+      );
+    });
+
+    // Then there is no slice to answer with, so it is refused
+    assertIdentical(error.name, "InvalidRange");
+  });
+
+  it("refuses any range of an empty Object", async () => {
+    // Given an Object holding nothing
+    const simS3 = await bucketHolding("");
+
+    // When the first byte of it is asked for
+    const error = await assertThrowsErrorAsync(async () => {
+      await simS3.getObject(
+        new GetObjectCommand({
+          Bucket: "widgets",
+          Key: "digits.txt",
+          Range: "bytes=0-",
+        }),
+      );
+    });
+
+    // Then it is refused, there being no byte at any offset
+    assertIdentical(error.name, "InvalidRange");
+  });
+
+  it("reads a Range it cannot make sense of as no Range at all", async () => {
+    // Given an Object of known bytes
+    const simS3 = await bucketHolding(content);
+
+    // When ranges S3 does not answer are asked for (another unit, a start after
+    // its end, several ranges at once, a header naming neither end of a range,
+    // and one naming no range at all)
+    const reads = await Promise.all(
+      ["items=0-1", "bytes=5-2", "bytes=0-1,4-5", "bytes=-", "bytes"].map(
+        async (header) => await readWholeObject(simS3, header),
+      ),
+    );
+
+    // Then each one answers with the whole Object, describing no range, as a
+    // read that asked for none does
+    for (const read of reads) {
+      assertIdentical(read.body, content);
+      assertUndefined(read.contentRange);
+    }
+  });
+
+  it("gives a partial read the whole Object's ETag", async () => {
+    // Given an Object of known bytes
+    const simS3 = await bucketHolding(content);
+
+    // When part of it is read
+    const whole = await simS3.getObject(
+      new GetObjectCommand({ Bucket: "widgets", Key: "digits.txt" }),
+    );
+    const part = await simS3.getObject(
+      new GetObjectCommand({
+        Bucket: "widgets",
+        Key: "digits.txt",
+        Range: "bytes=0-1",
+      }),
+    );
+
+    // Then it identifies the Object the bytes came from, not the bytes, which
+    // is what lets a client check the Object did not change between parts
+    assertIdentical(part.ETag, whole.ETag);
+  });
+
+  it("leaves a read of the whole Object as it was", async () => {
+    // Given an Object of known bytes
+    const simS3 = await bucketHolding(content);
+
+    // When it is read with no Range
+    const read = await simS3.getObject(
+      new GetObjectCommand({ Bucket: "widgets", Key: "digits.txt" }),
+    );
+
+    // Then the whole Object comes back, describing no range
+    assertIdentical(await readContent(read.Body), content);
+    assertIdentical(read.ContentLength, 10);
+    assertUndefined(read.ContentRange);
+  });
+});

--- a/src/service/s3/command/get-object/get-object.command.ts
+++ b/src/service/s3/command/get-object/get-object.command.ts
@@ -14,6 +14,12 @@ export interface SimGetObjectCommand {
 export interface SimGetObjectCommandInput {
   readonly Bucket?: string | undefined;
   readonly Key?: string | undefined;
+  /**
+   * The bytes of the Object to read, as an HTTP `Range` header: `bytes=0-499`,
+   * `bytes=500-` or `bytes=-500`. A read that states no range reads the whole
+   * Object.
+   */
+  readonly Range?: string | undefined;
 }
 
 /**
@@ -21,11 +27,18 @@ export interface SimGetObjectCommandInput {
  *
  * `ETag` is quoted, as real S3 and the SDK give it. `LastModified` is when the
  * Object was written, by the simulation's clock.
+ *
+ * `ContentLength` describes the body being sent rather than the Object, so a
+ * ranged read reports the size of its slice. `ContentRange` says which bytes
+ * of the Object those are, and is set only for a read that asked for some of
+ * them.
  */
 export interface SimGetObjectCommandOutput {
   readonly Body?: Readable;
   readonly Metadata?: Record<string, string>;
   readonly ETag?: string;
   readonly LastModified?: Date;
+  readonly ContentLength?: number;
+  readonly ContentRange?: string;
   readonly $metadata: SimResponseMetadata;
 }

--- a/src/service/s3/command/get-object/get-object.handler.ts
+++ b/src/service/s3/command/get-object/get-object.handler.ts
@@ -62,6 +62,9 @@ export class GetObjectCommandHandler implements CommandHandler<
    * - authorization occurs before key lookup so denied callers cannot determine
    *   whether an Object exists;
    * - the loader performs storage access only after authorization succeeds.
+   *
+   * A stated `Range` reaches the loader with the key, since which bytes of an
+   * Object a caller may read is not something IAM decides.
    */
   async handle(
     command: SimGetObjectCommand,
@@ -81,6 +84,10 @@ export class GetObjectCommandHandler implements CommandHandler<
 
     this.authorizer.authorize(bucket, command.input.Key, options);
 
-    return await this.loader.load(bucket, command.input.Key);
+    return await this.loader.load(
+      bucket,
+      command.input.Key,
+      command.input.Range,
+    );
   }
 }

--- a/src/service/s3/error/sim-s3.error.ts
+++ b/src/service/s3/error/sim-s3.error.ts
@@ -219,3 +219,20 @@ export class SimS3InvalidPartOrder extends SimS3Error {
     super(message, { httpStatusCode: 400 });
   }
 }
+
+/**
+ * Simulated S3 InvalidRange error.
+ *
+ * A read whose `Range` names bytes the Object does not hold, which real S3
+ * refuses with `416 Range Not Satisfiable` rather than answering with the
+ * bytes it does hold. A client that asked for a range it cannot have has
+ * misjudged the Object's size, and reading a different slice than the one it
+ * asked for would leave it assembling a file out of the wrong pieces.
+ */
+export class SimS3InvalidRange extends SimS3Error {
+  public override readonly name = "InvalidRange";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 416 });
+  }
+}

--- a/src/service/s3/object/s3-object-range.ts
+++ b/src/service/s3/object/s3-object-range.ts
@@ -1,0 +1,131 @@
+import { SimS3InvalidRange } from "../error/sim-s3.error.js";
+
+/**
+ * The bytes of an Object a read asked for, as offsets into it.
+ */
+export interface SimS3ObjectRange {
+  readonly start: number;
+  /** Inclusive, as the last byte of an HTTP byte range is. */
+  readonly end: number;
+}
+
+/**
+ * A single range of bytes, the only form S3 answers.
+ *
+ * A request for several ranges at once does not match, and neither does one
+ * counted in anything but bytes, so both fall through to being read as no
+ * range at all.
+ */
+const byteRange = /^\d*-\d*$/;
+
+const byteUnit = "bytes=";
+
+/**
+ * Resolve the `Range` of a read against the Object it was sent for.
+ *
+ * `undefined` means the whole Object, and covers both a read that asked for no
+ * range and one whose `Range` S3 does not answer. HTTP has an unsatisfiable
+ * range refused and an unreadable one ignored, and S3 follows it. A range S3
+ * cannot make sense of leaves the response as it would have been without it.
+ * A range naming bytes the Object does not hold is refused outright.
+ *
+ * https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html
+ */
+export function simS3ReadObjectRange(
+  header: string | undefined,
+  size: number,
+): SimS3ObjectRange | undefined {
+  const stated = header?.trim() ?? "";
+  const spec = stated.startsWith(byteUnit) ? stated.slice(byteUnit.length) : "";
+
+  if (!byteRange.test(spec)) {
+    return undefined;
+  }
+
+  const dash = spec.indexOf("-");
+  const from = spec.slice(0, dash);
+  const to = spec.slice(dash + 1);
+
+  if (from === "") {
+    return suffixRange(to, size, stated);
+  }
+
+  return offsetRange(Number(from), to, size, stated);
+}
+
+/**
+ * How a response describes the bytes it carries. It names them by offset, and
+ * gives the size of the Object they came from.
+ */
+export function simS3ContentRange(
+  range: SimS3ObjectRange,
+  size: number,
+): string {
+  return `bytes ${range.start}-${range.end}/${size}`;
+}
+
+/**
+ * The last so many bytes of an Object, which is what a read states when it
+ * knows how much it wants and not where the Object ends.
+ */
+function suffixRange(
+  suffix: string,
+  size: number,
+  header: string,
+): SimS3ObjectRange | undefined {
+  // `bytes=-` says neither where to start nor how much to read.
+  if (suffix === "") {
+    return undefined;
+  }
+
+  const length = Number(suffix);
+
+  // A suffix longer than the Object is the whole of it, so the only ones with
+  // nothing to answer are a suffix of no bytes and any suffix of an Object of
+  // no bytes.
+  if (length === 0 || size === 0) {
+    throw unsatisfiable(header, size);
+  }
+
+  return { start: Math.max(0, size - length), end: size - 1 };
+}
+
+/**
+ * A range stated as where to start reading, and where to stop if the read is
+ * not to run to the end of the Object.
+ */
+function offsetRange(
+  start: number,
+  to: string,
+  size: number,
+  header: string,
+): SimS3ObjectRange | undefined {
+  const statedEnd = to === "" ? undefined : Number(to);
+
+  // A range ending before it begins is one no response could carry, so it is
+  // read as no range rather than refused.
+  if (statedEnd !== undefined && statedEnd < start) {
+    return undefined;
+  }
+
+  if (start >= size) {
+    throw unsatisfiable(header, size);
+  }
+
+  // A read may ask for more than is there, and gets what there is. A client
+  // reading a file in fixed-size pieces asks for a whole piece at the end.
+  return { start, end: Math.min(statedEnd ?? size - 1, size - 1) };
+}
+
+/**
+ * Refuse a range of bytes the Object does not hold.
+ *
+ * `InvalidRange` is the code real S3 answers with, and 416 the status, so a
+ * client reads why it has to ask again for something else.
+ */
+function unsatisfiable(header: string, size: number): Error {
+  return new SimS3InvalidRange(
+    `The requested range is not satisfiable. ${header} names bytes ` +
+      `an S3 Object of ${size} bytes does not hold`,
+  );
+}

--- a/src/service/s3/object/s3-object-response-headers.ts
+++ b/src/service/s3/object/s3-object-response-headers.ts
@@ -12,6 +12,11 @@ export interface SimS3ObjectResponseDescription {
   readonly etag?: string | undefined;
   /** When S3 last wrote the Object. */
   readonly lastModified?: Date | undefined;
+  /**
+   * Which bytes of the Object are being served, for a read that asked for some
+   * of them rather than all of them.
+   */
+  readonly contentRange?: string | undefined;
 }
 
 /**
@@ -26,7 +31,8 @@ export interface SimS3ObjectResponseDescription {
  *
  * `ETag` and `Last-Modified` are not metadata but facts about the stored bytes,
  * and are what makes a conditional request or a content-hash comparison
- * possible over HTTP.
+ * possible over HTTP. `Content-Range` is a fact about the response rather than
+ * the Object. It says which of the Object's bytes the ones being sent are.
  *
  * Every path that serves an Object goes through here, so they agree on what
  * reading one looks like.
@@ -54,6 +60,10 @@ export function simS3ObjectResponseHeaders(
 
   if (description.lastModified !== undefined) {
     headers["last-modified"] = description.lastModified.toUTCString();
+  }
+
+  if (description.contentRange !== undefined) {
+    headers["content-range"] = description.contentRange;
   }
 
   return headers;

--- a/src/service/s3/serve/api/sim-s3-api-input.ts
+++ b/src/service/s3/serve/api/sim-s3-api-input.ts
@@ -8,13 +8,6 @@ export function bucketInput(request: SimS3ApiRequest): object {
 }
 
 /**
- * The input of an operation naming one Object.
- */
-export function objectInput(request: SimS3ApiRequest): object {
-  return { Bucket: request.bucketName, Key: request.objectKey };
-}
-
-/**
  * The input of an operation that names a Bucket and reads its body into one
  * member, which every configuration write does.
  */
@@ -24,34 +17,6 @@ export function bucketBodyInput<T>(
   read: (body: string) => T,
 ): object {
   return { Bucket: request.bucketName, [member]: read(utf8(request.body)) };
-}
-
-/**
- * The input of an upload, which carries its bytes and the headers describing
- * them.
- */
-export function putObjectInput(request: SimS3ApiRequest): object {
-  return { ...createMultipartUploadInput(request), Body: request.body };
-}
-
-/**
- * The input of a request that describes an Object without carrying its bytes,
- * which is what starting a multipart upload is.
- */
-export function createMultipartUploadInput(request: SimS3ApiRequest): object {
-  return {
-    Bucket: request.bucketName,
-    Key: request.objectKey,
-    ...optional("ContentType", request.headers.get("content-type")),
-    ...optional("CacheControl", request.headers.get("cache-control")),
-    ...optional(
-      "ContentDisposition",
-      request.headers.get("content-disposition"),
-    ),
-    ...optional("ContentEncoding", request.headers.get("content-encoding")),
-    ...optional("ContentLanguage", request.headers.get("content-language")),
-    ...simS3UserMetadata(request.headers),
-  };
 }
 
 /**

--- a/src/service/s3/serve/api/sim-s3-api-object-input.ts
+++ b/src/service/s3/serve/api/sim-s3-api-object-input.ts
@@ -1,0 +1,55 @@
+import { optional, simS3UserMetadata } from "./sim-s3-api-input.js";
+import type { SimS3ApiRequest } from "./sim-s3-api-request.js";
+
+/**
+ * Reading the Object operations' inputs out of a request.
+ *
+ * S3 puts an Object's key in the path and everything said about its bytes in
+ * the headers, so these read the two together where a Bucket operation reads
+ * the query string or the body.
+ */
+
+/**
+ * The input of an operation naming one Object.
+ */
+export function objectInput(request: SimS3ApiRequest): object {
+  return { Bucket: request.bucketName, Key: request.objectKey };
+}
+
+/**
+ * The input of a read, which can ask for part of an Object.
+ */
+export function getObjectInput(request: SimS3ApiRequest): object {
+  return {
+    ...objectInput(request),
+    ...optional("Range", request.headers.get("range")),
+  };
+}
+
+/**
+ * The input of an upload, which carries its bytes and the headers describing
+ * them.
+ */
+export function putObjectInput(request: SimS3ApiRequest): object {
+  return { ...createMultipartUploadInput(request), Body: request.body };
+}
+
+/**
+ * The input of a request that describes an Object without carrying its bytes,
+ * which is what starting a multipart upload is.
+ */
+export function createMultipartUploadInput(request: SimS3ApiRequest): object {
+  return {
+    Bucket: request.bucketName,
+    Key: request.objectKey,
+    ...optional("ContentType", request.headers.get("content-type")),
+    ...optional("CacheControl", request.headers.get("cache-control")),
+    ...optional(
+      "ContentDisposition",
+      request.headers.get("content-disposition"),
+    ),
+    ...optional("ContentEncoding", request.headers.get("content-encoding")),
+    ...optional("ContentLanguage", request.headers.get("content-language")),
+    ...simS3UserMetadata(request.headers),
+  };
+}

--- a/src/service/s3/serve/api/sim-s3-api-object-output.ts
+++ b/src/service/s3/serve/api/sim-s3-api-object-output.ts
@@ -2,19 +2,26 @@ import { simS3ObjectResponseHeaders } from "../../object/s3-object-response-head
 
 /**
  * Answer a read with the Object itself, headers and all.
+ *
+ * A read that asked for part of the Object is answered `206 Partial Content`
+ * and says which part it carries, because a client reading a large Object in
+ * pieces at once writes each response at the offset it asked for, and a `200`
+ * carrying the whole Object would be written over its neighbours.
  */
 export async function simS3GetObjectResponse(
   output: Record<string, unknown>,
 ): Promise<Response> {
   const body = await objectBodyBytes(output["Body"]);
+  const contentRange = output["ContentRange"] as string | undefined;
 
   return new Response(body, {
-    status: 200,
+    status: contentRange === undefined ? 200 : 206,
     headers: simS3ObjectResponseHeaders({
       metadata: output["Metadata"] as Record<string, string> | undefined,
       bodyLength: body.length,
       etag: output["ETag"] as string | undefined,
       lastModified: output["LastModified"] as Date | undefined,
+      contentRange,
     }),
   });
 }

--- a/src/service/s3/serve/api/sim-s3-api-object-routes.ts
+++ b/src/service/s3/serve/api/sim-s3-api-object-routes.ts
@@ -1,8 +1,9 @@
 import {
   createMultipartUploadInput,
+  getObjectInput,
   objectInput,
   putObjectInput,
-} from "./sim-s3-api-input.js";
+} from "./sim-s3-api-object-input.js";
 import {
   completeMultipartUploadInput,
   uploadInput,
@@ -24,7 +25,7 @@ export const simS3ObjectApiRoutes: readonly SimS3ApiRoute[] = [
     method: "GET",
     target: "object",
     commandName: "GetObjectCommand",
-    input: objectInput,
+    input: getObjectInput,
   },
   {
     method: "GET",

--- a/src/service/s3/serve/api/sim-s3-api.loc.test.ts
+++ b/src/service/s3/serve/api/sim-s3-api.loc.test.ts
@@ -136,6 +136,35 @@ describe("Serving the simulated S3 REST API on an endpoint URL", () => {
     assertIdentical(read.ContentType, "text/plain");
   });
 
+  it("reads part of an Object, and says which part it is", async () => {
+    // Given an Object of known bytes on the served endpoint
+    await client.send(new CreateBucketCommand({ Bucket: "ranged" }));
+    await client.send(
+      new PutObjectCommand({
+        Bucket: "ranged",
+        Key: "digits",
+        Body: "0123456789",
+      }),
+    );
+
+    // When some of its bytes are asked for, as a client downloading a large
+    // Object in pieces at once asks for each of them
+    const read = await client.send(
+      new GetObjectCommand({
+        Bucket: "ranged",
+        Key: "digits",
+        Range: "bytes=2-5",
+      }),
+    );
+
+    // Then that slice comes back as partial content, described by where in the
+    // Object it is, rather than the whole Object under a 200
+    assertIdentical(read.$metadata.httpStatusCode, 206);
+    assertIdentical(await read.Body?.transformToString(), "2345");
+    assertIdentical(read.ContentLength, 4);
+    assertIdentical(read.ContentRange, "bytes 2-5/10");
+  });
+
   it("lists Objects with their sizes, and filters by prefix", async () => {
     // Given a Bucket holding Objects under two prefixes
     await client.send(new CreateBucketCommand({ Bucket: "listing" }));

--- a/src/service/s3/serve/api/sim-s3-multipart-cli.loc.test.ts
+++ b/src/service/s3/serve/api/sim-s3-multipart-cli.loc.test.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
 import { promisify } from "node:util";
 
 import {
@@ -35,7 +36,7 @@ const runFile = promisify(execFile);
  * Nothing here knows the upload was in parts: `aws s3 cp` is asked for a file
  * and `aws s3 ls` is asked what the Bucket holds.
  */
-describe("Copying a large file into simulated S3 with the aws CLI", () => {
+describe("Copying a large file in and out of simulated S3 with the aws CLI", () => {
   const simAws = new SimAws();
   const srv = new SimAwsLocalServer({ simAws });
   const simS3 = simAws.s3();
@@ -183,5 +184,24 @@ describe("Copying a large file into simulated S3 with the aws CLI", () => {
     // ordinary tooling can put in and take out again
     const listed = await aws("s3", "ls", "s3://widgets/round-trip.bin");
     assertStringIncludes(listed, `${fileSize} round-trip.bin`);
+  });
+
+  it("writes the downloaded file byte for byte", async () => {
+    // Given an Object above the size the CLI downloads in one request, which
+    // it fetches as several ranged reads at once
+    await aws("s3", "cp", filePath, "s3://widgets/checked-download.bin");
+
+    // When it is copied back to a local file
+    const downloadPath = files.join("checked-download.bin");
+    await aws("s3", "cp", "s3://widgets/checked-download.bin", downloadPath);
+
+    // Then the file on disk is the file that was uploaded, which a read
+    // answering each of those requests with the whole Object would not be
+    // oxlint-disable-next-line security/detect-non-literal-fs-filename -- this test's own temporary directory
+    const downloaded = await readFile(downloadPath);
+    assertIdentical(downloaded.byteLength, fileSize);
+    assertIdentical(downloaded.at(0), byteAt(0));
+    assertIdentical(downloaded.at(9 * 1024 * 1024), byteAt(9 * 1024 * 1024));
+    assertIdentical(downloaded.at(fileSize - 1), byteAt(fileSize - 1));
   });
 });

--- a/src/service/s3/serve/sim-s3-rest-object-reader.ts
+++ b/src/service/s3/serve/sim-s3-rest-object-reader.ts
@@ -9,6 +9,11 @@ import { simS3ObjectResponseHeaders } from "../object/s3-object-response-headers
  * The two share everything but the body, because a `HEAD` is a `GET` whose
  * response real S3 stops short of sending, so they are read the same way here
  * and differ only in what comes back.
+ *
+ * A `GET` may ask for part of the Object, and is answered with that part and
+ * `206 Partial Content`. A `HEAD` may not. Simulated S3 describes the whole
+ * Object however it is asked about, and HeadObject does the same for an
+ * in-process caller.
  */
 export class SimS3RestObjectReader {
   /**
@@ -19,8 +24,17 @@ export class SimS3RestObjectReader {
     route: SimS3RestObjectRoute,
     serviceRequest: SimAwsServiceRequest,
   ): Promise<Response> {
+    const { request } = serviceRequest;
+    const head = request.method === "HEAD";
+
     const output = await simS3.getObject(
-      { input: { Bucket: route.bucket.bucketName, Key: route.objectKey } },
+      {
+        input: {
+          Bucket: route.bucket.bucketName,
+          Key: route.objectKey,
+          Range: head ? undefined : (request.headers.get("range") ?? undefined),
+        },
+      },
       { caller: serviceRequest.caller.toCaller() },
     );
 
@@ -30,13 +44,17 @@ export class SimS3RestObjectReader {
       bodyLength: body.length,
       etag: output.ETag,
       lastModified: output.LastModified,
+      contentRange: output.ContentRange,
     });
 
-    if (serviceRequest.request.method === "HEAD") {
+    if (head) {
       return new Response(undefined, { status: 200, headers });
     }
 
-    return new Response(body, { status: 200, headers });
+    return new Response(body, {
+      status: output.ContentRange === undefined ? 200 : 206,
+      headers,
+    });
   }
 }
 

--- a/src/service/s3/serve/sim-s3-rest-range.iso.test.ts
+++ b/src/service/s3/serve/sim-s3-rest-range.iso.test.ts
@@ -1,0 +1,118 @@
+import { GetObjectCommand, HeadObjectCommand } from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { assertIdentical } from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import type { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import {
+  presignBucketName,
+  presignObjectBody,
+  presignObjectKey,
+  presignSimulation,
+} from "../../../../test/s3/presign-simulation.js";
+
+interface PresignedRead {
+  readonly url: string;
+  readonly http: SimAwsHttp;
+}
+
+/**
+ * Asking the simulated S3 REST endpoint for part of an Object.
+ *
+ * A client downloading a large Object asks for its pieces at once and writes
+ * each response at the offset it asked for, so what matters over HTTP is that
+ * a partial response says it is a partial one. A `200` carrying the whole
+ * Object where a `206` was expected is written over its neighbours, and the
+ * file that lands is neither the right size nor the right content.
+ */
+describe("A ranged read at the simulated S3 REST endpoint", () => {
+  const presignedRead = async (): Promise<PresignedRead> => {
+    const { client, http } = await presignSimulation();
+    const url = await getSignedUrl(
+      client,
+      new GetObjectCommand({
+        Bucket: presignBucketName,
+        Key: presignObjectKey,
+      }),
+      { expiresIn: 900 },
+    );
+
+    return { url, http };
+  };
+
+  it("answers with the bytes asked for, as partial content", async () => {
+    // Given a presigned URL for an Object of known bytes
+    const { url, http } = await presignedRead();
+
+    // When the first nine bytes of it are read
+    const response = await http.fetch(url, { headers: { range: "bytes=0-8" } });
+
+    // Then those bytes come back as a partial response, saying which of the
+    // Object's bytes they are
+    assertIdentical(response.status, 206);
+    assertIdentical(await response.text(), presignObjectBody.slice(0, 9));
+    assertIdentical(response.headers.get("content-length"), "9");
+    assertIdentical(
+      response.headers.get("content-range"),
+      `bytes 0-8/${presignObjectBody.length}`,
+    );
+  });
+
+  it("answers a read of the whole Object as it did before", async () => {
+    // Given a presigned URL for an Object of known bytes
+    const { url, http } = await presignedRead();
+
+    // When it is read without asking for a range
+    const response = await http.fetch(url);
+
+    // Then the whole Object comes back, describing no range
+    assertIdentical(response.status, 200);
+    assertIdentical(await response.text(), presignObjectBody);
+    assertIdentical(response.headers.get("content-range"), null);
+  });
+
+  it("refuses a range of bytes the Object does not hold", async () => {
+    // Given a presigned URL for an Object of known bytes
+    const { url, http } = await presignedRead();
+
+    // When bytes beyond the end of it are read
+    const response = await http.fetch(url, {
+      headers: { range: "bytes=900-999" },
+    });
+
+    // Then the read is refused, in the XML shape a client reads the code out
+    // of, rather than answered with bytes it did not ask for
+    assertIdentical(response.status, 416);
+    expect(await response.text()).toMatch(/<Code>InvalidRange<\/Code>/);
+  });
+
+  it("describes the whole Object however a HEAD asks about it", async () => {
+    // Given a URL presigned for HEAD, since the method is signed and a URL
+    // presigned for GET cannot be used with another
+    const { client, http } = await presignSimulation();
+    const url = await getSignedUrl(
+      client,
+      new HeadObjectCommand({
+        Bucket: presignBucketName,
+        Key: presignObjectKey,
+      }),
+      { expiresIn: 900 },
+    );
+
+    // When the Object is asked about with a range
+    const response = await http.fetch(url, {
+      method: "HEAD",
+      headers: { range: "bytes=0-8" },
+    });
+
+    // Then the answer describes the Object rather than the range, which is
+    // what HeadObject tells an in-process caller too: simulated S3 does not
+    // answer a ranged HEAD as real S3 does
+    assertIdentical(response.status, 200);
+    assertIdentical(
+      response.headers.get("content-length"),
+      String(presignObjectBody.length),
+    );
+    assertIdentical(response.headers.get("content-range"), null);
+  });
+});


### PR DESCRIPTION
Simulated S3 answered every read with the whole Object, so `aws s3 cp` wrote a 20MB file for a 12MB Object above the CLI's 8MB threshold, where it splits a download into concurrent ranged GETs. `GetObjectCommand` now takes a `Range` and answers with the bytes it names, in the three forms real S3 reads, alongside a `ContentLength` for the slice and a `ContentRange` describing it. A served ranged read answers `206 Partial Content` with a `content-range` header, over an endpoint URL and the S3 REST endpoint alike, and a range naming bytes the Object does not hold is refused as `InvalidRange` under a 416. A `Range` S3 cannot make sense of is ignored and the whole Object comes back under a `200`, as before. `Range` on `HeadObject` and the `If-Range` conditional are left out.

Resolves #717