### PR TITLE
feat: attach a CFN Policy to a simulated User

### DIFF
--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -675,9 +675,11 @@ that never mentions IAM keeps working.
 
 Sim CloudFormation can create IAM resources from `AWS::IAM::Role`, `AWS::IAM::User`,
 `AWS::IAM::ManagedPolicy`, and `AWS::IAM::Policy`. An `AWS::IAM::Policy` puts its document onto each
-Role named in `Roles` as an inline policy. That is the shape CDK grants such as
-`bucket.grantRead(fn)` synthesize as a "DefaultPolicy" resource. A `Users` or `Groups` property on
-an `AWS::IAM::Policy` fails the creation outright.
+Role named in `Roles` and each User named in `Users` as an inline policy. That is the shape CDK
+grants such as `bucket.grantRead(fn)` and `bucket.grantRead(user)` synthesize as a "DefaultPolicy"
+resource. Every entry names a Role or a User in the Stack's Account. An entry naming no simulated
+principal fails the resource, and so does a policy naming no principal at all. A `Groups` property
+still fails the resource.
 
 An `AWS::IAM::ManagedPolicy` also carries `Roles`, and attaches itself to each Role it names as it
 is created (the attachment `AttachRolePolicy` records). A name no simulated Role in the Account
@@ -788,6 +790,9 @@ User name and `Fn::GetAtt` supports `Arn` and `UserId`.
 `CreateLoginProfile`. The profile records the password, its creation date and
 `PasswordResetRequired`. Real IAM never reads a password back, and neither does the simulator. A
 test asserting on the password reads the User record from `SimIam.users`.
+
+A separate `AWS::IAM::Policy` naming the User in `Users` puts its document onto the User as another
+inline policy. That is what a CDK grant against a User synthesizes.
 
 Group membership is a gap. A `Groups` entry fails the Resource. An empty list still deploys, and CDK
 leaves `Groups` out of the template for a User that belongs to no group.

--- a/src/service/iam/cfn/policy/sim-cfn-iam-policy-creator.ts
+++ b/src/service/iam/cfn/policy/sim-cfn-iam-policy-creator.ts
@@ -1,134 +1,80 @@
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimIam } from "../../sim-iam.js";
+import {
+  SimCfnIamPolicyPropertiesParser,
+  type SimCfnIamPolicyProperties,
+} from "./sim-cfn-iam-policy-properties-parser.js";
 
 interface SimCfnIamPolicyCreatorProperties {
   readonly iam: SimIam;
 }
 
 /**
- * Creates simulated IAM inline role policies from AWS::IAM::Policy
- * CloudFormation Resources.
+ * Creates simulated IAM inline policies from AWS::IAM::Policy CloudFormation
+ * Resources.
  *
  * AWS::IAM::Policy is an inline policy put onto the referenced principals,
- * which is how CDK grants such as bucket.grantRead(fn) attach permissions to
- * a function's execution role (the "DefaultPolicy" resource). Only Roles are
- * simulated; the policy has no standalone stored resource, so creation
- * returns undefined and Ref resolution uses the default adapter.
+ * which is how CDK grants such as bucket.grantRead(fn) attach permissions to a
+ * function's execution role, and bucket.grantRead(user) to a user (the
+ * "DefaultPolicy" resource). Roles and Users are simulated. The policy has no
+ * standalone stored resource, so creation returns undefined and Ref resolution
+ * uses the default adapter.
  */
 export class SimCfnIamPolicyCreator {
   private readonly iam: SimIam;
+  private readonly propsParser = new SimCfnIamPolicyPropertiesParser();
 
   constructor(properties: SimCfnIamPolicyCreatorProperties) {
     this.iam = properties.iam;
   }
 
   /**
-   * Put the inline policy onto each referenced Role.
+   * Put the inline policy onto each referenced Role and User.
    */
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
   ): Promise<undefined> {
-    this.rejectUnsimulatedPrincipals(resource, properties);
+    const policyProperties = this.propsParser.parse(resource, properties);
 
-    const policyName = this.policyName(resource, properties);
-    const policyDocument = this.policyDocument(resource, properties);
-    const roleNames = this.roleNames(resource, properties);
-
-    await Promise.all(
-      roleNames.map(async (roleName) =>
-        this.iam.putRolePolicy({
-          input: {
-            RoleName: roleName,
-            PolicyName: policyName,
-            PolicyDocument: policyDocument,
-          },
-        }),
-      ),
-    );
+    await Promise.all([
+      this.putRolePolicies(policyProperties),
+      this.putUserPolicies(policyProperties),
+    ]);
 
     return undefined;
   }
 
-  private policyName(
-    resource: SimCfnResource,
-    properties: SimCfnTemplateValueRecord,
-  ): string {
-    const policyName = properties["PolicyName"];
-
-    if (typeof policyName !== "string") {
-      throw new TypeError(
-        `Invalid AWS::IAM::Policy ${resource.logicalId}: PolicyName must be a string`,
-      );
-    }
-
-    return policyName;
+  private async putRolePolicies(
+    policyProperties: SimCfnIamPolicyProperties,
+  ): Promise<void> {
+    await Promise.all(
+      policyProperties.roleNames.map(async (roleName) =>
+        this.iam.putRolePolicy({
+          input: {
+            RoleName: roleName,
+            PolicyName: policyProperties.policyName,
+            PolicyDocument: policyProperties.policyDocument,
+          },
+        }),
+      ),
+    );
   }
 
-  private policyDocument(
-    resource: SimCfnResource,
-    properties: SimCfnTemplateValueRecord,
-  ): string {
-    const policyDocument = properties["PolicyDocument"];
-
-    if (
-      policyDocument === undefined ||
-      typeof policyDocument !== "object" ||
-      policyDocument === null ||
-      Array.isArray(policyDocument)
-    ) {
-      throw new TypeError(
-        `Invalid AWS::IAM::Policy ${resource.logicalId}: PolicyDocument must be an object`,
-      );
-    }
-
-    return JSON.stringify(policyDocument);
-  }
-
-  /**
-   * The Role names the policy attaches to. Role Refs are resolved to Role
-   * names before creation, so entries arrive as plain strings.
-   */
-  private roleNames(
-    resource: SimCfnResource,
-    properties: SimCfnTemplateValueRecord,
-  ): readonly string[] {
-    const roles = properties["Roles"];
-
-    if (!Array.isArray(roles) || roles.length === 0) {
-      throw new TypeError(
-        `Invalid AWS::IAM::Policy ${resource.logicalId}: Roles must be a non-empty array`,
-      );
-    }
-
-    return roles.map((roleName) => {
-      if (typeof roleName !== "string") {
-        throw new TypeError(
-          `Invalid AWS::IAM::Policy ${resource.logicalId}: Roles entries must be strings`,
-        );
-      }
-      return roleName;
-    });
-  }
-
-  /**
-   * IAM Users and Groups are not simulated as CloudFormation policy
-   * principals, and silently dropping a grant would be misleading, so their
-   * presence fails creation.
-   */
-  private rejectUnsimulatedPrincipals(
-    resource: SimCfnResource,
-    properties: SimCfnTemplateValueRecord,
-  ): void {
-    for (const principalProperty of ["Users", "Groups"]) {
-      // oxlint-disable-next-line security/detect-object-injection -- fixed property names.
-      if (properties[principalProperty] !== undefined) {
-        throw new TypeError(
-          `Invalid AWS::IAM::Policy ${resource.logicalId}: ` +
-            `${principalProperty} are not simulated`,
-        );
-      }
-    }
+  private async putUserPolicies(
+    policyProperties: SimCfnIamPolicyProperties,
+  ): Promise<void> {
+    await Promise.all(
+      policyProperties.usernames.map(async (username) =>
+        this.iam.putUserPolicy({
+          input: {
+            UserName: username,
+            PolicyName: policyProperties.policyName,
+            PolicyDocument: policyProperties.policyDocument,
+          },
+        }),
+      ),
+    );
   }
 }

--- a/src/service/iam/cfn/policy/sim-cfn-iam-policy-properties-parser.ts
+++ b/src/service/iam/cfn/policy/sim-cfn-iam-policy-properties-parser.ts
@@ -1,0 +1,129 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+export interface SimCfnIamPolicyProperties {
+  readonly policyName: string;
+  readonly policyDocument: string;
+  readonly roleNames: readonly string[];
+  readonly usernames: readonly string[];
+}
+
+type SimCfnIamPolicyPrincipalProperty = "Roles" | "Users";
+
+const resourceType = "AWS::IAM::Policy";
+
+/**
+ * Parses and validates AWS::IAM::Policy CloudFormation properties into the
+ * shape the sim IAM inline policy creator needs.
+ *
+ * Keeping the property-shape validation here keeps the creator focused on
+ * orchestrating IAM command calls.
+ */
+export class SimCfnIamPolicyPropertiesParser {
+  /**
+   * Parse the resolved CloudFormation properties for an AWS::IAM::Policy.
+   */
+  parse(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): SimCfnIamPolicyProperties {
+    this.rejectGroups(resource, properties);
+
+    const roleNames = this.principalNames(resource, properties, "Roles");
+    const usernames = this.principalNames(resource, properties, "Users");
+
+    if (roleNames.length === 0 && usernames.length === 0) {
+      throw this.invalid(
+        resource,
+        "Roles or Users must name at least one principal",
+      );
+    }
+
+    return {
+      policyName: this.policyName(resource, properties),
+      policyDocument: this.policyDocument(resource, properties),
+      roleNames,
+      usernames,
+    };
+  }
+
+  private policyName(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): string {
+    const policyName = properties["PolicyName"];
+
+    if (typeof policyName !== "string") {
+      throw this.invalid(resource, "PolicyName must be a string");
+    }
+
+    return policyName;
+  }
+
+  private policyDocument(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): string {
+    const policyDocument = properties["PolicyDocument"];
+
+    if (
+      typeof policyDocument !== "object" ||
+      policyDocument === null ||
+      Array.isArray(policyDocument)
+    ) {
+      throw this.invalid(resource, "PolicyDocument must be an object");
+    }
+
+    return JSON.stringify(policyDocument);
+  }
+
+  /**
+   * The principal names one property attaches the policy to. Role and User
+   * Refs are resolved to names before creation, so entries arrive as plain
+   * strings. An absent property is not an error on its own, because a policy
+   * naming only the other kind of principal is the usual CDK shape.
+   */
+  private principalNames(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+    property: SimCfnIamPolicyPrincipalProperty,
+  ): readonly string[] {
+    // oxlint-disable-next-line security/detect-object-injection -- fixed property names.
+    const principals = properties[property];
+
+    if (principals === undefined) {
+      return [];
+    }
+
+    if (!Array.isArray(principals)) {
+      throw this.invalid(resource, `${property} must be an array`);
+    }
+
+    return principals.map((name) => {
+      if (typeof name !== "string") {
+        throw this.invalid(resource, `${property} entries must be strings`);
+      }
+      return name;
+    });
+  }
+
+  /**
+   * IAM Groups are not simulated as CloudFormation policy principals, and
+   * silently dropping a grant would be misleading, so their presence fails
+   * creation.
+   */
+  private rejectGroups(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): void {
+    if (properties["Groups"] !== undefined) {
+      throw this.invalid(resource, "Groups are not simulated");
+    }
+  }
+
+  private invalid(resource: SimCfnResource, reason: string): TypeError {
+    return new TypeError(
+      `Invalid ${resourceType} ${resource.logicalId}: ${reason}`,
+    );
+  }
+}

--- a/src/service/iam/cfn/policy/sim-cfn-iam-policy-validation.iso.test.ts
+++ b/src/service/iam/cfn/policy/sim-cfn-iam-policy-validation.iso.test.ts
@@ -94,20 +94,35 @@ describe("IAM CloudFormation Policy validation", () => {
     );
   });
 
-  it("rejects missing, empty, or malformed Roles", async () => {
-    // Given Policy properties with missing or malformed Roles.
-    // When creation is attempted, then each rejects naming the property.
+  it("rejects a Policy naming no principal", async () => {
+    // Given Policy properties naming neither a Role nor a User, which leaves
+    // the policy with nothing to attach to.
+    // When creation is attempted, then each rejects naming both properties.
     await assertRejectsPolicy(
       { PolicyName: "BadPolicy", PolicyDocument: validPolicyDocument },
-      "Roles must be a non-empty array",
+      "Roles or Users must name at least one principal",
     );
     await assertRejectsPolicy(
       {
         PolicyName: "BadPolicy",
         PolicyDocument: validPolicyDocument,
         Roles: [],
+        Users: [],
       },
-      "Roles must be a non-empty array",
+      "Roles or Users must name at least one principal",
+    );
+  });
+
+  it("rejects malformed Roles", async () => {
+    // Given Policy properties with malformed Roles.
+    // When creation is attempted, then each rejects naming the property.
+    await assertRejectsPolicy(
+      {
+        PolicyName: "BadPolicy",
+        PolicyDocument: validPolicyDocument,
+        Roles: "ReaderRole",
+      },
+      "Roles must be an array",
     );
     await assertRejectsPolicy(
       {
@@ -116,6 +131,27 @@ describe("IAM CloudFormation Policy validation", () => {
         Roles: [42],
       },
       "Roles entries must be strings",
+    );
+  });
+
+  it("rejects malformed Users", async () => {
+    // Given Policy properties with malformed Users.
+    // When creation is attempted, then each rejects naming the property.
+    await assertRejectsPolicy(
+      {
+        PolicyName: "BadPolicy",
+        PolicyDocument: validPolicyDocument,
+        Users: "ReaderUser",
+      },
+      "Users must be an array",
+    );
+    await assertRejectsPolicy(
+      {
+        PolicyName: "BadPolicy",
+        PolicyDocument: validPolicyDocument,
+        Users: [42],
+      },
+      "Users entries must be strings",
     );
   });
 
@@ -147,20 +183,11 @@ describe("IAM CloudFormation Policy validation", () => {
     );
   });
 
-  it("rejects unsimulated Users and Groups principals", async () => {
-    // Given Policy properties naming Users or Groups, which sim IAM does not
-    // simulate as CloudFormation policy principals.
-    // When creation is attempted, then each rejects rather than silently
+  it("rejects an unsimulated Groups principal", async () => {
+    // Given Policy properties naming Groups, which sim IAM does not simulate
+    // as a CloudFormation policy principal.
+    // When creation is attempted, then it rejects rather than silently
     // dropping the grant.
-    await assertRejectsPolicy(
-      {
-        PolicyName: "BadPolicy",
-        PolicyDocument: validPolicyDocument,
-        Roles: ["ReaderRole"],
-        Users: ["SomeUser"],
-      },
-      "Users are not simulated",
-    );
     await assertRejectsPolicy(
       {
         PolicyName: "BadPolicy",

--- a/src/service/iam/cfn/policy/sim-cfn-iam-policy.iso.test.ts
+++ b/src/service/iam/cfn/policy/sim-cfn-iam-policy.iso.test.ts
@@ -1,12 +1,17 @@
 import {
   assertIdentical,
+  assertInstanceOf,
   assertNonNullable,
+  assertThrowsErrorAsync,
+  assertTrue,
   assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamNoSuchEntity } from "../../error/sim-iam.error.js";
 import type { SimIamRoleName } from "../../role/sim-iam-role.js";
+import type { SimIamUsername } from "../../user/sim-iam-user.js";
 
 const assumeRolePolicyDocument = {
   Version: "2012-10-17",
@@ -126,5 +131,130 @@ describe("IAM CloudFormation Policy", () => {
       assertNonNullable(role);
       assertNonNullable(role.inlinePolicies.get("SharedPolicy"));
     }
+  });
+
+  it("puts the inline policy onto referenced Users", async () => {
+    // Given a CloudFormation template with a User and an AWS::IAM::Policy
+    // referencing it, as a CDK grant against a user attaches permissions.
+    const simAws = new SimAws();
+
+    // When the template is deployed through sim CloudFormation.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "iam-user-inline-policy-stack",
+      template: {
+        Resources: {
+          ReaderUser: {
+            Type: "AWS::IAM::User",
+            Properties: {
+              UserName: "ReaderUser",
+            },
+          },
+          ReaderDefaultPolicy: {
+            Type: "AWS::IAM::Policy",
+            Properties: {
+              PolicyName: "ReaderDefaultPolicy",
+              PolicyDocument: readPolicyDocument,
+              Users: [
+                {
+                  Ref: "ReaderUser",
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    // Then the User carries the inline policy document.
+    const simIam = simAws.iam();
+    const user = simIam.users.get("ReaderUser" as SimIamUsername);
+
+    assertNonNullable(user);
+    const inlinePolicy = user.inlinePolicies.get("ReaderDefaultPolicy");
+    assertNonNullable(inlinePolicy);
+    assertIdentical(inlinePolicy, JSON.stringify(readPolicyDocument));
+
+    // And the policy reaches an authorization decision made for the User.
+    const decision = simIam.authorize({
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::data-bucket/daily.json",
+      caller: { kind: "arn", arn: user.arn },
+    });
+
+    assertTrue(decision.isAllowed);
+
+    // And the Policy Resource completes without a standalone sim resource.
+    const policyResource = stack.getResource("ReaderDefaultPolicy");
+    assertNonNullable(policyResource);
+    assertUndefined(policyResource.simResource);
+  });
+
+  it("puts the inline policy onto a Role and a User together", async () => {
+    // Given a template attaching one policy to both a Role and a User.
+    const simAws = new SimAws();
+
+    // When the template is deployed through sim CloudFormation.
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "iam-mixed-principal-policy-stack",
+      template: {
+        Resources: {
+          SharedRole: {
+            Type: "AWS::IAM::Role",
+            Properties: {
+              AssumeRolePolicyDocument: assumeRolePolicyDocument,
+            },
+          },
+          SharedUser: {
+            Type: "AWS::IAM::User",
+          },
+          SharedPolicy: {
+            Type: "AWS::IAM::Policy",
+            Properties: {
+              PolicyName: "SharedPolicy",
+              PolicyDocument: readPolicyDocument,
+              Roles: [{ Ref: "SharedRole" }],
+              Users: [{ Ref: "SharedUser" }],
+            },
+          },
+        },
+      },
+    });
+
+    // Then both principals carry the inline policy.
+    const simIam = simAws.iam();
+    const role = simIam.roles.get("SharedRole" as SimIamRoleName);
+    const user = simIam.users.get("SharedUser" as SimIamUsername);
+
+    assertNonNullable(role);
+    assertNonNullable(user);
+    assertNonNullable(role.inlinePolicies.get("SharedPolicy"));
+    assertNonNullable(user.inlinePolicies.get("SharedPolicy"));
+  });
+
+  it("fails the Resource for a Users entry naming no simulated User", async () => {
+    // Given a template whose policy names a User the stack never creates.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the Resource fails rather than
+    // dropping the grant, as an unknown Role does.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().deployTemplate({
+        stackName: "iam-missing-user-policy-stack",
+        template: {
+          Resources: {
+            OrphanPolicy: {
+              Type: "AWS::IAM::Policy",
+              Properties: {
+                PolicyName: "OrphanPolicy",
+                PolicyDocument: readPolicyDocument,
+                Users: ["AbsentUser"],
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    assertInstanceOf(error, SimIamNoSuchEntity);
   });
 });


### PR DESCRIPTION
An `AWS::IAM::Policy` puts its document onto each User named in `Users` as well as each Role named in `Roles`, with `PutUserPolicy` alongside `PutRolePolicy`. That is the shape every CDK grant against a user takes, because `User.addToPrincipalPolicy` builds a `Policy` construct carrying `Users`, so a stack with one user and one grant used to fail the resource. An entry naming no simulated User fails the resource, the same way an unknown Role does, and a policy naming no principal at all fails too. `Groups` keeps its refusal, since sim IAM has no groups. The property parsing moves into a `SimCfnIamPolicyPropertiesParser`, mirroring the User creator.

Resolves #722
