### PR TITLE
feat: cache a REST API authorizer's decision

### DIFF
--- a/docs/services/apigateway/README.md
+++ b/docs/services/apigateway/README.md
@@ -633,8 +633,11 @@ one.
 
 `authorizerResultTtlInSeconds` holds a decision for that many seconds. A second request presenting
 the same identity within that period reaches the handler without the function running again. AWS
-accepts a whole number of seconds up to 3600. The default is 0, and an authorizer left at 0
-decides every request afresh.
+accepts a whole number of seconds up to 3600, and 0 switches the holding off.
+
+An authorizer that says nothing about the member gets 0 here and gets 300 on real API Gateway.
+Write the member out to have a test and a deployment agree on it. CDK writes it either way, at five
+minutes by default (see [CDK](#cdk)).
 
 A `TOKEN` authorizer is keyed on the token it was handed. A `REQUEST` authorizer is keyed on the
 values its identity sources found, in the order they were configured. Both are held per method,
@@ -718,8 +721,9 @@ console.log(await call());
 await srv.close();
 ```
 
-A `COGNITO_USER_POOLS` authorizer verifies each token as it arrives, and `CreateAuthorizer` refuses
-`authorizerResultTtlInSeconds` on one.
+A `COGNITO_USER_POOLS` authorizer verifies each token as it arrives here, and `CreateAuthorizer`
+refuses `authorizerResultTtlInSeconds` on one. Real API Gateway holds a Cognito authorizer's
+decision too, and a token that expires inside the period is still accepted there.
 
 ## Protecting a method with IAM
 
@@ -1543,6 +1547,9 @@ and behave differently deployed. The refusals worth knowing about:
   `COGNITO_USER_POOLS` authorizer. Real API Gateway holds that decision, and a token expiring
   during the period would still be accepted. A Lambda authorizer takes the member. See
   [Caching the authorizer's decision](#caching-the-authorizers-decision).
+- **The default period.** A Lambda authorizer written with no `authorizerResultTtlInSeconds` holds
+  no decision here, where real API Gateway would hold one for 300 seconds. An authorizer counting
+  its own invocations counts one per request until the member is written out.
 - **Integration types.** Only `AWS_PROXY` with a Lambda function URI is simulated. `MOCK`, `HTTP`,
   `HTTP_PROXY` and the non-proxy `AWS` type each answer a request from somewhere this cannot reach.
 - **API keys and usage plans.** `apiKeyRequired: true` is refused, because a method requiring a key

--- a/docs/services/apigateway/README.md
+++ b/docs/services/apigateway/README.md
@@ -629,6 +629,98 @@ That ARN names no stage. A function used both as an integration and as an author
 permissions, as it does on AWS. CDK's `TokenAuthorizer` and `RequestAuthorizer` both write this
 one.
 
+### Caching the authorizer's decision
+
+`authorizerResultTtlInSeconds` holds a decision for that many seconds. A second request presenting
+the same identity within that period reaches the handler without the function running again. AWS
+accepts a whole number of seconds up to 3600. The default is 0, and an authorizer left at 0
+decides every request afresh.
+
+A `TOKEN` authorizer is keyed on the token it was handed. A `REQUEST` authorizer is keyed on the
+values its identity sources found, in the order they were configured. Both are held per method,
+because what is held is the admission or refusal the authorizer's policy produced for one method
+ARN, and that answer covers no other method. (An HTTP API keys on the identity source values alone,
+and one decision there covers every route using the authorizer.)
+
+A refusal is held the way an admission is. AWS holds whatever answer the authorizer gave. A failed
+authorizer holds no answer, and its function is asked again on the next request.
+
+Expiry follows simulated time. `simAws.clock().advanceBy(...)` drops a decision that was being
+reused a moment before.
+
+```typescript sim-apigateway-authorizer-cache
+/**
+ * Caching a simulated REST API Lambda authorizer's decision.
+ *
+ * The authorizer counts its own invocations and reports the count in its
+ * context, so the handler shows which decision served each request.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import { simRestApiLambdaProxyFactory } from "@kensio/yulin/apigateway";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const counter = { invocations: 0 };
+
+const restApi = await simRestApiLambdaProxyFactory.make(
+  {
+    resourcePaths: ["/orders"],
+    authorizerResultTtlSeconds: 300,
+    authorizerHandler: (event) => {
+      counter.invocations += 1;
+
+      return {
+        principalId: "user-6",
+        context: { ...counter },
+        policyDocument: {
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Action: "execute-api:Invoke",
+              Effect: "Allow",
+              Resource: event.methodArn,
+            },
+          ],
+        },
+      };
+    },
+    handler: (event) => ({
+      statusCode: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(event.requestContext.authorizer),
+    }),
+  },
+  simAws,
+);
+
+const srv = await serveSimAws({ simAws });
+const url = srv.localUrl(`${restApi.invokeUrl("prod")}/orders`);
+const call = async (): Promise<unknown> => {
+  const response = await fetch(url, {
+    headers: { authorization: "Bearer session-6" },
+  });
+
+  return await response.json();
+};
+
+console.log(await call());
+// { invocations: 1, principalId: 'user-6' }
+
+console.log(await call());
+// { invocations: 1, principalId: 'user-6' }, held rather than asked again
+
+await simAws.clock().advanceBy({ minutes: 6 });
+
+console.log(await call());
+// { invocations: 2, principalId: 'user-6' }
+
+await srv.close();
+```
+
+A `COGNITO_USER_POOLS` authorizer verifies each token as it arrives, and `CreateAuthorizer` refuses
+`authorizerResultTtlInSeconds` on one.
+
 ## Protecting a method with IAM
 
 A method declared `authorizationType: "AWS_IAM"` reaches its integration only when the caller is
@@ -1403,9 +1495,9 @@ method on the root and another on a `{proxy+}` resource, both in front of one fu
 hostname through `AWS::URLSuffix`.
 
 `TokenAuthorizer` and `RequestAuthorizer` deploy too, with the `AWS::Lambda::Permission` each
-writes for its own function. Give either one `resultsCacheTtl: Duration.seconds(0)`, since CDK
-holds a decision for five minutes by default and `AuthorizerResultTtlInSeconds` is one of the
-recorded properties.
+writes for its own function. CDK holds a decision for five minutes by default, and
+`resultsCacheTtl` sets that period. See
+[Caching the authorizer's decision](#caching-the-authorizers-decision).
 
 `CognitoUserPoolsAuthorizer` deploys as it stands, naming the pools it was given by ARN. A method
 takes it with `authorizationType: apigateway.AuthorizationType.COGNITO`, and a user pool the same
@@ -1447,8 +1539,10 @@ and behave differently deployed. The refusals worth knowing about:
   `CreateAuthorizer`.
 - **Scopes on a method that checks none.** `authorizationScopes` is refused on a method that is not
   `COGNITO_USER_POOLS`, since a method carrying scopes nothing checks reads as gated by them.
-- **Holding an authorizer's decision.** `authorizerResultTtlInSeconds` is refused. The function is
-  invoked once per request reaching the method.
+- **Holding a Cognito authorizer's decision.** `authorizerResultTtlInSeconds` is refused on a
+  `COGNITO_USER_POOLS` authorizer. Real API Gateway holds that decision, and a token expiring
+  during the period would still be accepted. A Lambda authorizer takes the member. See
+  [Caching the authorizer's decision](#caching-the-authorizers-decision).
 - **Integration types.** Only `AWS_PROXY` with a Lambda function URI is simulated. `MOCK`, `HTTP`,
   `HTTP_PROXY` and the non-proxy `AWS` type each answer a request from somewhere this cannot reach.
 - **API keys and usage plans.** `apiKeyRequired: true` is refused, because a method requiring a key

--- a/docs/services/apigateway/sim-apigateway-authorizer-cache.example.ts
+++ b/docs/services/apigateway/sim-apigateway-authorizer-cache.example.ts
@@ -1,0 +1,67 @@
+/**
+ * Caching a simulated REST API Lambda authorizer's decision.
+ *
+ * The authorizer counts its own invocations and reports the count in its
+ * context, so the handler shows which decision served each request.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import { simRestApiLambdaProxyFactory } from "@kensio/yulin/apigateway";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const counter = { invocations: 0 };
+
+const restApi = await simRestApiLambdaProxyFactory.make(
+  {
+    resourcePaths: ["/orders"],
+    authorizerResultTtlSeconds: 300,
+    authorizerHandler: (event) => {
+      counter.invocations += 1;
+
+      return {
+        principalId: "user-6",
+        context: { ...counter },
+        policyDocument: {
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Action: "execute-api:Invoke",
+              Effect: "Allow",
+              Resource: event.methodArn,
+            },
+          ],
+        },
+      };
+    },
+    handler: (event) => ({
+      statusCode: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(event.requestContext.authorizer),
+    }),
+  },
+  simAws,
+);
+
+const srv = await serveSimAws({ simAws });
+const url = srv.localUrl(`${restApi.invokeUrl("prod")}/orders`);
+const call = async (): Promise<unknown> => {
+  const response = await fetch(url, {
+    headers: { authorization: "Bearer session-6" },
+  });
+
+  return await response.json();
+};
+
+console.log(await call());
+// { invocations: 1, principalId: 'user-6' }
+
+console.log(await call());
+// { invocations: 1, principalId: 'user-6' }, held rather than asked again
+
+await simAws.clock().advanceBy({ minutes: 6 });
+
+console.log(await call());
+// { invocations: 2, principalId: 'user-6' }
+
+await srv.close();

--- a/src/service/apigateway/api/authorizer/sim-rest-api-authorizer-result-cache.ts
+++ b/src/service/apigateway/api/authorizer/sim-rest-api-authorizer-result-cache.ts
@@ -1,0 +1,117 @@
+import type { SimRestApiAuthorization } from "./sim-rest-api-authorization.js";
+
+/**
+ * One held decision, and the instant it stops being usable.
+ */
+interface SimRestApiCachedResult {
+  readonly authorization: SimRestApiAuthorization;
+  readonly expiresAt: Date;
+}
+
+/**
+ * What one held decision was made for.
+ */
+export interface SimRestApiCacheKey {
+  /**
+   * The ARN of the request the decision was made about, which is what the
+   * authorizer's policy was evaluated against.
+   */
+  readonly methodArn: string;
+  /**
+   * The values the authorizer's identity sources found, in the order they were
+   * configured. A `TOKEN` authorizer has one of these, and it is the token.
+   */
+  readonly identityValues: readonly string[];
+}
+
+/**
+ * The decisions one Lambda authorizer has already made, held for as long as
+ * its `AuthorizerResultTtlInSeconds` says.
+ *
+ * A `TOKEN` authorizer is keyed on the token it was handed and a `REQUEST`
+ * authorizer on the values of its identity sources, which come to the same
+ * thing here: a `TOKEN` authorizer has one identity source, and its value is
+ * the token.
+ *
+ * The method the request was made to is part of the key as well, because what
+ * is held is the decision rather than the policy it came from. That policy was
+ * evaluated against one request ARN, and the admission or refusal it produced
+ * says nothing about any other. An HTTP API keys on the identity source values
+ * alone, and holds a route-shaped answer that carries over.
+ *
+ * The cache belongs to the authorizer rather than to whatever is serving,
+ * because it outlives one request and one server the way the authorizer does.
+ * It holds no clock of its own: the caller passes the instant it is asking
+ * about, so expiry follows the simulation's clock and a test advances time
+ * rather than waiting.
+ */
+export class SimRestApiAuthorizerResultCache {
+  private readonly ttlSeconds: number;
+  private readonly results = new Map<string, SimRestApiCachedResult>();
+
+  constructor(ttlSeconds: number) {
+    this.ttlSeconds = ttlSeconds;
+  }
+
+  /**
+   * Whether this authorizer holds anything at all.
+   *
+   * A TTL of zero is what switches caching off, and is what an authorizer that
+   * says nothing about it gets.
+   */
+  get isEnabled(): boolean {
+    return this.ttlSeconds > 0;
+  }
+
+  /**
+   * The decision already made for this request, if one was made and has not
+   * expired.
+   */
+  find(key: SimRestApiCacheKey, at: Date): SimRestApiAuthorization | undefined {
+    const cached = this.results.get(this.keyOf(key));
+
+    if (cached === undefined) {
+      return undefined;
+    }
+
+    if (cached.expiresAt.getTime() <= at.getTime()) {
+      // Dropped rather than left to be overwritten, so an authorizer that is
+      // never asked about this identity again does not hold it for ever.
+      this.results.delete(this.keyOf(key));
+      return undefined;
+    }
+
+    return cached.authorization;
+  }
+
+  /**
+   * Hold a decision for this authorizer's TTL.
+   *
+   * A refusal is held the same way an admission is, which is what real API
+   * Gateway does: it holds the authorizer's answer, whatever that was.
+   */
+  store(
+    key: SimRestApiCacheKey,
+    at: Date,
+    authorization: SimRestApiAuthorization,
+  ): void {
+    if (!this.isEnabled) {
+      return;
+    }
+
+    this.results.set(this.keyOf(key), {
+      authorization,
+      expiresAt: new Date(at.getTime() + this.ttlSeconds * 1000),
+    });
+  }
+
+  /**
+   * The string one decision is held under.
+   *
+   * The parts are JSON-encoded rather than joined, so two sets that differ
+   * only in where one value ends and the next begins are different keys.
+   */
+  private keyOf(key: SimRestApiCacheKey): string {
+    return JSON.stringify([key.methodArn, key.identityValues]);
+  }
+}

--- a/src/service/apigateway/api/authorizer/sim-rest-api-authorizer.ts
+++ b/src/service/apigateway/api/authorizer/sim-rest-api-authorizer.ts
@@ -44,8 +44,8 @@ export function makeSimRestApiAuthorizerId(): SimRestApiAuthorizerId {
 /**
  * Minimal structural authorizer view, as the Create and Get commands return.
  *
- * `authorizerUri` and `providerARNs` belong to one kind of authorizer each, so
- * each view carries the one its kind has.
+ * `authorizerUri`, `providerARNs` and `authorizerResultTtlInSeconds` belong to
+ * one kind of authorizer each, so each view carries the ones its kind has.
  */
 export interface SimRestApiAuthorizerView {
   id: string;
@@ -55,6 +55,7 @@ export interface SimRestApiAuthorizerView {
   identitySource: string;
   authorizerUri?: string;
   providerARNs?: string[];
+  authorizerResultTtlInSeconds?: number;
 }
 
 interface SimRestApiAuthorizerProperties {

--- a/src/service/apigateway/api/authorizer/sim-rest-api-lambda-authorizer.ts
+++ b/src/service/apigateway/api/authorizer/sim-rest-api-lambda-authorizer.ts
@@ -1,5 +1,6 @@
 import type { SimRestApiLambdaUri } from "../method/sim-rest-api-lambda-uri.js";
 import type { SimRestApiIdentitySources } from "./identity/sim-rest-api-identity-sources.js";
+import { SimRestApiAuthorizerResultCache } from "./sim-rest-api-authorizer-result-cache.js";
 import {
   SimRestApiAuthorizer,
   type SimRestApiAuthorizerId,
@@ -18,6 +19,7 @@ interface SimRestApiLambdaAuthorizerProperties {
   readonly type: SimRestApiLambdaAuthorizerType;
   readonly lambdaUri: SimRestApiLambdaUri;
   readonly identitySources: SimRestApiIdentitySources;
+  readonly resultTtlSeconds: number;
 }
 
 /**
@@ -26,8 +28,8 @@ interface SimRestApiLambdaAuthorizerProperties {
  *
  * The function decides, so nothing here says what a caller has to present.
  * All this holds is which function to invoke, what the request has to carry
- * before it is worth invoking, and how much of the request that function is
- * shown.
+ * before it is worth invoking, how much of the request that function is shown,
+ * and the decisions it has already made.
  */
 export class SimRestApiLambdaAuthorizer extends SimRestApiAuthorizer {
   /**
@@ -49,11 +51,26 @@ export class SimRestApiLambdaAuthorizer extends SimRestApiAuthorizer {
    */
   public readonly identitySources: SimRestApiIdentitySources;
 
+  /**
+   * How long a decision is held for, in seconds, with zero meaning none.
+   */
+  public readonly resultTtlSeconds: number;
+
+  /**
+   * The decisions already made, which a request presenting the same identity
+   * to the same method is served from rather than invoking the function again.
+   */
+  public readonly results: SimRestApiAuthorizerResultCache;
+
   constructor(properties: SimRestApiLambdaAuthorizerProperties) {
     super(properties);
     this.type = properties.type;
     this.lambdaUri = properties.lambdaUri;
     this.identitySources = properties.identitySources;
+    this.resultTtlSeconds = properties.resultTtlSeconds;
+    this.results = new SimRestApiAuthorizerResultCache(
+      properties.resultTtlSeconds,
+    );
   }
 
   /**
@@ -67,6 +84,7 @@ export class SimRestApiLambdaAuthorizer extends SimRestApiAuthorizer {
       authType: simRestApiCustomAuthType,
       authorizerUri: this.lambdaUri.uri,
       identitySource: this.identitySources.expression,
+      authorizerResultTtlInSeconds: this.resultTtlSeconds,
     };
   }
 }

--- a/src/service/apigateway/api/sim-rest-api-lambda-proxy.factory.ts
+++ b/src/service/apigateway/api/sim-rest-api-lambda-proxy.factory.ts
@@ -91,6 +91,7 @@ export const simRestApiLambdaProxyFactory = new AsyncMappedFactory<
     cognitoUserPoolArns: undefined,
     authorizationScopes: [],
     authorizerIdentitySource: "method.request.header.Authorization",
+    authorizerResultTtlSeconds: 0,
     authorizerInvokePermission: true,
     disableExecuteApiEndpoint: false,
     iamAuthorization: false,

--- a/src/service/apigateway/api/sim-rest-api-proxy-authorizer.ts
+++ b/src/service/apigateway/api/sim-rest-api-proxy-authorizer.ts
@@ -53,6 +53,11 @@ export interface SimRestApiProxyAuthorizerInput {
    */
   readonly authorizerIdentitySource: string;
   /**
+   * How long a Lambda authorizer holds a decision for, with zero meaning none,
+   * which is what an authorizer says nothing about it gets.
+   */
+  readonly authorizerResultTtlSeconds: number;
+  /**
    * Whether the authorizer's function grants the API permission to invoke it,
    * under the ARN naming the authorizer. A test about that permission turns
    * this off.

--- a/src/service/apigateway/api/sim-rest-api-proxy-lambda-authorizer.ts
+++ b/src/service/apigateway/api/sim-rest-api-proxy-lambda-authorizer.ts
@@ -69,6 +69,7 @@ export async function simRestApiProxyLambdaAuthorizer(
       type: authorizerFn.type,
       authorizerUri: created.FunctionArn,
       identitySource: input.authorizerIdentitySource,
+      authorizerResultTtlInSeconds: input.authorizerResultTtlSeconds,
     },
   });
 

--- a/src/service/apigateway/cfn/authorizer/sim-cfn-rest-api-authorizer-properties.ts
+++ b/src/service/apigateway/cfn/authorizer/sim-cfn-rest-api-authorizer-properties.ts
@@ -6,11 +6,10 @@ import { SimCfnApiGatewayPropertyParser } from "../sim-cfn-api-gateway-property-
 /**
  * The AWS::ApiGateway::Authorizer properties this simulation deploys.
  *
- * `AuthorizerResultTtlInSeconds`, `AuthorizerCredentials`,
- * `IdentityValidationExpression` and `AuthType` are left out, so a template
- * carrying one has it recorded against the Resource. Each belongs to a piece
- * of work outside this one, and what an authorizer of a given `Type` requires
- * is stated by `CreateAuthorizer` rather than here.
+ * `AuthorizerCredentials`, `IdentityValidationExpression` and `AuthType` are
+ * left out, so a template carrying one has it recorded against the Resource.
+ * Each belongs to a piece of work outside this one, and what an authorizer of
+ * a given `Type` requires is stated by `CreateAuthorizer` rather than here.
  */
 const simulatedProperties = [
   "RestApiId",
@@ -19,6 +18,7 @@ const simulatedProperties = [
   "AuthorizerUri",
   "ProviderARNs",
   "IdentitySource",
+  "AuthorizerResultTtlInSeconds",
 ];
 
 interface SimCfnRestApiAuthorizerPropertiesProperties {
@@ -67,7 +67,6 @@ export class SimCfnRestApiAuthorizerProperties {
    *
    * `IdentitySource` is one comma-separated string, which is how a REST API
    * writes a list where an HTTP API takes one.
->>>>>>> d71bc9d5 (feat: gate a REST API method with a user pool)
    *
    * `AuthorizerUri` arrives as the wrapped
    * `arn:aws:apigateway:<region>:lambda:path/...` form CDK builds with
@@ -100,6 +99,11 @@ export class SimCfnRestApiAuthorizerProperties {
         this.resource,
         this.properties["IdentitySource"],
         "IdentitySource",
+      ),
+      authorizerResultTtlInSeconds: this.propertyParser.optionalNumber(
+        this.resource,
+        this.properties["AuthorizerResultTtlInSeconds"],
+        "AuthorizerResultTtlInSeconds",
       ),
     };
   }

--- a/src/service/apigateway/cfn/sim-cfn-api-gateway-scalar-values.ts
+++ b/src/service/apigateway/cfn/sim-cfn-api-gateway-scalar-values.ts
@@ -83,6 +83,35 @@ export class SimCfnApiGatewayScalarValues {
   }
 
   /**
+   * Parse a property value that must be a number when present, which is the
+   * shape an authorizer's `AuthorizerResultTtlInSeconds` takes.
+   *
+   * CloudFormation carries template numbers as strings in places, the same way
+   * it does booleans, so a string holding a number is read as that number.
+   */
+  optionalNumber(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): number | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value === "number") {
+      return value;
+    }
+
+    const parsed = this.numberString(value);
+
+    if (parsed === undefined) {
+      throw this.invalidPropertyError(resource, label, "a number");
+    }
+
+    return parsed;
+  }
+
+  /**
    * Build the diagnostic error for a malformed property value.
    */
   invalidPropertyError(
@@ -94,5 +123,22 @@ export class SimCfnApiGatewayScalarValues {
       `Invalid ${this.resourceType} ${resource.logicalId}: ` +
         `${label} must be ${expected}`,
     );
+  }
+
+  /**
+   * The number a template string holds, when it holds one.
+   */
+  private numberString(value: SimCfnTemplateValue): number | undefined {
+    if (typeof value !== "string" || value.trim().length === 0) {
+      return undefined;
+    }
+
+    const parsed = Number(value);
+
+    if (Number.isNaN(parsed)) {
+      return undefined;
+    }
+
+    return parsed;
   }
 }

--- a/src/service/apigateway/cfn/sim-cfn-rest-api-authorizer.iso.test.ts
+++ b/src/service/apigateway/cfn/sim-cfn-rest-api-authorizer.iso.test.ts
@@ -14,6 +14,7 @@ import {
 import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
 import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
 import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimRestApiLambdaAuthorizer } from "../api/authorizer/sim-rest-api-lambda-authorizer.js";
 import type { SimRestApi } from "../api/sim-rest-api.js";
 import { simCfnRestApiTemplateFactory } from "./sim-cfn-rest-api-template.factory.js";
 
@@ -181,14 +182,38 @@ describe("Deploying a REST API authorizer from CloudFormation", () => {
     assertIdentical(method?.authorizerId, authorizer.authorizerId);
   });
 
-  it("records a property outside the simulated set", async () => {
-    // Given an authorizer asking for its decisions to be held
+  it("deploys the period the authorizer holds a decision for", async () => {
+    // Given an authorizer asking for its decisions to be held, written as the
+    // string CloudFormation carries a template number as
     const simAws = simAwsInEuWest2();
 
     // When the template is deployed
     const stack = await deployRestApi(
       simAws,
-      gatedTemplate({ AuthorizerResultTtlInSeconds: 300 }),
+      gatedTemplate({ AuthorizerResultTtlInSeconds: "300" }),
+    );
+    const restApi = stack.resources.get("Api")?.simResource as
+      | SimRestApi
+      | undefined;
+    assertNonNullable(restApi);
+
+    // Then the authorizer holds its decisions for that many seconds
+    const [authorizer] = restApi.authorizers.list();
+    assertNonNullable(authorizer);
+    assertIdentical(
+      (authorizer as SimRestApiLambdaAuthorizer).resultTtlSeconds,
+      300,
+    );
+  });
+
+  it("records a property outside the simulated set", async () => {
+    // Given an authorizer asking for a validation expression
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const stack = await deployRestApi(
+      simAws,
+      gatedTemplate({ IdentityValidationExpression: "^Bearer .+$" }),
     );
 
     // Then the API deploys and the record says which of its parts behaves
@@ -199,7 +224,7 @@ describe("Deploying a REST API authorizer from CloudFormation", () => {
     );
     assertStringIncludes(
       ignoredReasons(stack).join("\n"),
-      "AWS::ApiGateway::Authorizer property AuthorizerResultTtlInSeconds is " +
+      "AWS::ApiGateway::Authorizer property IdentityValidationExpression is " +
         "not simulated",
     );
   });

--- a/src/service/apigateway/command/authorizer/authorizer.command.ts
+++ b/src/service/apigateway/command/authorizer/authorizer.command.ts
@@ -17,6 +17,7 @@ export interface SimCreateAuthorizerCommandInput {
   readonly authorizerUri?: string | undefined;
   readonly providerARNs?: readonly string[] | undefined;
   readonly identitySource?: string | undefined;
+  readonly authorizerResultTtlInSeconds?: number | undefined;
 }
 
 export interface SimCreateAuthorizerCommandOutput extends SimRestApiAuthorizerView {

--- a/src/service/apigateway/command/authorizer/sim-rest-api-authorizer-commands.iso.test.ts
+++ b/src/service/apigateway/command/authorizer/sim-rest-api-authorizer-commands.iso.test.ts
@@ -222,24 +222,61 @@ describe("Sim API Gateway REST API authorizer commands", () => {
     );
   });
 
-  it("refuses to hold a decision it was told to cache", async () => {
+  it("holds a decision for the seconds it was given", async () => {
     // Given a REST API
     const simAws = new SimAws();
     const restApiId = await givenRestApi(simAws.apiGateway());
 
-    // When an authorizer asks for its results to be held
-    const authorizer = simAws.apiGateway().createAuthorizer(
+    // When an authorizer asks for its decisions to be held for 5 minutes
+    const authorizer = await simAws.apiGateway().createAuthorizer(
       new CreateAuthorizerCommand({
         ...tokenAuthorizerInput(restApiId),
         authorizerResultTtlInSeconds: 300,
       }),
     );
 
-    // Then it is refused, because an authorizer invoked once per request here
-    // and once per five minutes on AWS is a difference a test would not see
-    await expect(authorizer).rejects.toThrow(SimApiGatewayBadRequest);
-    await expect(authorizer).rejects.toThrow(
-      "CreateAuthorizer authorizerResultTtlInSeconds is not simulated",
-    );
+    // Then it reports that period back
+    assertIdentical(authorizer.authorizerResultTtlInSeconds, 300);
   });
+
+  it("holds no decision for an authorizer that asked for none", async () => {
+    // Given a REST API
+    const simAws = new SimAws();
+    const restApiId = await givenRestApi(simAws.apiGateway());
+
+    // When an authorizer says nothing about holding its decisions
+    const authorizer = await simAws
+      .apiGateway()
+      .createAuthorizer(
+        new CreateAuthorizerCommand(tokenAuthorizerInput(restApiId)),
+      );
+
+    // Then it holds them for no time at all, which is what AWS defaults one to
+    assertIdentical(authorizer.authorizerResultTtlInSeconds, 0);
+  });
+
+  it.each([-1, 3601, 1.5, NaN])(
+    "refuses to hold a decision for %s seconds",
+    async (authorizerResultTtlInSeconds) => {
+      // Given a REST API
+      const simAws = new SimAws();
+      const restApiId = await givenRestApi(simAws.apiGateway());
+
+      // When an authorizer asks for a period AWS does not take
+      const authorizer = simAws.apiGateway().createAuthorizer(
+        new CreateAuthorizerCommand({
+          ...tokenAuthorizerInput(restApiId),
+          authorizerResultTtlInSeconds,
+        }),
+      );
+
+      // Then it is refused rather than holding a decision for a period no
+      // deployed authorizer could be configured with
+      await expect(authorizer).rejects.toThrow(SimApiGatewayBadRequest);
+      await expect(authorizer).rejects.toThrow(
+        "AWS holds an authorizer's decision for a whole number of seconds " +
+          "between 0 and 3600",
+      );
+    },
+  );
 });

--- a/src/service/apigateway/command/authorizer/sim-rest-api-authorizer-commands.ts
+++ b/src/service/apigateway/command/authorizer/sim-rest-api-authorizer-commands.ts
@@ -30,6 +30,7 @@ const acceptedCreateOptions = [
   "authorizerUri",
   "providerARNs",
   "identitySource",
+  "authorizerResultTtlInSeconds",
 ];
 
 const simulatedAuthorizerTypes: readonly SimRestApiAuthorizerType[] = [

--- a/src/service/apigateway/command/authorizer/sim-rest-api-authorizer-input.ts
+++ b/src/service/apigateway/command/authorizer/sim-rest-api-authorizer-input.ts
@@ -11,6 +11,7 @@ import { SimRestApiUserPoolProviders } from "../../api/authorizer/sim-rest-api-u
 import { SimRestApiLambdaUri } from "../../api/method/sim-rest-api-lambda-uri.js";
 import { SimApiGatewayBadRequest } from "../../error/sim-api-gateway.error.js";
 import type { SimCreateAuthorizerCommandInput } from "./authorizer.command.js";
+import { simRestApiAuthorizerResultTtl } from "./sim-rest-api-authorizer-result-ttl.js";
 
 interface SimRestApiAuthorizerInputProperties {
   readonly input: SimCreateAuthorizerCommandInput;
@@ -41,26 +42,29 @@ export class SimRestApiAuthorizerInput {
    */
   read(authorizerId: SimRestApiAuthorizerId): SimRestApiAuthorizer {
     const name = this.input.name ?? "";
+    const resultTtlSeconds = simRestApiAuthorizerResultTtl(
+      this.input,
+      this.type,
+    );
 
-    if (this.type === "COGNITO_USER_POOLS") {
-      return new SimRestApiCognitoAuthorizer({
-        authorizerId,
-        name,
-        providers: SimRestApiUserPoolProviders.parse(this.providerArns()),
-        identitySource: new SimRestApiIdentitySourceParser().header(
-          this.identitySource(),
-          this.type,
-        ),
-      });
-    }
-
-    return new SimRestApiLambdaAuthorizer({
-      authorizerId,
-      name,
-      type: this.type,
-      lambdaUri: this.lambdaUri(),
-      identitySources: this.identitySources(),
-    });
+    return this.type === "COGNITO_USER_POOLS"
+      ? new SimRestApiCognitoAuthorizer({
+          authorizerId,
+          name,
+          providers: SimRestApiUserPoolProviders.parse(this.providerArns()),
+          identitySource: new SimRestApiIdentitySourceParser().header(
+            this.identitySource(),
+            this.type,
+          ),
+        })
+      : new SimRestApiLambdaAuthorizer({
+          authorizerId,
+          name,
+          type: this.type,
+          lambdaUri: this.lambdaUri(),
+          identitySources: this.identitySources(),
+          resultTtlSeconds,
+        });
   }
 
   /**

--- a/src/service/apigateway/command/authorizer/sim-rest-api-authorizer-result-ttl.ts
+++ b/src/service/apigateway/command/authorizer/sim-rest-api-authorizer-result-ttl.ts
@@ -1,0 +1,48 @@
+import type { SimRestApiAuthorizerType } from "../../api/authorizer/sim-rest-api-authorizer.js";
+import { SimApiGatewayBadRequest } from "../../error/sim-api-gateway.error.js";
+import type { SimCreateAuthorizerCommandInput } from "./authorizer.command.js";
+
+/**
+ * The longest AWS holds a REST API authorizer's decision for.
+ */
+const maximumResultTtlSeconds = 3600;
+
+/**
+ * How long an authorizer's decisions are held for.
+ *
+ * Zero, and saying nothing, both mean no caching, which is what AWS defaults
+ * an authorizer to. AWS accepts a whole number of seconds up to an hour, so
+ * anything else is refused rather than held for a period no deployed
+ * authorizer could be configured with. That includes `NaN`, which no
+ * comparison refuses and which would otherwise hold a decision for ever.
+ *
+ * A `COGNITO_USER_POOLS` authorizer asking for a period is refused. Real API
+ * Gateway holds its decision too, and holding one here would mean a token that
+ * expired during the period was still accepted. Nothing is invoked either way,
+ * so the only thing caching changes for that kind of authorizer is the answer
+ * a test would get.
+ */
+export function simRestApiAuthorizerResultTtl(
+  input: SimCreateAuthorizerCommandInput,
+  type: SimRestApiAuthorizerType,
+): number {
+  const ttl = input.authorizerResultTtlInSeconds ?? 0;
+
+  if (!Number.isSafeInteger(ttl) || ttl < 0 || ttl > maximumResultTtlSeconds) {
+    throw new SimApiGatewayBadRequest(
+      `CreateAuthorizer authorizerResultTtlInSeconds is ${String(ttl)}: AWS ` +
+        `holds an authorizer's decision for a whole number of seconds ` +
+        `between 0 and ${String(maximumResultTtlSeconds)}`,
+    );
+  }
+
+  if (type === "COGNITO_USER_POOLS" && ttl > 0) {
+    throw new SimApiGatewayBadRequest(
+      "CreateAuthorizer authorizerResultTtlInSeconds is set on a " +
+        "COGNITO_USER_POOLS authorizer, which invokes nothing and verifies " +
+        "each token as it arrives: holding that decision is not simulated",
+    );
+  }
+
+  return ttl;
+}

--- a/src/service/apigateway/command/authorizer/sim-rest-api-cognito-authorizer-commands.iso.test.ts
+++ b/src/service/apigateway/command/authorizer/sim-rest-api-cognito-authorizer-commands.iso.test.ts
@@ -213,6 +213,29 @@ describe("Sim API Gateway REST API Cognito authorizer commands", () => {
     );
   });
 
+  it("refuses a Cognito authorizer asking to hold its decisions", async () => {
+    // Given a REST API
+    const simAws = new SimAws();
+    const created = await simAws
+      .apiGateway()
+      .createRestApi(new CreateRestApiCommand({ name: "orders" }));
+
+    // When the authorizer asks for its decisions to be held for 5 minutes
+    const authorizer = simAws.apiGateway().createAuthorizer(
+      new CreateAuthorizerCommand({
+        ...cognitoAuthorizerInput(created.id),
+        authorizerResultTtlInSeconds: 300,
+      }),
+    );
+
+    // Then it is refused, because a token expiring during the period would
+    // still be accepted on AWS and is verified again here
+    await expect(authorizer).rejects.toThrow(SimApiGatewayBadRequest);
+    await expect(authorizer).rejects.toThrow(
+      "authorizerResultTtlInSeconds is set on a COGNITO_USER_POOLS authorizer",
+    );
+  });
+
   it("refuses a method naming an authorizer of the other kind", async () => {
     // Given an API whose authorizer verifies user pool tokens
     const simAws = new SimAws();

--- a/src/service/apigateway/serve/auth/sim-rest-api-authorizer-decisions.ts
+++ b/src/service/apigateway/serve/auth/sim-rest-api-authorizer-decisions.ts
@@ -1,0 +1,62 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import type { SimRestApiAuthorization } from "../../api/authorizer/sim-rest-api-authorization.js";
+import type { SimRestApiCacheKey } from "../../api/authorizer/sim-rest-api-authorizer-result-cache.js";
+import type { SimRestApiLambdaAuthorizer } from "../../api/authorizer/sim-rest-api-lambda-authorizer.js";
+
+interface SimRestApiAuthorizerDecisionsProperties {
+  /**
+   * Clock a held decision expires against, so advancing simulated time drops
+   * one that was being reused a moment before.
+   */
+  readonly clock: SimClock;
+}
+
+/**
+ * Reuses a Lambda authorizer's decision for as long as its
+ * `authorizerResultTtlInSeconds` says, and makes a new one when there is none
+ * to reuse.
+ *
+ * What is held and what is not is the whole of this: a refusal is held the way
+ * an admission is, because AWS holds whatever answer the authorizer gave. An
+ * authorizer that could not answer at all is not held, since there is no
+ * answer to hold and a request a moment later may find its function working.
+ */
+export class SimRestApiAuthorizerDecisions {
+  private readonly clock: SimClock;
+
+  constructor(properties: SimRestApiAuthorizerDecisionsProperties) {
+    this.clock = properties.clock;
+  }
+
+  /**
+   * The decision for this identity at this method, made only if there is not
+   * one already.
+   */
+  async decide(
+    authorizer: SimRestApiLambdaAuthorizer,
+    key: SimRestApiCacheKey,
+    invoke: () => Promise<SimRestApiAuthorization>,
+  ): Promise<SimRestApiAuthorization> {
+    const cached = authorizer.results.find(key, this.clock.now());
+
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    const authorization = await invoke();
+
+    if (this.isAnswer(authorization)) {
+      authorizer.results.store(key, this.clock.now(), authorization);
+    }
+
+    return authorization;
+  }
+
+  /**
+   * Whether this is something the authorizer answered, rather than the
+   * authorizer failing to answer.
+   */
+  private isAnswer(authorization: SimRestApiAuthorization): boolean {
+    return authorization.admitted || authorization.kind !== "error";
+  }
+}

--- a/src/service/apigateway/serve/auth/sim-rest-api-method-authorizer.ts
+++ b/src/service/apigateway/serve/auth/sim-rest-api-method-authorizer.ts
@@ -6,6 +6,7 @@ import {
 } from "../../api/authorizer/sim-rest-api-authorization.js";
 import { SimRestApiLambdaAuthorizer } from "../../api/authorizer/sim-rest-api-lambda-authorizer.js";
 import { SimRestApiExecuteApiArn } from "../../api/sim-rest-api-execute-api-arn.js";
+import { SimRestApiAuthorizerDecisions } from "./sim-rest-api-authorizer-decisions.js";
 import {
   type SimRestApiAuthorizerFunctions,
   SimRestApiAuthorizerInvocation,
@@ -21,9 +22,10 @@ interface SimRestApiMethodAuthorizerProperties {
    */
   readonly functions: SimRestApiAuthorizerFunctions;
   /**
-   * Clock an authorizer's invocation event is stamped with, and a verified
-   * token's time claims are checked against, so advancing simulated time
-   * expires a token that was accepted before it.
+   * Clock an authorizer's invocation event is stamped with, a verified
+   * token's time claims are checked against, and a held decision expires
+   * against, so advancing simulated time expires a token that was accepted
+   * before it and drops a decision that was being reused.
    */
   readonly clock: SimClock;
 }
@@ -43,17 +45,27 @@ interface SimRestApiMethodAuthorizerProperties {
  * 1. the request has to carry something at every one of the authorizer's
  *    identity sources, or it is refused with a 401 and the function is never
  *    invoked;
- * 2. otherwise the function is asked, and the policy it answers with is
+ * 2. a decision already made for that same identity at that same method, and
+ *    not yet expired, is reused by `SimRestApiAuthorizerDecisions`, and
+ *    nothing further happens;
+ * 3. otherwise the function is asked, and the policy it answers with is
  *    evaluated against the ARN of the request being made.
+ *
+ * An authorizer with no `authorizerResultTtlInSeconds` holds nothing, so its
+ * function is invoked once per request reaching the method.
  */
 export class SimRestApiMethodAuthorizer {
   private readonly invocation: SimRestApiAuthorizerInvocation;
+  private readonly decisions: SimRestApiAuthorizerDecisions;
   private readonly iamAuthorizer = new SimRestApiIamMethodAuthorizer();
   private readonly cognito: SimRestApiCognitoMethodAuthorizer;
 
   constructor(properties: SimRestApiMethodAuthorizerProperties) {
     this.invocation = new SimRestApiAuthorizerInvocation({
       functions: properties.functions,
+      clock: properties.clock,
+    });
+    this.decisions = new SimRestApiAuthorizerDecisions({
       clock: properties.clock,
     });
     this.cognito = new SimRestApiCognitoMethodAuthorizer({
@@ -109,15 +121,22 @@ export class SimRestApiMethodAuthorizer {
       return SimRestApiRefused.unauthorized();
     }
 
-    return await this.invocation.invoke(
-      input,
+    const methodArn = SimRestApiExecuteApiArn.forRequest(
+      restApi,
+      match,
+      request.method,
+    ).toString();
+
+    return await this.decisions.decide(
       authorizer,
-      identityValues,
-      SimRestApiExecuteApiArn.forRequest(
-        restApi,
-        match,
-        request.method,
-      ).toString(),
+      { methodArn, identityValues },
+      async () =>
+        await this.invocation.invoke(
+          input,
+          authorizer,
+          identityValues,
+          methodArn,
+        ),
     );
   }
 }

--- a/src/service/apigateway/serve/sim-rest-api-authorizer-cache.iso.test.ts
+++ b/src/service/apigateway/serve/sim-rest-api-authorizer-cache.iso.test.ts
@@ -1,0 +1,236 @@
+import { assertIdentical, assertObjectMatches } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import type { SimPayload1Event } from "../../../serve/payload-1/sim-payload-1-event.type.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simRestApiLambdaProxyFactory } from "../api/sim-rest-api-lambda-proxy.factory.js";
+import type { SimRestApiLambdaProxyInput } from "../api/sim-rest-api-lambda-proxy.factory.js";
+import type { SimRestApi } from "../api/sim-rest-api.js";
+
+const goodToken = "Bearer session-6";
+
+/**
+ * An authorizer counting its own invocations, so a test can tell a held
+ * decision from a fresh one, and reporting the count in its context, so the
+ * handler can see which invocation the decision came from.
+ */
+function countingAuthorizer(
+  effect: "Allow" | "Deny" = "Allow",
+): (event: { methodArn: string }) => unknown {
+  let invocations = 0;
+
+  return (event) => {
+    invocations += 1;
+
+    return {
+      principalId: "user-6",
+      context: { invocations },
+      policyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Action: "execute-api:Invoke",
+            Effect: effect,
+            Resource: event.methodArn,
+          },
+        ],
+      },
+    };
+  };
+}
+
+/**
+ * A method reporting the authorizer's context back, so a test sees which
+ * decision served the request.
+ */
+const contextHandler = (event: SimPayload1Event): unknown => ({
+  statusCode: 200,
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify(event.requestContext.authorizer ?? null),
+});
+
+async function cachingApi(
+  simAws: SimAws,
+  input: Partial<SimRestApiLambdaProxyInput> = {},
+): Promise<SimRestApi> {
+  return await simRestApiLambdaProxyFactory.make(
+    {
+      resourcePaths: ["/orders", "/invoices"],
+      handler: contextHandler,
+      authorizerHandler: countingAuthorizer(),
+      authorizerResultTtlSeconds: 300,
+      ...input,
+    },
+    simAws,
+  );
+}
+
+function get(
+  simAws: SimAws,
+  restApi: SimRestApi,
+  path: string,
+  token: string = goodToken,
+): Promise<Response> {
+  return new SimAwsHttp({ simAws }).fetch(
+    new SimAwsLocalUrl({
+      input: `${restApi.invokeUrl("prod")}${path}`,
+    }).toString(),
+    { headers: { authorization: token } },
+  );
+}
+
+describe("Caching a sim REST API Lambda authorizer's decision", () => {
+  it("serves a second request from the decision already made", async () => {
+    // Given a method behind a TOKEN authorizer holding its decisions for 5
+    // minutes
+    const simAws = new SimAws();
+    const restApi = await cachingApi(simAws);
+
+    // When the same token is presented twice
+    const first = await get(simAws, restApi, "/orders");
+    const second = await get(simAws, restApi, "/orders");
+
+    // Then the authorizer ran once, and both requests were served by that one
+    // decision, context and all
+    assertIdentical(first.status, 200);
+    assertIdentical(second.status, 200);
+    assertObjectMatches(await first.json(), { invocations: 1 });
+    assertObjectMatches(await second.json(), { invocations: 1 });
+  });
+
+  it("decides separately for a different token", async () => {
+    // Given a method behind that authorizer
+    const simAws = new SimAws();
+    const restApi = await cachingApi(simAws);
+
+    // When two callers present different tokens
+    const ada = await get(simAws, restApi, "/orders", "Bearer ada");
+    const grace = await get(simAws, restApi, "/orders", "Bearer grace");
+
+    // Then each got a decision of its own, since a TOKEN authorizer is keyed
+    // on the token it was handed
+    assertObjectMatches(await ada.json(), { invocations: 1 });
+    assertObjectMatches(await grace.json(), { invocations: 2 });
+  });
+
+  it("decides separately for different identity source values", async () => {
+    // Given a REQUEST authorizer identifying its callers by two headers
+    const simAws = new SimAws();
+    const restApi = await cachingApi(simAws, {
+      authorizerHandler: undefined,
+      requestAuthorizerHandler: countingAuthorizer(),
+      authorizerIdentitySource:
+        "method.request.header.X-Tenant,method.request.header.Authorization",
+    });
+    const call = async (tenant: string): Promise<Response> =>
+      await new SimAwsHttp({ simAws }).fetch(
+        new SimAwsLocalUrl({
+          input: `${restApi.invokeUrl("prod")}/orders`,
+        }).toString(),
+        { headers: { "x-tenant": tenant, authorization: goodToken } },
+      );
+
+    // When the same token arrives for two tenants, and one of them twice
+    const acme = await call("acme");
+    const other = await call("globex");
+    const acmeAgain = await call("acme");
+
+    // Then each set of values got a decision of its own, and the repeat came
+    // from the one already made for it
+    assertObjectMatches(await acme.json(), { invocations: 1 });
+    assertObjectMatches(await other.json(), { invocations: 2 });
+    assertObjectMatches(await acmeAgain.json(), { invocations: 1 });
+  });
+
+  it("decides separately for each method the token reaches", async () => {
+    // Given two methods behind one authorizer
+    const simAws = new SimAws();
+    const restApi = await cachingApi(simAws);
+
+    // When the same token reaches each of them
+    const orders = await get(simAws, restApi, "/orders");
+    const invoices = await get(simAws, restApi, "/invoices");
+
+    // Then each method got a decision of its own: what is held is the answer
+    // the policy gave about one method ARN, and it says nothing about another
+    assertObjectMatches(await orders.json(), { invocations: 1 });
+    assertObjectMatches(await invoices.json(), { invocations: 2 });
+  });
+
+  it("invokes the authorizer again once the decision expires", async () => {
+    // Given a decision already made and reused
+    const simAws = new SimAws();
+    const restApi = await cachingApi(simAws);
+    await get(simAws, restApi, "/orders");
+    const reused = await get(simAws, restApi, "/orders");
+
+    // When simulated time passes the TTL
+    await simAws.clock().advanceBy({ minutes: 6 });
+    const expired = await get(simAws, restApi, "/orders");
+
+    // Then the authorizer is asked again rather than the test having to wait
+    assertObjectMatches(await reused.json(), { invocations: 1 });
+    assertObjectMatches(await expired.json(), { invocations: 2 });
+  });
+
+  it("holds a refusal the way it holds an admission", async () => {
+    // Given an authorizer refusing the method it is asked about
+    const simAws = new SimAws();
+    let invocations = 0;
+    const denying = countingAuthorizer("Deny");
+    const restApi = await cachingApi(simAws, {
+      authorizerHandler: (event) => {
+        invocations += 1;
+        return denying(event);
+      },
+    });
+
+    // When the same token is presented twice
+    const first = await get(simAws, restApi, "/orders");
+    const second = await get(simAws, restApi, "/orders");
+
+    // Then both are refused, and the authorizer was asked once: AWS holds
+    // whatever answer it got
+    assertIdentical(first.status, 403);
+    assertIdentical(second.status, 403);
+    assertIdentical(invocations, 1);
+  });
+
+  it("holds nothing for an authorizer that could not answer", async () => {
+    // Given an authorizer whose function fails
+    const simAws = new SimAws();
+    let invocations = 0;
+    const restApi = await cachingApi(simAws, {
+      authorizerHandler: (): unknown => {
+        invocations += 1;
+        throw new Error("no session store");
+      },
+    });
+
+    // When the same token is presented twice
+    const first = await get(simAws, restApi, "/orders");
+    const second = await get(simAws, restApi, "/orders");
+
+    // Then both answer 500 and the function was asked each time: there is no
+    // answer to hold, and the next request may find it working
+    assertIdentical(first.status, 500);
+    assertIdentical(second.status, 500);
+    assertIdentical(invocations, 2);
+  });
+
+  it("invokes the authorizer every time when nothing is held", async () => {
+    // Given an authorizer holding nothing, which is what AWS defaults one to
+    const simAws = new SimAws();
+    const restApi = await cachingApi(simAws, { authorizerResultTtlSeconds: 0 });
+
+    // When the same token is presented twice
+    const first = await get(simAws, restApi, "/orders");
+    const second = await get(simAws, restApi, "/orders");
+
+    // Then the authorizer decided each request on its own
+    assertObjectMatches(await first.json(), { invocations: 1 });
+    assertObjectMatches(await second.json(), { invocations: 2 });
+  });
+});


### PR DESCRIPTION
CreateAuthorizer takes authorizerResultTtlInSeconds and refuses anything outside a whole number of seconds from 0 to 3600. A TOKEN authorizer holds its decision under the token it was handed and a REQUEST authorizer under the values its identity sources found, both per method, because what is held is the answer the authorizer's policy gave about one method ARN. A refusal is held the way an admission is, and an authorizer that failed to answer holds nothing. Expiry follows the simulation's clock, and advancing time past the TTL drops the decision. AWS::ApiGateway::Authorizer deploys the property, and a COGNITO_USER_POOLS authorizer asking for one is refused.

Resolves #791


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable result caching for REST API Lambda authorizers.
  * Cached authorization decisions can be keyed by identity and method, including denied decisions.
  * Added configurable cache expiration, with support for disabling caching.
  * Added validation for cache durations from 0 to 3,600 seconds.
  * Added support for configuring cache duration through authorizer commands and templates.

* **Bug Fixes**
  * Authorizer failures are no longer cached.
  * Cognito user-pool authorizers now reject unsupported positive cache durations.

* **Documentation**
  * Documented caching behavior, expiration, defaults, cache keys, and configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->