### PR TITLE
feat: gate a REST API method with a user pool

### DIFF
--- a/docs/services/apigateway/README.md
+++ b/docs/services/apigateway/README.md
@@ -770,6 +770,169 @@ called by a principal with no ARN behind it. `accessKey`, `apiKey`, `apiKeyId`, 
 the two Cognito identity pool fields are `null` throughout. `sourceIp` and `userAgent` describe the
 request itself and are filled for every method.
 
+## Authorizing a method with a user pool
+
+A `COGNITO_USER_POOLS` authorizer verifies the token itself against the keys the user pools it names
+publish. Nothing is invoked, so there is no function to write and no policy to answer.
+`CreateAuthorizerCommand` takes the pools as `providerARNs`, and `PutMethodCommand` binds the
+authorizer to a method with `authorizationType: "COGNITO_USER_POOLS"`.
+
+```typescript sim-apigateway-cognito-authorizer
+/**
+ * Gating a REST API method with a Cognito user pool authorizer.
+ *
+ * The authorizer verifies the token against the keys the pool publishes, and
+ * the token's own claims reach the handler under `requestContext.authorizer`.
+ */
+
+import {
+  AdminCreateUserCommand,
+  AdminInitiateAuthCommand,
+  AdminSetUserPasswordCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+import { simRestApiLambdaProxyFactory } from "@kensio/yulin/apigateway";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const cognito = simAws.cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+);
+const UserPoolId = pool.UserPool!.Id!;
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId,
+    ClientName: "web",
+    ExplicitAuthFlows: ["ALLOW_ADMIN_USER_PASSWORD_AUTH"],
+  }),
+);
+const ClientId = appClient.UserPoolClient!.ClientId!;
+
+await cognito.adminCreateUser(
+  new AdminCreateUserCommand({ UserPoolId, Username: "ada" }),
+);
+await cognito.adminSetUserPassword(
+  new AdminSetUserPasswordCommand({
+    UserPoolId,
+    Username: "ada",
+    Password: "Correct-horse-1",
+    Permanent: true,
+  }),
+);
+
+const restApi = await simRestApiLambdaProxyFactory.make(
+  {
+    resourcePaths: ["/orders"],
+    cognitoUserPoolArns: [pool.UserPool!.Arn!],
+    handler: (event) => ({
+      statusCode: 200,
+      headers: { "content-type": "text/plain" },
+      body: `orders for ${
+        event.requestContext.authorizer?.claims?.["cognito:username"] ??
+        "nobody"
+      }`,
+    }),
+  },
+  simAws,
+);
+
+const signedIn = await cognito.adminInitiateAuth(
+  new AdminInitiateAuthCommand({
+    UserPoolId,
+    ClientId,
+    AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+    AuthParameters: { USERNAME: "ada", PASSWORD: "Correct-horse-1" },
+  }),
+);
+const idToken = signedIn.AuthenticationResult!.IdToken!;
+
+const srv = await serveSimAws({ simAws });
+const url = srv.localUrl(`${restApi.invokeUrl("prod")}/orders`);
+
+const anonymous = await fetch(url);
+
+console.log(anonymous.status);
+// 401
+
+const authorized = await fetch(url, { headers: { authorization: idToken } });
+
+console.log(await authorized.text());
+// "orders for ada"
+
+// Advancing the simulation's clock past the token's expiry closes the method
+// to the same token, with nothing reissued.
+await simAws.clock().advanceBy({ hours: 2 });
+
+const expired = await fetch(url, { headers: { authorization: idToken } });
+
+console.log(expired.status);
+// 401
+
+await srv.close();
+```
+
+`simRestApiLambdaProxyFactory` builds the authorizer and the methods bound to it when it is given
+`cognitoUserPoolArns`.
+
+A `providerARN` is read for the pool id it names, and the pool is looked up across every simulated
+account. The token is accepted when any one of the named pools signed it, its `iss` names that same
+pool, and its time claims hold against the simulation's clock. Advancing the clock past a token's
+`exp` therefore closes a method that was open to it.
+
+### The claims the handler receives
+
+The token's own claims reach the handler under `requestContext.authorizer.claims`, and every value
+arrives as a string. A list claim such as `cognito:groups` is rendered the way Go prints a slice, so
+two groups arrive as `[Admins Readers]`.
+
+```json
+{
+  "claims": {
+    "sub": "5c4a5f6c-6c31-4a2e-9a55-2c4dcb8f2f4f",
+    "cognito:username": "ada",
+    "cognito:groups": "[Admins Readers]",
+    "iss": "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_aBcDeFgHi",
+    "token_use": "id"
+  }
+}
+```
+
+An HTTP API puts the same claims under `requestContext.authorizer.jwt.claims`, with the scopes
+beside them, so a handler moved between the two reads a different shape.
+
+### Scopes
+
+`authorizationScopes` on the method is met by any one of the scopes the token's `scope` claim
+carries. The scopes are the method's own, so one authorizer covers methods asking for different
+ones.
+
+A method asking for no scope takes an id token and an access token alike, because `token_use` is not
+checked, which is what real API Gateway does. A method asking for a scope takes only an access
+token, since an id token carries no `scope` claim at all.
+
+### What a refused request gets back
+
+| Case                                                       | Answer                                               |
+| ---------------------------------------------------------- | ---------------------------------------------------- |
+| No value at the identity source                            | 401 `Unauthorized`                                   |
+| A value that is not a readable JWT                         | 401 `Unauthorized`                                   |
+| A token no named pool signed, or one signed by another key | 401 `Unauthorized`                                   |
+| A token that has expired, or has no `exp` at all           | 401 `Unauthorized`                                   |
+| A verified token claiming none of the method's scopes      | 403 `User is not authorized to access this resource` |
+
+Every refusal up to and including the claim checks is the same 401, so a client learns that its
+token was not accepted and nothing about which check it failed. An unmet scope is the one 403: the
+token was accepted, and it does not allow this method.
+
+The token is taken with or without the `Bearer` scheme in front of it. The identity source is one
+header, as it is for a `TOKEN` authorizer.
+
 ## Intercepting an SDK client
 
 `SimSdk` routes `@aws-sdk/client-api-gateway` commands to the simulation. Code under test builds its
@@ -1180,9 +1343,9 @@ behaves differently to the template. The simulated properties are:
 - `RestApi`: `Name`, `Description`, `DisableExecuteApiEndpoint`, `Body`, `FailOnWarnings`
 - `Resource`: `RestApiId`, `ParentId`, `PathPart`
 - `Method`: `RestApiId`, `ResourceId`, `HttpMethod`, `AuthorizationType`, `AuthorizerId`,
-  `ApiKeyRequired`, `OperationName`, `Integration`
+  `AuthorizationScopes`, `ApiKeyRequired`, `OperationName`, `Integration`
 - A method's `Integration` block: `Type`, `IntegrationHttpMethod`, `Uri`
-- `Authorizer`: `RestApiId`, `Name`, `Type`, `AuthorizerUri`, `IdentitySource`
+- `Authorizer`: `RestApiId`, `Name`, `Type`, `AuthorizerUri`, `ProviderARNs`, `IdentitySource`
 - `Deployment`: `RestApiId`, `Description`, `StageName`
 - `Stage`: `RestApiId`, `DeploymentId`, `StageName`, `Description`, `Variables`
 
@@ -1244,6 +1407,10 @@ writes for its own function. Give either one `resultsCacheTtl: Duration.seconds(
 holds a decision for five minutes by default and `AuthorizerResultTtlInSeconds` is one of the
 recorded properties.
 
+`CognitoUserPoolsAuthorizer` deploys as it stands, naming the pools it was given by ARN. A method
+takes it with `authorizationType: apigateway.AuthorizationType.COGNITO`, and a user pool the same
+stack declares is reached through the `Fn::GetAtt` on its ARN that CDK writes.
+
 CDK also writes an `AWS::ApiGateway::Account` and a CloudWatch role beside a default `RestApi`.
 Neither is simulated. The `Account` Resource is recorded in
 [`stack.skippedResources`](../cloudformation/README.md#inspecting-stacks-and-resources) and the rest of the
@@ -1270,14 +1437,16 @@ nothing on real AWS.
 An input outside what this simulates is refused. Dropping it would let a request look applied here
 and behave differently deployed. The refusals worth knowing about:
 
-- **Authorizer kinds.** `TOKEN` and `REQUEST` are the two simulated. A `COGNITO_USER_POOLS`
-  authorizer is refused by `CreateAuthorizer`, and a `COGNITO_USER_POOLS` method by `PutMethod`.
-  That is a separate piece of work. An `AWS_IAM` method is decided by IAM and names no authorizer.
-  See [Protecting a method with IAM](#protecting-a-method-with-iam).
+- **Authorizer kinds.** `CreateAuthorizer` takes `TOKEN`, `REQUEST` and `COGNITO_USER_POOLS`, which
+  is every kind a REST API has. The `JWT` authorizer an HTTP API takes is the v2 service's and is
+  refused here. An `AWS_IAM` method is decided by IAM and names no authorizer. See
+  [Protecting a method with IAM](#protecting-a-method-with-iam).
 - **Identity source expressions.** A `REQUEST` authorizer reads
   `method.request.header.<name>` and `method.request.querystring.<name>`. AWS also allows
   `method.request.path`, `context` and `stageVariables`, and each is refused by
   `CreateAuthorizer`.
+- **Scopes on a method that checks none.** `authorizationScopes` is refused on a method that is not
+  `COGNITO_USER_POOLS`, since a method carrying scopes nothing checks reads as gated by them.
 - **Holding an authorizer's decision.** `authorizerResultTtlInSeconds` is refused. The function is
   invoked once per request reaching the method.
 - **Integration types.** Only `AWS_PROXY` with a Lambda function URI is simulated. `MOCK`, `HTTP`,
@@ -1317,6 +1486,9 @@ and `Stage`, including the template CDK synthesizes from a `RestApi` or a `Lambd
   that is the form the platform's `Headers` hands over. Real API Gateway reports each separately.
 - A Lambda authorizer's `context` reaches the handler as the authorizer returned it. AWS accepts a
   string, a number or a boolean for each value, and how it renders them is not published.
+- A Cognito authorizer reads a `providerARN` for the pool id it names, so a pool in another account
+  is verified against whenever this simulation holds it. `identityValidationExpression`, which real
+  API Gateway matches a token against before verifying it, is outside this.
 - Binary media types negotiated by `Accept`, CORS preflight and gateway responses are outside this.
   A response body is still base64 decoded when the handler says `isBase64Encoded`.
 - WebSocket APIs are outside this and outside the v2 service.

--- a/docs/services/apigateway/sim-apigateway-cognito-authorizer.example.ts
+++ b/docs/services/apigateway/sim-apigateway-cognito-authorizer.example.ts
@@ -1,0 +1,97 @@
+/**
+ * Gating a REST API method with a Cognito user pool authorizer.
+ *
+ * The authorizer verifies the token against the keys the pool publishes, and
+ * the token's own claims reach the handler under `requestContext.authorizer`.
+ */
+
+import {
+  AdminCreateUserCommand,
+  AdminInitiateAuthCommand,
+  AdminSetUserPasswordCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+import { simRestApiLambdaProxyFactory } from "@kensio/yulin/apigateway";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const cognito = simAws.cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+);
+const UserPoolId = pool.UserPool!.Id!;
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId,
+    ClientName: "web",
+    ExplicitAuthFlows: ["ALLOW_ADMIN_USER_PASSWORD_AUTH"],
+  }),
+);
+const ClientId = appClient.UserPoolClient!.ClientId!;
+
+await cognito.adminCreateUser(
+  new AdminCreateUserCommand({ UserPoolId, Username: "ada" }),
+);
+await cognito.adminSetUserPassword(
+  new AdminSetUserPasswordCommand({
+    UserPoolId,
+    Username: "ada",
+    Password: "Correct-horse-1",
+    Permanent: true,
+  }),
+);
+
+const restApi = await simRestApiLambdaProxyFactory.make(
+  {
+    resourcePaths: ["/orders"],
+    cognitoUserPoolArns: [pool.UserPool!.Arn!],
+    handler: (event) => ({
+      statusCode: 200,
+      headers: { "content-type": "text/plain" },
+      body: `orders for ${
+        event.requestContext.authorizer?.claims?.["cognito:username"] ??
+        "nobody"
+      }`,
+    }),
+  },
+  simAws,
+);
+
+const signedIn = await cognito.adminInitiateAuth(
+  new AdminInitiateAuthCommand({
+    UserPoolId,
+    ClientId,
+    AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+    AuthParameters: { USERNAME: "ada", PASSWORD: "Correct-horse-1" },
+  }),
+);
+const idToken = signedIn.AuthenticationResult!.IdToken!;
+
+const srv = await serveSimAws({ simAws });
+const url = srv.localUrl(`${restApi.invokeUrl("prod")}/orders`);
+
+const anonymous = await fetch(url);
+
+console.log(anonymous.status);
+// 401
+
+const authorized = await fetch(url, { headers: { authorization: idToken } });
+
+console.log(await authorized.text());
+// "orders for ada"
+
+// Advancing the simulation's clock past the token's expiry closes the method
+// to the same token, with nothing reissued.
+await simAws.clock().advanceBy({ hours: 2 });
+
+const expired = await fetch(url, { headers: { authorization: idToken } });
+
+console.log(expired.status);
+// 401
+
+await srv.close();

--- a/src/serve/payload-1/sim-payload-1-event.type.ts
+++ b/src/serve/payload-1/sim-payload-1-event.type.ts
@@ -36,6 +36,32 @@ export interface SimPayload1LambdaAuthorizer {
 }
 
 /**
+ * What a `COGNITO_USER_POOLS` method's authorizer passed on to the handler.
+ *
+ * The claims are the accepted token's own, and every value arrives as a
+ * string. A REST API sends them alone, where payload format 2.0 puts the
+ * scopes beside them.
+ */
+export interface SimPayload1CognitoAuthorizer {
+  claims: Record<string, string>;
+}
+
+/**
+ * What the method's authorizer knows about the caller, whichever kind of
+ * authorizer ran.
+ *
+ * One block carries both kinds, as the event itself does: `principalId` and
+ * the flattened context beside it are a Lambda authorizer's, and `claims` is a
+ * Cognito one's. A handler reads whichever its own method has, and a method
+ * that authorizes nobody has no block at all.
+ */
+export interface SimPayload1Authorizer {
+  principalId?: string;
+  claims?: Record<string, string>;
+  [contextKey: string]: unknown;
+}
+
+/**
  * What payload format 1.0 says about the request beyond the request itself.
  */
 export interface SimPayload1RequestContext {
@@ -45,7 +71,7 @@ export interface SimPayload1RequestContext {
    * What the method's authorizer knows about the caller. It is absent on a
    * method that authorizes nobody, which is what real API Gateway sends.
    */
-  authorizer?: SimPayload1LambdaAuthorizer;
+  authorizer?: SimPayload1Authorizer;
   domainName: string;
   domainPrefix: string;
   extendedRequestId: string;

--- a/src/serve/payload-1/sim-payload-1-request-context.ts
+++ b/src/serve/payload-1/sim-payload-1-request-context.ts
@@ -5,6 +5,7 @@ import { simProxyEventTime } from "../proxy/sim-proxy-event-time.js";
 import type { SimPayload1Endpoint } from "./sim-payload-1-endpoint.js";
 import { SimPayload1IamCaller } from "./sim-payload-1-iam-caller.js";
 import type {
+  SimPayload1CognitoAuthorizer,
   SimPayload1Identity,
   SimPayload1LambdaAuthorizer,
   SimPayload1RequestContext,
@@ -14,7 +15,7 @@ import type {
  * What the endpoint's authorization knows about the caller, if it authorized
  * one.
  *
- * A method admitting anybody supplies neither, which is what leaves the
+ * A method admitting anybody supplies none of them, which is what leaves the
  * authorizer block out of the event and every identity field describing a
  * principal `null`.
  */
@@ -23,6 +24,8 @@ export interface SimPayload1Authorization {
   readonly lambda?: SimPayload1LambdaAuthorizer | undefined;
   /** The caller an `AWS_IAM` method allowed the request. */
   readonly caller?: SimAwsRequestCaller | undefined;
+  /** The claims of the token a Cognito authorizer accepted. */
+  readonly cognito?: SimPayload1CognitoAuthorizer | undefined;
 }
 
 interface SimPayload1RequestContextInput {
@@ -68,10 +71,13 @@ export class SimPayload1RequestContextBuilder {
       stage: endpoint.stage,
     };
 
-    const { lambda } = input.authorization ?? {};
+    const { lambda, cognito } = input.authorization ?? {};
+    const authorizer = lambda ?? cognito;
 
-    if (lambda !== undefined) {
-      requestContext.authorizer = lambda;
+    if (authorizer !== undefined) {
+      // Copied rather than carried over, so the one block a handler reads
+      // holds whichever kind of authorizer ran.
+      requestContext.authorizer = { ...authorizer };
     }
 
     return requestContext;

--- a/src/service/apigateway/README.md
+++ b/src/service/apigateway/README.md
@@ -95,14 +95,16 @@ The client's own authorization runs first. A request presenting no credentials i
 not the integration behind the method would have worked. Whether the API may invoke a function is a
 separate question, asked afterwards, and it is the API's rather than the client's.
 
-`serve/auth/` holds the authorization types, one decider each:
+`serve/auth/` holds the authorization types, and the pieces under each are the ones that type needs:
 
 ```text
-SimRestApiMethodAuthorizer            which type the method asks for
-├── SimRestApiIamMethodAuthorizer     the caller, put to IAM against the method ARN
-└── SimRestApiAuthorizerInvocation    the invoke permission, the event, the answer
-    ├── SimRestApiAuthorizerResponse  the principal, the context, the policy
-    └── SimRestApiAuthorizerPolicy    that policy, put to IAM against the method ARN
+SimRestApiMethodAuthorizer                which type the method asks for
+├── SimRestApiIamMethodAuthorizer         AWS_IAM: the caller, put to IAM against the method ARN
+├── SimRestApiAuthorizerInvocation        CUSTOM: the invoke permission, the event, the answer
+│   ├── SimRestApiAuthorizerResponse      the principal, the context, the policy
+│   └── SimRestApiAuthorizerPolicy        that policy, put to IAM against the method ARN
+└── SimRestApiCognitoMethodAuthorizer     COGNITO_USER_POOLS: the authorizer and the token
+    └── SimRestApiCognitoVerification     the key, the signature, the claims, the scopes
 ```
 
 An `AWS_IAM` method asks the IAM of the Account that owns the API about the caller the serving
@@ -117,6 +119,17 @@ payload format 1.0 event. Everything downstream of the answer is shared.
 `api/authorizer/identity/` reads the identity source expressions. A REST API writes them as one
 comma-separated string where an HTTP API takes a list, so the splitting lives here and the
 per-expression parsing mirrors `apigatewayv2/api/authorizer/identity/`.
+
+A `COGNITO_USER_POOLS` method invokes nothing and asks nothing. It verifies the token against the
+keys the pools its authorizer names publish, which it reaches through the `SimRestApiUserPools` port
+on the API. `SimCognitoRestApiUserPools` is the implementation reading simulated Cognito, and a
+standalone `SimApiGateway` gets `SimRestApiNoUserPools` so a gated method stays closed rather than
+admitting a token it could not check. The same split is in `../apigatewayv2/` for a JWT authorizer's
+issuer keys, and the JWT mechanics both use are in `src/util/jwt/`.
+
+`SimRestApiAuthorizer` is the base the three kinds share, holding the id, the name and the view.
+`SimRestApiLambdaAuthorizer` covers `TOKEN` and `REQUEST`, which differ only in the event, and
+`SimRestApiCognitoAuthorizer` names pools where that one names a function.
 
 The method ARN is the one part with no HTTP API equivalent worth copying. A REST API authorizer is
 handed the ARN of the request the client made, with the concrete path in it, and the policy it
@@ -218,10 +231,11 @@ type other than `AWS_PROXY` are all refused there, so a request naming one fails
 been applied on real AWS.
 
 Authorization is refused the same way, in the two commands that carry it.
-`CreateAuthorizer` takes `TOKEN` and refuses the other two kinds, and `PutMethod` takes `NONE`,
-`CUSTOM` and `AWS_IAM` and refuses `COGNITO_USER_POOLS`. A method served open where AWS would have
-gated it lets a test pass on a request real AWS rejects, so a template asking for one of them fails
-to deploy rather than deploying around it.
+`CreateAuthorizer` takes `TOKEN` and `COGNITO_USER_POOLS` and refuses `REQUEST`, and `PutMethod`
+takes all four of its types. A method served open where AWS would have gated it lets a test pass on
+a request real AWS rejects, so a template asking for a type nothing enforces fails to deploy rather
+than deploying around it. A method naming an authorizer of the other kind is refused for the same
+reason.
 
 An imported document meets those refusals through the commands, and `openapi/` adds the ones about
 members no command sees. A document-level `security`, an operation's `security`, a Swagger 2

--- a/src/service/apigateway/api/authorizer/identity/sim-rest-api-identity-source-parser.ts
+++ b/src/service/apigateway/api/authorizer/identity/sim-rest-api-identity-source-parser.ts
@@ -1,4 +1,5 @@
 import { SimApiGatewayBadRequest } from "../../../error/sim-api-gateway.error.js";
+import type { SimRestApiAuthorizerType } from "../sim-rest-api-authorizer.js";
 import {
   SimRestApiHeaderIdentitySource,
   simRestApiHeaderIdentityPrefix,
@@ -25,18 +26,22 @@ const httpFieldName = /^[!#$%&'*+.^_`|~\w-]+$/u;
  * `method.request.path`, `context` and `stageVariables`, which a `REQUEST`
  * authorizer may also name on AWS.
  *
- * A `TOKEN` authorizer reads one header and nothing else, which is the rule
- * real API Gateway holds one to, so it parses with `header`.
+ * A `TOKEN` and a `COGNITO_USER_POOLS` authorizer each read one header and
+ * nothing else, which is the rule real API Gateway holds both to, so they
+ * parse with `header`.
  */
 export class SimRestApiIdentitySourceParser {
   /**
-   * Read the one header a `TOKEN` authorizer takes its token from.
+   * Read the one header an authorizer of this kind takes its token from.
    */
-  header(expression: string): SimRestApiIdentitySource {
+  header(
+    expression: string,
+    authorizerType: SimRestApiAuthorizerType,
+  ): SimRestApiIdentitySource {
     if (!expression.startsWith(simRestApiHeaderIdentityPrefix)) {
       throw new SimApiGatewayBadRequest(
-        `identitySource '${expression}' is not simulated: a TOKEN ` +
-          `authorizer reads one header, written as ` +
+        `identitySource '${expression}' is not simulated: a ` +
+          `${authorizerType} authorizer reads one header, written as ` +
           `'${simRestApiHeaderIdentityPrefix}<name>'`,
       );
     }

--- a/src/service/apigateway/api/authorizer/identity/sim-rest-api-identity-sources.ts
+++ b/src/service/apigateway/api/authorizer/identity/sim-rest-api-identity-sources.ts
@@ -28,7 +28,9 @@ export class SimRestApiIdentitySources {
    * Read the one header a `TOKEN` authorizer takes its token from.
    */
   static token(identitySource: string): SimRestApiIdentitySources {
-    return new SimRestApiIdentitySources([parser.header(identitySource)]);
+    return new SimRestApiIdentitySources([
+      parser.header(identitySource, "TOKEN"),
+    ]);
   }
 
   /**

--- a/src/service/apigateway/api/authorizer/sim-cognito-rest-api-user-pools.ts
+++ b/src/service/apigateway/api/authorizer/sim-cognito-rest-api-user-pools.ts
@@ -1,0 +1,43 @@
+import { SimJwtKeys } from "../../../../util/jwt/sim-jwt-keys.js";
+import type { SimCognitoUserPoolRegistry } from "../../../cognito/registry/sim-cognito-user-pool-registry.js";
+import type {
+  SimRestApiUserPool,
+  SimRestApiUserPools,
+} from "./sim-rest-api-user-pools.js";
+
+interface SimCognitoRestApiUserPoolsProperties {
+  readonly userPoolRegistry: SimCognitoUserPoolRegistry;
+}
+
+/**
+ * Simulated Cognito user pools as the pools a REST API authorizer verifies
+ * against.
+ *
+ * All of the Cognito lookup lives here rather than in API Gateway, which knows
+ * only that an authorizer names pools by id. The registry spans simulated
+ * Accounts, matching an API Gateway authorizer that can name a pool in any
+ * Account.
+ */
+export class SimCognitoRestApiUserPools implements SimRestApiUserPools {
+  private readonly userPoolRegistry: SimCognitoUserPoolRegistry;
+
+  constructor(properties: SimCognitoRestApiUserPoolsProperties) {
+    this.userPoolRegistry = properties.userPoolRegistry;
+  }
+
+  /**
+   * The pool this id names, in whichever Account and Region created it.
+   */
+  find(userPoolId: string): SimRestApiUserPool | undefined {
+    const pool = this.userPoolRegistry.find(userPoolId);
+
+    if (pool === undefined) {
+      return undefined;
+    }
+
+    return {
+      issuerUrl: pool.issuerUrl,
+      keys: new SimJwtKeys(pool.jwks().keys),
+    };
+  }
+}

--- a/src/service/apigateway/api/authorizer/sim-rest-api-authorization.ts
+++ b/src/service/apigateway/api/authorizer/sim-rest-api-authorization.ts
@@ -1,4 +1,7 @@
-import type { SimPayload1LambdaAuthorizer } from "../../../../serve/payload-1/sim-payload-1-event.type.js";
+import type {
+  SimPayload1CognitoAuthorizer,
+  SimPayload1LambdaAuthorizer,
+} from "../../../../serve/payload-1/sim-payload-1-event.type.js";
 import type { SimAwsRequestCaller } from "../../../iam/request/sim-aws-request-caller.js";
 
 /**
@@ -24,13 +27,18 @@ interface SimRestApiAdmittedProperties {
   readonly lambda?: SimPayload1LambdaAuthorizer | undefined;
   /** The principal an `AWS_IAM` method allowed the request. */
   readonly caller?: SimAwsRequestCaller | undefined;
+  /**
+   * The claims of the token a `COGNITO_USER_POOLS` method's authorizer
+   * accepted.
+   */
+  readonly cognito?: SimPayload1CognitoAuthorizer | undefined;
 }
 
 /**
  * A request the method admitted, and what its authorization knows about the
  * caller.
  *
- * Both members are absent on a method that authorizes nobody, since there is
+ * Every member is absent on a method that authorizes nobody, since there is
  * no caller to describe. That is what leaves `requestContext.authorizer` out of
  * the event entirely and every `requestContext.identity` field describing a
  * principal `null`. Which one is present says which kind of authorization
@@ -40,10 +48,12 @@ export class SimRestApiAdmitted {
   public readonly admitted = true as const;
   public readonly lambda: SimPayload1LambdaAuthorizer | undefined;
   public readonly caller: SimAwsRequestCaller | undefined;
+  public readonly cognito: SimPayload1CognitoAuthorizer | undefined;
 
   constructor(properties: SimRestApiAdmittedProperties = {}) {
     this.lambda = properties.lambda;
     this.caller = properties.caller;
+    this.cognito = properties.cognito;
   }
 }
 

--- a/src/service/apigateway/api/authorizer/sim-rest-api-authorizer.ts
+++ b/src/service/apigateway/api/authorizer/sim-rest-api-authorizer.ts
@@ -1,8 +1,6 @@
 import { faker } from "@faker-js/faker";
 
 import type { Brand } from "../../../../util/brand.type.js";
-import type { SimRestApiLambdaUri } from "../method/sim-rest-api-lambda-uri.js";
-import type { SimRestApiIdentitySources } from "./identity/sim-rest-api-identity-sources.js";
 
 /**
  * The id API Gateway allocates for one authorizer.
@@ -10,25 +8,31 @@ import type { SimRestApiIdentitySources } from "./identity/sim-rest-api-identity
 export type SimRestApiAuthorizerId = Brand<string, "SimRestApiAuthorizerId">;
 
 /**
- * The kinds of authorizer a REST API has, of which two are simulated.
+ * The kinds of authorizer a REST API has.
  *
  * A `TOKEN` authorizer sends one header's value to a Lambda function. A
  * `REQUEST` authorizer sends the whole request to one instead, so it can
  * identify a caller by several headers together or by the query string. Both
- * do what the policy that function answers with says.
- *
- * `COGNITO_USER_POOLS` is a separate piece of work, and an authorizer asking
- * for it is refused rather than created as something else.
+ * do what the policy that function answers with says. A `COGNITO_USER_POOLS`
+ * authorizer invokes nothing and verifies the token against the user pools it
+ * names.
  */
-export type SimRestApiAuthorizerType = "TOKEN" | "REQUEST";
+export type SimRestApiAuthorizerType =
+  | "TOKEN"
+  | "REQUEST"
+  | "COGNITO_USER_POOLS";
 
 /**
- * What `GetAuthorizer` reports for the family an authorizer belongs to.
+ * What `GetAuthorizer` reports for the family a Lambda authorizer belongs to.
  *
- * A `TOKEN` or `REQUEST` authorizer is `custom`, and a Cognito one is
- * `cognito_user_pools`.
+ * A `TOKEN` or `REQUEST` authorizer is `custom`.
  */
 export const simRestApiCustomAuthType = "custom";
+
+/**
+ * What `GetAuthorizer` reports for the family a Cognito authorizer belongs to.
+ */
+export const simRestApiCognitoAuthType = "cognito_user_pools";
 
 /**
  * Allocate an authorizer id, in the same opaque shape as a resource id.
@@ -39,78 +43,50 @@ export function makeSimRestApiAuthorizerId(): SimRestApiAuthorizerId {
 
 /**
  * Minimal structural authorizer view, as the Create and Get commands return.
+ *
+ * `authorizerUri` and `providerARNs` belong to one kind of authorizer each, so
+ * each view carries the one its kind has.
  */
 export interface SimRestApiAuthorizerView {
   id: string;
   name: string;
   type: SimRestApiAuthorizerType;
   authType: string;
-  authorizerUri: string;
   identitySource: string;
+  authorizerUri?: string;
+  providerARNs?: string[];
 }
 
 interface SimRestApiAuthorizerProperties {
   readonly authorizerId: SimRestApiAuthorizerId;
   readonly name: string;
-  readonly type: SimRestApiAuthorizerType;
-  readonly lambdaUri: SimRestApiLambdaUri;
-  readonly identitySources: SimRestApiIdentitySources;
 }
 
 /**
- * A simulated REST API Lambda authorizer: the function a method sends a
- * request to before it reaches the integration.
+ * A simulated REST API authorizer: what a method sends a request through
+ * before it reaches the integration.
  *
  * An authorizer belongs to an API and is attached to methods by id, so one
- * authorizer covers as many methods of the API as name it.
- *
- * The function decides, so nothing here says what a caller has to present.
- * All this holds is which function to invoke, what the request has to carry
- * before it is worth invoking, and how much of the request that function is
- * shown.
+ * authorizer covers as many methods of the API as name it. What it does with
+ * a request is its kind's business, and that is all the subclasses are.
  */
-export class SimRestApiAuthorizer {
+export abstract class SimRestApiAuthorizer {
   public readonly authorizerId: SimRestApiAuthorizerId;
   public readonly name: string;
 
   /**
-   * How much of the request the function sees, which is the whole difference
-   * between the two kinds.
+   * Which kind of authorizer this is, which is also what decides whether a
+   * method may name it.
    */
-  public readonly type: SimRestApiAuthorizerType;
+  public abstract readonly type: SimRestApiAuthorizerType;
 
-  /**
-   * The Lambda function this authorizer invokes, read from its
-   * `authorizerUri`.
-   */
-  public readonly lambdaUri: SimRestApiLambdaUri;
-
-  /**
-   * Where the request has to carry something for the function to be invoked at
-   * all. A `TOKEN` authorizer has exactly one, and its value is the token the
-   * function is invoked with.
-   */
-  public readonly identitySources: SimRestApiIdentitySources;
-
-  constructor(properties: SimRestApiAuthorizerProperties) {
+  protected constructor(properties: SimRestApiAuthorizerProperties) {
     this.authorizerId = properties.authorizerId;
     this.name = properties.name;
-    this.type = properties.type;
-    this.lambdaUri = properties.lambdaUri;
-    this.identitySources = properties.identitySources;
   }
 
   /**
    * Get the AWS-like view of this authorizer.
    */
-  view(): SimRestApiAuthorizerView {
-    return {
-      id: this.authorizerId,
-      name: this.name,
-      type: this.type,
-      authType: simRestApiCustomAuthType,
-      authorizerUri: this.lambdaUri.uri,
-      identitySource: this.identitySources.expression,
-    };
-  }
+  abstract view(): SimRestApiAuthorizerView;
 }

--- a/src/service/apigateway/api/authorizer/sim-rest-api-cognito-authorizer.ts
+++ b/src/service/apigateway/api/authorizer/sim-rest-api-cognito-authorizer.ts
@@ -1,0 +1,64 @@
+import type { SimRestApiIdentitySource } from "./identity/sim-rest-api-identity-source.js";
+import {
+  SimRestApiAuthorizer,
+  type SimRestApiAuthorizerId,
+  type SimRestApiAuthorizerView,
+  simRestApiCognitoAuthType,
+} from "./sim-rest-api-authorizer.js";
+import type { SimRestApiUserPoolProviders } from "./sim-rest-api-user-pool-providers.js";
+
+interface SimRestApiCognitoAuthorizerProperties {
+  readonly authorizerId: SimRestApiAuthorizerId;
+  readonly name: string;
+  readonly providers: SimRestApiUserPoolProviders;
+  readonly identitySource: SimRestApiIdentitySource;
+}
+
+/**
+ * A simulated REST API `COGNITO_USER_POOLS` authorizer: the user pools whose
+ * tokens a method admits.
+ *
+ * Nothing is invoked for a request. The authorizer verifies the token itself
+ * against the keys the pools publish, which is why it names pools where a
+ * Lambda authorizer names a function.
+ *
+ * What a token has to carry beyond a signature one of those pools made is the
+ * method's business rather than this one's: the scopes a method asks for are
+ * declared on the method, so one authorizer covers methods asking for
+ * different scopes.
+ */
+export class SimRestApiCognitoAuthorizer extends SimRestApiAuthorizer {
+  public readonly type = "COGNITO_USER_POOLS" as const;
+
+  /**
+   * The user pools this authorizer accepts tokens from, read from its
+   * `providerARNs`.
+   */
+  public readonly providers: SimRestApiUserPoolProviders;
+
+  /**
+   * The header carrying the token, which is where the request is read from.
+   * There is one, as there is for a `TOKEN` authorizer.
+   */
+  public readonly identitySource: SimRestApiIdentitySource;
+
+  constructor(properties: SimRestApiCognitoAuthorizerProperties) {
+    super(properties);
+    this.providers = properties.providers;
+    this.identitySource = properties.identitySource;
+  }
+
+  /**
+   * Get the AWS-like view of this authorizer.
+   */
+  view(): SimRestApiAuthorizerView {
+    return {
+      id: this.authorizerId,
+      name: this.name,
+      type: this.type,
+      authType: simRestApiCognitoAuthType,
+      providerARNs: [...this.providers.arns],
+      identitySource: this.identitySource.expression,
+    };
+  }
+}

--- a/src/service/apigateway/api/authorizer/sim-rest-api-cognito-verification.iso.test.ts
+++ b/src/service/apigateway/api/authorizer/sim-rest-api-cognito-verification.iso.test.ts
@@ -1,0 +1,237 @@
+import {
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimFixedClock } from "../../../../util/clock/sim-clock.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimCognitoUserPoolRegistry } from "../../../cognito/registry/sim-cognito-user-pool-registry.js";
+import { simCognitoSignedInFactory } from "../../../cognito/user-pool/auth/sim-cognito-signed-in.factory.js";
+import { SimRestApiMethodScopes } from "../method/sim-rest-api-method-scopes.js";
+import { SimCognitoRestApiUserPools } from "./sim-cognito-rest-api-user-pools.js";
+import { makeSimRestApiAuthorizerId } from "./sim-rest-api-authorizer.js";
+import { SimRestApiAdmitted } from "./sim-rest-api-authorization.js";
+import { SimRestApiCognitoAuthorizer } from "./sim-rest-api-cognito-authorizer.js";
+import { SimRestApiCognitoVerification } from "./sim-rest-api-cognito-verification.js";
+import { SimRestApiIdentitySourceParser } from "./identity/sim-rest-api-identity-source-parser.js";
+import { SimRestApiUserPoolProviders } from "./sim-rest-api-user-pool-providers.js";
+import { SimRestApiNoUserPools } from "./sim-rest-api-user-pools.js";
+
+const now = new Date("2026-08-02T12:00:00.000Z");
+const nowSeconds = Math.floor(now.getTime() / 1000);
+
+/**
+ * The scopes a method asks for, where a test is not about them.
+ */
+const noScopes = new SimRestApiMethodScopes();
+
+interface Pool {
+  readonly userPoolArn: string;
+  readonly issuerUrl: string;
+  /** The registry the authorizer resolves this pool's id through. */
+  readonly registry: SimCognitoUserPoolRegistry;
+  /** Sign arbitrary claims with the pool's own key. */
+  readonly sign: (claims: object) => string;
+}
+
+/**
+ * A pool whose key signs whatever claims a test wants to verify, which is what
+ * the sign-in flows themselves cannot produce.
+ */
+async function pool(): Promise<Pool> {
+  const simAws = new SimAws();
+  const signedIn = await simCognitoSignedInFactory.make({}, simAws);
+  const userPool = simAws
+    .cognitoIdentityProvider()
+    .userPool(signedIn.userPoolId);
+  const registry = new SimCognitoUserPoolRegistry();
+  registry.register(userPool);
+
+  return {
+    userPoolArn: signedIn.userPoolArn,
+    issuerUrl: signedIn.issuerUrl,
+    registry,
+    sign: (claims) => userPool.signingKey.sign(claims),
+  };
+}
+
+function authorizerFor(userPoolArn: string): SimRestApiCognitoAuthorizer {
+  return new SimRestApiCognitoAuthorizer({
+    authorizerId: makeSimRestApiAuthorizerId(),
+    name: "user-pools",
+    providers: SimRestApiUserPoolProviders.parse([userPoolArn]),
+    identitySource: new SimRestApiIdentitySourceParser().header(
+      "method.request.header.Authorization",
+      "COGNITO_USER_POOLS",
+    ),
+  });
+}
+
+function verificationFor(
+  registry: SimCognitoUserPoolRegistry,
+): SimRestApiCognitoVerification {
+  return new SimRestApiCognitoVerification({
+    userPools: new SimCognitoRestApiUserPools({ userPoolRegistry: registry }),
+    clock: new SimFixedClock(now),
+  });
+}
+
+describe("Verifying a token against a REST API Cognito authorizer", () => {
+  it("accepts a token the named pool signed", async () => {
+    // Given a token from the pool the authorizer names
+    const { registry, userPoolArn, issuerUrl, sign } = await pool();
+    const token = sign({
+      iss: issuerUrl,
+      iat: nowSeconds - 60,
+      nbf: nowSeconds - 60,
+      exp: nowSeconds + 60,
+    });
+
+    // Then it is admitted
+    const authorization = verificationFor(registry).verify(
+      authorizerFor(userPoolArn),
+      token,
+      noScopes,
+    );
+    assertInstanceOf(authorization, SimRestApiAdmitted);
+  });
+
+  it("refuses a token signed with an algorithm that is not RS256", async () => {
+    // Given a token whose header names a symmetric algorithm, which is how a
+    // verifier that trusts the header is talked out of checking anything
+    const { registry, userPoolArn, issuerUrl } = await pool();
+    const header = Buffer.from('{"alg":"HS256"}', "utf8").toString("base64url");
+    const payload = Buffer.from(
+      JSON.stringify({ iss: issuerUrl, exp: nowSeconds + 60 }),
+      "utf8",
+    ).toString("base64url");
+
+    // Then it is refused before any key is looked for
+    const authorization = verificationFor(registry).verify(
+      authorizerFor(userPoolArn),
+      `${header}.${payload}.c2ln`,
+      noScopes,
+    );
+    assertFalse(authorization.admitted);
+  });
+
+  it("refuses a token the pool signed for another issuer", async () => {
+    // Given a token carrying the pool's own signature and another issuer
+    const { registry, userPoolArn, sign } = await pool();
+    const token = sign({
+      iss: "https://accounts.example.test",
+      exp: nowSeconds + 60,
+    });
+
+    // Then it is refused: the issuer has to be the pool that signed it, so a
+    // key reused across issuers admits nothing
+    const authorization = verificationFor(registry).verify(
+      authorizerFor(userPoolArn),
+      token,
+      noScopes,
+    );
+    assertFalse(authorization.admitted);
+  });
+
+  it("refuses a token that has expired, or has no expiry at all", async () => {
+    // Given a token past its expiry, one expiring exactly now, and one with no
+    // exp claim
+    const { registry, userPoolArn, issuerUrl, sign } = await pool();
+    const claims = { iss: issuerUrl };
+    const verification = verificationFor(registry);
+    const authorizer = authorizerFor(userPoolArn);
+
+    // Then all three are refused: the expiry is compared with no allowance for
+    // skew, and a token nothing can expire is not admitted
+    assertFalse(
+      verification.verify(
+        authorizer,
+        sign({ ...claims, exp: nowSeconds - 1 }),
+        noScopes,
+      ).admitted,
+    );
+    assertFalse(
+      verification.verify(
+        authorizer,
+        sign({ ...claims, exp: nowSeconds }),
+        noScopes,
+      ).admitted,
+    );
+    assertFalse(
+      verification.verify(authorizer, sign(claims), noScopes).admitted,
+    );
+  });
+
+  it("refuses a token that is not valid yet, or was issued in the future", async () => {
+    // Given tokens whose nbf and iat are ahead of the simulation's clock
+    const { registry, userPoolArn, issuerUrl, sign } = await pool();
+    const claims = { iss: issuerUrl, exp: nowSeconds + 600 };
+    const verification = verificationFor(registry);
+    const authorizer = authorizerFor(userPoolArn);
+
+    // Then each is refused
+    assertFalse(
+      verification.verify(
+        authorizer,
+        sign({ ...claims, nbf: nowSeconds + 60 }),
+        noScopes,
+      ).admitted,
+    );
+    assertFalse(
+      verification.verify(
+        authorizer,
+        sign({ ...claims, iat: nowSeconds + 60 }),
+        noScopes,
+      ).admitted,
+    );
+  });
+
+  it("renders claim values as strings the way real API Gateway does", async () => {
+    // Given a token carrying a list claim, a number and a boolean
+    const { registry, userPoolArn, issuerUrl, sign } = await pool();
+    const token = sign({
+      iss: issuerUrl,
+      exp: nowSeconds + 60,
+      "cognito:groups": ["Admins", "Readers"],
+      auth_time: nowSeconds,
+      email_verified: true,
+      address: { formatted: "1 Test Street" },
+    });
+
+    // Then every value arrives as a string, with a list rendered the way Go
+    // prints a slice rather than as JSON or as a comma-separated list
+    const authorization = verificationFor(registry).verify(
+      authorizerFor(userPoolArn),
+      token,
+      noScopes,
+    );
+    assertInstanceOf(authorization, SimRestApiAdmitted);
+    const claims = authorization.cognito?.claims ?? {};
+    assertIdentical(claims["cognito:groups"], "[Admins Readers]");
+    assertIdentical(claims["auth_time"], String(nowSeconds));
+    // oxlint-disable-next-line smartass/prefer-specific-assertions -- the expected value is the string a boolean claim renders as, not a boolean.
+    assertIdentical(claims["email_verified"], "true");
+    assertIdentical(claims["address"], '{"formatted":"1 Test Street"}');
+  });
+
+  it("refuses every token for a standalone API Gateway", async () => {
+    // Given a simulated API Gateway with no Cognito behind it
+    const { userPoolArn, issuerUrl, sign } = await pool();
+    const verification = new SimRestApiCognitoVerification({
+      userPools: new SimRestApiNoUserPools(),
+      clock: new SimFixedClock(now),
+    });
+
+    // Then a token that would otherwise be accepted is refused, which keeps a
+    // method configured to be closed closed
+    assertFalse(
+      verification.verify(
+        authorizerFor(userPoolArn),
+        sign({ iss: issuerUrl, exp: nowSeconds + 60 }),
+        noScopes,
+      ).admitted,
+    );
+  });
+});

--- a/src/service/apigateway/api/authorizer/sim-rest-api-cognito-verification.ts
+++ b/src/service/apigateway/api/authorizer/sim-rest-api-cognito-verification.ts
@@ -1,0 +1,146 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import { simJwtClaimStrings } from "../../../../util/jwt/sim-jwt-claim-strings.js";
+import type { SimJwk } from "../../../../util/jwt/sim-jwt-keys.js";
+import { SimJwtRs256 } from "../../../../util/jwt/sim-jwt-rs256.js";
+import { simJwtScopes } from "../../../../util/jwt/sim-jwt-scopes.js";
+import { SimJwtTimeClaims } from "../../../../util/jwt/sim-jwt-time-claims.js";
+import { SimJwt } from "../../../../util/jwt/sim-jwt.js";
+import type { SimRestApiMethodScopes } from "../method/sim-rest-api-method-scopes.js";
+import {
+  SimRestApiAdmitted,
+  type SimRestApiAuthorization,
+  SimRestApiRefused,
+} from "./sim-rest-api-authorization.js";
+import type { SimRestApiCognitoAuthorizer } from "./sim-rest-api-cognito-authorizer.js";
+import type {
+  SimRestApiUserPool,
+  SimRestApiUserPools,
+} from "./sim-rest-api-user-pools.js";
+
+interface SimRestApiCognitoVerificationProperties {
+  readonly userPools: SimRestApiUserPools;
+  readonly clock: SimClock;
+}
+
+/**
+ * One pool of the authorizer, and the key of that pool a token names.
+ */
+interface SimRestApiSigningPool {
+  readonly pool: SimRestApiUserPool;
+  readonly key: SimJwk;
+}
+
+/**
+ * Verifies one token against one `COGNITO_USER_POOLS` authorizer.
+ *
+ * The checks are the ones a JWT verifier makes: decode the token, check its
+ * algorithm, find the pool publishing the key its `kid` names, verify the
+ * signature, then check the claims. Every one of them answers the same 401, so
+ * a client learns that its token was not accepted and nothing about which
+ * check it failed.
+ *
+ * `token_use` is not checked, so an id token and an access token are both
+ * accepted by a method asking for no scope. The method's scopes are the one
+ * thing that tells the two apart, since only an access token carries a `scope`
+ * claim, and they are checked here because they are checked against the token.
+ */
+export class SimRestApiCognitoVerification {
+  private readonly userPools: SimRestApiUserPools;
+  private readonly times: SimJwtTimeClaims;
+  private readonly rs256 = new SimJwtRs256();
+
+  constructor(properties: SimRestApiCognitoVerificationProperties) {
+    this.userPools = properties.userPools;
+    this.times = new SimJwtTimeClaims({ clock: properties.clock });
+  }
+
+  /**
+   * Verify a token, answering what the method should do with the request that
+   * carried it.
+   */
+  verify(
+    authorizer: SimRestApiCognitoAuthorizer,
+    token: string,
+    scopes: SimRestApiMethodScopes,
+  ): SimRestApiAuthorization {
+    const jwt = this.decode(token);
+
+    if (jwt === undefined || !this.rs256.isSupportedAlgorithm(jwt)) {
+      return SimRestApiRefused.unauthorized();
+    }
+
+    const signing = this.signingPool(authorizer, jwt);
+
+    if (signing === undefined || !this.rs256.verify(jwt, signing.key)) {
+      return SimRestApiRefused.unauthorized();
+    }
+
+    if (
+      jwt.claims.text("iss") !== signing.pool.issuerUrl ||
+      !this.times.hold(jwt.claims)
+    ) {
+      return SimRestApiRefused.unauthorized();
+    }
+
+    return this.admitted(jwt, scopes);
+  }
+
+  /**
+   * The request once the token is known to be genuine, which the method's
+   * scopes can still refuse.
+   *
+   * An unmet scope is a 403 rather than a 401: the token was accepted, and it
+   * does not allow this method. It is the same refusal a policy allowing
+   * nothing relevant gets, since both are a caller API Gateway identified and
+   * then would not admit.
+   */
+  private admitted(
+    jwt: SimJwt,
+    scopes: SimRestApiMethodScopes,
+  ): SimRestApiAuthorization {
+    if (!scopes.permits(simJwtScopes(jwt.claims))) {
+      return SimRestApiRefused.implicitDeny();
+    }
+
+    return new SimRestApiAdmitted({
+      cognito: { claims: simJwtClaimStrings(jwt.claims) },
+    });
+  }
+
+  /**
+   * The pool of this authorizer that published the key the token names.
+   *
+   * A pool the simulation has not got publishes nothing and matches nothing,
+   * which is what makes an authorizer naming a deleted pool refuse every
+   * token rather than admit one it could not check.
+   */
+  private signingPool(
+    authorizer: SimRestApiCognitoAuthorizer,
+    jwt: SimJwt,
+  ): SimRestApiSigningPool | undefined {
+    for (const userPoolId of authorizer.providers.userPoolIds) {
+      const pool = this.userPools.find(userPoolId);
+      const key = pool?.keys.find(jwt.header.kid);
+
+      if (pool !== undefined && key !== undefined) {
+        return { pool, key };
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Read the token, or answer undefined for one that is not a JWT at all.
+   *
+   * The refusal for an unreadable token and for one that fails verification is
+   * the same, so nothing is gained by carrying the parse error further.
+   */
+  private decode(token: string): SimJwt | undefined {
+    try {
+      return SimJwt.parse(token);
+    } catch {
+      return undefined;
+    }
+  }
+}

--- a/src/service/apigateway/api/authorizer/sim-rest-api-lambda-authorizer.ts
+++ b/src/service/apigateway/api/authorizer/sim-rest-api-lambda-authorizer.ts
@@ -1,0 +1,72 @@
+import type { SimRestApiLambdaUri } from "../method/sim-rest-api-lambda-uri.js";
+import type { SimRestApiIdentitySources } from "./identity/sim-rest-api-identity-sources.js";
+import {
+  SimRestApiAuthorizer,
+  type SimRestApiAuthorizerId,
+  type SimRestApiAuthorizerView,
+  simRestApiCustomAuthType,
+} from "./sim-rest-api-authorizer.js";
+
+/**
+ * The kinds of authorizer that decide by invoking a function.
+ */
+export type SimRestApiLambdaAuthorizerType = "TOKEN" | "REQUEST";
+
+interface SimRestApiLambdaAuthorizerProperties {
+  readonly authorizerId: SimRestApiAuthorizerId;
+  readonly name: string;
+  readonly type: SimRestApiLambdaAuthorizerType;
+  readonly lambdaUri: SimRestApiLambdaUri;
+  readonly identitySources: SimRestApiIdentitySources;
+}
+
+/**
+ * A simulated REST API Lambda authorizer: the function a method sends a
+ * request to before it reaches the integration.
+ *
+ * The function decides, so nothing here says what a caller has to present.
+ * All this holds is which function to invoke, what the request has to carry
+ * before it is worth invoking, and how much of the request that function is
+ * shown.
+ */
+export class SimRestApiLambdaAuthorizer extends SimRestApiAuthorizer {
+  /**
+   * How much of the request the function sees, which is the whole difference
+   * between the two kinds.
+   */
+  public readonly type: SimRestApiLambdaAuthorizerType;
+
+  /**
+   * The Lambda function this authorizer invokes, read from its
+   * `authorizerUri`.
+   */
+  public readonly lambdaUri: SimRestApiLambdaUri;
+
+  /**
+   * Where the request has to carry something for the function to be invoked at
+   * all. A `TOKEN` authorizer has exactly one, and its value is the token the
+   * function is invoked with.
+   */
+  public readonly identitySources: SimRestApiIdentitySources;
+
+  constructor(properties: SimRestApiLambdaAuthorizerProperties) {
+    super(properties);
+    this.type = properties.type;
+    this.lambdaUri = properties.lambdaUri;
+    this.identitySources = properties.identitySources;
+  }
+
+  /**
+   * Get the AWS-like view of this authorizer.
+   */
+  view(): SimRestApiAuthorizerView {
+    return {
+      id: this.authorizerId,
+      name: this.name,
+      type: this.type,
+      authType: simRestApiCustomAuthType,
+      authorizerUri: this.lambdaUri.uri,
+      identitySource: this.identitySources.expression,
+    };
+  }
+}

--- a/src/service/apigateway/api/authorizer/sim-rest-api-user-pool-providers.ts
+++ b/src/service/apigateway/api/authorizer/sim-rest-api-user-pool-providers.ts
@@ -1,0 +1,75 @@
+import { SimApiGatewayBadRequest } from "../../error/sim-api-gateway.error.js";
+
+/**
+ * The ARN of one Cognito user pool, whose last segment is the pool's own id.
+ *
+ * The Account and the Region the ARN names are not read. A pool in another
+ * Account is out of scope here, and the pool id already carries its Region, so
+ * the id is the whole of what this simulation looks a pool up by.
+ */
+const userPoolArn =
+  /^arn:aws:cognito-idp:[a-z0-9-]+:\d{12}:userpool\/(?<poolId>[a-z0-9-]+_[A-Za-z0-9]+)$/u;
+
+/**
+ * The user pools a `COGNITO_USER_POOLS` authorizer accepts tokens from.
+ *
+ * Real `CreateAuthorizer` takes them as ARNs and requires at least one, and a
+ * token is admitted when any one of the pools issued it. The ARNs are kept as
+ * they were written, because that is what `GetAuthorizer` hands back, and the
+ * pool ids are what a token is verified against.
+ */
+export class SimRestApiUserPoolProviders {
+  /**
+   * The ARNs as they were written, which is what the API reports back.
+   */
+  public readonly arns: readonly string[];
+
+  /**
+   * The pool ids those ARNs name, in the order they were written.
+   */
+  public readonly userPoolIds: readonly string[];
+
+  private constructor(arns: readonly string[], userPoolIds: readonly string[]) {
+    this.arns = arns;
+    this.userPoolIds = userPoolIds;
+  }
+
+  /**
+   * Read the `providerARNs` an authorizer was created with, refusing a list
+   * this simulation could not verify a token against.
+   *
+   * An authorizer naming no pool, or naming something that is not a user pool
+   * ARN, refuses every request. That reads to a caller like a signing problem
+   * rather than the configuration one it is, so it is refused when the
+   * authorizer is created.
+   */
+  static parse(providerArns: readonly string[]): SimRestApiUserPoolProviders {
+    if (providerArns.length === 0) {
+      throw new SimApiGatewayBadRequest(
+        "CreateAuthorizer with type COGNITO_USER_POOLS requires providerARNs " +
+          "naming at least one user pool",
+      );
+    }
+
+    return new SimRestApiUserPoolProviders(
+      [...providerArns],
+      providerArns.map((arn) => userPoolId(arn)),
+    );
+  }
+}
+
+/**
+ * The pool an ARN names, refusing one that names no user pool.
+ */
+function userPoolId(arn: string): string {
+  const poolId = userPoolArn.exec(arn)?.groups?.["poolId"];
+
+  if (poolId === undefined) {
+    throw new SimApiGatewayBadRequest(
+      `providerARNs entry '${arn}' is not a user pool ARN, which is written ` +
+        `as 'arn:aws:cognito-idp:<region>:<account>:userpool/<poolId>'`,
+    );
+  }
+
+  return poolId;
+}

--- a/src/service/apigateway/api/authorizer/sim-rest-api-user-pools.ts
+++ b/src/service/apigateway/api/authorizer/sim-rest-api-user-pools.ts
@@ -1,0 +1,49 @@
+import type { SimJwtKeys } from "../../../../util/jwt/sim-jwt-keys.js";
+
+/**
+ * One user pool a `COGNITO_USER_POOLS` authorizer verifies tokens against.
+ */
+export interface SimRestApiUserPool {
+  /** The URL this pool's tokens name as their issuer. */
+  readonly issuerUrl: string;
+  /** The public keys this pool publishes. */
+  readonly keys: SimJwtKeys;
+}
+
+/**
+ * The user pools an API Gateway can reach, as its Cognito authorizers see
+ * them.
+ *
+ * A REST API authorizer names a pool by ARN, and all this asks for is what the
+ * pool id in that ARN resolves to. That is how a Cognito authorizer reaches
+ * simulated Cognito without API Gateway depending on it.
+ *
+ * Nothing is fetched over HTTP. A pool's published OpenID configuration names
+ * the localhost origin it is served from, while its tokens name the real AWS
+ * URL, so a discovery client would reject its own issuer's tokens. Resolving
+ * in process compares the two strings that both come from the same getter.
+ */
+export interface SimRestApiUserPools {
+  /**
+   * The pool this id names, which is nothing when this simulation has no such
+   * pool.
+   */
+  find(userPoolId: string): SimRestApiUserPool | undefined;
+}
+
+/**
+ * The pools available to an API Gateway that has no Cognito to ask.
+ *
+ * Every pool id resolves to nothing, so every token fails key selection and
+ * every request to a Cognito method is refused. That is the safe answer for a
+ * simulated API Gateway standing on its own: a method configured to be closed
+ * stays closed.
+ */
+export class SimRestApiNoUserPools implements SimRestApiUserPools {
+  /**
+   * No pool id resolves here.
+   */
+  find(): undefined {
+    return;
+  }
+}

--- a/src/service/apigateway/api/method/sim-rest-api-method-scopes.ts
+++ b/src/service/apigateway/api/method/sim-rest-api-method-scopes.ts
@@ -1,0 +1,42 @@
+/**
+ * The scopes a method asks a token for.
+ *
+ * A method with no scopes asks for nothing beyond a token its authorizer
+ * accepted. A method with scopes is satisfied by any one of them, which is
+ * what AWS documents: the check is any-of, not all-of.
+ *
+ * Only a `COGNITO_USER_POOLS` method has them, since they are checked against
+ * the token's own `scope` claim.
+ */
+export class SimRestApiMethodScopes {
+  public readonly values: readonly string[];
+
+  constructor(values: readonly string[] = []) {
+    this.values = values;
+  }
+
+  /**
+   * Whether this method asks for no scope in particular.
+   */
+  get isEmpty(): boolean {
+    return this.values.length === 0;
+  }
+
+  /**
+   * Whether a token claiming these scopes may have this method.
+   *
+   * A token claiming no scopes at all, which is every Cognito id token, meets
+   * no method scope and is refused by any method that asks for one.
+   */
+  permits(claimed: readonly string[] | null): boolean {
+    if (this.isEmpty) {
+      return true;
+    }
+
+    if (claimed === null) {
+      return false;
+    }
+
+    return claimed.some((scope) => this.values.includes(scope));
+  }
+}

--- a/src/service/apigateway/api/method/sim-rest-api-method.ts
+++ b/src/service/apigateway/api/method/sim-rest-api-method.ts
@@ -2,6 +2,7 @@ import type {
   SimRestApiIntegration,
   SimRestApiIntegrationView,
 } from "./sim-rest-api-integration.js";
+import { SimRestApiMethodScopes } from "./sim-rest-api-method-scopes.js";
 
 /**
  * The method matching any HTTP method the client used, where no method of that
@@ -13,13 +14,17 @@ export const simRestApiAnyMethod = "ANY";
  * The authorization types simulated so far.
  *
  * `NONE` is an open method, `CUSTOM` sends the request through the Lambda
- * authorizer the method names, and `AWS_IAM` asks IAM whether the caller the
- * request was attributed to may invoke the method. `COGNITO_USER_POOLS` is a
- * separate piece of work, and a method asking for it is refused when it is
- * created. A method served open where AWS would have gated it lets a test pass
- * on a request real AWS rejects.
+ * authorizer the method names, `AWS_IAM` asks IAM whether the caller the
+ * request was attributed to may invoke the method, and `COGNITO_USER_POOLS`
+ * verifies the token against the user pools its authorizer names. A method
+ * served open where AWS would have gated it lets a test pass on a request
+ * real AWS rejects.
  */
-export type SimRestApiAuthorizationType = "NONE" | "CUSTOM" | "AWS_IAM";
+export type SimRestApiAuthorizationType =
+  | "NONE"
+  | "CUSTOM"
+  | "AWS_IAM"
+  | "COGNITO_USER_POOLS";
 
 interface SimRestApiMethodProperties {
   readonly httpMethod: string;
@@ -27,6 +32,7 @@ interface SimRestApiMethodProperties {
   readonly apiKeyRequired: boolean;
   readonly operationName?: string | undefined;
   readonly authorizerId?: string | undefined;
+  readonly authorizationScopes?: SimRestApiMethodScopes | undefined;
 }
 
 /**
@@ -38,6 +44,7 @@ export interface SimRestApiMethodView {
   apiKeyRequired: boolean;
   operationName?: string;
   authorizerId?: string;
+  authorizationScopes?: string[];
   methodIntegration?: SimRestApiIntegrationView;
 }
 
@@ -61,6 +68,13 @@ export class SimRestApiMethod {
   public readonly authorizerId?: string | undefined;
 
   /**
+   * The scopes a `COGNITO_USER_POOLS` method asks the token for, which are
+   * the method's own rather than its authorizer's. A method of any other type
+   * asks for none.
+   */
+  public readonly authorizationScopes: SimRestApiMethodScopes;
+
+  /**
    * What this method does with a request. A method with none declared is a
    * method real API Gateway answers 500 for, and it is what `PutMethod`
    * leaves behind until `PutIntegration` follows it.
@@ -73,6 +87,8 @@ export class SimRestApiMethod {
     this.apiKeyRequired = properties.apiKeyRequired;
     this.operationName = properties.operationName;
     this.authorizerId = properties.authorizerId;
+    this.authorizationScopes =
+      properties.authorizationScopes ?? new SimRestApiMethodScopes();
   }
 
   /**
@@ -91,6 +107,10 @@ export class SimRestApiMethod {
 
     if (this.authorizerId !== undefined) {
       view.authorizerId = this.authorizerId;
+    }
+
+    if (!this.authorizationScopes.isEmpty) {
+      view.authorizationScopes = [...this.authorizationScopes.values];
     }
 
     if (this.integration !== undefined) {

--- a/src/service/apigateway/api/sim-rest-api-declared-method.ts
+++ b/src/service/apigateway/api/sim-rest-api-declared-method.ts
@@ -1,4 +1,4 @@
-import type { SimPutMethodCommandInput } from "../command/method/method.command.js";
+import type { SimRestApiProxyAuthorization } from "./sim-rest-api-proxy-authorizer.js";
 import type { SimApiGateway } from "../sim-api-gateway.js";
 
 interface SimRestApiDeclaredMethodInput {
@@ -7,10 +7,8 @@ interface SimRestApiDeclaredMethodInput {
   readonly resourcePath: string;
   readonly httpMethod: string;
   readonly functionArn: string;
-  /** The authorizer every method is gated by, where the API has one. */
-  readonly authorizerId: string | undefined;
-  /** Whether every method is decided by IAM instead. */
-  readonly iamAuthorization: boolean;
+  /** How every method of the API says who may call it. */
+  readonly authorization: SimRestApiProxyAuthorization;
 }
 
 /**
@@ -48,12 +46,7 @@ async function declaredMethod(
   );
 
   await apiGateway.putMethod({
-    input: {
-      restApiId,
-      resourceId,
-      httpMethod,
-      ...declaredAuthorization(input),
-    },
+    input: { restApiId, resourceId, httpMethod, ...input.authorization },
   });
   await apiGateway.putIntegration({
     input: {
@@ -65,24 +58,6 @@ async function declaredMethod(
       uri: input.functionArn,
     },
   });
-}
-
-/**
- * The authorization every method of the API is declared with.
- *
- * An `AWS_IAM` method names no authorizer, so a test asking for both is asking
- * for something PutMethod refuses, and gets that refusal.
- */
-function declaredAuthorization(
-  input: SimRestApiDeclaredMethodInput,
-): Pick<SimPutMethodCommandInput, "authorizationType" | "authorizerId"> {
-  if (input.authorizerId !== undefined) {
-    return { authorizationType: "CUSTOM", authorizerId: input.authorizerId };
-  }
-
-  return {
-    authorizationType: input.iamAuthorization ? "AWS_IAM" : "NONE",
-  };
 }
 
 /**

--- a/src/service/apigateway/api/sim-rest-api-lambda-proxy.factory.ts
+++ b/src/service/apigateway/api/sim-rest-api-lambda-proxy.factory.ts
@@ -6,7 +6,7 @@ import { DEFAULT_SIM_AWS_ACCOUNT_ID } from "../../aws/sim-aws-account.js";
 import type { SimAws } from "../../aws/sim-aws.js";
 import { declaredMethods } from "./sim-rest-api-declared-method.js";
 import {
-  simRestApiProxyAuthorizer,
+  simRestApiProxyAuthorization,
   type SimRestApiProxyAuthorizerInput,
 } from "./sim-rest-api-proxy-authorizer.js";
 import {
@@ -24,11 +24,6 @@ export interface SimRestApiLambdaProxyInput extends SimRestApiProxyAuthorizerInp
   /** The function code every method of the API hands its requests to. */
   readonly handler: (event: SimPayload1Event) => unknown;
   readonly disableExecuteApiEndpoint: boolean;
-  /**
-   * Whether every method is authorized by IAM, which is what an `AWS_IAM`
-   * method asks for. An API asking for this names no authorizer.
-   */
-  readonly iamAuthorization: boolean;
   /**
    * The resource paths the API declares, written as templates such as
    * `/orders/{orderId}` or `/{proxy+}`. Each one gets the method below.
@@ -63,7 +58,9 @@ export interface SimRestApiLambdaProxyInput extends SimRestApiProxyAuthorizerInp
  * Supplying an `authorizerHandler` puts a `TOKEN` authorizer in front of every
  * method, invoking a second simulated function of its own. A
  * `requestAuthorizerHandler` puts a `REQUEST` authorizer there instead, and
- * asking for `iamAuthorization` puts every method behind IAM.
+ * `cognitoUserPoolArns` puts a `COGNITO_USER_POOLS` authorizer there, which
+ * invokes nothing and verifies the token itself. Asking for
+ * `iamAuthorization` puts every method behind IAM.
  *
  * ```typescript
  * const restApi = await simRestApiLambdaProxyFactory.make(
@@ -91,6 +88,8 @@ export const simRestApiLambdaProxyFactory = new AsyncMappedFactory<
     handler: (): unknown => ({ statusCode: 200, body: "hello" }),
     authorizerHandler: undefined,
     requestAuthorizerHandler: undefined,
+    cognitoUserPoolArns: undefined,
+    authorizationScopes: [],
     authorizerIdentitySource: "method.request.header.Authorization",
     authorizerInvokePermission: true,
     disableExecuteApiEndpoint: false,
@@ -117,8 +116,11 @@ export const simRestApiLambdaProxyFactory = new AsyncMappedFactory<
       rootResourceId: created.rootResourceId,
       httpMethod: input.httpMethod,
       functionArn,
-      authorizerId: await simRestApiProxyAuthorizer(simAws, input, restApiId),
-      iamAuthorization: input.iamAuthorization,
+      authorization: await simRestApiProxyAuthorization(
+        simAws,
+        input,
+        restApiId,
+      ),
     });
 
     if (input.invokePermission) {

--- a/src/service/apigateway/api/sim-rest-api-proxy-authorizer.ts
+++ b/src/service/apigateway/api/sim-rest-api-proxy-authorizer.ts
@@ -1,17 +1,23 @@
 import type { SimAws } from "../../aws/sim-aws.js";
-import { makeLambdaZipFileInput } from "../../lambda/function/code/lambda-zip-file-input.js";
-import type { SimRestApiAuthorizerType } from "./authorizer/sim-rest-api-authorizer.js";
 import type { SimRestApiTokenAuthorizerEvent } from "../serve/auth/sim-rest-api-authorizer-event.js";
 import type { SimRestApiRequestAuthorizerEvent } from "../serve/auth/sim-rest-api-request-authorizer-event.js";
-import { simApiGatewayServicePrincipal } from "../sim-api-gateway-service-principal.js";
+import { simRestApiProxyLambdaAuthorizer } from "./sim-rest-api-proxy-lambda-authorizer.js";
 
 /**
- * What a test asks for when it wants its REST API gated by a Lambda
- * authorizer.
+ * How the methods of a test's REST API say who may call them.
+ */
+export interface SimRestApiProxyAuthorization {
+  readonly authorizationType: string;
+  readonly authorizerId?: string | undefined;
+  readonly authorizationScopes?: readonly string[] | undefined;
+}
+
+/**
+ * What a test asks for when it wants its REST API gated by an authorizer.
  *
- * The two kinds hand their function different events, so a test says which it
- * is writing by which handler it supplies rather than by naming a type. A
- * `REQUEST` handler wins where both are given.
+ * The two Lambda kinds hand their function different events, so a test says
+ * which it is writing by which handler it supplies rather than by naming a
+ * type. A `REQUEST` handler wins where both are given.
  */
 export interface SimRestApiProxyAuthorizerInput {
   /**
@@ -29,6 +35,19 @@ export interface SimRestApiProxyAuthorizerInput {
     | ((event: SimRestApiRequestAuthorizerEvent) => unknown)
     | undefined;
   /**
+   * The user pools a `COGNITO_USER_POOLS` authorizer accepts tokens from,
+   * named by ARN. Supplying them gates every method with that authorizer
+   * instead of a Lambda one, and it invokes nothing.
+   */
+  readonly cognitoUserPoolArns: readonly string[] | undefined;
+  /** The scopes each method asks a verified token for. */
+  readonly authorizationScopes: readonly string[];
+  /**
+   * Whether every method is authorized by IAM, which is what an `AWS_IAM`
+   * method asks for. An API asking for this names no authorizer.
+   */
+  readonly iamAuthorization: boolean;
+  /**
    * Where the authorizer looks for what identifies a caller. A `REQUEST`
    * authorizer writes as many expressions as it likes, separated by commas.
    */
@@ -42,89 +61,50 @@ export interface SimRestApiProxyAuthorizerInput {
 }
 
 /**
- * The kind of authorizer a test asked for and the code of its function, or
- * nothing at all where it asked for no authorizer.
- *
- * The two handlers are read apart rather than together because each is written
- * against the event its own kind of authorizer receives.
- */
-function authorizerFunction(
-  input: SimRestApiProxyAuthorizerInput,
-):
-  | { readonly type: SimRestApiAuthorizerType; readonly code: Uint8Array }
-  | undefined {
-  const { authorizerHandler, requestAuthorizerHandler } = input;
-
-  if (requestAuthorizerHandler !== undefined) {
-    return {
-      type: "REQUEST",
-      code: makeLambdaZipFileInput(requestAuthorizerHandler),
-    };
-  }
-
-  if (authorizerHandler !== undefined) {
-    return { type: "TOKEN", code: makeLambdaZipFileInput(authorizerHandler) };
-  }
-
-  return undefined;
-}
-
-/**
  * Create the authorizer a test's REST API gates its methods with, and answer
- * its id.
+ * how the methods name it.
  *
- * The function is a second one beside the integration's, because a REST API
- * authorizer is invoked under an ARN naming the authorizer rather than any
- * method, and needs a grant of its own. That grant is the one CDK's
- * `TokenAuthorizer` and `RequestAuthorizer` write.
+ * An API with no authorizer function, no user pools and no IAM authorization
+ * declares open methods, which is what a test about anything else wants. An
+ * `AWS_IAM` method names no authorizer, so a test asking for both is asking
+ * for something PutMethod refuses, and gets that refusal.
  */
-export async function simRestApiProxyAuthorizer(
+export async function simRestApiProxyAuthorization(
   simAws: SimAws,
   input: SimRestApiProxyAuthorizerInput,
   restApiId: string,
-): Promise<string | undefined> {
-  const authorizerFn = authorizerFunction(input);
+): Promise<SimRestApiProxyAuthorization> {
+  const providerARNs = input.cognitoUserPoolArns;
 
-  if (authorizerFn === undefined) {
-    return undefined;
-  }
-
-  const lambda = simAws.account(input.functionAccountId).lambda();
-  const name = `${restApiId}-authorizer`;
-  const created = await lambda.createFunction({
-    input: {
-      FunctionName: name,
-      Role: input.roleArn,
-      Code: { ZipFile: authorizerFn.code },
-    },
-  });
-
-  const { id } = await simAws.apiGateway().createAuthorizer({
-    input: {
-      restApiId,
-      name: "orders-authorizer",
-      type: authorizerFn.type,
-      authorizerUri: created.FunctionArn,
-      identitySource: input.authorizerIdentitySource,
-    },
-  });
-
-  if (input.authorizerInvokePermission) {
-    const { accountId, regionName } =
-      simAws.accountRegionScope().accountRegionScope;
-
-    await lambda.addPermission({
+  if (providerARNs !== undefined) {
+    const { id } = await simAws.apiGateway().createAuthorizer({
       input: {
-        FunctionName: name,
-        StatementId: "api-gateway-invoke-authorizer",
-        Action: "lambda:InvokeFunction",
-        Principal: simApiGatewayServicePrincipal,
-        SourceArn:
-          `arn:aws:execute-api:${regionName}:${accountId}:` +
-          `${restApiId}/authorizers/${id}`,
+        restApiId,
+        name: "orders-user-pools",
+        type: "COGNITO_USER_POOLS",
+        providerARNs,
+        identitySource: input.authorizerIdentitySource,
       },
     });
+
+    return {
+      authorizationType: "COGNITO_USER_POOLS",
+      authorizerId: id,
+      authorizationScopes: input.authorizationScopes,
+    };
   }
 
-  return id;
+  const authorizerId = await simRestApiProxyLambdaAuthorizer(
+    simAws,
+    input,
+    restApiId,
+  );
+
+  if (authorizerId !== undefined) {
+    return { authorizationType: "CUSTOM", authorizerId };
+  }
+
+  return {
+    authorizationType: input.iamAuthorization ? "AWS_IAM" : "NONE",
+  };
 }

--- a/src/service/apigateway/api/sim-rest-api-proxy-lambda-authorizer.ts
+++ b/src/service/apigateway/api/sim-rest-api-proxy-lambda-authorizer.ts
@@ -1,0 +1,93 @@
+import type { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../lambda/function/code/lambda-zip-file-input.js";
+import type { SimRestApiLambdaAuthorizerType } from "./authorizer/sim-rest-api-lambda-authorizer.js";
+import { simApiGatewayServicePrincipal } from "../sim-api-gateway-service-principal.js";
+import type { SimRestApiProxyAuthorizerInput } from "./sim-rest-api-proxy-authorizer.js";
+
+/**
+ * The kind of authorizer a test asked for and the code of its function, or
+ * nothing at all where it asked for no Lambda authorizer.
+ *
+ * The two handlers are read apart rather than together because each is written
+ * against the event its own kind of authorizer receives.
+ */
+function authorizerFunction(
+  input: SimRestApiProxyAuthorizerInput,
+):
+  | { readonly type: SimRestApiLambdaAuthorizerType; readonly code: Uint8Array }
+  | undefined {
+  const { authorizerHandler, requestAuthorizerHandler } = input;
+
+  if (requestAuthorizerHandler !== undefined) {
+    return {
+      type: "REQUEST",
+      code: makeLambdaZipFileInput(requestAuthorizerHandler),
+    };
+  }
+
+  if (authorizerHandler !== undefined) {
+    return { type: "TOKEN", code: makeLambdaZipFileInput(authorizerHandler) };
+  }
+
+  return undefined;
+}
+
+/**
+ * Create the Lambda authorizer a test's REST API gates its methods with, and
+ * answer its id.
+ *
+ * The function is a second one beside the integration's, because a REST API
+ * authorizer is invoked under an ARN naming the authorizer rather than any
+ * method, and needs a grant of its own. That grant is the one CDK's
+ * `TokenAuthorizer` and `RequestAuthorizer` write.
+ */
+export async function simRestApiProxyLambdaAuthorizer(
+  simAws: SimAws,
+  input: SimRestApiProxyAuthorizerInput,
+  restApiId: string,
+): Promise<string | undefined> {
+  const authorizerFn = authorizerFunction(input);
+
+  if (authorizerFn === undefined) {
+    return undefined;
+  }
+
+  const lambda = simAws.account(input.functionAccountId).lambda();
+  const name = `${restApiId}-authorizer`;
+  const created = await lambda.createFunction({
+    input: {
+      FunctionName: name,
+      Role: input.roleArn,
+      Code: { ZipFile: authorizerFn.code },
+    },
+  });
+
+  const { id } = await simAws.apiGateway().createAuthorizer({
+    input: {
+      restApiId,
+      name: "orders-authorizer",
+      type: authorizerFn.type,
+      authorizerUri: created.FunctionArn,
+      identitySource: input.authorizerIdentitySource,
+    },
+  });
+
+  if (input.authorizerInvokePermission) {
+    const { accountId, regionName } =
+      simAws.accountRegionScope().accountRegionScope;
+
+    await lambda.addPermission({
+      input: {
+        FunctionName: name,
+        StatementId: "api-gateway-invoke-authorizer",
+        Action: "lambda:InvokeFunction",
+        Principal: simApiGatewayServicePrincipal,
+        SourceArn:
+          `arn:aws:execute-api:${regionName}:${accountId}:` +
+          `${restApiId}/authorizers/${id}`,
+      },
+    });
+  }
+
+  return id;
+}

--- a/src/service/apigateway/api/sim-rest-api.ts
+++ b/src/service/apigateway/api/sim-rest-api.ts
@@ -1,5 +1,6 @@
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import { SimRestApiAuthorizerStore } from "./authorizer/sim-rest-api-authorizer-store.js";
+import type { SimRestApiUserPools } from "./authorizer/sim-rest-api-user-pools.js";
 import { SimRestApiDeploymentStore } from "./deployment/sim-rest-api-deployment-store.js";
 import { SimRestApiResourceStore } from "./resource/sim-rest-api-resource-store.js";
 import type { SimRestApiResource } from "./resource/sim-rest-api-resource.js";
@@ -20,6 +21,7 @@ interface SimRestApiProperties {
   readonly name: string;
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly createdDate: Date;
+  readonly userPools: SimRestApiUserPools;
   readonly description?: string | undefined;
   readonly disableExecuteApiEndpoint?: boolean | undefined;
 }
@@ -40,6 +42,14 @@ export class SimRestApi {
   public readonly disableExecuteApiEndpoint: boolean;
 
   /**
+   * The user pools this API's Cognito authorizers verify tokens against.
+   *
+   * They are held on the API because a request is served without a command,
+   * and the serving layer reaches the API and nothing around it.
+   */
+  public readonly userPools: SimRestApiUserPools;
+
+  /**
    * The API's name and description, which `UpdateRestApi` can replace. Neither
    * identifies the API, and two APIs in one Account and Region may share both.
    */
@@ -58,6 +68,7 @@ export class SimRestApi {
     this.name = properties.name;
     this.accountRegionScope = properties.accountRegionScope;
     this.createdDate = properties.createdDate;
+    this.userPools = properties.userPools;
     this.description = properties.description;
     this.disableExecuteApiEndpoint =
       properties.disableExecuteApiEndpoint ?? false;

--- a/src/service/apigateway/cfn/authorizer/sim-cfn-rest-api-authorizer-properties.ts
+++ b/src/service/apigateway/cfn/authorizer/sim-cfn-rest-api-authorizer-properties.ts
@@ -6,7 +6,7 @@ import { SimCfnApiGatewayPropertyParser } from "../sim-cfn-api-gateway-property-
 /**
  * The AWS::ApiGateway::Authorizer properties this simulation deploys.
  *
- * `AuthorizerResultTtlInSeconds`, `ProviderARNs`, `AuthorizerCredentials`,
+ * `AuthorizerResultTtlInSeconds`, `AuthorizerCredentials`,
  * `IdentityValidationExpression` and `AuthType` are left out, so a template
  * carrying one has it recorded against the Resource. Each belongs to a piece
  * of work outside this one, and what an authorizer of a given `Type` requires
@@ -17,6 +17,7 @@ const simulatedProperties = [
   "Name",
   "Type",
   "AuthorizerUri",
+  "ProviderARNs",
   "IdentitySource",
 ];
 
@@ -59,13 +60,14 @@ export class SimCfnRestApiAuthorizerProperties {
   /**
    * The CreateAuthorizer input this Resource asks for.
    *
-   * Everything but the shape of each value is passed through, so a
-   * `COGNITO_USER_POOLS` authorizer, one naming no function and one whose
-   * identity source names somewhere this simulation reads nothing from are all
-   * refused by CreateAuthorizer with the reason it refuses them.
+   * Everything but the shape of each value is passed through, so an
+   * authorizer naming no function or no user pool, and one whose identity
+   * source names somewhere this simulation reads nothing from, are refused by
+   * CreateAuthorizer with the reason it refuses them.
    *
    * `IdentitySource` is one comma-separated string, which is how a REST API
    * writes a list where an HTTP API takes one.
+>>>>>>> d71bc9d5 (feat: gate a REST API method with a user pool)
    *
    * `AuthorizerUri` arrives as the wrapped
    * `arn:aws:apigateway:<region>:lambda:path/...` form CDK builds with
@@ -88,6 +90,11 @@ export class SimCfnRestApiAuthorizerProperties {
         this.resource,
         this.properties["AuthorizerUri"],
         "AuthorizerUri",
+      ),
+      providerARNs: this.propertyParser.optionalStringList(
+        this.resource,
+        this.properties["ProviderARNs"],
+        "ProviderARNs",
       ),
       identitySource: this.propertyParser.optionalString(
         this.resource,

--- a/src/service/apigateway/cfn/method/sim-cfn-rest-api-method-properties.ts
+++ b/src/service/apigateway/cfn/method/sim-cfn-rest-api-method-properties.ts
@@ -8,11 +8,9 @@ import { SimCfnRestApiIntegrationProperties } from "./sim-cfn-rest-api-integrati
 /**
  * The AWS::ApiGateway::Method properties this simulation deploys.
  *
- * `AuthorizationScopes`, `RequestParameters`, `RequestModels`,
- * `RequestValidatorId` and `MethodResponses` are left out, so a template
- * carrying one has it recorded against the Resource. Scopes belong to a
- * `COGNITO_USER_POOLS` method, which `AuthorizationType` refuses before they
- * matter.
+ * `RequestParameters`, `RequestModels`, `RequestValidatorId` and
+ * `MethodResponses` are left out, so a template carrying one has it recorded
+ * against the Resource.
  */
 const simulatedProperties = [
   "RestApiId",
@@ -20,6 +18,7 @@ const simulatedProperties = [
   "HttpMethod",
   "AuthorizationType",
   "AuthorizerId",
+  "AuthorizationScopes",
   "ApiKeyRequired",
   "OperationName",
   "Integration",
@@ -110,11 +109,11 @@ export class SimCfnRestApiMethodProperties {
   /**
    * The PutMethod input this Resource asks for.
    *
-   * `AuthorizationType`, `AuthorizerId` and `ApiKeyRequired` are passed
-   * through as the template wrote them, so a method asking for an
-   * authorization type this simulation does not enforce, for an authorizer the
-   * API has not got, or for an API key is refused by PutMethod with the reason
-   * it refuses it.
+   * `AuthorizationType`, `AuthorizerId`, `AuthorizationScopes` and
+   * `ApiKeyRequired` are passed through as the template wrote them, so a
+   * method asking for an authorization type this simulation does not enforce,
+   * for an authorizer the API has not got, for scopes nothing checks, or for
+   * an API key is refused by PutMethod with the reason it refuses it.
    */
   putMethodInput(): SimPutMethodCommandInput {
     return {
@@ -130,6 +129,11 @@ export class SimCfnRestApiMethodProperties {
         this.resource,
         this.properties["AuthorizerId"],
         "AuthorizerId",
+      ),
+      authorizationScopes: this.propertyParser.optionalStringList(
+        this.resource,
+        this.properties["AuthorizationScopes"],
+        "AuthorizationScopes",
       ),
       apiKeyRequired: this.propertyParser.optionalBoolean(
         this.resource,

--- a/src/service/apigateway/cfn/sim-cfn-api-gateway-property-parser.ts
+++ b/src/service/apigateway/cfn/sim-cfn-api-gateway-property-parser.ts
@@ -82,6 +82,29 @@ export class SimCfnApiGatewayPropertyParser extends SimCfnApiGatewayScalarValues
   }
 
   /**
+   * Parse a property value that must be a list of strings when present, which
+   * is the shape an authorizer's `ProviderARNs` and a method's
+   * `AuthorizationScopes` take.
+   */
+  optionalStringList(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): string[] | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (!Array.isArray(value)) {
+      throw this.invalidPropertyError(resource, label, "a list of strings");
+    }
+
+    return value.map((entry, index) =>
+      this.requiredString(resource, entry, `${label}[${index}]`),
+    );
+  }
+
+  /**
    * Parse a property value that must be an object of strings when present,
    * which is the shape a stage's `Variables` takes.
    */

--- a/src/service/apigateway/cfn/sim-cfn-rest-api-cognito-authorizer.iso.test.ts
+++ b/src/service/apigateway/cfn/sim-cfn-rest-api-cognito-authorizer.iso.test.ts
@@ -1,0 +1,156 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertObjectMatches,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  deployRestApi,
+  simAwsInEuWest2,
+} from "../../../../test/apigateway/cfn-deploy.js";
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import {
+  type SimCognitoSignedIn,
+  simCognitoSignedInFactory,
+} from "../../cognito/user-pool/auth/sim-cognito-signed-in.factory.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimRestApi } from "../api/sim-rest-api.js";
+import { simCfnRestApiTemplateFactory } from "./sim-cfn-rest-api-template.factory.js";
+
+/**
+ * The scope a Cognito sign-in through the user pool API puts in a token.
+ */
+const adminScope = "aws.cognito.signin.user.admin";
+
+/**
+ * A handler reporting the claims the authorizer accepted.
+ */
+const claimsHandlerSource = `
+exports.handler = async (event) => ({
+  statusCode: 200,
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify(event.requestContext.authorizer),
+});
+`;
+
+/**
+ * The template that deploys a REST API gated by a Cognito authorizer.
+ *
+ * The pool is created before the stack rather than deployed with it, so the
+ * template is about the authorizer alone. A stack declaring its own
+ * `AWS::Cognito::UserPool` reaches the same authorizer through a `Fn::GetAtt`
+ * on its ARN.
+ */
+function gatedTemplate(
+  userPoolArn: string,
+  methodProperties: SimCfnTemplateValueRecord = {},
+): ReturnType<typeof simCfnRestApiTemplateFactory.make> {
+  return simCfnRestApiTemplateFactory.make({
+    handlerSource: claimsHandlerSource,
+    methods: [{ httpMethod: "GET", path: ["orders"] }],
+    methodProperties: {
+      AuthorizationType: "COGNITO_USER_POOLS",
+      AuthorizerId: { Ref: "Authorizer" },
+      ...methodProperties,
+    },
+    resources: {
+      Authorizer: {
+        Type: "AWS::ApiGateway::Authorizer",
+        Properties: {
+          RestApiId: { Ref: "Api" },
+          Name: "user-pools",
+          Type: "COGNITO_USER_POOLS",
+          IdentitySource: "method.request.header.Authorization",
+          ProviderARNs: [userPoolArn],
+        },
+      },
+    },
+  });
+}
+
+/**
+ * Deploy that template against a pool with a signed-in user, and answer what
+ * a test needs to call the deployed method.
+ */
+async function deployGatedApi(
+  methodProperties: SimCfnTemplateValueRecord = {},
+): Promise<{
+  readonly simAws: SimAws;
+  readonly url: string;
+  readonly signedIn: SimCognitoSignedIn;
+}> {
+  const simAws = simAwsInEuWest2();
+  const signedIn = await simCognitoSignedInFactory.make({}, simAws);
+  const stack = await deployRestApi(
+    simAws,
+    gatedTemplate(signedIn.userPoolArn, methodProperties),
+  );
+  const restApi = stack.resources.get("Api")?.simResource as
+    | SimRestApi
+    | undefined;
+  assertNonNullable(restApi);
+
+  return {
+    simAws,
+    url: new SimAwsLocalUrl({
+      input: `${restApi.invokeUrl("prod")}/orders`,
+    }).toString(),
+    signedIn,
+  };
+}
+
+describe("Deploying a REST API Cognito authorizer from CloudFormation", () => {
+  it("gates a method with the user pool the template names", async () => {
+    // Given a deployed API whose method names a COGNITO_USER_POOLS authorizer
+    const { simAws, url, signedIn } = await deployGatedApi();
+
+    // When the method is requested with and without a token that pool issued
+    const http = new SimAwsHttp({ simAws });
+    const admitted = await http.fetch(url, {
+      headers: { authorization: signedIn.accessToken },
+    });
+    const refused = await http.fetch(url);
+
+    // Then the deployed authorizer decides both, and the token's claims reach
+    // the handler
+    assertIdentical(admitted.status, 200);
+    assertIdentical(refused.status, 401);
+    assertObjectMatches(await admitted.json(), {
+      claims: { iss: signedIn.issuerUrl, username: signedIn.username },
+    });
+  });
+
+  it("refuses a token that does not meet the scopes the template asks for", async () => {
+    // Given a deployed method asking for a scope no simulated flow issues
+    const { simAws, url, signedIn } = await deployGatedApi({
+      AuthorizationScopes: ["orders.write"],
+    });
+
+    // When an otherwise acceptable token is presented
+    const response = await new SimAwsHttp({ simAws }).fetch(url, {
+      headers: { authorization: signedIn.accessToken },
+    });
+
+    // Then the deployed scopes decided it, with the 403 an accepted token
+    // that allows nothing here gets
+    assertIdentical(response.status, 403);
+  });
+
+  it("serves a method whose deployed scope the token claims", async () => {
+    // Given a deployed method asking for the scope a pool sign-in issues
+    const { simAws, url, signedIn } = await deployGatedApi({
+      AuthorizationScopes: [adminScope],
+    });
+
+    // When an access token carrying that scope is presented
+    const response = await new SimAwsHttp({ simAws }).fetch(url, {
+      headers: { authorization: signedIn.accessToken },
+    });
+
+    // Then the method is reached, because one method scope matched
+    assertIdentical(response.status, 200);
+  });
+});

--- a/src/service/apigateway/cfn/sim-cfn-rest-api-validation.iso.test.ts
+++ b/src/service/apigateway/cfn/sim-cfn-rest-api-validation.iso.test.ts
@@ -16,14 +16,14 @@ import { simCfnRestApiTemplateFactory } from "./sim-cfn-rest-api-template.factor
 
 describe("API Gateway REST API CloudFormation refusals", () => {
   it("refuses a method asking for an authorization type nothing enforces", async () => {
-    // Given a method behind a user pool
+    // Given a method asking to be authorized by a REQUEST authorizer
     const simAws = simAwsInEuWest2();
 
     // When the template is deployed
     const error = await deployRestApiFailure(
       simAws,
       simCfnRestApiTemplateFactory.make({
-        methodProperties: { AuthorizationType: "COGNITO_USER_POOLS" },
+        methodProperties: { AuthorizationType: "REQUEST" },
       }),
     );
 
@@ -31,7 +31,7 @@ describe("API Gateway REST API CloudFormation refusals", () => {
     // would have gated
     assertStringIncludes(
       error.message,
-      "PutMethod authorizationType 'COGNITO_USER_POOLS' is not simulated",
+      "PutMethod authorizationType 'REQUEST' is not simulated",
     );
   });
 
@@ -196,8 +196,8 @@ describe("API Gateway REST API CloudFormation Resource types left out", () => {
     assertIdentical(account.status, "CREATE_COMPLETE");
   });
 
-  it("refuses an authorizer of a kind nothing here invokes", async () => {
-    // Given a template declaring a Cognito authorizer
+  it("refuses an authorizer of a kind a REST API does not have", async () => {
+    // Given a template declaring the JWT authorizer an HTTP API takes
     const simAws = simAwsInEuWest2();
 
     // When the template is deployed
@@ -210,7 +210,7 @@ describe("API Gateway REST API CloudFormation Resource types left out", () => {
             Properties: {
               RestApiId: { Ref: "Api" },
               Name: "session-cookie",
-              Type: "COGNITO_USER_POOLS",
+              Type: "JWT",
             },
           },
         },
@@ -221,7 +221,7 @@ describe("API Gateway REST API CloudFormation Resource types left out", () => {
     // authorizer that decides nothing
     assertStringIncludes(
       error.message,
-      "CreateAuthorizer type 'COGNITO_USER_POOLS' is not simulated",
+      "CreateAuthorizer type 'JWT' is not simulated",
     );
   });
 });

--- a/src/service/apigateway/command/api/sim-rest-api-commands.ts
+++ b/src/service/apigateway/command/api/sim-rest-api-commands.ts
@@ -1,5 +1,6 @@
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimRestApiUserPools } from "../../api/authorizer/sim-rest-api-user-pools.js";
 import type { SimRestApiStore } from "../../api/sim-rest-api-store.js";
 import { SimRestApi } from "../../api/sim-rest-api.js";
 import type { SimRestApiRegistry } from "../../registry/sim-rest-api-registry.js";
@@ -32,6 +33,7 @@ interface SimRestApiCommandsProperties {
   readonly access: SimRestApiAccess;
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly clock: SimClock;
+  readonly userPools: SimRestApiUserPools;
 }
 
 /**
@@ -43,6 +45,7 @@ export class SimRestApiCommands {
   private readonly access: SimRestApiAccess;
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly clock: SimClock;
+  private readonly userPools: SimRestApiUserPools;
 
   constructor(properties: SimRestApiCommandsProperties) {
     this.apis = properties.apis;
@@ -50,6 +53,7 @@ export class SimRestApiCommands {
     this.access = properties.access;
     this.accountRegionScope = properties.accountRegionScope;
     this.clock = properties.clock;
+    this.userPools = properties.userPools;
   }
 
   /**
@@ -74,6 +78,7 @@ export class SimRestApiCommands {
       name,
       accountRegionScope: this.accountRegionScope,
       createdDate: this.clock.now(),
+      userPools: this.userPools,
       description: input.description,
       disableExecuteApiEndpoint: input.disableExecuteApiEndpoint,
     });

--- a/src/service/apigateway/command/authorizer/authorizer.command.ts
+++ b/src/service/apigateway/command/authorizer/authorizer.command.ts
@@ -15,6 +15,7 @@ export interface SimCreateAuthorizerCommandInput {
   readonly name?: string | undefined;
   readonly type?: string | undefined;
   readonly authorizerUri?: string | undefined;
+  readonly providerARNs?: readonly string[] | undefined;
   readonly identitySource?: string | undefined;
 }
 

--- a/src/service/apigateway/command/authorizer/sim-rest-api-authorizer-commands.iso.test.ts
+++ b/src/service/apigateway/command/authorizer/sim-rest-api-authorizer-commands.iso.test.ts
@@ -160,24 +160,24 @@ describe("Sim API Gateway REST API authorizer commands", () => {
     await expect(authorizer).rejects.toThrow(SimApiGatewayNotFound);
   });
 
-  it("refuses an authorizer kind nothing here invokes", async () => {
+  it("refuses an authorizer kind a REST API does not have", async () => {
     // Given a REST API
     const simAws = new SimAws();
     const restApiId = await givenRestApi(simAws.apiGateway());
 
-    // When a Cognito authorizer is asked for
-    const authorizer = simAws.apiGateway().createAuthorizer(
-      new CreateAuthorizerCommand({
-        ...tokenAuthorizerInput(restApiId),
-        type: "COGNITO_USER_POOLS",
-      }),
-    );
+    // When the JWT authorizer an HTTP API takes is asked for here. The SDK's
+    // own AuthorizerType has no room for the value, so the command is written
+    // out rather than built, which is what a caller reaching the simulation
+    // from another language would send.
+    const authorizer = simAws.apiGateway().createAuthorizer({
+      input: { ...tokenAuthorizerInput(restApiId), type: "JWT" },
+    });
 
     // Then it is refused, rather than created as something that decides
     // nothing
     await expect(authorizer).rejects.toThrow(SimApiGatewayBadRequest);
     await expect(authorizer).rejects.toThrow(
-      "CreateAuthorizer type 'COGNITO_USER_POOLS' is not simulated",
+      "CreateAuthorizer type 'JWT' is not simulated",
     );
   });
 

--- a/src/service/apigateway/command/authorizer/sim-rest-api-authorizer-commands.ts
+++ b/src/service/apigateway/command/authorizer/sim-rest-api-authorizer-commands.ts
@@ -28,17 +28,19 @@ const acceptedCreateOptions = [
   "name",
   "type",
   "authorizerUri",
+  "providerARNs",
   "identitySource",
 ];
 
 const simulatedAuthorizerTypes: readonly SimRestApiAuthorizerType[] = [
   "TOKEN",
   "REQUEST",
+  "COGNITO_USER_POOLS",
 ];
 
 const authorizerTypeRefusal =
-  "a COGNITO_USER_POOLS authorizer verifies a user pool token itself rather " +
-  "than invoking a function, and that is not built here";
+  "a REST API authorizer invokes a function or verifies a user pool token, " +
+  "and the JWT authorizer an HTTP API takes is the v2 service's";
 
 interface SimRestApiAuthorizerCommandsProperties {
   readonly access: SimRestApiAccess;

--- a/src/service/apigateway/command/authorizer/sim-rest-api-authorizer-input.ts
+++ b/src/service/apigateway/command/authorizer/sim-rest-api-authorizer-input.ts
@@ -1,9 +1,13 @@
+import { SimRestApiIdentitySourceParser } from "../../api/authorizer/identity/sim-rest-api-identity-source-parser.js";
 import { SimRestApiIdentitySources } from "../../api/authorizer/identity/sim-rest-api-identity-sources.js";
-import {
+import type {
   SimRestApiAuthorizer,
-  type SimRestApiAuthorizerId,
-  type SimRestApiAuthorizerType,
+  SimRestApiAuthorizerId,
+  SimRestApiAuthorizerType,
 } from "../../api/authorizer/sim-rest-api-authorizer.js";
+import { SimRestApiCognitoAuthorizer } from "../../api/authorizer/sim-rest-api-cognito-authorizer.js";
+import { SimRestApiLambdaAuthorizer } from "../../api/authorizer/sim-rest-api-lambda-authorizer.js";
+import { SimRestApiUserPoolProviders } from "../../api/authorizer/sim-rest-api-user-pool-providers.js";
 import { SimRestApiLambdaUri } from "../../api/method/sim-rest-api-lambda-uri.js";
 import { SimApiGatewayBadRequest } from "../../error/sim-api-gateway.error.js";
 import type { SimCreateAuthorizerCommandInput } from "./authorizer.command.js";
@@ -15,12 +19,13 @@ interface SimRestApiAuthorizerInputProperties {
 }
 
 /**
- * Reads the inputs a Lambda authorizer is created from.
+ * Reads the inputs an authorizer is created from.
  *
- * The function and the identity source are both required by real
- * `CreateAuthorizer` for either type, and neither has a value worth guessing.
- * An authorizer naming no function has nothing to ask, and one naming nowhere
- * to look would be invoked for every request including one carrying nothing.
+ * The identity source is required by real `CreateAuthorizer` for every type,
+ * and an authorizer naming nowhere to look would read nothing on every
+ * request. What decides then differs: a Lambda authorizer requires the
+ * function it asks, and a `COGNITO_USER_POOLS` one requires the pools it
+ * verifies against. Neither has a value worth guessing.
  */
 export class SimRestApiAuthorizerInput {
   private readonly input: SimCreateAuthorizerCommandInput;
@@ -35,9 +40,23 @@ export class SimRestApiAuthorizerInput {
    * The authorizer this input asks for.
    */
   read(authorizerId: SimRestApiAuthorizerId): SimRestApiAuthorizer {
-    return new SimRestApiAuthorizer({
+    const name = this.input.name ?? "";
+
+    if (this.type === "COGNITO_USER_POOLS") {
+      return new SimRestApiCognitoAuthorizer({
+        authorizerId,
+        name,
+        providers: SimRestApiUserPoolProviders.parse(this.providerArns()),
+        identitySource: new SimRestApiIdentitySourceParser().header(
+          this.identitySource(),
+          this.type,
+        ),
+      });
+    }
+
+    return new SimRestApiLambdaAuthorizer({
       authorizerId,
-      name: this.input.name ?? "",
+      name,
       type: this.type,
       lambdaUri: this.lambdaUri(),
       identitySources: this.identitySources(),
@@ -45,7 +64,7 @@ export class SimRestApiAuthorizerInput {
   }
 
   /**
-   * The function this authorizer invokes.
+   * The function a Lambda authorizer invokes.
    *
    * An `authorizerUri` is written in the same wrapped form an integration URI
    * is, so it is read by the same parser and refused for the same reasons.
@@ -59,18 +78,51 @@ export class SimRestApiAuthorizerInput {
       );
     }
 
+    if (this.input.providerARNs !== undefined) {
+      throw new SimApiGatewayBadRequest(
+        `CreateAuthorizer providerARNs is set on a ${this.type} authorizer, ` +
+          `which decides by invoking its function rather than by verifying a ` +
+          `user pool token`,
+      );
+    }
+
     return SimRestApiLambdaUri.parse(uri);
   }
 
   /**
-   * Where the authorizer looks for what identifies a caller, which real
-   * `CreateAuthorizer` requires for both simulated types.
+   * The user pools a `COGNITO_USER_POOLS` authorizer accepts tokens from.
+   */
+  private providerArns(): readonly string[] {
+    if (this.input.authorizerUri !== undefined) {
+      throw new SimApiGatewayBadRequest(
+        "CreateAuthorizer authorizerUri is set on a COGNITO_USER_POOLS " +
+          "authorizer, which verifies the token itself and invokes nothing",
+      );
+    }
+
+    return this.input.providerARNs ?? [];
+  }
+
+  /**
+   * Where a Lambda authorizer looks for what identifies a caller.
    *
    * A `TOKEN` authorizer names one header. A `REQUEST` authorizer names as
    * many headers and query string parameters as it likes, written as one
    * comma-separated string.
    */
   private identitySources(): SimRestApiIdentitySources {
+    const identitySource = this.identitySource();
+
+    return this.type === "TOKEN"
+      ? SimRestApiIdentitySources.token(identitySource)
+      : SimRestApiIdentitySources.request(identitySource);
+  }
+
+  /**
+   * The identity source as it was written, which real `CreateAuthorizer`
+   * requires for every type.
+   */
+  private identitySource(): string {
     const identitySource = this.input.identitySource;
 
     if (identitySource === undefined || identitySource.length === 0) {
@@ -80,8 +132,6 @@ export class SimRestApiAuthorizerInput {
       );
     }
 
-    return this.type === "TOKEN"
-      ? SimRestApiIdentitySources.token(identitySource)
-      : SimRestApiIdentitySources.request(identitySource);
+    return identitySource;
   }
 }

--- a/src/service/apigateway/command/authorizer/sim-rest-api-cognito-authorizer-commands.iso.test.ts
+++ b/src/service/apigateway/command/authorizer/sim-rest-api-cognito-authorizer-commands.iso.test.ts
@@ -1,0 +1,264 @@
+import {
+  CreateAuthorizerCommand,
+  CreateResourceCommand,
+  CreateRestApiCommand,
+  GetAuthorizerCommand,
+  GetMethodCommand,
+  PutMethodCommand,
+} from "@aws-sdk/client-api-gateway";
+import { assertIdentical, assertUndefined } from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimApiGatewayBadRequest } from "../../error/sim-api-gateway.error.js";
+import type { SimApiGateway } from "../../sim-api-gateway.js";
+
+const userPoolArn =
+  "arn:aws:cognito-idp:eu-west-2:111111111111:userpool/eu-west-2_aBcDeFgHi";
+
+const secondUserPoolArn =
+  "arn:aws:cognito-idp:eu-west-2:111111111111:userpool/eu-west-2_jKlMnOpQr";
+
+interface GatedApi {
+  readonly restApiId: string;
+  readonly resourceId: string;
+  readonly authorizerId: string;
+}
+
+/**
+ * The input a working COGNITO_USER_POOLS authorizer is created from.
+ */
+function cognitoAuthorizerInput(restApiId: string): {
+  readonly restApiId: string;
+  readonly name: string;
+  readonly type: "COGNITO_USER_POOLS";
+  readonly providerARNs: string[];
+  readonly identitySource: string;
+} {
+  return {
+    restApiId,
+    name: "user-pools",
+    type: "COGNITO_USER_POOLS",
+    providerARNs: [userPoolArn],
+    identitySource: "method.request.header.Authorization",
+  };
+}
+
+/**
+ * An API with a resource and a Cognito authorizer, ready for a method that
+ * names it.
+ */
+async function givenGatedApi(apiGateway: SimApiGateway): Promise<GatedApi> {
+  const created = await apiGateway.createRestApi(
+    new CreateRestApiCommand({ name: "orders" }),
+  );
+  const resource = await apiGateway.createResource(
+    new CreateResourceCommand({
+      restApiId: created.id,
+      parentId: created.rootResourceId,
+      pathPart: "orders",
+    }),
+  );
+  const authorizer = await apiGateway.createAuthorizer(
+    new CreateAuthorizerCommand(cognitoAuthorizerInput(created.id)),
+  );
+
+  return {
+    restApiId: created.id,
+    resourceId: resource.id,
+    authorizerId: authorizer.id,
+  };
+}
+
+describe("Sim API Gateway REST API Cognito authorizer commands", () => {
+  it("creates a COGNITO_USER_POOLS authorizer on an API", async () => {
+    // Given a REST API
+    const simAws = new SimAws();
+    const created = await simAws
+      .apiGateway()
+      .createRestApi(new CreateRestApiCommand({ name: "orders" }));
+
+    // When an authorizer naming two user pools is created on it
+    const authorizer = await simAws.apiGateway().createAuthorizer(
+      new CreateAuthorizerCommand({
+        ...cognitoAuthorizerInput(created.id),
+        providerARNs: [userPoolArn, secondUserPoolArn],
+      }),
+    );
+
+    // Then it reports the pools it was given and the family it belongs to,
+    // which is what tells it apart from a Lambda authorizer
+    expect(authorizer.id).toMatch(/^[a-z0-9]+$/u);
+    assertIdentical(authorizer.type, "COGNITO_USER_POOLS");
+    assertIdentical(authorizer.authType, "cognito_user_pools");
+    expect(authorizer.providerARNs).toStrictEqual([
+      userPoolArn,
+      secondUserPoolArn,
+    ]);
+    assertIdentical(
+      authorizer.identitySource,
+      "method.request.header.Authorization",
+    );
+  });
+
+  it("reads a Cognito authorizer back by id", async () => {
+    // Given an API with a Cognito authorizer
+    const simAws = new SimAws();
+    const { restApiId, authorizerId } = await givenGatedApi(
+      simAws.apiGateway(),
+    );
+
+    // When it is read back
+    const authorizer = await simAws
+      .apiGateway()
+      .getAuthorizer(new GetAuthorizerCommand({ restApiId, authorizerId }));
+
+    // Then it reports the pools it verifies against and no function, since it
+    // invokes nothing
+    expect(authorizer.providerARNs).toStrictEqual([userPoolArn]);
+    assertUndefined(authorizer.authorizerUri);
+  });
+
+  it("gates a method with the authorizer and the scopes it asks for", async () => {
+    // Given an API with a resource and a Cognito authorizer
+    const simAws = new SimAws();
+    const { restApiId, resourceId, authorizerId } = await givenGatedApi(
+      simAws.apiGateway(),
+    );
+
+    // When a method names it and asks the token for a scope
+    await simAws.apiGateway().putMethod(
+      new PutMethodCommand({
+        restApiId,
+        resourceId,
+        httpMethod: "GET",
+        authorizationType: "COGNITO_USER_POOLS",
+        authorizerId,
+        authorizationScopes: ["orders.read"],
+      }),
+    );
+    const method = await simAws
+      .apiGateway()
+      .getMethod(
+        new GetMethodCommand({ restApiId, resourceId, httpMethod: "GET" }),
+      );
+
+    // Then the method reports both, as real GetMethod does
+    assertIdentical(method.authorizationType, "COGNITO_USER_POOLS");
+    assertIdentical(method.authorizerId, authorizerId);
+    expect(method.authorizationScopes).toStrictEqual(["orders.read"]);
+  });
+
+  it("refuses an authorizer naming no user pool", async () => {
+    // Given a REST API
+    const simAws = new SimAws();
+    const created = await simAws
+      .apiGateway()
+      .createRestApi(new CreateRestApiCommand({ name: "orders" }));
+
+    // When a Cognito authorizer is created with no providerARNs
+    const authorizer = simAws.apiGateway().createAuthorizer(
+      new CreateAuthorizerCommand({
+        ...cognitoAuthorizerInput(created.id),
+        providerARNs: undefined,
+      }),
+    );
+
+    // Then it is refused, since it would have nothing to verify against and
+    // would refuse every request
+    await expect(authorizer).rejects.toThrow(SimApiGatewayBadRequest);
+    await expect(authorizer).rejects.toThrow(
+      "CreateAuthorizer with type COGNITO_USER_POOLS requires providerARNs",
+    );
+  });
+
+  it("refuses a providerARN that names no user pool", async () => {
+    // Given a REST API
+    const simAws = new SimAws();
+    const created = await simAws
+      .apiGateway()
+      .createRestApi(new CreateRestApiCommand({ name: "orders" }));
+
+    // When the ARN names something else
+    const authorizer = simAws.apiGateway().createAuthorizer(
+      new CreateAuthorizerCommand({
+        ...cognitoAuthorizerInput(created.id),
+        providerARNs: ["arn:aws:sns:eu-west-2:111111111111:orders"],
+      }),
+    );
+
+    // Then it is refused where it was written, rather than at request time
+    await expect(authorizer).rejects.toThrow("is not a user pool ARN");
+  });
+
+  it("refuses a Cognito authorizer naming a function", async () => {
+    // Given a REST API
+    const simAws = new SimAws();
+    const created = await simAws
+      .apiGateway()
+      .createRestApi(new CreateRestApiCommand({ name: "orders" }));
+
+    // When the authorizer carries an authorizerUri as well as its pools
+    const authorizer = simAws.apiGateway().createAuthorizer(
+      new CreateAuthorizerCommand({
+        ...cognitoAuthorizerInput(created.id),
+        authorizerUri:
+          "arn:aws:lambda:eu-west-2:111111111111:function:session-check",
+      }),
+    );
+
+    // Then it is refused, because nothing would ever invoke that function
+    await expect(authorizer).rejects.toThrow(
+      "authorizerUri is set on a COGNITO_USER_POOLS authorizer",
+    );
+  });
+
+  it("refuses a method naming an authorizer of the other kind", async () => {
+    // Given an API whose authorizer verifies user pool tokens
+    const simAws = new SimAws();
+    const { restApiId, resourceId, authorizerId } = await givenGatedApi(
+      simAws.apiGateway(),
+    );
+
+    // When a CUSTOM method names it
+    const method = simAws.apiGateway().putMethod(
+      new PutMethodCommand({
+        restApiId,
+        resourceId,
+        httpMethod: "GET",
+        authorizationType: "CUSTOM",
+        authorizerId,
+      }),
+    );
+
+    // Then it is refused, since the two never stand in for each other
+    await expect(method).rejects.toThrow(SimApiGatewayBadRequest);
+    await expect(method).rejects.toThrow(
+      "names a COGNITO_USER_POOLS authorizer, which does not serve " +
+        "authorizationType CUSTOM",
+    );
+  });
+
+  it("refuses scopes on a method that checks none", async () => {
+    // Given an API with a resource
+    const simAws = new SimAws();
+    const { restApiId, resourceId } = await givenGatedApi(simAws.apiGateway());
+
+    // When an open method carries scopes
+    const method = simAws.apiGateway().putMethod(
+      new PutMethodCommand({
+        restApiId,
+        resourceId,
+        httpMethod: "GET",
+        authorizationType: "NONE",
+        authorizationScopes: ["orders.read"],
+      }),
+    );
+
+    // Then it is refused, because a method carrying scopes nothing checks
+    // reads as gated by them and is not
+    await expect(method).rejects.toThrow(
+      "PutMethod authorizationScopes is set on GET /orders",
+    );
+  });
+});

--- a/src/service/apigateway/command/method/method.command.ts
+++ b/src/service/apigateway/command/method/method.command.ts
@@ -17,6 +17,7 @@ export interface SimPutMethodCommandInput {
   readonly httpMethod?: string | undefined;
   readonly authorizationType?: string | undefined;
   readonly authorizerId?: string | undefined;
+  readonly authorizationScopes?: readonly string[] | undefined;
   readonly apiKeyRequired?: boolean | undefined;
   readonly operationName?: string | undefined;
 }

--- a/src/service/apigateway/command/method/sim-rest-api-method-authorization-options.ts
+++ b/src/service/apigateway/command/method/sim-rest-api-method-authorization-options.ts
@@ -1,0 +1,88 @@
+import type { SimRestApiAuthorizationType } from "../../api/method/sim-rest-api-method.js";
+import type { SimRestApiResource } from "../../api/resource/sim-rest-api-resource.js";
+import { SimApiGatewayBadRequest } from "../../error/sim-api-gateway.error.js";
+import type { SimPutMethodCommandInput } from "./method.command.js";
+import { simRestApiCognitoAuthorizationType } from "./sim-rest-api-method-authorizer-input.js";
+
+/**
+ * An authorization type that decides a request without asking an authorizer.
+ */
+export type SimRestApiAuthorizerlessType = Exclude<
+  SimRestApiAuthorizationType,
+  "CUSTOM" | "COGNITO_USER_POOLS"
+>;
+
+interface SimRestApiMethodAuthorizationOptionsProperties {
+  readonly input: SimPutMethodCommandInput;
+  readonly resource: SimRestApiResource;
+  readonly httpMethod: string;
+}
+
+/**
+ * Refuses the options a method's authorization type has no use for.
+ *
+ * An option nothing reads would be ignored, leaving the caller that wrote it
+ * reading a gate the method has not got.
+ *
+ * The resource and the HTTP method are carried for the messages, which name
+ * the method the way a caller wrote it.
+ */
+export class SimRestApiMethodAuthorizationOptions {
+  private readonly properties: SimRestApiMethodAuthorizationOptionsProperties;
+
+  constructor(properties: SimRestApiMethodAuthorizationOptionsProperties) {
+    this.properties = properties;
+  }
+
+  /**
+   * Refuse scopes on a method that checks none.
+   *
+   * Scopes are read off the token, so only the type that reads a token has a
+   * use for them.
+   */
+  refuseScopes(authorizationType: SimRestApiAuthorizationType): void {
+    if (this.properties.input.authorizationScopes === undefined) {
+      return;
+    }
+
+    throw this.refusal(
+      "authorizationScopes",
+      authorizationType,
+      `scopes are only checked against the token a ` +
+        `${simRestApiCognitoAuthorizationType} method verifies`,
+    );
+  }
+
+  /**
+   * Refuse an authorizer named by a method that has none to name.
+   */
+  refuseAuthorizerId(authorizationType: SimRestApiAuthorizerlessType): void {
+    if (this.properties.input.authorizerId === undefined) {
+      return;
+    }
+
+    throw this.refusal(
+      "authorizerId",
+      authorizationType,
+      authorizationType === "NONE"
+        ? "an open method sends its requests through nothing"
+        : "an AWS_IAM method is decided by IAM rather than by a function",
+    );
+  }
+
+  /**
+   * A refusal naming the option, the method it is set on and its type.
+   */
+  private refusal(
+    option: string,
+    authorizationType: SimRestApiAuthorizationType,
+    reason: string,
+  ): SimApiGatewayBadRequest {
+    const { httpMethod, resource } = this.properties;
+
+    return new SimApiGatewayBadRequest(
+      `PutMethod ${option} is set on ${httpMethod} ${resource.path} with ` +
+        `authorizationType ${authorizationType}, and ${reason}`,
+    );
+  }
+}

--- a/src/service/apigateway/command/method/sim-rest-api-method-authorization-type.ts
+++ b/src/service/apigateway/command/method/sim-rest-api-method-authorization-type.ts
@@ -1,0 +1,59 @@
+import type { SimRestApiAuthorizationType } from "../../api/method/sim-rest-api-method.js";
+import { SimApiGatewayBadRequest } from "../../error/sim-api-gateway.error.js";
+import { simRestApiCognitoAuthorizationType } from "./sim-rest-api-method-authorizer-input.js";
+
+/**
+ * The authorization types real `PutMethod` takes but this simulation does not
+ * build, and what a reader should know about each.
+ */
+const unsimulatedTypes = new Map([
+  [
+    "REQUEST",
+    "a REQUEST authorizer receives the whole request, and that event is not " +
+      "built here",
+  ],
+]);
+
+/**
+ * The authorization types `PutMethod` takes here, each of which something
+ * enforces when a request reaches the method.
+ */
+const simulatedTypes = new Set<string>([
+  "NONE",
+  "CUSTOM",
+  "AWS_IAM",
+  simRestApiCognitoAuthorizationType,
+]);
+
+function isSimulatedType(
+  declared: string,
+): declared is SimRestApiAuthorizationType {
+  return simulatedTypes.has(declared);
+}
+
+/**
+ * The authorization type a `PutMethod` input asks for, refusing one this
+ * simulation would leave open.
+ *
+ * Real `PutMethod` requires it, and defaulting an absent one to `NONE` here
+ * would declare an open method for a request AWS rejects outright.
+ */
+export function simRestApiMethodAuthorizationType(
+  declared: string | undefined,
+): SimRestApiAuthorizationType {
+  if (declared === undefined || declared.length === 0) {
+    throw new SimApiGatewayBadRequest("PutMethod requires authorizationType");
+  }
+
+  if (isSimulatedType(declared)) {
+    return declared;
+  }
+
+  const reason = unsimulatedTypes.get(declared);
+
+  throw new SimApiGatewayBadRequest(
+    `PutMethod authorizationType '${declared}' is not simulated` +
+      `${reason === undefined ? "" : `: ${reason}`}. NONE, CUSTOM, AWS_IAM ` +
+      `and ${simRestApiCognitoAuthorizationType} are supported.`,
+  );
+}

--- a/src/service/apigateway/command/method/sim-rest-api-method-authorization.ts
+++ b/src/service/apigateway/command/method/sim-rest-api-method-authorization.ts
@@ -1,51 +1,29 @@
 import type { SimRestApiAuthorizationType } from "../../api/method/sim-rest-api-method.js";
+import { SimRestApiMethodScopes } from "../../api/method/sim-rest-api-method-scopes.js";
 import type { SimRestApiResource } from "../../api/resource/sim-rest-api-resource.js";
 import type { SimRestApi } from "../../api/sim-rest-api.js";
-import { SimApiGatewayBadRequest } from "../../error/sim-api-gateway.error.js";
 import type { SimPutMethodCommandInput } from "./method.command.js";
+import { SimRestApiMethodAuthorizationOptions } from "./sim-rest-api-method-authorization-options.js";
+import { simRestApiMethodAuthorizationType } from "./sim-rest-api-method-authorization-type.js";
+import {
+  simRestApiCognitoAuthorizationType,
+  SimRestApiMethodAuthorizerInput,
+} from "./sim-rest-api-method-authorizer-input.js";
 
 /**
- * The authorization types real `PutMethod` takes but this simulation does not
- * build, and what a reader should know about each.
- */
-const unsimulatedTypes = new Map([
-  [
-    "REQUEST",
-    "a REQUEST authorizer receives the whole request, and that event is not " +
-      "built here",
-  ],
-  [
-    "COGNITO_USER_POOLS",
-    "verifying a user pool token against a method is not simulated",
-  ],
-]);
-
-/**
- * The authorization types `PutMethod` takes here, each of which something
- * enforces when a request reaches the method.
- */
-const simulatedTypes = new Set<string>(["NONE", "CUSTOM", "AWS_IAM"]);
-
-function isSimulatedType(
-  declared: string,
-): declared is SimRestApiAuthorizationType {
-  return simulatedTypes.has(declared);
-}
-
-/**
- * An authorization type that decides a request without asking an authorizer.
- */
-type SimRestApiAuthorizerlessType = Exclude<
-  SimRestApiAuthorizationType,
-  "CUSTOM"
->;
-
-/**
- * What a method's authorization type and authorizer id come to.
+ * What a method's authorization type, authorizer id and scopes come to.
  */
 export interface SimRestApiMethodAuthorization {
   readonly authorizationType: SimRestApiAuthorizationType;
   readonly authorizerId?: string | undefined;
+  readonly authorizationScopes: SimRestApiMethodScopes;
+}
+
+interface SimRestApiMethodAuthorizationInputProperties {
+  readonly input: SimPutMethodCommandInput;
+  readonly restApi: SimRestApi;
+  readonly resource: SimRestApiResource;
+  readonly httpMethod: string;
 }
 
 /**
@@ -55,119 +33,65 @@ export interface SimRestApiMethodAuthorization {
  * Every other pairing is refused, because a method that looked gated to the
  * caller that declared it and answered every request here is worse than a
  * refused command.
+ *
+ * Which options each type has a use for is
+ * `SimRestApiMethodAuthorizationOptions`, and finding the authorizer named is
+ * `SimRestApiMethodAuthorizerInput`, so what is left here is which of the four
+ * a method asked for.
  */
 export class SimRestApiMethodAuthorizationInput {
-  private readonly input: SimPutMethodCommandInput;
+  private readonly properties: SimRestApiMethodAuthorizationInputProperties;
+  private readonly options: SimRestApiMethodAuthorizationOptions;
 
-  constructor(input: SimPutMethodCommandInput) {
-    this.input = input;
+  constructor(properties: SimRestApiMethodAuthorizationInputProperties) {
+    this.properties = properties;
+    this.options = new SimRestApiMethodAuthorizationOptions(properties);
   }
 
   /**
    * The authorization this method is declared with, refusing a type nothing
-   * enforces and an authorizer the API has not got.
-   *
-   * The resource is only needed for the message, which names the method the
-   * way a caller wrote it.
+   * enforces, an authorizer the API has not got and scopes nothing checks.
    */
-  read(
-    restApi: SimRestApi,
-    resource: SimRestApiResource,
-    httpMethod: string,
-  ): SimRestApiMethodAuthorization {
-    const authorizationType = this.authorizationType();
+  read(): SimRestApiMethodAuthorization {
+    const { input } = this.properties;
+    const authorizationType = simRestApiMethodAuthorizationType(
+      input.authorizationType,
+    );
+
+    if (authorizationType === simRestApiCognitoAuthorizationType) {
+      // The one type the scopes apply to, since they are checked against the
+      // token it verifies.
+      return this.gated(authorizationType, input.authorizationScopes ?? []);
+    }
+
+    this.options.refuseScopes(authorizationType);
 
     if (authorizationType === "CUSTOM") {
-      return {
+      return this.gated(authorizationType, []);
+    }
+
+    this.options.refuseAuthorizerId(authorizationType);
+
+    return {
+      authorizationType,
+      authorizationScopes: new SimRestApiMethodScopes(),
+    };
+  }
+
+  /**
+   * A method that sends its requests through one of the API's authorizers.
+   */
+  private gated(
+    authorizationType: SimRestApiAuthorizationType,
+    scopes: readonly string[],
+  ): SimRestApiMethodAuthorization {
+    return {
+      authorizationType,
+      authorizerId: new SimRestApiMethodAuthorizerInput(this.properties).read(
+        this.properties.input.authorizerId,
         authorizationType,
-        authorizerId: this.authorizerId(restApi, resource, httpMethod),
-      };
-    }
-
-    this.refuseAuthorizerId(authorizationType, resource, httpMethod);
-
-    return { authorizationType };
-  }
-
-  /**
-   * The authorization type, refusing one this simulation would leave open.
-   *
-   * Real `PutMethod` requires it, and defaulting an absent one to `NONE` here
-   * would declare an open method for a request AWS rejects outright.
-   */
-  private authorizationType(): SimRestApiAuthorizationType {
-    const declared = this.input.authorizationType;
-
-    if (declared === undefined || declared.length === 0) {
-      throw new SimApiGatewayBadRequest("PutMethod requires authorizationType");
-    }
-
-    if (isSimulatedType(declared)) {
-      return declared;
-    }
-
-    const reason = unsimulatedTypes.get(declared);
-
-    throw new SimApiGatewayBadRequest(
-      `PutMethod authorizationType '${declared}' is not simulated` +
-        `${reason === undefined ? "" : `: ${reason}`}. NONE, CUSTOM and ` +
-        `AWS_IAM are supported.`,
-    );
-  }
-
-  /**
-   * The authorizer a `CUSTOM` method names, refusing one the API has not got.
-   *
-   * An id nothing answers to would leave a method that refuses every request
-   * for a reason a caller reads as a signing problem.
-   */
-  private authorizerId(
-    restApi: SimRestApi,
-    resource: SimRestApiResource,
-    httpMethod: string,
-  ): string {
-    const authorizerId = this.input.authorizerId;
-
-    if (authorizerId === undefined || authorizerId.length === 0) {
-      throw new SimApiGatewayBadRequest(
-        `PutMethod with authorizationType CUSTOM requires authorizerId for ` +
-          `${httpMethod} ${resource.path}`,
-      );
-    }
-
-    if (restApi.authorizers.find(authorizerId) === undefined) {
-      throw new SimApiGatewayBadRequest(
-        `PutMethod authorizerId '${authorizerId}' for ${httpMethod} ` +
-          `${resource.path} names no authorizer of REST API ${restApi.apiId}`,
-      );
-    }
-
-    return authorizerId;
-  }
-
-  /**
-   * Refuse an authorizer named by a method that has none to name.
-   *
-   * A method whose type takes no authorizer would ignore the id, leaving the
-   * caller that wrote it reading a gate the method has not got.
-   */
-  private refuseAuthorizerId(
-    authorizationType: SimRestApiAuthorizerlessType,
-    resource: SimRestApiResource,
-    httpMethod: string,
-  ): void {
-    if (this.input.authorizerId === undefined) {
-      return;
-    }
-
-    const reason =
-      authorizationType === "NONE"
-        ? "an open method sends its requests through nothing"
-        : "an AWS_IAM method is decided by IAM rather than by a function";
-
-    throw new SimApiGatewayBadRequest(
-      `PutMethod authorizerId is set on ${httpMethod} ${resource.path} with ` +
-        `authorizationType ${authorizationType}, and ${reason}`,
-    );
+      ),
+      authorizationScopes: new SimRestApiMethodScopes(scopes),
+    };
   }
 }

--- a/src/service/apigateway/command/method/sim-rest-api-method-authorizer-input.ts
+++ b/src/service/apigateway/command/method/sim-rest-api-method-authorizer-input.ts
@@ -1,0 +1,107 @@
+import type { SimRestApiAuthorizer } from "../../api/authorizer/sim-rest-api-authorizer.js";
+import type { SimRestApiAuthorizationType } from "../../api/method/sim-rest-api-method.js";
+import type { SimRestApiResource } from "../../api/resource/sim-rest-api-resource.js";
+import type { SimRestApi } from "../../api/sim-rest-api.js";
+import { SimApiGatewayBadRequest } from "../../error/sim-api-gateway.error.js";
+
+/**
+ * The authorization type of a method whose token a user pool issued.
+ */
+export const simRestApiCognitoAuthorizationType = "COGNITO_USER_POOLS";
+
+interface SimRestApiMethodAuthorizerInputProperties {
+  readonly restApi: SimRestApi;
+  readonly resource: SimRestApiResource;
+  readonly httpMethod: string;
+}
+
+/**
+ * Finds the authorizer a gated method names, against the API it is declared
+ * on.
+ *
+ * A method that names nothing, one naming an id the API has not got, and one
+ * naming an authorizer that decides some other way are all refused. Each would
+ * leave a method refusing every request for a reason a caller reads as a
+ * signing problem.
+ *
+ * The resource and the HTTP method are carried for the messages, which name
+ * the method the way a caller wrote it.
+ */
+export class SimRestApiMethodAuthorizerInput {
+  private readonly restApi: SimRestApi;
+  private readonly resource: SimRestApiResource;
+  private readonly httpMethod: string;
+
+  constructor(properties: SimRestApiMethodAuthorizerInputProperties) {
+    this.restApi = properties.restApi;
+    this.resource = properties.resource;
+    this.httpMethod = properties.httpMethod;
+  }
+
+  /**
+   * The id of the authorizer this method may be declared with.
+   */
+  read(
+    authorizerId: string | undefined,
+    authorizationType: SimRestApiAuthorizationType,
+  ): string {
+    if (authorizerId === undefined || authorizerId.length === 0) {
+      throw new SimApiGatewayBadRequest(
+        `PutMethod with authorizationType ${authorizationType} requires ` +
+          `authorizerId for ${this.httpMethod} ${this.resource.path}`,
+      );
+    }
+
+    const authorizer = this.restApi.authorizers.find(authorizerId);
+
+    if (authorizer === undefined) {
+      throw this.refusal(
+        `authorizerId '${authorizerId}'`,
+        `names no authorizer of REST API ${this.restApi.apiId}`,
+      );
+    }
+
+    this.refuseOtherKind(authorizer, authorizationType);
+
+    return authorizerId;
+  }
+
+  /**
+   * Refuse an authorizer that decides some other way than the method's
+   * authorization type says.
+   *
+   * A `COGNITO_USER_POOLS` method verifies a user pool token, and every other
+   * gated method invokes a function, so the two never stand in for each other.
+   */
+  private refuseOtherKind(
+    authorizer: SimRestApiAuthorizer,
+    authorizationType: SimRestApiAuthorizationType,
+  ): void {
+    const cognitoAuthorizer =
+      authorizer.type === simRestApiCognitoAuthorizationType;
+
+    if (
+      cognitoAuthorizer ===
+      (authorizationType === simRestApiCognitoAuthorizationType)
+    ) {
+      return;
+    }
+
+    throw this.refusal(
+      `authorizerId '${authorizer.authorizerId}'`,
+      `names a ${authorizer.type} authorizer, which does not serve ` +
+        `authorizationType ${authorizationType}`,
+    );
+  }
+
+  /**
+   * A refusal naming the option, then the method it is set on.
+   */
+  private refusal(option: string, reason: string): SimApiGatewayBadRequest {
+    return new SimApiGatewayBadRequest(
+      `PutMethod ${option} for ${this.httpMethod} ${this.resource.path} ${
+        reason
+      }`,
+    );
+  }
+}

--- a/src/service/apigateway/command/method/sim-rest-api-method-commands.iso.test.ts
+++ b/src/service/apigateway/command/method/sim-rest-api-method-commands.iso.test.ts
@@ -140,13 +140,13 @@ describe("Sim API Gateway REST API method commands", () => {
     const simAws = new SimAws();
     const { restApiId, resourceId } = await givenResource(simAws.apiGateway());
 
-    // When a method asks to be authorized by a user pool
+    // When a method asks to be authorized by a REQUEST authorizer
     const method = simAws.apiGateway().putMethod(
       new PutMethodCommand({
         restApiId,
         resourceId,
         httpMethod: "GET",
-        authorizationType: "COGNITO_USER_POOLS",
+        authorizationType: "REQUEST",
       }),
     );
 
@@ -154,7 +154,7 @@ describe("Sim API Gateway REST API method commands", () => {
     // that real AWS would reject
     await expect(method).rejects.toThrow(SimApiGatewayBadRequest);
     await expect(method).rejects.toThrow(
-      "PutMethod authorizationType 'COGNITO_USER_POOLS' is not simulated",
+      "PutMethod authorizationType 'REQUEST' is not simulated",
     );
   });
 

--- a/src/service/apigateway/command/method/sim-rest-api-method-commands.ts
+++ b/src/service/apigateway/command/method/sim-rest-api-method-commands.ts
@@ -20,6 +20,7 @@ const acceptedPutOptions = [
   ...simRestApiMethodOptions,
   "authorizationType",
   "authorizerId",
+  "authorizationScopes",
   "apiKeyRequired",
   "operationName",
 ];
@@ -63,11 +64,12 @@ export class SimRestApiMethodCommands {
       httpMethod: target.httpMethod,
       apiKeyRequired: false,
       operationName: input.operationName,
-      ...new SimRestApiMethodAuthorizationInput(input).read(
-        target.restApi,
-        target.resource,
-        target.httpMethod,
-      ),
+      ...new SimRestApiMethodAuthorizationInput({
+        input,
+        restApi: target.restApi,
+        resource: target.resource,
+        httpMethod: target.httpMethod,
+      }).read(),
     });
     target.resource.addMethod(method);
 

--- a/src/service/apigateway/command/sim-api-gateway-unsimulated-input.ts
+++ b/src/service/apigateway/command/sim-api-gateway-unsimulated-input.ts
@@ -65,9 +65,12 @@ export class SimApiGatewayUnsimulatedInput {
       return;
     }
 
+    const quoted = simulated.map((one) => `'${one}'`);
+    const last = quoted.at(-1);
+
     throw new SimApiGatewayBadRequest(
       `${this.operation} ${option} '${value}' is not simulated: ` +
-        `${feature}. Only ${simulated.map((one) => `'${one}'`).join(" and ")} ` +
+        `${feature}. Only ${quoted.slice(0, -1).join(", ")} and ${last} ` +
         `are supported.`,
     );
   }

--- a/src/service/apigateway/index.ts
+++ b/src/service/apigateway/index.ts
@@ -27,8 +27,21 @@ export {
   type SimRestApiAuthorizerId,
   type SimRestApiAuthorizerType,
   type SimRestApiAuthorizerView,
+  simRestApiCognitoAuthType,
   simRestApiCustomAuthType,
 } from "./api/authorizer/sim-rest-api-authorizer.js";
+export {
+  SimRestApiLambdaAuthorizer,
+  type SimRestApiLambdaAuthorizerType,
+} from "./api/authorizer/sim-rest-api-lambda-authorizer.js";
+export { SimRestApiCognitoAuthorizer } from "./api/authorizer/sim-rest-api-cognito-authorizer.js";
+export { SimRestApiUserPoolProviders } from "./api/authorizer/sim-rest-api-user-pool-providers.js";
+export {
+  SimRestApiNoUserPools,
+  type SimRestApiUserPool,
+  type SimRestApiUserPools,
+} from "./api/authorizer/sim-rest-api-user-pools.js";
+export { SimCognitoRestApiUserPools } from "./api/authorizer/sim-cognito-rest-api-user-pools.js";
 export { SimRestApiAuthorizerStore } from "./api/authorizer/sim-rest-api-authorizer-store.js";
 export {
   SimRestApiAdmitted,
@@ -50,6 +63,7 @@ export {
   SimRestApiQueryStringIdentitySource,
   simRestApiQueryStringIdentityPrefix,
 } from "./api/authorizer/identity/sim-rest-api-query-string-identity-source.js";
+export { SimRestApiMethodScopes } from "./api/method/sim-rest-api-method-scopes.js";
 export {
   simRestApiAnyMethod,
   SimRestApiMethod,

--- a/src/service/apigateway/serve/auth/sim-rest-api-authorizer-invocation.ts
+++ b/src/service/apigateway/serve/auth/sim-rest-api-authorizer-invocation.ts
@@ -3,7 +3,7 @@ import {
   type SimRestApiAuthorization,
   SimRestApiRefused,
 } from "../../api/authorizer/sim-rest-api-authorization.js";
-import type { SimRestApiAuthorizer } from "../../api/authorizer/sim-rest-api-authorizer.js";
+import type { SimRestApiLambdaAuthorizer } from "../../api/authorizer/sim-rest-api-lambda-authorizer.js";
 import type { SimRestApiLambdaUri } from "../../api/method/sim-rest-api-lambda-uri.js";
 import { simRestApiEndpoint } from "../sim-rest-api-endpoint.js";
 import type { SimRestApiFunctionTarget } from "../sim-rest-api-function-target.js";
@@ -56,7 +56,7 @@ export class SimRestApiAuthorizerInvocation {
    */
   async invoke(
     input: SimRestApiMethodAuthorizeInput,
-    authorizer: SimRestApiAuthorizer,
+    authorizer: SimRestApiLambdaAuthorizer,
     identityValues: readonly string[],
     methodArn: string,
   ): Promise<SimRestApiAuthorization> {
@@ -87,7 +87,7 @@ export class SimRestApiAuthorizerInvocation {
    */
   private async event(
     input: SimRestApiMethodAuthorizeInput,
-    authorizer: SimRestApiAuthorizer,
+    authorizer: SimRestApiLambdaAuthorizer,
     identityValues: readonly string[],
     methodArn: string,
   ): Promise<unknown> {

--- a/src/service/apigateway/serve/auth/sim-rest-api-cognito-method-authorizer.ts
+++ b/src/service/apigateway/serve/auth/sim-rest-api-cognito-method-authorizer.ts
@@ -1,0 +1,63 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import { simJwtBearerToken } from "../../../../util/jwt/sim-jwt-bearer-token.js";
+import {
+  type SimRestApiAuthorization,
+  SimRestApiRefused,
+} from "../../api/authorizer/sim-rest-api-authorization.js";
+import { SimRestApiCognitoAuthorizer } from "../../api/authorizer/sim-rest-api-cognito-authorizer.js";
+import { SimRestApiCognitoVerification } from "../../api/authorizer/sim-rest-api-cognito-verification.js";
+import type { SimRestApiMethodAuthorizeInput } from "./sim-rest-api-method-authorize-input.js";
+
+interface SimRestApiCognitoMethodAuthorizerProperties {
+  /**
+   * Clock the token's time claims are checked against, so advancing simulated
+   * time expires a token that was accepted before it.
+   */
+  readonly clock: SimClock;
+}
+
+/**
+ * Decides whether one request may have a `COGNITO_USER_POOLS` method.
+ *
+ * Nothing is invoked. The token has to verify against the keys one of the
+ * authorizer's pools publishes, and the scopes the method asks for have to be
+ * met.
+ */
+export class SimRestApiCognitoMethodAuthorizer {
+  private readonly clock: SimClock;
+
+  constructor(properties: SimRestApiCognitoMethodAuthorizerProperties) {
+    this.clock = properties.clock;
+  }
+
+  /**
+   * Authorize one request against the `COGNITO_USER_POOLS` method that
+   * matched it.
+   */
+  authorize(input: SimRestApiMethodAuthorizeInput): SimRestApiAuthorization {
+    const { restApi, match, request } = input;
+    const authorizer = restApi.authorizers.find(
+      match.method.authorizerId ?? "",
+    );
+
+    // Such a method always names a Cognito authorizer, and that authorizer can
+    // still be deleted out from under it, so the two come to the same thing
+    // here: with nothing to verify against, the method stays closed.
+    if (!(authorizer instanceof SimRestApiCognitoAuthorizer)) {
+      return SimRestApiRefused.unauthorized();
+    }
+
+    const presented = simJwtBearerToken(
+      authorizer.identitySource.value(request),
+    );
+
+    if (presented === undefined) {
+      return SimRestApiRefused.unauthorized();
+    }
+
+    return new SimRestApiCognitoVerification({
+      userPools: restApi.userPools,
+      clock: this.clock,
+    }).verify(authorizer, presented, match.method.authorizationScopes);
+  }
+}

--- a/src/service/apigateway/serve/auth/sim-rest-api-method-authorizer.ts
+++ b/src/service/apigateway/serve/auth/sim-rest-api-method-authorizer.ts
@@ -4,11 +4,13 @@ import {
   type SimRestApiAuthorization,
   SimRestApiRefused,
 } from "../../api/authorizer/sim-rest-api-authorization.js";
+import { SimRestApiLambdaAuthorizer } from "../../api/authorizer/sim-rest-api-lambda-authorizer.js";
 import { SimRestApiExecuteApiArn } from "../../api/sim-rest-api-execute-api-arn.js";
 import {
   type SimRestApiAuthorizerFunctions,
   SimRestApiAuthorizerInvocation,
 } from "./sim-rest-api-authorizer-invocation.js";
+import { SimRestApiCognitoMethodAuthorizer } from "./sim-rest-api-cognito-method-authorizer.js";
 import { SimRestApiIamMethodAuthorizer } from "./sim-rest-api-iam-method-authorizer.js";
 import type { SimRestApiMethodAuthorizeInput } from "./sim-rest-api-method-authorize-input.js";
 
@@ -18,7 +20,11 @@ interface SimRestApiMethodAuthorizerProperties {
    * finds an integration's.
    */
   readonly functions: SimRestApiAuthorizerFunctions;
-  /** Clock an authorizer's invocation event is stamped with. */
+  /**
+   * Clock an authorizer's invocation event is stamped with, and a verified
+   * token's time claims are checked against, so advancing simulated time
+   * expires a token that was accepted before it.
+   */
   readonly clock: SimClock;
 }
 
@@ -43,10 +49,14 @@ interface SimRestApiMethodAuthorizerProperties {
 export class SimRestApiMethodAuthorizer {
   private readonly invocation: SimRestApiAuthorizerInvocation;
   private readonly iamAuthorizer = new SimRestApiIamMethodAuthorizer();
+  private readonly cognito: SimRestApiCognitoMethodAuthorizer;
 
   constructor(properties: SimRestApiMethodAuthorizerProperties) {
     this.invocation = new SimRestApiAuthorizerInvocation({
       functions: properties.functions,
+      clock: properties.clock,
+    });
+    this.cognito = new SimRestApiCognitoMethodAuthorizer({
       clock: properties.clock,
     });
   }
@@ -66,6 +76,9 @@ export class SimRestApiMethodAuthorizer {
       case "AWS_IAM": {
         return this.iamAuthorizer.authorize(input);
       }
+      case "COGNITO_USER_POOLS": {
+        return this.cognito.authorize(input);
+      }
       case "CUSTOM": {
         return await this.custom(input);
       }
@@ -83,10 +96,10 @@ export class SimRestApiMethodAuthorizer {
       match.method.authorizerId ?? "",
     );
 
-    // A CUSTOM method always names an authorizer, and that authorizer can
-    // still be deleted out from under it, so the two come to the same thing
-    // here: with nothing to ask, the method stays closed.
-    if (authorizer === undefined) {
+    // A CUSTOM method always names a Lambda authorizer, and that authorizer
+    // can still be deleted out from under it, so the two come to the same
+    // thing here: with nothing to ask, the method stays closed.
+    if (!(authorizer instanceof SimRestApiLambdaAuthorizer)) {
       return SimRestApiRefused.unauthorized();
     }
 

--- a/src/service/apigateway/serve/sim-rest-api-cognito-authorizer.iso.test.ts
+++ b/src/service/apigateway/serve/sim-rest-api-cognito-authorizer.iso.test.ts
@@ -1,0 +1,340 @@
+import { assertIdentical, assertObjectMatches } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import type { SimPayload1Event } from "../../../serve/payload-1/sim-payload-1-event.type.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import {
+  type SimCognitoSignedIn,
+  simCognitoSignedInFactory,
+} from "../../cognito/user-pool/auth/sim-cognito-signed-in.factory.js";
+import { simRestApiLambdaProxyFactory } from "../api/sim-rest-api-lambda-proxy.factory.js";
+import type { SimRestApi } from "../api/sim-rest-api.js";
+
+/**
+ * The scope a Cognito sign-in through the user pool API puts in a token.
+ */
+const adminScope = "aws.cognito.signin.user.admin";
+
+/**
+ * A handler reporting what the authorizer told it about the caller, so a test
+ * can assert on the claims rather than only on the status.
+ */
+const claimsHandler = (event: SimPayload1Event): unknown => ({
+  statusCode: 200,
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify(event.requestContext.authorizer ?? null),
+});
+
+interface GatedApi {
+  readonly simAws: SimAws;
+  readonly restApi: SimRestApi;
+  readonly signedIn: SimCognitoSignedIn;
+}
+
+/**
+ * A pool with a signed-in user, and an API whose one method is gated by a
+ * Cognito authorizer naming that pool.
+ */
+async function gatedApi(
+  authorizationScopes: readonly string[] = [],
+): Promise<GatedApi> {
+  const simAws = new SimAws();
+  const signedIn = await simCognitoSignedInFactory.make({}, simAws);
+  const restApi = await simRestApiLambdaProxyFactory.make(
+    {
+      handler: claimsHandler,
+      resourcePaths: ["/orders"],
+      httpMethod: "GET",
+      cognitoUserPoolArns: [signedIn.userPoolArn],
+      authorizationScopes,
+    },
+    simAws,
+  );
+
+  return { simAws, restApi, signedIn };
+}
+
+function get(
+  simAws: SimAws,
+  restApi: SimRestApi,
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  return new SimAwsHttp({ simAws }).fetch(
+    new SimAwsLocalUrl({
+      input: `${restApi.invokeUrl("prod")}/orders`,
+    }).toString(),
+    { headers },
+  );
+}
+
+describe("Authorizing a sim REST API method with a Cognito authorizer", () => {
+  it("lets a signed-in user's access token through to the handler", async () => {
+    // Given a gated method and a token from a simulated Cognito sign-in
+    const { simAws, restApi, signedIn } = await gatedApi();
+
+    // When the method is called with that token
+    const response = await get(simAws, restApi, {
+      authorization: signedIn.accessToken,
+    });
+
+    // Then the handler ran, and the token's own claims reached it under
+    // `claims`, which is where a REST API puts them
+    assertIdentical(response.status, 200);
+    assertObjectMatches(await response.json(), {
+      claims: {
+        client_id: signedIn.clientId,
+        iss: signedIn.issuerUrl,
+        token_use: "access",
+        username: signedIn.username,
+      },
+    });
+  });
+
+  it("takes an id token, and renders a list claim as API Gateway does", async () => {
+    // Given a signed-in user who belongs to two groups
+    const simAws = new SimAws();
+    const signedIn = await simCognitoSignedInFactory.make(
+      { groupNames: ["Admins", "Readers"] },
+      simAws,
+    );
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      {
+        handler: claimsHandler,
+        resourcePaths: ["/orders"],
+        httpMethod: "GET",
+        cognitoUserPoolArns: [signedIn.userPoolArn],
+      },
+      simAws,
+    );
+
+    // When the method is called with their id token
+    const response = await get(simAws, restApi, {
+      authorization: signedIn.idToken,
+    });
+
+    // Then it is accepted, since a method asking for no scope tells the two
+    // token types apart by nothing, and the groups arrive as one string,
+    // rendered the way Go prints a slice
+    assertIdentical(response.status, 200);
+    assertObjectMatches(await response.json(), {
+      claims: { token_use: "id", "cognito:groups": "[Admins Readers]" },
+    });
+  });
+
+  it("takes the token with or without the Bearer prefix", async () => {
+    // Given a gated method
+    const { simAws, restApi, signedIn } = await gatedApi();
+
+    // When the token is sent under the scheme, in two cases of it
+    const upperCase = await get(simAws, restApi, {
+      authorization: `Bearer ${signedIn.accessToken}`,
+    });
+    const lowerCase = await get(simAws, restApi, {
+      authorization: `bearer ${signedIn.accessToken}`,
+    });
+
+    // Then both are read, since API Gateway strips the scheme rather than
+    // requiring it
+    assertIdentical(upperCase.status, 200);
+    assertIdentical(lowerCase.status, 200);
+  });
+
+  it("refuses a request carrying no token", async () => {
+    // Given a gated method
+    const { simAws, restApi } = await gatedApi();
+
+    // When it is called with nothing in the identity source
+    const response = await get(simAws, restApi);
+
+    // Then the request is refused, and the handler never ran
+    assertIdentical(response.status, 401);
+    assertIdentical(await response.text(), '{"message":"Unauthorized"}');
+  });
+
+  it("refuses a header that is not a readable JWT", async () => {
+    // Given a gated method
+    const { simAws, restApi } = await gatedApi();
+
+    // When something that is not a token is presented
+    const response = await get(simAws, restApi, {
+      authorization: "Bearer not-a-token",
+    });
+
+    // Then it is refused the same way a missing token is, so a client learns
+    // nothing about which check it failed
+    assertIdentical(response.status, 401);
+    assertIdentical(await response.text(), '{"message":"Unauthorized"}');
+  });
+
+  it("refuses a token no named pool issued", async () => {
+    // Given a gated method and a token from a pool it does not name
+    const { simAws, restApi } = await gatedApi();
+    const otherPool = await simCognitoSignedInFactory.make(
+      { poolName: "other-users" },
+      simAws,
+    );
+
+    // When that token is presented
+    const response = await get(simAws, restApi, {
+      authorization: otherPool.accessToken,
+    });
+
+    // Then it is refused: it is signed by a key no named pool published, and
+    // it names another issuer
+    assertIdentical(response.status, 401);
+  });
+
+  it("refuses a token signed by a key the pool never published", async () => {
+    // Given a gated method and a token the same pool would not have signed
+    const { simAws, restApi, signedIn } = await gatedApi();
+    const forged = await simCognitoSignedInFactory.make(
+      { poolName: "forgers" },
+      simAws,
+    );
+    const [header, , signature] = forged.accessToken.split(".", 3);
+    const [, claims] = signedIn.accessToken.split(".", 2);
+
+    // When it carries the accepted pool's claims under another pool's key
+    const response = await get(simAws, restApi, {
+      authorization: `${header}.${claims}.${signature}`,
+    });
+
+    // Then it is refused, because the signature is checked rather than read
+    assertIdentical(response.status, 401);
+  });
+
+  it("expires an already-issued token when the clock advances", async () => {
+    // Given a gated method and a token that works
+    const { simAws, restApi, signedIn } = await gatedApi();
+    const accepted = await get(simAws, restApi, {
+      authorization: signedIn.accessToken,
+    });
+
+    // When simulated time passes the token's expiry, with nothing reissued
+    await simAws.clock().advanceBy({ hours: 2 });
+
+    // Then the same token is refused
+    const expired = await get(simAws, restApi, {
+      authorization: signedIn.accessToken,
+    });
+    assertIdentical(accepted.status, 200);
+    assertIdentical(expired.status, 401);
+  });
+
+  it("lets a token through that claims a scope the method asks for", async () => {
+    // Given a method asking for the scope a pool sign-in issues
+    const { simAws, restApi, signedIn } = await gatedApi([adminScope]);
+
+    // When an access token carrying that scope is presented
+    const response = await get(simAws, restApi, {
+      authorization: signedIn.accessToken,
+    });
+
+    // Then the method is reached, because one method scope matched
+    assertIdentical(response.status, 200);
+  });
+
+  it("refuses a verified token claiming none of the method's scopes", async () => {
+    // Given a method asking for a scope no simulated flow issues
+    const { simAws, restApi, signedIn } = await gatedApi(["orders.write"]);
+
+    // When an accepted access token is presented
+    const response = await get(simAws, restApi, {
+      authorization: signedIn.accessToken,
+    });
+
+    // Then the answer is 403 rather than 401: the token was accepted, and it
+    // does not allow this method
+    assertIdentical(response.status, 403);
+    assertObjectMatches(await response.json(), {
+      Message: "User is not authorized to access this resource",
+    });
+  });
+
+  it("refuses an id token on a method that asks for a scope", async () => {
+    // Given a method asking for the access token's scope
+    const { simAws, restApi, signedIn } = await gatedApi([adminScope]);
+
+    // When the id token is presented
+    const response = await get(simAws, restApi, {
+      authorization: signedIn.idToken,
+    });
+
+    // Then it is refused, because an id token carries no scope claim at all.
+    // Method scopes are the only thing that tells the two token types apart.
+    assertIdentical(response.status, 403);
+  });
+
+  it("refuses every request once the method's authorizer is deleted", async () => {
+    // Given a gated method whose authorizer is then deleted
+    const { simAws, restApi, signedIn } = await gatedApi();
+    const [authorizer] = restApi.authorizers.list();
+    await simAws.apiGateway().deleteAuthorizer({
+      input: {
+        restApiId: restApi.apiId,
+        authorizerId: authorizer?.authorizerId,
+      },
+    });
+
+    // When a token that worked before is presented
+    const response = await get(simAws, restApi, {
+      authorization: signedIn.accessToken,
+    });
+
+    // Then the method stays closed rather than falling open, since there is
+    // nothing left to verify the token against
+    assertIdentical(response.status, 401);
+  });
+
+  it("refuses every token when the named pool is gone", async () => {
+    // Given a gated method whose pool is deleted out from under it
+    const { simAws, restApi, signedIn } = await gatedApi();
+    await simAws.cognitoIdentityProvider().deleteUserPool({
+      input: { UserPoolId: signedIn.userPoolId },
+    });
+
+    // When a token that pool issued is presented
+    const response = await get(simAws, restApi, {
+      authorization: signedIn.accessToken,
+    });
+
+    // Then it is refused, because a pool that is gone publishes nothing to
+    // check the signature against
+    assertIdentical(response.status, 401);
+  });
+
+  it("admits a token from any one of the pools the authorizer names", async () => {
+    // Given a method naming two pools, and a user signed in to the second
+    const simAws = new SimAws();
+    const first = await simCognitoSignedInFactory.make(
+      { poolName: "staff" },
+      simAws,
+    );
+    const second = await simCognitoSignedInFactory.make(
+      { poolName: "customers", username: "grace" },
+      simAws,
+    );
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      {
+        handler: claimsHandler,
+        resourcePaths: ["/orders"],
+        httpMethod: "GET",
+        cognitoUserPoolArns: [first.userPoolArn, second.userPoolArn],
+      },
+      simAws,
+    );
+
+    // When that user's token is presented
+    const response = await get(simAws, restApi, {
+      authorization: second.accessToken,
+    });
+
+    // Then it is admitted, since any one of the named pools is enough
+    assertIdentical(response.status, 200);
+    assertObjectMatches(await response.json(), {
+      claims: { iss: second.issuerUrl, username: "grace" },
+    });
+  });
+});

--- a/src/service/apigateway/serve/sim-rest-api-integration-invocation.ts
+++ b/src/service/apigateway/serve/sim-rest-api-integration-invocation.ts
@@ -69,6 +69,7 @@ export class SimRestApiIntegrationInvocation {
         {
           lambda: input.authorization.lambda,
           caller: input.authorization.caller,
+          cognito: input.authorization.cognito,
         },
       );
       const result = await target.simFunction.invoke(event);

--- a/src/service/apigateway/sim-api-gateway-commands.ts
+++ b/src/service/apigateway/sim-api-gateway-commands.ts
@@ -8,6 +8,10 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import {
+  SimRestApiNoUserPools,
+  type SimRestApiUserPools,
+} from "./api/authorizer/sim-rest-api-user-pools.js";
 import { SimRestApiStore } from "./api/sim-rest-api-store.js";
 import { SimRestApiCommands } from "./command/api/sim-rest-api-commands.js";
 import { SimRestApiImportCommands } from "./command/api/sim-rest-api-import-commands.js";
@@ -29,6 +33,13 @@ export interface SimApiGatewayProperties {
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
   readonly registry?: SimRestApiRegistry;
+  /**
+   * The user pools this API Gateway's Cognito authorizers verify tokens
+   * against. A standalone simulated API Gateway has none, so a
+   * `COGNITO_USER_POOLS` method refuses every request rather than admitting
+   * one it could not check.
+   */
+  readonly userPools?: SimRestApiUserPools;
 }
 
 /**
@@ -57,6 +68,7 @@ export class SimApiGatewayCommands {
       iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
       registry = new SimRestApiRegistry(),
+      userPools = new SimRestApiNoUserPools(),
     } = properties;
 
     const access = new SimRestApiAccess({
@@ -71,6 +83,7 @@ export class SimApiGatewayCommands {
       access,
       accountRegionScope,
       clock: background,
+      userPools,
     });
     this.resources = new SimRestApiResourceCommands({ access });
     this.authorizers = new SimRestApiAuthorizerCommands({ access });

--- a/src/service/apigatewayv2/api/authorizer/sim-http-api-jwt-claim-checks.ts
+++ b/src/service/apigatewayv2/api/authorizer/sim-http-api-jwt-claim-checks.ts
@@ -1,5 +1,6 @@
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import type { SimJwtClaims } from "../../../../util/jwt/sim-jwt-claims.js";
+import { SimJwtTimeClaims } from "../../../../util/jwt/sim-jwt-time-claims.js";
 import { SimHttpApiRefused } from "./sim-http-api-authorization.js";
 import type { SimHttpApiJwtConfiguration } from "./sim-http-api-jwt-configuration.js";
 
@@ -29,10 +30,10 @@ interface SimHttpApiJwtClaimChecksProperties {
  * request into a refused one with nothing else changed.
  */
 export class SimHttpApiJwtClaimChecks {
-  private readonly clock: SimClock;
+  private readonly times: SimJwtTimeClaims;
 
   constructor(properties: SimHttpApiJwtClaimChecksProperties) {
-    this.clock = properties.clock;
+    this.times = new SimJwtTimeClaims({ clock: properties.clock });
   }
 
   /**
@@ -51,7 +52,9 @@ export class SimHttpApiJwtClaimChecks {
       return SimHttpApiRefused.unauthorized(simHttpApiInvalidAudience);
     }
 
-    return this.checkTimes(claims);
+    return this.times.hold(claims)
+      ? undefined
+      : SimHttpApiRefused.unauthorized();
   }
 
   /**
@@ -71,39 +74,5 @@ export class SimHttpApiJwtClaimChecks {
     const clientId = claims.text("client_id");
 
     return clientId === undefined ? [] : [clientId];
-  }
-
-  /**
-   * Check `exp`, `nbf` and `iat` against the simulation's clock.
-   *
-   * A token with no `exp` is refused rather than treated as one that never
-   * expires: real Cognito always sets it, and admitting a token nothing can
-   * expire is the divergence worth failing on.
-   */
-  private checkTimes(claims: SimJwtClaims): SimHttpApiRefused | undefined {
-    const now = Math.floor(this.clock.now().getTime() / 1000);
-    const expiresAt = claims.number("exp");
-
-    if (expiresAt === undefined || now >= expiresAt) {
-      return SimHttpApiRefused.unauthorized();
-    }
-
-    if (this.isBefore(now, claims.number("nbf"))) {
-      return SimHttpApiRefused.unauthorized();
-    }
-
-    if (this.isBefore(now, claims.number("iat"))) {
-      return SimHttpApiRefused.unauthorized();
-    }
-
-    return undefined;
-  }
-
-  /**
-   * Whether now is earlier than a time claim the token carries. A claim the
-   * token does not carry is nothing to be earlier than.
-   */
-  private isBefore(now: number, claimed: number | undefined): boolean {
-    return claimed !== undefined && now < claimed;
   }
 }

--- a/src/service/apigatewayv2/api/authorizer/sim-http-api-jwt-claims.ts
+++ b/src/service/apigatewayv2/api/authorizer/sim-http-api-jwt-claims.ts
@@ -1,26 +1,15 @@
 import type { SimPayload2JwtAuthorizer } from "../../../../serve/payload-2/sim-payload-2-event.type.js";
-import {
-  isSimJwtClaimList,
-  type SimJwtClaims,
-  type SimJwtClaimValue,
-} from "../../../../util/jwt/sim-jwt-claims.js";
+import { simJwtClaimStrings } from "../../../../util/jwt/sim-jwt-claim-strings.js";
+import type { SimJwtClaims } from "../../../../util/jwt/sim-jwt-claims.js";
+import { simJwtScopes } from "../../../../util/jwt/sim-jwt-scopes.js";
 
 /**
- * The claims a scope can be written in.
+ * The claims of an accepted token, as an HTTP API hands them to the handler.
  *
- * `scope` is what an OAuth 2.0 access token carries, and `scp` is what some
- * issuers use instead. Cognito writes `scope`.
- */
-const scopeClaimNames = ["scope", "scp"];
-
-/**
- * The claims of an accepted token, as they reach the handler.
- *
- * Two things here are observed rather than published by AWS. Every claim value
- * arrives at the handler as a string, and a list claim such as
- * `cognito:groups` is rendered the way Go prints a slice, so two groups arrive
- * as `[GroupA GroupB]` rather than as JSON or as a comma-separated list. And
- * `scopes` is null, not an empty list, when the token carries no scope claim.
+ * The rendering is the same one a REST API applies, and lives beside the JWT
+ * reader. What is here is the shape a payload format 2.0 event carries: the
+ * claims and the scopes beside them, with `scopes` null rather than an empty
+ * list when the token carries no scope claim.
  */
 export class SimHttpApiJwtClaims {
   private readonly claims: SimJwtClaims;
@@ -33,65 +22,13 @@ export class SimHttpApiJwtClaims {
    * The `requestContext.authorizer.jwt` block for this token.
    */
   toAuthorizerContext(): SimPayload2JwtAuthorizer {
-    return { claims: this.claimStrings(), scopes: this.scopes() };
+    return { claims: simJwtClaimStrings(this.claims), scopes: this.scopes() };
   }
 
   /**
    * The scopes this token claims, or null when it claims none.
    */
   scopes(): string[] | null {
-    for (const name of scopeClaimNames) {
-      const claimed = this.claimedScopes(name);
-
-      if (claimed !== undefined) {
-        return claimed;
-      }
-    }
-
-    return null;
-  }
-
-  private claimedScopes(name: string): string[] | undefined {
-    const text = this.claims.text(name);
-
-    if (text !== undefined) {
-      return text.split(/\s+/).filter((scope) => scope.length > 0);
-    }
-
-    const list = this.claims.textList(name);
-
-    return list === undefined ? undefined : [...list];
-  }
-
-  private claimStrings(): Record<string, string> {
-    return Object.fromEntries(
-      Object.entries(this.claims.toRecord()).map(([name, value]) => [
-        name,
-        this.claimString(value),
-      ]),
-    );
-  }
-
-  /**
-   * One claim value as the string the handler receives.
-   *
-   * A nested object claim is JSON-encoded, which is the one shape here that
-   * was not observed on real AWS: no simulated issuer emits one, and neither
-   * does Cognito.
-   */
-  private claimString(value: SimJwtClaimValue): string {
-    if (typeof value === "string") {
-      return value;
-    }
-
-    if (isSimJwtClaimList(value)) {
-      return `[${value.map((entry) => this.claimString(entry)).join(" ")}]`;
-    }
-
-    if (typeof value === "object" && value !== null) {
-      return JSON.stringify(value);
-    }
-
-    return String(value);
+    return simJwtScopes(this.claims);
   }
 }

--- a/src/service/apigatewayv2/serve/auth/sim-http-api-jwt-route-authorizer.ts
+++ b/src/service/apigatewayv2/serve/auth/sim-http-api-jwt-route-authorizer.ts
@@ -1,9 +1,9 @@
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import { simJwtBearerToken } from "../../../../util/jwt/sim-jwt-bearer-token.js";
 import {
   type SimHttpApiAuthorization,
   SimHttpApiRefused,
 } from "../../api/authorizer/sim-http-api-authorization.js";
-import { simHttpApiBearerToken } from "../../api/authorizer/sim-http-api-bearer-token.js";
 import { SimHttpApiJwtAuthorizer } from "../../api/authorizer/sim-http-api-jwt-authorizer.js";
 import { SimHttpApiJwtVerification } from "../../api/authorizer/sim-http-api-jwt-verification.js";
 import type { SimHttpApiRouteAuthorizeInput } from "./sim-http-api-route-authorize-input.js";
@@ -46,7 +46,7 @@ export class SimHttpApiJwtRouteAuthorizer {
       return SimHttpApiRefused.unauthorized();
     }
 
-    const presented = simHttpApiBearerToken(
+    const presented = simJwtBearerToken(
       authorizer.identitySource.value({
         request,
         routeKey: route.routeKey,

--- a/src/service/aws/factory/sim-aws-cross-account-collaborators.ts
+++ b/src/service/aws/factory/sim-aws-cross-account-collaborators.ts
@@ -1,4 +1,5 @@
 import { SimRoute53AcmDnsRecords } from "../../acm/validation/sim-route53-acm-dns-records.js";
+import { SimCognitoRestApiUserPools } from "../../apigateway/api/authorizer/sim-cognito-rest-api-user-pools.js";
 import { SimCognitoHttpApiJwtIssuerKeys } from "../../apigatewayv2/api/authorizer/sim-cognito-http-api-jwt-issuer-keys.js";
 import { SimAwsEventBridgeDeliveryTargets } from "../../eventbridge/delivery/sim-aws-event-bridge-delivery-targets.js";
 import { SimAwsRekognitionImageObjects } from "../../rekognition/image/s3/sim-aws-rekognition-image-objects.js";
@@ -30,6 +31,20 @@ export function simAwsHttpApiJwtIssuerKeys(
   registries: SimAwsScopedServiceRegistries,
 ): SimCognitoHttpApiJwtIssuerKeys {
   return new SimCognitoHttpApiJwtIssuerKeys({
+    userPoolRegistry: registries.cognito,
+  });
+}
+
+/**
+ * The user pools a simulated REST API's Cognito authorizer verifies against.
+ *
+ * An authorizer can name a pool in any Account, as a real one can, so this
+ * reads the whole simulation's Cognito rather than one scope's.
+ */
+export function simAwsRestApiUserPools(
+  registries: SimAwsScopedServiceRegistries,
+): SimCognitoRestApiUserPools {
+  return new SimCognitoRestApiUserPools({
     userPoolRegistry: registries.cognito,
   });
 }

--- a/src/service/aws/factory/sim-aws-registered-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-registered-service-builder.ts
@@ -5,6 +5,7 @@ import { SimApiGatewayV2 } from "../../apigatewayv2/index.js";
 import {
   simAwsAcmDnsRecords,
   simAwsHttpApiJwtIssuerKeys,
+  simAwsRestApiUserPools,
 } from "./sim-aws-cross-account-collaborators.js";
 import { SimEcr } from "../../ecr/index.js";
 import { SimElbV2 } from "../../elbv2/index.js";
@@ -65,6 +66,7 @@ export class SimAwsRegisteredServiceBuilder {
       // API ids are unique across the simulation, and an API is reachable by
       // id alone from the serving layer, whichever scope created it.
       registry: this.registries.restApi,
+      userPools: simAwsRestApiUserPools(this.registries),
     });
   }
 

--- a/src/service/cloudformation/cdk/apigateway/sim-cdk-rest-api-cognito-authorizer.loc.test.ts
+++ b/src/service/cloudformation/cdk/apigateway/sim-cdk-rest-api-cognito-authorizer.loc.test.ts
@@ -1,0 +1,170 @@
+import {
+  AdminCreateUserCommand,
+  AdminInitiateAuthCommand,
+  AdminSetUserPasswordCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { assertIdentical, assertTypeString } from "@kensio/smartass";
+import path from "node:path";
+import { describe, it } from "vitest";
+
+/**
+ * Slower local integration test. Calls the real CDK CLI to synth the output
+ * template file, then serves the deployed REST API over real localhost HTTP
+ * and signs in against the deployed user pool to call it.
+ */
+import { serveSimAws } from "../../../../serve/index.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { TemporaryDirectory } from "../../../../util/filesystem/temporary-directory.js";
+import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+
+/**
+ * The method's handler, reporting the username off the claims the authorizer
+ * accepted. A REST API puts them under `claims`, where an HTTP API nests them
+ * under `jwt`.
+ */
+const ordersHandlerSource = `
+exports.handler = async (event) => ({
+  statusCode: 200,
+  headers: { "content-type": "text/plain" },
+  body: event.requestContext.authorizer.claims["cognito:username"],
+});
+`;
+
+/**
+ * The app client is passed nothing but the flows the sign-in below needs.
+ * Left to itself, CDK's defaults emit the OAuth properties simulated Cognito
+ * refuses.
+ */
+const cdkApp = `
+import * as cdk from "aws-cdk-lib/core";
+import * as cognito from "aws-cdk-lib/aws-cognito";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as apigw from "aws-cdk-lib/aws-apigateway";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "111111111111", region: "eu-west-2" },
+});
+
+const pool = new cognito.UserPool(stack, "Pool");
+const client = pool.addClient("Client", {
+  disableOAuth: true,
+  authFlows: { adminUserPassword: true },
+});
+
+const ordersFunction = new lambda.Function(stack, "OrdersFunction", {
+  functionName: "cdk-orders",
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: lambda.Code.fromInline(${JSON.stringify(ordersHandlerSource)}),
+});
+
+const api = new apigw.RestApi(stack, "OrdersApi", { restApiName: "orders" });
+
+const authorizer = new apigw.CognitoUserPoolsAuthorizer(stack, "PoolAuthorizer", {
+  cognitoUserPools: [pool],
+});
+
+api.root
+  .addResource("orders")
+  .addMethod("GET", new apigw.LambdaIntegration(ordersFunction), {
+    authorizer,
+    authorizationType: apigw.AuthorizationType.COGNITO,
+  });
+
+new cdk.CfnOutput(stack, "ApiUrl", { value: api.url });
+new cdk.CfnOutput(stack, "PoolId", { value: pool.userPoolId });
+new cdk.CfnOutput(stack, "ClientId", { value: client.userPoolClientId });
+
+app.synth();
+`;
+
+describe("Sim CDK REST API Cognito authorizer local integration", () => {
+  it("gates a CDK-deployed method with a CDK-deployed user pool", async () => {
+    // Given a CDK stack with a user pool, an app client, and a REST API whose
+    // one method goes through a CognitoUserPoolsAuthorizer trusting that pool.
+    const simAws = new SimAws({
+      defaultAccountId: "111111111111",
+      defaultRegionName: "eu-west-2",
+    });
+    const projectDirectory = new TemporaryDirectory();
+    const cdkProject = new TestCdkProject({ projectDirectory });
+    await cdkProject.writeCdkAppFile(cdkApp);
+
+    // And we synth the CDK template.
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When we deploy the template into sim CloudFormation.
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+    await simAws.backgroundTasksComplete();
+
+    const apiUrl = stack.outputs.get("ApiUrl")?.value;
+    const userPoolId = stack.outputs.get("PoolId")?.value;
+    const clientId = stack.outputs.get("ClientId")?.value;
+    assertTypeString(apiUrl);
+    assertTypeString(userPoolId);
+    assertTypeString(clientId);
+
+    // And a user of the deployed pool signs in.
+    const cognito = simAws.cognitoIdentityProvider();
+    await cognito.adminCreateUser(
+      new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "ada" }),
+    );
+    await cognito.adminSetUserPassword(
+      new AdminSetUserPasswordCommand({
+        UserPoolId: userPoolId,
+        Username: "ada",
+        Password: "Correct-horse-1",
+        Permanent: true,
+      }),
+    );
+    const signedIn = await cognito.adminInitiateAuth(
+      new AdminInitiateAuthCommand({
+        UserPoolId: userPoolId,
+        ClientId: clientId,
+        AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+        AuthParameters: { USERNAME: "ada", PASSWORD: "Correct-horse-1" },
+      }),
+    );
+    // Asserted rather than defaulted, so a sign-in that answered a challenge
+    // instead of a token fails here rather than as a puzzling 401 below.
+    const idToken = signedIn.AuthenticationResult?.IdToken;
+    assertTypeString(idToken);
+
+    const srv = await serveSimAws({ simAws });
+
+    try {
+      const url = srv.localUrl(`${apiUrl}orders`);
+
+      // Then the deployed method is closed to a request carrying no token.
+      const anonymous = await fetch(url);
+      assertIdentical(anonymous.status, 401);
+      assertIdentical(await anonymous.text(), '{"message":"Unauthorized"}');
+
+      // And the id token from that sign-in reaches the handler, which read
+      // the username off the claims the authorizer accepted.
+      const authorized = await fetch(url, {
+        headers: { authorization: idToken },
+      });
+      assertIdentical(authorized.status, 200);
+      assertIdentical(await authorized.text(), "ada");
+
+      // And advancing the simulation's clock past the token's expiry closes
+      // the method to the same token, with nothing reissued.
+      await simAws.clock().advanceBy({ hours: 2 });
+
+      const expired = await fetch(url, {
+        headers: { authorization: idToken },
+      });
+      assertIdentical(expired.status, 401);
+    } finally {
+      await srv.close();
+    }
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/service/cognito/user-pool/auth/sim-cognito-signed-in.factory.ts
+++ b/src/service/cognito/user-pool/auth/sim-cognito-signed-in.factory.ts
@@ -21,6 +21,8 @@ export interface SimCognitoSignedInInput {
  */
 export interface SimCognitoSignedIn {
   readonly userPoolId: string;
+  /** The ARN of that pool, which is how another service names it. */
+  readonly userPoolArn: string;
   readonly clientId: string;
   readonly username: string;
   readonly accessToken: string;
@@ -123,6 +125,7 @@ export const simCognitoSignedInFactory = new AsyncMappedFactory<
 
     return {
       userPoolId,
+      userPoolArn: userPool.arn.value,
       clientId,
       username: input.username,
       accessToken,

--- a/src/util/jwt/sim-jwt-bearer-token.ts
+++ b/src/util/jwt/sim-jwt-bearer-token.ts
@@ -5,16 +5,16 @@
  * there rather than required. The comparison is case-insensitive, since HTTP
  * authorization schemes are.
  */
-const bearerPrefix = /^bearer\s+/i;
+const bearerPrefix = /^bearer\s+/iu;
 
 /**
  * The token an identity source value carries, if it carries one at all.
  *
- * This is a JWT authorizer's reading of the value. A Lambda `REQUEST`
- * authorizer is handed the value as it arrived instead, since what it names
- * may be a cookie or an API key rather than a bearer token.
+ * This is how a verifier of tokens reads the value. A Lambda authorizer is
+ * handed the value as it arrived instead, since what it names may be a cookie
+ * or an API key rather than a bearer token.
  */
-export function simHttpApiBearerToken(
+export function simJwtBearerToken(
   value: string | undefined,
 ): string | undefined {
   const token = value?.replace(bearerPrefix, "").trim();

--- a/src/util/jwt/sim-jwt-claim-strings.ts
+++ b/src/util/jwt/sim-jwt-claim-strings.ts
@@ -1,0 +1,49 @@
+import {
+  isSimJwtClaimList,
+  type SimJwtClaims,
+  type SimJwtClaimValue,
+} from "./sim-jwt-claims.js";
+
+/**
+ * The claims of an accepted token, as they reach a handler behind API Gateway.
+ *
+ * Two things here are observed rather than published by AWS. Every claim value
+ * arrives at the handler as a string, and a list claim such as
+ * `cognito:groups` is rendered the way Go prints a slice, so two groups arrive
+ * as `[GroupA GroupB]` rather than as JSON or as a comma-separated list. Both
+ * API Gateway versions render them the same way, which is why this is here
+ * rather than in one of them.
+ */
+export function simJwtClaimStrings(
+  claims: SimJwtClaims,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(claims.toRecord()).map(([name, value]) => [
+      name,
+      simJwtClaimString(value),
+    ]),
+  );
+}
+
+/**
+ * One claim value as the string the handler receives.
+ *
+ * A nested object claim is JSON-encoded, which is the one shape here that was
+ * not observed on real AWS: no simulated issuer emits one, and neither does
+ * Cognito.
+ */
+function simJwtClaimString(value: SimJwtClaimValue): string {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (isSimJwtClaimList(value)) {
+    return `[${value.map((entry) => simJwtClaimString(entry)).join(" ")}]`;
+  }
+
+  if (typeof value === "object" && value !== null) {
+    return JSON.stringify(value);
+  }
+
+  return String(value);
+}

--- a/src/util/jwt/sim-jwt-scopes.ts
+++ b/src/util/jwt/sim-jwt-scopes.ts
@@ -1,0 +1,46 @@
+import type { SimJwtClaims } from "./sim-jwt-claims.js";
+
+/**
+ * The claims a scope can be written in.
+ *
+ * `scope` is what an OAuth 2.0 access token carries, and `scp` is what some
+ * issuers use instead. Cognito writes `scope`.
+ */
+const scopeClaimNames = ["scope", "scp"];
+
+/**
+ * The scopes a token claims, or null when it claims none.
+ *
+ * Null rather than an empty list is what API Gateway reports for a token
+ * carrying no scope claim at all, which is every Cognito id token.
+ */
+export function simJwtScopes(claims: SimJwtClaims): string[] | null {
+  for (const name of scopeClaimNames) {
+    const claimed = claimedScopes(claims, name);
+
+    if (claimed !== undefined) {
+      return claimed;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * The scopes one claim holds, whether it was written as space-separated text
+ * or as a list.
+ */
+function claimedScopes(
+  claims: SimJwtClaims,
+  name: string,
+): string[] | undefined {
+  const text = claims.text(name);
+
+  if (text !== undefined) {
+    return text.split(/\s+/u).filter((scope) => scope.length > 0);
+  }
+
+  const list = claims.textList(name);
+
+  return list === undefined ? undefined : [...list];
+}

--- a/src/util/jwt/sim-jwt-time-claims.ts
+++ b/src/util/jwt/sim-jwt-time-claims.ts
@@ -1,0 +1,50 @@
+import type { SimClock } from "../clock/sim-clock.js";
+import type { SimJwtClaims } from "./sim-jwt-claims.js";
+
+interface SimJwtTimeClaimsProperties {
+  readonly clock: SimClock;
+}
+
+/**
+ * The time claims of a token, checked against a clock.
+ *
+ * The comparison allows nothing for clock skew. That is what makes advancing
+ * the simulation's clock past a token's `exp` turn an accepted request into a
+ * refused one with nothing else changed.
+ */
+export class SimJwtTimeClaims {
+  private readonly clock: SimClock;
+
+  constructor(properties: SimJwtTimeClaimsProperties) {
+    this.clock = properties.clock;
+  }
+
+  /**
+   * Whether `exp`, `nbf` and `iat` all hold at this moment.
+   *
+   * A token with no `exp` holds nothing rather than never expiring: real
+   * Cognito always sets it, and admitting a token nothing can expire is the
+   * divergence worth failing on.
+   */
+  hold(claims: SimJwtClaims): boolean {
+    const now = Math.floor(this.clock.now().getTime() / 1000);
+    const expiresAt = claims.number("exp");
+
+    if (expiresAt === undefined || now >= expiresAt) {
+      return false;
+    }
+
+    return (
+      !this.isBefore(now, claims.number("nbf")) &&
+      !this.isBefore(now, claims.number("iat"))
+    );
+  }
+
+  /**
+   * Whether now is earlier than a time claim the token carries. A claim the
+   * token does not carry is nothing to be earlier than.
+   */
+  private isBefore(now: number, claimed: number | undefined): boolean {
+    return claimed !== undefined && now < claimed;
+  }
+}


### PR DESCRIPTION
`CreateAuthorizer` takes `type: COGNITO_USER_POOLS` with `providerARNs` naming simulated user pools,
and `PutMethod` takes `authorizationType: COGNITO_USER_POOLS` with the authorizer id and the scopes
the method asks for. A request carrying a token one of those pools signed reaches the handler with
the token's claims under `requestContext.authorizer.claims`, every value a string. A token no named
pool issued, an expired one, one signed by an unknown key and a header that is not a readable JWT
are each refused with 401, and a token meeting none of the method's `authorizationScopes` gets a
403. `AWS::ApiGateway::Authorizer` with `Type: COGNITO_USER_POOLS` deploys, and a CDK stack using
`apigateway.CognitoUserPoolsAuthorizer` serves a request end to end.

Resolves #792
