### PR TITLE
feat: expand SAM queue, stream, topic and bucket events

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -2227,6 +2227,14 @@ states one event name or a list of them, and each one becomes a configuration of
 event's `Filter` on it. Notifications the bucket already declared are kept, and so are the ones
 another function's event put there.
 
+Two shapes are refused rather than expanded. A bucket writing its `NotificationConfiguration` or its
+`LambdaConfigurations` as an intrinsic such as `Fn::If` is one, because there is no appending to a
+list CloudFormation has not resolved yet, and adding the event's own entries would drop whatever the
+intrinsic resolved to. The other is a function the template conditions out, which real CloudFormation
+refuses for the same reason SAM cannot fix it: the notification belongs to the bucket, the bucket is
+not conditioned, and nothing can condition one entry of somebody else's property. Condition the
+bucket along with the function, or declare the notification on the bucket yourself.
+
 ### Simple tables
 
 `AWS::Serverless::SimpleTable` deploys a table with one partition key and on-demand billing.

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -1982,9 +1982,9 @@ its own `Role` runs as that role, and gets no expanded one.
 
 ### Function events
 
-`Events` on a SAM function expand into whatever puts the function behind them. `HttpApi`,
-`Schedule`, `ScheduleV2` and `EventBridgeRule` are the types this covers. An event of any other type
-is left where it is, and the function deploys with nothing in front of it.
+`Events` on a SAM function expand into whatever puts the function behind them. `HttpApi`, `SQS`,
+`DynamoDB`, `SNS`, `S3`, `Schedule`, `ScheduleV2` and `EventBridgeRule` are the types this covers. An
+event of any other type is left where it is, and the function deploys with nothing in front of it.
 
 An `HttpApi` event becomes an `AWS::ApiGatewayV2::Integration`, an `AWS::ApiGatewayV2::Route` and the
 `AWS::Lambda::Permission` the API invokes the function under. `Path` and `Method` become the route
@@ -2132,6 +2132,100 @@ once, and a failed one is recorded by the rule or the schedule that made it.
 A `FunctionUrlConfig` on the function expands into an `AWS::Lambda::Url` named after it, `RatesUrl`
 for a function called `Rates`. `AuthType` and `InvokeMode` carry over. `Cors` is left out (the
 simulated Function URL answers no preflight request).
+
+### Queue, stream, topic and bucket events
+
+These four event types point the function at something the template already has. Expanding one never
+creates the queue, table, topic or bucket it names.
+
+An `SQS` event becomes an `AWS::Lambda::EventSourceMapping` polling the queue its `Queue` ARN names,
+and a `DynamoDB` event becomes one reading the stream its `Stream` ARN names. Both are named after
+the function and the event (`OrdersWorkEventSourceMapping` for an event called `Work` on a function
+called `Orders`). Whatever else the event states goes onto the mapping under the same name, so
+`BatchSize`, `StartingPosition`, `Enabled` and `FilterCriteria` all carry across. A property the
+mapping has no meaning for is refused by name.
+
+The expanded execution role gains the policy it polls the source under, the way SAM attaches one of
+its own. Lambda refuses a mapping whose role cannot poll. A function naming its own `Role` runs as
+that role and keeps whatever the template granted it.
+
+```typescript sim-cloudformation-sam-queue-event
+/**
+ * A SAM function fed by the queue its SQS event names.
+ */
+
+import { GetQueueUrlCommand, SendMessageCommand } from "@aws-sdk/client-sqs";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const received: string[][] = [];
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Transform: "AWS::Serverless-2016-10-31",
+    Resources: {
+      OrdersQueue: {
+        Type: "AWS::SQS::Queue",
+        Properties: { QueueName: "orders" },
+      },
+      Orders: {
+        Type: "AWS::Serverless::Function",
+        Properties: {
+          Handler: "index.handler",
+          Runtime: "nodejs22.x",
+          Events: {
+            Work: {
+              Type: "SQS",
+              Properties: {
+                Queue: { "Fn::GetAtt": ["OrdersQueue", "Arn"] },
+                BatchSize: 5,
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  bindings: [
+    {
+      logicalId: "Orders",
+      handler: (event: { Records: readonly { body: string }[] }): string[] => {
+        const bodies = event.Records.map((record) => record.body);
+        received.push(bodies);
+
+        return bodies;
+      },
+    },
+  ],
+});
+
+await stack.waitForDeployComplete();
+
+const { QueueUrl } = await simAws
+  .sqs()
+  .getQueueUrl(new GetQueueUrlCommand({ QueueName: "orders" }));
+
+await simAws
+  .sqs()
+  .sendMessage(new SendMessageCommand({ QueueUrl, MessageBody: "order-1" }));
+
+await simAws.backgroundTasksComplete();
+
+console.log(received);
+```
+
+An `SNS` event becomes an `AWS::SNS::Subscription` on the `lambda` protocol, together with the
+`AWS::Lambda::Permission` the topic invokes the function under. `Topic` is the topic's ARN.
+`FilterPolicy` and `FilterPolicyScope` carry across as the subscription attributes of those names.
+
+An `S3` event is the one with no resource of its own. In CloudFormation a bucket carries its own
+notifications, so the event adds a `LambdaConfigurations` entry to the `NotificationConfiguration` of
+the bucket its `Bucket` names, and brings the permission S3 invokes the function under. `Bucket` is a
+logical ID here rather than an ARN, and the bucket has to be one the template declares. `Events`
+states one event name or a list of them, and each one becomes a configuration of its own with the
+event's `Filter` on it. Notifications the bucket already declared are kept, and so are the ones
+another function's event put there.
 
 ### Simple tables
 

--- a/docs/services/cloudformation/sim-cloudformation-sam-queue-event.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-sam-queue-event.example.ts
@@ -1,0 +1,63 @@
+/**
+ * A SAM function fed by the queue its SQS event names.
+ */
+
+import { GetQueueUrlCommand, SendMessageCommand } from "@aws-sdk/client-sqs";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const received: string[][] = [];
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Transform: "AWS::Serverless-2016-10-31",
+    Resources: {
+      OrdersQueue: {
+        Type: "AWS::SQS::Queue",
+        Properties: { QueueName: "orders" },
+      },
+      Orders: {
+        Type: "AWS::Serverless::Function",
+        Properties: {
+          Handler: "index.handler",
+          Runtime: "nodejs22.x",
+          Events: {
+            Work: {
+              Type: "SQS",
+              Properties: {
+                Queue: { "Fn::GetAtt": ["OrdersQueue", "Arn"] },
+                BatchSize: 5,
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  bindings: [
+    {
+      logicalId: "Orders",
+      handler: (event: { Records: readonly { body: string }[] }): string[] => {
+        const bodies = event.Records.map((record) => record.body);
+        received.push(bodies);
+
+        return bodies;
+      },
+    },
+  ],
+});
+
+await stack.waitForDeployComplete();
+
+const { QueueUrl } = await simAws
+  .sqs()
+  .getQueueUrl(new GetQueueUrlCommand({ QueueName: "orders" }));
+
+await simAws
+  .sqs()
+  .sendMessage(new SendMessageCommand({ QueueUrl, MessageBody: "order-1" }));
+
+await simAws.backgroundTasksComplete();
+
+console.log(received);

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-declared-event.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-declared-event.ts
@@ -1,0 +1,102 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../template/value/sim-cfn-template-value.js";
+import { isSamTemplateRecord } from "../../sim-cfn-sam-record.js";
+import { samConditionAttribute } from "../sim-cfn-sam-function-properties.js";
+
+/**
+ * What the expansion of a SAM function is asked about its events.
+ */
+export interface SamFunctionEventsProperties {
+  /** The logical ID of the SAM function whose events these are. */
+  readonly logicalId: string;
+  /** The function properties, with the `Globals` defaults already merged in. */
+  readonly functionProperties: SimCfnTemplateValueRecord;
+  /** The `Condition` the SAM Resource carried, where it carried one. */
+  readonly condition: SimCfnTemplateValue | undefined;
+}
+
+/**
+ * What an expansion is told about the event it is expanding.
+ */
+export interface SamFunctionEvent {
+  /**
+   * The logical ID of the SAM function the event is declared on, which is also
+   * the logical ID of the Lambda function it is expanded into.
+   */
+  readonly functionLogicalId: string;
+  /** The name the function declared the event under in `Events`. */
+  readonly eventName: string;
+  /**
+   * The `Properties` of the event. An event stating none states an empty
+   * record.
+   */
+  readonly properties: SimCfnTemplateValueRecord;
+  /**
+   * The `Condition` attribute to put on the Resources that exist only because
+   * this function does, ready to spread. A function carrying no condition
+   * supplies nothing.
+   */
+  readonly condition: SimCfnTemplateValueRecord;
+}
+
+/**
+ * One event of a function, as the expansion tables are asked about it.
+ */
+export interface SamDeclaredEvent {
+  /** The name the event wrote under `Type`. */
+  readonly type: string;
+  readonly event: SamFunctionEvent;
+}
+
+/**
+ * The events a function declares, as the expansion tables are told about them.
+ *
+ * An event this cannot read at all, or one naming no `Type`, is left out. The
+ * function deploys with nothing in front of it rather than the deployment
+ * failing over an event nothing reads.
+ */
+export function samDeclaredEvents(
+  properties: SamFunctionEventsProperties,
+): readonly SamDeclaredEvent[] {
+  const events = properties.functionProperties["Events"];
+
+  if (!isSamTemplateRecord(events)) {
+    return [];
+  }
+
+  return Object.entries(events).flatMap(([eventName, event]) =>
+    declaredEvent(properties, eventName, event),
+  );
+}
+
+function declaredEvent(
+  properties: SamFunctionEventsProperties,
+  eventName: string,
+  event: SimCfnTemplateValue,
+): readonly SamDeclaredEvent[] {
+  if (!isSamTemplateRecord(event)) {
+    return [];
+  }
+
+  const type = event["Type"];
+
+  if (typeof type !== "string") {
+    return [];
+  }
+
+  const eventProperties = event["Properties"];
+
+  return [
+    {
+      type,
+      event: {
+        functionLogicalId: properties.logicalId,
+        eventName,
+        properties: isSamTemplateRecord(eventProperties) ? eventProperties : {},
+        condition: samConditionAttribute(properties.condition),
+      },
+    },
+  ];
+}

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-event-source-kind.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-event-source-kind.ts
@@ -1,0 +1,58 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../template/value/sim-cfn-template-value.js";
+
+/**
+ * What one kind of polled event source is called and what polling it takes.
+ */
+export interface SamEventSourceKind {
+  /** The event property naming what the mapping polls. */
+  readonly sourceProperty: string;
+  /** The statements the execution Role polls the source under. */
+  readonly pollingStatements: (
+    source: SimCfnTemplateValue,
+  ) => readonly SimCfnTemplateValueRecord[];
+}
+
+/**
+ * A queue, polled with the three operations a poller performs on one, on the
+ * queue itself.
+ */
+export const samSqsEventSource: SamEventSourceKind = {
+  sourceProperty: "Queue",
+  pollingStatements: (source) => [
+    {
+      Effect: "Allow",
+      Action: [
+        "sqs:ReceiveMessage",
+        "sqs:DeleteMessage",
+        "sqs:GetQueueAttributes",
+      ],
+      Resource: source,
+    },
+  ],
+};
+
+/**
+ * A table's stream, read with three operations on the stream and listed across
+ * every stream.
+ *
+ * The split is the one the DynamoDB Streams API forces, since a stream cannot
+ * be listed by its own ARN, and it is how CDK writes the same grant.
+ */
+export const samDynamoDbEventSource: SamEventSourceKind = {
+  sourceProperty: "Stream",
+  pollingStatements: (source) => [
+    {
+      Effect: "Allow",
+      Action: [
+        "dynamodb:DescribeStream",
+        "dynamodb:GetRecords",
+        "dynamodb:GetShardIterator",
+      ],
+      Resource: source,
+    },
+    { Effect: "Allow", Action: "dynamodb:ListStreams", Resource: "*" },
+  ],
+};

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-event-source-mapping-event.iso.test.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-event-source-mapping-event.iso.test.ts
@@ -1,0 +1,349 @@
+import { PutItemCommand } from "@aws-sdk/client-dynamodb";
+import { SendMessageCommand } from "@aws-sdk/client-sqs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../aws/sim-aws.js";
+import { SimLambdaEventSourceMapping } from "../../../../lambda/event-source/sim-lambda-event-source-mapping.js";
+import type { SimLambdaDynamoDbStreamEvent } from "../../../../lambda/event-source/poll/sim-lambda-dynamodb-stream-event.types.js";
+import type { SimLambdaSqsEvent } from "../../../../lambda/event-source/poll/sim-lambda-sqs-event.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../template/value/sim-cfn-template-value.js";
+import { samExpandedTemplate } from "../../sim-cfn-sam-expansion.js";
+import {
+  samFunctionTemplateLogicalId,
+  simCfnSamFunctionTemplateFactory,
+} from "../sim-cfn-sam-function-template.factory.js";
+import {
+  ordersQueue,
+  ordersTable,
+} from "./sim-cfn-sam-event-source.resources.js";
+
+/**
+ * The logical ID the event's mapping is expanded under, for an event named
+ * `Work` on the function the factory builds.
+ */
+const mappingLogicalId = `${samFunctionTemplateLogicalId}WorkEventSourceMapping`;
+
+/**
+ * The simulated mapping a deployed template's event made.
+ */
+function deployedMapping(
+  stack: Awaited<
+    ReturnType<ReturnType<SimAws["cloudFormation"]>["deployTemplate"]>
+  >,
+): SimLambdaEventSourceMapping {
+  const resource = stack.getResource(mappingLogicalId);
+
+  assertNonNullable(resource);
+  assertInstanceOf(resource.simResource, SimLambdaEventSourceMapping);
+
+  return resource.simResource;
+}
+
+/**
+ * The `Properties` the mapping is expanded with, read off the expanded
+ * template rather than a deployment.
+ *
+ * A property simulated Lambda refuses is still a property the expansion has to
+ * carry across, so it can be seen arriving before it can be deployed.
+ */
+function expandedMappingProperties(
+  eventProperties: SimCfnTemplateValueRecord,
+  eventType: string,
+): SimCfnTemplateValueRecord {
+  const expanded = samExpandedTemplate(
+    simCfnSamFunctionTemplateFactory.make({
+      functionProperties: {
+        Events: { Work: { Type: eventType, Properties: eventProperties } },
+      },
+    }),
+  );
+  const mapping = entry(
+    expanded.Resources,
+    mappingLogicalId,
+  ) as SimCfnTemplateValueRecord;
+
+  assertNonNullable(mapping);
+
+  return entry(mapping, "Properties") as SimCfnTemplateValueRecord;
+}
+
+/**
+ * One entry of a template record, read through a Map so a logical ID coming
+ * from a variable is not an index into an object.
+ */
+function entry(
+  record: SimCfnTemplateValueRecord,
+  name: string,
+): SimCfnTemplateValue | undefined {
+  return new Map(Object.entries(record)).get(name);
+}
+
+describe("SAM SQS and DynamoDB event expansion", () => {
+  it("delivers a message on the queue an SQS event names", async () => {
+    // Given a SAM function with an SQS event naming a queue the template
+    // declares
+    const simAws = new SimAws();
+    const events: SimLambdaSqsEvent[] = [];
+
+    // When it is deployed and a message is sent to that queue
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: simCfnSamFunctionTemplateFactory.make({
+        functionProperties: {
+          Events: {
+            Work: {
+              Type: "SQS",
+              Properties: {
+                Queue: { "Fn::GetAtt": ["OrdersQueue", "Arn"] },
+                BatchSize: 5,
+              },
+            },
+          },
+        },
+        resources: { OrdersQueue: ordersQueue },
+      }),
+      bindings: [
+        {
+          logicalId: samFunctionTemplateLogicalId,
+          handler: (event: SimLambdaSqsEvent): undefined => {
+            events.push(event);
+
+            return undefined;
+          },
+        },
+      ],
+    });
+    await stack.waitForDeployComplete();
+
+    await simAws.sqs().sendMessage(
+      new SendMessageCommand({
+        QueueUrl: simAws.sqs().findQueue("orders")?.url,
+        MessageBody: "order-1",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the event made a mapping carrying the batch size it stated, and the
+    // message reached the bound handler
+    assertIdentical(deployedMapping(stack).batchSize, 5);
+    assertArrayLength(events, 1);
+    assertIdentical(events[0].Records[0]?.body, "order-1");
+  });
+
+  it("reads the stream a DynamoDB event names", async () => {
+    // Given a SAM function with a DynamoDB event naming a streamed table's
+    // stream
+    const simAws = new SimAws();
+    const events: SimLambdaDynamoDbStreamEvent[] = [];
+
+    // When it is deployed and an item is written to that table
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "projector-stack",
+      template: simCfnSamFunctionTemplateFactory.make({
+        functionProperties: {
+          Events: {
+            Work: {
+              Type: "DynamoDB",
+              Properties: {
+                Stream: { "Fn::GetAtt": ["OrdersTable", "StreamArn"] },
+                StartingPosition: "TRIM_HORIZON",
+                BatchSize: 10,
+              },
+            },
+          },
+        },
+        resources: { OrdersTable: ordersTable },
+      }),
+      bindings: [
+        {
+          logicalId: samFunctionTemplateLogicalId,
+          handler: (event: SimLambdaDynamoDbStreamEvent): undefined => {
+            events.push(event);
+
+            return undefined;
+          },
+        },
+      ],
+    });
+    await stack.waitForDeployComplete();
+
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: "orders",
+        Item: { orderId: { S: "order-1" }, total: { N: "101" } },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the mapping started where the event said, and the write reached the
+    // bound handler as a stream record
+    assertIdentical(deployedMapping(stack).startingPosition, "TRIM_HORIZON");
+    assertArrayLength(events, 1);
+
+    const record = events[0].Records[0];
+    assertNonNullable(record);
+    assertIdentical(record.eventName, "INSERT");
+    assertIdentical(record.dynamodb.NewImage?.["total"]?.N, "101");
+  });
+
+  it("disables the mapping of an event stating Enabled false", async () => {
+    // Given an SQS event the template turns off
+    const simAws = new SimAws();
+    const events: SimLambdaSqsEvent[] = [];
+
+    // When it is deployed and a message is sent to the queue
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "paused-orders-stack",
+      template: simCfnSamFunctionTemplateFactory.make({
+        functionProperties: {
+          Events: {
+            Work: {
+              Type: "SQS",
+              Properties: {
+                Queue: { "Fn::GetAtt": ["OrdersQueue", "Arn"] },
+                Enabled: false,
+              },
+            },
+          },
+        },
+        resources: { OrdersQueue: ordersQueue },
+      }),
+      bindings: [
+        {
+          logicalId: samFunctionTemplateLogicalId,
+          handler: (event: SimLambdaSqsEvent): undefined => {
+            events.push(event);
+
+            return undefined;
+          },
+        },
+      ],
+    });
+    await stack.waitForDeployComplete();
+
+    await simAws.sqs().sendMessage(
+      new SendMessageCommand({
+        QueueUrl: simAws.sqs().findQueue("orders")?.url,
+        MessageBody: "order-1",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the mapping was deployed polling nothing, and the message sat on
+    // the queue
+    assertIdentical(deployedMapping(stack).state, "Disabled");
+    assertArrayLength(events, 0);
+  });
+
+  it("adds the permission to poll beside the policies the function stated", async () => {
+    // Given a function that already carries a policy of its own, and an SQS
+    // event whose mapping the execution Role has to be able to poll for
+    const simAws = new SimAws();
+    const events: SimLambdaSqsEvent[] = [];
+
+    // When it is deployed and a message is sent to the queue
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "policied-orders-stack",
+      template: simCfnSamFunctionTemplateFactory.make({
+        functionProperties: {
+          Policies: [
+            {
+              Version: "2012-10-17",
+              Statement: [
+                { Effect: "Allow", Action: "s3:GetObject", Resource: "*" },
+              ],
+            },
+          ],
+          Events: {
+            Work: {
+              Type: "SQS",
+              Properties: { Queue: { "Fn::GetAtt": ["OrdersQueue", "Arn"] } },
+            },
+          },
+        },
+        resources: { OrdersQueue: ordersQueue },
+      }),
+      bindings: [
+        {
+          logicalId: samFunctionTemplateLogicalId,
+          handler: (event: SimLambdaSqsEvent): undefined => {
+            events.push(event);
+
+            return undefined;
+          },
+        },
+      ],
+    });
+    await stack.waitForDeployComplete();
+
+    await simAws.sqs().sendMessage(
+      new SendMessageCommand({
+        QueueUrl: simAws.sqs().findQueue("orders")?.url,
+        MessageBody: "order-1",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the function's own policy did not cost it the permission to poll
+    assertArrayLength(events, 1);
+  });
+
+  it("carries a FilterCriteria the event states onto the mapping", () => {
+    // Given an SQS event filtering what the function is given, which is a
+    // mapping property simulated Lambda refuses rather than ignores
+    const criteria = {
+      Filters: [{ Pattern: '{"body":{"total":[{"numeric":[">",100]}]}}' }],
+    };
+
+    // When the template is expanded
+    const properties = expandedMappingProperties(
+      {
+        Queue: "arn:aws:sqs:eu-west-2:111111111111:orders",
+        FilterCriteria: criteria,
+      },
+      "SQS",
+    );
+
+    // Then the criteria reached the mapping under the name the mapping reads
+    // it by, rather than being dropped on the way
+    assertIdentical(
+      JSON.stringify(properties["FilterCriteria"]),
+      JSON.stringify(criteria),
+    );
+  });
+
+  it("expands nothing for an event naming no source", async () => {
+    // Given a DynamoDB event that names no stream to read
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "sourceless-stack",
+      template: simCfnSamFunctionTemplateFactory.make({
+        functionProperties: {
+          Events: {
+            Work: {
+              Type: "DynamoDB",
+              Properties: { StartingPosition: "TRIM_HORIZON" },
+            },
+          },
+        },
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the function deployed with nothing polling for it, rather than the
+    // deployment failing over a mapping with nothing to poll
+    assertNonNullable(stack.getResource(samFunctionTemplateLogicalId));
+    assertArrayLength(stack.skippedResources, 0);
+  });
+});

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-event-source-mapping-event.iso.test.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-event-source-mapping-event.iso.test.ts
@@ -49,6 +49,37 @@ function deployedMapping(
 }
 
 /**
+ * A policy document a function states for itself, which has nothing to do with
+ * polling and has to survive the event's own addition to the Role.
+ */
+const statedPolicy: SimCfnTemplateValueRecord = {
+  Version: "2012-10-17",
+  Statement: [{ Effect: "Allow", Action: "s3:GetObject", Resource: "*" }],
+};
+
+/**
+ * The `Policies` of the execution Role the function is expanded with.
+ */
+function expandedRolePolicies(
+  functionProperties: SimCfnTemplateValueRecord,
+): readonly SimCfnTemplateValueRecord[] {
+  const expanded = samExpandedTemplate(
+    simCfnSamFunctionTemplateFactory.make({ functionProperties }),
+  );
+  const role = entry(
+    expanded.Resources,
+    `${samFunctionTemplateLogicalId}Role`,
+  ) as SimCfnTemplateValueRecord;
+
+  assertNonNullable(role);
+
+  const properties = entry(role, "Properties") as SimCfnTemplateValueRecord;
+
+  return (entry(properties, "Policies") ??
+    []) as readonly SimCfnTemplateValueRecord[];
+}
+
+/**
  * The `Properties` the mapping is expanded with, read off the expanded
  * template rather than a deployment.
  *
@@ -255,14 +286,7 @@ describe("SAM SQS and DynamoDB event expansion", () => {
       stackName: "policied-orders-stack",
       template: simCfnSamFunctionTemplateFactory.make({
         functionProperties: {
-          Policies: [
-            {
-              Version: "2012-10-17",
-              Statement: [
-                { Effect: "Allow", Action: "s3:GetObject", Resource: "*" },
-              ],
-            },
-          ],
+          Policies: [statedPolicy],
           Events: {
             Work: {
               Type: "SQS",
@@ -293,7 +317,29 @@ describe("SAM SQS and DynamoDB event expansion", () => {
     );
     await simAws.backgroundTasksComplete();
 
-    // Then the function's own policy did not cost it the permission to poll
+    // Then the Role carries both, the policy the function stated and the one
+    // the event added, and the function's own did not cost it the permission
+    // to poll
+    const policies = expandedRolePolicies({
+      Policies: [statedPolicy],
+      Events: {
+        Work: {
+          Type: "SQS",
+          Properties: { Queue: "arn:aws:sqs:eu-west-2:111111111111:orders" },
+        },
+      },
+    });
+
+    assertArrayLength(policies, 2);
+    assertIdentical(
+      JSON.stringify(policies[0]["PolicyDocument"]),
+      JSON.stringify(statedPolicy),
+    );
+    assertIdentical(
+      policies[1]["PolicyName"],
+      `${samFunctionTemplateLogicalId}WorkPollerPolicy`,
+    );
+
     assertArrayLength(events, 1);
   });
 

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-event-source-mapping-event.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-event-source-mapping-event.ts
@@ -1,0 +1,73 @@
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import { samRecordWithout } from "../../sim-cfn-sam-record.js";
+import type { SamFunctionEvent } from "./sim-cfn-sam-declared-event.js";
+import type { SamEventSourceKind } from "./sim-cfn-sam-event-source-kind.js";
+import {
+  samDynamoDbEventSource,
+  samSqsEventSource,
+} from "./sim-cfn-sam-event-source-kind.js";
+
+/**
+ * Expand one `SQS` event into the mapping that polls the queue for the
+ * function.
+ *
+ * The queue is named as an ARN, so an event naming one the template declares
+ * writes `Fn::GetAtt` and one naming a queue from elsewhere writes a literal.
+ * Either way the queue itself is somebody else's Resource.
+ */
+export function samSqsEventResources(
+  event: SamFunctionEvent,
+): Record<string, SimCfnTemplateValue> {
+  return mappingResources(event, samSqsEventSource);
+}
+
+/**
+ * Expand one `DynamoDB` event into the mapping that reads the table's stream
+ * for the function.
+ *
+ * `Stream` is the stream's ARN rather than the table's, which is what
+ * `Fn::GetAtt` on a table's `StreamArn` answers with.
+ */
+export function samDynamoDbEventResources(
+  event: SamFunctionEvent,
+): Record<string, SimCfnTemplateValue> {
+  return mappingResources(event, samDynamoDbEventSource);
+}
+
+/**
+ * The AWS::Lambda::EventSourceMapping an event polling a source expands into.
+ *
+ * Everything the event states beside the source goes onto the mapping under
+ * the name it already carries, so `BatchSize`, `StartingPosition`, `Enabled`
+ * and `FilterCriteria` arrive without being listed here. A property the
+ * mapping has no meaning for is refused by the mapping, which names it, rather
+ * than dropped on the way.
+ *
+ * An event naming no source expands into nothing. There is no mapping to make
+ * without one, and a mapping polling nothing would fail the whole deployment
+ * where the function on its own still stands.
+ */
+function mappingResources(
+  event: SamFunctionEvent,
+  kind: SamEventSourceKind,
+): Record<string, SimCfnTemplateValue> {
+  const source = event.properties[kind.sourceProperty];
+
+  if (source === undefined) {
+    return {};
+  }
+
+  return {
+    [`${event.functionLogicalId}${event.eventName}EventSourceMapping`]: {
+      Type: "AWS::Lambda::EventSourceMapping",
+      ...event.condition,
+      Properties: {
+        ...samRecordWithout(event.properties, kind.sourceProperty),
+        EventSourceArn: source,
+        // `Ref` on a function answers its name, which is what a mapping names
+        // its function by.
+        FunctionName: { Ref: event.functionLogicalId },
+      },
+    },
+  };
+}

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-event-source-role.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-event-source-role.ts
@@ -1,0 +1,81 @@
+import type { SimCfnTemplateValueRecord } from "../../../template/value/sim-cfn-template-value.js";
+import { samRecordAt, samValueList } from "../../sim-cfn-sam-record.js";
+import type { SamFunctionEvent } from "./sim-cfn-sam-declared-event.js";
+import type { SamEventSourceKind } from "./sim-cfn-sam-event-source-kind.js";
+import {
+  samDynamoDbEventSource,
+  samSqsEventSource,
+} from "./sim-cfn-sam-event-source-kind.js";
+import type { SamResourceEdit } from "./sim-cfn-sam-resource-edit.js";
+
+/**
+ * What an `SQS` event adds to the function's generated execution Role.
+ */
+export function samSqsEventEdits(
+  event: SamFunctionEvent,
+): readonly SamResourceEdit[] {
+  return pollingRoleEdits(event, samSqsEventSource);
+}
+
+/**
+ * What a `DynamoDB` event adds to the function's generated execution Role.
+ */
+export function samDynamoDbEventEdits(
+  event: SamFunctionEvent,
+): readonly SamResourceEdit[] {
+  return pollingRoleEdits(event, samDynamoDbEventSource);
+}
+
+/**
+ * The permission to poll, added to the execution Role the function was
+ * expanded with.
+ *
+ * Lambda refuses to create a mapping whose Role cannot poll the source, so the
+ * grant is part of expanding the event rather than something the template is
+ * left to write. SAM does the same thing by attaching a managed policy of its
+ * own.
+ *
+ * A function running as a Role it named itself was expanded with no Role, and
+ * this edit finds nothing to change. A Role the template declared says what
+ * the function may do, and SAM leaves that one alone too.
+ */
+function pollingRoleEdits(
+  event: SamFunctionEvent,
+  kind: SamEventSourceKind,
+): readonly SamResourceEdit[] {
+  const source = event.properties[kind.sourceProperty];
+
+  if (source === undefined) {
+    return [];
+  }
+
+  const policy = {
+    PolicyName: `${event.functionLogicalId}${event.eventName}PollerPolicy`,
+    PolicyDocument: {
+      Version: "2012-10-17",
+      Statement: [...kind.pollingStatements(source)],
+    },
+  };
+
+  return [
+    {
+      logicalId: `${event.functionLogicalId}Role`,
+      edit: (resource) => roleWithPolicy(resource, policy),
+    },
+  ];
+}
+
+function roleWithPolicy(
+  resource: SimCfnTemplateValueRecord,
+  policy: SimCfnTemplateValueRecord,
+): SimCfnTemplateValueRecord {
+  const properties = samRecordAt(resource, "Properties");
+
+  return {
+    ...resource,
+    Properties: {
+      ...properties,
+      Policies: [...samValueList(properties["Policies"]), policy],
+    },
+  };
+}

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-event-source.resources.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-event-source.resources.ts
@@ -1,0 +1,47 @@
+import type { SimCfnTemplateValueRecord } from "../../../template/value/sim-cfn-template-value.js";
+
+/**
+ * The Resources a SAM event points at, which the template declares itself.
+ *
+ * An event names a queue, a stream, a topic or a Bucket that already exists,
+ * so every test about one needs the thing it names standing beside the
+ * function. None of them is what any of these tests is about.
+ */
+
+/**
+ * The queue an `SQS` event polls.
+ */
+export const ordersQueue: SimCfnTemplateValueRecord = {
+  Type: "AWS::SQS::Queue",
+  Properties: { QueueName: "orders" },
+};
+
+/**
+ * The streamed table a `DynamoDB` event reads.
+ */
+export const ordersTable: SimCfnTemplateValueRecord = {
+  Type: "AWS::DynamoDB::Table",
+  Properties: {
+    TableName: "orders",
+    KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+    StreamSpecification: { StreamViewType: "NEW_AND_OLD_IMAGES" },
+  },
+};
+
+/**
+ * The topic an `SNS` event subscribes to.
+ */
+export const ordersTopic: SimCfnTemplateValueRecord = {
+  Type: "AWS::SNS::Topic",
+  Properties: { TopicName: "orders" },
+};
+
+/**
+ * The Bucket an `S3` event is notified by.
+ */
+export const uploadsBucket: SimCfnTemplateValueRecord = {
+  Type: "AWS::S3::Bucket",
+  Properties: { BucketName: "uploads" },
+};

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-function-events.iso.test.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-function-events.iso.test.ts
@@ -1,0 +1,95 @@
+import {
+  assertArrayLength,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../aws/sim-aws.js";
+import type { SimCfnTemplateValueRecord } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnStack } from "../../../stack/sim-cfn-stack.js";
+import {
+  samFunctionTemplateLogicalId,
+  simCfnSamFunctionTemplateFactory,
+} from "../sim-cfn-sam-function-template.factory.js";
+
+/**
+ * Deploy a SAM function carrying the given `Events` section, whatever shape it
+ * is in.
+ */
+async function deployedEvents(
+  stackName: string,
+  events: SimCfnTemplateValueRecord,
+  resources: SimCfnTemplateValueRecord = {},
+): Promise<SimCfnStack> {
+  const stack = await new SimAws().cloudFormation().deployTemplate({
+    stackName,
+    template: simCfnSamFunctionTemplateFactory.make({
+      functionProperties: { Events: events },
+      resources,
+    }),
+  });
+  await stack.waitForDeployComplete();
+
+  return stack;
+}
+
+describe("SAM function events the expansion cannot read", () => {
+  it("leaves the function as it is for an event that is not an object", async () => {
+    // Given a function whose event is a bare string, which is not what an
+    // event is written as
+
+    // When it is deployed
+    const stack = await deployedEvents("stringly-stack", { Work: "SQS" });
+
+    // Then the function deployed with nothing in front of it, rather than the
+    // deployment failing over an event nothing can read
+    assertNonNullable(stack.getResource(samFunctionTemplateLogicalId));
+    assertArrayLength(stack.skippedResources, 0);
+  });
+
+  it("leaves the function as it is for an event naming no Type", async () => {
+    // Given an event stating properties and no type to read them as
+    const stack = await deployedEvents("typeless-stack", {
+      Work: { Properties: { Queue: "arn:aws:sqs:us-east-1:1:orders" } },
+    });
+
+    // Then the function deployed on its own
+    assertNonNullable(stack.getResource(samFunctionTemplateLogicalId));
+    assertArrayLength(stack.skippedResources, 0);
+  });
+
+  it("leaves the function as it is for an event stating no Properties", async () => {
+    // Given an event of a type this expands, stating nothing for it to expand
+    const stack = await deployedEvents("propertyless-stack", {
+      Work: { Type: "SQS" },
+    });
+
+    // Then the function deployed with nothing polling for it
+    assertNonNullable(stack.getResource(samFunctionTemplateLogicalId));
+    assertUndefined(
+      stack.getResource(
+        `${samFunctionTemplateLogicalId}WorkEventSourceMapping`,
+      ),
+    );
+    assertArrayLength(stack.skippedResources, 0);
+  });
+
+  it("changes nothing for an event naming a Resource the template lacks", async () => {
+    // Given an S3 event naming a Bucket the template never declares
+    const stack = await deployedEvents("absent-bucket-stack", {
+      Upload: {
+        Type: "S3",
+        Properties: { Bucket: "Missing", Events: "s3:ObjectCreated:*" },
+      },
+    });
+
+    // Then the permission the event brought was deployed and there was
+    // nothing to notify
+    assertNonNullable(
+      stack.getResource(`${samFunctionTemplateLogicalId}UploadS3Permission`),
+    );
+    assertUndefined(stack.getResource("Missing"));
+    assertArrayLength(stack.skippedResources, 0);
+  });
+});

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-function-events.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-function-events.ts
@@ -1,46 +1,29 @@
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
 import type {
-  SimCfnTemplateValue,
-  SimCfnTemplateValueRecord,
-} from "../../../template/value/sim-cfn-template-value.js";
-import { isSamTemplateRecord } from "../../sim-cfn-sam-record.js";
-import { samConditionAttribute } from "../sim-cfn-sam-function-properties.js";
+  SamFunctionEvent,
+  SamFunctionEventsProperties,
+} from "./sim-cfn-sam-declared-event.js";
+import { samDeclaredEvents } from "./sim-cfn-sam-declared-event.js";
+import {
+  samDynamoDbEventResources,
+  samSqsEventResources,
+} from "./sim-cfn-sam-event-source-mapping-event.js";
+import {
+  samDynamoDbEventEdits,
+  samSqsEventEdits,
+} from "./sim-cfn-sam-event-source-role.js";
 import { samEventBridgeRuleEventResources } from "./sim-cfn-sam-event-bridge-rule-event.js";
 import { samHttpApiEventResources } from "./sim-cfn-sam-http-api-event.js";
+import type { SamResourceEdit } from "./sim-cfn-sam-resource-edit.js";
+import {
+  samS3EventEdits,
+  samS3EventResources,
+} from "./sim-cfn-sam-s3-event.js";
 import { samScheduleEventResources } from "./sim-cfn-sam-schedule-event.js";
 import { samScheduleV2EventResources } from "./sim-cfn-sam-schedule-v2-event.js";
+import { samSnsEventResources } from "./sim-cfn-sam-sns-event.js";
 
-interface SamFunctionEventsProperties {
-  /** The logical ID of the SAM function whose events these are. */
-  readonly logicalId: string;
-  /** The function properties, with the `Globals` defaults already merged in. */
-  readonly functionProperties: SimCfnTemplateValueRecord;
-  /** The `Condition` the SAM Resource carried, where it carried one. */
-  readonly condition: SimCfnTemplateValue | undefined;
-}
-
-/**
- * What an expansion is told about the event it is expanding.
- */
-export interface SamFunctionEvent {
-  /**
-   * The logical ID of the SAM function the event is declared on, which is also
-   * the logical ID of the Lambda function it is expanded into.
-   */
-  readonly functionLogicalId: string;
-  /** The name the function declared the event under in `Events`. */
-  readonly eventName: string;
-  /**
-   * The `Properties` of the event. An event stating none states an empty
-   * record.
-   */
-  readonly properties: SimCfnTemplateValueRecord;
-  /**
-   * The `Condition` attribute to put on the Resources that exist only because
-   * this function does, ready to spread. A function carrying no condition
-   * supplies nothing.
-   */
-  readonly condition: SimCfnTemplateValueRecord;
-}
+export type { SamFunctionEvent } from "./sim-cfn-sam-declared-event.js";
 
 /**
  * What one event type is expanded into, keyed by logical ID the way a function
@@ -49,6 +32,13 @@ export interface SamFunctionEvent {
 export type SamFunctionEventExpansion = (
   event: SamFunctionEvent,
 ) => Record<string, SimCfnTemplateValue>;
+
+/**
+ * What one event type changes about Resources it did not make.
+ */
+export type SamFunctionEventEdit = (
+  event: SamFunctionEvent,
+) => readonly SamResourceEdit[];
 
 /**
  * The SAM event types this expansion covers, by the name an event writes under
@@ -61,12 +51,36 @@ export type SamFunctionEventExpansion = (
  */
 const eventExpansions: ReadonlyMap<string, SamFunctionEventExpansion> = new Map(
   [
+    ["DynamoDB", samDynamoDbEventResources],
     ["EventBridgeRule", samEventBridgeRuleEventResources],
     ["HttpApi", samHttpApiEventResources],
+    ["S3", samS3EventResources],
+    ["SNS", samSnsEventResources],
+    ["SQS", samSqsEventResources],
     ["Schedule", samScheduleEventResources],
     ["ScheduleV2", samScheduleV2EventResources],
   ],
 );
+
+/**
+ * What one event type changes about Resources it did not make, by the name the
+ * event writes under `Type`.
+ *
+ * This is the second half of the same table, for what an event cannot express
+ * as a Resource of its own. An `S3` event notifies a Bucket the template
+ * declares, and a polled event grants the function's own execution Role the
+ * permission to poll. Keying either by the logical ID it changes would deploy
+ * the change in place of the Resource, since expanded Resources are merged
+ * last write wins.
+ *
+ * An event type belongs in both tables where it does both, as all three of
+ * these do.
+ */
+const eventEdits: ReadonlyMap<string, SamFunctionEventEdit> = new Map([
+  ["DynamoDB", samDynamoDbEventEdits],
+  ["S3", samS3EventEdits],
+  ["SQS", samSqsEventEdits],
+]);
 
 /**
  * The Resources the `Events` of a SAM function are expanded into.
@@ -79,45 +93,27 @@ const eventExpansions: ReadonlyMap<string, SamFunctionEventExpansion> = new Map(
 export function samFunctionEventResources(
   properties: SamFunctionEventsProperties,
 ): Record<string, SimCfnTemplateValue> {
-  const events = properties.functionProperties["Events"];
-
-  if (!isSamTemplateRecord(events)) {
-    return {};
-  }
-
   return Object.fromEntries(
-    Object.entries(events).flatMap(([eventName, event]) =>
-      Object.entries(expandedEvent(properties, eventName, event)),
+    samDeclaredEvents(properties).flatMap((declared) =>
+      Object.entries(
+        eventExpansions.get(declared.type)?.(declared.event) ?? {},
+      ),
     ),
   );
 }
 
 /**
- * The Resources one event is expanded into.
+ * The changes the `Events` of a SAM function make to Resources the template
+ * already declares.
+ *
+ * They are collected rather than applied here, because the Resources they name
+ * are the template's own and are nowhere near the function. They are applied
+ * once every SAM Resource in the template has been expanded.
  */
-function expandedEvent(
+export function samFunctionEventEdits(
   properties: SamFunctionEventsProperties,
-  eventName: string,
-  event: SimCfnTemplateValue,
-): Record<string, SimCfnTemplateValue> {
-  if (!isSamTemplateRecord(event)) {
-    return {};
-  }
-
-  const eventType = event["Type"];
-  const expansion =
-    typeof eventType === "string" ? eventExpansions.get(eventType) : undefined;
-
-  if (expansion === undefined) {
-    return {};
-  }
-
-  const eventProperties = event["Properties"];
-
-  return expansion({
-    functionLogicalId: properties.logicalId,
-    eventName,
-    properties: isSamTemplateRecord(eventProperties) ? eventProperties : {},
-    condition: samConditionAttribute(properties.condition),
-  });
+): readonly SamResourceEdit[] {
+  return samDeclaredEvents(properties).flatMap(
+    (declared) => eventEdits.get(declared.type)?.(declared.event) ?? [],
+  );
 }

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-http-api-event.iso.test.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-http-api-event.iso.test.ts
@@ -325,13 +325,16 @@ describe("SAM HttpApi event expansion", () => {
 
     // When it is deployed
     const stack = await simAws.cloudFormation().deployTemplate({
-      stackName: "queued-rates-stack",
+      stackName: "streamed-rates-stack",
       template: simCfnSamFunctionTemplateFactory.make({
         functionProperties: {
           Events: {
             Work: {
-              Type: "SQS",
-              Properties: { Queue: "arn:aws:sqs:eu-west-2:111111111111:work" },
+              Type: "Kinesis",
+              Properties: {
+                Stream: "arn:aws:kinesis:eu-west-2:111111111111:stream/work",
+                StartingPosition: "LATEST",
+              },
             },
           },
         },

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-resource-edit.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-resource-edit.ts
@@ -1,0 +1,58 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../template/value/sim-cfn-template-value.js";
+import { isSamTemplateRecord } from "../../sim-cfn-sam-record.js";
+
+/**
+ * A change an event makes to a Resource the template already declares.
+ *
+ * Most events expand into Resources of their own, which are keyed by a logical
+ * ID nothing else uses and merged into the template alongside everything else.
+ * An `S3` event has nowhere to put one. In CloudFormation a Bucket carries its
+ * own notifications, and the event adds to a Resource it did not make. Keying
+ * the expansion by the Bucket's logical ID would replace the Bucket, since the
+ * expanded Resources are merged last write wins. An edit instead says which
+ * Resource it changes, and is handed that Resource to rebuild.
+ */
+export interface SamResourceEdit {
+  /** The logical ID of the Resource in the template this edit changes. */
+  readonly logicalId: string;
+  /** The Resource as the edit leaves it, from the Resource as it stands. */
+  readonly edit: (
+    resource: SimCfnTemplateValueRecord,
+  ) => SimCfnTemplateValueRecord;
+}
+
+/**
+ * The expanded Resources with every edit applied, in the order the edits were
+ * collected.
+ *
+ * Each edit is handed what the one before it left, so two events notifying the
+ * same Bucket both reach it. An edit naming a Resource the template does not
+ * declare changes nothing, the way an event of a type nothing expands leaves
+ * the function as it is.
+ */
+export function samEditedResources(
+  resources: Record<string, SimCfnTemplateValue>,
+  edits: readonly SamResourceEdit[],
+): Record<string, SimCfnTemplateValue> {
+  return edits.reduce(
+    (edited, edit) => ({
+      ...edited,
+      ...editedResource(edited[edit.logicalId], edit),
+    }),
+    resources,
+  );
+}
+
+function editedResource(
+  resource: SimCfnTemplateValue | undefined,
+  edit: SamResourceEdit,
+): Record<string, SimCfnTemplateValue> {
+  if (!isSamTemplateRecord(resource)) {
+    return {};
+  }
+
+  return { [edit.logicalId]: edit.edit(resource) };
+}

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-s3-event.iso.test.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-s3-event.iso.test.ts
@@ -1,0 +1,209 @@
+import { PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../../template/sim-cfn-template.js";
+import type { SimCfnTemplateValueRecord } from "../../../template/value/sim-cfn-template-value.js";
+import {
+  samFunctionTemplateLogicalId,
+  simCfnSamFunctionTemplateFactory,
+} from "../sim-cfn-sam-function-template.factory.js";
+import { uploadsBucket } from "./sim-cfn-sam-event-source.resources.js";
+
+/**
+ * The part of the S3 event document these tests read.
+ */
+interface S3EventDocument {
+  readonly Records: readonly [
+    {
+      readonly eventName: string;
+      readonly s3: { readonly object: { readonly key: string } };
+    },
+  ];
+}
+
+/**
+ * A SAM template notifying the function about the Bucket it declares.
+ */
+function notifiedTemplate(
+  eventProperties: SimCfnTemplateValueRecord,
+  bucket: SimCfnTemplateValueRecord = uploadsBucket,
+): CfnTemplateBodyRecord {
+  return simCfnSamFunctionTemplateFactory.make({
+    functionProperties: {
+      Events: {
+        Upload: {
+          Type: "S3",
+          Properties: { Bucket: "UploadsBucket", ...eventProperties },
+        },
+      },
+    },
+    resources: { UploadsBucket: bucket },
+  });
+}
+
+/**
+ * Deploy a template, put the given Object keys into the Bucket it declares,
+ * and answer with what the bound handler was given.
+ */
+async function uploadedObjects(
+  template: CfnTemplateBodyRecord,
+  keys: readonly string[],
+): Promise<readonly S3EventDocument[]> {
+  const simAws = new SimAws();
+  const received: S3EventDocument[] = [];
+
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "uploads-stack",
+    template,
+    bindings: [
+      {
+        logicalId: samFunctionTemplateLogicalId,
+        handler: (event: S3EventDocument): undefined => {
+          received.push(event);
+
+          return undefined;
+        },
+      },
+    ],
+  });
+  await stack.waitForDeployComplete();
+
+  await Promise.all(
+    keys.map(async (key) =>
+      simAws.s3().putObject(
+        new PutObjectCommand({
+          Bucket: "uploads",
+          Key: key,
+          Body: "a picture",
+        }),
+      ),
+    ),
+  );
+  await simAws.backgroundTasksComplete();
+
+  return received;
+}
+
+describe("SAM S3 event expansion", () => {
+  it("notifies the function of an Object put into the Bucket", async () => {
+    // Given a SAM function with an S3 event naming a Bucket the template
+    // declares
+
+    // When it is deployed and an Object is put into that Bucket
+    const received = await uploadedObjects(
+      notifiedTemplate({ Events: "s3:ObjectCreated:*" }),
+      ["cat.jpg"],
+    );
+
+    // Then the put reached the bound handler, which means the event both
+    // notified the Bucket and granted S3 the permission to invoke the function
+    assertArrayLength(received, 1);
+    assertIdentical(received[0].Records[0].eventName, "ObjectCreated:Put");
+    assertIdentical(received[0].Records[0].s3.object.key, "cat.jpg");
+  });
+
+  it("notifies only what the event's Filter matches", async () => {
+    // Given an S3 event filtered to one suffix
+
+    // When Objects of two suffixes are put into the Bucket
+    const received = await uploadedObjects(
+      notifiedTemplate({
+        Events: "s3:ObjectCreated:*",
+        Filter: { S3Key: { Rules: [{ Name: "suffix", Value: ".jpg" }] } },
+      }),
+      ["cat.jpg", "notes.txt"],
+    );
+
+    // Then only the matching one reached the function
+    assertArrayLength(received, 1);
+    assertIdentical(received[0].Records[0].s3.object.key, "cat.jpg");
+  });
+
+  it("keeps the notifications the Bucket already declared", async () => {
+    // Given a Bucket that already notifies the function of removals and waits
+    // on it, and an event adding creations to that
+    const withRemovals: SimCfnTemplateValueRecord = {
+      Type: "AWS::S3::Bucket",
+      DependsOn: samFunctionTemplateLogicalId,
+      Properties: {
+        BucketName: "uploads",
+        NotificationConfiguration: {
+          LambdaConfigurations: [
+            {
+              Event: "s3:ObjectRemoved:*",
+              Function: {
+                "Fn::GetAtt": [samFunctionTemplateLogicalId, "Arn"],
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    // When it is deployed and an Object is put into the Bucket
+    const received = await uploadedObjects(
+      notifiedTemplate({ Events: ["s3:ObjectCreated:*"] }, withRemovals),
+      ["cat.jpg"],
+    );
+
+    // Then the event's own notification was added rather than replacing the
+    // one the template wrote by hand
+    assertArrayLength(received, 1);
+    assertIdentical(received[0].Records[0].eventName, "ObjectCreated:Put");
+  });
+
+  it("expands nothing for an event naming no event to be told about", async () => {
+    // Given an S3 event naming a Bucket and no S3 event to be notified of
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "eventless-uploads-stack",
+      template: notifiedTemplate({}),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the Bucket deployed unnotified, rather than carrying a
+    // configuration naming nothing
+    assertNonNullable(stack.getResource("UploadsBucket"));
+    assertUndefined(
+      stack.getResource(`${samFunctionTemplateLogicalId}UploadS3Permission`),
+    );
+    assertArrayLength(stack.skippedResources, 0);
+  });
+
+  it("expands nothing for an event naming no Bucket", async () => {
+    // Given an S3 event that names no Bucket to be notified by
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "bucketless-stack",
+      template: simCfnSamFunctionTemplateFactory.make({
+        functionProperties: {
+          Events: {
+            Upload: {
+              Type: "S3",
+              Properties: { Events: "s3:ObjectCreated:*" },
+            },
+          },
+        },
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the function deployed with nothing notifying it
+    assertNonNullable(stack.getResource(samFunctionTemplateLogicalId));
+    assertUndefined(
+      stack.getResource(`${samFunctionTemplateLogicalId}UploadS3Permission`),
+    );
+    assertArrayLength(stack.skippedResources, 0);
+  });
+});

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-s3-event.iso.test.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-s3-event.iso.test.ts
@@ -1,8 +1,10 @@
-import { PutObjectCommand } from "@aws-sdk/client-s3";
+import { DeleteObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
 import {
   assertArrayLength,
   assertIdentical,
   assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
   assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
@@ -55,6 +57,7 @@ function notifiedTemplate(
 async function uploadedObjects(
   template: CfnTemplateBodyRecord,
   keys: readonly string[],
+  deletedKeys: readonly string[] = [],
 ): Promise<readonly S3EventDocument[]> {
   const simAws = new SimAws();
   const received: S3EventDocument[] = [];
@@ -84,6 +87,15 @@ async function uploadedObjects(
           Body: "a picture",
         }),
       ),
+    ),
+  );
+  await simAws.backgroundTasksComplete();
+
+  await Promise.all(
+    deletedKeys.map(async (key) =>
+      simAws
+        .s3()
+        .deleteObject(new DeleteObjectCommand({ Bucket: "uploads", Key: key })),
     ),
   );
   await simAws.backgroundTasksComplete();
@@ -147,16 +159,124 @@ describe("SAM S3 event expansion", () => {
       },
     };
 
-    // When it is deployed and an Object is put into the Bucket
+    // When it is deployed, and an Object is put into the Bucket and then
+    // deleted again
     const received = await uploadedObjects(
       notifiedTemplate({ Events: ["s3:ObjectCreated:*"] }, withRemovals),
       ["cat.jpg"],
+      ["cat.jpg"],
     );
 
-    // Then the event's own notification was added rather than replacing the
-    // one the template wrote by hand
-    assertArrayLength(received, 1);
+    // Then both notifications fired, so the event's own was added rather than
+    // put in place of the one the template wrote by hand
+    assertArrayLength(received, 2);
     assertIdentical(received[0].Records[0].eventName, "ObjectCreated:Put");
+    assertIdentical(received[1].Records[0].eventName, "ObjectRemoved:Delete");
+  });
+
+  it("refuses a Bucket whose notification list is an intrinsic", async () => {
+    // Given a Bucket stating its notifications through Fn::If, which is a list
+    // CloudFormation has not resolved by the time the event is expanded
+    const simAws = new SimAws();
+    const conditional: SimCfnTemplateValueRecord = {
+      Type: "AWS::S3::Bucket",
+      Properties: {
+        BucketName: "uploads",
+        NotificationConfiguration: {
+          LambdaConfigurations: {
+            "Fn::If": [
+              "IsProduction",
+              [
+                {
+                  Event: "s3:ObjectRemoved:*",
+                  Function: {
+                    "Fn::GetAtt": [samFunctionTemplateLogicalId, "Arn"],
+                  },
+                },
+              ],
+              [],
+            ],
+          },
+        },
+      },
+    };
+
+    // When an S3 event asks to be added to it
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "intrinsic-uploads-stack",
+        template: {
+          ...notifiedTemplate({ Events: "s3:ObjectCreated:*" }, conditional),
+          Parameters: { Stage: { Type: "String" } },
+          Conditions: {
+            IsProduction: { "Fn::Equals": [{ Ref: "Stage" }, "production"] },
+          },
+        },
+        parameters: { Stage: "test" },
+      });
+    });
+
+    // Then the Bucket is refused by name, rather than deploying with the
+    // notifications it declared quietly dropped
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::S3::Bucket NotificationConfiguration in Resource " +
+        "UploadsBucket",
+    );
+    assertStringIncludes(error.message, "LambdaConfigurations");
+  });
+
+  it("refuses a Bucket a conditioned function's event would break", async () => {
+    // Given a function the template conditions out, with an S3 event on a
+    // Bucket that is not conditioned
+    const simAws = new SimAws();
+
+    // When it is deployed with the condition false
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "conditioned-uploads-stack",
+        template: {
+          Transform: "AWS::Serverless-2016-10-31",
+          Parameters: { Stage: { Type: "String" } },
+          Conditions: {
+            IsProduction: { "Fn::Equals": [{ Ref: "Stage" }, "production"] },
+          },
+          Resources: {
+            UploadsBucket: uploadsBucket,
+            [samFunctionTemplateLogicalId]: {
+              Type: "AWS::Serverless::Function",
+              Condition: "IsProduction",
+              Properties: {
+                FunctionName: "rates",
+                Handler: "index.handler",
+                Runtime: "nodejs22.x",
+                InlineCode: "exports.handler = async () => 'rates';",
+                Events: {
+                  Upload: {
+                    Type: "S3",
+                    Properties: {
+                      Bucket: "UploadsBucket",
+                      Events: "s3:ObjectCreated:*",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        parameters: { Stage: "test" },
+      });
+    });
+
+    // Then the Stack says which Resource named the function it never created.
+    // A notification belongs to the Bucket, and there is no conditioning one
+    // entry of somebody else's property, so a template wanting the function
+    // conditioned has to condition the Bucket with it.
+    assertStringIncludes(
+      error.message,
+      `Resource UploadsBucket names Resource ${samFunctionTemplateLogicalId}`,
+    );
+    assertStringIncludes(error.message, "Condition IsProduction is false");
   });
 
   it("expands nothing for an event naming no event to be told about", async () => {

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-s3-event.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-s3-event.ts
@@ -79,6 +79,7 @@ export function samS3EventEdits(
       logicalId: notification.bucketLogicalId,
       edit: (resource) =>
         samS3NotifiedBucket(resource, {
+          bucketLogicalId: notification.bucketLogicalId,
           configurations: notification.configurations,
           permissionLogicalId: permissionLogicalId(event),
         }),

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-s3-event.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-s3-event.ts
@@ -1,0 +1,139 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../template/value/sim-cfn-template-value.js";
+import { samValueList } from "../../sim-cfn-sam-record.js";
+import type { SamFunctionEvent } from "./sim-cfn-sam-declared-event.js";
+import type { SamResourceEdit } from "./sim-cfn-sam-resource-edit.js";
+import { samS3NotifiedBucket } from "./sim-cfn-sam-s3-notified-bucket.js";
+
+/**
+ * What an `S3` event puts on the Bucket and what it needs beside it.
+ */
+interface SamS3EventNotification {
+  /** The logical ID of the Bucket the event names. */
+  readonly bucketLogicalId: string;
+  /** One `LambdaConfigurations` entry for each event name stated. */
+  readonly configurations: readonly SimCfnTemplateValueRecord[];
+}
+
+/**
+ * The Resource an `S3` event expands into, which is the permission S3 invokes
+ * the function under.
+ *
+ * S3 checks the function's resource policy as the notification is applied and
+ * again on every event, so the Bucket's own Resource is not enough on its own.
+ *
+ * The grant names the Account rather than the Bucket. A Bucket ARN would have
+ * to come from `Fn::GetAtt` on the Bucket, and the Bucket already names the
+ * function, which is the circular dependency CloudFormation refuses.
+ */
+export function samS3EventResources(
+  event: SamFunctionEvent,
+): Record<string, SimCfnTemplateValue> {
+  if (samS3EventNotification(event) === undefined) {
+    return {};
+  }
+
+  return {
+    [permissionLogicalId(event)]: {
+      Type: "AWS::Lambda::Permission",
+      ...event.condition,
+      Properties: {
+        Action: "lambda:InvokeFunction",
+        FunctionName: { "Fn::GetAtt": [event.functionLogicalId, "Arn"] },
+        Principal: "s3.amazonaws.com",
+        SourceAccount: { Ref: "AWS::AccountId" },
+      },
+    },
+  };
+}
+
+/**
+ * The change an `S3` event makes to the Bucket the template already declares.
+ *
+ * An S3 notification is a property of the Bucket, so this is the one event type
+ * with no Resource of its own to be. The event adds its own
+ * `LambdaConfigurations` entries and leaves whatever the Bucket already
+ * carried, so a template configuring notifications by hand keeps them and two
+ * events on one Bucket both arrive.
+ *
+ * The Bucket is made to depend on the permission, because S3 refuses a
+ * destination it may not invoke and nothing else orders the two.
+ *
+ * The notification is unconditional even where the function is conditioned. A
+ * `Condition` covers a whole Resource, and there is no conditioning a fragment
+ * of somebody else's property.
+ */
+export function samS3EventEdits(
+  event: SamFunctionEvent,
+): readonly SamResourceEdit[] {
+  const notification = samS3EventNotification(event);
+
+  if (notification === undefined) {
+    return [];
+  }
+
+  return [
+    {
+      logicalId: notification.bucketLogicalId,
+      edit: (resource) =>
+        samS3NotifiedBucket(resource, {
+          configurations: notification.configurations,
+          permissionLogicalId: permissionLogicalId(event),
+        }),
+    },
+  ];
+}
+
+/**
+ * What the event asks of the Bucket, or nothing where it named no Bucket or no
+ * event to be told about.
+ *
+ * Either one missing leaves the function as it is rather than failing the
+ * deployment, the same answer an event of a type nothing expands gets.
+ */
+function samS3EventNotification(
+  event: SamFunctionEvent,
+): SamS3EventNotification | undefined {
+  const bucket = event.properties["Bucket"];
+  const configurations = lambdaConfigurations(event);
+
+  if (typeof bucket !== "string" || configurations.length === 0) {
+    return undefined;
+  }
+
+  return { bucketLogicalId: bucket, configurations };
+}
+
+/**
+ * The `LambdaConfigurations` entries the event's `Events` name.
+ *
+ * `Events` holds one event name or a list of them, where a CloudFormation
+ * configuration carries exactly one, so a list of three is three
+ * configurations pointing at the same function. The `Filter` an event states is
+ * already written the way a Bucket writes one, and goes on each of them.
+ */
+function lambdaConfigurations(
+  event: SamFunctionEvent,
+): readonly SimCfnTemplateValueRecord[] {
+  const filter = event.properties["Filter"];
+
+  return eventNames(event.properties["Events"]).map((name) => ({
+    Event: name,
+    ...(filter !== undefined && { Filter: filter }),
+    Function: { "Fn::GetAtt": [event.functionLogicalId, "Arn"] },
+  }));
+}
+
+function eventNames(events: SimCfnTemplateValue | undefined): string[] {
+  if (typeof events === "string") {
+    return [events];
+  }
+
+  return samValueList(events).filter((name) => typeof name === "string");
+}
+
+function permissionLogicalId(event: SamFunctionEvent): string {
+  return `${event.functionLogicalId}${event.eventName}S3Permission`;
+}

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-s3-notified-bucket.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-s3-notified-bucket.ts
@@ -1,0 +1,58 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../template/value/sim-cfn-template-value.js";
+import { samRecordAt, samValueList } from "../../sim-cfn-sam-record.js";
+
+interface SamS3NotifiedBucketProperties {
+  /** The `LambdaConfigurations` entries the event adds. */
+  readonly configurations: readonly SimCfnTemplateValueRecord[];
+  /** The logical ID of the permission S3 invokes the function under. */
+  readonly permissionLogicalId: string;
+}
+
+/**
+ * The Bucket with an event's notifications on it and the permission ahead of
+ * it.
+ *
+ * What the Bucket already carried is kept, so a template configuring
+ * notifications by hand keeps them and two events on one Bucket both arrive.
+ *
+ * The Bucket is made to depend on the permission, because S3 refuses a
+ * destination it may not invoke and nothing else orders the two.
+ */
+export function samS3NotifiedBucket(
+  resource: SimCfnTemplateValueRecord,
+  notified: SamS3NotifiedBucketProperties,
+): SimCfnTemplateValueRecord {
+  const properties = samRecordAt(resource, "Properties");
+  const configuration = samRecordAt(properties, "NotificationConfiguration");
+
+  return {
+    ...resource,
+    DependsOn: [
+      ...dependencies(resource["DependsOn"]),
+      notified.permissionLogicalId,
+    ],
+    Properties: {
+      ...properties,
+      NotificationConfiguration: {
+        ...configuration,
+        LambdaConfigurations: [
+          ...samValueList(configuration["LambdaConfigurations"]),
+          ...notified.configurations,
+        ],
+      },
+    },
+  };
+}
+
+/**
+ * The `DependsOn` a Resource carries as a list, since CloudFormation takes a
+ * single logical ID in place of one.
+ */
+function dependencies(
+  dependsOn: SimCfnTemplateValue | undefined,
+): readonly SimCfnTemplateValue[] {
+  return typeof dependsOn === "string" ? [dependsOn] : samValueList(dependsOn);
+}

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-s3-notified-bucket.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-s3-notified-bucket.ts
@@ -1,10 +1,17 @@
+import { s3BucketNotificationError } from "../../../../s3/cfn/bucket/error/sim-cfn-s3-bucket-error.js";
 import type {
   SimCfnTemplateValue,
   SimCfnTemplateValueRecord,
 } from "../../../template/value/sim-cfn-template-value.js";
-import { samRecordAt, samValueList } from "../../sim-cfn-sam-record.js";
+import {
+  isSamTemplateRecord,
+  samRecordAt,
+  samValueList,
+} from "../../sim-cfn-sam-record.js";
 
 interface SamS3NotifiedBucketProperties {
+  /** The logical ID of the Bucket, for a refusal to name it. */
+  readonly bucketLogicalId: string;
   /** The `LambdaConfigurations` entries the event adds. */
   readonly configurations: readonly SimCfnTemplateValueRecord[];
   /** The logical ID of the permission S3 invokes the function under. */
@@ -26,7 +33,7 @@ export function samS3NotifiedBucket(
   notified: SamS3NotifiedBucketProperties,
 ): SimCfnTemplateValueRecord {
   const properties = samRecordAt(resource, "Properties");
-  const configuration = samRecordAt(properties, "NotificationConfiguration");
+  const configuration = declaredConfiguration(properties, notified);
 
   return {
     ...resource,
@@ -39,12 +46,66 @@ export function samS3NotifiedBucket(
       NotificationConfiguration: {
         ...configuration,
         LambdaConfigurations: [
-          ...samValueList(configuration["LambdaConfigurations"]),
+          ...declaredLambdaConfigurations(configuration, notified),
           ...notified.configurations,
         ],
       },
     },
   };
+}
+
+/**
+ * The `NotificationConfiguration` the Bucket already carries.
+ *
+ * A Bucket writing it as an intrinsic is refused rather than expanded. The
+ * event's own configurations would go on the Bucket and everything the
+ * intrinsic resolved to would be dropped, which is a Bucket that quietly stops
+ * notifying whatever it used to.
+ */
+function declaredConfiguration(
+  properties: SimCfnTemplateValueRecord,
+  notified: SamS3NotifiedBucketProperties,
+): SimCfnTemplateValueRecord {
+  const declared = properties["NotificationConfiguration"];
+
+  if (declared !== undefined && !isSamTemplateRecord(declared)) {
+    throw notificationError(notified, "NotificationConfiguration");
+  }
+
+  return samRecordAt(properties, "NotificationConfiguration");
+}
+
+/**
+ * The `LambdaConfigurations` the Bucket already carries, refusing one an event
+ * cannot be added to.
+ *
+ * CloudFormation has no way to append to a list it has not resolved yet, so a
+ * list written as an intrinsic is the end of it.
+ */
+function declaredLambdaConfigurations(
+  configuration: SimCfnTemplateValueRecord,
+  notified: SamS3NotifiedBucketProperties,
+): readonly SimCfnTemplateValue[] {
+  const declared = configuration["LambdaConfigurations"];
+
+  if (declared !== undefined && !Array.isArray(declared)) {
+    throw notificationError(notified, "LambdaConfigurations");
+  }
+
+  return samValueList(declared);
+}
+
+function notificationError(
+  notified: SamS3NotifiedBucketProperties,
+  propertyName: string,
+): Error {
+  return s3BucketNotificationError(
+    notified.bucketLogicalId,
+    `${propertyName} is written as an intrinsic, and an S3 event on a SAM ` +
+      "function has no way to add to one CloudFormation has not resolved " +
+      "yet. Declare the notification the event asks for on the Bucket " +
+      "instead of stating the event",
+  );
 }
 
 /**

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-sns-event.iso.test.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-sns-event.iso.test.ts
@@ -1,0 +1,151 @@
+import { PublishCommand } from "@aws-sdk/client-sns";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../../template/sim-cfn-template.js";
+import type { SimCfnTemplateValueRecord } from "../../../template/value/sim-cfn-template-value.js";
+import {
+  samFunctionTemplateLogicalId,
+  simCfnSamFunctionTemplateFactory,
+} from "../sim-cfn-sam-function-template.factory.js";
+import { ordersTopic } from "./sim-cfn-sam-event-source.resources.js";
+
+/**
+ * The part of the SNS event document these tests read.
+ */
+interface SnsEventDocument {
+  readonly Records: readonly [{ readonly Sns: { readonly Message: string } }];
+}
+
+/**
+ * A SAM template subscribing the function to the topic it declares.
+ */
+function subscribedTemplate(
+  eventProperties: SimCfnTemplateValueRecord,
+): CfnTemplateBodyRecord {
+  return simCfnSamFunctionTemplateFactory.make({
+    functionProperties: {
+      Events: {
+        Orders: {
+          Type: "SNS",
+          Properties: { Topic: { Ref: "OrdersTopic" }, ...eventProperties },
+        },
+      },
+    },
+    resources: { OrdersTopic: ordersTopic },
+  });
+}
+
+/**
+ * Deploy a template, publish one message to the topic it declares, and answer
+ * with what the bound handler was given.
+ */
+async function publishedMessages(
+  template: CfnTemplateBodyRecord,
+  attributes: SimCfnTemplateValueRecord = {},
+): Promise<readonly SnsEventDocument[]> {
+  const simAws = new SimAws();
+  const received: SnsEventDocument[] = [];
+
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "orders-stack",
+    template,
+    bindings: [
+      {
+        logicalId: samFunctionTemplateLogicalId,
+        handler: (event: SnsEventDocument): undefined => {
+          received.push(event);
+
+          return undefined;
+        },
+      },
+    ],
+  });
+  await stack.waitForDeployComplete();
+
+  await simAws.sns().publish(
+    new PublishCommand({
+      TopicArn: `arn:aws:sns:${simAws.defaultRegionName}:${simAws.defaultAccountId}:orders`,
+      Message: "order-1",
+      ...attributes,
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+
+  assertArrayLength(simAws.sns().deliveryFailures, 0);
+
+  return received;
+}
+
+describe("SAM SNS event expansion", () => {
+  it("delivers a publish on the topic the event names to the function", async () => {
+    // Given a SAM function with an SNS event naming a topic the template
+    // declares
+
+    // When it is deployed and a message is published to that topic
+    const received = await publishedMessages(subscribedTemplate({}));
+
+    // Then the message reached the bound handler, which means the event both
+    // subscribed the function and granted SNS the permission to invoke it
+    assertArrayLength(received, 1);
+    assertIdentical(received[0].Records[0].Sns.Message, "order-1");
+  });
+
+  it("filters what reaches the function by the event's FilterPolicy", async () => {
+    // Given an SNS event subscribing only to the messages it wants
+
+    // When a message the policy does not match is published
+    const unmatched = await publishedMessages(
+      subscribedTemplate({ FilterPolicy: { region: ["eu-west-2"] } }),
+      {
+        MessageAttributes: {
+          region: { DataType: "String", StringValue: "us-east-1" },
+        },
+      },
+    );
+
+    // Then it did not reach the function
+    assertArrayLength(unmatched, 0);
+
+    // And a message the policy does match does reach it
+    const matched = await publishedMessages(
+      subscribedTemplate({ FilterPolicy: { region: ["eu-west-2"] } }),
+      {
+        MessageAttributes: {
+          region: { DataType: "String", StringValue: "eu-west-2" },
+        },
+      },
+    );
+
+    assertArrayLength(matched, 1);
+  });
+
+  it("expands nothing for an event naming no topic", async () => {
+    // Given an SNS event that names no topic to subscribe to
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "topicless-stack",
+      template: simCfnSamFunctionTemplateFactory.make({
+        functionProperties: {
+          Events: { Orders: { Type: "SNS", Properties: {} } },
+        },
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the function deployed with nothing subscribed for it
+    assertNonNullable(stack.getResource(samFunctionTemplateLogicalId));
+    assertUndefined(
+      stack.getResource(`${samFunctionTemplateLogicalId}OrdersSnsSubscription`),
+    );
+    assertArrayLength(stack.skippedResources, 0);
+  });
+});

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-sns-event.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-sns-event.ts
@@ -1,0 +1,78 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../template/value/sim-cfn-template-value.js";
+import { samRecordWithout } from "../../sim-cfn-sam-record.js";
+import type { SamFunctionEvent } from "./sim-cfn-sam-function-events.js";
+
+/**
+ * Expand one `SNS` event into the subscription that delivers the topic's
+ * messages to the function.
+ *
+ * The subscription is the function itself rather than a queue in front of it,
+ * so the protocol is `lambda` and the endpoint is the function's ARN. SNS
+ * consults the function's resource policy on every delivery, so the permission
+ * admitting SNS comes with it. Without one the topic has a subscription it
+ * cannot deliver to.
+ *
+ * Everything the event states beside `Topic` goes onto the subscription under
+ * the name it already carries, which is how `FilterPolicy` and its scope
+ * arrive. `SqsSubscription`, which asks for a queue between the two, is not a
+ * subscription property and is refused by the subscription rather than
+ * silently deploying the direct delivery the event did not ask for.
+ *
+ * An event naming no topic expands into nothing, the way a mapping with no
+ * source does.
+ */
+export function samSnsEventResources(
+  event: SamFunctionEvent,
+): Record<string, SimCfnTemplateValue> {
+  const topic = event.properties["Topic"];
+
+  if (topic === undefined) {
+    return {};
+  }
+
+  const prefix = `${event.functionLogicalId}${event.eventName}Sns`;
+
+  return {
+    [`${prefix}Subscription`]: subscriptionResource(event, topic),
+    [`${prefix}Permission`]: permissionResource(event, topic),
+  };
+}
+
+function subscriptionResource(
+  event: SamFunctionEvent,
+  topic: SimCfnTemplateValue,
+): SimCfnTemplateValueRecord {
+  return {
+    Type: "AWS::SNS::Subscription",
+    ...event.condition,
+    Properties: {
+      ...samRecordWithout(event.properties, "Topic"),
+      TopicArn: topic,
+      Protocol: "lambda",
+      Endpoint: { "Fn::GetAtt": [event.functionLogicalId, "Arn"] },
+    },
+  };
+}
+
+/**
+ * The AWS::Lambda::Permission the topic invokes the function under, granted
+ * for that topic alone.
+ */
+function permissionResource(
+  event: SamFunctionEvent,
+  topic: SimCfnTemplateValue,
+): SimCfnTemplateValueRecord {
+  return {
+    Type: "AWS::Lambda::Permission",
+    ...event.condition,
+    Properties: {
+      Action: "lambda:InvokeFunction",
+      FunctionName: { "Fn::GetAtt": [event.functionLogicalId, "Arn"] },
+      Principal: "sns.amazonaws.com",
+      SourceArn: topic,
+    },
+  };
+}

--- a/src/service/cloudformation/sam/function/sim-cfn-sam-function.ts
+++ b/src/service/cloudformation/sam/function/sim-cfn-sam-function.ts
@@ -3,7 +3,11 @@ import type {
   SimCfnTemplateValueRecord,
 } from "../../template/value/sim-cfn-template-value.js";
 import { samMergedFunctionProperties } from "../sim-cfn-sam-globals.js";
-import { samFunctionEventResources } from "./event/sim-cfn-sam-function-events.js";
+import {
+  samFunctionEventEdits,
+  samFunctionEventResources,
+} from "./event/sim-cfn-sam-function-events.js";
+import type { SamResourceEdit } from "./event/sim-cfn-sam-resource-edit.js";
 import {
   samCarriedAttributes,
   samCarriedProperties,
@@ -76,4 +80,28 @@ export function samFunctionResources(
     ...samFunctionUrlResources({ logicalId, functionProperties, condition }),
     ...samFunctionEventResources({ logicalId, functionProperties, condition }),
   };
+}
+
+/**
+ * The changes the `Events` of one AWS::Serverless::Function make to Resources
+ * the template already declares.
+ *
+ * An `S3` event notifies a Bucket the template declares elsewhere, and a
+ * polled event grants the function's own execution Role the permission to
+ * poll. Neither can be keyed by the logical ID it changes. That key is already
+ * taken, and the expanded Resources are merged last write wins.
+ */
+export function samFunctionResourceEdits(
+  properties: SamFunctionExpansionProperties,
+): readonly SamResourceEdit[] {
+  const { logicalId, resource, globals } = properties;
+
+  return samFunctionEventEdits({
+    logicalId,
+    functionProperties: samMergedFunctionProperties(
+      globals,
+      samResourceProperties(resource),
+    ),
+    condition: resource["Condition"],
+  });
 }

--- a/src/service/cloudformation/sam/sim-cfn-sam-expansion.ts
+++ b/src/service/cloudformation/sam/sim-cfn-sam-expansion.ts
@@ -5,7 +5,10 @@ import {
   samHttpApiResources,
   samHttpApiType,
 } from "./api/sim-cfn-sam-http-api.js";
+import type { SamResourceEdit } from "./function/event/sim-cfn-sam-resource-edit.js";
+import { samEditedResources } from "./function/event/sim-cfn-sam-resource-edit.js";
 import {
+  samFunctionResourceEdits,
   samFunctionResources,
   samFunctionType,
 } from "./function/sim-cfn-sam-function.js";
@@ -48,15 +51,44 @@ export function samExpandedTemplate(
   }
 
   const globals = samTemplateGlobals(template);
+  const resources = Object.entries(template.Resources);
 
   return {
     ...withoutSamSections(template),
-    Resources: Object.fromEntries(
-      Object.entries(template.Resources).flatMap(([logicalId, resource]) =>
-        Object.entries(expandedResource(logicalId, resource, globals)),
+    Resources: samEditedResources(
+      Object.fromEntries(
+        resources.flatMap(([logicalId, resource]) =>
+          Object.entries(expandedResource(logicalId, resource, globals)),
+        ),
+      ),
+      resources.flatMap(([logicalId, resource]) =>
+        resourceEdits(logicalId, resource, globals),
       ),
     ),
   };
+}
+
+/**
+ * The changes one template Resource makes to Resources it did not make.
+ *
+ * They are collected across the whole template and applied to the expanded
+ * Resources afterwards, because a Resource being edited may be expanded from a
+ * SAM Resource of its own and may not have been read yet.
+ */
+function resourceEdits(
+  logicalId: string,
+  resource: SimCfnTemplateValue,
+  globals: SamTemplateGlobals,
+): readonly SamResourceEdit[] {
+  if (!isSamTemplateRecord(resource) || resource["Type"] !== samFunctionType) {
+    return [];
+  }
+
+  return samFunctionResourceEdits({
+    logicalId,
+    resource,
+    globals: globals.forFunction,
+  });
 }
 
 /**

--- a/src/service/cloudformation/sam/sim-cfn-sam-record.ts
+++ b/src/service/cloudformation/sam/sim-cfn-sam-record.ts
@@ -1,5 +1,8 @@
 import { isRecord } from "../../../util/type-guard/record.js";
-import type { SimCfnTemplateValueRecord } from "../template/value/sim-cfn-template-value.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../template/value/sim-cfn-template-value.js";
 
 /**
  * Whether a template value is an object, and so something the expansion can
@@ -14,4 +17,54 @@ export function isSamTemplateRecord(
   value: unknown,
 ): value is SimCfnTemplateValueRecord {
   return isRecord(value);
+}
+
+/**
+ * A record without one of its keys.
+ *
+ * An event states the Resource it points at under a name of its own, `Queue`
+ * against `EventSourceArn` and `Topic` against `TopicArn`, and everything else
+ * it states is named the way the Resource names it. Dropping the one and
+ * carrying the rest is what expands the event without a list of property names
+ * to keep up to date, and a property the Resource has no meaning for is refused
+ * by the Resource rather than dropped here.
+ */
+export function samRecordWithout(
+  record: SimCfnTemplateValueRecord,
+  name: string,
+): SimCfnTemplateValueRecord {
+  return Object.fromEntries(
+    Object.entries(record).filter(([key]) => key !== name),
+  );
+}
+
+/**
+ * The record one name of a record holds, or an empty one where it holds
+ * nothing or holds something else.
+ *
+ * An expansion reading its way into a Resource asks for `Properties` and then
+ * for a property of them, and a Resource stating neither is a Resource with
+ * nothing there rather than a template to refuse.
+ */
+export function samRecordAt(
+  record: SimCfnTemplateValueRecord,
+  name: string,
+): SimCfnTemplateValueRecord {
+  // oxlint-disable-next-line security/detect-object-injection -- a template record read by the name of one of its own properties.
+  const value = record[name];
+
+  return isSamTemplateRecord(value) ? value : {};
+}
+
+/**
+ * A template value as a list, or an empty one where it is not a list at all.
+ *
+ * Adding to a list a Resource may not carry is the same shape everywhere it
+ * happens, whether the list is notification configurations, Role policies or
+ * the `DependsOn` of a Resource.
+ */
+export function samValueList(
+  value: SimCfnTemplateValue | undefined,
+): readonly SimCfnTemplateValue[] {
+  return Array.isArray(value) ? value : [];
 }


### PR DESCRIPTION
`SQS`, `DynamoDB`, `SNS` and `S3` events on an `AWS::Serverless::Function` now expand into the resources CloudFormation would create for them, so a message sent to the queue, a write to the streamed table, a publish to the topic and an object put into the bucket all reach the bound handler. A polled event becomes an `AWS::Lambda::EventSourceMapping` carrying whatever the event stated beside its source, which is how `BatchSize`, `StartingPosition`, `Enabled` and `FilterCriteria` arrive under the names the mapping reads them by. Two of the four have no resource of their own to be, since an `S3` event belongs to the bucket's `NotificationConfiguration` and a polled event needs the function's generated execution role to be allowed to poll, so the expansion gained a second table beside `eventExpansions` for edits to resources an event did not make, applied once every SAM resource in the template has been read. The `SamFunctionEventExpansion` contract and its existing entries are untouched.

Resolves #750

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for SAM function events triggered by SQS queues, DynamoDB streams, SNS topics, and S3 buckets.
  - Automatically configures event-source mappings, subscriptions, invocation permissions, polling policies, filters, and S3 notifications.
  - Preserves existing resource settings and supports conditional functions and asynchronous queue processing.
  - Added an end-to-end queue event example demonstrating message delivery and batch handling.

- **Documentation**
  - Expanded CloudFormation SAM event documentation with configuration details and examples.

- **Tests**
  - Added coverage for valid, filtered, disabled, incomplete, and unsupported event configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->