### PR TITLE
feat: read earlier Stacks in a cdk.out transform

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -1188,6 +1188,10 @@ console.log(stacks.keys().toArray());
 
 Naming a Stack the assembly lacks fails the call, listing the Stacks it does hold.
 
+The order the Stacks are named in is the order they deploy in. A Stack the manifest says another
+depends on still goes first, whatever order the two are named in, and an assembly deployed whole
+keeps the order its own manifest holds.
+
 ### Bindings and transforms for one Stack
 
 A call naming a directory has no single template to attach bindings to, so `stackOptions` keys them
@@ -1220,6 +1224,59 @@ console.log(stacks.get("ApiStack")?.stackName);
 
 An options key matching no Stack being deployed fails the call, so a renamed Stack takes its
 bindings with it rather than quietly losing them.
+
+### Transforming a Stack with an earlier Stack's values
+
+A `stackOptions` transform is handed the Stacks the same call has already deployed, keyed by Stack
+name. A CDK app that creates a certificate in one Stack and uses it in another passes the ARN across
+as a plain string, and the ARN the synthesized template carries belongs to the real account.
+Simulated ACM issues its own. Reading it back off the Stack that created it keeps both Stacks in one
+`deployCdkOut` call.
+
+```typescript sim-cloudformation-cdk-out-stack-transform
+import { SimAws } from "@kensio/yulin";
+import type { CfnTemplateBodyRecord } from "@kensio/yulin/cloudformation";
+
+const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+/** The ARN the CDK app pins, because the Stack that issues it is another one. */
+const synthesizedCertificateArn =
+  "arn:aws:acm:us-east-1:111122223333:certificate/11111111-2222-3333-4444-555555555555";
+
+/** Put the ARN simulated ACM issued wherever the synthesized one is named. */
+function withSimulatedCertificate(
+  template: CfnTemplateBodyRecord,
+  certificateArn: string,
+): CfnTemplateBodyRecord {
+  return JSON.parse(
+    JSON.stringify(template).replaceAll(
+      synthesizedCertificateArn,
+      () => certificateArn,
+    ),
+  ) as CfnTemplateBodyRecord;
+}
+
+const stacks = await simAws.cloudFormation().deployCdkOut({
+  directoryPath: "cdk.out",
+  stackNames: ["DnsStack", "SiteStack"],
+  stackOptions: {
+    SiteStack: {
+      transform: (template, deployed): CfnTemplateBodyRecord =>
+        withSimulatedCertificate(
+          template,
+          deployed.get("DnsStack")?.output("SiteCertificateArn") ?? "",
+        ),
+    },
+  },
+});
+
+console.log(stacks.get("SiteStack")?.stackName);
+```
+
+The map holds the Stacks deployed ahead of this one and nothing else. The first Stack to deploy is
+handed an empty one. Naming the Stacks in the order they have to go in is what puts the certificate
+there in time, since two Stacks passing a plain string between them declare no dependency for the
+manifest to carry.
 
 ## Editing a synthesized template before deploying it
 

--- a/docs/services/cloudformation/sim-cloudformation-cdk-out-stack-transform.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-cdk-out-stack-transform.example.ts
@@ -1,0 +1,37 @@
+import { SimAws } from "@kensio/yulin";
+import type { CfnTemplateBodyRecord } from "@kensio/yulin/cloudformation";
+
+const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+/** The ARN the CDK app pins, because the Stack that issues it is another one. */
+const synthesizedCertificateArn =
+  "arn:aws:acm:us-east-1:111122223333:certificate/11111111-2222-3333-4444-555555555555";
+
+/** Put the ARN simulated ACM issued wherever the synthesized one is named. */
+function withSimulatedCertificate(
+  template: CfnTemplateBodyRecord,
+  certificateArn: string,
+): CfnTemplateBodyRecord {
+  return JSON.parse(
+    JSON.stringify(template).replaceAll(
+      synthesizedCertificateArn,
+      () => certificateArn,
+    ),
+  ) as CfnTemplateBodyRecord;
+}
+
+const stacks = await simAws.cloudFormation().deployCdkOut({
+  directoryPath: "cdk.out",
+  stackNames: ["DnsStack", "SiteStack"],
+  stackOptions: {
+    SiteStack: {
+      transform: (template, deployed): CfnTemplateBodyRecord =>
+        withSimulatedCertificate(
+          template,
+          deployed.get("DnsStack")?.output("SiteCertificateArn") ?? "",
+        ),
+    },
+  },
+});
+
+console.log(stacks.get("SiteStack")?.stackName);

--- a/src/service/cloudformation/cdk/sim-cdk-assembly-selection.ts
+++ b/src/service/cloudformation/cdk/sim-cdk-assembly-selection.ts
@@ -8,6 +8,10 @@ import type { SimCdkAssemblyStack } from "./sim-cdk-assembly-manifest.js";
  * Stage deploys a Stack whose artifact ID is not what the Stack is called.
  * Naming nothing takes every Stack in the assembly.
  *
+ * The Stacks come back in the order they were named, which is the order they
+ * deploy in wherever the manifest declares no dependency between them. Naming
+ * one twice takes it once, under the first name it was given.
+ *
  * Throws naming the Stacks the assembly does hold, which is what a caller who
  * has just renamed one needs to see.
  */
@@ -22,13 +26,13 @@ export function selectCdkAssemblyStacks(properties: {
     return stacks;
   }
 
-  const selected = new Set(
-    stackNames.map((stackName) =>
-      selectOne({ stacks, stackName, directoryPath }),
+  return [
+    ...new Set(
+      stackNames.map((stackName) =>
+        selectOne({ stacks, stackName, directoryPath }),
+      ),
     ),
-  );
-
-  return stacks.filter((stack) => selected.has(stack));
+  ];
 }
 
 function selectOne(properties: {

--- a/src/service/cloudformation/deploy/sim-cfn-cdk-out-deployer.iso.test.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-cdk-out-deployer.iso.test.ts
@@ -108,6 +108,79 @@ describe("Deploying a CDK cloud assembly [iso]", () => {
     );
   });
 
+  it("deploys the named Stacks in the order they are named", async () => {
+    // Given an assembly holding two Stacks with no dependency between them.
+    const directory = await simCdkCloudAssemblyFactory.make({
+      stacks: [
+        { artifactId: "SiteStack", regionName: "eu-west-2" },
+        { artifactId: "DnsStack", regionName: "us-east-1" },
+      ],
+    });
+
+    // When they are named the other way round to the manifest.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+    const stacks = await simAws.cloudFormation().deployCdkOut({
+      directoryPath: directory.join("cdk.out"),
+      stackNames: ["DnsStack", "SiteStack"],
+    });
+
+    // Then they deployed in the order they were named.
+    assertArrayEquals(stacks.keys().toArray(), ["DnsStack", "SiteStack"]);
+  });
+
+  it("deploys a depended-on Stack first however the two are named", async () => {
+    // Given an assembly whose manifest says one Stack comes after another.
+    const directory = await simCdkCloudAssemblyFactory.make({
+      stacks: [
+        {
+          artifactId: "ConsumerStack",
+          regionName: "eu-west-2",
+          dependencies: ["ProducerStack"],
+        },
+        { artifactId: "ProducerStack", regionName: "eu-west-2" },
+      ],
+    });
+
+    // When the consumer is named first.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+    const stacks = await simAws.cloudFormation().deployCdkOut({
+      directoryPath: directory.join("cdk.out"),
+      stackNames: ["ConsumerStack", "ProducerStack"],
+    });
+
+    // Then the manifest dependency still went first.
+    assertArrayEquals(stacks.keys().toArray(), [
+      "ProducerStack",
+      "ConsumerStack",
+    ]);
+  });
+
+  it("deploys a Stack once when it is named twice", async () => {
+    // Given an assembly holding a Stack whose name and artifact ID differ.
+    const directory = await simCdkCloudAssemblyFactory.make({
+      stacks: [
+        {
+          artifactId: "SiteStackArtifact",
+          stackName: "SiteStack",
+          regionName: "eu-west-2",
+        },
+      ],
+    });
+
+    // When it is named by both.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+    const stacks = await simAws.cloudFormation().deployCdkOut({
+      directoryPath: directory.join("cdk.out"),
+      stackNames: ["SiteStack", "SiteStackArtifact"],
+    });
+
+    // Then it deployed once.
+    assertArrayEquals(stacks.keys().toArray(), ["SiteStack"]);
+  });
+
   it("deploys an environment-agnostic Stack into the region it is asked in", async () => {
     // Given an assembly whose Stack was synthesized with no `env`.
     const directory = await simCdkCloudAssemblyFactory.make({

--- a/src/service/cloudformation/deploy/sim-cfn-cdk-out-deployer.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-cdk-out-deployer.ts
@@ -1,7 +1,10 @@
 import type { SimAws } from "../../aws/sim-aws.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type { SimCfnStack } from "../stack/sim-cfn-stack.js";
-import { cdkOutOptionsFor } from "./sim-cfn-cdk-out-stack-options.js";
+import {
+  cdkOutBoundTransform,
+  cdkOutOptionsFor,
+} from "./sim-cfn-cdk-out-stack-options.js";
 import {
   planCdkOutDeployment,
   type SimCfnCdkOutPlan,
@@ -9,7 +12,10 @@ import {
   type SimCloudFormationDeployCdkOutProperties,
 } from "./sim-cfn-cdk-out-plan.js";
 
-export type { SimCfnCdkOutStackOptions } from "./sim-cfn-cdk-out-stack-options.js";
+export type {
+  SimCfnCdkOutStackOptions,
+  SimCfnCdkOutTemplateTransform,
+} from "./sim-cfn-cdk-out-stack-options.js";
 export type { SimCloudFormationDeployCdkOutProperties } from "./sim-cfn-cdk-out-plan.js";
 
 interface SimCfnCdkOutDeployerProperties {
@@ -39,7 +45,7 @@ export class SimCfnCdkOutDeployer {
 
     for (const stack of plan.stacks) {
       // oxlint-disable-next-line no-await-in-loop -- one Stack at a time, since a later one may depend on an earlier one
-      const deployedStack = await this.deployStack(stack, plan);
+      const deployedStack = await this.deployStack(stack, plan, deployed);
 
       deployed.set(stack.stackName, deployedStack);
     }
@@ -50,8 +56,13 @@ export class SimCfnCdkOutDeployer {
   private async deployStack(
     stack: SimCfnCdkOutPlannedStack,
     plan: SimCfnCdkOutPlan,
+    deployed: ReadonlyMap<string, SimCfnStack>,
   ): Promise<SimCfnStack> {
     const { simAws, accountRegionScope } = this.scope;
+    const { transform, ...options } = cdkOutOptionsFor(
+      stack,
+      plan.stackOptions,
+    );
 
     return await simAws
       .accountRegionScope(accountRegionScope.accountId, stack.regionName)
@@ -59,7 +70,8 @@ export class SimCfnCdkOutDeployer {
       .deployTemplateFile({
         templatePath: stack.templatePath,
         stackName: stack.stackName,
-        ...cdkOutOptionsFor(stack, plan.stackOptions),
+        ...options,
+        transform: cdkOutBoundTransform(transform, deployed),
       });
   }
 }

--- a/src/service/cloudformation/deploy/sim-cfn-cdk-out-plan.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-cdk-out-plan.ts
@@ -21,6 +21,10 @@ export interface SimCloudFormationDeployCdkOutProperties {
    * Every Stack in the assembly is deployed when this is left out, which is
    * rarely what a test wants of an app that also synthesizes a deployment
    * pipeline.
+   *
+   * The order they are named is the order they deploy in. A Stack the manifest
+   * says another depends on still goes first, whatever order the two are named
+   * in.
    */
   readonly stackNames?: readonly string[] | undefined;
 

--- a/src/service/cloudformation/deploy/sim-cfn-cdk-out-stack-options.iso.test.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-cdk-out-stack-options.iso.test.ts
@@ -1,6 +1,7 @@
 import { InvokeCommand } from "@aws-sdk/client-lambda";
 import {
   assertIdentical,
+  assertMapSize,
   assertNonNullable,
   assertStringIncludes,
   assertThrowsErrorAsync,
@@ -12,7 +13,10 @@ import {
   assemblyStackBucketName,
   simCdkCloudAssemblyFactory,
 } from "../cdk/sim-cdk-cloud-assembly.factory.js";
+import type { SimCfnStack } from "../stack/sim-cfn-stack.js";
+import type { CfnTemplateBodyRecord } from "../template/sim-cfn-template.js";
 import type { SimCfnTemplateValueRecord } from "../template/value/sim-cfn-template-value.js";
+import type { SimCfnCdkOutTemplateTransform } from "./sim-cfn-cdk-out-stack-options.js";
 
 const assumeRolePolicyDocument = {
   Version: "2012-10-17",
@@ -128,6 +132,86 @@ describe("Deploying a CDK cloud assembly with per-Stack options [iso]", () => {
     );
   });
 
+  it("transforms a Stack with a value an earlier Stack in the call created", async () => {
+    // Given an assembly where a DNS Stack shares a value the simulation
+    // allocates, and a site Stack whose template names the real one.
+    const directory = await simCdkCloudAssemblyFactory.make({
+      stacks: [
+        {
+          artifactId: "DnsStack",
+          regionName: "us-east-1",
+          outputs: { SiteBucketName: { Value: { Ref: "DnsStackBucket" } } },
+        },
+        {
+          artifactId: "SiteStack",
+          regionName: "eu-west-2",
+          resources: {
+            SiteTopic: {
+              Type: "AWS::SNS::Topic",
+              Properties: {
+                TopicName: "site-topic",
+                DisplayName: "the-real-account-value",
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    // When the site Stack is transformed with the deployment so far.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+    const stacks = await simAws.cloudFormation().deployCdkOut({
+      directoryPath: directory.join("cdk.out"),
+      stackOptions: {
+        SiteStack: {
+          transform: (template, deployed) =>
+            withTopicDisplayName(
+              template,
+              deployedOutput(deployed, "DnsStack", "SiteBucketName"),
+            ),
+        },
+      },
+    });
+
+    // Then the Stack deployed the value the DNS Stack had just created.
+    assertIdentical(
+      stacks.get("SiteStack")?.resources.get("SiteTopic")?.properties[
+        "DisplayName"
+      ],
+      assemblyStackBucketName("DnsStack"),
+    );
+  });
+
+  it("transforms the first Stack with a deployment holding nothing yet", async () => {
+    // Given an assembly whose first Stack is transformed.
+    const directory = await simCdkCloudAssemblyFactory.make({
+      stacks: [
+        { artifactId: "DnsStack", regionName: "us-east-1" },
+        { artifactId: "SiteStack", regionName: "eu-west-2" },
+      ],
+    });
+
+    const deployments = new Map<string, ReadonlyMap<string, SimCfnStack>>();
+
+    // When both Stacks record the deployment their transform was handed.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+    await simAws.cloudFormation().deployCdkOut({
+      directoryPath: directory.join("cdk.out"),
+      stackOptions: {
+        DnsStack: { transform: recordingTransform(deployments, "DnsStack") },
+        SiteStack: { transform: recordingTransform(deployments, "SiteStack") },
+      },
+    });
+
+    // Then the first Stack saw nothing, and the second saw the first.
+    assertMapSize(assertedDeployment(deployments, "DnsStack"), 0);
+    assertNonNullable(
+      assertedDeployment(deployments, "SiteStack").get("DnsStack"),
+    );
+  });
+
   it("fails when options name a Stack that is not being deployed", async () => {
     // Given an assembly whose Stack has since been renamed.
     const directory = await simCdkCloudAssemblyFactory.make({
@@ -159,3 +243,50 @@ describe("Deploying a CDK cloud assembly with per-Stack options [iso]", () => {
     );
   });
 });
+
+function deployedOutput(
+  deployed: ReadonlyMap<string, SimCfnStack>,
+  stackName: string,
+  outputKey: string,
+): string {
+  const stack = deployed.get(stackName);
+  assertNonNullable(stack);
+
+  return stack.output(outputKey);
+}
+
+function withTopicDisplayName(
+  template: CfnTemplateBodyRecord,
+  displayName: string,
+): CfnTemplateBodyRecord {
+  return {
+    ...template,
+    Resources: {
+      SiteTopic: {
+        Type: "AWS::SNS::Topic",
+        Properties: { TopicName: "site-topic", DisplayName: displayName },
+      },
+    },
+  };
+}
+
+function recordingTransform(
+  deployments: Map<string, ReadonlyMap<string, SimCfnStack>>,
+  stackName: string,
+): SimCfnCdkOutTemplateTransform {
+  return (template, deployed) => {
+    deployments.set(stackName, deployed);
+
+    return template;
+  };
+}
+
+function assertedDeployment(
+  deployments: ReadonlyMap<string, ReadonlyMap<string, SimCfnStack>>,
+  stackName: string,
+): ReadonlyMap<string, SimCfnStack> {
+  const deployment = deployments.get(stackName);
+  assertNonNullable(deployment);
+
+  return deployment;
+}

--- a/src/service/cloudformation/deploy/sim-cfn-cdk-out-stack-options.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-cdk-out-stack-options.ts
@@ -1,17 +1,37 @@
 import type { SimCdkAssemblyStack } from "../cdk/sim-cdk-assembly-manifest.js";
 import type { SimCfnDeployBinding } from "../bind/sim-cfn-deploy-binding.js";
+import type { SimCfnStack } from "../stack/sim-cfn-stack.js";
+import type { CfnTemplateBodyRecord } from "../template/sim-cfn-template.js";
 import type { SimCfnTemplateFileTransform } from "./sim-cfn-template-file-transform.js";
+
+/**
+ * Adapts one Stack's parsed template, with the Stacks the same call has already
+ * deployed to hand.
+ *
+ * A synthesized template names the real account's resources as literals, and a
+ * simulation allocates its own identifiers for them. The deployed Stacks are
+ * keyed by Stack name, and a value one of them created is reached through
+ * `output(...)` or `getResource(...)`.
+ *
+ * A transform taking the template alone is this type too, since the deployed
+ * Stacks are the second argument.
+ */
+export type SimCfnCdkOutTemplateTransform = (
+  template: CfnTemplateBodyRecord,
+  deployed: ReadonlyMap<string, SimCfnStack>,
+) => CfnTemplateBodyRecord;
 
 /**
  * What one Stack in a cloud assembly is deployed with.
  *
  * These are the per-template options `deployTemplateFile` takes, for the one
- * Stack they are keyed against.
+ * Stack they are keyed against. The transform sees more than that one does,
+ * because a Stack in an assembly has Stacks in front of it.
  */
 export interface SimCfnCdkOutStackOptions {
   readonly parameters?: Record<string, string> | undefined;
   readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
-  readonly transform?: SimCfnTemplateFileTransform | undefined;
+  readonly transform?: SimCfnCdkOutTemplateTransform | undefined;
 }
 
 export type SimCfnCdkOutStackOptionsByName = Record<
@@ -29,6 +49,25 @@ export function cdkOutOptionsFor(
   return (
     optionsByName?.[stack.stackName] ?? optionsByName?.[stack.artifactId] ?? {}
   );
+}
+
+/**
+ * Bind a Stack's transform to the Stacks deployed ahead of it.
+ *
+ * The deployment is copied on the way in, so a transform holding on to the map
+ * keeps the deployment it was handed while the call goes on deploying.
+ */
+export function cdkOutBoundTransform(
+  transform: SimCfnCdkOutTemplateTransform | undefined,
+  deployed: ReadonlyMap<string, SimCfnStack>,
+): SimCfnTemplateFileTransform | undefined {
+  if (transform === undefined) {
+    return undefined;
+  }
+
+  const deployedSoFar = new Map(deployed);
+
+  return (template) => transform(template, deployedSoFar);
 }
 
 /**

--- a/src/service/cloudformation/index.ts
+++ b/src/service/cloudformation/index.ts
@@ -2,7 +2,10 @@ export { SimCloudFormation } from "./sim-cloudformation.js";
 export type { CfnTemplateBodyRecord } from "./template/sim-cfn-template.js";
 export type { SimCfnTemplateFileTransform } from "./deploy/sim-cfn-template-file-transform.js";
 export type { SimCloudFormationDeployCdkOutProperties } from "./deploy/sim-cfn-cdk-out-deployer.js";
-export type { SimCfnCdkOutStackOptions } from "./deploy/sim-cfn-cdk-out-stack-options.js";
+export type {
+  SimCfnCdkOutStackOptions,
+  SimCfnCdkOutTemplateTransform,
+} from "./deploy/sim-cfn-cdk-out-stack-options.js";
 export type {
   SimCfnTemplateFileWatchOptions,
   SimCfnWatchReloadTarget,


### PR DESCRIPTION
A `stackOptions` transform is handed the Stacks the same `deployCdkOut` call has already deployed, keyed by Stack name. A template naming a value the simulation allocates takes it from the Stack that created it, with no second deployment call giving up the manifest's per-Stack regions and ordering. The Stacks a call names now deploy in the order they are named, and a Stack the manifest says another depends on still goes first.

Resolves https://github.com/KensioSoftware/yulin/issues/738

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`
