### PR TITLE
feat: style the sim Cognito managed login pages

### DIFF
--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -1926,8 +1926,11 @@ What `/forgotPassword` shows for a username the pool lacks is the app client's
 `PreventUserExistenceErrors` decision. A client set to `ENABLED` sends the browser on to the code
 page either way, and one left on the `LEGACY` default says the user is not there.
 
-There is no styling and no script on any of the five. Matching what real managed login looks like
-would be work no test could tell apart from a bare form.
+All five carry a small inline stylesheet that approximates real managed login. A card centred on the
+page, a bold heading, labels above full-width fields, and a full-width blue submit button. The
+stylesheet is part of the page. Nothing else is fetched to render one. There is no script on any of
+them, and no close match to what real managed login looks like. Real managed login is built on
+Cloudscape and draws components these pages have no equivalent for.
 
 ### Signing out
 
@@ -4173,12 +4176,13 @@ Current documented limitations:
 - A pool's schema is settled when the pool is created. `AddCustomAttributes` is unimplemented, and
   an `UpdateUserPool` request carrying a `Schema` is refused, because real `UpdateUserPool` has no
   such input.
-- The managed login pages are bare forms with no styling and no script, and
-  `AWS::Cognito::ManagedLoginBranding` is an unsupported resource type. They are also at paths of
-  this simulation's own. Real managed login serves its sign-in form at `/login` and confirms a
-  sign-up within `/signup`, where here the authorize endpoint answers with the form itself and
-  `/confirm` is a page. `/oauth2/userInfo`, `/oauth2/revoke`, `/oauth2/idpresponse` and the SAML
-  endpoints go unserved.
+- The managed login pages approximate what real managed login looks like and go no closer. Their
+  stylesheet is a few dozen lines held inline, where real managed login is built on Cloudscape.
+  There is no script on them, and `AWS::Cognito::ManagedLoginBranding` is an unsupported resource
+  type. They are also at paths of this simulation's own. Real managed login serves its sign-in form
+  at `/login` and confirms a sign-up within `/signup`, where here the authorize endpoint answers
+  with the form itself and `/confirm` is a page. `/oauth2/userInfo`, `/oauth2/revoke`,
+  `/oauth2/idpresponse` and the SAML endpoints go unserved.
 - The pages hold no session and set no cookie, so each of them carries the authorize parameters in
   hidden inputs instead. Real managed login keeps a session cookie, which is what signs a returning
   browser straight back in without the form.

--- a/src/service/cognito/README.md
+++ b/src/service/cognito/README.md
@@ -446,8 +446,9 @@ Sim Lambda's outbound HTTP rewrites that endpoint to the local hostname and rout
 (see `src/service/lambda/README.md`).
 
 `serve/page/` under it is the managed login pages. `SimCognitoPageMarkup` is the HTML they are built
-from, `SimCognitoPageForm` is one request read as the form it fetched or posted, and
-`SimCognitoManagedLogin` is what `SimCognitoDomainEndpoints` hands a page request to. The five pages
+from, `simCognitoPageStyle` is the stylesheet it writes into every page, `SimCognitoPageForm` is one
+request read as the form it fetched or posted, and `SimCognitoManagedLogin` is what
+`SimCognitoDomainEndpoints` hands a page request to. The five pages
 are `SimCognitoSignInPage`, `SimCognitoSignUpPage`, `SimCognitoConfirmPage`,
 `SimCognitoForgotPasswordPage` and `SimCognitoResetPasswordPage`, and the last four call `SignUp`,
 `ConfirmSignUp`, `ResendConfirmationCode`, `ForgotPassword` and `ConfirmForgotPassword` as an
@@ -669,8 +670,9 @@ resource, here or on real AWS.
   developer credentials, and nothing here tells one caller from another that way.
 - Users are resolved by username only, and real Cognito also accepts a `sub` there.
 - `AdminListGroupsForUser` sorts by precedence. Real Cognito does not document an order for it.
-- The managed login pages are bare forms at paths of this simulation's own. The authorize endpoint
-  answers with the sign-in form where real managed login redirects to `/login`, and `/confirm` is a
+- The managed login pages carry an inline stylesheet approximating real managed login, and go no
+  closer than that. They are at paths of this simulation's own. The authorize endpoint answers with
+  the sign-in form where real managed login redirects to `/login`, and `/confirm` is a
   page where real managed login confirms within `/signup`. They hold no session and set no cookie,
   and carry the authorize parameters in hidden inputs instead. A sign-in managed login would answer
   with a second page, which is a user owing a second factor and a user holding a temporary

--- a/src/service/cognito/serve/page/sim-cognito-page-markup.ts
+++ b/src/service/cognito/serve/page/sim-cognito-page-markup.ts
@@ -1,3 +1,5 @@
+import { simCognitoPageStyle } from "./sim-cognito-page-style.js";
+
 /**
  * The parameters a managed login page carries from one step to the next.
  *
@@ -18,10 +20,10 @@ const escapes = new Map([
 /**
  * The HTML the simulated managed login pages are built from.
  *
- * There is no styling and there is no script. The pages exist so that a
- * browser in a local development server can complete a sign-up and a sign-in,
- * and so that a test can post the same forms. Matching what real managed login
- * looks like would be work no test could tell apart from this.
+ * The pages exist so that a browser in a local development server can complete
+ * a sign-up and a sign-in, and so that a test can post the same forms. Every
+ * page carries `simCognitoPageStyle`, which approximates what real managed
+ * login looks like. There is no script on any of them.
  *
  * Every value that reaches the page goes through `escaped`. A `state` is
  * whatever the application put in it, and it is written back into a hidden
@@ -35,9 +37,11 @@ export class SimCognitoPageMarkup {
   page(title: string, body: string): Response {
     const html =
       `<!doctype html>\n<html lang="en">\n<head>\n` +
-      `<meta charset="utf-8">\n<title>${this.escaped(title)}</title>\n` +
-      `</head>\n<body>\n<h1>${this.escaped(title)}</h1>\n${body}\n` +
-      `</body>\n</html>\n`;
+      `<meta charset="utf-8">\n` +
+      `<meta name="viewport" content="width=device-width, initial-scale=1">\n` +
+      `<title>${this.escaped(title)}</title>\n${simCognitoPageStyle}\n` +
+      `</head>\n<body>\n<main>\n<h1>${this.escaped(title)}</h1>\n${body}\n` +
+      `</main>\n</body>\n</html>\n`;
 
     return new Response(html, {
       status: 200,

--- a/src/service/cognito/serve/page/sim-cognito-page-style.ts
+++ b/src/service/cognito/serve/page/sim-cognito-page-style.ts
@@ -1,0 +1,72 @@
+/**
+ * Styling for the managed login pages.
+ *
+ * Held inline in each page. There is no asset route to serve and no second
+ * request from the browser.
+ *
+ * The values approximate real managed login, measured from a live sign-in
+ * page. A card centred on the page, a bold heading, labels above full-width
+ * fields, and a full-width primary button. A close match is no aim of this.
+ * Real managed login is built on Cloudscape and carries components these
+ * pages have no equivalent for.
+ *
+ * The second submit button on a page is the one carrying `formnovalidate`,
+ * and it is styled as the secondary of the two.
+ */
+export const simCognitoPageStyle = `<style>
+body {
+  margin: 0;
+  min-height: 100vh;
+  padding: 24px;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f9f9fa;
+  color: #000716;
+  font: 400 14px/20px "Helvetica Neue", Roboto, Arial, sans-serif;
+}
+main {
+  box-sizing: border-box;
+  width: 402px;
+  max-width: 100%;
+  padding: 24px;
+  background: #fff;
+  border: 1px solid #c6c6cd;
+  border-radius: 8px;
+}
+h1 { margin: 0 0 16px; font-size: 24px; line-height: 30px; }
+p { margin: 0 0 16px; }
+p:last-child { margin-bottom: 0; }
+label { display: block; margin-bottom: 4px; font-weight: 700; }
+input:not([type="hidden"]) {
+  box-sizing: border-box;
+  width: 100%;
+  padding: 5px 12px;
+  border: 1px solid #7d8998;
+  border-radius: 8px;
+  font: inherit;
+  color: #414d5c;
+}
+button {
+  box-sizing: border-box;
+  width: 100%;
+  padding: 4px 20px;
+  border: 2px solid #0972d3;
+  border-radius: 8px;
+  background: #0972d3;
+  color: #fff;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+button[formnovalidate] { background: #fff; color: #0972d3; }
+a { color: #0972d3; text-decoration: none; }
+a:hover { text-decoration: underline; }
+.message {
+  padding: 8px 12px;
+  border: 1px solid #7d8998;
+  border-radius: 8px;
+  background: #f9f9fa;
+}
+</style>`;

--- a/src/service/cognito/serve/sim-cognito-managed-login.iso.test.ts
+++ b/src/service/cognito/serve/sim-cognito-managed-login.iso.test.ts
@@ -53,6 +53,29 @@ describe("The pages a sim Cognito hosted domain serves", () => {
     assertStringIncludes(page, "identity_provider=Google");
   });
 
+  it("styles the page it serves from a stylesheet held inline", async () => {
+    // Given a pool with a hosted domain.
+    const setUp = await simCognitoHosted();
+
+    // When the browser is sent to the authorize endpoint.
+    const response = await simCognitoGetPage(
+      setUp,
+      "/oauth2/authorize",
+      simCognitoAuthorizeParameters(setUp),
+    );
+
+    // Then the page carries the stylesheet itself, with the form in a card the
+    // stylesheet has something to select.
+    const page = await response.text();
+    assertStringIncludes(page, "<style>");
+    assertStringIncludes(page, "<main>");
+
+    // And it asks for nothing else to render, because a browser fetching an
+    // asset from the simulation would need a route to fetch it from.
+    assertStringNotIncludes(page, "<link");
+    assertStringNotIncludes(page, "<script");
+  });
+
   it("signs a user in when the form is posted", async () => {
     // Given a pool holding a confirmed user of its own.
     const setUp = await simCognitoHosted();


### PR DESCRIPTION
The five managed login pages were unstyled HTML, which reads as broken to anyone using Yulin as a local development server rather than only in tests. Every page now carries an inline stylesheet approximating what real managed login looks like, with a card centred on the page, a bold heading, labels above full-width fields, and a full-width blue submit button. The values come from a live managed login sign-in page. Holding the stylesheet in the page keeps each one a single response with no asset route to serve, which is what `simRoute53SummaryStyle` already does for the hosted-zone summary page.

Resolves https://github.com/KensioSoftware/yulin/issues/786

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`

## Notes for review

All five pages go through `SimCognitoPageMarkup.page`, so the stylesheet is wired in at that one point. `page` also now wraps the body in `<main>`, because it previously wrote the heading and body straight into `<body>` with no element for a card to hang on.

Verified by rendering pages through the real `SimCognitoPageMarkup` and reading computed geometry back out of a browser. The card comes out 402px wide and centred on both axes, with a `#c6c6cd` border at 8px radius, `#7d8998` inputs 32px tall, and a `#0972d3` full-width button, all matching the live page. Hidden inputs stay at zero height and there is no horizontal scroll at 400px wide.

Two judgement calls worth a look:

- The `message` class is a neutral box rather than a red one. `SimCognitoConfirmPage` uses `message()` for "Another code has been sent." as well as for errors, and the markup gives no way to tell the two apart. Colouring it red would mislabel the success case. A `kind` on `message()` would fix that properly and is more than this issue asked for.
- The second submit button on a page is styled as the secondary of the two, keyed off `formnovalidate`. The confirm page is the only page with two buttons, and two identical full-width blue ones look wrong. This couples appearance to a validation attribute, so a dedicated flag on `submit()` would be cleaner if preferred.

The stylesheet deliberately stops well short of the real thing. Real managed login is built on Cloudscape and draws components these pages have no equivalent for.
