### PR TITLE
fix: keep repeated Set-Cookie headers

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -760,6 +760,26 @@ suffix and port are dropped before the function runs. A function building a URL 
 `event.request.headers.host.value` behaves as it would on AWS. As on AWS, `host` is read-only, and a
 host a function writes is discarded before the Origin sees it.
 
+A header arriving more than once reaches the Function as one entry holding every value it arrived
+with. `value` carries the first, and `multiValue` carries all of them, the same shape a repeated
+query string parameter has. A response setting three cookies gives a viewer-response Function this:
+
+```typescript
+event.response.headers["set-cookie"];
+// {
+//   value: "session=abc123; Path=/",
+//   multiValue: [
+//     { value: "session=abc123; Path=/" },
+//     { value: "state=; Max-Age=0" },
+//     { value: "signed-in=1; Path=/" },
+//   ],
+// }
+```
+
+A Function returning that response untouched leaves all three cookies on their way to the viewer. A
+Function writing `multiValue` sends one header per value in it, and CloudFront ignores `value` while
+both are there. Writing `value` on its own sends a single header.
+
 ```typescript sim-cloudfront-function
 /**
  * Simulated CloudFront Functions.

--- a/src/serve/http/node-fetch-http-adapter.ts
+++ b/src/serve/http/node-fetch-http-adapter.ts
@@ -1,4 +1,8 @@
-import type { IncomingMessage, ServerResponse } from "node:http";
+import type {
+  IncomingMessage,
+  OutgoingHttpHeaders,
+  ServerResponse,
+} from "node:http";
 import { assertDefined } from "../../util/type-guard/defined.js";
 
 /**
@@ -28,10 +32,7 @@ export class NodeFetchHttpAdapter {
     nodeResponse: ServerResponse,
     response: Response,
   ): Promise<void> {
-    nodeResponse.writeHead(
-      response.status,
-      Object.fromEntries(response.headers.entries()),
-    );
+    nodeResponse.writeHead(response.status, this.outgoingHeaders(response));
 
     if (response.body === null) {
       nodeResponse.end();
@@ -40,6 +41,27 @@ export class NodeFetchHttpAdapter {
 
     const body = Buffer.from(await response.arrayBuffer());
     nodeResponse.end(body);
+  }
+
+  /**
+   * Convert response headers to the shape Node sends.
+   *
+   * `Headers.entries()` yields one entry per `Set-Cookie` header, and
+   * collecting them into an object keeps only the last. Node takes an array for
+   * a header sent more than once. A response establishing one cookie and
+   * clearing another reaches the client whole.
+   */
+  private outgoingHeaders(response: Response): OutgoingHttpHeaders {
+    const outgoing: OutgoingHttpHeaders = Object.fromEntries(
+      response.headers.entries(),
+    );
+
+    const setCookies = response.headers.getSetCookie();
+    if (setCookies.length > 0) {
+      outgoing["set-cookie"] = setCookies;
+    }
+
+    return outgoing;
   }
 
   private nodeRequestHeaders(nodeRequest: IncomingMessage): Headers {

--- a/src/serve/http/sim-aws-local-set-cookie.loc.test.ts
+++ b/src/serve/http/sim-aws-local-set-cookie.loc.test.ts
@@ -1,0 +1,59 @@
+import {
+  CreateFunctionCommand,
+  CreateFunctionUrlConfigCommand,
+} from "@aws-sdk/client-lambda";
+import { assertArrayEquals, assertNonNullable } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { serveSimAws } from "./local-server/sim-aws-local-server.js";
+import { SimAws } from "../../service/aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../service/lambda/function/code/lambda-zip-file-input.js";
+
+describe("Repeated Set-Cookie headers served on localhost", () => {
+  it("sends one header per cookie the response carries", async () => {
+    // Given a sign-out route clearing two cookies at once.
+    const simAws = new SimAws();
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "sign-out",
+        Role: "arn:aws:iam::111111111111:role/SignOutRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput(() => ({
+            statusCode: 303,
+            headers: { location: "/" },
+            cookies: [
+              "session=; Path=/; Max-Age=0",
+              "signed-in=; Path=/; Max-Age=0",
+            ],
+          })),
+        },
+      }),
+    );
+    const { FunctionUrl: functionUrl } = await simAws
+      .lambda()
+      .createFunctionUrlConfig(
+        new CreateFunctionUrlConfigCommand({
+          FunctionName: "sign-out",
+          AuthType: "NONE",
+        }),
+      );
+    assertNonNullable(functionUrl);
+
+    const srv = await serveSimAws({ simAws });
+
+    try {
+      // When it answers a request over the local server.
+      const response = await fetch(srv.localUrl(`${functionUrl}sign-out`), {
+        redirect: "manual",
+      });
+
+      // Then the viewer is given both cookies to clear.
+      assertArrayEquals(response.headers.getSetCookie(), [
+        "session=; Path=/; Max-Age=0",
+        "signed-in=; Path=/; Max-Age=0",
+      ]);
+    } finally {
+      await srv.close();
+    }
+  });
+});

--- a/src/service/cloudfront/cff/adapter/sim-cff-repeated-headers.iso.test.ts
+++ b/src/service/cloudfront/cff/adapter/sim-cff-repeated-headers.iso.test.ts
@@ -1,0 +1,92 @@
+import { describe, it } from "vitest";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertObjectMatches,
+  assertTrue,
+} from "@kensio/smartass";
+import { SimCffEventAdapter } from "./sim-cff-event-adapter.js";
+import { cloudFrontResponseFactory } from "../../factory/cloudfront-functions.factory.js";
+
+describe("repeated headers through a sim CloudFront Function", () => {
+  const adapter = new SimCffEventAdapter();
+
+  const signInCookie = "session=abc123; Path=/; HttpOnly";
+  const signedInCookie = "signed-in=1; Path=/";
+
+  it("gives a Function every value of a repeated Set-Cookie", () => {
+    // Given an origin response setting two cookies.
+    const request = new Request("https://example.test/callback");
+    const response = new Response(null, { status: 303 });
+    response.headers.append("set-cookie", signInCookie);
+    response.headers.append("set-cookie", signedInCookie);
+
+    const event = adapter.toViewerResponseEvent(request, response);
+
+    assertObjectMatches(event.response.headers, {
+      "set-cookie": {
+        value: signInCookie,
+        multiValue: [{ value: signInCookie }, { value: signedInCookie }],
+      },
+    });
+  });
+
+  it("presents a single Set-Cookie as a plain value", () => {
+    const request = new Request("https://example.test/callback");
+    const response = new Response(null, { status: 303 });
+    response.headers.append("set-cookie", signInCookie);
+
+    const event = adapter.toViewerResponseEvent(request, response);
+
+    assertObjectMatches(event.response.headers, {
+      "set-cookie": { value: signInCookie },
+    });
+    assertTrue(!("multiValue" in event.response.headers["set-cookie"]));
+  });
+
+  it("keeps both cookies when a Function returns the response unchanged", () => {
+    // Given a Function that only adds a header of its own.
+    const request = new Request("https://example.test/callback");
+    const response = new Response(null, { status: 303 });
+    response.headers.append("set-cookie", signInCookie);
+    response.headers.append("set-cookie", signedInCookie);
+
+    const event = adapter.toViewerResponseEvent(request, response);
+    event.response.headers["x-checked-by"] = { value: "sign-in" };
+
+    const viewerResponse = adapter.fromViewerResponseResult(
+      event.response,
+      response,
+    );
+
+    assertArrayEquals(viewerResponse.headers.getSetCookie(), [
+      signInCookie,
+      signedInCookie,
+    ]);
+    assertIdentical(viewerResponse.headers.get("x-checked-by"), "sign-in");
+  });
+
+  it("sends the cookies a Function writes into multiValue", () => {
+    // Given a Function replacing the origin's cookies with its own.
+    const originalResponse = new Response(null, { status: 200 });
+    const cffResponse = cloudFrontResponseFactory.make({
+      statusCode: 200,
+      headers: {
+        "set-cookie": {
+          value: signInCookie,
+          multiValue: [{ value: signInCookie }, { value: signedInCookie }],
+        },
+      },
+    });
+
+    const viewerResponse = adapter.fromViewerResponseResult(
+      cffResponse,
+      originalResponse,
+    );
+
+    assertArrayEquals(viewerResponse.headers.getSetCookie(), [
+      signInCookie,
+      signedInCookie,
+    ]);
+  });
+});

--- a/src/service/cloudfront/cff/adapter/sim-cff-request-metadata-adapter.ts
+++ b/src/service/cloudfront/cff/adapter/sim-cff-request-metadata-adapter.ts
@@ -10,8 +10,12 @@ export class SimCffRequestMetadataAdapter {
   toCffHeaders(headers: Headers): CloudFrontFunction.Headers {
     const cffHeaders = Object.create(null) as CloudFrontFunction.Headers;
 
-    for (const [name, value] of headers.entries()) {
-      cffHeaders[name.toLowerCase()] = { value };
+    for (const [name, values] of this.headerValuesByName(headers)) {
+      const cffValue = this.toCffValue(values);
+      if (cffValue !== undefined) {
+        // oxlint-disable-next-line security/detect-object-injection
+        cffHeaders[name] = cffValue;
+      }
     }
 
     return cffHeaders;
@@ -26,8 +30,10 @@ export class SimCffRequestMetadataAdapter {
   ): Headers {
     const nativeHeaders = new Headers();
 
-    for (const [name, { value }] of Object.entries(headers)) {
-      nativeHeaders.set(name, value);
+    for (const [name, valueOrMultiValue] of Object.entries(headers)) {
+      for (const value of this.fromCffValue(valueOrMultiValue)) {
+        nativeHeaders.append(name, value);
+      }
     }
 
     const cookieHeader = this.fromCffCookies(cookies);
@@ -48,19 +54,10 @@ export class SimCffRequestMetadataAdapter {
 
     const searchParameterKeys = new Set(searchParameters.keys());
     for (const key of searchParameterKeys) {
-      const values = searchParameters.getAll(key).map((value) => ({ value }));
-
-      if (values[0] !== undefined) {
+      const cffValue = this.toCffValue(searchParameters.getAll(key));
+      if (cffValue !== undefined) {
         // oxlint-disable-next-line security/detect-object-injection
-        queryString[key] = values[0];
-        if (values.length > 1) {
-          // Multi-value: first value as `value`, all values in `multiValue`
-          // oxlint-disable-next-line security/detect-object-injection
-          queryString[key] = {
-            value: values[0].value,
-            multiValue: values,
-          };
-        }
+        queryString[key] = cffValue;
       }
     }
 
@@ -74,12 +71,8 @@ export class SimCffRequestMetadataAdapter {
     const searchParameters = new URLSearchParams();
 
     for (const [key, valueOrMultiValue] of Object.entries(querystring)) {
-      if ("multiValue" in valueOrMultiValue) {
-        for (const { value } of valueOrMultiValue.multiValue) {
-          searchParameters.append(key, value);
-        }
-      } else {
-        searchParameters.append(key, valueOrMultiValue.value);
+      for (const value of this.fromCffValue(valueOrMultiValue)) {
+        searchParameters.append(key, value);
       }
     }
 
@@ -111,6 +104,67 @@ export class SimCffRequestMetadataAdapter {
     }
 
     return cookies;
+  }
+
+  /**
+   * Group header values under their lowercased name.
+   *
+   * A `Set-Cookie` header repeated on a response is the case this exists for.
+   * Node fetch Headers keep each one, and CloudFront presents a repeated
+   * header as one entry holding all of its values.
+   */
+  private headerValuesByName(headers: Headers): Map<string, string[]> {
+    const valuesByName = new Map<string, string[]>();
+
+    for (const [name, value] of headers.entries()) {
+      const headerName = name.toLowerCase();
+      const values = valuesByName.get(headerName) ?? [];
+      values.push(value);
+      valuesByName.set(headerName, values);
+    }
+
+    return valuesByName;
+  }
+
+  /**
+   * Present values in the shape CloudFront gives a repeated name.
+   *
+   * A single value is `value` alone. Repeated values keep the first in `value`
+   * and all of them in `multiValue`. That is what a Function reads for a header
+   * or a query parameter appearing more than once.
+   */
+  private toCffValue(
+    values: readonly string[],
+  ): CloudFrontFunction.Value | CloudFrontFunction.MultiValue | undefined {
+    const [first] = values;
+    if (first === undefined) {
+      return undefined;
+    }
+
+    if (values.length === 1) {
+      return { value: first };
+    }
+
+    return {
+      value: first,
+      multiValue: values.map((value) => ({ value })),
+    };
+  }
+
+  /**
+   * Read back the values a Function left under one name.
+   *
+   * A Function that means to send several values sets `multiValue`, and
+   * CloudFront sends those in place of `value`.
+   */
+  private fromCffValue(
+    valueOrMultiValue: CloudFrontFunction.Value | CloudFrontFunction.MultiValue,
+  ): string[] {
+    if ("multiValue" in valueOrMultiValue) {
+      return valueOrMultiValue.multiValue.map(({ value }) => value);
+    }
+
+    return [valueOrMultiValue.value];
   }
 
   private fromCffCookies(

--- a/src/service/cloudfront/cff/sim-cff-set-cookie.loc.test.ts
+++ b/src/service/cloudfront/cff/sim-cff-set-cookie.loc.test.ts
@@ -1,0 +1,129 @@
+import {
+  CreateDistributionCommand,
+  CreateFunctionCommand as CreateCloudFrontFunctionCommand,
+} from "@aws-sdk/client-cloudfront";
+import {
+  CreateFunctionCommand,
+  CreateFunctionUrlConfigCommand,
+} from "@aws-sdk/client-lambda";
+import { assertArrayEquals, assertNonNullable } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { serveSimAws } from "../../../serve/index.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../lambda/function/code/lambda-zip-file-input.js";
+import { makeCffFunctionCodeInput } from "./function-code-input/cff-function-code-input.js";
+import type { CloudFrontFunction } from "../typings/cloudfront-functions.namespace.js";
+
+describe("Set-Cookie through a viewer-response sim CloudFront Function", () => {
+  const cookies = [
+    "session=abc123; Path=/; Secure; HttpOnly; SameSite=Lax",
+    "state=; Path=/; Max-Age=0",
+    "signed-in=1; Path=/",
+  ];
+
+  it("sends every cookie the Origin set", async () => {
+    // Given a sign-in callback answering with three cookies.
+    const simAws = new SimAws();
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "callback",
+        Role: "arn:aws:iam::111111111111:role/CallbackRole",
+        Code: {
+          // The Function code is serialized, and cannot read the cookies
+          // named above it.
+          ZipFile: makeLambdaZipFileInput(() => ({
+            statusCode: 303,
+            headers: { location: "/" },
+            cookies: [
+              "session=abc123; Path=/; Secure; HttpOnly; SameSite=Lax",
+              "state=; Path=/; Max-Age=0",
+              "signed-in=1; Path=/",
+            ],
+          })),
+        },
+      }),
+    );
+    const { FunctionUrl: functionUrl } = await simAws
+      .lambda()
+      .createFunctionUrlConfig(
+        new CreateFunctionUrlConfigCommand({
+          FunctionName: "callback",
+          AuthType: "NONE",
+        }),
+      );
+    assertNonNullable(functionUrl);
+
+    // And a viewer-response Function on the behaviour in front of it.
+    function viewerResponseHandler(
+      event: CloudFrontFunction.ViewerResponseEvent,
+    ) {
+      event.response.headers["x-frame-options"] = { value: "DENY" };
+      return event.response;
+    }
+    const cffCreation = await simAws.cloudFront().createFunction(
+      new CreateCloudFrontFunctionCommand({
+        Name: "security-headers",
+        FunctionConfig: {
+          Comment: "Security headers",
+          Runtime: "cloudfront-js-2.0",
+        },
+        FunctionCode: makeCffFunctionCodeInput(viewerResponseHandler),
+      }),
+    );
+
+    const creation = await simAws.cloudFront().createDistribution(
+      new CreateDistributionCommand({
+        DistributionConfig: {
+          CallerReference: "viewer-response-set-cookie",
+          Comment: "Sign-in CDN",
+          Enabled: true,
+          Origins: {
+            Quantity: 1,
+            Items: [
+              {
+                Id: "function-origin",
+                DomainName: new URL(functionUrl).hostname,
+                CustomOriginConfig: {
+                  HTTPPort: 80,
+                  HTTPSPort: 443,
+                  OriginProtocolPolicy: "https-only",
+                },
+              },
+            ],
+          },
+          DefaultCacheBehavior: {
+            TargetOriginId: "function-origin",
+            ViewerProtocolPolicy: "allow-all",
+            FunctionAssociations: {
+              Quantity: 1,
+              Items: [
+                {
+                  EventType: "viewer-response",
+                  FunctionARN: cffCreation.FunctionMetadata.FunctionARN,
+                },
+              ],
+            },
+          },
+        },
+      }),
+    );
+    const distroHostname = creation.Distribution?.DomainName;
+    assertNonNullable(distroHostname);
+
+    const srv = await serveSimAws({ simAws });
+
+    try {
+      // When the viewer follows the callback.
+      const response = await fetch(
+        srv.localUrl(`http://${distroHostname}/user/callback`),
+        { redirect: "manual" },
+      );
+
+      // Then it holds all three cookies, not only the last.
+      assertArrayEquals(response.headers.getSetCookie(), cookies);
+    } finally {
+      await srv.close();
+    }
+  });
+});

--- a/src/service/cloudfront/typings/cloudfront-functions.namespace.ts
+++ b/src/service/cloudfront/typings/cloudfront-functions.namespace.ts
@@ -8,7 +8,7 @@ export declare namespace CloudFrontFunction {
     multiValue: Value[];
   }
 
-  export type Headers = Record<string, Value>;
+  export type Headers = Record<string, Value | MultiValue>;
 
   export type QueryString = Record<string, Value | MultiValue>;
 


### PR DESCRIPTION
A viewer-response CloudFront Function collapsed a repeated response header to
the last of its values, and the local server collapsed whatever survived that. A
sign-in callback setting three cookies reached the viewer holding one. Headers
now carry `multiValue` the way query strings already did, giving a Function
every value and letting it write several back, and the local server hands Node
an array for a header sent more than once.

Resolves #762