### PR TITLE
feat: deploy Lambda versions and aliases

### DIFF
--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -2067,6 +2067,11 @@ after the logical ID, and so does this.
 `FunctionName` accepts either a `Ref` to the function, giving its name, or an `Fn::GetAtt` on it,
 giving the ARN. A synthesized CDK app deploys either way with no special casing.
 
+A `FunctionName` carrying a version number or an alias name grants on that qualified resource, and
+the statement's `Resource` is the qualified ARN. This is how CDK writes `grantInvoke` on a
+`lambda.Alias`, and a grant made that way admits a call through the alias while `$LATEST` keeps a
+policy of its own. See [versions and aliases](#versions-and-aliases).
+
 ## Environment variables
 
 A function can declare its own environment variables with `Environment.Variables`, as on real
@@ -2497,6 +2502,102 @@ CDK templates work the same way. Synth the app, deploy the template file, and re
 `AWS::Lambda::Permission`, which deploys alongside it as
 [permissions in templates](#permissions-in-templates) covers.
 
+## Versions and aliases in templates
+
+`AWS::Lambda::Version` publishes a version of the function its `FunctionName` names, and
+`AWS::Lambda::Alias` gives one of those versions a name. CDK emits both for `fn.currentVersion` and
+`new lambda.Alias(...)`, and the integrations in such an app point at the alias.
+
+`FunctionName` accepts either a `Ref` to the function, giving its name, or an `Fn::GetAtt` on it,
+giving the ARN. `Ref` on the version resolves to the qualified function ARN
+(`arn:aws:lambda:us-east-1:888888888888:function:greeter:1`) and `Fn::GetAtt` `Version` to the
+number on the end of it. An alias's `FunctionVersion` is usually written from that number. `Ref` on
+the alias resolves to the alias ARN. `Fn::GetAtt` also supports `FunctionArn` on a version and
+`AliasArn` on an alias.
+
+```typescript sim-lambda-cloudformation-alias
+/**
+ * Deploying a Lambda version and an alias on it from a CloudFormation
+ * template, and invoking the function through the alias.
+ */
+
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "greeter-stack",
+  template: {
+    Resources: {
+      GreeterFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "greeter",
+          Role: "arn:aws:iam::111111111111:role/GreeterRole",
+          Handler: "index.handler",
+          Runtime: "nodejs22.x",
+          Code: {
+            ZipFile:
+              "exports.handler = async (event, context) => " +
+              "context.functionVersion;",
+          },
+        },
+      },
+      GreeterVersion: {
+        Type: "AWS::Lambda::Version",
+        Properties: {
+          FunctionName: { Ref: "GreeterFunction" },
+        },
+      },
+      GreeterAlias: {
+        Type: "AWS::Lambda::Alias",
+        Properties: {
+          FunctionName: { Ref: "GreeterFunction" },
+          Name: "live",
+          FunctionVersion: { "Fn::GetAtt": ["GreeterVersion", "Version"] },
+        },
+      },
+    },
+    Outputs: {
+      GreeterAliasArn: { Value: { Ref: "GreeterAlias" } },
+    },
+  },
+});
+await stack.waitForDeployComplete();
+
+console.log(stack.output("GreeterAliasArn"));
+
+const invoked = await simAws
+  .lambda()
+  .invoke(new InvokeCommand({ FunctionName: "greeter", Qualifier: "live" }));
+
+console.log(invoked.ExecutedVersion);
+
+await simAws.backgroundTasksComplete();
+```
+
+Supported `AWS::Lambda::Version` properties:
+
+- `FunctionName`
+- `Description`, which describes the published version and leaves the function's own description
+  alone
+
+Supported `AWS::Lambda::Alias` properties:
+
+- `FunctionName`
+- `Name`
+- `FunctionVersion`
+- `Description`
+
+An `AWS::Lambda::Permission` naming a version or an alias grants on it. See
+[permissions in templates](#permissions-in-templates).
+
+Deleting the Stack deletes the alias. Lambda has no operation that deletes one published version.
+The version Resource has nothing of its own to do on teardown, and the version it published goes
+when the function does.
+
 ## Executable bindings
 
 Deploy-time `bindings` let a template function be backed by a real in-process handler instead of its
@@ -2751,9 +2852,12 @@ Sim Lambda currently supports:
   `lambda:GetFunction`, `lambda:InvokeFunction`, the Function URL config actions, and the version
   and alias actions)
 - AWS-like validation and errors, such as `ResourceConflictException` for a duplicate function name
-- The `AWS::Lambda::Function`, `AWS::Lambda::Url`, `AWS::Lambda::Permission` and
-  `AWS::Lambda::EventSourceMapping` CloudFormation resources, with `Ref`/`Fn::GetAtt` support and
-  deploy-time executable bindings
+- The `AWS::Lambda::Function`, `AWS::Lambda::Url`, `AWS::Lambda::Permission`,
+  `AWS::Lambda::Version`, `AWS::Lambda::Alias` and `AWS::Lambda::EventSourceMapping`
+  CloudFormation resources, with `Ref`/`Fn::GetAtt` support and deploy-time executable bindings
+- A CDK app built on `fn.currentVersion` or a `lambda.Alias`, which deploys with the alias its
+  integrations point at, and where an `AWS::Lambda::Permission` naming that alias grants on the
+  alias
 - `AWS::Lambda::EventSourceMapping` on a queue or on a table's stream, including the
   `StartingPosition` a stream mapping needs, so a CDK `SqsEventSource` or `DynamoEventSource`
   deploys as it is synthesised
@@ -2787,13 +2891,16 @@ Current documented limitations:
   out.
 - A published version keeps what it was published with, and `UpdateFunctionCode` is absent, so
   `$LATEST` has no way to drift from it yet. The `CodeSha256` and `RevisionId` checks
-  `PublishVersion` makes are left out, along with `Description` on a published version, alias
-  `RoutingConfig` weights, provisioned concurrency, and the `Marker`/`MaxItems` paging on the two
-  listings.
+  `PublishVersion` makes are left out, along with alias `RoutingConfig` weights, provisioned
+  concurrency, and the `Marker`/`MaxItems` paging on the two listings. `CodeSha256`, `RuntimePolicy`
+  and `ProvisionedConcurrencyConfig` on `AWS::Lambda::Version`, and `RoutingConfig` and
+  `ProvisionedConcurrencyConfig` on `AWS::Lambda::Alias`, are accepted and ignored. SAM's
+  `AutoPublishAlias` is left out.
 - A qualified function ARN reaches a function through S3 notifications, SNS subscriptions,
   CloudWatch Logs subscriptions, Cognito triggers, EventBridge targets, event source mappings and
-  API Gateway integration and authorizer URIs. The CloudFormation target-function reader still
-  refuses or drops a qualifier.
+  API Gateway integration and authorizer URIs, and `AWS::Lambda::Permission`. The
+  `AWS::Lambda::Url` and `AWS::Lambda::EventSourceMapping` template readers still refuse or drop a
+  qualifier.
 - The vm runtime supports CommonJS function code only. ES module source (`.mjs` / `export` syntax)
   has yet to land.
 - A handler function reference is recorded through the process console and the process standard

--- a/docs/services/lambda/sim-lambda-cloudformation-alias.example.ts
+++ b/docs/services/lambda/sim-lambda-cloudformation-alias.example.ts
@@ -1,0 +1,60 @@
+/**
+ * Deploying a Lambda version and an alias on it from a CloudFormation
+ * template, and invoking the function through the alias.
+ */
+
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "greeter-stack",
+  template: {
+    Resources: {
+      GreeterFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "greeter",
+          Role: "arn:aws:iam::111111111111:role/GreeterRole",
+          Handler: "index.handler",
+          Runtime: "nodejs22.x",
+          Code: {
+            ZipFile:
+              "exports.handler = async (event, context) => " +
+              "context.functionVersion;",
+          },
+        },
+      },
+      GreeterVersion: {
+        Type: "AWS::Lambda::Version",
+        Properties: {
+          FunctionName: { Ref: "GreeterFunction" },
+        },
+      },
+      GreeterAlias: {
+        Type: "AWS::Lambda::Alias",
+        Properties: {
+          FunctionName: { Ref: "GreeterFunction" },
+          Name: "live",
+          FunctionVersion: { "Fn::GetAtt": ["GreeterVersion", "Version"] },
+        },
+      },
+    },
+    Outputs: {
+      GreeterAliasArn: { Value: { Ref: "GreeterAlias" } },
+    },
+  },
+});
+await stack.waitForDeployComplete();
+
+console.log(stack.output("GreeterAliasArn"));
+
+const invoked = await simAws
+  .lambda()
+  .invoke(new InvokeCommand({ FunctionName: "greeter", Qualifier: "live" }));
+
+console.log(invoked.ExecutedVersion);
+
+await simAws.backgroundTasksComplete();

--- a/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-alias.loc.test.ts
+++ b/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-alias.loc.test.ts
@@ -1,0 +1,106 @@
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertTypeString,
+} from "@kensio/smartass";
+import path from "node:path";
+import { describe, it } from "vitest";
+
+/**
+ * Slower local integration test. Calls the real CDK CLI to synth the output
+ * template file, then deploys the AWS::Lambda::Version and AWS::Lambda::Alias
+ * a `lambda.Alias` app puts in it.
+ */
+import { SimAws } from "../../../aws/sim-aws.js";
+import { TemporaryDirectory } from "../../../../util/filesystem/temporary-directory.js";
+import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+
+/**
+ * The Account and Region the stack is deployed into, which are the
+ * simulation's defaults, so the ARNs the app synthesizes and the ARNs the
+ * simulator creates are the same.
+ */
+const accountId = "888888888888";
+const regionName = "us-east-1";
+
+describe("Sim CDK Lambda alias local integration", () => {
+  it("deploys an alias an invocation reaches the published version through", async () => {
+    // Given a CDK stack with a function, its current version and a live alias
+    // on that version, which is the three Resources CDK synthesizes for it.
+    const simAws = new SimAws();
+    const projectDirectory = new TemporaryDirectory();
+    const cdkProject = new TestCdkProject({ projectDirectory });
+    await cdkProject.writeCdkAppFile(
+      `
+import * as cdk from "aws-cdk-lib/core";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: ${JSON.stringify(accountId)}, region: ${JSON.stringify(regionName)} },
+});
+
+const greeterFunction = new lambda.Function(stack, "GreeterFunction", {
+  functionName: "cdk-greeter",
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: lambda.Code.fromInline(
+    "exports.handler = async (event, context) => context.functionVersion;",
+  ),
+});
+
+const greeterAlias = new lambda.Alias(stack, "GreeterAlias", {
+  aliasName: "live",
+  version: greeterFunction.currentVersion,
+});
+
+new cdk.CfnOutput(stack, "AliasArn", { value: greeterAlias.functionArn });
+new cdk.CfnOutput(stack, "AliasVersion", {
+  value: greeterAlias.version.version,
+});
+
+app.synth();
+      `,
+    );
+
+    // And we synth the CDK template.
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When we deploy the template into sim CloudFormation.
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // Then the alias the app declared is what its outputs name.
+    const aliasArn = stack.outputs.get("AliasArn")?.value;
+    assertTypeString(aliasArn);
+    assertIdentical(
+      aliasArn,
+      `arn:aws:lambda:${regionName}:${accountId}:function:cdk-greeter:live`,
+    );
+    assertIdentical(stack.outputs.get("AliasVersion")?.value, "1");
+
+    // And an invocation through the alias runs the published version rather
+    // than $LATEST, which is what the function itself still answers as.
+    const throughAlias = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: aliasArn }));
+    assertIdentical(throughAlias.ExecutedVersion, "1");
+    assertNonNullable(throughAlias.Payload);
+    assertIdentical(
+      JSON.parse(Buffer.from(throughAlias.Payload).toString()),
+      "1",
+    );
+
+    const unqualified = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "cdk-greeter" }));
+    assertIdentical(unqualified.ExecutedVersion, "$LATEST");
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/service/cloudformation/resource/cfn/lambda/sim-lambda-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/lambda/sim-lambda-cfn-value-adapter.ts
@@ -1,9 +1,12 @@
 import { SimLambdaEventSourceMapping } from "../../../../lambda/event-source/sim-lambda-event-source-mapping.js";
 import { SimLambdaEventSourceMappingCfn } from "./sim-lambda-event-source-mapping-cfn.js";
 import { SimLambdaFunction } from "../../../../lambda/function/sim-lambda-function.js";
+import { SimLambdaFunctionAlias } from "../../../../lambda/function/version/sim-lambda-function-alias.js";
 import { SimLambdaFunctionUrl } from "../../../../lambda/function/url/sim-lambda-function-url.js";
+import { SimLambdaFunctionAliasCfn } from "./sim-lambda-function-alias-cfn.js";
 import { SimLambdaFunctionCfn } from "./sim-lambda-function-cfn.js";
 import { SimLambdaFunctionUrlCfn } from "./sim-lambda-function-url-cfn.js";
+import { SimLambdaFunctionVersionCfn } from "./sim-lambda-function-version-cfn.js";
 import type {
   SimCfnResourceValueAdapterProperties,
   SimCfnServiceValueAdapter,
@@ -20,6 +23,20 @@ export function lambdaValueAdapter(
     properties.simResource instanceof SimLambdaFunction
   ) {
     return new SimLambdaFunctionCfn({ lambdaFunction: properties.simResource });
+  }
+
+  if (
+    properties.type === "AWS::Lambda::Version" &&
+    properties.simResource instanceof SimLambdaFunction
+  ) {
+    return new SimLambdaFunctionVersionCfn({ version: properties.simResource });
+  }
+
+  if (
+    properties.type === "AWS::Lambda::Alias" &&
+    properties.simResource instanceof SimLambdaFunctionAlias
+  ) {
+    return new SimLambdaFunctionAliasCfn({ alias: properties.simResource });
   }
 
   if (

--- a/src/service/cloudformation/resource/cfn/lambda/sim-lambda-function-alias-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/lambda/sim-lambda-function-alias-cfn.ts
@@ -1,0 +1,44 @@
+import type { SimLambdaFunctionAlias } from "../../../../lambda/function/version/sim-lambda-function-alias.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimLambdaFunctionAliasCfnProperties {
+  readonly alias: SimLambdaFunctionAlias;
+}
+
+/**
+ * CloudFormation-facing behaviour for an AWS::Lambda::Alias Resource.
+ *
+ * The alias ARN is what the rest of a template interpolates, and CDK reads the
+ * alias name back out of it, so the ARN carries the name on the end rather
+ * than standing for the function.
+ */
+export class SimLambdaFunctionAliasCfn implements SimCfnResourceValueAdapter {
+  private readonly alias: SimLambdaFunctionAlias;
+
+  constructor(properties: SimLambdaFunctionAliasCfnProperties) {
+    this.alias = properties.alias;
+  }
+
+  /**
+   * CloudFormation Ref for AWS::Lambda::Alias returns the alias ARN.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.alias.arn;
+  }
+
+  /**
+   * CloudFormation attributes for AWS::Lambda::Alias.
+   *
+   * AWS::Lambda::Alias supports Fn::GetAtt for AliasArn.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    if (attributeName === "AliasArn") {
+      return this.alias.arn;
+    }
+
+    throw new Error(
+      `Unsupported AWS::Lambda::Alias attribute ${attributeName}`,
+    );
+  }
+}

--- a/src/service/cloudformation/resource/cfn/lambda/sim-lambda-function-version-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/lambda/sim-lambda-function-version-cfn.ts
@@ -1,0 +1,54 @@
+import type { SimLambdaFunction } from "../../../../lambda/function/sim-lambda-function.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimLambdaFunctionVersionCfnProperties {
+  readonly version: SimLambdaFunction;
+}
+
+/**
+ * CloudFormation-facing behaviour for an AWS::Lambda::Version Resource.
+ *
+ * A version is a function under a number, so the same simulated function
+ * object backs this Resource and AWS::Lambda::Function. What differs is what
+ * templates want from it: the ARN with the number on the end, which is what a
+ * later alias or integration has to be pointed at to reach this version rather
+ * than `$LATEST`.
+ */
+export class SimLambdaFunctionVersionCfn implements SimCfnResourceValueAdapter {
+  private readonly version: SimLambdaFunction;
+
+  constructor(properties: SimLambdaFunctionVersionCfnProperties) {
+    this.version = properties.version;
+  }
+
+  /**
+   * CloudFormation Ref for AWS::Lambda::Version returns the qualified function
+   * ARN, which is the function's own ARN with the version number appended.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.version.arn;
+  }
+
+  /**
+   * CloudFormation attributes for AWS::Lambda::Version.
+   *
+   * `Version` is the number the function was published under, which is what an
+   * alias's FunctionVersion is written from. `FunctionArn` is what
+   * PublishVersion answers with, so it names the version rather than the
+   * function.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    if (attributeName === "Version") {
+      return this.version.version;
+    }
+
+    if (attributeName === "FunctionArn") {
+      return this.version.arn;
+    }
+
+    throw new Error(
+      `Unsupported AWS::Lambda::Version attribute ${attributeName}`,
+    );
+  }
+}

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -388,10 +388,11 @@ before it is reported missing.
 Both answers come from one lookup. `SimLambdaFunctionTarget` carries the resource a qualifier named
 and the version that runs, and `findTarget` and `requireTarget` on the version store are what
 everything else here is built on. `SimLambdaFunctionLookup` offers the same two by function name,
-and `SimLambda.getSimFunctionTarget` is how the other simulated services reach a function a target
-ARN points at. Each of them resolves the qualifier at the moment it is asked, so an alias moved to
-another version moves what a standing notification, subscription, trigger, rule target, event
-source mapping or API Gateway route delivers to.
+and `SimLambda.getSimFunctionTarget` is how the other simulated services, and the CloudFormation
+version and permission creators, reach a function a target ARN points at. Each of them resolves the
+qualifier at the moment it is asked, so an alias moved to another version moves what a standing
+notification, subscription, trigger, rule target, event source mapping or API Gateway route
+delivers to.
 
 `SimLambdaServiceInvokeAuthorizer` takes that resource rather than the function, so a delivery to
 an alias is admitted by a grant made on the alias. The service being the caller is the only thing
@@ -704,13 +705,40 @@ rule. `StartingPosition` and `StartingPositionTimestamp` are read and passed on 
 here, since a stream mapping has to have a position and a queue mapping is refused for naming one,
 and only `CreateEventSourceMapping` knows which source the ARN names.
 
-Other `AWS::Lambda::*` resource types (`Version`, `Alias`, ...) are not supported and are skipped by
-the CloudFormation engine with an "Unsupported" diagnostic.
+### Versions and aliases
+
+`cfn/version/` publishes `AWS::Lambda::Version` through `PublishVersion`, and `cfn/alias/` creates
+`AWS::Lambda::Alias` through `CreateAlias`. A deployed template reaches the same store an SDK
+caller does. Both are what CDK emits for `fn.currentVersion` and `new lambda.Alias(...)`, and the
+integrations in such an app point at the alias.
+
+Each hands back the object the command created. The version creator reads it back with
+`SimLambda.getSimFunctionTarget(...)`, which answers with the version a number names, and the alias
+creator with `getSimFunctionAlias(...)`. `Ref` on the version resolves to the qualified function
+ARN and `Fn::GetAtt` `Version` to the number, and `Ref` on the alias resolves to the alias ARN. `SimLambdaFunctionVersionCfn` and `SimLambdaFunctionAliasCfn` under
+`src/service/cloudformation/resource/cfn/lambda/` hold that. The version adapter matches on the
+Resource type, since a published version and the function it came from are both a
+`SimLambdaFunction` and only the template says which Resource is being read.
+
+`cfn/permission/` reads a qualifier out of `FunctionName` and passes it to `AddPermission` as the
+`Qualifier`, then reads the statement back off the resource `getSimFunctionTarget` answers with.
+That is how a CDK `grantInvoke` on an alias lands on the alias. The other readers
+(`cfn/url/` and `cfn/event-source-mapping/`) act on the function itself and keep dropping it,
+through `simCfnLambdaTargetFunctionName`.
+
+`SimCfnLambdaResourceDeleter` deletes the alias on teardown. A version has no deleter, and the
+`Version` case does nothing on purpose. Lambda has no operation that deletes one published version.
+The version goes when the function it was published from does, and the Stack is tearing that
+function down in the same teardown.
+
+Other `AWS::Lambda::*` resource types (`LayerVersion`, `CodeSigningConfig`, ...) are not supported
+and are skipped by the CloudFormation engine with an "Unsupported" diagnostic.
 
 ## Not simulated yet
 
 - `AWS::Lambda::*` CloudFormation resource types other than `AWS::Lambda::Function`,
-  `AWS::Lambda::Url`, `AWS::Lambda::Permission` and `AWS::Lambda::EventSourceMapping`
+  `AWS::Lambda::Url`, `AWS::Lambda::Permission`, `AWS::Lambda::Version`, `AWS::Lambda::Alias` and
+  `AWS::Lambda::EventSourceMapping`
 - event sources other than SQS queues and DynamoDB streams, `FilterCriteria`,
   `UpdateEventSourceMapping`, and polling concurrency
 - Function URL `Cors` configuration and OPTIONS preflight handling
@@ -721,7 +749,8 @@ the CloudFormation engine with an "Unsupported" diagnostic.
   skipped or refused where neither does
 - `UpdateFunctionCode` and function listing
 - `RevisionId` and `EventSourceToken` on the permission commands, qualified Function URLs, alias
-  `RoutingConfig` weights, and provisioned concurrency
+  `RoutingConfig` weights, and provisioned concurrency, including `RoutingConfig`,
+  `ProvisionedConcurrencyConfig`, `CodeSha256` and `RuntimePolicy` on the two template resources
 - version and alias operations over the served HTTP API endpoint, which routes the other sixteen
 - Lambda Layers
 - environment variables reaching a real in-process handler's module scope (see "Environment

--- a/src/service/lambda/cfn/alias/sim-cfn-lambda-alias-creator.ts
+++ b/src/service/lambda/cfn/alias/sim-cfn-lambda-alias-creator.ts
@@ -1,0 +1,78 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimLambdaFunctionAlias } from "../../function/version/sim-lambda-function-alias.js";
+import type { SimLambda } from "../../sim-lambda.js";
+import { SimCfnLambdaPropertyParser } from "../function/sim-cfn-lambda-property-parser.js";
+import { simCfnLambdaTargetFunctionName } from "../function/sim-cfn-lambda-target-function.js";
+
+interface SimCfnLambdaAliasCreatorProperties {
+  readonly lambda: SimLambda;
+}
+
+/**
+ * Creates Lambda aliases from CloudFormation Resources.
+ *
+ * This is what CDK emits for `new lambda.Alias(...)` and for
+ * `fn.addAlias("live")`, and it is what the rest of such an app points at, so
+ * an integration deployed beside it reaches the version the alias names rather
+ * than `$LATEST`.
+ *
+ * `RoutingConfig` weights and `ProvisionedConcurrencyConfig` are not
+ * simulated. An alias here names one version, so a template splitting traffic
+ * across two gets the version its `FunctionVersion` names.
+ */
+export class SimCfnLambdaAliasCreator {
+  private readonly lambda: SimLambda;
+  private readonly propertyParser = new SimCfnLambdaPropertyParser();
+
+  constructor(properties: SimCfnLambdaAliasCreatorProperties) {
+    this.lambda = properties.lambda;
+  }
+
+  /**
+   * Create an alias from an AWS::Lambda::Alias Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimLambdaFunctionAlias> {
+    const functionName = simCfnLambdaTargetFunctionName(
+      this.propertyParser.requiredString(
+        resource,
+        properties["FunctionName"],
+        "FunctionName",
+      ),
+    );
+    const name = this.propertyParser.requiredString(
+      resource,
+      properties["Name"],
+      "Name",
+    );
+
+    await this.lambda.createAlias({
+      input: {
+        FunctionName: functionName,
+        Name: name,
+        FunctionVersion: this.propertyParser.requiredString(
+          resource,
+          properties["FunctionVersion"],
+          "FunctionVersion",
+        ),
+        Description: this.propertyParser.optionalString(
+          resource,
+          properties["Description"],
+          "Description",
+        ),
+      },
+    });
+
+    const alias = this.lambda.getSimFunctionAlias(functionName, name);
+    assertDefined(
+      alias,
+      `Sim Lambda alias ${name} of ${functionName} after CloudFormation creation`,
+    );
+
+    return alias;
+  }
+}

--- a/src/service/lambda/cfn/alias/sim-cfn-lambda-alias.iso.test.ts
+++ b/src/service/lambda/cfn/alias/sim-cfn-lambda-alias.iso.test.ts
@@ -1,0 +1,220 @@
+import { GetPolicyCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertObjectEquals,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../../cloudformation/template/sim-cfn-template.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimLambdaResourceNotFoundException } from "../../error/sim-lambda.error.js";
+import { SimLambdaFunctionAlias } from "../../function/version/sim-lambda-function-alias.js";
+
+const callerRoleArn = "arn:aws:iam::222222222222:role/Caller";
+
+const greeterFunction = {
+  Type: "AWS::Lambda::Function",
+  Properties: {
+    FunctionName: "greeter",
+    Role: "arn:aws:iam::888888888888:role/GreeterRole",
+    Code: { ZipFile: "exports.handler = async () => 'hello';" },
+    Handler: "index.handler",
+    Runtime: "nodejs22.x",
+  },
+};
+
+const greeterVersion = {
+  Type: "AWS::Lambda::Version",
+  Properties: { FunctionName: { Ref: "GreeterFunction" } },
+};
+
+function greeterTemplate(
+  aliasProperties: Record<string, SimCfnTemplateValue>,
+  extraResources: Record<string, unknown> = {},
+): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      GreeterFunction: greeterFunction,
+      GreeterVersion: greeterVersion,
+      GreeterAlias: {
+        Type: "AWS::Lambda::Alias",
+        Properties: aliasProperties,
+      },
+      ...extraResources,
+    },
+    Outputs: {
+      AliasRef: { Value: { Ref: "GreeterAlias" } },
+      AliasArn: { Value: { "Fn::GetAtt": ["GreeterAlias", "AliasArn"] } },
+    },
+  };
+}
+
+const liveAlias = {
+  FunctionName: { Ref: "GreeterFunction" },
+  Name: "live",
+  FunctionVersion: { "Fn::GetAtt": ["GreeterVersion", "Version"] },
+};
+
+describe("Lambda CloudFormation Alias deployment", () => {
+  it("creates an alias at the version its FunctionVersion names", async () => {
+    // Given a template with a function, a published version and an alias
+    // pointing at that version, which is what a CDK app synthesizes
+    const simAws = new SimAws();
+
+    // When the template is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "greeter-stack",
+      template: greeterTemplate({
+        ...liveAlias,
+        Description: "What callers reach",
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the Resource is backed by a simulated alias at that version
+    const alias = stack.getResource("GreeterAlias")?.simResource;
+    assertInstanceOf(alias, SimLambdaFunctionAlias);
+    assertIdentical(alias.name, "live");
+    assertIdentical(alias.functionVersion, "1");
+    assertIdentical(alias.configuration().Description, "What callers reach");
+
+    // And an invocation through the alias runs the published version rather
+    // than $LATEST
+    const invoked = await simAws
+      .lambda()
+      .invoke(
+        new InvokeCommand({ FunctionName: "greeter", Qualifier: "live" }),
+      );
+    assertIdentical(invoked.ExecutedVersion, "1");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("resolves Ref and Fn::GetAtt AliasArn to the alias ARN", async () => {
+    // Given a deployed stack with an alias
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "greeter-stack",
+      template: greeterTemplate(liveAlias),
+    });
+    await stack.waitForDeployComplete();
+
+    // When the stack outputs are read
+    // Then both name the alias, which is the function ARN with the alias name
+    // on the end, so the rest of the template reaches the alias rather than
+    // the function
+    const aliasArn =
+      "arn:aws:lambda:us-east-1:888888888888:function:greeter:live";
+    assertIdentical(stack.outputs.get("AliasRef")?.value, aliasArn);
+    assertIdentical(stack.outputs.get("AliasArn")?.value, aliasArn);
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("grants an AWS::Lambda::Permission naming the alias on the alias", async () => {
+    // Given a template granting another Account's Role the alias, which is
+    // how CDK writes grantInvoke on a lambda.Alias
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "greeter-stack",
+      template: greeterTemplate(liveAlias, {
+        GreeterAliasPermission: {
+          Type: "AWS::Lambda::Permission",
+          Properties: {
+            FunctionName: { Ref: "GreeterAlias" },
+            Action: "lambda:InvokeFunction",
+            Principal: callerRoleArn,
+          },
+        },
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the statement is held against the alias, with the alias ARN as its
+    // Resource, rather than against the function the alias points into
+    const policy = await simAws
+      .lambda()
+      .getPolicy(
+        new GetPolicyCommand({ FunctionName: "greeter", Qualifier: "live" }),
+      );
+    const statements = JSON.parse(policy.Policy).Statement;
+    assertArrayLength(statements, 1);
+    assertObjectEquals(statements[0], {
+      Sid: "GreeterAliasPermission",
+      Effect: "Allow",
+      Principal: { AWS: callerRoleArn },
+      Action: "lambda:InvokeFunction",
+      Resource: "arn:aws:lambda:us-east-1:888888888888:function:greeter:live",
+    });
+
+    // And the function itself was granted nothing, so a call on $LATEST is
+    // decided by a policy of its own
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws
+          .lambda()
+          .getPolicy(new GetPolicyCommand({ FunctionName: "greeter" })),
+    );
+    assertInstanceOf(error, SimLambdaResourceNotFoundException);
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("deletes the alias before the function it is on", async () => {
+    // Given a deployed stack with an alias
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "greeter-stack",
+      template: greeterTemplate(liveAlias),
+    });
+    await stack.waitForDeployComplete();
+    const simFunction = simAws.lambda().getSimFunctionByName("greeter");
+    assertNonNullable(simFunction);
+
+    // When the stack is deleted
+    await stack.delete();
+    await stack.waitForDeleteComplete();
+
+    // Then the alias Resource was deleted, and the function went with the
+    // Resource that created it rather than with the alias
+    const aliasResource = stack.getResource("GreeterAlias");
+    assertNonNullable(aliasResource);
+    assertTrue(aliasResource.deleted);
+    assertUndefined(simAws.lambda().getSimFunctionByName("greeter"));
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("fails the Resource when Name is missing", async () => {
+    // Given a template whose alias has no name
+    const simAws = new SimAws();
+
+    // When the template is deployed
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "greeter-stack",
+        template: greeterTemplate({
+          FunctionName: { Ref: "GreeterFunction" },
+          FunctionVersion: { "Fn::GetAtt": ["GreeterVersion", "Version"] },
+        }),
+      });
+      await stack.waitForDeployComplete();
+    });
+
+    // Then the failure names the Resource type, property and logical ID
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::Lambda::Alias GreeterAlias: Name must be a string",
+    );
+  });
+});

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-target-function.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-target-function.ts
@@ -1,10 +1,13 @@
-import { simLambdaFunctionNameOf } from "../../function/sim-lambda-function-name.js";
+import {
+  type SimLambdaFunctionReference,
+  simLambdaFunctionReferenceOf,
+} from "../../function/sim-lambda-function-reference.js";
 
 /**
  * Get the function name a template property pointing at a function names.
  *
  * `AWS::Lambda::Url` reaches this through `TargetFunctionArn`, and
- * `AWS::Lambda::Permission` and `AWS::Lambda::EventSourceMapping` through
+ * `AWS::Lambda::EventSourceMapping` and `AWS::Lambda::Version` through
  * `FunctionName`. Templates reach either in two ways: `Fn::GetAtt` on the
  * function, giving a full ARN, or `Ref`, giving the function name. Both are
  * accepted, as both are valid template ways to point at the same function.
@@ -12,5 +15,20 @@ import { simLambdaFunctionNameOf } from "../../function/sim-lambda-function-name
 export function simCfnLambdaTargetFunctionName(
   targetFunctionArn: string,
 ): string {
-  return simLambdaFunctionNameOf(targetFunctionArn);
+  return simLambdaFunctionReferenceOf(targetFunctionArn).functionName;
+}
+
+/**
+ * Get the function and the version or alias a template property names.
+ *
+ * `AWS::Lambda::Permission` points at whatever it grants on, and CDK writes
+ * that as the qualified ARN of a version or an alias rather than as a separate
+ * qualifier. The grant belongs on what the template named, so the qualifier is
+ * carried through rather than dropped the way the callers acting on the
+ * function itself drop it.
+ */
+export function simCfnLambdaTargetFunction(
+  targetFunctionArn: string,
+): SimLambdaFunctionReference {
+  return simLambdaFunctionReferenceOf(targetFunctionArn);
 }

--- a/src/service/lambda/cfn/permission/sim-cfn-lambda-permission-creator.ts
+++ b/src/service/lambda/cfn/permission/sim-cfn-lambda-permission-creator.ts
@@ -4,7 +4,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimLambdaPermission } from "../../function/policy/sim-lambda-permission.js";
 import type { SimLambda } from "../../sim-lambda.js";
 import { SimCfnLambdaPropertyParser } from "../function/sim-cfn-lambda-property-parser.js";
-import { simCfnLambdaTargetFunctionName } from "../function/sim-cfn-lambda-target-function.js";
+import { simCfnLambdaTargetFunction } from "../function/sim-cfn-lambda-target-function.js";
 
 interface SimCfnLambdaPermissionCreatorProperties {
   readonly lambda: SimLambda;
@@ -17,7 +17,12 @@ interface SimCfnLambdaPermissionCreatorProperties {
  * This is what CDK emits for every `grantInvoke` and `grantInvokeUrl`, so a
  * synthesized template reaches it whether or not the app mentions permissions
  * itself. A template that declares one and a test that calls `AddPermission`
- * produce the same statement, because both end up on the same function policy.
+ * produce the same statement, because both end up on the same policy.
+ *
+ * That policy is the one belonging to whatever the template named. CDK grants
+ * on an alias by writing the alias ARN as the `FunctionName`, so the qualifier
+ * is carried through to `AddPermission` rather than dropped, and the grant
+ * decides calls through the alias rather than calls on `$LATEST`.
  */
 export class SimCfnLambdaPermissionCreator {
   private readonly lambda: SimLambda;
@@ -38,7 +43,7 @@ export class SimCfnLambdaPermissionCreator {
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
   ): Promise<SimLambdaPermission> {
-    const functionName = simCfnLambdaTargetFunctionName(
+    const { functionName, qualifier } = simCfnLambdaTargetFunction(
       this.propertyParser.requiredString(
         resource,
         properties["FunctionName"],
@@ -49,6 +54,7 @@ export class SimCfnLambdaPermissionCreator {
     await this.lambda.addPermission({
       input: {
         FunctionName: functionName,
+        Qualifier: qualifier,
         StatementId: resource.logicalId,
         Action: this.propertyParser.requiredString(
           resource,
@@ -89,8 +95,8 @@ export class SimCfnLambdaPermissionCreator {
     });
 
     const permission = this.lambda
-      .getSimFunctionByName(functionName)
-      ?.resourcePolicy.get(resource.logicalId);
+      .getSimFunctionTarget(functionName, qualifier)
+      ?.resource.resourcePolicy.get(resource.logicalId);
 
     assertDefined(
       permission,

--- a/src/service/lambda/cfn/permission/sim-cfn-lambda-permission-revoker.ts
+++ b/src/service/lambda/cfn/permission/sim-cfn-lambda-permission-revoker.ts
@@ -1,0 +1,34 @@
+import type { SimLambdaPermission } from "../../function/policy/sim-lambda-permission.js";
+import type { SimLambda } from "../../sim-lambda.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import { simCfnLambdaCreatedResource } from "../sim-cfn-lambda-created-resource.js";
+import { simCfnLambdaTargetFunction } from "../function/sim-cfn-lambda-target-function.js";
+
+/**
+ * Take an AWS::Lambda::Permission back off what it was granted on.
+ *
+ * The statement is named after the Resource's logical ID when it is added,
+ * because AWS::Lambda::Permission has no StatementId property, so that is what
+ * addresses it again here. A grant made on a version or an alias is revoked
+ * from that same qualified resource, which the statement's own ARN names.
+ */
+export async function simCfnLambdaRevokePermission(
+  lambda: SimLambda,
+  resource: SimCfnResource,
+): Promise<void> {
+  const permission = simCfnLambdaCreatedResource<SimLambdaPermission>(
+    resource,
+    "permission",
+  );
+  const { functionName, qualifier } = simCfnLambdaTargetFunction(
+    permission.resourceArn,
+  );
+
+  await lambda.removePermission({
+    input: {
+      FunctionName: functionName,
+      Qualifier: qualifier,
+      StatementId: permission.statementId,
+    },
+  });
+}

--- a/src/service/lambda/cfn/sim-cfn-lambda-created-resource.ts
+++ b/src/service/lambda/cfn/sim-cfn-lambda-created-resource.ts
@@ -1,0 +1,23 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+
+/**
+ * What a Lambda CloudFormation Resource's creation produced, or a failure
+ * naming the Resource that had nothing behind it.
+ *
+ * Every deletion addresses the object creation left on the Resource, and each
+ * one starts here.
+ */
+export function simCfnLambdaCreatedResource<T extends object>(
+  resource: SimCfnResource,
+  label: string,
+): T {
+  const created = resource.simResource as T | undefined;
+
+  assertDefined(
+    created,
+    `sim Lambda ${label} for CloudFormation Resource ${resource.logicalId}`,
+  );
+
+  return created;
+}

--- a/src/service/lambda/cfn/sim-cfn-lambda-resource-deleter.ts
+++ b/src/service/lambda/cfn/sim-cfn-lambda-resource-deleter.ts
@@ -3,8 +3,9 @@ import type { SimLambda } from "../sim-lambda.js";
 import type { SimLambdaFunction } from "../function/sim-lambda-function.js";
 import type { SimLambdaFunctionUrl } from "../function/url/sim-lambda-function-url.js";
 import type { SimLambdaEventSourceMapping } from "../event-source/sim-lambda-event-source-mapping.js";
-import type { SimLambdaPermission } from "../function/policy/sim-lambda-permission.js";
-import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimLambdaFunctionAlias } from "../function/version/sim-lambda-function-alias.js";
+import { simCfnLambdaCreatedResource } from "./sim-cfn-lambda-created-resource.js";
+import { simCfnLambdaRevokePermission } from "./permission/sim-cfn-lambda-permission-revoker.js";
 import { simCfnLambdaTargetFunctionName } from "./function/sim-cfn-lambda-target-function.js";
 
 interface SimCfnLambdaResourceDeleterProperties {
@@ -46,7 +47,19 @@ export class SimCfnLambdaResourceDeleter {
         return;
       }
       case "Permission": {
-        await this.removePermission(resource);
+        await simCfnLambdaRevokePermission(this.lambda, resource);
+        return;
+      }
+      case "Version": {
+        // Nothing to do. Lambda has no operation that deletes one published
+        // version, and a version goes when the function it was published from
+        // does. A Stack that published one is tearing that function down in
+        // the same teardown, so leaving the version alone here leaves it
+        // reachable for exactly as long as the function is.
+        return;
+      }
+      case "Alias": {
+        await this.deleteAlias(resource);
         return;
       }
       default: {
@@ -58,10 +71,9 @@ export class SimCfnLambdaResourceDeleter {
   }
 
   private async deleteFunction(resource: SimCfnResource): Promise<void> {
-    const simFunction = resource.simResource as SimLambdaFunction | undefined;
-    assertDefined(
-      simFunction,
-      `sim Lambda Function for CloudFormation Resource ${resource.logicalId}`,
+    const simFunction = simCfnLambdaCreatedResource<SimLambdaFunction>(
+      resource,
+      "function",
     );
 
     await this.lambda.deleteFunction({
@@ -70,12 +82,9 @@ export class SimCfnLambdaResourceDeleter {
   }
 
   private async deleteFunctionUrl(resource: SimCfnResource): Promise<void> {
-    const functionUrl = resource.simResource as
-      | SimLambdaFunctionUrl
-      | undefined;
-    assertDefined(
-      functionUrl,
-      `sim Lambda Function URL for CloudFormation Resource ${resource.logicalId}`,
+    const functionUrl = simCfnLambdaCreatedResource<SimLambdaFunctionUrl>(
+      resource,
+      "Function URL",
     );
 
     await this.lambda.deleteFunctionUrlConfig({
@@ -86,12 +95,9 @@ export class SimCfnLambdaResourceDeleter {
   private async deleteEventSourceMapping(
     resource: SimCfnResource,
   ): Promise<void> {
-    const mapping = resource.simResource as
-      | SimLambdaEventSourceMapping
-      | undefined;
-    assertDefined(
-      mapping,
-      `sim Lambda event source mapping for CloudFormation Resource ${resource.logicalId}`,
+    const mapping = simCfnLambdaCreatedResource<SimLambdaEventSourceMapping>(
+      resource,
+      "event source mapping",
     );
 
     await this.lambda.deleteEventSourceMapping({
@@ -100,23 +106,18 @@ export class SimCfnLambdaResourceDeleter {
   }
 
   /**
-   * Take a permission back off the function it was added to.
-   *
-   * The statement is named after the Resource's logical ID when it is added,
-   * because AWS::Lambda::Permission has no StatementId property, so that is
-   * what addresses it again here.
+   * Drop an alias, leaving the version it pointed at where it is.
    */
-  private async removePermission(resource: SimCfnResource): Promise<void> {
-    const permission = resource.simResource as SimLambdaPermission | undefined;
-    assertDefined(
-      permission,
-      `sim Lambda permission for CloudFormation Resource ${resource.logicalId}`,
+  private async deleteAlias(resource: SimCfnResource): Promise<void> {
+    const alias = simCfnLambdaCreatedResource<SimLambdaFunctionAlias>(
+      resource,
+      "alias",
     );
 
-    await this.lambda.removePermission({
+    await this.lambda.deleteAlias({
       input: {
-        FunctionName: simCfnLambdaTargetFunctionName(permission.resourceArn),
-        StatementId: permission.statementId,
+        FunctionName: simCfnLambdaTargetFunctionName(alias.arn),
+        Name: alias.name,
       },
     });
   }

--- a/src/service/lambda/cfn/sim-cfn-lambda-resource-factory.iso.test.ts
+++ b/src/service/lambda/cfn/sim-cfn-lambda-resource-factory.iso.test.ts
@@ -180,9 +180,9 @@ describe("SimLambdaCloudFormationResourceFactory", () => {
     const simLambda = simAws.lambda();
     const resource = new SimCfnResource({
       accountRegionScope,
-      logicalId: "ExampleAlias",
+      logicalId: "ExampleLayer",
       template: {
-        Type: "AWS::Lambda::Alias",
+        Type: "AWS::Lambda::LayerVersion",
       },
     });
     const context: SimCloudFormationResourceCreateContext = {
@@ -194,13 +194,13 @@ describe("SimLambdaCloudFormationResourceFactory", () => {
     // When creation is attempted, then it rejects with an unsupported Resource
     // type error.
     const error = await assertThrowsErrorAsync(async () =>
-      factory.create("Alias", resource, context),
+      factory.create("LayerVersion", resource, context),
     );
 
     // Then the unsupported Resource type name is included for diagnosis.
     assertIdentical(
       error.message,
-      "Unsupported sim Lambda CloudFormation Resource Alias",
+      "Unsupported sim Lambda CloudFormation Resource LayerVersion",
     );
   });
 });

--- a/src/service/lambda/cfn/sim-cfn-lambda-resource-factory.ts
+++ b/src/service/lambda/cfn/sim-cfn-lambda-resource-factory.ts
@@ -4,10 +4,12 @@ import type {
 } from "../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
 import type { SimLambda } from "../sim-lambda.js";
+import { SimCfnLambdaAliasCreator } from "./alias/sim-cfn-lambda-alias-creator.js";
 import { SimCfnLambdaEventSourceMappingCreator } from "./event-source-mapping/sim-cfn-lambda-event-source-mapping-creator.js";
 import { SimCfnLambdaFunctionCreator } from "./function/sim-cfn-lambda-function-creator.js";
 import { SimCfnLambdaPermissionCreator } from "./permission/sim-cfn-lambda-permission-creator.js";
 import { SimCfnLambdaUrlCreator } from "./url/sim-cfn-lambda-url-creator.js";
+import { SimCfnLambdaVersionCreator } from "./version/sim-cfn-lambda-version-creator.js";
 import { SimCfnLambdaResourceDeleter } from "./sim-cfn-lambda-resource-deleter.js";
 
 /**
@@ -17,6 +19,8 @@ export class SimLambdaCloudFormationResourceFactory implements SimCfnServiceReso
   private readonly functionCreator: SimCfnLambdaFunctionCreator;
   private readonly urlCreator: SimCfnLambdaUrlCreator;
   private readonly permissionCreator: SimCfnLambdaPermissionCreator;
+  private readonly versionCreator: SimCfnLambdaVersionCreator;
+  private readonly aliasCreator: SimCfnLambdaAliasCreator;
   private readonly eventSourceMappingCreator: SimCfnLambdaEventSourceMappingCreator;
   private readonly deleter: SimCfnLambdaResourceDeleter;
 
@@ -25,6 +29,8 @@ export class SimLambdaCloudFormationResourceFactory implements SimCfnServiceReso
     this.functionCreator = new SimCfnLambdaFunctionCreator({ lambda });
     this.urlCreator = new SimCfnLambdaUrlCreator({ lambda });
     this.permissionCreator = new SimCfnLambdaPermissionCreator({ lambda });
+    this.versionCreator = new SimCfnLambdaVersionCreator({ lambda });
+    this.aliasCreator = new SimCfnLambdaAliasCreator({ lambda });
     this.eventSourceMappingCreator = new SimCfnLambdaEventSourceMappingCreator({
       lambda,
     });
@@ -60,6 +66,18 @@ export class SimLambdaCloudFormationResourceFactory implements SimCfnServiceReso
       }
       case "Permission": {
         return await this.permissionCreator.create(
+          resource,
+          context.resolvedProperties ?? resource.properties,
+        );
+      }
+      case "Version": {
+        return await this.versionCreator.create(
+          resource,
+          context.resolvedProperties ?? resource.properties,
+        );
+      }
+      case "Alias": {
+        return await this.aliasCreator.create(
           resource,
           context.resolvedProperties ?? resource.properties,
         );

--- a/src/service/lambda/cfn/version/sim-cfn-lambda-version-creator.ts
+++ b/src/service/lambda/cfn/version/sim-cfn-lambda-version-creator.ts
@@ -1,0 +1,73 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
+import type { SimLambda } from "../../sim-lambda.js";
+import { SimCfnLambdaPropertyParser } from "../function/sim-cfn-lambda-property-parser.js";
+import { simCfnLambdaTargetFunctionName } from "../function/sim-cfn-lambda-target-function.js";
+
+interface SimCfnLambdaVersionCreatorProperties {
+  readonly lambda: SimLambda;
+}
+
+/**
+ * Creates published Lambda versions from CloudFormation Resources.
+ *
+ * This is what CDK emits for `fn.currentVersion`, and what every
+ * `lambda.Alias` sits on top of, so a synthesized template is the usual way a
+ * version comes into existence outside a direct SDK call. Deploying one
+ * publishes the function as it stands, exactly as a `PublishVersion` call
+ * would, so the version carries the code the Stack deployed.
+ *
+ * `CodeSha256` and `RuntimePolicy` are not simulated. Neither changes what a
+ * version is here, so a template carrying them publishes the same version as
+ * one that does not.
+ */
+export class SimCfnLambdaVersionCreator {
+  private readonly lambda: SimLambda;
+  private readonly propertyParser = new SimCfnLambdaPropertyParser();
+
+  constructor(properties: SimCfnLambdaVersionCreatorProperties) {
+    this.lambda = properties.lambda;
+  }
+
+  /**
+   * Publish a version from an AWS::Lambda::Version Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimLambdaFunction> {
+    const functionName = simCfnLambdaTargetFunctionName(
+      this.propertyParser.requiredString(
+        resource,
+        properties["FunctionName"],
+        "FunctionName",
+      ),
+    );
+
+    const published = await this.lambda.publishVersion({
+      input: {
+        FunctionName: functionName,
+        Description: this.propertyParser.optionalString(
+          resource,
+          properties["Description"],
+          "Description",
+        ),
+      },
+    });
+
+    const version = this.lambda.getSimFunctionTarget(
+      functionName,
+      published.Version,
+    )?.simFunction;
+
+    assertDefined(
+      version,
+      `Sim Lambda version ${published.Version} of ${functionName} after ` +
+        "CloudFormation creation",
+    );
+
+    return version;
+  }
+}

--- a/src/service/lambda/cfn/version/sim-cfn-lambda-version.iso.test.ts
+++ b/src/service/lambda/cfn/version/sim-cfn-lambda-version.iso.test.ts
@@ -1,0 +1,187 @@
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../../cloudformation/template/sim-cfn-template.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimLambdaFunction } from "../../function/sim-lambda-function.js";
+
+function greeterTemplate(
+  versionProperties: Record<string, SimCfnTemplateValue>,
+  outputs: Record<string, { Value: SimCfnTemplateValue }> = {},
+): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      GreeterFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "greeter",
+          Role: "arn:aws:iam::888888888888:role/GreeterRole",
+          Code: { ZipFile: "exports.handler = async () => 'hello';" },
+          Handler: "index.handler",
+          Runtime: "nodejs22.x",
+        },
+      },
+      GreeterVersion: {
+        Type: "AWS::Lambda::Version",
+        Properties: versionProperties,
+      },
+    },
+    Outputs: {
+      VersionRef: { Value: { Ref: "GreeterVersion" } },
+      VersionNumber: { Value: { "Fn::GetAtt": ["GreeterVersion", "Version"] } },
+      ...outputs,
+    },
+  };
+}
+
+describe("Lambda CloudFormation Version deployment", () => {
+  it("publishes a version from AWS::Lambda::Version", async () => {
+    // Given a template with a function and a version published from it
+    const simAws = new SimAws();
+
+    // When the template is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "greeter-stack",
+      template: greeterTemplate({ FunctionName: { Ref: "GreeterFunction" } }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the Resource is backed by the published version, which is the
+    // function under a number rather than the function itself
+    const version = stack.getResource("GreeterVersion")?.simResource;
+    assertInstanceOf(version, SimLambdaFunction);
+    assertIdentical(version.version, "1");
+    assertIdentical(
+      simAws.lambda().getSimFunctionByName("greeter")?.version,
+      "$LATEST",
+    );
+
+    // And the version answers an invocation asking for it by number
+    const invoked = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "greeter", Qualifier: "1" }));
+    assertIdentical(invoked.ExecutedVersion, "1");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("resolves Ref to the qualified function ARN", async () => {
+    // Given a deployed stack with a published version
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "greeter-stack",
+      template: greeterTemplate(
+        { FunctionName: { "Fn::GetAtt": ["GreeterFunction", "Arn"] } },
+        {
+          VersionFunctionArn: {
+            Value: { "Fn::GetAtt": ["GreeterVersion", "FunctionArn"] },
+          },
+        },
+      ),
+    });
+    await stack.waitForDeployComplete();
+
+    // When the stack outputs are read
+    // Then Ref is the function ARN with the version number on the end, which
+    // is what an alias or an integration has to be pointed at to reach this
+    // version rather than $LATEST
+    assertIdentical(
+      stack.outputs.get("VersionRef")?.value,
+      "arn:aws:lambda:us-east-1:888888888888:function:greeter:1",
+    );
+
+    // And Fn::GetAtt Version is the number itself
+    assertIdentical(stack.outputs.get("VersionNumber")?.value, "1");
+
+    // And Fn::GetAtt FunctionArn names the version, as PublishVersion answers
+    assertIdentical(
+      stack.outputs.get("VersionFunctionArn")?.value,
+      "arn:aws:lambda:us-east-1:888888888888:function:greeter:1",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("describes the version the template describes", async () => {
+    // Given a template describing the version rather than the function
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "greeter-stack",
+      template: greeterTemplate({
+        FunctionName: { Ref: "GreeterFunction" },
+        Description: "The greeting that went out on Tuesday",
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the published version carries that description, and the function it
+    // was published from keeps its own
+    const version = stack.getResource("GreeterVersion")?.simResource;
+    assertInstanceOf(version, SimLambdaFunction);
+    assertIdentical(
+      version.description,
+      "The greeting that went out on Tuesday",
+    );
+    assertUndefined(
+      simAws.lambda().getSimFunctionByName("greeter")?.description,
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("leaves the version alone when the Stack is deleted", async () => {
+    // Given a deployed stack with a published version
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "greeter-stack",
+      template: greeterTemplate({ FunctionName: { Ref: "GreeterFunction" } }),
+    });
+    await stack.waitForDeployComplete();
+
+    // When the stack is deleted
+    await stack.delete();
+    await stack.waitForDeleteComplete();
+
+    // Then the Version Resource tears down without a delete of its own, since
+    // Lambda has no operation that deletes one version, and the function it
+    // was published from takes it away as it goes
+    const version = stack.getResource("GreeterVersion");
+    assertNonNullable(version);
+    assertTrue(version.deleteComplete);
+    assertUndefined(simAws.lambda().getSimFunctionByName("greeter"));
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("fails the Resource when FunctionName is missing", async () => {
+    // Given a template whose version names no function
+    const simAws = new SimAws();
+
+    // When the template is deployed
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "greeter-stack",
+        template: greeterTemplate({ Description: "Nothing in particular" }),
+      });
+      await stack.waitForDeployComplete();
+    });
+
+    // Then the failure names the Resource type, property and logical ID
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::Lambda::Version GreeterVersion: FunctionName must be a string",
+    );
+  });
+});

--- a/src/service/lambda/command/publish-version/publish-version.command.ts
+++ b/src/service/lambda/command/publish-version/publish-version.command.ts
@@ -15,12 +15,17 @@ export interface SimPublishVersionCommand {
 /**
  * Minimal structural sim Lambda PublishVersion input.
  *
+ * A `Description` describes the version rather than the function it was
+ * published from, so the version keeps the function's own description when
+ * none is given.
+ *
  * Real Lambda takes a `CodeSha256` and a `RevisionId` here to publish only
  * code the caller has already seen. Neither is simulated, so both are left out
  * rather than accepted and ignored.
  */
 export interface SimPublishVersionCommandInput {
   readonly FunctionName?: string | undefined;
+  readonly Description?: string | undefined;
 }
 
 /**

--- a/src/service/lambda/command/publish-version/publish-version.handler.ts
+++ b/src/service/lambda/command/publish-version/publish-version.handler.ts
@@ -85,7 +85,10 @@ export class PublishVersionCommandHandler implements CommandHandler<
       options?.caller,
     );
 
-    const version = this.versions.publish(this.functions.require(functionName));
+    const version = this.versions.publish(
+      this.functions.require(functionName),
+      command.input.Description,
+    );
 
     return { $metadata: {}, ...version.configuration() };
   }

--- a/src/service/lambda/function/sim-lambda-function.ts
+++ b/src/service/lambda/function/sim-lambda-function.ts
@@ -192,17 +192,18 @@ export class SimLambdaFunction {
 
   /**
    * A copy of this function as it stands now, published under a version
-   * number, keeping the code, handler, timeout, memory and environment it was
-   * published with. It is Active from the start, since the code it copied is
-   * already resolved and has nothing left to become.
+   * number, with a description of its own where one is given, and keeping the
+   * code, handler, timeout, memory and environment it was published with. It
+   * is Active from the start, since the code it copied is already resolved.
    */
-  publishedAs(version: string): SimLambdaFunction {
+  publishedAs(version: string, description?: string): SimLambdaFunction {
     return new SimLambdaFunction({
       ...this.properties,
       code: this.code,
       environment: this.environment,
       runAsOwner: this.runAsOwner,
       state: "Active",
+      description: description ?? this.description,
       version,
     });
   }

--- a/src/service/lambda/function/version/sim-lambda-function-version-store.ts
+++ b/src/service/lambda/function/version/sim-lambda-function-version-store.ts
@@ -27,10 +27,14 @@ export class SimLambdaFunctionVersionStore {
   >();
 
   /**
-   * Publish a function as it stands as its next version.
+   * Publish a function as it stands as its next version, described as the
+   * caller asked for or as the function itself is.
    */
-  publish(simFunction: SimLambdaFunction): SimLambdaFunction {
-    return this.of(simFunction).publish(simFunction);
+  publish(
+    simFunction: SimLambdaFunction,
+    description?: string,
+  ): SimLambdaFunction {
+    return this.of(simFunction).publish(simFunction, description);
   }
 
   /**

--- a/src/service/lambda/function/version/sim-lambda-function-versions.ts
+++ b/src/service/lambda/function/version/sim-lambda-function-versions.ts
@@ -36,8 +36,14 @@ export class SimLambdaFunctionVersions {
   /**
    * Publish the function as it stands as the next version.
    */
-  publish(simFunction: SimLambdaFunction): SimLambdaFunction {
-    const version = simFunction.publishedAs(String(this.nextVersionNumber));
+  publish(
+    simFunction: SimLambdaFunction,
+    description?: string,
+  ): SimLambdaFunction {
+    const version = simFunction.publishedAs(
+      String(this.nextVersionNumber),
+      description,
+    );
 
     this.nextVersionNumber += 1;
     this.published.push(version);

--- a/src/service/lambda/sim-lambda-inspection.ts
+++ b/src/service/lambda/sim-lambda-inspection.ts
@@ -8,6 +8,7 @@ import type {
   SimLambdaFunctionUrl,
   SimLambdaFunctionUrlId,
 } from "./function/url/sim-lambda-function-url.js";
+import type { SimLambdaFunctionAlias } from "./function/version/sim-lambda-function-alias.js";
 import type { SimLambdaFunctionTarget } from "./function/version/sim-lambda-function-target.js";
 import type { SimLambdaCommands } from "./sim-lambda-commands.js";
 
@@ -50,6 +51,18 @@ export abstract class SimLambdaInspection {
     qualifier?: string,
   ): SimLambdaFunctionTarget | undefined {
     return this.commands.functionLookup.findTarget(functionName, qualifier);
+  }
+
+  /** Get one alias of a simulated Lambda function, if it has one by name. */
+  getSimFunctionAlias(
+    functionName: SimLambdaFunctionName | string,
+    aliasName: string,
+  ): SimLambdaFunctionAlias | undefined {
+    const simFunction = this.getSimFunctionByName(functionName);
+
+    return simFunction === undefined
+      ? undefined
+      : this.commands.versionStore.of(simFunction).alias(aliasName);
   }
 
   /** Get a simulated Lambda function's Function URL, if it has one. */


### PR DESCRIPTION
`AWS::Lambda::Version` publishes a version of the function its `FunctionName` names, and `AWS::Lambda::Alias` creates the alias at the version its `FunctionVersion` gives, so a CDK app built on `fn.currentVersion` or a `lambda.Alias` deploys with the alias its integrations point at. `Ref` on a version resolves to the qualified function ARN, `Fn::GetAtt` `Version` to the number, and `Ref` on an alias to the alias ARN. An `AWS::Lambda::Permission` whose `FunctionName` carries a qualifier grants on that version or alias, matching what CDK writes for `grantInvoke` on an alias. Tearing the Stack down deletes the alias. Lambda has no operation that deletes one published version, and the `Version` Resource does nothing on teardown because the version goes when its function does. `PublishVersion` gained the `Description` that `AWS::Lambda::Version` carries.

Resolves #760

Brief, concise description of the change:

<!-- CodeRabbit will fill in a more detailed description once this is open. -->

<!-- If there is an issue, link it here:
     Resolves https://github.com/KensioSoftware/yulin/issues/N -->

- [ ] Conventional commit message, used as the title

- [ ] Conventional branch name, like `feat/concise-description`
- [ ] Full check with `pnpm run check` passed
- [ ] Rebased off latest main
- [ ] User-facing behaviour is documented in `docs/`

See https://www.conventionalcommits.org/en/v1.0.0/

<!-- One exception to that spec: no `!` in the title and no `BREAKING CHANGE:`
     footer. Major versions are published by hand here, so the release run
     refuses one rather than shipping it. -->
