### PR TITLE
feat: deploy REST APIs from CloudFormation

### DIFF
--- a/docs/services/apigateway/README.md
+++ b/docs/services/apigateway/README.md
@@ -387,6 +387,244 @@ console.log(listed.items?.map((restApi) => restApi.name));
 The client's region decides which simulated account and region scope the API lands in, the same way
 it does for every other intercepted service.
 
+## Deploying from CloudFormation and CDK
+
+[Simulated CloudFormation](../cloudformation/ "Simulated CloudFormation docs") deploys
+`AWS::ApiGateway::RestApi`, `AWS::ApiGateway::Resource`, `AWS::ApiGateway::Method`,
+`AWS::ApiGateway::Deployment` and `AWS::ApiGateway::Stage`. A synthesized or hand-written template
+produces an API that serves requests.
+
+`Ref` and `Fn::GetAtt` return what real CloudFormation returns for each type:
+
+| Resource type | `Ref`             | `Fn::GetAtt`                  |
+| ------------- | ----------------- | ----------------------------- |
+| `RestApi`     | the API id        | `RestApiId`, `RootResourceId` |
+| `Resource`    | the resource id   | `ResourceId`                  |
+| `Method`      | the logical id    | none, as AWS documents none   |
+| `Deployment`  | the deployment id | `DeploymentId`                |
+| `Stage`       | the stage name    | none, as AWS documents none   |
+
+A REST API method has no id of its own. It is addressed by its API, its resource and its HTTP verb,
+and a `Ref` to one falls back on the CloudFormation logical id. CDK reads that value only to publish
+`Method.methodId`.
+
+The API publishes no endpoint attribute either, because real API Gateway reports none. CDK joins the
+URL out of a `Ref` to the API, the region, `AWS::URLSuffix` and a `Ref` to the stage. That suffix
+resolves to the local `sim-aws.localhost` hostname, and the stage is the first path segment of what
+it builds.
+
+A `Resource` names its place in the tree through `ParentId`. The top of the tree reads
+`Fn::GetAtt: ["<Api>", "RootResourceId"]`, and everything below it a `Ref` to the node above.
+
+A `Method` carries its integration as an `Integration` block of its own, which is how the REST API
+models one. The block becomes the `PutIntegration` that follows the method's `PutMethod`, and its
+`Uri` is read as the bare Lambda function ARN or as the
+`arn:aws:apigateway:<region>:lambda:path/2015-03-31/functions/<function-arn>/invocations` string CDK
+builds with `Fn::Join`.
+
+```typescript sim-apigateway-cloudformation
+/**
+ * Deploying a simulated REST API from a CloudFormation template.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Resources: {
+      HandlerRole: {
+        Type: "AWS::IAM::Role",
+        Properties: {
+          RoleName: "orders-role",
+          AssumeRolePolicyDocument: {
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Principal: { Service: "lambda.amazonaws.com" },
+                Action: "sts:AssumeRole",
+              },
+            ],
+          },
+        },
+      },
+      Handler: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "orders",
+          Role: { "Fn::GetAtt": ["HandlerRole", "Arn"] },
+          Handler: "index.handler",
+          Runtime: "nodejs20.x",
+          Code: {
+            ZipFile:
+              "exports.handler = async (event) => ({ statusCode: 200, body: 'order ' + event.pathParameters.orderId });",
+          },
+        },
+      },
+      HandlerPermission: {
+        Type: "AWS::Lambda::Permission",
+        Properties: {
+          Action: "lambda:InvokeFunction",
+          FunctionName: { "Fn::GetAtt": ["Handler", "Arn"] },
+          Principal: "apigateway.amazonaws.com",
+          SourceArn: {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:execute-api:",
+                { Ref: "AWS::Region" },
+                ":",
+                { Ref: "AWS::AccountId" },
+                ":",
+                { Ref: "Api" },
+                "/*/*/*",
+              ],
+            ],
+          },
+        },
+      },
+      Api: {
+        Type: "AWS::ApiGateway::RestApi",
+        Properties: { Name: "orders" },
+      },
+      OrdersResource: {
+        Type: "AWS::ApiGateway::Resource",
+        Properties: {
+          RestApiId: { Ref: "Api" },
+          ParentId: { "Fn::GetAtt": ["Api", "RootResourceId"] },
+          PathPart: "orders",
+        },
+      },
+      OrderResource: {
+        Type: "AWS::ApiGateway::Resource",
+        Properties: {
+          RestApiId: { Ref: "Api" },
+          ParentId: { Ref: "OrdersResource" },
+          PathPart: "{orderId}",
+        },
+      },
+      GetOrder: {
+        Type: "AWS::ApiGateway::Method",
+        Properties: {
+          RestApiId: { Ref: "Api" },
+          ResourceId: { Ref: "OrderResource" },
+          HttpMethod: "GET",
+          AuthorizationType: "NONE",
+          Integration: {
+            Type: "AWS_PROXY",
+            IntegrationHttpMethod: "POST",
+            Uri: {
+              "Fn::Join": [
+                "",
+                [
+                  "arn:aws:apigateway:",
+                  { Ref: "AWS::Region" },
+                  ":lambda:path/2015-03-31/functions/",
+                  { "Fn::GetAtt": ["Handler", "Arn"] },
+                  "/invocations",
+                ],
+              ],
+            },
+          },
+        },
+      },
+      Deployment: {
+        Type: "AWS::ApiGateway::Deployment",
+        Properties: { RestApiId: { Ref: "Api" } },
+        DependsOn: ["GetOrder"],
+      },
+      Stage: {
+        Type: "AWS::ApiGateway::Stage",
+        Properties: {
+          RestApiId: { Ref: "Api" },
+          DeploymentId: { Ref: "Deployment" },
+          StageName: "prod",
+        },
+      },
+    },
+    Outputs: {
+      ApiUrl: {
+        Value: {
+          "Fn::Join": [
+            "",
+            [
+              "https://",
+              { Ref: "Api" },
+              ".execute-api.",
+              { Ref: "AWS::Region" },
+              ".",
+              { Ref: "AWS::URLSuffix" },
+              "/",
+              { Ref: "Stage" },
+              "/",
+            ],
+          ],
+        },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+// https://<api-id>.execute-api.us-east-1.sim-aws.localhost/prod/
+const apiUrl = stack.output("ApiUrl");
+
+const srv = await serveSimAws({ simAws });
+
+const response = await fetch(srv.localUrl(`${apiUrl}orders/6`));
+
+console.log(response.status);
+// 200
+
+console.log(await response.text());
+// "order 6"
+
+await srv.close();
+```
+
+Every property outside the simulated set is left out of what is created and recorded in
+[`stack.ignoredProperties`](../cloudformation/README.md#properties-a-resource-was-created-without),
+naming the Resource type, the logical id and the ones this can act on. The API, resource, method,
+deployment or stage is created either way. The stack deploys, and the record says which of its parts
+behaves differently to the template. The simulated properties are:
+
+- `RestApi`: `Name`, `Description`, `DisableExecuteApiEndpoint`
+- `Resource`: `RestApiId`, `ParentId`, `PathPart`
+- `Method`: `RestApiId`, `ResourceId`, `HttpMethod`, `AuthorizationType`, `ApiKeyRequired`,
+  `OperationName`, `Integration`
+- A method's `Integration` block: `Type`, `IntegrationHttpMethod`, `Uri`
+- `Deployment`: `RestApiId`, `Description`, `StageName`
+- `Stage`: `RestApiId`, `DeploymentId`, `StageName`, `Description`, `Variables`
+
+A `Body` on the `RestApi` is one of the recorded ones. It is an OpenAPI document declaring the API's
+resources, methods and integrations, and reading one is outside this. An API declared that way
+deploys with a root resource and an empty tree under it.
+
+`StageName` on a `Deployment` is the older one-Resource form, where the deployment publishes a stage
+of that name by itself and the template carries one Resource fewer.
+
+### CDK
+
+CDK's `RestApi` and `LambdaRestApi` both deploy and serve. `LambdaRestApi` synthesizes an `ANY`
+method on the root and another on a `{proxy+}` resource, both in front of one function, with the
+`AWS::Lambda::Permission` each needs. `restApi.url` and `restApi.urlForPath` resolve to the local
+hostname through `AWS::URLSuffix`.
+
+CDK also writes an `AWS::ApiGateway::Account` and a CloudWatch role beside a default `RestApi`.
+Neither is simulated. The `Account` Resource is recorded in
+[`stack.skippedResources`](../cloudformation/README.md#inspecting-stacks-and-resources) and the rest of the
+stack deploys.
+
+`Authorizer`, `ApiKey`, `UsagePlan`, `UsagePlanKey`, `RequestValidator`, `Model`, `DomainName` and
+`BasePathMapping` are recorded there too, each naming the reason. A method under one of them is
+refused by `PutMethod`, because a method that looked gated to the template and answered every
+request here is worse than a failed deployment.
+
 ## Authorization
 
 Every command is authorized by simulated IAM, and API Gateway asks IAM an unusual question. The
@@ -423,9 +661,15 @@ and behave differently deployed. The refusals worth knowing about:
 | Integrations | `PutIntegration`, `GetIntegration`                                             |
 | Publishing   | `CreateDeployment`, `CreateStage`, `GetStage`, `GetStages`, `DeleteStage`      |
 
+CloudFormation deploys `AWS::ApiGateway::RestApi`, `Resource`, `Method`, `Deployment` and `Stage`,
+including the template CDK synthesizes from a `RestApi` or a `LambdaRestApi`. See
+[Deploying from CloudFormation and CDK](#deploying-from-cloudformation-and-cdk).
+
 ## Limitations
 
-- CloudFormation and CDK deployment of `AWS::ApiGateway::*` resources is still to come.
+- An `AWS::ApiGateway::Deployment` is created and never deleted, because API Gateway deletes one
+  and this simulation has no command for it. A Stack teardown lists it in
+  `stack.skippedResourceDeletions` and the deployment goes with its API a moment later.
 - A repeated request header reaches the handler as one joined value in `multiValueHeaders`, because
   that is the form the platform's `Headers` hands over. Real API Gateway reports each separately.
 - Binary media types negotiated by `Accept`, CORS preflight and gateway responses are outside this.

--- a/docs/services/apigateway/sim-apigateway-cloudformation.example.ts
+++ b/docs/services/apigateway/sim-apigateway-cloudformation.example.ts
@@ -1,0 +1,162 @@
+/**
+ * Deploying a simulated REST API from a CloudFormation template.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Resources: {
+      HandlerRole: {
+        Type: "AWS::IAM::Role",
+        Properties: {
+          RoleName: "orders-role",
+          AssumeRolePolicyDocument: {
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Principal: { Service: "lambda.amazonaws.com" },
+                Action: "sts:AssumeRole",
+              },
+            ],
+          },
+        },
+      },
+      Handler: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "orders",
+          Role: { "Fn::GetAtt": ["HandlerRole", "Arn"] },
+          Handler: "index.handler",
+          Runtime: "nodejs20.x",
+          Code: {
+            ZipFile:
+              "exports.handler = async (event) => ({ statusCode: 200, body: 'order ' + event.pathParameters.orderId });",
+          },
+        },
+      },
+      HandlerPermission: {
+        Type: "AWS::Lambda::Permission",
+        Properties: {
+          Action: "lambda:InvokeFunction",
+          FunctionName: { "Fn::GetAtt": ["Handler", "Arn"] },
+          Principal: "apigateway.amazonaws.com",
+          SourceArn: {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:execute-api:",
+                { Ref: "AWS::Region" },
+                ":",
+                { Ref: "AWS::AccountId" },
+                ":",
+                { Ref: "Api" },
+                "/*/*/*",
+              ],
+            ],
+          },
+        },
+      },
+      Api: {
+        Type: "AWS::ApiGateway::RestApi",
+        Properties: { Name: "orders" },
+      },
+      OrdersResource: {
+        Type: "AWS::ApiGateway::Resource",
+        Properties: {
+          RestApiId: { Ref: "Api" },
+          ParentId: { "Fn::GetAtt": ["Api", "RootResourceId"] },
+          PathPart: "orders",
+        },
+      },
+      OrderResource: {
+        Type: "AWS::ApiGateway::Resource",
+        Properties: {
+          RestApiId: { Ref: "Api" },
+          ParentId: { Ref: "OrdersResource" },
+          PathPart: "{orderId}",
+        },
+      },
+      GetOrder: {
+        Type: "AWS::ApiGateway::Method",
+        Properties: {
+          RestApiId: { Ref: "Api" },
+          ResourceId: { Ref: "OrderResource" },
+          HttpMethod: "GET",
+          AuthorizationType: "NONE",
+          Integration: {
+            Type: "AWS_PROXY",
+            IntegrationHttpMethod: "POST",
+            Uri: {
+              "Fn::Join": [
+                "",
+                [
+                  "arn:aws:apigateway:",
+                  { Ref: "AWS::Region" },
+                  ":lambda:path/2015-03-31/functions/",
+                  { "Fn::GetAtt": ["Handler", "Arn"] },
+                  "/invocations",
+                ],
+              ],
+            },
+          },
+        },
+      },
+      Deployment: {
+        Type: "AWS::ApiGateway::Deployment",
+        Properties: { RestApiId: { Ref: "Api" } },
+        DependsOn: ["GetOrder"],
+      },
+      Stage: {
+        Type: "AWS::ApiGateway::Stage",
+        Properties: {
+          RestApiId: { Ref: "Api" },
+          DeploymentId: { Ref: "Deployment" },
+          StageName: "prod",
+        },
+      },
+    },
+    Outputs: {
+      ApiUrl: {
+        Value: {
+          "Fn::Join": [
+            "",
+            [
+              "https://",
+              { Ref: "Api" },
+              ".execute-api.",
+              { Ref: "AWS::Region" },
+              ".",
+              { Ref: "AWS::URLSuffix" },
+              "/",
+              { Ref: "Stage" },
+              "/",
+            ],
+          ],
+        },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+// https://<api-id>.execute-api.us-east-1.sim-aws.localhost/prod/
+const apiUrl = stack.output("ApiUrl");
+
+const srv = await serveSimAws({ simAws });
+
+const response = await fetch(srv.localUrl(`${apiUrl}orders/6`));
+
+console.log(response.status);
+// 200
+
+console.log(await response.text());
+// "order 6"
+
+await srv.close();

--- a/docs/services/apigatewayv2/README.md
+++ b/docs/services/apigatewayv2/README.md
@@ -1894,7 +1894,11 @@ const stack = await simAws.cloudFormation().deployTemplate({
             "Fn::Join": [
               "",
               [
-                "arn:aws:execute-api:us-east-1:111111111111:",
+                "arn:aws:execute-api:",
+                { Ref: "AWS::Region" },
+                ":",
+                { Ref: "AWS::AccountId" },
+                ":",
                 { Ref: "Api" },
                 "/*/*",
               ],
@@ -1951,7 +1955,10 @@ const srv = await serveSimAws({ simAws });
 const response = await fetch(srv.localUrl(`${apiEndpoint}/orders`));
 
 console.log(response.status);
+// 200
+
 console.log(await response.text());
+// "orders"
 
 await srv.close();
 ```

--- a/docs/services/apigatewayv2/README.md
+++ b/docs/services/apigatewayv2/README.md
@@ -2134,8 +2134,8 @@ Current documented limitations:
 - `AWS_PROXY` is the only integration type, and its URI must name a Lambda function ARN, written
   either as that ARN or as the
   `arn:aws:apigateway:<region>:lambda:path/2015-03-31/functions/<function-arn>/invocations` form.
-  Both reach the same function, and `GetIntegrations` answers with the function ARN whichever was
-  written. A version or alias qualifier on the end is kept and resolved at each request (see
+  Both reach the same function, and `GetIntegrations` answers with the URI as it was written, as AWS
+  does. A version or alias qualifier on the end is kept and resolved at each request (see
   [Routing to a published version or an alias](#routing-to-a-published-version-or-an-alias)). HTTP
   proxy integrations and AWS service integrations are outside the simulation.
 - Payload format 1.0 is refused. A handler written for 1.0 reads event fields absent from a 2.0

--- a/docs/services/apigatewayv2/sim-apigatewayv2-cloudformation.example.ts
+++ b/docs/services/apigatewayv2/sim-apigatewayv2-cloudformation.example.ts
@@ -50,7 +50,11 @@ const stack = await simAws.cloudFormation().deployTemplate({
             "Fn::Join": [
               "",
               [
-                "arn:aws:execute-api:us-east-1:111111111111:",
+                "arn:aws:execute-api:",
+                { Ref: "AWS::Region" },
+                ":",
+                { Ref: "AWS::AccountId" },
+                ":",
                 { Ref: "Api" },
                 "/*/*",
               ],
@@ -107,6 +111,9 @@ const srv = await serveSimAws({ simAws });
 const response = await fetch(srv.localUrl(`${apiEndpoint}/orders`));
 
 console.log(response.status);
+// 200
+
 console.log(await response.text());
+// "orders"
 
 await srv.close();

--- a/src/service/apigateway/README.md
+++ b/src/service/apigateway/README.md
@@ -108,6 +108,7 @@ SimApiGatewayCfnResourceFactory              which creator answers a Resource ty
 ├── sim-cfn-api-gateway-property-parser.ts   the allow-list of properties
 ├── sim-cfn-api-gateway-scalar-values.ts     the value shapes each may take
 ├── sim-cfn-rest-api-template.factory.ts     the template tests deploy
+├── sim-cfn-rest-api-template-ids.ts         the logical IDs a test names it by
 ├── sim-cfn-rest-api-part-deleter.ts         what a teardown deletes an API's parts by
 ├── api/         RestApi
 ├── resource/    Resource
@@ -124,7 +125,9 @@ every request.
 
 A method is one Resource and two commands, because the REST API declares a method and what it does
 with a request separately. The template writes both as one entry, with the integration as a block of
-the method, so `PutMethod` and `PutIntegration` go together or neither does.
+the method, and `PutMethod` and `PutIntegration` go together or neither does. An integration real
+API Gateway refuses takes the method back out again, because the next deployment of the corrected
+template would otherwise be refused for a method that already exists.
 
 A teardown deletes each part through the command that removes it, and the API last. A deployment is
 the exception. API Gateway deletes one and nothing here does. The Resource is reported as a deletion

--- a/src/service/apigateway/README.md
+++ b/src/service/apigateway/README.md
@@ -99,6 +99,42 @@ the id. That split is made when the request is routed rather than while the host
 for the same reason a load balancer's DNS name resolves before anything asks whether a load balancer
 still answers on it.
 
+## Deploying from a template
+
+`cfn/` turns the `AWS::ApiGateway::*` Resource types into the same commands an SDK caller sends:
+
+```text
+SimApiGatewayCfnResourceFactory              which creator answers a Resource type
+├── sim-cfn-api-gateway-property-parser.ts   the allow-list of properties
+├── sim-cfn-api-gateway-scalar-values.ts     the value shapes each may take
+├── sim-cfn-rest-api-template.factory.ts     the template tests deploy
+├── sim-cfn-rest-api-part-deleter.ts         what a teardown deletes an API's parts by
+├── api/         RestApi
+├── resource/    Resource
+├── method/      Method, and the Integration block it carries
+├── deployment/  Deployment
+└── stage/       Stage
+```
+
+Every creator goes through the ordinary command. A template is held to the same rules an SDK caller
+is, and the refusals below apply to a deployed Resource as well. Each properties reader states the
+properties its type simulates and records every other one against the Resource. That record is what
+keeps a template from deploying an API that looks configured to the template and unconfigured to
+every request.
+
+A method is one Resource and two commands, because the REST API declares a method and what it does
+with a request separately. The template writes both as one entry, with the integration as a block of
+the method, so `PutMethod` and `PutIntegration` go together or neither does.
+
+A teardown deletes each part through the command that removes it, and the API last. A deployment is
+the exception. API Gateway deletes one and nothing here does. The Resource is reported as a deletion
+nothing carried out, and the deployment goes with its API a moment later.
+
+`Ref` and `Fn::GetAtt` live beside the CloudFormation engine, in
+`src/service/cloudformation/resource/cfn/apigateway/`, where every service keeps its value adapters.
+A method has no adapter there. It has no id of its own on real AWS, and the engine's fallback
+answers a `Ref` with the logical ID.
+
 ## What is refused
 
 `command/sim-api-gateway-unsimulated-input.ts` refuses every input outside the accepted set of each

--- a/src/service/apigateway/cfn/api/sim-cfn-rest-api-creator.ts
+++ b/src/service/apigateway/cfn/api/sim-cfn-rest-api-creator.ts
@@ -1,0 +1,47 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimRestApi } from "../../api/sim-rest-api.js";
+import type { SimApiGateway } from "../../sim-api-gateway.js";
+import { SimCfnRestApiProperties } from "./sim-cfn-rest-api-properties.js";
+
+interface SimCfnRestApiCreatorProperties {
+  readonly apiGateway: SimApiGateway;
+}
+
+/**
+ * Creates simulated REST APIs from AWS::ApiGateway::RestApi Resources.
+ *
+ * The API goes through the ordinary CreateRestApi command, so a template is
+ * held to the same rules an SDK caller is, with the reason the command gives.
+ */
+export class SimCfnRestApiCreator {
+  private readonly apiGateway: SimApiGateway;
+
+  constructor(properties: SimCfnRestApiCreatorProperties) {
+    this.apiGateway = properties.apiGateway;
+  }
+
+  /**
+   * Create a REST API from an AWS::ApiGateway::RestApi Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimRestApi> {
+    const created = await this.apiGateway.createRestApi({
+      input: new SimCfnRestApiProperties({
+        resource,
+        properties,
+      }).createRestApiInput(),
+    });
+
+    const restApi = this.apiGateway.findRestApi(created.id);
+    assertDefined(
+      restApi,
+      `sim REST API ${created.id} after CloudFormation creation`,
+    );
+
+    return restApi;
+  }
+}

--- a/src/service/apigateway/cfn/api/sim-cfn-rest-api-properties.ts
+++ b/src/service/apigateway/cfn/api/sim-cfn-rest-api-properties.ts
@@ -1,0 +1,71 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCreateRestApiCommandInput } from "../../command/api/rest-api.command.js";
+import { SimCfnApiGatewayPropertyParser } from "../sim-cfn-api-gateway-property-parser.js";
+
+/**
+ * The AWS::ApiGateway::RestApi properties this simulation deploys.
+ *
+ * `Body`, `BodyS3Location`, `Mode`, `EndpointConfiguration`, `Policy`,
+ * `BinaryMediaTypes`, `MinimumCompressionSize`, `ApiKeySourceType`,
+ * `Parameters`, `CloneFrom`, `FailOnWarnings` and `Tags` are all left out, so
+ * a template carrying one has it recorded against the Resource. The API is
+ * created without it.
+ */
+const simulatedProperties = [
+  "Name",
+  "Description",
+  "DisableExecuteApiEndpoint",
+];
+
+interface SimCfnRestApiPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::ApiGateway::RestApi CloudFormation properties into the
+ * CreateRestApi input the API creator needs.
+ *
+ * A `Body` is an OpenAPI document declaring the API's resources, methods and
+ * integrations. Nothing here reads one, so an API declared that way deploys
+ * with a root resource and nothing under it, and the record says so.
+ */
+export class SimCfnRestApiProperties {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly propertyParser = new SimCfnApiGatewayPropertyParser({
+    resourceType: "AWS::ApiGateway::RestApi",
+    simulated: simulatedProperties,
+  });
+
+  constructor(properties: SimCfnRestApiPropertiesProperties) {
+    this.resource = properties.resource;
+    this.properties = properties.properties;
+
+    this.propertyParser.ignoreUnsimulated(this.resource, this.properties);
+  }
+
+  /**
+   * The CreateRestApi input this Resource asks for.
+   */
+  createRestApiInput(): SimCreateRestApiCommandInput {
+    return {
+      name: this.propertyParser.requiredString(
+        this.resource,
+        this.properties["Name"],
+        "Name",
+      ),
+      description: this.propertyParser.optionalString(
+        this.resource,
+        this.properties["Description"],
+        "Description",
+      ),
+      disableExecuteApiEndpoint: this.propertyParser.optionalBoolean(
+        this.resource,
+        this.properties["DisableExecuteApiEndpoint"],
+        "DisableExecuteApiEndpoint",
+      ),
+    };
+  }
+}

--- a/src/service/apigateway/cfn/deployment/sim-cfn-rest-api-deployment-creator.ts
+++ b/src/service/apigateway/cfn/deployment/sim-cfn-rest-api-deployment-creator.ts
@@ -1,0 +1,54 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimRestApiDeployment } from "../../api/deployment/sim-rest-api-deployment.js";
+import type { SimApiGateway } from "../../sim-api-gateway.js";
+import { SimCfnRestApiDeploymentProperties } from "./sim-cfn-rest-api-deployment-properties.js";
+
+interface SimCfnRestApiDeploymentCreatorProperties {
+  readonly apiGateway: SimApiGateway;
+}
+
+/**
+ * Creates deployments from AWS::ApiGateway::Deployment Resources.
+ *
+ * CDK writes a `DependsOn` naming every method of the API, so the deployment
+ * is created after the resources and methods it publishes. Nothing here reads
+ * that ordering, because a stage serves the API's current resources rather
+ * than a frozen copy of them.
+ */
+export class SimCfnRestApiDeploymentCreator {
+  private readonly apiGateway: SimApiGateway;
+
+  constructor(properties: SimCfnRestApiDeploymentCreatorProperties) {
+    this.apiGateway = properties.apiGateway;
+  }
+
+  /**
+   * Create a deployment from an AWS::ApiGateway::Deployment Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimRestApiDeployment> {
+    const deploymentProperties = new SimCfnRestApiDeploymentProperties({
+      resource,
+      properties,
+    });
+    const restApiId = deploymentProperties.restApiId();
+
+    const created = await this.apiGateway.createDeployment({
+      input: deploymentProperties.createDeploymentInput(),
+    });
+
+    const deployment = this.apiGateway
+      .findRestApi(restApiId)
+      ?.deployments.find(created.id);
+    assertDefined(
+      deployment,
+      `sim REST API deployment ${created.id} after CloudFormation creation`,
+    );
+
+    return deployment;
+  }
+}

--- a/src/service/apigateway/cfn/deployment/sim-cfn-rest-api-deployment-properties.ts
+++ b/src/service/apigateway/cfn/deployment/sim-cfn-rest-api-deployment-properties.ts
@@ -1,0 +1,70 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCreateDeploymentCommandInput } from "../../command/stage/stage.command.js";
+import { SimCfnApiGatewayPropertyParser } from "../sim-cfn-api-gateway-property-parser.js";
+
+/**
+ * The AWS::ApiGateway::Deployment properties this simulation deploys.
+ *
+ * `StageDescription` and `DeploymentCanarySettings` are left out, so a
+ * template carrying one has it recorded against the Resource. `StageName` is
+ * the older one-Resource form, where the deployment publishes a stage of its
+ * own instead of an AWS::ApiGateway::Stage naming it.
+ */
+const simulatedProperties = ["RestApiId", "Description", "StageName"];
+
+interface SimCfnRestApiDeploymentPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::ApiGateway::Deployment CloudFormation properties into the
+ * CreateDeployment input the deployment creator needs.
+ */
+export class SimCfnRestApiDeploymentProperties {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly propertyParser = new SimCfnApiGatewayPropertyParser({
+    resourceType: "AWS::ApiGateway::Deployment",
+    simulated: simulatedProperties,
+  });
+
+  constructor(properties: SimCfnRestApiDeploymentPropertiesProperties) {
+    this.resource = properties.resource;
+    this.properties = properties.properties;
+
+    this.propertyParser.ignoreUnsimulated(this.resource, this.properties);
+  }
+
+  /**
+   * The API this deployment belongs to, which a template reaches with a `Ref`
+   * on its AWS::ApiGateway::RestApi.
+   */
+  restApiId(): string {
+    return this.propertyParser.requiredString(
+      this.resource,
+      this.properties["RestApiId"],
+      "RestApiId",
+    );
+  }
+
+  /**
+   * The CreateDeployment input this Resource asks for.
+   */
+  createDeploymentInput(): SimCreateDeploymentCommandInput {
+    return {
+      restApiId: this.restApiId(),
+      stageName: this.propertyParser.optionalString(
+        this.resource,
+        this.properties["StageName"],
+        "StageName",
+      ),
+      description: this.propertyParser.optionalString(
+        this.resource,
+        this.properties["Description"],
+        "Description",
+      ),
+    };
+  }
+}

--- a/src/service/apigateway/cfn/method/sim-cfn-rest-api-integration-properties.ts
+++ b/src/service/apigateway/cfn/method/sim-cfn-rest-api-integration-properties.ts
@@ -1,0 +1,97 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimPutIntegrationCommandInput } from "../../command/method/method.command.js";
+import { SimCfnApiGatewayPropertyParser } from "../sim-cfn-api-gateway-property-parser.js";
+
+/**
+ * The properties of a method's `Integration` block this simulation deploys.
+ *
+ * `Credentials`, `PassthroughBehavior`, `RequestParameters`,
+ * `RequestTemplates`, `IntegrationResponses`, `ContentHandling`,
+ * `TimeoutInMillis`, `ConnectionType`, `ConnectionId`, `CacheKeyParameters`
+ * and `CacheNamespace` are left out, so a template carrying one has it
+ * recorded against the method and the integration is created without it.
+ */
+const simulatedProperties = ["Type", "IntegrationHttpMethod", "Uri"];
+
+/**
+ * Where an ignored property of the block is recorded, so a reader sees which
+ * block of the method it came from.
+ */
+const integrationPath = "Integration.";
+
+interface SimCfnRestApiIntegrationPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+  readonly restApiId: string;
+  readonly resourceId: string;
+  readonly httpMethod: string;
+}
+
+/**
+ * Reads the `Integration` block of an AWS::ApiGateway::Method into the
+ * PutIntegration input the method creator needs.
+ *
+ * A REST API integration is part of its method rather than a Resource of its
+ * own, which is why it arrives as a block of the method that declares it. It
+ * is addressed by the same API, resource and HTTP method the method is.
+ */
+export class SimCfnRestApiIntegrationProperties {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly restApiId: string;
+  private readonly resourceId: string;
+  private readonly httpMethod: string;
+  private readonly propertyParser = new SimCfnApiGatewayPropertyParser({
+    resourceType: "AWS::ApiGateway::Method Integration",
+    simulated: simulatedProperties,
+  });
+
+  constructor(properties: SimCfnRestApiIntegrationPropertiesProperties) {
+    this.resource = properties.resource;
+    this.properties = properties.properties;
+    this.restApiId = properties.restApiId;
+    this.resourceId = properties.resourceId;
+    this.httpMethod = properties.httpMethod;
+
+    this.propertyParser.ignoreUnsimulated(
+      this.resource,
+      this.properties,
+      integrationPath,
+    );
+  }
+
+  /**
+   * The PutIntegration input this block asks for.
+   *
+   * `Type` and `IntegrationHttpMethod` are passed through as the template
+   * wrote them, so a MOCK, HTTP, HTTP_PROXY or non-proxy AWS integration is
+   * refused by PutIntegration with the reason it refuses it. The `Uri` arrives
+   * as the `arn:aws:apigateway:<region>:lambda:path/...` string CDK builds
+   * with `Fn::Join`, and is kept as the template wrote it. It is optional
+   * here, because a MOCK integration carries none and reaching the refusal
+   * that names the type is more use than one about a missing URI.
+   */
+  putIntegrationInput(): SimPutIntegrationCommandInput {
+    return {
+      restApiId: this.restApiId,
+      resourceId: this.resourceId,
+      httpMethod: this.httpMethod,
+      type: this.propertyParser.requiredString(
+        this.resource,
+        this.properties["Type"],
+        `${integrationPath}Type`,
+      ),
+      integrationHttpMethod: this.propertyParser.optionalString(
+        this.resource,
+        this.properties["IntegrationHttpMethod"],
+        `${integrationPath}IntegrationHttpMethod`,
+      ),
+      uri: this.propertyParser.optionalString(
+        this.resource,
+        this.properties["Uri"],
+        `${integrationPath}Uri`,
+      ),
+    };
+  }
+}

--- a/src/service/apigateway/cfn/method/sim-cfn-rest-api-method-creator.ts
+++ b/src/service/apigateway/cfn/method/sim-cfn-rest-api-method-creator.ts
@@ -1,0 +1,62 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimRestApiMethod } from "../../api/method/sim-rest-api-method.js";
+import type { SimApiGateway } from "../../sim-api-gateway.js";
+import { SimCfnRestApiMethodProperties } from "./sim-cfn-rest-api-method-properties.js";
+
+interface SimCfnRestApiMethodCreatorProperties {
+  readonly apiGateway: SimApiGateway;
+}
+
+/**
+ * Creates methods, and the integrations behind them, from
+ * AWS::ApiGateway::Method Resources.
+ *
+ * One Resource is two commands here, because a REST API declares a method and
+ * what it does with a request separately. The template writes both as one
+ * entry, with the integration as a block of the method, so the two go together
+ * or neither does.
+ */
+export class SimCfnRestApiMethodCreator {
+  private readonly apiGateway: SimApiGateway;
+
+  constructor(properties: SimCfnRestApiMethodCreatorProperties) {
+    this.apiGateway = properties.apiGateway;
+  }
+
+  /**
+   * Create a method from an AWS::ApiGateway::Method Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimRestApiMethod> {
+    const methodProperties = new SimCfnRestApiMethodProperties({
+      resource,
+      properties,
+    });
+
+    await this.apiGateway.putMethod({
+      input: methodProperties.putMethodInput(),
+    });
+
+    const integrationInput = methodProperties.putIntegrationInput();
+
+    if (integrationInput !== undefined) {
+      await this.apiGateway.putIntegration({ input: integrationInput });
+    }
+
+    const method = this.apiGateway
+      .findRestApi(methodProperties.restApiId())
+      ?.resources.find(methodProperties.resourceId())
+      ?.findMethod(methodProperties.httpMethod());
+    assertDefined(
+      method,
+      `sim REST API method ${methodProperties.httpMethod()} after ` +
+        `CloudFormation creation`,
+    );
+
+    return method;
+  }
+}

--- a/src/service/apigateway/cfn/method/sim-cfn-rest-api-method-creator.ts
+++ b/src/service/apigateway/cfn/method/sim-cfn-rest-api-method-creator.ts
@@ -40,12 +40,7 @@ export class SimCfnRestApiMethodCreator {
     await this.apiGateway.putMethod({
       input: methodProperties.putMethodInput(),
     });
-
-    const integrationInput = methodProperties.putIntegrationInput();
-
-    if (integrationInput !== undefined) {
-      await this.apiGateway.putIntegration({ input: integrationInput });
-    }
+    await this.putIntegration(methodProperties);
 
     const method = this.apiGateway
       .findRestApi(methodProperties.restApiId())
@@ -58,5 +53,36 @@ export class SimCfnRestApiMethodCreator {
     );
 
     return method;
+  }
+
+  /**
+   * Declare what the method does with a request, taking the method back out
+   * again where the block cannot be applied.
+   *
+   * `PutMethod` has already left a method on the resource by this point, and
+   * an integration real API Gateway refuses would leave that method behind on
+   * a Resource CloudFormation reports as failed. The next deployment of the
+   * corrected template would then be refused for a method that already exists.
+   */
+  private async putIntegration(
+    methodProperties: SimCfnRestApiMethodProperties,
+  ): Promise<void> {
+    try {
+      const integrationInput = methodProperties.putIntegrationInput();
+
+      if (integrationInput !== undefined) {
+        await this.apiGateway.putIntegration({ input: integrationInput });
+      }
+    } catch (error) {
+      await this.apiGateway.deleteMethod({
+        input: {
+          restApiId: methodProperties.restApiId(),
+          resourceId: methodProperties.resourceId(),
+          httpMethod: methodProperties.httpMethod(),
+        },
+      });
+
+      throw error;
+    }
   }
 }

--- a/src/service/apigateway/cfn/method/sim-cfn-rest-api-method-properties.ts
+++ b/src/service/apigateway/cfn/method/sim-cfn-rest-api-method-properties.ts
@@ -1,0 +1,145 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimPutIntegrationCommandInput } from "../../command/method/method.command.js";
+import type { SimPutMethodCommandInput } from "../../command/method/method.command.js";
+import { SimCfnApiGatewayPropertyParser } from "../sim-cfn-api-gateway-property-parser.js";
+import { SimCfnRestApiIntegrationProperties } from "./sim-cfn-rest-api-integration-properties.js";
+
+/**
+ * The AWS::ApiGateway::Method properties this simulation deploys.
+ *
+ * `AuthorizerId`, `AuthorizationScopes`, `RequestParameters`,
+ * `RequestModels`, `RequestValidatorId` and `MethodResponses` are left out, so
+ * a template carrying one has it recorded against the Resource. A method
+ * asking to be authorized is refused by `AuthorizationType` before any of them
+ * matters.
+ */
+const simulatedProperties = [
+  "RestApiId",
+  "ResourceId",
+  "HttpMethod",
+  "AuthorizationType",
+  "ApiKeyRequired",
+  "OperationName",
+  "Integration",
+];
+
+interface SimCfnRestApiMethodPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::ApiGateway::Method CloudFormation properties into the PutMethod
+ * and PutIntegration input the method creator needs.
+ */
+export class SimCfnRestApiMethodProperties {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly propertyParser = new SimCfnApiGatewayPropertyParser({
+    resourceType: "AWS::ApiGateway::Method",
+    simulated: simulatedProperties,
+  });
+
+  constructor(properties: SimCfnRestApiMethodPropertiesProperties) {
+    this.resource = properties.resource;
+    this.properties = properties.properties;
+
+    this.propertyParser.ignoreUnsimulated(this.resource, this.properties);
+  }
+
+  /**
+   * The API this method belongs to, which a template reaches with a `Ref` on
+   * its AWS::ApiGateway::RestApi.
+   */
+  restApiId(): string {
+    return this.propertyParser.requiredString(
+      this.resource,
+      this.properties["RestApiId"],
+      "RestApiId",
+    );
+  }
+
+  /**
+   * The node of the path tree this method is declared on, which a template
+   * reaches with a `Ref` on an AWS::ApiGateway::Resource or with
+   * `Fn::GetAtt RootResourceId` for a method on the root.
+   */
+  resourceId(): string {
+    return this.propertyParser.requiredString(
+      this.resource,
+      this.properties["ResourceId"],
+      "ResourceId",
+    );
+  }
+
+  /**
+   * The HTTP verb this method answers, which is `ANY` for every verb the node
+   * declares no method of its own for.
+   */
+  httpMethod(): string {
+    return this.propertyParser.requiredString(
+      this.resource,
+      this.properties["HttpMethod"],
+      "HttpMethod",
+    );
+  }
+
+  /**
+   * The PutMethod input this Resource asks for.
+   *
+   * `AuthorizationType` and `ApiKeyRequired` are passed through as the
+   * template wrote them, so a method asking for an authorizer or an API key is
+   * refused by PutMethod with the reason it refuses it.
+   */
+  putMethodInput(): SimPutMethodCommandInput {
+    return {
+      restApiId: this.restApiId(),
+      resourceId: this.resourceId(),
+      httpMethod: this.httpMethod(),
+      authorizationType: this.propertyParser.optionalString(
+        this.resource,
+        this.properties["AuthorizationType"],
+        "AuthorizationType",
+      ),
+      apiKeyRequired: this.propertyParser.optionalBoolean(
+        this.resource,
+        this.properties["ApiKeyRequired"],
+        "ApiKeyRequired",
+      ),
+      operationName: this.propertyParser.optionalString(
+        this.resource,
+        this.properties["OperationName"],
+        "OperationName",
+      ),
+    };
+  }
+
+  /**
+   * The PutIntegration input the method's `Integration` block asks for, where
+   * it declares one.
+   *
+   * A method without one is a method real API Gateway answers 500 for, and a
+   * template can leave it out, so the absence is carried through rather than
+   * refused.
+   */
+  putIntegrationInput(): SimPutIntegrationCommandInput | undefined {
+    const integration = this.propertyParser.optionalRecord(
+      this.resource,
+      this.properties["Integration"],
+      "Integration",
+    );
+
+    if (integration === undefined) {
+      return undefined;
+    }
+
+    return new SimCfnRestApiIntegrationProperties({
+      resource: this.resource,
+      properties: integration,
+      restApiId: this.restApiId(),
+      resourceId: this.resourceId(),
+      httpMethod: this.httpMethod(),
+    }).putIntegrationInput();
+  }
+}

--- a/src/service/apigateway/cfn/resource/sim-cfn-rest-api-resource-creator.ts
+++ b/src/service/apigateway/cfn/resource/sim-cfn-rest-api-resource-creator.ts
@@ -1,0 +1,53 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimRestApiResource } from "../../api/resource/sim-rest-api-resource.js";
+import type { SimApiGateway } from "../../sim-api-gateway.js";
+import { SimCfnRestApiResourceProperties } from "./sim-cfn-rest-api-resource-properties.js";
+
+interface SimCfnRestApiResourceCreatorProperties {
+  readonly apiGateway: SimApiGateway;
+}
+
+/**
+ * Creates the nodes of a REST API's path tree from AWS::ApiGateway::Resource
+ * Resources.
+ *
+ * A node names its parent, so CloudFormation creates the tree from the root
+ * down, in the order the `Ref`s between the Resources give it.
+ */
+export class SimCfnRestApiResourceCreator {
+  private readonly apiGateway: SimApiGateway;
+
+  constructor(properties: SimCfnRestApiResourceCreatorProperties) {
+    this.apiGateway = properties.apiGateway;
+  }
+
+  /**
+   * Create a path tree node from an AWS::ApiGateway::Resource Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimRestApiResource> {
+    const resourceProperties = new SimCfnRestApiResourceProperties({
+      resource,
+      properties,
+    });
+    const restApiId = resourceProperties.restApiId();
+
+    const created = await this.apiGateway.createResource({
+      input: resourceProperties.createResourceInput(),
+    });
+
+    const apiResource = this.apiGateway
+      .findRestApi(restApiId)
+      ?.resources.find(created.id);
+    assertDefined(
+      apiResource,
+      `sim REST API resource ${created.id} after CloudFormation creation`,
+    );
+
+    return apiResource;
+  }
+}

--- a/src/service/apigateway/cfn/resource/sim-cfn-rest-api-resource-properties.ts
+++ b/src/service/apigateway/cfn/resource/sim-cfn-rest-api-resource-properties.ts
@@ -1,0 +1,71 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCreateResourceCommandInput } from "../../command/resource/resource.command.js";
+import { SimCfnApiGatewayPropertyParser } from "../sim-cfn-api-gateway-property-parser.js";
+
+/**
+ * The AWS::ApiGateway::Resource properties this simulation deploys, which is
+ * every property the Resource type has.
+ */
+const simulatedProperties = ["RestApiId", "ParentId", "PathPart"];
+
+interface SimCfnRestApiResourcePropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::ApiGateway::Resource CloudFormation properties into the
+ * CreateResource input the resource creator needs.
+ */
+export class SimCfnRestApiResourceProperties {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly propertyParser = new SimCfnApiGatewayPropertyParser({
+    resourceType: "AWS::ApiGateway::Resource",
+    simulated: simulatedProperties,
+  });
+
+  constructor(properties: SimCfnRestApiResourcePropertiesProperties) {
+    this.resource = properties.resource;
+    this.properties = properties.properties;
+
+    this.propertyParser.ignoreUnsimulated(this.resource, this.properties);
+  }
+
+  /**
+   * The API this node belongs to, which a template reaches with a `Ref` on its
+   * AWS::ApiGateway::RestApi.
+   */
+  restApiId(): string {
+    return this.propertyParser.requiredString(
+      this.resource,
+      this.properties["RestApiId"],
+      "RestApiId",
+    );
+  }
+
+  /**
+   * The CreateResource input this Resource asks for.
+   *
+   * `ParentId` is the root resource id a template reads with
+   * `Fn::GetAtt RootResourceId`, or a `Ref` to the resource above this one.
+   * A path part real API Gateway refuses is refused by CreateResource with the
+   * reason it refuses it.
+   */
+  createResourceInput(): SimCreateResourceCommandInput {
+    return {
+      restApiId: this.restApiId(),
+      parentId: this.propertyParser.requiredString(
+        this.resource,
+        this.properties["ParentId"],
+        "ParentId",
+      ),
+      pathPart: this.propertyParser.requiredString(
+        this.resource,
+        this.properties["PathPart"],
+        "PathPart",
+      ),
+    };
+  }
+}

--- a/src/service/apigateway/cfn/sim-cfn-api-gateway-property-parser.ts
+++ b/src/service/apigateway/cfn/sim-cfn-api-gateway-property-parser.ts
@@ -1,0 +1,126 @@
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimCfnApiGatewayScalarValues } from "./sim-cfn-api-gateway-scalar-values.js";
+
+interface SimCfnApiGatewayPropertyParserProperties {
+  readonly resourceType: string;
+  readonly simulated: readonly string[];
+}
+
+/**
+ * Reads the AWS::ApiGateway::* CloudFormation properties of one Resource type:
+ * which of them are acted on, and, through the value parsing it inherits, what
+ * shape each of those has to be.
+ *
+ * Each Resource type states the properties it simulates, and every other
+ * property is recorded against the Resource and left out of what is created.
+ * An allow-list rather than a list of known-unsimulated properties is what
+ * keeps a template from quietly deploying an API that looks configured to the
+ * template that configured it and unconfigured to every request it serves. The
+ * API is created either way, and the record says which of the two it is.
+ *
+ * The Resource type is carried here because five of them are created, and a
+ * record naming the wrong one would send a reader to the wrong template entry.
+ */
+export class SimCfnApiGatewayPropertyParser extends SimCfnApiGatewayScalarValues {
+  private readonly simulated: readonly string[];
+
+  constructor(properties: SimCfnApiGatewayPropertyParserProperties) {
+    super(properties.resourceType);
+    this.simulated = properties.simulated;
+  }
+
+  /**
+   * Record every property this Resource type does not simulate.
+   *
+   * A property whose only simulated value is one of the values it can take,
+   * such as `AuthorizationType`, counts as simulated here and is refused
+   * further down by the API Gateway command that receives it, which is where
+   * the reason lives.
+   *
+   * The path prefix is what a nested block passes, so a method's ignored
+   * `Integration` properties are recorded under the block they came from
+   * rather than beside the method's own.
+   */
+  ignoreUnsimulated(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+    pathPrefix = "",
+  ): void {
+    for (const name of Object.keys(properties)) {
+      if (!this.simulated.includes(name)) {
+        resource.ignoreProperty(
+          `${pathPrefix}${name}`,
+          this.unsimulatedPropertyReason(name),
+        );
+      }
+    }
+  }
+
+  /**
+   * Parse a property value that must be a record of further properties when
+   * present, which is the shape a method's `Integration` takes.
+   */
+  optionalRecord(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+    expected = "an object",
+  ): SimCfnTemplateValueRecord | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+      throw this.invalidPropertyError(resource, label, expected);
+    }
+
+    return value;
+  }
+
+  /**
+   * Parse a property value that must be an object of strings when present,
+   * which is the shape a stage's `Variables` takes.
+   */
+  optionalStringMap(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): Record<string, string> | undefined {
+    const record = this.optionalRecord(
+      resource,
+      value,
+      label,
+      "an object of strings",
+    );
+
+    if (record === undefined) {
+      return undefined;
+    }
+
+    return Object.fromEntries(
+      Object.entries(record).map(([name, entry]) => [
+        name,
+        this.requiredString(resource, entry, `${label}.${name}`),
+      ]),
+    );
+  }
+
+  /**
+   * Say why a property this simulator does not model was left out.
+   *
+   * The simulated names are listed because an API Gateway Resource type has
+   * many more properties than this creates the API from, so what it can act on
+   * is the shorter and more useful half to read.
+   */
+  private unsimulatedPropertyReason(label: string): string {
+    return (
+      `${this.resourceType} property ${label} is not simulated, so the ` +
+      `Resource is created without it and behaves differently here than on ` +
+      `AWS. The simulated properties are ${this.simulated.join(", ")}.`
+    );
+  }
+}

--- a/src/service/apigateway/cfn/sim-cfn-api-gateway-resource-deleter.ts
+++ b/src/service/apigateway/cfn/sim-cfn-api-gateway-resource-deleter.ts
@@ -1,0 +1,59 @@
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimRestApi } from "../api/sim-rest-api.js";
+import type { SimApiGateway } from "../sim-api-gateway.js";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import { SimCfnRestApiPartDeleter } from "./sim-cfn-rest-api-part-deleter.js";
+
+interface SimCfnApiGatewayResourceDeleterProperties {
+  readonly apiGateway: SimApiGateway;
+}
+
+/**
+ * Deletes the simulated API Gateway REST API resources a CloudFormation Stack
+ * created.
+ *
+ * The API itself is the only Resource type addressed by nothing but its own
+ * object. Everything else is a part of an API, and is deleted by
+ * SimCfnRestApiPartDeleter, which knows to find the API first.
+ *
+ * A deployment is the one part with no delete of its own. API Gateway deletes
+ * one, and this simulation has no command for it, so the Resource is reported
+ * as a deletion nothing carried out. The deployment goes when its API does,
+ * which is the same Stack teardown a moment later.
+ */
+export class SimCfnApiGatewayResourceDeleter {
+  private readonly apiGateway: SimApiGateway;
+  private readonly partDeleter: SimCfnRestApiPartDeleter;
+
+  constructor(properties: SimCfnApiGatewayResourceDeleterProperties) {
+    this.apiGateway = properties.apiGateway;
+    this.partDeleter = new SimCfnRestApiPartDeleter(properties);
+  }
+
+  /**
+   * Delete a simulated API Gateway REST API resource created from a
+   * CloudFormation Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<void> {
+    if (resourceTypeName !== "RestApi") {
+      await this.partDeleter.delete(resourceTypeName, resource, properties);
+
+      return;
+    }
+
+    const restApi = resource.simResource as SimRestApi | undefined;
+    assertDefined(
+      restApi,
+      `sim REST API for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    await this.apiGateway.deleteRestApi({
+      input: { restApiId: restApi.apiId },
+    });
+  }
+}

--- a/src/service/apigateway/cfn/sim-cfn-api-gateway-resource-factory.ts
+++ b/src/service/apigateway/cfn/sim-cfn-api-gateway-resource-factory.ts
@@ -1,0 +1,129 @@
+import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCloudFormationResourceDeleteContext } from "../../cloudformation/resource/sim-cfn-resource.type.js";
+import type { SimApiGateway } from "../sim-api-gateway.js";
+import { SimCfnRestApiCreator } from "./api/sim-cfn-rest-api-creator.js";
+import { SimCfnRestApiDeploymentCreator } from "./deployment/sim-cfn-rest-api-deployment-creator.js";
+import { SimCfnRestApiMethodCreator } from "./method/sim-cfn-rest-api-method-creator.js";
+import { SimCfnRestApiResourceCreator } from "./resource/sim-cfn-rest-api-resource-creator.js";
+import { SimCfnApiGatewayResourceDeleter } from "./sim-cfn-api-gateway-resource-deleter.js";
+import { SimCfnRestApiStageCreator } from "./stage/sim-cfn-rest-api-stage-creator.js";
+
+/**
+ * The Resource types belonging to the parts of a REST API this simulation
+ * leaves alone, and what a reader should know about each group.
+ */
+const unsupportedReasons = new Map([
+  ["Authorizer", "authorizing a method is not simulated"],
+  ["ApiKey", "API keys and usage plans are not simulated"],
+  ["UsagePlan", "API keys and usage plans are not simulated"],
+  ["UsagePlanKey", "API keys and usage plans are not simulated"],
+  ["RequestValidator", "request validation is not simulated"],
+  ["Model", "request and response models are not simulated"],
+  ["DomainName", "custom domain names are not simulated"],
+  ["DomainNameV2", "custom domain names are not simulated"],
+  ["BasePathMapping", "custom domain names are not simulated"],
+  ["BasePathMappingV2", "custom domain names are not simulated"],
+  [
+    "Account",
+    "the Account-wide CloudWatch role is not simulated, and nothing here " +
+      "logs a request to CloudWatch",
+  ],
+]);
+
+interface SimApiGatewayCfnResourceFactoryProperties {
+  readonly apiGateway: SimApiGateway;
+}
+
+/**
+ * CloudFormation Resource factory for simulated API Gateway REST API
+ * resources.
+ */
+export class SimApiGatewayCfnResourceFactory implements SimCfnServiceResourceFactory {
+  private readonly apiCreator: SimCfnRestApiCreator;
+  private readonly resourceCreator: SimCfnRestApiResourceCreator;
+  private readonly methodCreator: SimCfnRestApiMethodCreator;
+  private readonly deploymentCreator: SimCfnRestApiDeploymentCreator;
+  private readonly stageCreator: SimCfnRestApiStageCreator;
+  private readonly deleter: SimCfnApiGatewayResourceDeleter;
+
+  constructor(properties: SimApiGatewayCfnResourceFactoryProperties) {
+    this.apiCreator = new SimCfnRestApiCreator(properties);
+    this.resourceCreator = new SimCfnRestApiResourceCreator(properties);
+    this.methodCreator = new SimCfnRestApiMethodCreator(properties);
+    this.deploymentCreator = new SimCfnRestApiDeploymentCreator(properties);
+    this.stageCreator = new SimCfnRestApiStageCreator(properties);
+    this.deleter = new SimCfnApiGatewayResourceDeleter(properties);
+  }
+
+  /**
+   * Create a simulated API Gateway REST API resource from a CloudFormation
+   * Resource.
+   *
+   * Authorizers, API keys, usage plans, request validators, models, custom
+   * domain names and the Account-wide CloudWatch role are all reported as
+   * unsupported rather than quietly treated as deployed. CDK writes the
+   * `Account` Resource and its role beside a default `RestApi`, so a stack
+   * carrying one deploys with that Resource recorded and the API served.
+   */
+  async create(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<object | undefined> {
+    const properties = context.resolvedProperties ?? resource.properties;
+
+    switch (resourceTypeName) {
+      case "RestApi": {
+        return await this.apiCreator.create(resource, properties);
+      }
+      case "Resource": {
+        return await this.resourceCreator.create(resource, properties);
+      }
+      case "Method": {
+        return await this.methodCreator.create(resource, properties);
+      }
+      case "Deployment": {
+        return await this.deploymentCreator.create(resource, properties);
+      }
+      case "Stage": {
+        return await this.stageCreator.create(resource, properties);
+      }
+      default: {
+        throw new Error(
+          `Unsupported sim API Gateway CloudFormation Resource ` +
+            `${resourceTypeName}${this.unsupportedReason(resourceTypeName)}`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Delete a simulated API Gateway REST API resource created from a
+   * CloudFormation Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceDeleteContext,
+  ): Promise<void> {
+    await this.deleter.delete(
+      resourceTypeName,
+      resource,
+      context.resolvedProperties ?? resource.properties,
+    );
+  }
+
+  /**
+   * Say why a Resource type is unsupported when there is more to say than that
+   * nothing creates it yet.
+   */
+  private unsupportedReason(resourceTypeName: string): string {
+    const reason = unsupportedReasons.get(resourceTypeName);
+
+    return reason === undefined ? "" : `, because ${reason}`;
+  }
+}

--- a/src/service/apigateway/cfn/sim-cfn-api-gateway-scalar-values.ts
+++ b/src/service/apigateway/cfn/sim-cfn-api-gateway-scalar-values.ts
@@ -1,0 +1,98 @@
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValue } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+/**
+ * Reads the single-value shapes an AWS::ApiGateway::* property can take.
+ *
+ * The objects and the allow-list of properties are
+ * `SimCfnApiGatewayPropertyParser` above this, and they are built out of these
+ * readers, so the rules for what one string or one boolean may be are stated
+ * once whether it stands alone or sits in an object.
+ *
+ * The Resource type is carried so a message names the template entry a reader
+ * has to go and fix.
+ */
+export class SimCfnApiGatewayScalarValues {
+  protected readonly resourceType: string;
+
+  constructor(resourceType: string) {
+    this.resourceType = resourceType;
+  }
+
+  /**
+   * Parse a property value that must be a string when present.
+   */
+  optionalString(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): string | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value !== "string") {
+      throw this.invalidPropertyError(resource, label, "a string");
+    }
+
+    return value;
+  }
+
+  /**
+   * Parse a property value that has to be there and has to be a string.
+   */
+  requiredString(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): string {
+    const parsed = this.optionalString(resource, value, label);
+
+    if (parsed === undefined) {
+      throw this.invalidPropertyError(resource, label, "a string");
+    }
+
+    return parsed;
+  }
+
+  /**
+   * Parse a property value that must be a boolean when present.
+   *
+   * CloudFormation carries template booleans as the strings "true" and "false"
+   * in places, so both forms are accepted, as CloudFormation itself accepts
+   * them.
+   */
+  optionalBoolean(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): boolean | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value === "boolean") {
+      return value;
+    }
+
+    if (value === "true" || value === "false") {
+      return value === "true";
+    }
+
+    throw this.invalidPropertyError(resource, label, "a boolean");
+  }
+
+  /**
+   * Build the diagnostic error for a malformed property value.
+   */
+  invalidPropertyError(
+    resource: SimCfnResource,
+    label: string,
+    expected: string,
+  ): TypeError {
+    return new TypeError(
+      `Invalid ${this.resourceType} ${resource.logicalId}: ` +
+        `${label} must be ${expected}`,
+    );
+  }
+}

--- a/src/service/apigateway/cfn/sim-cfn-rest-api-deploy.iso.test.ts
+++ b/src/service/apigateway/cfn/sim-cfn-rest-api-deploy.iso.test.ts
@@ -11,6 +11,10 @@ import {
 } from "../../../../test/apigateway/cfn-deploy.js";
 import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
 import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import {
+  simCfnRestApiMethodLogicalId,
+  simCfnRestApiResourceLogicalId,
+} from "./sim-cfn-rest-api-template-ids.js";
 import { simCfnRestApiTemplateFactory } from "./sim-cfn-rest-api-template.factory.js";
 
 /**
@@ -169,12 +173,25 @@ describe("API Gateway REST API CloudFormation deployment", () => {
             Value: { "Fn::GetAtt": ["Api", "RootResourceId"] },
           },
           OrdersResourceId: {
-            Value: { "Fn::GetAtt": ["Resourceorders", "ResourceId"] },
+            Value: {
+              "Fn::GetAtt": [
+                simCfnRestApiResourceLogicalId(["orders"]),
+                "ResourceId",
+              ],
+            },
           },
           DeploymentId: {
             Value: { "Fn::GetAtt": ["Deployment", "DeploymentId"] },
           },
           StageName: { Value: { Ref: "Stage" } },
+          MethodRef: {
+            Value: {
+              Ref: simCfnRestApiMethodLogicalId({
+                httpMethod: "GET",
+                path: ["orders"],
+              }),
+            },
+          },
         },
       }),
     );
@@ -200,6 +217,13 @@ describe("API Gateway REST API CloudFormation deployment", () => {
       stack.getResource("Deployment")?.refValue,
     );
     assertIdentical(stack.outputs.get("StageName")?.value, "prod");
+
+    // And a method answers with its logical id, since a REST API method has no
+    // id of its own and CloudFormation's own fallback is what answers
+    assertIdentical(
+      stack.outputs.get("MethodRef")?.value,
+      simCfnRestApiMethodLogicalId({ httpMethod: "GET", path: ["orders"] }),
+    );
   });
 
   it("carries the stage variables and descriptions the template gave", async () => {
@@ -275,6 +299,7 @@ describe("API Gateway REST API CloudFormation deployment", () => {
     const apiId = stack.getResource("Api")?.refValue;
     assertTypeString(apiId);
     const deploymentId = stack.getResource("Deployment")?.refValue;
+    assertTypeString(deploymentId);
 
     // When the API is read back and both stages are requested
     const restApi = simAws.apiGateway().findRestApi(apiId);

--- a/src/service/apigateway/cfn/sim-cfn-rest-api-deploy.iso.test.ts
+++ b/src/service/apigateway/cfn/sim-cfn-rest-api-deploy.iso.test.ts
@@ -1,0 +1,296 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import {
+  deployRestApi,
+  simAwsInEuWest2,
+} from "../../../../test/apigateway/cfn-deploy.js";
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import { simCfnRestApiTemplateFactory } from "./sim-cfn-rest-api-template.factory.js";
+
+/**
+ * A handler reporting the resource path that served the request and the path
+ * parameters it captured, so a test with several methods can tell them apart.
+ */
+const routeReportingHandler = `
+exports.handler = async (event) => ({
+  statusCode: 200,
+  headers: { "content-type": "text/plain" },
+  body: event.httpMethod + " " + event.resource
+    + " " + JSON.stringify(event.pathParameters ?? {}),
+});
+`;
+
+function localUrl(apiUrl: string, path: string): string {
+  return new SimAwsLocalUrl({ input: `${apiUrl}${path}` }).toString();
+}
+
+describe("API Gateway REST API CloudFormation deployment", () => {
+  it("serves a request through a deployed API, resource and method", async () => {
+    // Given a template declaring an API, a path tree, a method with its
+    // integration, a deployment and a stage in front of a Lambda function
+    const simAws = simAwsInEuWest2();
+    const stack = await deployRestApi(
+      simAws,
+      simCfnRestApiTemplateFactory.make({
+        handlerSource: routeReportingHandler,
+        methods: [{ httpMethod: "GET", path: ["orders", "{orderId}"] }],
+      }),
+    );
+
+    // When the deployed endpoint is requested
+    const apiUrl = stack.outputs.get("ApiUrl")?.value;
+    assertTypeString(apiUrl);
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(apiUrl, "orders/YL-1"),
+    );
+
+    // Then the request reached the integration's function through the method
+    assertIdentical(response.status, 200);
+    assertIdentical(
+      await response.text(),
+      'GET /orders/{orderId} {"orderId":"YL-1"}',
+    );
+  });
+
+  it("serves the stage segment CDK builds the API's URL with", async () => {
+    // Given a template whose stage is not the one CDK names by default
+    const simAws = simAwsInEuWest2();
+    const stack = await deployRestApi(
+      simAws,
+      simCfnRestApiTemplateFactory.make({
+        handlerSource: routeReportingHandler,
+        methods: [{ httpMethod: "GET", path: ["orders"] }],
+        stageName: "live",
+      }),
+    );
+
+    // When the URL the template published is requested
+    const apiUrl = stack.outputs.get("ApiUrl")?.value;
+    assertTypeString(apiUrl);
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(apiUrl, "orders"),
+    );
+
+    // Then the stage is a path segment of it, and the request was served
+    assertTypeString(apiUrl);
+    expect(apiUrl).toContain("/live/");
+    assertIdentical(response.status, 200);
+    assertIdentical(await response.text(), "GET /orders {}");
+  });
+
+  it("hangs several methods off one path tree", async () => {
+    // Given a template with methods on the root, on a shared node, and on a
+    // node below it
+    const simAws = simAwsInEuWest2();
+    const stack = await deployRestApi(
+      simAws,
+      simCfnRestApiTemplateFactory.make({
+        handlerSource: routeReportingHandler,
+        methods: [
+          { httpMethod: "GET", path: [] },
+          { httpMethod: "GET", path: ["orders"] },
+          { httpMethod: "POST", path: ["orders"] },
+          { httpMethod: "GET", path: ["orders", "{orderId}"] },
+        ],
+      }),
+    );
+    const apiUrl = stack.outputs.get("ApiUrl")?.value;
+    assertTypeString(apiUrl);
+    const http = new SimAwsHttp({ simAws });
+
+    // When each is requested
+    const root = await http.fetch(localUrl(apiUrl, ""));
+    const list = await http.fetch(localUrl(apiUrl, "orders"));
+    const create = await http.fetch(localUrl(apiUrl, "orders"), {
+      method: "POST",
+    });
+    const read = await http.fetch(localUrl(apiUrl, "orders/YL-1"));
+
+    // Then each reaches the function through the method that matched it, and
+    // the two methods on `/orders` share the one node
+    assertIdentical(await root.text(), "GET / {}");
+    assertIdentical(await list.text(), "GET /orders {}");
+    assertIdentical(await create.text(), "POST /orders {}");
+    assertIdentical(
+      await read.text(),
+      'GET /orders/{orderId} {"orderId":"YL-1"}',
+    );
+  });
+
+  it("serves every verb through a greedy proxy method, as LambdaRestApi does", async () => {
+    // Given the shape CDK's LambdaRestApi synthesizes: an ANY method on a
+    // `{proxy+}` node and another on the root
+    const simAws = simAwsInEuWest2();
+    const stack = await deployRestApi(
+      simAws,
+      simCfnRestApiTemplateFactory.make({
+        handlerSource: routeReportingHandler,
+        methods: [
+          { httpMethod: "ANY", path: [] },
+          { httpMethod: "ANY", path: ["{proxy+}"] },
+        ],
+      }),
+    );
+    const apiUrl = stack.outputs.get("ApiUrl")?.value;
+    assertTypeString(apiUrl);
+    const http = new SimAwsHttp({ simAws });
+
+    // When two verbs are sent to a path nothing declares
+    const read = await http.fetch(localUrl(apiUrl, "orders/YL-1/items"));
+    const write = await http.fetch(localUrl(apiUrl, "orders"), {
+      method: "DELETE",
+    });
+
+    // Then the greedy method caught both, with the rest of the path captured
+    assertIdentical(
+      await read.text(),
+      'GET /{proxy+} {"proxy":"orders/YL-1/items"}',
+    );
+    assertIdentical(await write.text(), 'DELETE /{proxy+} {"proxy":"orders"}');
+  });
+
+  it("answers Ref and Fn::GetAtt with the ids the API allocated", async () => {
+    // Given a deployed API whose outputs read each value a template can take
+    // off the Resources
+    const simAws = simAwsInEuWest2();
+    const stack = await deployRestApi(
+      simAws,
+      simCfnRestApiTemplateFactory.make({
+        methods: [{ httpMethod: "GET", path: ["orders"] }],
+        outputs: {
+          RestApiId: { Value: { "Fn::GetAtt": ["Api", "RestApiId"] } },
+          RootResourceId: {
+            Value: { "Fn::GetAtt": ["Api", "RootResourceId"] },
+          },
+          OrdersResourceId: {
+            Value: { "Fn::GetAtt": ["Resourceorders", "ResourceId"] },
+          },
+          DeploymentId: {
+            Value: { "Fn::GetAtt": ["Deployment", "DeploymentId"] },
+          },
+          StageName: { Value: { Ref: "Stage" } },
+        },
+      }),
+    );
+
+    // When the deployed API is read back
+    const apiId = stack.getResource("Api")?.refValue;
+    assertTypeString(apiId);
+    const restApi = simAws.apiGateway().findRestApi(apiId);
+    assertNonNullable(restApi);
+
+    // Then each output names what the API allocated
+    assertIdentical(stack.outputs.get("RestApiId")?.value, apiId);
+    assertIdentical(
+      stack.outputs.get("RootResourceId")?.value,
+      restApi.rootResource.resourceId,
+    );
+    assertIdentical(
+      stack.outputs.get("OrdersResourceId")?.value,
+      restApi.resources.findByPath("/orders")?.resourceId,
+    );
+    assertIdentical(
+      stack.outputs.get("DeploymentId")?.value,
+      stack.getResource("Deployment")?.refValue,
+    );
+    assertIdentical(stack.outputs.get("StageName")?.value, "prod");
+  });
+
+  it("carries the stage variables and descriptions the template gave", async () => {
+    // Given a stage and a deployment declaring what they are for
+    const simAws = simAwsInEuWest2();
+    const stack = await deployRestApi(
+      simAws,
+      simCfnRestApiTemplateFactory.make({
+        methods: [{ httpMethod: "GET", path: ["orders"] }],
+        apiProperties: { Description: "the orders API" },
+        deploymentProperties: { Description: "deployed by the stack" },
+        stageProperties: {
+          Description: "the production stage",
+          Variables: { catalogue: "v2" },
+        },
+      }),
+    );
+
+    // When the deployed API is read back
+    const apiId = stack.getResource("Api")?.refValue;
+    assertTypeString(apiId);
+    const restApi = simAws.apiGateway().findRestApi(apiId);
+    const stage = restApi?.stages.find("prod");
+
+    // Then each holds them, as one created by an SDK caller would
+    assertNonNullable(restApi);
+    assertNonNullable(stage);
+    assertIdentical(restApi.description, "the orders API");
+    assertIdentical(stage.description, "the production stage");
+    expect(stage.variables).toStrictEqual({ catalogue: "v2" });
+    assertIdentical(
+      restApi.deployments.find(stage.deploymentId)?.description,
+      "deployed by the stack",
+    );
+  });
+
+  it("refuses the generated endpoint when the API disables it", async () => {
+    // Given an API deployed with the generated endpoint turned off
+    const simAws = simAwsInEuWest2();
+    const stack = await deployRestApi(
+      simAws,
+      simCfnRestApiTemplateFactory.make({
+        methods: [{ httpMethod: "GET", path: ["orders"] }],
+        apiProperties: { DisableExecuteApiEndpoint: true },
+      }),
+    );
+
+    // When the generated endpoint is requested
+    const apiUrl = stack.outputs.get("ApiUrl")?.value;
+    assertTypeString(apiUrl);
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(apiUrl, "orders"),
+    );
+
+    // Then it is refused rather than served
+    assertIdentical(response.status, 403);
+    expect(await response.json()).toStrictEqual({ message: "Forbidden" });
+  });
+
+  it("publishes a stage from a deployment that names one", async () => {
+    // Given the older one-Resource form, where the deployment carries a stage
+    // name of its own beside the AWS::ApiGateway::Stage the template declares
+    const simAws = simAwsInEuWest2();
+    const stack = await deployRestApi(
+      simAws,
+      simCfnRestApiTemplateFactory.make({
+        handlerSource: routeReportingHandler,
+        methods: [{ httpMethod: "GET", path: ["orders"] }],
+        stageName: "live",
+        deploymentProperties: { StageName: "prod" },
+      }),
+    );
+    const apiId = stack.getResource("Api")?.refValue;
+    assertTypeString(apiId);
+    const deploymentId = stack.getResource("Deployment")?.refValue;
+
+    // When the API is read back and both stages are requested
+    const restApi = simAws.apiGateway().findRestApi(apiId);
+    assertNonNullable(restApi);
+    const http = new SimAwsHttp({ simAws });
+    const fromDeploymentStage = await http.fetch(
+      localUrl(restApi.invokeUrl("prod"), "/orders"),
+    );
+    const fromStageResource = await http.fetch(
+      localUrl(restApi.invokeUrl("live"), "/orders"),
+    );
+
+    // Then the deployment published its own stage, and both serve the API
+    assertIdentical(restApi.stages.find("prod")?.deploymentId, deploymentId);
+    assertIdentical(restApi.stages.find("live")?.deploymentId, deploymentId);
+    assertIdentical(await fromDeploymentStage.text(), "GET /orders {}");
+    assertIdentical(await fromStageResource.text(), "GET /orders {}");
+  });
+});

--- a/src/service/apigateway/cfn/sim-cfn-rest-api-part-deleter.ts
+++ b/src/service/apigateway/cfn/sim-cfn-rest-api-part-deleter.ts
@@ -1,0 +1,130 @@
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimRestApiResource } from "../api/resource/sim-rest-api-resource.js";
+import type { SimRestApiStage } from "../api/stage/sim-rest-api-stage.js";
+import type { SimApiGateway } from "../sim-api-gateway.js";
+
+interface SimCfnRestApiPartDeleterProperties {
+  readonly apiGateway: SimApiGateway;
+}
+
+/**
+ * Deletes the parts of a REST API a CloudFormation Stack declared as their own
+ * Resources.
+ *
+ * Each is addressed by the API it belongs to and by whatever else names it,
+ * all read from the Resource's own properties, which is where creation read
+ * them from. They still resolve because the API outlives everything declared
+ * on it.
+ *
+ * The Stack tears down in reverse dependency order, so a method goes before
+ * the resource it was declared on and a stage before its deployment. That
+ * matters because deleting a resource takes the subtree with it, and a child
+ * Resource deleted afterwards would name a node the parent's deletion had
+ * already removed.
+ */
+export class SimCfnRestApiPartDeleter {
+  private readonly apiGateway: SimApiGateway;
+
+  constructor(properties: SimCfnRestApiPartDeleterProperties) {
+    this.apiGateway = properties.apiGateway;
+  }
+
+  /**
+   * Delete one part of a REST API, or report a part type nothing deletes.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<void> {
+    const restApiId = this.restApiId(resource, properties);
+
+    switch (resourceTypeName) {
+      case "Resource": {
+        const { resourceId } = this.part<SimRestApiResource>(resource);
+
+        await this.apiGateway.deleteResource({
+          input: { restApiId, resourceId },
+        });
+
+        return;
+      }
+      case "Method": {
+        await this.apiGateway.deleteMethod({
+          input: {
+            restApiId,
+            resourceId: this.property(
+              resource,
+              properties["ResourceId"],
+              "ResourceId",
+            ),
+            httpMethod: this.property(
+              resource,
+              properties["HttpMethod"],
+              "HttpMethod",
+            ),
+          },
+        });
+
+        return;
+      }
+      case "Stage": {
+        const { stageName } = this.part<SimRestApiStage>(resource);
+
+        await this.apiGateway.deleteStage({
+          input: { restApiId, stageName },
+        });
+
+        return;
+      }
+      default: {
+        throw new Error(
+          `Unsupported sim API Gateway CloudFormation Resource ` +
+            `${resourceTypeName} deletion`,
+        );
+      }
+    }
+  }
+
+  /**
+   * The simulated object created for this Resource.
+   */
+  private part<T extends object>(resource: SimCfnResource): T {
+    const part = resource.simResource as T | undefined;
+
+    /* v8 ignore if -- a Resource that was never created is not deleted */
+    if (part === undefined) {
+      throw new TypeError(
+        `sim REST API part for CloudFormation Resource ${resource.logicalId} is missing`,
+      );
+    }
+
+    return part;
+  }
+
+  private restApiId(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): string {
+    return this.property(resource, properties["RestApiId"], "RestApiId");
+  }
+
+  private property(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    name: string,
+  ): string {
+    /* v8 ignore if -- creation refused the Resource without this string */
+    if (typeof value !== "string") {
+      throw new TypeError(
+        `AWS::ApiGateway Resource ${resource.logicalId} requires a ${name} string to delete`,
+      );
+    }
+
+    return value;
+  }
+}

--- a/src/service/apigateway/cfn/sim-cfn-rest-api-properties.iso.test.ts
+++ b/src/service/apigateway/cfn/sim-cfn-rest-api-properties.iso.test.ts
@@ -1,0 +1,227 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertTrue,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import {
+  deployRestApi,
+  deployRestApiFailure,
+  ignoredReasons,
+  simAwsInEuWest2,
+} from "../../../../test/apigateway/cfn-deploy.js";
+import { simCfnRestApiTemplateFactory } from "./sim-cfn-rest-api-template.factory.js";
+
+describe("API Gateway REST API CloudFormation property shapes", () => {
+  it("refuses a property that has to be a string and is not", async () => {
+    // Given an API whose description is a number
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const error = await deployRestApiFailure(
+      simAws,
+      simCfnRestApiTemplateFactory.make({
+        apiProperties: { Description: 42 },
+      }),
+    );
+
+    // Then the stack fails saying what the property has to be
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::ApiGateway::RestApi Api: Description must be a string",
+    );
+  });
+
+  it("refuses a required property the template left out", async () => {
+    // Given an API with no name, which CreateRestApi cannot work without
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const error = await deployRestApiFailure(
+      simAws,
+      simCfnRestApiTemplateFactory.make({
+        apiProperties: { Name: undefined },
+      }),
+    );
+
+    // Then the stack fails naming the property it needed
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::ApiGateway::RestApi Api: Name must be a string",
+    );
+  });
+
+  it("refuses a method whose Integration is not an object", async () => {
+    // Given a method whose integration block is a string
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const error = await deployRestApiFailure(
+      simAws,
+      simCfnRestApiTemplateFactory.make({
+        methodProperties: { Integration: "AWS_PROXY" },
+      }),
+    );
+
+    // Then the stack fails saying what the block has to be
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::ApiGateway::Method MethodGETorders: Integration must be an object",
+    );
+  });
+
+  it("refuses an integration with no URI", async () => {
+    // Given an integration naming no function
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const error = await deployRestApiFailure(
+      simAws,
+      simCfnRestApiTemplateFactory.make({
+        integrationProperties: { Uri: undefined },
+      }),
+    );
+
+    // Then PutIntegration refuses it, since an AWS_PROXY integration with
+    // nothing to proxy to would match requests and hand them nowhere
+    assertStringIncludes(error.message, "PutIntegration requires uri");
+  });
+
+  it("reads a boolean written as a template string", async () => {
+    // Given an API turning its generated endpoint off with the string
+    // CloudFormation carries booleans as in places
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const stack = await deployRestApi(
+      simAws,
+      simCfnRestApiTemplateFactory.make({
+        apiProperties: { DisableExecuteApiEndpoint: "true" },
+      }),
+    );
+
+    // Then it was read as the boolean it stands for
+    const apiId = stack.getResource("Api")?.refValue;
+    assertTypeString(apiId);
+    assertTrue(
+      simAws.apiGateway().findRestApi(apiId)?.disableExecuteApiEndpoint,
+    );
+  });
+
+  it("refuses stage variables that are not strings", async () => {
+    // Given a stage whose variable holds a number
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const error = await deployRestApiFailure(
+      simAws,
+      simCfnRestApiTemplateFactory.make({
+        stageProperties: { Variables: { catalogue: 2 } },
+      }),
+    );
+
+    // Then the stack fails naming the entry
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::ApiGateway::Stage Stage: Variables.catalogue must be a string",
+    );
+  });
+});
+
+describe("API Gateway REST API CloudFormation properties left out", () => {
+  it("records the OpenAPI Body an API is declared with", async () => {
+    // Given an API declaring its resources and methods as a document
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const stack = await deployRestApi(
+      simAws,
+      simCfnRestApiTemplateFactory.make({
+        apiProperties: { Body: { openapi: "3.0.1" }, FailOnWarnings: true },
+      }),
+    );
+
+    // Then the API is created and the document is reported, since nothing here
+    // reads one and the API has only what its sibling Resources declared
+    const apiId = stack.getResource("Api")?.refValue;
+    assertTypeString(apiId);
+    assertNonNullable(simAws.apiGateway().findRestApi(apiId));
+    expect(ignoredReasons(stack)).toStrictEqual([
+      "Api AWS::ApiGateway::RestApi property Body is not simulated, so the " +
+        "Resource is created without it and behaves differently here than on " +
+        "AWS. The simulated properties are Name, Description, " +
+        "DisableExecuteApiEndpoint.",
+      "Api AWS::ApiGateway::RestApi property FailOnWarnings is not simulated, " +
+        "so the Resource is created without it and behaves differently here " +
+        "than on AWS. The simulated properties are Name, Description, " +
+        "DisableExecuteApiEndpoint.",
+    ]);
+  });
+
+  it("records an unsimulated property of a method and of its integration apart", async () => {
+    // Given a method declaring request parameters and an integration
+    // declaring a request template
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const stack = await deployRestApi(
+      simAws,
+      simCfnRestApiTemplateFactory.make({
+        methodProperties: {
+          RequestParameters: { "method.request.querystring.page": false },
+        },
+        integrationProperties: {
+          RequestTemplates: { "application/json": "{}" },
+        },
+      }),
+    );
+
+    // Then each is recorded under the block it was declared in
+    const ignored = stack.ignoredProperties.map((entry) => entry.path);
+    expect(ignored).toStrictEqual([
+      "RequestParameters",
+      "Integration.RequestTemplates",
+    ]);
+    const [, integrationProperty] = stack.ignoredProperties;
+    assertNonNullable(integrationProperty);
+    assertIdentical(
+      integrationProperty.resourceType,
+      "AWS::ApiGateway::Method",
+    );
+    assertStringIncludes(
+      integrationProperty.reason,
+      "AWS::ApiGateway::Method Integration property RequestTemplates is not simulated",
+    );
+  });
+
+  it("records the settings a stage was created without", async () => {
+    // Given a stage asking for throttling and access logs
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const stack = await deployRestApi(
+      simAws,
+      simCfnRestApiTemplateFactory.make({
+        stageProperties: {
+          MethodSettings: [{ HttpMethod: "*", ThrottlingBurstLimit: 10 }],
+          TracingEnabled: true,
+        },
+      }),
+    );
+
+    // Then the stage serves the API and both are reported, since a stage that
+    // looked throttled to the template and was not is the failure to avoid
+    const apiId = stack.getResource("Api")?.refValue;
+    assertTypeString(apiId);
+    assertNonNullable(
+      simAws.apiGateway().findRestApi(apiId)?.stages.find("prod"),
+    );
+    expect(stack.ignoredProperties.map((entry) => entry.path)).toStrictEqual([
+      "MethodSettings",
+      "TracingEnabled",
+    ]);
+  });
+});

--- a/src/service/apigateway/cfn/sim-cfn-rest-api-properties.iso.test.ts
+++ b/src/service/apigateway/cfn/sim-cfn-rest-api-properties.iso.test.ts
@@ -13,7 +13,17 @@ import {
   ignoredReasons,
   simAwsInEuWest2,
 } from "../../../../test/apigateway/cfn-deploy.js";
+import { simCfnRestApiMethodLogicalId } from "./sim-cfn-rest-api-template-ids.js";
 import { simCfnRestApiTemplateFactory } from "./sim-cfn-rest-api-template.factory.js";
+
+/**
+ * The logical ID of the one method the default template carries, which a
+ * message about a malformed property names.
+ */
+const methodLogicalId = simCfnRestApiMethodLogicalId({
+  httpMethod: "GET",
+  path: ["orders"],
+});
 
 describe("API Gateway REST API CloudFormation property shapes", () => {
   it("refuses a property that has to be a string and is not", async () => {
@@ -69,7 +79,8 @@ describe("API Gateway REST API CloudFormation property shapes", () => {
     // Then the stack fails saying what the block has to be
     assertStringIncludes(
       error.message,
-      "Invalid AWS::ApiGateway::Method MethodGETorders: Integration must be an object",
+      `Invalid AWS::ApiGateway::Method ${methodLogicalId}: ` +
+        `Integration must be an object`,
     );
   });
 
@@ -223,5 +234,42 @@ describe("API Gateway REST API CloudFormation properties left out", () => {
       "MethodSettings",
       "TracingEnabled",
     ]);
+  });
+});
+
+describe("API Gateway REST API CloudFormation template logical IDs", () => {
+  it("gives two paths that differ only in punctuation their own Resources", async () => {
+    // Given methods on a literal `proxy` node, a `{proxy}` parameter and a
+    // greedy `{proxy+}`, which spell one path part three ways
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const stack = await deployRestApi(
+      simAws,
+      simCfnRestApiTemplateFactory.make({
+        methods: [
+          { httpMethod: "GET", path: ["orders", "proxy"] },
+          { httpMethod: "GET", path: ["orders", "{proxy}"] },
+          { httpMethod: "GET", path: ["{proxy+}"] },
+        ],
+      }),
+    );
+
+    // Then each is its own node of the tree, rather than one node three
+    // Resources overwrote in turn
+    const apiId = stack.getResource("Api")?.refValue;
+    assertTypeString(apiId);
+    const { resources } = simAws.apiGateway().findRestApi(apiId) ?? {};
+    assertNonNullable(resources);
+    const paths = resources.list().map((resource) => resource.path);
+    expect(new Set(paths)).toStrictEqual(
+      new Set([
+        "/",
+        "/orders",
+        "/orders/proxy",
+        "/orders/{proxy}",
+        "/{proxy+}",
+      ]),
+    );
   });
 });

--- a/src/service/apigateway/cfn/sim-cfn-rest-api-teardown.iso.test.ts
+++ b/src/service/apigateway/cfn/sim-cfn-rest-api-teardown.iso.test.ts
@@ -1,0 +1,111 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  deployRestApi,
+  simAwsInEuWest2,
+} from "../../../../test/apigateway/cfn-deploy.js";
+import type { SimRestApi } from "../api/sim-rest-api.js";
+import {
+  simCfnRestApiMethodLogicalId,
+  simCfnRestApiResourceLogicalId,
+} from "./sim-cfn-rest-api-template-parts.js";
+import { simCfnRestApiTemplateFactory } from "./sim-cfn-rest-api-template.factory.js";
+
+describe("REST API CloudFormation Resource teardown", () => {
+  it("deletes an API after the method, resource, deployment and stage on it", async () => {
+    // Given a deployed REST API in front of a Lambda function, which is the
+    // seven-Resource shape CDK synthesises
+    const simAws = simAwsInEuWest2();
+    const stack = await deployRestApi(
+      simAws,
+      simCfnRestApiTemplateFactory.make({
+        methods: [{ httpMethod: "GET", path: ["orders", "{orderId}"] }],
+      }),
+    );
+
+    const restApi = stack.resources.get("Api")?.simResource as
+      | SimRestApi
+      | undefined;
+    assertNonNullable(restApi);
+
+    // When the Stack's Resources are torn down
+    await stack.teardown();
+
+    // Then the API is gone, with everything under it
+    assertUndefined(simAws.apiGateway().findRestApi(restApi.apiId));
+
+    for (const logicalId of [
+      simCfnRestApiMethodLogicalId({
+        httpMethod: "GET",
+        path: ["orders", "{orderId}"],
+      }),
+      simCfnRestApiResourceLogicalId(["orders", "{orderId}"]),
+      simCfnRestApiResourceLogicalId(["orders"]),
+      "Stage",
+      "Api",
+    ]) {
+      assertIdentical(
+        stack.resources.get(logicalId)?.status,
+        "DELETE_COMPLETE",
+        `${logicalId} status`,
+      );
+    }
+  });
+
+  it("records the deployment as a deletion nothing carried out", async () => {
+    // Given the same Stack
+    const simAws = simAwsInEuWest2();
+    const stack = await deployRestApi(
+      simAws,
+      simCfnRestApiTemplateFactory.make({
+        methods: [{ httpMethod: "GET", path: ["orders"] }],
+      }),
+    );
+
+    // When the Stack's Resources are torn down
+    await stack.teardown();
+
+    // Then the deployment is reported rather than deleted, because API Gateway
+    // deletes one and this simulation has no command for it. The deployment
+    // goes with its API a moment later in the same teardown.
+    const deployment = stack.resources.get("Deployment");
+    assertNonNullable(deployment);
+    assertTrue(deployment.deletionSkipped);
+    assertStringIncludes(
+      deployment.deletionSkippedReason ?? "",
+      "Unsupported sim API Gateway CloudFormation Resource Deployment deletion",
+    );
+  });
+
+  it("deletes the function, its permission and its Role with the API", async () => {
+    // Given the same Stack, whose Lambda half is a function, the permission
+    // API Gateway invokes it under, and the execution Role
+    const simAws = simAwsInEuWest2();
+    const stack = await deployRestApi(
+      simAws,
+      simCfnRestApiTemplateFactory.make({
+        methods: [{ httpMethod: "GET", path: ["orders"] }],
+      }),
+    );
+
+    assertNonNullable(simAws.lambda().getSimFunctionByName("orders"));
+
+    // When the Stack's Resources are torn down
+    await stack.teardown();
+
+    // Then the function and the Role it ran as are both gone
+    assertUndefined(simAws.lambda().getSimFunctionByName("orders"));
+    assertUndefined(simAws.iam().roles.get("orders-role" as never));
+    assertIdentical(
+      stack.resources.get("HandlerPermission")?.status,
+      "DELETE_COMPLETE",
+    );
+  });
+});

--- a/src/service/apigateway/cfn/sim-cfn-rest-api-teardown.iso.test.ts
+++ b/src/service/apigateway/cfn/sim-cfn-rest-api-teardown.iso.test.ts
@@ -15,7 +15,7 @@ import type { SimRestApi } from "../api/sim-rest-api.js";
 import {
   simCfnRestApiMethodLogicalId,
   simCfnRestApiResourceLogicalId,
-} from "./sim-cfn-rest-api-template-parts.js";
+} from "./sim-cfn-rest-api-template-ids.js";
 import { simCfnRestApiTemplateFactory } from "./sim-cfn-rest-api-template.factory.js";
 
 describe("REST API CloudFormation Resource teardown", () => {

--- a/src/service/apigateway/cfn/sim-cfn-rest-api-template-ids.ts
+++ b/src/service/apigateway/cfn/sim-cfn-rest-api-template-ids.ts
@@ -1,0 +1,49 @@
+import type { SimCfnRestApiTemplateMethod } from "./sim-cfn-rest-api-template.factory.js";
+
+/**
+ * The logical IDs the REST API template test factory names its Resources by.
+ *
+ * A path spells its own ID, so two methods under one path name one node and a
+ * test asserting on a node can build the ID from the path it asked for.
+ */
+
+/**
+ * The logical ID of the Resource carrying one path of the template's tree.
+ *
+ * A test asserting on a node names it through here, so the naming stays in one
+ * place. The path spells the ID, so two methods under one path name one node.
+ */
+export function simCfnRestApiResourceLogicalId(
+  path: readonly string[],
+): string {
+  return `Resource${path.map(pathPartLabel).join("")}`;
+}
+
+/**
+ * The logical ID of the Resource carrying one method of the template's API.
+ */
+export function simCfnRestApiMethodLogicalId(
+  method: SimCfnRestApiTemplateMethod,
+): string {
+  return `Method${method.httpMethod}${method.path.map(pathPartLabel).join("")}`;
+}
+
+/**
+ * One path segment as part of a logical ID.
+ *
+ * A logical ID is alphanumeric, so anything else a path part carries is
+ * spelled as its character code rather than dropped, and every segment is
+ * prefixed. Dropping the punctuation and running the segments together would
+ * give `{proxy}` and `{proxy+}` one ID, and give `orders/{id}` and `orders{id}`
+ * another.
+ */
+function pathPartLabel(pathPart: string): string {
+  const label = pathPart.replaceAll(
+    /[^a-zA-Z0-9]/g,
+    (character) =>
+      /* v8 ignore next -- the pattern matches one character, which has a code point */
+      `X${(character.codePointAt(0) ?? 0).toString(16)}`,
+  );
+
+  return `Part${label}`;
+}

--- a/src/service/apigateway/cfn/sim-cfn-rest-api-template-parts.ts
+++ b/src/service/apigateway/cfn/sim-cfn-rest-api-template-parts.ts
@@ -1,8 +1,9 @@
 import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
-import type {
-  SimCfnRestApiTemplateInput,
-  SimCfnRestApiTemplateMethod,
-} from "./sim-cfn-rest-api-template.factory.js";
+import type { SimCfnRestApiTemplateInput } from "./sim-cfn-rest-api-template.factory.js";
+import {
+  simCfnRestApiMethodLogicalId,
+  simCfnRestApiResourceLogicalId,
+} from "./sim-cfn-rest-api-template-ids.js";
 
 /**
  * The Resources under the API in the template test factory, and the logical
@@ -12,27 +13,6 @@ import type {
  * spells one path over several Resources. The factory beside this holds the
  * Resources every template carries whatever its methods are.
  */
-
-/**
- * The logical ID of the Resource carrying one path of the template's tree.
- *
- * A test asserting on a node names it through here, so the naming stays in one
- * place. The path spells the ID, so two methods under one path name one node.
- */
-export function simCfnRestApiResourceLogicalId(
-  path: readonly string[],
-): string {
-  return `Resource${path.map(pathPartLabel).join("")}`;
-}
-
-/**
- * The logical ID of the Resource carrying one method of the template's API.
- */
-export function simCfnRestApiMethodLogicalId(
-  method: SimCfnRestApiTemplateMethod,
-): string {
-  return `Method${method.httpMethod}${method.path.map(pathPartLabel).join("")}`;
-}
 
 /**
  * One AWS::ApiGateway::Resource per node the template's methods need, each
@@ -123,12 +103,4 @@ function resourceIdValue(path: readonly string[]): SimCfnTemplateValueRecord {
  */
 export function methodLogicalIds(input: SimCfnRestApiTemplateInput): string[] {
   return input.methods.map((method) => simCfnRestApiMethodLogicalId(method));
-}
-
-/**
- * One path segment as part of a logical ID, with the braces of a path
- * parameter taken out, since a logical ID is alphanumeric.
- */
-function pathPartLabel(pathPart: string): string {
-  return pathPart.replaceAll(/[^a-zA-Z0-9]/g, "");
 }

--- a/src/service/apigateway/cfn/sim-cfn-rest-api-template-parts.ts
+++ b/src/service/apigateway/cfn/sim-cfn-rest-api-template-parts.ts
@@ -1,0 +1,134 @@
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type {
+  SimCfnRestApiTemplateInput,
+  SimCfnRestApiTemplateMethod,
+} from "./sim-cfn-rest-api-template.factory.js";
+
+/**
+ * The Resources under the API in the template test factory, and the logical
+ * IDs a test names them by.
+ *
+ * The path tree is the half of the template a test varies, because a REST API
+ * spells one path over several Resources. The factory beside this holds the
+ * Resources every template carries whatever its methods are.
+ */
+
+/**
+ * The logical ID of the Resource carrying one path of the template's tree.
+ *
+ * A test asserting on a node names it through here, so the naming stays in one
+ * place. The path spells the ID, so two methods under one path name one node.
+ */
+export function simCfnRestApiResourceLogicalId(
+  path: readonly string[],
+): string {
+  return `Resource${path.map(pathPartLabel).join("")}`;
+}
+
+/**
+ * The logical ID of the Resource carrying one method of the template's API.
+ */
+export function simCfnRestApiMethodLogicalId(
+  method: SimCfnRestApiTemplateMethod,
+): string {
+  return `Method${method.httpMethod}${method.path.map(pathPartLabel).join("")}`;
+}
+
+/**
+ * One AWS::ApiGateway::Resource per node the template's methods need, each
+ * naming its parent by `Ref` and the root by `Fn::GetAtt RootResourceId`.
+ *
+ * Two methods under one path spell the same logical ID, so they share the node
+ * rather than declaring it twice.
+ */
+export function pathResources(
+  input: SimCfnRestApiTemplateInput,
+): SimCfnTemplateValueRecord {
+  const resources: SimCfnTemplateValueRecord = {};
+
+  for (const method of input.methods) {
+    for (const [index, pathPart] of method.path.entries()) {
+      const path = method.path.slice(0, index + 1);
+
+      resources[simCfnRestApiResourceLogicalId(path)] = {
+        Type: "AWS::ApiGateway::Resource",
+        Properties: {
+          RestApiId: { Ref: "Api" },
+          ParentId: resourceIdValue(path.slice(0, -1)),
+          PathPart: pathPart,
+        },
+      };
+    }
+  }
+
+  return resources;
+}
+
+/**
+ * One AWS::ApiGateway::Method per method, each carrying the proxy integration
+ * as a block of its own, the way a template declares one.
+ */
+export function methodResources(
+  input: SimCfnRestApiTemplateInput,
+): SimCfnTemplateValueRecord {
+  const methods: SimCfnTemplateValueRecord = {};
+
+  for (const method of input.methods) {
+    methods[simCfnRestApiMethodLogicalId(method)] = {
+      Type: "AWS::ApiGateway::Method",
+      Properties: {
+        RestApiId: { Ref: "Api" },
+        ResourceId: resourceIdValue(method.path),
+        HttpMethod: method.httpMethod,
+        AuthorizationType: "NONE",
+        Integration: {
+          Type: "AWS_PROXY",
+          IntegrationHttpMethod: "POST",
+          Uri: {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:apigateway:",
+                { Ref: "AWS::Region" },
+                ":lambda:path/2015-03-31/functions/",
+                { "Fn::GetAtt": ["Handler", "Arn"] },
+                "/invocations",
+              ],
+            ],
+          },
+          ...input.integrationProperties,
+        },
+        ...input.methodProperties,
+      },
+    };
+  }
+
+  return methods;
+}
+
+/**
+ * What a template names one node of the tree by, which is the API's root
+ * resource for the empty path and a `Ref` to the node's own Resource
+ * otherwise.
+ */
+function resourceIdValue(path: readonly string[]): SimCfnTemplateValueRecord {
+  return path.length === 0
+    ? { "Fn::GetAtt": ["Api", "RootResourceId"] }
+    : { Ref: simCfnRestApiResourceLogicalId(path) };
+}
+
+/**
+ * The methods the deployment waits for, as CDK's `DependsOn` does, so the
+ * stage is published after everything it serves.
+ */
+export function methodLogicalIds(input: SimCfnRestApiTemplateInput): string[] {
+  return input.methods.map((method) => simCfnRestApiMethodLogicalId(method));
+}
+
+/**
+ * One path segment as part of a logical ID, with the braces of a path
+ * parameter taken out, since a logical ID is alphanumeric.
+ */
+function pathPartLabel(pathPart: string): string {
+  return pathPart.replaceAll(/[^a-zA-Z0-9]/g, "");
+}

--- a/src/service/apigateway/cfn/sim-cfn-rest-api-template.factory.ts
+++ b/src/service/apigateway/cfn/sim-cfn-rest-api-template.factory.ts
@@ -1,0 +1,184 @@
+import { MappedFactory } from "@kensio/part-factory";
+
+import type { CfnTemplateBodyRecord } from "../../cloudformation/template/sim-cfn-template.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import {
+  methodLogicalIds,
+  methodResources,
+  pathResources,
+} from "./sim-cfn-rest-api-template-parts.js";
+
+/**
+ * One method of the template's API, and where in the path tree it hangs.
+ *
+ * The path is the segments under the root, so `[]` is a method on the root
+ * resource and `["orders", "{orderId}"]` is one two nodes down. Methods
+ * sharing a prefix share the nodes that spell it, as a template written by
+ * hand or by CDK does.
+ */
+export interface SimCfnRestApiTemplateMethod {
+  readonly httpMethod: string;
+  readonly path: readonly string[];
+}
+
+/**
+ * What a test asks for when it wants a template deploying a REST API in front
+ * of a Lambda function.
+ *
+ * Seven Resources stand between a test and an API it can call, and most tests
+ * about the API Gateway Resource types are about one property of one of them.
+ * The `*Properties` records are merged in last, so a test states the one
+ * property it is about rather than the whole template.
+ */
+export interface SimCfnRestApiTemplateInput {
+  readonly functionName: string;
+  /** The inline function code every method of the API hands its requests to. */
+  readonly handlerSource: string;
+  readonly methods: readonly SimCfnRestApiTemplateMethod[];
+  readonly stageName: string;
+  readonly apiProperties: SimCfnTemplateValueRecord;
+  /** Applied to every method the template carries. */
+  readonly methodProperties: SimCfnTemplateValueRecord;
+  /** Applied to the `Integration` block of every method. */
+  readonly integrationProperties: SimCfnTemplateValueRecord;
+  readonly deploymentProperties: SimCfnTemplateValueRecord;
+  readonly stageProperties: SimCfnTemplateValueRecord;
+  /** Resources the template carries beyond the ones built here. */
+  readonly resources: SimCfnTemplateValueRecord;
+  readonly outputs: SimCfnTemplateValueRecord;
+}
+
+const assumeRolePolicyDocument = {
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Principal: { Service: "lambda.amazonaws.com" },
+      Action: "sts:AssumeRole",
+    },
+  ],
+};
+
+/**
+ * Builds a template deploying a REST API that proxies to a Lambda function.
+ *
+ * ```typescript
+ * const stack = await simAws.cloudFormation().deployTemplate({
+ *   stackName: "orders-stack",
+ *   template: simCfnRestApiTemplateFactory.make({
+ *     methods: [{ httpMethod: "GET", path: ["orders"] }],
+ *   }),
+ * });
+ * ```
+ *
+ * The `AWS::Lambda::Permission` is the grant CDK writes for a REST API proxy
+ * integration, so a request served through this template is one a real
+ * permission admitted. The `ApiUrl` output is the URL CDK publishes, built
+ * from a `Ref` to the API and a `Ref` to the stage.
+ */
+export const simCfnRestApiTemplateFactory = new MappedFactory<
+  SimCfnRestApiTemplateInput,
+  CfnTemplateBodyRecord
+>(
+  () => ({
+    functionName: "orders",
+    handlerSource: "exports.handler = async () => 'orders';",
+    methods: [{ httpMethod: "GET", path: ["orders"] }],
+    stageName: "prod",
+    apiProperties: {},
+    methodProperties: {},
+    integrationProperties: {},
+    deploymentProperties: {},
+    stageProperties: {},
+    resources: {},
+    outputs: {},
+  }),
+  (input) => ({
+    Resources: {
+      HandlerRole: {
+        Type: "AWS::IAM::Role",
+        Properties: {
+          RoleName: `${input.functionName}-role`,
+          AssumeRolePolicyDocument: assumeRolePolicyDocument,
+        },
+      },
+      Handler: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: input.functionName,
+          Role: { "Fn::GetAtt": ["HandlerRole", "Arn"] },
+          Code: { ZipFile: input.handlerSource },
+          Handler: "index.handler",
+          Runtime: "nodejs20.x",
+        },
+      },
+      HandlerPermission: {
+        Type: "AWS::Lambda::Permission",
+        Properties: {
+          Action: "lambda:InvokeFunction",
+          FunctionName: { "Fn::GetAtt": ["Handler", "Arn"] },
+          Principal: "apigateway.amazonaws.com",
+          SourceArn: {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:execute-api:",
+                { Ref: "AWS::Region" },
+                ":",
+                { Ref: "AWS::AccountId" },
+                ":",
+                { Ref: "Api" },
+                "/*/*/*",
+              ],
+            ],
+          },
+        },
+      },
+      Api: {
+        Type: "AWS::ApiGateway::RestApi",
+        Properties: { Name: "orders", ...input.apiProperties },
+      },
+      ...pathResources(input),
+      ...methodResources(input),
+      Deployment: {
+        Type: "AWS::ApiGateway::Deployment",
+        Properties: {
+          RestApiId: { Ref: "Api" },
+          ...input.deploymentProperties,
+        },
+        DependsOn: methodLogicalIds(input),
+      },
+      Stage: {
+        Type: "AWS::ApiGateway::Stage",
+        Properties: {
+          RestApiId: { Ref: "Api" },
+          DeploymentId: { Ref: "Deployment" },
+          StageName: input.stageName,
+          ...input.stageProperties,
+        },
+      },
+      ...input.resources,
+    },
+    Outputs: {
+      ApiUrl: {
+        Value: {
+          "Fn::Join": [
+            "",
+            [
+              "https://",
+              { Ref: "Api" },
+              ".execute-api.",
+              { Ref: "AWS::Region" },
+              ".",
+              { Ref: "AWS::URLSuffix" },
+              "/",
+              { Ref: "Stage" },
+              "/",
+            ],
+          ],
+        },
+      },
+      ...input.outputs,
+    },
+  }),
+);

--- a/src/service/apigateway/cfn/sim-cfn-rest-api-validation.iso.test.ts
+++ b/src/service/apigateway/cfn/sim-cfn-rest-api-validation.iso.test.ts
@@ -1,0 +1,185 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertTrue,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  deployRestApi,
+  deployRestApiFailure,
+  simAwsInEuWest2,
+} from "../../../../test/apigateway/cfn-deploy.js";
+import { simCfnRestApiTemplateFactory } from "./sim-cfn-rest-api-template.factory.js";
+
+describe("API Gateway REST API CloudFormation refusals", () => {
+  it("refuses a method asking to be authorized", async () => {
+    // Given a method declaring a Lambda authorizer
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const error = await deployRestApiFailure(
+      simAws,
+      simCfnRestApiTemplateFactory.make({
+        methodProperties: { AuthorizationType: "CUSTOM" },
+      }),
+    );
+
+    // Then PutMethod refuses it, rather than serving open a method real AWS
+    // would have gated
+    assertStringIncludes(
+      error.message,
+      "PutMethod authorizationType 'CUSTOM' is not simulated",
+    );
+  });
+
+  it("refuses a method requiring an API key", async () => {
+    // Given a method behind a usage plan
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const error = await deployRestApiFailure(
+      simAws,
+      simCfnRestApiTemplateFactory.make({
+        methodProperties: { ApiKeyRequired: true },
+      }),
+    );
+
+    // Then PutMethod refuses it, since a method here would answer requests
+    // real AWS rejects
+    assertStringIncludes(
+      error.message,
+      "PutMethod apiKeyRequired is not simulated",
+    );
+  });
+
+  it("refuses an integration type that answers from somewhere else", async () => {
+    // Given a mock integration
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const error = await deployRestApiFailure(
+      simAws,
+      simCfnRestApiTemplateFactory.make({
+        integrationProperties: { Type: "MOCK", Uri: undefined },
+      }),
+    );
+
+    // Then PutIntegration refuses it, since only a Lambda proxy integration is
+    // simulated
+    assertStringIncludes(
+      error.message,
+      "PutIntegration type 'MOCK' is not simulated",
+    );
+  });
+
+  it("refuses a path part real API Gateway would refuse", async () => {
+    // Given a node spelling two segments in one path part
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const error = await deployRestApiFailure(
+      simAws,
+      simCfnRestApiTemplateFactory.make({
+        methods: [{ httpMethod: "GET", path: ["orders/open"] }],
+      }),
+    );
+
+    // Then CreateResource refuses it with the reason it refuses it
+    assertStringIncludes(error.message, "Path part 'orders/open' is invalid");
+  });
+
+  it("refuses a stage naming a deployment the API has not got", async () => {
+    // Given a stage whose DeploymentId names nothing, which is what a `Ref` to
+    // a Resource this simulation skipped resolves to
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const error = await deployRestApiFailure(
+      simAws,
+      simCfnRestApiTemplateFactory.make({
+        stageProperties: { DeploymentId: "SomeSkippedResource" },
+      }),
+    );
+
+    // Then CreateStage refuses it, rather than publishing a stage that serves
+    // nothing
+    assertStringIncludes(
+      error.message,
+      "Invalid deployment identifier specified: SomeSkippedResource",
+    );
+  });
+});
+
+describe("API Gateway REST API CloudFormation Resource types left out", () => {
+  it("records the Account Resource CDK writes beside a RestApi", async () => {
+    // Given the Account-wide CloudWatch role CDK synthesises with a default
+    // RestApi
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const stack = await deployRestApi(
+      simAws,
+      simCfnRestApiTemplateFactory.make({
+        resources: {
+          ApiAccount: {
+            Type: "AWS::ApiGateway::Account",
+            Properties: {
+              CloudWatchRoleArn: { "Fn::GetAtt": ["HandlerRole", "Arn"] },
+            },
+          },
+        },
+      }),
+    );
+
+    // Then the API deploys and the Account Resource is reported, since nothing
+    // here logs a request to CloudWatch
+    const apiId = stack.getResource("Api")?.refValue;
+    assertTypeString(apiId);
+    assertNonNullable(simAws.apiGateway().findRestApi(apiId));
+
+    const account = stack.resources.get("ApiAccount");
+    assertNonNullable(account);
+    assertTrue(account.skipped);
+    assertStringIncludes(
+      account.skippedReason ?? "",
+      "Unsupported sim API Gateway CloudFormation Resource Account, because " +
+        "the Account-wide CloudWatch role is not simulated",
+    );
+    assertIdentical(account.status, "CREATE_COMPLETE");
+  });
+
+  it("records an authorizer as a Resource nothing created", async () => {
+    // Given a template declaring a Lambda authorizer
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const stack = await deployRestApi(
+      simAws,
+      simCfnRestApiTemplateFactory.make({
+        resources: {
+          Authorizer: {
+            Type: "AWS::ApiGateway::Authorizer",
+            Properties: {
+              RestApiId: { Ref: "Api" },
+              Name: "session-cookie",
+              Type: "REQUEST",
+            },
+          },
+        },
+      }),
+    );
+
+    // Then the rest of the stack deploys and the authorizer is reported
+    const authorizer = stack.resources.get("Authorizer");
+    assertNonNullable(authorizer);
+    assertTrue(authorizer.skipped);
+    assertStringIncludes(
+      authorizer.skippedReason ?? "",
+      "Unsupported sim API Gateway CloudFormation Resource Authorizer, " +
+        "because authorizing a method is not simulated",
+    );
+  });
+});

--- a/src/service/apigateway/cfn/sim-cfn-rest-api-validation.iso.test.ts
+++ b/src/service/apigateway/cfn/sim-cfn-rest-api-validation.iso.test.ts
@@ -5,7 +5,7 @@ import {
   assertTrue,
   assertTypeString,
 } from "@kensio/smartass";
-import { describe, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import {
   deployRestApi,
@@ -73,6 +73,31 @@ describe("API Gateway REST API CloudFormation refusals", () => {
       error.message,
       "PutIntegration type 'MOCK' is not simulated",
     );
+  });
+
+  it("takes the method back out when its integration is refused", async () => {
+    // Given the same mock integration, whose method PutMethod has already
+    // declared by the time the integration is read
+    const simAws = simAwsInEuWest2();
+    await deployRestApiFailure(
+      simAws,
+      simCfnRestApiTemplateFactory.make({
+        integrationProperties: { Type: "MOCK", Uri: undefined },
+      }),
+    );
+
+    // When the API the failed stack created is read back
+    const { items } = await simAws.apiGateway().getRestApis({ input: {} });
+    const [created] = items;
+    assertNonNullable(created);
+    const restApi = simAws.apiGateway().findRestApi(created.id);
+
+    // Then the resource carries no method. The corrected template deploys
+    // rather than being refused for a method that already exists.
+    assertNonNullable(restApi);
+    expect(
+      restApi.resources.findByPath("/orders")?.listMethods(),
+    ).toStrictEqual([]);
   });
 
   it("refuses a path part real API Gateway would refuse", async () => {

--- a/src/service/apigateway/cfn/stage/sim-cfn-rest-api-stage-creator.ts
+++ b/src/service/apigateway/cfn/stage/sim-cfn-rest-api-stage-creator.ts
@@ -1,0 +1,52 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimRestApiStage } from "../../api/stage/sim-rest-api-stage.js";
+import type { SimApiGateway } from "../../sim-api-gateway.js";
+import { SimCfnRestApiStageProperties } from "./sim-cfn-rest-api-stage-properties.js";
+
+interface SimCfnRestApiStageCreatorProperties {
+  readonly apiGateway: SimApiGateway;
+}
+
+/**
+ * Creates simulated stages from AWS::ApiGateway::Stage Resources.
+ *
+ * A stage names the deployment it serves, so CloudFormation creates it after
+ * that deployment, which CDK in turn puts after every method of the API.
+ */
+export class SimCfnRestApiStageCreator {
+  private readonly apiGateway: SimApiGateway;
+
+  constructor(properties: SimCfnRestApiStageCreatorProperties) {
+    this.apiGateway = properties.apiGateway;
+  }
+
+  /**
+   * Create a stage from an AWS::ApiGateway::Stage Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimRestApiStage> {
+    const stageProperties = new SimCfnRestApiStageProperties({
+      resource,
+      properties,
+    });
+    const restApiId = stageProperties.restApiId();
+
+    const created = await this.apiGateway.createStage({
+      input: stageProperties.createStageInput(),
+    });
+
+    const stage = this.apiGateway
+      .findRestApi(restApiId)
+      ?.stages.find(created.stageName);
+    assertDefined(
+      stage,
+      `sim REST API stage ${created.stageName} after CloudFormation creation`,
+    );
+
+    return stage;
+  }
+}

--- a/src/service/apigateway/cfn/stage/sim-cfn-rest-api-stage-properties.ts
+++ b/src/service/apigateway/cfn/stage/sim-cfn-rest-api-stage-properties.ts
@@ -1,0 +1,101 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCreateStageCommandInput } from "../../command/stage/stage.command.js";
+import { SimCfnApiGatewayPropertyParser } from "../sim-cfn-api-gateway-property-parser.js";
+
+/**
+ * The AWS::ApiGateway::Stage properties this simulation deploys.
+ *
+ * `MethodSettings`, `AccessLogSetting`, `CanarySetting`, `CacheClusterEnabled`,
+ * `CacheClusterSize`, `ClientCertificateId`, `DocumentationVersion`,
+ * `TracingEnabled` and `Tags` are left out, so a template carrying one has it
+ * recorded against the Resource. None of them is modelled, and a stage that
+ * looked throttled or logged to the template and did neither when serving is
+ * the failure worth avoiding.
+ */
+const simulatedProperties = [
+  "RestApiId",
+  "DeploymentId",
+  "StageName",
+  "Description",
+  "Variables",
+];
+
+interface SimCfnRestApiStagePropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::ApiGateway::Stage CloudFormation properties into the CreateStage
+ * input the stage creator needs.
+ */
+export class SimCfnRestApiStageProperties {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly propertyParser = new SimCfnApiGatewayPropertyParser({
+    resourceType: "AWS::ApiGateway::Stage",
+    simulated: simulatedProperties,
+  });
+
+  constructor(properties: SimCfnRestApiStagePropertiesProperties) {
+    this.resource = properties.resource;
+    this.properties = properties.properties;
+
+    this.propertyParser.ignoreUnsimulated(this.resource, this.properties);
+  }
+
+  /**
+   * The API this stage belongs to, which a template reaches with a `Ref` on
+   * its AWS::ApiGateway::RestApi.
+   */
+  restApiId(): string {
+    return this.propertyParser.requiredString(
+      this.resource,
+      this.properties["RestApiId"],
+      "RestApiId",
+    );
+  }
+
+  /**
+   * The stage's name, which is also what a `Ref` on this Resource returns and
+   * the first path segment of the endpoint it serves on.
+   */
+  stageName(): string {
+    return this.propertyParser.requiredString(
+      this.resource,
+      this.properties["StageName"],
+      "StageName",
+    );
+  }
+
+  /**
+   * The CreateStage input this Resource asks for.
+   *
+   * `DeploymentId` is the `Ref` to the AWS::ApiGateway::Deployment this stage
+   * serves. A deployment id naming nothing on the API is refused by
+   * CreateStage, which is what stops a `Ref` to a Resource this simulation
+   * skipped from publishing a stage that serves nothing.
+   */
+  createStageInput(): SimCreateStageCommandInput {
+    return {
+      restApiId: this.restApiId(),
+      stageName: this.stageName(),
+      deploymentId: this.propertyParser.requiredString(
+        this.resource,
+        this.properties["DeploymentId"],
+        "DeploymentId",
+      ),
+      description: this.propertyParser.optionalString(
+        this.resource,
+        this.properties["Description"],
+        "Description",
+      ),
+      variables: this.propertyParser.optionalStringMap(
+        this.resource,
+        this.properties["Variables"],
+        "Variables",
+      ),
+    };
+  }
+}

--- a/src/service/apigateway/sim-api-gateway-service-principal.ts
+++ b/src/service/apigateway/sim-api-gateway-service-principal.ts
@@ -5,5 +5,10 @@
  * so it lives at the service root rather than inside the serving layer that
  * evaluates the grant. That keeps the API model, which writes the permission
  * in test setup, from reaching into the layer that reads it.
+ *
+ * REST APIs and HTTP APIs are separate services and separate SDK clients, and
+ * they invoke a function as the same principal. A permission granted to it
+ * therefore says nothing about which of the two is calling, which is what the
+ * source ARN says.
  */
 export const simApiGatewayServicePrincipal = "apigateway.amazonaws.com";

--- a/src/service/apigateway/sim-api-gateway.ts
+++ b/src/service/apigateway/sim-api-gateway.ts
@@ -1,5 +1,6 @@
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
 import type { SimRestApi } from "./api/sim-rest-api.js";
+import { SimApiGatewayCfnResourceFactory } from "./cfn/sim-cfn-api-gateway-resource-factory.js";
 import type * as simApiGatewayCommands from "./command/sim-api-gateway-command.types.js";
 import type { SimApiGatewayRequestOptions } from "./command/sim-api-gateway-request-options.js";
 import { SimApiGatewaySdkCommandRouter } from "./sdk/sim-api-gateway-sdk-command-router.js";
@@ -26,6 +27,9 @@ import {
 export class SimApiGateway {
   private readonly commands: SimApiGatewayCommands;
   private readonly sdkRouter = new SimApiGatewaySdkCommandRouter(this);
+  private readonly cfnFactory = new SimApiGatewayCfnResourceFactory({
+    apiGateway: this,
+  });
 
   constructor(properties: SimApiGatewayProperties = {}) {
     this.commands = new SimApiGatewayCommands(properties);
@@ -248,6 +252,13 @@ export class SimApiGateway {
   ): Promise<simApiGatewayCommands.SimDeleteStageCommandOutput> {
     await this.commands.background.sequence();
     return this.commands.stages.deleteStage(command, options);
+  }
+
+  /**
+   * Get this service's CloudFormation Resource factory.
+   */
+  cfnResourceFactory(): SimApiGatewayCfnResourceFactory {
+    return this.cfnFactory;
   }
 
   /**

--- a/src/service/apigatewayv2/api/integration/sim-http-api-lambda-uri.ts
+++ b/src/service/apigatewayv2/api/integration/sim-http-api-lambda-uri.ts
@@ -15,10 +15,17 @@ import { SimApiGatewayV2BadRequest } from "../../error/sim-api-gateway-v2.error.
  * A URI is written either as the bare function ARN or wrapped in an API
  * Gateway invoke path, and both reach the same function. Reading them through
  * one reader is what lets an SDK caller, a template and an imported document
- * write whichever form they write.
+ * write whichever form they write. The string is kept as it was given, because
+ * `GetIntegration` and `GetAuthorizer` echo back what was configured. The
+ * function ARN is held beside it for whatever has to reach the function.
  */
 export class SimHttpApiLambdaUri {
+  /** The URI as it was configured, which is what the API hands back. */
   public readonly uri: string;
+
+  /** The function ARN the URI named, with any wrapper taken off. */
+  public readonly functionArn: string;
+
   public readonly regionName: string;
   public readonly accountId: string;
   public readonly functionName: string;
@@ -30,12 +37,14 @@ export class SimHttpApiLambdaUri {
 
   private constructor(properties: {
     readonly uri: string;
+    readonly functionArn: string;
     readonly regionName: string;
     readonly accountId: string;
     readonly functionName: string;
     readonly qualifier: string | undefined;
   }) {
     this.uri = properties.uri;
+    this.functionArn = properties.functionArn;
     this.regionName = properties.regionName;
     this.accountId = properties.accountId;
     this.functionName = properties.functionName;
@@ -83,9 +92,6 @@ export class SimHttpApiLambdaUri {
       );
     }
 
-    return new SimHttpApiLambdaUri({
-      ...invocation,
-      uri: invocation.functionArn,
-    });
+    return new SimHttpApiLambdaUri({ ...invocation, uri });
   }
 }

--- a/src/service/apigatewayv2/api/sim-http-api-lambda-proxy.factory.ts
+++ b/src/service/apigatewayv2/api/sim-http-api-lambda-proxy.factory.ts
@@ -2,10 +2,10 @@ import { AsyncMappedFactory } from "@kensio/part-factory";
 
 import type { SimPayload2Event } from "../../../serve/payload-2/sim-payload-2-event.type.js";
 import { assertDefined } from "../../../util/type-guard/defined.js";
+import { simApiGatewayServicePrincipal } from "../../apigateway/sim-api-gateway-service-principal.js";
 import { DEFAULT_SIM_AWS_ACCOUNT_ID } from "../../aws/sim-aws-account.js";
 import type { SimAws } from "../../aws/sim-aws.js";
 import { makeLambdaZipFileInput } from "../../lambda/function/code/lambda-zip-file-input.js";
-import { simApiGatewayServicePrincipal } from "../serve/auth/sim-http-api-invoke-authorizer.js";
 import type { SimHttpApi } from "./sim-http-api.js";
 import {
   simHttpApiProxyAuthorization,

--- a/src/service/apigatewayv2/api/sim-http-api-proxy-request-authorizer.ts
+++ b/src/service/apigatewayv2/api/sim-http-api-proxy-request-authorizer.ts
@@ -1,7 +1,7 @@
+import { simApiGatewayServicePrincipal } from "../../apigateway/sim-api-gateway-service-principal.js";
 import type { SimAws } from "../../aws/sim-aws.js";
 import { makeLambdaZipFileInput } from "../../lambda/function/code/lambda-zip-file-input.js";
 import type { SimCreateRouteCommandInput } from "../command/route/route.command.js";
-import { simApiGatewayServicePrincipal } from "../serve/auth/sim-http-api-invoke-authorizer.js";
 import type { SimHttpApiAuthorizerEvent } from "../serve/auth/sim-http-api-authorizer-event.js";
 
 /**

--- a/src/service/apigatewayv2/cfn/sim-cfn-http-api-request-authorizer.iso.test.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-http-api-request-authorizer.iso.test.ts
@@ -181,13 +181,15 @@ describe("Deploying an AWS::ApiGatewayV2::Authorizer of type REQUEST", () => {
       .getRoutes({ input: { ApiId: apiId } });
 
     // Then the authorizer carries what the template gave it, including the
-    // function ARN the wrapped AuthorizerUri named, and the route is the one
+    // wrapped AuthorizerUri as the template wrote it, and the route is the one
     // pointed at it
     assertObjectMatches(authorizers.Items[0] ?? {}, {
       Name: "session-cookie",
       AuthorizerType: "REQUEST",
       AuthorizerUri:
-        "arn:aws:lambda:eu-west-2:888888888888:function:session-authorizer",
+        "arn:aws:apigateway:eu-west-2:lambda:path/2015-03-31/functions/" +
+        "arn:aws:lambda:eu-west-2:888888888888:function:session-authorizer" +
+        "/invocations",
       AuthorizerPayloadFormatVersion: "2.0",
       EnableSimpleResponses: true,
       AuthorizerResultTtlInSeconds: 300,

--- a/src/service/apigatewayv2/command/authorizer/sim-http-api-request-authorizer-commands.iso.test.ts
+++ b/src/service/apigatewayv2/command/authorizer/sim-http-api-request-authorizer-commands.iso.test.ts
@@ -154,21 +154,22 @@ describe("Creating a sim HTTP API Lambda REQUEST authorizer", () => {
     const apiId = await createdApiId(simAws);
 
     // When the authorizer names its function the long way round
+    const wrappedUri =
+      `arn:aws:apigateway:eu-west-2:lambda:path/2015-03-31/functions/` +
+      `${functionArn}/invocations`;
     const created = await simAws.apiGatewayV2().createAuthorizer(
       new CreateAuthorizerCommand({
         ApiId: apiId,
         Name: "wrapped",
         AuthorizerType: "REQUEST",
-        AuthorizerUri:
-          `arn:aws:apigateway:eu-west-2:lambda:path/2015-03-31/functions/` +
-          `${functionArn}/invocations`,
+        AuthorizerUri: wrappedUri,
         AuthorizerPayloadFormatVersion: "2.0",
         IdentitySource: ["$request.header.cookie"],
       }),
     );
 
-    // Then it is held as the function ARN, the way an integration URI is
-    assertIdentical(created.AuthorizerUri, functionArn);
+    // Then it is handed back as it was written, the way an integration URI is
+    assertIdentical(created.AuthorizerUri, wrappedUri);
   });
 
   it("attaches to a route as CUSTOM authorization", async () => {

--- a/src/service/apigatewayv2/command/integration/sim-http-api-integration-commands.iso.test.ts
+++ b/src/service/apigatewayv2/command/integration/sim-http-api-integration-commands.iso.test.ts
@@ -146,19 +146,20 @@ describe("Sim API Gateway v2 integration commands", () => {
         PayloadFormatVersion: "2.0",
       }),
     );
+    const wrappedUri =
+      `arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/` +
+      `${functionArn}:3/invocations`;
     const version = await simAws.apiGatewayV2().createIntegration(
       new CreateIntegrationCommand({
         ApiId: apiId,
         IntegrationType: "AWS_PROXY",
-        IntegrationUri:
-          `arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/` +
-          `${functionArn}:3/invocations`,
+        IntegrationUri: wrappedUri,
         PayloadFormatVersion: "2.0",
       }),
     );
 
-    // Then each is created, and each keeps the qualifier it was given
+    // Then each is created, and each is handed back as it was written
     assertIdentical(alias.IntegrationUri, `${functionArn}:live`);
-    assertIdentical(version.IntegrationUri, `${functionArn}:3`);
+    assertIdentical(version.IntegrationUri, wrappedUri);
   });
 });

--- a/src/service/apigatewayv2/openapi/sim-http-api-openapi-request-authorizer.iso.test.ts
+++ b/src/service/apigatewayv2/openapi/sim-http-api-openapi-request-authorizer.iso.test.ts
@@ -27,6 +27,17 @@ const unusedFunctionArn =
   "arn:aws:lambda:us-east-1:111111111111:function:session-authorizer";
 
 /**
+ * The `authorizerUri` a scheme names a function with, which is the wrapped
+ * invoke path a document writes and the API hands back as written.
+ */
+function wrappedAuthorizerUri(functionArn: string): string {
+  return (
+    `arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/` +
+    `${functionArn}/invocations`
+  );
+}
+
+/**
  * The security scheme an HTTP API declares a Lambda `REQUEST` authorizer with:
  * an `apiKey` scheme carrying an authorizer of type `request`.
  */
@@ -38,9 +49,7 @@ function requestScheme(functionArn = unusedFunctionArn): JSONObject {
     "x-amazon-apigateway-authorizer": {
       type: "request",
       identitySource: "$request.header.cookie",
-      authorizerUri:
-        `arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/` +
-        `${functionArn}/invocations`,
+      authorizerUri: wrappedAuthorizerUri(functionArn),
       authorizerPayloadFormatVersion: "2.0",
       enableSimpleResponses: true,
       authorizerResultTtlInSeconds: 300,
@@ -121,7 +130,10 @@ describe("Importing a sim HTTP API's Lambda REQUEST authorizers", () => {
     assertNonNullable(authorizer);
     assertIdentical(authorizer.Name, "session-authorizer");
     assertIdentical(authorizer.AuthorizerType, "REQUEST");
-    assertIdentical(authorizer.AuthorizerUri, unusedFunctionArn);
+    assertIdentical(
+      authorizer.AuthorizerUri,
+      wrappedAuthorizerUri(unusedFunctionArn),
+    );
     assertTrue(authorizer.EnableSimpleResponses);
     assertIdentical(authorizer.AuthorizerResultTtlInSeconds, 300);
     expect(authorizer.IdentitySource).toStrictEqual(["$request.header.cookie"]);

--- a/src/service/apigatewayv2/serve/auth/sim-http-api-invoke-authorizer.ts
+++ b/src/service/apigatewayv2/serve/auth/sim-http-api-invoke-authorizer.ts
@@ -1,3 +1,4 @@
+import { simApiGatewayServicePrincipal } from "../../../apigateway/sim-api-gateway-service-principal.js";
 import type {
   SimIamAuthorizationDecision,
   SimIamInterServiceAuthZ,
@@ -7,12 +8,6 @@ import type { SimHttpApiRequestAuthorizer } from "../../api/authorizer/sim-http-
 import { SimHttpApiExecuteApiArn } from "../../api/sim-http-api-execute-api-arn.js";
 import type { SimHttpApi } from "../../api/sim-http-api.js";
 import type { SimHttpApiFunctionTarget } from "../sim-http-api-function-target.js";
-
-/**
- * The service principal API Gateway invokes a Lambda function as, whether that
- * function is behind an integration or behind an authorizer.
- */
-export const simApiGatewayServicePrincipal = "apigateway.amazonaws.com";
 
 interface SimHttpApiInvokeAuthorizerProperties {
   readonly iam: SimIamInterServiceAuthZ;

--- a/src/service/apigatewayv2/serve/sim-http-api-lambda-qualifier.iso.test.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-lambda-qualifier.iso.test.ts
@@ -24,8 +24,8 @@ import {
 } from "../../../../test/lambda/alias-fixture.js";
 import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
 import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import { simApiGatewayServicePrincipal } from "../../apigateway/sim-api-gateway-service-principal.js";
 import { SimAws } from "../../aws/sim-aws.js";
-import { simApiGatewayServicePrincipal } from "./auth/sim-http-api-invoke-authorizer.js";
 
 /**
  * What the handler behind every route here answers with. The version that ran

--- a/src/service/cloudformation/cdk/apigateway/sim-cdk-rest-api.loc.test.ts
+++ b/src/service/cloudformation/cdk/apigateway/sim-cdk-rest-api.loc.test.ts
@@ -1,0 +1,137 @@
+import { GetPolicyCommand } from "@aws-sdk/client-lambda";
+import {
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertTrue,
+  assertTypeString,
+} from "@kensio/smartass";
+import path from "node:path";
+import { describe, it } from "vitest";
+
+/**
+ * Slower local integration test. Calls the real CDK CLI to synth the output
+ * template file, then serves the deployed REST API over real localhost HTTP.
+ */
+import { serveSimAws } from "../../../../serve/index.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { TemporaryDirectory } from "../../../../util/filesystem/temporary-directory.js";
+import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+
+/**
+ * Inline function code, as CDK packages Code.fromInline source. The handler
+ * reads the path the greedy proxy resource captured out of the payload format
+ * 1.0 event.
+ */
+const ordersHandlerSource = `
+exports.handler = async (event) => ({
+  statusCode: 200,
+  headers: { "content-type": "text/plain" },
+  body: event.httpMethod + " order " + (event.pathParameters?.proxy ?? "none"),
+});
+`;
+
+const cdkApp = `
+import * as cdk from "aws-cdk-lib/core";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as apigw from "aws-cdk-lib/aws-apigateway";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "111111111111", region: "eu-west-2" },
+});
+
+const ordersFunction = new lambda.Function(stack, "OrdersFunction", {
+  functionName: "cdk-orders",
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: lambda.Code.fromInline(${JSON.stringify(ordersHandlerSource)}),
+});
+
+const api = new apigw.LambdaRestApi(stack, "OrdersApi", {
+  restApiName: "orders",
+  handler: ordersFunction,
+});
+
+new cdk.CfnOutput(stack, "ApiUrl", { value: api.url });
+new cdk.CfnOutput(stack, "StageName", { value: api.deploymentStage.stageName });
+
+app.synth();
+`;
+
+describe("Sim CDK REST API deployment local integration", () => {
+  it("serves a CDK-deployed LambdaRestApi over localhost", async () => {
+    // Given a CDK stack with a LambdaRestApi in front of a Lambda function,
+    // and a simulated AWS scoped to the Account and Region the stack names,
+    // which is what CDK baked into the endpoint it publishes.
+    const simAws = new SimAws({
+      defaultAccountId: "111111111111",
+      defaultRegionName: "eu-west-2",
+    });
+    const projectDirectory = new TemporaryDirectory();
+    const cdkProject = new TestCdkProject({ projectDirectory });
+    await cdkProject.writeCdkAppFile(cdkApp);
+
+    // And we synth the CDK template.
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When we deploy the template into sim CloudFormation and serve it.
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // Then the URL CDK publishes carries the API id and the stage segment, and
+    // resolves through AWS::URLSuffix to the local hostname.
+    const apiUrl = stack.outputs.get("ApiUrl")?.value;
+    assertTypeString(apiUrl);
+    assertIdentical(stack.outputs.get("StageName")?.value, "prod");
+    assertStringIncludes(apiUrl, ".execute-api.eu-west-2.sim-aws.localhost/");
+    assertStringIncludes(apiUrl, "/prod/");
+
+    // And a request reaches the function through the ANY method on the
+    // {proxy+} resource, with the rest of the path captured.
+    const srv = await serveSimAws({ simAws });
+
+    try {
+      const read = await fetch(srv.localUrl(`${apiUrl}orders/YL-1`));
+      assertIdentical(read.status, 200);
+      assertIdentical(read.headers.get("content-type"), "text/plain");
+      assertIdentical(await read.text(), "GET order orders/YL-1");
+
+      const write = await fetch(srv.localUrl(`${apiUrl}orders`), {
+        method: "POST",
+      });
+      assertIdentical(await write.text(), "POST order orders");
+    } finally {
+      await srv.close();
+    }
+
+    // And the invocation was gated by the AWS::Lambda::Permission CDK pairs
+    // with the method, which is deployed rather than skipped.
+    const permissionResource = stack.resources
+      .values()
+      .find((resource) => resource.type === "AWS::Lambda::Permission");
+    assertNonNullable(permissionResource);
+    assertFalse(permissionResource.skipped);
+
+    const policy = await simAws
+      .lambda()
+      .getPolicy(new GetPolicyCommand({ FunctionName: "cdk-orders" }));
+    assertStringIncludes(policy.Policy, "lambda:InvokeFunction");
+    assertStringIncludes(policy.Policy, "apigateway.amazonaws.com");
+
+    // And the AWS::ApiGateway::Account CDK writes beside a default RestApi is
+    // recorded rather than deployed, which is what leaves the rest served.
+    const accountResource = stack.resources
+      .values()
+      .find((resource) => resource.type === "AWS::ApiGateway::Account");
+    assertNonNullable(accountResource);
+    assertTrue(accountResource.skipped);
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/service/cloudformation/resource/cfn/apigateway/sim-api-gateway-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/apigateway/sim-api-gateway-cfn-value-adapter.ts
@@ -1,0 +1,56 @@
+import { SimRestApiDeployment } from "../../../../apigateway/api/deployment/sim-rest-api-deployment.js";
+import { SimRestApiResource } from "../../../../apigateway/api/resource/sim-rest-api-resource.js";
+import { SimRestApi } from "../../../../apigateway/api/sim-rest-api.js";
+import { SimRestApiStage } from "../../../../apigateway/api/stage/sim-rest-api-stage.js";
+import type {
+  SimCfnResourceValueAdapterProperties,
+  SimCfnServiceValueAdapter,
+} from "../sim-cfn-resource-value-adapter.js";
+import { SimRestApiCfn } from "./sim-rest-api-cfn.js";
+import { SimRestApiDeploymentCfn } from "./sim-rest-api-deployment-cfn.js";
+import { SimRestApiResourceCfn } from "./sim-rest-api-resource-cfn.js";
+import { SimRestApiStageCfn } from "./sim-rest-api-stage-cfn.js";
+
+/**
+ * The CloudFormation-facing value adapter for a simulated API Gateway REST API
+ * Resource.
+ *
+ * `AWS::ApiGateway::Method` is missing on purpose. A REST API method is
+ * addressed by its API, its resource and its HTTP verb, and has no id of its
+ * own, so there is nothing for a `Ref` to answer with. CloudFormation's own
+ * fallback answers with the logical ID, and nothing in a template needs the
+ * value. CDK reads it only to publish `Method.methodId`.
+ */
+export function apiGatewayValueAdapter(
+  properties: SimCfnResourceValueAdapterProperties,
+): SimCfnServiceValueAdapter {
+  if (
+    properties.type === "AWS::ApiGateway::RestApi" &&
+    properties.simResource instanceof SimRestApi
+  ) {
+    return new SimRestApiCfn({ restApi: properties.simResource });
+  }
+
+  if (
+    properties.type === "AWS::ApiGateway::Resource" &&
+    properties.simResource instanceof SimRestApiResource
+  ) {
+    return new SimRestApiResourceCfn({ resource: properties.simResource });
+  }
+
+  if (
+    properties.type === "AWS::ApiGateway::Deployment" &&
+    properties.simResource instanceof SimRestApiDeployment
+  ) {
+    return new SimRestApiDeploymentCfn({ deployment: properties.simResource });
+  }
+
+  if (
+    properties.type === "AWS::ApiGateway::Stage" &&
+    properties.simResource instanceof SimRestApiStage
+  ) {
+    return new SimRestApiStageCfn({ stage: properties.simResource });
+  }
+
+  return undefined;
+}

--- a/src/service/cloudformation/resource/cfn/apigateway/sim-rest-api-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/apigateway/sim-rest-api-cfn.ts
@@ -1,0 +1,48 @@
+import type { SimRestApi } from "../../../../apigateway/api/sim-rest-api.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimRestApiCfnProperties {
+  readonly restApi: SimRestApi;
+}
+
+/**
+ * CloudFormation-facing values for a simulated REST API.
+ */
+export class SimRestApiCfn implements SimCfnResourceValueAdapter {
+  private readonly restApi: SimRestApi;
+
+  constructor(properties: SimRestApiCfnProperties) {
+    this.restApi = properties.restApi;
+  }
+
+  /**
+   * AWS::ApiGateway::RestApi Ref returns the API id, which is what every
+   * resource, method, deployment and stage under the API names it by.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.restApi.apiId;
+  }
+
+  /**
+   * AWS::ApiGateway::RestApi publishes RestApiId and RootResourceId.
+   *
+   * `RootResourceId` is how a template hangs its first path segment off the
+   * API, since the root resource is created with the API rather than declared.
+   * There is no endpoint attribute, because a REST API reports none. CDK
+   * builds the URL out of a `Ref` to the API and a `Ref` to the stage.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    if (attributeName === "RestApiId") {
+      return this.restApi.apiId;
+    }
+
+    if (attributeName === "RootResourceId") {
+      return this.restApi.rootResource.resourceId;
+    }
+
+    throw new Error(
+      `Unsupported AWS::ApiGateway::RestApi attribute ${attributeName}`,
+    );
+  }
+}

--- a/src/service/cloudformation/resource/cfn/apigateway/sim-rest-api-deployment-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/apigateway/sim-rest-api-deployment-cfn.ts
@@ -1,0 +1,39 @@
+import type { SimRestApiDeployment } from "../../../../apigateway/api/deployment/sim-rest-api-deployment.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimRestApiDeploymentCfnProperties {
+  readonly deployment: SimRestApiDeployment;
+}
+
+/**
+ * CloudFormation-facing values for a simulated REST API deployment.
+ */
+export class SimRestApiDeploymentCfn implements SimCfnResourceValueAdapter {
+  private readonly deployment: SimRestApiDeployment;
+
+  constructor(properties: SimRestApiDeploymentCfnProperties) {
+    this.deployment = properties.deployment;
+  }
+
+  /**
+   * AWS::ApiGateway::Deployment Ref returns the deployment id, which is what a
+   * stage's `DeploymentId` names it by.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.deployment.deploymentId;
+  }
+
+  /**
+   * AWS::ApiGateway::Deployment publishes DeploymentId.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    if (attributeName === "DeploymentId") {
+      return this.deployment.deploymentId;
+    }
+
+    throw new Error(
+      `Unsupported AWS::ApiGateway::Deployment attribute ${attributeName}`,
+    );
+  }
+}

--- a/src/service/cloudformation/resource/cfn/apigateway/sim-rest-api-resource-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/apigateway/sim-rest-api-resource-cfn.ts
@@ -1,0 +1,40 @@
+import type { SimRestApiResource } from "../../../../apigateway/api/resource/sim-rest-api-resource.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimRestApiResourceCfnProperties {
+  readonly resource: SimRestApiResource;
+}
+
+/**
+ * CloudFormation-facing values for one node of a simulated REST API's path
+ * tree.
+ */
+export class SimRestApiResourceCfn implements SimCfnResourceValueAdapter {
+  private readonly resource: SimRestApiResource;
+
+  constructor(properties: SimRestApiResourceCfnProperties) {
+    this.resource = properties.resource;
+  }
+
+  /**
+   * AWS::ApiGateway::Resource Ref returns the resource id, which is what a
+   * method's `ResourceId` and a child resource's `ParentId` name it by.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.resource.resourceId;
+  }
+
+  /**
+   * AWS::ApiGateway::Resource publishes ResourceId.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    if (attributeName === "ResourceId") {
+      return this.resource.resourceId;
+    }
+
+    throw new Error(
+      `Unsupported AWS::ApiGateway::Resource attribute ${attributeName}`,
+    );
+  }
+}

--- a/src/service/cloudformation/resource/cfn/apigateway/sim-rest-api-stage-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/apigateway/sim-rest-api-stage-cfn.ts
@@ -1,0 +1,36 @@
+import type { SimRestApiStage } from "../../../../apigateway/api/stage/sim-rest-api-stage.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimRestApiStageCfnProperties {
+  readonly stage: SimRestApiStage;
+}
+
+/**
+ * CloudFormation-facing values for a simulated REST API stage.
+ */
+export class SimRestApiStageCfn implements SimCfnResourceValueAdapter {
+  private readonly stage: SimRestApiStage;
+
+  constructor(properties: SimRestApiStageCfnProperties) {
+    this.stage = properties.stage;
+  }
+
+  /**
+   * AWS::ApiGateway::Stage Ref returns the stage name. That is also the first
+   * path segment of the endpoint the stage serves on, which is how CDK builds
+   * the API's URL.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.stage.stageName;
+  }
+
+  /**
+   * AWS::ApiGateway::Stage publishes no Fn::GetAtt attributes.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    throw new Error(
+      `Unsupported AWS::ApiGateway::Stage attribute ${attributeName}`,
+    );
+  }
+}

--- a/src/service/cloudformation/resource/cfn/sim-cfn-service-value-adapters.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-service-value-adapters.ts
@@ -1,4 +1,5 @@
 import { acmValueAdapter } from "./acm/sim-acm-cfn-value-adapter.js";
+import { apiGatewayValueAdapter } from "./apigateway/sim-api-gateway-cfn-value-adapter.js";
 import { apiGatewayV2ValueAdapter } from "./apigatewayv2/sim-api-gateway-v2-cfn-value-adapter.js";
 import { cloudFrontValueAdapter } from "./cloudfront/sim-cloudfront-cfn-value-adapter.js";
 import { cloudWatchValueAdapter } from "./cloudwatch/sim-cloudwatch-cfn-value-adapter.js";
@@ -38,6 +39,7 @@ export const simCfnServiceValueAdapters: readonly ((
   properties: SimCfnResourceValueAdapterProperties,
 ) => SimCfnServiceValueAdapter)[] = [
   acmValueAdapter,
+  apiGatewayValueAdapter,
   apiGatewayV2ValueAdapter,
   cloudFrontValueAdapter,
   cloudWatchValueAdapter,

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
@@ -36,6 +36,11 @@ export const simCfnServiceResourceFactories: ReadonlyMap<
   ["ACM", acmResourceFactory],
   ["CertificateManager", acmResourceFactory],
   [
+    "ApiGateway",
+    (scopedAws): SimCfnServiceResourceFactory =>
+      scopedAws.apiGateway().cfnResourceFactory(),
+  ],
+  [
     "ApiGatewayV2",
     (scopedAws): SimCfnServiceResourceFactory =>
       scopedAws.apiGatewayV2().cfnResourceFactory(),

--- a/test/apigateway/cfn-deploy.ts
+++ b/test/apigateway/cfn-deploy.ts
@@ -1,0 +1,66 @@
+/**
+ * Deployment helpers the API Gateway REST API CloudFormation test files share.
+ *
+ * Both the deployment and the validation suites deploy a template and then
+ * read either the stack or the error it failed with. This lives under `test/`
+ * for the same reasons as `test/apigatewayv2/`: eslint rejects a test file
+ * that exports helpers alongside its own `describe` calls, and `test/**` is
+ * type-checked with everything else, excluded from the published build, not
+ * collected as a suite, and not counted in coverage.
+ */
+
+import { assertInstanceOf, assertThrowsErrorAsync } from "@kensio/smartass";
+
+import { SimAws } from "../../src/service/aws/sim-aws.js";
+import type { SimCfnStack } from "../../src/service/cloudformation/stack/sim-cfn-stack.js";
+import type { CfnTemplateBodyRecord } from "../../src/service/cloudformation/template/sim-cfn-template.js";
+
+/**
+ * A simulated AWS in the region the API Gateway CloudFormation tests deploy
+ * into, which is not the default one, so a region reaching an endpoint is a
+ * region the template put there.
+ */
+export function simAwsInEuWest2(): SimAws {
+  return new SimAws({ defaultRegionName: "eu-west-2" });
+}
+
+/**
+ * Deploy a template and wait for it to finish.
+ */
+export async function deployRestApi(
+  simAws: SimAws,
+  template: CfnTemplateBodyRecord,
+): Promise<SimCfnStack> {
+  const stack = await simAws
+    .cloudFormation()
+    .deployTemplate({ stackName: "orders-stack", template });
+  await stack.waitForDeployComplete();
+
+  return stack;
+}
+
+/**
+ * Deploy a template that is expected to fail, and give back the error.
+ */
+export async function deployRestApiFailure(
+  simAws: SimAws,
+  template: CfnTemplateBodyRecord,
+): Promise<Error> {
+  const error = await assertThrowsErrorAsync(async () => {
+    await deployRestApi(simAws, template);
+  });
+
+  assertInstanceOf(error, Error);
+
+  return error;
+}
+
+/**
+ * The reasons a deployed stack gave for the properties it created Resources
+ * without, as one string per ignored property.
+ */
+export function ignoredReasons(stack: SimCfnStack): string[] {
+  return stack.ignoredProperties.map((ignored) => {
+    return `${ignored.logicalId} ${ignored.reason}`;
+  });
+}


### PR DESCRIPTION
`AWS::ApiGateway::RestApi`, `Resource`, `Method`, `Deployment` and `Stage` deploy into simulated REST APIs, so a CDK stack built on `RestApi` or `LambdaRestApi` synthesizes, deploys from `cdk.out` and serves a request through to the handler. A method's inline `Integration` block becomes the `PutIntegration` that follows its `PutMethod`, which is how the REST API models an integration. `Ref` answers with the API id, the resource id, the deployment id and the stage name, and `Fn::GetAtt` adds `RootResourceId`, which is what a template hangs its first path segment off. A teardown deletes each part before the API. Authorizers, API keys, usage plans, request validators, models, domain names and the `AWS::ApiGateway::Account` CDK writes beside a default `RestApi` are recorded as skips, and the rest of the stack deploys around them.

Two cleanups left over from the preceding issues ride along as their own commits. The API Gateway service principal was declared twice with the same value, and the apigatewayv2 copy is gone. `SimHttpApiLambdaUri` normalised an integration URI to the bare function ARN, and it now echoes back what was configured, which is what the REST service already does and what the SDK model documents. A third commit fixes a CloudFormation example on the HTTP API docs page whose Lambda permission named the wrong account, so running it printed a 500.

Resolves #781

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for deploying API Gateway REST APIs through simulated CloudFormation and CDK.
  - Supports REST APIs, resources, methods, Lambda proxy integrations, deployments, stages, generated URLs, references, and teardown.
  - Added working deployment examples and expanded REST API configuration documentation.

- **Bug Fixes**
  - Preserved configured Lambda integration and authorizer URIs exactly as provided.
  - Improved region and account handling in API Gateway examples.

- **Tests**
  - Added comprehensive coverage for routing, validation, deployment, deletion, references, stages, and CDK deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->