### PR TITLE
feat: import an authorizer from a security scheme

### DIFF
--- a/docs/services/apigateway/README.md
+++ b/docs/services/apigateway/README.md
@@ -1174,9 +1174,9 @@ await srv.close();
 
 The API is named by `info.title`. `uri` is read as either the long
 `arn:aws:apigateway:<region>:lambda:path/2015-03-31/functions/<function-arn>/invocations` form above
-or as the bare function ARN. Every imported method is declared with `AuthorizationType: "NONE"`, and
-a document naming an authorizer is refused. Gate a method with `CreateAuthorizer` and `PutMethod`
-instead, as [Authorizing a method](#authorizing-a-method) covers.
+or as the bare function ARN. An operation carrying no `security` becomes an open method, and one
+naming a security scheme is gated by the authorizer that scheme declares. See
+[Security schemes](#security-schemes).
 
 ### The catch-all operation key
 
@@ -1196,6 +1196,176 @@ the resource has no method of its own for, and OpenAPI has no operation key of i
 A `{proxy+}` segment becomes a greedy resource that matches the rest of the request path. One path
 of `/{proxy+}` carrying that extension is the whole of what CDK's `LambdaRestApi` builds.
 
+### Security schemes
+
+A `components.securitySchemes` member carrying `x-amazon-apigateway-authtype` becomes an authorizer,
+and `security` on an operation puts that authorizer in front of the method. The scheme key names it.
+One authorizer is created per scheme, shared by every operation naming it.
+
+```typescript sim-apigateway-openapi-authorizer
+/**
+ * Importing a REST API whose method is gated by a security scheme.
+ */
+
+import {
+  GetAuthorizersCommand,
+  GetMethodCommand,
+  GetResourcesCommand,
+  ImportRestApiCommand,
+} from "@aws-sdk/client-api-gateway";
+import { CreateFunctionCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import type { SimRestApiTokenAuthorizerEvent } from "@kensio/yulin/apigateway";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+
+const { FunctionArn: petsArn } = await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "pets",
+    Role: "arn:aws:iam::111111111111:role/PetsRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput(() => ({
+        statusCode: 200,
+        body: "pets",
+      })),
+    },
+  }),
+);
+
+const { FunctionArn: authorizerArn } = await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "pet-authorizer",
+    Role: "arn:aws:iam::111111111111:role/PetsRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput(
+        (event: SimRestApiTokenAuthorizerEvent) => ({
+          principalId: "pet-owner",
+          policyDocument: {
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Action: "execute-api:Invoke",
+                Effect:
+                  event.authorizationToken === "Bearer valid"
+                    ? "Allow"
+                    : "Deny",
+                Resource: event.methodArn,
+              },
+            ],
+          },
+        }),
+      ),
+    },
+  }),
+);
+
+const openApi = {
+  openapi: "3.0.1",
+  info: { title: "pets", version: "1.0" },
+  paths: {
+    "/pets": {
+      get: {
+        security: [{ "pet-authorizer": [] }],
+        "x-amazon-apigateway-integration": {
+          type: "aws_proxy",
+          httpMethod: "POST",
+          uri: petsArn,
+        },
+      },
+    },
+  },
+  components: {
+    securitySchemes: {
+      "pet-authorizer": {
+        type: "apiKey",
+        name: "Authorization",
+        in: "header",
+        "x-amazon-apigateway-authtype": "custom",
+        "x-amazon-apigateway-authorizer": {
+          type: "token",
+          authorizerUri: authorizerArn,
+          authorizerResultTtlInSeconds: 300,
+        },
+      },
+    },
+  },
+};
+
+const apiGateway = simAws.apiGateway();
+
+const definition = new TextEncoder().encode(JSON.stringify(openApi));
+
+const { id: restApiId } = await apiGateway.importRestApi(
+  new ImportRestApiCommand({ body: definition }),
+);
+
+const authorizers = await apiGateway.getAuthorizers(
+  new GetAuthorizersCommand({ restApiId }),
+);
+
+console.log(authorizers.items.map((one) => [one.name, one.type]));
+// [ [ "pet-authorizer", "TOKEN" ] ]
+
+const resources = await apiGateway.getResources(
+  new GetResourcesCommand({ restApiId }),
+);
+const pets = resources.items.find((resource) => resource.path === "/pets");
+
+const method = await apiGateway.getMethod(
+  new GetMethodCommand({ restApiId, resourceId: pets?.id, httpMethod: "GET" }),
+);
+
+console.log(method.authorizationType);
+// "CUSTOM"
+```
+
+Three `x-amazon-apigateway-authtype` values are read, and each writes a different kind of gate on
+the method.
+
+| `x-amazon-apigateway-authtype` | The authorizer `type` under it | Method `AuthorizationType` |
+| ------------------------------ | ------------------------------ | -------------------------- |
+| `custom`                       | `token` or `request`           | `CUSTOM`                   |
+| `cognito_user_pools`           | `cognito_user_pools`           | `COGNITO_USER_POOLS`       |
+| `awsSigv4`                     | (the scheme carries none)      | `AWS_IAM`                  |
+
+A `cognito_user_pools` authorizer carries the `providerARNs` of the pools it accepts tokens from,
+and the scopes a requirement asks for (`security: [{ "pet-authorizer": ["pets.read"] }]`) become the
+method's `authorizationScopes`. `PutMethod` refuses scopes on every other kind of method, since a
+token is what they are checked against.
+
+An `awsSigv4` scheme names a header and leaves the deciding to IAM. `x-amazon-apigateway-auth` on an
+operation asks for the same gate, and is what an API Gateway console export writes:
+
+```json
+{ "x-amazon-apigateway-auth": { "type": "AWS_IAM" } }
+```
+
+A `token` or `cognito_user_pools` authorizer reads the one header the scheme's own `name` and `in`
+name, which for the scheme above is `method.request.header.Authorization`. That is where AWS reads
+it from, and an `identitySource` written inside either authorizer is refused. A `request` authorizer
+names its own `identitySource`, with as many comma-separated expressions as identify its callers.
+
+`authorizerResultTtlInSeconds` on a Lambda authorizer is how long its decisions are held for, the
+same as it is on `CreateAuthorizer`. See
+[Caching the authorizer's decision](#caching-the-authorizers-decision).
+
+A scheme whose `x-amazon-apigateway-authtype` and whose authorizer `type` disagree is refused,
+naming the pointer of the member they disagree about, such as
+`#/components/securitySchemes/pet-authorizer/x-amazon-apigateway-authorizer/type`. These are refused
+where a document writes them too:
+
+- An `apiKey` scheme carrying no `x-amazon-apigateway-authtype`. That is an API key, and API keys
+  and usage plans are outside this simulation.
+- An `http`, `oauth2` or `openIdConnect` scheme. A REST API method is gated by the three authtypes
+  above and by nothing else.
+- `authorizerCredentials` and `identityValidationExpression` on an authorizer. `CreateAuthorizer`
+  refuses both of them as well.
+- A `security` requirement at the root of the document. Write the requirement on each operation.
+- An operation naming two requirements, or one requirement naming two schemes. One authorizer
+  decides a method.
+
 ### Members that are ignored
 
 AWS sorts what an import finds into three categories, and the third is valid OpenAPI a REST API
@@ -1213,8 +1383,8 @@ pointer of the member, such as
 ### Replacing a definition
 
 `PutRestApiCommand` with `mode: "overwrite"` replaces an API's whole definition with the document's.
-The API keeps its id, its endpoint and the stages serving it, and its path tree is built again from
-the document.
+The API keeps its id, its endpoint and the stages serving it. Its path tree and its authorizers are
+built again from the document, and an authorizer the previous definition left behind goes with them.
 
 ```typescript
 await apiGateway.putRestApi(
@@ -1557,10 +1727,11 @@ and behave differently deployed. The refusals worth knowing about:
 - **Paging.** Every list command answers in full, and `limit` or `position` is refused.
 - **Endpoint types, request validators, models, mapping templates and WAF.** All refused.
 - **Updates.** `UpdateRestApi` replaces `/name` and `/description`. Any other patch path is refused.
-- **OpenAPI extensions.** An import reads `x-amazon-apigateway-integration` and
-  `x-amazon-apigateway-any-method`. Every other `x-amazon-apigateway-*` extension is refused, and so
-  is any integration member beyond `type`, `httpMethod` and `uri`. Each refusal names the JSON
-  pointer of the member.
+- **OpenAPI extensions.** An import reads `x-amazon-apigateway-integration`,
+  `x-amazon-apigateway-any-method`, `x-amazon-apigateway-authtype`,
+  `x-amazon-apigateway-authorizer` and `x-amazon-apigateway-auth`. Every other
+  `x-amazon-apigateway-*` extension is refused, and so is any integration member beyond `type`,
+  `httpMethod` and `uri`. Each refusal names the JSON pointer of the member.
 
 ## Available functionality
 
@@ -1597,9 +1768,8 @@ and `Stage`, including the template CDK synthesizes from a `RestApi` or a `Lambd
   document and an `openapi: "3.1.0"` one by version. A `Body` carrying a Swagger 2.0 document is
   recorded and the API deploys without it. The body is JSON, and YAML is refused with the same
   message.
-- A security scheme carrying `x-amazon-apigateway-authorizer` is not read, and an operation with a
-  `security` requirement is refused. An imported method is open or the import did not happen. A
-  method gated by an authorizer is declared through `CreateAuthorizer` and `PutMethod` instead. See
-  [Authorizing a method](#authorizing-a-method).
+- A security scheme declares a Lambda authorizer, a Cognito one or IAM authorization. An `apiKey`
+  scheme carrying no `x-amazon-apigateway-authtype` is an API key and is refused, and so are the
+  `http`, `oauth2` and `openIdConnect` scheme types. See [Security schemes](#security-schemes).
 - `PutRestApi` replaces a definition and never merges one. `BodyS3Location` on the Resource, and a
   document held anywhere but inline, are outside this.

--- a/docs/services/apigateway/sim-apigateway-openapi-authorizer.example.ts
+++ b/docs/services/apigateway/sim-apigateway-openapi-authorizer.example.ts
@@ -1,0 +1,116 @@
+/**
+ * Importing a REST API whose method is gated by a security scheme.
+ */
+
+import {
+  GetAuthorizersCommand,
+  GetMethodCommand,
+  GetResourcesCommand,
+  ImportRestApiCommand,
+} from "@aws-sdk/client-api-gateway";
+import { CreateFunctionCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import type { SimRestApiTokenAuthorizerEvent } from "@kensio/yulin/apigateway";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+
+const { FunctionArn: petsArn } = await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "pets",
+    Role: "arn:aws:iam::111111111111:role/PetsRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput(() => ({
+        statusCode: 200,
+        body: "pets",
+      })),
+    },
+  }),
+);
+
+const { FunctionArn: authorizerArn } = await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "pet-authorizer",
+    Role: "arn:aws:iam::111111111111:role/PetsRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput(
+        (event: SimRestApiTokenAuthorizerEvent) => ({
+          principalId: "pet-owner",
+          policyDocument: {
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Action: "execute-api:Invoke",
+                Effect:
+                  event.authorizationToken === "Bearer valid"
+                    ? "Allow"
+                    : "Deny",
+                Resource: event.methodArn,
+              },
+            ],
+          },
+        }),
+      ),
+    },
+  }),
+);
+
+const openApi = {
+  openapi: "3.0.1",
+  info: { title: "pets", version: "1.0" },
+  paths: {
+    "/pets": {
+      get: {
+        security: [{ "pet-authorizer": [] }],
+        "x-amazon-apigateway-integration": {
+          type: "aws_proxy",
+          httpMethod: "POST",
+          uri: petsArn,
+        },
+      },
+    },
+  },
+  components: {
+    securitySchemes: {
+      "pet-authorizer": {
+        type: "apiKey",
+        name: "Authorization",
+        in: "header",
+        "x-amazon-apigateway-authtype": "custom",
+        "x-amazon-apigateway-authorizer": {
+          type: "token",
+          authorizerUri: authorizerArn,
+          authorizerResultTtlInSeconds: 300,
+        },
+      },
+    },
+  },
+};
+
+const apiGateway = simAws.apiGateway();
+
+const definition = new TextEncoder().encode(JSON.stringify(openApi));
+
+const { id: restApiId } = await apiGateway.importRestApi(
+  new ImportRestApiCommand({ body: definition }),
+);
+
+const authorizers = await apiGateway.getAuthorizers(
+  new GetAuthorizersCommand({ restApiId }),
+);
+
+console.log(authorizers.items.map((one) => [one.name, one.type]));
+// [ [ "pet-authorizer", "TOKEN" ] ]
+
+const resources = await apiGateway.getResources(
+  new GetResourcesCommand({ restApiId }),
+);
+const pets = resources.items.find((resource) => resource.path === "/pets");
+
+const method = await apiGateway.getMethod(
+  new GetMethodCommand({ restApiId, resourceId: pets?.id, httpMethod: "GET" }),
+);
+
+console.log(method.authorizationType);
+// "CUSTOM"

--- a/src/service/apigateway/README.md
+++ b/src/service/apigateway/README.md
@@ -153,13 +153,15 @@ still answers on it.
 `openapi/` reads an OpenAPI 3.0 document into the same commands an SDK caller sends:
 
 ```text
-SimRestApiOpenApiDocument        the root, the version check, and the paths
-├── SimRestApiOpenApiPathItem    one path: its segments and its operations
-├── SimRestApiOpenApiIntegration one x-amazon-apigateway-integration
-├── SimRestApiOpenApiPathTree    a resource per segment, shared between paths
-├── SimRestApiOpenApiMethods     PutMethod and PutIntegration for one operation
-├── SimRestApiOpenApiImport      the walk over the document
-└── SimRestApiOpenApiReplacement the overwrite PutRestApi asks for
+SimRestApiOpenApiDocument          the root, the version check, and the paths
+├── SimRestApiOpenApiPathItem      one path: its segments and its operations
+├── SimRestApiOpenApiIntegration   one x-amazon-apigateway-integration
+├── SimRestApiOpenApiPathTree      a resource per segment, shared between paths
+├── SimRestApiOpenApiSecurityScheme one components.securitySchemes member
+├── SimRestApiOpenApiAuthorization what an operation says about who may call it
+├── SimRestApiOpenApiMethods       PutMethod and PutIntegration for one operation
+├── SimRestApiOpenApiImport        the walk over the document
+└── SimRestApiOpenApiReplacement   the overwrite PutRestApi asks for
 ```
 
 `ImportRestApi`, `PutRestApi` and a `Body` on an `AWS::ApiGateway::RestApi` all arrive here with the
@@ -231,13 +233,14 @@ type other than `AWS_PROXY` are all refused there, so a request naming one fails
 been applied on real AWS.
 
 Authorization is refused the same way, in the two commands that carry it.
-`CreateAuthorizer` takes `TOKEN` and `COGNITO_USER_POOLS` and refuses `REQUEST`, and `PutMethod`
+`CreateAuthorizer` takes `TOKEN`, `REQUEST` and `COGNITO_USER_POOLS`, and `PutMethod`
 takes all four of its types. A method served open where AWS would have gated it lets a test pass on
 a request real AWS rejects, so a template asking for a type nothing enforces fails to deploy rather
 than deploying around it. A method naming an authorizer of the other kind is refused for the same
 reason.
 
 An imported document meets those refusals through the commands, and `openapi/` adds the ones about
-members no command sees. A document-level `security`, an operation's `security`, a Swagger 2
-document and every `x-amazon-apigateway-*` extension outside the two that are read are refused
-where they are written.
+members no command sees. A document-level `security`, a Swagger 2 document and every
+`x-amazon-apigateway-*` extension outside the five that are read are refused where they are
+written. A security scheme becomes an authorizer through `CreateAuthorizer`, so what a scheme may
+carry is what that command takes.

--- a/src/service/apigateway/cfn/sim-cfn-imported-rest-api-template.factory.ts
+++ b/src/service/apigateway/cfn/sim-cfn-imported-rest-api-template.factory.ts
@@ -7,8 +7,8 @@ import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/va
  * What a test asks for when it wants a template declaring a REST API as an
  * OpenAPI document rather than as Resources.
  *
- * `paths` is the document's own, so a test states the one operation it is
- * about. The resources, methods and integrations they declare are created by
+ * `paths` and `components` are the document's own, so a test states the one
+ * operation or security scheme it is about. The resources, methods and integrations they declare are created by
  * the import, so the template carries no `AWS::ApiGateway::Resource` or
  * `Method` of its own.
  */
@@ -17,6 +17,7 @@ export interface SimCfnImportedRestApiTemplateInput {
   /** The inline function code the document's integrations point at. */
   readonly handlerSource: string;
   readonly paths: SimCfnTemplateValueRecord;
+  readonly components: SimCfnTemplateValueRecord;
   /** Merged into the Api Resource last, so a test states one property. */
   readonly apiProperties: SimCfnTemplateValueRecord;
   /** Resources the template carries beyond the ones built here. */
@@ -58,6 +59,7 @@ export const simCfnImportedRestApiTemplateFactory = new MappedFactory<
     functionName: "pets",
     handlerSource: "exports.handler = async () => 'pets';",
     paths: {},
+    components: {},
     apiProperties: {},
     resources: {},
   }),
@@ -95,6 +97,7 @@ export const simCfnImportedRestApiTemplateFactory = new MappedFactory<
             openapi: "3.0.1",
             info: { title: input.functionName, version: "1.0" },
             paths: input.paths,
+            components: input.components,
           },
           ...input.apiProperties,
         },

--- a/src/service/apigateway/cfn/sim-cfn-rest-api-body.iso.test.ts
+++ b/src/service/apigateway/cfn/sim-cfn-rest-api-body.iso.test.ts
@@ -1,7 +1,10 @@
 import {
+  GetAuthorizersCommand,
+  GetMethodCommand,
   GetResourcesCommand,
   GetRestApiCommand,
 } from "@aws-sdk/client-api-gateway";
+import { assertNonNullable } from "@kensio/smartass";
 import { assertIdentical, assertTypeString } from "@kensio/smartass";
 import { describe, expect, it } from "vitest";
 
@@ -247,5 +250,69 @@ describe("Deploying a sim REST API from an AWS::ApiGateway::RestApi Body", () =>
     expect(failure.message).toMatch(
       /#\/paths\/~1pets\/get\/x-amazon-apigateway-integration\/passthroughBehavior/,
     );
+  });
+
+  it("deploys the authorizer a security scheme declares", async () => {
+    // Given a template whose document gates its operation with a Lambda
+    // authorizer, pointed at the function the same stack deploys
+    const simAws = simAwsInEuWest2();
+    const stack = await deployRestApi(
+      simAws,
+      simCfnImportedRestApiTemplateFactory.make({
+        paths: {
+          "/pets": {
+            get: {
+              security: [{ "pet-authorizer": [] }],
+              "x-amazon-apigateway-integration":
+                simCfnImportedRestApiIntegration,
+            },
+          },
+        },
+        components: {
+          securitySchemes: {
+            "pet-authorizer": {
+              type: "apiKey",
+              name: "Authorization",
+              in: "header",
+              "x-amazon-apigateway-authtype": "custom",
+              "x-amazon-apigateway-authorizer": {
+                type: "token",
+                authorizerUri: { "Fn::GetAtt": ["Handler", "Arn"] },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    // Then the deployed API carries the authorizer the scheme named, with the
+    // function URI the template resolved, and its method sends requests
+    // through it
+    const apiUrl = stack.outputs.get("ApiUrl")?.value;
+    assertTypeString(apiUrl);
+    const restApiId = apiIdOf(apiUrl);
+    const authorizers = await simAws
+      .apiGateway()
+      .getAuthorizers(new GetAuthorizersCommand({ restApiId }));
+    const [authorizer] = authorizers.items;
+    assertNonNullable(authorizer);
+    assertIdentical(authorizer.name, "pet-authorizer");
+    assertIdentical(authorizer.type, "TOKEN");
+    expect(authorizer.authorizerUri).toMatch(/:function:pets$/u);
+
+    const resources = await simAws
+      .apiGateway()
+      .getResources(new GetResourcesCommand({ restApiId }));
+    const pets = resources.items.find((resource) => resource.path === "/pets");
+    assertNonNullable(pets);
+    const method = await simAws.apiGateway().getMethod(
+      new GetMethodCommand({
+        restApiId,
+        resourceId: pets.id,
+        httpMethod: "GET",
+      }),
+    );
+    assertIdentical(method.authorizationType, "CUSTOM");
+    assertIdentical(method.authorizerId, authorizer.id);
   });
 });

--- a/src/service/apigateway/command/api/sim-rest-api-import-commands.ts
+++ b/src/service/apigateway/command/api/sim-rest-api-import-commands.ts
@@ -5,6 +5,7 @@ import type { SimRestApiOpenApiDocument } from "../../openapi/sim-rest-api-opena
 import { SimRestApiOpenApiImport } from "../../openapi/sim-rest-api-openapi-import.js";
 import { SimRestApiOpenApiReplacement } from "../../openapi/sim-rest-api-openapi-replacement.js";
 import type { SimRestApiRegistry } from "../../registry/sim-rest-api-registry.js";
+import type { SimRestApiAuthorizerCommands } from "../authorizer/sim-rest-api-authorizer-commands.js";
 import type { SimRestApiIntegrationCommands } from "../integration/sim-rest-api-integration-commands.js";
 import type { SimRestApiMethodCommands } from "../method/sim-rest-api-method-commands.js";
 import type { SimRestApiResourceCommands } from "../resource/sim-rest-api-resource-commands.js";
@@ -28,6 +29,7 @@ interface SimRestApiImportCommandsProperties {
   readonly resourceCommands: SimRestApiResourceCommands;
   readonly methodCommands: SimRestApiMethodCommands;
   readonly integrationCommands: SimRestApiIntegrationCommands;
+  readonly authorizerCommands: SimRestApiAuthorizerCommands;
 }
 
 /**
@@ -57,6 +59,7 @@ export class SimRestApiImportCommands {
     this.openApiImport = new SimRestApiOpenApiImport(properties);
     this.replacement = new SimRestApiOpenApiReplacement({
       resourceCommands: properties.resourceCommands,
+      authorizerCommands: properties.authorizerCommands,
       openApiImport: this.openApiImport,
     });
   }

--- a/src/service/apigateway/openapi/sim-rest-api-openapi-authorizer-type.ts
+++ b/src/service/apigateway/openapi/sim-rest-api-openapi-authorizer-type.ts
@@ -1,0 +1,54 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimRestApiAuthorizerType } from "../api/authorizer/sim-rest-api-authorizer.js";
+import type { SimRestApiOpenApiObject } from "./sim-rest-api-openapi-object.js";
+
+/**
+ * The authorizer each `x-amazon-apigateway-authtype` is declared with: the
+ * `type` its `x-amazon-apigateway-authorizer` carries, and the
+ * `CreateAuthorizer` type that becomes.
+ */
+const authorizerTypes = new Map<string, Map<string, SimRestApiAuthorizerType>>([
+  [
+    "custom",
+    new Map([
+      ["token", "TOKEN"],
+      ["request", "REQUEST"],
+    ]),
+  ],
+  [
+    "cognito_user_pools",
+    new Map([["cognito_user_pools", "COGNITO_USER_POOLS"]]),
+  ],
+]);
+
+/**
+ * Whether an authtype declares an authorizer of its own.
+ */
+export function simRestApiOpenApiDeclaresAuthorizer(authType: string): boolean {
+  return authorizerTypes.has(authType);
+}
+
+/**
+ * The kind of authorizer a security scheme carries, refusing one the scheme's
+ * own authtype does not declare.
+ */
+export function simRestApiOpenApiAuthorizerType(
+  authorizer: SimRestApiOpenApiObject,
+  authType: string,
+): SimRestApiAuthorizerType {
+  const types = authorizerTypes.get(authType);
+  assertDefined(types, `the authorizer types of ${authType}`);
+  const declared = authorizer.member("type");
+  const written = declared.requiredString();
+  const type = types.get(written);
+
+  if (type === undefined) {
+    throw declared.refusal(
+      `is '${written}', and the security scheme carrying it declares ` +
+        `x-amazon-apigateway-authtype '${authType}', which is written with ` +
+        `an authorizer of type ${types.keys().toArray().join(" or ")}`,
+    );
+  }
+
+  return type;
+}

--- a/src/service/apigateway/openapi/sim-rest-api-openapi-cognito-authorizer-scheme.ts
+++ b/src/service/apigateway/openapi/sim-rest-api-openapi-cognito-authorizer-scheme.ts
@@ -1,0 +1,71 @@
+import type { SimCreateAuthorizerCommandInput } from "../command/authorizer/authorizer.command.js";
+import type { SimRestApiOpenApiObject } from "./sim-rest-api-openapi-object.js";
+import { simRestApiOpenApiSchemeIdentitySource } from "./sim-rest-api-openapi-scheme-identity-source.js";
+
+/**
+ * The members that belong to a Lambda authorizer, refused rather than ignored
+ * so a scheme declaring one under a `cognito_user_pools` authorizer does not
+ * import as something quieter than it says.
+ */
+const lambdaMembers = [
+  "authorizerUri",
+  "authorizerCredentials",
+  "identityValidationExpression",
+];
+
+const lambdaMember =
+  "configures the function a Lambda authorizer invokes, and a " +
+  "cognito_user_pools authorizer invokes nothing: it verifies the token " +
+  "against the user pools it names";
+
+const cognitoIdentitySource =
+  "is read from the scheme's own name and in for a cognito_user_pools " +
+  "authorizer, so an identitySource here would be applied by neither AWS nor " +
+  "this simulation";
+
+interface SimRestApiOpenApiCognitoAuthorizerSchemeProperties {
+  readonly scheme: SimRestApiOpenApiObject;
+  readonly authorizer: SimRestApiOpenApiObject;
+}
+
+/**
+ * An `x-amazon-apigateway-authorizer` of `type: cognito_user_pools`, read into
+ * the CreateAuthorizer input it asks for.
+ *
+ * The pool ARNs are handed to CreateAuthorizer as the document wrote them, so
+ * what an authorizer verifying a user pool token requires is stated where
+ * every other caller meets it. `authorizerResultTtlInSeconds` goes with them,
+ * and that command refuses a period on an authorizer verifying each token as
+ * it arrives.
+ */
+export class SimRestApiOpenApiCognitoAuthorizerScheme {
+  private readonly scheme: SimRestApiOpenApiObject;
+  private readonly authorizer: SimRestApiOpenApiObject;
+
+  constructor(properties: SimRestApiOpenApiCognitoAuthorizerSchemeProperties) {
+    this.scheme = properties.scheme;
+    this.authorizer = properties.authorizer;
+  }
+
+  /**
+   * The CreateAuthorizer input this authorizer asks for.
+   */
+  createAuthorizerInput(
+    restApiId: string,
+    name: string,
+  ): SimCreateAuthorizerCommandInput {
+    this.authorizer.refuseMembers(lambdaMembers, lambdaMember);
+    this.authorizer.refuseMember("identitySource", cognitoIdentitySource);
+
+    return {
+      restApiId,
+      name,
+      type: "COGNITO_USER_POOLS",
+      providerARNs: this.authorizer.member("providerARNs").optionalStringList(),
+      identitySource: simRestApiOpenApiSchemeIdentitySource(this.scheme),
+      authorizerResultTtlInSeconds: this.authorizer
+        .member("authorizerResultTtlInSeconds")
+        .optionalNumber(),
+    };
+  }
+}

--- a/src/service/apigateway/openapi/sim-rest-api-openapi-document.factory.ts
+++ b/src/service/apigateway/openapi/sim-rest-api-openapi-document.factory.ts
@@ -5,13 +5,15 @@ import type { JSONObject } from "../../../util/type-guard/json.js";
 /**
  * What a test asks for when it wants an OpenAPI document to import.
  *
- * `paths` is empty by default rather than carrying an operation of its own, so
- * a test states the one path item it is about and nothing is merged into it.
+ * `paths` and `components` are empty by default rather than carrying an
+ * operation of their own, so a test states the one path item or security
+ * scheme it is about and nothing is merged into it.
  */
 export interface SimRestApiOpenApiDocumentInput {
   readonly openapi: string;
   readonly title: string;
   readonly paths: JSONObject;
+  readonly components: JSONObject;
 }
 
 /**
@@ -35,10 +37,12 @@ export const simRestApiOpenApiDocumentFactory = new MappedFactory<
     openapi: "3.0.1",
     title: "pets",
     paths: {},
+    components: {},
   }),
   (input) => ({
     openapi: input.openapi,
     info: { title: input.title, version: "1.0" },
     paths: input.paths,
+    components: input.components,
   }),
 );

--- a/src/service/apigateway/openapi/sim-rest-api-openapi-document.ts
+++ b/src/service/apigateway/openapi/sim-rest-api-openapi-document.ts
@@ -2,6 +2,7 @@ import { simRestApiOpenApiRoot } from "./sim-rest-api-openapi-body.js";
 import { simRestApiOpenApiRefusedRootMembers } from "./sim-rest-api-openapi-root-members.js";
 import type { SimRestApiOpenApiObject } from "./sim-rest-api-openapi-object.js";
 import { SimRestApiOpenApiPaths } from "./sim-rest-api-openapi-paths.js";
+import { SimRestApiOpenApiValue } from "./sim-rest-api-openapi-value.js";
 
 /**
  * The OpenAPI versions a REST API is imported from.
@@ -49,6 +50,29 @@ export class SimRestApiOpenApiDocument {
    */
   paths(): SimRestApiOpenApiPaths {
     return new SimRestApiOpenApiPaths(this.root.member("paths"));
+  }
+
+  /**
+   * The security schemes an operation's security requirement can name.
+   */
+  securitySchemes(): SimRestApiOpenApiValue {
+    return this.component("securitySchemes");
+  }
+
+  /**
+   * One member of `components`, whether or not the document has any.
+   */
+  private component(name: string): SimRestApiOpenApiValue {
+    const components = this.root.member("components").optionalObject();
+
+    if (components === undefined) {
+      return new SimRestApiOpenApiValue({
+        pointer: this.root.pointer.child("components").child(name),
+        value: undefined,
+      });
+    }
+
+    return components.member(name);
   }
 
   /**

--- a/src/service/apigateway/openapi/sim-rest-api-openapi-iam-authorization.ts
+++ b/src/service/apigateway/openapi/sim-rest-api-openapi-iam-authorization.ts
@@ -1,0 +1,40 @@
+import type { SimRestApiOpenApiObject } from "./sim-rest-api-openapi-object.js";
+
+/**
+ * The one authorization `x-amazon-apigateway-auth` declares, which is the
+ * extension a document writes IAM authorization on an operation with.
+ */
+const iamAuthorizationType = "AWS_IAM";
+
+/**
+ * Whether an operation asks for its method to be decided by IAM.
+ *
+ * The extension carries a type and nothing else, and `AWS_IAM` is all AWS
+ * writes there. Anything else is refused rather than read as IAM
+ * authorization, since a method decided by the wrong thing is worse than a
+ * refused import.
+ */
+export function simRestApiOpenApiIamAuthorization(
+  operation: SimRestApiOpenApiObject,
+): boolean {
+  const declared = operation
+    .member("x-amazon-apigateway-auth")
+    .optionalObject();
+
+  if (declared === undefined) {
+    return false;
+  }
+
+  const type = declared.member("type");
+  const authorizationType = type.requiredString();
+
+  if (authorizationType !== iamAuthorizationType) {
+    throw type.refusal(
+      `is '${authorizationType}', and ${iamAuthorizationType} is the one ` +
+        `authorization x-amazon-apigateway-auth declares. An authorizer is ` +
+        `named by a security requirement instead.`,
+    );
+  }
+
+  return true;
+}

--- a/src/service/apigateway/openapi/sim-rest-api-openapi-import.ts
+++ b/src/service/apigateway/openapi/sim-rest-api-openapi-import.ts
@@ -1,21 +1,25 @@
 import type { SimRestApi } from "../api/sim-rest-api.js";
+import type { SimRestApiAuthorizerCommands } from "../command/authorizer/sim-rest-api-authorizer-commands.js";
 import type { SimRestApiIntegrationCommands } from "../command/integration/sim-rest-api-integration-commands.js";
 import type { SimRestApiMethodCommands } from "../command/method/sim-rest-api-method-commands.js";
 import type { SimRestApiResourceCommands } from "../command/resource/sim-rest-api-resource-commands.js";
 import { SimRestApiOpenApiCommand } from "./sim-rest-api-openapi-command.js";
 import type { SimRestApiOpenApiDocument } from "./sim-rest-api-openapi-document.js";
 import { SimRestApiOpenApiMethods } from "./sim-rest-api-openapi-method.js";
+import { SimRestApiOpenApiAuthorization } from "./sim-rest-api-openapi-method-authorization.js";
 import { SimRestApiOpenApiPathTree } from "./sim-rest-api-openapi-path-tree.js";
+import { SimRestApiOpenApiSecuritySchemes } from "./sim-rest-api-openapi-security-schemes.js";
 
 interface SimRestApiOpenApiImportProperties {
   readonly resourceCommands: SimRestApiResourceCommands;
   readonly methodCommands: SimRestApiMethodCommands;
   readonly integrationCommands: SimRestApiIntegrationCommands;
+  readonly authorizerCommands: SimRestApiAuthorizerCommands;
 }
 
 /**
- * Turns a read OpenAPI document into the resources, methods and integrations
- * of an API that already exists.
+ * Turns a read OpenAPI document into the resources, methods, integrations and
+ * authorizers of an API that already exists.
  *
  * Everything is created through the ordinary commands, so an imported API is
  * held to the rules an SDK caller is held to.
@@ -30,6 +34,10 @@ export class SimRestApiOpenApiImport {
     this.methods = new SimRestApiOpenApiMethods({
       methodCommands: properties.methodCommands,
       integrationCommands: properties.integrationCommands,
+      authorization: new SimRestApiOpenApiAuthorization({
+        authorizerCommands: properties.authorizerCommands,
+        command: this.command,
+      }),
       command: this.command,
     });
   }
@@ -44,12 +52,15 @@ export class SimRestApiOpenApiImport {
       resourceCommands: this.resourceCommands,
       command: this.command,
     });
+    const schemes = new SimRestApiOpenApiSecuritySchemes({
+      schemes: document.securitySchemes(),
+    });
 
     for (const item of document.paths().items()) {
       const resourceId = tree.resourceIdFor(item);
 
       for (const operation of item.operations()) {
-        this.methods.declare(restApi.apiId, resourceId, operation);
+        this.methods.declare(restApi.apiId, resourceId, operation, schemes);
       }
     }
   }

--- a/src/service/apigateway/openapi/sim-rest-api-openapi-lambda-authorizer-scheme.ts
+++ b/src/service/apigateway/openapi/sim-rest-api-openapi-lambda-authorizer-scheme.ts
@@ -1,0 +1,98 @@
+import type { SimCreateAuthorizerCommandInput } from "../command/authorizer/authorizer.command.js";
+import type { SimRestApiOpenApiObject } from "./sim-rest-api-openapi-object.js";
+import { simRestApiOpenApiSchemeIdentitySource } from "./sim-rest-api-openapi-scheme-identity-source.js";
+
+const authorizerCredentials =
+  "names an IAM Role for API Gateway to assume before invoking the " +
+  "authorizer function, and nothing here assumes one: the function's own " +
+  "resource policy is what admits the call";
+
+const identityValidationExpression =
+  "checks the token against a regular expression before the function is " +
+  "invoked, and that check is not simulated, so the function would be " +
+  "invoked for a token AWS refuses without it";
+
+const providerArns =
+  "names the user pools a cognito_user_pools authorizer verifies tokens " +
+  "against, and this one decides by invoking its function";
+
+const tokenIdentitySource =
+  "is read from the scheme's own name and in for a token authorizer, so an " +
+  "identitySource here would be applied by neither AWS nor this simulation. " +
+  "Declare the authorizer as type request to name the request parameters it " +
+  "identifies a caller by.";
+
+interface SimRestApiOpenApiLambdaAuthorizerSchemeProperties {
+  readonly scheme: SimRestApiOpenApiObject;
+  readonly authorizer: SimRestApiOpenApiObject;
+  /** Which of the two kinds of Lambda authorizer the scheme declares. */
+  readonly type: "TOKEN" | "REQUEST";
+}
+
+/**
+ * An `x-amazon-apigateway-authorizer` of `type: token` or `type: request`,
+ * read into the CreateAuthorizer input it asks for.
+ *
+ * The values are handed to CreateAuthorizer as the document wrote them, so
+ * what a Lambda authorizer requires is stated where an SDK caller and a
+ * template already meet it. That covers the wrapped function URI, the identity
+ * source expressions a `REQUEST` authorizer identifies a caller by, and how
+ * long its decisions are held for.
+ */
+export class SimRestApiOpenApiLambdaAuthorizerScheme {
+  private readonly scheme: SimRestApiOpenApiObject;
+  private readonly authorizer: SimRestApiOpenApiObject;
+  private readonly type: "TOKEN" | "REQUEST";
+
+  constructor(properties: SimRestApiOpenApiLambdaAuthorizerSchemeProperties) {
+    this.scheme = properties.scheme;
+    this.authorizer = properties.authorizer;
+    this.type = properties.type;
+  }
+
+  /**
+   * The CreateAuthorizer input this authorizer asks for.
+   */
+  createAuthorizerInput(
+    restApiId: string,
+    name: string,
+  ): SimCreateAuthorizerCommandInput {
+    this.authorizer.refuseMember(
+      "authorizerCredentials",
+      authorizerCredentials,
+    );
+    this.authorizer.refuseMember(
+      "identityValidationExpression",
+      identityValidationExpression,
+    );
+    this.authorizer.refuseMember("providerARNs", providerArns);
+
+    return {
+      restApiId,
+      name,
+      type: this.type,
+      authorizerUri: this.authorizer.member("authorizerUri").optionalString(),
+      identitySource: this.identitySource(),
+      authorizerResultTtlInSeconds: this.authorizer
+        .member("authorizerResultTtlInSeconds")
+        .optionalNumber(),
+    };
+  }
+
+  /**
+   * Where this authorizer looks for what identifies a caller.
+   *
+   * A `TOKEN` authorizer reads the header the scheme names. A `REQUEST` one
+   * names its own request parameters, which is the whole of what it has over
+   * the other kind.
+   */
+  private identitySource(): string | undefined {
+    if (this.type === "REQUEST") {
+      return this.authorizer.member("identitySource").optionalString();
+    }
+
+    this.authorizer.refuseMember("identitySource", tokenIdentitySource);
+
+    return simRestApiOpenApiSchemeIdentitySource(this.scheme);
+  }
+}

--- a/src/service/apigateway/openapi/sim-rest-api-openapi-method-authorization.ts
+++ b/src/service/apigateway/openapi/sim-rest-api-openapi-method-authorization.ts
@@ -1,0 +1,140 @@
+import type { SimRestApiAuthorizerView } from "../api/authorizer/sim-rest-api-authorizer.js";
+import type { SimRestApiAuthorizerCommands } from "../command/authorizer/sim-rest-api-authorizer-commands.js";
+import type { SimPutMethodCommandInput } from "../command/method/method.command.js";
+import { simRestApiCognitoAuthorizationType } from "../command/method/sim-rest-api-method-authorizer-input.js";
+import type { SimRestApiOpenApiCommand } from "./sim-rest-api-openapi-command.js";
+import type {
+  SimRestApiOpenApiOperation,
+  SimRestApiOpenApiSecurityRequirement,
+} from "./sim-rest-api-openapi-operation.js";
+import type { SimRestApiOpenApiSecuritySchemes } from "./sim-rest-api-openapi-security-schemes.js";
+
+/**
+ * The authorization a method created from a document is declared with.
+ */
+export type SimRestApiOpenApiMethodAuthorization = Pick<
+  SimPutMethodCommandInput,
+  "authorizationType" | "authorizerId" | "authorizationScopes"
+>;
+
+const declaredTwice =
+  "names a security scheme, and the operation also carries " +
+  "x-amazon-apigateway-auth, so it says twice who may call the method. A " +
+  "method is decided one way.";
+
+interface SimRestApiOpenApiAuthorizationProperties {
+  readonly authorizerCommands: SimRestApiAuthorizerCommands;
+  readonly command: SimRestApiOpenApiCommand;
+}
+
+/**
+ * Turns what an operation says about who may call it into the authorization
+ * its method is declared with, creating the authorizer a security requirement
+ * names.
+ *
+ * An operation saying nothing is open, which is what an imported method with
+ * no authorizer is on AWS.
+ */
+export class SimRestApiOpenApiAuthorization {
+  private readonly authorizerCommands: SimRestApiAuthorizerCommands;
+  private readonly command: SimRestApiOpenApiCommand;
+
+  constructor(properties: SimRestApiOpenApiAuthorizationProperties) {
+    this.authorizerCommands = properties.authorizerCommands;
+    this.command = properties.command;
+  }
+
+  /**
+   * How the method one operation becomes says who may call it.
+   */
+  of(
+    restApiId: string,
+    operation: SimRestApiOpenApiOperation,
+    schemes: SimRestApiOpenApiSecuritySchemes,
+  ): SimRestApiOpenApiMethodAuthorization {
+    const iam = operation.iamAuthorization();
+    const requirement = operation.security();
+
+    if (requirement === undefined) {
+      return { authorizationType: iam ? "AWS_IAM" : "NONE" };
+    }
+
+    if (iam) {
+      throw requirement.value.refusal(declaredTwice);
+    }
+
+    const authorizer = this.authorizerFor(restApiId, requirement, schemes);
+
+    return authorizer === undefined
+      ? {
+          authorizationType: "AWS_IAM",
+          authorizationScopes: scopesOf(requirement),
+        }
+      : this.gated(authorizer, requirement);
+  }
+
+  /**
+   * The authorizer the scheme a requirement names declares, shared with every
+   * method that named it before, and nothing at all where the scheme declares
+   * a method decided by IAM.
+   */
+  private authorizerFor(
+    restApiId: string,
+    requirement: SimRestApiOpenApiSecurityRequirement,
+    schemes: SimRestApiOpenApiSecuritySchemes,
+  ): SimRestApiAuthorizerView | undefined {
+    const shared = schemes.createdAuthorizer(requirement.schemeName);
+
+    if (shared !== undefined) {
+      return shared;
+    }
+
+    const { input, pointer } = schemes.authorizer(restApiId, requirement);
+
+    if (input === undefined) {
+      return undefined;
+    }
+
+    const created = this.command.run(pointer, () =>
+      this.authorizerCommands.createAuthorizer({ input }),
+    );
+    schemes.remember(requirement.schemeName, created);
+
+    return created;
+  }
+
+  /**
+   * A method that sends its requests through one of the API's authorizers, of
+   * the type that authorizer is.
+   *
+   * The requirement's scopes go with it rather than being dropped: AWS checks
+   * scopes against the token a `COGNITO_USER_POOLS` method verifies, so
+   * `PutMethod` refuses them on a method that checks none.
+   */
+  private gated(
+    authorizer: SimRestApiAuthorizerView,
+    requirement: SimRestApiOpenApiSecurityRequirement,
+  ): SimRestApiOpenApiMethodAuthorization {
+    return {
+      authorizationType:
+        authorizer.type === simRestApiCognitoAuthorizationType
+          ? simRestApiCognitoAuthorizationType
+          : "CUSTOM",
+      authorizerId: authorizer.id,
+      authorizationScopes: scopesOf(requirement),
+    };
+  }
+}
+
+/**
+ * The scopes a requirement asks for, left out where it asks for none.
+ *
+ * An empty list is what most requirements carry, and `PutMethod` refuses
+ * scopes on every method but the one kind that checks them, so an empty list
+ * would refuse a method the document never asked to gate by scope.
+ */
+function scopesOf(
+  requirement: SimRestApiOpenApiSecurityRequirement,
+): readonly string[] | undefined {
+  return requirement.scopes.length === 0 ? undefined : requirement.scopes;
+}

--- a/src/service/apigateway/openapi/sim-rest-api-openapi-method.ts
+++ b/src/service/apigateway/openapi/sim-rest-api-openapi-method.ts
@@ -2,38 +2,34 @@ import type { SimRestApiIntegrationCommands } from "../command/integration/sim-r
 import type { SimRestApiMethodCommands } from "../command/method/sim-rest-api-method-commands.js";
 import type { SimRestApiOpenApiCommand } from "./sim-rest-api-openapi-command.js";
 import { SimRestApiOpenApiIntegration } from "./sim-rest-api-openapi-integration.js";
+import type { SimRestApiOpenApiAuthorization } from "./sim-rest-api-openapi-method-authorization.js";
 import type { SimRestApiOpenApiOperation } from "./sim-rest-api-openapi-operation.js";
-
-/**
- * The authorization type every imported method is declared with.
- *
- * A document naming an authorizer is refused while reading one out of a
- * document is unsimulated, so an imported method is an open one or the import
- * did not happen. `CreateAuthorizer` and `PutMethod` gate a method that was
- * declared through the commands.
- */
-const importedAuthorizationType = "NONE";
+import type { SimRestApiOpenApiSecuritySchemes } from "./sim-rest-api-openapi-security-schemes.js";
 
 interface SimRestApiOpenApiMethodsProperties {
   readonly methodCommands: SimRestApiMethodCommands;
   readonly integrationCommands: SimRestApiIntegrationCommands;
+  readonly authorization: SimRestApiOpenApiAuthorization;
   readonly command: SimRestApiOpenApiCommand;
 }
 
 /**
- * Declares the method one operation becomes, and what it does with a request.
+ * Declares the method one operation becomes, who may call it, and what it does
+ * with a request.
  *
- * A REST API declares the two separately, so one operation is two commands,
- * both of them the ordinary ones.
+ * A REST API declares the method and its integration separately, so one
+ * operation is two commands, both of them the ordinary ones.
  */
 export class SimRestApiOpenApiMethods {
   private readonly methodCommands: SimRestApiMethodCommands;
   private readonly integrationCommands: SimRestApiIntegrationCommands;
+  private readonly authorization: SimRestApiOpenApiAuthorization;
   private readonly command: SimRestApiOpenApiCommand;
 
   constructor(properties: SimRestApiOpenApiMethodsProperties) {
     this.methodCommands = properties.methodCommands;
     this.integrationCommands = properties.integrationCommands;
+    this.authorization = properties.authorization;
     this.command = properties.command;
   }
 
@@ -48,16 +44,18 @@ export class SimRestApiOpenApiMethods {
     restApiId: string,
     resourceId: string,
     operation: SimRestApiOpenApiOperation,
+    schemes: SimRestApiOpenApiSecuritySchemes,
   ): void {
     const declared = operation.integration();
     const integration = new SimRestApiOpenApiIntegration(
       declared,
     ).putIntegrationInput();
+    const authorization = this.authorization.of(restApiId, operation, schemes);
     const address = { restApiId, resourceId, httpMethod: operation.httpMethod };
 
     this.command.run(operation.pointer(), () =>
       this.methodCommands.putMethod({
-        input: { ...address, authorizationType: importedAuthorizationType },
+        input: { ...address, ...authorization },
       }),
     );
 

--- a/src/service/apigateway/openapi/sim-rest-api-openapi-operation.ts
+++ b/src/service/apigateway/openapi/sim-rest-api-openapi-operation.ts
@@ -1,23 +1,13 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import { simRestApiOpenApiIamAuthorization } from "./sim-rest-api-openapi-iam-authorization.js";
 import type { SimRestApiOpenApiPointer } from "./sim-rest-api-openapi-pointer.js";
 import type { SimRestApiOpenApiValue } from "./sim-rest-api-openapi-value.js";
 
 /**
- * The operation members that decide who may call the method, none of which is
- * read out of a document yet.
+ * The operation members that decide who may call the method and are not read
+ * out of a document.
  */
 const refusedOperationMembers: readonly (readonly [string, string])[] = [
-  [
-    "security",
-    "a security requirement names the authorizer in front of the method, and " +
-      "reading an authorizer out of a document is not simulated. Every " +
-      "imported method is declared with AuthorizationType NONE. Create the " +
-      "authorizer with CreateAuthorizer and declare the method against it.",
-  ],
-  [
-    "x-amazon-apigateway-auth",
-    "it declares IAM authorization on the method, and AWS_IAM is not a " +
-      "simulated authorization type",
-  ],
   [
     "x-amazon-apigateway-api-key-source",
     "API keys and usage plans are not simulated",
@@ -35,8 +25,20 @@ interface SimRestApiOpenApiOperationProperties {
 }
 
 /**
- * One operation of the document being imported: the method it becomes and the
- * integration behind it.
+ * What one operation says about who may call the method it becomes.
+ */
+export interface SimRestApiOpenApiSecurityRequirement {
+  /** The `components.securitySchemes` member the requirement names. */
+  readonly schemeName: string;
+  /** The scopes the method asks the presented token for. */
+  readonly scopes: readonly string[];
+  /** The requirement itself, so a refusal about it names where it is. */
+  readonly value: SimRestApiOpenApiValue;
+}
+
+/**
+ * One operation of the document being imported: the method it becomes, the
+ * integration behind it, and who may call it.
  *
  * `requestBody`, the content schemas under `responses`, `parameters`,
  * `summary`, `description` and `tags` are all ignored, which is what AWS does
@@ -82,5 +84,68 @@ export class SimRestApiOpenApiOperation {
     }
 
     return integration;
+  }
+
+  /**
+   * The one security requirement this operation carries, if it carries any.
+   *
+   * More than one is refused. One authorizer decides a method, and a second
+   * requirement would be dropped here and refused by AWS.
+   */
+  security(): SimRestApiOpenApiSecurityRequirement | undefined {
+    const security = this.value.object().member("security");
+    const requirements = security.optionalArray();
+
+    if (requirements === undefined || requirements.length === 0) {
+      return undefined;
+    }
+
+    if (requirements.length > 1) {
+      throw security.refusal(
+        `carries ${String(requirements.length)} security requirements, and a ` +
+          `method is decided by one authorizer, so only the first would be ` +
+          `applied here`,
+      );
+    }
+
+    const [requirement] = requirements;
+    assertDefined(requirement, "the security requirement just counted");
+
+    return this.requirement(requirement);
+  }
+
+  /**
+   * Whether this operation asks for the method to be decided by IAM, which a
+   * document writes as `x-amazon-apigateway-auth`.
+   */
+  iamAuthorization(): boolean {
+    return simRestApiOpenApiIamAuthorization(this.value.object());
+  }
+
+  /**
+   * The scheme and scopes one security requirement names.
+   */
+  private requirement(
+    value: SimRestApiOpenApiValue,
+  ): SimRestApiOpenApiSecurityRequirement {
+    const requirement = value.object();
+    const schemeNames = requirement.memberNames();
+
+    if (schemeNames.length !== 1) {
+      throw requirement.refusal(
+        `names ${String(schemeNames.length)} security schemes, and a method ` +
+          `is decided by one authorizer, so only one scheme can be applied ` +
+          `to it`,
+      );
+    }
+
+    const [schemeName] = schemeNames;
+    assertDefined(schemeName, "the security scheme name just counted");
+    // A member the document carries is never absent, so the scopes are the
+    // list it wrote or a refusal about the shape it wrote instead.
+    const scopes = requirement.member(schemeName).optionalStringList();
+    assertDefined(scopes, `the scopes of the ${schemeName} requirement`);
+
+    return { schemeName, scopes, value };
   }
 }

--- a/src/service/apigateway/openapi/sim-rest-api-openapi-refusals.iso.test.ts
+++ b/src/service/apigateway/openapi/sim-rest-api-openapi-refusals.iso.test.ts
@@ -130,25 +130,6 @@ describe("Refusing an OpenAPI document a sim REST API cannot serve", () => {
     );
   });
 
-  it("refuses an operation that says who may call it", async () => {
-    // Given an operation naming a security scheme
-    const simAws = new SimAws();
-
-    // When it is imported
-    // Then it is refused, because authorizing a REST API method is not
-    // simulated and an open method is not what the document asked for
-    await expect(
-      importingPath(simAws, "/pets", {
-        get: {
-          security: [{ "pet-authorizer": [] }],
-          "x-amazon-apigateway-integration": integration,
-        },
-      }),
-    ).rejects.toThrow(
-      /#\/paths\/~1pets\/get\/security: a security requirement names the/,
-    );
-  });
-
   it("refuses an operation with no integration behind it", async () => {
     // Given an operation declaring only its responses
     const simAws = new SimAws();

--- a/src/service/apigateway/openapi/sim-rest-api-openapi-replacement.ts
+++ b/src/service/apigateway/openapi/sim-rest-api-openapi-replacement.ts
@@ -1,10 +1,12 @@
 import type { SimRestApi } from "../api/sim-rest-api.js";
+import type { SimRestApiAuthorizerCommands } from "../command/authorizer/sim-rest-api-authorizer-commands.js";
 import type { SimRestApiResourceCommands } from "../command/resource/sim-rest-api-resource-commands.js";
 import type { SimRestApiOpenApiDocument } from "./sim-rest-api-openapi-document.js";
 import type { SimRestApiOpenApiImport } from "./sim-rest-api-openapi-import.js";
 
 interface SimRestApiOpenApiReplacementProperties {
   readonly resourceCommands: SimRestApiResourceCommands;
+  readonly authorizerCommands: SimRestApiAuthorizerCommands;
   readonly openApiImport: SimRestApiOpenApiImport;
 }
 
@@ -17,10 +19,12 @@ interface SimRestApiOpenApiReplacementProperties {
  */
 export class SimRestApiOpenApiReplacement {
   private readonly resourceCommands: SimRestApiResourceCommands;
+  private readonly authorizerCommands: SimRestApiAuthorizerCommands;
   private readonly openApiImport: SimRestApiOpenApiImport;
 
   constructor(properties: SimRestApiOpenApiReplacementProperties) {
     this.resourceCommands = properties.resourceCommands;
+    this.authorizerCommands = properties.authorizerCommands;
     this.openApiImport = properties.openApiImport;
   }
 
@@ -45,11 +49,14 @@ export class SimRestApiOpenApiReplacement {
   }
 
   /**
-   * Delete every resource under the root, through the ordinary command.
+   * Delete the whole definition, through the ordinary commands.
    *
    * Only the resources directly under the root are named, because deleting one
    * takes its subtree with it. The root itself stays, since every REST API has
-   * one.
+   * one. The authorizers go with the methods that named them, since a document
+   * declares the authorizers of the API it replaces along with everything
+   * else, and each import of the same document would otherwise create another
+   * authorizer nothing names.
    */
   private empty(restApi: SimRestApi): void {
     for (const child of restApi.resources.children(
@@ -57,6 +64,15 @@ export class SimRestApiOpenApiReplacement {
     )) {
       this.resourceCommands.deleteResource({
         input: { restApiId: restApi.apiId, resourceId: child.resourceId },
+      });
+    }
+
+    for (const authorizer of restApi.authorizers.list()) {
+      this.authorizerCommands.deleteAuthorizer({
+        input: {
+          restApiId: restApi.apiId,
+          authorizerId: authorizer.authorizerId,
+        },
       });
     }
   }

--- a/src/service/apigateway/openapi/sim-rest-api-openapi-root-members.ts
+++ b/src/service/apigateway/openapi/sim-rest-api-openapi-root-members.ts
@@ -12,8 +12,8 @@ export const simRestApiOpenApiRefusedRootMembers: readonly (readonly [
   ],
   [
     "security",
-    "a security requirement applying to every operation is not simulated, " +
-      "because authorizing a method is not simulated",
+    "a security requirement applying to every operation is not simulated. " +
+      "Declare the requirement on each operation instead.",
   ],
   [
     "x-amazon-apigateway-policy",

--- a/src/service/apigateway/openapi/sim-rest-api-openapi-scheme-identity-source.ts
+++ b/src/service/apigateway/openapi/sim-rest-api-openapi-scheme-identity-source.ts
@@ -1,0 +1,27 @@
+import { simRestApiHeaderIdentityPrefix } from "../api/authorizer/identity/sim-rest-api-header-identity-source.js";
+import type { SimRestApiOpenApiObject } from "./sim-rest-api-openapi-object.js";
+
+/**
+ * The header an `apiKey` security scheme names, which is where AWS reads the
+ * identity source of a `TOKEN` or `COGNITO_USER_POOLS` authorizer from.
+ *
+ * Both kinds read one header and nothing else, and the scheme's own `name` and
+ * `in` are what say which. An `x-amazon-apigateway-authorizer` of either kind
+ * carries no `identitySource` of its own, so a scheme that writes one is
+ * refused where it wrote it rather than importing as a header it did not name.
+ */
+export function simRestApiOpenApiSchemeIdentitySource(
+  scheme: SimRestApiOpenApiObject,
+): string {
+  const where = scheme.member("in");
+  const declared = where.requiredString();
+
+  if (declared !== "header") {
+    throw where.refusal(
+      `is '${declared}', and the authorizer this scheme declares reads one ` +
+        `request header, so the scheme names that header with 'in: header'`,
+    );
+  }
+
+  return `${simRestApiHeaderIdentityPrefix}${scheme.member("name").requiredString()}`;
+}

--- a/src/service/apigateway/openapi/sim-rest-api-openapi-security-refusals.iso.test.ts
+++ b/src/service/apigateway/openapi/sim-rest-api-openapi-security-refusals.iso.test.ts
@@ -1,0 +1,312 @@
+import { ImportRestApiCommand } from "@aws-sdk/client-api-gateway";
+import { describe, expect, it } from "vitest";
+
+import type { JSONObject, JSONValue } from "../../../util/type-guard/json.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simRestApiOpenApiDocumentFactory } from "./sim-rest-api-openapi-document.factory.js";
+import { simRestApiOpenApiIntegrationFactory } from "./sim-rest-api-openapi-integration.factory.js";
+
+const integration = simRestApiOpenApiIntegrationFactory.make();
+
+const authorizerUri =
+  "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/" +
+  "arn:aws:lambda:us-east-1:555555555555:function:PetAuthorizer/invocations";
+
+const userPoolArn =
+  "arn:aws:cognito-idp:us-east-1:111111111111:userpool/us-east-1_aBcDeFgHi";
+
+/**
+ * Import a document built around one operation, whatever it says about who may
+ * call it.
+ */
+async function importingOperation(
+  simAws: SimAws,
+  operation: JSONObject,
+  components: JSONObject = {},
+): Promise<unknown> {
+  const document = simRestApiOpenApiDocumentFactory.make({
+    paths: {
+      "/pets": {
+        get: { ...operation, "x-amazon-apigateway-integration": integration },
+      },
+    },
+    components,
+  });
+
+  const body = new TextEncoder().encode(JSON.stringify(document));
+
+  return await simAws
+    .apiGateway()
+    .importRestApi(new ImportRestApiCommand({ body }));
+}
+
+/**
+ * Import a document whose one operation names the scheme under test.
+ */
+async function importingScheme(
+  simAws: SimAws,
+  scheme: JSONObject,
+  scopes: string[] = [],
+): Promise<unknown> {
+  return await importingOperation(
+    simAws,
+    { security: [{ "pet-authorizer": scopes }] },
+    { securitySchemes: { "pet-authorizer": scheme } },
+  );
+}
+
+/**
+ * A `custom` scheme carrying the authorizer members under test.
+ */
+function customScheme(authorizer: JSONObject): JSONObject {
+  return {
+    type: "apiKey",
+    name: "Authorization",
+    in: "header",
+    "x-amazon-apigateway-authtype": "custom",
+    "x-amazon-apigateway-authorizer": {
+      type: "token",
+      authorizerUri,
+      ...authorizer,
+    },
+  };
+}
+
+describe("Refusing a security scheme a sim REST API cannot be gated by", () => {
+  it("refuses a scheme that is not an apiKey one", async () => {
+    // Given the scheme types a REST API declares no authorizer under
+    const simAws = new SimAws();
+    const refused: readonly JSONObject[] = [
+      { type: "http", scheme: "basic" },
+      { type: "oauth2", flows: {} },
+      { type: "openIdConnect", openIdConnectUrl: "https://pets.example.com" },
+    ];
+
+    // When each is imported
+    // Then each is refused where it is written, since a REST API writes
+    // every authorizer it has as an apiKey scheme
+    await Promise.all(
+      refused.map(async (scheme) => {
+        await expect(importingScheme(simAws, scheme)).rejects.toThrow(
+          /#\/components\/securitySchemes\/pet-authorizer\/type: is not 'apiKey'/,
+        );
+      }),
+    );
+  });
+
+  it("refuses an apiKey scheme declaring an API key", async () => {
+    // Given a scheme carrying no authtype, which is what an API key is
+    const simAws = new SimAws();
+    const scheme: JSONObject = {
+      type: "apiKey",
+      name: "x-api-key",
+      in: "header",
+    };
+
+    // When it is imported
+    // Then it is refused, since API keys and usage plans are not simulated
+    await expect(importingScheme(simAws, scheme)).rejects.toThrow(
+      /x-amazon-apigateway-authtype: is required: an apiKey scheme carrying/,
+    );
+  });
+
+  it("refuses an authtype no REST API authorization is declared with", async () => {
+    // Given a scheme declaring an authtype from another API kind
+    const simAws = new SimAws();
+    const scheme: JSONObject = {
+      type: "apiKey",
+      name: "Authorization",
+      in: "header",
+      "x-amazon-apigateway-authtype": "oauth2",
+    };
+
+    // When it is imported
+    // Then it is refused, naming the three a REST API method is decided by
+    await expect(importingScheme(simAws, scheme)).rejects.toThrow(
+      /x-amazon-apigateway-authtype: is 'oauth2', and a REST API method is/,
+    );
+  });
+
+  it("refuses a scheme whose authtype and authorizer disagree", async () => {
+    // Given a custom scheme carrying a user pool authorizer, and a
+    // cognito_user_pools scheme carrying a Lambda one
+    const simAws = new SimAws();
+    const cognitoUnderCustom: JSONObject = {
+      type: "apiKey",
+      name: "Authorization",
+      in: "header",
+      "x-amazon-apigateway-authtype": "custom",
+      "x-amazon-apigateway-authorizer": {
+        type: "cognito_user_pools",
+        providerARNs: [userPoolArn],
+      },
+    };
+    const lambdaUnderCognito: JSONObject = {
+      type: "apiKey",
+      name: "Authorization",
+      in: "header",
+      "x-amazon-apigateway-authtype": "cognito_user_pools",
+      "x-amazon-apigateway-authorizer": { type: "token", authorizerUri },
+    };
+
+    // When each is imported
+    // Then each is refused at the pointer of the type they disagree about,
+    // rather than resolved either way
+    await expect(importingScheme(simAws, cognitoUnderCustom)).rejects.toThrow(
+      /securitySchemes\/pet-authorizer\/x-amazon-apigateway-authorizer\/type: is 'cognito_user_pools', and/,
+    );
+    await expect(importingScheme(simAws, lambdaUnderCognito)).rejects.toThrow(
+      /x-amazon-apigateway-authorizer\/type: is 'token', and the security scheme/,
+    );
+  });
+
+  it("refuses an awsSigv4 scheme carrying an authorizer", async () => {
+    // Given a scheme declaring IAM authorization and an authorizer to invoke
+    const simAws = new SimAws();
+    const scheme: JSONObject = {
+      type: "apiKey",
+      name: "Authorization",
+      in: "header",
+      "x-amazon-apigateway-authtype": "awsSigv4",
+      "x-amazon-apigateway-authorizer": { type: "token", authorizerUri },
+    };
+
+    // When it is imported
+    // Then it is refused, since an IAM method asks no authorizer anything
+    await expect(importingScheme(simAws, scheme)).rejects.toThrow(
+      /pet-authorizer\/x-amazon-apigateway-authorizer: declares an authorizer/,
+    );
+  });
+
+  it("refuses an authorizer member it would not apply", async () => {
+    // Given authorizers carrying each of them
+    const simAws = new SimAws();
+    const refused: readonly (readonly [string, JSONValue])[] = [
+      ["authorizerCredentials", "arn:aws:iam::111111111111:role/Pets"],
+      ["identityValidationExpression", "^Bearer .+"],
+      ["providerARNs", [userPoolArn]],
+      ["identitySource", "method.request.header.Authorization"],
+    ];
+
+    // When each is imported
+    // Then each is refused naming the member, since a token authorizer here
+    // applies none of it
+    await Promise.all(
+      refused.map(async ([member, value]) => {
+        await expect(
+          importingScheme(simAws, customScheme({ [member]: value })),
+        ).rejects.toThrow(
+          `#/components/securitySchemes/pet-authorizer/` +
+            `x-amazon-apigateway-authorizer/${member}: `,
+        );
+      }),
+    );
+  });
+
+  it("refuses a period held on an authorizer that verifies each token", async () => {
+    // Given a user pool scheme asking for its decision to be held
+    const simAws = new SimAws();
+    const scheme: JSONObject = {
+      type: "apiKey",
+      name: "Authorization",
+      in: "header",
+      "x-amazon-apigateway-authtype": "cognito_user_pools",
+      "x-amazon-apigateway-authorizer": {
+        type: "cognito_user_pools",
+        providerARNs: [userPoolArn],
+        authorizerResultTtlInSeconds: 300,
+      },
+    };
+
+    // When it is imported
+    // Then CreateAuthorizer refuses it, under the pointer of the scheme the
+    // period was written on
+    await expect(importingScheme(simAws, scheme)).rejects.toThrow(
+      /securitySchemes\/pet-authorizer: CreateAuthorizer authorizerResultTtlInSeconds is set on a COGNITO_USER_POOLS/,
+    );
+  });
+
+  it("refuses a scheme naming a header no request carries one in", async () => {
+    // Given a scheme whose token is read from the query string
+    const simAws = new SimAws();
+    const scheme = { ...customScheme({}), in: "query", name: "token" };
+
+    // When it is imported
+    // Then it is refused, since a token authorizer reads one request header
+    await expect(importingScheme(simAws, scheme)).rejects.toThrow(
+      /pet-authorizer\/in: is 'query', and the authorizer this scheme declares/,
+    );
+  });
+
+  it("refuses a requirement naming a scheme the document does not define", async () => {
+    // Given an operation naming a scheme nothing declares
+    const simAws = new SimAws();
+
+    // When it is imported
+    // Then it is refused, naming where the schemes would have been
+    await expect(
+      importingOperation(simAws, { security: [{ "pet-authorizer": [] }] }),
+    ).rejects.toThrow(
+      /security\/0: names the security scheme 'pet-authorizer', which #\/components\/securitySchemes does not define/,
+    );
+  });
+
+  it("refuses an operation saying twice who may call it", async () => {
+    // Given operations naming two requirements, two schemes in one
+    // requirement, and both a requirement and IAM authorization
+    const simAws = new SimAws();
+
+    // When each is imported
+    // Then each is refused, since one method is decided by one authorizer
+    await expect(
+      importingOperation(simAws, {
+        security: [{ "pet-authorizer": [] }, { "owner-authorizer": [] }],
+      }),
+    ).rejects.toThrow(/get\/security: carries 2 security requirements/);
+    await expect(
+      importingOperation(simAws, {
+        security: [{ "pet-authorizer": [], "owner-authorizer": [] }],
+      }),
+    ).rejects.toThrow(/get\/security\/0: names 2 security schemes/);
+    await expect(
+      importingOperation(
+        simAws,
+        {
+          security: [{ "pet-authorizer": [] }],
+          "x-amazon-apigateway-auth": { type: "AWS_IAM" },
+        },
+        { securitySchemes: { "pet-authorizer": customScheme({}) } },
+      ),
+    ).rejects.toThrow(/get\/security\/0: names a security scheme, and the/);
+  });
+
+  it("refuses an x-amazon-apigateway-auth that is not IAM authorization", async () => {
+    // Given an operation declaring some other authorization on the extension
+    const simAws = new SimAws();
+
+    // When it is imported
+    // Then it is refused, since IAM authorization is all the extension
+    // declares
+    await expect(
+      importingOperation(simAws, {
+        "x-amazon-apigateway-auth": { type: "CUSTOM" },
+      }),
+    ).rejects.toThrow(
+      /x-amazon-apigateway-auth\/type: is 'CUSTOM', and AWS_IAM is the one/,
+    );
+  });
+
+  it("refuses scopes on a method that checks none", async () => {
+    // Given an operation asking a Lambda authorizer's caller for a scope
+    const simAws = new SimAws();
+
+    // When it is imported
+    // Then it is refused by PutMethod, under the pointer of the operation the
+    // scopes were written on
+    await expect(
+      importingScheme(simAws, customScheme({}), ["pets.read"]),
+    ).rejects.toThrow(
+      /#\/paths\/~1pets\/get: PutMethod authorizationScopes is set on GET \/pets/,
+    );
+  });
+});

--- a/src/service/apigateway/openapi/sim-rest-api-openapi-security-scheme.ts
+++ b/src/service/apigateway/openapi/sim-rest-api-openapi-security-scheme.ts
@@ -1,0 +1,125 @@
+import type { SimCreateAuthorizerCommandInput } from "../command/authorizer/authorizer.command.js";
+import {
+  simRestApiOpenApiAuthorizerType,
+  simRestApiOpenApiDeclaresAuthorizer,
+} from "./sim-rest-api-openapi-authorizer-type.js";
+import { SimRestApiOpenApiCognitoAuthorizerScheme } from "./sim-rest-api-openapi-cognito-authorizer-scheme.js";
+import { SimRestApiOpenApiLambdaAuthorizerScheme } from "./sim-rest-api-openapi-lambda-authorizer-scheme.js";
+import type { SimRestApiOpenApiObject } from "./sim-rest-api-openapi-object.js";
+
+/**
+ * The security scheme type a REST API declares every authorizer under.
+ *
+ * `custom`, `cognito_user_pools` and `awsSigv4` are all written as an `apiKey`
+ * scheme naming the header the caller presents, and told apart by
+ * `x-amazon-apigateway-authtype`.
+ */
+const apiKeySchemeType = "apiKey";
+
+/**
+ * The `x-amazon-apigateway-authtype` of a method decided by IAM, which
+ * declares no authorizer of its own.
+ */
+const iamAuthType = "awsSigv4";
+
+const schemeTypeRefusal =
+  `is not '${apiKeySchemeType}', and a REST API declares every authorizer it ` +
+  `has as an apiKey scheme naming the header the caller presents. An http, ` +
+  `oauth2 or openIdConnect scheme names nothing a REST API method is gated by.`;
+
+const apiKeyRefusal =
+  "is required: an apiKey scheme carrying no x-amazon-apigateway-authtype " +
+  "declares an API key, and API keys and usage plans are not simulated";
+
+const authTypeRefusal =
+  `and a REST API method is decided by a 'custom' Lambda authorizer, a ` +
+  `'cognito_user_pools' one, or '${iamAuthType}' IAM authorization`;
+
+const iamAuthorizerRefusal =
+  `declares an authorizer to invoke or verify a token with, and the scheme ` +
+  `carrying it declares x-amazon-apigateway-authtype '${iamAuthType}', which ` +
+  `is decided by IAM and asks nothing else`;
+
+/**
+ * One `components.securitySchemes` member, read into what the methods naming
+ * it are gated by.
+ *
+ * Which of the three kinds of authorization a scheme declares is decided here,
+ * by `x-amazon-apigateway-authtype`, and reading each kind of authorizer is
+ * the class named after it. A scheme whose authtype and whose authorizer type
+ * disagree is refused rather than resolved either way.
+ */
+export class SimRestApiOpenApiSecurityScheme {
+  private readonly scheme: SimRestApiOpenApiObject;
+
+  constructor(scheme: SimRestApiOpenApiObject) {
+    this.scheme = scheme;
+  }
+
+  /**
+   * The CreateAuthorizer input this scheme asks for, or nothing at all when it
+   * declares a method decided by IAM.
+   */
+  createAuthorizerInput(
+    restApiId: string,
+    name: string,
+  ): SimCreateAuthorizerCommandInput | undefined {
+    const authType = this.authType();
+
+    if (authType === iamAuthType) {
+      this.scheme.refuseMember(
+        "x-amazon-apigateway-authorizer",
+        iamAuthorizerRefusal,
+      );
+
+      return undefined;
+    }
+
+    const authorizer = this.scheme
+      .member("x-amazon-apigateway-authorizer")
+      .object();
+    const type = simRestApiOpenApiAuthorizerType(authorizer, authType);
+
+    if (type === "COGNITO_USER_POOLS") {
+      return new SimRestApiOpenApiCognitoAuthorizerScheme({
+        scheme: this.scheme,
+        authorizer,
+      }).createAuthorizerInput(restApiId, name);
+    }
+
+    return new SimRestApiOpenApiLambdaAuthorizerScheme({
+      scheme: this.scheme,
+      authorizer,
+      type,
+    }).createAuthorizerInput(restApiId, name);
+  }
+
+  /**
+   * The kind of authorization this scheme declares, refusing a scheme a REST
+   * API method cannot be gated by.
+   */
+  private authType(): string {
+    const schemeType = this.scheme.member("type");
+
+    if (schemeType.requiredString() !== apiKeySchemeType) {
+      throw schemeType.refusal(schemeTypeRefusal);
+    }
+
+    const declared = this.scheme.member("x-amazon-apigateway-authtype");
+
+    if (declared.absent()) {
+      throw declared.refusal(apiKeyRefusal);
+    }
+
+    const authType = declared.requiredString();
+
+    if (
+      authType !== iamAuthType &&
+      !simRestApiOpenApiDeclaresAuthorizer(authType)
+    ) {
+      throw declared.refusal(`is '${authType}', ${authTypeRefusal}`);
+    }
+
+    return authType;
+  }
+}

--- a/src/service/apigateway/openapi/sim-rest-api-openapi-security-schemes.ts
+++ b/src/service/apigateway/openapi/sim-rest-api-openapi-security-schemes.ts
@@ -1,0 +1,93 @@
+import type { SimRestApiAuthorizerView } from "../api/authorizer/sim-rest-api-authorizer.js";
+import type { SimCreateAuthorizerCommandInput } from "../command/authorizer/authorizer.command.js";
+import type { SimRestApiOpenApiObject } from "./sim-rest-api-openapi-object.js";
+import type { SimRestApiOpenApiSecurityRequirement } from "./sim-rest-api-openapi-operation.js";
+import type { SimRestApiOpenApiPointer } from "./sim-rest-api-openapi-pointer.js";
+import { SimRestApiOpenApiSecurityScheme } from "./sim-rest-api-openapi-security-scheme.js";
+import type { SimRestApiOpenApiValue } from "./sim-rest-api-openapi-value.js";
+
+/**
+ * What one security scheme comes to.
+ */
+export interface SimRestApiOpenApiSchemeAuthorizer {
+  /**
+   * The authorizer to create, or nothing when the scheme declares a method
+   * decided by IAM, which asks no authorizer anything.
+   */
+  readonly input: SimCreateAuthorizerCommandInput | undefined;
+  /** Where the scheme is, for a refusal CreateAuthorizer makes about it. */
+  readonly pointer: SimRestApiOpenApiPointer;
+}
+
+interface SimRestApiOpenApiSecuritySchemesProperties {
+  readonly schemes: SimRestApiOpenApiValue;
+}
+
+/**
+ * The `components.securitySchemes` an operation's security requirement names.
+ *
+ * One authorizer is created per scheme name, shared by every method naming it,
+ * which is what a REST API has: an authorizer belongs to the API rather than
+ * to a method. A scheme nothing names creates nothing, so it is never read and
+ * never refused.
+ */
+export class SimRestApiOpenApiSecuritySchemes {
+  private readonly schemes: SimRestApiOpenApiValue;
+  private readonly created = new Map<string, SimRestApiAuthorizerView>();
+
+  constructor(properties: SimRestApiOpenApiSecuritySchemesProperties) {
+    this.schemes = properties.schemes;
+  }
+
+  /**
+   * What the scheme a requirement names gates its methods with.
+   */
+  authorizer(
+    restApiId: string,
+    requirement: SimRestApiOpenApiSecurityRequirement,
+  ): SimRestApiOpenApiSchemeAuthorizer {
+    const scheme = this.scheme(requirement);
+
+    return {
+      input: new SimRestApiOpenApiSecurityScheme(scheme).createAuthorizerInput(
+        restApiId,
+        requirement.schemeName,
+      ),
+      pointer: scheme.pointer,
+    };
+  }
+
+  /**
+   * The authorizer already created for a scheme, if one was.
+   */
+  createdAuthorizer(schemeName: string): SimRestApiAuthorizerView | undefined {
+    return this.created.get(schemeName);
+  }
+
+  /**
+   * Remember the authorizer created for a scheme, so the next method naming it
+   * shares that one.
+   */
+  remember(schemeName: string, authorizer: SimRestApiAuthorizerView): void {
+    this.created.set(schemeName, authorizer);
+  }
+
+  /**
+   * The security scheme a requirement names, refusing one the document does
+   * not define.
+   */
+  private scheme(
+    requirement: SimRestApiOpenApiSecurityRequirement,
+  ): SimRestApiOpenApiObject {
+    const schemes = this.schemes.optionalObject();
+
+    if (schemes?.has(requirement.schemeName) !== true) {
+      throw requirement.value.refusal(
+        `names the security scheme '${requirement.schemeName}', which ` +
+          `${this.schemes.pointer.toString()} does not define`,
+      );
+    }
+
+    return schemes.member(requirement.schemeName).object();
+  }
+}

--- a/src/service/apigateway/openapi/sim-rest-api-openapi-security.iso.test.ts
+++ b/src/service/apigateway/openapi/sim-rest-api-openapi-security.iso.test.ts
@@ -1,0 +1,356 @@
+import {
+  GetAuthorizersCommand,
+  GetMethodCommand,
+  GetResourcesCommand,
+  ImportRestApiCommand,
+  PutRestApiCommand,
+} from "@aws-sdk/client-api-gateway";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import type { JSONObject, JSONValue } from "../../../util/type-guard/json.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simRestApiOpenApiDocumentFactory } from "./sim-rest-api-openapi-document.factory.js";
+import { simRestApiOpenApiIntegrationFactory } from "./sim-rest-api-openapi-integration.factory.js";
+
+const integration = simRestApiOpenApiIntegrationFactory.make();
+
+const authorizerUri =
+  "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/" +
+  "arn:aws:lambda:us-east-1:555555555555:function:PetAuthorizer/invocations";
+
+const userPoolArn =
+  "arn:aws:cognito-idp:us-east-1:111111111111:userpool/us-east-1_aBcDeFgHi";
+
+/**
+ * The scheme a document declares a `TOKEN` authorizer with, which reads the
+ * header the scheme itself names.
+ */
+const tokenScheme: JSONObject = {
+  type: "apiKey",
+  name: "Authorization",
+  in: "header",
+  "x-amazon-apigateway-authtype": "custom",
+  "x-amazon-apigateway-authorizer": {
+    type: "token",
+    authorizerUri,
+    authorizerResultTtlInSeconds: 300,
+  },
+};
+
+/**
+ * A document whose one operation is gated by the scheme under test.
+ */
+function gatedDocument(
+  scheme: JSONObject,
+  security: JSONValue = [{ "pet-authorizer": [] }],
+): object {
+  return simRestApiOpenApiDocumentFactory.make({
+    paths: {
+      "/pets": {
+        get: { security, "x-amazon-apigateway-integration": integration },
+      },
+    },
+    components: { securitySchemes: { "pet-authorizer": scheme } },
+  });
+}
+
+/**
+ * Import a document the way an SDK caller does.
+ */
+function importCommand(document: object): ImportRestApiCommand {
+  return new ImportRestApiCommand({
+    body: new TextEncoder().encode(JSON.stringify(document)),
+  });
+}
+
+/**
+ * The method one path of an imported API declares.
+ */
+async function methodOf(
+  simAws: SimAws,
+  restApiId: string,
+  path: string,
+  httpMethod = "GET",
+): Promise<{
+  readonly authorizationType?: string | undefined;
+  readonly authorizerId?: string | undefined;
+  readonly authorizationScopes?: string[] | undefined;
+}> {
+  const resources = await simAws
+    .apiGateway()
+    .getResources(new GetResourcesCommand({ restApiId }));
+  const resource = resources.items.find((one) => one.path === path);
+  assertNonNullable(resource);
+
+  return await simAws
+    .apiGateway()
+    .getMethod(
+      new GetMethodCommand({ restApiId, resourceId: resource.id, httpMethod }),
+    );
+}
+
+describe("Importing a sim REST API's authorizers from its security schemes", () => {
+  it("creates one Lambda authorizer named after the security scheme", async () => {
+    // Given a document whose operation names a token authorizer's scheme
+    const simAws = new SimAws();
+
+    // When it is imported
+    const imported = await simAws
+      .apiGateway()
+      .importRestApi(importCommand(gatedDocument(tokenScheme)));
+
+    // Then the scheme key named the authorizer, its identity source is the
+    // header the scheme itself names, and it holds its decisions for the
+    // period the document asked for
+    const authorizers = await simAws
+      .apiGateway()
+      .getAuthorizers(new GetAuthorizersCommand({ restApiId: imported.id }));
+    expect(authorizers.items).toHaveLength(1);
+    const [authorizer] = authorizers.items;
+    assertNonNullable(authorizer);
+    assertIdentical(authorizer.name, "pet-authorizer");
+    assertIdentical(authorizer.type, "TOKEN");
+    assertIdentical(authorizer.authType, "custom");
+    assertIdentical(authorizer.authorizerUri, authorizerUri);
+    assertIdentical(
+      authorizer.identitySource,
+      "method.request.header.Authorization",
+    );
+    assertIdentical(authorizer.authorizerResultTtlInSeconds, 300);
+
+    // And the method the operation became sends its requests through it
+    const method = await methodOf(simAws, imported.id, "/pets");
+    assertIdentical(method.authorizationType, "CUSTOM");
+    assertIdentical(method.authorizerId, authorizer.id);
+  });
+
+  it("creates a REQUEST authorizer from the expressions it names", async () => {
+    // Given a scheme whose authorizer identifies a caller by two request
+    // parameters of its own
+    const simAws = new SimAws();
+    const scheme: JSONObject = {
+      type: "apiKey",
+      name: "Unused",
+      in: "header",
+      "x-amazon-apigateway-authtype": "custom",
+      "x-amazon-apigateway-authorizer": {
+        type: "request",
+        authorizerUri,
+        identitySource:
+          "method.request.header.Authorization, method.request.querystring.pet",
+      },
+    };
+
+    // When it is imported
+    const imported = await simAws
+      .apiGateway()
+      .importRestApi(importCommand(gatedDocument(scheme)));
+
+    // Then the authorizer reads both, rather than the header the scheme names
+    const authorizers = await simAws
+      .apiGateway()
+      .getAuthorizers(new GetAuthorizersCommand({ restApiId: imported.id }));
+    const [authorizer] = authorizers.items;
+    assertNonNullable(authorizer);
+    assertIdentical(authorizer.type, "REQUEST");
+    assertIdentical(
+      authorizer.identitySource,
+      "method.request.header.Authorization,method.request.querystring.pet",
+    );
+    const method = await methodOf(simAws, imported.id, "/pets");
+    assertIdentical(method.authorizationType, "CUSTOM");
+  });
+
+  it("creates a Cognito authorizer, with the scopes the requirement asks for", async () => {
+    // Given a scheme declaring a user pool authorizer, named by an operation
+    // asking a token for one scope
+    const simAws = new SimAws();
+    const scheme: JSONObject = {
+      type: "apiKey",
+      name: "Authorization",
+      in: "header",
+      "x-amazon-apigateway-authtype": "cognito_user_pools",
+      "x-amazon-apigateway-authorizer": {
+        type: "cognito_user_pools",
+        providerARNs: [userPoolArn],
+      },
+    };
+
+    // When it is imported
+    const imported = await simAws
+      .apiGateway()
+      .importRestApi(
+        importCommand(
+          gatedDocument(scheme, [{ "pet-authorizer": ["pets.read"] }]),
+        ),
+      );
+
+    // Then the authorizer verifies tokens the named pool issued, and invokes
+    // nothing
+    const authorizers = await simAws
+      .apiGateway()
+      .getAuthorizers(new GetAuthorizersCommand({ restApiId: imported.id }));
+    const [authorizer] = authorizers.items;
+    assertNonNullable(authorizer);
+    assertIdentical(authorizer.type, "COGNITO_USER_POOLS");
+    expect(authorizer.providerARNs).toStrictEqual([userPoolArn]);
+    assertUndefined(authorizer.authorizerUri);
+
+    // And the method checks the token for the scope the requirement named
+    const method = await methodOf(simAws, imported.id, "/pets");
+    assertIdentical(method.authorizationType, "COGNITO_USER_POOLS");
+    assertIdentical(method.authorizerId, authorizer.id);
+    expect(method.authorizationScopes).toStrictEqual(["pets.read"]);
+  });
+
+  it("gives a method named by an awsSigv4 scheme IAM authorization", async () => {
+    // Given a scheme declaring IAM authorization, which asks no authorizer
+    // anything
+    const simAws = new SimAws();
+    const scheme: JSONObject = {
+      type: "apiKey",
+      name: "Authorization",
+      in: "header",
+      "x-amazon-apigateway-authtype": "awsSigv4",
+    };
+
+    // When it is imported
+    const imported = await simAws
+      .apiGateway()
+      .importRestApi(importCommand(gatedDocument(scheme)));
+
+    // Then the method is decided by IAM, and the API has no authorizer
+    const method = await methodOf(simAws, imported.id, "/pets");
+    assertIdentical(method.authorizationType, "AWS_IAM");
+    assertUndefined(method.authorizerId);
+    const authorizers = await simAws
+      .apiGateway()
+      .getAuthorizers(new GetAuthorizersCommand({ restApiId: imported.id }));
+    expect(authorizers.items).toStrictEqual([]);
+  });
+
+  it("gives a method carrying x-amazon-apigateway-auth IAM authorization", async () => {
+    // Given an operation declaring IAM authorization on the extension rather
+    // than through a security scheme
+    const simAws = new SimAws();
+    const document = simRestApiOpenApiDocumentFactory.make({
+      paths: {
+        "/pets": {
+          get: {
+            "x-amazon-apigateway-auth": { type: "AWS_IAM" },
+            "x-amazon-apigateway-integration": integration,
+          },
+        },
+      },
+    });
+
+    // When it is imported
+    const imported = await simAws
+      .apiGateway()
+      .importRestApi(importCommand(document));
+
+    // Then the method is decided by IAM, which is the one authorization the
+    // extension declares
+    const method = await methodOf(simAws, imported.id, "/pets");
+    assertIdentical(method.authorizationType, "AWS_IAM");
+  });
+
+  it("shares one authorizer between every operation naming the scheme", async () => {
+    // Given two operations naming the same scheme
+    const simAws = new SimAws();
+    const document = simRestApiOpenApiDocumentFactory.make({
+      paths: {
+        "/pets": {
+          get: {
+            security: [{ "pet-authorizer": [] }],
+            "x-amazon-apigateway-integration": integration,
+          },
+          post: {
+            security: [{ "pet-authorizer": [] }],
+            "x-amazon-apigateway-integration": integration,
+          },
+        },
+      },
+      components: { securitySchemes: { "pet-authorizer": tokenScheme } },
+    });
+
+    // When it is imported
+    const imported = await simAws
+      .apiGateway()
+      .importRestApi(importCommand(document));
+
+    // Then the authorizer was created once, as a REST API authorizer belongs
+    // to the API rather than to a method, and both methods name it
+    const authorizers = await simAws
+      .apiGateway()
+      .getAuthorizers(new GetAuthorizersCommand({ restApiId: imported.id }));
+    expect(authorizers.items).toHaveLength(1);
+    const [authorizer] = authorizers.items;
+    assertNonNullable(authorizer);
+    const get = await methodOf(simAws, imported.id, "/pets");
+    const post = await methodOf(simAws, imported.id, "/pets", "POST");
+    assertIdentical(get.authorizerId, authorizer.id);
+    assertIdentical(post.authorizerId, authorizer.id);
+  });
+
+  it("leaves an operation naming no scheme open", async () => {
+    // Given a document declaring a scheme, and an operation that does not name
+    // it
+    const simAws = new SimAws();
+    const document = simRestApiOpenApiDocumentFactory.make({
+      paths: {
+        "/pets": { get: { "x-amazon-apigateway-integration": integration } },
+      },
+      components: { securitySchemes: { "pet-authorizer": tokenScheme } },
+    });
+
+    // When it is imported
+    const imported = await simAws
+      .apiGateway()
+      .importRestApi(importCommand(document));
+
+    // Then the method is open, and the scheme nothing named created nothing
+    const method = await methodOf(simAws, imported.id, "/pets");
+    assertIdentical(method.authorizationType, "NONE");
+    const authorizers = await simAws
+      .apiGateway()
+      .getAuthorizers(new GetAuthorizersCommand({ restApiId: imported.id }));
+    expect(authorizers.items).toStrictEqual([]);
+  });
+
+  it("replaces the authorizers of the definition a PutRestApi puts over", async () => {
+    // Given an imported API gated by a scheme's authorizer
+    const simAws = new SimAws();
+    const imported = await simAws
+      .apiGateway()
+      .importRestApi(importCommand(gatedDocument(tokenScheme)));
+
+    // When the same document is put over it
+    const replacement = new TextEncoder().encode(
+      JSON.stringify(gatedDocument(tokenScheme)),
+    );
+    await simAws.apiGateway().putRestApi(
+      new PutRestApiCommand({
+        restApiId: imported.id,
+        mode: "overwrite",
+        body: replacement,
+      }),
+    );
+
+    // Then the API is gated by the replacement's one authorizer rather than by
+    // that one and the authorizer the first import left behind
+    const authorizers = await simAws
+      .apiGateway()
+      .getAuthorizers(new GetAuthorizersCommand({ restApiId: imported.id }));
+    expect(authorizers.items).toHaveLength(1);
+    const [authorizer] = authorizers.items;
+    assertNonNullable(authorizer);
+    const method = await methodOf(simAws, imported.id, "/pets");
+    assertIdentical(method.authorizerId, authorizer.id);
+  });
+});

--- a/src/service/apigateway/openapi/sim-rest-api-openapi-serve.iso.test.ts
+++ b/src/service/apigateway/openapi/sim-rest-api-openapi-serve.iso.test.ts
@@ -1,13 +1,17 @@
 import {
   CreateDeploymentCommand,
+  GetAuthorizersCommand,
   ImportRestApiCommand,
 } from "@aws-sdk/client-api-gateway";
+import { AddPermissionCommand } from "@aws-sdk/client-lambda";
 import { assertIdentical, assertNonNullable } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
 import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
 import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
 import type { SimPayload1Event } from "../../../serve/payload-1/sim-payload-1-event.type.js";
+import { simApiGatewayServicePrincipal } from "../sim-api-gateway-service-principal.js";
+import type { SimRestApiTokenAuthorizerEvent } from "../serve/auth/sim-rest-api-authorizer-event.js";
 import { SimAws } from "../../aws/sim-aws.js";
 import {
   simRestApiInvokePermission,
@@ -72,5 +76,122 @@ describe("Serving a request through an imported sim REST API", () => {
 
     assertIdentical(response.status, 200);
     assertIdentical(await response.text(), "pet 42");
+  });
+
+  it("sends a request through the authorizer the document declared", async () => {
+    // Given a function behind the API, a second one deciding who may call it,
+    // and a document declaring the second as a token authorizer's scheme
+    const simAws = new SimAws();
+    const functionArn = await simRestApiProxyFunction(simAws, {
+      functionAccountId,
+      functionName,
+      roleArn: "arn:aws:iam::888888888888:role/PetsRole",
+      handler: (): unknown => ({ statusCode: 200, body: "pets" }),
+    });
+    const authorizerArn = await simRestApiProxyFunction(simAws, {
+      functionAccountId,
+      functionName: "pet-authorizer",
+      roleArn: "arn:aws:iam::888888888888:role/PetsRole",
+      handler: (event: SimRestApiTokenAuthorizerEvent): unknown => ({
+        principalId: "pet-owner",
+        policyDocument: {
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Action: "execute-api:Invoke",
+              Effect:
+                event.authorizationToken === "Bearer session-6"
+                  ? "Allow"
+                  : "Deny",
+              Resource: event.methodArn,
+            },
+          ],
+        },
+      }),
+    });
+    const document = simRestApiOpenApiDocumentFactory.make({
+      paths: {
+        "/pets": {
+          get: {
+            security: [{ "pet-authorizer": [] }],
+            "x-amazon-apigateway-integration":
+              simRestApiOpenApiIntegrationFactory.make({ functionArn }),
+          },
+        },
+      },
+      components: {
+        securitySchemes: {
+          "pet-authorizer": {
+            type: "apiKey",
+            name: "Authorization",
+            in: "header",
+            "x-amazon-apigateway-authtype": "custom",
+            "x-amazon-apigateway-authorizer": {
+              type: "token",
+              authorizerUri: authorizerArn,
+            },
+          },
+        },
+      },
+    });
+
+    // When the document is imported, both functions admit the API and it is
+    // deployed to a stage
+    const body = new TextEncoder().encode(JSON.stringify(document));
+    const imported = await simAws
+      .apiGateway()
+      .importRestApi(new ImportRestApiCommand({ body }));
+    await simRestApiInvokePermission(
+      simAws,
+      { functionAccountId, functionName },
+      imported.id,
+    );
+    const authorizers = await simAws
+      .apiGateway()
+      .getAuthorizers(new GetAuthorizersCommand({ restApiId: imported.id }));
+    const [authorizer] = authorizers.items;
+    assertNonNullable(authorizer);
+    const { accountId, regionName } =
+      simAws.accountRegionScope().accountRegionScope;
+    await simAws
+      .account(functionAccountId)
+      .lambda()
+      .addPermission(
+        new AddPermissionCommand({
+          FunctionName: "pet-authorizer",
+          StatementId: "api-gateway-invoke-authorizer",
+          Action: "lambda:InvokeFunction",
+          Principal: simApiGatewayServicePrincipal,
+          SourceArn:
+            `arn:aws:execute-api:${regionName}:${accountId}:` +
+            `${imported.id}/authorizers/${authorizer.id}`,
+        }),
+      );
+    await simAws.apiGateway().createDeployment(
+      new CreateDeploymentCommand({
+        restApiId: imported.id,
+        stageName: "prod",
+      }),
+    );
+
+    // Then the imported method sends its requests through that authorizer,
+    // which decides them by the token the scheme's own header carried
+    const restApi = simAws.apiGateway().findRestApi(imported.id);
+    assertNonNullable(restApi);
+    const url = new SimAwsLocalUrl({
+      input: `${restApi.invokeUrl("prod")}/pets`,
+    }).toString();
+    const http = new SimAwsHttp({ simAws });
+
+    const refused = await http.fetch(url, {
+      headers: { authorization: "Bearer expired" },
+    });
+    assertIdentical(refused.status, 403);
+
+    const served = await http.fetch(url, {
+      headers: { authorization: "Bearer session-6" },
+    });
+    assertIdentical(served.status, 200);
+    assertIdentical(await served.text(), "pets");
   });
 });

--- a/src/service/apigateway/openapi/sim-rest-api-openapi-value.ts
+++ b/src/service/apigateway/openapi/sim-rest-api-openapi-value.ts
@@ -106,6 +106,22 @@ export class SimRestApiOpenApiValue {
   }
 
   /**
+   * This value as a number when the document carries one, which is the shape
+   * an authorizer's `authorizerResultTtlInSeconds` takes.
+   */
+  optionalNumber(): number | undefined {
+    if (this.value === undefined) {
+      return undefined;
+    }
+
+    if (typeof this.value !== "number") {
+      throw this.refusal("has to be a number");
+    }
+
+    return this.value;
+  }
+
+  /**
    * The entries of this value as an array, when the document carries one.
    */
   optionalArray(): readonly SimRestApiOpenApiValue[] | undefined {
@@ -124,5 +140,12 @@ export class SimRestApiOpenApiValue {
           value: entry,
         }),
     );
+  }
+
+  /**
+   * The entries of this value as strings, when the document carries them.
+   */
+  optionalStringList(): readonly string[] | undefined {
+    return this.optionalArray()?.map((entry) => entry.requiredString());
   }
 }

--- a/src/service/apigateway/sim-api-gateway-commands.ts
+++ b/src/service/apigateway/sim-api-gateway-commands.ts
@@ -102,6 +102,7 @@ export class SimApiGatewayCommands {
       resourceCommands: this.resources,
       methodCommands: this.methods,
       integrationCommands: this.integrations,
+      authorizerCommands: this.authorizers,
     });
   }
 }


### PR DESCRIPTION
A `components.securitySchemes` member carrying `x-amazon-apigateway-authtype` becomes an authorizer,
and `security` on an operation puts it in front of the method that operation becomes. An authtype of
`custom` takes a `token` or `request` authorizer and gives the method `AuthorizationType: CUSTOM`,
`cognito_user_pools` takes `providerARNs` and gives it `COGNITO_USER_POOLS`, and `awsSigv4` gives it
`AWS_IAM`, as does `x-amazon-apigateway-auth` on the operation itself. The scheme key names the
authorizer, one authorizer is created per scheme and shared by every operation naming it, and an
operation carrying no `security` stays open. `ImportRestApi`, `PutRestApi` and a `Body` on an
`AWS::ApiGateway::RestApi` all reach this with the same document, and a `PutRestApi` overwrite now
takes the API's authorizers with the rest of the definition it replaces. A scheme whose authtype and
whose authorizer type disagree is refused naming the JSON pointer of the member, an `apiKey` scheme
carrying no authtype is still refused as an API key, and so are the `http` and `openIdConnect`
scheme types.

Rebased onto #805, which landed while this was open. `authorizerResultTtlInSeconds` inside a
scheme's `x-amazon-apigateway-authorizer` is now read and handed to `CreateAuthorizer` rather than
refused, so the example document in #797 imports as written, and a `cognito_user_pools` scheme
asking for a period gets that command's refusal under the scheme's own pointer.

Resolves #797
