### PR TITLE
fix: notice a save a watch never reported

### DIFF
--- a/src/service/cloudformation/README.md
+++ b/src/service/cloudformation/README.md
@@ -210,7 +210,8 @@ updates the stack rather than needing the process restarted:
   watch in the process starts or stops. A save landing during a rebuild is delivered nowhere, so a
   process that also mounts a directory into a bucket, deploys a second stack, or serves with live
   reload can lose one outright. Reading the file reports the same change without depending on the
-  stream, and both sources report into the one settle window.
+  stream, and a read finding a change the events already reported stays quiet about it, so one save
+  stays one update.
 - `SimCfnTemplateWatchUpdate` decides what a save came to: an update, a file written without being
   changed, or a failure. Nothing thrown gets past it, since the watch applies changes in a queue
   that a rejection would stop. An update is where the `reload` target is told, after the `onUpdated`

--- a/src/service/cloudformation/README.md
+++ b/src/service/cloudformation/README.md
@@ -205,6 +205,12 @@ updates the stack rather than needing the process restarted:
   name, because a synthesis renames a temporary file over the template and a watch on the file
   itself would be left holding the file that was replaced. Changes are settled through
   `SimWatchSettle`, the same debounce `yulin watch` uses, and applied one after another.
+- `SimWatchFilePoll` reads the template on a timer behind those events, because macOS gives a
+  process one FSEvents stream for all of its watches and libuv rebuilds that stream whenever any
+  watch in the process starts or stops. A save landing during a rebuild is delivered nowhere, so a
+  process that also mounts a directory into a bucket, deploys a second stack, or serves with live
+  reload can lose one outright. Reading the file reports the same change without depending on the
+  stream, and both sources report into the one settle window.
 - `SimCfnTemplateWatchUpdate` decides what a save came to: an update, a file written without being
   changed, or a failure. Nothing thrown gets past it, since the watch applies changes in a queue
   that a rejection would stop. An update is where the `reload` target is told, after the `onUpdated`

--- a/src/service/cloudformation/watch/sim-cfn-template-file-events.ts
+++ b/src/service/cloudformation/watch/sim-cfn-template-file-events.ts
@@ -47,7 +47,7 @@ export class SimCfnTemplateFileEvents {
   start(): void {
     // oxlint-disable-next-line security/detect-non-literal-fs-filename
     const watcher = fs.watch(this.directoryPath, (_event, fileName) => {
-      if (!(fileName === this.fileName)) {
+      if (fileName !== this.fileName) {
         return;
       }
 

--- a/src/service/cloudformation/watch/sim-cfn-template-file-events.ts
+++ b/src/service/cloudformation/watch/sim-cfn-template-file-events.ts
@@ -20,9 +20,8 @@ interface SimCfnTemplateFileEventsProperties {
  * Behind the events the file is read on a timer, because an event can go
  * missing outright: macOS gives a process one FSEvents stream for every watch
  * in it, and a save that lands while libuv is rebuilding that stream is
- * delivered nowhere. Reading the file is what notices the save the stream lost.
- * Both sources report into the same settle window, so a save they both notice
- * is the one change it was.
+ * delivered nowhere. Reading the file is what notices the save the stream lost,
+ * and it stays quiet about a save the stream reported.
  */
 export class SimCfnTemplateFileEvents {
   private readonly directoryPath: string;
@@ -48,9 +47,12 @@ export class SimCfnTemplateFileEvents {
   start(): void {
     // oxlint-disable-next-line security/detect-non-literal-fs-filename
     const watcher = fs.watch(this.directoryPath, (_event, fileName) => {
-      if (fileName === this.fileName) {
-        this.onEvent();
+      if (!(fileName === this.fileName)) {
+        return;
       }
+
+      this.poll.reported();
+      this.onEvent();
     });
 
     // The directory can be deleted or replaced, and a watcher with no error

--- a/src/service/cloudformation/watch/sim-cfn-template-file-events.ts
+++ b/src/service/cloudformation/watch/sim-cfn-template-file-events.ts
@@ -1,5 +1,7 @@
 import fs, { type FSWatcher } from "node:fs";
 import path from "node:path";
+import { SimWatchFilePoll } from "../../../watch/sim-watch-file-poll.js";
+import { simWatchConfig } from "../../../watch/sim-watch.config.js";
 
 interface SimCfnTemplateFileEventsProperties {
   readonly templatePath: string;
@@ -14,17 +16,30 @@ interface SimCfnTemplateFileEventsProperties {
  * itself is left holding the file that was replaced. Events for anything else
  * in the directory, which for a cloud assembly is every other stack in it and
  * every staged asset, are dropped by name.
+ *
+ * Behind the events the file is read on a timer, because an event can go
+ * missing outright: macOS gives a process one FSEvents stream for every watch
+ * in it, and a save that lands while libuv is rebuilding that stream is
+ * delivered nowhere. Reading the file is what notices the save the stream lost.
+ * Both sources report into the same settle window, so a save they both notice
+ * is the one change it was.
  */
 export class SimCfnTemplateFileEvents {
   private readonly directoryPath: string;
   private readonly fileName: string;
   private readonly onEvent: () => void;
+  private readonly poll: SimWatchFilePoll;
   private watcher: FSWatcher | undefined;
 
   constructor(properties: SimCfnTemplateFileEventsProperties) {
     this.directoryPath = path.dirname(properties.templatePath);
     this.fileName = path.basename(properties.templatePath);
     this.onEvent = properties.onEvent;
+    this.poll = new SimWatchFilePoll({
+      filePath: properties.templatePath,
+      intervalMs: simWatchConfig.filePollMs,
+      onChanged: this.onEvent,
+    });
   }
 
   /**
@@ -49,12 +64,14 @@ export class SimCfnTemplateFileEvents {
     });
 
     this.watcher = watcher;
+    this.poll.start();
   }
 
   /**
    * Stop listening.
    */
   close(): void {
+    this.poll.close();
     this.watcher?.close();
     this.watcher = undefined;
   }

--- a/src/watch/sim-watch-file-poll.loc.test.ts
+++ b/src/watch/sim-watch-file-poll.loc.test.ts
@@ -9,8 +9,8 @@ describe("SimWatchFilePoll", () => {
     const polled = await PolledFile.of();
 
     try {
-      // When the file is written
-      await polled.write("changed");
+      // When the file is saved
+      await polled.write();
 
       // Then reading it is what notices
       await polled.changes(1);
@@ -19,47 +19,54 @@ describe("SimWatchFilePoll", () => {
     }
   });
 
-  it("reports each save that follows the one before it", async () => {
-    // Given a file that has already been written and reported once
-    const polled = await PolledFile.of();
-    await polled.write("first");
-    await polled.changes(1);
-
-    try {
-      // When it is written again
-      await polled.write("second");
-
-      // Then that is a save of its own rather than the first one again
-      await polled.changes(2);
-    } finally {
-      polled.close();
-    }
-  });
-
-  it("says nothing about a file nobody has written", async () => {
-    // Given a file being read that no save has touched
+  it("stays quiet about a save the watch got to first", async () => {
     const polled = await PolledFile.of();
 
     try {
-      // When it is left alone for several turns of the read
+      // Given a watch that reported a save as it happened
+      polled.poll.reported();
+
+      // When the read comes round to that same save
+      await polled.write();
       await polled.pause(400);
 
-      // Then nothing is reported, because reading it is what this does and
-      // changing is what it reports
+      // Then it is left as the one change the watch already made of it, rather
+      // than becoming a second one a moment later
       assertIdentical(polled.changeCount(), 0);
     } finally {
       polled.close();
     }
   });
 
-  it("stops reading a file it has been closed on", async () => {
-    // Given a file that is no longer being read
+  it("reports the next save after one the watch reported", async () => {
     const polled = await PolledFile.of();
-    polled.close();
 
     try {
-      // When it is written
-      await polled.write("changed");
+      // Given a save the watch reported and the read stayed quiet about
+      polled.poll.reported();
+      await polled.write();
+      await polled.pause(400);
+
+      // When the watch loses the save after it
+      await polled.write();
+
+      // Then that one is reported, because staying quiet covers the save the
+      // watch reported rather than every save after it
+      await polled.changes(1);
+    } finally {
+      polled.close();
+    }
+  });
+
+  it("stops reading a file it has been closed on", async () => {
+    const polled = await PolledFile.of();
+
+    try {
+      // Given a file that is no longer being read
+      polled.close();
+
+      // When it is saved
+      await polled.write();
       await polled.pause(400);
 
       // Then nothing is reported, and nothing is left holding the process open

--- a/src/watch/sim-watch-file-poll.loc.test.ts
+++ b/src/watch/sim-watch-file-poll.loc.test.ts
@@ -1,0 +1,71 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { PolledFile } from "../../test/watch/polled-file.js";
+
+describe("SimWatchFilePoll", () => {
+  it("reports a save nothing else reported", async () => {
+    // Given a file being read behind a watch that has said nothing about it,
+    // as a watch does when the save it should have reported went missing
+    const polled = await PolledFile.of();
+
+    try {
+      // When the file is written
+      await polled.write("changed");
+
+      // Then reading it is what notices
+      await polled.changes(1);
+    } finally {
+      polled.close();
+    }
+  });
+
+  it("reports each save that follows the one before it", async () => {
+    // Given a file that has already been written and reported once
+    const polled = await PolledFile.of();
+    await polled.write("first");
+    await polled.changes(1);
+
+    try {
+      // When it is written again
+      await polled.write("second");
+
+      // Then that is a save of its own rather than the first one again
+      await polled.changes(2);
+    } finally {
+      polled.close();
+    }
+  });
+
+  it("says nothing about a file nobody has written", async () => {
+    // Given a file being read that no save has touched
+    const polled = await PolledFile.of();
+
+    try {
+      // When it is left alone for several turns of the read
+      await polled.pause(400);
+
+      // Then nothing is reported, because reading it is what this does and
+      // changing is what it reports
+      assertIdentical(polled.changeCount(), 0);
+    } finally {
+      polled.close();
+    }
+  });
+
+  it("stops reading a file it has been closed on", async () => {
+    // Given a file that is no longer being read
+    const polled = await PolledFile.of();
+    polled.close();
+
+    try {
+      // When it is written
+      await polled.write("changed");
+      await polled.pause(400);
+
+      // Then nothing is reported, and nothing is left holding the process open
+      assertIdentical(polled.changeCount(), 0);
+    } finally {
+      polled.close();
+    }
+  });
+});

--- a/src/watch/sim-watch-file-poll.ts
+++ b/src/watch/sim-watch-file-poll.ts
@@ -1,0 +1,64 @@
+import { unwatchFile, watchFile } from "node:fs";
+
+interface SimWatchFilePollProperties {
+  readonly filePath: string;
+  readonly intervalMs: number;
+  readonly onChanged: () => void;
+}
+
+/**
+ * Notices a file changing by reading it, rather than by being told.
+ *
+ * This stands behind a filesystem watch rather than replacing one. macOS hands
+ * a process every event it asked for over a single FSEvents stream, and libuv
+ * rebuilds that stream from the current instant whenever any watch in the
+ * process is started or closed. A write that lands during the rebuild reaches
+ * nothing: the watch stays open, reports no error, and simply never mentions
+ * the save. A process that watches a template while it also mounts a directory
+ * into a Bucket, deploys a second Stack from the same cloud assembly, or serves
+ * with live reload is a process where that keeps happening.
+ *
+ * Reading the file asks the file rather than the platform, so it answers
+ * whatever the stream is doing. It is the slower of the two and the one that
+ * always works, which is why both are here: the event is what makes a save feel
+ * immediate, and this is what makes sure it arrives.
+ *
+ * Nothing here tries to tell a save the watch reported from one it lost, and
+ * every read that finds a change reports it. A settle window turns the two of
+ * them into the one change they are, and it is the same window that already
+ * turns one editor save into one change.
+ */
+export class SimWatchFilePoll {
+  private readonly filePath: string;
+  private readonly intervalMs: number;
+
+  // Held as one function so it can be taken off the file again. Node keys
+  // polled files by path and by listener, which is what lets two Stacks
+  // deployed from one file each stop reading it without stopping the other.
+  private readonly onPolled: () => void;
+
+  constructor(properties: SimWatchFilePollProperties) {
+    this.filePath = properties.filePath;
+    this.intervalMs = properties.intervalMs;
+    this.onPolled = properties.onChanged;
+  }
+
+  /**
+   * Start reading the file, and report it changing.
+   *
+   * A file that is not there yet is read all the same, and reports itself once
+   * it appears.
+   */
+  start(): void {
+    // oxlint-disable-next-line security/detect-non-literal-fs-filename
+    watchFile(this.filePath, { interval: this.intervalMs }, this.onPolled);
+  }
+
+  /**
+   * Stop reading it, so nothing is left holding the process open.
+   */
+  close(): void {
+    // oxlint-disable-next-line security/detect-non-literal-fs-filename
+    unwatchFile(this.filePath, this.onPolled);
+  }
+}

--- a/src/watch/sim-watch-file-poll.ts
+++ b/src/watch/sim-watch-file-poll.ts
@@ -23,35 +23,59 @@ interface SimWatchFilePollProperties {
  * always works, which is why both are here: the event is what makes a save feel
  * immediate, and this is what makes sure it arrives.
  *
- * Nothing here tries to tell a save the watch reported from one it lost, and
- * every read that finds a change reports it. A settle window turns the two of
- * them into the one change they are, and it is the same window that already
- * turns one editor save into one change.
+ * A save the watch did report is the same save this finds a moment later, and
+ * acting on it twice is two updates for one change. `reported()` is how the
+ * watch says it got there first, and the next read to find the file changed
+ * stays quiet about it.
  */
 export class SimWatchFilePoll {
   private readonly filePath: string;
   private readonly intervalMs: number;
+  private readonly onChanged: () => void;
+  private reportedElsewhere = false;
 
   // Held as one function so it can be taken off the file again. Node keys
   // polled files by path and by listener, which is what lets two Stacks
   // deployed from one file each stop reading it without stopping the other.
-  private readonly onPolled: () => void;
+  private readonly onPolled = (): void => {
+    if (this.reportedElsewhere) {
+      this.reportedElsewhere = false;
+
+      return;
+    }
+
+    this.onChanged();
+  };
 
   constructor(properties: SimWatchFilePollProperties) {
     this.filePath = properties.filePath;
     this.intervalMs = properties.intervalMs;
-    this.onPolled = properties.onChanged;
+    this.onChanged = properties.onChanged;
   }
 
   /**
    * Start reading the file, and report it changing.
    *
-   * A file that is not there yet is read all the same, and reports itself once
-   * it appears.
+   * Starting is asking for a first look rather than taking one, and a save
+   * landing before that look is part of the state the file is found in. The
+   * deployment that starts a watch has just read the template, so the save this
+   * would miss is one it already has.
    */
   start(): void {
     // oxlint-disable-next-line security/detect-non-literal-fs-filename
     watchFile(this.filePath, { interval: this.intervalMs }, this.onPolled);
+  }
+
+  /**
+   * Say that a save has been reported by whatever this stands behind, so the
+   * next change found here is taken as that same save.
+   *
+   * Only the next one. Two saves inside a single interval, where the watch
+   * reported the first and lost the second, leave the second for the save after
+   * it to carry, because one read of the file cannot tell two writes apart.
+   */
+  reported(): void {
+    this.reportedElsewhere = true;
   }
 
   /**

--- a/src/watch/sim-watch.config.ts
+++ b/src/watch/sim-watch.config.ts
@@ -30,6 +30,17 @@ export const simWatchConfig = {
   // takes, so it is a backstop for a stream that will not stop rather than
   // something a build runs into.
   settleMaxWaitMs: 5000,
+  // How often a watched file's metadata is read, behind the events for it.
+  // macOS delivers a process's filesystem events over one FSEvents stream,
+  // which libuv rebuilds whenever any watch in the process starts or stops, and
+  // a write that lands during the rebuild reaches nothing. Reading the file
+  // says the same thing without depending on the stream.
+  //
+  // Well inside `settleMs`, so an event and a read noticing the same save fall
+  // in one burst and are one change rather than two. That is also what it costs:
+  // a read landing inside the window pushes the window back, so a save the
+  // events did report is acted on up to one interval later than it would be.
+  filePollMs: 100,
   // How long the supervisor waits for a process to say it has told its browsers
   // a reload is coming. A process not running Yulin's runtime never answers, so
   // this is a short wait rather than a requirement.

--- a/src/watch/sim-watch.config.ts
+++ b/src/watch/sim-watch.config.ts
@@ -36,10 +36,9 @@ export const simWatchConfig = {
   // a write that lands during the rebuild reaches nothing. Reading the file
   // says the same thing without depending on the stream.
   //
-  // Well inside `settleMs`, so an event and a read noticing the same save fall
-  // in one burst and are one change rather than two. That is also what it costs:
-  // a read landing inside the window pushes the window back, so a save the
-  // events did report is acted on up to one interval later than it would be.
+  // How long a lost save waits, and no longer than a person notices. A read
+  // finding a change the events already reported stays quiet about it, so this
+  // is the delay on the saves the events lose and nothing else.
   filePollMs: 100,
   // How long the supervisor waits for a process to say it has told its browsers
   // a reload is coming. A process not running Yulin's runtime never answers, so

--- a/test/watch/polled-file.ts
+++ b/test/watch/polled-file.ts
@@ -11,8 +11,10 @@ const fileName = "Site.template.json";
  * testing.
  */
 export class PolledFile {
-  private readonly poll: SimWatchFilePoll;
-  private readonly changed: string[] = [];
+  readonly poll: SimWatchFilePoll;
+
+  private changed = 0;
+  private saves = 0;
 
   private constructor(private readonly directory: TemporaryDirectory) {
     this.poll = new SimWatchFilePoll({
@@ -21,34 +23,48 @@ export class PolledFile {
       // interval a running simulation reads its templates on.
       intervalMs: 50,
       onChanged: (): void => {
-        this.changed.push(fileName);
+        this.changed++;
       },
     });
     this.poll.start();
   }
 
   /**
-   * Write a file and start reading it.
+   * Write a file, start reading it, and wait until the read is running.
    */
   static async of(): Promise<PolledFile> {
     const directory = new TemporaryDirectory();
     await directory.writeFile(fileName, "initial");
+    const polled = new PolledFile(directory);
 
-    return new PolledFile(directory);
+    try {
+      await polled.running();
+    } catch (error) {
+      polled.close();
+
+      throw error;
+    }
+
+    return polled;
   }
 
   /**
-   * Save the file, as whatever writes it does.
+   * Save the file.
+   *
+   * Every save is a different length. A read comparing what the file looks like
+   * has that to go on wherever the timestamps behind it are coarser than the
+   * gap between two saves.
    */
-  async write(content: string): Promise<void> {
-    await this.directory.writeFile(fileName, content);
+  async write(): Promise<void> {
+    this.saves++;
+    await this.directory.writeFile(fileName, "save".repeat(this.saves));
   }
 
   /**
    * How many changes the read has reported.
    */
   changeCount(): number {
-    return this.changed.length;
+    return this.changed;
   }
 
   /**
@@ -58,10 +74,10 @@ export class PolledFile {
   async changes(count: number, withinMs = 5000): Promise<void> {
     const giveUpAt = Date.now() + withinMs;
 
-    while (this.changed.length < count) {
+    while (this.changed < count) {
       if (Date.now() >= giveUpAt) {
         throw new Error(
-          `Polled file reported ${String(this.changed.length)} changes, expected ${String(count)}`,
+          `Polled file reported ${String(this.changed)} changes, expected ${String(count)}`,
         );
       }
 
@@ -85,5 +101,32 @@ export class PolledFile {
    */
   close(): void {
     this.poll.close();
+  }
+
+  /**
+   * Wait until the read has taken its first look at the file.
+   *
+   * Starting one asks for that look rather than taking it, and a save arriving
+   * before it is part of the state the file is found in. A test about what a
+   * save does starts from a read that has already looked, so it saves until one
+   * is reported and then counts from zero again.
+   */
+  private async running(withinMs = 5000): Promise<void> {
+    const giveUpAt = Date.now() + withinMs;
+
+    while (this.changed === 0) {
+      if (Date.now() >= giveUpAt) {
+        throw new Error(
+          "Polled file never reported the save it was started on",
+        );
+      }
+
+      // oxlint-disable-next-line no-await-in-loop -- waiting on a real read
+      await this.write();
+      // oxlint-disable-next-line no-await-in-loop -- waiting on a real read
+      await this.pause(20);
+    }
+
+    this.changed = 0;
   }
 }

--- a/test/watch/polled-file.ts
+++ b/test/watch/polled-file.ts
@@ -1,0 +1,89 @@
+import { SimWatchFilePoll } from "../../src/watch/sim-watch-file-poll.js";
+import { TemporaryDirectory } from "../../src/util/filesystem/temporary-directory.js";
+
+const fileName = "Site.template.json";
+
+/**
+ * A real file with a real read on it.
+ *
+ * Reading a file for what it looks like on disk is the whole of what the poll
+ * does, so a stand-in for the filesystem would leave nothing here worth
+ * testing.
+ */
+export class PolledFile {
+  private readonly poll: SimWatchFilePoll;
+  private readonly changed: string[] = [];
+
+  private constructor(private readonly directory: TemporaryDirectory) {
+    this.poll = new SimWatchFilePoll({
+      filePath: directory.join(fileName),
+      // Short, so a test waits for a few turns of it rather than for the
+      // interval a running simulation reads its templates on.
+      intervalMs: 50,
+      onChanged: (): void => {
+        this.changed.push(fileName);
+      },
+    });
+    this.poll.start();
+  }
+
+  /**
+   * Write a file and start reading it.
+   */
+  static async of(): Promise<PolledFile> {
+    const directory = new TemporaryDirectory();
+    await directory.writeFile(fileName, "initial");
+
+    return new PolledFile(directory);
+  }
+
+  /**
+   * Save the file, as whatever writes it does.
+   */
+  async write(content: string): Promise<void> {
+    await this.directory.writeFile(fileName, content);
+  }
+
+  /**
+   * How many changes the read has reported.
+   */
+  changeCount(): number {
+    return this.changed.length;
+  }
+
+  /**
+   * Wait for the file to have been reported as changed so many times, rather
+   * than waiting out how long a read takes on the machine running this.
+   */
+  async changes(count: number, withinMs = 5000): Promise<void> {
+    const giveUpAt = Date.now() + withinMs;
+
+    while (this.changed.length < count) {
+      if (Date.now() >= giveUpAt) {
+        throw new Error(
+          `Polled file reported ${String(this.changed.length)} changes, expected ${String(count)}`,
+        );
+      }
+
+      // oxlint-disable-next-line no-await-in-loop -- waiting on a real read
+      await this.pause(20);
+    }
+  }
+
+  /**
+   * Give the read several turns to happen, for a test asserting it stayed
+   * quiet.
+   */
+  async pause(milliseconds: number): Promise<void> {
+    await new Promise((resolve) => {
+      setTimeout(resolve, milliseconds);
+    });
+  }
+
+  /**
+   * Stop reading it, so nothing is left holding the test process open.
+   */
+  close(): void {
+    this.poll.close();
+  }
+}


### PR DESCRIPTION
macOS gives a process one FSEvents stream for all of its watches, and libuv rebuilds that stream from the current instant whenever any watch in the process starts or closes. A save landing during a rebuild reaches nothing, while the watch stays open and reports no error. That is what the intermittent failure in `sim-cfn-template-transform-watch.loc.test.ts` came down to. `SimWatchFilePoll` now reads the template every 100ms behind the events, and a read finding a change the events already reported stays quiet about it, so one save stays one update. A reproduction opening and closing another watch every 11ms in the same process lost the save in 11 of 60 attempts before the change and none in 200 after it.

The flake was the simulator losing a save, not the test being impatient. `updated()` was timing out with nothing recorded and nothing failed, because `fs.watch` never mentioned the write. A 20-line Node script with no Yulin in it reproduces the same drop, so the timeout was reporting a real loss and no timeout was widened.

Reproduction, both against a script driving `deployTemplateFile` with a watch and against `fs.watch` on its own:

| | dropped saves |
| --- | --- |
| `fs.watch` alone, no other watch in the process | 0 of 60 |
| `fs.watch` alone, another watch opening and closing every 11ms | 9 of 60 |
| watched template, same churn, before this change | 11 of 60 |
| watched template, same churn, after it | 0 of 200 |

The de-duplication covers all but one case, which is documented on `reported()`. Two saves inside a single interval, where the events reported the first and lost the second, leave the second for the save after it to carry, because one read of the file cannot tell two writes apart.

`SimS3MountDirectoryEvents` and the `yulin watch` supervisor hold recursive directory watches with the same exposure, and a read on one file does not cover a tree. Worth an issue of its own.

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [ ] User-facing behaviour is documented in `docs/` (no user-facing change, the internal README in `src/service/cloudformation/` carries the mechanism)