### PR TITLE
feat: route a REST API request to its Lambda integration

### DIFF
--- a/docs/services/apigateway/README.md
+++ b/docs/services/apigateway/README.md
@@ -9,9 +9,8 @@ This is the v1 service. HTTP APIs are v2, on a separate SDK client, and they are
 [API Gateway HTTP APIs](../apigatewayv2/). The two hold separate state. A REST API created here
 stays out of `simAws.apiGatewayV2()`.
 
-What this covers is building an API and reading it back. That is enough for a test asserting on the
-shape of the API a CDK or SAM stack produces. Serving a request through one is a separate piece of
-work, still to come.
+A handler behind a REST API can be tested against a real HTTP request, with no hand-built event to
+keep in step.
 
 ## Creating a REST API
 
@@ -255,10 +254,108 @@ reaches no client until another deployment is created. Here a stage serves the A
 resources. A test that edits a method sees the change straight away, with no redeployment in
 between. That is the one place this departs from AWS.
 
+## Serving a request
+
+A request to the stage's invoke URL walks the resource tree to a method and invokes that method's
+integration, and the handler's response becomes the HTTP response.
+
+```typescript sim-apigateway-serve
+/**
+ * Serving a request through a REST API to its Lambda proxy integration.
+ *
+ * The handler reads the payload format 1.0 event a REST API sends, which is
+ * the older of the two formats and the only one a REST API uses.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import { simRestApiLambdaProxyFactory } from "@kensio/yulin/apigateway";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+const restApi = await simRestApiLambdaProxyFactory.make(
+  {
+    resourcePaths: ["/orders/{orderId}"],
+    handler: (event) => ({
+      statusCode: 200,
+      headers: { "content-type": "text/plain" },
+      body: `order ${event.pathParameters?.["orderId"] ?? "none"}`,
+    }),
+  },
+  simAws,
+);
+
+const srv = await serveSimAws({ simAws });
+
+const response = await fetch(
+  srv.localUrl(`${restApi.invokeUrl("prod")}/orders/6`),
+);
+
+console.log(response.status);
+// 200
+
+console.log(await response.text());
+// "order 6"
+
+await srv.close();
+```
+
+`simRestApiLambdaProxyFactory` builds the function, the resources, the method, the integration, the
+invoke permission and the deployment in one call. A test about serving wants all of them and is
+about none of them. A test about the commands themselves sends them one at a time.
+
+### The event a handler receives
+
+A REST API sends payload format 1.0. It carries both a single-value and a multi-value map for the
+headers and the query string, and it sends `null` for an empty map where format 2.0 omits the field:
+
+| Field                                                      | Empty case |
+| ---------------------------------------------------------- | ---------- |
+| `queryStringParameters`, `multiValueQueryStringParameters` | `null`     |
+| `pathParameters`, `stageVariables`                         | `null`     |
+| `body`                                                     | `null`     |
+
+`resource` is the template the path matched, such as `/orders/{orderId}`, and `path` is the path the
+client asked for, stage segment and all. A handler behind a `{proxy+}` reads `resource` to tell which
+template caught its request.
+
+Each format's handler reads the other format's event wrongly. One function behind both an HTTP API
+and a REST API therefore has to pick a side.
+
+### The response a handler returns
+
+A REST API proxy integration takes one shape. A result carrying a numeric `statusCode` becomes the
+response, and `multiValueHeaders` sends a header more than once. Anything else is a 502 with
+`Internal server error`. That is what real API Gateway answers when it cannot read the integration
+response. Payload format 2.0 is the lenient one, wrapping an unrecognised value in a 200, and a
+handler relying on that behaves differently here for the same reason it does on AWS.
+
+### Answers when the request matches nothing
+
+| Case                                          | Answer                             |
+| --------------------------------------------- | ---------------------------------- |
+| A stage the API does not serve                | 403 `Forbidden`                    |
+| A path or method the stage has no entry for   | 403 `Missing Authentication Token` |
+| The generated endpoint switched off           | 403 `Forbidden`                    |
+| No integration, no function, or no permission | 502 `Internal server error`        |
+| The handler threw                             | 502 `Internal server error`        |
+
+`Missing Authentication Token` is the wording real API Gateway is well known for. It answers a path
+that matched nothing just as much as one that needed credentials.
+
+### The invoke permission
+
+A method's integration runs once the function's resource policy allows
+`apigateway.amazonaws.com` to invoke it, exactly as on AWS. The method the request matched is
+supplied as `AWS:SourceArn`, in the form
+`arn:aws:execute-api:{region}:{account}:{apiId}/{stage}/{METHOD}/{resourcePath}`. A permission
+granted for one method therefore leaves the others closed. CDK wildcards the stage, method and path segments,
+which admits every method of the API.
+
 ## Intercepting an SDK client
 
 `SimSdk` routes `@aws-sdk/client-api-gateway` commands to the simulation. Code under test builds its
-own client and reaches simulated API Gateway through it, with nothing handed in.
+own client and reaches simulated API Gateway through it.
 
 ```typescript sim-apigateway-sdk-interception
 /**
@@ -328,7 +425,9 @@ and behave differently deployed. The refusals worth knowing about:
 
 ## Limitations
 
-- Serving a request through a simulated REST API is still to come. An integrated Lambda function is
-  recorded here and never invoked.
 - CloudFormation and CDK deployment of `AWS::ApiGateway::*` resources is still to come.
+- A repeated request header reaches the handler as one joined value in `multiValueHeaders`, because
+  that is the form the platform's `Headers` hands over. Real API Gateway reports each separately.
+- Binary media types negotiated by `Accept`, CORS preflight and gateway responses are outside this.
+  A response body is still base64 decoded when the handler says `isBase64Encoded`.
 - WebSocket APIs are outside this and outside the v2 service.

--- a/docs/services/apigateway/sim-apigateway-serve.example.ts
+++ b/docs/services/apigateway/sim-apigateway-serve.example.ts
@@ -1,0 +1,38 @@
+/**
+ * Serving a request through a REST API to its Lambda proxy integration.
+ *
+ * The handler reads the payload format 1.0 event a REST API sends, which is
+ * the older of the two formats and the only one a REST API uses.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import { simRestApiLambdaProxyFactory } from "@kensio/yulin/apigateway";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+const restApi = await simRestApiLambdaProxyFactory.make(
+  {
+    resourcePaths: ["/orders/{orderId}"],
+    handler: (event) => ({
+      statusCode: 200,
+      headers: { "content-type": "text/plain" },
+      body: `order ${event.pathParameters?.["orderId"] ?? "none"}`,
+    }),
+  },
+  simAws,
+);
+
+const srv = await serveSimAws({ simAws });
+
+const response = await fetch(
+  srv.localUrl(`${restApi.invokeUrl("prod")}/orders/6`),
+);
+
+console.log(response.status);
+// 200
+
+console.log(await response.text());
+// "order 6"
+
+await srv.close();

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -5,6 +5,7 @@
     "tsBuildInfoFile": "../tsconfig.docs.tsbuildinfo",
     "paths": {
       "@kensio/yulin": ["../src/index.ts"],
+      "@kensio/yulin/apigateway": ["../src/service/apigateway/index.ts"],
       "@kensio/yulin/apigatewayv2": ["../src/service/apigatewayv2/index.ts"],
       "@kensio/yulin/cloudformation": [
         "../src/service/cloudformation/index.ts"

--- a/src/serve/controller/factory/sim-aws-service-controller-factory.ts
+++ b/src/serve/controller/factory/sim-aws-service-controller-factory.ts
@@ -1,6 +1,6 @@
 import type { SimAwsServiceController } from "../sim-service-controller.js";
 import type { SimAws } from "../../../service/aws/sim-aws.js";
-import { SimApiGatewayV2ServiceController } from "../../../service/apigatewayv2/serve/sim-api-gateway-v2-controller.js";
+import { SimExecuteApiController } from "../../execute-api/sim-execute-api-controller.js";
 import { SimCloudFrontServiceController } from "../../../service/cloudfront/controller/sim-cloudfront-controller.js";
 import { SimCognitoServiceController } from "../../../service/cognito/serve/sim-cognito-controller.js";
 import { SimElbV2ServiceController } from "../../../service/elbv2/serve/sim-elbv2-controller.js";
@@ -33,8 +33,8 @@ export class SimAwsServiceControllerFactory {
       case "route53": {
         return new SimRoute53ServiceController({ simAws: this.simAws });
       }
-      case "apiGatewayV2": {
-        return new SimApiGatewayV2ServiceController({ simAws: this.simAws });
+      case "executeApi": {
+        return new SimExecuteApiController({ simAws: this.simAws });
       }
       case "elbV2": {
         return new SimElbV2ServiceController({ simAws: this.simAws });

--- a/src/serve/controller/sim-aws-service-signing-name.ts
+++ b/src/serve/controller/sim-aws-service-signing-name.ts
@@ -27,9 +27,10 @@ export function simAwsServiceSigningName(
     case "cognitoIdentityProvider": {
       return "cognito-idp";
     }
-    case "apiGatewayV2": {
-      // The generated API endpoint signs as execute-api, not as the
-      // apigateway control plane that created the API.
+    case "executeApi": {
+      // Both API kinds are issued a generated endpoint under this one host,
+      // and it signs as execute-api rather than as the apigateway control
+      // plane that created the API.
       return "execute-api";
     }
     case "elbV2": {

--- a/src/serve/controller/sim-service-controller.ts
+++ b/src/serve/controller/sim-service-controller.ts
@@ -23,7 +23,7 @@ export interface SimAwsServiceTarget {
     | "lambda"
     | "route53"
     | "cognitoIdentityProvider"
-    | "apiGatewayV2"
+    | "executeApi"
     | "elbV2";
   readonly resourceName: string;
   // regionName is used for validation, not look-up

--- a/src/serve/execute-api/sim-execute-api-controller.ts
+++ b/src/serve/execute-api/sim-execute-api-controller.ts
@@ -1,0 +1,61 @@
+import { SimApiGatewayServiceController } from "../../service/apigateway/serve/sim-api-gateway-controller.js";
+import { SimApiGatewayV2ServiceController } from "../../service/apigatewayv2/serve/sim-api-gateway-v2-controller.js";
+import type { SimAws } from "../../service/aws/sim-aws.js";
+import type {
+  SimAwsServiceController,
+  SimAwsServiceRequest,
+} from "../controller/sim-service-controller.js";
+
+interface SimExecuteApiControllerProperties {
+  readonly simAws: SimAws;
+}
+
+/**
+ * Localhost HTTP controller for the `execute-api` endpoint.
+ *
+ * API Gateway issues both of its API kinds an endpoint under one hostname
+ * shape, `<api-id>.execute-api.<region>.amazonaws.com`, and a REST API id
+ * looks exactly like an HTTP API id. The hostname therefore says which
+ * endpoint was addressed and not which service owns it, so the request is
+ * handed to whichever service allocated the id.
+ *
+ * That split is made here rather than while the hostname is resolved, for the
+ * same reason a load balancer's DNS name resolves before anything asks whether
+ * a load balancer still answers on it. Resolution recognises shape, and what
+ * exists is settled when the request is routed.
+ *
+ * An id neither service allocated goes to the HTTP API controller, which
+ * answers for an API that is not there.
+ */
+export class SimExecuteApiController implements SimAwsServiceController {
+  private readonly simAws: SimAws;
+  private readonly restApis: SimApiGatewayServiceController;
+  private readonly httpApis: SimApiGatewayV2ServiceController;
+
+  constructor(properties: SimExecuteApiControllerProperties) {
+    this.simAws = properties.simAws;
+    this.restApis = new SimApiGatewayServiceController({
+      simAws: this.simAws,
+    });
+    this.httpApis = new SimApiGatewayV2ServiceController({
+      simAws: this.simAws,
+    });
+  }
+
+  /**
+   * Hand the request to the service that owns the API id it addressed.
+   */
+  async handleRequest(serviceRequest: SimAwsServiceRequest): Promise<Response> {
+    return await this.owner(serviceRequest.target.resourceName).handleRequest(
+      serviceRequest,
+    );
+  }
+
+  private owner(apiId: string): SimAwsServiceController {
+    const isRestApi =
+      this.simAws.serviceFactory.registries.restApi.accountIdForApi(apiId) !==
+      undefined;
+
+    return isRestApi ? this.restApis : this.httpApis;
+  }
+}

--- a/src/serve/index.ts
+++ b/src/serve/index.ts
@@ -22,3 +22,12 @@ export {
   simAwsErrorDetailHeaderName,
   simAwsErrorHeaderName,
 } from "./http/response/sim-aws-response-hints.js";
+export type {
+  SimPayload1Event,
+  SimPayload1Identity,
+  SimPayload1RequestContext,
+  SimPayload1Result,
+} from "./payload-1/sim-payload-1-event.type.js";
+export type { SimPayload1Endpoint } from "./payload-1/sim-payload-1-endpoint.js";
+export { SimPayload1EventBuilder } from "./payload-1/sim-payload-1-event-builder.js";
+export { SimPayload1ResponseBuilder } from "./payload-1/sim-payload-1-response-builder.js";

--- a/src/serve/payload-1/sim-payload-1-body.ts
+++ b/src/serve/payload-1/sim-payload-1-body.ts
@@ -1,0 +1,31 @@
+import { SimProxyBodyEncoding } from "../proxy/sim-proxy-body-encoding.js";
+
+const bodyEncoding = new SimProxyBodyEncoding();
+
+/**
+ * How a request body reaches a payload format 1.0 handler.
+ *
+ * A request with no body sends `null` rather than an empty string, and the
+ * flag tells the handler whether what it did get was base64 encoded.
+ */
+export interface SimPayload1Body {
+  readonly body: string | null;
+  readonly isBase64Encoded: boolean;
+}
+
+/**
+ * Read a request body for the event.
+ */
+export function simPayload1Body(
+  bytes: Uint8Array,
+  contentType: string | null,
+): SimPayload1Body {
+  if (bytes.length === 0) {
+    return { body: null, isBase64Encoded: false };
+  }
+
+  return {
+    body: bodyEncoding.encode(bytes, contentType),
+    isBase64Encoded: !bodyEncoding.isText(contentType),
+  };
+}

--- a/src/serve/payload-1/sim-payload-1-endpoint.ts
+++ b/src/serve/payload-1/sim-payload-1-endpoint.ts
@@ -1,0 +1,28 @@
+/**
+ * The endpoint identity a payload format 1.0 event describes.
+ *
+ * Everything here is what the REST API calls itself for one matched request:
+ * the API, the stage that served it, the resource the path reached and the
+ * values that path captured. Gathering them lets the event builder ask the
+ * endpoint rather than know about the service.
+ */
+export interface SimPayload1Endpoint {
+  /** The API id, which is the leading label of the endpoint hostname. */
+  readonly apiId: string;
+  /** The Account that owns the API. */
+  readonly accountId: string;
+  /** The AWS-shaped hostname of the endpoint, not the local one served. */
+  readonly domainName: string;
+  /** The stage that served the request. */
+  readonly stage: string;
+  /** The allocated id of the resource the request matched. */
+  readonly resourceId: string;
+  /** The resource path template, such as `/orders/{orderId}`. */
+  readonly resourcePath: string;
+  /** The method declared on that resource, which may be `ANY`. */
+  readonly httpMethod: string;
+  /** Values captured by the resource path, if it captured any. */
+  readonly pathParameters?: Readonly<Record<string, string>> | undefined;
+  /** The stage's variables, if it has any. */
+  readonly stageVariables?: Readonly<Record<string, string>> | undefined;
+}

--- a/src/serve/payload-1/sim-payload-1-event-builder.ts
+++ b/src/serve/payload-1/sim-payload-1-event-builder.ts
@@ -1,0 +1,83 @@
+import { type SimClock, SimRealClock } from "../../util/clock/sim-clock.js";
+import {
+  simAwsProxiedSourceIp,
+  simAwsProxiedTraceId,
+} from "../http/sim-aws-proxied-connection.js";
+import type { SimPayload1Endpoint } from "./sim-payload-1-endpoint.js";
+import type { SimPayload1Event } from "./sim-payload-1-event.type.js";
+import { SimPayload1RequestContextBuilder } from "./sim-payload-1-request-context.js";
+import { simPayload1Body } from "./sim-payload-1-body.js";
+import {
+  orNull,
+  simPayload1Headers,
+  simPayload1QueryStringParameters,
+} from "./sim-payload-1-request-parts.js";
+
+interface SimPayload1EventBuilderProperties {
+  /**
+   * Clock stamping the event's requestContext time, so a handler sees the same
+   * "now" as the rest of the simulation.
+   */
+  readonly clock?: SimClock;
+}
+
+/**
+ * Builds the payload format 1.0 event a REST API's proxy integration passes to
+ * the function handler.
+ *
+ * This is the older of the two formats and the only one a REST API sends. It
+ * carries both a single-value and a multi-value map for the headers and the
+ * query string, and it sends `null` where payload format 2.0 leaves a field
+ * out. A handler written for one reads the other wrongly, which is why the two
+ * builders stay apart.
+ */
+export class SimPayload1EventBuilder {
+  private readonly requestContext = new SimPayload1RequestContextBuilder();
+  private readonly clock: SimClock;
+
+  constructor(properties: SimPayload1EventBuilderProperties = {}) {
+    this.clock = properties.clock ?? new SimRealClock();
+  }
+
+  /**
+   * Build the invocation event for one request to an endpoint.
+   */
+  async build(
+    request: Request,
+    endpoint: SimPayload1Endpoint,
+  ): Promise<SimPayload1Event> {
+    const url = new URL(request.url);
+    const at = this.clock.now();
+    const body = simPayload1Body(
+      new Uint8Array(await request.arrayBuffer()),
+      request.headers.get("content-type"),
+    );
+
+    const headers = simPayload1Headers(request, {
+      domainName: endpoint.domainName,
+      traceId: simAwsProxiedTraceId(at),
+      sourceIp: simAwsProxiedSourceIp,
+    });
+    const query = simPayload1QueryStringParameters(url.searchParams);
+
+    return {
+      resource: endpoint.resourcePath,
+      path: url.pathname,
+      httpMethod: request.method,
+      headers: orNull(headers.single),
+      multiValueHeaders: orNull(headers.multi),
+      queryStringParameters: orNull(query.single),
+      multiValueQueryStringParameters: orNull(query.multi),
+      pathParameters: orNull({ ...endpoint.pathParameters }),
+      stageVariables: orNull({ ...endpoint.stageVariables }),
+      requestContext: this.requestContext.build({
+        request,
+        url,
+        endpoint,
+        sourceIp: simAwsProxiedSourceIp,
+        at,
+      }),
+      ...body,
+    };
+  }
+}

--- a/src/serve/payload-1/sim-payload-1-event.type.ts
+++ b/src/serve/payload-1/sim-payload-1-event.type.ts
@@ -1,0 +1,89 @@
+/**
+ * Who API Gateway says made the request.
+ *
+ * Real events carry every field, with `null` for the ones that do not apply,
+ * which is why a handler reading `identity.userArn` on an open method finds
+ * `null` rather than nothing at all.
+ */
+export interface SimPayload1Identity {
+  sourceIp: string;
+  userAgent: string | null;
+  accessKey: string | null;
+  accountId: string | null;
+  apiKey: string | null;
+  apiKeyId: string | null;
+  caller: string | null;
+  cognitoAuthenticationProvider: string | null;
+  cognitoAuthenticationType: string | null;
+  cognitoIdentityId: string | null;
+  cognitoIdentityPoolId: string | null;
+  principalOrgId: string | null;
+  user: string | null;
+  userArn: string | null;
+}
+
+/**
+ * What payload format 1.0 says about the request beyond the request itself.
+ */
+export interface SimPayload1RequestContext {
+  accountId: string;
+  apiId: string;
+  domainName: string;
+  domainPrefix: string;
+  extendedRequestId: string;
+  httpMethod: string;
+  identity: SimPayload1Identity;
+  /** The request path, stage segment and all. */
+  path: string;
+  protocol: string;
+  requestId: string;
+  requestTime: string;
+  requestTimeEpoch: number;
+  resourceId: string;
+  /** The resource path template the request matched, without the stage. */
+  resourcePath: string;
+  stage: string;
+}
+
+/**
+ * The event a REST API's Lambda proxy integration passes to the handler.
+ *
+ * The empty cases are `null` rather than absent, which is what real API
+ * Gateway sends and what a handler checking `event.queryStringParameters ===
+ * null` relies on. Payload format 2.0 leaves them out instead, and that
+ * difference is the reason a handler written for one format cannot read the
+ * other.
+ */
+export interface SimPayload1Event {
+  resource: string;
+  path: string;
+  httpMethod: string;
+  headers: Record<string, string> | null;
+  multiValueHeaders: Record<string, string[]> | null;
+  queryStringParameters: Record<string, string> | null;
+  multiValueQueryStringParameters: Record<string, string[]> | null;
+  pathParameters: Record<string, string> | null;
+  stageVariables: Record<string, string> | null;
+  requestContext: SimPayload1RequestContext;
+  body: string | null;
+  isBase64Encoded: boolean;
+}
+
+/**
+ * The structured response a payload format 1.0 handler returns.
+ */
+export interface SimPayload1Result {
+  statusCode?: number | undefined;
+  headers?: Record<string, string | number | boolean> | undefined;
+  multiValueHeaders?: Record<string, (string | number | boolean)[]> | undefined;
+  body?: string | undefined;
+  isBase64Encoded?: boolean | undefined;
+}
+
+/**
+ * A handler result carrying the status code that makes it a structured
+ * response.
+ */
+export interface SimPayload1StructuredResult extends SimPayload1Result {
+  statusCode: number;
+}

--- a/src/serve/payload-1/sim-payload-1-request-context.ts
+++ b/src/serve/payload-1/sim-payload-1-request-context.ts
@@ -1,0 +1,78 @@
+import { randomUUID } from "node:crypto";
+
+import { simProxyEventTime } from "../proxy/sim-proxy-event-time.js";
+import type { SimPayload1Endpoint } from "./sim-payload-1-endpoint.js";
+import type {
+  SimPayload1Identity,
+  SimPayload1RequestContext,
+} from "./sim-payload-1-event.type.js";
+
+interface SimPayload1RequestContextInput {
+  readonly request: Request;
+  readonly url: URL;
+  readonly endpoint: SimPayload1Endpoint;
+  readonly sourceIp: string;
+  readonly at: Date;
+}
+
+/**
+ * Builds the `requestContext` of a payload format 1.0 event.
+ *
+ * This is what the REST API says about the request rather than what the client
+ * sent. The resource fields name the tree node the path matched, which is what
+ * lets a handler behind a `{proxy+}` tell which template caught it.
+ */
+export class SimPayload1RequestContextBuilder {
+  /**
+   * Build the request context for one request to an endpoint.
+   */
+  build(input: SimPayload1RequestContextInput): SimPayload1RequestContext {
+    const { endpoint, url, at } = input;
+
+    return {
+      accountId: endpoint.accountId,
+      apiId: endpoint.apiId,
+      domainName: endpoint.domainName,
+      domainPrefix: endpoint.apiId,
+      extendedRequestId: randomUUID(),
+      httpMethod: input.request.method,
+      identity: this.identity(input),
+      path: url.pathname,
+      // Simulated endpoints are served over plain localhost HTTP, and this
+      // describes the AWS endpoint the request names.
+      protocol: "HTTP/1.1",
+      requestId: randomUUID(),
+      requestTime: simProxyEventTime(at),
+      requestTimeEpoch: at.getTime(),
+      resourceId: endpoint.resourceId,
+      resourcePath: endpoint.resourcePath,
+      stage: endpoint.stage,
+    };
+  }
+
+  /**
+   * Who API Gateway says made the request.
+   *
+   * Only the open case is described here. Authorizing a method is a separate
+   * piece of work, and the fields an authorizer would fill stay `null` until
+   * something fills them.
+   */
+  private identity(input: SimPayload1RequestContextInput): SimPayload1Identity {
+    return {
+      sourceIp: input.sourceIp,
+      userAgent: input.request.headers.get("user-agent"),
+      accessKey: null,
+      accountId: null,
+      apiKey: null,
+      apiKeyId: null,
+      caller: null,
+      cognitoAuthenticationProvider: null,
+      cognitoAuthenticationType: null,
+      cognitoIdentityId: null,
+      cognitoIdentityPoolId: null,
+      principalOrgId: null,
+      user: null,
+      userArn: null,
+    };
+  }
+}

--- a/src/serve/payload-1/sim-payload-1-request-parts.ts
+++ b/src/serve/payload-1/sim-payload-1-request-parts.ts
@@ -1,0 +1,87 @@
+import {
+  simProxyHeaders,
+  type SimProxiedConnection,
+} from "../proxy/sim-proxy-headers.js";
+
+/**
+ * The single-value and multi-value forms of one set of request values.
+ */
+export interface SimPayload1Values {
+  readonly single: Record<string, string>;
+  readonly multi: Record<string, string[]>;
+}
+
+/**
+ * A map that is `null` when it holds nothing.
+ *
+ * Payload format 1.0 sends `null` for an empty map rather than leaving the
+ * field out, and a handler checking `event.queryStringParameters === null`
+ * depends on it.
+ */
+export function orNull<Value>(
+  entries: Record<string, Value>,
+): Record<string, Value> | null {
+  return Object.keys(entries).length === 0 ? null : entries;
+}
+
+/**
+ * The request headers, in both forms payload format 1.0 sends.
+ *
+ * The single-value map keeps the last value of a repeated header, which is
+ * what real API Gateway does, and the multi-value map keeps them all. The
+ * headers AWS rewrites itself land on top of whatever the client sent.
+ */
+export function simPayload1Headers(
+  request: Request,
+  proxied: SimProxiedConnection,
+): SimPayload1Values {
+  const multi = new Map<string, string[]>();
+
+  // A repeated request header arrives already joined, because that is what the
+  // Fetch API's Headers does with one. The multi-value map therefore reports
+  // one joined value where real API Gateway would report each separately.
+  request.headers.forEach((value, name) => {
+    multi.set(name, [value]);
+  });
+
+  const awsHeaders = Object.entries(simProxyHeaders(proxied));
+
+  for (const [name, value] of awsHeaders) {
+    multi.set(name, [value]);
+  }
+
+  return valuesOf(multi);
+}
+
+/**
+ * The query string, in both forms payload format 1.0 sends.
+ *
+ * The single-value map keeps the last value of a repeated key, which is what
+ * real API Gateway does. Payload format 2.0 joins repeats with a comma
+ * instead, and that difference is visible to a handler reading either.
+ */
+export function simPayload1QueryStringParameters(
+  searchParameters: URLSearchParams,
+): SimPayload1Values {
+  const multi = new Map<string, string[]>();
+  const keys = new Set(searchParameters.keys());
+
+  for (const key of keys) {
+    multi.set(key, searchParameters.getAll(key));
+  }
+
+  return valuesOf(multi);
+}
+
+/**
+ * Both forms of a set of values, from the multi-value one.
+ */
+function valuesOf(multi: ReadonlyMap<string, string[]>): SimPayload1Values {
+  return {
+    single: Object.fromEntries(
+      /* v8 ignore next -- every entry is set with at least one value */
+      multi.entries().map(([name, values]) => [name, values.at(-1) ?? ""]),
+    ),
+    multi: Object.fromEntries(multi),
+  };
+}

--- a/src/serve/payload-1/sim-payload-1-response-builder.ts
+++ b/src/serve/payload-1/sim-payload-1-response-builder.ts
@@ -1,0 +1,67 @@
+import { SimProxyBodyEncoding } from "../proxy/sim-proxy-body-encoding.js";
+import type {
+  SimPayload1Result,
+  SimPayload1StructuredResult,
+} from "./sim-payload-1-event.type.js";
+
+/**
+ * Turns a payload format 1.0 handler result into the HTTP response the client
+ * sees.
+ *
+ * A REST API proxy integration takes one shape only. A handler returning
+ * anything without a numeric `statusCode` produces a 502 from real API
+ * Gateway, with `Internal server error` in the body, because the integration
+ * response could not be read. Payload format 2.0 is the lenient one, wrapping
+ * an unrecognised value in a 200, and a handler relying on that behaves
+ * differently here for the same reason it does on AWS.
+ */
+export class SimPayload1ResponseBuilder {
+  private readonly bodyEncoding = new SimProxyBodyEncoding();
+
+  /**
+   * Whether a handler result is a response API Gateway can send.
+   */
+  isStructuredResult(result: unknown): result is SimPayload1StructuredResult {
+    return (
+      typeof result === "object" &&
+      result !== null &&
+      "statusCode" in result &&
+      typeof (result as SimPayload1Result).statusCode === "number"
+    );
+  }
+
+  /**
+   * Build the HTTP response for one structured handler result.
+   */
+  build(result: SimPayload1StructuredResult): Response {
+    const headers = new Headers();
+    const single = Object.entries(result.headers ?? {});
+    const repeated = Object.entries(result.multiValueHeaders ?? {});
+
+    for (const [name, value] of single) {
+      headers.set(name, String(value));
+    }
+
+    // multiValueHeaders wins over the single-value map for a name in both,
+    // which is what lets a handler send one header twice.
+    for (const [name, values] of repeated) {
+      headers.delete(name);
+
+      for (const value of values) {
+        headers.append(name, String(value));
+      }
+    }
+
+    const body = this.bodyEncoding.decode(
+      result.body ?? "",
+      result.isBase64Encoded ?? false,
+    );
+
+    return new Response(
+      // An empty body is sent as no body at all, so statuses that must not
+      // carry one, such as 204, stay valid responses.
+      body.length === 0 ? null : body,
+      { status: result.statusCode, headers },
+    );
+  }
+}

--- a/src/serve/payload-2/sim-payload-2-event-builder.ts
+++ b/src/serve/payload-2/sim-payload-2-event-builder.ts
@@ -3,7 +3,7 @@ import {
   simAwsProxiedSourceIp,
   simAwsProxiedTraceId,
 } from "../http/sim-aws-proxied-connection.js";
-import { SimPayload2BodyEncoding } from "./sim-payload-2-body-encoding.js";
+import { SimProxyBodyEncoding } from "../proxy/sim-proxy-body-encoding.js";
 import type { SimPayload2Endpoint } from "./sim-payload-2-endpoint.js";
 import type { SimPayload2Event } from "./sim-payload-2-event.type.js";
 import {
@@ -37,7 +37,7 @@ interface SimPayload2EventBuilderProperties {
  * is always present, as an empty string when there was no query.
  */
 export class SimPayload2EventBuilder {
-  private readonly bodyEncoding = new SimPayload2BodyEncoding();
+  private readonly bodyEncoding = new SimProxyBodyEncoding();
   private readonly requestParts = new SimPayload2RequestParts();
   private readonly requestContext = new SimPayload2RequestContextBuilder();
   private readonly clock: SimClock;

--- a/src/serve/payload-2/sim-payload-2-event.factory.ts
+++ b/src/serve/payload-2/sim-payload-2-event.factory.ts
@@ -2,18 +2,16 @@ import { faker } from "@faker-js/faker";
 import { DynamicFactory, type ItemFactory } from "@kensio/part-factory";
 
 import { simAwsProxiedTraceId } from "../http/sim-aws-proxied-connection.js";
+import { simProxyHeaders } from "../proxy/sim-proxy-headers.js";
 import type { SimPayload2EndpointStyle } from "./sim-payload-2-endpoint-style.js";
-import { simPayload2EventTime } from "./sim-payload-2-event-time.js";
+import { simProxyEventTime } from "../proxy/sim-proxy-event-time.js";
 import {
   type SimPayload2EventRequest,
   simPayload2EventRequest,
 } from "./sim-payload-2-event-request.js";
 import type { SimPayload2Event } from "./sim-payload-2-event.type.js";
 import { simPayload2AnonymousAccountId } from "./sim-payload-2-iam-caller.js";
-import {
-  simPayload2ProxyHeaders,
-  simPayload2QueryStringParameters,
-} from "./sim-payload-2-request-parts.js";
+import { simPayload2QueryStringParameters } from "./sim-payload-2-request-parts.js";
 
 /**
  * Build the factory making the invocation events of one kind of payload format
@@ -58,7 +56,7 @@ function eventHeaders(
   return {
     accept: "*/*",
     "user-agent": request.userAgent,
-    ...simPayload2ProxyHeaders({
+    ...simProxyHeaders({
       domainName: request.domainName,
       traceId: simAwsProxiedTraceId(request.at),
       sourceIp: request.sourceIp,
@@ -86,7 +84,7 @@ function eventRequestContext(
     requestId: faker.string.uuid(),
     routeKey: request.routeKey,
     stage: request.stage,
-    time: simPayload2EventTime(request.at),
+    time: simProxyEventTime(request.at),
     timeEpoch: request.at.getTime(),
   };
 }

--- a/src/serve/payload-2/sim-payload-2-request-context.ts
+++ b/src/serve/payload-2/sim-payload-2-request-context.ts
@@ -8,7 +8,7 @@ import type {
   SimPayload2LambdaAuthorizer,
   SimPayload2RequestContext,
 } from "./sim-payload-2-event.type.js";
-import { simPayload2EventTime } from "./sim-payload-2-event-time.js";
+import { simProxyEventTime } from "../proxy/sim-proxy-event-time.js";
 import {
   simPayload2AnonymousAccountId,
   SimPayload2IamCaller,
@@ -75,7 +75,7 @@ export class SimPayload2RequestContextBuilder {
       requestId: randomUUID(),
       routeKey: endpoint.routeKey,
       stage: endpoint.stage,
-      time: simPayload2EventTime(at),
+      time: simProxyEventTime(at),
       timeEpoch: at.getTime(),
     };
 

--- a/src/serve/payload-2/sim-payload-2-request-parts.ts
+++ b/src/serve/payload-2/sim-payload-2-request-parts.ts
@@ -1,39 +1,7 @@
-/**
- * What AWS knows about a request it proxied, beyond the request itself.
- */
-export interface SimPayload2ProxiedConnection {
-  /** The AWS-shaped hostname of the endpoint the request reached. */
-  readonly domainName: string;
-  readonly traceId: string;
-  readonly sourceIp: string;
-}
-
-interface SimPayload2ProxiedRequest extends SimPayload2ProxiedConnection {
-  readonly request: Request;
-}
-
-/**
- * The headers AWS sets itself on a request it proxies to a function.
- *
- * These are set rather than merged: AWS terminates the connection itself and
- * rewrites them before the handler sees them, so whatever a client sent under
- * those names does not survive.
- */
-export function simPayload2ProxyHeaders(
-  proxied: SimPayload2ProxiedConnection,
-): Record<string, string> {
-  return {
-    // The endpoint's own hostname, not the localhost one the request arrived
-    // at, because that is the hostname the request named on real AWS.
-    host: proxied.domainName,
-    "x-amzn-trace-id": proxied.traceId,
-    "x-forwarded-for": proxied.sourceIp,
-    // Simulated endpoints are reached over plain localhost HTTP, while a real
-    // one is only reachable over HTTPS, so these describe the AWS endpoint.
-    "x-forwarded-port": "443",
-    "x-forwarded-proto": "https",
-  };
-}
+import {
+  simProxyHeaders,
+  type SimProxiedRequest,
+} from "../proxy/sim-proxy-headers.js";
 
 /**
  * Collect query string parameters, joining repeated keys with commas as
@@ -67,7 +35,7 @@ export class SimPayload2RequestParts {
    * Cookies are left out because they travel in their own event field, and the
    * headers AWS rewrites itself land on top of whatever the client sent.
    */
-  headers(proxied: SimPayload2ProxiedRequest): Record<string, string> {
+  headers(proxied: SimProxiedRequest): Record<string, string> {
     // Fetch API header names are already lowercased, which is the case
     // payload format 2.0 delivers them in, and repeats are already joined.
     const headers = new Map<string, string>();
@@ -78,7 +46,7 @@ export class SimPayload2RequestParts {
 
     return {
       ...Object.fromEntries(headers),
-      ...simPayload2ProxyHeaders(proxied),
+      ...simProxyHeaders(proxied),
     };
   }
 

--- a/src/serve/payload-2/sim-payload-2-response-builder.ts
+++ b/src/serve/payload-2/sim-payload-2-response-builder.ts
@@ -1,4 +1,4 @@
-import { SimPayload2BodyEncoding } from "./sim-payload-2-body-encoding.js";
+import { SimProxyBodyEncoding } from "../proxy/sim-proxy-body-encoding.js";
 import type {
   SimPayload2Result,
   SimPayload2StructuredResult,
@@ -19,7 +19,7 @@ const jsonContentType = "application/json";
  * AWS.
  */
 export class SimPayload2ResponseBuilder {
-  private readonly bodyEncoding = new SimPayload2BodyEncoding();
+  private readonly bodyEncoding = new SimProxyBodyEncoding();
 
   /**
    * Build the HTTP response for one handler result.

--- a/src/serve/proxy/sim-proxy-body-encoding.iso.test.ts
+++ b/src/serve/proxy/sim-proxy-body-encoding.iso.test.ts
@@ -1,12 +1,12 @@
 import { assertFalse, assertIdentical, assertTrue } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
-import { SimPayload2BodyEncoding } from "./sim-payload-2-body-encoding.js";
+import { SimProxyBodyEncoding } from "./sim-proxy-body-encoding.js";
 
 describe("Payload format 2.0 body encoding", () => {
   it("treats text media types as text", () => {
     // Given the body encoding rules.
-    const encoding = new SimPayload2BodyEncoding();
+    const encoding = new SimProxyBodyEncoding();
 
     // When text-ish content types are checked.
     // Then each is treated as text the handler receives as a string.
@@ -19,7 +19,7 @@ describe("Payload format 2.0 body encoding", () => {
 
   it("treats other media types as binary", () => {
     // Given the body encoding rules.
-    const encoding = new SimPayload2BodyEncoding();
+    const encoding = new SimProxyBodyEncoding();
 
     // When binary content types are checked.
     // Then each is treated as binary, including a missing content type.
@@ -30,7 +30,7 @@ describe("Payload format 2.0 body encoding", () => {
 
   it("encodes binary request bodies as base64", () => {
     // Given some bytes that are not text.
-    const encoding = new SimPayload2BodyEncoding();
+    const encoding = new SimProxyBodyEncoding();
     const bytes = new Uint8Array([0, 1, 2]);
 
     // When they are encoded for the handler event.
@@ -42,7 +42,7 @@ describe("Payload format 2.0 body encoding", () => {
 
   it("passes text request bodies through as UTF-8", () => {
     // Given UTF-8 bytes with a text content type.
-    const encoding = new SimPayload2BodyEncoding();
+    const encoding = new SimProxyBodyEncoding();
     const bytes = new TextEncoder().encode("héllo");
 
     // When they are encoded for the handler event.
@@ -54,7 +54,7 @@ describe("Payload format 2.0 body encoding", () => {
 
   it("returns response bodies unchanged when not base64", () => {
     // Given a plain handler response body.
-    const encoding = new SimPayload2BodyEncoding();
+    const encoding = new SimProxyBodyEncoding();
 
     // When it is decoded for the client.
     const body = encoding.decode("hello", false);

--- a/src/serve/proxy/sim-proxy-body-encoding.ts
+++ b/src/serve/proxy/sim-proxy-body-encoding.ts
@@ -7,12 +7,13 @@ const textContentTypes: ReadonlySet<string> = new Set([
 
 /**
  * Decides how a request or response body crosses the boundary between HTTP
- * bytes and the string a payload format 2.0 event carries.
+ * bytes and the string a Lambda proxy integration event carries.
  *
  * Real AWS passes text bodies through as UTF-8 strings and base64-encodes
  * everything else, telling the handler which happened with isBase64Encoded.
+ * Both payload formats do it the same way, so both read the rules from here.
  */
-export class SimPayload2BodyEncoding {
+export class SimProxyBodyEncoding {
   /**
    * Whether a content type's body is passed to the handler as text.
    *

--- a/src/serve/proxy/sim-proxy-event-time.iso.test.ts
+++ b/src/serve/proxy/sim-proxy-event-time.iso.test.ts
@@ -1,7 +1,7 @@
 import { assertIdentical } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
-import { simPayload2EventTime } from "./sim-payload-2-event-time.js";
+import { simProxyEventTime } from "../proxy/sim-proxy-event-time.js";
 
 describe("Payload format 2.0 event time", () => {
   it("formats the time as real events carry it", () => {
@@ -9,7 +9,7 @@ describe("Payload format 2.0 event time", () => {
     const at = new Date("2020-03-12T19:03:58.390Z");
 
     // When it is formatted for the event request context.
-    const time = simPayload2EventTime(at);
+    const time = simProxyEventTime(at);
 
     // Then it is the Common Log Format stamp, not an ISO-8601 one.
     assertIdentical(time, "12/Mar/2020:19:03:58 +0000");
@@ -20,7 +20,7 @@ describe("Payload format 2.0 event time", () => {
     const at = new Date("2024-01-01T23:07:05Z");
 
     // When it is formatted.
-    const time = simPayload2EventTime(at);
+    const time = simProxyEventTime(at);
 
     // Then the UTC date and time are used, with the fixed +0000 offset.
     assertIdentical(time, "01/Jan/2024:23:07:05 +0000");

--- a/src/serve/proxy/sim-proxy-event-time.ts
+++ b/src/serve/proxy/sim-proxy-event-time.ts
@@ -20,13 +20,15 @@ function twoDigits(value: number): string {
 }
 
 /**
- * Format the time payload format 2.0 carries in requestContext.time.
+ * Format the time a proxy integration event carries.
  *
  * This is the Common Log Format stamp real events use, such as
- * `12/Mar/2020:19:03:58 +0000`, always in UTC. The event's timeEpoch field is
- * the same instant in milliseconds, for handlers that want to compute with it.
+ * `12/Mar/2020:19:03:58 +0000`, always in UTC. Payload format 2.0 puts it in
+ * `requestContext.time` and format 1.0 in `requestContext.requestTime`, and
+ * both carry the same instant in milliseconds beside it for handlers that want
+ * to compute with it.
  */
-export function simPayload2EventTime(at: Date): string {
+export function simProxyEventTime(at: Date): string {
   const month = months[at.getUTCMonth()];
   assertDefined(month, `Month name for ${at.toISOString()}`);
 

--- a/src/serve/proxy/sim-proxy-headers.ts
+++ b/src/serve/proxy/sim-proxy-headers.ts
@@ -1,0 +1,38 @@
+/**
+ * What AWS knows about a request it proxied, beyond the request itself.
+ */
+export interface SimProxiedConnection {
+  /** The AWS-shaped hostname of the endpoint the request reached. */
+  readonly domainName: string;
+  readonly traceId: string;
+  readonly sourceIp: string;
+}
+
+export interface SimProxiedRequest extends SimProxiedConnection {
+  readonly request: Request;
+}
+
+/**
+ * The headers AWS sets itself on a request it proxies to a function.
+ *
+ * Both payload formats carry the same ones, so both read them from here.
+ *
+ * These are set rather than merged: AWS terminates the connection itself and
+ * rewrites them before the handler sees them, so whatever a client sent under
+ * those names does not survive.
+ */
+export function simProxyHeaders(
+  proxied: SimProxiedConnection,
+): Record<string, string> {
+  return {
+    // The endpoint's own hostname, not the localhost one the request arrived
+    // at, because that is the hostname the request named on real AWS.
+    host: proxied.domainName,
+    "x-amzn-trace-id": proxied.traceId,
+    "x-forwarded-for": proxied.sourceIp,
+    // Simulated endpoints are reached over plain localhost HTTP, while a real
+    // one is only reachable over HTTPS, so these describe the AWS endpoint.
+    "x-forwarded-port": "443",
+    "x-forwarded-proto": "https",
+  };
+}

--- a/src/service/apigateway/README.md
+++ b/src/service/apigateway/README.md
@@ -57,8 +57,12 @@ id and nothing else, and `CreateResource` names its parent by id. Each resource 
 full path its place in the tree gives it, which `CreateResource` computes and hands back.
 
 A greedy `{proxy+}` part matches the rest of the request path. A resource carrying one therefore
-takes no children. Walking a request path against this tree belongs to the serving layer, and that
-layer is still to be built.
+takes no children.
+
+`api/match/` walks a request path against this tree. At each segment the children are tried in the
+order real API Gateway resolves them, an exact literal first, then a single-segment `{name}`, then a
+greedy `{name+}`. That order is what makes `/orders/new` reach a literal `new` resource where an
+`{orderId}` sibling would otherwise have caught it.
 
 ## Stages and deployments
 
@@ -74,6 +78,26 @@ into it, and an edit made afterwards reaches no client until another deployment 
 stage serves the API's current resources. A test that edits a method sees the change straight away,
 with no redeployment between the edit and the assertion about it. That is the one place this
 departs from AWS.
+
+## Serving a request
+
+`serve/` answers a request to the generated endpoint:
+
+```text
+SimApiGatewayServiceController   the entry point, and what a miss is answered with
+├── SimApiGatewayRouter          an API id to its scope, an integration URI to its function
+└── SimRestApiIntegrationInvocation   the invoke permission, the event, the response
+```
+
+The event and response shapes live in `src/serve/payload-1/`, beside the payload format 2.0 ones an
+HTTP API and a Lambda Function URL use. The two formats share their body encoding, their proxy
+headers and their time format, which are in `src/serve/proxy/`, and differ in everything else.
+
+Both API kinds are issued endpoints under one hostname shape, and a REST API id looks exactly like
+an HTTP API id. `src/serve/execute-api/` is what tells them apart, by asking which service allocated
+the id. That split is made when the request is routed rather than while the hostname is resolved,
+for the same reason a load balancer's DNS name resolves before anything asks whether a load balancer
+still answers on it.
 
 ## What is refused
 

--- a/src/service/apigateway/api/match/sim-rest-api-match.iso.test.ts
+++ b/src/service/apigateway/api/match/sim-rest-api-match.iso.test.ts
@@ -1,0 +1,190 @@
+import { PutMethodCommand } from "@aws-sdk/client-api-gateway";
+import { assertIdentical, assertNonNullable } from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simRestApiLambdaProxyFactory } from "../sim-rest-api-lambda-proxy.factory.js";
+import type { SimRestApi } from "../sim-rest-api.js";
+import {
+  isSimRestApiMatch,
+  type SimRestApiMatch,
+} from "./sim-rest-api-match.js";
+import { SimRestApiRequest } from "./sim-rest-api-request.js";
+
+/**
+ * A REST API deployed to `prod`, declaring the given paths with one method
+ * each.
+ */
+async function givenApi(
+  simAws: SimAws,
+  resourcePaths: readonly string[],
+  httpMethod = "GET",
+): Promise<SimRestApi> {
+  return await simRestApiLambdaProxyFactory.make(
+    { resourcePaths, httpMethod },
+    simAws,
+  );
+}
+
+function matched(
+  restApi: SimRestApi,
+  method: string,
+  path: string,
+): SimRestApiMatch {
+  const match = restApi.match(new SimRestApiRequest({ method, path }));
+  assertNonNullable(isSimRestApiMatch(match) ? match : undefined);
+
+  return match as SimRestApiMatch;
+}
+
+describe("Matching a request to a simulated REST API", () => {
+  it("takes the stage off before walking the resource tree", async () => {
+    // Given an API deployed to prod with a method on /orders
+    const restApi = await givenApi(new SimAws(), ["/orders"]);
+
+    // When a request comes in under the stage segment
+    const match = matched(restApi, "GET", "/prod/orders");
+
+    // Then the stage is the one it named, and the tree saw the rest
+    assertIdentical(match.stage.stageName, "prod");
+    assertIdentical(match.resource.path, "/orders");
+    assertIdentical(match.method.httpMethod, "GET");
+  });
+
+  it("matches the root resource at the stage root", async () => {
+    // Given a method on the API's root resource
+    const restApi = await givenApi(new SimAws(), ["/"]);
+
+    // When the stage root is requested
+    const match = matched(restApi, "GET", "/prod");
+
+    // Then the root resource answers
+    assertIdentical(match.resource.path, "/");
+  });
+
+  it("captures a path parameter", async () => {
+    // Given /orders/{orderId}
+    const restApi = await givenApi(new SimAws(), ["/orders/{orderId}"]);
+
+    // When one order is requested
+    const match = matched(restApi, "GET", "/prod/orders/6");
+
+    // Then the segment is captured under the parameter's name
+    expect(match.pathParameters).toStrictEqual({ orderId: "6" });
+  });
+
+  it("percent-decodes a captured segment", async () => {
+    // Given /orders/{orderId}
+    const restApi = await givenApi(new SimAws(), ["/orders/{orderId}"]);
+
+    // When the segment carries an encoded character
+    const match = matched(restApi, "GET", "/prod/orders/a%2Fb");
+
+    // Then the handler reads it decoded, as it does on AWS
+    expect(match.pathParameters).toStrictEqual({ orderId: "a/b" });
+  });
+
+  it("prefers a literal segment over a path parameter beside it", async () => {
+    // Given both /orders/{orderId} and /orders/new
+    const restApi = await givenApi(new SimAws(), [
+      "/orders/{orderId}",
+      "/orders/new",
+    ]);
+
+    // When the literal one is requested
+    const match = matched(restApi, "GET", "/prod/orders/new");
+
+    // Then the literal wins, which is what stops {orderId} catching it
+    assertIdentical(match.resource.path, "/orders/new");
+    expect(match.pathParameters).toStrictEqual({});
+  });
+
+  it("gives the rest of the path to a greedy parameter", async () => {
+    // Given a catch-all under the root
+    const restApi = await givenApi(new SimAws(), ["/{proxy+}"], "ANY");
+
+    // When a deep path is requested
+    const match = matched(restApi, "POST", "/prod/orders/6/items");
+
+    // Then everything after the stage is the greedy parameter
+    assertIdentical(match.resource.path, "/{proxy+}");
+    expect(match.pathParameters).toStrictEqual({ proxy: "orders/6/items" });
+  });
+
+  it("prefers a declared path over the greedy one beside it", async () => {
+    // Given a catch-all and an explicit path
+    const restApi = await givenApi(
+      new SimAws(),
+      ["/{proxy+}", "/orders"],
+      "ANY",
+    );
+
+    // When the explicit path is requested
+    const match = matched(restApi, "GET", "/prod/orders");
+
+    // Then it answers rather than the catch-all
+    assertIdentical(match.resource.path, "/orders");
+  });
+
+  it("falls back to ANY where the resource declares no such method", async () => {
+    // Given a resource with only an ANY method
+    const restApi = await givenApi(new SimAws(), ["/orders"], "ANY");
+
+    // When a DELETE is requested
+    const match = matched(restApi, "DELETE", "/prod/orders");
+
+    // Then ANY answers it
+    assertIdentical(match.method.httpMethod, "ANY");
+  });
+
+  it("prefers a declared method over ANY on the same resource", async () => {
+    // Given a resource declaring both ANY and GET
+    const simAws = new SimAws();
+    const restApi = await givenApi(simAws, ["/orders"], "ANY");
+    await simAws.apiGateway().putMethod(
+      new PutMethodCommand({
+        restApiId: restApi.apiId,
+        resourceId: restApi.resources.findByPath("/orders")?.resourceId,
+        httpMethod: "GET",
+        authorizationType: "NONE",
+      }),
+    );
+
+    // When the declared method is requested
+    const match = matched(restApi, "GET", "/prod/orders");
+
+    // Then it wins over the catch-all
+    assertIdentical(match.method.httpMethod, "GET");
+  });
+
+  it("reports a stage that is not there apart from an unmatched path", async () => {
+    // Given an API deployed to prod
+    const restApi = await givenApi(new SimAws(), ["/orders"]);
+
+    // When another stage is requested, and when a path the tree has not got is
+    const stageMiss = restApi.match(
+      new SimRestApiRequest({ method: "GET", path: "/dev/orders" }),
+    );
+    const routeMiss = restApi.match(
+      new SimRestApiRequest({ method: "GET", path: "/prod/invoices" }),
+    );
+
+    // Then the two are told apart, because real API Gateway answers them with
+    // different messages
+    assertIdentical(stageMiss, "stage");
+    assertIdentical(routeMiss, "route");
+  });
+
+  it("reports a method the matched resource has not got", async () => {
+    // Given a resource with only a GET
+    const restApi = await givenApi(new SimAws(), ["/orders"]);
+
+    // When a POST is requested
+    const match = restApi.match(
+      new SimRestApiRequest({ method: "POST", path: "/prod/orders" }),
+    );
+
+    // Then nothing answers it
+    assertIdentical(match, "route");
+  });
+});

--- a/src/service/apigateway/api/match/sim-rest-api-match.ts
+++ b/src/service/apigateway/api/match/sim-rest-api-match.ts
@@ -1,0 +1,92 @@
+import { simRestApiAnyMethod } from "../method/sim-rest-api-method.js";
+import type { SimRestApiMethod } from "../method/sim-rest-api-method.js";
+import type { SimRestApiResource } from "../resource/sim-rest-api-resource.js";
+import type { SimRestApiStage } from "../stage/sim-rest-api-stage.js";
+import type { SimRestApi } from "../sim-rest-api.js";
+import type { SimRestApiRequest } from "./sim-rest-api-request.js";
+import {
+  type SimRestApiResourceMatch,
+  SimRestApiResourceWalk,
+} from "./sim-rest-api-resource-walk.js";
+
+/**
+ * What a simulated REST API found for one request.
+ */
+export interface SimRestApiMatch {
+  readonly stage: SimRestApiStage;
+  readonly resource: SimRestApiResource;
+  readonly method: SimRestApiMethod;
+  readonly pathParameters: Readonly<Record<string, string>>;
+}
+
+/**
+ * Why a request reached nothing.
+ *
+ * The two are told apart because real API Gateway answers them differently. A
+ * stage that is not there is a plain `Forbidden`, while a request that reached
+ * the stage and matched no method gets the `Missing Authentication Token`
+ * message API Gateway is well known for.
+ */
+export type SimRestApiMiss = "stage" | "route";
+
+/**
+ * Matches a request to a stage, a resource and a method of one REST API.
+ *
+ * The stage goes first, because every REST API request carries its stage as
+ * the first path segment and the resource tree knows nothing about it. A
+ * request to `/prod/orders/6` on stage `prod` reaches the tree as the segments
+ * `orders` and `6`.
+ */
+export class SimRestApiMatcher {
+  private readonly walk = new SimRestApiResourceWalk();
+
+  /**
+   * Find what should handle one request, or why nothing does.
+   */
+  match(
+    restApi: SimRestApi,
+    request: SimRestApiRequest,
+  ): SimRestApiMatch | SimRestApiMiss {
+    const [stageName, ...segments] = request.segments;
+    const stage = restApi.stages.find(stageName ?? "");
+
+    if (stage === undefined) {
+      return "stage";
+    }
+
+    const reached = this.walk.walk(restApi.resources, segments);
+
+    if (reached === undefined) {
+      return "route";
+    }
+
+    return this.matched(stage, reached, request) ?? "route";
+  }
+
+  /**
+   * The method of the reached resource that answers this request.
+   *
+   * An explicit method wins over `ANY`, which is the catch-all for whatever
+   * the resource declares no method of its own for.
+   */
+  private matched(
+    stage: SimRestApiStage,
+    reached: SimRestApiResourceMatch,
+    request: SimRestApiRequest,
+  ): SimRestApiMatch | undefined {
+    const method =
+      reached.resource.findMethod(request.method) ??
+      reached.resource.findMethod(simRestApiAnyMethod);
+
+    return method === undefined ? undefined : { stage, method, ...reached };
+  }
+}
+
+/**
+ * Whether matching found something to invoke.
+ */
+export function isSimRestApiMatch(
+  match: SimRestApiMatch | SimRestApiMiss,
+): match is SimRestApiMatch {
+  return typeof match !== "string";
+}

--- a/src/service/apigateway/api/match/sim-rest-api-request.ts
+++ b/src/service/apigateway/api/match/sim-rest-api-request.ts
@@ -1,0 +1,29 @@
+interface SimRestApiRequestProperties {
+  readonly method: string;
+  readonly path: string;
+}
+
+/**
+ * One HTTP request as a simulated REST API sees it for matching.
+ *
+ * The path is the whole request path, stage segment and all. A REST API always
+ * carries its stage as the first segment, and taking it off is the first step
+ * of matching rather than something the caller does beforehand.
+ */
+export class SimRestApiRequest {
+  public readonly method: string;
+  public readonly path: string;
+
+  constructor(properties: SimRestApiRequestProperties) {
+    this.method = properties.method;
+    this.path = properties.path;
+  }
+
+  /**
+   * The path segments, with the empty strings a leading or trailing separator
+   * produces dropped.
+   */
+  get segments(): readonly string[] {
+    return this.path.split("/").filter((segment) => segment.length > 0);
+  }
+}

--- a/src/service/apigateway/api/match/sim-rest-api-resource-walk.ts
+++ b/src/service/apigateway/api/match/sim-rest-api-resource-walk.ts
@@ -1,0 +1,132 @@
+import type { SimRestApiResourceStore } from "../resource/sim-rest-api-resource-store.js";
+import type { SimRestApiResource } from "../resource/sim-rest-api-resource.js";
+
+/**
+ * The resource a request path reached, and the path parameters captured on the
+ * way to it.
+ */
+export interface SimRestApiResourceMatch {
+  readonly resource: SimRestApiResource;
+  readonly pathParameters: Readonly<Record<string, string>>;
+}
+
+/**
+ * Walks a request path down a REST API's resource tree.
+ *
+ * At each segment the children are tried in the order real API Gateway
+ * resolves them: an exact literal first, then a single-segment `{name}` path
+ * parameter, then a greedy `{name+}` one that takes the rest of the path. That
+ * order is what makes `/orders/new` reach a literal `new` resource where an
+ * `{orderId}` sibling would otherwise have caught it.
+ */
+export class SimRestApiResourceWalk {
+  /**
+   * Find the resource a request path reaches, if the tree has one.
+   */
+  walk(
+    resources: SimRestApiResourceStore,
+    segments: readonly string[],
+  ): SimRestApiResourceMatch | undefined {
+    return this.from(resources, resources.root, segments, {});
+  }
+
+  private from(
+    resources: SimRestApiResourceStore,
+    resource: SimRestApiResource,
+    segments: readonly string[],
+    captured: Readonly<Record<string, string>>,
+  ): SimRestApiResourceMatch | undefined {
+    if (segments.length === 0) {
+      return { resource, pathParameters: captured };
+    }
+
+    const children = resources.children(resource.resourceId);
+
+    return (
+      this.literal(resources, children, segments, captured) ??
+      this.parameter(resources, children, segments, captured) ??
+      this.greedy(children, segments, captured)
+    );
+  }
+
+  /**
+   * Follow a child whose path part is the segment itself.
+   */
+  private literal(
+    resources: SimRestApiResourceStore,
+    children: readonly SimRestApiResource[],
+    segments: readonly string[],
+    captured: Readonly<Record<string, string>>,
+  ): SimRestApiResourceMatch | undefined {
+    const child = children.find(
+      (one) =>
+        one.pathPart?.parameterName === undefined &&
+        one.pathPart?.pathPart === segments[0],
+    );
+
+    return child === undefined
+      ? undefined
+      : this.from(resources, child, segments.slice(1), captured);
+  }
+
+  /**
+   * Follow a `{name}` child, capturing the segment it stands for.
+   */
+  private parameter(
+    resources: SimRestApiResourceStore,
+    children: readonly SimRestApiResource[],
+    segments: readonly string[],
+    captured: Readonly<Record<string, string>>,
+  ): SimRestApiResourceMatch | undefined {
+    const child = children.find(
+      (one) => one.pathPart?.parameterName !== undefined && !one.greedy,
+    );
+    const name = child?.pathPart?.parameterName;
+
+    if (child === undefined || name === undefined) {
+      return undefined;
+    }
+
+    return this.from(resources, child, segments.slice(1), {
+      ...captured,
+      /* v8 ignore next -- the walk only recurses while a segment is left */
+      [name]: decodedSegment(segments[0] ?? ""),
+    });
+  }
+
+  /**
+   * Follow a `{name+}` child, which takes every segment that is left.
+   */
+  private greedy(
+    children: readonly SimRestApiResource[],
+    segments: readonly string[],
+    captured: Readonly<Record<string, string>>,
+  ): SimRestApiResourceMatch | undefined {
+    const child = children.find((one) => one.greedy);
+    const name = child?.pathPart?.parameterName;
+
+    if (child === undefined || name === undefined) {
+      return undefined;
+    }
+
+    return {
+      resource: child,
+      pathParameters: {
+        ...captured,
+        [name]: segments.map((segment) => decodedSegment(segment)).join("/"),
+      },
+    };
+  }
+}
+
+/**
+ * A path segment as a handler reads it. API Gateway percent-decodes what it
+ * puts in `pathParameters`, and leaves a segment it cannot decode alone.
+ */
+function decodedSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}

--- a/src/service/apigateway/api/sim-rest-api-declared-method.ts
+++ b/src/service/apigateway/api/sim-rest-api-declared-method.ts
@@ -1,0 +1,97 @@
+import type { SimApiGateway } from "../sim-api-gateway.js";
+
+interface SimRestApiDeclaredMethodInput {
+  readonly restApiId: string;
+  readonly rootResourceId: string;
+  readonly resourcePath: string;
+  readonly httpMethod: string;
+  readonly functionArn: string;
+}
+
+/**
+ * Declare every path template of an API, each with its method and the
+ * integration behind it.
+ *
+ * They are declared one at a time because they share resources. Two paths
+ * under `/orders` build that resource once, and whichever gets there first
+ * creates it.
+ */
+export async function declaredMethods(
+  apiGateway: SimApiGateway,
+  resourcePaths: readonly string[],
+  input: Omit<SimRestApiDeclaredMethodInput, "resourcePath">,
+): Promise<void> {
+  for (const resourcePath of resourcePaths) {
+    // oxlint-disable-next-line no-await-in-loop -- paths share resources, so one at a time
+    await declaredMethod(apiGateway, { ...input, resourcePath });
+  }
+}
+
+/**
+ * Declare one path template, its method, and the integration behind it.
+ */
+async function declaredMethod(
+  apiGateway: SimApiGateway,
+  input: SimRestApiDeclaredMethodInput,
+): Promise<void> {
+  const { restApiId, httpMethod } = input;
+  const resourceId = await declaredResource(
+    apiGateway,
+    restApiId,
+    input.rootResourceId,
+    input.resourcePath,
+  );
+
+  await apiGateway.putMethod({
+    input: { restApiId, resourceId, httpMethod, authorizationType: "NONE" },
+  });
+  await apiGateway.putIntegration({
+    input: {
+      restApiId,
+      resourceId,
+      httpMethod,
+      type: "AWS_PROXY",
+      integrationHttpMethod: "POST",
+      uri: input.functionArn,
+    },
+  });
+}
+
+/**
+ * Declare the chain of resources one path template needs, reusing whatever the
+ * API already has, and answer the id of the leaf.
+ */
+async function declaredResource(
+  apiGateway: SimApiGateway,
+  restApiId: string,
+  rootResourceId: string,
+  resourcePath: string,
+): Promise<string> {
+  const pathParts = resourcePath.split("/").filter((part) => part !== "");
+  let parentId = rootResourceId;
+
+  for (const pathPart of pathParts) {
+    const existing = apiGateway
+      .findRestApi(restApiId)
+      ?.resources.list()
+      .find(
+        (one) =>
+          one.parentId === parentId && one.pathPart?.pathPart === pathPart,
+      );
+
+    if (existing !== undefined) {
+      parentId = existing.resourceId;
+      continue;
+    }
+
+    // Each resource is the parent of the next, so the chain is built one at a
+    // time rather than in parallel.
+    // oxlint-disable-next-line no-await-in-loop -- each parent id comes from the call before it
+    const created = await apiGateway.createResource({
+      input: { restApiId, parentId, pathPart },
+    });
+    parentId = created.id;
+  }
+
+  return parentId;
+}

--- a/src/service/apigateway/api/sim-rest-api-execute-api-arn.ts
+++ b/src/service/apigateway/api/sim-rest-api-execute-api-arn.ts
@@ -1,0 +1,68 @@
+import type { SimRestApiMatch } from "./match/sim-rest-api-match.js";
+import type { SimRestApi } from "./sim-rest-api.js";
+
+interface SimRestApiExecuteApiArnProperties {
+  readonly restApi: SimRestApi;
+  readonly stageName: string;
+  /** The method and path part, such as `GET/orders/{orderId}`. */
+  readonly methodAndPath: string;
+}
+
+/**
+ * The `execute-api` ARN of one request to a REST API.
+ *
+ * ```text
+ * arn:aws:execute-api:<region>:<account>:<apiId>/<stage>/<METHOD>/<path>
+ * ```
+ *
+ * This is the `SourceArn` an `AWS::Lambda::Permission` for a proxy integration
+ * is granted on, and it is the same shape an HTTP API uses. What differs is
+ * the last part. A REST API names the resource path template with its braces
+ * intact, which is the form CDK's `arnForExecuteApi` writes, while an HTTP API
+ * names a route key.
+ *
+ * The method segment carries the verb the client used rather than the `ANY` a
+ * resource may have declared. CDK wildcards that segment, and a concrete verb
+ * matches a wildcard where a literal `ANY` would not, so this is the reading
+ * that keeps a CDK-deployed API working.
+ */
+export class SimRestApiExecuteApiArn {
+  private readonly restApi: SimRestApi;
+  private readonly stageName: string;
+  private readonly methodAndPath: string;
+
+  constructor(properties: SimRestApiExecuteApiArnProperties) {
+    this.restApi = properties.restApi;
+    this.stageName = properties.stageName;
+    this.methodAndPath = properties.methodAndPath;
+  }
+
+  /**
+   * The ARN of the method a request matched.
+   */
+  static forMatch(
+    restApi: SimRestApi,
+    match: SimRestApiMatch,
+    requestMethod: string,
+  ): SimRestApiExecuteApiArn {
+    return new SimRestApiExecuteApiArn({
+      restApi,
+      stageName: match.stage.stageName,
+      // The resource path carries a leading separator and the ARN supplies its
+      // own, so a root-resource request reads `<apiId>/<stage>/GET/`.
+      methodAndPath: `${requestMethod}${match.resource.path}`,
+    });
+  }
+
+  /**
+   * The ARN as a permission or a policy names it.
+   */
+  toString(): string {
+    const { accountId, regionName } = this.restApi.accountRegionScope;
+
+    return (
+      `arn:aws:execute-api:${regionName}:${accountId}:` +
+      `${this.restApi.apiId}/${this.stageName}/${this.methodAndPath}`
+    );
+  }
+}

--- a/src/service/apigateway/api/sim-rest-api-lambda-proxy.factory.ts
+++ b/src/service/apigateway/api/sim-rest-api-lambda-proxy.factory.ts
@@ -1,0 +1,131 @@
+import { AsyncMappedFactory } from "@kensio/part-factory";
+
+import type { SimPayload1Event } from "../../../serve/payload-1/sim-payload-1-event.type.js";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import { DEFAULT_SIM_AWS_ACCOUNT_ID } from "../../aws/sim-aws-account.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import { declaredMethods } from "./sim-rest-api-declared-method.js";
+import {
+  simRestApiInvokePermission,
+  simRestApiProxyFunction,
+} from "./sim-rest-api-proxy-function.js";
+import type { SimRestApi } from "./sim-rest-api.js";
+
+/**
+ * What a test asks for when it wants a REST API that serves something.
+ */
+export interface SimRestApiLambdaProxyInput {
+  readonly apiName: string;
+  readonly functionName: string;
+  /**
+   * The Account the function belongs to, which need not be the API's: an
+   * integration URI is free to name another one.
+   */
+  readonly functionAccountId: string;
+  readonly roleArn: string;
+  /** The function code every method of the API hands its requests to. */
+  readonly handler: (event: SimPayload1Event) => unknown;
+  readonly disableExecuteApiEndpoint: boolean;
+  /**
+   * The resource paths the API declares, written as templates such as
+   * `/orders/{orderId}` or `/{proxy+}`. Each one gets the method below.
+   */
+  readonly resourcePaths: readonly string[];
+  /** The HTTP method declared on each of those resources. */
+  readonly httpMethod: string;
+  /** The stage the API is deployed to, which every request goes through. */
+  readonly stageName: string;
+  /** The variables that stage carries. */
+  readonly stageVariables: Readonly<Record<string, string>>;
+  /**
+   * Whether the function grants the API permission to invoke it, which it
+   * needs before any method serves anything.
+   *
+   * The grant is the one CDK writes: `apigateway.amazonaws.com` may
+   * `lambda:InvokeFunction` for any stage and method of this API. A test about
+   * the permission itself turns this off and grants what it means to test.
+   */
+  readonly invokePermission: boolean;
+}
+
+/**
+ * Creates a REST API that proxies every request to a simulated Lambda
+ * function, through the ordinary commands.
+ *
+ * A resource per path segment, a method, an integration, a deployment and a
+ * function stand between a test and a request it can serve, and a test about
+ * serving is about none of them. Tests about the commands themselves send them
+ * one at a time instead.
+ *
+ * ```typescript
+ * const restApi = await simRestApiLambdaProxyFactory.make(
+ *   { handler: () => ({ statusCode: 200, body: "hello" }) },
+ *   simAws,
+ * );
+ * const response = await new SimAwsHttp({ simAws }).fetch(
+ *   new SimAwsLocalUrl({ input: restApi.invokeUrl("prod") }).toString(),
+ * );
+ * ```
+ *
+ * The API is created in the default Account and Region of the simulated AWS it
+ * is given, and so is the function unless another Account is asked for.
+ */
+export const simRestApiLambdaProxyFactory = new AsyncMappedFactory<
+  SimRestApiLambdaProxyInput,
+  SimRestApi,
+  SimAws
+>(
+  () => ({
+    apiName: "orders",
+    functionName: "orders",
+    functionAccountId: DEFAULT_SIM_AWS_ACCOUNT_ID,
+    roleArn: "arn:aws:iam::111111111111:role/OrdersRole",
+    handler: (): unknown => ({ statusCode: 200, body: "hello" }),
+    disableExecuteApiEndpoint: false,
+    resourcePaths: ["/{proxy+}"],
+    httpMethod: "ANY",
+    stageName: "prod",
+    stageVariables: {},
+    invokePermission: true,
+  }),
+  async (input, simAws) => {
+    const functionArn = await simRestApiProxyFunction(simAws, input);
+    const apiGateway = simAws.apiGateway();
+    const created = await apiGateway.createRestApi({
+      input: {
+        name: input.apiName,
+        disableExecuteApiEndpoint: input.disableExecuteApiEndpoint,
+      },
+    });
+    const restApiId = created.id;
+
+    await declaredMethods(apiGateway, input.resourcePaths, {
+      restApiId,
+      rootResourceId: created.rootResourceId,
+      httpMethod: input.httpMethod,
+      functionArn,
+    });
+
+    if (input.invokePermission) {
+      await simRestApiInvokePermission(simAws, input, restApiId);
+    }
+
+    await apiGateway.createDeployment({
+      input: {
+        restApiId,
+        stageName: input.stageName,
+        variables: input.stageVariables,
+      },
+    });
+
+    // An id CreateRestApi allocated is an API the store holds, so this is only
+    // missing if something is wrong with the simulator itself.
+    const restApi = apiGateway.findRestApi(restApiId);
+    assertDefined(
+      restApi,
+      `Simulated API Gateway created the API ${restApiId} and then did not hold it`,
+    );
+
+    return restApi;
+  },
+);

--- a/src/service/apigateway/api/sim-rest-api-proxy-function.ts
+++ b/src/service/apigateway/api/sim-rest-api-proxy-function.ts
@@ -1,6 +1,6 @@
 import type { SimAws } from "../../aws/sim-aws.js";
 import { makeLambdaZipFileInput } from "../../lambda/function/code/lambda-zip-file-input.js";
-import { simApiGatewayServicePrincipal } from "../serve/sim-rest-api-integration-invocation.js";
+import { simApiGatewayServicePrincipal } from "../sim-api-gateway-service-principal.js";
 
 interface SimRestApiProxyFunctionInput {
   readonly functionAccountId: string;

--- a/src/service/apigateway/api/sim-rest-api-proxy-function.ts
+++ b/src/service/apigateway/api/sim-rest-api-proxy-function.ts
@@ -1,0 +1,61 @@
+import type { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../lambda/function/code/lambda-zip-file-input.js";
+import { simApiGatewayServicePrincipal } from "../serve/sim-rest-api-integration-invocation.js";
+
+interface SimRestApiProxyFunctionInput {
+  readonly functionAccountId: string;
+  readonly functionName: string;
+  readonly roleArn: string;
+  readonly handler: (event: never) => unknown;
+}
+
+/**
+ * Create the simulated Lambda function a test's REST API proxies to, and
+ * answer its ARN.
+ */
+export async function simRestApiProxyFunction(
+  simAws: SimAws,
+  input: SimRestApiProxyFunctionInput,
+): Promise<string> {
+  const { FunctionArn: functionArn } = await simAws
+    .account(input.functionAccountId)
+    .lambda()
+    .createFunction({
+      input: {
+        FunctionName: input.functionName,
+        Role: input.roleArn,
+        Code: { ZipFile: makeLambdaZipFileInput(input.handler) },
+      },
+    });
+
+  return functionArn;
+}
+
+/**
+ * Grant the API permission to invoke the function, the way CDK writes it.
+ *
+ * The ARN names the API's own Account and Region, which is where the request
+ * arrives, whatever Account the function belongs to. Every stage and method of
+ * the API is wildcarded, as a `LambdaRestApi` grant is.
+ */
+export async function simRestApiInvokePermission(
+  simAws: SimAws,
+  input: { readonly functionAccountId: string; readonly functionName: string },
+  restApiId: string,
+): Promise<void> {
+  const { accountId, regionName } =
+    simAws.accountRegionScope().accountRegionScope;
+
+  await simAws
+    .account(input.functionAccountId)
+    .lambda()
+    .addPermission({
+      input: {
+        FunctionName: input.functionName,
+        StatementId: "api-gateway-invoke",
+        Action: "lambda:InvokeFunction",
+        Principal: simApiGatewayServicePrincipal,
+        SourceArn: `arn:aws:execute-api:${regionName}:${accountId}:${restApiId}/*/*/*`,
+      },
+    });
+}

--- a/src/service/apigateway/api/sim-rest-api.ts
+++ b/src/service/apigateway/api/sim-rest-api.ts
@@ -4,6 +4,12 @@ import { SimRestApiResourceStore } from "./resource/sim-rest-api-resource-store.
 import type { SimRestApiResource } from "./resource/sim-rest-api-resource.js";
 import { SimApiGatewayNotFound } from "../error/sim-api-gateway.error.js";
 import { SimRestApiStageStore } from "./stage/sim-rest-api-stage-store.js";
+import {
+  type SimRestApiMatch,
+  SimRestApiMatcher,
+  type SimRestApiMiss,
+} from "./match/sim-rest-api-match.js";
+import type { SimRestApiRequest } from "./match/sim-rest-api-request.js";
 import { simRestApiHost } from "./sim-rest-api-host.js";
 import type { SimRestApiId } from "./sim-rest-api-id.js";
 import { simRestApiView, type SimRestApiView } from "./sim-rest-api-view.js";
@@ -43,6 +49,8 @@ export class SimRestApi {
   public readonly deployments = new SimRestApiDeploymentStore();
   public readonly stages = new SimRestApiStageStore();
 
+  private readonly matcher = new SimRestApiMatcher();
+
   constructor(properties: SimRestApiProperties) {
     this.apiId = properties.apiId;
     this.name = properties.name;
@@ -79,6 +87,13 @@ export class SimRestApi {
    */
   invokeUrl(stageName: string): string {
     return `https://${this.hostname}/${stageName}`;
+  }
+
+  /**
+   * Find what should handle one request to this API, or why nothing does.
+   */
+  match(request: SimRestApiRequest): SimRestApiMatch | SimRestApiMiss {
+    return this.matcher.match(this, request);
   }
 
   /**

--- a/src/service/apigateway/index.ts
+++ b/src/service/apigateway/index.ts
@@ -35,6 +35,25 @@ export {
 } from "./api/method/sim-rest-api-integration.js";
 export { SimRestApiLambdaUri } from "./api/method/sim-rest-api-lambda-uri.js";
 export {
+  isSimRestApiMatch,
+  type SimRestApiMatch,
+  SimRestApiMatcher,
+  type SimRestApiMiss,
+} from "./api/match/sim-rest-api-match.js";
+export { SimRestApiRequest } from "./api/match/sim-rest-api-request.js";
+export { SimRestApiExecuteApiArn } from "./api/sim-rest-api-execute-api-arn.js";
+export {
+  simRestApiLambdaProxyFactory,
+  type SimRestApiLambdaProxyInput,
+} from "./api/sim-rest-api-lambda-proxy.factory.js";
+export { SimApiGatewayServiceController } from "./serve/sim-api-gateway-controller.js";
+export { SimApiGatewayRouter } from "./serve/sim-api-gateway-router.js";
+export {
+  simApiGatewayServicePrincipal,
+  SimRestApiIntegrationInvocation,
+} from "./serve/sim-rest-api-integration-invocation.js";
+export type { SimRestApiFunctionTarget } from "./serve/sim-rest-api-function-target.js";
+export {
   makeSimRestApiDeploymentId,
   SimRestApiDeployment,
   type SimRestApiDeploymentId,

--- a/src/service/apigateway/index.ts
+++ b/src/service/apigateway/index.ts
@@ -48,10 +48,8 @@ export {
 } from "./api/sim-rest-api-lambda-proxy.factory.js";
 export { SimApiGatewayServiceController } from "./serve/sim-api-gateway-controller.js";
 export { SimApiGatewayRouter } from "./serve/sim-api-gateway-router.js";
-export {
-  simApiGatewayServicePrincipal,
-  SimRestApiIntegrationInvocation,
-} from "./serve/sim-rest-api-integration-invocation.js";
+export { SimRestApiIntegrationInvocation } from "./serve/sim-rest-api-integration-invocation.js";
+export { simApiGatewayServicePrincipal } from "./sim-api-gateway-service-principal.js";
 export type { SimRestApiFunctionTarget } from "./serve/sim-rest-api-function-target.js";
 export {
   makeSimRestApiDeploymentId,

--- a/src/service/apigateway/serve/sim-api-gateway-controller.ts
+++ b/src/service/apigateway/serve/sim-api-gateway-controller.ts
@@ -1,0 +1,102 @@
+import type {
+  SimAwsServiceController,
+  SimAwsServiceRequest,
+} from "../../../serve/controller/sim-service-controller.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import {
+  isSimRestApiMatch,
+  type SimRestApiMiss,
+} from "../api/match/sim-rest-api-match.js";
+import { SimRestApiRequest } from "../api/match/sim-rest-api-request.js";
+import type { SimRestApi } from "../api/sim-rest-api.js";
+import { SimApiGatewayErrorResponse } from "./sim-api-gateway-error-response.js";
+import { SimApiGatewayRouter } from "./sim-api-gateway-router.js";
+import { SimRestApiIntegrationInvocation } from "./sim-rest-api-integration-invocation.js";
+
+interface SimApiGatewayServiceControllerProperties {
+  readonly simAws?: SimAws;
+  readonly router?: SimApiGatewayRouter;
+}
+
+/**
+ * Localhost HTTP controller for simulated API Gateway REST APIs.
+ *
+ * A request reaching the generated endpoint is matched to a stage, then walked
+ * down the resource tree to a method, and that method's integration invokes a
+ * simulated Lambda function with a payload format 1.0 event. The function runs
+ * as its execution Role, as it does for any other invocation.
+ *
+ * Authorizing a method is a separate piece of work. Every method served here
+ * is open, and a method declaring an authorizer is refused when it is created
+ * rather than served without one.
+ */
+export class SimApiGatewayServiceController implements SimAwsServiceController {
+  private readonly router: SimApiGatewayRouter;
+  private readonly integration: SimRestApiIntegrationInvocation;
+  private readonly errorResponse = new SimApiGatewayErrorResponse();
+
+  constructor(properties: SimApiGatewayServiceControllerProperties = {}) {
+    const { simAws = new SimAws() } = properties;
+    this.router = properties.router ?? new SimApiGatewayRouter({ simAws });
+    // The clock is taken from the router rather than from properties, so a
+    // supplied router and the event timestamps belong to the same simulation.
+    this.integration = new SimRestApiIntegrationInvocation({
+      router: this.router,
+      clock: this.router.simAws,
+    });
+  }
+
+  /**
+   * Handle an HTTP request routed to a simulated REST API.
+   */
+  async handleRequest(serviceRequest: SimAwsServiceRequest): Promise<Response> {
+    const restApi = this.router.route(serviceRequest.target);
+
+    if (restApi === undefined) {
+      return this.errorResponse.forbidden();
+    }
+
+    if (restApi.disableExecuteApiEndpoint) {
+      // The API exists and has switched its generated endpoint off, which is
+      // how an API reachable only through a custom domain is configured.
+      return this.errorResponse.forbidden();
+    }
+
+    return await this.invoke(restApi, serviceRequest);
+  }
+
+  private async invoke(
+    restApi: SimRestApi,
+    serviceRequest: SimAwsServiceRequest,
+  ): Promise<Response> {
+    const { request } = serviceRequest;
+    // The whole request path, stage segment and all. The stage takes its own
+    // segment off, and the event reports the path as the client sent it.
+    const match = restApi.match(
+      new SimRestApiRequest({
+        method: request.method,
+        path: new URL(request.url).pathname,
+      }),
+    );
+
+    if (!isSimRestApiMatch(match)) {
+      return this.missResponse(match);
+    }
+
+    return await this.integration.invoke({ restApi, match, request });
+  }
+
+  /**
+   * What a request that reached nothing is answered with.
+   *
+   * Real API Gateway tells the two apart. A stage the API does not serve is a
+   * plain `Forbidden`, while a request that found the stage and matched no
+   * method gets `Missing Authentication Token`, whether or not it carried
+   * credentials.
+   */
+  private missResponse(miss: SimRestApiMiss): Response {
+    return miss === "stage"
+      ? this.errorResponse.forbidden()
+      : this.errorResponse.missingAuthenticationToken();
+  }
+}

--- a/src/service/apigateway/serve/sim-api-gateway-error-response.ts
+++ b/src/service/apigateway/serve/sim-api-gateway-error-response.ts
@@ -1,0 +1,43 @@
+/**
+ * The error responses a REST API endpoint returns itself, before or instead of
+ * an integration producing one.
+ *
+ * Real API Gateway answers these with a small JSON document whose field is
+ * `message`. The wording is what the endpoint was observed to answer, since
+ * AWS publishes neither the status nor the body for most of them.
+ */
+export class SimApiGatewayErrorResponse {
+  /**
+   * Nothing at this API serves the request.
+   *
+   * `Missing Authentication Token` is the message real API Gateway is well
+   * known for, and it answers a path that matched no method just as much as
+   * one that needed credentials. A client reading it here reads what it would
+   * read on AWS, misleading wording and all.
+   */
+  missingAuthenticationToken(): Response {
+    return this.jsonResponse(403, "Missing Authentication Token");
+  }
+
+  /**
+   * No such API, or a stage the API does not serve.
+   */
+  forbidden(): Response {
+    return this.jsonResponse(403, "Forbidden");
+  }
+
+  /**
+   * The integration could not be reached, or answered something that is not a
+   * response.
+   */
+  badGateway(): Response {
+    return this.jsonResponse(502, "Internal server error");
+  }
+
+  private jsonResponse(status: number, message: string): Response {
+    return Response.json(
+      { message },
+      { status, headers: { "content-type": "application/json" } },
+    );
+  }
+}

--- a/src/service/apigateway/serve/sim-api-gateway-router.ts
+++ b/src/service/apigateway/serve/sim-api-gateway-router.ts
@@ -1,0 +1,81 @@
+import type { SimAwsServiceTarget } from "../../../serve/controller/sim-service-controller.js";
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { AwsRegionName } from "../../aws/sim-aws-region.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimRestApiLambdaUri } from "../api/method/sim-rest-api-lambda-uri.js";
+import type { SimRestApi } from "../api/sim-rest-api.js";
+import type { SimRestApiRegistry } from "../registry/sim-rest-api-registry.js";
+import type { SimRestApiFunctionTarget } from "./sim-rest-api-function-target.js";
+
+interface SimApiGatewayRouterProperties {
+  readonly simAws?: SimAws;
+}
+
+/**
+ * Routes a served REST API request to the API behind it, and an integration to
+ * the function behind that.
+ *
+ * The request hostname gives the API id and the Region, and not the Account.
+ * The registry supplies that missing hop. The integrated function is a second
+ * hop again, because its ARN names its own Account and Region, which need not
+ * be the API's.
+ */
+export class SimApiGatewayRouter {
+  /**
+   * The simulation this router routes within.
+   *
+   * Exposed so collaborators needing the same simulation, such as the clock
+   * stamping invocation events, take it from here rather than being given a
+   * second SimAws that could be a different one.
+   */
+  public readonly simAws: SimAws;
+
+  private readonly registry: SimRestApiRegistry;
+
+  constructor(properties: SimApiGatewayRouterProperties = {}) {
+    this.simAws = properties.simAws ?? new SimAws();
+    this.registry = this.simAws.serviceFactory.registries.restApi;
+  }
+
+  /**
+   * Find the REST API a request target addresses.
+   */
+  route(target: SimAwsServiceTarget): SimRestApi | undefined {
+    const accountId = this.registry.accountIdForApi(target.resourceName);
+
+    if (accountId === undefined) {
+      return undefined;
+    }
+
+    return this.simAws
+      .accountRegionScope(accountId, target.regionName)
+      .apiGateway()
+      .findRestApi(target.resourceName);
+  }
+
+  /**
+   * Find the function a URI names, and the IAM deciding whether API Gateway
+   * may invoke it.
+   *
+   * The function is looked up in the Account and Region its own ARN names,
+   * rather than the API's, because an integration URI is free to name either.
+   *
+   * A version or alias qualifier on the URI is resolved here, once per
+   * request, so a method built on an alias runs whichever version the alias
+   * points at now. A qualifier naming neither answers with nothing, the way a
+   * function that was never created does.
+   */
+  functionFor(
+    lambdaUri: SimRestApiLambdaUri,
+  ): SimRestApiFunctionTarget | undefined {
+    const scope = this.simAws.accountRegionScope(
+      lambdaUri.accountId as SimAwsAccountId,
+      lambdaUri.regionName as AwsRegionName,
+    );
+    const target = scope
+      .lambda()
+      .getSimFunctionTarget(lambdaUri.functionName, lambdaUri.qualifier);
+
+    return target === undefined ? undefined : { ...target, iam: scope.iam() };
+  }
+}

--- a/src/service/apigateway/serve/sim-rest-api-endpoint.ts
+++ b/src/service/apigateway/serve/sim-rest-api-endpoint.ts
@@ -1,0 +1,27 @@
+import type { SimPayload1Endpoint } from "../../../serve/payload-1/sim-payload-1-endpoint.js";
+import type { SimRestApiMatch } from "../api/match/sim-rest-api-match.js";
+import type { SimRestApi } from "../api/sim-rest-api.js";
+
+/**
+ * Describe a matched request as the endpoint identity the event builder reads.
+ *
+ * The resource fields name the tree node the path matched rather than the path
+ * the client asked for, which is what lets a handler behind a `{proxy+}` tell
+ * which template caught its request.
+ */
+export function simRestApiEndpoint(
+  restApi: SimRestApi,
+  match: SimRestApiMatch,
+): SimPayload1Endpoint {
+  return {
+    apiId: restApi.apiId,
+    accountId: restApi.accountRegionScope.accountId,
+    domainName: restApi.hostname,
+    stage: match.stage.stageName,
+    resourceId: match.resource.resourceId,
+    resourcePath: match.resource.path,
+    httpMethod: match.method.httpMethod,
+    pathParameters: match.pathParameters,
+    stageVariables: match.stage.variables,
+  };
+}

--- a/src/service/apigateway/serve/sim-rest-api-function-target.ts
+++ b/src/service/apigateway/serve/sim-rest-api-function-target.ts
@@ -1,0 +1,17 @@
+import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimLambdaFunctionTarget } from "../../lambda/function/version/sim-lambda-function-target.js";
+
+/**
+ * A function a REST API invokes, and what decides whether it may.
+ *
+ * What the API invokes is what any service delivering to a function ARN
+ * invokes, so the resource named and the version that runs come from Lambda's
+ * own target. All this adds is the IAM the decision is made in.
+ */
+export interface SimRestApiFunctionTarget extends SimLambdaFunctionTarget {
+  /**
+   * IAM of the Account that owns the function, which is what the API's invoke
+   * permission is evaluated against. It need not be the API's Account.
+   */
+  readonly iam: SimIamInterServiceAuthZ;
+}

--- a/src/service/apigateway/serve/sim-rest-api-integration-invocation.ts
+++ b/src/service/apigateway/serve/sim-rest-api-integration-invocation.ts
@@ -5,15 +5,11 @@ import { SimLambdaServiceInvokeAuthorizer } from "../../lambda/command/authorize
 import type { SimRestApiMatch } from "../api/match/sim-rest-api-match.js";
 import { SimRestApiExecuteApiArn } from "../api/sim-rest-api-execute-api-arn.js";
 import type { SimRestApi } from "../api/sim-rest-api.js";
+import { simApiGatewayServicePrincipal } from "../sim-api-gateway-service-principal.js";
 import { SimApiGatewayErrorResponse } from "./sim-api-gateway-error-response.js";
 import type { SimApiGatewayRouter } from "./sim-api-gateway-router.js";
 import { simRestApiEndpoint } from "./sim-rest-api-endpoint.js";
 import type { SimRestApiFunctionTarget } from "./sim-rest-api-function-target.js";
-
-/**
- * The service principal API Gateway invokes a Lambda function as.
- */
-export const simApiGatewayServicePrincipal = "apigateway.amazonaws.com";
 
 interface SimRestApiIntegrationInvocationProperties {
   readonly router: SimApiGatewayRouter;

--- a/src/service/apigateway/serve/sim-rest-api-integration-invocation.ts
+++ b/src/service/apigateway/serve/sim-rest-api-integration-invocation.ts
@@ -1,0 +1,124 @@
+import { SimPayload1EventBuilder } from "../../../serve/payload-1/sim-payload-1-event-builder.js";
+import { SimPayload1ResponseBuilder } from "../../../serve/payload-1/sim-payload-1-response-builder.js";
+import type { SimClock } from "../../../util/clock/sim-clock.js";
+import { SimLambdaServiceInvokeAuthorizer } from "../../lambda/command/authorize/sim-lambda-service-invoke-authorizer.js";
+import type { SimRestApiMatch } from "../api/match/sim-rest-api-match.js";
+import { SimRestApiExecuteApiArn } from "../api/sim-rest-api-execute-api-arn.js";
+import type { SimRestApi } from "../api/sim-rest-api.js";
+import { SimApiGatewayErrorResponse } from "./sim-api-gateway-error-response.js";
+import type { SimApiGatewayRouter } from "./sim-api-gateway-router.js";
+import { simRestApiEndpoint } from "./sim-rest-api-endpoint.js";
+import type { SimRestApiFunctionTarget } from "./sim-rest-api-function-target.js";
+
+/**
+ * The service principal API Gateway invokes a Lambda function as.
+ */
+export const simApiGatewayServicePrincipal = "apigateway.amazonaws.com";
+
+interface SimRestApiIntegrationInvocationProperties {
+  readonly router: SimApiGatewayRouter;
+  /** Clock the invocation event is stamped with. */
+  readonly clock: SimClock;
+}
+
+interface SimRestApiIntegrationInvocationInput {
+  readonly restApi: SimRestApi;
+  readonly match: SimRestApiMatch;
+  readonly request: Request;
+}
+
+/**
+ * Invokes the Lambda function behind the matched method's integration, and
+ * turns what it returns into the HTTP response.
+ *
+ * A method with no integration, one naming a function that is not there, one
+ * the API may not invoke, and one whose handler threw are all the same 502 on
+ * real API Gateway, with `Internal server error` in the body and the reason
+ * only in the API's own logs.
+ */
+export class SimRestApiIntegrationInvocation {
+  private readonly router: SimApiGatewayRouter;
+  private readonly eventBuilder: SimPayload1EventBuilder;
+  private readonly responseBuilder = new SimPayload1ResponseBuilder();
+  private readonly errorResponse = new SimApiGatewayErrorResponse();
+
+  constructor(properties: SimRestApiIntegrationInvocationProperties) {
+    this.router = properties.router;
+    this.eventBuilder = new SimPayload1EventBuilder({
+      clock: properties.clock,
+    });
+  }
+
+  /**
+   * Invoke the integration behind one matched request.
+   */
+  async invoke(input: SimRestApiIntegrationInvocationInput): Promise<Response> {
+    const target = this.integrationTarget(input);
+
+    if (target === undefined) {
+      return this.errorResponse.badGateway();
+    }
+
+    try {
+      const event = await this.eventBuilder.build(
+        input.request,
+        simRestApiEndpoint(input.restApi, input.match),
+      );
+      const result = await target.simFunction.invoke(event);
+
+      return this.responseBuilder.isStructuredResult(result)
+        ? this.responseBuilder.build(result)
+        : this.errorResponse.badGateway();
+    } catch {
+      // Real API Gateway reports an unhandled integration error as a 502, with
+      // the error itself only visible in the function's logs. Reading the
+      // request body can fail the same way, so building the event is inside
+      // this too.
+      return this.errorResponse.badGateway();
+    }
+  }
+
+  /**
+   * The function this request's method invokes, where there is one the API is
+   * allowed to invoke.
+   */
+  private integrationTarget(
+    input: SimRestApiIntegrationInvocationInput,
+  ): SimRestApiFunctionTarget | undefined {
+    const { integration } = input.match.method;
+
+    if (integration === undefined) {
+      return undefined;
+    }
+
+    const target = this.router.functionFor(integration.lambdaUri);
+
+    return target === undefined || this.mayNotInvoke(input, target)
+      ? undefined
+      : target;
+  }
+
+  /**
+   * Whether the API lacks permission to invoke the integrated function.
+   *
+   * The method the request matched is supplied as the source ARN, so a
+   * permission granted for one method does not open another.
+   */
+  private mayNotInvoke(
+    input: SimRestApiIntegrationInvocationInput,
+    target: SimRestApiFunctionTarget,
+  ): boolean {
+    const { restApi, match, request } = input;
+
+    return new SimLambdaServiceInvokeAuthorizer({ iam: target.iam }).authorize({
+      resource: target.resource,
+      servicePrincipal: simApiGatewayServicePrincipal,
+      sourceArn: SimRestApiExecuteApiArn.forMatch(
+        restApi,
+        match,
+        request.method,
+      ).toString(),
+      sourceAccount: restApi.accountRegionScope.accountId,
+    }).isDenied;
+  }
+}

--- a/src/service/apigateway/serve/sim-rest-api-serve-edges.iso.test.ts
+++ b/src/service/apigateway/serve/sim-rest-api-serve-edges.iso.test.ts
@@ -1,0 +1,236 @@
+import { PutMethodCommand } from "@aws-sdk/client-api-gateway";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import { SimPayload1EventBuilder } from "../../../serve/payload-1/sim-payload-1-event-builder.js";
+import { SimPayload1ResponseBuilder } from "../../../serve/payload-1/sim-payload-1-response-builder.js";
+import type { SimPayload1Event } from "../../../serve/payload-1/sim-payload-1-event.type.js";
+import { SimAwsServiceRequest } from "../../../serve/controller/sim-service-controller.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simRestApiLambdaProxyFactory } from "../api/sim-rest-api-lambda-proxy.factory.js";
+import type { SimRestApi } from "../api/sim-rest-api.js";
+import { SimApiGatewayServiceController } from "./sim-api-gateway-controller.js";
+import { SimApiGatewayRouter } from "./sim-api-gateway-router.js";
+
+function localUrl(restApi: SimRestApi, path = "", stage = "prod"): string {
+  return new SimAwsLocalUrl({
+    input: `${restApi.invokeUrl(stage)}${path}`,
+  }).toString();
+}
+
+describe("The edges of serving a sim REST API", () => {
+  it("serves the handler the factory defaults to", async () => {
+    // Given an API asked for with nothing specified
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make({}, simAws);
+
+    // When it is requested
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/orders"),
+    );
+
+    // Then the default handler answers
+    assertIdentical(response.status, 200);
+    assertIdentical(await response.text(), "hello");
+  });
+
+  it("matches the stage root with no path after it", async () => {
+    // Given a method on the API's root resource
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      { resourcePaths: ["/"] },
+      simAws,
+    );
+
+    // When the stage is requested with nothing after it
+    const response = await new SimAwsHttp({ simAws }).fetch(localUrl(restApi));
+
+    // Then the root resource answers
+    assertIdentical(response.status, 200);
+  });
+
+  it("answers a request naming no stage at all with Forbidden", async () => {
+    // Given a deployed API
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make({}, simAws);
+
+    // When the bare hostname is requested, which names no stage
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      new SimAwsLocalUrl({ input: `https://${restApi.hostname}/` }).toString(),
+    );
+
+    // Then there is no stage to serve it, so it is refused
+    assertIdentical(response.status, 403);
+    expect(await response.json()).toStrictEqual({ message: "Forbidden" });
+  });
+
+  it("leaves a path segment it cannot decode as it was sent", async () => {
+    // Given a parameterised resource
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      {
+        resourcePaths: ["/orders/{orderId}"],
+        handler: (event) => ({
+          statusCode: 200,
+          body: String(event.pathParameters?.["orderId"]),
+        }),
+      },
+      simAws,
+    );
+
+    // When the segment carries a percent sign that decodes to nothing
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/orders/%ZZ"),
+    );
+
+    // Then it reaches the handler as it was sent, rather than failing the
+    // request
+    assertIdentical(await response.text(), "%ZZ");
+  });
+
+  it("answers 502 for a method with no integration behind it", async () => {
+    // Given a method declared with nothing behind it
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      { resourcePaths: ["/orders"], httpMethod: "GET" },
+      simAws,
+    );
+    await simAws.apiGateway().putMethod(
+      new PutMethodCommand({
+        restApiId: restApi.apiId,
+        resourceId: restApi.resources.findByPath("/orders")?.resourceId,
+        httpMethod: "POST",
+        authorizationType: "NONE",
+      }),
+    );
+
+    // When that method is requested
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/orders"),
+      { method: "POST" },
+    );
+
+    // Then it is the same 502 an unreachable integration gets, which is what
+    // real API Gateway answers for a method it cannot integrate
+    assertIdentical(response.status, 502);
+  });
+
+  it("routes to nothing for an API id it never allocated", () => {
+    // Given a router over a simulation with no REST APIs
+    const router = new SimApiGatewayRouter({ simAws: new SimAws() });
+
+    // When an id nothing allocated is routed
+    const found = router.route({
+      service: "executeApi",
+      resourceName: "nosuchapi1",
+    });
+
+    // Then nothing answers for it
+    assertUndefined(found);
+  });
+
+  it("answers Forbidden for an API the router cannot reach", async () => {
+    // Given the controller over a simulation with no REST APIs, which is what
+    // a caller constructing it directly gets
+    const controller = new SimApiGatewayServiceController({
+      simAws: new SimAws(),
+    });
+
+    // When a request naming an API is handled
+    const response = await controller.handleRequest(
+      new SimAwsServiceRequest({
+        target: { service: "executeApi", resourceName: "nosuchapi1" },
+        request: new Request(
+          "https://nosuchapi1.execute-api.us-east-1.amazonaws.com/prod",
+        ),
+      }),
+    );
+
+    // Then there is nothing to serve it
+    assertIdentical(response.status, 403);
+  });
+
+  it("builds a router over its own simulation where none is supplied", () => {
+    // Given a router asked for with nothing
+    const router = new SimApiGatewayRouter();
+
+    // Then it has a simulation of its own to route within
+    assertNonNullable(router.simAws);
+  });
+
+  it("answers 502 where the integration names a function that is not there", async () => {
+    // Given an API whose integration points at a function nothing created
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make({}, simAws);
+    await simAws.lambda().deleteFunction({ input: { FunctionName: "orders" } });
+
+    // When the API is requested
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/orders"),
+    );
+
+    // Then API Gateway discovers it only when it tries to invoke, as it does
+    // on AWS
+    assertIdentical(response.status, 502);
+  });
+
+  it("stamps the event from the real clock where no clock is supplied", async () => {
+    // Given an event builder with no clock of its own
+    const builder = new SimPayload1EventBuilder();
+
+    // When an event is built
+    const event: SimPayload1Event = await builder.build(
+      new Request(
+        "https://abc1234567.execute-api.us-east-1.amazonaws.com/prod/orders",
+      ),
+      {
+        apiId: "abc1234567",
+        accountId: "111111111111",
+        domainName: "abc1234567.execute-api.us-east-1.amazonaws.com",
+        stage: "prod",
+        resourceId: "res1234",
+        resourcePath: "/orders",
+        httpMethod: "GET",
+      },
+    );
+
+    // Then it carries a time, taken from the host clock
+    assertNonNullable(event.requestContext.requestTime);
+    expect(event.requestContext.requestTimeEpoch).toBeGreaterThan(0);
+  });
+
+  it("sends an empty handler body as no body at all", () => {
+    // Given a handler answering 204 with nothing
+    const builder = new SimPayload1ResponseBuilder();
+
+    // When the response is built
+    const response = builder.build({ statusCode: 204 });
+
+    // Then the status stays valid, which it would not with an empty body
+    assertIdentical(response.status, 204);
+    assertIdentical(response.body, null);
+  });
+
+  it("decodes a base64 handler body", async () => {
+    // Given a handler answering with base64 content
+    const builder = new SimPayload1ResponseBuilder();
+
+    // When the response is built
+    const response = builder.build({
+      statusCode: 200,
+      body: "AQID",
+      isBase64Encoded: true,
+    });
+
+    // Then the client gets the bytes back
+    expect(new Uint8Array(await response.arrayBuffer())).toStrictEqual(
+      new Uint8Array([1, 2, 3]),
+    );
+  });
+});

--- a/src/service/apigateway/serve/sim-rest-api-serve-errors.iso.test.ts
+++ b/src/service/apigateway/serve/sim-rest-api-serve-errors.iso.test.ts
@@ -1,0 +1,211 @@
+import {
+  CreateApiCommand,
+  CreateStageCommand,
+} from "@aws-sdk/client-apigatewayv2";
+import { assertIdentical } from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simRestApiLambdaProxyFactory } from "../api/sim-rest-api-lambda-proxy.factory.js";
+import type { SimRestApi } from "../api/sim-rest-api.js";
+
+function localUrl(restApi: SimRestApi, path = "", stage = "prod"): string {
+  return new SimAwsLocalUrl({
+    input: `${restApi.invokeUrl(stage)}${path}`,
+  }).toString();
+}
+
+describe("What a sim REST API answers when nothing serves the request", () => {
+  it("answers a stage it does not serve with Forbidden", async () => {
+    // Given an API deployed to prod
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make({}, simAws);
+
+    // When another stage is requested
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/orders", "dev"),
+    );
+
+    // Then it is a plain Forbidden, which is what real API Gateway answers for
+    // a stage that is not there
+    assertIdentical(response.status, 403);
+    expect(await response.json()).toStrictEqual({ message: "Forbidden" });
+  });
+
+  it("answers a path it has no method for with Missing Authentication Token", async () => {
+    // Given an API declaring one path
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      { resourcePaths: ["/orders"] },
+      simAws,
+    );
+
+    // When another path is requested
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/invoices"),
+    );
+
+    // Then it is the message real API Gateway is well known for, misleading
+    // wording and all
+    assertIdentical(response.status, 403);
+    expect(await response.json()).toStrictEqual({
+      message: "Missing Authentication Token",
+    });
+  });
+
+  it("answers a method the resource does not declare the same way", async () => {
+    // Given a resource declaring only GET
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      { resourcePaths: ["/orders"], httpMethod: "GET" },
+      simAws,
+    );
+
+    // When it is posted to
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/orders"),
+      { method: "POST" },
+    );
+
+    // Then nothing matched, so the same answer comes back
+    assertIdentical(response.status, 403);
+    expect(await response.json()).toStrictEqual({
+      message: "Missing Authentication Token",
+    });
+  });
+
+  it("answers an API with its generated endpoint switched off with Forbidden", async () => {
+    // Given an API reachable only through a custom domain
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      { disableExecuteApiEndpoint: true },
+      simAws,
+    );
+
+    // When the generated endpoint is requested
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/orders"),
+    );
+
+    // Then it is refused
+    assertIdentical(response.status, 403);
+  });
+
+  it("answers 502 where the API may not invoke the function", async () => {
+    // Given an integration the function granted nothing
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      { invokePermission: false },
+      simAws,
+    );
+
+    // When the API is requested
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/orders"),
+    );
+
+    // Then it is the 502 real API Gateway answers, with the reason left in its
+    // own logs
+    assertIdentical(response.status, 502);
+    expect(await response.json()).toStrictEqual({
+      message: "Internal server error",
+    });
+  });
+
+  it("answers 502 where the handler returns no status code", async () => {
+    // Given a handler returning a plain object
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      { handler: () => ({ body: "hi" }) },
+      simAws,
+    );
+
+    // When the API is requested
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/orders"),
+    );
+
+    // Then it is a 502, because a REST API proxy integration takes one shape
+    // only. Payload format 2.0 is the lenient one, and a handler relying on
+    // that behaves differently here for the same reason it does on AWS
+    assertIdentical(response.status, 502);
+  });
+
+  it("answers 502 where the handler throws", async () => {
+    // Given a handler that fails
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      {
+        handler: () => {
+          throw new Error("no items");
+        },
+      },
+      simAws,
+    );
+
+    // When the API is requested
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/orders"),
+    );
+
+    // Then the error stays in the function's logs and the client gets a 502
+    assertIdentical(response.status, 502);
+  });
+
+  it("answers an API id nothing allocated with the HTTP API's own answer", async () => {
+    // Given a simulation with no APIs at all
+    const simAws = new SimAws();
+
+    // When an invented endpoint is requested
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      new SimAwsLocalUrl({
+        input: "https://nosuchapi1.execute-api.us-east-1.amazonaws.com/prod",
+      }).toString(),
+    );
+
+    // Then the HTTP API controller answers, since neither service allocated
+    // the id and that is what the endpoint answered before REST APIs existed
+    assertIdentical(response.status, 404);
+  });
+
+  it("keeps a REST API and an HTTP API apart on one simulation", async () => {
+    // Given both kinds of API in one simulated AWS
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      { handler: () => ({ statusCode: 200, body: "rest" }) },
+      simAws,
+    );
+    const { ApiId: httpApiId } = await simAws
+      .apiGatewayV2()
+      .createApi(
+        new CreateApiCommand({ Name: "orders", ProtocolType: "HTTP" }),
+      );
+    await simAws.apiGatewayV2().createStage(
+      new CreateStageCommand({
+        ApiId: httpApiId,
+        StageName: "$default",
+        AutoDeploy: true,
+      }),
+    );
+
+    // When each endpoint is requested
+    const restResponse = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/orders"),
+    );
+    const httpResponse = await new SimAwsHttp({ simAws }).fetch(
+      new SimAwsLocalUrl({
+        input: `https://${httpApiId}.execute-api.us-east-1.amazonaws.com/orders`,
+      }).toString(),
+    );
+
+    // Then each reaches its own service, though both endpoints share the
+    // execute-api hostname shape
+    assertIdentical(restResponse.status, 200);
+    assertIdentical(await restResponse.text(), "rest");
+    // The HTTP API has no route for the path, which is its own 404 rather than
+    // anything the REST API would have said
+    assertIdentical(httpResponse.status, 404);
+  });
+});

--- a/src/service/apigateway/serve/sim-rest-api-serve.iso.test.ts
+++ b/src/service/apigateway/serve/sim-rest-api-serve.iso.test.ts
@@ -1,0 +1,219 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import type { SimPayload1Event } from "../../../serve/payload-1/sim-payload-1-event.type.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simRestApiLambdaProxyFactory } from "../api/sim-rest-api-lambda-proxy.factory.js";
+import type { SimRestApi } from "../api/sim-rest-api.js";
+
+function localUrl(restApi: SimRestApi, path = "", stage = "prod"): string {
+  return new SimAwsLocalUrl({
+    input: `${restApi.invokeUrl(stage)}${path}`,
+  }).toString();
+}
+
+/**
+ * A handler echoing the event back, for tests about what the event carries.
+ */
+const echoHandler = (event: SimPayload1Event): unknown => ({
+  statusCode: 200,
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify(event),
+});
+
+describe("Serving a request through a sim REST API", () => {
+  it("routes a request to the integrated function", async () => {
+    // Given an API proxying every request to a simulated Lambda function
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      {
+        handler: (event) => ({
+          statusCode: 200,
+          headers: { "content-type": "text/plain" },
+          body: `orders limit ${event.queryStringParameters?.["limit"] ?? "none"}`,
+        }),
+      },
+      simAws,
+    );
+
+    // When the generated endpoint is requested under its stage
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/orders?limit=10"),
+    );
+
+    // Then the function's response is what the client gets back
+    assertIdentical(response.status, 200);
+    assertIdentical(response.headers.get("content-type"), "text/plain");
+    assertIdentical(await response.text(), "orders limit 10");
+  });
+
+  it("sends the payload format 1.0 event a REST API sends", async () => {
+    // Given an API with a parameterised resource
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      { handler: echoHandler, resourcePaths: ["/orders/{orderId}"] },
+      simAws,
+    );
+
+    // When one order is requested
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/orders/6?fields=id&fields=total"),
+    );
+    const event = (await response.json()) as SimPayload1Event;
+
+    // Then the event names the resource template, the path as sent and the
+    // stage, and carries both forms of the query string
+    assertIdentical(event.resource, "/orders/{orderId}");
+    assertIdentical(event.path, "/prod/orders/6");
+    assertIdentical(event.httpMethod, "GET");
+    expect(event.pathParameters).toStrictEqual({ orderId: "6" });
+    expect(event.queryStringParameters).toStrictEqual({ fields: "total" });
+    expect(event.multiValueQueryStringParameters).toStrictEqual({
+      fields: ["id", "total"],
+    });
+    assertIdentical(event.requestContext.stage, "prod");
+    assertIdentical(event.requestContext.resourcePath, "/orders/{orderId}");
+    assertIdentical(event.requestContext.apiId, restApi.apiId);
+    assertIdentical(event.body, null);
+    expect(event.multiValueHeaders?.["host"]).toStrictEqual([restApi.hostname]);
+  });
+
+  it("sends null for the maps a request left empty", async () => {
+    // Given an API with a resource taking no parameters
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      { handler: echoHandler, resourcePaths: ["/orders"] },
+      simAws,
+    );
+
+    // When it is requested with no query string
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/orders"),
+    );
+    const event = (await response.json()) as SimPayload1Event;
+
+    // Then the empty maps are null rather than absent, which is what payload
+    // format 1.0 sends and what a handler checking for null relies on
+    assertIdentical(event.queryStringParameters, null);
+    assertIdentical(event.multiValueQueryStringParameters, null);
+    assertIdentical(event.pathParameters, null);
+    assertIdentical(event.stageVariables, null);
+  });
+
+  it("carries the stage variables the stage was deployed with", async () => {
+    // Given a stage with variables
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      { handler: echoHandler, stageVariables: { catalogue: "v2" } },
+      simAws,
+    );
+
+    // When the API is requested
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/orders"),
+    );
+    const event = (await response.json()) as SimPayload1Event;
+
+    // Then the handler reads them
+    expect(event.stageVariables).toStrictEqual({ catalogue: "v2" });
+  });
+
+  it("posts a request body to the function", async () => {
+    // Given an API proxying to a handler that reads the body
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      {
+        handler: (event) => ({
+          statusCode: 201,
+          body: `created ${String(event.body)} base64 ${String(event.isBase64Encoded)}`,
+        }),
+      },
+      simAws,
+    );
+
+    // When a JSON body is posted
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/orders"),
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: '{"total":10}',
+      },
+    );
+
+    // Then the handler read it as text, since JSON is a text content type
+    assertIdentical(response.status, 201);
+    assertIdentical(await response.text(), 'created {"total":10} base64 false');
+  });
+
+  it("base64 encodes a body that is not text", async () => {
+    // Given an API proxying to a handler reporting what it was sent
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      {
+        handler: (event) => ({
+          statusCode: 200,
+          body: `${String(event.body)}/${String(event.isBase64Encoded)}`,
+        }),
+      },
+      simAws,
+    );
+
+    // When binary content is posted
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/orders"),
+      {
+        method: "POST",
+        headers: { "content-type": "application/octet-stream" },
+        body: new Uint8Array([1, 2, 3]),
+      },
+    );
+
+    // Then the handler is told it was base64 encoded, as AWS tells it
+    assertIdentical(await response.text(), "AQID/true");
+  });
+
+  it("sends repeated response headers from multiValueHeaders", async () => {
+    // Given a handler setting two cookies
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      {
+        handler: () => ({
+          statusCode: 200,
+          multiValueHeaders: { "set-cookie": ["a=1", "b=2"] },
+          body: "ok",
+        }),
+      },
+      simAws,
+    );
+
+    // When the API is requested
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/orders"),
+    );
+
+    // Then both survive, which is what multiValueHeaders is for
+    expect(response.headers.getSetCookie()).toStrictEqual(["a=1", "b=2"]);
+  });
+
+  it("gives a greedy resource the rest of the path", async () => {
+    // Given a catch-all API
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      { handler: echoHandler },
+      simAws,
+    );
+
+    // When a deep path is requested
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/orders/6/items"),
+    );
+    const event = (await response.json()) as SimPayload1Event;
+
+    // Then the handler is told which template caught it, and what it caught
+    assertIdentical(event.resource, "/{proxy+}");
+    expect(event.pathParameters).toStrictEqual({ proxy: "orders/6/items" });
+  });
+});

--- a/src/service/apigateway/serve/sim-rest-api-serve.loc.test.ts
+++ b/src/service/apigateway/serve/sim-rest-api-serve.loc.test.ts
@@ -1,0 +1,47 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { serveSimAws } from "../../../serve/index.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simRestApiLambdaProxyFactory } from "../api/sim-rest-api-lambda-proxy.factory.js";
+
+/**
+ * Slower local integration test. Serves the simulation over real localhost
+ * HTTP and drives it with the platform fetch, rather than in process.
+ */
+describe("Serving a sim REST API on localhost", () => {
+  it("proxies a real localhost request to the integrated function", async () => {
+    // Given a REST API proxying every request to a simulated Lambda function
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      {
+        resourcePaths: ["/orders/{orderId}"],
+        handler: (event) => ({
+          statusCode: 200,
+          headers: { "content-type": "text/plain" },
+          body: `order ${event.pathParameters?.["orderId"] ?? "none"} limit ${
+            event.queryStringParameters?.["limit"] ?? "none"
+          }`,
+        }),
+      },
+      simAws,
+    );
+
+    // And the simulation served on localhost
+    const srv = await serveSimAws({ simAws });
+
+    try {
+      // When the stage's invoke URL is fetched over real localhost HTTP
+      const response = await fetch(
+        srv.localUrl(`${restApi.invokeUrl("prod")}/orders/6?limit=10`),
+      );
+
+      // Then the function handled the real HTTP request
+      assertIdentical(response.status, 200);
+      assertIdentical(response.headers.get("content-type"), "text/plain");
+      assertIdentical(await response.text(), "order 6 limit 10");
+    } finally {
+      await srv.close();
+    }
+  });
+});

--- a/src/service/apigateway/sim-api-gateway-service-principal.ts
+++ b/src/service/apigateway/sim-api-gateway-service-principal.ts
@@ -1,0 +1,9 @@
+/**
+ * The service principal API Gateway invokes a Lambda function as.
+ *
+ * An `AWS::Lambda::Permission` for a proxy integration grants this principal,
+ * so it lives at the service root rather than inside the serving layer that
+ * evaluates the grant. That keeps the API model, which writes the permission
+ * in test setup, from reaching into the layer that reads it.
+ */
+export const simApiGatewayServicePrincipal = "apigateway.amazonaws.com";

--- a/src/service/apigatewayv2/serve/sim-api-gateway-v2-router.ts
+++ b/src/service/apigatewayv2/serve/sim-api-gateway-v2-router.ts
@@ -36,7 +36,7 @@ export class SimApiGatewayV2Router {
 
   constructor(properties: SimApiGatewayV2RouterProperties = {}) {
     this.simAws = properties.simAws ?? new SimAws();
-    this.registry = this.simAws.serviceFactory.httpApiRegistry;
+    this.registry = this.simAws.serviceFactory.registries.httpApi;
   }
 
   /**

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -7,7 +7,6 @@ import type { SimAws } from "../sim-aws.js";
 import type { SimAcm } from "../../acm/sim-acm.js";
 import type { SimApiGateway } from "../../apigateway/index.js";
 import type { SimApiGatewayV2 } from "../../apigatewayv2/index.js";
-import type { SimHttpApiRegistry } from "../../apigatewayv2/registry/sim-http-api-registry.js";
 import type { SimCloudFormation } from "../../cloudformation/index.js";
 import type { SimCognitoIdentityProvider } from "../../cognito/index.js";
 import { SimCloudFrontRegistry } from "../../cloudfront/registry/sim-cloud-front-registry.js";
@@ -21,7 +20,6 @@ import type { SimRoute53 } from "../../route53/index.js";
 import type { SimS3 } from "../../s3/sim-s3.js";
 import type { SimScheduler } from "../../scheduler/index.js";
 import type { SimElbV2 } from "../../elbv2/index.js";
-import type { SimElbV2Registry } from "../../elbv2/registry/sim-elbv2-registry.js";
 import type { SimIam } from "../../iam/index.js";
 import { SimIamRegistry } from "../../iam/registry/sim-iam-registry.js";
 import type { SimKms } from "../../kms/index.js";
@@ -101,8 +99,14 @@ export class SimAwsServiceFactory {
 
   /**
    * The registries this simulation's scoped services share between them.
+   *
+   * A serving layer reaching a resource by a name that carries no scope starts
+   * here: an API id in an `execute-api` hostname, a load balancer's DNS name,
+   * the registry host of an image URI. Each of them resolves to the Account
+   * and Region scope holding the resource.
+   * @internal
    */
-  private readonly registries = new SimAwsScopedServiceRegistries();
+  public readonly registries = new SimAwsScopedServiceRegistries();
 
   private readonly accountServices: SimAwsAccountServiceCache;
   private readonly accountRegionServices: SimAwsAccountRegionServiceBuilder;
@@ -138,30 +142,6 @@ export class SimAwsServiceFactory {
     this.selfContainedServices = new SimAwsSelfContainedServiceBuilder({
       accountServices: this.accountServices,
     });
-  }
-
-  /**
-   * Shared simulated API Gateway HTTP API registry.
-   *
-   * This maps API ids to the Accounts that own them, so the localhost serving
-   * layer routes a request to the right Account/Region scope from the request
-   * host name alone.
-   * @internal
-   */
-  get httpApiRegistry(): SimHttpApiRegistry {
-    return this.registries.httpApi;
-  }
-
-  /**
-   * Shared simulated ELBv2 registry.
-   *
-   * This maps load balancer DNS names to the Accounts that own them, so a
-   * request reaching a load balancer is routed to the right Account/Region
-   * scope from the host name alone.
-   * @internal
-   */
-  get elbV2Registry(): SimElbV2Registry {
-    return this.registries.elbV2;
   }
 
   /** Create simulated ACM for an Account Region scope. */

--- a/src/service/elbv2/serve/sim-elbv2-router.ts
+++ b/src/service/elbv2/serve/sim-elbv2-router.ts
@@ -63,7 +63,7 @@ export class SimElbV2Router {
 
   constructor(properties: SimElbV2RouterProperties) {
     this.simAws = properties.simAws;
-    this.registry = this.simAws.serviceFactory.elbV2Registry;
+    this.registry = this.simAws.serviceFactory.registries.elbV2;
   }
 
   /**

--- a/src/service/route53/resolve/sim-r53-regional-service-target.ts
+++ b/src/service/route53/resolve/sim-r53-regional-service-target.ts
@@ -105,7 +105,7 @@ export class SimRoute53RegionalServiceTargets {
     }
 
     if (service === executeApiHostLabel) {
-      return "apiGatewayV2";
+      return "executeApi";
     }
 
     return undefined;


### PR DESCRIPTION
A request to a simulated REST API's generated endpoint now matches a stage, walks the resource tree to a method, and invokes that method's Lambda proxy integration with the payload format 1.0 event a REST API sends, returning the handler's response to the client. Literal path segments beat a `{name}` parameter, which beats a greedy `{name+}`, and an explicit HTTP method beats `ANY`. The invoke permission is checked against the matched method's `execute-api` ARN, so a grant for one method leaves the others closed. Both API kinds are issued endpoints under one `execute-api` hostname shape and their ids are indistinguishable, so `src/serve/execute-api/` asks which service allocated the id when the request is routed, the way a load balancer's DNS name resolves before anything asks whether one still answers on it. The body encoding, the proxy headers and the event time format both payload formats share moved to `src/serve/proxy/`.

Resolves #780


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for serving real HTTP requests through simulated API Gateway REST APIs backed by Lambda proxy integrations.
  * Added REST API routing for stages, literal and parameterized paths, greedy paths, `ANY` methods, query strings, headers, and binary bodies.
  * Added support for payload format 1.0 events and structured Lambda responses.
  * Added local serving examples and expanded public API documentation.

* **Bug Fixes**
  * Improved API endpoint routing and authorization checks, with clearer errors for unavailable stages, routes, methods, integrations, and permissions.
  * Preserved repeated headers and correctly handled base64-encoded responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->