### PR TITLE
feat: authorize a REST API method with IAM

### DIFF
--- a/docs/services/apigateway/README.md
+++ b/docs/services/apigateway/README.md
@@ -521,6 +521,147 @@ arn:aws:execute-api:{region}:{account}:{apiId}/authorizers/{authorizerId}
 That ARN names no stage. A function used both as an integration and as an authorizer needs two
 permissions, as it does on AWS. CDK's `TokenAuthorizer` writes this one.
 
+## Protecting a method with IAM
+
+A method declared `authorizationType: "AWS_IAM"` reaches its integration only when the caller is
+allowed `execute-api:Invoke` on the ARN of the method being called. IAM decides. The method takes no
+authorizer, and naming one is refused by `PutMethod`.
+
+The caller comes from the request, through either a SigV4 signature or an `x-sim-aws-caller` header
+naming a principal directly. A request offering neither is anonymous, owns no policies, and is
+refused. See [callers of HTTP requests](../iam/#callers-of-http-requests) in the IAM docs for how that
+resolution works and how to sign a served request.
+
+The ARN a request is authorized against is:
+
+```text
+arn:aws:execute-api:<region>:<account>:<apiId>/<stage>/<METHOD>/<path>
+```
+
+- The Account and Region are the API's own, not the caller's.
+- The stage is the one that served the request.
+- The method is the one the client sent, upper case. A `GET` reaching a resource declaring `ANY`
+  gives `GET`.
+- The path is the request path with the stage segment and the leading slash taken off, so
+  `/prod/orders/42` served from stage `prod` gives `orders/42`. It is the path the client asked for,
+  because a policy names it by hand. A request to a method declared on `/orders/{orderId}` is
+  authorized under `GET/orders/42`, with no braces in it. A request to the API root gives an ARN
+  ending `/GET/`.
+
+An identity policy may wildcard any part of that. `<apiId>/*`, `<apiId>/prod/*` and
+`<apiId>/*/GET/orders/*` all allow a `GET` of `/orders/42` on stage `prod`.
+
+```typescript sim-apigateway-iam-authorization
+/**
+ * Protecting a simulated REST API method with IAM.
+ *
+ * The caller the request was attributed to has to be allowed
+ * execute-api:Invoke on the method it is calling.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+
+import { SimAws } from "@kensio/yulin";
+import { simRestApiLambdaProxyFactory } from "@kensio/yulin/apigateway";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+const restApi = await simRestApiLambdaProxyFactory.make(
+  {
+    iamAuthorization: true,
+    resourcePaths: ["/orders/{orderId}"],
+    handler: (event) => ({
+      statusCode: 200,
+      headers: { "content-type": "text/plain" },
+      body: `orders for ${event.requestContext.identity.userArn ?? "nobody"}`,
+    }),
+  },
+  simAws,
+);
+
+// A Role of the API's own Account, allowed to call the orders methods of this
+// API on the stage it is deployed to.
+await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "Reporter",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { AWS: "arn:aws:iam::888888888888:root" },
+          Action: "sts:AssumeRole",
+        },
+      ],
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "Reporter",
+    PolicyName: "InvokeOrders",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Action: "execute-api:Invoke",
+          Resource: `arn:aws:execute-api:us-east-1:888888888888:${restApi.apiId}/prod/GET/orders/*`,
+        },
+      ],
+    }),
+  }),
+);
+
+const srv = await serveSimAws({ simAws });
+const url = srv.localUrl(`${restApi.invokeUrl("prod")}/orders/42`);
+
+const anonymous = await fetch(url);
+
+console.log(anonymous.status);
+// 403
+
+const reporter = await fetch(url, {
+  headers: { "x-sim-aws-caller": "arn:aws:iam::888888888888:role/Reporter" },
+});
+
+console.log(await reporter.text());
+// "orders for arn:aws:iam::888888888888:role/Reporter"
+
+await srv.close();
+```
+
+A caller IAM does not allow gets 403 with `User is not authorized to access this resource`. An
+explicit Deny gets that same body, where a Lambda authorizer's Deny gets one of its own.
+
+Only the caller's identity policies are read. A REST API also has a resource policy on real AWS, and
+`Policy` on an `AWS::ApiGateway::RestApi` is recorded against the Resource with the API deployed
+without it. A caller from another Account is therefore always refused, because a cross-Account
+request needs an Allow from each side. The way through, here as on AWS, is to assume a Role in the
+API's Account.
+
+### The identity the handler receives
+
+An admitted caller reaches the handler under `requestContext.identity`.
+
+| Field       | What it carries                    |
+| ----------- | ---------------------------------- |
+| `accountId` | The Account the caller's ARN names |
+| `caller`    | The caller's ARN                   |
+| `user`      | The caller's ARN                   |
+| `userArn`   | The caller's ARN                   |
+
+Real API Gateway puts the unique id of the principal in `caller` and `user`, such as `AIDA...` for a
+User. A request carries no such id into the simulation, so the ARN identifying the caller goes in
+every field that can be filled from it.
+
+A method of any other authorization type leaves those four `null`, and so does an `AWS_IAM` method
+called by a principal with no ARN behind it. `accessKey`, `apiKey`, `apiKeyId`, `principalOrgId` and
+the two Cognito identity pool fields are `null` throughout. `sourceIp` and `userAgent` describe the
+request itself and are filled for every method.
+
 ## Intercepting an SDK client
 
 `SimSdk` routes `@aws-sdk/client-api-gateway` commands to the simulation. Code under test builds its
@@ -1021,8 +1162,9 @@ An input outside what this simulates is refused. Dropping it would let a request
 and behave differently deployed. The refusals worth knowing about:
 
 - **Authorizer kinds.** `TOKEN` is the one simulated. A `REQUEST` or `COGNITO_USER_POOLS`
-  authorizer is refused by `CreateAuthorizer`, and an `AWS_IAM` method by `PutMethod`. Each is a
-  separate piece of work.
+  authorizer is refused by `CreateAuthorizer`, and a `COGNITO_USER_POOLS` method by `PutMethod`.
+  Each is a separate piece of work. An `AWS_IAM` method is decided by IAM and names no authorizer.
+  See [Protecting a method with IAM](#protecting-a-method-with-iam).
 - **Holding an authorizer's decision.** `authorizerResultTtlInSeconds` is refused. The function is
   invoked once per request reaching the method.
 - **Integration types.** Only `AWS_PROXY` with a Lambda function URI is simulated. `MOCK`, `HTTP`,

--- a/docs/services/apigateway/sim-apigateway-iam-authorization.example.ts
+++ b/docs/services/apigateway/sim-apigateway-iam-authorization.example.ts
@@ -1,0 +1,79 @@
+/**
+ * Protecting a simulated REST API method with IAM.
+ *
+ * The caller the request was attributed to has to be allowed
+ * execute-api:Invoke on the method it is calling.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+
+import { SimAws } from "@kensio/yulin";
+import { simRestApiLambdaProxyFactory } from "@kensio/yulin/apigateway";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+const restApi = await simRestApiLambdaProxyFactory.make(
+  {
+    iamAuthorization: true,
+    resourcePaths: ["/orders/{orderId}"],
+    handler: (event) => ({
+      statusCode: 200,
+      headers: { "content-type": "text/plain" },
+      body: `orders for ${event.requestContext.identity.userArn ?? "nobody"}`,
+    }),
+  },
+  simAws,
+);
+
+// A Role of the API's own Account, allowed to call the orders methods of this
+// API on the stage it is deployed to.
+await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "Reporter",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { AWS: "arn:aws:iam::888888888888:root" },
+          Action: "sts:AssumeRole",
+        },
+      ],
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "Reporter",
+    PolicyName: "InvokeOrders",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Action: "execute-api:Invoke",
+          Resource: `arn:aws:execute-api:us-east-1:888888888888:${restApi.apiId}/prod/GET/orders/*`,
+        },
+      ],
+    }),
+  }),
+);
+
+const srv = await serveSimAws({ simAws });
+const url = srv.localUrl(`${restApi.invokeUrl("prod")}/orders/42`);
+
+const anonymous = await fetch(url);
+
+console.log(anonymous.status);
+// 403
+
+const reporter = await fetch(url, {
+  headers: { "x-sim-aws-caller": "arn:aws:iam::888888888888:role/Reporter" },
+});
+
+console.log(await reporter.text());
+// "orders for arn:aws:iam::888888888888:role/Reporter"
+
+await srv.close();

--- a/src/serve/payload-1/sim-payload-1-iam-caller.iso.test.ts
+++ b/src/serve/payload-1/sim-payload-1-iam-caller.iso.test.ts
@@ -1,0 +1,81 @@
+import { assertObjectMatches } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsRequestCaller } from "../../service/iam/request/sim-aws-request-caller.js";
+import { SimPayload1IamCaller } from "./sim-payload-1-iam-caller.js";
+
+describe("The IAM caller of a payload format 1.0 invocation", () => {
+  it("describes a principal by its ARN", () => {
+    // Given a caller resolved to an IAM user
+    const arn = "arn:aws:iam::111111111111:user/Invoker";
+    const caller = new SimPayload1IamCaller(
+      new SimAwsRequestCaller({
+        principal: { kind: "arn", arn },
+        authMethod: "sigv4",
+      }),
+    );
+
+    // When it is described for the invocation event
+    // Then the ARN identifies it in every field the simulator can honestly
+    // fill, since the unique id real AWS puts in `caller` and `user` is not
+    // something the request boundary knows
+    assertObjectMatches(caller.identity(), {
+      accountId: "111111111111",
+      caller: arn,
+      user: arn,
+      userArn: arn,
+    });
+  });
+
+  it("describes no caller for a principal without an ARN", () => {
+    // Given a caller that is an AWS service rather than an IAM identity
+    const caller = new SimPayload1IamCaller(
+      new SimAwsRequestCaller({
+        principal: { kind: "service", service: "s3.amazonaws.com" },
+        authMethod: "caller-header",
+      }),
+    );
+
+    // When it is described for the invocation event
+    // Then there is nothing to name, and a handler reads the `null` it reads
+    // for a request nobody authorized
+    assertObjectMatches(caller.identity(), {
+      accountId: null,
+      caller: null,
+      user: null,
+      userArn: null,
+    });
+  });
+
+  it("reports no Account for an ARN carrying none", () => {
+    // Given a caller named by an ARN with no Account component, as S3 ARNs are
+    const caller = new SimPayload1IamCaller(
+      new SimAwsRequestCaller({
+        principal: { kind: "arn", arn: "arn:aws:s3:::reports-bucket" },
+        authMethod: "caller-header",
+      }),
+    );
+
+    // When it is described for the invocation event
+    // Then the Account is null rather than the empty string the ARN carries
+    assertObjectMatches(caller.identity(), {
+      accountId: null,
+      userArn: "arn:aws:s3:::reports-bucket",
+    });
+  });
+
+  it("names nobody at all for a request nothing authenticated", () => {
+    // Given a method that authorized nobody, so there is no caller
+    const caller = new SimPayload1IamCaller(undefined);
+
+    // When the identity is described
+    // Then every field naming a principal is null, which is what real API
+    // Gateway sends for an open method
+    assertObjectMatches(caller.identity(), {
+      accountId: null,
+      caller: null,
+      user: null,
+      userArn: null,
+    });
+  });
+});

--- a/src/serve/payload-1/sim-payload-1-iam-caller.ts
+++ b/src/serve/payload-1/sim-payload-1-iam-caller.ts
@@ -1,0 +1,70 @@
+import type { SimAwsRequestCaller } from "../../service/iam/request/sim-aws-request-caller.js";
+import type { SimPayload1Identity } from "./sim-payload-1-event.type.js";
+
+/**
+ * The `requestContext.identity` fields describing the caller of an `AWS_IAM`
+ * method, which are `null` for a request nobody authorized.
+ */
+type SimPayload1IdentityCaller = Pick<
+  SimPayload1Identity,
+  "accountId" | "caller" | "user" | "userArn"
+>;
+
+/**
+ * How the IAM caller of a payload format 1.0 invocation appears in the event.
+ *
+ * Everything here is derived from the caller's ARN. Real API Gateway puts the
+ * unique id of the principal, `AIDA...` for a User, in `caller` and `user`,
+ * and the simulator has no such id to give, so the ARN identifying the caller
+ * goes in each field it can honestly fill. A caller without an ARN is described
+ * the way an unauthenticated one is rather than filled in with something no
+ * real invocation would carry.
+ */
+export class SimPayload1IamCaller {
+  private readonly caller: SimAwsRequestCaller | undefined;
+
+  /**
+   * An absent caller is one nothing authenticated, which is every caller of a
+   * method that authorizes nobody.
+   */
+  constructor(caller: SimAwsRequestCaller | undefined) {
+    this.caller = caller;
+  }
+
+  /**
+   * The identity fields naming this caller, or `null` in each of them where
+   * there is no IAM principal to name.
+   */
+  identity(): SimPayload1IdentityCaller {
+    const arn = this.arn();
+
+    if (arn === undefined) {
+      return { accountId: null, caller: null, user: null, userArn: null };
+    }
+
+    return {
+      accountId: this.accountId(arn),
+      caller: arn,
+      user: arn,
+      userArn: arn,
+    };
+  }
+
+  /**
+   * The Account of the principal the request was attributed to, which is the
+   * caller's own rather than the API's, and `null` for an ARN carrying none.
+   */
+  private accountId(arn: string): string | null {
+    const arnAccountId = arn.split(":", 6)[4];
+
+    return arnAccountId === undefined || arnAccountId.length === 0
+      ? null
+      : arnAccountId;
+  }
+
+  private arn(): string | undefined {
+    const principal = this.caller?.principal;
+
+    return principal?.kind === "arn" ? principal.arn : undefined;
+  }
+}

--- a/src/serve/payload-1/sim-payload-1-request-context.ts
+++ b/src/serve/payload-1/sim-payload-1-request-context.ts
@@ -1,7 +1,9 @@
 import { randomUUID } from "node:crypto";
 
+import type { SimAwsRequestCaller } from "../../service/iam/request/sim-aws-request-caller.js";
 import { simProxyEventTime } from "../proxy/sim-proxy-event-time.js";
 import type { SimPayload1Endpoint } from "./sim-payload-1-endpoint.js";
+import { SimPayload1IamCaller } from "./sim-payload-1-iam-caller.js";
 import type {
   SimPayload1Identity,
   SimPayload1LambdaAuthorizer,
@@ -9,14 +11,18 @@ import type {
 } from "./sim-payload-1-event.type.js";
 
 /**
- * What the endpoint's authorizer knows about the caller, if it authorized one.
+ * What the endpoint's authorization knows about the caller, if it authorized
+ * one.
  *
- * A method admitting anybody supplies none, which is what leaves the
- * authorizer block out of the event.
+ * A method admitting anybody supplies neither, which is what leaves the
+ * authorizer block out of the event and every identity field describing a
+ * principal `null`.
  */
 export interface SimPayload1Authorization {
   /** The principal and the context a Lambda authorizer answered with. */
   readonly lambda?: SimPayload1LambdaAuthorizer | undefined;
+  /** The caller an `AWS_IAM` method allowed the request. */
+  readonly caller?: SimAwsRequestCaller | undefined;
 }
 
 interface SimPayload1RequestContextInput {
@@ -74,26 +80,24 @@ export class SimPayload1RequestContextBuilder {
   /**
    * Who API Gateway says made the request.
    *
-   * Only the open case is described here. The fields an `AWS_IAM` method
-   * fills stay `null`, because that authorization type is a separate piece of
-   * work.
+   * The fields naming a principal are filled for an `AWS_IAM` method, which is
+   * the one authorization type that authenticates the caller itself, and are
+   * `null` for every other method. The Cognito identity pool fields are `null`
+   * throughout, as they are for any request that came without one.
    */
   private identity(input: SimPayload1RequestContextInput): SimPayload1Identity {
     return {
       sourceIp: input.sourceIp,
       userAgent: input.request.headers.get("user-agent"),
       accessKey: null,
-      accountId: null,
       apiKey: null,
       apiKeyId: null,
-      caller: null,
       cognitoAuthenticationProvider: null,
       cognitoAuthenticationType: null,
       cognitoIdentityId: null,
       cognitoIdentityPoolId: null,
       principalOrgId: null,
-      user: null,
-      userArn: null,
+      ...new SimPayload1IamCaller(input.authorization?.caller).identity(),
     };
   }
 }

--- a/src/service/apigateway/README.md
+++ b/src/service/apigateway/README.md
@@ -95,14 +95,19 @@ The client's own authorization runs first. A request presenting no credentials i
 not the integration behind the method would have worked. Whether the API may invoke a function is a
 separate question, asked afterwards, and it is the API's rather than the client's.
 
-`serve/auth/` holds one authorization type, and the pieces are the ones a `TOKEN` authorizer needs:
+`serve/auth/` holds the authorization types, one decider each:
 
 ```text
 SimRestApiMethodAuthorizer            which type the method asks for
+├── SimRestApiIamMethodAuthorizer     the caller, put to IAM against the method ARN
 └── SimRestApiAuthorizerInvocation    the invoke permission, the event, the answer
     ├── SimRestApiAuthorizerResponse  the principal, the context, the policy
     └── SimRestApiAuthorizerPolicy    that policy, put to IAM against the method ARN
 ```
+
+An `AWS_IAM` method asks the IAM of the Account that owns the API about the caller the serving
+boundary resolved. The caller travels on with the admission, and `src/serve/payload-1/` describes it
+to the handler under `requestContext.identity`.
 
 The method ARN is the one part with no HTTP API equivalent worth copying. A REST API authorizer is
 handed the ARN of the request the client made, with the concrete path in it, and the policy it
@@ -204,10 +209,10 @@ type other than `AWS_PROXY` are all refused there, so a request naming one fails
 been applied on real AWS.
 
 Authorization is refused the same way, in the two commands that carry it.
-`CreateAuthorizer` takes `TOKEN` and refuses the other two kinds, and `PutMethod` takes `NONE` and
-`CUSTOM` and refuses the other two types. A method served open where AWS would have gated it lets a
-test pass on a request real AWS rejects, so a template asking for one of them fails to deploy rather
-than deploying around it.
+`CreateAuthorizer` takes `TOKEN` and refuses the other two kinds, and `PutMethod` takes `NONE`,
+`CUSTOM` and `AWS_IAM` and refuses `COGNITO_USER_POOLS`. A method served open where AWS would have
+gated it lets a test pass on a request real AWS rejects, so a template asking for one of them fails
+to deploy rather than deploying around it.
 
 An imported document meets those refusals through the commands, and `openapi/` adds the ones about
 members no command sees. A document-level `security`, an operation's `security`, a Swagger 2

--- a/src/service/apigateway/api/authorizer/sim-rest-api-authorization.ts
+++ b/src/service/apigateway/api/authorizer/sim-rest-api-authorization.ts
@@ -1,4 +1,5 @@
 import type { SimPayload1LambdaAuthorizer } from "../../../../serve/payload-1/sim-payload-1-event.type.js";
+import type { SimAwsRequestCaller } from "../../../iam/request/sim-aws-request-caller.js";
 
 /**
  * Why a method refused a request, which decides the response it gets.
@@ -21,22 +22,28 @@ interface SimRestApiAdmittedProperties {
    * absent on a method admitting anybody.
    */
   readonly lambda?: SimPayload1LambdaAuthorizer | undefined;
+  /** The principal an `AWS_IAM` method allowed the request. */
+  readonly caller?: SimAwsRequestCaller | undefined;
 }
 
 /**
- * A request the method admitted, and what its authorizer knows about the
+ * A request the method admitted, and what its authorization knows about the
  * caller.
  *
- * `lambda` is absent on a method that authorizes nobody, since there is no
- * caller to describe. That absence is what leaves `requestContext.authorizer`
- * out of the event entirely.
+ * Both members are absent on a method that authorizes nobody, since there is
+ * no caller to describe. That is what leaves `requestContext.authorizer` out of
+ * the event entirely and every `requestContext.identity` field describing a
+ * principal `null`. Which one is present says which kind of authorization
+ * admitted the request.
  */
 export class SimRestApiAdmitted {
   public readonly admitted = true as const;
   public readonly lambda: SimPayload1LambdaAuthorizer | undefined;
+  public readonly caller: SimAwsRequestCaller | undefined;
 
   constructor(properties: SimRestApiAdmittedProperties = {}) {
     this.lambda = properties.lambda;
+    this.caller = properties.caller;
   }
 }
 

--- a/src/service/apigateway/api/method/sim-rest-api-method.ts
+++ b/src/service/apigateway/api/method/sim-rest-api-method.ts
@@ -12,13 +12,14 @@ export const simRestApiAnyMethod = "ANY";
 /**
  * The authorization types simulated so far.
  *
- * `NONE` is an open method, and `CUSTOM` sends the request through the Lambda
- * authorizer the method names. `COGNITO_USER_POOLS` and `AWS_IAM` are
- * separate pieces of work, and a method asking for either is refused when it
- * is created. A method served open where AWS would have gated it lets a test
- * pass on a request real AWS rejects.
+ * `NONE` is an open method, `CUSTOM` sends the request through the Lambda
+ * authorizer the method names, and `AWS_IAM` asks IAM whether the caller the
+ * request was attributed to may invoke the method. `COGNITO_USER_POOLS` is a
+ * separate piece of work, and a method asking for it is refused when it is
+ * created. A method served open where AWS would have gated it lets a test pass
+ * on a request real AWS rejects.
  */
-export type SimRestApiAuthorizationType = "NONE" | "CUSTOM";
+export type SimRestApiAuthorizationType = "NONE" | "CUSTOM" | "AWS_IAM";
 
 interface SimRestApiMethodProperties {
   readonly httpMethod: string;

--- a/src/service/apigateway/api/sim-rest-api-declared-method.ts
+++ b/src/service/apigateway/api/sim-rest-api-declared-method.ts
@@ -1,3 +1,4 @@
+import type { SimPutMethodCommandInput } from "../command/method/method.command.js";
 import type { SimApiGateway } from "../sim-api-gateway.js";
 
 interface SimRestApiDeclaredMethodInput {
@@ -8,6 +9,8 @@ interface SimRestApiDeclaredMethodInput {
   readonly functionArn: string;
   /** The authorizer every method is gated by, where the API has one. */
   readonly authorizerId: string | undefined;
+  /** Whether every method is decided by IAM instead. */
+  readonly iamAuthorization: boolean;
 }
 
 /**
@@ -49,9 +52,7 @@ async function declaredMethod(
       restApiId,
       resourceId,
       httpMethod,
-      ...(input.authorizerId === undefined
-        ? { authorizationType: "NONE" }
-        : { authorizationType: "CUSTOM", authorizerId: input.authorizerId }),
+      ...declaredAuthorization(input),
     },
   });
   await apiGateway.putIntegration({
@@ -64,6 +65,24 @@ async function declaredMethod(
       uri: input.functionArn,
     },
   });
+}
+
+/**
+ * The authorization every method of the API is declared with.
+ *
+ * An `AWS_IAM` method names no authorizer, so a test asking for both is asking
+ * for something PutMethod refuses, and gets that refusal.
+ */
+function declaredAuthorization(
+  input: SimRestApiDeclaredMethodInput,
+): Pick<SimPutMethodCommandInput, "authorizationType" | "authorizerId"> {
+  if (input.authorizerId !== undefined) {
+    return { authorizationType: "CUSTOM", authorizerId: input.authorizerId };
+  }
+
+  return {
+    authorizationType: input.iamAuthorization ? "AWS_IAM" : "NONE",
+  };
 }
 
 /**

--- a/src/service/apigateway/api/sim-rest-api-lambda-proxy.factory.ts
+++ b/src/service/apigateway/api/sim-rest-api-lambda-proxy.factory.ts
@@ -25,6 +25,11 @@ export interface SimRestApiLambdaProxyInput extends SimRestApiProxyAuthorizerInp
   readonly handler: (event: SimPayload1Event) => unknown;
   readonly disableExecuteApiEndpoint: boolean;
   /**
+   * Whether every method is authorized by IAM, which is what an `AWS_IAM`
+   * method asks for. An API asking for this names no authorizer.
+   */
+  readonly iamAuthorization: boolean;
+  /**
    * The resource paths the API declares, written as templates such as
    * `/orders/{orderId}` or `/{proxy+}`. Each one gets the method below.
    */
@@ -56,7 +61,8 @@ export interface SimRestApiLambdaProxyInput extends SimRestApiProxyAuthorizerInp
  * one at a time instead.
  *
  * Supplying an `authorizerHandler` puts a `TOKEN` authorizer in front of every
- * method, invoking a second simulated function of its own.
+ * method, invoking a second simulated function of its own, and asking for
+ * `iamAuthorization` puts every method behind IAM instead.
  *
  * ```typescript
  * const restApi = await simRestApiLambdaProxyFactory.make(
@@ -86,6 +92,7 @@ export const simRestApiLambdaProxyFactory = new AsyncMappedFactory<
     authorizerIdentitySource: "method.request.header.Authorization",
     authorizerInvokePermission: true,
     disableExecuteApiEndpoint: false,
+    iamAuthorization: false,
     resourcePaths: ["/{proxy+}"],
     httpMethod: "ANY",
     stageName: "prod",
@@ -109,6 +116,7 @@ export const simRestApiLambdaProxyFactory = new AsyncMappedFactory<
       httpMethod: input.httpMethod,
       functionArn,
       authorizerId: await simRestApiProxyAuthorizer(simAws, input, restApiId),
+      iamAuthorization: input.iamAuthorization,
     });
 
     if (input.invokePermission) {

--- a/src/service/apigateway/cfn/sim-cfn-rest-api-deploy.iso.test.ts
+++ b/src/service/apigateway/cfn/sim-cfn-rest-api-deploy.iso.test.ts
@@ -1,3 +1,4 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import {
   assertIdentical,
   assertNonNullable,
@@ -11,6 +12,9 @@ import {
 } from "../../../../test/apigateway/cfn-deploy.js";
 import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
 import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import { DEFAULT_SIM_AWS_ACCOUNT_ID } from "../../aws/sim-aws-account.js";
+import { simAwsCallerHeaderName } from "../../iam/request/sim-aws-caller-header.js";
+import { simIamPolicyDocumentFactory } from "../../iam/policy/sim-iam-policy-document.factory.js";
 import {
   simCfnRestApiMethodLogicalId,
   simCfnRestApiResourceLogicalId,
@@ -258,6 +262,68 @@ describe("API Gateway REST API CloudFormation deployment", () => {
       restApi.deployments.find(stage.deploymentId)?.description,
       "deployed by the stack",
     );
+  });
+
+  it("gates a deployed method with the IAM authorization it declares", async () => {
+    // Given a template whose one method is authorized by IAM
+    const simAws = simAwsInEuWest2();
+    const stack = await deployRestApi(
+      simAws,
+      simCfnRestApiTemplateFactory.make({
+        handlerSource: routeReportingHandler,
+        methods: [{ httpMethod: "GET", path: ["orders"] }],
+        methodProperties: { AuthorizationType: "AWS_IAM" },
+      }),
+    );
+
+    // And a Role of the API's Account allowed to invoke that one method
+    const apiId = stack.getResource("Api")?.refValue;
+    assertTypeString(apiId);
+    const iam = simAws.iam();
+    await iam.createRole(
+      new CreateRoleCommand({
+        RoleName: "Reporter",
+        AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Principal: {
+              AWS: `arn:aws:iam::${DEFAULT_SIM_AWS_ACCOUNT_ID}:root`,
+            },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+    await iam.putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "Reporter",
+        PolicyName: "InvokeOrders",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Action: "execute-api:Invoke",
+            Resource:
+              `arn:aws:execute-api:eu-west-2:${DEFAULT_SIM_AWS_ACCOUNT_ID}:` +
+              `${apiId}/prod/GET/orders`,
+          },
+        }),
+      }),
+    );
+
+    // When the deployed endpoint is requested with and without that Role
+    const apiUrl = stack.outputs.get("ApiUrl")?.value;
+    assertTypeString(apiUrl);
+    const http = new SimAwsHttp({ simAws });
+    const anonymous = await http.fetch(localUrl(apiUrl, "orders"));
+    const reporter = await http.fetch(localUrl(apiUrl, "orders"), {
+      headers: {
+        [simAwsCallerHeaderName]: `arn:aws:iam::${DEFAULT_SIM_AWS_ACCOUNT_ID}:role/Reporter`,
+      },
+    });
+
+    // Then the template deployed a method IAM decides, closed to a request
+    // carrying no identity and open to the Role that was allowed it
+    assertIdentical(anonymous.status, 403);
+    assertIdentical(reporter.status, 200);
+    assertIdentical(await reporter.text(), "GET /orders {}");
   });
 
   it("refuses the generated endpoint when the API disables it", async () => {

--- a/src/service/apigateway/cfn/sim-cfn-rest-api-validation.iso.test.ts
+++ b/src/service/apigateway/cfn/sim-cfn-rest-api-validation.iso.test.ts
@@ -16,14 +16,14 @@ import { simCfnRestApiTemplateFactory } from "./sim-cfn-rest-api-template.factor
 
 describe("API Gateway REST API CloudFormation refusals", () => {
   it("refuses a method asking for an authorization type nothing enforces", async () => {
-    // Given a method behind IAM authorization
+    // Given a method behind a user pool
     const simAws = simAwsInEuWest2();
 
     // When the template is deployed
     const error = await deployRestApiFailure(
       simAws,
       simCfnRestApiTemplateFactory.make({
-        methodProperties: { AuthorizationType: "AWS_IAM" },
+        methodProperties: { AuthorizationType: "COGNITO_USER_POOLS" },
       }),
     );
 
@@ -31,7 +31,7 @@ describe("API Gateway REST API CloudFormation refusals", () => {
     // would have gated
     assertStringIncludes(
       error.message,
-      "PutMethod authorizationType 'AWS_IAM' is not simulated",
+      "PutMethod authorizationType 'COGNITO_USER_POOLS' is not simulated",
     );
   });
 

--- a/src/service/apigateway/command/method/sim-rest-api-method-authorization.ts
+++ b/src/service/apigateway/command/method/sim-rest-api-method-authorization.ts
@@ -18,12 +18,27 @@ const unsimulatedTypes = new Map([
     "COGNITO_USER_POOLS",
     "verifying a user pool token against a method is not simulated",
   ],
-  [
-    "AWS_IAM",
-    "authorizing a signed request against the caller's identity policy is " +
-      "not simulated for a method",
-  ],
 ]);
+
+/**
+ * The authorization types `PutMethod` takes here, each of which something
+ * enforces when a request reaches the method.
+ */
+const simulatedTypes = new Set<string>(["NONE", "CUSTOM", "AWS_IAM"]);
+
+function isSimulatedType(
+  declared: string,
+): declared is SimRestApiAuthorizationType {
+  return simulatedTypes.has(declared);
+}
+
+/**
+ * An authorization type that decides a request without asking an authorizer.
+ */
+type SimRestApiAuthorizerlessType = Exclude<
+  SimRestApiAuthorizationType,
+  "CUSTOM"
+>;
 
 /**
  * What a method's authorization type and authorizer id come to.
@@ -36,9 +51,10 @@ export interface SimRestApiMethodAuthorization {
 /**
  * Reads the authorization a `PutMethod` input asks for.
  *
- * A method is open or it names one of the API's authorizers. Every other
- * pairing is refused, because a method that looked gated to the caller that
- * declared it and answered every request here is worse than a refused command.
+ * A method is open, decided by IAM, or it names one of the API's authorizers.
+ * Every other pairing is refused, because a method that looked gated to the
+ * caller that declared it and answered every request here is worse than a
+ * refused command.
  */
 export class SimRestApiMethodAuthorizationInput {
   private readonly input: SimPutMethodCommandInput;
@@ -61,16 +77,16 @@ export class SimRestApiMethodAuthorizationInput {
   ): SimRestApiMethodAuthorization {
     const authorizationType = this.authorizationType();
 
-    if (authorizationType === "NONE") {
-      this.refuseAuthorizerId(resource, httpMethod);
-
-      return { authorizationType };
+    if (authorizationType === "CUSTOM") {
+      return {
+        authorizationType,
+        authorizerId: this.authorizerId(restApi, resource, httpMethod),
+      };
     }
 
-    return {
-      authorizationType,
-      authorizerId: this.authorizerId(restApi, resource, httpMethod),
-    };
+    this.refuseAuthorizerId(authorizationType, resource, httpMethod);
+
+    return { authorizationType };
   }
 
   /**
@@ -86,7 +102,7 @@ export class SimRestApiMethodAuthorizationInput {
       throw new SimApiGatewayBadRequest("PutMethod requires authorizationType");
     }
 
-    if (declared === "NONE" || declared === "CUSTOM") {
+    if (isSimulatedType(declared)) {
       return declared;
     }
 
@@ -94,8 +110,8 @@ export class SimRestApiMethodAuthorizationInput {
 
     throw new SimApiGatewayBadRequest(
       `PutMethod authorizationType '${declared}' is not simulated` +
-        `${reason === undefined ? "" : `: ${reason}`}. NONE and CUSTOM are ` +
-        `supported.`,
+        `${reason === undefined ? "" : `: ${reason}`}. NONE, CUSTOM and ` +
+        `AWS_IAM are supported.`,
     );
   }
 
@@ -130,18 +146,28 @@ export class SimRestApiMethodAuthorizationInput {
   }
 
   /**
-   * Refuse an authorizer named by a method that authorizes nobody.
+   * Refuse an authorizer named by a method that has none to name.
+   *
+   * A method whose type takes no authorizer would ignore the id, leaving the
+   * caller that wrote it reading a gate the method has not got.
    */
   private refuseAuthorizerId(
+    authorizationType: SimRestApiAuthorizerlessType,
     resource: SimRestApiResource,
     httpMethod: string,
   ): void {
-    if (this.input.authorizerId !== undefined) {
-      throw new SimApiGatewayBadRequest(
-        `PutMethod authorizerId is set on ${httpMethod} ${resource.path} ` +
-          `with authorizationType NONE, and an open method sends its ` +
-          `requests through nothing`,
-      );
+    if (this.input.authorizerId === undefined) {
+      return;
     }
+
+    const reason =
+      authorizationType === "NONE"
+        ? "an open method sends its requests through nothing"
+        : "an AWS_IAM method is decided by IAM rather than by a function";
+
+    throw new SimApiGatewayBadRequest(
+      `PutMethod authorizerId is set on ${httpMethod} ${resource.path} with ` +
+        `authorizationType ${authorizationType}, and ${reason}`,
+    );
   }
 }

--- a/src/service/apigateway/command/method/sim-rest-api-method-commands.iso.test.ts
+++ b/src/service/apigateway/command/method/sim-rest-api-method-commands.iso.test.ts
@@ -3,7 +3,11 @@ import {
   CreateRestApiCommand,
   PutMethodCommand,
 } from "@aws-sdk/client-api-gateway";
-import { assertFalse, assertIdentical } from "@kensio/smartass";
+import {
+  assertFalse,
+  assertIdentical,
+  assertUndefined,
+} from "@kensio/smartass";
 import { describe, expect, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
@@ -83,6 +87,52 @@ describe("Sim API Gateway REST API method commands", () => {
 
     // Then it is refused, since one resource declares each method once
     await expect(again).rejects.toThrow(SimApiGatewayConflict);
+  });
+
+  it("declares a method IAM decides, with no authorizer to name", async () => {
+    // Given a resource
+    const simAws = new SimAws();
+    const { restApiId, resourceId } = await givenResource(simAws.apiGateway());
+
+    // When a method asks to be authorized by IAM
+    const method = await simAws.apiGateway().putMethod(
+      new PutMethodCommand({
+        restApiId,
+        resourceId,
+        httpMethod: "GET",
+        authorizationType: "AWS_IAM",
+      }),
+    );
+
+    // Then it carries the type and names no authorizer, since IAM decides its
+    // requests rather than a function of the API's
+    assertIdentical(method.authorizationType, "AWS_IAM");
+    assertUndefined(method.authorizerId);
+  });
+
+  it("refuses an authorizer named by a method IAM decides", async () => {
+    // Given a resource
+    const simAws = new SimAws();
+    const { restApiId, resourceId } = await givenResource(simAws.apiGateway());
+
+    // When an AWS_IAM method names an authorizer as well
+    const method = simAws.apiGateway().putMethod(
+      new PutMethodCommand({
+        restApiId,
+        resourceId,
+        httpMethod: "GET",
+        authorizationType: "AWS_IAM",
+        authorizerId: "auth123",
+      }),
+    );
+
+    // Then it is refused rather than served with the id ignored, which would
+    // leave the caller that wrote it reading a gate the method has not got
+    await expect(method).rejects.toThrow(SimApiGatewayBadRequest);
+    await expect(method).rejects.toThrow(
+      "PutMethod authorizerId is set on GET /orders with authorizationType " +
+        "AWS_IAM",
+    );
   });
 
   it("refuses an authorization type nothing here enforces", async () => {

--- a/src/service/apigateway/serve/auth/sim-rest-api-iam-method-authorizer.ts
+++ b/src/service/apigateway/serve/auth/sim-rest-api-iam-method-authorizer.ts
@@ -1,0 +1,54 @@
+import {
+  SimRestApiAdmitted,
+  type SimRestApiAuthorization,
+  SimRestApiRefused,
+} from "../../api/authorizer/sim-rest-api-authorization.js";
+import { SimRestApiExecuteApiArn } from "../../api/sim-rest-api-execute-api-arn.js";
+import { simExecuteApiInvokeAction } from "./sim-rest-api-authorizer-policy.js";
+import type { SimRestApiMethodAuthorizeInput } from "./sim-rest-api-method-authorize-input.js";
+
+/**
+ * Decides whether a caller may have an `AWS_IAM` method.
+ *
+ * This is the client's own authorization, evaluated against the identity
+ * policies of the caller the serving boundary resolved. Resource policies on
+ * the API are a second mechanism a REST API has and this does not read, so the
+ * caller's identity policies are the whole decision, and a caller from another
+ * Account is refused: a cross-Account request needs an Allow from each side.
+ * The way through, here as on AWS, is to assume a Role in the API's Account.
+ *
+ * A request carrying no credentials is anonymous rather than unauthenticated,
+ * so it comes here like any other and is refused because nothing allows an
+ * anonymous caller anything.
+ */
+export class SimRestApiIamMethodAuthorizer {
+  /**
+   * Evaluate `execute-api:Invoke` for the caller against the method being
+   * called.
+   */
+  authorize(input: SimRestApiMethodAuthorizeInput): SimRestApiAuthorization {
+    const { restApi, match, request, caller, iam } = input;
+    const decision = iam.authorize({
+      action: simExecuteApiInvokeAction,
+      // The ARN of the request the client made, which names the concrete path
+      // rather than the resource template, because an identity policy is
+      // written by hand against the request being made.
+      resource: SimRestApiExecuteApiArn.forRequest(
+        restApi,
+        match,
+        request.method,
+      ).toString(),
+      caller: caller.toCaller(),
+    });
+
+    if (decision.isDenied) {
+      // Whether a Deny statement matched or nothing allowed the method is not
+      // told apart, because a service-facing decision does not carry it. Both
+      // are the 403 real API Gateway answers, with the body it gives a caller
+      // its policies left short.
+      return SimRestApiRefused.implicitDeny();
+    }
+
+    return new SimRestApiAdmitted({ caller });
+  }
+}

--- a/src/service/apigateway/serve/auth/sim-rest-api-method-authorize-input.ts
+++ b/src/service/apigateway/serve/auth/sim-rest-api-method-authorize-input.ts
@@ -1,3 +1,5 @@
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimAwsRequestCaller } from "../../../iam/request/sim-aws-request-caller.js";
 import type { SimRestApiMatch } from "../../api/match/sim-rest-api-match.js";
 import type { SimRestApi } from "../../api/sim-rest-api.js";
 
@@ -12,4 +14,15 @@ export interface SimRestApiMethodAuthorizeInput {
   readonly restApi: SimRestApi;
   readonly match: SimRestApiMatch;
   readonly request: Request;
+  /**
+   * The principal the serving boundary attributed the request to, from a
+   * signature or from a named caller, and anonymous when it carried neither.
+   */
+  readonly caller: SimAwsRequestCaller;
+  /**
+   * IAM of the Account that owns the API, which is what decides an `AWS_IAM`
+   * method. It is the API's own rather than the caller's, and rather than the
+   * integrated function's.
+   */
+  readonly iam: SimIamInterServiceAuthZ;
 }

--- a/src/service/apigateway/serve/auth/sim-rest-api-method-authorizer.ts
+++ b/src/service/apigateway/serve/auth/sim-rest-api-method-authorizer.ts
@@ -8,6 +8,7 @@ import {
   type SimRestApiAuthorizerFunctions,
   SimRestApiAuthorizerInvocation,
 } from "./sim-rest-api-authorizer-invocation.js";
+import { SimRestApiIamMethodAuthorizer } from "./sim-rest-api-iam-method-authorizer.js";
 import type { SimRestApiMethodAuthorizeInput } from "./sim-rest-api-method-authorize-input.js";
 
 interface SimRestApiMethodAuthorizerProperties {
@@ -26,7 +27,9 @@ interface SimRestApiMethodAuthorizerProperties {
  * is refused whether or not the integration behind the method would have
  * worked.
  *
- * The steps for a `CUSTOM` method are the ones real API Gateway takes:
+ * Which kind of authorization the method asks for is settled here, and each
+ * kind decides on its own terms. The steps for a `CUSTOM` method are the ones
+ * real API Gateway takes:
  *
  * 1. the request has to carry something at the authorizer's identity source,
  *    or it is refused with a 401 and the function is never invoked;
@@ -35,6 +38,7 @@ interface SimRestApiMethodAuthorizerProperties {
  */
 export class SimRestApiMethodAuthorizer {
   private readonly invocation: SimRestApiAuthorizerInvocation;
+  private readonly iamAuthorizer = new SimRestApiIamMethodAuthorizer();
 
   constructor(properties: SimRestApiMethodAuthorizerProperties) {
     this.invocation = new SimRestApiAuthorizerInvocation({
@@ -48,13 +52,19 @@ export class SimRestApiMethodAuthorizer {
   async authorize(
     input: SimRestApiMethodAuthorizeInput,
   ): Promise<SimRestApiAuthorization> {
-    if (input.match.method.authorizationType === "NONE") {
-      // Nobody was authorized, so there is no caller to describe, which is
-      // what leaves requestContext.authorizer out of the event entirely.
-      return new SimRestApiAdmitted();
+    switch (input.match.method.authorizationType) {
+      case "NONE": {
+        // Nobody was authorized, so there is no caller to describe, which is
+        // what leaves requestContext.authorizer out of the event entirely.
+        return new SimRestApiAdmitted();
+      }
+      case "AWS_IAM": {
+        return this.iamAuthorizer.authorize(input);
+      }
+      case "CUSTOM": {
+        return await this.custom(input);
+      }
     }
-
-    return await this.custom(input);
   }
 
   /**

--- a/src/service/apigateway/serve/sim-api-gateway-controller.ts
+++ b/src/service/apigateway/serve/sim-api-gateway-controller.ts
@@ -28,9 +28,10 @@ interface SimApiGatewayServiceControllerProperties {
  * simulated Lambda function with a payload format 1.0 event. The function runs
  * as its execution Role, as it does for any other invocation.
  *
- * A method that authorizes anybody is checked before any of that. Its
- * authorizer's Lambda function has to allow the request, or the request is
- * refused and the integration is never invoked. Whether the API may invoke a
+ * A method that authorizes anybody is checked before any of that. An `AWS_IAM`
+ * method's caller has to be allowed `execute-api:Invoke` on the method, and a
+ * `CUSTOM` method's Lambda authorizer has to allow the request, or the request
+ * is refused and the integration is never invoked. Whether the API may invoke a
  * function is a separate question, and the API's own rather than the client's.
  */
 export class SimApiGatewayServiceController implements SimAwsServiceController {
@@ -98,6 +99,8 @@ export class SimApiGatewayServiceController implements SimAwsServiceController {
       restApi,
       match,
       request,
+      caller: serviceRequest.caller,
+      iam: this.router.iamFor(restApi),
     });
 
     if (!authorization.admitted) {

--- a/src/service/apigateway/serve/sim-api-gateway-router.ts
+++ b/src/service/apigateway/serve/sim-api-gateway-router.ts
@@ -2,6 +2,7 @@ import type { SimAwsServiceTarget } from "../../../serve/controller/sim-service-
 import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
 import type { AwsRegionName } from "../../aws/sim-aws-region.js";
 import { SimAws } from "../../aws/sim-aws.js";
+import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import type { SimRestApiLambdaUri } from "../api/method/sim-rest-api-lambda-uri.js";
 import type { SimRestApi } from "../api/sim-rest-api.js";
 import type { SimRestApiRegistry } from "../registry/sim-rest-api-registry.js";
@@ -51,6 +52,18 @@ export class SimApiGatewayRouter {
       .accountRegionScope(accountId, target.regionName)
       .apiGateway()
       .findRestApi(target.resourceName);
+  }
+
+  /**
+   * The IAM that decides an `AWS_IAM` method of one API.
+   *
+   * It is the IAM of the Account that owns the API, which is where the
+   * policies allowing a caller `execute-api:Invoke` on its methods live.
+   */
+  iamFor(restApi: SimRestApi): SimIamInterServiceAuthZ {
+    const { accountId, regionName } = restApi.accountRegionScope;
+
+    return this.simAws.accountRegionScope(accountId, regionName).iam();
   }
 
   /**

--- a/src/service/apigateway/serve/sim-rest-api-iam-authorizer.iso.test.ts
+++ b/src/service/apigateway/serve/sim-rest-api-iam-authorizer.iso.test.ts
@@ -1,0 +1,274 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { assertIdentical, assertObjectMatches } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import type { SimPayload1RequestContext } from "../../../serve/payload-1/sim-payload-1-event.type.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simAwsCallerHeaderName } from "../../iam/request/sim-aws-caller-header.js";
+import { simIamPolicyDocumentFactory } from "../../iam/policy/sim-iam-policy-document.factory.js";
+import { simRestApiLambdaProxyFactory } from "../api/sim-rest-api-lambda-proxy.factory.js";
+import type { SimRestApi } from "../api/sim-rest-api.js";
+
+const accountId = "888888888888";
+const reporterArn = `arn:aws:iam::${accountId}:role/Reporter`;
+
+/**
+ * A handler reporting its own requestContext, so a test can assert on what the
+ * method's authorization told it about the caller rather than only on the
+ * status.
+ */
+const reportContext = (event: {
+  requestContext: SimPayload1RequestContext;
+}): unknown => ({
+  statusCode: 200,
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify(event.requestContext),
+});
+
+/**
+ * A Role in the API's own Account, allowed to invoke one `execute-api`
+ * resource.
+ */
+async function reporterRole(simAws: SimAws, resource: string): Promise<void> {
+  const iam = simAws.iam();
+  await iam.createRole(
+    new CreateRoleCommand({
+      RoleName: "Reporter",
+      AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: {
+          Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+  await iam.putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "Reporter",
+      PolicyName: "InvokeOrders",
+      PolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: { Action: "execute-api:Invoke", Resource: resource },
+      }),
+    }),
+  );
+}
+
+function get(
+  simAws: SimAws,
+  restApi: SimRestApi,
+  path: string,
+  callerArn?: string,
+): Promise<Response> {
+  return new SimAwsHttp({ simAws }).fetch(
+    new SimAwsLocalUrl({
+      input: `${restApi.invokeUrl("prod")}${path}`,
+    }).toString(),
+    callerArn === undefined
+      ? {}
+      : { headers: { [simAwsCallerHeaderName]: callerArn } },
+  );
+}
+
+/**
+ * The ARN of one method of an API, as an identity policy names it.
+ */
+function methodArn(restApi: SimRestApi, methodAndPath: string): string {
+  return (
+    `arn:aws:execute-api:us-east-1:${accountId}:` +
+    `${restApi.apiId}/prod/${methodAndPath}`
+  );
+}
+
+describe("Authorizing a sim REST API method with AWS_IAM", () => {
+  it("refuses an unsigned request and never invokes the integration", async () => {
+    // Given an AWS_IAM method
+    const simAws = new SimAws();
+    let invocations = 0;
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      {
+        iamAuthorization: true,
+        resourcePaths: ["/orders/{orderId}"],
+        handler: (): unknown => {
+          invocations += 1;
+
+          return { statusCode: 200, body: "one order" };
+        },
+      },
+      simAws,
+    );
+
+    // When it is called with no credentials at all
+    const response = await get(simAws, restApi, "/orders/42");
+
+    // Then the request resolved to an anonymous caller, nothing allows that
+    // caller anything, and the handler never ran
+    assertIdentical(response.status, 403);
+    assertIdentical(invocations, 0);
+  });
+
+  it("admits a caller allowed execute-api:Invoke on the method", async () => {
+    // Given an AWS_IAM method and a Role allowed to invoke it
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      {
+        iamAuthorization: true,
+        resourcePaths: ["/orders/{orderId}"],
+        handler: (): unknown => ({ statusCode: 200, body: "one order" }),
+      },
+      simAws,
+    );
+    await reporterRole(simAws, methodArn(restApi, "GET/orders/*"));
+
+    // When that Role calls it
+    const response = await get(simAws, restApi, "/orders/42", reporterArn);
+
+    // Then the handler ran
+    assertIdentical(response.status, 200);
+    assertIdentical(await response.text(), "one order");
+  });
+
+  it("refuses a caller whose policies allow another method of the API", async () => {
+    // Given an API with two AWS_IAM methods, and a Role allowed one of them
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      {
+        iamAuthorization: true,
+        resourcePaths: ["/orders/{orderId}", "/invoices/{invoiceId}"],
+        handler: (): unknown => ({ statusCode: 200, body: "one order" }),
+      },
+      simAws,
+    );
+    await reporterRole(simAws, methodArn(restApi, "GET/orders/*"));
+
+    // When that Role calls each of them
+    const allowed = await get(simAws, restApi, "/orders/42", reporterArn);
+    const other = await get(simAws, restApi, "/invoices/42", reporterArn);
+
+    // Then being allowed one method of the API leaves the other closed, since
+    // the policy is evaluated against the ARN of the request being made
+    assertIdentical(allowed.status, 200);
+    assertIdentical(other.status, 403);
+  });
+
+  it("refuses a caller whose policies allow no execute-api action", async () => {
+    // Given an AWS_IAM method and a Role allowed to read a Bucket instead
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      { iamAuthorization: true, resourcePaths: ["/orders/{orderId}"] },
+      simAws,
+    );
+    await simAws.iam().createRole(
+      new CreateRoleCommand({
+        RoleName: "Reporter",
+        AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+    await simAws.iam().putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "Reporter",
+        PolicyName: "ReadReports",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: { Action: "s3:GetObject", Resource: "*" },
+        }),
+      }),
+    );
+
+    // When that Role calls the method
+    const response = await get(simAws, restApi, "/orders/42", reporterArn);
+
+    // Then being a known principal is not enough, and the body is the one API
+    // Gateway answers a caller its policies left short
+    assertIdentical(response.status, 403);
+    assertIdentical(
+      await response.text(),
+      '{"Message":"User is not authorized to access this resource"}',
+    );
+  });
+
+  it("lets an explicit Deny beat an Allow", async () => {
+    // Given a Role allowed every API and denied this one method
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      { iamAuthorization: true, resourcePaths: ["/orders/{orderId}"] },
+      simAws,
+    );
+    await reporterRole(simAws, "*");
+    const denyOrders = simIamPolicyDocumentFactory.make({
+      Statement: {
+        Effect: "Deny",
+        Action: "execute-api:Invoke",
+        Resource: methodArn(restApi, "GET/orders/*"),
+      },
+    });
+    await simAws.iam().putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "Reporter",
+        PolicyName: "DenyOrders",
+        PolicyDocument: denyOrders,
+      }),
+    );
+
+    // When that Role calls the denied method
+    const response = await get(simAws, restApi, "/orders/42", reporterArn);
+
+    // Then the Deny wins, as it does in any IAM evaluation
+    assertIdentical(response.status, 403);
+  });
+
+  it("describes the admitted caller in the event identity", async () => {
+    // Given an admitted caller on an AWS_IAM method
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      {
+        iamAuthorization: true,
+        resourcePaths: ["/orders/{orderId}"],
+        handler: reportContext,
+      },
+      simAws,
+    );
+    await reporterRole(simAws, "*");
+
+    // When the handler reads its invocation event
+    const response = await get(simAws, restApi, "/orders/42", reporterArn);
+    const context = (await response.json()) as SimPayload1RequestContext;
+
+    // Then it can tell who called it and from which Account, which is the
+    // point of the authorization type for handler code
+    assertObjectMatches(context.identity, {
+      accountId,
+      caller: reporterArn,
+      user: reporterArn,
+      userArn: reporterArn,
+    });
+  });
+
+  it("names nobody in the identity of an open method", async () => {
+    // Given a method that authorizes nobody
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      { resourcePaths: ["/orders/{orderId}"], handler: reportContext },
+      simAws,
+    );
+
+    // When a request reaches the handler, caller header and all
+    const response = await get(simAws, restApi, "/orders/42", reporterArn);
+    const context = (await response.json()) as SimPayload1RequestContext;
+
+    // Then nothing authorized that caller, so the identity names no principal,
+    // and the fields are null rather than absent
+    assertIdentical(response.status, 200);
+    assertObjectMatches(context.identity, {
+      accountId: null,
+      caller: null,
+      user: null,
+      userArn: null,
+    });
+  });
+});

--- a/src/service/apigateway/serve/sim-rest-api-iam-signed.iso.test.ts
+++ b/src/service/apigateway/serve/sim-rest-api-iam-signed.iso.test.ts
@@ -1,0 +1,144 @@
+import {
+  CreateAccessKeyCommand,
+  CreateUserCommand,
+  PutUserPolicyCommand,
+} from "@aws-sdk/client-iam";
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { signAwsRequest } from "../../../../test/sigv4/sign-aws-request.js";
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { simAwsAuthHeaderName } from "../../../serve/http/response/sim-aws-response-hints.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import type { SimPayload1RequestContext } from "../../../serve/payload-1/sim-payload-1-event.type.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simIamPolicyDocumentFactory } from "../../iam/policy/sim-iam-policy-document.factory.js";
+import { simRestApiLambdaProxyFactory } from "../api/sim-rest-api-lambda-proxy.factory.js";
+import type { SimRestApi } from "../api/sim-rest-api.js";
+
+const accountId = "888888888888";
+
+/**
+ * A handler reporting its own requestContext, so a test can read the caller
+ * the signature was attributed to.
+ */
+const reportContext = (event: {
+  requestContext: SimPayload1RequestContext;
+}): unknown => ({
+  statusCode: 200,
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify(event.requestContext),
+});
+
+/**
+ * A User with one identity policy, and the access key it signs with.
+ */
+async function signingUser(
+  simAws: SimAws,
+  resource: string,
+): Promise<{ accessKeyId: string; secretAccessKey: string }> {
+  const iam = simAws.iam();
+  await iam.createUser(new CreateUserCommand({ UserName: "Reporter" }));
+  await iam.putUserPolicy(
+    new PutUserPolicyCommand({
+      UserName: "Reporter",
+      PolicyName: "InvokeOrders",
+      PolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: { Action: "execute-api:Invoke", Resource: resource },
+      }),
+    }),
+  );
+  const key = await iam.createAccessKey(
+    new CreateAccessKeyCommand({ UserName: "Reporter" }),
+  );
+
+  return {
+    accessKeyId: key.AccessKey.AccessKeyId,
+    secretAccessKey: key.AccessKey.SecretAccessKey,
+  };
+}
+
+/**
+ * Sign a request to a method of the API, for the `execute-api` service and the
+ * API's own Region, and serve it.
+ */
+async function signedGet(
+  simAws: SimAws,
+  restApi: SimRestApi,
+  path: string,
+  credentials: { accessKeyId: string; secretAccessKey: string },
+): Promise<Response> {
+  const signed = await signAwsRequest({
+    url: new SimAwsLocalUrl({
+      input: `${restApi.invokeUrl("prod")}${path}`,
+    }).toString(),
+    credentials,
+    service: "execute-api",
+    region: restApi.accountRegionScope.regionName,
+  });
+
+  return await new SimAwsHttp({ simAws }).handleRequest(signed.request);
+}
+
+async function iamRestApi(simAws: SimAws): Promise<SimRestApi> {
+  return await simRestApiLambdaProxyFactory.make(
+    {
+      iamAuthorization: true,
+      resourcePaths: ["/orders/{orderId}"],
+      handler: reportContext,
+    },
+    simAws,
+  );
+}
+
+describe("Calling an AWS_IAM sim REST API method with a signed request", () => {
+  it("admits a signed caller the API's Account allows", async () => {
+    // Given an AWS_IAM method and a User allowed to invoke it
+    const simAws = new SimAws();
+    const restApi = await iamRestApi(simAws);
+    const credentials = await signingUser(
+      simAws,
+      `arn:aws:execute-api:us-east-1:${accountId}:${restApi.apiId}` +
+        `/prod/GET/orders/*`,
+    );
+
+    // When they sign a request to the method and it is served
+    const response = await signedGet(
+      simAws,
+      restApi,
+      "/orders/42",
+      credentials,
+    );
+    const context = (await response.json()) as SimPayload1RequestContext;
+
+    // Then the signature identified them, and the handler was told who called
+    assertIdentical(response.status, 200);
+    assertIdentical(response.headers.get(simAwsAuthHeaderName), "sigv4");
+    assertIdentical(
+      context.identity.userArn,
+      `arn:aws:iam::${accountId}:user/Reporter`,
+    );
+  });
+
+  it("refuses a signed caller with no matching Allow", async () => {
+    // Given an AWS_IAM method and a User allowed another API entirely
+    const simAws = new SimAws();
+    const restApi = await iamRestApi(simAws);
+    const credentials = await signingUser(
+      simAws,
+      `arn:aws:execute-api:us-east-1:${accountId}:another01/*`,
+    );
+
+    // When they sign a request to the method and it is served
+    const response = await signedGet(
+      simAws,
+      restApi,
+      "/orders/42",
+      credentials,
+    );
+
+    // Then a valid signature is authentication rather than authorization, and
+    // the method stays closed to them
+    assertIdentical(response.status, 403);
+  });
+});

--- a/src/service/apigateway/serve/sim-rest-api-integration-invocation.ts
+++ b/src/service/apigateway/serve/sim-rest-api-integration-invocation.ts
@@ -66,7 +66,10 @@ export class SimRestApiIntegrationInvocation {
       const event = await this.eventBuilder.build(
         input.request,
         simRestApiEndpoint(input.restApi, input.match),
-        { lambda: input.authorization.lambda },
+        {
+          lambda: input.authorization.lambda,
+          caller: input.authorization.caller,
+        },
       );
       const result = await target.simFunction.invoke(event);
 

--- a/src/service/cloudformation/cdk/apigateway/sim-cdk-rest-api-iam-authorizer.loc.test.ts
+++ b/src/service/cloudformation/cdk/apigateway/sim-cdk-rest-api-iam-authorizer.loc.test.ts
@@ -1,0 +1,160 @@
+import {
+  CreateAccessKeyCommand,
+  CreateUserCommand,
+  PutUserPolicyCommand,
+} from "@aws-sdk/client-iam";
+import { assertIdentical, assertTypeString } from "@kensio/smartass";
+import path from "node:path";
+import { describe, it } from "vitest";
+
+/**
+ * Slower local integration test. Calls the real CDK CLI to synth the output
+ * template file, then serves the deployed REST API over real localhost HTTP
+ * and calls its IAM-authorized method with a SigV4-signed request.
+ */
+import { signAwsRequest } from "../../../../../test/sigv4/sign-aws-request.js";
+import { serveSimAws } from "../../../../serve/index.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
+import { TemporaryDirectory } from "../../../../util/filesystem/temporary-directory.js";
+import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+
+const accountId = "111111111111";
+
+/**
+ * Inline function code, as CDK packages Code.fromInline source. The handler
+ * reports the caller the method's authorization attributed the request to.
+ */
+const ordersHandlerSource = `
+exports.handler = async (event) => ({
+  statusCode: 200,
+  headers: { "content-type": "text/plain" },
+  body: event.requestContext.identity.userArn,
+});
+`;
+
+/**
+ * `AuthorizationType.IAM` emits the type alone on the Method. There is no
+ * AWS::ApiGateway::Authorizer Resource in the synthesised template at all,
+ * because IAM decides the method rather than a function of the API's.
+ */
+const cdkApp = `
+import * as cdk from "aws-cdk-lib/core";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as apigw from "aws-cdk-lib/aws-apigateway";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "${accountId}", region: "eu-west-2" },
+});
+
+const ordersFunction = new lambda.Function(stack, "OrdersFunction", {
+  functionName: "cdk-orders",
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: lambda.Code.fromInline(${JSON.stringify(ordersHandlerSource)}),
+});
+
+const api = new apigw.RestApi(stack, "OrdersApi", { restApiName: "orders" });
+
+api.root
+  .addResource("orders")
+  .addMethod("GET", new apigw.LambdaIntegration(ordersFunction), {
+    authorizationType: apigw.AuthorizationType.IAM,
+  });
+
+new cdk.CfnOutput(stack, "ApiUrl", { value: api.url });
+
+app.synth();
+`;
+
+/**
+ * A User allowed to invoke the deployed method, and the access key it signs
+ * with.
+ */
+async function signingUser(
+  simAws: SimAws,
+): Promise<{ accessKeyId: string; secretAccessKey: string }> {
+  const iam = simAws.iam();
+  await iam.createUser(new CreateUserCommand({ UserName: "Reporter" }));
+  await iam.putUserPolicy(
+    new PutUserPolicyCommand({
+      UserName: "Reporter",
+      PolicyName: "InvokeOrders",
+      PolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: {
+          Action: "execute-api:Invoke",
+          Resource: `arn:aws:execute-api:eu-west-2:${accountId}:*/prod/GET/orders`,
+        },
+      }),
+    }),
+  );
+  const key = await iam.createAccessKey(
+    new CreateAccessKeyCommand({ UserName: "Reporter" }),
+  );
+
+  return {
+    accessKeyId: key.AccessKey.AccessKeyId,
+    secretAccessKey: key.AccessKey.SecretAccessKey,
+  };
+}
+
+describe("Sim CDK REST API IAM authorization local integration", () => {
+  it("closes a CDK-deployed method to everyone IAM does not allow", async () => {
+    // Given a CDK stack whose one method is declared AuthorizationType.IAM
+    const simAws = new SimAws({
+      defaultAccountId: accountId as SimAwsAccountId,
+      defaultRegionName: "eu-west-2",
+    });
+    const projectDirectory = new TemporaryDirectory();
+    const cdkProject = new TestCdkProject({ projectDirectory });
+    await cdkProject.writeCdkAppFile(cdkApp);
+
+    // And we synth the CDK template.
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When we deploy the template into sim CloudFormation.
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+    await simAws.backgroundTasksComplete();
+
+    const apiUrl = stack.outputs.get("ApiUrl")?.value;
+    assertTypeString(apiUrl);
+
+    // And a User of the API's Account is allowed to invoke that one method.
+    const credentials = await signingUser(simAws);
+
+    const srv = await serveSimAws({ simAws });
+
+    try {
+      const url = srv.localUrl(`${apiUrl}orders`).toString();
+
+      // Then the deployed method is closed to a request carrying no identity.
+      const anonymous = await fetch(url);
+      assertIdentical(anonymous.status, 403);
+
+      // And a request that User signed reaches the handler, which read their
+      // ARN off the identity the method's authorization put in the event.
+      const signed = await signAwsRequest({
+        url,
+        credentials,
+        service: "execute-api",
+        region: "eu-west-2",
+      });
+      const reporter = await fetch(signed.request);
+      assertIdentical(reporter.status, 200);
+      assertIdentical(
+        await reporter.text(),
+        `arn:aws:iam::${accountId}:user/Reporter`,
+      );
+    } finally {
+      await srv.close();
+    }
+
+    await simAws.backgroundTasksComplete();
+  });
+});


### PR DESCRIPTION
PutMethod takes authorizationType AWS_IAM, and a method declared with it
reaches its integration only when the caller the serving boundary resolved is
allowed execute-api:Invoke on the ARN of the request being made. A signed
request and one naming a caller directly are attributed the same way, and a
request carrying neither is anonymous and gets a 403, as does a caller whose
policies cover another method of the same API. The admitted caller reaches the
handler under requestContext.identity, filling accountId, caller, user and
userArn, which stay null on a method of any other type. The method names no
authorizer, since IAM decides it. AWS::ApiGateway::Method deploys with
AuthorizationType AWS_IAM, and a CDK stack using AuthorizationType.IAM serves a
signed request end to end.

Resolves #793
