### PR TITLE
feat: expand SAM schedule and event rule events

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -1982,9 +1982,9 @@ its own `Role` runs as that role, and gets no expanded one.
 
 ### Function events
 
-`Events` on a SAM function expand into whatever puts the function behind them. `HttpApi` is the type
-this covers. An event of any other type is left where it is, and the function deploys with nothing in
-front of it.
+`Events` on a SAM function expand into whatever puts the function behind them. `HttpApi`,
+`Schedule`, `ScheduleV2` and `EventBridgeRule` are the types this covers. An event of any other type
+is left where it is, and the function deploys with nothing in front of it.
 
 An `HttpApi` event becomes an `AWS::ApiGatewayV2::Integration`, an `AWS::ApiGatewayV2::Route` and the
 `AWS::Lambda::Permission` the API invokes the function under. `Path` and `Method` become the route
@@ -2057,6 +2057,77 @@ await srv.close();
 ```
 
 `Auth` on the event is left out. Every request matching the expanded route reaches the function.
+
+A `Schedule` event becomes an `AWS::Events::Rule` on a timer, with the `AWS::Lambda::Permission` the
+rule invokes the function under. The event's `Schedule` is the rule's `ScheduleExpression`, and the
+function runs as a test advances simulated time past a due instant. An `EventBridgeRule` event
+becomes the same pair, with the event's `Pattern` as the rule's `EventPattern`. A matching event put
+on the bus invokes the function. Both events take `Name` (an `EventBridgeRule` event calls it
+`RuleName`), `Description`, `Input` and `Enabled`, and an event naming an `EventBusName` watches
+that bus.
+
+```typescript sim-cloudformation-sam-schedule-event
+/**
+ * A SAM function put on a timer by its Schedule event.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const runs: string[] = [];
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "reconciliation-stack",
+  template: {
+    Transform: "AWS::Serverless-2016-10-31",
+    Resources: {
+      Reconcile: {
+        Type: "AWS::Serverless::Function",
+        Properties: {
+          Handler: "index.handler",
+          Runtime: "nodejs22.x",
+          Events: {
+            Hourly: {
+              Type: "Schedule",
+              Properties: {
+                Schedule: "rate(1 hour)",
+                Input: JSON.stringify({ ledger: "rates" }),
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  bindings: [
+    {
+      logicalId: "Reconcile",
+      handler: (event: { ledger: string }): string => {
+        runs.push(event.ledger);
+
+        return "reconciled";
+      },
+    },
+  ],
+});
+
+await stack.waitForDeployComplete();
+
+await simAws.clock().advanceBy({ hours: 3 });
+
+console.log(runs);
+```
+
+A `ScheduleV2` event becomes an `AWS::Scheduler::Schedule` and the `AWS::IAM::Role` Scheduler assumes
+to invoke the function. The role trusts `scheduler.amazonaws.com` and may invoke the one function the
+event was declared on. An event naming a `RoleArn` runs as that role, and the expansion makes no role
+of its own. `Name`, `Description`, `Input`, `Enabled`, `GroupName`, `StartDate`, `EndDate`,
+`ScheduleExpressionTimezone`, `KmsKeyArn` and `FlexibleTimeWindow` carry over. An event stating no
+time window gets `OFF`.
+
+`DeadLetterConfig` and `RetryPolicy` on these three events are left out. A delivery is attempted
+once, and a failed one is recorded by the rule or the schedule that made it.
 
 A `FunctionUrlConfig` on the function expands into an `AWS::Lambda::Url` named after it, `RatesUrl`
 for a function called `Rates`. `AuthType` and `InvokeMode` carry over. `Cors` is left out (the
@@ -2722,6 +2793,9 @@ Sim CloudFormation currently supports:
   `Globals.Function` and `Globals.HttpApi` defaults applied
 - The `HttpApi` event of a SAM function, expanded into the API, integration, route, stage and invoke
   permission that serve it, and `FunctionUrlConfig`, expanded into a Function URL
+- The `Schedule`, `ScheduleV2` and `EventBridgeRule` events of a SAM function, expanded into the
+  EventBridge rule or Scheduler schedule that fires the function, and the permission or execution
+  Role the invocation is authorized by
 
 The resource types it creates are:
 
@@ -2823,9 +2897,11 @@ Each service's own docs describe what its resource types support.
 - The `Condition` attribute is read on resources but not on outputs. An output carrying one is
   resolved and present in `stack.outputs` whichever way its condition falls, where real
   CloudFormation would leave it out.
-- The SAM transform is expanded for `AWS::Serverless::Function` alone. Every other
-  `AWS::Serverless::*` resource type is recorded as unsupported. `HttpApi` is the only event type
-  expanded, so a SAM `Api`, schedule or queue trigger creates nothing. `Auth` on an `HttpApi` event
+- The SAM transform is expanded for `AWS::Serverless::Function`, `AWS::Serverless::SimpleTable` and
+  `AWS::Serverless::HttpApi`. Every other `AWS::Serverless::*` resource type is recorded as
+  unsupported. `HttpApi`, `Schedule`, `ScheduleV2` and `EventBridgeRule` are the event types
+  expanded. An event of another type, such as `Api` or `SQS`, creates nothing. `Auth` on an
+  `HttpApi` event
   and on the implicit API it shares is left out. `AutoPublishAlias` and `DeploymentPreference` are
   left out too, because the simulator has one version of a function and nothing to shift traffic
   between.

--- a/docs/services/cloudformation/sim-cloudformation-sam-schedule-event.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-sam-schedule-event.example.ts
@@ -1,0 +1,50 @@
+/**
+ * A SAM function put on a timer by its Schedule event.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const runs: string[] = [];
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "reconciliation-stack",
+  template: {
+    Transform: "AWS::Serverless-2016-10-31",
+    Resources: {
+      Reconcile: {
+        Type: "AWS::Serverless::Function",
+        Properties: {
+          Handler: "index.handler",
+          Runtime: "nodejs22.x",
+          Events: {
+            Hourly: {
+              Type: "Schedule",
+              Properties: {
+                Schedule: "rate(1 hour)",
+                Input: JSON.stringify({ ledger: "rates" }),
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  bindings: [
+    {
+      logicalId: "Reconcile",
+      handler: (event: { ledger: string }): string => {
+        runs.push(event.ledger);
+
+        return "reconciled";
+      },
+    },
+  ],
+});
+
+await stack.waitForDeployComplete();
+
+await simAws.clock().advanceBy({ hours: 3 });
+
+console.log(runs);

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-event-bridge-rule-event.iso.test.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-event-bridge-rule-event.iso.test.ts
@@ -1,0 +1,203 @@
+import { PutEventsCommand } from "@aws-sdk/client-eventbridge";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../aws/sim-aws.js";
+import type { SimEventRule } from "../../../../eventbridge/rule/sim-event-rule.js";
+import type { SimCfnStack } from "../../../stack/sim-cfn-stack.js";
+import type { SimCfnTemplateValueRecord } from "../../../template/value/sim-cfn-template-value.js";
+import {
+  samFunctionTemplateLogicalId,
+  simCfnSamFunctionTemplateFactory,
+} from "../sim-cfn-sam-function-template.factory.js";
+
+const ratePattern = { source: ["rates.service"] };
+
+/**
+ * Deploy a SAM function whose `Events` are what the test is about, with a
+ * handler recording everything the function is invoked with.
+ */
+async function deployMatching(properties: {
+  readonly simAws: SimAws;
+  readonly events: SimCfnTemplateValueRecord;
+  readonly resources?: SimCfnTemplateValueRecord;
+  readonly received: unknown[];
+}): Promise<SimCfnStack> {
+  const stack = await properties.simAws.cloudFormation().deployTemplate({
+    stackName: "rates-stack",
+    template: simCfnSamFunctionTemplateFactory.make({
+      functionProperties: { Events: properties.events },
+      resources: properties.resources ?? {},
+    }),
+    bindings: [
+      {
+        logicalId: samFunctionTemplateLogicalId,
+        handler: (event: unknown): string => {
+          properties.received.push(event);
+
+          return "published";
+        },
+      },
+    ],
+  });
+
+  await stack.waitForDeployComplete();
+
+  return stack;
+}
+
+/**
+ * Put one rate event, on the default bus unless told otherwise, and wait for
+ * what it caused.
+ */
+async function putRate(simAws: SimAws, busName?: string): Promise<void> {
+  await simAws.eventBridge().putEvents(
+    new PutEventsCommand({
+      Entries: [
+        {
+          Source: "rates.service",
+          DetailType: "RatePublished",
+          Detail: JSON.stringify({ currency: "GBP" }),
+          EventBusName: busName,
+        },
+      ],
+    }),
+  );
+
+  await simAws.backgroundTasksComplete();
+}
+
+describe("SAM EventBridgeRule event expansion", () => {
+  it("invokes the bound handler for an event the pattern matches", async () => {
+    // Given a SAM function with an EventBridgeRule event stating a pattern
+    const simAws = new SimAws();
+    const received: unknown[] = [];
+
+    const stack = await deployMatching({
+      simAws,
+      events: {
+        Published: {
+          Type: "EventBridgeRule",
+          Properties: { Pattern: ratePattern },
+        },
+      },
+      received,
+    });
+
+    // When a matching event is put, and then one the pattern does not match
+    await putRate(simAws);
+
+    await simAws.eventBridge().putEvents(
+      new PutEventsCommand({
+        Entries: [
+          {
+            Source: "orders.service",
+            DetailType: "OrderPlaced",
+            Detail: JSON.stringify({ orderId: "order-1" }),
+          },
+        ],
+      }),
+    );
+
+    await simAws.backgroundTasksComplete();
+
+    // Then only the matching event reached the function, so the rule carries
+    // the pattern and the permission it was expanded with admitted the rule
+    assertArrayLength(stack.skippedResources, 0);
+    assertArrayLength(received, 1);
+  });
+
+  it("names the rule what the event called it", async () => {
+    // Given an EventBridgeRule event stating a rule name and a state
+    const simAws = new SimAws();
+    const received: unknown[] = [];
+
+    // When it is deployed
+    const stack = await deployMatching({
+      simAws,
+      events: {
+        Published: {
+          Type: "EventBridgeRule",
+          Properties: {
+            Pattern: ratePattern,
+            RuleName: "published-rates",
+            State: "DISABLED",
+          },
+        },
+      },
+      received,
+    });
+
+    // Then the rule carries the name and state the event stated, and a
+    // matching event reaches nothing
+    const rule = stack.getResource("RatesPublishedRule")
+      ?.simResource as SimEventRule;
+
+    assertNonNullable(rule);
+    assertIdentical(rule.name.value, "published-rates");
+    assertIdentical(rule.state.value, "DISABLED");
+
+    await putRate(simAws);
+
+    assertArrayLength(received, 0);
+  });
+
+  it("watches the bus the event named rather than the default one", async () => {
+    // Given an event naming a bus the template declares beside the function
+    const simAws = new SimAws();
+    const received: unknown[] = [];
+
+    await deployMatching({
+      simAws,
+      events: {
+        Published: {
+          Type: "EventBridgeRule",
+          Properties: {
+            Pattern: ratePattern,
+            EventBusName: { Ref: "RatesBus" },
+          },
+        },
+      },
+      resources: {
+        RatesBus: {
+          Type: "AWS::Events::EventBus",
+          Properties: { Name: "rates" },
+        },
+      },
+      received,
+    });
+
+    // When a matching event is put on the default bus, and then on that bus
+    await putRate(simAws);
+
+    assertArrayLength(received, 0);
+
+    await putRate(simAws, "rates");
+
+    // Then only the event on the named bus reached the function
+    assertArrayLength(received, 1);
+  });
+
+  it("refuses an event stating no pattern rather than guessing one", async () => {
+    // Given an EventBridgeRule event that never said what to match
+    const simAws = new SimAws();
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployMatching({
+        simAws,
+        events: { Published: { Type: "EventBridgeRule", Properties: {} } },
+        received: [],
+      });
+    });
+
+    // Then the deployment failed naming the rule the event expanded into,
+    // rather than invoking the function for events it never asked for
+    assertStringIncludes(error.message, "RatesPublishedRule");
+  });
+});

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-event-bridge-rule-event.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-event-bridge-rule-event.ts
@@ -1,0 +1,26 @@
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import { samEventRuleResources } from "./sim-cfn-sam-event-rule.js";
+import type { SamFunctionEvent } from "./sim-cfn-sam-function-events.js";
+
+/**
+ * Expand one `EventBridgeRule` event into the rule that invokes the function
+ * for a matching event.
+ *
+ * The event's `Pattern` is the rule's `EventPattern`, and an event naming an
+ * `EventBusName` watches that bus rather than the default one. A pattern the
+ * rule cannot parse is refused by the rule rather than being read here.
+ *
+ * An event stating no `Pattern` expands into a rule matching nothing, which
+ * the rule then refuses. A pattern guessed for an event that named none would
+ * be a function invoked for events it never asked for.
+ */
+export function samEventBridgeRuleEventResources(
+  event: SamFunctionEvent,
+): Record<string, SimCfnTemplateValue> {
+  const pattern = event.properties["Pattern"];
+
+  return samEventRuleResources({
+    event,
+    trigger: pattern === undefined ? {} : { EventPattern: pattern },
+  });
+}

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-event-rule.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-event-rule.ts
@@ -1,0 +1,115 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../template/value/sim-cfn-template-value.js";
+import { samPickedProperties } from "../../sim-cfn-sam-picked.js";
+import { samEventStateProperty } from "./sim-cfn-sam-event-state.js";
+import type { SamFunctionEvent } from "./sim-cfn-sam-function-events.js";
+
+interface SamEventRuleProperties {
+  readonly event: SamFunctionEvent;
+  /**
+   * What makes the rule fire, as the property that carries it. An event on a
+   * timer states a `ScheduleExpression`, and one matching events states an
+   * `EventPattern`.
+   */
+  readonly trigger: SimCfnTemplateValueRecord;
+}
+
+/**
+ * The properties an event and a rule name the same thing, so expanding them is
+ * carrying them across.
+ */
+const carriedProperties = new Set(["Description", "EventBusName"]);
+
+/**
+ * The Resources an event fired by an EventBridge rule is expanded into.
+ *
+ * The rule holds the function as its one inline target, and the permission
+ * beside it is what lets EventBridge invoke it. Without the permission the
+ * rule matches, the delivery is refused, and the function never runs.
+ *
+ * Both are named after the function and the event, so a function with two
+ * events of its own gets a rule for each. They are conditioned the way the
+ * function is, since a function the template conditioned out has nothing for a
+ * rule to invoke.
+ */
+export function samEventRuleResources(
+  properties: SamEventRuleProperties,
+): Record<string, SimCfnTemplateValue> {
+  const { event, trigger } = properties;
+  const prefix = `${event.functionLogicalId}${event.eventName}`;
+  const ruleLogicalId = `${prefix}Rule`;
+
+  return {
+    [ruleLogicalId]: {
+      Type: "AWS::Events::Rule",
+      ...event.condition,
+      Properties: {
+        ...trigger,
+        ...samEventRuleName(event.properties),
+        ...samPickedProperties(event.properties, carriedProperties),
+        ...samEventStateProperty(event.properties),
+        Targets: [samEventRuleTarget(event, prefix)],
+      },
+    },
+    [`${prefix}Permission`]: samEventRulePermission(event, ruleLogicalId),
+  };
+}
+
+/**
+ * The `Name` the rule is created under, for an event naming one.
+ *
+ * A `Schedule` event calls it `Name` and an `EventBridgeRule` event calls it
+ * `RuleName`, and both are the name of the same rule. An event naming neither
+ * gets the name CloudFormation generates from the stack and the logical ID.
+ */
+function samEventRuleName(
+  properties: SimCfnTemplateValueRecord,
+): SimCfnTemplateValueRecord {
+  const name = properties["Name"] ?? properties["RuleName"];
+
+  return name === undefined ? {} : { Name: name };
+}
+
+/**
+ * The rule's one target, which is the function the event was declared on.
+ *
+ * `Input` is the fixed JSON the target receives in place of the event. A
+ * scheduled function usually wants one, since a schedule has nothing to say
+ * beyond having fallen due.
+ */
+function samEventRuleTarget(
+  event: SamFunctionEvent,
+  prefix: string,
+): SimCfnTemplateValueRecord {
+  return {
+    Id: `${prefix}Target`,
+    Arn: { "Fn::GetAtt": [event.functionLogicalId, "Arn"] },
+    ...samPickedProperties(event.properties, new Set(["Input"])),
+  };
+}
+
+/**
+ * The AWS::Lambda::Permission the rule invokes the function under.
+ *
+ * A rule reaches a function as the `events.amazonaws.com` service principal,
+ * and the function's own resource policy is what admits it. The grant is
+ * scoped to this rule's ARN, so it is the rule the event made rather than
+ * EventBridge at large that may invoke the function.
+ */
+function samEventRulePermission(
+  event: SamFunctionEvent,
+  ruleLogicalId: string,
+): SimCfnTemplateValueRecord {
+  return {
+    Type: "AWS::Lambda::Permission",
+    ...event.condition,
+    Properties: {
+      Action: "lambda:InvokeFunction",
+      FunctionName: { "Fn::GetAtt": [event.functionLogicalId, "Arn"] },
+      Principal: "events.amazonaws.com",
+      SourceArn: { "Fn::GetAtt": [ruleLogicalId, "Arn"] },
+    },
+  };
+}

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-event-state.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-event-state.ts
@@ -1,0 +1,33 @@
+import type { SimCfnTemplateValueRecord } from "../../../template/value/sim-cfn-template-value.js";
+
+/**
+ * The `State` the expanded rule or schedule is created in.
+ *
+ * A SAM event says this twice over. `State` is the string the Resource itself
+ * takes, and `Enabled` is the boolean SAM had first, so an event stating the
+ * string is carried across and an event stating the boolean is turned into
+ * one. An event stating neither leaves the Resource to its own default, which
+ * is enabled.
+ *
+ * `Enabled` written as anything but a boolean is left alone rather than read
+ * for truthiness. A template holding it as an unresolved intrinsic is the one
+ * way that happens, and a rule silently disabled by a value nobody read is
+ * worse than one deployed enabled.
+ */
+export function samEventStateProperty(
+  properties: SimCfnTemplateValueRecord,
+): SimCfnTemplateValueRecord {
+  const state = properties["State"];
+
+  if (typeof state === "string") {
+    return { State: state };
+  }
+
+  const enabled = properties["Enabled"];
+
+  if (typeof enabled !== "boolean") {
+    return {};
+  }
+
+  return { State: enabled ? "ENABLED" : "DISABLED" };
+}

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-function-events.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-function-events.ts
@@ -4,7 +4,10 @@ import type {
 } from "../../../template/value/sim-cfn-template-value.js";
 import { isSamTemplateRecord } from "../../sim-cfn-sam-record.js";
 import { samConditionAttribute } from "../sim-cfn-sam-function-properties.js";
+import { samEventBridgeRuleEventResources } from "./sim-cfn-sam-event-bridge-rule-event.js";
 import { samHttpApiEventResources } from "./sim-cfn-sam-http-api-event.js";
+import { samScheduleEventResources } from "./sim-cfn-sam-schedule-event.js";
+import { samScheduleV2EventResources } from "./sim-cfn-sam-schedule-v2-event.js";
 
 interface SamFunctionEventsProperties {
   /** The logical ID of the SAM function whose events these are. */
@@ -57,7 +60,12 @@ export type SamFunctionEventExpansion = (
  * template deploys a function nothing calls, and the deployment stands.
  */
 const eventExpansions: ReadonlyMap<string, SamFunctionEventExpansion> = new Map(
-  [["HttpApi", samHttpApiEventResources]],
+  [
+    ["EventBridgeRule", samEventBridgeRuleEventResources],
+    ["HttpApi", samHttpApiEventResources],
+    ["Schedule", samScheduleEventResources],
+    ["ScheduleV2", samScheduleV2EventResources],
+  ],
 );
 
 /**

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-schedule-event.iso.test.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-schedule-event.iso.test.ts
@@ -1,0 +1,168 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertObjectEquals,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimFixedClock } from "../../../../../util/clock/sim-clock.js";
+import { SimAws } from "../../../../aws/sim-aws.js";
+import type { SimEventRule } from "../../../../eventbridge/rule/sim-event-rule.js";
+import type { SimCfnStack } from "../../../stack/sim-cfn-stack.js";
+import type { SimCfnTemplateValueRecord } from "../../../template/value/sim-cfn-template-value.js";
+import {
+  samFunctionTemplateLogicalId,
+  simCfnSamFunctionTemplateFactory,
+} from "../sim-cfn-sam-function-template.factory.js";
+
+const startedAt = "2026-07-26T09:00:00.000Z";
+
+/**
+ * A simulation whose clock a test moves, since a scheduled function runs when
+ * simulated time passes rather than when the host's clock does.
+ */
+function scheduledSimulation(): SimAws {
+  return new SimAws({ clock: new SimFixedClock(new Date(startedAt)) });
+}
+
+/**
+ * Deploy a SAM function whose `Events` are what the test is about, with a
+ * handler recording everything the function is invoked with.
+ */
+async function deployScheduled(properties: {
+  readonly simAws: SimAws;
+  readonly events: SimCfnTemplateValueRecord;
+  readonly received: unknown[];
+}): Promise<SimCfnStack> {
+  const stack = await properties.simAws.cloudFormation().deployTemplate({
+    stackName: "reconciliation-stack",
+    template: simCfnSamFunctionTemplateFactory.make({
+      functionProperties: { Events: properties.events },
+    }),
+    bindings: [
+      {
+        logicalId: samFunctionTemplateLogicalId,
+        handler: (event: unknown): string => {
+          properties.received.push(event);
+
+          return "reconciled";
+        },
+      },
+    ],
+  });
+
+  await stack.waitForDeployComplete();
+
+  return stack;
+}
+
+describe("SAM Schedule event expansion", () => {
+  it("invokes the bound handler as simulated time advances", async () => {
+    // Given a SAM function with an hourly Schedule event
+    const simAws = scheduledSimulation();
+    const received: unknown[] = [];
+
+    // When it is deployed and three simulated hours pass
+    const stack = await deployScheduled({
+      simAws,
+      events: {
+        Reconcile: {
+          Type: "Schedule",
+          Properties: { Schedule: "rate(1 hour)" },
+        },
+      },
+      received,
+    });
+
+    await simAws.clock().advanceBy({ hours: 3 });
+
+    // Then the rule the event made invoked the function once an hour, so the
+    // permission it was expanded with admitted EventBridge
+    assertArrayLength(stack.skippedResources, 0);
+    assertArrayLength(received, 3);
+  });
+
+  it("names the rule and carries what the event said about it", async () => {
+    // Given a Schedule event stating a name, a description and an input
+    const simAws = scheduledSimulation();
+    const received: unknown[] = [];
+
+    // When it is deployed and an hour passes
+    const stack = await deployScheduled({
+      simAws,
+      events: {
+        Reconcile: {
+          Type: "Schedule",
+          Properties: {
+            Schedule: "rate(1 hour)",
+            Name: "hourly-reconciliation",
+            Description: "Reconciles the day's rates",
+            Input: JSON.stringify({ ledger: "rates" }),
+          },
+        },
+      },
+      received,
+    });
+
+    await simAws.clock().advanceBy({ hours: 1 });
+
+    // Then the rule carries the name and description the event stated
+    const rule = stack.getResource("RatesReconcileRule")
+      ?.simResource as SimEventRule;
+
+    assertNonNullable(rule);
+    assertIdentical(rule.name.value, "hourly-reconciliation");
+    assertIdentical(rule.description, "Reconciles the day's rates");
+
+    // And the handler was invoked with the input rather than with the event
+    assertObjectEquals(received, [{ ledger: "rates" }]);
+  });
+
+  it("leaves a disabled event's function alone as time passes", async () => {
+    // Given a Schedule event the template disabled
+    const simAws = scheduledSimulation();
+    const received: unknown[] = [];
+
+    // When it is deployed and three simulated hours pass
+    const stack = await deployScheduled({
+      simAws,
+      events: {
+        Reconcile: {
+          Type: "Schedule",
+          Properties: { Schedule: "rate(1 hour)", Enabled: false },
+        },
+      },
+      received,
+    });
+
+    await simAws.clock().advanceBy({ hours: 3 });
+
+    // Then the rule is there and disabled, and the function never ran
+    const rule = stack.getResource("RatesReconcileRule")
+      ?.simResource as SimEventRule;
+
+    assertNonNullable(rule);
+    assertIdentical(rule.state.value, "DISABLED");
+    assertArrayLength(received, 0);
+  });
+
+  it("refuses an event stating no schedule rather than guessing one", async () => {
+    // Given a Schedule event that never said when to fire
+    const simAws = scheduledSimulation();
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployScheduled({
+        simAws,
+        events: { Reconcile: { Type: "Schedule", Properties: {} } },
+        received: [],
+      });
+    });
+
+    // Then the deployment failed naming the rule the event expanded into,
+    // rather than putting the function on a timer nobody asked for
+    assertStringIncludes(error.message, "RatesReconcileRule");
+  });
+});

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-schedule-event.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-schedule-event.ts
@@ -1,0 +1,27 @@
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import { samEventRuleResources } from "./sim-cfn-sam-event-rule.js";
+import type { SamFunctionEvent } from "./sim-cfn-sam-function-events.js";
+
+/**
+ * Expand one `Schedule` event into the rule that fires the function on a
+ * timer.
+ *
+ * The event's `Schedule` is the rule's `ScheduleExpression`, which is the
+ * whole of what a `Schedule` event says beyond what every rule event says. A
+ * rate or cron expression the rule refuses is refused by the rule, naming
+ * itself, rather than being read here.
+ *
+ * An event stating no `Schedule` expands into a rule with nothing to fire it,
+ * which the rule then refuses. A schedule guessed for an event that named none
+ * would be a function firing on a timer nobody asked for.
+ */
+export function samScheduleEventResources(
+  event: SamFunctionEvent,
+): Record<string, SimCfnTemplateValue> {
+  const expression = event.properties["Schedule"];
+
+  return samEventRuleResources({
+    event,
+    trigger: expression === undefined ? {} : { ScheduleExpression: expression },
+  });
+}

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-schedule-v2-event.iso.test.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-schedule-v2-event.iso.test.ts
@@ -1,0 +1,193 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertObjectEquals,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimFixedClock } from "../../../../../util/clock/sim-clock.js";
+import { SimAws } from "../../../../aws/sim-aws.js";
+import type { SimCfnStack } from "../../../stack/sim-cfn-stack.js";
+import type { SimCfnTemplateValueRecord } from "../../../template/value/sim-cfn-template-value.js";
+import {
+  samFunctionTemplateLogicalId,
+  simCfnSamFunctionTemplateFactory,
+} from "../sim-cfn-sam-function-template.factory.js";
+
+const startedAt = "2026-07-26T09:00:00.000Z";
+
+/**
+ * Deploy a SAM function whose `Events` are what the test is about, on a clock
+ * the test moves, with a handler recording every invocation.
+ */
+async function deployScheduled(properties: {
+  readonly simAws: SimAws;
+  readonly events: SimCfnTemplateValueRecord;
+  readonly resources?: SimCfnTemplateValueRecord;
+  readonly received: unknown[];
+}): Promise<SimCfnStack> {
+  const stack = await properties.simAws.cloudFormation().deployTemplate({
+    stackName: "reporting-stack",
+    template: simCfnSamFunctionTemplateFactory.make({
+      functionProperties: { Events: properties.events },
+      resources: properties.resources ?? {},
+    }),
+    bindings: [
+      {
+        logicalId: samFunctionTemplateLogicalId,
+        handler: (event: unknown): string => {
+          properties.received.push(event);
+
+          return "reported";
+        },
+      },
+    ],
+  });
+
+  await stack.waitForDeployComplete();
+
+  return stack;
+}
+
+describe("SAM ScheduleV2 event expansion", () => {
+  it("invokes the bound handler from a schedule rather than a rule", async () => {
+    // Given a SAM function with an hourly ScheduleV2 event
+    const simAws = new SimAws({
+      clock: new SimFixedClock(new Date(startedAt)),
+    });
+    const received: unknown[] = [];
+
+    // When it is deployed and three simulated hours pass
+    const stack = await deployScheduled({
+      simAws,
+      events: {
+        Report: {
+          Type: "ScheduleV2",
+          Properties: { ScheduleExpression: "rate(1 hour)" },
+        },
+      },
+      received,
+    });
+
+    await simAws.clock().advanceBy({ hours: 3 });
+
+    // Then the schedule invoked the function once an hour as the execution
+    // role it was expanded with, and no rule was made for it
+    assertArrayLength(stack.skippedResources, 0);
+    assertNonNullable(stack.getResource("RatesReportSchedule"));
+    assertUndefined(stack.getResource("RatesReportRule"));
+    assertArrayLength(received, 3);
+  });
+
+  it("carries what the event said about the schedule", async () => {
+    // Given a ScheduleV2 event stating a name, a description and an input
+    const simAws = new SimAws({
+      clock: new SimFixedClock(new Date(startedAt)),
+    });
+    const received: unknown[] = [];
+
+    // When it is deployed and an hour passes
+    await deployScheduled({
+      simAws,
+      events: {
+        Report: {
+          Type: "ScheduleV2",
+          Properties: {
+            ScheduleExpression: "rate(1 hour)",
+            Name: "hourly-report",
+            Description: "Reports the day's rates",
+            Enabled: true,
+            Input: JSON.stringify({ ledger: "rates" }),
+          },
+        },
+      },
+      received,
+    });
+
+    await simAws.clock().advanceBy({ hours: 1 });
+
+    // Then the schedule carries the name and description the event stated
+    const schedule = simAws.scheduler().findSchedule("hourly-report");
+
+    assertNonNullable(schedule);
+    assertIdentical(schedule.description, "Reports the day's rates");
+    assertIdentical(schedule.state.value, "ENABLED");
+
+    // And the handler was invoked with the input the event stated
+    assertObjectEquals(received, [{ ledger: "rates" }]);
+  });
+
+  it("runs as the role the event named, expanding none of its own", async () => {
+    // Given an event naming a role the template declares beside the function
+    const simAws = new SimAws({
+      clock: new SimFixedClock(new Date(startedAt)),
+    });
+    const received: unknown[] = [];
+
+    // When it is deployed and an hour passes
+    const stack = await deployScheduled({
+      simAws,
+      events: {
+        Report: {
+          Type: "ScheduleV2",
+          Properties: {
+            ScheduleExpression: "rate(1 hour)",
+            Name: "hourly-report",
+            FlexibleTimeWindow: { Mode: "OFF" },
+            RoleArn: { "Fn::GetAtt": ["ReportingRole", "Arn"] },
+          },
+        },
+      },
+      resources: {
+        ReportingRole: {
+          Type: "AWS::IAM::Role",
+          Properties: {
+            RoleName: "ReportingRole",
+            AssumeRolePolicyDocument: {
+              Version: "2012-10-17",
+              Statement: [
+                {
+                  Effect: "Allow",
+                  Principal: { Service: "scheduler.amazonaws.com" },
+                  Action: "sts:AssumeRole",
+                },
+              ],
+            },
+            Policies: [
+              {
+                PolicyName: "InvokeRates",
+                PolicyDocument: {
+                  Version: "2012-10-17",
+                  Statement: [
+                    {
+                      Effect: "Allow",
+                      Action: "lambda:InvokeFunction",
+                      Resource: { "Fn::GetAtt": ["Rates", "Arn"] },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+      received,
+    });
+
+    await simAws.clock().advanceBy({ hours: 1 });
+
+    // Then the schedule assumed the named role, and the expansion left the
+    // role it would otherwise have made out of the stack
+    const schedule = simAws.scheduler().findSchedule("hourly-report");
+
+    assertNonNullable(schedule);
+    assertIdentical(
+      schedule.target.roleArn,
+      stack.getResource("ReportingRole")?.attributeValue("Arn"),
+    );
+    assertUndefined(stack.getResource("RatesReportScheduleRole"));
+    assertArrayLength(received, 1);
+  });
+});

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-schedule-v2-event.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-schedule-v2-event.ts
@@ -1,0 +1,112 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../template/value/sim-cfn-template-value.js";
+import { samPickedProperties } from "../../sim-cfn-sam-picked.js";
+import { samEventStateProperty } from "./sim-cfn-sam-event-state.js";
+import type { SamFunctionEvent } from "./sim-cfn-sam-function-events.js";
+
+/**
+ * The properties an event and a schedule name the same thing, so expanding
+ * them is carrying them across.
+ */
+const carriedProperties = new Set([
+  "Description",
+  "EndDate",
+  "GroupName",
+  "KmsKeyArn",
+  "Name",
+  "ScheduleExpression",
+  "ScheduleExpressionTimezone",
+  "StartDate",
+]);
+
+/**
+ * The time window AWS requires on a schedule, for an event stating none.
+ */
+const fixedTimeWindow: SimCfnTemplateValueRecord = { Mode: "OFF" };
+
+/**
+ * Expand one `ScheduleV2` event into the EventBridge Scheduler schedule that
+ * invokes the function.
+ *
+ * This is the other way to put a function on a timer, and it expands into an
+ * `AWS::Scheduler::Schedule` rather than a rule. The difference that shows is
+ * how the invocation is authorized. A schedule assumes an execution role and
+ * invokes as that role, where a rule arrives as a service principal and the
+ * function's resource policy decides. So this expands a Role rather than a
+ * permission, unless the event named a `RoleArn` of its own to run as.
+ */
+export function samScheduleV2EventResources(
+  event: SamFunctionEvent,
+): Record<string, SimCfnTemplateValue> {
+  const prefix = `${event.functionLogicalId}${event.eventName}`;
+  const roleLogicalId = `${prefix}ScheduleRole`;
+  const declaredRoleArn = event.properties["RoleArn"];
+
+  return {
+    [`${prefix}Schedule`]: {
+      Type: "AWS::Scheduler::Schedule",
+      ...event.condition,
+      Properties: {
+        ...samPickedProperties(event.properties, carriedProperties),
+        ...samEventStateProperty(event.properties),
+        FlexibleTimeWindow:
+          event.properties["FlexibleTimeWindow"] ?? fixedTimeWindow,
+        Target: {
+          Arn: { "Fn::GetAtt": [event.functionLogicalId, "Arn"] },
+          RoleArn: declaredRoleArn ?? { "Fn::GetAtt": [roleLogicalId, "Arn"] },
+          ...samPickedProperties(event.properties, new Set(["Input"])),
+        },
+      },
+    },
+    ...(declaredRoleArn === undefined && {
+      [roleLogicalId]: samScheduleV2RoleResource(event, prefix),
+    }),
+  };
+}
+
+/**
+ * The AWS::IAM::Role the schedule invokes the function as.
+ *
+ * Scheduler assumes this role for every invocation, so it trusts the Scheduler
+ * service principal and may invoke the one function the event was declared on.
+ * A role granting `lambda:InvokeFunction` on everything would be the same
+ * schedule with a wider grant than the event asked for.
+ */
+function samScheduleV2RoleResource(
+  event: SamFunctionEvent,
+  prefix: string,
+): SimCfnTemplateValueRecord {
+  return {
+    Type: "AWS::IAM::Role",
+    ...event.condition,
+    Properties: {
+      AssumeRolePolicyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Principal: { Service: "scheduler.amazonaws.com" },
+            Action: "sts:AssumeRole",
+          },
+        ],
+      },
+      Policies: [
+        {
+          PolicyName: `${prefix}ScheduleRolePolicy`,
+          PolicyDocument: {
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Action: "lambda:InvokeFunction",
+                Resource: { "Fn::GetAtt": [event.functionLogicalId, "Arn"] },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  };
+}


### PR DESCRIPTION
A SAM function's `Schedule` and `EventBridgeRule` events now expand into an `AWS::Events::Rule` holding the function as its one target, with the `AWS::Lambda::Permission` EventBridge invokes it under, and a `ScheduleV2` event expands into an `AWS::Scheduler::Schedule` and the execution Role Scheduler assumes to invoke the function. An event naming a `RoleArn` runs as that role and gets no expanded one. `Name` (`RuleName` on an `EventBridgeRule` event), `Description`, `Enabled` and `Input` reach the expanded Resource, and an event naming an `EventBusName` watches that bus. A scheduled function runs when a test advances simulated time, and a function behind an `EventBridgeRule` event runs when a matching event is put. `DeadLetterConfig` and `RetryPolicy` are left out.

Resolves #751