### PR TITLE
feat: expand SAM simple tables and HTTP APIs

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -2083,10 +2083,11 @@ part of an identifier). `AccessLogSettings`, `DefaultRouteSettings`, `RouteSetti
 `StageVariables` and `Tags` go on the stage, and the rest of the API's properties on the API.
 
 A `DefinitionBody` reaches the API as its OpenAPI `Body`, and the routes, integrations and
-authorizers the document declares are created from it. An API declaring its routes as
-`AWS::ApiGatewayV2::Route` resources of their own has them name the API by `ApiId`, with `Ref` on
-the SAM logical ID. An API naming a `DefinitionUri` is recorded as unsupported, because nothing here
-reads a document off disk or out of S3.
+authorizers the document declares are created from it. Routes declared outside the document name the
+API by `ApiId`, with `Ref` on the SAM logical ID. That is how an `HttpApi` event on a function
+reaches an API the template declared, and how an `AWS::ApiGatewayV2::Route` resource of its own
+does. An API naming a `DefinitionUri` is recorded as unsupported, because nothing here reads a
+document off disk or out of S3.
 
 The API is deployed without `Auth` and `Domain`. SAM writes an `Auth` block into the document it
 generates, and deploys a `Domain` as a custom domain name resource, and neither is expanded here.

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -2067,8 +2067,9 @@ simulated Function URL answers no preflight request).
 `AWS::Serverless::SimpleTable` deploys a table with one partition key and on-demand billing.
 `PrimaryKey` names that key, and its `Type` is the SAM name for the attribute type (`String`,
 `Number` or `Binary`). A table naming no key is keyed on a string `id`, the key SAM gives it.
-`TableName`, `SSESpecification` and `ProvisionedThroughput` carry across as the template wrote them,
-and a table asking for capacity is billed for the capacity it asked for. `Tags` are stated as a map
+`TableName`, `SSESpecification`, `PointInTimeRecoverySpecification` and `ProvisionedThroughput`
+carry across as the template wrote them, and a table asking for capacity is billed for the capacity
+it asked for. `Tags` are stated as a map
 of one value per tag name, and reach the table as the list of `Key` and `Value` pairs DynamoDB
 takes.
 
@@ -2076,8 +2077,9 @@ takes.
 
 `AWS::Serverless::HttpApi` deploys an HTTP API and the stage that serves it. The stage is `$default`
 until `StageName` names another one, and it carries the logical ID SAM builds for it
-(`OrdersApiGatewayDefaultStage` for an API called `Orders`, and `OrdersprodStage` for the same API
-with `StageName: prod`). `AccessLogSettings`, `DefaultRouteSettings`, `RouteSettings`,
+(`OrdersApiGatewayDefaultStage` for an API called `Orders`, `OrdersprodStage` for the same API with
+`StageName: prod`, and `OrdersStage` followed by ten characters of a hash where the name cannot be
+part of an identifier). `AccessLogSettings`, `DefaultRouteSettings`, `RouteSettings`,
 `StageVariables` and `Tags` go on the stage, and the rest of the API's properties on the API.
 
 A `DefinitionBody` reaches the API as its OpenAPI `Body`, and the routes, integrations and

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -1908,8 +1908,10 @@ a matching binding keep their template code, running in the simulated vm runtime
 
 A template naming the `AWS::Serverless-2016-10-31` transform has its SAM resources expanded before
 the stack deploys, the way CloudFormation expands them. `AWS::Serverless::Function` becomes an
-`AWS::Lambda::Function` and the `AWS::IAM::Role` it runs as. `Globals.Function` supplies the
-defaults every function takes, and a value on the function itself wins.
+`AWS::Lambda::Function` and the `AWS::IAM::Role` it runs as. `AWS::Serverless::SimpleTable` becomes
+an `AWS::DynamoDB::Table`, and `AWS::Serverless::HttpApi` becomes an `AWS::ApiGatewayV2::Api` and
+its stage. `Globals.Function` and `Globals.HttpApi` supply the defaults every function and every API
+takes, and a value on the resource itself wins.
 
 The expanded function keeps the logical ID the SAM resource had. `Ref` and `Fn::GetAtt` against that
 name answer for the function, and a binding targeting that logical ID backs it with your real
@@ -2059,6 +2061,79 @@ await srv.close();
 A `FunctionUrlConfig` on the function expands into an `AWS::Lambda::Url` named after it, `RatesUrl`
 for a function called `Rates`. `AuthType` and `InvokeMode` carry over. `Cors` is left out (the
 simulated Function URL answers no preflight request).
+
+### Simple tables
+
+`AWS::Serverless::SimpleTable` deploys a table with one partition key and on-demand billing.
+`PrimaryKey` names that key, and its `Type` is the SAM name for the attribute type (`String`,
+`Number` or `Binary`). A table naming no key is keyed on a string `id`, the key SAM gives it.
+`TableName`, `SSESpecification` and `ProvisionedThroughput` carry across as the template wrote them,
+and a table asking for capacity is billed for the capacity it asked for. `Tags` are stated as a map
+of one value per tag name, and reach the table as the list of `Key` and `Value` pairs DynamoDB
+takes.
+
+### HTTP APIs
+
+`AWS::Serverless::HttpApi` deploys an HTTP API and the stage that serves it. The stage is `$default`
+until `StageName` names another one, and it carries the logical ID SAM builds for it
+(`OrdersApiGatewayDefaultStage` for an API called `Orders`, and `OrdersprodStage` for the same API
+with `StageName: prod`). `AccessLogSettings`, `DefaultRouteSettings`, `RouteSettings`,
+`StageVariables` and `Tags` go on the stage, and the rest of the API's properties on the API.
+
+A `DefinitionBody` reaches the API as its OpenAPI `Body`, and the routes, integrations and
+authorizers the document declares are created from it. An API declaring its routes as
+`AWS::ApiGatewayV2::Route` resources of their own has them name the API by `ApiId`, with `Ref` on
+the SAM logical ID. An API naming a `DefinitionUri` is recorded as unsupported, because nothing here
+reads a document off disk or out of S3.
+
+The API is deployed without `Auth` and `Domain`. SAM writes an `Auth` block into the document it
+generates, and deploys a `Domain` as a custom domain name resource, and neither is expanded here.
+
+```typescript sim-cloudformation-sam-table-api
+/**
+ * Deploying a SAM AWS::Serverless::SimpleTable and AWS::Serverless::HttpApi.
+ */
+
+import { DescribeTableCommand } from "@aws-sdk/client-dynamodb";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Transform: "AWS::Serverless-2016-10-31",
+    Globals: {
+      HttpApi: {
+        StageVariables: { TABLE_NAME: "orders" },
+      },
+    },
+    Resources: {
+      OrdersTable: {
+        Type: "AWS::Serverless::SimpleTable",
+        Properties: {
+          TableName: "orders",
+          PrimaryKey: { Name: "orderId", Type: "String" },
+        },
+      },
+      Orders: {
+        Type: "AWS::Serverless::HttpApi",
+        Properties: { Name: "orders" },
+      },
+    },
+  },
+});
+await stack.waitForDeployComplete();
+
+console.log(stack.getResource("Orders")?.type);
+console.log(stack.getResource("OrdersApiGatewayDefaultStage")?.type);
+
+const described = await simAws
+  .dynamoDb()
+  .describeTable(new DescribeTableCommand({ TableName: "orders" }));
+
+console.log(described.Table?.KeySchema);
+```
 
 ## Serving deployed resources on localhost
 
@@ -2639,7 +2714,9 @@ Sim CloudFormation currently supports:
 - Explicit resource dependencies with `DependsOn`
 - Implicit dependencies from resource `Ref` expressions
 - SAM templates naming the `AWS::Serverless-2016-10-31` transform, with `AWS::Serverless::Function`
-  expanded into a Lambda function and its execution Role, and `Globals.Function` defaults applied
+  expanded into a Lambda function and its execution Role, `AWS::Serverless::SimpleTable` into a
+  DynamoDB table, `AWS::Serverless::HttpApi` into an HTTP API and its stage, and the
+  `Globals.Function` and `Globals.HttpApi` defaults applied
 - The `HttpApi` event of a SAM function, expanded into the API, integration, route, stage and invoke
   permission that serve it, and `FunctionUrlConfig`, expanded into a Function URL
 

--- a/docs/services/cloudformation/sim-cloudformation-sam-table-api.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-sam-table-api.example.ts
@@ -1,0 +1,43 @@
+/**
+ * Deploying a SAM AWS::Serverless::SimpleTable and AWS::Serverless::HttpApi.
+ */
+
+import { DescribeTableCommand } from "@aws-sdk/client-dynamodb";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Transform: "AWS::Serverless-2016-10-31",
+    Globals: {
+      HttpApi: {
+        StageVariables: { TABLE_NAME: "orders" },
+      },
+    },
+    Resources: {
+      OrdersTable: {
+        Type: "AWS::Serverless::SimpleTable",
+        Properties: {
+          TableName: "orders",
+          PrimaryKey: { Name: "orderId", Type: "String" },
+        },
+      },
+      Orders: {
+        Type: "AWS::Serverless::HttpApi",
+        Properties: { Name: "orders" },
+      },
+    },
+  },
+});
+await stack.waitForDeployComplete();
+
+console.log(stack.getResource("Orders")?.type);
+console.log(stack.getResource("OrdersApiGatewayDefaultStage")?.type);
+
+const described = await simAws
+  .dynamoDb()
+  .describeTable(new DescribeTableCommand({ TableName: "orders" }));
+
+console.log(described.Table?.KeySchema);

--- a/src/service/cloudformation/sam/api/sim-cfn-sam-http-api-stage.ts
+++ b/src/service/cloudformation/sam/api/sim-cfn-sam-http-api-stage.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import type {
   SimCfnTemplateValue,
   SimCfnTemplateValueRecord,
@@ -60,14 +62,14 @@ export function samHttpApiStageResources(
 }
 
 /**
- * The logical ID the stage is deployed under, which SAM builds out of the
- * API's logical ID and the stage's name.
+ * The logical ID the stage is deployed under, which SAM builds out of the API's
+ * logical ID and the stage's name.
  *
- * The name is in there because it is what a template writing `Ref` on the
- * stage is reaching for. SAM hashes a name that cannot be part of an
- * identifier. An API has one stage and nothing here collides, and an
- * unhashable name gets the plain suffix (a hash would be a logical ID no
- * reader could predict).
+ * The three forms are SAM's own. A name that can be part of an identifier goes
+ * in whole, `$default` becomes the suffix SAM spells out, and anything else is
+ * hashed, down to the ten hexadecimal characters SAM takes off a SHA-1 of the
+ * name. A stage the template names with an intrinsic function has no name to
+ * hash at this point, and SAM hashes the empty string for it.
  */
 function samHttpApiStageLogicalId(
   logicalId: string,
@@ -81,7 +83,17 @@ function samHttpApiStageLogicalId(
     return `${logicalId}${stageName}Stage`;
   }
 
-  return `${logicalId}Stage`;
+  return `${logicalId}Stage${samStageNameHash(stageName)}`;
+}
+
+/**
+ * The hash SAM builds a stage's logical ID out of when the name cannot be part
+ * of one.
+ */
+function samStageNameHash(stageName: SimCfnTemplateValue): string {
+  const name = typeof stageName === "string" ? stageName : "";
+
+  return createHash("sha1").update(name).digest("hex").slice(0, 10);
 }
 
 /**

--- a/src/service/cloudformation/sam/api/sim-cfn-sam-http-api-stage.ts
+++ b/src/service/cloudformation/sam/api/sim-cfn-sam-http-api-stage.ts
@@ -1,0 +1,96 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../template/value/sim-cfn-template-value.js";
+import { samPickedProperties } from "../sim-cfn-sam-picked.js";
+
+interface SamHttpApiStageProperties {
+  readonly logicalId: string;
+  readonly resource: SimCfnTemplateValueRecord;
+  readonly apiProperties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * The stage an API naming none is deployed with. SAM deploys the same one, and
+ * a request reaches it without naming a stage in its path.
+ */
+const defaultStageName = "$default";
+
+/**
+ * The properties the stage takes off the SAM Resource. Their names and
+ * meanings are the same on both.
+ */
+const propertyNames = new Set([
+  "AccessLogSettings",
+  "DefaultRouteSettings",
+  "RouteSettings",
+  "StageVariables",
+  "Tags",
+]);
+
+/**
+ * The AWS::ApiGatewayV2::Stage Resource a SAM HTTP API is expanded with.
+ *
+ * An HTTP API serves nothing until a stage is deployed to it, and a SAM
+ * template names no stage Resource of its own. The expansion deploys one. It
+ * deploys itself, the way SAM's stage does, and the routes the API gains after
+ * it are served with no deployment Resource to sequence.
+ *
+ * The stage is conditioned the way the API is. An API the template conditioned
+ * out leaves no stage behind for the Stack to create.
+ */
+export function samHttpApiStageResources(
+  properties: SamHttpApiStageProperties,
+): Record<string, SimCfnTemplateValue> {
+  const { logicalId, resource, apiProperties } = properties;
+  const stageName = apiProperties["StageName"] ?? defaultStageName;
+
+  return {
+    [samHttpApiStageLogicalId(logicalId, stageName)]: {
+      Type: "AWS::ApiGatewayV2::Stage",
+      ...samStageCondition(resource),
+      Properties: {
+        ...samPickedProperties(apiProperties, propertyNames),
+        ApiId: { Ref: logicalId },
+        StageName: stageName,
+        AutoDeploy: true,
+      },
+    },
+  };
+}
+
+/**
+ * The logical ID the stage is deployed under, which SAM builds out of the
+ * API's logical ID and the stage's name.
+ *
+ * The name is in there because it is what a template writing `Ref` on the
+ * stage is reaching for. SAM hashes a name that cannot be part of an
+ * identifier. An API has one stage and nothing here collides, and an
+ * unhashable name gets the plain suffix (a hash would be a logical ID no
+ * reader could predict).
+ */
+function samHttpApiStageLogicalId(
+  logicalId: string,
+  stageName: SimCfnTemplateValue,
+): string {
+  if (stageName === defaultStageName) {
+    return `${logicalId}ApiGatewayDefaultStage`;
+  }
+
+  if (typeof stageName === "string" && /^[A-Za-z0-9]+$/.test(stageName)) {
+    return `${logicalId}${stageName}Stage`;
+  }
+
+  return `${logicalId}Stage`;
+}
+
+/**
+ * The `Condition` attribute the stage carries, where the API carried one.
+ */
+function samStageCondition(
+  resource: SimCfnTemplateValueRecord,
+): SimCfnTemplateValueRecord {
+  const condition = resource["Condition"];
+
+  return condition === undefined ? {} : { Condition: condition };
+}

--- a/src/service/cloudformation/sam/api/sim-cfn-sam-http-api-template.factory.ts
+++ b/src/service/cloudformation/sam/api/sim-cfn-sam-http-api-template.factory.ts
@@ -1,0 +1,136 @@
+import { MappedFactory } from "@kensio/part-factory";
+
+import type { CfnTemplateBodyRecord } from "../../template/sim-cfn-template.js";
+import type { SimCfnTemplateValueRecord } from "../../template/value/sim-cfn-template-value.js";
+import { samFunctionType } from "../function/sim-cfn-sam-function.js";
+import { samTransformName } from "../sim-cfn-sam-transform.js";
+import { samHttpApiType } from "./sim-cfn-sam-http-api.js";
+
+/**
+ * What a test asks for when it wants a SAM template holding one HTTP API in
+ * front of one function.
+ */
+export interface SimCfnSamHttpApiTemplateInput {
+  /**
+   * What this test is about, added to the properties of an API that already
+   * deploys.
+   */
+  readonly apiProperties: SimCfnTemplateValueRecord;
+  /**
+   * The route the API routes onto the function, as Resources of its own. A
+   * test declaring its routes in a `DefinitionBody` asks for none.
+   */
+  readonly routeKey: string | undefined;
+}
+
+/**
+ * The logical ID the API carries, and so the name the HTTP API is expanded
+ * under.
+ */
+export const samHttpApiTemplateLogicalId = "Orders";
+
+/**
+ * The logical ID the expanded stage carries, for the API that names no stage.
+ */
+export const samHttpApiTemplateStageLogicalId = "OrdersApiGatewayDefaultStage";
+
+/**
+ * A handler reporting the route and the stage that reached it. A request
+ * served through the template says which of the API's routes served it.
+ */
+const handlerSource = `
+exports.handler = async (event) => ({
+  statusCode: 200,
+  headers: { "content-type": "text/plain" },
+  body: event.routeKey + " " + event.requestContext.stage,
+});
+`;
+
+/**
+ * Builds a SAM template holding one AWS::Serverless::HttpApi.
+ *
+ * ```typescript
+ * const stack = await simAws.cloudFormation().deployTemplate({
+ *   stackName: "orders-stack",
+ *   template: simCfnSamHttpApiTemplateFactory.make({
+ *     apiProperties: { StageName: "prod" },
+ *   }),
+ * });
+ * ```
+ *
+ * The routes and the integration are Resources naming the API by `ApiId`, the
+ * way a template writes them against an API it declared. A request the
+ * template serves is one the SAM logical ID answered for.
+ */
+export const simCfnSamHttpApiTemplateFactory = new MappedFactory<
+  SimCfnSamHttpApiTemplateInput,
+  CfnTemplateBodyRecord
+>(
+  () => ({ apiProperties: {}, routeKey: "GET /orders" }),
+  (input) => ({
+    Transform: samTransformName,
+    Resources: {
+      [samHttpApiTemplateLogicalId]: {
+        Type: samHttpApiType,
+        Properties: { ...input.apiProperties },
+      },
+      Handler: {
+        Type: samFunctionType,
+        Properties: {
+          FunctionName: "orders",
+          Handler: "index.handler",
+          Runtime: "nodejs22.x",
+          InlineCode: handlerSource,
+        },
+      },
+      HandlerPermission: {
+        Type: "AWS::Lambda::Permission",
+        Properties: {
+          Action: "lambda:InvokeFunction",
+          FunctionName: { "Fn::GetAtt": ["Handler", "Arn"] },
+          Principal: "apigateway.amazonaws.com",
+        },
+      },
+      ...integrationResources(input),
+    },
+    Outputs: {
+      ApiId: { Value: { Ref: samHttpApiTemplateLogicalId } },
+      ApiEndpoint: {
+        Value: { "Fn::GetAtt": [samHttpApiTemplateLogicalId, "ApiEndpoint"] },
+      },
+    },
+  }),
+);
+
+/**
+ * The integration and the route reaching it, for a template that declares its
+ * routes as Resources of their own.
+ */
+function integrationResources(
+  input: SimCfnSamHttpApiTemplateInput,
+): SimCfnTemplateValueRecord {
+  if (input.routeKey === undefined) {
+    return {};
+  }
+
+  return {
+    Integration: {
+      Type: "AWS::ApiGatewayV2::Integration",
+      Properties: {
+        ApiId: { Ref: samHttpApiTemplateLogicalId },
+        IntegrationType: "AWS_PROXY",
+        IntegrationUri: { "Fn::GetAtt": ["Handler", "Arn"] },
+        PayloadFormatVersion: "2.0",
+      },
+    },
+    Route: {
+      Type: "AWS::ApiGatewayV2::Route",
+      Properties: {
+        ApiId: { Ref: samHttpApiTemplateLogicalId },
+        RouteKey: input.routeKey,
+        AuthorizationType: "NONE",
+        Target: { "Fn::Join": ["", ["integrations/", { Ref: "Integration" }]] },
+      },
+    },
+  };
+}

--- a/src/service/cloudformation/sam/api/sim-cfn-sam-http-api.ts
+++ b/src/service/cloudformation/sam/api/sim-cfn-sam-http-api.ts
@@ -1,0 +1,113 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../template/value/sim-cfn-template-value.js";
+import {
+  samCarriedAttributes,
+  samResourceProperties,
+} from "../function/sim-cfn-sam-function-properties.js";
+import { samMergedHttpApiProperties } from "../sim-cfn-sam-globals.js";
+import { samPickedProperties } from "../sim-cfn-sam-picked.js";
+import { samHttpApiStageResources } from "./sim-cfn-sam-http-api-stage.js";
+
+interface SamHttpApiExpansionProperties {
+  readonly logicalId: string;
+  readonly resource: SimCfnTemplateValueRecord;
+  readonly globals: SimCfnTemplateValueRecord;
+}
+
+/**
+ * The SAM Resource type this expansion covers.
+ */
+export const samHttpApiType = "AWS::Serverless::HttpApi";
+
+/**
+ * The properties whose names and meanings are the same on both Resource types.
+ * Expanding one of them is carrying it across.
+ *
+ * `Auth` and `Domain` are absent from the list. SAM writes an `Auth` block
+ * into the OpenAPI document it generates, and deploys a `Domain` as a custom
+ * domain name Resource. Neither is expanded here, and an API declaring one is
+ * deployed without it.
+ */
+const propertyNames = new Set([
+  "CorsConfiguration",
+  "Description",
+  "DisableExecuteApiEndpoint",
+  "FailOnWarnings",
+  "Name",
+]);
+
+/**
+ * Expand one AWS::Serverless::HttpApi into the Resources CloudFormation
+ * deploys for it.
+ *
+ * The API keeps the logical ID the template gave the SAM Resource. `Ref` and
+ * `Fn::GetAtt` against that name answer what they answer for the API, and a
+ * route naming the API by `ApiId` reaches the one the template declared. Its
+ * stage is a second Resource named after it.
+ *
+ * A `DefinitionBody` is the API's OpenAPI document, and becomes the `Body` the
+ * API is imported from, routes and integrations and all. A `DefinitionUri`
+ * points at a document on disk or in S3. Nothing here reads either, and an API
+ * declaring one is left as the template wrote it, to be recorded as
+ * unsupported. The alternative is an API deployed with no routes at all.
+ */
+export function samHttpApiResources(
+  properties: SamHttpApiExpansionProperties,
+): Record<string, SimCfnTemplateValue> {
+  const { logicalId, resource, globals } = properties;
+  const apiProperties = samMergedHttpApiProperties(
+    globals,
+    samResourceProperties(resource),
+  );
+
+  if (apiProperties["DefinitionUri"] !== undefined) {
+    return { [logicalId]: resource };
+  }
+
+  return {
+    [logicalId]: {
+      Type: "AWS::ApiGatewayV2::Api",
+      ...samCarriedAttributes(resource),
+      Properties: {
+        ...samPickedProperties(apiProperties, propertyNames),
+        ...samHttpApiName(logicalId, apiProperties),
+        ProtocolType: "HTTP",
+        ...samHttpApiBody(apiProperties),
+      },
+    },
+    ...samHttpApiStageResources({ logicalId, resource, apiProperties }),
+  };
+}
+
+/**
+ * The name of an API that named itself none.
+ *
+ * An HTTP API is named where a SAM one need not be, and the logical ID is the
+ * name the template already has for it. An API imported from a document takes
+ * its name from the document's title, and is left unnamed here for that title
+ * to name.
+ */
+function samHttpApiName(
+  logicalId: string,
+  apiProperties: SimCfnTemplateValueRecord,
+): SimCfnTemplateValueRecord {
+  const named =
+    apiProperties["Name"] !== undefined ||
+    apiProperties["DefinitionBody"] !== undefined;
+
+  return named ? {} : { Name: logicalId };
+}
+
+/**
+ * The OpenAPI document the API is imported from, where the template declared
+ * one inline.
+ */
+function samHttpApiBody(
+  apiProperties: SimCfnTemplateValueRecord,
+): SimCfnTemplateValueRecord {
+  const definitionBody = apiProperties["DefinitionBody"];
+
+  return definitionBody === undefined ? {} : { Body: definitionBody };
+}

--- a/src/service/cloudformation/sam/sim-cfn-sam-expansion.ts
+++ b/src/service/cloudformation/sam/sim-cfn-sam-expansion.ts
@@ -2,10 +2,19 @@ import { isRecord } from "../../../util/type-guard/record.js";
 import type { CfnTemplateBodyRecord } from "../template/sim-cfn-template.js";
 import type { SimCfnTemplateValue } from "../template/value/sim-cfn-template-value.js";
 import {
+  samHttpApiResources,
+  samHttpApiType,
+} from "./api/sim-cfn-sam-http-api.js";
+import {
   samFunctionResources,
   samFunctionType,
 } from "./function/sim-cfn-sam-function.js";
-import { samFunctionGlobals } from "./sim-cfn-sam-globals.js";
+import {
+  samSimpleTableResources,
+  samSimpleTableType,
+} from "./table/sim-cfn-sam-simple-table.js";
+import type { SamTemplateGlobals } from "./sim-cfn-sam-globals.js";
+import { samTemplateGlobals } from "./sim-cfn-sam-globals.js";
 import { isSamTemplateRecord } from "./sim-cfn-sam-record.js";
 import {
   templateNamesSamTransform,
@@ -38,7 +47,7 @@ export function samExpandedTemplate(
     return template;
   }
 
-  const globals = samFunctionGlobals(template);
+  const globals = samTemplateGlobals(template);
 
   return {
     ...withoutSamSections(template),
@@ -57,11 +66,33 @@ export function samExpandedTemplate(
 function expandedResource(
   logicalId: string,
   resource: SimCfnTemplateValue,
-  globals: Record<string, SimCfnTemplateValue>,
+  globals: SamTemplateGlobals,
 ): Record<string, SimCfnTemplateValue> {
-  if (!isSamTemplateRecord(resource) || resource["Type"] !== samFunctionType) {
+  if (!isSamTemplateRecord(resource)) {
     return { [logicalId]: resource };
   }
 
-  return samFunctionResources({ logicalId, resource, globals });
+  const type = resource["Type"];
+
+  if (type === samFunctionType) {
+    return samFunctionResources({
+      logicalId,
+      resource,
+      globals: globals.forFunction,
+    });
+  }
+
+  if (type === samHttpApiType) {
+    return samHttpApiResources({
+      logicalId,
+      resource,
+      globals: globals.forHttpApi,
+    });
+  }
+
+  if (type === samSimpleTableType) {
+    return samSimpleTableResources({ logicalId, resource });
+  }
+
+  return { [logicalId]: resource };
 }

--- a/src/service/cloudformation/sam/sim-cfn-sam-globals.ts
+++ b/src/service/cloudformation/sam/sim-cfn-sam-globals.ts
@@ -3,21 +3,56 @@ import type { SimCfnTemplateValueRecord } from "../template/value/sim-cfn-templa
 import { isSamTemplateRecord } from "./sim-cfn-sam-record.js";
 
 /**
- * The `Globals.Function` defaults a template states. A template carrying no
- * `Globals` section states none.
+ * The `Globals` defaults a template states, by the SAM Resource type each
+ * section supplies them to.
  */
-export function samFunctionGlobals(
+export interface SamTemplateGlobals {
+  /** The `Globals.Function` defaults every SAM function takes. */
+  readonly forFunction: SimCfnTemplateValueRecord;
+  /** The `Globals.HttpApi` defaults every SAM HTTP API takes. */
+  readonly forHttpApi: SimCfnTemplateValueRecord;
+}
+
+/**
+ * The `Globals` defaults a template states. A template carrying no `Globals`
+ * section states none.
+ */
+export function samTemplateGlobals(
   template: CfnTemplateBodyRecord,
-): SimCfnTemplateValueRecord {
+): SamTemplateGlobals {
   const globals = template["Globals"];
 
   if (!isSamTemplateRecord(globals)) {
-    return {};
+    return { forFunction: {}, forHttpApi: {} };
   }
 
-  const functionGlobals = globals["Function"];
+  return {
+    forFunction: samGlobalsSection(globals["Function"]),
+    forHttpApi: samGlobalsSection(globals["HttpApi"]),
+  };
+}
 
-  return isSamTemplateRecord(functionGlobals) ? functionGlobals : {};
+/**
+ * One section of the `Globals` a template states. A template stating a section
+ * in some other shape states no defaults.
+ */
+function samGlobalsSection(section: unknown): SimCfnTemplateValueRecord {
+  return isSamTemplateRecord(section) ? section : {};
+}
+
+/**
+ * The properties an HTTP API is expanded with, from the `Globals.HttpApi`
+ * defaults and what the API states for itself.
+ *
+ * A property the API states wins outright. Nothing here is merged the way a
+ * function's environment variables are, because none of what an HTTP API takes
+ * from `Globals` is a set of named entries a second declaration adds to.
+ */
+export function samMergedHttpApiProperties(
+  globals: SimCfnTemplateValueRecord,
+  properties: SimCfnTemplateValueRecord,
+): SimCfnTemplateValueRecord {
+  return { ...globals, ...properties };
 }
 
 /**

--- a/src/service/cloudformation/sam/sim-cfn-sam-http-api-globals.iso.test.ts
+++ b/src/service/cloudformation/sam/sim-cfn-sam-http-api-globals.iso.test.ts
@@ -1,0 +1,64 @@
+import { assertIdentical, assertNonNullable } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import type { SimHttpApiStage } from "../../apigatewayv2/api/stage/sim-http-api-stage.js";
+import { SimAws } from "../../aws/sim-aws.js";
+
+describe("SAM Globals HttpApi defaults", () => {
+  it("applies the defaults to every API in the template", async () => {
+    // Given a SAM template stating defaults and two APIs taking them
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "globals-api-stack",
+      template: {
+        Transform: "AWS::Serverless-2016-10-31",
+        Globals: {
+          HttpApi: { StageVariables: { table: "orders-dev" } },
+        },
+        Resources: {
+          Orders: { Type: "AWS::Serverless::HttpApi" },
+          Rates: { Type: "AWS::Serverless::HttpApi" },
+        },
+      },
+    });
+
+    // Then both APIs are serving from a stage carrying them
+    for (const logicalId of ["Orders", "Rates"]) {
+      const stage = stack.getResource(`${logicalId}ApiGatewayDefaultStage`)
+        ?.simResource as SimHttpApiStage;
+      assertNonNullable(stage);
+
+      assertIdentical(stage.stageName, "$default");
+      assertIdentical(stage.stageVariables["table"], "orders-dev");
+    }
+  });
+
+  it("prefers what the API states over the default", async () => {
+    // Given an API naming a stage of its own over the default one
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "globals-api-override-stack",
+      template: {
+        Transform: "AWS::Serverless-2016-10-31",
+        Globals: { HttpApi: { StageName: "dev" } },
+        Resources: {
+          Orders: {
+            Type: "AWS::Serverless::HttpApi",
+            Properties: { StageName: "prod" },
+          },
+        },
+      },
+    });
+
+    // Then the API is served from the stage it named
+    const stage = stack.getResource("OrdersprodStage")
+      ?.simResource as SimHttpApiStage;
+    assertNonNullable(stage);
+
+    assertIdentical(stage.stageName, "prod");
+  });
+});

--- a/src/service/cloudformation/sam/sim-cfn-sam-http-api.iso.test.ts
+++ b/src/service/cloudformation/sam/sim-cfn-sam-http-api.iso.test.ts
@@ -264,4 +264,53 @@ describe("SAM Serverless HttpApi expansion", () => {
     assertUndefined(stack.getResource(samHttpApiTemplateLogicalId));
     assertUndefined(stack.getResource(samHttpApiTemplateStageLogicalId));
   });
+
+  it("serves a function whose HttpApi event names the API by ApiId", async () => {
+    // Given a function routed to the API the template declared, which is how a
+    // SAM template puts a function behind an API of its own
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await deployHttpApi(simAws, {
+      Transform: "AWS::Serverless-2016-10-31",
+      Resources: {
+        Orders: { Type: "AWS::Serverless::HttpApi" },
+        Handler: {
+          Type: "AWS::Serverless::Function",
+          Properties: {
+            Handler: "index.handler",
+            Runtime: "nodejs22.x",
+            InlineCode: `
+exports.handler = async (event) => ({
+  statusCode: 200,
+  headers: { "content-type": "text/plain" },
+  body: event.routeKey + " " + event.requestContext.stage,
+});
+`,
+            Events: {
+              Get: {
+                Type: "HttpApi",
+                Properties: {
+                  ApiId: { Ref: samHttpApiTemplateLogicalId },
+                  Path: "/orders",
+                  Method: "GET",
+                },
+              },
+            },
+          },
+        },
+      },
+      Outputs: {
+        ApiEndpoint: {
+          Value: { "Fn::GetAtt": [samHttpApiTemplateLogicalId, "ApiEndpoint"] },
+        },
+      },
+    });
+
+    // Then the event's route is served from the expanded API's stage
+    const response = await requestApi(simAws, stack, "/orders");
+
+    assertIdentical(response.status, 200);
+    assertIdentical(await response.text(), "GET /orders $default");
+  });
 });

--- a/src/service/cloudformation/sam/sim-cfn-sam-http-api.iso.test.ts
+++ b/src/service/cloudformation/sam/sim-cfn-sam-http-api.iso.test.ts
@@ -213,7 +213,7 @@ describe("SAM Serverless HttpApi expansion", () => {
 
   it("names the stage of an API whose stage name is no identifier", async () => {
     // Given an API naming a stage a logical ID cannot be built out of, which
-    // SAM names by hashing it
+    // SAM hashes into one
     const simAws = new SimAws();
 
     // When it is deployed
@@ -224,8 +224,9 @@ describe("SAM Serverless HttpApi expansion", () => {
       }),
     );
 
-    // Then the stage carries the plain suffix, and serves the API's routes
-    const stage = stack.getResource("OrdersStage")
+    // Then the stage carries the logical ID SAM hashes the name into, and
+    // serves the API's routes
+    const stage = stack.getResource("OrdersStageaed0986a76")
       ?.simResource as SimHttpApiStage;
     assertNonNullable(stage);
     assertIdentical(stage.stageName, "orders-dev");

--- a/src/service/cloudformation/sam/sim-cfn-sam-http-api.iso.test.ts
+++ b/src/service/cloudformation/sam/sim-cfn-sam-http-api.iso.test.ts
@@ -1,0 +1,266 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertObjectEquals,
+  assertTypeString,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import type { SimHttpApiStage } from "../../apigatewayv2/api/stage/sim-http-api-stage.js";
+import type { SimHttpApi } from "../../apigatewayv2/api/sim-http-api.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnStack } from "../stack/sim-cfn-stack.js";
+import type { CfnTemplateBodyRecord } from "../template/sim-cfn-template.js";
+import {
+  samHttpApiTemplateLogicalId,
+  samHttpApiTemplateStageLogicalId,
+  simCfnSamHttpApiTemplateFactory,
+} from "./api/sim-cfn-sam-http-api-template.factory.js";
+
+/**
+ * The `x-amazon-apigateway-integration` a document declares its routes with,
+ * whose URI is the function the same template deploys.
+ */
+const documentIntegration = {
+  type: "aws_proxy",
+  httpMethod: "POST",
+  uri: { "Fn::GetAtt": ["Handler", "Arn"] },
+  payloadFormatVersion: "2.0",
+};
+
+/**
+ * Deploy a SAM template and wait for the API it holds to be serving.
+ */
+async function deployHttpApi(
+  simAws: SimAws,
+  template: CfnTemplateBodyRecord,
+): Promise<SimCfnStack> {
+  const stack = await simAws
+    .cloudFormation()
+    .deployTemplate({ stackName: "orders-stack", template });
+  await stack.waitForDeployComplete();
+
+  return stack;
+}
+
+/**
+ * Request a path of the API the stack deployed, through the endpoint the stack
+ * reported for it.
+ */
+async function requestApi(
+  simAws: SimAws,
+  stack: SimCfnStack,
+  path: string,
+): Promise<Response> {
+  const apiEndpoint = stack.outputs.get("ApiEndpoint")?.value;
+  assertTypeString(apiEndpoint);
+
+  return await new SimAwsHttp({ simAws }).fetch(
+    new SimAwsLocalUrl({ input: `${apiEndpoint}${path}` }).toString(),
+  );
+}
+
+describe("SAM Serverless HttpApi expansion", () => {
+  it("deploys a SAM HTTP API as an API and the stage that serves it", async () => {
+    // Given a SAM template declaring one HTTP API routing to a function
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await deployHttpApi(
+      simAws,
+      simCfnSamHttpApiTemplateFactory.make(),
+    );
+
+    // Then the SAM logical ID is a simulated HTTP API, with a stage of its own
+    const apiResource = stack.getResource(samHttpApiTemplateLogicalId);
+    assertNonNullable(apiResource);
+    assertIdentical(apiResource.type, "AWS::ApiGatewayV2::Api");
+
+    const stageResource = stack.getResource(samHttpApiTemplateStageLogicalId);
+    assertNonNullable(stageResource);
+    assertIdentical(stageResource.type, "AWS::ApiGatewayV2::Stage");
+    assertArrayLength(stack.skippedResources, 0);
+
+    // And the route the template declared against it is served from that stage
+    const response = await requestApi(simAws, stack, "/orders");
+
+    assertIdentical(response.status, 200);
+    assertIdentical(await response.text(), "GET /orders $default");
+  });
+
+  it("answers Ref and Fn::GetAtt against the SAM logical ID", async () => {
+    // Given a SAM template outputting what its API's logical ID resolves to
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await deployHttpApi(
+      simAws,
+      simCfnSamHttpApiTemplateFactory.make(),
+    );
+
+    // Then both answer for the API the SAM Resource was expanded into
+    const httpApi = stack.getResource(samHttpApiTemplateLogicalId)
+      ?.simResource as SimHttpApi;
+    assertNonNullable(httpApi);
+
+    assertIdentical(stack.outputs.get("ApiId")?.value, httpApi.apiId);
+    assertIdentical(
+      stack.outputs.get("ApiEndpoint")?.value,
+      `https://${httpApi.apiId}.execute-api.${simAws.defaultRegionName}.amazonaws.com`,
+    );
+
+    // And the API the routes named by ApiId is that one, since it served them
+    const response = await requestApi(simAws, stack, "/orders");
+    assertIdentical(response.status, 200);
+  });
+
+  it("imports the API from the OpenAPI document it declares", async () => {
+    // Given an API declaring its routes as a DefinitionBody rather than as
+    // Resources of their own
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await deployHttpApi(
+      simAws,
+      simCfnSamHttpApiTemplateFactory.make({
+        routeKey: undefined,
+        apiProperties: {
+          DefinitionBody: {
+            openapi: "3.0.1",
+            info: { title: "orders-api", version: "1.0" },
+            paths: {
+              "/orders/{orderId}": {
+                get: {
+                  "x-amazon-apigateway-integration": documentIntegration,
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    // Then the document's routes are the API's, and its title named the API
+    const response = await requestApi(simAws, stack, "/orders/YL-1");
+
+    assertIdentical(response.status, 200);
+    assertIdentical(await response.text(), "GET /orders/{orderId} $default");
+
+    const httpApi = stack.getResource(samHttpApiTemplateLogicalId)
+      ?.simResource as SimHttpApi;
+    assertNonNullable(httpApi);
+    assertIdentical(httpApi.name, "orders-api");
+  });
+
+  it("deploys the stage the API names, under the path it is served at", async () => {
+    // Given an API naming a stage rather than taking the default one
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await deployHttpApi(
+      simAws,
+      simCfnSamHttpApiTemplateFactory.make({
+        apiProperties: {
+          StageName: "prod",
+          StageVariables: { table: "orders-prod" },
+        },
+      }),
+    );
+
+    // Then the stage carries the name, and the variables the API stated
+    const stageResource = stack.getResource("OrdersprodStage");
+    assertNonNullable(stageResource);
+
+    const stage = stageResource.simResource as SimHttpApiStage;
+    assertIdentical(stage.stageName, "prod");
+    assertObjectEquals(stage.stageVariables, { table: "orders-prod" });
+
+    // And it serves the API's routes under its own path segment
+    const response = await requestApi(simAws, stack, "/prod/orders");
+
+    assertIdentical(response.status, 200);
+    assertIdentical(await response.text(), "GET /orders prod");
+  });
+
+  it("records an API declaring a DefinitionUri as unsupported", async () => {
+    // Given an API whose document is a file this reads nothing from
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await deployHttpApi(
+      simAws,
+      simCfnSamHttpApiTemplateFactory.make({
+        routeKey: undefined,
+        apiProperties: { DefinitionUri: "openapi/orders.yaml" },
+      }),
+    );
+
+    // Then the API is recorded the way any Resource type nothing models is,
+    // rather than deployed as an API serving nothing
+    assertArrayLength(stack.skippedResources, 1);
+    const skipped = stack.skippedResources[0];
+    assertNonNullable(skipped);
+    assertIdentical(skipped.logicalId, samHttpApiTemplateLogicalId);
+    assertIdentical(
+      skipped.skippedReason,
+      "Unsupported sim CloudFormation Resource service Serverless",
+    );
+  });
+
+  it("names the stage of an API whose stage name is no identifier", async () => {
+    // Given an API naming a stage a logical ID cannot be built out of, which
+    // SAM names by hashing it
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await deployHttpApi(
+      simAws,
+      simCfnSamHttpApiTemplateFactory.make({
+        apiProperties: { StageName: "orders-dev" },
+      }),
+    );
+
+    // Then the stage carries the plain suffix, and serves the API's routes
+    const stage = stack.getResource("OrdersStage")
+      ?.simResource as SimHttpApiStage;
+    assertNonNullable(stage);
+    assertIdentical(stage.stageName, "orders-dev");
+
+    const response = await requestApi(simAws, stack, "/orders-dev/orders");
+
+    assertIdentical(response.status, 200);
+    assertIdentical(await response.text(), "GET /orders orders-dev");
+  });
+
+  it("leaves out the stage of an API the template conditioned out", async () => {
+    // Given an API the template only deploys under a condition it fails
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Transform: "AWS::Serverless-2016-10-31",
+        Conditions: {
+          IsProduction: { "Fn::Equals": ["dev", "prod"] },
+        },
+        Resources: {
+          Orders: {
+            Type: "AWS::Serverless::HttpApi",
+            Condition: "IsProduction",
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then neither the API nor the stage it would have been served from was
+    // created
+    assertUndefined(stack.getResource(samHttpApiTemplateLogicalId));
+    assertUndefined(stack.getResource(samHttpApiTemplateStageLogicalId));
+  });
+});

--- a/src/service/cloudformation/sam/sim-cfn-sam-picked.ts
+++ b/src/service/cloudformation/sam/sim-cfn-sam-picked.ts
@@ -1,0 +1,17 @@
+import type { SimCfnTemplateValueRecord } from "../template/value/sim-cfn-template-value.js";
+
+/**
+ * The entries of a record whose keys are in the given set.
+ *
+ * Every SAM Resource type is expanded by naming the properties that mean the
+ * same thing on the Resource it becomes, and carrying those across. Each
+ * expansion states one set of names and reaches for this.
+ */
+export function samPickedProperties(
+  record: SimCfnTemplateValueRecord,
+  names: ReadonlySet<string>,
+): SimCfnTemplateValueRecord {
+  return Object.fromEntries(
+    Object.entries(record).filter(([name]) => names.has(name)),
+  );
+}

--- a/src/service/cloudformation/sam/sim-cfn-sam-simple-table.iso.test.ts
+++ b/src/service/cloudformation/sam/sim-cfn-sam-simple-table.iso.test.ts
@@ -19,6 +19,7 @@ import type { SimDynamoDbTableDescription } from "../../dynamodb/command/table/t
 import type { CfnTemplateBodyRecord } from "../template/sim-cfn-template.js";
 import type { SimCfnStack } from "../stack/sim-cfn-stack.js";
 import {
+  samSimpleTableTemplateLogicalId,
   samSimpleTableTemplateTableName,
   simCfnSamSimpleTableTemplateFactory,
 } from "./table/sim-cfn-sam-simple-table-template.factory.js";
@@ -282,5 +283,35 @@ describe("SAM Serverless SimpleTable expansion", () => {
     // And the failure is the one CreateTable gives, because the type was
     // carried across for CreateTable to answer for
     assertStringIncludes(error.message, "Text");
+  });
+
+  it("carries the point in time recovery the table asks for", async () => {
+    // Given a table asking for point in time recovery, which SAM passes to the
+    // DynamoDB table and this simulation has no answer for
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await deploySimpleTable(
+      simAws,
+      simCfnSamSimpleTableTemplateFactory.make({
+        tableProperties: {
+          PointInTimeRecoverySpecification: {
+            PointInTimeRecoveryEnabled: true,
+          },
+        },
+      }),
+    );
+
+    // Then the table was created, and the property it was created without is
+    // recorded against it under the DynamoDB Resource type
+    assertArrayLength(stack.ignoredProperties, 1);
+    const ignored = stack.ignoredProperties[0];
+    assertNonNullable(ignored);
+    assertIdentical(ignored.logicalId, samSimpleTableTemplateLogicalId);
+    assertStringIncludes(
+      ignored.reason,
+      "PointInTimeRecoverySpecification is a real AWS::DynamoDB::Table " +
+        "property that simulated DynamoDB does not simulate",
+    );
   });
 });

--- a/src/service/cloudformation/sam/sim-cfn-sam-simple-table.iso.test.ts
+++ b/src/service/cloudformation/sam/sim-cfn-sam-simple-table.iso.test.ts
@@ -1,0 +1,286 @@
+import {
+  DescribeTableCommand,
+  GetItemCommand,
+  ListTagsOfResourceCommand,
+  PutItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertObjectEquals,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimDynamoDbTableDescription } from "../../dynamodb/command/table/table.types.js";
+import type { CfnTemplateBodyRecord } from "../template/sim-cfn-template.js";
+import type { SimCfnStack } from "../stack/sim-cfn-stack.js";
+import {
+  samSimpleTableTemplateTableName,
+  simCfnSamSimpleTableTemplateFactory,
+} from "./table/sim-cfn-sam-simple-table-template.factory.js";
+
+/**
+ * Deploy a SAM template and wait for the table it holds to become ACTIVE, the
+ * way a table an SDK caller created becomes ACTIVE in the background.
+ */
+async function deploySimpleTable(
+  simAws: SimAws,
+  template: CfnTemplateBodyRecord,
+): Promise<SimCfnStack> {
+  const stack = await simAws
+    .cloudFormation()
+    .deployTemplate({ stackName: "rates-stack", template });
+  await stack.waitForDeployComplete();
+  await simAws.backgroundTasksComplete();
+
+  return stack;
+}
+
+/**
+ * The table the template deployed, described the way an SDK caller's table is,
+ * so a wrong value in the template is a wrong value here.
+ */
+async function describeTable(
+  simAws: SimAws,
+): Promise<SimDynamoDbTableDescription> {
+  const described = await simAws.dynamoDb().describeTable(
+    new DescribeTableCommand({
+      TableName: samSimpleTableTemplateTableName,
+    }),
+  );
+  assertNonNullable(described.Table);
+
+  return described.Table;
+}
+
+describe("SAM Serverless SimpleTable expansion", () => {
+  it("deploys a SAM simple table as a table keyed the way it named", async () => {
+    // Given a SAM template declaring one table with a primary key of its own
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await deploySimpleTable(
+      simAws,
+      simCfnSamSimpleTableTemplateFactory.make({
+        tableProperties: { PrimaryKey: { Name: "currency", Type: "String" } },
+      }),
+    );
+
+    // Then the SAM logical ID is a simulated DynamoDB table
+    const tableResource = stack.getResource("Rates");
+    assertNonNullable(tableResource);
+    assertIdentical(tableResource.type, "AWS::DynamoDB::Table");
+    assertArrayLength(stack.skippedResources, 0);
+
+    // And the key it named is the table's partition key, billed on demand
+    const table = await describeTable(simAws);
+
+    assertObjectEquals(table.KeySchema, [
+      { AttributeName: "currency", KeyType: "HASH" },
+    ]);
+    assertObjectEquals(table.AttributeDefinitions, [
+      { AttributeName: "currency", AttributeType: "S" },
+    ]);
+    assertIdentical(table.BillingModeSummary?.BillingMode, "PAY_PER_REQUEST");
+
+    // And the table holds the items written to the key it was given
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: samSimpleTableTemplateTableName,
+        Item: { currency: { S: "GBP" }, rate: { N: "1" } },
+      }),
+    );
+    const item = await simAws.dynamoDb().getItem(
+      new GetItemCommand({
+        TableName: samSimpleTableTemplateTableName,
+        Key: { currency: { S: "GBP" } },
+      }),
+    );
+
+    assertIdentical(item.Item?.["rate"]?.N, "1");
+  });
+
+  it("answers Ref and Fn::GetAtt against the SAM logical ID", async () => {
+    // Given a SAM template outputting what its table's logical ID resolves to
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await deploySimpleTable(
+      simAws,
+      simCfnSamSimpleTableTemplateFactory.make(),
+    );
+
+    // Then both answer for the table the SAM Resource was expanded into
+    assertIdentical(
+      stack.outputs.get("TableName")?.value,
+      samSimpleTableTemplateTableName,
+    );
+    assertIdentical(
+      stack.outputs.get("TableArn")?.value,
+      `arn:aws:dynamodb:${simAws.defaultRegionName}:` +
+        `${simAws.defaultAccountId}:table/${samSimpleTableTemplateTableName}`,
+    );
+  });
+
+  it("gives a table naming no key the one SAM gives it", async () => {
+    // Given a SAM table stating no primary key, which SAM keys on a string id
+    const simAws = new SimAws();
+
+    // When it is deployed
+    await deploySimpleTable(simAws, simCfnSamSimpleTableTemplateFactory.make());
+
+    // Then the table is keyed on that id
+    const table = await describeTable(simAws);
+
+    assertObjectEquals(table.KeySchema, [
+      { AttributeName: "id", KeyType: "HASH" },
+    ]);
+    assertObjectEquals(table.AttributeDefinitions, [
+      { AttributeName: "id", AttributeType: "S" },
+    ]);
+  });
+
+  it("keys a table on the number attribute type SAM names", async () => {
+    // Given a table keyed on a number, which SAM names differently from the
+    // way DynamoDB names it
+    const simAws = new SimAws();
+
+    // When it is deployed
+    await deploySimpleTable(
+      simAws,
+      simCfnSamSimpleTableTemplateFactory.make({
+        tableProperties: { PrimaryKey: { Name: "sequence", Type: "Number" } },
+      }),
+    );
+
+    // Then the attribute is defined as the type DynamoDB calls it
+    const table = await describeTable(simAws);
+
+    assertObjectEquals(table.AttributeDefinitions, [
+      { AttributeName: "sequence", AttributeType: "N" },
+    ]);
+  });
+
+  it("provisions the capacity a simple table asks for", async () => {
+    // Given a table asking for capacity rather than taking on-demand billing
+    const simAws = new SimAws();
+
+    // When it is deployed
+    await deploySimpleTable(
+      simAws,
+      simCfnSamSimpleTableTemplateFactory.make({
+        tableProperties: {
+          ProvisionedThroughput: {
+            ReadCapacityUnits: 5,
+            WriteCapacityUnits: 3,
+          },
+        },
+      }),
+    );
+
+    // Then the table is provisioned with it rather than billed on demand
+    const table = await describeTable(simAws);
+
+    const throughput = table.ProvisionedThroughput;
+    assertNonNullable(throughput);
+    assertIdentical(throughput.ReadCapacityUnits, 5);
+    assertIdentical(throughput.WriteCapacityUnits, 3);
+  });
+
+  it("tags the table with the tags SAM states as a map", async () => {
+    // Given a table tagged the way a SAM template tags one
+    const simAws = new SimAws();
+
+    // When it is deployed
+    await deploySimpleTable(
+      simAws,
+      simCfnSamSimpleTableTemplateFactory.make({
+        tableProperties: { Tags: { Environment: "test", Owner: "platform" } },
+      }),
+    );
+
+    // Then the tags are on the table an SDK caller reads
+    const table = await describeTable(simAws);
+    assertNonNullable(table.TableArn);
+
+    const tags = await simAws
+      .dynamoDb()
+      .listTagsOfResource(
+        new ListTagsOfResourceCommand({ ResourceArn: table.TableArn }),
+      );
+
+    assertArrayLength(tags.Tags, 2);
+    assertObjectEquals(tags.Tags[0], { Key: "Environment", Value: "test" });
+    assertObjectEquals(tags.Tags[1], { Key: "Owner", Value: "platform" });
+  });
+
+  it("keys a table on a string where the key names no type", async () => {
+    // Given a primary key naming an attribute and no type for it
+    const simAws = new SimAws();
+
+    // When it is deployed
+    await deploySimpleTable(
+      simAws,
+      simCfnSamSimpleTableTemplateFactory.make({
+        tableProperties: { PrimaryKey: { Name: "currency" } },
+      }),
+    );
+
+    // Then the attribute is defined as the string SAM defaults it to
+    const table = await describeTable(simAws);
+
+    assertObjectEquals(table.AttributeDefinitions, [
+      { AttributeName: "currency", AttributeType: "S" },
+    ]);
+  });
+
+  it("tags the table with the tags SAM states as a list", async () => {
+    // Given a table tagged the way a CloudFormation template tags one, which
+    // SAM carries through as it was written
+    const simAws = new SimAws();
+
+    // When it is deployed
+    await deploySimpleTable(
+      simAws,
+      simCfnSamSimpleTableTemplateFactory.make({
+        tableProperties: { Tags: [{ Key: "Environment", Value: "test" }] },
+      }),
+    );
+
+    // Then the tags are on the table an SDK caller reads
+    const table = await describeTable(simAws);
+    assertNonNullable(table.TableArn);
+
+    const tags = await simAws
+      .dynamoDb()
+      .listTagsOfResource(
+        new ListTagsOfResourceCommand({ ResourceArn: table.TableArn }),
+      );
+
+    assertArrayLength(tags.Tags, 1);
+    assertObjectEquals(tags.Tags[0], { Key: "Environment", Value: "test" });
+  });
+
+  it("refuses a key type CreateTable has no such attribute type for", async () => {
+    // Given a primary key naming a type neither SAM nor DynamoDB knows
+    const simAws = new SimAws();
+
+    // When it is deployed, then the deployment fails
+    const error = await assertThrowsErrorAsync(async () => {
+      return await deploySimpleTable(
+        simAws,
+        simCfnSamSimpleTableTemplateFactory.make({
+          tableProperties: { PrimaryKey: { Name: "currency", Type: "Text" } },
+        }),
+      );
+    });
+
+    // And the failure is the one CreateTable gives, because the type was
+    // carried across for CreateTable to answer for
+    assertStringIncludes(error.message, "Text");
+  });
+});

--- a/src/service/cloudformation/sam/sim-cfn-sam-transform.iso.test.ts
+++ b/src/service/cloudformation/sam/sim-cfn-sam-transform.iso.test.ts
@@ -63,28 +63,49 @@ describe("SAM transform", () => {
   });
 
   it("records a SAM Resource type it does not expand as unsupported", async () => {
-    // Given a SAM template holding a function and a table
+    // Given a SAM template holding a function and a state machine, which is a
+    // SAM Resource type with no simulated service behind it
     const simAws = new SimAws();
 
     // When it is deployed
     const stack = await simAws.cloudFormation().deployTemplate({
-      stackName: "simple-table-stack",
+      stackName: "state-machine-stack",
       template: {
         Transform: "AWS::Serverless-2016-10-31",
         Resources: {
           Rates: ratesFunction,
-          RatesTable: {
-            Type: "AWS::Serverless::SimpleTable",
-            Properties: { TableName: "rates" },
+          RatesWorkflow: {
+            Type: "AWS::Serverless::StateMachine",
+            Properties: { Definition: { StartAt: "Rates" } },
           },
         },
       },
     });
 
-    // Then the function deployed, and the table is recorded the way any
-    // Resource type nothing models is
+    // Then the function deployed, and the state machine is recorded the way
+    // any Resource type nothing models is
     assertNonNullable(simAws.lambda().getSimFunctionByName("rates"));
     assertArrayLength(stack.skippedResources, 1);
-    assertIdentical(stack.skippedResources[0].logicalId, "RatesTable");
+    assertIdentical(stack.skippedResources[0].logicalId, "RatesWorkflow");
+  });
+
+  it("leaves a Resource it cannot read for the template to answer for", async () => {
+    // Given a SAM template holding a Resource written as a string, which is a
+    // Resource the expansion has no Type to read
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "malformed-stack",
+      template: {
+        Transform: "AWS::Serverless-2016-10-31",
+        Resources: { Rates: ratesFunction, Quotes: "quotes" },
+      },
+    });
+
+    // Then the function deployed, and the malformed Resource was carried
+    // through the expansion for the template body to answer for
+    assertNonNullable(simAws.lambda().getSimFunctionByName("rates"));
+    assertArrayLength(stack.skippedResources, 0);
   });
 });

--- a/src/service/cloudformation/sam/table/sim-cfn-sam-simple-table-key.ts
+++ b/src/service/cloudformation/sam/table/sim-cfn-sam-simple-table-key.ts
@@ -1,0 +1,82 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../template/value/sim-cfn-template-value.js";
+import { isSamTemplateRecord } from "../sim-cfn-sam-record.js";
+
+/**
+ * The partition key a table is created with: the attribute definition DynamoDB
+ * takes, and the name its key schema names.
+ */
+export interface SamSimpleTableKey {
+  readonly definition: SimCfnTemplateValueRecord;
+  readonly name: SimCfnTemplateValue;
+}
+
+/**
+ * What SAM calls each attribute type, against what DynamoDB calls it.
+ *
+ * A `Type` outside this is carried across as the template wrote it.
+ * `CreateTable` is the one place that says which attribute types a table can
+ * have, and it refuses a type neither of them knows, by name.
+ */
+const attributeTypes = new Map([
+  ["Binary", "B"],
+  ["Number", "N"],
+  ["String", "S"],
+]);
+
+/**
+ * The name and type of the key a table naming none is given, which is the key
+ * SAM gives it.
+ */
+const defaultKeyName = "id";
+const defaultKeyType = "S";
+
+/**
+ * The attribute definition of the table's partition key.
+ *
+ * Both halves are carried across as the template wrote them, apart from the
+ * type name. A key an intrinsic function names is resolved the way the rest of
+ * the template is.
+ */
+export function samSimpleTablePrimaryKey(
+  tableProperties: SimCfnTemplateValueRecord,
+): SamSimpleTableKey {
+  const primaryKey = tableProperties["PrimaryKey"];
+
+  if (!isSamTemplateRecord(primaryKey)) {
+    return samKey(defaultKeyName, defaultKeyType);
+  }
+
+  return samKey(
+    primaryKey["Name"] ?? defaultKeyName,
+    samAttributeType(primaryKey["Type"]),
+  );
+}
+
+/**
+ * One partition key, as both halves of what the table is created from.
+ */
+function samKey(
+  name: SimCfnTemplateValue,
+  type: SimCfnTemplateValue,
+): SamSimpleTableKey {
+  return {
+    definition: { AttributeName: name, AttributeType: type },
+    name,
+  };
+}
+
+/**
+ * What DynamoDB calls the attribute type a key names.
+ */
+function samAttributeType(
+  type: SimCfnTemplateValue | undefined,
+): SimCfnTemplateValue {
+  if (typeof type !== "string") {
+    return type ?? defaultKeyType;
+  }
+
+  return attributeTypes.get(type) ?? type;
+}

--- a/src/service/cloudformation/sam/table/sim-cfn-sam-simple-table-template.factory.ts
+++ b/src/service/cloudformation/sam/table/sim-cfn-sam-simple-table-template.factory.ts
@@ -1,0 +1,69 @@
+import { MappedFactory } from "@kensio/part-factory";
+
+import type { CfnTemplateBodyRecord } from "../../template/sim-cfn-template.js";
+import type { SimCfnTemplateValueRecord } from "../../template/value/sim-cfn-template-value.js";
+import { samTransformName } from "../sim-cfn-sam-transform.js";
+import { samSimpleTableType } from "./sim-cfn-sam-simple-table.js";
+
+/**
+ * What a test asks for when it wants a SAM template holding one simple table.
+ */
+export interface SimCfnSamSimpleTableTemplateInput {
+  /**
+   * What this test is about, added to the properties of a table that already
+   * deploys.
+   */
+  readonly tableProperties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * The logical ID the table carries, and so the name the DynamoDB table is
+ * expanded under.
+ */
+export const samSimpleTableTemplateLogicalId = "Rates";
+
+/**
+ * The name the table is deployed under, which a test reads it back by.
+ */
+export const samSimpleTableTemplateTableName = "rates";
+
+/**
+ * Builds a SAM template holding one AWS::Serverless::SimpleTable.
+ *
+ * ```typescript
+ * const stack = await simAws.cloudFormation().deployTemplate({
+ *   stackName: "rates-stack",
+ *   template: simCfnSamSimpleTableTemplateFactory.make({
+ *     tableProperties: { PrimaryKey: { Name: "currency", Type: "String" } },
+ *   }),
+ * });
+ * ```
+ *
+ * The `Outputs` carry what `Ref` and `Fn::GetAtt` answer for the SAM logical
+ * ID, since what those answer is half of what expanding a Resource has to get
+ * right.
+ */
+export const simCfnSamSimpleTableTemplateFactory = new MappedFactory<
+  SimCfnSamSimpleTableTemplateInput,
+  CfnTemplateBodyRecord
+>(
+  () => ({ tableProperties: {} }),
+  (input) => ({
+    Transform: samTransformName,
+    Resources: {
+      [samSimpleTableTemplateLogicalId]: {
+        Type: samSimpleTableType,
+        Properties: {
+          TableName: samSimpleTableTemplateTableName,
+          ...input.tableProperties,
+        },
+      },
+    },
+    Outputs: {
+      TableName: { Value: { Ref: samSimpleTableTemplateLogicalId } },
+      TableArn: {
+        Value: { "Fn::GetAtt": [samSimpleTableTemplateLogicalId, "Arn"] },
+      },
+    },
+  }),
+);

--- a/src/service/cloudformation/sam/table/sim-cfn-sam-simple-table.ts
+++ b/src/service/cloudformation/sam/table/sim-cfn-sam-simple-table.ts
@@ -24,7 +24,11 @@ export const samSimpleTableType = "AWS::Serverless::SimpleTable";
  * The properties whose names and meanings are the same on both Resource types.
  * Expanding one of them is carrying it across.
  */
-const propertyNames = new Set(["SSESpecification", "TableName"]);
+const propertyNames = new Set([
+  "PointInTimeRecoverySpecification",
+  "SSESpecification",
+  "TableName",
+]);
 
 /**
  * Expand one AWS::Serverless::SimpleTable into the Resource CloudFormation

--- a/src/service/cloudformation/sam/table/sim-cfn-sam-simple-table.ts
+++ b/src/service/cloudformation/sam/table/sim-cfn-sam-simple-table.ts
@@ -1,0 +1,97 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../template/value/sim-cfn-template-value.js";
+import {
+  samCarriedAttributes,
+  samResourceProperties,
+} from "../function/sim-cfn-sam-function-properties.js";
+import { samPickedProperties } from "../sim-cfn-sam-picked.js";
+import { isSamTemplateRecord } from "../sim-cfn-sam-record.js";
+import { samSimpleTablePrimaryKey } from "./sim-cfn-sam-simple-table-key.js";
+
+interface SamSimpleTableExpansionProperties {
+  readonly logicalId: string;
+  readonly resource: SimCfnTemplateValueRecord;
+}
+
+/**
+ * The SAM Resource type this expansion covers.
+ */
+export const samSimpleTableType = "AWS::Serverless::SimpleTable";
+
+/**
+ * The properties whose names and meanings are the same on both Resource types.
+ * Expanding one of them is carrying it across.
+ */
+const propertyNames = new Set(["SSESpecification", "TableName"]);
+
+/**
+ * Expand one AWS::Serverless::SimpleTable into the Resource CloudFormation
+ * deploys for it.
+ *
+ * The table keeps the logical ID the template gave the SAM Resource. `Ref`
+ * and `Fn::GetAtt` against that name answer what they answer for the table.
+ *
+ * A simple table has one partition key and no sort key. That is the whole of
+ * what makes it simple. The key it names becomes both the key schema and the
+ * one attribute definition, and a table naming no key gets the `id` string key
+ * SAM gives one. Billing is on demand until the table asks for capacity, the
+ * way SAM bills one.
+ */
+export function samSimpleTableResources(
+  properties: SamSimpleTableExpansionProperties,
+): Record<string, SimCfnTemplateValue> {
+  const { logicalId, resource } = properties;
+  const tableProperties = samResourceProperties(resource);
+  const primaryKey = samSimpleTablePrimaryKey(tableProperties);
+
+  return {
+    [logicalId]: {
+      Type: "AWS::DynamoDB::Table",
+      ...samCarriedAttributes(resource),
+      Properties: {
+        ...samPickedProperties(tableProperties, propertyNames),
+        AttributeDefinitions: [primaryKey.definition],
+        KeySchema: [{ AttributeName: primaryKey.name, KeyType: "HASH" }],
+        ...samSimpleTableBilling(tableProperties["ProvisionedThroughput"]),
+        ...samSimpleTableTags(tableProperties["Tags"]),
+      },
+    },
+  };
+}
+
+/**
+ * How the table is billed. A simple table asking for no capacity is billed on
+ * demand, and one asking for capacity is billed for the capacity it asked for.
+ */
+function samSimpleTableBilling(
+  throughput: SimCfnTemplateValue | undefined,
+): SimCfnTemplateValueRecord {
+  return throughput === undefined
+    ? { BillingMode: "PAY_PER_REQUEST" }
+    : { ProvisionedThroughput: throughput };
+}
+
+/**
+ * The tags the table carries.
+ *
+ * SAM states them as a map of one value per tag name. A DynamoDB table takes
+ * the list of `Key` and `Value` pairs every taggable Resource takes, and the
+ * map is turned into that list here. A template already writing the list keeps
+ * it.
+ */
+function samSimpleTableTags(
+  tags: SimCfnTemplateValue | undefined,
+): SimCfnTemplateValueRecord {
+  if (!isSamTemplateRecord(tags)) {
+    return tags === undefined ? {} : { Tags: tags };
+  }
+
+  return {
+    Tags: Object.entries(tags).map(([name, value]) => ({
+      Key: name,
+      Value: value,
+    })),
+  };
+}


### PR DESCRIPTION
`AWS::Serverless::SimpleTable` now expands into an `AWS::DynamoDB::Table` keyed on its `PrimaryKey` and billed on demand, and `AWS::Serverless::HttpApi` into an `AWS::ApiGatewayV2::Api` and the stage that serves it, with a `DefinitionBody` reaching the API as its OpenAPI `Body`. Both keep the SAM logical ID, and `Ref` and `Fn::GetAtt` against that name answer for the expanded Resource. `Globals.HttpApi` supplies defaults the way `Globals.Function` already does, and a value on the resource itself wins. An API naming a `DefinitionUri` stays recorded as unsupported, because nothing here reads a document off disk or out of S3.

Resolves #752

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for expanding `AWS::Serverless::HttpApi` resources into deployable API Gateway resources, including stages, routes, OpenAPI definitions, conditions, and stage variables.
  - Added support for expanding `AWS::Serverless::SimpleTable` resources into DynamoDB tables with partition keys, billing options, throughput, and tags.
  - Added support for `Globals.HttpApi` defaults, with resource-level settings taking precedence.

- **Documentation**
  - Expanded SAM documentation with supported properties, defaults, limitations, and deployment examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->