### PR TITLE
docs: add an AI skill page

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ npm i -D @kensio/yulin
 
 ## Feature specific docs
 
+- [AI skill](./docs/ai-skill "Yulin AI skill docs")
 - [The AWS CLI](./docs/cli "The AWS CLI against simulated AWS docs")
 - [AWS SDK interception](./docs/sdk "Simulated AWS SDK docs")
 - [Serving on localhost](./docs/serve "Serving simulated AWS on localhost docs")

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ behaviour and includes example code that can be copied into tests or local devel
 
 ## Feature documentation
 
+- [AI skill](./ai-skill/ "Yulin AI skill usage docs")
 - [The AWS CLI](./cli/ "The AWS CLI against simulated AWS usage docs")
 - [AWS SDK interception](./sdk/ "Simulated AWS SDK usage docs")
 - [Event factories](./factories/ "Test factories for AWS event shapes usage docs")

--- a/docs/ai-skill/README.md
+++ b/docs/ai-skill/README.md
@@ -1,0 +1,62 @@
+# AI skill
+
+Yulin has an AI skill that teaches a coding agent how to test AWS code with the simulator well. It
+is `yulin-aws-simulation`, a `SKILL.md` written to the
+[Agent Skills specification](https://agentskills.io/specification) and installable into Claude Code,
+Codex CLI, Cursor, VS Code and anything else that reads one. It covers the part that lives outside
+the API.
+
+These docs and the skill answer different questions. A page here says what a simulated service does
+and what its commands take. The skill says what to do with that. An AI agent reaching for Yulin
+without it tends to build a harness around the simulator, leave hand-rolled stubs in place beside
+it, or write an `instanceof` check against an SDK exception class that passes in production and
+fails against the simulation.
+
+## Install
+
+```bash
+npx @kensio/skills add yulin-aws-simulation
+```
+
+That copies the skill into `.agents/skills/`, the directory Codex CLI, Cursor, VS Code and Gemini
+CLI read. `--agent claude` puts it in `.claude/skills/`, and `--user` installs it under your home
+directory for every project.
+
+As a Claude Code plugin:
+
+```bash
+claude plugin marketplace add KensioSoftware/kensio.ai
+claude plugin install yulin-aws-simulation@kensio
+```
+
+It is also on npm as `@kensio/yulin-aws-simulation`, and every
+[kensio.ai release](https://github.com/KensioSoftware/kensio.ai/releases) carries it as a zip for a
+machine with no registry reach.
+
+## What it covers
+
+- Using `SimAws` and `SimSdk` directly, and spotting the helper class or `setupSimulatedAws()`
+  wrapper that starts to grow around them.
+- One synthesized CDK template behind the tests, the dev server and production, deployed with
+  `deployTemplateFile` or `deployCdkOut`.
+- When to register a resource at a chosen id, and when to deploy the stack that creates it.
+- Interception over hand-rolled stubs, down to the requests a fake accepts and the simulation
+  refuses.
+- Freezing the clock, then advancing it on purpose.
+- Assertions that read the simulation back.
+- Why service errors match by `name` and not by `instanceof`.
+- Deploying an expensive stack once per test file.
+- Running a handler as a real simulated Lambda, under its execution role, its declared environment
+  and its own log group.
+- Refusals as a feature, and gaps raised upstream.
+
+## Reading the API alongside it
+
+The skill sends the AI agent to these docs for anything API-shaped, and
+[llms.txt](https://yulinsim.dev/llms.txt) is the index it uses. Every page here is available as
+plain markdown by appending `llms.txt` to its URL, one file per guide and one per simulated service.
+That index works with or without the skill installed.
+
+The skill is maintained at
+[KensioSoftware/kensio.ai](https://github.com/KensioSoftware/kensio.ai/tree/main/plugins/yulin-aws-simulation),
+versioned separately from Yulin and licensed Apache-2.0.


### PR DESCRIPTION
Yulin has an AI skill, yulin-aws-simulation, and nothing here said so. A user arriving at these docs had no way to find out that the judgement around the API is written down and installable.

The page covers what the skill is, how to install it through the three routes kensio.ai publishes, what it covers section by section, and how it sits alongside these pages. The split is the thing worth stating: a page here says what a simulated service does and what its commands take, and the skill says what to do with that. An AI agent reaching for Yulin without it tends to build a harness around the simulator, leave hand-rolled stubs beside it, or write an instanceof check against an SDK exception class that passes in production and fails against the simulation.

"AI" rather than "agent" in the title and the slug, since that is the word most readers recognise. The term "agent" is kept where it is the precise one, in the Agent Skills specification and in what reads a SKILL.md.

The H1 is what the docs site turns into the sidebar label, so it is two words. The opening sentence is what llms.txt turns into the page's one-line description, so it says what the skill is for rather than only naming it.

Listed under Feature documentation in docs/README.md and under Feature specific docs in the root README.

Brief, concise description of the change:

<!-- CodeRabbit will fill in a more detailed description once this is open. -->

<!-- If there is an issue, link it here:
     Resolves https://github.com/KensioSoftware/yulin/issues/N -->

- [ ] Conventional commit message, used as the title

- [ ] Conventional branch name, like `feat/concise-description`
- [ ] Full check with `pnpm run check` passed
- [ ] Rebased off latest main
- [ ] User-facing behaviour is documented in `docs/`

See https://www.conventionalcommits.org/en/v1.0.0/

<!-- One exception to that spec: no `!` in the title and no `BREAKING CHANGE:`
     footer. Major versions are published by hand here, so the release run
     refuses one rather than shipping it. -->
