### PR TITLE
feat: localise Location headers when serving

### DIFF
--- a/docs/serve/README.md
+++ b/docs/serve/README.md
@@ -52,6 +52,28 @@ console.log(srv.localUrl(websiteUrl).toString());
 await srv.close();
 ```
 
+### Redirects
+
+A simulated service redirects to the hostname it would use against real AWS. Served on localhost that
+address reaches the public internet, and a browser following it leaves the simulation behind.
+
+A `Location` header naming a hostname the simulation serves is put into its localhost form on the way
+out of the local server. A sign-in page behind `www.example.com` redirecting to its user pool domain
+answers with an address the browser can open:
+
+```http
+303 See Other
+Location: http://auth.example.com.sim-aws.localhost:8787/oauth2/authorize?client_id=1a2b3c
+```
+
+The rewrite is `srv.localUrl(...)` applied to the header, and the hostname is matched the way an
+arriving request's hostname is matched. A `Location` naming an address the simulation serves nothing
+at is passed on as the service wrote it. So is a relative one, since that is already relative to the
+address the client arrived at.
+
+Only the local server does this. `SimAwsHttp` reaches every simulated hostname by its own name. A
+test using it sees the `Location` the service issued and asserts on the production hostname.
+
 ## Requests without a port
 
 `SimAwsHttp` is the same request path with no socket under it. It takes a Fetch API `Request` and
@@ -962,6 +984,9 @@ it is without watch mode.
 - An injected page is not byte for byte what the real service would return, and its `cache-control`
   is the simulator's rather than the service's. That is the point of the feature, and the reason it
   is off by default and says so on startup.
+- The `Location` header is the only place a simulated hostname is rewritten for a browser. A
+  hostname in a page body, in a JSON response or in a cookie `Domain` is left as the service wrote
+  it.
 - `/__sim-aws/live-reload` is shadowed on every served hostname while live reload is on.
 - Injection decodes the HTML as UTF-8. A page stored in another encoding would be corrupted, so
   serve HTML as UTF-8.

--- a/src/serve/http/local-server/sim-aws-local-location.iso.test.ts
+++ b/src/serve/http/local-server/sim-aws-local-location.iso.test.ts
@@ -1,0 +1,146 @@
+import {
+  ChangeResourceRecordSetsCommand,
+  CreateHostedZoneCommand,
+} from "@aws-sdk/client-route-53";
+import { assertIdentical, assertResponseStatus } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../service/aws/sim-aws.js";
+import { SimAwsLocalLocation } from "./sim-aws-local-location.js";
+
+const port = "51178";
+
+/**
+ * A hosted zone pointing `www.example.test` at a simulated CloudFront
+ * distribution, which is the shape a served application's own domain has.
+ */
+async function makeDistributionRecord(simAws: SimAws): Promise<void> {
+  const route53 = simAws.route53();
+  const hostedZone = await route53.createHostedZone(
+    new CreateHostedZoneCommand({
+      Name: "example.test",
+      CallerReference: "local-location-zone",
+    }),
+  );
+
+  await route53.changeResourceRecordSets(
+    new ChangeResourceRecordSetsCommand({
+      HostedZoneId: hostedZone.HostedZone?.Id,
+      ChangeBatch: {
+        Changes: [
+          {
+            Action: "CREATE",
+            ResourceRecordSet: {
+              Name: "www.example.test",
+              Type: "CNAME",
+              TTL: 60,
+              ResourceRecords: [{ Value: "d111111abcdef8.cloudfront.net" }],
+            },
+          },
+        ],
+      },
+    }),
+  );
+
+  await simAws.backgroundTasksComplete();
+}
+
+function redirectTo(location: string): Response {
+  return new Response("Redirecting", {
+    status: 303,
+    headers: { location, "content-type": "text/plain" },
+  });
+}
+
+describe("Localising a Location header on the way out of the local server", () => {
+  it("localises a redirect to a hostname a record resolves", async () => {
+    // Given a simulated environment serving www.example.test
+    const simAws = new SimAws();
+    await makeDistributionRecord(simAws);
+    const localLocation = new SimAwsLocalLocation({
+      simAws,
+      port: () => port,
+    });
+
+    // When a redirect to that hostname is served
+    const response = localLocation.localise(
+      redirectTo("https://www.example.test/user/callback?code=abcd1234"),
+    );
+
+    // Then it names the address the local server answers on, and the rest of
+    // the response is the one the service wrote
+    assertIdentical(
+      response.headers.get("location"),
+      `http://www.example.test.sim-aws.localhost:${port}/user/callback?code=abcd1234`,
+    );
+    assertResponseStatus(response, 303);
+    assertIdentical(response.headers.get("content-type"), "text/plain");
+    assertIdentical(await response.text(), "Redirecting");
+  });
+
+  it("localises a redirect to an AWS service endpoint", () => {
+    // Given a simulated environment with no records of its own
+    const localLocation = new SimAwsLocalLocation({
+      simAws: new SimAws(),
+      port: () => port,
+    });
+
+    // When a redirect to a hostname the simulation serves as an AWS endpoint
+    // is served
+    const response = localLocation.localise(
+      redirectTo("https://foo-site.s3-website.us-east-1.amazonaws.com/in.html"),
+    );
+
+    // Then the AWS domain is replaced by the local one, as a request for the
+    // same endpoint has it replaced on the way in
+    assertIdentical(
+      response.headers.get("location"),
+      `http://foo-site.s3-website.us-east-1.sim-aws.localhost:${port}/in.html`,
+    );
+  });
+
+  it("leaves a redirect to a hostname the simulation does not serve", () => {
+    // Given a simulated environment serving nothing under example.test
+    const localLocation = new SimAwsLocalLocation({
+      simAws: new SimAws(),
+      port: () => port,
+    });
+
+    // When a redirect to a hostname outside the simulation is served
+    const location = "https://auth.example.test/authorize?client_id=abcd1234";
+    const response = localLocation.localise(redirectTo(location));
+
+    // Then the client is sent where the service sent it
+    assertIdentical(response.headers.get("location"), location);
+  });
+
+  it("leaves a relative redirect", () => {
+    // Given a simulated environment served on localhost
+    const localLocation = new SimAwsLocalLocation({
+      simAws: new SimAws(),
+      port: () => port,
+    });
+
+    // When a redirect within the same hostname is served
+    const response = localLocation.localise(redirectTo("/user/sign-in"));
+
+    // Then it is passed on, having named no hostname to localise
+    assertIdentical(response.headers.get("location"), "/user/sign-in");
+  });
+
+  it("passes on a response carrying no Location header", async () => {
+    // Given a simulated environment served on localhost
+    const localLocation = new SimAwsLocalLocation({
+      simAws: new SimAws(),
+      port: () => port,
+    });
+
+    // When an ordinary page is served
+    const response = localLocation.localise(
+      new Response("<h1>Hello, world!</h1>", { status: 200 }),
+    );
+
+    // Then it is the response the service wrote
+    assertResponseStatus(response, 200);
+    assertIdentical(await response.text(), "<h1>Hello, world!</h1>");
+  });
+});

--- a/src/serve/http/local-server/sim-aws-local-location.loc.test.ts
+++ b/src/serve/http/local-server/sim-aws-local-location.loc.test.ts
@@ -1,0 +1,112 @@
+import {
+  CreateFunctionCommand,
+  CreateFunctionUrlConfigCommand,
+} from "@aws-sdk/client-lambda";
+import { assertIdentical, assertResponseStatus } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../service/aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../../service/lambda/function/code/lambda-zip-file-input.js";
+import { serveSimAws } from "./sim-aws-local-server.js";
+
+/**
+ * A Function URL that redirects to a second one, in the way a sign-in page
+ * redirects to the endpoint that answers it.
+ */
+async function makeRedirectingFunctionUrl(simAws: SimAws): Promise<{
+  readonly signInUrl: string;
+  readonly callbackUrl: string;
+}> {
+  const lambda = simAws.lambda();
+
+  await lambda.createFunction(
+    new CreateFunctionCommand({
+      FunctionName: "callback",
+      Role: "arn:aws:iam::111111111111:role/CallbackRole",
+      Code: {
+        ZipFile: makeLambdaZipFileInput(() => ({
+          statusCode: 200,
+          headers: { "content-type": "text/plain" },
+          body: "Signed in",
+        })),
+      },
+    }),
+  );
+
+  const callback = await lambda.createFunctionUrlConfig(
+    new CreateFunctionUrlConfigCommand({
+      FunctionName: "callback",
+      AuthType: "NONE",
+    }),
+  );
+
+  const callbackUrl = `${callback.FunctionUrl}callback`;
+
+  await lambda.createFunction(
+    new CreateFunctionCommand({
+      FunctionName: "sign-in",
+      Role: "arn:aws:iam::111111111111:role/SignInRole",
+      Code: {
+        ZipFile: makeLambdaZipFileInput(() => ({
+          statusCode: 303,
+          headers: { location: callbackUrl },
+          body: "",
+        })),
+      },
+    }),
+  );
+
+  const signIn = await lambda.createFunctionUrlConfig(
+    new CreateFunctionUrlConfigCommand({
+      FunctionName: "sign-in",
+      AuthType: "NONE",
+    }),
+  );
+
+  return { signInUrl: signIn.FunctionUrl, callbackUrl };
+}
+
+describe("Serving a redirect to a simulated hostname on localhost", () => {
+  it("answers with the local address of the hostname the redirect names", async () => {
+    // Given a served environment whose sign-in Function URL redirects to
+    // another Function URL of its own
+    const simAws = new SimAws();
+    const { signInUrl, callbackUrl } = await makeRedirectingFunctionUrl(simAws);
+    const srv = await serveSimAws({ simAws });
+
+    try {
+      // When a client that follows redirects itself asks for the sign-in URL
+      const response = await fetch(srv.localUrl(signInUrl), {
+        redirect: "manual",
+      });
+
+      // Then the address it is sent to is the one it can open a connection to
+      assertResponseStatus(response, 303);
+      assertIdentical(
+        response.headers.get("location"),
+        srv.localUrl(callbackUrl).toString(),
+      );
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("carries a browser following the redirect back into the simulation", async () => {
+    // Given the same sign-in Function URL, served on localhost
+    const simAws = new SimAws();
+    const { signInUrl } = await makeRedirectingFunctionUrl(simAws);
+    const srv = await serveSimAws({ simAws });
+
+    try {
+      // When the sign-in URL is fetched with redirects followed
+      const response = await fetch(srv.localUrl(signInUrl));
+
+      // Then the redirect was followed to the second function, over real
+      // localhost HTTP
+      assertResponseStatus(response, 200);
+      assertIdentical(await response.text(), "Signed in");
+    } finally {
+      await srv.close();
+    }
+  });
+});

--- a/src/serve/http/local-server/sim-aws-local-location.ts
+++ b/src/serve/http/local-server/sim-aws-local-location.ts
@@ -1,0 +1,104 @@
+import type { SimAws } from "../../../service/aws/sim-aws.js";
+import { SimAwsLocalUrl } from "../url/sim-aws-local-url.js";
+
+interface SimAwsLocalLocationProperties {
+  readonly simAws: SimAws;
+
+  /**
+   * Where the port this server took is read from, since a response is
+   * localised long after the server was built.
+   */
+  readonly port: () => string;
+}
+
+/**
+ * Puts a `Location` header naming a simulated hostname into the localhost form
+ * a browser can follow.
+ *
+ * A simulated service redirects to the hostname it would use against real AWS.
+ * A browser handed that hostname leaves the simulation and goes to the public
+ * internet. The localhost form is the address the same environment answers on,
+ * and it is what `srv.localUrl` gives a caller holding a simulated URL. Both
+ * ends of a redirect now agree.
+ *
+ * A hostname this simulation resolves is rewritten, and everything else is
+ * passed on as the service wrote it, including a redirect to a real address.
+ * The hostname is read the way an arriving request's is read. A redirect to
+ * `www.example.com` and a request for `www.example.com` reach the same place.
+ *
+ * The scheme goes with the host, because the local form is served over HTTP.
+ *
+ * Only the local server does this. `SimAwsHttp` answers in the process that
+ * built the environment and reaches every simulated hostname by its own name.
+ * A test using it sees the hostname the service issued.
+ */
+export class SimAwsLocalLocation {
+  private readonly simAws: SimAws;
+  private readonly port: () => string;
+
+  constructor(properties: SimAwsLocalLocationProperties) {
+    this.simAws = properties.simAws;
+    this.port = properties.port;
+  }
+
+  /**
+   * Return the response a client should get, with its `Location` header
+   * localised where that header names a simulated hostname.
+   */
+  localise(response: Response): Response {
+    const location = response.headers.get("location");
+
+    if (location === null) {
+      return response;
+    }
+
+    const localUrl = this.localUrl(location);
+
+    if (localUrl === undefined) {
+      return response;
+    }
+
+    const headers = new Headers(response.headers);
+    headers.set("location", localUrl.href);
+
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  }
+
+  /**
+   * The local address a `Location` header points at, where the simulation
+   * serves what it named.
+   *
+   * A relative location is left alone. It is already relative to a hostname
+   * the client reached this server by.
+   */
+  private localUrl(location: string): URL | undefined {
+    const url = URL.parse(location);
+
+    if (url === null) {
+      return undefined;
+    }
+
+    const localUrl = new SimAwsLocalUrl({
+      input: url,
+      port: this.port(),
+    }).toURL();
+
+    if (this.resolves(url.hostname) || this.resolves(localUrl.hostname)) {
+      return localUrl;
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Whether simulated Route53 resolves a hostname to a service of this
+   * simulation.
+   */
+  private resolves(hostname: string): boolean {
+    return this.simAws.route53().resolveHttpHost(hostname) !== undefined;
+  }
+}

--- a/src/serve/http/local-server/sim-aws-local-request-handler.ts
+++ b/src/serve/http/local-server/sim-aws-local-request-handler.ts
@@ -2,9 +2,11 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { NodeFetchHttpAdapter } from "../node-fetch-http-adapter.js";
 import type { SimAwsHttp } from "../sim-aws-http.js";
 import type { SimLiveReload } from "../live-reload/sim-live-reload.js";
+import type { SimAwsLocalLocation } from "./sim-aws-local-location.js";
 
 interface SimAwsLocalRequestHandlerProperties {
   readonly simAwsHttp: SimAwsHttp;
+  readonly location: SimAwsLocalLocation;
   readonly liveReload?: SimLiveReload;
 }
 
@@ -20,15 +22,21 @@ interface SimAwsLocalRequestHandlerProperties {
  * interface is also the SDK interception path and the in-process test path, so
  * keeping the reload channel and the injected script out here means only a real
  * browser talking to the local server ever sees either of them.
+ *
+ * A `Location` header is localised out here for the same reason. Only a client
+ * that reached the simulation over a socket needs an address it can open
+ * another one to.
  */
 export class SimAwsLocalRequestHandler {
   private readonly simAwsHttp: SimAwsHttp;
+  private readonly location: SimAwsLocalLocation;
   private readonly liveReload: SimLiveReload | undefined;
   private readonly nodeFetchHttpAdapter = new NodeFetchHttpAdapter();
 
   constructor(properties: SimAwsLocalRequestHandlerProperties) {
-    const { simAwsHttp, liveReload } = properties;
+    const { simAwsHttp, location, liveReload } = properties;
     this.simAwsHttp = simAwsHttp;
+    this.location = location;
     this.liveReload = liveReload;
   }
 
@@ -66,11 +74,13 @@ export class SimAwsLocalRequestHandler {
     request: Request,
     response: Response,
   ): Promise<Response> {
+    const located = this.location.localise(response);
+
     if (this.liveReload === undefined) {
-      return response;
+      return located;
     }
 
-    return this.liveReload.injectInto(request, response);
+    return this.liveReload.injectInto(request, located);
   }
 
   private respondWithError(error: unknown, nodeResponse: ServerResponse): void {

--- a/src/serve/http/local-server/sim-aws-local-server.ts
+++ b/src/serve/http/local-server/sim-aws-local-server.ts
@@ -5,6 +5,7 @@ import { SimAwsHttp } from "../sim-aws-http.js";
 import { SimAwsLocalUrl } from "../url/sim-aws-local-url.js";
 import { NodeServerPortBinder } from "./node-server-port-binder.js";
 import { nodeServerPort } from "./node-server-port.js";
+import { SimAwsLocalLocation } from "./sim-aws-local-location.js";
 import { SimAwsLocalRequestHandler } from "./sim-aws-local-request-handler.js";
 import { SimAwsDnsServer } from "../../dns/sim-aws-dns-server.js";
 import { SimLocalLiveReload } from "../live-reload/sim-local-live-reload.js";
@@ -37,6 +38,10 @@ export class SimAwsLocalServer {
     const channel = this.liveReload.channel();
     this.requestHandler = new SimAwsLocalRequestHandler({
       simAwsHttp: new SimAwsHttp({ simAws }),
+      location: new SimAwsLocalLocation({
+        simAws,
+        port: (): string => this.port,
+      }),
       ...(channel !== undefined && { liveReload: channel }),
     });
     this.dnsServer = new SimAwsDnsServer({ simAws });

--- a/src/service/cloudfront/cff/sim-cloudfront-functions.loc.test.ts
+++ b/src/service/cloudfront/cff/sim-cloudfront-functions.loc.test.ts
@@ -110,16 +110,18 @@ describe("Serve sim CloudFront Functions on localhost", () => {
   it("gives a viewer-request CFF the Distribution domain name as its host", async () => {
     const simCloudFront = simAws.cloudFront();
 
-    // Given a CFF that redirects to the host it was given.
-    function hostRedirectHandlerFunction(
+    // Given a CFF that answers with the host it was given. The host is
+    // reported in a header of its own, since a Location header naming a
+    // hostname this simulation serves is localised on the way to the client.
+    function hostReportingHandlerFunction(
       event: CloudFrontFunction.ViewerRequestEvent,
     ) {
       const host = event.request.headers["host"]?.value ?? "no-host";
       return {
-        statusCode: 302,
-        statusDescription: "Found",
+        statusCode: 200,
+        statusDescription: "OK",
         headers: {
-          location: { value: `https://${host}/redirected.html` },
+          "x-cff-host": { value: host },
         },
       };
     }
@@ -130,7 +132,7 @@ describe("Serve sim CloudFront Functions on localhost", () => {
           Comment: "Host Viewer Request CloudFront Function",
           Runtime: "cloudfront-js-2.0",
         },
-        FunctionCode: makeCffFunctionCodeInput(hostRedirectHandlerFunction),
+        FunctionCode: makeCffFunctionCodeInput(hostReportingHandlerFunction),
       }),
     );
 
@@ -172,14 +174,13 @@ describe("Serve sim CloudFront Functions on localhost", () => {
     // When the Distribution is requested by its CloudFront domain name.
     const distroHostResponse = await fetch(
       `http://${distroId.toLowerCase()}.cloudfront.net.sim-aws.localhost:${srv.port}/index.html`,
-      { redirect: "manual" },
     );
 
     // Then the CFF saw the CloudFront domain name, without the local suffix
     // and without the local server port.
     assertIdentical(
-      distroHostResponse.headers.get("location"),
-      `https://${distroId.toLowerCase()}.cloudfront.net/redirected.html`,
+      distroHostResponse.headers.get("x-cff-host"),
+      `${distroId.toLowerCase()}.cloudfront.net`,
     );
   });
 


### PR DESCRIPTION
A simulated service redirects to the hostname it would use against real AWS, and a browser served on localhost follows that address out onto the public internet. The local server now puts a `Location` header naming a hostname the simulation serves into the localhost form `srv.localUrl` gives, reading the hostname the way an arriving request's hostname is read. A `Location` naming anything else is passed on as the service wrote it. `SimAwsHttp` is unchanged, and an in-process test goes on seeing the hostname the service issued.

One existing test moved off the `Location` header. The CloudFront Functions local test used a redirect to report the host a viewer-request function saw, and that header is now localised on the way out, so the function reports the host in `x-cff-host` instead.

Resolves #765