### PR TITLE
docs: AI Skill page links

### DIFF
--- a/docs/ai-skill/README.md
+++ b/docs/ai-skill/README.md
@@ -57,6 +57,6 @@ The skill sends the AI agent to these docs for anything API-shaped, and
 plain markdown by appending `llms.txt` to its URL, one file per guide and one per simulated service.
 That index works with or without the skill installed.
 
-The skill is maintained at
-[KensioSoftware/kensio.ai](https://github.com/KensioSoftware/kensio.ai/tree/main/plugins/yulin-aws-simulation),
-versioned separately from Yulin and licensed Apache-2.0.
+The skill lives at
+[kensio.ai/skills/yulin-aws-simulation](https://kensio.ai/skills/yulin-aws-simulation), versioned
+separately from Yulin and licensed Apache-2.0.

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -1,4 +1,4 @@
-# The AWS CLI against simulated AWS
+# AWS CLI
 
 The real `aws` CLI reaches a served simulated environment over a local endpoint URL, and twenty of
 Yulin's twenty-five SDK-facing services answer it.

--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -1,4 +1,4 @@
-# Simulated Cognito user pools
+# Simulated Cognito IDP
 
 Yulin includes a simulated Cognito user pool directory for tests and local development. Pools and
 their app clients are held in memory, and every operation is authorized by simulated IAM.


### PR DESCRIPTION
Brief, concise description of the change:

<!-- CodeRabbit will fill in a more detailed description once this is open. -->

<!-- If there is an issue, link it here:
     Resolves https://github.com/KensioSoftware/yulin/issues/N -->

- [ ] Conventional commit message, used as the title

- [ ] Conventional branch name, like `feat/concise-description`
- [ ] Full check with `pnpm run check` passed
- [ ] Rebased off latest main
- [ ] User-facing behaviour is documented in `docs/`

See https://www.conventionalcommits.org/en/v1.0.0/

<!-- One exception to that spec: no `!` in the title and no `BREAKING CHANGE:`
     footer. Major versions are published by hand here, so the release run
     refuses one rather than shipping it. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the AI skill documentation link.
  * Simplified the AWS CLI documentation title.
  * Updated the Cognito documentation title to reference the simulated Cognito identity provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->