### PR TITLE
test: drive sim S3 uploads through lib-storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -204,6 +204,7 @@
     "@aws-sdk/client-ssm": "^3.1101.0",
     "@aws-sdk/client-sts": "^3.1101.0",
     "@aws-sdk/lib-dynamodb": "^3.1101.0",
+    "@aws-sdk/lib-storage": "^3.1112.0",
     "@aws-sdk/s3-request-presigner": "^3.1101.0",
     "@eslint/js": "^10.0.1",
     "@kensio/smartass": "^1.37.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       '@aws-sdk/lib-dynamodb':
         specifier: ^3.1101.0
         version: 3.1108.0(@aws-sdk/client-dynamodb@3.1108.0)
+      '@aws-sdk/lib-storage':
+        specifier: ^3.1112.0
+        version: 3.1112.0(@aws-sdk/client-s3@3.1108.0)
       '@aws-sdk/s3-request-presigner':
         specifier: ^3.1101.0
         version: 3.1108.0
@@ -457,6 +460,12 @@ packages:
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@aws-sdk/client-dynamodb': ^3.1108.0
+
+  '@aws-sdk/lib-storage@3.1112.0':
+    resolution: {integrity: sha512-IjQd2q6fWjBX7Ipzj3h1gRjd5JVFPRAXGWJdxKGGaQ5XX2aks/O2ibfid/cCZ4IHQO/XQ9azWlzuHCPmjARfQQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@aws-sdk/client-s3': ^3.1112.0
 
   '@aws-sdk/middleware-endpoint-discovery@3.972.29':
     resolution: {integrity: sha512-cXW7QNIOhUSfccZmwJEjn9EdCAjzdOtt/+MtO5HWgxIZdhzyC1kNuQKIgGEDkgabxiXymWw0/VFWdqxqeLbgMA==}
@@ -1762,6 +1771,9 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.11.13:
     resolution: {integrity: sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==}
     engines: {node: '>=6.0.0'}
@@ -1788,6 +1800,9 @@ packages:
     resolution: {integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer@5.6.0:
+    resolution: {integrity: sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==}
 
   builtin-modules@5.3.0:
     resolution: {integrity: sha512-hMQUl2bUFG339QygPM97E+mc8OY1IAchORZxm4a/frcYwKzozMzRVDBwHW0NjOqGElLm2O37AVQE8ikxlZHrMQ==}
@@ -2095,6 +2110,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
   execa@10.0.1:
     resolution: {integrity: sha512-ge98qjkRK4IB7tL7Ju/6qmm5LHoH1eEMt5FNZrz3f4UIYhF28lggX20z3FaX1sgc67msLEn0N0BscOs29iuwyw==}
     engines: {node: '>=22'}
@@ -2278,6 +2297,9 @@ packages:
   identifier-regex@1.1.0:
     resolution: {integrity: sha512-SLX4H/vtcYlYnL7XqnuJKHU7Z8517TgsW9nmQiGOgMCjQ8V/deLYu6bEmbGoXe7WMMhc9+EUGyFFneHja8KabA==}
     engines: {node: '>=18'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2979,6 +3001,10 @@ packages:
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
   regexp-tree@0.1.27:
     resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
     hasBin: true
@@ -3092,6 +3118,9 @@ packages:
 
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
+  stream-browserify@3.0.0:
+    resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
 
   stream-combiner2@1.1.1:
     resolution: {integrity: sha512-3PnJbYgS56AeWgtKF5jtJRT6uFJe56Z0Hc5Ngg/6sI6rIt8iiMBTa9cvdyFfpMQjaVHr8dusbNeFGIIonxOvKw==}
@@ -4056,6 +4085,16 @@ snapshots:
       '@aws-sdk/util-dynamodb': 3.996.9(@aws-sdk/client-dynamodb@3.1108.0)
       '@smithy/core': 3.33.2
       '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/lib-storage@3.1112.0(@aws-sdk/client-s3@3.1108.0)':
+    dependencies:
+      '@aws-sdk/client-s3': 3.1108.0
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      buffer: 5.6.0
+      events: 3.3.0
+      stream-browserify: 3.0.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-endpoint-discovery@3.972.29':
@@ -5176,6 +5215,8 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.11.13: {}
 
   before-after-hook@4.0.0: {}
@@ -5199,6 +5240,11 @@ snapshots:
       electron-to-chromium: 1.5.405
       node-releases: 2.0.53
       update-browserslist-db: 1.3.1(browserslist@4.28.8)
+
+  buffer@5.6.0:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   builtin-modules@5.3.0: {}
 
@@ -5552,6 +5598,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  events@3.3.0: {}
+
   execa@10.0.1:
     dependencies:
       '@sindresorhus/merge-streams': 4.0.0
@@ -5746,6 +5794,8 @@ snapshots:
   identifier-regex@1.1.0:
     dependencies:
       reserved-identifiers: 1.2.0
+
+  ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
 
@@ -6322,6 +6372,12 @@ snapshots:
       string_decoder: 1.1.1
       util-deprecate: 1.0.2
 
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
   regexp-tree@0.1.27: {}
 
   registry-auth-token@5.1.1:
@@ -6467,6 +6523,11 @@ snapshots:
   stackback@0.0.2: {}
 
   std-env@4.2.0: {}
+
+  stream-browserify@3.0.0:
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   stream-combiner2@1.1.1:
     dependencies:

--- a/src/service/s3/command/multipart/sim-s3-upload-helper.iso.test.ts
+++ b/src/service/s3/command/multipart/sim-s3-upload-helper.iso.test.ts
@@ -1,0 +1,190 @@
+import { createHash } from "node:crypto";
+import { Readable } from "node:stream";
+
+import {
+  CreateBucketCommand,
+  GetObjectCommand,
+  ListMultipartUploadsCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { Upload } from "@aws-sdk/lib-storage";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertStringEndsWith,
+  assertStringNotIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import {
+  simS3MultipartETag,
+  simS3ObjectETag,
+  simS3QuotedETag,
+} from "../../object/s3-object-etag.js";
+import { SimSdk } from "../../../../sdk/index.js";
+import { simS3BodyToBuffer } from "../../storage/s3-body-buffer.js";
+
+/**
+ * Uploading through `@aws-sdk/lib-storage`, which is what production code does.
+ *
+ * The individual multipart operations are covered by their own tests, and this
+ * one exists because passing those does not prove this works. `Upload` decides
+ * on its own which path to take, and it takes the single-part one below its
+ * part size: a test fixture of a few bytes therefore exercises PutObject and
+ * says nothing about the code path a real file goes down. Both paths are driven
+ * here from bodies sized either side of that threshold, so a change that breaks
+ * either one fails here rather than in a caller's production upload.
+ */
+describe("Simulated S3 upload through lib-storage", () => {
+  // What `Upload` splits a body at unless it is told otherwise, and the
+  // smallest part size S3 accepts, so a test cannot shrink it to save memory.
+  const partSize = 5 * 1024 * 1024;
+
+  const interceptedClient = async (
+    simSdk: SimSdk,
+    bucketName: string,
+  ): Promise<S3Client> => {
+    const client = new S3Client({ region: "us-east-1" });
+    simSdk.intercept(client);
+    await client.send(new CreateBucketCommand({ Bucket: bucketName }));
+
+    return client;
+  };
+
+  // The stored bytes as a length and a digest rather than the bytes
+  // themselves. A body of this size is compared this way because a failed
+  // comparison of two multi-megabyte Buffers leaves the test runner building a
+  // diff it cannot finish, which costs a suite run rather than a test.
+  const storedDigest = async (
+    client: S3Client,
+    bucketName: string,
+    key: string,
+  ): Promise<string> => {
+    const read = await client.send(
+      new GetObjectCommand({ Bucket: bucketName, Key: key }),
+    );
+    assertDefined(read.Body, "the read Object body");
+    const body = await simS3BodyToBuffer(read.Body as Readable);
+
+    return `${body.length} bytes, md5 ${simS3ObjectETag(body)}`;
+  };
+
+  const expectedDigest = (body: Buffer): string =>
+    `${body.length} bytes, md5 ${simS3ObjectETag(body)}`;
+
+  it("uploads a body larger than the part size in parts", async () => {
+    // Given a body of three parts' worth, each part filled differently so that
+    // parts joined in the wrong order do not read back as the original bytes.
+    using simSdk = new SimSdk();
+    const client = await interceptedClient(simSdk, "lib-storage");
+    const parts = [
+      Buffer.alloc(partSize, "a"),
+      Buffer.alloc(partSize, "b"),
+      Buffer.alloc(2 * 1024 * 1024, "c"),
+    ];
+    const body = Buffer.concat(parts);
+
+    // When lib-storage uploads it, choosing its own path as production would.
+    const upload = new Upload({
+      client,
+      params: { Bucket: "lib-storage", Key: "big.bin", Body: body },
+    });
+    const completed = await upload.done();
+
+    // Then the Object holds the bytes that went in, in order.
+    assertIdentical(
+      await storedDigest(client, "lib-storage", "big.bin"),
+      expectedDigest(body),
+    );
+
+    // And it carries the multipart ETag over the three parts lib-storage sent,
+    // which is how a caller comparing hashes tells the two forms apart.
+    const expected = simS3QuotedETag(
+      simS3MultipartETag(parts.map((part) => simS3ObjectETag(part))),
+    );
+    assertIdentical(completed.ETag, expected);
+    assertStringEndsWith(expected, '-3"');
+
+    // And nothing is left in progress: the upload was completed, not abandoned
+    // with its parts still holding storage as an interrupted one would.
+    const inProgress = await client.send(
+      new ListMultipartUploadsCommand({ Bucket: "lib-storage" }),
+    );
+    assertArrayLength(inProgress.Uploads ?? [], 0);
+  });
+
+  it("uploads a body smaller than the part size in one request", async () => {
+    // Given a body of the size a test fixture usually is, which lib-storage
+    // sends as a single PutObject rather than starting an upload for.
+    using simSdk = new SimSdk();
+    const client = await interceptedClient(simSdk, "small-uploads");
+    const body = Buffer.from("small enough to go in one request");
+
+    // When lib-storage uploads it.
+    const upload = new Upload({
+      client,
+      params: { Bucket: "small-uploads", Key: "small.txt", Body: body },
+    });
+    const completed = await upload.done();
+
+    // Then the Object is the plain MD5 of its bytes, with no part-count suffix,
+    // which is what says the single-part path was the one taken.
+    assertIdentical(
+      await storedDigest(client, "small-uploads", "small.txt"),
+      expectedDigest(body),
+    );
+    assertIdentical(
+      completed.ETag,
+      simS3QuotedETag(createHash("md5").update(body).digest("hex")),
+    );
+    assertStringNotIncludes(completed.ETag ?? "", "-");
+  });
+
+  it("reports progress across the parts it sends", async () => {
+    // Given an upload of two parts with its progress being watched, as an
+    // upload of a file of real size is.
+    using simSdk = new SimSdk();
+    const client = await interceptedClient(simSdk, "progress");
+    const body = Buffer.alloc(partSize + 1024, "d");
+    const upload = new Upload({
+      client,
+      params: { Bucket: "progress", Key: "watched.bin", Body: body },
+    });
+    const loadedAtEachStep: number[] = [];
+    upload.on("httpUploadProgress", (progress) => {
+      loadedAtEachStep.push(progress.loaded ?? 0);
+    });
+
+    // When it runs to completion.
+    await upload.done();
+
+    // Then progress was reported once per part and reached the whole body, so
+    // a caller driving a progress bar off this sees it finish.
+    assertArrayLength(loadedAtEachStep, 2);
+    assertIdentical(loadedAtEachStep.at(-1), body.length);
+  });
+
+  it("uploads a stream, whose length it cannot know in advance", async () => {
+    // Given a body arriving as a stream, which is how a file being read or a
+    // response being passed straight through reaches an upload. Its length is
+    // not known when the upload starts, so lib-storage reads it part by part.
+    using simSdk = new SimSdk();
+    const client = await interceptedClient(simSdk, "streamed");
+    const parts = [Buffer.alloc(partSize, "f"), Buffer.from("tail")];
+    const body = Readable.from(parts);
+
+    // When lib-storage uploads it.
+    const completed = await new Upload({
+      client,
+      params: { Bucket: "streamed", Key: "streamed.bin", Body: body },
+    }).done();
+
+    // Then the Object holds the whole stream, under a two-part ETag.
+    assertIdentical(
+      await storedDigest(client, "streamed", "streamed.bin"),
+      expectedDigest(Buffer.concat(parts)),
+    );
+    assertStringEndsWith(completed.ETag ?? "", '-2"');
+  });
+});


### PR DESCRIPTION
Brief, concise description of the change:

The multipart operations each have a test of their own, all of them calling the simulator
directly. `@aws-sdk/lib-storage` chooses its own path by body size. A body under the 5MB part size
goes out as a single PutObject. A test fixture of a few bytes therefore exercises a different path
from the one a real file takes, and the documented claim that `Upload` works rested on the command
surface being right. Four cases now drive the real `Upload` through a `SimSdk`-intercepted client,
covering a 12MB buffer under a three-part ETag, a small body under a plain MD5, progress events
across parts, and a stream whose length is unknown when the upload starts.

Two things worth a reviewer's attention. An abort case was written and then dropped. `Upload.done()`
races the upload against an abort listener that rejects straight away, so the promise settles before
lib-storage sends `AbortMultipartUpload`, and the test only passed because the body had already
finished uploading. Asserting on that would have pinned lib-storage's internal timing.
`AbortMultipartUpload` is covered directly in `sim-s3-multipart-upload.iso.test.ts`. Separately, the
large bodies are compared by length and MD5 rather than by Buffer. Mutating the simulator to join
parts in reverse order showed a failed comparison of two 12MB Buffers leaving vitest building a diff
it never finishes, at the cost of a whole suite run. With digests the same mutation fails in 54ms
with a readable message. Both mutations were checked, swapping the multipart ETag for a plain MD5
and reversing part order, and each fails the two multipart cases.

The file is named after the helper rather than the package because oxlint's `unicorn/name-replacements`
rejects `lib` in a filename. `lib-dynamodb` support lives under `document/` for the same reason.

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [ ] User-facing behaviour is documented in `docs/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for simulated S3 uploads using multipart and single-part buffers.
  * Added validation for upload progress, content integrity, ETags, multipart cleanup, and streams with unknown lengths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->