### PR TITLE
feat: gate a REST API method with an authorizer

### DIFF
--- a/docs/services/apigateway/README.md
+++ b/docs/services/apigateway/README.md
@@ -352,6 +352,175 @@ supplied as `AWS:SourceArn`, in the form
 granted for one method therefore leaves the others closed. CDK wildcards the stage, method and path segments,
 which admits every method of the API.
 
+## Authorizing a method
+
+A method is open unless it names an authorizer. `CreateAuthorizerCommand` creates one, and
+`PutMethodCommand` binds it to a method with `authorizationType: "CUSTOM"` and the `authorizerId` the
+API allocated.
+
+A `TOKEN` authorizer reads one header and sends its value to a Lambda function of its own. That
+function answers an IAM policy document, which is evaluated for `execute-api:Invoke` against the ARN
+of the request being made. Whatever `context` it returns reaches the handler.
+
+```typescript sim-apigateway-token-authorizer
+/**
+ * Gating a REST API method with a TOKEN Lambda authorizer.
+ *
+ * The authorizer reads the Authorization header, and the policy it answers is
+ * evaluated against the ARN of the request being made.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import { simRestApiLambdaProxyFactory } from "@kensio/yulin/apigateway";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+const restApi = await simRestApiLambdaProxyFactory.make(
+  {
+    resourcePaths: ["/orders"],
+    authorizerHandler: (event) => ({
+      principalId: "user-6",
+      context: { tenantId: "acme" },
+      policyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Action: "execute-api:Invoke",
+            Effect:
+              event.authorizationToken === "Bearer valid" ? "Allow" : "Deny",
+            Resource: event.methodArn,
+          },
+        ],
+      },
+    }),
+    handler: (event) => ({
+      statusCode: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(event.requestContext.authorizer),
+    }),
+  },
+  simAws,
+);
+
+const srv = await serveSimAws({ simAws });
+const url = srv.localUrl(`${restApi.invokeUrl("prod")}/orders`);
+
+const admitted = await fetch(url, {
+  headers: { authorization: "Bearer valid" },
+});
+
+console.log(admitted.status);
+// 200
+
+console.log(await admitted.text());
+// '{"tenantId":"acme","principalId":"user-6"}'
+
+const refused = await fetch(url, {
+  headers: { authorization: "Bearer stale" },
+});
+
+console.log(refused.status);
+// 403
+
+const anonymous = await fetch(url);
+
+console.log(anonymous.status);
+// 401
+
+await srv.close();
+```
+
+`simRestApiLambdaProxyFactory` builds the authorizer's function, the authorizer, its invoke
+permission and the methods bound to it when it is given an `authorizerHandler`.
+
+### The event the authorizer receives
+
+A `TOKEN` authorizer sees three fields and no more.
+
+| Field                | What it carries                                                          |
+| -------------------- | ------------------------------------------------------------------------ |
+| `type`               | The literal `TOKEN`                                                      |
+| `authorizationToken` | The value the request carried at the identity source                     |
+| `methodArn`          | `arn:aws:execute-api:{region}:{account}:{apiId}/{stage}/{METHOD}/{path}` |
+
+The `methodArn` names the path the client asked for rather than the resource template it matched. A
+request to `/orders/6` behind an `/orders/{orderId}` resource is named as `GET/orders/6`.
+
+The identity source is one header, written as `method.request.header.Authorization`. An expression
+naming anywhere else is refused by `CreateAuthorizer`, because an authorizer that looks where the
+request never carries anything refuses everyone. That refusal reads like a signing problem when the
+configuration is what went wrong.
+
+### Answering with a policy
+
+A REST API authorizer always answers a policy. An HTTP API authorizer may answer a boolean instead.
+A function written for one is read wrongly by the other.
+
+```json
+{
+  "principalId": "user-6",
+  "context": { "tenantId": "acme" },
+  "policyDocument": {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Action": "execute-api:Invoke",
+        "Effect": "Allow",
+        "Resource": "arn:aws:execute-api:eu-west-2:111111111111:a1b2c3d4e5/prod/GET/orders"
+      }
+    ]
+  }
+}
+```
+
+The document goes to simulated IAM and is evaluated for `execute-api:Invoke` on the `methodArn`. A
+policy naming one method leaves the others unauthorized, and an authorizer wanting to open the whole
+API wildcards the resource the way any IAM policy does.
+
+`principalId` is a name the authorizer chose for the caller. It identifies that caller in the
+authorizer's own logs, and IAM never sees it.
+
+### The context the handler receives
+
+`context` reaches the handler under `requestContext.authorizer`, flattened alongside `principalId`.
+Payload format 2.0 keeps the context in a block of its own, so a handler moved between a REST API and
+an HTTP API reads a different shape.
+
+An open method has no caller to describe, and leaves `requestContext.authorizer` out of the event
+altogether.
+
+### What a refused request gets back
+
+| Case                                                         | Answer                                                                     |
+| ------------------------------------------------------------ | -------------------------------------------------------------------------- |
+| No value at the identity source                              | 401 `Unauthorized`                                                         |
+| The authorizer returned `{ "errorMessage": "Unauthorized" }` | 401 `Unauthorized`                                                         |
+| A Deny statement matched the method                          | 403 `User is not authorized to access this resource with an explicit deny` |
+| The policy allowed nothing covering the method               | 403 `User is not authorized to access this resource`                       |
+| The authorizer failed, or answered a shape AWS cannot read   | 500 `Internal server error`                                                |
+
+A request carrying nothing at the identity source is refused before the function is invoked. An
+authorizer counting its own invocations never sees one.
+
+The 401 body member is `message` and the 403 one is `Message`. Real API Gateway is inconsistent about
+the two and this follows it.
+
+A function that throws is an authorizer failure, and gets the 500. Real Lambda turns a thrown error
+into a payload carrying `errorMessage`, while simulated Lambda rejects with the error itself.
+Returning the value is the way to ask for a 401.
+
+### The authorizer's invoke permission
+
+The authorizer's function needs a grant of its own, under an ARN naming the authorizer:
+
+```text
+arn:aws:execute-api:{region}:{account}:{apiId}/authorizers/{authorizerId}
+```
+
+That ARN names no stage. A function used both as an integration and as an authorizer needs two
+permissions, as it does on AWS. CDK's `TokenAuthorizer` writes this one.
+
 ## Intercepting an SDK client
 
 `SimSdk` routes `@aws-sdk/client-api-gateway` commands to the simulation. Code under test builds its
@@ -595,9 +764,10 @@ behaves differently to the template. The simulated properties are:
 
 - `RestApi`: `Name`, `Description`, `DisableExecuteApiEndpoint`
 - `Resource`: `RestApiId`, `ParentId`, `PathPart`
-- `Method`: `RestApiId`, `ResourceId`, `HttpMethod`, `AuthorizationType`, `ApiKeyRequired`,
-  `OperationName`, `Integration`
+- `Method`: `RestApiId`, `ResourceId`, `HttpMethod`, `AuthorizationType`, `AuthorizerId`,
+  `ApiKeyRequired`, `OperationName`, `Integration`
 - A method's `Integration` block: `Type`, `IntegrationHttpMethod`, `Uri`
+- `Authorizer`: `RestApiId`, `Name`, `Type`, `AuthorizerUri`, `IdentitySource`
 - `Deployment`: `RestApiId`, `Description`, `StageName`
 - `Stage`: `RestApiId`, `DeploymentId`, `StageName`, `Description`, `Variables`
 
@@ -615,12 +785,16 @@ method on the root and another on a `{proxy+}` resource, both in front of one fu
 `AWS::Lambda::Permission` each needs. `restApi.url` and `restApi.urlForPath` resolve to the local
 hostname through `AWS::URLSuffix`.
 
+`TokenAuthorizer` deploys too, with the `AWS::Lambda::Permission` it writes for its own function.
+Give it `resultsCacheTtl: Duration.seconds(0)`, since CDK holds a decision for five minutes by
+default and `AuthorizerResultTtlInSeconds` is one of the recorded properties.
+
 CDK also writes an `AWS::ApiGateway::Account` and a CloudWatch role beside a default `RestApi`.
 Neither is simulated. The `Account` Resource is recorded in
 [`stack.skippedResources`](../cloudformation/README.md#inspecting-stacks-and-resources) and the rest of the
 stack deploys.
 
-`Authorizer`, `ApiKey`, `UsagePlan`, `UsagePlanKey`, `RequestValidator`, `Model`, `DomainName` and
+`ApiKey`, `UsagePlan`, `UsagePlanKey`, `RequestValidator`, `Model`, `DomainName` and
 `BasePathMapping` are recorded there too, each naming the reason. A method under one of them is
 refused by `PutMethod`, because a method that looked gated to the template and answered every
 request here is worse than a failed deployment.
@@ -641,8 +815,11 @@ nothing on real AWS.
 An input outside what this simulates is refused. Dropping it would let a request look applied here
 and behave differently deployed. The refusals worth knowing about:
 
-- **Authorizers.** `authorizationType` other than `NONE` is refused. `TOKEN`, `REQUEST`,
-  `COGNITO_USER_POOLS` and `AWS_IAM` methods are a separate piece of work.
+- **Authorizer kinds.** `TOKEN` is the one simulated. A `REQUEST` or `COGNITO_USER_POOLS`
+  authorizer is refused by `CreateAuthorizer`, and an `AWS_IAM` method by `PutMethod`. Each is a
+  separate piece of work.
+- **Holding an authorizer's decision.** `authorizerResultTtlInSeconds` is refused. The function is
+  invoked once per request reaching the method.
 - **Integration types.** Only `AWS_PROXY` with a Lambda function URI is simulated. `MOCK`, `HTTP`,
   `HTTP_PROXY` and the non-proxy `AWS` type each answer a request from somewhere this cannot reach.
 - **API keys and usage plans.** `apiKeyRequired: true` is refused, because a method requiring a key
@@ -657,12 +834,13 @@ and behave differently deployed. The refusals worth knowing about:
 | ------------ | ------------------------------------------------------------------------------ |
 | REST APIs    | `CreateRestApi`, `GetRestApi`, `GetRestApis`, `UpdateRestApi`, `DeleteRestApi` |
 | Resources    | `CreateResource`, `GetResource`, `GetResources`, `DeleteResource`              |
+| Authorizers  | `CreateAuthorizer`, `GetAuthorizer`, `GetAuthorizers`, `DeleteAuthorizer`      |
 | Methods      | `PutMethod`, `GetMethod`, `DeleteMethod`                                       |
 | Integrations | `PutIntegration`, `GetIntegration`                                             |
 | Publishing   | `CreateDeployment`, `CreateStage`, `GetStage`, `GetStages`, `DeleteStage`      |
 
-CloudFormation deploys `AWS::ApiGateway::RestApi`, `Resource`, `Method`, `Deployment` and `Stage`,
-including the template CDK synthesizes from a `RestApi` or a `LambdaRestApi`. See
+CloudFormation deploys `AWS::ApiGateway::RestApi`, `Resource`, `Method`, `Authorizer`, `Deployment`
+and `Stage`, including the template CDK synthesizes from a `RestApi` or a `LambdaRestApi`. See
 [Deploying from CloudFormation and CDK](#deploying-from-cloudformation-and-cdk).
 
 ## Limitations
@@ -672,6 +850,8 @@ including the template CDK synthesizes from a `RestApi` or a `LambdaRestApi`. Se
   `stack.skippedResourceDeletions` and the deployment goes with its API a moment later.
 - A repeated request header reaches the handler as one joined value in `multiValueHeaders`, because
   that is the form the platform's `Headers` hands over. Real API Gateway reports each separately.
+- A Lambda authorizer's `context` reaches the handler as the authorizer returned it. AWS accepts a
+  string, a number or a boolean for each value, and how it renders them is not published.
 - Binary media types negotiated by `Accept`, CORS preflight and gateway responses are outside this.
   A response body is still base64 decoded when the handler says `isBase64Encoded`.
 - WebSocket APIs are outside this and outside the v2 service.

--- a/docs/services/apigateway/sim-apigateway-token-authorizer.example.ts
+++ b/docs/services/apigateway/sim-apigateway-token-authorizer.example.ts
@@ -1,0 +1,66 @@
+/**
+ * Gating a REST API method with a TOKEN Lambda authorizer.
+ *
+ * The authorizer reads the Authorization header, and the policy it answers is
+ * evaluated against the ARN of the request being made.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import { simRestApiLambdaProxyFactory } from "@kensio/yulin/apigateway";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+const restApi = await simRestApiLambdaProxyFactory.make(
+  {
+    resourcePaths: ["/orders"],
+    authorizerHandler: (event) => ({
+      principalId: "user-6",
+      context: { tenantId: "acme" },
+      policyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Action: "execute-api:Invoke",
+            Effect:
+              event.authorizationToken === "Bearer valid" ? "Allow" : "Deny",
+            Resource: event.methodArn,
+          },
+        ],
+      },
+    }),
+    handler: (event) => ({
+      statusCode: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(event.requestContext.authorizer),
+    }),
+  },
+  simAws,
+);
+
+const srv = await serveSimAws({ simAws });
+const url = srv.localUrl(`${restApi.invokeUrl("prod")}/orders`);
+
+const admitted = await fetch(url, {
+  headers: { authorization: "Bearer valid" },
+});
+
+console.log(admitted.status);
+// 200
+
+console.log(await admitted.text());
+// '{"tenantId":"acme","principalId":"user-6"}'
+
+const refused = await fetch(url, {
+  headers: { authorization: "Bearer stale" },
+});
+
+console.log(refused.status);
+// 403
+
+const anonymous = await fetch(url);
+
+console.log(anonymous.status);
+// 401
+
+await srv.close();

--- a/src/serve/index.ts
+++ b/src/serve/index.ts
@@ -25,9 +25,11 @@ export {
 export type {
   SimPayload1Event,
   SimPayload1Identity,
+  SimPayload1LambdaAuthorizer,
   SimPayload1RequestContext,
   SimPayload1Result,
 } from "./payload-1/sim-payload-1-event.type.js";
 export type { SimPayload1Endpoint } from "./payload-1/sim-payload-1-endpoint.js";
+export type { SimPayload1Authorization } from "./payload-1/sim-payload-1-request-context.js";
 export { SimPayload1EventBuilder } from "./payload-1/sim-payload-1-event-builder.js";
 export { SimPayload1ResponseBuilder } from "./payload-1/sim-payload-1-response-builder.js";

--- a/src/serve/payload-1/sim-payload-1-event-builder.ts
+++ b/src/serve/payload-1/sim-payload-1-event-builder.ts
@@ -5,7 +5,10 @@ import {
 } from "../http/sim-aws-proxied-connection.js";
 import type { SimPayload1Endpoint } from "./sim-payload-1-endpoint.js";
 import type { SimPayload1Event } from "./sim-payload-1-event.type.js";
-import { SimPayload1RequestContextBuilder } from "./sim-payload-1-request-context.js";
+import {
+  type SimPayload1Authorization,
+  SimPayload1RequestContextBuilder,
+} from "./sim-payload-1-request-context.js";
 import { simPayload1Body } from "./sim-payload-1-body.js";
 import {
   orNull,
@@ -41,10 +44,15 @@ export class SimPayload1EventBuilder {
 
   /**
    * Build the invocation event for one request to an endpoint.
+   *
+   * An authorization is supplied only when the method authorized a caller,
+   * which is what makes the authorizer block present for an authorized
+   * invocation and absent for an open one.
    */
   async build(
     request: Request,
     endpoint: SimPayload1Endpoint,
+    authorization?: SimPayload1Authorization,
   ): Promise<SimPayload1Event> {
     const url = new URL(request.url);
     const at = this.clock.now();
@@ -76,6 +84,7 @@ export class SimPayload1EventBuilder {
         endpoint,
         sourceIp: simAwsProxiedSourceIp,
         at,
+        authorization,
       }),
       ...body,
     };

--- a/src/serve/payload-1/sim-payload-1-event.type.ts
+++ b/src/serve/payload-1/sim-payload-1-event.type.ts
@@ -23,11 +23,29 @@ export interface SimPayload1Identity {
 }
 
 /**
+ * What a Lambda authorizer passed on to the handler.
+ *
+ * `principalId` is the name the authorizer chose for the caller, and every
+ * other member is one the authorizer's own `context` carried. A REST API
+ * flattens the two together, where payload format 2.0 keeps the context in a
+ * block of its own.
+ */
+export interface SimPayload1LambdaAuthorizer {
+  principalId?: string;
+  [contextKey: string]: unknown;
+}
+
+/**
  * What payload format 1.0 says about the request beyond the request itself.
  */
 export interface SimPayload1RequestContext {
   accountId: string;
   apiId: string;
+  /**
+   * What the method's authorizer knows about the caller. It is absent on a
+   * method that authorizes nobody, which is what real API Gateway sends.
+   */
+  authorizer?: SimPayload1LambdaAuthorizer;
   domainName: string;
   domainPrefix: string;
   extendedRequestId: string;

--- a/src/serve/payload-1/sim-payload-1-request-context.ts
+++ b/src/serve/payload-1/sim-payload-1-request-context.ts
@@ -4,8 +4,20 @@ import { simProxyEventTime } from "../proxy/sim-proxy-event-time.js";
 import type { SimPayload1Endpoint } from "./sim-payload-1-endpoint.js";
 import type {
   SimPayload1Identity,
+  SimPayload1LambdaAuthorizer,
   SimPayload1RequestContext,
 } from "./sim-payload-1-event.type.js";
+
+/**
+ * What the endpoint's authorizer knows about the caller, if it authorized one.
+ *
+ * A method admitting anybody supplies none, which is what leaves the
+ * authorizer block out of the event.
+ */
+export interface SimPayload1Authorization {
+  /** The principal and the context a Lambda authorizer answered with. */
+  readonly lambda?: SimPayload1LambdaAuthorizer | undefined;
+}
 
 interface SimPayload1RequestContextInput {
   readonly request: Request;
@@ -13,6 +25,7 @@ interface SimPayload1RequestContextInput {
   readonly endpoint: SimPayload1Endpoint;
   readonly sourceIp: string;
   readonly at: Date;
+  readonly authorization?: SimPayload1Authorization | undefined;
 }
 
 /**
@@ -29,7 +42,7 @@ export class SimPayload1RequestContextBuilder {
   build(input: SimPayload1RequestContextInput): SimPayload1RequestContext {
     const { endpoint, url, at } = input;
 
-    return {
+    const requestContext: SimPayload1RequestContext = {
       accountId: endpoint.accountId,
       apiId: endpoint.apiId,
       domainName: endpoint.domainName,
@@ -48,14 +61,22 @@ export class SimPayload1RequestContextBuilder {
       resourcePath: endpoint.resourcePath,
       stage: endpoint.stage,
     };
+
+    const { lambda } = input.authorization ?? {};
+
+    if (lambda !== undefined) {
+      requestContext.authorizer = lambda;
+    }
+
+    return requestContext;
   }
 
   /**
    * Who API Gateway says made the request.
    *
-   * Only the open case is described here. Authorizing a method is a separate
-   * piece of work, and the fields an authorizer would fill stay `null` until
-   * something fills them.
+   * Only the open case is described here. The fields an `AWS_IAM` method
+   * fills stay `null`, because that authorization type is a separate piece of
+   * work.
    */
   private identity(input: SimPayload1RequestContextInput): SimPayload1Identity {
     return {

--- a/src/service/apigateway/README.md
+++ b/src/service/apigateway/README.md
@@ -26,6 +26,7 @@ SimRestApi
 ├── SimRestApiResourceStore     the path tree, keyed by allocated resource id
 │   └── SimRestApiResource      each node owns its methods, keyed by HTTP method
 │       └── SimRestApiMethod    each method owns its integration
+├── SimRestApiAuthorizerStore   authorizers, keyed by allocated id
 ├── SimRestApiDeploymentStore   deployments, keyed by allocated id
 └── SimRestApiStageStore        stages, keyed by stage name
 ```
@@ -86,8 +87,29 @@ departs from AWS.
 ```text
 SimApiGatewayServiceController   the entry point, and what a miss is answered with
 ├── SimApiGatewayRouter          an API id to its scope, an integration URI to its function
+├── SimRestApiMethodAuthorizer   what the client may have, in serve/auth/
 └── SimRestApiIntegrationInvocation   the invoke permission, the event, the response
 ```
+
+The client's own authorization runs first. A request presenting no credentials is refused whether or
+not the integration behind the method would have worked. Whether the API may invoke a function is a
+separate question, asked afterwards, and it is the API's rather than the client's.
+
+`serve/auth/` holds one authorization type, and the pieces are the ones a `TOKEN` authorizer needs:
+
+```text
+SimRestApiMethodAuthorizer            which type the method asks for
+└── SimRestApiAuthorizerInvocation    the invoke permission, the event, the answer
+    ├── SimRestApiAuthorizerResponse  the principal, the context, the policy
+    └── SimRestApiAuthorizerPolicy    that policy, put to IAM against the method ARN
+```
+
+The method ARN is the one part with no HTTP API equivalent worth copying. A REST API authorizer is
+handed the ARN of the request the client made, with the concrete path in it, and the policy it
+answers is evaluated against that same ARN. `SimRestApiExecuteApiArn` builds it, and builds the two
+other forms beside it. One is the resource template form an integration's invoke permission is
+matched against. The other is the `<apiId>/authorizers/<authorizerId>` form the authorizer's own
+function is invoked under, which names no stage.
 
 The event and response shapes live in `src/serve/payload-1/`, beside the payload format 2.0 ones an
 HTTP API and a Lambda Function URL use. The two formats share their body encoding, their proxy
@@ -112,6 +134,7 @@ SimApiGatewayCfnResourceFactory              which creator answers a Resource ty
 ├── sim-cfn-rest-api-part-deleter.ts         what a teardown deletes an API's parts by
 ├── api/         RestApi
 ├── resource/    Resource
+├── authorizer/  Authorizer
 ├── method/      Method, and the Integration block it carries
 ├── deployment/  Deployment
 └── stage/       Stage
@@ -141,6 +164,12 @@ answers a `Ref` with the logical ID.
 ## What is refused
 
 `command/sim-api-gateway-unsimulated-input.ts` refuses every input outside the accepted set of each
-command. Authorizers, API keys, usage plans, request validators, models, mapping templates and every
-integration type other than `AWS_PROXY` are all refused there, so a request naming one fails here
-and would have been applied on real AWS.
+command. API keys, usage plans, request validators, models, mapping templates and every integration
+type other than `AWS_PROXY` are all refused there, so a request naming one fails here and would have
+been applied on real AWS.
+
+Authorization is refused the same way, in the two commands that carry it.
+`CreateAuthorizer` takes `TOKEN` and refuses the other two kinds, and `PutMethod` takes `NONE` and
+`CUSTOM` and refuses the other two types. A method served open where AWS would have gated it lets a
+test pass on a request real AWS rejects, so a template asking for one of them fails to deploy rather
+than deploying around it.

--- a/src/service/apigateway/api/authorizer/sim-rest-api-authorization.ts
+++ b/src/service/apigateway/api/authorizer/sim-rest-api-authorization.ts
@@ -1,0 +1,90 @@
+import type { SimPayload1LambdaAuthorizer } from "../../../../serve/payload-1/sim-payload-1-event.type.js";
+
+/**
+ * Why a method refused a request, which decides the response it gets.
+ *
+ * `unauthorized` is a request carrying no token at the authorizer's identity
+ * source, and a token the authorizer answered `Unauthorized` for.
+ * `explicit-deny` and `implicit-deny` are both 403 with different bodies, as
+ * real API Gateway answers them. `error` is the authorizer itself failing,
+ * which is the API's problem rather than the caller's.
+ */
+export type SimRestApiRefusalKind =
+  | "unauthorized"
+  | "explicit-deny"
+  | "implicit-deny"
+  | "error";
+
+interface SimRestApiAdmittedProperties {
+  /**
+   * What a `CUSTOM` method's authorizer passed on to the integration, which is
+   * absent on a method admitting anybody.
+   */
+  readonly lambda?: SimPayload1LambdaAuthorizer | undefined;
+}
+
+/**
+ * A request the method admitted, and what its authorizer knows about the
+ * caller.
+ *
+ * `lambda` is absent on a method that authorizes nobody, since there is no
+ * caller to describe. That absence is what leaves `requestContext.authorizer`
+ * out of the event entirely.
+ */
+export class SimRestApiAdmitted {
+  public readonly admitted = true as const;
+  public readonly lambda: SimPayload1LambdaAuthorizer | undefined;
+
+  constructor(properties: SimRestApiAdmittedProperties = {}) {
+    this.lambda = properties.lambda;
+  }
+}
+
+/**
+ * A request the method refused, before any integration was invoked.
+ */
+export class SimRestApiRefused {
+  public readonly admitted = false as const;
+  public readonly kind: SimRestApiRefusalKind;
+
+  private constructor(kind: SimRestApiRefusalKind) {
+    this.kind = kind;
+  }
+
+  /**
+   * The request carried nothing at the authorizer's identity source, or the
+   * authorizer answered `Unauthorized`.
+   */
+  static unauthorized(): SimRestApiRefused {
+    return new SimRestApiRefused("unauthorized");
+  }
+
+  /**
+   * A Deny statement in the authorizer's policy matched the method.
+   */
+  static explicitDeny(): SimRestApiRefused {
+    return new SimRestApiRefused("explicit-deny");
+  }
+
+  /**
+   * The authorizer's policy allowed nothing that covers the method.
+   */
+  static implicitDeny(): SimRestApiRefused {
+    return new SimRestApiRefused("implicit-deny");
+  }
+
+  /**
+   * The method's authorizer could not answer at all. Its function is missing,
+   * may not be invoked, failed, or replied in a shape API Gateway does not
+   * understand. None of that is the caller's doing, so it is the 500 an
+   * authorizer failure gets on real AWS.
+   */
+  static error(): SimRestApiRefused {
+    return new SimRestApiRefused("error");
+  }
+}
+
+/**
+ * What a method decided about one request.
+ */
+export type SimRestApiAuthorization = SimRestApiAdmitted | SimRestApiRefused;

--- a/src/service/apigateway/api/authorizer/sim-rest-api-authorizer-store.ts
+++ b/src/service/apigateway/api/authorizer/sim-rest-api-authorizer-store.ts
@@ -1,0 +1,60 @@
+import {
+  makeSimRestApiAuthorizerId,
+  type SimRestApiAuthorizer,
+  type SimRestApiAuthorizerId,
+} from "./sim-rest-api-authorizer.js";
+
+/**
+ * The authorizers of one REST API, keyed by the id the API allocated.
+ *
+ * An authorizer belongs to an API on real AWS, so ids only have to be unique
+ * within one, and this store is what makes them so.
+ */
+export class SimRestApiAuthorizerStore {
+  private readonly authorizers = new Map<
+    SimRestApiAuthorizerId,
+    SimRestApiAuthorizer
+  >();
+
+  /**
+   * Allocate an authorizer id this API is not already using.
+   */
+  allocateId(): SimRestApiAuthorizerId {
+    let authorizerId = makeSimRestApiAuthorizerId();
+
+    while (this.authorizers.has(authorizerId)) {
+      /* v8 ignore next -- does not happen in practice */
+      authorizerId = makeSimRestApiAuthorizerId();
+    }
+
+    return authorizerId;
+  }
+
+  /**
+   * Add an authorizer to this API.
+   */
+  add(authorizer: SimRestApiAuthorizer): void {
+    this.authorizers.set(authorizer.authorizerId, authorizer);
+  }
+
+  /**
+   * Find an authorizer by id.
+   */
+  find(authorizerId: string): SimRestApiAuthorizer | undefined {
+    return this.authorizers.get(authorizerId as SimRestApiAuthorizerId);
+  }
+
+  /**
+   * Forget a deleted authorizer.
+   */
+  remove(authorizerId: SimRestApiAuthorizerId): void {
+    this.authorizers.delete(authorizerId);
+  }
+
+  /**
+   * List every authorizer of this API, in the order they were created.
+   */
+  list(): SimRestApiAuthorizer[] {
+    return this.authorizers.values().toArray();
+  }
+}

--- a/src/service/apigateway/api/authorizer/sim-rest-api-authorizer.ts
+++ b/src/service/apigateway/api/authorizer/sim-rest-api-authorizer.ts
@@ -1,0 +1,104 @@
+import { faker } from "@faker-js/faker";
+
+import type { Brand } from "../../../../util/brand.type.js";
+import type { SimRestApiLambdaUri } from "../method/sim-rest-api-lambda-uri.js";
+import type { SimRestApiIdentitySource } from "./sim-rest-api-identity-source.js";
+
+/**
+ * The id API Gateway allocates for one authorizer.
+ */
+export type SimRestApiAuthorizerId = Brand<string, "SimRestApiAuthorizerId">;
+
+/**
+ * The kinds of authorizer a REST API has, of which one is simulated.
+ *
+ * A `TOKEN` authorizer sends one header's value to a Lambda function and does
+ * what the policy that function answers with says. `REQUEST` and
+ * `COGNITO_USER_POOLS` are separate pieces of work, and an authorizer asking
+ * for either is refused rather than created as something else.
+ */
+export type SimRestApiAuthorizerType = "TOKEN";
+
+/**
+ * What `GetAuthorizer` reports for the family an authorizer belongs to.
+ *
+ * A `TOKEN` or `REQUEST` authorizer is `custom`, and a Cognito one is
+ * `cognito_user_pools`.
+ */
+export const simRestApiCustomAuthType = "custom";
+
+/**
+ * Allocate an authorizer id, in the same opaque shape as a resource id.
+ */
+export function makeSimRestApiAuthorizerId(): SimRestApiAuthorizerId {
+  return faker.helpers.fromRegExp(/[a-z0-9]{6}/) as SimRestApiAuthorizerId;
+}
+
+/**
+ * Minimal structural authorizer view, as the Create and Get commands return.
+ */
+export interface SimRestApiAuthorizerView {
+  id: string;
+  name: string;
+  type: SimRestApiAuthorizerType;
+  authType: string;
+  authorizerUri: string;
+  identitySource: string;
+}
+
+interface SimRestApiAuthorizerProperties {
+  readonly authorizerId: SimRestApiAuthorizerId;
+  readonly name: string;
+  readonly lambdaUri: SimRestApiLambdaUri;
+  readonly identitySource: SimRestApiIdentitySource;
+}
+
+/**
+ * A simulated REST API `TOKEN` authorizer: the function a method sends a
+ * request to before it reaches the integration.
+ *
+ * An authorizer belongs to an API and is attached to methods by id, so one
+ * authorizer covers as many methods of the API as name it.
+ *
+ * The function decides, so nothing here says what a caller has to present.
+ * All this holds is which function to invoke and which header carries the
+ * token it is invoked with.
+ */
+export class SimRestApiAuthorizer {
+  public readonly authorizerId: SimRestApiAuthorizerId;
+  public readonly name: string;
+  public readonly type: SimRestApiAuthorizerType = "TOKEN";
+
+  /**
+   * The Lambda function this authorizer invokes, read from its
+   * `authorizerUri`.
+   */
+  public readonly lambdaUri: SimRestApiLambdaUri;
+
+  /**
+   * The header carrying the token, whose value is sent to the function as
+   * `authorizationToken`.
+   */
+  public readonly identitySource: SimRestApiIdentitySource;
+
+  constructor(properties: SimRestApiAuthorizerProperties) {
+    this.authorizerId = properties.authorizerId;
+    this.name = properties.name;
+    this.lambdaUri = properties.lambdaUri;
+    this.identitySource = properties.identitySource;
+  }
+
+  /**
+   * Get the AWS-like view of this authorizer.
+   */
+  view(): SimRestApiAuthorizerView {
+    return {
+      id: this.authorizerId,
+      name: this.name,
+      type: this.type,
+      authType: simRestApiCustomAuthType,
+      authorizerUri: this.lambdaUri.uri,
+      identitySource: this.identitySource.expression,
+    };
+  }
+}

--- a/src/service/apigateway/api/authorizer/sim-rest-api-identity-source.ts
+++ b/src/service/apigateway/api/authorizer/sim-rest-api-identity-source.ts
@@ -1,0 +1,103 @@
+import { SimApiGatewayBadRequest } from "../../error/sim-api-gateway.error.js";
+
+/**
+ * The prefix a header identity source is written with.
+ */
+export const simRestApiHeaderIdentityPrefix = "method.request.header.";
+
+/**
+ * The characters an HTTP field name holds, which is the RFC 9110 token.
+ */
+const httpFieldName = /^[!#$%&'*+.^_`|~\w-]+$/u;
+
+/**
+ * Where a `TOKEN` authorizer takes the token it identifies the caller by.
+ *
+ * The expression is a request mapping expression naming one header, such as
+ * `method.request.header.Authorization`. A `TOKEN` authorizer reads a header
+ * and nothing else, which is the rule real API Gateway holds one to.
+ *
+ * Header names are matched case-insensitively, which is what `Headers` does
+ * and what HTTP requires.
+ */
+export class SimRestApiIdentitySource {
+  /**
+   * The expression as it was written, which is what the API reports back.
+   */
+  public readonly expression: string;
+
+  private readonly headerName: string;
+
+  private constructor(headerName: string) {
+    this.expression = `${simRestApiHeaderIdentityPrefix}${headerName}`;
+    this.headerName = headerName;
+  }
+
+  /**
+   * Read an identity source expression, refusing one naming anywhere a
+   * `TOKEN` authorizer cannot read from.
+   *
+   * An expression this simulation would look for nowhere is refused when the
+   * authorizer is created. An authorizer that never finds what it looks for
+   * refuses every request, and that reads like a signing problem rather than
+   * the configuration one it is.
+   */
+  static parse(expression: string): SimRestApiIdentitySource {
+    if (!expression.startsWith(simRestApiHeaderIdentityPrefix)) {
+      throw new SimApiGatewayBadRequest(
+        `identitySource '${expression}' is not simulated: a TOKEN ` +
+          `authorizer reads one header, written as ` +
+          `'${simRestApiHeaderIdentityPrefix}<name>'`,
+      );
+    }
+
+    return new SimRestApiIdentitySource(
+      headerName(
+        expression,
+        expression.slice(simRestApiHeaderIdentityPrefix.length),
+      ),
+    );
+  }
+
+  /**
+   * What this request carries at this identity source, if it carries anything.
+   *
+   * An empty value counts as nothing. Real API Gateway refuses a request whose
+   * identity source it finds nothing at, with a 401 and without invoking the
+   * authorizer.
+   */
+  value(request: Request): string | undefined {
+    const value = request.headers.get(this.headerName);
+
+    if (value === null || value.trim().length === 0) {
+      return undefined;
+    }
+
+    return value;
+  }
+}
+
+/**
+ * The header an expression names, refusing one no request could carry.
+ *
+ * Reading a header by an invalid name throws, and it would throw on every
+ * request to the method rather than on the command that configured it.
+ */
+function headerName(expression: string, name: string): string {
+  if (name.length === 0) {
+    throw new SimApiGatewayBadRequest(
+      `identitySource '${expression}' names no header, so it would find ` +
+        `nothing on every request`,
+    );
+  }
+
+  if (!httpFieldName.test(name)) {
+    throw new SimApiGatewayBadRequest(
+      `identitySource '${expression}' names the header '${name}', which is ` +
+        `not a header name: an HTTP field name holds letters, digits and ` +
+        `the characters !#$%&'*+-.^_\`|~`,
+    );
+  }
+
+  return name;
+}

--- a/src/service/apigateway/api/match/sim-rest-api-match.ts
+++ b/src/service/apigateway/api/match/sim-rest-api-match.ts
@@ -17,6 +17,15 @@ export interface SimRestApiMatch {
   readonly resource: SimRestApiResource;
   readonly method: SimRestApiMethod;
   readonly pathParameters: Readonly<Record<string, string>>;
+  /**
+   * The request path with the stage segment taken off and no leading
+   * separator, such as `orders/6`. A request to the stage root leaves it
+   * empty.
+   *
+   * This is the path a Lambda authorizer's `methodArn` names, which is the
+   * path the client asked for rather than the resource template it matched.
+   */
+  readonly pathAfterStage: string;
 }
 
 /**
@@ -60,7 +69,7 @@ export class SimRestApiMatcher {
       return "route";
     }
 
-    return this.matched(stage, reached, request) ?? "route";
+    return this.matched(stage, reached, request, segments.join("/")) ?? "route";
   }
 
   /**
@@ -73,12 +82,15 @@ export class SimRestApiMatcher {
     stage: SimRestApiStage,
     reached: SimRestApiResourceMatch,
     request: SimRestApiRequest,
+    pathAfterStage: string,
   ): SimRestApiMatch | undefined {
     const method =
       reached.resource.findMethod(request.method) ??
       reached.resource.findMethod(simRestApiAnyMethod);
 
-    return method === undefined ? undefined : { stage, method, ...reached };
+    return method === undefined
+      ? undefined
+      : { stage, method, pathAfterStage, ...reached };
   }
 }
 

--- a/src/service/apigateway/api/method/sim-rest-api-method.ts
+++ b/src/service/apigateway/api/method/sim-rest-api-method.ts
@@ -10,17 +10,22 @@ import type {
 export const simRestApiAnyMethod = "ANY";
 
 /**
- * The only authorization type simulated so far. Authorizers are a separate
- * piece of work, and a method asking for one is refused rather than served
- * open, which would let a test pass on a request real AWS would reject.
+ * The authorization types simulated so far.
+ *
+ * `NONE` is an open method, and `CUSTOM` sends the request through the Lambda
+ * authorizer the method names. `COGNITO_USER_POOLS` and `AWS_IAM` are
+ * separate pieces of work, and a method asking for either is refused when it
+ * is created. A method served open where AWS would have gated it lets a test
+ * pass on a request real AWS rejects.
  */
-export type SimRestApiAuthorizationType = "NONE";
+export type SimRestApiAuthorizationType = "NONE" | "CUSTOM";
 
 interface SimRestApiMethodProperties {
   readonly httpMethod: string;
   readonly authorizationType: SimRestApiAuthorizationType;
   readonly apiKeyRequired: boolean;
   readonly operationName?: string | undefined;
+  readonly authorizerId?: string | undefined;
 }
 
 /**
@@ -31,6 +36,7 @@ export interface SimRestApiMethodView {
   authorizationType: SimRestApiAuthorizationType;
   apiKeyRequired: boolean;
   operationName?: string;
+  authorizerId?: string;
   methodIntegration?: SimRestApiIntegrationView;
 }
 
@@ -48,6 +54,12 @@ export class SimRestApiMethod {
   public readonly operationName?: string | undefined;
 
   /**
+   * The authorizer of this API a `CUSTOM` method sends its requests through.
+   * An open method names none.
+   */
+  public readonly authorizerId?: string | undefined;
+
+  /**
    * What this method does with a request. A method with none declared is a
    * method real API Gateway answers 500 for, and it is what `PutMethod`
    * leaves behind until `PutIntegration` follows it.
@@ -59,6 +71,7 @@ export class SimRestApiMethod {
     this.authorizationType = properties.authorizationType;
     this.apiKeyRequired = properties.apiKeyRequired;
     this.operationName = properties.operationName;
+    this.authorizerId = properties.authorizerId;
   }
 
   /**
@@ -73,6 +86,10 @@ export class SimRestApiMethod {
 
     if (this.operationName !== undefined) {
       view.operationName = this.operationName;
+    }
+
+    if (this.authorizerId !== undefined) {
+      view.authorizerId = this.authorizerId;
     }
 
     if (this.integration !== undefined) {

--- a/src/service/apigateway/api/sim-rest-api-declared-method.ts
+++ b/src/service/apigateway/api/sim-rest-api-declared-method.ts
@@ -6,6 +6,8 @@ interface SimRestApiDeclaredMethodInput {
   readonly resourcePath: string;
   readonly httpMethod: string;
   readonly functionArn: string;
+  /** The authorizer every method is gated by, where the API has one. */
+  readonly authorizerId: string | undefined;
 }
 
 /**
@@ -43,7 +45,14 @@ async function declaredMethod(
   );
 
   await apiGateway.putMethod({
-    input: { restApiId, resourceId, httpMethod, authorizationType: "NONE" },
+    input: {
+      restApiId,
+      resourceId,
+      httpMethod,
+      ...(input.authorizerId === undefined
+        ? { authorizationType: "NONE" }
+        : { authorizationType: "CUSTOM", authorizerId: input.authorizerId }),
+    },
   });
   await apiGateway.putIntegration({
     input: {

--- a/src/service/apigateway/api/sim-rest-api-execute-api-arn.ts
+++ b/src/service/apigateway/api/sim-rest-api-execute-api-arn.ts
@@ -25,6 +25,16 @@ interface SimRestApiExecuteApiArnProperties {
  * resource may have declared. CDK wildcards that segment, and a concrete verb
  * matches a wildcard where a literal `ANY` would not, so this is the reading
  * that keeps a CDK-deployed API working.
+ *
+ * Three things want this ARN and they fill the last part differently:
+ *
+ * - the invoke permission a Lambda integration is authorized against, where
+ *   the path is the matched resource's template with its braces intact;
+ * - the `methodArn` a Lambda authorizer is handed, and the resource the policy
+ *   it answers with is evaluated against, where the path is the one the client
+ *   asked for;
+ * - the ARN API Gateway invokes an authorizer's own function under, which
+ *   names the authorizer and no stage at all.
  */
 export class SimRestApiExecuteApiArn {
   private readonly restApi: SimRestApi;
@@ -51,6 +61,51 @@ export class SimRestApiExecuteApiArn {
       // The resource path carries a leading separator and the ARN supplies its
       // own, so a root-resource request reads `<apiId>/<stage>/GET/`.
       methodAndPath: `${requestMethod}${match.resource.path}`,
+    });
+  }
+
+  /**
+   * The ARN of the request a client made, which is the `methodArn` a Lambda
+   * authorizer is handed.
+   *
+   * This names the concrete path rather than the resource template, so an
+   * authorizer behind a `{proxy+}` sees the path that was asked for. The
+   * policy it answers with is evaluated against this same ARN, which is why an
+   * authorizer allowing one path leaves another unauthorized.
+   */
+  static forRequest(
+    restApi: SimRestApi,
+    match: SimRestApiMatch,
+    requestMethod: string,
+  ): SimRestApiExecuteApiArn {
+    return new SimRestApiExecuteApiArn({
+      restApi,
+      stageName: match.stage.stageName,
+      methodAndPath: `${requestMethod.toUpperCase()}/${match.pathAfterStage}`,
+    });
+  }
+
+  /**
+   * The ARN API Gateway invokes one of an API's authorizers under.
+   *
+   * ```text
+   * arn:aws:execute-api:<region>:<account>:<apiId>/authorizers/<authorizerId>
+   * ```
+   *
+   * This is the `SourceArn` AWS documents for granting API Gateway permission
+   * to invoke a Lambda authorizer's function, and it names no stage. An
+   * authorizer belongs to the API rather than to anything serving a request. A
+   * function integrated behind a method and used as that method's authorizer
+   * therefore needs two permissions, as it does on AWS.
+   */
+  static forAuthorizer(
+    restApi: SimRestApi,
+    authorizerId: string,
+  ): SimRestApiExecuteApiArn {
+    return new SimRestApiExecuteApiArn({
+      restApi,
+      stageName: "authorizers",
+      methodAndPath: authorizerId,
     });
   }
 

--- a/src/service/apigateway/api/sim-rest-api-lambda-proxy.factory.ts
+++ b/src/service/apigateway/api/sim-rest-api-lambda-proxy.factory.ts
@@ -6,6 +6,10 @@ import { DEFAULT_SIM_AWS_ACCOUNT_ID } from "../../aws/sim-aws-account.js";
 import type { SimAws } from "../../aws/sim-aws.js";
 import { declaredMethods } from "./sim-rest-api-declared-method.js";
 import {
+  simRestApiProxyAuthorizer,
+  type SimRestApiProxyAuthorizerInput,
+} from "./sim-rest-api-proxy-authorizer.js";
+import {
   simRestApiInvokePermission,
   simRestApiProxyFunction,
 } from "./sim-rest-api-proxy-function.js";
@@ -14,15 +18,9 @@ import type { SimRestApi } from "./sim-rest-api.js";
 /**
  * What a test asks for when it wants a REST API that serves something.
  */
-export interface SimRestApiLambdaProxyInput {
+export interface SimRestApiLambdaProxyInput extends SimRestApiProxyAuthorizerInput {
   readonly apiName: string;
   readonly functionName: string;
-  /**
-   * The Account the function belongs to, which need not be the API's: an
-   * integration URI is free to name another one.
-   */
-  readonly functionAccountId: string;
-  readonly roleArn: string;
   /** The function code every method of the API hands its requests to. */
   readonly handler: (event: SimPayload1Event) => unknown;
   readonly disableExecuteApiEndpoint: boolean;
@@ -57,6 +55,9 @@ export interface SimRestApiLambdaProxyInput {
  * serving is about none of them. Tests about the commands themselves send them
  * one at a time instead.
  *
+ * Supplying an `authorizerHandler` puts a `TOKEN` authorizer in front of every
+ * method, invoking a second simulated function of its own.
+ *
  * ```typescript
  * const restApi = await simRestApiLambdaProxyFactory.make(
  *   { handler: () => ({ statusCode: 200, body: "hello" }) },
@@ -81,6 +82,9 @@ export const simRestApiLambdaProxyFactory = new AsyncMappedFactory<
     functionAccountId: DEFAULT_SIM_AWS_ACCOUNT_ID,
     roleArn: "arn:aws:iam::111111111111:role/OrdersRole",
     handler: (): unknown => ({ statusCode: 200, body: "hello" }),
+    authorizerHandler: undefined,
+    authorizerIdentitySource: "method.request.header.Authorization",
+    authorizerInvokePermission: true,
     disableExecuteApiEndpoint: false,
     resourcePaths: ["/{proxy+}"],
     httpMethod: "ANY",
@@ -104,6 +108,7 @@ export const simRestApiLambdaProxyFactory = new AsyncMappedFactory<
       rootResourceId: created.rootResourceId,
       httpMethod: input.httpMethod,
       functionArn,
+      authorizerId: await simRestApiProxyAuthorizer(simAws, input, restApiId),
     });
 
     if (input.invokePermission) {

--- a/src/service/apigateway/api/sim-rest-api-proxy-authorizer.ts
+++ b/src/service/apigateway/api/sim-rest-api-proxy-authorizer.ts
@@ -1,0 +1,89 @@
+import type { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../lambda/function/code/lambda-zip-file-input.js";
+import type { SimRestApiTokenAuthorizerEvent } from "../serve/auth/sim-rest-api-authorizer-event.js";
+import { simApiGatewayServicePrincipal } from "../sim-api-gateway-service-principal.js";
+
+/**
+ * What a test asks for when it wants its REST API gated by a `TOKEN`
+ * authorizer.
+ */
+export interface SimRestApiProxyAuthorizerInput {
+  /**
+   * The Account the functions belong to, which need not be the API's. An
+   * integration URI and an authorizer URI are each free to name another one.
+   */
+  readonly functionAccountId: string;
+  readonly roleArn: string;
+  /** The function the authorizer invokes, which decides every request. */
+  readonly authorizerHandler:
+    | ((event: SimRestApiTokenAuthorizerEvent) => unknown)
+    | undefined;
+  /** The header the authorizer takes its token from. */
+  readonly authorizerIdentitySource: string;
+  /**
+   * Whether the authorizer's function grants the API permission to invoke it,
+   * under the ARN naming the authorizer. A test about that permission turns
+   * this off.
+   */
+  readonly authorizerInvokePermission: boolean;
+}
+
+/**
+ * Create the authorizer a test's REST API gates its methods with, and answer
+ * its id.
+ *
+ * The function is a second one beside the integration's, because a REST API
+ * authorizer is invoked under an ARN naming the authorizer rather than any
+ * method, and needs a grant of its own. That grant is the one CDK's
+ * `TokenAuthorizer` writes.
+ */
+export async function simRestApiProxyAuthorizer(
+  simAws: SimAws,
+  input: SimRestApiProxyAuthorizerInput,
+  restApiId: string,
+): Promise<string | undefined> {
+  const handler = input.authorizerHandler;
+
+  if (handler === undefined) {
+    return undefined;
+  }
+
+  const lambda = simAws.account(input.functionAccountId).lambda();
+  const name = `${restApiId}-authorizer`;
+  const created = await lambda.createFunction({
+    input: {
+      FunctionName: name,
+      Role: input.roleArn,
+      Code: { ZipFile: makeLambdaZipFileInput(handler) },
+    },
+  });
+
+  const { id } = await simAws.apiGateway().createAuthorizer({
+    input: {
+      restApiId,
+      name: "orders-authorizer",
+      type: "TOKEN",
+      authorizerUri: created.FunctionArn,
+      identitySource: input.authorizerIdentitySource,
+    },
+  });
+
+  if (input.authorizerInvokePermission) {
+    const { accountId, regionName } =
+      simAws.accountRegionScope().accountRegionScope;
+
+    await lambda.addPermission({
+      input: {
+        FunctionName: name,
+        StatementId: "api-gateway-invoke-authorizer",
+        Action: "lambda:InvokeFunction",
+        Principal: simApiGatewayServicePrincipal,
+        SourceArn:
+          `arn:aws:execute-api:${regionName}:${accountId}:` +
+          `${restApiId}/authorizers/${id}`,
+      },
+    });
+  }
+
+  return id;
+}

--- a/src/service/apigateway/api/sim-rest-api.ts
+++ b/src/service/apigateway/api/sim-rest-api.ts
@@ -1,4 +1,5 @@
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { SimRestApiAuthorizerStore } from "./authorizer/sim-rest-api-authorizer-store.js";
 import { SimRestApiDeploymentStore } from "./deployment/sim-rest-api-deployment-store.js";
 import { SimRestApiResourceStore } from "./resource/sim-rest-api-resource-store.js";
 import type { SimRestApiResource } from "./resource/sim-rest-api-resource.js";
@@ -46,6 +47,7 @@ export class SimRestApi {
   public description?: string | undefined;
 
   public readonly resources = new SimRestApiResourceStore();
+  public readonly authorizers = new SimRestApiAuthorizerStore();
   public readonly deployments = new SimRestApiDeploymentStore();
   public readonly stages = new SimRestApiStageStore();
 

--- a/src/service/apigateway/cfn/authorizer/sim-cfn-rest-api-authorizer-creator.ts
+++ b/src/service/apigateway/cfn/authorizer/sim-cfn-rest-api-authorizer-creator.ts
@@ -1,0 +1,53 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimRestApiAuthorizer } from "../../api/authorizer/sim-rest-api-authorizer.js";
+import type { SimApiGateway } from "../../sim-api-gateway.js";
+import { SimCfnRestApiAuthorizerProperties } from "./sim-cfn-rest-api-authorizer-properties.js";
+
+interface SimCfnRestApiAuthorizerCreatorProperties {
+  readonly apiGateway: SimApiGateway;
+}
+
+/**
+ * Creates simulated authorizers from AWS::ApiGateway::Authorizer Resources.
+ *
+ * The authorizer goes through the ordinary CreateAuthorizer command, so a
+ * `Type` other than `TOKEN`, a missing `AuthorizerUri` and an `IdentitySource`
+ * naming something other than a header are all refused here with the reason
+ * the command gives.
+ */
+export class SimCfnRestApiAuthorizerCreator {
+  private readonly apiGateway: SimApiGateway;
+
+  constructor(properties: SimCfnRestApiAuthorizerCreatorProperties) {
+    this.apiGateway = properties.apiGateway;
+  }
+
+  /**
+   * Create an authorizer from an AWS::ApiGateway::Authorizer Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimRestApiAuthorizer> {
+    const authorizerProperties = new SimCfnRestApiAuthorizerProperties({
+      resource,
+      properties,
+    });
+
+    const created = await this.apiGateway.createAuthorizer({
+      input: authorizerProperties.createAuthorizerInput(),
+    });
+
+    const authorizer = this.apiGateway
+      .findRestApi(authorizerProperties.restApiId())
+      ?.authorizers.find(created.id);
+    assertDefined(
+      authorizer,
+      `sim REST API authorizer ${created.id} after CloudFormation creation`,
+    );
+
+    return authorizer;
+  }
+}

--- a/src/service/apigateway/cfn/authorizer/sim-cfn-rest-api-authorizer-properties.ts
+++ b/src/service/apigateway/cfn/authorizer/sim-cfn-rest-api-authorizer-properties.ts
@@ -1,0 +1,96 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCreateAuthorizerCommandInput } from "../../command/authorizer/authorizer.command.js";
+import { SimCfnApiGatewayPropertyParser } from "../sim-cfn-api-gateway-property-parser.js";
+
+/**
+ * The AWS::ApiGateway::Authorizer properties this simulation deploys.
+ *
+ * `AuthorizerResultTtlInSeconds`, `ProviderARNs`, `AuthorizerCredentials`,
+ * `IdentityValidationExpression` and `AuthType` are left out, so a template
+ * carrying one has it recorded against the Resource. Each belongs to a piece
+ * of work outside this one, and what a `TOKEN` authorizer requires is stated
+ * by `CreateAuthorizer` rather than here.
+ */
+const simulatedProperties = [
+  "RestApiId",
+  "Name",
+  "Type",
+  "AuthorizerUri",
+  "IdentitySource",
+];
+
+interface SimCfnRestApiAuthorizerPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::ApiGateway::Authorizer CloudFormation properties into the
+ * CreateAuthorizer input the authorizer creator needs.
+ */
+export class SimCfnRestApiAuthorizerProperties {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly propertyParser = new SimCfnApiGatewayPropertyParser({
+    resourceType: "AWS::ApiGateway::Authorizer",
+    simulated: simulatedProperties,
+  });
+
+  constructor(properties: SimCfnRestApiAuthorizerPropertiesProperties) {
+    this.resource = properties.resource;
+    this.properties = properties.properties;
+
+    this.propertyParser.ignoreUnsimulated(this.resource, this.properties);
+  }
+
+  /**
+   * The API this authorizer belongs to, which a template reaches with a `Ref`
+   * on its AWS::ApiGateway::RestApi.
+   */
+  restApiId(): string {
+    return this.propertyParser.requiredString(
+      this.resource,
+      this.properties["RestApiId"],
+      "RestApiId",
+    );
+  }
+
+  /**
+   * The CreateAuthorizer input this Resource asks for.
+   *
+   * Everything but the shape of each value is passed through, so a `REQUEST`
+   * or `COGNITO_USER_POOLS` authorizer, one naming no function and one whose
+   * identity source is not a header are all refused by CreateAuthorizer with
+   * the reason it refuses them.
+   *
+   * `AuthorizerUri` arrives as the wrapped
+   * `arn:aws:apigateway:<region>:lambda:path/...` form CDK builds with
+   * `Fn::Join`, which is one of the two forms CreateAuthorizer takes.
+   */
+  createAuthorizerInput(): SimCreateAuthorizerCommandInput {
+    return {
+      restApiId: this.restApiId(),
+      name: this.propertyParser.optionalString(
+        this.resource,
+        this.properties["Name"],
+        "Name",
+      ),
+      type: this.propertyParser.optionalString(
+        this.resource,
+        this.properties["Type"],
+        "Type",
+      ),
+      authorizerUri: this.propertyParser.optionalString(
+        this.resource,
+        this.properties["AuthorizerUri"],
+        "AuthorizerUri",
+      ),
+      identitySource: this.propertyParser.optionalString(
+        this.resource,
+        this.properties["IdentitySource"],
+        "IdentitySource",
+      ),
+    };
+  }
+}

--- a/src/service/apigateway/cfn/method/sim-cfn-rest-api-method-properties.ts
+++ b/src/service/apigateway/cfn/method/sim-cfn-rest-api-method-properties.ts
@@ -8,17 +8,18 @@ import { SimCfnRestApiIntegrationProperties } from "./sim-cfn-rest-api-integrati
 /**
  * The AWS::ApiGateway::Method properties this simulation deploys.
  *
- * `AuthorizerId`, `AuthorizationScopes`, `RequestParameters`,
- * `RequestModels`, `RequestValidatorId` and `MethodResponses` are left out, so
- * a template carrying one has it recorded against the Resource. A method
- * asking to be authorized is refused by `AuthorizationType` before any of them
- * matters.
+ * `AuthorizationScopes`, `RequestParameters`, `RequestModels`,
+ * `RequestValidatorId` and `MethodResponses` are left out, so a template
+ * carrying one has it recorded against the Resource. Scopes belong to a
+ * `COGNITO_USER_POOLS` method, which `AuthorizationType` refuses before they
+ * matter.
  */
 const simulatedProperties = [
   "RestApiId",
   "ResourceId",
   "HttpMethod",
   "AuthorizationType",
+  "AuthorizerId",
   "ApiKeyRequired",
   "OperationName",
   "Integration",
@@ -88,9 +89,11 @@ export class SimCfnRestApiMethodProperties {
   /**
    * The PutMethod input this Resource asks for.
    *
-   * `AuthorizationType` and `ApiKeyRequired` are passed through as the
-   * template wrote them, so a method asking for an authorizer or an API key is
-   * refused by PutMethod with the reason it refuses it.
+   * `AuthorizationType`, `AuthorizerId` and `ApiKeyRequired` are passed
+   * through as the template wrote them, so a method asking for an
+   * authorization type this simulation does not enforce, for an authorizer the
+   * API has not got, or for an API key is refused by PutMethod with the reason
+   * it refuses it.
    */
   putMethodInput(): SimPutMethodCommandInput {
     return {
@@ -101,6 +104,11 @@ export class SimCfnRestApiMethodProperties {
         this.resource,
         this.properties["AuthorizationType"],
         "AuthorizationType",
+      ),
+      authorizerId: this.propertyParser.optionalString(
+        this.resource,
+        this.properties["AuthorizerId"],
+        "AuthorizerId",
       ),
       apiKeyRequired: this.propertyParser.optionalBoolean(
         this.resource,

--- a/src/service/apigateway/cfn/sim-cfn-api-gateway-resource-factory.ts
+++ b/src/service/apigateway/cfn/sim-cfn-api-gateway-resource-factory.ts
@@ -6,33 +6,13 @@ import type {
 import type { SimCloudFormationResourceDeleteContext } from "../../cloudformation/resource/sim-cfn-resource.type.js";
 import type { SimApiGateway } from "../sim-api-gateway.js";
 import { SimCfnRestApiCreator } from "./api/sim-cfn-rest-api-creator.js";
+import { SimCfnRestApiAuthorizerCreator } from "./authorizer/sim-cfn-rest-api-authorizer-creator.js";
 import { SimCfnRestApiDeploymentCreator } from "./deployment/sim-cfn-rest-api-deployment-creator.js";
 import { SimCfnRestApiMethodCreator } from "./method/sim-cfn-rest-api-method-creator.js";
 import { SimCfnRestApiResourceCreator } from "./resource/sim-cfn-rest-api-resource-creator.js";
 import { SimCfnApiGatewayResourceDeleter } from "./sim-cfn-api-gateway-resource-deleter.js";
+import { simCfnApiGatewayUnsupportedReason } from "./sim-cfn-api-gateway-unsupported.js";
 import { SimCfnRestApiStageCreator } from "./stage/sim-cfn-rest-api-stage-creator.js";
-
-/**
- * The Resource types belonging to the parts of a REST API this simulation
- * leaves alone, and what a reader should know about each group.
- */
-const unsupportedReasons = new Map([
-  ["Authorizer", "authorizing a method is not simulated"],
-  ["ApiKey", "API keys and usage plans are not simulated"],
-  ["UsagePlan", "API keys and usage plans are not simulated"],
-  ["UsagePlanKey", "API keys and usage plans are not simulated"],
-  ["RequestValidator", "request validation is not simulated"],
-  ["Model", "request and response models are not simulated"],
-  ["DomainName", "custom domain names are not simulated"],
-  ["DomainNameV2", "custom domain names are not simulated"],
-  ["BasePathMapping", "custom domain names are not simulated"],
-  ["BasePathMappingV2", "custom domain names are not simulated"],
-  [
-    "Account",
-    "the Account-wide CloudWatch role is not simulated, and nothing here " +
-      "logs a request to CloudWatch",
-  ],
-]);
 
 interface SimApiGatewayCfnResourceFactoryProperties {
   readonly apiGateway: SimApiGateway;
@@ -45,6 +25,7 @@ interface SimApiGatewayCfnResourceFactoryProperties {
 export class SimApiGatewayCfnResourceFactory implements SimCfnServiceResourceFactory {
   private readonly apiCreator: SimCfnRestApiCreator;
   private readonly resourceCreator: SimCfnRestApiResourceCreator;
+  private readonly authorizerCreator: SimCfnRestApiAuthorizerCreator;
   private readonly methodCreator: SimCfnRestApiMethodCreator;
   private readonly deploymentCreator: SimCfnRestApiDeploymentCreator;
   private readonly stageCreator: SimCfnRestApiStageCreator;
@@ -53,6 +34,7 @@ export class SimApiGatewayCfnResourceFactory implements SimCfnServiceResourceFac
   constructor(properties: SimApiGatewayCfnResourceFactoryProperties) {
     this.apiCreator = new SimCfnRestApiCreator(properties);
     this.resourceCreator = new SimCfnRestApiResourceCreator(properties);
+    this.authorizerCreator = new SimCfnRestApiAuthorizerCreator(properties);
     this.methodCreator = new SimCfnRestApiMethodCreator(properties);
     this.deploymentCreator = new SimCfnRestApiDeploymentCreator(properties);
     this.stageCreator = new SimCfnRestApiStageCreator(properties);
@@ -63,9 +45,9 @@ export class SimApiGatewayCfnResourceFactory implements SimCfnServiceResourceFac
    * Create a simulated API Gateway REST API resource from a CloudFormation
    * Resource.
    *
-   * Authorizers, API keys, usage plans, request validators, models, custom
-   * domain names and the Account-wide CloudWatch role are all reported as
-   * unsupported rather than quietly treated as deployed. CDK writes the
+   * API keys, usage plans, request validators, models, custom domain names
+   * and the Account-wide CloudWatch role are all reported as unsupported
+   * rather than quietly treated as deployed. CDK writes the
    * `Account` Resource and its role beside a default `RestApi`, so a stack
    * carrying one deploys with that Resource recorded and the API served.
    */
@@ -83,6 +65,9 @@ export class SimApiGatewayCfnResourceFactory implements SimCfnServiceResourceFac
       case "Resource": {
         return await this.resourceCreator.create(resource, properties);
       }
+      case "Authorizer": {
+        return await this.authorizerCreator.create(resource, properties);
+      }
       case "Method": {
         return await this.methodCreator.create(resource, properties);
       }
@@ -94,8 +79,7 @@ export class SimApiGatewayCfnResourceFactory implements SimCfnServiceResourceFac
       }
       default: {
         throw new Error(
-          `Unsupported sim API Gateway CloudFormation Resource ` +
-            `${resourceTypeName}${this.unsupportedReason(resourceTypeName)}`,
+          `Unsupported sim API Gateway CloudFormation Resource ${resourceTypeName}${simCfnApiGatewayUnsupportedReason(resourceTypeName)}`,
         );
       }
     }
@@ -115,15 +99,5 @@ export class SimApiGatewayCfnResourceFactory implements SimCfnServiceResourceFac
       resource,
       context.resolvedProperties ?? resource.properties,
     );
-  }
-
-  /**
-   * Say why a Resource type is unsupported when there is more to say than that
-   * nothing creates it yet.
-   */
-  private unsupportedReason(resourceTypeName: string): string {
-    const reason = unsupportedReasons.get(resourceTypeName);
-
-    return reason === undefined ? "" : `, because ${reason}`;
   }
 }

--- a/src/service/apigateway/cfn/sim-cfn-api-gateway-unsupported.ts
+++ b/src/service/apigateway/cfn/sim-cfn-api-gateway-unsupported.ts
@@ -1,0 +1,32 @@
+/**
+ * The Resource types belonging to the parts of a REST API this simulation
+ * leaves alone, and what a reader should know about each group.
+ */
+const unsupportedReasons = new Map([
+  ["ApiKey", "API keys and usage plans are not simulated"],
+  ["UsagePlan", "API keys and usage plans are not simulated"],
+  ["UsagePlanKey", "API keys and usage plans are not simulated"],
+  ["RequestValidator", "request validation is not simulated"],
+  ["Model", "request and response models are not simulated"],
+  ["DomainName", "custom domain names are not simulated"],
+  ["DomainNameV2", "custom domain names are not simulated"],
+  ["BasePathMapping", "custom domain names are not simulated"],
+  ["BasePathMappingV2", "custom domain names are not simulated"],
+  [
+    "Account",
+    "the Account-wide CloudWatch role is not simulated, and nothing here " +
+      "logs a request to CloudWatch",
+  ],
+]);
+
+/**
+ * Say why a Resource type is unsupported when there is more to say than that
+ * nothing creates it yet.
+ */
+export function simCfnApiGatewayUnsupportedReason(
+  resourceTypeName: string,
+): string {
+  const reason = unsupportedReasons.get(resourceTypeName);
+
+  return reason === undefined ? "" : `, because ${reason}`;
+}

--- a/src/service/apigateway/cfn/sim-cfn-rest-api-authorizer.iso.test.ts
+++ b/src/service/apigateway/cfn/sim-cfn-rest-api-authorizer.iso.test.ts
@@ -1,0 +1,246 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import {
+  deployRestApi,
+  ignoredReasons,
+  simAwsInEuWest2,
+} from "../../../../test/apigateway/cfn-deploy.js";
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimRestApi } from "../api/sim-rest-api.js";
+import { simCfnRestApiTemplateFactory } from "./sim-cfn-rest-api-template.factory.js";
+
+/**
+ * The authorizer's own function, and the grant API Gateway needs to invoke it.
+ *
+ * The `SourceArn` names the authorizer rather than any method, which is what
+ * CDK's `TokenAuthorizer` writes and what the API is asked about at request
+ * time.
+ */
+const authorizerResources: SimCfnTemplateValueRecord = {
+  AuthorizerFunction: {
+    Type: "AWS::Lambda::Function",
+    Properties: {
+      FunctionName: "session-check",
+      Role: { "Fn::GetAtt": ["HandlerRole", "Arn"] },
+      Code: {
+        ZipFile:
+          "exports.handler = async (event) => ({" +
+          "  principalId: 'user-6'," +
+          "  context: { tenantId: 'acme' }," +
+          "  policyDocument: { Version: '2012-10-17', Statement: [" +
+          "    { Action: 'execute-api:Invoke', Effect: 'Allow'," +
+          "      Resource: event.methodArn }] }," +
+          "});",
+      },
+      Handler: "index.handler",
+      Runtime: "nodejs20.x",
+    },
+  },
+  Authorizer: {
+    Type: "AWS::ApiGateway::Authorizer",
+    Properties: {
+      RestApiId: { Ref: "Api" },
+      Name: "session-check",
+      Type: "TOKEN",
+      IdentitySource: "method.request.header.Authorization",
+      AuthorizerUri: {
+        "Fn::Join": [
+          "",
+          [
+            "arn:aws:apigateway:",
+            { Ref: "AWS::Region" },
+            ":lambda:path/2015-03-31/functions/",
+            { "Fn::GetAtt": ["AuthorizerFunction", "Arn"] },
+            "/invocations",
+          ],
+        ],
+      },
+    },
+  },
+  AuthorizerPermission: {
+    Type: "AWS::Lambda::Permission",
+    Properties: {
+      Action: "lambda:InvokeFunction",
+      FunctionName: { "Fn::GetAtt": ["AuthorizerFunction", "Arn"] },
+      Principal: "apigateway.amazonaws.com",
+      SourceArn: {
+        "Fn::Join": [
+          "",
+          [
+            "arn:aws:execute-api:",
+            { Ref: "AWS::Region" },
+            ":",
+            { Ref: "AWS::AccountId" },
+            ":",
+            { Ref: "Api" },
+            "/authorizers/",
+            { Ref: "Authorizer" },
+          ],
+        ],
+      },
+    },
+  },
+};
+
+/**
+ * A handler reporting what the authorizer passed on to it.
+ */
+const authorizerContextHandler = `
+exports.handler = async (event) => ({
+  statusCode: 200,
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify(event.requestContext.authorizer),
+});
+`;
+
+/**
+ * The template that deploys a REST API gated by that authorizer.
+ */
+function gatedTemplate(
+  authorizerProperties: SimCfnTemplateValueRecord = {},
+): ReturnType<typeof simCfnRestApiTemplateFactory.make> {
+  const authorizer = authorizerResources["Authorizer"] as {
+    Type: string;
+    Properties: SimCfnTemplateValueRecord;
+  };
+
+  return simCfnRestApiTemplateFactory.make({
+    handlerSource: authorizerContextHandler,
+    methods: [{ httpMethod: "GET", path: ["orders"] }],
+    methodProperties: {
+      AuthorizationType: "CUSTOM",
+      AuthorizerId: { Ref: "Authorizer" },
+    },
+    resources: {
+      ...authorizerResources,
+      Authorizer: {
+        ...authorizer,
+        Properties: { ...authorizer.Properties, ...authorizerProperties },
+      },
+    },
+  });
+}
+
+describe("Deploying a REST API authorizer from CloudFormation", () => {
+  it("gates a method with the authorizer the template declares", async () => {
+    // Given a deployed API whose method names an AWS::ApiGateway::Authorizer
+    const simAws = simAwsInEuWest2();
+    const stack = await deployRestApi(simAws, gatedTemplate());
+    const restApi = stack.resources.get("Api")?.simResource as
+      | SimRestApi
+      | undefined;
+    assertNonNullable(restApi);
+    const url = new SimAwsLocalUrl({
+      input: `${restApi.invokeUrl("prod")}/orders`,
+    }).toString();
+
+    // When the method is requested with and without a token
+    const http = new SimAwsHttp({ simAws });
+    const admitted = await http.fetch(url, {
+      headers: { authorization: "Bearer session-6" },
+    });
+    const refused = await http.fetch(url);
+
+    // Then the deployed authorizer decides both, rather than the method
+    // answering everything, and what it passed on reaches the handler
+    assertIdentical(admitted.status, 200);
+    assertIdentical(refused.status, 401);
+    expect(await admitted.json()).toStrictEqual({
+      principalId: "user-6",
+      tenantId: "acme",
+    });
+  });
+
+  it("answers a Ref on the authorizer with its id", async () => {
+    // Given a deployed API gated by an authorizer
+    const simAws = simAwsInEuWest2();
+    const stack = await deployRestApi(simAws, gatedTemplate());
+    const restApi = stack.resources.get("Api")?.simResource as
+      | SimRestApi
+      | undefined;
+    assertNonNullable(restApi);
+
+    // When the method that names it by Ref is read back
+    const [authorizer] = restApi.authorizers.list();
+    const method = restApi.resources
+      .list()
+      .flatMap((resource) => resource.listMethods())
+      .find((one) => one.httpMethod === "GET");
+
+    // Then the Ref resolved to the id the API allocated, which is what a
+    // method names an authorizer by
+    assertNonNullable(authorizer);
+    assertIdentical(method?.authorizerId, authorizer.authorizerId);
+  });
+
+  it("records a property outside the simulated set", async () => {
+    // Given an authorizer asking for its decisions to be held
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const stack = await deployRestApi(
+      simAws,
+      gatedTemplate({ AuthorizerResultTtlInSeconds: 300 }),
+    );
+
+    // Then the API deploys and the record says which of its parts behaves
+    // differently to the template
+    assertIdentical(
+      stack.resources.get("Authorizer")?.status,
+      "CREATE_COMPLETE",
+    );
+    assertStringIncludes(
+      ignoredReasons(stack).join("\n"),
+      "AWS::ApiGateway::Authorizer property AuthorizerResultTtlInSeconds is " +
+        "not simulated",
+    );
+  });
+
+  it("deletes the authorizer with the rest of the stack", async () => {
+    // Given a deployed API gated by an authorizer
+    const simAws = simAwsInEuWest2();
+    const stack = await deployRestApi(simAws, gatedTemplate());
+    const restApi = stack.resources.get("Api")?.simResource as
+      | SimRestApi
+      | undefined;
+    assertNonNullable(restApi);
+
+    // When the Stack's Resources are torn down
+    await stack.teardown();
+
+    // Then the authorizer went through DeleteAuthorizer, and the API is gone
+    assertIdentical(
+      stack.resources.get("Authorizer")?.status,
+      "DELETE_COMPLETE",
+    );
+    assertUndefined(simAws.apiGateway().findRestApi(restApi.apiId));
+  });
+
+  it("refuses a method naming an authorizer the API has not got", async () => {
+    // Given a method gated by an id nothing answers to
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const deploy = deployRestApi(
+      simAws,
+      simCfnRestApiTemplateFactory.make({
+        methodProperties: {
+          AuthorizationType: "CUSTOM",
+          AuthorizerId: "nothere",
+        },
+      }),
+    );
+
+    // Then PutMethod refuses it, since the method would refuse every request
+    // for a reason a caller reads as a signing problem
+    await expect(deploy).rejects.toThrow("names no authorizer of REST API");
+  });
+});

--- a/src/service/apigateway/cfn/sim-cfn-rest-api-part-deleter.ts
+++ b/src/service/apigateway/cfn/sim-cfn-rest-api-part-deleter.ts
@@ -3,6 +3,7 @@ import type {
   SimCfnTemplateValue,
   SimCfnTemplateValueRecord,
 } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimRestApiAuthorizer } from "../api/authorizer/sim-rest-api-authorizer.js";
 import type { SimRestApiResource } from "../api/resource/sim-rest-api-resource.js";
 import type { SimRestApiStage } from "../api/stage/sim-rest-api-stage.js";
 import type { SimApiGateway } from "../sim-api-gateway.js";
@@ -49,6 +50,15 @@ export class SimCfnRestApiPartDeleter {
 
         await this.apiGateway.deleteResource({
           input: { restApiId, resourceId },
+        });
+
+        return;
+      }
+      case "Authorizer": {
+        const { authorizerId } = this.part<SimRestApiAuthorizer>(resource);
+
+        await this.apiGateway.deleteAuthorizer({
+          input: { restApiId, authorizerId },
         });
 
         return;

--- a/src/service/apigateway/cfn/sim-cfn-rest-api-validation.iso.test.ts
+++ b/src/service/apigateway/cfn/sim-cfn-rest-api-validation.iso.test.ts
@@ -15,8 +15,28 @@ import {
 import { simCfnRestApiTemplateFactory } from "./sim-cfn-rest-api-template.factory.js";
 
 describe("API Gateway REST API CloudFormation refusals", () => {
-  it("refuses a method asking to be authorized", async () => {
-    // Given a method declaring a Lambda authorizer
+  it("refuses a method asking for an authorization type nothing enforces", async () => {
+    // Given a method behind IAM authorization
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const error = await deployRestApiFailure(
+      simAws,
+      simCfnRestApiTemplateFactory.make({
+        methodProperties: { AuthorizationType: "AWS_IAM" },
+      }),
+    );
+
+    // Then PutMethod refuses it, rather than serving open a method real AWS
+    // would have gated
+    assertStringIncludes(
+      error.message,
+      "PutMethod authorizationType 'AWS_IAM' is not simulated",
+    );
+  });
+
+  it("refuses a CUSTOM method naming no authorizer", async () => {
+    // Given a method gated by an authorizer it does not name
     const simAws = simAwsInEuWest2();
 
     // When the template is deployed
@@ -27,11 +47,11 @@ describe("API Gateway REST API CloudFormation refusals", () => {
       }),
     );
 
-    // Then PutMethod refuses it, rather than serving open a method real AWS
-    // would have gated
+    // Then PutMethod refuses it, since a method with nothing to ask would
+    // refuse every request for a reason that reads like a signing problem
     assertStringIncludes(
       error.message,
-      "PutMethod authorizationType 'CUSTOM' is not simulated",
+      "PutMethod with authorizationType CUSTOM requires authorizerId",
     );
   });
 
@@ -176,12 +196,12 @@ describe("API Gateway REST API CloudFormation Resource types left out", () => {
     assertIdentical(account.status, "CREATE_COMPLETE");
   });
 
-  it("records an authorizer as a Resource nothing created", async () => {
-    // Given a template declaring a Lambda authorizer
+  it("refuses an authorizer of a kind nothing here invokes", async () => {
+    // Given a template declaring a REQUEST authorizer
     const simAws = simAwsInEuWest2();
 
     // When the template is deployed
-    const stack = await deployRestApi(
+    const error = await deployRestApiFailure(
       simAws,
       simCfnRestApiTemplateFactory.make({
         resources: {
@@ -197,14 +217,11 @@ describe("API Gateway REST API CloudFormation Resource types left out", () => {
       }),
     );
 
-    // Then the rest of the stack deploys and the authorizer is reported
-    const authorizer = stack.resources.get("Authorizer");
-    assertNonNullable(authorizer);
-    assertTrue(authorizer.skipped);
+    // Then CreateAuthorizer refuses it, rather than leaving a method behind an
+    // authorizer that decides nothing
     assertStringIncludes(
-      authorizer.skippedReason ?? "",
-      "Unsupported sim API Gateway CloudFormation Resource Authorizer, " +
-        "because authorizing a method is not simulated",
+      error.message,
+      "CreateAuthorizer type 'REQUEST' is not simulated",
     );
   });
 });

--- a/src/service/apigateway/command/authorizer/authorizer.command.ts
+++ b/src/service/apigateway/command/authorizer/authorizer.command.ts
@@ -1,0 +1,79 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimRestApiAuthorizerView } from "../../api/authorizer/sim-rest-api-authorizer.js";
+
+/**
+ * Minimal structural sim API Gateway CreateAuthorizer command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/api-gateway/command/CreateAuthorizerCommand/
+ */
+export interface SimCreateAuthorizerCommand {
+  readonly input: SimCreateAuthorizerCommandInput;
+}
+
+export interface SimCreateAuthorizerCommandInput {
+  readonly restApiId?: string | undefined;
+  readonly name?: string | undefined;
+  readonly type?: string | undefined;
+  readonly authorizerUri?: string | undefined;
+  readonly identitySource?: string | undefined;
+}
+
+export interface SimCreateAuthorizerCommandOutput extends SimRestApiAuthorizerView {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim API Gateway GetAuthorizer command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/api-gateway/command/GetAuthorizerCommand/
+ */
+export interface SimGetAuthorizerCommand {
+  readonly input: SimGetAuthorizerCommandInput;
+}
+
+export interface SimGetAuthorizerCommandInput {
+  readonly restApiId?: string | undefined;
+  readonly authorizerId?: string | undefined;
+}
+
+export interface SimGetAuthorizerCommandOutput extends SimRestApiAuthorizerView {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim API Gateway GetAuthorizers command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/api-gateway/command/GetAuthorizersCommand/
+ */
+export interface SimGetAuthorizersCommand {
+  readonly input: SimGetAuthorizersCommandInput;
+}
+
+export interface SimGetAuthorizersCommandInput {
+  readonly restApiId?: string | undefined;
+  readonly limit?: number | undefined;
+  readonly position?: string | undefined;
+}
+
+export interface SimGetAuthorizersCommandOutput {
+  readonly items: SimRestApiAuthorizerView[];
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim API Gateway DeleteAuthorizer command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/api-gateway/command/DeleteAuthorizerCommand/
+ */
+export interface SimDeleteAuthorizerCommand {
+  readonly input: SimDeleteAuthorizerCommandInput;
+}
+
+export interface SimDeleteAuthorizerCommandInput {
+  readonly restApiId?: string | undefined;
+  readonly authorizerId?: string | undefined;
+}
+
+export interface SimDeleteAuthorizerCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/apigateway/command/authorizer/sim-rest-api-authorizer-commands.iso.test.ts
+++ b/src/service/apigateway/command/authorizer/sim-rest-api-authorizer-commands.iso.test.ts
@@ -1,0 +1,245 @@
+import {
+  CreateAuthorizerCommand,
+  CreateRestApiCommand,
+  DeleteAuthorizerCommand,
+  GetAuthorizerCommand,
+  GetAuthorizersCommand,
+} from "@aws-sdk/client-api-gateway";
+import { assertIdentical, assertArrayLength } from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimApiGatewayBadRequest,
+  SimApiGatewayNotFound,
+} from "../../error/sim-api-gateway.error.js";
+import type { SimApiGateway } from "../../sim-api-gateway.js";
+
+const authorizerFunctionArn =
+  "arn:aws:lambda:us-east-1:111111111111:function:session-check";
+
+/**
+ * A REST API with nothing on it yet, which is all an authorizer needs.
+ */
+async function givenRestApi(apiGateway: SimApiGateway): Promise<string> {
+  const created = await apiGateway.createRestApi(
+    new CreateRestApiCommand({ name: "orders" }),
+  );
+
+  return created.id;
+}
+
+/**
+ * The input a working TOKEN authorizer is created from.
+ */
+function tokenAuthorizerInput(restApiId: string): {
+  readonly restApiId: string;
+  readonly name: string;
+  readonly type: "TOKEN";
+  readonly authorizerUri: string;
+  readonly identitySource: string;
+} {
+  return {
+    restApiId,
+    name: "session-check",
+    type: "TOKEN",
+    authorizerUri: authorizerFunctionArn,
+    identitySource: "method.request.header.Authorization",
+  };
+}
+
+describe("Sim API Gateway REST API authorizer commands", () => {
+  it("creates a TOKEN authorizer on an API", async () => {
+    // Given a REST API
+    const simAws = new SimAws();
+    const restApiId = await givenRestApi(simAws.apiGateway());
+
+    // When a TOKEN authorizer is created on it
+    const authorizer = await simAws
+      .apiGateway()
+      .createAuthorizer(
+        new CreateAuthorizerCommand(tokenAuthorizerInput(restApiId)),
+      );
+
+    // Then it reports the id it was allocated and how it was configured
+    expect(authorizer.id).toMatch(/^[a-z0-9]+$/u);
+    assertIdentical(authorizer.name, "session-check");
+    assertIdentical(authorizer.type, "TOKEN");
+    assertIdentical(authorizer.authorizerUri, authorizerFunctionArn);
+    assertIdentical(
+      authorizer.identitySource,
+      "method.request.header.Authorization",
+    );
+    // A TOKEN authorizer belongs to the custom family, which is what a Cognito
+    // authorizer is told apart from.
+    assertIdentical(authorizer.authType, "custom");
+  });
+
+  it("reads an authorizer back by id", async () => {
+    // Given an API with an authorizer
+    const simAws = new SimAws();
+    const restApiId = await givenRestApi(simAws.apiGateway());
+    const created = await simAws
+      .apiGateway()
+      .createAuthorizer(
+        new CreateAuthorizerCommand(tokenAuthorizerInput(restApiId)),
+      );
+
+    // When it is read back
+    const authorizer = await simAws
+      .apiGateway()
+      .getAuthorizer(
+        new GetAuthorizerCommand({ restApiId, authorizerId: created.id }),
+      );
+
+    // Then it is the one that was created
+    assertIdentical(authorizer.id, created.id);
+    assertIdentical(authorizer.name, "session-check");
+  });
+
+  it("lists the authorizers of one API", async () => {
+    // Given two APIs, each with an authorizer
+    const simAws = new SimAws();
+    const apiGateway = simAws.apiGateway();
+    const restApiId = await givenRestApi(apiGateway);
+    const otherRestApiId = await givenRestApi(apiGateway);
+    await apiGateway.createAuthorizer(
+      new CreateAuthorizerCommand(tokenAuthorizerInput(restApiId)),
+    );
+    await apiGateway.createAuthorizer(
+      new CreateAuthorizerCommand({
+        ...tokenAuthorizerInput(otherRestApiId),
+        name: "other-check",
+      }),
+    );
+
+    // When one API's authorizers are listed
+    const listed = await apiGateway.getAuthorizers(
+      new GetAuthorizersCommand({ restApiId }),
+    );
+
+    // Then only its own is there, because an authorizer belongs to an API
+    assertArrayLength(listed.items, 1);
+    assertIdentical(listed.items[0].name, "session-check");
+  });
+
+  it("deletes an authorizer", async () => {
+    // Given an API with an authorizer
+    const simAws = new SimAws();
+    const apiGateway = simAws.apiGateway();
+    const restApiId = await givenRestApi(apiGateway);
+    const created = await apiGateway.createAuthorizer(
+      new CreateAuthorizerCommand(tokenAuthorizerInput(restApiId)),
+    );
+
+    // When it is deleted
+    await apiGateway.deleteAuthorizer(
+      new DeleteAuthorizerCommand({ restApiId, authorizerId: created.id }),
+    );
+
+    // Then the API no longer has it
+    const listed = await apiGateway.getAuthorizers(
+      new GetAuthorizersCommand({ restApiId }),
+    );
+    assertArrayLength(listed.items, 0);
+  });
+
+  it("refuses to read an authorizer the API has not got", async () => {
+    // Given an API with no authorizers
+    const simAws = new SimAws();
+    const restApiId = await givenRestApi(simAws.apiGateway());
+
+    // When one is read by an id nothing answers to
+    const authorizer = simAws
+      .apiGateway()
+      .getAuthorizer(
+        new GetAuthorizerCommand({ restApiId, authorizerId: "nothere" }),
+      );
+
+    // Then it is a not found, as it is on real AWS
+    await expect(authorizer).rejects.toThrow(SimApiGatewayNotFound);
+  });
+
+  it("refuses an authorizer kind nothing here invokes", async () => {
+    // Given a REST API
+    const simAws = new SimAws();
+    const restApiId = await givenRestApi(simAws.apiGateway());
+
+    // When a REQUEST authorizer is asked for
+    const authorizer = simAws.apiGateway().createAuthorizer(
+      new CreateAuthorizerCommand({
+        ...tokenAuthorizerInput(restApiId),
+        type: "REQUEST",
+      }),
+    );
+
+    // Then it is refused, rather than created as something that decides
+    // nothing
+    await expect(authorizer).rejects.toThrow(SimApiGatewayBadRequest);
+    await expect(authorizer).rejects.toThrow(
+      "CreateAuthorizer type 'REQUEST' is not simulated",
+    );
+  });
+
+  it("refuses an identity source that is not a header", async () => {
+    // Given a REST API
+    const simAws = new SimAws();
+    const restApiId = await givenRestApi(simAws.apiGateway());
+
+    // When the authorizer takes its token from the query string
+    const authorizer = simAws.apiGateway().createAuthorizer(
+      new CreateAuthorizerCommand({
+        ...tokenAuthorizerInput(restApiId),
+        identitySource: "method.request.querystring.token",
+      }),
+    );
+
+    // Then it is refused when it is configured, because an authorizer looking
+    // somewhere nothing reads refuses every request for a reason that reads
+    // like a signing problem
+    await expect(authorizer).rejects.toThrow(SimApiGatewayBadRequest);
+    await expect(authorizer).rejects.toThrow(
+      "a TOKEN authorizer reads one header",
+    );
+  });
+
+  it("refuses an authorizer naming no function", async () => {
+    // Given a REST API
+    const simAws = new SimAws();
+    const restApiId = await givenRestApi(simAws.apiGateway());
+
+    // When an authorizer is created with no URI
+    const authorizer = simAws.apiGateway().createAuthorizer(
+      new CreateAuthorizerCommand({
+        ...tokenAuthorizerInput(restApiId),
+        authorizerUri: undefined,
+      }),
+    );
+
+    // Then it is refused, since it would have nothing to ask
+    await expect(authorizer).rejects.toThrow(
+      "CreateAuthorizer with type TOKEN requires authorizerUri",
+    );
+  });
+
+  it("refuses to hold a decision it was told to cache", async () => {
+    // Given a REST API
+    const simAws = new SimAws();
+    const restApiId = await givenRestApi(simAws.apiGateway());
+
+    // When an authorizer asks for its results to be held
+    const authorizer = simAws.apiGateway().createAuthorizer(
+      new CreateAuthorizerCommand({
+        ...tokenAuthorizerInput(restApiId),
+        authorizerResultTtlInSeconds: 300,
+      }),
+    );
+
+    // Then it is refused, because an authorizer invoked once per request here
+    // and once per five minutes on AWS is a difference a test would not see
+    await expect(authorizer).rejects.toThrow(SimApiGatewayBadRequest);
+    await expect(authorizer).rejects.toThrow(
+      "CreateAuthorizer authorizerResultTtlInSeconds is not simulated",
+    );
+  });
+});

--- a/src/service/apigateway/command/authorizer/sim-rest-api-authorizer-commands.ts
+++ b/src/service/apigateway/command/authorizer/sim-rest-api-authorizer-commands.ts
@@ -1,0 +1,201 @@
+import type { SimRestApiAuthorizer } from "../../api/authorizer/sim-rest-api-authorizer.js";
+import type { SimRestApi } from "../../api/sim-rest-api.js";
+import { SimApiGatewayNotFound } from "../../error/sim-api-gateway.error.js";
+import type { SimApiGatewayRequestOptions } from "../sim-api-gateway-request-options.js";
+import { SimApiGatewayUnsimulatedInput } from "../sim-api-gateway-unsimulated-input.js";
+import type { SimRestApiAccess } from "../sim-rest-api-access.js";
+import type {
+  SimCreateAuthorizerCommand,
+  SimCreateAuthorizerCommandOutput,
+  SimDeleteAuthorizerCommand,
+  SimDeleteAuthorizerCommandInput,
+  SimDeleteAuthorizerCommandOutput,
+  SimGetAuthorizerCommand,
+  SimGetAuthorizerCommandInput,
+  SimGetAuthorizerCommandOutput,
+  SimGetAuthorizersCommand,
+  SimGetAuthorizersCommandOutput,
+} from "./authorizer.command.js";
+import { SimRestApiAuthorizerInput } from "./sim-rest-api-authorizer-input.js";
+
+const authorizersPath = "/authorizers";
+
+const acceptedCreateOptions = [
+  "restApiId",
+  "name",
+  "type",
+  "authorizerUri",
+  "identitySource",
+];
+
+const simulatedAuthorizerType = "TOKEN";
+
+const authorizerTypeRefusal =
+  "a REQUEST authorizer receives the whole request and a " +
+  "COGNITO_USER_POOLS one verifies a user pool token, and neither is built " +
+  "here";
+
+interface SimRestApiAuthorizerCommandsProperties {
+  readonly access: SimRestApiAccess;
+}
+
+/**
+ * The commands addressing the authorizers of a REST API.
+ */
+export class SimRestApiAuthorizerCommands {
+  private readonly access: SimRestApiAccess;
+
+  constructor(properties: SimRestApiAuthorizerCommandsProperties) {
+    this.access = properties.access;
+  }
+
+  /**
+   * Handle a CreateAuthorizer command.
+   */
+  createAuthorizer(
+    command: SimCreateAuthorizerCommand,
+    options?: SimApiGatewayRequestOptions,
+  ): SimCreateAuthorizerCommandOutput {
+    const { input } = command;
+    const unsimulated = new SimApiGatewayUnsimulatedInput("CreateAuthorizer");
+    unsimulated.refuseUnaccepted(input, acceptedCreateOptions);
+    const restApiId = unsimulated.require("restApiId", input.restApiId);
+    unsimulated.require("name", input.name);
+    unsimulated.require("type", input.type);
+    unsimulated.refuseUnless(
+      "type",
+      input.type,
+      simulatedAuthorizerType,
+      authorizerTypeRefusal,
+    );
+
+    const authorizerInput = new SimRestApiAuthorizerInput(input);
+
+    const restApi = this.access.api({
+      method: "POST",
+      restApiId,
+      childPath: authorizersPath,
+      caller: options?.caller,
+    });
+
+    const authorizer = authorizerInput.read(restApi.authorizers.allocateId());
+    restApi.authorizers.add(authorizer);
+
+    return { ...authorizer.view(), $metadata: {} };
+  }
+
+  /**
+   * Handle a GetAuthorizer command.
+   */
+  getAuthorizer(
+    command: SimGetAuthorizerCommand,
+    options?: SimApiGatewayRequestOptions,
+  ): SimGetAuthorizerCommandOutput {
+    const { restApi, authorizerId } = this.addressed(
+      "GET",
+      "GetAuthorizer",
+      command.input,
+      options,
+    );
+
+    return { ...this.declared(restApi, authorizerId).view(), $metadata: {} };
+  }
+
+  /**
+   * Handle a GetAuthorizers command.
+   */
+  getAuthorizers(
+    command: SimGetAuthorizersCommand,
+    options?: SimApiGatewayRequestOptions,
+  ): SimGetAuthorizersCommandOutput {
+    const unsimulated = new SimApiGatewayUnsimulatedInput("GetAuthorizers");
+    unsimulated.refusePaging(command.input);
+    unsimulated.refuseUnaccepted(command.input, ["restApiId"]);
+    const restApiId = unsimulated.require("restApiId", command.input.restApiId);
+
+    const restApi = this.access.api({
+      method: "GET",
+      restApiId,
+      childPath: authorizersPath,
+      caller: options?.caller,
+    });
+
+    return {
+      items: restApi.authorizers.list().map((one) => one.view()),
+      $metadata: {},
+    };
+  }
+
+  /**
+   * Handle a DeleteAuthorizer command.
+   *
+   * A method still naming the deleted authorizer keeps its authorization type
+   * and refuses every request, since there is no longer anything to send the
+   * request through. What real API Gateway does with such a method is not
+   * established, so the method stays closed rather than being opened.
+   */
+  deleteAuthorizer(
+    command: SimDeleteAuthorizerCommand,
+    options?: SimApiGatewayRequestOptions,
+  ): SimDeleteAuthorizerCommandOutput {
+    const { restApi, authorizerId } = this.addressed(
+      "DELETE",
+      "DeleteAuthorizer",
+      command.input,
+      options,
+    );
+
+    restApi.authorizers.remove(
+      this.declared(restApi, authorizerId).authorizerId,
+    );
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * The API and authorizer id a command names, once the caller is allowed to
+   * address them.
+   */
+  private addressed(
+    accessMethod: "GET" | "DELETE",
+    operation: string,
+    input: SimGetAuthorizerCommandInput | SimDeleteAuthorizerCommandInput,
+    options?: SimApiGatewayRequestOptions,
+  ): { readonly restApi: SimRestApi; readonly authorizerId: string } {
+    const unsimulated = new SimApiGatewayUnsimulatedInput(operation);
+    unsimulated.refuseUnaccepted(input, ["restApiId", "authorizerId"]);
+    const restApiId = unsimulated.require("restApiId", input.restApiId);
+    const authorizerId = unsimulated.require(
+      "authorizerId",
+      input.authorizerId,
+    );
+
+    return {
+      restApi: this.access.api({
+        method: accessMethod,
+        restApiId,
+        childPath: `${authorizersPath}/${authorizerId}`,
+        caller: options?.caller,
+      }),
+      authorizerId,
+    };
+  }
+
+  /**
+   * An authorizer of this API, refusing an id it has none for.
+   */
+  private declared(
+    restApi: SimRestApi,
+    authorizerId: string,
+  ): SimRestApiAuthorizer {
+    const authorizer = restApi.authorizers.find(authorizerId);
+
+    if (authorizer === undefined) {
+      throw new SimApiGatewayNotFound(
+        `Invalid Authorizer identifier specified: ${authorizerId}`,
+      );
+    }
+
+    return authorizer;
+  }
+}

--- a/src/service/apigateway/command/authorizer/sim-rest-api-authorizer-input.ts
+++ b/src/service/apigateway/command/authorizer/sim-rest-api-authorizer-input.ts
@@ -1,0 +1,71 @@
+import {
+  SimRestApiAuthorizer,
+  type SimRestApiAuthorizerId,
+} from "../../api/authorizer/sim-rest-api-authorizer.js";
+import { SimRestApiIdentitySource } from "../../api/authorizer/sim-rest-api-identity-source.js";
+import { SimRestApiLambdaUri } from "../../api/method/sim-rest-api-lambda-uri.js";
+import { SimApiGatewayBadRequest } from "../../error/sim-api-gateway.error.js";
+import type { SimCreateAuthorizerCommandInput } from "./authorizer.command.js";
+
+/**
+ * Reads the inputs a `TOKEN` authorizer is created from.
+ *
+ * The function and the header are both required by real `CreateAuthorizer` for
+ * this type, and neither has a value worth guessing. An authorizer naming no
+ * function has nothing to ask, and one naming no header would send an empty
+ * token to whatever it did name.
+ */
+export class SimRestApiAuthorizerInput {
+  private readonly input: SimCreateAuthorizerCommandInput;
+
+  constructor(input: SimCreateAuthorizerCommandInput) {
+    this.input = input;
+  }
+
+  /**
+   * The authorizer this input asks for.
+   */
+  read(authorizerId: SimRestApiAuthorizerId): SimRestApiAuthorizer {
+    return new SimRestApiAuthorizer({
+      authorizerId,
+      name: this.input.name ?? "",
+      lambdaUri: this.lambdaUri(),
+      identitySource: SimRestApiIdentitySource.parse(this.identitySource()),
+    });
+  }
+
+  /**
+   * The function this authorizer invokes.
+   *
+   * An `authorizerUri` is written in the same wrapped form an integration URI
+   * is, so it is read by the same parser and refused for the same reasons.
+   */
+  private lambdaUri(): SimRestApiLambdaUri {
+    const uri = this.input.authorizerUri;
+
+    if (uri === undefined || uri.length === 0) {
+      throw new SimApiGatewayBadRequest(
+        "CreateAuthorizer with type TOKEN requires authorizerUri",
+      );
+    }
+
+    return SimRestApiLambdaUri.parse(uri);
+  }
+
+  /**
+   * The header carrying the token, which real `CreateAuthorizer` requires for
+   * this type.
+   */
+  private identitySource(): string {
+    const identitySource = this.input.identitySource;
+
+    if (identitySource === undefined || identitySource.length === 0) {
+      throw new SimApiGatewayBadRequest(
+        "CreateAuthorizer with type TOKEN requires identitySource, such as " +
+          "method.request.header.Authorization",
+      );
+    }
+
+    return identitySource;
+  }
+}

--- a/src/service/apigateway/command/method/method.command.ts
+++ b/src/service/apigateway/command/method/method.command.ts
@@ -16,6 +16,7 @@ export interface SimPutMethodCommandInput {
   readonly resourceId?: string | undefined;
   readonly httpMethod?: string | undefined;
   readonly authorizationType?: string | undefined;
+  readonly authorizerId?: string | undefined;
   readonly apiKeyRequired?: boolean | undefined;
   readonly operationName?: string | undefined;
 }

--- a/src/service/apigateway/command/method/sim-rest-api-method-address.ts
+++ b/src/service/apigateway/command/method/sim-rest-api-method-address.ts
@@ -1,5 +1,6 @@
 import type { SimRestApiMethod } from "../../api/method/sim-rest-api-method.js";
 import type { SimRestApiResource } from "../../api/resource/sim-rest-api-resource.js";
+import type { SimRestApi } from "../../api/sim-rest-api.js";
 import type { SimApiGatewayRequestOptions } from "../sim-api-gateway-request-options.js";
 import { SimApiGatewayUnsimulatedInput } from "../sim-api-gateway-unsimulated-input.js";
 import type { SimRestApiAccess } from "../sim-rest-api-access.js";
@@ -28,6 +29,7 @@ export interface SimRestApiMethodAddressInput {
  * The resource and HTTP method a command addressed.
  */
 export interface SimRestApiMethodTarget {
+  readonly restApi: SimRestApi;
   readonly resource: SimRestApiResource;
   readonly httpMethod: string;
 }
@@ -84,7 +86,11 @@ export class SimRestApiMethodAddress {
       caller: options?.caller,
     });
 
-    return { resource: restApi.requireResource(resourceId), httpMethod };
+    return {
+      restApi,
+      resource: restApi.requireResource(resourceId),
+      httpMethod,
+    };
   }
 
   /**

--- a/src/service/apigateway/command/method/sim-rest-api-method-authorization.ts
+++ b/src/service/apigateway/command/method/sim-rest-api-method-authorization.ts
@@ -1,0 +1,147 @@
+import type { SimRestApiAuthorizationType } from "../../api/method/sim-rest-api-method.js";
+import type { SimRestApiResource } from "../../api/resource/sim-rest-api-resource.js";
+import type { SimRestApi } from "../../api/sim-rest-api.js";
+import { SimApiGatewayBadRequest } from "../../error/sim-api-gateway.error.js";
+import type { SimPutMethodCommandInput } from "./method.command.js";
+
+/**
+ * The authorization types real `PutMethod` takes but this simulation does not
+ * build, and what a reader should know about each.
+ */
+const unsimulatedTypes = new Map([
+  [
+    "REQUEST",
+    "a REQUEST authorizer receives the whole request, and that event is not " +
+      "built here",
+  ],
+  [
+    "COGNITO_USER_POOLS",
+    "verifying a user pool token against a method is not simulated",
+  ],
+  [
+    "AWS_IAM",
+    "authorizing a signed request against the caller's identity policy is " +
+      "not simulated for a method",
+  ],
+]);
+
+/**
+ * What a method's authorization type and authorizer id come to.
+ */
+export interface SimRestApiMethodAuthorization {
+  readonly authorizationType: SimRestApiAuthorizationType;
+  readonly authorizerId?: string | undefined;
+}
+
+/**
+ * Reads the authorization a `PutMethod` input asks for.
+ *
+ * A method is open or it names one of the API's authorizers. Every other
+ * pairing is refused, because a method that looked gated to the caller that
+ * declared it and answered every request here is worse than a refused command.
+ */
+export class SimRestApiMethodAuthorizationInput {
+  private readonly input: SimPutMethodCommandInput;
+
+  constructor(input: SimPutMethodCommandInput) {
+    this.input = input;
+  }
+
+  /**
+   * The authorization this method is declared with, refusing a type nothing
+   * enforces and an authorizer the API has not got.
+   *
+   * The resource is only needed for the message, which names the method the
+   * way a caller wrote it.
+   */
+  read(
+    restApi: SimRestApi,
+    resource: SimRestApiResource,
+    httpMethod: string,
+  ): SimRestApiMethodAuthorization {
+    const authorizationType = this.authorizationType();
+
+    if (authorizationType === "NONE") {
+      this.refuseAuthorizerId(resource, httpMethod);
+
+      return { authorizationType };
+    }
+
+    return {
+      authorizationType,
+      authorizerId: this.authorizerId(restApi, resource, httpMethod),
+    };
+  }
+
+  /**
+   * The authorization type, refusing one this simulation would leave open.
+   *
+   * Real `PutMethod` requires it, and defaulting an absent one to `NONE` here
+   * would declare an open method for a request AWS rejects outright.
+   */
+  private authorizationType(): SimRestApiAuthorizationType {
+    const declared = this.input.authorizationType;
+
+    if (declared === undefined || declared.length === 0) {
+      throw new SimApiGatewayBadRequest("PutMethod requires authorizationType");
+    }
+
+    if (declared === "NONE" || declared === "CUSTOM") {
+      return declared;
+    }
+
+    const reason = unsimulatedTypes.get(declared);
+
+    throw new SimApiGatewayBadRequest(
+      `PutMethod authorizationType '${declared}' is not simulated` +
+        `${reason === undefined ? "" : `: ${reason}`}. NONE and CUSTOM are ` +
+        `supported.`,
+    );
+  }
+
+  /**
+   * The authorizer a `CUSTOM` method names, refusing one the API has not got.
+   *
+   * An id nothing answers to would leave a method that refuses every request
+   * for a reason a caller reads as a signing problem.
+   */
+  private authorizerId(
+    restApi: SimRestApi,
+    resource: SimRestApiResource,
+    httpMethod: string,
+  ): string {
+    const authorizerId = this.input.authorizerId;
+
+    if (authorizerId === undefined || authorizerId.length === 0) {
+      throw new SimApiGatewayBadRequest(
+        `PutMethod with authorizationType CUSTOM requires authorizerId for ` +
+          `${httpMethod} ${resource.path}`,
+      );
+    }
+
+    if (restApi.authorizers.find(authorizerId) === undefined) {
+      throw new SimApiGatewayBadRequest(
+        `PutMethod authorizerId '${authorizerId}' for ${httpMethod} ` +
+          `${resource.path} names no authorizer of REST API ${restApi.apiId}`,
+      );
+    }
+
+    return authorizerId;
+  }
+
+  /**
+   * Refuse an authorizer named by a method that authorizes nobody.
+   */
+  private refuseAuthorizerId(
+    resource: SimRestApiResource,
+    httpMethod: string,
+  ): void {
+    if (this.input.authorizerId !== undefined) {
+      throw new SimApiGatewayBadRequest(
+        `PutMethod authorizerId is set on ${httpMethod} ${resource.path} ` +
+          `with authorizationType NONE, and an open method sends its ` +
+          `requests through nothing`,
+      );
+    }
+  }
+}

--- a/src/service/apigateway/command/method/sim-rest-api-method-commands.iso.test.ts
+++ b/src/service/apigateway/command/method/sim-rest-api-method-commands.iso.test.ts
@@ -85,12 +85,12 @@ describe("Sim API Gateway REST API method commands", () => {
     await expect(again).rejects.toThrow(SimApiGatewayConflict);
   });
 
-  it("refuses a method asking for an authorizer", async () => {
+  it("refuses an authorization type nothing here enforces", async () => {
     // Given a resource
     const simAws = new SimAws();
     const { restApiId, resourceId } = await givenResource(simAws.apiGateway());
 
-    // When a method asks to be authorized
+    // When a method asks to be authorized by a user pool
     const method = simAws.apiGateway().putMethod(
       new PutMethodCommand({
         restApiId,
@@ -104,7 +104,7 @@ describe("Sim API Gateway REST API method commands", () => {
     // that real AWS would reject
     await expect(method).rejects.toThrow(SimApiGatewayBadRequest);
     await expect(method).rejects.toThrow(
-      "authorizing a method is not simulated",
+      "PutMethod authorizationType 'COGNITO_USER_POOLS' is not simulated",
     );
   });
 

--- a/src/service/apigateway/command/method/sim-rest-api-method-commands.ts
+++ b/src/service/apigateway/command/method/sim-rest-api-method-commands.ts
@@ -6,6 +6,7 @@ import {
   SimRestApiMethodAddress,
   simRestApiMethodOptions,
 } from "./sim-rest-api-method-address.js";
+import { SimRestApiMethodAuthorizationInput } from "./sim-rest-api-method-authorization.js";
 import type {
   SimDeleteMethodCommand,
   SimDeleteMethodCommandOutput,
@@ -15,16 +16,13 @@ import type {
   SimPutMethodCommandOutput,
 } from "./method.command.js";
 
-const simulatedAuthorizationType = "NONE";
-
 const acceptedPutOptions = [
   ...simRestApiMethodOptions,
   "authorizationType",
+  "authorizerId",
   "apiKeyRequired",
   "operationName",
 ];
-
-const authorizerRefusal = "authorizing a method is not simulated yet";
 
 const apiKeyRefusal =
   "API keys and usage plans are not simulated, and a method requiring one " +
@@ -54,15 +52,6 @@ export class SimRestApiMethodCommands {
     const { input } = command;
     const unsimulated = new SimApiGatewayUnsimulatedInput("PutMethod");
     unsimulated.refuseUnaccepted(input, acceptedPutOptions);
-    // Real PutMethod requires it, and defaulting an absent one to NONE here
-    // would declare an open method for a request AWS rejects outright.
-    unsimulated.require("authorizationType", input.authorizationType);
-    unsimulated.refuseUnless(
-      "authorizationType",
-      input.authorizationType,
-      simulatedAuthorizationType,
-      authorizerRefusal,
-    );
     unsimulated.refuseEnabled(
       "apiKeyRequired",
       input.apiKeyRequired,
@@ -72,9 +61,13 @@ export class SimRestApiMethodCommands {
     const target = this.address.target("PUT", "PutMethod", input, options);
     const method = new SimRestApiMethod({
       httpMethod: target.httpMethod,
-      authorizationType: simulatedAuthorizationType,
       apiKeyRequired: false,
       operationName: input.operationName,
+      ...new SimRestApiMethodAuthorizationInput(input).read(
+        target.restApi,
+        target.resource,
+        target.httpMethod,
+      ),
     });
     target.resource.addMethod(method);
 

--- a/src/service/apigateway/command/sim-api-gateway-command.types.ts
+++ b/src/service/apigateway/command/sim-api-gateway-command.types.ts
@@ -51,6 +51,20 @@ export type {
   SimPutMethodCommandOutput,
 } from "./method/method.command.js";
 export type {
+  SimCreateAuthorizerCommand,
+  SimCreateAuthorizerCommandInput,
+  SimCreateAuthorizerCommandOutput,
+  SimDeleteAuthorizerCommand,
+  SimDeleteAuthorizerCommandInput,
+  SimDeleteAuthorizerCommandOutput,
+  SimGetAuthorizerCommand,
+  SimGetAuthorizerCommandInput,
+  SimGetAuthorizerCommandOutput,
+  SimGetAuthorizersCommand,
+  SimGetAuthorizersCommandInput,
+  SimGetAuthorizersCommandOutput,
+} from "./authorizer/authorizer.command.js";
+export type {
   SimCreateDeploymentCommand,
   SimCreateDeploymentCommandInput,
   SimCreateDeploymentCommandOutput,

--- a/src/service/apigateway/index.ts
+++ b/src/service/apigateway/index.ts
@@ -22,6 +22,25 @@ export {
 export { SimRestApiPathPart } from "./api/resource/sim-rest-api-path-part.js";
 export { SimRestApiResourceStore } from "./api/resource/sim-rest-api-resource-store.js";
 export {
+  makeSimRestApiAuthorizerId,
+  SimRestApiAuthorizer,
+  type SimRestApiAuthorizerId,
+  type SimRestApiAuthorizerType,
+  type SimRestApiAuthorizerView,
+  simRestApiCustomAuthType,
+} from "./api/authorizer/sim-rest-api-authorizer.js";
+export { SimRestApiAuthorizerStore } from "./api/authorizer/sim-rest-api-authorizer-store.js";
+export {
+  SimRestApiAdmitted,
+  type SimRestApiAuthorization,
+  SimRestApiRefused,
+  type SimRestApiRefusalKind,
+} from "./api/authorizer/sim-rest-api-authorization.js";
+export {
+  SimRestApiIdentitySource,
+  simRestApiHeaderIdentityPrefix,
+} from "./api/authorizer/sim-rest-api-identity-source.js";
+export {
   simRestApiAnyMethod,
   SimRestApiMethod,
   type SimRestApiAuthorizationType,
@@ -48,6 +67,9 @@ export {
 } from "./api/sim-rest-api-lambda-proxy.factory.js";
 export { SimApiGatewayServiceController } from "./serve/sim-api-gateway-controller.js";
 export { SimApiGatewayRouter } from "./serve/sim-api-gateway-router.js";
+export { SimRestApiMethodAuthorizer } from "./serve/auth/sim-rest-api-method-authorizer.js";
+export { SimRestApiRefusalResponse } from "./serve/sim-rest-api-refusal-response.js";
+export type { SimRestApiTokenAuthorizerEvent } from "./serve/auth/sim-rest-api-authorizer-event.js";
 export { SimRestApiIntegrationInvocation } from "./serve/sim-rest-api-integration-invocation.js";
 export { simApiGatewayServicePrincipal } from "./sim-api-gateway-service-principal.js";
 export type { SimRestApiFunctionTarget } from "./serve/sim-rest-api-function-target.js";

--- a/src/service/apigateway/sdk/sim-api-gateway-sdk-command-router.ts
+++ b/src/service/apigateway/sdk/sim-api-gateway-sdk-command-router.ts
@@ -13,6 +13,10 @@ import type {
   SimGetResourceCommand,
   SimGetResourcesCommand,
   SimDeleteResourceCommand,
+  SimCreateAuthorizerCommand,
+  SimGetAuthorizerCommand,
+  SimGetAuthorizersCommand,
+  SimDeleteAuthorizerCommand,
   SimPutMethodCommand,
   SimGetMethodCommand,
   SimDeleteMethodCommand,
@@ -107,6 +111,38 @@ export class SimApiGatewaySdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simApiGateway.deleteResource(
             command as SimDeleteResourceCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "CreateAuthorizerCommand",
+        async (command, context): Promise<unknown> =>
+          await simApiGateway.createAuthorizer(
+            command as SimCreateAuthorizerCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetAuthorizerCommand",
+        async (command, context): Promise<unknown> =>
+          await simApiGateway.getAuthorizer(
+            command as SimGetAuthorizerCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetAuthorizersCommand",
+        async (command, context): Promise<unknown> =>
+          await simApiGateway.getAuthorizers(
+            command as SimGetAuthorizersCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteAuthorizerCommand",
+        async (command, context): Promise<unknown> =>
+          await simApiGateway.deleteAuthorizer(
+            command as SimDeleteAuthorizerCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/apigateway/serve/auth/sim-rest-api-authorizer-event.ts
+++ b/src/service/apigateway/serve/auth/sim-rest-api-authorizer-event.ts
@@ -1,0 +1,28 @@
+/**
+ * The event a `TOKEN` authorizer's function is invoked with.
+ *
+ * A `TOKEN` authorizer sees three things and no more: that it is a `TOKEN`
+ * authorizer, the value the request carried at its identity source, and the
+ * ARN of the method being called. It never sees the rest of the request, which
+ * is the whole difference between this and a `REQUEST` authorizer.
+ */
+export interface SimRestApiTokenAuthorizerEvent {
+  type: "TOKEN";
+  /** The value the request carried at the authorizer's identity source. */
+  authorizationToken: string;
+  /**
+   * The `execute-api` ARN of the request being authorized. The policy the
+   * function answers with is evaluated against this same ARN.
+   */
+  methodArn: string;
+}
+
+/**
+ * Build the event a `TOKEN` authorizer is invoked with.
+ */
+export function simRestApiTokenAuthorizerEvent(
+  authorizationToken: string,
+  methodArn: string,
+): SimRestApiTokenAuthorizerEvent {
+  return { type: "TOKEN", authorizationToken, methodArn };
+}

--- a/src/service/apigateway/serve/auth/sim-rest-api-authorizer-invocation.ts
+++ b/src/service/apigateway/serve/auth/sim-rest-api-authorizer-invocation.ts
@@ -1,0 +1,71 @@
+import {
+  type SimRestApiAuthorization,
+  SimRestApiRefused,
+} from "../../api/authorizer/sim-rest-api-authorization.js";
+import type { SimRestApiAuthorizer } from "../../api/authorizer/sim-rest-api-authorizer.js";
+import type { SimRestApiLambdaUri } from "../../api/method/sim-rest-api-lambda-uri.js";
+import type { SimRestApiFunctionTarget } from "../sim-rest-api-function-target.js";
+import { simRestApiTokenAuthorizerEvent } from "./sim-rest-api-authorizer-event.js";
+import { SimRestApiAuthorizerResponse } from "./sim-rest-api-authorizer-response.js";
+import { simRestApiMayNotInvokeAuthorizer } from "./sim-rest-api-invoke-authorizer.js";
+import type { SimRestApiMethodAuthorizeInput } from "./sim-rest-api-method-authorize-input.js";
+
+/**
+ * Finds the function an authorizer names, which the serving router does.
+ */
+export interface SimRestApiAuthorizerFunctions {
+  functionFor(
+    lambdaUri: SimRestApiLambdaUri,
+  ): SimRestApiFunctionTarget | undefined;
+}
+
+interface SimRestApiAuthorizerInvocationProperties {
+  readonly functions: SimRestApiAuthorizerFunctions;
+}
+
+/**
+ * Invokes a `TOKEN` authorizer's function and reads what it answered.
+ *
+ * The API's permission to invoke that function is asked first, under an ARN
+ * naming the authorizer rather than any method. A function that is not there,
+ * one the API may not invoke, and one that failed are the same 500, as they
+ * are on real AWS. None of them is anything the caller could act on.
+ */
+export class SimRestApiAuthorizerInvocation {
+  private readonly functions: SimRestApiAuthorizerFunctions;
+
+  constructor(properties: SimRestApiAuthorizerInvocationProperties) {
+    this.functions = properties.functions;
+  }
+
+  /**
+   * Ask the authorizer's function about one request.
+   */
+  async invoke(
+    input: SimRestApiMethodAuthorizeInput,
+    authorizer: SimRestApiAuthorizer,
+    authorizationToken: string,
+    methodArn: string,
+  ): Promise<SimRestApiAuthorization> {
+    const target = this.functions.functionFor(authorizer.lambdaUri);
+
+    if (
+      target === undefined ||
+      simRestApiMayNotInvokeAuthorizer(input.restApi, authorizer, target)
+    ) {
+      return SimRestApiRefused.error();
+    }
+
+    try {
+      const result = await target.simFunction.invoke(
+        simRestApiTokenAuthorizerEvent(authorizationToken, methodArn),
+      );
+
+      return new SimRestApiAuthorizerResponse(methodArn).read(result);
+    } catch {
+      // An authorizer that failed tells the caller nothing, the way an
+      // integration that failed does not.
+      return SimRestApiRefused.error();
+    }
+  }
+}

--- a/src/service/apigateway/serve/auth/sim-rest-api-authorizer-policy.ts
+++ b/src/service/apigateway/serve/auth/sim-rest-api-authorizer-policy.ts
@@ -1,0 +1,79 @@
+import { SimIamEitherSideAllowRequirement } from "../../../iam/authorize/allow/sim-iam-allow-requirement.js";
+import { SimIamPolicyDecision } from "../../../iam/authorize/sim-iam-decision.js";
+import type { SimIamPolicyDocument } from "../../../iam/policy/sim-iam-policy.js";
+import {
+  type SimRestApiAuthorization,
+  SimRestApiRefused,
+} from "../../api/authorizer/sim-rest-api-authorization.js";
+
+/**
+ * The IAM action a request to a method is authorized against.
+ *
+ * It is the only `execute-api` action evaluated here. The others AWS defines
+ * are WebSocket management and REST API cache invalidation, and nothing
+ * constrains the action string a policy may name, so a policy is free to grant
+ * one of them and nothing will ask about it.
+ */
+export const simExecuteApiInvokeAction = "execute-api:Invoke";
+
+/**
+ * The IAM policy document a Lambda authorizer answers with, evaluated for
+ * `execute-api:Invoke` on the method ARN the request was authorized under.
+ *
+ * The document the authorizer returned is the whole decision. There are no
+ * stored policies to gather, because there is no IAM principal here at all.
+ * The `principalId` returned alongside is a name the authorizer chose for the
+ * caller, so it identifies the caller in the authorizer's own logs and grants
+ * nothing.
+ *
+ * An explicit Deny wins over an Allow, and a document allowing nothing
+ * relevant refuses the request. Real API Gateway answers the two with
+ * different bodies, so they are told apart here.
+ */
+export class SimRestApiAuthorizerPolicy {
+  private readonly document: SimIamPolicyDocument;
+
+  constructor(document: SimIamPolicyDocument) {
+    this.document = document;
+  }
+
+  /**
+   * What this document says about a request to one method, answering
+   * `undefined` where it allows the request through.
+   *
+   * Throws the way IAM does for a document it cannot read, which the caller
+   * answers with the same 500 any other unusable authorizer response gets.
+   */
+  refusal(methodArn: string): SimRestApiAuthorization | undefined {
+    const decision = new SimIamPolicyDecision({
+      // The document is evaluated as the identity side, which is the side with
+      // no Principal to state. An authorizer's policy says what the caller it
+      // just identified may do rather than who may reach the method.
+      identityPolicies: [
+        {
+          sourceType: "identity-inline",
+          document: this.document,
+          policyName: "AuthorizerPolicyDocument",
+        },
+      ],
+      resourcePolicies: [],
+      allowRequirement: new SimIamEitherSideAllowRequirement(),
+      action: simExecuteApiInvokeAction,
+      resource: methodArn,
+      conditionContext: {},
+      // There is no principal behind this document, and nothing in it can name
+      // one, so the caller is anonymous. A condition on a principal key
+      // therefore never matches, which is the strict direction to be wrong in.
+      caller: {
+        principal: { kind: "anonymous" },
+        identityPolicyPrincipal: { kind: "anonymous" },
+      },
+    });
+
+    if (decision.isExplicitDeny) {
+      return SimRestApiRefused.explicitDeny();
+    }
+
+    return decision.isAllowed ? undefined : SimRestApiRefused.implicitDeny();
+  }
+}

--- a/src/service/apigateway/serve/auth/sim-rest-api-authorizer-response.ts
+++ b/src/service/apigateway/serve/auth/sim-rest-api-authorizer-response.ts
@@ -1,0 +1,101 @@
+import type { SimPayload1LambdaAuthorizer } from "../../../../serve/payload-1/sim-payload-1-event.type.js";
+import { isRecord } from "../../../../util/type-guard/record.js";
+import type { SimIamPolicyDocument } from "../../../iam/policy/sim-iam-policy.js";
+import {
+  SimRestApiAdmitted,
+  type SimRestApiAuthorization,
+  SimRestApiRefused,
+} from "../../api/authorizer/sim-rest-api-authorization.js";
+import { SimRestApiAuthorizerPolicy } from "./sim-rest-api-authorizer-policy.js";
+
+/**
+ * The one message a Lambda authorizer answers a 401 with.
+ */
+const unauthorizedErrorMessage = "Unauthorized";
+
+/**
+ * Reads what a REST API Lambda authorizer answered.
+ *
+ * There is one shape: a `principalId` naming the caller and an IAM
+ * `policyDocument` that has to allow `execute-api:Invoke` on the method ARN. A
+ * REST API authorizer always answers a policy, where an HTTP API authorizer
+ * may answer a boolean. A response of any other shape is a 500 rather than a
+ * refusal, because API Gateway could not read it either.
+ *
+ * `{ "errorMessage": "Unauthorized" }` is the one answer that produces a 401.
+ * A function that throws is an invocation failure here rather than that value.
+ * Real Lambda turns a thrown error into a payload carrying this member, while
+ * simulated Lambda rejects with the error itself, so returning the value is
+ * the way to ask for a 401.
+ */
+export class SimRestApiAuthorizerResponse {
+  private readonly methodArn: string;
+
+  constructor(methodArn: string) {
+    this.methodArn = methodArn;
+  }
+
+  /**
+   * What the endpoint should do with the request, given what the authorizer
+   * answered.
+   */
+  read(result: unknown): SimRestApiAuthorization {
+    if (!isRecord(result)) {
+      return SimRestApiRefused.error();
+    }
+
+    if (result["errorMessage"] === unauthorizedErrorMessage) {
+      return SimRestApiRefused.unauthorized();
+    }
+
+    const policyDocument = result["policyDocument"];
+
+    if (
+      typeof result["principalId"] !== "string" ||
+      !isRecord(policyDocument)
+    ) {
+      return SimRestApiRefused.error();
+    }
+
+    return this.evaluated(policyDocument, result);
+  }
+
+  /**
+   * Put the returned document to IAM, and gather what reaches the handler
+   * where it allows the request.
+   */
+  private evaluated(
+    policyDocument: SimIamPolicyDocument,
+    result: Record<string, unknown>,
+  ): SimRestApiAuthorization {
+    try {
+      return (
+        new SimRestApiAuthorizerPolicy(policyDocument).refusal(
+          this.methodArn,
+        ) ?? new SimRestApiAdmitted({ lambda: this.authorizerContext(result) })
+      );
+    } catch {
+      // IAM refused to read the document, which is a malformed policy rather
+      // than a policy that says no.
+      return SimRestApiRefused.error();
+    }
+  }
+
+  /**
+   * The `requestContext.authorizer` block for an admitted request.
+   *
+   * A REST API flattens the authorizer's `context` alongside its
+   * `principalId`, so a handler reads `requestContext.authorizer.tenantId`
+   * where payload format 2.0 would put the context in a block of its own. A
+   * context that is not an object is left out, since a handler reading a
+   * member off it would find something else here.
+   */
+  private authorizerContext(
+    result: Record<string, unknown>,
+  ): SimPayload1LambdaAuthorizer {
+    const context = result["context"];
+    const principalId = { principalId: result["principalId"] as string };
+
+    return isRecord(context) ? { ...context, ...principalId } : principalId;
+  }
+}

--- a/src/service/apigateway/serve/auth/sim-rest-api-invoke-authorizer.ts
+++ b/src/service/apigateway/serve/auth/sim-rest-api-invoke-authorizer.ts
@@ -1,0 +1,33 @@
+import { SimLambdaServiceInvokeAuthorizer } from "../../../lambda/command/authorize/sim-lambda-service-invoke-authorizer.js";
+import type { SimRestApiAuthorizer } from "../../api/authorizer/sim-rest-api-authorizer.js";
+import { SimRestApiExecuteApiArn } from "../../api/sim-rest-api-execute-api-arn.js";
+import type { SimRestApi } from "../../api/sim-rest-api.js";
+import { simApiGatewayServicePrincipal } from "../../sim-api-gateway-service-principal.js";
+import type { SimRestApiFunctionTarget } from "../sim-rest-api-function-target.js";
+
+/**
+ * Whether the API may not invoke a function as one of its authorizers.
+ *
+ * Whether a service may invoke a function is Lambda's own rule, so the
+ * decision is made there. What this adds is the part only API Gateway knows,
+ * which is what the function is being invoked for.
+ *
+ * The source ARN names the authorizer rather than any method, so a function
+ * granted the invoke action for the API's methods is not thereby usable as its
+ * authorizer, as on real AWS.
+ */
+export function simRestApiMayNotInvokeAuthorizer(
+  restApi: SimRestApi,
+  authorizer: SimRestApiAuthorizer,
+  target: SimRestApiFunctionTarget,
+): boolean {
+  return new SimLambdaServiceInvokeAuthorizer({ iam: target.iam }).authorize({
+    resource: target.resource,
+    servicePrincipal: simApiGatewayServicePrincipal,
+    sourceArn: SimRestApiExecuteApiArn.forAuthorizer(
+      restApi,
+      authorizer.authorizerId,
+    ).toString(),
+    sourceAccount: restApi.accountRegionScope.accountId,
+  }).isDenied;
+}

--- a/src/service/apigateway/serve/auth/sim-rest-api-method-authorize-input.ts
+++ b/src/service/apigateway/serve/auth/sim-rest-api-method-authorize-input.ts
@@ -1,0 +1,15 @@
+import type { SimRestApiMatch } from "../../api/match/sim-rest-api-match.js";
+import type { SimRestApi } from "../../api/sim-rest-api.js";
+
+/**
+ * Everything a method authorization decision is made from.
+ *
+ * The whole match is carried rather than only the method, because the
+ * `methodArn` an authorizer is handed names the stage that served the request
+ * and the path it asked for, both of which the match settled.
+ */
+export interface SimRestApiMethodAuthorizeInput {
+  readonly restApi: SimRestApi;
+  readonly match: SimRestApiMatch;
+  readonly request: Request;
+}

--- a/src/service/apigateway/serve/auth/sim-rest-api-method-authorizer.ts
+++ b/src/service/apigateway/serve/auth/sim-rest-api-method-authorizer.ts
@@ -1,0 +1,95 @@
+import {
+  SimRestApiAdmitted,
+  type SimRestApiAuthorization,
+  SimRestApiRefused,
+} from "../../api/authorizer/sim-rest-api-authorization.js";
+import { SimRestApiExecuteApiArn } from "../../api/sim-rest-api-execute-api-arn.js";
+import {
+  type SimRestApiAuthorizerFunctions,
+  SimRestApiAuthorizerInvocation,
+} from "./sim-rest-api-authorizer-invocation.js";
+import type { SimRestApiMethodAuthorizeInput } from "./sim-rest-api-method-authorize-input.js";
+
+interface SimRestApiMethodAuthorizerProperties {
+  /**
+   * Where an authorizer's function is found, which is the same router that
+   * finds an integration's.
+   */
+  readonly functions: SimRestApiAuthorizerFunctions;
+}
+
+/**
+ * Decides whether one request may have the method that matched it.
+ *
+ * This is the client's side of the question, and it runs before the API asks
+ * whether it may invoke the integration. A request presenting no credentials
+ * is refused whether or not the integration behind the method would have
+ * worked.
+ *
+ * The steps for a `CUSTOM` method are the ones real API Gateway takes:
+ *
+ * 1. the request has to carry something at the authorizer's identity source,
+ *    or it is refused with a 401 and the function is never invoked;
+ * 2. otherwise the function is asked, and the policy it answers with is
+ *    evaluated against the ARN of the request being made.
+ */
+export class SimRestApiMethodAuthorizer {
+  private readonly invocation: SimRestApiAuthorizerInvocation;
+
+  constructor(properties: SimRestApiMethodAuthorizerProperties) {
+    this.invocation = new SimRestApiAuthorizerInvocation({
+      functions: properties.functions,
+    });
+  }
+
+  /**
+   * Authorize one request against the method that matched it.
+   */
+  async authorize(
+    input: SimRestApiMethodAuthorizeInput,
+  ): Promise<SimRestApiAuthorization> {
+    if (input.match.method.authorizationType === "NONE") {
+      // Nobody was authorized, so there is no caller to describe, which is
+      // what leaves requestContext.authorizer out of the event entirely.
+      return new SimRestApiAdmitted();
+    }
+
+    return await this.custom(input);
+  }
+
+  /**
+   * Authorize one request against the `CUSTOM` method that matched it.
+   */
+  private async custom(
+    input: SimRestApiMethodAuthorizeInput,
+  ): Promise<SimRestApiAuthorization> {
+    const { restApi, match, request } = input;
+    const authorizer = restApi.authorizers.find(
+      match.method.authorizerId ?? "",
+    );
+
+    // A CUSTOM method always names an authorizer, and that authorizer can
+    // still be deleted out from under it, so the two come to the same thing
+    // here: with nothing to ask, the method stays closed.
+    if (authorizer === undefined) {
+      return SimRestApiRefused.unauthorized();
+    }
+
+    const authorizationToken = authorizer.identitySource.value(request);
+
+    if (authorizationToken === undefined) {
+      return SimRestApiRefused.unauthorized();
+    }
+
+    return await this.invocation.invoke(
+      input,
+      authorizer,
+      authorizationToken,
+      SimRestApiExecuteApiArn.forRequest(
+        restApi,
+        match,
+        request.method,
+      ).toString(),
+    );
+  }
+}

--- a/src/service/apigateway/serve/sim-api-gateway-controller.ts
+++ b/src/service/apigateway/serve/sim-api-gateway-controller.ts
@@ -9,9 +9,11 @@ import {
 } from "../api/match/sim-rest-api-match.js";
 import { SimRestApiRequest } from "../api/match/sim-rest-api-request.js";
 import type { SimRestApi } from "../api/sim-rest-api.js";
+import { SimRestApiMethodAuthorizer } from "./auth/sim-rest-api-method-authorizer.js";
 import { SimApiGatewayErrorResponse } from "./sim-api-gateway-error-response.js";
 import { SimApiGatewayRouter } from "./sim-api-gateway-router.js";
 import { SimRestApiIntegrationInvocation } from "./sim-rest-api-integration-invocation.js";
+import { SimRestApiRefusalResponse } from "./sim-rest-api-refusal-response.js";
 
 interface SimApiGatewayServiceControllerProperties {
   readonly simAws?: SimAws;
@@ -26,18 +28,24 @@ interface SimApiGatewayServiceControllerProperties {
  * simulated Lambda function with a payload format 1.0 event. The function runs
  * as its execution Role, as it does for any other invocation.
  *
- * Authorizing a method is a separate piece of work. Every method served here
- * is open, and a method declaring an authorizer is refused when it is created
- * rather than served without one.
+ * A method that authorizes anybody is checked before any of that. Its
+ * authorizer's Lambda function has to allow the request, or the request is
+ * refused and the integration is never invoked. Whether the API may invoke a
+ * function is a separate question, and the API's own rather than the client's.
  */
 export class SimApiGatewayServiceController implements SimAwsServiceController {
   private readonly router: SimApiGatewayRouter;
+  private readonly methodAuthorizer: SimRestApiMethodAuthorizer;
   private readonly integration: SimRestApiIntegrationInvocation;
   private readonly errorResponse = new SimApiGatewayErrorResponse();
+  private readonly refusalResponse = new SimRestApiRefusalResponse();
 
   constructor(properties: SimApiGatewayServiceControllerProperties = {}) {
     const { simAws = new SimAws() } = properties;
     this.router = properties.router ?? new SimApiGatewayRouter({ simAws });
+    this.methodAuthorizer = new SimRestApiMethodAuthorizer({
+      functions: this.router,
+    });
     // The clock is taken from the router rather than from properties, so a
     // supplied router and the event timestamps belong to the same simulation.
     this.integration = new SimRestApiIntegrationInvocation({
@@ -83,7 +91,25 @@ export class SimApiGatewayServiceController implements SimAwsServiceController {
       return this.missResponse(match);
     }
 
-    return await this.integration.invoke({ restApi, match, request });
+    // The client's own authorization comes first: a request with no
+    // credentials is refused whether or not the integration behind the method
+    // would work.
+    const authorization = await this.methodAuthorizer.authorize({
+      restApi,
+      match,
+      request,
+    });
+
+    if (!authorization.admitted) {
+      return this.refusalResponse.build(authorization);
+    }
+
+    return await this.integration.invoke({
+      restApi,
+      match,
+      request,
+      authorization,
+    });
   }
 
   /**

--- a/src/service/apigateway/serve/sim-api-gateway-error-response.ts
+++ b/src/service/apigateway/serve/sim-api-gateway-error-response.ts
@@ -27,6 +27,45 @@ export class SimApiGatewayErrorResponse {
   }
 
   /**
+   * The request carried nothing at the authorizer's identity source, or the
+   * authorizer answered `Unauthorized`.
+   */
+  unauthorized(): Response {
+    return this.jsonResponse(401, "Unauthorized");
+  }
+
+  /**
+   * A Deny statement in the authorizer's policy matched the method.
+   *
+   * The body names the deny, and its member is `Message` where every other
+   * message here is `message`. Real API Gateway is inconsistent about the two
+   * and this follows it.
+   */
+  explicitDeny(): Response {
+    return this.messageResponse(
+      403,
+      "User is not authorized to access this resource with an explicit deny",
+    );
+  }
+
+  /**
+   * The authorizer's policy allowed nothing covering the method.
+   */
+  implicitDeny(): Response {
+    return this.messageResponse(
+      403,
+      "User is not authorized to access this resource",
+    );
+  }
+
+  /**
+   * The method's authorizer could not answer at all.
+   */
+  internalServerError(): Response {
+    return this.jsonResponse(500, "Internal server error");
+  }
+
+  /**
    * The integration could not be reached, or answered something that is not a
    * response.
    */
@@ -37,6 +76,13 @@ export class SimApiGatewayErrorResponse {
   private jsonResponse(status: number, message: string): Response {
     return Response.json(
       { message },
+      { status, headers: { "content-type": "application/json" } },
+    );
+  }
+
+  private messageResponse(status: number, message: string): Response {
+    return Response.json(
+      { Message: message },
       { status, headers: { "content-type": "application/json" } },
     );
   }

--- a/src/service/apigateway/serve/sim-rest-api-integration-invocation.ts
+++ b/src/service/apigateway/serve/sim-rest-api-integration-invocation.ts
@@ -2,6 +2,7 @@ import { SimPayload1EventBuilder } from "../../../serve/payload-1/sim-payload-1-
 import { SimPayload1ResponseBuilder } from "../../../serve/payload-1/sim-payload-1-response-builder.js";
 import type { SimClock } from "../../../util/clock/sim-clock.js";
 import { SimLambdaServiceInvokeAuthorizer } from "../../lambda/command/authorize/sim-lambda-service-invoke-authorizer.js";
+import type { SimRestApiAdmitted } from "../api/authorizer/sim-rest-api-authorization.js";
 import type { SimRestApiMatch } from "../api/match/sim-rest-api-match.js";
 import { SimRestApiExecuteApiArn } from "../api/sim-rest-api-execute-api-arn.js";
 import type { SimRestApi } from "../api/sim-rest-api.js";
@@ -21,11 +22,17 @@ interface SimRestApiIntegrationInvocationInput {
   readonly restApi: SimRestApi;
   readonly match: SimRestApiMatch;
   readonly request: Request;
+  /** What the method's authorization knows about the caller. */
+  readonly authorization: SimRestApiAdmitted;
 }
 
 /**
  * Invokes the Lambda function behind the matched method's integration, and
  * turns what it returns into the HTTP response.
+ *
+ * Whether the API may invoke the function is asked here, and is the API's own
+ * question rather than the client's. The client's was already answered by the
+ * method's authorization.
  *
  * A method with no integration, one naming a function that is not there, one
  * the API may not invoke, and one whose handler threw are all the same 502 on
@@ -59,6 +66,7 @@ export class SimRestApiIntegrationInvocation {
       const event = await this.eventBuilder.build(
         input.request,
         simRestApiEndpoint(input.restApi, input.match),
+        { lambda: input.authorization.lambda },
       );
       const result = await target.simFunction.invoke(event);
 

--- a/src/service/apigateway/serve/sim-rest-api-refusal-response.ts
+++ b/src/service/apigateway/serve/sim-rest-api-refusal-response.ts
@@ -1,0 +1,35 @@
+import type { SimRestApiRefused } from "../api/authorizer/sim-rest-api-authorization.js";
+import { SimApiGatewayErrorResponse } from "./sim-api-gateway-error-response.js";
+
+/**
+ * The response a request the method's authorization refused gets back.
+ *
+ * Real API Gateway answers a deny with two different bodies, one for a Deny
+ * statement that matched and one for a policy allowing nothing relevant, so
+ * both are here. An authorizer that could not answer is the API's problem
+ * rather than the caller's, and gets the same 500 it does on AWS. A request
+ * carrying no token is the one 401.
+ */
+export class SimRestApiRefusalResponse {
+  private readonly errorResponse = new SimApiGatewayErrorResponse();
+
+  /**
+   * Build the response for one refusal.
+   */
+  build(refused: SimRestApiRefused): Response {
+    switch (refused.kind) {
+      case "unauthorized": {
+        return this.errorResponse.unauthorized();
+      }
+      case "explicit-deny": {
+        return this.errorResponse.explicitDeny();
+      }
+      case "implicit-deny": {
+        return this.errorResponse.implicitDeny();
+      }
+      case "error": {
+        return this.errorResponse.internalServerError();
+      }
+    }
+  }
+}

--- a/src/service/apigateway/serve/sim-rest-api-token-authorizer.iso.test.ts
+++ b/src/service/apigateway/serve/sim-rest-api-token-authorizer.iso.test.ts
@@ -1,0 +1,330 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import type { SimPayload1Event } from "../../../serve/payload-1/sim-payload-1-event.type.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simRestApiLambdaProxyFactory } from "../api/sim-rest-api-lambda-proxy.factory.js";
+import type { SimRestApi } from "../api/sim-rest-api.js";
+import type { SimRestApiTokenAuthorizerEvent } from "./auth/sim-rest-api-authorizer-event.js";
+
+function localUrl(restApi: SimRestApi, path = "", stage = "prod"): string {
+  return new SimAwsLocalUrl({
+    input: `${restApi.invokeUrl(stage)}${path}`,
+  }).toString();
+}
+
+/**
+ * A handler echoing the event back, for tests about what reaches it.
+ */
+const echoHandler = (event: SimPayload1Event): unknown => ({
+  statusCode: 200,
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify(event),
+});
+
+/**
+ * A policy allowing or refusing one resource, as an authorizer answers with.
+ */
+function policy(effect: "Allow" | "Deny", resource: string): unknown {
+  return {
+    principalId: "user-6",
+    policyDocument: {
+      Version: "2012-10-17",
+      Statement: [
+        { Action: "execute-api:Invoke", Effect: effect, Resource: resource },
+      ],
+    },
+  };
+}
+
+/**
+ * An authorizer allowing exactly the method it was asked about.
+ */
+const allowingAuthorizer = (event: SimRestApiTokenAuthorizerEvent): unknown =>
+  policy("Allow", event.methodArn);
+
+describe("Authorizing a sim REST API method with a TOKEN authorizer", () => {
+  it("invokes the authorizer with the token and the method ARN", async () => {
+    // Given an API whose authorizer echoes the event it was invoked with back
+    // through its policy
+    const simAws = new SimAws();
+    const seen: SimRestApiTokenAuthorizerEvent[] = [];
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      {
+        resourcePaths: ["/orders/{orderId}"],
+        authorizerHandler: (event) => {
+          seen.push(event);
+          return policy("Allow", event.methodArn);
+        },
+      },
+      simAws,
+    );
+
+    // When one order is requested with a token
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/orders/6"),
+      { headers: { authorization: "Bearer session-6" } },
+    );
+
+    // Then the authorizer saw the header value and the ARN of the request,
+    // which names the path that was asked for rather than the template
+    assertIdentical(response.status, 200);
+    const [event] = seen;
+    assertNonNullable(event);
+    assertIdentical(event.type, "TOKEN");
+    assertIdentical(event.authorizationToken, "Bearer session-6");
+    assertIdentical(
+      event.methodArn,
+      `arn:aws:execute-api:${simAws.accountRegionScope().accountRegionScope.regionName}:` +
+        `${simAws.accountRegionScope().accountRegionScope.accountId}:` +
+        `${restApi.apiId}/prod/GET/orders/6`,
+    );
+  });
+
+  it("answers 403 for a Deny policy", async () => {
+    // Given an authorizer refusing the method it is asked about
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      {
+        authorizerHandler: (event) => policy("Deny", event.methodArn),
+      },
+      simAws,
+    );
+
+    // When the API is requested with a token
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/orders"),
+      { headers: { authorization: "Bearer session-6" } },
+    );
+
+    // Then the request is refused with the body real API Gateway sends for a
+    // Deny statement that matched
+    assertIdentical(response.status, 403);
+    expect(await response.json()).toStrictEqual({
+      Message:
+        "User is not authorized to access this resource with an explicit deny",
+    });
+  });
+
+  it("leaves a method the policy does not cover unauthorized", async () => {
+    // Given an authorizer that always allows one path and nothing else
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      {
+        resourcePaths: ["/orders", "/invoices"],
+        httpMethod: "GET",
+        authorizerHandler: (event) =>
+          policy("Allow", event.methodArn.replace(/\/[^/]+$/u, "/orders")),
+      },
+      simAws,
+    );
+    const http = new SimAwsHttp({ simAws });
+    const headers = { authorization: "Bearer session-6" };
+
+    // When each path is requested with the same token
+    const allowed = await http.fetch(localUrl(restApi, "/orders"), { headers });
+    const refused = await http.fetch(localUrl(restApi, "/invoices"), {
+      headers,
+    });
+
+    // Then the one the policy names is served and the other is not, because
+    // the document is evaluated against the ARN of the request being made
+    assertIdentical(allowed.status, 200);
+    assertIdentical(refused.status, 403);
+    expect(await refused.json()).toStrictEqual({
+      Message: "User is not authorized to access this resource",
+    });
+  });
+
+  it("hands the authorizer's context to the handler", async () => {
+    // Given an authorizer passing something on about the caller
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      {
+        handler: echoHandler,
+        authorizerHandler: (event) => ({
+          ...(policy("Allow", event.methodArn) as object),
+          context: { tenantId: "acme", tier: "gold" },
+        }),
+      },
+      simAws,
+    );
+
+    // When the API is requested with a token
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/orders"),
+      { headers: { authorization: "Bearer session-6" } },
+    );
+    const event = (await response.json()) as SimPayload1Event;
+
+    // Then the handler reads it beside the principal the authorizer named, all
+    // flattened onto requestContext.authorizer as a REST API sends it
+    expect(event.requestContext.authorizer).toStrictEqual({
+      principalId: "user-6",
+      tenantId: "acme",
+      tier: "gold",
+    });
+  });
+
+  it("leaves the authorizer block out for an open method", async () => {
+    // Given an API with no authorizer in front of it
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      { handler: echoHandler },
+      simAws,
+    );
+
+    // When the API is requested
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/orders"),
+    );
+    const event = (await response.json()) as SimPayload1Event;
+
+    // Then there is no caller to describe, which is what real API Gateway
+    // sends for a method authorizing nobody
+    assertUndefined(event.requestContext.authorizer);
+  });
+
+  it("answers 401 for a request carrying no token", async () => {
+    // Given a gated API
+    const simAws = new SimAws();
+    let invocations = 0;
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      {
+        authorizerHandler: (event) => {
+          invocations += 1;
+          return policy("Allow", event.methodArn);
+        },
+      },
+      simAws,
+    );
+
+    // When it is requested with no Authorization header
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/orders"),
+    );
+
+    // Then it is refused before the authorizer is asked anything
+    assertIdentical(response.status, 401);
+    assertIdentical(invocations, 0);
+    expect(await response.json()).toStrictEqual({ message: "Unauthorized" });
+  });
+
+  it("answers 401 for the Unauthorized the authorizer returns", async () => {
+    // Given an authorizer that refuses the token it was given
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      { authorizerHandler: () => ({ errorMessage: "Unauthorized" }) },
+      simAws,
+    );
+
+    // When the API is requested with a token
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/orders"),
+      { headers: { authorization: "Bearer session-6" } },
+    );
+
+    // Then the caller is told its token was rejected, as it is on real AWS
+    assertIdentical(response.status, 401);
+  });
+
+  it("answers 500 for an authorizer the API may not invoke", async () => {
+    // Given an authorizer whose function granted the API nothing
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      {
+        authorizerHandler: allowingAuthorizer,
+        authorizerInvokePermission: false,
+      },
+      simAws,
+    );
+
+    // When the API is requested with a token
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/orders"),
+      { headers: { authorization: "Bearer session-6" } },
+    );
+
+    // Then the API's own problem is a 500 rather than something the caller
+    // could act on. The permission for the integration does not cover the
+    // authorizer, because the two are granted on different ARNs.
+    assertIdentical(response.status, 500);
+    expect(await response.json()).toStrictEqual({
+      message: "Internal server error",
+    });
+  });
+
+  it("answers 500 for an authorizer that failed", async () => {
+    // Given an authorizer whose function throws
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      {
+        authorizerHandler: (): unknown => {
+          throw new Error("token service unreachable");
+        },
+      },
+      simAws,
+    );
+
+    // When the API is requested with a token
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/orders"),
+      { headers: { authorization: "Bearer session-6" } },
+    );
+
+    // Then the caller learns nothing about it, the way an integration failure
+    // tells it nothing
+    assertIdentical(response.status, 500);
+  });
+
+  it("answers 500 for a response API Gateway could not read", async () => {
+    // Given an authorizer answering a shape that is not a policy
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      { authorizerHandler: () => ({ isAuthorized: true }) },
+      simAws,
+    );
+
+    // When the API is requested with a token
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/orders"),
+      { headers: { authorization: "Bearer session-6" } },
+    );
+
+    // Then it is a 500, because a REST API authorizer always answers a policy
+    // where an HTTP API one may answer a boolean
+    assertIdentical(response.status, 500);
+  });
+
+  it("closes a method whose authorizer was deleted", async () => {
+    // Given a gated API whose authorizer is then removed
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      { authorizerHandler: allowingAuthorizer },
+      simAws,
+    );
+    const [authorizer] = restApi.authorizers.list();
+    await simAws.apiGateway().deleteAuthorizer({
+      input: {
+        restApiId: restApi.apiId,
+        authorizerId: authorizer?.authorizerId,
+      },
+    });
+
+    // When the API is requested with a token
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/orders"),
+      { headers: { authorization: "Bearer session-6" } },
+    );
+
+    // Then the method stays closed, since there is nothing left to send the
+    // request through
+    assertIdentical(response.status, 401);
+  });
+});

--- a/src/service/apigateway/sim-api-gateway-commands.ts
+++ b/src/service/apigateway/sim-api-gateway-commands.ts
@@ -11,6 +11,7 @@ import {
 import { SimRestApiStore } from "./api/sim-rest-api-store.js";
 import { SimRestApiCommands } from "./command/api/sim-rest-api-commands.js";
 import { SimApiGatewayAuthorizer } from "./command/authorize/sim-api-gateway-authorizer.js";
+import { SimRestApiAuthorizerCommands } from "./command/authorizer/sim-rest-api-authorizer-commands.js";
 import { SimRestApiDeploymentCommands } from "./command/deployment/sim-rest-api-deployment-commands.js";
 import { SimRestApiIntegrationCommands } from "./command/integration/sim-rest-api-integration-commands.js";
 import { SimRestApiMethodCommands } from "./command/method/sim-rest-api-method-commands.js";
@@ -41,6 +42,7 @@ export class SimApiGatewayCommands {
   public readonly apis = new SimRestApiStore();
   public readonly api: SimRestApiCommands;
   public readonly resources: SimRestApiResourceCommands;
+  public readonly authorizers: SimRestApiAuthorizerCommands;
   public readonly methods: SimRestApiMethodCommands;
   public readonly integrations: SimRestApiIntegrationCommands;
   public readonly deployments: SimRestApiDeploymentCommands;
@@ -69,6 +71,7 @@ export class SimApiGatewayCommands {
       clock: background,
     });
     this.resources = new SimRestApiResourceCommands({ access });
+    this.authorizers = new SimRestApiAuthorizerCommands({ access });
     this.methods = new SimRestApiMethodCommands({ access });
     this.integrations = new SimRestApiIntegrationCommands({ access });
     this.deployments = new SimRestApiDeploymentCommands({

--- a/src/service/apigateway/sim-api-gateway.ts
+++ b/src/service/apigateway/sim-api-gateway.ts
@@ -8,6 +8,7 @@ import {
   SimApiGatewayCommands,
   type SimApiGatewayProperties,
 } from "./sim-api-gateway-commands.js";
+import { SimRestApiParts } from "./sim-rest-api-parts.js";
 
 /**
  * Simulated API Gateway. Handles SDK commands. Emulates AWS behaviour and
@@ -24,15 +25,14 @@ import {
  * methods, because every one of them is addressed by `restApiId` on real AWS
  * and none of them outlives the API.
  */
-export class SimApiGateway {
-  private readonly commands: SimApiGatewayCommands;
+export class SimApiGateway extends SimRestApiParts {
   private readonly sdkRouter = new SimApiGatewaySdkCommandRouter(this);
   private readonly cfnFactory = new SimApiGatewayCfnResourceFactory({
     apiGateway: this,
   });
 
   constructor(properties: SimApiGatewayProperties = {}) {
-    this.commands = new SimApiGatewayCommands(properties);
+    super(new SimApiGatewayCommands(properties));
   }
 
   /**
@@ -98,105 +98,6 @@ export class SimApiGateway {
   ): Promise<simApiGatewayCommands.SimDeleteRestApiCommandOutput> {
     await this.commands.background.sequence();
     return this.commands.api.deleteRestApi(command, options);
-  }
-
-  /**
-   * Handle a CreateResource Command from the SDK.
-   */
-  async createResource(
-    command: simApiGatewayCommands.SimCreateResourceCommand,
-    options?: SimApiGatewayRequestOptions,
-  ): Promise<simApiGatewayCommands.SimCreateResourceCommandOutput> {
-    await this.commands.background.sequence();
-    return this.commands.resources.createResource(command, options);
-  }
-
-  /**
-   * Handle a GetResource Command from the SDK.
-   */
-  async getResource(
-    command: simApiGatewayCommands.SimGetResourceCommand,
-    options?: SimApiGatewayRequestOptions,
-  ): Promise<simApiGatewayCommands.SimGetResourceCommandOutput> {
-    await this.commands.background.sequence();
-    return this.commands.resources.getResource(command, options);
-  }
-
-  /**
-   * Handle a GetResources Command from the SDK.
-   */
-  async getResources(
-    command: simApiGatewayCommands.SimGetResourcesCommand,
-    options?: SimApiGatewayRequestOptions,
-  ): Promise<simApiGatewayCommands.SimGetResourcesCommandOutput> {
-    await this.commands.background.sequence();
-    return this.commands.resources.getResources(command, options);
-  }
-
-  /**
-   * Handle a DeleteResource Command from the SDK.
-   */
-  async deleteResource(
-    command: simApiGatewayCommands.SimDeleteResourceCommand,
-    options?: SimApiGatewayRequestOptions,
-  ): Promise<simApiGatewayCommands.SimDeleteResourceCommandOutput> {
-    await this.commands.background.sequence();
-    return this.commands.resources.deleteResource(command, options);
-  }
-
-  /**
-   * Handle a PutMethod Command from the SDK.
-   */
-  async putMethod(
-    command: simApiGatewayCommands.SimPutMethodCommand,
-    options?: SimApiGatewayRequestOptions,
-  ): Promise<simApiGatewayCommands.SimPutMethodCommandOutput> {
-    await this.commands.background.sequence();
-    return this.commands.methods.putMethod(command, options);
-  }
-
-  /**
-   * Handle a GetMethod Command from the SDK.
-   */
-  async getMethod(
-    command: simApiGatewayCommands.SimGetMethodCommand,
-    options?: SimApiGatewayRequestOptions,
-  ): Promise<simApiGatewayCommands.SimGetMethodCommandOutput> {
-    await this.commands.background.sequence();
-    return this.commands.methods.getMethod(command, options);
-  }
-
-  /**
-   * Handle a DeleteMethod Command from the SDK.
-   */
-  async deleteMethod(
-    command: simApiGatewayCommands.SimDeleteMethodCommand,
-    options?: SimApiGatewayRequestOptions,
-  ): Promise<simApiGatewayCommands.SimDeleteMethodCommandOutput> {
-    await this.commands.background.sequence();
-    return this.commands.methods.deleteMethod(command, options);
-  }
-
-  /**
-   * Handle a PutIntegration Command from the SDK.
-   */
-  async putIntegration(
-    command: simApiGatewayCommands.SimPutIntegrationCommand,
-    options?: SimApiGatewayRequestOptions,
-  ): Promise<simApiGatewayCommands.SimPutIntegrationCommandOutput> {
-    await this.commands.background.sequence();
-    return this.commands.integrations.putIntegration(command, options);
-  }
-
-  /**
-   * Handle a GetIntegration Command from the SDK.
-   */
-  async getIntegration(
-    command: simApiGatewayCommands.SimGetIntegrationCommand,
-    options?: SimApiGatewayRequestOptions,
-  ): Promise<simApiGatewayCommands.SimGetIntegrationCommandOutput> {
-    await this.commands.background.sequence();
-    return this.commands.integrations.getIntegration(command, options);
   }
 
   /**

--- a/src/service/apigateway/sim-rest-api-parts.ts
+++ b/src/service/apigateway/sim-rest-api-parts.ts
@@ -1,0 +1,163 @@
+import type * as simApiGatewayCommands from "./command/sim-api-gateway-command.types.js";
+import type { SimApiGatewayRequestOptions } from "./command/sim-api-gateway-request-options.js";
+import type { SimApiGatewayCommands } from "./sim-api-gateway-commands.js";
+
+/**
+ * The commands addressing what a REST API holds: its path tree, its
+ * authorizers, and the methods and integrations declared on its resources.
+ *
+ * `SimApiGateway` extends this, so a caller reaches every operation on the one
+ * service object the way the real API presents them. They are split up because
+ * the API itself, the parts declared on it and publishing it are separate
+ * concerns, and each is long enough to read on its own.
+ */
+export abstract class SimRestApiParts {
+  protected readonly commands: SimApiGatewayCommands;
+
+  protected constructor(commands: SimApiGatewayCommands) {
+    this.commands = commands;
+  }
+
+  /**
+   * Handle a CreateResource Command from the SDK.
+   */
+  async createResource(
+    command: simApiGatewayCommands.SimCreateResourceCommand,
+    options?: SimApiGatewayRequestOptions,
+  ): Promise<simApiGatewayCommands.SimCreateResourceCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.resources.createResource(command, options);
+  }
+
+  /**
+   * Handle a GetResource Command from the SDK.
+   */
+  async getResource(
+    command: simApiGatewayCommands.SimGetResourceCommand,
+    options?: SimApiGatewayRequestOptions,
+  ): Promise<simApiGatewayCommands.SimGetResourceCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.resources.getResource(command, options);
+  }
+
+  /**
+   * Handle a GetResources Command from the SDK.
+   */
+  async getResources(
+    command: simApiGatewayCommands.SimGetResourcesCommand,
+    options?: SimApiGatewayRequestOptions,
+  ): Promise<simApiGatewayCommands.SimGetResourcesCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.resources.getResources(command, options);
+  }
+
+  /**
+   * Handle a DeleteResource Command from the SDK.
+   */
+  async deleteResource(
+    command: simApiGatewayCommands.SimDeleteResourceCommand,
+    options?: SimApiGatewayRequestOptions,
+  ): Promise<simApiGatewayCommands.SimDeleteResourceCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.resources.deleteResource(command, options);
+  }
+
+  /**
+   * Handle a CreateAuthorizer Command from the SDK.
+   */
+  async createAuthorizer(
+    command: simApiGatewayCommands.SimCreateAuthorizerCommand,
+    options?: SimApiGatewayRequestOptions,
+  ): Promise<simApiGatewayCommands.SimCreateAuthorizerCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.authorizers.createAuthorizer(command, options);
+  }
+
+  /**
+   * Handle a GetAuthorizer Command from the SDK.
+   */
+  async getAuthorizer(
+    command: simApiGatewayCommands.SimGetAuthorizerCommand,
+    options?: SimApiGatewayRequestOptions,
+  ): Promise<simApiGatewayCommands.SimGetAuthorizerCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.authorizers.getAuthorizer(command, options);
+  }
+
+  /**
+   * Handle a GetAuthorizers Command from the SDK.
+   */
+  async getAuthorizers(
+    command: simApiGatewayCommands.SimGetAuthorizersCommand,
+    options?: SimApiGatewayRequestOptions,
+  ): Promise<simApiGatewayCommands.SimGetAuthorizersCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.authorizers.getAuthorizers(command, options);
+  }
+
+  /**
+   * Handle a DeleteAuthorizer Command from the SDK.
+   */
+  async deleteAuthorizer(
+    command: simApiGatewayCommands.SimDeleteAuthorizerCommand,
+    options?: SimApiGatewayRequestOptions,
+  ): Promise<simApiGatewayCommands.SimDeleteAuthorizerCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.authorizers.deleteAuthorizer(command, options);
+  }
+
+  /**
+   * Handle a PutMethod Command from the SDK.
+   */
+  async putMethod(
+    command: simApiGatewayCommands.SimPutMethodCommand,
+    options?: SimApiGatewayRequestOptions,
+  ): Promise<simApiGatewayCommands.SimPutMethodCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.methods.putMethod(command, options);
+  }
+
+  /**
+   * Handle a GetMethod Command from the SDK.
+   */
+  async getMethod(
+    command: simApiGatewayCommands.SimGetMethodCommand,
+    options?: SimApiGatewayRequestOptions,
+  ): Promise<simApiGatewayCommands.SimGetMethodCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.methods.getMethod(command, options);
+  }
+
+  /**
+   * Handle a DeleteMethod Command from the SDK.
+   */
+  async deleteMethod(
+    command: simApiGatewayCommands.SimDeleteMethodCommand,
+    options?: SimApiGatewayRequestOptions,
+  ): Promise<simApiGatewayCommands.SimDeleteMethodCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.methods.deleteMethod(command, options);
+  }
+
+  /**
+   * Handle a PutIntegration Command from the SDK.
+   */
+  async putIntegration(
+    command: simApiGatewayCommands.SimPutIntegrationCommand,
+    options?: SimApiGatewayRequestOptions,
+  ): Promise<simApiGatewayCommands.SimPutIntegrationCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.integrations.putIntegration(command, options);
+  }
+
+  /**
+   * Handle a GetIntegration Command from the SDK.
+   */
+  async getIntegration(
+    command: simApiGatewayCommands.SimGetIntegrationCommand,
+    options?: SimApiGatewayRequestOptions,
+  ): Promise<simApiGatewayCommands.SimGetIntegrationCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.integrations.getIntegration(command, options);
+  }
+}

--- a/src/service/cloudformation/cdk/apigateway/sim-cdk-rest-api-token-authorizer.loc.test.ts
+++ b/src/service/cloudformation/cdk/apigateway/sim-cdk-rest-api-token-authorizer.loc.test.ts
@@ -1,0 +1,154 @@
+import { assertIdentical, assertTypeString } from "@kensio/smartass";
+import path from "node:path";
+import { describe, it } from "vitest";
+
+/**
+ * Slower local integration test. Calls the real CDK CLI to synth the output
+ * template file, then serves the deployed REST API over real localhost HTTP
+ * and calls it through the authorizer the stack deployed.
+ */
+import { serveSimAws } from "../../../../serve/index.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { TemporaryDirectory } from "../../../../util/filesystem/temporary-directory.js";
+import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+
+/**
+ * The authorizer function, which admits one token and passes a tenant on.
+ *
+ * It answers the policy every REST API authorizer answers, allowing exactly
+ * the method it was asked about.
+ */
+const authorizerSource = `
+exports.handler = async (event) => {
+  if (event.authorizationToken !== "Bearer valid") {
+    return { errorMessage: "Unauthorized" };
+  }
+
+  return {
+    principalId: "user-6",
+    context: { tenant: "acme" },
+    policyDocument: {
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Action: "execute-api:Invoke",
+          Effect: "Allow",
+          Resource: event.methodArn,
+        },
+      ],
+    },
+  };
+};
+`;
+
+/**
+ * The method's own handler, reporting what the authorizer passed on to it.
+ */
+const ordersHandlerSource = `
+exports.handler = async (event) => ({
+  statusCode: 200,
+  headers: { "content-type": "text/plain" },
+  body: event.requestContext.authorizer.principalId
+    + " " + event.requestContext.authorizer.tenant,
+});
+`;
+
+/**
+ * `resultsCacheTtl` is zero because holding a decision is a separate piece of
+ * work, and CDK defaults a TokenAuthorizer to five minutes.
+ */
+const cdkApp = `
+import * as cdk from "aws-cdk-lib/core";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as apigw from "aws-cdk-lib/aws-apigateway";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "111111111111", region: "eu-west-2" },
+});
+
+const authorizerFunction = new lambda.Function(stack, "AuthorizerFunction", {
+  functionName: "cdk-session-authorizer",
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: lambda.Code.fromInline(${JSON.stringify(authorizerSource)}),
+});
+
+const ordersFunction = new lambda.Function(stack, "OrdersFunction", {
+  functionName: "cdk-orders",
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: lambda.Code.fromInline(${JSON.stringify(ordersHandlerSource)}),
+});
+
+const api = new apigw.RestApi(stack, "OrdersApi", { restApiName: "orders" });
+
+const authorizer = new apigw.TokenAuthorizer(stack, "SessionAuthorizer", {
+  handler: authorizerFunction,
+  identitySource: apigw.IdentitySource.header("Authorization"),
+  resultsCacheTtl: cdk.Duration.seconds(0),
+});
+
+api.root
+  .addResource("orders")
+  .addMethod("GET", new apigw.LambdaIntegration(ordersFunction), {
+    authorizer,
+  });
+
+new cdk.CfnOutput(stack, "ApiUrl", { value: api.url });
+
+app.synth();
+`;
+
+describe("Sim CDK REST API TOKEN authorizer local integration", () => {
+  it("gates a CDK-deployed method with a CDK-deployed authorizer", async () => {
+    // Given a CDK stack whose one method goes through a TokenAuthorizer
+    const simAws = new SimAws({
+      defaultAccountId: "111111111111",
+      defaultRegionName: "eu-west-2",
+    });
+    const projectDirectory = new TemporaryDirectory();
+    const cdkProject = new TestCdkProject({ projectDirectory });
+    await cdkProject.writeCdkAppFile(cdkApp);
+
+    // And we synth the CDK template.
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When we deploy the template into sim CloudFormation.
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+    await simAws.backgroundTasksComplete();
+
+    const apiUrl = stack.outputs.get("ApiUrl")?.value;
+    assertTypeString(apiUrl);
+
+    const srv = await serveSimAws({ simAws });
+
+    try {
+      const url = srv.localUrl(`${apiUrl}orders`);
+
+      // Then a request carrying the token the authorizer admits reaches the
+      // handler, with the context the authorizer passed on
+      const admitted = await fetch(url, {
+        headers: { authorization: "Bearer valid" },
+      });
+      assertIdentical(admitted.status, 200);
+      assertIdentical(await admitted.text(), "user-6 acme");
+
+      // And one carrying a token it refuses gets a 401
+      const refused = await fetch(url, {
+        headers: { authorization: "Bearer stale" },
+      });
+      assertIdentical(refused.status, 401);
+
+      // And one carrying nothing never reaches the authorizer at all
+      const anonymous = await fetch(url);
+      assertIdentical(anonymous.status, 401);
+    } finally {
+      await srv.close();
+    }
+  });
+});

--- a/src/service/cloudformation/resource/cfn/apigateway/sim-api-gateway-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/apigateway/sim-api-gateway-cfn-value-adapter.ts
@@ -1,3 +1,4 @@
+import { SimRestApiAuthorizer } from "../../../../apigateway/api/authorizer/sim-rest-api-authorizer.js";
 import { SimRestApiDeployment } from "../../../../apigateway/api/deployment/sim-rest-api-deployment.js";
 import { SimRestApiResource } from "../../../../apigateway/api/resource/sim-rest-api-resource.js";
 import { SimRestApi } from "../../../../apigateway/api/sim-rest-api.js";
@@ -6,6 +7,7 @@ import type {
   SimCfnResourceValueAdapterProperties,
   SimCfnServiceValueAdapter,
 } from "../sim-cfn-resource-value-adapter.js";
+import { SimRestApiAuthorizerCfn } from "./sim-rest-api-authorizer-cfn.js";
 import { SimRestApiCfn } from "./sim-rest-api-cfn.js";
 import { SimRestApiDeploymentCfn } from "./sim-rest-api-deployment-cfn.js";
 import { SimRestApiResourceCfn } from "./sim-rest-api-resource-cfn.js";
@@ -36,6 +38,13 @@ export function apiGatewayValueAdapter(
     properties.simResource instanceof SimRestApiResource
   ) {
     return new SimRestApiResourceCfn({ resource: properties.simResource });
+  }
+
+  if (
+    properties.type === "AWS::ApiGateway::Authorizer" &&
+    properties.simResource instanceof SimRestApiAuthorizer
+  ) {
+    return new SimRestApiAuthorizerCfn({ authorizer: properties.simResource });
   }
 
   if (

--- a/src/service/cloudformation/resource/cfn/apigateway/sim-rest-api-authorizer-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/apigateway/sim-rest-api-authorizer-cfn.ts
@@ -1,0 +1,39 @@
+import type { SimRestApiAuthorizer } from "../../../../apigateway/api/authorizer/sim-rest-api-authorizer.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimRestApiAuthorizerCfnProperties {
+  readonly authorizer: SimRestApiAuthorizer;
+}
+
+/**
+ * CloudFormation-facing values for a simulated REST API authorizer.
+ */
+export class SimRestApiAuthorizerCfn implements SimCfnResourceValueAdapter {
+  private readonly authorizer: SimRestApiAuthorizer;
+
+  constructor(properties: SimRestApiAuthorizerCfnProperties) {
+    this.authorizer = properties.authorizer;
+  }
+
+  /**
+   * AWS::ApiGateway::Authorizer Ref returns the authorizer id, which is what a
+   * method names it by and what CDK builds the authorizer's own ARN from.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.authorizer.authorizerId;
+  }
+
+  /**
+   * AWS::ApiGateway::Authorizer publishes AuthorizerId.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    if (attributeName === "AuthorizerId") {
+      return this.authorizer.authorizerId;
+    }
+
+    throw new Error(
+      `Unsupported AWS::ApiGateway::Authorizer attribute ${attributeName}`,
+    );
+  }
+}


### PR DESCRIPTION
CreateAuthorizer builds a TOKEN authorizer over a Lambda function, and PutMethod binds one to a
method with authorizationType CUSTOM. A request to that method sends the header the authorizer names
to its function, under an invoke permission granted on the authorizer's own ARN, and the IAM policy
document the function answers with is evaluated for execute-api:Invoke against the ARN of the request
being made. A policy covering one method therefore leaves another unauthorized, and whatever context
the function returns reaches the handler under requestContext.authorizer.
AWS::ApiGateway::Authorizer deploys through the same command, and a CDK TokenAuthorizer serves end to
end.

Issue #782 carried seven acceptance criteria across four authorization types. Measured against the
HTTP API equivalents, which came to roughly 12,000 added lines over four pull requests for two kinds
plus AWS_IAM, the whole of it is several times the size a branch should be. The other three types and
the result cache were split out, each depending on the authorizer model and the serving path here:
#790 for REQUEST, #791 for AuthorizerResultTtlInSeconds, #792 for COGNITO_USER_POOLS and #793 for
AWS_IAM.

Resolves #782
