### PR TITLE
feat: record bound Lambda handler output

### DIFF
--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -204,10 +204,65 @@ of this.
 written to, and stream names use the real `YYYY/MM/DD/[$LATEST]<hash>` format. The hash identifies
 the execution environment rather than the request. Match the shape, and leave the value alone.
 
-Only zip-packaged code is recorded. A function backed by a handler function reference, including one
-bound to a container image, is an ordinary function closing over the test's own module scope. Its
-`console.log` reaches the host console directly, and intercepting that would mean patching a global
-the whole test run shares. Capturing the host stream is still the way to assert on one of those.
+A function backed by a handler function reference is recorded too, whether the handler arrived
+through `Code.ZipFile`, through a CloudFormation stack binding, or as the image of a simulated ECR
+repository. Such a handler is a closure over your own module scope and prints through the same
+console and standard streams as the rest of the test run, and both are bridged to the function's log
+group for the length of an invocation, in the way `process.env` and `Date` are. `console.log`,
+`console.info`, `console.debug`, `console.warn` and `console.error` all arrive, along with anything
+written to `process.stdout` or `process.stderr`, so a logging library building its own console over
+the process streams is recorded as well. Printing with no invocation running reaches the host
+console alone.
+
+A test that binds its handler for a breakpoint, or so the handler can close over its own state, can
+still assert on the lines it logged:
+
+```typescript sim-lambda-bound-handler-output
+/**
+ * Asserting on what a bound in-process Lambda handler printed.
+ */
+
+import { FilterLogEventsCommand } from "@aws-sdk/client-cloudwatch-logs";
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "orders",
+    Role: "arn:aws:iam::111111111111:role/OrdersRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: { orderId: string }) => {
+        console.log(`ERROR ${event.orderId} has no items`);
+
+        return "rejected";
+      }),
+    },
+  }),
+);
+
+await simAws.lambda().invoke(
+  new InvokeCommand({
+    FunctionName: "orders",
+    Payload: JSON.stringify({ orderId: "order-1" }),
+  }),
+);
+
+const logged = await simAws.logs().filterLogEvents(
+  new FilterLogEventsCommand({
+    logGroupName: "/aws/lambda/orders",
+    filterPattern: "ERROR",
+  }),
+);
+
+// [ 'ERROR order-1 has no items' ]
+console.log(logged.events?.map((event) => event.message));
+
+await simAws.backgroundTasksComplete();
+```
 
 ## Function code from S3
 
@@ -2498,10 +2553,10 @@ Current documented limitations:
 - Function versions, aliases, and qualifiers are left out (`Version` is always `$LATEST`).
 - The vm runtime supports CommonJS function code only. ES module source (`.mjs` / `export` syntax)
   has yet to land.
-- Only zip-packaged code has its output recorded into a log group. A function backed by a handler
-  function reference, including a container image binding, writes to the host console directly and
-  goes unrecorded, so a test asserting on its output still has to capture the host stream. See
-  [What a handler prints](#what-a-handler-prints).
+- A handler function reference is recorded through the process console and the process standard
+  streams, both of which a test runner is free to replace. `console.trace` and `console.dir`
+  decorate what they print, and either one reaches the log group only where the host console passes
+  it on to `process.stdout`. See [What a handler prints](#what-a-handler-prints).
 - The platform `START`, `END` and `REPORT` lines a real log stream carries are left out, and
   execution environments are never recycled, so a function keeps one log stream for as long as it
   exists.

--- a/docs/services/lambda/sim-lambda-bound-handler-output.example.ts
+++ b/docs/services/lambda/sim-lambda-bound-handler-output.example.ts
@@ -1,0 +1,44 @@
+/**
+ * Asserting on what a bound in-process Lambda handler printed.
+ */
+
+import { FilterLogEventsCommand } from "@aws-sdk/client-cloudwatch-logs";
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "orders",
+    Role: "arn:aws:iam::111111111111:role/OrdersRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: { orderId: string }) => {
+        console.log(`ERROR ${event.orderId} has no items`);
+
+        return "rejected";
+      }),
+    },
+  }),
+);
+
+await simAws.lambda().invoke(
+  new InvokeCommand({
+    FunctionName: "orders",
+    Payload: JSON.stringify({ orderId: "order-1" }),
+  }),
+);
+
+const logged = await simAws.logs().filterLogEvents(
+  new FilterLogEventsCommand({
+    logGroupName: "/aws/lambda/orders",
+    filterPattern: "ERROR",
+  }),
+);
+
+// [ 'ERROR order-1 has no items' ]
+console.log(logged.events?.map((event) => event.message));
+
+await simAws.backgroundTasksComplete();

--- a/docs/services/logs/README.md
+++ b/docs/services/logs/README.md
@@ -210,8 +210,9 @@ console.log(
 
 ## Lambda handler output
 
-A zip-packaged Lambda function's output is recorded into `/aws/lambda/<function name>` as it runs.
-A test can then assert on what a handler logged by searching its log group.
+A Lambda function's output is recorded into `/aws/lambda/<function name>` as it runs, whether its
+code is a zip archive or a real in-process handler. A test can then assert on what a handler logged
+by searching its log group.
 
 ```typescript sim-logs-lambda-output
 /**
@@ -548,6 +549,7 @@ console.log(described.logGroups?.[0]?.logGroupArn);
   differently in an account.
 - **Per-stream `storedBytes`.** Always zero, matching real CloudWatch Logs, which stopped reporting
   the figure per stream in 2019. `DescribeLogGroups` reports the bytes a group holds.
-- **Log capture from anything but zip-packaged Lambda code.** A function backed by a handler
-  function reference, including a container image binding, writes to the host console directly and
-  is not recorded. See the Lambda docs for why.
+- **Log capture from a handler function reference.** Recorded through the process console and the
+  process standard streams, both of which a test runner is free to replace. `console.trace` and
+  `console.dir` reach the log group only where the host console passes them on to `process.stdout`.
+  See the Lambda docs for the detail.

--- a/src/service/lambda/function/code/sim-lambda-executable-code.ts
+++ b/src/service/lambda/function/code/sim-lambda-executable-code.ts
@@ -42,15 +42,16 @@ export class SimLambdaHandlerReferenceCode implements SimLambdaExecutableCode {
   constructor(private readonly handler: SimLambdaHandler) {}
 
   /**
-   * Record nothing.
+   * Record nothing here.
    *
-   * A referenced handler has no streams of its own to tee: it is an ordinary
-   * function closing over the test's own module scope, so its `console.log`
-   * reaches the host console directly and there is nothing here to intercept
-   * without patching a global the whole test run shares.
+   * A referenced handler has no streams of its own to tee. It is an ordinary
+   * function closing over the test's own module scope, and it prints through
+   * the process console and the process standard streams. Its invocation is
+   * run with those bridged to the function's sink instead, the way the clock
+   * and process.env are bridged for the same code.
    */
   recordOutputTo(): void {
-    // Nothing to record from.
+    // Recorded by the invocation, from the process globals.
   }
 
   /**

--- a/src/service/lambda/function/invoke/sim-lambda-host-scope.ts
+++ b/src/service/lambda/function/invoke/sim-lambda-host-scope.ts
@@ -1,7 +1,9 @@
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import type { SimLambdaOutputSink } from "../logging/sim-lambda-output-sink.js";
 import type { SimLambdaOutboundHttp } from "../outbound/sim-lambda-outbound-http.js";
 import { simLambdaProcessClock } from "./sim-lambda-process-clock.js";
 import { simLambdaProcessOutbound } from "./sim-lambda-process-outbound.js";
+import { simLambdaProcessOutput } from "./sim-lambda-process-output.js";
 
 /**
  * What an invocation of host-scope code has bridged to it.
@@ -16,25 +18,40 @@ interface SimLambdaHostScope {
    * and its requests go where they were addressed.
    */
   readonly outboundHttp: SimLambdaOutboundHttp | undefined;
+
+  /**
+   * Where what the invocation prints is recorded. A function built standalone,
+   * outside a SimAws instance, has no simulated CloudWatch Logs to record to,
+   * and its output reaches the host console alone.
+   */
+  readonly output: SimLambdaOutputSink | undefined;
 }
 
 /**
  * Run an invocation of code in the host scope with the process globals it
  * reads bridged to its simulation.
  *
- * Only code running in the host scope needs this. Zip code reads the Date and
- * the HTTP clients its own vm sandbox was given, so a function backed by one
- * leaves the globals alone entirely and never comes here.
+ * Only code running in the host scope needs this. Zip code reads the Date, the
+ * HTTP clients and the standard streams its own vm sandbox was given, so a
+ * function backed by one leaves the globals alone entirely and never comes
+ * here.
  */
 export async function runSimLambdaInHostScope<T>(
   scope: SimLambdaHostScope,
   run: () => Promise<T>,
 ): Promise<T> {
-  const { outboundHttp } = scope;
+  const { clock, outboundHttp, output } = scope;
 
-  return await simLambdaProcessClock.run(scope.clock, async () =>
+  const recording =
+    output === undefined
+      ? run
+      : async (): Promise<T> => await simLambdaProcessOutput.run(output, run);
+
+  const reachingTheSimulation =
     outboundHttp === undefined
-      ? await run()
-      : await simLambdaProcessOutbound.run(outboundHttp, run),
-  );
+      ? recording
+      : async (): Promise<T> =>
+          await simLambdaProcessOutbound.run(outboundHttp, recording);
+
+  return await simLambdaProcessClock.run(clock, reachingTheSimulation);
 }

--- a/src/service/lambda/function/invoke/sim-lambda-process-output.iso.test.ts
+++ b/src/service/lambda/function/invoke/sim-lambda-process-output.iso.test.ts
@@ -1,0 +1,193 @@
+import { assertArrayEquals, assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import type { SimLambdaOutputSink } from "../logging/sim-lambda-output-sink.js";
+import {
+  SimLambdaProcessOutput,
+  type SimLambdaProcessGlobals,
+  type SimLambdaProcessStream,
+} from "./sim-lambda-process-output.js";
+
+/**
+ * Somewhere to record, standing in for the log writer a function invocation
+ * brings with it.
+ */
+class RecordingSink implements SimLambdaOutputSink {
+  readonly recorded: string[] = [];
+
+  write(chunk: string): void {
+    this.recorded.push(chunk);
+  }
+}
+
+/**
+ * A standard stream that keeps what was written to it.
+ */
+class WatchedStream implements SimLambdaProcessStream {
+  readonly written: string[] = [];
+
+  write = (chunk: string | Uint8Array): boolean => {
+    this.written.push(
+      typeof chunk === "string" ? chunk : Buffer.from(chunk).toString(),
+    );
+
+    return true;
+  };
+}
+
+/**
+ * Process globals a test can watch, with a console that prints to the given
+ * standard output the way the host console does.
+ */
+function watchedGlobals(): {
+  globals: SimLambdaProcessGlobals;
+  stdout: WatchedStream;
+  stderr: WatchedStream;
+} {
+  const stdout = new WatchedStream();
+  const stderr = new WatchedStream();
+  const print = (...arguments_: readonly unknown[]): void => {
+    stdout.write(`${arguments_.join(" ")}\n`);
+  };
+
+  return {
+    globals: {
+      console: {
+        log: print,
+        info: print,
+        debug: print,
+        warn: print,
+        error: print,
+      },
+      stdout,
+      stderr,
+    },
+    stdout,
+    stderr,
+  };
+}
+
+/**
+ * Resolve after a real pause, so a test can interleave two runs and prove they
+ * do not record into each other's sink.
+ */
+async function tick(milliseconds: number): Promise<void> {
+  await new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+}
+
+describe("sim Lambda process output", () => {
+  it("records what the run printed through the console", async () => {
+    // Given process globals a test can watch.
+    const { globals, stdout } = watchedGlobals();
+    const output = new SimLambdaProcessOutput(() => globals);
+    const sink = new RecordingSink();
+
+    // When a run prints.
+    await output.run(sink, async () => {
+      globals.console.log("INFO handling order-1");
+      await Promise.resolve();
+    });
+
+    // Then the line was recorded, and it still reached the host console.
+    assertArrayEquals(sink.recorded, ["INFO handling order-1\n"]);
+    assertArrayEquals(stdout.written, ["INFO handling order-1\n"]);
+  });
+
+  it("records a printed line once, where the console prints to the stream", async () => {
+    // Given a console that writes to standard output, as the host one does.
+    const { globals } = watchedGlobals();
+    const output = new SimLambdaProcessOutput(() => globals);
+    const sink = new RecordingSink();
+
+    // When a run prints one line through it.
+    await output.run(sink, async () => {
+      globals.console.error("ERROR order has no items");
+      await Promise.resolve();
+    });
+
+    // Then the line was recorded once: the console patch hands on outside the
+    // store, so the write it causes finds nothing recording.
+    assertArrayEquals(sink.recorded, ["ERROR order has no items\n"]);
+  });
+
+  it("records what the run wrote to a standard stream", async () => {
+    // Given process globals a test can watch.
+    const { globals, stderr } = watchedGlobals();
+    const output = new SimLambdaProcessOutput(() => globals);
+    const sink = new RecordingSink();
+
+    // When a run writes to a stream itself.
+    await output.run(sink, async () => {
+      globals.stdout.write("no newline");
+      globals.stderr.write(Buffer.from("bytes\n"));
+      await Promise.resolve();
+    });
+
+    // Then both writes were recorded, and both still reached the host stream.
+    assertArrayEquals(sink.recorded, ["no newline", "bytes\n"]);
+    assertArrayEquals(stderr.written, ["bytes\n"]);
+  });
+
+  it("records a character split across two writes whole", async () => {
+    // Given a multibyte character written in two halves, as code writing
+    // bytes it read in pieces does.
+    const { globals } = watchedGlobals();
+    const output = new SimLambdaProcessOutput(() => globals);
+    const sink = new RecordingSink();
+    const bytes = Buffer.from("玉\n");
+
+    // When a run writes it a byte at a time.
+    await output.run(sink, async () => {
+      globals.stdout.write(bytes.subarray(0, 1));
+      globals.stdout.write(bytes.subarray(1));
+      await Promise.resolve();
+    });
+
+    // Then what was recorded holds the character rather than two replacements.
+    assertIdentical(sink.recorded.join(""), "玉\n");
+  });
+
+  it("leaves output made outside a run alone", async () => {
+    // Given a run that has installed the patches.
+    const { globals, stdout } = watchedGlobals();
+    const output = new SimLambdaProcessOutput(() => globals);
+    const sink = new RecordingSink();
+
+    await output.run(sink, () => Promise.resolve());
+
+    // When the rest of the test run prints.
+    globals.console.log("a line from the test");
+    globals.stdout.write("another\n");
+
+    // Then nothing was recorded, and both reached the host console.
+    assertArrayEquals(sink.recorded, []);
+    assertArrayEquals(stdout.written, ["a line from the test\n", "another\n"]);
+  });
+
+  it("keeps two concurrent runs apart", async () => {
+    // Given two runs interleaved over their own sinks.
+    const { globals } = watchedGlobals();
+    const output = new SimLambdaProcessOutput(() => globals);
+    const orders = new RecordingSink();
+    const invoices = new RecordingSink();
+
+    // When both print on either side of a pause.
+    await Promise.all([
+      output.run(orders, async () => {
+        globals.console.log("order-1");
+        await tick(20);
+        globals.console.log("order-2");
+      }),
+      output.run(invoices, async () => {
+        await tick(10);
+        globals.console.log("invoice-1");
+      }),
+    ]);
+
+    // Then each sink holds only what its own run printed.
+    assertArrayEquals(orders.recorded, ["order-1\n", "order-2\n"]);
+    assertArrayEquals(invoices.recorded, ["invoice-1\n"]);
+  });
+});

--- a/src/service/lambda/function/invoke/sim-lambda-process-output.ts
+++ b/src/service/lambda/function/invoke/sim-lambda-process-output.ts
@@ -1,0 +1,181 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { StringDecoder } from "node:string_decoder";
+import { format } from "node:util";
+
+import type { SimLambdaOutputSink } from "../logging/sim-lambda-output-sink.js";
+
+/**
+ * The console methods an invocation's output is taken from.
+ *
+ * These are the ones that format their arguments the way `console.log` does,
+ * so what is recorded is what the host console prints. `console.trace` and
+ * `console.dir` decorate their output, and recording a plain format of their
+ * arguments would put something in the log group that the handler never
+ * printed. Both still reach the host console, and both are recorded when the
+ * host console goes on to write them to `process.stdout`.
+ */
+const CONSOLE_METHODS = ["log", "info", "debug", "warn", "error"] as const;
+
+type ConsoleMethod = (typeof CONSOLE_METHODS)[number];
+
+type StreamChunk = string | Uint8Array;
+
+/**
+ * One of the process's standard streams, as much of it as recording needs.
+ */
+export interface SimLambdaProcessStream {
+  write: (chunk: StreamChunk, ...rest: never[]) => boolean;
+}
+
+/**
+ * The process console, as much of it as recording needs.
+ */
+export type SimLambdaProcessConsole = Record<
+  ConsoleMethod,
+  (...arguments_: readonly unknown[]) => void
+>;
+
+/**
+ * What an invocation of host-scope code prints through.
+ */
+export interface SimLambdaProcessGlobals {
+  readonly console: SimLambdaProcessConsole;
+  readonly stdout: SimLambdaProcessStream;
+  readonly stderr: SimLambdaProcessStream;
+}
+
+/**
+ * The real process globals, read when the patch is installed.
+ */
+function hostProcessGlobals(): SimLambdaProcessGlobals {
+  return {
+    console: globalThis.console,
+    stdout: process.stdout,
+    stderr: process.stderr,
+  };
+}
+
+/**
+ * What a sim Lambda handler running in the host scope prints.
+ *
+ * A handler backed by a real in-process function is a closure over its own
+ * module scope, so it prints through the host process's console and streams
+ * like any other code in the test run. Zip code has a vm sandbox with streams
+ * of its own and needs none of this. Node.js asynchronous context tracking
+ * bridges the gap for the in-process case, exactly as it does for the clock
+ * and for process.env: the invocation's sink is held in an AsyncLocalStorage
+ * store, and a write resolves to it while it is set.
+ *
+ * The store follows the invocation across await points, so concurrent
+ * invocations each record to their own function's log group, and output from
+ * the rest of the test run reaches the host console alone.
+ *
+ * Both the console and the standard streams are patched, because a test runner
+ * commonly replaces the global console with one of its own that writes
+ * somewhere else. Vitest does, which means a patch on `process.stdout` alone
+ * would see a handler's direct writes and miss every `console.log` it made.
+ * The console patch delegates outside the store, so a line the host console
+ * passes on to `process.stdout` is recorded once.
+ *
+ * The process globals are taken from a function so that a test can build an
+ * instance over streams it can watch. Everything else shares the one below.
+ */
+export class SimLambdaProcessOutput {
+  private readonly storage = new AsyncLocalStorage<SimLambdaOutputSink>();
+  private installed = false;
+
+  constructor(
+    private readonly processGlobals: () => SimLambdaProcessGlobals = hostProcessGlobals,
+  ) {}
+
+  /**
+   * Run an invocation with the given sink recording what it prints.
+   */
+  async run<T>(sink: SimLambdaOutputSink, run: () => Promise<T>): Promise<T> {
+    this.install();
+
+    return await this.storage.run(sink, run);
+  }
+
+  /**
+   * Tee the process console and standard streams into the invocation store.
+   *
+   * Installed on the first invocation that has somewhere to record rather than
+   * at import, so a test run that only ever invokes zip code, or that builds a
+   * function standalone outside a SimAws instance, is left completely alone.
+   *
+   * With no invocation running, both patches forward and record nothing, so an
+   * installed patch behaves exactly like no patch at all. Neither is ever
+   * removed: removing one would be unsafe while another invocation is in
+   * flight, and there is nothing to gain.
+   */
+  private install(): void {
+    if (this.installed) {
+      return;
+    }
+
+    this.installed = true;
+
+    const globals = this.processGlobals();
+
+    this.patchConsole(globals.console);
+    this.patchStream(globals.stdout);
+    this.patchStream(globals.stderr);
+  }
+
+  /**
+   * Record what the console prints during an invocation.
+   *
+   * The host method is held from install time. A test runner that wraps the
+   * console afterwards wraps the patch, so its own interception still sees
+   * every write, and one that replaces the console object outright takes the
+   * patch with it and gets the output the handler wrote.
+   */
+  private patchConsole(hostConsole: SimLambdaProcessConsole): void {
+    for (const method of CONSOLE_METHODS) {
+      // oxlint-disable-next-line security/detect-object-injection -- one of this module's own fixed method names.
+      const hostMethod = hostConsole[method].bind(hostConsole);
+
+      // oxlint-disable-next-line security/detect-object-injection -- one of this module's own fixed method names.
+      hostConsole[method] = (...arguments_: readonly unknown[]): void => {
+        this.storage.getStore()?.write(`${format(...arguments_)}\n`);
+
+        // Delegated outside the store, because the host console writing to
+        // process.stdout would otherwise record the same line a second time.
+        this.storage.exit(() => {
+          hostMethod(...arguments_);
+        });
+      };
+    }
+  }
+
+  /**
+   * Record what is written to one of the process's standard streams.
+   *
+   * Chunks are decoded as one stream rather than one at a time. A handler
+   * writing bytes in pieces can split a multibyte character across two writes,
+   * and decoding each chunk on its own would record a replacement character in
+   * place of both halves.
+   */
+  private patchStream(hostStream: SimLambdaProcessStream): void {
+    const hostWrite = hostStream.write.bind(hostStream);
+    const decoder = new StringDecoder("utf8");
+
+    hostStream.write = (chunk: StreamChunk, ...rest: never[]): boolean => {
+      const sink = this.storage.getStore();
+
+      if (sink !== undefined) {
+        sink.write(
+          typeof chunk === "string" ? chunk : decoder.write(Buffer.from(chunk)),
+        );
+      }
+
+      return hostWrite(chunk, ...rest);
+    };
+  }
+}
+
+/**
+ * Shared because it patches process globals: one patch, one store.
+ */
+export const simLambdaProcessOutput = new SimLambdaProcessOutput();

--- a/src/service/lambda/function/logging/sim-lambda-bound-handler-log-capture.iso.test.ts
+++ b/src/service/lambda/function/logging/sim-lambda-bound-handler-log-capture.iso.test.ts
@@ -1,0 +1,175 @@
+/* oxlint-disable no-console -- printing is what these handlers are here to do. */
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import { FilterLogEventsCommand } from "@aws-sdk/client-cloudwatch-logs";
+import { assertArrayEquals } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../code/lambda-zip-file-input.js";
+import type { SimLambdaHandler } from "../sim-lambda-handler.type.js";
+
+/**
+ * Resolve after a real pause, so two invocations can interleave their output.
+ */
+async function tick(milliseconds: number): Promise<void> {
+  await new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+}
+
+/**
+ * A simulated AWS with one function bound to the given in-process handler.
+ */
+async function simAwsWithBoundFunction(
+  functionName: string,
+  handler: SimLambdaHandler,
+  simAws: SimAws = new SimAws(),
+): Promise<SimAws> {
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: functionName,
+      Role: `arn:aws:iam::${simAws.defaultAccountId}:role/${functionName}Role`,
+      Code: { ZipFile: makeLambdaZipFileInput(handler) },
+    }),
+  );
+
+  await simAws.backgroundTasksComplete();
+
+  return simAws;
+}
+
+async function messagesIn(
+  simAws: SimAws,
+  logGroupName: string,
+): Promise<readonly string[]> {
+  const found = await simAws
+    .logs()
+    .filterLogEvents(new FilterLogEventsCommand({ logGroupName }));
+
+  return found.events?.map((event) => event.message) ?? [];
+}
+
+describe("bound Lambda handler output in CloudWatch Logs", () => {
+  it("records what a bound handler printed into its own log group", async () => {
+    // Given a function bound to an in-process handler that prints as it runs.
+    const simAws = await simAwsWithBoundFunction("orders", () => {
+      console.log("INFO handling order-1");
+      console.error("ERROR order has no items");
+
+      return "done";
+    });
+
+    // When it is invoked.
+    await simAws.lambda().invoke(new InvokeCommand({ FunctionName: "orders" }));
+
+    // Then both lines are in the function's log group, where a test can
+    // search for them as it can for zip code's output.
+    assertArrayEquals(await messagesIn(simAws, "/aws/lambda/orders"), [
+      "INFO handling order-1",
+      "ERROR order has no items",
+    ]);
+  });
+
+  it("records what a bound handler wrote to a standard stream", async () => {
+    // Given a handler writing to process.stdout itself, as a logging library
+    // building its own console over the stream does.
+    const simAws = await simAwsWithBoundFunction("invoices", () => {
+      process.stdout.write("INFO invoice-1 sent\n");
+
+      return "done";
+    });
+
+    // When it is invoked.
+    await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "invoices" }));
+
+    // Then the line reached the function's log group.
+    assertArrayEquals(await messagesIn(simAws, "/aws/lambda/invoices"), [
+      "INFO invoice-1 sent",
+    ]);
+  });
+
+  it("records a handler bound to a container image repository", async () => {
+    // Given an image function whose image stands in for an in-process handler.
+    const simAws = new SimAws();
+    const imageRepository =
+      `${simAws.defaultAccountId}.dkr.ecr.` +
+      `${simAws.defaultRegionName}.amazonaws.com/shipments`;
+
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "shipments-stack",
+      template: {
+        Resources: {
+          ShipmentsFunction: {
+            Type: "AWS::Lambda::Function",
+            Properties: {
+              FunctionName: "shipments",
+              Role: `arn:aws:iam::${simAws.defaultAccountId}:role/ShipmentsRole`,
+              PackageType: "Image",
+              Code: { ImageUri: `${imageRepository}:build-4172` },
+            },
+          },
+        },
+      },
+      bindings: [
+        {
+          imageRepository,
+          handler: (): string => {
+            console.log("INFO shipment-1 dispatched");
+
+            return "done";
+          },
+        },
+      ],
+    });
+
+    // When it is invoked.
+    await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "shipments" }));
+
+    // Then its output is in the log group too: an image binding resolves to
+    // the same host-scope code as any other handler reference.
+    assertArrayEquals(await messagesIn(simAws, "/aws/lambda/shipments"), [
+      "INFO shipment-1 dispatched",
+    ]);
+  });
+
+  it("keeps two concurrent invocations in their own log groups", async () => {
+    // Given two bound functions printing on either side of a pause.
+    const simAws = await simAwsWithBoundFunction("payments", async () => {
+      console.log("INFO payment-1 taken");
+      await tick(20);
+      console.log("INFO payment-1 settled");
+
+      return "done";
+    });
+
+    await simAwsWithBoundFunction(
+      "refunds",
+      async () => {
+        await tick(10);
+        console.log("INFO refund-1 issued");
+
+        return "done";
+      },
+      simAws,
+    );
+
+    // When both are invoked at once.
+    await Promise.all([
+      simAws.lambda().invoke(new InvokeCommand({ FunctionName: "payments" })),
+      simAws.lambda().invoke(new InvokeCommand({ FunctionName: "refunds" })),
+    ]);
+
+    // Then each function's log group holds only its own output.
+    assertArrayEquals(await messagesIn(simAws, "/aws/lambda/payments"), [
+      "INFO payment-1 taken",
+      "INFO payment-1 settled",
+    ]);
+    assertArrayEquals(await messagesIn(simAws, "/aws/lambda/refunds"), [
+      "INFO refund-1 issued",
+    ]);
+  });
+});

--- a/src/service/lambda/function/logging/sim-lambda-function-logging.ts
+++ b/src/service/lambda/function/logging/sim-lambda-function-logging.ts
@@ -1,5 +1,6 @@
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import type { SimLogsServiceWriter } from "../../../logs/write/sim-logs-service-writer.js";
+import type { SimLambdaOutputSink } from "./sim-lambda-output-sink.js";
 import type { SimLambdaExecutableCode } from "../code/sim-lambda-executable-code.js";
 import { SimLambdaLogWriter } from "./sim-lambda-log-writer.js";
 import {
@@ -72,6 +73,18 @@ export class SimLambdaFunctionLogging {
     if (writer !== undefined) {
       code.recordOutputTo(writer);
     }
+  }
+
+  /**
+   * Where this function's output goes, once its execution environment has
+   * cold started.
+   *
+   * Code with streams of its own is given this through recordFrom. Host-scope
+   * code has none, and its invocation runs with this as the sink the process
+   * console and standard streams tee into.
+   */
+  outputSink(): SimLambdaOutputSink | undefined {
+    return this.#writer;
   }
 
   /**

--- a/src/service/lambda/function/sim-lambda-function.ts
+++ b/src/service/lambda/function/sim-lambda-function.ts
@@ -284,16 +284,17 @@ export class SimLambdaFunction {
 
   /**
    * Run an invocation with the process globals host-scope code reads bridged
-   * to this simulation: the current time, and the HTTP clients it reaches for.
+   * to this simulation: the current time, the HTTP clients it reaches for,
+   * and the console and streams it prints through.
    */
   private async runInHostScope<T>(run: () => Promise<T>): Promise<T> {
     if (!this.code.runsInHostScope) {
       return await run();
     }
 
-    return await runSimLambdaInHostScope(
-      { clock: this.clock, outboundHttp: this.outboundHttp },
-      run,
-    );
+    const { clock, outboundHttp } = this;
+    const output = this.logging.outputSink();
+
+    return await runSimLambdaInHostScope({ clock, outboundHttp, output }, run);
   }
 }


### PR DESCRIPTION
A function backed by a real in-process handler printed to the host console and nowhere else, which left a route whose only visible effect is a log line untestable through that binding. The invocation now bridges the process console and the process standard streams to the function's log group, the way it already bridges the clock and process.env, so a bound handler's output reads back through FilterLogEvents as zip code's does. An AsyncLocalStorage store keeps concurrent invocations in their own log groups and leaves the rest of the test run's output alone, the console patch hands on outside the store so a line the host console passes to process.stdout is recorded once, and a handler standing in for a container image records the same way. Both the console and the streams are patched because a test runner commonly replaces the global console with one that writes somewhere else, which vitest does.

Resolves #733