### PR TITLE
feat: evaluate rules on simulated WAFv2 web ACLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ npm i -D @kensio/yulin
 - [SQS](./docs/services/sqs "Simulated SQS docs")
 - [SSM Parameter Store](./docs/services/ssm "Simulated SSM Parameter Store docs")
 - [STS](./docs/services/sts "Simulated STS docs")
+- [WAFv2](./docs/services/wafv2 "Simulated WAFv2 docs")
 
 ## Feature specific docs
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@ behaviour and includes example code that can be copied into tests or local devel
 - [SQS](./services/sqs/ "Simulated SQS usage docs")
 - [SSM Parameter Store](./services/ssm/ "Simulated SSM Parameter Store usage docs")
 - [STS](./services/sts/ "Simulated STS usage docs")
+- [WAFv2](./services/wafv2/ "Simulated WAFv2 usage docs")
 
 ## Feature documentation
 

--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -244,7 +244,7 @@ descriptors is in [the sim DynamoDB docs](../services/dynamodb/README.md#the-doc
 These simulated services support SDK interception: ACM, API Gateway v2, CloudFormation, CloudFront,
 CloudWatch, CloudWatch Logs, Cognito, DynamoDB, DynamoDB Streams, ECS, Elastic Load Balancing v2,
 EventBridge, EventBridge Scheduler, IAM, KMS, Lambda, Rekognition, Route53, S3, Secrets Manager,
-SES, SNS, SQS, SSM and STS. Each service's own docs under
+SES, SNS, SQS, SSM, STS and WAFv2. Each service's own docs under
 [docs/services](../services/) list the Commands it simulates.
 
 A gap in that coverage is refused on send, with a different error for each kind:

--- a/docs/services/wafv2/README.md
+++ b/docs/services/wafv2/README.md
@@ -1,0 +1,539 @@
+# Simulated WAFv2
+
+Yulin includes a simulated AWS WAFv2 for tests and local development. It holds web ACLs, IP sets and
+regex pattern sets, and it evaluates a request against a web ACL's rules to reach a decision. A test
+can assert that a request to `/admin` is blocked and one to `/` is allowed, without an AWS account
+and without a distribution in front of anything.
+
+Association comes separately. Putting a web ACL in front of a CloudFront distribution, an API
+Gateway REST API stage or a Cognito user pool arrives later. Until then a test asks the web ACL
+about a request itself.
+
+WAFv2 specific types are imported from the `@kensio/yulin/wafv2` subpath.
+
+## Deciding what happens to a request
+
+`evaluateRequest` puts one request through a web ACL. It takes the web ACL's ARN and an ordinary
+`Request`, and answers with the decision.
+
+```typescript sim-wafv2-evaluate
+/**
+ * Blocking requests to an admin path with a simulated web ACL.
+ */
+
+import { CreateWebACLCommand } from "@aws-sdk/client-wafv2";
+
+import { SimAws } from "@kensio/yulin";
+
+const waf = new SimAws().wafV2();
+
+const created = await waf.createWebAcl(
+  new CreateWebACLCommand({
+    Name: "api-acl",
+    Scope: "REGIONAL",
+    DefaultAction: { Allow: {} },
+    VisibilityConfig: {
+      SampledRequestsEnabled: false,
+      CloudWatchMetricsEnabled: false,
+      MetricName: "api",
+    },
+    Rules: [
+      {
+        Name: "block-admin",
+        Priority: 0,
+        Action: { Block: {} },
+        Statement: {
+          ByteMatchStatement: {
+            FieldToMatch: { UriPath: {} },
+            PositionalConstraint: "STARTS_WITH",
+            SearchString: Buffer.from("/admin"),
+            TextTransformations: [{ Priority: 0, Type: "LOWERCASE" }],
+          },
+        },
+        VisibilityConfig: {
+          SampledRequestsEnabled: false,
+          CloudWatchMetricsEnabled: false,
+          MetricName: "block-admin",
+        },
+      },
+    ],
+  }),
+);
+
+const webAclArn = created.Summary!.ARN;
+
+const blocked = waf.evaluateRequest({
+  webAclArn,
+  request: new Request("https://example.test/admin/users"),
+});
+const allowed = waf.evaluateRequest({
+  webAclArn,
+  request: new Request("https://example.test/"),
+});
+
+// "BLOCK" "block-admin" 403
+console.log(
+  blocked.action,
+  blocked.terminatingRuleName,
+  blocked.blocked?.statusCode,
+);
+
+// "ALLOW" undefined
+console.log(allowed.action, allowed.terminatingRuleName);
+```
+
+The decision names the rule that reached it. A request no rule claims gets the web ACL's
+`DefaultAction`, and `terminatingRuleName` is then absent.
+
+`simWafBlockedHttpResponse` turns a blocked decision into the `Response` a client would receive,
+carrying the status, the body and any headers the rule named.
+
+## Rules run in priority order
+
+Rules are evaluated in ascending `Priority` and not in the order the list was written. The first
+rule that matches and carries a terminating action (`Allow` or `Block`) decides the request.
+
+A `Count` action records the match and lets the next rule have a look. That is how a rule is staged
+before it is turned on, and `countedRuleNames` is what a test asserts against.
+
+```typescript sim-wafv2-count
+/**
+ * Staging a rule in count mode before turning it on.
+ */
+
+import { CreateWebACLCommand } from "@aws-sdk/client-wafv2";
+
+import { SimAws } from "@kensio/yulin";
+
+const waf = new SimAws().wafV2();
+
+const visibility = {
+  SampledRequestsEnabled: false,
+  CloudWatchMetricsEnabled: false,
+  MetricName: "api",
+};
+
+const created = await waf.createWebAcl(
+  new CreateWebACLCommand({
+    Name: "api-acl",
+    Scope: "REGIONAL",
+    DefaultAction: { Allow: {} },
+    VisibilityConfig: visibility,
+    Rules: [
+      {
+        Name: "watch-uploads",
+        Priority: 0,
+        Action: { Count: {} },
+        Statement: {
+          SizeConstraintStatement: {
+            FieldToMatch: { Body: { OversizeHandling: "CONTINUE" } },
+            ComparisonOperator: "GT",
+            Size: 1024,
+            TextTransformations: [{ Priority: 0, Type: "NONE" }],
+          },
+        },
+        VisibilityConfig: visibility,
+      },
+    ],
+  }),
+);
+
+const decision = waf.evaluateRequest({
+  webAclArn: created.Summary!.ARN,
+  request: new Request("https://example.test/upload", { method: "POST" }),
+  body: new TextEncoder().encode("x".repeat(2048)),
+});
+
+// "ALLOW" [ 'watch-uploads' ]
+console.log(decision.action, decision.countedRuleNames);
+```
+
+The body is passed in already read. A request body is a stream that cannot be consumed twice, and
+whatever serves the request has usually read it by the time WAF gets a look.
+
+## What a statement can inspect
+
+A statement reads one part of the request, applies the rule's text transformations to it, and tests
+what comes out.
+
+The parts a statement can be pointed at are `UriPath`, `QueryString`, `SingleQueryArgument`,
+`AllQueryArguments`, `SingleHeader`, `Headers`, `Cookies`, `Method` and `Body`. `Headers` and
+`Cookies` take a `MatchPattern` selecting which of them to read and a `MatchScope` of `KEY`, `VALUE`
+or `ALL`.
+
+The transformations are `NONE`, `LOWERCASE`, `URL_DECODE`, `COMPRESS_WHITE_SPACE` and
+`HTML_ENTITY_DECODE`. They run in ascending `Priority`, so lowercasing after decoding is a different
+rule from decoding after lowercasing.
+
+The tests are `ByteMatchStatement` (with `EXACTLY`, `STARTS_WITH`, `ENDS_WITH`, `CONTAINS` and
+`CONTAINS_WORD`), `RegexMatchStatement`, `RegexPatternSetReferenceStatement` and
+`SizeConstraintStatement`. `AndStatement`, `OrStatement` and `NotStatement` join and negate them,
+and they nest.
+
+Matching is case sensitive, as it is on AWS. A rule that means to ignore case says so with a
+`LOWERCASE` transformation and a lower case search string.
+
+WAF stops reading a body, a header set or a cookie set at 8 KB. The rule's `OversizeHandling` says
+what content past that point counts as. `MATCH` and `NO_MATCH` settle the statement without looking,
+and `CONTINUE` inspects as much as WAF would have read.
+
+## Answering a blocked request
+
+A `Block` action answers 403 with WAF's own body. A `CustomResponse` overrides the status and the
+body, taking the body from the web ACL's `CustomResponseBodies` by key. Headers a rule names are
+prefixed with `x-amzn-waf-`, as WAF prefixes them.
+
+```typescript sim-wafv2-custom-response
+/**
+ * Answering a blocked request with a body the web ACL holds.
+ */
+
+import { CreateWebACLCommand } from "@aws-sdk/client-wafv2";
+
+import { SimAws } from "@kensio/yulin";
+import { simWafBlockedHttpResponse } from "@kensio/yulin/wafv2";
+
+const waf = new SimAws().wafV2();
+
+const visibility = {
+  SampledRequestsEnabled: false,
+  CloudWatchMetricsEnabled: false,
+  MetricName: "api",
+};
+
+const created = await waf.createWebAcl(
+  new CreateWebACLCommand({
+    Name: "api-acl",
+    Scope: "REGIONAL",
+    DefaultAction: { Allow: {} },
+    VisibilityConfig: visibility,
+    CustomResponseBodies: {
+      "not-here": {
+        ContentType: "APPLICATION_JSON",
+        Content: '{"message":"Not found"}',
+      },
+    },
+    Rules: [
+      {
+        Name: "hide-admin",
+        Priority: 0,
+        Action: {
+          Block: {
+            CustomResponse: {
+              ResponseCode: 404,
+              CustomResponseBodyKey: "not-here",
+              ResponseHeaders: [{ Name: "rule", Value: "hide-admin" }],
+            },
+          },
+        },
+        Statement: {
+          ByteMatchStatement: {
+            FieldToMatch: { UriPath: {} },
+            PositionalConstraint: "STARTS_WITH",
+            SearchString: Buffer.from("/admin"),
+            TextTransformations: [{ Priority: 0, Type: "NONE" }],
+          },
+        },
+        VisibilityConfig: visibility,
+      },
+    ],
+  }),
+);
+
+const decision = waf.evaluateRequest({
+  webAclArn: created.Summary!.ARN,
+  request: new Request("https://example.test/admin"),
+});
+const response = simWafBlockedHttpResponse(decision.blocked!);
+
+// 404 "hide-admin" '{"message":"Not found"}'
+console.log(
+  response.status,
+  response.headers.get("x-amzn-waf-rule"),
+  await response.text(),
+);
+```
+
+The default body is Yulin's own. Real WAF hands the blocking off to whatever the web ACL is in front
+of, and each of those writes its own page. The status is 403 either way.
+
+## Regex pattern sets
+
+A rule can point at a regex pattern set by ARN, and matches when any expression in the set matches.
+The set is resolved when the rule is written. An ARN naming nothing is refused by `CreateWebACL`
+the way real WAF refuses it.
+
+```typescript sim-wafv2-regex-pattern-set
+/**
+ * Blocking a set of user agents held in a regex pattern set.
+ */
+
+import {
+  CreateRegexPatternSetCommand,
+  CreateWebACLCommand,
+} from "@aws-sdk/client-wafv2";
+
+import { SimAws } from "@kensio/yulin";
+
+const waf = new SimAws().wafV2();
+
+const patternSet = await waf.createRegexPatternSet(
+  new CreateRegexPatternSetCommand({
+    Name: "scanners",
+    Scope: "REGIONAL",
+    RegularExpressionList: [
+      { RegexString: "sqlmap" },
+      { RegexString: "nikto" },
+    ],
+  }),
+);
+
+const visibility = {
+  SampledRequestsEnabled: false,
+  CloudWatchMetricsEnabled: false,
+  MetricName: "api",
+};
+
+const created = await waf.createWebAcl(
+  new CreateWebACLCommand({
+    Name: "api-acl",
+    Scope: "REGIONAL",
+    DefaultAction: { Allow: {} },
+    VisibilityConfig: visibility,
+    Rules: [
+      {
+        Name: "block-scanners",
+        Priority: 0,
+        Action: { Block: {} },
+        Statement: {
+          RegexPatternSetReferenceStatement: {
+            ARN: patternSet.Summary!.ARN,
+            FieldToMatch: { SingleHeader: { Name: "user-agent" } },
+            TextTransformations: [{ Priority: 0, Type: "LOWERCASE" }],
+          },
+        },
+        VisibilityConfig: visibility,
+      },
+    ],
+  }),
+);
+
+const decision = waf.evaluateRequest({
+  webAclArn: created.Summary!.ARN,
+  request: new Request("https://example.test/", {
+    headers: { "user-agent": "sqlmap/1.7" },
+  }),
+});
+
+// "BLOCK"
+console.log(decision.action);
+```
+
+IP sets are created, read, listed and deleted the same way. No rule reads one, for the reason in
+[Refusals](#refusals) below.
+
+## Scopes
+
+A web ACL is created in `CLOUDFRONT` or `REGIONAL` scope. The two are separate namespaces, and one
+name can be taken in both.
+
+`CLOUDFRONT` scope resources live in `us-east-1`, because CloudFront is global. A `CLOUDFRONT`
+request made anywhere else is refused, as real WAFv2 refuses it.
+
+```typescript sim-wafv2-cloudfront-scope
+/**
+ * Creating a web ACL for a CloudFront distribution.
+ */
+
+import { CreateWebACLCommand } from "@aws-sdk/client-wafv2";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const waf = simAws
+  .accountRegionScope(simAws.defaultAccountId, "us-east-1")
+  .wafV2();
+
+const created = await waf.createWebAcl(
+  new CreateWebACLCommand({
+    Name: "site-acl",
+    Scope: "CLOUDFRONT",
+    DefaultAction: { Allow: {} },
+    VisibilityConfig: {
+      SampledRequestsEnabled: false,
+      CloudWatchMetricsEnabled: false,
+      MetricName: "site",
+    },
+  }),
+);
+
+// arn:aws:wafv2:us-east-1:...:global/webacl/site-acl/...
+console.log(created.Summary?.ARN);
+```
+
+## Lock tokens
+
+Every WAFv2 resource carries a lock token that changes on each write. `UpdateWebACL` and the deletes
+take the token from the last read, and a write made against a stale one is refused with
+`WAFOptimisticLockException`.
+
+`CreateWebACL` reports the first token in its summary, and `GetWebACL` reports the current one.
+`UpdateWebACL` answers with `NextLockToken` for the write after it.
+
+## Permissions
+
+Every command goes through simulated IAM. An operation on one resource authorizes against that
+resource's ARN. The id in the ARN is generated. A policy that names a resource therefore ends in a
+wildcard where the id goes.
+
+`ListWebACLs`, `ListIPSets` and `ListRegexPatternSets` have no resource type on real WAFv2. They
+authorize against `*`, and a policy scoped to web ACL ARNs allows none of them, however broadly
+those ARNs are written.
+
+```typescript sim-wafv2-permissions
+/**
+ * Reading a web ACL as a Role, with a policy naming it.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateWebACLCommand, GetWebACLCommand } from "@aws-sdk/client-wafv2";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultAccountId: "111111111111" });
+const roleArn = "arn:aws:iam::111111111111:role/FirewallReaderRole";
+
+await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "FirewallReaderRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { Service: "lambda.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      ],
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "FirewallReaderRole",
+    PolicyName: "ReadApiAcl",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Action: "wafv2:GetWebACL",
+          Resource:
+            "arn:aws:wafv2:us-east-1:111111111111:regional/webacl/api-acl/*",
+        },
+      ],
+    }),
+  }),
+);
+
+const waf = simAws.wafV2();
+const created = await waf.createWebAcl(
+  new CreateWebACLCommand({
+    Name: "api-acl",
+    Scope: "REGIONAL",
+    DefaultAction: { Allow: {} },
+    VisibilityConfig: {
+      SampledRequestsEnabled: false,
+      CloudWatchMetricsEnabled: false,
+      MetricName: "api",
+    },
+  }),
+);
+
+const read = await waf.getWebAcl(
+  new GetWebACLCommand({
+    Name: "api-acl",
+    Scope: "REGIONAL",
+    Id: created.Summary?.Id,
+  }),
+  { caller: { kind: "arn", arn: roleArn } },
+);
+
+// "api-acl"
+console.log(read.WebACL?.Name);
+```
+
+## SDK interception
+
+An intercepted `WAFV2Client` routes to the simulated WAFv2 in the Account and Region the client was
+configured for. See [the SDK docs](../../sdk/README.md) for how interception works.
+
+```typescript sim-wafv2-sdk-interception
+/**
+ * Routing an intercepted WAFv2 SDK client to the simulator.
+ */
+
+import { CreateWebACLCommand, WAFV2Client } from "@aws-sdk/client-wafv2";
+
+import { SimSdk } from "@kensio/yulin/sdk";
+
+using simSdk = new SimSdk();
+
+simSdk.intercept(WAFV2Client);
+
+const client = new WAFV2Client({ region: "eu-west-2" });
+
+await client.send(
+  new CreateWebACLCommand({
+    Name: "api-acl",
+    Scope: "REGIONAL",
+    DefaultAction: { Allow: {} },
+    VisibilityConfig: {
+      SampledRequestsEnabled: false,
+      CloudWatchMetricsEnabled: false,
+      MetricName: "api",
+    },
+  }),
+);
+
+const scoped = simSdk.simAws.accountRegionScope(
+  simSdk.simAws.defaultAccountId,
+  "eu-west-2",
+);
+
+// "api-acl"
+console.log(scoped.wafV2().allWebAcls("REGIONAL")[0]?.name);
+```
+
+## Refusals
+
+A rule Yulin cannot evaluate is refused by `CreateWebACL` and `UpdateWebACL`, naming the rule and
+what in it was refused. A web ACL that accepted such a rule would allow a request AWS blocks, and a
+silent hole in a security layer is worse than a missing one.
+
+These statement kinds are refused:
+
+- `IPSetReferenceStatement`, `GeoMatchStatement` and `AsnMatchStatement`. Every request in this
+  simulation reports a source address of `127.0.0.1`, and a rule on where a request came from would
+  see one client for the whole simulation.
+- `RateBasedStatement`. Counting requests over a time window against the simulated clock is
+  feasible and is not part of this yet.
+- `SqliMatchStatement` and `XssMatchStatement`. AWS publishes no description of the detection they
+  run.
+- `ManagedRuleGroupStatement`, `RuleGroupReferenceStatement` and `LabelMatchStatement`. The AWS
+  managed rule groups are a body of rules Yulin would have to carry, and labels arrive with them.
+
+`JsonBody`, `HeaderOrder`, `UriFragment`, `JA3Fingerprint` and `JA4Fingerprint` are refused as
+fields to match. The `Captcha` and `Challenge` actions are refused, along with the `CaptchaConfig`,
+`ChallengeConfig` and `TokenDomains` that configure them, because a browser has to answer them.
+
+Tags, logging, sampled requests and CloudWatch metrics for a web ACL are not simulated.
+`AssociationConfig`, `DataProtectionConfig`, `OnSourceDDoSProtectionConfig` and `ApplicationConfig`
+are refused for the same reason, each naming what it would have configured.
+
+## Simulated commands
+
+`CreateWebACL`, `GetWebACL`, `UpdateWebACL`, `ListWebACLs`, `DeleteWebACL`, `CreateIPSet`,
+`GetIPSet`, `ListIPSets`, `DeleteIPSet`, `CreateRegexPatternSet`, `GetRegexPatternSet`,
+`ListRegexPatternSets` and `DeleteRegexPatternSet`.

--- a/docs/services/wafv2/README.md
+++ b/docs/services/wafv2/README.md
@@ -329,8 +329,11 @@ const decision = waf.evaluateRequest({
 console.log(decision.action);
 ```
 
-IP sets are created, read, listed and deleted the same way. No rule reads one, for the reason in
-[Refusals](#refusals) below.
+An update to a pattern set reaches the rules pointing at it. A reference resolves to the set when
+the rule is written and reads its expressions when a request arrives, as it does on AWS.
+
+IP sets are created, read, updated, listed and deleted the same way. No rule reads one, for the
+reason in [Refusals](#refusals) below.
 
 ## Scopes
 
@@ -373,7 +376,7 @@ console.log(created.Summary?.ARN);
 
 ## Lock tokens
 
-Every WAFv2 resource carries a lock token that changes on each write. `UpdateWebACL` and the deletes
+Every WAFv2 resource carries a lock token that changes on each write. The updates and the deletes
 take the token from the last read, and a write made against a stale one is refused with
 `WAFOptimisticLockException`.
 
@@ -535,5 +538,6 @@ are refused for the same reason, each naming what it would have configured.
 ## Simulated commands
 
 `CreateWebACL`, `GetWebACL`, `UpdateWebACL`, `ListWebACLs`, `DeleteWebACL`, `CreateIPSet`,
-`GetIPSet`, `ListIPSets`, `DeleteIPSet`, `CreateRegexPatternSet`, `GetRegexPatternSet`,
-`ListRegexPatternSets` and `DeleteRegexPatternSet`.
+`GetIPSet`, `UpdateIPSet`, `ListIPSets`, `DeleteIPSet`, `CreateRegexPatternSet`,
+`GetRegexPatternSet`, `UpdateRegexPatternSet`, `ListRegexPatternSets` and
+`DeleteRegexPatternSet`.

--- a/docs/services/wafv2/sim-wafv2-cloudfront-scope.example.ts
+++ b/docs/services/wafv2/sim-wafv2-cloudfront-scope.example.ts
@@ -1,0 +1,28 @@
+/**
+ * Creating a web ACL for a CloudFront distribution.
+ */
+
+import { CreateWebACLCommand } from "@aws-sdk/client-wafv2";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const waf = simAws
+  .accountRegionScope(simAws.defaultAccountId, "us-east-1")
+  .wafV2();
+
+const created = await waf.createWebAcl(
+  new CreateWebACLCommand({
+    Name: "site-acl",
+    Scope: "CLOUDFRONT",
+    DefaultAction: { Allow: {} },
+    VisibilityConfig: {
+      SampledRequestsEnabled: false,
+      CloudWatchMetricsEnabled: false,
+      MetricName: "site",
+    },
+  }),
+);
+
+// arn:aws:wafv2:us-east-1:...:global/webacl/site-acl/...
+console.log(created.Summary?.ARN);

--- a/docs/services/wafv2/sim-wafv2-count.example.ts
+++ b/docs/services/wafv2/sim-wafv2-count.example.ts
@@ -1,0 +1,49 @@
+/**
+ * Staging a rule in count mode before turning it on.
+ */
+
+import { CreateWebACLCommand } from "@aws-sdk/client-wafv2";
+
+import { SimAws } from "@kensio/yulin";
+
+const waf = new SimAws().wafV2();
+
+const visibility = {
+  SampledRequestsEnabled: false,
+  CloudWatchMetricsEnabled: false,
+  MetricName: "api",
+};
+
+const created = await waf.createWebAcl(
+  new CreateWebACLCommand({
+    Name: "api-acl",
+    Scope: "REGIONAL",
+    DefaultAction: { Allow: {} },
+    VisibilityConfig: visibility,
+    Rules: [
+      {
+        Name: "watch-uploads",
+        Priority: 0,
+        Action: { Count: {} },
+        Statement: {
+          SizeConstraintStatement: {
+            FieldToMatch: { Body: { OversizeHandling: "CONTINUE" } },
+            ComparisonOperator: "GT",
+            Size: 1024,
+            TextTransformations: [{ Priority: 0, Type: "NONE" }],
+          },
+        },
+        VisibilityConfig: visibility,
+      },
+    ],
+  }),
+);
+
+const decision = waf.evaluateRequest({
+  webAclArn: created.Summary!.ARN,
+  request: new Request("https://example.test/upload", { method: "POST" }),
+  body: new TextEncoder().encode("x".repeat(2048)),
+});
+
+// "ALLOW" [ 'watch-uploads' ]
+console.log(decision.action, decision.countedRuleNames);

--- a/docs/services/wafv2/sim-wafv2-custom-response.example.ts
+++ b/docs/services/wafv2/sim-wafv2-custom-response.example.ts
@@ -1,0 +1,68 @@
+/**
+ * Answering a blocked request with a body the web ACL holds.
+ */
+
+import { CreateWebACLCommand } from "@aws-sdk/client-wafv2";
+
+import { SimAws } from "@kensio/yulin";
+import { simWafBlockedHttpResponse } from "@kensio/yulin/wafv2";
+
+const waf = new SimAws().wafV2();
+
+const visibility = {
+  SampledRequestsEnabled: false,
+  CloudWatchMetricsEnabled: false,
+  MetricName: "api",
+};
+
+const created = await waf.createWebAcl(
+  new CreateWebACLCommand({
+    Name: "api-acl",
+    Scope: "REGIONAL",
+    DefaultAction: { Allow: {} },
+    VisibilityConfig: visibility,
+    CustomResponseBodies: {
+      "not-here": {
+        ContentType: "APPLICATION_JSON",
+        Content: '{"message":"Not found"}',
+      },
+    },
+    Rules: [
+      {
+        Name: "hide-admin",
+        Priority: 0,
+        Action: {
+          Block: {
+            CustomResponse: {
+              ResponseCode: 404,
+              CustomResponseBodyKey: "not-here",
+              ResponseHeaders: [{ Name: "rule", Value: "hide-admin" }],
+            },
+          },
+        },
+        Statement: {
+          ByteMatchStatement: {
+            FieldToMatch: { UriPath: {} },
+            PositionalConstraint: "STARTS_WITH",
+            SearchString: Buffer.from("/admin"),
+            TextTransformations: [{ Priority: 0, Type: "NONE" }],
+          },
+        },
+        VisibilityConfig: visibility,
+      },
+    ],
+  }),
+);
+
+const decision = waf.evaluateRequest({
+  webAclArn: created.Summary!.ARN,
+  request: new Request("https://example.test/admin"),
+});
+const response = simWafBlockedHttpResponse(decision.blocked!);
+
+// 404 "hide-admin" '{"message":"Not found"}'
+console.log(
+  response.status,
+  response.headers.get("x-amzn-waf-rule"),
+  await response.text(),
+);

--- a/docs/services/wafv2/sim-wafv2-evaluate.example.ts
+++ b/docs/services/wafv2/sim-wafv2-evaluate.example.ts
@@ -1,0 +1,63 @@
+/**
+ * Blocking requests to an admin path with a simulated web ACL.
+ */
+
+import { CreateWebACLCommand } from "@aws-sdk/client-wafv2";
+
+import { SimAws } from "@kensio/yulin";
+
+const waf = new SimAws().wafV2();
+
+const created = await waf.createWebAcl(
+  new CreateWebACLCommand({
+    Name: "api-acl",
+    Scope: "REGIONAL",
+    DefaultAction: { Allow: {} },
+    VisibilityConfig: {
+      SampledRequestsEnabled: false,
+      CloudWatchMetricsEnabled: false,
+      MetricName: "api",
+    },
+    Rules: [
+      {
+        Name: "block-admin",
+        Priority: 0,
+        Action: { Block: {} },
+        Statement: {
+          ByteMatchStatement: {
+            FieldToMatch: { UriPath: {} },
+            PositionalConstraint: "STARTS_WITH",
+            SearchString: Buffer.from("/admin"),
+            TextTransformations: [{ Priority: 0, Type: "LOWERCASE" }],
+          },
+        },
+        VisibilityConfig: {
+          SampledRequestsEnabled: false,
+          CloudWatchMetricsEnabled: false,
+          MetricName: "block-admin",
+        },
+      },
+    ],
+  }),
+);
+
+const webAclArn = created.Summary!.ARN;
+
+const blocked = waf.evaluateRequest({
+  webAclArn,
+  request: new Request("https://example.test/admin/users"),
+});
+const allowed = waf.evaluateRequest({
+  webAclArn,
+  request: new Request("https://example.test/"),
+});
+
+// "BLOCK" "block-admin" 403
+console.log(
+  blocked.action,
+  blocked.terminatingRuleName,
+  blocked.blocked?.statusCode,
+);
+
+// "ALLOW" undefined
+console.log(allowed.action, allowed.terminatingRuleName);

--- a/docs/services/wafv2/sim-wafv2-permissions.example.ts
+++ b/docs/services/wafv2/sim-wafv2-permissions.example.ts
@@ -1,0 +1,71 @@
+/**
+ * Reading a web ACL as a Role, with a policy naming it.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateWebACLCommand, GetWebACLCommand } from "@aws-sdk/client-wafv2";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultAccountId: "111111111111" });
+const roleArn = "arn:aws:iam::111111111111:role/FirewallReaderRole";
+
+await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "FirewallReaderRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { Service: "lambda.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      ],
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "FirewallReaderRole",
+    PolicyName: "ReadApiAcl",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Action: "wafv2:GetWebACL",
+          Resource:
+            "arn:aws:wafv2:us-east-1:111111111111:regional/webacl/api-acl/*",
+        },
+      ],
+    }),
+  }),
+);
+
+const waf = simAws.wafV2();
+const created = await waf.createWebAcl(
+  new CreateWebACLCommand({
+    Name: "api-acl",
+    Scope: "REGIONAL",
+    DefaultAction: { Allow: {} },
+    VisibilityConfig: {
+      SampledRequestsEnabled: false,
+      CloudWatchMetricsEnabled: false,
+      MetricName: "api",
+    },
+  }),
+);
+
+const read = await waf.getWebAcl(
+  new GetWebACLCommand({
+    Name: "api-acl",
+    Scope: "REGIONAL",
+    Id: created.Summary?.Id,
+  }),
+  { caller: { kind: "arn", arn: roleArn } },
+);
+
+// "api-acl"
+console.log(read.WebACL?.Name);

--- a/docs/services/wafv2/sim-wafv2-regex-pattern-set.example.ts
+++ b/docs/services/wafv2/sim-wafv2-regex-pattern-set.example.ts
@@ -1,0 +1,63 @@
+/**
+ * Blocking a set of user agents held in a regex pattern set.
+ */
+
+import {
+  CreateRegexPatternSetCommand,
+  CreateWebACLCommand,
+} from "@aws-sdk/client-wafv2";
+
+import { SimAws } from "@kensio/yulin";
+
+const waf = new SimAws().wafV2();
+
+const patternSet = await waf.createRegexPatternSet(
+  new CreateRegexPatternSetCommand({
+    Name: "scanners",
+    Scope: "REGIONAL",
+    RegularExpressionList: [
+      { RegexString: "sqlmap" },
+      { RegexString: "nikto" },
+    ],
+  }),
+);
+
+const visibility = {
+  SampledRequestsEnabled: false,
+  CloudWatchMetricsEnabled: false,
+  MetricName: "api",
+};
+
+const created = await waf.createWebAcl(
+  new CreateWebACLCommand({
+    Name: "api-acl",
+    Scope: "REGIONAL",
+    DefaultAction: { Allow: {} },
+    VisibilityConfig: visibility,
+    Rules: [
+      {
+        Name: "block-scanners",
+        Priority: 0,
+        Action: { Block: {} },
+        Statement: {
+          RegexPatternSetReferenceStatement: {
+            ARN: patternSet.Summary!.ARN,
+            FieldToMatch: { SingleHeader: { Name: "user-agent" } },
+            TextTransformations: [{ Priority: 0, Type: "LOWERCASE" }],
+          },
+        },
+        VisibilityConfig: visibility,
+      },
+    ],
+  }),
+);
+
+const decision = waf.evaluateRequest({
+  webAclArn: created.Summary!.ARN,
+  request: new Request("https://example.test/", {
+    headers: { "user-agent": "sqlmap/1.7" },
+  }),
+});
+
+// "BLOCK"
+console.log(decision.action);

--- a/docs/services/wafv2/sim-wafv2-sdk-interception.example.ts
+++ b/docs/services/wafv2/sim-wafv2-sdk-interception.example.ts
@@ -1,0 +1,34 @@
+/**
+ * Routing an intercepted WAFv2 SDK client to the simulator.
+ */
+
+import { CreateWebACLCommand, WAFV2Client } from "@aws-sdk/client-wafv2";
+
+import { SimSdk } from "@kensio/yulin/sdk";
+
+using simSdk = new SimSdk();
+
+simSdk.intercept(WAFV2Client);
+
+const client = new WAFV2Client({ region: "eu-west-2" });
+
+await client.send(
+  new CreateWebACLCommand({
+    Name: "api-acl",
+    Scope: "REGIONAL",
+    DefaultAction: { Allow: {} },
+    VisibilityConfig: {
+      SampledRequestsEnabled: false,
+      CloudWatchMetricsEnabled: false,
+      MetricName: "api",
+    },
+  }),
+);
+
+const scoped = simSdk.simAws.accountRegionScope(
+  simSdk.simAws.defaultAccountId,
+  "eu-west-2",
+);
+
+// "api-acl"
+console.log(scoped.wafV2().allWebAcls("REGIONAL")[0]?.name);

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -34,6 +34,7 @@
       "@kensio/yulin/ses": ["../src/service/ses/index.ts"],
       "@kensio/yulin/sns": ["../src/service/sns/index.ts"],
       "@kensio/yulin/sqs": ["../src/service/sqs/index.ts"],
+      "@kensio/yulin/wafv2": ["../src/service/wafv2/index.ts"],
       "@kensio/yulin/watch": ["../src/watch/index.ts"]
     }
   },

--- a/package.json
+++ b/package.json
@@ -164,6 +164,10 @@
       "import": "./dist/serve/index.js",
       "types": "./dist/serve/index.d.ts"
     },
+    "./wafv2": {
+      "import": "./dist/service/wafv2/index.js",
+      "types": "./dist/service/wafv2/index.d.ts"
+    },
     "./watch": {
       "import": "./dist/watch/index.js",
       "types": "./dist/watch/index.d.ts"
@@ -208,6 +212,7 @@
     "@aws-sdk/client-sqs": "^3.1101.0",
     "@aws-sdk/client-ssm": "^3.1101.0",
     "@aws-sdk/client-sts": "^3.1101.0",
+    "@aws-sdk/client-wafv2": "^3.1113.0",
     "@aws-sdk/lib-dynamodb": "^3.1101.0",
     "@aws-sdk/lib-storage": "^3.1112.0",
     "@aws-sdk/s3-request-presigner": "^3.1101.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       '@aws-sdk/client-sts':
         specifier: ^3.1101.0
         version: 3.1109.0
+      '@aws-sdk/client-wafv2':
+        specifier: ^3.1113.0
+        version: 3.1113.0
       '@aws-sdk/lib-dynamodb':
         specifier: ^3.1101.0
         version: 3.1109.0(@aws-sdk/client-dynamodb@3.1109.0)
@@ -383,6 +386,10 @@ packages:
 
   '@aws-sdk/client-sts@3.1109.0':
     resolution: {integrity: sha512-67YVNnWJ+6JGdXqs2XB3m+6rK8yBs90O8box2wLpoc5mlz+7JF2Y00BZ/AhJdB9uhN7ovaVTyjjQjSmEcR5kxw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-wafv2@3.1113.0':
+    resolution: {integrity: sha512-z6AQe7oH00Ammi4Jc/ABPTmU/1ajPZPiMbgR4mQULXBqbi1Dy/1gMek2YkAbbVXZGZblLhCzSYEI/MKNHokRLQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/core@3.977.7':
@@ -3895,6 +3902,17 @@ snapshots:
       '@aws-sdk/core': 3.977.8
       '@aws-sdk/credential-provider-node': 3.972.80
       '@aws-sdk/signature-v4-multi-region': 3.996.45
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/client-wafv2@3.1113.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/credential-provider-node': 3.972.80
       '@aws-sdk/types': 3.974.4
       '@smithy/core': 3.33.2
       '@smithy/fetch-http-handler': 5.7.2

--- a/src/sdk/router/resolve-sim-sdk-command-router.ts
+++ b/src/sdk/router/resolve-sim-sdk-command-router.ts
@@ -108,6 +108,7 @@ const scopedRouters: ReadonlyMap<string, SimSdkScopedRouter> = new Map<
   ["SQS", (scoped): SimSdkCommandRouter => scoped.sqs().sdkCommandRouter()],
   ["SSM", (scoped): SimSdkCommandRouter => scoped.ssm().sdkCommandRouter()],
   ["STS", (scoped): SimSdkCommandRouter => scoped.sts().sdkCommandRouter()],
+  ["WAFV2", (scoped): SimSdkCommandRouter => scoped.wafV2().sdkCommandRouter()],
 ]);
 
 /**

--- a/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
@@ -4,6 +4,7 @@ import { SimSecretsManager } from "../../secretsmanager/index.js";
 import { SimSesV2 } from "../../ses/index.js";
 import { SimSqs } from "../../sqs/index.js";
 import { SimSsm } from "../../ssm/index.js";
+import { SimWafV2 } from "../../wafv2/index.js";
 import type { SimAwsAccountServiceCache } from "./sim-aws-account-service-cache.js";
 import type { SimAwsScopedServiceProperties } from "./sim-aws-scoped-service-properties.js";
 
@@ -76,6 +77,17 @@ export class SimAwsSelfContainedServiceBuilder {
    */
   createSsm(scope: SimAwsAccountRegionContainer): SimSsm {
     return new SimSsm({ ...this.scoped(scope), kms: scope.kms() });
+  }
+
+  /**
+   * Create simulated WAFv2 for an Account Region scope.
+   *
+   * Web ACLs are Region-scoped on real AWS, and the `CLOUDFRONT` scope is held
+   * in `us-east-1` because CloudFront is global. Both fall out of the scope
+   * this is built in.
+   */
+  createWafV2(scope: SimAwsAccountRegionContainer): SimWafV2 {
+    return new SimWafV2(this.scoped(scope));
   }
 
   /**

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -33,6 +33,7 @@ import type { SimSns } from "../../sns/index.js";
 import type { SimSqs } from "../../sqs/index.js";
 import type { SimSsm } from "../../ssm/index.js";
 import type { SimSts } from "../../sts/sim-sts.js";
+import type { SimWafV2 } from "../../wafv2/index.js";
 import { SimAwsAccountRegionServiceBuilder } from "./sim-aws-account-region-service-builder.js";
 import { SimAwsRegisteredServiceBuilder } from "./sim-aws-registered-service-builder.js";
 import { SimAwsSelfContainedServiceBuilder } from "./sim-aws-self-contained-service-builder.js";
@@ -274,5 +275,10 @@ export class SimAwsServiceFactory {
   /** Create simulated STS for an Account/Region scope. */
   createSts(scope: SimAwsAccountRegionContainer): SimSts {
     return this.accountRegionServices.createSts(scope);
+  }
+
+  /** Create simulated WAFv2 for an Account Region scope. */
+  createWafV2(scope: SimAwsAccountRegionContainer): SimWafV2 {
+    return this.selfContainedServices.createWafV2(scope);
   }
 }

--- a/src/service/aws/sim-aws-account-region-scope.ts
+++ b/src/service/aws/sim-aws-account-region-scope.ts
@@ -33,6 +33,7 @@ import type { SimSns } from "../sns/index.js";
 import type { SimSqs } from "../sqs/index.js";
 import type { SimSsm } from "../ssm/index.js";
 import type { SimSts } from "../sts/sim-sts.js";
+import type { SimWafV2 } from "../wafv2/index.js";
 
 export type SimAccountRegionScopeKey = `${SimAwsAccountId}:${AwsRegionName}`;
 
@@ -247,6 +248,11 @@ export class SimAwsAccountRegionContainer {
   /** Get simulated STS for this account and region. */
   sts(): SimSts {
     return this.memo.getOrCreate("sts", () => this.factory.createSts(this));
+  }
+
+  /** Get simulated WAFv2 for this account and region. */
+  wafV2(): SimWafV2 {
+    return this.memo.getOrCreate("wafV2", () => this.factory.createWafV2(this));
   }
 
   /**

--- a/src/service/aws/sim-aws-service-accessors.ts
+++ b/src/service/aws/sim-aws-service-accessors.ts
@@ -29,6 +29,7 @@ import type { SimSns } from "../sns/index.js";
 import type { SimSqs } from "../sqs/index.js";
 import type { SimSsm } from "../ssm/index.js";
 import type { SimSts } from "../sts/sim-sts.js";
+import type { SimWafV2 } from "../wafv2/index.js";
 
 /**
  * Per-service accessors for a default Account Region scope.
@@ -184,5 +185,10 @@ export abstract class SimAwsServiceAccessors {
   /** Get simulated STS in the default Account Region scope. */
   sts(): SimSts {
     return this.defaultAccountRegionScope().sts();
+  }
+
+  /** Get simulated WAFv2 in the default Account Region scope. */
+  wafV2(): SimWafV2 {
+    return this.defaultAccountRegionScope().wafV2();
   }
 }

--- a/src/service/wafv2/README.md
+++ b/src/service/wafv2/README.md
@@ -1,0 +1,128 @@
+# Simulated WAFv2 implementation
+
+This directory contains the simulated AWS WAFv2 implementation. It holds web ACLs, IP sets and
+regex pattern sets, and it evaluates a request against a web ACL's rules to reach a decision.
+
+Association comes later. A CloudFront distribution, an API Gateway REST API stage and a Cognito
+user pool each get a web ACL in the issues after the one this was built for.
+`SimWafV2.evaluateRequest` is the entry point those serving paths will call once they have a web ACL
+ARN to hand.
+
+## Entry points
+
+- `sim-wafv2.ts` is the service facade for one Account and Region scope.
+- `sim-wafv2-commands.ts` is the wiring behind it, held apart because the facade grows by one method
+  per SDK operation and the two would otherwise compete for room in one file.
+- `index.ts` exports the public WAFv2 simulator API for `@kensio/yulin/wafv2`.
+
+The service is scoped to an Account and Region, and within that to `CLOUDFRONT` or `REGIONAL`. The
+two scopes are separate namespaces (one name can be taken in both), and `CLOUDFRONT` is only
+reachable from `us-east-1` because CloudFront is global and its web ACLs live there.
+
+## The resource model
+
+`resource/sim-waf-resource.ts` is what the three resource types share. Each is named within a scope,
+carries a generated id that is part of its ARN, and is written through a lock token. WAFv2 changes
+the token on every write and refuses a write made against a stale one. That is how two callers
+editing the same rules find out about each other, and reproducing it means a caller that keeps a
+token from an earlier read fails here the way it fails on AWS.
+
+`resource/sim-waf-resource-store.ts` is generic over the resource type. Names are unique within a
+scope, and a read takes the name and the id together, because a name can have belonged to more than
+one resource over time.
+
+`command/sim-wafv2-resource-lookup.ts` covers the reads, updates and deletes of all three types with
+one function. Authorizing happens before the lookup. That keeps a denial and a missing resource
+apart. A caller with no permission for a web ACL learns only about the permission.
+
+## Rule evaluation
+
+`web-acl/sim-waf-web-acl.ts` holds the loop, and it is short because everything it needs was worked
+out when the web ACL was written. Rules run in ascending `Priority`. The first rule that matches and
+carries a terminating action decides the request. A `Count` action records the match and lets the
+next rule have a look. A request no rule terminates gets the ACL's `DefaultAction`.
+
+`evaluate/sim-waf-decision.ts` is what comes back. It carries the action, the rule that decided, the
+rules that counted, the headers to add to a forwarded request, and what to answer a blocked request
+with. The counted rules matter because a `Count` action leaves the request as it found it. A test
+staging a rule before turning it on asserts against that list.
+
+`evaluate/sim-waf-blocked-response.ts` holds the default 403 body. Real WAF hands the blocking off
+to whatever the web ACL is in front of, and each of those writes its own page (CloudFront's error
+page, API Gateway's `{"message":"Forbidden"}`). This is Yulin's own body until there is a fronting
+service to ask, and it is documented as a divergence in `docs/services/wafv2`.
+
+## Compiling a statement
+
+`statement/sim-waf-statement.ts` turns a statement into a matcher when the web ACL is written. That
+is the decision the whole directory is arranged around. A rule Yulin cannot evaluate is refused by
+`CreateWebACL` and `UpdateWebACL`, at the point where the rule was written. Every rule a request
+meets has already been compiled into something that can answer about it.
+
+The pieces underneath it each answer one question about a statement:
+
+- `sim-waf-field-to-match.ts` and `sim-waf-set-field.ts` read the part of the request the statement
+  inspects. A field can hold more than one string (all the query arguments, the headers a pattern
+  selected), and a statement matches when any of them does.
+- `sim-waf-text-transformation.ts` applies the rule's transformations in ascending `Priority`. WAF
+  orders them by priority and not by how the list was written. Lowercasing after decoding is a
+  different rule from decoding after lowercasing.
+- `sim-waf-byte-match.ts`, `sim-waf-regex-match.ts` and `sim-waf-size-constraint.ts` are the three
+  tests a field is put through.
+- `sim-waf-logical-statement.ts` joins and negates the others.
+
+`sim-waf-field-content.ts` is where the inspection limit lives. WAF stops reading a body, a header
+set or a cookie set at 8 KB, and the rule says what content past that point counts as. `MATCH` and
+`NO_MATCH` settle the statement without looking. `CONTINUE` inspects as much as WAF would have
+read.
+
+Matching is case sensitive throughout, as it is on AWS. A rule that means to ignore case says so
+with a `LOWERCASE` transformation and a lower case search string.
+
+## Refusals
+
+Three files hold them, one per level.
+
+- `statement/sim-waf-unsimulated-statement.ts` for the statement kinds.
+- `statement/sim-waf-unsimulated-field.ts` for the field-to-match kinds.
+- `web-acl/sim-waf-rule-input.ts` and `command/web-acl/sim-wafv2-unsimulated-web-acl-input.ts` for
+  the members of a rule and of a web ACL.
+
+Every refusal names the rule and what in it was refused, because a web ACL is a list of rules that
+all look alike from the outside and the name is the only thing that says which one to go and look
+at.
+
+The reasons are worth knowing. `IPSetReferenceStatement`, `GeoMatchStatement` and
+`AsnMatchStatement` are refused because every request in this simulation reports a source address of
+`127.0.0.1` (`simAwsProxiedSourceIp`), and a rule on where a request came from would see one client
+for the whole simulation. `SqliMatchStatement` and `XssMatchStatement` are refused because AWS
+publishes no description of the detection they run. `RateBasedStatement` needs request counting over
+a window against the simulated clock (feasible, and not part of this). The rule group
+statements and `LabelMatchStatement` arrive with the AWS managed rule groups.
+
+An IP set is held and reported, and no rule reads one, for the same reason
+`IPSetReferenceStatement` is refused. A stack that creates one still deploys, and a test can read
+back what it created.
+
+## Authorization
+
+`command/authorize/sim-wafv2-authorizer.ts` authorizes an operation on one resource against that
+resource's ARN. The id in the ARN is generated. A policy that names a resource therefore ends in a
+wildcard where the id goes, as WAFv2 policies do on AWS
+(`arn:aws:wafv2:us-east-1:111111111111:regional/webacl/api-acl/*`).
+
+The three listings have no resource type on real WAFv2. They authorize against `*`, and a policy
+scoped to web ACL ARNs allows none of them, however broadly those ARNs are written.
+
+## Testing
+
+Tests are colocated with the code they exercise. `sim-wafv2.fixture.ts` holds two helpers, and both
+exist for the same reason. `createSimWafWebAcl` reads the summary a create reported, holding the
+id, the ARN and the first lock token. `simWafStatementMatches` puts one statement behind a blocking
+rule and answers with a predicate over requests. That predicate is the whole of what a test about a
+statement kind wants to say.
+
+`web-acl/sim-waf-rule.factory.ts` and `command/web-acl/sim-waf-create-web-acl.factory.ts` build the
+two shapes a test writes over and over. Overrides are merged into the defaults, and `Statement` and
+`Action` each hold one kind at a time, and a test replaces those whole. Merging two statement kinds
+onto one statement produces a rule WAF would refuse, and the factory says as much.

--- a/src/service/wafv2/command/authorize/sim-wafv2-authorizer.ts
+++ b/src/service/wafv2/command/authorize/sim-wafv2-authorizer.ts
@@ -1,0 +1,71 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+
+/**
+ * The resource an action with no resource type authorizes against.
+ *
+ * The three listings have no resource type on real WAFv2, so IAM evaluates
+ * them against `*` and only a policy whose Resource is `*` allows them. A
+ * policy naming web ACL ARNs allows no listing, however broadly those ARNs are
+ * written.
+ */
+const noResource = "*";
+
+interface SimWafAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * Applies simulated IAM authorization to WAFv2 requests.
+ *
+ * An operation on one resource authorizes against that resource's ARN, which
+ * is the form WAFv2 policies are written in. The id is generated, so a policy
+ * that names a resource ends in a wildcard where the id goes:
+ * `arn:aws:wafv2:us-east-1:111111111111:regional/webacl/api-acl/*`.
+ */
+export class SimWafAuthorizer {
+  readonly #iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: SimWafAuthorizerProperties) {
+    this.#iam = properties.iam;
+  }
+
+  /**
+   * Ensure the caller may perform an action on one WAFv2 resource.
+   *
+   * The resource need not exist. Real IAM evaluates a request before the
+   * service handles it, so a caller with no permission is refused whether or
+   * not the resource is there, and a create authorizes against the ARN the
+   * resource is about to have.
+   */
+  authorizeResource(
+    action: string,
+    resource: string,
+    caller?: SimAwsCaller,
+  ): SimAwsResolvedCaller {
+    const decision = this.#iam.authorize({ action, resource, caller });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action,
+        resource,
+      });
+    }
+
+    return decision.caller;
+  }
+
+  /**
+   * Ensure the caller may perform an action real WAFv2 gives no resource type,
+   * which is each of the three listings.
+   */
+  authorizeNoResource(
+    action: string,
+    caller?: SimAwsCaller,
+  ): SimAwsResolvedCaller {
+    return this.authorizeResource(action, noResource, caller);
+  }
+}

--- a/src/service/wafv2/command/authorize/sim-wafv2-iam.iso.test.ts
+++ b/src/service/wafv2/command/authorize/sim-wafv2-iam.iso.test.ts
@@ -1,0 +1,198 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { GetWebACLCommand, ListWebACLsCommand } from "@aws-sdk/client-wafv2";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
+import { simWafCreateWebAclFactory } from "../web-acl/sim-waf-create-web-acl.factory.js";
+import { createSimWafWebAcl } from "../../sim-wafv2.fixture.js";
+
+const accountIdOneOnes = "111111111111";
+
+/**
+ * A simulation with one Role, and whatever policy statement the test wants it
+ * to have.
+ */
+async function simAwsWithRole(policyStatement?: object): Promise<SimAws> {
+  const simAws = new SimAws({ defaultAccountId: accountIdOneOnes });
+
+  await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "FirewallAdminRole",
+      AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: {
+          Principal: { Service: "lambda.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  if (policyStatement !== undefined) {
+    await simAws.iam().putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "FirewallAdminRole",
+        PolicyName: "ManageWebAcls",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: policyStatement,
+        }),
+      }),
+    );
+  }
+
+  return simAws;
+}
+
+/** The request options that make a call arrive as the Role. */
+const asRole = {
+  caller: {
+    kind: "arn",
+    arn: `arn:aws:iam::${accountIdOneOnes}:role/FirewallAdminRole`,
+  },
+} as const;
+
+describe("WAFv2 IAM authorization", () => {
+  it("allows a read of the web ACL a policy names", async () => {
+    // Given a Role allowed to read one web ACL by name, with the generated id
+    // left as a wildcard.
+    const simAws = await simAwsWithRole({
+      Action: "wafv2:GetWebACL",
+      Resource: `arn:aws:wafv2:us-east-1:${accountIdOneOnes}:regional/webacl/api-acl/*`,
+    });
+    const waf = simAws.wafV2();
+    const created = await createSimWafWebAcl(
+      waf,
+      simWafCreateWebAclFactory.make({ Name: "api-acl" }),
+    );
+
+    // When the Role reads it.
+    const read = await waf.getWebAcl(
+      new GetWebACLCommand({
+        Name: "api-acl",
+        Scope: "REGIONAL",
+        Id: created.Id,
+      }),
+      asRole,
+    );
+
+    // Then it is allowed. A policy has to leave the id as a wildcard, since
+    // WAFv2 generates it.
+    assertIdentical(read.WebACL?.Name, "api-acl");
+  });
+
+  it("denies a read of a web ACL the policy does not name", async () => {
+    // Given a Role allowed to read one web ACL.
+    const simAws = await simAwsWithRole({
+      Action: "wafv2:GetWebACL",
+      Resource: `arn:aws:wafv2:us-east-1:${accountIdOneOnes}:regional/webacl/api-acl/*`,
+    });
+    const waf = simAws.wafV2();
+    const created = await createSimWafWebAcl(
+      waf,
+      simWafCreateWebAclFactory.make({ Name: "site-acl" }),
+    );
+
+    // When it reads another.
+    const error = await assertThrowsErrorAsync(async () => {
+      await waf.getWebAcl(
+        new GetWebACLCommand({
+          Name: "site-acl",
+          Scope: "REGIONAL",
+          Id: created.Id,
+        }),
+        asRole,
+      );
+    });
+
+    // Then it is denied, naming the action and the resource.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertStringIncludes(error.message, "wafv2:GetWebACL");
+    assertStringIncludes(error.message, "site-acl");
+  });
+
+  it("denies a caller with no policy at all", async () => {
+    // Given a Role with nothing granted to it.
+    const simAws = await simAwsWithRole();
+
+    // When it creates a web ACL.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .wafV2()
+        .createWebAcl({ input: simWafCreateWebAclFactory.make() }, asRole);
+    });
+
+    // Then it is denied.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertStringIncludes(error.message, "wafv2:CreateWebACL");
+  });
+
+  it("denies a read before saying whether the web ACL is there", async () => {
+    // Given a Role with nothing granted to it.
+    const simAws = await simAwsWithRole();
+
+    // When it reads a web ACL that does not exist.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.wafV2().getWebAcl(
+        new GetWebACLCommand({
+          Name: "missing",
+          Scope: "REGIONAL",
+          Id: "0f5a1b2c-3d4e-5f60-7182-93a4b5c6d7e8",
+        }),
+        asRole,
+      );
+    });
+
+    // Then it is denied rather than told the web ACL is missing, so a caller
+    // with no permission learns nothing about what is there.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("allows a listing only through a policy written against everything", async () => {
+    // Given a Role allowed to list, granted on `*` as WAFv2 requires.
+    const simAws = await simAwsWithRole({
+      Action: "wafv2:ListWebACLs",
+      Resource: "*",
+    });
+    const waf = simAws.wafV2();
+
+    await createSimWafWebAcl(waf, simWafCreateWebAclFactory.make());
+
+    // When it lists.
+    const listed = await waf.listWebAcls(
+      new ListWebACLsCommand({ Scope: "REGIONAL" }),
+      asRole,
+    );
+
+    // Then the listing is allowed.
+    assertArrayLength(listed.WebACLs ?? [], 1);
+  });
+
+  it("denies a listing granted only on web ACL ARNs", async () => {
+    // Given a Role allowed to list, granted on every web ACL in the Account
+    // and Region.
+    const simAws = await simAwsWithRole({
+      Action: "wafv2:ListWebACLs",
+      Resource: `arn:aws:wafv2:us-east-1:${accountIdOneOnes}:regional/webacl/*`,
+    });
+
+    // When it lists.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .wafV2()
+        .listWebAcls(new ListWebACLsCommand({ Scope: "REGIONAL" }), asRole);
+    });
+
+    // Then it is denied. ListWebACLs has no resource type on real WAFv2, so it
+    // is evaluated against `*` and a policy scoped to ARNs allows none of it,
+    // however broadly those ARNs are written.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+});

--- a/src/service/wafv2/command/ip-set/ip-set.command.ts
+++ b/src/service/wafv2/command/ip-set/ip-set.command.ts
@@ -1,0 +1,99 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimWafSummaryOutput } from "../web-acl/web-acl.command.js";
+
+/**
+ * Minimal structural sim WAFv2 CreateIPSet command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/wafv2/command/CreateIPSetCommand/
+ */
+export interface SimCreateIpSetCommand {
+  readonly input: SimCreateIpSetCommandInput;
+}
+
+export interface SimCreateIpSetCommandInput {
+  readonly Name?: string | undefined;
+  readonly Scope?: string | undefined;
+  readonly IPAddressVersion?: string | undefined;
+  readonly Addresses?: readonly string[] | undefined;
+  readonly Description?: string | undefined;
+  readonly Tags?: readonly unknown[] | undefined;
+}
+
+export interface SimCreateIpSetCommandOutput {
+  readonly Summary?: SimWafSummaryOutput | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim WAFv2 GetIPSet command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/wafv2/command/GetIPSetCommand/
+ */
+export interface SimGetIpSetCommand {
+  readonly input: SimGetIpSetCommandInput;
+}
+
+export interface SimGetIpSetCommandInput {
+  readonly Name?: string | undefined;
+  readonly Scope?: string | undefined;
+  readonly Id?: string | undefined;
+}
+
+/**
+ * What GetIPSet reports about one IP set.
+ */
+export interface SimWafIpSetOutput {
+  readonly Name: string;
+  readonly Id: string;
+  readonly ARN: string;
+  readonly Description: string | undefined;
+  readonly IPAddressVersion: string;
+  readonly Addresses: readonly string[];
+}
+
+export interface SimGetIpSetCommandOutput {
+  readonly IPSet?: SimWafIpSetOutput | undefined;
+  readonly LockToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim WAFv2 ListIPSets command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/wafv2/command/ListIPSetsCommand/
+ */
+export interface SimListIpSetsCommand {
+  readonly input: SimListIpSetsCommandInput;
+}
+
+export interface SimListIpSetsCommandInput {
+  readonly Scope?: string | undefined;
+  readonly Limit?: number | undefined;
+  readonly NextMarker?: string | undefined;
+}
+
+export interface SimListIpSetsCommandOutput {
+  readonly IPSets?: readonly SimWafSummaryOutput[] | undefined;
+  readonly NextMarker?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim WAFv2 DeleteIPSet command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/wafv2/command/DeleteIPSetCommand/
+ */
+export interface SimDeleteIpSetCommand {
+  readonly input: SimDeleteIpSetCommandInput;
+}
+
+export interface SimDeleteIpSetCommandInput {
+  readonly Name?: string | undefined;
+  readonly Scope?: string | undefined;
+  readonly Id?: string | undefined;
+  readonly LockToken?: string | undefined;
+}
+
+export interface SimDeleteIpSetCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/wafv2/command/ip-set/ip-set.command.ts
+++ b/src/service/wafv2/command/ip-set/ip-set.command.ts
@@ -58,6 +58,29 @@ export interface SimGetIpSetCommandOutput {
 }
 
 /**
+ * Minimal structural sim WAFv2 UpdateIPSet command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/wafv2/command/UpdateIPSetCommand/
+ */
+export interface SimUpdateIpSetCommand {
+  readonly input: SimUpdateIpSetCommandInput;
+}
+
+export interface SimUpdateIpSetCommandInput {
+  readonly Name?: string | undefined;
+  readonly Scope?: string | undefined;
+  readonly Id?: string | undefined;
+  readonly Addresses?: readonly string[] | undefined;
+  readonly Description?: string | undefined;
+  readonly LockToken?: string | undefined;
+}
+
+export interface SimUpdateIpSetCommandOutput {
+  readonly NextLockToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
  * Minimal structural sim WAFv2 ListIPSets command.
  *
  * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/wafv2/command/ListIPSetsCommand/

--- a/src/service/wafv2/command/ip-set/sim-wafv2-ip-set-commands.ts
+++ b/src/service/wafv2/command/ip-set/sim-wafv2-ip-set-commands.ts
@@ -11,6 +11,8 @@ import { refuseSimWafTags, requiredSimWafName } from "../sim-wafv2-input.js";
 import type { SimWafRequestOptions } from "../sim-wafv2-request-options.js";
 import { requireSimWafResource } from "../sim-wafv2-resource-lookup.js";
 import type {
+  SimUpdateIpSetCommand,
+  SimUpdateIpSetCommandOutput,
   SimCreateIpSetCommand,
   SimCreateIpSetCommandOutput,
   SimDeleteIpSetCommand,
@@ -98,6 +100,25 @@ export class SimWafIpSetCommands {
         Addresses: ipSet.addresses,
       },
     };
+  }
+
+  /**
+   * Write a new list of ranges over an IP set.
+   */
+  updateIpSet(
+    command: SimUpdateIpSetCommand,
+    options?: SimWafRequestOptions,
+  ): SimUpdateIpSetCommandOutput {
+    const { input } = command;
+    const ipSet = this.require(input, "wafv2:UpdateIPSet", options);
+
+    ipSet.replaceAddresses({
+      addresses: input.Addresses ?? [],
+      description: input.Description,
+      lockToken: input.LockToken,
+    });
+
+    return { $metadata: {}, NextLockToken: ipSet.lockToken };
   }
 
   /**

--- a/src/service/wafv2/command/ip-set/sim-wafv2-ip-set-commands.ts
+++ b/src/service/wafv2/command/ip-set/sim-wafv2-ip-set-commands.ts
@@ -1,0 +1,160 @@
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import {
+  SimWafIpSet,
+  requiredSimWafIpAddressVersion,
+} from "../../ip-set/sim-waf-ip-set.js";
+import type { SimWafResourceStore } from "../../resource/sim-waf-resource-store.js";
+import { requiredSimWafScope } from "../../scope/sim-waf-scope.js";
+import type { SimWafAuthorizer } from "../authorize/sim-wafv2-authorizer.js";
+import { SimWafPage } from "../sim-wafv2-page.js";
+import { refuseSimWafTags, requiredSimWafName } from "../sim-wafv2-input.js";
+import type { SimWafRequestOptions } from "../sim-wafv2-request-options.js";
+import { requireSimWafResource } from "../sim-wafv2-resource-lookup.js";
+import type {
+  SimCreateIpSetCommand,
+  SimCreateIpSetCommandOutput,
+  SimDeleteIpSetCommand,
+  SimDeleteIpSetCommandOutput,
+  SimGetIpSetCommand,
+  SimGetIpSetCommandOutput,
+  SimListIpSetsCommand,
+  SimListIpSetsCommandOutput,
+} from "./ip-set.command.js";
+
+interface SimWafIpSetCommandsProperties {
+  readonly ipSets: SimWafResourceStore<SimWafIpSet>;
+  readonly authorizer: SimWafAuthorizer;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * The commands that make, read, list and remove IP sets.
+ *
+ * The addresses are held and reported and nothing evaluates them, because
+ * `IPSetReferenceStatement` is refused: every request in this simulation comes
+ * from 127.0.0.1.
+ */
+export class SimWafIpSetCommands {
+  readonly #ipSets: SimWafResourceStore<SimWafIpSet>;
+  readonly #authorizer: SimWafAuthorizer;
+  readonly #accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimWafIpSetCommandsProperties) {
+    this.#ipSets = properties.ipSets;
+    this.#authorizer = properties.authorizer;
+    this.#accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Make an IP set from a list of address ranges.
+   */
+  createIpSet(
+    command: SimCreateIpSetCommand,
+    options?: SimWafRequestOptions,
+  ): SimCreateIpSetCommandOutput {
+    const { input } = command;
+
+    refuseSimWafTags(input.Tags, "CreateIPSet");
+
+    const ipSet = new SimWafIpSet({
+      name: requiredSimWafName(input.Name),
+      scope: requiredSimWafScope(
+        input.Scope,
+        this.#accountRegionScope.regionName,
+      ),
+      accountRegionScope: this.#accountRegionScope,
+      description: input.Description,
+      ipAddressVersion: requiredSimWafIpAddressVersion(input.IPAddressVersion),
+      addresses: input.Addresses ?? [],
+    });
+
+    this.#authorizer.authorizeResource(
+      "wafv2:CreateIPSet",
+      ipSet.arn,
+      options?.caller,
+    );
+
+    return { $metadata: {}, Summary: this.#ipSets.add(ipSet).summary() };
+  }
+
+  /**
+   * Read one IP set and the token the next write to it has to present.
+   */
+  getIpSet(
+    command: SimGetIpSetCommand,
+    options?: SimWafRequestOptions,
+  ): SimGetIpSetCommandOutput {
+    const ipSet = this.require(command.input, "wafv2:GetIPSet", options);
+
+    return {
+      $metadata: {},
+      LockToken: ipSet.lockToken,
+      IPSet: {
+        Name: ipSet.name,
+        Id: ipSet.id,
+        ARN: ipSet.arn,
+        Description: ipSet.description,
+        IPAddressVersion: ipSet.ipAddressVersion,
+        Addresses: ipSet.addresses,
+      },
+    };
+  }
+
+  /**
+   * List the IP sets in one scope, in the order they were created.
+   */
+  listIpSets(
+    command: SimListIpSetsCommand,
+    options?: SimWafRequestOptions,
+  ): SimListIpSetsCommandOutput {
+    const scope = requiredSimWafScope(
+      command.input.Scope,
+      this.#accountRegionScope.regionName,
+    );
+
+    this.#authorizer.authorizeNoResource("wafv2:ListIPSets", options?.caller);
+
+    const page = new SimWafPage({
+      listed: this.#ipSets.all(scope),
+      limit: command.input.Limit,
+      nextMarker: command.input.NextMarker,
+    });
+
+    return {
+      $metadata: {},
+      IPSets: page.items.map((ipSet) => ipSet.summary()),
+      NextMarker: page.nextMarker,
+    };
+  }
+
+  /**
+   * Remove an IP set.
+   */
+  deleteIpSet(
+    command: SimDeleteIpSetCommand,
+    options?: SimWafRequestOptions,
+  ): SimDeleteIpSetCommandOutput {
+    const ipSet = this.require(command.input, "wafv2:DeleteIPSet", options);
+
+    ipSet.takeLock(command.input.LockToken);
+    this.#ipSets.remove(ipSet);
+
+    return { $metadata: {} };
+  }
+
+  private require(
+    input: SimGetIpSetCommand["input"],
+    action: string,
+    options: SimWafRequestOptions | undefined,
+  ): SimWafIpSet {
+    return requireSimWafResource({
+      store: this.#ipSets,
+      input,
+      kind: "ipset",
+      action,
+      authorizer: this.#authorizer,
+      accountRegionScope: this.#accountRegionScope,
+      caller: options?.caller,
+    });
+  }
+}

--- a/src/service/wafv2/command/regex-pattern-set/regex-pattern-set.command.ts
+++ b/src/service/wafv2/command/regex-pattern-set/regex-pattern-set.command.ts
@@ -1,0 +1,100 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimWafRegularExpressionInput } from "../../regex-pattern-set/sim-waf-regex-pattern-set.js";
+import type { SimWafSummaryOutput } from "../web-acl/web-acl.command.js";
+
+/**
+ * Minimal structural sim WAFv2 CreateRegexPatternSet command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/wafv2/command/CreateRegexPatternSetCommand/
+ */
+export interface SimCreateRegexPatternSetCommand {
+  readonly input: SimCreateRegexPatternSetCommandInput;
+}
+
+export interface SimCreateRegexPatternSetCommandInput {
+  readonly Name?: string | undefined;
+  readonly Scope?: string | undefined;
+  readonly RegularExpressionList?:
+    | readonly SimWafRegularExpressionInput[]
+    | undefined;
+  readonly Description?: string | undefined;
+  readonly Tags?: readonly unknown[] | undefined;
+}
+
+export interface SimCreateRegexPatternSetCommandOutput {
+  readonly Summary?: SimWafSummaryOutput | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim WAFv2 GetRegexPatternSet command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/wafv2/command/GetRegexPatternSetCommand/
+ */
+export interface SimGetRegexPatternSetCommand {
+  readonly input: SimGetRegexPatternSetCommandInput;
+}
+
+export interface SimGetRegexPatternSetCommandInput {
+  readonly Name?: string | undefined;
+  readonly Scope?: string | undefined;
+  readonly Id?: string | undefined;
+}
+
+/**
+ * What GetRegexPatternSet reports about one regex pattern set.
+ */
+export interface SimWafRegexPatternSetOutput {
+  readonly Name: string;
+  readonly Id: string;
+  readonly ARN: string;
+  readonly Description: string | undefined;
+  readonly RegularExpressionList: readonly { readonly RegexString: string }[];
+}
+
+export interface SimGetRegexPatternSetCommandOutput {
+  readonly RegexPatternSet?: SimWafRegexPatternSetOutput | undefined;
+  readonly LockToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim WAFv2 ListRegexPatternSets command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/wafv2/command/ListRegexPatternSetsCommand/
+ */
+export interface SimListRegexPatternSetsCommand {
+  readonly input: SimListRegexPatternSetsCommandInput;
+}
+
+export interface SimListRegexPatternSetsCommandInput {
+  readonly Scope?: string | undefined;
+  readonly Limit?: number | undefined;
+  readonly NextMarker?: string | undefined;
+}
+
+export interface SimListRegexPatternSetsCommandOutput {
+  readonly RegexPatternSets?: readonly SimWafSummaryOutput[] | undefined;
+  readonly NextMarker?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim WAFv2 DeleteRegexPatternSet command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/wafv2/command/DeleteRegexPatternSetCommand/
+ */
+export interface SimDeleteRegexPatternSetCommand {
+  readonly input: SimDeleteRegexPatternSetCommandInput;
+}
+
+export interface SimDeleteRegexPatternSetCommandInput {
+  readonly Name?: string | undefined;
+  readonly Scope?: string | undefined;
+  readonly Id?: string | undefined;
+  readonly LockToken?: string | undefined;
+}
+
+export interface SimDeleteRegexPatternSetCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/wafv2/command/regex-pattern-set/regex-pattern-set.command.ts
+++ b/src/service/wafv2/command/regex-pattern-set/regex-pattern-set.command.ts
@@ -59,6 +59,31 @@ export interface SimGetRegexPatternSetCommandOutput {
 }
 
 /**
+ * Minimal structural sim WAFv2 UpdateRegexPatternSet command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/wafv2/command/UpdateRegexPatternSetCommand/
+ */
+export interface SimUpdateRegexPatternSetCommand {
+  readonly input: SimUpdateRegexPatternSetCommandInput;
+}
+
+export interface SimUpdateRegexPatternSetCommandInput {
+  readonly Name?: string | undefined;
+  readonly Scope?: string | undefined;
+  readonly Id?: string | undefined;
+  readonly RegularExpressionList?:
+    | readonly SimWafRegularExpressionInput[]
+    | undefined;
+  readonly Description?: string | undefined;
+  readonly LockToken?: string | undefined;
+}
+
+export interface SimUpdateRegexPatternSetCommandOutput {
+  readonly NextLockToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
  * Minimal structural sim WAFv2 ListRegexPatternSets command.
  *
  * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/wafv2/command/ListRegexPatternSetsCommand/

--- a/src/service/wafv2/command/regex-pattern-set/sim-wafv2-regex-pattern-set-commands.ts
+++ b/src/service/wafv2/command/regex-pattern-set/sim-wafv2-regex-pattern-set-commands.ts
@@ -8,6 +8,8 @@ import { refuseSimWafTags, requiredSimWafName } from "../sim-wafv2-input.js";
 import type { SimWafRequestOptions } from "../sim-wafv2-request-options.js";
 import { requireSimWafResource } from "../sim-wafv2-resource-lookup.js";
 import type {
+  SimUpdateRegexPatternSetCommand,
+  SimUpdateRegexPatternSetCommandOutput,
   SimCreateRegexPatternSetCommand,
   SimCreateRegexPatternSetCommandOutput,
   SimDeleteRegexPatternSetCommand,
@@ -103,6 +105,32 @@ export class SimWafRegexPatternSetCommands {
         })),
       },
     };
+  }
+
+  /**
+   * Write a new list of expressions over a regex pattern set.
+   *
+   * A rule pointing at the set follows it, because a reference resolves to the
+   * set and reads its expressions when a request arrives.
+   */
+  updateRegexPatternSet(
+    command: SimUpdateRegexPatternSetCommand,
+    options?: SimWafRequestOptions,
+  ): SimUpdateRegexPatternSetCommandOutput {
+    const { input } = command;
+    const patternSet = this.require(
+      input,
+      "wafv2:UpdateRegexPatternSet",
+      options,
+    );
+
+    patternSet.replaceExpressions({
+      regularExpressions: input.RegularExpressionList ?? [],
+      description: input.Description,
+      lockToken: input.LockToken,
+    });
+
+    return { $metadata: {}, NextLockToken: patternSet.lockToken };
   }
 
   /**

--- a/src/service/wafv2/command/regex-pattern-set/sim-wafv2-regex-pattern-set-commands.ts
+++ b/src/service/wafv2/command/regex-pattern-set/sim-wafv2-regex-pattern-set-commands.ts
@@ -1,0 +1,172 @@
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import { SimWafRegexPatternSet } from "../../regex-pattern-set/sim-waf-regex-pattern-set.js";
+import type { SimWafResourceStore } from "../../resource/sim-waf-resource-store.js";
+import { requiredSimWafScope } from "../../scope/sim-waf-scope.js";
+import type { SimWafAuthorizer } from "../authorize/sim-wafv2-authorizer.js";
+import { SimWafPage } from "../sim-wafv2-page.js";
+import { refuseSimWafTags, requiredSimWafName } from "../sim-wafv2-input.js";
+import type { SimWafRequestOptions } from "../sim-wafv2-request-options.js";
+import { requireSimWafResource } from "../sim-wafv2-resource-lookup.js";
+import type {
+  SimCreateRegexPatternSetCommand,
+  SimCreateRegexPatternSetCommandOutput,
+  SimDeleteRegexPatternSetCommand,
+  SimDeleteRegexPatternSetCommandOutput,
+  SimGetRegexPatternSetCommand,
+  SimGetRegexPatternSetCommandOutput,
+  SimListRegexPatternSetsCommand,
+  SimListRegexPatternSetsCommandOutput,
+} from "./regex-pattern-set.command.js";
+
+interface SimWafRegexPatternSetCommandsProperties {
+  readonly regexPatternSets: SimWafResourceStore<SimWafRegexPatternSet>;
+  readonly authorizer: SimWafAuthorizer;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * The commands that make, read, list and remove regex pattern sets.
+ *
+ * A set is what a `RegexPatternSetReferenceStatement` points at, so these are
+ * the one resource here besides the web ACL that takes part in evaluating a
+ * request.
+ */
+export class SimWafRegexPatternSetCommands {
+  readonly #regexPatternSets: SimWafResourceStore<SimWafRegexPatternSet>;
+  readonly #authorizer: SimWafAuthorizer;
+  readonly #accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimWafRegexPatternSetCommandsProperties) {
+    this.#regexPatternSets = properties.regexPatternSets;
+    this.#authorizer = properties.authorizer;
+    this.#accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Make a regex pattern set from a list of expressions.
+   */
+  createRegexPatternSet(
+    command: SimCreateRegexPatternSetCommand,
+    options?: SimWafRequestOptions,
+  ): SimCreateRegexPatternSetCommandOutput {
+    const { input } = command;
+
+    refuseSimWafTags(input.Tags, "CreateRegexPatternSet");
+
+    const patternSet = new SimWafRegexPatternSet({
+      name: requiredSimWafName(input.Name),
+      scope: requiredSimWafScope(
+        input.Scope,
+        this.#accountRegionScope.regionName,
+      ),
+      accountRegionScope: this.#accountRegionScope,
+      description: input.Description,
+      regularExpressions: input.RegularExpressionList ?? [],
+    });
+
+    this.#authorizer.authorizeResource(
+      "wafv2:CreateRegexPatternSet",
+      patternSet.arn,
+      options?.caller,
+    );
+
+    return {
+      $metadata: {},
+      Summary: this.#regexPatternSets.add(patternSet).summary(),
+    };
+  }
+
+  /**
+   * Read one regex pattern set and the token the next write to it has to
+   * present.
+   */
+  getRegexPatternSet(
+    command: SimGetRegexPatternSetCommand,
+    options?: SimWafRequestOptions,
+  ): SimGetRegexPatternSetCommandOutput {
+    const patternSet = this.require(
+      command.input,
+      "wafv2:GetRegexPatternSet",
+      options,
+    );
+
+    return {
+      $metadata: {},
+      LockToken: patternSet.lockToken,
+      RegexPatternSet: {
+        Name: patternSet.name,
+        Id: patternSet.id,
+        ARN: patternSet.arn,
+        Description: patternSet.description,
+        RegularExpressionList: patternSet.regularExpressions.map((pattern) => ({
+          RegexString: pattern,
+        })),
+      },
+    };
+  }
+
+  /**
+   * List the regex pattern sets in one scope, in the order they were created.
+   */
+  listRegexPatternSets(
+    command: SimListRegexPatternSetsCommand,
+    options?: SimWafRequestOptions,
+  ): SimListRegexPatternSetsCommandOutput {
+    const scope = requiredSimWafScope(
+      command.input.Scope,
+      this.#accountRegionScope.regionName,
+    );
+
+    this.#authorizer.authorizeNoResource(
+      "wafv2:ListRegexPatternSets",
+      options?.caller,
+    );
+
+    const page = new SimWafPage({
+      listed: this.#regexPatternSets.all(scope),
+      limit: command.input.Limit,
+      nextMarker: command.input.NextMarker,
+    });
+
+    return {
+      $metadata: {},
+      RegexPatternSets: page.items.map((patternSet) => patternSet.summary()),
+      NextMarker: page.nextMarker,
+    };
+  }
+
+  /**
+   * Remove a regex pattern set.
+   */
+  deleteRegexPatternSet(
+    command: SimDeleteRegexPatternSetCommand,
+    options?: SimWafRequestOptions,
+  ): SimDeleteRegexPatternSetCommandOutput {
+    const patternSet = this.require(
+      command.input,
+      "wafv2:DeleteRegexPatternSet",
+      options,
+    );
+
+    patternSet.takeLock(command.input.LockToken);
+    this.#regexPatternSets.remove(patternSet);
+
+    return { $metadata: {} };
+  }
+
+  private require(
+    input: SimGetRegexPatternSetCommand["input"],
+    action: string,
+    options: SimWafRequestOptions | undefined,
+  ): SimWafRegexPatternSet {
+    return requireSimWafResource({
+      store: this.#regexPatternSets,
+      input,
+      kind: "regexpatternset",
+      action,
+      authorizer: this.#authorizer,
+      accountRegionScope: this.#accountRegionScope,
+      caller: options?.caller,
+    });
+  }
+}

--- a/src/service/wafv2/command/sim-wafv2-command.types.ts
+++ b/src/service/wafv2/command/sim-wafv2-command.types.ts
@@ -14,6 +14,9 @@ export type {
   SimListIpSetsCommand,
   SimListIpSetsCommandInput,
   SimListIpSetsCommandOutput,
+  SimUpdateIpSetCommand,
+  SimUpdateIpSetCommandInput,
+  SimUpdateIpSetCommandOutput,
   SimWafIpSetOutput,
 } from "./ip-set/ip-set.command.js";
 export type {
@@ -29,6 +32,9 @@ export type {
   SimListRegexPatternSetsCommand,
   SimListRegexPatternSetsCommandInput,
   SimListRegexPatternSetsCommandOutput,
+  SimUpdateRegexPatternSetCommand,
+  SimUpdateRegexPatternSetCommandInput,
+  SimUpdateRegexPatternSetCommandOutput,
   SimWafRegexPatternSetOutput,
 } from "./regex-pattern-set/regex-pattern-set.command.js";
 export type {

--- a/src/service/wafv2/command/sim-wafv2-command.types.ts
+++ b/src/service/wafv2/command/sim-wafv2-command.types.ts
@@ -1,0 +1,53 @@
+/**
+ * The sim WAFv2 Command types, gathered for the service facade.
+ */
+export type {
+  SimCreateIpSetCommand,
+  SimCreateIpSetCommandInput,
+  SimCreateIpSetCommandOutput,
+  SimDeleteIpSetCommand,
+  SimDeleteIpSetCommandInput,
+  SimDeleteIpSetCommandOutput,
+  SimGetIpSetCommand,
+  SimGetIpSetCommandInput,
+  SimGetIpSetCommandOutput,
+  SimListIpSetsCommand,
+  SimListIpSetsCommandInput,
+  SimListIpSetsCommandOutput,
+  SimWafIpSetOutput,
+} from "./ip-set/ip-set.command.js";
+export type {
+  SimCreateRegexPatternSetCommand,
+  SimCreateRegexPatternSetCommandInput,
+  SimCreateRegexPatternSetCommandOutput,
+  SimDeleteRegexPatternSetCommand,
+  SimDeleteRegexPatternSetCommandInput,
+  SimDeleteRegexPatternSetCommandOutput,
+  SimGetRegexPatternSetCommand,
+  SimGetRegexPatternSetCommandInput,
+  SimGetRegexPatternSetCommandOutput,
+  SimListRegexPatternSetsCommand,
+  SimListRegexPatternSetsCommandInput,
+  SimListRegexPatternSetsCommandOutput,
+  SimWafRegexPatternSetOutput,
+} from "./regex-pattern-set/regex-pattern-set.command.js";
+export type {
+  SimCreateWebAclCommand,
+  SimCreateWebAclCommandInput,
+  SimCreateWebAclCommandOutput,
+  SimDeleteWebAclCommand,
+  SimDeleteWebAclCommandInput,
+  SimDeleteWebAclCommandOutput,
+  SimGetWebAclCommand,
+  SimGetWebAclCommandInput,
+  SimGetWebAclCommandOutput,
+  SimListWebAclsCommand,
+  SimListWebAclsCommandInput,
+  SimListWebAclsCommandOutput,
+  SimUpdateWebAclCommand,
+  SimUpdateWebAclCommandInput,
+  SimUpdateWebAclCommandOutput,
+  SimWafSummaryOutput,
+  SimWafWebAclOutput,
+  SimWafWebAclWriteInput,
+} from "./web-acl/web-acl.command.js";

--- a/src/service/wafv2/command/sim-wafv2-input.ts
+++ b/src/service/wafv2/command/sim-wafv2-input.ts
@@ -1,0 +1,53 @@
+import {
+  SimWafInvalidParameterException,
+  SimWafUnsimulatedInputException,
+} from "../error/sim-wafv2.error.js";
+
+/**
+ * Read the name a request named, refusing a request with none.
+ */
+export function requiredSimWafName(name: string | undefined): string {
+  if (name === undefined || name === "") {
+    throw new SimWafInvalidParameterException(
+      "Error reason: A WAFv2 resource is named, field: NAME, parameter: Name",
+    );
+  }
+
+  return name;
+}
+
+/**
+ * Read the id a request named, refusing a request with none.
+ *
+ * A name is unique within a scope, so the id looks redundant until two
+ * resources have carried the name over time. WAFv2 asks for both on every
+ * read, and so does this.
+ */
+export function requiredSimWafId(id: string | undefined): string {
+  if (id === undefined || id === "") {
+    throw new SimWafInvalidParameterException(
+      "Error reason: A WAFv2 resource read names its Id, field: RESOURCE_ID, " +
+        "parameter: Id",
+    );
+  }
+
+  return id;
+}
+
+/**
+ * Refuse tags on a WAFv2 resource.
+ *
+ * Nothing here reads a tag, and a resource that reported tags it was never
+ * asked about would be worse than one that says it does not carry them.
+ */
+export function refuseSimWafTags(
+  tags: readonly unknown[] | undefined,
+  operation: string,
+): void {
+  if (tags !== undefined && tags.length > 0) {
+    throw new SimWafUnsimulatedInputException(
+      `WAFv2 resource tags are not simulated, so ${operation} refuses them ` +
+        `rather than dropping them`,
+    );
+  }
+}

--- a/src/service/wafv2/command/sim-wafv2-page.ts
+++ b/src/service/wafv2/command/sim-wafv2-page.ts
@@ -3,7 +3,7 @@ import { SimWafInvalidParameterException } from "../error/sim-wafv2.error.js";
 /**
  * The largest page a WAFv2 listing will hand back.
  */
-const maximumLimit = 500;
+const maximumLimit = 100;
 
 interface SimWafPageProperties<T> {
   /** Everything the request selected, before paging. */

--- a/src/service/wafv2/command/sim-wafv2-page.ts
+++ b/src/service/wafv2/command/sim-wafv2-page.ts
@@ -1,0 +1,75 @@
+import { SimWafInvalidParameterException } from "../error/sim-wafv2.error.js";
+
+/**
+ * The largest page a WAFv2 listing will hand back.
+ */
+const maximumLimit = 500;
+
+interface SimWafPageProperties<T> {
+  /** Everything the request selected, before paging. */
+  readonly listed: readonly T[];
+
+  readonly limit?: number | undefined;
+  readonly nextMarker?: string | undefined;
+}
+
+/**
+ * One page of a WAFv2 listing, and the marker that reaches the next one.
+ *
+ * The marker is an offset into what the request selected. That is only
+ * meaningful against the same selection, so a marker issued elsewhere is
+ * refused rather than quietly starting again from the beginning.
+ */
+export class SimWafPage<T> {
+  readonly items: readonly T[];
+  readonly nextMarker: string | undefined;
+
+  constructor(properties: SimWafPageProperties<T>) {
+    const { listed } = properties;
+    const limit = requiredLimit(properties.limit);
+    const startIndex = pageStartIndex(properties.nextMarker, listed.length);
+    const nextIndex = startIndex + limit;
+
+    this.items = listed.slice(startIndex, nextIndex);
+    this.nextMarker =
+      nextIndex >= listed.length ? undefined : String(nextIndex);
+  }
+}
+
+function requiredLimit(requested: number | undefined): number {
+  const limit = requested ?? maximumLimit;
+
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > maximumLimit) {
+    throw new SimWafInvalidParameterException(
+      `Error reason: The limit ${String(requested)} is not between 1 and ` +
+        `${maximumLimit}, field: LIMIT, parameter: ${String(requested)}`,
+    );
+  }
+
+  return limit;
+}
+
+function pageStartIndex(
+  nextMarker: string | undefined,
+  listedCount: number,
+): number {
+  if (nextMarker === undefined) {
+    return 0;
+  }
+
+  const startIndex = Number(nextMarker);
+
+  if (
+    !Number.isSafeInteger(startIndex) ||
+    startIndex < 0 ||
+    startIndex >= listedCount ||
+    String(startIndex) !== nextMarker
+  ) {
+    throw new SimWafInvalidParameterException(
+      "Error reason: The NextMarker is not a marker this simulation issued, " +
+        `field: NEXT_MARKER, parameter: ${nextMarker}`,
+    );
+  }
+
+  return startIndex;
+}

--- a/src/service/wafv2/command/sim-wafv2-request-options.ts
+++ b/src/service/wafv2/command/sim-wafv2-request-options.ts
@@ -1,0 +1,12 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+
+/**
+ * What a simulated WAFv2 request carries besides its command input.
+ */
+export interface SimWafRequestOptions {
+  /**
+   * Who is making the request. An omitted caller is the Account root, as it is
+   * everywhere else in the simulation.
+   */
+  readonly caller?: SimAwsCaller;
+}

--- a/src/service/wafv2/command/sim-wafv2-resource-lookup.ts
+++ b/src/service/wafv2/command/sim-wafv2-resource-lookup.ts
@@ -1,0 +1,61 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimWafResource } from "../resource/sim-waf-resource.js";
+import type { SimWafResourceStore } from "../resource/sim-waf-resource-store.js";
+import { requiredSimWafScope } from "../scope/sim-waf-scope.js";
+import { type SimWafResourceKind, simWafArn } from "../sim-wafv2-arn.js";
+import type { SimWafAuthorizer } from "./authorize/sim-wafv2-authorizer.js";
+import { requiredSimWafId, requiredSimWafName } from "./sim-wafv2-input.js";
+
+/**
+ * How every read, update and delete names the resource it works on.
+ */
+export interface SimWafResourceInput {
+  readonly Name?: string | undefined;
+  readonly Scope?: string | undefined;
+  readonly Id?: string | undefined;
+}
+
+export interface SimWafResourceLookup<T extends SimWafResource> {
+  readonly store: SimWafResourceStore<T>;
+  readonly input: SimWafResourceInput;
+  readonly kind: SimWafResourceKind;
+  readonly action: string;
+  readonly authorizer: SimWafAuthorizer;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly caller?: SimAwsCaller | undefined;
+}
+
+/**
+ * Authorize a caller for one WAFv2 resource and then find it.
+ *
+ * Authorizing before looking up keeps a denial and a missing resource
+ * separate, so a caller with no permission for a web ACL never learns whether
+ * it is there. The three resource kinds all name themselves the same way,
+ * which is why one function covers all of them.
+ */
+export function requireSimWafResource<T extends SimWafResource>(
+  lookup: SimWafResourceLookup<T>,
+): T {
+  const { input } = lookup;
+  const name = requiredSimWafName(input.Name);
+  const id = requiredSimWafId(input.Id);
+  const scope = requiredSimWafScope(
+    input.Scope,
+    lookup.accountRegionScope.regionName,
+  );
+
+  lookup.authorizer.authorizeResource(
+    lookup.action,
+    simWafArn({
+      accountRegionScope: lookup.accountRegionScope,
+      scope,
+      kind: lookup.kind,
+      name,
+      id,
+    }),
+    lookup.caller,
+  );
+
+  return lookup.store.require({ scope, name, id });
+}

--- a/src/service/wafv2/command/web-acl/sim-waf-create-web-acl.factory.ts
+++ b/src/service/wafv2/command/web-acl/sim-waf-create-web-acl.factory.ts
@@ -1,0 +1,21 @@
+import { faker } from "@faker-js/faker";
+import { DynamicFactory } from "@kensio/part-factory";
+
+import { simWafVisibilityConfig } from "../../web-acl/sim-waf-rule.factory.js";
+import type { SimCreateWebAclCommandInput } from "./web-acl.command.js";
+
+/**
+ * Makes minimally valid CreateWebACL inputs.
+ *
+ * The web ACL allows what no rule claims and holds no rules at all, so a test
+ * adds the rules it is about and says nothing about the rest. Names are
+ * generated because a name is unique within a scope, and two tests sharing one
+ * would fail each other rather than themselves.
+ */
+export const simWafCreateWebAclFactory =
+  new DynamicFactory<SimCreateWebAclCommandInput>(() => ({
+    Name: `acl-${faker.string.alphanumeric(8)}`,
+    Scope: "REGIONAL",
+    DefaultAction: { Allow: {} },
+    VisibilityConfig: simWafVisibilityConfig,
+  }));

--- a/src/service/wafv2/command/web-acl/sim-wafv2-unsimulated-web-acl-input.ts
+++ b/src/service/wafv2/command/web-acl/sim-wafv2-unsimulated-web-acl-input.ts
@@ -1,0 +1,68 @@
+import { SimWafUnsimulatedInputException } from "../../error/sim-wafv2.error.js";
+import { refuseSimWafTags } from "../sim-wafv2-input.js";
+import type { SimWafWebAclWriteInput } from "./web-acl.command.js";
+
+/**
+ * One web ACL member real WAFv2 takes and this simulation does not.
+ */
+type SimWafRefusedMember = readonly [
+  read: (input: SimWafWebAclWriteInput) => unknown,
+  member: string,
+  reason: string,
+];
+
+const tokenActions =
+  "the CAPTCHA and Challenge actions are answered by a browser, and nothing " +
+  "in a test does that";
+
+const refusedMembers: readonly SimWafRefusedMember[] = [
+  [(input): unknown => input.CaptchaConfig, "CaptchaConfig", tokenActions],
+  [(input): unknown => input.ChallengeConfig, "ChallengeConfig", tokenActions],
+  [(input): unknown => input.TokenDomains, "TokenDomains", tokenActions],
+  [
+    (input): unknown => input.AssociationConfig,
+    "AssociationConfig",
+    "it sets the body size a web ACL inspects for the resources it is " +
+      "associated with, and nothing is associated with a web ACL yet",
+  ],
+  [
+    (input): unknown => input.DataProtectionConfig,
+    "DataProtectionConfig",
+    "it decides what a request field looks like in logs, and web ACL logging " +
+      "is not simulated",
+  ],
+  [
+    (input): unknown => input.OnSourceDDoSProtectionConfig,
+    "OnSourceDDoSProtectionConfig",
+    "it responds to traffic volume, which a simulated request never has",
+  ],
+  [
+    (input): unknown => input.ApplicationConfig,
+    "ApplicationConfig",
+    "it configures the WAF-hosted sign-in pages, which are not simulated",
+  ],
+];
+
+/**
+ * Refuse the web ACL members this simulation does not model.
+ *
+ * Each of them changes what a web ACL does on real WAF, so accepting one and
+ * dropping it would leave the web ACL looking configured to the request that
+ * wrote it and unconfigured to every request it then evaluated.
+ */
+export function refuseUnsimulatedSimWafWebAclInput(
+  input: SimWafWebAclWriteInput,
+  operation: string,
+): void {
+  refuseSimWafTags(input.Tags, operation);
+
+  for (const [read, member, reason] of refusedMembers) {
+    if (read(input) !== undefined) {
+      throw new SimWafUnsimulatedInputException(
+        `${operation} refuses ${member}, which Yulin does not simulate: ${
+          reason
+        }`,
+      );
+    }
+  }
+}

--- a/src/service/wafv2/command/web-acl/sim-wafv2-web-acl-commands.ts
+++ b/src/service/wafv2/command/web-acl/sim-wafv2-web-acl-commands.ts
@@ -1,0 +1,211 @@
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimWafRegexPatternSet } from "../../regex-pattern-set/sim-waf-regex-pattern-set.js";
+import type { SimWafResourceStore } from "../../resource/sim-waf-resource-store.js";
+import { requiredSimWafScope } from "../../scope/sim-waf-scope.js";
+import type { SimWafWebAclConfiguration } from "../../web-acl/sim-waf-web-acl-configuration.js";
+import { SimWafWebAcl } from "../../web-acl/sim-waf-web-acl.js";
+import type { SimWafAuthorizer } from "../authorize/sim-wafv2-authorizer.js";
+import { SimWafPage } from "../sim-wafv2-page.js";
+import { requiredSimWafName } from "../sim-wafv2-input.js";
+import {
+  requireSimWafResource,
+  type SimWafResourceInput,
+} from "../sim-wafv2-resource-lookup.js";
+import type { SimWafRequestOptions } from "../sim-wafv2-request-options.js";
+import { refuseUnsimulatedSimWafWebAclInput } from "./sim-wafv2-unsimulated-web-acl-input.js";
+import type {
+  SimCreateWebAclCommand,
+  SimCreateWebAclCommandOutput,
+  SimDeleteWebAclCommand,
+  SimDeleteWebAclCommandOutput,
+  SimGetWebAclCommand,
+  SimGetWebAclCommandOutput,
+  SimListWebAclsCommand,
+  SimListWebAclsCommandOutput,
+  SimUpdateWebAclCommand,
+  SimUpdateWebAclCommandOutput,
+  SimWafWebAclWriteInput,
+} from "./web-acl.command.js";
+
+interface SimWafWebAclCommandsProperties {
+  readonly webAcls: SimWafResourceStore<SimWafWebAcl>;
+  readonly regexPatternSets: SimWafResourceStore<SimWafRegexPatternSet>;
+  readonly authorizer: SimWafAuthorizer;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * The commands that make, read, list, change and remove web ACLs.
+ *
+ * Every rule is compiled where the web ACL is written, so a statement kind
+ * this simulation cannot evaluate is refused by CreateWebACL and UpdateWebACL
+ * rather than by the request that would have been let through.
+ */
+export class SimWafWebAclCommands {
+  readonly #webAcls: SimWafResourceStore<SimWafWebAcl>;
+  readonly #regexPatternSets: SimWafResourceStore<SimWafRegexPatternSet>;
+  readonly #authorizer: SimWafAuthorizer;
+  readonly #accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimWafWebAclCommandsProperties) {
+    this.#webAcls = properties.webAcls;
+    this.#regexPatternSets = properties.regexPatternSets;
+    this.#authorizer = properties.authorizer;
+    this.#accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Make a web ACL from a default action and a list of rules.
+   */
+  createWebAcl(
+    command: SimCreateWebAclCommand,
+    options?: SimWafRequestOptions,
+  ): SimCreateWebAclCommandOutput {
+    const { input } = command;
+    const name = requiredSimWafName(input.Name);
+    const scope = requiredSimWafScope(
+      input.Scope,
+      this.#accountRegionScope.regionName,
+    );
+
+    refuseUnsimulatedSimWafWebAclInput(input, "CreateWebACL");
+
+    const webAcl = new SimWafWebAcl({
+      name,
+      scope,
+      accountRegionScope: this.#accountRegionScope,
+      description: input.Description,
+      configuration: configurationOf(input),
+      regexPatternSets: this.#regexPatternSets,
+    });
+
+    this.#authorizer.authorizeResource(
+      "wafv2:CreateWebACL",
+      webAcl.arn,
+      options?.caller,
+    );
+
+    return { $metadata: {}, Summary: this.#webAcls.add(webAcl).summary() };
+  }
+
+  /**
+   * Read one web ACL and the token the next write to it has to present.
+   */
+  getWebAcl(
+    command: SimGetWebAclCommand,
+    options?: SimWafRequestOptions,
+  ): SimGetWebAclCommandOutput {
+    const webAcl = this.require(command.input, "wafv2:GetWebACL", options);
+    const { configuration } = webAcl;
+
+    return {
+      $metadata: {},
+      LockToken: webAcl.lockToken,
+      WebACL: {
+        Name: webAcl.name,
+        Id: webAcl.id,
+        ARN: webAcl.arn,
+        Description: webAcl.description,
+        DefaultAction: configuration.defaultAction,
+        Rules: configuration.rules ?? [],
+        VisibilityConfig: configuration.visibilityConfig,
+        CustomResponseBodies: configuration.customResponseBodies,
+      },
+    };
+  }
+
+  /**
+   * Write a new default action and set of rules over a web ACL.
+   */
+  updateWebAcl(
+    command: SimUpdateWebAclCommand,
+    options?: SimWafRequestOptions,
+  ): SimUpdateWebAclCommandOutput {
+    const { input } = command;
+
+    refuseUnsimulatedSimWafWebAclInput(input, "UpdateWebACL");
+
+    const webAcl = this.require(input, "wafv2:UpdateWebACL", options);
+
+    webAcl.reconfigure(configurationOf(input), input.LockToken);
+
+    return { $metadata: {}, NextLockToken: webAcl.lockToken };
+  }
+
+  /**
+   * List the web ACLs in one scope, in the order they were created.
+   *
+   * Real WAFv2 gives this action no resource type at all, so it authorizes
+   * against `*`: a policy scoped to web ACL ARNs allows no listing, however
+   * broadly those ARNs are written.
+   */
+  listWebAcls(
+    command: SimListWebAclsCommand,
+    options?: SimWafRequestOptions,
+  ): SimListWebAclsCommandOutput {
+    const scope = requiredSimWafScope(
+      command.input.Scope,
+      this.#accountRegionScope.regionName,
+    );
+
+    this.#authorizer.authorizeNoResource("wafv2:ListWebACLs", options?.caller);
+
+    const page = new SimWafPage({
+      listed: this.#webAcls.all(scope),
+      limit: command.input.Limit,
+      nextMarker: command.input.NextMarker,
+    });
+
+    return {
+      $metadata: {},
+      WebACLs: page.items.map((webAcl) => webAcl.summary()),
+      NextMarker: page.nextMarker,
+    };
+  }
+
+  /**
+   * Remove a web ACL.
+   */
+  deleteWebAcl(
+    command: SimDeleteWebAclCommand,
+    options?: SimWafRequestOptions,
+  ): SimDeleteWebAclCommandOutput {
+    const webAcl = this.require(command.input, "wafv2:DeleteWebACL", options);
+
+    webAcl.takeLock(command.input.LockToken);
+    this.#webAcls.remove(webAcl);
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * Find a web ACL a request named, once its caller is authorized for it.
+   */
+  private require(
+    input: SimWafResourceInput,
+    action: string,
+    options: SimWafRequestOptions | undefined,
+  ): SimWafWebAcl {
+    return requireSimWafResource({
+      store: this.#webAcls,
+      input,
+      kind: "webacl",
+      action,
+      authorizer: this.#authorizer,
+      accountRegionScope: this.#accountRegionScope,
+      caller: options?.caller,
+    });
+  }
+}
+
+function configurationOf(
+  input: SimWafWebAclWriteInput,
+): SimWafWebAclConfiguration {
+  return {
+    defaultAction: input.DefaultAction,
+    rules: input.Rules,
+    customResponseBodies: input.CustomResponseBodies,
+    visibilityConfig: input.VisibilityConfig,
+    description: input.Description,
+  };
+}

--- a/src/service/wafv2/command/web-acl/web-acl.command.ts
+++ b/src/service/wafv2/command/web-acl/web-acl.command.ts
@@ -1,0 +1,147 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimWafActionInput } from "../../web-acl/sim-waf-action.type.js";
+import type { SimWafCustomResponseBodies } from "../../web-acl/sim-waf-custom-response.type.js";
+import type { SimWafRuleInput } from "../../web-acl/sim-waf-rule.type.js";
+
+/**
+ * What a listing reports about one web ACL, IP set or regex pattern set.
+ */
+export interface SimWafSummaryOutput {
+  readonly Name: string;
+  readonly Id: string;
+  readonly Description: string | undefined;
+  readonly LockToken: string;
+  readonly ARN: string;
+}
+
+/**
+ * What a web ACL is written with, shared by CreateWebACL and UpdateWebACL.
+ */
+export interface SimWafWebAclWriteInput {
+  readonly Name?: string | undefined;
+  readonly Scope?: string | undefined;
+  readonly DefaultAction?: SimWafActionInput | undefined;
+  readonly Description?: string | undefined;
+  readonly Rules?: readonly SimWafRuleInput[] | undefined;
+  readonly VisibilityConfig?: unknown;
+  readonly CustomResponseBodies?: SimWafCustomResponseBodies | undefined;
+  readonly Tags?: readonly unknown[] | undefined;
+  readonly CaptchaConfig?: unknown;
+  readonly ChallengeConfig?: unknown;
+  readonly TokenDomains?: readonly string[] | undefined;
+  readonly AssociationConfig?: unknown;
+  readonly DataProtectionConfig?: unknown;
+  readonly OnSourceDDoSProtectionConfig?: unknown;
+  readonly ApplicationConfig?: unknown;
+}
+
+/**
+ * Minimal structural sim WAFv2 CreateWebACL command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/wafv2/command/CreateWebACLCommand/
+ */
+export interface SimCreateWebAclCommand {
+  readonly input: SimCreateWebAclCommandInput;
+}
+
+export type SimCreateWebAclCommandInput = SimWafWebAclWriteInput;
+
+export interface SimCreateWebAclCommandOutput {
+  readonly Summary?: SimWafSummaryOutput | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim WAFv2 GetWebACL command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/wafv2/command/GetWebACLCommand/
+ */
+export interface SimGetWebAclCommand {
+  readonly input: SimGetWebAclCommandInput;
+}
+
+export interface SimGetWebAclCommandInput {
+  readonly Name?: string | undefined;
+  readonly Scope?: string | undefined;
+  readonly Id?: string | undefined;
+}
+
+/**
+ * What GetWebACL reports about one web ACL.
+ */
+export interface SimWafWebAclOutput {
+  readonly Name: string;
+  readonly Id: string;
+  readonly ARN: string;
+  readonly Description: string | undefined;
+  readonly DefaultAction: SimWafActionInput | undefined;
+  readonly Rules: readonly SimWafRuleInput[];
+  readonly VisibilityConfig: unknown;
+  readonly CustomResponseBodies: SimWafCustomResponseBodies | undefined;
+}
+
+export interface SimGetWebAclCommandOutput {
+  readonly WebACL?: SimWafWebAclOutput | undefined;
+  readonly LockToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim WAFv2 UpdateWebACL command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/wafv2/command/UpdateWebACLCommand/
+ */
+export interface SimUpdateWebAclCommand {
+  readonly input: SimUpdateWebAclCommandInput;
+}
+
+export interface SimUpdateWebAclCommandInput extends SimWafWebAclWriteInput {
+  readonly Id?: string | undefined;
+  readonly LockToken?: string | undefined;
+}
+
+export interface SimUpdateWebAclCommandOutput {
+  readonly NextLockToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim WAFv2 ListWebACLs command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/wafv2/command/ListWebACLsCommand/
+ */
+export interface SimListWebAclsCommand {
+  readonly input: SimListWebAclsCommandInput;
+}
+
+export interface SimListWebAclsCommandInput {
+  readonly Scope?: string | undefined;
+  readonly Limit?: number | undefined;
+  readonly NextMarker?: string | undefined;
+}
+
+export interface SimListWebAclsCommandOutput {
+  readonly WebACLs?: readonly SimWafSummaryOutput[] | undefined;
+  readonly NextMarker?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim WAFv2 DeleteWebACL command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/wafv2/command/DeleteWebACLCommand/
+ */
+export interface SimDeleteWebAclCommand {
+  readonly input: SimDeleteWebAclCommandInput;
+}
+
+export interface SimDeleteWebAclCommandInput {
+  readonly Name?: string | undefined;
+  readonly Scope?: string | undefined;
+  readonly Id?: string | undefined;
+  readonly LockToken?: string | undefined;
+}
+
+export interface SimDeleteWebAclCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/wafv2/error/sim-wafv2.error.ts
+++ b/src/service/wafv2/error/sim-wafv2.error.ts
@@ -1,0 +1,94 @@
+/**
+ * Minimal metadata shape for simulated WAFv2 errors.
+ */
+export interface SimWafErrorMetadata {
+  readonly httpStatusCode?: number;
+}
+
+/**
+ * Base class for simulated WAFv2 errors.
+ */
+export class SimWafError extends Error {
+  constructor(
+    message: string,
+    public readonly $metadata: SimWafErrorMetadata = {},
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Simulated WAFv2 WAFInvalidParameterException error.
+ *
+ * WAFv2 reports input it will not accept this way, from a missing name to two
+ * rules claiming one priority.
+ */
+export class SimWafInvalidParameterException extends SimWafError {
+  public override readonly name = "WAFInvalidParameterException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated WAFv2 WAFNonexistentItemException error.
+ *
+ * Reading, changing or deleting a web ACL, IP set or regex pattern set that is
+ * not there produces this, and so does a rule naming a regex pattern set that
+ * does not exist.
+ */
+export class SimWafNonexistentItemException extends SimWafError {
+  public override readonly name = "WAFNonexistentItemException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated WAFv2 WAFDuplicateItemException error.
+ *
+ * Names are unique within one scope, so creating a second web ACL under a name
+ * that is taken fails rather than answering with the one that exists.
+ */
+export class SimWafDuplicateItemException extends SimWafError {
+  public override readonly name = "WAFDuplicateItemException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated WAFv2 WAFOptimisticLockException error.
+ *
+ * Every WAFv2 resource carries a lock token that changes with each write, and
+ * a change made against a stale one is refused. That is how the API stops two
+ * callers overwriting each other's rules, and it is worth reproducing: code
+ * that keeps a token from an earlier read fails here the way it fails on AWS.
+ */
+export class SimWafOptimisticLockException extends SimWafError {
+  public override readonly name = "WAFOptimisticLockException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Request input that real WAFv2 takes and this simulation does not.
+ *
+ * Held apart from a validation failure because the two mean different things:
+ * one says the request is wrong, and this one says the request is right and
+ * the simulator does not go that far. A web ACL that accepted a rule it cannot
+ * evaluate would allow a request AWS blocks, and a silent hole in a security
+ * layer is worse than a missing one.
+ */
+export class SimWafUnsimulatedInputException extends SimWafError {
+  public override readonly name = "UnsimulatedInputException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}

--- a/src/service/wafv2/evaluate/sim-waf-blocked-response.ts
+++ b/src/service/wafv2/evaluate/sim-waf-blocked-response.ts
@@ -1,0 +1,53 @@
+import type { SimWafHeader } from "../web-acl/sim-waf-custom-response.type.js";
+
+/**
+ * What a blocked request is answered with.
+ */
+export interface SimWafBlockedResponse {
+  readonly statusCode: number;
+  readonly contentType: string;
+  readonly body: string;
+  readonly headers: readonly SimWafHeader[];
+}
+
+/**
+ * The body a block action with no custom response of its own answers with.
+ *
+ * Real WAF hands the blocking off to whatever the web ACL is in front of, and
+ * each of them writes its own page: CloudFront's error page, API Gateway's
+ * `{"message":"Forbidden"}`. Nothing is associated with a web ACL yet, so this
+ * is the simulator's own body until there is a fronting service to ask, and
+ * the status is the 403 all of them answer with.
+ */
+export function simWafDefaultBlockedResponse(): SimWafBlockedResponse {
+  return {
+    statusCode: 403,
+    contentType: "text/html",
+    body:
+      "<html><head><title>403 Forbidden</title></head>" +
+      "<body>Request blocked by AWS WAF.</body></html>",
+    headers: [],
+  };
+}
+
+/**
+ * Turn a blocked verdict into the HTTP response to send.
+ *
+ * This is what a serving path uses once a web ACL is in front of it, so the
+ * status, the body and the headers a custom response named all reach the
+ * client together.
+ */
+export function simWafBlockedHttpResponse(
+  blocked: SimWafBlockedResponse,
+): Response {
+  const headers = new Headers({ "content-type": blocked.contentType });
+
+  for (const header of blocked.headers) {
+    headers.set(header.name, header.value);
+  }
+
+  return new Response(blocked.body, {
+    status: blocked.statusCode,
+    headers,
+  });
+}

--- a/src/service/wafv2/evaluate/sim-waf-decision.ts
+++ b/src/service/wafv2/evaluate/sim-waf-decision.ts
@@ -1,0 +1,36 @@
+import type { SimWafHeader } from "../web-acl/sim-waf-custom-response.type.js";
+import type { SimWafBlockedResponse } from "./sim-waf-blocked-response.js";
+
+/**
+ * What a web ACL decided about one request.
+ *
+ * This is what a fronting service acts on: allow the request through, adding
+ * whatever headers the matching rules asked for, or answer with the blocked
+ * response and never reach the origin at all.
+ *
+ * The counted rules are here because that is the whole point of a `Count`
+ * action. A rule in count mode changes nothing about the request, so the only
+ * way to know it matched is to be told, and a test staging a rule before
+ * turning it on has nothing else to assert against.
+ */
+export interface SimWafDecision {
+  readonly action: "ALLOW" | "BLOCK";
+
+  readonly webAclName: string;
+  readonly webAclArn: string;
+
+  /**
+   * The rule whose terminating action decided this, or nothing when no rule
+   * matched and the web ACL's default action decided instead.
+   */
+  readonly terminatingRuleName: string | undefined;
+
+  /** The rules that matched in count mode, in the order they were evaluated. */
+  readonly countedRuleNames: readonly string[];
+
+  /** The headers to add to the request before it is forwarded. */
+  readonly insertedHeaders: readonly SimWafHeader[];
+
+  /** What to answer with, when the decision was to block. */
+  readonly blocked: SimWafBlockedResponse | undefined;
+}

--- a/src/service/wafv2/evaluate/sim-waf-inspected-request.ts
+++ b/src/service/wafv2/evaluate/sim-waf-inspected-request.ts
@@ -1,0 +1,48 @@
+/**
+ * The parts of an HTTP request a web ACL's rules are matched against.
+ *
+ * A rule reads the request rather than anything about the resource it reached,
+ * so this is everything the simulated field-to-match kinds need and nothing
+ * else. It is what the CloudFront, API Gateway and Cognito serving paths hand
+ * to a web ACL once they are associated with one.
+ */
+export interface SimWafInspectedRequest {
+  /** The request method, upper case, as WAF reports it. */
+  readonly method: string;
+
+  /** The path of the request URL, which is not its query string. */
+  readonly uriPath: string;
+
+  /** The query string with no leading `?`, undecoded. */
+  readonly queryString: string;
+
+  readonly headers: Headers;
+
+  /** The request body, or nothing when the request carried none. */
+  readonly body: Uint8Array | undefined;
+}
+
+/**
+ * Read the parts of an HTTP request that a web ACL inspects.
+ *
+ * The body is passed in rather than read here because a request body is a
+ * stream that cannot be consumed twice, and everything that serves a request in
+ * this simulator has already buffered it by the time WAF gets a look.
+ */
+export function simWafInspectedRequest(
+  request: Request,
+  body?: Uint8Array,
+): SimWafInspectedRequest {
+  const url = new URL(request.url);
+
+  return {
+    method: request.method,
+    // The pathname excludes the query string and keeps its percent encoding,
+    // which is the value real WAF compares a `UriPath` rule against. Decoding
+    // it is what the URL_DECODE text transformation is for.
+    uriPath: url.pathname,
+    queryString: url.search.replace(/^\?/u, ""),
+    headers: request.headers,
+    body,
+  };
+}

--- a/src/service/wafv2/index.ts
+++ b/src/service/wafv2/index.ts
@@ -1,0 +1,53 @@
+export { SimWafV2, type SimWafEvaluationRequest } from "./sim-wafv2.js";
+export type { SimWafV2Properties } from "./sim-wafv2-commands.js";
+export type { SimWafRequestOptions } from "./command/sim-wafv2-request-options.js";
+export {
+  type SimWafScope,
+  simWafCloudFrontRegion,
+  simWafScopePath,
+} from "./scope/sim-waf-scope.js";
+export {
+  simWafArn,
+  simWafArnPrefix,
+  type SimWafResourceKind,
+} from "./sim-wafv2-arn.js";
+export {
+  SimWafResource,
+  type SimWafResourceSummary,
+} from "./resource/sim-waf-resource.js";
+export { SimWafWebAcl } from "./web-acl/sim-waf-web-acl.js";
+export type { SimWafWebAclConfiguration } from "./web-acl/sim-waf-web-acl-configuration.js";
+export { SimWafRule } from "./web-acl/sim-waf-rule.js";
+export type { SimWafRuleInput } from "./web-acl/sim-waf-rule.type.js";
+export { SimWafAction } from "./web-acl/sim-waf-action.js";
+export type {
+  SimWafActionInput,
+  SimWafActionKind,
+} from "./web-acl/sim-waf-action.type.js";
+export type { SimWafHeader } from "./web-acl/sim-waf-custom-response.type.js";
+export {
+  SimWafIpSet,
+  type SimWafIpAddressVersion,
+} from "./ip-set/sim-waf-ip-set.js";
+export { SimWafRegexPatternSet } from "./regex-pattern-set/sim-waf-regex-pattern-set.js";
+export type { SimWafDecision } from "./evaluate/sim-waf-decision.js";
+export {
+  simWafBlockedHttpResponse,
+  type SimWafBlockedResponse,
+  simWafDefaultBlockedResponse,
+} from "./evaluate/sim-waf-blocked-response.js";
+export {
+  type SimWafInspectedRequest,
+  simWafInspectedRequest,
+} from "./evaluate/sim-waf-inspected-request.js";
+export { simWafInspectionLimitBytes } from "./statement/sim-waf-field-content.js";
+export type { SimWafStatementInput } from "./statement/sim-waf-statement.type.js";
+export {
+  SimWafDuplicateItemException,
+  SimWafError,
+  type SimWafErrorMetadata,
+  SimWafInvalidParameterException,
+  SimWafNonexistentItemException,
+  SimWafOptimisticLockException,
+  SimWafUnsimulatedInputException,
+} from "./error/sim-wafv2.error.js";

--- a/src/service/wafv2/ip-set/sim-waf-ip-set.ts
+++ b/src/service/wafv2/ip-set/sim-waf-ip-set.ts
@@ -28,16 +28,53 @@ interface SimWafIpSetProperties extends SimWafResourceProperties {
  */
 export class SimWafIpSet extends SimWafResource {
   public readonly ipAddressVersion: SimWafIpAddressVersion;
-  public readonly addresses: readonly string[];
+
+  #addresses: readonly string[];
 
   constructor(properties: SimWafIpSetProperties) {
     super("ipset", properties);
 
     this.ipAddressVersion = properties.ipAddressVersion;
-    this.addresses = properties.addresses.map((address) =>
-      checkedAddress(address, properties.ipAddressVersion),
+    this.#addresses = checkedAddresses(
+      properties.addresses,
+      properties.ipAddressVersion,
     );
   }
+
+  /**
+   * The ranges this set holds.
+   */
+  get addresses(): readonly string[] {
+    return this.#addresses;
+  }
+
+  /**
+   * Write a new list of ranges over this one.
+   *
+   * The addresses are checked before anything is replaced. A set that refuses
+   * an update keeps the ranges it had.
+   */
+  replaceAddresses(properties: {
+    readonly addresses: readonly string[];
+    readonly description?: string | undefined;
+    readonly lockToken: string | undefined;
+  }): void {
+    const addresses = checkedAddresses(
+      properties.addresses,
+      this.ipAddressVersion,
+    );
+
+    this.takeLock(properties.lockToken);
+    this.replaceDescription(properties.description);
+    this.#addresses = addresses;
+  }
+}
+
+function checkedAddresses(
+  addresses: readonly string[],
+  version: SimWafIpAddressVersion,
+): readonly string[] {
+  return addresses.map((address) => checkedAddress(address, version));
 }
 
 /**

--- a/src/service/wafv2/ip-set/sim-waf-ip-set.ts
+++ b/src/service/wafv2/ip-set/sim-waf-ip-set.ts
@@ -1,0 +1,89 @@
+import { isIPv4, isIPv6 } from "node:net";
+
+import { SimWafInvalidParameterException } from "../error/sim-wafv2.error.js";
+import {
+  SimWafResource,
+  type SimWafResourceProperties,
+} from "../resource/sim-waf-resource.js";
+
+/**
+ * Which kind of address an IP set holds. A set holds one or the other, never
+ * both, as it does on AWS.
+ */
+export type SimWafIpAddressVersion = "IPV4" | "IPV6";
+
+interface SimWafIpSetProperties extends SimWafResourceProperties {
+  readonly ipAddressVersion: SimWafIpAddressVersion;
+  readonly addresses: readonly string[];
+}
+
+/**
+ * One named list of address ranges.
+ *
+ * Nothing evaluates an IP set here, because `IPSetReferenceStatement` is
+ * refused: every request in this simulation comes from 127.0.0.1, so a rule on
+ * the client address would see one client for the whole simulation. The
+ * resource is still held, so a stack that creates one deploys and a test can
+ * read back what it created.
+ */
+export class SimWafIpSet extends SimWafResource {
+  public readonly ipAddressVersion: SimWafIpAddressVersion;
+  public readonly addresses: readonly string[];
+
+  constructor(properties: SimWafIpSetProperties) {
+    super("ipset", properties);
+
+    this.ipAddressVersion = properties.ipAddressVersion;
+    this.addresses = properties.addresses.map((address) =>
+      checkedAddress(address, properties.ipAddressVersion),
+    );
+  }
+}
+
+/**
+ * Read the address version a request named, refusing anything else.
+ */
+export function requiredSimWafIpAddressVersion(
+  version: string | undefined,
+): SimWafIpAddressVersion {
+  if (version !== "IPV4" && version !== "IPV6") {
+    throw new SimWafInvalidParameterException(
+      `Error reason: The IP address version is not valid, field: ` +
+        `IP_ADDRESS_VERSION, parameter: ${String(version)}`,
+    );
+  }
+
+  return version;
+}
+
+/**
+ * Check one address is written the way WAF wants it.
+ *
+ * WAF takes CIDR notation and nothing else, so a bare address is refused here
+ * as it is on AWS: `192.0.2.44` has to be written `192.0.2.44/32`, and that is
+ * a mistake worth meeting in a test rather than in a deployment.
+ */
+function checkedAddress(
+  address: string,
+  version: SimWafIpAddressVersion,
+): string {
+  const isAddress = version === "IPV4" ? isIPv4 : isIPv6;
+  const longestPrefix = version === "IPV4" ? 32 : 128;
+  const separator = address.lastIndexOf("/");
+  const prefixLength = Number(address.slice(separator + 1));
+
+  if (
+    separator === -1 ||
+    !isAddress(address.slice(0, separator)) ||
+    !Number.isSafeInteger(prefixLength) ||
+    prefixLength < 0 ||
+    prefixLength > longestPrefix
+  ) {
+    throw new SimWafInvalidParameterException(
+      `Error reason: The IP address ${address} is not valid ${version} CIDR ` +
+        `notation, field: IP_ADDRESS, parameter: ${address}`,
+    );
+  }
+
+  return address;
+}

--- a/src/service/wafv2/regex-pattern-set/sim-waf-regex-pattern-set.ts
+++ b/src/service/wafv2/regex-pattern-set/sim-waf-regex-pattern-set.ts
@@ -1,16 +1,12 @@
-import { SimWafInvalidParameterException } from "../error/sim-wafv2.error.js";
 import {
   SimWafResource,
   type SimWafResourceProperties,
 } from "../resource/sim-waf-resource.js";
-import { simWafRegExp } from "../statement/sim-waf-regex.js";
-
-/**
- * Minimal structural WAFv2 Regex.
- */
-export interface SimWafRegularExpressionInput {
-  readonly RegexString?: string | undefined;
-}
+import {
+  compiledSimWafExpression,
+  type SimWafRegularExpressionInput,
+  simWafPatternStrings,
+} from "./sim-waf-regular-expressions.js";
 
 interface SimWafRegexPatternSetProperties extends SimWafResourceProperties {
   readonly regularExpressions: readonly SimWafRegularExpressionInput[];
@@ -24,43 +20,55 @@ interface SimWafRegexPatternSetProperties extends SimWafResourceProperties {
  * matching nothing when a request arrives.
  */
 export class SimWafRegexPatternSet extends SimWafResource {
-  public readonly regularExpressions: readonly string[];
-  public readonly expressions: readonly RegExp[];
+  #regularExpressions: readonly string[];
+  #expressions: readonly RegExp[];
 
   constructor(properties: SimWafRegexPatternSetProperties) {
     super("regexpatternset", properties);
 
-    this.regularExpressions = properties.regularExpressions.map(
-      (regularExpression) => requiredRegexString(regularExpression),
+    this.#regularExpressions = simWafPatternStrings(
+      properties.regularExpressions,
     );
-    this.expressions = this.regularExpressions.map((pattern) =>
-      compiled(pattern),
-    );
-  }
-}
-
-function requiredRegexString(
-  regularExpression: SimWafRegularExpressionInput,
-): string {
-  if (regularExpression.RegexString === undefined) {
-    throw new SimWafInvalidParameterException(
-      "Error reason: A regular expression needs a RegexString, field: " +
-        "REGULAR_EXPRESSION, parameter: RegexString",
+    this.#expressions = this.#regularExpressions.map((pattern) =>
+      compiledSimWafExpression(pattern),
     );
   }
 
-  return regularExpression.RegexString;
-}
-
-function compiled(pattern: string): RegExp {
-  const expression = simWafRegExp(pattern);
-
-  if (expression === undefined) {
-    throw new SimWafInvalidParameterException(
-      `Error reason: The regular expression is not valid, field: ` +
-        `REGULAR_EXPRESSION, parameter: ${pattern}`,
-    );
+  /**
+   * The expressions this set holds, as they were written.
+   */
+  get regularExpressions(): readonly string[] {
+    return this.#regularExpressions;
   }
 
-  return expression;
+  /**
+   * The expressions this set holds, compiled.
+   */
+  get expressions(): readonly RegExp[] {
+    return this.#expressions;
+  }
+
+  /**
+   * Write a new list of expressions over this one.
+   *
+   * Every expression is compiled before anything is replaced. A set that
+   * refuses an update keeps the expressions it had.
+   */
+  replaceExpressions(properties: {
+    readonly regularExpressions: readonly SimWafRegularExpressionInput[];
+    readonly description?: string | undefined;
+    readonly lockToken: string | undefined;
+  }): void {
+    const patterns = simWafPatternStrings(properties.regularExpressions);
+    const expressions = patterns.map((pattern) =>
+      compiledSimWafExpression(pattern),
+    );
+
+    this.takeLock(properties.lockToken);
+    this.replaceDescription(properties.description);
+    this.#regularExpressions = patterns;
+    this.#expressions = expressions;
+  }
 }
+
+export { type SimWafRegularExpressionInput } from "./sim-waf-regular-expressions.js";

--- a/src/service/wafv2/regex-pattern-set/sim-waf-regex-pattern-set.ts
+++ b/src/service/wafv2/regex-pattern-set/sim-waf-regex-pattern-set.ts
@@ -1,0 +1,66 @@
+import { SimWafInvalidParameterException } from "../error/sim-wafv2.error.js";
+import {
+  SimWafResource,
+  type SimWafResourceProperties,
+} from "../resource/sim-waf-resource.js";
+import { simWafRegExp } from "../statement/sim-waf-regex.js";
+
+/**
+ * Minimal structural WAFv2 Regex.
+ */
+export interface SimWafRegularExpressionInput {
+  readonly RegexString?: string | undefined;
+}
+
+interface SimWafRegexPatternSetProperties extends SimWafResourceProperties {
+  readonly regularExpressions: readonly SimWafRegularExpressionInput[];
+}
+
+/**
+ * One named list of regular expressions a rule can point at.
+ *
+ * The patterns are compiled when the set is created, so an expression that
+ * will not compile is refused where it was written rather than quietly
+ * matching nothing when a request arrives.
+ */
+export class SimWafRegexPatternSet extends SimWafResource {
+  public readonly regularExpressions: readonly string[];
+  public readonly expressions: readonly RegExp[];
+
+  constructor(properties: SimWafRegexPatternSetProperties) {
+    super("regexpatternset", properties);
+
+    this.regularExpressions = properties.regularExpressions.map(
+      (regularExpression) => requiredRegexString(regularExpression),
+    );
+    this.expressions = this.regularExpressions.map((pattern) =>
+      compiled(pattern),
+    );
+  }
+}
+
+function requiredRegexString(
+  regularExpression: SimWafRegularExpressionInput,
+): string {
+  if (regularExpression.RegexString === undefined) {
+    throw new SimWafInvalidParameterException(
+      "Error reason: A regular expression needs a RegexString, field: " +
+        "REGULAR_EXPRESSION, parameter: RegexString",
+    );
+  }
+
+  return regularExpression.RegexString;
+}
+
+function compiled(pattern: string): RegExp {
+  const expression = simWafRegExp(pattern);
+
+  if (expression === undefined) {
+    throw new SimWafInvalidParameterException(
+      `Error reason: The regular expression is not valid, field: ` +
+        `REGULAR_EXPRESSION, parameter: ${pattern}`,
+    );
+  }
+
+  return expression;
+}

--- a/src/service/wafv2/regex-pattern-set/sim-waf-regular-expressions.ts
+++ b/src/service/wafv2/regex-pattern-set/sim-waf-regular-expressions.ts
@@ -1,0 +1,49 @@
+import { SimWafInvalidParameterException } from "../error/sim-wafv2.error.js";
+import { simWafRegExp } from "../statement/sim-waf-regex.js";
+
+/**
+ * Minimal structural WAFv2 Regex.
+ */
+export interface SimWafRegularExpressionInput {
+  readonly RegexString?: string | undefined;
+}
+
+/**
+ * Read the expressions a pattern set was written with.
+ */
+export function simWafPatternStrings(
+  regularExpressions: readonly SimWafRegularExpressionInput[],
+): readonly string[] {
+  return regularExpressions.map((regularExpression) =>
+    requiredRegexString(regularExpression),
+  );
+}
+
+function requiredRegexString(
+  regularExpression: SimWafRegularExpressionInput,
+): string {
+  if (regularExpression.RegexString === undefined) {
+    throw new SimWafInvalidParameterException(
+      "Error reason: A regular expression needs a RegexString, field: " +
+        "REGULAR_EXPRESSION, parameter: RegexString",
+    );
+  }
+
+  return regularExpression.RegexString;
+}
+
+/**
+ * Compile one expression, refusing one that will not compile.
+ */
+export function compiledSimWafExpression(pattern: string): RegExp {
+  const expression = simWafRegExp(pattern);
+
+  if (expression === undefined) {
+    throw new SimWafInvalidParameterException(
+      `Error reason: The regular expression is not valid, field: ` +
+        `REGULAR_EXPRESSION, parameter: ${pattern}`,
+    );
+  }
+
+  return expression;
+}

--- a/src/service/wafv2/resource/sim-waf-resource-store.ts
+++ b/src/service/wafv2/resource/sim-waf-resource-store.ts
@@ -1,0 +1,112 @@
+import {
+  SimWafDuplicateItemException,
+  SimWafNonexistentItemException,
+} from "../error/sim-wafv2.error.js";
+import type { SimWafScope } from "../scope/sim-waf-scope.js";
+import type { SimWafResource } from "./sim-waf-resource.js";
+
+/**
+ * How one WAFv2 resource is asked for.
+ *
+ * All three reads take the same three parts, because a name is unique within a
+ * scope but is not on its own what a resource is: the id says which of two
+ * resources created under that name over time this one is.
+ */
+export interface SimWafResourceKey {
+  readonly scope: SimWafScope;
+  readonly name: string;
+  readonly id?: string | undefined;
+}
+
+/**
+ * The WAFv2 resources of one kind in one account and region.
+ *
+ * `CLOUDFRONT` and `REGIONAL` are separate namespaces here as on AWS, which is
+ * why the scope is part of every lookup rather than a property to filter on.
+ */
+export class SimWafResourceStore<T extends SimWafResource> {
+  readonly #kindLabel: string;
+  readonly #resources = new Map<string, T>();
+
+  constructor(kindLabel: string) {
+    this.#kindLabel = kindLabel;
+  }
+
+  /**
+   * Every resource in one scope, in the order they were created.
+   */
+  all(scope: SimWafScope): readonly T[] {
+    return this.#resources
+      .values()
+      .filter((resource) => resource.scope === scope)
+      .toArray();
+  }
+
+  /**
+   * Hold a new resource, refusing a name that is taken.
+   */
+  add(resource: T): T {
+    const key = storeKey(resource.scope, resource.name);
+
+    if (this.#resources.has(key)) {
+      throw new SimWafDuplicateItemException(
+        `AWS WAF couldn't perform the operation because some resource in ` +
+          `your account already has the name ${resource.name}.`,
+      );
+    }
+
+    this.#resources.set(key, resource);
+
+    return resource;
+  }
+
+  /**
+   * Find a resource, or nothing when the scope, name and id name none.
+   */
+  find(key: SimWafResourceKey): T | undefined {
+    const found = this.#resources.get(storeKey(key.scope, key.name));
+
+    if (found === undefined || (key.id !== undefined && found.id !== key.id)) {
+      return undefined;
+    }
+
+    return found;
+  }
+
+  /**
+   * Find a resource by its ARN, or nothing when this store holds none.
+   *
+   * A rule referring to another WAFv2 resource carries its ARN and nothing
+   * else, which is what this is for.
+   */
+  findByArn(arn: string): T | undefined {
+    return this.#resources.values().find((resource) => resource.arn === arn);
+  }
+
+  /**
+   * Get a resource, refusing one that is not there.
+   */
+  require(key: SimWafResourceKey): T {
+    const found = this.find(key);
+
+    if (found === undefined) {
+      throw new SimWafNonexistentItemException(
+        `AWS WAF couldn't perform the operation because your resource ` +
+          `doesn't exist: ${this.#kindLabel} ${key.name}.`,
+      );
+    }
+
+    return found;
+  }
+
+  /**
+   * Remove a resource.
+   */
+  remove(resource: T): void {
+    this.#resources.delete(storeKey(resource.scope, resource.name));
+  }
+}
+
+function storeKey(scope: SimWafScope, name: string): string {
+  return `${scope}:${name}`;
+}

--- a/src/service/wafv2/resource/sim-waf-resource.ts
+++ b/src/service/wafv2/resource/sim-waf-resource.ts
@@ -1,0 +1,110 @@
+import { randomUUID } from "node:crypto";
+
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { SimWafOptimisticLockException } from "../error/sim-wafv2.error.js";
+import { type SimWafResourceKind, simWafArn } from "../sim-wafv2-arn.js";
+import type { SimWafScope } from "../scope/sim-waf-scope.js";
+
+/**
+ * What every WAFv2 resource reports about itself in a listing.
+ */
+export interface SimWafResourceSummary {
+  readonly Name: string;
+  readonly Id: string;
+  readonly Description: string | undefined;
+  readonly LockToken: string;
+  readonly ARN: string;
+}
+
+export interface SimWafResourceProperties {
+  readonly name: string;
+  readonly scope: SimWafScope;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly description?: string | undefined;
+}
+
+/**
+ * What a web ACL, an IP set and a regex pattern set have in common.
+ *
+ * All three are named within a scope, carry a generated id that is part of
+ * their ARN, and are written through a lock token. The token is the part worth
+ * sharing rather than repeating: WAFv2 changes it on every write and refuses a
+ * write made against a stale one, which is how two callers editing the same
+ * rules find out about each other.
+ */
+export abstract class SimWafResource {
+  public readonly name: string;
+  public readonly scope: SimWafScope;
+  public readonly id: string = randomUUID();
+  public readonly arn: string;
+  #description: string | undefined;
+  #lockToken: string = randomUUID();
+
+  protected constructor(
+    kind: SimWafResourceKind,
+    properties: SimWafResourceProperties,
+  ) {
+    this.name = properties.name;
+    this.scope = properties.scope;
+    this.#description = properties.description;
+    this.arn = simWafArn({
+      accountRegionScope: properties.accountRegionScope,
+      scope: properties.scope,
+      kind,
+      name: this.name,
+      id: this.id,
+    });
+  }
+
+  /**
+   * What the resource was created or last updated with as its description.
+   */
+  get description(): string | undefined {
+    return this.#description;
+  }
+
+  /**
+   * The token the next write to this resource has to present.
+   */
+  get lockToken(): string {
+    return this.#lockToken;
+  }
+
+  /**
+   * What a listing reports about this resource.
+   */
+  summary(): SimWafResourceSummary {
+    return {
+      Name: this.name,
+      Id: this.id,
+      Description: this.#description,
+      LockToken: this.#lockToken,
+      ARN: this.arn,
+    };
+  }
+
+  /**
+   * Check the token a write presented and move it on.
+   *
+   * A caller holding a token from before somebody else's write is refused, so
+   * two changes made from the same read cannot both land.
+   */
+  takeLock(lockToken: string | undefined): void {
+    if (lockToken !== this.#lockToken) {
+      throw new SimWafOptimisticLockException(
+        `AWS WAF couldn't save your changes because someone changed the ` +
+          `resource after you started editing it. Retrieve the resource and ` +
+          `try again.`,
+      );
+    }
+
+    this.#lockToken = randomUUID();
+  }
+
+  /**
+   * Take on the description a write gave.
+   */
+  protected replaceDescription(description: string | undefined): void {
+    this.#description = description;
+  }
+}

--- a/src/service/wafv2/scope/sim-waf-scope.ts
+++ b/src/service/wafv2/scope/sim-waf-scope.ts
@@ -1,0 +1,55 @@
+import type { AwsRegionName } from "../../aws/sim-aws-region.js";
+import { SimWafInvalidParameterException } from "../error/sim-wafv2.error.js";
+
+/**
+ * Which fronting layer a WAFv2 resource is for.
+ *
+ * The two are separate namespaces rather than a label: a name is unique within
+ * one of them, and a `REGIONAL` web ACL cannot be put in front of a CloudFront
+ * distribution however it is named.
+ */
+export type SimWafScope = "CLOUDFRONT" | "REGIONAL";
+
+/**
+ * The Region every `CLOUDFRONT` scope resource lives in.
+ *
+ * CloudFront is global and its WAFv2 resources are held in `us-east-1`, so a
+ * client anywhere else has nothing to create them through.
+ */
+export const simWafCloudFrontRegion: AwsRegionName = "us-east-1";
+
+/**
+ * The part of an ARN that says which scope a resource belongs to.
+ */
+export function simWafScopePath(scope: SimWafScope): string {
+  return scope === "CLOUDFRONT" ? "global" : "regional";
+}
+
+/**
+ * Read the scope a request named, refusing anything else.
+ *
+ * A `CLOUDFRONT` scope request outside `us-east-1` is refused rather than
+ * quietly served, because a web ACL created that way would be invisible to the
+ * distribution it was written for.
+ */
+export function requiredSimWafScope(
+  scope: string | undefined,
+  regionName: AwsRegionName,
+): SimWafScope {
+  if (scope !== "CLOUDFRONT" && scope !== "REGIONAL") {
+    throw new SimWafInvalidParameterException(
+      `Error reason: The scope is not valid., field: SCOPE_VALUE, ` +
+        `parameter: ${String(scope)}`,
+    );
+  }
+
+  if (scope === "CLOUDFRONT" && regionName !== simWafCloudFrontRegion) {
+    throw new SimWafInvalidParameterException(
+      `Error reason: The scope CLOUDFRONT is only available in ` +
+        `${simWafCloudFrontRegion}, and this request was made in ` +
+        `${regionName}., field: SCOPE_VALUE, parameter: CLOUDFRONT`,
+    );
+  }
+
+  return scope;
+}

--- a/src/service/wafv2/sdk/sim-wafv2-sdk-command-router.ts
+++ b/src/service/wafv2/sdk/sim-wafv2-sdk-command-router.ts
@@ -71,6 +71,14 @@ export class SimWafSdkCommandRouter implements SimSdkCommandRouter {
           ),
       ],
       [
+        "UpdateIPSetCommand",
+        async (command, context): Promise<unknown> =>
+          await simWaf.updateIpSet(
+            command as simWafCommands.SimUpdateIpSetCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
         "ListIPSetsCommand",
         async (command, context): Promise<unknown> =>
           await simWaf.listIpSets(
@@ -99,6 +107,14 @@ export class SimWafSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simWaf.getRegexPatternSet(
             command as simWafCommands.SimGetRegexPatternSetCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "UpdateRegexPatternSetCommand",
+        async (command, context): Promise<unknown> =>
+          await simWaf.updateRegexPatternSet(
+            command as simWafCommands.SimUpdateRegexPatternSetCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/wafv2/sdk/sim-wafv2-sdk-command-router.ts
+++ b/src/service/wafv2/sdk/sim-wafv2-sdk-command-router.ts
@@ -1,0 +1,137 @@
+import {
+  simSdkCallerOptions,
+  type SimSdkCommandRoute,
+  type SimSdkCommandRouter,
+} from "../../../sdk/index.js";
+import type * as simWafCommands from "../command/sim-wafv2-command.types.js";
+import type { SimWafV2 } from "../sim-wafv2.js";
+
+/**
+ * Routes intercepted SDK Commands to one scoped simulated WAFv2.
+ */
+export class SimWafSdkCommandRouter implements SimSdkCommandRouter {
+  readonly #routes: ReadonlyMap<string, SimSdkCommandRoute>;
+
+  constructor(simWaf: SimWafV2) {
+    this.#routes = new Map<string, SimSdkCommandRoute>([
+      [
+        "CreateWebACLCommand",
+        async (command, context): Promise<unknown> =>
+          await simWaf.createWebAcl(
+            command as simWafCommands.SimCreateWebAclCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetWebACLCommand",
+        async (command, context): Promise<unknown> =>
+          await simWaf.getWebAcl(
+            command as simWafCommands.SimGetWebAclCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "UpdateWebACLCommand",
+        async (command, context): Promise<unknown> =>
+          await simWaf.updateWebAcl(
+            command as simWafCommands.SimUpdateWebAclCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListWebACLsCommand",
+        async (command, context): Promise<unknown> =>
+          await simWaf.listWebAcls(
+            command as simWafCommands.SimListWebAclsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteWebACLCommand",
+        async (command, context): Promise<unknown> =>
+          await simWaf.deleteWebAcl(
+            command as simWafCommands.SimDeleteWebAclCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "CreateIPSetCommand",
+        async (command, context): Promise<unknown> =>
+          await simWaf.createIpSet(
+            command as simWafCommands.SimCreateIpSetCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetIPSetCommand",
+        async (command, context): Promise<unknown> =>
+          await simWaf.getIpSet(
+            command as simWafCommands.SimGetIpSetCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListIPSetsCommand",
+        async (command, context): Promise<unknown> =>
+          await simWaf.listIpSets(
+            command as simWafCommands.SimListIpSetsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteIPSetCommand",
+        async (command, context): Promise<unknown> =>
+          await simWaf.deleteIpSet(
+            command as simWafCommands.SimDeleteIpSetCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "CreateRegexPatternSetCommand",
+        async (command, context): Promise<unknown> =>
+          await simWaf.createRegexPatternSet(
+            command as simWafCommands.SimCreateRegexPatternSetCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetRegexPatternSetCommand",
+        async (command, context): Promise<unknown> =>
+          await simWaf.getRegexPatternSet(
+            command as simWafCommands.SimGetRegexPatternSetCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListRegexPatternSetsCommand",
+        async (command, context): Promise<unknown> =>
+          await simWaf.listRegexPatternSets(
+            command as simWafCommands.SimListRegexPatternSetsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteRegexPatternSetCommand",
+        async (command, context): Promise<unknown> =>
+          await simWaf.deleteRegexPatternSet(
+            command as simWafCommands.SimDeleteRegexPatternSetCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+    ]);
+  }
+
+  /**
+   * The SDK Command names simulated WAFv2 can handle.
+   */
+  supportedCommandNames(): readonly string[] {
+    return this.#routes.keys().toArray();
+  }
+
+  /**
+   * Get the route for an SDK Command name, if simulated WAFv2 supports it.
+   */
+  route(commandName: string): SimSdkCommandRoute | undefined {
+    return this.#routes.get(commandName);
+  }
+}

--- a/src/service/wafv2/sdk/sim-wafv2-sdk-routing.iso.test.ts
+++ b/src/service/wafv2/sdk/sim-wafv2-sdk-routing.iso.test.ts
@@ -1,0 +1,243 @@
+import {
+  AssociateWebACLCommand,
+  CreateIPSetCommand,
+  CreateRegexPatternSetCommand,
+  CreateWebACLCommand,
+  DeleteIPSetCommand,
+  DeleteRegexPatternSetCommand,
+  DeleteWebACLCommand,
+  GetIPSetCommand,
+  GetRegexPatternSetCommand,
+  GetWebACLCommand,
+  ListIPSetsCommand,
+  ListRegexPatternSetsCommand,
+  ListWebACLsCommand,
+  UpdateWebACLCommand,
+  WAFV2Client,
+} from "@aws-sdk/client-wafv2";
+import {
+  assertArrayIncludesAll,
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimSdk, SimSdkUnsupportedCommandError } from "../../../sdk/index.js";
+import { SimAws } from "../../aws/sim-aws.js";
+
+/**
+ * A web ACL as ordinary SDK code writes one.
+ *
+ * This is written out rather than built from the test factory because the SDK
+ * Command types are stricter than the shapes simulated WAFv2 accepts, which is
+ * the point of interception: what goes in is what an application sends.
+ */
+const apiAclInput = {
+  Name: "api-acl",
+  Scope: "REGIONAL",
+  DefaultAction: { Allow: {} },
+  VisibilityConfig: {
+    SampledRequestsEnabled: false,
+    CloudWatchMetricsEnabled: false,
+    MetricName: "api",
+  },
+} as const;
+
+describe("SimWafSdkCommandRouter", () => {
+  it("names every Command simulated WAFv2 handles", () => {
+    // Given a scoped simulated WAFv2.
+    const simAws = new SimAws();
+
+    // When its supported Command names are asked for.
+    const names = simAws.wafV2().sdkCommandRouter().supportedCommandNames();
+
+    // Then each simulated operation is routable by SDK Command name.
+    assertArrayIncludesAll(names, [
+      "CreateWebACLCommand",
+      "GetWebACLCommand",
+      "UpdateWebACLCommand",
+      "ListWebACLsCommand",
+      "DeleteWebACLCommand",
+      "CreateIPSetCommand",
+      "GetIPSetCommand",
+      "ListIPSetsCommand",
+      "DeleteIPSetCommand",
+      "CreateRegexPatternSetCommand",
+      "GetRegexPatternSetCommand",
+      "ListRegexPatternSetsCommand",
+      "DeleteRegexPatternSetCommand",
+    ]);
+  });
+
+  it("has no route for a Command it does not handle", () => {
+    // Given a scoped simulated WAFv2.
+    const simAws = new SimAws();
+
+    // When a WAFv2 Command outside what is simulated is looked up.
+    const route = simAws
+      .wafV2()
+      .sdkCommandRouter()
+      .route("AssociateWebACLCommand");
+
+    // Then there is no route for it. Association follows in its own issues.
+    assertUndefined(route);
+  });
+});
+
+describe("WAFv2 SDK interception", () => {
+  it("routes an intercepted WAFV2Client to simulated WAFv2", async () => {
+    // Given an intercepted WAFv2 SDK client.
+    using simSdk = new SimSdk();
+    simSdk.intercept(WAFV2Client);
+
+    const client = new WAFV2Client({ region: "eu-west-2" });
+    const scoped = simSdk.simAws.accountRegionScope(
+      simSdk.simAws.defaultAccountId,
+      "eu-west-2",
+    );
+
+    // When ordinary SDK code creates a web ACL.
+    const created = await client.send(new CreateWebACLCommand(apiAclInput));
+
+    // Then it reached the simulated WAFv2 for the Region the client was
+    // configured for, with nothing touching the network.
+    const [webAcl] = scoped.wafV2().allWebAcls("REGIONAL");
+
+    assertNonNullable(webAcl);
+    assertIdentical(webAcl.name, "api-acl");
+    assertIdentical(webAcl.arn, created.Summary?.ARN);
+  });
+
+  it("routes every remaining Command through the intercepted client", async () => {
+    // Given an intercepted client.
+    using simSdk = new SimSdk();
+    simSdk.intercept(WAFV2Client);
+
+    const client = new WAFV2Client({ region: "eu-west-2" });
+
+    // When each of the remaining operations is used.
+    const created = await client.send(new CreateWebACLCommand(apiAclInput));
+    const read = await client.send(
+      new GetWebACLCommand({
+        Name: "api-acl",
+        Scope: "REGIONAL",
+        Id: created.Summary?.Id,
+      }),
+    );
+    const updated = await client.send(
+      new UpdateWebACLCommand({
+        ...apiAclInput,
+        Id: created.Summary?.Id,
+        LockToken: read.LockToken,
+        Description: "the public API",
+      }),
+    );
+    const listedAcls = await client.send(
+      new ListWebACLsCommand({ Scope: "REGIONAL" }),
+    );
+
+    const ipSet = await client.send(
+      new CreateIPSetCommand({
+        Name: "office",
+        Scope: "REGIONAL",
+        IPAddressVersion: "IPV4",
+        Addresses: ["192.0.2.0/24"],
+      }),
+    );
+    const readIpSet = await client.send(
+      new GetIPSetCommand({
+        Name: "office",
+        Scope: "REGIONAL",
+        Id: ipSet.Summary?.Id,
+      }),
+    );
+    const listedIpSets = await client.send(
+      new ListIPSetsCommand({ Scope: "REGIONAL" }),
+    );
+
+    const patternSet = await client.send(
+      new CreateRegexPatternSetCommand({
+        Name: "bad-agents",
+        Scope: "REGIONAL",
+        RegularExpressionList: [{ RegexString: "sqlmap" }],
+      }),
+    );
+    const readPatternSet = await client.send(
+      new GetRegexPatternSetCommand({
+        Name: "bad-agents",
+        Scope: "REGIONAL",
+        Id: patternSet.Summary?.Id,
+      }),
+    );
+    const listedPatternSets = await client.send(
+      new ListRegexPatternSetsCommand({ Scope: "REGIONAL" }),
+    );
+
+    await client.send(
+      new DeleteIPSetCommand({
+        Name: "office",
+        Scope: "REGIONAL",
+        Id: ipSet.Summary?.Id,
+        LockToken: readIpSet.LockToken,
+      }),
+    );
+    await client.send(
+      new DeleteRegexPatternSetCommand({
+        Name: "bad-agents",
+        Scope: "REGIONAL",
+        Id: patternSet.Summary?.Id,
+        LockToken: readPatternSet.LockToken,
+      }),
+    );
+    await client.send(
+      new DeleteWebACLCommand({
+        Name: "api-acl",
+        Scope: "REGIONAL",
+        Id: created.Summary?.Id,
+        LockToken: updated.NextLockToken,
+      }),
+    );
+    const afterDelete = await client.send(
+      new ListWebACLsCommand({ Scope: "REGIONAL" }),
+    );
+
+    // Then each one reached simulated WAFv2.
+    assertIdentical(read.WebACL?.Name, "api-acl");
+    assertArrayLength(listedAcls.WebACLs ?? [], 1);
+    assertIdentical(readIpSet.IPSet?.Addresses?.[0], "192.0.2.0/24");
+    assertArrayLength(listedIpSets.IPSets ?? [], 1);
+    assertIdentical(
+      readPatternSet.RegexPatternSet?.RegularExpressionList?.[0]?.RegexString,
+      "sqlmap",
+    );
+    assertArrayLength(listedPatternSets.RegexPatternSets ?? [], 1);
+    assertArrayLength(afterDelete.WebACLs ?? [], 0);
+  });
+
+  it("refuses a Command simulated WAFv2 does not handle", async () => {
+    // Given an intercepted client.
+    using simSdk = new SimSdk();
+    simSdk.intercept(WAFV2Client);
+
+    const client = new WAFV2Client({ region: "eu-west-2" });
+
+    // When it associates a web ACL with something.
+    const error = await assertThrowsErrorAsync(async () => {
+      await client.send(
+        new AssociateWebACLCommand({
+          WebACLArn: "arn:aws:wafv2:eu-west-2:111111111111:regional/webacl/x/y",
+          ResourceArn: "arn:aws:elasticloadbalancing:eu-west-2:111111111111:x",
+        }),
+      );
+    });
+
+    // Then it is refused by name rather than reaching real AWS.
+    assertInstanceOf(error, SimSdkUnsupportedCommandError);
+    assertStringIncludes(error.message, "AssociateWebACLCommand");
+  });
+});

--- a/src/service/wafv2/sdk/sim-wafv2-sdk-routing.iso.test.ts
+++ b/src/service/wafv2/sdk/sim-wafv2-sdk-routing.iso.test.ts
@@ -65,10 +65,12 @@ describe("SimWafSdkCommandRouter", () => {
       "DeleteWebACLCommand",
       "CreateIPSetCommand",
       "GetIPSetCommand",
+      "UpdateIPSetCommand",
       "ListIPSetsCommand",
       "DeleteIPSetCommand",
       "CreateRegexPatternSetCommand",
       "GetRegexPatternSetCommand",
+      "UpdateRegexPatternSetCommand",
       "ListRegexPatternSetsCommand",
       "DeleteRegexPatternSetCommand",
     ]);

--- a/src/service/wafv2/sim-wafv2-arn.ts
+++ b/src/service/wafv2/sim-wafv2-arn.ts
@@ -1,0 +1,40 @@
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import { type SimWafScope, simWafScopePath } from "./scope/sim-waf-scope.js";
+
+/**
+ * The three WAFv2 resource types this simulation holds, spelled as their ARNs
+ * spell them.
+ */
+export type SimWafResourceKind = "webacl" | "ipset" | "regexpatternset";
+
+/**
+ * The start of every WAFv2 ARN in one account, region and scope.
+ */
+export function simWafArnPrefix(
+  accountRegionScope: SimAwsAccountRegionScope,
+  scope: SimWafScope,
+): string {
+  return (
+    `arn:aws:wafv2:${accountRegionScope.regionName}:` +
+    `${accountRegionScope.accountId}:${simWafScopePath(scope)}/`
+  );
+}
+
+/**
+ * The ARN of one WAFv2 resource.
+ *
+ * The id is part of the name, which is why every read takes both: two web ACLs
+ * created under the same name at different times are different resources, and
+ * only the id tells them apart.
+ */
+export function simWafArn(properties: {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly scope: SimWafScope;
+  readonly kind: SimWafResourceKind;
+  readonly name: string;
+  readonly id: string;
+}): string {
+  const { accountRegionScope, scope, kind, name, id } = properties;
+
+  return `${simWafArnPrefix(accountRegionScope, scope)}${kind}/${name}/${id}`;
+}

--- a/src/service/wafv2/sim-wafv2-commands.ts
+++ b/src/service/wafv2/sim-wafv2-commands.ts
@@ -1,0 +1,73 @@
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../util/background/background.js";
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimWafAuthorizer } from "./command/authorize/sim-wafv2-authorizer.js";
+import { SimWafIpSetCommands } from "./command/ip-set/sim-wafv2-ip-set-commands.js";
+import { SimWafRegexPatternSetCommands } from "./command/regex-pattern-set/sim-wafv2-regex-pattern-set-commands.js";
+import { SimWafWebAclCommands } from "./command/web-acl/sim-wafv2-web-acl-commands.js";
+import type { SimWafIpSet } from "./ip-set/sim-waf-ip-set.js";
+import type { SimWafRegexPatternSet } from "./regex-pattern-set/sim-waf-regex-pattern-set.js";
+import { SimWafResourceStore } from "./resource/sim-waf-resource-store.js";
+import type { SimWafWebAcl } from "./web-acl/sim-waf-web-acl.js";
+
+export interface SimWafV2Properties {
+  readonly accountRegionScope?: SimAwsAccountRegionScope;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * The collaborators one simulated WAFv2 scope is built from.
+ *
+ * Held apart from SimWafV2 for the reason simulated SES holds its own: the
+ * facade is one method per SDK Command and grows by one with every operation
+ * added, so the wiring deciding what those methods delegate to needs somewhere
+ * it is not competing for room with them.
+ */
+export class SimWafCommands {
+  readonly webAcls = new SimWafResourceStore<SimWafWebAcl>("web ACL");
+  readonly ipSets = new SimWafResourceStore<SimWafIpSet>("IP set");
+  readonly regexPatternSets = new SimWafResourceStore<SimWafRegexPatternSet>(
+    "regex pattern set",
+  );
+
+  readonly webAclCommands: SimWafWebAclCommands;
+  readonly ipSetCommands: SimWafIpSetCommands;
+  readonly regexPatternSetCommands: SimWafRegexPatternSetCommands;
+  readonly background: BackgroundScheduler;
+
+  constructor(properties: SimWafV2Properties = {}) {
+    const {
+      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    const authorizer = new SimWafAuthorizer({ iam });
+
+    this.background = background;
+    this.webAclCommands = new SimWafWebAclCommands({
+      webAcls: this.webAcls,
+      regexPatternSets: this.regexPatternSets,
+      authorizer,
+      accountRegionScope,
+    });
+    this.ipSetCommands = new SimWafIpSetCommands({
+      ipSets: this.ipSets,
+      authorizer,
+      accountRegionScope,
+    });
+    this.regexPatternSetCommands = new SimWafRegexPatternSetCommands({
+      regexPatternSets: this.regexPatternSets,
+      authorizer,
+      accountRegionScope,
+    });
+  }
+}

--- a/src/service/wafv2/sim-wafv2-evaluation.iso.test.ts
+++ b/src/service/wafv2/sim-wafv2-evaluation.iso.test.ts
@@ -1,0 +1,318 @@
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertResponseStatus,
+  assertStringIncludes,
+  assertThrowsError,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import { simWafCreateWebAclFactory } from "./command/web-acl/sim-waf-create-web-acl.factory.js";
+import type { SimCreateWebAclCommandInput } from "./command/web-acl/web-acl.command.js";
+import { SimWafNonexistentItemException } from "./error/sim-wafv2.error.js";
+import { simWafBlockedHttpResponse } from "./evaluate/sim-waf-blocked-response.js";
+import type { SimWafDecision } from "./evaluate/sim-waf-decision.js";
+import { simWafInspectedRequest } from "./evaluate/sim-waf-inspected-request.js";
+import { createSimWafWebAcl } from "./sim-wafv2.fixture.js";
+import type { SimWafRuleInput } from "./web-acl/sim-waf-rule.type.js";
+import { simWafRuleFactory } from "./web-acl/sim-waf-rule.factory.js";
+
+/**
+ * A rule claiming every request whose path holds one string.
+ */
+function pathRule(
+  name: string,
+  priority: number,
+  path: string,
+  action: SimWafRuleInput["Action"],
+): SimWafRuleInput {
+  return {
+    ...simWafRuleFactory.make({ Name: name, Priority: priority }),
+    Action: action,
+    Statement: {
+      ByteMatchStatement: {
+        SearchString: path,
+        PositionalConstraint: "CONTAINS",
+        FieldToMatch: { UriPath: {} },
+        TextTransformations: [{ Priority: 0, Type: "NONE" }],
+      },
+    },
+  };
+}
+
+/**
+ * Put one request through a web ACL made of the given rules.
+ */
+async function decide(
+  rules: readonly SimWafRuleInput[],
+  path: string,
+  webAcl: Partial<SimCreateWebAclCommandInput> = {},
+): Promise<SimWafDecision> {
+  const waf = new SimAws().wafV2();
+  const created = await createSimWafWebAcl(waf, {
+    ...simWafCreateWebAclFactory.make(),
+    ...webAcl,
+    Rules: rules,
+  });
+
+  return waf.evaluateRequest({
+    webAclArn: created.ARN,
+    request: new Request(`https://example.test${path}`),
+  });
+}
+
+describe("SimWafV2 rule evaluation", () => {
+  it("lets the first terminating match decide, in priority order", async () => {
+    // Given two rules that both claim the request, the allowing one at the
+    // lower priority and written last.
+    const rules = [
+      pathRule("block-admin", 10, "/admin", { Block: {} }),
+      pathRule("allow-health", 1, "/admin", { Allow: {} }),
+    ];
+
+    // When a request both rules claim is evaluated.
+    const decision = await decide(rules, "/admin");
+
+    // Then the lower priority decided it, whatever order the rules were
+    // written in.
+    assertIdentical(decision.action, "ALLOW");
+    assertIdentical(decision.terminatingRuleName, "allow-health");
+  });
+
+  it("gives a request no rule claims the default action", async () => {
+    // Given a web ACL that blocks one path and allows by default.
+    const rules = [pathRule("block-admin", 0, "/admin", { Block: {} })];
+
+    // When a request outside that path is evaluated.
+    const decision = await decide(rules, "/public");
+
+    // Then the default action decided, and no rule is named as having done it.
+    assertIdentical(decision.action, "ALLOW");
+    assertUndefined(decision.terminatingRuleName);
+  });
+
+  it("blocks by default when the default action says so", async () => {
+    // Given a web ACL whose default action blocks.
+    const decision = await decide([], "/anything", {
+      DefaultAction: { Block: {} },
+    });
+
+    // Then a request no rule claimed is blocked.
+    assertIdentical(decision.action, "BLOCK");
+    assertIdentical(decision.blocked?.statusCode, 403);
+  });
+
+  it("records a count match and carries on to the next rule", async () => {
+    // Given a rule in count mode ahead of one that blocks.
+    const rules = [
+      pathRule("watch-admin", 0, "/admin", { Count: {} }),
+      pathRule("block-admin", 1, "/admin", { Block: {} }),
+    ];
+
+    // When a request both claim is evaluated.
+    const decision = await decide(rules, "/admin");
+
+    // Then the count was recorded and the rule after it decided, which is what
+    // staging a rule before turning it on looks like.
+    assertArrayEquals(decision.countedRuleNames, ["watch-admin"]);
+    assertIdentical(decision.terminatingRuleName, "block-admin");
+    assertIdentical(decision.action, "BLOCK");
+  });
+
+  it("counts a match and still reaches the default action", async () => {
+    // Given only a counting rule.
+    const rules = [pathRule("watch-admin", 0, "/admin", { Count: {} })];
+
+    // When a request it claims is evaluated.
+    const decision = await decide(rules, "/admin");
+
+    // Then the request was allowed by the default action, with the match on
+    // record.
+    assertArrayEquals(decision.countedRuleNames, ["watch-admin"]);
+    assertIdentical(decision.action, "ALLOW");
+    assertUndefined(decision.terminatingRuleName);
+  });
+
+  it("answers a blocked request with WAF's own 403", async () => {
+    // Given a web ACL that blocks a path.
+    const rules = [pathRule("block-admin", 0, "/admin", { Block: {} })];
+
+    // When a request it claims is evaluated and answered.
+    const decision = await decide(rules, "/admin");
+
+    assertNonNullable(decision.blocked);
+
+    const response = simWafBlockedHttpResponse(decision.blocked);
+
+    // Then it is a 403 carrying WAF's own body.
+    assertResponseStatus(response, 403);
+    assertIdentical(response.headers.get("content-type"), "text/html");
+    assertStringIncludes(await response.text(), "403 Forbidden");
+  });
+
+  it("answers with the custom response a block action named", async () => {
+    // Given a web ACL holding a custom response body, and a rule that answers
+    // with it.
+    const rules = [
+      pathRule("block-admin", 0, "/admin", {
+        Block: {
+          CustomResponse: {
+            ResponseCode: 429,
+            CustomResponseBodyKey: "slow-down",
+            ResponseHeaders: [{ Name: "reason", Value: "too-many" }],
+          },
+        },
+      }),
+    ];
+
+    // When a request it claims is evaluated.
+    const decision = await decide(rules, "/admin", {
+      CustomResponseBodies: {
+        "slow-down": {
+          ContentType: "APPLICATION_JSON",
+          Content: '{"message":"slow down"}',
+        },
+      },
+    });
+
+    assertNonNullable(decision.blocked);
+
+    const response = simWafBlockedHttpResponse(decision.blocked);
+
+    // Then the status, the body and the header the rule named all reach the
+    // client, with WAF's own prefix on the header name.
+    assertResponseStatus(response, 429);
+    assertIdentical(response.headers.get("x-amzn-waf-reason"), "too-many");
+    assertIdentical(await response.text(), '{"message":"slow down"}');
+  });
+
+  it("keeps WAF's own body when a custom response only sets the status", async () => {
+    // Given a rule that blocks with a status of its own and no body.
+    const rules = [
+      pathRule("block-admin", 0, "/admin", {
+        Block: { CustomResponse: { ResponseCode: 503 } },
+      }),
+    ];
+
+    // When a request it claims is evaluated.
+    const decision = await decide(rules, "/admin");
+
+    // Then the status is the rule's and the body is still WAF's own.
+    assertNonNullable(decision.blocked);
+    assertIdentical(decision.blocked.statusCode, 503);
+    assertStringIncludes(decision.blocked.body, "403 Forbidden");
+  });
+
+  it("answers with an empty custom body when the web ACL holds one", async () => {
+    // Given a web ACL holding a body with a content type and no content.
+    const rules = [
+      pathRule("block-admin", 0, "/admin", {
+        Block: {
+          CustomResponse: { CustomResponseBodyKey: "silence" },
+        },
+      }),
+    ];
+
+    // When a request it claims is evaluated.
+    const decision = await decide(rules, "/admin", {
+      CustomResponseBodies: { silence: { ContentType: "TEXT_PLAIN" } },
+    });
+
+    // Then the answer carries that content type and nothing in it.
+    assertNonNullable(decision.blocked);
+    assertIdentical(decision.blocked.contentType, "text/plain");
+    assertIdentical(decision.blocked.body, "");
+  });
+
+  it("carries the headers an allow action asked to insert", async () => {
+    // Given a rule that allows and asks for a header on the way through.
+    const rules = [
+      pathRule("allow-admin", 0, "/admin", {
+        Allow: {
+          CustomRequestHandling: {
+            InsertHeaders: [{ Name: "checked" }],
+          },
+        },
+      }),
+    ];
+
+    // When a request it claims is evaluated.
+    const decision = await decide(rules, "/admin");
+
+    // Then the header is on the decision, for whatever forwards the request to
+    // add, under the prefix WAF puts on every header it inserts.
+    assertArrayEquals(
+      decision.insertedHeaders.map((header) => header.name),
+      ["x-amzn-waf-checked"],
+    );
+    assertArrayEquals(
+      decision.insertedHeaders.map((header) => header.value),
+      [""],
+    );
+  });
+
+  it("inserts no headers into a request it blocks", async () => {
+    // Given a counting rule that asks for a header, ahead of one that blocks.
+    const rules = [
+      pathRule("watch-admin", 0, "/admin", {
+        Count: {
+          CustomRequestHandling: {
+            InsertHeaders: [{ Name: "watched", Value: "yes" }],
+          },
+        },
+      }),
+      pathRule("block-admin", 1, "/admin", { Block: {} }),
+    ];
+
+    // When a request both claim is evaluated.
+    const decision = await decide(rules, "/admin");
+
+    // Then nothing is inserted, because nothing is forwarded.
+    assertArrayLength(decision.insertedHeaders, 0);
+  });
+
+  it("names the web ACL that decided", async () => {
+    // Given a web ACL with a name of its own.
+    const waf = new SimAws().wafV2();
+    const created = await createSimWafWebAcl(
+      waf,
+      simWafCreateWebAclFactory.make({ Name: "api-acl" }),
+    );
+
+    // When a request is evaluated against it.
+    const webAcl = waf.findWebAclByArn(created.ARN);
+
+    assertNonNullable(webAcl);
+
+    const request = simWafInspectedRequest(
+      new Request("https://example.test/"),
+    );
+    const decision = webAcl.evaluate(request);
+
+    // Then the decision says which web ACL reached it, which matters once a
+    // request can meet more than one.
+    assertIdentical(decision.webAclName, "api-acl");
+    assertIdentical(decision.webAclArn, created.ARN);
+  });
+
+  it("refuses to evaluate against a web ACL that is not there", () => {
+    // Given a simulated WAFv2 with nothing in it.
+    const waf = new SimAws().wafV2();
+
+    // When a request is evaluated against an ARN naming no web ACL.
+    const error = assertThrowsError(() => {
+      waf.evaluateRequest({
+        webAclArn: "arn:aws:wafv2:eu-west-2:111111111111:regional/webacl/x/y",
+        request: new Request("https://example.test/"),
+      });
+    });
+
+    // Then it is refused rather than quietly allowing the request.
+    assertInstanceOf(error, SimWafNonexistentItemException);
+  });
+});

--- a/src/service/wafv2/sim-wafv2-ip-sets.iso.test.ts
+++ b/src/service/wafv2/sim-wafv2-ip-sets.iso.test.ts
@@ -1,0 +1,275 @@
+import {
+  CreateIPSetCommand,
+  DeleteIPSetCommand,
+  GetIPSetCommand,
+  ListIPSetsCommand,
+  UpdateIPSetCommand,
+} from "@aws-sdk/client-wafv2";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import { SimWafInvalidParameterException } from "./error/sim-wafv2.error.js";
+
+describe("SimWafV2 IP sets", () => {
+  it("creates an IP set and reads it back", async () => {
+    // Given a simulated WAFv2.
+    const waf = new SimAws().wafV2();
+
+    // When an IP set is created and read back.
+    const created = await waf.createIpSet(
+      new CreateIPSetCommand({
+        Name: "office",
+        Scope: "REGIONAL",
+        IPAddressVersion: "IPV4",
+        Addresses: ["192.0.2.0/24"],
+        Description: "the office",
+      }),
+    );
+    const read = await waf.getIpSet(
+      new GetIPSetCommand({
+        Name: "office",
+        Scope: "REGIONAL",
+        Id: created.Summary?.Id,
+      }),
+    );
+
+    // Then it reports the addresses it was written with.
+    assertNonNullable(read.IPSet);
+    assertArrayEquals(read.IPSet.Addresses, ["192.0.2.0/24"]);
+    assertIdentical(read.IPSet.IPAddressVersion, "IPV4");
+    assertIdentical(read.IPSet.Description, "the office");
+    assertStringIncludes(read.IPSet.ARN, "regional/ipset/office/");
+  });
+
+  it("refuses an address that is not written as CIDR", async () => {
+    // Given a simulated WAFv2.
+    const waf = new SimAws().wafV2();
+
+    // When an IP set is created from a bare address.
+    const error = await assertThrowsErrorAsync(async () => {
+      await waf.createIpSet(
+        new CreateIPSetCommand({
+          Name: "office",
+          Scope: "REGIONAL",
+          IPAddressVersion: "IPV4",
+          Addresses: ["192.0.2.44"],
+        }),
+      );
+    });
+
+    // Then it is refused, as real WAF refuses it: `192.0.2.44` has to be
+    // written `192.0.2.44/32`.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "192.0.2.44");
+  });
+
+  it("refuses an address version it does not hold", async () => {
+    // Given a simulated WAFv2.
+    const waf = new SimAws().wafV2();
+
+    // When an IP set names neither of the two versions.
+    const error = await assertThrowsErrorAsync(async () => {
+      await waf.createIpSet({
+        input: {
+          Name: "office",
+          Scope: "REGIONAL",
+          IPAddressVersion: "IPV5",
+          Addresses: [],
+        },
+      });
+    });
+
+    // Then it is refused. A set holds one version or the other, never both.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+  });
+
+  it("holds IPv6 ranges", async () => {
+    // Given a simulated WAFv2.
+    const waf = new SimAws().wafV2();
+
+    // When an IPv6 set is created.
+    const created = await waf.createIpSet(
+      new CreateIPSetCommand({
+        Name: "office-v6",
+        Scope: "REGIONAL",
+        IPAddressVersion: "IPV6",
+        Addresses: ["2001:db8::/32"],
+      }),
+    );
+
+    // Then it is there.
+    const read = await waf.getIpSet(
+      new GetIPSetCommand({
+        Name: "office-v6",
+        Scope: "REGIONAL",
+        Id: created.Summary?.Id,
+      }),
+    );
+
+    assertArrayEquals(read.IPSet?.Addresses, ["2001:db8::/32"]);
+  });
+
+  it("lists and deletes IP sets", async () => {
+    // Given an IP set.
+    const waf = new SimAws().wafV2();
+    const created = await waf.createIpSet(
+      new CreateIPSetCommand({
+        Name: "office",
+        Scope: "REGIONAL",
+        IPAddressVersion: "IPV4",
+        Addresses: [],
+      }),
+    );
+    const listed = await waf.listIpSets(
+      new ListIPSetsCommand({ Scope: "REGIONAL" }),
+    );
+
+    // When it is deleted with its lock token.
+    await waf.deleteIpSet(
+      new DeleteIPSetCommand({
+        Name: "office",
+        Scope: "REGIONAL",
+        Id: created.Summary?.Id,
+        LockToken: created.Summary?.LockToken,
+      }),
+    );
+
+    const after = await waf.listIpSets(
+      new ListIPSetsCommand({ Scope: "REGIONAL" }),
+    );
+
+    // Then it was listed before and is gone after.
+    assertArrayEquals(
+      listed.IPSets?.map((summary) => summary.Name),
+      ["office"],
+    );
+    assertArrayEquals(after.IPSets ?? [], []);
+  });
+
+  it("creates an IP set holding no addresses yet", async () => {
+    // Given a simulated WAFv2.
+    const waf = new SimAws().wafV2();
+
+    // When an IP set is created without naming any addresses.
+    const created = await waf.createIpSet({
+      input: { Name: "office", Scope: "REGIONAL", IPAddressVersion: "IPV4" },
+    });
+    const read = await waf.getIpSet(
+      new GetIPSetCommand({
+        Name: "office",
+        Scope: "REGIONAL",
+        Id: created.Summary?.Id,
+      }),
+    );
+
+    // Then it is there and empty, which is what a set filled in later starts
+    // as.
+    assertArrayEquals(read.IPSet?.Addresses ?? [], []);
+  });
+
+  it("refuses a read that names no id", async () => {
+    // Given an IP set.
+    const waf = new SimAws().wafV2();
+
+    await waf.createIpSet(
+      new CreateIPSetCommand({
+        Name: "office",
+        Scope: "REGIONAL",
+        IPAddressVersion: "IPV4",
+        Addresses: [],
+      }),
+    );
+
+    // When it is read by name alone.
+    const error = await assertThrowsErrorAsync(async () => {
+      await waf.getIpSet({ input: { Name: "office", Scope: "REGIONAL" } });
+    });
+
+    // Then it is refused. WAFv2 asks for the id on every read, because a name
+    // can have belonged to more than one resource over time.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+  });
+
+  it("writes a new list of ranges over an IP set", async () => {
+    // Given an IP set with one range in it.
+    const waf = new SimAws().wafV2();
+    const created = await waf.createIpSet(
+      new CreateIPSetCommand({
+        Name: "office",
+        Scope: "REGIONAL",
+        IPAddressVersion: "IPV4",
+        Addresses: ["192.0.2.0/24"],
+      }),
+    );
+
+    // When it is updated with the token creation issued.
+    await waf.updateIpSet(
+      new UpdateIPSetCommand({
+        Name: "office",
+        Scope: "REGIONAL",
+        Id: created.Summary?.Id,
+        LockToken: created.Summary?.LockToken,
+        Addresses: ["198.51.100.0/24"],
+        Description: "the new office",
+      }),
+    );
+
+    const read = await waf.getIpSet(
+      new GetIPSetCommand({
+        Name: "office",
+        Scope: "REGIONAL",
+        Id: created.Summary?.Id,
+      }),
+    );
+
+    // Then the new ranges are what it holds.
+    assertNonNullable(read.IPSet);
+    assertArrayEquals(read.IPSet.Addresses, ["198.51.100.0/24"]);
+    assertIdentical(read.IPSet.Description, "the new office");
+  });
+
+  it("keeps the ranges it had when an update is refused", async () => {
+    // Given an IP set with one range in it.
+    const waf = new SimAws().wafV2();
+    const created = await waf.createIpSet(
+      new CreateIPSetCommand({
+        Name: "office",
+        Scope: "REGIONAL",
+        IPAddressVersion: "IPV4",
+        Addresses: ["192.0.2.0/24"],
+      }),
+    );
+
+    // When an update carrying an address WAF will not take is refused.
+    await assertThrowsErrorAsync(async () => {
+      await waf.updateIpSet(
+        new UpdateIPSetCommand({
+          Name: "office",
+          Scope: "REGIONAL",
+          Id: created.Summary?.Id,
+          LockToken: created.Summary?.LockToken,
+          Addresses: ["198.51.100.7"],
+        }),
+      );
+    });
+
+    const read = await waf.getIpSet(
+      new GetIPSetCommand({
+        Name: "office",
+        Scope: "REGIONAL",
+        Id: created.Summary?.Id,
+      }),
+    );
+
+    // Then the set still holds the range it had.
+    assertArrayEquals(read.IPSet?.Addresses, ["192.0.2.0/24"]);
+  });
+});

--- a/src/service/wafv2/sim-wafv2-refusals.iso.test.ts
+++ b/src/service/wafv2/sim-wafv2-refusals.iso.test.ts
@@ -1,0 +1,244 @@
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import { simWafCreateWebAclFactory } from "./command/web-acl/sim-waf-create-web-acl.factory.js";
+import type { SimCreateWebAclCommandInput } from "./command/web-acl/web-acl.command.js";
+import { SimWafUnsimulatedInputException } from "./error/sim-wafv2.error.js";
+import { createSimWafWebAcl } from "./sim-wafv2.fixture.js";
+import type { SimWafStatementInput } from "./statement/sim-waf-statement.type.js";
+import type { SimWafRuleInput } from "./web-acl/sim-waf-rule.type.js";
+import { simWafRuleFactory } from "./web-acl/sim-waf-rule.factory.js";
+
+/**
+ * Try to create a web ACL, and answer with whatever it was refused for.
+ */
+async function refusalFor(
+  webAcl: Partial<SimCreateWebAclCommandInput>,
+): Promise<Error> {
+  const waf = new SimAws().wafV2();
+
+  return await assertThrowsErrorAsync(async () => {
+    await createSimWafWebAcl(waf, {
+      ...simWafCreateWebAclFactory.make(),
+      ...webAcl,
+    });
+  });
+}
+
+/**
+ * Try to create a web ACL holding one rule, and answer with the refusal.
+ */
+async function refusalForRule(rule: SimWafRuleInput): Promise<Error> {
+  return await refusalFor({ Rules: [rule] });
+}
+
+/**
+ * Try to create a web ACL whose one rule carries a statement, and answer with
+ * the refusal.
+ */
+async function refusalForStatement(
+  statement: SimWafStatementInput,
+): Promise<Error> {
+  return await refusalForRule({
+    ...simWafRuleFactory.make({ Name: "the-rule" }),
+    Statement: statement,
+  });
+}
+
+describe("SimWafV2 refusals", () => {
+  it("refuses a rule on the client address", async () => {
+    // When a rule matches on an IP set or on a country.
+    const ipSet = await refusalForStatement({
+      IPSetReferenceStatement: {
+        ARN: "arn:aws:wafv2:eu-west-2:111111111111:regional/ipset/x/y",
+      },
+    });
+    const geo = await refusalForStatement({
+      GeoMatchStatement: { CountryCodes: ["CN"] },
+    });
+
+    // Then both are refused, naming the rule and the kind. Every request here
+    // comes from 127.0.0.1, so either rule would see one client for the whole
+    // simulation.
+    assertInstanceOf(ipSet, SimWafUnsimulatedInputException);
+    assertStringIncludes(ipSet.message, "the-rule");
+    assertStringIncludes(ipSet.message, "IPSetReferenceStatement");
+    assertStringIncludes(geo.message, "GeoMatchStatement");
+    assertStringIncludes(geo.message, "127.0.0.1");
+  });
+
+  it("refuses a rate based rule", async () => {
+    // When a rule limits by request rate.
+    const error = await refusalForStatement({
+      RateBasedStatement: { Limit: 100, AggregateKeyType: "IP" },
+    });
+
+    // Then it is refused rather than accepted and never enforced. Counting
+    // requests over a window against the simulated clock is feasible and is
+    // not part of this.
+    assertInstanceOf(error, SimWafUnsimulatedInputException);
+    assertStringIncludes(error.message, "RateBasedStatement");
+  });
+
+  it("refuses the injection detections AWS does not document", async () => {
+    // When a rule uses the SQL injection or cross-site scripting detection.
+    const sqli = await refusalForStatement({
+      SqliMatchStatement: {
+        FieldToMatch: { UriPath: {} },
+        TextTransformations: [{ Priority: 0, Type: "NONE" }],
+      },
+    });
+    const xss = await refusalForStatement({
+      XssMatchStatement: {
+        FieldToMatch: { UriPath: {} },
+        TextTransformations: [{ Priority: 0, Type: "NONE" }],
+      },
+    });
+
+    // Then both are refused: AWS publishes no description of what they detect,
+    // so a simulation of them would agree with real WAF by coincidence.
+    assertStringIncludes(sqli.message, "SqliMatchStatement");
+    assertStringIncludes(xss.message, "XssMatchStatement");
+  });
+
+  it("refuses the rule group statements", async () => {
+    // When a rule refers to a managed or customer rule group, or to a label
+    // one of them would have added.
+    const managed = await refusalForStatement({
+      ManagedRuleGroupStatement: {
+        VendorName: "AWS",
+        Name: "AWSManagedRulesCommonRuleSet",
+      },
+    });
+    const group = await refusalForStatement({
+      RuleGroupReferenceStatement: {
+        ARN: "arn:aws:wafv2:eu-west-2:111111111111:regional/rulegroup/x/y",
+      },
+    });
+    const label = await refusalForStatement({
+      LabelMatchStatement: { Scope: "LABEL", Key: "awswaf:managed:aws:x" },
+    });
+
+    // Then each is refused by name.
+    assertStringIncludes(managed.message, "ManagedRuleGroupStatement");
+    assertStringIncludes(group.message, "RuleGroupReferenceStatement");
+    assertStringIncludes(label.message, "LabelMatchStatement");
+  });
+
+  it("refuses a field to match this simulation does not read", async () => {
+    // When a rule reads a parsed JSON body.
+    const error = await refusalForStatement({
+      ByteMatchStatement: {
+        SearchString: "x",
+        PositionalConstraint: "CONTAINS",
+        FieldToMatch: {
+          JsonBody: {
+            MatchPattern: { All: {} },
+            MatchScope: "VALUE",
+            OversizeHandling: "CONTINUE",
+          },
+        },
+        TextTransformations: [{ Priority: 0, Type: "NONE" }],
+      },
+    });
+
+    // Then it is refused rather than read as a rule with no field, which would
+    // match nothing and let the request through.
+    assertInstanceOf(error, SimWafUnsimulatedInputException);
+    assertStringIncludes(error.message, "JsonBody");
+  });
+
+  it("refuses a TLS fingerprint field", async () => {
+    // When a rule reads the fingerprint of the TLS handshake.
+    const error = await refusalForStatement({
+      ByteMatchStatement: {
+        SearchString: "x",
+        PositionalConstraint: "CONTAINS",
+        FieldToMatch: { JA4Fingerprint: { FallbackBehavior: "NO_MATCH" } },
+        TextTransformations: [{ Priority: 0, Type: "NONE" }],
+      },
+    });
+
+    // Then it is refused: a request that reached a simulated service made no
+    // handshake to fingerprint.
+    assertStringIncludes(error.message, "JA4Fingerprint");
+  });
+
+  it("refuses a text transformation this simulation does not apply", async () => {
+    // When a rule asks for a transformation outside the simulated set.
+    const error = await refusalForStatement({
+      ByteMatchStatement: {
+        SearchString: "x",
+        PositionalConstraint: "CONTAINS",
+        FieldToMatch: { UriPath: {} },
+        TextTransformations: [{ Priority: 0, Type: "BASE64_DECODE" }],
+      },
+    });
+
+    // Then it is refused rather than silently left out, which would compare
+    // the raw value against a search string written for the decoded one.
+    assertInstanceOf(error, SimWafUnsimulatedInputException);
+    assertStringIncludes(error.message, "BASE64_DECODE");
+  });
+
+  it("refuses the actions that need a browser to answer them", async () => {
+    // When a rule answers with a CAPTCHA or a challenge.
+    const captcha = await refusalForRule({
+      ...simWafRuleFactory.make({ Name: "the-rule" }),
+      Action: { Captcha: {} },
+    });
+    const challenge = await refusalForRule({
+      ...simWafRuleFactory.make({ Name: "the-rule" }),
+      Action: { Challenge: {} },
+    });
+
+    // Then both are refused: a test has no browser to solve the puzzle and
+    // send the token back.
+    assertStringIncludes(captcha.message, "Captcha");
+    assertStringIncludes(challenge.message, "Challenge");
+  });
+
+  it("refuses a rule carrying labels nothing can read", async () => {
+    // When a rule adds a label.
+    const error = await refusalForRule(
+      simWafRuleFactory.make({
+        Name: "the-rule",
+        RuleLabels: [{ Name: "internal" }],
+      }),
+    );
+
+    // Then it is refused, because LabelMatchStatement arrives with the managed
+    // rule groups and nothing here would read the label.
+    assertStringIncludes(error.message, "RuleLabels");
+  });
+
+  it("refuses a web ACL member this simulation does not model", async () => {
+    // When a web ACL sets the body size its associations inspect.
+    const error = await refusalFor({
+      AssociationConfig: {
+        RequestBody: { CLOUDFRONT: { DefaultSizeInspectionLimit: "KB_16" } },
+      },
+    });
+
+    // Then it is refused, since nothing is associated with a web ACL yet.
+    assertInstanceOf(error, SimWafUnsimulatedInputException);
+    assertStringIncludes(error.message, "AssociationConfig");
+  });
+
+  it("refuses tags on a web ACL", async () => {
+    // When a web ACL is created with tags.
+    const error = await refusalFor({
+      Tags: [{ Key: "Team", Value: "payments" }],
+    });
+
+    // Then they are refused rather than dropped, because nothing here would
+    // report them back.
+    assertInstanceOf(error, SimWafUnsimulatedInputException);
+    assertStringIncludes(error.message, "tags");
+  });
+});

--- a/src/service/wafv2/sim-wafv2-regex-pattern-sets.iso.test.ts
+++ b/src/service/wafv2/sim-wafv2-regex-pattern-sets.iso.test.ts
@@ -1,20 +1,17 @@
 import {
-  CreateIPSetCommand,
   CreateRegexPatternSetCommand,
-  DeleteIPSetCommand,
   DeleteRegexPatternSetCommand,
-  GetIPSetCommand,
   GetRegexPatternSetCommand,
-  ListIPSetsCommand,
   ListRegexPatternSetsCommand,
+  UpdateRegexPatternSetCommand,
 } from "@aws-sdk/client-wafv2";
 import {
   assertArrayEquals,
-  assertIdentical,
+  assertFalse,
   assertInstanceOf,
   assertNonNullable,
-  assertStringIncludes,
   assertThrowsErrorAsync,
+  assertTrue,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
@@ -25,187 +22,7 @@ import {
   SimWafOptimisticLockException,
   SimWafUnsimulatedInputException,
 } from "./error/sim-wafv2.error.js";
-
-describe("SimWafV2 IP sets", () => {
-  it("creates an IP set and reads it back", async () => {
-    // Given a simulated WAFv2.
-    const waf = new SimAws().wafV2();
-
-    // When an IP set is created and read back.
-    const created = await waf.createIpSet(
-      new CreateIPSetCommand({
-        Name: "office",
-        Scope: "REGIONAL",
-        IPAddressVersion: "IPV4",
-        Addresses: ["192.0.2.0/24"],
-        Description: "the office",
-      }),
-    );
-    const read = await waf.getIpSet(
-      new GetIPSetCommand({
-        Name: "office",
-        Scope: "REGIONAL",
-        Id: created.Summary?.Id,
-      }),
-    );
-
-    // Then it reports the addresses it was written with.
-    assertNonNullable(read.IPSet);
-    assertArrayEquals(read.IPSet.Addresses, ["192.0.2.0/24"]);
-    assertIdentical(read.IPSet.IPAddressVersion, "IPV4");
-    assertIdentical(read.IPSet.Description, "the office");
-    assertStringIncludes(read.IPSet.ARN, "regional/ipset/office/");
-  });
-
-  it("refuses an address that is not written as CIDR", async () => {
-    // Given a simulated WAFv2.
-    const waf = new SimAws().wafV2();
-
-    // When an IP set is created from a bare address.
-    const error = await assertThrowsErrorAsync(async () => {
-      await waf.createIpSet(
-        new CreateIPSetCommand({
-          Name: "office",
-          Scope: "REGIONAL",
-          IPAddressVersion: "IPV4",
-          Addresses: ["192.0.2.44"],
-        }),
-      );
-    });
-
-    // Then it is refused, as real WAF refuses it: `192.0.2.44` has to be
-    // written `192.0.2.44/32`.
-    assertInstanceOf(error, SimWafInvalidParameterException);
-    assertStringIncludes(error.message, "192.0.2.44");
-  });
-
-  it("refuses an address version it does not hold", async () => {
-    // Given a simulated WAFv2.
-    const waf = new SimAws().wafV2();
-
-    // When an IP set names neither of the two versions.
-    const error = await assertThrowsErrorAsync(async () => {
-      await waf.createIpSet({
-        input: {
-          Name: "office",
-          Scope: "REGIONAL",
-          IPAddressVersion: "IPV5",
-          Addresses: [],
-        },
-      });
-    });
-
-    // Then it is refused. A set holds one version or the other, never both.
-    assertInstanceOf(error, SimWafInvalidParameterException);
-  });
-
-  it("holds IPv6 ranges", async () => {
-    // Given a simulated WAFv2.
-    const waf = new SimAws().wafV2();
-
-    // When an IPv6 set is created.
-    const created = await waf.createIpSet(
-      new CreateIPSetCommand({
-        Name: "office-v6",
-        Scope: "REGIONAL",
-        IPAddressVersion: "IPV6",
-        Addresses: ["2001:db8::/32"],
-      }),
-    );
-
-    // Then it is there.
-    const read = await waf.getIpSet(
-      new GetIPSetCommand({
-        Name: "office-v6",
-        Scope: "REGIONAL",
-        Id: created.Summary?.Id,
-      }),
-    );
-
-    assertArrayEquals(read.IPSet?.Addresses, ["2001:db8::/32"]);
-  });
-
-  it("lists and deletes IP sets", async () => {
-    // Given an IP set.
-    const waf = new SimAws().wafV2();
-    const created = await waf.createIpSet(
-      new CreateIPSetCommand({
-        Name: "office",
-        Scope: "REGIONAL",
-        IPAddressVersion: "IPV4",
-        Addresses: [],
-      }),
-    );
-    const listed = await waf.listIpSets(
-      new ListIPSetsCommand({ Scope: "REGIONAL" }),
-    );
-
-    // When it is deleted with its lock token.
-    await waf.deleteIpSet(
-      new DeleteIPSetCommand({
-        Name: "office",
-        Scope: "REGIONAL",
-        Id: created.Summary?.Id,
-        LockToken: created.Summary?.LockToken,
-      }),
-    );
-
-    const after = await waf.listIpSets(
-      new ListIPSetsCommand({ Scope: "REGIONAL" }),
-    );
-
-    // Then it was listed before and is gone after.
-    assertArrayEquals(
-      listed.IPSets?.map((summary) => summary.Name),
-      ["office"],
-    );
-    assertArrayEquals(after.IPSets ?? [], []);
-  });
-
-  it("creates an IP set holding no addresses yet", async () => {
-    // Given a simulated WAFv2.
-    const waf = new SimAws().wafV2();
-
-    // When an IP set is created without naming any addresses.
-    const created = await waf.createIpSet({
-      input: { Name: "office", Scope: "REGIONAL", IPAddressVersion: "IPV4" },
-    });
-    const read = await waf.getIpSet(
-      new GetIPSetCommand({
-        Name: "office",
-        Scope: "REGIONAL",
-        Id: created.Summary?.Id,
-      }),
-    );
-
-    // Then it is there and empty, which is what a set filled in later starts
-    // as.
-    assertArrayEquals(read.IPSet?.Addresses ?? [], []);
-  });
-
-  it("refuses a read that names no id", async () => {
-    // Given an IP set.
-    const waf = new SimAws().wafV2();
-
-    await waf.createIpSet(
-      new CreateIPSetCommand({
-        Name: "office",
-        Scope: "REGIONAL",
-        IPAddressVersion: "IPV4",
-        Addresses: [],
-      }),
-    );
-
-    // When it is read by name alone.
-    const error = await assertThrowsErrorAsync(async () => {
-      await waf.getIpSet({ input: { Name: "office", Scope: "REGIONAL" } });
-    });
-
-    // Then it is refused. WAFv2 asks for the id on every read, because a name
-    // can have belonged to more than one resource over time.
-    assertInstanceOf(error, SimWafInvalidParameterException);
-  });
-});
+import { simWafStatementMatches } from "./sim-wafv2.fixture.js";
 
 describe("SimWafV2 regex pattern sets", () => {
   it("creates a regex pattern set and reads it back", async () => {
@@ -386,5 +203,87 @@ describe("SimWafV2 regex pattern sets", () => {
     });
 
     assertInstanceOf(error, SimWafNonexistentItemException);
+  });
+
+  it("follows a pattern set that changes under it", async () => {
+    // Given a rule pointing at a pattern set that matches nothing yet.
+    const waf = new SimAws().wafV2();
+    const created = await waf.createRegexPatternSet(
+      new CreateRegexPatternSetCommand({
+        Name: "scanners",
+        Scope: "REGIONAL",
+        RegularExpressionList: [{ RegexString: "nikto" }],
+      }),
+    );
+
+    assertNonNullable(created.Summary);
+
+    const matches = await simWafStatementMatches(waf, {
+      RegexPatternSetReferenceStatement: {
+        ARN: created.Summary.ARN,
+        FieldToMatch: { SingleHeader: { Name: "user-agent" } },
+        TextTransformations: [{ Priority: 0, Type: "NONE" }],
+      },
+    });
+    const request = new Request("https://example.test/", {
+      headers: { "user-agent": "sqlmap" },
+    });
+
+    assertFalse(matches(request));
+
+    // When the set gains the expression the request would match.
+    await waf.updateRegexPatternSet(
+      new UpdateRegexPatternSetCommand({
+        Name: "scanners",
+        Scope: "REGIONAL",
+        Id: created.Summary.Id,
+        LockToken: created.Summary.LockToken,
+        RegularExpressionList: [{ RegexString: "sqlmap" }],
+      }),
+    );
+
+    // Then the rule follows it, without the web ACL being rewritten.
+    assertTrue(matches(request));
+  });
+
+  it("keeps the expressions it had when an update is refused", async () => {
+    // Given a pattern set with one expression in it.
+    const waf = new SimAws().wafV2();
+    const created = await waf.createRegexPatternSet(
+      new CreateRegexPatternSetCommand({
+        Name: "scanners",
+        Scope: "REGIONAL",
+        RegularExpressionList: [{ RegexString: "nikto" }],
+      }),
+    );
+
+    // When an update carrying an expression that will not compile is refused.
+    await assertThrowsErrorAsync(async () => {
+      await waf.updateRegexPatternSet(
+        new UpdateRegexPatternSetCommand({
+          Name: "scanners",
+          Scope: "REGIONAL",
+          Id: created.Summary?.Id,
+          LockToken: created.Summary?.LockToken,
+          RegularExpressionList: [{ RegexString: "(unclosed" }],
+        }),
+      );
+    });
+
+    const read = await waf.getRegexPatternSet(
+      new GetRegexPatternSetCommand({
+        Name: "scanners",
+        Scope: "REGIONAL",
+        Id: created.Summary?.Id,
+      }),
+    );
+
+    // Then the set still holds the expression it had.
+    assertArrayEquals(
+      read.RegexPatternSet?.RegularExpressionList.map(
+        (expression) => expression.RegexString,
+      ),
+      ["nikto"],
+    );
   });
 });

--- a/src/service/wafv2/sim-wafv2-sets.iso.test.ts
+++ b/src/service/wafv2/sim-wafv2-sets.iso.test.ts
@@ -1,0 +1,390 @@
+import {
+  CreateIPSetCommand,
+  CreateRegexPatternSetCommand,
+  DeleteIPSetCommand,
+  DeleteRegexPatternSetCommand,
+  GetIPSetCommand,
+  GetRegexPatternSetCommand,
+  ListIPSetsCommand,
+  ListRegexPatternSetsCommand,
+} from "@aws-sdk/client-wafv2";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import {
+  SimWafInvalidParameterException,
+  SimWafNonexistentItemException,
+  SimWafOptimisticLockException,
+  SimWafUnsimulatedInputException,
+} from "./error/sim-wafv2.error.js";
+
+describe("SimWafV2 IP sets", () => {
+  it("creates an IP set and reads it back", async () => {
+    // Given a simulated WAFv2.
+    const waf = new SimAws().wafV2();
+
+    // When an IP set is created and read back.
+    const created = await waf.createIpSet(
+      new CreateIPSetCommand({
+        Name: "office",
+        Scope: "REGIONAL",
+        IPAddressVersion: "IPV4",
+        Addresses: ["192.0.2.0/24"],
+        Description: "the office",
+      }),
+    );
+    const read = await waf.getIpSet(
+      new GetIPSetCommand({
+        Name: "office",
+        Scope: "REGIONAL",
+        Id: created.Summary?.Id,
+      }),
+    );
+
+    // Then it reports the addresses it was written with.
+    assertNonNullable(read.IPSet);
+    assertArrayEquals(read.IPSet.Addresses, ["192.0.2.0/24"]);
+    assertIdentical(read.IPSet.IPAddressVersion, "IPV4");
+    assertIdentical(read.IPSet.Description, "the office");
+    assertStringIncludes(read.IPSet.ARN, "regional/ipset/office/");
+  });
+
+  it("refuses an address that is not written as CIDR", async () => {
+    // Given a simulated WAFv2.
+    const waf = new SimAws().wafV2();
+
+    // When an IP set is created from a bare address.
+    const error = await assertThrowsErrorAsync(async () => {
+      await waf.createIpSet(
+        new CreateIPSetCommand({
+          Name: "office",
+          Scope: "REGIONAL",
+          IPAddressVersion: "IPV4",
+          Addresses: ["192.0.2.44"],
+        }),
+      );
+    });
+
+    // Then it is refused, as real WAF refuses it: `192.0.2.44` has to be
+    // written `192.0.2.44/32`.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "192.0.2.44");
+  });
+
+  it("refuses an address version it does not hold", async () => {
+    // Given a simulated WAFv2.
+    const waf = new SimAws().wafV2();
+
+    // When an IP set names neither of the two versions.
+    const error = await assertThrowsErrorAsync(async () => {
+      await waf.createIpSet({
+        input: {
+          Name: "office",
+          Scope: "REGIONAL",
+          IPAddressVersion: "IPV5",
+          Addresses: [],
+        },
+      });
+    });
+
+    // Then it is refused. A set holds one version or the other, never both.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+  });
+
+  it("holds IPv6 ranges", async () => {
+    // Given a simulated WAFv2.
+    const waf = new SimAws().wafV2();
+
+    // When an IPv6 set is created.
+    const created = await waf.createIpSet(
+      new CreateIPSetCommand({
+        Name: "office-v6",
+        Scope: "REGIONAL",
+        IPAddressVersion: "IPV6",
+        Addresses: ["2001:db8::/32"],
+      }),
+    );
+
+    // Then it is there.
+    const read = await waf.getIpSet(
+      new GetIPSetCommand({
+        Name: "office-v6",
+        Scope: "REGIONAL",
+        Id: created.Summary?.Id,
+      }),
+    );
+
+    assertArrayEquals(read.IPSet?.Addresses, ["2001:db8::/32"]);
+  });
+
+  it("lists and deletes IP sets", async () => {
+    // Given an IP set.
+    const waf = new SimAws().wafV2();
+    const created = await waf.createIpSet(
+      new CreateIPSetCommand({
+        Name: "office",
+        Scope: "REGIONAL",
+        IPAddressVersion: "IPV4",
+        Addresses: [],
+      }),
+    );
+    const listed = await waf.listIpSets(
+      new ListIPSetsCommand({ Scope: "REGIONAL" }),
+    );
+
+    // When it is deleted with its lock token.
+    await waf.deleteIpSet(
+      new DeleteIPSetCommand({
+        Name: "office",
+        Scope: "REGIONAL",
+        Id: created.Summary?.Id,
+        LockToken: created.Summary?.LockToken,
+      }),
+    );
+
+    const after = await waf.listIpSets(
+      new ListIPSetsCommand({ Scope: "REGIONAL" }),
+    );
+
+    // Then it was listed before and is gone after.
+    assertArrayEquals(
+      listed.IPSets?.map((summary) => summary.Name),
+      ["office"],
+    );
+    assertArrayEquals(after.IPSets ?? [], []);
+  });
+
+  it("creates an IP set holding no addresses yet", async () => {
+    // Given a simulated WAFv2.
+    const waf = new SimAws().wafV2();
+
+    // When an IP set is created without naming any addresses.
+    const created = await waf.createIpSet({
+      input: { Name: "office", Scope: "REGIONAL", IPAddressVersion: "IPV4" },
+    });
+    const read = await waf.getIpSet(
+      new GetIPSetCommand({
+        Name: "office",
+        Scope: "REGIONAL",
+        Id: created.Summary?.Id,
+      }),
+    );
+
+    // Then it is there and empty, which is what a set filled in later starts
+    // as.
+    assertArrayEquals(read.IPSet?.Addresses ?? [], []);
+  });
+
+  it("refuses a read that names no id", async () => {
+    // Given an IP set.
+    const waf = new SimAws().wafV2();
+
+    await waf.createIpSet(
+      new CreateIPSetCommand({
+        Name: "office",
+        Scope: "REGIONAL",
+        IPAddressVersion: "IPV4",
+        Addresses: [],
+      }),
+    );
+
+    // When it is read by name alone.
+    const error = await assertThrowsErrorAsync(async () => {
+      await waf.getIpSet({ input: { Name: "office", Scope: "REGIONAL" } });
+    });
+
+    // Then it is refused. WAFv2 asks for the id on every read, because a name
+    // can have belonged to more than one resource over time.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+  });
+});
+
+describe("SimWafV2 regex pattern sets", () => {
+  it("creates a regex pattern set and reads it back", async () => {
+    // Given a simulated WAFv2.
+    const waf = new SimAws().wafV2();
+
+    // When a pattern set is created and read back.
+    const created = await waf.createRegexPatternSet(
+      new CreateRegexPatternSetCommand({
+        Name: "bad-agents",
+        Scope: "REGIONAL",
+        RegularExpressionList: [{ RegexString: "sqlmap" }],
+      }),
+    );
+    const read = await waf.getRegexPatternSet(
+      new GetRegexPatternSetCommand({
+        Name: "bad-agents",
+        Scope: "REGIONAL",
+        Id: created.Summary?.Id,
+      }),
+    );
+
+    // Then it reports the expressions it was written with.
+    assertArrayEquals(
+      read.RegexPatternSet?.RegularExpressionList.map(
+        (expression) => expression.RegexString,
+      ),
+      ["sqlmap"],
+    );
+  });
+
+  it("creates a pattern set holding no expressions yet", async () => {
+    // Given a simulated WAFv2.
+    const waf = new SimAws().wafV2();
+
+    // When a pattern set is created without naming any expressions.
+    const created = await waf.createRegexPatternSet({
+      input: { Name: "empty", Scope: "REGIONAL" },
+    });
+    const read = await waf.getRegexPatternSet(
+      new GetRegexPatternSetCommand({
+        Name: "empty",
+        Scope: "REGIONAL",
+        Id: created.Summary?.Id,
+      }),
+    );
+
+    // Then it is there and empty.
+    assertArrayEquals(read.RegexPatternSet?.RegularExpressionList ?? [], []);
+  });
+
+  it("refuses an expression that will not compile", async () => {
+    // Given a simulated WAFv2.
+    const waf = new SimAws().wafV2();
+
+    // When a pattern set carries something that is not an expression.
+    const error = await assertThrowsErrorAsync(async () => {
+      await waf.createRegexPatternSet(
+        new CreateRegexPatternSetCommand({
+          Name: "broken",
+          Scope: "REGIONAL",
+          RegularExpressionList: [{ RegexString: "(unclosed" }],
+        }),
+      );
+    });
+
+    // Then it is refused where it was written rather than matching nothing
+    // when a request arrives.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+  });
+
+  it("refuses an expression with no pattern in it", async () => {
+    // Given a simulated WAFv2.
+    const waf = new SimAws().wafV2();
+
+    // When a pattern set carries an expression naming nothing.
+    const error = await assertThrowsErrorAsync(async () => {
+      await waf.createRegexPatternSet(
+        new CreateRegexPatternSetCommand({
+          Name: "empty",
+          Scope: "REGIONAL",
+          RegularExpressionList: [{}],
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimWafInvalidParameterException);
+  });
+
+  it("refuses tags on a pattern set", async () => {
+    // Given a simulated WAFv2.
+    const waf = new SimAws().wafV2();
+
+    // When a pattern set is created with tags.
+    const error = await assertThrowsErrorAsync(async () => {
+      await waf.createRegexPatternSet(
+        new CreateRegexPatternSetCommand({
+          Name: "tagged",
+          Scope: "REGIONAL",
+          RegularExpressionList: [],
+          Tags: [{ Key: "Team", Value: "payments" }],
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimWafUnsimulatedInputException);
+  });
+
+  it("lists and deletes regex pattern sets", async () => {
+    // Given a pattern set.
+    const waf = new SimAws().wafV2();
+    const created = await waf.createRegexPatternSet(
+      new CreateRegexPatternSetCommand({
+        Name: "bad-agents",
+        Scope: "REGIONAL",
+        RegularExpressionList: [],
+      }),
+    );
+
+    // When it is deleted with its lock token.
+    await waf.deleteRegexPatternSet(
+      new DeleteRegexPatternSetCommand({
+        Name: "bad-agents",
+        Scope: "REGIONAL",
+        Id: created.Summary?.Id,
+        LockToken: created.Summary?.LockToken,
+      }),
+    );
+
+    const after = await waf.listRegexPatternSets(
+      new ListRegexPatternSetsCommand({ Scope: "REGIONAL" }),
+    );
+
+    // Then it is gone.
+    assertArrayEquals(after.RegexPatternSets ?? [], []);
+  });
+
+  it("refuses a delete against a stale lock token", async () => {
+    // Given a pattern set that has been read once.
+    const waf = new SimAws().wafV2();
+    const created = await waf.createRegexPatternSet(
+      new CreateRegexPatternSetCommand({
+        Name: "bad-agents",
+        Scope: "REGIONAL",
+        RegularExpressionList: [],
+      }),
+    );
+
+    // When it is deleted with a token that is not the one it holds.
+    const error = await assertThrowsErrorAsync(async () => {
+      await waf.deleteRegexPatternSet(
+        new DeleteRegexPatternSetCommand({
+          Name: "bad-agents",
+          Scope: "REGIONAL",
+          Id: created.Summary?.Id,
+          LockToken: "0f5a1b2c-3d4e-5f60-7182-93a4b5c6d7e8",
+        }),
+      );
+    });
+
+    // Then it is refused and the pattern set is still there.
+    assertInstanceOf(error, SimWafOptimisticLockException);
+  });
+
+  it("refuses a read of a pattern set that is not there", async () => {
+    // Given a simulated WAFv2 with nothing in it.
+    const waf = new SimAws().wafV2();
+
+    // When one is read by a name naming none.
+    const error = await assertThrowsErrorAsync(async () => {
+      await waf.getRegexPatternSet(
+        new GetRegexPatternSetCommand({
+          Name: "missing",
+          Scope: "REGIONAL",
+          Id: "0f5a1b2c-3d4e-5f60-7182-93a4b5c6d7e8",
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimWafNonexistentItemException);
+  });
+});

--- a/src/service/wafv2/sim-wafv2-validation.iso.test.ts
+++ b/src/service/wafv2/sim-wafv2-validation.iso.test.ts
@@ -1,0 +1,282 @@
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import { simWafCreateWebAclFactory } from "./command/web-acl/sim-waf-create-web-acl.factory.js";
+import type { SimCreateWebAclCommandInput } from "./command/web-acl/web-acl.command.js";
+import { SimWafInvalidParameterException } from "./error/sim-wafv2.error.js";
+import {
+  createSimWafWebAcl,
+  simWafStatementMatches,
+} from "./sim-wafv2.fixture.js";
+import type { SimWafStatementInput } from "./statement/sim-waf-statement.type.js";
+import type { SimWafRuleInput } from "./web-acl/sim-waf-rule.type.js";
+import { simWafRuleFactory } from "./web-acl/sim-waf-rule.factory.js";
+
+/**
+ * Try to create a web ACL, and answer with what it was refused for.
+ */
+async function refusalFor(
+  webAcl: Partial<SimCreateWebAclCommandInput>,
+): Promise<Error> {
+  const waf = new SimAws().wafV2();
+
+  return await assertThrowsErrorAsync(async () => {
+    await createSimWafWebAcl(waf, {
+      ...simWafCreateWebAclFactory.make(),
+      ...webAcl,
+    });
+  });
+}
+
+/**
+ * Try to create a web ACL holding one rule, and answer with the refusal.
+ */
+async function refusalForRule(rule: SimWafRuleInput): Promise<Error> {
+  return await refusalFor({ Rules: [rule] });
+}
+
+/**
+ * Try to create a web ACL whose one rule carries a statement, and answer with
+ * the refusal.
+ */
+async function refusalForStatement(
+  statement: SimWafStatementInput,
+): Promise<Error> {
+  return await assertThrowsErrorAsync(async () => {
+    await simWafStatementMatches(new SimAws().wafV2(), statement);
+  });
+}
+
+describe("SimWafV2 input validation", () => {
+  it("refuses a web ACL with no name", async () => {
+    // When a web ACL is created with no name.
+    const error = await refusalFor({ Name: undefined });
+
+    // Then it is refused. A name is how a web ACL is read back.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+  });
+
+  it("refuses a scope it does not know", async () => {
+    // When a web ACL names neither of the two scopes.
+    const error = await refusalFor({ Scope: "EVERYWHERE" });
+
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "EVERYWHERE");
+  });
+
+  it("refuses a listing limit outside the range WAFv2 allows", async () => {
+    // Given a simulated WAFv2.
+    const waf = new SimAws().wafV2();
+
+    // When a listing asks for no items at all.
+    const error = await assertThrowsErrorAsync(async () => {
+      await waf.listWebAcls({ input: { Scope: "REGIONAL", Limit: 0 } });
+    });
+
+    assertInstanceOf(error, SimWafInvalidParameterException);
+  });
+
+  it("refuses a rule with no name, priority, statement or action", async () => {
+    // When each of the four things a rule has to say is left out.
+    const nameless = await refusalForRule({ Priority: 0 });
+    const priorityless = await refusalForRule(
+      simWafRuleFactory.make({ Name: "the-rule", Priority: 1.5 }),
+    );
+    const statementless = await refusalForRule({
+      ...simWafRuleFactory.make({ Name: "the-rule" }),
+      Statement: undefined,
+    });
+    const actionless = await refusalForRule({
+      ...simWafRuleFactory.make({ Name: "the-rule" }),
+      Action: {},
+    });
+
+    // Then each is refused rather than defaulted to something the rule did
+    // not ask for.
+    assertInstanceOf(nameless, SimWafInvalidParameterException);
+    assertStringIncludes(priorityless.message, "Priority");
+    assertStringIncludes(statementless.message, "needs a Statement");
+    assertStringIncludes(actionless.message, "no action to take");
+  });
+
+  it("refuses a rule naming two actions", async () => {
+    // When one rule both allows and blocks.
+    const error = await refusalForRule({
+      ...simWafRuleFactory.make({ Name: "the-rule" }),
+      Action: { Allow: {}, Block: {} },
+    });
+
+    // Then it is refused, rather than the order they are checked in deciding
+    // which one applies.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "one action");
+  });
+
+  it("refuses a web ACL whose default action counts", async () => {
+    // When the default action is Count.
+    const error = await refusalFor({ DefaultAction: { Count: {} } });
+
+    // Then it is refused: a default action that counted would leave every
+    // unmatched request unanswered.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "Allow or Block");
+  });
+
+  it("refuses a block action naming a response body the web ACL has not got", async () => {
+    // When a rule answers with a body key naming nothing.
+    const error = await refusalFor({
+      Rules: [
+        {
+          ...simWafRuleFactory.make({ Name: "the-rule" }),
+          Action: {
+            Block: { CustomResponse: { CustomResponseBodyKey: "missing" } },
+          },
+        },
+      ],
+    });
+
+    // Then it is refused, rather than answering with WAF's own body instead of
+    // the one the rule named.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "missing");
+  });
+
+  it("refuses a statement with nothing to match against", async () => {
+    // When a statement names no field, or a field naming no part of a request.
+    const fieldless = await refusalForStatement({
+      ByteMatchStatement: {
+        SearchString: "x",
+        PositionalConstraint: "CONTAINS",
+        TextTransformations: [{ Priority: 0, Type: "NONE" }],
+      },
+    });
+    const emptyField = await refusalForStatement({
+      ByteMatchStatement: {
+        SearchString: "x",
+        PositionalConstraint: "CONTAINS",
+        FieldToMatch: {},
+        TextTransformations: [{ Priority: 0, Type: "NONE" }],
+      },
+    });
+
+    assertStringIncludes(fieldless.message, "FieldToMatch is required");
+    assertStringIncludes(emptyField.message, "names no field");
+  });
+
+  it("refuses a byte match statement it cannot carry out", async () => {
+    // When the search string or the positional constraint is missing.
+    const searchless = await refusalForStatement({
+      ByteMatchStatement: {
+        PositionalConstraint: "CONTAINS",
+        FieldToMatch: { UriPath: {} },
+        TextTransformations: [{ Priority: 0, Type: "NONE" }],
+      },
+    });
+    const constraintless = await refusalForStatement({
+      ByteMatchStatement: {
+        SearchString: "x",
+        FieldToMatch: { UriPath: {} },
+        TextTransformations: [{ Priority: 0, Type: "NONE" }],
+      },
+    });
+
+    assertStringIncludes(searchless.message, "SearchString");
+    assertStringIncludes(constraintless.message, "positional constraint");
+  });
+
+  it("refuses a size constraint it cannot carry out", async () => {
+    // When the comparison or the size is missing.
+    const comparisonless = await refusalForStatement({
+      SizeConstraintStatement: {
+        Size: 1,
+        FieldToMatch: { UriPath: {} },
+        TextTransformations: [{ Priority: 0, Type: "NONE" }],
+      },
+    });
+    const sizeless = await refusalForStatement({
+      SizeConstraintStatement: {
+        ComparisonOperator: "GT",
+        FieldToMatch: { UriPath: {} },
+        TextTransformations: [{ Priority: 0, Type: "NONE" }],
+      },
+    });
+
+    assertStringIncludes(comparisonless.message, "comparison operator");
+    assertStringIncludes(sizeless.message, "needs a Size");
+  });
+
+  it("refuses a regular expression statement with nothing to match", async () => {
+    // When the expression or the pattern set ARN is missing.
+    const patternless = await refusalForStatement({
+      RegexMatchStatement: {
+        FieldToMatch: { UriPath: {} },
+        TextTransformations: [{ Priority: 0, Type: "NONE" }],
+      },
+    });
+    const arnless = await refusalForStatement({
+      RegexPatternSetReferenceStatement: {
+        FieldToMatch: { UriPath: {} },
+        TextTransformations: [{ Priority: 0, Type: "NONE" }],
+      },
+    });
+
+    assertStringIncludes(patternless.message, "RegexString");
+    assertStringIncludes(arnless.message, "an ARN");
+  });
+
+  it("refuses a field to match that is missing what it needs", async () => {
+    // When a named field has no name, a header set no match scope, and a body
+    // an oversize handling WAF does not offer.
+    const unnamed = await refusalForStatement(
+      byteMatch({ SingleHeader: { Name: "" } }),
+    );
+    const scopeless = await refusalForStatement(
+      byteMatch({
+        Headers: { MatchPattern: { All: {} }, OversizeHandling: "CONTINUE" },
+      }),
+    );
+    const oversize = await refusalForStatement(
+      byteMatch({ Body: { OversizeHandling: "IGNORE" } }),
+    );
+
+    assertStringIncludes(unnamed.message, "needs a Name");
+    assertStringIncludes(scopeless.message, "match scope");
+    assertStringIncludes(oversize.message, "oversize handling");
+  });
+
+  it("refuses the remaining field kinds it does not read", async () => {
+    // When a rule reads the header order or a URI fragment.
+    const headerOrder = await refusalForStatement(
+      byteMatch({ HeaderOrder: { OversizeHandling: "CONTINUE" } }),
+    );
+    const fragment = await refusalForStatement(
+      byteMatch({ UriFragment: { FallbackBehavior: "NO_MATCH" } }),
+    );
+    const ja3 = await refusalForStatement(
+      byteMatch({ JA3Fingerprint: { FallbackBehavior: "NO_MATCH" } }),
+    );
+
+    assertStringIncludes(headerOrder.message, "HeaderOrder");
+    assertStringIncludes(fragment.message, "UriFragment");
+    assertStringIncludes(ja3.message, "JA3Fingerprint");
+  });
+});
+
+/**
+ * A byte match statement pointed at whichever field the test is about.
+ */
+function byteMatch(field: unknown): SimWafStatementInput {
+  return {
+    ByteMatchStatement: {
+      SearchString: "x",
+      PositionalConstraint: "CONTAINS",
+      FieldToMatch: field as Record<string, never>,
+      TextTransformations: [{ Priority: 0, Type: "NONE" }],
+    },
+  };
+}

--- a/src/service/wafv2/sim-wafv2-validation.iso.test.ts
+++ b/src/service/wafv2/sim-wafv2-validation.iso.test.ts
@@ -146,6 +146,18 @@ describe("SimWafV2 input validation", () => {
     assertStringIncludes(error.message, "missing");
   });
 
+  it("refuses a custom header with no name", async () => {
+    // When a rule inserts a header it did not name.
+    const error = await refusalForRule({
+      ...simWafRuleFactory.make({ Name: "the-rule" }),
+      Action: { Allow: { CustomRequestHandling: { InsertHeaders: [{}] } } },
+    });
+
+    // Then it is refused, rather than inserting a header named after nothing.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "custom header");
+  });
+
   it("refuses a statement with nothing to match against", async () => {
     // When a statement names no field, or a field naming no part of a request.
     const fieldless = await refusalForStatement({

--- a/src/service/wafv2/sim-wafv2-web-acls.iso.test.ts
+++ b/src/service/wafv2/sim-wafv2-web-acls.iso.test.ts
@@ -1,0 +1,383 @@
+import {
+  DeleteWebACLCommand,
+  GetWebACLCommand,
+  ListWebACLsCommand,
+} from "@aws-sdk/client-wafv2";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import type { SimAwsAccountId } from "../aws/sim-aws-account.js";
+import { SimAws } from "../aws/sim-aws.js";
+import { simWafCreateWebAclFactory } from "./command/web-acl/sim-waf-create-web-acl.factory.js";
+import {
+  SimWafDuplicateItemException,
+  SimWafInvalidParameterException,
+  SimWafNonexistentItemException,
+  SimWafOptimisticLockException,
+} from "./error/sim-wafv2.error.js";
+import { createSimWafWebAcl } from "./sim-wafv2.fixture.js";
+import { simWafRuleFactory } from "./web-acl/sim-waf-rule.factory.js";
+
+const accountIdTwoTwos = "222222222222" as SimAwsAccountId;
+
+describe("SimWafV2 web ACLs", () => {
+  it("creates a web ACL and reads it back", async () => {
+    // Given a simulated WAFv2.
+    const waf = new SimAws().wafV2();
+    const input = simWafCreateWebAclFactory.make({
+      Description: "the public API",
+      Rules: [simWafRuleFactory.make({ Name: "block-everything" })],
+    });
+
+    // When a web ACL is created and read back.
+    const created = await createSimWafWebAcl(waf, input);
+    const read = await waf.getWebAcl(
+      new GetWebACLCommand({
+        Name: input.Name,
+        Scope: "REGIONAL",
+        Id: created.Id,
+      }),
+    );
+
+    // Then it reports the rules and the default action it was written with.
+    assertNonNullable(read.WebACL);
+    assertIdentical(read.WebACL.Name, input.Name);
+    assertIdentical(read.WebACL.Description, "the public API");
+    assertArrayEquals(
+      read.WebACL.Rules.map((rule) => rule.Name),
+      ["block-everything"],
+    );
+  });
+
+  it("names a web ACL by the account, region and scope it is in", async () => {
+    // Given a simulated WAFv2 in one account and region.
+    const waf = new SimAws()
+      .accountRegionScope(accountIdTwoTwos, "eu-west-2")
+      .wafV2();
+
+    // When a REGIONAL web ACL is created.
+    const created = await createSimWafWebAcl(
+      waf,
+      simWafCreateWebAclFactory.make({ Name: "api-acl" }),
+    );
+
+    // Then its ARN names that account, region and scope, ending with the id
+    // WAFv2 generated for it.
+    assertStringIncludes(
+      created.ARN,
+      `arn:aws:wafv2:eu-west-2:222222222222:regional/webacl/api-acl/`,
+    );
+    assertStringIncludes(created.ARN, created.Id);
+  });
+
+  it("holds a CLOUDFRONT scope web ACL in us-east-1", async () => {
+    // Given a simulated WAFv2 in us-east-1.
+    const simAws = new SimAws();
+    const waf = simAws
+      .accountRegionScope(simAws.defaultAccountId, "us-east-1")
+      .wafV2();
+
+    // When a CLOUDFRONT scope web ACL is created.
+    const created = await createSimWafWebAcl(
+      waf,
+      simWafCreateWebAclFactory.make({
+        Name: "site-acl",
+        Scope: "CLOUDFRONT",
+      }),
+    );
+
+    // Then its ARN says global, which is what a CloudFront distribution is
+    // pointed at.
+    assertStringIncludes(created.ARN, "us-east-1");
+    assertStringIncludes(created.ARN, "global/webacl/site-acl/");
+  });
+
+  it("refuses a CLOUDFRONT scope web ACL outside us-east-1", async () => {
+    // Given a simulated WAFv2 somewhere other than us-east-1.
+    const simAws = new SimAws();
+    const waf = simAws
+      .accountRegionScope(simAws.defaultAccountId, "eu-west-2")
+      .wafV2();
+
+    // When a CLOUDFRONT scope web ACL is asked for.
+    const error = await assertThrowsErrorAsync(async () => {
+      await createSimWafWebAcl(
+        waf,
+        simWafCreateWebAclFactory.make({ Scope: "CLOUDFRONT" }),
+      );
+    });
+
+    // Then it is refused, as real WAFv2 refuses it: CloudFront is global and
+    // its web ACLs are held in us-east-1.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "us-east-1");
+  });
+
+  it("keeps the two scopes in separate namespaces", async () => {
+    // Given a REGIONAL web ACL in us-east-1.
+    const simAws = new SimAws();
+    const waf = simAws
+      .accountRegionScope(simAws.defaultAccountId, "us-east-1")
+      .wafV2();
+
+    await createSimWafWebAcl(
+      waf,
+      simWafCreateWebAclFactory.make({ Name: "shared-name" }),
+    );
+
+    // When a CLOUDFRONT web ACL takes the same name.
+    await createSimWafWebAcl(
+      waf,
+      simWafCreateWebAclFactory.make({
+        Name: "shared-name",
+        Scope: "CLOUDFRONT",
+      }),
+    );
+
+    // Then both are there. A name is unique within a scope and the scopes do
+    // not see each other.
+    assertArrayLength(waf.allWebAcls("REGIONAL"), 1);
+    assertArrayLength(waf.allWebAcls("CLOUDFRONT"), 1);
+  });
+
+  it("refuses a second web ACL under a name that is taken", async () => {
+    // Given a web ACL.
+    const waf = new SimAws().wafV2();
+    const input = simWafCreateWebAclFactory.make();
+
+    await createSimWafWebAcl(waf, input);
+
+    // When another is created under the same name in the same scope.
+    const error = await assertThrowsErrorAsync(async () => {
+      await createSimWafWebAcl(waf, input);
+    });
+
+    // Then it is refused rather than answering with the one that exists.
+    assertInstanceOf(error, SimWafDuplicateItemException);
+  });
+
+  it("refuses two rules claiming one priority", async () => {
+    // Given a simulated WAFv2.
+    const waf = new SimAws().wafV2();
+
+    // When a web ACL is written with two rules at the same priority.
+    const rules = [
+      simWafRuleFactory.make({ Name: "first", Priority: 3 }),
+      simWafRuleFactory.make({ Name: "second", Priority: 3 }),
+    ];
+    const input = simWafCreateWebAclFactory.make({ Rules: rules });
+    const error = await assertThrowsErrorAsync(async () => {
+      await createSimWafWebAcl(waf, input);
+    });
+
+    // Then it is refused, as real WAF refuses it: rules run in priority order,
+    // and two rules at one priority have no order between them.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "first");
+    assertStringIncludes(error.message, "second");
+  });
+
+  it("changes a web ACL through its lock token", async () => {
+    // Given a web ACL with one rule.
+    const waf = new SimAws().wafV2();
+    const input = simWafCreateWebAclFactory.make({
+      Rules: [simWafRuleFactory.make({ Name: "first" })],
+    });
+    const created = await createSimWafWebAcl(waf, input);
+
+    // When it is updated with the token creation issued.
+    await waf.updateWebAcl({
+      input: {
+        ...input,
+        Id: created.Id,
+        LockToken: created.LockToken,
+        Rules: [simWafRuleFactory.make({ Name: "second" })],
+      },
+    });
+
+    // Then the new rules are what it holds.
+    const read = await waf.getWebAcl(
+      new GetWebACLCommand({
+        Name: input.Name,
+        Scope: "REGIONAL",
+        Id: created.Id,
+      }),
+    );
+
+    assertArrayEquals(
+      read.WebACL?.Rules.map((rule) => rule.Name),
+      ["second"],
+    );
+  });
+
+  it("refuses a change made against a stale lock token", async () => {
+    // Given a web ACL that has been written once already.
+    const waf = new SimAws().wafV2();
+    const input = simWafCreateWebAclFactory.make();
+    const created = await createSimWafWebAcl(waf, input);
+    const staleToken = created.LockToken;
+
+    await waf.updateWebAcl({
+      input: { ...input, Id: created.Id, LockToken: staleToken },
+    });
+
+    // When a second change is made from the token of the first read.
+    const error = await assertThrowsErrorAsync(async () => {
+      await waf.updateWebAcl({
+        input: { ...input, Id: created.Id, LockToken: staleToken },
+      });
+    });
+
+    // Then it is refused. That is what stops two callers editing one web ACL
+    // from the same read and only one of the changes landing.
+    assertInstanceOf(error, SimWafOptimisticLockException);
+  });
+
+  it("keeps the rules it had when an update is refused", async () => {
+    // Given a web ACL with one rule.
+    const waf = new SimAws().wafV2();
+    const input = simWafCreateWebAclFactory.make({
+      Rules: [simWafRuleFactory.make({ Name: "first" })],
+    });
+    const created = await createSimWafWebAcl(waf, input);
+
+    // When an update carrying a rule WAFv2 will not take is refused.
+    await assertThrowsErrorAsync(async () => {
+      await waf.updateWebAcl({
+        input: {
+          ...input,
+          Id: created.Id,
+          LockToken: created.LockToken,
+          Rules: [
+            {
+              ...simWafRuleFactory.make({ Name: "rate-limited" }),
+              Statement: { RateBasedStatement: { Limit: 100 } },
+            },
+          ],
+        },
+      });
+    });
+
+    // Then the web ACL still holds the rule it had, rather than being left
+    // with none.
+    const read = await waf.getWebAcl(
+      new GetWebACLCommand({
+        Name: input.Name,
+        Scope: "REGIONAL",
+        Id: created.Id,
+      }),
+    );
+
+    assertArrayEquals(
+      read.WebACL?.Rules.map((rule) => rule.Name),
+      ["first"],
+    );
+  });
+
+  it("lists web ACLs a page at a time", async () => {
+    // Given three web ACLs in one scope.
+    const waf = new SimAws().wafV2();
+
+    await createSimWafWebAcl(
+      waf,
+      simWafCreateWebAclFactory.make({ Name: "one" }),
+    );
+    await createSimWafWebAcl(
+      waf,
+      simWafCreateWebAclFactory.make({ Name: "two" }),
+    );
+    await createSimWafWebAcl(
+      waf,
+      simWafCreateWebAclFactory.make({ Name: "three" }),
+    );
+
+    // When they are read a page at a time.
+    const first = await waf.listWebAcls(
+      new ListWebACLsCommand({ Scope: "REGIONAL", Limit: 2 }),
+    );
+    const second = await waf.listWebAcls(
+      new ListWebACLsCommand({
+        Scope: "REGIONAL",
+        Limit: 2,
+        NextMarker: first.NextMarker,
+      }),
+    );
+
+    // Then the marker from the first page reaches the rest, and the last page
+    // offers none.
+    assertArrayEquals(
+      first.WebACLs?.map((summary) => summary.Name),
+      ["one", "two"],
+    );
+    assertArrayEquals(
+      second.WebACLs?.map((summary) => summary.Name),
+      ["three"],
+    );
+    assertUndefined(second.NextMarker);
+  });
+
+  it("refuses a listing marker this simulation did not issue", async () => {
+    // Given a web ACL.
+    const waf = new SimAws().wafV2();
+
+    await createSimWafWebAcl(waf, simWafCreateWebAclFactory.make());
+
+    // When a listing is asked for with a marker from somewhere else.
+    const error = await assertThrowsErrorAsync(async () => {
+      await waf.listWebAcls(
+        new ListWebACLsCommand({ Scope: "REGIONAL", NextMarker: "elsewhere" }),
+      );
+    });
+
+    // Then it is refused rather than quietly starting again at the beginning.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+  });
+
+  it("deletes a web ACL", async () => {
+    // Given a web ACL.
+    const waf = new SimAws().wafV2();
+    const input = simWafCreateWebAclFactory.make();
+    const created = await createSimWafWebAcl(waf, input);
+
+    // When it is deleted with its lock token.
+    await waf.deleteWebAcl(
+      new DeleteWebACLCommand({
+        Name: input.Name,
+        Scope: "REGIONAL",
+        Id: created.Id,
+        LockToken: created.LockToken,
+      }),
+    );
+
+    // Then it is gone.
+    assertArrayLength(waf.allWebAcls("REGIONAL"), 0);
+  });
+
+  it("refuses a read of a web ACL that is not there", async () => {
+    // Given a simulated WAFv2 with nothing in it.
+    const waf = new SimAws().wafV2();
+
+    // When a web ACL is read by a name and id naming none.
+    const error = await assertThrowsErrorAsync(async () => {
+      await waf.getWebAcl(
+        new GetWebACLCommand({
+          Name: "missing",
+          Scope: "REGIONAL",
+          Id: "0f5a1b2c-3d4e-5f60-7182-93a4b5c6d7e8",
+        }),
+      );
+    });
+
+    // Then it is refused rather than answered with nothing.
+    assertInstanceOf(error, SimWafNonexistentItemException);
+  });
+});

--- a/src/service/wafv2/sim-wafv2.fixture.ts
+++ b/src/service/wafv2/sim-wafv2.fixture.ts
@@ -1,0 +1,63 @@
+import { assertDefined } from "../../util/type-guard/defined.js";
+import { simWafCreateWebAclFactory } from "./command/web-acl/sim-waf-create-web-acl.factory.js";
+import type {
+  SimCreateWebAclCommandInput,
+  SimWafSummaryOutput,
+} from "./command/web-acl/web-acl.command.js";
+import type { SimWafStatementInput } from "./statement/sim-waf-statement.type.js";
+import type { SimWafV2 } from "./sim-wafv2.js";
+import { simWafRuleFactory } from "./web-acl/sim-waf-rule.factory.js";
+
+/**
+ * Create a web ACL and answer with what CreateWebACL reported about it.
+ *
+ * The summary is where the generated id, the ARN and the first lock token
+ * come from, and a test needs all three to do anything else with the web ACL.
+ * CreateWebACL reports one for every web ACL it makes, so a test reading
+ * around a missing summary would be writing around a simulator fault.
+ */
+export async function createSimWafWebAcl(
+  simWaf: SimWafV2,
+  input: SimCreateWebAclCommandInput,
+): Promise<SimWafSummaryOutput> {
+  const created = await simWaf.createWebAcl({ input });
+
+  assertDefined(
+    created.Summary,
+    "Simulated WAFv2 created a web ACL and reported no summary for it",
+  );
+
+  return created.Summary;
+}
+
+/**
+ * Whether one statement claims a request.
+ */
+export type SimWafStatementMatch = (
+  request: Request,
+  body?: Uint8Array,
+) => boolean;
+
+/**
+ * Create a web ACL whose one rule blocks whatever a statement claims, and
+ * answer with a way to ask that statement about a request.
+ *
+ * A test about one statement kind is about which requests that statement
+ * claims, and the web ACL around it is the same every time: one rule, blocking,
+ * over a default action of allow. A blocked request is then one the statement
+ * matched, and an allowed one is a request it did not.
+ */
+export async function simWafStatementMatches(
+  simWaf: SimWafV2,
+  statement: SimWafStatementInput,
+): Promise<SimWafStatementMatch> {
+  const { ARN: webAclArn } = await createSimWafWebAcl(
+    simWaf,
+    simWafCreateWebAclFactory.make({
+      Rules: [{ ...simWafRuleFactory.make(), Statement: statement }],
+    }),
+  );
+
+  return (request, body): boolean =>
+    simWaf.evaluateRequest({ webAclArn, request, body }).action === "BLOCK";
+}

--- a/src/service/wafv2/sim-wafv2.ts
+++ b/src/service/wafv2/sim-wafv2.ts
@@ -172,6 +172,17 @@ export class SimWafV2 {
   }
 
   /**
+   * Handle an UpdateIPSet Command from the SDK.
+   */
+  async updateIpSet(
+    command: simWafCommands.SimUpdateIpSetCommand,
+    options?: SimWafRequestOptions,
+  ): Promise<simWafCommands.SimUpdateIpSetCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.ipSetCommands.updateIpSet(command, options);
+  }
+
+  /**
    * Handle a ListIPSets Command from the SDK.
    */
   async listIpSets(
@@ -216,6 +227,20 @@ export class SimWafV2 {
   ): Promise<simWafCommands.SimGetRegexPatternSetCommandOutput> {
     await this.#commands.background.sequence();
     return this.#commands.regexPatternSetCommands.getRegexPatternSet(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Handle an UpdateRegexPatternSet Command from the SDK.
+   */
+  async updateRegexPatternSet(
+    command: simWafCommands.SimUpdateRegexPatternSetCommand,
+    options?: SimWafRequestOptions,
+  ): Promise<simWafCommands.SimUpdateRegexPatternSetCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.regexPatternSetCommands.updateRegexPatternSet(
       command,
       options,
     );

--- a/src/service/wafv2/sim-wafv2.ts
+++ b/src/service/wafv2/sim-wafv2.ts
@@ -1,0 +1,258 @@
+import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
+import type * as simWafCommands from "./command/sim-wafv2-command.types.js";
+import type { SimWafRequestOptions } from "./command/sim-wafv2-request-options.js";
+import { SimWafNonexistentItemException } from "./error/sim-wafv2.error.js";
+import type { SimWafDecision } from "./evaluate/sim-waf-decision.js";
+import { simWafInspectedRequest } from "./evaluate/sim-waf-inspected-request.js";
+import type { SimWafScope } from "./scope/sim-waf-scope.js";
+import { SimWafSdkCommandRouter } from "./sdk/sim-wafv2-sdk-command-router.js";
+import {
+  SimWafCommands,
+  type SimWafV2Properties,
+} from "./sim-wafv2-commands.js";
+import type { SimWafWebAcl } from "./web-acl/sim-waf-web-acl.js";
+
+/**
+ * What a web ACL is asked to decide about.
+ */
+export interface SimWafEvaluationRequest {
+  /** The web ACL to evaluate against, by ARN. */
+  readonly webAclArn: string;
+
+  readonly request: Request;
+
+  /**
+   * The request body, when the rules might inspect it. A request body is a
+   * stream that cannot be read twice, so it is passed in already buffered.
+   */
+  readonly body?: Uint8Array | undefined;
+}
+
+/**
+ * Simulated AWS WAFv2. Handles SDK commands. Emulates AWS behaviour and state.
+ *
+ * A web ACL is a list of rules and a decision about the requests none of them
+ * claims, and `evaluateRequest` is what that adds up to. Association with a
+ * CloudFront distribution, an API Gateway stage or a Cognito user pool comes
+ * separately: this holds the rules and reaches the verdict, and the fronting
+ * services will ask it for one.
+ *
+ * Resources are scoped to an Account and Region, and within that to
+ * `CLOUDFRONT` or `REGIONAL`. The two scopes are separate namespaces rather
+ * than a label, and `CLOUDFRONT` lives in `us-east-1` because CloudFront is
+ * global and its web ACLs are held there.
+ */
+export class SimWafV2 {
+  readonly #commands: SimWafCommands;
+  readonly #sdkRouter = new SimWafSdkCommandRouter(this);
+
+  constructor(properties: SimWafV2Properties = {}) {
+    this.#commands = new SimWafCommands(properties);
+  }
+
+  /**
+   * Every web ACL in one scope, in the order they were created.
+   *
+   * The simulator's own accessor, for tests inspecting web ACL state without
+   * going through a Command and its authorization.
+   */
+  allWebAcls(scope: SimWafScope): readonly SimWafWebAcl[] {
+    return this.#commands.webAcls.all(scope);
+  }
+
+  /**
+   * Find a web ACL by its ARN.
+   *
+   * This is how a fronting service reaches the web ACL it was associated with,
+   * since an association carries the ARN and nothing else.
+   */
+  findWebAclByArn(webAclArn: string): SimWafWebAcl | undefined {
+    return this.#commands.webAcls.findByArn(webAclArn);
+  }
+
+  /**
+   * Evaluate one HTTP request against a web ACL's rules.
+   *
+   * Rules run in ascending priority, the first terminating match decides, and
+   * a request no rule terminates gets the web ACL's default action. This is
+   * the simulator's own entry point rather than a WAFv2 operation: on AWS the
+   * evaluation happens because the request reached something the web ACL is in
+   * front of.
+   */
+  evaluateRequest(evaluation: SimWafEvaluationRequest): SimWafDecision {
+    const webAcl = this.findWebAclByArn(evaluation.webAclArn);
+
+    if (webAcl === undefined) {
+      throw new SimWafNonexistentItemException(
+        `AWS WAF couldn't perform the operation because your resource ` +
+          `doesn't exist: web ACL ${evaluation.webAclArn}.`,
+      );
+    }
+
+    return webAcl.evaluate(
+      simWafInspectedRequest(evaluation.request, evaluation.body),
+    );
+  }
+
+  /**
+   * Handle a CreateWebACL Command from the SDK.
+   */
+  async createWebAcl(
+    command: simWafCommands.SimCreateWebAclCommand,
+    options?: SimWafRequestOptions,
+  ): Promise<simWafCommands.SimCreateWebAclCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.webAclCommands.createWebAcl(command, options);
+  }
+
+  /**
+   * Handle a GetWebACL Command from the SDK.
+   */
+  async getWebAcl(
+    command: simWafCommands.SimGetWebAclCommand,
+    options?: SimWafRequestOptions,
+  ): Promise<simWafCommands.SimGetWebAclCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.webAclCommands.getWebAcl(command, options);
+  }
+
+  /**
+   * Handle an UpdateWebACL Command from the SDK.
+   */
+  async updateWebAcl(
+    command: simWafCommands.SimUpdateWebAclCommand,
+    options?: SimWafRequestOptions,
+  ): Promise<simWafCommands.SimUpdateWebAclCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.webAclCommands.updateWebAcl(command, options);
+  }
+
+  /**
+   * Handle a ListWebACLs Command from the SDK.
+   */
+  async listWebAcls(
+    command: simWafCommands.SimListWebAclsCommand,
+    options?: SimWafRequestOptions,
+  ): Promise<simWafCommands.SimListWebAclsCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.webAclCommands.listWebAcls(command, options);
+  }
+
+  /**
+   * Handle a DeleteWebACL Command from the SDK.
+   */
+  async deleteWebAcl(
+    command: simWafCommands.SimDeleteWebAclCommand,
+    options?: SimWafRequestOptions,
+  ): Promise<simWafCommands.SimDeleteWebAclCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.webAclCommands.deleteWebAcl(command, options);
+  }
+
+  /**
+   * Handle a CreateIPSet Command from the SDK.
+   */
+  async createIpSet(
+    command: simWafCommands.SimCreateIpSetCommand,
+    options?: SimWafRequestOptions,
+  ): Promise<simWafCommands.SimCreateIpSetCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.ipSetCommands.createIpSet(command, options);
+  }
+
+  /**
+   * Handle a GetIPSet Command from the SDK.
+   */
+  async getIpSet(
+    command: simWafCommands.SimGetIpSetCommand,
+    options?: SimWafRequestOptions,
+  ): Promise<simWafCommands.SimGetIpSetCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.ipSetCommands.getIpSet(command, options);
+  }
+
+  /**
+   * Handle a ListIPSets Command from the SDK.
+   */
+  async listIpSets(
+    command: simWafCommands.SimListIpSetsCommand,
+    options?: SimWafRequestOptions,
+  ): Promise<simWafCommands.SimListIpSetsCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.ipSetCommands.listIpSets(command, options);
+  }
+
+  /**
+   * Handle a DeleteIPSet Command from the SDK.
+   */
+  async deleteIpSet(
+    command: simWafCommands.SimDeleteIpSetCommand,
+    options?: SimWafRequestOptions,
+  ): Promise<simWafCommands.SimDeleteIpSetCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.ipSetCommands.deleteIpSet(command, options);
+  }
+
+  /**
+   * Handle a CreateRegexPatternSet Command from the SDK.
+   */
+  async createRegexPatternSet(
+    command: simWafCommands.SimCreateRegexPatternSetCommand,
+    options?: SimWafRequestOptions,
+  ): Promise<simWafCommands.SimCreateRegexPatternSetCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.regexPatternSetCommands.createRegexPatternSet(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Handle a GetRegexPatternSet Command from the SDK.
+   */
+  async getRegexPatternSet(
+    command: simWafCommands.SimGetRegexPatternSetCommand,
+    options?: SimWafRequestOptions,
+  ): Promise<simWafCommands.SimGetRegexPatternSetCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.regexPatternSetCommands.getRegexPatternSet(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Handle a ListRegexPatternSets Command from the SDK.
+   */
+  async listRegexPatternSets(
+    command: simWafCommands.SimListRegexPatternSetsCommand,
+    options?: SimWafRequestOptions,
+  ): Promise<simWafCommands.SimListRegexPatternSetsCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.regexPatternSetCommands.listRegexPatternSets(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Handle a DeleteRegexPatternSet Command from the SDK.
+   */
+  async deleteRegexPatternSet(
+    command: simWafCommands.SimDeleteRegexPatternSetCommand,
+    options?: SimWafRequestOptions,
+  ): Promise<simWafCommands.SimDeleteRegexPatternSetCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.regexPatternSetCommands.deleteRegexPatternSet(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Get this service's SDK Command router for SDK client interception.
+   */
+  sdkCommandRouter(): SimSdkCommandRouter {
+    return this.#sdkRouter;
+  }
+}

--- a/src/service/wafv2/statement/sim-waf-byte-match.iso.test.ts
+++ b/src/service/wafv2/statement/sim-waf-byte-match.iso.test.ts
@@ -1,0 +1,141 @@
+import { assertFalse, assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { simWafStatementMatches } from "../sim-wafv2.fixture.js";
+import type { SimWafStatementInput } from "./sim-waf-statement.type.js";
+
+/**
+ * A byte match statement over the request path.
+ */
+function pathMatch(
+  searchString: string,
+  positionalConstraint: string,
+): SimWafStatementInput {
+  return {
+    ByteMatchStatement: {
+      SearchString: searchString,
+      PositionalConstraint: positionalConstraint,
+      FieldToMatch: { UriPath: {} },
+      TextTransformations: [{ Priority: 0, Type: "NONE" }],
+    },
+  };
+}
+
+function get(path: string): Request {
+  return new Request(`https://example.test${path}`);
+}
+
+describe("SimWafV2 ByteMatchStatement", () => {
+  it("matches a path that is exactly the search string", async () => {
+    // Given a statement matching one path exactly.
+    const matches = await simWafStatementMatches(
+      new SimAws().wafV2(),
+      pathMatch("/admin", "EXACTLY"),
+    );
+
+    // Then only that path matches.
+    assertTrue(matches(get("/admin")));
+    assertFalse(matches(get("/admin/users")));
+  });
+
+  it("matches a path that starts with the search string", async () => {
+    // Given a statement matching a path prefix.
+    const matches = await simWafStatementMatches(
+      new SimAws().wafV2(),
+      pathMatch("/admin", "STARTS_WITH"),
+    );
+
+    // Then anything under that prefix matches.
+    assertTrue(matches(get("/admin/users")));
+    assertFalse(matches(get("/public/admin")));
+  });
+
+  it("matches a path that ends with the search string", async () => {
+    // Given a statement matching a path suffix.
+    const matches = await simWafStatementMatches(
+      new SimAws().wafV2(),
+      pathMatch(".php", "ENDS_WITH"),
+    );
+
+    // Then anything ending that way matches.
+    assertTrue(matches(get("/wp-login.php")));
+    assertFalse(matches(get("/wp-login.php.txt")));
+  });
+
+  it("matches a path holding the search string anywhere", async () => {
+    // Given a statement matching a path fragment.
+    const matches = await simWafStatementMatches(
+      new SimAws().wafV2(),
+      pathMatch("etc/passwd", "CONTAINS"),
+    );
+
+    // Then it matches wherever the fragment sits.
+    assertTrue(matches(get("/files/../etc/passwd")));
+    assertFalse(matches(get("/files/etc-passwd")));
+  });
+
+  it("matches the search string only as a word of its own", async () => {
+    // Given a statement matching a word.
+    const matches = await simWafStatementMatches(
+      new SimAws().wafV2(),
+      pathMatch("admin", "CONTAINS_WORD"),
+    );
+
+    // Then the word matches where a letter, digit or underscore does not run
+    // into it, which is what stops `administrator` claiming the rule.
+    assertTrue(matches(get("/admin")));
+    assertTrue(matches(get("/site/admin/users")));
+    assertFalse(matches(get("/administrator")));
+    assertFalse(matches(get("/site_admin_users")));
+  });
+
+  it("matches a word that appears twice, once as a word", async () => {
+    // Given a statement matching a word.
+    const matches = await simWafStatementMatches(
+      new SimAws().wafV2(),
+      pathMatch("admin", "CONTAINS_WORD"),
+    );
+
+    // Then a path where the first occurrence is inside another word still
+    // matches on the second.
+    assertTrue(matches(get("/administrator/admin")));
+  });
+
+  it("matches without regard to case only when asked to", async () => {
+    // Given one statement matching as written and one lower casing first.
+    const waf = new SimAws().wafV2();
+    const caseSensitive = await simWafStatementMatches(
+      waf,
+      pathMatch("/admin", "STARTS_WITH"),
+    );
+    const lowerCased = await simWafStatementMatches(waf, {
+      ByteMatchStatement: {
+        SearchString: "/admin",
+        PositionalConstraint: "STARTS_WITH",
+        FieldToMatch: { UriPath: {} },
+        TextTransformations: [{ Priority: 0, Type: "LOWERCASE" }],
+      },
+    });
+
+    // Then WAF's own case sensitivity is what a rule gets unless it asks for
+    // a LOWERCASE transformation.
+    assertFalse(caseSensitive(get("/Admin")));
+    assertTrue(lowerCased(get("/Admin")));
+  });
+
+  it("matches a search string given as bytes", async () => {
+    // Given a statement whose search string is the bytes the SDK sends.
+    const matches = await simWafStatementMatches(new SimAws().wafV2(), {
+      ByteMatchStatement: {
+        SearchString: new TextEncoder().encode("/admin"),
+        PositionalConstraint: "STARTS_WITH",
+        FieldToMatch: { UriPath: {} },
+        TextTransformations: [{ Priority: 0, Type: "NONE" }],
+      },
+    });
+
+    // Then it matches what those bytes spell.
+    assertTrue(matches(get("/admin")));
+  });
+});

--- a/src/service/wafv2/statement/sim-waf-byte-match.ts
+++ b/src/service/wafv2/statement/sim-waf-byte-match.ts
@@ -1,0 +1,99 @@
+import { invalidSimWafRule } from "./sim-waf-rule-refusals.js";
+import type { SimWafValueTest } from "./sim-waf-field-match.js";
+
+/**
+ * Minimal structural WAFv2 ByteMatchStatement.
+ */
+export interface SimWafByteMatchStatementInput {
+  readonly SearchString?: Uint8Array | string | undefined;
+  readonly PositionalConstraint?: string | undefined;
+}
+
+const decoder = new TextDecoder();
+
+/**
+ * Characters WAF counts as part of a word, for CONTAINS_WORD.
+ */
+const wordCharacter = /[\da-z_]/iu;
+
+/**
+ * Build the test a ByteMatchStatement puts each string through.
+ *
+ * Matching is case sensitive here as it is on AWS. A rule that means to ignore
+ * case says so with a LOWERCASE text transformation and a lower case search
+ * string, which is why the transformations are part of the statement rather
+ * than a property of the comparison.
+ */
+export function simWafByteMatchTest(
+  statement: SimWafByteMatchStatementInput,
+  ruleName: string,
+): SimWafValueTest {
+  const searchString = readSearchString(statement.SearchString, ruleName);
+  const constraint = statement.PositionalConstraint ?? "";
+
+  switch (constraint) {
+    case "EXACTLY": {
+      return (value): boolean => value === searchString;
+    }
+    case "STARTS_WITH": {
+      return (value): boolean => value.startsWith(searchString);
+    }
+    case "ENDS_WITH": {
+      return (value): boolean => value.endsWith(searchString);
+    }
+    case "CONTAINS": {
+      return (value): boolean => value.includes(searchString);
+    }
+    case "CONTAINS_WORD": {
+      return (value): boolean => containsWord(value, searchString);
+    }
+    default: {
+      invalidSimWafRule(
+        ruleName,
+        `The positional constraint ${String(statement.PositionalConstraint)} ` +
+          `is not valid`,
+      );
+    }
+  }
+}
+
+/**
+ * Whether the search string appears in the value as a word of its own.
+ *
+ * A word here is what WAF says it is: the match has to start at the beginning
+ * of the value or after something that is not a letter, digit or underscore,
+ * and end at the end of the value or before something that is not.
+ */
+function containsWord(value: string, searchString: string): boolean {
+  let from = value.indexOf(searchString);
+
+  while (from !== -1) {
+    if (
+      isBoundary(value[from - 1]) &&
+      isBoundary(value[from + searchString.length])
+    ) {
+      return true;
+    }
+
+    from = value.indexOf(searchString, from + 1);
+  }
+
+  return false;
+}
+
+function isBoundary(character: string | undefined): boolean {
+  return character === undefined || !wordCharacter.test(character);
+}
+
+function readSearchString(
+  searchString: Uint8Array | string | undefined,
+  ruleName: string,
+): string {
+  if (searchString === undefined) {
+    invalidSimWafRule(ruleName, "ByteMatchStatement needs a SearchString");
+  }
+
+  return typeof searchString === "string"
+    ? searchString
+    : decoder.decode(searchString);
+}

--- a/src/service/wafv2/statement/sim-waf-field-content.ts
+++ b/src/service/wafv2/statement/sim-waf-field-content.ts
@@ -1,0 +1,98 @@
+import { invalidSimWafRule } from "./sim-waf-rule-refusals.js";
+
+/**
+ * What a rule found when it read the request field it inspects.
+ *
+ * Most reads answer with the strings to match against, which is `inspect`. The
+ * other two are what oversize content means: WAF stops reading a field at a
+ * fixed size, and the rule says whether content it could not read counts as a
+ * match or not.
+ */
+export type SimWafFieldContent =
+  | { readonly outcome: "inspect"; readonly candidates: readonly string[] }
+  | { readonly outcome: "match" }
+  | { readonly outcome: "noMatch" };
+
+/**
+ * How much of a request body, header set or cookie set WAF reads.
+ *
+ * Real WAF stops at 8 KB for a web ACL as it is created here. A CloudFront
+ * association can raise the body limit, which is settled where associations
+ * are, so this is the one figure until then.
+ */
+export const simWafInspectionLimitBytes = 8192;
+
+/**
+ * What a rule does about content too large for WAF to read.
+ */
+export type SimWafOversizeHandling = "CONTINUE" | "MATCH" | "NO_MATCH";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+/**
+ * Read the oversize handling a rule named, refusing anything else.
+ */
+export function requiredSimWafOversizeHandling(
+  handling: string | undefined,
+  ruleName: string,
+): SimWafOversizeHandling {
+  const wanted = handling ?? "CONTINUE";
+
+  if (wanted !== "CONTINUE" && wanted !== "MATCH" && wanted !== "NO_MATCH") {
+    invalidSimWafRule(
+      ruleName,
+      `The oversize handling ${String(handling)} is not valid`,
+    );
+  }
+
+  return wanted;
+}
+
+/**
+ * Decide what a rule inspects, given everything the field held.
+ *
+ * Content within the limit is inspected whole. Past it, `MATCH` and `NO_MATCH`
+ * settle the statement without looking, and `CONTINUE` inspects as much as WAF
+ * would have read: whole entries while they fit, and the first entry cut to
+ * the limit when even one does not.
+ */
+export function simWafFieldContent(
+  candidates: readonly string[],
+  oversizeHandling: SimWafOversizeHandling,
+): SimWafFieldContent {
+  const encoded = candidates.map((candidate) => encoder.encode(candidate));
+  const total = encoded.reduce((sum, bytes) => sum + bytes.length, 0);
+
+  if (total <= simWafInspectionLimitBytes) {
+    return { outcome: "inspect", candidates };
+  }
+
+  if (oversizeHandling !== "CONTINUE") {
+    return { outcome: oversizeHandling === "MATCH" ? "match" : "noMatch" };
+  }
+
+  return { outcome: "inspect", candidates: readWithinLimit(encoded) };
+}
+
+/**
+ * The content WAF would have read before it stopped.
+ */
+function readWithinLimit(encoded: readonly Uint8Array[]): readonly string[] {
+  const read: string[] = [];
+  let budget = simWafInspectionLimitBytes;
+
+  for (const bytes of encoded) {
+    if (bytes.length > budget) {
+      // An entry over the remaining budget is cut where WAF stopped reading,
+      // which for a body is the only case that happens.
+      read.push(decoder.decode(bytes.subarray(0, budget)));
+      break;
+    }
+
+    read.push(decoder.decode(bytes));
+    budget -= bytes.length;
+  }
+
+  return read;
+}

--- a/src/service/wafv2/statement/sim-waf-field-match.ts
+++ b/src/service/wafv2/statement/sim-waf-field-match.ts
@@ -1,0 +1,55 @@
+import type { SimWafInspectedRequest } from "../evaluate/sim-waf-inspected-request.js";
+import { compileSimWafFieldToMatch } from "./sim-waf-field-to-match.js";
+import type { SimWafFieldToMatchInput } from "./sim-waf-field-to-match.type.js";
+import {
+  compileSimWafTextTransformations,
+  type SimWafTextTransformationInput,
+} from "./sim-waf-text-transformation.js";
+
+/**
+ * Whether one statement claims a request.
+ */
+export type SimWafMatcher = (request: SimWafInspectedRequest) => boolean;
+
+/**
+ * Whether one string a field held is what a statement is looking for.
+ */
+export type SimWafValueTest = (value: string) => boolean;
+
+/**
+ * What the three statement kinds that read a request field have in common.
+ */
+export interface SimWafFieldMatcherProperties {
+  readonly field: SimWafFieldToMatchInput | undefined;
+  readonly transformations:
+    | readonly SimWafTextTransformationInput[]
+    | undefined;
+  readonly ruleName: string;
+  readonly test: SimWafValueTest;
+}
+
+/**
+ * Build the matcher for a statement that reads one request field.
+ *
+ * A field can hold more than one string, and WAF matches a statement when any
+ * of them matches: one header out of the set a pattern selected is enough, and
+ * so is one query argument out of all of them.
+ */
+export function compileSimWafFieldMatcher(
+  properties: SimWafFieldMatcherProperties,
+): SimWafMatcher {
+  const read = compileSimWafFieldToMatch(properties.field, properties.ruleName);
+  const transform = compileSimWafTextTransformations(
+    properties.transformations,
+    properties.ruleName,
+  );
+  const { test } = properties;
+
+  return (request): boolean => {
+    const content = read(request);
+
+    return content.outcome === "inspect"
+      ? content.candidates.some((candidate) => test(transform(candidate)))
+      : content.outcome === "match";
+  };
+}

--- a/src/service/wafv2/statement/sim-waf-field-to-match.iso.test.ts
+++ b/src/service/wafv2/statement/sim-waf-field-to-match.iso.test.ts
@@ -1,0 +1,353 @@
+import { assertFalse, assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { simWafStatementMatches } from "../sim-wafv2.fixture.js";
+import type { SimWafFieldToMatchInput } from "./sim-waf-field-to-match.type.js";
+import { simWafInspectionLimitBytes } from "./sim-waf-field-content.js";
+import type { SimWafStatementInput } from "./sim-waf-statement.type.js";
+
+/**
+ * A statement looking for one string in whichever field it is pointed at.
+ */
+function contains(
+  searchString: string,
+  field: SimWafFieldToMatchInput,
+): SimWafStatementInput {
+  return {
+    ByteMatchStatement: {
+      SearchString: searchString,
+      PositionalConstraint: "CONTAINS",
+      FieldToMatch: field,
+      TextTransformations: [{ Priority: 0, Type: "NONE" }],
+    },
+  };
+}
+
+const encoder = new TextEncoder();
+
+describe("SimWafV2 field to match", () => {
+  it("reads the query string without its leading question mark", async () => {
+    // Given a statement over the query string.
+    const matches = await simWafStatementMatches(
+      new SimAws().wafV2(),
+      contains("debug=true", { QueryString: {} }),
+    );
+
+    // Then it matches the query string as sent.
+    assertTrue(matches(new Request("https://example.test/?debug=true")));
+    assertFalse(matches(new Request("https://example.test/debug=true")));
+  });
+
+  it("reads the request method", async () => {
+    // Given a statement over the method.
+    const matches = await simWafStatementMatches(
+      new SimAws().wafV2(),
+      contains("DELETE", { Method: {} }),
+    );
+
+    // Then it matches the method the request was made with.
+    assertTrue(
+      matches(new Request("https://example.test/", { method: "DELETE" })),
+    );
+    assertFalse(matches(new Request("https://example.test/")));
+  });
+
+  it("reads every query argument value", async () => {
+    // Given a statement over all the query arguments.
+    const matches = await simWafStatementMatches(
+      new SimAws().wafV2(),
+      contains("../", { AllQueryArguments: {} }),
+    );
+
+    // Then one argument holding it is enough, and the argument names are not
+    // read.
+    assertTrue(matches(new Request("https://example.test/?page=1&file=../x")));
+    assertFalse(matches(new Request("https://example.test/?page=1")));
+  });
+
+  it("reads one query argument by name, without regard to its case", async () => {
+    // Given a statement over one named query argument.
+    const matches = await simWafStatementMatches(
+      new SimAws().wafV2(),
+      contains("../", { SingleQueryArgument: { Name: "file" } }),
+    );
+
+    // Then only that argument is read, and WAF lower cases the name on both
+    // sides before comparing.
+    assertTrue(matches(new Request("https://example.test/?File=../x")));
+    assertFalse(matches(new Request("https://example.test/?page=../x")));
+  });
+
+  it("reads one header by name", async () => {
+    // Given a statement over one named header.
+    const matches = await simWafStatementMatches(
+      new SimAws().wafV2(),
+      contains("curl", { SingleHeader: { Name: "user-agent" } }),
+    );
+
+    // Then it matches that header and nothing else.
+    assertTrue(
+      matches(
+        new Request("https://example.test/", {
+          headers: { "user-agent": "curl/8.0" },
+        }),
+      ),
+    );
+    assertFalse(matches(new Request("https://example.test/")));
+  });
+
+  it("reads the headers a match pattern selects", async () => {
+    // Given a statement over two named headers' values.
+    const matches = await simWafStatementMatches(
+      new SimAws().wafV2(),
+      contains("suspect", {
+        Headers: {
+          MatchPattern: { IncludedHeaders: ["x-forwarded-for", "referer"] },
+          MatchScope: "VALUE",
+          OversizeHandling: "CONTINUE",
+        },
+      }),
+    );
+
+    // Then a header outside the pattern is not read.
+    assertTrue(
+      matches(
+        new Request("https://example.test/", {
+          headers: { referer: "https://suspect.test/" },
+        }),
+      ),
+    );
+    assertFalse(
+      matches(
+        new Request("https://example.test/", {
+          headers: { "user-agent": "suspect" },
+        }),
+      ),
+    );
+  });
+
+  it("reads every header but the ones a pattern excludes", async () => {
+    // Given a statement over all headers except one.
+    const matches = await simWafStatementMatches(
+      new SimAws().wafV2(),
+      contains("suspect", {
+        Headers: {
+          MatchPattern: { ExcludedHeaders: ["user-agent"] },
+          MatchScope: "VALUE",
+          OversizeHandling: "CONTINUE",
+        },
+      }),
+    );
+
+    // Then the excluded header is the one that cannot match.
+    assertFalse(
+      matches(
+        new Request("https://example.test/", {
+          headers: { "user-agent": "suspect" },
+        }),
+      ),
+    );
+    assertTrue(
+      matches(
+        new Request("https://example.test/", {
+          headers: { referer: "suspect" },
+        }),
+      ),
+    );
+  });
+
+  it("reads header names when the match scope says keys", async () => {
+    // Given a statement over the header names.
+    const matches = await simWafStatementMatches(
+      new SimAws().wafV2(),
+      contains("x-internal", {
+        Headers: {
+          MatchPattern: { All: {} },
+          MatchScope: "KEY",
+          OversizeHandling: "CONTINUE",
+        },
+      }),
+    );
+
+    // Then the name is what matches, whatever the value is.
+    assertTrue(
+      matches(
+        new Request("https://example.test/", {
+          headers: { "x-internal": "1" },
+        }),
+      ),
+    );
+    assertFalse(
+      matches(
+        new Request("https://example.test/", { headers: { "x-public": "1" } }),
+      ),
+    );
+  });
+
+  it("reads names and values when the match scope says all", async () => {
+    // Given a statement over both sides of every header.
+    const matches = await simWafStatementMatches(
+      new SimAws().wafV2(),
+      contains("secret", {
+        Headers: {
+          MatchPattern: { All: {} },
+          MatchScope: "ALL",
+          OversizeHandling: "CONTINUE",
+        },
+      }),
+    );
+
+    // Then either side matching is enough.
+    assertTrue(
+      matches(
+        new Request("https://example.test/", { headers: { "x-secret": "1" } }),
+      ),
+    );
+    assertTrue(
+      matches(
+        new Request("https://example.test/", {
+          headers: { "x-note": "secret" },
+        }),
+      ),
+    );
+  });
+
+  it("reads the cookies a request sent", async () => {
+    // Given a statement over one cookie's value.
+    const matches = await simWafStatementMatches(
+      new SimAws().wafV2(),
+      contains("stolen", {
+        Cookies: {
+          MatchPattern: { IncludedCookies: ["session"] },
+          MatchScope: "VALUE",
+          OversizeHandling: "CONTINUE",
+        },
+      }),
+    );
+
+    // Then the cookie header is split into its cookies and only the named one
+    // is read.
+    assertTrue(
+      matches(
+        new Request("https://example.test/", {
+          headers: { cookie: "theme=dark; session=stolen" },
+        }),
+      ),
+    );
+    assertFalse(
+      matches(
+        new Request("https://example.test/", {
+          headers: { cookie: "theme=stolen" },
+        }),
+      ),
+    );
+  });
+
+  it("reads a query argument and a cookie that carry no value", async () => {
+    // Given statements over an argument name and a cookie name.
+    const waf = new SimAws().wafV2();
+    const argument = await simWafStatementMatches(
+      waf,
+      contains("", { SingleQueryArgument: { Name: "debug" } }),
+    );
+    const cookie = await simWafStatementMatches(
+      waf,
+      contains("consent", {
+        Cookies: {
+          MatchPattern: { All: {} },
+          MatchScope: "KEY",
+          OversizeHandling: "CONTINUE",
+        },
+      }),
+    );
+
+    // Then each is still read, with an empty value, the way it arrived.
+    assertTrue(argument(new Request("https://example.test/?debug")));
+    assertTrue(
+      cookie(
+        new Request("https://example.test/", {
+          headers: { cookie: "consent" },
+        }),
+      ),
+    );
+  });
+
+  it("reads the headers that fit before WAF stops reading", async () => {
+    // Given a statement over every header value, and a request whose headers
+    // are together over the inspection limit.
+    const matches = await simWafStatementMatches(
+      new SimAws().wafV2(),
+      contains("needle", {
+        Headers: {
+          MatchPattern: { All: {} },
+          MatchScope: "VALUE",
+          OversizeHandling: "CONTINUE",
+        },
+      }),
+    );
+    const headers = new Headers({ "x-first": "needle" });
+
+    headers.set("x-second", "y".repeat(simWafInspectionLimitBytes));
+
+    // Then a header WAF read before it stopped still matches.
+    assertTrue(matches(new Request("https://example.test/", { headers })));
+  });
+
+  it("reads the request body", async () => {
+    // Given a statement over the body.
+    const matches = await simWafStatementMatches(
+      new SimAws().wafV2(),
+      contains("DROP TABLE", { Body: { OversizeHandling: "CONTINUE" } }),
+    );
+
+    // Then the body is what matches, and a request with none matches nothing.
+    assertTrue(
+      matches(
+        new Request("https://example.test/", { method: "POST" }),
+        encoder.encode("name=x; DROP TABLE users"),
+      ),
+    );
+    assertFalse(matches(new Request("https://example.test/")));
+  });
+
+  it("reads only as much of a body as WAF reads", async () => {
+    // Given a statement over the body, and a body with the search string past
+    // the point WAF stops reading.
+    const matches = await simWafStatementMatches(
+      new SimAws().wafV2(),
+      contains("needle", { Body: { OversizeHandling: "CONTINUE" } }),
+    );
+    const body = encoder.encode(
+      `${"x".repeat(simWafInspectionLimitBytes)}needle`,
+    );
+
+    // Then it does not match, because WAF never got that far either.
+    assertFalse(matches(new Request("https://example.test/"), body));
+  });
+
+  it("matches an oversize body when the rule says to", async () => {
+    // Given a statement that treats a body it cannot read as a match.
+    const matches = await simWafStatementMatches(
+      new SimAws().wafV2(),
+      contains("needle", { Body: { OversizeHandling: "MATCH" } }),
+    );
+    const body = encoder.encode("x".repeat(simWafInspectionLimitBytes + 1));
+
+    // Then a body over the limit matches without being looked at, which is how
+    // a rule refuses to let anything past that it cannot inspect.
+    assertTrue(matches(new Request("https://example.test/"), body));
+  });
+
+  it("lets an oversize body past when the rule says to", async () => {
+    // Given a statement that treats a body it cannot read as no match.
+    const matches = await simWafStatementMatches(
+      new SimAws().wafV2(),
+      contains("x", { Body: { OversizeHandling: "NO_MATCH" } }),
+    );
+    const body = encoder.encode("x".repeat(simWafInspectionLimitBytes + 1));
+
+    // Then it does not match, even though what it was looking for is in there.
+    assertFalse(matches(new Request("https://example.test/"), body));
+  });
+});

--- a/src/service/wafv2/statement/sim-waf-field-to-match.ts
+++ b/src/service/wafv2/statement/sim-waf-field-to-match.ts
@@ -1,0 +1,126 @@
+import type { SimWafInspectedRequest } from "../evaluate/sim-waf-inspected-request.js";
+import type { SimWafFieldContent } from "./sim-waf-field-content.js";
+import type {
+  SimWafFieldToMatchInput,
+  SimWafNamedFieldInput,
+} from "./sim-waf-field-to-match.type.js";
+import { compileSimWafSetField } from "./sim-waf-set-field.js";
+import {
+  type SimWafNameValue,
+  simWafQueryArguments,
+} from "./sim-waf-request-fields.js";
+import { invalidSimWafRule } from "./sim-waf-rule-refusals.js";
+import { refuseUnsimulatedSimWafField } from "./sim-waf-unsimulated-field.js";
+
+/**
+ * How a compiled rule reads the field it inspects.
+ */
+export type SimWafFieldReader = (
+  request: SimWafInspectedRequest,
+) => SimWafFieldContent;
+
+/**
+ * Build the reader a rule uses to get at the part of a request it inspects.
+ *
+ * A reader answers with every string the field held, because several of the
+ * field kinds hold more than one: all the query arguments, all the headers a
+ * pattern selected. A statement matches when any of them matches, which is
+ * what WAF does.
+ */
+export function compileSimWafFieldToMatch(
+  field: SimWafFieldToMatchInput | undefined,
+  ruleName: string,
+): SimWafFieldReader {
+  if (field === undefined) {
+    invalidSimWafRule(ruleName, "FieldToMatch is required");
+  }
+
+  refuseUnsimulatedSimWafField(field, ruleName);
+
+  return compileWholeField(field, ruleName);
+}
+
+/**
+ * The fields that are read whole, with nothing to select within them.
+ */
+function compileWholeField(
+  field: SimWafFieldToMatchInput,
+  ruleName: string,
+): SimWafFieldReader {
+  if (field.UriPath !== undefined) {
+    return (request): SimWafFieldContent => inspect([request.uriPath]);
+  }
+
+  if (field.QueryString !== undefined) {
+    return (request): SimWafFieldContent => inspect([request.queryString]);
+  }
+
+  if (field.Method !== undefined) {
+    return (request): SimWafFieldContent => inspect([request.method]);
+  }
+
+  if (field.AllQueryArguments !== undefined) {
+    return (request): SimWafFieldContent =>
+      inspect(values(simWafQueryArguments(request.queryString)));
+  }
+
+  return compileNamedField(field, ruleName);
+}
+
+/**
+ * The fields that name what they read within a set.
+ */
+function compileNamedField(
+  field: SimWafFieldToMatchInput,
+  ruleName: string,
+): SimWafFieldReader {
+  if (field.SingleQueryArgument !== undefined) {
+    const wanted = requiredName(field.SingleQueryArgument, ruleName);
+
+    return (request): SimWafFieldContent =>
+      inspect(
+        values(
+          simWafQueryArguments(request.queryString).filter(
+            (argument) => argument.name === wanted,
+          ),
+        ),
+      );
+  }
+
+  if (field.SingleHeader !== undefined) {
+    const wanted = requiredName(field.SingleHeader, ruleName);
+
+    return (request): SimWafFieldContent =>
+      inspect(headerValues(request.headers, wanted));
+  }
+
+  return compileSimWafSetField(field, ruleName);
+}
+
+function inspect(candidates: readonly string[]): SimWafFieldContent {
+  return { outcome: "inspect", candidates };
+}
+
+function values(entries: readonly SimWafNameValue[]): readonly string[] {
+  return entries.map((entry) => entry.value);
+}
+
+/**
+ * Every value a header carries.
+ *
+ * The Headers class joins repeats with a comma, and WAF inspects the joined
+ * value the same way, so this is one candidate or none.
+ */
+function headerValues(headers: Headers, name: string): readonly string[] {
+  const value = headers.get(name);
+
+  return value === null ? [] : [value];
+}
+
+function requiredName(field: SimWafNamedFieldInput, ruleName: string): string {
+  if (field.Name === undefined || field.Name === "") {
+    invalidSimWafRule(ruleName, "The field to match needs a Name");
+  }
+
+  return field.Name.toLowerCase();
+}

--- a/src/service/wafv2/statement/sim-waf-field-to-match.type.ts
+++ b/src/service/wafv2/statement/sim-waf-field-to-match.type.ts
@@ -1,0 +1,44 @@
+import type { SimWafMatchPatternInput } from "./sim-waf-request-fields.js";
+
+/**
+ * The parts of a request a WAFv2 rule can be pointed at, in the API's own
+ * shape.
+ *
+ * The members Yulin does not simulate are declared here rather than left out,
+ * so a rule that names one is refused by name instead of being read as a rule
+ * with no field at all.
+ */
+export interface SimWafFieldToMatchInput {
+  readonly UriPath?: unknown;
+  readonly QueryString?: unknown;
+  readonly Method?: unknown;
+  readonly AllQueryArguments?: unknown;
+  readonly SingleQueryArgument?: SimWafNamedFieldInput | undefined;
+  readonly SingleHeader?: SimWafNamedFieldInput | undefined;
+  readonly Headers?: SimWafHeadersFieldInput | undefined;
+  readonly Cookies?: SimWafHeadersFieldInput | undefined;
+  readonly Body?:
+    | { readonly OversizeHandling?: string | undefined }
+    | undefined;
+  readonly JsonBody?: unknown;
+  readonly HeaderOrder?: unknown;
+  readonly JA3Fingerprint?: unknown;
+  readonly JA4Fingerprint?: unknown;
+  readonly UriFragment?: unknown;
+}
+
+/**
+ * A field that names the one header or query argument it reads.
+ */
+export interface SimWafNamedFieldInput {
+  readonly Name?: string | undefined;
+}
+
+/**
+ * A field that reads a set of headers or cookies.
+ */
+export interface SimWafHeadersFieldInput {
+  readonly MatchPattern?: SimWafMatchPatternInput | undefined;
+  readonly MatchScope?: string | undefined;
+  readonly OversizeHandling?: string | undefined;
+}

--- a/src/service/wafv2/statement/sim-waf-logical-statement.ts
+++ b/src/service/wafv2/statement/sim-waf-logical-statement.ts
@@ -1,0 +1,63 @@
+import {
+  compileSimWafStatement,
+  type SimWafStatementScope,
+} from "./sim-waf-statement.js";
+import type { SimWafMatcher } from "./sim-waf-field-match.js";
+import { invalidSimWafRule } from "./sim-waf-rule-refusals.js";
+import type { SimWafStatementInput } from "./sim-waf-statement.type.js";
+
+/**
+ * Build the matcher for a statement that joins or negates other statements.
+ *
+ * These are the last kinds tried, because a statement that is none of them and
+ * none of the field statements either names no kind at all.
+ */
+export function compileSimWafLogicalStatement(
+  statement: SimWafStatementInput,
+  scope: SimWafStatementScope,
+): SimWafMatcher {
+  if (statement.AndStatement !== undefined) {
+    const matchers = compileAll(statement.AndStatement.Statements, scope);
+
+    return (request): boolean => matchers.every((matches) => matches(request));
+  }
+
+  if (statement.OrStatement !== undefined) {
+    const matchers = compileAll(statement.OrStatement.Statements, scope);
+
+    return (request): boolean => matchers.some((matches) => matches(request));
+  }
+
+  if (statement.NotStatement !== undefined) {
+    const matches = compileSimWafStatement(
+      statement.NotStatement.Statement,
+      scope,
+    );
+
+    return (request): boolean => !matches(request);
+  }
+
+  invalidSimWafRule(scope.ruleName, "The statement names no statement kind");
+}
+
+/**
+ * Compile the statements a logical statement joins, refusing an empty list.
+ *
+ * Real WAF requires at least two, and an `AndStatement` with none would
+ * otherwise match every request while looking like it narrowed one.
+ */
+function compileAll(
+  statements: readonly SimWafStatementInput[] | undefined,
+  scope: SimWafStatementScope,
+): readonly SimWafMatcher[] {
+  if (statements === undefined || statements.length === 0) {
+    invalidSimWafRule(
+      scope.ruleName,
+      "An AndStatement or OrStatement needs statements to join",
+    );
+  }
+
+  return statements.map((statement) =>
+    compileSimWafStatement(statement, scope),
+  );
+}

--- a/src/service/wafv2/statement/sim-waf-regex-match.ts
+++ b/src/service/wafv2/statement/sim-waf-regex-match.ts
@@ -1,0 +1,80 @@
+import type { SimWafRegexPatternSet } from "../regex-pattern-set/sim-waf-regex-pattern-set.js";
+import type { SimWafResourceStore } from "../resource/sim-waf-resource-store.js";
+import type { SimWafValueTest } from "./sim-waf-field-match.js";
+import { simWafRegExp } from "./sim-waf-regex.js";
+import { invalidSimWafRule } from "./sim-waf-rule-refusals.js";
+import { SimWafNonexistentItemException } from "../error/sim-wafv2.error.js";
+
+/**
+ * Minimal structural WAFv2 RegexMatchStatement.
+ */
+export interface SimWafRegexMatchStatementInput {
+  readonly RegexString?: string | undefined;
+}
+
+/**
+ * Minimal structural WAFv2 RegexPatternSetReferenceStatement.
+ */
+export interface SimWafRegexPatternSetReferenceInput {
+  readonly ARN?: string | undefined;
+}
+
+/**
+ * Build the test a RegexMatchStatement puts each string through.
+ */
+export function simWafRegexTest(
+  statement: SimWafRegexMatchStatementInput,
+  ruleName: string,
+): SimWafValueTest {
+  const pattern = statement.RegexString;
+
+  if (pattern === undefined) {
+    invalidSimWafRule(ruleName, "RegexMatchStatement needs a RegexString");
+  }
+
+  const expression = simWafRegExp(pattern);
+
+  if (expression === undefined) {
+    invalidSimWafRule(
+      ruleName,
+      `The regular expression ${pattern} is not valid`,
+    );
+  }
+
+  return (value): boolean => expression.test(value);
+}
+
+/**
+ * Build the test a RegexPatternSetReferenceStatement puts each string through.
+ *
+ * The set is resolved when the rule is written rather than when a request
+ * arrives, so an ARN naming nothing is refused by CreateWebACL the way real
+ * WAF refuses it. The patterns themselves are read at match time, from the set
+ * the reference resolved to, so a rule follows the set it names.
+ */
+export function simWafRegexPatternSetTest(
+  statement: SimWafRegexPatternSetReferenceInput,
+  ruleName: string,
+  regexPatternSets: SimWafResourceStore<SimWafRegexPatternSet>,
+): SimWafValueTest {
+  const arn = statement.ARN;
+
+  if (arn === undefined) {
+    invalidSimWafRule(
+      ruleName,
+      "RegexPatternSetReferenceStatement needs an ARN",
+    );
+  }
+
+  const patternSet = regexPatternSets.findByArn(arn);
+
+  if (patternSet === undefined) {
+    throw new SimWafNonexistentItemException(
+      `AWS WAF couldn't perform the operation because your resource doesn't ` +
+        `exist: the rule ${ruleName} refers to the regex pattern set ${arn}.`,
+    );
+  }
+
+  return (value): boolean =>
+    patternSet.expressions.some((expression) => expression.test(value));
+}

--- a/src/service/wafv2/statement/sim-waf-regex.ts
+++ b/src/service/wafv2/statement/sim-waf-regex.ts
@@ -1,0 +1,27 @@
+/**
+ * Compile one WAFv2 regular expression, or answer with nothing when it will
+ * not compile.
+ *
+ * WAF matches without anchoring, so a pattern claims a value when it is found
+ * anywhere in it, and matching is case sensitive unless the rule asked for a
+ * LOWERCASE transformation.
+ *
+ * The pattern is compiled without the unicode flag. WAF's own dialect is a
+ * subset of PCRE, and a pattern written for it can hold escapes that a unicode
+ * mode expression rejects outright, so the looser mode is the one that accepts
+ * what AWS accepts.
+ */
+export function simWafRegExp(pattern: string): RegExp | undefined {
+  try {
+    /*
+     * The pattern comes from whoever wrote the web ACL, never from a request,
+     * so a pattern that backtracks badly holds up that author's own test run
+     * and nothing else. Real WAF bounds the expression instead, at 200
+     * characters and its own capacity units.
+     */
+    // oxlint-disable-next-line security/detect-non-literal-regexp
+    return new RegExp(pattern);
+  } catch {
+    return undefined;
+  }
+}

--- a/src/service/wafv2/statement/sim-waf-request-fields.ts
+++ b/src/service/wafv2/statement/sim-waf-request-fields.ts
@@ -1,0 +1,135 @@
+import { invalidSimWafRule } from "./sim-waf-rule-refusals.js";
+
+/**
+ * One header, cookie or query argument, as WAF sees it.
+ */
+export interface SimWafNameValue {
+  readonly name: string;
+  readonly value: string;
+}
+
+/**
+ * Which headers or cookies a rule reads.
+ */
+export interface SimWafMatchPatternInput {
+  readonly All?: unknown;
+  readonly IncludedHeaders?: readonly string[] | undefined;
+  readonly ExcludedHeaders?: readonly string[] | undefined;
+  readonly IncludedCookies?: readonly string[] | undefined;
+  readonly ExcludedCookies?: readonly string[] | undefined;
+}
+
+/**
+ * Whether a rule reads the names, the values, or both.
+ */
+export type SimWafMatchScope = "ALL" | "KEY" | "VALUE";
+
+/**
+ * Split a query string into its arguments without decoding them.
+ *
+ * Decoding is what the URL_DECODE text transformation is for, so a rule that
+ * did not ask for it sees the argument as it arrived. Names are lower cased,
+ * as WAF lower cases both sides before comparing a `SingleQueryArgument`.
+ */
+export function simWafQueryArguments(
+  queryString: string,
+): readonly SimWafNameValue[] {
+  return queryString
+    .split("&")
+    .filter((pair) => pair !== "")
+    .map((pair) => {
+      const separator = pair.indexOf("=");
+
+      return separator === -1
+        ? { name: pair.toLowerCase(), value: "" }
+        : {
+            name: pair.slice(0, separator).toLowerCase(),
+            value: pair.slice(separator + 1),
+          };
+    });
+}
+
+/**
+ * Read the cookies one request sent.
+ */
+export function simWafCookies(headers: Headers): readonly SimWafNameValue[] {
+  return (headers.get("cookie") ?? "")
+    .split(";")
+    .map((cookie) => cookie.trim())
+    .filter((cookie) => cookie !== "")
+    .map((cookie) => {
+      const separator = cookie.indexOf("=");
+
+      return separator === -1
+        ? { name: cookie, value: "" }
+        : {
+            name: cookie.slice(0, separator),
+            value: cookie.slice(separator + 1),
+          };
+    });
+}
+
+/**
+ * Read the headers one request sent, lower cased as HTTP treats them.
+ */
+export function simWafHeaderEntries(
+  headers: Headers,
+): readonly SimWafNameValue[] {
+  return [...headers].map(([name, value]) => ({ name, value }));
+}
+
+/**
+ * Narrow a set of headers or cookies to the ones a rule inspects, and read the
+ * part of each that it matches against.
+ */
+export function simWafPatternCandidates(properties: {
+  readonly entries: readonly SimWafNameValue[];
+  readonly pattern: SimWafMatchPatternInput | undefined;
+  readonly matchScope: SimWafMatchScope;
+}): readonly string[] {
+  const { entries, pattern, matchScope } = properties;
+  const included = names(pattern?.IncludedHeaders ?? pattern?.IncludedCookies);
+  const excluded = names(pattern?.ExcludedHeaders ?? pattern?.ExcludedCookies);
+
+  return entries
+    .filter(
+      (entry) =>
+        (included === undefined || included.has(entry.name.toLowerCase())) &&
+        (excluded === undefined || !excluded.has(entry.name.toLowerCase())),
+    )
+    .flatMap((entry) => scoped(entry, matchScope));
+}
+
+/**
+ * Read the match scope a rule named, refusing anything else.
+ */
+export function requiredSimWafMatchScope(
+  matchScope: string | undefined,
+  ruleName: string,
+): SimWafMatchScope {
+  if (matchScope !== "ALL" && matchScope !== "KEY" && matchScope !== "VALUE") {
+    invalidSimWafRule(
+      ruleName,
+      `The match scope ${String(matchScope)} is not valid`,
+    );
+  }
+
+  return matchScope;
+}
+
+function names(listed: readonly string[] | undefined): Set<string> | undefined {
+  return listed === undefined
+    ? undefined
+    : new Set(listed.map((name) => name.toLowerCase()));
+}
+
+function scoped(
+  entry: SimWafNameValue,
+  matchScope: SimWafMatchScope,
+): string[] {
+  if (matchScope === "KEY") {
+    return [entry.name];
+  }
+
+  return matchScope === "VALUE" ? [entry.value] : [entry.name, entry.value];
+}

--- a/src/service/wafv2/statement/sim-waf-rule-refusals.ts
+++ b/src/service/wafv2/statement/sim-waf-rule-refusals.ts
@@ -1,0 +1,33 @@
+import {
+  SimWafInvalidParameterException,
+  SimWafUnsimulatedInputException,
+} from "../error/sim-wafv2.error.js";
+
+/**
+ * Refuse something in a rule that real WAFv2 takes and this simulation does
+ * not.
+ *
+ * Every refusal names the rule and what in it was refused, because a web ACL
+ * is a list of rules that all look alike from the outside and the name is the
+ * only thing that says which one to go and look at.
+ */
+export function refuseSimWafRuleInput(
+  ruleName: string,
+  refused: string,
+  reason: string,
+): never {
+  throw new SimWafUnsimulatedInputException(
+    `Rule ${ruleName} uses ${refused}, which Yulin does not simulate: ` +
+      `${reason}. A web ACL that accepted a rule it cannot evaluate would ` +
+      `allow a request AWS blocks.`,
+  );
+}
+
+/**
+ * Refuse a rule real WAFv2 would refuse too.
+ */
+export function invalidSimWafRule(ruleName: string, reason: string): never {
+  throw new SimWafInvalidParameterException(
+    `Error reason: ${reason}, field: RULE, parameter: ${ruleName}`,
+  );
+}

--- a/src/service/wafv2/statement/sim-waf-set-field.ts
+++ b/src/service/wafv2/statement/sim-waf-set-field.ts
@@ -1,0 +1,84 @@
+import type { SimWafInspectedRequest } from "../evaluate/sim-waf-inspected-request.js";
+import {
+  type SimWafFieldContent,
+  requiredSimWafOversizeHandling,
+  simWafFieldContent,
+} from "./sim-waf-field-content.js";
+import type {
+  SimWafFieldToMatchInput,
+  SimWafHeadersFieldInput,
+} from "./sim-waf-field-to-match.type.js";
+import type { SimWafFieldReader } from "./sim-waf-field-to-match.js";
+import {
+  type SimWafNameValue,
+  requiredSimWafMatchScope,
+  simWafCookies,
+  simWafHeaderEntries,
+  simWafPatternCandidates,
+} from "./sim-waf-request-fields.js";
+import { invalidSimWafRule } from "./sim-waf-rule-refusals.js";
+
+const decoder = new TextDecoder();
+
+/**
+ * Build the reader for the fields whose content WAF stops reading once it
+ * reaches its inspection limit.
+ *
+ * These three are the ones that carry an `OversizeHandling`, because they are
+ * the ones a request can make too big to read: a body, a header set, a cookie
+ * set.
+ */
+export function compileSimWafSetField(
+  field: SimWafFieldToMatchInput,
+  ruleName: string,
+): SimWafFieldReader {
+  if (field.Headers !== undefined) {
+    return entriesReader(field.Headers, ruleName, (request) =>
+      simWafHeaderEntries(request.headers),
+    );
+  }
+
+  if (field.Cookies !== undefined) {
+    return entriesReader(field.Cookies, ruleName, (request) =>
+      simWafCookies(request.headers),
+    );
+  }
+
+  if (field.Body === undefined) {
+    invalidSimWafRule(ruleName, "FieldToMatch names no field to match on");
+  }
+
+  const oversize = requiredSimWafOversizeHandling(
+    field.Body.OversizeHandling,
+    ruleName,
+  );
+
+  return (request): SimWafFieldContent =>
+    simWafFieldContent(
+      request.body === undefined ? [] : [decoder.decode(request.body)],
+      oversize,
+    );
+}
+
+function entriesReader(
+  input: SimWafHeadersFieldInput,
+  ruleName: string,
+  entries: (request: SimWafInspectedRequest) => readonly SimWafNameValue[],
+): SimWafFieldReader {
+  const matchScope = requiredSimWafMatchScope(input.MatchScope, ruleName);
+  const oversize = requiredSimWafOversizeHandling(
+    input.OversizeHandling,
+    ruleName,
+  );
+  const pattern = input.MatchPattern;
+
+  return (request): SimWafFieldContent =>
+    simWafFieldContent(
+      simWafPatternCandidates({
+        entries: entries(request),
+        pattern,
+        matchScope,
+      }),
+      oversize,
+    );
+}

--- a/src/service/wafv2/statement/sim-waf-size-constraint.ts
+++ b/src/service/wafv2/statement/sim-waf-size-constraint.ts
@@ -1,0 +1,52 @@
+import type { SimWafValueTest } from "./sim-waf-field-match.js";
+import { invalidSimWafRule } from "./sim-waf-rule-refusals.js";
+
+/**
+ * Minimal structural WAFv2 SizeConstraintStatement.
+ */
+export interface SimWafSizeConstraintStatementInput {
+  readonly ComparisonOperator?: string | undefined;
+  readonly Size?: number | undefined;
+}
+
+const encoder = new TextEncoder();
+
+const comparisons = new Map<string, (size: number, against: number) => boolean>(
+  [
+    ["EQ", (size, against): boolean => size === against],
+    ["NE", (size, against): boolean => size !== against],
+    ["LE", (size, against): boolean => size <= against],
+    ["LT", (size, against): boolean => size < against],
+    ["GE", (size, against): boolean => size >= against],
+    ["GT", (size, against): boolean => size > against],
+  ],
+);
+
+/**
+ * Build the test a SizeConstraintStatement puts each string through.
+ *
+ * The size is in bytes rather than characters, and it is the size after the
+ * rule's text transformations have run: a rule that decodes before it measures
+ * is measuring the decoded value.
+ */
+export function simWafSizeTest(
+  statement: SimWafSizeConstraintStatementInput,
+  ruleName: string,
+): SimWafValueTest {
+  const compare = comparisons.get(statement.ComparisonOperator ?? "");
+  const against = statement.Size;
+
+  if (compare === undefined) {
+    invalidSimWafRule(
+      ruleName,
+      `The comparison operator ${String(statement.ComparisonOperator)} is ` +
+        `not valid`,
+    );
+  }
+
+  if (against === undefined) {
+    invalidSimWafRule(ruleName, "SizeConstraintStatement needs a Size");
+  }
+
+  return (value): boolean => compare(encoder.encode(value).length, against);
+}

--- a/src/service/wafv2/statement/sim-waf-statement.ts
+++ b/src/service/wafv2/statement/sim-waf-statement.ts
@@ -1,0 +1,111 @@
+import type { SimWafRegexPatternSet } from "../regex-pattern-set/sim-waf-regex-pattern-set.js";
+import type { SimWafResourceStore } from "../resource/sim-waf-resource-store.js";
+import { simWafByteMatchTest } from "./sim-waf-byte-match.js";
+import {
+  compileSimWafFieldMatcher,
+  type SimWafMatcher,
+} from "./sim-waf-field-match.js";
+import {
+  simWafRegexPatternSetTest,
+  simWafRegexTest,
+} from "./sim-waf-regex-match.js";
+import { compileSimWafLogicalStatement } from "./sim-waf-logical-statement.js";
+import { invalidSimWafRule } from "./sim-waf-rule-refusals.js";
+import { simWafSizeTest } from "./sim-waf-size-constraint.js";
+import type {
+  SimWafFieldStatementInput,
+  SimWafStatementInput,
+} from "./sim-waf-statement.type.js";
+import { refuseUnsimulatedSimWafStatement } from "./sim-waf-unsimulated-statement.js";
+
+/**
+ * What a statement needs from the rest of the simulation to be compiled.
+ */
+export interface SimWafStatementScope {
+  readonly regexPatternSets: SimWafResourceStore<SimWafRegexPatternSet>;
+  readonly ruleName: string;
+}
+
+/**
+ * Turn one statement into the matcher a rule evaluates a request with.
+ *
+ * Compiling happens when the web ACL is written rather than when a request
+ * arrives, which is what lets `CreateWebACL` refuse a statement kind it cannot
+ * evaluate. It also means a rule does no parsing per request: what a request
+ * meets is a closure over what the rule already worked out.
+ */
+export function compileSimWafStatement(
+  statement: SimWafStatementInput | undefined,
+  scope: SimWafStatementScope,
+): SimWafMatcher {
+  const { ruleName } = scope;
+
+  if (statement === undefined) {
+    invalidSimWafRule(ruleName, "A rule needs a Statement");
+  }
+
+  refuseUnsimulatedSimWafStatement(statement, ruleName);
+
+  return (
+    compileFieldStatement(statement, scope) ??
+    compileSimWafLogicalStatement(statement, scope)
+  );
+}
+
+function compileFieldStatement(
+  statement: SimWafStatementInput,
+  scope: SimWafStatementScope,
+): SimWafMatcher | undefined {
+  const { ruleName } = scope;
+
+  if (statement.ByteMatchStatement !== undefined) {
+    const byteMatch = statement.ByteMatchStatement;
+
+    return fieldMatcher(
+      byteMatch,
+      ruleName,
+      simWafByteMatchTest(byteMatch, ruleName),
+    );
+  }
+
+  if (statement.RegexMatchStatement !== undefined) {
+    const regexMatch = statement.RegexMatchStatement;
+
+    return fieldMatcher(
+      regexMatch,
+      ruleName,
+      simWafRegexTest(regexMatch, ruleName),
+    );
+  }
+
+  if (statement.RegexPatternSetReferenceStatement !== undefined) {
+    const reference = statement.RegexPatternSetReferenceStatement;
+
+    return fieldMatcher(
+      reference,
+      ruleName,
+      simWafRegexPatternSetTest(reference, ruleName, scope.regexPatternSets),
+    );
+  }
+
+  if (statement.SizeConstraintStatement !== undefined) {
+    const size = statement.SizeConstraintStatement;
+
+    return fieldMatcher(size, ruleName, simWafSizeTest(size, ruleName));
+  }
+
+  return undefined;
+}
+
+function fieldMatcher(
+  statement: SimWafFieldStatementInput,
+  ruleName: string,
+  test: (value: string) => boolean,
+): SimWafMatcher {
+  return compileSimWafFieldMatcher({
+    field: statement.FieldToMatch,
+    transformations: statement.TextTransformations,
+    ruleName,
+    test,
+  });
+}

--- a/src/service/wafv2/statement/sim-waf-statement.type.ts
+++ b/src/service/wafv2/statement/sim-waf-statement.type.ts
@@ -1,0 +1,60 @@
+import type { SimWafByteMatchStatementInput } from "./sim-waf-byte-match.js";
+import type { SimWafFieldToMatchInput } from "./sim-waf-field-to-match.type.js";
+import type {
+  SimWafRegexMatchStatementInput,
+  SimWafRegexPatternSetReferenceInput,
+} from "./sim-waf-regex-match.js";
+import type { SimWafSizeConstraintStatementInput } from "./sim-waf-size-constraint.js";
+import type { SimWafTextTransformationInput } from "./sim-waf-text-transformation.js";
+
+/**
+ * What every statement that reads a request field carries.
+ */
+export interface SimWafFieldStatementInput {
+  readonly FieldToMatch?: SimWafFieldToMatchInput | undefined;
+  readonly TextTransformations?:
+    | readonly SimWafTextTransformationInput[]
+    | undefined;
+}
+
+/**
+ * Minimal structural WAFv2 Statement.
+ *
+ * The kinds Yulin refuses are declared alongside the ones it evaluates, so a
+ * rule that uses one is refused by name rather than read as a rule with no
+ * statement in it.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/wafv2/Interface/Statement/
+ */
+export interface SimWafStatementInput {
+  readonly ByteMatchStatement?:
+    | (SimWafByteMatchStatementInput & SimWafFieldStatementInput)
+    | undefined;
+  readonly RegexMatchStatement?:
+    | (SimWafRegexMatchStatementInput & SimWafFieldStatementInput)
+    | undefined;
+  readonly RegexPatternSetReferenceStatement?:
+    | (SimWafRegexPatternSetReferenceInput & SimWafFieldStatementInput)
+    | undefined;
+  readonly SizeConstraintStatement?:
+    | (SimWafSizeConstraintStatementInput & SimWafFieldStatementInput)
+    | undefined;
+  readonly AndStatement?:
+    | { readonly Statements?: readonly SimWafStatementInput[] | undefined }
+    | undefined;
+  readonly OrStatement?:
+    | { readonly Statements?: readonly SimWafStatementInput[] | undefined }
+    | undefined;
+  readonly NotStatement?:
+    | { readonly Statement?: SimWafStatementInput | undefined }
+    | undefined;
+  readonly IPSetReferenceStatement?: unknown;
+  readonly GeoMatchStatement?: unknown;
+  readonly AsnMatchStatement?: unknown;
+  readonly RateBasedStatement?: unknown;
+  readonly SqliMatchStatement?: unknown;
+  readonly XssMatchStatement?: unknown;
+  readonly LabelMatchStatement?: unknown;
+  readonly RuleGroupReferenceStatement?: unknown;
+  readonly ManagedRuleGroupStatement?: unknown;
+}

--- a/src/service/wafv2/statement/sim-waf-statements.iso.test.ts
+++ b/src/service/wafv2/statement/sim-waf-statements.iso.test.ts
@@ -1,0 +1,265 @@
+import { CreateRegexPatternSetCommand } from "@aws-sdk/client-wafv2";
+import {
+  assertFalse,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import {
+  SimWafInvalidParameterException,
+  SimWafNonexistentItemException,
+} from "../error/sim-wafv2.error.js";
+import { simWafStatementMatches } from "../sim-wafv2.fixture.js";
+import type { SimWafStatementInput } from "./sim-waf-statement.type.js";
+
+/**
+ * A byte match statement over the request path.
+ */
+function pathIs(searchString: string): SimWafStatementInput {
+  return {
+    ByteMatchStatement: {
+      SearchString: searchString,
+      PositionalConstraint: "STARTS_WITH",
+      FieldToMatch: { UriPath: {} },
+      TextTransformations: [{ Priority: 0, Type: "NONE" }],
+    },
+  };
+}
+
+/**
+ * A byte match statement over one header.
+ */
+function headerIs(name: string, value: string): SimWafStatementInput {
+  return {
+    ByteMatchStatement: {
+      SearchString: value,
+      PositionalConstraint: "EXACTLY",
+      FieldToMatch: { SingleHeader: { Name: name } },
+      TextTransformations: [{ Priority: 0, Type: "NONE" }],
+    },
+  };
+}
+
+function get(path: string, headers: Record<string, string> = {}): Request {
+  return new Request(`https://example.test${path}`, { headers });
+}
+
+describe("SimWafV2 statement kinds", () => {
+  it("matches a regular expression anywhere in a field", async () => {
+    // Given a statement over a regular expression.
+    const matches = await simWafStatementMatches(new SimAws().wafV2(), {
+      RegexMatchStatement: {
+        RegexString: String.raw`/wp-(login|admin)\.php`,
+        FieldToMatch: { UriPath: {} },
+        TextTransformations: [{ Priority: 0, Type: "NONE" }],
+      },
+    });
+
+    // Then a path the expression finds matches, and one it does not, does not.
+    assertTrue(matches(get("/wp-login.php")));
+    assertTrue(matches(get("/blog/wp-admin.php")));
+    assertFalse(matches(get("/wp-content/themes")));
+  });
+
+  it("refuses a regular expression that will not compile", async () => {
+    // Given a simulated WAFv2.
+    const waf = new SimAws().wafV2();
+
+    // When a rule carries an expression that is not one.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simWafStatementMatches(waf, {
+        RegexMatchStatement: {
+          RegexString: "(unclosed",
+          FieldToMatch: { UriPath: {} },
+          TextTransformations: [{ Priority: 0, Type: "NONE" }],
+        },
+      });
+    });
+
+    // Then it is refused where the rule was written rather than matching
+    // nothing when a request arrives.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+  });
+
+  it("matches any expression in a regex pattern set", async () => {
+    // Given a regex pattern set with two expressions in it.
+    const waf = new SimAws().wafV2();
+    const created = await waf.createRegexPatternSet(
+      new CreateRegexPatternSetCommand({
+        Name: "bad-agents",
+        Scope: "REGIONAL",
+        RegularExpressionList: [
+          { RegexString: "sqlmap" },
+          { RegexString: "nikto" },
+        ],
+      }),
+    );
+
+    assertNonNullable(created.Summary);
+
+    // When a rule points at it.
+    const matches = await simWafStatementMatches(waf, {
+      RegexPatternSetReferenceStatement: {
+        ARN: created.Summary.ARN,
+        FieldToMatch: { SingleHeader: { Name: "user-agent" } },
+        TextTransformations: [{ Priority: 0, Type: "NONE" }],
+      },
+    });
+
+    // Then either expression matching is enough.
+    assertTrue(matches(get("/", { "user-agent": "sqlmap/1.7" })));
+    assertTrue(matches(get("/", { "user-agent": "nikto" })));
+    assertFalse(matches(get("/", { "user-agent": "curl/8.0" })));
+  });
+
+  it("refuses a rule pointing at a regex pattern set that is not there", async () => {
+    // Given a simulated WAFv2 with no pattern sets in it.
+    const waf = new SimAws().wafV2();
+
+    // When a rule points at one by ARN anyway.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simWafStatementMatches(waf, {
+        RegexPatternSetReferenceStatement: {
+          ARN: "arn:aws:wafv2:eu-west-2:111111111111:regional/regexpatternset/x/y",
+          FieldToMatch: { UriPath: {} },
+          TextTransformations: [{ Priority: 0, Type: "NONE" }],
+        },
+      });
+    });
+
+    // Then the web ACL is refused, as real WAF refuses one naming a resource
+    // that does not exist.
+    assertInstanceOf(error, SimWafNonexistentItemException);
+  });
+
+  it("matches on the size of a field in bytes", async () => {
+    // Given a statement over the size of the request body.
+    const matches = await simWafStatementMatches(new SimAws().wafV2(), {
+      SizeConstraintStatement: {
+        ComparisonOperator: "GT",
+        Size: 8,
+        FieldToMatch: { Body: { OversizeHandling: "CONTINUE" } },
+        TextTransformations: [{ Priority: 0, Type: "NONE" }],
+      },
+    });
+    const encoder = new TextEncoder();
+    const sending = (body: string): boolean =>
+      matches(
+        new Request("https://example.test/", { method: "POST" }),
+        encoder.encode(body),
+      );
+
+    // Then the byte length decides, not the character count: five Greek
+    // letters are ten bytes and are over a limit eight characters are under.
+    assertTrue(sending("123456789"));
+    assertFalse(sending("12345678"));
+    assertTrue(sending("ααααα"));
+  });
+
+  it("compares a size every way WAF compares one", async () => {
+    // Given statements using each comparison against a five byte path.
+    const waf = new SimAws().wafV2();
+    const compares = await Promise.all(
+      ["EQ", "NE", "LE", "LT", "GE"].map(
+        async (operator) =>
+          await simWafStatementMatches(waf, {
+            SizeConstraintStatement: {
+              ComparisonOperator: operator,
+              Size: 5,
+              FieldToMatch: { UriPath: {} },
+              TextTransformations: [{ Priority: 0, Type: "NONE" }],
+            },
+          }),
+      ),
+    );
+
+    // Then each answers about `/blog` as arithmetic says it should.
+    const [equal, notEqual, atMost, lessThan, atLeast] = compares;
+
+    assertTrue(equal?.(get("/blog")));
+    assertFalse(notEqual?.(get("/blog")));
+    assertTrue(atMost?.(get("/blog")));
+    assertFalse(lessThan?.(get("/blog")));
+    assertTrue(atLeast?.(get("/blog")));
+  });
+
+  it("matches when every statement of an AndStatement matches", async () => {
+    // Given a statement joining two.
+    const matches = await simWafStatementMatches(new SimAws().wafV2(), {
+      AndStatement: {
+        Statements: [pathIs("/admin"), headerIs("x-role", "guest")],
+      },
+    });
+
+    // Then both have to match.
+    assertTrue(matches(get("/admin", { "x-role": "guest" })));
+    assertFalse(matches(get("/admin", { "x-role": "staff" })));
+    assertFalse(matches(get("/public", { "x-role": "guest" })));
+  });
+
+  it("matches when any statement of an OrStatement matches", async () => {
+    // Given a statement joining two.
+    const matches = await simWafStatementMatches(new SimAws().wafV2(), {
+      OrStatement: {
+        Statements: [pathIs("/admin"), pathIs("/internal")],
+      },
+    });
+
+    // Then either matching is enough.
+    assertTrue(matches(get("/admin")));
+    assertTrue(matches(get("/internal")));
+    assertFalse(matches(get("/public")));
+  });
+
+  it("matches the requests a NotStatement's statement does not", async () => {
+    // Given a statement over the absence of a header, nested inside an And.
+    const matches = await simWafStatementMatches(new SimAws().wafV2(), {
+      AndStatement: {
+        Statements: [
+          pathIs("/internal"),
+          { NotStatement: { Statement: headerIs("x-role", "staff") } },
+        ],
+      },
+    });
+
+    // Then the internal path is claimed for everyone but staff, which is what
+    // nesting the three together is for.
+    assertTrue(matches(get("/internal", { "x-role": "guest" })));
+    assertFalse(matches(get("/internal", { "x-role": "staff" })));
+    assertFalse(matches(get("/public", { "x-role": "guest" })));
+  });
+
+  it("refuses an AndStatement with nothing to join", async () => {
+    // Given a simulated WAFv2.
+    const waf = new SimAws().wafV2();
+
+    // When a rule joins an empty list of statements.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simWafStatementMatches(waf, { AndStatement: { Statements: [] } });
+    });
+
+    // Then it is refused rather than claiming every request, which is what an
+    // empty `every` would do.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "statements to join");
+  });
+
+  it("refuses a rule whose statement names no kind", async () => {
+    // Given a simulated WAFv2.
+    const waf = new SimAws().wafV2();
+
+    // When a rule carries an empty statement.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simWafStatementMatches(waf, {});
+    });
+
+    // Then it is refused rather than matching nothing.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "no statement kind");
+  });
+});

--- a/src/service/wafv2/statement/sim-waf-text-transformation.iso.test.ts
+++ b/src/service/wafv2/statement/sim-waf-text-transformation.iso.test.ts
@@ -1,0 +1,172 @@
+import { assertFalse, assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import {
+  type SimWafStatementMatch,
+  simWafStatementMatches,
+} from "../sim-wafv2.fixture.js";
+import type { SimWafStatementInput } from "./sim-waf-statement.type.js";
+import type { SimWafTextTransformationInput } from "./sim-waf-text-transformation.js";
+
+/**
+ * A statement looking for one string in the request body, after the given
+ * transformations.
+ *
+ * The body is the field here because it carries whatever bytes a test sends.
+ * A URL drops tabs and newlines and cuts a value off at a `#`, so a query
+ * string could not carry the input these transformations exist for.
+ */
+function transformed(
+  searchString: string,
+  transformations: readonly SimWafTextTransformationInput[],
+): SimWafStatementInput {
+  return {
+    ByteMatchStatement: {
+      SearchString: searchString,
+      PositionalConstraint: "CONTAINS",
+      FieldToMatch: { Body: { OversizeHandling: "CONTINUE" } },
+      TextTransformations: transformations,
+    },
+  };
+}
+
+const encoder = new TextEncoder();
+
+/**
+ * Whether a statement claims a request carrying one body.
+ */
+function sending(matches: SimWafStatementMatch, body: string): boolean {
+  return matches(
+    new Request("https://example.test/", { method: "POST" }),
+    encoder.encode(body),
+  );
+}
+
+describe("SimWafV2 text transformations", () => {
+  it("reads a field as it arrived under NONE", async () => {
+    // Given a statement that transforms nothing.
+    const matches = await simWafStatementMatches(
+      new SimAws().wafV2(),
+      transformed("%2e%2e%2f", [{ Priority: 0, Type: "NONE" }]),
+    );
+
+    // Then the field is compared as it was sent.
+    assertTrue(sending(matches, "path=%2e%2e%2f"));
+  });
+
+  it("lower cases a field", async () => {
+    // Given a statement that lower cases first.
+    const matches = await simWafStatementMatches(
+      new SimAws().wafV2(),
+      transformed("select", [{ Priority: 0, Type: "LOWERCASE" }]),
+    );
+
+    // Then a value in any case matches.
+    assertTrue(sending(matches, "q=SELECT"));
+  });
+
+  it("decodes percent escapes and plus signs", async () => {
+    // Given a statement that URL decodes first.
+    const waf = new SimAws().wafV2();
+    const matches = await simWafStatementMatches(
+      waf,
+      transformed("../etc/passwd", [{ Priority: 0, Type: "URL_DECODE" }]),
+    );
+    const spaced = await simWafStatementMatches(
+      waf,
+      transformed("one two", [{ Priority: 0, Type: "URL_DECODE" }]),
+    );
+
+    // Then an escaped traversal matches the plain one it decodes to, and a
+    // plus sign decodes to a space as it does in a form encoded value.
+    assertTrue(sending(matches, "file=%2e%2e%2fetc%2fpasswd"));
+    assertTrue(sending(spaced, "q=one+two"));
+  });
+
+  it("leaves an escape that decodes to nothing as it stands", async () => {
+    // Given a statement that URL decodes first.
+    const matches = await simWafStatementMatches(
+      new SimAws().wafV2(),
+      transformed("%e0", [{ Priority: 0, Type: "URL_DECODE" }]),
+    );
+
+    // Then a malformed escape is still inspected rather than throwing the
+    // whole match away, which would be a way past the rule.
+    assertTrue(sending(matches, "q=%e0"));
+  });
+
+  it("collapses whitespace to single spaces", async () => {
+    // Given a statement that compresses whitespace first.
+    const matches = await simWafStatementMatches(
+      new SimAws().wafV2(),
+      transformed("union select", [
+        { Priority: 0, Type: "COMPRESS_WHITE_SPACE" },
+      ]),
+    );
+
+    // Then tabs, newlines and runs of spaces all read as one space, which is
+    // what stops whitespace being used to break the search string up.
+    assertTrue(sending(matches, "q=union\t\n   select"));
+  });
+
+  it("decodes HTML entities, named and numbered", async () => {
+    // Given a statement that decodes HTML entities first.
+    const matches = await simWafStatementMatches(
+      new SimAws().wafV2(),
+      transformed("<script>", [{ Priority: 0, Type: "HTML_ENTITY_DECODE" }]),
+    );
+
+    // Then either spelling of an entity decodes to the character it names.
+    assertTrue(sending(matches, "q=&lt;script&gt;"));
+    assertTrue(sending(matches, "q=&#60;script&#x3e;"));
+  });
+
+  it("leaves an entity it does not know as it stands", async () => {
+    // Given a statement that decodes HTML entities first.
+    const matches = await simWafStatementMatches(
+      new SimAws().wafV2(),
+      transformed("&dagger;", [{ Priority: 0, Type: "HTML_ENTITY_DECODE" }]),
+    );
+
+    // Then an entity outside the set WAF decodes stays in the value.
+    assertTrue(sending(matches, "q=&dagger;"));
+  });
+
+  it("leaves a code point outside Unicode as it stands", async () => {
+    // Given a statement that decodes HTML entities first.
+    const matches = await simWafStatementMatches(
+      new SimAws().wafV2(),
+      transformed("&#x110000;", [{ Priority: 0, Type: "HTML_ENTITY_DECODE" }]),
+    );
+
+    // Then a numbered entity naming no character is not decoded.
+    assertTrue(sending(matches, "q=&#x110000;"));
+  });
+
+  it("applies transformations in ascending priority", async () => {
+    // Given two statements with the same transformations in the two orders,
+    // looking for a string only one order can produce.
+    const waf = new SimAws().wafV2();
+    const decodeThenLower = await simWafStatementMatches(
+      waf,
+      transformed("select", [
+        { Priority: 1, Type: "LOWERCASE" },
+        { Priority: 0, Type: "URL_DECODE" },
+      ]),
+    );
+    const lowerThenDecode = await simWafStatementMatches(
+      waf,
+      transformed("select", [
+        { Priority: 0, Type: "LOWERCASE" },
+        { Priority: 1, Type: "URL_DECODE" },
+      ]),
+    );
+
+    // Then priority decides, not the order the list was written in: lower
+    // casing `%53ELECT` before decoding leaves `%53elect`, which decodes to
+    // `Select` and does not match.
+    assertTrue(sending(decodeThenLower, "q=%53ELECT"));
+    assertFalse(sending(lowerThenDecode, "q=%53ELECT"));
+  });
+});

--- a/src/service/wafv2/statement/sim-waf-text-transformation.ts
+++ b/src/service/wafv2/statement/sim-waf-text-transformation.ts
@@ -1,0 +1,137 @@
+import { refuseSimWafRuleInput } from "./sim-waf-rule-refusals.js";
+
+/**
+ * Minimal structural WAFv2 text transformation.
+ */
+export interface SimWafTextTransformationInput {
+  readonly Priority?: number | undefined;
+  readonly Type?: string | undefined;
+}
+
+/**
+ * What a rule does to a field before it matches against it.
+ */
+export type SimWafTextTransform = (value: string) => string;
+
+const namedEntities = new Map<string, string>([
+  ["quot", '"'],
+  ["nbsp", " "],
+  ["amp", "&"],
+  ["lt", "<"],
+  ["gt", ">"],
+]);
+
+const transforms = new Map<string, SimWafTextTransform>([
+  ["NONE", (value): string => value],
+  ["LOWERCASE", (value): string => value.toLowerCase()],
+  ["URL_DECODE", urlDecode],
+  ["COMPRESS_WHITE_SPACE", compressWhitespace],
+  ["HTML_ENTITY_DECODE", htmlEntityDecode],
+]);
+
+/**
+ * Build the transformation a rule applies to every field it reads.
+ *
+ * WAF applies them in ascending `Priority` rather than in the order they were
+ * written, so lowercasing after decoding is a different rule from decoding
+ * after lowercasing however the list is arranged.
+ */
+export function compileSimWafTextTransformations(
+  transformations: readonly SimWafTextTransformationInput[] | undefined,
+  ruleName: string,
+): SimWafTextTransform {
+  const ordered = (transformations ?? [])
+    .toSorted((left, right) => (left.Priority ?? 0) - (right.Priority ?? 0))
+    .map((transformation) => compileOne(transformation, ruleName));
+
+  return (value): string => {
+    let transformed = value;
+
+    for (const transform of ordered) {
+      transformed = transform(transformed);
+    }
+
+    return transformed;
+  };
+}
+
+function compileOne(
+  transformation: SimWafTextTransformationInput,
+  ruleName: string,
+): SimWafTextTransform {
+  const transform = transforms.get(transformation.Type ?? "");
+
+  if (transform === undefined) {
+    refuseSimWafRuleInput(
+      ruleName,
+      `the text transformation ${String(transformation.Type)}`,
+      "only NONE, LOWERCASE, URL_DECODE, COMPRESS_WHITE_SPACE and " +
+        "HTML_ENTITY_DECODE are simulated",
+    );
+  }
+
+  return transform;
+}
+
+/**
+ * Decode percent escapes and `+` as a space, as WAF's URL_DECODE does.
+ *
+ * An escape that decodes to nothing is left as it stands rather than failing
+ * the whole match. WAF still inspects malformed input, and a rule that threw
+ * its hands up at it would be a way past the rule.
+ */
+function urlDecode(value: string): string {
+  return value.replaceAll(/\+|%[\da-f]{2}/giu, (escape) => {
+    if (escape === "+") {
+      return " ";
+    }
+
+    try {
+      return decodeURIComponent(escape);
+    } catch {
+      return escape;
+    }
+  });
+}
+
+/**
+ * Replace every whitespace character with a space and collapse runs of them.
+ *
+ * The set is WAF's own, which includes the non-breaking space that a plain
+ * `\s` leaves alone.
+ */
+function compressWhitespace(value: string): string {
+  return value.replaceAll(/[\f\n\r\t\v\u{20}\u{A0}]+/gu, " ");
+}
+
+/**
+ * Decode the HTML entities WAF's HTML_ENTITY_DECODE decodes, named and
+ * numbered alike.
+ */
+function htmlEntityDecode(value: string): string {
+  return value.replaceAll(
+    /&(#x[\da-f]+|#\d+|[a-z]+);?/giu,
+    (entity: string, body: string) =>
+      decodeEntity(body.toLowerCase()) ?? entity,
+  );
+}
+
+function decodeEntity(body: string): string | undefined {
+  if (body.startsWith("#x")) {
+    return fromCodePoint(Number.parseInt(body.slice(2), 16));
+  }
+
+  if (body.startsWith("#")) {
+    return fromCodePoint(Number(body.slice(1)));
+  }
+
+  return namedEntities.get(body);
+}
+
+function fromCodePoint(codePoint: number): string | undefined {
+  return Number.isSafeInteger(codePoint) &&
+    codePoint >= 0 &&
+    codePoint <= 0x10_ff_ff
+    ? String.fromCodePoint(codePoint)
+    : undefined;
+}

--- a/src/service/wafv2/statement/sim-waf-unsimulated-field.ts
+++ b/src/service/wafv2/statement/sim-waf-unsimulated-field.ts
@@ -1,0 +1,62 @@
+import type { SimWafFieldToMatchInput } from "./sim-waf-field-to-match.type.js";
+import { refuseSimWafRuleInput } from "./sim-waf-rule-refusals.js";
+
+/**
+ * Refuse the field-to-match kinds real WAFv2 offers and this simulation does
+ * not read.
+ *
+ * Each is named where the rule was written, because a field that was accepted
+ * and then never read would leave the rule matching nothing at all: the web
+ * ACL would look like it covered the request and would let it through.
+ */
+export function refuseUnsimulatedSimWafField(
+  field: SimWafFieldToMatchInput,
+  ruleName: string,
+): void {
+  if (field.JsonBody !== undefined) {
+    refuseSimWafRuleInput(
+      ruleName,
+      "the field to match JsonBody",
+      "matching inside a parsed JSON body has a path syntax of its own, and " +
+        "its own answer for a body that will not parse",
+    );
+  }
+
+  if (field.HeaderOrder !== undefined) {
+    refuseSimWafRuleInput(
+      ruleName,
+      "the field to match HeaderOrder",
+      "the order headers arrived in is not something a simulated request " +
+        "carries",
+    );
+  }
+
+  if (field.UriFragment !== undefined) {
+    refuseSimWafRuleInput(
+      ruleName,
+      "the field to match UriFragment",
+      "a fragment is never sent to a server, so no request here has one",
+    );
+  }
+
+  refuseFingerprintFields(field, ruleName);
+}
+
+function refuseFingerprintFields(
+  field: SimWafFieldToMatchInput,
+  ruleName: string,
+): void {
+  const fingerprint =
+    field.JA3Fingerprint === undefined ? undefined : "JA3Fingerprint";
+  const named =
+    field.JA4Fingerprint === undefined ? fingerprint : "JA4Fingerprint";
+
+  if (named !== undefined) {
+    refuseSimWafRuleInput(
+      ruleName,
+      `the field to match ${named}`,
+      "a TLS fingerprint comes from the handshake, and a request that " +
+        "reached a simulated service made none",
+    );
+  }
+}

--- a/src/service/wafv2/statement/sim-waf-unsimulated-statement.ts
+++ b/src/service/wafv2/statement/sim-waf-unsimulated-statement.ts
@@ -1,0 +1,58 @@
+import { refuseSimWafRuleInput } from "./sim-waf-rule-refusals.js";
+import type { SimWafStatementInput } from "./sim-waf-statement.type.js";
+
+const oneClientAddress =
+  "every request in this simulation reports a source address of 127.0.0.1, " +
+  "so a rule on where a request came from would see one client for the " +
+  "whole simulation";
+
+const undocumentedDetection =
+  "AWS does not document the detection it runs, so a simulation of it would " +
+  "agree with real WAF by coincidence or not at all";
+
+/**
+ * The statement kinds real WAFv2 evaluates and this simulation does not, and
+ * why each of them is refused rather than deferred.
+ */
+const refusedStatements = new Map<string, string>([
+  ["IPSetReferenceStatement", oneClientAddress],
+  ["GeoMatchStatement", oneClientAddress],
+  ["AsnMatchStatement", oneClientAddress],
+  ["SqliMatchStatement", undocumentedDetection],
+  ["XssMatchStatement", undocumentedDetection],
+  [
+    "RateBasedStatement",
+    "counting requests over a time window against the simulated clock is " +
+      "feasible and is not part of this",
+  ],
+  [
+    "LabelMatchStatement",
+    "nothing here adds a label to a request, and labels arrive with the AWS " +
+      "managed rule groups",
+  ],
+  [
+    "ManagedRuleGroupStatement",
+    "the AWS managed rule groups are a body of rules Yulin would have to " +
+      "carry, and they have an issue of their own",
+  ],
+  [
+    "RuleGroupReferenceStatement",
+    "a rule group is a resource in its own right, and none is simulated",
+  ],
+]);
+
+/**
+ * Refuse a statement kind this simulation cannot evaluate.
+ */
+export function refuseUnsimulatedSimWafStatement(
+  statement: SimWafStatementInput,
+  ruleName: string,
+): void {
+  for (const [kind, value] of Object.entries(statement)) {
+    const reason = refusedStatements.get(kind);
+
+    if (reason !== undefined && value !== undefined) {
+      refuseSimWafRuleInput(ruleName, `the statement kind ${kind}`, reason);
+    }
+  }
+}

--- a/src/service/wafv2/web-acl/sim-waf-action-input.ts
+++ b/src/service/wafv2/web-acl/sim-waf-action-input.ts
@@ -1,0 +1,79 @@
+import {
+  simWafDefaultBlockedResponse,
+  type SimWafBlockedResponse,
+} from "../evaluate/sim-waf-blocked-response.js";
+import {
+  invalidSimWafRule,
+  refuseSimWafRuleInput,
+} from "../statement/sim-waf-rule-refusals.js";
+import {
+  requiredSimWafResponseBody,
+  simWafCustomHeaders,
+} from "./sim-waf-custom-response.js";
+import type {
+  SimWafCustomResponseBodies,
+  SimWafCustomResponseInput,
+} from "./sim-waf-custom-response.type.js";
+import type { SimWafActionInput } from "./sim-waf-action.type.js";
+
+/**
+ * What a block action answers with, which is WAF's own 403 unless the rule
+ * named a response of its own.
+ */
+export function simWafBlockedResponse(
+  customResponse: SimWafCustomResponseInput | undefined,
+  bodies: SimWafCustomResponseBodies,
+): SimWafBlockedResponse {
+  const fallback = simWafDefaultBlockedResponse();
+
+  if (customResponse === undefined) {
+    return fallback;
+  }
+
+  const key = customResponse.CustomResponseBodyKey;
+  const body =
+    key === undefined ? undefined : requiredSimWafResponseBody(key, bodies);
+
+  return {
+    statusCode: customResponse.ResponseCode ?? fallback.statusCode,
+    contentType: body?.contentType ?? fallback.contentType,
+    body: body?.content ?? fallback.body,
+    headers: simWafCustomHeaders(customResponse.ResponseHeaders),
+  };
+}
+
+/**
+ * Refuse an action this simulation cannot carry out.
+ *
+ * `Captcha` and `Challenge` are answered by a browser solving a puzzle and
+ * sending a token back, which nothing in a test does. An action naming two
+ * things to do is refused as well: real WAFv2 takes one, so reading the first
+ * one found would make which of them applied a matter of the order they are
+ * checked in.
+ */
+export function refuseUnsimulatedSimWafAction(
+  action: SimWafActionInput | undefined,
+  ruleName: string,
+): void {
+  const named = Object.entries(action ?? {})
+    .filter(([, value]) => value !== undefined)
+    .map(([kind]) => kind);
+
+  for (const kind of named) {
+    if (kind === "Captcha" || kind === "Challenge") {
+      refuseSimWafRuleInput(
+        ruleName,
+        `the ${kind} action`,
+        "it is answered by a browser solving a puzzle and sending a token " +
+          "back, and nothing in a test does that",
+      );
+    }
+  }
+
+  if (named.length > 1) {
+    invalidSimWafRule(
+      ruleName,
+      `The action names ${named.join(" and ")}, and a rule takes one action`,
+    );
+  }
+}

--- a/src/service/wafv2/web-acl/sim-waf-action.ts
+++ b/src/service/wafv2/web-acl/sim-waf-action.ts
@@ -1,0 +1,91 @@
+import type { SimWafBlockedResponse } from "../evaluate/sim-waf-blocked-response.js";
+import { invalidSimWafRule } from "../statement/sim-waf-rule-refusals.js";
+import {
+  refuseUnsimulatedSimWafAction,
+  simWafBlockedResponse,
+} from "./sim-waf-action-input.js";
+import type {
+  SimWafActionInput,
+  SimWafActionKind,
+  SimWafHandledActionInput,
+} from "./sim-waf-action.type.js";
+import { simWafCustomHeaders } from "./sim-waf-custom-response.js";
+import type {
+  SimWafCustomResponseBodies,
+  SimWafHeader,
+} from "./sim-waf-custom-response.type.js";
+
+interface SimWafActionProperties {
+  readonly kind: SimWafActionKind;
+  readonly insertHeaders: readonly SimWafHeader[];
+  readonly blocked: SimWafBlockedResponse | undefined;
+}
+
+/**
+ * One resolved action, ready to apply to a request.
+ *
+ * `Count` is the odd one: it records that the rule matched and lets evaluation
+ * carry on to the next rule, so it is the one action that does not decide
+ * anything. `isTerminating` is what the evaluation loop reads.
+ */
+export class SimWafAction {
+  public readonly kind: SimWafActionKind;
+  public readonly insertHeaders: readonly SimWafHeader[];
+  public readonly blocked: SimWafBlockedResponse | undefined;
+
+  private constructor(properties: SimWafActionProperties) {
+    this.kind = properties.kind;
+    this.insertHeaders = properties.insertHeaders;
+    this.blocked = properties.blocked;
+  }
+
+  /**
+   * Read the action a rule or a web ACL default named.
+   */
+  static read(
+    action: SimWafActionInput | undefined,
+    ruleName: string,
+    bodies: SimWafCustomResponseBodies,
+  ): SimWafAction {
+    refuseUnsimulatedSimWafAction(action, ruleName);
+
+    if (action?.Allow !== undefined) {
+      return this.handling("ALLOW", action.Allow);
+    }
+
+    if (action?.Count !== undefined) {
+      return this.handling("COUNT", action.Count);
+    }
+
+    if (action?.Block !== undefined) {
+      return new SimWafAction({
+        kind: "BLOCK",
+        insertHeaders: [],
+        blocked: simWafBlockedResponse(action.Block.CustomResponse, bodies),
+      });
+    }
+
+    invalidSimWafRule(ruleName, "The action names no action to take");
+  }
+
+  private static handling(
+    kind: SimWafActionKind,
+    action: SimWafHandledActionInput,
+  ): SimWafAction {
+    return new SimWafAction({
+      kind,
+      insertHeaders: simWafCustomHeaders(
+        action.CustomRequestHandling?.InsertHeaders,
+      ),
+      blocked: undefined,
+    });
+  }
+
+  /**
+   * Whether this action decides the request rather than noting it and moving
+   * on.
+   */
+  get isTerminating(): boolean {
+    return this.kind !== "COUNT";
+  }
+}

--- a/src/service/wafv2/web-acl/sim-waf-action.type.ts
+++ b/src/service/wafv2/web-acl/sim-waf-action.type.ts
@@ -1,0 +1,30 @@
+import type {
+  SimWafCustomRequestHandlingInput,
+  SimWafCustomResponseInput,
+} from "./sim-waf-custom-response.type.js";
+
+/**
+ * What a rule does with a request it claims.
+ */
+export type SimWafActionKind = "ALLOW" | "BLOCK" | "COUNT";
+
+/**
+ * Minimal structural WAFv2 RuleAction, which is also the shape of a web ACL's
+ * DefaultAction bar the two actions a default action cannot take.
+ */
+export interface SimWafActionInput {
+  readonly Allow?: SimWafHandledActionInput | undefined;
+  readonly Block?:
+    | { readonly CustomResponse?: SimWafCustomResponseInput | undefined }
+    | undefined;
+  readonly Count?: SimWafHandledActionInput | undefined;
+  readonly Captcha?: unknown;
+  readonly Challenge?: unknown;
+}
+
+/**
+ * An action that can add headers to the request it lets through.
+ */
+export interface SimWafHandledActionInput {
+  readonly CustomRequestHandling?: SimWafCustomRequestHandlingInput | undefined;
+}

--- a/src/service/wafv2/web-acl/sim-waf-custom-response.ts
+++ b/src/service/wafv2/web-acl/sim-waf-custom-response.ts
@@ -1,0 +1,53 @@
+import { SimWafInvalidParameterException } from "../error/sim-wafv2.error.js";
+import type {
+  SimWafCustomHeaderInput,
+  SimWafCustomResponseBodies,
+  SimWafHeader,
+  SimWafResponseBody,
+} from "./sim-waf-custom-response.type.js";
+
+const contentTypes = new Map<string, string>([
+  ["TEXT_PLAIN", "text/plain"],
+  ["TEXT_HTML", "text/html"],
+  ["APPLICATION_JSON", "application/json"],
+]);
+
+/**
+ * Read the headers a custom response or a custom request handling names.
+ *
+ * WAF prefixes every one of them with `x-amzn-waf-`, so a header a rule
+ * inserts cannot be mistaken for one the client sent.
+ */
+export function simWafCustomHeaders(
+  headers: readonly SimWafCustomHeaderInput[] | undefined,
+): readonly SimWafHeader[] {
+  return (headers ?? []).map((header) => ({
+    name: `x-amzn-waf-${String(header.Name)}`,
+    value: header.Value ?? "",
+  }));
+}
+
+/**
+ * Find the body a block action asked for among the web ACL's own.
+ *
+ * A key naming no body is refused where the web ACL is written, because a
+ * block action that fell back to the default body would answer with something
+ * other than what the rule said.
+ */
+export function requiredSimWafResponseBody(
+  key: string,
+  bodies: SimWafCustomResponseBodies,
+): SimWafResponseBody {
+  const body = new Map(Object.entries(bodies)).get(key);
+  const contentType = contentTypes.get(body?.ContentType ?? "");
+
+  if (body === undefined || contentType === undefined) {
+    throw new SimWafInvalidParameterException(
+      `Error reason: The custom response body ${key} is not one of this web ` +
+        `ACL's CustomResponseBodies with a content type WAF answers with, ` +
+        `field: CUSTOM_RESPONSE_BODY, parameter: ${key}`,
+    );
+  }
+
+  return { contentType, content: body.Content ?? "" };
+}

--- a/src/service/wafv2/web-acl/sim-waf-custom-response.ts
+++ b/src/service/wafv2/web-acl/sim-waf-custom-response.ts
@@ -22,9 +22,20 @@ export function simWafCustomHeaders(
   headers: readonly SimWafCustomHeaderInput[] | undefined,
 ): readonly SimWafHeader[] {
   return (headers ?? []).map((header) => ({
-    name: `x-amzn-waf-${String(header.Name)}`,
+    name: `x-amzn-waf-${requiredHeaderName(header.Name)}`,
     value: header.Value ?? "",
   }));
+}
+
+function requiredHeaderName(name: string | undefined): string {
+  if (name === undefined || name === "") {
+    throw new SimWafInvalidParameterException(
+      "Error reason: A custom header needs a Name, field: CUSTOM_HTTP_HEADER, " +
+        "parameter: Name",
+    );
+  }
+
+  return name;
 }
 
 /**

--- a/src/service/wafv2/web-acl/sim-waf-custom-response.type.ts
+++ b/src/service/wafv2/web-acl/sim-waf-custom-response.type.ts
@@ -1,0 +1,55 @@
+/**
+ * One header WAF adds to what it sends back, or to what it forwards.
+ */
+export interface SimWafHeader {
+  readonly name: string;
+  readonly value: string;
+}
+
+/**
+ * Minimal structural WAFv2 CustomHTTPHeader.
+ */
+export interface SimWafCustomHeaderInput {
+  readonly Name?: string | undefined;
+  readonly Value?: string | undefined;
+}
+
+/**
+ * Minimal structural WAFv2 CustomResponse.
+ */
+export interface SimWafCustomResponseInput {
+  readonly ResponseCode?: number | undefined;
+  readonly CustomResponseBodyKey?: string | undefined;
+  readonly ResponseHeaders?: readonly SimWafCustomHeaderInput[] | undefined;
+}
+
+/**
+ * Minimal structural WAFv2 CustomRequestHandling.
+ */
+export interface SimWafCustomRequestHandlingInput {
+  readonly InsertHeaders?: readonly SimWafCustomHeaderInput[] | undefined;
+}
+
+/**
+ * Minimal structural WAFv2 CustomResponseBody.
+ */
+export interface SimWafCustomResponseBodyInput {
+  readonly ContentType?: string | undefined;
+  readonly Content?: string | undefined;
+}
+
+/**
+ * The bodies a web ACL's block actions can answer with, by the key they are
+ * held under.
+ */
+export type SimWafCustomResponseBodies = Readonly<
+  Record<string, SimWafCustomResponseBodyInput>
+>;
+
+/**
+ * One body a block action answers with, ready to send.
+ */
+export interface SimWafResponseBody {
+  readonly contentType: string;
+  readonly content: string;
+}

--- a/src/service/wafv2/web-acl/sim-waf-rule-input.ts
+++ b/src/service/wafv2/web-acl/sim-waf-rule-input.ts
@@ -1,0 +1,71 @@
+import { SimWafInvalidParameterException } from "../error/sim-wafv2.error.js";
+import {
+  invalidSimWafRule,
+  refuseSimWafRuleInput,
+} from "../statement/sim-waf-rule-refusals.js";
+import type { SimWafRuleInput } from "./sim-waf-rule.type.js";
+
+const browserAnswered =
+  "the two actions they configure are answered by a browser, and nothing in " +
+  "a test does that";
+
+/**
+ * The rule members real WAFv2 takes and this simulation does not.
+ */
+const refusedMembers = new Map<string, string>([
+  [
+    "OverrideAction",
+    "it only applies to a rule group statement, and no rule group is simulated",
+  ],
+  [
+    "RuleLabels",
+    "nothing here reads a label, since LabelMatchStatement arrives with the " +
+      "AWS managed rule groups",
+  ],
+  ["CaptchaConfig", browserAnswered],
+  ["ChallengeConfig", browserAnswered],
+]);
+
+/**
+ * Read the name a rule was written under, refusing one with none.
+ */
+export function requiredSimWafRuleName(name: string | undefined): string {
+  if (name === undefined || name === "") {
+    throw new SimWafInvalidParameterException(
+      "Error reason: A rule needs a Name, field: RULE, parameter: Name",
+    );
+  }
+
+  return name;
+}
+
+/**
+ * Read the priority a rule runs at, refusing anything that is not a place in
+ * an order.
+ */
+export function requiredSimWafRulePriority(
+  priority: number | undefined,
+  name: string,
+): number {
+  if (priority === undefined || !Number.isSafeInteger(priority)) {
+    invalidSimWafRule(name, "A rule needs a whole number Priority");
+  }
+
+  return priority;
+}
+
+/**
+ * Refuse the parts of a rule real WAFv2 takes and this simulation does not.
+ */
+export function refuseUnsimulatedSimWafRuleInput(
+  input: SimWafRuleInput,
+  name: string,
+): void {
+  for (const [member, value] of Object.entries(input)) {
+    const reason = refusedMembers.get(member);
+
+    if (reason !== undefined && value !== undefined) {
+      refuseSimWafRuleInput(name, member, reason);
+    }
+  }
+}

--- a/src/service/wafv2/web-acl/sim-waf-rule.factory.ts
+++ b/src/service/wafv2/web-acl/sim-waf-rule.factory.ts
@@ -1,0 +1,43 @@
+import { faker } from "@faker-js/faker";
+import { DynamicFactory } from "@kensio/part-factory";
+
+import type { SimWafRuleInput } from "./sim-waf-rule.type.js";
+
+/**
+ * The visibility configuration every WAFv2 rule and web ACL carries.
+ *
+ * Nothing is emitted from it: web ACL metrics and sampled requests are not
+ * simulated. It is here because real WAFv2 asks for one on every rule, so a
+ * rule written without it is not a rule anyone would write.
+ */
+export const simWafVisibilityConfig = {
+  SampledRequestsEnabled: false,
+  CloudWatchMetricsEnabled: false,
+  MetricName: "sim",
+};
+
+/**
+ * Makes minimally valid WAFv2 rules that block every request.
+ *
+ * The statement claims any request, so a test about the order rules run in
+ * says nothing about matching.
+ *
+ * `Statement` and `Action` are replaced whole rather than overridden, because
+ * overrides are merged into the defaults and both of these are one-of: a
+ * statement naming two kinds, or an action naming both `Allow` and `Block`, is
+ * not something WAF would take, and is refused where the rule is written.
+ */
+export const simWafRuleFactory = new DynamicFactory<SimWafRuleInput>(() => ({
+  Name: `rule-${faker.string.alphanumeric(8)}`,
+  Priority: 0,
+  Action: { Block: {} },
+  Statement: {
+    ByteMatchStatement: {
+      SearchString: "/",
+      PositionalConstraint: "CONTAINS",
+      FieldToMatch: { UriPath: {} },
+      TextTransformations: [{ Priority: 0, Type: "NONE" }],
+    },
+  },
+  VisibilityConfig: simWafVisibilityConfig,
+}));

--- a/src/service/wafv2/web-acl/sim-waf-rule.ts
+++ b/src/service/wafv2/web-acl/sim-waf-rule.ts
@@ -1,0 +1,65 @@
+import type { SimWafInspectedRequest } from "../evaluate/sim-waf-inspected-request.js";
+import type { SimWafMatcher } from "../statement/sim-waf-field-match.js";
+import { compileSimWafStatement } from "../statement/sim-waf-statement.js";
+import { SimWafAction } from "./sim-waf-action.js";
+import {
+  refuseUnsimulatedSimWafRuleInput,
+  requiredSimWafRuleName,
+  requiredSimWafRulePriority,
+} from "./sim-waf-rule-input.js";
+import type { SimWafRuleInput, SimWafRuleScope } from "./sim-waf-rule.type.js";
+
+interface SimWafRuleProperties {
+  readonly name: string;
+  readonly priority: number;
+  readonly action: SimWafAction;
+  readonly matcher: SimWafMatcher;
+}
+
+/**
+ * One rule of a web ACL, compiled so a request can be evaluated against it.
+ *
+ * The statement is turned into a matcher when the web ACL is written, which is
+ * what lets a rule Yulin cannot evaluate be refused at that point rather than
+ * silently letting requests past later on.
+ */
+export class SimWafRule {
+  public readonly name: string;
+  public readonly priority: number;
+  public readonly action: SimWafAction;
+
+  readonly #matcher: SimWafMatcher;
+
+  private constructor(properties: SimWafRuleProperties) {
+    this.name = properties.name;
+    this.priority = properties.priority;
+    this.action = properties.action;
+    this.#matcher = properties.matcher;
+  }
+
+  /**
+   * Compile one rule as it was written.
+   */
+  static compile(input: SimWafRuleInput, scope: SimWafRuleScope): SimWafRule {
+    const name = requiredSimWafRuleName(input.Name);
+
+    refuseUnsimulatedSimWafRuleInput(input, name);
+
+    return new SimWafRule({
+      name,
+      priority: requiredSimWafRulePriority(input.Priority, name),
+      action: SimWafAction.read(input.Action, name, scope.customResponseBodies),
+      matcher: compileSimWafStatement(input.Statement, {
+        regexPatternSets: scope.regexPatternSets,
+        ruleName: name,
+      }),
+    });
+  }
+
+  /**
+   * Whether this rule claims a request.
+   */
+  matches(request: SimWafInspectedRequest): boolean {
+    return this.#matcher(request);
+  }
+}

--- a/src/service/wafv2/web-acl/sim-waf-rule.type.ts
+++ b/src/service/wafv2/web-acl/sim-waf-rule.type.ts
@@ -1,0 +1,30 @@
+import type { SimWafRegexPatternSet } from "../regex-pattern-set/sim-waf-regex-pattern-set.js";
+import type { SimWafResourceStore } from "../resource/sim-waf-resource-store.js";
+import type { SimWafStatementInput } from "../statement/sim-waf-statement.type.js";
+import type { SimWafActionInput } from "./sim-waf-action.type.js";
+import type { SimWafCustomResponseBodies } from "./sim-waf-custom-response.type.js";
+
+/**
+ * Minimal structural WAFv2 Rule.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/wafv2/Interface/Rule/
+ */
+export interface SimWafRuleInput {
+  readonly Name?: string | undefined;
+  readonly Priority?: number | undefined;
+  readonly Statement?: SimWafStatementInput | undefined;
+  readonly Action?: SimWafActionInput | undefined;
+  readonly OverrideAction?: unknown;
+  readonly RuleLabels?: readonly unknown[] | undefined;
+  readonly CaptchaConfig?: unknown;
+  readonly ChallengeConfig?: unknown;
+  readonly VisibilityConfig?: unknown;
+}
+
+/**
+ * What a rule is compiled against.
+ */
+export interface SimWafRuleScope {
+  readonly regexPatternSets: SimWafResourceStore<SimWafRegexPatternSet>;
+  readonly customResponseBodies: SimWafCustomResponseBodies;
+}

--- a/src/service/wafv2/web-acl/sim-waf-rules.ts
+++ b/src/service/wafv2/web-acl/sim-waf-rules.ts
@@ -1,0 +1,43 @@
+import { SimWafInvalidParameterException } from "../error/sim-wafv2.error.js";
+import { SimWafRule } from "./sim-waf-rule.js";
+import type { SimWafRuleInput, SimWafRuleScope } from "./sim-waf-rule.type.js";
+
+/**
+ * Compile a web ACL's rules into the order they are evaluated in.
+ *
+ * Rules run in ascending `Priority` rather than in the order they were
+ * written, which is the part that surprises people: moving a rule up the list
+ * changes nothing, and changing its priority changes everything.
+ *
+ * Two rules cannot claim one priority, as real WAF requires. Without that,
+ * which of them decided a request would come down to how the list happened to
+ * be sorted.
+ */
+export function compileSimWafRules(
+  rules: readonly SimWafRuleInput[] | undefined,
+  scope: SimWafRuleScope,
+): readonly SimWafRule[] {
+  const compiled = (rules ?? []).map((rule) => SimWafRule.compile(rule, scope));
+
+  refuseRepeatedPriority(compiled);
+
+  return compiled.toSorted((left, right) => left.priority - right.priority);
+}
+
+function refuseRepeatedPriority(rules: readonly SimWafRule[]): void {
+  const claimed = new Map<number, string>();
+
+  for (const rule of rules) {
+    const already = claimed.get(rule.priority);
+
+    if (already !== undefined) {
+      throw new SimWafInvalidParameterException(
+        `Error reason: The rules ${already} and ${rule.name} both have ` +
+          `priority ${rule.priority}, and a web ACL evaluates its rules in ` +
+          `priority order, field: RULE, parameter: ${rule.name}`,
+      );
+    }
+
+    claimed.set(rule.priority, rule.name);
+  }
+}

--- a/src/service/wafv2/web-acl/sim-waf-web-acl-configuration.ts
+++ b/src/service/wafv2/web-acl/sim-waf-web-acl-configuration.ts
@@ -1,0 +1,42 @@
+import { SimWafInvalidParameterException } from "../error/sim-wafv2.error.js";
+import { SimWafAction } from "./sim-waf-action.js";
+import type { SimWafActionInput } from "./sim-waf-action.type.js";
+import type { SimWafCustomResponseBodies } from "./sim-waf-custom-response.type.js";
+import type { SimWafRuleInput } from "./sim-waf-rule.type.js";
+
+/**
+ * Everything a web ACL is written with, on creation and on every update.
+ */
+export interface SimWafWebAclConfiguration {
+  readonly defaultAction?: SimWafActionInput | undefined;
+  readonly rules?: readonly SimWafRuleInput[] | undefined;
+  readonly customResponseBodies?: SimWafCustomResponseBodies | undefined;
+  readonly visibilityConfig?: unknown;
+  readonly description?: string | undefined;
+}
+
+/**
+ * Read the action a request no rule claims is given.
+ *
+ * Only `Allow` and `Block` are valid here on real WAF, and `Count` is the one
+ * worth refusing by name: a default action that counted would leave every
+ * unmatched request unanswered.
+ */
+export function readSimWafDefaultAction(
+  configuration: SimWafWebAclConfiguration,
+): SimWafAction {
+  const action = SimWafAction.read(
+    configuration.defaultAction,
+    "the web ACL default action",
+    configuration.customResponseBodies ?? {},
+  );
+
+  if (action.kind === "COUNT") {
+    throw new SimWafInvalidParameterException(
+      "Error reason: A web ACL DefaultAction is Allow or Block, field: " +
+        "DEFAULT_ACTION, parameter: Count",
+    );
+  }
+
+  return action;
+}

--- a/src/service/wafv2/web-acl/sim-waf-web-acl.ts
+++ b/src/service/wafv2/web-acl/sim-waf-web-acl.ts
@@ -1,0 +1,129 @@
+import type { SimWafDecision } from "../evaluate/sim-waf-decision.js";
+import type { SimWafInspectedRequest } from "../evaluate/sim-waf-inspected-request.js";
+import type { SimWafRegexPatternSet } from "../regex-pattern-set/sim-waf-regex-pattern-set.js";
+import {
+  SimWafResource,
+  type SimWafResourceProperties,
+} from "../resource/sim-waf-resource.js";
+import type { SimWafResourceStore } from "../resource/sim-waf-resource-store.js";
+import type { SimWafAction } from "./sim-waf-action.js";
+import type { SimWafHeader } from "./sim-waf-custom-response.type.js";
+import type { SimWafRule } from "./sim-waf-rule.js";
+import { compileSimWafRules } from "./sim-waf-rules.js";
+import {
+  readSimWafDefaultAction,
+  type SimWafWebAclConfiguration,
+} from "./sim-waf-web-acl-configuration.js";
+
+interface SimWafWebAclProperties extends SimWafResourceProperties {
+  readonly configuration: SimWafWebAclConfiguration;
+  readonly regexPatternSets: SimWafResourceStore<SimWafRegexPatternSet>;
+}
+
+/**
+ * One web ACL: an ordered list of rules and what to do with a request none of
+ * them claims.
+ *
+ * Evaluating is the whole of what a web ACL is for, and it happens in
+ * ascending rule priority. The first rule that matches and carries a
+ * terminating action decides the request; a `Count` action records the match
+ * and lets the next rule have a look. A request no rule terminates gets the
+ * default action.
+ */
+export class SimWafWebAcl extends SimWafResource {
+  readonly #regexPatternSets: SimWafResourceStore<SimWafRegexPatternSet>;
+
+  #configuration: SimWafWebAclConfiguration;
+  #defaultAction: SimWafAction;
+  #rules: readonly SimWafRule[];
+
+  constructor(properties: SimWafWebAclProperties) {
+    super("webacl", properties);
+
+    this.#regexPatternSets = properties.regexPatternSets;
+    this.#configuration = properties.configuration;
+    this.#defaultAction = readSimWafDefaultAction(properties.configuration);
+    this.#rules = this.compileRules(properties.configuration);
+  }
+
+  /**
+   * What this web ACL was last written with, as the API reports it.
+   */
+  get configuration(): SimWafWebAclConfiguration {
+    return this.#configuration;
+  }
+
+  /**
+   * Write a new configuration over this one.
+   *
+   * The rules are compiled before anything is replaced, so a web ACL that
+   * refuses an update keeps the rules it had rather than being left with none.
+   */
+  reconfigure(
+    configuration: SimWafWebAclConfiguration,
+    lockToken: string | undefined,
+  ): void {
+    const defaultAction = readSimWafDefaultAction(configuration);
+    const rules = this.compileRules(configuration);
+
+    this.takeLock(lockToken);
+    this.replaceDescription(configuration.description);
+    this.#configuration = configuration;
+    this.#defaultAction = defaultAction;
+    this.#rules = rules;
+  }
+
+  /**
+   * Decide what happens to one request.
+   */
+  evaluate(request: SimWafInspectedRequest): SimWafDecision {
+    const counted: string[] = [];
+    const inserted: SimWafHeader[] = [];
+
+    for (const rule of this.#rules) {
+      if (!rule.matches(request)) {
+        continue;
+      }
+
+      inserted.push(...rule.action.insertHeaders);
+
+      if (rule.action.isTerminating) {
+        return this.decision(rule.action, rule.name, counted, inserted);
+      }
+
+      counted.push(rule.name);
+    }
+
+    return this.decision(this.#defaultAction, undefined, counted, inserted);
+  }
+
+  private decision(
+    action: SimWafAction,
+    terminatingRuleName: string | undefined,
+    countedRuleNames: readonly string[],
+    insertedHeaders: readonly SimWafHeader[],
+  ): SimWafDecision {
+    const blocking = action.kind === "BLOCK";
+
+    return {
+      action: blocking ? "BLOCK" : "ALLOW",
+      webAclName: this.name,
+      webAclArn: this.arn,
+      terminatingRuleName,
+      countedRuleNames,
+      // Nothing is forwarded when the request is blocked, so there is nothing
+      // for a rule's inserted headers to be added to.
+      insertedHeaders: blocking ? [] : insertedHeaders,
+      blocked: action.blocked,
+    };
+  }
+
+  private compileRules(
+    configuration: SimWafWebAclConfiguration,
+  ): readonly SimWafRule[] {
+    return compileSimWafRules(configuration.rules, {
+      regexPatternSets: this.#regexPatternSets,
+      customResponseBodies: configuration.customResponseBodies ?? {},
+    });
+  }
+}


### PR DESCRIPTION
Adds a simulated AWS WAFv2 that holds web ACLs, IP sets and regex pattern sets, and evaluates a request against a web ACL's rules. Rules run in ascending priority and the first terminating match decides, a Count action records the match and lets evaluation carry on, and a request no rule claims gets the default action. The statements that read a request are simulated over every field-to-match kind and text transformation, from a byte match on the URI path to nested And, Or and Not. Every other statement kind is refused by CreateWebACL and UpdateWebACL, naming the rule and the kind, because a web ACL that accepted a rule it cannot evaluate would allow a request AWS blocks. Association with a distribution, a stage or a user pool follows in later issues, and `evaluateRequest` is the entry point those serving paths will call.

## Sequencing worth deciding on

`CreateWebACL` now refuses `RateBasedStatement`, as the issue asks. ChineseBoost's user pool ACL (KensioSoftware/chineseboost#209) is three rules and all three are rate-based, so once #813 lands that template goes from deploying with both WAFv2 resources on `skippedResources` to not deploying at all. The refusal is right and the order the pieces land in decides whether anybody meets that. Either #813 waits for rate-based statements, or the consumer gets a release note.

Resolves #807

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated AWS WAFv2 support.
  * Create, retrieve, update, list, and delete Web ACLs, IP sets, and regex pattern sets.
  * Evaluate requests using rules, priorities, matching statements, transformations, count/block actions, custom responses, and inserted headers.
  * Added regional and CloudFront scopes with IAM authorization and lock-token validation.
  * Added AWS SDK interception support.
* **Documentation**
  * Added service documentation, usage guidance, and executable examples.
* **Tests**
  * Added comprehensive coverage for evaluation, validation, authorization, routing, and resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->