### PR TITLE
feat: delete a sim IAM User

### DIFF
--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -798,7 +798,7 @@ Group membership is a gap. A `Groups` entry fails the Resource. An empty list st
 leaves `Groups` out of the template for a User that belongs to no group.
 
 Deleting the Stack deletes the User. Its inline policies and managed policy attachments come off
-first, the way a Role's do, and the User name is free for the same template to deploy again.
+first, as they do for a Role, and the User name is free for the same template to deploy again.
 
 ```typescript sim-iam-cloudformation-user
 /**
@@ -1087,9 +1087,9 @@ Sim IAM models the policy behaviour that multi-service tests most commonly need.
   fails too
 - Permissions boundaries, session policies, and service control policies are not evaluated
 - Managed Policies have a single version, and the policy version commands are absent
-- A User's policies only come off with the User. `DeleteUserPolicy` and `DetachUserPolicy` are
-  absent, along with `DeleteAccessKey` and `DeleteLoginProfile`. CloudFormation teardown clears a
-  User's policies itself before deleting it
+- `DeleteUserPolicy` and `DetachUserPolicy` are absent, along with `DeleteAccessKey` and
+  `DeleteLoginProfile`. `DeleteUserCommand` refuses a User that still holds a policy, and
+  CloudFormation teardown clears a User's policies before deleting it
 - Only the condition operators listed above are supported. A statement using any other operator
   fails closed, matching no request
 - Signature age is deliberately not enforced. `X-Amz-Date` must be present, well formed, and agree

--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -298,6 +298,11 @@ issue access keys with `CreateAccessKeyCommand`. Access keys are registered with
 credential registry. Credentials can then be supplied as the caller of an authorization attempt,
 and are authenticated before policy evaluation.
 
+`DeleteUserCommand` removes a User. IAM refuses it while the User still holds an inline policy or an
+attached managed policy, the way `DeleteRoleCommand` refuses a Role, and answers `NoSuchEntity` for
+a name the Account does not hold. Real IAM also refuses a User that still has access keys or a login
+profile. Sim IAM serves no way to remove either, and lets the User go.
+
 ```typescript sim-iam-user-access-key
 /**
  * Simulated IAM Users, inline policies, and access keys.
@@ -792,6 +797,9 @@ test asserting on the password reads the User record from `SimIam.users`.
 Group membership is a gap. A `Groups` entry fails the Resource. An empty list still deploys, and CDK
 leaves `Groups` out of the template for a User that belongs to no group.
 
+Deleting the Stack deletes the User. Its inline policies and managed policy attachments come off
+first, the way a Role's do, and the User name is free for the same template to deploy again.
+
 ```typescript sim-iam-cloudformation-user
 /**
  * Creating an IAM User through simulated CloudFormation.
@@ -1054,7 +1062,7 @@ Sim IAM currently supports:
 - `PutRolePolicyCommand`, for inline Role policies
 - `CreatePolicyCommand`, `GetPolicyCommand` and `ListPoliciesCommand`, for managed Policies
 - `AttachRolePolicyCommand`
-- `CreateUserCommand`, `PutUserPolicyCommand` and `AttachUserPolicyCommand`
+- `CreateUserCommand`, `DeleteUserCommand`, `PutUserPolicyCommand` and `AttachUserPolicyCommand`
 - `CreateLoginProfileCommand`, for a User's console password
 - `CreateAccessKeyCommand`, registering access keys for credential authentication
 - Allow/deny authorization decisions with `authorize(...)`, evaluating identity policies,
@@ -1079,7 +1087,9 @@ Sim IAM models the policy behaviour that multi-service tests most commonly need.
   fails too
 - Permissions boundaries, session policies, and service control policies are not evaluated
 - Managed Policies have a single version, and the policy version commands are absent
-- Deleting and detaching resources (Roles, Users, Policies, access keys) is not yet supported
+- A User's policies only come off with the User. `DeleteUserPolicy` and `DetachUserPolicy` are
+  absent, along with `DeleteAccessKey` and `DeleteLoginProfile`. CloudFormation teardown clears a
+  User's policies itself before deleting it
 - Only the condition operators listed above are supported. A statement using any other operator
   fails closed, matching no request
 - Signature age is deliberately not enforced. `X-Amz-Date` must be present, well formed, and agree

--- a/src/service/iam/cfn/sim-cfn-iam-resource-deleter.ts
+++ b/src/service/iam/cfn/sim-cfn-iam-resource-deleter.ts
@@ -4,6 +4,7 @@ import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/va
 import type { SimIam } from "../sim-iam.js";
 import type { SimIamManagedPolicy } from "../policy/sim-iam-policy.js";
 import { SimCfnIamRoleDeleter } from "./role/sim-cfn-iam-role-deleter.js";
+import { SimCfnIamUserDeleter } from "./user/sim-cfn-iam-user-deleter.js";
 import { assertDefined } from "../../../util/type-guard/defined.js";
 
 interface SimCfnIamResourceDeleterProperties {
@@ -16,10 +17,12 @@ interface SimCfnIamResourceDeleterProperties {
 export class SimCfnIamResourceDeleter {
   private readonly iam: SimIam;
   private readonly roleDeleter: SimCfnIamRoleDeleter;
+  private readonly userDeleter: SimCfnIamUserDeleter;
 
   constructor(properties: SimCfnIamResourceDeleterProperties) {
     this.iam = properties.iam;
     this.roleDeleter = new SimCfnIamRoleDeleter({ iam: properties.iam });
+    this.userDeleter = new SimCfnIamUserDeleter({ iam: properties.iam });
   }
 
   /**
@@ -41,6 +44,10 @@ export class SimCfnIamResourceDeleter {
       }
       case "Role": {
         await this.roleDeleter.delete(resource);
+        return;
+      }
+      case "User": {
+        await this.userDeleter.delete(resource);
         return;
       }
       default: {

--- a/src/service/iam/cfn/sim-cfn-iam-teardown.iso.test.ts
+++ b/src/service/iam/cfn/sim-cfn-iam-teardown.iso.test.ts
@@ -9,6 +9,7 @@ import { describe, it } from "vitest";
 
 import { SimAws } from "../../aws/sim-aws.js";
 import type { SimIamRole } from "../role/sim-iam-role.js";
+import type { SimIamUser } from "../user/sim-iam-user.js";
 
 const assumeRolePolicyDocument = {
   Version: "2012-10-17",
@@ -62,6 +63,31 @@ const template = {
   },
 };
 
+const userTemplate = {
+  Resources: {
+    PublishPolicy: {
+      Type: "AWS::IAM::ManagedPolicy",
+      Properties: {
+        ManagedPolicyName: "publish-objects",
+        PolicyDocument: readObjectsDocument,
+      },
+    },
+    PublisherUser: {
+      Type: "AWS::IAM::User",
+      Properties: {
+        UserName: "publisher-user",
+        ManagedPolicyArns: [{ Ref: "PublishPolicy" }],
+        Policies: [
+          {
+            PolicyName: "inline-publish",
+            PolicyDocument: readObjectsDocument,
+          },
+        ],
+      },
+    },
+  },
+};
+
 describe("IAM CloudFormation Resource teardown", () => {
   it("takes a Role's policies off it before deleting the Role", async () => {
     // Given a deployed Role carrying an attached managed policy and two inline
@@ -90,6 +116,60 @@ describe("IAM CloudFormation Resource teardown", () => {
     assertIdentical(
       stack.resources.get("ReadPolicy")?.status,
       "DELETE_COMPLETE",
+    );
+  });
+
+  it("takes a User's policies off it before deleting the User", async () => {
+    // Given a deployed User carrying an attached managed policy and an inline
+    // policy. IAM refuses DeleteUser while either of them is still on it.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "publisher-stack",
+      template: userTemplate,
+    });
+
+    const user = stack.resources.get("PublisherUser")?.simResource as
+      | SimIamUser
+      | undefined;
+    assertIdentical(user?.userName, "publisher-user");
+    assertSetSize(user.attachedPolicyArns, 1);
+    assertMapSize(user.inlinePolicies, 1);
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then the User is gone, along with the managed policy it used.
+    assertUndefined(simAws.iam().users.get(user.userName));
+    assertMapSize(simAws.iam().policies, 0);
+    assertIdentical(
+      stack.resources.get("PublisherUser")?.status,
+      "DELETE_COMPLETE",
+    );
+  });
+
+  it("redeploys the same template into the Account the first Stack left", async () => {
+    // Given a deployed Stack naming its User, which CreateUser refuses a
+    // second time while the first User still holds the name.
+    const simAws = new SimAws();
+    const first = await simAws
+      .cloudFormation()
+      .deployTemplate({ stackName: "publisher-stack", template: userTemplate });
+    await first.teardown();
+
+    // When the same template is deployed into the same Account again.
+    const second = await simAws.cloudFormation().deployTemplate({
+      stackName: "publisher-stack-again",
+      template: userTemplate,
+    });
+
+    // Then the Stack reaches its User, with the name free to take again.
+    const user = second.resources.get("PublisherUser")?.simResource as
+      | SimIamUser
+      | undefined;
+    assertIdentical(user?.userName, "publisher-user");
+    assertIdentical(
+      simAws.iam().users.get(user.userName)?.userName,
+      "publisher-user",
     );
   });
 

--- a/src/service/iam/cfn/user/sim-cfn-iam-user-deleter.ts
+++ b/src/service/iam/cfn/user/sim-cfn-iam-user-deleter.ts
@@ -1,0 +1,43 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimIam } from "../../sim-iam.js";
+import type { SimIamUser } from "../../user/sim-iam-user.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+
+interface SimCfnIamUserDeleterProperties {
+  readonly iam: SimIam;
+}
+
+/**
+ * Deletes simulated Users created from AWS::IAM::User Resources.
+ *
+ * DeleteUser refuses a User that still has policies on it, the way DeleteRole
+ * refuses a Role, so the User's policies come off first. Real CloudFormation
+ * does the same for the ones it put there itself: a `ManagedPolicyArns` entry
+ * is detached and a `Policies` entry removed as part of deleting the User.
+ *
+ * Sim IAM serves no DeleteUserPolicy or DetachUserPolicy, so both come off the
+ * User record here rather than through a command.
+ */
+export class SimCfnIamUserDeleter {
+  private readonly iam: SimIam;
+
+  constructor(properties: SimCfnIamUserDeleterProperties) {
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Delete the User a CloudFormation Resource created.
+   */
+  async delete(resource: SimCfnResource): Promise<void> {
+    const user = resource.simResource as SimIamUser | undefined;
+    assertDefined(
+      user,
+      `sim IAM User for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    user.attachedPolicyArns.clear();
+    user.inlinePolicies.clear();
+
+    await this.iam.deleteUser({ input: { UserName: user.userName } });
+  }
+}

--- a/src/service/iam/command/sim-iam-command.types.ts
+++ b/src/service/iam/command/sim-iam-command.types.ts
@@ -73,3 +73,7 @@ export type {
   SimCreateUserCommand,
   SimCreateUserCommandOutput,
 } from "./user/create-user/create-user.command.js";
+export type {
+  SimDeleteUserCommand,
+  SimDeleteUserCommandOutput,
+} from "./user/delete-user/delete-user.command.js";

--- a/src/service/iam/command/user/delete-user/delete-user.command.ts
+++ b/src/service/iam/command/user/delete-user/delete-user.command.ts
@@ -1,0 +1,20 @@
+/**
+ * Minimal structural sim IAM DeleteUser command.
+ */
+export interface SimDeleteUserCommand {
+  readonly input: SimDeleteUserCommandInput;
+}
+
+/**
+ * Minimal structural sim IAM DeleteUser input.
+ */
+export interface SimDeleteUserCommandInput {
+  readonly UserName?: string | undefined;
+}
+
+/**
+ * Minimal structural sim IAM DeleteUser output.
+ *
+ * Real IAM answers a successful DeleteUser with an empty response body.
+ */
+export type SimDeleteUserCommandOutput = Record<string, never>;

--- a/src/service/iam/command/user/delete-user/delete-user.handler.ts
+++ b/src/service/iam/command/user/delete-user/delete-user.handler.ts
@@ -1,0 +1,86 @@
+import type { CommandHandler } from "../../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../../util/background/background.js";
+import {
+  SimIamDeleteConflict,
+  SimIamNoSuchEntity,
+} from "../../../error/sim-iam.error.js";
+import type { SimIamUser, SimIamUsername } from "../../../user/sim-iam-user.js";
+import type {
+  SimDeleteUserCommand,
+  SimDeleteUserCommandOutput,
+} from "./delete-user.command.js";
+
+interface DeleteUserCommandHandlerProperties {
+  readonly users: Map<SimIamUsername, SimIamUser>;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * IAM DeleteUserCommand handler.
+ *
+ * Real IAM only deletes a User nothing is hanging off, the way DeleteRole
+ * refuses a Role still carrying policies. A User with inline policies or
+ * attached managed policies is refused here too, which is why a CloudFormation
+ * Stack takes a User's policies off before deleting it.
+ *
+ * Real IAM also refuses a User that still has access keys, a login profile or
+ * an MFA device. The simulator serves no way to remove any of those, so
+ * refusing on them would leave a User that could never be deleted.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/iam/command/DeleteUserCommand/
+ */
+export class DeleteUserCommandHandler implements CommandHandler<
+  SimDeleteUserCommand,
+  SimDeleteUserCommandOutput
+> {
+  private readonly users: Map<SimIamUsername, SimIamUser>;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: DeleteUserCommandHandlerProperties) {
+    const { users, background = new BackgroundTasks() } = properties;
+
+    this.users = users;
+    this.background = background;
+  }
+
+  /**
+   * Handle a DeleteUserCommand from the SDK.
+   */
+  async handle(
+    command: SimDeleteUserCommand,
+  ): Promise<SimDeleteUserCommandOutput> {
+    const username = command.input.UserName as SimIamUsername | undefined;
+
+    if (username === undefined || username.length === 0) {
+      throw new Error("UserName is required");
+    }
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    const user = this.users.get(username);
+
+    if (user === undefined) {
+      throw new SimIamNoSuchEntity(`No IAM User with name ${username}`);
+    }
+
+    this.assertNothingAttached(user);
+    this.users.delete(username);
+
+    return {};
+  }
+
+  private assertNothingAttached(user: SimIamUser): void {
+    const attached = user.inlinePolicies.size + user.attachedPolicyArns.size;
+
+    if (attached > 0) {
+      throw new SimIamDeleteConflict(
+        `Cannot delete entity, must detach all policies first: ` +
+          `IAM User ${user.userName}`,
+      );
+    }
+  }
+}

--- a/src/service/iam/command/user/delete-user/delete-user.iso.test.ts
+++ b/src/service/iam/command/user/delete-user/delete-user.iso.test.ts
@@ -1,0 +1,145 @@
+import {
+  AttachUserPolicyCommand,
+  CreatePolicyCommand,
+  CreateUserCommand,
+  DeleteUserCommand,
+  PutUserPolicyCommand,
+} from "@aws-sdk/client-iam";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimIam } from "../../../sim-iam.js";
+import {
+  SimIamDeleteConflict,
+  SimIamNoSuchEntity,
+} from "../../../error/sim-iam.error.js";
+import type { SimIamUsername } from "../../../user/sim-iam-user.js";
+
+const readObjectsDocument = JSON.stringify({
+  Version: "2012-10-17",
+  Statement: {
+    Effect: "Allow",
+    Action: "s3:GetObject",
+    Resource: "*",
+  },
+});
+
+describe("IAM DeleteUserCommand", () => {
+  it("deletes a User that has no policies on it", async () => {
+    // Given a User with nothing attached to it.
+    const simIam = new SimIam();
+    await simIam.createUser(new CreateUserCommand({ UserName: "BareUser" }));
+
+    // When the User is deleted.
+    await simIam.deleteUser(new DeleteUserCommand({ UserName: "BareUser" }));
+
+    // Then IAM no longer has it.
+    assertUndefined(simIam.users.get("BareUser" as SimIamUsername));
+  });
+
+  it("refuses a User that still has an inline policy", async () => {
+    // Given a User carrying an inline policy.
+    const simIam = new SimIam();
+    await simIam.createUser(
+      new CreateUserCommand({ UserName: "InlinePolicyUser" }),
+    );
+    await simIam.putUserPolicy(
+      new PutUserPolicyCommand({
+        UserName: "InlinePolicyUser",
+        PolicyName: "ReadObjects",
+        PolicyDocument: readObjectsDocument,
+      }),
+    );
+
+    // When the User is deleted.
+    const error = await assertThrowsErrorAsync(async () =>
+      simIam.deleteUser(
+        new DeleteUserCommand({ UserName: "InlinePolicyUser" }),
+      ),
+    );
+
+    // Then IAM refuses, as it does until the policies are removed.
+    assertInstanceOf(error, SimIamDeleteConflict);
+    assertIdentical(error.$metadata.httpStatusCode, 409);
+    assertStringIncludes(error.message, "must detach all policies first");
+  });
+
+  it("refuses a User that still has a managed policy attached", async () => {
+    // Given a User with a managed policy attached to it.
+    const simIam = new SimIam();
+    await simIam.createUser(
+      new CreateUserCommand({ UserName: "AttachedPolicyUser" }),
+    );
+    const policy = await simIam.createPolicy(
+      new CreatePolicyCommand({
+        PolicyName: "ReadObjects",
+        PolicyDocument: readObjectsDocument,
+      }),
+    );
+    await simIam.attachUserPolicy(
+      new AttachUserPolicyCommand({
+        UserName: "AttachedPolicyUser",
+        PolicyArn: policy.Policy.Arn,
+      }),
+    );
+
+    // When the User is deleted.
+    const error = await assertThrowsErrorAsync(async () =>
+      simIam.deleteUser(
+        new DeleteUserCommand({ UserName: "AttachedPolicyUser" }),
+      ),
+    );
+
+    // Then IAM refuses.
+    assertInstanceOf(error, SimIamDeleteConflict);
+  });
+
+  it("frees the name for another User of the same name", async () => {
+    // Given a User whose name a later CreateUser would otherwise collide with.
+    const simIam = new SimIam();
+    await simIam.createUser(new CreateUserCommand({ UserName: "Reporting" }));
+    await simIam.deleteUser(new DeleteUserCommand({ UserName: "Reporting" }));
+
+    // When a User of the same name is created again.
+    const recreated = await simIam.createUser(
+      new CreateUserCommand({ UserName: "Reporting" }),
+    );
+
+    // Then IAM takes it, with a User ID of its own.
+    assertIdentical(recreated.User.UserName, "Reporting");
+  });
+
+  it("rejects a User that does not exist", async () => {
+    // Given an IAM Account without the requested User.
+    const simIam = new SimIam();
+
+    // When the missing User is deleted.
+    const error = await assertThrowsErrorAsync(async () =>
+      simIam.deleteUser(new DeleteUserCommand({ UserName: "Absent" })),
+    );
+
+    // Then IAM answers with its missing-entity error.
+    assertInstanceOf(error, SimIamNoSuchEntity);
+  });
+
+  it("rejects a missing required UserName input", async () => {
+    // Given an IAM Account.
+    const simIam = new SimIam();
+
+    // When DeleteUser is called without its required UserName.
+    const error = await assertThrowsErrorAsync(async () =>
+      simIam.deleteUser(
+        // @ts-expect-error -- testing invalid input
+        new DeleteUserCommand({}),
+      ),
+    );
+
+    // Then request validation identifies the missing input.
+    assertStringIncludes(error.message, "UserName is required");
+  });
+});

--- a/src/service/iam/command/user/sim-iam-user-command-handlers.ts
+++ b/src/service/iam/command/user/sim-iam-user-command-handlers.ts
@@ -25,6 +25,11 @@ import type {
   SimCreateUserCommand,
   SimCreateUserCommandOutput,
 } from "./create-user/create-user.command.js";
+import { DeleteUserCommandHandler } from "./delete-user/delete-user.handler.js";
+import type {
+  SimDeleteUserCommand,
+  SimDeleteUserCommandOutput,
+} from "./delete-user/delete-user.command.js";
 
 interface SimIamUserCommandHandlersProperties {
   readonly accountId: SimAwsAccountId;
@@ -82,6 +87,25 @@ export class SimIamUserCommandHandlers {
     );
     const handler = new CreateUserCommandHandler({
       accountId: this.accountId,
+      users: this.users,
+      background: this.background,
+    });
+    return await handler.handle(command);
+  }
+
+  /**
+   * Handle a DeleteUser command from the SDK.
+   */
+  async deleteUser(
+    command: SimDeleteUserCommand,
+    options?: SimIamRequestOptions,
+  ): Promise<SimDeleteUserCommandOutput> {
+    this.authorizer.authorize(
+      "iam:DeleteUser",
+      this.userArn(command.input.UserName),
+      options?.caller,
+    );
+    const handler = new DeleteUserCommandHandler({
       users: this.users,
       background: this.background,
     });

--- a/src/service/iam/sdk/sim-iam-sdk-command-router.iso.test.ts
+++ b/src/service/iam/sdk/sim-iam-sdk-command-router.iso.test.ts
@@ -7,6 +7,7 @@ import {
   CreatePolicyCommand,
   CreateRoleCommand,
   CreateUserCommand,
+  DeleteAccessKeyCommand,
   DeletePolicyCommand,
   DeleteRoleCommand,
   DeleteRolePolicyCommand,
@@ -235,6 +236,21 @@ describe("simulated IAM SDK Command routing", () => {
     assertIdentical(identity.principal.kind, "arn");
   });
 
+  it("deletes a User through an intercepted client", async () => {
+    using simSdk = new SimSdk();
+    const client = new IAMClient({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    await client.send(new CreateUserCommand({ UserName: "TransientUser" }));
+    await client.send(new DeleteUserCommand({ UserName: "TransientUser" }));
+
+    // The User is gone, so deleting it again is a missing entity.
+    const error = await assertThrowsErrorAsync(async () => {
+      await client.send(new DeleteUserCommand({ UserName: "TransientUser" }));
+    });
+    assertIdentical(error.name, "NoSuchEntity");
+  });
+
   it("does not give a denied run-as caller root privileges", async () => {
     using simSdk = new SimSdk();
     const accountId = simSdk.simAws.defaultAccountId;
@@ -261,10 +277,15 @@ describe("simulated IAM SDK Command routing", () => {
     simSdk.intercept(client);
 
     const error = await assertThrowsErrorAsync(async () => {
-      await client.send(new DeleteUserCommand({ UserName: "InterceptUser" }));
+      await client.send(
+        new DeleteAccessKeyCommand({
+          UserName: "InterceptUser",
+          AccessKeyId: "AKIAINTERCEPTKEY",
+        }),
+      );
     });
 
-    assertStringIncludes(error.message, "DeleteUserCommand");
+    assertStringIncludes(error.message, "DeleteAccessKeyCommand");
     assertStringIncludes(error.message, "CreateRoleCommand");
   });
 });

--- a/src/service/iam/sdk/sim-iam-sdk-command-router.ts
+++ b/src/service/iam/sdk/sim-iam-sdk-command-router.ts
@@ -20,6 +20,7 @@ import type { SimAttachUserPolicyCommand } from "../command/user/attach-user-pol
 import type { SimCreateAccessKeyCommand } from "../command/user/create-access-key/create-access-key.command.js";
 import type { SimCreateLoginProfileCommand } from "../command/user/create-login-profile/create-login-profile.command.js";
 import type { SimCreateUserCommand } from "../command/user/create-user/create-user.command.js";
+import type { SimDeleteUserCommand } from "../command/user/delete-user/delete-user.command.js";
 import type { SimIam } from "../sim-iam.js";
 
 /**
@@ -59,6 +60,14 @@ export class SimIamSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simIam.deleteRole(
             command as SimDeleteRoleCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteUserCommand",
+        async (command, context): Promise<unknown> =>
+          await simIam.deleteUser(
+            command as SimDeleteUserCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/iam/sim-iam.ts
+++ b/src/service/iam/sim-iam.ts
@@ -245,6 +245,16 @@ export class SimIam
   }
 
   /**
+   * Handle an IAM DeleteUser command.
+   */
+  async deleteUser(
+    command: simIamCommands.SimDeleteUserCommand,
+    options?: SimIamRequestOptions,
+  ): Promise<simIamCommands.SimDeleteUserCommandOutput> {
+    return await this.commands.users.deleteUser(command, options);
+  }
+
+  /**
    * Handle an IAM AttachUserPolicy command.
    */
   async attachUserPolicy(


### PR DESCRIPTION
Sim IAM now serves DeleteUser, following DeleteRole. A User still carrying an inline policy or an attached managed policy is refused with the delete-conflict error, and a name the Account does not hold with the no-such-entity error. Deleting a Stack that created an AWS::IAM::User deletes the User, taking its policies off first the way the Role deleter does. The User used to stay in SimIam.users after the Stack was gone, and the next deploy of the same template into the same Account failed with EntityAlreadyExists.

Resolves #723

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for deleting IAM users through the simulated IAM API.
  - Users can be deleted successfully after inline and managed policies are detached.
  - CloudFormation teardown now removes IAM users and their policies.
  - Reusing a deleted user name is supported.
  - Missing users and users with attached policies return appropriate errors.

- **Documentation**
  - Updated IAM documentation with deletion prerequisites, limitations, supported commands, and teardown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->