### PR TITLE
feat: sign a returning browser in from a session

### DIFF
--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -1932,12 +1932,85 @@ stylesheet is part of the page. Nothing else is fetched to render one. There is 
 them, and no close match to what real managed login looks like. Real managed login is built on
 Cloudscape and draws components these pages have no equivalent for.
 
+### The browser's managed login session
+
+A sign-in at the hosted domain starts a session for that browser. Real managed login keeps it in a
+cookie named `cognito` on the pool's domain and holds it for an hour, and a served sign-in here sets
+the same cookie. An authorize request carrying it is answered with a code and asks for no
+credentials, which is what signs a returning browser back in without the form.
+
+A test driving the endpoints in process passes the session as a third argument, and reads what
+happened from `redirect.session`.
+
+```typescript sim-cognito-hosted-session
+/**
+ * A browser signing in once with its password, and again from its session.
+ */
+
+import type { SimAws } from "@kensio/yulin";
+
+declare const simAws: SimAws;
+declare const userPoolId: string;
+declare const clientId: string;
+
+const cognito = simAws.cognitoIdentityProvider();
+const pool = cognito.userPool(userPoolId);
+const parameters = {
+  response_type: "code",
+  client_id: clientId,
+  redirect_uri: "https://www.example.com/user/callback",
+  scope: "openid email",
+};
+
+const first = await cognito.hostedAuthorize(pool, {
+  ...parameters,
+  username: "alice",
+  password: "Sup3rSecret!",
+});
+
+console.log(first.session.outcome); // "started"
+
+// The same browser, sent back to authorize carrying no credentials.
+const second = await cognito.hostedAuthorize(
+  pool,
+  parameters,
+  first.session.startedSession,
+);
+
+console.log(second.session.outcome); // "reused"
+console.log(second.username); // "alice"
+```
+
+The `outcome` is `started` where the sign-in took credentials, `reused` where the browser's own
+session answered it, and `ended` at the logout endpoint. Asserting on it is how a test tells a
+sign-in that needed a password from one that did not.
+
+Three parts of the real behaviour are modelled with it.
+
+- Signing in from the session leaves the hour where the interactive sign-in put it. A browser coming
+  back at fifty minutes gets a code, and the same browser at seventy minutes gets the form.
+- The session belongs to the pool's domain. A browser that signed in for one app client is a
+  returning browser to every other app client of the same pool.
+- A sign-in at an identity provider starts one too, so a Google user comes back to a plain authorize
+  request already signed in.
+
+A user disabled since the session started is refused the way every other sign-in refuses one, and a
+user deleted since then leaves the session with nobody to sign in, so the form answers instead.
+Attribute and password changes go by without disturbing it.
+
 ### Signing out
 
-`GET /logout?client_id=...&logout_uri=...` redirects to the sign-out URL, once it has checked it is
-one of the app client's `LogoutURLs`. It ends no session, because there is no managed login cookie
-here. Every authorize request signs in afresh at the identity provider. `GlobalSignOut` and
-`AdminUserGlobalSignOut` are what revoke a user's tokens.
+`GET /logout?client_id=...&logout_uri=...` ends the browser's managed login session and redirects to
+the sign-out URL, once it has checked it is one of the app client's `LogoutURLs`. The served form
+clears the `cognito` cookie. After that the next authorize request asks for a password again.
+
+`GlobalSignOut` and `AdminUserGlobalSignOut` revoke a user's tokens and leave the managed login
+session alone, as they do on real Cognito. An application that clears its own cookies and revokes
+the tokens has not signed the browser out of the hosted domain, and the sign-in link takes it
+straight back in with no password. Sending the browser to `/logout` is what ends it.
+
+Nobody is signed out at the identity provider, which real Cognito also leaves undone. A user signed
+out here is still signed in at Google.
 
 ### PKCE
 
@@ -3887,6 +3960,8 @@ Sim Cognito currently supports:
   with PKCE and with a `refresh_token` grant
 - An authorize request naming no identity provider, signing one of the pool's own users in from a
   `username` and a `password` it carries
+- The managed login session a sign-in starts for the browser, held in the `cognito` cookie for an
+  hour, signing a returning browser in without credentials until `/logout` ends it
 - A served sign-in form at `/oauth2/authorize`, a sign-up form at `/signup`, a confirmation form at
   `/confirm`, and the two password reset forms at `/forgotPassword` and `/confirmForgotPassword`,
   each carrying the authorize parameters through to the next
@@ -4183,9 +4258,9 @@ Current documented limitations:
   at `/login` and confirms a sign-up within `/signup`, where here the authorize endpoint answers
   with the form itself and `/confirm` is a page. `/oauth2/userInfo`, `/oauth2/revoke`,
   `/oauth2/idpresponse` and the SAML endpoints go unserved.
-- The pages hold no session and set no cookie, so each of them carries the authorize parameters in
-  hidden inputs instead. Real managed login keeps a session cookie, which is what signs a returning
-  browser straight back in without the form.
+- The pages carry the authorize parameters in hidden inputs, where real managed login carries them
+  in a `page-data` cookie. The `cognito` session cookie is set and read, and the `XSRF-TOKEN`,
+  `csrf-state`, `lang` and `page-data` cookies real managed login also sets go unset.
 - A hosted sign-in that real managed login would answer with a further page is refused. That is a
   user which has registered a second factor, and a user holding a temporary password. Both
   challenges are simulated at `InitiateAuth` and `AdminInitiateAuth`, which is where a test drives
@@ -4203,9 +4278,13 @@ Current documented limitations:
 - A custom domain answers on its own hostname with no Route53 record of its own, where real AWS
   needs an alias record to the CloudFront distribution Cognito creates. The distribution name a
   domain reports is a name unserved here.
-- `/logout` redirects and ends no session. There is no managed login session cookie here, because
-  every authorize request signs in afresh at the identity provider, leaving it nothing to end. It
-  signs nobody out at the provider either, which real Cognito also leaves undone.
+- `/logout` ends the browser's managed login session and redirects. It signs nobody out at the
+  identity provider, which real Cognito also leaves undone, so a user signed out here is still
+  signed in at Google.
+- A managed login session is reused for any authorize request that names no identity provider and
+  carries no credentials. Real Cognito records which method started the session, and a request
+  naming a provider here signs in at that provider afresh whatever the browser is holding. `prompt`
+  goes unread, so there is no way to ask for a sign-in the session cannot answer.
 - A pool creates no group for each identity provider, where real Cognito creates one named
   `<userPoolId>_<ProviderName>` and puts each federated user in it. A `cognito:groups` claim here
   therefore names only the groups something added the user to.

--- a/docs/services/cognito/sim-cognito-hosted-session.example.ts
+++ b/docs/services/cognito/sim-cognito-hosted-session.example.ts
@@ -1,0 +1,36 @@
+/**
+ * A browser signing in once with its password, and again from its session.
+ */
+
+import type { SimAws } from "@kensio/yulin";
+
+declare const simAws: SimAws;
+declare const userPoolId: string;
+declare const clientId: string;
+
+const cognito = simAws.cognitoIdentityProvider();
+const pool = cognito.userPool(userPoolId);
+const parameters = {
+  response_type: "code",
+  client_id: clientId,
+  redirect_uri: "https://www.example.com/user/callback",
+  scope: "openid email",
+};
+
+const first = await cognito.hostedAuthorize(pool, {
+  ...parameters,
+  username: "alice",
+  password: "Sup3rSecret!",
+});
+
+console.log(first.session.outcome); // "started"
+
+// The same browser, sent back to authorize carrying no credentials.
+const second = await cognito.hostedAuthorize(
+  pool,
+  parameters,
+  first.session.startedSession,
+);
+
+console.log(second.session.outcome); // "reused"
+console.log(second.username); // "alice"

--- a/src/service/cognito/README.md
+++ b/src/service/cognito/README.md
@@ -482,6 +482,14 @@ client and the one challenge it was issued for, and lasts the three minutes real
 It also holds the code an `SMS_MFA` challenge texted, because that code belongs to that challenge:
 it goes when the session goes.
 
+`SimCognitoManagedLoginSession` is the other kind of session, and the two are easy to confuse. An
+auth session is one authentication part way through, and a managed login session is a browser that
+has finished one. It lives in `SimCognitoManagedLoginSessionStore`, is keyed by the value the
+`cognito` cookie carries, belongs to the pool's domain rather than to an app client, and lasts the
+hour real Cognito gives one. `SimCognitoBrowserSession` is what starts and reuses it from the
+authorize endpoint. Signing a user out globally leaves it alone, and `/logout` ends it, which is
+what real Cognito does with each.
+
 `SimCognitoIssuedToken` is a token the pool has handed out, and `SimCognitoIssuedTokenStore` holds
 them. A refresh token is kept because the pool is what exchanges it later, and an access token
 because the pool is what a sign-out presents one to. Signing a user out forgets both kinds, which is
@@ -673,8 +681,9 @@ resource, here or on real AWS.
 - The managed login pages carry an inline stylesheet approximating real managed login, and go no
   closer than that. They are at paths of this simulation's own. The authorize endpoint answers with
   the sign-in form where real managed login redirects to `/login`, and `/confirm` is a
-  page where real managed login confirms within `/signup`. They hold no session and set no cookie,
-  and carry the authorize parameters in hidden inputs instead. A sign-in managed login would answer
+  page where real managed login confirms within `/signup`. They carry the authorize parameters in
+  hidden inputs, where real managed login carries them in a `page-data` cookie. A sign-in managed
+  login would answer
   with a second page, which is a user owing a second factor and a user holding a temporary
   password, is refused. The implicit and client credentials grants are refused too, and
   `/oauth2/userInfo`, `/oauth2/revoke` and the SAML endpoints are not served.
@@ -683,7 +692,11 @@ resource, here or on real AWS.
 - A custom domain answers on its own hostname with no Route53 record, where real AWS needs an alias
   record to the CloudFront distribution Cognito creates. The distribution name a domain reports is a
   name nothing here serves.
-- `/logout` redirects and ends no session, because there is no managed login session cookie here.
+- `/logout` ends the browser's managed login session and redirects. The session is held in the
+  `cognito` cookie, as real managed login holds it, and it is reused only by an authorize request
+  naming no identity provider and carrying no credentials. Real Cognito records which method started
+  the session, and a request naming a provider here signs in at that provider afresh. `prompt` goes
+  unread.
 - A pool creates no group for an identity provider, where real Cognito creates one named
   `<userPoolId>_<ProviderName>` and puts each federated user in it.
 - A federated sign-in whose username is already a user of the pool's own is refused with

--- a/src/service/cognito/command/hosted/hosted-auth.command.ts
+++ b/src/service/cognito/command/hosted/hosted-auth.command.ts
@@ -1,3 +1,5 @@
+import type { SimCognitoSessionChange } from "./sim-cognito-session-change.js";
+
 /**
  * The `/oauth2/authorize` query parameters this simulation reads.
  *
@@ -38,6 +40,16 @@ export interface SimCognitoHostedRedirect {
 
   /** The user the redirect signed in, where one was signed in. */
   readonly username?: string | undefined;
+
+  /**
+   * What the request did to the browser's managed login session.
+   *
+   * A sign-in that took credentials starts one, a sign-in the browser's own
+   * session answered reuses it, and a sign-out ends it. Every request that
+   * reaches a redirect has done one of the three, so reading this is how a
+   * test tells a sign-in that needed a password from one that did not.
+   */
+  readonly session: SimCognitoSessionChange;
 }
 
 /**

--- a/src/service/cognito/command/hosted/sim-cognito-authorize-endpoint.ts
+++ b/src/service/cognito/command/hosted/sim-cognito-authorize-endpoint.ts
@@ -27,9 +27,10 @@ interface SimCognitoAuthorizeEndpointProperties {
  * A request naming a provider signs in the user that provider has been told is
  * signed in at it. A request naming none signs in one of the pool's own users,
  * with the username and password real managed login would have taken from its
- * form. Nothing here draws the form: the serving layer is what answers a
- * browser with a page, and a test calling this directly passes the two fields
- * the form would have posted.
+ * form, or from the managed login session the browser presented. Nothing here
+ * draws the form: the serving layer is what answers a browser with a page, and
+ * a test calling this directly passes the two fields the form would have
+ * posted.
  */
 export class SimCognitoAuthorizeEndpoint {
   private readonly signIn: SimCognitoHostedSignIn;
@@ -45,10 +46,14 @@ export class SimCognitoAuthorizeEndpoint {
   /**
    * Sign a user in, and send the browser back to the application with an
    * authorization code.
+   *
+   * `presentedSession` is the managed login session the browser carried, which
+   * the serving layer reads out of the `cognito` cookie.
    */
   handle(
     pool: SimCognitoUserPool,
     input: SimCognitoAuthorizeInput,
+    presentedSession?: string,
   ): SimCognitoHostedRedirect {
     const client = this.hostedClient.forAuthorize(pool, input.client_id);
     const redirectUri = this.hostedClient.requiredRedirectUri(
@@ -64,7 +69,8 @@ export class SimCognitoAuthorizeEndpoint {
     this.request.requireChallengeMethod(input);
 
     const scopes = new SimCognitoGrantedScopes(client, input.scope);
-    const user = this.signIn.signIn(pool, client, input);
+    const signedIn = this.signIn.signIn(pool, client, input, presentedSession);
+    const { user } = signedIn;
 
     const code = new SimCognitoAuthorizationCode({
       username: user.username,
@@ -80,6 +86,7 @@ export class SimCognitoAuthorizeEndpoint {
     return {
       location: this.redirectWithCode(redirectUri, code.value, input.state),
       username: user.username,
+      session: signedIn.session,
     };
   }
 

--- a/src/service/cognito/command/hosted/sim-cognito-browser-session.iso.test.ts
+++ b/src/service/cognito/command/hosted/sim-cognito-browser-session.iso.test.ts
@@ -1,0 +1,266 @@
+import {
+  AdminDeleteUserCommand,
+  AdminDisableUserCommand,
+  CreateUserPoolClientCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimCognitoNotAuthorizedException } from "../../error/sim-cognito.error.js";
+import { SimCognitoManagedLoginRequired } from "../../error/sim-cognito-managed-login.error.js";
+import {
+  simCognitoCallbackUrl,
+  simCognitoHosted,
+  simCognitoLocalPassword,
+  simCognitoLocalUser,
+  simCognitoLocalUsername,
+  simCognitoSignedInAtGoogle,
+  type SimCognitoHostedSetUp,
+} from "../../../../../test/cognito/federation-fixture.js";
+
+/**
+ * The authorize parameters an application sends the browser on with, holding
+ * no credentials. This is the request real managed login answers from the
+ * `cognito` cookie, and answers with the sign-in form when there is none.
+ */
+function authorizeInput(
+  setUp: SimCognitoHostedSetUp,
+  overrides: Record<string, string> = {},
+): Record<string, string> {
+  return {
+    response_type: "code",
+    client_id: setUp.clientId,
+    redirect_uri: simCognitoCallbackUrl,
+    scope: "openid email",
+    state: "csrf-token",
+    ...overrides,
+  };
+}
+
+/**
+ * The same request with the two fields managed login's form posts.
+ */
+function signInInput(
+  setUp: SimCognitoHostedSetUp,
+  overrides: Record<string, string> = {},
+): Record<string, string> {
+  return authorizeInput(setUp, {
+    username: simCognitoLocalUsername,
+    password: simCognitoLocalPassword,
+    ...overrides,
+  });
+}
+
+describe("Signing in from a sim Cognito managed login session", () => {
+  it("starts a session for the browser when the sign-in takes a password", async () => {
+    // Given a hosted domain over a pool holding a confirmed user of its own.
+    const setUp = await simCognitoHosted();
+    await simCognitoLocalUser(setUp);
+    const pool = setUp.cognito.userPool(setUp.userPoolId);
+
+    // When the user signs in with the password managed login's form takes.
+    const redirect = await setUp.cognito.hostedAuthorize(
+      pool,
+      signInInput(setUp),
+    );
+
+    // Then the browser is given a managed login session to come back with.
+    assertIdentical(redirect.session.outcome, "started");
+    assertNonNullable(redirect.session.startedSession);
+  });
+
+  it("signs a returning browser in without asking for a password", async () => {
+    // Given a browser that signed in with its password a moment ago.
+    const setUp = await simCognitoHosted();
+    await simCognitoLocalUser(setUp);
+    const pool = setUp.cognito.userPool(setUp.userPoolId);
+    const first = await setUp.cognito.hostedAuthorize(pool, signInInput(setUp));
+    const session = first.session.startedSession;
+    assertNonNullable(session);
+
+    // When the application sends it back to authorize carrying no credentials.
+    const second = await setUp.cognito.hostedAuthorize(
+      pool,
+      authorizeInput(setUp),
+      session,
+    );
+
+    // Then the same user is signed in from the session it was already holding.
+    assertIdentical(second.username, simCognitoLocalUsername);
+    assertIdentical(second.session.outcome, "reused");
+    assertNonNullable(new URL(second.location).searchParams.get("code"));
+  });
+
+  it("asks for the form again once no session is presented", async () => {
+    // Given a pool with a user who has never signed in at this browser.
+    const setUp = await simCognitoHosted();
+    await simCognitoLocalUser(setUp);
+    const pool = setUp.cognito.userPool(setUp.userPoolId);
+
+    // When an authorize request arrives with neither credentials nor session.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.hostedAuthorize(pool, authorizeInput(setUp));
+    });
+
+    // Then the sign-in form is what answers, as it did before sessions.
+    assertInstanceOf(error, SimCognitoManagedLoginRequired);
+  });
+
+  it("shows the form again when the password field comes back empty", async () => {
+    // Given a pool with a user, and a form posted with the password left out.
+    const setUp = await simCognitoHosted();
+    await simCognitoLocalUser(setUp);
+    const pool = setUp.cognito.userPool(setUp.userPoolId);
+
+    // When that reaches the authorize endpoint from a browser holding nothing.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.hostedAuthorize(
+        pool,
+        authorizeInput(setUp, { username: simCognitoLocalUsername }),
+      );
+    });
+
+    // Then the form is what answers, as it does for a request naming nobody.
+    assertInstanceOf(error, SimCognitoManagedLoginRequired);
+  });
+
+  it("signs in whoever the form posts, over the session the browser holds", async () => {
+    // Given a browser holding alice's session, and bob signing in on it.
+    const setUp = await simCognitoHosted();
+    await simCognitoLocalUser(setUp);
+    await simCognitoLocalUser(setUp, { username: "bob" });
+    const pool = setUp.cognito.userPool(setUp.userPoolId);
+    const first = await setUp.cognito.hostedAuthorize(pool, signInInput(setUp));
+    const session = first.session.startedSession;
+    assertNonNullable(session);
+
+    // When the form is posted with bob's credentials.
+    const second = await setUp.cognito.hostedAuthorize(
+      pool,
+      signInInput(setUp, { username: "bob" }),
+      session,
+    );
+
+    // Then bob is signed in, and the browser is given his session instead.
+    assertIdentical(second.username, "bob");
+    assertIdentical(second.session.outcome, "started");
+  });
+
+  it("starts a session for a sign-in at an identity provider", async () => {
+    // Given a browser signing in through the pool's Google provider.
+    const setUp = await simCognitoHosted();
+    simCognitoSignedInAtGoogle(setUp, "google-subject-1", {
+      email: "someone@example.com",
+    });
+    const pool = setUp.cognito.userPool(setUp.userPoolId);
+
+    // When it completes the federated sign-in.
+    const redirect = await setUp.cognito.hostedAuthorize(
+      pool,
+      authorizeInput(setUp, { identity_provider: "Google" }),
+    );
+    const session = redirect.session.startedSession;
+    assertNonNullable(session);
+
+    // Then it comes back to a plain authorize request signed in already, the
+    // way real Cognito remembers a provider sign-in in the same cookie.
+    const returning = await setUp.cognito.hostedAuthorize(
+      pool,
+      authorizeInput(setUp),
+      session,
+    );
+
+    assertIdentical(returning.session.outcome, "reused");
+    assertIdentical(returning.username, redirect.username);
+  });
+
+  it("signs the browser in at another app client of the same pool", async () => {
+    // Given a browser that signed in for one of the pool's app clients.
+    const setUp = await simCognitoHosted();
+    await simCognitoLocalUser(setUp);
+    const pool = setUp.cognito.userPool(setUp.userPoolId);
+    const first = await setUp.cognito.hostedAuthorize(pool, signInInput(setUp));
+    const session = first.session.startedSession;
+    assertNonNullable(session);
+
+    // When a second app client of the same pool sends it to authorize.
+    const second = await setUp.cognito.createUserPoolClient(
+      new CreateUserPoolClientCommand({
+        UserPoolId: setUp.userPoolId,
+        ClientName: "admin",
+        AllowedOAuthFlowsUserPoolClient: true,
+        AllowedOAuthFlows: ["code"],
+        AllowedOAuthScopes: ["openid", "email"],
+        CallbackURLs: [simCognitoCallbackUrl],
+        SupportedIdentityProviders: ["COGNITO"],
+      }),
+    );
+    assertNonNullable(second.UserPoolClient?.ClientId);
+
+    const redirect = await setUp.cognito.hostedAuthorize(
+      pool,
+      authorizeInput(setUp, { client_id: second.UserPoolClient.ClientId }),
+      session,
+    );
+
+    // Then the session signs it in there too, because the session belongs to
+    // the pool's domain rather than to one app client.
+    assertIdentical(redirect.session.outcome, "reused");
+    assertIdentical(redirect.username, simCognitoLocalUsername);
+  });
+
+  it("refuses a session whose user has been disabled", async () => {
+    // Given a browser holding a session for a user disabled since it signed in.
+    const setUp = await simCognitoHosted();
+    await simCognitoLocalUser(setUp);
+    const pool = setUp.cognito.userPool(setUp.userPoolId);
+    const first = await setUp.cognito.hostedAuthorize(pool, signInInput(setUp));
+    const session = first.session.startedSession;
+    assertNonNullable(session);
+
+    await setUp.cognito.adminDisableUser(
+      new AdminDisableUserCommand({
+        UserPoolId: setUp.userPoolId,
+        Username: simCognitoLocalUsername,
+      }),
+    );
+
+    // When it comes back to authorize with that session.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.hostedAuthorize(pool, authorizeInput(setUp), session);
+    });
+
+    // Then it is refused the way every other sign-in refuses a disabled user.
+    assertInstanceOf(error, SimCognitoNotAuthorizedException);
+  });
+
+  it("asks for the form when the session's user has been deleted", async () => {
+    // Given a browser holding a session for a user deleted since it signed in.
+    const setUp = await simCognitoHosted();
+    await simCognitoLocalUser(setUp);
+    const pool = setUp.cognito.userPool(setUp.userPoolId);
+    const first = await setUp.cognito.hostedAuthorize(pool, signInInput(setUp));
+    const session = first.session.startedSession;
+    assertNonNullable(session);
+
+    await setUp.cognito.adminDeleteUser(
+      new AdminDeleteUserCommand({
+        UserPoolId: setUp.userPoolId,
+        Username: simCognitoLocalUsername,
+      }),
+    );
+
+    // When it comes back to authorize with that session.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.hostedAuthorize(pool, authorizeInput(setUp), session);
+    });
+
+    // Then the session has nobody to sign in, so the form is what answers.
+    assertInstanceOf(error, SimCognitoManagedLoginRequired);
+  });
+});

--- a/src/service/cognito/command/hosted/sim-cognito-browser-session.ts
+++ b/src/service/cognito/command/hosted/sim-cognito-browser-session.ts
@@ -1,0 +1,73 @@
+import { SimCognitoManagedLoginSession } from "../../user-pool/auth/sim-cognito-managed-login-session.js";
+import { requireSimCognitoEnabled } from "../../user-pool/auth/sim-cognito-sign-in.js";
+import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
+import type { SimCognitoUser } from "../../user-pool/user/sim-cognito-user.js";
+import { SimCognitoHostedSignedIn } from "./sim-cognito-hosted-signed-in.js";
+import { SimCognitoSessionChange } from "./sim-cognito-session-change.js";
+
+/**
+ * The managed login session a browser holds at a pool's hosted domain.
+ *
+ * Real managed login starts one whenever a user signs in at the domain, with
+ * its own credentials or at an identity provider, and answers an authorize
+ * request carrying it with a code and no further questions. That is what makes
+ * a sign-out which clears the application's own cookies and revokes the user's
+ * tokens leave the browser signed in here.
+ */
+export class SimCognitoBrowserSession {
+  /**
+   * Start a session for a browser that has just signed in.
+   */
+  start(
+    pool: SimCognitoUserPool,
+    user: SimCognitoUser,
+    now: Date,
+  ): SimCognitoHostedSignedIn {
+    const session = new SimCognitoManagedLoginSession({
+      username: user.username,
+      startedAt: now,
+    });
+
+    pool.auth.addManagedLoginSession(session);
+
+    return new SimCognitoHostedSignedIn({
+      user,
+      session: SimCognitoSessionChange.started(session.value),
+    });
+  }
+
+  /**
+   * The user the session a browser presented signs in, where it still has one.
+   *
+   * Real Cognito lets attribute and authentication changes go by without
+   * disturbing the session, so nothing is rechecked but the user itself. A
+   * user deleted since the session started leaves it with nobody to sign in,
+   * and a disabled user is refused the way every other sign-in refuses one.
+   */
+  signIn(
+    pool: SimCognitoUserPool,
+    presented: string | undefined,
+    now: Date,
+  ): SimCognitoHostedSignedIn | undefined {
+    const session = pool.auth.findManagedLoginSession(presented, now);
+
+    if (session === undefined) {
+      return undefined;
+    }
+
+    const user = pool.findUser(session.username);
+
+    if (user === undefined) {
+      pool.auth.endManagedLoginSession(session.value);
+
+      return undefined;
+    }
+
+    requireSimCognitoEnabled(user);
+
+    return new SimCognitoHostedSignedIn({
+      user,
+      session: SimCognitoSessionChange.reused(),
+    });
+  }
+}

--- a/src/service/cognito/command/hosted/sim-cognito-hosted-credentials.ts
+++ b/src/service/cognito/command/hosted/sim-cognito-hosted-credentials.ts
@@ -1,0 +1,39 @@
+import type { SimCognitoAuthorizeInput } from "./hosted-auth.command.js";
+
+/**
+ * The username and password managed login's form posts.
+ *
+ * Real managed login reads these two out of its form, and this simulation
+ * reads them out of the authorize request, because a get carrying them and a
+ * post of the form it serves are the same request here. A request carrying
+ * neither has nobody to sign in, and the sign-in it is part of decides what to
+ * do about that.
+ */
+export class SimCognitoHostedCredentials {
+  public readonly username: string;
+  public readonly password: string;
+
+  private constructor(username: string, password: string) {
+    this.username = username;
+    this.password = password;
+  }
+
+  /**
+   * The credentials an authorize request carries, where it carries both.
+   */
+  static in(
+    input: SimCognitoAuthorizeInput,
+  ): SimCognitoHostedCredentials | undefined {
+    const { username, password } = input;
+
+    if (username === undefined || username === "") {
+      return undefined;
+    }
+
+    if (password === undefined || password === "") {
+      return undefined;
+    }
+
+    return new SimCognitoHostedCredentials(username, password);
+  }
+}

--- a/src/service/cognito/command/hosted/sim-cognito-hosted-password-sign-in.ts
+++ b/src/service/cognito/command/hosted/sim-cognito-hosted-password-sign-in.ts
@@ -1,5 +1,4 @@
 import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
-import { SimCognitoManagedLoginRequired } from "../../error/sim-cognito-managed-login.error.js";
 import {
   requireSimCognitoConfirmed,
   requireSimCognitoPasswordSet,
@@ -10,15 +9,7 @@ import type { SimCognitoUserPoolClient } from "../../user-pool/client/sim-cognit
 import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
 import type { SimCognitoUser } from "../../user-pool/user/sim-cognito-user.js";
 import { simCognitoChallengeFactor } from "../auth/sim-cognito-mfa-factor-choice.js";
-import type { SimCognitoAuthorizeInput } from "./hosted-auth.command.js";
-
-/**
- * The credentials a local sign-in at the authorize endpoint carries.
- */
-interface SimCognitoHostedCredentials {
-  readonly username: string;
-  readonly password: string;
-}
+import type { SimCognitoHostedCredentials } from "./sim-cognito-hosted-credentials.js";
 
 /**
  * Signing one of a pool's own users in at the authorize endpoint.
@@ -36,14 +27,14 @@ interface SimCognitoHostedCredentials {
  */
 export class SimCognitoHostedPasswordSignIn {
   /**
-   * The user this request signs in, having checked its password.
+   * The user these credentials sign in, having checked the password.
    */
   signIn(
     pool: SimCognitoUserPool,
     client: SimCognitoUserPoolClient,
-    input: SimCognitoAuthorizeInput,
+    credentials: SimCognitoHostedCredentials,
   ): SimCognitoUser {
-    const { username, password } = this.requiredCredentials(input);
+    const { username, password } = credentials;
     const user = requireSimCognitoSignInUser(pool, client, username);
 
     requireSimCognitoSignIn(user, password);
@@ -53,30 +44,6 @@ export class SimCognitoHostedPasswordSignIn {
     this.requireNoFurtherPage(pool, user);
 
     return user;
-  }
-
-  /**
-   * The username and password the request carried.
-   *
-   * A request carrying neither, and naming no identity provider, is one a
-   * browser is shown the sign-in page for. The serving layer is what answers
-   * with that page, from this refusal.
-   */
-  private requiredCredentials(
-    input: SimCognitoAuthorizeInput,
-  ): SimCognitoHostedCredentials {
-    const { username, password } = input;
-
-    if (
-      username === undefined ||
-      username === "" ||
-      password === undefined ||
-      password === ""
-    ) {
-      throw new SimCognitoManagedLoginRequired();
-    }
-
-    return { username, password };
   }
 
   /**

--- a/src/service/cognito/command/hosted/sim-cognito-hosted-sign-in.ts
+++ b/src/service/cognito/command/hosted/sim-cognito-hosted-sign-in.ts
@@ -1,10 +1,13 @@
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import { SimCognitoManagedLoginRequired } from "../../error/sim-cognito-managed-login.error.js";
 import type { SimCognitoUserPoolClient } from "../../user-pool/client/sim-cognito-user-pool-client.js";
 import type { SimCognitoFederatedSignIn } from "../../user-pool/idp/sim-cognito-federated-sign-in.js";
 import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
-import type { SimCognitoUser } from "../../user-pool/user/sim-cognito-user.js";
 import { SimCognitoAuthorizeRequest } from "./sim-cognito-authorize-request.js";
+import { SimCognitoBrowserSession } from "./sim-cognito-browser-session.js";
+import { SimCognitoHostedCredentials } from "./sim-cognito-hosted-credentials.js";
 import { SimCognitoHostedPasswordSignIn } from "./sim-cognito-hosted-password-sign-in.js";
+import type { SimCognitoHostedSignedIn } from "./sim-cognito-hosted-signed-in.js";
 import type { SimCognitoAuthorizeInput } from "./hosted-auth.command.js";
 
 interface SimCognitoHostedSignInProperties {
@@ -15,17 +18,19 @@ interface SimCognitoHostedSignInProperties {
 /**
  * Which user an authorize request signs in.
  *
- * Real Cognito has two answers here. A request naming an identity provider
- * goes to that provider's own sign-in page, and one naming none goes to
- * managed login's form. The choice is made from the same parameter either way,
- * so it is made in one place, and what comes back is the pool user the
- * authorization code is issued for.
+ * Real Cognito has three answers here. A request naming an identity provider
+ * goes to that provider's own sign-in page. A request carrying credentials is
+ * managed login's form coming back. A request carrying neither is answered by
+ * the browser's own managed login session, and by the form where the browser
+ * holds none. What comes back is the pool user the authorization code is
+ * issued for, and what the browser should hold afterwards.
  */
 export class SimCognitoHostedSignIn {
   private readonly federatedSignIn: SimCognitoFederatedSignIn;
   private readonly clock: SimClock;
   private readonly request = new SimCognitoAuthorizeRequest();
   private readonly passwordSignIn = new SimCognitoHostedPasswordSignIn();
+  private readonly browserSession = new SimCognitoBrowserSession();
 
   constructor(properties: SimCognitoHostedSignInProperties) {
     this.federatedSignIn = properties.federatedSignIn;
@@ -33,23 +38,58 @@ export class SimCognitoHostedSignIn {
   }
 
   /**
-   * The user this request signs in, at a provider or in the pool itself.
+   * The user this request signs in, at a provider, in the pool itself, or from
+   * the managed login session the browser presented.
    */
   signIn(
     pool: SimCognitoUserPool,
     client: SimCognitoUserPoolClient,
     input: SimCognitoAuthorizeInput,
-  ): SimCognitoUser {
+    presentedSession: string | undefined,
+  ): SimCognitoHostedSignedIn {
     const provider = this.request.signInProvider(pool, client, input);
 
     if (provider === undefined) {
-      return this.passwordSignIn.signIn(pool, client, input);
+      return this.localSignIn(pool, client, input, presentedSession);
     }
 
-    return this.federatedSignIn.signIn({
-      pool,
-      provider,
-      now: this.clock.now(),
-    });
+    const now = this.clock.now();
+    const user = this.federatedSignIn.signIn({ pool, provider, now });
+
+    return this.browserSession.start(pool, user, now);
+  }
+
+  /**
+   * Sign in one of the pool's own users, from a password or from the session
+   * the browser is already holding.
+   *
+   * Credentials win over a session, because a request carrying them is the
+   * sign-in form coming back and real managed login answers that with a fresh
+   * sign-in. A request carrying neither, from a browser holding no session, is
+   * one the sign-in form is shown for. The serving layer answers with that
+   * page, from this refusal.
+   */
+  private localSignIn(
+    pool: SimCognitoUserPool,
+    client: SimCognitoUserPoolClient,
+    input: SimCognitoAuthorizeInput,
+    presentedSession: string | undefined,
+  ): SimCognitoHostedSignedIn {
+    const now = this.clock.now();
+    const credentials = SimCognitoHostedCredentials.in(input);
+
+    if (credentials === undefined) {
+      const returning = this.browserSession.signIn(pool, presentedSession, now);
+
+      if (returning === undefined) {
+        throw new SimCognitoManagedLoginRequired();
+      }
+
+      return returning;
+    }
+
+    const user = this.passwordSignIn.signIn(pool, client, credentials);
+
+    return this.browserSession.start(pool, user, now);
   }
 }

--- a/src/service/cognito/command/hosted/sim-cognito-hosted-signed-in.ts
+++ b/src/service/cognito/command/hosted/sim-cognito-hosted-signed-in.ts
@@ -1,0 +1,25 @@
+import type { SimCognitoUser } from "../../user-pool/user/sim-cognito-user.js";
+import type { SimCognitoSessionChange } from "./sim-cognito-session-change.js";
+
+interface SimCognitoHostedSignedInProperties {
+  readonly user: SimCognitoUser;
+  readonly session: SimCognitoSessionChange;
+}
+
+/**
+ * Who an authorize request signed in, and what it did to the browser's managed
+ * login session on the way.
+ *
+ * The two travel together because the endpoint needs both: the user is who the
+ * authorization code is issued for, and the session change is what the
+ * response tells the browser to hold.
+ */
+export class SimCognitoHostedSignedIn {
+  public readonly user: SimCognitoUser;
+  public readonly session: SimCognitoSessionChange;
+
+  constructor(properties: SimCognitoHostedSignedInProperties) {
+    this.user = properties.user;
+    this.session = properties.session;
+  }
+}

--- a/src/service/cognito/command/hosted/sim-cognito-logout-endpoint.ts
+++ b/src/service/cognito/command/hosted/sim-cognito-logout-endpoint.ts
@@ -1,6 +1,7 @@
 import { SimCognitoOAuthError } from "../../error/sim-cognito-oauth.error.js";
 import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
 import { SimCognitoHostedClient } from "./sim-cognito-hosted-client.js";
+import { SimCognitoSessionChange } from "./sim-cognito-session-change.js";
 import type {
   SimCognitoHostedRedirect,
   SimCognitoLogoutInput,
@@ -10,23 +11,31 @@ import type {
  * The `/logout` endpoint of a pool's hosted domain.
  *
  * Real Cognito ends the managed login session in the browser's cookie and
- * sends the user to one of the app client's sign-out URLs. There is no such
- * session here, because every authorize request signs in afresh at the
- * identity provider rather than reusing a cookie, so what is left is the
- * redirect and the check that the URL is one the app client registered.
+ * sends the user to one of the app client's sign-out URLs. Both happen here.
+ * Ending the session is what makes the next authorize request ask for a
+ * password again, and it is why an application's own sign-out has to come
+ * through this endpoint. Clearing its own cookies and revoking the user's
+ * tokens leaves this session where it was.
  *
- * It signs nobody out at the identity provider either, which real Cognito also
- * does not do: a user signed out here is still signed in at Google.
+ * It signs nobody out at the identity provider, which real Cognito also does
+ * not do: a user signed out here is still signed in at Google.
  */
 export class SimCognitoLogoutEndpoint {
   private readonly hostedClient = new SimCognitoHostedClient();
 
   /**
-   * Send the browser to the application's sign-out page.
+   * End the browser's managed login session, and send it to the application's
+   * sign-out page.
+   *
+   * `presentedSession` is the session the browser carried, which the serving
+   * layer reads out of the `cognito` cookie. A request arriving without one is
+   * a sign-out by a browser that holds no session, and it redirects the same
+   * way.
    */
   handle(
     pool: SimCognitoUserPool,
     input: SimCognitoLogoutInput,
+    presentedSession?: string,
   ): SimCognitoHostedRedirect {
     const client = this.hostedClient.forAuthorize(pool, input.client_id);
     const { logout_uri: logoutUri } = input;
@@ -52,6 +61,8 @@ export class SimCognitoLogoutEndpoint {
       });
     }
 
-    return { location: logoutUri };
+    pool.auth.endManagedLoginSession(presentedSession);
+
+    return { location: logoutUri, session: SimCognitoSessionChange.ended() };
   }
 }

--- a/src/service/cognito/command/hosted/sim-cognito-managed-login-session-life.iso.test.ts
+++ b/src/service/cognito/command/hosted/sim-cognito-managed-login-session-life.iso.test.ts
@@ -1,0 +1,196 @@
+import { AdminUserGlobalSignOutCommand } from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimCognitoManagedLoginRequired } from "../../error/sim-cognito-managed-login.error.js";
+import {
+  simCognitoCallbackUrl,
+  simCognitoHosted,
+  simCognitoLocalPassword,
+  simCognitoLocalUser,
+  simCognitoLocalUsername,
+  simCognitoLogoutUrl,
+  type SimCognitoHostedSetUp,
+} from "../../../../../test/cognito/federation-fixture.js";
+
+/**
+ * How long the browser's session lasts, which real Cognito fixes at an hour.
+ */
+const sessionHours = 1;
+
+function authorizeInput(
+  setUp: SimCognitoHostedSetUp,
+  overrides: Record<string, string> = {},
+): Record<string, string> {
+  return {
+    response_type: "code",
+    client_id: setUp.clientId,
+    redirect_uri: simCognitoCallbackUrl,
+    scope: "openid email",
+    ...overrides,
+  };
+}
+
+function signInInput(setUp: SimCognitoHostedSetUp): Record<string, string> {
+  return authorizeInput(setUp, {
+    username: simCognitoLocalUsername,
+    password: simCognitoLocalPassword,
+  });
+}
+
+/**
+ * Sign a browser in with its password and give back the session it was handed.
+ */
+async function signedInSession(setUp: SimCognitoHostedSetUp): Promise<string> {
+  const pool = setUp.cognito.userPool(setUp.userPoolId);
+  const redirect = await setUp.cognito.hostedAuthorize(
+    pool,
+    signInInput(setUp),
+  );
+  const session = redirect.session.startedSession;
+  assertNonNullable(session);
+
+  return session;
+}
+
+describe("How long a sim Cognito managed login session lasts", () => {
+  it("asks for a password again once the hour is up", async () => {
+    // Given a browser that signed in with its password.
+    const setUp = await simCognitoHosted();
+    await simCognitoLocalUser(setUp);
+    const session = await signedInSession(setUp);
+    const pool = setUp.cognito.userPool(setUp.userPoolId);
+
+    // When it comes back more than an hour later.
+    await setUp.simAws.clock().advanceBy({ hours: sessionHours, minutes: 1 });
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.hostedAuthorize(pool, authorizeInput(setUp), session);
+    });
+
+    // Then the session has run out, and the sign-in form is what answers.
+    assertInstanceOf(error, SimCognitoManagedLoginRequired);
+
+    // And signing in again starts a session the browser can come back with,
+    // leaving the one that ran out behind.
+    const again = await signedInSession(setUp);
+
+    const returning = await setUp.cognito.hostedAuthorize(
+      pool,
+      authorizeInput(setUp),
+      again,
+    );
+    assertIdentical(returning.session.outcome, "reused");
+  });
+
+  it("leaves the hour where the interactive sign-in started it", async () => {
+    // Given a browser that signed in, then signed in again from its session
+    // fifty minutes later.
+    const setUp = await simCognitoHosted();
+    await simCognitoLocalUser(setUp);
+    const session = await signedInSession(setUp);
+    const pool = setUp.cognito.userPool(setUp.userPoolId);
+
+    await setUp.simAws.clock().advanceBy({ minutes: 50 });
+
+    const returning = await setUp.cognito.hostedAuthorize(
+      pool,
+      authorizeInput(setUp),
+      session,
+    );
+    assertIdentical(returning.session.outcome, "reused");
+
+    // When it comes back twenty minutes after that, which is over an hour from
+    // the password but only twenty minutes from the last sign-in.
+    await setUp.simAws.clock().advanceBy({ minutes: 20 });
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.hostedAuthorize(pool, authorizeInput(setUp), session);
+    });
+
+    // Then the session has still run out. Signing in from it does not buy the
+    // browser another hour, which is what real Cognito does.
+    assertInstanceOf(error, SimCognitoManagedLoginRequired);
+  });
+
+  it("ends the session at the logout endpoint", async () => {
+    // Given a browser signed in at the hosted domain.
+    const setUp = await simCognitoHosted();
+    await simCognitoLocalUser(setUp);
+    const session = await signedInSession(setUp);
+    const pool = setUp.cognito.userPool(setUp.userPoolId);
+
+    // When it is sent to the logout endpoint holding that session.
+    const signedOut = await setUp.cognito.hostedSignOut(
+      pool,
+      { client_id: setUp.clientId, logout_uri: simCognitoLogoutUrl },
+      session,
+    );
+
+    // Then it goes to the app client's sign-out URL holding nothing, and the
+    // next authorize request asks for a password again.
+    assertIdentical(signedOut.location, simCognitoLogoutUrl);
+    assertIdentical(signedOut.session.outcome, "ended");
+
+    assertInstanceOf(
+      await assertThrowsErrorAsync(async () => {
+        await setUp.cognito.hostedAuthorize(
+          pool,
+          authorizeInput(setUp),
+          session,
+        );
+      }),
+      SimCognitoManagedLoginRequired,
+    );
+  });
+
+  it("signs a browser out that was holding no session", async () => {
+    // Given a browser at the logout endpoint carrying no session cookie, which
+    // is what a second sign-out or a fresh browser sends.
+    const setUp = await simCognitoHosted();
+    const pool = setUp.cognito.userPool(setUp.userPoolId);
+
+    // When it reaches the logout endpoint.
+    const signedOut = await setUp.cognito.hostedSignOut(pool, {
+      client_id: setUp.clientId,
+      logout_uri: simCognitoLogoutUrl,
+    });
+
+    // Then it goes to the sign-out URL the same way.
+    assertIdentical(signedOut.location, simCognitoLogoutUrl);
+    assertIdentical(signedOut.session.outcome, "ended");
+  });
+
+  it("leaves the session alone when the user is signed out globally", async () => {
+    // Given a browser signed in at the hosted domain.
+    const setUp = await simCognitoHosted();
+    await simCognitoLocalUser(setUp);
+    const session = await signedInSession(setUp);
+    const pool = setUp.cognito.userPool(setUp.userPoolId);
+
+    // When the application revokes the user's tokens rather than sending the
+    // browser to the logout endpoint.
+    await setUp.cognito.adminUserGlobalSignOut(
+      new AdminUserGlobalSignOutCommand({
+        UserPoolId: setUp.userPoolId,
+        Username: simCognitoLocalUsername,
+      }),
+    );
+
+    // Then the browser signs straight back in with no password, which is the
+    // real behaviour an application's own sign-out has to reckon with.
+    const redirect = await setUp.cognito.hostedAuthorize(
+      pool,
+      authorizeInput(setUp),
+      session,
+    );
+
+    assertIdentical(redirect.session.outcome, "reused");
+    assertIdentical(redirect.username, simCognitoLocalUsername);
+  });
+});

--- a/src/service/cognito/command/hosted/sim-cognito-session-change.ts
+++ b/src/service/cognito/command/hosted/sim-cognito-session-change.ts
@@ -1,0 +1,60 @@
+/**
+ * What a hosted request did to the browser's managed login session.
+ */
+export type SimCognitoSessionOutcome = "started" | "reused" | "ended";
+
+/**
+ * The change a hosted endpoint makes to the browser's managed login session.
+ *
+ * Real managed login keeps the session in the `cognito` cookie on the pool's
+ * domain, and the serving layer here is what sets and clears that cookie. A
+ * test calling an endpoint directly reads the change from here, which is how
+ * it tells a sign-in that took a password from one the session answered.
+ */
+export class SimCognitoSessionChange {
+  public readonly outcome: SimCognitoSessionOutcome;
+
+  /**
+   * The session the browser is given, where this request started one.
+   */
+  public readonly startedSession: string | undefined;
+
+  private constructor(
+    outcome: SimCognitoSessionOutcome,
+    startedSession: string | undefined,
+  ) {
+    this.outcome = outcome;
+    this.startedSession = startedSession;
+  }
+
+  /**
+   * A sign-in that took credentials and started a session for the browser.
+   */
+  static started(value: string): SimCognitoSessionChange {
+    return new SimCognitoSessionChange("started", value);
+  }
+
+  /**
+   * A sign-in the browser's own session answered, taking no credentials.
+   *
+   * Nothing is handed back, because the browser already holds the session.
+   * Real Cognito leaves the hour where the first sign-in started it.
+   */
+  static reused(): SimCognitoSessionChange {
+    return new SimCognitoSessionChange("reused", undefined);
+  }
+
+  /**
+   * A sign-out, which leaves the browser holding no session.
+   */
+  static ended(): SimCognitoSessionChange {
+    return new SimCognitoSessionChange("ended", undefined);
+  }
+
+  /**
+   * Whether this request took the session out of the browser.
+   */
+  get endsSession(): boolean {
+    return this.outcome === "ended";
+  }
+}

--- a/src/service/cognito/serve/sim-cognito-authorize-route.ts
+++ b/src/service/cognito/serve/sim-cognito-authorize-route.ts
@@ -1,0 +1,64 @@
+import { SimCognitoManagedLogin } from "./page/sim-cognito-managed-login.js";
+import type { SimCognitoPageParameters } from "./page/sim-cognito-page-markup.js";
+import { SimCognitoPageRequest } from "./page/sim-cognito-page-request.js";
+import type { SimCognitoDomainRequest } from "./sim-cognito-domain-request.js";
+import { SimCognitoOAuthResponse } from "./sim-cognito-oauth-response.js";
+import { SimCognitoSessionCookie } from "./sim-cognito-session-cookie.js";
+
+/**
+ * What a served `/oauth2/authorize` request is answered with.
+ *
+ * Three requests reach this one path. An application sends the browser here to
+ * start a sign-in, the sign-in form posts back here to finish one, and a
+ * browser holding a managed login session arrives here and is signed in
+ * without being asked anything. They are one endpoint because real Cognito
+ * serves them as one, and the parameters are read the same way whichever
+ * arrived.
+ */
+export class SimCognitoAuthorizeRoute {
+  private readonly response = new SimCognitoOAuthResponse();
+  private readonly pageRequest = new SimCognitoPageRequest();
+  private readonly pages = new SimCognitoManagedLogin();
+  private readonly sessionCookie = new SimCognitoSessionCookie();
+
+  /**
+   * Sign a user in and send the browser back to the application with a code,
+   * or serve the form that asks who is signing in.
+   */
+  async handle(request: SimCognitoDomainRequest): Promise<Response> {
+    const parameters = this.pageRequest.values(
+      request.serviceRequest,
+      request.url,
+    );
+
+    try {
+      return this.response.redirect(
+        await request.cognito.hostedAuthorize(
+          request.pool,
+          parameters,
+          this.sessionCookie.read(request.serviceRequest.request),
+        ),
+      );
+    } catch (error) {
+      return this.refused(request, parameters, error);
+    }
+  }
+
+  /**
+   * Answer a refused sign-in, on the form or at the application.
+   */
+  private refused(
+    request: SimCognitoDomainRequest,
+    parameters: SimCognitoPageParameters,
+    error: unknown,
+  ): Response {
+    return (
+      this.pages.refusedSignIn(request, parameters, error) ??
+      this.response.refusedRedirect(
+        error,
+        parameters["redirect_uri"],
+        parameters["state"],
+      )
+    );
+  }
+}

--- a/src/service/cognito/serve/sim-cognito-domain-endpoints.ts
+++ b/src/service/cognito/serve/sim-cognito-domain-endpoints.ts
@@ -1,9 +1,9 @@
 import { SimCognitoManagedLogin } from "./page/sim-cognito-managed-login.js";
-import type { SimCognitoPageParameters } from "./page/sim-cognito-page-markup.js";
 import { simCognitoAuthorizePath } from "./page/sim-cognito-page-paths.js";
-import { SimCognitoPageRequest } from "./page/sim-cognito-page-request.js";
+import { SimCognitoAuthorizeRoute } from "./sim-cognito-authorize-route.js";
 import type { SimCognitoDomainRequest } from "./sim-cognito-domain-request.js";
 import { SimCognitoOAuthResponse } from "./sim-cognito-oauth-response.js";
+import { SimCognitoSessionCookie } from "./sim-cognito-session-cookie.js";
 import { SimCognitoTokenRequest } from "./sim-cognito-token-request.js";
 
 /**
@@ -31,8 +31,9 @@ export type { SimCognitoDomainRequest } from "./sim-cognito-domain-request.js";
 export class SimCognitoDomainEndpoints {
   private readonly response = new SimCognitoOAuthResponse();
   private readonly tokenRequest = new SimCognitoTokenRequest();
-  private readonly pageRequest = new SimCognitoPageRequest();
   private readonly pages = new SimCognitoManagedLogin();
+  private readonly sessionCookie = new SimCognitoSessionCookie();
+  private readonly authorizeRoute = new SimCognitoAuthorizeRoute();
 
   /**
    * Answer a request that reached the domain's hostname.
@@ -62,45 +63,12 @@ export class SimCognitoDomainEndpoints {
   }
 
   /**
-   * Sign a user in and send the browser back to the application with a code,
-   * or serve the form that asks who is signing in.
-   *
-   * A get carrying credentials and a post of the sign-in form are the same
-   * request to the simulation. Both name the user and its password, and the
-   * only difference is where those two were read from.
+   * Answer the pool's authorize endpoint, which takes the post of the sign-in
+   * form it serves as well as the get an application sends the browser on.
    */
   private async authorize(request: SimCognitoDomainRequest): Promise<Response> {
-    return await this.answered(request, pageMethods, async () => {
-      const parameters = this.pageRequest.values(
-        request.serviceRequest,
-        request.url,
-      );
-
-      try {
-        return this.response.redirect(
-          await request.cognito.hostedAuthorize(request.pool, parameters),
-        );
-      } catch (error) {
-        return this.refused(request, parameters, error);
-      }
-    });
-  }
-
-  /**
-   * Answer a refused sign-in, on the form or at the application.
-   */
-  private refused(
-    request: SimCognitoDomainRequest,
-    parameters: SimCognitoPageParameters,
-    error: unknown,
-  ): Response {
-    return (
-      this.pages.refusedSignIn(request, parameters, error) ??
-      this.response.refusedRedirect(
-        error,
-        parameters["redirect_uri"],
-        parameters["state"],
-      )
+    return await this.answered(request, pageMethods, async () =>
+      this.authorizeRoute.handle(request),
     );
   }
 
@@ -123,7 +91,8 @@ export class SimCognitoDomainEndpoints {
   }
 
   /**
-   * Send the browser to the application's sign-out page.
+   * End the browser's managed login session and send it to the application's
+   * sign-out page.
    */
   private async logout(request: SimCognitoDomainRequest): Promise<Response> {
     const parameters = Object.fromEntries(request.url.searchParams);
@@ -131,7 +100,11 @@ export class SimCognitoDomainEndpoints {
     return await this.answered(request, "GET", async () => {
       try {
         return this.response.redirect(
-          await request.cognito.hostedSignOut(request.pool, parameters),
+          await request.cognito.hostedSignOut(
+            request.pool,
+            parameters,
+            this.sessionCookie.read(request.serviceRequest.request),
+          ),
         );
       } catch (error) {
         return this.response.refusedRequest(error);

--- a/src/service/cognito/serve/sim-cognito-oauth-response.ts
+++ b/src/service/cognito/serve/sim-cognito-oauth-response.ts
@@ -3,6 +3,7 @@ import {
   SimCognitoOAuthError,
 } from "../error/sim-cognito-oauth.error.js";
 import type { SimCognitoHostedRedirect } from "../command/hosted/hosted-auth.command.js";
+import { SimCognitoSessionCookie } from "./sim-cognito-session-cookie.js";
 
 /**
  * The responses a pool's hosted OAuth endpoints answer with.
@@ -14,6 +15,8 @@ import type { SimCognitoHostedRedirect } from "../command/hosted/hosted-auth.com
  * browser can see.
  */
 export class SimCognitoOAuthResponse {
+  private readonly sessionCookie = new SimCognitoSessionCookie();
+
   /**
    * Read an error as an OAuth one, whatever it turned out to be.
    *
@@ -42,13 +45,18 @@ export class SimCognitoOAuthResponse {
   }
 
   /**
-   * Send the browser on to where an endpoint decided it goes.
+   * Send the browser on to where an endpoint decided it goes, holding the
+   * managed login session the endpoint gave it.
    */
   redirect(redirect: SimCognitoHostedRedirect): Response {
-    return new Response(undefined, {
-      status: 302,
-      headers: { location: redirect.location },
-    });
+    const headers = new Headers({ location: redirect.location });
+    const cookie = this.sessionCookie.headerFor(redirect.session);
+
+    if (cookie !== undefined) {
+      headers.set("set-cookie", cookie);
+    }
+
+    return new Response(undefined, { status: 302, headers });
   }
 
   /**

--- a/src/service/cognito/serve/sim-cognito-session-cookie.iso.test.ts
+++ b/src/service/cognito/serve/sim-cognito-session-cookie.iso.test.ts
@@ -1,0 +1,252 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import {
+  simCognitoCallbackUrl,
+  simCognitoHosted,
+  simCognitoLocalPassword,
+  simCognitoLocalUser,
+  simCognitoLocalUsername,
+  simCognitoLogoutUrl,
+  type SimCognitoHostedSetUp,
+} from "../../../../test/cognito/federation-fixture.js";
+
+describe("The sim Cognito managed login session cookie", () => {
+  /**
+   * A URL on the pool's hosted domain, rewritten to the localhost form the
+   * simulation serves on.
+   */
+  function hostedUrl(
+    setUp: SimCognitoHostedSetUp,
+    path: string,
+    parameters: Record<string, string> = {},
+  ): string {
+    const query = new URLSearchParams(parameters).toString();
+
+    return new SimAwsLocalUrl({
+      input: `https://${setUp.domainHost}${path}?${query}`,
+    }).toString();
+  }
+
+  /**
+   * The value of a cookie in a `Set-Cookie` header.
+   */
+  function cookieValueIn(response: Response, name: string): string {
+    const header = response.headers.get("set-cookie");
+    assertNonNullable(header);
+    assertStringIncludes(header, `${name}=`);
+
+    const [pair = ""] = header.split(";", 1);
+
+    return pair.slice(pair.indexOf("=") + 1);
+  }
+
+  it("hands the browser a cognito cookie when it signs in", async () => {
+    // Given a hosted domain over a pool holding a confirmed user of its own.
+    const setUp = await simCognitoHosted();
+    await simCognitoLocalUser(setUp);
+    const http = new SimAwsHttp({ simAws: setUp.simAws });
+
+    // When the sign-in form is posted to the authorize endpoint.
+    const response = await http.fetch(
+      hostedUrl(setUp, "/oauth2/authorize", {
+        response_type: "code",
+        client_id: setUp.clientId,
+        redirect_uri: simCognitoCallbackUrl,
+        username: simCognitoLocalUsername,
+        password: simCognitoLocalPassword,
+      }),
+    );
+
+    // Then the response carries the session cookie real managed login sets,
+    // scoped to the domain and held for the hour Cognito gives one.
+    assertIdentical(response.status, 302);
+
+    const header = response.headers.get("set-cookie");
+    assertNonNullable(header);
+    assertStringIncludes(header, "cognito=");
+    assertStringIncludes(header, "Path=/");
+    assertStringIncludes(header, "HttpOnly");
+    assertStringIncludes(header, "Max-Age=3600");
+  });
+
+  it("signs a browser carrying the cookie in with no credentials", async () => {
+    // Given a browser that has signed in and kept its cookie.
+    const setUp = await simCognitoHosted();
+    await simCognitoLocalUser(setUp);
+    const http = new SimAwsHttp({ simAws: setUp.simAws });
+
+    const signedIn = await http.fetch(
+      hostedUrl(setUp, "/oauth2/authorize", {
+        response_type: "code",
+        client_id: setUp.clientId,
+        redirect_uri: simCognitoCallbackUrl,
+        username: simCognitoLocalUsername,
+        password: simCognitoLocalPassword,
+      }),
+    );
+    const session = cookieValueIn(signedIn, "cognito");
+
+    // When the application sends it back to authorize with no credentials.
+    const response = await http.fetch(
+      hostedUrl(setUp, "/oauth2/authorize", {
+        response_type: "code",
+        client_id: setUp.clientId,
+        redirect_uri: simCognitoCallbackUrl,
+      }),
+      { headers: { cookie: `cognito=${session}` } },
+    );
+
+    // Then it goes straight back to the callback with a code, rather than
+    // being shown the sign-in form.
+    assertIdentical(response.status, 302);
+
+    const location = response.headers.get("location");
+    assertNonNullable(location);
+    assertNonNullable(new URL(location).searchParams.get("code"));
+  });
+
+  it("clears the cookie at the logout endpoint", async () => {
+    // Given a browser signed in at the hosted domain.
+    const setUp = await simCognitoHosted();
+    await simCognitoLocalUser(setUp);
+    const http = new SimAwsHttp({ simAws: setUp.simAws });
+
+    const signedIn = await http.fetch(
+      hostedUrl(setUp, "/oauth2/authorize", {
+        response_type: "code",
+        client_id: setUp.clientId,
+        redirect_uri: simCognitoCallbackUrl,
+        username: simCognitoLocalUsername,
+        password: simCognitoLocalPassword,
+      }),
+    );
+    const session = cookieValueIn(signedIn, "cognito");
+
+    // When it follows the application's sign-out to the logout endpoint.
+    const signedOut = await http.fetch(
+      hostedUrl(setUp, "/logout", {
+        client_id: setUp.clientId,
+        logout_uri: simCognitoLogoutUrl,
+      }),
+      { headers: { cookie: `cognito=${session}` } },
+    );
+
+    // Then the cookie is taken out of the browser.
+    assertIdentical(signedOut.status, 302);
+
+    const header = signedOut.headers.get("set-cookie");
+    assertNonNullable(header);
+    assertStringIncludes(header, "cognito=;");
+    assertStringIncludes(header, "Max-Age=0");
+
+    // And an authorize request still carrying the old value is answered with
+    // the sign-in form rather than a code.
+    const afterwards = await http.fetch(
+      hostedUrl(setUp, "/oauth2/authorize", {
+        response_type: "code",
+        client_id: setUp.clientId,
+        redirect_uri: simCognitoCallbackUrl,
+      }),
+      { headers: { cookie: `cognito=${session}` } },
+    );
+
+    assertIdentical(afterwards.status, 200);
+    assertStringIncludes(await afterwards.text(), 'name="password"');
+  });
+
+  it("shows the form to a browser whose cookies hold no session", async () => {
+    // Given a browser carrying the other cookies managed login sets and no
+    // session of its own.
+    const setUp = await simCognitoHosted();
+    await simCognitoLocalUser(setUp);
+    const http = new SimAwsHttp({ simAws: setUp.simAws });
+
+    // When it arrives at the authorize endpoint.
+    const response = await http.fetch(
+      hostedUrl(setUp, "/oauth2/authorize", {
+        response_type: "code",
+        client_id: setUp.clientId,
+        redirect_uri: simCognitoCallbackUrl,
+      }),
+      { headers: { cookie: "lang=en; XSRF-TOKEN=a1b2c3" } },
+    );
+
+    // Then it is shown the sign-in form.
+    assertIdentical(response.status, 200);
+    assertStringIncludes(await response.text(), 'name="password"');
+  });
+
+  it("finds the session among cookies that carry no value", async () => {
+    // Given a browser signed in, whose cookie header also holds a bare flag.
+    const setUp = await simCognitoHosted();
+    await simCognitoLocalUser(setUp);
+    const http = new SimAwsHttp({ simAws: setUp.simAws });
+
+    const signedIn = await http.fetch(
+      hostedUrl(setUp, "/oauth2/authorize", {
+        response_type: "code",
+        client_id: setUp.clientId,
+        redirect_uri: simCognitoCallbackUrl,
+        username: simCognitoLocalUsername,
+        password: simCognitoLocalPassword,
+      }),
+    );
+    const session = cookieValueIn(signedIn, "cognito");
+
+    // When it comes back with that flag ahead of the session.
+    const response = await http.fetch(
+      hostedUrl(setUp, "/oauth2/authorize", {
+        response_type: "code",
+        client_id: setUp.clientId,
+        redirect_uri: simCognitoCallbackUrl,
+      }),
+      { headers: { cookie: `flag; cognito=${session}` } },
+    );
+
+    // Then the session is still read, and it signs the browser in.
+    assertIdentical(response.status, 302);
+
+    const location = response.headers.get("location");
+    assertNonNullable(location);
+    assertNonNullable(new URL(location).searchParams.get("code"));
+  });
+
+  it("sets no cookie on a sign-in the browser's own session answered", async () => {
+    // Given a browser that has signed in and kept its cookie.
+    const setUp = await simCognitoHosted();
+    await simCognitoLocalUser(setUp);
+    const http = new SimAwsHttp({ simAws: setUp.simAws });
+
+    const signedIn = await http.fetch(
+      hostedUrl(setUp, "/oauth2/authorize", {
+        response_type: "code",
+        client_id: setUp.clientId,
+        redirect_uri: simCognitoCallbackUrl,
+        username: simCognitoLocalUsername,
+        password: simCognitoLocalPassword,
+      }),
+    );
+    const session = cookieValueIn(signedIn, "cognito");
+
+    // When it signs in again from that session.
+    const response = await http.fetch(
+      hostedUrl(setUp, "/oauth2/authorize", {
+        response_type: "code",
+        client_id: setUp.clientId,
+        redirect_uri: simCognitoCallbackUrl,
+      }),
+      { headers: { cookie: `cognito=${session}` } },
+    );
+
+    // Then nothing is set, because real Cognito leaves the hour where the
+    // interactive sign-in put it.
+    assertIdentical(response.headers.get("set-cookie"), null);
+  });
+});

--- a/src/service/cognito/serve/sim-cognito-session-cookie.ts
+++ b/src/service/cognito/serve/sim-cognito-session-cookie.ts
@@ -1,0 +1,76 @@
+import type { SimCognitoSessionChange } from "../command/hosted/sim-cognito-session-change.js";
+
+/**
+ * The name real managed login gives its session cookie.
+ */
+const cookieName = "cognito";
+
+/**
+ * How long the browser holds the cookie, which is the hour real Cognito gives
+ * a managed login session.
+ */
+const cookieSeconds = 3600;
+
+/**
+ * The attributes every form of the cookie carries.
+ *
+ * Real Cognito sets this cookie `Secure`, and this simulation leaves that off,
+ * because a user pool domain is served over http on localhost and a browser
+ * sends a `Secure` cookie back over https alone.
+ */
+const cookieAttributes = "Path=/; HttpOnly; SameSite=Lax";
+
+/**
+ * The `cognito` cookie a browser carries its managed login session in.
+ *
+ * Reading it is what tells a returning browser from a new one, and setting it
+ * is what makes the browser return. Both sit in the serving layer, because the
+ * endpoints behind it take the session as a value and know nothing about
+ * cookies.
+ */
+export class SimCognitoSessionCookie {
+  /**
+   * The managed login session a request carried, where it carried one.
+   */
+  read(request: Request): string | undefined {
+    const header = request.headers.get("cookie");
+
+    if (header === null) {
+      return undefined;
+    }
+
+    for (const pair of header.split(";")) {
+      const separator = pair.indexOf("=");
+
+      if (separator === -1) {
+        continue;
+      }
+
+      if (pair.slice(0, separator).trim() === cookieName) {
+        return pair.slice(separator + 1).trim();
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
+   * The `Set-Cookie` header a response carries, where the request changed the
+   * browser's session.
+   *
+   * A sign-in the session itself answered sets nothing. Real Cognito leaves
+   * the hour where the sign-in that started it put the hour, so a returning
+   * browser keeps the cookie it already has.
+   */
+  headerFor(change: SimCognitoSessionChange): string | undefined {
+    if (change.startedSession !== undefined) {
+      return `${cookieName}=${change.startedSession}; ${cookieAttributes}; Max-Age=${String(cookieSeconds)}`;
+    }
+
+    if (change.endsSession) {
+      return `${cookieName}=; ${cookieAttributes}; Max-Age=0`;
+    }
+
+    return undefined;
+  }
+}

--- a/src/service/cognito/sim-cognito-federation.ts
+++ b/src/service/cognito/sim-cognito-federation.ts
@@ -131,13 +131,19 @@ export abstract class SimCognitoFederation extends SimCognitoUserDirectory {
    *
    * The answer is where the browser goes next, which for a request that signs
    * a user in is the app client's callback URL carrying an authorization code.
+   *
+   * `presentedSession` is the managed login session the browser holds, which a
+   * served request carries in the `cognito` cookie. Passing one signs the
+   * browser in without credentials, the way real managed login answers a
+   * browser it recognises.
    */
   async hostedAuthorize(
     pool: SimCognitoUserPool,
     input: SimCognitoAuthorizeInput,
+    presentedSession?: string,
   ): Promise<SimCognitoHostedRedirect> {
     await this.background.sequence();
-    return this.commands.hosted.authorize.handle(pool, input);
+    return this.commands.hosted.authorize.handle(pool, input, presentedSession);
   }
 
   /**
@@ -153,12 +159,16 @@ export abstract class SimCognitoFederation extends SimCognitoUserDirectory {
 
   /**
    * Handle a request to a pool's `/logout` endpoint.
+   *
+   * `presentedSession` is the managed login session the browser holds. Ending
+   * it is what makes the next authorize request ask for a password again.
    */
   async hostedSignOut(
     pool: SimCognitoUserPool,
     input: SimCognitoLogoutInput,
+    presentedSession?: string,
   ): Promise<SimCognitoHostedRedirect> {
     await this.background.sequence();
-    return this.commands.hosted.logout.handle(pool, input);
+    return this.commands.hosted.logout.handle(pool, input, presentedSession);
   }
 }

--- a/src/service/cognito/user-pool/auth/sim-cognito-managed-login-session-store.ts
+++ b/src/service/cognito/user-pool/auth/sim-cognito-managed-login-session-store.ts
@@ -1,0 +1,56 @@
+import type { SimCognitoManagedLoginSession } from "./sim-cognito-managed-login-session.js";
+
+/**
+ * The managed login sessions one simulated user pool has going.
+ *
+ * A session belongs to the pool's domain rather than to an app client, as a
+ * real one does: a browser that signed in for one app client is a returning
+ * browser to every other app client of the same pool.
+ */
+export class SimCognitoManagedLoginSessionStore {
+  private readonly sessions = new Map<string, SimCognitoManagedLoginSession>();
+
+  /**
+   * Remember a session a sign-in started for a browser.
+   */
+  add(session: SimCognitoManagedLoginSession): void {
+    this.sessions.set(session.value, session);
+  }
+
+  /**
+   * The session a browser presented, if this pool still holds it.
+   */
+  find(
+    value: string | undefined,
+    now: Date,
+  ): SimCognitoManagedLoginSession | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    const session = this.sessions.get(value);
+
+    if (session === undefined) {
+      return undefined;
+    }
+
+    if (session.isExpiredAt(now)) {
+      this.sessions.delete(value);
+
+      return undefined;
+    }
+
+    return session;
+  }
+
+  /**
+   * Forget a session, because the browser holding it has signed out.
+   */
+  end(value: string | undefined): void {
+    if (value === undefined) {
+      return;
+    }
+
+    this.sessions.delete(value);
+  }
+}

--- a/src/service/cognito/user-pool/auth/sim-cognito-managed-login-session.ts
+++ b/src/service/cognito/user-pool/auth/sim-cognito-managed-login-session.ts
@@ -1,0 +1,47 @@
+import { randomUUID } from "node:crypto";
+
+/**
+ * How long a managed login session lasts.
+ *
+ * Real Cognito gives the browser an hour, and nothing configures that. Signing
+ * in from the session leaves the hour where it started, so a browser signing
+ * in from the same cookie all morning is asked for credentials again at the
+ * end of the first hour.
+ */
+const sessionMinutes = 60;
+
+interface SimCognitoManagedLoginSessionProperties {
+  readonly username: string;
+  readonly startedAt: Date;
+}
+
+/**
+ * One managed login session, which is what signs a returning browser in
+ * without asking for a password again.
+ *
+ * Real managed login keeps this in the `cognito` cookie on the pool's domain.
+ * The value is opaque, and the user it signed in is all it carries, because a
+ * sign-in from the session issues a code the same way the first sign-in did.
+ */
+export class SimCognitoManagedLoginSession {
+  public readonly value: string;
+  public readonly username: string;
+  public readonly startedAt: Date;
+
+  constructor(properties: SimCognitoManagedLoginSessionProperties) {
+    this.value = randomUUID();
+    this.username = properties.username;
+    this.startedAt = properties.startedAt;
+  }
+
+  /**
+   * Whether this session has run out by a given moment.
+   */
+  isExpiredAt(now: Date): boolean {
+    const expiresAt = new Date(
+      this.startedAt.getTime() + sessionMinutes * 60_000,
+    );
+
+    return now.getTime() >= expiresAt.getTime();
+  }
+}

--- a/src/service/cognito/user-pool/auth/sim-cognito-pool-auth.ts
+++ b/src/service/cognito/user-pool/auth/sim-cognito-pool-auth.ts
@@ -8,6 +8,8 @@ import {
 import type { SimCognitoAuthorizationCode } from "./sim-cognito-authorization-code.js";
 import { SimCognitoAuthorizationCodeStore } from "./sim-cognito-authorization-code-store.js";
 import type { SimCognitoIssuedToken } from "./sim-cognito-issued-token.js";
+import type { SimCognitoManagedLoginSession } from "./sim-cognito-managed-login-session.js";
+import { SimCognitoManagedLoginSessionStore } from "./sim-cognito-managed-login-session-store.js";
 import {
   SimCognitoIssuedTokenStore,
   type SimCognitoRefreshTokenRequest,
@@ -34,6 +36,7 @@ export class SimCognitoPoolAuth {
   public readonly identityProviders = new SimCognitoIdentityProviderStore();
 
   private readonly sessions = new SimCognitoAuthSessionStore();
+  private readonly managedLogin = new SimCognitoManagedLoginSessionStore();
   private readonly codes = new SimCognitoAuthorizationCodeStore();
   private readonly tokens = new SimCognitoIssuedTokenStore();
 
@@ -142,7 +145,37 @@ export class SimCognitoPoolAuth {
   }
 
   /**
+   * Remember the managed login session a hosted sign-in started for a browser.
+   */
+  addManagedLoginSession(session: SimCognitoManagedLoginSession): void {
+    this.managedLogin.add(session);
+  }
+
+  /**
+   * The managed login session a browser presented, if this pool still holds
+   * it and it has not run out.
+   */
+  findManagedLoginSession(
+    value: string | undefined,
+    now: Date,
+  ): SimCognitoManagedLoginSession | undefined {
+    return this.managedLogin.find(value, now);
+  }
+
+  /**
+   * End the managed login session a browser presented at `/logout`.
+   */
+  endManagedLoginSession(value: string | undefined): void {
+    this.managedLogin.end(value);
+  }
+
+  /**
    * Sign a user out of every app client, forgetting the tokens it holds.
+   *
+   * The managed login sessions are left alone, because real `GlobalSignOut`
+   * and `AdminUserGlobalSignOut` leave them alone. They revoke tokens, and a
+   * browser still holding the `cognito` cookie signs in again at the authorize
+   * endpoint without a password. `/logout` is what ends that.
    */
   signOut(username: string): void {
     this.tokens.forgetUser(username);


### PR DESCRIPTION
A sign-in at a pool's hosted domain now starts a managed login session for the browser. Real managed login holds it in a cookie named `cognito` for an hour, and an authorize request carrying it is answered with a code and asks for no credentials. `/logout` ends it.

Resolves https://github.com/KensioSoftware/yulin/issues/804

## Why it matters

Simulated Cognito had no such session. A sign-out that cleared an application's own cookies and revoked the user's tokens looked complete here, and left the browser signed in on the account. That is a false pass, and #804 records the production defect it let through. The behaviour is now under test both ways round. `AdminUserGlobalSignOut` leaves the session alone, as it does on real Cognito, and `/logout` is what ends it.

## What a sign-in does now

Four answers, in order. A request naming an identity provider signs in there. A request carrying credentials is the sign-in form coming back. A request carrying neither is answered by the browser's own session. A browser holding none is shown the form.

Putting credentials ahead of the session leaves every existing test passing unchanged, and keeps a get carrying `username` and `password` meaning what it already meant.

`SimCognitoHostedRedirect.session` reports which of the three happened, as `started`, `reused` or `ended`. A test asserting `started` is asserting that the sign-in needed a password, which is the assertion #804 says the suite had no way to write.

## Grounded in the AWS reference

The cookie name, the hour, and the rule that signing in from the session buys no further hour all come from [the managed login page](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-managed-login.html). A sign-in at an identity provider starts a session too, which the same page documents.

## Two divergences worth flagging

The cookie is set without `Secure`, where real Cognito sets it. A user pool domain is served over http on localhost, and a browser sends a `Secure` cookie back over https alone. The code comment and the docs both say so.

A session is reused only by a request naming no identity provider and carrying no credentials. Real Cognito records which method started the session, and `prompt` goes unread here. Both are in the limitations.

## Also in here

`sim-cognito-domain-endpoints.ts` crossed the FTA threshold at 50.08 once it started reading the cookie, so the authorize handling moved to `SimCognitoAuthorizeRoute`.

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`
