### PR TITLE
feat: grant a Lambda permission on a qualifier

### DIFF
--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -718,13 +718,15 @@ carries that number as `functionVersion` and the qualified ARN as `invokedFuncti
 
 ```typescript sim-lambda-versions-and-aliases
 /**
- * Publishing a simulated Lambda function version, pointing an alias at it, and
- * invoking through the alias.
+ * Publishing a simulated Lambda function version, pointing an alias at it,
+ * invoking through the alias, and granting a permission on the alias alone.
  */
 
 import {
+  AddPermissionCommand,
   CreateAliasCommand,
   CreateFunctionCommand,
+  GetPolicyCommand,
   InvokeCommand,
   ListVersionsByFunctionCommand,
   PublishVersionCommand,
@@ -771,6 +773,22 @@ const versions = await lambda.listVersionsByFunction(
   new ListVersionsByFunctionCommand({ FunctionName: "orders" }),
 );
 console.log(versions.Versions.map((version) => version.Version));
+
+await lambda.addPermission(
+  new AddPermissionCommand({
+    FunctionName: "orders",
+    Qualifier: "live",
+    StatementId: "AllowReporting",
+    Action: "lambda:InvokeFunction",
+    Principal: "222222222222",
+  }),
+);
+
+// The statements granted on the alias, and on nothing else.
+const aliasPolicy = await lambda.getPolicy(
+  new GetPolicyCommand({ FunctionName: "orders", Qualifier: "live" }),
+);
+console.log(aliasPolicy.Policy);
 ```
 
 A function with no qualifier is `$LATEST`, which is what every caller that passes none reaches, and
@@ -784,6 +802,18 @@ it is on real Lambda. A qualifier naming no version and no alias fails with
 and a version nothing published is reported as missing rather than answered with an empty listing.
 Deleting an alias leaves the version it pointed at invokable by its number. Deleting the function
 takes its versions and aliases with it.
+
+`AddPermissionCommand`, `RemovePermissionCommand` and `GetPolicyCommand` take the same `Qualifier`.
+The statement is held against the version or the alias it names, and carries that qualified ARN as
+its `Resource`. `GetPolicy` reads back the statements of the one resource it was asked for, and a
+request with no qualifier reads the function's own. An `Invoke` is authorized against the resource
+it names. A grant on `live` admits a call through `live`, and a call on the function itself or on
+the version behind the alias needs a grant of its own. See
+[Resource-based policies](#resource-based-policies).
+
+An alias keeps the grants made on it when `UpdateAliasCommand` moves it to another version. That is
+what makes an alias a stable thing for another Account or another service to be granted (the grant
+belongs to the name that was integrated against).
 
 The version and alias commands act on the function itself, so they take its name or its unqualified
 ARN. A `FunctionName` carrying a qualifier (`orders:live`) is refused with an
@@ -1893,6 +1923,10 @@ statement carrying one matches no request of theirs.
 the grant that was made. No value is supplied for them at request time, and a statement carrying one
 of those never matches.
 
+All three commands take a `Qualifier` naming a published version or an alias, and each qualified
+resource holds its own policy. See
+[Versions and aliases](#versions-and-aliases) for what a grant on one covers.
+
 A function with no grant on it has no policy at all. `GetPolicy` reports that as a
 `ResourceNotFoundException`, and never as an empty document. Granting a `StatementId` that is
 already in use is a `ResourceConflictException`, and removing one that was never granted is a
@@ -2600,8 +2634,8 @@ Sim Lambda currently supports:
   token verifier fetches from the regional Cognito endpoint
 - Execution roles, evaluated against simulated IAM
 - Published versions and aliases, with `PublishVersion`, `ListVersionsByFunction`, `CreateAlias`,
-  `UpdateAlias`, `GetAlias`, `ListAliases` and `DeleteAlias`, and a `Qualifier` on `Invoke` and
-  `GetFunction`
+  `UpdateAlias`, `GetAlias`, `ListAliases` and `DeleteAlias`, and a `Qualifier` on `Invoke`,
+  `GetFunction` and the permission commands, each qualified resource holding its own policy
 - IAM authorization of the Lambda commands themselves (`lambda:CreateFunction`,
   `lambda:GetFunction`, `lambda:InvokeFunction`, the Function URL config actions, and the version
   and alias actions)
@@ -2631,8 +2665,7 @@ Current documented limitations:
   `PrincipalOrgID` and `InvokedViaFunctionUrl` are written into the statement so `GetPolicy` reports
   the grant that was made, and no value is supplied for them, so a statement carrying one never
   matches.
-- `Qualifier`, `RevisionId` and `EventSourceToken` on the permission commands are left out. A
-  permission granted on a function admits an invocation of any of its versions.
+- `RevisionId` and `EventSourceToken` on the permission commands are left out.
 - `requestContext.authorizer.iam` reports `accessKey` as empty, and `callerId` and `userId` as the
   caller ARN rather than the opaque unique id real AWS uses. `cognitoIdentity` and `principalOrgId`
   are always null.

--- a/docs/services/lambda/sim-lambda-versions-and-aliases.example.ts
+++ b/docs/services/lambda/sim-lambda-versions-and-aliases.example.ts
@@ -1,11 +1,13 @@
 /**
- * Publishing a simulated Lambda function version, pointing an alias at it, and
- * invoking through the alias.
+ * Publishing a simulated Lambda function version, pointing an alias at it,
+ * invoking through the alias, and granting a permission on the alias alone.
  */
 
 import {
+  AddPermissionCommand,
   CreateAliasCommand,
   CreateFunctionCommand,
+  GetPolicyCommand,
   InvokeCommand,
   ListVersionsByFunctionCommand,
   PublishVersionCommand,
@@ -52,3 +54,19 @@ const versions = await lambda.listVersionsByFunction(
   new ListVersionsByFunctionCommand({ FunctionName: "orders" }),
 );
 console.log(versions.Versions.map((version) => version.Version));
+
+await lambda.addPermission(
+  new AddPermissionCommand({
+    FunctionName: "orders",
+    Qualifier: "live",
+    StatementId: "AllowReporting",
+    Action: "lambda:InvokeFunction",
+    Principal: "222222222222",
+  }),
+);
+
+// The statements granted on the alias, and on nothing else.
+const aliasPolicy = await lambda.getPolicy(
+  new GetPolicyCommand({ FunctionName: "orders", Qualifier: "live" }),
+);
+console.log(aliasPolicy.Policy);

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -71,13 +71,18 @@ facade itself is state and delegation and nothing else.
 
 Function state lives under `function/`.
 
-`function/policy/` holds the function's resource-based policy: a map of `SimLambdaPermission`
-statements keyed by `StatementId`, which is how `AddPermission` and `RemovePermission` address
-them. `AddPermission` is a shorthand for writing a policy statement, so the permission holds the
-parts it was given and expands them into a statement on demand, rather than storing a statement
-nothing can address. The policy belongs to the function because it survives exactly as long as the
-function does, and because it is this Account's half of admitting a principal from another Account:
-the other half is that Account's own identity policy, which IAM asks it for.
+`function/policy/` holds a resource-based policy: a map of `SimLambdaPermission` statements keyed by
+`StatementId`, which is how `AddPermission` and `RemovePermission` address them. `AddPermission` is
+a shorthand for writing a policy statement, so the permission holds the parts it was given and
+expands them into a statement on demand, rather than storing a statement nothing can address. A
+policy survives exactly as long as the thing it is granted on does, and it is this Account's half of
+admitting a principal from another Account: the other half is that Account's own identity policy,
+which IAM asks it for.
+
+A function, each of its published versions and each of its aliases holds one of these.
+`SimLambdaPolicyResource` is the interface the three share, an ARN and a policy. Real Lambda holds a
+policy per qualified resource. A grant made on the alias `live` decides a call on `live`, and the
+version behind it needs a grant of its own.
 
 `SimLambdaFunction` is the stored simulated resource: name, execution role ARN, scope, AWS-like
 configuration metadata, and the real handler function reference that backs it. A new function
@@ -369,9 +374,13 @@ version pattern, before anything of that name is looked for. Invoking through an
 version number it resolved to as `ExecutedVersion`, not the alias name, and the handler's context
 carries the same number and the qualified ARN.
 
-Authorization stays against the function's own ARN for now. Qualified statements in a function's
-resource policy are their own piece of work, so a permission granted on the function admits an
-invocation of any of its versions.
+Authorization is against the resource the request named, and so is a grant. `AddPermission`,
+`RemovePermission` and `GetPolicy` take a `Qualifier` of their own, and `requireResource` on the
+version store answers with the resource it names. An alias answers as itself there, where `require`
+carries on to the version behind it. Resolving the alias first would put the version's policy in
+front of a request made against the alias. `Invoke` reaches the same resource through
+`findResource`. It tolerates a function that is absent, since a request naming one is authorized
+before it is reported missing.
 
 ## Event source mappings
 
@@ -687,8 +696,8 @@ the CloudFormation engine with an "Unsupported" diagnostic.
   in-process handler an executable binding or a simulated ECR repository stands in with, and is
   skipped or refused where neither does
 - `UpdateFunctionCode` and function listing
-- `Qualifier` on the permission commands, qualified Function URLs, alias `RoutingConfig` weights,
-  provisioned concurrency, and `RevisionId`
+- `RevisionId` and `EventSourceToken` on the permission commands, qualified Function URLs, alias
+  `RoutingConfig` weights, and provisioned concurrency
 - version and alias operations over the served HTTP API endpoint, which routes the other sixteen
 - Lambda Layers
 - environment variables reaching a real in-process handler's module scope (see "Environment

--- a/src/service/lambda/command/add-permission/add-permission.command.ts
+++ b/src/service/lambda/command/add-permission/add-permission.command.ts
@@ -12,6 +12,7 @@ export interface SimAddPermissionCommand {
  */
 export interface SimAddPermissionCommandInput {
   readonly FunctionName?: string | undefined;
+  readonly Qualifier?: string | undefined;
   readonly StatementId?: string | undefined;
   readonly Action?: string | undefined;
   readonly Principal?: string | undefined;

--- a/src/service/lambda/command/add-permission/add-permission.handler.ts
+++ b/src/service/lambda/command/add-permission/add-permission.handler.ts
@@ -3,6 +3,8 @@ import type { BackgroundScheduler } from "../../../../util/background/background
 import { assertDefined } from "../../../../util/type-guard/defined.js";
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simLambdaQualifiedFunctionOf } from "../../function/sim-lambda-function-reference.js";
+import type { SimLambdaFunctionVersionStore } from "../../function/version/sim-lambda-function-version-store.js";
 import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
 import { SimLambdaPermission } from "../../function/policy/sim-lambda-permission.js";
 import { FunctionUrlAuthorizer } from "../function-url/function-url-authorizer.js";
@@ -13,6 +15,7 @@ import type {
 
 interface AddPermissionCommandHandlerProperties {
   readonly functions: SimLambdaFunctionLookup;
+  readonly versions: SimLambdaFunctionVersionStore;
   readonly iam: SimIamInterServiceAuthZ;
   readonly background: BackgroundScheduler;
 }
@@ -31,11 +34,13 @@ export class AddPermissionCommandHandler implements CommandHandler<
   SimAddPermissionCommandOutput
 > {
   private readonly functions: SimLambdaFunctionLookup;
+  private readonly versions: SimLambdaFunctionVersionStore;
   private readonly authorizer: FunctionUrlAuthorizer;
   private readonly background: BackgroundScheduler;
 
   constructor(properties: AddPermissionCommandHandlerProperties) {
     this.functions = properties.functions;
+    this.versions = properties.versions;
     this.authorizer = new FunctionUrlAuthorizer({
       iam: properties.iam,
       action: "lambda:AddPermission",
@@ -44,7 +49,11 @@ export class AddPermissionCommandHandler implements CommandHandler<
   }
 
   /**
-   * Grant a permission on a sim Lambda function's resource policy.
+   * Grant a permission on the resource policy of a sim Lambda function, or of
+   * the version or alias a qualifier names.
+   *
+   * The statement is held against the qualified resource and carries its ARN,
+   * so a grant made on an alias admits a call through that alias alone.
    */
   async handle(
     command: SimAddPermissionCommand,
@@ -67,18 +76,24 @@ export class AddPermissionCommandHandler implements CommandHandler<
 
     await this.background.sequence();
 
-    const functionName = input.FunctionName;
+    const { functionName, qualifier } = simLambdaQualifiedFunctionOf(
+      input.FunctionName,
+      input.Qualifier,
+    );
     this.authorizer.authorize(
-      this.functions.functionArn(functionName),
+      this.functions.functionArn(functionName, qualifier),
       options?.caller,
     );
-    const simFunction = this.functions.require(functionName);
+    const resource = this.versions.requireResource(
+      this.functions.require(functionName),
+      qualifier,
+    );
 
     const permission = new SimLambdaPermission({
       statementId: input.StatementId,
       action: input.Action,
       principal: input.Principal,
-      resourceArn: simFunction.arn,
+      resourceArn: resource.arn,
       functionUrlAuthType: input.FunctionUrlAuthType,
       sourceArn: input.SourceArn,
       sourceAccount: input.SourceAccount,
@@ -86,7 +101,7 @@ export class AddPermissionCommandHandler implements CommandHandler<
       invokedViaFunctionUrl: input.InvokedViaFunctionUrl,
     });
 
-    simFunction.resourcePolicy.add(permission);
+    resource.resourcePolicy.add(permission);
 
     return {
       $metadata: {},

--- a/src/service/lambda/command/authorize/sim-lambda-resource-policies.ts
+++ b/src/service/lambda/command/authorize/sim-lambda-resource-policies.ts
@@ -1,5 +1,5 @@
 import type { SimIamResourcePolicyInput } from "../../../iam/authorize/context/sim-iam-auth-z-context-builder.js";
-import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
+import type { SimLambdaPolicyResource } from "../../function/policy/sim-lambda-policy-resource.js";
 
 /**
  * The name real Lambda reports a function's resource policy under.
@@ -8,25 +8,27 @@ const policyName = "FunctionPolicy";
 
 /**
  * The resource policies IAM should evaluate alongside identity policies for an
- * action on a function.
+ * action on a function, one of its versions or one of its aliases.
  *
- * A function with no permissions granted contributes nothing, which leaves
- * authorization exactly as it was before resource policies existed. A function
- * that does not exist contributes nothing either: the caller is refused or the
- * function is reported missing, and neither needs a policy.
+ * The resource is whichever of the three the request named, so a grant made on
+ * an alias decides a call on that alias and nothing else. A resource with no
+ * permissions granted contributes nothing, which leaves authorization exactly
+ * as it was before resource policies existed. A resource that does not exist
+ * contributes nothing either: the caller is refused or the resource is
+ * reported missing, and neither needs a policy.
  */
 export function simLambdaResourcePolicies(
-  simFunction: SimLambdaFunction | undefined,
+  resource: SimLambdaPolicyResource | undefined,
 ): readonly SimIamResourcePolicyInput[] {
-  if (simFunction === undefined || simFunction.resourcePolicy.isEmpty()) {
+  if (resource === undefined || resource.resourcePolicy.isEmpty()) {
     return [];
   }
 
   return [
     {
-      document: simFunction.resourcePolicy.document(),
+      document: resource.resourcePolicy.document(),
       policyName,
-      resourceArn: simFunction.arn,
+      resourceArn: resource.arn,
     },
   ];
 }

--- a/src/service/lambda/command/get-policy/get-policy.command.ts
+++ b/src/service/lambda/command/get-policy/get-policy.command.ts
@@ -12,6 +12,7 @@ export interface SimGetPolicyCommand {
  */
 export interface SimGetPolicyCommandInput {
   readonly FunctionName?: string | undefined;
+  readonly Qualifier?: string | undefined;
 }
 
 /**

--- a/src/service/lambda/command/get-policy/get-policy.handler.ts
+++ b/src/service/lambda/command/get-policy/get-policy.handler.ts
@@ -4,6 +4,8 @@ import { assertDefined } from "../../../../util/type-guard/defined.js";
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimLambdaResourceNotFoundException } from "../../error/sim-lambda.error.js";
+import { simLambdaQualifiedFunctionOf } from "../../function/sim-lambda-function-reference.js";
+import type { SimLambdaFunctionVersionStore } from "../../function/version/sim-lambda-function-version-store.js";
 import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
 import { FunctionUrlAuthorizer } from "../function-url/function-url-authorizer.js";
 import type {
@@ -13,6 +15,7 @@ import type {
 
 interface GetPolicyCommandHandlerProperties {
   readonly functions: SimLambdaFunctionLookup;
+  readonly versions: SimLambdaFunctionVersionStore;
   readonly iam: SimIamInterServiceAuthZ;
   readonly background: BackgroundScheduler;
 }
@@ -31,11 +34,13 @@ export class GetPolicyCommandHandler implements CommandHandler<
   SimGetPolicyCommandOutput
 > {
   private readonly functions: SimLambdaFunctionLookup;
+  private readonly versions: SimLambdaFunctionVersionStore;
   private readonly authorizer: FunctionUrlAuthorizer;
   private readonly background: BackgroundScheduler;
 
   constructor(properties: GetPolicyCommandHandlerProperties) {
     this.functions = properties.functions;
+    this.versions = properties.versions;
     this.authorizer = new FunctionUrlAuthorizer({
       iam: properties.iam,
       action: "lambda:GetPolicy",
@@ -44,11 +49,13 @@ export class GetPolicyCommandHandler implements CommandHandler<
   }
 
   /**
-   * Read a sim Lambda function's resource policy.
+   * Read the resource policy of a sim Lambda function, or of the version or
+   * alias a qualifier names.
    *
-   * A function that has been granted nothing has no policy at all, which real
+   * A resource that has been granted nothing has no policy at all, which real
    * Lambda reports as the policy not being found rather than as an empty
-   * document.
+   * document. Each qualified resource answers with its own statements, so the
+   * function's policy is what a request with no qualifier reads.
    */
   async handle(
     command: SimGetPolicyCommand,
@@ -61,11 +68,17 @@ export class GetPolicyCommandHandler implements CommandHandler<
 
     await this.background.sequence();
 
-    const functionName = command.input.FunctionName;
-    const functionArn = this.functions.functionArn(functionName);
+    const { functionName, qualifier } = simLambdaQualifiedFunctionOf(
+      command.input.FunctionName,
+      command.input.Qualifier,
+    );
+    const functionArn = this.functions.functionArn(functionName, qualifier);
     this.authorizer.authorize(functionArn, options?.caller);
 
-    const { resourcePolicy } = this.functions.require(functionName);
+    const { resourcePolicy } = this.versions.requireResource(
+      this.functions.require(functionName),
+      qualifier,
+    );
 
     if (resourcePolicy.isEmpty()) {
       throw new SimLambdaResourceNotFoundException(

--- a/src/service/lambda/command/invoke/invoke-authorizer.ts
+++ b/src/service/lambda/command/invoke/invoke-authorizer.ts
@@ -1,7 +1,7 @@
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
-import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
+import type { SimLambdaPolicyResource } from "../../function/policy/sim-lambda-policy-resource.js";
 import { simLambdaResourcePolicies } from "../authorize/sim-lambda-resource-policies.js";
 
 interface InvokeAuthorizerProperties {
@@ -12,11 +12,14 @@ interface InvokeAuthorizerProperties {
  * Applies IAM authorization to a Lambda Invoke request.
  *
  * AWS maps the Invoke API operation to the lambda:InvokeFunction IAM action.
- * The resource is the function ARN being invoked.
+ * The resource is the function ARN being invoked, qualified when the request
+ * named a version or an alias.
  *
- * The function's own resource-based policy is evaluated alongside the caller's
- * identity policies, so a permission added with AddPermission allows an
- * invocation the caller's own policies do not, which is the whole point of one.
+ * That resource's own resource-based policy is evaluated alongside the
+ * caller's identity policies, so a permission added with AddPermission allows
+ * an invocation the caller's own policies do not, which is the whole point of
+ * one. A grant on the function admits an unqualified call, and a grant on an
+ * alias admits a call through that alias.
  */
 export class InvokeAuthorizer {
   private static readonly action = "lambda:InvokeFunction";
@@ -28,23 +31,23 @@ export class InvokeAuthorizer {
   }
 
   /**
-   * Ensure the caller may invoke the Lambda function with the given ARN.
+   * Ensure the caller may invoke the Lambda resource with the given ARN.
    *
    * The caller is passed through unchanged so sim IAM can distinguish an
    * omitted caller, which defaults to Account root, from an explicit anonymous
-   * caller. The function is optional because a request naming one that does not
+   * caller. The resource is optional because a request naming one that does not
    * exist is still authorized first, as it is on AWS.
    */
   authorize(
     functionArn: string,
     caller?: SimAwsCaller,
-    simFunction?: SimLambdaFunction,
+    resource?: SimLambdaPolicyResource,
   ): void {
     const decision = this.iam.authorize({
       action: InvokeAuthorizer.action,
       resource: functionArn,
       caller,
-      resourcePolicies: simLambdaResourcePolicies(simFunction),
+      resourcePolicies: simLambdaResourcePolicies(resource),
     });
 
     if (decision.isDenied) {

--- a/src/service/lambda/command/invoke/invoke.handler.ts
+++ b/src/service/lambda/command/invoke/invoke.handler.ts
@@ -95,17 +95,22 @@ export class InvokeCommandHandler implements CommandHandler<
     const functionArn = simLambdaFunctionArn(
       this.accountRegionScope,
       functionName,
+      qualifier,
     );
     const simFunction = this.functions.get(
       functionName as SimLambdaFunctionName,
     );
 
-    // Looked up before authorizing, because the function's own resource policy
-    // is part of what decides the answer, but still reported as missing only
-    // after authorization, as AWS orders the two. Authorization is against the
-    // function rather than the version, since a resource policy statement is
-    // not qualified here yet.
-    this.authorizer.authorize(functionArn, options?.caller, simFunction);
+    // Looked up before authorizing, because the resource's own policy is part
+    // of what decides the answer, but still reported as missing only after
+    // authorization, as AWS orders the two. Authorization is against the
+    // resource the request named, so a grant on an alias admits a call through
+    // that alias and a grant on the function admits an unqualified call.
+    this.authorizer.authorize(
+      functionArn,
+      options?.caller,
+      this.versions.findResource(simFunction, qualifier),
+    );
 
     if (simFunction === undefined) {
       throw new SimLambdaResourceNotFoundException(

--- a/src/service/lambda/command/permission/sim-lambda-permission-commands.ts
+++ b/src/service/lambda/command/permission/sim-lambda-permission-commands.ts
@@ -1,6 +1,7 @@
 import type { BackgroundScheduler } from "../../../../util/background/background.js";
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimLambdaFunctionVersionStore } from "../../function/version/sim-lambda-function-version-store.js";
 import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
 import { AddPermissionCommandHandler } from "../add-permission/add-permission.handler.js";
 import type {
@@ -20,6 +21,7 @@ import type {
 
 interface SimLambdaPermissionCommandsProperties {
   readonly functions: SimLambdaFunctionLookup;
+  readonly versions: SimLambdaFunctionVersionStore;
   readonly iam: SimIamInterServiceAuthZ;
   readonly background: BackgroundScheduler;
 }
@@ -43,7 +45,8 @@ export class SimLambdaPermissionCommands {
   }
 
   /**
-   * Grant a permission on a function.
+   * Grant a permission on a function, or on the version or alias a qualifier
+   * names.
    */
   async add(
     command: SimAddPermissionCommand,
@@ -56,7 +59,8 @@ export class SimLambdaPermissionCommands {
   }
 
   /**
-   * Revoke a permission from a function.
+   * Revoke a permission from a function, or from the version or alias a
+   * qualifier names.
    */
   async remove(
     command: SimRemovePermissionCommand,
@@ -69,7 +73,8 @@ export class SimLambdaPermissionCommands {
   }
 
   /**
-   * Read a function's resource policy.
+   * Read the resource policy of a function, or of the version or alias a
+   * qualifier names.
    */
   async getPolicy(
     command: SimGetPolicyCommand,

--- a/src/service/lambda/command/permission/sim-lambda-qualified-permissions.iso.test.ts
+++ b/src/service/lambda/command/permission/sim-lambda-qualified-permissions.iso.test.ts
@@ -1,0 +1,286 @@
+import {
+  AddPermissionCommand,
+  CreateAliasCommand,
+  CreateFunctionCommand,
+  GetPolicyCommand,
+  InvokeCommand,
+  PublishVersionCommand,
+  RemovePermissionCommand,
+  UpdateAliasCommand,
+} from "@aws-sdk/client-lambda";
+import { describe, expect, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { SimLambdaResourceNotFoundException } from "../../error/sim-lambda.error.js";
+import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
+import type { SimLambda } from "../../sim-lambda.js";
+
+const accountId = "888888888888";
+const callerRoleArn = `arn:aws:iam::${accountId}:role/Caller`;
+const functionArn = `arn:aws:lambda:us-east-1:${accountId}:function:orders`;
+
+describe("Simulated Lambda permissions on a version or an alias", () => {
+  /**
+   * A function with one published version, and an alias pointing at it.
+   */
+  async function givenPublishedFunction(): Promise<SimLambda> {
+    const lambda = new SimAws().lambda();
+
+    await lambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "orders",
+        Role: `arn:aws:iam::${accountId}:role/OrdersRole`,
+        Code: { ZipFile: makeLambdaZipFileInput(() => "ordered") },
+      }),
+    );
+    await lambda.publishVersion(
+      new PublishVersionCommand({ FunctionName: "orders" }),
+    );
+    await lambda.createAlias(
+      new CreateAliasCommand({
+        FunctionName: "orders",
+        Name: "live",
+        FunctionVersion: "1",
+      }),
+    );
+
+    return lambda;
+  }
+
+  /**
+   * Grant a principal in the function's own Account permission to invoke the
+   * resource a qualifier names, which within one Account is enough on its own.
+   */
+  async function grantInvoke(
+    lambda: SimLambda,
+    statementId: string,
+    qualifier?: string,
+  ): Promise<string> {
+    const added = await lambda.addPermission(
+      new AddPermissionCommand({
+        FunctionName: "orders",
+        Qualifier: qualifier,
+        StatementId: statementId,
+        Action: "lambda:InvokeFunction",
+        Principal: callerRoleArn,
+      }),
+    );
+
+    return added.Statement;
+  }
+
+  function statementIds(policy: string): string[] {
+    return (
+      JSON.parse(policy) as { Statement: { Sid: string }[] }
+    ).Statement.map((statement) => statement.Sid);
+  }
+
+  it("grants a statement against the ARN of the alias it names", async () => {
+    // Given a function with an alias
+    const lambda = await givenPublishedFunction();
+
+    // When a permission is granted for that alias
+    const statement = await grantInvoke(lambda, "AllowLive", "live");
+
+    // Then the statement it answers with is on the alias, not on the function
+    expect(JSON.parse(statement)).toMatchObject({
+      Sid: "AllowLive",
+      Resource: `${functionArn}:live`,
+    });
+  });
+
+  it("grants a statement against the ARN of the version it names", async () => {
+    // Given a function with a published version
+    const lambda = await givenPublishedFunction();
+
+    // When a permission is granted for that version number
+    const statement = await grantInvoke(lambda, "AllowVersion", "1");
+
+    // Then the statement carries the version's own qualified ARN
+    expect(JSON.parse(statement)).toMatchObject({
+      Resource: `${functionArn}:1`,
+    });
+  });
+
+  it("takes the qualifier appended to the function name", async () => {
+    // Given a function with an alias
+    const lambda = await givenPublishedFunction();
+
+    // When a permission is granted naming the alias on the function name
+    const added = await lambda.addPermission(
+      new AddPermissionCommand({
+        FunctionName: "orders:live",
+        StatementId: "AllowLive",
+        Action: "lambda:InvokeFunction",
+        Principal: callerRoleArn,
+      }),
+    );
+
+    // Then it lands on the alias, as a Qualifier of its own would
+    expect(JSON.parse(added.Statement)).toMatchObject({
+      Resource: `${functionArn}:live`,
+    });
+  });
+
+  it("reports the statements of the resource the policy was asked for", async () => {
+    // Given a function, a version and an alias each granted their own
+    // statement
+    const lambda = await givenPublishedFunction();
+    await grantInvoke(lambda, "AllowFunction");
+    await grantInvoke(lambda, "AllowVersion", "1");
+    await grantInvoke(lambda, "AllowLive", "live");
+
+    // When each policy is read back
+    const read = async (qualifier?: string): Promise<string[]> => {
+      const policy = await lambda.getPolicy(
+        new GetPolicyCommand({ FunctionName: "orders", Qualifier: qualifier }),
+      );
+
+      return statementIds(policy.Policy);
+    };
+
+    // Then each resource reports what was granted on it and nothing else
+    expect(await read()).toStrictEqual(["AllowFunction"]);
+    expect(await read("1")).toStrictEqual(["AllowVersion"]);
+    expect(await read("live")).toStrictEqual(["AllowLive"]);
+  });
+
+  it("has no policy on an alias nothing was granted on", async () => {
+    // Given a function granted a statement of its own
+    const lambda = await givenPublishedFunction();
+    await grantInvoke(lambda, "AllowFunction");
+
+    // When the alias's policy is read
+    // Then the function's grant is not the alias's, so the alias has no policy
+    // at all, which is what AWS reports rather than an empty document
+    await expect(
+      lambda.getPolicy(
+        new GetPolicyCommand({ FunctionName: "orders", Qualifier: "live" }),
+      ),
+    ).rejects.toThrow(SimLambdaResourceNotFoundException);
+  });
+
+  it("removes a statement from the resource it was granted on", async () => {
+    // Given an alias with one statement granted on it
+    const lambda = await givenPublishedFunction();
+    await grantInvoke(lambda, "AllowLive", "live");
+
+    // When it is removed for that alias
+    await lambda.removePermission(
+      new RemovePermissionCommand({
+        FunctionName: "orders",
+        Qualifier: "live",
+        StatementId: "AllowLive",
+      }),
+    );
+
+    // Then the alias is back to having no policy at all
+    await expect(
+      lambda.getPolicy(
+        new GetPolicyCommand({ FunctionName: "orders", Qualifier: "live" }),
+      ),
+    ).rejects.toThrow(SimLambdaResourceNotFoundException);
+  });
+
+  it("refuses to remove a statement granted on another qualifier", async () => {
+    // Given a statement granted on an alias
+    const lambda = await givenPublishedFunction();
+    await grantInvoke(lambda, "AllowLive", "live");
+
+    // When it is removed from the function itself
+    // Then the function's own policy has no such statement, and it is reported
+    // as not found rather than reaching the alias
+    await expect(
+      lambda.removePermission(
+        new RemovePermissionCommand({
+          FunctionName: "orders",
+          StatementId: "AllowLive",
+        }),
+      ),
+    ).rejects.toThrow(/Statement AllowLive is not found/);
+  });
+
+  it("admits an invocation through the alias it was granted on", async () => {
+    // Given a principal granted the invocation on the alias
+    const lambda = await givenPublishedFunction();
+    await grantInvoke(lambda, "AllowLive", "live");
+
+    // When they invoke the function through that alias
+    const invoked = await lambda.invoke(
+      new InvokeCommand({ FunctionName: "orders", Qualifier: "live" }),
+      { caller: { kind: "arn", arn: callerRoleArn } },
+    );
+
+    // Then the grant on the alias is what admits the call
+    expect(invoked.StatusCode).toBe(200);
+    expect(invoked.ExecutedVersion).toBe("1");
+  });
+
+  it("refuses an alias invocation granted only on the function", async () => {
+    // Given a principal granted the invocation on the function itself
+    const lambda = await givenPublishedFunction();
+    await grantInvoke(lambda, "AllowFunction");
+
+    // When they invoke it through the alias instead
+    // Then the grant covers a different resource and nothing admits the call
+    await expect(
+      lambda.invoke(
+        new InvokeCommand({ FunctionName: "orders", Qualifier: "live" }),
+        { caller: { kind: "arn", arn: callerRoleArn } },
+      ),
+    ).rejects.toThrow(SimIamAccessDenied);
+  });
+
+  it("refuses an unqualified invocation granted only on the alias", async () => {
+    // Given a principal granted the invocation on the alias
+    const lambda = await givenPublishedFunction();
+    await grantInvoke(lambda, "AllowLive", "live");
+
+    // When they invoke the function itself
+    // Then the alias grant says nothing about the function, so the call is
+    // denied
+    await expect(
+      lambda.invoke(new InvokeCommand({ FunctionName: "orders" }), {
+        caller: { kind: "arn", arn: callerRoleArn },
+      }),
+    ).rejects.toThrow(SimIamAccessDenied);
+  });
+
+  it("keeps a grant with the alias when it moves to another version", async () => {
+    // Given an alias granted an invocation, moved on to a second version
+    const lambda = await givenPublishedFunction();
+    await grantInvoke(lambda, "AllowLive", "live");
+    await lambda.publishVersion(
+      new PublishVersionCommand({ FunctionName: "orders" }),
+    );
+    await lambda.updateAlias(
+      new UpdateAliasCommand({
+        FunctionName: "orders",
+        Name: "live",
+        FunctionVersion: "2",
+      }),
+    );
+
+    // When the principal invokes through the alias
+    const invoked = await lambda.invoke(
+      new InvokeCommand({ FunctionName: "orders", Qualifier: "live" }),
+      { caller: { kind: "arn", arn: callerRoleArn } },
+    );
+
+    // Then the grant belongs to the name rather than to the version behind it,
+    // which is what makes an alias a stable thing to grant on
+    expect(invoked.ExecutedVersion).toBe("2");
+  });
+
+  it("fails when the qualifier names no version or alias", async () => {
+    // Given a function whose aliases do not include the one named
+    const lambda = await givenPublishedFunction();
+
+    // When a permission is granted for it
+    // Then there is nothing to hold the statement against
+    await expect(
+      grantInvoke(lambda, "AllowStaging", "staging"),
+    ).rejects.toThrow(SimLambdaResourceNotFoundException);
+  });
+});

--- a/src/service/lambda/command/remove-permission/remove-permission.command.ts
+++ b/src/service/lambda/command/remove-permission/remove-permission.command.ts
@@ -12,6 +12,7 @@ export interface SimRemovePermissionCommand {
  */
 export interface SimRemovePermissionCommandInput {
   readonly FunctionName?: string | undefined;
+  readonly Qualifier?: string | undefined;
   readonly StatementId?: string | undefined;
 }
 

--- a/src/service/lambda/command/remove-permission/remove-permission.handler.ts
+++ b/src/service/lambda/command/remove-permission/remove-permission.handler.ts
@@ -3,6 +3,8 @@ import type { BackgroundScheduler } from "../../../../util/background/background
 import { assertDefined } from "../../../../util/type-guard/defined.js";
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simLambdaQualifiedFunctionOf } from "../../function/sim-lambda-function-reference.js";
+import type { SimLambdaFunctionVersionStore } from "../../function/version/sim-lambda-function-version-store.js";
 import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
 import { FunctionUrlAuthorizer } from "../function-url/function-url-authorizer.js";
 import type {
@@ -12,6 +14,7 @@ import type {
 
 interface RemovePermissionCommandHandlerProperties {
   readonly functions: SimLambdaFunctionLookup;
+  readonly versions: SimLambdaFunctionVersionStore;
   readonly iam: SimIamInterServiceAuthZ;
   readonly background: BackgroundScheduler;
 }
@@ -30,11 +33,13 @@ export class RemovePermissionCommandHandler implements CommandHandler<
   SimRemovePermissionCommandOutput
 > {
   private readonly functions: SimLambdaFunctionLookup;
+  private readonly versions: SimLambdaFunctionVersionStore;
   private readonly authorizer: FunctionUrlAuthorizer;
   private readonly background: BackgroundScheduler;
 
   constructor(properties: RemovePermissionCommandHandlerProperties) {
     this.functions = properties.functions;
+    this.versions = properties.versions;
     this.authorizer = new FunctionUrlAuthorizer({
       iam: properties.iam,
       action: "lambda:RemovePermission",
@@ -43,7 +48,11 @@ export class RemovePermissionCommandHandler implements CommandHandler<
   }
 
   /**
-   * Revoke a permission from a sim Lambda function's resource policy.
+   * Revoke a permission from the resource policy of a sim Lambda function, or
+   * of the version or alias a qualifier names.
+   *
+   * A statement is only ever revoked from the resource it was granted on, so a
+   * statement id granted on an alias is not found on the function itself.
    */
   async handle(
     command: SimRemovePermissionCommand,
@@ -61,14 +70,17 @@ export class RemovePermissionCommandHandler implements CommandHandler<
 
     await this.background.sequence();
 
-    const functionName = input.FunctionName;
+    const { functionName, qualifier } = simLambdaQualifiedFunctionOf(
+      input.FunctionName,
+      input.Qualifier,
+    );
     this.authorizer.authorize(
-      this.functions.functionArn(functionName),
+      this.functions.functionArn(functionName, qualifier),
       options?.caller,
     );
 
-    this.functions
-      .require(functionName)
+    this.versions
+      .requireResource(this.functions.require(functionName), qualifier)
       .resourcePolicy.remove(input.StatementId);
 
     return { $metadata: {} };

--- a/src/service/lambda/function/policy/sim-lambda-policy-resource.ts
+++ b/src/service/lambda/function/policy/sim-lambda-policy-resource.ts
@@ -1,0 +1,17 @@
+import type { SimLambdaFunctionArn } from "../sim-lambda-function-configuration.js";
+import type { SimLambdaFunctionPolicy } from "./sim-lambda-function-policy.js";
+
+/**
+ * Something a Lambda resource policy can be granted on: a function, one of its
+ * published versions, or one of its aliases.
+ *
+ * Real Lambda holds a policy per qualified resource rather than one per
+ * function, so a grant made on the alias `live` admits a call on `live` and
+ * says nothing about the version behind it. Each of the three answers for its
+ * own ARN and its own policy, which is all `AddPermission`, `GetPolicy` and
+ * authorization need of them.
+ */
+export interface SimLambdaPolicyResource {
+  readonly arn: SimLambdaFunctionArn;
+  readonly resourcePolicy: SimLambdaFunctionPolicy;
+}

--- a/src/service/lambda/function/sim-lambda-function-configuration.ts
+++ b/src/service/lambda/function/sim-lambda-function-configuration.ts
@@ -27,24 +27,20 @@ export type SimLambdaFunctionArn =
  *
  * A qualifier is appended as real Lambda appends one, so a published version
  * and an alias are addressed by the ARN of the function they belong to with
- * their own name on the end.
+ * their own name on the end. `$LATEST` is the function itself, so it is
+ * addressed by an unqualified ARN.
  */
 export function simLambdaFunctionArn(
   scope: SimAwsAccountRegionScope,
   name: string,
   qualifier?: string,
 ): SimLambdaFunctionArn {
-  const qualifierSuffix = qualifier === undefined ? "" : `:${qualifier}`;
+  const qualifierSuffix =
+    qualifier === undefined || qualifier === SIM_LAMBDA_LATEST_VERSION
+      ? ""
+      : `:${qualifier}`;
 
   return `arn:aws:lambda:${scope.regionName}:${scope.accountId}:function:${name}${qualifierSuffix}`;
-}
-
-/**
- * The qualifier a version's ARN carries. `$LATEST` carries none, since the
- * function itself is addressed by an unqualified ARN.
- */
-export function simLambdaVersionQualifier(version: string): string | undefined {
-  return version === SIM_LAMBDA_LATEST_VERSION ? undefined : version;
 }
 
 /**

--- a/src/service/lambda/function/sim-lambda-function.ts
+++ b/src/service/lambda/function/sim-lambda-function.ts
@@ -11,7 +11,6 @@ import {
   simLambdaFunctionArn,
   type SimLambdaFunctionConfiguration,
   type SimLambdaFunctionState,
-  simLambdaVersionQualifier,
 } from "./sim-lambda-function-configuration.js";
 import {
   type SimLambdaExecutableCode,
@@ -187,7 +186,7 @@ export class SimLambdaFunction {
     return simLambdaFunctionArn(
       this.accountRegionScope,
       this.name,
-      simLambdaVersionQualifier(this.version),
+      this.version,
     );
   }
 

--- a/src/service/lambda/function/url/sim-lambda-function-lookup.ts
+++ b/src/service/lambda/function/url/sim-lambda-function-lookup.ts
@@ -33,10 +33,15 @@ export class SimLambdaFunctionLookup {
   }
 
   /**
-   * Build the ARN a function has, or would have, in this scope.
+   * Build the ARN a function has, or would have, in this scope, qualified by
+   * the version or alias a request named.
    */
-  functionArn(functionName: string): SimLambdaFunctionArn {
-    return simLambdaFunctionArn(this.accountRegionScope, functionName);
+  functionArn(functionName: string, qualifier?: string): SimLambdaFunctionArn {
+    return simLambdaFunctionArn(
+      this.accountRegionScope,
+      functionName,
+      qualifier,
+    );
   }
 
   /**

--- a/src/service/lambda/function/version/sim-lambda-function-alias-store.ts
+++ b/src/service/lambda/function/version/sim-lambda-function-alias-store.ts
@@ -51,7 +51,7 @@ export class SimLambdaFunctionAliasStore {
     }
 
     const alias = new SimLambdaFunctionAlias({
-      aliasArn: simLambdaQualifiedFunctionArn(simFunction, name),
+      arn: simLambdaQualifiedFunctionArn(simFunction, name),
       name,
       functionVersion,
       description,

--- a/src/service/lambda/function/version/sim-lambda-function-alias.ts
+++ b/src/service/lambda/function/version/sim-lambda-function-alias.ts
@@ -1,3 +1,4 @@
+import { SimLambdaFunctionPolicy } from "../policy/sim-lambda-function-policy.js";
 import type { SimLambdaFunctionArn } from "../sim-lambda-function-configuration.js";
 
 /**
@@ -12,7 +13,7 @@ export interface SimLambdaFunctionAliasConfiguration {
 }
 
 interface SimLambdaFunctionAliasProperties {
-  readonly aliasArn: SimLambdaFunctionArn;
+  readonly arn: SimLambdaFunctionArn;
   readonly name: string;
   readonly functionVersion: string;
   readonly description?: string | undefined;
@@ -26,14 +27,24 @@ interface SimLambdaFunctionAliasProperties {
  * changes while the name integrations were built against stays where it is.
  */
 export class SimLambdaFunctionAlias {
-  public readonly aliasArn: SimLambdaFunctionArn;
+  public readonly arn: SimLambdaFunctionArn;
   public readonly name: string;
+  /**
+   * This alias's own resource-based policy, which says who may act on the
+   * alias.
+   *
+   * An alias holds a policy apart from the version it points at, as real
+   * Lambda does. A grant made on `live` is what admits a call on `live`, and
+   * moving the alias to another version carries the grant with the name rather
+   * than leaving it behind.
+   */
+  public readonly resourcePolicy = new SimLambdaFunctionPolicy();
 
   #functionVersion: string;
   #description: string | undefined;
 
   constructor(properties: SimLambdaFunctionAliasProperties) {
-    this.aliasArn = properties.aliasArn;
+    this.arn = properties.arn;
     this.name = properties.name;
     this.#functionVersion = properties.functionVersion;
     this.#description = properties.description;
@@ -64,7 +75,7 @@ export class SimLambdaFunctionAlias {
    */
   configuration(): SimLambdaFunctionAliasConfiguration {
     return {
-      AliasArn: this.aliasArn,
+      AliasArn: this.arn,
       Name: this.name,
       FunctionVersion: this.#functionVersion,
       Description: this.#description,

--- a/src/service/lambda/function/version/sim-lambda-function-version-store.ts
+++ b/src/service/lambda/function/version/sim-lambda-function-version-store.ts
@@ -1,4 +1,5 @@
 import { SimLambdaResourceNotFoundException } from "../../error/sim-lambda.error.js";
+import type { SimLambdaPolicyResource } from "../policy/sim-lambda-policy-resource.js";
 import { SIM_LAMBDA_LATEST_VERSION } from "../sim-lambda-function-configuration.js";
 import type {
   SimLambdaFunction,
@@ -63,6 +64,52 @@ export class SimLambdaFunctionVersionStore {
     }
 
     return resolved;
+  }
+
+  /**
+   * The resource a qualifier names, or nothing when there is no such function
+   * or the qualifier names neither a version nor an alias.
+   *
+   * An alias answers as itself here rather than as the version it points at,
+   * because the two hold their own resource policies. Resolving the alias
+   * first would evaluate the version's policy for a request made against the
+   * alias. A function that is not there answers with nothing, since a request
+   * naming one is authorized before it is reported missing.
+   */
+  findResource(
+    simFunction: SimLambdaFunction | undefined,
+    qualifier: string | undefined,
+  ): SimLambdaPolicyResource | undefined {
+    if (simFunction === undefined) {
+      return undefined;
+    }
+
+    return qualifier === undefined || qualifier === SIM_LAMBDA_LATEST_VERSION
+      ? simFunction
+      : this.of(simFunction).named(qualifier);
+  }
+
+  /**
+   * The resource a qualifier names, or fail as AWS does when it names neither
+   * a version nor an alias.
+   */
+  requireResource(
+    simFunction: SimLambdaFunction,
+    qualifier: string | undefined,
+  ): SimLambdaPolicyResource {
+    if (qualifier === undefined || qualifier === SIM_LAMBDA_LATEST_VERSION) {
+      return simFunction;
+    }
+
+    const resource = this.of(simFunction).named(qualifier);
+
+    if (resource === undefined) {
+      throw new SimLambdaResourceNotFoundException(
+        `Function not found: ${simLambdaQualifiedFunctionArn(simFunction, qualifier)}`,
+      );
+    }
+
+    return resource;
   }
 
   /**

--- a/src/service/lambda/function/version/sim-lambda-function-versions.ts
+++ b/src/service/lambda/function/version/sim-lambda-function-versions.ts
@@ -2,6 +2,7 @@ import {
   type SimLambdaFunctionArn,
   simLambdaFunctionArn,
 } from "../sim-lambda-function-configuration.js";
+import type { SimLambdaPolicyResource } from "../policy/sim-lambda-policy-resource.js";
 import type { SimLambdaFunction } from "../sim-lambda-function.js";
 import type { SimLambdaFunctionAlias } from "./sim-lambda-function-alias.js";
 
@@ -59,7 +60,7 @@ export class SimLambdaFunctionVersions {
    * all digits, so a qualifier that is one is a version number.
    */
   resolve(qualifier: string): SimLambdaFunction | undefined {
-    if (/^\d+$/.test(qualifier)) {
+    if (isVersionNumber(qualifier)) {
       return this.version(qualifier);
     }
 
@@ -68,6 +69,20 @@ export class SimLambdaFunctionVersions {
     return alias === undefined
       ? undefined
       : this.version(alias.functionVersion);
+  }
+
+  /**
+   * The resource a qualifier names, or nothing when it names neither a version
+   * nor an alias.
+   *
+   * This stops where `resolve` carries on: an alias is the resource a grant is
+   * made on and a request is authorized against, so it answers as itself
+   * rather than as the version behind it.
+   */
+  named(qualifier: string): SimLambdaPolicyResource | undefined {
+    return isVersionNumber(qualifier)
+      ? this.version(qualifier)
+      : this.aliases.get(qualifier);
   }
 
   /**
@@ -106,4 +121,12 @@ export class SimLambdaFunctionVersions {
   deleteAlias(name: string): void {
     this.aliases.delete(name);
   }
+}
+
+/**
+ * Whether a qualifier is a version number rather than an alias name, which is
+ * how real Lambda tells the two apart.
+ */
+function isVersionNumber(qualifier: string): boolean {
+  return /^\d+$/.test(qualifier);
 }

--- a/src/service/lambda/sim-lambda-commands.ts
+++ b/src/service/lambda/sim-lambda-commands.ts
@@ -138,6 +138,7 @@ export class SimLambdaCommands {
     });
     this.permissions = new SimLambdaPermissionCommands({
       functions: this.functionLookup,
+      versions: this.versionStore,
       iam,
       background,
     });


### PR DESCRIPTION
Brief, concise description of the change:

`AddPermission`, `RemovePermission` and `GetPolicy` take a `Qualifier` naming a published version or an alias, and hold each statement against the resource it names, with that qualified ARN as the statement's `Resource`. A published version already carried a policy of its own and an alias now carries one too, so a grant on `live` decides a call through `live` and the version behind it needs a grant of its own. `Invoke` authorizes against the resource the request named rather than against the function, and a qualifier naming no version and no alias fails with `ResourceNotFoundException`. `RevisionId` and `EventSourceToken` stay out, along with the services that refuse a qualified target ARN.

Resolves https://github.com/KensioSoftware/yulin/issues/758

- [x] Conventional commit message, used as the title

- [ ] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`

Notes for review:

- `SimLambdaPolicyResource` is the interface a function, a published version and an alias share, an ARN and a policy. `SimLambdaFunctionVersions.named` answers with the alias itself where `resolve` carries on to the version, since resolving first would put the version's policy in front of a request made against the alias.
- `simLambdaFunctionArn` now treats `$LATEST` as the function itself, which retires `simLambdaVersionQualifier`. `SimLambdaFunctionAlias.aliasArn` is renamed to `arn` for the shared interface, and `AliasArn` in the alias configuration is unchanged.
- The served HTTP endpoint still ignores a `Qualifier` on the permission routes, as it does on `GetFunction`. Only `Invoke` reads one there today, and version and alias operations over that endpoint are already recorded as absent.
- The CloudFormation permission path still strips a qualifier from `FunctionName`, which belongs with #761.