### PR TITLE
feat: register a sim Cognito pool by chosen id

### DIFF
--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -2867,6 +2867,78 @@ Cognito allows if the two are longer than that together. Real CloudFormation add
 on the end and this adds none. The name is the same on every deployment of the same template, and a
 test can assert it.
 
+## Registering a pool with a chosen pool id
+
+`CreateUserPoolCommand` allocates its own pool id, as real Cognito does, and takes none from you.
+`CreateUserPoolClientCommand` allocates the app client id the same way. When something else already
+decided either, register the pool and the app client as part of your test setup.
+
+The usual reason is a CDK app whose pool lives in one stack and whose Lambda function lives in
+another, with the two deliberately not joined by a CloudFormation export. Both ids reach the
+synthesized template as literal strings, the pool id in the function's environment and the pool ARN
+in its execution role's policy. Registering the pool and the client first lets that template deploy
+as it is, with no rewriting.
+
+```typescript sim-cognito-register-user-pool
+/**
+ * Registering a simulated Cognito user pool and app client with chosen ids.
+ */
+
+import { DescribeUserPoolClientCommand } from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+const cognito = simAws.cognitoIdentityProvider();
+
+// The ids the CDK app pins, the stack that creates the pool being another one.
+cognito.registerUserPool({
+  id: "eu-west-2_aBcDeFgHi",
+  name: "myapp-users",
+  settings: { Policies: { PasswordPolicy: { MinimumLength: 12 } } },
+});
+
+cognito.registerUserPoolClient({
+  userPoolId: "eu-west-2_aBcDeFgHi",
+  id: "examplewebclient0000000000",
+  name: "web",
+  settings: { ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH"] },
+});
+
+const described = await cognito.describeUserPoolClient(
+  new DescribeUserPoolClientCommand({
+    UserPoolId: "eu-west-2_aBcDeFgHi",
+    ClientId: "examplewebclient0000000000",
+  }),
+);
+
+console.log(described.UserPoolClient?.ClientName);
+```
+
+A registered pool behaves like any other. It answers `DescribeUserPoolCommand` and
+`ListUserPoolsCommand`, holds users, groups and app clients, and serves its JWKS and OpenID
+configuration on localhost. Everything written against a pool id follows from the id it was
+registered under: its ARN, its issuer URL, the `iss` claim of its tokens and its `ProviderName`. A
+policy naming `arn:aws:cognito-idp:eu-west-2:111111111111:userpool/eu-west-2_aBcDeFgHi` authorizes
+the handler that reads the pool, which is what a template carrying the id in two places needs.
+
+`registerUserPool` takes the same optional `settings` as `CreateUserPoolCommand`, and
+`registerUserPoolClient` the same optional `settings` as `CreateUserPoolClientCommand`, with
+`ClientName` given as `name`. A registered app client signs users in through `InitiateAuthCommand`,
+which names no pool and finds one from the client id alone.
+
+Registration is refused rather than allowed to produce a pool no real Cognito matches:
+
+- A pool id another pool holds, whether it was registered or created, gives
+  `UserPoolAlreadyExists`.
+- A client id another pool in the simulation holds gives `UserPoolClientAlreadyExists`. That lookup
+  from a client id to a pool is what `InitiateAuth` makes, and two pools sharing a client id would
+  make it ambiguous.
+- A value that is no pool id or client id gives `InvalidParameterException`.
+- A pool id naming another Region gives `InvalidParameterException`, saying which simulated Cognito
+  to register it on. A pool id carries the Region its pool lives in, and the ARN carries the Region
+  of the simulated Cognito holding it, so crossing the two would name two Regions in one pool.
+
 ## Properties accepted without being simulated
 
 A CDK `UserPool` construct emits six properties on `AWS::Cognito::UserPool` before it has been asked
@@ -3731,6 +3803,8 @@ Sim Cognito currently supports:
   `AWS::Cognito::UserPoolDomain` and `AWS::Cognito::UserPoolIdentityProvider` deployed from a
   CloudFormation template, with the `Ref` and `Fn::GetAtt` values real CloudFormation returns
 - Pool ids in the real `<region>_<nine characters>` form, and pool ARNs built from them
+- `registerUserPool` and `registerUserPoolClient`, which stand a pool and an app client up under
+  chosen ids, for a template that names ids another stack allocated
 - The real default password policy, applied to the passwords users are given
 - The real user status lifecycle, in which an admin-created user stays in `FORCE_CHANGE_PASSWORD`
   until it has a permanent password, a signed-up user stays in `UNCONFIRMED` until it confirms, and

--- a/docs/services/cognito/sim-cognito-register-user-pool.example.ts
+++ b/docs/services/cognito/sim-cognito-register-user-pool.example.ts
@@ -1,0 +1,33 @@
+/**
+ * Registering a simulated Cognito user pool and app client with chosen ids.
+ */
+
+import { DescribeUserPoolClientCommand } from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+const cognito = simAws.cognitoIdentityProvider();
+
+// The ids the CDK app pins, the stack that creates the pool being another one.
+cognito.registerUserPool({
+  id: "eu-west-2_aBcDeFgHi",
+  name: "myapp-users",
+  settings: { Policies: { PasswordPolicy: { MinimumLength: 12 } } },
+});
+
+cognito.registerUserPoolClient({
+  userPoolId: "eu-west-2_aBcDeFgHi",
+  id: "examplewebclient0000000000",
+  name: "web",
+  settings: { ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH"] },
+});
+
+const described = await cognito.describeUserPoolClient(
+  new DescribeUserPoolClientCommand({
+    UserPoolId: "eu-west-2_aBcDeFgHi",
+    ClientId: "examplewebclient0000000000",
+  }),
+);
+
+console.log(described.UserPoolClient?.ClientName);

--- a/src/service/cognito/cfn/sim-cfn-cognito-registered-pool.iso.test.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-registered-pool.iso.test.ts
@@ -1,0 +1,207 @@
+import { DescribeUserPoolClientCommand } from "@aws-sdk/client-cognito-identity-provider";
+import { CognitoIdentityProviderClient } from "@aws-sdk/client-cognito-identity-provider";
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../cloudformation/template/sim-cfn-template.js";
+import type { SimLambdaHandler } from "../../lambda/function/sim-lambda-handler.type.js";
+
+// The ids a CDK app pins as literal strings, the stack that creates the pool
+// being a different one from the stack that reads it.
+const pinnedUserPoolId = "eu-west-2_aBcDeFgHi";
+const pinnedClientId = "examplewebclient0000000000";
+
+const accountId = "888888888888";
+const regionName = "eu-west-2";
+
+/**
+ * The pool ARN a synthesized template carries, which is the pinned pool id
+ * after `userpool/`.
+ */
+function pinnedUserPoolArn(userPoolId: string): string {
+  return `arn:aws:cognito-idp:${regionName}:${accountId}:userpool/${userPoolId}`;
+}
+
+/**
+ * The stack that reads the pool, as `cdk synth` writes it.
+ *
+ * Both ids reach the template as literals, and the pool ARN in the execution
+ * role's policy carries the pool id a second time. Nothing here declares the
+ * pool: it belongs to another stack.
+ */
+function userReadingStack(policyUserPoolId: string): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      UserFunctionRole: {
+        Type: "AWS::IAM::Role",
+        Properties: {
+          RoleName: "UserFunctionRole",
+          AssumeRolePolicyDocument: {
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Principal: { Service: "lambda.amazonaws.com" },
+                Action: "sts:AssumeRole",
+              },
+            ],
+          },
+          Policies: [
+            {
+              PolicyName: "ReadUserPool",
+              PolicyDocument: {
+                Version: "2012-10-17",
+                Statement: [
+                  {
+                    Effect: "Allow",
+                    Action: "cognito-idp:DescribeUserPoolClient",
+                    Resource: pinnedUserPoolArn(policyUserPoolId),
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      UserFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "user",
+          Role: { "Fn::GetAtt": ["UserFunctionRole", "Arn"] },
+          Handler: "index.handler",
+          Runtime: "nodejs22.x",
+          Code: { ZipFile: "exports.handler = async () => 'user';" },
+          Environment: {
+            Variables: {
+              USER_POOL_ID: pinnedUserPoolId,
+              USER_POOL_CLIENT_ID: pinnedClientId,
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+/**
+ * A handler reading the app client it is configured with, as one working out
+ * where to send a browser for sign-in does.
+ */
+const clientReadingHandler: SimLambdaHandler = async (): Promise<unknown> => {
+  const cognito = new CognitoIdentityProviderClient({});
+  const described = await cognito.send(
+    new DescribeUserPoolClientCommand({
+      UserPoolId: process.env["USER_POOL_ID"],
+      ClientId: process.env["USER_POOL_CLIENT_ID"],
+    }),
+  );
+
+  return { clientName: described.UserPoolClient?.ClientName };
+};
+
+/**
+ * A simulated AWS holding the pool and app client the stack names, registered
+ * under the ids the template was synthesized with.
+ */
+function simAwsWithRegisteredPool(): SimAws {
+  const simAws = new SimAws({
+    defaultAccountId: accountId,
+    defaultRegionName: regionName,
+  });
+  const cognito = simAws.cognitoIdentityProvider();
+
+  cognito.registerUserPool({ id: pinnedUserPoolId, name: "myapp-users" });
+  cognito.registerUserPoolClient({
+    userPoolId: pinnedUserPoolId,
+    id: pinnedClientId,
+    name: "web",
+  });
+
+  return simAws;
+}
+
+/**
+ * Deploy the stack with the handler bound to its function.
+ */
+async function deployUserStack(
+  simAws: SimAws,
+  policyUserPoolId: string,
+): Promise<void> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "user-stack",
+    template: userReadingStack(policyUserPoolId),
+    bindings: [{ functionName: "user", handler: clientReadingHandler }],
+  });
+
+  await stack.waitForDeployComplete();
+}
+
+/**
+ * Invoke the deployed function.
+ */
+async function invokeUserFunction(simAws: SimAws): Promise<{
+  readonly error: string | undefined;
+  readonly payload: unknown;
+}> {
+  const output = await simAws
+    .lambda()
+    .invoke(new InvokeCommand({ FunctionName: "user" }));
+
+  assertNonNullable(output.Payload, "Invocation payload");
+
+  return {
+    error: output.FunctionError,
+    payload: JSON.parse(Buffer.from(output.Payload).toString()) as unknown,
+  };
+}
+
+describe("A template naming a registered simulated Cognito user pool", () => {
+  it("deploys and authorizes its handler against the registered pool", async () => {
+    // Given a simulation holding the pool and app client the template names.
+    const simAws = simAwsWithRegisteredPool();
+
+    // When the stack deploys with no rewriting, and its function runs.
+    await deployUserStack(simAws, pinnedUserPoolId);
+
+    const invoked = await invokeUserFunction(simAws);
+
+    // Then the handler read the app client its environment names, authorized by
+    // an execution role whose policy names the same pool ARN.
+    assertUndefined(invoked.error);
+    assertIdentical(
+      (invoked.payload as { clientName?: string }).clientName,
+      "web",
+    );
+  });
+
+  it("refuses the handler where the role's policy names another pool", async () => {
+    // Given the same simulation, and a template whose policy names a pool the
+    // registered ids have nothing to do with.
+    const simAws = simAwsWithRegisteredPool();
+
+    simAws
+      .cognitoIdentityProvider()
+      .registerUserPool({ id: "eu-west-2_jKlMnOpQr", name: "other-users" });
+
+    // When the function runs against a policy scoped to that other pool.
+    await deployUserStack(simAws, "eu-west-2_jKlMnOpQr");
+
+    const invoked = await invokeUserFunction(simAws);
+
+    // Then the call is denied, which is what makes the ARN in the policy worth
+    // getting right: a pool id moving without the ARN it is the tail of gives
+    // the handler an AccessDenied naming a pool it plainly has a statement for.
+    assertIdentical(invoked.error, "Unhandled");
+    assertStringIncludes(
+      JSON.stringify(invoked.payload),
+      "cognito-idp:DescribeUserPoolClient",
+    );
+  });
+});

--- a/src/service/cognito/command/sim-cognito-commands.ts
+++ b/src/service/cognito/command/sim-cognito-commands.ts
@@ -3,6 +3,7 @@ import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-
 import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimCognitoUserPoolClientFactory } from "../user-pool/client/sim-cognito-user-pool-client-factory.js";
 import { SimCognitoGroupFactory } from "../user-pool/group/sim-cognito-group-factory.js";
+import { SimCognitoRegistrations } from "../user-pool/sim-cognito-registrations.js";
 import { SimCognitoUserPoolFactory } from "../user-pool/sim-cognito-user-pool-factory.js";
 import type { SimCognitoUserPoolStore } from "../user-pool/sim-cognito-user-pool-store.js";
 import { SimCognitoPoolMessenger } from "../user-pool/message/sim-cognito-pool-messenger.js";
@@ -70,6 +71,12 @@ export class SimCognitoCommands {
   public readonly identityProviders: SimCognitoIdentityProviderCommands;
   public readonly hosted: SimCognitoHostedCommands;
 
+  /**
+   * The pools and app clients this simulation is told already exist, which no
+   * AWS operation creates.
+   */
+  public readonly registrations: SimCognitoRegistrations;
+
   constructor(properties: SimCognitoCommandsProperties) {
     const { accountRegionScope, iam, clock, pools, domains, triggerFunctions } =
       properties;
@@ -92,21 +99,32 @@ export class SimCognitoCommands {
     // the access token is what says which pool the request is for.
     const tokenUser = new SimCognitoTokenUser({ pools, clock });
 
+    // One factory each serves the create commands and the registrations, so a
+    // pool the simulation is told about is built the same way as one it made.
+    const poolFactory = new SimCognitoUserPoolFactory({
+      accountRegionScope,
+      pools,
+      clock,
+    });
+    const clientFactory = new SimCognitoUserPoolClientFactory({ clock });
+
     this.userPools = new SimCognitoUserPoolCommands({
       pools,
-      poolFactory: new SimCognitoUserPoolFactory({
-        accountRegionScope,
-        pools,
-        clock,
-      }),
+      poolFactory,
       authorizer,
     });
     this.userPoolMfa = new SimCognitoUserPoolMfaCommands({ pools, authorizer });
     this.listUserPools = new SimCognitoListUserPools({ pools, authorizer });
     this.clients = new SimCognitoUserPoolClientCommands({
       pools,
-      clientFactory: new SimCognitoUserPoolClientFactory({ clock }),
+      clientFactory,
       authorizer,
+    });
+    this.registrations = new SimCognitoRegistrations({
+      regionName: accountRegionScope.regionName,
+      pools,
+      poolFactory,
+      clientFactory,
     });
     this.listClients = new SimCognitoListUserPoolClients({ pools, authorizer });
     this.users = new SimCognitoUserCommands({

--- a/src/service/cognito/error/sim-cognito.error.ts
+++ b/src/service/cognito/error/sim-cognito.error.ts
@@ -234,3 +234,33 @@ export class SimCognitoPasswordResetRequiredException extends SimCognitoError {
     super(message, { httpStatusCode: 400 });
   }
 }
+
+/**
+ * A user pool registered under an id something else already holds.
+ *
+ * Real Cognito allocates a pool id and has no error for a duplicate, so this
+ * one belongs to the simulator's own registration and never reaches an SDK
+ * caller.
+ */
+export class SimCognitoUserPoolAlreadyExists extends SimCognitoError {
+  public override readonly name = "UserPoolAlreadyExists";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 409 });
+  }
+}
+
+/**
+ * An app client registered under an id another pool in this simulated Cognito
+ * already holds.
+ *
+ * A client id is what `InitiateAuth` finds a pool from, and it names no pool
+ * itself, so two pools sharing one would make that lookup ambiguous.
+ */
+export class SimCognitoUserPoolClientAlreadyExists extends SimCognitoError {
+  public override readonly name = "UserPoolClientAlreadyExists";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 409 });
+  }
+}

--- a/src/service/cognito/index.ts
+++ b/src/service/cognito/index.ts
@@ -3,6 +3,10 @@ export {
   type SimCognitoIdentityProviderRequestOptions,
 } from "./sim-cognito-identity-provider.js";
 export { SimCognitoUserPool } from "./user-pool/sim-cognito-user-pool.js";
+export type {
+  SimCognitoUserPoolClientRegistration,
+  SimCognitoUserPoolRegistration,
+} from "./user-pool/sim-cognito-registration.types.js";
 export {
   SimCognitoUserPoolArn,
   cognitoUserPoolArnPrefix,
@@ -155,4 +159,6 @@ export {
   SimCognitoUsernameExistsException,
   SimCognitoUserNotConfirmedException,
   SimCognitoUserNotFoundException,
+  SimCognitoUserPoolAlreadyExists,
+  SimCognitoUserPoolClientAlreadyExists,
 } from "./error/sim-cognito.error.js";

--- a/src/service/cognito/sim-cognito-identity-provider.ts
+++ b/src/service/cognito/sim-cognito-identity-provider.ts
@@ -17,7 +17,12 @@ import { SimCognitoUserPoolRegistry } from "./registry/sim-cognito-user-pool-reg
 import { SimCognitoSdkCommandRouter } from "./sdk/sim-cognito-sdk-command-router.js";
 import { SimCognitoAppClients } from "./sim-cognito-app-clients.js";
 import type { SimCognitoIdentityProviderRequestOptions } from "./sim-cognito-user-directory.js";
+import type { SimCognitoUserPoolClient } from "./user-pool/client/sim-cognito-user-pool-client.js";
 import type { SimCognitoUserPoolDomain } from "./user-pool/domain/sim-cognito-user-pool-domain.js";
+import type {
+  SimCognitoUserPoolClientRegistration,
+  SimCognitoUserPoolRegistration,
+} from "./user-pool/sim-cognito-registration.types.js";
 
 import type { SimCognitoUserPool } from "./user-pool/sim-cognito-user-pool.js";
 import {
@@ -159,6 +164,38 @@ export class SimCognitoIdentityProvider extends SimCognitoAppClients {
    */
   userPool(userPoolId: string): SimCognitoUserPool {
     return this.pools.require(requireSimCognitoUserPoolId(userPoolId));
+  }
+
+  /**
+   * Register a user pool the simulation is told already exists, under a chosen
+   * pool id.
+   *
+   * `CreateUserPool` allocates its own id, as real Cognito does, and takes
+   * none from you. This is for the pool something else already decided the id
+   * of, such as one a CDK app creates in another stack and names in this one
+   * as a literal string.
+   *
+   * The pool is the same thing a creation would have made. Its ARN, issuer
+   * URL, `iss` claim and `ProviderName` all follow from the id, and it is in
+   * the registry that serves its JWKS and OpenID configuration.
+   */
+  registerUserPool(
+    registration: SimCognitoUserPoolRegistration,
+  ): SimCognitoUserPool {
+    return this.commands.registrations.userPool(registration);
+  }
+
+  /**
+   * Register an app client of a pool, under a chosen client id.
+   *
+   * The pool is named by id and has to exist, whether it was registered or
+   * created. A client id is pinned alongside the pool id it belongs to, which
+   * is why this is here as well as `registerUserPool`.
+   */
+  registerUserPoolClient(
+    registration: SimCognitoUserPoolClientRegistration,
+  ): SimCognitoUserPoolClient {
+    return this.commands.registrations.userPoolClient(registration);
   }
 
   /**

--- a/src/service/cognito/user-pool/client/sim-cognito-user-pool-client-factory.ts
+++ b/src/service/cognito/user-pool/client/sim-cognito-user-pool-client-factory.ts
@@ -2,7 +2,10 @@ import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import type { SimCognitoUserPool } from "../sim-cognito-user-pool.js";
 import { makeSimCognitoClientSecret } from "./sim-cognito-client-secret.js";
 import { SimCognitoUserPoolClient } from "./sim-cognito-user-pool-client.js";
-import { makeSimCognitoUserPoolClientId } from "./sim-cognito-user-pool-client-id.js";
+import {
+  makeSimCognitoUserPoolClientId,
+  type SimCognitoUserPoolClientId,
+} from "./sim-cognito-user-pool-client-id.js";
 import type { SimCognitoUserPoolClientSettings } from "./sim-cognito-user-pool-client-settings.js";
 
 interface SimCognitoUserPoolClientFactoryProperties {
@@ -13,6 +16,15 @@ interface SimCognitoMakeUserPoolClientProperties {
   readonly pool: SimCognitoUserPool;
   readonly generateSecret?: boolean | undefined;
   readonly settings: SimCognitoUserPoolClientSettings;
+
+  /**
+   * The id the client takes, where something else already decided it.
+   *
+   * `CreateUserPoolClient` leaves this out and gets an allocated id, as real
+   * Cognito allocates one. A registration passes the id it was given, having
+   * checked that no pool in this simulated Cognito holds it.
+   */
+  readonly id?: SimCognitoUserPoolClientId | undefined;
 }
 
 /**
@@ -38,7 +50,7 @@ export class SimCognitoUserPoolClientFactory {
     const { pool } = properties;
 
     return new SimCognitoUserPoolClient({
-      id: makeSimCognitoUserPoolClientId(pool.clientIds),
+      id: properties.id ?? makeSimCognitoUserPoolClientId(pool.clientIds),
       userPoolId: pool.id,
       secret: this.secretFor(properties.generateSecret),
       settings: properties.settings,

--- a/src/service/cognito/user-pool/register-sim-cognito-user-pool-client.ts
+++ b/src/service/cognito/user-pool/register-sim-cognito-user-pool-client.ts
@@ -1,0 +1,56 @@
+import { SimCognitoUserPoolClientAlreadyExists } from "../error/sim-cognito.error.js";
+import type { SimCognitoUserPoolClientFactory } from "./client/sim-cognito-user-pool-client-factory.js";
+import { requireSimCognitoUserPoolClientId } from "./client/sim-cognito-user-pool-client-id.js";
+import { SimCognitoUserPoolClientSettings } from "./client/sim-cognito-user-pool-client-settings.js";
+import type { SimCognitoUserPoolClient } from "./client/sim-cognito-user-pool-client.js";
+import type { SimCognitoUserPoolClientRegistration } from "./sim-cognito-registration.types.js";
+import { requireSimCognitoUserPoolId } from "./sim-cognito-user-pool-id.js";
+import type { SimCognitoUserPoolStore } from "./sim-cognito-user-pool-store.js";
+
+interface RegisterSimCognitoUserPoolClientProperties {
+  readonly pools: SimCognitoUserPoolStore;
+  readonly clientFactory: SimCognitoUserPoolClientFactory;
+}
+
+/**
+ * Register an app client of a pool under a chosen client id.
+ *
+ * A client id is pinned alongside the pool id it belongs to, and real Cognito
+ * allocates it the same way, so the two are registered the same way too.
+ *
+ * The pool has to be there already, whether it was registered or created. A
+ * client belongs to a pool, and `CreateUserPoolClient` refuses an unknown pool
+ * the same way. The id has to be free across every pool in this simulated
+ * Cognito, because `InitiateAuth` finds a pool from a client id alone.
+ */
+export function registerSimCognitoUserPoolClient(
+  registration: SimCognitoUserPoolClientRegistration,
+  properties: RegisterSimCognitoUserPoolClientProperties,
+): SimCognitoUserPoolClient {
+  const { pools } = properties;
+  const pool = pools.require(
+    requireSimCognitoUserPoolId(registration.userPoolId),
+  );
+  const clientId = requireSimCognitoUserPoolClientId(registration.id);
+  const holder = pools.findClient(clientId);
+
+  if (holder !== undefined) {
+    throw new SimCognitoUserPoolClientAlreadyExists(
+      `A sim Cognito app client with id ${clientId} is in pool ${holder.pool.id}`,
+    );
+  }
+
+  const client = properties.clientFactory.make({
+    id: clientId,
+    pool,
+    generateSecret: registration.generateSecret,
+    settings: new SimCognitoUserPoolClientSettings({
+      ...registration.settings,
+      ClientName: registration.name,
+    }),
+  });
+
+  pool.addClient(client);
+
+  return client;
+}

--- a/src/service/cognito/user-pool/register-sim-cognito-user-pool.ts
+++ b/src/service/cognito/user-pool/register-sim-cognito-user-pool.ts
@@ -1,0 +1,52 @@
+import { SimCognitoUserPoolAlreadyExists } from "../error/sim-cognito.error.js";
+import type { SimCognitoUserPoolRegistration } from "./sim-cognito-registration.types.js";
+import type { SimCognitoUserPool } from "./sim-cognito-user-pool.js";
+import type { SimCognitoUserPoolFactory } from "./sim-cognito-user-pool-factory.js";
+import { requireSimCognitoUserPoolIdInRegion } from "./sim-cognito-user-pool-id.js";
+import type { SimCognitoUserPoolStore } from "./sim-cognito-user-pool-store.js";
+
+interface RegisterSimCognitoUserPoolProperties {
+  readonly regionName: string;
+  readonly pools: SimCognitoUserPoolStore;
+  readonly poolFactory: SimCognitoUserPoolFactory;
+}
+
+/**
+ * Register a user pool the simulation is told already exists.
+ *
+ * Real Cognito allocates a pool id, so nothing on the command surface takes
+ * one. A CDK app that creates its pool in one stack and reads it from another
+ * carries the id across as a literal string, and every template naming it
+ * deploys against an id the simulation never chose. This is how a simulation
+ * comes to own that id before the template deploys.
+ *
+ * The pool goes through the same factory a created one does, so it gets the
+ * same ARN, the same settings defaults, and the same place in the cross-Account
+ * registry that serves its JWKS.
+ */
+export function registerSimCognitoUserPool(
+  registration: SimCognitoUserPoolRegistration,
+  properties: RegisterSimCognitoUserPoolProperties,
+): SimCognitoUserPool {
+  const { pools } = properties;
+  const userPoolId = requireSimCognitoUserPoolIdInRegion(
+    registration.id,
+    properties.regionName,
+  );
+
+  if (pools.ids.has(userPoolId)) {
+    throw new SimCognitoUserPoolAlreadyExists(
+      `A sim Cognito user pool with id ${userPoolId} already exists`,
+    );
+  }
+
+  const pool = properties.poolFactory.make({
+    id: userPoolId,
+    name: registration.name,
+    settings: registration.settings ?? {},
+  });
+
+  pools.add(pool);
+
+  return pool;
+}

--- a/src/service/cognito/user-pool/sim-cognito-registration.types.ts
+++ b/src/service/cognito/user-pool/sim-cognito-registration.types.ts
@@ -1,0 +1,49 @@
+import type { SimCognitoUserPoolClientSettingsProperties } from "./client/sim-cognito-user-pool-client-settings.js";
+import type { SimCognitoUserPoolSettingsInput } from "./sim-cognito-user-pool-settings.js";
+
+/**
+ * What a simulation says about a user pool it registers as already existing.
+ */
+export interface SimCognitoUserPoolRegistration {
+  /**
+   * The pool id the simulated pool takes, in the `<region>_<characters>` form
+   * real Cognito allocates. The Region it names has to be the Region of the
+   * simulated Cognito registering it.
+   */
+  readonly id: string;
+
+  readonly name: string;
+
+  /**
+   * The rest of the pool's configuration, in the shape `CreateUserPool` sends
+   * it. A registration that leaves it out gets the same defaults a creation
+   * would have given the pool.
+   */
+  readonly settings?: SimCognitoUserPoolSettingsInput | undefined;
+}
+
+/**
+ * What a simulation says about an app client it registers as already existing.
+ */
+export interface SimCognitoUserPoolClientRegistration {
+  readonly userPoolId: string;
+
+  /**
+   * The client id the simulated app client takes, as real Cognito allocates
+   * one.
+   */
+  readonly id: string;
+
+  readonly name: string;
+
+  readonly generateSecret?: boolean | undefined;
+
+  /**
+   * The rest of the client's configuration, in the shape
+   * `CreateUserPoolClient` sends it. `ClientName` is left out of it, `name`
+   * carrying that.
+   */
+  readonly settings?:
+    | Omit<SimCognitoUserPoolClientSettingsProperties, "ClientName">
+    | undefined;
+}

--- a/src/service/cognito/user-pool/sim-cognito-registrations.iso.test.ts
+++ b/src/service/cognito/user-pool/sim-cognito-registrations.iso.test.ts
@@ -1,0 +1,390 @@
+import {
+  AdminCreateUserCommand,
+  AdminSetUserPasswordCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  DescribeUserPoolClientCommand,
+  DescribeUserPoolCommand,
+  InitiateAuthCommand,
+  ListUserPoolsCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertObjectEquals,
+  assertObjectMatches,
+  assertStringIncludes,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import {
+  SimCognitoInvalidParameterException,
+  SimCognitoResourceNotFoundException,
+  SimCognitoUserPoolAlreadyExists,
+  SimCognitoUserPoolClientAlreadyExists,
+} from "../error/sim-cognito.error.js";
+
+// The ids a CDK app pins as literal strings, because the stack that creates the
+// pool is not the stack that names it.
+const pinnedUserPoolId = "eu-west-2_aBcDeFgHi";
+const pinnedClientId = "examplewebclient0000000000";
+
+const accountId = "111111111111";
+const regionName = "eu-west-2";
+
+/**
+ * A simulated Cognito in the Region the pinned pool id names.
+ */
+function simCognito(): SimAws {
+  return new SimAws({
+    defaultAccountId: accountId,
+    defaultRegionName: regionName,
+  });
+}
+
+describe("Registering a simulated Cognito user pool", () => {
+  it("answers DescribeUserPool under the registered pool id", async () => {
+    // Given a simulated Cognito.
+    const simAws = simCognito();
+    const cognito = simAws.cognitoIdentityProvider();
+
+    // When a user pool is registered with a chosen id.
+    cognito.registerUserPool({
+      id: pinnedUserPoolId,
+      name: "myapp-users",
+      settings: { DeletionProtection: "ACTIVE" },
+    });
+
+    // Then it is described under that id, with the settings it was registered
+    // with.
+    const described = await cognito.describeUserPool(
+      new DescribeUserPoolCommand({ UserPoolId: pinnedUserPoolId }),
+    );
+
+    assertObjectMatches(described.UserPool, {
+      Id: pinnedUserPoolId,
+      Name: "myapp-users",
+      DeletionProtection: "ACTIVE",
+    });
+  });
+
+  it("gives the pool the ARN, issuer URL and provider name its id implies", () => {
+    // Given a simulated Cognito.
+    const simAws = simCognito();
+    const cognito = simAws.cognitoIdentityProvider();
+
+    // When a pool is registered.
+    const pool = cognito.registerUserPool({
+      id: pinnedUserPoolId,
+      name: "myapp-users",
+    });
+
+    // Then everything a policy or a token verifier is written against follows
+    // from the id it was registered under.
+    assertIdentical(
+      pool.arn.value,
+      `arn:aws:cognito-idp:${regionName}:${accountId}:userpool/${pinnedUserPoolId}`,
+    );
+    assertIdentical(
+      pool.issuerUrl,
+      `https://cognito-idp.${regionName}.amazonaws.com/${pinnedUserPoolId}`,
+    );
+    assertIdentical(
+      pool.providerName,
+      `cognito-idp.${regionName}.amazonaws.com/${pinnedUserPoolId}`,
+    );
+
+    // And the pool is in the registry the served JWKS and OpenID documents are
+    // resolved through, as a created pool is.
+    const registered = cognito.findUserPoolInAnyAccount(pinnedUserPoolId);
+    assertNonNullable(registered, "Registered pool in the simulation registry");
+    assertObjectEquals(registered.jwks(), pool.jwks());
+  });
+
+  it("lists the registered pool like any other", async () => {
+    // Given a simulated Cognito.
+    const simAws = simCognito();
+    const cognito = simAws.cognitoIdentityProvider();
+
+    // When a pool is registered.
+    cognito.registerUserPool({ id: pinnedUserPoolId, name: "myapp-users" });
+
+    // Then ListUserPools answers with it.
+    const listed = await cognito.listUserPools(
+      new ListUserPoolsCommand({ MaxResults: 10 }),
+    );
+
+    assertArrayLength(listed.UserPools, 1);
+    assertObjectMatches(listed.UserPools[0], {
+      Id: pinnedUserPoolId,
+      Name: "myapp-users",
+    });
+  });
+
+  it("signs a user in through an app client registered under a chosen id", async () => {
+    // Given a registered pool holding a user with a password.
+    const simAws = simCognito();
+    const cognito = simAws.cognitoIdentityProvider();
+
+    cognito.registerUserPool({ id: pinnedUserPoolId, name: "myapp-users" });
+    cognito.registerUserPoolClient({
+      userPoolId: pinnedUserPoolId,
+      id: pinnedClientId,
+      name: "web",
+      settings: { ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH"] },
+    });
+
+    await cognito.adminCreateUser(
+      new AdminCreateUserCommand({
+        UserPoolId: pinnedUserPoolId,
+        Username: "alice",
+      }),
+    );
+    await cognito.adminSetUserPassword(
+      new AdminSetUserPasswordCommand({
+        UserPoolId: pinnedUserPoolId,
+        Username: "alice",
+        Password: "Sup3rSecret!",
+        Permanent: true,
+      }),
+    );
+
+    // When the user signs in, naming the pinned client id and no pool at all.
+    const signedIn = await cognito.initiateAuth(
+      new InitiateAuthCommand({
+        ClientId: pinnedClientId,
+        AuthFlow: "USER_PASSWORD_AUTH",
+        AuthParameters: { USERNAME: "alice", PASSWORD: "Sup3rSecret!" },
+      }),
+    );
+
+    // Then the client id alone found the pool, and its token names the pool as
+    // its issuer.
+    const accessToken = signedIn.AuthenticationResult?.AccessToken;
+    assertNonNullable(accessToken, "Access token from the registered client");
+
+    const payload = String(accessToken.split(".", 2)[1]);
+    const claims = JSON.parse(Buffer.from(payload, "base64url").toString()) as {
+      iss: string;
+      client_id: string;
+    };
+
+    assertIdentical(
+      claims.iss,
+      `https://cognito-idp.${regionName}.amazonaws.com/${pinnedUserPoolId}`,
+    );
+    assertIdentical(claims.client_id, pinnedClientId);
+  });
+
+  it("describes the registered app client under the pool it was registered in", async () => {
+    // Given a registered pool and app client.
+    const simAws = simCognito();
+    const cognito = simAws.cognitoIdentityProvider();
+
+    cognito.registerUserPool({ id: pinnedUserPoolId, name: "myapp-users" });
+    cognito.registerUserPoolClient({
+      userPoolId: pinnedUserPoolId,
+      id: pinnedClientId,
+      name: "web",
+      generateSecret: true,
+      settings: {
+        AllowedOAuthFlowsUserPoolClient: true,
+        AllowedOAuthFlows: ["code"],
+        AllowedOAuthScopes: ["openid"],
+        CallbackURLs: ["https://app.example.test/signed-in"],
+      },
+    });
+
+    // When the client is described.
+    const described = await cognito.describeUserPoolClient(
+      new DescribeUserPoolClientCommand({
+        UserPoolId: pinnedUserPoolId,
+        ClientId: pinnedClientId,
+      }),
+    );
+
+    // Then it holds the id and the settings it was registered with, and the
+    // secret it asked for.
+    assertObjectMatches(described.UserPoolClient, {
+      UserPoolId: pinnedUserPoolId,
+      ClientId: pinnedClientId,
+      ClientName: "web",
+      CallbackURLs: ["https://app.example.test/signed-in"],
+    });
+    assertNonNullable(
+      described.UserPoolClient.ClientSecret,
+      "Registered client secret",
+    );
+  });
+
+  it("refuses a pool id another registered pool holds", () => {
+    // Given a registered pool.
+    const simAws = simCognito();
+    const cognito = simAws.cognitoIdentityProvider();
+
+    cognito.registerUserPool({ id: pinnedUserPoolId, name: "myapp-users" });
+
+    // When the same id is registered again.
+    const error = assertThrowsError(() => {
+      cognito.registerUserPool({ id: pinnedUserPoolId, name: "other-users" });
+    });
+
+    // Then the taken id is refused.
+    assertInstanceOf(error, SimCognitoUserPoolAlreadyExists);
+    assertStringIncludes(error.message, pinnedUserPoolId);
+  });
+
+  it("refuses a pool id a created pool already allocated", async () => {
+    // Given a pool created through the Cognito API.
+    const simAws = simCognito();
+    const cognito = simAws.cognitoIdentityProvider();
+
+    const created = await cognito.createUserPool(
+      new CreateUserPoolCommand({ PoolName: "created-users" }),
+    );
+    const createdUserPoolId = created.UserPool?.Id;
+    assertNonNullable(createdUserPoolId, "Created pool id");
+
+    // When its allocated id is registered.
+    const error = assertThrowsError(() => {
+      cognito.registerUserPool({
+        id: createdUserPoolId,
+        name: "registered-users",
+      });
+    });
+
+    // Then the taken id is refused.
+    assertInstanceOf(error, SimCognitoUserPoolAlreadyExists);
+    assertStringIncludes(error.message, createdUserPoolId);
+  });
+
+  it("refuses a pool id naming another Region", () => {
+    // Given a simulated Cognito in eu-west-2.
+    const simAws = simCognito();
+    const cognito = simAws.cognitoIdentityProvider();
+
+    // When a pool id from another Region is registered.
+    const error = assertThrowsError(() => {
+      cognito.registerUserPool({
+        id: "us-east-1_aBcDeFgHi",
+        name: "myapp-users",
+      });
+    });
+
+    // Then it is refused, and the message says which Region to register it on.
+    // A pool whose ARN and issuer URL named different Regions is one no real
+    // pool matches.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "us-east-1");
+    assertStringIncludes(error.message, regionName);
+  });
+
+  it("refuses a value that is no pool id at all", () => {
+    // Given a simulated Cognito.
+    const simAws = simCognito();
+    const cognito = simAws.cognitoIdentityProvider();
+
+    // When a malformed id is registered.
+    const error = assertThrowsError(() => {
+      cognito.registerUserPool({ id: "not-a-pool-id", name: "myapp-users" });
+    });
+
+    // Then it is refused as a bad parameter, as a request naming it would be.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "not-a-pool-id");
+  });
+
+  it("refuses a client id another pool in the simulation holds", () => {
+    // Given a registered pool holding an app client.
+    const simAws = simCognito();
+    const cognito = simAws.cognitoIdentityProvider();
+
+    cognito.registerUserPool({ id: pinnedUserPoolId, name: "myapp-users" });
+    cognito.registerUserPoolClient({
+      userPoolId: pinnedUserPoolId,
+      id: pinnedClientId,
+      name: "web",
+    });
+
+    // When the same client id is registered in a second pool.
+    cognito.registerUserPool({
+      id: "eu-west-2_jKlMnOpQr",
+      name: "other-users",
+    });
+
+    const error = assertThrowsError(() => {
+      cognito.registerUserPoolClient({
+        userPoolId: "eu-west-2_jKlMnOpQr",
+        id: pinnedClientId,
+        name: "other-web",
+      });
+    });
+
+    // Then it is refused. A client id is what InitiateAuth finds a pool from,
+    // and two pools sharing one would make that lookup ambiguous.
+    assertInstanceOf(error, SimCognitoUserPoolClientAlreadyExists);
+    assertStringIncludes(error.message, pinnedUserPoolId);
+  });
+
+  it("refuses an app client for a pool that is not there", () => {
+    // Given a simulated Cognito with no pools.
+    const simAws = simCognito();
+    const cognito = simAws.cognitoIdentityProvider();
+
+    // When a client is registered for an unknown pool.
+    const error = assertThrowsError(() => {
+      cognito.registerUserPoolClient({
+        userPoolId: pinnedUserPoolId,
+        id: pinnedClientId,
+        name: "web",
+      });
+    });
+
+    // Then the missing pool is refused, as CreateUserPoolClient refuses one.
+    assertInstanceOf(error, SimCognitoResourceNotFoundException);
+    assertStringIncludes(error.message, pinnedUserPoolId);
+  });
+
+  it("still allocates its own ids for a created pool and client", async () => {
+    // Given a simulated Cognito holding a registered pool and client.
+    const simAws = simCognito();
+    const cognito = simAws.cognitoIdentityProvider();
+
+    cognito.registerUserPool({ id: pinnedUserPoolId, name: "myapp-users" });
+    cognito.registerUserPoolClient({
+      userPoolId: pinnedUserPoolId,
+      id: pinnedClientId,
+      name: "web",
+    });
+
+    // When a pool and a client are created through the API.
+    const createdPool = await cognito.createUserPool(
+      new CreateUserPoolCommand({ PoolName: "created-users" }),
+    );
+    const createdUserPoolId = createdPool.UserPool?.Id;
+    assertNonNullable(createdUserPoolId, "Created pool id");
+
+    const createdClient = await cognito.createUserPoolClient(
+      new CreateUserPoolClientCommand({
+        UserPoolId: createdUserPoolId,
+        ClientName: "created-web",
+      }),
+    );
+
+    // Then both took ids of the simulation's own choosing, neither command
+    // having an input to ask for one.
+    assertFalse(
+      createdUserPoolId === pinnedUserPoolId,
+      "A created pool takes an allocated id",
+    );
+    assertFalse(
+      createdClient.UserPoolClient?.ClientId === pinnedClientId,
+      "A created app client takes an allocated id",
+    );
+  });
+});

--- a/src/service/cognito/user-pool/sim-cognito-registrations.ts
+++ b/src/service/cognito/user-pool/sim-cognito-registrations.ts
@@ -1,0 +1,47 @@
+import { registerSimCognitoUserPoolClient } from "./register-sim-cognito-user-pool-client.js";
+import { registerSimCognitoUserPool } from "./register-sim-cognito-user-pool.js";
+import type { SimCognitoUserPoolClientFactory } from "./client/sim-cognito-user-pool-client-factory.js";
+import type { SimCognitoUserPoolClient } from "./client/sim-cognito-user-pool-client.js";
+import type {
+  SimCognitoUserPoolClientRegistration,
+  SimCognitoUserPoolRegistration,
+} from "./sim-cognito-registration.types.js";
+import type { SimCognitoUserPool } from "./sim-cognito-user-pool.js";
+import type { SimCognitoUserPoolFactory } from "./sim-cognito-user-pool-factory.js";
+import type { SimCognitoUserPoolStore } from "./sim-cognito-user-pool-store.js";
+
+interface SimCognitoRegistrationsProperties {
+  /** The Region a pool registered here has to name in its id. */
+  readonly regionName: string;
+
+  readonly pools: SimCognitoUserPoolStore;
+  readonly poolFactory: SimCognitoUserPoolFactory;
+  readonly clientFactory: SimCognitoUserPoolClientFactory;
+}
+
+/**
+ * The user pools and app clients a simulation is told already exist.
+ *
+ * These are the simulator's own setup operations rather than AWS ones, so they
+ * skip the command surface and its authorization, as `mountBucketFilesystem`
+ * and `registerHostedZone` do.
+ */
+export class SimCognitoRegistrations {
+  constructor(private readonly properties: SimCognitoRegistrationsProperties) {}
+
+  /**
+   * Register a user pool under a chosen pool id.
+   */
+  userPool(registration: SimCognitoUserPoolRegistration): SimCognitoUserPool {
+    return registerSimCognitoUserPool(registration, this.properties);
+  }
+
+  /**
+   * Register an app client of a pool under a chosen client id.
+   */
+  userPoolClient(
+    registration: SimCognitoUserPoolClientRegistration,
+  ): SimCognitoUserPoolClient {
+    return registerSimCognitoUserPoolClient(registration, this.properties);
+  }
+}

--- a/src/service/cognito/user-pool/sim-cognito-user-pool-factory.ts
+++ b/src/service/cognito/user-pool/sim-cognito-user-pool-factory.ts
@@ -3,7 +3,10 @@ import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-
 import { SimCognitoName } from "./sim-cognito-name.js";
 import { SimCognitoUserPool } from "./sim-cognito-user-pool.js";
 import { SimCognitoUserPoolArn } from "./sim-cognito-user-pool-arn.js";
-import { makeSimCognitoUserPoolId } from "./sim-cognito-user-pool-id.js";
+import {
+  makeSimCognitoUserPoolId,
+  type SimCognitoUserPoolId,
+} from "./sim-cognito-user-pool-id.js";
 import {
   SimCognitoUserPoolSettings,
   type SimCognitoUserPoolSettingsInput,
@@ -23,6 +26,15 @@ interface SimCognitoMakeUserPoolProperties {
    * The `CreateUserPool` request the pool's settings are read out of.
    */
   readonly settings: SimCognitoUserPoolSettingsInput;
+
+  /**
+   * The id the pool takes, where something else already decided it.
+   *
+   * `CreateUserPool` leaves this out and gets an allocated id, as real Cognito
+   * allocates one. A registration passes the id it was given, having checked
+   * that it is free and that it names this scope's region.
+   */
+  readonly id?: SimCognitoUserPoolId | undefined;
 }
 
 /**
@@ -47,10 +59,12 @@ export class SimCognitoUserPoolFactory {
    * Make a new pool with no app clients yet.
    */
   make(properties: SimCognitoMakeUserPoolProperties): SimCognitoUserPool {
-    const userPoolId = makeSimCognitoUserPoolId(
-      this.accountRegionScope.regionName,
-      this.pools.ids,
-    );
+    const userPoolId =
+      properties.id ??
+      makeSimCognitoUserPoolId(
+        this.accountRegionScope.regionName,
+        this.pools.ids,
+      );
 
     return new SimCognitoUserPool({
       id: userPoolId,

--- a/src/service/cognito/user-pool/sim-cognito-user-pool-id.ts
+++ b/src/service/cognito/user-pool/sim-cognito-user-pool-id.ts
@@ -69,6 +69,32 @@ export function requireSimCognitoUserPoolId(
 }
 
 /**
+ * Read a requested user pool id that has to belong to one Region.
+ *
+ * A pool id carries the Region its pool lives in, and a pool's ARN carries the
+ * Region of the simulated Cognito holding it. Registering a pool under an id
+ * from another Region would name two Regions in one pool, which no real pool
+ * does.
+ */
+export function requireSimCognitoUserPoolIdInRegion(
+  value: string | undefined,
+  regionName: string,
+): SimCognitoUserPoolId {
+  const userPoolId = requireSimCognitoUserPoolId(value);
+  const idRegionName = simCognitoUserPoolRegionName(userPoolId);
+
+  if (idRegionName !== regionName) {
+    throw new SimCognitoInvalidParameterException(
+      `UserPoolId '${userPoolId}' names Region ${idRegionName}, and this ` +
+        `simulated Cognito is ${regionName}. Register the pool on the ` +
+        `simulated Cognito of Region ${idRegionName}.`,
+    );
+  }
+
+  return userPoolId;
+}
+
+/**
  * The Region a pool lives in, which its id names.
  *
  * This is where SDK code and token verifiers get it from too: splitting the id

--- a/src/service/cognito/user-pool/sim-cognito-user-pool-store.ts
+++ b/src/service/cognito/user-pool/sim-cognito-user-pool-store.ts
@@ -140,6 +140,27 @@ export class SimCognitoUserPoolStore {
    * from.
    */
   requireClient(clientId: SimCognitoUserPoolClientId): SimCognitoClientInPool {
+    const found = this.findClient(clientId);
+
+    if (found === undefined) {
+      throw new SimCognitoResourceNotFoundException(
+        `App client ${clientId} does not exist.`,
+      );
+    }
+
+    return found;
+  }
+
+  /**
+   * Find an app client by id alone, and the pool holding it.
+   *
+   * This is the same search `requireClient` makes, for a caller that has
+   * something to do with the absence. Registering a client under a chosen id
+   * uses it to keep one client id out of two pools.
+   */
+  findClient(
+    clientId: SimCognitoUserPoolClientId,
+  ): SimCognitoClientInPool | undefined {
     for (const pool of this.all) {
       const client = pool.findClient(clientId);
 
@@ -148,9 +169,7 @@ export class SimCognitoUserPoolStore {
       }
     }
 
-    throw new SimCognitoResourceNotFoundException(
-      `App client ${clientId} does not exist.`,
-    );
+    return undefined;
   }
 
   /**


### PR DESCRIPTION
Real Cognito allocates a pool id and an app client id, so nothing on the command surface takes either. A CDK app whose pool lives in one stack and whose Lambda function lives in another carries both across as literal strings, and a template naming those literals used to deploy against ids the simulation had chosen for itself. The handler ended up pointed at a pool nothing had, and at a client the pool had never heard of. `registerUserPool` and `registerUserPoolClient` stand both up under the pinned ids first, the way `registerHostedZone` does for a zone a lookup baked into a template, so the template deploys with no rewriting.

Resolves https://github.com/KensioSoftware/yulin/issues/735

Both registrations go through the factories the create commands use, so a registered pool is the same thing a created one is. Its ARN, issuer URL, `iss` claim, `ProviderName` and place in the cross-Account registry that serves the JWKS all follow from the id it was registered under, which is what a template carrying the pool id twice needs: once alone in the function's environment, once as the tail of the pool ARN in the execution role's policy. `CreateUserPool` and `CreateUserPoolClient` still allocate their own ids and take none from the caller.

Registration refuses a pool id another pool holds, a client id another pool in the simulation holds, a value that is no pool or client id, and a pool id naming another Region. The last one keeps a pool from having an ARN and an issuer URL that name different Regions, and its message says which simulated Cognito to register the pool on instead. The client id is checked across every pool in the scope rather than within one, because `InitiateAuth` finds a pool from a client id alone.

The API takes `settings` in the shape `CreateUserPool` and `CreateUserPoolClient` send them, mirroring `registerHostedZone`'s `config`, so a registered client is validated exactly as a created one. `sim-cfn-cognito-registered-pool.iso.test.ts` deploys a template carrying both pinned ids as literals, invokes the bound handler and asserts it reads its app client, then points the role's policy at another pool and asserts the `AccessDenied`. That second case is the failure this feature exists to avoid.

- [x] Conventional commit message, used as the title

- [ ] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`
