### PR TITLE
feat: deliver to a Lambda version or alias

### DIFF
--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -1970,6 +1970,100 @@ The function is a simulated Lambda function anywhere in the simulation, and it h
 `cognito-idp.amazonaws.com` for the pool. `AddPermission` grants that, and CDK's `addTrigger` emits
 an `AWS::Lambda::Permission` for it.
 
+A `LambdaConfig` ARN can carry a version number or an alias name on the end, and the trigger runs the
+version that qualifier names. The permission is made on the same qualifier:
+
+```typescript sim-cognito-trigger-alias
+/**
+ * A user pool whose PreSignUp trigger names a Lambda alias, so sign-ups run the
+ * version the alias points at.
+ */
+
+import {
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  SignUpCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  AddPermissionCommand,
+  CreateAliasCommand,
+  CreateFunctionCommand,
+  PublishVersionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+const cognito = simAws.cognitoIdentityProvider();
+const triggerArn = `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:auth-trigger`;
+
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "auth-trigger",
+    Role: `arn:aws:iam::${simAws.defaultAccountId}:role/TriggerRole`,
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event, context) => {
+        console.log(context.functionVersion); // "1", the version behind `live`
+
+        // A trigger hands the event back, changed or not.
+        return event;
+      }),
+    },
+  }),
+);
+
+const published = await lambda.publishVersion(
+  new PublishVersionCommand({ FunctionName: "auth-trigger" }),
+);
+
+await lambda.createAlias(
+  new CreateAliasCommand({
+    FunctionName: "auth-trigger",
+    Name: "live",
+    FunctionVersion: published.Version,
+  }),
+);
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({
+    PoolName: "myapp-users",
+    LambdaConfig: { PreSignUp: `${triggerArn}:live` },
+  }),
+);
+
+await lambda.addPermission(
+  new AddPermissionCommand({
+    FunctionName: "auth-trigger",
+    Qualifier: "live",
+    StatementId: "AllowCognito",
+    Action: "lambda:InvokeFunction",
+    Principal: "cognito-idp.amazonaws.com",
+    SourceArn: pool.UserPool!.Arn!,
+  }),
+);
+
+const client = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: pool.UserPool!.Id!,
+    ClientName: "web",
+  }),
+);
+
+await cognito.signUp(
+  new SignUpCommand({
+    ClientId: client.UserPoolClient!.ClientId!,
+    Username: "alice",
+    Password: "Sup3rSecret!",
+  }),
+);
+```
+
+The qualifier is resolved when the trigger fires, the same way the function itself is, so the pool
+can be created before either exists. One naming no version and no alias refuses the sign-in with
+`UnexpectedLambdaException`, and the message says what it reached for.
+
 ### Sign-up triggers
 
 `PreSignUp` runs before the pool takes the new user. A handler that throws refuses the sign-up with

--- a/docs/services/cognito/sim-cognito-trigger-alias.example.ts
+++ b/docs/services/cognito/sim-cognito-trigger-alias.example.ts
@@ -1,0 +1,84 @@
+/**
+ * A user pool whose PreSignUp trigger names a Lambda alias, so sign-ups run the
+ * version the alias points at.
+ */
+
+import {
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  SignUpCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  AddPermissionCommand,
+  CreateAliasCommand,
+  CreateFunctionCommand,
+  PublishVersionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+const cognito = simAws.cognitoIdentityProvider();
+const triggerArn = `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:auth-trigger`;
+
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "auth-trigger",
+    Role: `arn:aws:iam::${simAws.defaultAccountId}:role/TriggerRole`,
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event, context) => {
+        console.log(context.functionVersion); // "1", the version behind `live`
+
+        // A trigger hands the event back, changed or not.
+        return event;
+      }),
+    },
+  }),
+);
+
+const published = await lambda.publishVersion(
+  new PublishVersionCommand({ FunctionName: "auth-trigger" }),
+);
+
+await lambda.createAlias(
+  new CreateAliasCommand({
+    FunctionName: "auth-trigger",
+    Name: "live",
+    FunctionVersion: published.Version,
+  }),
+);
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({
+    PoolName: "myapp-users",
+    LambdaConfig: { PreSignUp: `${triggerArn}:live` },
+  }),
+);
+
+await lambda.addPermission(
+  new AddPermissionCommand({
+    FunctionName: "auth-trigger",
+    Qualifier: "live",
+    StatementId: "AllowCognito",
+    Action: "lambda:InvokeFunction",
+    Principal: "cognito-idp.amazonaws.com",
+    SourceArn: pool.UserPool!.Arn!,
+  }),
+);
+
+const client = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: pool.UserPool!.Id!,
+    ClientName: "web",
+  }),
+);
+
+await cognito.signUp(
+  new SignUpCommand({
+    ClientId: client.UserPoolClient!.ClientId!,
+    Username: "alice",
+    Password: "Sup3rSecret!",
+  }),
+);

--- a/docs/services/eventbridge/README.md
+++ b/docs/services/eventbridge/README.md
@@ -471,6 +471,103 @@ console.log(JSON.stringify(queuePolicy).length > 0); // true
 
 An event delivered across accounts still names the account it was put in, and never the target's.
 
+## Sending to a Lambda version or alias
+
+A function target ARN can carry a version number or an alias name on the end, and matched events go
+to the version that qualifier names. The grant is made on the same qualifier:
+
+```typescript sim-event-bridge-lambda-alias
+/**
+ * A rule sending order events to a Lambda alias, which runs the version it
+ * points at.
+ */
+
+import {
+  PutEventsCommand,
+  PutRuleCommand,
+  PutTargetsCommand,
+} from "@aws-sdk/client-eventbridge";
+import {
+  AddPermissionCommand,
+  CreateAliasCommand,
+  CreateFunctionCommand,
+  PublishVersionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+const functionArn = `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:fulfilment`;
+
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "fulfilment",
+    Role: `arn:aws:iam::${simAws.defaultAccountId}:role/FulfilmentRole`,
+    Code: {
+      ZipFile: makeLambdaZipFileInput((_event, context) => {
+        console.log(context.functionVersion); // "1", the version behind `live`
+
+        return "fulfilled";
+      }),
+    },
+  }),
+);
+
+const published = await lambda.publishVersion(
+  new PublishVersionCommand({ FunctionName: "fulfilment" }),
+);
+
+await lambda.createAlias(
+  new CreateAliasCommand({
+    FunctionName: "fulfilment",
+    Name: "live",
+    FunctionVersion: published.Version,
+  }),
+);
+
+// The grant is made on the alias, which is the resource the target names.
+await lambda.addPermission(
+  new AddPermissionCommand({
+    FunctionName: "fulfilment",
+    Qualifier: "live",
+    StatementId: "AllowEvents",
+    Action: "lambda:InvokeFunction",
+    Principal: "events.amazonaws.com",
+  }),
+);
+
+await simAws.eventBridge().putRule(
+  new PutRuleCommand({
+    Name: "orders",
+    EventPattern: JSON.stringify({ source: ["orders.service"] }),
+  }),
+);
+
+await simAws.eventBridge().putTargets(
+  new PutTargetsCommand({
+    Rule: "orders",
+    Targets: [{ Id: "fulfilment", Arn: `${functionArn}:live` }],
+  }),
+);
+
+await simAws.eventBridge().putEvents(
+  new PutEventsCommand({
+    Entries: [
+      { Source: "orders.service", DetailType: "OrderPlaced", Detail: "{}" },
+    ],
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+```
+
+The qualifier is resolved on every delivery, so `UpdateAlias` moves what the rule reaches and the
+target stays as it is. A target naming no version and no alias is recorded on
+`simAws.eventBridge().deliveryFailures`, the way a missing function is. See
+[reading back a failed delivery](#reading-back-a-failed-delivery).
+
 ## Running an ECS task
 
 A target whose ARN names an ECS cluster runs a [simulated ECS](../ecs/) task instead of receiving

--- a/docs/services/eventbridge/sim-event-bridge-lambda-alias.example.ts
+++ b/docs/services/eventbridge/sim-event-bridge-lambda-alias.example.ts
@@ -1,0 +1,84 @@
+/**
+ * A rule sending order events to a Lambda alias, which runs the version it
+ * points at.
+ */
+
+import {
+  PutEventsCommand,
+  PutRuleCommand,
+  PutTargetsCommand,
+} from "@aws-sdk/client-eventbridge";
+import {
+  AddPermissionCommand,
+  CreateAliasCommand,
+  CreateFunctionCommand,
+  PublishVersionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+const functionArn = `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:fulfilment`;
+
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "fulfilment",
+    Role: `arn:aws:iam::${simAws.defaultAccountId}:role/FulfilmentRole`,
+    Code: {
+      ZipFile: makeLambdaZipFileInput((_event, context) => {
+        console.log(context.functionVersion); // "1", the version behind `live`
+
+        return "fulfilled";
+      }),
+    },
+  }),
+);
+
+const published = await lambda.publishVersion(
+  new PublishVersionCommand({ FunctionName: "fulfilment" }),
+);
+
+await lambda.createAlias(
+  new CreateAliasCommand({
+    FunctionName: "fulfilment",
+    Name: "live",
+    FunctionVersion: published.Version,
+  }),
+);
+
+// The grant is made on the alias, which is the resource the target names.
+await lambda.addPermission(
+  new AddPermissionCommand({
+    FunctionName: "fulfilment",
+    Qualifier: "live",
+    StatementId: "AllowEvents",
+    Action: "lambda:InvokeFunction",
+    Principal: "events.amazonaws.com",
+  }),
+);
+
+await simAws.eventBridge().putRule(
+  new PutRuleCommand({
+    Name: "orders",
+    EventPattern: JSON.stringify({ source: ["orders.service"] }),
+  }),
+);
+
+await simAws.eventBridge().putTargets(
+  new PutTargetsCommand({
+    Rule: "orders",
+    Targets: [{ Id: "fulfilment", Arn: `${functionArn}:live` }],
+  }),
+);
+
+await simAws.eventBridge().putEvents(
+  new PutEventsCommand({
+    Entries: [
+      { Source: "orders.service", DetailType: "OrderPlaced", Detail: "{}" },
+    ],
+  }),
+);
+
+await simAws.backgroundTasksComplete();

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -942,6 +942,117 @@ function's execution role has to be allowed `sqs:ReceiveMessage`, `sqs:DeleteMes
 returns and `Enabled` once the simulation has caught up, as on real Lambda. Deleting it stops the
 polling.
 
+### Mapping onto a version or an alias
+
+A `FunctionName` can carry a version number or an alias name on the end, or be a qualified function
+ARN, and batches then go to the version that qualifier names. `FunctionArn` on the mapping is the
+alias, and the version behind it is what runs:
+
+```typescript sim-lambda-event-source-alias
+/**
+ * An event source mapping onto an alias, polling for the version it points at.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateAliasCommand,
+  CreateEventSourceMappingCommand,
+  CreateFunctionCommand,
+  PublishVersionCommand,
+} from "@aws-sdk/client-lambda";
+import { CreateQueueCommand, SendMessageCommand } from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:orders`;
+
+const { QueueUrl } = await simAws
+  .sqs()
+  .createQueue(new CreateQueueCommand({ QueueName: "orders" }));
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "OrderConsumerRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "OrderConsumerRole",
+    PolicyName: "ConsumeOrders",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: [
+          "sqs:ReceiveMessage",
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes",
+        ],
+        Resource: queueArn,
+      },
+    }),
+  }),
+);
+
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "order-consumer",
+    Role: role.Role.Arn,
+    Code: {
+      ZipFile: makeLambdaZipFileInput((_event, context) => {
+        console.log(context.functionVersion); // "1", the version behind `live`
+
+        return "handled";
+      }),
+    },
+  }),
+);
+
+const published = await lambda.publishVersion(
+  new PublishVersionCommand({ FunctionName: "order-consumer" }),
+);
+
+await lambda.createAlias(
+  new CreateAliasCommand({
+    FunctionName: "order-consumer",
+    Name: "live",
+    FunctionVersion: published.Version,
+  }),
+);
+
+const mapping = await lambda.createEventSourceMapping(
+  new CreateEventSourceMappingCommand({
+    EventSourceArn: queueArn,
+    FunctionName: "order-consumer:live",
+  }),
+);
+
+console.log(mapping.FunctionArn); // ...:function:order-consumer:live
+
+await simAws
+  .sqs()
+  .sendMessage(new SendMessageCommand({ QueueUrl, MessageBody: "order-1" }));
+await simAws.backgroundTasksComplete();
+```
+
+The qualifier is resolved on every poll, so `UpdateAlias` moves what an existing mapping delivers to.
+The version has to be there when the mapping is made. A qualifier naming none fails with
+`ResourceNotFoundException`, the way a function that is not there does. Polling still runs as the
+function's execution role, which a published version carries over from the function it was published
+from.
+
 ### When the handler fails
 
 A handler that returns normally has handled the batch, and the messages are deleted from the queue.
@@ -2679,9 +2790,9 @@ Current documented limitations:
   `PublishVersion` makes are left out, along with `Description` on a published version, alias
   `RoutingConfig` weights, provisioned concurrency, and the `Marker`/`MaxItems` paging on the two
   listings.
-- A qualified function ARN reaches simulated Lambda itself. The services that name a function
-  elsewhere (S3 notifications, SNS subscriptions, CloudWatch Logs subscriptions, Cognito triggers,
-  EventBridge targets, event source mappings and the CloudFormation target-function reader) still
+- A qualified function ARN reaches a function through S3 notifications, SNS subscriptions,
+  CloudWatch Logs subscriptions, Cognito triggers, EventBridge targets and event source mappings.
+  API Gateway integration and authorizer URIs and the CloudFormation target-function reader still
   refuse or drop a qualifier.
 - The vm runtime supports CommonJS function code only. ES module source (`.mjs` / `export` syntax)
   has yet to land.

--- a/docs/services/lambda/sim-lambda-event-source-alias.example.ts
+++ b/docs/services/lambda/sim-lambda-event-source-alias.example.ts
@@ -1,0 +1,96 @@
+/**
+ * An event source mapping onto an alias, polling for the version it points at.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateAliasCommand,
+  CreateEventSourceMappingCommand,
+  CreateFunctionCommand,
+  PublishVersionCommand,
+} from "@aws-sdk/client-lambda";
+import { CreateQueueCommand, SendMessageCommand } from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:orders`;
+
+const { QueueUrl } = await simAws
+  .sqs()
+  .createQueue(new CreateQueueCommand({ QueueName: "orders" }));
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "OrderConsumerRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "OrderConsumerRole",
+    PolicyName: "ConsumeOrders",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: [
+          "sqs:ReceiveMessage",
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes",
+        ],
+        Resource: queueArn,
+      },
+    }),
+  }),
+);
+
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "order-consumer",
+    Role: role.Role.Arn,
+    Code: {
+      ZipFile: makeLambdaZipFileInput((_event, context) => {
+        console.log(context.functionVersion); // "1", the version behind `live`
+
+        return "handled";
+      }),
+    },
+  }),
+);
+
+const published = await lambda.publishVersion(
+  new PublishVersionCommand({ FunctionName: "order-consumer" }),
+);
+
+await lambda.createAlias(
+  new CreateAliasCommand({
+    FunctionName: "order-consumer",
+    Name: "live",
+    FunctionVersion: published.Version,
+  }),
+);
+
+const mapping = await lambda.createEventSourceMapping(
+  new CreateEventSourceMappingCommand({
+    EventSourceArn: queueArn,
+    FunctionName: "order-consumer:live",
+  }),
+);
+
+console.log(mapping.FunctionArn); // ...:function:order-consumer:live
+
+await simAws
+  .sqs()
+  .sendMessage(new SendMessageCommand({ QueueUrl, MessageBody: "order-1" }));
+await simAws.backgroundTasksComplete();

--- a/docs/services/logs/README.md
+++ b/docs/services/logs/README.md
@@ -422,7 +422,106 @@ The behaviour in detail:
   picks up what that function wrote. A forwarder can be tested against a real handler's output.
 - **Lambda is the only destination.** Kinesis, Firehose and cross-account destinations are refused
   outright.
+- **A destination can name a version or an alias.** See
+  [Subscribing a Lambda alias](#subscribing-a-lambda-alias).
 - **Two filters per log group**, the current AWS account default.
+
+### Subscribing a Lambda alias
+
+A `destinationArn` can carry a version number or an alias name on the end, and matched events go to
+the version that qualifier names. The grant is made on the same qualifier:
+
+```typescript sim-logs-subscription-alias
+/**
+ * Delivering matched log events to a simulated Lambda alias.
+ */
+
+import {
+  CreateLogGroupCommand,
+  CreateLogStreamCommand,
+  PutLogEventsCommand,
+  PutSubscriptionFilterCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+  AddPermissionCommand,
+  CreateAliasCommand,
+  CreateFunctionCommand,
+  PublishVersionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+const logGroupName = "/aws/lambda/orders";
+const logStreamName = "2026/08/19/[$LATEST]0f7c1a";
+const trackerArn = `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:error-tracker`;
+
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "error-tracker",
+    Role: `arn:aws:iam::${simAws.defaultAccountId}:role/TrackerRole`,
+    Code: {
+      ZipFile: makeLambdaZipFileInput((_event, context) => {
+        console.log(context.functionVersion); // "1", the version behind `live`
+
+        return "recorded";
+      }),
+    },
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+const published = await lambda.publishVersion(
+  new PublishVersionCommand({ FunctionName: "error-tracker" }),
+);
+
+await lambda.createAlias(
+  new CreateAliasCommand({
+    FunctionName: "error-tracker",
+    Name: "live",
+    FunctionVersion: published.Version,
+  }),
+);
+
+await lambda.addPermission(
+  new AddPermissionCommand({
+    FunctionName: "error-tracker",
+    Qualifier: "live",
+    StatementId: "logs",
+    Action: "lambda:InvokeFunction",
+    Principal: `logs.${simAws.defaultRegionName}.amazonaws.com`,
+  }),
+);
+
+await simAws.logs().createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+await simAws
+  .logs()
+  .createLogStream(new CreateLogStreamCommand({ logGroupName, logStreamName }));
+
+await simAws.logs().putSubscriptionFilter(
+  new PutSubscriptionFilterCommand({
+    logGroupName,
+    filterName: "errors-to-tracker",
+    filterPattern: "ERROR",
+    destinationArn: `${trackerArn}:live`,
+  }),
+);
+
+await simAws.logs().putLogEvents(
+  new PutLogEventsCommand({
+    logGroupName,
+    logStreamName,
+    logEvents: [{ timestamp: 1000, message: "ERROR order has no items" }],
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+```
+
+A qualifier naming no version and no alias is refused where the filter is put, the way a missing
+function is. `UpdateAlias` moves what the filter reaches, and the filter stays as it is.
 
 ## Permissions
 

--- a/docs/services/logs/sim-logs-subscription-alias.example.ts
+++ b/docs/services/logs/sim-logs-subscription-alias.example.ts
@@ -1,0 +1,86 @@
+/**
+ * Delivering matched log events to a simulated Lambda alias.
+ */
+
+import {
+  CreateLogGroupCommand,
+  CreateLogStreamCommand,
+  PutLogEventsCommand,
+  PutSubscriptionFilterCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+  AddPermissionCommand,
+  CreateAliasCommand,
+  CreateFunctionCommand,
+  PublishVersionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+const logGroupName = "/aws/lambda/orders";
+const logStreamName = "2026/08/19/[$LATEST]0f7c1a";
+const trackerArn = `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:error-tracker`;
+
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "error-tracker",
+    Role: `arn:aws:iam::${simAws.defaultAccountId}:role/TrackerRole`,
+    Code: {
+      ZipFile: makeLambdaZipFileInput((_event, context) => {
+        console.log(context.functionVersion); // "1", the version behind `live`
+
+        return "recorded";
+      }),
+    },
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+const published = await lambda.publishVersion(
+  new PublishVersionCommand({ FunctionName: "error-tracker" }),
+);
+
+await lambda.createAlias(
+  new CreateAliasCommand({
+    FunctionName: "error-tracker",
+    Name: "live",
+    FunctionVersion: published.Version,
+  }),
+);
+
+await lambda.addPermission(
+  new AddPermissionCommand({
+    FunctionName: "error-tracker",
+    Qualifier: "live",
+    StatementId: "logs",
+    Action: "lambda:InvokeFunction",
+    Principal: `logs.${simAws.defaultRegionName}.amazonaws.com`,
+  }),
+);
+
+await simAws.logs().createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+await simAws
+  .logs()
+  .createLogStream(new CreateLogStreamCommand({ logGroupName, logStreamName }));
+
+await simAws.logs().putSubscriptionFilter(
+  new PutSubscriptionFilterCommand({
+    logGroupName,
+    filterName: "errors-to-tracker",
+    filterPattern: "ERROR",
+    destinationArn: `${trackerArn}:live`,
+  }),
+);
+
+await simAws.logs().putLogEvents(
+  new PutLogEventsCommand({
+    logGroupName,
+    logStreamName,
+    logEvents: [{ timestamp: 1000, message: "ERROR order has no items" }],
+  }),
+);
+
+await simAws.backgroundTasksComplete();

--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -814,6 +814,103 @@ const configurations = read.LambdaFunctionConfigurations ?? [];
 The two commands are authorized as `s3:PutBucketNotification` and `s3:GetBucketNotification`. Those
 are the real IAM action names, and they do not match the API names.
 
+### To a Lambda version or alias
+
+A `LambdaFunctionArn` can carry a version number or an alias name on the end, and the events go to
+the version that qualifier names. The permission it needs is one made on the same qualifier, which
+`AddPermission` takes as a `Qualifier`:
+
+```typescript sim-s3-notification-lambda-alias
+/**
+ * Notifying a simulated Lambda alias, which runs the version it points at.
+ */
+
+import {
+  AddPermissionCommand,
+  CreateAliasCommand,
+  CreateFunctionCommand,
+  PublishVersionCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  CreateBucketCommand,
+  PutBucketNotificationConfigurationCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+const thumbnailerArn = `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:thumbnailer`;
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "thumbnailer",
+    Role: `arn:aws:iam::${simAws.defaultAccountId}:role/ThumbnailerRole`,
+    Code: {
+      ZipFile: makeLambdaZipFileInput((_event, context) => {
+        console.log(context.functionVersion); // "1", the version behind `live`
+
+        return "thumbnailed";
+      }),
+    },
+  }),
+);
+
+const published = await lambda.publishVersion(
+  new PublishVersionCommand({ FunctionName: "thumbnailer" }),
+);
+
+await lambda.createAlias(
+  new CreateAliasCommand({
+    FunctionName: "thumbnailer",
+    Name: "live",
+    FunctionVersion: published.Version,
+  }),
+);
+
+// The grant is made on the alias, which is the resource the notification names.
+await lambda.addPermission(
+  new AddPermissionCommand({
+    FunctionName: "thumbnailer",
+    Qualifier: "live",
+    StatementId: "AllowS3",
+    Action: "lambda:InvokeFunction",
+    Principal: "s3.amazonaws.com",
+    SourceArn: "arn:aws:s3:::uploads",
+    SourceAccount: simAws.defaultAccountId,
+  }),
+);
+
+await simAws.s3().putBucketNotificationConfiguration(
+  new PutBucketNotificationConfigurationCommand({
+    Bucket: "uploads",
+    NotificationConfiguration: {
+      LambdaFunctionConfigurations: [
+        {
+          Id: "thumbnail-uploads",
+          Events: ["s3:ObjectCreated:*"],
+          LambdaFunctionArn: `${thumbnailerArn}:live`,
+        },
+      ],
+    },
+  }),
+);
+
+await simAws
+  .s3()
+  .putObject(
+    new PutObjectCommand({ Bucket: "uploads", Key: "cat.jpg", Body: "cat" }),
+  );
+await simAws.backgroundTasksComplete();
+```
+
+`UpdateAlias` moves what the notification reaches, and the configuration stays as it is. A qualifier
+naming no version and no alias is refused where the configuration is applied, the way a missing
+function is.
+
 ### To an SQS queue
 
 A `QueueConfigurations` entry names a queue by ARN. The whole `Records` document arrives as one

--- a/docs/services/s3/sim-s3-notification-lambda-alias.example.ts
+++ b/docs/services/s3/sim-s3-notification-lambda-alias.example.ts
@@ -1,0 +1,84 @@
+/**
+ * Notifying a simulated Lambda alias, which runs the version it points at.
+ */
+
+import {
+  AddPermissionCommand,
+  CreateAliasCommand,
+  CreateFunctionCommand,
+  PublishVersionCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  CreateBucketCommand,
+  PutBucketNotificationConfigurationCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+const thumbnailerArn = `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:thumbnailer`;
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "thumbnailer",
+    Role: `arn:aws:iam::${simAws.defaultAccountId}:role/ThumbnailerRole`,
+    Code: {
+      ZipFile: makeLambdaZipFileInput((_event, context) => {
+        console.log(context.functionVersion); // "1", the version behind `live`
+
+        return "thumbnailed";
+      }),
+    },
+  }),
+);
+
+const published = await lambda.publishVersion(
+  new PublishVersionCommand({ FunctionName: "thumbnailer" }),
+);
+
+await lambda.createAlias(
+  new CreateAliasCommand({
+    FunctionName: "thumbnailer",
+    Name: "live",
+    FunctionVersion: published.Version,
+  }),
+);
+
+// The grant is made on the alias, which is the resource the notification names.
+await lambda.addPermission(
+  new AddPermissionCommand({
+    FunctionName: "thumbnailer",
+    Qualifier: "live",
+    StatementId: "AllowS3",
+    Action: "lambda:InvokeFunction",
+    Principal: "s3.amazonaws.com",
+    SourceArn: "arn:aws:s3:::uploads",
+    SourceAccount: simAws.defaultAccountId,
+  }),
+);
+
+await simAws.s3().putBucketNotificationConfiguration(
+  new PutBucketNotificationConfigurationCommand({
+    Bucket: "uploads",
+    NotificationConfiguration: {
+      LambdaFunctionConfigurations: [
+        {
+          Id: "thumbnail-uploads",
+          Events: ["s3:ObjectCreated:*"],
+          LambdaFunctionArn: `${thumbnailerArn}:live`,
+        },
+      ],
+    },
+  }),
+);
+
+await simAws
+  .s3()
+  .putObject(
+    new PutObjectCommand({ Bucket: "uploads", Key: "cat.jpg", Body: "cat" }),
+  );
+await simAws.backgroundTasksComplete();

--- a/docs/services/sns/README.md
+++ b/docs/services/sns/README.md
@@ -371,9 +371,9 @@ by it.
 
 The endpoint has to be what the protocol implies, and it is checked when the subscription is made. A
 queue ARN over the `lambda` protocol is refused, as it is on real SNS, and so is an `sms` endpoint
-outside E.164. A qualified function ARN naming a version or an alias is refused too, since simulated
-Lambda has no versions or aliases. Subscribing `$LATEST` in its place would be a different function
-from the one asked for.
+outside E.164. A function ARN may carry a version number or an alias name on the end
+(`arn:aws:lambda:us-east-1:888888888888:function:orders:live`), and messages then go to the version
+that qualifier names.
 
 Subscribing the same endpoint to the same topic twice answers with the subscription that is already
 there, as real SNS does. The attributes the repeated request carries are ignored, the same way a
@@ -633,6 +633,95 @@ there too. Delivery to the topic's other subscriptions carries on.
 
 A function in another account or another region is invoked the same way, on that account's own
 resource policy.
+
+An endpoint carrying a version number or an alias name delivers to the version it names, and the
+grant it needs is one made on that same qualifier. `AddPermission` takes a `Qualifier` for it. The
+version behind an alias runs, and `UpdateAlias` moves what an existing subscription reaches without
+touching the subscription:
+
+```typescript sim-sns-lambda-alias
+/**
+ * Subscribing a simulated Lambda alias to a topic, so published messages reach
+ * the version the alias points at.
+ */
+
+import {
+  AddPermissionCommand,
+  CreateAliasCommand,
+  CreateFunctionCommand,
+  PublishVersionCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  CreateTopicCommand,
+  PublishCommand,
+  SubscribeCommand,
+} from "@aws-sdk/client-sns";
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const sns = simAws.sns();
+const lambda = simAws.lambda();
+const functionArn = `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:order-consumer`;
+
+const { TopicArn } = await sns.createTopic(
+  new CreateTopicCommand({ Name: "orders" }),
+);
+
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "order-consumer",
+    Role: `arn:aws:iam::${simAws.defaultAccountId}:role/OrderConsumerRole`,
+    Code: {
+      ZipFile: makeLambdaZipFileInput((_event, context) => {
+        console.log(context.functionVersion); // "1", the version behind `live`
+
+        return "handled";
+      }),
+    },
+  }),
+);
+
+const published = await lambda.publishVersion(
+  new PublishVersionCommand({ FunctionName: "order-consumer" }),
+);
+
+await lambda.createAlias(
+  new CreateAliasCommand({
+    FunctionName: "order-consumer",
+    Name: "live",
+    FunctionVersion: published.Version,
+  }),
+);
+
+// The grant is made on the alias, which is the resource the delivery names.
+await lambda.addPermission(
+  new AddPermissionCommand({
+    FunctionName: "order-consumer",
+    Qualifier: "live",
+    StatementId: "AllowSns",
+    Action: "lambda:InvokeFunction",
+    Principal: "sns.amazonaws.com",
+    SourceArn: TopicArn,
+  }),
+);
+
+await sns.subscribe(
+  new SubscribeCommand({
+    TopicArn,
+    Protocol: "lambda",
+    Endpoint: `${functionArn}:live`,
+  }),
+);
+
+await sns.publish(new PublishCommand({ TopicArn, Message: "order-1" }));
+await simAws.backgroundTasksComplete();
+```
+
+The qualifier is resolved on every delivery, along with the resource policy. An endpoint naming a
+version or an alias that is not there is recorded on `simAws.sns().deliveryFailures` the way a
+missing function is. Real SNS checks no endpoint at `Subscribe` time, so this is where a subscription
+pointing at nothing shows up.
 
 ## The event a Lambda function receives
 
@@ -1723,9 +1812,6 @@ Current documented limitations:
   out.
 - `RawMessageDelivery` is accepted on a `lambda` subscription and has no effect on it, as it has none
   on real SNS.
-- A qualified function ARN naming a version or an alias is refused as a subscription endpoint.
-  Simulated Lambda has no versions or aliases, so subscribing `$LATEST` instead would be a different
-  function from the one named.
 - `SigningCertURL` and `UnsubscribeURL` name `sns.<region>.yulin.invalid` rather than
   `sns.<region>.amazonaws.com`, and both are unfetchable, since simulated SNS has no HTTP endpoint.
   The certificate is handed out in process by `simAws.sns().signingCertificate(url)`. A real SNS

--- a/docs/services/sns/sim-sns-lambda-alias.example.ts
+++ b/docs/services/sns/sim-sns-lambda-alias.example.ts
@@ -1,0 +1,76 @@
+/**
+ * Subscribing a simulated Lambda alias to a topic, so published messages reach
+ * the version the alias points at.
+ */
+
+import {
+  AddPermissionCommand,
+  CreateAliasCommand,
+  CreateFunctionCommand,
+  PublishVersionCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  CreateTopicCommand,
+  PublishCommand,
+  SubscribeCommand,
+} from "@aws-sdk/client-sns";
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const sns = simAws.sns();
+const lambda = simAws.lambda();
+const functionArn = `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:order-consumer`;
+
+const { TopicArn } = await sns.createTopic(
+  new CreateTopicCommand({ Name: "orders" }),
+);
+
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "order-consumer",
+    Role: `arn:aws:iam::${simAws.defaultAccountId}:role/OrderConsumerRole`,
+    Code: {
+      ZipFile: makeLambdaZipFileInput((_event, context) => {
+        console.log(context.functionVersion); // "1", the version behind `live`
+
+        return "handled";
+      }),
+    },
+  }),
+);
+
+const published = await lambda.publishVersion(
+  new PublishVersionCommand({ FunctionName: "order-consumer" }),
+);
+
+await lambda.createAlias(
+  new CreateAliasCommand({
+    FunctionName: "order-consumer",
+    Name: "live",
+    FunctionVersion: published.Version,
+  }),
+);
+
+// The grant is made on the alias, which is the resource the delivery names.
+await lambda.addPermission(
+  new AddPermissionCommand({
+    FunctionName: "order-consumer",
+    Qualifier: "live",
+    StatementId: "AllowSns",
+    Action: "lambda:InvokeFunction",
+    Principal: "sns.amazonaws.com",
+    SourceArn: TopicArn,
+  }),
+);
+
+await sns.subscribe(
+  new SubscribeCommand({
+    TopicArn,
+    Protocol: "lambda",
+    Endpoint: `${functionArn}:live`,
+  }),
+);
+
+await sns.publish(new PublishCommand({ TopicArn, Message: "order-1" }));
+await simAws.backgroundTasksComplete();

--- a/src/service/apigatewayv2/serve/auth/sim-http-api-invoke-authorizer.ts
+++ b/src/service/apigatewayv2/serve/auth/sim-http-api-invoke-authorizer.ts
@@ -64,7 +64,7 @@ export class SimHttpApiInvokeAuthorizer {
     input: SimHttpApiInvokeAuthorizationInput,
   ): SimIamAuthorizationDecision {
     return this.lambdaAuthorizer.authorize({
-      simFunction: input.simFunction,
+      resource: input.simFunction,
       servicePrincipal: simApiGatewayServicePrincipal,
       sourceArn: input.sourceArn.toString(),
       sourceAccount: input.api.accountRegionScope.accountId,

--- a/src/service/cognito/README.md
+++ b/src/service/cognito/README.md
@@ -534,7 +534,10 @@ the pool records.
 `SimAwsCognitoTriggerFunctions` is the bridge to simulated Lambda, and
 `SimCognitoNoTriggerFunctions` is what a standalone `SimCognitoIdentityProvider` gets instead. The
 functions come from the whole simulation rather than from the pool's own scope, because a
-`LambdaConfig` names a function by ARN and that ARN can name any Account and Region.
+`LambdaConfig` names a function by ARN and that ARN can name any Account and Region. That ARN may
+carry a version or alias qualifier, resolved through `getSimFunctionTarget` when the trigger fires,
+so the pool is free to name a version published after it was created. The alias is what the
+invocation is authorized against and the version behind it is what runs.
 
 ## Command handling
 

--- a/src/service/cognito/user-pool/trigger/sim-aws-cognito-trigger-functions.iso.test.ts
+++ b/src/service/cognito/user-pool/trigger/sim-aws-cognito-trigger-functions.iso.test.ts
@@ -49,13 +49,13 @@ describe("Simulated Lambda functions as Cognito user pool triggers", () => {
     assertStringIncludes(refusal, "is not a Lambda function ARN");
   });
 
-  it("refuses a function version or alias", () => {
+  it("refuses a qualifier naming no version or alias", () => {
     // Given a simulation.
     const functions = new SimAwsCognitoTriggerFunctions({
       simAws: new SimAws(),
     });
 
-    // When a trigger names a published version rather than the function.
+    // When a trigger names an alias nothing points at.
     const refusal = functions.invokeRefusal(
       request("arn:aws:lambda:us-east-1:888888888888:function:pre-auth:PROD"),
     );
@@ -63,7 +63,10 @@ describe("Simulated Lambda functions as Cognito user pool triggers", () => {
     // Then it is refused rather than run against `$LATEST`, which is a
     // different function to the one the pool named.
     assertNonNullable(refusal);
-    assertStringIncludes(refusal, "names a function version or alias");
+    assertStringIncludes(
+      refusal,
+      "names no simulated Lambda function version or alias",
+    );
   });
 
   it("refuses to invoke a function that is not there", async () => {

--- a/src/service/cognito/user-pool/trigger/sim-aws-cognito-trigger-functions.ts
+++ b/src/service/cognito/user-pool/trigger/sim-aws-cognito-trigger-functions.ts
@@ -1,7 +1,7 @@
 import type { SimAws } from "../../../aws/sim-aws.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimLambdaServiceInvokeAuthorizer } from "../../../lambda/command/authorize/sim-lambda-service-invoke-authorizer.js";
-import type { SimLambdaFunction } from "../../../lambda/function/sim-lambda-function.js";
+import type { SimLambdaFunctionTarget } from "../../../lambda/function/version/sim-lambda-function-target.js";
 import {
   parseSimLambdaFunctionArn,
   type SimLambdaFunctionArnParts,
@@ -64,21 +64,13 @@ export class SimAwsCognitoTriggerFunctions implements SimCognitoTriggerFunctions
       return `${request.functionArn} is not a Lambda function ARN.`;
     }
 
-    if (arn.qualifier !== undefined) {
-      return (
-        `${request.functionArn} names a function version or alias, and ` +
-        "simulated Lambda has neither, so it is refused rather than treated " +
-        "as the unqualified function."
-      );
+    const target = this.findTarget(arn);
+
+    if (target === undefined) {
+      return missingFunctionRefusal(arn, request.functionArn);
     }
 
-    const simFunction = this.findFunction(arn);
-
-    if (simFunction === undefined) {
-      return `${request.functionArn} is not a simulated Lambda function.`;
-    }
-
-    return this.policyRefusal(simFunction, request);
+    return this.policyRefusal(target, request);
   }
 
   /**
@@ -96,26 +88,26 @@ export class SimAwsCognitoTriggerFunctions implements SimCognitoTriggerFunctions
     event: object,
   ): Promise<unknown> {
     const arn = parseSimLambdaFunctionArn(request.functionArn);
-    const simFunction = arn === undefined ? undefined : this.findFunction(arn);
+    const target = arn === undefined ? undefined : this.findTarget(arn);
 
     // oxlint-disable-next-line yulin/assert-defined-guard -- `assertDefined` is denser per line, and this file is close enough to the FTA threshold that the guard costs less kept as it is
-    if (simFunction === undefined) {
+    if (target === undefined) {
       throw new Error(
         `${request.functionArn} is not a simulated Lambda function.`,
       );
     }
 
-    return await simFunction.invoke(event);
+    return await target.simFunction.invoke(event);
   }
 
   private policyRefusal(
-    simFunction: SimLambdaFunction,
+    target: SimLambdaFunctionTarget,
     request: SimCognitoTriggerFunctionRequest,
   ): string | undefined {
     const decision = new SimLambdaServiceInvokeAuthorizer({
-      iam: this.iam(simFunction),
+      iam: this.iam(target),
     }).authorize({
-      simFunction,
+      resource: target.resource,
       servicePrincipal: simCognitoServicePrincipal,
       sourceArn: request.userPoolArn,
       sourceAccount: request.userPoolAccountId,
@@ -133,18 +125,34 @@ export class SimAwsCognitoTriggerFunctions implements SimCognitoTriggerFunctions
     return undefined;
   }
 
-  private findFunction(
+  private findTarget(
     arn: SimLambdaFunctionArnParts,
-  ): SimLambdaFunction | undefined {
+  ): SimLambdaFunctionTarget | undefined {
     return this.simAws
       .accountRegionScope(arn.accountId, arn.regionName)
       .lambda()
-      .getSimFunctionByName(arn.functionName);
+      .getSimFunctionTarget(arn.functionName, arn.qualifier);
   }
 
-  private iam(simFunction: SimLambdaFunction): SimIamInterServiceAuthZ {
-    const { accountId, regionName } = simFunction.accountRegionScope;
+  private iam(target: SimLambdaFunctionTarget): SimIamInterServiceAuthZ {
+    const { accountId, regionName } = target.simFunction.accountRegionScope;
 
     return this.simAws.accountRegionScope(accountId, regionName).iam();
   }
+}
+
+/**
+ * Why a trigger ARN reaches nothing, for the pool to repeat back in its
+ * `UnexpectedLambdaException`.
+ *
+ * A qualified ARN says so, since the function it names may well be there while
+ * the version or alias it asked for is not.
+ */
+function missingFunctionRefusal(
+  arn: SimLambdaFunctionArnParts,
+  functionArn: string,
+): string {
+  return arn.qualifier === undefined
+    ? `${functionArn} is not a simulated Lambda function.`
+    : `${functionArn} names no simulated Lambda function version or alias.`;
 }

--- a/src/service/cognito/user-pool/trigger/sim-cognito-qualified-trigger.iso.test.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-qualified-trigger.iso.test.ts
@@ -1,0 +1,125 @@
+import {
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  SignUpCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  type SimLambdaAliasedFunction,
+  simLambdaAliasedFunction,
+  simLambdaAllowAliasInvoke,
+} from "../../../../../test/lambda/alias-fixture.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simCognitoServicePrincipal } from "./sim-aws-cognito-trigger-functions.js";
+
+/**
+ * A pool whose PreSignUp trigger names a function ARN, and the client to sign
+ * up through.
+ */
+interface SimCognitoAliasTriggerPool {
+  readonly simAws: SimAws;
+  readonly clientId: string;
+  readonly trigger: SimLambdaAliasedFunction;
+}
+
+/**
+ * Build a pool running a PreSignUp trigger against a qualified function ARN.
+ *
+ * The function is created before the pool, because a `LambdaConfig` names it by
+ * ARN, and the permission after it, because that names the pool by ARN in turn.
+ */
+async function poolTriggering(
+  triggerArn: (trigger: SimLambdaAliasedFunction) => string,
+): Promise<SimCognitoAliasTriggerPool> {
+  const simAws = new SimAws();
+  const trigger = await simLambdaAliasedFunction(simAws, "auth-trigger", {
+    result: (event) => event,
+  });
+  const cognito = simAws.cognitoIdentityProvider();
+  const pool = await cognito.createUserPool(
+    new CreateUserPoolCommand({
+      PoolName: "myapp-users",
+      LambdaConfig: { PreSignUp: triggerArn(trigger) },
+    }),
+  );
+
+  assertNonNullable(pool.UserPool?.Id, "CreateUserPool answered with a pool");
+  assertNonNullable(pool.UserPool.Arn, "The created pool has an ARN");
+
+  await simLambdaAllowAliasInvoke(
+    simAws,
+    "auth-trigger",
+    simCognitoServicePrincipal,
+    pool.UserPool.Arn,
+  );
+
+  const client = await cognito.createUserPoolClient(
+    new CreateUserPoolClientCommand({
+      UserPoolId: pool.UserPool.Id,
+      ClientName: "web",
+    }),
+  );
+
+  assertNonNullable(
+    client.UserPoolClient?.ClientId,
+    "CreateUserPoolClient answered with a client",
+  );
+
+  return { simAws, clientId: client.UserPoolClient.ClientId, trigger };
+}
+
+/**
+ * Sign a user up through the pool, which is what fires the PreSignUp trigger.
+ */
+async function signUp(pool: SimCognitoAliasTriggerPool): Promise<void> {
+  await pool.simAws.cognitoIdentityProvider().signUp(
+    new SignUpCommand({
+      ClientId: pool.clientId,
+      Username: "alice",
+      Password: "Sup3rSecret!",
+    }),
+  );
+}
+
+describe("A simulated Cognito user pool trigger naming a Lambda alias", () => {
+  it("runs the version the alias points at", async () => {
+    // Given a pool whose PreSignUp trigger names an alias admitting Cognito.
+    const pool = await poolTriggering((trigger) => trigger.aliasArn);
+
+    // When a user signs up.
+    await signUp(pool);
+
+    // Then the version behind the alias ran, rather than `$LATEST`.
+    assertArrayEquals(pool.trigger.ranAs, [pool.trigger.version]);
+  });
+
+  it("refuses a qualifier naming no version or alias", async () => {
+    // Given a pool whose trigger names an alias the function does not have.
+    const pool = await poolTriggering(
+      (trigger) => `${trigger.functionArn}:old`,
+    );
+
+    // When a user signs up.
+    const error = await assertThrowsErrorAsync(async () => {
+      await signUp(pool);
+    });
+
+    // Then the sign-up is refused rather than running `$LATEST`, and nothing
+    // was invoked. The pool is created before the function's alias has to be
+    // there, the same way it is created before the function itself, so this is
+    // where a qualifier reaching nothing is found.
+    assertStringIncludes(
+      error.message,
+      "names no simulated Lambda function version or alias",
+    );
+    assertArrayLength(pool.trigger.ranAs, 0);
+  });
+});

--- a/src/service/elbv2/serve/sim-elbv2-invoke-authorizer.ts
+++ b/src/service/elbv2/serve/sim-elbv2-invoke-authorizer.ts
@@ -61,7 +61,7 @@ export class SimElbV2InvokeAuthorizer {
     input: SimElbV2InvokeAuthorizationInput,
   ): SimIamAuthorizationDecision {
     return this.lambdaAuthorizer.authorize({
-      simFunction: input.simFunction,
+      resource: input.simFunction,
       servicePrincipal: simElbV2ServicePrincipal,
       sourceArn: input.targetGroup.arn,
       sourceAccount: input.accountId,

--- a/src/service/eventbridge/README.md
+++ b/src/service/eventbridge/README.md
@@ -125,6 +125,11 @@ that cannot work says so at the point it was written. The two services whose res
 a type are checked for naming something in it, because a layer ARN and a task definition ARN are
 both well formed ARNs of a service this delivers to, and neither names anything a rule can reach.
 
+A function target ARN may carry a version or alias qualifier, which `functionQualifier` reads beside
+`functionName`. `SimEventBridgeDeliveryFunction` resolves the two together through
+`getSimFunctionTarget` on every delivery, so an alias moved to another version moves what the rule
+reaches.
+
 Delivery has one class per destination service, and each asks that service's own authorizer:
 `SimSqsServiceSendAuthorizer`, `SimSnsServicePublishAuthorizer` and
 `SimLambdaServiceInvokeAuthorizer`. Those already existed for simulated SNS's own fan-out, and they

--- a/src/service/eventbridge/command/target/sim-event-bridge-target-commands.iso.test.ts
+++ b/src/service/eventbridge/command/target/sim-event-bridge-target-commands.iso.test.ts
@@ -238,7 +238,7 @@ describe("EventBridge target commands", () => {
     assertIdentical(removed.FailedEntryCount, 0);
   });
 
-  it("reads the function name out of a qualified Lambda target ARN", async () => {
+  it("reads the qualifier out of a qualified Lambda target ARN", async () => {
     // Given a target ARN carrying a version after the function name.
     const simAws = await simAwsWithRule();
 
@@ -254,11 +254,12 @@ describe("EventBridge target commands", () => {
       }),
     );
 
-    // Then the name is read without the qualifier, which this simulation does
-    // not model.
+    // Then the name and the version it names are both read, so the rule
+    // delivers to the version rather than to `$LATEST`.
     const [target] = simAws.eventBridge().ruleTargets("orders");
 
     assertNonNullable(target);
     assertIdentical(target.arn.functionName, "fulfilment");
+    assertIdentical(target.arn.functionQualifier, "2");
   });
 });

--- a/src/service/eventbridge/delivery/sim-event-bridge-delivery-function.ts
+++ b/src/service/eventbridge/delivery/sim-event-bridge-delivery-function.ts
@@ -34,28 +34,36 @@ export class SimEventBridgeDeliveryFunction {
    * Invoke the function with the event, if it admits EventBridge for this
    * rule.
    *
-   * The resource policy is consulted on every delivery rather than remembered
+   * The function, the version or alias a qualified target named, and the
+   * resource policy are all resolved on every delivery rather than remembered
    * from the moment the target was added, so a permission taken away
-   * afterwards stops delivery. Real EventBridge does not check it at
-   * `PutTargets` time either.
+   * afterwards stops delivery and an alias moved to another version moves what
+   * runs. Real EventBridge does not check any of it at `PutTargets` time
+   * either.
    */
   async deliver(request: SimEventBridgeDeliveryRequest): Promise<void> {
     const source = simEventBridgeDeliverySource(request);
     const targetArn = request.target.arn;
-    const simFunction = this.scope
+    const target = this.scope
       .lambda()
-      .getSimFunctionByName(targetArn.functionName);
+      .getSimFunctionTarget(
+        targetArn.functionName,
+        targetArn.functionQualifier,
+      );
 
-    if (simFunction === undefined) {
+    if (target === undefined) {
       throw new SimEventBridgeTargetNotFound(
-        `${targetArn.value} is not a simulated Lambda function.`,
+        targetArn.functionQualifier === undefined
+          ? `${targetArn.value} is not a simulated Lambda function.`
+          : `${targetArn.value} names no simulated Lambda function version ` +
+              "or alias.",
       );
     }
 
     const decision = new SimLambdaServiceInvokeAuthorizer({
       iam: this.scope.iam(),
     }).authorize({
-      simFunction,
+      resource: target.resource,
       servicePrincipal: simEventBridgeServicePrincipal,
       ...source,
     });
@@ -73,6 +81,6 @@ export class SimEventBridgeDeliveryFunction {
     // asynchronous invocation real EventBridge makes, and because a handler
     // failure has to reach the delivery outcome rather than being swallowed
     // as an asynchronous invocation error.
-    await simFunction.invoke(simEventBridgeDeliveryDocument(request));
+    await target.simFunction.invoke(simEventBridgeDeliveryDocument(request));
   }
 }

--- a/src/service/eventbridge/delivery/sim-event-bridge-qualified-target.iso.test.ts
+++ b/src/service/eventbridge/delivery/sim-event-bridge-qualified-target.iso.test.ts
@@ -1,0 +1,99 @@
+import {
+  PutEventsCommand,
+  PutRuleCommand,
+  PutTargetsCommand,
+} from "@aws-sdk/client-eventbridge";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertNonNullable,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  simLambdaAliasedFunction,
+  simLambdaAllowAliasInvoke,
+} from "../../../../test/lambda/alias-fixture.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simEventBridgeServicePrincipal } from "./sim-event-bridge-delivery.js";
+
+const orderPattern = JSON.stringify({ source: ["orders.service"] });
+
+/**
+ * A rule sending order events to one target, and one order event put through
+ * it.
+ */
+async function deliverOrderTo(
+  simAws: SimAws,
+  targetArn: string,
+): Promise<void> {
+  await simAws
+    .eventBridge()
+    .putRule(
+      new PutRuleCommand({ Name: "orders", EventPattern: orderPattern }),
+    );
+  await simAws.eventBridge().putTargets(
+    new PutTargetsCommand({
+      Rule: "orders",
+      Targets: [{ Id: "fulfilment", Arn: targetArn }],
+    }),
+  );
+  await simAws.eventBridge().putEvents(
+    new PutEventsCommand({
+      Entries: [
+        { Source: "orders.service", DetailType: "OrderPlaced", Detail: "{}" },
+      ],
+    }),
+  );
+
+  await simAws.backgroundTasksComplete();
+}
+
+describe("An EventBridge rule target naming a Lambda alias", () => {
+  it("invokes the version the alias points at", async () => {
+    // Given a function whose alias admits EventBridge.
+    const simAws = new SimAws();
+    const fulfilment = await simLambdaAliasedFunction(simAws, "fulfilment");
+    await simLambdaAllowAliasInvoke(
+      simAws,
+      "fulfilment",
+      simEventBridgeServicePrincipal,
+    );
+
+    // When a rule targeting the alias matches an event.
+    await deliverOrderTo(simAws, fulfilment.aliasArn);
+
+    // Then the version behind the alias ran, rather than `$LATEST`.
+    assertArrayEquals(fulfilment.ranAs, [fulfilment.version]);
+    assertArrayLength(simAws.eventBridge().deliveryFailures, 0);
+  });
+
+  it("reports a target naming no version or alias", async () => {
+    // Given a function with an alias, and a rule targeting one it does not
+    // have.
+    const simAws = new SimAws();
+    const fulfilment = await simLambdaAliasedFunction(simAws, "fulfilment");
+    await simLambdaAllowAliasInvoke(
+      simAws,
+      "fulfilment",
+      simEventBridgeServicePrincipal,
+    );
+
+    // When the rule matches an event.
+    await deliverOrderTo(simAws, `${fulfilment.functionArn}:old`);
+
+    // Then nothing ran, and the failure says the qualifier reaches nothing.
+    // Real EventBridge checks no target at `PutTargets` time, so this is where
+    // a rule pointing at nothing is found, as it is for a missing function.
+    assertArrayLength(fulfilment.ranAs, 0);
+
+    const [failure] = simAws.eventBridge().deliveryFailures;
+
+    assertNonNullable(failure);
+    assertStringIncludes(
+      failure.message,
+      "names no simulated Lambda function version or alias",
+    );
+  });
+});

--- a/src/service/eventbridge/target/sim-event-target-arn.ts
+++ b/src/service/eventbridge/target/sim-event-target-arn.ts
@@ -157,17 +157,29 @@ export class SimEventTargetArn {
    * something else in Lambda.
    *
    * A function ARN's resource is `function:<name>`, and may carry a version or
-   * alias after a second colon, which this simulation does not model and so
-   * reads as part of nothing. The resource type is checked rather than
-   * assumed, because Lambda writes more than functions this way: a layer is
-   * `layer:<name>` and an event source mapping is
-   * `event-source-mapping:<uuid>`, and taking the part after the first colon
-   * would read either as a function that is not there.
+   * alias after a second colon, which `functionQualifier` reads. The resource
+   * type is checked rather than assumed, because Lambda writes more than
+   * functions this way: a layer is `layer:<name>` and an event source mapping
+   * is `event-source-mapping:<uuid>`, and taking the part after the first
+   * colon would read either as a function that is not there.
    */
   get functionName(): string {
-    const [resourceType, name = ""] = this.resource.split(":", 2);
+    const [resourceType, name = ""] = this.resource.split(":", 3);
 
     return resourceType === "function" ? name : "";
+  }
+
+  /**
+   * The version or alias this ARN qualified the function with, or nothing when
+   * it named the function itself.
+   *
+   * A rule delivers to the version a qualified target names, so the qualifier
+   * is read rather than dropped.
+   */
+  get functionQualifier(): string | undefined {
+    const [resourceType, , qualifier] = this.resource.split(":", 3);
+
+    return resourceType === "function" ? qualifier : undefined;
   }
 
   /**

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -10,6 +10,9 @@ code can interact with it through familiar AWS SDK commands.
 ## Entry points
 
 - `sim-lambda.ts` is the main in-memory service object for one account/region scope.
+- `sim-lambda-inspection.ts` holds the simulator's own accessors, which go through no Command and no
+  authorization. `SimLambda` extends it, the way `SimEventBridge` extends its own inspection base,
+  and the split keeps the facade to delegating SDK commands.
 - `index.ts` exports the public Lambda simulator API for `@kensio/yulin/lambda`.
 
 A `SimLambda` instance owns an in-memory map of functions:
@@ -382,6 +385,18 @@ front of a request made against the alias. `Invoke` reaches the same resource th
 `findResource`. It tolerates a function that is absent, since a request naming one is authorized
 before it is reported missing.
 
+Both answers come from one lookup. `SimLambdaFunctionTarget` carries the resource a qualifier named
+and the version that runs, and `findTarget` and `requireTarget` on the version store are what
+everything else here is built on. `SimLambdaFunctionLookup` offers the same two by function name,
+and `SimLambda.getSimFunctionTarget` is how the other simulated services reach a function a target
+ARN points at. Each of them resolves the qualifier at the moment it is asked, so an alias moved to
+another version moves what a standing notification, subscription, trigger, rule target or event
+source mapping delivers to.
+
+`SimLambdaServiceInvokeAuthorizer` takes that resource rather than the function, so a delivery to
+an alias is admitted by a grant made on the alias. The service being the caller is the only thing
+that differs from an `Invoke`.
+
 ## Event source mappings
 
 `event-source/` owns delivery from a simulated SQS queue or DynamoDB stream to a function.
@@ -424,6 +439,15 @@ exists, and that the execution role may perform the operations polling it takes
 (`SimLambdaEventSourceRolePermissions`, which reads those operations off the ARN — for a queue,
 `ReceiveMessage`, `DeleteMessage` and `GetQueueAttributes`). Both failures are the mapping's, not
 the poller's: a mapping that cannot poll looks like a working subscription and delivers nothing.
+
+A `FunctionName` may carry a version or alias qualifier. `SimLambdaEventSourceMappingInput` reads it
+with `simLambdaFunctionReferenceOf` and the mapping holds it beside the name, so each poll resolves
+it again through `SimLambdaFunctionLookup.findTarget` and an alias moved to another version moves
+what the mapping delivers to. The version has to be there when the mapping is created, checked with
+`requireTarget` alongside the function. `FunctionArn` on the mapping is the resource it was pointed
+at, so a mapping onto an alias reports the alias. `simLambdaFunctionNameOf` is left where the
+qualifier genuinely has no bearing, which is the `ListEventSourceMappings` filter and the
+CloudFormation target-function reader.
 
 `poll/` holds what one poll does. `SimLambdaEventSourcePoller` is the three-method interface
 (`watch`, `pollNow`, `stop`) the mapping's pollers are held behind, and

--- a/src/service/lambda/command/authorize/sim-lambda-service-invoke-authorizer.iso.test.ts
+++ b/src/service/lambda/command/authorize/sim-lambda-service-invoke-authorizer.iso.test.ts
@@ -41,7 +41,7 @@ describe("Authorizing a simulated service to invoke a Lambda function", () => {
     const decision = new SimLambdaServiceInvokeAuthorizer({
       iam: simAws.iam(),
     }).authorize({
-      simFunction,
+      resource: simFunction,
       servicePrincipal: s3ServicePrincipal,
       sourceArn: bucketArn,
       sourceAccount: bucketAccountId,
@@ -71,7 +71,7 @@ describe("Authorizing a simulated service to invoke a Lambda function", () => {
     const decision = new SimLambdaServiceInvokeAuthorizer({
       iam: simAws.iam(),
     }).authorize({
-      simFunction,
+      resource: simFunction,
       servicePrincipal: s3ServicePrincipal,
       sourceArn: bucketArn,
       sourceAccount: bucketAccountId,
@@ -99,7 +99,7 @@ describe("Authorizing a simulated service to invoke a Lambda function", () => {
     const decision = new SimLambdaServiceInvokeAuthorizer({
       iam: simAws.iam(),
     }).authorize({
-      simFunction,
+      resource: simFunction,
       servicePrincipal: s3ServicePrincipal,
       sourceArn: bucketArn,
       sourceAccount: "222222222222",
@@ -131,13 +131,13 @@ describe("Authorizing a simulated service to invoke a Lambda function", () => {
 
     // When both match, and when only one of them does
     const both = authorizer.authorize({
-      simFunction,
+      resource: simFunction,
       servicePrincipal: s3ServicePrincipal,
       sourceArn: bucketArn,
       sourceAccount: bucketAccountId,
     });
     const otherBucket = authorizer.authorize({
-      simFunction,
+      resource: simFunction,
       servicePrincipal: s3ServicePrincipal,
       sourceArn: "arn:aws:s3:::refunds",
       sourceAccount: bucketAccountId,
@@ -166,7 +166,7 @@ describe("Authorizing a simulated service to invoke a Lambda function", () => {
     const decision = new SimLambdaServiceInvokeAuthorizer({
       iam: simAws.iam(),
     }).authorize({
-      simFunction,
+      resource: simFunction,
       servicePrincipal: s3ServicePrincipal,
     });
 
@@ -192,7 +192,7 @@ describe("Authorizing a simulated service to invoke a Lambda function", () => {
     const decision = new SimLambdaServiceInvokeAuthorizer({
       iam: simAws.iam(),
     }).authorize({
-      simFunction,
+      resource: simFunction,
       servicePrincipal: "events.amazonaws.com",
       sourceAccount: bucketAccountId,
     });

--- a/src/service/lambda/command/authorize/sim-lambda-service-invoke-authorizer.ts
+++ b/src/service/lambda/command/authorize/sim-lambda-service-invoke-authorizer.ts
@@ -6,7 +6,7 @@ import {
   simLambdaSourceAccountConditionKey,
   simLambdaSourceArnConditionKey,
 } from "../../function/policy/sim-lambda-permission.js";
-import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
+import type { SimLambdaPolicyResource } from "../../function/policy/sim-lambda-policy-resource.js";
 import type { SimIamConditionValue } from "../../../iam/policy/sim-iam-policy.js";
 import { simLambdaResourcePolicies } from "./sim-lambda-resource-policies.js";
 
@@ -15,7 +15,15 @@ interface SimLambdaServiceInvokeAuthorizerProperties {
 }
 
 interface SimLambdaServiceInvokeAuthorizationInput {
-  readonly simFunction: SimLambdaFunction;
+  /**
+   * What the service is invoking, which is a function, a published version or
+   * an alias.
+   *
+   * Each qualified resource holds a policy of its own. A delivery to the alias
+   * `live` is admitted by a grant made on `live`, and one to the function
+   * itself by a grant on the function.
+   */
+  readonly resource: SimLambdaPolicyResource;
 
   /** The service principal the invoking service calls Lambda as. */
   readonly servicePrincipal: string;
@@ -67,9 +75,9 @@ export class SimLambdaServiceInvokeAuthorizer {
   ): SimIamAuthorizationDecision {
     return this.iam.authorize({
       action: SimLambdaServiceInvokeAuthorizer.action,
-      resource: input.simFunction.arn,
+      resource: input.resource.arn,
       caller: { kind: "service", service: input.servicePrincipal },
-      resourcePolicies: simLambdaResourcePolicies(input.simFunction),
+      resourcePolicies: simLambdaResourcePolicies(input.resource),
       conditionContext: this.conditionContext(input),
     });
   }

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-input.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-input.ts
@@ -6,7 +6,7 @@ import {
 import type { SimLambdaFunctionResponseType } from "../../event-source/sim-lambda-event-source-mapping.js";
 import type { SimLambdaEventSourceStartingPosition } from "../../event-source/sim-lambda-event-source-starting-position.js";
 import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
-import { simLambdaFunctionNameOf } from "../../function/sim-lambda-function-name.js";
+import { simLambdaFunctionReferenceOf } from "../../function/sim-lambda-function-reference.js";
 import {
   functionResponseTypesIn,
   requiredString,
@@ -20,6 +20,7 @@ import type { SimCreateEventSourceMappingCommandInput } from "./event-source-map
 interface SimLambdaEventSourceMappingInputProperties {
   readonly eventSourceArn: SimLambdaEventSourceArn;
   readonly functionName: string;
+  readonly qualifier: string | undefined;
   readonly batchSize: number;
   readonly startingPosition: SimLambdaEventSourceStartingPosition | undefined;
   readonly enabled: boolean;
@@ -39,6 +40,15 @@ interface SimLambdaEventSourceMappingInputProperties {
 export class SimLambdaEventSourceMappingInput {
   public readonly eventSourceArn: SimLambdaEventSourceArn;
   public readonly functionName: string;
+
+  /**
+   * The version or alias the request qualified the function name with, if it
+   * named one.
+   *
+   * A mapping onto `orders:live` delivers to the version the alias points at,
+   * so the qualifier travels with the name rather than being dropped.
+   */
+  public readonly qualifier: string | undefined;
   public readonly batchSize: number;
   public readonly startingPosition:
     | SimLambdaEventSourceStartingPosition
@@ -49,6 +59,7 @@ export class SimLambdaEventSourceMappingInput {
   private constructor(properties: SimLambdaEventSourceMappingInputProperties) {
     this.eventSourceArn = properties.eventSourceArn;
     this.functionName = properties.functionName;
+    this.qualifier = properties.qualifier;
     this.batchSize = properties.batchSize;
     this.startingPosition = properties.startingPosition;
     this.enabled = properties.enabled;
@@ -70,7 +81,7 @@ export class SimLambdaEventSourceMappingInput {
 
     return new this({
       eventSourceArn,
-      functionName: simLambdaFunctionNameOf(
+      ...simLambdaFunctionReferenceOf(
         requiredString(input.FunctionName, "functionName"),
       ),
       batchSize: eventSourceArn.batchRules.sizeIn(input.BatchSize),

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping.handler.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping.handler.ts
@@ -13,6 +13,7 @@ import { SimLambdaEventSourceRolePermissions } from "../../event-source/sim-lamb
 import type { SimLambdaEventSourceStreams } from "../../event-source/stream/sim-lambda-event-source-streams.js";
 import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
 import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
+import type { SimLambdaFunctionTarget } from "../../function/version/sim-lambda-function-target.js";
 import { FunctionUrlAuthorizer } from "../function-url/function-url-authorizer.js";
 import { SimLambdaEventSourceMappingInput } from "./create-event-source-mapping-input.js";
 import type {
@@ -87,17 +88,20 @@ export class CreateEventSourceMappingCommandHandler implements CommandHandler<
     const { functions } = this.properties;
 
     this.authorizer.authorize(
-      functions.functionArn(input.functionName),
+      functions.functionArn(input.functionName, input.qualifier),
       options?.caller,
     );
 
-    const simFunction = functions.require(input.functionName);
+    // The version a qualifier names has to be there when the mapping is made,
+    // the same way the function does, so a mapping onto an alias nothing
+    // published is refused rather than polling into nothing.
+    const target = functions.requireTarget(input.functionName, input.qualifier);
 
-    await this.assertPollable(simFunction, input.eventSourceArn);
+    await this.assertPollable(target.simFunction, input.eventSourceArn);
 
     return {
       $metadata: {},
-      ...this.created(input, simFunction).configuration(),
+      ...this.created(input, target).configuration(),
     };
   }
 
@@ -122,13 +126,17 @@ export class CreateEventSourceMappingCommandHandler implements CommandHandler<
 
   private created(
     input: SimLambdaEventSourceMappingInput,
-    simFunction: SimLambdaFunction,
+    target: SimLambdaFunctionTarget,
   ): SimLambdaEventSourceMapping {
     const mapping = new SimLambdaEventSourceMapping({
       accountRegionScope: this.properties.accountRegionScope,
       eventSourceArn: input.eventSourceArn.value,
       functionName: input.functionName,
-      functionArn: simFunction.arn,
+      qualifier: input.qualifier,
+      // The ARN the mapping reports is the resource it was pointed at, so a
+      // mapping onto an alias reports the alias rather than the version behind
+      // it, as real Lambda does.
+      functionArn: target.resource.arn,
       batchSize: input.batchSize,
       startingPosition: input.startingPosition,
       enabled: input.enabled,

--- a/src/service/lambda/command/event-source-mapping/qualified-event-source-mapping.iso.test.ts
+++ b/src/service/lambda/command/event-source-mapping/qualified-event-source-mapping.iso.test.ts
@@ -1,0 +1,90 @@
+import { CreateEventSourceMappingCommand } from "@aws-sdk/client-lambda";
+import { SendMessageCommand } from "@aws-sdk/client-sqs";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  type SimLambdaAliasedFunction,
+  simLambdaAliasedFunction,
+} from "../../../../../test/lambda/alias-fixture.js";
+import {
+  makePollingRole,
+  makeSourceQueue,
+} from "../../../../../test/lambda/event-source-fixture.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+
+interface SimLambdaQualifiedMapping {
+  readonly simAws: SimAws;
+  readonly queueUrl: string;
+  readonly consumer: SimLambdaAliasedFunction;
+}
+
+/**
+ * A queue and a function with an alias, ready to be mapped to one another.
+ *
+ * The role is made before the function, because a mapping only polls as a role
+ * that may read the queue.
+ */
+async function queueAndAliasedConsumer(): Promise<SimLambdaQualifiedMapping> {
+  const simAws = new SimAws();
+  const queue = await makeSourceQueue(simAws);
+  const roleArn = await makePollingRole(simAws, queue.queueArn);
+  const consumer = await simLambdaAliasedFunction(simAws, "order-consumer", {
+    roleArn,
+  });
+
+  return { simAws, queueUrl: queue.queueUrl, consumer };
+}
+
+describe("An event source mapping onto a Lambda alias", () => {
+  it("delivers to the version the alias points at", async () => {
+    // Given a queue and a function with an alias.
+    const { simAws, queueUrl, consumer } = await queueAndAliasedConsumer();
+
+    // When a mapping names the alias and a message arrives.
+    const mapping = await simAws.lambda().createEventSourceMapping(
+      new CreateEventSourceMappingCommand({
+        EventSourceArn: simAws.sqs().findQueue("orders")?.arn.value,
+        FunctionName: `${consumer.functionArn}:live`,
+      }),
+    );
+
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // Then the version behind the alias ran, and the mapping reports the alias
+    // it was pointed at rather than the version behind it.
+    assertArrayEquals(consumer.ranAs, [consumer.version]);
+    assertIdentical(mapping.FunctionArn, consumer.aliasArn);
+  });
+
+  it("refuses a qualifier naming no version or alias", async () => {
+    // Given a queue and a function with an alias.
+    const { simAws, consumer } = await queueAndAliasedConsumer();
+
+    // When a mapping names an alias the function does not have.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.lambda().createEventSourceMapping(
+          new CreateEventSourceMappingCommand({
+            EventSourceArn: simAws.sqs().findQueue("orders")?.arn.value,
+            FunctionName: `${consumer.functionArn}:old`,
+          }),
+        ),
+    );
+
+    // Then the mapping is refused where it is created, the same way one onto a
+    // function that is not there is.
+    assertIdentical(error.name, "ResourceNotFoundException");
+    assertStringIncludes(error.message, "Function not found");
+  });
+});

--- a/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-event-source-poller.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-event-source-poller.ts
@@ -2,6 +2,7 @@ import type { BackgroundScheduler } from "../../../../util/background/background
 import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
 import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
 import type { SimLambdaEventSourceMapping } from "../sim-lambda-event-source-mapping.js";
+import { simLambdaEventSourceFunction } from "./sim-lambda-event-source-function.js";
 import type { SimLambdaDynamoDbStreamEventSourceArn } from "../stream/sim-lambda-dynamodb-stream-event-source-arn.js";
 import type { SimLambdaEventSourceStreams } from "../stream/sim-lambda-event-source-streams.js";
 import { SimLambdaDynamoDbPolledStream } from "./sim-lambda-dynamodb-polled-stream.js";
@@ -153,6 +154,6 @@ export class SimLambdaDynamoDbStreamEventSourcePoller
       return undefined;
     }
 
-    return this.functions.find(this.mapping.functionName);
+    return simLambdaEventSourceFunction(this.functions, this.mapping);
   }
 }

--- a/src/service/lambda/event-source/poll/sim-lambda-event-source-function.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-event-source-function.ts
@@ -1,0 +1,19 @@
+import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
+import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
+import type { SimLambdaEventSourceMapping } from "../sim-lambda-event-source-mapping.js";
+
+/**
+ * The function a mapping delivers to, or nothing when it reaches none.
+ *
+ * A mapping created against a version or an alias resolves its qualifier on
+ * every poll, so an alias moved to another version moves what the mapping
+ * delivers to. A function that has gone, and a qualifier that names nothing,
+ * both answer with nothing, and the poll then does nothing.
+ */
+export function simLambdaEventSourceFunction(
+  functions: SimLambdaFunctionLookup,
+  mapping: SimLambdaEventSourceMapping,
+): SimLambdaFunction | undefined {
+  return functions.findTarget(mapping.functionName, mapping.qualifier)
+    ?.simFunction;
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-sqs-event-source-consumer.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-sqs-event-source-consumer.ts
@@ -8,6 +8,7 @@ import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
 import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
 import type { SimLambdaSqsEventSourceArn } from "../queue/sim-lambda-sqs-event-source-arn.js";
 import type { SimLambdaEventSourceMapping } from "../sim-lambda-event-source-mapping.js";
+import { simLambdaEventSourceFunction } from "./sim-lambda-event-source-function.js";
 import type { SimLambdaEventSourceDelivery } from "./sim-lambda-event-source-delivery.js";
 import { makeSimLambdaSqsDelivery } from "./sim-lambda-sqs-delivery.js";
 
@@ -69,6 +70,6 @@ export class SimLambdaSqsEventSourceConsumer implements SimSqsPollConsumer {
       return undefined;
     }
 
-    return this.functions.find(this.mapping.functionName);
+    return simLambdaEventSourceFunction(this.functions, this.mapping);
   }
 }

--- a/src/service/lambda/event-source/sim-lambda-event-source-mapping.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-mapping.ts
@@ -33,6 +33,7 @@ interface SimLambdaEventSourceMappingProperties {
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly eventSourceArn: string;
   readonly functionName: string;
+  readonly qualifier?: string | undefined;
   readonly functionArn: SimLambdaFunctionArn;
   readonly batchSize: number;
   readonly startingPosition?: SimLambdaEventSourceStartingPosition | undefined;
@@ -76,6 +77,15 @@ export class SimLambdaEventSourceMapping {
   public readonly uuid: string = randomUUID();
   public readonly eventSourceArn: string;
   public readonly functionName: string;
+
+  /**
+   * The version or alias this mapping delivers to, if it was created with one.
+   *
+   * It is resolved on every poll rather than at creation, so an alias moved to
+   * another version moves what the mapping delivers to.
+   */
+  public readonly qualifier: string | undefined;
+
   public readonly functionArn: SimLambdaFunctionArn;
   public readonly batchSize: number;
   /**
@@ -97,6 +107,7 @@ export class SimLambdaEventSourceMapping {
     this.accountRegionScope = properties.accountRegionScope;
     this.eventSourceArn = properties.eventSourceArn;
     this.functionName = properties.functionName;
+    this.qualifier = properties.qualifier;
     this.functionArn = properties.functionArn;
     this.batchSize = properties.batchSize;
     this.startingPosition = properties.startingPosition;

--- a/src/service/lambda/function/url/sim-lambda-function-lookup.ts
+++ b/src/service/lambda/function/url/sim-lambda-function-lookup.ts
@@ -9,10 +9,13 @@ import {
   type SimLambdaFunctionArn,
   simLambdaFunctionArn,
 } from "../sim-lambda-function-configuration.js";
+import type { SimLambdaFunctionTarget } from "../version/sim-lambda-function-target.js";
+import type { SimLambdaFunctionVersionStore } from "../version/sim-lambda-function-version-store.js";
 
 interface SimLambdaFunctionLookupProperties {
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly functions: SimLambdaFunctionMap;
+  readonly versions: SimLambdaFunctionVersionStore;
 }
 
 /**
@@ -26,10 +29,12 @@ interface SimLambdaFunctionLookupProperties {
 export class SimLambdaFunctionLookup {
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly functions: SimLambdaFunctionMap;
+  private readonly versions: SimLambdaFunctionVersionStore;
 
   constructor(properties: SimLambdaFunctionLookupProperties) {
     this.accountRegionScope = properties.accountRegionScope;
     this.functions = properties.functions;
+    this.versions = properties.versions;
   }
 
   /**
@@ -49,6 +54,31 @@ export class SimLambdaFunctionLookup {
    */
   find(functionName: string): SimLambdaFunction | undefined {
     return this.functions.get(functionName as SimLambdaFunctionName);
+  }
+
+  /**
+   * Get what a name and a qualifier together name, or nothing when there is no
+   * such function, version or alias.
+   *
+   * A qualifier is resolved on every lookup rather than once, so an alias
+   * moved to another version afterwards moves what a standing target reaches.
+   */
+  findTarget(
+    functionName: string,
+    qualifier?: string,
+  ): SimLambdaFunctionTarget | undefined {
+    return this.versions.findTarget(this.find(functionName), qualifier);
+  }
+
+  /**
+   * Get what a name and a qualifier together name, or fail as AWS does when
+   * there is no such function, version or alias.
+   */
+  requireTarget(
+    functionName: string,
+    qualifier?: string,
+  ): SimLambdaFunctionTarget {
+    return this.versions.requireTarget(this.require(functionName), qualifier);
   }
 
   /**

--- a/src/service/lambda/function/version/sim-lambda-function-target.ts
+++ b/src/service/lambda/function/version/sim-lambda-function-target.ts
@@ -1,0 +1,16 @@
+import type { SimLambdaPolicyResource } from "../policy/sim-lambda-policy-resource.js";
+import type { SimLambdaFunction } from "../sim-lambda-function.js";
+
+/**
+ * Somewhere a request or another service delivers to: the resource it named,
+ * and the version that runs.
+ *
+ * The two are one thing for a function and for a published version, and are
+ * two for an alias. A grant made on `live` is what admits the delivery, and
+ * the version `live` points at is what runs, so both travel together rather
+ * than being resolved twice from either end.
+ */
+export interface SimLambdaFunctionTarget {
+  readonly resource: SimLambdaPolicyResource;
+  readonly simFunction: SimLambdaFunction;
+}

--- a/src/service/lambda/function/version/sim-lambda-function-version-store.ts
+++ b/src/service/lambda/function/version/sim-lambda-function-version-store.ts
@@ -5,6 +5,7 @@ import type {
   SimLambdaFunction,
   SimLambdaFunctionName,
 } from "../sim-lambda-function.js";
+import type { SimLambdaFunctionTarget } from "./sim-lambda-function-target.js";
 import {
   simLambdaQualifiedFunctionArn,
   SimLambdaFunctionVersions,
@@ -51,19 +52,53 @@ export class SimLambdaFunctionVersionStore {
     simFunction: SimLambdaFunction,
     qualifier: string | undefined,
   ): SimLambdaFunction {
-    if (qualifier === undefined || qualifier === SIM_LAMBDA_LATEST_VERSION) {
-      return simFunction;
+    return this.requireTarget(simFunction, qualifier).simFunction;
+  }
+
+  /**
+   * What a qualifier names, or nothing when there is no such function or the
+   * qualifier names neither a version nor an alias.
+   *
+   * A function that is not there answers with nothing, since a request naming
+   * one is authorized before it is reported missing, and since a service whose
+   * target was configured before the function was created has to be able to
+   * ask.
+   */
+  findTarget(
+    simFunction: SimLambdaFunction | undefined,
+    qualifier: string | undefined,
+  ): SimLambdaFunctionTarget | undefined {
+    if (simFunction === undefined) {
+      return undefined;
     }
 
-    const resolved = this.of(simFunction).resolve(qualifier);
+    return qualifier === undefined || qualifier === SIM_LAMBDA_LATEST_VERSION
+      ? { resource: simFunction, simFunction }
+      : this.of(simFunction).target(qualifier);
+  }
 
-    if (resolved === undefined) {
+  /**
+   * What a qualifier names, or fail as AWS does when it names neither a
+   * version nor an alias.
+   */
+  requireTarget(
+    simFunction: SimLambdaFunction,
+    qualifier: string | undefined,
+  ): SimLambdaFunctionTarget {
+    const target = this.findTarget(simFunction, qualifier);
+
+    if (target === undefined) {
+      // Only a qualifier naming neither a version nor an alias reaches here,
+      // since a caller passing none gets the function itself.
       throw new SimLambdaResourceNotFoundException(
-        `Function not found: ${simLambdaQualifiedFunctionArn(simFunction, qualifier)}`,
+        `Function not found: ${simLambdaQualifiedFunctionArn(
+          simFunction,
+          qualifier ?? SIM_LAMBDA_LATEST_VERSION,
+        )}`,
       );
     }
 
-    return resolved;
+    return target;
   }
 
   /**
@@ -73,20 +108,13 @@ export class SimLambdaFunctionVersionStore {
    * An alias answers as itself here rather than as the version it points at,
    * because the two hold their own resource policies. Resolving the alias
    * first would evaluate the version's policy for a request made against the
-   * alias. A function that is not there answers with nothing, since a request
-   * naming one is authorized before it is reported missing.
+   * alias.
    */
   findResource(
     simFunction: SimLambdaFunction | undefined,
     qualifier: string | undefined,
   ): SimLambdaPolicyResource | undefined {
-    if (simFunction === undefined) {
-      return undefined;
-    }
-
-    return qualifier === undefined || qualifier === SIM_LAMBDA_LATEST_VERSION
-      ? simFunction
-      : this.of(simFunction).named(qualifier);
+    return this.findTarget(simFunction, qualifier)?.resource;
   }
 
   /**
@@ -97,19 +125,7 @@ export class SimLambdaFunctionVersionStore {
     simFunction: SimLambdaFunction,
     qualifier: string | undefined,
   ): SimLambdaPolicyResource {
-    if (qualifier === undefined || qualifier === SIM_LAMBDA_LATEST_VERSION) {
-      return simFunction;
-    }
-
-    const resource = this.of(simFunction).named(qualifier);
-
-    if (resource === undefined) {
-      throw new SimLambdaResourceNotFoundException(
-        `Function not found: ${simLambdaQualifiedFunctionArn(simFunction, qualifier)}`,
-      );
-    }
-
-    return resource;
+    return this.requireTarget(simFunction, qualifier).resource;
   }
 
   /**

--- a/src/service/lambda/function/version/sim-lambda-function-versions.ts
+++ b/src/service/lambda/function/version/sim-lambda-function-versions.ts
@@ -2,9 +2,9 @@ import {
   type SimLambdaFunctionArn,
   simLambdaFunctionArn,
 } from "../sim-lambda-function-configuration.js";
-import type { SimLambdaPolicyResource } from "../policy/sim-lambda-policy-resource.js";
 import type { SimLambdaFunction } from "../sim-lambda-function.js";
 import type { SimLambdaFunctionAlias } from "./sim-lambda-function-alias.js";
+import type { SimLambdaFunctionTarget } from "./sim-lambda-function-target.js";
 
 /**
  * The ARN a version or an alias of a function has, which is the function's own
@@ -53,36 +53,32 @@ export class SimLambdaFunctionVersions {
   }
 
   /**
-   * The version a qualifier names, or nothing when it names neither a version
-   * nor an alias.
+   * What a qualifier names, or nothing when it names neither a version nor an
+   * alias.
    *
    * Real Lambda tells the two apart the way this does. An alias name cannot be
    * all digits, so a qualifier that is one is a version number.
+   *
+   * An alias is the resource a grant is made on and a request is authorized
+   * against, so it answers as the resource while the version it points at is
+   * what runs.
    */
-  resolve(qualifier: string): SimLambdaFunction | undefined {
+  target(qualifier: string): SimLambdaFunctionTarget | undefined {
     if (isVersionNumber(qualifier)) {
-      return this.version(qualifier);
+      const version = this.version(qualifier);
+
+      return version === undefined
+        ? undefined
+        : { resource: version, simFunction: version };
     }
 
     const alias = this.aliases.get(qualifier);
+    const version =
+      alias === undefined ? undefined : this.version(alias.functionVersion);
 
-    return alias === undefined
+    return alias === undefined || version === undefined
       ? undefined
-      : this.version(alias.functionVersion);
-  }
-
-  /**
-   * The resource a qualifier names, or nothing when it names neither a version
-   * nor an alias.
-   *
-   * This stops where `resolve` carries on: an alias is the resource a grant is
-   * made on and a request is authorized against, so it answers as itself
-   * rather than as the version behind it.
-   */
-  named(qualifier: string): SimLambdaPolicyResource | undefined {
-    return isVersionNumber(qualifier)
-      ? this.version(qualifier)
-      : this.aliases.get(qualifier);
+      : { resource: alias, simFunction: version };
   }
 
   /**

--- a/src/service/lambda/sim-lambda-commands.ts
+++ b/src/service/lambda/sim-lambda-commands.ts
@@ -124,6 +124,7 @@ export class SimLambdaCommands {
     this.functionLookup = new SimLambdaFunctionLookup({
       accountRegionScope,
       functions: properties.functions,
+      versions: this.versionStore,
     });
     this.functionUrlStore = new SimLambdaFunctionUrlStore({
       accountRegionScope,

--- a/src/service/lambda/sim-lambda-inspection.ts
+++ b/src/service/lambda/sim-lambda-inspection.ts
@@ -1,0 +1,73 @@
+import type { SimLambdaEventSourceMapping } from "./event-source/sim-lambda-event-source-mapping.js";
+import type {
+  SimLambdaFunction,
+  SimLambdaFunctionMap,
+  SimLambdaFunctionName,
+} from "./function/sim-lambda-function.js";
+import type {
+  SimLambdaFunctionUrl,
+  SimLambdaFunctionUrlId,
+} from "./function/url/sim-lambda-function-url.js";
+import type { SimLambdaFunctionTarget } from "./function/version/sim-lambda-function-target.js";
+import type { SimLambdaCommands } from "./sim-lambda-commands.js";
+
+/**
+ * What a test or another simulated service can ask a simulated Lambda about
+ * its own state.
+ *
+ * These are the simulator's own accessors rather than simulated API
+ * operations: they go through no Command and no authorization. They are held
+ * apart from the facade because the facade's job is delegating SDK commands,
+ * and this is a different job that happens to live on the same object.
+ */
+export abstract class SimLambdaInspection {
+  protected abstract readonly functions: SimLambdaFunctionMap;
+  protected abstract readonly commands: SimLambdaCommands;
+
+  /** Get a simulated event source mapping by its UUID. */
+  getSimEventSourceMapping(
+    uuid: string,
+  ): SimLambdaEventSourceMapping | undefined {
+    return this.commands.eventSourceMappings.find(uuid);
+  }
+
+  /** Get a simulated Lambda function instance by name. */
+  getSimFunctionByName(
+    functionName: SimLambdaFunctionName | string,
+  ): SimLambdaFunction | undefined {
+    return this.functions.get(functionName as SimLambdaFunctionName);
+  }
+
+  /**
+   * Get what a function name and a version or alias qualifier together name.
+   *
+   * This is how another simulated service reaches the function a target ARN
+   * points at. The resource it answers with is what a delivery is authorized
+   * against, and the function is the version that runs.
+   */
+  getSimFunctionTarget(
+    functionName: SimLambdaFunctionName | string,
+    qualifier?: string,
+  ): SimLambdaFunctionTarget | undefined {
+    return this.commands.functionLookup.findTarget(functionName, qualifier);
+  }
+
+  /** Get a simulated Lambda function's Function URL, if it has one. */
+  getSimFunctionUrl(
+    functionName: SimLambdaFunctionName | string,
+  ): SimLambdaFunctionUrl | undefined {
+    return this.commands.functionUrlStore.get(functionName);
+  }
+
+  /**
+   * Get a simulated Lambda Function URL by the id in its hostname.
+   *
+   * This is how the localhost serving layer finds the Function URL a request
+   * was addressed to, once the registry has named the owning Account.
+   */
+  getSimFunctionUrlById(
+    urlId: SimLambdaFunctionUrlId,
+  ): SimLambdaFunctionUrl | undefined {
+    return this.commands.functionUrlStore.byUrlId(urlId);
+  }
+}

--- a/src/service/lambda/sim-lambda.ts
+++ b/src/service/lambda/sim-lambda.ts
@@ -2,22 +2,14 @@ import type { SimSdkCommandRouter } from "../../sdk/index.js";
 import type { SimAwsCaller } from "../aws/caller/sim-aws-caller.js";
 import type { SimCfnServiceResourceFactory } from "../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
 import { SimLambdaCloudFormationResourceFactory } from "./cfn/sim-cfn-lambda-resource-factory.js";
-import type { SimLambdaEventSourceMapping } from "./event-source/sim-lambda-event-source-mapping.js";
 import type { SimLambdaContainerImages } from "./function/code/image/sim-lambda-container-images.js";
-import type {
-  SimLambdaFunction,
-  SimLambdaFunctionMap,
-  SimLambdaFunctionName,
-} from "./function/sim-lambda-function.js";
-import type {
-  SimLambdaFunctionUrl,
-  SimLambdaFunctionUrlId,
-} from "./function/url/sim-lambda-function-url.js";
+import type { SimLambdaFunctionMap } from "./function/sim-lambda-function.js";
 import type * as simLambdaCommands from "./command/sim-lambda-command.types.js";
 import {
   SimLambdaCommands,
   type SimLambdaProperties,
 } from "./sim-lambda-commands.js";
+import { SimLambdaInspection } from "./sim-lambda-inspection.js";
 import { SimLambdaSdkCommandRouter } from "./sdk/sim-lambda-sdk-command-router.js";
 
 export interface SimLambdaRequestOptions {
@@ -30,10 +22,12 @@ export interface SimLambdaRequestOptions {
  * Each command below carries a one line doc comment rather than a block. This
  * file grows by one delegating method per simulated operation and is close to
  * the max-lines limit, which is the same reason `SimDynamoDb` reads that way.
+ * The simulator's own accessors are held apart in `SimLambdaInspection`, which
+ * this extends.
  */
-export class SimLambda {
-  private readonly functions: SimLambdaFunctionMap = new Map();
-  private readonly commands: SimLambdaCommands;
+export class SimLambda extends SimLambdaInspection {
+  protected readonly functions: SimLambdaFunctionMap = new Map();
+  protected readonly commands: SimLambdaCommands;
 
   private readonly cfnFactory = new SimLambdaCloudFormationResourceFactory(
     this,
@@ -42,6 +36,7 @@ export class SimLambda {
   private readonly sdkRouter = new SimLambdaSdkCommandRouter(this);
 
   constructor(properties: SimLambdaProperties = {}) {
+    super();
     this.commands = new SimLambdaCommands({
       ...properties,
       functions: this.functions,
@@ -246,39 +241,6 @@ export class SimLambda {
     options?: SimLambdaRequestOptions,
   ): Promise<simLambdaCommands.SimGetPolicyCommandOutput> {
     return await this.commands.permissions.getPolicy(command, options);
-  }
-
-  /** Get a simulated event source mapping by its UUID. */
-  getSimEventSourceMapping(
-    uuid: string,
-  ): SimLambdaEventSourceMapping | undefined {
-    return this.commands.eventSourceMappings.find(uuid);
-  }
-
-  /** Get a simulated Lambda function instance by name. */
-  getSimFunctionByName(
-    functionName: SimLambdaFunctionName | string,
-  ): SimLambdaFunction | undefined {
-    return this.functions.get(functionName as SimLambdaFunctionName);
-  }
-
-  /** Get a simulated Lambda function's Function URL, if it has one. */
-  getSimFunctionUrl(
-    functionName: SimLambdaFunctionName | string,
-  ): SimLambdaFunctionUrl | undefined {
-    return this.commands.functionUrlStore.get(functionName);
-  }
-
-  /**
-   * Get a simulated Lambda Function URL by the id in its hostname.
-   *
-   * This is how the localhost serving layer finds the Function URL a request
-   * was addressed to, once the registry has named the owning Account.
-   */
-  getSimFunctionUrlById(
-    urlId: SimLambdaFunctionUrlId,
-  ): SimLambdaFunctionUrl | undefined {
-    return this.commands.functionUrlStore.byUrlId(urlId);
   }
 
   /** Get this service's CloudFormation Resource factory. */

--- a/src/service/logs/README.md
+++ b/src/service/logs/README.md
@@ -141,6 +141,11 @@ permission fails the call rather than leaving a filter that drops every event in
 resource policy is then consulted again on every delivery, so a permission taken away afterwards
 stops delivery, which is what an account does.
 
+A destination ARN may carry a version or alias qualifier. `SimLogsSubscriptionFunctionArn` holds it
+beside the function name and `permittedSimLogsDestinationFunction` resolves it through
+`getSimFunctionTarget` at both of those points. The alias is what the delivery is authorized
+against, and the version behind it is what runs.
+
 Failures are kept rather than thrown. Real CloudWatch Logs tells nobody about a failed delivery,
 which would leave a test with a handler that mysteriously never ran, so every failure lands in
 `subscriptionFailures` for a test to read.

--- a/src/service/logs/subscription/lambda/sim-aws-logs-subscription-functions.ts
+++ b/src/service/logs/subscription/lambda/sim-aws-logs-subscription-functions.ts
@@ -53,7 +53,7 @@ export class SimAwsLogsSubscriptionFunctions implements SimLogsSubscriptionDesti
     // already inside the background task that stands for the asynchronous
     // delivery real CloudWatch Logs makes, and because a handler failure has
     // to reach the delivery outcome rather than being swallowed.
-    await this.permitted(destinationArn).invoke(
+    await this.permitted(destinationArn).simFunction.invoke(
       simLogsSubscriptionEventPayload(delivery),
     );
   }
@@ -67,8 +67,7 @@ export class SimAwsLogsSubscriptionFunctions implements SimLogsSubscriptionDesti
     );
 
     return permittedSimLogsDestinationFunction(
-      destinationArn,
-      arn.functionName,
+      arn,
       this.#simAws.accountRegionScope(arn.accountId, arn.regionName),
     );
   }

--- a/src/service/logs/subscription/lambda/sim-logs-destination-permission.ts
+++ b/src/service/logs/subscription/lambda/sim-logs-destination-permission.ts
@@ -1,8 +1,9 @@
 import type { SimAwsAccountRegionContainer } from "../../../aws/sim-aws-account-region-scope.js";
 import { SimLambdaServiceInvokeAuthorizer } from "../../../lambda/command/authorize/sim-lambda-service-invoke-authorizer.js";
-import type { SimLambdaFunction } from "../../../lambda/function/sim-lambda-function.js";
+import type { SimLambdaFunctionTarget } from "../../../lambda/function/version/sim-lambda-function-target.js";
 import { SimLogsDeliveryNotPermitted } from "../../error/sim-logs-delivery.error.js";
 import { SimLogsResourceNotFoundException } from "../../error/sim-logs.error.js";
+import type { SimLogsSubscriptionFunctionArn } from "./sim-logs-subscription-function-arn.js";
 
 /**
  * The service principal CloudWatch Logs invokes a destination function as.
@@ -19,27 +20,32 @@ export function simLogsServicePrincipal(regionName: string): string {
  * The destination function, refusing one that is missing or does not admit
  * CloudWatch Logs.
  *
- * The resource policy is consulted on every delivery rather than remembered
- * from when the filter was put, so a permission taken away afterwards stops
- * delivery, as it does in an account.
+ * The function and the resource policy are both resolved on every delivery
+ * rather than remembered from when the filter was put, so a permission taken
+ * away afterwards stops delivery, as it does in an account, and an alias moved
+ * to another version moves what runs.
  */
 export function permittedSimLogsDestinationFunction(
-  destinationArn: string,
-  functionName: string,
+  arn: SimLogsSubscriptionFunctionArn,
   scope: SimAwsAccountRegionContainer,
-): SimLambdaFunction {
-  const simFunction = scope.lambda().getSimFunctionByName(functionName);
+): SimLambdaFunctionTarget {
+  const destinationArn = arn.value;
+  const target = scope
+    .lambda()
+    .getSimFunctionTarget(arn.functionName, arn.qualifier);
 
-  if (simFunction === undefined) {
+  if (target === undefined) {
     throw new SimLogsResourceNotFoundException(
-      `${destinationArn} is not a simulated Lambda function.`,
+      arn.qualifier === undefined
+        ? `${destinationArn} is not a simulated Lambda function.`
+        : `${destinationArn} names no simulated Lambda function version or alias.`,
     );
   }
 
   const servicePrincipal = simLogsServicePrincipal(scope.region.regionName);
   const decision = new SimLambdaServiceInvokeAuthorizer({
     iam: scope.iam(),
-  }).authorize({ simFunction, servicePrincipal });
+  }).authorize({ resource: target.resource, servicePrincipal });
 
   if (decision.isDenied) {
     throw new SimLogsDeliveryNotPermitted(
@@ -50,5 +56,5 @@ export function permittedSimLogsDestinationFunction(
     );
   }
 
-  return simFunction;
+  return target;
 }

--- a/src/service/logs/subscription/lambda/sim-logs-qualified-destination.iso.test.ts
+++ b/src/service/logs/subscription/lambda/sim-logs-qualified-destination.iso.test.ts
@@ -1,0 +1,106 @@
+import {
+  CreateLogGroupCommand,
+  CreateLogStreamCommand,
+  PutLogEventsCommand,
+  PutSubscriptionFilterCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+  assertArrayEquals,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  simLambdaAliasedFunction,
+  simLambdaAllowAliasInvoke,
+} from "../../../../../test/lambda/alias-fixture.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simLogsServicePrincipal } from "./sim-logs-destination-permission.js";
+
+const logGroupName = "/aws/lambda/orders";
+const logStreamName = "2026/08/19/[$LATEST]abc";
+
+/**
+ * A simulation with a log group and a stream to write to.
+ */
+async function simAwsWithLogGroup(): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simAws
+    .logs()
+    .createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+  await simAws
+    .logs()
+    .createLogStream(
+      new CreateLogStreamCommand({ logGroupName, logStreamName }),
+    );
+
+  return simAws;
+}
+
+/**
+ * Subscribe a destination to everything the group receives.
+ */
+async function subscribe(
+  simAws: SimAws,
+  destinationArn: string,
+): Promise<void> {
+  await simAws.logs().putSubscriptionFilter(
+    new PutSubscriptionFilterCommand({
+      logGroupName,
+      filterName: "errors",
+      filterPattern: "",
+      destinationArn,
+    }),
+  );
+}
+
+describe("A CloudWatch Logs subscription filter delivering to a Lambda alias", () => {
+  it("delivers to the version the alias points at", async () => {
+    // Given a log group and a function whose alias admits CloudWatch Logs.
+    const simAws = await simAwsWithLogGroup();
+    const tracker = await simLambdaAliasedFunction(simAws, "error-tracker");
+    await simLambdaAllowAliasInvoke(
+      simAws,
+      "error-tracker",
+      simLogsServicePrincipal(simAws.defaultRegionName),
+    );
+
+    // When the alias is subscribed and a line is written.
+    await subscribe(simAws, tracker.aliasArn);
+    await simAws.logs().putLogEvents(
+      new PutLogEventsCommand({
+        logGroupName,
+        logStreamName,
+        logEvents: [{ timestamp: 1000, message: "order failed" }],
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the version behind the alias ran, rather than `$LATEST`.
+    assertArrayEquals(tracker.ranAs, [tracker.version]);
+  });
+
+  it("refuses a destination naming no version or alias", async () => {
+    // Given a log group and a function with an alias.
+    const simAws = await simAwsWithLogGroup();
+    const tracker = await simLambdaAliasedFunction(simAws, "error-tracker");
+    await simLambdaAllowAliasInvoke(
+      simAws,
+      "error-tracker",
+      simLogsServicePrincipal(simAws.defaultRegionName),
+    );
+
+    // When a filter names an alias the function does not have.
+    const error = await assertThrowsErrorAsync(async () => {
+      await subscribe(simAws, `${tracker.functionArn}:old`);
+    });
+
+    // Then it is refused where the filter is put, as a missing function is.
+    assertStringIncludes(
+      error.message,
+      "names no simulated Lambda function version or alias",
+    );
+  });
+});

--- a/src/service/logs/subscription/lambda/sim-logs-subscription-function-arn.ts
+++ b/src/service/logs/subscription/lambda/sim-logs-subscription-function-arn.ts
@@ -12,6 +12,7 @@ interface SimLogsSubscriptionFunctionArnProperties {
   readonly regionName: AwsRegionName;
   readonly accountId: SimAwsAccountId;
   readonly functionName: string;
+  readonly qualifier: string | undefined;
 }
 
 /**
@@ -26,11 +27,22 @@ export class SimLogsSubscriptionFunctionArn {
   readonly accountId: SimAwsAccountId;
   readonly functionName: string;
 
+  /**
+   * The version or alias the destination qualified the function with, if it
+   * named one.
+   *
+   * A filter whose destination is `orders:live` delivers to the version the
+   * alias points at, so the qualifier is held here and resolved when the
+   * filter is put and again on every delivery.
+   */
+  readonly qualifier: string | undefined;
+
   private constructor(properties: SimLogsSubscriptionFunctionArnProperties) {
     this.value = properties.value;
     this.regionName = properties.regionName;
     this.accountId = properties.accountId;
     this.functionName = properties.functionName;
+    this.qualifier = properties.qualifier;
   }
 
   /**
@@ -62,14 +74,6 @@ export class SimLogsSubscriptionFunctionArn {
       );
     }
 
-    if (parts.qualifier !== undefined) {
-      throw new SimLogsInvalidParameterException(
-        `${destinationArn} names a function version or alias, and simulated ` +
-          `Lambda has neither, so delivering to the unqualified function ` +
-          `instead would be delivering to a different one`,
-      );
-    }
-
     if (parts.accountId !== scope.accountId) {
       throw new SimLogsInvalidParameterException(
         `${destinationArn} is in Account ${parts.accountId}, and a Lambda ` +
@@ -92,6 +96,7 @@ export class SimLogsSubscriptionFunctionArn {
       regionName: parts.regionName,
       accountId: parts.accountId,
       functionName: parts.functionName,
+      qualifier: parts.qualifier,
     });
   }
 }

--- a/src/service/logs/subscription/sim-logs-subscription-filters.iso.test.ts
+++ b/src/service/logs/subscription/sim-logs-subscription-filters.iso.test.ts
@@ -255,11 +255,11 @@ describe("CloudWatch Logs subscription filters", () => {
     assertStringIncludes(noDestination.message, "destinationArn");
   });
 
-  it("refuses a destination naming a function version", async () => {
-    // Given a log group and a qualified function ARN.
+  it("refuses a destination naming no version or alias", async () => {
+    // Given a log group and a function nothing was published from.
     const simAws = await simAwsWithTrackers();
 
-    // When a filter is put on it.
+    // When a filter names a version of it.
     const error = await assertThrowsErrorAsync(
       async () =>
         await simAws.logs().putSubscriptionFilter(
@@ -272,10 +272,12 @@ describe("CloudWatch Logs subscription filters", () => {
         ),
     );
 
-    // Then it is refused, because simulated Lambda has no versions and
-    // delivering to the unqualified function would be a different one.
-    assertInstanceOf(error, SimLogsInvalidParameterException);
-    assertStringIncludes(error.message, "version or alias");
+    // Then it is refused where the filter is put, rather than delivering to
+    // the unqualified function, which would be a different one.
+    assertStringIncludes(
+      error.message,
+      "names no simulated Lambda function version or alias",
+    );
   });
 
   it("refuses a destination in another Account or Region", async () => {

--- a/src/service/s3/README.md
+++ b/src/service/s3/README.md
@@ -601,7 +601,11 @@ returned.
 
 `SimAwsS3NotificationFunctions` resolves and invokes the function. Whether S3 may invoke a function
 is Lambda's own rule, so the decision comes from `SimLambdaServiceInvokeAuthorizer` with the Bucket
-ARN and Account supplied as the source.
+ARN and Account supplied as the source. A destination ARN carrying a version or alias qualifier is
+resolved through `getSimFunctionTarget`, which answers with the resource the ARN named and the
+version behind it. The alias is what the delivery is authorized against and the version is what
+runs. A qualifier naming neither is refused where the configuration is applied, the way a missing
+function is.
 
 `SimAwsS3NotificationQueues` does the same for a queue, and splits in two: it applies the one rule
 that is S3's, that the queue is in the Bucket's Region, and hands the rest to

--- a/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-destination.iso.test.ts
+++ b/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-destination.iso.test.ts
@@ -142,14 +142,21 @@ describe("The destination a simulated S3 notification configuration names", () =
     assertStringIncludes(error.message, "not a simulated Lambda function");
   });
 
-  it("refuses a qualified function ARN", async () => {
-    // Given a Bucket
+  it("refuses a qualifier naming no version or alias", async () => {
+    // Given a Bucket and a function nothing was published from
     const simAws = new SimAws();
     await simAws
       .s3()
       .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "thumbnailer",
+        Role: "arn:aws:iam::888888888888:role/ThumbnailerRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "thumbnailed") },
+      }),
+    );
 
-    // When a configuration names a function version
+    // When a configuration names a version nothing published
     const error = await assertThrowsErrorAsync(async () =>
       simAws.s3().putBucketNotificationConfiguration(
         new PutBucketNotificationConfigurationCommand({
@@ -167,7 +174,10 @@ describe("The destination a simulated S3 notification configuration names", () =
     );
 
     // Then it is refused rather than read as the unqualified function
-    assertStringIncludes(error.message, "versions or aliases");
+    assertStringIncludes(
+      error.message,
+      "names no simulated Lambda function version or alias",
+    );
   });
 
   it("refuses a Lambda destination ARN naming another service", async () => {

--- a/src/service/s3/notification/destination/lambda/sim-aws-s3-notification-functions.ts
+++ b/src/service/s3/notification/destination/lambda/sim-aws-s3-notification-functions.ts
@@ -1,6 +1,6 @@
 import type { SimAws } from "../../../../aws/sim-aws.js";
 import { SimLambdaServiceInvokeAuthorizer } from "../../../../lambda/command/authorize/sim-lambda-service-invoke-authorizer.js";
-import type { SimLambdaFunction } from "../../../../lambda/function/sim-lambda-function.js";
+import type { SimLambdaFunctionTarget } from "../../../../lambda/function/version/sim-lambda-function-target.js";
 import type { SimIamInterServiceAuthZ } from "../../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import type { SimS3NotificationDestinationRequest } from "../sim-s3-notification-destination.js";
 import { simS3ServicePrincipal } from "../sim-s3-service-principal.js";
@@ -40,16 +40,16 @@ export class SimAwsS3NotificationFunctions implements SimS3NotificationFunctions
     request: SimS3NotificationDestinationRequest,
   ): string | undefined {
     const arn = SimS3NotificationFunctionArn.parse(request.destinationArn);
-    const simFunction = this.findFunction(arn);
+    const target = this.findTarget(arn);
 
-    if (simFunction === undefined) {
-      return `${request.destinationArn} is not a simulated Lambda function.`;
+    if (target === undefined) {
+      return missingFunctionRefusal(arn, request.destinationArn);
     }
 
     const decision = new SimLambdaServiceInvokeAuthorizer({
       iam: this.iam(arn),
     }).authorize({
-      simFunction,
+      resource: target.resource,
       servicePrincipal: simS3ServicePrincipal,
       sourceArn: request.bucketArn,
       sourceAccount: request.bucketOwnerAccountId,
@@ -80,22 +80,22 @@ export class SimAwsS3NotificationFunctions implements SimS3NotificationFunctions
     event: object,
   ): Promise<void> {
     const arn = SimS3NotificationFunctionArn.parse(request.destinationArn);
-    const simFunction = this.findFunction(arn);
+    const target = this.findTarget(arn);
 
     // oxlint-disable-next-line yulin/assert-defined-guard -- `assertDefined` is denser per line, and this file is close enough to the FTA threshold that the guard costs less kept as it is
-    if (simFunction === undefined) {
-      throw new Error(
-        `${request.destinationArn} is not a simulated Lambda function.`,
-      );
+    if (target === undefined) {
+      throw new Error(missingFunctionRefusal(arn, request.destinationArn));
     }
 
-    await simFunction.invoke(event);
+    await target.simFunction.invoke(event);
   }
 
-  private findFunction(
+  private findTarget(
     arn: SimS3NotificationFunctionArn,
-  ): SimLambdaFunction | undefined {
-    return this.scope(arn).lambda().getSimFunctionByName(arn.functionName);
+  ): SimLambdaFunctionTarget | undefined {
+    return this.scope(arn)
+      .lambda()
+      .getSimFunctionTarget(arn.functionName, arn.qualifier);
   }
 
   private iam(arn: SimS3NotificationFunctionArn): SimIamInterServiceAuthZ {
@@ -107,4 +107,19 @@ export class SimAwsS3NotificationFunctions implements SimS3NotificationFunctions
   ): ReturnType<SimAws["accountRegionScope"]> {
     return this.simAws.accountRegionScope(arn.accountId, arn.regionName);
   }
+}
+
+/**
+ * Why a destination ARN reaches nothing, for a Bucket to repeat back.
+ *
+ * A qualified ARN says so, since the function it names may well be there while
+ * the version or alias it asked for is not.
+ */
+function missingFunctionRefusal(
+  arn: SimS3NotificationFunctionArn,
+  destinationArn: string,
+): string {
+  return arn.qualifier === undefined
+    ? `${destinationArn} is not a simulated Lambda function.`
+    : `${destinationArn} names no simulated Lambda function version or alias.`;
 }

--- a/src/service/s3/notification/destination/lambda/sim-s3-notification-function-arn.ts
+++ b/src/service/s3/notification/destination/lambda/sim-s3-notification-function-arn.ts
@@ -1,10 +1,7 @@
 import type { SimAwsAccountId } from "../../../../aws/sim-aws-account.js";
 import type { AwsRegionName } from "../../../../aws/sim-aws-region.js";
 import { parseSimLambdaFunctionArn } from "../../../../lambda/function/sim-lambda-function-arn-parts.js";
-import {
-  SimS3InvalidArgument,
-  SimS3NotImplemented,
-} from "../../../error/sim-s3.error.js";
+import { SimS3InvalidArgument } from "../../../error/sim-s3.error.js";
 
 /**
  * The Lambda function ARN a notification configuration names.
@@ -18,22 +15,29 @@ export class SimS3NotificationFunctionArn {
   public readonly accountId: SimAwsAccountId;
   public readonly functionName: string;
 
+  /**
+   * The version or alias the ARN qualified the function with, if it named one.
+   *
+   * A qualified ARN notifies the version it names rather than the function, so
+   * the qualifier is held here and resolved when the notification is
+   * configured and again when an event is delivered.
+   */
+  public readonly qualifier: string | undefined;
+
   private constructor(
     regionName: AwsRegionName,
     accountId: SimAwsAccountId,
     functionName: string,
+    qualifier: string | undefined,
   ) {
     this.regionName = regionName;
     this.accountId = accountId;
     this.functionName = functionName;
+    this.qualifier = qualifier;
   }
 
   /**
    * Read a Lambda function ARN, refusing anything else.
-   *
-   * A qualified ARN naming a version or an alias is refused rather than being
-   * read as the unqualified function, because simulated Lambda has neither and
-   * silently notifying `$LATEST` instead would be the wrong function.
    */
   static parse(arn: string): SimS3NotificationFunctionArn {
     const parts = parseSimLambdaFunctionArn(arn);
@@ -42,18 +46,11 @@ export class SimS3NotificationFunctionArn {
       throw new SimS3InvalidArgument(`${arn} is not a Lambda function ARN.`);
     }
 
-    if (parts.qualifier !== undefined) {
-      throw new SimS3NotImplemented(
-        `Cannot notify ${arn}: simulated Lambda has no function versions or ` +
-          "aliases, so a qualified function ARN is refused rather than " +
-          "treated as the unqualified function.",
-      );
-    }
-
     return new SimS3NotificationFunctionArn(
       parts.regionName,
       parts.accountId,
       parts.functionName,
+      parts.qualifier,
     );
   }
 }

--- a/src/service/s3/notification/destination/lambda/sim-s3-qualified-notification.iso.test.ts
+++ b/src/service/s3/notification/destination/lambda/sim-s3-qualified-notification.iso.test.ts
@@ -1,0 +1,124 @@
+import {
+  CreateBucketCommand,
+  PutBucketNotificationConfigurationCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertArrayEquals,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  simLambdaAliasedFunction,
+  simLambdaAllowAliasInvoke,
+} from "../../../../../../test/lambda/alias-fixture.js";
+import { SimAws } from "../../../../aws/sim-aws.js";
+import { simS3ServicePrincipal } from "../sim-s3-service-principal.js";
+
+const bucketArn = "arn:aws:s3:::uploads";
+
+/**
+ * A simulation with a Bucket to notify from.
+ */
+async function simAwsWithBucket(): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simAws
+    .s3()
+    .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+  return simAws;
+}
+
+/**
+ * Configure the Bucket to notify a destination on object creation.
+ */
+async function notifyOnUpload(
+  simAws: SimAws,
+  destinationArn: string,
+): Promise<void> {
+  await simAws.s3().putBucketNotificationConfiguration(
+    new PutBucketNotificationConfigurationCommand({
+      Bucket: "uploads",
+      NotificationConfiguration: {
+        LambdaFunctionConfigurations: [
+          {
+            Id: "thumbnails",
+            Events: ["s3:ObjectCreated:*"],
+            LambdaFunctionArn: destinationArn,
+          },
+        ],
+      },
+    }),
+  );
+}
+
+describe("A simulated S3 notification to a Lambda alias", () => {
+  it("invokes the version the alias points at", async () => {
+    // Given a Bucket and a function with an alias admitting S3.
+    const simAws = await simAwsWithBucket();
+    const thumbnailer = await simLambdaAliasedFunction(simAws, "thumbnailer");
+    await simLambdaAllowAliasInvoke(
+      simAws,
+      "thumbnailer",
+      simS3ServicePrincipal,
+      bucketArn,
+    );
+
+    // When the Bucket notifies the alias and an object is uploaded.
+    await notifyOnUpload(simAws, thumbnailer.aliasArn);
+    await simAws
+      .s3()
+      .putObject(
+        new PutObjectCommand({ Bucket: "uploads", Key: "one.png", Body: "x" }),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // Then the version behind the alias ran, rather than `$LATEST`.
+    assertArrayEquals(thumbnailer.ranAs, [thumbnailer.version]);
+  });
+
+  it("refuses a qualifier naming no version or alias", async () => {
+    // Given a Bucket and a function with an alias.
+    const simAws = await simAwsWithBucket();
+    const thumbnailer = await simLambdaAliasedFunction(simAws, "thumbnailer");
+
+    // When the configuration names an alias the function does not have.
+    const error = await assertThrowsErrorAsync(async () => {
+      await notifyOnUpload(simAws, `${thumbnailer.functionArn}:old`);
+    });
+
+    // Then it is refused where the notification is configured.
+    assertStringIncludes(
+      error.message,
+      "names no simulated Lambda function version or alias",
+    );
+  });
+
+  it("does not deliver to an alias its grant does not cover", async () => {
+    // Given a Bucket and a function granting S3 the invoke action on the
+    // function itself rather than on the alias.
+    const simAws = await simAwsWithBucket();
+    const thumbnailer = await simLambdaAliasedFunction(simAws, "thumbnailer");
+    await simAws.lambda().addPermission({
+      input: {
+        FunctionName: "thumbnailer",
+        StatementId: "AllowS3",
+        Action: "lambda:InvokeFunction",
+        Principal: simS3ServicePrincipal,
+        SourceArn: bucketArn,
+      },
+    });
+
+    // When the configuration names the alias.
+    const error = await assertThrowsErrorAsync(async () => {
+      await notifyOnUpload(simAws, thumbnailer.aliasArn);
+    });
+
+    // Then the grant on the function says nothing about the alias, the same
+    // way it does for an Invoke through one.
+    assertStringIncludes(error.message, "does not allow s3.amazonaws.com");
+  });
+});

--- a/src/service/sns/README.md
+++ b/src/service/sns/README.md
@@ -65,9 +65,10 @@ protocol's question, answered by `requireSimSnsSubscriptionEndpoint`: `SimSnsQue
 `sqs`, `SimSnsFunctionEndpointArn` for `lambda`, and `SimSnsPhoneNumber` for `sms`. The Account and
 the Region are optional on the endpoint, since an `sms` endpoint is a phone number. Reading a function
 ARN is Lambda's own business, so those parts come from `parseSimLambdaFunctionArn`; what SNS adds is
-what an unreadable one means to a `Subscribe` request. A qualified function ARN naming a version or
-an alias is refused, since simulated Lambda has neither and delivering to `$LATEST` instead would be
-the wrong function.
+what an unreadable one means to a `Subscribe` request. A qualifier naming a version or an alias is
+held alongside the function name, and `SimSnsDeliveryFunction` resolves it against simulated Lambda
+on every delivery. The alias is what the delivery is authorized against, and the version behind it
+is what runs.
 
 Nothing checks that the endpoint queue or function exists when a subscription is created, because
 real SNS does not either: a subscription to something that is not there is created, and fails when

--- a/src/service/sns/delivery/lambda/sim-sns-delivery-function.ts
+++ b/src/service/sns/delivery/lambda/sim-sns-delivery-function.ts
@@ -35,32 +35,37 @@ export class SimSnsDeliveryFunction {
   /**
    * Invoke the function with the event, if it still admits SNS for this topic.
    *
-   * The resource policy is consulted on every delivery rather than remembered
-   * from the moment the subscription was made, so a permission taken away
-   * afterwards stops delivery. Real SNS does not check it at `Subscribe` time
-   * at all, which is why this is the only place it is asked.
+   * The function, and the version or alias a qualified endpoint named, are
+   * resolved on every delivery, along with the resource policy, so a
+   * permission taken away afterwards stops delivery and an alias moved to
+   * another version moves what runs. Real SNS checks none of it at
+   * `Subscribe` time, which is why this is the only place it is asked.
    */
   async deliver(request: SimSnsDeliveryRequest): Promise<void> {
     const source = simSnsDeliverySource(request);
     const endpointArn = request.subscription.endpoint.value;
-    const simFunction = this.scope
+    const target = this.scope
       .lambda()
-      .getSimFunctionByName(this.arn.functionName);
+      .getSimFunctionTarget(this.arn.functionName, this.arn.qualifier);
 
-    if (simFunction === undefined) {
+    if (target === undefined) {
       // Not a refusal: the resource policy said nothing, because there is no
       // function. A subscription pointing at nothing is a mistake worth
       // warning about, where a policy saying no is a modelled outcome a test
-      // may be asking for on purpose.
+      // may be asking for on purpose. A qualified endpoint reaches here for a
+      // version or alias that is not there as well.
       throw new SimSnsNotFoundException(
-        `${endpointArn} is not a simulated Lambda function.`,
+        this.arn.qualifier === undefined
+          ? `${endpointArn} is not a simulated Lambda function.`
+          : `${endpointArn} names no simulated Lambda function version or ` +
+              "alias.",
       );
     }
 
     const decision = new SimLambdaServiceInvokeAuthorizer({
       iam: this.scope.iam(),
     }).authorize({
-      simFunction,
+      resource: target.resource,
       servicePrincipal: simSnsServicePrincipal,
       ...source,
     });
@@ -78,6 +83,6 @@ export class SimSnsDeliveryFunction {
     // asynchronous invocation real SNS makes, and because a handler failure
     // has to reach the delivery outcome rather than being swallowed as an
     // asynchronous invocation error.
-    await simFunction.invoke(simSnsLambdaEventDocument(request));
+    await target.simFunction.invoke(simSnsLambdaEventDocument(request));
   }
 }

--- a/src/service/sns/delivery/lambda/sim-sns-qualified-delivery.iso.test.ts
+++ b/src/service/sns/delivery/lambda/sim-sns-qualified-delivery.iso.test.ts
@@ -1,0 +1,80 @@
+import { PublishCommand } from "@aws-sdk/client-sns";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertNonNullable,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  simLambdaAliasedFunction,
+  simLambdaAllowAliasInvoke,
+} from "../../../../../test/lambda/alias-fixture.js";
+import { subscribeFunction } from "../../../../../test/sns/function-fixture.js";
+import { simAwsWithTopic } from "../../../../../test/sns/topic-fixture.js";
+import type { SimAws } from "../../../aws/sim-aws.js";
+import { simSnsServicePrincipal } from "../sim-sns-delivery.js";
+
+/**
+ * Publish one message and wait for whatever delivery it caused.
+ */
+async function publishOrder(simAws: SimAws, topicArn: string): Promise<void> {
+  await simAws
+    .sns()
+    .publish(new PublishCommand({ TopicArn: topicArn, Message: "order-1" }));
+
+  await simAws.backgroundTasksComplete();
+}
+
+describe("SNS delivery to a Lambda alias", () => {
+  it("delivers to the version the alias points at", async () => {
+    // Given a topic and a function whose alias admits SNS for it.
+    const { simAws, topicArn } = await simAwsWithTopic();
+    const consumer = await simLambdaAliasedFunction(simAws, "order-consumer");
+    await simLambdaAllowAliasInvoke(
+      simAws,
+      "order-consumer",
+      simSnsServicePrincipal,
+      topicArn,
+    );
+    await subscribeFunction(simAws, topicArn, consumer.aliasArn);
+
+    // When a message is published.
+    await publishOrder(simAws, topicArn);
+
+    // Then the version behind the alias ran, rather than `$LATEST`.
+    assertArrayEquals(consumer.ranAs, [consumer.version]);
+    assertArrayLength(simAws.sns().deliveryFailures, 0);
+  });
+
+  it("reports an endpoint naming no version or alias", async () => {
+    // Given a topic and a function subscribed by an alias it does not have.
+    const { simAws, topicArn } = await simAwsWithTopic();
+    const consumer = await simLambdaAliasedFunction(simAws, "order-consumer");
+    await simLambdaAllowAliasInvoke(
+      simAws,
+      "order-consumer",
+      simSnsServicePrincipal,
+      topicArn,
+    );
+    await subscribeFunction(simAws, topicArn, `${consumer.functionArn}:old`);
+
+    // When a message is published.
+    await publishOrder(simAws, topicArn);
+
+    // Then nothing ran, and the failure says the qualifier reaches nothing.
+    // Real SNS checks no endpoint at `Subscribe` time, so this is where a
+    // subscription pointing at nothing is found, as it is for a function that
+    // is not there.
+    assertArrayLength(consumer.ranAs, 0);
+
+    const [failure] = simAws.sns().deliveryFailures;
+
+    assertNonNullable(failure);
+    assertStringIncludes(
+      failure.reason,
+      "names no simulated Lambda function version or alias",
+    );
+  });
+});

--- a/src/service/sns/subscription/sim-sns-function-endpoint-arn.iso.test.ts
+++ b/src/service/sns/subscription/sim-sns-function-endpoint-arn.iso.test.ts
@@ -1,6 +1,13 @@
-import { assertInstanceOf, assertStringIncludes } from "@kensio/smartass";
+import { GetSubscriptionAttributesCommand } from "@aws-sdk/client-sns";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+} from "@kensio/smartass";
 import { describe, it } from "vitest";
+import { subscribeFunction } from "../../../../test/sns/function-fixture.js";
 import { subscribeRefusal } from "../../../../test/sns/subscription-fixture.js";
+import { simAwsWithTopic } from "../../../../test/sns/topic-fixture.js";
 import { SimSnsInvalidParameterException } from "../error/sim-sns.error.js";
 
 /**
@@ -45,15 +52,28 @@ describe("The endpoint of a lambda subscription", () => {
     }
   });
 
-  it("refuses a qualified function ARN naming a version or an alias", async () => {
+  it("takes a qualified function ARN naming a version or an alias", async () => {
     // Given a topic.
+    const { simAws, topicArn } = await simAwsWithTopic();
+
     // When a function alias is subscribed.
-    const error = await functionEndpointRefusal(
+    const subscriptionArn = await subscribeFunction(
+      simAws,
+      topicArn,
       "arn:aws:lambda:us-east-1:888888888888:function:orders:PROD",
     );
 
-    // Then it is refused rather than quietly subscribing the unqualified
-    // function, which would be a different function from the one asked for.
-    assertStringIncludes(error.message, "no function versions or aliases");
+    // Then the alias is the endpoint, and the qualifier is kept rather than
+    // read off to leave the unqualified function subscribed.
+    const attributes = await simAws.sns().getSubscriptionAttributes(
+      new GetSubscriptionAttributesCommand({
+        SubscriptionArn: subscriptionArn,
+      }),
+    );
+
+    assertIdentical(
+      attributes.Attributes?.["Endpoint"],
+      "arn:aws:lambda:us-east-1:888888888888:function:orders:PROD",
+    );
   });
 });

--- a/src/service/sns/subscription/sim-sns-function-endpoint-arn.ts
+++ b/src/service/sns/subscription/sim-sns-function-endpoint-arn.ts
@@ -1,16 +1,14 @@
 import type { SimAwsAccountId } from "../../aws/sim-aws-account-id.js";
 import type { AwsRegionName } from "../../aws/sim-aws-region.js";
 import { parseSimLambdaFunctionArn } from "../../lambda/function/sim-lambda-function-arn-parts.js";
-import {
-  SimSnsInvalidParameterException,
-  SimSnsUnsimulatedInputException,
-} from "../error/sim-sns.error.js";
+import { SimSnsInvalidParameterException } from "../error/sim-sns.error.js";
 
 interface SimSnsFunctionEndpointArnProperties {
   readonly value: string;
   readonly regionName: AwsRegionName;
   readonly accountId: SimAwsAccountId;
   readonly functionName: string;
+  readonly qualifier: string | undefined;
 }
 
 /**
@@ -27,11 +25,21 @@ export class SimSnsFunctionEndpointArn {
   public readonly accountId: SimAwsAccountId;
   public readonly functionName: string;
 
+  /**
+   * The version or alias the endpoint qualified the function with, if it named
+   * one.
+   *
+   * A subscription to `orders:live` delivers to the version the alias points
+   * at, so the qualifier is held here and resolved on every delivery.
+   */
+  public readonly qualifier: string | undefined;
+
   private constructor(properties: SimSnsFunctionEndpointArnProperties) {
     this.value = properties.value;
     this.regionName = properties.regionName;
     this.accountId = properties.accountId;
     this.functionName = properties.functionName;
+    this.qualifier = properties.qualifier;
   }
 
   /**
@@ -41,10 +49,6 @@ export class SimSnsFunctionEndpointArn {
    * What SNS adds is what an unreadable one means to a `Subscribe` request,
    * which is the same `InvalidParameterException` a queue ARN that is not one
    * gets.
-   *
-   * A qualified ARN naming a version or an alias is refused rather than read as
-   * the unqualified function, because simulated Lambda has neither and
-   * delivering to `$LATEST` instead would be the wrong function.
    */
   static parse(endpoint: string): SimSnsFunctionEndpointArn {
     const parts = parseSimLambdaFunctionArn(endpoint);
@@ -57,19 +61,12 @@ export class SimSnsFunctionEndpointArn {
       );
     }
 
-    if (parts.qualifier !== undefined) {
-      throw new SimSnsUnsimulatedInputException(
-        `Cannot subscribe ${endpoint}: simulated Lambda has no function ` +
-          "versions or aliases, so a qualified function ARN is refused rather " +
-          "than treated as the unqualified function.",
-      );
-    }
-
     return new this({
       value: endpoint,
       regionName: parts.regionName,
       accountId: parts.accountId,
       functionName: parts.functionName,
+      qualifier: parts.qualifier,
     });
   }
 }

--- a/test/lambda/alias-fixture.ts
+++ b/test/lambda/alias-fixture.ts
@@ -1,0 +1,153 @@
+/**
+ * A function with a published version behind an alias, which every test of a
+ * service delivering to a qualified function ARN needs before it can say which
+ * version ran.
+ *
+ * This lives under `test/` for the same reason as the other fixtures here:
+ * eslint rejects a test file that exports helpers alongside its own `describe`
+ * calls, and `test/**` is type-checked with everything else, excluded from the
+ * published build, not collected as a suite, and not counted in coverage.
+ */
+
+import {
+  AddPermissionCommand,
+  CreateAliasCommand,
+  CreateFunctionCommand,
+  PublishVersionCommand,
+} from "@aws-sdk/client-lambda";
+import { assertNonNullable } from "@kensio/smartass";
+
+import type { SimAws } from "../../src/service/aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../src/service/lambda/function/code/lambda-zip-file-input.js";
+
+/** The alias every one of these tests points its target at. */
+export const simLambdaLiveAlias = "live";
+
+/**
+ * A function, the version behind its alias, and what each invocation ran as.
+ */
+export interface SimLambdaAliasedFunction {
+  /** The unqualified ARN of the function itself. */
+  readonly functionArn: string;
+
+  /** The ARN of the alias, which is what a qualified target names. */
+  readonly aliasArn: string;
+
+  /** The version number the alias points at. */
+  readonly version: string;
+
+  /**
+   * The version each invocation ran as, in invocation order.
+   *
+   * This is what tells an invocation of the alias apart from one of `$LATEST`,
+   * since a published version is a copy of the function and behaves the same
+   * way in every other respect.
+   */
+  readonly ranAs: string[];
+
+  /** The event each invocation was handed, in invocation order. */
+  readonly events: unknown[];
+}
+
+interface SimLambdaAliasedFunctionOptions {
+  readonly roleArn?: string;
+
+  /**
+   * What the handler answers with, for a caller that reads the result.
+   *
+   * A Cognito trigger reads it and goes on with what it was handed, where an
+   * event notification drops it, so it is given the event rather than being a
+   * value.
+   */
+  readonly result?: (event: unknown) => unknown;
+}
+
+/**
+ * Create a function, publish a version of it, and point an alias at that
+ * version.
+ *
+ * The handler records the version it ran as, so a test asserts on which
+ * version a delivery reached rather than on the delivery having happened at
+ * all.
+ */
+export async function simLambdaAliasedFunction(
+  simAws: SimAws,
+  functionName: string,
+  options: SimLambdaAliasedFunctionOptions = {},
+): Promise<SimLambdaAliasedFunction> {
+  const ranAs: string[] = [];
+  const events: unknown[] = [];
+  const lambda = simAws.lambda();
+
+  await lambda.createFunction(
+    new CreateFunctionCommand({
+      FunctionName: functionName,
+      Role:
+        options.roleArn ??
+        `arn:aws:iam::${simAws.defaultAccountId}:role/${functionName}Role`,
+      Code: {
+        ZipFile: makeLambdaZipFileInput((event, context) => {
+          ranAs.push(context.functionVersion);
+          events.push(event);
+
+          return options.result === undefined
+            ? "handled"
+            : options.result(event);
+        }),
+      },
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+
+  const published = await lambda.publishVersion(
+    new PublishVersionCommand({ FunctionName: functionName }),
+  );
+
+  assertNonNullable(
+    published.Version,
+    "PublishVersion answered with a version",
+  );
+
+  await lambda.createAlias(
+    new CreateAliasCommand({
+      FunctionName: functionName,
+      Name: simLambdaLiveAlias,
+      FunctionVersion: published.Version,
+    }),
+  );
+
+  const functionArn = `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:${functionName}`;
+
+  return {
+    functionArn,
+    aliasArn: `${functionArn}:${simLambdaLiveAlias}`,
+    version: published.Version,
+    ranAs,
+    events,
+  };
+}
+
+/**
+ * Grant a service principal the invoke action on the alias alone.
+ *
+ * The grant is made with a `Qualifier`, so it is held against the alias rather
+ * than against the function, which is what makes it the grant a delivery
+ * through the alias needs.
+ */
+export async function simLambdaAllowAliasInvoke(
+  simAws: SimAws,
+  functionName: string,
+  servicePrincipal: string,
+  sourceArn?: string,
+): Promise<void> {
+  await simAws.lambda().addPermission(
+    new AddPermissionCommand({
+      FunctionName: functionName,
+      Qualifier: simLambdaLiveAlias,
+      StatementId: "AllowService",
+      Action: "lambda:InvokeFunction",
+      Principal: servicePrincipal,
+      ...(sourceArn !== undefined && { SourceArn: sourceArn }),
+    }),
+  );
+}


### PR DESCRIPTION
S3 notifications, SNS subscriptions, CloudWatch Logs subscription filters, Cognito user pool triggers, EventBridge rule targets and event source mappings all take a function ARN carrying a version number or an alias name, and deliver to the version that qualifier names. Each holds the qualifier beside the function name and resolves it through one lookup that answers with the resource the target named and the version behind it, so a grant made on an alias admits the delivery and moving the alias moves what runs. A qualifier naming no version and no alias is refused wherever that service already checks the function, which is when the target is configured for S3, CloudWatch Logs and event source mappings, and when the delivery is made for the other three, where the function itself goes unchecked until then and a template is free to deploy the two in either order.

Resolves #761