### PR TITLE
fix: tighten simulated WAFv2 rule validation

### DIFF
--- a/docs/services/wafv2/README.md
+++ b/docs/services/wafv2/README.md
@@ -180,8 +180,13 @@ and `CONTINUE` inspects as much as WAF would have read.
 ## Answering a blocked request
 
 A `Block` action answers 403 with WAF's own body. A `CustomResponse` overrides the status and the
-body, taking the body from the web ACL's `CustomResponseBodies` by key. Headers a rule names are
-prefixed with `x-amzn-waf-`, as WAF prefixes them.
+body, taking the body from the web ACL's `CustomResponseBodies` by key. It carries a `ResponseCode`
+of its own, from 200 to 599, and any response headers it names reach the client under the names it
+gave them.
+
+The `x-amzn-waf-` prefix belongs to the other direction. WAF puts it on the headers an `Allow` or
+`Count` action inserts into the request it forwards, which is what tells a rule's header apart from
+one the client sent.
 
 ```typescript sim-wafv2-custom-response
 /**
@@ -249,7 +254,7 @@ const response = simWafBlockedHttpResponse(decision.blocked!);
 // 404 "hide-admin" '{"message":"Not found"}'
 console.log(
   response.status,
-  response.headers.get("x-amzn-waf-rule"),
+  response.headers.get("rule"),
   await response.text(),
 );
 ```

--- a/docs/services/wafv2/sim-wafv2-custom-response.example.ts
+++ b/docs/services/wafv2/sim-wafv2-custom-response.example.ts
@@ -63,6 +63,6 @@ const response = simWafBlockedHttpResponse(decision.blocked!);
 // 404 "hide-admin" '{"message":"Not found"}'
 console.log(
   response.status,
-  response.headers.get("x-amzn-waf-rule"),
+  response.headers.get("rule"),
   await response.text(),
 );

--- a/src/service/wafv2/README.md
+++ b/src/service/wafv2/README.md
@@ -47,6 +47,10 @@ rules that counted, the headers to add to a forwarded request, and what to answe
 with. The counted rules matter because a `Count` action leaves the request as it found it. A test
 staging a rule before turning it on asserts against that list.
 
+`web-acl/sim-waf-custom-response.ts` keeps the two header readers apart, and the difference is
+easy to get wrong. WAF prefixes an inserted request header with `x-amzn-waf-` as it adds it to what
+it forwards. A custom response header keeps the name the rule gave it.
+
 `evaluate/sim-waf-blocked-response.ts` holds the default 403 body. Real WAF hands the blocking off
 to whatever the web ACL is in front of, and each of those writes its own page (CloudFront's error
 page, API Gateway's `{"message":"Forbidden"}`). This is Yulin's own body until there is a fronting
@@ -66,7 +70,10 @@ The pieces underneath it each answer one question about a statement:
   selected), and a statement matches when any of them does.
 - `sim-waf-text-transformation.ts` applies the rule's transformations in ascending `Priority`. WAF
   orders them by priority and not by how the list was written. Lowercasing after decoding is a
-  different rule from decoding after lowercasing.
+  different rule from decoding after lowercasing. `sim-waf-url-decode.ts` is the one of them worth
+  its own file, because a run of percent escapes has to be decoded together for a non-ASCII
+  character to come out of it.
+- `sim-waf-match-pattern.ts` reads which headers or cookies a rule selects.
 - `sim-waf-byte-match.ts`, `sim-waf-regex-match.ts` and `sim-waf-size-constraint.ts` are the three
   tests a field is put through.
 - `sim-waf-logical-statement.ts` joins and negates the others.

--- a/src/service/wafv2/ip-set/sim-waf-ip-set.ts
+++ b/src/service/wafv2/ip-set/sim-waf-ip-set.ts
@@ -94,6 +94,14 @@ export function requiredSimWafIpAddressVersion(
 }
 
 /**
+ * A prefix length as WAF writes one, which is digits and nothing else.
+ *
+ * Reading it as a number alone would take `192.0.2.0/` as `/0`, and would take
+ * a signed, spaced or hexadecimal prefix as well.
+ */
+const decimalPrefix = /^\d+$/u;
+
+/**
  * Check one address is written the way WAF wants it.
  *
  * WAF takes CIDR notation and nothing else, so a bare address is refused here
@@ -107,14 +115,13 @@ function checkedAddress(
   const isAddress = version === "IPV4" ? isIPv4 : isIPv6;
   const longestPrefix = version === "IPV4" ? 32 : 128;
   const separator = address.lastIndexOf("/");
-  const prefixLength = Number(address.slice(separator + 1));
+  const prefix = address.slice(separator + 1);
 
   if (
     separator === -1 ||
     !isAddress(address.slice(0, separator)) ||
-    !Number.isSafeInteger(prefixLength) ||
-    prefixLength < 0 ||
-    prefixLength > longestPrefix
+    !decimalPrefix.test(prefix) ||
+    Number(prefix) > longestPrefix
   ) {
     throw new SimWafInvalidParameterException(
       `Error reason: The IP address ${address} is not valid ${version} CIDR ` +

--- a/src/service/wafv2/sim-wafv2-evaluation.iso.test.ts
+++ b/src/service/wafv2/sim-wafv2-evaluation.iso.test.ts
@@ -185,9 +185,10 @@ describe("SimWafV2 rule evaluation", () => {
     const response = simWafBlockedHttpResponse(decision.blocked);
 
     // Then the status, the body and the header the rule named all reach the
-    // client, with WAF's own prefix on the header name.
+    // client, under the name the rule gave it. The `x-amzn-waf-` prefix is for
+    // headers inserted into a request, not for a response.
     assertResponseStatus(response, 429);
-    assertIdentical(response.headers.get("x-amzn-waf-reason"), "too-many");
+    assertIdentical(response.headers.get("reason"), "too-many");
     assertIdentical(await response.text(), '{"message":"slow down"}');
   });
 
@@ -213,7 +214,10 @@ describe("SimWafV2 rule evaluation", () => {
     const rules = [
       pathRule("block-admin", 0, "/admin", {
         Block: {
-          CustomResponse: { CustomResponseBodyKey: "silence" },
+          CustomResponse: {
+            ResponseCode: 403,
+            CustomResponseBodyKey: "silence",
+          },
         },
       }),
     ];

--- a/src/service/wafv2/sim-wafv2-ip-sets.iso.test.ts
+++ b/src/service/wafv2/sim-wafv2-ip-sets.iso.test.ts
@@ -71,6 +71,27 @@ describe("SimWafV2 IP sets", () => {
     assertStringIncludes(error.message, "192.0.2.44");
   });
 
+  it("refuses an address whose prefix length is not digits", async () => {
+    // Given a simulated WAFv2.
+    const waf = new SimAws().wafV2();
+
+    // When an IP set carries a range with an empty prefix length.
+    const error = await assertThrowsErrorAsync(async () => {
+      await waf.createIpSet(
+        new CreateIPSetCommand({
+          Name: "office",
+          Scope: "REGIONAL",
+          IPAddressVersion: "IPV4",
+          Addresses: ["192.0.2.0/"],
+        }),
+      );
+    });
+
+    // Then it is refused, rather than being read as `/0` and covering every
+    // address there is.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+  });
+
   it("refuses an address version it does not hold", async () => {
     // Given a simulated WAFv2.
     const waf = new SimAws().wafV2();

--- a/src/service/wafv2/sim-wafv2-validation.iso.test.ts
+++ b/src/service/wafv2/sim-wafv2-validation.iso.test.ts
@@ -134,7 +134,12 @@ describe("SimWafV2 input validation", () => {
         {
           ...simWafRuleFactory.make({ Name: "the-rule" }),
           Action: {
-            Block: { CustomResponse: { CustomResponseBodyKey: "missing" } },
+            Block: {
+              CustomResponse: {
+                ResponseCode: 404,
+                CustomResponseBodyKey: "missing",
+              },
+            },
           },
         },
       ],
@@ -156,6 +161,55 @@ describe("SimWafV2 input validation", () => {
     // Then it is refused, rather than inserting a header named after nothing.
     assertInstanceOf(error, SimWafInvalidParameterException);
     assertStringIncludes(error.message, "custom header");
+  });
+
+  it("refuses a custom response with no usable status", async () => {
+    // When a block action names no status, or one outside the range WAF
+    // answers with.
+    const missing = await refusalForRule({
+      ...simWafRuleFactory.make({ Name: "the-rule" }),
+      Action: { Block: { CustomResponse: {} } },
+    });
+    const outOfRange = await refusalForRule({
+      ...simWafRuleFactory.make({ Name: "the-rule" }),
+      Action: { Block: { CustomResponse: { ResponseCode: 700 } } },
+    });
+
+    // Then both are refused, rather than answering with WAF's own 403 under a
+    // rule that asked for something else.
+    assertInstanceOf(missing, SimWafInvalidParameterException);
+    assertStringIncludes(outOfRange.message, "200 to 599");
+  });
+
+  it("refuses a custom response setting its own content type", async () => {
+    // When a block action carries a content-type header.
+    const error = await refusalForRule({
+      ...simWafRuleFactory.make({ Name: "the-rule" }),
+      Action: {
+        Block: {
+          CustomResponse: {
+            ResponseCode: 403,
+            ResponseHeaders: [{ Name: "Content-Type", Value: "text/plain" }],
+          },
+        },
+      },
+    });
+
+    // Then it is refused. The custom response body decides the content type,
+    // and a header setting it again would contradict the body.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "content type");
+  });
+
+  it("refuses a rule at a negative priority", async () => {
+    // When a rule asks to run before the first one.
+    const error = await refusalForRule(
+      simWafRuleFactory.make({ Name: "the-rule", Priority: -1 }),
+    );
+
+    // Then it is refused. Real WAF numbers rules from zero upwards.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "zero or more");
   });
 
   it("refuses a statement with nothing to match against", async () => {

--- a/src/service/wafv2/statement/sim-waf-field-content.ts
+++ b/src/service/wafv2/statement/sim-waf-field-content.ts
@@ -83,6 +83,10 @@ function readWithinLimit(encoded: readonly Uint8Array[]): readonly string[] {
   let budget = simWafInspectionLimitBytes;
 
   for (const bytes of encoded) {
+    if (budget === 0) {
+      break;
+    }
+
     if (bytes.length > budget) {
       // An entry over the remaining budget is cut where WAF stopped reading,
       // which for a body is the only case that happens.

--- a/src/service/wafv2/statement/sim-waf-field-refusals.iso.test.ts
+++ b/src/service/wafv2/statement/sim-waf-field-refusals.iso.test.ts
@@ -1,0 +1,85 @@
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimWafInvalidParameterException } from "../error/sim-wafv2.error.js";
+import { simWafStatementMatches } from "../sim-wafv2.fixture.js";
+import type { SimWafFieldToMatchInput } from "./sim-waf-field-to-match.type.js";
+
+/**
+ * Try to write a rule that reads one field, and answer with the refusal.
+ */
+async function refusalForField(field: SimWafFieldToMatchInput): Promise<Error> {
+  return await assertThrowsErrorAsync(async () => {
+    await simWafStatementMatches(new SimAws().wafV2(), {
+      ByteMatchStatement: {
+        SearchString: "x",
+        PositionalConstraint: "CONTAINS",
+        FieldToMatch: field,
+        TextTransformations: [{ Priority: 0, Type: "NONE" }],
+      },
+    });
+  });
+}
+
+describe("SimWafV2 field to match refusals", () => {
+  it("refuses a field naming two request components", async () => {
+    // When one statement reads both the path and the method.
+    const error = await refusalForField({ UriPath: {}, Method: {} });
+
+    // Then it is refused. Real WAF inspects one component per statement, and
+    // a rule that wants two is written as two rules.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "UriPath and Method");
+  });
+
+  it("refuses a match pattern naming two selectors", async () => {
+    // When a header pattern both includes and excludes.
+    const error = await refusalForField({
+      Headers: {
+        MatchPattern: {
+          IncludedHeaders: ["referer"],
+          ExcludedHeaders: ["user-agent"],
+        },
+        MatchScope: "VALUE",
+        OversizeHandling: "CONTINUE",
+      },
+    });
+
+    // Then it is refused rather than one of them quietly winning.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "match pattern");
+  });
+
+  it("refuses a match pattern naming none", async () => {
+    // When a cookie pattern selects nothing at all.
+    const error = await refusalForField({
+      Cookies: {
+        MatchPattern: {},
+        MatchScope: "KEY",
+        OversizeHandling: "CONTINUE",
+      },
+    });
+
+    assertInstanceOf(error, SimWafInvalidParameterException);
+  });
+
+  it("refuses a match pattern whose list is empty", async () => {
+    // When a header pattern includes an empty list of names.
+    const error = await refusalForField({
+      Headers: {
+        MatchPattern: { IncludedHeaders: [] },
+        MatchScope: "VALUE",
+        OversizeHandling: "CONTINUE",
+      },
+    });
+
+    // Then it is refused, rather than reading no headers while looking like it
+    // read some.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+  });
+});

--- a/src/service/wafv2/statement/sim-waf-field-to-match.iso.test.ts
+++ b/src/service/wafv2/statement/sim-waf-field-to-match.iso.test.ts
@@ -294,6 +294,29 @@ describe("SimWafV2 field to match", () => {
     assertTrue(matches(new Request("https://example.test/", { headers })));
   });
 
+  it("stops at the header that used the last of the budget", async () => {
+    // Given a statement over every header value, and a first header that fills
+    // the inspection limit exactly.
+    const matches = await simWafStatementMatches(
+      new SimAws().wafV2(),
+      contains("needle", {
+        Headers: {
+          MatchPattern: { All: {} },
+          MatchScope: "VALUE",
+          OversizeHandling: "CONTINUE",
+        },
+      }),
+    );
+    const headers = new Headers({
+      "x-first": "y".repeat(simWafInspectionLimitBytes),
+      "x-second": "needle",
+    });
+
+    // Then the header after it is not read at all, and no empty value stands
+    // in for it.
+    assertFalse(matches(new Request("https://example.test/", { headers })));
+  });
+
   it("reads the request body", async () => {
     // Given a statement over the body.
     const matches = await simWafStatementMatches(

--- a/src/service/wafv2/statement/sim-waf-field-to-match.type.ts
+++ b/src/service/wafv2/statement/sim-waf-field-to-match.type.ts
@@ -1,4 +1,4 @@
-import type { SimWafMatchPatternInput } from "./sim-waf-request-fields.js";
+import type { SimWafMatchPatternInput } from "./sim-waf-match-pattern.js";
 
 /**
  * The parts of a request a WAFv2 rule can be pointed at, in the API's own

--- a/src/service/wafv2/statement/sim-waf-match-pattern.ts
+++ b/src/service/wafv2/statement/sim-waf-match-pattern.ts
@@ -1,0 +1,58 @@
+import { invalidSimWafRule } from "./sim-waf-rule-refusals.js";
+
+/**
+ * Which headers or cookies a rule reads.
+ */
+export interface SimWafMatchPatternInput {
+  readonly All?: unknown;
+  readonly IncludedHeaders?: readonly string[] | undefined;
+  readonly ExcludedHeaders?: readonly string[] | undefined;
+  readonly IncludedCookies?: readonly string[] | undefined;
+  readonly ExcludedCookies?: readonly string[] | undefined;
+}
+
+/**
+ * Which of a request's headers or cookies a rule reads.
+ */
+export interface SimWafPatternSelection {
+  readonly included: ReadonlySet<string> | undefined;
+  readonly excluded: ReadonlySet<string> | undefined;
+}
+
+/**
+ * Read the pattern a rule selects headers or cookies with, refusing anything
+ * else.
+ *
+ * Real WAFv2 takes one of `All`, an included list or an excluded list, and a
+ * list has to name something. A pattern naming two of them, or none, or an
+ * empty list, would leave which headers the rule read up to the order they
+ * happen to be checked in.
+ */
+export function requiredSimWafPatternSelection(
+  pattern: SimWafMatchPatternInput | undefined,
+  ruleName: string,
+): SimWafPatternSelection {
+  const included =
+    pattern?.IncludedHeaders ?? pattern?.IncludedCookies ?? undefined;
+  const excluded =
+    pattern?.ExcludedHeaders ?? pattern?.ExcludedCookies ?? undefined;
+  const named = [pattern?.All, included, excluded].filter(
+    (selector) => selector !== undefined,
+  );
+
+  if (named.length !== 1 || included?.length === 0 || excluded?.length === 0) {
+    invalidSimWafRule(
+      ruleName,
+      "A match pattern names All, one list of headers or cookies to include, " +
+        "or one list to exclude",
+    );
+  }
+
+  return { included: names(included), excluded: names(excluded) };
+}
+
+function names(listed: readonly string[] | undefined): Set<string> | undefined {
+  return listed === undefined
+    ? undefined
+    : new Set(listed.map((name) => name.toLowerCase()));
+}

--- a/src/service/wafv2/statement/sim-waf-request-fields.ts
+++ b/src/service/wafv2/statement/sim-waf-request-fields.ts
@@ -1,3 +1,4 @@
+import type { SimWafPatternSelection } from "./sim-waf-match-pattern.js";
 import { invalidSimWafRule } from "./sim-waf-rule-refusals.js";
 
 /**
@@ -6,17 +7,6 @@ import { invalidSimWafRule } from "./sim-waf-rule-refusals.js";
 export interface SimWafNameValue {
   readonly name: string;
   readonly value: string;
-}
-
-/**
- * Which headers or cookies a rule reads.
- */
-export interface SimWafMatchPatternInput {
-  readonly All?: unknown;
-  readonly IncludedHeaders?: readonly string[] | undefined;
-  readonly ExcludedHeaders?: readonly string[] | undefined;
-  readonly IncludedCookies?: readonly string[] | undefined;
-  readonly ExcludedCookies?: readonly string[] | undefined;
 }
 
 /**
@@ -84,12 +74,11 @@ export function simWafHeaderEntries(
  */
 export function simWafPatternCandidates(properties: {
   readonly entries: readonly SimWafNameValue[];
-  readonly pattern: SimWafMatchPatternInput | undefined;
+  readonly selection: SimWafPatternSelection;
   readonly matchScope: SimWafMatchScope;
 }): readonly string[] {
-  const { entries, pattern, matchScope } = properties;
-  const included = names(pattern?.IncludedHeaders ?? pattern?.IncludedCookies);
-  const excluded = names(pattern?.ExcludedHeaders ?? pattern?.ExcludedCookies);
+  const { entries, matchScope } = properties;
+  const { included, excluded } = properties.selection;
 
   return entries
     .filter(
@@ -115,12 +104,6 @@ export function requiredSimWafMatchScope(
   }
 
   return matchScope;
-}
-
-function names(listed: readonly string[] | undefined): Set<string> | undefined {
-  return listed === undefined
-    ? undefined
-    : new Set(listed.map((name) => name.toLowerCase()));
 }
 
 function scoped(

--- a/src/service/wafv2/statement/sim-waf-set-field.ts
+++ b/src/service/wafv2/statement/sim-waf-set-field.ts
@@ -9,6 +9,7 @@ import type {
   SimWafHeadersFieldInput,
 } from "./sim-waf-field-to-match.type.js";
 import type { SimWafFieldReader } from "./sim-waf-field-to-match.js";
+import { requiredSimWafPatternSelection } from "./sim-waf-match-pattern.js";
 import {
   type SimWafNameValue,
   requiredSimWafMatchScope,
@@ -70,13 +71,16 @@ function entriesReader(
     input.OversizeHandling,
     ruleName,
   );
-  const pattern = input.MatchPattern;
+  const selection = requiredSimWafPatternSelection(
+    input.MatchPattern,
+    ruleName,
+  );
 
   return (request): SimWafFieldContent =>
     simWafFieldContent(
       simWafPatternCandidates({
         entries: entries(request),
-        pattern,
+        selection,
         matchScope,
       }),
       oversize,

--- a/src/service/wafv2/statement/sim-waf-text-transformation.iso.test.ts
+++ b/src/service/wafv2/statement/sim-waf-text-transformation.iso.test.ts
@@ -84,6 +84,18 @@ describe("SimWafV2 text transformations", () => {
     assertTrue(sending(spaced, "q=one+two"));
   });
 
+  it("decodes a run of escapes that spell one character", async () => {
+    // Given a statement that URL decodes first.
+    const matches = await simWafStatementMatches(
+      new SimAws().wafV2(),
+      transformed("café", [{ Priority: 0, Type: "URL_DECODE" }]),
+    );
+
+    // Then a non-ASCII character arriving as several escapes decodes to the
+    // character, which a byte at a time would not.
+    assertTrue(sending(matches, "q=caf%C3%A9"));
+  });
+
   it("leaves an escape that decodes to nothing as it stands", async () => {
     // Given a statement that URL decodes first.
     const matches = await simWafStatementMatches(

--- a/src/service/wafv2/statement/sim-waf-text-transformation.ts
+++ b/src/service/wafv2/statement/sim-waf-text-transformation.ts
@@ -1,4 +1,5 @@
 import { refuseSimWafRuleInput } from "./sim-waf-rule-refusals.js";
+import { simWafUrlDecode } from "./sim-waf-url-decode.js";
 
 /**
  * Minimal structural WAFv2 text transformation.
@@ -24,7 +25,7 @@ const namedEntities = new Map<string, string>([
 const transforms = new Map<string, SimWafTextTransform>([
   ["NONE", (value): string => value],
   ["LOWERCASE", (value): string => value.toLowerCase()],
-  ["URL_DECODE", urlDecode],
+  ["URL_DECODE", simWafUrlDecode],
   ["COMPRESS_WHITE_SPACE", compressWhitespace],
   ["HTML_ENTITY_DECODE", htmlEntityDecode],
 ]);
@@ -71,27 +72,6 @@ function compileOne(
   }
 
   return transform;
-}
-
-/**
- * Decode percent escapes and `+` as a space, as WAF's URL_DECODE does.
- *
- * An escape that decodes to nothing is left as it stands rather than failing
- * the whole match. WAF still inspects malformed input, and a rule that threw
- * its hands up at it would be a way past the rule.
- */
-function urlDecode(value: string): string {
-  return value.replaceAll(/\+|%[\da-f]{2}/giu, (escape) => {
-    if (escape === "+") {
-      return " ";
-    }
-
-    try {
-      return decodeURIComponent(escape);
-    } catch {
-      return escape;
-    }
-  });
 }
 
 /**

--- a/src/service/wafv2/statement/sim-waf-unsimulated-field.ts
+++ b/src/service/wafv2/statement/sim-waf-unsimulated-field.ts
@@ -1,5 +1,8 @@
 import type { SimWafFieldToMatchInput } from "./sim-waf-field-to-match.type.js";
-import { refuseSimWafRuleInput } from "./sim-waf-rule-refusals.js";
+import {
+  invalidSimWafRule,
+  refuseSimWafRuleInput,
+} from "./sim-waf-rule-refusals.js";
 
 /**
  * Refuse the field-to-match kinds real WAFv2 offers and this simulation does
@@ -13,6 +16,8 @@ export function refuseUnsimulatedSimWafField(
   field: SimWafFieldToMatchInput,
   ruleName: string,
 ): void {
+  refuseTwoFields(field, ruleName);
+
   if (field.JsonBody !== undefined) {
     refuseSimWafRuleInput(
       ruleName,
@@ -40,6 +45,31 @@ export function refuseUnsimulatedSimWafField(
   }
 
   refuseFingerprintFields(field, ruleName);
+}
+
+/**
+ * Refuse a field to match naming more than one part of the request.
+ *
+ * Real WAFv2 takes one request component per `FieldToMatch`, and a rule that
+ * wants two is written as two rules. Reading the first component found would
+ * make which of them the rule inspected a matter of the order they are checked
+ * in.
+ */
+function refuseTwoFields(
+  field: SimWafFieldToMatchInput,
+  ruleName: string,
+): void {
+  const named = Object.entries(field)
+    .filter(([, value]) => value !== undefined)
+    .map(([component]) => component);
+
+  if (named.length > 1) {
+    invalidSimWafRule(
+      ruleName,
+      `The field to match names ${named.join(" and ")}, and a statement ` +
+        `inspects one request component`,
+    );
+  }
 }
 
 function refuseFingerprintFields(

--- a/src/service/wafv2/statement/sim-waf-url-decode.ts
+++ b/src/service/wafv2/statement/sim-waf-url-decode.ts
@@ -1,0 +1,51 @@
+/**
+ * Decode percent escapes and `+` as a space, as WAF's URL_DECODE does.
+ *
+ * Consecutive escapes are decoded as one run, because a non-ASCII character
+ * arrives as several of them and decoding a byte at a time would leave the
+ * whole sequence encoded.
+ *
+ * An escape that decodes to nothing is left as it stands rather than failing
+ * the whole match. WAF still inspects malformed input, and a rule that threw
+ * its hands up at it would be a way past the rule.
+ */
+export function simWafUrlDecode(value: string): string {
+  /*
+   * The repeated group is fixed width and every alternative starts with a
+   * character the others cannot, so each position is decided without
+   * backtracking. The unsafe-expression check reads the nested quantifier and
+   * cannot see that.
+   */
+  // oxlint-disable-next-line security/detect-unsafe-regex
+  const escapeRun = /\+|(?:%[\da-f]{2})+/giu;
+
+  return value.replaceAll(escapeRun, (escapes) => {
+    if (escapes === "+") {
+      return " ";
+    }
+
+    try {
+      return decodeURIComponent(escapes);
+    } catch {
+      return decodeEachEscape(escapes);
+    }
+  });
+}
+
+/**
+ * Decode what can be decoded in a run of escapes, leaving the rest alone.
+ *
+ * A run that is not valid UTF-8 still holds escapes that stand for a character
+ * on their own, and WAF inspects what it can read of it.
+ */
+function decodeEachEscape(escapes: string): string {
+  return (escapes.match(/%[\da-f]{2}/giu) ?? [])
+    .map((escape) => {
+      try {
+        return decodeURIComponent(escape);
+      } catch {
+        return escape;
+      }
+    })
+    .join("");
+}

--- a/src/service/wafv2/web-acl/sim-waf-action-input.ts
+++ b/src/service/wafv2/web-acl/sim-waf-action-input.ts
@@ -2,13 +2,14 @@ import {
   simWafDefaultBlockedResponse,
   type SimWafBlockedResponse,
 } from "../evaluate/sim-waf-blocked-response.js";
+import { SimWafInvalidParameterException } from "../error/sim-wafv2.error.js";
 import {
   invalidSimWafRule,
   refuseSimWafRuleInput,
 } from "../statement/sim-waf-rule-refusals.js";
 import {
   requiredSimWafResponseBody,
-  simWafCustomHeaders,
+  simWafResponseHeaders,
 } from "./sim-waf-custom-response.js";
 import type {
   SimWafCustomResponseBodies,
@@ -35,11 +36,33 @@ export function simWafBlockedResponse(
     key === undefined ? undefined : requiredSimWafResponseBody(key, bodies);
 
   return {
-    statusCode: customResponse.ResponseCode ?? fallback.statusCode,
+    statusCode: requiredResponseCode(customResponse.ResponseCode),
     contentType: body?.contentType ?? fallback.contentType,
     body: body?.content ?? fallback.body,
-    headers: simWafCustomHeaders(customResponse.ResponseHeaders),
+    headers: simWafResponseHeaders(customResponse.ResponseHeaders),
   };
+}
+
+/**
+ * Read the status a custom response answers with.
+ *
+ * Real WAFv2 requires one in the 200 to 599 range. Falling back to WAF's own
+ * 403 would answer with a status the rule did not ask for.
+ */
+function requiredResponseCode(responseCode: number | undefined): number {
+  if (
+    responseCode === undefined ||
+    !Number.isSafeInteger(responseCode) ||
+    responseCode < 200 ||
+    responseCode > 599
+  ) {
+    throw new SimWafInvalidParameterException(
+      `Error reason: A custom response code is a whole number from 200 to ` +
+        `599, field: CUSTOM_RESPONSE, parameter: ${String(responseCode)}`,
+    );
+  }
+
+  return responseCode;
 }
 
 /**

--- a/src/service/wafv2/web-acl/sim-waf-action.ts
+++ b/src/service/wafv2/web-acl/sim-waf-action.ts
@@ -9,7 +9,7 @@ import type {
   SimWafActionKind,
   SimWafHandledActionInput,
 } from "./sim-waf-action.type.js";
-import { simWafCustomHeaders } from "./sim-waf-custom-response.js";
+import { simWafInsertedHeaders } from "./sim-waf-custom-response.js";
 import type {
   SimWafCustomResponseBodies,
   SimWafHeader,
@@ -74,7 +74,7 @@ export class SimWafAction {
   ): SimWafAction {
     return new SimWafAction({
       kind,
-      insertHeaders: simWafCustomHeaders(
+      insertHeaders: simWafInsertedHeaders(
         action.CustomRequestHandling?.InsertHeaders,
       ),
       blocked: undefined,

--- a/src/service/wafv2/web-acl/sim-waf-custom-response.ts
+++ b/src/service/wafv2/web-acl/sim-waf-custom-response.ts
@@ -13,18 +13,46 @@ const contentTypes = new Map<string, string>([
 ]);
 
 /**
- * Read the headers a custom response or a custom request handling names.
+ * Read the headers a custom request handling asks to insert.
  *
- * WAF prefixes every one of them with `x-amzn-waf-`, so a header a rule
- * inserts cannot be mistaken for one the client sent.
+ * WAF prefixes every one of them with `x-amzn-waf-` as it inserts them, so a
+ * header a rule added cannot be mistaken for one the client sent.
  */
-export function simWafCustomHeaders(
+export function simWafInsertedHeaders(
   headers: readonly SimWafCustomHeaderInput[] | undefined,
 ): readonly SimWafHeader[] {
   return (headers ?? []).map((header) => ({
     name: `x-amzn-waf-${requiredHeaderName(header.Name)}`,
     value: header.Value ?? "",
   }));
+}
+
+/**
+ * Read the headers a custom response carries.
+ *
+ * These keep the names they were configured with. The `x-amzn-waf-` prefix is
+ * for request header insertion, where it tells a rule's header apart from the
+ * client's. `content-type` is refused, because the custom response body
+ * decides that and a header setting it again would contradict the body.
+ */
+export function simWafResponseHeaders(
+  headers: readonly SimWafCustomHeaderInput[] | undefined,
+): readonly SimWafHeader[] {
+  return (headers ?? []).map((header) => ({
+    name: refusedContentType(requiredHeaderName(header.Name)),
+    value: header.Value ?? "",
+  }));
+}
+
+function refusedContentType(name: string): string {
+  if (name.toLowerCase() === "content-type") {
+    throw new SimWafInvalidParameterException(
+      "Error reason: A custom response takes its content type from its body, " +
+        "field: CUSTOM_HTTP_HEADER, parameter: content-type",
+    );
+  }
+
+  return name;
 }
 
 function requiredHeaderName(name: string | undefined): string {

--- a/src/service/wafv2/web-acl/sim-waf-rule-input.ts
+++ b/src/service/wafv2/web-acl/sim-waf-rule-input.ts
@@ -47,8 +47,12 @@ export function requiredSimWafRulePriority(
   priority: number | undefined,
   name: string,
 ): number {
-  if (priority === undefined || !Number.isSafeInteger(priority)) {
-    invalidSimWafRule(name, "A rule needs a whole number Priority");
+  if (
+    priority === undefined ||
+    !Number.isSafeInteger(priority) ||
+    priority < 0
+  ) {
+    invalidSimWafRule(name, "A rule needs a Priority of zero or more");
   }
 
   return priority;


### PR DESCRIPTION
Follow-up to #814, which merged before these landed.

Refuses a field to match naming two request components and a header or cookie match pattern naming two selectors, none, or an empty list, since real WAFv2 takes one of each and reading the first one found would leave what a rule inspected to the order the members happen to be checked in. A custom response now needs a status from 200 to 599 and keeps the names it gave its response headers, because the `x-amzn-waf-` prefix belongs to headers inserted into a forwarded request. URL decoding reads a run of percent escapes together, so a non-ASCII character arriving as several of them decodes to the character. A CIDR prefix length has to be digits, a rule priority cannot be negative, and an oversize header or cookie set stops at the entry that used the last of the inspection budget rather than reading an empty one.

## What was left alone

- **The create paths validate before they authorize.** `src/service/rekognition/README.md` documents that order deliberately, and a create has to build the resource to know the ARN its generated id gives it.
- **Regex backtracking.** A pattern comes from whoever wrote the web ACL, never from a request, so a pathological one holds up that author's own test run and nothing else. `sim-waf-regex.ts` says so.