### PR TITLE
docs: drop a stale S3 Lambda alias limitation

### DIFF
--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -1511,8 +1511,6 @@ writes fall outside it. Without that, the simulation stops after a thousand deli
 - A CDK `BucketDeployment` and `mountBucketFilesystem(...)` both replace the whole storage backend
   rather than putting Objects, and neither raises an event. Real CDK `BucketDeployment` fires one
   `ObjectCreated:Put` per file.
-- A function ARN naming a version or an alias is refused, since simulated Lambda has no versions or
-  aliases.
 - A topic destination publishes with no message attributes, since real S3 publishes none. The only
   thing on the message besides the event document is the `Amazon S3 Notification` subject.
 - `s3:TestEvent` is left out. Real S3 puts one on a queue or topic when a configuration naming it is


### PR DESCRIPTION
The S3 notification limitations still said a function ARN naming a version or an alias is refused. That stopped being true when qualified notification targets landed in #772, and the same page already documents the behaviour under "To a Lambda version or alias".