### PR TITLE
feat: publish Lambda versions and aliases

### DIFF
--- a/docs/serve/README.md
+++ b/docs/serve/README.md
@@ -457,7 +457,7 @@ aws lambda create-function --function-name orders \
   --zip-file fileb://orders.zip
 ```
 
-The operations served are the sixteen simulated Lambda implements:
+The operations served are sixteen of the ones simulated Lambda implements:
 
 - **Functions** — `CreateFunction`, `GetFunction`, `DeleteFunction`, `Invoke`
 - **Function URLs** — `CreateFunctionUrlConfig`, `GetFunctionUrlConfig`,
@@ -465,6 +465,9 @@ The operations served are the sixteen simulated Lambda implements:
 - **Permissions** — `AddPermission`, `RemovePermission`, `GetPolicy`
 - **Event source mappings** — `CreateEventSourceMapping`, `GetEventSourceMapping`,
   `ListEventSourceMappings`, `DeleteEventSourceMapping`
+
+The version and alias operations have no route here yet, and reach the simulation through `SimAws`
+or SDK interception instead.
 
 Anything else is refused as `NotImplemented`, which an SDK raises under that name. The refusal names
 the path it arrived at. `aws lambda list-functions` reports that `GET /2015-03-31/functions` is

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -702,6 +702,88 @@ console.log(dryRunOutput.StatusCode);
 `Event` invocation handler errors are dropped. Asynchronous retries and failure destinations are
 left out so far.
 
+## Versions and aliases
+
+`PublishVersionCommand` copies a function as it stands and numbers the copy. The first is version
+`1`, and each later one counts up. The copy keeps the code, handler, timeout, memory and
+environment it was published with. `CreateAliasCommand` gives one of those versions a name, and
+`UpdateAliasCommand` moves the name to another version, so a deployment can repoint what callers
+invoke.
+
+`InvokeCommand` and `GetFunctionCommand` take a `Qualifier` naming a version number or an alias.
+The same qualifier can travel on the `FunctionName` instead, appended to the name (`orders:live`)
+or to a function ARN. `ExecutedVersion` on the invocation output is the version number that ran,
+and an invocation through an alias reports the version behind it. Inside the handler, `context`
+carries that number as `functionVersion` and the qualified ARN as `invokedFunctionArn`.
+
+```typescript sim-lambda-versions-and-aliases
+/**
+ * Publishing a simulated Lambda function version, pointing an alias at it, and
+ * invoking through the alias.
+ */
+
+import {
+  CreateAliasCommand,
+  CreateFunctionCommand,
+  InvokeCommand,
+  ListVersionsByFunctionCommand,
+  PublishVersionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "orders",
+    Role: "arn:aws:iam::111111111111:role/OrdersRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput((_event, context) => ({
+        ranAs: context.functionVersion,
+      })),
+    },
+  }),
+);
+
+const published = await lambda.publishVersion(
+  new PublishVersionCommand({ FunctionName: "orders" }),
+);
+console.log(published.Version);
+console.log(published.FunctionArn);
+
+await lambda.createAlias(
+  new CreateAliasCommand({
+    FunctionName: "orders",
+    Name: "live",
+    FunctionVersion: published.Version,
+  }),
+);
+
+const invoked = await lambda.invoke(
+  new InvokeCommand({ FunctionName: "orders", Qualifier: "live" }),
+);
+console.log(invoked.ExecutedVersion);
+
+const versions = await lambda.listVersionsByFunction(
+  new ListVersionsByFunctionCommand({ FunctionName: "orders" }),
+);
+console.log(versions.Versions.map((version) => version.Version));
+```
+
+A function with no qualifier is `$LATEST`, which is what every caller that passes none reaches, and
+what `ListVersionsByFunctionCommand` lists ahead of the published versions. An alias points at a
+published version, and `$LATEST` is refused with a `ValidationException` on the version pattern, as
+it is on real Lambda. A qualifier naming no version and no alias fails with
+`ResourceNotFoundException` against the qualified ARN.
+
+`GetAliasCommand`, `ListAliasesCommand` and `DeleteAliasCommand` read and remove aliases.
+`ListAliasesCommand` takes a `FunctionVersion` to narrow the answer to the aliases on one version.
+Deleting an alias leaves the version it pointed at invokable by its number. Deleting the function
+takes its versions and aliases with it.
+
 ## Triggering a function from an SQS queue
 
 An event source mapping connects a [simulated queue](../sqs/ "Simulated SQS docs") to a function.
@@ -2512,8 +2594,12 @@ Sim Lambda currently supports:
   every hostname it serves, including a Cognito user pool domain's OAuth endpoints and the JWKS a
   token verifier fetches from the regional Cognito endpoint
 - Execution roles, evaluated against simulated IAM
+- Published versions and aliases, with `PublishVersion`, `ListVersionsByFunction`, `CreateAlias`,
+  `UpdateAlias`, `GetAlias`, `ListAliases` and `DeleteAlias`, and a `Qualifier` on `Invoke` and
+  `GetFunction`
 - IAM authorization of the Lambda commands themselves (`lambda:CreateFunction`,
-  `lambda:GetFunction`, `lambda:InvokeFunction`, and the Function URL config actions)
+  `lambda:GetFunction`, `lambda:InvokeFunction`, the Function URL config actions, and the version
+  and alias actions)
 - AWS-like validation and errors, such as `ResourceConflictException` for a duplicate function name
 - The `AWS::Lambda::Function`, `AWS::Lambda::Url`, `AWS::Lambda::Permission` and
   `AWS::Lambda::EventSourceMapping` CloudFormation resources, with `Ref`/`Fn::GetAtt` support and
@@ -2526,10 +2612,10 @@ Sim Lambda currently supports:
 
 Current documented limitations:
 
-- Only `CreateFunctionCommand`, `GetFunctionCommand`, `InvokeCommand`, the permission commands
-  (`AddPermissionCommand`, `RemovePermissionCommand`, `GetPolicyCommand`), the Function URL config
-  commands and the event source mapping commands are supported. `UpdateFunctionCode`,
-  `DeleteFunction` and function listing are absent so far.
+- Only `CreateFunctionCommand`, `GetFunctionCommand`, `DeleteFunctionCommand`, `InvokeCommand`, the
+  permission commands (`AddPermissionCommand`, `RemovePermissionCommand`, `GetPolicyCommand`), the
+  version and alias commands, the Function URL config commands and the event source mapping
+  commands are supported. `UpdateFunctionCode` and function listing are absent so far.
 - A cross-account grant is only half of what admits a call. The caller's own Account has to allow
   the action too, and its IAM has to be part of the same `SimAws` instance for its policies to be
   found. A caller from an Account outside the simulation is denied.
@@ -2540,8 +2626,8 @@ Current documented limitations:
   `PrincipalOrgID` and `InvokedViaFunctionUrl` are written into the statement so `GetPolicy` reports
   the grant that was made, and no value is supplied for them, so a statement carrying one never
   matches.
-- `Qualifier`, `RevisionId` and `EventSourceToken` on the permission commands are left out, along
-  with versions and aliases.
+- `Qualifier`, `RevisionId` and `EventSourceToken` on the permission commands are left out. A
+  permission granted on a function admits an invocation of any of its versions.
 - `requestContext.authorizer.iam` reports `accessKey` as empty, and `callerId` and `userId` as the
   caller ARN rather than the opaque unique id real AWS uses. `cognitoIdentity` and `principalOrgId`
   are always null.
@@ -2550,7 +2636,15 @@ Current documented limitations:
   buffered.
 - A function has at most one Function URL, and qualified (version or alias) Function URLs are left
   out.
-- Function versions, aliases, and qualifiers are left out (`Version` is always `$LATEST`).
+- A published version keeps what it was published with, and `UpdateFunctionCode` is absent, so
+  `$LATEST` has no way to drift from it yet. The `CodeSha256` and `RevisionId` checks
+  `PublishVersion` makes are left out, along with `Description` on a published version, alias
+  `RoutingConfig` weights, provisioned concurrency, and the `Marker`/`MaxItems` paging on the two
+  listings.
+- A qualified function ARN reaches simulated Lambda itself. The services that name a function
+  elsewhere (S3 notifications, SNS subscriptions, CloudWatch Logs subscriptions, Cognito triggers,
+  EventBridge targets, event source mappings and the CloudFormation target-function reader) still
+  refuse or drop a qualifier.
 - The vm runtime supports CommonJS function code only. ES module source (`.mjs` / `export` syntax)
   has yet to land.
 - A handler function reference is recorded through the process console and the process standard
@@ -2627,5 +2721,7 @@ Current documented limitations:
 - The `vm` context is a namespacing convenience rather than a security boundary. Function code runs
   in-process with the same trust as the test suite itself. Do not run untrusted code through the
   simulator.
-- Only Function URLs are served over HTTP by `serveSimAws`. The Lambda control-plane API itself is
-  not served, and SDK commands go through `SimAws` or [SDK interception](../../sdk/) instead.
+- `serveSimAws` serves sixteen of these operations over HTTP, listed in the
+  [serving docs](../../serve/README.md#lambda-over-the-endpoint). The version and alias operations have no
+  route there yet, and reach the simulation through `SimAws` or
+  [SDK interception](../../sdk/) instead.

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -780,9 +780,14 @@ it is on real Lambda. A qualifier naming no version and no alias fails with
 `ResourceNotFoundException` against the qualified ARN.
 
 `GetAliasCommand`, `ListAliasesCommand` and `DeleteAliasCommand` read and remove aliases.
-`ListAliasesCommand` takes a `FunctionVersion` to narrow the answer to the aliases on one version.
+`ListAliasesCommand` takes a `FunctionVersion` to narrow the answer to the aliases on one version,
+and a version nothing published is reported as missing rather than answered with an empty listing.
 Deleting an alias leaves the version it pointed at invokable by its number. Deleting the function
 takes its versions and aliases with it.
+
+The version and alias commands act on the function itself, so they take its name or its unqualified
+ARN. A `FunctionName` carrying a qualifier (`orders:live`) is refused with an
+`InvalidParameterValueException` rather than acted on as though the qualifier were absent.
 
 ## Triggering a function from an SQS queue
 

--- a/docs/services/lambda/sim-lambda-versions-and-aliases.example.ts
+++ b/docs/services/lambda/sim-lambda-versions-and-aliases.example.ts
@@ -1,0 +1,54 @@
+/**
+ * Publishing a simulated Lambda function version, pointing an alias at it, and
+ * invoking through the alias.
+ */
+
+import {
+  CreateAliasCommand,
+  CreateFunctionCommand,
+  InvokeCommand,
+  ListVersionsByFunctionCommand,
+  PublishVersionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "orders",
+    Role: "arn:aws:iam::111111111111:role/OrdersRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput((_event, context) => ({
+        ranAs: context.functionVersion,
+      })),
+    },
+  }),
+);
+
+const published = await lambda.publishVersion(
+  new PublishVersionCommand({ FunctionName: "orders" }),
+);
+console.log(published.Version);
+console.log(published.FunctionArn);
+
+await lambda.createAlias(
+  new CreateAliasCommand({
+    FunctionName: "orders",
+    Name: "live",
+    FunctionVersion: published.Version,
+  }),
+);
+
+const invoked = await lambda.invoke(
+  new InvokeCommand({ FunctionName: "orders", Qualifier: "live" }),
+);
+console.log(invoked.ExecutedVersion);
+
+const versions = await lambda.listVersionsByFunction(
+  new ListVersionsByFunctionCommand({ FunctionName: "orders" }),
+);
+console.log(versions.Versions.map((version) => version.Version));

--- a/src/service/cloudformation/bind/validate/sim-cfn-exec-binding-matcher.ts
+++ b/src/service/cloudformation/bind/validate/sim-cfn-exec-binding-matcher.ts
@@ -1,4 +1,4 @@
-import { simLambdaFunctionArn } from "../../../lambda/function/sim-lambda-function.js";
+import { simLambdaFunctionArn } from "../../../lambda/function/sim-lambda-function-configuration.js";
 import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
 import type { SimCfnExecutableResourceBinding } from "../sim-cfn-exec-binding.type.js";
 import { SimCfnImageRepositoryTarget } from "./sim-cfn-image-repository-target.js";

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -53,10 +53,13 @@ Current command areas include:
   `update-function-url-config/`, `delete-function-url-config/`,
   `list-function-url-configs/`
 - `add-permission/`, `remove-permission/`, `get-policy/`
+- `publish-version/`, `list-versions-by-function/`
+- `create-alias/`, `update-alias/`, `get-alias/`, `list-aliases/`, `delete-alias/`
 - `event-source-mapping/`
 
 Commands sharing a set of collaborators are grouped behind one class per area — `command/function/`,
-`command/function-url/`, `command/permission/`, `command/event-source-mapping/` — so the `SimLambda`
+`command/function-url/`, `command/permission/`, `command/version/`, `command/alias/`,
+`command/event-source-mapping/` — so the `SimLambda`
 facade stays a delegation rather than repeating the same wiring block per command.
 `command/sim-lambda-command.types.ts` gathers the command types for the same reason.
 
@@ -333,6 +336,38 @@ execution roles.
 
 A standalone `SimLambda` (constructed directly rather than through `SimAws`) is its own run-as
 owner, keeping its ambient callers isolated.
+
+## Versions and aliases
+
+`function/version/` holds what `PublishVersion` and the alias commands act on.
+
+A published version is a copy of the function as it stood, made by
+`SimLambdaFunction.publishedAs(...)`. The copy carries the same code, handler, timeout, memory and
+environment, under a version number and a qualified ARN. It is a copy rather than a second reference to the function so
+that a later change to the function leaves what was published running what it was published as,
+which is the whole point of publishing one.
+
+Versions and aliases live in `SimLambdaFunctionVersionStore` and `SimLambdaFunctionAliasStore`,
+beside the function map rather than on the function itself. That is what keeps a bare function name
+resolving to `$LATEST` for every caller that passes no qualifier, which is most of them.
+`DeleteFunction` forgets both, as deleting a function on AWS takes its versions and aliases with it.
+
+A request names the version to act on in one of two places. It carries a `Qualifier` of its own, or
+a qualifier appended to the `FunctionName`, which may be a name or a function ARN.
+`simLambdaQualifiedFunctionOf` reads both and refuses a request that states one of each and
+disagrees with itself, as real Lambda does. `Invoke` and `GetFunction` resolve the qualifier
+through the version store. A number is a version, anything else is an alias name, and `$LATEST` or
+nothing at all is the function. A qualifier naming neither fails with `ResourceNotFoundException`
+against the qualified ARN.
+
+An alias points at a published version and only at one: `$LATEST` is refused on the API-level
+version pattern, before anything of that name is looked for. Invoking through an alias reports the
+version number it resolved to as `ExecutedVersion`, not the alias name, and the handler's context
+carries the same number and the qualified ARN.
+
+Authorization stays against the function's own ARN for now. Qualified statements in a function's
+resource policy are their own piece of work, so a permission granted on the function admits an
+invocation of any of its versions.
 
 ## Event source mappings
 
@@ -647,7 +682,10 @@ the CloudFormation engine with an "Unsupported" diagnostic.
 - running a container image: nothing reads one, so a function naming `Code.ImageUri` runs the real
   in-process handler an executable binding or a simulated ECR repository stands in with, and is
   skipped or refused where neither does
-- `UpdateFunctionCode`, `DeleteFunction`, function listing, versions, aliases and qualifiers
+- `UpdateFunctionCode` and function listing
+- `Qualifier` on the permission commands, qualified Function URLs, alias `RoutingConfig` weights,
+  provisioned concurrency, and `RevisionId`
+- version and alias operations over the served HTTP API endpoint, which routes the other sixteen
 - Lambda Layers
 - environment variables reaching a real in-process handler's module scope (see "Environment
   variables" above), and the same limitation for a time read there or a request made there

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -360,6 +360,10 @@ through the version store. A number is a version, anything else is an alias name
 nothing at all is the function. A qualifier naming neither fails with `ResourceNotFoundException`
 against the qualified ARN.
 
+`PublishVersion`, `ListVersionsByFunction` and the alias commands act on the function itself, and
+`simLambdaUnqualifiedFunctionOf` refuses a qualified `FunctionName` for them. Dropping the qualifier
+would act on something other than what the caller named.
+
 An alias points at a published version and only at one: `$LATEST` is refused on the API-level
 version pattern, before anything of that name is looked for. Invoking through an alias reports the
 version number it resolved to as `ExecutedVersion`, not the alias name, and the handler's context

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-code-input.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-code-input.ts
@@ -4,7 +4,7 @@ import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-re
 import type { SimLambdaFunctionCode } from "../../command/create-function/create-function.command.js";
 import type { SimLambdaContainerImages } from "../../function/code/image/sim-lambda-container-images.js";
 import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
-import { simLambdaFunctionArn } from "../../function/sim-lambda-function.js";
+import { simLambdaFunctionArn } from "../../function/sim-lambda-function-configuration.js";
 import type { SimLambdaHandler } from "../../function/sim-lambda-handler.type.js";
 import type { SimCfnLambdaFunctionProperties } from "./sim-cfn-lambda-function-properties-parser.js";
 

--- a/src/service/lambda/cfn/sim-cfn-lambda-resource-factory.iso.test.ts
+++ b/src/service/lambda/cfn/sim-cfn-lambda-resource-factory.iso.test.ts
@@ -12,11 +12,11 @@ import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type { SimCloudFormationResourceCreateContext } from "../../cloudformation/resource/sim-cfn-resource.js";
 import { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import { SimLambdaFunction } from "../function/sim-lambda-function.js";
 import {
   DEFAULT_SIM_LAMBDA_MEMORY_SIZE_MB,
   DEFAULT_SIM_LAMBDA_TIMEOUT_SECONDS,
-  SimLambdaFunction,
-} from "../function/sim-lambda-function.js";
+} from "../function/sim-lambda-function-configuration.js";
 import { SimLambdaCloudFormationResourceFactory } from "./sim-cfn-lambda-resource-factory.js";
 
 const accountRegionScope: SimAwsAccountRegionScope = {

--- a/src/service/lambda/command/alias/alias-input.ts
+++ b/src/service/lambda/command/alias/alias-input.ts
@@ -1,0 +1,35 @@
+import { SimLambdaValidationException } from "../../error/sim-lambda.error.js";
+
+const versionNumberPattern = /^\d+$/;
+
+/**
+ * Validates the version an alias command points an alias at.
+ *
+ * An alias names a published version, and only a published version. Real
+ * Lambda refuses `$LATEST` here on the API-level pattern, before it looks for
+ * anything of that name. The command types constrain this already, but
+ * templates and plain JavaScript callers reach the same handlers, so the value
+ * is checked at runtime and reported the way real Lambda reports it.
+ */
+export class AliasInputParser {
+  /**
+   * Parse a required FunctionVersion, as CreateAlias requires one.
+   */
+  requireFunctionVersion(value: string): string {
+    if (!versionNumberPattern.test(value)) {
+      throw new SimLambdaValidationException(
+        `1 validation error detected: Value '${value}' at 'functionVersion' failed to satisfy constraint: Member must satisfy regular expression pattern: [0-9]+`,
+      );
+    }
+
+    return value;
+  }
+
+  /**
+   * Parse an optional FunctionVersion, as UpdateAlias allows omitting it to
+   * leave the alias pointing where it points.
+   */
+  parseOptionalFunctionVersion(value: string | undefined): string | undefined {
+    return value === undefined ? undefined : this.requireFunctionVersion(value);
+  }
+}

--- a/src/service/lambda/command/alias/sim-lambda-alias-commands.ts
+++ b/src/service/lambda/command/alias/sim-lambda-alias-commands.ts
@@ -1,0 +1,121 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimLambdaFunctionAliasStore } from "../../function/version/sim-lambda-function-alias-store.js";
+import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
+import { CreateAliasCommandHandler } from "../create-alias/create-alias.handler.js";
+import type {
+  SimCreateAliasCommand,
+  SimCreateAliasCommandOutput,
+} from "../create-alias/create-alias.command.js";
+import { DeleteAliasCommandHandler } from "../delete-alias/delete-alias.handler.js";
+import type {
+  SimDeleteAliasCommand,
+  SimDeleteAliasCommandOutput,
+} from "../delete-alias/delete-alias.command.js";
+import { GetAliasCommandHandler } from "../get-alias/get-alias.handler.js";
+import type {
+  SimGetAliasCommand,
+  SimGetAliasCommandOutput,
+} from "../get-alias/get-alias.command.js";
+import { ListAliasesCommandHandler } from "../list-aliases/list-aliases.handler.js";
+import type {
+  SimListAliasesCommand,
+  SimListAliasesCommandOutput,
+} from "../list-aliases/list-aliases.command.js";
+import { UpdateAliasCommandHandler } from "../update-alias/update-alias.handler.js";
+import type {
+  SimUpdateAliasCommand,
+  SimUpdateAliasCommandOutput,
+} from "../update-alias/update-alias.command.js";
+
+interface SimLambdaAliasCommandsProperties {
+  readonly functions: SimLambdaFunctionLookup;
+  readonly aliases: SimLambdaFunctionAliasStore;
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly background: BackgroundScheduler;
+}
+
+interface SimLambdaAliasCommandOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The alias commands of one simulated Lambda scope.
+ *
+ * These five share the same collaborators and differ only in the handler they
+ * run, so grouping them keeps the SimLambda facade a thin delegation rather
+ * than five near-identical wiring blocks.
+ */
+export class SimLambdaAliasCommands {
+  private readonly properties: SimLambdaAliasCommandsProperties;
+
+  constructor(properties: SimLambdaAliasCommandsProperties) {
+    this.properties = properties;
+  }
+
+  /**
+   * Point a new alias at a published version.
+   */
+  async create(
+    command: SimCreateAliasCommand,
+    options?: SimLambdaAliasCommandOptions,
+  ): Promise<SimCreateAliasCommandOutput> {
+    return await new CreateAliasCommandHandler(this.properties).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Point an existing alias at another version.
+   */
+  async update(
+    command: SimUpdateAliasCommand,
+    options?: SimLambdaAliasCommandOptions,
+  ): Promise<SimUpdateAliasCommandOutput> {
+    return await new UpdateAliasCommandHandler(this.properties).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Read one alias of a function.
+   */
+  async get(
+    command: SimGetAliasCommand,
+    options?: SimLambdaAliasCommandOptions,
+  ): Promise<SimGetAliasCommandOutput> {
+    return await new GetAliasCommandHandler(this.properties).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * List a function's aliases.
+   */
+  async list(
+    command: SimListAliasesCommand,
+    options?: SimLambdaAliasCommandOptions,
+  ): Promise<SimListAliasesCommandOutput> {
+    return await new ListAliasesCommandHandler(this.properties).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Drop one alias of a function.
+   */
+  async delete(
+    command: SimDeleteAliasCommand,
+    options?: SimLambdaAliasCommandOptions,
+  ): Promise<SimDeleteAliasCommandOutput> {
+    return await new DeleteAliasCommandHandler(this.properties).handle(
+      command,
+      options,
+    );
+  }
+}

--- a/src/service/lambda/command/alias/sim-lambda-alias-refusals.iso.test.ts
+++ b/src/service/lambda/command/alias/sim-lambda-alias-refusals.iso.test.ts
@@ -1,0 +1,172 @@
+import {
+  CreateAliasCommand,
+  CreateFunctionCommand,
+  ListAliasesCommand,
+  PublishVersionCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimLambdaInvalidParameterValueException,
+  SimLambdaResourceConflictException,
+  SimLambdaResourceNotFoundException,
+  SimLambdaValidationException,
+} from "../../error/sim-lambda.error.js";
+import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
+import type { SimLambda } from "../../sim-lambda.js";
+
+/**
+ * A function with two published versions, which is the state every refusal
+ * here is measured against.
+ */
+async function givenFunctionWithTwoVersions(): Promise<SimLambda> {
+  const lambda = new SimAws().lambda();
+
+  await lambda.createFunction(
+    new CreateFunctionCommand({
+      FunctionName: "orders",
+      Role: "arn:aws:iam::111111111111:role/OrdersRole",
+      Code: { ZipFile: makeLambdaZipFileInput(() => "handled") },
+    }),
+  );
+  await lambda.publishVersion(
+    new PublishVersionCommand({ FunctionName: "orders" }),
+  );
+  await lambda.publishVersion(
+    new PublishVersionCommand({ FunctionName: "orders" }),
+  );
+
+  return lambda;
+}
+
+describe("Lambda alias command refusals", () => {
+  it("refuses an alias for a version that does not exist", async () => {
+    const lambda = await givenFunctionWithTwoVersions();
+
+    // When an alias is created for a version nothing published.
+    const error = await assertThrowsErrorAsync(async () =>
+      lambda.createAlias(
+        new CreateAliasCommand({
+          FunctionName: "orders",
+          Name: "live",
+          FunctionVersion: "7",
+        }),
+      ),
+    );
+
+    // Then the version that is missing is what gets reported.
+    assertInstanceOf(error, SimLambdaResourceNotFoundException);
+    assertStringIncludes(error.message, ":function:orders:7");
+  });
+
+  it("refuses an alias for $LATEST", async () => {
+    const lambda = await givenFunctionWithTwoVersions();
+
+    // When an alias is pointed at the function itself.
+    const error = await assertThrowsErrorAsync(async () =>
+      lambda.createAlias(
+        new CreateAliasCommand({
+          FunctionName: "orders",
+          Name: "live",
+          FunctionVersion: "$LATEST",
+        }),
+      ),
+    );
+
+    // Then it fails the version pattern, as it does on real Lambda.
+    assertInstanceOf(error, SimLambdaValidationException);
+    assertStringIncludes(error.message, "'functionVersion'");
+  });
+
+  it("refuses an alias name that is already taken", async () => {
+    const lambda = await givenFunctionWithTwoVersions();
+
+    // Given an alias that exists.
+    await lambda.createAlias(
+      new CreateAliasCommand({
+        FunctionName: "orders",
+        Name: "live",
+        FunctionVersion: "1",
+      }),
+    );
+
+    // When another alias is created under the same name.
+    const error = await assertThrowsErrorAsync(async () =>
+      lambda.createAlias(
+        new CreateAliasCommand({
+          FunctionName: "orders",
+          Name: "live",
+          FunctionVersion: "2",
+        }),
+      ),
+    );
+
+    // Then the conflict is reported.
+    assertInstanceOf(error, SimLambdaResourceConflictException);
+    assertStringIncludes(error.message, "Alias already exists");
+  });
+
+  it("refuses a function name carrying a qualifier", async () => {
+    const lambda = await givenFunctionWithTwoVersions();
+
+    // When an alias is created against a name naming a version.
+    const error = await assertThrowsErrorAsync(async () =>
+      lambda.createAlias(
+        new CreateAliasCommand({
+          FunctionName: "orders:1",
+          Name: "live",
+          FunctionVersion: "1",
+        }),
+      ),
+    );
+
+    // Then it is refused rather than acting on the function anyway.
+    assertInstanceOf(error, SimLambdaInvalidParameterValueException);
+    assertStringIncludes(error.message, "qualified function");
+  });
+
+  it("checks the version it was given before looking the function up", async () => {
+    const lambda = await givenFunctionWithTwoVersions();
+
+    // When an alias is created on a missing function with an unusable version.
+    const error = await assertThrowsErrorAsync(async () =>
+      lambda.createAlias(
+        new CreateAliasCommand({
+          FunctionName: "missing",
+          Name: "live",
+          FunctionVersion: "$LATEST",
+        }),
+      ),
+    );
+
+    // Then the input is what gets reported, as AWS reports it ahead of
+    // anything about the resource.
+    assertInstanceOf(error, SimLambdaValidationException);
+    assertStringIncludes(error.message, "'functionVersion'");
+  });
+
+  it("throws when listing the aliases of a version that does not exist", async () => {
+    const lambda = await givenFunctionWithTwoVersions();
+
+    // When the listing is narrowed to a version nothing published.
+    const error = await assertThrowsErrorAsync(async () =>
+      lambda.listAliases(
+        new ListAliasesCommand({
+          FunctionName: "orders",
+          FunctionVersion: "8",
+        }),
+      ),
+    );
+
+    // Then the version that is missing is what gets reported, rather than an
+    // empty listing.
+    assertInstanceOf(error, SimLambdaResourceNotFoundException);
+    assertStringIncludes(error.message, ":function:orders:8");
+  });
+});

--- a/src/service/lambda/command/alias/sim-lambda-aliases.iso.test.ts
+++ b/src/service/lambda/command/alias/sim-lambda-aliases.iso.test.ts
@@ -1,0 +1,366 @@
+import {
+  CreateAliasCommand,
+  CreateFunctionCommand,
+  DeleteAliasCommand,
+  GetAliasCommand,
+  ListAliasesCommand,
+  PublishVersionCommand,
+  UpdateAliasCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import {
+  SimLambdaResourceConflictException,
+  SimLambdaResourceNotFoundException,
+  SimLambdaValidationException,
+} from "../../error/sim-lambda.error.js";
+import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
+import type { SimLambda } from "../../sim-lambda.js";
+
+/**
+ * A function with two published versions, which is the state every alias
+ * command here acts on.
+ */
+async function givenFunctionWithTwoVersions(): Promise<SimLambda> {
+  const lambda = new SimAws().lambda();
+
+  await lambda.createFunction(
+    new CreateFunctionCommand({
+      FunctionName: "orders",
+      Role: "arn:aws:iam::111111111111:role/OrdersRole",
+      Code: { ZipFile: makeLambdaZipFileInput(() => "handled") },
+    }),
+  );
+  await lambda.publishVersion(
+    new PublishVersionCommand({ FunctionName: "orders" }),
+  );
+  await lambda.publishVersion(
+    new PublishVersionCommand({ FunctionName: "orders" }),
+  );
+
+  return lambda;
+}
+
+describe("Lambda alias commands", () => {
+  it("points a new alias at a published version", async () => {
+    const lambda = await givenFunctionWithTwoVersions();
+
+    // When an alias is created for version 1.
+    const alias = await lambda.createAlias(
+      new CreateAliasCommand({
+        FunctionName: "orders",
+        Name: "live",
+        FunctionVersion: "1",
+        Description: "What the shop calls",
+      }),
+    );
+
+    // Then it is addressed by the function ARN with its own name on the end.
+    assertIdentical(alias.Name, "live");
+    assertIdentical(alias.FunctionVersion, "1");
+    assertIdentical(alias.Description, "What the shop calls");
+    assertStringIncludes(alias.AliasArn, ":function:orders:live");
+  });
+
+  it("refuses an alias for a version that does not exist", async () => {
+    const lambda = await givenFunctionWithTwoVersions();
+
+    // When an alias is created for a version nothing published.
+    const error = await assertThrowsErrorAsync(async () =>
+      lambda.createAlias(
+        new CreateAliasCommand({
+          FunctionName: "orders",
+          Name: "live",
+          FunctionVersion: "7",
+        }),
+      ),
+    );
+
+    // Then the version that is missing is what gets reported.
+    assertInstanceOf(error, SimLambdaResourceNotFoundException);
+    assertStringIncludes(error.message, ":function:orders:7");
+  });
+
+  it("refuses an alias for $LATEST", async () => {
+    const lambda = await givenFunctionWithTwoVersions();
+
+    // When an alias is pointed at the function itself.
+    const error = await assertThrowsErrorAsync(async () =>
+      lambda.createAlias(
+        new CreateAliasCommand({
+          FunctionName: "orders",
+          Name: "live",
+          FunctionVersion: "$LATEST",
+        }),
+      ),
+    );
+
+    // Then it fails the version pattern, as it does on real Lambda.
+    assertInstanceOf(error, SimLambdaValidationException);
+    assertStringIncludes(error.message, "'functionVersion'");
+  });
+
+  it("refuses an alias name that is already taken", async () => {
+    const lambda = await givenFunctionWithTwoVersions();
+
+    // Given an alias that exists.
+    await lambda.createAlias(
+      new CreateAliasCommand({
+        FunctionName: "orders",
+        Name: "live",
+        FunctionVersion: "1",
+      }),
+    );
+
+    // When another alias is created under the same name.
+    const error = await assertThrowsErrorAsync(async () =>
+      lambda.createAlias(
+        new CreateAliasCommand({
+          FunctionName: "orders",
+          Name: "live",
+          FunctionVersion: "2",
+        }),
+      ),
+    );
+
+    // Then the conflict is reported.
+    assertInstanceOf(error, SimLambdaResourceConflictException);
+    assertStringIncludes(error.message, "Alias already exists");
+  });
+
+  it("points an existing alias at another version", async () => {
+    const lambda = await givenFunctionWithTwoVersions();
+
+    // Given an alias on version 1.
+    await lambda.createAlias(
+      new CreateAliasCommand({
+        FunctionName: "orders",
+        Name: "live",
+        FunctionVersion: "1",
+        Description: "What the shop calls",
+      }),
+    );
+
+    // When it is moved to version 2 without describing it again.
+    const updated = await lambda.updateAlias(
+      new UpdateAliasCommand({
+        FunctionName: "orders",
+        Name: "live",
+        FunctionVersion: "2",
+      }),
+    );
+
+    // Then it points at the new version, and the description it had is left
+    // as it was.
+    assertIdentical(updated.FunctionVersion, "2");
+    assertIdentical(updated.Description, "What the shop calls");
+  });
+
+  it("describes an alias again without moving it", async () => {
+    const lambda = await givenFunctionWithTwoVersions();
+
+    // Given an alias on version 2.
+    await lambda.createAlias(
+      new CreateAliasCommand({
+        FunctionName: "orders",
+        Name: "live",
+        FunctionVersion: "2",
+        Description: "What the shop calls",
+      }),
+    );
+
+    // When only its description is updated.
+    const updated = await lambda.updateAlias(
+      new UpdateAliasCommand({
+        FunctionName: "orders",
+        Name: "live",
+        Description: "What the shop calls now",
+      }),
+    );
+
+    // Then it still points where it did, under the new description.
+    assertIdentical(updated.FunctionVersion, "2");
+    assertIdentical(updated.Description, "What the shop calls now");
+  });
+
+  it("refuses moving an alias to a version that does not exist", async () => {
+    const lambda = await givenFunctionWithTwoVersions();
+
+    // Given an alias on version 1.
+    await lambda.createAlias(
+      new CreateAliasCommand({
+        FunctionName: "orders",
+        Name: "live",
+        FunctionVersion: "1",
+      }),
+    );
+
+    // When it is moved to a version nothing published.
+    const error = await assertThrowsErrorAsync(async () =>
+      lambda.updateAlias(
+        new UpdateAliasCommand({
+          FunctionName: "orders",
+          Name: "live",
+          FunctionVersion: "9",
+        }),
+      ),
+    );
+
+    // Then the version that is missing is what gets reported, and the alias
+    // stays where it was.
+    assertInstanceOf(error, SimLambdaResourceNotFoundException);
+    const alias = await lambda.getAlias(
+      new GetAliasCommand({ FunctionName: "orders", Name: "live" }),
+    );
+    assertIdentical(alias.FunctionVersion, "1");
+  });
+
+  it("throws when updating an alias that does not exist", async () => {
+    const lambda = await givenFunctionWithTwoVersions();
+
+    // When an alias nothing created is updated.
+    const error = await assertThrowsErrorAsync(async () =>
+      lambda.updateAlias(
+        new UpdateAliasCommand({
+          FunctionName: "orders",
+          Name: "missing",
+          FunctionVersion: "1",
+        }),
+      ),
+    );
+
+    // Then the missing alias is what gets reported.
+    assertInstanceOf(error, SimLambdaResourceNotFoundException);
+    assertStringIncludes(error.message, "Alias not found");
+  });
+
+  it("lists a function's aliases, and the ones on one version", async () => {
+    const lambda = await givenFunctionWithTwoVersions();
+
+    // Given two aliases on different versions.
+    await lambda.createAlias(
+      new CreateAliasCommand({
+        FunctionName: "orders",
+        Name: "live",
+        FunctionVersion: "1",
+      }),
+    );
+    await lambda.createAlias(
+      new CreateAliasCommand({
+        FunctionName: "orders",
+        Name: "next",
+        FunctionVersion: "2",
+      }),
+    );
+
+    // When they are listed, with and without a version to narrow to.
+    const all = await lambda.listAliases(
+      new ListAliasesCommand({ FunctionName: "orders" }),
+    );
+    const onVersionTwo = await lambda.listAliases(
+      new ListAliasesCommand({ FunctionName: "orders", FunctionVersion: "2" }),
+    );
+
+    // Then both come back in the order they were created, and the narrowed
+    // listing has only the alias pointing at that version.
+    assertArrayEquals(
+      all.Aliases.map((alias) => alias.Name),
+      ["live", "next"],
+    );
+    assertArrayEquals(
+      onVersionTwo.Aliases.map((alias) => alias.Name),
+      ["next"],
+    );
+  });
+
+  it("drops an alias, leaving the version it pointed at", async () => {
+    const lambda = await givenFunctionWithTwoVersions();
+
+    // Given an alias on version 1.
+    await lambda.createAlias(
+      new CreateAliasCommand({
+        FunctionName: "orders",
+        Name: "live",
+        FunctionVersion: "1",
+      }),
+    );
+
+    // When it is deleted.
+    await lambda.deleteAlias(
+      new DeleteAliasCommand({ FunctionName: "orders", Name: "live" }),
+    );
+
+    // Then the alias is gone and the version is still there.
+    const error = await assertThrowsErrorAsync(async () =>
+      lambda.getAlias(
+        new GetAliasCommand({ FunctionName: "orders", Name: "live" }),
+      ),
+    );
+    assertInstanceOf(error, SimLambdaResourceNotFoundException);
+    const listed = await lambda.listAliases(
+      new ListAliasesCommand({ FunctionName: "orders" }),
+    );
+    assertArrayEquals(
+      listed.Aliases.map((alias) => alias.Name),
+      [],
+    );
+  });
+
+  it("throws when deleting an alias that does not exist", async () => {
+    const lambda = await givenFunctionWithTwoVersions();
+
+    // When an alias nothing created is deleted.
+    const error = await assertThrowsErrorAsync(async () =>
+      lambda.deleteAlias(
+        new DeleteAliasCommand({ FunctionName: "orders", Name: "missing" }),
+      ),
+    );
+
+    // Then the missing alias is what gets reported.
+    assertInstanceOf(error, SimLambdaResourceNotFoundException);
+    assertStringIncludes(error.message, "Alias not found");
+  });
+
+  it("throws on an undefined alias name", async () => {
+    const lambda = await givenFunctionWithTwoVersions();
+
+    // When an alias is read without naming one.
+    const error = await assertThrowsErrorAsync(async () =>
+      lambda.getAlias(
+        new GetAliasCommand({ FunctionName: "orders", Name: undefined }),
+      ),
+    );
+
+    // Then the missing input is reported.
+    assertStringIncludes(error.message, "GetAliasCommand.input.Name required");
+  });
+
+  it("denies an explicitly anonymous caller through sim IAM", async () => {
+    const lambda = await givenFunctionWithTwoVersions();
+
+    // When an anonymous caller creates an alias.
+    const error = await assertThrowsErrorAsync(async () =>
+      lambda.createAlias(
+        new CreateAliasCommand({
+          FunctionName: "orders",
+          Name: "live",
+          FunctionVersion: "1",
+        }),
+        { caller: { kind: "anonymous" } },
+      ),
+    );
+
+    // Then the request is denied for the matching IAM action.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "lambda:CreateAlias");
+  });
+});

--- a/src/service/lambda/command/alias/sim-lambda-aliases.iso.test.ts
+++ b/src/service/lambda/command/alias/sim-lambda-aliases.iso.test.ts
@@ -18,11 +18,7 @@ import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
-import {
-  SimLambdaResourceConflictException,
-  SimLambdaResourceNotFoundException,
-  SimLambdaValidationException,
-} from "../../error/sim-lambda.error.js";
+import { SimLambdaResourceNotFoundException } from "../../error/sim-lambda.error.js";
 import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
 import type { SimLambda } from "../../sim-lambda.js";
 
@@ -69,72 +65,6 @@ describe("Lambda alias commands", () => {
     assertIdentical(alias.FunctionVersion, "1");
     assertIdentical(alias.Description, "What the shop calls");
     assertStringIncludes(alias.AliasArn, ":function:orders:live");
-  });
-
-  it("refuses an alias for a version that does not exist", async () => {
-    const lambda = await givenFunctionWithTwoVersions();
-
-    // When an alias is created for a version nothing published.
-    const error = await assertThrowsErrorAsync(async () =>
-      lambda.createAlias(
-        new CreateAliasCommand({
-          FunctionName: "orders",
-          Name: "live",
-          FunctionVersion: "7",
-        }),
-      ),
-    );
-
-    // Then the version that is missing is what gets reported.
-    assertInstanceOf(error, SimLambdaResourceNotFoundException);
-    assertStringIncludes(error.message, ":function:orders:7");
-  });
-
-  it("refuses an alias for $LATEST", async () => {
-    const lambda = await givenFunctionWithTwoVersions();
-
-    // When an alias is pointed at the function itself.
-    const error = await assertThrowsErrorAsync(async () =>
-      lambda.createAlias(
-        new CreateAliasCommand({
-          FunctionName: "orders",
-          Name: "live",
-          FunctionVersion: "$LATEST",
-        }),
-      ),
-    );
-
-    // Then it fails the version pattern, as it does on real Lambda.
-    assertInstanceOf(error, SimLambdaValidationException);
-    assertStringIncludes(error.message, "'functionVersion'");
-  });
-
-  it("refuses an alias name that is already taken", async () => {
-    const lambda = await givenFunctionWithTwoVersions();
-
-    // Given an alias that exists.
-    await lambda.createAlias(
-      new CreateAliasCommand({
-        FunctionName: "orders",
-        Name: "live",
-        FunctionVersion: "1",
-      }),
-    );
-
-    // When another alias is created under the same name.
-    const error = await assertThrowsErrorAsync(async () =>
-      lambda.createAlias(
-        new CreateAliasCommand({
-          FunctionName: "orders",
-          Name: "live",
-          FunctionVersion: "2",
-        }),
-      ),
-    );
-
-    // Then the conflict is reported.
-    assertInstanceOf(error, SimLambdaResourceConflictException);
-    assertStringIncludes(error.message, "Alias already exists");
   });
 
   it("points an existing alias at another version", async () => {

--- a/src/service/lambda/command/create-alias/create-alias.command.ts
+++ b/src/service/lambda/command/create-alias/create-alias.command.ts
@@ -1,0 +1,34 @@
+/**
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/CreateAliasCommand/
+ */
+
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimLambdaFunctionAliasConfiguration } from "../../function/version/sim-lambda-function-alias.js";
+
+/**
+ * Minimal structural sim Lambda CreateAlias command.
+ */
+export interface SimCreateAliasCommand {
+  readonly input: SimCreateAliasCommandInput;
+}
+
+/**
+ * Minimal structural sim Lambda CreateAlias input.
+ *
+ * The `RoutingConfig` real Lambda takes here splits an alias's traffic across
+ * two versions. That is not simulated, so it is left out rather than accepted
+ * and ignored.
+ */
+export interface SimCreateAliasCommandInput {
+  readonly FunctionName?: string | undefined;
+  readonly Name?: string | undefined;
+  readonly FunctionVersion?: string | undefined;
+  readonly Description?: string | undefined;
+}
+
+/**
+ * Minimal structural sim Lambda CreateAlias output.
+ */
+export interface SimCreateAliasCommandOutput extends SimLambdaFunctionAliasConfiguration {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/lambda/command/create-alias/create-alias.handler.ts
+++ b/src/service/lambda/command/create-alias/create-alias.handler.ts
@@ -9,7 +9,7 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
-import { simLambdaFunctionReferenceOf } from "../../function/sim-lambda-function-reference.js";
+import { simLambdaUnqualifiedFunctionOf } from "../../function/sim-lambda-function-reference.js";
 import type { SimLambdaFunctionAliasStore } from "../../function/version/sim-lambda-function-alias-store.js";
 import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
 import { AliasInputParser } from "../alias/alias-input.js";
@@ -82,18 +82,22 @@ export class CreateAliasCommandHandler implements CommandHandler<
     // Allow for potential non-deterministic sequencing of async events.
     await this.background.sequence();
 
-    const { functionName } = simLambdaFunctionReferenceOf(input.FunctionName);
+    const functionName = simLambdaUnqualifiedFunctionOf(input.FunctionName);
     this.authorizer.authorize(
       this.functions.functionArn(functionName),
       options?.caller,
     );
 
+    // Checked before the function is looked up, as AWS reports input that
+    // fails an API-level constraint ahead of anything about the resource.
+    const functionVersion = this.inputParser.requireFunctionVersion(
+      input.FunctionVersion,
+    );
+
     const alias = this.aliases.create({
       simFunction: this.functions.require(functionName),
       name: input.Name,
-      functionVersion: this.inputParser.requireFunctionVersion(
-        input.FunctionVersion,
-      ),
+      functionVersion,
       description: input.Description,
     });
 

--- a/src/service/lambda/command/create-alias/create-alias.handler.ts
+++ b/src/service/lambda/command/create-alias/create-alias.handler.ts
@@ -1,0 +1,102 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simLambdaFunctionReferenceOf } from "../../function/sim-lambda-function-reference.js";
+import type { SimLambdaFunctionAliasStore } from "../../function/version/sim-lambda-function-alias-store.js";
+import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
+import { AliasInputParser } from "../alias/alias-input.js";
+import { VersionAuthorizer } from "../version/version-authorizer.js";
+import type {
+  SimCreateAliasCommand,
+  SimCreateAliasCommandOutput,
+} from "./create-alias.command.js";
+
+interface CreateAliasCommandHandlerProperties {
+  readonly functions: SimLambdaFunctionLookup;
+  readonly aliases: SimLambdaFunctionAliasStore;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+interface CreateAliasCommandHandlerOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * Simulated Lambda CreateAliasCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/CreateAliasCommand/
+ */
+export class CreateAliasCommandHandler implements CommandHandler<
+  SimCreateAliasCommand,
+  SimCreateAliasCommandOutput
+> {
+  private readonly functions: SimLambdaFunctionLookup;
+  private readonly aliases: SimLambdaFunctionAliasStore;
+  private readonly authorizer: VersionAuthorizer;
+  private readonly background: BackgroundScheduler;
+  private readonly inputParser = new AliasInputParser();
+
+  constructor(properties: CreateAliasCommandHandlerProperties) {
+    const {
+      functions,
+      aliases,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+    this.functions = functions;
+    this.aliases = aliases;
+    this.authorizer = new VersionAuthorizer({
+      iam,
+      action: "lambda:CreateAlias",
+    });
+    this.background = background;
+  }
+
+  /**
+   * Point a new alias at a published version of a sim Lambda function.
+   */
+  async handle(
+    command: SimCreateAliasCommand,
+    options?: CreateAliasCommandHandlerOptions,
+  ): Promise<SimCreateAliasCommandOutput> {
+    const { input } = command;
+    assertDefined(
+      input.FunctionName,
+      "CreateAliasCommand.input.FunctionName required",
+    );
+    assertDefined(input.Name, "CreateAliasCommand.input.Name required");
+    assertDefined(
+      input.FunctionVersion,
+      "CreateAliasCommand.input.FunctionVersion required",
+    );
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    const { functionName } = simLambdaFunctionReferenceOf(input.FunctionName);
+    this.authorizer.authorize(
+      this.functions.functionArn(functionName),
+      options?.caller,
+    );
+
+    const alias = this.aliases.create({
+      simFunction: this.functions.require(functionName),
+      name: input.Name,
+      functionVersion: this.inputParser.requireFunctionVersion(
+        input.FunctionVersion,
+      ),
+      description: input.Description,
+    });
+
+    return { $metadata: {}, ...alias.configuration() };
+  }
+}

--- a/src/service/lambda/command/create-function/create-function.command.ts
+++ b/src/service/lambda/command/create-function/create-function.command.ts
@@ -3,7 +3,7 @@
  */
 
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
-import type { SimLambdaFunctionConfiguration } from "../../function/sim-lambda-function.js";
+import type { SimLambdaFunctionConfiguration } from "../../function/sim-lambda-function-configuration.js";
 
 /**
  * Minimal structural sim Lambda CreateFunction command.

--- a/src/service/lambda/command/create-function/create-function.handler.ts
+++ b/src/service/lambda/command/create-function/create-function.handler.ts
@@ -21,12 +21,14 @@ import type { SimLambdaOutboundHttp } from "../../function/outbound/sim-lambda-o
 import { SimLambdaEnvironmentConflicts } from "../../function/environment/sim-lambda-environment-conflicts.js";
 import { SimLambdaEnvironment } from "../../function/environment/sim-lambda-environment.js";
 import {
-  DEFAULT_SIM_LAMBDA_MEMORY_SIZE_MB,
   SimLambdaFunction,
   type SimLambdaFunctionMap,
   type SimLambdaFunctionName,
-  simLambdaFunctionArn,
 } from "../../function/sim-lambda-function.js";
+import {
+  DEFAULT_SIM_LAMBDA_MEMORY_SIZE_MB,
+  simLambdaFunctionArn,
+} from "../../function/sim-lambda-function-configuration.js";
 import { CreateFunctionAuthorizer } from "./create-function-authorizer.js";
 import {
   type CreateFunctionInput,

--- a/src/service/lambda/command/delete-alias/delete-alias.command.ts
+++ b/src/service/lambda/command/delete-alias/delete-alias.command.ts
@@ -1,0 +1,27 @@
+/**
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/DeleteAliasCommand/
+ */
+
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim Lambda DeleteAlias command.
+ */
+export interface SimDeleteAliasCommand {
+  readonly input: SimDeleteAliasCommandInput;
+}
+
+/**
+ * Minimal structural sim Lambda DeleteAlias input.
+ */
+export interface SimDeleteAliasCommandInput {
+  readonly FunctionName?: string | undefined;
+  readonly Name?: string | undefined;
+}
+
+/**
+ * Minimal structural sim Lambda DeleteAlias output.
+ */
+export interface SimDeleteAliasCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/lambda/command/delete-alias/delete-alias.handler.ts
+++ b/src/service/lambda/command/delete-alias/delete-alias.handler.ts
@@ -1,0 +1,92 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simLambdaFunctionReferenceOf } from "../../function/sim-lambda-function-reference.js";
+import type { SimLambdaFunctionAliasStore } from "../../function/version/sim-lambda-function-alias-store.js";
+import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
+import { VersionAuthorizer } from "../version/version-authorizer.js";
+import type {
+  SimDeleteAliasCommand,
+  SimDeleteAliasCommandOutput,
+} from "./delete-alias.command.js";
+
+interface DeleteAliasCommandHandlerProperties {
+  readonly functions: SimLambdaFunctionLookup;
+  readonly aliases: SimLambdaFunctionAliasStore;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+interface DeleteAliasCommandHandlerOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * Simulated Lambda DeleteAliasCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/DeleteAliasCommand/
+ */
+export class DeleteAliasCommandHandler implements CommandHandler<
+  SimDeleteAliasCommand,
+  SimDeleteAliasCommandOutput
+> {
+  private readonly functions: SimLambdaFunctionLookup;
+  private readonly aliases: SimLambdaFunctionAliasStore;
+  private readonly authorizer: VersionAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: DeleteAliasCommandHandlerProperties) {
+    const {
+      functions,
+      aliases,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+    this.functions = functions;
+    this.aliases = aliases;
+    this.authorizer = new VersionAuthorizer({
+      iam,
+      action: "lambda:DeleteAlias",
+    });
+    this.background = background;
+  }
+
+  /**
+   * Drop one of a sim Lambda function's aliases.
+   *
+   * The version the alias pointed at stays where it is, and stays invokable by
+   * its number.
+   */
+  async handle(
+    command: SimDeleteAliasCommand,
+    options?: DeleteAliasCommandHandlerOptions,
+  ): Promise<SimDeleteAliasCommandOutput> {
+    const { input } = command;
+    assertDefined(
+      input.FunctionName,
+      "DeleteAliasCommand.input.FunctionName required",
+    );
+    assertDefined(input.Name, "DeleteAliasCommand.input.Name required");
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    const { functionName } = simLambdaFunctionReferenceOf(input.FunctionName);
+    this.authorizer.authorize(
+      this.functions.functionArn(functionName),
+      options?.caller,
+    );
+
+    this.aliases.delete(this.functions.require(functionName), input.Name);
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/lambda/command/delete-alias/delete-alias.handler.ts
+++ b/src/service/lambda/command/delete-alias/delete-alias.handler.ts
@@ -9,7 +9,7 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
-import { simLambdaFunctionReferenceOf } from "../../function/sim-lambda-function-reference.js";
+import { simLambdaUnqualifiedFunctionOf } from "../../function/sim-lambda-function-reference.js";
 import type { SimLambdaFunctionAliasStore } from "../../function/version/sim-lambda-function-alias-store.js";
 import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
 import { VersionAuthorizer } from "../version/version-authorizer.js";
@@ -79,7 +79,7 @@ export class DeleteAliasCommandHandler implements CommandHandler<
     // Allow for potential non-deterministic sequencing of async events.
     await this.background.sequence();
 
-    const { functionName } = simLambdaFunctionReferenceOf(input.FunctionName);
+    const functionName = simLambdaUnqualifiedFunctionOf(input.FunctionName);
     this.authorizer.authorize(
       this.functions.functionArn(functionName),
       options?.caller,

--- a/src/service/lambda/command/delete-function/delete-function.handler.ts
+++ b/src/service/lambda/command/delete-function/delete-function.handler.ts
@@ -11,12 +11,13 @@ import {
   type SimIamInterServiceAuthZ,
 } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimLambdaResourceNotFoundException } from "../../error/sim-lambda.error.js";
-import {
-  type SimLambdaFunctionMap,
-  type SimLambdaFunctionName,
-  simLambdaFunctionArn,
+import type {
+  SimLambdaFunctionMap,
+  SimLambdaFunctionName,
 } from "../../function/sim-lambda-function.js";
+import { simLambdaFunctionArn } from "../../function/sim-lambda-function-configuration.js";
 import type { SimLambdaFunctionUrlStore } from "../../function/url/sim-lambda-function-url-store.js";
+import type { SimLambdaFunctionVersionStore } from "../../function/version/sim-lambda-function-version-store.js";
 import { DeleteFunctionAuthorizer } from "./delete-function-authorizer.js";
 import type {
   SimDeleteFunctionCommand,
@@ -27,6 +28,7 @@ interface DeleteFunctionCommandHandlerProperties {
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly functions: SimLambdaFunctionMap;
   readonly functionUrls: SimLambdaFunctionUrlStore;
+  readonly versions: SimLambdaFunctionVersionStore;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
 }
@@ -47,6 +49,7 @@ export class DeleteFunctionCommandHandler implements CommandHandler<
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly functions: SimLambdaFunctionMap;
   private readonly functionUrls: SimLambdaFunctionUrlStore;
+  private readonly versions: SimLambdaFunctionVersionStore;
   private readonly authorizer: DeleteFunctionAuthorizer;
   private readonly background: BackgroundScheduler;
 
@@ -55,6 +58,7 @@ export class DeleteFunctionCommandHandler implements CommandHandler<
       accountRegionScope,
       functions,
       functionUrls,
+      versions,
       iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
     } = properties;
@@ -62,6 +66,7 @@ export class DeleteFunctionCommandHandler implements CommandHandler<
     this.accountRegionScope = accountRegionScope;
     this.functions = functions;
     this.functionUrls = functionUrls;
+    this.versions = versions;
     this.authorizer = new DeleteFunctionAuthorizer({ iam });
     this.background = background;
   }
@@ -75,7 +80,8 @@ export class DeleteFunctionCommandHandler implements CommandHandler<
    * function as nothing to deliver to.
    *
    * The resource policy the Add Permission command builds is held on the
-   * function itself, so it goes at the same time.
+   * function itself, so it goes at the same time. So do the versions published
+   * from it and the aliases pointing at those, as they do on real Lambda.
    */
   async handle(
     command: SimDeleteFunctionCommand,
@@ -105,6 +111,7 @@ export class DeleteFunctionCommandHandler implements CommandHandler<
     }
 
     this.functionUrls.deleteIfPresent(simFunction);
+    this.versions.forget(simFunction);
     this.functions.delete(functionName);
 
     return { $metadata: {} };

--- a/src/service/lambda/command/delete-function/delete-function.iso.test.ts
+++ b/src/service/lambda/command/delete-function/delete-function.iso.test.ts
@@ -5,8 +5,11 @@ import {
   DeleteFunctionCommand,
   GetFunctionCommand,
   GetFunctionUrlConfigCommand,
+  ListVersionsByFunctionCommand,
+  PublishVersionCommand,
 } from "@aws-sdk/client-lambda";
 import {
+  assertArrayEquals,
   assertIdentical,
   assertInstanceOf,
   assertStringIncludes,
@@ -39,6 +42,35 @@ async function givenFunction(
 }
 
 describe("Lambda DeleteFunctionCommand", () => {
+  it("takes the function's published versions with it", async () => {
+    // Given a function with a published version, deleted and made again.
+    const simLambda = new SimLambda();
+    await givenFunction(simLambda, "disposable");
+    await simLambda.publishVersion(
+      new PublishVersionCommand({ FunctionName: "disposable" }),
+    );
+    await simLambda.deleteFunction(
+      new DeleteFunctionCommand({ FunctionName: "disposable" }),
+    );
+    await givenFunction(simLambda, "disposable");
+
+    // When the new function's versions are listed.
+    const listed = await simLambda.listVersionsByFunction(
+      new ListVersionsByFunctionCommand({ FunctionName: "disposable" }),
+    );
+
+    // Then nothing published from the old one is left, and the next version
+    // it publishes starts again at 1.
+    assertArrayEquals(
+      listed.Versions.map((version) => version.Version),
+      ["$LATEST"],
+    );
+    const published = await simLambda.publishVersion(
+      new PublishVersionCommand({ FunctionName: "disposable" }),
+    );
+    assertIdentical(published.Version, "1");
+  });
+
   it("deletes a function so it can no longer be read", async () => {
     // Given an existing function.
     const simLambda = new SimLambda();

--- a/src/service/lambda/command/function/sim-lambda-function-commands.ts
+++ b/src/service/lambda/command/function/sim-lambda-function-commands.ts
@@ -11,6 +11,7 @@ import type { SimLambdaOutboundHttp } from "../../function/outbound/sim-lambda-o
 import type { SimLambdaEnvironmentConflicts } from "../../function/environment/sim-lambda-environment-conflicts.js";
 import type { SimLambdaFunctionMap } from "../../function/sim-lambda-function.js";
 import type { SimLambdaFunctionUrlStore } from "../../function/url/sim-lambda-function-url-store.js";
+import type { SimLambdaFunctionVersionStore } from "../../function/version/sim-lambda-function-version-store.js";
 import { CreateFunctionCommandHandler } from "../create-function/create-function.handler.js";
 import type {
   SimCreateFunctionCommand,
@@ -39,6 +40,7 @@ interface SimLambdaFunctionCommandsProperties {
   readonly background: BackgroundScheduler;
   readonly runAsOwner: SimAwsRunAsOwner;
   readonly functionUrls: SimLambdaFunctionUrlStore;
+  readonly versions: SimLambdaFunctionVersionStore;
   readonly environmentConflicts: SimLambdaEnvironmentConflicts;
   readonly codeStore?: SimLambdaCodeStore | undefined;
   readonly containerImages?: SimLambdaContainerImages | undefined;
@@ -105,7 +107,7 @@ export class SimLambdaFunctionCommands {
   }
 
   /**
-   * Invoke a function.
+   * Invoke a function, or the version a qualifier names.
    */
   async invoke(
     command: SimInvokeCommand,

--- a/src/service/lambda/command/get-alias/get-alias.command.ts
+++ b/src/service/lambda/command/get-alias/get-alias.command.ts
@@ -1,0 +1,28 @@
+/**
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/GetAliasCommand/
+ */
+
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimLambdaFunctionAliasConfiguration } from "../../function/version/sim-lambda-function-alias.js";
+
+/**
+ * Minimal structural sim Lambda GetAlias command.
+ */
+export interface SimGetAliasCommand {
+  readonly input: SimGetAliasCommandInput;
+}
+
+/**
+ * Minimal structural sim Lambda GetAlias input.
+ */
+export interface SimGetAliasCommandInput {
+  readonly FunctionName?: string | undefined;
+  readonly Name?: string | undefined;
+}
+
+/**
+ * Minimal structural sim Lambda GetAlias output.
+ */
+export interface SimGetAliasCommandOutput extends SimLambdaFunctionAliasConfiguration {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/lambda/command/get-alias/get-alias.handler.ts
+++ b/src/service/lambda/command/get-alias/get-alias.handler.ts
@@ -1,0 +1,89 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simLambdaFunctionReferenceOf } from "../../function/sim-lambda-function-reference.js";
+import type { SimLambdaFunctionAliasStore } from "../../function/version/sim-lambda-function-alias-store.js";
+import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
+import { VersionAuthorizer } from "../version/version-authorizer.js";
+import type {
+  SimGetAliasCommand,
+  SimGetAliasCommandOutput,
+} from "./get-alias.command.js";
+
+interface GetAliasCommandHandlerProperties {
+  readonly functions: SimLambdaFunctionLookup;
+  readonly aliases: SimLambdaFunctionAliasStore;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+interface GetAliasCommandHandlerOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * Simulated Lambda GetAliasCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/GetAliasCommand/
+ */
+export class GetAliasCommandHandler implements CommandHandler<
+  SimGetAliasCommand,
+  SimGetAliasCommandOutput
+> {
+  private readonly functions: SimLambdaFunctionLookup;
+  private readonly aliases: SimLambdaFunctionAliasStore;
+  private readonly authorizer: VersionAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: GetAliasCommandHandlerProperties) {
+    const {
+      functions,
+      aliases,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+    this.functions = functions;
+    this.aliases = aliases;
+    this.authorizer = new VersionAuthorizer({ iam, action: "lambda:GetAlias" });
+    this.background = background;
+  }
+
+  /**
+   * Read one of a sim Lambda function's aliases.
+   */
+  async handle(
+    command: SimGetAliasCommand,
+    options?: GetAliasCommandHandlerOptions,
+  ): Promise<SimGetAliasCommandOutput> {
+    const { input } = command;
+    assertDefined(
+      input.FunctionName,
+      "GetAliasCommand.input.FunctionName required",
+    );
+    assertDefined(input.Name, "GetAliasCommand.input.Name required");
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    const { functionName } = simLambdaFunctionReferenceOf(input.FunctionName);
+    this.authorizer.authorize(
+      this.functions.functionArn(functionName),
+      options?.caller,
+    );
+
+    const alias = this.aliases.require(
+      this.functions.require(functionName),
+      input.Name,
+    );
+
+    return { $metadata: {}, ...alias.configuration() };
+  }
+}

--- a/src/service/lambda/command/get-alias/get-alias.handler.ts
+++ b/src/service/lambda/command/get-alias/get-alias.handler.ts
@@ -9,7 +9,7 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
-import { simLambdaFunctionReferenceOf } from "../../function/sim-lambda-function-reference.js";
+import { simLambdaUnqualifiedFunctionOf } from "../../function/sim-lambda-function-reference.js";
 import type { SimLambdaFunctionAliasStore } from "../../function/version/sim-lambda-function-alias-store.js";
 import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
 import { VersionAuthorizer } from "../version/version-authorizer.js";
@@ -73,7 +73,7 @@ export class GetAliasCommandHandler implements CommandHandler<
     // Allow for potential non-deterministic sequencing of async events.
     await this.background.sequence();
 
-    const { functionName } = simLambdaFunctionReferenceOf(input.FunctionName);
+    const functionName = simLambdaUnqualifiedFunctionOf(input.FunctionName);
     this.authorizer.authorize(
       this.functions.functionArn(functionName),
       options?.caller,

--- a/src/service/lambda/command/get-function/get-function.command.ts
+++ b/src/service/lambda/command/get-function/get-function.command.ts
@@ -3,7 +3,7 @@
  */
 
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
-import type { SimLambdaFunctionConfiguration } from "../../function/sim-lambda-function.js";
+import type { SimLambdaFunctionConfiguration } from "../../function/sim-lambda-function-configuration.js";
 
 /**
  * Minimal structural sim Lambda GetFunction command.
@@ -17,6 +17,7 @@ export interface SimGetFunctionCommand {
  */
 export interface SimGetFunctionCommandInput {
   readonly FunctionName?: string | undefined;
+  readonly Qualifier?: string | undefined;
 }
 
 /**

--- a/src/service/lambda/command/get-function/get-function.handler.ts
+++ b/src/service/lambda/command/get-function/get-function.handler.ts
@@ -11,11 +11,13 @@ import {
   type SimIamInterServiceAuthZ,
 } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimLambdaResourceNotFoundException } from "../../error/sim-lambda.error.js";
-import {
-  type SimLambdaFunctionMap,
-  type SimLambdaFunctionName,
-  simLambdaFunctionArn,
+import { simLambdaQualifiedFunctionOf } from "../../function/sim-lambda-function-reference.js";
+import type { SimLambdaFunctionVersionStore } from "../../function/version/sim-lambda-function-version-store.js";
+import type {
+  SimLambdaFunctionMap,
+  SimLambdaFunctionName,
 } from "../../function/sim-lambda-function.js";
+import { simLambdaFunctionArn } from "../../function/sim-lambda-function-configuration.js";
 import { GetFunctionAuthorizer } from "./get-function-authorizer.js";
 import type {
   SimGetFunctionCommand,
@@ -25,6 +27,7 @@ import type {
 interface GetFunctionCommandHandlerProperties {
   accountRegionScope: SimAwsAccountRegionScope;
   functions: SimLambdaFunctionMap;
+  versions: SimLambdaFunctionVersionStore;
   iam?: SimIamInterServiceAuthZ;
   background?: BackgroundScheduler;
 }
@@ -44,6 +47,7 @@ export class GetFunctionCommandHandler implements CommandHandler<
 > {
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly functions: SimLambdaFunctionMap;
+  private readonly versions: SimLambdaFunctionVersionStore;
   private readonly authorizer: GetFunctionAuthorizer;
   private readonly background: BackgroundScheduler;
 
@@ -51,17 +55,20 @@ export class GetFunctionCommandHandler implements CommandHandler<
     const {
       accountRegionScope,
       functions,
+      versions,
       iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
     } = properties;
     this.accountRegionScope = accountRegionScope;
     this.functions = functions;
+    this.versions = versions;
     this.authorizer = new GetFunctionAuthorizer({ iam });
     this.background = background;
   }
 
   /**
-   * Get a sim Lambda function's configuration.
+   * Get a sim Lambda function's configuration, or that of the version a
+   * qualifier names.
    */
   async handle(
     command: SimGetFunctionCommand,
@@ -75,14 +82,18 @@ export class GetFunctionCommandHandler implements CommandHandler<
     // Allow for potential non-deterministic sequencing of async events.
     await this.background.sequence();
 
+    const { functionName, qualifier } = simLambdaQualifiedFunctionOf(
+      command.input.FunctionName,
+      command.input.Qualifier,
+    );
     const functionArn = simLambdaFunctionArn(
       this.accountRegionScope,
-      command.input.FunctionName,
+      functionName,
     );
     this.authorizer.authorize(functionArn, options?.caller);
 
     const simFunction = this.functions.get(
-      command.input.FunctionName as SimLambdaFunctionName,
+      functionName as SimLambdaFunctionName,
     );
     if (simFunction === undefined) {
       throw new SimLambdaResourceNotFoundException(
@@ -92,7 +103,9 @@ export class GetFunctionCommandHandler implements CommandHandler<
 
     return {
       $metadata: {},
-      Configuration: simFunction.configuration(),
+      Configuration: this.versions
+        .require(simFunction, qualifier)
+        .configuration(),
     };
   }
 }

--- a/src/service/lambda/command/get-function/get-function.iso.test.ts
+++ b/src/service/lambda/command/get-function/get-function.iso.test.ts
@@ -101,6 +101,38 @@ describe("Lambda GetFunctionCommand", () => {
     );
   });
 
+  it("reads a version off a qualified function ARN", async () => {
+    // Given a function with a published version.
+    const simLambda = new SimLambda();
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "orders",
+        Role: "arn:aws:iam::111111111111:role/OrdersRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => null) },
+      }),
+    );
+    await simLambda.publishVersion(
+      new PublishVersionCommand({ FunctionName: "orders" }),
+    );
+    const { Configuration } = await simLambda.getFunction(
+      new GetFunctionCommand({ FunctionName: "orders" }),
+    );
+
+    // When the function is read by an ARN naming that version.
+    const fetched = await simLambda.getFunction(
+      new GetFunctionCommand({
+        FunctionName: `${Configuration.FunctionArn}:1`,
+      }),
+    );
+
+    // Then it resolves the same way a Qualifier does.
+    assertIdentical(fetched.Configuration.Version, "1");
+    assertStringIncludes(
+      fetched.Configuration.FunctionArn,
+      ":function:orders:1",
+    );
+  });
+
   it("throws on a Qualifier naming no version or alias", async () => {
     // Given a function with nothing published.
     const simLambda = new SimLambda();

--- a/src/service/lambda/command/get-function/get-function.iso.test.ts
+++ b/src/service/lambda/command/get-function/get-function.iso.test.ts
@@ -1,6 +1,7 @@
 import {
   CreateFunctionCommand,
   GetFunctionCommand,
+  PublishVersionCommand,
 } from "@aws-sdk/client-lambda";
 import {
   assertIdentical,
@@ -71,6 +72,56 @@ describe("Lambda GetFunctionCommand", () => {
 
     assertInstanceOf(error, SimIamAccessDenied);
     assertIdentical(error.action, "lambda:GetFunction");
+  });
+
+  it("gets a published version's configuration for a Qualifier", async () => {
+    // Given a function with a published version.
+    const simLambda = new SimLambda();
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "orders",
+        Role: "arn:aws:iam::111111111111:role/OrdersRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => null) },
+      }),
+    );
+    await simLambda.publishVersion(
+      new PublishVersionCommand({ FunctionName: "orders" }),
+    );
+
+    // When the function is read for that version.
+    const fetched = await simLambda.getFunction(
+      new GetFunctionCommand({ FunctionName: "orders", Qualifier: "1" }),
+    );
+
+    // Then the version's own configuration comes back, under its own ARN.
+    assertIdentical(fetched.Configuration.Version, "1");
+    assertStringIncludes(
+      fetched.Configuration.FunctionArn,
+      ":function:orders:1",
+    );
+  });
+
+  it("throws on a Qualifier naming no version or alias", async () => {
+    // Given a function with nothing published.
+    const simLambda = new SimLambda();
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "orders",
+        Role: "arn:aws:iam::111111111111:role/OrdersRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => null) },
+      }),
+    );
+
+    // When the function is read for a version nothing published.
+    const error = await assertThrowsErrorAsync(async () =>
+      simLambda.getFunction(
+        new GetFunctionCommand({ FunctionName: "orders", Qualifier: "3" }),
+      ),
+    );
+
+    // Then the qualified function is what gets reported as missing.
+    assertInstanceOf(error, SimLambdaResourceNotFoundException);
+    assertStringIncludes(error.message, ":function:orders:3");
   });
 
   it("throws on undefined function name", async () => {

--- a/src/service/lambda/command/invoke/invoke-dispatcher.ts
+++ b/src/service/lambda/command/invoke/invoke-dispatcher.ts
@@ -20,6 +20,9 @@ interface SimLambdaInvocationDispatcherProperties {
 /**
  * Dispatches an authorized Invoke request to a sim Lambda function using the
  * requested AWS invocation type.
+ *
+ * The function it is given is the one the request resolved to, so a request
+ * for a published version reports that version as the one it ran.
  */
 export class SimLambdaInvocationDispatcher {
   private readonly background: BackgroundScheduler;
@@ -63,14 +66,14 @@ export class SimLambdaInvocationDispatcher {
       return {
         $metadata: {},
         StatusCode: 200,
-        ExecutedVersion: "$LATEST",
+        ExecutedVersion: simFunction.version,
         Payload: resultPayload(result),
       };
     } catch (error) {
       return {
         $metadata: {},
         StatusCode: 200,
-        ExecutedVersion: "$LATEST",
+        ExecutedVersion: simFunction.version,
         FunctionError: "Unhandled",
         Payload: functionErrorPayload(error),
       };

--- a/src/service/lambda/command/invoke/invoke-qualifier.iso.test.ts
+++ b/src/service/lambda/command/invoke/invoke-qualifier.iso.test.ts
@@ -1,0 +1,193 @@
+import {
+  CreateAliasCommand,
+  CreateFunctionCommand,
+  GetFunctionCommand,
+  InvokeCommand,
+  PublishVersionCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimLambdaInvalidParameterValueException,
+  SimLambdaResourceNotFoundException,
+} from "../../error/sim-lambda.error.js";
+import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
+import type { SimLambda } from "../../sim-lambda.js";
+
+/**
+ * A function whose handler reports the version and ARN it was invoked as, with
+ * one published version behind an alias.
+ */
+async function givenPublishedFunction(): Promise<SimLambda> {
+  const lambda = new SimAws().lambda();
+
+  await lambda.createFunction(
+    new CreateFunctionCommand({
+      FunctionName: "orders",
+      Role: "arn:aws:iam::111111111111:role/OrdersRole",
+      Code: {
+        ZipFile: makeLambdaZipFileInput((_event, context) => ({
+          functionVersion: context.functionVersion,
+          invokedFunctionArn: context.invokedFunctionArn,
+        })),
+      },
+    }),
+  );
+  await lambda.publishVersion(
+    new PublishVersionCommand({ FunctionName: "orders" }),
+  );
+  await lambda.createAlias(
+    new CreateAliasCommand({
+      FunctionName: "orders",
+      Name: "live",
+      FunctionVersion: "1",
+    }),
+  );
+
+  return lambda;
+}
+
+function invokedPayload(payload: Uint8Array | undefined): {
+  functionVersion: string;
+  invokedFunctionArn: string;
+} {
+  assertNonNullable(payload);
+
+  return JSON.parse(Buffer.from(payload).toString()) as {
+    functionVersion: string;
+    invokedFunctionArn: string;
+  };
+}
+
+describe("Lambda Invoke with a qualifier", () => {
+  it("runs the version a Qualifier names", async () => {
+    const lambda = await givenPublishedFunction();
+
+    // When the function is invoked for version 1.
+    const invoked = await lambda.invoke(
+      new InvokeCommand({ FunctionName: "orders", Qualifier: "1" }),
+    );
+
+    // Then that version ran, and is what the answer reports.
+    assertIdentical(invoked.ExecutedVersion, "1");
+    const payload = invokedPayload(invoked.Payload);
+    assertIdentical(payload.functionVersion, "1");
+    assertStringIncludes(payload.invokedFunctionArn, ":function:orders:1");
+  });
+
+  it("runs the version an alias points at", async () => {
+    const lambda = await givenPublishedFunction();
+
+    // When the function is invoked through its alias.
+    const invoked = await lambda.invoke(
+      new InvokeCommand({ FunctionName: "orders", Qualifier: "live" }),
+    );
+
+    // Then the version behind the alias ran, reported by its number.
+    assertIdentical(invoked.ExecutedVersion, "1");
+    assertIdentical(invokedPayload(invoked.Payload).functionVersion, "1");
+  });
+
+  it("reads the qualifier off a qualified function ARN", async () => {
+    const lambda = await givenPublishedFunction();
+    const { Configuration } = await lambda.getFunction(
+      new GetFunctionCommand({ FunctionName: "orders" }),
+    );
+
+    // When the function is invoked by an ARN naming the alias.
+    const invoked = await lambda.invoke(
+      new InvokeCommand({
+        FunctionName: `${Configuration.FunctionArn}:live`,
+      }),
+    );
+
+    // Then it resolves the same way a Qualifier does.
+    assertIdentical(invoked.ExecutedVersion, "1");
+  });
+
+  it("runs the function itself for $LATEST and for no qualifier", async () => {
+    const lambda = await givenPublishedFunction();
+
+    // When the function is invoked with $LATEST, and with nothing.
+    const latest = await lambda.invoke(
+      new InvokeCommand({ FunctionName: "orders", Qualifier: "$LATEST" }),
+    );
+    const unqualified = await lambda.invoke(
+      new InvokeCommand({ FunctionName: "orders" }),
+    );
+
+    // Then both run the function rather than any published version.
+    assertIdentical(latest.ExecutedVersion, "$LATEST");
+    assertIdentical(unqualified.ExecutedVersion, "$LATEST");
+    assertStringIncludes(
+      invokedPayload(unqualified.Payload).invokedFunctionArn,
+      ":function:orders",
+    );
+  });
+
+  it("throws on a qualifier naming no version or alias", async () => {
+    const lambda = await givenPublishedFunction();
+
+    // When the function is invoked for something nothing published.
+    const error = await assertThrowsErrorAsync(async () =>
+      lambda.invoke(
+        new InvokeCommand({ FunctionName: "orders", Qualifier: "PROD" }),
+      ),
+    );
+
+    // Then the qualified function is what gets reported as missing.
+    assertInstanceOf(error, SimLambdaResourceNotFoundException);
+    assertStringIncludes(error.message, ":function:orders:PROD");
+  });
+
+  it("throws when the name and the Qualifier disagree", async () => {
+    const lambda = await givenPublishedFunction();
+
+    // When a request qualifies the name one way and asks for another.
+    const error = await assertThrowsErrorAsync(async () =>
+      lambda.invoke(
+        new InvokeCommand({ FunctionName: "orders:live", Qualifier: "1" }),
+      ),
+    );
+
+    // Then it is refused rather than one of the two being picked.
+    assertInstanceOf(error, SimLambdaInvalidParameterValueException);
+    assertStringIncludes(error.message, "does not match");
+  });
+
+  it("reports the version that failed when a handler throws", async () => {
+    // Given a published version whose handler throws.
+    const lambda = new SimAws().lambda();
+    await lambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "orders",
+        Role: "arn:aws:iam::111111111111:role/OrdersRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput(() => {
+            throw new Error("no");
+          }),
+        },
+      }),
+    );
+    await lambda.publishVersion(
+      new PublishVersionCommand({ FunctionName: "orders" }),
+    );
+
+    // When that version is invoked.
+    const invoked = await lambda.invoke(
+      new InvokeCommand({ FunctionName: "orders", Qualifier: "1" }),
+    );
+
+    // Then the failure is reported against the version that ran.
+    assertIdentical(invoked.FunctionError, "Unhandled");
+    assertIdentical(invoked.ExecutedVersion, "1");
+  });
+});

--- a/src/service/lambda/command/invoke/invoke.handler.ts
+++ b/src/service/lambda/command/invoke/invoke.handler.ts
@@ -11,11 +11,13 @@ import {
   type SimIamInterServiceAuthZ,
 } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimLambdaResourceNotFoundException } from "../../error/sim-lambda.error.js";
-import {
-  type SimLambdaFunctionMap,
-  type SimLambdaFunctionName,
-  simLambdaFunctionArn,
+import { simLambdaQualifiedFunctionOf } from "../../function/sim-lambda-function-reference.js";
+import type { SimLambdaFunctionVersionStore } from "../../function/version/sim-lambda-function-version-store.js";
+import type {
+  SimLambdaFunctionMap,
+  SimLambdaFunctionName,
 } from "../../function/sim-lambda-function.js";
+import { simLambdaFunctionArn } from "../../function/sim-lambda-function-configuration.js";
 import { InvokeAuthorizer } from "./invoke-authorizer.js";
 import { SimLambdaInvocationDispatcher } from "./invoke-dispatcher.js";
 import type {
@@ -26,6 +28,7 @@ import type {
 interface InvokeCommandHandlerProperties {
   accountRegionScope: SimAwsAccountRegionScope;
   functions: SimLambdaFunctionMap;
+  versions: SimLambdaFunctionVersionStore;
   iam?: SimIamInterServiceAuthZ;
   background?: BackgroundScheduler;
 }
@@ -45,6 +48,7 @@ export class InvokeCommandHandler implements CommandHandler<
 > {
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly functions: SimLambdaFunctionMap;
+  private readonly versions: SimLambdaFunctionVersionStore;
   private readonly authorizer: InvokeAuthorizer;
   private readonly background: BackgroundScheduler;
   private readonly dispatcher: SimLambdaInvocationDispatcher;
@@ -53,18 +57,24 @@ export class InvokeCommandHandler implements CommandHandler<
     const {
       accountRegionScope,
       functions,
+      versions,
       iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
     } = properties;
     this.accountRegionScope = accountRegionScope;
     this.functions = functions;
+    this.versions = versions;
     this.authorizer = new InvokeAuthorizer({ iam });
     this.background = background;
     this.dispatcher = new SimLambdaInvocationDispatcher({ background });
   }
 
   /**
-   * Invoke a sim Lambda function.
+   * Invoke a sim Lambda function, or the version a qualifier names.
+   *
+   * The qualifier comes from the request's own `Qualifier` or from the
+   * function name it was addressed to, and an alias resolves to the version it
+   * points at.
    */
   async handle(
     command: SimInvokeCommand,
@@ -78,17 +88,23 @@ export class InvokeCommandHandler implements CommandHandler<
     // Allow for potential non-deterministic sequencing of async events.
     await this.background.sequence();
 
+    const { functionName, qualifier } = simLambdaQualifiedFunctionOf(
+      command.input.FunctionName,
+      command.input.Qualifier,
+    );
     const functionArn = simLambdaFunctionArn(
       this.accountRegionScope,
-      command.input.FunctionName,
+      functionName,
     );
     const simFunction = this.functions.get(
-      command.input.FunctionName as SimLambdaFunctionName,
+      functionName as SimLambdaFunctionName,
     );
 
     // Looked up before authorizing, because the function's own resource policy
     // is part of what decides the answer, but still reported as missing only
-    // after authorization, as AWS orders the two.
+    // after authorization, as AWS orders the two. Authorization is against the
+    // function rather than the version, since a resource policy statement is
+    // not qualified here yet.
     this.authorizer.authorize(functionArn, options?.caller, simFunction);
 
     if (simFunction === undefined) {
@@ -97,6 +113,9 @@ export class InvokeCommandHandler implements CommandHandler<
       );
     }
 
-    return await this.dispatcher.dispatch(simFunction, command);
+    return await this.dispatcher.dispatch(
+      this.versions.require(simFunction, qualifier),
+      command,
+    );
   }
 }

--- a/src/service/lambda/command/list-aliases/list-aliases.command.ts
+++ b/src/service/lambda/command/list-aliases/list-aliases.command.ts
@@ -1,0 +1,33 @@
+/**
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/ListAliasesCommand/
+ */
+
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimLambdaFunctionAliasConfiguration } from "../../function/version/sim-lambda-function-alias.js";
+
+/**
+ * Minimal structural sim Lambda ListAliases command.
+ */
+export interface SimListAliasesCommand {
+  readonly input: SimListAliasesCommandInput;
+}
+
+/**
+ * Minimal structural sim Lambda ListAliases input.
+ *
+ * Every alias is reported in one answer, so the `Marker` and `MaxItems` real
+ * Lambda pages with are left out. A `FunctionVersion` narrows the answer to
+ * the aliases pointing at one version.
+ */
+export interface SimListAliasesCommandInput {
+  readonly FunctionName?: string | undefined;
+  readonly FunctionVersion?: string | undefined;
+}
+
+/**
+ * Minimal structural sim Lambda ListAliases output.
+ */
+export interface SimListAliasesCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+  Aliases: SimLambdaFunctionAliasConfiguration[];
+}

--- a/src/service/lambda/command/list-aliases/list-aliases.handler.ts
+++ b/src/service/lambda/command/list-aliases/list-aliases.handler.ts
@@ -1,0 +1,95 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simLambdaFunctionReferenceOf } from "../../function/sim-lambda-function-reference.js";
+import type { SimLambdaFunctionAliasStore } from "../../function/version/sim-lambda-function-alias-store.js";
+import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
+import { VersionAuthorizer } from "../version/version-authorizer.js";
+import type {
+  SimListAliasesCommand,
+  SimListAliasesCommandOutput,
+} from "./list-aliases.command.js";
+
+interface ListAliasesCommandHandlerProperties {
+  readonly functions: SimLambdaFunctionLookup;
+  readonly aliases: SimLambdaFunctionAliasStore;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+interface ListAliasesCommandHandlerOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * Simulated Lambda ListAliasesCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/ListAliasesCommand/
+ */
+export class ListAliasesCommandHandler implements CommandHandler<
+  SimListAliasesCommand,
+  SimListAliasesCommandOutput
+> {
+  private readonly functions: SimLambdaFunctionLookup;
+  private readonly aliases: SimLambdaFunctionAliasStore;
+  private readonly authorizer: VersionAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: ListAliasesCommandHandlerProperties) {
+    const {
+      functions,
+      aliases,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+    this.functions = functions;
+    this.aliases = aliases;
+    this.authorizer = new VersionAuthorizer({
+      iam,
+      action: "lambda:ListAliases",
+    });
+    this.background = background;
+  }
+
+  /**
+   * List a sim Lambda function's aliases, or the ones pointing at one of its
+   * versions.
+   */
+  async handle(
+    command: SimListAliasesCommand,
+    options?: ListAliasesCommandHandlerOptions,
+  ): Promise<SimListAliasesCommandOutput> {
+    const { input } = command;
+    assertDefined(
+      input.FunctionName,
+      "ListAliasesCommand.input.FunctionName required",
+    );
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    const { functionName } = simLambdaFunctionReferenceOf(input.FunctionName);
+    this.authorizer.authorize(
+      this.functions.functionArn(functionName),
+      options?.caller,
+    );
+
+    const aliases = this.aliases.all(
+      this.functions.require(functionName),
+      input.FunctionVersion,
+    );
+
+    return {
+      $metadata: {},
+      Aliases: aliases.map((alias) => alias.configuration()),
+    };
+  }
+}

--- a/src/service/lambda/command/list-aliases/list-aliases.handler.ts
+++ b/src/service/lambda/command/list-aliases/list-aliases.handler.ts
@@ -9,7 +9,7 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
-import { simLambdaFunctionReferenceOf } from "../../function/sim-lambda-function-reference.js";
+import { simLambdaUnqualifiedFunctionOf } from "../../function/sim-lambda-function-reference.js";
 import type { SimLambdaFunctionAliasStore } from "../../function/version/sim-lambda-function-alias-store.js";
 import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
 import { VersionAuthorizer } from "../version/version-authorizer.js";
@@ -76,7 +76,7 @@ export class ListAliasesCommandHandler implements CommandHandler<
     // Allow for potential non-deterministic sequencing of async events.
     await this.background.sequence();
 
-    const { functionName } = simLambdaFunctionReferenceOf(input.FunctionName);
+    const functionName = simLambdaUnqualifiedFunctionOf(input.FunctionName);
     this.authorizer.authorize(
       this.functions.functionArn(functionName),
       options?.caller,

--- a/src/service/lambda/command/list-versions-by-function/list-versions-by-function.command.ts
+++ b/src/service/lambda/command/list-versions-by-function/list-versions-by-function.command.ts
@@ -1,0 +1,31 @@
+/**
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/ListVersionsByFunctionCommand/
+ */
+
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimLambdaFunctionConfiguration } from "../../function/sim-lambda-function-configuration.js";
+
+/**
+ * Minimal structural sim Lambda ListVersionsByFunction command.
+ */
+export interface SimListVersionsByFunctionCommand {
+  readonly input: SimListVersionsByFunctionCommandInput;
+}
+
+/**
+ * Minimal structural sim Lambda ListVersionsByFunction input.
+ *
+ * Every version is reported in one answer, so the `Marker` and `MaxItems`
+ * real Lambda pages with are left out.
+ */
+export interface SimListVersionsByFunctionCommandInput {
+  readonly FunctionName?: string | undefined;
+}
+
+/**
+ * Minimal structural sim Lambda ListVersionsByFunction output.
+ */
+export interface SimListVersionsByFunctionCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+  Versions: SimLambdaFunctionConfiguration[];
+}

--- a/src/service/lambda/command/list-versions-by-function/list-versions-by-function.handler.ts
+++ b/src/service/lambda/command/list-versions-by-function/list-versions-by-function.handler.ts
@@ -9,7 +9,7 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
-import { simLambdaFunctionReferenceOf } from "../../function/sim-lambda-function-reference.js";
+import { simLambdaUnqualifiedFunctionOf } from "../../function/sim-lambda-function-reference.js";
 import type { SimLambdaFunctionVersionStore } from "../../function/version/sim-lambda-function-version-store.js";
 import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
 import { VersionAuthorizer } from "../version/version-authorizer.js";
@@ -75,7 +75,7 @@ export class ListVersionsByFunctionCommandHandler implements CommandHandler<
     // Allow for potential non-deterministic sequencing of async events.
     await this.background.sequence();
 
-    const { functionName } = simLambdaFunctionReferenceOf(
+    const functionName = simLambdaUnqualifiedFunctionOf(
       command.input.FunctionName,
     );
     this.authorizer.authorize(

--- a/src/service/lambda/command/list-versions-by-function/list-versions-by-function.handler.ts
+++ b/src/service/lambda/command/list-versions-by-function/list-versions-by-function.handler.ts
@@ -1,0 +1,93 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simLambdaFunctionReferenceOf } from "../../function/sim-lambda-function-reference.js";
+import type { SimLambdaFunctionVersionStore } from "../../function/version/sim-lambda-function-version-store.js";
+import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
+import { VersionAuthorizer } from "../version/version-authorizer.js";
+import type {
+  SimListVersionsByFunctionCommand,
+  SimListVersionsByFunctionCommandOutput,
+} from "./list-versions-by-function.command.js";
+
+interface ListVersionsByFunctionCommandHandlerProperties {
+  readonly functions: SimLambdaFunctionLookup;
+  readonly versions: SimLambdaFunctionVersionStore;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+interface ListVersionsByFunctionCommandHandlerOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * Simulated Lambda ListVersionsByFunctionCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/ListVersionsByFunctionCommand/
+ */
+export class ListVersionsByFunctionCommandHandler implements CommandHandler<
+  SimListVersionsByFunctionCommand,
+  SimListVersionsByFunctionCommandOutput
+> {
+  private readonly functions: SimLambdaFunctionLookup;
+  private readonly versions: SimLambdaFunctionVersionStore;
+  private readonly authorizer: VersionAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: ListVersionsByFunctionCommandHandlerProperties) {
+    const {
+      functions,
+      versions,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+    this.functions = functions;
+    this.versions = versions;
+    this.authorizer = new VersionAuthorizer({
+      iam,
+      action: "lambda:ListVersionsByFunction",
+    });
+    this.background = background;
+  }
+
+  /**
+   * List a sim Lambda function's versions, which are `$LATEST` and each
+   * version published from it, oldest first.
+   */
+  async handle(
+    command: SimListVersionsByFunctionCommand,
+    options?: ListVersionsByFunctionCommandHandlerOptions,
+  ): Promise<SimListVersionsByFunctionCommandOutput> {
+    assertDefined(
+      command.input.FunctionName,
+      "ListVersionsByFunctionCommand.input.FunctionName required",
+    );
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    const { functionName } = simLambdaFunctionReferenceOf(
+      command.input.FunctionName,
+    );
+    this.authorizer.authorize(
+      this.functions.functionArn(functionName),
+      options?.caller,
+    );
+
+    const versions = this.versions.all(this.functions.require(functionName));
+
+    return {
+      $metadata: {},
+      Versions: versions.map((version) => version.configuration()),
+    };
+  }
+}

--- a/src/service/lambda/command/list-versions-by-function/list-versions-by-function.iso.test.ts
+++ b/src/service/lambda/command/list-versions-by-function/list-versions-by-function.iso.test.ts
@@ -1,0 +1,131 @@
+import {
+  CreateFunctionCommand,
+  ListVersionsByFunctionCommand,
+  PublishVersionCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { SimLambdaResourceNotFoundException } from "../../error/sim-lambda.error.js";
+import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
+import { SimLambda } from "../../sim-lambda.js";
+
+describe("Lambda ListVersionsByFunctionCommand", () => {
+  it("lists $LATEST and each published version", async () => {
+    // Given a function with two published versions.
+    const simAws = new SimAws();
+    const lambda = simAws.lambda();
+    await lambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "orders",
+        Role: "arn:aws:iam::111111111111:role/OrdersRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "handled") },
+      }),
+    );
+    await lambda.publishVersion(
+      new PublishVersionCommand({ FunctionName: "orders" }),
+    );
+    await lambda.publishVersion(
+      new PublishVersionCommand({ FunctionName: "orders" }),
+    );
+
+    // When the function's versions are listed.
+    const listed = await lambda.listVersionsByFunction(
+      new ListVersionsByFunctionCommand({ FunctionName: "orders" }),
+    );
+
+    // Then $LATEST comes first, followed by each version in the order they
+    // were published.
+    assertArrayLength(listed.Versions, 3);
+    assertArrayEquals(
+      listed.Versions.map((version) => version.Version),
+      ["$LATEST", "1", "2"],
+    );
+    assertStringIncludes(listed.Versions[2].FunctionArn, ":orders:2");
+  });
+
+  it("lists only $LATEST for a function that has published nothing", async () => {
+    // Given a function with no published versions.
+    const simLambda = new SimLambda();
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "orders",
+        Role: "arn:aws:iam::111111111111:role/OrdersRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "handled") },
+      }),
+    );
+
+    // When its versions are listed.
+    const listed = await simLambda.listVersionsByFunction(
+      new ListVersionsByFunctionCommand({ FunctionName: "orders" }),
+    );
+
+    // Then the function itself is the only version there is.
+    assertArrayLength(listed.Versions, 1);
+    assertIdentical(listed.Versions[0].Version, "$LATEST");
+  });
+
+  it("throws on a function that does not exist", async () => {
+    // Given a simulated AWS with no functions.
+    const simAws = new SimAws();
+
+    // When the versions of a missing function are listed.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .lambda()
+        .listVersionsByFunction(
+          new ListVersionsByFunctionCommand({ FunctionName: "missing" }),
+        ),
+    );
+
+    // Then the missing function is what gets reported.
+    assertInstanceOf(error, SimLambdaResourceNotFoundException);
+    assertStringIncludes(error.message, "Function not found");
+  });
+
+  it("throws on an undefined function name", async () => {
+    // Given a standalone sim Lambda.
+    const simLambda = new SimLambda();
+
+    // When versions are listed without naming a function.
+    const error = await assertThrowsErrorAsync(async () =>
+      simLambda.listVersionsByFunction(
+        new ListVersionsByFunctionCommand({ FunctionName: undefined }),
+      ),
+    );
+
+    // Then the missing input is reported.
+    assertStringIncludes(
+      error.message,
+      "ListVersionsByFunctionCommand.input.FunctionName required",
+    );
+  });
+
+  it("denies an explicitly anonymous caller through sim IAM", async () => {
+    // Given a simulated AWS with sim IAM in play.
+    const simAws = new SimAws();
+
+    // When an anonymous caller lists a function's versions.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .lambda()
+        .listVersionsByFunction(
+          new ListVersionsByFunctionCommand({ FunctionName: "orders" }),
+          { caller: { kind: "anonymous" } },
+        ),
+    );
+
+    // Then the request is denied for the matching IAM action.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "lambda:ListVersionsByFunction");
+  });
+});

--- a/src/service/lambda/command/publish-version/publish-version.command.ts
+++ b/src/service/lambda/command/publish-version/publish-version.command.ts
@@ -1,0 +1,32 @@
+/**
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/PublishVersionCommand/
+ */
+
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimLambdaFunctionConfiguration } from "../../function/sim-lambda-function-configuration.js";
+
+/**
+ * Minimal structural sim Lambda PublishVersion command.
+ */
+export interface SimPublishVersionCommand {
+  readonly input: SimPublishVersionCommandInput;
+}
+
+/**
+ * Minimal structural sim Lambda PublishVersion input.
+ *
+ * Real Lambda takes a `CodeSha256` and a `RevisionId` here to publish only
+ * code the caller has already seen. Neither is simulated, so both are left out
+ * rather than accepted and ignored.
+ */
+export interface SimPublishVersionCommandInput {
+  readonly FunctionName?: string | undefined;
+}
+
+/**
+ * Minimal structural sim Lambda PublishVersion output, which is the published
+ * version's own configuration.
+ */
+export interface SimPublishVersionCommandOutput extends SimLambdaFunctionConfiguration {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/lambda/command/publish-version/publish-version.handler.ts
+++ b/src/service/lambda/command/publish-version/publish-version.handler.ts
@@ -9,7 +9,7 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
-import { simLambdaFunctionReferenceOf } from "../../function/sim-lambda-function-reference.js";
+import { simLambdaUnqualifiedFunctionOf } from "../../function/sim-lambda-function-reference.js";
 import type { SimLambdaFunctionVersionStore } from "../../function/version/sim-lambda-function-version-store.js";
 import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
 import { VersionAuthorizer } from "../version/version-authorizer.js";
@@ -77,7 +77,7 @@ export class PublishVersionCommandHandler implements CommandHandler<
     // Allow for potential non-deterministic sequencing of async events.
     await this.background.sequence();
 
-    const { functionName } = simLambdaFunctionReferenceOf(
+    const functionName = simLambdaUnqualifiedFunctionOf(
       command.input.FunctionName,
     );
     this.authorizer.authorize(

--- a/src/service/lambda/command/publish-version/publish-version.handler.ts
+++ b/src/service/lambda/command/publish-version/publish-version.handler.ts
@@ -1,0 +1,92 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simLambdaFunctionReferenceOf } from "../../function/sim-lambda-function-reference.js";
+import type { SimLambdaFunctionVersionStore } from "../../function/version/sim-lambda-function-version-store.js";
+import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
+import { VersionAuthorizer } from "../version/version-authorizer.js";
+import type {
+  SimPublishVersionCommand,
+  SimPublishVersionCommandOutput,
+} from "./publish-version.command.js";
+
+interface PublishVersionCommandHandlerProperties {
+  readonly functions: SimLambdaFunctionLookup;
+  readonly versions: SimLambdaFunctionVersionStore;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+interface PublishVersionCommandHandlerOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * Simulated Lambda PublishVersionCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/PublishVersionCommand/
+ */
+export class PublishVersionCommandHandler implements CommandHandler<
+  SimPublishVersionCommand,
+  SimPublishVersionCommandOutput
+> {
+  private readonly functions: SimLambdaFunctionLookup;
+  private readonly versions: SimLambdaFunctionVersionStore;
+  private readonly authorizer: VersionAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: PublishVersionCommandHandlerProperties) {
+    const {
+      functions,
+      versions,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+    this.functions = functions;
+    this.versions = versions;
+    this.authorizer = new VersionAuthorizer({
+      iam,
+      action: "lambda:PublishVersion",
+    });
+    this.background = background;
+  }
+
+  /**
+   * Publish a sim Lambda function as it stands as its next version.
+   *
+   * The first version a function publishes is 1, and each later one counts up
+   * from there.
+   */
+  async handle(
+    command: SimPublishVersionCommand,
+    options?: PublishVersionCommandHandlerOptions,
+  ): Promise<SimPublishVersionCommandOutput> {
+    assertDefined(
+      command.input.FunctionName,
+      "PublishVersionCommand.input.FunctionName required",
+    );
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    const { functionName } = simLambdaFunctionReferenceOf(
+      command.input.FunctionName,
+    );
+    this.authorizer.authorize(
+      this.functions.functionArn(functionName),
+      options?.caller,
+    );
+
+    const version = this.versions.publish(this.functions.require(functionName));
+
+    return { $metadata: {}, ...version.configuration() };
+  }
+}

--- a/src/service/lambda/command/publish-version/publish-version.iso.test.ts
+++ b/src/service/lambda/command/publish-version/publish-version.iso.test.ts
@@ -14,7 +14,10 @@ import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
-import { SimLambdaResourceNotFoundException } from "../../error/sim-lambda.error.js";
+import {
+  SimLambdaInvalidParameterValueException,
+  SimLambdaResourceNotFoundException,
+} from "../../error/sim-lambda.error.js";
 import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
 import { SimLambda } from "../../sim-lambda.js";
 
@@ -111,6 +114,33 @@ describe("Lambda PublishVersionCommand", () => {
     // Then the missing function is what gets reported.
     assertInstanceOf(error, SimLambdaResourceNotFoundException);
     assertStringIncludes(error.message, "Function not found");
+  });
+
+  it("refuses a function name carrying a qualifier", async () => {
+    // Given a function with a published version.
+    const simAws = new SimAws();
+    const lambda = simAws.lambda();
+    await lambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "orders",
+        Role: "arn:aws:iam::111111111111:role/OrdersRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "handled") },
+      }),
+    );
+    await lambda.publishVersion(
+      new PublishVersionCommand({ FunctionName: "orders" }),
+    );
+
+    // When a version is published from a name naming one of its versions.
+    const error = await assertThrowsErrorAsync(async () =>
+      lambda.publishVersion(
+        new PublishVersionCommand({ FunctionName: "orders:1" }),
+      ),
+    );
+
+    // Then it is refused rather than published from the function anyway.
+    assertInstanceOf(error, SimLambdaInvalidParameterValueException);
+    assertStringIncludes(error.message, "qualified function");
   });
 
   it("throws on an undefined function name", async () => {

--- a/src/service/lambda/command/publish-version/publish-version.iso.test.ts
+++ b/src/service/lambda/command/publish-version/publish-version.iso.test.ts
@@ -1,0 +1,151 @@
+import {
+  CreateFunctionCommand,
+  GetFunctionCommand,
+  PublishVersionCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringEndsWith,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { SimLambdaResourceNotFoundException } from "../../error/sim-lambda.error.js";
+import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
+import { SimLambda } from "../../sim-lambda.js";
+
+describe("Lambda PublishVersionCommand", () => {
+  it("publishes a function's first version as 1", async () => {
+    // Given a function with no published versions.
+    const simLambda = new SimLambda();
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "orders",
+        Role: "arn:aws:iam::111111111111:role/OrdersRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "handled") },
+        MemorySize: 512,
+        Timeout: 30,
+        Environment: { Variables: { STAGE: "live" } },
+      }),
+    );
+
+    // When a version is published.
+    const published = await simLambda.publishVersion(
+      new PublishVersionCommand({ FunctionName: "orders" }),
+    );
+
+    // Then it is version 1, addressed by a qualified ARN, and carries the
+    // configuration it was published with.
+    assertIdentical(published.Version, "1");
+    assertStringIncludes(published.FunctionArn, ":function:orders:1");
+    assertIdentical(published.State, "Active");
+    assertIdentical(published.MemorySize, 512);
+    assertIdentical(published.Timeout, 30);
+    assertIdentical(published.Environment?.Variables["STAGE"], "live");
+  });
+
+  it("numbers each later version upwards", async () => {
+    // Given a function that has published a version already.
+    const simAws = new SimAws();
+    const lambda = simAws.lambda();
+    await lambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "orders",
+        Role: "arn:aws:iam::111111111111:role/OrdersRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "handled") },
+      }),
+    );
+    await lambda.publishVersion(
+      new PublishVersionCommand({ FunctionName: "orders" }),
+    );
+
+    // When another is published.
+    const published = await lambda.publishVersion(
+      new PublishVersionCommand({ FunctionName: "orders" }),
+    );
+
+    // Then it is the next number up.
+    assertIdentical(published.Version, "2");
+  });
+
+  it("leaves the function itself reporting $LATEST", async () => {
+    // Given a function with a published version.
+    const simAws = new SimAws();
+    const lambda = simAws.lambda();
+    await lambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "orders",
+        Role: "arn:aws:iam::111111111111:role/OrdersRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "handled") },
+      }),
+    );
+    await lambda.publishVersion(
+      new PublishVersionCommand({ FunctionName: "orders" }),
+    );
+
+    // When the function is read without a qualifier.
+    const fetched = await lambda.getFunction(
+      new GetFunctionCommand({ FunctionName: "orders" }),
+    );
+
+    // Then the version it reports is still $LATEST, under the unqualified ARN.
+    assertIdentical(fetched.Configuration.Version, "$LATEST");
+    assertStringEndsWith(fetched.Configuration.FunctionArn, ":function:orders");
+  });
+
+  it("throws on a function that does not exist", async () => {
+    // Given a simulated AWS with no functions.
+    const simAws = new SimAws();
+
+    // When a version is published for a missing function.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .lambda()
+        .publishVersion(new PublishVersionCommand({ FunctionName: "missing" })),
+    );
+
+    // Then the missing function is what gets reported.
+    assertInstanceOf(error, SimLambdaResourceNotFoundException);
+    assertStringIncludes(error.message, "Function not found");
+  });
+
+  it("throws on an undefined function name", async () => {
+    // Given a standalone sim Lambda.
+    const simLambda = new SimLambda();
+
+    // When a version is published without naming a function.
+    const error = await assertThrowsErrorAsync(async () =>
+      simLambda.publishVersion(
+        new PublishVersionCommand({ FunctionName: undefined }),
+      ),
+    );
+
+    // Then the missing input is reported.
+    assertStringIncludes(
+      error.message,
+      "PublishVersionCommand.input.FunctionName required",
+    );
+  });
+
+  it("denies an explicitly anonymous caller through sim IAM", async () => {
+    // Given a simulated AWS with sim IAM in play.
+    const simAws = new SimAws();
+
+    // When an anonymous caller publishes a version.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .lambda()
+        .publishVersion(new PublishVersionCommand({ FunctionName: "orders" }), {
+          caller: { kind: "anonymous" },
+        }),
+    );
+
+    // Then the request is denied for the matching IAM action.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "lambda:PublishVersion");
+  });
+});

--- a/src/service/lambda/command/sim-lambda-command.types.ts
+++ b/src/service/lambda/command/sim-lambda-command.types.ts
@@ -26,6 +26,10 @@ export type {
   SimListEventSourceMappingsCommandOutput,
 } from "./event-source-mapping/event-source-mapping.command.js";
 export type {
+  SimCreateAliasCommand,
+  SimCreateAliasCommandOutput,
+} from "./create-alias/create-alias.command.js";
+export type {
   SimCreateFunctionCommand,
   SimCreateFunctionCommandOutput,
 } from "./create-function/create-function.command.js";
@@ -34,6 +38,10 @@ export type {
   SimCreateFunctionUrlConfigCommandOutput,
 } from "./create-function-url-config/create-function-url-config.command.js";
 export type {
+  SimDeleteAliasCommand,
+  SimDeleteAliasCommandOutput,
+} from "./delete-alias/delete-alias.command.js";
+export type {
   SimDeleteFunctionCommand,
   SimDeleteFunctionCommandOutput,
 } from "./delete-function/delete-function.command.js";
@@ -41,6 +49,10 @@ export type {
   SimDeleteFunctionUrlConfigCommand,
   SimDeleteFunctionUrlConfigCommandOutput,
 } from "./delete-function-url-config/delete-function-url-config.command.js";
+export type {
+  SimGetAliasCommand,
+  SimGetAliasCommandOutput,
+} from "./get-alias/get-alias.command.js";
 export type {
   SimGetFunctionCommand,
   SimGetFunctionCommandOutput,
@@ -58,13 +70,29 @@ export type {
   SimInvokeCommandOutput,
 } from "./invoke/invoke.command.js";
 export type {
+  SimListAliasesCommand,
+  SimListAliasesCommandOutput,
+} from "./list-aliases/list-aliases.command.js";
+export type {
   SimListFunctionUrlConfigsCommand,
   SimListFunctionUrlConfigsCommandOutput,
 } from "./list-function-url-configs/list-function-url-configs.command.js";
 export type {
+  SimListVersionsByFunctionCommand,
+  SimListVersionsByFunctionCommandOutput,
+} from "./list-versions-by-function/list-versions-by-function.command.js";
+export type {
+  SimPublishVersionCommand,
+  SimPublishVersionCommandOutput,
+} from "./publish-version/publish-version.command.js";
+export type {
   SimRemovePermissionCommand,
   SimRemovePermissionCommandOutput,
 } from "./remove-permission/remove-permission.command.js";
+export type {
+  SimUpdateAliasCommand,
+  SimUpdateAliasCommandOutput,
+} from "./update-alias/update-alias.command.js";
 export type {
   SimUpdateFunctionUrlConfigCommand,
   SimUpdateFunctionUrlConfigCommandOutput,

--- a/src/service/lambda/command/update-alias/update-alias.command.ts
+++ b/src/service/lambda/command/update-alias/update-alias.command.ts
@@ -1,0 +1,34 @@
+/**
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/UpdateAliasCommand/
+ */
+
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimLambdaFunctionAliasConfiguration } from "../../function/version/sim-lambda-function-alias.js";
+
+/**
+ * Minimal structural sim Lambda UpdateAlias command.
+ */
+export interface SimUpdateAliasCommand {
+  readonly input: SimUpdateAliasCommandInput;
+}
+
+/**
+ * Minimal structural sim Lambda UpdateAlias input.
+ *
+ * An omitted member leaves that part of the alias as it is. The
+ * `RoutingConfig` and `RevisionId` real Lambda takes here are left out, as
+ * neither weighted routing nor revisions are simulated.
+ */
+export interface SimUpdateAliasCommandInput {
+  readonly FunctionName?: string | undefined;
+  readonly Name?: string | undefined;
+  readonly FunctionVersion?: string | undefined;
+  readonly Description?: string | undefined;
+}
+
+/**
+ * Minimal structural sim Lambda UpdateAlias output.
+ */
+export interface SimUpdateAliasCommandOutput extends SimLambdaFunctionAliasConfiguration {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/lambda/command/update-alias/update-alias.handler.ts
+++ b/src/service/lambda/command/update-alias/update-alias.handler.ts
@@ -9,7 +9,7 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
-import { simLambdaFunctionReferenceOf } from "../../function/sim-lambda-function-reference.js";
+import { simLambdaUnqualifiedFunctionOf } from "../../function/sim-lambda-function-reference.js";
 import type { SimLambdaFunctionAliasStore } from "../../function/version/sim-lambda-function-alias-store.js";
 import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
 import { AliasInputParser } from "../alias/alias-input.js";
@@ -78,7 +78,7 @@ export class UpdateAliasCommandHandler implements CommandHandler<
     // Allow for potential non-deterministic sequencing of async events.
     await this.background.sequence();
 
-    const { functionName } = simLambdaFunctionReferenceOf(input.FunctionName);
+    const functionName = simLambdaUnqualifiedFunctionOf(input.FunctionName);
     this.authorizer.authorize(
       this.functions.functionArn(functionName),
       options?.caller,

--- a/src/service/lambda/command/update-alias/update-alias.handler.ts
+++ b/src/service/lambda/command/update-alias/update-alias.handler.ts
@@ -1,0 +1,98 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simLambdaFunctionReferenceOf } from "../../function/sim-lambda-function-reference.js";
+import type { SimLambdaFunctionAliasStore } from "../../function/version/sim-lambda-function-alias-store.js";
+import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
+import { AliasInputParser } from "../alias/alias-input.js";
+import { VersionAuthorizer } from "../version/version-authorizer.js";
+import type {
+  SimUpdateAliasCommand,
+  SimUpdateAliasCommandOutput,
+} from "./update-alias.command.js";
+
+interface UpdateAliasCommandHandlerProperties {
+  readonly functions: SimLambdaFunctionLookup;
+  readonly aliases: SimLambdaFunctionAliasStore;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+interface UpdateAliasCommandHandlerOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * Simulated Lambda UpdateAliasCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/UpdateAliasCommand/
+ */
+export class UpdateAliasCommandHandler implements CommandHandler<
+  SimUpdateAliasCommand,
+  SimUpdateAliasCommandOutput
+> {
+  private readonly functions: SimLambdaFunctionLookup;
+  private readonly aliases: SimLambdaFunctionAliasStore;
+  private readonly authorizer: VersionAuthorizer;
+  private readonly background: BackgroundScheduler;
+  private readonly inputParser = new AliasInputParser();
+
+  constructor(properties: UpdateAliasCommandHandlerProperties) {
+    const {
+      functions,
+      aliases,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+    this.functions = functions;
+    this.aliases = aliases;
+    this.authorizer = new VersionAuthorizer({
+      iam,
+      action: "lambda:UpdateAlias",
+    });
+    this.background = background;
+  }
+
+  /**
+   * Point an existing alias at another version, and describe it again.
+   */
+  async handle(
+    command: SimUpdateAliasCommand,
+    options?: UpdateAliasCommandHandlerOptions,
+  ): Promise<SimUpdateAliasCommandOutput> {
+    const { input } = command;
+    assertDefined(
+      input.FunctionName,
+      "UpdateAliasCommand.input.FunctionName required",
+    );
+    assertDefined(input.Name, "UpdateAliasCommand.input.Name required");
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    const { functionName } = simLambdaFunctionReferenceOf(input.FunctionName);
+    this.authorizer.authorize(
+      this.functions.functionArn(functionName),
+      options?.caller,
+    );
+
+    const alias = this.aliases.update({
+      simFunction: this.functions.require(functionName),
+      name: input.Name,
+      functionVersion: this.inputParser.parseOptionalFunctionVersion(
+        input.FunctionVersion,
+      ),
+      description: input.Description,
+    });
+
+    return { $metadata: {}, ...alias.configuration() };
+  }
+}

--- a/src/service/lambda/command/version/sim-lambda-version-commands.ts
+++ b/src/service/lambda/command/version/sim-lambda-version-commands.ts
@@ -1,0 +1,66 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimLambdaFunctionVersionStore } from "../../function/version/sim-lambda-function-version-store.js";
+import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
+import { ListVersionsByFunctionCommandHandler } from "../list-versions-by-function/list-versions-by-function.handler.js";
+import type {
+  SimListVersionsByFunctionCommand,
+  SimListVersionsByFunctionCommandOutput,
+} from "../list-versions-by-function/list-versions-by-function.command.js";
+import { PublishVersionCommandHandler } from "../publish-version/publish-version.handler.js";
+import type {
+  SimPublishVersionCommand,
+  SimPublishVersionCommandOutput,
+} from "../publish-version/publish-version.command.js";
+
+interface SimLambdaVersionCommandsProperties {
+  readonly functions: SimLambdaFunctionLookup;
+  readonly versions: SimLambdaFunctionVersionStore;
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly background: BackgroundScheduler;
+}
+
+interface SimLambdaVersionCommandOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The published version commands of one simulated Lambda scope.
+ *
+ * These two share the same collaborators and differ only in the handler they
+ * run, so grouping them keeps the SimLambda facade a thin delegation rather
+ * than two near-identical wiring blocks.
+ */
+export class SimLambdaVersionCommands {
+  private readonly properties: SimLambdaVersionCommandsProperties;
+
+  constructor(properties: SimLambdaVersionCommandsProperties) {
+    this.properties = properties;
+  }
+
+  /**
+   * Publish a function as it stands as its next version.
+   */
+  async publish(
+    command: SimPublishVersionCommand,
+    options?: SimLambdaVersionCommandOptions,
+  ): Promise<SimPublishVersionCommandOutput> {
+    return await new PublishVersionCommandHandler(this.properties).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * List a function's versions.
+   */
+  async list(
+    command: SimListVersionsByFunctionCommand,
+    options?: SimLambdaVersionCommandOptions,
+  ): Promise<SimListVersionsByFunctionCommandOutput> {
+    return await new ListVersionsByFunctionCommandHandler(
+      this.properties,
+    ).handle(command, options);
+  }
+}

--- a/src/service/lambda/command/version/version-authorizer.ts
+++ b/src/service/lambda/command/version/version-authorizer.ts
@@ -1,0 +1,49 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+
+interface VersionAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly action: string;
+}
+
+/**
+ * Applies IAM authorization to a Lambda version or alias request.
+ *
+ * AWS maps each of these operations to the IAM action of the same name,
+ * always against the ARN of the function the version or alias belongs to. The
+ * action varies but nothing else does, so one authorizer serves all seven
+ * rather than a near-identical class per command.
+ */
+export class VersionAuthorizer {
+  private readonly iam: SimIamInterServiceAuthZ;
+  private readonly action: string;
+
+  constructor(properties: VersionAuthorizerProperties) {
+    this.iam = properties.iam;
+    this.action = properties.action;
+  }
+
+  /**
+   * Ensure the caller may perform this action on the function.
+   *
+   * The caller is passed through unchanged so sim IAM can distinguish an
+   * omitted caller, which defaults to Account root, from an explicit
+   * anonymous caller.
+   */
+  authorize(functionArn: string, caller?: SimAwsCaller): void {
+    const decision = this.iam.authorize({
+      action: this.action,
+      resource: functionArn,
+      caller,
+    });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action: this.action,
+        resource: functionArn,
+      });
+    }
+  }
+}

--- a/src/service/lambda/event-source/sim-lambda-event-source-mapping.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-mapping.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
-import type { SimLambdaFunctionArn } from "../function/sim-lambda-function.js";
+import type { SimLambdaFunctionArn } from "../function/sim-lambda-function-configuration.js";
 import type { SimLambdaEventSourceStartingPosition } from "./sim-lambda-event-source-starting-position.js";
 
 /**

--- a/src/service/lambda/function/invoke/sim-lambda-handler-runner.iso.test.ts
+++ b/src/service/lambda/function/invoke/sim-lambda-handler-runner.iso.test.ts
@@ -13,6 +13,7 @@ import { SimLambdaHandlerRunner } from "./sim-lambda-handler-runner.js";
 import { SimLambdaInvokeContextBuilder } from "./sim-lambda-invoke-context-builder.js";
 
 const contextBuilder = new SimLambdaInvokeContextBuilder({
+  functionVersion: "$LATEST",
   functionName: "runner-test",
   invokedFunctionArn:
     "arn:aws:lambda:eu-west-2:111111111111:function:runner-test",

--- a/src/service/lambda/function/invoke/sim-lambda-invoke-context-builder.ts
+++ b/src/service/lambda/function/invoke/sim-lambda-invoke-context-builder.ts
@@ -10,6 +10,8 @@ import {
 
 interface SimLambdaInvokeContextBuilderProperties {
   readonly functionName: string;
+  /** The version the invocation is running, which is `$LATEST` or a number. */
+  readonly functionVersion: string;
   readonly invokedFunctionArn: string;
   readonly timeoutSeconds: number;
   readonly memorySizeMb: number;
@@ -42,6 +44,7 @@ export class SimLambdaInvokeContextBuilder {
   build(callback: SimLambdaCallback): SimLambdaContext {
     const {
       functionName,
+      functionVersion,
       invokedFunctionArn,
       timeoutSeconds,
       memorySizeMb,
@@ -55,7 +58,7 @@ export class SimLambdaInvokeContextBuilder {
     return {
       callbackWaitsForEmptyEventLoop: true,
       functionName,
-      functionVersion: "$LATEST",
+      functionVersion,
       invokedFunctionArn,
       memoryLimitInMB: String(memorySizeMb),
       awsRequestId,

--- a/src/service/lambda/function/sim-lambda-function-arn-parts.ts
+++ b/src/service/lambda/function/sim-lambda-function-arn-parts.ts
@@ -5,9 +5,9 @@ import type { AwsRegionName } from "../../aws/sim-aws-region.js";
  * The parts of a Lambda function ARN.
  *
  * The qualifier is the version or alias a qualified ARN names, and it is
- * reported rather than ignored: simulated Lambda has neither, so a service
- * pointed at `:PROD` would otherwise reach `$LATEST` and think it had done as
- * it was told.
+ * reported rather than ignored: a service that cannot follow one refuses the
+ * target rather than reaching `$LATEST` and thinking it had done as it was
+ * told.
  */
 export interface SimLambdaFunctionArnParts {
   readonly regionName: AwsRegionName;

--- a/src/service/lambda/function/sim-lambda-function-configuration.ts
+++ b/src/service/lambda/function/sim-lambda-function-configuration.ts
@@ -1,0 +1,66 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+
+/**
+ * The version qualifier every function answers to, which is the function
+ * itself rather than any of the versions published from it.
+ */
+export const SIM_LAMBDA_LATEST_VERSION = "$LATEST";
+
+export const DEFAULT_SIM_LAMBDA_TIMEOUT_SECONDS = 3;
+export const DEFAULT_SIM_LAMBDA_MEMORY_SIZE_MB = 128;
+
+export type SimLambdaFunctionState =
+  | "Pending"
+  | "Active"
+  | "Inactive"
+  | "Failed";
+
+/**
+ * Lambda function ARNs address the function with a colon, not a slash, and a
+ * qualified one appends the version or alias with another colon.
+ */
+export type SimLambdaFunctionArn =
+  `arn:aws:lambda:${string}:${string}:function:${string}`;
+
+/**
+ * Build the ARN a sim Lambda function has, or would have, in a scope.
+ *
+ * A qualifier is appended as real Lambda appends one, so a published version
+ * and an alias are addressed by the ARN of the function they belong to with
+ * their own name on the end.
+ */
+export function simLambdaFunctionArn(
+  scope: SimAwsAccountRegionScope,
+  name: string,
+  qualifier?: string,
+): SimLambdaFunctionArn {
+  const qualifierSuffix = qualifier === undefined ? "" : `:${qualifier}`;
+
+  return `arn:aws:lambda:${scope.regionName}:${scope.accountId}:function:${name}${qualifierSuffix}`;
+}
+
+/**
+ * The qualifier a version's ARN carries. `$LATEST` carries none, since the
+ * function itself is addressed by an unqualified ARN.
+ */
+export function simLambdaVersionQualifier(version: string): string | undefined {
+  return version === SIM_LAMBDA_LATEST_VERSION ? undefined : version;
+}
+
+/**
+ * Minimal structural Lambda function configuration, as returned by
+ * CreateFunction and GetFunction.
+ */
+export interface SimLambdaFunctionConfiguration {
+  FunctionName: string;
+  FunctionArn: SimLambdaFunctionArn;
+  Role: string;
+  State: SimLambdaFunctionState;
+  Version: string;
+  Timeout: number;
+  MemorySize: number;
+  Handler?: string | undefined;
+  Runtime?: string | undefined;
+  Description?: string | undefined;
+  Environment?: { Variables: Record<string, string> } | undefined;
+}

--- a/src/service/lambda/function/sim-lambda-function-name.ts
+++ b/src/service/lambda/function/sim-lambda-function-name.ts
@@ -6,7 +6,8 @@ const functionArnSeparator = ":function:";
  * Real Lambda accepts a name or a function ARN wherever it takes a
  * `FunctionName`, and CloudFormation templates point at a function either way
  * too: `Ref` gives the name and `Fn::GetAtt` gives the ARN. A version or alias
- * qualifier on the ARN is dropped, as qualified functions are not simulated.
+ * qualifier on the ARN is dropped, for the callers that act on the function
+ * whichever version it was pointed at.
  */
 export function simLambdaFunctionNameOf(functionNameOrArn: string): string {
   const separatorIndex = functionNameOrArn.indexOf(functionArnSeparator);

--- a/src/service/lambda/function/sim-lambda-function-name.ts
+++ b/src/service/lambda/function/sim-lambda-function-name.ts
@@ -6,8 +6,9 @@ const functionArnSeparator = ":function:";
  * Real Lambda accepts a name or a function ARN wherever it takes a
  * `FunctionName`, and CloudFormation templates point at a function either way
  * too: `Ref` gives the name and `Fn::GetAtt` gives the ARN. A version or alias
- * qualifier on the ARN is dropped, for the callers that act on the function
- * whichever version it was pointed at.
+ * qualified ARN is reduced to the bare function name, dropping the version or
+ * alias, for the callers that act on the function whichever version they were
+ * pointed at.
  */
 export function simLambdaFunctionNameOf(functionNameOrArn: string): string {
   const separatorIndex = functionNameOrArn.indexOf(functionArnSeparator);

--- a/src/service/lambda/function/sim-lambda-function-reference.iso.test.ts
+++ b/src/service/lambda/function/sim-lambda-function-reference.iso.test.ts
@@ -1,0 +1,87 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsError,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimLambdaInvalidParameterValueException } from "../error/sim-lambda.error.js";
+import {
+  simLambdaFunctionReferenceOf,
+  simLambdaQualifiedFunctionOf,
+} from "./sim-lambda-function-reference.js";
+
+const functionArn = "arn:aws:lambda:eu-west-2:111111111111:function:orders";
+
+describe("sim Lambda function reference", () => {
+  it("reads a bare function name", () => {
+    // When a name on its own is read.
+    const reference = simLambdaFunctionReferenceOf("orders");
+
+    // Then it names the function and no version.
+    assertIdentical(reference.functionName, "orders");
+    assertUndefined(reference.qualifier);
+  });
+
+  it("reads a qualifier appended to a name", () => {
+    // When a name with a qualifier is read.
+    const reference = simLambdaFunctionReferenceOf("orders:live");
+
+    // Then both parts come back.
+    assertIdentical(reference.functionName, "orders");
+    assertIdentical(reference.qualifier, "live");
+  });
+
+  it("reads a function ARN, qualified or not", () => {
+    // When each form of ARN is read.
+    const unqualified = simLambdaFunctionReferenceOf(functionArn);
+    const qualified = simLambdaFunctionReferenceOf(`${functionArn}:2`);
+
+    // Then the name comes off both, and the qualifier off the one that has it.
+    assertIdentical(unqualified.functionName, "orders");
+    assertUndefined(unqualified.qualifier);
+    assertIdentical(qualified.functionName, "orders");
+    assertIdentical(qualified.qualifier, "2");
+  });
+
+  it("takes the qualifier a request asked for over none on the name", () => {
+    // When a request names a function and asks for a version.
+    const reference = simLambdaQualifiedFunctionOf("orders", "live");
+
+    // Then the version it asked for is the one to run.
+    assertIdentical(reference.functionName, "orders");
+    assertIdentical(reference.qualifier, "live");
+  });
+
+  it("takes the qualifier off the name when the request asks for none", () => {
+    // When a request names a qualified function and asks for nothing.
+    const reference = simLambdaQualifiedFunctionOf(
+      `${functionArn}:live`,
+      undefined,
+    );
+
+    // Then the qualifier on the name is the one to run.
+    assertIdentical(reference.qualifier, "live");
+  });
+
+  it("allows a request that asks for the qualifier it named", () => {
+    // When a request qualifies the name and asks for the same qualifier.
+    const reference = simLambdaQualifiedFunctionOf("orders:live", "live");
+
+    // Then the two agreeing is not a conflict.
+    assertIdentical(reference.qualifier, "live");
+  });
+
+  it("refuses a request whose name and qualifier disagree", () => {
+    // When a request qualifies the name one way and asks for another.
+    const error = assertThrowsError(() =>
+      simLambdaQualifiedFunctionOf("orders:live", "2"),
+    );
+
+    // Then it is refused rather than one of the two being picked.
+    assertInstanceOf(error, SimLambdaInvalidParameterValueException);
+    assertStringIncludes(error.message, "does not match");
+  });
+});

--- a/src/service/lambda/function/sim-lambda-function-reference.ts
+++ b/src/service/lambda/function/sim-lambda-function-reference.ts
@@ -65,3 +65,26 @@ export function simLambdaQualifiedFunctionOf(
 
   return { functionName, qualifier: requestedQualifier ?? qualifier };
 }
+
+/**
+ * The function a request names, refusing a qualifier the operation has no use
+ * for.
+ *
+ * Publishing a version, listing versions and the alias operations all act on
+ * the function itself. Dropping a qualifier there would act on something other
+ * than what the caller named, so it is refused instead.
+ */
+export function simLambdaUnqualifiedFunctionOf(
+  functionNameOrArn: string,
+): string {
+  const { functionName, qualifier } =
+    simLambdaFunctionReferenceOf(functionNameOrArn);
+
+  if (qualifier !== undefined) {
+    throw new SimLambdaInvalidParameterValueException(
+      `This operation is not permitted on a qualified function: ${functionNameOrArn}`,
+    );
+  }
+
+  return functionName;
+}

--- a/src/service/lambda/function/sim-lambda-function-reference.ts
+++ b/src/service/lambda/function/sim-lambda-function-reference.ts
@@ -1,0 +1,67 @@
+import { SimLambdaInvalidParameterValueException } from "../error/sim-lambda.error.js";
+
+const functionArnSeparator = ":function:";
+
+/**
+ * The function a request named, and the version or alias qualifier that came
+ * with it, if any.
+ */
+export interface SimLambdaFunctionReference {
+  readonly functionName: string;
+  readonly qualifier: string | undefined;
+}
+
+/**
+ * Read the function and qualifier out of whatever names a function.
+ *
+ * Real Lambda takes four forms wherever a request names a function. The name
+ * on its own, the name with a qualifier appended, a function ARN, and a
+ * function ARN with a qualifier appended. All four end in the name and the
+ * qualifier, so they are read the same way.
+ */
+export function simLambdaFunctionReferenceOf(
+  functionNameOrArn: string,
+): SimLambdaFunctionReference {
+  const separatorIndex = functionNameOrArn.indexOf(functionArnSeparator);
+  const nameAndQualifier =
+    separatorIndex === -1
+      ? functionNameOrArn
+      : functionNameOrArn.slice(separatorIndex + functionArnSeparator.length);
+
+  const qualifierIndex = nameAndQualifier.indexOf(":");
+
+  return qualifierIndex === -1
+    ? { functionName: nameAndQualifier, qualifier: undefined }
+    : {
+        functionName: nameAndQualifier.slice(0, qualifierIndex),
+        qualifier: nameAndQualifier.slice(qualifierIndex + 1),
+      };
+}
+
+/**
+ * Read the function and version a request named, from the name it gave and
+ * the qualifier it asked for.
+ *
+ * A request can qualify the function name, ask for a `Qualifier` of its own,
+ * or do both. Real Lambda refuses a request that does both and disagrees with
+ * itself, rather than picking one of the two.
+ */
+export function simLambdaQualifiedFunctionOf(
+  functionNameOrArn: string,
+  requestedQualifier: string | undefined,
+): SimLambdaFunctionReference {
+  const { functionName, qualifier } =
+    simLambdaFunctionReferenceOf(functionNameOrArn);
+
+  if (
+    qualifier !== undefined &&
+    requestedQualifier !== undefined &&
+    qualifier !== requestedQualifier
+  ) {
+    throw new SimLambdaInvalidParameterValueException(
+      "The derived qualifier from the function name does not match the specified qualifier.",
+    );
+  }
+
+  return { functionName, qualifier: requestedQualifier ?? qualifier };
+}

--- a/src/service/lambda/function/sim-lambda-function.iso.test.ts
+++ b/src/service/lambda/function/sim-lambda-function.iso.test.ts
@@ -32,6 +32,42 @@ describe("sim Lambda function model", () => {
     );
   });
 
+  it("publishes a copy of itself under a version number", async () => {
+    // Given a function with code, configuration and an environment.
+    const simFunction = new SimLambdaFunction({
+      name: "publish-test",
+      roleArn: "arn:aws:iam::111111111111:role/PublishRole",
+      accountRegionScope,
+      handlerFunction: () => "published code",
+      handlerName: "index.handler",
+      timeoutSeconds: 30,
+      memorySizeMb: 512,
+    });
+
+    // When it is published as version 1.
+    const version = simFunction.publishedAs("1");
+
+    // Then the version is a copy carrying what it was published with, and the
+    // function it came from is still $LATEST.
+    assertIdentical(version.version, "1");
+    assertIdentical(
+      version.arn,
+      "arn:aws:lambda:eu-west-2:111111111111:function:publish-test:1",
+    );
+    assertIdentical(await version.invoke({}), "published code");
+
+    const configuration = version.configuration();
+    assertIdentical(configuration.Version, "1");
+    assertIdentical(configuration.State, "Active");
+    assertIdentical(configuration.Handler, "index.handler");
+    assertIdentical(configuration.Timeout, 30);
+    assertIdentical(configuration.MemorySize, 512);
+
+    assertIdentical(simFunction.version, "$LATEST");
+    assertIdentical(simFunction.configuration().Version, "$LATEST");
+    assertIdentical(simFunction.state, "Pending");
+  });
+
   it("starts Pending with AWS-like defaults and activates to Active", async () => {
     const simFunction = new SimLambdaFunction({
       name: "defaults-test",

--- a/src/service/lambda/function/sim-lambda-function.ts
+++ b/src/service/lambda/function/sim-lambda-function.ts
@@ -4,6 +4,16 @@ import { simAwsRunAsContext } from "../../aws/caller/sim-aws-run-as-context.js";
 import { simAwsAccountRegionScopeFactory } from "../../aws/sim-aws-account-region-scope.factory.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import {
+  DEFAULT_SIM_LAMBDA_MEMORY_SIZE_MB,
+  SIM_LAMBDA_LATEST_VERSION,
+  DEFAULT_SIM_LAMBDA_TIMEOUT_SECONDS,
+  type SimLambdaFunctionArn,
+  simLambdaFunctionArn,
+  type SimLambdaFunctionConfiguration,
+  type SimLambdaFunctionState,
+  simLambdaVersionQualifier,
+} from "./sim-lambda-function-configuration.js";
+import {
   type SimLambdaExecutableCode,
   SimLambdaHandlerReferenceCode,
 } from "./code/sim-lambda-executable-code.js";
@@ -23,53 +33,10 @@ import {
 
 export type SimLambdaFunctionName = Brand<string, "SimLambdaFunctionName">;
 
-export const DEFAULT_SIM_LAMBDA_TIMEOUT_SECONDS = 3;
-export const DEFAULT_SIM_LAMBDA_MEMORY_SIZE_MB = 128;
-
 export type SimLambdaFunctionMap = Map<
   SimLambdaFunctionName,
   SimLambdaFunction
 >;
-
-export type SimLambdaFunctionState =
-  | "Pending"
-  | "Active"
-  | "Inactive"
-  | "Failed";
-
-/**
- * Lambda function ARNs address the function with a colon, not a slash.
- */
-export type SimLambdaFunctionArn =
-  `arn:aws:lambda:${string}:${string}:function:${string}`;
-
-/**
- * Build the ARN a sim Lambda function has, or would have, in a scope.
- */
-export function simLambdaFunctionArn(
-  scope: SimAwsAccountRegionScope,
-  name: string,
-): SimLambdaFunctionArn {
-  return `arn:aws:lambda:${scope.regionName}:${scope.accountId}:function:${name}`;
-}
-
-/**
- * Minimal structural Lambda function configuration, as returned by
- * CreateFunction and GetFunction.
- */
-export interface SimLambdaFunctionConfiguration {
-  FunctionName: string;
-  FunctionArn: SimLambdaFunctionArn;
-  Role: string;
-  State: SimLambdaFunctionState;
-  Version: string;
-  Timeout: number;
-  MemorySize: number;
-  Handler?: string | undefined;
-  Runtime?: string | undefined;
-  Description?: string | undefined;
-  Environment?: { Variables: Record<string, string> } | undefined;
-}
 
 interface SimLambdaFunctionProperties {
   name: SimLambdaFunctionName | string;
@@ -85,6 +52,11 @@ interface SimLambdaFunctionProperties {
   memorySizeMb?: number | undefined;
   environment?: SimLambdaEnvironment | undefined;
   runAsOwner?: SimAwsRunAsOwner;
+  /**
+   * The version this is. A function is `$LATEST`, and a version published
+   * from one is a copy of it under the number it was published as.
+   */
+  version?: string | undefined;
   /**
    * Clock this function's invocations measure their remaining time against. A
    * function built standalone, outside a SimAws instance, falls back to the
@@ -124,6 +96,7 @@ export class SimLambdaFunction {
   public readonly timeoutSeconds: number;
   public readonly memorySizeMb: number;
   public readonly environment: SimLambdaEnvironment;
+  public readonly version: string;
   /**
    * This function's resource-based policy, which says who may act on it.
    *
@@ -135,6 +108,7 @@ export class SimLambdaFunction {
   public readonly resourcePolicy = new SimLambdaFunctionPolicy();
 
   #state: SimLambdaFunctionState;
+  private readonly properties: SimLambdaFunctionProperties;
   private readonly code: SimLambdaExecutableCode;
   private readonly runAsOwner: SimAwsRunAsOwner;
   private readonly runner = new SimLambdaHandlerRunner();
@@ -157,11 +131,14 @@ export class SimLambdaFunction {
       memorySizeMb = DEFAULT_SIM_LAMBDA_MEMORY_SIZE_MB,
       environment,
       runAsOwner = this,
+      version = SIM_LAMBDA_LATEST_VERSION,
       clock = new SimRealClock(),
       logs,
       outboundHttp,
     } = properties;
+    this.properties = properties;
     this.clock = clock;
+    this.version = version;
     this.name = name as SimLambdaFunctionName;
     this.roleArn = roleArn;
     this.accountRegionScope = accountRegionScope;
@@ -203,10 +180,32 @@ export class SimLambdaFunction {
   }
 
   /**
-   * Get the ARN for this sim Lambda function.
+   * Get the ARN for this sim Lambda function, qualified when it is a
+   * published version rather than the function itself.
    */
   get arn(): SimLambdaFunctionArn {
-    return simLambdaFunctionArn(this.accountRegionScope, this.name);
+    return simLambdaFunctionArn(
+      this.accountRegionScope,
+      this.name,
+      simLambdaVersionQualifier(this.version),
+    );
+  }
+
+  /**
+   * A copy of this function as it stands now, published under a version
+   * number, keeping the code, handler, timeout, memory and environment it was
+   * published with. It is Active from the start, since the code it copied is
+   * already resolved and has nothing left to become.
+   */
+  publishedAs(version: string): SimLambdaFunction {
+    return new SimLambdaFunction({
+      ...this.properties,
+      code: this.code,
+      environment: this.environment,
+      runAsOwner: this.runAsOwner,
+      state: "Active",
+      version,
+    });
   }
 
   /**
@@ -226,7 +225,7 @@ export class SimLambdaFunction {
       FunctionArn: this.arn,
       Role: this.roleArn,
       State: this.state,
-      Version: "$LATEST",
+      Version: this.version,
       Timeout: this.timeoutSeconds,
       MemorySize: this.memorySizeMb,
       Handler: this.handlerName,
@@ -251,6 +250,7 @@ export class SimLambdaFunction {
   async invoke(event: unknown): Promise<unknown> {
     const contextBuilder = new SimLambdaInvokeContextBuilder({
       functionName: this.name,
+      functionVersion: this.version,
       invokedFunctionArn: this.arn,
       timeoutSeconds: this.timeoutSeconds,
       memorySizeMb: this.memorySizeMb,

--- a/src/service/lambda/function/url/sim-lambda-function-lookup.ts
+++ b/src/service/lambda/function/url/sim-lambda-function-lookup.ts
@@ -1,12 +1,14 @@
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import { SimLambdaResourceNotFoundException } from "../../error/sim-lambda.error.js";
-import {
-  type SimLambdaFunction,
-  type SimLambdaFunctionArn,
-  type SimLambdaFunctionMap,
-  type SimLambdaFunctionName,
-  simLambdaFunctionArn,
+import type {
+  SimLambdaFunction,
+  SimLambdaFunctionMap,
+  SimLambdaFunctionName,
 } from "../sim-lambda-function.js";
+import {
+  type SimLambdaFunctionArn,
+  simLambdaFunctionArn,
+} from "../sim-lambda-function-configuration.js";
 
 interface SimLambdaFunctionLookupProperties {
   readonly accountRegionScope: SimAwsAccountRegionScope;

--- a/src/service/lambda/function/version/sim-lambda-function-alias-store.ts
+++ b/src/service/lambda/function/version/sim-lambda-function-alias-store.ts
@@ -97,6 +97,10 @@ export class SimLambdaFunctionAliasStore {
 
   /**
    * Every alias a function has, narrowed to one version when asked for.
+   *
+   * The version has to be one the function has. Narrowing to a version nothing
+   * published is a request against something that is not there, and comes back
+   * as that rather than as an empty listing.
    */
   all(
     simFunction: SimLambdaFunction,
@@ -104,9 +108,13 @@ export class SimLambdaFunctionAliasStore {
   ): readonly SimLambdaFunctionAlias[] {
     const aliases = this.versions.of(simFunction).allAliases();
 
-    return functionVersion === undefined
-      ? aliases
-      : aliases.filter((alias) => alias.functionVersion === functionVersion);
+    if (functionVersion === undefined) {
+      return aliases;
+    }
+
+    this.versions.require(simFunction, functionVersion);
+
+    return aliases.filter((alias) => alias.functionVersion === functionVersion);
   }
 
   /**

--- a/src/service/lambda/function/version/sim-lambda-function-alias-store.ts
+++ b/src/service/lambda/function/version/sim-lambda-function-alias-store.ts
@@ -1,0 +1,120 @@
+import { SimLambdaResourceConflictException } from "../../error/sim-lambda.error.js";
+import { SimLambdaResourceNotFoundException } from "../../error/sim-lambda.error.js";
+import type { SimLambdaFunction } from "../sim-lambda-function.js";
+import { SimLambdaFunctionAlias } from "./sim-lambda-function-alias.js";
+import type { SimLambdaFunctionVersionStore } from "./sim-lambda-function-version-store.js";
+import { simLambdaQualifiedFunctionArn } from "./sim-lambda-function-versions.js";
+
+interface SimLambdaFunctionAliasStoreProperties {
+  readonly versions: SimLambdaFunctionVersionStore;
+}
+
+interface SimLambdaCreateAliasProperties {
+  readonly simFunction: SimLambdaFunction;
+  readonly name: string;
+  readonly functionVersion: string;
+  readonly description?: string | undefined;
+}
+
+interface SimLambdaUpdateAliasProperties {
+  readonly simFunction: SimLambdaFunction;
+  readonly name: string;
+  readonly functionVersion?: string | undefined;
+  readonly description?: string | undefined;
+}
+
+/**
+ * Alias state for one Account/Region scope of simulated Lambda.
+ *
+ * An alias belongs to the function it names a version of, and is held beside
+ * that function's versions so that deleting the function drops both at once.
+ */
+export class SimLambdaFunctionAliasStore {
+  private readonly versions: SimLambdaFunctionVersionStore;
+
+  constructor(properties: SimLambdaFunctionAliasStoreProperties) {
+    this.versions = properties.versions;
+  }
+
+  /**
+   * Point a new alias at a published version of a function.
+   */
+  create(properties: SimLambdaCreateAliasProperties): SimLambdaFunctionAlias {
+    const { simFunction, name, functionVersion, description } = properties;
+
+    this.versions.requireVersion(simFunction, functionVersion);
+
+    if (this.versions.of(simFunction).alias(name) !== undefined) {
+      throw new SimLambdaResourceConflictException(
+        `Alias already exists: ${simLambdaQualifiedFunctionArn(simFunction, name)}`,
+      );
+    }
+
+    const alias = new SimLambdaFunctionAlias({
+      aliasArn: simLambdaQualifiedFunctionArn(simFunction, name),
+      name,
+      functionVersion,
+      description,
+    });
+    this.versions.of(simFunction).addAlias(alias);
+
+    return alias;
+  }
+
+  /**
+   * Point an existing alias at another version, and describe it again.
+   */
+  update(properties: SimLambdaUpdateAliasProperties): SimLambdaFunctionAlias {
+    const { simFunction, name, functionVersion, description } = properties;
+    const alias = this.require(simFunction, name);
+
+    if (functionVersion !== undefined) {
+      this.versions.requireVersion(simFunction, functionVersion);
+    }
+
+    alias.update({ functionVersion, description });
+
+    return alias;
+  }
+
+  /**
+   * A function's alias by name, or fail as AWS does when it has no such alias.
+   */
+  require(
+    simFunction: SimLambdaFunction,
+    name: string,
+  ): SimLambdaFunctionAlias {
+    const alias = this.versions.of(simFunction).alias(name);
+
+    if (alias === undefined) {
+      throw new SimLambdaResourceNotFoundException(
+        `Alias not found: ${simLambdaQualifiedFunctionArn(simFunction, name)}`,
+      );
+    }
+
+    return alias;
+  }
+
+  /**
+   * Every alias a function has, narrowed to one version when asked for.
+   */
+  all(
+    simFunction: SimLambdaFunction,
+    functionVersion?: string,
+  ): readonly SimLambdaFunctionAlias[] {
+    const aliases = this.versions.of(simFunction).allAliases();
+
+    return functionVersion === undefined
+      ? aliases
+      : aliases.filter((alias) => alias.functionVersion === functionVersion);
+  }
+
+  /**
+   * Drop an alias of a function, or fail as AWS does when it has no such
+   * alias.
+   */
+  delete(simFunction: SimLambdaFunction, name: string): void {
+    this.require(simFunction, name);
+    this.versions.of(simFunction).deleteAlias(name);
+  }
+}

--- a/src/service/lambda/function/version/sim-lambda-function-alias.ts
+++ b/src/service/lambda/function/version/sim-lambda-function-alias.ts
@@ -1,0 +1,73 @@
+import type { SimLambdaFunctionArn } from "../sim-lambda-function-configuration.js";
+
+/**
+ * Minimal structural Lambda alias configuration, as returned by CreateAlias,
+ * UpdateAlias, GetAlias and ListAliases.
+ */
+export interface SimLambdaFunctionAliasConfiguration {
+  AliasArn: SimLambdaFunctionArn;
+  Name: string;
+  FunctionVersion: string;
+  Description?: string | undefined;
+}
+
+interface SimLambdaFunctionAliasProperties {
+  readonly aliasArn: SimLambdaFunctionArn;
+  readonly name: string;
+  readonly functionVersion: string;
+  readonly description?: string | undefined;
+}
+
+/**
+ * Simulated Lambda alias resource. An alias is a name for one published
+ * version.
+ *
+ * An alias is what a deployed application invokes, so the version it points at
+ * changes while the name integrations were built against stays where it is.
+ */
+export class SimLambdaFunctionAlias {
+  public readonly aliasArn: SimLambdaFunctionArn;
+  public readonly name: string;
+
+  #functionVersion: string;
+  #description: string | undefined;
+
+  constructor(properties: SimLambdaFunctionAliasProperties) {
+    this.aliasArn = properties.aliasArn;
+    this.name = properties.name;
+    this.#functionVersion = properties.functionVersion;
+    this.#description = properties.description;
+  }
+
+  /**
+   * The published version this alias points at.
+   */
+  get functionVersion(): string {
+    return this.#functionVersion;
+  }
+
+  /**
+   * Point this alias at another version, and describe it again.
+   *
+   * Omitted values are left as they are, as real UpdateAlias leaves them.
+   */
+  update(properties: {
+    readonly functionVersion?: string | undefined;
+    readonly description?: string | undefined;
+  }): void {
+    this.#functionVersion = properties.functionVersion ?? this.#functionVersion;
+    this.#description = properties.description ?? this.#description;
+  }
+
+  /**
+   * Get the AWS-like configuration for this alias.
+   */
+  configuration(): SimLambdaFunctionAliasConfiguration {
+    return {
+      AliasArn: this.aliasArn,
+      Name: this.name,
+      FunctionVersion: this.#functionVersion,
+      Description: this.#description,
+    };
+  }
+}

--- a/src/service/lambda/function/version/sim-lambda-function-version-store.ts
+++ b/src/service/lambda/function/version/sim-lambda-function-version-store.ts
@@ -1,0 +1,100 @@
+import { SimLambdaResourceNotFoundException } from "../../error/sim-lambda.error.js";
+import { SIM_LAMBDA_LATEST_VERSION } from "../sim-lambda-function-configuration.js";
+import type {
+  SimLambdaFunction,
+  SimLambdaFunctionName,
+} from "../sim-lambda-function.js";
+import {
+  simLambdaQualifiedFunctionArn,
+  SimLambdaFunctionVersions,
+} from "./sim-lambda-function-versions.js";
+
+/**
+ * Published version state for one Account/Region scope of simulated Lambda.
+ *
+ * Versions belong to the function they were published from, so they are held
+ * by function name and go when the function does, the way a Function URL
+ * does. Holding them beside the function map rather than on the function
+ * itself is what keeps a bare name resolving to `$LATEST` for every caller
+ * that asks for no qualifier.
+ */
+export class SimLambdaFunctionVersionStore {
+  private readonly versions = new Map<
+    SimLambdaFunctionName,
+    SimLambdaFunctionVersions
+  >();
+
+  /**
+   * Publish a function as it stands as its next version.
+   */
+  publish(simFunction: SimLambdaFunction): SimLambdaFunction {
+    return this.of(simFunction).publish(simFunction);
+  }
+
+  /**
+   * Every version of a function, `$LATEST` first, as ListVersionsByFunction
+   * reports them.
+   */
+  all(simFunction: SimLambdaFunction): readonly SimLambdaFunction[] {
+    return [simFunction, ...this.of(simFunction).all()];
+  }
+
+  /**
+   * The version of a function a qualifier names, or fail as AWS does when the
+   * qualifier names neither a version nor an alias.
+   *
+   * A caller asking for no qualifier, or for `$LATEST`, gets the function
+   * itself. An alias resolves to the version it points at.
+   */
+  require(
+    simFunction: SimLambdaFunction,
+    qualifier: string | undefined,
+  ): SimLambdaFunction {
+    if (qualifier === undefined || qualifier === SIM_LAMBDA_LATEST_VERSION) {
+      return simFunction;
+    }
+
+    const resolved = this.of(simFunction).resolve(qualifier);
+
+    if (resolved === undefined) {
+      throw new SimLambdaResourceNotFoundException(
+        `Function not found: ${simLambdaQualifiedFunctionArn(simFunction, qualifier)}`,
+      );
+    }
+
+    return resolved;
+  }
+
+  /**
+   * Ensure a version of a function was published under a number, as an alias
+   * only ever points at one that was.
+   */
+  requireVersion(simFunction: SimLambdaFunction, versionNumber: string): void {
+    if (this.of(simFunction).version(versionNumber) === undefined) {
+      throw new SimLambdaResourceNotFoundException(
+        `Function not found: ${simLambdaQualifiedFunctionArn(simFunction, versionNumber)}`,
+      );
+    }
+  }
+
+  /**
+   * Forget everything published from a function, as deleting a function takes
+   * its versions and aliases with it.
+   */
+  forget(simFunction: SimLambdaFunction): void {
+    this.versions.delete(simFunction.name);
+  }
+
+  /**
+   * The versions and aliases of one function, which is where the alias store
+   * keeps its own state as well.
+   */
+  of(simFunction: SimLambdaFunction): SimLambdaFunctionVersions {
+    const versions =
+      this.versions.get(simFunction.name) ?? new SimLambdaFunctionVersions();
+
+    this.versions.set(simFunction.name, versions);
+
+    return versions;
+  }
+}

--- a/src/service/lambda/function/version/sim-lambda-function-versions.ts
+++ b/src/service/lambda/function/version/sim-lambda-function-versions.ts
@@ -1,0 +1,109 @@
+import {
+  type SimLambdaFunctionArn,
+  simLambdaFunctionArn,
+} from "../sim-lambda-function-configuration.js";
+import type { SimLambdaFunction } from "../sim-lambda-function.js";
+import type { SimLambdaFunctionAlias } from "./sim-lambda-function-alias.js";
+
+/**
+ * The ARN a version or an alias of a function has, which is the function's own
+ * ARN with the qualifier on the end.
+ */
+export function simLambdaQualifiedFunctionArn(
+  simFunction: SimLambdaFunction,
+  qualifier: string,
+): SimLambdaFunctionArn {
+  return simLambdaFunctionArn(
+    simFunction.accountRegionScope,
+    simFunction.name,
+    qualifier,
+  );
+}
+
+/**
+ * The published versions and aliases of one simulated Lambda function.
+ *
+ * Version numbers count up from 1 and are never reused, so the next one comes
+ * from a counter rather than from how many versions are held.
+ */
+export class SimLambdaFunctionVersions {
+  private readonly published: SimLambdaFunction[] = [];
+  private readonly aliases = new Map<string, SimLambdaFunctionAlias>();
+
+  private nextVersionNumber = 1;
+
+  /**
+   * Publish the function as it stands as the next version.
+   */
+  publish(simFunction: SimLambdaFunction): SimLambdaFunction {
+    const version = simFunction.publishedAs(String(this.nextVersionNumber));
+
+    this.nextVersionNumber += 1;
+    this.published.push(version);
+
+    return version;
+  }
+
+  /**
+   * Every published version, oldest first.
+   */
+  all(): readonly SimLambdaFunction[] {
+    return this.published;
+  }
+
+  /**
+   * The version a qualifier names, or nothing when it names neither a version
+   * nor an alias.
+   *
+   * Real Lambda tells the two apart the way this does. An alias name cannot be
+   * all digits, so a qualifier that is one is a version number.
+   */
+  resolve(qualifier: string): SimLambdaFunction | undefined {
+    if (/^\d+$/.test(qualifier)) {
+      return this.version(qualifier);
+    }
+
+    const alias = this.aliases.get(qualifier);
+
+    return alias === undefined
+      ? undefined
+      : this.version(alias.functionVersion);
+  }
+
+  /**
+   * The version with a number, or nothing when none was published under it.
+   */
+  version(versionNumber: string): SimLambdaFunction | undefined {
+    return this.published.find(
+      (published) => published.version === versionNumber,
+    );
+  }
+
+  /**
+   * The alias with a name, or nothing when no alias has it.
+   */
+  alias(name: string): SimLambdaFunctionAlias | undefined {
+    return this.aliases.get(name);
+  }
+
+  /**
+   * Every alias, in the order they were created.
+   */
+  allAliases(): readonly SimLambdaFunctionAlias[] {
+    return this.aliases.values().toArray();
+  }
+
+  /**
+   * Hold an alias under its own name.
+   */
+  addAlias(alias: SimLambdaFunctionAlias): void {
+    this.aliases.set(alias.name, alias);
+  }
+
+  /**
+   * Drop an alias, leaving the version it pointed at where it is.
+   */
+  deleteAlias(name: string): void {
+    this.aliases.delete(name);
+  }
+}

--- a/src/service/lambda/sdk/sim-lambda-sdk-command-router.ts
+++ b/src/service/lambda/sdk/sim-lambda-sdk-command-router.ts
@@ -4,6 +4,13 @@ import {
   type SimSdkCommandRouter,
 } from "../../../sdk/index.js";
 import type { SimAddPermissionCommand } from "../command/add-permission/add-permission.command.js";
+import type { SimCreateAliasCommand } from "../command/create-alias/create-alias.command.js";
+import type { SimDeleteAliasCommand } from "../command/delete-alias/delete-alias.command.js";
+import type { SimGetAliasCommand } from "../command/get-alias/get-alias.command.js";
+import type { SimListAliasesCommand } from "../command/list-aliases/list-aliases.command.js";
+import type { SimListVersionsByFunctionCommand } from "../command/list-versions-by-function/list-versions-by-function.command.js";
+import type { SimPublishVersionCommand } from "../command/publish-version/publish-version.command.js";
+import type { SimUpdateAliasCommand } from "../command/update-alias/update-alias.command.js";
 import type { SimCreateFunctionCommand } from "../command/create-function/create-function.command.js";
 import type {
   SimCreateEventSourceMappingCommand,
@@ -52,6 +59,62 @@ export class SimLambdaSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simLambda.invoke(
             command as SimInvokeCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "PublishVersionCommand",
+        async (command, context): Promise<unknown> =>
+          await simLambda.publishVersion(
+            command as SimPublishVersionCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListVersionsByFunctionCommand",
+        async (command, context): Promise<unknown> =>
+          await simLambda.listVersionsByFunction(
+            command as SimListVersionsByFunctionCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "CreateAliasCommand",
+        async (command, context): Promise<unknown> =>
+          await simLambda.createAlias(
+            command as SimCreateAliasCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "UpdateAliasCommand",
+        async (command, context): Promise<unknown> =>
+          await simLambda.updateAlias(
+            command as SimUpdateAliasCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetAliasCommand",
+        async (command, context): Promise<unknown> =>
+          await simLambda.getAlias(
+            command as SimGetAliasCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListAliasesCommand",
+        async (command, context): Promise<unknown> =>
+          await simLambda.listAliases(
+            command as SimListAliasesCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteAliasCommand",
+        async (command, context): Promise<unknown> =>
+          await simLambda.deleteAlias(
+            command as SimDeleteAliasCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/lambda/sdk/sim-lambda-version-sdk-routing.iso.test.ts
+++ b/src/service/lambda/sdk/sim-lambda-version-sdk-routing.iso.test.ts
@@ -1,0 +1,93 @@
+import {
+  CreateAliasCommand,
+  CreateFunctionCommand,
+  DeleteAliasCommand,
+  GetAliasCommand,
+  InvokeCommand,
+  LambdaClient,
+  ListAliasesCommand,
+  ListVersionsByFunctionCommand,
+  PublishVersionCommand,
+  UpdateAliasCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimSdk } from "../../../sdk/index.js";
+import { makeLambdaZipFileInput } from "../function/code/lambda-zip-file-input.js";
+
+describe("simulated Lambda version and alias SDK Command routing", () => {
+  it("round-trips the version and alias Commands through an intercepted client", async () => {
+    // Given an intercepted Lambda client with a function
+    using simSdk = new SimSdk();
+    const client = new LambdaClient({ region: "eu-west-2" });
+    simSdk.intercept(client);
+
+    await client.send(
+      new CreateFunctionCommand({
+        FunctionName: "intercepted",
+        Role: "arn:aws:iam::111111111111:role/InterceptedRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+      }),
+    );
+
+    // When versions are published and an alias is moved between them
+    const first = await client.send(
+      new PublishVersionCommand({ FunctionName: "intercepted" }),
+    );
+    const second = await client.send(
+      new PublishVersionCommand({ FunctionName: "intercepted" }),
+    );
+    await client.send(
+      new CreateAliasCommand({
+        FunctionName: "intercepted",
+        Name: "live",
+        FunctionVersion: first.Version,
+      }),
+    );
+    await client.send(
+      new UpdateAliasCommand({
+        FunctionName: "intercepted",
+        Name: "live",
+        FunctionVersion: second.Version,
+      }),
+    );
+
+    // Then each Command reaches the simulation, and the alias invokes the
+    // version it was moved to
+    const alias = await client.send(
+      new GetAliasCommand({ FunctionName: "intercepted", Name: "live" }),
+    );
+    assertIdentical(alias.FunctionVersion, "2");
+
+    const versions = await client.send(
+      new ListVersionsByFunctionCommand({ FunctionName: "intercepted" }),
+    );
+    assertArrayEquals(
+      (versions.Versions ?? []).map((version) => version.Version),
+      ["$LATEST", "1", "2"],
+    );
+
+    const invoked = await client.send(
+      new InvokeCommand({ FunctionName: "intercepted", Qualifier: "live" }),
+    );
+    assertIdentical(invoked.ExecutedVersion, "2");
+
+    const listed = await client.send(
+      new ListAliasesCommand({ FunctionName: "intercepted" }),
+    );
+    assertArrayLength(listed.Aliases ?? [], 1);
+
+    await client.send(
+      new DeleteAliasCommand({ FunctionName: "intercepted", Name: "live" }),
+    );
+    const remaining = await client.send(
+      new ListAliasesCommand({ FunctionName: "intercepted" }),
+    );
+    assertArrayLength(remaining.Aliases ?? [], 0);
+  });
+});

--- a/src/service/lambda/serve/api/sim-lambda-api-routes.ts
+++ b/src/service/lambda/serve/api/sim-lambda-api-routes.ts
@@ -6,7 +6,8 @@ import { simLambdaUrlApiRoutes } from "./sim-lambda-api-url-routes.js";
 
 /**
  * The Lambda operations reachable through the served AWS API endpoint, which
- * are the sixteen simulated Lambda implements.
+ * are sixteen of the ones simulated Lambda implements. The version and alias
+ * operations are handled as Commands and have no route here yet.
  *
  * No two of these share a method and a path, so the order they are listed in
  * decides nothing. A path that is not one of these is refused rather than

--- a/src/service/lambda/serve/api/sim-lambda-api.iso.test.ts
+++ b/src/service/lambda/serve/api/sim-lambda-api.iso.test.ts
@@ -101,8 +101,8 @@ describe("Serving the simulated Lambda control plane", () => {
       routes: [
         {
           method: "POST",
-          path: "/2015-03-31/functions/{FunctionName}/versions",
-          commandName: "PublishVersionCommand",
+          path: "/2015-03-31/functions/{FunctionName}/code",
+          commandName: "UpdateFunctionCodeCommand",
           input: (input) => ({ FunctionName: input.label("FunctionName") }),
         },
       ],
@@ -111,7 +111,7 @@ describe("Serving the simulated Lambda control plane", () => {
     // When it is asked for
     const response = await served.handle(
       new Request(
-        `${servedLambdaApiEndpoint}/2015-03-31/functions/orders/versions`,
+        `${servedLambdaApiEndpoint}/2015-03-31/functions/orders/code`,
         { method: "POST" },
       ),
       new Uint8Array(),
@@ -122,6 +122,6 @@ describe("Serving the simulated Lambda control plane", () => {
     // Then the endpoint says so rather than answering with a server error
     assertIdentical(response.status, 501);
     assertIdentical(response.headers.get("x-amzn-errortype"), "NotImplemented");
-    assertStringIncludes(await response.text(), "PublishVersionCommand");
+    assertStringIncludes(await response.text(), "UpdateFunctionCodeCommand");
   });
 });

--- a/src/service/lambda/sim-lambda-commands.ts
+++ b/src/service/lambda/sim-lambda-commands.ts
@@ -10,10 +10,12 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimLambdaAliasCommands } from "./command/alias/sim-lambda-alias-commands.js";
 import { SimLambdaEventSourceMappingCommands } from "./command/event-source-mapping/sim-lambda-event-source-mapping-commands.js";
 import { SimLambdaFunctionCommands } from "./command/function/sim-lambda-function-commands.js";
 import { SimLambdaFunctionUrlCommands } from "./command/function-url/sim-lambda-function-url-commands.js";
 import { SimLambdaPermissionCommands } from "./command/permission/sim-lambda-permission-commands.js";
+import { SimLambdaVersionCommands } from "./command/version/sim-lambda-version-commands.js";
 import { SimLambdaEventSourcePollers } from "./event-source/sim-lambda-event-source-pollers.js";
 import { SimLambdaNoEventSourceQueues } from "./event-source/queue/sim-lambda-no-event-source-queues.js";
 import {
@@ -32,6 +34,8 @@ import { SimLambdaEnvironmentConflicts } from "./function/environment/sim-lambda
 import type { SimLambdaFunctionMap } from "./function/sim-lambda-function.js";
 import { SimLambdaFunctionLookup } from "./function/url/sim-lambda-function-lookup.js";
 import { SimLambdaFunctionUrlStore } from "./function/url/sim-lambda-function-url-store.js";
+import { SimLambdaFunctionAliasStore } from "./function/version/sim-lambda-function-alias-store.js";
+import { SimLambdaFunctionVersionStore } from "./function/version/sim-lambda-function-version-store.js";
 import { SimLambdaUrlRegistry } from "./registry/sim-lambda-url-registry.js";
 
 /**
@@ -80,10 +84,16 @@ export class SimLambdaCommands {
   public readonly containerImages: SimLambdaContainerImages;
 
   public readonly functionUrlStore: SimLambdaFunctionUrlStore;
+  public readonly versionStore = new SimLambdaFunctionVersionStore();
+  public readonly aliasStore = new SimLambdaFunctionAliasStore({
+    versions: this.versionStore,
+  });
   public readonly functionLookup: SimLambdaFunctionLookup;
   public readonly functions: SimLambdaFunctionCommands;
   public readonly functionUrls: SimLambdaFunctionUrlCommands;
   public readonly permissions: SimLambdaPermissionCommands;
+  public readonly versions: SimLambdaVersionCommands;
+  public readonly aliases: SimLambdaAliasCommands;
   public readonly eventSourceMappings: SimLambdaEventSourceMappingCommands;
 
   constructor(properties: SimLambdaCommandsProperties) {
@@ -131,6 +141,18 @@ export class SimLambdaCommands {
       iam,
       background,
     });
+    this.versions = new SimLambdaVersionCommands({
+      functions: this.functionLookup,
+      versions: this.versionStore,
+      iam,
+      background,
+    });
+    this.aliases = new SimLambdaAliasCommands({
+      functions: this.functionLookup,
+      aliases: this.aliasStore,
+      iam,
+      background,
+    });
     this.eventSourceMappings = new SimLambdaEventSourceMappingCommands({
       accountRegionScope,
       pollers: new SimLambdaEventSourcePollers({
@@ -149,6 +171,7 @@ export class SimLambdaCommands {
       accountRegionScope,
       functions: properties.functions,
       functionUrls: this.functionUrlStore,
+      versions: this.versionStore,
       iam,
       background,
       runAsOwner: properties.runAsOwner,

--- a/src/service/lambda/sim-lambda.ts
+++ b/src/service/lambda/sim-lambda.ts
@@ -26,6 +26,10 @@ export interface SimLambdaRequestOptions {
 
 /**
  * Simulated Lambda. Handles SDK commands. Emulates AWS behaviour and state.
+ *
+ * Each command below carries a one line doc comment rather than a block. This
+ * file grows by one delegating method per simulated operation and is close to
+ * the max-lines limit, which is the same reason `SimDynamoDb` reads that way.
  */
 export class SimLambda {
   private readonly functions: SimLambdaFunctionMap = new Map();
@@ -60,9 +64,7 @@ export class SimLambda {
     return this.commands.containerImages;
   }
 
-  /**
-   * Handle a Create Function Command from the SDK.
-   */
+  /** Handle a Create Function Command from the SDK. */
   async createFunction(
     command: simLambdaCommands.SimCreateFunctionCommand,
     options?: SimLambdaRequestOptions,
@@ -70,9 +72,7 @@ export class SimLambda {
     return await this.commands.functions.create(command, options);
   }
 
-  /**
-   * Handle a Get Function Command from the SDK.
-   */
+  /** Handle a Get Function Command from the SDK. */
   async getFunction(
     command: simLambdaCommands.SimGetFunctionCommand,
     options?: SimLambdaRequestOptions,
@@ -80,9 +80,7 @@ export class SimLambda {
     return await this.commands.functions.get(command, options);
   }
 
-  /**
-   * Handle a Delete Function Command from the SDK.
-   */
+  /** Handle a Delete Function Command from the SDK. */
   async deleteFunction(
     command: simLambdaCommands.SimDeleteFunctionCommand,
     options?: SimLambdaRequestOptions,
@@ -90,9 +88,7 @@ export class SimLambda {
     return await this.commands.functions.delete(command, options);
   }
 
-  /**
-   * Handle an Invoke Command from the SDK.
-   */
+  /** Handle an Invoke Command from the SDK. */
   async invoke(
     command: simLambdaCommands.SimInvokeCommand,
     options?: SimLambdaRequestOptions,
@@ -100,9 +96,63 @@ export class SimLambda {
     return await this.commands.functions.invoke(command, options);
   }
 
-  /**
-   * Handle a Create Function Url Config Command from the SDK.
-   */
+  /** Handle a Publish Version Command from the SDK. */
+  async publishVersion(
+    command: simLambdaCommands.SimPublishVersionCommand,
+    options?: SimLambdaRequestOptions,
+  ): Promise<simLambdaCommands.SimPublishVersionCommandOutput> {
+    return await this.commands.versions.publish(command, options);
+  }
+
+  /** Handle a List Versions By Function Command from the SDK. */
+  async listVersionsByFunction(
+    command: simLambdaCommands.SimListVersionsByFunctionCommand,
+    options?: SimLambdaRequestOptions,
+  ): Promise<simLambdaCommands.SimListVersionsByFunctionCommandOutput> {
+    return await this.commands.versions.list(command, options);
+  }
+
+  /** Handle a Create Alias Command from the SDK. */
+  async createAlias(
+    command: simLambdaCommands.SimCreateAliasCommand,
+    options?: SimLambdaRequestOptions,
+  ): Promise<simLambdaCommands.SimCreateAliasCommandOutput> {
+    return await this.commands.aliases.create(command, options);
+  }
+
+  /** Handle an Update Alias Command from the SDK. */
+  async updateAlias(
+    command: simLambdaCommands.SimUpdateAliasCommand,
+    options?: SimLambdaRequestOptions,
+  ): Promise<simLambdaCommands.SimUpdateAliasCommandOutput> {
+    return await this.commands.aliases.update(command, options);
+  }
+
+  /** Handle a Get Alias Command from the SDK. */
+  async getAlias(
+    command: simLambdaCommands.SimGetAliasCommand,
+    options?: SimLambdaRequestOptions,
+  ): Promise<simLambdaCommands.SimGetAliasCommandOutput> {
+    return await this.commands.aliases.get(command, options);
+  }
+
+  /** Handle a List Aliases Command from the SDK. */
+  async listAliases(
+    command: simLambdaCommands.SimListAliasesCommand,
+    options?: SimLambdaRequestOptions,
+  ): Promise<simLambdaCommands.SimListAliasesCommandOutput> {
+    return await this.commands.aliases.list(command, options);
+  }
+
+  /** Handle a Delete Alias Command from the SDK. */
+  async deleteAlias(
+    command: simLambdaCommands.SimDeleteAliasCommand,
+    options?: SimLambdaRequestOptions,
+  ): Promise<simLambdaCommands.SimDeleteAliasCommandOutput> {
+    return await this.commands.aliases.delete(command, options);
+  }
+
+  /** Handle a Create Function Url Config Command from the SDK. */
   async createFunctionUrlConfig(
     command: simLambdaCommands.SimCreateFunctionUrlConfigCommand,
     options?: SimLambdaRequestOptions,
@@ -110,9 +160,7 @@ export class SimLambda {
     return await this.commands.functionUrls.create(command, options);
   }
 
-  /**
-   * Handle a Get Function Url Config Command from the SDK.
-   */
+  /** Handle a Get Function Url Config Command from the SDK. */
   async getFunctionUrlConfig(
     command: simLambdaCommands.SimGetFunctionUrlConfigCommand,
     options?: SimLambdaRequestOptions,
@@ -120,9 +168,7 @@ export class SimLambda {
     return await this.commands.functionUrls.get(command, options);
   }
 
-  /**
-   * Handle an Update Function Url Config Command from the SDK.
-   */
+  /** Handle an Update Function Url Config Command from the SDK. */
   async updateFunctionUrlConfig(
     command: simLambdaCommands.SimUpdateFunctionUrlConfigCommand,
     options?: SimLambdaRequestOptions,
@@ -130,9 +176,7 @@ export class SimLambda {
     return await this.commands.functionUrls.update(command, options);
   }
 
-  /**
-   * Handle a Delete Function Url Config Command from the SDK.
-   */
+  /** Handle a Delete Function Url Config Command from the SDK. */
   async deleteFunctionUrlConfig(
     command: simLambdaCommands.SimDeleteFunctionUrlConfigCommand,
     options?: SimLambdaRequestOptions,
@@ -140,9 +184,7 @@ export class SimLambda {
     return await this.commands.functionUrls.delete(command, options);
   }
 
-  /**
-   * Handle a List Function Url Configs Command from the SDK.
-   */
+  /** Handle a List Function Url Configs Command from the SDK. */
   async listFunctionUrlConfigs(
     command: simLambdaCommands.SimListFunctionUrlConfigsCommand,
     options?: SimLambdaRequestOptions,
@@ -150,9 +192,7 @@ export class SimLambda {
     return await this.commands.functionUrls.list(command, options);
   }
 
-  /**
-   * Handle a Create Event Source Mapping Command from the SDK.
-   */
+  /** Handle a Create Event Source Mapping Command from the SDK. */
   async createEventSourceMapping(
     command: simLambdaCommands.SimCreateEventSourceMappingCommand,
     options?: SimLambdaRequestOptions,
@@ -160,9 +200,7 @@ export class SimLambda {
     return await this.commands.eventSourceMappings.create(command, options);
   }
 
-  /**
-   * Handle a Get Event Source Mapping Command from the SDK.
-   */
+  /** Handle a Get Event Source Mapping Command from the SDK. */
   async getEventSourceMapping(
     command: simLambdaCommands.SimGetEventSourceMappingCommand,
     options?: SimLambdaRequestOptions,
@@ -170,9 +208,7 @@ export class SimLambda {
     return await this.commands.eventSourceMappings.get(command, options);
   }
 
-  /**
-   * Handle a List Event Source Mappings Command from the SDK.
-   */
+  /** Handle a List Event Source Mappings Command from the SDK. */
   async listEventSourceMappings(
     command: simLambdaCommands.SimListEventSourceMappingsCommand,
     options?: SimLambdaRequestOptions,
@@ -180,9 +216,7 @@ export class SimLambda {
     return await this.commands.eventSourceMappings.list(command, options);
   }
 
-  /**
-   * Handle a Delete Event Source Mapping Command from the SDK.
-   */
+  /** Handle a Delete Event Source Mapping Command from the SDK. */
   async deleteEventSourceMapping(
     command: simLambdaCommands.SimDeleteEventSourceMappingCommand,
     options?: SimLambdaRequestOptions,
@@ -190,9 +224,7 @@ export class SimLambda {
     return await this.commands.eventSourceMappings.delete(command, options);
   }
 
-  /**
-   * Handle an Add Permission Command from the SDK.
-   */
+  /** Handle an Add Permission Command from the SDK. */
   async addPermission(
     command: simLambdaCommands.SimAddPermissionCommand,
     options?: SimLambdaRequestOptions,
@@ -200,9 +232,7 @@ export class SimLambda {
     return await this.commands.permissions.add(command, options);
   }
 
-  /**
-   * Handle a Remove Permission Command from the SDK.
-   */
+  /** Handle a Remove Permission Command from the SDK. */
   async removePermission(
     command: simLambdaCommands.SimRemovePermissionCommand,
     options?: SimLambdaRequestOptions,
@@ -210,9 +240,7 @@ export class SimLambda {
     return await this.commands.permissions.remove(command, options);
   }
 
-  /**
-   * Handle a Get Policy Command from the SDK.
-   */
+  /** Handle a Get Policy Command from the SDK. */
   async getPolicy(
     command: simLambdaCommands.SimGetPolicyCommand,
     options?: SimLambdaRequestOptions,
@@ -220,27 +248,21 @@ export class SimLambda {
     return await this.commands.permissions.getPolicy(command, options);
   }
 
-  /**
-   * Get a simulated event source mapping by its UUID.
-   */
+  /** Get a simulated event source mapping by its UUID. */
   getSimEventSourceMapping(
     uuid: string,
   ): SimLambdaEventSourceMapping | undefined {
     return this.commands.eventSourceMappings.find(uuid);
   }
 
-  /**
-   * Get a simulated Lambda function instance by name.
-   */
+  /** Get a simulated Lambda function instance by name. */
   getSimFunctionByName(
     functionName: SimLambdaFunctionName | string,
   ): SimLambdaFunction | undefined {
     return this.functions.get(functionName as SimLambdaFunctionName);
   }
 
-  /**
-   * Get a simulated Lambda function's Function URL, if it has one.
-   */
+  /** Get a simulated Lambda function's Function URL, if it has one. */
   getSimFunctionUrl(
     functionName: SimLambdaFunctionName | string,
   ): SimLambdaFunctionUrl | undefined {
@@ -259,16 +281,12 @@ export class SimLambda {
     return this.commands.functionUrlStore.byUrlId(urlId);
   }
 
-  /**
-   * Get this service's CloudFormation Resource factory.
-   */
+  /** Get this service's CloudFormation Resource factory. */
   cfnResourceFactory(): SimCfnServiceResourceFactory {
     return this.cfnFactory;
   }
 
-  /**
-   * Get this service's SDK Command router for SDK client interception.
-   */
+  /** Get this service's SDK Command router for SDK client interception. */
   sdkCommandRouter(): SimSdkCommandRouter {
     return this.sdkRouter;
   }


### PR DESCRIPTION
PublishVersion copies a function as it stands and numbers the copy, and CreateAlias, UpdateAlias, GetAlias, ListAliases and DeleteAlias give those numbers names. Invoke and GetFunction resolve a Qualifier, or one appended to the function name, and an invocation reports the number it ran as ExecutedVersion. Versions and aliases are held beside the function map, so a bare function name still resolves to `$LATEST` for every caller that passes no qualifier, and deleting a function drops both.

A published version is a copy of the function rather than a second reference to it, so what was published keeps its code, handler, timeout, memory and environment. `UpdateFunctionCode` is still absent, so nothing can make `$LATEST` drift from a published version yet. The four services that refuse a qualified ARN, `Qualifier` on the permission commands, `AWS::Lambda::Version` and `AWS::Lambda::Alias`, and the API Gateway URI are the rest of the series and are left alone here.

Resolves #757

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Lambda function version publishing and version listing.
  - Added alias creation, updating, retrieval, listing, and deletion.
  - Added invocation and configuration support using version or alias qualifiers.
  - Added SDK interception support for version and alias commands.
  - Added an example demonstrating published versions and aliases.

- **Documentation**
  - Expanded Lambda guidance to cover versions, aliases, qualified requests, and limitations.
  - Clarified that HTTP serving supports 16 Lambda operations; version and alias commands remain available in-process or through SDK interception.

- **Bug Fixes**
  - Function deletion now also removes associated versions and aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->