### PR TITLE
feat: resolve ssm-secure dynamic references

### DIFF
--- a/docs/services/ssm/README.md
+++ b/docs/services/ssm/README.md
@@ -440,8 +440,10 @@ Real CloudFormation makes no dependency out of a dynamic reference, and neither 
 parameter another resource of the same stack creates is only there in time when the template says
 `DependsOn`.
 
-`{{resolve:ssm-secure:...}}` and `{{resolve:secretsmanager:...}}` are left in the template as
-written. Neither is resolved yet.
+A `SecureString` parameter is read through `{{resolve:ssm-secure:...}}`, which the next section
+covers. `{{resolve:secretsmanager:...}}` reads a secret, and
+[simulated Secrets Manager](../secretsmanager/README.md#reading-a-secret-with-a-dynamic-reference)
+covers that one.
 
 ### A reference the simulation cannot answer
 
@@ -454,6 +456,104 @@ The substitution is recorded on
 naming the property that held the reference and why the value is a stand-in. A version the parameter
 never had, a `SecureString`, and a body that is not a name and an optional integer version are all
 recorded the same way.
+
+## Reading a SecureString with an ssm-secure reference
+
+`{{resolve:ssm-secure:name}}` reads a `SecureString` parameter and resolves to its decrypted value.
+`{{resolve:ssm-secure:name:3}}` reads version 3. The string scanning is the one plain `ssm`
+references use, so a reference can sit inside a longer value and inside `Fn::Sub`.
+
+Decryption goes to simulated KMS under the key the parameter was written with, as the caller
+deploying the stack. A caller lacking `kms:Decrypt` on that key fails the resource with the
+`AccessDenied` a decrypting `GetParameter` raises (see
+[A customer managed key needs its own permission](#a-customer-managed-key-needs-its-own-permission)).
+
+CDK writes one of these from `SecretValue.ssmSecure`, from
+`ssm.StringParameter.fromSecureStringParameterAttributes` and from the deprecated
+`valueForSecureStringParameter`.
+
+### Where a reference is accepted
+
+Real CloudFormation reads an `ssm-secure` reference in eleven resource properties and refuses it in
+every other one. Simulated CloudFormation holds a template to the same list.
+
+| Resource                               | Property                                    |
+| -------------------------------------- | ------------------------------------------- |
+| `AWS::DirectoryService::MicrosoftAD`   | `Password`                                  |
+| `AWS::DirectoryService::SimpleAD`      | `Password`                                  |
+| `AWS::ElastiCache::ReplicationGroup`   | `AuthToken`                                 |
+| `AWS::IAM::User`                       | `LoginProfile.Password`                     |
+| `AWS::KinesisFirehose::DeliveryStream` | `RedshiftDestinationConfiguration.Password` |
+| `AWS::OpsWorks::App`                   | `Source.Password`                           |
+| `AWS::OpsWorks::Stack`                 | `CustomCookbooksSource.Password`            |
+| `AWS::OpsWorks::Stack`                 | `RdsDbInstances.DbPassword`                 |
+| `AWS::RDS::DBCluster`                  | `MasterUserPassword`                        |
+| `AWS::RDS::DBInstance`                 | `MasterUserPassword`                        |
+| `AWS::Redshift::Cluster`               | `MasterUserPassword`                        |
+
+A reference anywhere else fails the resource, naming the property that held it. A template breaking
+this rule is broken on real CloudFormation too.
+
+`AWS::IAM::User` `LoginProfile.Password` is the pair a simulated resource holds today, and it is
+where CDK writes `SecretValue.ssmSecure`. The other ten name resource types this simulation has yet
+to reach.
+
+```typescript sim-ssm-secure-dynamic-reference
+/**
+ * Reading a SecureString parameter into a resource property from a template.
+ */
+
+import { PutParameterCommand } from "@aws-sdk/client-ssm";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.ssm().putParameter(
+  new PutParameterCommand({
+    Name: "/myapp/prod/console-password",
+    Type: "SecureString",
+    Value: "hunter2",
+  }),
+);
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "console-stack",
+  template: {
+    Resources: {
+      ConsoleUser: {
+        Type: "AWS::IAM::User",
+        Properties: {
+          UserName: "ConsoleUser",
+          LoginProfile: {
+            Password: "{{resolve:ssm-secure:/myapp/prod/console-password}}",
+          },
+        },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+const user = simAws
+  .iam()
+  .users.values()
+  .find((each) => each.userName === "ConsoleUser");
+
+console.log(user?.loginProfile?.password); // "hunter2"
+```
+
+A reference naming a `String` or a `StringList` parameter fails the resource, as real CloudFormation
+fails it. Read a parameter stored in the clear with a plain `{{resolve:ssm:...}}` reference.
+
+### An ssm-secure reference the simulation cannot answer
+
+The best-effort path is the one plain `ssm` references take. A reference naming a parameter that was
+never created, or a version the parameter never had, resolves to `dummy-value-for-<name>` and the
+stack carries on deploying. So does a body that is not a name and an optional integer version. Each
+substitution is recorded on
+[`stack.ignoredProperties`](../cloudformation/README.md#properties-a-resource-was-created-without).
 
 ## Reading a parameter through a template Parameter
 
@@ -896,6 +996,8 @@ Sim SSM currently supports:
 - The `AWS::SSM::Parameter` CloudFormation resource, including `Ref` and `Fn::GetAtt`
 - `{{resolve:ssm:...}}` dynamic references in CloudFormation resource properties, by version or by
   current value, embedded in a longer string and inside `Fn::Sub`
+- `{{resolve:ssm-secure:...}}` dynamic references, decrypting the `SecureString` through the KMS key
+  it was written under, in the eleven resource properties CloudFormation reads one in
 - `StringList` parameters read through a dynamic reference as the comma-separated string `Fn::Split`
   then splits
 - `AWS::SSM::Parameter::Value<String>` template parameters, resolving `Ref` to the stored value
@@ -951,11 +1053,12 @@ Current documented limitations:
 - The value a template parameter resolves to goes unvalidated against the inner type. The
   `AWS::EC2::*` and `AWS::Route53::HostedZone::Id` inner types name EC2 and Route53 resources, which
   this simulation holds none of.
-- `{{resolve:ssm-secure:...}}` dynamic references are absent. Reading a `SecureString` into a
-  template means decrypting it, which the CloudFormation engine has no route to yet.
-- A `{{resolve:ssm:...}}` reference naming a parameter, or a version, that simulated Parameter Store
-  has never held resolves to `dummy-value-for-<name>` and records the substitution. Real
-  CloudFormation fails the stack. A template parameter naming one gets the same stand-in value.
+- A `{{resolve:ssm:...}}` or `{{resolve:ssm-secure:...}}` reference naming a parameter, or a
+  version, that simulated Parameter Store has never held resolves to `dummy-value-for-<name>` and
+  records the substitution. Real CloudFormation fails the stack. A template parameter naming one
+  gets the same stand-in value.
+- An `ssm-secure` reference reads the stack's own account and region. A parameter in another account
+  is out of reach on real CloudFormation as well.
 - Public parameters under `/aws/service/...` do not exist, and names under the reserved `aws` and
   `ssm` prefixes are refused, as they are on real AWS.
 - The Parameters and Secrets Lambda extension HTTP endpoint is absent. Handler code has to use the

--- a/docs/services/ssm/sim-ssm-secure-dynamic-reference.example.ts
+++ b/docs/services/ssm/sim-ssm-secure-dynamic-reference.example.ts
@@ -1,0 +1,43 @@
+/**
+ * Reading a SecureString parameter into a resource property from a template.
+ */
+
+import { PutParameterCommand } from "@aws-sdk/client-ssm";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.ssm().putParameter(
+  new PutParameterCommand({
+    Name: "/myapp/prod/console-password",
+    Type: "SecureString",
+    Value: "hunter2",
+  }),
+);
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "console-stack",
+  template: {
+    Resources: {
+      ConsoleUser: {
+        Type: "AWS::IAM::User",
+        Properties: {
+          UserName: "ConsoleUser",
+          LoginProfile: {
+            Password: "{{resolve:ssm-secure:/myapp/prod/console-password}}",
+          },
+        },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+const user = simAws
+  .iam()
+  .users.values()
+  .find((each) => each.userName === "ConsoleUser");
+
+console.log(user?.loginProfile?.password); // "hunter2"

--- a/src/service/cloudformation/resource/resolve/property/sim-cfn-resource-property-resolver.ts
+++ b/src/service/cloudformation/resource/resolve/property/sim-cfn-resource-property-resolver.ts
@@ -18,6 +18,12 @@ interface SimCfnResourcePropertyResolverProperties {
   readonly exports?: SimCfnExports | undefined;
   readonly accountRegionScope?: SimAwsAccountRegionScope | undefined;
   readonly propertyIgnorer?: SimCfnPropertyIgnorer | undefined;
+
+  /**
+   * The type of the Resource these properties belong to, which an
+   * `ssm-secure` dynamic reference is accepted or refused by.
+   */
+  readonly resourceType?: string | undefined;
 }
 
 /**
@@ -39,6 +45,7 @@ export class SimCfnResourcePropertyResolver {
   private readonly exports: SimCfnExports | undefined;
   private readonly accountRegionScope: SimAwsAccountRegionScope | undefined;
   private readonly propertyIgnorer: SimCfnPropertyIgnorer | undefined;
+  private readonly resourceType: string | undefined;
 
   constructor(properties: SimCfnResourcePropertyResolverProperties = {}) {
     this.parameters = properties.parameters;
@@ -46,6 +53,7 @@ export class SimCfnResourcePropertyResolver {
     this.exports = properties.exports;
     this.accountRegionScope = properties.accountRegionScope;
     this.propertyIgnorer = properties.propertyIgnorer;
+    this.resourceType = properties.resourceType;
   }
 
   /**
@@ -128,6 +136,7 @@ export class SimCfnResourcePropertyResolver {
       simAws,
       accountRegionScope: this.accountRegionScope,
       propertyIgnorer: this.propertyIgnorer,
+      resourceType: this.resourceType,
     });
   }
 }

--- a/src/service/cloudformation/resource/sim-cfn-resource-record.ts
+++ b/src/service/cloudformation/resource/sim-cfn-resource-record.ts
@@ -68,6 +68,7 @@ export abstract class SimCfnResourceRecord implements SimCfnPropertyIgnorer {
       exports,
       accountRegionScope: this.accountRegionScope,
       propertyIgnorer: this,
+      resourceType: this.type,
     });
     this.resourceLogicalIds = resourceLogicalIds;
   }

--- a/src/service/cloudformation/template/dynamic/make-sim-cfn-dynamic-references.ts
+++ b/src/service/cloudformation/template/dynamic/make-sim-cfn-dynamic-references.ts
@@ -8,6 +8,7 @@ interface MakeSimCfnDynamicReferencesProperties {
   readonly simAws: SimAws;
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly propertyIgnorer?: SimCfnPropertyIgnorer | undefined;
+  readonly resourceType?: string | undefined;
 }
 
 /**
@@ -16,7 +17,8 @@ interface MakeSimCfnDynamicReferencesProperties {
 export function makeSimCfnDynamicReferences(
   properties: MakeSimCfnDynamicReferencesProperties,
 ): SimCfnDynamicReferences {
-  const { simAws, accountRegionScope, propertyIgnorer } = properties;
+  const { simAws, accountRegionScope, propertyIgnorer, resourceType } =
+    properties;
 
   const scopedAws = simAws.accountRegionScope(
     accountRegionScope.accountId,
@@ -25,6 +27,7 @@ export function makeSimCfnDynamicReferences(
 
   return new SimCfnDynamicReferences({
     propertyIgnorer,
+    resourceType,
     resolvers: new Map(
       simCfnDynamicReferenceResolvers
         .entries()

--- a/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-reference-resolvers.ts
+++ b/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-reference-resolvers.ts
@@ -42,6 +42,11 @@ export const simCfnDynamicReferenceResolvers: ReadonlyMap<
       scopedAws.ssm().cfnDynamicReferenceResolver(),
   ],
   [
+    "ssm-secure",
+    ({ scopedAws }): SimCfnDynamicReferenceResolver =>
+      scopedAws.ssm().cfnSecureDynamicReferenceResolver(),
+  ],
+  [
     "secretsmanager",
     ({ simAws, scopedAws }): SimCfnDynamicReferenceResolver =>
       new SimCfnSecretsManagerDynamicReferenceResolver({

--- a/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-reference.type.ts
+++ b/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-reference.type.ts
@@ -36,6 +36,22 @@ export interface SimCfnDynamicReferenceResolution {
 }
 
 /**
+ * Where in a Stack one dynamic reference was written.
+ *
+ * CloudFormation accepts an `ssm-secure` reference in a fixed list of Resource
+ * properties and refuses it everywhere else, so the service answering a
+ * reference has to be told where the reference sits. The path is the one an
+ * ignored property is recorded under, e.g. `LoginProfile.Password`.
+ */
+export interface SimCfnDynamicReferenceSite {
+  /** The Resource type holding the reference, e.g. `AWS::IAM::User`. */
+  readonly resourceType: string | undefined;
+
+  /** The path to the property inside the Resource's `Properties`. */
+  readonly propertyPath: string;
+}
+
+/**
  * How one simulated service answers the dynamic references naming it.
  *
  * A service that cannot answer without being waited on returns a promise, as
@@ -43,10 +59,15 @@ export interface SimCfnDynamicReferenceResolution {
  * Property resolution stays synchronous either way. A promised answer is
  * substituted once the Resource's properties have resolved around it, so the
  * resolver is free to await whatever answering takes.
+ *
+ * Throwing fails the Resource, which is what a reference the template had no
+ * business writing does. A reference the service simply could not answer
+ * resolves to a stand-in value instead.
  */
 export interface SimCfnDynamicReferenceResolver {
   resolve(
     reference: SimCfnDynamicReference,
+    site: SimCfnDynamicReferenceSite,
   ):
     | SimCfnDynamicReferenceResolution
     | Promise<SimCfnDynamicReferenceResolution>;

--- a/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-references.ts
+++ b/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-references.ts
@@ -12,6 +12,12 @@ import type {
 interface SimCfnDynamicReferencesProperties {
   readonly resolvers: ReadonlyMap<string, SimCfnDynamicReferenceResolver>;
   readonly propertyIgnorer?: SimCfnPropertyIgnorer | undefined;
+
+  /**
+   * The type of the Resource whose properties are being resolved, which a
+   * service restricting where its references may be written needs.
+   */
+  readonly resourceType?: string | undefined;
 }
 
 /**
@@ -34,11 +40,14 @@ export class SimCfnDynamicReferences {
 
   private readonly propertyIgnorer: SimCfnPropertyIgnorer | undefined;
 
+  private readonly resourceType: string | undefined;
+
   private readonly awaited = new SimCfnAwaitedDynamicReferences();
 
   constructor(properties: SimCfnDynamicReferencesProperties) {
     this.resolvers = properties.resolvers;
     this.propertyIgnorer = properties.propertyIgnorer;
+    this.resourceType = properties.resourceType;
   }
 
   /**
@@ -56,13 +65,17 @@ export class SimCfnDynamicReferences {
         return;
       }
 
-      const resolution = resolver.resolve(reference);
+      const path = currentSimCfnValuePath();
+      const resolution = resolver.resolve(reference, {
+        resourceType: this.resourceType,
+        propertyPath: path,
+      });
 
       if (resolution instanceof Promise) {
-        return this.awaited.hold(resolution, currentSimCfnValuePath());
+        return this.awaited.hold(resolution, path);
       }
 
-      return this.answer(resolution, currentSimCfnValuePath());
+      return this.answer(resolution, path);
     });
   }
 

--- a/src/service/ssm/cfn/dynamic/sim-cfn-ssm-dynamic-reference-best-effort.iso.test.ts
+++ b/src/service/ssm/cfn/dynamic/sim-cfn-ssm-dynamic-reference-best-effort.iso.test.ts
@@ -160,17 +160,14 @@ describe("SSM CloudFormation dynamic references the simulation cannot answer", (
   });
 
   it("leaves a reference to a service with no resolver as it was written", async () => {
-    // Given a reference to a service this simulation does not resolve yet.
+    // Given a reference naming a service this simulation has no resolver for.
     const simAws = simAwsInEuWest2();
 
     // When the template is deployed.
-    const stack = await deployReading(
-      simAws,
-      "{{resolve:ssm-secure:/myapp/token}}",
-    );
+    const stack = await deployReading(simAws, "{{resolve:vault:/myapp/token}}");
 
     // Then the reference is untouched and nothing is recorded about it.
-    assertIdentical(readValue(simAws), "{{resolve:ssm-secure:/myapp/token}}");
+    assertIdentical(readValue(simAws), "{{resolve:vault:/myapp/token}}");
     assertArrayLength(stack.ignoredProperties, 0);
   });
 });

--- a/src/service/ssm/cfn/dynamic/sim-cfn-ssm-dynamic-reference-resolver.ts
+++ b/src/service/ssm/cfn/dynamic/sim-cfn-ssm-dynamic-reference-resolver.ts
@@ -6,44 +6,8 @@ import type {
 import { SimSsmParameterVersionNotFound } from "../../error/sim-ssm.error.js";
 import type { SimSsmParameter } from "../../parameter/sim-ssm-parameter.js";
 import type { SimSsm } from "../../sim-ssm.js";
-
-/** The characters CloudFormation documents a referenced parameter name as. */
-const ssmReferenceName = /^[a-zA-Z0-9_.\-/]+$/;
-
-/** The version selector, which CloudFormation documents as an integer. */
-const ssmReferenceVersion = /^\d+$/;
-
-/** A reference body read as the parameter name and the version after it. */
-interface SimCfnSsmReferenceBody {
-  readonly name: string;
-  readonly version: string | undefined;
-}
-
-/**
- * Read a reference body as a parameter name and an optional version.
- *
- * A parameter name holds no colon, so the last one always opens the version.
- */
-function parseSsmReferenceBody(
-  body: string,
-): SimCfnSsmReferenceBody | undefined {
-  const colon = body.lastIndexOf(":");
-
-  if (colon === -1) {
-    return ssmReferenceName.test(body)
-      ? { name: body, version: undefined }
-      : undefined;
-  }
-
-  const name = body.slice(0, colon);
-  const version = body.slice(colon + 1);
-
-  if (!ssmReferenceName.test(name) || !ssmReferenceVersion.test(version)) {
-    return undefined;
-  }
-
-  return { name, version };
-}
+import { parseSimCfnSsmReferenceBody } from "./sim-cfn-ssm-reference-body.js";
+import { simCfnSsmReferenceStandIn } from "./sim-cfn-ssm-reference-stand-in.js";
 
 interface SimCfnSsmDynamicReferenceResolverProperties {
   readonly ssm: SimSsm;
@@ -73,10 +37,10 @@ export class SimCfnSsmDynamicReferenceResolver implements SimCfnDynamicReference
    * Resolve one reference to the parameter value it names.
    */
   resolve(reference: SimCfnDynamicReference): SimCfnDynamicReferenceResolution {
-    const parsed = parseSsmReferenceBody(reference.body);
+    const parsed = parseSimCfnSsmReferenceBody(reference.body);
 
     if (parsed === undefined) {
-      return this.standIn(
+      return simCfnSsmReferenceStandIn(
         reference,
         reference.body,
         `which is not the parameter name, optionally followed by an integer ` +
@@ -88,7 +52,7 @@ export class SimCfnSsmDynamicReferenceResolver implements SimCfnDynamicReference
     const parameter = this.ssm.findParameter(name);
 
     if (parameter === undefined) {
-      return this.standIn(
+      return simCfnSsmReferenceStandIn(
         reference,
         name,
         `and simulated Parameter Store holds no parameter '${name}'`,
@@ -96,7 +60,7 @@ export class SimCfnSsmDynamicReferenceResolver implements SimCfnDynamicReference
     }
 
     if (parameter.type.value === "SecureString") {
-      return this.standIn(
+      return simCfnSsmReferenceStandIn(
         reference,
         name,
         `and '${name}' is a SecureString, which real CloudFormation reads ` +
@@ -128,30 +92,11 @@ export class SimCfnSsmDynamicReferenceResolver implements SimCfnDynamicReference
         throw error;
       }
 
-      return this.standIn(
+      return simCfnSsmReferenceStandIn(
         reference,
         name,
         `and '${name}' has no version ${version}`,
       );
     }
-  }
-
-  /**
-   * The value a reference Parameter Store could not answer resolves to.
-   *
-   * The shape follows CDK, which fills an unresolved context lookup with
-   * `dummy-value-for-<name>`. A test reading one back sees where it came from.
-   */
-  private standIn(
-    reference: SimCfnDynamicReference,
-    name: string,
-    reason: string,
-  ): SimCfnDynamicReferenceResolution {
-    return {
-      value: `dummy-value-for-${name}`,
-      reason:
-        `holds ${reference.text}, ${reason}, so the Resource is created ` +
-        `with a stand-in value`,
-    };
   }
 }

--- a/src/service/ssm/cfn/dynamic/sim-cfn-ssm-reference-body.ts
+++ b/src/service/ssm/cfn/dynamic/sim-cfn-ssm-reference-body.ts
@@ -1,0 +1,39 @@
+/** The characters CloudFormation documents a referenced parameter name as. */
+const ssmReferenceName = /^[a-zA-Z0-9_.\-/]+$/;
+
+/** The version selector, which CloudFormation documents as an integer. */
+const ssmReferenceVersion = /^\d+$/;
+
+/** A reference body read as the parameter name and the version after it. */
+export interface SimCfnSsmReferenceBody {
+  readonly name: string;
+  readonly version: string | undefined;
+}
+
+/**
+ * Read a reference body as a parameter name and an optional version.
+ *
+ * A parameter name holds no colon, so the last one always opens the version.
+ * `ssm` and `ssm-secure` references take the same body, and read it the same
+ * way.
+ */
+export function parseSimCfnSsmReferenceBody(
+  body: string,
+): SimCfnSsmReferenceBody | undefined {
+  const colon = body.lastIndexOf(":");
+
+  if (colon === -1) {
+    return ssmReferenceName.test(body)
+      ? { name: body, version: undefined }
+      : undefined;
+  }
+
+  const name = body.slice(0, colon);
+  const version = body.slice(colon + 1);
+
+  if (!ssmReferenceName.test(name) || !ssmReferenceVersion.test(version)) {
+    return undefined;
+  }
+
+  return { name, version };
+}

--- a/src/service/ssm/cfn/dynamic/sim-cfn-ssm-reference-stand-in.ts
+++ b/src/service/ssm/cfn/dynamic/sim-cfn-ssm-reference-stand-in.ts
@@ -1,0 +1,25 @@
+import type {
+  SimCfnDynamicReference,
+  SimCfnDynamicReferenceResolution,
+} from "../../../cloudformation/template/dynamic/sim-cfn-dynamic-reference.type.js";
+
+/**
+ * The value a reference Parameter Store could not answer resolves to.
+ *
+ * The shape follows CDK, which fills an unresolved context lookup with
+ * `dummy-value-for-<name>`. A test reading one back sees where it came from.
+ * `ssm` and `ssm-secure` references both take this path, and both record the
+ * reason against the property that held the reference.
+ */
+export function simCfnSsmReferenceStandIn(
+  reference: SimCfnDynamicReference,
+  name: string,
+  reason: string,
+): SimCfnDynamicReferenceResolution {
+  return {
+    value: `dummy-value-for-${name}`,
+    reason:
+      `holds ${reference.text}, ${reason}, so the Resource is created ` +
+      `with a stand-in value`,
+  };
+}

--- a/src/service/ssm/cfn/dynamic/sim-cfn-ssm-secure-dynamic-reference-best-effort.iso.test.ts
+++ b/src/service/ssm/cfn/dynamic/sim-cfn-ssm-secure-dynamic-reference-best-effort.iso.test.ts
@@ -1,0 +1,140 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCfnStack } from "../../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimIamUser } from "../../../iam/user/sim-iam-user.js";
+
+const accountIdOneOnes = "111111111111";
+
+function simAwsInEuWest2(): SimAws {
+  return new SimAws({
+    defaultAccountId: accountIdOneOnes,
+    defaultRegionName: "eu-west-2",
+  });
+}
+
+async function deployConsoleUser(
+  simAws: SimAws,
+  password: string,
+): Promise<SimCfnStack> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "console-stack",
+    template: {
+      Resources: {
+        ConsoleUser: {
+          Type: "AWS::IAM::User",
+          Properties: {
+            UserName: "ConsoleUser",
+            LoginProfile: { Password: password },
+          },
+        },
+      },
+    },
+  });
+  await stack.waitForDeployComplete();
+
+  return stack;
+}
+
+function consolePassword(stack: SimCfnStack): string {
+  const user = stack.getResource("ConsoleUser")?.simResource as
+    | SimIamUser
+    | undefined;
+  assertNonNullable(user?.loginProfile, "the deployed User's login profile");
+
+  return user.loginProfile.password;
+}
+
+/**
+ * The one record the Stack made about a dynamic reference.
+ *
+ * A Resource can record properties of its own alongside this, so the reference
+ * is picked out by what its reason quotes.
+ */
+function dynamicReferenceRecord(stack: SimCfnStack): {
+  path: string;
+  reason: string;
+} {
+  const [ignored, ...rest] = stack.ignoredProperties.filter((property) =>
+    property.reason.includes("{{resolve:"),
+  );
+  assertNonNullable(ignored, "a recorded dynamic reference");
+  assertArrayLength(rest, 0, "no second recorded dynamic reference");
+
+  return { path: ignored.path, reason: ignored.reason };
+}
+
+describe("SSM CloudFormation ssm-secure dynamic references the simulation cannot answer", () => {
+  it("deploys with a stand-in value where the parameter is absent", async () => {
+    // Given nothing in Parameter Store.
+    const simAws = simAwsInEuWest2();
+
+    // When a template reads a parameter that was never created.
+    const stack = await deployConsoleUser(
+      simAws,
+      "{{resolve:ssm-secure:/myapp/console-password}}",
+    );
+
+    // Then the Stack deploys and the Resource holds a stand-in value.
+    assertIdentical(stack.status, "CREATE_COMPLETE");
+    assertIdentical(
+      consolePassword(stack),
+      "dummy-value-for-/myapp/console-password",
+    );
+
+    // And the substitution is recorded against the property that held it.
+    const ignored = dynamicReferenceRecord(stack);
+    assertIdentical(ignored.path, "LoginProfile.Password");
+    assertStringIncludes(ignored.reason, "/myapp/console-password");
+    assertStringIncludes(ignored.reason, "stand-in value");
+  });
+
+  it("deploys with a stand-in value where the version is absent", async () => {
+    // Given a SecureString parameter with one version.
+    const simAws = simAwsInEuWest2();
+    await simAws.ssm().putParameter({
+      input: {
+        Name: "/myapp/console-password",
+        Type: "SecureString",
+        Value: "hunter2",
+      },
+    });
+
+    // When a template names a version it has never had.
+    const stack = await deployConsoleUser(
+      simAws,
+      "{{resolve:ssm-secure:/myapp/console-password:4}}",
+    );
+
+    // Then the Resource holds a stand-in value naming the missing version.
+    assertIdentical(
+      consolePassword(stack),
+      "dummy-value-for-/myapp/console-password",
+    );
+    assertStringIncludes(dynamicReferenceRecord(stack).reason, "version 4");
+  });
+
+  it("deploys with a stand-in value where the reference body is malformed", async () => {
+    // Given a reference whose version is not an integer.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed.
+    const stack = await deployConsoleUser(
+      simAws,
+      "{{resolve:ssm-secure:/myapp/console-password:latest}}",
+    );
+
+    // Then it deploys, saying the body was not a name and a version.
+    assertIdentical(stack.status, "CREATE_COMPLETE");
+    assertStringIncludes(
+      dynamicReferenceRecord(stack).reason,
+      "integer version",
+    );
+  });
+});

--- a/src/service/ssm/cfn/dynamic/sim-cfn-ssm-secure-dynamic-reference-best-effort.iso.test.ts
+++ b/src/service/ssm/cfn/dynamic/sim-cfn-ssm-secure-dynamic-reference-best-effort.iso.test.ts
@@ -120,6 +120,22 @@ describe("SSM CloudFormation ssm-secure dynamic references the simulation cannot
     assertStringIncludes(dynamicReferenceRecord(stack).reason, "version 4");
   });
 
+  it("deploys with a stand-in value where the reference names no parameter", async () => {
+    // Given a reference whose body is empty.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed.
+    const stack = await deployConsoleUser(simAws, "{{resolve:ssm-secure:}}");
+
+    // Then it deploys, saying the body names no parameter.
+    assertIdentical(stack.status, "CREATE_COMPLETE");
+    assertIdentical(consolePassword(stack), "dummy-value-for-");
+    assertStringIncludes(
+      dynamicReferenceRecord(stack).reason,
+      "parameter name",
+    );
+  });
+
   it("deploys with a stand-in value where the reference body is malformed", async () => {
     // Given a reference whose version is not an integer.
     const simAws = simAwsInEuWest2();

--- a/src/service/ssm/cfn/dynamic/sim-cfn-ssm-secure-dynamic-reference-refusals.iso.test.ts
+++ b/src/service/ssm/cfn/dynamic/sim-cfn-ssm-secure-dynamic-reference-refusals.iso.test.ts
@@ -1,0 +1,179 @@
+import { CreateKeyCommand } from "@aws-sdk/client-kms";
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+
+const accountIdOneOnes = "111111111111";
+
+function simAwsInEuWest2(): SimAws {
+  return new SimAws({
+    defaultAccountId: accountIdOneOnes,
+    defaultRegionName: "eu-west-2",
+  });
+}
+
+/**
+ * Deploy a console User whose password is the value under test, returning
+ * whatever the deployment failed with.
+ */
+async function deployConsoleUserFailure(
+  simAws: SimAws,
+  password: SimCfnTemplateValue,
+): Promise<Error> {
+  return await assertThrowsErrorAsync(async () =>
+    simAws.cloudFormation().deployTemplate({
+      stackName: "console-stack",
+      template: {
+        Resources: {
+          ConsoleUser: {
+            Type: "AWS::IAM::User",
+            Properties: {
+              UserName: "ConsoleUser",
+              LoginProfile: { Password: password },
+            },
+          },
+        },
+      },
+    }),
+  );
+}
+
+describe("SSM CloudFormation ssm-secure dynamic references CloudFormation refuses", () => {
+  it("fails a Resource whose property is off the documented list", async () => {
+    // Given a SecureString parameter a template could have read.
+    const simAws = simAwsInEuWest2();
+    await simAws.ssm().putParameter({
+      input: { Name: "/myapp/token", Type: "SecureString", Value: "hunter2" },
+    });
+
+    // When a queue tag reads it, which real CloudFormation refuses.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().deployTemplate({
+        stackName: "queue-stack",
+        template: {
+          Resources: {
+            Queue: {
+              Type: "AWS::SQS::Queue",
+              Properties: {
+                QueueName: "work",
+                Tags: [
+                  {
+                    Key: "owner",
+                    Value: "{{resolve:ssm-secure:/myapp/token}}",
+                  },
+                ],
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    // Then the deployment fails, naming the property that held the reference.
+    assertStringIncludes(error.message, "Tags[0].Value");
+    assertStringIncludes(error.message, "AWS::SQS::Queue");
+    assertStringIncludes(error.message, "eleven Resource properties");
+  });
+
+  it("fails a Resource whose property belongs to another Resource type", async () => {
+    // Given a SecureString parameter a template could have read.
+    const simAws = simAwsInEuWest2();
+    await simAws.ssm().putParameter({
+      input: { Name: "/myapp/token", Type: "SecureString", Value: "hunter2" },
+    });
+
+    // When a queue reads it into a property another Resource type does accept
+    // an ssm-secure reference in.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().deployTemplate({
+        stackName: "queue-stack",
+        template: {
+          Resources: {
+            Queue: {
+              Type: "AWS::SQS::Queue",
+              Properties: {
+                QueueName: "work",
+                MasterUserPassword: "{{resolve:ssm-secure:/myapp/token}}",
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    // Then the list is read per Resource type rather than per property name.
+    assertStringIncludes(error.message, "MasterUserPassword");
+    assertStringIncludes(error.message, "eleven Resource properties");
+  });
+
+  it("fails a Resource whose reference names a String parameter", async () => {
+    // Given a parameter stored in the clear.
+    const simAws = simAwsInEuWest2();
+    await simAws.ssm().putParameter({
+      input: {
+        Name: "/myapp/console-password",
+        Type: "String",
+        Value: "hunter2",
+      },
+    });
+
+    // When an ssm-secure reference reads it.
+    const error = await deployConsoleUserFailure(
+      simAws,
+      "{{resolve:ssm-secure:/myapp/console-password}}",
+    );
+
+    // Then it is refused, as real CloudFormation refuses it.
+    assertStringIncludes(error.message, "is a String parameter");
+    assertStringIncludes(error.message, "reads a SecureString");
+  });
+
+  it("fails a Resource whose deploying caller cannot decrypt the key", async () => {
+    // Given a key its Account may encrypt with and not decrypt with.
+    const simAws = simAwsInEuWest2();
+    const key = await simAws.kms().createKey(
+      new CreateKeyCommand({
+        Description: "Console key",
+        Policy: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Sid: "Encrypt only",
+              Effect: "Allow",
+              Principal: { AWS: `arn:aws:iam::${accountIdOneOnes}:root` },
+              Action: "kms:Encrypt",
+              Resource: "*",
+            },
+          ],
+        }),
+      }),
+    );
+
+    // And a SecureString parameter written under it.
+    await simAws.ssm().putParameter({
+      input: {
+        Name: "/myapp/console-password",
+        Type: "SecureString",
+        Value: "hunter2",
+        KeyId: key.KeyMetadata?.Arn,
+      },
+    });
+
+    // When a template reads it through an ssm-secure dynamic reference.
+    const error = await deployConsoleUserFailure(
+      simAws,
+      "{{resolve:ssm-secure:/myapp/console-password}}",
+    );
+
+    // Then the Resource fails the way a decrypting GetParameter fails, rather
+    // than being created with something that is not the password.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+});

--- a/src/service/ssm/cfn/dynamic/sim-cfn-ssm-secure-dynamic-reference-resolver.ts
+++ b/src/service/ssm/cfn/dynamic/sim-cfn-ssm-secure-dynamic-reference-resolver.ts
@@ -1,0 +1,105 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type {
+  SimCfnDynamicReference,
+  SimCfnDynamicReferenceResolution,
+  SimCfnDynamicReferenceResolver,
+  SimCfnDynamicReferenceSite,
+} from "../../../cloudformation/template/dynamic/sim-cfn-dynamic-reference.type.js";
+import { SimSsmError } from "../../error/sim-ssm.error.js";
+import type { SimSsm } from "../../sim-ssm.js";
+import { parseSimCfnSsmReferenceBody } from "./sim-cfn-ssm-reference-body.js";
+import { simCfnSsmReferenceStandIn } from "./sim-cfn-ssm-reference-stand-in.js";
+import {
+  requireSecureStringParameter,
+  requireSsmSecureReferenceProperty,
+} from "./sim-cfn-ssm-secure-refusals.js";
+
+interface SimCfnSsmSecureDynamicReferenceResolverProperties {
+  readonly ssm: SimSsm;
+}
+
+/**
+ * Answers `{{resolve:ssm-secure:...}}` references from the simulated Parameter
+ * Store.
+ *
+ * The parameter is read the way `GetParameter` with `WithDecryption` reads it,
+ * as the caller deploying the Stack, so the value comes back decrypted through
+ * the simulated KMS key it was written under. A caller the key does not admit
+ * is denied here, which is the failure a real deployment hits. Decrypting
+ * cannot be done synchronously, so the answer comes back as a promise for the
+ * CloudFormation engine to wait on.
+ *
+ * A reference the template had no business writing fails the Resource, which
+ * `sim-cfn-ssm-secure-refusals.ts` holds the rules for. Everything else
+ * Parameter Store cannot answer becomes a stand-in value carrying a reason. A
+ * template naming parameters a test never created still deploys, and the
+ * Resource records what it was given instead.
+ */
+export class SimCfnSsmSecureDynamicReferenceResolver implements SimCfnDynamicReferenceResolver {
+  private readonly ssm: SimSsm;
+
+  constructor(properties: SimCfnSsmSecureDynamicReferenceResolverProperties) {
+    this.ssm = properties.ssm;
+  }
+
+  /**
+   * Resolve one reference to the decrypted parameter value it names.
+   *
+   * Where the reference sits is checked before anything is read, so a template
+   * writing one somewhere CloudFormation refuses it fails without a parameter
+   * being touched.
+   */
+  resolve(
+    reference: SimCfnDynamicReference,
+    site: SimCfnDynamicReferenceSite,
+  ):
+    | SimCfnDynamicReferenceResolution
+    | Promise<SimCfnDynamicReferenceResolution> {
+    requireSsmSecureReferenceProperty(reference, site);
+
+    const parsed = parseSimCfnSsmReferenceBody(reference.body);
+
+    if (parsed === undefined) {
+      return simCfnSsmReferenceStandIn(
+        reference,
+        reference.body,
+        `which is not the parameter name, optionally followed by an integer ` +
+          `version, that an ssm-secure dynamic reference takes`,
+      );
+    }
+
+    return this.decrypted(reference, parsed.name, parsed.version);
+  }
+
+  /**
+   * Read the version the reference selects, or the current one, decrypted.
+   */
+  private async decrypted(
+    reference: SimCfnDynamicReference,
+    name: string,
+    version: string | undefined,
+  ): Promise<SimCfnDynamicReferenceResolution> {
+    const selector = version === undefined ? name : `${name}:${version}`;
+
+    try {
+      const read = await this.ssm.getParameter({
+        input: { Name: selector, WithDecryption: true },
+      });
+
+      assertDefined(read.Parameter, `Parameter Store read of '${name}'`);
+      requireSecureStringParameter(name, read.Parameter);
+
+      return { value: read.Parameter.Value ?? "" };
+    } catch (error) {
+      if (!(error instanceof SimSsmError)) {
+        throw error;
+      }
+
+      return simCfnSsmReferenceStandIn(
+        reference,
+        name,
+        `and simulated Parameter Store could not read it (${error.message})`,
+      );
+    }
+  }
+}

--- a/src/service/ssm/cfn/dynamic/sim-cfn-ssm-secure-dynamic-reference-resolver.ts
+++ b/src/service/ssm/cfn/dynamic/sim-cfn-ssm-secure-dynamic-reference-resolver.ts
@@ -86,10 +86,13 @@ export class SimCfnSsmSecureDynamicReferenceResolver implements SimCfnDynamicRef
         input: { Name: selector, WithDecryption: true },
       });
 
-      assertDefined(read.Parameter, `Parameter Store read of '${name}'`);
-      requireSecureStringParameter(name, read.Parameter);
+      const parameter = read.Parameter;
 
-      return { value: read.Parameter.Value ?? "" };
+      assertDefined(parameter, `the parameter read for '${name}'`);
+      requireSecureStringParameter(name, parameter);
+      assertDefined(parameter.Value, `the value read for '${name}'`);
+
+      return { value: parameter.Value };
     } catch (error) {
       if (!(error instanceof SimSsmError)) {
         throw error;

--- a/src/service/ssm/cfn/dynamic/sim-cfn-ssm-secure-dynamic-reference.iso.test.ts
+++ b/src/service/ssm/cfn/dynamic/sim-cfn-ssm-secure-dynamic-reference.iso.test.ts
@@ -1,0 +1,185 @@
+import { CreateKeyCommand } from "@aws-sdk/client-kms";
+import { assertIdentical, assertNonNullable } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCfnStack } from "../../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimIamUser } from "../../../iam/user/sim-iam-user.js";
+
+const accountIdOneOnes = "111111111111";
+
+function simAwsInEuWest2(): SimAws {
+  return new SimAws({
+    defaultAccountId: accountIdOneOnes,
+    defaultRegionName: "eu-west-2",
+  });
+}
+
+/**
+ * Deploy a console User whose password is the value under test.
+ *
+ * `AWS::IAM::User` `LoginProfile.Password` is the one property on
+ * CloudFormation's `ssm-secure` list that a simulated Resource holds, and it is
+ * where CDK writes `SecretValue.ssmSecure`.
+ */
+async function deployConsoleUser(
+  simAws: SimAws,
+  password: SimCfnTemplateValue,
+  parameters: Record<string, { Type: string; Default?: string }> = {},
+): Promise<SimCfnStack> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "console-stack",
+    template: {
+      Parameters: parameters,
+      Resources: {
+        ConsoleUser: {
+          Type: "AWS::IAM::User",
+          Properties: {
+            UserName: "ConsoleUser",
+            LoginProfile: { Password: password },
+          },
+        },
+      },
+    },
+  });
+  await stack.waitForDeployComplete();
+
+  return stack;
+}
+
+/**
+ * The password the deployed User was created with.
+ */
+function consolePassword(stack: SimCfnStack): string {
+  const user = stack.getResource("ConsoleUser")?.simResource as
+    | SimIamUser
+    | undefined;
+  assertNonNullable(user?.loginProfile, "the deployed User's login profile");
+
+  return user.loginProfile.password;
+}
+
+describe("SSM CloudFormation ssm-secure dynamic references", () => {
+  it("resolves a reference to the decrypted parameter value", async () => {
+    // Given a SecureString parameter holding a password.
+    const simAws = simAwsInEuWest2();
+    await simAws.ssm().putParameter({
+      input: {
+        Name: "/myapp/console-password",
+        Type: "SecureString",
+        Value: "hunter2",
+      },
+    });
+
+    // When a template reads it through an ssm-secure dynamic reference.
+    const stack = await deployConsoleUser(
+      simAws,
+      "{{resolve:ssm-secure:/myapp/console-password}}",
+    );
+
+    // Then the Resource is created with the plaintext rather than the
+    // ciphertext Parameter Store holds.
+    assertIdentical(consolePassword(stack), "hunter2");
+  });
+
+  it("resolves a reference to the version it names", async () => {
+    // Given a SecureString parameter written twice.
+    const simAws = simAwsInEuWest2();
+    await simAws.ssm().putParameter({
+      input: {
+        Name: "/myapp/console-password",
+        Type: "SecureString",
+        Value: "first-password",
+      },
+    });
+    await simAws.ssm().putParameter({
+      input: {
+        Name: "/myapp/console-password",
+        Value: "second-password",
+        Overwrite: true,
+      },
+    });
+
+    // When a template names the first version.
+    const stack = await deployConsoleUser(
+      simAws,
+      "{{resolve:ssm-secure:/myapp/console-password:1}}",
+    );
+
+    // Then that version's value is decrypted rather than the current one.
+    assertIdentical(consolePassword(stack), "first-password");
+  });
+
+  it("substitutes a reference sitting inside a longer string", async () => {
+    // Given a SecureString parameter holding part of a password.
+    const simAws = simAwsInEuWest2();
+    await simAws.ssm().putParameter({
+      input: {
+        Name: "/myapp/console-password",
+        Type: "SecureString",
+        Value: "hunter2",
+      },
+    });
+
+    // When a template wraps the reference in surrounding text.
+    const stack = await deployConsoleUser(
+      simAws,
+      "prefix-{{resolve:ssm-secure:/myapp/console-password}}-suffix",
+    );
+
+    // Then only the reference is replaced.
+    assertIdentical(consolePassword(stack), "prefix-hunter2-suffix");
+  });
+
+  it("resolves a reference whose name comes from an Fn::Sub variable", async () => {
+    // Given a SecureString parameter under an environment-specific path.
+    const simAws = simAwsInEuWest2();
+    await simAws.ssm().putParameter({
+      input: {
+        Name: "/myapp/prod/console-password",
+        Type: "SecureString",
+        Value: "prod-password",
+      },
+    });
+
+    // When the reference names it through an Fn::Sub variable.
+    const stack = await deployConsoleUser(
+      simAws,
+      {
+        "Fn::Sub":
+          // oxlint-disable-next-line no-template-curly-in-string -- Fn::Sub syntax, not a JavaScript template.
+          "{{resolve:ssm-secure:/myapp/${Environment}/console-password}}",
+      },
+      { Environment: { Type: "String", Default: "prod" } },
+    );
+
+    // Then the substituted name is what Parameter Store is asked for.
+    assertIdentical(consolePassword(stack), "prod-password");
+  });
+
+  it("decrypts through the customer managed key the parameter names", async () => {
+    // Given a SecureString parameter written under a key of its own.
+    const simAws = simAwsInEuWest2();
+    const key = await simAws
+      .kms()
+      .createKey(new CreateKeyCommand({ Description: "Console key" }));
+    await simAws.ssm().putParameter({
+      input: {
+        Name: "/myapp/console-password",
+        Type: "SecureString",
+        Value: "hunter2",
+        KeyId: key.KeyMetadata?.Arn,
+      },
+    });
+
+    // When a template reads it through an ssm-secure dynamic reference.
+    const stack = await deployConsoleUser(
+      simAws,
+      "{{resolve:ssm-secure:/myapp/console-password}}",
+    );
+
+    // Then the deploying caller decrypted it with that key.
+    assertIdentical(consolePassword(stack), "hunter2");
+  });
+});

--- a/src/service/ssm/cfn/dynamic/sim-cfn-ssm-secure-reference-properties.iso.test.ts
+++ b/src/service/ssm/cfn/dynamic/sim-cfn-ssm-secure-reference-properties.iso.test.ts
@@ -1,0 +1,55 @@
+import { assertFalse, assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { acceptsSsmSecureReference } from "./sim-cfn-ssm-secure-reference-properties.js";
+
+describe("SSM CloudFormation ssm-secure reference properties", () => {
+  it("accepts the property a simulated Resource holds", () => {
+    // Given the one pair on the documented list this simulation reaches.
+    // When it is looked up, then it is accepted.
+    assertTrue(
+      acceptsSsmSecureReference("AWS::IAM::User", "LoginProfile.Password"),
+    );
+  });
+
+  it("accepts a property of a Resource type nothing simulates", () => {
+    // Given a pair on the documented list that no simulated Resource holds.
+    // When it is looked up, then it is still accepted: the rule is
+    // CloudFormation's rather than this simulation's reach.
+    assertTrue(
+      acceptsSsmSecureReference("AWS::RDS::DBInstance", "MasterUserPassword"),
+    );
+  });
+
+  it("accepts a property inside a list", () => {
+    // Given a documented property that sits inside a list, so a resolved path
+    // to it carries the list position.
+    // When it is looked up, then the position is not part of the match.
+    assertTrue(
+      acceptsSsmSecureReference(
+        "AWS::OpsWorks::Stack",
+        "RdsDbInstances.0.DbPassword",
+      ),
+    );
+  });
+
+  it("refuses a property the Resource type does not hold on the list", () => {
+    // Given a property documented for another Resource type.
+    // When it is looked up, then it is refused: the list is per pair.
+    assertFalse(
+      acceptsSsmSecureReference("AWS::IAM::User", "MasterUserPassword"),
+    );
+  });
+
+  it("refuses every property of a Resource type off the list", () => {
+    // Given a Resource type the list does not name at all.
+    // When any property of it is looked up, then it is refused.
+    assertFalse(acceptsSsmSecureReference("AWS::SQS::Queue", "Tags.0.Value"));
+  });
+
+  it("refuses a Resource with no type", () => {
+    // Given a Resource whose template carries no Type.
+    // When a property of it is looked up, then there is nothing to match.
+    assertFalse(acceptsSsmSecureReference(undefined, "LoginProfile.Password"));
+  });
+});

--- a/src/service/ssm/cfn/dynamic/sim-cfn-ssm-secure-reference-properties.ts
+++ b/src/service/ssm/cfn/dynamic/sim-cfn-ssm-secure-reference-properties.ts
@@ -1,0 +1,69 @@
+/**
+ * The Resource properties real CloudFormation reads an `ssm-secure` dynamic
+ * reference in.
+ *
+ * Every other property refuses one, which is a rule worth keeping because a
+ * template breaking it is wrong wherever it deploys. The list is short and
+ * fixed, and AWS documents it in full:
+ * https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references-ssm-secure-strings.html
+ *
+ * `AWS::IAM::User` `LoginProfile.Password` is the only pair a simulated
+ * Resource holds today. The other ten name Resource types nothing here
+ * simulates, and they are listed anyway so that the rule is the documented one
+ * rather than the part of it this simulation happens to reach.
+ */
+const acceptingProperties: ReadonlyMap<string, ReadonlySet<string>> = new Map([
+  ["AWS::DirectoryService::MicrosoftAD", new Set(["Password"])],
+  ["AWS::DirectoryService::SimpleAD", new Set(["Password"])],
+  ["AWS::ElastiCache::ReplicationGroup", new Set(["AuthToken"])],
+  ["AWS::IAM::User", new Set(["LoginProfile.Password"])],
+  [
+    "AWS::KinesisFirehose::DeliveryStream",
+    new Set(["RedshiftDestinationConfiguration.Password"]),
+  ],
+  ["AWS::OpsWorks::App", new Set(["Source.Password"])],
+  [
+    "AWS::OpsWorks::Stack",
+    new Set(["CustomCookbooksSource.Password", "RdsDbInstances.DbPassword"]),
+  ],
+  ["AWS::RDS::DBCluster", new Set(["MasterUserPassword"])],
+  ["AWS::RDS::DBInstance", new Set(["MasterUserPassword"])],
+  ["AWS::Redshift::Cluster", new Set(["MasterUserPassword"])],
+]);
+
+/** A list position in a resolved property path, such as the `0` of `Tags.0`. */
+const listPosition = /^\d+$/;
+
+/**
+ * Whether an `ssm-secure` reference is accepted in one Resource property.
+ *
+ * A Resource with no type in its template accepts none, since there is nothing
+ * to match it against.
+ */
+export function acceptsSsmSecureReference(
+  resourceType: string | undefined,
+  propertyPath: string,
+): boolean {
+  if (resourceType === undefined) {
+    return false;
+  }
+
+  return (
+    acceptingProperties.get(resourceType)?.has(namedProperty(propertyPath)) ===
+    true
+  );
+}
+
+/**
+ * The property a resolved path names, with the list positions taken out.
+ *
+ * `RdsDbInstances` holds a list, so the path to a password inside it reads
+ * `RdsDbInstances.0.DbPassword` while the documented property is
+ * `RdsDbInstances.DbPassword`.
+ */
+function namedProperty(propertyPath: string): string {
+  return propertyPath
+    .split(".")
+    .filter((segment) => !listPosition.test(segment))
+    .join(".");
+}

--- a/src/service/ssm/cfn/dynamic/sim-cfn-ssm-secure-refusals.iso.test.ts
+++ b/src/service/ssm/cfn/dynamic/sim-cfn-ssm-secure-refusals.iso.test.ts
@@ -1,0 +1,44 @@
+import { assertStringIncludes, assertThrowsError } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import type { SimCfnDynamicReference } from "../../../cloudformation/template/dynamic/sim-cfn-dynamic-reference.type.js";
+import {
+  requireSecureStringParameter,
+  requireSsmSecureReferenceProperty,
+} from "./sim-cfn-ssm-secure-refusals.js";
+
+const reference: SimCfnDynamicReference = {
+  text: "{{resolve:ssm-secure:/myapp/token}}",
+  service: "ssm-secure",
+  body: "/myapp/token",
+};
+
+describe("SSM CloudFormation ssm-secure reference refusals", () => {
+  it("refuses a reference in a Resource carrying no Type", () => {
+    // Given a Resource whose template names no type, which is nothing the
+    // documented list can match.
+    // When a reference in one of its properties is checked, then it is refused
+    // in terms a template author can act on.
+    const error = assertThrowsError(() => {
+      requireSsmSecureReferenceProperty(reference, {
+        resourceType: undefined,
+        propertyPath: "LoginProfile.Password",
+      });
+    });
+
+    assertStringIncludes(error.message, "no Type");
+    assertStringIncludes(error.message, reference.text);
+  });
+
+  it("refuses a parameter Parameter Store reported no type for", () => {
+    // Given a parameter read back without a type.
+    // When it is checked, then it is refused rather than taken for a
+    // SecureString.
+    const error = assertThrowsError(() => {
+      requireSecureStringParameter("/myapp/token", { Value: "hunter2" });
+    });
+
+    assertStringIncludes(error.message, "typeless");
+    assertStringIncludes(error.message, "reads a SecureString");
+  });
+});

--- a/src/service/ssm/cfn/dynamic/sim-cfn-ssm-secure-refusals.ts
+++ b/src/service/ssm/cfn/dynamic/sim-cfn-ssm-secure-refusals.ts
@@ -1,0 +1,57 @@
+import { SimCloudFormationValidationError } from "../../../cloudformation/error/sim-cloudformation.error.js";
+import type {
+  SimCfnDynamicReference,
+  SimCfnDynamicReferenceSite,
+} from "../../../cloudformation/template/dynamic/sim-cfn-dynamic-reference.type.js";
+import type { SimSsmParameterOutput } from "../../command/parameter/parameter.command.js";
+import { acceptsSsmSecureReference } from "./sim-cfn-ssm-secure-reference-properties.js";
+
+/** What a Resource carrying no `Type` is called in a refusal. */
+const untypedResource = "A Resource with no Type";
+
+/** The parameter type an `ssm-secure` reference reads. */
+const secureString = "SecureString";
+
+/**
+ * Fail a reference written into a property CloudFormation does not read one
+ * in.
+ *
+ * This fails the Resource rather than resolving to a stand-in value. A
+ * template breaking the rule is wrong wherever it deploys, so saying so is
+ * more use than deploying something that was never the secret.
+ */
+export function requireSsmSecureReferenceProperty(
+  reference: SimCfnDynamicReference,
+  site: SimCfnDynamicReferenceSite,
+): void {
+  if (acceptsSsmSecureReference(site.resourceType, site.propertyPath)) {
+    return;
+  }
+
+  throw new SimCloudFormationValidationError(
+    `${site.resourceType ?? untypedResource} holds ${reference.text}. ` +
+      `CloudFormation reads an ssm-secure dynamic reference in eleven ` +
+      `Resource properties, and this is not one of them.`,
+  );
+}
+
+/**
+ * Fail a reference naming a parameter stored in the clear.
+ *
+ * Real CloudFormation refuses one the same way. The plain `ssm` reference
+ * beside it is what reads a `String` or a `StringList`.
+ */
+export function requireSecureStringParameter(
+  name: string,
+  parameter: SimSsmParameterOutput,
+): void {
+  if (parameter.Type === secureString) {
+    return;
+  }
+
+  throw new SimCloudFormationValidationError(
+    `'${name}' is a ${parameter.Type ?? "typeless"} parameter, and an ` +
+      `ssm-secure dynamic reference reads a ${secureString}. Read a plain ` +
+      `parameter with an ssm reference instead.`,
+  );
+}

--- a/src/service/ssm/sim-ssm.ts
+++ b/src/service/ssm/sim-ssm.ts
@@ -20,6 +20,7 @@ import { SimSsmPutParameter } from "./command/parameter/sim-ssm-put-parameter.js
 import type * as simSsmCommands from "./command/sim-ssm-command.types.js";
 import { SimSsmCfnResourceFactory } from "./cfn/sim-cfn-ssm-resource-factory.js";
 import { SimCfnSsmDynamicReferenceResolver } from "./cfn/dynamic/sim-cfn-ssm-dynamic-reference-resolver.js";
+import { SimCfnSsmSecureDynamicReferenceResolver } from "./cfn/dynamic/sim-cfn-ssm-secure-dynamic-reference-resolver.js";
 import { SimCfnSsmParameterValueReader } from "./cfn/parameter/sim-cfn-ssm-parameter-value-reader.js";
 import type { SimSsmParameter } from "./parameter/sim-ssm-parameter.js";
 import { SimSsmParameterEncryption } from "./parameter/sim-ssm-parameter-encryption.js";
@@ -211,6 +212,13 @@ export class SimSsm {
    */
   cfnDynamicReferenceResolver(): SimCfnSsmDynamicReferenceResolver {
     return new SimCfnSsmDynamicReferenceResolver({ ssm: this });
+  }
+
+  /**
+   * Get the resolver for `{{resolve:ssm-secure:...}}` dynamic references.
+   */
+  cfnSecureDynamicReferenceResolver(): SimCfnSsmSecureDynamicReferenceResolver {
+    return new SimCfnSsmSecureDynamicReferenceResolver({ ssm: this });
   }
 
   /**


### PR DESCRIPTION
A `{{resolve:ssm-secure:...}}` reference in a Resource property now resolves to the decrypted value of the `SecureString` parameter it names, read as the caller deploying the Stack through `GetParameter` with `WithDecryption`, so decryption goes to simulated KMS under the key the parameter was written with and a caller lacking `kms:Decrypt` on that key fails the Resource with the denial a decrypting read raises. `{{resolve:ssm-secure:name:3}}` selects a version, and the string scanning is the one plain `ssm` references use, so a reference sits inside a longer value and inside `Fn::Sub`. Simulated CloudFormation holds a template to the eleven Resource properties real CloudFormation reads one in, which needed the Resource type and the property path carried to the resolver, and a reference written anywhere else fails the Resource, as does one naming a parameter stored in the clear. A reference simulated Parameter Store cannot answer keeps the best-effort path, resolving to a stand-in value recorded on `stack.ignoredProperties`.

Resolves #707
