### PR TITLE
feat: refuse oversized CloudFront Function code

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -964,6 +964,12 @@ constructs ordinary JavaScript allows. Yulin publishes ESLint and Oxlint configs
 refusals in the editor, ahead of publication. See
 [Linting CloudFront Functions JS2](../../lint/ "CloudFront Functions JS2 lint config usage docs").
 
+CloudFront also caps Function code at 10 KB, counted on the source as uploaded, comments and all.
+Simulated `CreateFunction` refuses anything larger with `FunctionSizeLimitExceeded`, as the real
+service does. A test that deploys the Stack reports the overrun where the rest of the suite runs,
+ahead of `cdk deploy`. A handler passed as a function reference carries no source to count, and the
+limit leaves it alone.
+
 ### Calling a Function handler without a Distribution
 
 A test of the handler on its own, with no Distribution in front of it, still has to pass it a whole
@@ -1800,6 +1806,7 @@ Sim CloudFront currently supports:
 - `CreateDistributionCommand`, `GetDistributionCommand`, `UpdateDistributionCommand` and
   `DeleteDistributionCommand`
 - `CreateFunctionCommand` and `DeleteFunctionCommand`
+- Refusing Function code over CloudFront's 10 KB size limit, with `FunctionSizeLimitExceeded`
 - Key value stores, through both the CloudFront client and the key value store data client
 - S3 Origins backed by sim S3 Buckets, reading them as the Bucket policy allows
 - Custom Origins reaching sim HTTP APIs and sim Lambda Function URLs in process
@@ -1864,6 +1871,10 @@ Where sim CloudFront knowingly behaves differently from AWS:
 - **A key value store association is fixed once the Function is created.** There is no
   `UpdateFunction` here, and the store a Function reads is the one it was created with. Delete the
   Function and create it again to change it.
+- **A bound handler goes unmeasured.** Function code over CloudFront's 10 KB limit is refused with
+  `FunctionSizeLimitExceeded`, counted on the source as uploaded. A handler passed as a function
+  reference, through `makeCffFunctionCodeInput` or a CloudFormation binding, carries no source to
+  count. The limit reaches only the inline code a real deploy would upload.
 - **`ImportSource` is unsupported.** `CreateKeyValueStoreCommand` ignores it, and
   `AWS::CloudFront::KeyValueStore` refuses a Resource carrying one. Nothing here reads an S3 Object
   as key data, and deploying an empty store would let a test pass against data the deploy should

--- a/src/service/cloudfront/cfn/cff/sim-cfn-cff-config.iso.test.ts
+++ b/src/service/cloudfront/cfn/cff/sim-cfn-cff-config.iso.test.ts
@@ -9,6 +9,7 @@ import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
 import { SimCloudFrontFunction } from "../../cff/sim-cloudfront-function.js";
+import { maxCffCodeBytes } from "../../command/create-function/create-function-code-size.js";
 
 describe("Sim CloudFormation CloudFront Function configuration", () => {
   it("creates a CloudFront Function when FunctionConfig is omitted", async () => {
@@ -107,5 +108,38 @@ function handler(event) {
       error.message,
       "AWS::CloudFront::Function InvalidCodeFunction FunctionCode must be a string",
     );
+  });
+
+  it("rejects a CloudFront Function template with oversized FunctionCode", async () => {
+    // Given a CloudFormation template whose inline FunctionCode is over the
+    // CloudFront size limit.
+    const simAws = new SimAws();
+    const handlerSource =
+      "function handler(event) { return event.request; }\n// ";
+    const oversized = handlerSource.padEnd(maxCffCodeBytes + 1, "x");
+
+    // When the template is deployed, then simulated CloudFront refuses it.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().deployTemplate({
+        template: {
+          Resources: {
+            OversizedFunction: {
+              Type: "AWS::CloudFront::Function",
+              Properties: {
+                Name: "oversized-function",
+                FunctionConfig: {
+                  Comment: "Oversized FunctionCode",
+                  Runtime: "cloudfront-js-2.0",
+                },
+                FunctionCode: oversized,
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    assertIdentical(error.name, "FunctionSizeLimitExceeded");
+    assertStringIncludes(error.message, String(maxCffCodeBytes + 1));
   });
 });

--- a/src/service/cloudfront/command/create-function/create-function-code-size.iso.test.ts
+++ b/src/service/cloudfront/command/create-function/create-function-code-size.iso.test.ts
@@ -1,0 +1,117 @@
+import { CreateFunctionCommand } from "@aws-sdk/client-cloudfront";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { CloudFrontFunction } from "../../typings/cloudfront-functions.namespace.js";
+import { makeCffFunctionCodeInput } from "../../cff/function-code-input/cff-function-code-input.js";
+import { SimCloudFrontFunctionSizeLimitExceeded } from "../../error/sim-cloudfront.error.js";
+import { maxCffCodeBytes } from "./create-function-code-size.js";
+
+const handlerSource = "function handler(event) { return event.request; }\n// ";
+
+const passThroughHandler: CloudFrontFunction.ViewerRequestHandler = (
+  event: CloudFrontFunction.ViewerRequestEvent,
+) => event.request;
+
+/**
+ * Runnable Function source padded out to an exact byte length.
+ *
+ * The padding is a trailing line comment of ASCII, where one character is one
+ * byte. CloudFront measures the source as uploaded, and the comment counts.
+ */
+function sourceOfBytes(byteLength: number): Buffer {
+  return Buffer.from(handlerSource.padEnd(byteLength, "x"));
+}
+
+describe("The size of a CloudFront Function's code", () => {
+  it("refuses source over the CloudFront limit", async () => {
+    // Given source one byte over what CloudFront takes
+    const simAws = new SimAws();
+    const source = sourceOfBytes(maxCffCodeBytes + 1);
+
+    // When a Function is created from it
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.cloudFront().createFunction(
+          new CreateFunctionCommand({
+            Name: "oversized",
+            FunctionConfig: {
+              Comment: "Too much source",
+              Runtime: "cloudfront-js-2.0",
+            },
+            FunctionCode: source,
+          }),
+        ),
+    );
+
+    // Then CloudFront refuses it the way the real service does
+    assertInstanceOf(error, SimCloudFrontFunctionSizeLimitExceeded);
+    assertIdentical(error.name, "FunctionSizeLimitExceeded");
+    assertIdentical(error.$metadata.httpStatusCode, 413);
+
+    // And the message names both byte counts
+    assertStringIncludes(error.message, String(maxCffCodeBytes + 1));
+    assertStringIncludes(error.message, String(maxCffCodeBytes));
+
+    // And the Function was never created
+    assertUndefined(
+      simAws.cloudFront().getCloudFrontFunctionByName("oversized"),
+    );
+  });
+
+  it("takes source at exactly the limit", async () => {
+    // Given source of exactly the most CloudFront takes
+    const simAws = new SimAws();
+    const source = sourceOfBytes(maxCffCodeBytes);
+    assertIdentical(source.byteLength, maxCffCodeBytes);
+
+    // When a Function is created from it
+    await simAws.cloudFront().createFunction(
+      new CreateFunctionCommand({
+        Name: "at-the-limit",
+        FunctionConfig: {
+          Comment: "Exactly the limit",
+          Runtime: "cloudfront-js-2.0",
+        },
+        FunctionCode: source,
+      }),
+    );
+
+    // Then the Function exists and runs
+    const cff = simAws.cloudFront().getCloudFrontFunctionByName("at-the-limit");
+    assertNonNullable(cff);
+
+    const result = await cff.handleViewerRequest(
+      new Request("https://example.cloudfront.net/object.json"),
+    );
+    assertIdentical(new URL(result.url).pathname, "/object.json");
+  });
+
+  it("takes a bound handler with no source to measure", async () => {
+    // Given a handler function reference in place of source
+    const simAws = new SimAws();
+
+    // When a Function is created from it
+    await simAws.cloudFront().createFunction(
+      new CreateFunctionCommand({
+        Name: "bound",
+        FunctionConfig: {
+          Comment: "A handler reference",
+          Runtime: "cloudfront-js-2.0",
+        },
+        FunctionCode: makeCffFunctionCodeInput(passThroughHandler),
+      }),
+    );
+
+    // Then the limit has nothing to say about it
+    assertNonNullable(simAws.cloudFront().getCloudFrontFunctionByName("bound"));
+  });
+});

--- a/src/service/cloudfront/command/create-function/create-function-code-size.ts
+++ b/src/service/cloudfront/command/create-function/create-function-code-size.ts
@@ -1,0 +1,42 @@
+import { CffUint8ArrayStowaway } from "../../cff/function-code-input/cff-function-code-input.js";
+import { SimCloudFrontFunctionSizeLimitExceeded } from "../../error/sim-cloudfront.error.js";
+import type { SimCreateFunctionCommandInput } from "./create-function.command.js";
+
+/**
+ * The most Function source CloudFront takes.
+ *
+ * The quota is published as 10 KB and is not adjustable. AWS never says which
+ * byte count that means. 10,240 is the looser of the two readings, and it keeps
+ * the simulator from refusing a Function real CloudFront would take.
+ *
+ * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-limits.html#limits-functions
+ */
+export const maxCffCodeBytes = 10_240;
+
+/**
+ * Refuse Function source over the CloudFront size limit.
+ *
+ * The limit is on the source as uploaded, comments and all, and nothing
+ * minifies it on the way to CloudFront. A consumer who goes over otherwise
+ * finds out at deploy time, after the whole test suite has already passed.
+ *
+ * A stowaway carries a handler reference in place of source. It has no bytes to
+ * measure and goes unchecked.
+ */
+export function assertCffCodeWithinSizeLimit(
+  functionName: string,
+  functionCode: SimCreateFunctionCommandInput["FunctionCode"],
+): void {
+  if (functionCode instanceof CffUint8ArrayStowaway) {
+    return;
+  }
+
+  const byteLength = functionCode?.byteLength ?? 0;
+
+  if (byteLength > maxCffCodeBytes) {
+    throw new SimCloudFrontFunctionSizeLimitExceeded(
+      `CloudFront Function ${functionName} code is ${String(byteLength)} ` +
+        `bytes, over the ${String(maxCffCodeBytes)} CloudFront takes`,
+    );
+  }
+}

--- a/src/service/cloudfront/command/create-function/create-function.handler.ts
+++ b/src/service/cloudfront/command/create-function/create-function.handler.ts
@@ -22,6 +22,7 @@ import {
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import { CreateFunctionAuthorizer } from "./create-function-authorizer.js";
 import { CreateFunctionKeyValueStoreAssociation } from "./create-function-kvs-association.js";
+import { assertCffCodeWithinSizeLimit } from "./create-function-code-size.js";
 import { SimCloudFrontKeyValueStoreRegistry } from "../../key-value-store/sim-cf-key-value-store-registry.js";
 
 export type SimCloudFrontFunctionMap = Map<
@@ -93,6 +94,11 @@ export class CreateFunctionCommandHandler implements CommandHandler<
     await this.background.sequence();
 
     this.authorizer.authorize(command.input.Name, options?.caller);
+
+    assertCffCodeWithinSizeLimit(
+      command.input.Name,
+      command.input.FunctionCode,
+    );
 
     const keyValueStore = this.keyValueStoreAssociation.resolve(
       command.input.Name,

--- a/src/service/cloudfront/error/sim-cloudfront.error.ts
+++ b/src/service/cloudfront/error/sim-cloudfront.error.ts
@@ -202,3 +202,18 @@ export class SimCloudFrontDistributionNotDisabled extends SimCloudFrontError {
     super(message, { httpStatusCode: 409 });
   }
 }
+
+/**
+ * Simulated CloudFront FunctionSizeLimitExceeded error.
+ *
+ * CloudFront caps Function source at 10 KB and will not raise the quota. What
+ * counts is the source as uploaded, comments and all, because nothing minifies
+ * it on the way.
+ */
+export class SimCloudFrontFunctionSizeLimitExceeded extends SimCloudFrontError {
+  public override readonly name = "FunctionSizeLimitExceeded";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 413 });
+  }
+}


### PR DESCRIPTION
CloudFront caps Function code at 10 KB, counted on the source as uploaded with its comments, and nothing minifies it on the way. Simulated `CreateFunction` now refuses anything larger with `FunctionSizeLimitExceeded` and HTTP 413, as the real service does. The overrun surfaces in the test suite ahead of `cdk deploy`. The limit is taken as 10,240 bytes, the looser of the two readings AWS's published 10 KB allows. A handler passed as a function reference through `makeCffFunctionCodeInput` or a CloudFormation binding carries no source to count and goes through unmeasured.

Resolves #736
