### PR TITLE
feat: deploy SAM REST APIs and Api events

### DIFF
--- a/.github/workflows/coverage-badge.yml
+++ b/.github/workflows/coverage-badge.yml
@@ -26,6 +26,11 @@ jobs:
         with:
           version: 11.17.0
           cache: true
+      # The SAM expansion tests compare against real SAM. The CLI has no npm
+      # package, so the workflow installs it beside the Node toolchain.
+      - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:coverage
       - name: Read coverage

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,6 +42,11 @@ jobs:
         with:
           version: 11.17.0
           cache: true
+      # The SAM expansion tests compare against real SAM. The CLI has no npm
+      # package, so the workflow installs it beside the Node toolchain.
+      - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:coverage
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,11 @@ jobs:
         with:
           version: 11.17.0
           cache: true
+      # The SAM expansion tests compare against real SAM. The CLI has no npm
+      # package, so the workflow installs it beside the Node toolchain.
+      - uses: aws-actions/setup-sam@f84ec7d548307efafe33230528756de3c5841a17 # v2
+        with:
+          use-installer: true
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:coverage
 

--- a/README.md
+++ b/README.md
@@ -374,3 +374,14 @@ Install pnpm
 ```bash
 pnpm i
 ```
+
+The local test suite compares Yulin's SAM expansion against real SAM, and needs the AWS SAM CLI on
+the `PATH` to do it. The CLI has no npm package. It installs through Homebrew, pip or the AWS
+installer:
+
+```bash
+brew install aws-sam-cli
+```
+
+`pnpm test:iso` runs without it. `pnpm test:local` and `pnpm check` skip the comparison with a
+warning where the CLI is absent, and a CI run that cannot find it fails.

--- a/docs/services/apigateway/README.md
+++ b/docs/services/apigateway/README.md
@@ -608,6 +608,14 @@ deploys with a root resource and an empty tree under it.
 `StageName` on a `Deployment` is the older one-Resource form, where the deployment publishes a stage
 of that name by itself and the template carries one Resource fewer.
 
+### SAM
+
+A template naming the SAM transform reaches the same resource types.
+`AWS::Serverless::Api` becomes a REST API with its deployment and stage, and the `Api` event of an
+`AWS::Serverless::Function` becomes the path resources, the method and the invoke permission that
+put the function behind it. Events naming no `RestApiId` share one API on a `Prod` stage.
+[The SAM section of the CloudFormation docs](../cloudformation/README.md#rest-apis) covers both.
+
 ### CDK
 
 CDK's `RestApi` and `LambdaRestApi` both deploy and serve. `LambdaRestApi` synthesizes an `ANY`

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -1909,9 +1909,10 @@ a matching binding keep their template code, running in the simulated vm runtime
 A template naming the `AWS::Serverless-2016-10-31` transform has its SAM resources expanded before
 the stack deploys, the way CloudFormation expands them. `AWS::Serverless::Function` becomes an
 `AWS::Lambda::Function` and the `AWS::IAM::Role` it runs as. `AWS::Serverless::SimpleTable` becomes
-an `AWS::DynamoDB::Table`, and `AWS::Serverless::HttpApi` becomes an `AWS::ApiGatewayV2::Api` and
-its stage. `Globals.Function` and `Globals.HttpApi` supply the defaults every function and every API
-takes, and a value on the resource itself wins.
+an `AWS::DynamoDB::Table`. `AWS::Serverless::HttpApi` becomes an `AWS::ApiGatewayV2::Api` and its
+stage, and `AWS::Serverless::Api` becomes an `AWS::ApiGateway::RestApi` with the deployment and
+stage that publish it. `Globals.Function`, `Globals.HttpApi` and `Globals.Api` supply the defaults
+every function and every API takes, and a value on the resource itself wins.
 
 The expanded function keeps the logical ID the SAM resource had. `Ref` and `Fn::GetAtt` against that
 name answer for the function, and a binding targeting that logical ID backs it with your real
@@ -1982,9 +1983,10 @@ its own `Role` runs as that role, and gets no expanded one.
 
 ### Function events
 
-`Events` on a SAM function expand into whatever puts the function behind them. `HttpApi`, `SQS`,
-`DynamoDB`, `SNS`, `S3`, `Schedule`, `ScheduleV2` and `EventBridgeRule` are the types this covers. An
-event of any other type is left where it is, and the function deploys with nothing in front of it.
+`Events` on a SAM function expand into whatever puts the function behind them. `Api`, `HttpApi`,
+`SQS`, `DynamoDB`, `SNS`, `S3`, `Schedule`, `ScheduleV2` and `EventBridgeRule` are the types this
+covers. An event of any other type is left where it is, and the function deploys with nothing in
+front of it.
 
 An `HttpApi` event becomes an `AWS::ApiGatewayV2::Integration`, an `AWS::ApiGatewayV2::Route` and the
 `AWS::Lambda::Permission` the API invokes the function under. `Path` and `Method` become the route
@@ -2057,6 +2059,99 @@ await srv.close();
 ```
 
 `Auth` on the event is left out. Every request matching the expanded route reaches the function.
+
+An `Api` event is the REST half of the same idea. It becomes an `AWS::ApiGateway::Resource` for each
+segment of `Path`, an `AWS::ApiGateway::Method` on the last of them carrying a proxy `Integration`
+to the function, and the `AWS::Lambda::Permission` the API invokes it under. A `Method` of `any`
+becomes `ANY`, and an event stating none gets `ANY` as well. Two events sharing a path prefix share
+the resources that spell it, so `/rates` and `/rates/{currency}` sit on one branch of one tree.
+
+Events naming no `RestApiId` share the API SAM calls `ServerlessRestApi`, published to a `Prod`
+stage. A REST API carries the stage as the first segment of every path it serves. The example below
+requests `/Prod/rates/GBP` for that reason.
+
+```typescript sim-cloudformation-sam-api-event
+/**
+ * A SAM function reached through the REST API its Api event made.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "rates-api-stack",
+  template: {
+    Transform: "AWS::Serverless-2016-10-31",
+    Resources: {
+      Rates: {
+        Type: "AWS::Serverless::Function",
+        Properties: {
+          Handler: "index.handler",
+          Runtime: "nodejs22.x",
+          Events: {
+            Get: {
+              Type: "Api",
+              Properties: { Path: "/rates/{currency}", Method: "GET" },
+            },
+          },
+        },
+      },
+    },
+    Outputs: {
+      ApiUrl: {
+        Value: {
+          "Fn::Join": [
+            "",
+            [
+              "https://",
+              { Ref: "ServerlessRestApi" },
+              ".execute-api.",
+              { Ref: "AWS::Region" },
+              ".",
+              { Ref: "AWS::URLSuffix" },
+              "/",
+              { Ref: "ServerlessRestApiProdStage" },
+              "/",
+            ],
+          ],
+        },
+      },
+    },
+  },
+  bindings: [
+    {
+      logicalId: "Rates",
+      handler: (request: {
+        pathParameters?: Record<string, string> | null;
+      }): { statusCode: number; body: string } => ({
+        statusCode: 200,
+        body: `rate for ${request.pathParameters?.["currency"]}`,
+      }),
+    },
+  ],
+});
+
+await stack.waitForDeployComplete();
+
+const srv = await serveSimAws({ simAws });
+
+const response = await fetch(
+  srv.localUrl(`${stack.output("ApiUrl")}rates/GBP`),
+);
+
+console.log(await response.text());
+// "rate for GBP"
+
+await srv.close();
+```
+
+An event naming a `RestApiId` puts its method on the API that logical ID belongs to, whether an
+`AWS::Serverless::Api` or an `AWS::ApiGateway::RestApi` the template declared. The API is named as
+the logical ID or as a `Ref` to it. An event naming it any other way, such as through
+`Fn::ImportValue`, expands into no resources at all, because a REST API path tree is built downwards
+from a root resource this has no way to reach. `Auth` on the event is left out, the same as on an `HttpApi` one.
 
 A `Schedule` event becomes an `AWS::Events::Rule` on a timer, with the `AWS::Lambda::Permission` the
 rule invokes the function under. The event's `Schedule` is the rule's `ScheduleExpression`, and the
@@ -2310,6 +2405,76 @@ const described = await simAws
 
 console.log(described.Table?.KeySchema);
 ```
+
+### REST APIs
+
+`AWS::Serverless::Api` deploys a REST API, the deployment that publishes it, and the stage `StageName`
+names. The stage carries the logical ID SAM builds for it (`OrdersprodStage` for an API called
+`Orders` with `StageName: prod`, and `OrdersStage` followed by ten characters of a hash where the
+name cannot be part of an identifier). The deployment is `OrdersDeployment`, where SAM appends a
+hash of the document it generates. `Variables` become the stage's stage variables, and `Name`,
+`Description` and `DisableExecuteApiEndpoint` go on the API.
+
+`StageName` is required on an `AWS::Serverless::Api`, and real SAM refuses a template leaving it
+out. Deployment here is best effort, so an API without one publishes to `Prod`, the stage SAM gives
+the implicit API.
+
+A REST API takes a name whatever else it declares, and an API stating no `Name` is named after its
+logical ID. Methods reach it as resources naming it by `RestApiId`. That is how an `Api` event on a
+function reaches an API the template declared, and how an `AWS::ApiGateway::Method` resource of its
+own does.
+
+A `DefinitionBody` reaches the API as its Swagger `Body` and is recorded as a property the API was
+created without, because reading the document is outside this. An API declaring one deploys with a
+root resource and an empty tree under it. An API naming a `DefinitionUri` is recorded as
+unsupported, because this reads no document off disk or out of S3.
+
+The API is deployed without `Auth`, `Cors`, `Domain`, `GatewayResponses`, `MethodSettings` and
+`BinaryMediaTypes`. SAM writes each of them into the document it generates, and none is expanded
+here.
+
+```typescript sim-cloudformation-sam-rest-api
+/**
+ * Deploying a SAM AWS::Serverless::Api, with the Globals.Api defaults.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Transform: "AWS::Serverless-2016-10-31",
+    Globals: {
+      Api: { Variables: { TABLE_NAME: "orders" } },
+    },
+    Resources: {
+      Orders: {
+        Type: "AWS::Serverless::Api",
+        Properties: { Name: "orders-api", StageName: "prod" },
+      },
+    },
+  },
+});
+await stack.waitForDeployComplete();
+
+console.log(stack.getResource("Orders")?.type);
+// "AWS::ApiGateway::RestApi"
+
+console.log(stack.getResource("OrdersDeployment")?.type);
+// "AWS::ApiGateway::Deployment"
+
+console.log(stack.getResource("OrdersprodStage")?.type);
+// "AWS::ApiGateway::Stage"
+```
+
+SAM expands a REST API through the Swagger document it generates, with the paths, methods and
+integrations inside the `Body` of one resource. The expansion here writes the
+`AWS::ApiGateway::Resource` and `AWS::ApiGateway::Method` resources directly. A method is then
+something the stack holds, answers `Ref` for and tears down. The APIs, stages and methods come out
+the same either way, and the logical IDs of the path resources have no counterpart in what SAM
+produces.
 
 ## Serving deployed resources on localhost
 
@@ -2891,16 +3056,21 @@ Sim CloudFormation currently supports:
 - Implicit dependencies from resource `Ref` expressions
 - SAM templates naming the `AWS::Serverless-2016-10-31` transform, with `AWS::Serverless::Function`
   expanded into a Lambda function and its execution Role, `AWS::Serverless::SimpleTable` into a
-  DynamoDB table, `AWS::Serverless::HttpApi` into an HTTP API and its stage, and the
-  `Globals.Function` and `Globals.HttpApi` defaults applied
+  DynamoDB table, `AWS::Serverless::HttpApi` into an HTTP API and its stage,
+  `AWS::Serverless::Api` into a REST API with its deployment and stage, and the `Globals.Function`,
+  `Globals.HttpApi` and `Globals.Api` defaults applied
 - The `HttpApi` event of a SAM function, expanded into the API, integration, route, stage and invoke
-  permission that serve it, and `FunctionUrlConfig`, expanded into a Function URL
+  permission that serve it, and the `Api` event, expanded into the API, path resources, method,
+  deployment, stage and invoke permission that serve it
+- `FunctionUrlConfig` on a SAM function, expanded into a Function URL
 - The `Schedule`, `ScheduleV2` and `EventBridgeRule` events of a SAM function, expanded into the
   EventBridge rule or Scheduler schedule that fires the function, and the permission or execution
   Role the invocation is authorized by
 
 The resource types it creates are:
 
+- `AWS::ApiGateway::RestApi`, `AWS::ApiGateway::Resource`, `AWS::ApiGateway::Method`,
+  `AWS::ApiGateway::Deployment` and `AWS::ApiGateway::Stage`
 - `AWS::ApiGatewayV2::Api`, `AWS::ApiGatewayV2::Integration`, `AWS::ApiGatewayV2::Route` and
   `AWS::ApiGatewayV2::Stage`
 - `AWS::CertificateManager::Certificate`
@@ -2999,12 +3169,11 @@ Each service's own docs describe what its resource types support.
 - The `Condition` attribute is read on resources but not on outputs. An output carrying one is
   resolved and present in `stack.outputs` whichever way its condition falls, where real
   CloudFormation would leave it out.
-- The SAM transform is expanded for `AWS::Serverless::Function`, `AWS::Serverless::SimpleTable` and
-  `AWS::Serverless::HttpApi`. Every other `AWS::Serverless::*` resource type is recorded as
-  unsupported. `HttpApi`, `Schedule`, `ScheduleV2` and `EventBridgeRule` are the event types
-  expanded. An event of another type, such as `Api` or `SQS`, creates nothing. `Auth` on an
-  `HttpApi` event
-  and on the implicit API it shares is left out. `AutoPublishAlias` and `DeploymentPreference` are
-  left out too, because the simulator has one version of a function and nothing to shift traffic
-  between.
+- The SAM transform is expanded for `AWS::Serverless::Function`, `AWS::Serverless::SimpleTable`,
+  `AWS::Serverless::HttpApi` and `AWS::Serverless::Api`. Every other `AWS::Serverless::*` resource
+  type is recorded as unsupported. `Api`, `HttpApi`, `SQS`, `DynamoDB`, `SNS`, `S3`, `Schedule`,
+  `ScheduleV2` and `EventBridgeRule` are the event types expanded, and an event of another type,
+  such as `Cognito`, is left where it is. `Auth` on an `Api` or `HttpApi` event, and on the implicit API
+  either of them shares, is left out. `AutoPublishAlias` and `DeploymentPreference` are left out
+  too, because the simulator has one version of a function and nothing to shift traffic between.
 - Many advanced CloudFormation features are outside the simulation.

--- a/docs/services/cloudformation/sim-cloudformation-sam-api-event.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-sam-api-event.example.ts
@@ -1,0 +1,74 @@
+/**
+ * A SAM function reached through the REST API its Api event made.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "rates-api-stack",
+  template: {
+    Transform: "AWS::Serverless-2016-10-31",
+    Resources: {
+      Rates: {
+        Type: "AWS::Serverless::Function",
+        Properties: {
+          Handler: "index.handler",
+          Runtime: "nodejs22.x",
+          Events: {
+            Get: {
+              Type: "Api",
+              Properties: { Path: "/rates/{currency}", Method: "GET" },
+            },
+          },
+        },
+      },
+    },
+    Outputs: {
+      ApiUrl: {
+        Value: {
+          "Fn::Join": [
+            "",
+            [
+              "https://",
+              { Ref: "ServerlessRestApi" },
+              ".execute-api.",
+              { Ref: "AWS::Region" },
+              ".",
+              { Ref: "AWS::URLSuffix" },
+              "/",
+              { Ref: "ServerlessRestApiProdStage" },
+              "/",
+            ],
+          ],
+        },
+      },
+    },
+  },
+  bindings: [
+    {
+      logicalId: "Rates",
+      handler: (request: {
+        pathParameters?: Record<string, string> | null;
+      }): { statusCode: number; body: string } => ({
+        statusCode: 200,
+        body: `rate for ${request.pathParameters?.["currency"]}`,
+      }),
+    },
+  ],
+});
+
+await stack.waitForDeployComplete();
+
+const srv = await serveSimAws({ simAws });
+
+const response = await fetch(
+  srv.localUrl(`${stack.output("ApiUrl")}rates/GBP`),
+);
+
+console.log(await response.text());
+// "rate for GBP"
+
+await srv.close();

--- a/docs/services/cloudformation/sim-cloudformation-sam-rest-api.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-sam-rest-api.example.ts
@@ -1,0 +1,33 @@
+/**
+ * Deploying a SAM AWS::Serverless::Api, with the Globals.Api defaults.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Transform: "AWS::Serverless-2016-10-31",
+    Globals: {
+      Api: { Variables: { TABLE_NAME: "orders" } },
+    },
+    Resources: {
+      Orders: {
+        Type: "AWS::Serverless::Api",
+        Properties: { Name: "orders-api", StageName: "prod" },
+      },
+    },
+  },
+});
+await stack.waitForDeployComplete();
+
+console.log(stack.getResource("Orders")?.type);
+// "AWS::ApiGateway::RestApi"
+
+console.log(stack.getResource("OrdersDeployment")?.type);
+// "AWS::ApiGateway::Deployment"
+
+console.log(stack.getResource("OrdersprodStage")?.type);
+// "AWS::ApiGateway::Stage"

--- a/src/service/cloudformation/sam/api/sim-cfn-sam-http-api-stage.ts
+++ b/src/service/cloudformation/sam/api/sim-cfn-sam-http-api-stage.ts
@@ -1,10 +1,10 @@
-import { createHash } from "node:crypto";
-
 import type {
   SimCfnTemplateValue,
   SimCfnTemplateValueRecord,
 } from "../../template/value/sim-cfn-template-value.js";
+import { samConditionAttribute } from "../function/sim-cfn-sam-function-properties.js";
 import { samPickedProperties } from "../sim-cfn-sam-picked.js";
+import { samStageLogicalId } from "./sim-cfn-sam-stage-logical-id.js";
 
 interface SamHttpApiStageProperties {
   readonly logicalId: string;
@@ -50,7 +50,7 @@ export function samHttpApiStageResources(
   return {
     [samHttpApiStageLogicalId(logicalId, stageName)]: {
       Type: "AWS::ApiGatewayV2::Stage",
-      ...samStageCondition(resource),
+      ...samConditionAttribute(resource["Condition"]),
       Properties: {
         ...samPickedProperties(apiProperties, propertyNames),
         ApiId: { Ref: logicalId },
@@ -65,11 +65,8 @@ export function samHttpApiStageResources(
  * The logical ID the stage is deployed under, which SAM builds out of the API's
  * logical ID and the stage's name.
  *
- * The three forms are SAM's own. A name that can be part of an identifier goes
- * in whole, `$default` becomes the suffix SAM spells out, and anything else is
- * hashed, down to the ten hexadecimal characters SAM takes off a SHA-1 of the
- * name. A stage the template names with an intrinsic function has no name to
- * hash at this point, and SAM hashes the empty string for it.
+ * `$default` becomes the suffix SAM spells out for it, and every other name
+ * takes the form both API kinds share.
  */
 function samHttpApiStageLogicalId(
   logicalId: string,
@@ -79,30 +76,5 @@ function samHttpApiStageLogicalId(
     return `${logicalId}ApiGatewayDefaultStage`;
   }
 
-  if (typeof stageName === "string" && /^[A-Za-z0-9]+$/.test(stageName)) {
-    return `${logicalId}${stageName}Stage`;
-  }
-
-  return `${logicalId}Stage${samStageNameHash(stageName)}`;
-}
-
-/**
- * The hash SAM builds a stage's logical ID out of when the name cannot be part
- * of one.
- */
-function samStageNameHash(stageName: SimCfnTemplateValue): string {
-  const name = typeof stageName === "string" ? stageName : "";
-
-  return createHash("sha1").update(name).digest("hex").slice(0, 10);
-}
-
-/**
- * The `Condition` attribute the stage carries, where the API carried one.
- */
-function samStageCondition(
-  resource: SimCfnTemplateValueRecord,
-): SimCfnTemplateValueRecord {
-  const condition = resource["Condition"];
-
-  return condition === undefined ? {} : { Condition: condition };
+  return samStageLogicalId(logicalId, stageName);
 }

--- a/src/service/cloudformation/sam/api/sim-cfn-sam-http-api.ts
+++ b/src/service/cloudformation/sam/api/sim-cfn-sam-http-api.ts
@@ -6,7 +6,7 @@ import {
   samCarriedAttributes,
   samResourceProperties,
 } from "../function/sim-cfn-sam-function-properties.js";
-import { samMergedHttpApiProperties } from "../sim-cfn-sam-globals.js";
+import { samMergedApiProperties } from "../sim-cfn-sam-globals.js";
 import { samPickedProperties } from "../sim-cfn-sam-picked.js";
 import { samHttpApiStageResources } from "./sim-cfn-sam-http-api-stage.js";
 
@@ -57,7 +57,7 @@ export function samHttpApiResources(
   properties: SamHttpApiExpansionProperties,
 ): Record<string, SimCfnTemplateValue> {
   const { logicalId, resource, globals } = properties;
-  const apiProperties = samMergedHttpApiProperties(
+  const apiProperties = samMergedApiProperties(
     globals,
     samResourceProperties(resource),
   );

--- a/src/service/cloudformation/sam/api/sim-cfn-sam-rest-api-stage.ts
+++ b/src/service/cloudformation/sam/api/sim-cfn-sam-rest-api-stage.ts
@@ -1,0 +1,71 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../template/value/sim-cfn-template-value.js";
+import { samConditionAttribute } from "../function/sim-cfn-sam-function-properties.js";
+import { samPickedProperties } from "../sim-cfn-sam-picked.js";
+import { samStageLogicalId } from "./sim-cfn-sam-stage-logical-id.js";
+
+interface SamRestApiStageProperties {
+  readonly logicalId: string;
+  readonly resource: SimCfnTemplateValueRecord;
+  readonly apiProperties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * The stage of an API that names none.
+ *
+ * `StageName` is required on an AWS::Serverless::Api, and SAM refuses a
+ * template leaving it out. Deployment here is best effort, so an API missing
+ * it takes the name SAM gives the implicit API rather than failing the stack.
+ */
+export const samRestApiDefaultStageName = "Prod";
+
+/**
+ * The properties the stage takes off the SAM Resource. `Variables` are the
+ * stage variables, and are named the same on both.
+ */
+const propertyNames = new Set(["Variables"]);
+
+/**
+ * The AWS::ApiGateway::Deployment and AWS::ApiGateway::Stage Resources a SAM
+ * REST API is expanded with.
+ *
+ * A REST API serves nothing until a stage is published to it, and a stage is
+ * published from a deployment, so the pair go together. A SAM template names
+ * neither Resource, and the expansion deploys both.
+ *
+ * The deployment carries no `DependsOn` naming the methods, the way a
+ * hand-written template does. A simulated stage serves the API's current
+ * resources rather than a frozen copy, so a method created after the
+ * deployment is served by it.
+ *
+ * Both are conditioned the way the API is. An API the template conditioned out
+ * leaves neither behind for the Stack to create.
+ */
+export function samRestApiStageResources(
+  properties: SamRestApiStageProperties,
+): Record<string, SimCfnTemplateValue> {
+  const { logicalId, resource, apiProperties } = properties;
+  const stageName = apiProperties["StageName"] ?? samRestApiDefaultStageName;
+  const deploymentLogicalId = `${logicalId}Deployment`;
+  const condition = samConditionAttribute(resource["Condition"]);
+
+  return {
+    [deploymentLogicalId]: {
+      Type: "AWS::ApiGateway::Deployment",
+      ...condition,
+      Properties: { RestApiId: { Ref: logicalId } },
+    },
+    [samStageLogicalId(logicalId, stageName)]: {
+      Type: "AWS::ApiGateway::Stage",
+      ...condition,
+      Properties: {
+        ...samPickedProperties(apiProperties, propertyNames),
+        RestApiId: { Ref: logicalId },
+        DeploymentId: { Ref: deploymentLogicalId },
+        StageName: stageName,
+      },
+    },
+  };
+}

--- a/src/service/cloudformation/sam/api/sim-cfn-sam-rest-api-template.factory.ts
+++ b/src/service/cloudformation/sam/api/sim-cfn-sam-rest-api-template.factory.ts
@@ -1,0 +1,138 @@
+import { MappedFactory } from "@kensio/part-factory";
+
+import type { CfnTemplateBodyRecord } from "../../template/sim-cfn-template.js";
+import type { SimCfnTemplateValueRecord } from "../../template/value/sim-cfn-template-value.js";
+import { samFunctionType } from "../function/sim-cfn-sam-function.js";
+import { samTransformName } from "../sim-cfn-sam-transform.js";
+import { samRestApiType } from "./sim-cfn-sam-rest-api.js";
+
+/**
+ * What a test asks for when it wants a SAM template holding one REST API in
+ * front of one function.
+ */
+export interface SimCfnSamRestApiTemplateInput {
+  /**
+   * What this test is about, added to the properties of an API that already
+   * deploys.
+   */
+  readonly apiProperties: SimCfnTemplateValueRecord;
+  /**
+   * The path the function's `Api` event puts a method on. A test about the API
+   * rather than about what it serves asks for none.
+   */
+  readonly path: string | undefined;
+  /**
+   * The `Globals.Api` defaults the template states.
+   */
+  readonly globals: SimCfnTemplateValueRecord;
+}
+
+/**
+ * The logical ID the API carries, and so the name the REST API is expanded
+ * under.
+ */
+export const samRestApiTemplateLogicalId = "Orders";
+
+/**
+ * The logical ID the expanded stage carries, for an API taking the stage name
+ * the factory states by default.
+ */
+export const samRestApiTemplateStageLogicalId = "OrdersprodStage";
+
+/**
+ * The stage name the factory's API publishes under.
+ */
+export const samRestApiTemplateStageName = "prod";
+
+/**
+ * A handler reporting the method, the resource path and the stage that reached
+ * it. A request served through the template says which of the API's methods
+ * served it.
+ */
+const handlerSource = `
+exports.handler = async (event) => ({
+  statusCode: 200,
+  headers: { "content-type": "text/plain" },
+  body: event.httpMethod + " " + event.resource
+    + " " + event.requestContext.stage,
+});
+`;
+
+/**
+ * Builds a SAM template holding one AWS::Serverless::Api.
+ *
+ * ```typescript
+ * const stack = await simAws.cloudFormation().deployTemplate({
+ *   stackName: "orders-stack",
+ *   template: simCfnSamRestApiTemplateFactory.make({
+ *     apiProperties: { StageName: "live" },
+ *   }),
+ * });
+ * ```
+ *
+ * The method is an `Api` event naming the API by `RestApiId`, the way a SAM
+ * template puts a function behind an API it declared. A request the template
+ * serves is one the SAM logical ID answered for.
+ */
+export const simCfnSamRestApiTemplateFactory = new MappedFactory<
+  SimCfnSamRestApiTemplateInput,
+  CfnTemplateBodyRecord
+>(
+  () => ({
+    apiProperties: { StageName: samRestApiTemplateStageName },
+    path: "/orders/{orderId}",
+    globals: {},
+  }),
+  (input) => ({
+    Transform: samTransformName,
+    Globals: { Api: input.globals },
+    Resources: {
+      [samRestApiTemplateLogicalId]: {
+        Type: samRestApiType,
+        Properties: { ...input.apiProperties },
+      },
+      Handler: {
+        Type: samFunctionType,
+        Properties: {
+          FunctionName: "orders",
+          Handler: "index.handler",
+          Runtime: "nodejs22.x",
+          InlineCode: handlerSource,
+          ...functionEvents(input),
+        },
+      },
+    },
+    Outputs: {
+      ApiId: { Value: { Ref: samRestApiTemplateLogicalId } },
+      RootResourceId: {
+        Value: {
+          "Fn::GetAtt": [samRestApiTemplateLogicalId, "RootResourceId"],
+        },
+      },
+    },
+  }),
+);
+
+/**
+ * The `Events` of the function, for a template whose API serves a path.
+ */
+function functionEvents(
+  input: SimCfnSamRestApiTemplateInput,
+): SimCfnTemplateValueRecord {
+  if (input.path === undefined) {
+    return {};
+  }
+
+  return {
+    Events: {
+      Get: {
+        Type: "Api",
+        Properties: {
+          RestApiId: { Ref: samRestApiTemplateLogicalId },
+          Path: input.path,
+          Method: "GET",
+        },
+      },
+    },
+  };
+}

--- a/src/service/cloudformation/sam/api/sim-cfn-sam-rest-api.ts
+++ b/src/service/cloudformation/sam/api/sim-cfn-sam-rest-api.ts
@@ -1,0 +1,107 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../template/value/sim-cfn-template-value.js";
+import {
+  samCarriedAttributes,
+  samResourceProperties,
+} from "../function/sim-cfn-sam-function-properties.js";
+import { samMergedApiProperties } from "../sim-cfn-sam-globals.js";
+import { samPickedProperties } from "../sim-cfn-sam-picked.js";
+import { samRestApiStageResources } from "./sim-cfn-sam-rest-api-stage.js";
+
+interface SamRestApiExpansionProperties {
+  readonly logicalId: string;
+  readonly resource: SimCfnTemplateValueRecord;
+  readonly globals: SimCfnTemplateValueRecord;
+  /**
+   * What names an API that names itself none. The logical ID names one the
+   * template declared, and the implicit API asks for the stack name SAM titles
+   * it with.
+   */
+  readonly defaultName?: SimCfnTemplateValue;
+}
+
+/**
+ * The SAM Resource type this expansion covers.
+ */
+export const samRestApiType = "AWS::Serverless::Api";
+
+/**
+ * The properties whose names and meanings are the same on both Resource types.
+ * Expanding one of them is carrying it across.
+ *
+ * `Auth`, `Cors`, `Domain`, `GatewayResponses`, `MethodSettings` and
+ * `BinaryMediaTypes` are absent from the list. SAM writes all of them into the
+ * Swagger document it generates, and none is expanded here, so an API
+ * declaring one is deployed without it.
+ */
+const propertyNames = new Set([
+  "Description",
+  "DisableExecuteApiEndpoint",
+  "Name",
+]);
+
+/**
+ * Expand one AWS::Serverless::Api into the Resources CloudFormation deploys
+ * for it.
+ *
+ * The API keeps the logical ID the template gave the SAM Resource. `Ref` and
+ * `Fn::GetAtt` against that name answer what they answer for the API, and an
+ * event naming the API by `RestApiId` reaches the one the template declared.
+ * Its deployment and stage are two Resources named after it.
+ *
+ * SAM expands a REST API through a Swagger 2.0 document, with the paths,
+ * methods and integrations written into the `Body` of the API. The Resources
+ * are written directly here instead, the way the HTTP API expansion beside
+ * this one does, so a method is an `AWS::ApiGateway::Method` a Stack holds and
+ * tears down rather than a line of a document nothing reads.
+ *
+ * A `DefinitionBody` goes on as the API's `Body`, which is recorded as a
+ * property the API was created without until the OpenAPI reader lands. A
+ * `DefinitionUri` points at a document on disk or in S3, and an API declaring
+ * one is left as the template wrote it, to be recorded as unsupported. The
+ * alternative is an API deployed with an empty path tree and no sign of why.
+ */
+export function samRestApiResources(
+  properties: SamRestApiExpansionProperties,
+): Record<string, SimCfnTemplateValue> {
+  const { logicalId, resource, globals, defaultName = logicalId } = properties;
+  const apiProperties = samMergedApiProperties(
+    globals,
+    samResourceProperties(resource),
+  );
+
+  if (apiProperties["DefinitionUri"] !== undefined) {
+    return { [logicalId]: resource };
+  }
+
+  return {
+    [logicalId]: {
+      Type: "AWS::ApiGateway::RestApi",
+      ...samCarriedAttributes(resource),
+      Properties: {
+        Name: defaultName,
+        ...samPickedProperties(apiProperties, propertyNames),
+        ...samRestApiBody(apiProperties),
+      },
+    },
+    ...samRestApiStageResources({ logicalId, resource, apiProperties }),
+  };
+}
+
+/**
+ * The Swagger document the API is imported from, where the template declared
+ * one inline.
+ *
+ * A REST API is named whatever the template named it either way. The document
+ * carries a title of its own, and an API Gateway REST API takes a name whether
+ * a document declares one or not.
+ */
+function samRestApiBody(
+  apiProperties: SimCfnTemplateValueRecord,
+): SimCfnTemplateValueRecord {
+  const definitionBody = apiProperties["DefinitionBody"];
+
+  return definitionBody === undefined ? {} : { Body: definitionBody };
+}

--- a/src/service/cloudformation/sam/api/sim-cfn-sam-stage-logical-id.ts
+++ b/src/service/cloudformation/sam/api/sim-cfn-sam-stage-logical-id.ts
@@ -1,0 +1,37 @@
+import { createHash } from "node:crypto";
+
+import type { SimCfnTemplateValue } from "../../template/value/sim-cfn-template-value.js";
+
+/**
+ * The logical ID SAM builds for an API's stage, out of the API's logical ID
+ * and the stage's name.
+ *
+ * A name that can be part of an identifier goes in whole, and anything else is
+ * hashed, down to the ten hexadecimal characters SAM takes off a SHA-1 of the
+ * name. A stage the template names with an intrinsic function has no name to
+ * hash at this point, and SAM hashes the empty string for it.
+ *
+ * Both API kinds build the ID this way. An HTTP API has one form more, for the
+ * `$default` stage a REST API has no equivalent of, and spells that one before
+ * reaching here.
+ */
+export function samStageLogicalId(
+  logicalId: string,
+  stageName: SimCfnTemplateValue,
+): string {
+  if (typeof stageName === "string" && /^[A-Za-z0-9]+$/.test(stageName)) {
+    return `${logicalId}${stageName}Stage`;
+  }
+
+  return `${logicalId}Stage${samStageNameHash(stageName)}`;
+}
+
+/**
+ * The hash SAM builds a stage's logical ID out of when the name cannot be part
+ * of one.
+ */
+function samStageNameHash(stageName: SimCfnTemplateValue): string {
+  const name = typeof stageName === "string" ? stageName : "";
+
+  return createHash("sha1").update(name).digest("hex").slice(0, 10);
+}

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-api-event-path.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-api-event-path.ts
@@ -1,0 +1,93 @@
+import { createHash } from "node:crypto";
+
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../template/value/sim-cfn-template-value.js";
+
+/**
+ * The path an `Api` event states, as the segments under the API's root.
+ *
+ * `/rates/{currency}` is two segments, and `/` is none. A REST API spells a
+ * path over one Resource per segment, where an HTTP API route states the whole
+ * path as its key, so this is where the two expansions part company.
+ */
+export function samApiEventPathParts(path: string): readonly string[] {
+  return path.split("/").filter((part) => part.length > 0);
+}
+
+/**
+ * One AWS::ApiGateway::Resource per node the event's path needs, each naming
+ * its parent by `ParentId` and the top of the tree by `RootResourceId`.
+ *
+ * Nodes are keyed by the path they spell, so two events under one path share
+ * the node rather than declaring it twice. That is what puts `/rates` and
+ * `/rates/{currency}` on one branch of one tree, whether the events are on one
+ * function or spread over several.
+ *
+ * A node carries no `Condition`, the way the implicit API carries none. The
+ * tree is shared, and the other events on it may be conditioned differently or
+ * not at all. A path a conditioned-out function asked for is a node with no
+ * method on it, which answers nothing.
+ */
+export function samApiEventPathResources(
+  apiLogicalId: string,
+  path: readonly string[],
+): Record<string, SimCfnTemplateValue> {
+  return Object.fromEntries(
+    path.map((pathPart, index) => {
+      const nodePath = path.slice(0, index + 1);
+
+      return [
+        samApiEventPathLogicalId(apiLogicalId, nodePath),
+        {
+          Type: "AWS::ApiGateway::Resource",
+          Properties: {
+            RestApiId: { Ref: apiLogicalId },
+            ParentId: samApiEventResourceId(
+              apiLogicalId,
+              nodePath.slice(0, -1),
+            ),
+            PathPart: pathPart,
+          },
+        },
+      ];
+    }),
+  );
+}
+
+/**
+ * What names one node of the tree, which is the API's root resource for the
+ * empty path and a `Ref` to the node's own Resource otherwise.
+ */
+export function samApiEventResourceId(
+  apiLogicalId: string,
+  path: readonly string[],
+): SimCfnTemplateValueRecord {
+  return path.length === 0
+    ? { "Fn::GetAtt": [apiLogicalId, "RootResourceId"] }
+    : { Ref: samApiEventPathLogicalId(apiLogicalId, path) };
+}
+
+/**
+ * The logical ID of the Resource carrying one node of the tree.
+ *
+ * SAM writes its paths into a Swagger document and so names no Resource for
+ * one, which leaves nothing here to match. The path is hashed the way SAM
+ * hashes anything it has to build an identifier out of, because a path part is
+ * `{currency}` or `{proxy+}` as often as it is a word, and every scheme that
+ * spells those out either drops the punctuation that tells them apart or
+ * produces an ID no reader gets anything from. Two events under one path hash
+ * alike and converge on the node.
+ */
+function samApiEventPathLogicalId(
+  apiLogicalId: string,
+  path: readonly string[],
+): string {
+  const hash = createHash("sha1")
+    .update(path.join("/"))
+    .digest("hex")
+    .slice(0, 10);
+
+  return `${apiLogicalId}Resource${hash}`;
+}

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-api-event.iso.test.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-api-event.iso.test.ts
@@ -1,0 +1,400 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsHttp } from "../../../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../../../serve/http/url/sim-aws-local-url.js";
+import type { SimRestApi } from "../../../../apigateway/api/sim-rest-api.js";
+import { SimAws } from "../../../../aws/sim-aws.js";
+import type { SimCfnStack } from "../../../stack/sim-cfn-stack.js";
+import type { SimCfnTemplateValueRecord } from "../../../template/value/sim-cfn-template-value.js";
+import {
+  samFunctionTemplateLogicalId,
+  simCfnSamFunctionTemplateFactory,
+} from "../sim-cfn-sam-function-template.factory.js";
+import { samImplicitRestApiLogicalId } from "./sim-cfn-sam-implicit-rest-api.js";
+
+/**
+ * The stage the implicit API publishes under, which is the one SAM names.
+ */
+const implicitStageName = "Prod";
+
+/**
+ * The proxy event a handler behind a REST API method is handed, as far as
+ * these tests read it.
+ */
+interface RatesRequest {
+  readonly httpMethod: string;
+  readonly pathParameters?: Record<string, string> | null;
+}
+
+/**
+ * A handler answering with the method it was asked and the path parameter it
+ * captured, so a response says which method served it.
+ */
+function ratesHandler(request: RatesRequest): SimCfnTemplateValueRecord {
+  return {
+    statusCode: 200,
+    body: `${request.httpMethod} rate for ${
+      request.pathParameters?.["currency"] ?? "nothing"
+    }`,
+  };
+}
+
+/**
+ * The implicit API the stack deployed, under the logical ID SAM gives it.
+ */
+function implicitApi(stack: SimCfnStack): SimRestApi {
+  const api = stack.getResource(samImplicitRestApiLogicalId)
+    ?.simResource as SimRestApi;
+  assertNonNullable(api);
+
+  return api;
+}
+
+/**
+ * Request a path of a deployed API through the in-process HTTP entry point.
+ */
+async function requestApi(
+  simAws: SimAws,
+  api: SimRestApi,
+  path: string,
+  options: { readonly method?: string; readonly stageName?: string } = {},
+): Promise<Response> {
+  const { method = "GET", stageName = implicitStageName } = options;
+
+  return await new SimAwsHttp({ simAws }).fetch(
+    new SimAwsLocalUrl({
+      input: `${api.invokeUrl(stageName)}${path}`,
+    }).toString(),
+    { method },
+  );
+}
+
+describe("SAM Api event expansion", () => {
+  it("serves a request to the event's path through the function", async () => {
+    // Given a SAM function with an Api event stating a path and a method
+    const simAws = new SimAws();
+
+    // When it is deployed with a handler bound to the function
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "rates-stack",
+      template: simCfnSamFunctionTemplateFactory.make({
+        functionProperties: {
+          Events: {
+            Get: {
+              Type: "Api",
+              Properties: { Path: "/rates/{currency}", Method: "GET" },
+            },
+          },
+        },
+      }),
+      bindings: [
+        { logicalId: samFunctionTemplateLogicalId, handler: ratesHandler },
+      ],
+    });
+
+    // Then the event made an API the Stack holds under the SAM name for it
+    const api = implicitApi(stack);
+    assertArrayLength(stack.skippedResources, 0);
+
+    // And a request to the path the event stated reaches the bound handler
+    const response = await requestApi(simAws, api, "/rates/GBP");
+
+    assertIdentical(response.status, 200);
+    assertIdentical(await response.text(), "GET rate for GBP");
+  });
+
+  it("serves any method where the event asks for one", async () => {
+    // Given an Api event whose method is the `any` a SAM template writes
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "any-rates-stack",
+      template: simCfnSamFunctionTemplateFactory.make({
+        functionProperties: {
+          Events: {
+            Any: { Type: "Api", Properties: { Path: "/rates", Method: "any" } },
+          },
+        },
+      }),
+      bindings: [
+        { logicalId: samFunctionTemplateLogicalId, handler: ratesHandler },
+      ],
+    });
+
+    // Then a method the event never named is served by the same method
+    const response = await requestApi(simAws, implicitApi(stack), "/rates", {
+      method: "DELETE",
+    });
+
+    assertIdentical(response.status, 200);
+    assertIdentical(await response.text(), "DELETE rate for nothing");
+  });
+
+  it("shares one implicit API between the events that name none", async () => {
+    // Given two SAM functions whose events both name no RestApiId, on paths
+    // that share the segment above them
+    const simAws = new SimAws();
+
+    // When they are deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "shared-rates-stack",
+      template: simCfnSamFunctionTemplateFactory.make({
+        functionProperties: {
+          Events: {
+            Get: {
+              Type: "Api",
+              Properties: { Path: "/rates/{currency}", Method: "GET" },
+            },
+          },
+        },
+        resources: {
+          Fees: {
+            Type: "AWS::Serverless::Function",
+            Properties: {
+              FunctionName: "fees",
+              Handler: "index.handler",
+              Runtime: "nodejs22.x",
+              InlineCode:
+                "exports.handler = async () => " +
+                "({ statusCode: 200, body: 'fees' });",
+              Events: {
+                Get: {
+                  Type: "Api",
+                  Properties: { Path: "/rates/fees", Method: "GET" },
+                },
+              },
+            },
+          },
+        },
+      }),
+      bindings: [
+        { logicalId: samFunctionTemplateLogicalId, handler: ratesHandler },
+      ],
+    });
+
+    // Then one API serves both paths, off one node spelling the segment they
+    // share
+    const api = implicitApi(stack);
+    assertArrayLength(api.resources.list(), 4);
+
+    const response = await requestApi(simAws, api, "/rates/GBP");
+    assertIdentical(await response.text(), "GET rate for GBP");
+
+    const shared = await requestApi(simAws, api, "/rates/fees");
+    assertIdentical(await shared.text(), "fees");
+  });
+
+  it("puts a method on the root where the event's path is one", async () => {
+    // Given an Api event whose path is the root of the API
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "root-rates-stack",
+      template: simCfnSamFunctionTemplateFactory.make({
+        functionProperties: {
+          Events: {
+            Get: { Type: "Api", Properties: { Path: "/", Method: "GET" } },
+          },
+        },
+      }),
+      bindings: [
+        { logicalId: samFunctionTemplateLogicalId, handler: ratesHandler },
+      ],
+    });
+
+    // Then the method went on the API's root resource, with no node under it
+    const api = implicitApi(stack);
+    assertArrayLength(api.resources.list(), 1);
+
+    const response = await requestApi(simAws, api, "/");
+
+    assertIdentical(response.status, 200);
+    assertIdentical(await response.text(), "GET rate for nothing");
+  });
+
+  it("routes to the API an event names by RestApiId", async () => {
+    // Given a template declaring a REST API of its own, and an event naming it
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "named-rates-stack",
+      template: simCfnSamFunctionTemplateFactory.make({
+        functionProperties: {
+          Events: {
+            Get: {
+              Type: "Api",
+              Properties: {
+                RestApiId: { Ref: "RatesApi" },
+                Path: "/rates/{currency}",
+                Method: "GET",
+              },
+            },
+          },
+        },
+        resources: {
+          RatesApi: {
+            Type: "AWS::ApiGateway::RestApi",
+            Properties: { Name: "rates-api" },
+          },
+          RatesApiDeployment: {
+            Type: "AWS::ApiGateway::Deployment",
+            Properties: { RestApiId: { Ref: "RatesApi" } },
+          },
+          RatesApiStage: {
+            Type: "AWS::ApiGateway::Stage",
+            Properties: {
+              RestApiId: { Ref: "RatesApi" },
+              DeploymentId: { Ref: "RatesApiDeployment" },
+              StageName: "live",
+            },
+          },
+        },
+      }),
+      bindings: [
+        { logicalId: samFunctionTemplateLogicalId, handler: ratesHandler },
+      ],
+    });
+
+    // Then the method went onto the API the event named, and no implicit API
+    // was made for it
+    assertUndefined(stack.getResource(samImplicitRestApiLogicalId));
+
+    const api = stack.getResource("RatesApi")?.simResource as SimRestApi;
+    assertNonNullable(api);
+
+    const response = await requestApi(simAws, api, "/rates/USD", {
+      stageName: "live",
+    });
+
+    assertIdentical(await response.text(), "GET rate for USD");
+  });
+
+  it("takes the Globals.Api defaults for the implicit API", async () => {
+    // Given a template stating defaults for every API, and a function whose
+    // event makes the implicit one
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "globals-rates-stack",
+      template: simCfnSamFunctionTemplateFactory.make({
+        apiGlobals: { Name: "rates-api" },
+        functionProperties: {
+          Events: {
+            Get: { Type: "Api", Properties: { Path: "/rates", Method: "GET" } },
+          },
+        },
+      }),
+    });
+
+    // Then the API the event made was named by them, where it would otherwise
+    // have taken the name of the stack
+    assertIdentical(implicitApi(stack).name, "rates-api");
+  });
+
+  it("conditions what the event made the way the function is", async () => {
+    // Given a SAM function with an Api event that the template conditions out
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "conditioned-rates-stack",
+      template: {
+        Transform: "AWS::Serverless-2016-10-31",
+        Parameters: { Stage: { Type: "String" } },
+        Conditions: {
+          IsProduction: { "Fn::Equals": [{ Ref: "Stage" }, "production"] },
+        },
+        Resources: {
+          Rates: {
+            Type: "AWS::Serverless::Function",
+            Condition: "IsProduction",
+            Properties: {
+              FunctionName: "conditioned-rates",
+              Handler: "index.handler",
+              Runtime: "nodejs22.x",
+              InlineCode: "exports.handler = async () => 'rates';",
+              Events: {
+                Get: {
+                  Type: "Api",
+                  Properties: { Path: "/rates", Method: "GET" },
+                },
+              },
+            },
+          },
+        },
+      },
+      parameters: { Stage: "test" },
+    });
+
+    // Then the method and the permission went with the function, and the API
+    // the event would have shared has nothing to answer with
+    assertUndefined(stack.getResource("RatesGetMethod"));
+    assertUndefined(stack.getResource("RatesGetPermission"));
+
+    const response = await requestApi(simAws, implicitApi(stack), "/rates");
+
+    assertIdentical(response.status, 403);
+  });
+
+  it("leaves the function alone for an event naming an API by nothing", async () => {
+    // Given an Api event whose RestApiId is neither a logical ID nor a Ref to
+    // one, so nothing here can reach the root the path tree hangs off
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "imported-rates-stack",
+      template: simCfnSamFunctionTemplateFactory.make({
+        functionProperties: {
+          Events: {
+            Get: {
+              Type: "Api",
+              Properties: {
+                RestApiId: { "Fn::ImportValue": "shared-api-id" },
+                Path: "/rates",
+                Method: "GET",
+              },
+            },
+          },
+        },
+      }),
+    });
+
+    // Then the function deployed with nothing in front of it, rather than the
+    // deployment failing over an API this cannot build a tree on
+    assertNonNullable(stack.getResource(samFunctionTemplateLogicalId));
+    assertUndefined(stack.getResource(samImplicitRestApiLogicalId));
+    assertUndefined(stack.getResource("RatesGetMethod"));
+    assertArrayLength(stack.skippedResources, 0);
+  });
+
+  it("leaves the function alone for an event stating no path", async () => {
+    // Given an Api event with no Path, and so no node for a method to hang off
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "pathless-rates-stack",
+      template: simCfnSamFunctionTemplateFactory.make({
+        functionProperties: {
+          Events: { Get: { Type: "Api", Properties: { Method: "GET" } } },
+        },
+      }),
+    });
+
+    // Then the function deployed with nothing in front of it
+    assertNonNullable(stack.getResource(samFunctionTemplateLogicalId));
+    assertUndefined(stack.getResource(samImplicitRestApiLogicalId));
+    assertArrayLength(stack.skippedResources, 0);
+  });
+});

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-api-event.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-api-event.ts
@@ -1,0 +1,172 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../template/value/sim-cfn-template-value.js";
+import { isSamTemplateRecord } from "../../sim-cfn-sam-record.js";
+import { samApiInvokePermissionResource } from "./sim-cfn-sam-api-invoke-permission.js";
+import {
+  samApiEventPathParts,
+  samApiEventPathResources,
+  samApiEventResourceId,
+} from "./sim-cfn-sam-api-event-path.js";
+import type { SamFunctionEvent } from "./sim-cfn-sam-function-events.js";
+import {
+  samImplicitRestApiLogicalId,
+  samImplicitRestApiResources,
+} from "./sim-cfn-sam-implicit-rest-api.js";
+
+/**
+ * The method an event stating none is served under, matching the path whatever
+ * the request did to it.
+ */
+const anyMethod = "ANY";
+
+/**
+ * Expand one `Api` event into the Resources that put a method in front of the
+ * function.
+ *
+ * The event becomes the nodes of the path it states, a method on the last of
+ * them carrying a proxy integration to the function, and the permission the
+ * API invokes the function under. An event naming no `RestApiId` brings the
+ * implicit API, its deployment and its stage with it, and an event naming one
+ * leaves all three to whatever declared it.
+ *
+ * The method and the permission are named after the function and the event, so
+ * two events on one function are two methods, and two functions answering the
+ * same API keep permissions of their own. Both are conditioned the way the
+ * function is, since a function the template conditioned out has nothing for a
+ * method to reach.
+ */
+export function samApiEventResources(
+  event: SamFunctionEvent,
+): Record<string, SimCfnTemplateValue> {
+  const restApiId = event.properties["RestApiId"];
+  const apiLogicalId = samApiEventApiLogicalId(restApiId);
+  const path = samApiEventPath(event.properties);
+
+  if (apiLogicalId === undefined || path === undefined) {
+    return {};
+  }
+
+  const prefix = `${event.functionLogicalId}${event.eventName}`;
+
+  return {
+    ...(restApiId === undefined &&
+      samImplicitRestApiResources(event.apiGlobals)),
+    ...samApiEventPathResources(apiLogicalId, path),
+    [`${prefix}Method`]: methodResource({ event, apiLogicalId, path }),
+    [`${prefix}Permission`]: samApiInvokePermissionResource({
+      event,
+      apiId: { Ref: apiLogicalId },
+      sourceArnSuffix: "/*/*/*",
+    }),
+  };
+}
+
+/**
+ * The logical ID of the API this event puts its method on.
+ *
+ * An event naming no `RestApiId` gets the implicit API. An event naming one
+ * states it as the logical ID or as a `Ref` to it, which is what SAM accepts,
+ * and both name a Resource of this template.
+ *
+ * A `RestApiId` written as anything else names an API whose root resource
+ * nothing here can reach, and a REST API path tree is built downwards from
+ * that root. Such an event expands into nothing, the way an event of a type
+ * this has no entry for does, and the function deploys with nothing in front
+ * of it.
+ */
+function samApiEventApiLogicalId(
+  restApiId: SimCfnTemplateValue | undefined,
+): string | undefined {
+  if (restApiId === undefined) {
+    return samImplicitRestApiLogicalId;
+  }
+
+  if (typeof restApiId === "string") {
+    return restApiId;
+  }
+
+  const reference = isSamTemplateRecord(restApiId)
+    ? restApiId["Ref"]
+    : undefined;
+
+  return typeof reference === "string" ? reference : undefined;
+}
+
+/**
+ * The segments of the `Path` the event states.
+ *
+ * An event stating no path states no method either, since a REST API method
+ * hangs off a node of the tree and there is no node to hang it on. Nothing is
+ * expanded for it.
+ */
+function samApiEventPath(
+  properties: SimCfnTemplateValueRecord,
+): readonly string[] | undefined {
+  const path = properties["Path"];
+
+  return typeof path === "string" ? samApiEventPathParts(path) : undefined;
+}
+
+interface SamApiEventMethodProperties {
+  readonly event: SamFunctionEvent;
+  readonly apiLogicalId: string;
+  readonly path: readonly string[];
+}
+
+/**
+ * The AWS::ApiGateway::Method the event's path and method are served by.
+ *
+ * SAM integrates an `Api` event as a proxy, which is the shape the function is
+ * handed the request in, and the REST API declares an integration as a block
+ * of the method. `Auth` on the event is not expanded, so the method authorizes
+ * nothing and every request matching it reaches the function.
+ */
+function methodResource(
+  properties: SamApiEventMethodProperties,
+): SimCfnTemplateValueRecord {
+  const { event, apiLogicalId, path } = properties;
+
+  return {
+    Type: "AWS::ApiGateway::Method",
+    ...event.condition,
+    Properties: {
+      RestApiId: { Ref: apiLogicalId },
+      ResourceId: samApiEventResourceId(apiLogicalId, path),
+      HttpMethod: samApiEventHttpMethod(event.properties),
+      AuthorizationType: "NONE",
+      Integration: {
+        Type: "AWS_PROXY",
+        IntegrationHttpMethod: "POST",
+        Uri: {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              { Ref: "AWS::Partition" },
+              ":apigateway:",
+              { Ref: "AWS::Region" },
+              ":lambda:path/2015-03-31/functions/",
+              { "Fn::GetAtt": [event.functionLogicalId, "Arn"] },
+              "/invocations",
+            ],
+          ],
+        },
+      },
+    },
+  };
+}
+
+/**
+ * The HTTP method the event asked for.
+ *
+ * A method in lower case is upper-cased, the only case API Gateway takes, so
+ * the `any` a SAM template usually writes becomes `ANY`. An event stating no
+ * method gets `ANY` as well.
+ */
+function samApiEventHttpMethod(properties: SimCfnTemplateValueRecord): string {
+  const method = properties["Method"];
+
+  return typeof method === "string" ? method.toUpperCase() : anyMethod;
+}

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-api-invoke-permission.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-api-invoke-permission.ts
@@ -4,20 +4,33 @@ import type {
 } from "../../../template/value/sim-cfn-template-value.js";
 import type { SamFunctionEvent } from "./sim-cfn-sam-function-events.js";
 
+interface SamApiInvokePermissionProperties {
+  readonly event: SamFunctionEvent;
+  /** The API the permission is granted to, as the expanded Resources name it. */
+  readonly apiId: SimCfnTemplateValue;
+  /**
+   * What the source ARN wildcards after the API's id. An HTTP API addresses a
+   * request by stage and route, and a REST API by stage, method and resource
+   * path, so the two grants are a segment apart.
+   */
+  readonly sourceArnSuffix: string;
+}
+
 /**
- * The AWS::Lambda::Permission the API invokes the function under.
+ * The AWS::Lambda::Permission an API invokes the function under.
  *
  * A Lambda proxy integration works only once the function's resource policy
  * admits API Gateway. Without this the route answers 500.
  *
- * The source ARN wildcards the stage and the route, the grant SAM writes.
- * Every route this API sends the function is one an event of its own asked
+ * The source ARN wildcards everything under the API, the grant SAM writes.
+ * Every request this API sends the function is one an event of its own asked
  * for.
  */
-export function samHttpApiPermissionResource(
-  event: SamFunctionEvent,
-  apiId: SimCfnTemplateValue,
+export function samApiInvokePermissionResource(
+  properties: SamApiInvokePermissionProperties,
 ): SimCfnTemplateValueRecord {
+  const { event, apiId, sourceArnSuffix } = properties;
+
   return {
     Type: "AWS::Lambda::Permission",
     ...event.condition,
@@ -37,7 +50,7 @@ export function samHttpApiPermissionResource(
             { Ref: "AWS::AccountId" },
             ":",
             apiId,
-            "/*/*",
+            sourceArnSuffix,
           ],
         ],
       },

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-declared-event.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-declared-event.ts
@@ -13,6 +13,11 @@ export interface SamFunctionEventsProperties {
   readonly logicalId: string;
   /** The function properties, with the `Globals` defaults already merged in. */
   readonly functionProperties: SimCfnTemplateValueRecord;
+  /**
+   * The `Globals.Api` defaults the template states, for the events that make
+   * an API of their own.
+   */
+  readonly apiGlobals: SimCfnTemplateValueRecord;
   /** The `Condition` the SAM Resource carried, where it carried one. */
   readonly condition: SimCfnTemplateValue | undefined;
 }
@@ -39,6 +44,12 @@ export interface SamFunctionEvent {
    * supplies nothing.
    */
   readonly condition: SimCfnTemplateValueRecord;
+  /**
+   * The `Globals.Api` defaults the template states. An `Api` event naming no
+   * `RestApiId` makes the implicit API, and SAM gives that API the same
+   * defaults as one the template declared.
+   */
+  readonly apiGlobals: SimCfnTemplateValueRecord;
 }
 
 /**
@@ -96,6 +107,7 @@ function declaredEvent(
         eventName,
         properties: isSamTemplateRecord(eventProperties) ? eventProperties : {},
         condition: samConditionAttribute(properties.condition),
+        apiGlobals: properties.apiGlobals,
       },
     },
   ];

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-function-events.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-function-events.ts
@@ -12,6 +12,7 @@ import {
   samDynamoDbEventEdits,
   samSqsEventEdits,
 } from "./sim-cfn-sam-event-source-role.js";
+import { samApiEventResources } from "./sim-cfn-sam-api-event.js";
 import { samEventBridgeRuleEventResources } from "./sim-cfn-sam-event-bridge-rule-event.js";
 import { samHttpApiEventResources } from "./sim-cfn-sam-http-api-event.js";
 import type { SamResourceEdit } from "./sim-cfn-sam-resource-edit.js";
@@ -51,6 +52,7 @@ export type SamFunctionEventEdit = (
  */
 const eventExpansions: ReadonlyMap<string, SamFunctionEventExpansion> = new Map(
   [
+    ["Api", samApiEventResources],
     ["DynamoDB", samDynamoDbEventResources],
     ["EventBridgeRule", samEventBridgeRuleEventResources],
     ["HttpApi", samHttpApiEventResources],

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-http-api-event.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-http-api-event.ts
@@ -4,7 +4,7 @@ import type {
 } from "../../../template/value/sim-cfn-template-value.js";
 import { isSamTemplateRecord } from "../../sim-cfn-sam-record.js";
 import type { SamFunctionEvent } from "./sim-cfn-sam-function-events.js";
-import { samHttpApiPermissionResource } from "./sim-cfn-sam-http-api-permission.js";
+import { samApiInvokePermissionResource } from "./sim-cfn-sam-api-invoke-permission.js";
 import { samHttpApiRouteResource } from "./sim-cfn-sam-http-api-route.js";
 import {
   samImplicitHttpApiLogicalId,
@@ -43,7 +43,11 @@ export function samHttpApiEventResources(
       integrationLogicalId,
       event,
     }),
-    [`${prefix}Permission`]: samHttpApiPermissionResource(event, apiId),
+    [`${prefix}Permission`]: samApiInvokePermissionResource({
+      event,
+      apiId,
+      sourceArnSuffix: "/*/*",
+    }),
   };
 }
 

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-implicit-rest-api.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-implicit-rest-api.ts
@@ -1,0 +1,36 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../template/value/sim-cfn-template-value.js";
+import { samRestApiResources } from "../../api/sim-cfn-sam-rest-api.js";
+
+/**
+ * The logical ID SAM gives the API that every `Api` event naming no
+ * `RestApiId` shares. It is the name a template reaches the implicit API by,
+ * in an `Output` or in a `Ref` from a Resource of its own.
+ */
+export const samImplicitRestApiLogicalId = "ServerlessRestApi";
+
+/**
+ * The API, deployment and stage an `Api` event naming no `RestApiId` is served
+ * by.
+ *
+ * The API is expanded as though the template had declared an
+ * `AWS::Serverless::Api` stating nothing, which is what SAM's implicit API is.
+ * That gives it the `Prod` stage SAM names, and the `Globals.Api` defaults
+ * every API takes. SAM titles the document it generates with the stack name,
+ * so that is the name this API answers to when `Globals.Api` states none.
+ *
+ * Every event naming no `RestApiId` produces this same set, and they are keyed
+ * by logical ID, so the API is created once however many events share it.
+ */
+export function samImplicitRestApiResources(
+  globals: SimCfnTemplateValueRecord,
+): Record<string, SimCfnTemplateValue> {
+  return samRestApiResources({
+    logicalId: samImplicitRestApiLogicalId,
+    resource: {},
+    globals,
+    defaultName: { Ref: "AWS::StackName" },
+  });
+}

--- a/src/service/cloudformation/sam/function/sim-cfn-sam-function-template.factory.ts
+++ b/src/service/cloudformation/sam/function/sim-cfn-sam-function-template.factory.ts
@@ -20,6 +20,11 @@ export interface SimCfnSamFunctionTemplateInput {
    */
   readonly globals: SimCfnTemplateValueRecord;
   /**
+   * The `Globals.Api` defaults the template states, for a test about what an
+   * `Api` event takes from them. A test stating none gets no section.
+   */
+  readonly apiGlobals: SimCfnTemplateValueRecord;
+  /**
    * Resources the template carries beside the function, such as the API an
    * event names or a second function sharing one.
    */
@@ -58,7 +63,12 @@ export const simCfnSamFunctionTemplateFactory = new MappedFactory<
   SimCfnSamFunctionTemplateInput,
   CfnTemplateBodyRecord
 >(
-  () => ({ functionProperties: {}, globals: {}, resources: {} }),
+  () => ({
+    functionProperties: {},
+    globals: {},
+    apiGlobals: {},
+    resources: {},
+  }),
   (input) => ({
     Transform: samTransformName,
     ...globalsSection(input),
@@ -78,9 +88,21 @@ export const simCfnSamFunctionTemplateFactory = new MappedFactory<
 function globalsSection(
   input: SimCfnSamFunctionTemplateInput,
 ): SimCfnTemplateValueRecord {
-  if (Object.keys(input.globals).length === 0) {
-    return {};
-  }
+  const globals = {
+    ...section("Function", input.globals),
+    ...section("Api", input.apiGlobals),
+  };
 
-  return { Globals: { Function: input.globals } };
+  return Object.keys(globals).length === 0 ? {} : { Globals: globals };
+}
+
+/**
+ * One section of the `Globals`, for a test stating defaults for that kind of
+ * Resource.
+ */
+function section(
+  name: string,
+  defaults: SimCfnTemplateValueRecord,
+): SimCfnTemplateValueRecord {
+  return Object.keys(defaults).length === 0 ? {} : { [name]: defaults };
 }

--- a/src/service/cloudformation/sam/function/sim-cfn-sam-function.ts
+++ b/src/service/cloudformation/sam/function/sim-cfn-sam-function.ts
@@ -2,6 +2,7 @@ import type {
   SimCfnTemplateValue,
   SimCfnTemplateValueRecord,
 } from "../../template/value/sim-cfn-template-value.js";
+import type { SamTemplateGlobals } from "../sim-cfn-sam-globals.js";
 import { samMergedFunctionProperties } from "../sim-cfn-sam-globals.js";
 import {
   samFunctionEventEdits,
@@ -19,7 +20,11 @@ import { samFunctionUrlResources } from "./sim-cfn-sam-function-url.js";
 interface SamFunctionExpansionProperties {
   readonly logicalId: string;
   readonly resource: SimCfnTemplateValueRecord;
-  readonly globals: SimCfnTemplateValueRecord;
+  /**
+   * The whole `Globals` section. The function takes its own defaults from
+   * `Function`, and its `Api` events take theirs from `Api`.
+   */
+  readonly globals: SamTemplateGlobals;
 }
 
 /**
@@ -52,7 +57,7 @@ export function samFunctionResources(
 ): Record<string, SimCfnTemplateValue> {
   const { logicalId, resource, globals } = properties;
   const functionProperties = samMergedFunctionProperties(
-    globals,
+    globals.forFunction,
     samResourceProperties(resource),
   );
   const roleLogicalId = `${logicalId}Role`;
@@ -78,7 +83,12 @@ export function samFunctionResources(
       }),
     }),
     ...samFunctionUrlResources({ logicalId, functionProperties, condition }),
-    ...samFunctionEventResources({ logicalId, functionProperties, condition }),
+    ...samFunctionEventResources({
+      logicalId,
+      functionProperties,
+      condition,
+      apiGlobals: globals.forApi,
+    }),
   };
 }
 
@@ -99,9 +109,10 @@ export function samFunctionResourceEdits(
   return samFunctionEventEdits({
     logicalId,
     functionProperties: samMergedFunctionProperties(
-      globals,
+      globals.forFunction,
       samResourceProperties(resource),
     ),
     condition: resource["Condition"],
+    apiGlobals: globals.forApi,
   });
 }

--- a/src/service/cloudformation/sam/sim-cfn-sam-expansion.ts
+++ b/src/service/cloudformation/sam/sim-cfn-sam-expansion.ts
@@ -5,6 +5,10 @@ import {
   samHttpApiResources,
   samHttpApiType,
 } from "./api/sim-cfn-sam-http-api.js";
+import {
+  samRestApiResources,
+  samRestApiType,
+} from "./api/sim-cfn-sam-rest-api.js";
 import type { SamResourceEdit } from "./function/event/sim-cfn-sam-resource-edit.js";
 import { samEditedResources } from "./function/event/sim-cfn-sam-resource-edit.js";
 import {
@@ -84,11 +88,7 @@ function resourceEdits(
     return [];
   }
 
-  return samFunctionResourceEdits({
-    logicalId,
-    resource,
-    globals: globals.forFunction,
-  });
+  return samFunctionResourceEdits({ logicalId, resource, globals });
 }
 
 /**
@@ -107,11 +107,7 @@ function expandedResource(
   const type = resource["Type"];
 
   if (type === samFunctionType) {
-    return samFunctionResources({
-      logicalId,
-      resource,
-      globals: globals.forFunction,
-    });
+    return samFunctionResources({ logicalId, resource, globals });
   }
 
   if (type === samHttpApiType) {
@@ -119,6 +115,14 @@ function expandedResource(
       logicalId,
       resource,
       globals: globals.forHttpApi,
+    });
+  }
+
+  if (type === samRestApiType) {
+    return samRestApiResources({
+      logicalId,
+      resource,
+      globals: globals.forApi,
     });
   }
 

--- a/src/service/cloudformation/sam/sim-cfn-sam-globals.ts
+++ b/src/service/cloudformation/sam/sim-cfn-sam-globals.ts
@@ -11,6 +11,8 @@ export interface SamTemplateGlobals {
   readonly forFunction: SimCfnTemplateValueRecord;
   /** The `Globals.HttpApi` defaults every SAM HTTP API takes. */
   readonly forHttpApi: SimCfnTemplateValueRecord;
+  /** The `Globals.Api` defaults every SAM REST API takes. */
+  readonly forApi: SimCfnTemplateValueRecord;
 }
 
 /**
@@ -23,12 +25,13 @@ export function samTemplateGlobals(
   const globals = template["Globals"];
 
   if (!isSamTemplateRecord(globals)) {
-    return { forFunction: {}, forHttpApi: {} };
+    return { forFunction: {}, forHttpApi: {}, forApi: {} };
   }
 
   return {
     forFunction: samGlobalsSection(globals["Function"]),
     forHttpApi: samGlobalsSection(globals["HttpApi"]),
+    forApi: samGlobalsSection(globals["Api"]),
   };
 }
 
@@ -41,14 +44,16 @@ function samGlobalsSection(section: unknown): SimCfnTemplateValueRecord {
 }
 
 /**
- * The properties an HTTP API is expanded with, from the `Globals.HttpApi`
- * defaults and what the API states for itself.
+ * The properties an API is expanded with, from the `Globals` defaults its kind
+ * takes and what the API states for itself.
  *
  * A property the API states wins outright. Nothing here is merged the way a
- * function's environment variables are, because none of what an HTTP API takes
- * from `Globals` is a set of named entries a second declaration adds to.
+ * function's environment variables are, because none of what an API takes from
+ * `Globals` is a set of named entries a second declaration adds to.
+ *
+ * Both API kinds merge the same way, against the section of their own.
  */
-export function samMergedHttpApiProperties(
+export function samMergedApiProperties(
   globals: SimCfnTemplateValueRecord,
   properties: SimCfnTemplateValueRecord,
 ): SimCfnTemplateValueRecord {

--- a/src/service/cloudformation/sam/sim-cfn-sam-rest-api.iso.test.ts
+++ b/src/service/cloudformation/sam/sim-cfn-sam-rest-api.iso.test.ts
@@ -1,0 +1,318 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertObjectEquals,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import type { SimRestApi } from "../../apigateway/api/sim-rest-api.js";
+import type { SimRestApiStage } from "../../apigateway/api/stage/sim-rest-api-stage.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnStack } from "../stack/sim-cfn-stack.js";
+import type { CfnTemplateBodyRecord } from "../template/sim-cfn-template.js";
+import {
+  samRestApiTemplateLogicalId,
+  samRestApiTemplateStageLogicalId,
+  samRestApiTemplateStageName,
+  simCfnSamRestApiTemplateFactory,
+} from "./api/sim-cfn-sam-rest-api-template.factory.js";
+
+/**
+ * Deploy a SAM template and wait for the API it holds to be serving.
+ */
+async function deployRestApi(
+  simAws: SimAws,
+  template: CfnTemplateBodyRecord,
+): Promise<SimCfnStack> {
+  const stack = await simAws
+    .cloudFormation()
+    .deployTemplate({ stackName: "orders-stack", template });
+  await stack.waitForDeployComplete();
+
+  return stack;
+}
+
+/**
+ * The API the stack deployed under the SAM logical ID.
+ */
+function deployedApi(stack: SimCfnStack): SimRestApi {
+  const api = stack.getResource(samRestApiTemplateLogicalId)
+    ?.simResource as SimRestApi;
+  assertNonNullable(api);
+
+  return api;
+}
+
+/**
+ * Request a path of the API the stack deployed, through one of its stages.
+ */
+async function requestApi(
+  simAws: SimAws,
+  stack: SimCfnStack,
+  path: string,
+  stageName = samRestApiTemplateStageName,
+): Promise<Response> {
+  return await new SimAwsHttp({ simAws }).fetch(
+    new SimAwsLocalUrl({
+      input: `${deployedApi(stack).invokeUrl(stageName)}${path}`,
+    }).toString(),
+  );
+}
+
+describe("SAM Serverless Api expansion", () => {
+  it("deploys a SAM REST API as an API, a deployment and a stage", async () => {
+    // Given a SAM template declaring one REST API in front of a function
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await deployRestApi(
+      simAws,
+      simCfnSamRestApiTemplateFactory.make(),
+    );
+
+    // Then the SAM logical ID is a simulated REST API, with a deployment and a
+    // stage of its own
+    assertIdentical(
+      stack.getResource(samRestApiTemplateLogicalId)?.type,
+      "AWS::ApiGateway::RestApi",
+    );
+    assertIdentical(
+      stack.getResource("OrdersDeployment")?.type,
+      "AWS::ApiGateway::Deployment",
+    );
+    assertIdentical(
+      stack.getResource(samRestApiTemplateStageLogicalId)?.type,
+      "AWS::ApiGateway::Stage",
+    );
+    assertArrayLength(stack.skippedResources, 0);
+
+    // And the method the event declared against it is served from that stage
+    const response = await requestApi(simAws, stack, "/orders/YL-1");
+
+    assertIdentical(response.status, 200);
+    assertIdentical(await response.text(), "GET /orders/{orderId} prod");
+  });
+
+  it("names an API that names itself none after its logical ID", async () => {
+    // Given an API stating no Name, which a REST API cannot go without
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await deployRestApi(
+      simAws,
+      simCfnSamRestApiTemplateFactory.make(),
+    );
+
+    // Then the logical ID the template already had for it named it
+    assertIdentical(deployedApi(stack).name, samRestApiTemplateLogicalId);
+  });
+
+  it("answers Ref and Fn::GetAtt against the SAM logical ID", async () => {
+    // Given a SAM template outputting what its API's logical ID resolves to
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await deployRestApi(
+      simAws,
+      simCfnSamRestApiTemplateFactory.make(),
+    );
+
+    // Then both answer for the API the SAM Resource was expanded into
+    const api = deployedApi(stack);
+
+    assertIdentical(stack.outputs.get("ApiId")?.value, api.apiId);
+    assertIdentical(
+      stack.outputs.get("RootResourceId")?.value,
+      api.rootResource.resourceId,
+    );
+  });
+
+  it("deploys the stage the API names, with the variables it states", async () => {
+    // Given an API naming a stage and the variables it serves under
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await deployRestApi(
+      simAws,
+      simCfnSamRestApiTemplateFactory.make({
+        apiProperties: {
+          StageName: "live",
+          Variables: { table: "orders-live" },
+        },
+      }),
+    );
+
+    // Then the stage carries the name and the variables the API stated
+    const stage = stack.getResource("OrdersliveStage")
+      ?.simResource as SimRestApiStage;
+    assertNonNullable(stage);
+    assertIdentical(stage.stageName, "live");
+    assertObjectEquals(stage.variables, { table: "orders-live" });
+
+    // And it serves the API's methods under its own path segment
+    const response = await requestApi(simAws, stack, "/orders/YL-1", "live");
+
+    assertIdentical(response.status, 200);
+    assertIdentical(await response.text(), "GET /orders/{orderId} live");
+  });
+
+  it("names the stage of an API whose stage name is no identifier", async () => {
+    // Given an API naming a stage a logical ID cannot be built out of, which
+    // SAM hashes into one
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await deployRestApi(
+      simAws,
+      simCfnSamRestApiTemplateFactory.make({
+        apiProperties: { StageName: "orders-dev" },
+      }),
+    );
+
+    // Then the stage carries the logical ID SAM hashes the name into, and
+    // serves the API's methods
+    const stage = stack.getResource("OrdersStageaed0986a76")
+      ?.simResource as SimRestApiStage;
+    assertNonNullable(stage);
+    assertIdentical(stage.stageName, "orders-dev");
+
+    const response = await requestApi(
+      simAws,
+      stack,
+      "/orders/YL-1",
+      "orders-dev",
+    );
+
+    assertIdentical(response.status, 200);
+    assertIdentical(await response.text(), "GET /orders/{orderId} orders-dev");
+  });
+
+  it("publishes the stage SAM names where the API names none", async () => {
+    // Given an API leaving out the StageName SAM requires of one
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await deployRestApi(simAws, {
+      Transform: "AWS::Serverless-2016-10-31",
+      Resources: {
+        [samRestApiTemplateLogicalId]: { Type: "AWS::Serverless::Api" },
+      },
+    });
+
+    // Then it deploys under the stage SAM gives the implicit API, rather than
+    // failing the stack over a property a hand-written template forgot
+    const stage = stack.getResource("OrdersProdStage")
+      ?.simResource as SimRestApiStage;
+    assertNonNullable(stage);
+    assertIdentical(stage.stageName, "Prod");
+  });
+
+  it("records a DefinitionBody as a property the API was created without", async () => {
+    // Given an API declaring its methods as a Swagger document, which nothing
+    // here reads yet
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await deployRestApi(
+      simAws,
+      simCfnSamRestApiTemplateFactory.make({
+        path: undefined,
+        apiProperties: {
+          DefinitionBody: {
+            swagger: "2.0",
+            info: { title: "orders-api", version: "1.0" },
+            paths: {},
+          },
+        },
+      }),
+    );
+
+    // Then the API deploys with an empty tree, and the record says the
+    // document is what it was created without
+    assertArrayLength(deployedApi(stack).resources.list(), 1);
+    assertTrue(
+      stack.ignoredProperties.some(
+        (ignored) =>
+          ignored.logicalId === samRestApiTemplateLogicalId &&
+          ignored.reason.includes("Body"),
+      ),
+    );
+  });
+
+  it("records an API declaring a DefinitionUri as unsupported", async () => {
+    // Given an API whose document is a file this reads nothing from
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await deployRestApi(
+      simAws,
+      simCfnSamRestApiTemplateFactory.make({
+        path: undefined,
+        apiProperties: { DefinitionUri: "swagger/orders.yaml" },
+      }),
+    );
+
+    // Then the API is recorded the way any Resource type nothing models is,
+    // rather than deployed as an API serving nothing
+    assertArrayLength(stack.skippedResources, 1);
+    const skipped = stack.skippedResources[0];
+    assertNonNullable(skipped);
+    assertIdentical(skipped.logicalId, samRestApiTemplateLogicalId);
+    assertIdentical(
+      skipped.skippedReason,
+      "Unsupported sim CloudFormation Resource service Serverless",
+    );
+  });
+
+  it("leaves out the deployment and stage of an API conditioned out", async () => {
+    // Given an API the template only deploys under a condition it fails
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await deployRestApi(simAws, {
+      Transform: "AWS::Serverless-2016-10-31",
+      Conditions: { IsProduction: { "Fn::Equals": ["dev", "prod"] } },
+      Resources: {
+        [samRestApiTemplateLogicalId]: {
+          Type: "AWS::Serverless::Api",
+          Condition: "IsProduction",
+          Properties: { StageName: "prod" },
+        },
+      },
+    });
+
+    // Then none of the three Resources it expands into was created
+    assertUndefined(stack.getResource(samRestApiTemplateLogicalId));
+    assertUndefined(stack.getResource("OrdersDeployment"));
+    assertUndefined(stack.getResource(samRestApiTemplateStageLogicalId));
+  });
+
+  it("takes the Globals.Api defaults, and lets the API overrule them", async () => {
+    // Given a template stating defaults for every API, and an API stating one
+    // of them for itself
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await deployRestApi(
+      simAws,
+      simCfnSamRestApiTemplateFactory.make({
+        globals: { Name: "every-api", Variables: { table: "orders" } },
+        apiProperties: { Name: "orders-api" },
+      }),
+    );
+
+    // Then the default the API said nothing about reached it, and the one it
+    // stated for itself won
+    assertIdentical(deployedApi(stack).name, "orders-api");
+
+    const stage = stack.getResource(samRestApiTemplateStageLogicalId)
+      ?.simResource as SimRestApiStage;
+    assertNonNullable(stage);
+    assertObjectEquals(stage.variables, { table: "orders" });
+  });
+});

--- a/src/service/cloudformation/sam/sim-cfn-sam-rest-api.loc.test.ts
+++ b/src/service/cloudformation/sam/sim-cfn-sam-rest-api.loc.test.ts
@@ -1,0 +1,73 @@
+import { assertArrayEquals, assertNonNullable } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  samCliMissing,
+  samRestApiTemplate,
+  servedMethods,
+  sortedNames,
+  stageLogicalIds,
+} from "../../../../test/cloudformation/sam-cli.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { TestSamProject } from "../../../util/filesystem/test-sam-project.js";
+
+/**
+ * The stages the template publishes, as the SAM CLI names them.
+ */
+const expectedStages = [
+  "RatesApiStageaed0986a76",
+  "ServerlessRestApiProdStage",
+];
+
+/**
+ * The APIs the template deploys, as the SAM CLI names them.
+ */
+const expectedApis = ["RatesApi", "ServerlessRestApi"];
+
+describe.skipIf(samCliMissing)(
+  "SAM REST API expansion against the SAM CLI",
+  () => {
+    it("expands the APIs, stages and methods real SAM expands", async () => {
+      // Given a SAM template the real CLI and this simulation are both given
+      const samProject = new TestSamProject();
+      await samProject.writeTemplate(samRestApiTemplate);
+
+      // When the SAM CLI is asked what deploying it would create, and the same
+      // template is deployed here
+      const samResources = await samProject.listResources();
+      const samEndpoints = await samProject.listEndpoints();
+
+      const simAws = new SimAws();
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "rates-stack",
+        template: samRestApiTemplate,
+      });
+      await stack.waitForDeployComplete();
+
+      // Then the stages SAM publishes are the stages deployed here, under the
+      // logical IDs SAM builds for them
+      assertArrayEquals(stageLogicalIds(samResources), expectedStages);
+
+      for (const logicalId of expectedStages) {
+        assertNonNullable(
+          stack.getResource(logicalId),
+          `${logicalId} was not deployed`,
+        );
+      }
+
+      // And every API SAM reports serves the methods it reports, off the paths
+      // it reports them under
+      assertArrayEquals(
+        sortedNames(samEndpoints.map((endpoint) => endpoint.logicalId)),
+        expectedApis,
+      );
+
+      for (const endpoint of samEndpoints) {
+        assertArrayEquals(
+          servedMethods(stack, endpoint.logicalId),
+          sortedNames(endpoint.methods),
+        );
+      }
+    });
+  },
+);

--- a/src/util/filesystem/test-sam-endpoint-methods.ts
+++ b/src/util/filesystem/test-sam-endpoint-methods.ts
@@ -1,0 +1,27 @@
+/**
+ * The Swagger extension SAM writes a path with no method of its own under.
+ */
+const anyMethodKey = "x-amazon-apigateway-any-method";
+
+/**
+ * The methods of one path the SAM CLI reported.
+ *
+ * It spells them as the path followed by the Swagger operation keys under it,
+ * as in `/rates/{id}['post', 'get']`, and each one comes back as the
+ * `POST /rates/{id}` an API Gateway method is read as here.
+ */
+export function samEndpointMethods(endpoint: string): string[] {
+  const [path = endpoint, keys = ""] = endpoint.split("[", 2);
+
+  return keys
+    .replaceAll(/[[\]']/g, "")
+    .split(",")
+    .map((key) => `${samHttpMethod(key.trim())} ${path}`);
+}
+
+/**
+ * One Swagger operation key as the HTTP method it stands for.
+ */
+function samHttpMethod(key: string): string {
+  return key === anyMethodKey ? "ANY" : key.toUpperCase();
+}

--- a/src/util/filesystem/test-sam-project.ts
+++ b/src/util/filesystem/test-sam-project.ts
@@ -1,0 +1,138 @@
+import { execa } from "execa";
+import { samEndpointMethods } from "./test-sam-endpoint-methods.js";
+import { TemporaryDirectory } from "./temporary-directory.js";
+
+interface TestSamProjectProperties {
+  projectDirectory?: TemporaryDirectory;
+}
+
+/**
+ * One API of a template, and the methods the SAM CLI says it serves.
+ */
+export interface TestSamEndpoint {
+  /** The logical ID the expansion gave the API. */
+  readonly logicalId: string;
+  /** One `GET /rates/{currency}` per method, in no particular order. */
+  readonly methods: readonly string[];
+}
+
+/**
+ * The name the SAM CLI is invoked by. It installs through pip, Homebrew or the
+ * AWS installer and has no npm package, so it is whatever the machine put on
+ * the PATH rather than something under `node_modules`.
+ */
+const samBinaryName = "sam";
+
+/**
+ * The Region every command is given. The SAM CLI refuses to read a template at
+ * all without one, and nothing here talks to AWS.
+ */
+const regionName = "us-east-1";
+
+/**
+ * The environment the SAM CLI runs under. Telemetry is off because these are
+ * tests, and they run on every CI build.
+ */
+const samEnvironment = { SAM_CLI_TELEMETRY: "0" };
+
+/**
+ * The version of the SAM CLI on the PATH, or nothing where there is none.
+ *
+ * A test comparing against real SAM asks for this first, because a machine
+ * without the CLI has to skip rather than fail.
+ */
+export async function testSamCliVersion(): Promise<string | undefined> {
+  try {
+    const { stdout } = await execa(samBinaryName, ["--version"], {
+      env: samEnvironment,
+    });
+
+    return stdout.trim();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Convenience wrapper for temporary SAM projects used in tests.
+ *
+ * The SAM CLI expands a template through `aws-sam-translator`, the Python
+ * library AWS runs the real transform in. `sam list` reads a template off disk
+ * and reports what deploying it would create, which is the expansion itself
+ * with nothing built and no AWS account involved.
+ */
+export class TestSamProject {
+  readonly projectDirectory: TemporaryDirectory;
+
+  constructor(properties: TestSamProjectProperties = {}) {
+    const { projectDirectory = new TemporaryDirectory() } = properties;
+    this.projectDirectory = projectDirectory;
+  }
+
+  /**
+   * Write the SAM template this project is expanded from.
+   *
+   * The template is written as JSON, which the SAM CLI reads as readily as
+   * YAML, so one template object drives both the CLI and a simulated
+   * deployment of the same thing.
+   */
+  async writeTemplate(template: object): Promise<void> {
+    await this.projectDirectory.writeFile(
+      "template.json",
+      JSON.stringify(template, undefined, 2),
+    );
+  }
+
+  /**
+   * The logical IDs of the Resources deploying this template would create.
+   */
+  async listResources(): Promise<string[]> {
+    const listed = await this.list<{ LogicalResourceId: string }>("resources");
+
+    return listed.map((resource) => resource.LogicalResourceId);
+  }
+
+  /**
+   * The APIs this template deploys, and the methods each of them serves.
+   *
+   * A function is listed here too, with `Methods` set to a placeholder rather
+   * than a list, and is left out.
+   */
+  async listEndpoints(): Promise<TestSamEndpoint[]> {
+    const listed = await this.list<{
+      LogicalResourceId: string;
+      Methods: string[] | string;
+    }>("endpoints");
+
+    return listed
+      .filter((endpoint) => Array.isArray(endpoint.Methods))
+      .map((endpoint) => ({
+        logicalId: endpoint.LogicalResourceId,
+        methods: [endpoint.Methods].flat().flatMap(samEndpointMethods),
+      }));
+  }
+
+  /**
+   * Run one `sam list` command over this project's template.
+   */
+  private async list<Listed>(area: string): Promise<Listed[]> {
+    await this.projectDirectory.resolvePath();
+
+    const { stdout } = await execa(
+      samBinaryName,
+      [
+        "list",
+        area,
+        "--output",
+        "json",
+        "--region",
+        regionName,
+        "--template-file",
+        this.projectDirectory.join("template.json"),
+      ],
+      { env: samEnvironment },
+    );
+
+    return JSON.parse(stdout) as Listed[];
+  }
+}

--- a/test/cloudformation/sam-cli.ts
+++ b/test/cloudformation/sam-cli.ts
@@ -1,0 +1,130 @@
+/**
+ * What the SAM expansion comparison runs against, and whether it runs at all.
+ *
+ * This lives under `test/` for the same reasons as `test/apigateway/`. Eslint
+ * rejects a test file that exports helpers alongside its own `describe` calls,
+ * and `test/**` is type-checked with everything else, excluded from the
+ * published build, not collected as a suite, and not counted in coverage.
+ */
+
+import { assertNonNullable } from "@kensio/smartass";
+
+import type { SimRestApi } from "../../src/service/apigateway/api/sim-rest-api.js";
+import type { SimCfnStack } from "../../src/service/cloudformation/stack/sim-cfn-stack.js";
+import type { CfnTemplateBodyRecord } from "../../src/service/cloudformation/template/sim-cfn-template.js";
+import { testSamCliVersion } from "../../src/util/filesystem/test-sam-project.js";
+
+/**
+ * The version of the AWS SAM CLI on the PATH, or nothing where the machine has
+ * none.
+ */
+export const samCliVersion = await testSamCliVersion();
+
+/**
+ * Whether a comparison against real SAM can run here.
+ *
+ * The SAM CLI installs through pip, Homebrew or the AWS installer and has no
+ * npm package, so a developer machine may be without it and the comparison
+ * skips there. CI installs it before the local tests, and a CI run that cannot
+ * find it fails below, because a test nobody ever runs is worse than no test.
+ */
+export const samCliMissing = samCliVersion === undefined;
+
+if (samCliMissing && process.env["CI"] !== undefined) {
+  throw new Error(
+    "The AWS SAM CLI is not on the PATH. CI installs it before the local " +
+      "tests run, so this is a workflow to fix rather than a test to skip.",
+  );
+}
+
+if (samCliMissing) {
+  // oxlint-disable-next-line no-console -- a skipped suite is worth saying out loud.
+  console.warn(
+    "Skipping the SAM CLI comparison: no `sam` on the PATH. Install the AWS " +
+      "SAM CLI to run it, for example with `brew install aws-sam-cli`.",
+  );
+}
+
+/**
+ * A handler standing in for whatever a function does. The comparison is about
+ * the APIs, stages and methods in front of it.
+ */
+const handlerSource = "exports.handler = async () => 'rates';";
+
+/**
+ * A template exercising every shape the REST half of SAM expands into: events
+ * sharing the implicit API, two methods on one path, a method on the root, an
+ * `any` method, and an event naming an `AWS::Serverless::Api` whose stage name
+ * cannot be part of a logical ID.
+ */
+export const samRestApiTemplate: CfnTemplateBodyRecord = {
+  Transform: "AWS::Serverless-2016-10-31",
+  Resources: {
+    Rates: {
+      Type: "AWS::Serverless::Function",
+      Properties: {
+        Handler: "index.handler",
+        Runtime: "nodejs22.x",
+        InlineCode: handlerSource,
+        Events: {
+          Get: {
+            Type: "Api",
+            Properties: { Path: "/rates/{currency}", Method: "GET" },
+          },
+          Post: {
+            Type: "Api",
+            Properties: { Path: "/rates/{currency}", Method: "POST" },
+          },
+          Any: { Type: "Api", Properties: { Path: "/fees", Method: "any" } },
+          Root: { Type: "Api", Properties: { Path: "/", Method: "GET" } },
+          Named: {
+            Type: "Api",
+            Properties: {
+              RestApiId: { Ref: "RatesApi" },
+              Path: "/named",
+              Method: "POST",
+            },
+          },
+        },
+      },
+    },
+    RatesApi: {
+      Type: "AWS::Serverless::Api",
+      Properties: { StageName: "orders-dev" },
+    },
+  },
+};
+
+/**
+ * Names in a settled order, so a comparison is about what is in each list.
+ */
+export function sortedNames(names: readonly string[]): string[] {
+  return names.toSorted((left, right) => left.localeCompare(right));
+}
+
+/**
+ * The stages a list of logical IDs holds, which is what the comparison checks
+ * against the stages deployed here.
+ */
+export function stageLogicalIds(logicalIds: readonly string[]): string[] {
+  return sortedNames(logicalIds.filter((name) => name.includes("Stage")));
+}
+
+/**
+ * The methods one deployed API serves, as one `GET /rates/{currency}` per
+ * method, which is the shape the SAM CLI reports its own in.
+ */
+export function servedMethods(stack: SimCfnStack, logicalId: string): string[] {
+  const api = stack.getResource(logicalId)?.simResource as SimRestApi;
+  assertNonNullable(api, `${logicalId} was not deployed as a REST API`);
+
+  return sortedNames(
+    api.resources
+      .list()
+      .flatMap((resource) =>
+        resource
+          .listMethods()
+          .map((method) => `${method.httpMethod} ${resource.path}`),
+      ),
+  );
+}


### PR DESCRIPTION
`AWS::Serverless::Api` expands into an `AWS::ApiGateway::RestApi` with the deployment and stage that publish it, and the `Api` event of a SAM function into the path resources, the method, the invoke permission and, where the event names no `RestApiId`, the implicit `ServerlessRestApi` on its `Prod` stage. `Globals.Api` supplies the defaults every API takes, the implicit one included. Real SAM writes all of this into a generated Swagger document, and the CloudFormation Resources are written directly here, so a method is something the stack holds and tears down. A local test runs the SAM CLI over the same template and holds the expansion to the stages and methods real SAM produces, which needs the CLI on the `PATH` and so a workflow step to install it.

Resolves #784