### PR TITLE
feat: deploy a YAML CloudFormation template

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -1085,8 +1085,8 @@ is ready.
 
 ## Deploying synthesized CDK templates
 
-Use `deployTemplateFile(...)` to deploy a JSON template file, including templates produced by CDK
-synthesis.
+Use `deployTemplateFile(...)` to deploy a template file, including the JSON templates CDK synthesis
+produces.
 
 ```typescript sim-cloudformation-cdk-template-file
 /**
@@ -1131,6 +1131,57 @@ create the simulated resources from that synthesized output template.
 A template path with no file at it is refused with
 `No Sim CloudFormation template file at <path>`, naming the resolved path. A synthesized template
 is build output, and a checkout that has yet to synthesize one meets this on the first run.
+
+## Deploying a template written as YAML
+
+CloudFormation takes a template in JSON or in YAML, and a template written by hand is usually YAML.
+`deployTemplateFile(...)` reads a `.yaml` or `.yml` file as YAML.
+
+```yaml
+Resources:
+  WorkQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub "${AWS::StackName}-work"
+Outputs:
+  QueueArn:
+    Value: !GetAtt WorkQueue.Arn
+```
+
+```typescript sim-cloudformation-yaml-template-file
+/**
+ * Deploying a hand-written YAML template file into simulated AWS.
+ */
+
+import path from "node:path";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws
+  .cloudFormation()
+  .deployTemplateFile(
+    path.join(process.cwd(), "infrastructure", "work-stack.yaml"),
+  );
+
+await stack.waitForDeployComplete();
+
+console.log(stack.stackName); // "work-stack"
+```
+
+The Stack name comes from the file name with the extension dropped, the way a synthesized name drops
+`.template.json`.
+
+Short-form tags resolve to what their long forms resolve to. `!GetAtt WorkQueue.Arn` and
+`Fn::GetAtt: [WorkQueue, Arn]` are the same Output. The tags Yulin reads are `!Ref`, `!GetAtt`,
+`!Join`, `!Sub`, `!FindInMap`, `!If`, `!Split`, `!Select`, `!ImportValue`, `!And`, `!Equals`, `!Not`,
+`!Or` and `!Condition`. A tag for an intrinsic Yulin has no behaviour for, such as `!Base64`, fails
+the deployment by name. Nothing deploys holding the bare value the tag was written against.
+
+A file that does not parse is refused by naming the resolved path, along with the line and column the
+parser stopped at. `updateTemplateFile(...)` and watching read the file the same way, and a saved
+YAML template updates its Stack in place.
 
 ## Deploying a whole cloud assembly
 
@@ -2369,7 +2420,8 @@ Sim CloudFormation currently supports:
 - The resource `DeletionPolicy` attribute, for `Retain` and `RetainExceptOnCreate`
 - `deployTemplate(...)` for parsed template objects, optionally naming the synthesized template file
   a template edited in memory came from
-- `deployTemplateFile(...)` for synthesized JSON template files
+- `deployTemplateFile(...)` for template files, written as JSON or as YAML with short-form
+  intrinsic tags
 - `updateTemplateFile(...)` for applying a synthesized template file to the stack it was deployed as
 - Watching a deployed template file, updating its stack in place whenever the file changes
 - Template `Parameters` with supplied values and defaults
@@ -2413,8 +2465,8 @@ Each service's own docs describe what its resource types support.
 
 ## Limitations
 
-- `TemplateBody` must be JSON when using `CreateStackCommand` or `UpdateStackCommand`. YAML parsing
-  is outside the CloudFormation service for now.
+- `TemplateBody` must be JSON when using `CreateStackCommand` or `UpdateStackCommand`. A template
+  file deployed with `deployTemplateFile(...)` may be JSON or YAML.
 - Only supported resource types create simulated service resources. An unsupported resource may be
   skipped or may fail the stack, depending on how safely the simulator can model it. A skipped
   resource answers `Ref` and `Fn::GetAtt` with

--- a/docs/services/cloudformation/sim-cloudformation-yaml-template-file.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-yaml-template-file.example.ts
@@ -1,0 +1,19 @@
+/**
+ * Deploying a hand-written YAML template file into simulated AWS.
+ */
+
+import path from "node:path";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws
+  .cloudFormation()
+  .deployTemplateFile(
+    path.join(process.cwd(), "infrastructure", "work-stack.yaml"),
+  );
+
+await stack.waitForDeployComplete();
+
+console.log(stack.stackName); // "work-stack"

--- a/package.json
+++ b/package.json
@@ -241,7 +241,8 @@
   "dependencies": {
     "@faker-js/faker": "^10.5.0",
     "@kensio/part-factory": "^1.9.0",
-    "lodash-es": "^4.18.1"
+    "lodash-es": "^4.18.1",
+    "yaml": "^2.9.0"
   },
   "peerDependencies": {
     "eslint": "^10.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       lodash-es:
         specifier: ^4.18.1
         version: 4.18.1
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
     devDependencies:
       '@aws-crypto/sha256-js':
         specifier: ^5.2.0

--- a/src/service/cloudformation/README.md
+++ b/src/service/cloudformation/README.md
@@ -148,7 +148,7 @@ or drain broader simulator background tasks when appropriate.
 `SimCloudFormation` also exposes helper methods for tests and local tooling:
 
 - `deployTemplate(...)`, for a parsed template object
-- `deployTemplateFile(...)`, for a synthesized CDK template file
+- `deployTemplateFile(...)`, for a template file, synthesized or written by hand
 - `updateTemplateFile(...)`, for applying such a file to the stack it was deployed as
 
 The first two are wrappers around the same stack creation machinery, and the third around the same
@@ -175,6 +175,16 @@ reading an `AWS::ECS::TaskDefinition`, and no service's schema belongs in the en
 
 The important design point is that these helpers do not bypass stack/resource lifecycle. They feed
 additional context into the normal CloudFormation creation pipeline.
+
+`SimCfnTemplateFileLoader` reads the file, and `parseTemplateFileBody` parses it in the format the
+file name gives it. A `.yaml` or `.yml` file goes to `parseSimCfnTemplateYaml` in `template/yaml/`,
+which parses the document under a tag schema covering CloudFormation's short-form intrinsics.
+`!GetAtt Bucket.Arn` becomes `{ "Fn::GetAtt": "Bucket.Arn" }` before anything downstream sees it.
+The node parser and the rest of the template model read one template shape, whichever format the
+file was written in. A tag outside that schema, such as `!Base64`, fails the parse by name, the way
+the long form of an intrinsic the simulator has no parser for fails the template. Any other file
+name is read as JSON, which is what CDK synthesizes. The Stack name a path is taken from drops
+`.template.json`, `.yaml` and `.yml` alike.
 
 `SimCfnTemplateFileUpdater` is the update half of the same idea. It reads the file with the same
 `SimCfnTemplateFileLoader` a deployment reads it with, and submits an `UpdateStackCommand`, so an
@@ -213,8 +223,9 @@ it would throw away the simulated state that updating in place exists to keep.
 
 `SimCfnTemplate` wraps a parsed CloudFormation template object.
 
-Yulin accepts parsed template objects in helper APIs and JSON strings for `CreateStackCommand`
-`TemplateBody`. It does not implement a YAML parser in the CloudFormation service.
+Yulin accepts parsed template objects in helper APIs, and JSON or YAML template files through
+`deployTemplateFile(...)`. `CreateStackCommand` and `UpdateStackCommand` take a JSON `TemplateBody`
+only.
 
 A valid simulated template must contain a usable `Resources` section. The template may also contain
 `Parameters` and other CloudFormation sections, but only the implemented parts affect deployment.

--- a/src/service/cloudformation/deploy/sim-cfn-template-file-loader-yaml.iso.test.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-template-file-loader-yaml.iso.test.ts
@@ -1,0 +1,95 @@
+/* oxlint-disable no-template-curly-in-string -- Fn::Sub syntax, not JavaScript templates. */
+import path from "node:path";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertObjectMatches,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { TemporaryDirectory } from "../../../util/filesystem/temporary-directory.js";
+import type { SimCloudFormationStackName } from "../stack/sim-cfn-stack.js";
+import { SimCfnTemplateFileLoader } from "./sim-cfn-template-file-loader.js";
+
+describe("SimCfnTemplateFileLoader reading a YAML template file", () => {
+  it("loads a template file written as YAML, resolving its short-form tags", async () => {
+    // Given a hand-written YAML template, as CloudFormation takes one.
+    const temporaryDirectory = new TemporaryDirectory();
+    const templatePath = "WorkStack.yaml";
+
+    await temporaryDirectory.writeFile(
+      templatePath,
+      [
+        "Resources:",
+        "  WorkQueue:",
+        "    Type: AWS::SQS::Queue",
+        "    Properties:",
+        '      QueueName: !Sub "${AWS::StackName}-work"',
+      ].join("\n"),
+    );
+
+    // When the template file is loaded.
+    const fileLoader = new SimCfnTemplateFileLoader();
+    const loadedTemplate = await fileLoader.load(
+      temporaryDirectory.join(templatePath),
+    );
+
+    // Then it holds what the same template written as JSON holds, and the
+    // Stack name drops the extension the way a synthesized name does.
+    assertIdentical(loadedTemplate.stackName, "WorkStack");
+    assertObjectMatches(loadedTemplate.template.Resources, {
+      WorkQueue: {
+        Properties: { QueueName: { "Fn::Sub": "${AWS::StackName}-work" } },
+      },
+    });
+  });
+
+  it("drops every YAML suffix a template file is named with from the Stack name", async () => {
+    // Given the same template under each name a YAML template file carries.
+    const temporaryDirectory = new TemporaryDirectory();
+    const fileLoader = new SimCfnTemplateFileLoader();
+    const stackNames: (SimCloudFormationStackName | string)[] = [];
+
+    // When each of them is loaded.
+    for (const fileName of [
+      "WorkStack.yml",
+      "WorkStack.template.yaml",
+      "WorkStack.template.yml",
+    ]) {
+      // oxlint-disable no-await-in-loop -- one file at a time is the point
+      await temporaryDirectory.writeFile(fileName, "Resources: {}\n");
+      const loaded = await fileLoader.load(temporaryDirectory.join(fileName));
+      // oxlint-enable no-await-in-loop
+      stackNames.push(loaded.stackName);
+    }
+
+    // Then each Stack is named for the template rather than for the file.
+    assertArrayEquals(stackNames, ["WorkStack", "WorkStack", "WorkStack"]);
+  });
+
+  it("reports the parse failure for a template file holding invalid YAML, naming the path", async () => {
+    // Given a YAML template file that does not parse.
+    const temporaryDirectory = new TemporaryDirectory();
+    const templatePath = "BrokenStack.yaml";
+
+    await temporaryDirectory.writeFile(
+      templatePath,
+      "Resources:\n  WorkQueue:\n Type: AWS::SQS::Queue\n",
+    );
+
+    // When the template file is loaded.
+    const fileLoader = new SimCfnTemplateFileLoader();
+    const error = await assertThrowsErrorAsync(async () => {
+      await fileLoader.load(temporaryDirectory.join(templatePath));
+    });
+
+    // Then the refusal names the resolved path, since where the parser stopped
+    // is no use without the file it stopped in.
+    assertStringIncludes(
+      error.message,
+      path.resolve(temporaryDirectory.join(templatePath)),
+    );
+    assertStringIncludes(error.message, "is not YAML this simulation can read");
+  });
+});

--- a/src/service/cloudformation/deploy/sim-cfn-template-file-loader.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-template-file-loader.ts
@@ -1,7 +1,6 @@
 import path from "node:path";
 import type { SimCloudFormationStackName } from "../stack/sim-cfn-stack.js";
 import type { CfnTemplateBodyRecord } from "../template/sim-cfn-template.js";
-import { jsonParse } from "../../../util/type-guard/json.js";
 import {
   loadSiblingCdkAssetsManifest,
   type SimCdkOutContext,
@@ -15,6 +14,7 @@ import {
   type SimCfnTemplateFileTransform,
 } from "./sim-cfn-template-file-transform.js";
 import { readTemplateFile } from "./sim-cfn-template-file-read.js";
+import { parseTemplateFileBody } from "./sim-cfn-template-file-parse.js";
 
 export interface SimCloudFormationDeployTemplateFileProperties {
   readonly templatePath: string;
@@ -83,7 +83,7 @@ export class SimCfnTemplateFileLoader {
     simWatch.reportPath(templatePath);
 
     const template = transformedTemplate(
-      jsonParse(await readTemplateFile(templatePath)),
+      parseTemplateFileBody(templatePath, await readTemplateFile(templatePath)),
       deployment.transform,
     );
     // Read from the path rather than the template, so what a transform did to
@@ -105,5 +105,8 @@ function stackNameFromTemplatePath(
 ): SimCloudFormationStackName {
   return path
     .basename(templatePath)
-    .replace(/\.template\.json$/u, "") as SimCloudFormationStackName;
+    .replace(
+      /\.template\.json$|(?:\.template)?\.ya?ml$/u,
+      "",
+    ) as SimCloudFormationStackName;
 }

--- a/src/service/cloudformation/deploy/sim-cfn-template-file-parse.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-template-file-parse.ts
@@ -1,0 +1,39 @@
+import path from "node:path";
+import { jsonParse, type JSONString } from "../../../util/type-guard/json.js";
+import type { CfnTemplateBodyRecord } from "../template/sim-cfn-template.js";
+import { parseSimCfnTemplateYaml } from "../template/yaml/sim-cfn-template-yaml.js";
+
+const YAML_TEMPLATE_FILE_NAME = /\.ya?ml$/u;
+
+/**
+ * Parse a template file in the format its name gives it.
+ *
+ * CloudFormation takes a template as JSON or as YAML, and a file says which of
+ * the two it holds by what it is called. A `.yaml` or `.yml` file is read as
+ * YAML. Every other name is read as JSON, which is what CDK synthesizes.
+ */
+export function parseTemplateFileBody(
+  templatePath: string,
+  templateBody: string,
+): CfnTemplateBodyRecord {
+  if (!YAML_TEMPLATE_FILE_NAME.test(templatePath)) {
+    return jsonParse(templateBody as JSONString<CfnTemplateBodyRecord>);
+  }
+
+  try {
+    return parseSimCfnTemplateYaml(templateBody);
+  } catch (error) {
+    // The path is named because a YAML failure reports a line and column, and
+    // a line and column with no file to look them up in is no use to anyone
+    // deploying more than one template.
+    throw new Error(
+      `Sim CloudFormation template file at ${path.resolve(templatePath)} ` +
+        `is not YAML this simulation can read: ${reasonFor(error)}`,
+      { cause: error },
+    );
+  }
+}
+
+function reasonFor(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/service/cloudformation/deploy/sim-cfn-template-file-read.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-template-file-read.ts
@@ -1,10 +1,8 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import type { JSONString } from "../../../util/type-guard/json.js";
-import type { CfnTemplateBodyRecord } from "../template/sim-cfn-template.js";
 
 /**
- * Read the synthesized template file a deployment names.
+ * Read the template file a deployment names.
  *
  * A path with no file at it is refused by naming the resolved path and what
  * was expected there. A template under `cdk.out` is build output that a fresh
@@ -12,14 +10,10 @@ import type { CfnTemplateBodyRecord } from "../template/sim-cfn-template.js";
  * the path failed to open, which is what leaves callers writing their own
  * guard in front of the deployment.
  */
-export async function readTemplateFile(
-  templatePath: string,
-): Promise<JSONString<CfnTemplateBodyRecord>> {
+export async function readTemplateFile(templatePath: string): Promise<string> {
   try {
     // oxlint-disable-next-line security/detect-non-literal-fs-filename
-    const templateBody = await readFile(templatePath, "utf8");
-
-    return templateBody as JSONString<CfnTemplateBodyRecord>;
+    return await readFile(templatePath, "utf8");
   } catch (error) {
     if (isMissingPathError(error)) {
       throw new Error(

--- a/src/service/cloudformation/deploy/sim-cfn-template-file-yaml.iso.test.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-template-file-yaml.iso.test.ts
@@ -1,0 +1,75 @@
+/* oxlint-disable no-template-curly-in-string -- Fn::Sub syntax, not JavaScript templates. */
+import { assertIdentical, assertNonNullable } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { TemporaryDirectory } from "../../../util/filesystem/temporary-directory.js";
+import { jsonStringify } from "../../../util/type-guard/json.js";
+
+const yamlTemplate = [
+  "Resources:",
+  "  WorkQueue:",
+  "    Type: AWS::SQS::Queue",
+  "    Properties:",
+  '      QueueName: !Sub "${AWS::StackName}-work"',
+  "Outputs:",
+  "  QueueArn:",
+  "    Value: !GetAtt WorkQueue.Arn",
+].join("\n");
+
+const jsonTemplate = {
+  Resources: {
+    WorkQueue: {
+      Type: "AWS::SQS::Queue",
+      Properties: {
+        QueueName: { "Fn::Sub": "${AWS::StackName}-work" },
+      },
+    },
+  },
+  Outputs: {
+    QueueArn: { Value: { "Fn::GetAtt": ["WorkQueue", "Arn"] } },
+  },
+};
+
+describe("deploying a template file written as YAML", () => {
+  it("creates the Resources the template describes", async () => {
+    // Given a hand-written YAML template file.
+    const directory = new TemporaryDirectory();
+    await directory.writeFile("WorkStack.yaml", yamlTemplate);
+
+    // When it is deployed.
+    const simAws = new SimAws();
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplateFile(directory.join("WorkStack.yaml"));
+
+    // Then the Queue is there under the name the intrinsic resolved to, in a
+    // Stack named for the template file.
+    assertIdentical(stack.stackName, "WorkStack");
+    assertNonNullable(simAws.sqs().findQueue("WorkStack-work"));
+  });
+
+  it("resolves a short-form tag the way the same template resolves its long form", async () => {
+    // Given the same infrastructure written twice, once with short-form tags
+    // in YAML and once with the long forms in JSON.
+    const directory = new TemporaryDirectory();
+    await directory.writeFile("WorkStack.yaml", yamlTemplate);
+    await directory.writeFile(
+      "WorkStack.template.json",
+      jsonStringify(jsonTemplate),
+    );
+
+    // When each of them is deployed.
+    const fromYaml = await new SimAws()
+      .cloudFormation()
+      .deployTemplateFile(directory.join("WorkStack.yaml"));
+    const fromJson = await new SimAws()
+      .cloudFormation()
+      .deployTemplateFile(directory.join("WorkStack.template.json"));
+
+    // Then the Output resolved from the tag holds what the long form resolved
+    // to, down to the ARN of the Queue the Stack created.
+    const arn = fromYaml.outputs.get("QueueArn")?.value;
+    assertNonNullable(arn);
+    assertIdentical(arn, fromJson.outputs.get("QueueArn")?.value);
+  });
+});

--- a/src/service/cloudformation/template/yaml/sim-cfn-template-yaml.iso.test.ts
+++ b/src/service/cloudformation/template/yaml/sim-cfn-template-yaml.iso.test.ts
@@ -1,0 +1,149 @@
+/* oxlint-disable no-template-curly-in-string -- Fn::Sub syntax, not JavaScript templates. */
+import {
+  assertObjectEquals,
+  assertStringIncludes,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { parseSimCfnTemplateYaml } from "./sim-cfn-template-yaml.js";
+
+describe("parsing a CloudFormation template written as YAML", () => {
+  it("reads each short-form tag as the object its long form is written as", () => {
+    // Given a template calling every intrinsic the simulator parses, written
+    // with the short-form tag a hand-written template uses.
+    const body = [
+      "Conditions:",
+      "  IsProd: !Equals [!Ref Stage, prod]",
+      "  IsNotProd: !Not [!Condition IsProd]",
+      "  IsEither: !Or [!Condition IsProd, !Condition IsNotProd]",
+      "  IsBoth: !And [!Condition IsProd, !Condition IsEither]",
+      "Resources:",
+      "  Work:",
+      "    Type: AWS::SQS::Queue",
+      "    Properties:",
+      '      QueueName: !Sub "${AWS::StackName}-work"',
+      '      Label: !Join ["-", [!Ref Stage, work]]',
+      '      Prefix: !Select [0, !Split ["-", !Ref Stage]]',
+      "      Region: !FindInMap [Regions, !Ref Stage, name]",
+      "      Retention: !If [IsProd, 14, 1]",
+      "      DeadLetter: !ImportValue shared-dead-letter",
+      "      Upstream: !ImportValue",
+      '        Fn::Sub: "${AWS::StackName}-upstream"',
+      "Outputs:",
+      "  QueueArn:",
+      "    Value: !GetAtt Work.Arn",
+      "  QueueName:",
+      "    Value: !GetAtt [Work, QueueName]",
+    ].join("\n");
+
+    // When it is parsed as YAML.
+    const template = parseSimCfnTemplateYaml(body);
+
+    // Then every tag holds what the same template written as JSON holds.
+    assertObjectEquals(template, {
+      Conditions: {
+        IsProd: { "Fn::Equals": [{ Ref: "Stage" }, "prod"] },
+        IsNotProd: { "Fn::Not": [{ Condition: "IsProd" }] },
+        IsEither: {
+          "Fn::Or": [{ Condition: "IsProd" }, { Condition: "IsNotProd" }],
+        },
+        IsBoth: {
+          "Fn::And": [{ Condition: "IsProd" }, { Condition: "IsEither" }],
+        },
+      },
+      Resources: {
+        Work: {
+          Type: "AWS::SQS::Queue",
+          Properties: {
+            QueueName: { "Fn::Sub": "${AWS::StackName}-work" },
+            Label: { "Fn::Join": ["-", [{ Ref: "Stage" }, "work"]] },
+            Prefix: {
+              "Fn::Select": [0, { "Fn::Split": ["-", { Ref: "Stage" }] }],
+            },
+            Region: { "Fn::FindInMap": ["Regions", { Ref: "Stage" }, "name"] },
+            Retention: { "Fn::If": ["IsProd", 14, 1] },
+            DeadLetter: { "Fn::ImportValue": "shared-dead-letter" },
+            Upstream: {
+              "Fn::ImportValue": { "Fn::Sub": "${AWS::StackName}-upstream" },
+            },
+          },
+        },
+      },
+      Outputs: {
+        QueueArn: { Value: { "Fn::GetAtt": "Work.Arn" } },
+        QueueName: { Value: { "Fn::GetAtt": ["Work", "QueueName"] } },
+      },
+    });
+  });
+
+  it("reads a short-form tag holding a list the way its long form reads one", () => {
+    // Given a template whose Fn::Sub carries the variables it substitutes,
+    // which is the list form of a tag the example above writes as a scalar.
+    const body = [
+      "Resources:",
+      "  Work:",
+      "    Type: AWS::SQS::Queue",
+      "    Properties:",
+      '      QueueName: !Sub ["${prefix}-work", { prefix: !Ref Stage }]',
+    ].join("\n");
+
+    // When it is parsed as YAML.
+    const template = parseSimCfnTemplateYaml(body);
+
+    // Then the list and everything nested in it is there as written.
+    assertObjectEquals(template.Resources["Work"], {
+      Type: "AWS::SQS::Queue",
+      Properties: {
+        QueueName: {
+          "Fn::Sub": ["${prefix}-work", { prefix: { Ref: "Stage" } }],
+        },
+      },
+    });
+  });
+
+  it("refuses a tag for an intrinsic this simulation has no behaviour for", () => {
+    // Given a template calling an intrinsic function the simulator does not
+    // parse in its long form either.
+    const body = [
+      "Resources:",
+      "  Work:",
+      "    Type: AWS::SQS::Queue",
+      "    Properties:",
+      "      QueueName: !Base64 work",
+    ].join("\n");
+
+    // When it is parsed as YAML.
+    const error = assertThrowsError(() => parseSimCfnTemplateYaml(body));
+
+    // Then the tag is refused by name, rather than the template deploying with
+    // the bare value the tag was written against.
+    assertStringIncludes(error.message, "Unresolved tag: !Base64");
+  });
+
+  it("refuses a file that is not YAML, saying where it stopped", () => {
+    // Given a file whose contents are not a YAML document.
+    const body = "Resources:\n  Work:\n Type: AWS::SQS::Queue\n";
+
+    // When it is parsed as YAML.
+    const error = assertThrowsError(() => parseSimCfnTemplateYaml(body));
+
+    // Then the parse failure is what comes back.
+    assertStringIncludes(error.message, "All mapping items");
+  });
+
+  it("refuses YAML holding something other than template sections", () => {
+    // Given a file that is YAML but is not a mapping, as a note left where a
+    // template was expected is.
+    const body = "a template goes here\n";
+
+    // When it is parsed as YAML.
+    const error = assertThrowsError(() => parseSimCfnTemplateYaml(body));
+
+    // Then it is refused for its shape rather than read as a template with no
+    // sections in it.
+    assertStringIncludes(
+      error.message,
+      "a template must be a mapping of template sections",
+    );
+  });
+});

--- a/src/service/cloudformation/template/yaml/sim-cfn-template-yaml.ts
+++ b/src/service/cloudformation/template/yaml/sim-cfn-template-yaml.ts
@@ -1,0 +1,49 @@
+import { parseDocument, type YAMLError } from "yaml";
+import { isRecord } from "../../../../util/type-guard/record.js";
+import type { CfnTemplateBodyRecord } from "../sim-cfn-template.js";
+import { simCfnYamlShortFormTags } from "./sim-cfn-yaml-short-forms.js";
+
+/**
+ * What a YAML parser calls a tag it has no entry for.
+ *
+ * A YAML parser calls that a warning and carries on with the value the tag was
+ * written against, which would read `!Base64 secret` as the string `secret`.
+ * It is a failure here, the way the long form of an intrinsic this simulation
+ * has no behaviour for fails the template that calls it.
+ */
+const UNRESOLVED_TAG = "TAG_RESOLVE_FAILED";
+
+/**
+ * Parse a CloudFormation template written as YAML.
+ *
+ * What comes back is the template object the same infrastructure written as
+ * JSON parses to, with short-form intrinsic tags resolved to the objects their
+ * long forms are written as. Everything downstream reads one template shape,
+ * whichever format the template arrived in.
+ */
+export function parseSimCfnTemplateYaml(body: string): CfnTemplateBodyRecord {
+  const document = parseDocument(body, {
+    customTags: simCfnYamlShortFormTags(),
+  });
+
+  const failures = [
+    ...document.errors,
+    ...document.warnings.filter((warning) => warning.code === UNRESOLVED_TAG),
+  ];
+
+  if (failures.length > 0) {
+    throw new Error(failureMessage(failures));
+  }
+
+  const template: unknown = document.toJS();
+
+  if (!isRecord(template)) {
+    throw new TypeError("a template must be a mapping of template sections");
+  }
+
+  return template as CfnTemplateBodyRecord;
+}
+
+function failureMessage(failures: readonly YAMLError[]): string {
+  return failures.map((failure) => failure.message).join("; ");
+}

--- a/src/service/cloudformation/template/yaml/sim-cfn-yaml-short-forms.ts
+++ b/src/service/cloudformation/template/yaml/sim-cfn-yaml-short-forms.ts
@@ -1,0 +1,84 @@
+import {
+  Pair,
+  YAMLMap,
+  type CollectionTag,
+  type ScalarTag,
+  type YAMLSeq,
+} from "yaml";
+
+/**
+ * The short-form tag a YAML template can write an intrinsic function as, and
+ * the name the same function carries when it is written out in full.
+ *
+ * This is the set the simulator parses. The functions in
+ * `makeSimCfnFunctionParsers`, the `Ref` the node parser reads, and the
+ * functions a Condition is built from. A tag outside it is left unresolved. A
+ * template calling an intrinsic this simulation has no behaviour for is then
+ * refused as the file is read.
+ */
+const SIM_CFN_YAML_SHORT_FORMS: ReadonlyMap<string, string> = new Map([
+  ["!Ref", "Ref"],
+  ["!GetAtt", "Fn::GetAtt"],
+  ["!Join", "Fn::Join"],
+  ["!Sub", "Fn::Sub"],
+  ["!FindInMap", "Fn::FindInMap"],
+  ["!If", "Fn::If"],
+  ["!Split", "Fn::Split"],
+  ["!Select", "Fn::Select"],
+  ["!ImportValue", "Fn::ImportValue"],
+  ["!And", "Fn::And"],
+  ["!Equals", "Fn::Equals"],
+  ["!Not", "Fn::Not"],
+  ["!Or", "Fn::Or"],
+  ["!Condition", "Condition"],
+]);
+
+/**
+ * The YAML tags that turn CloudFormation's short-form intrinsics into the
+ * objects their long forms are written as.
+ *
+ * `!GetAtt Bucket.Arn` becomes `{ "Fn::GetAtt": "Bucket.Arn" }`, and the rest
+ * of the simulator reads the template it would have read had the template been
+ * written in JSON.
+ *
+ * Every tag is registered against scalars, sequences and mappings alike, since
+ * the tag itself only says which function the value belongs to. What shape a
+ * function accepts is the business of the parser that reads its long form.
+ * That parser is where `!Ref [Bucket, Arn]` is refused, and it refuses the
+ * same template written in JSON.
+ */
+export function simCfnYamlShortFormTags(): (ScalarTag | CollectionTag)[] {
+  return [...SIM_CFN_YAML_SHORT_FORMS].flatMap(([tag, functionName]) => [
+    scalarShortFormTag(tag, functionName),
+    collectionShortFormTag(tag, functionName, "seq"),
+    collectionShortFormTag(tag, functionName, "map"),
+  ]);
+}
+
+function scalarShortFormTag(tag: string, functionName: string): ScalarTag {
+  return {
+    tag,
+    resolve: (value: string): Record<string, string> => ({
+      [functionName]: value,
+    }),
+  };
+}
+
+function collectionShortFormTag(
+  tag: string,
+  functionName: string,
+  collection: "map" | "seq",
+): CollectionTag {
+  return {
+    tag,
+    collection,
+    // Wrapped as a node. A plain object would leave the values inside the
+    // collection as nodes when the document is turned into JavaScript.
+    resolve: (value: YAMLMap | YAMLSeq): YAMLMap => {
+      const wrapped = new YAMLMap();
+      wrapped.add(new Pair(functionName, value));
+
+      return wrapped;
+    },
+  };
+}

--- a/src/service/cloudformation/watch/sim-cfn-template-yaml-watch.loc.test.ts
+++ b/src/service/cloudformation/watch/sim-cfn-template-yaml-watch.loc.test.ts
@@ -1,0 +1,73 @@
+/* oxlint-disable no-template-curly-in-string -- Fn::Sub syntax, not JavaScript templates. */
+import { assertNonNullable, assertUndefined } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { TemporaryDirectory } from "../../../util/filesystem/temporary-directory.js";
+import {
+  templatePause,
+  untilApplied,
+} from "../../../../test/cloudformation/watched-template.js";
+
+describe("a watched template file written as YAML", () => {
+  it("applies the change the file was saved with to the deployed Stack", async () => {
+    // Given a Stack deployed from a watched YAML template file
+    const directory = new TemporaryDirectory();
+    await directory.writeFile("site.yaml", siteTemplate());
+
+    // macOS delivers filesystem events with a short delay, so the write above
+    // is settled before the watch starts rather than arriving as a change.
+    await templatePause(250);
+
+    const simAws = new SimAws();
+    const updates: string[] = [];
+    await simAws.cloudFormation().deployTemplateFile({
+      templatePath: directory.join("site.yaml"),
+      watch: {
+        settleMs: 40,
+        onUpdated: (): void => {
+          updates.push("updated");
+        },
+      },
+    });
+
+    assertUndefined(simAws.s3().getSimBucketByName("site-uploads"));
+
+    try {
+      // When the file is saved with another Bucket in it
+      await directory.writeFile(
+        "site.yaml",
+        siteTemplate({ withUploads: true }),
+      );
+      await untilApplied(updates);
+
+      // Then the Bucket the change added is serving, named by the intrinsic
+      // the short-form tag carried
+      assertNonNullable(simAws.s3().getSimBucketByName("site-uploads"));
+    } finally {
+      simAws.cloudFormation().stopWatchingTemplateFiles();
+    }
+  });
+});
+
+interface SiteTemplateProperties {
+  readonly withUploads?: boolean;
+}
+
+function siteTemplate(properties: SiteTemplateProperties = {}): string {
+  return [
+    "Resources:",
+    "  Site:",
+    "    Type: AWS::S3::Bucket",
+    "    Properties:",
+    '      BucketName: !Sub "${AWS::StackName}-content"',
+    ...(properties.withUploads === true
+      ? [
+          "  Uploads:",
+          "    Type: AWS::S3::Bucket",
+          "    Properties:",
+          '      BucketName: !Sub "${AWS::StackName}-uploads"',
+        ]
+      : []),
+    "",
+  ].join("\n");
+}


### PR DESCRIPTION
`deployTemplateFile()` reads a `.yaml` or `.yml` file as YAML, so a hand-written template deploys without being converted to JSON first. A tag schema turns CloudFormation's short-form intrinsics into the objects their long forms are written as, covering the functions the simulator already parses along with `Ref` and the condition functions, and everything downstream reads one template shape. A tag outside that set, such as `!Base64`, fails the parse by name, the way the long form of an unimplemented intrinsic fails a template. The Stack name a template path is taken from drops the YAML suffixes the way it drops `.template.json`, and `updateTemplateFile()` and watching read the file through the same loader, so a watched YAML template updates its Stack on save. `TemplateBody` for `CreateStackCommand` and `UpdateStackCommand` is still JSON only, which is #747.

Resolves #746