### PR TITLE
feat: route an HTTP API to a Lambda alias

### DIFF
--- a/docs/services/apigatewayv2/README.md
+++ b/docs/services/apigatewayv2/README.md
@@ -193,6 +193,147 @@ value at request time. The request is refused with the same 500.
 AWS documents neither the method nor the path as the value API Gateway supplies. Both are inferred
 from the permission patterns AWS and CDK write. The code that builds the ARN records that.
 
+## Routing to a published version or an alias
+
+An integration URI may end in a version number or an alias name, in either of the two forms:
+
+```text
+arn:aws:lambda:eu-west-2:111111111111:function:orders:live
+arn:aws:apigateway:eu-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-west-2:111111111111:function:orders:live/invocations
+```
+
+A Lambda `REQUEST` authorizer's `AuthorizerUri` takes the same qualifier.
+
+The qualifier is read when the request arrives. A route built on the alias `live` runs whichever
+version `live` points at now, and `UpdateAliasCommand` carries the route to another version with the
+API untouched. (That is how a deployment behind an HTTP API usually moves on AWS.)
+
+The invoke permission is granted on the qualifier as well. An alias holds a resource policy of its
+own, and a grant made on the function admits an unqualified call and says nothing about `live`. Pass
+`Qualifier` to `AddPermissionCommand` with the same `SourceArn` an unqualified grant carries.
+
+```typescript sim-apigatewayv2-lambda-alias
+/**
+ * Serving an HTTP API route from a Lambda alias, and moving the alias.
+ */
+
+import {
+  CreateApiCommand,
+  CreateIntegrationCommand,
+  CreateRouteCommand,
+  CreateStageCommand,
+} from "@aws-sdk/client-apigatewayv2";
+import {
+  AddPermissionCommand,
+  CreateAliasCommand,
+  CreateFunctionCommand,
+  PublishVersionCommand,
+  UpdateAliasCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+
+const { FunctionArn } = await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "orders",
+    Role: "arn:aws:iam::111111111111:role/OrdersRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput((_event, context) => ({
+        statusCode: 200,
+        headers: { "content-type": "text/plain" },
+        body: `served by version ${context.functionVersion}`,
+      })),
+    },
+  }),
+);
+
+await lambda.publishVersion(
+  new PublishVersionCommand({ FunctionName: "orders" }),
+);
+await lambda.publishVersion(
+  new PublishVersionCommand({ FunctionName: "orders" }),
+);
+
+await lambda.createAlias(
+  new CreateAliasCommand({
+    FunctionName: "orders",
+    Name: "live",
+    FunctionVersion: "1",
+  }),
+);
+
+const apiGateway = simAws.apiGatewayV2();
+
+const { ApiId, ApiEndpoint } = await apiGateway.createApi(
+  new CreateApiCommand({ Name: "orders", ProtocolType: "HTTP" }),
+);
+
+const { IntegrationId } = await apiGateway.createIntegration(
+  new CreateIntegrationCommand({
+    ApiId,
+    IntegrationType: "AWS_PROXY",
+    IntegrationUri: `${FunctionArn}:live`,
+    PayloadFormatVersion: "2.0",
+  }),
+);
+
+await apiGateway.createRoute(
+  new CreateRouteCommand({
+    ApiId,
+    RouteKey: "$default",
+    Target: `integrations/${IntegrationId}`,
+  }),
+);
+
+await apiGateway.createStage(
+  new CreateStageCommand({ ApiId, StageName: "$default", AutoDeploy: true }),
+);
+
+// The grant names the alias. One made on the function alone leaves this call
+// refused with a 500.
+await lambda.addPermission(
+  new AddPermissionCommand({
+    FunctionName: "orders",
+    Qualifier: "live",
+    StatementId: "api-gateway-invoke",
+    Action: "lambda:InvokeFunction",
+    Principal: "apigateway.amazonaws.com",
+    SourceArn: `arn:aws:execute-api:us-east-1:888888888888:${ApiId}/*/*`,
+  }),
+);
+
+const srv = await serveSimAws({ simAws });
+
+const first = await fetch(srv.localUrl(ApiEndpoint));
+console.log(await first.text());
+
+await lambda.updateAlias(
+  new UpdateAliasCommand({
+    FunctionName: "orders",
+    Name: "live",
+    FunctionVersion: "2",
+  }),
+);
+
+const second = await fetch(srv.localUrl(ApiEndpoint));
+console.log(await second.text());
+
+await srv.close();
+```
+
+```text
+served by version 1
+served by version 2
+```
+
+A qualifier belonging to no version and no alias surfaces at the request, the way a function that
+was never created does. The endpoint answers 500 and the handler never runs.
+
 ## Route keys
 
 A route key is either the literal `$default` or an upper-case HTTP method and a path separated by one
@@ -1962,6 +2103,9 @@ the simulation without being given one. See the
   payload format 2.0 event and turning its result back into an HTTP response
 - The invoke permission of an integration's function and of an authorizer's, each evaluated against
   that function's resource policy with its own `AWS:SourceArn`
+- An integration URI or `AuthorizerUri` ending in a published version number or an alias name, read
+  at each request so a route follows its alias, with the invoke permission decided against the
+  qualified resource
 - `DisableExecuteApiEndpoint`, refusing requests to the generated endpoint
 - `ImportApi` for an OpenAPI 3.0 document, creating one route and one integration per operation and
   one JWT or Lambda `REQUEST` authorizer per security scheme an operation names
@@ -1987,11 +2131,12 @@ Current documented limitations:
   created.
 - `RouteSettings`, `DefaultRouteSettings` and `AccessLogSettings` on a stage are refused, as is any
   other option `CreateStage` takes and this one lacks.
-- `AWS_PROXY` is the only integration type, and its URI must name an unqualified Lambda function
-  ARN, written either as that ARN or as the
+- `AWS_PROXY` is the only integration type, and its URI must name a Lambda function ARN, written
+  either as that ARN or as the
   `arn:aws:apigateway:<region>:lambda:path/2015-03-31/functions/<function-arn>/invocations` form.
   Both reach the same function, and `GetIntegrations` answers with the function ARN whichever was
-  written. A version or alias qualifier is refused, since simulated Lambda has no versions. HTTP
+  written. A version or alias qualifier on the end is kept and resolved at each request (see
+  [Routing to a published version or an alias](#routing-to-a-published-version-or-an-alias)). HTTP
   proxy integrations and AWS service integrations are outside the simulation.
 - Payload format 1.0 is refused. A handler written for 1.0 reads event fields absent from a 2.0
   event, so treating one as the other would pass here and fail on AWS.

--- a/docs/services/apigatewayv2/sim-apigatewayv2-lambda-alias.example.ts
+++ b/docs/services/apigatewayv2/sim-apigatewayv2-lambda-alias.example.ts
@@ -1,0 +1,111 @@
+/**
+ * Serving an HTTP API route from a Lambda alias, and moving the alias.
+ */
+
+import {
+  CreateApiCommand,
+  CreateIntegrationCommand,
+  CreateRouteCommand,
+  CreateStageCommand,
+} from "@aws-sdk/client-apigatewayv2";
+import {
+  AddPermissionCommand,
+  CreateAliasCommand,
+  CreateFunctionCommand,
+  PublishVersionCommand,
+  UpdateAliasCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+
+const { FunctionArn } = await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "orders",
+    Role: "arn:aws:iam::111111111111:role/OrdersRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput((_event, context) => ({
+        statusCode: 200,
+        headers: { "content-type": "text/plain" },
+        body: `served by version ${context.functionVersion}`,
+      })),
+    },
+  }),
+);
+
+await lambda.publishVersion(
+  new PublishVersionCommand({ FunctionName: "orders" }),
+);
+await lambda.publishVersion(
+  new PublishVersionCommand({ FunctionName: "orders" }),
+);
+
+await lambda.createAlias(
+  new CreateAliasCommand({
+    FunctionName: "orders",
+    Name: "live",
+    FunctionVersion: "1",
+  }),
+);
+
+const apiGateway = simAws.apiGatewayV2();
+
+const { ApiId, ApiEndpoint } = await apiGateway.createApi(
+  new CreateApiCommand({ Name: "orders", ProtocolType: "HTTP" }),
+);
+
+const { IntegrationId } = await apiGateway.createIntegration(
+  new CreateIntegrationCommand({
+    ApiId,
+    IntegrationType: "AWS_PROXY",
+    IntegrationUri: `${FunctionArn}:live`,
+    PayloadFormatVersion: "2.0",
+  }),
+);
+
+await apiGateway.createRoute(
+  new CreateRouteCommand({
+    ApiId,
+    RouteKey: "$default",
+    Target: `integrations/${IntegrationId}`,
+  }),
+);
+
+await apiGateway.createStage(
+  new CreateStageCommand({ ApiId, StageName: "$default", AutoDeploy: true }),
+);
+
+// The grant names the alias. One made on the function alone leaves this call
+// refused with a 500.
+await lambda.addPermission(
+  new AddPermissionCommand({
+    FunctionName: "orders",
+    Qualifier: "live",
+    StatementId: "api-gateway-invoke",
+    Action: "lambda:InvokeFunction",
+    Principal: "apigateway.amazonaws.com",
+    SourceArn: `arn:aws:execute-api:us-east-1:888888888888:${ApiId}/*/*`,
+  }),
+);
+
+const srv = await serveSimAws({ simAws });
+
+const first = await fetch(srv.localUrl(ApiEndpoint));
+console.log(await first.text());
+
+await lambda.updateAlias(
+  new UpdateAliasCommand({
+    FunctionName: "orders",
+    Name: "live",
+    FunctionVersion: "2",
+  }),
+);
+
+const second = await fetch(srv.localUrl(ApiEndpoint));
+console.log(await second.text());
+
+await srv.close();

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -2791,9 +2791,9 @@ Current documented limitations:
   `RoutingConfig` weights, provisioned concurrency, and the `Marker`/`MaxItems` paging on the two
   listings.
 - A qualified function ARN reaches a function through S3 notifications, SNS subscriptions,
-  CloudWatch Logs subscriptions, Cognito triggers, EventBridge targets and event source mappings.
-  API Gateway integration and authorizer URIs and the CloudFormation target-function reader still
-  refuse or drop a qualifier.
+  CloudWatch Logs subscriptions, Cognito triggers, EventBridge targets, event source mappings and
+  API Gateway integration and authorizer URIs. The CloudFormation target-function reader still
+  refuses or drops a qualifier.
 - The vm runtime supports CommonJS function code only. ES module source (`.mjs` / `export` syntax)
   has yet to land.
 - A handler function reference is recorded through the process console and the process standard

--- a/src/service/apigatewayv2/README.md
+++ b/src/service/apigatewayv2/README.md
@@ -234,7 +234,12 @@ fails the stack rather than deploying a template written two ways at once.
 1. `sim-api-gateway-v2-router.ts` finds the API from the request hostname, through the registry, and
    the integrated function from the integration's ARN. The function is looked up in the Account and
    Region its own ARN names, which need not be the API's, and the router hands back that Account's
-   IAM alongside the function.
+   IAM alongside the function. A version or alias qualifier on the ARN is resolved here, once per
+   request, by `SimLambda.getSimFunctionTarget`, which is what every simulated service delivering to
+   a qualified function ARN goes through. That is what lets a route follow an alias after
+   `UpdateAlias` moves it. A qualified URI gives the router two things. One is the version to
+   invoke. The other is the resource the invoke permission is decided against. For an alias the two
+   differ, and the permission belongs to the alias.
 2. `serve/auth/sim-http-api-route-authorizer.ts` asks whether the client may have the matched route.
    This comes first, before the integration is even looked up: a request presenting no credentials is
    refused whether or not the integration behind the route would have worked. It settles which kind
@@ -272,8 +277,10 @@ fails the stack rather than deploying a template written two ways at once.
    simulated service invoking a function goes through. This supplies the part API Gateway knows: the
    service principal `apigateway.amazonaws.com`, `AWS:SourceArn` from
    `api/sim-http-api-execute-api-arn.ts`, and the API's own Account as `AWS:SourceAccount`, which is
-   the Account the source ARN names rather than the one owning the function. A function with no
-   matching permission answers 500 and is never invoked, as it is on real AWS. Both an integration's
+   the Account the source ARN names rather than the one owning the function. A URI ending in a
+   version or an alias is decided against that resource and its own policy. An integration on
+   `orders:live` needs a grant made on `live`. A function with no matching permission answers 500
+   and is never invoked, as it is on real AWS. Both an integration's
    function and an authorizer's go through this, under different ARNs: the route for one,
    `<apiId>/authorizers/<authorizerId>` for the other. That ARN builder carries the reasoning for
    what the method and path segments of the ARN hold, since neither is documented by AWS.
@@ -341,8 +348,8 @@ simulation exists to avoid:
 - a `WEBSOCKET` protocol type, and the `RouteKey`/`Target` quick-create shorthand
 - `CorsConfiguration` and `Tags`
 - payload format `1.0`, which builds a different event
-- an integration type other than `AWS_PROXY`, and an integration URI that is not an unqualified
-  Lambda function ARN
+- an integration type other than `AWS_PROXY`, and an integration URI that is not a Lambda function
+  ARN, with or without a version or alias qualifier
 - a malformed route key, refused at `CreateRoute`, which is where real API Gateway refuses it
 - an `AuthorizerId` or `AuthorizationScopes` on a route that has no use for either, and an
   `AuthorizerId` naming an authorizer of the kind the route's authorization type does not take

--- a/src/service/apigatewayv2/api/integration/sim-http-api-lambda-uri.ts
+++ b/src/service/apigatewayv2/api/integration/sim-http-api-lambda-uri.ts
@@ -4,6 +4,18 @@ const lambdaFunctionArn =
   /^arn:aws:lambda:(?<regionName>[a-z0-9-]+):(?<accountId>\d{12}):function:(?<functionName>[a-zA-Z0-9-_]+)$/;
 
 /**
+ * A version number or an alias name on the end of a function ARN. `$LATEST`
+ * is one of them, which is what the `$` is there for.
+ */
+const lambdaQualifier = /^[a-zA-Z0-9-_$]+$/;
+
+/**
+ * How many colon-separated fields an unqualified function ARN has. A
+ * qualified one has an eighth.
+ */
+const functionArnFieldCount = 7;
+
+/**
  * The other form an integration URI is written in, wrapping a Lambda function
  * ARN in an API Gateway path:
  *
@@ -22,10 +34,11 @@ const apiGatewayLambdaPathUri =
  * `IntegrationUri` of an `AWS_PROXY` integration, or the `AuthorizerUri` of a
  * `REQUEST` authorizer. Both are written the same way.
  *
- * Only an unqualified function ARN is accepted. A version or alias qualifier
- * on the end names a published function version, and simulated Lambda has no
- * versions, so one is refused rather than invoked as the unpublished function
- * it is not.
+ * A version or alias qualifier on the end of the function ARN is held apart
+ * from the function name, because the two are resolved separately. The name
+ * finds the function and the qualifier picks which of its versions runs.
+ * Neither is resolved here. That is what lets a route built on an alias follow
+ * that alias wherever it is moved to afterwards.
  *
  * Both URI forms reach the same function, and both are held as the function
  * ARN, which is what the API hands back. Reading them here rather than in each
@@ -38,9 +51,19 @@ export class SimHttpApiLambdaUri {
   public readonly accountId: string;
   public readonly functionName: string;
 
-  private constructor(uri: string, groups: Record<string, string>) {
+  /**
+   * The published version or the alias the URI named, if it named one.
+   */
+  public readonly qualifier: string | undefined;
+
+  private constructor(
+    uri: string,
+    qualifier: string | undefined,
+    groups: Record<string, string>,
+  ) {
     this.uri = uri;
-    /* v8 ignore next 3 -- the pattern that matched fills all three groups */
+    this.qualifier = qualifier;
+    /* v8 ignore next 3 -- the pattern that matched fills each of these three */
     this.regionName = groups["regionName"] ?? "";
     this.accountId = groups["accountId"] ?? "";
     this.functionName = groups["functionName"] ?? "";
@@ -54,8 +77,8 @@ export class SimHttpApiLambdaUri {
     return this.read(
       "IntegrationUri",
       uri,
-      "an AWS_PROXY integration is simulated only for an unqualified Lambda " +
-        "function ARN",
+      "an AWS_PROXY integration is simulated only for a Lambda function ARN, " +
+        "with or without a version or alias qualifier",
     );
   }
 
@@ -66,8 +89,8 @@ export class SimHttpApiLambdaUri {
     return this.read(
       "AuthorizerUri",
       uri,
-      "a REQUEST authorizer is simulated only for an unqualified Lambda " +
-        "function ARN",
+      "a REQUEST authorizer is simulated only for a Lambda function ARN, " +
+        "with or without a version or alias qualifier",
     );
   }
 
@@ -77,17 +100,19 @@ export class SimHttpApiLambdaUri {
     refusal: string,
   ): SimHttpApiLambdaUri {
     const functionArn = this.functionArn(uri);
-    const groups = lambdaFunctionArn.exec(functionArn)?.groups;
+    const { unqualified, qualifier } = this.split(functionArn);
+    const groups = lambdaFunctionArn.exec(unqualified)?.groups;
 
-    if (groups === undefined) {
+    if (groups === undefined || !this.qualifierAccepted(qualifier)) {
       throw new SimApiGatewayV2BadRequest(
         `${option} '${uri}' is not a simulated invocation target: ` +
           `${refusal}, such as ` +
-          `arn:aws:lambda:eu-west-2:111111111111:function:orders`,
+          `arn:aws:lambda:eu-west-2:111111111111:function:orders or ` +
+          `arn:aws:lambda:eu-west-2:111111111111:function:orders:live`,
       );
     }
 
-    return new SimHttpApiLambdaUri(functionArn, groups);
+    return new SimHttpApiLambdaUri(functionArn, qualifier, groups);
   }
 
   /**
@@ -95,5 +120,35 @@ export class SimHttpApiLambdaUri {
    */
   private static functionArn(uri: string): string {
     return apiGatewayLambdaPathUri.exec(uri)?.groups?.["functionArn"] ?? uri;
+  }
+
+  /**
+   * A function ARN split from the qualifier on the end of it.
+   *
+   * The split is by field rather than by pattern, since a function name and a
+   * qualifier are written from the same characters and only the colon between
+   * them tells the two apart.
+   */
+  private static split(functionArn: string): {
+    readonly unqualified: string;
+    readonly qualifier: string | undefined;
+  } {
+    const fields = functionArn.split(":");
+
+    return fields.length > functionArnFieldCount
+      ? {
+          unqualified: fields.slice(0, functionArnFieldCount).join(":"),
+          qualifier: fields.slice(functionArnFieldCount).join(":"),
+        }
+      : { unqualified: functionArn, qualifier: undefined };
+  }
+
+  /**
+   * Whether what came off the end of the ARN could be a qualifier at all. A
+   * URI carrying more fields than a qualified function ARN has is refused
+   * here.
+   */
+  private static qualifierAccepted(qualifier: string | undefined): boolean {
+    return qualifier === undefined || lambdaQualifier.test(qualifier);
   }
 }

--- a/src/service/apigatewayv2/command/authorizer/sim-http-api-request-authorizer-refusals.iso.test.ts
+++ b/src/service/apigatewayv2/command/authorizer/sim-http-api-request-authorizer-refusals.iso.test.ts
@@ -149,7 +149,7 @@ describe("What a Lambda REQUEST authorizer refuses rather than ignores", () => {
     const simAws = new SimAws();
     const apiId = await createdApiId(simAws);
 
-    // When an authorizer names no function, then a qualified one
+    // When an authorizer names no function, then a Lambda Function URL
     // Then each is refused rather than created with nothing to ask
     await expect(
       simAws
@@ -160,7 +160,7 @@ describe("What a Lambda REQUEST authorizer refuses rather than ignores", () => {
     await expect(
       simAws.apiGatewayV2().createAuthorizer(
         requestAuthorizer(apiId, {
-          AuthorizerUri: `${functionArn}:live`,
+          AuthorizerUri: "https://abc123.lambda-url.us-east-1.on.aws/",
         }),
       ),
     ).rejects.toThrow(/AuthorizerUri .+ is not a simulated invocation target/);

--- a/src/service/apigatewayv2/command/integration/sim-http-api-integration-commands.iso.test.ts
+++ b/src/service/apigatewayv2/command/integration/sim-http-api-integration-commands.iso.test.ts
@@ -112,18 +112,53 @@ describe("Sim API Gateway v2 integration commands", () => {
         new CreateApiCommand({ Name: "orders", ProtocolType: "HTTP" }),
       );
 
-    // When an integration names a published function version, which simulated
-    // Lambda has no notion of
-    // Then it is refused rather than invoking the unpublished function
+    // When an integration names an HTTP endpoint, which is what an HTTP_PROXY
+    // integration points at
+    // Then it is refused rather than created with nothing to invoke
     await expect(
       simAws.apiGatewayV2().createIntegration(
         new CreateIntegrationCommand({
           ApiId: apiId,
           IntegrationType: "AWS_PROXY",
-          IntegrationUri: `${functionArn}:PROD`,
+          IntegrationUri: "https://orders.example.com/intake",
           PayloadFormatVersion: "2.0",
         }),
       ),
     ).rejects.toThrow(SimApiGatewayV2BadRequest);
+  });
+
+  it("creates an integration on a version or an alias", async () => {
+    // Given an API
+    const simAws = new SimAws();
+    const { ApiId: apiId } = await simAws
+      .apiGatewayV2()
+      .createApi(
+        new CreateApiCommand({ Name: "orders", ProtocolType: "HTTP" }),
+      );
+
+    // When one integration names an alias and another names a version number,
+    // written in the API Gateway path form
+    const alias = await simAws.apiGatewayV2().createIntegration(
+      new CreateIntegrationCommand({
+        ApiId: apiId,
+        IntegrationType: "AWS_PROXY",
+        IntegrationUri: `${functionArn}:live`,
+        PayloadFormatVersion: "2.0",
+      }),
+    );
+    const version = await simAws.apiGatewayV2().createIntegration(
+      new CreateIntegrationCommand({
+        ApiId: apiId,
+        IntegrationType: "AWS_PROXY",
+        IntegrationUri:
+          `arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/` +
+          `${functionArn}:3/invocations`,
+        PayloadFormatVersion: "2.0",
+      }),
+    );
+
+    // Then each is created, and each keeps the qualifier it was given
+    assertIdentical(alias.IntegrationUri, `${functionArn}:live`);
+    assertIdentical(version.IntegrationUri, `${functionArn}:3`);
   });
 });

--- a/src/service/apigatewayv2/serve/auth/sim-http-api-authorizer-invocation.ts
+++ b/src/service/apigatewayv2/serve/auth/sim-http-api-authorizer-invocation.ts
@@ -6,7 +6,7 @@ import {
 import type { SimHttpApiRequestAuthorizer } from "../../api/authorizer/sim-http-api-request-authorizer.js";
 import type { SimHttpApiLambdaUri } from "../../api/integration/sim-http-api-lambda-uri.js";
 import { SimHttpApiExecuteApiArn } from "../../api/sim-http-api-execute-api-arn.js";
-import type { SimHttpApiFunctionTarget } from "../sim-api-gateway-v2-router.js";
+import type { SimHttpApiFunctionTarget } from "../sim-http-api-function-target.js";
 import { simHttpApiEndpoint } from "../sim-http-api-endpoint.js";
 import { SimHttpApiAuthorizerEventBuilder } from "./sim-http-api-authorizer-event.js";
 import { SimHttpApiAuthorizerResponse } from "./sim-http-api-authorizer-response.js";

--- a/src/service/apigatewayv2/serve/auth/sim-http-api-invoke-authorizer.ts
+++ b/src/service/apigatewayv2/serve/auth/sim-http-api-invoke-authorizer.ts
@@ -3,11 +3,10 @@ import type {
   SimIamInterServiceAuthZ,
 } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimLambdaServiceInvokeAuthorizer } from "../../../lambda/command/authorize/sim-lambda-service-invoke-authorizer.js";
-import type { SimLambdaFunction } from "../../../lambda/function/sim-lambda-function.js";
 import type { SimHttpApiRequestAuthorizer } from "../../api/authorizer/sim-http-api-request-authorizer.js";
 import { SimHttpApiExecuteApiArn } from "../../api/sim-http-api-execute-api-arn.js";
 import type { SimHttpApi } from "../../api/sim-http-api.js";
-import type { SimHttpApiFunctionTarget } from "../sim-api-gateway-v2-router.js";
+import type { SimHttpApiFunctionTarget } from "../sim-http-api-function-target.js";
 
 /**
  * The service principal API Gateway invokes a Lambda function as, whether that
@@ -21,7 +20,8 @@ interface SimHttpApiInvokeAuthorizerProperties {
 
 interface SimHttpApiInvokeAuthorizationInput {
   readonly api: SimHttpApi;
-  readonly simFunction: SimLambdaFunction;
+  /** The function to invoke, and the resource the grant was made on. */
+  readonly target: SimHttpApiFunctionTarget;
   readonly sourceArn: SimHttpApiExecuteApiArn;
 }
 
@@ -59,12 +59,16 @@ export class SimHttpApiInvokeAuthorizer {
    * usable as an authorizer. The API's own Account is supplied as
    * `AWS:SourceAccount`, which is the Account the source ARN names rather than
    * the one owning the function.
+   *
+   * A URI ending in a version or an alias is decided against that resource and
+   * its own policy. An integration on `orders:live` needs a grant made on
+   * `live`.
    */
   authorize(
     input: SimHttpApiInvokeAuthorizationInput,
   ): SimIamAuthorizationDecision {
     return this.lambdaAuthorizer.authorize({
-      resource: input.simFunction,
+      resource: input.target.resource,
       servicePrincipal: simApiGatewayServicePrincipal,
       sourceArn: input.sourceArn.toString(),
       sourceAccount: input.api.accountRegionScope.accountId,
@@ -86,7 +90,7 @@ export function simHttpApiMayNotInvokeAuthorizer(
 ): boolean {
   return new SimHttpApiInvokeAuthorizer({ iam: target.iam }).authorize({
     api,
-    simFunction: target.simFunction,
+    target,
     sourceArn: SimHttpApiExecuteApiArn.forAuthorizer(
       api,
       authorizer.authorizerId,

--- a/src/service/apigatewayv2/serve/sim-api-gateway-v2-router.ts
+++ b/src/service/apigatewayv2/serve/sim-api-gateway-v2-router.ts
@@ -2,27 +2,15 @@ import type { SimAwsServiceTarget } from "../../../serve/controller/sim-service-
 import type { AwsRegionName } from "../../aws/sim-aws-region.js";
 import { SimAws } from "../../aws/sim-aws.js";
 import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
-import type { SimLambdaFunction } from "../../lambda/function/sim-lambda-function.js";
 import type { SimHttpApiIntegration } from "../api/integration/sim-http-api-integration.js";
 import type { SimHttpApiLambdaUri } from "../api/integration/sim-http-api-lambda-uri.js";
 import type { SimHttpApi } from "../api/sim-http-api.js";
 import type { SimHttpApiRegistry } from "../registry/sim-http-api-registry.js";
+import type { SimHttpApiFunctionTarget } from "./sim-http-api-function-target.js";
 import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
 
 interface SimApiGatewayV2RouterProperties {
   readonly simAws?: SimAws;
-}
-
-/**
- * A function the API invokes, and what decides whether it may.
- */
-export interface SimHttpApiFunctionTarget {
-  readonly simFunction: SimLambdaFunction;
-  /**
-   * IAM of the Account that owns the function, which is what the API's invoke
-   * permission is evaluated against. It need not be the API's Account.
-   */
-  readonly iam: SimIamInterServiceAuthZ;
 }
 
 /**
@@ -98,22 +86,28 @@ export class SimApiGatewayV2Router {
    * The function is looked up in the Account and Region its own ARN names, not
    * the API's, because an integration URI and an authorizer URI are each free
    * to name either.
+   *
+   * A version or alias qualifier on the URI is resolved here, once per
+   * request. A route built on an alias runs whichever version the alias points
+   * at now. A qualifier naming neither a version nor an alias answers with
+   * nothing, the way a function that was never created does. Both are
+   * invocation-time failures on real AWS.
+   *
+   * The target carries the resource the URI named as well as the version that
+   * runs. They differ for an alias, and the grant admitting the call was made
+   * on the alias.
    */
   functionFor(
     lambdaUri: SimHttpApiLambdaUri,
   ): SimHttpApiFunctionTarget | undefined {
-    const { accountId, regionName, functionName } = lambdaUri;
-
     const scope = this.simAws.accountRegionScope(
-      accountId as SimAwsAccountId,
-      regionName as AwsRegionName,
+      lambdaUri.accountId as SimAwsAccountId,
+      lambdaUri.regionName as AwsRegionName,
     );
-    const simFunction = scope.lambda().getSimFunctionByName(functionName);
+    const target = scope
+      .lambda()
+      .getSimFunctionTarget(lambdaUri.functionName, lambdaUri.qualifier);
 
-    if (simFunction === undefined) {
-      return undefined;
-    }
-
-    return { simFunction, iam: scope.iam() };
+    return target === undefined ? undefined : { ...target, iam: scope.iam() };
   }
 }

--- a/src/service/apigatewayv2/serve/sim-http-api-function-target.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-function-target.ts
@@ -1,0 +1,17 @@
+import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimLambdaFunctionTarget } from "../../lambda/function/version/sim-lambda-function-target.js";
+
+/**
+ * A function the API invokes, and what decides whether it may.
+ *
+ * What the API invokes is what any service delivering to a function ARN
+ * invokes, so the resource named and the version that runs come from Lambda's
+ * own target. All this adds is the IAM the decision is made in.
+ */
+export interface SimHttpApiFunctionTarget extends SimLambdaFunctionTarget {
+  /**
+   * IAM of the Account that owns the function, which is what the API's invoke
+   * permission is evaluated against. It need not be the API's Account.
+   */
+  readonly iam: SimIamInterServiceAuthZ;
+}

--- a/src/service/apigatewayv2/serve/sim-http-api-integration-invocation.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-integration-invocation.ts
@@ -7,10 +7,8 @@ import { SimHttpApiExecuteApiArn } from "../api/sim-http-api-execute-api-arn.js"
 import type { SimHttpApi } from "../api/sim-http-api.js";
 import { SimHttpApiInvokeAuthorizer } from "./auth/sim-http-api-invoke-authorizer.js";
 import { SimApiGatewayV2ErrorResponse } from "./sim-api-gateway-v2-error-response.js";
-import type {
-  SimApiGatewayV2Router,
-  SimHttpApiFunctionTarget,
-} from "./sim-api-gateway-v2-router.js";
+import type { SimApiGatewayV2Router } from "./sim-api-gateway-v2-router.js";
+import type { SimHttpApiFunctionTarget } from "./sim-http-api-function-target.js";
 import { simHttpApiEndpoint } from "./sim-http-api-endpoint.js";
 
 interface SimHttpApiIntegrationInvocationProperties {
@@ -98,7 +96,7 @@ export class SimHttpApiIntegrationInvocation {
 
     return new SimHttpApiInvokeAuthorizer({ iam: target.iam }).authorize({
       api,
-      simFunction: target.simFunction,
+      target,
       sourceArn: SimHttpApiExecuteApiArn.forMatchedRoute(
         api,
         match,

--- a/src/service/apigatewayv2/serve/sim-http-api-lambda-qualifier.iso.test.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-lambda-qualifier.iso.test.ts
@@ -1,0 +1,343 @@
+import {
+  CreateApiCommand,
+  CreateAuthorizerCommand,
+  CreateIntegrationCommand,
+  CreateRouteCommand,
+  CreateStageCommand,
+} from "@aws-sdk/client-apigatewayv2";
+import {
+  AddPermissionCommand,
+  PublishVersionCommand,
+  UpdateAliasCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertNonNullable,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  simLambdaAliasedFunction,
+  simLambdaAllowAliasInvoke,
+  type SimLambdaAliasedFunction,
+} from "../../../../test/lambda/alias-fixture.js";
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simApiGatewayServicePrincipal } from "./auth/sim-http-api-invoke-authorizer.js";
+
+/**
+ * What the handler behind every route here answers with. The version that ran
+ * is recorded by the fixture rather than carried in the body, since a
+ * published version is a copy of the function and answers the same way.
+ */
+const handled = {
+  statusCode: 200,
+  headers: { "content-type": "text/plain" },
+  body: "handled",
+};
+
+/**
+ * An API serving one route from the function a URI names, with a stage to
+ * serve it from.
+ */
+async function servedApi(
+  simAws: SimAws,
+  integrationUri: string,
+): Promise<{ readonly apiId: string; readonly apiEndpoint: string }> {
+  const apiGateway = simAws.apiGatewayV2();
+  const { ApiId: apiId, ApiEndpoint: apiEndpoint } = await apiGateway.createApi(
+    new CreateApiCommand({ Name: "orders", ProtocolType: "HTTP" }),
+  );
+  const { IntegrationId: integrationId } = await apiGateway.createIntegration(
+    new CreateIntegrationCommand({
+      ApiId: apiId,
+      IntegrationType: "AWS_PROXY",
+      IntegrationUri: integrationUri,
+      PayloadFormatVersion: "2.0",
+    }),
+  );
+  await apiGateway.createRoute(
+    new CreateRouteCommand({
+      ApiId: apiId,
+      RouteKey: "$default",
+      Target: `integrations/${integrationId}`,
+    }),
+  );
+  await apiGateway.createStage(
+    new CreateStageCommand({
+      ApiId: apiId,
+      StageName: "$default",
+      AutoDeploy: true,
+    }),
+  );
+
+  return { apiId, apiEndpoint };
+}
+
+/**
+ * The `execute-api` ARN a grant for every route and stage of an API names.
+ */
+function apiSourceArn(simAws: SimAws, apiId: string): string {
+  return `arn:aws:execute-api:${simAws.defaultRegionName}:${simAws.defaultAccountId}:${apiId}/*/*`;
+}
+
+function get(
+  simAws: SimAws,
+  apiEndpoint: string,
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  return new SimAwsHttp({ simAws }).fetch(
+    new SimAwsLocalUrl({ input: apiEndpoint }).toString(),
+    { headers },
+  );
+}
+
+/**
+ * A second published version of the fixture's function, which the alias can be
+ * moved to.
+ */
+async function publishSecondVersion(
+  simAws: SimAws,
+  functionName: string,
+): Promise<string> {
+  const { Version } = await simAws
+    .lambda()
+    .publishVersion(new PublishVersionCommand({ FunctionName: functionName }));
+
+  assertNonNullable(Version, "PublishVersion answered with a version");
+
+  return Version;
+}
+
+describe("Serving a sim HTTP API route backed by a Lambda version or alias", () => {
+  it("runs the version the integration's alias points at", async () => {
+    // Given a route whose integration names an alias that admits the API
+    const simAws = new SimAws();
+    const orders = await aliasedOrders(simAws);
+    const { apiId, apiEndpoint } = await servedApi(simAws, orders.aliasArn);
+    await simLambdaAllowAliasInvoke(
+      simAws,
+      "orders",
+      simApiGatewayServicePrincipal,
+      apiSourceArn(simAws, apiId),
+    );
+
+    // When the route is requested
+    const response = await get(simAws, apiEndpoint);
+
+    // Then the version behind the alias served it, rather than $LATEST
+    assertIdentical(response.status, 200);
+    assertArrayEquals(orders.ranAs, [orders.version]);
+  });
+
+  it("follows the alias after UpdateAlias moves it", async () => {
+    // Given a route serving through the alias, and a second published version
+    const simAws = new SimAws();
+    const orders = await aliasedOrders(simAws);
+    const { apiId, apiEndpoint } = await servedApi(simAws, orders.aliasArn);
+    await simLambdaAllowAliasInvoke(
+      simAws,
+      "orders",
+      simApiGatewayServicePrincipal,
+      apiSourceArn(simAws, apiId),
+    );
+    const second = await publishSecondVersion(simAws, "orders");
+    await get(simAws, apiEndpoint);
+
+    // When the alias is moved to that version, with the API untouched
+    await simAws.lambda().updateAlias(
+      new UpdateAliasCommand({
+        FunctionName: "orders",
+        Name: "live",
+        FunctionVersion: second,
+      }),
+    );
+    await get(simAws, apiEndpoint);
+
+    // Then the route served the first version and now serves the second
+    assertArrayEquals(orders.ranAs, [orders.version, second]);
+  });
+
+  it("runs the version an integration names by number", async () => {
+    // Given a route naming a version number, in the API Gateway path form a
+    // hand-written template writes
+    const simAws = new SimAws();
+    const orders = await aliasedOrders(simAws);
+    const { apiId, apiEndpoint } = await servedApi(
+      simAws,
+      `arn:aws:apigateway:${simAws.defaultRegionName}:lambda:path/2015-03-31/` +
+        `functions/${orders.functionArn}:${orders.version}/invocations`,
+    );
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "orders",
+        Qualifier: orders.version,
+        StatementId: "api-gateway-invoke",
+        Action: "lambda:InvokeFunction",
+        Principal: simApiGatewayServicePrincipal,
+        SourceArn: apiSourceArn(simAws, apiId),
+      }),
+    );
+
+    // When the route is requested
+    const response = await get(simAws, apiEndpoint);
+
+    // Then that version served it
+    assertIdentical(response.status, 200);
+    assertArrayEquals(orders.ranAs, [orders.version]);
+  });
+
+  it("answers 500 when the grant was made on the function rather than the alias", async () => {
+    // Given a route serving through an alias, with the invoke permission
+    // granted on the function itself
+    const simAws = new SimAws();
+    const orders = await aliasedOrders(simAws);
+    const { apiId, apiEndpoint } = await servedApi(simAws, orders.aliasArn);
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "orders",
+        StatementId: "api-gateway-invoke",
+        Action: "lambda:InvokeFunction",
+        Principal: simApiGatewayServicePrincipal,
+        SourceArn: apiSourceArn(simAws, apiId),
+      }),
+    );
+
+    // When the route is requested
+    const response = await get(simAws, apiEndpoint);
+
+    // Then the call is refused, because the alias holds a policy of its own
+    // and nothing was granted on it
+    assertIdentical(response.status, 500);
+    assertArrayEquals(orders.ranAs, []);
+  });
+
+  it("answers 500 when the qualifier names no version and no alias", async () => {
+    // Given a route whose integration names an alias nothing created
+    const simAws = new SimAws();
+    const orders = await aliasedOrders(simAws);
+    const { apiId, apiEndpoint } = await servedApi(
+      simAws,
+      `${orders.functionArn}:staging`,
+    );
+    await simLambdaAllowAliasInvoke(
+      simAws,
+      "orders",
+      simApiGatewayServicePrincipal,
+      apiSourceArn(simAws, apiId),
+    );
+
+    // When the route is requested
+    const response = await get(simAws, apiEndpoint);
+
+    // Then the missing qualifier surfaces where a missing function does, at
+    // the invocation rather than at the integration that named it
+    assertIdentical(response.status, 500);
+    assertArrayEquals(orders.ranAs, []);
+  });
+
+  it("runs the version a REQUEST authorizer's alias points at", async () => {
+    // Given a route behind an authorizer whose URI names an alias
+    const simAws = new SimAws();
+    const orders = await aliasedOrders(simAws);
+    const authorizer = await simLambdaAliasedFunction(
+      simAws,
+      "session-authorizer",
+      { result: () => ({ isAuthorized: true, context: { tenant: "acme" } }) },
+    );
+    const { apiId, apiEndpoint } = await servedApiWithAuthorizer(
+      simAws,
+      orders,
+      authorizer.aliasArn,
+    );
+    await simLambdaAllowAliasInvoke(
+      simAws,
+      "orders",
+      simApiGatewayServicePrincipal,
+      apiSourceArn(simAws, apiId),
+    );
+    await simLambdaAllowAliasInvoke(
+      simAws,
+      "session-authorizer",
+      simApiGatewayServicePrincipal,
+      apiSourceArn(simAws, apiId),
+    );
+
+    // When the route is requested with the identity source the authorizer
+    // reads
+    const response = await get(simAws, apiEndpoint, {
+      cookie: "session=valid",
+    });
+
+    // Then the published version behind the alias answered, not $LATEST
+    assertIdentical(response.status, 200);
+    assertArrayEquals(authorizer.ranAs, [authorizer.version]);
+    assertArrayEquals(orders.ranAs, [orders.version]);
+  });
+});
+
+/**
+ * The `orders` function every route here serves from, with a version behind
+ * the alias `live`.
+ */
+async function aliasedOrders(
+  simAws: SimAws,
+): Promise<SimLambdaAliasedFunction> {
+  return await simLambdaAliasedFunction(simAws, "orders", {
+    result: () => handled,
+  });
+}
+
+/**
+ * An API whose one route goes through a `REQUEST` authorizer before it reaches
+ * the integration.
+ */
+async function servedApiWithAuthorizer(
+  simAws: SimAws,
+  orders: SimLambdaAliasedFunction,
+  authorizerUri: string,
+): Promise<{ readonly apiId: string; readonly apiEndpoint: string }> {
+  const apiGateway = simAws.apiGatewayV2();
+  const { ApiId: apiId, ApiEndpoint: apiEndpoint } = await apiGateway.createApi(
+    new CreateApiCommand({ Name: "orders", ProtocolType: "HTTP" }),
+  );
+  const { IntegrationId: integrationId } = await apiGateway.createIntegration(
+    new CreateIntegrationCommand({
+      ApiId: apiId,
+      IntegrationType: "AWS_PROXY",
+      IntegrationUri: orders.aliasArn,
+      PayloadFormatVersion: "2.0",
+    }),
+  );
+  const { AuthorizerId: authorizerId } = await apiGateway.createAuthorizer(
+    new CreateAuthorizerCommand({
+      ApiId: apiId,
+      Name: "session",
+      AuthorizerType: "REQUEST",
+      AuthorizerUri: authorizerUri,
+      AuthorizerPayloadFormatVersion: "2.0",
+      EnableSimpleResponses: true,
+      IdentitySource: ["$request.header.cookie"],
+    }),
+  );
+  await apiGateway.createRoute(
+    new CreateRouteCommand({
+      ApiId: apiId,
+      RouteKey: "$default",
+      Target: `integrations/${integrationId}`,
+      AuthorizationType: "CUSTOM",
+      AuthorizerId: authorizerId,
+    }),
+  );
+  await apiGateway.createStage(
+    new CreateStageCommand({
+      ApiId: apiId,
+      StageName: "$default",
+      AutoDeploy: true,
+    }),
+  );
+
+  return { apiId, apiEndpoint };
+}

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -390,8 +390,8 @@ and the version that runs, and `findTarget` and `requireTarget` on the version s
 everything else here is built on. `SimLambdaFunctionLookup` offers the same two by function name,
 and `SimLambda.getSimFunctionTarget` is how the other simulated services reach a function a target
 ARN points at. Each of them resolves the qualifier at the moment it is asked, so an alias moved to
-another version moves what a standing notification, subscription, trigger, rule target or event
-source mapping delivers to.
+another version moves what a standing notification, subscription, trigger, rule target, event
+source mapping or API Gateway route delivers to.
 
 `SimLambdaServiceInvokeAuthorizer` takes that resource rather than the function, so a delivery to
 an alias is admitted by a grant made on the alias. The service being the caller is the only thing


### PR DESCRIPTION
An `AWS_PROXY` integration URI and a `REQUEST` authorizer URI accept a version or alias qualifier on
the function ARN, in the bare form and in the API Gateway path form. A route built on `live` runs
whichever version the alias points at after `UpdateAlias` moves it, with the API left alone.

Resolves https://github.com/KensioSoftware/yulin/issues/759

## What changed

`SimHttpApiLambdaUri` splits a qualifier off the end of the function ARN and holds it beside the
function name. The split is by colon-separated field rather than by a widened pattern, because a
regex ending in an optional qualifier group trips `detect-unsafe-regex`. Both refusal messages name
a qualified ARN as an accepted example now.

The serving router resolves the qualifier per request through `SimLambda.getSimFunctionTarget`,
which #772 landed for the other services delivering to a qualified ARN. `SimHttpApiFunctionTarget`
moved into a file of its own and now extends `SimLambdaFunctionTarget`, so it carries the resource
the URI named alongside the version that runs. Those differ for an alias, and the invoke permission
is decided against the resource, so an integration on `orders:live` needs a grant made on `live`.

Nothing is pinned when the integration is created, which is what lets a route follow its alias. Both
invocation paths go through the same lookup, so a `REQUEST` authorizer's `AuthorizerUri` follows an
alias the same way.

## One deviation from the issue

The fourth acceptance criterion says an unresolvable qualifier is "refused when the integration is
created, the way an unknown function is". The two halves disagree. An unknown function is not
refused at `CreateIntegration`, and `sim-http-api-serve-errors.iso.test.ts` records that as the
design ("the missing function surfaces where real API Gateway finds it too, at the invocation rather
than at the integration that named it"). Real API Gateway validates neither.

I followed "the way an unknown function is". A qualifier belonging to no version and no alias
answers 500 at the request, covered by a test. Refusing at creation would need a Lambda collaborator
wired into the API Gateway command layer, which today has no reach into Lambda at all and would have
to reach across Accounts. Say the word and I will wire the port instead.

## Notes for review

- This was written before #772 landed and rebased onto it. The Lambda-side machinery I had added
  (a version-store lookup, a `SimLambda` accessor, a resource on `SimLambdaServiceInvokeAuthorizer`)
  is all gone in favour of what #772 shipped. What is left outside `apigatewayv2` is two stale lines
  in the Lambda READMEs, which listed API Gateway among the callers that refuse a qualifier.
- `docs/services/apigatewayv2/sim-apigatewayv2-lambda-alias.example.ts` was run, not just compiled.
  It prints the two lines the docs show.

- [x] Conventional commit message, used as the title
- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`
