### PR TITLE
feat: expand a SAM Serverless Function

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -1805,6 +1805,80 @@ function's execution Role as the ambient simulated caller, so downstream calls m
 `SimSdk`-intercepted clients are authorized by simulated IAM as on real Lambda. Functions without
 a matching binding keep their template code, running in the simulated vm runtime.
 
+## SAM templates
+
+A template naming the `AWS::Serverless-2016-10-31` transform has its SAM resources expanded before
+the stack deploys, the way CloudFormation expands them. `AWS::Serverless::Function` becomes an
+`AWS::Lambda::Function` and the `AWS::IAM::Role` it runs as. `Globals.Function` supplies the
+defaults every function takes, and a value on the function itself wins.
+
+The expanded function keeps the logical ID the SAM resource had. `Ref` and `Fn::GetAtt` against that
+name answer for the function, and a binding targeting that logical ID backs it with your real
+handler. `CodeUri` is never read from disk (a bound function can leave the code out of the template
+altogether).
+
+```typescript sim-cloudformation-sam-function
+/**
+ * Deploying a SAM AWS::Serverless::Function into simulated AWS.
+ */
+
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "rates-stack",
+  template: {
+    Transform: "AWS::Serverless-2016-10-31",
+    Globals: {
+      Function: {
+        Runtime: "nodejs22.x",
+        Timeout: 10,
+      },
+    },
+    Resources: {
+      Rates: {
+        Type: "AWS::Serverless::Function",
+        Properties: {
+          FunctionName: "rates",
+          CodeUri: "src/rates/",
+          Handler: "index.handler",
+          Environment: {
+            Variables: { TABLE_NAME: "rates-table" },
+          },
+        },
+      },
+    },
+  },
+  bindings: [
+    {
+      logicalId: "Rates",
+      handler: (event: { currency: string }): string =>
+        `rate for ${event.currency}`,
+    },
+  ],
+});
+
+console.log(stack.getResource("Rates")?.type);
+
+const output = await simAws.lambda().invoke(
+  new InvokeCommand({
+    FunctionName: "rates",
+    Payload: JSON.stringify({ currency: "GBP" }),
+  }),
+);
+
+console.log(new TextDecoder().decode(output.Payload));
+```
+
+The execution role is named after the function, `RatesRole` for a function called `Rates`, and
+carries the basic execution policy SAM gives one. `Policies` on the function reach it. A policy
+document goes on as an inline policy, and a managed policy ARN is attached. SAM policy templates
+such as `DynamoDBCrudPolicy` are left ungenerated, because simulated IAM allows every call by
+default and a role missing those statements authorizes the same calls either way. A function naming
+its own `Role` runs as that role, and gets no expanded one.
+
 ## Serving deployed resources on localhost
 
 CloudFormation itself is not served as an HTTP API. Instead, you deploy infrastructure through Sim
@@ -2381,6 +2455,8 @@ Sim CloudFormation currently supports:
   `Fn::Select` intrinsic functions
 - Explicit resource dependencies with `DependsOn`
 - Implicit dependencies from resource `Ref` expressions
+- SAM templates naming the `AWS::Serverless-2016-10-31` transform, with `AWS::Serverless::Function`
+  expanded into a Lambda function and its execution Role, and `Globals.Function` defaults applied
 
 The resource types it creates are:
 
@@ -2484,4 +2560,9 @@ Each service's own docs describe what its resource types support.
 - The `Condition` attribute is read on resources but not on outputs. An output carrying one is
   resolved and present in `stack.outputs` whichever way its condition falls, where real
   CloudFormation would leave it out.
+- The SAM transform is expanded for `AWS::Serverless::Function` alone. `Events` on a function are
+  left out. A SAM API, schedule or queue trigger creates nothing, and every other
+  `AWS::Serverless::*` resource type is recorded as unsupported. `AutoPublishAlias` and
+  `DeploymentPreference` are left out too, because the simulator has one version of a function and
+  nothing to shift traffic between.
 - Many advanced CloudFormation features are outside the simulation.

--- a/docs/services/cloudformation/sim-cloudformation-sam-function.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-sam-function.example.ts
@@ -1,0 +1,52 @@
+/**
+ * Deploying a SAM AWS::Serverless::Function into simulated AWS.
+ */
+
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "rates-stack",
+  template: {
+    Transform: "AWS::Serverless-2016-10-31",
+    Globals: {
+      Function: {
+        Runtime: "nodejs22.x",
+        Timeout: 10,
+      },
+    },
+    Resources: {
+      Rates: {
+        Type: "AWS::Serverless::Function",
+        Properties: {
+          FunctionName: "rates",
+          CodeUri: "src/rates/",
+          Handler: "index.handler",
+          Environment: {
+            Variables: { TABLE_NAME: "rates-table" },
+          },
+        },
+      },
+    },
+  },
+  bindings: [
+    {
+      logicalId: "Rates",
+      handler: (event: { currency: string }): string =>
+        `rate for ${event.currency}`,
+    },
+  ],
+});
+
+console.log(stack.getResource("Rates")?.type);
+
+const output = await simAws.lambda().invoke(
+  new InvokeCommand({
+    FunctionName: "rates",
+    Payload: JSON.stringify({ currency: "GBP" }),
+  }),
+);
+
+console.log(new TextDecoder().decode(output.Payload));

--- a/src/service/cloudformation/sam/function/sim-cfn-sam-function-policies.ts
+++ b/src/service/cloudformation/sam/function/sim-cfn-sam-function-policies.ts
@@ -1,0 +1,103 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../template/value/sim-cfn-template-value.js";
+import { isSamTemplateRecord } from "../sim-cfn-sam-record.js";
+
+/**
+ * The trust policy the Role carries, which lets Lambda assume it.
+ */
+export const lambdaAssumeRolePolicyDocument: SimCfnTemplateValueRecord = {
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Principal: { Service: "lambda.amazonaws.com" },
+      Action: "sts:AssumeRole",
+    },
+  ],
+};
+
+/**
+ * The managed policy SAM attaches to every function Role it generates.
+ */
+export const basicExecutionPolicyArn: SimCfnTemplateValueRecord = {
+  "Fn::Join": [
+    "",
+    [
+      "arn:",
+      { Ref: "AWS::Partition" },
+      ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+    ],
+  ],
+};
+
+/**
+ * What the `Policies` of a SAM function say about the Role it is expanded
+ * with.
+ */
+export interface SamFunctionPolicies {
+  /** Policy documents, named the way SAM names them. */
+  readonly inlinePolicies: readonly SimCfnTemplateValueRecord[];
+  /** Managed policy ARNs the Role attaches. */
+  readonly managedPolicyArns: readonly string[];
+}
+
+/**
+ * Read the `Policies` of a SAM function into the two lists an AWS::IAM::Role
+ * carries.
+ *
+ * `Policies` holds one entry or a list of them, and an entry is a policy
+ * document, a managed policy ARN, or a SAM policy template naming permissions
+ * to generate. The templates are not expanded here. There are around a hundred
+ * of them, and the default `SimIamAllowAllAuth` means a Role missing their
+ * statements authorizes the same calls either way.
+ */
+export function samFunctionPolicies(
+  logicalId: string,
+  policies: SimCfnTemplateValue | undefined,
+): SamFunctionPolicies {
+  const entries = policyEntries(policies);
+
+  return {
+    inlinePolicies: entries
+      .filter((entry) => isPolicyDocument(entry))
+      .map((document, index) => ({
+        PolicyName: `${logicalId}RolePolicy${String(index)}`,
+        PolicyDocument: document,
+      })),
+    managedPolicyArns: entries.filter((entry) => isManagedPolicyArn(entry)),
+  };
+}
+
+/**
+ * The `Policies` property as a list, since SAM accepts a single entry in place
+ * of one.
+ */
+function policyEntries(
+  policies: SimCfnTemplateValue | undefined,
+): SimCfnTemplateValue[] {
+  if (policies === undefined) {
+    return [];
+  }
+
+  return Array.isArray(policies) ? policies : [policies];
+}
+
+/**
+ * Whether an entry is a policy document. A policy template is an object of one
+ * key naming the template.
+ */
+function isPolicyDocument(
+  entry: SimCfnTemplateValue,
+): entry is SimCfnTemplateValueRecord {
+  return isSamTemplateRecord(entry) && "Statement" in entry;
+}
+
+/**
+ * Whether an entry is a managed policy ARN. A policy template arrives as a
+ * bare name.
+ */
+function isManagedPolicyArn(entry: SimCfnTemplateValue): entry is string {
+  return typeof entry === "string" && entry.startsWith("arn:");
+}

--- a/src/service/cloudformation/sam/function/sim-cfn-sam-function-properties.ts
+++ b/src/service/cloudformation/sam/function/sim-cfn-sam-function-properties.ts
@@ -1,0 +1,79 @@
+import type { SimCfnTemplateValueRecord } from "../../template/value/sim-cfn-template-value.js";
+import { isSamTemplateRecord } from "../sim-cfn-sam-record.js";
+
+/**
+ * The Resource attributes the Lambda function carries over. They are the ones
+ * saying whether it is created at all and what has to exist first.
+ */
+const attributeNames = new Set(["Condition", "DependsOn"]);
+
+/**
+ * The properties whose names and meanings are the same on both Resource types,
+ * so expanding them is carrying them across.
+ */
+const propertyNames = new Set([
+  "Description",
+  "Environment",
+  "FunctionName",
+  "Handler",
+  "MemorySize",
+  "Runtime",
+  "Timeout",
+]);
+
+/**
+ * The `Properties` of the SAM Resource. A function taking everything it has
+ * from `Globals` can leave the section out.
+ */
+export function samResourceProperties(
+  resource: SimCfnTemplateValueRecord,
+): SimCfnTemplateValueRecord {
+  const properties = resource["Properties"];
+
+  return isSamTemplateRecord(properties) ? properties : {};
+}
+
+/**
+ * The Resource attributes the expanded Lambda function carries.
+ */
+export function samCarriedAttributes(
+  resource: SimCfnTemplateValueRecord,
+): SimCfnTemplateValueRecord {
+  return picked(resource, attributeNames);
+}
+
+/**
+ * The properties the expanded Lambda function carries, from the SAM function
+ * properties the `Globals` defaults have already been merged into.
+ */
+export function samCarriedProperties(
+  functionProperties: SimCfnTemplateValueRecord,
+): SimCfnTemplateValueRecord {
+  return {
+    ...picked(functionProperties, propertyNames),
+    ...inlineCode(functionProperties),
+  };
+}
+
+/**
+ * The `Code` of a function whose source the template holds inline.
+ */
+function inlineCode(
+  functionProperties: SimCfnTemplateValueRecord,
+): SimCfnTemplateValueRecord {
+  const source = functionProperties["InlineCode"];
+
+  return typeof source === "string" ? { Code: { ZipFile: source } } : {};
+}
+
+/**
+ * The entries of a record whose keys are in the given set.
+ */
+function picked(
+  record: SimCfnTemplateValueRecord,
+  names: ReadonlySet<string>,
+): SimCfnTemplateValueRecord {
+  return Object.fromEntries(
+    Object.entries(record).filter(([name]) => names.has(name)),
+  );
+}

--- a/src/service/cloudformation/sam/function/sim-cfn-sam-function-role.ts
+++ b/src/service/cloudformation/sam/function/sim-cfn-sam-function-role.ts
@@ -1,0 +1,66 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../template/value/sim-cfn-template-value.js";
+import {
+  basicExecutionPolicyArn,
+  lambdaAssumeRolePolicyDocument,
+  samFunctionPolicies,
+} from "./sim-cfn-sam-function-policies.js";
+
+interface SamFunctionRoleProperties {
+  readonly logicalId: string;
+  readonly functionProperties: SimCfnTemplateValueRecord;
+  readonly condition: SimCfnTemplateValue | undefined;
+}
+
+/**
+ * The AWS::IAM::Role Resource a SAM function is expanded with, for a function
+ * that named no Role of its own.
+ *
+ * Every SAM function gets the basic execution policy, as SAM gives one, and
+ * whatever its `Policies` said on top. The Role is conditioned the way the
+ * function is. A function the template conditioned out leaves no Role behind
+ * for the Stack to create.
+ */
+export function samFunctionRoleResource(
+  properties: SamFunctionRoleProperties,
+): SimCfnTemplateValueRecord {
+  const { logicalId, functionProperties, condition } = properties;
+  const policies = samFunctionPolicies(
+    logicalId,
+    functionProperties["Policies"],
+  );
+
+  return {
+    Type: "AWS::IAM::Role",
+    ...roleCondition(condition),
+    Properties: {
+      AssumeRolePolicyDocument: lambdaAssumeRolePolicyDocument,
+      ManagedPolicyArns: [
+        basicExecutionPolicyArn,
+        ...policies.managedPolicyArns,
+      ],
+      ...inlinePolicies(policies.inlinePolicies),
+    },
+  };
+}
+
+/**
+ * The `Condition` attribute the Role carries, where the function carried one.
+ */
+function roleCondition(
+  condition: SimCfnTemplateValue | undefined,
+): SimCfnTemplateValueRecord {
+  return condition === undefined ? {} : { Condition: condition };
+}
+
+/**
+ * The `Policies` property the Role carries, where the function stated policy
+ * documents to put there.
+ */
+function inlinePolicies(
+  policies: readonly SimCfnTemplateValueRecord[],
+): SimCfnTemplateValueRecord {
+  return policies.length > 0 ? { Policies: [...policies] } : {};
+}

--- a/src/service/cloudformation/sam/function/sim-cfn-sam-function-template.factory.ts
+++ b/src/service/cloudformation/sam/function/sim-cfn-sam-function-template.factory.ts
@@ -1,0 +1,80 @@
+import { MappedFactory } from "@kensio/part-factory";
+
+import type { CfnTemplateBodyRecord } from "../../template/sim-cfn-template.js";
+import type { SimCfnTemplateValueRecord } from "../../template/value/sim-cfn-template-value.js";
+import { samTransformName } from "../sim-cfn-sam-transform.js";
+import { samFunctionType } from "./sim-cfn-sam-function.js";
+
+/**
+ * What a test asks for when it wants a SAM template holding one function.
+ */
+export interface SimCfnSamFunctionTemplateInput {
+  /**
+   * What this test is about, added to the properties of a function that
+   * already runs.
+   */
+  readonly functionProperties: SimCfnTemplateValueRecord;
+  /**
+   * The `Globals.Function` defaults the template states. A test stating none
+   * gets no `Globals` section.
+   */
+  readonly globals: SimCfnTemplateValueRecord;
+}
+
+/**
+ * The logical ID the function carries, and so the name the Lambda function and
+ * its execution Role are expanded under.
+ */
+export const samFunctionTemplateLogicalId = "Rates";
+
+const workingFunction: SimCfnTemplateValueRecord = {
+  FunctionName: "rates",
+  Handler: "index.handler",
+  Runtime: "nodejs22.x",
+  InlineCode: "exports.handler = async () => 'rates';",
+};
+
+/**
+ * Builds a SAM template holding one AWS::Serverless::Function.
+ *
+ * ```typescript
+ * const stack = await simAws.cloudFormation().deployTemplate({
+ *   stackName: "rates-stack",
+ *   template: simCfnSamFunctionTemplateFactory.make({
+ *     functionProperties: { Timeout: 30 },
+ *   }),
+ * });
+ * ```
+ *
+ * The function runs as it comes, with its source inline and a handler and
+ * runtime naming it. What a test states is what the test is about.
+ */
+export const simCfnSamFunctionTemplateFactory = new MappedFactory<
+  SimCfnSamFunctionTemplateInput,
+  CfnTemplateBodyRecord
+>(
+  () => ({ functionProperties: {}, globals: {} }),
+  (input) => ({
+    Transform: samTransformName,
+    ...globalsSection(input),
+    Resources: {
+      [samFunctionTemplateLogicalId]: {
+        Type: samFunctionType,
+        Properties: { ...workingFunction, ...input.functionProperties },
+      },
+    },
+  }),
+);
+
+/**
+ * The `Globals` section, for a template stating defaults to put in one.
+ */
+function globalsSection(
+  input: SimCfnSamFunctionTemplateInput,
+): SimCfnTemplateValueRecord {
+  if (Object.keys(input.globals).length === 0) {
+    return {};
+  }
+
+  return { Globals: { Function: input.globals } };
+}

--- a/src/service/cloudformation/sam/function/sim-cfn-sam-function.ts
+++ b/src/service/cloudformation/sam/function/sim-cfn-sam-function.ts
@@ -1,0 +1,71 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../template/value/sim-cfn-template-value.js";
+import { samMergedFunctionProperties } from "../sim-cfn-sam-globals.js";
+import {
+  samCarriedAttributes,
+  samCarriedProperties,
+  samResourceProperties,
+} from "./sim-cfn-sam-function-properties.js";
+import { samFunctionRoleResource } from "./sim-cfn-sam-function-role.js";
+
+interface SamFunctionExpansionProperties {
+  readonly logicalId: string;
+  readonly resource: SimCfnTemplateValueRecord;
+  readonly globals: SimCfnTemplateValueRecord;
+}
+
+/**
+ * The SAM Resource type this expansion covers.
+ */
+export const samFunctionType = "AWS::Serverless::Function";
+
+/**
+ * Expand one AWS::Serverless::Function into the Resources CloudFormation
+ * deploys for it.
+ *
+ * The Lambda function keeps the logical ID the template gave the SAM Resource,
+ * so `Ref` and `Fn::GetAtt` against that name answer what they answer for the
+ * function, and a handler bound to it by logical ID backs the function it
+ * names. The execution Role is a second Resource named after it, unless the
+ * function named a Role of its own to run as.
+ *
+ * `CodeUri` is not carried over. Nothing reads code off disk here, and a
+ * function a bound handler backs needs no `Code` at all. A function carrying
+ * neither is reported as skipped the way an unbacked AWS::Lambda::Function
+ * is.
+ */
+export function samFunctionResources(
+  properties: SamFunctionExpansionProperties,
+): Record<string, SimCfnTemplateValue> {
+  const { logicalId, resource, globals } = properties;
+  const functionProperties = samMergedFunctionProperties(
+    globals,
+    samResourceProperties(resource),
+  );
+  const roleLogicalId = `${logicalId}Role`;
+  const declaredRole = functionProperties["Role"];
+
+  const lambdaFunction: SimCfnTemplateValueRecord = {
+    Type: "AWS::Lambda::Function",
+    ...samCarriedAttributes(resource),
+    Properties: {
+      ...samCarriedProperties(functionProperties),
+      Role: declaredRole ?? { "Fn::GetAtt": [roleLogicalId, "Arn"] },
+    },
+  };
+
+  if (declaredRole !== undefined) {
+    return { [logicalId]: lambdaFunction };
+  }
+
+  return {
+    [logicalId]: lambdaFunction,
+    [roleLogicalId]: samFunctionRoleResource({
+      logicalId,
+      functionProperties,
+      condition: resource["Condition"],
+    }),
+  };
+}

--- a/src/service/cloudformation/sam/sim-cfn-sam-expansion.ts
+++ b/src/service/cloudformation/sam/sim-cfn-sam-expansion.ts
@@ -1,0 +1,67 @@
+import { isRecord } from "../../../util/type-guard/record.js";
+import type { CfnTemplateBodyRecord } from "../template/sim-cfn-template.js";
+import type { SimCfnTemplateValue } from "../template/value/sim-cfn-template-value.js";
+import {
+  samFunctionResources,
+  samFunctionType,
+} from "./function/sim-cfn-sam-function.js";
+import { samFunctionGlobals } from "./sim-cfn-sam-globals.js";
+import { isSamTemplateRecord } from "./sim-cfn-sam-record.js";
+import {
+  templateNamesSamTransform,
+  withoutSamSections,
+} from "./sim-cfn-sam-transform.js";
+
+/**
+ * Expand the SAM Resources of a template into the Resource types simulated AWS
+ * creates.
+ *
+ * This is what CloudFormation does with a template naming the SAM transform.
+ * It runs ahead of everything that reads the template, and a Stack is deployed
+ * from a body holding no `AWS::Serverless::*` Resource left to interpret. A
+ * template naming no SAM transform is returned as it came, and so is one this
+ * cannot read at all, leaving the body validation to say what is wrong with it.
+ *
+ * The expansion is a subset. AWS runs the real one in `aws-sam-translator`, a
+ * Python library with no JavaScript equivalent, and what is written here covers
+ * the SAM Resources Yulin models. A SAM Resource type outside it stays where it
+ * is and is recorded as unsupported, the same as before.
+ */
+export function samExpandedTemplate(
+  template: CfnTemplateBodyRecord,
+): CfnTemplateBodyRecord {
+  if (!isRecord(template) || !isRecord(template.Resources)) {
+    return template;
+  }
+
+  if (!templateNamesSamTransform(template)) {
+    return template;
+  }
+
+  const globals = samFunctionGlobals(template);
+
+  return {
+    ...withoutSamSections(template),
+    Resources: Object.fromEntries(
+      Object.entries(template.Resources).flatMap(([logicalId, resource]) =>
+        Object.entries(expandedResource(logicalId, resource, globals)),
+      ),
+    ),
+  };
+}
+
+/**
+ * The Resources one template Resource is deployed as. Anything the expansion
+ * does not cover is deployed as itself.
+ */
+function expandedResource(
+  logicalId: string,
+  resource: SimCfnTemplateValue,
+  globals: Record<string, SimCfnTemplateValue>,
+): Record<string, SimCfnTemplateValue> {
+  if (!isSamTemplateRecord(resource) || resource["Type"] !== samFunctionType) {
+    return { [logicalId]: resource };
+  }
+
+  return samFunctionResources({ logicalId, resource, globals });
+}

--- a/src/service/cloudformation/sam/sim-cfn-sam-function-role.iso.test.ts
+++ b/src/service/cloudformation/sam/sim-cfn-sam-function-role.iso.test.ts
@@ -1,0 +1,153 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertMapSize,
+  assertNonNullable,
+  assertStringIncludes,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { makeSimAwsAccountId } from "../../aws/sim-aws-account.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimIamRole } from "../../iam/role/sim-iam-role.js";
+import type { SimLambdaFunction } from "../../lambda/function/sim-lambda-function.js";
+import type { SimCfnTemplateValue } from "../template/value/sim-cfn-template-value.js";
+import { simCfnSamFunctionTemplateFactory } from "./function/sim-cfn-sam-function-template.factory.js";
+
+const readRatesTable: SimCfnTemplateValue = {
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Action: "dynamodb:GetItem",
+      Resource: "arn:aws:dynamodb:eu-west-2:111111111111:table/rates",
+    },
+  ],
+};
+
+describe("SAM Serverless Function execution Role", () => {
+  it("gives the Role the basic execution policy SAM gives one", async () => {
+    // Given a SAM function stating no policies at all
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "rates-basic-role-stack",
+      template: simCfnSamFunctionTemplateFactory.make(),
+    });
+
+    // Then the Role it was expanded with attaches the basic execution policy,
+    // resolved against the partition the Stack deployed into
+    const role = stack.getResource("RatesRole")?.simResource as SimIamRole;
+    assertNonNullable(role);
+
+    assertTrue(
+      role.attachedPolicyArns.has(
+        "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+      ),
+    );
+
+    // And it trusts Lambda to assume it
+    assertNonNullable(role.assumeRolePolicyDocument);
+    assertStringIncludes(role.assumeRolePolicyDocument, "lambda.amazonaws.com");
+  });
+
+  it("puts the policy documents a function states onto its Role", async () => {
+    // Given a SAM function stating a policy document of its own
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "rates-policies-stack",
+      template: simCfnSamFunctionTemplateFactory.make({
+        functionProperties: { Policies: [readRatesTable] },
+      }),
+    });
+
+    // Then the Role holds it as an inline policy
+    const role = stack.getResource("RatesRole")?.simResource as SimIamRole;
+    assertNonNullable(role);
+
+    const policyDocument = role.inlinePolicies.get("RatesRolePolicy0");
+    assertNonNullable(policyDocument);
+    assertStringIncludes(policyDocument, "dynamodb:GetItem");
+  });
+
+  it("attaches a managed policy ARN a function states", async () => {
+    // Given a SAM function stating one managed policy ARN rather than a list
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "rates-managed-policy-stack",
+      template: simCfnSamFunctionTemplateFactory.make({
+        functionProperties: {
+          Policies: "arn:aws:iam::aws:policy/AmazonDynamoDBReadOnlyAccess",
+        },
+      }),
+    });
+
+    // Then the Role attaches it
+    const role = stack.getResource("RatesRole")?.simResource as SimIamRole;
+    assertNonNullable(role);
+
+    assertTrue(
+      role.attachedPolicyArns.has(
+        "arn:aws:iam::aws:policy/AmazonDynamoDBReadOnlyAccess",
+      ),
+    );
+  });
+
+  it("deploys a function whose policies are SAM policy templates", async () => {
+    // Given a SAM function asking for a policy template, which is a named set
+    // of permissions SAM generates statements from
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "rates-policy-template-stack",
+      template: simCfnSamFunctionTemplateFactory.make({
+        functionProperties: {
+          Policies: [{ DynamoDBCrudPolicy: { TableName: "rates" } }],
+        },
+      }),
+    });
+
+    // Then the function and its Role still deploy, with the template left
+    // ungenerated. Simulated IAM allows every call by default, and a Role
+    // missing those statements authorizes the same calls either way
+    const role = stack.getResource("RatesRole")?.simResource as SimIamRole;
+    assertNonNullable(role);
+    assertMapSize(role.inlinePolicies, 0);
+    assertArrayLength(stack.skippedResources, 0);
+  });
+
+  it("expands no Role for a function naming the Role it runs as", async () => {
+    // Given a SAM function naming an execution Role by ARN
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws();
+    const roleArn = `arn:aws:iam::${accountId}:role/RatesExecution`;
+
+    // When it is deployed
+    const stack = await simAws
+      .account(accountId)
+      .region("eu-west-2")
+      .cloudFormation()
+      .deployTemplate({
+        stackName: "rates-own-role-stack",
+        template: simCfnSamFunctionTemplateFactory.make({
+          functionProperties: { Role: roleArn },
+        }),
+      });
+
+    // Then the function runs as the Role it named, and the Stack holds no Role
+    // of its own
+    const simFunction = stack.getResource("Rates")
+      ?.simResource as SimLambdaFunction;
+    assertNonNullable(simFunction);
+    assertIdentical(simFunction.roleArn, roleArn);
+    assertUndefined(stack.getResource("RatesRole"));
+  });
+});

--- a/src/service/cloudformation/sam/sim-cfn-sam-function.iso.test.ts
+++ b/src/service/cloudformation/sam/sim-cfn-sam-function.iso.test.ts
@@ -1,0 +1,356 @@
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimIamRole } from "../../iam/role/sim-iam-role.js";
+import type { SimLambdaFunction } from "../../lambda/function/sim-lambda-function.js";
+
+describe("SAM Serverless Function expansion", () => {
+  it("deploys a SAM function as an invokable Lambda function", async () => {
+    // Given a SAM template declaring one function with its source inline
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "rates-stack",
+      template: {
+        Transform: "AWS::Serverless-2016-10-31",
+        Resources: {
+          Rates: {
+            Type: "AWS::Serverless::Function",
+            Properties: {
+              FunctionName: "rates",
+              Handler: "index.handler",
+              Runtime: "nodejs22.x",
+              InlineCode: "exports.handler = async () => 'from SAM';",
+            },
+          },
+        },
+      },
+    });
+
+    // Then the SAM logical ID is a simulated Lambda function
+    const functionResource = stack.getResource("Rates");
+    assertNonNullable(functionResource);
+    assertIdentical(functionResource.type, "AWS::Lambda::Function");
+    assertIdentical(
+      functionResource.simResource,
+      simAws.lambda().getSimFunctionByName("rates"),
+    );
+
+    // And nothing about the template was left unsupported
+    assertArrayLength(stack.skippedResources, 0);
+
+    // And the function runs the source the template held inline
+    const output = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "rates" }));
+
+    assertIdentical(output.StatusCode, 200);
+    assertNonNullable(output.Payload);
+    assertIdentical(
+      JSON.parse(Buffer.from(output.Payload).toString()),
+      "from SAM",
+    );
+  });
+
+  it("carries the function configuration onto the Lambda function", async () => {
+    // Given a SAM function stating every property the expansion carries
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "rates-config-stack",
+      template: {
+        Transform: "AWS::Serverless-2016-10-31",
+        Resources: {
+          Rates: {
+            Type: "AWS::Serverless::Function",
+            Properties: {
+              FunctionName: "configured-rates",
+              Handler: "rates.handler",
+              Runtime: "nodejs22.x",
+              Timeout: 42,
+              MemorySize: 512,
+              Description: "Exchange rates",
+              Environment: { Variables: { TABLE_NAME: "rates-table" } },
+              InlineCode: "exports.handler = async () => 'rates';",
+            },
+          },
+        },
+      },
+    });
+
+    // Then the simulated function was created with what the SAM Resource said
+    const simFunction = stack.getResource("Rates")
+      ?.simResource as SimLambdaFunction;
+    assertNonNullable(simFunction);
+
+    assertIdentical(simFunction.name, "configured-rates");
+    assertIdentical(simFunction.handlerName, "rates.handler");
+    assertIdentical(simFunction.runtimeName, "nodejs22.x");
+    assertIdentical(simFunction.timeoutSeconds, 42);
+    assertIdentical(simFunction.memorySizeMb, 512);
+    assertIdentical(simFunction.description, "Exchange rates");
+    assertIdentical(
+      simFunction.environment.variables()["TABLE_NAME"],
+      "rates-table",
+    );
+  });
+
+  it("names the function from the SAM logical ID where the template does not", async () => {
+    // Given a SAM function that names itself nothing
+    const simAws = new SimAws();
+
+    // When it is deployed
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "unnamed-rates-stack",
+      template: {
+        Transform: "AWS::Serverless-2016-10-31",
+        Resources: {
+          Rates: {
+            Type: "AWS::Serverless::Function",
+            Properties: {
+              Handler: "index.handler",
+              Runtime: "nodejs22.x",
+              InlineCode: "exports.handler = async () => 'unnamed';",
+            },
+          },
+        },
+      },
+    });
+
+    // Then the function is named after the logical ID, as CloudFormation names
+    // an unnamed function from one
+    assertNonNullable(simAws.lambda().getSimFunctionByName("Rates"));
+  });
+
+  it("answers Ref and Fn::GetAtt against the SAM logical ID", async () => {
+    // Given a SAM template whose Outputs read the function by its SAM name
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "rates-outputs-stack",
+      template: {
+        Transform: "AWS::Serverless-2016-10-31",
+        Resources: {
+          Rates: {
+            Type: "AWS::Serverless::Function",
+            Properties: {
+              FunctionName: "referenced-rates",
+              Handler: "index.handler",
+              Runtime: "nodejs22.x",
+              InlineCode: "exports.handler = async () => 'rates';",
+            },
+          },
+        },
+        Outputs: {
+          FunctionName: { Value: { Ref: "Rates" } },
+          FunctionArn: { Value: { "Fn::GetAtt": ["Rates", "Arn"] } },
+        },
+      },
+    });
+
+    // Then they answer what they answer for the function it expanded into
+    const simFunction = stack.getResource("Rates")
+      ?.simResource as SimLambdaFunction;
+    assertNonNullable(simFunction);
+
+    assertIdentical(stack.output("FunctionName"), "referenced-rates");
+    assertIdentical(stack.output("FunctionArn"), simFunction.arn);
+  });
+
+  it("backs the function with a handler bound by logical ID", async () => {
+    // Given a SAM function whose CodeUri names a directory nothing reads
+    const simAws = new SimAws();
+    const observedEvents: unknown[] = [];
+
+    // When it is deployed with a handler bound to its logical ID
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "bound-rates-stack",
+      template: {
+        Transform: "AWS::Serverless-2016-10-31",
+        Resources: {
+          Rates: {
+            Type: "AWS::Serverless::Function",
+            Properties: {
+              FunctionName: "bound-rates",
+              CodeUri: "src/rates/",
+              Handler: "index.handler",
+              Runtime: "nodejs22.x",
+            },
+          },
+        },
+      },
+      bindings: [
+        {
+          logicalId: "Rates",
+          handler: (event: { currency: string }) => {
+            observedEvents.push(event);
+            return `rate for ${event.currency}`;
+          },
+        },
+      ],
+    });
+
+    // Then invoking the function runs the bound handler in-process
+    const output = await simAws.lambda().invoke(
+      new InvokeCommand({
+        FunctionName: "bound-rates",
+        Payload: JSON.stringify({ currency: "GBP" }),
+      }),
+    );
+
+    assertNonNullable(output.Payload);
+    assertIdentical(
+      JSON.parse(Buffer.from(output.Payload).toString()),
+      "rate for GBP",
+    );
+    assertArrayLength(observedEvents, 1);
+    assertArrayLength(stack.skippedResources, 0);
+  });
+
+  it("runs the function as the execution Role it was expanded with", async () => {
+    // Given a SAM function that names no Role of its own
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "rates-role-stack",
+      template: {
+        Transform: "AWS::Serverless-2016-10-31",
+        Resources: {
+          Rates: {
+            Type: "AWS::Serverless::Function",
+            Properties: {
+              FunctionName: "roled-rates",
+              Handler: "index.handler",
+              Runtime: "nodejs22.x",
+              InlineCode: "exports.handler = async () => 'rates';",
+            },
+          },
+        },
+      },
+    });
+
+    // Then the Stack holds an execution Role named after the function
+    const roleResource = stack.getResource("RatesRole");
+    assertNonNullable(roleResource);
+    assertIdentical(roleResource.type, "AWS::IAM::Role");
+
+    // And the function runs as it
+    const role = roleResource.simResource as SimIamRole;
+    const simFunction = stack.getResource("Rates")
+      ?.simResource as SimLambdaFunction;
+    assertNonNullable(role);
+    assertNonNullable(simFunction);
+    assertIdentical(simFunction.roleArn, role.arn);
+  });
+
+  it("conditions the function and its Role the way the template did", async () => {
+    // Given a SAM function the template conditions out
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "conditioned-rates-stack",
+      template: {
+        Transform: "AWS::Serverless-2016-10-31",
+        Parameters: { Stage: { Type: "String" } },
+        Conditions: {
+          IsProduction: { "Fn::Equals": [{ Ref: "Stage" }, "production"] },
+        },
+        Resources: {
+          Rates: {
+            Type: "AWS::Serverless::Function",
+            Condition: "IsProduction",
+            Properties: {
+              FunctionName: "conditioned-rates",
+              Handler: "index.handler",
+              Runtime: "nodejs22.x",
+              InlineCode: "exports.handler = async () => 'rates';",
+            },
+          },
+        },
+      },
+      parameters: { Stage: "test" },
+    });
+
+    // Then neither the function nor the Role it would have run as was created
+    assertUndefined(stack.getResource("Rates"));
+    assertUndefined(stack.getResource("RatesRole"));
+    assertUndefined(simAws.lambda().getSimFunctionByName("conditioned-rates"));
+  });
+
+  it("carries what the SAM Resource depends on onto the function", async () => {
+    // Given a SAM function and a Bucket each declaring they need the other
+    // first, which the Stack can only see as a cycle if the function kept what
+    // the SAM Resource depended on
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const deployment = simAws.cloudFormation().deployTemplate({
+      stackName: "circular-rates-stack",
+      template: {
+        Transform: "AWS::Serverless-2016-10-31",
+        Resources: {
+          Rates: {
+            Type: "AWS::Serverless::Function",
+            DependsOn: "RatesBucket",
+            Properties: {
+              FunctionName: "circular-rates",
+              Handler: "index.handler",
+              Runtime: "nodejs22.x",
+              InlineCode: "exports.handler = async () => 'rates';",
+            },
+          },
+          RatesBucket: {
+            Type: "AWS::S3::Bucket",
+            DependsOn: "Rates",
+            Properties: { BucketName: "rates-bucket" },
+          },
+        },
+      },
+    });
+
+    // Then the Stack refuses the dependencies it cannot resolve
+    const error = await assertThrowsErrorAsync(async () => deployment);
+
+    assertStringIncludes(
+      error.message,
+      "Could not resolve simulated CloudFormation Resource dependencies",
+    );
+  });
+
+  it("expands a function that states nothing beyond the defaults", async () => {
+    // Given a SAM function taking everything it has from Globals
+    const simAws = new SimAws();
+
+    // When it is deployed with a handler bound to it
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "defaulted-rates-stack",
+      template: {
+        Transform: "AWS::Serverless-2016-10-31",
+        Globals: {
+          Function: { Handler: "index.handler", Runtime: "nodejs22.x" },
+        },
+        Resources: { Rates: { Type: "AWS::Serverless::Function" } },
+      },
+      bindings: [{ logicalId: "Rates", handler: () => "defaulted rates" }],
+    });
+
+    // Then the function was created from the defaults alone
+    const simFunction = simAws.lambda().getSimFunctionByName("Rates");
+    assertNonNullable(simFunction);
+    assertIdentical(simFunction.runtimeName, "nodejs22.x");
+  });
+});

--- a/src/service/cloudformation/sam/sim-cfn-sam-globals.iso.test.ts
+++ b/src/service/cloudformation/sam/sim-cfn-sam-globals.iso.test.ts
@@ -1,0 +1,119 @@
+import { assertIdentical, assertNonNullable } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimLambdaFunction } from "../../lambda/function/sim-lambda-function.js";
+import { simCfnSamFunctionTemplateFactory } from "./function/sim-cfn-sam-function-template.factory.js";
+
+describe("SAM Globals Function defaults", () => {
+  it("applies the defaults to every function in the template", async () => {
+    // Given a SAM template stating defaults and two functions taking them
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "globals-stack",
+      template: {
+        Transform: "AWS::Serverless-2016-10-31",
+        Globals: {
+          Function: {
+            Handler: "index.handler",
+            Runtime: "nodejs22.x",
+            Timeout: 10,
+          },
+        },
+        Resources: {
+          Rates: {
+            Type: "AWS::Serverless::Function",
+            Properties: {
+              InlineCode: "exports.handler = async () => 'rates';",
+            },
+          },
+          Quotes: {
+            Type: "AWS::Serverless::Function",
+            Properties: {
+              InlineCode: "exports.handler = async () => 'quotes';",
+            },
+          },
+        },
+      },
+    });
+
+    // Then both functions were created with them
+    for (const logicalId of ["Rates", "Quotes"]) {
+      const simFunction = stack.getResource(logicalId)
+        ?.simResource as SimLambdaFunction;
+      assertNonNullable(simFunction);
+
+      assertIdentical(simFunction.handlerName, "index.handler");
+      assertIdentical(simFunction.runtimeName, "nodejs22.x");
+      assertIdentical(simFunction.timeoutSeconds, 10);
+    }
+  });
+
+  it("prefers what the function states over the default", async () => {
+    // Given a function stating a timeout of its own over the default one
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "globals-override-stack",
+      template: simCfnSamFunctionTemplateFactory.make({
+        globals: { Timeout: 10 },
+        functionProperties: { Timeout: 30 },
+      }),
+    });
+
+    // Then the function was created with its own
+    const simFunction = stack.getResource("Rates")
+      ?.simResource as SimLambdaFunction;
+    assertNonNullable(simFunction);
+
+    assertIdentical(simFunction.timeoutSeconds, 30);
+  });
+
+  it("merges the variables a function adds with the ones every function gets", async () => {
+    // Given a function adding an environment variable to the default ones
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "globals-environment-stack",
+      template: simCfnSamFunctionTemplateFactory.make({
+        globals: { Environment: { Variables: { STAGE: "test" } } },
+        functionProperties: {
+          Environment: { Variables: { TABLE_NAME: "rates-table" } },
+        },
+      }),
+    });
+
+    // Then the function has both, rather than only the one it stated
+    const simFunction = stack.getResource("Rates")
+      ?.simResource as SimLambdaFunction;
+    assertNonNullable(simFunction);
+
+    const variables = simFunction.environment.variables();
+    assertIdentical(variables["STAGE"], "test");
+    assertIdentical(variables["TABLE_NAME"], "rates-table");
+  });
+
+  it("gives the default environment to a function stating none", async () => {
+    // Given a function that states no environment of its own
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "globals-only-environment-stack",
+      template: simCfnSamFunctionTemplateFactory.make({
+        globals: { Environment: { Variables: { STAGE: "test" } } },
+      }),
+    });
+
+    // Then it runs with the variables every function gets
+    const simFunction = stack.getResource("Rates")
+      ?.simResource as SimLambdaFunction;
+    assertNonNullable(simFunction);
+
+    assertIdentical(simFunction.environment.variables()["STAGE"], "test");
+  });
+});

--- a/src/service/cloudformation/sam/sim-cfn-sam-globals.ts
+++ b/src/service/cloudformation/sam/sim-cfn-sam-globals.ts
@@ -1,0 +1,78 @@
+import type { CfnTemplateBodyRecord } from "../template/sim-cfn-template.js";
+import type { SimCfnTemplateValueRecord } from "../template/value/sim-cfn-template-value.js";
+import { isSamTemplateRecord } from "./sim-cfn-sam-record.js";
+
+/**
+ * The `Globals.Function` defaults a template states. A template carrying no
+ * `Globals` section states none.
+ */
+export function samFunctionGlobals(
+  template: CfnTemplateBodyRecord,
+): SimCfnTemplateValueRecord {
+  const globals = template["Globals"];
+
+  if (!isSamTemplateRecord(globals)) {
+    return {};
+  }
+
+  const functionGlobals = globals["Function"];
+
+  return isSamTemplateRecord(functionGlobals) ? functionGlobals : {};
+}
+
+/**
+ * The properties a function is expanded with, from the `Globals.Function`
+ * defaults and what the function states for itself.
+ *
+ * A property the function states wins outright, apart from the environment
+ * variables, which are merged key by key so a function adding one of its own
+ * still gets the ones every function is given.
+ */
+export function samMergedFunctionProperties(
+  globals: SimCfnTemplateValueRecord,
+  properties: SimCfnTemplateValueRecord,
+): SimCfnTemplateValueRecord {
+  return {
+    ...globals,
+    ...properties,
+    ...mergedEnvironment(globals["Environment"], properties["Environment"]),
+  };
+}
+
+/**
+ * The `Environment` of a function that states one over a default that states
+ * one too. Either side missing leaves the other where the merge above put it.
+ */
+function mergedEnvironment(
+  globalEnvironment: unknown,
+  ownEnvironment: unknown,
+): SimCfnTemplateValueRecord {
+  if (
+    !isSamTemplateRecord(globalEnvironment) ||
+    !isSamTemplateRecord(ownEnvironment)
+  ) {
+    return {};
+  }
+
+  return {
+    Environment: {
+      ...globalEnvironment,
+      ...ownEnvironment,
+      Variables: {
+        ...environmentVariables(globalEnvironment),
+        ...environmentVariables(ownEnvironment),
+      },
+    },
+  };
+}
+
+/**
+ * The `Variables` an environment holds, as a record to merge.
+ */
+function environmentVariables(
+  environment: SimCfnTemplateValueRecord,
+): SimCfnTemplateValueRecord {
+  const variables = environment["Variables"];
+
+  return isSamTemplateRecord(variables) ? variables : {};
+}

--- a/src/service/cloudformation/sam/sim-cfn-sam-record.ts
+++ b/src/service/cloudformation/sam/sim-cfn-sam-record.ts
@@ -1,0 +1,17 @@
+import { isRecord } from "../../../util/type-guard/record.js";
+import type { SimCfnTemplateValueRecord } from "../template/value/sim-cfn-template-value.js";
+
+/**
+ * Whether a template value is an object, and so something the expansion can
+ * read properties off.
+ *
+ * A SAM template is written by hand more often than a CloudFormation one is,
+ * and the expansion reads what it finds. A property in the wrong shape is left
+ * for the Resource it expands into to refuse, where the diagnostic names the
+ * Resource type and the property.
+ */
+export function isSamTemplateRecord(
+  value: unknown,
+): value is SimCfnTemplateValueRecord {
+  return isRecord(value);
+}

--- a/src/service/cloudformation/sam/sim-cfn-sam-transform.iso.test.ts
+++ b/src/service/cloudformation/sam/sim-cfn-sam-transform.iso.test.ts
@@ -1,0 +1,90 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimLambdaFunction } from "../../lambda/function/sim-lambda-function.js";
+
+const ratesFunction = {
+  Type: "AWS::Serverless::Function",
+  Properties: {
+    FunctionName: "rates",
+    Handler: "index.handler",
+    Runtime: "nodejs22.x",
+    InlineCode: "exports.handler = async () => 'rates';",
+  },
+};
+
+describe("SAM transform", () => {
+  it("expands the SAM Resources of a template naming another macro too", async () => {
+    // Given a template running SAM alongside a macro of its own
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "two-macro-stack",
+      template: {
+        Transform: ["AWS::LanguageExtensions", "AWS::Serverless-2016-10-31"],
+        Resources: { Rates: ratesFunction },
+      },
+    });
+
+    // Then the SAM function was expanded, since SAM is one of the macros the
+    // template named
+    const simFunction = stack.getResource("Rates")
+      ?.simResource as SimLambdaFunction;
+    assertNonNullable(simFunction);
+    assertIdentical(simFunction.name, "rates");
+  });
+
+  it("records a SAM function as unsupported without the transform", async () => {
+    // Given a template declaring a SAM function while naming no transform,
+    // which is a template real CloudFormation has no expansion for either
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "untransformed-stack",
+      template: { Resources: { Rates: ratesFunction } },
+    });
+
+    // Then the function is recorded as unsupported rather than created
+    assertArrayLength(stack.skippedResources, 1);
+    const skipped = stack.skippedResources[0];
+    assertNonNullable(skipped);
+    assertIdentical(skipped.logicalId, "Rates");
+    assertIdentical(
+      skipped.skippedReason,
+      "Unsupported sim CloudFormation Resource service Serverless",
+    );
+  });
+
+  it("records a SAM Resource type it does not expand as unsupported", async () => {
+    // Given a SAM template holding a function and a table
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "simple-table-stack",
+      template: {
+        Transform: "AWS::Serverless-2016-10-31",
+        Resources: {
+          Rates: ratesFunction,
+          RatesTable: {
+            Type: "AWS::Serverless::SimpleTable",
+            Properties: { TableName: "rates" },
+          },
+        },
+      },
+    });
+
+    // Then the function deployed, and the table is recorded the way any
+    // Resource type nothing models is
+    assertNonNullable(simAws.lambda().getSimFunctionByName("rates"));
+    assertArrayLength(stack.skippedResources, 1);
+    assertIdentical(stack.skippedResources[0].logicalId, "RatesTable");
+  });
+});

--- a/src/service/cloudformation/sam/sim-cfn-sam-transform.ts
+++ b/src/service/cloudformation/sam/sim-cfn-sam-transform.ts
@@ -1,0 +1,64 @@
+import type { CfnTemplateBodyRecord } from "../template/sim-cfn-template.js";
+
+/**
+ * The macro a template names to have its `AWS::Serverless::*` Resources
+ * expanded into the plain Resource types CloudFormation deploys.
+ */
+export const samTransformName = "AWS::Serverless-2016-10-31";
+
+/**
+ * Whether the template asks for the SAM transform.
+ *
+ * `Transform` holds either the one macro name or a list of them. A template
+ * running another macro alongside SAM names both.
+ */
+export function templateNamesSamTransform(
+  template: CfnTemplateBodyRecord,
+): boolean {
+  const transform = template["Transform"];
+
+  if (typeof transform === "string") {
+    return transform === samTransformName;
+  }
+
+  if (Array.isArray(transform)) {
+    return transform.includes(samTransformName);
+  }
+
+  return false;
+}
+
+/**
+ * The template without the sections the expansion has consumed.
+ *
+ * The expanded body is the one CloudFormation deploys, and by then SAM has
+ * been applied. The transform is off the list, and the `Globals` defaults are
+ * written into the Resources that took them. Another macro named alongside SAM
+ * stays named, since expanding SAM says nothing about it.
+ */
+export function withoutSamSections(
+  template: CfnTemplateBodyRecord,
+): CfnTemplateBodyRecord {
+  return {
+    ...template,
+    Globals: undefined,
+    Transform: remainingTransforms(template["Transform"]),
+  };
+}
+
+/**
+ * The macros still to run once SAM is off the `Transform` section, where the
+ * template named any.
+ */
+function remainingTransforms(transform: unknown): string[] | undefined {
+  if (!Array.isArray(transform)) {
+    return undefined;
+  }
+
+  const remaining = transform.filter(
+    (name: unknown): name is string =>
+      typeof name === "string" && name !== samTransformName,
+  );
+
+  return remaining.length > 0 ? remaining : undefined;
+}

--- a/src/service/cloudformation/template/sim-cfn-template.ts
+++ b/src/service/cloudformation/template/sim-cfn-template.ts
@@ -18,6 +18,7 @@ import type {
 } from "./condition/sim-cfn-conditions.js";
 import { SimCfnResourceConditions } from "./condition/sim-cfn-resource-conditions.js";
 import type { SimCfnExports } from "../export/sim-cfn-exports.js";
+import { samExpandedTemplate } from "../sam/sim-cfn-sam-expansion.js";
 
 /**
  * Parsed CloudFormation template body accepted by the simulator.
@@ -95,6 +96,10 @@ export class SimCfnTemplate {
 
   /**
    * Parse a JSON CloudFormation template body.
+   *
+   * A template naming the SAM transform is expanded on the way through, so
+   * what the Stack is deployed from holds the Resource types simulated AWS
+   * creates rather than the `AWS::Serverless::*` ones the author wrote.
    */
   static fromJson(
     templateBody: JSONString<CfnTemplateBodyRecord>,
@@ -114,7 +119,7 @@ export class SimCfnTemplate {
     }
 
     return new SimCfnTemplate({
-      template,
+      template: samExpandedTemplate(template),
       parameters: properties.parameters,
       stackName: properties.stackName,
       accountRegionScope: properties.accountRegionScope,


### PR DESCRIPTION
A template naming the `AWS::Serverless-2016-10-31` transform now has its `AWS::Serverless::Function` Resources expanded into the `AWS::Lambda::Function` and `AWS::IAM::Role` the simulator already creates, where the function was recorded as unsupported and the Stack deployed without it. The expanded function keeps the SAM logical ID, so `Ref`, `Fn::GetAtt` and a handler bound by logical ID all reach it, and `CodeUri` stays unread. `Globals.Function` supplies the defaults, with a value on the function itself winning and environment variables merged key by key. `Policies` reach the generated Role as inline policy documents and managed policy ARNs, while SAM policy templates are left ungenerated because the default `SimIamAllowAllAuth` authorizes the same calls either way. `Events`, the other `AWS::Serverless::*` Resource types and the deployment properties stay out, and carry on being recorded as unsupported. The expansion runs on the parsed body ahead of `SimCfnTemplate`, and is tested against JSON templates, so it lands independently of the YAML parsing in #746.

Resolves #748