### PR TITLE
feat: block requests at a distribution web ACL

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -1056,6 +1056,148 @@ headers.
 The [event factories page](../../factories/ "Test factories for AWS event shapes usage docs")
 covers what the factories have in common.
 
+## Web ACLs
+
+A Distribution can put a WAFv2 web ACL in front of everything it serves. Name the web ACL's ARN in
+`WebACLId` and the Distribution evaluates it against every request that arrives. A request the web
+ACL blocks gets 403 from the edge. A request it allows carries on to the cache Behavior and the
+Origin.
+
+CloudFront takes its web ACL this way. WAFv2's `AssociateWebACL` covers the regional resource types.
+
+The web ACL has to be a `CLOUDFRONT` scope one, created in `us-east-1` (see
+[scopes](../wafv2/README.md#scopes)). A `WebACLId` naming a `REGIONAL` web ACL, or one this
+simulation never created, is refused with `InvalidWebACLId` at `CreateDistribution` and at
+`UpdateDistribution`.
+
+The web ACL decides before any other stage sees the request. A blocked request never reaches a
+viewer-request CloudFront Function, a cache Behavior, a response headers policy or the Origin.
+
+```typescript sim-cloudfront-web-acl
+/**
+ * Blocking a request to a Distribution with a web ACL.
+ */
+
+import { CreateDistributionCommand } from "@aws-sdk/client-cloudfront";
+import {
+  CreateBucketCommand,
+  PutBucketPolicyCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { CreateWebACLCommand } from "@aws-sdk/client-wafv2";
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws });
+
+try {
+  const simS3 = simAws.s3();
+  await simS3.createBucket(new CreateBucketCommand({ Bucket: "site-bucket" }));
+  await simS3.putBucketPolicy(
+    new PutBucketPolicyCommand({
+      Bucket: "site-bucket",
+      Policy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::site-bucket/*",
+        },
+      }),
+    }),
+  );
+  await simS3.putObject(
+    new PutObjectCommand({
+      Bucket: "site-bucket",
+      Key: "admin/users.html",
+      ContentType: "text/html",
+      Body: "<h1>Users</h1>",
+    }),
+  );
+
+  // A CLOUDFRONT scope web ACL lives in us-east-1, wherever the Distribution
+  // was created from.
+  const acl = await simAws
+    .accountRegionScope(simAws.defaultAccountId, "us-east-1")
+    .wafV2()
+    .createWebAcl(
+      new CreateWebACLCommand({
+        Name: "site-acl",
+        Scope: "CLOUDFRONT",
+        DefaultAction: { Allow: {} },
+        VisibilityConfig: {
+          SampledRequestsEnabled: false,
+          CloudWatchMetricsEnabled: false,
+          MetricName: "site",
+        },
+        Rules: [
+          {
+            Name: "block-admin",
+            Priority: 0,
+            Action: { Block: {} },
+            Statement: {
+              ByteMatchStatement: {
+                FieldToMatch: { UriPath: {} },
+                PositionalConstraint: "STARTS_WITH",
+                SearchString: Buffer.from("/admin"),
+                TextTransformations: [{ Priority: 0, Type: "LOWERCASE" }],
+              },
+            },
+            VisibilityConfig: {
+              SampledRequestsEnabled: false,
+              CloudWatchMetricsEnabled: false,
+              MetricName: "block-admin",
+            },
+          },
+        ],
+      }),
+    );
+
+  const creation = await simAws.cloudFront().createDistribution(
+    new CreateDistributionCommand({
+      DistributionConfig: {
+        CallerReference: "guarded-site",
+        Comment: "Site behind a web ACL",
+        Enabled: true,
+        WebACLId: acl.Summary!.ARN,
+        Origins: {
+          Quantity: 1,
+          Items: [
+            {
+              Id: "site-origin",
+              DomainName: "site-bucket.s3.amazonaws.com",
+              S3OriginConfig: { OriginAccessIdentity: "" },
+            },
+          ],
+        },
+        DefaultCacheBehavior: {
+          TargetOriginId: "site-origin",
+          ViewerProtocolPolicy: "allow-all",
+        },
+      },
+    }),
+  );
+
+  const distroHostname = creation.Distribution!.DomainName!;
+
+  const blocked = await fetch(
+    srv.localUrl(`http://${distroHostname}/admin/users.html`),
+  );
+  console.log(blocked.status); // 403
+
+  // The Bucket still holds the page. The request never got as far as the
+  // Origin to ask for it.
+} finally {
+  await srv.close();
+}
+```
+
+See [simulated WAFv2](../wafv2/README.md) for what a rule can inspect and how a blocked request is
+answered.
+
 ## Response headers policies
 
 A response headers policy sets headers on everything a cache Behavior serves. Declare one as
@@ -1839,6 +1981,7 @@ Sim CloudFront currently supports:
 - `AWS::CloudFront::KeyValueStore`, and `KeyValueStoreAssociations` on `AWS::CloudFront::Function`
 - `AWS::CloudFront::OriginAccessControl`, letting an Origin read a private Bucket as CloudFront
 - Viewer certificates from sim ACM, including CloudFront's `us-east-1` requirement
+- `WebACLId`, putting a simulated WAFv2 web ACL in front of everything a Distribution serves
 - Serving simulated CloudFront traffic on localhost with `serveSimAws`
 
 The simulator focuses on useful behaviour for tests and local development, ahead of full CloudFront
@@ -1879,6 +2022,11 @@ Where sim CloudFront knowingly behaves differently from AWS:
   does a hand-written `{ Items: [...] }` with the count left out. The AWS SDK types make omitting
   `Quantity` a compile error, so what arrives without one is a different mistake from the one this
   catches.
+- **A web ACL a Distribution names has to exist here.** `WebACLId` resolves to a web ACL created in
+  this simulation, and the ARN carries the Account and Region holding it. A managed web ACL, or one
+  from a real account, is refused at create and at update. Deleting a web ACL a Distribution still
+  names leaves the Distribution answering `InvalidWebACLId` on every request, because real WAF
+  refuses that deletion and nothing here tracks the association to refuse it.
 - **`IfMatch` ETags are ignored on a Distribution or a Function.** `UpdateDistributionCommand`,
   `DeleteDistributionCommand` and `DeleteFunctionCommand` all accept `IfMatch` and ignore it,
   leaving both `PreconditionFailed` and `InvalidIfMatchVersion` unused there. A stale ETag there

--- a/docs/services/cloudfront/sim-cloudfront-web-acl.example.ts
+++ b/docs/services/cloudfront/sim-cloudfront-web-acl.example.ts
@@ -1,0 +1,119 @@
+/**
+ * Blocking a request to a Distribution with a web ACL.
+ */
+
+import { CreateDistributionCommand } from "@aws-sdk/client-cloudfront";
+import {
+  CreateBucketCommand,
+  PutBucketPolicyCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { CreateWebACLCommand } from "@aws-sdk/client-wafv2";
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws });
+
+try {
+  const simS3 = simAws.s3();
+  await simS3.createBucket(new CreateBucketCommand({ Bucket: "site-bucket" }));
+  await simS3.putBucketPolicy(
+    new PutBucketPolicyCommand({
+      Bucket: "site-bucket",
+      Policy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::site-bucket/*",
+        },
+      }),
+    }),
+  );
+  await simS3.putObject(
+    new PutObjectCommand({
+      Bucket: "site-bucket",
+      Key: "admin/users.html",
+      ContentType: "text/html",
+      Body: "<h1>Users</h1>",
+    }),
+  );
+
+  // A CLOUDFRONT scope web ACL lives in us-east-1, wherever the Distribution
+  // was created from.
+  const acl = await simAws
+    .accountRegionScope(simAws.defaultAccountId, "us-east-1")
+    .wafV2()
+    .createWebAcl(
+      new CreateWebACLCommand({
+        Name: "site-acl",
+        Scope: "CLOUDFRONT",
+        DefaultAction: { Allow: {} },
+        VisibilityConfig: {
+          SampledRequestsEnabled: false,
+          CloudWatchMetricsEnabled: false,
+          MetricName: "site",
+        },
+        Rules: [
+          {
+            Name: "block-admin",
+            Priority: 0,
+            Action: { Block: {} },
+            Statement: {
+              ByteMatchStatement: {
+                FieldToMatch: { UriPath: {} },
+                PositionalConstraint: "STARTS_WITH",
+                SearchString: Buffer.from("/admin"),
+                TextTransformations: [{ Priority: 0, Type: "LOWERCASE" }],
+              },
+            },
+            VisibilityConfig: {
+              SampledRequestsEnabled: false,
+              CloudWatchMetricsEnabled: false,
+              MetricName: "block-admin",
+            },
+          },
+        ],
+      }),
+    );
+
+  const creation = await simAws.cloudFront().createDistribution(
+    new CreateDistributionCommand({
+      DistributionConfig: {
+        CallerReference: "guarded-site",
+        Comment: "Site behind a web ACL",
+        Enabled: true,
+        WebACLId: acl.Summary!.ARN,
+        Origins: {
+          Quantity: 1,
+          Items: [
+            {
+              Id: "site-origin",
+              DomainName: "site-bucket.s3.amazonaws.com",
+              S3OriginConfig: { OriginAccessIdentity: "" },
+            },
+          ],
+        },
+        DefaultCacheBehavior: {
+          TargetOriginId: "site-origin",
+          ViewerProtocolPolicy: "allow-all",
+        },
+      },
+    }),
+  );
+
+  const distroHostname = creation.Distribution!.DomainName!;
+
+  const blocked = await fetch(
+    srv.localUrl(`http://${distroHostname}/admin/users.html`),
+  );
+  console.log(blocked.status); // 403
+
+  // The Bucket still holds the page. The request never got as far as the
+  // Origin to ask for it.
+} finally {
+  await srv.close();
+}

--- a/docs/services/wafv2/README.md
+++ b/docs/services/wafv2/README.md
@@ -5,9 +5,9 @@ regex pattern sets, and it evaluates a request against a web ACL's rules to reac
 can assert that a request to `/admin` is blocked and one to `/` is allowed, without an AWS account
 and without a distribution in front of anything.
 
-Association comes separately. Putting a web ACL in front of a CloudFront distribution, an API
-Gateway REST API stage or a Cognito user pool arrives later. Until then a test asks the web ACL
-about a request itself.
+A CloudFront distribution takes a web ACL through its own `WebACLId`. An API Gateway REST API stage
+and a Cognito user pool arrive later. A test can also ask a web ACL about a request itself, with no
+association at all.
 
 WAFv2 specific types are imported from the `@kensio/yulin/wafv2` subpath.
 
@@ -378,6 +378,15 @@ const created = await waf.createWebAcl(
 // arn:aws:wafv2:us-east-1:...:global/webacl/site-acl/...
 console.log(created.Summary?.ARN);
 ```
+
+## In front of a CloudFront distribution
+
+A distribution names its web ACL in `WebACLId` on its `DistributionConfig`. The ARN has to be a
+`CLOUDFRONT` scope one, and the distribution answers 403 to every request the web ACL blocks.
+
+CloudFront is associated this way and not through `AssociateWebACL`, which real WAF keeps for the
+regional resource types. See
+[web ACLs in the CloudFront docs](../cloudfront/README.md#web-acls) for the whole example.
 
 ## Lock tokens
 

--- a/src/service/aws/factory/sim-aws-account-service-cache.ts
+++ b/src/service/aws/factory/sim-aws-account-service-cache.ts
@@ -9,6 +9,7 @@ import type { SimCloudFrontRegistry } from "../../cloudfront/registry/sim-cloud-
 import { makeSimCfS3OriginResolver } from "../../cloudfront/origin/s3/sim-cf-s3-origin-resolver-factory.js";
 import { makeSimCfCustomOriginDispatcher } from "../../cloudfront/origin/custom/sim-cf-custom-origin-dispatcher.factory.js";
 import { SimCloudFront } from "../../cloudfront/sim-cloudfront.js";
+import { makeSimCfWebAclResolver } from "../../cloudfront/web-acl/sim-cf-web-acl-resolver.factory.js";
 import { SimRoute53 } from "../../route53/index.js";
 import type { SimRoute53Registry } from "../../route53/registry/sim-route53-registry.js";
 import type { SimKmsRegistry } from "../../kms/registry/sim-kms-registry.js";
@@ -122,6 +123,10 @@ export class SimAwsAccountServiceCache {
           customOriginDispatcher: makeSimCfCustomOriginDispatcher(this.simAws),
           iam,
           acmRegistry: this.acmRegistry,
+          // A CLOUDFRONT scope web ACL is held by the WAFv2 of the Account and
+          // Region its ARN names, which CloudFront reaches through the
+          // simulation rather than holding itself.
+          webAclResolver: makeSimCfWebAclResolver(this.simAws),
           background: this.background,
         }),
     );

--- a/src/service/cloudfront/README.md
+++ b/src/service/cloudfront/README.md
@@ -166,6 +166,16 @@ accepted: `ACMCertificateArn`/`SSLSupportMethod` from the API, and
 Certificates are resolved through `SimAcmRegistry`, so a standalone `SimCloudFront` with no
 registry checks nothing.
 
+### Web ACLs
+
+`web-acl/` holds what a Distribution's `WebACLId` means. `SimCfWebAclResolver` finds the web ACL an
+ARN names, in the Account and Region the ARN carries, through that scope's simulated WAFv2.
+`makeSimCfWebAclResolver` builds one over a `SimAws`, and a standalone `SimCloudFront` has none.
+
+`SimCfDistributionWebAcl` refuses a `DistributionConfig` naming a web ACL nothing created, and one
+naming a `REGIONAL` scope web ACL, both as `InvalidWebACLId`. The check runs at create and at
+update, before anything is applied, the way a missing response headers policy is refused.
+
 ## Request routing and handling
 
 HTTP request behaviour is split across a few directories:
@@ -181,6 +191,11 @@ HTTP request behaviour is split across a few directories:
   error response and before the viewer-response CloudFront Function. That ordering is CloudFront's
   own: an error page carries the policy's headers, and a function sees them in its event and can
   change them.
+  `controller/web-acl/` puts the request through the Distribution's web ACL, first of all the stages
+  and before Behavior resolution. CloudFront asks WAF ahead of every content-handling stage. A
+  blocked request is answered with the web ACL's 403, and no Behavior, viewer-request function or
+  Origin sees it. An allowing rule's custom request handling headers are added to the request that
+  carries on.
 - `router/` resolves an incoming `Request` to a simulated Distribution by CloudFront hostname or
   alternate domain name.
 - `resolver/` chooses the matching Cache Behavior for a request path.
@@ -308,6 +323,8 @@ The key integration points are:
   `SimCloudFront` has no dispatcher, and refuses a custom Origin rather than reaching the network.
 - `SimAcmRegistry`, which resolves the ACM Certificate a Distribution's viewer certificate ARN
   names, wherever in the simulated AWS instance it lives.
+- `SimCfWebAclResolver`, which reaches the simulated WAFv2 holding the `CLOUDFRONT` scope web ACL a
+  Distribution names, and hands the request to `SimWafV2.evaluateRequest` for a decision.
 
 A standalone `SimCloudFront` instance can be used directly, but full CloudFront routing is usually
 most useful through `SimAws`, where CloudFront, S3, and the shared registry are wired together.

--- a/src/service/cloudfront/README.md
+++ b/src/service/cloudfront/README.md
@@ -170,7 +170,8 @@ registry checks nothing.
 
 `web-acl/` holds what a Distribution's `WebACLId` means. `SimCfWebAclResolver` finds the web ACL an
 ARN names, in the Account and Region the ARN carries, through that scope's simulated WAFv2.
-`makeSimCfWebAclResolver` builds one over a `SimAws`, and a standalone `SimCloudFront` has none.
+`makeSimCfWebAclResolver` builds one over a `SimAws`. A standalone `SimCloudFront` has none, and
+refuses any `WebACLId` for want of anywhere to find the web ACL.
 
 `SimCfDistributionWebAcl` refuses a `DistributionConfig` naming a web ACL nothing created, and one
 naming a `REGIONAL` scope web ACL, both as `InvalidWebACLId`. The check runs at create and at

--- a/src/service/cloudfront/command/create-distribution/create-distribution.command.ts
+++ b/src/service/cloudfront/command/create-distribution/create-distribution.command.ts
@@ -64,6 +64,16 @@ export interface SimCloudFrontDistributionConfig {
           | undefined;
       };
   readonly ViewerCertificate?: SimCloudFrontViewerCertificate | undefined;
+  /**
+   * The ARN of the `CLOUDFRONT` scope WAFv2 web ACL in front of the
+   * Distribution.
+   *
+   * CloudFront names its web ACL here rather than through `AssociateWebACL`,
+   * which WAFv2 keeps for the regional resource types. The name is the one the
+   * CloudFront API uses, and an empty value means no web ACL, as it does in
+   * AWS.
+   */
+  readonly WebACLId?: string | undefined;
 }
 
 /**

--- a/src/service/cloudfront/command/create-distribution/create-distribution.handler.ts
+++ b/src/service/cloudfront/command/create-distribution/create-distribution.handler.ts
@@ -14,6 +14,7 @@ import type { SimCloudFrontS3OriginResolver } from "../../origin/s3/sim-cloudfro
 import type { SimCfCustomOriginDispatcher } from "../../origin/custom/sim-cf-custom-origin-dispatcher.js";
 import type { SimCloudFrontOriginAccessControlRegistry } from "../../origin-access-control/sim-cf-origin-access-control-registry.js";
 import type { SimCloudFrontResponseHeadersPolicyRegistry } from "../../response-headers-policy/sim-cf-response-headers-policy-registry.js";
+import type { SimCfWebAclResolver } from "../../web-acl/sim-cf-web-acl.js";
 import type { BackgroundScheduler } from "../../../../util/background/background.js";
 import { makeSimCloudFrontDistributionConfigurator } from "../../distribution/configurator/sim-cf-distribution-configurator.factory.js";
 import type { SimCloudFrontDistributionConfigurator } from "../../distribution/configurator/sim-cloud-front-distribution-configurator.js";
@@ -39,6 +40,7 @@ interface CreateDistributionCommandHandlerProperties {
   readonly customOriginDispatcher?: SimCfCustomOriginDispatcher | undefined;
   readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry;
   readonly responseHeadersPolicies: SimCloudFrontResponseHeadersPolicyRegistry;
+  readonly webAclResolver?: SimCfWebAclResolver | undefined;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly acmRegistry?: SimAcmRegistry | undefined;
   readonly background: BackgroundScheduler;

--- a/src/service/cloudfront/command/update-distribution/update-distribution.handler.ts
+++ b/src/service/cloudfront/command/update-distribution/update-distribution.handler.ts
@@ -23,6 +23,7 @@ import type { SimCfCustomOriginDispatcher } from "../../origin/custom/sim-cf-cus
 import type { SimCloudFrontS3OriginResolver } from "../../origin/s3/sim-cloudfront-s3-origin.js";
 import type { SimCloudFrontOriginAccessControlRegistry } from "../../origin-access-control/sim-cf-origin-access-control-registry.js";
 import type { SimCloudFrontResponseHeadersPolicyRegistry } from "../../response-headers-policy/sim-cf-response-headers-policy-registry.js";
+import type { SimCfWebAclResolver } from "../../web-acl/sim-cf-web-acl.js";
 import type { SimCloudFrontRegistry } from "../../registry/sim-cloud-front-registry.js";
 import { SimCloudFrontDistributionConfigNormalizer } from "../create-distribution/sim-cf-distro-config-normalizer.js";
 import { UpdateDistributionAuthorizer } from "./update-distribution-authorizer.js";
@@ -42,6 +43,7 @@ interface UpdateDistributionCommandHandlerProperties {
   readonly customOriginDispatcher?: SimCfCustomOriginDispatcher | undefined;
   readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry;
   readonly responseHeadersPolicies: SimCloudFrontResponseHeadersPolicyRegistry;
+  readonly webAclResolver?: SimCfWebAclResolver | undefined;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly acmRegistry?: SimAcmRegistry | undefined;
   readonly background?: BackgroundScheduler;

--- a/src/service/cloudfront/controller/dependency/sim-cf-controller-dependency.ts
+++ b/src/service/cloudfront/controller/dependency/sim-cf-controller-dependency.ts
@@ -8,11 +8,14 @@ import { SimCffApplicator } from "../cff/sim-cff-applicator.js";
 import { SimCloudFrontOriginFetcher } from "../origin/sim-cloudfront-origin-fetcher.js";
 import { SimCfCustomErrorResponder } from "../error/sim-cf-custom-error-responder.js";
 import { SimCfResponseHeadersApplicator } from "../response-headers/sim-cf-response-headers-applicator.js";
+import { SimCfWebAclGuard } from "../web-acl/sim-cf-web-acl-guard.js";
+import { makeSimCfWebAclResolver } from "../../web-acl/sim-cf-web-acl-resolver.factory.js";
 
 export interface SimCloudFrontServiceControllerProperties {
   readonly simAws?: SimAws;
   readonly cloudFrontRegistry?: SimCloudFrontRegistry;
   readonly distroRouter?: SimCloudFrontDistroRouter;
+  readonly webAclGuard?: SimCfWebAclGuard;
   readonly behaviourResolver?: SimCloudFrontBehaviorResolver;
   readonly cffApplicator?: SimCffApplicator;
   readonly originFetcher?: SimCloudFrontOriginFetcher;
@@ -22,6 +25,7 @@ export interface SimCloudFrontServiceControllerProperties {
 
 export interface SimCloudFrontControllerDependencies {
   readonly distroRouter: SimCloudFrontDistroRouter;
+  readonly webAclGuard: SimCfWebAclGuard;
   readonly behaviourResolver: SimCloudFrontBehaviorResolver;
   readonly cffApplicator: SimCffApplicator;
   readonly originFetcher: SimCloudFrontOriginFetcher;
@@ -59,6 +63,9 @@ export class SimCloudFrontControllerDependenciesFactory {
           simAws,
           cloudFrontRegistry,
         }),
+      webAclGuard:
+        properties.webAclGuard ??
+        new SimCfWebAclGuard(makeSimCfWebAclResolver(simAws)),
       behaviourResolver,
       cffApplicator: properties.cffApplicator ?? new SimCffApplicator(),
       originFetcher,

--- a/src/service/cloudfront/controller/sim-cloudfront-request-pipeline.ts
+++ b/src/service/cloudfront/controller/sim-cloudfront-request-pipeline.ts
@@ -3,10 +3,11 @@ import { simCfDefaultRootObjectRequest } from "./root-object/sim-cf-default-root
 
 /**
  * Runs a single simulated CloudFront request through its lifecycle:
- * route to a Distribution, apply the default root object, resolve the matching
- * Behavior, run viewer-request hooks, fetch from the Origin, replace an error
- * response with the Distribution's custom error page, apply the Behavior's
- * response headers policy, then run viewer-response hooks.
+ * route to a Distribution, put the request through the Distribution's web ACL,
+ * apply the default root object, resolve the matching Behavior, run
+ * viewer-request hooks, fetch from the Origin, replace an error response with
+ * the Distribution's custom error page, apply the Behavior's response headers
+ * policy, then run viewer-response hooks.
  *
  * This is the request-processing core, kept separate from the service
  * controller so the controller stays a thin adapter to the shared
@@ -31,6 +32,19 @@ export class SimCloudFrontRequestPipeline {
     }
 
     const { cloudFront, distribution: distro } = route;
+
+    // Put the request through the Distribution's web ACL, if it has one.
+    // CloudFront asks WAF before any content handling, so a blocked request is
+    // answered at the edge without a Behavior, a CloudFront Function or the
+    // Origin ever seeing it.
+    const webAclResult = await this.stages.webAclGuard.apply(
+      requestReference,
+      distro,
+    );
+    if (webAclResult instanceof Response) {
+      return webAclResult;
+    }
+    requestReference = webAclResult;
 
     requestReference = simCfDefaultRootObjectRequest(requestReference, distro);
 

--- a/src/service/cloudfront/controller/web-acl/sim-cf-web-acl-guard.iso.test.ts
+++ b/src/service/cloudfront/controller/web-acl/sim-cf-web-acl-guard.iso.test.ts
@@ -1,0 +1,381 @@
+import {
+  CreateDistributionCommand,
+  CreateFunctionCommand,
+  type DistributionConfig,
+} from "@aws-sdk/client-cloudfront";
+import {
+  CreateLogGroupCommand,
+  FilterLogEventsCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import { DeleteWebACLCommand } from "@aws-sdk/client-wafv2";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertResponseStatus,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simHttpApiLambdaProxyFactory } from "../../../apigatewayv2/api/sim-http-api-lambda-proxy.factory.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simWafCreateWebAclFactory } from "../../../wafv2/command/web-acl/sim-waf-create-web-acl.factory.js";
+import { simWafCloudFrontRegion } from "../../../wafv2/scope/sim-waf-scope.js";
+import { createSimWafWebAcl } from "../../../wafv2/sim-wafv2.fixture.js";
+import type { SimWafActionInput } from "../../../wafv2/web-acl/sim-waf-action.type.js";
+import { simWafRuleFactory } from "../../../wafv2/web-acl/sim-waf-rule.factory.js";
+import { makeCffFunctionCodeInput } from "../../cff/function-code-input/cff-function-code-input.js";
+import type { CloudFrontFunction } from "../../typings/cloudfront-functions.namespace.js";
+import { simCfSiteRequest } from "../../../../../test/cloudfront/site-fixture.js";
+
+/** The log group the Origin function writes what it served to. */
+const logGroupName = "/aws/lambda/site";
+
+/**
+ * A simulation whose Origin is an HTTP API that records what it was asked for.
+ *
+ * A request that never reaches the Origin is the whole point of a web ACL, and
+ * the only way to see that from outside is to have the Origin say when it was
+ * reached. The log group is created up front so that a request that got
+ * nowhere near it leaves an empty group rather than no group at all.
+ */
+async function simAwsWithRecordingOrigin(): Promise<{
+  readonly simAws: SimAws;
+  readonly originDomainName: string;
+}> {
+  const simAws = new SimAws();
+  const api = await simHttpApiLambdaProxyFactory.make(
+    {
+      functionName: "site",
+      handler: (event): unknown => {
+        // The Origin says what it served through its own log group, which is
+        // the only way a test can see that a blocked request never got here.
+        // oxlint-disable-next-line no-console -- the record under assertion
+        console.log(`served ${event.rawPath} ${event.body ?? ""}`.trimEnd());
+
+        return { statusCode: 200, body: "origin page" };
+      },
+    },
+    simAws,
+  );
+
+  await simAws
+    .logs()
+    .createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+
+  return { simAws, originDomainName: new URL(api.apiEndpoint).hostname };
+}
+
+/**
+ * What the Origin was asked for, in the order it served the requests.
+ */
+async function servedByOrigin(simAws: SimAws): Promise<readonly string[]> {
+  await simAws.backgroundTasksComplete();
+  const found = await simAws
+    .logs()
+    .filterLogEvents(new FilterLogEventsCommand({ logGroupName }));
+
+  return found.events?.map((event) => event.message) ?? [];
+}
+
+/**
+ * A CLOUDFRONT scope web ACL whose one rule claims everything under `/admin`
+ * and takes the action given.
+ */
+async function adminWebAclArn(
+  simAws: SimAws,
+  action: SimWafActionInput,
+): Promise<string> {
+  const created = await createSimWafWebAcl(
+    simAws.region(simWafCloudFrontRegion).account().wafV2(),
+    simWafCreateWebAclFactory.make({
+      Scope: "CLOUDFRONT",
+      Rules: [
+        {
+          ...simWafRuleFactory.make({ Name: "admin" }),
+          Action: action,
+          Statement: {
+            ByteMatchStatement: {
+              SearchString: "/admin",
+              PositionalConstraint: "STARTS_WITH",
+              FieldToMatch: { UriPath: {} },
+              TextTransformations: [{ Priority: 0, Type: "NONE" }],
+            },
+          },
+        },
+      ],
+    }),
+  );
+
+  return created.ARN;
+}
+
+/**
+ * A CloudFront Function that answers every request itself, reporting the
+ * header WAF inserts for a `reviewed-by` custom request handling header.
+ *
+ * It stands in for everything downstream of the web ACL: a request it never
+ * saw is one that never got past WAF, and one it did see carries whatever WAF
+ * added on the way through.
+ */
+async function reportingFunctionArn(simAws: SimAws): Promise<string> {
+  const created = await simAws.cloudFront().createFunction(
+    new CreateFunctionCommand({
+      Name: "report-web-acl-handling",
+      FunctionConfig: {
+        Comment: "Answers with the reviewed-by header it was given",
+        Runtime: "cloudfront-js-2.0",
+      },
+      FunctionCode: makeCffFunctionCodeInput(
+        (event: CloudFrontFunction.ViewerRequestEvent) => ({
+          statusCode: 204,
+          headers: {
+            "x-reviewed-by": {
+              value:
+                event.request.headers["x-amzn-waf-reviewed-by"]?.value ??
+                "nobody",
+            },
+          },
+        }),
+      ),
+    }),
+  );
+
+  return created.FunctionMetadata.FunctionARN;
+}
+
+/**
+ * A Distribution serving the recording Origin from behind a web ACL, with the
+ * viewer-request Function attached when one is named.
+ */
+async function guardedDistributionId(
+  simAws: SimAws,
+  properties: {
+    readonly originDomainName: string;
+    readonly webAclArn: string;
+    readonly functionArn?: string | undefined;
+  },
+): Promise<string> {
+  const { functionArn } = properties;
+  const distributionConfig: DistributionConfig = {
+    CallerReference: "web-acl-guarded",
+    Comment: "Guarded by a web ACL",
+    Enabled: true,
+    WebACLId: properties.webAclArn,
+    Origins: {
+      Quantity: 1,
+      Items: [
+        {
+          Id: "api-origin",
+          DomainName: properties.originDomainName,
+          CustomOriginConfig: {
+            HTTPPort: 80,
+            HTTPSPort: 443,
+            OriginProtocolPolicy: "https-only",
+          },
+        },
+      ],
+    },
+    DefaultCacheBehavior: {
+      TargetOriginId: "api-origin",
+      ViewerProtocolPolicy: "allow-all",
+      AllowedMethods: {
+        Quantity: 3,
+        Items: ["GET", "HEAD", "POST"],
+        CachedMethods: { Quantity: 2, Items: ["GET", "HEAD"] },
+      },
+      FunctionAssociations:
+        functionArn === undefined
+          ? undefined
+          : {
+              Quantity: 1,
+              Items: [
+                { EventType: "viewer-request", FunctionARN: functionArn },
+              ],
+            },
+    },
+  };
+
+  const creation = await simAws
+    .cloudFront()
+    .createDistribution(
+      new CreateDistributionCommand({ DistributionConfig: distributionConfig }),
+    );
+
+  assertNonNullable(creation.Distribution?.Id);
+
+  return creation.Distribution.Id;
+}
+
+describe("A request to a sim CloudFront Distribution behind a web ACL", () => {
+  it("gets 403 and never reaches the Origin when the web ACL blocks it", async () => {
+    // Given a Distribution behind a web ACL that blocks everything under
+    // /admin.
+    const { simAws, originDomainName } = await simAwsWithRecordingOrigin();
+    const distributionId = await guardedDistributionId(simAws, {
+      originDomainName,
+      webAclArn: await adminWebAclArn(simAws, { Block: {} }),
+    });
+
+    // When a viewer asks for a page under it.
+    const response = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/admin/users",
+    );
+
+    // Then the edge answered it with WAF's own 403 page, and the Origin was
+    // never asked for anything.
+    assertResponseStatus(response, 403);
+    assertStringIncludes(await response.text(), "Request blocked by AWS WAF");
+    assertArrayLength(await servedByOrigin(simAws), 0);
+  });
+
+  it("reaches the Origin unchanged when the web ACL allows it", async () => {
+    // Given the same Distribution behind the same web ACL.
+    const { simAws, originDomainName } = await simAwsWithRecordingOrigin();
+    const distributionId = await guardedDistributionId(simAws, {
+      originDomainName,
+      webAclArn: await adminWebAclArn(simAws, { Block: {} }),
+    });
+
+    // When a viewer asks for a page no rule claims.
+    const response = await simCfSiteRequest(simAws, distributionId, "/orders");
+
+    // Then the Origin served it, as it would with no web ACL in front at all.
+    assertResponseStatus(response, 200);
+    assertIdentical(await response.text(), "origin page");
+    assertArrayEquals(await servedByOrigin(simAws), ["served /orders"]);
+  });
+
+  it("never invokes a viewer-request Function for a blocked request", async () => {
+    // Given a Distribution behind a blocking web ACL whose viewer-request
+    // Function answers every request it sees.
+    const { simAws, originDomainName } = await simAwsWithRecordingOrigin();
+    const distributionId = await guardedDistributionId(simAws, {
+      originDomainName,
+      webAclArn: await adminWebAclArn(simAws, { Block: {} }),
+      functionArn: await reportingFunctionArn(simAws),
+    });
+
+    // When a viewer asks for a page the web ACL blocks.
+    const response = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/admin/users",
+    );
+
+    // Then WAF answered it and the Function never ran, because CloudFront asks
+    // WAF ahead of every edge function.
+    assertResponseStatus(response, 403);
+    assertIdentical(response.headers.get("x-reviewed-by"), null);
+  });
+
+  it("carries the headers an allowing rule inserted past the web ACL", async () => {
+    // Given a Distribution whose web ACL allows /admin with a header of its
+    // own added to what it lets through.
+    const { simAws, originDomainName } = await simAwsWithRecordingOrigin();
+    const distributionId = await guardedDistributionId(simAws, {
+      originDomainName,
+      webAclArn: await adminWebAclArn(simAws, {
+        Allow: {
+          CustomRequestHandling: {
+            InsertHeaders: [{ Name: "reviewed-by", Value: "waf" }],
+          },
+        },
+      }),
+      functionArn: await reportingFunctionArn(simAws),
+    });
+
+    // When a viewer asks for a page the rule claims.
+    const response = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/admin/users",
+    );
+
+    // Then what runs after the web ACL sees the header it inserted.
+    assertResponseStatus(response, 204);
+    assertIdentical(response.headers.get("x-reviewed-by"), "waf");
+  });
+
+  it("decides on the request body, and forwards it to the Origin all the same", async () => {
+    // Given a Distribution behind a web ACL whose rule reads the request body.
+    const { simAws, originDomainName } = await simAwsWithRecordingOrigin();
+    const created = await createSimWafWebAcl(
+      simAws.region(simWafCloudFrontRegion).account().wafV2(),
+      simWafCreateWebAclFactory.make({
+        Scope: "CLOUDFRONT",
+        Rules: [
+          {
+            ...simWafRuleFactory.make({ Name: "no-secrets" }),
+            Action: { Block: {} },
+            Statement: {
+              ByteMatchStatement: {
+                SearchString: "secret",
+                PositionalConstraint: "CONTAINS",
+                FieldToMatch: { Body: {} },
+                TextTransformations: [{ Priority: 0, Type: "NONE" }],
+              },
+            },
+          },
+        ],
+      }),
+    );
+    const distributionId = await guardedDistributionId(simAws, {
+      originDomainName,
+      webAclArn: created.ARN,
+    });
+
+    // When one POST carries what the rule claims and another does not.
+    const blocked = await simCfSiteRequest(simAws, distributionId, "/orders", {
+      method: "POST",
+      body: "a secret",
+    });
+    const allowed = await simCfSiteRequest(simAws, distributionId, "/orders", {
+      method: "POST",
+      body: "an order",
+    });
+
+    // Then the first is blocked at the edge, and the second reaches the Origin
+    // with the body it was sent with: reading it for WAF does not consume it.
+    assertResponseStatus(blocked, 403);
+    assertResponseStatus(allowed, 200);
+    assertArrayEquals(await servedByOrigin(simAws), [
+      "served /orders an order",
+    ]);
+  });
+
+  it("refuses to serve once the web ACL it names has been deleted", async () => {
+    // Given a Distribution behind a web ACL.
+    const { simAws, originDomainName } = await simAwsWithRecordingOrigin();
+    const waf = simAws.region(simWafCloudFrontRegion).account().wafV2();
+    const webAclArn = await adminWebAclArn(simAws, { Block: {} });
+    const distributionId = await guardedDistributionId(simAws, {
+      originDomainName,
+      webAclArn,
+    });
+
+    // When the web ACL is deleted out from under it, which real WAF refuses
+    // while a Distribution is still in front of it.
+    const webAcl = waf.findWebAclByArn(webAclArn);
+    assertNonNullable(webAcl);
+    await waf.deleteWebAcl(
+      new DeleteWebACLCommand({
+        Name: webAcl.name,
+        Scope: "CLOUDFRONT",
+        Id: webAcl.id,
+        LockToken: webAcl.lockToken,
+      }),
+    );
+
+    // Then the Distribution says so, rather than quietly serving the requests
+    // the web ACL would have decided.
+    const response = await simCfSiteRequest(simAws, distributionId, "/orders");
+
+    assertResponseStatus(response, 400);
+    assertStringIncludes(await response.text(), webAclArn);
+    assertArrayLength(await servedByOrigin(simAws), 0);
+  });
+});

--- a/src/service/cloudfront/controller/web-acl/sim-cf-web-acl-guard.ts
+++ b/src/service/cloudfront/controller/web-acl/sim-cf-web-acl-guard.ts
@@ -1,0 +1,114 @@
+import {
+  simWafBlockedHttpResponse,
+  simWafDefaultBlockedResponse,
+} from "../../../wafv2/evaluate/sim-waf-blocked-response.js";
+import type { SimWafDecision } from "../../../wafv2/evaluate/sim-waf-decision.js";
+import type { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
+import { SimCloudFrontInvalidWebAclId } from "../../error/sim-cloudfront.error.js";
+import type { SimCfWebAclResolver } from "../../web-acl/sim-cf-web-acl.js";
+
+/**
+ * Puts a request through the web ACL a Distribution names, before anything
+ * else has a look at it.
+ *
+ * CloudFront asks WAF ahead of every content-handling stage, so a blocked
+ * request never reaches a viewer-request CloudFront Function, a cache
+ * Behavior, a response headers policy or the Origin. It is answered at the
+ * edge with the 403 the web ACL's block action describes.
+ */
+export class SimCfWebAclGuard {
+  /**
+   * A guard with nothing to resolve a web ACL through stands in front of a
+   * simulation holding none, so a Distribution naming one is refused rather
+   * than served as though it named nothing.
+   */
+  constructor(private readonly resolveWebAcl?: SimCfWebAclResolver) {}
+
+  /**
+   * Answer with the request to carry on with, or the response a blocked
+   * request gets.
+   *
+   * The request comes back rather than a bare verdict because an allowing rule
+   * can insert headers into what is forwarded, which is what WAF's custom
+   * request handling is for.
+   */
+  async apply(
+    request: Request,
+    distribution: SimCloudFrontDistribution,
+  ): Promise<Request | Response> {
+    const webAclArn = distribution.webAclArn;
+
+    if (webAclArn === undefined) {
+      return request;
+    }
+
+    const found = this.resolveWebAcl?.(webAclArn);
+
+    if (found === undefined) {
+      throw new SimCloudFrontInvalidWebAclId(
+        `Sim CloudFront Distribution ${distribution.distributionId} names ` +
+          `web ACL ${webAclArn}, which does not exist. A web ACL a ` +
+          `Distribution is still in front of cannot be deleted in AWS, so a ` +
+          `simulation that deleted one has left the Distribution naming ` +
+          `nothing.`,
+      );
+    }
+
+    const decision = found.wafV2.evaluateRequest({
+      webAclArn,
+      request,
+      body: await requestBody(request),
+    });
+
+    return decision.action === "BLOCK"
+      ? simWafBlockedHttpResponse(
+          decision.blocked ?? simWafDefaultBlockedResponse(),
+        )
+      : allowedRequest(request, decision);
+  }
+}
+
+/**
+ * The request as it carries on past the web ACL.
+ *
+ * A rule that matched with custom request handling adds headers to what is
+ * forwarded, so the Origin and any CloudFront Function see them. A decision
+ * that inserted none leaves the request exactly as the viewer sent it.
+ */
+function allowedRequest(request: Request, decision: SimWafDecision): Request {
+  if (decision.insertedHeaders.length === 0) {
+    return request;
+  }
+
+  const headers = new Headers(request.headers);
+
+  for (const header of decision.insertedHeaders) {
+    headers.set(header.name, header.value);
+  }
+
+  const isBodyAllowed = !/^(?:get|head)$/iu.test(request.method);
+
+  return new Request(request.url, {
+    method: request.method,
+    headers,
+    body: isBodyAllowed ? request.clone().body : null,
+    duplex: "half",
+    redirect: request.redirect,
+    signal: request.signal,
+  });
+}
+
+/**
+ * The request body the web ACL's rules are matched against.
+ *
+ * WAF reads the body of the request as it arrived, and a body is a stream that
+ * can only be read once, so it is read from a clone and the request carries on
+ * with its own copy intact.
+ */
+async function requestBody(request: Request): Promise<Uint8Array | undefined> {
+  if (request.body === null) {
+    return undefined;
+  }
+
+  return new Uint8Array(await request.clone().arrayBuffer());
+}

--- a/src/service/cloudfront/controller/web-acl/sim-cf-web-acl-guard.ts
+++ b/src/service/cloudfront/controller/web-acl/sim-cf-web-acl-guard.ts
@@ -17,12 +17,7 @@ import type { SimCfWebAclResolver } from "../../web-acl/sim-cf-web-acl.js";
  * edge with the 403 the web ACL's block action describes.
  */
 export class SimCfWebAclGuard {
-  /**
-   * A guard with nothing to resolve a web ACL through stands in front of a
-   * simulation holding none, so a Distribution naming one is refused rather
-   * than served as though it named nothing.
-   */
-  constructor(private readonly resolveWebAcl?: SimCfWebAclResolver) {}
+  constructor(private readonly resolveWebAcl: SimCfWebAclResolver) {}
 
   /**
    * Answer with the request to carry on with, or the response a blocked
@@ -42,7 +37,7 @@ export class SimCfWebAclGuard {
       return request;
     }
 
-    const found = this.resolveWebAcl?.(webAclArn);
+    const found = this.resolveWebAcl(webAclArn);
 
     if (found === undefined) {
       throw new SimCloudFrontInvalidWebAclId(

--- a/src/service/cloudfront/distribution/configurator/sim-cf-distribution-configurator.factory.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cf-distribution-configurator.factory.ts
@@ -2,16 +2,19 @@ import type { SimCfCustomOriginDispatcher } from "../../origin/custom/sim-cf-cus
 import type { SimCloudFrontS3OriginResolver } from "../../origin/s3/sim-cloudfront-s3-origin.js";
 import type { SimCloudFrontOriginAccessControlRegistry } from "../../origin-access-control/sim-cf-origin-access-control-registry.js";
 import type { SimCloudFrontResponseHeadersPolicyRegistry } from "../../response-headers-policy/sim-cf-response-headers-policy-registry.js";
+import { SimCfDistributionWebAcl } from "../../web-acl/sim-cf-distribution-web-acl.js";
+import type { SimCfWebAclResolver } from "../../web-acl/sim-cf-web-acl.js";
 import { SimCfBehaviorResponseHeadersPolicy } from "./sim-cf-behavior-response-headers-policy.js";
 import { SimCloudFrontBehaviorConfigurator } from "./sim-cloud-front-behavior-configurator.js";
 import { SimCloudFrontDistributionConfigurator } from "./sim-cloud-front-distribution-configurator.js";
 import { SimCloudFrontOriginConfigurator } from "./sim-cloud-front-origin-configurator.js";
 
-interface SimCloudFrontConfiguratorOrigins {
+interface SimCloudFrontConfiguratorProperties {
   readonly s3OriginResolver: SimCloudFrontS3OriginResolver;
   readonly customOriginDispatcher?: SimCfCustomOriginDispatcher | undefined;
   readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry;
   readonly responseHeadersPolicies: SimCloudFrontResponseHeadersPolicyRegistry;
+  readonly webAclResolver?: SimCfWebAclResolver | undefined;
 }
 
 /**
@@ -21,19 +24,20 @@ interface SimCloudFrontConfiguratorOrigins {
  * same set of configurators.
  */
 export function makeSimCloudFrontDistributionConfigurator(
-  origins: SimCloudFrontConfiguratorOrigins,
+  properties: SimCloudFrontConfiguratorProperties,
 ): SimCloudFrontDistributionConfigurator {
   const responseHeadersPolicy = new SimCfBehaviorResponseHeadersPolicy(
-    origins.responseHeadersPolicies,
+    properties.responseHeadersPolicies,
   );
 
   return new SimCloudFrontDistributionConfigurator(
     new SimCloudFrontOriginConfigurator(
-      origins.s3OriginResolver,
-      origins.originAccessControls,
-      origins.customOriginDispatcher,
+      properties.s3OriginResolver,
+      properties.originAccessControls,
+      properties.customOriginDispatcher,
     ),
     new SimCloudFrontBehaviorConfigurator(responseHeadersPolicy),
     responseHeadersPolicy,
+    new SimCfDistributionWebAcl(properties.webAclResolver),
   );
 }

--- a/src/service/cloudfront/distribution/configurator/sim-cloud-front-distribution-configurator.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cloud-front-distribution-configurator.ts
@@ -5,6 +5,10 @@ import type { SimCloudFrontBehaviorConfigurator } from "./sim-cloud-front-behavi
 import type { SimCfBehaviorResponseHeadersPolicy } from "./sim-cf-behavior-response-headers-policy.js";
 import { SimCloudFrontCustomErrorConfigurator } from "./sim-cloud-front-custom-error-configurator.js";
 import { SimCloudFrontInvalidDefaultRootObject } from "../../error/sim-cloudfront.error.js";
+import {
+  type SimCfDistributionWebAcl,
+  simCfWebAclArn,
+} from "../../web-acl/sim-cf-distribution-web-acl.js";
 
 /**
  * Applies top-level Distribution configuration to a sim CloudFront Distribution.
@@ -18,6 +22,10 @@ import { SimCloudFrontInvalidDefaultRootObject } from "../../error/sim-cloudfron
  *
  * Named Cache Behaviors must be added after the default so that the default
  * always acts as the fallback when no path pattern matches.
+ *
+ * The web ACL comes before all of it, because a web ACL decides a request
+ * before any of the above handles it, and a config naming one that is not
+ * there is refused rather than half applied.
  */
 export class SimCloudFrontDistributionConfigurator {
   private readonly customErrorConfigurator =
@@ -27,6 +35,7 @@ export class SimCloudFrontDistributionConfigurator {
     private readonly originConfigurator: SimCloudFrontOriginConfigurator,
     private readonly behaviorConfigurator: SimCloudFrontBehaviorConfigurator,
     private readonly responseHeadersPolicy: SimCfBehaviorResponseHeadersPolicy,
+    private readonly webAcl: SimCfDistributionWebAcl,
   ) {}
 
   /**
@@ -43,6 +52,7 @@ export class SimCloudFrontDistributionConfigurator {
     distributionConfig: SimCloudFrontDistributionConfig,
   ): void {
     this.responseHeadersPolicy.assertAllExist(distributionConfig);
+    this.webAcl.assertUsable(distributionConfig);
   }
 
   /**
@@ -52,6 +62,11 @@ export class SimCloudFrontDistributionConfigurator {
     distribution: SimCloudFrontDistribution,
     distributionConfig: SimCloudFrontDistributionConfig,
   ): void {
+    // A web ACL the simulation cannot find is refused before anything is
+    // applied, so a creation is turned away for it as an update already is.
+    this.webAcl.assertUsable(distributionConfig);
+    distribution.webAclArn = simCfWebAclArn(distributionConfig);
+
     const aliasItems = distributionConfig.Aliases?.Items ?? [];
     for (const alias of aliasItems) {
       distribution.addAlternateDomainName(alias);

--- a/src/service/cloudfront/distribution/sim-cf-distribution-configuration-state.ts
+++ b/src/service/cloudfront/distribution/sim-cf-distribution-configuration-state.ts
@@ -1,0 +1,24 @@
+import type { SimAcmRegistry } from "../../acm/registry/sim-acm-registry.js";
+import type { SimCfCustomOriginDispatcher } from "../origin/custom/sim-cf-custom-origin-dispatcher.js";
+import type { SimCloudFrontS3OriginResolver } from "../origin/s3/sim-cloudfront-s3-origin.js";
+import type { SimCloudFrontOriginAccessControlRegistry } from "../origin-access-control/sim-cf-origin-access-control-registry.js";
+import type { SimCloudFrontResponseHeadersPolicyRegistry } from "../response-headers-policy/sim-cf-response-headers-policy-registry.js";
+import type { SimCfWebAclResolver } from "../web-acl/sim-cf-web-acl.js";
+
+/**
+ * How the commands that configure a Distribution reach everything a
+ * DistributionConfig names outside itself.
+ *
+ * A DistributionConfig is mostly references: a Bucket or a hostname per
+ * Origin, a certificate, an origin access control, a response headers policy,
+ * a web ACL. None of them belongs to CloudFront, and creation and update
+ * resolve every one of them the same way, so they travel together.
+ */
+export interface SimCfDistributionConfigurationState {
+  readonly s3OriginResolver: SimCloudFrontS3OriginResolver;
+  readonly customOriginDispatcher: SimCfCustomOriginDispatcher | undefined;
+  readonly acmRegistry: SimAcmRegistry | undefined;
+  readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry;
+  readonly responseHeadersPolicies: SimCloudFrontResponseHeadersPolicyRegistry;
+  readonly webAclResolver: SimCfWebAclResolver | undefined;
+}

--- a/src/service/cloudfront/distribution/sim-cf-distribution-reconfigurer.ts
+++ b/src/service/cloudfront/distribution/sim-cf-distribution-reconfigurer.ts
@@ -4,6 +4,7 @@ import type { SimCloudFrontS3OriginResolver } from "../origin/s3/sim-cloudfront-
 import type { SimCloudFrontOriginAccessControlRegistry } from "../origin-access-control/sim-cf-origin-access-control-registry.js";
 import type { SimCloudFrontResponseHeadersPolicyRegistry } from "../response-headers-policy/sim-cf-response-headers-policy-registry.js";
 import type { SimCloudFrontRegistry } from "../registry/sim-cloud-front-registry.js";
+import type { SimCfWebAclResolver } from "../web-acl/sim-cf-web-acl.js";
 import { makeSimCloudFrontDistributionConfigurator } from "./configurator/sim-cf-distribution-configurator.factory.js";
 import type { SimCloudFrontDistributionConfigurator } from "./configurator/sim-cloud-front-distribution-configurator.js";
 import type { SimCloudFrontDistribution } from "./sim-cloudfront-distribution.js";
@@ -14,6 +15,7 @@ interface SimCloudFrontDistributionReconfigurerProperties {
   readonly customOriginDispatcher?: SimCfCustomOriginDispatcher | undefined;
   readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry;
   readonly responseHeadersPolicies: SimCloudFrontResponseHeadersPolicyRegistry;
+  readonly webAclResolver?: SimCfWebAclResolver | undefined;
 }
 
 /**

--- a/src/service/cloudfront/distribution/sim-cloudfront-distribution.ts
+++ b/src/service/cloudfront/distribution/sim-cloudfront-distribution.ts
@@ -44,6 +44,7 @@ export class SimCloudFrontDistribution {
   #distributionConfig: SimCloudFrontDistributionConfig | undefined;
   #enabled: boolean;
   #defaultRootObject: string | undefined;
+  #webAclArn: string | undefined;
   private readonly alternateDomainNames = new Set<string>();
 
   private readonly origins = new Map<string, SimCloudFrontOrigin>();
@@ -101,6 +102,24 @@ export class SimCloudFrontDistribution {
   }
 
   /**
+   * The ARN of the web ACL this sim Distribution is behind, if any.
+   *
+   * CloudFront names its web ACL in the DistributionConfig rather than through
+   * WAFv2's AssociateWebACL, so this is read from the config the same way the
+   * default root object is.
+   */
+  get webAclArn(): string | undefined {
+    return this.#webAclArn;
+  }
+
+  /**
+   * Set the ARN of the web ACL this sim Distribution is behind.
+   */
+  set webAclArn(webAclArn: string | undefined) {
+    this.#webAclArn = webAclArn;
+  }
+
+  /**
    * Move the sim Distribution into Deployed status.
    */
   completeDeployment(): Promise<void> {
@@ -124,6 +143,7 @@ export class SimCloudFrontDistribution {
     this.#enabled = distributionConfig.Enabled ?? true;
     this.#status = "Deploying";
     this.#defaultRootObject = undefined;
+    this.#webAclArn = undefined;
     this.behaviors.length = 0;
     this.customErrorResponses.length = 0;
     this.alternateDomainNames.clear();

--- a/src/service/cloudfront/error/sim-cloudfront.error.ts
+++ b/src/service/cloudfront/error/sim-cloudfront.error.ts
@@ -217,3 +217,18 @@ export class SimCloudFrontFunctionSizeLimitExceeded extends SimCloudFrontError {
     super(message, { httpStatusCode: 413 });
   }
 }
+
+/**
+ * Simulated CloudFront InvalidWebACLId error.
+ *
+ * What CloudFront answers when a DistributionConfig's `WebACLId` names no
+ * `CLOUDFRONT` scope web ACL this simulation holds, at Distribution create or
+ * update time rather than when the first request needs a decision.
+ */
+export class SimCloudFrontInvalidWebAclId extends SimCloudFrontError {
+  public override readonly name = "InvalidWebACLId";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}

--- a/src/service/cloudfront/sim-cloudfront-commands.ts
+++ b/src/service/cloudfront/sim-cloudfront-commands.ts
@@ -55,6 +55,8 @@ import {
 import type { SimCloudFrontOriginAccessControlRegistry } from "./origin-access-control/sim-cf-origin-access-control-registry.js";
 import type { SimCloudFrontResponseHeadersPolicyRegistry } from "./response-headers-policy/sim-cf-response-headers-policy-registry.js";
 import { SimCloudFrontRegistry } from "./registry/sim-cloud-front-registry.js";
+import type { SimCfDistributionConfigurationState } from "./distribution/sim-cf-distribution-configuration-state.js";
+import type { SimCfWebAclResolver } from "./web-acl/sim-cf-web-acl.js";
 import { SimCfKeyValueStoreAccess } from "./key-value-store/sim-cf-key-value-store-access.js";
 import { SimCfKeyValueStoreCommands } from "./key-value-store/sim-cf-key-value-store-commands.js";
 import { SimCloudFrontKeyValueStoreRegistry } from "./key-value-store/sim-cf-key-value-store-registry.js";
@@ -71,6 +73,8 @@ export interface SimCloudFrontProperties {
   readonly customOriginDispatcher?: SimCfCustomOriginDispatcher | undefined;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly acmRegistry?: SimAcmRegistry | undefined;
+  /** How a Distribution's `WebACLId` is resolved to the web ACL it names. */
+  readonly webAclResolver?: SimCfWebAclResolver | undefined;
   readonly background?: BackgroundScheduler;
 }
 
@@ -137,13 +141,7 @@ export class SimCloudFrontCommands {
 
   private readonly distributionState: SimCloudFrontDistributionState;
   private readonly functionState: SimCloudFrontFunctionState;
-  private readonly s3OriginResolver: SimCloudFrontS3OriginResolver;
-  private readonly customOriginDispatcher:
-    | SimCfCustomOriginDispatcher
-    | undefined;
-  private readonly acmRegistry: SimAcmRegistry | undefined;
-  private readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry;
-  private readonly responseHeadersPolicies: SimCloudFrontResponseHeadersPolicyRegistry;
+  private readonly configurationState: SimCfDistributionConfigurationState;
 
   constructor(properties: SimCloudFrontCommandsProperties) {
     const {
@@ -155,6 +153,7 @@ export class SimCloudFrontCommands {
       customOriginDispatcher,
       iam = new SimIamAllowAllAuth(),
       acmRegistry,
+      webAclResolver,
       background = new BackgroundTasks(),
     } = properties;
 
@@ -174,11 +173,14 @@ export class SimCloudFrontCommands {
       background,
       keyValueStores,
     };
-    this.s3OriginResolver = s3OriginResolver;
-    this.customOriginDispatcher = customOriginDispatcher;
-    this.acmRegistry = acmRegistry;
-    this.originAccessControls = properties.originAccessControls;
-    this.responseHeadersPolicies = properties.responseHeadersPolicies;
+    this.configurationState = {
+      s3OriginResolver,
+      customOriginDispatcher,
+      acmRegistry,
+      webAclResolver,
+      originAccessControls: properties.originAccessControls,
+      responseHeadersPolicies: properties.responseHeadersPolicies,
+    };
     const keyValueStoreAccess = new SimCfKeyValueStoreAccess({
       accountId,
       stores: keyValueStores,
@@ -206,7 +208,7 @@ export class SimCloudFrontCommands {
   ): Promise<SimCreateDistributionCommandOutput> {
     return await new CreateDistributionCommandHandler({
       ...this.distributionState,
-      ...this.originState(),
+      ...this.configurationState,
     }).handle(command, options);
   }
 
@@ -231,7 +233,7 @@ export class SimCloudFrontCommands {
   ): Promise<SimUpdateDistributionCommandOutput> {
     return await new UpdateDistributionCommandHandler({
       ...this.distributionState,
-      ...this.originState(),
+      ...this.configurationState,
     }).handle(command, options);
   }
 
@@ -271,24 +273,5 @@ export class SimCloudFrontCommands {
       command,
       options,
     );
-  }
-
-  /**
-   * How the commands that configure a Distribution reach its Origins.
-   */
-  private originState(): {
-    readonly s3OriginResolver: SimCloudFrontS3OriginResolver;
-    readonly customOriginDispatcher: SimCfCustomOriginDispatcher | undefined;
-    readonly acmRegistry: SimAcmRegistry | undefined;
-    readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry;
-    readonly responseHeadersPolicies: SimCloudFrontResponseHeadersPolicyRegistry;
-  } {
-    return {
-      s3OriginResolver: this.s3OriginResolver,
-      customOriginDispatcher: this.customOriginDispatcher,
-      acmRegistry: this.acmRegistry,
-      originAccessControls: this.originAccessControls,
-      responseHeadersPolicies: this.responseHeadersPolicies,
-    };
   }
 }

--- a/src/service/cloudfront/web-acl/sim-cf-distribution-web-acl.iso.test.ts
+++ b/src/service/cloudfront/web-acl/sim-cf-distribution-web-acl.iso.test.ts
@@ -19,6 +19,7 @@ import { simWafCreateWebAclFactory } from "../../wafv2/command/web-acl/sim-waf-c
 import { simWafCloudFrontRegion } from "../../wafv2/scope/sim-waf-scope.js";
 import { createSimWafWebAcl } from "../../wafv2/sim-wafv2.fixture.js";
 import { SimCloudFrontInvalidWebAclId } from "../error/sim-cloudfront.error.js";
+import { SimCloudFront } from "../sim-cloudfront.js";
 import {
   simCfSiteBucket,
   simCfSiteDistributionConfig,
@@ -128,6 +129,35 @@ describe("A sim CloudFront Distribution's web ACL", () => {
     assertInstanceOf(error, SimCloudFrontInvalidWebAclId);
     assertStringIncludes(error.message, missingWebAclArn);
     assertMapSize(simAws.cloudFront().getDistributions(), 0);
+  });
+
+  it("refuses a WebACLId on a CloudFront with no simulation around it", async () => {
+    // Given a simulated CloudFront built on its own, with no simulated WAFv2
+    // anywhere to hold a web ACL.
+    const cloudFront = new SimCloudFront();
+
+    // When a Distribution is created naming one.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cloudFront.createDistribution(
+        new CreateDistributionCommand({
+          DistributionConfig: {
+            CallerReference: "standalone",
+            Comment: "Standalone Distribution",
+            Enabled: true,
+            WebACLId: missingWebAclArn,
+            Origins: { Quantity: 0, Items: [] },
+            DefaultCacheBehavior: {
+              TargetOriginId: "unused-origin",
+              ViewerProtocolPolicy: "allow-all",
+            },
+          },
+        }),
+      );
+    });
+
+    // Then it is refused at create, rather than taken on and then failing
+    // every request it has no way to decide.
+    assertInstanceOf(error, SimCloudFrontInvalidWebAclId);
   });
 
   it("refuses a Distribution naming a REGIONAL scope web ACL", async () => {

--- a/src/service/cloudfront/web-acl/sim-cf-distribution-web-acl.iso.test.ts
+++ b/src/service/cloudfront/web-acl/sim-cf-distribution-web-acl.iso.test.ts
@@ -1,0 +1,245 @@
+import {
+  CreateDistributionCommand,
+  type DistributionConfig,
+  UpdateDistributionCommand,
+} from "@aws-sdk/client-cloudfront";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertMapSize,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { simWafCreateWebAclFactory } from "../../wafv2/command/web-acl/sim-waf-create-web-acl.factory.js";
+import { simWafCloudFrontRegion } from "../../wafv2/scope/sim-waf-scope.js";
+import { createSimWafWebAcl } from "../../wafv2/sim-wafv2.fixture.js";
+import { SimCloudFrontInvalidWebAclId } from "../error/sim-cloudfront.error.js";
+import {
+  simCfSiteBucket,
+  simCfSiteDistributionConfig,
+  simCfSiteDistributionId,
+} from "../../../../test/cloudfront/site-fixture.js";
+
+/** The Bucket every Distribution here serves from. */
+const bucketName = "web-acl-site";
+
+/** An ARN of the right shape naming a web ACL nothing created. */
+const missingWebAclArn =
+  "arn:aws:wafv2:us-east-1:111111111111:global/webacl/gone/" +
+  "4a2b1c8d-0e6f-4a2b-9c8d-0e6f4a2b1c8d";
+
+/**
+ * A simulated AWS with the Bucket every Distribution here is in front of.
+ */
+async function simAwsWithSite(): Promise<SimAws> {
+  const simAws = new SimAws();
+  await simCfSiteBucket(simAws, bucketName, { "index.html": "<h1>Home</h1>" });
+
+  return simAws;
+}
+
+/**
+ * The ARN of a new web ACL in the scope named.
+ *
+ * Both scopes are created in us-east-1, which is where a `CLOUDFRONT` scope
+ * web ACL has to live, so the two differ by scope and nothing else.
+ */
+async function webAclArn(
+  simAws: SimAws,
+  scope: "CLOUDFRONT" | "REGIONAL",
+): Promise<string> {
+  const created = await createSimWafWebAcl(
+    simAws.region(simWafCloudFrontRegion).account().wafV2(),
+    simWafCreateWebAclFactory.make({ Scope: scope }),
+  );
+
+  return created.ARN;
+}
+
+/** The site DistributionConfig, behind the web ACL named. */
+function siteConfig(webAclId?: string): DistributionConfig {
+  return simCfSiteDistributionConfig(
+    bucketName,
+    webAclId === undefined ? {} : { WebACLId: webAclId },
+  );
+}
+
+describe("A sim CloudFront Distribution's web ACL", () => {
+  it("reports back the web ACL a Distribution was created with", async () => {
+    // Given a CLOUDFRONT scope web ACL.
+    const simAws = await simAwsWithSite();
+    const arn = await webAclArn(simAws, "CLOUDFRONT");
+
+    // When a Distribution is created naming it.
+    const creation = await simAws
+      .cloudFront()
+      .createDistribution(
+        new CreateDistributionCommand({ DistributionConfig: siteConfig(arn) }),
+      );
+
+    // Then the Distribution the API answered with carries it, and so does the
+    // Distribution serving requests.
+    const distributionId = creation.Distribution?.Id;
+    assertNonNullable(distributionId);
+    assertIdentical(creation.Distribution?.DistributionConfig?.WebACLId, arn);
+    assertIdentical(
+      simAws.cloudFront().getSimDistributionById(distributionId)?.webAclArn,
+      arn,
+    );
+  });
+
+  it("takes an empty WebACLId as no web ACL at all", async () => {
+    // Given a Distribution described the way CloudFormation describes one that
+    // was never given a web ACL.
+    const simAws = await simAwsWithSite();
+    const distributionId = await simCfSiteDistributionId(
+      simAws,
+      siteConfig(""),
+    );
+
+    // Then it is behind no web ACL, rather than behind one named by an empty
+    // ARN.
+    assertUndefined(
+      simAws.cloudFront().getSimDistributionById(distributionId)?.webAclArn,
+    );
+  });
+
+  it("refuses a Distribution naming a web ACL that does not exist", async () => {
+    // Given a simulation holding no web ACLs.
+    const simAws = await simAwsWithSite();
+
+    // When a Distribution is created naming one.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFront().createDistribution(
+        new CreateDistributionCommand({
+          DistributionConfig: siteConfig(missingWebAclArn),
+        }),
+      );
+    });
+
+    // Then CloudFront refuses it, as it refuses a missing response headers
+    // policy, rather than serving every request as though there were no web
+    // ACL.
+    assertInstanceOf(error, SimCloudFrontInvalidWebAclId);
+    assertStringIncludes(error.message, missingWebAclArn);
+    assertMapSize(simAws.cloudFront().getDistributions(), 0);
+  });
+
+  it("refuses a Distribution naming a REGIONAL scope web ACL", async () => {
+    // Given a REGIONAL scope web ACL, which fronts a stage or a load balancer
+    // rather than a Distribution.
+    const simAws = await simAwsWithSite();
+    const arn = await webAclArn(simAws, "REGIONAL");
+
+    // When a Distribution is created naming it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFront().createDistribution(
+        new CreateDistributionCommand({
+          DistributionConfig: siteConfig(arn),
+        }),
+      );
+    });
+
+    // Then CloudFront refuses it, as real WAF does.
+    assertInstanceOf(error, SimCloudFrontInvalidWebAclId);
+    assertStringIncludes(error.message, "REGIONAL");
+  });
+
+  it("takes the web ACL an update names, and drops the one it leaves out", async () => {
+    // Given a Distribution behind a web ACL.
+    const simAws = await simAwsWithSite();
+    const arn = await webAclArn(simAws, "CLOUDFRONT");
+    const distributionId = await simCfSiteDistributionId(
+      simAws,
+      siteConfig(arn),
+    );
+    const distribution = simAws
+      .cloudFront()
+      .getSimDistributionById(distributionId);
+    assertNonNullable(distribution);
+
+    // When an update names another one.
+    const replacementArn = await webAclArn(simAws, "CLOUDFRONT");
+    await simAws.cloudFront().updateDistribution(
+      new UpdateDistributionCommand({
+        Id: distributionId,
+        DistributionConfig: siteConfig(replacementArn),
+      }),
+    );
+
+    // Then the Distribution is behind the one that update named.
+    assertIdentical(distribution.webAclArn, replacementArn);
+
+    // And an update naming none leaves it behind nothing.
+    await simAws.cloudFront().updateDistribution(
+      new UpdateDistributionCommand({
+        Id: distributionId,
+        DistributionConfig: siteConfig(),
+      }),
+    );
+
+    assertUndefined(distribution.webAclArn);
+  });
+
+  it("refuses an update naming a web ACL that does not exist", async () => {
+    // Given a Distribution behind a web ACL.
+    const simAws = await simAwsWithSite();
+    const arn = await webAclArn(simAws, "CLOUDFRONT");
+    const distributionId = await simCfSiteDistributionId(
+      simAws,
+      siteConfig(arn),
+    );
+
+    // When an update names one that is not there.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFront().updateDistribution(
+        new UpdateDistributionCommand({
+          Id: distributionId,
+          DistributionConfig: siteConfig(missingWebAclArn),
+        }),
+      );
+    });
+
+    // Then the update is refused, and the Distribution is left behind the web
+    // ACL it already had rather than half replaced.
+    assertInstanceOf(error, SimCloudFrontInvalidWebAclId);
+    assertIdentical(
+      simAws.cloudFront().getSimDistributionById(distributionId)?.webAclArn,
+      arn,
+    );
+  });
+
+  it("refuses an update naming a REGIONAL scope web ACL", async () => {
+    // Given a Distribution behind a CLOUDFRONT scope web ACL.
+    const simAws = await simAwsWithSite();
+    const arn = await webAclArn(simAws, "CLOUDFRONT");
+    const distributionId = await simCfSiteDistributionId(
+      simAws,
+      siteConfig(arn),
+    );
+
+    // When an update names a REGIONAL scope one instead.
+    const regionalArn = await webAclArn(simAws, "REGIONAL");
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFront().updateDistribution(
+        new UpdateDistributionCommand({
+          Id: distributionId,
+          DistributionConfig: siteConfig(regionalArn),
+        }),
+      );
+    });
+
+    // Then the update is refused and the Distribution keeps serving behind the
+    // web ACL it had.
+    assertInstanceOf(error, SimCloudFrontInvalidWebAclId);
+    assertIdentical(
+      simAws.cloudFront().getSimDistributionById(distributionId)?.webAclArn,
+      arn,
+    );
+  });
+});

--- a/src/service/cloudfront/web-acl/sim-cf-distribution-web-acl.ts
+++ b/src/service/cloudfront/web-acl/sim-cf-distribution-web-acl.ts
@@ -1,0 +1,70 @@
+import type { SimCloudFrontDistributionConfig } from "../command/create-distribution/create-distribution.command.js";
+import { SimCloudFrontInvalidWebAclId } from "../error/sim-cloudfront.error.js";
+import type { SimCfWebAclResolver } from "./sim-cf-web-acl.js";
+
+/**
+ * The web ACL ARN a DistributionConfig names, or nothing when it names none.
+ *
+ * An empty `WebACLId` is how CloudFront says there is no web ACL, and it is
+ * what CloudFormation emits for a Distribution that was never given one, so it
+ * means the same here as an absent one.
+ */
+export function simCfWebAclArn(
+  distributionConfig: SimCloudFrontDistributionConfig,
+): string | undefined {
+  const webAclId = distributionConfig.WebACLId;
+
+  return webAclId === undefined || webAclId === "" ? undefined : webAclId;
+}
+
+/**
+ * Refuses a DistributionConfig naming a web ACL that cannot go in front of a
+ * Distribution.
+ *
+ * Real CloudFront checks this when the Distribution is created or updated, so
+ * a template naming a mistyped ARN or a `REGIONAL` scope web ACL fails the
+ * deploy there too, rather than deploying successfully and answering every
+ * request as though there were no web ACL at all.
+ */
+export class SimCfDistributionWebAcl {
+  constructor(private readonly resolve: SimCfWebAclResolver | undefined) {}
+
+  /**
+   * Refuse a DistributionConfig whose `WebACLId` names no web ACL this
+   * simulation can use, without touching the Distribution.
+   *
+   * An update replaces a Distribution's whole configuration, so this runs
+   * before any of it is torn down: a refusal here leaves the Distribution
+   * serving exactly what it served before.
+   */
+  assertUsable(distributionConfig: SimCloudFrontDistributionConfig): void {
+    const webAclArn = simCfWebAclArn(distributionConfig);
+    const resolve = this.resolve;
+
+    // A simulated CloudFront built on its own has no simulation around it to
+    // find a web ACL in, so there is nothing to check the ARN against.
+    if (webAclArn === undefined || resolve === undefined) {
+      return;
+    }
+
+    const found = resolve(webAclArn);
+
+    if (found === undefined) {
+      throw new SimCloudFrontInvalidWebAclId(
+        `Sim CloudFront DistributionConfig names web ACL ${webAclArn}, which ` +
+          `does not exist. Only a web ACL created in this simulation can be ` +
+          `named, so a managed web ACL ARN, or one from a real account, will ` +
+          `not be found.`,
+      );
+    }
+
+    if (found.webAcl.scope !== "CLOUDFRONT") {
+      throw new SimCloudFrontInvalidWebAclId(
+        `Sim CloudFront DistributionConfig names web ACL ${webAclArn}, which ` +
+          `is a ${found.webAcl.scope} scope web ACL. A Distribution takes a ` +
+          `CLOUDFRONT scope web ACL, created in us-east-1, and a REGIONAL one ` +
+          `goes in front of an API Gateway stage or a load balancer instead.`,
+      );
+    }
+  }
+}

--- a/src/service/cloudfront/web-acl/sim-cf-distribution-web-acl.ts
+++ b/src/service/cloudfront/web-acl/sim-cf-distribution-web-acl.ts
@@ -39,15 +39,15 @@ export class SimCfDistributionWebAcl {
    */
   assertUsable(distributionConfig: SimCloudFrontDistributionConfig): void {
     const webAclArn = simCfWebAclArn(distributionConfig);
-    const resolve = this.resolve;
 
-    // A simulated CloudFront built on its own has no simulation around it to
-    // find a web ACL in, so there is nothing to check the ARN against.
-    if (webAclArn === undefined || resolve === undefined) {
+    if (webAclArn === undefined) {
       return;
     }
 
-    const found = resolve(webAclArn);
+    // A simulated CloudFront built on its own has no simulation around it
+    // holding web ACLs, and a resolver that finds nothing means the same thing
+    // here as one that looked and came back empty.
+    const found = this.resolve?.(webAclArn);
 
     if (found === undefined) {
       throw new SimCloudFrontInvalidWebAclId(

--- a/src/service/cloudfront/web-acl/sim-cf-web-acl-resolver.factory.ts
+++ b/src/service/cloudfront/web-acl/sim-cf-web-acl-resolver.factory.ts
@@ -1,0 +1,31 @@
+import { parseSimArn } from "../../aws/arn.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfWebAclResolver } from "./sim-cf-web-acl.js";
+
+/**
+ * Create a web ACL resolver backed by a simulated AWS environment.
+ *
+ * A `CLOUDFRONT` scope web ACL is held by the WAFv2 of the Account and Region
+ * its ARN names, which is `us-east-1` for every web ACL CloudFront can use.
+ * The ARN is read for that scope rather than assumed, so a `REGIONAL` web ACL
+ * named here is found in the Region it was created in and refused for what it
+ * is, rather than going missing.
+ */
+export function makeSimCfWebAclResolver(simAws: SimAws): SimCfWebAclResolver {
+  return (webAclArn: string) => {
+    const arn = parseSimArn(webAclArn);
+
+    if (arn?.service !== "wafv2") {
+      return;
+    }
+
+    const wafV2 = simAws.accountRegionScope(arn.accountId, arn.region).wafV2();
+    const webAcl = wafV2.findWebAclByArn(webAclArn);
+
+    if (webAcl === undefined) {
+      return;
+    }
+
+    return { wafV2, webAcl };
+  };
+}

--- a/src/service/cloudfront/web-acl/sim-cf-web-acl.ts
+++ b/src/service/cloudfront/web-acl/sim-cf-web-acl.ts
@@ -18,10 +18,9 @@ export interface SimCfWebAcl {
 /**
  * Find the web ACL an ARN names, wherever in the simulation it was created.
  *
- * Nothing means no web ACL of that ARN, which is what a Distribution is
- * refused for. A CloudFront Distribution is created without one more often
- * than with one, so a simulated CloudFront built outside a SimAws has no
- * resolver at all and answers nothing.
+ * Nothing means no web ACL of that ARN, which is what a Distribution naming
+ * one is refused for. A simulated CloudFront built outside a SimAws has no
+ * resolver at all, and a `WebACLId` is refused there for the same reason.
  */
 export type SimCfWebAclResolver = (
   webAclArn: string,

--- a/src/service/cloudfront/web-acl/sim-cf-web-acl.ts
+++ b/src/service/cloudfront/web-acl/sim-cf-web-acl.ts
@@ -1,0 +1,28 @@
+import type { SimWafV2 } from "../../wafv2/sim-wafv2.js";
+import type { SimWafWebAcl } from "../../wafv2/web-acl/sim-waf-web-acl.js";
+
+/**
+ * A web ACL a Distribution's `WebACLId` names, and the simulated WAFv2 that
+ * holds it.
+ *
+ * The service comes back with the web ACL because it is what decides a
+ * request: `evaluateRequest` is the entry point WAFv2 offers a fronting
+ * service, and the web ACL itself is what says whether it can be put in front
+ * of a Distribution at all.
+ */
+export interface SimCfWebAcl {
+  readonly wafV2: SimWafV2;
+  readonly webAcl: SimWafWebAcl;
+}
+
+/**
+ * Find the web ACL an ARN names, wherever in the simulation it was created.
+ *
+ * Nothing means no web ACL of that ARN, which is what a Distribution is
+ * refused for. A CloudFront Distribution is created without one more often
+ * than with one, so a simulated CloudFront built outside a SimAws has no
+ * resolver at all and answers nothing.
+ */
+export type SimCfWebAclResolver = (
+  webAclArn: string,
+) => SimCfWebAcl | undefined;

--- a/src/service/wafv2/README.md
+++ b/src/service/wafv2/README.md
@@ -3,10 +3,10 @@
 This directory contains the simulated AWS WAFv2 implementation. It holds web ACLs, IP sets and
 regex pattern sets, and it evaluates a request against a web ACL's rules to reach a decision.
 
-Association comes later. A CloudFront distribution, an API Gateway REST API stage and a Cognito
-user pool each get a web ACL in the issues after the one this was built for.
-`SimWafV2.evaluateRequest` is the entry point those serving paths will call once they have a web ACL
-ARN to hand.
+`SimWafV2.evaluateRequest` is the entry point a fronting service calls once it has a web ACL ARN to
+hand. Simulated CloudFront calls it for every request to a distribution whose `WebACLId` names one,
+in `cloudfront/controller/web-acl/`. An API Gateway REST API stage and a Cognito user pool get
+theirs in later issues, through `AssociateWebACL`.
 
 ## Entry points
 


### PR DESCRIPTION
A simulated CloudFront distribution now reads `WebACLId` from its `DistributionConfig` at CreateDistribution and UpdateDistribution, reports it back on the distribution, and evaluates the named CLOUDFRONT scope web ACL against every request. The check runs as soon as a request is routed to a distribution and before any stage handles it. A blocked request gets the web ACL's 403 without a cache behaviour, a viewer-request CloudFront Function or the origin seeing it, and an allowing rule's custom request handling headers reach what carries on. A `WebACLId` naming a web ACL nothing created, or a REGIONAL scope one, is refused with `InvalidWebACLId` at create and at update, matching how a missing response headers policy is already refused.

Resolves #809

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated CloudFront Web ACL support through WAFv2.
  * Distributions can attach and validate CloudFront-scoped Web ACLs during creation and updates.
  * Requests are evaluated before routing; blocked requests return configurable 403 responses, while allowed requests continue normally.
  * WAF-inserted headers and request-body inspection are supported.

* **Bug Fixes**
  * Added validation and clear errors for missing, invalid, or regional-scope Web ACLs.

* **Documentation**
  * Added CloudFront and WAFv2 usage guidance and a working integration example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->