### PR TITLE
feat: expand SAM HttpApi events

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -1930,6 +1930,88 @@ such as `DynamoDBCrudPolicy` are left ungenerated, because simulated IAM allows 
 default and a role missing those statements authorizes the same calls either way. A function naming
 its own `Role` runs as that role, and gets no expanded one.
 
+### Function events
+
+`Events` on a SAM function expand into whatever puts the function behind them. `HttpApi` is the type
+this covers. An event of any other type is left where it is, and the function deploys with nothing in
+front of it.
+
+An `HttpApi` event becomes an `AWS::ApiGatewayV2::Integration`, an `AWS::ApiGatewayV2::Route` and the
+`AWS::Lambda::Permission` the API invokes the function under. `Path` and `Method` become the route
+key (`GET /rates/{currency}`). An event stating no method gets `ANY`, and a `Path` of `$default`
+becomes the catch-all route.
+
+Events naming no `ApiId` share one API under the logical ID SAM gives it, `ServerlessHttpApi`, with a
+`$default` stage. Two functions with events of their own answer on the same endpoint. An event naming
+an `ApiId` routes to the API that logical ID belongs to, and the template brings the stage.
+
+```typescript sim-cloudformation-sam-http-api-event
+/**
+ * A SAM function reached through the HTTP API its HttpApi event made.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "rates-api-stack",
+  template: {
+    Transform: "AWS::Serverless-2016-10-31",
+    Resources: {
+      Rates: {
+        Type: "AWS::Serverless::Function",
+        Properties: {
+          Handler: "index.handler",
+          Runtime: "nodejs22.x",
+          Events: {
+            Get: {
+              Type: "HttpApi",
+              Properties: { Path: "/rates/{currency}", Method: "GET" },
+            },
+          },
+        },
+      },
+    },
+    Outputs: {
+      ApiEndpoint: {
+        Value: { "Fn::GetAtt": ["ServerlessHttpApi", "ApiEndpoint"] },
+      },
+    },
+  },
+  bindings: [
+    {
+      logicalId: "Rates",
+      handler: (request: {
+        pathParameters?: Record<string, string>;
+      }): { statusCode: number; body: string } => ({
+        statusCode: 200,
+        body: `rate for ${request.pathParameters?.["currency"]}`,
+      }),
+    },
+  ],
+});
+
+await stack.waitForDeployComplete();
+
+const srv = await serveSimAws({ simAws });
+
+const response = await fetch(
+  srv.localUrl(`${stack.output("ApiEndpoint")}/rates/GBP`),
+);
+
+console.log(await response.text());
+
+await srv.close();
+```
+
+`Auth` on the event is left out. Every request matching the expanded route reaches the function.
+
+A `FunctionUrlConfig` on the function expands into an `AWS::Lambda::Url` named after it, `RatesUrl`
+for a function called `Rates`. `AuthType` and `InvokeMode` carry over. `Cors` is left out (the
+simulated Function URL answers no preflight request).
+
 ## Serving deployed resources on localhost
 
 CloudFormation itself is not served as an HTTP API. Instead, you deploy infrastructure through Sim
@@ -2509,6 +2591,8 @@ Sim CloudFormation currently supports:
 - Implicit dependencies from resource `Ref` expressions
 - SAM templates naming the `AWS::Serverless-2016-10-31` transform, with `AWS::Serverless::Function`
   expanded into a Lambda function and its execution Role, and `Globals.Function` defaults applied
+- The `HttpApi` event of a SAM function, expanded into the API, integration, route, stage and invoke
+  permission that serve it, and `FunctionUrlConfig`, expanded into a Function URL
 
 The resource types it creates are:
 
@@ -2612,9 +2696,10 @@ Each service's own docs describe what its resource types support.
 - The `Condition` attribute is read on resources but not on outputs. An output carrying one is
   resolved and present in `stack.outputs` whichever way its condition falls, where real
   CloudFormation would leave it out.
-- The SAM transform is expanded for `AWS::Serverless::Function` alone. `Events` on a function are
-  left out. A SAM API, schedule or queue trigger creates nothing, and every other
-  `AWS::Serverless::*` resource type is recorded as unsupported. `AutoPublishAlias` and
-  `DeploymentPreference` are left out too, because the simulator has one version of a function and
-  nothing to shift traffic between.
+- The SAM transform is expanded for `AWS::Serverless::Function` alone. Every other
+  `AWS::Serverless::*` resource type is recorded as unsupported. `HttpApi` is the only event type
+  expanded, so a SAM `Api`, schedule or queue trigger creates nothing. `Auth` on an `HttpApi` event
+  and on the implicit API it shares is left out. `AutoPublishAlias` and `DeploymentPreference` are
+  left out too, because the simulator has one version of a function and nothing to shift traffic
+  between.
 - Many advanced CloudFormation features are outside the simulation.

--- a/docs/services/cloudformation/sim-cloudformation-sam-http-api-event.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-sam-http-api-event.example.ts
@@ -1,0 +1,58 @@
+/**
+ * A SAM function reached through the HTTP API its HttpApi event made.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "rates-api-stack",
+  template: {
+    Transform: "AWS::Serverless-2016-10-31",
+    Resources: {
+      Rates: {
+        Type: "AWS::Serverless::Function",
+        Properties: {
+          Handler: "index.handler",
+          Runtime: "nodejs22.x",
+          Events: {
+            Get: {
+              Type: "HttpApi",
+              Properties: { Path: "/rates/{currency}", Method: "GET" },
+            },
+          },
+        },
+      },
+    },
+    Outputs: {
+      ApiEndpoint: {
+        Value: { "Fn::GetAtt": ["ServerlessHttpApi", "ApiEndpoint"] },
+      },
+    },
+  },
+  bindings: [
+    {
+      logicalId: "Rates",
+      handler: (request: {
+        pathParameters?: Record<string, string>;
+      }): { statusCode: number; body: string } => ({
+        statusCode: 200,
+        body: `rate for ${request.pathParameters?.["currency"]}`,
+      }),
+    },
+  ],
+});
+
+await stack.waitForDeployComplete();
+
+const srv = await serveSimAws({ simAws });
+
+const response = await fetch(
+  srv.localUrl(`${stack.output("ApiEndpoint")}/rates/GBP`),
+);
+
+console.log(await response.text());
+
+await srv.close();

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-function-events.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-function-events.ts
@@ -1,0 +1,115 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../template/value/sim-cfn-template-value.js";
+import { isSamTemplateRecord } from "../../sim-cfn-sam-record.js";
+import { samConditionAttribute } from "../sim-cfn-sam-function-properties.js";
+import { samHttpApiEventResources } from "./sim-cfn-sam-http-api-event.js";
+
+interface SamFunctionEventsProperties {
+  /** The logical ID of the SAM function whose events these are. */
+  readonly logicalId: string;
+  /** The function properties, with the `Globals` defaults already merged in. */
+  readonly functionProperties: SimCfnTemplateValueRecord;
+  /** The `Condition` the SAM Resource carried, where it carried one. */
+  readonly condition: SimCfnTemplateValue | undefined;
+}
+
+/**
+ * What an expansion is told about the event it is expanding.
+ */
+export interface SamFunctionEvent {
+  /**
+   * The logical ID of the SAM function the event is declared on, which is also
+   * the logical ID of the Lambda function it is expanded into.
+   */
+  readonly functionLogicalId: string;
+  /** The name the function declared the event under in `Events`. */
+  readonly eventName: string;
+  /**
+   * The `Properties` of the event. An event stating none states an empty
+   * record.
+   */
+  readonly properties: SimCfnTemplateValueRecord;
+  /**
+   * The `Condition` attribute to put on the Resources that exist only because
+   * this function does, ready to spread. A function carrying no condition
+   * supplies nothing.
+   */
+  readonly condition: SimCfnTemplateValueRecord;
+}
+
+/**
+ * What one event type is expanded into, keyed by logical ID the way a function
+ * is.
+ */
+export type SamFunctionEventExpansion = (
+  event: SamFunctionEvent,
+) => Record<string, SimCfnTemplateValue>;
+
+/**
+ * The SAM event types this expansion covers, by the name an event writes under
+ * `Type`.
+ *
+ * This table is the list of supported event types, the way the intrinsic
+ * function parsers are a table of the supported functions. An event of a type
+ * absent from it expands into nothing and leaves the function as it is. The
+ * template deploys a function nothing calls, and the deployment stands.
+ */
+const eventExpansions: ReadonlyMap<string, SamFunctionEventExpansion> = new Map(
+  [["HttpApi", samHttpApiEventResources]],
+);
+
+/**
+ * The Resources the `Events` of a SAM function are expanded into.
+ *
+ * Every event is expanded on its own and the results are merged, so two events
+ * naming the same shared Resource converge on one entry. That is what gives
+ * every event naming no `ApiId` the same implicit API, whether the events are
+ * on one function or spread over several.
+ */
+export function samFunctionEventResources(
+  properties: SamFunctionEventsProperties,
+): Record<string, SimCfnTemplateValue> {
+  const events = properties.functionProperties["Events"];
+
+  if (!isSamTemplateRecord(events)) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(events).flatMap(([eventName, event]) =>
+      Object.entries(expandedEvent(properties, eventName, event)),
+    ),
+  );
+}
+
+/**
+ * The Resources one event is expanded into.
+ */
+function expandedEvent(
+  properties: SamFunctionEventsProperties,
+  eventName: string,
+  event: SimCfnTemplateValue,
+): Record<string, SimCfnTemplateValue> {
+  if (!isSamTemplateRecord(event)) {
+    return {};
+  }
+
+  const eventType = event["Type"];
+  const expansion =
+    typeof eventType === "string" ? eventExpansions.get(eventType) : undefined;
+
+  if (expansion === undefined) {
+    return {};
+  }
+
+  const eventProperties = event["Properties"];
+
+  return expansion({
+    functionLogicalId: properties.logicalId,
+    eventName,
+    properties: isSamTemplateRecord(eventProperties) ? eventProperties : {},
+    condition: samConditionAttribute(properties.condition),
+  });
+}

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-http-api-event.iso.test.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-http-api-event.iso.test.ts
@@ -1,0 +1,347 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsHttp } from "../../../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../../../serve/http/url/sim-aws-local-url.js";
+import type { SimHttpApi } from "../../../../apigatewayv2/api/sim-http-api.js";
+import { SimAws } from "../../../../aws/sim-aws.js";
+import type { SimCfnTemplateValueRecord } from "../../../template/value/sim-cfn-template-value.js";
+import {
+  samFunctionTemplateLogicalId,
+  simCfnSamFunctionTemplateFactory,
+} from "../sim-cfn-sam-function-template.factory.js";
+import { samImplicitHttpApiLogicalId } from "./sim-cfn-sam-implicit-http-api.js";
+
+/**
+ * The proxy event a handler behind an HTTP API route is handed, as far as
+ * these tests read it.
+ */
+interface RatesRequest {
+  readonly requestContext: { readonly http: { readonly method: string } };
+  readonly pathParameters?: Record<string, string>;
+}
+
+/**
+ * A handler answering with the method it was asked and the path parameter it
+ * captured, so a response says which route served it.
+ */
+function ratesHandler(request: RatesRequest): SimCfnTemplateValueRecord {
+  return {
+    statusCode: 200,
+    body: `${request.requestContext.http.method} rate for ${
+      request.pathParameters?.["currency"] ?? "nothing"
+    }`,
+  };
+}
+
+/**
+ * Request a path of a deployed API through the in-process HTTP entry point.
+ */
+async function requestApi(
+  simAws: SimAws,
+  api: SimHttpApi,
+  path: string,
+): Promise<Response> {
+  return await new SimAwsHttp({ simAws }).fetch(
+    new SimAwsLocalUrl({ input: `${api.apiEndpoint}${path}` }).toString(),
+  );
+}
+
+/**
+ * The body a path of a deployed API answers with.
+ */
+async function requestApiText(
+  simAws: SimAws,
+  api: SimHttpApi,
+  path: string,
+): Promise<string> {
+  const response = await requestApi(simAws, api, path);
+
+  return await response.text();
+}
+
+describe("SAM HttpApi event expansion", () => {
+  it("serves a request to the event's path through the function", async () => {
+    // Given a SAM function with an HttpApi event stating a path and a method
+    const simAws = new SimAws();
+
+    // When it is deployed with a handler bound to the function
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "rates-stack",
+      template: simCfnSamFunctionTemplateFactory.make({
+        functionProperties: {
+          Events: {
+            Get: {
+              Type: "HttpApi",
+              Properties: { Path: "/rates/{currency}", Method: "GET" },
+            },
+          },
+        },
+      }),
+      bindings: [
+        { logicalId: samFunctionTemplateLogicalId, handler: ratesHandler },
+      ],
+    });
+
+    // Then the event made an API the Stack holds under the SAM name for it
+    const api = stack.getResource(samImplicitHttpApiLogicalId)
+      ?.simResource as SimHttpApi;
+    assertNonNullable(api);
+    assertArrayLength(stack.skippedResources, 0);
+
+    // And a request to the path the event stated reaches the bound handler
+    const response = await requestApi(simAws, api, "/rates/GBP");
+
+    assertIdentical(response.status, 200);
+    assertIdentical(await response.text(), "GET rate for GBP");
+  });
+
+  it("serves any method where the event states none", async () => {
+    // Given an HttpApi event stating a path and no method
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "any-rates-stack",
+      template: simCfnSamFunctionTemplateFactory.make({
+        functionProperties: {
+          Events: {
+            Any: { Type: "HttpApi", Properties: { Path: "/rates" } },
+          },
+        },
+      }),
+      bindings: [
+        { logicalId: samFunctionTemplateLogicalId, handler: ratesHandler },
+      ],
+    });
+
+    // Then a method the event never named is served by the same route
+    const api = stack.getResource(samImplicitHttpApiLogicalId)
+      ?.simResource as SimHttpApi;
+    assertNonNullable(api);
+
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      new SimAwsLocalUrl({ input: `${api.apiEndpoint}/rates` }).toString(),
+      { method: "DELETE" },
+    );
+
+    assertIdentical(response.status, 200);
+    assertIdentical(await response.text(), "DELETE rate for nothing");
+  });
+
+  it("shares one implicit API between the events that name none", async () => {
+    // Given two SAM functions whose events both name no ApiId
+    const simAws = new SimAws();
+
+    // When they are deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "shared-rates-stack",
+      template: simCfnSamFunctionTemplateFactory.make({
+        functionProperties: {
+          Events: {
+            Get: {
+              Type: "HttpApi",
+              Properties: { Path: "/rates/{currency}", Method: "GET" },
+            },
+          },
+        },
+        resources: {
+          Fees: {
+            Type: "AWS::Serverless::Function",
+            Properties: {
+              FunctionName: "fees",
+              Handler: "index.handler",
+              Runtime: "nodejs22.x",
+              InlineCode:
+                "exports.handler = async () => " +
+                "({ statusCode: 200, body: 'fees' });",
+              Events: {
+                Get: {
+                  Type: "HttpApi",
+                  Properties: { Path: "/fees", Method: "GET" },
+                },
+              },
+            },
+          },
+        },
+      }),
+      bindings: [
+        { logicalId: samFunctionTemplateLogicalId, handler: ratesHandler },
+      ],
+    });
+
+    // Then one API serves both paths, each through its own function
+    const api = stack.getResource(samImplicitHttpApiLogicalId)
+      ?.simResource as SimHttpApi;
+    assertNonNullable(api);
+    assertArrayLength(api.routes.list(), 2);
+
+    assertIdentical(
+      await requestApiText(simAws, api, "/rates/GBP"),
+      "GET rate for GBP",
+    );
+    assertIdentical(await requestApiText(simAws, api, "/fees"), "fees");
+  });
+
+  it("routes to the API an event names by ApiId", async () => {
+    // Given a template declaring an API of its own, and an event naming it
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "named-rates-stack",
+      template: simCfnSamFunctionTemplateFactory.make({
+        functionProperties: {
+          Events: {
+            Get: {
+              Type: "HttpApi",
+              Properties: {
+                ApiId: { Ref: "RatesApi" },
+                Path: "/rates/{currency}",
+                Method: "GET",
+              },
+            },
+          },
+        },
+        resources: {
+          RatesApi: {
+            Type: "AWS::ApiGatewayV2::Api",
+            Properties: { Name: "rates-api", ProtocolType: "HTTP" },
+          },
+          RatesApiStage: {
+            Type: "AWS::ApiGatewayV2::Stage",
+            Properties: {
+              ApiId: { Ref: "RatesApi" },
+              StageName: "$default",
+              AutoDeploy: true,
+            },
+          },
+        },
+      }),
+      bindings: [
+        { logicalId: samFunctionTemplateLogicalId, handler: ratesHandler },
+      ],
+    });
+
+    // Then the route went onto the API the event named, and no implicit API
+    // was made for it
+    assertUndefined(stack.getResource(samImplicitHttpApiLogicalId));
+
+    const api = stack.getResource("RatesApi")?.simResource as SimHttpApi;
+    assertNonNullable(api);
+    assertIdentical(
+      await requestApiText(simAws, api, "/rates/USD"),
+      "GET rate for USD",
+    );
+  });
+
+  it("serves whatever the API has no route for from a $default path", async () => {
+    // Given an HttpApi event whose path is the catch-all one
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "default-rates-stack",
+      template: simCfnSamFunctionTemplateFactory.make({
+        functionProperties: {
+          Events: {
+            Fallback: { Type: "HttpApi", Properties: { Path: "$default" } },
+          },
+        },
+      }),
+      bindings: [
+        { logicalId: samFunctionTemplateLogicalId, handler: ratesHandler },
+      ],
+    });
+
+    // Then a path the API has no route of its own for reaches the function
+    const api = stack.getResource(samImplicitHttpApiLogicalId)
+      ?.simResource as SimHttpApi;
+    assertNonNullable(api);
+
+    const response = await requestApi(simAws, api, "/anything/at/all");
+
+    assertIdentical(response.status, 200);
+    assertIdentical(await response.text(), "GET rate for nothing");
+  });
+
+  it("conditions what the event made the way the function is", async () => {
+    // Given a SAM function with an HttpApi event that the template conditions
+    // out
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "conditioned-rates-stack",
+      template: {
+        Transform: "AWS::Serverless-2016-10-31",
+        Parameters: { Stage: { Type: "String" } },
+        Conditions: {
+          IsProduction: { "Fn::Equals": [{ Ref: "Stage" }, "production"] },
+        },
+        Resources: {
+          Rates: {
+            Type: "AWS::Serverless::Function",
+            Condition: "IsProduction",
+            Properties: {
+              FunctionName: "conditioned-rates",
+              Handler: "index.handler",
+              Runtime: "nodejs22.x",
+              InlineCode: "exports.handler = async () => 'rates';",
+              Events: {
+                Get: {
+                  Type: "HttpApi",
+                  Properties: { Path: "/rates", Method: "GET" },
+                },
+              },
+            },
+          },
+        },
+      },
+      parameters: { Stage: "test" },
+    });
+
+    // Then the route, integration and permission went with the function, and
+    // the API the event would have shared has no route on it
+    assertUndefined(stack.getResource("RatesGetHttpApiRoute"));
+    assertUndefined(stack.getResource("RatesGetHttpApiIntegration"));
+    assertUndefined(stack.getResource("RatesGetHttpApiPermission"));
+
+    const api = stack.getResource(samImplicitHttpApiLogicalId)
+      ?.simResource as SimHttpApi;
+    assertNonNullable(api);
+    assertArrayLength(api.routes.list(), 0);
+  });
+
+  it("leaves the function as it is for an event type it does not expand", async () => {
+    // Given a SAM function whose only event is one this expansion has no
+    // entry for
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "queued-rates-stack",
+      template: simCfnSamFunctionTemplateFactory.make({
+        functionProperties: {
+          Events: {
+            Work: {
+              Type: "SQS",
+              Properties: { Queue: "arn:aws:sqs:eu-west-2:111111111111:work" },
+            },
+          },
+        },
+      }),
+    });
+
+    // Then the function deployed with nothing in front of it, rather than the
+    // deployment failing over an event nothing reads
+    assertNonNullable(stack.getResource(samFunctionTemplateLogicalId));
+    assertUndefined(stack.getResource(samImplicitHttpApiLogicalId));
+    assertArrayLength(stack.skippedResources, 0);
+  });
+});

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-http-api-event.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-http-api-event.ts
@@ -1,0 +1,91 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../template/value/sim-cfn-template-value.js";
+import { isSamTemplateRecord } from "../../sim-cfn-sam-record.js";
+import type { SamFunctionEvent } from "./sim-cfn-sam-function-events.js";
+import { samHttpApiPermissionResource } from "./sim-cfn-sam-http-api-permission.js";
+import { samHttpApiRouteResource } from "./sim-cfn-sam-http-api-route.js";
+import {
+  samImplicitHttpApiLogicalId,
+  samImplicitHttpApiResources,
+} from "./sim-cfn-sam-implicit-http-api.js";
+
+/**
+ * Expand one `HttpApi` event into the Resources that put a route in front of
+ * the function.
+ *
+ * The event becomes an integration to the function, a route pointing at it,
+ * and the permission the API invokes the function under. An event naming no
+ * `ApiId` brings the implicit API and its stage with it, and an event naming
+ * one leaves the API to whatever declared it.
+ *
+ * The route and the integration are named after the function and the event, so
+ * two events on one function are two routes, and two functions answering the
+ * same API keep integrations of their own. They are conditioned the way the
+ * function is, since a function the template conditioned out has nothing for a
+ * route to reach. The implicit API keeps no condition of its own. It is shared,
+ * and the other functions on it may be conditioned differently or not at all.
+ */
+export function samHttpApiEventResources(
+  event: SamFunctionEvent,
+): Record<string, SimCfnTemplateValue> {
+  const apiId = samHttpApiEventApiId(event.properties);
+  const prefix = `${event.functionLogicalId}${event.eventName}HttpApi`;
+  const integrationLogicalId = `${prefix}Integration`;
+
+  return {
+    ...(event.properties["ApiId"] === undefined &&
+      samImplicitHttpApiResources()),
+    [integrationLogicalId]: integrationResource(event, apiId),
+    [`${prefix}Route`]: samHttpApiRouteResource({
+      apiId,
+      integrationLogicalId,
+      event,
+    }),
+    [`${prefix}Permission`]: samHttpApiPermissionResource(event, apiId),
+  };
+}
+
+/**
+ * The API this event routes to, as the value the expanded Resources put in
+ * their `ApiId`.
+ *
+ * An event naming an API by logical ID is answered with a `Ref` to it, which
+ * an `AWS::Serverless::HttpApi` and an `AWS::ApiGatewayV2::Api` both answer
+ * with the API's id. An `ApiId` already written as an intrinsic goes through
+ * as it came, since `!Ref MyApi` is how a SAM template usually names one.
+ */
+function samHttpApiEventApiId(
+  properties: SimCfnTemplateValueRecord,
+): SimCfnTemplateValue {
+  const apiId = properties["ApiId"];
+
+  if (apiId === undefined) {
+    return { Ref: samImplicitHttpApiLogicalId };
+  }
+
+  return isSamTemplateRecord(apiId) ? apiId : { Ref: apiId };
+}
+
+/**
+ * The AWS::ApiGatewayV2::Integration the route sends its requests through.
+ *
+ * SAM integrates an `HttpApi` event as a payload format 2.0 proxy. That is the
+ * shape the function is handed the request in.
+ */
+function integrationResource(
+  event: SamFunctionEvent,
+  apiId: SimCfnTemplateValue,
+): SimCfnTemplateValueRecord {
+  return {
+    Type: "AWS::ApiGatewayV2::Integration",
+    ...event.condition,
+    Properties: {
+      ApiId: apiId,
+      IntegrationType: "AWS_PROXY",
+      IntegrationUri: { "Fn::GetAtt": [event.functionLogicalId, "Arn"] },
+      PayloadFormatVersion: "2.0",
+    },
+  };
+}

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-http-api-permission.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-http-api-permission.ts
@@ -1,0 +1,46 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../template/value/sim-cfn-template-value.js";
+import type { SamFunctionEvent } from "./sim-cfn-sam-function-events.js";
+
+/**
+ * The AWS::Lambda::Permission the API invokes the function under.
+ *
+ * A Lambda proxy integration works only once the function's resource policy
+ * admits API Gateway. Without this the route answers 500.
+ *
+ * The source ARN wildcards the stage and the route, the grant SAM writes.
+ * Every route this API sends the function is one an event of its own asked
+ * for.
+ */
+export function samHttpApiPermissionResource(
+  event: SamFunctionEvent,
+  apiId: SimCfnTemplateValue,
+): SimCfnTemplateValueRecord {
+  return {
+    Type: "AWS::Lambda::Permission",
+    ...event.condition,
+    Properties: {
+      Action: "lambda:InvokeFunction",
+      FunctionName: { "Fn::GetAtt": [event.functionLogicalId, "Arn"] },
+      Principal: "apigateway.amazonaws.com",
+      SourceArn: {
+        "Fn::Join": [
+          "",
+          [
+            "arn:",
+            { Ref: "AWS::Partition" },
+            ":execute-api:",
+            { Ref: "AWS::Region" },
+            ":",
+            { Ref: "AWS::AccountId" },
+            ":",
+            apiId,
+            "/*/*",
+          ],
+        ],
+      },
+    },
+  };
+}

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-http-api-route.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-http-api-route.ts
@@ -1,0 +1,79 @@
+import { simHttpApiDefaultRouteKey } from "../../../../apigatewayv2/api/route/key/sim-http-api-default-route-key.js";
+import { simHttpApiAnyMethod } from "../../../../apigatewayv2/api/route/key/sim-http-api-route-method.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../template/value/sim-cfn-template-value.js";
+import type { SamFunctionEvent } from "./sim-cfn-sam-function-events.js";
+
+interface SamHttpApiRouteProperties {
+  /** The API the route belongs to. */
+  readonly apiId: SimCfnTemplateValue;
+  /** The logical ID of the integration the route targets. */
+  readonly integrationLogicalId: string;
+  readonly event: SamFunctionEvent;
+}
+
+/**
+ * The AWS::ApiGatewayV2::Route the event's path and method are served by.
+ *
+ * `Auth` on the event is not expanded. The route authorizes nothing, and every
+ * request matching it reaches the function.
+ */
+export function samHttpApiRouteResource(
+  route: SamHttpApiRouteProperties,
+): SimCfnTemplateValueRecord {
+  return {
+    Type: "AWS::ApiGatewayV2::Route",
+    ...route.event.condition,
+    Properties: {
+      ApiId: route.apiId,
+      ...samHttpApiRouteKey(route.event.properties),
+      AuthorizationType: "NONE",
+      Target: {
+        "Fn::Join": [
+          "",
+          ["integrations/", { Ref: route.integrationLogicalId }],
+        ],
+      },
+    },
+  };
+}
+
+/**
+ * The `RouteKey` property the `Path` and `Method` of an `HttpApi` event name.
+ *
+ * A method the event leaves out is `ANY`, matching the path whatever the
+ * request did to it. A method in lower case is upper-cased, the only case a
+ * route key takes. A `Path` of `$default` names the catch-all route.
+ *
+ * An event stating no `Path` names no route key at all. The Route it expands
+ * into then refuses itself by name, where a route key guessed from a missing
+ * path would be a route no request ever reached.
+ */
+function samHttpApiRouteKey(
+  properties: SimCfnTemplateValueRecord,
+): SimCfnTemplateValueRecord {
+  const path = properties["Path"];
+
+  if (typeof path !== "string") {
+    return {};
+  }
+
+  if (path === simHttpApiDefaultRouteKey) {
+    return { RouteKey: path };
+  }
+
+  return { RouteKey: `${samHttpApiMethod(properties)} ${path}` };
+}
+
+/**
+ * The method half of the route key.
+ */
+function samHttpApiMethod(properties: SimCfnTemplateValueRecord): string {
+  const method = properties["Method"];
+
+  return typeof method === "string"
+    ? method.toUpperCase()
+    : simHttpApiAnyMethod;
+}

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-implicit-http-api.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-implicit-http-api.ts
@@ -1,0 +1,47 @@
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+
+/**
+ * The logical ID SAM gives the API that every `HttpApi` event naming no
+ * `ApiId` shares. It is the name a template reaches the implicit API by, in an
+ * `Output` or in a `Ref` from a Resource of its own.
+ */
+export const samImplicitHttpApiLogicalId = "ServerlessHttpApi";
+
+/**
+ * The logical ID SAM gives the implicit API's stage.
+ */
+const implicitStageLogicalId = `${samImplicitHttpApiLogicalId}ApiGatewayDefaultStage`;
+
+/**
+ * The API and stage an `HttpApi` event naming no `ApiId` is served by.
+ *
+ * The API is named after the stack, which is the name SAM gives it, and the
+ * stage is `$default`: an HTTP API's default stage serves its routes at the
+ * root of the endpoint, so a path the event stated is the path a request asks
+ * for.
+ *
+ * Every event naming no `ApiId` produces this same pair, and they are keyed by
+ * logical ID, so the API is created once however many events share it.
+ */
+export function samImplicitHttpApiResources(): Record<
+  string,
+  SimCfnTemplateValue
+> {
+  return {
+    [samImplicitHttpApiLogicalId]: {
+      Type: "AWS::ApiGatewayV2::Api",
+      Properties: {
+        Name: { Ref: "AWS::StackName" },
+        ProtocolType: "HTTP",
+      },
+    },
+    [implicitStageLogicalId]: {
+      Type: "AWS::ApiGatewayV2::Stage",
+      Properties: {
+        ApiId: { Ref: samImplicitHttpApiLogicalId },
+        StageName: "$default",
+        AutoDeploy: true,
+      },
+    },
+  };
+}

--- a/src/service/cloudformation/sam/function/sim-cfn-sam-function-properties.ts
+++ b/src/service/cloudformation/sam/function/sim-cfn-sam-function-properties.ts
@@ -1,4 +1,7 @@
-import type { SimCfnTemplateValueRecord } from "../../template/value/sim-cfn-template-value.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../template/value/sim-cfn-template-value.js";
 import { isSamTemplateRecord } from "../sim-cfn-sam-record.js";
 
 /**
@@ -40,6 +43,19 @@ export function samCarriedAttributes(
   resource: SimCfnTemplateValueRecord,
 ): SimCfnTemplateValueRecord {
   return picked(resource, attributeNames);
+}
+
+/**
+ * The `Condition` attribute a Resource expanded beside the function carries.
+ *
+ * Everything the function was expanded with exists because the function does,
+ * so a function the template conditioned out leaves none of them behind for
+ * the Stack to create.
+ */
+export function samConditionAttribute(
+  condition: SimCfnTemplateValue | undefined,
+): SimCfnTemplateValueRecord {
+  return condition === undefined ? {} : { Condition: condition };
 }
 
 /**

--- a/src/service/cloudformation/sam/function/sim-cfn-sam-function-role.ts
+++ b/src/service/cloudformation/sam/function/sim-cfn-sam-function-role.ts
@@ -2,6 +2,7 @@ import type {
   SimCfnTemplateValue,
   SimCfnTemplateValueRecord,
 } from "../../template/value/sim-cfn-template-value.js";
+import { samConditionAttribute } from "./sim-cfn-sam-function-properties.js";
 import {
   basicExecutionPolicyArn,
   lambdaAssumeRolePolicyDocument,
@@ -34,7 +35,7 @@ export function samFunctionRoleResource(
 
   return {
     Type: "AWS::IAM::Role",
-    ...roleCondition(condition),
+    ...samConditionAttribute(condition),
     Properties: {
       AssumeRolePolicyDocument: lambdaAssumeRolePolicyDocument,
       ManagedPolicyArns: [
@@ -44,15 +45,6 @@ export function samFunctionRoleResource(
       ...inlinePolicies(policies.inlinePolicies),
     },
   };
-}
-
-/**
- * The `Condition` attribute the Role carries, where the function carried one.
- */
-function roleCondition(
-  condition: SimCfnTemplateValue | undefined,
-): SimCfnTemplateValueRecord {
-  return condition === undefined ? {} : { Condition: condition };
 }
 
 /**

--- a/src/service/cloudformation/sam/function/sim-cfn-sam-function-template.factory.ts
+++ b/src/service/cloudformation/sam/function/sim-cfn-sam-function-template.factory.ts
@@ -19,6 +19,11 @@ export interface SimCfnSamFunctionTemplateInput {
    * gets no `Globals` section.
    */
   readonly globals: SimCfnTemplateValueRecord;
+  /**
+   * Resources the template carries beside the function, such as the API an
+   * event names or a second function sharing one.
+   */
+  readonly resources: SimCfnTemplateValueRecord;
 }
 
 /**
@@ -53,7 +58,7 @@ export const simCfnSamFunctionTemplateFactory = new MappedFactory<
   SimCfnSamFunctionTemplateInput,
   CfnTemplateBodyRecord
 >(
-  () => ({ functionProperties: {}, globals: {} }),
+  () => ({ functionProperties: {}, globals: {}, resources: {} }),
   (input) => ({
     Transform: samTransformName,
     ...globalsSection(input),
@@ -62,6 +67,7 @@ export const simCfnSamFunctionTemplateFactory = new MappedFactory<
         Type: samFunctionType,
         Properties: { ...workingFunction, ...input.functionProperties },
       },
+      ...input.resources,
     },
   }),
 );

--- a/src/service/cloudformation/sam/function/sim-cfn-sam-function-url.iso.test.ts
+++ b/src/service/cloudformation/sam/function/sim-cfn-sam-function-url.iso.test.ts
@@ -1,0 +1,74 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsHttp } from "../../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../../serve/http/url/sim-aws-local-url.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimLambdaFunctionUrl } from "../../../lambda/function/url/sim-lambda-function-url.js";
+import {
+  samFunctionTemplateLogicalId,
+  simCfnSamFunctionTemplateFactory,
+} from "./sim-cfn-sam-function-template.factory.js";
+
+describe("SAM function FunctionUrlConfig expansion", () => {
+  it("serves the function on the URL its config asked for", async () => {
+    // Given a SAM function declaring a Function URL open to anyone
+    const simAws = new SimAws();
+
+    // When it is deployed with a handler bound to it
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "rates-url-stack",
+      template: simCfnSamFunctionTemplateFactory.make({
+        functionProperties: {
+          FunctionUrlConfig: { AuthType: "NONE", InvokeMode: "BUFFERED" },
+        },
+      }),
+      bindings: [
+        {
+          logicalId: samFunctionTemplateLogicalId,
+          handler: (request: { rawPath: string }) => ({
+            statusCode: 200,
+            body: `rates at ${request.rawPath}`,
+          }),
+        },
+      ],
+    });
+
+    // Then the Stack holds a Function URL named after the function
+    const urlResource = stack.getResource(`${samFunctionTemplateLogicalId}Url`);
+    assertNonNullable(urlResource);
+    assertIdentical(urlResource.type, "AWS::Lambda::Url");
+
+    const functionUrl = urlResource.simResource;
+    assertInstanceOf(functionUrl, SimLambdaFunctionUrl);
+    assertIdentical(functionUrl.invokeMode, "BUFFERED");
+    assertArrayLength(stack.skippedResources, 0);
+
+    // And a request to it runs the bound handler
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      new SimAwsLocalUrl({ input: `${functionUrl.url}rates` }).toString(),
+    );
+
+    assertIdentical(await response.text(), "rates at /rates");
+  });
+
+  it("leaves a function stating no URL config without one", async () => {
+    // Given a SAM function saying nothing about a Function URL
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "rates-no-url-stack",
+      template: simCfnSamFunctionTemplateFactory.make({}),
+    });
+
+    // Then nothing was expanded to serve it
+    assertUndefined(stack.getResource(`${samFunctionTemplateLogicalId}Url`));
+  });
+});

--- a/src/service/cloudformation/sam/function/sim-cfn-sam-function-url.ts
+++ b/src/service/cloudformation/sam/function/sim-cfn-sam-function-url.ts
@@ -1,0 +1,54 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../template/value/sim-cfn-template-value.js";
+import { isSamTemplateRecord } from "../sim-cfn-sam-record.js";
+import { samConditionAttribute } from "./sim-cfn-sam-function-properties.js";
+
+interface SamFunctionUrlProperties {
+  readonly logicalId: string;
+  readonly functionProperties: SimCfnTemplateValueRecord;
+  readonly condition: SimCfnTemplateValue | undefined;
+}
+
+/**
+ * The `FunctionUrlConfig` properties the AWS::Lambda::Url carries over.
+ *
+ * `Cors` is left out. The simulated Function URL answers no preflight request,
+ * and carrying the property over would say it did.
+ */
+const carriedNames = new Set(["AuthType", "InvokeMode"]);
+
+/**
+ * The AWS::Lambda::Url a function's `FunctionUrlConfig` is expanded into.
+ *
+ * The URL is named after the function, as SAM names it, so a template reading
+ * `Fn::GetAtt` on `RatesUrl` for a function called `Rates` gets the endpoint.
+ *
+ * `AuthType` goes over as it came rather than being defaulted, so a config
+ * stating none is refused by the Resource it expands into rather than quietly
+ * served to anyone.
+ */
+export function samFunctionUrlResources(
+  properties: SamFunctionUrlProperties,
+): Record<string, SimCfnTemplateValue> {
+  const { logicalId, functionProperties, condition } = properties;
+  const config = functionProperties["FunctionUrlConfig"];
+
+  if (!isSamTemplateRecord(config)) {
+    return {};
+  }
+
+  return {
+    [`${logicalId}Url`]: {
+      Type: "AWS::Lambda::Url",
+      ...samConditionAttribute(condition),
+      Properties: {
+        TargetFunctionArn: { "Fn::GetAtt": [logicalId, "Arn"] },
+        ...Object.fromEntries(
+          Object.entries(config).filter(([name]) => carriedNames.has(name)),
+        ),
+      },
+    },
+  };
+}

--- a/src/service/cloudformation/sam/function/sim-cfn-sam-function.ts
+++ b/src/service/cloudformation/sam/function/sim-cfn-sam-function.ts
@@ -3,12 +3,14 @@ import type {
   SimCfnTemplateValueRecord,
 } from "../../template/value/sim-cfn-template-value.js";
 import { samMergedFunctionProperties } from "../sim-cfn-sam-globals.js";
+import { samFunctionEventResources } from "./event/sim-cfn-sam-function-events.js";
 import {
   samCarriedAttributes,
   samCarriedProperties,
   samResourceProperties,
 } from "./sim-cfn-sam-function-properties.js";
 import { samFunctionRoleResource } from "./sim-cfn-sam-function-role.js";
+import { samFunctionUrlResources } from "./sim-cfn-sam-function-url.js";
 
 interface SamFunctionExpansionProperties {
   readonly logicalId: string;
@@ -31,6 +33,11 @@ export const samFunctionType = "AWS::Serverless::Function";
  * names. The execution Role is a second Resource named after it, unless the
  * function named a Role of its own to run as.
  *
+ * The `Events` of the function reach the world in front of it, and a
+ * `FunctionUrlConfig` is the AWS::Lambda::Url it answers on. Both expand into
+ * Resources beside the function, named after it, so what an event made is
+ * something a template can `Ref` and something a Stack tears down.
+ *
  * `CodeUri` is not carried over. Nothing reads code off disk here, and a
  * function a bound handler backs needs no `Code` at all. A function carrying
  * neither is reported as skipped the way an unbacked AWS::Lambda::Function
@@ -46,6 +53,7 @@ export function samFunctionResources(
   );
   const roleLogicalId = `${logicalId}Role`;
   const declaredRole = functionProperties["Role"];
+  const condition = resource["Condition"];
 
   const lambdaFunction: SimCfnTemplateValueRecord = {
     Type: "AWS::Lambda::Function",
@@ -56,16 +64,16 @@ export function samFunctionResources(
     },
   };
 
-  if (declaredRole !== undefined) {
-    return { [logicalId]: lambdaFunction };
-  }
-
   return {
     [logicalId]: lambdaFunction,
-    [roleLogicalId]: samFunctionRoleResource({
-      logicalId,
-      functionProperties,
-      condition: resource["Condition"],
+    ...(declaredRole === undefined && {
+      [roleLogicalId]: samFunctionRoleResource({
+        logicalId,
+        functionProperties,
+        condition,
+      }),
     }),
+    ...samFunctionUrlResources({ logicalId, functionProperties, condition }),
+    ...samFunctionEventResources({ logicalId, functionProperties, condition }),
   };
 }


### PR DESCRIPTION
An `HttpApi` event on an `AWS::Serverless::Function` now expands into the API Gateway v2 integration and route that serve it, plus the Lambda permission the API invokes the function under. Events naming no `ApiId` share the implicit `ServerlessHttpApi` and its `$default` stage, an event naming one routes to that API by logical ID, and `Path` and `Method` become the route key with `ANY` for an omitted method. `FunctionUrlConfig` on the function expands into an `AWS::Lambda::Url`. Events are dispatched from a table keyed by event `Type`, in the way the intrinsic function parsers are, leaving the `SQS`, `DynamoDB`, `SNS`, `S3` and schedule event types an entry each to add.

Resolves #749