### PR TITLE
feat: register a sim ACM cert at a chosen ARN

### DIFF
--- a/docs/services/acm/README.md
+++ b/docs/services/acm/README.md
@@ -556,6 +556,87 @@ await scopedAcm.requestCertificate(
 
 Each `SimAws` instance has its own isolated state. Create a fresh instance per test or share one across related local setup.
 
+## Register a certificate with a chosen ARN
+
+`RequestCertificateCommand` allocates its own certificate ARN, as real ACM does, and takes none from
+you. When something else already decided the ARN, register the certificate as part of your test setup
+instead.
+
+The usual reason is a CDK app that creates its certificate in one stack and uses it in another. The
+ARN crosses between the two as a plain string, and the stack using it carries that ARN into its
+synthesized template. Simulated CloudFront checks the certificate before it creates a Distribution,
+so registering the certificate first lets the template deploy as it is, with no rewriting.
+
+```typescript sim-acm-register-certificate
+/**
+ * Registering a simulated ACM certificate with a chosen certificate ARN.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+// The certificate ARN a CDK app carried into the template of the stack using it.
+const certificateArn =
+  "arn:aws:acm:us-east-1:111122223333:certificate/3b82191c-b029-4e5f-a94f-038f98a53ede";
+
+// Register it in the account and region the ARN itself names.
+simAws
+  .account("111122223333")
+  .region("us-east-1")
+  .acm()
+  .registerCertificate({
+    arn: certificateArn,
+    domainName: "example.test",
+    subjectAlternativeNames: ["www.example.test"],
+  });
+
+const stack = await simAws
+  .account("111122223333")
+  .region("us-east-1")
+  .cloudFormation()
+  .deployTemplate({
+    stackName: "site-stack",
+    template: {
+      Resources: {
+        SiteDistribution: {
+          Type: "AWS::CloudFront::Distribution",
+          Properties: {
+            DistributionConfig: {
+              CallerReference: "site-distribution",
+              Enabled: true,
+              Aliases: ["www.example.test"],
+              DefaultCacheBehavior: {
+                TargetOriginId: "origin",
+                ViewerProtocolPolicy: "redirect-to-https",
+              },
+              ViewerCertificate: {
+                AcmCertificateArn: certificateArn,
+                SslSupportMethod: "sni-only",
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+await stack.waitForDeployComplete();
+
+console.log(stack.getResource("SiteDistribution")?.status);
+```
+
+A registered certificate behaves like any other. It answers `DescribeCertificateCommand`, appears in
+`ListCertificatesCommand` under an `ISSUED` status filter, and satisfies the certificate lookups
+simulated CloudFront and ELBv2 make. It is `ISSUED` from the moment it is registered, since the
+simulation was told it already exists, and it carries no DNS validation records.
+
+Pass `status` to register a certificate in some other state, such as `EXPIRED`, to see what a
+Distribution does with it. An ARN that another certificate already holds is refused with
+`InvalidArgsException`, as is a string that is no ACM certificate ARN. So is an ARN naming an account
+or region other than the ACM's own, since other services find a certificate through the account and
+region inside its ARN.
+
 ## Create a certificate with CloudFormation
 
 Simulated CloudFormation can create ACM certificates from `AWS::CertificateManager::Certificate`.
@@ -721,6 +802,7 @@ Simulated ACM supports:
 - Subject alternative names
 - Certificate tags, up to the ACM limit of 50
 - Deterministic certificate ARNs scoped to account and region
+- Certificates registered under a caller-chosen ARN, for a template naming one another stack created
 - Deterministic DNS validation CNAME records
 - Background certificate issuance from `PENDING_VALIDATION` to `ISSUED`
 - Per-domain validation status for multi-domain certificates

--- a/docs/services/acm/sim-acm-register-certificate.example.ts
+++ b/docs/services/acm/sim-acm-register-certificate.example.ts
@@ -1,0 +1,56 @@
+/**
+ * Registering a simulated ACM certificate with a chosen certificate ARN.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+// The certificate ARN a CDK app carried into the template of the stack using it.
+const certificateArn =
+  "arn:aws:acm:us-east-1:111122223333:certificate/3b82191c-b029-4e5f-a94f-038f98a53ede";
+
+// Register it in the account and region the ARN itself names.
+simAws
+  .account("111122223333")
+  .region("us-east-1")
+  .acm()
+  .registerCertificate({
+    arn: certificateArn,
+    domainName: "example.test",
+    subjectAlternativeNames: ["www.example.test"],
+  });
+
+const stack = await simAws
+  .account("111122223333")
+  .region("us-east-1")
+  .cloudFormation()
+  .deployTemplate({
+    stackName: "site-stack",
+    template: {
+      Resources: {
+        SiteDistribution: {
+          Type: "AWS::CloudFront::Distribution",
+          Properties: {
+            DistributionConfig: {
+              CallerReference: "site-distribution",
+              Enabled: true,
+              Aliases: ["www.example.test"],
+              DefaultCacheBehavior: {
+                TargetOriginId: "origin",
+                ViewerProtocolPolicy: "redirect-to-https",
+              },
+              ViewerCertificate: {
+                AcmCertificateArn: certificateArn,
+                SslSupportMethod: "sni-only",
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+await stack.waitForDeployComplete();
+
+console.log(stack.getResource("SiteDistribution")?.status);

--- a/src/service/acm/README.md
+++ b/src/service/acm/README.md
@@ -141,6 +141,27 @@ Current behaviour:
 
 Listing order follows the map insertion order.
 
+## Registered certificates
+
+`registerSimAcmCertificate` stands up a certificate under an ARN the caller chose, for a template that
+names a certificate some other stack created. This is setup, and it lives outside `command/` for that
+reason. `SimAcm.registerCertificate` is its only entry point, with `SimRoute53.registerHostedZone` as
+the precedent.
+
+Three registrations are refused, all as `InvalidArgsException`. An ARN another certificate holds, a
+string that parses as no ACM certificate ARN, and an ARN outside this ACM's own account and Region.
+That last refusal keeps the two views of a certificate together. `SimAcmRegistry` resolves an ARN
+through the account and Region inside it, and a certificate registered elsewhere would answer commands
+here while every service looking it up missed it.
+
+A registered certificate is `ISSUED` by default and holds no domain validation options. The
+validation flow leaves it alone. `status` overrides the default for a test that wants an expired or
+revoked certificate.
+
+`RequestCertificate` allocates ARNs from the size of the certificate Map, and a registered certificate
+can sit on the sequence number that count reaches. `makeUntakenCertificate` in the command handler
+steps past a taken ARN, keeping an allocation from replacing a registration.
+
 ## CloudFormation support
 
 ACM CloudFormation support lives under `cfn/`.

--- a/src/service/acm/certificate/register-sim-acm-certificate.iso.test.ts
+++ b/src/service/acm/certificate/register-sim-acm-certificate.iso.test.ts
@@ -224,6 +224,24 @@ describe("Registering a simulated ACM Certificate", () => {
     );
   });
 
+  it("refuses an ACM ARN with no certificate ID", () => {
+    // Given a simulated ACM service.
+    const simAws = new SimAws();
+    const simAcm = simAcmInAccount(simAws);
+
+    // When an ARN naming no certificate is registered.
+    const error = assertThrowsError(() => {
+      simAcm.registerCertificate({
+        arn: "arn:aws:acm:us-east-1:111122223333:certificate/",
+        domainName: "example.test",
+      });
+    });
+
+    // Then it is refused, the same as any other string that names none.
+    assertInstanceOf(error, SimAcmInvalidArgumentsException);
+    assertMapSize(simAcm.certificates, 0);
+  });
+
   it("still allocates its own ARN for a requested Certificate", async () => {
     // Given a registered Certificate.
     const simAws = new SimAws();

--- a/src/service/acm/certificate/register-sim-acm-certificate.iso.test.ts
+++ b/src/service/acm/certificate/register-sim-acm-certificate.iso.test.ts
@@ -1,0 +1,248 @@
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertMapSize,
+  assertNonNullable,
+  assertObjectMatches,
+  assertStringIncludes,
+  assertThrowsError,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  DescribeCertificateCommand,
+  ListCertificatesCommand,
+  RequestCertificateCommand,
+} from "@aws-sdk/client-acm";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimAcmInvalidArgumentsException } from "../error/sim-acm.error.js";
+
+// A real-shaped certificate ARN, as a CDK app that took the ARN from another
+// stack would carry into its template.
+const passedInCertificateArn =
+  "arn:aws:acm:us-east-1:111122223333:certificate/3b82191c-b029-4e5f-a94f-038f98a53ede";
+
+function simAcmInAccount(simAws: SimAws) {
+  return simAws.account("111122223333").region("us-east-1").acm();
+}
+
+describe("Registering a simulated ACM Certificate", () => {
+  it("describes the Certificate under the registered ARN", async () => {
+    // Given a simulated ACM service.
+    const simAws = new SimAws();
+    const simAcm = simAcmInAccount(simAws);
+
+    // When a Certificate is registered with a chosen ARN.
+    simAcm.registerCertificate({
+      arn: passedInCertificateArn,
+      domainName: "example.test",
+      subjectAlternativeNames: ["www.example.test"],
+    });
+
+    // Then it is described under that ARN, issued and needing no validation.
+    const describeOutput = await simAcm.describeCertificate(
+      new DescribeCertificateCommand({
+        CertificateArn: passedInCertificateArn,
+      }),
+    );
+
+    assertNonNullable(describeOutput.Certificate);
+    assertIdentical(
+      describeOutput.Certificate.CertificateArn,
+      passedInCertificateArn,
+    );
+    assertIdentical(describeOutput.Certificate.DomainName, "example.test");
+    assertArrayEquals(describeOutput.Certificate.SubjectAlternativeNames, [
+      "www.example.test",
+    ]);
+    assertIdentical(describeOutput.Certificate.Status, "ISSUED");
+    assertNonNullable(describeOutput.Certificate.IssuedAt);
+    assertArrayLength(describeOutput.Certificate.DomainValidationOptions, 0);
+  });
+
+  it("lists the registered Certificate under an issued status filter", async () => {
+    // Given a simulated ACM service.
+    const simAws = new SimAws();
+    const simAcm = simAcmInAccount(simAws);
+
+    // When a Certificate is registered.
+    simAcm.registerCertificate({
+      arn: passedInCertificateArn,
+      domainName: "example.test",
+    });
+
+    // Then it is listed like any other issued Certificate.
+    const listOutput = await simAcm.listCertificates(
+      new ListCertificatesCommand({ CertificateStatuses: ["ISSUED"] }),
+    );
+
+    assertArrayLength(listOutput.CertificateSummaryList, 1);
+    assertObjectMatches(listOutput.CertificateSummaryList[0], {
+      CertificateArn: passedInCertificateArn,
+      DomainName: "example.test",
+    });
+  });
+
+  it("registers a Certificate in a status of the caller's choosing", () => {
+    // Given a simulated ACM service.
+    const simAws = new SimAws();
+    const simAcm = simAcmInAccount(simAws);
+
+    // When a Certificate is registered as expired.
+    const certificate = simAcm.registerCertificate({
+      arn: passedInCertificateArn,
+      domainName: "example.test",
+      status: "EXPIRED",
+    });
+
+    // Then it holds that status, with no issued time.
+    assertIdentical(certificate.status, "EXPIRED");
+    assertUndefined(certificate.issuedAt);
+  });
+
+  it("refuses an ARN another registered Certificate holds", () => {
+    // Given a registered Certificate.
+    const simAws = new SimAws();
+    const simAcm = simAcmInAccount(simAws);
+
+    simAcm.registerCertificate({
+      arn: passedInCertificateArn,
+      domainName: "example.test",
+    });
+
+    // When the same ARN is registered again.
+    const error = assertThrowsError(() => {
+      simAcm.registerCertificate({
+        arn: passedInCertificateArn,
+        domainName: "other.example.test",
+      });
+    });
+
+    // Then the duplicate ARN is refused.
+    assertInstanceOf(error, SimAcmInvalidArgumentsException);
+    assertStringIncludes(error.message, passedInCertificateArn);
+    assertMapSize(simAcm.certificates, 1);
+  });
+
+  it("refuses an ARN a requested Certificate already allocated", async () => {
+    // Given a Certificate requested through the ACM API.
+    const simAws = new SimAws();
+    const simAcm = simAcmInAccount(simAws);
+
+    const requestOutput = await simAcm.requestCertificate(
+      new RequestCertificateCommand({ DomainName: "requested.example.test" }),
+    );
+    const requestedArn = requestOutput.CertificateArn;
+    assertNonNullable(requestedArn);
+
+    // When its allocated ARN is registered.
+    const error = assertThrowsError(() => {
+      simAcm.registerCertificate({
+        arn: requestedArn,
+        domainName: "registered.example.test",
+      });
+    });
+
+    // Then the taken ARN is refused.
+    assertInstanceOf(error, SimAcmInvalidArgumentsException);
+    assertStringIncludes(error.message, requestedArn);
+  });
+
+  it("refuses an ARN outside its own Account and Region", () => {
+    // Given a simulated ACM service in one Account and Region.
+    const simAws = new SimAws();
+    const simAcm = simAws.account("555555555555").region("eu-west-1").acm();
+
+    // When a Certificate ARN from another scope is registered.
+    const error = assertThrowsError(() => {
+      simAcm.registerCertificate({
+        arn: passedInCertificateArn,
+        domainName: "example.test",
+      });
+    });
+
+    // Then it is refused, naming both scopes.
+    assertInstanceOf(error, SimAcmInvalidArgumentsException);
+    assertStringIncludes(error.message, "111122223333");
+    assertStringIncludes(error.message, "eu-west-1");
+    assertMapSize(simAcm.certificates, 0);
+  });
+
+  it("refuses a string that is no ACM Certificate ARN", () => {
+    // Given a simulated ACM service.
+    const simAws = new SimAws();
+    const simAcm = simAcmInAccount(simAws);
+
+    // When a malformed ARN is registered.
+    const error = assertThrowsError(() => {
+      simAcm.registerCertificate({
+        arn: "not-a-certificate-arn",
+        domainName: "example.test",
+      });
+    });
+
+    // Then it is refused before any Certificate exists to answer for it.
+    assertInstanceOf(error, SimAcmInvalidArgumentsException);
+    assertStringIncludes(error.message, "not-a-certificate-arn");
+    assertMapSize(simAcm.certificates, 0);
+  });
+
+  it("allocates past a sequence ARN a registered Certificate holds", async () => {
+    // Given a Certificate registered on the ARN the next allocation would take.
+    const simAws = new SimAws();
+    const simAcm = simAcmInAccount(simAws);
+
+    simAcm.registerCertificate({
+      arn: "arn:aws:acm:us-east-1:111122223333:certificate/00000002",
+      domainName: "registered.example.test",
+    });
+
+    // When a Certificate is requested through the ACM API.
+    const requestOutput = await simAcm.requestCertificate(
+      new RequestCertificateCommand({ DomainName: "requested.example.test" }),
+    );
+
+    // Then it takes the next free ARN, leaving the registered one alone.
+    assertIdentical(
+      requestOutput.CertificateArn,
+      "arn:aws:acm:us-east-1:111122223333:certificate/00000003",
+    );
+    assertMapSize(simAcm.certificates, 2);
+
+    const describeOutput = await simAcm.describeCertificate(
+      new DescribeCertificateCommand({
+        CertificateArn:
+          "arn:aws:acm:us-east-1:111122223333:certificate/00000002",
+      }),
+    );
+    assertIdentical(
+      describeOutput.Certificate?.DomainName,
+      "registered.example.test",
+    );
+  });
+
+  it("still allocates its own ARN for a requested Certificate", async () => {
+    // Given a registered Certificate.
+    const simAws = new SimAws();
+    const simAcm = simAcmInAccount(simAws);
+
+    simAcm.registerCertificate({
+      arn: passedInCertificateArn,
+      domainName: "example.test",
+    });
+
+    // When another Certificate is requested through the ACM API.
+    const requestOutput = await simAcm.requestCertificate(
+      new RequestCertificateCommand({ DomainName: "requested.example.test" }),
+    );
+
+    // Then its ARN is allocated by the simulator, as real ACM allocates it.
+    assertIdentical(
+      requestOutput.CertificateArn,
+      "arn:aws:acm:us-east-1:111122223333:certificate/00000002",
+    );
+  });
+});

--- a/src/service/acm/certificate/register-sim-acm-certificate.ts
+++ b/src/service/acm/certificate/register-sim-acm-certificate.ts
@@ -92,7 +92,11 @@ function scopedCertificateArn(
 ): SimArn {
   const arn = parseSimArn(value);
 
-  if (arn?.service !== "acm" || arn.resourceType !== "certificate") {
+  if (
+    arn?.service !== "acm" ||
+    arn.resourceType !== "certificate" ||
+    arn.resourceId === ""
+  ) {
     throw new SimAcmInvalidArgumentsException(
       `${value} is not a sim ACM Certificate ARN`,
     );

--- a/src/service/acm/certificate/register-sim-acm-certificate.ts
+++ b/src/service/acm/certificate/register-sim-acm-certificate.ts
@@ -1,0 +1,111 @@
+import { parseSimArn, type SimArn } from "../../aws/arn.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { SimAcmInvalidArgumentsException } from "../error/sim-acm.error.js";
+import {
+  SimAcmCertificate,
+  type SimAcmCertificateStatus,
+} from "./sim-acm-certificate.js";
+import { type SimClock, SimRealClock } from "../../../util/clock/sim-clock.js";
+
+/**
+ * What a simulation says about a Certificate it registers as already existing.
+ */
+export interface SimAcmCertificateRegistration {
+  /**
+   * The Certificate ARN the simulated Certificate takes. It has to be in this
+   * ACM's own Account and Region, since that is how other services find it.
+   */
+  readonly arn: string;
+  readonly domainName: string;
+  readonly subjectAlternativeNames?: readonly string[] | undefined;
+  /**
+   * The status the Certificate holds. `ISSUED` by default, a registered
+   * Certificate having been described as already existing.
+   */
+  readonly status?: SimAcmCertificateStatus | undefined;
+}
+
+interface RegisterSimAcmCertificateProperties {
+  readonly certificates: Map<SimArn, SimAcmCertificate>;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly clock?: SimClock | undefined;
+}
+
+/**
+ * Register a Certificate the simulation is told already exists.
+ *
+ * Real ACM allocates a Certificate ARN, so nothing on the command surface
+ * takes one. A CDK app that passes a certificate ARN between stacks bakes that
+ * ARN into the template of the stack using it, and this is how a simulation
+ * comes to own that ARN before the template deploys.
+ *
+ * The Certificate is ISSUED from the start. There is nothing to validate: it
+ * is described as already existing rather than requested here, so it carries
+ * no domain validation options.
+ */
+export function registerSimAcmCertificate(
+  registration: SimAcmCertificateRegistration,
+  properties: RegisterSimAcmCertificateProperties,
+): SimAcmCertificate {
+  const { certificates, accountRegionScope } = properties;
+  const certificateArn = scopedCertificateArn(
+    registration.arn,
+    accountRegionScope,
+  );
+
+  if (certificates.has(certificateArn)) {
+    throw new SimAcmInvalidArgumentsException(
+      `A sim ACM Certificate with ARN ${certificateArn} already exists`,
+    );
+  }
+
+  const clock = properties.clock ?? new SimRealClock();
+  const registeredAt = clock.now();
+  const status = registration.status ?? "ISSUED";
+
+  const certificate = new SimAcmCertificate({
+    certificateArn,
+    domainName: registration.domainName,
+    subjectAlternativeNames: registration.subjectAlternativeNames ?? [],
+    status,
+    clock,
+    createdAt: registeredAt,
+    issuedAt: status === "ISSUED" ? registeredAt : undefined,
+  });
+
+  certificates.set(certificateArn, certificate);
+
+  return certificate;
+}
+
+/**
+ * Read a Certificate ARN this ACM can be found by.
+ *
+ * Other services reach a Certificate through the Account and Region in its
+ * ARN, so an ARN naming another scope would answer ACM commands here and be
+ * missed by every service that looks it up. Refusing it keeps the two views of
+ * the Certificate together.
+ */
+function scopedCertificateArn(
+  value: string,
+  accountRegionScope: SimAwsAccountRegionScope,
+): SimArn {
+  const arn = parseSimArn(value);
+
+  if (arn?.service !== "acm" || arn.resourceType !== "certificate") {
+    throw new SimAcmInvalidArgumentsException(
+      `${value} is not a sim ACM Certificate ARN`,
+    );
+  }
+
+  const { accountId, regionName } = accountRegionScope;
+
+  if (arn.accountId !== accountId || arn.region !== regionName) {
+    throw new SimAcmInvalidArgumentsException(
+      `Sim ACM Certificate ARN ${value} names Account ${arn.accountId} in ${arn.region}, ` +
+        `but this sim ACM is Account ${accountId} in ${regionName}`,
+    );
+  }
+
+  return value as SimArn;
+}

--- a/src/service/acm/command/request-certificate/request-certificate.handler.ts
+++ b/src/service/acm/command/request-certificate/request-certificate.handler.ts
@@ -89,10 +89,7 @@ export class RequestCertificateCommandHandler implements CommandHandler<
 
     this.authorizer.authorize(options?.caller);
 
-    const certificate = this.certificateFactory.makeCertificate(
-      command,
-      this.certificates.size,
-    );
+    const certificate = this.makeUntakenCertificate(command);
     const { certificateArn } = certificate;
 
     this.certificates.set(certificateArn, certificate);
@@ -104,5 +101,33 @@ export class RequestCertificateCommandHandler implements CommandHandler<
       $metadata: {},
       CertificateArn: certificateArn,
     };
+  }
+
+  /**
+   * Build the certificate, on an ARN no other certificate holds.
+   *
+   * ARNs are allocated from the number of certificates ACM holds, and a
+   * registered certificate holds an ARN the simulation never allocated. One of
+   * those can sit on the sequence number this count reaches, and stepping past
+   * it keeps a requested certificate from replacing a registered one.
+   */
+  private makeUntakenCertificate(
+    command: SimRequestCertificateCommand,
+  ): SimAcmCertificate {
+    let certificateCount = this.certificates.size;
+    let certificate = this.certificateFactory.makeCertificate(
+      command,
+      certificateCount,
+    );
+
+    while (this.certificates.has(certificate.certificateArn)) {
+      certificateCount += 1;
+      certificate = this.certificateFactory.makeCertificate(
+        command,
+        certificateCount,
+      );
+    }
+
+    return certificate;
   }
 }

--- a/src/service/acm/sim-acm.ts
+++ b/src/service/acm/sim-acm.ts
@@ -10,6 +10,10 @@ import type {
 } from "./command/request-certificate/request-certificate.command.js";
 import { RequestCertificateCommandHandler } from "./command/request-certificate/request-certificate.handler.js";
 import type { SimAcmCertificate } from "./certificate/sim-acm-certificate.js";
+import {
+  registerSimAcmCertificate,
+  type SimAcmCertificateRegistration,
+} from "./certificate/register-sim-acm-certificate.js";
 import type {
   SimDescribeCertificateCommand,
   SimDescribeCertificateCommandOutput,
@@ -129,6 +133,29 @@ export class SimAcm {
     certificate: SimAcmCertificate,
   ): Promise<void> {
     await this.validation.settle(certificate);
+  }
+
+  /**
+   * Register a Certificate that already exists, with an ARN of your choosing.
+   *
+   * `RequestCertificate` allocates its own ARN, as real ACM does, so this is
+   * the way to stand up a Certificate a template already names. A CDK app that
+   * passes a certificate ARN into another stack bakes that ARN into the
+   * template it synthesizes, and a registered Certificate answers ACM commands
+   * and satisfies the CloudFront and ELBv2 lookups the same as one this
+   * simulation issued.
+   *
+   * An ARN another Certificate holds, an ARN outside this ACM's own Account and
+   * Region, or a string that is no ACM Certificate ARN, is refused.
+   */
+  registerCertificate(
+    registration: SimAcmCertificateRegistration,
+  ): SimAcmCertificate {
+    return registerSimAcmCertificate(registration, {
+      certificates: this.certificates,
+      accountRegionScope: this.accountRegionScope,
+      clock: this.background,
+    });
   }
 
   /**

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-viewer-cert.iso.test.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-viewer-cert.iso.test.ts
@@ -46,6 +46,22 @@ function distributionTemplate(certificateArn: string): CfnTemplateBodyRecord {
   };
 }
 
+// A real-shaped certificate ARN, as a CDK app that took the ARN from another
+// stack would carry into its template.
+const passedInCertificateArn =
+  "arn:aws:acm:us-east-1:111122223333:certificate/3b82191c-b029-4e5f-a94f-038f98a53ede";
+
+/**
+ * Register a Certificate on the ARN the template names, in the Account and
+ * Region that ARN belongs to.
+ */
+function registerCertificate(simAws: SimAws, domainName: string): void {
+  simAws.account("111122223333").region("us-east-1").acm().registerCertificate({
+    arn: passedInCertificateArn,
+    domainName,
+  });
+}
+
 async function issuedCertificateArn(
   simAws: SimAws,
   regionName: "us-east-1" | "eu-west-2",
@@ -75,6 +91,41 @@ describe("Sim CloudFormation CloudFront viewer certificate", () => {
 
     // Then the distribution is created.
     assertTypeString(stack.outputs.get("DistributionId")?.value);
+  });
+
+  it("creates a distribution with a registered certificate", async () => {
+    // Given a Certificate registered under the ARN the template carries.
+    const simAws = new SimAws();
+    registerCertificate(simAws, "example.test");
+
+    // When a template names it as the viewer certificate.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "cloudfront-registered-certificate-stack",
+      template: distributionTemplate(passedInCertificateArn),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the distribution is created, with no certificate to request first.
+    assertTypeString(stack.outputs.get("DistributionId")?.value);
+  });
+
+  it("fails the stack for an alias the registered certificate misses", async () => {
+    // Given a registered Certificate for another domain name.
+    const simAws = new SimAws();
+    registerCertificate(simAws, "other.test");
+
+    // When a template names it as the viewer certificate.
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "cloudfront-uncovered-alias-stack",
+        template: distributionTemplate(passedInCertificateArn),
+      });
+      await stack.waitForDeployComplete();
+    });
+
+    // Then the stack fails, naming the alias the Certificate does not cover.
+    assertStringIncludes(error.message, "SiteDistribution");
+    assertStringIncludes(error.message, "example.test");
   });
 
   it("fails the stack for a certificate outside us-east-1", async () => {


### PR DESCRIPTION
Simulated ACM allocated every certificate ARN itself, and a CloudFormation template naming a certificate another stack created could not deploy, since simulated CloudFront checks the ViewerCertificate against ACM before it creates a Distribution. SimAcm.registerCertificate now stands up a certificate under an ARN the caller chose, ISSUED from the start and holding no validation records, mirroring SimRoute53.registerHostedZone. It refuses an ARN another certificate holds, an ARN outside the ACM's own Account and Region, and a string that is no ACM certificate ARN. RequestCertificate keeps allocating its own ARNs, and now steps past one a registration already took.

Resolves #734