### PR TITLE
feat: put a web ACL in front of a REST API stage

### DIFF
--- a/docs/services/apigateway/README.md
+++ b/docs/services/apigateway/README.md
@@ -1029,6 +1029,18 @@ token was accepted, and it does not allow this method.
 The token is taken with or without the `Bearer` scheme in front of it. The identity source is one
 header, as it is for a `TOKEN` authorizer.
 
+## Protecting a stage with a web ACL
+
+A simulated WAFv2 web ACL can go in front of a stage, and every request that stage serves is then
+put through its rules. `AssociateWebACL` names the stage by its ARN, which `SimRestApi.stageArn`
+builds.
+
+The web ACL sees the request before the method is matched and before any authorizer runs, ahead of
+IAM, a Lambda authorizer and a Cognito authorizer alike. A blocked request gets 403 with WAF's body,
+and the integration is never invoked. See
+[Protecting an API Gateway REST API stage](../wafv2/#protecting-an-api-gateway-rest-api-stage) in
+the WAFv2 docs.
+
 ## Intercepting an SDK client
 
 `SimSdk` routes `@aws-sdk/client-api-gateway` commands to the simulation. Code under test builds its
@@ -1744,6 +1756,9 @@ and behave differently deployed. The refusals worth knowing about:
 | Methods      | `PutMethod`, `GetMethod`, `DeleteMethod`                                       |
 | Integrations | `PutIntegration`, `GetIntegration`                                             |
 | Publishing   | `CreateDeployment`, `CreateStage`, `GetStage`, `GetStages`, `DeleteStage`      |
+
+A stage can be protected by a simulated WAFv2 web ACL. See
+[Protecting a stage with a web ACL](#protecting-a-stage-with-a-web-acl).
 
 CloudFormation deploys `AWS::ApiGateway::RestApi`, `Resource`, `Method`, `Authorizer`, `Deployment`
 and `Stage`, including the template CDK synthesizes from a `RestApi` or a `LambdaRestApi`. See

--- a/docs/services/wafv2/README.md
+++ b/docs/services/wafv2/README.md
@@ -5,9 +5,9 @@ regex pattern sets, and it evaluates a request against a web ACL's rules to reac
 can assert that a request to `/admin` is blocked and one to `/` is allowed, without an AWS account
 and without a distribution in front of anything.
 
-Association comes separately. Putting a web ACL in front of a CloudFront distribution, an API
-Gateway REST API stage or a Cognito user pool arrives later. Until then a test asks the web ACL
-about a request itself.
+A web ACL can also go in front of a simulated API Gateway REST API stage, and every request that
+stage serves is then put through its rules. CloudFront distributions and Cognito user pools arrive
+later.
 
 WAFv2 specific types are imported from the `@kensio/yulin/wafv2` subpath.
 
@@ -179,7 +179,9 @@ and `CONTINUE` inspects as much as WAF would have read.
 
 ## Answering a blocked request
 
-A `Block` action answers 403 with WAF's own body. A `CustomResponse` overrides the status and the
+A `Block` action answers 403 with WAF's own body, and so does a request a protected REST API stage
+blocked. Real API Gateway writes `{"message":"Forbidden"}` there. A `CustomResponse` overrides the
+status and the
 body, taking the body from the web ACL's `CustomResponseBodies` by key. It carries a `ResponseCode`
 of its own, from 200 to 599, and any response headers it names reach the client under the names it
 gave them.
@@ -261,6 +263,112 @@ console.log(
 
 The default body is Yulin's own. Real WAF hands the blocking off to whatever the web ACL is in front
 of, and each of those writes its own page. The status is 403 either way.
+
+## Protecting an API Gateway REST API stage
+
+`AssociateWebACL` puts a `REGIONAL` web ACL in front of a simulated REST API stage, named by the
+stage's ARN. `SimRestApi.stageArn` builds that ARN, of the form
+`arn:aws:apigateway:<region>::/restapis/<api-id>/stages/<stage-name>`.
+
+The stage then puts every request through the web ACL before it matches the method and before any
+authorizer runs. That is the order real API Gateway evaluates in, ahead of resource policies, IAM,
+Lambda authorizers and Cognito authorizers alike. A blocked request gets 403 with WAF's body, and
+neither the authorizer nor the integration behind the method sees it. An allowed request carries on,
+with the headers an `Allow` rule inserted added to what the integration receives.
+
+```typescript sim-wafv2-api-gateway-stage
+/**
+ * Blocking a request to a REST API stage with a web ACL in front of it.
+ */
+
+import {
+  AssociateWebACLCommand,
+  CreateWebACLCommand,
+} from "@aws-sdk/client-wafv2";
+
+import { SimAws } from "@kensio/yulin";
+import { simRestApiLambdaProxyFactory } from "@kensio/yulin/apigateway";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const waf = simAws.wafV2();
+
+const restApi = await simRestApiLambdaProxyFactory.make(
+  { handler: () => ({ statusCode: 200, body: "orders" }) },
+  simAws,
+);
+
+const visibility = {
+  SampledRequestsEnabled: false,
+  CloudWatchMetricsEnabled: false,
+  MetricName: "api",
+};
+
+const created = await waf.createWebAcl(
+  new CreateWebACLCommand({
+    Name: "api-acl",
+    Scope: "REGIONAL",
+    DefaultAction: { Allow: {} },
+    VisibilityConfig: visibility,
+    Rules: [
+      {
+        Name: "block-admin",
+        Priority: 0,
+        Action: { Block: {} },
+        Statement: {
+          ByteMatchStatement: {
+            FieldToMatch: { UriPath: {} },
+            PositionalConstraint: "CONTAINS",
+            SearchString: Buffer.from("/admin"),
+            TextTransformations: [{ Priority: 0, Type: "NONE" }],
+          },
+        },
+        VisibilityConfig: { ...visibility, MetricName: "block-admin" },
+      },
+    ],
+  }),
+);
+
+await waf.associateWebAcl(
+  new AssociateWebACLCommand({
+    WebACLArn: created.Summary?.ARN,
+    ResourceArn: restApi.stageArn("prod"),
+  }),
+);
+
+const srv = await serveSimAws({ simAws });
+
+const blocked = await fetch(
+  srv.localUrl(`${restApi.invokeUrl("prod")}/admin/users`),
+);
+const allowed = await fetch(
+  srv.localUrl(`${restApi.invokeUrl("prod")}/orders`),
+);
+
+console.log(blocked.status, allowed.status);
+// 403 200
+
+await srv.close();
+```
+
+`DisassociateWebACL` takes the web ACL back off. `GetWebACLForResource` reports the web ACL one
+stage carries, and `ListResourcesForWebACL` reports the stages one web ACL protects. That listing
+takes a `ResourceType` of `API_GATEWAY`. Real WAFv2 lists `APPLICATION_LOAD_BALANCER` for a request
+that names no type. Load balancers are outside this simulation, and a listing that names no type is
+refused.
+
+Deleting the stage or the whole API takes the association with it. A stage deployed again under the
+same name carries no web ACL. A web ACL that is still in front of a stage cannot be deleted, and
+`DeleteWebACL` names the stages still pointing at it.
+
+The web ACL and the stage belong to one Account and Region. A `CLOUDFRONT` scope web ACL is refused,
+because a distribution takes its web ACL from the distribution and not from `AssociateWebACL`. A web
+ACL from another Region or another Account is refused, as it is on AWS.
+
+An API Gateway HTTP API stage is refused. AWS WAF has no resource type for one, and an association
+accepted here would let a test cover protection AWS never applies. Application Load Balancer,
+AppSync, App Runner, Amplify and Verified Access resources are refused as unsimulated, each naming
+what it would have protected.
 
 ## Regex pattern sets
 
@@ -544,5 +652,5 @@ are refused for the same reason, each naming what it would have configured.
 
 `CreateWebACL`, `GetWebACL`, `UpdateWebACL`, `ListWebACLs`, `DeleteWebACL`, `CreateIPSet`,
 `GetIPSet`, `UpdateIPSet`, `ListIPSets`, `DeleteIPSet`, `CreateRegexPatternSet`,
-`GetRegexPatternSet`, `UpdateRegexPatternSet`, `ListRegexPatternSets` and
-`DeleteRegexPatternSet`.
+`GetRegexPatternSet`, `UpdateRegexPatternSet`, `ListRegexPatternSets`, `DeleteRegexPatternSet`,
+`AssociateWebACL`, `DisassociateWebACL`, `GetWebACLForResource` and `ListResourcesForWebACL`.

--- a/docs/services/wafv2/sim-wafv2-api-gateway-stage.example.ts
+++ b/docs/services/wafv2/sim-wafv2-api-gateway-stage.example.ts
@@ -1,0 +1,72 @@
+/**
+ * Blocking a request to a REST API stage with a web ACL in front of it.
+ */
+
+import {
+  AssociateWebACLCommand,
+  CreateWebACLCommand,
+} from "@aws-sdk/client-wafv2";
+
+import { SimAws } from "@kensio/yulin";
+import { simRestApiLambdaProxyFactory } from "@kensio/yulin/apigateway";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const waf = simAws.wafV2();
+
+const restApi = await simRestApiLambdaProxyFactory.make(
+  { handler: () => ({ statusCode: 200, body: "orders" }) },
+  simAws,
+);
+
+const visibility = {
+  SampledRequestsEnabled: false,
+  CloudWatchMetricsEnabled: false,
+  MetricName: "api",
+};
+
+const created = await waf.createWebAcl(
+  new CreateWebACLCommand({
+    Name: "api-acl",
+    Scope: "REGIONAL",
+    DefaultAction: { Allow: {} },
+    VisibilityConfig: visibility,
+    Rules: [
+      {
+        Name: "block-admin",
+        Priority: 0,
+        Action: { Block: {} },
+        Statement: {
+          ByteMatchStatement: {
+            FieldToMatch: { UriPath: {} },
+            PositionalConstraint: "CONTAINS",
+            SearchString: Buffer.from("/admin"),
+            TextTransformations: [{ Priority: 0, Type: "NONE" }],
+          },
+        },
+        VisibilityConfig: { ...visibility, MetricName: "block-admin" },
+      },
+    ],
+  }),
+);
+
+await waf.associateWebAcl(
+  new AssociateWebACLCommand({
+    WebACLArn: created.Summary?.ARN,
+    ResourceArn: restApi.stageArn("prod"),
+  }),
+);
+
+const srv = await serveSimAws({ simAws });
+
+const blocked = await fetch(
+  srv.localUrl(`${restApi.invokeUrl("prod")}/admin/users`),
+);
+const allowed = await fetch(
+  srv.localUrl(`${restApi.invokeUrl("prod")}/orders`),
+);
+
+console.log(blocked.status, allowed.status);
+// 403 200
+
+await srv.close();

--- a/src/service/apigateway/README.md
+++ b/src/service/apigateway/README.md
@@ -87,11 +87,19 @@ departs from AWS.
 ```text
 SimApiGatewayServiceController   the entry point, and what a miss is answered with
 ├── SimApiGatewayRouter          an API id to its scope, an integration URI to its function
+├── SimRestApiWebAclInspection   the stage's web ACL, before anything else
 ├── SimRestApiMethodAuthorizer   what the client may have, in serve/auth/
 └── SimRestApiIntegrationInvocation   the invoke permission, the event, the response
 ```
 
-The client's own authorization runs first. A request presenting no credentials is refused whether or
+A web ACL in front of the stage runs before any of that, in
+`SimRestApiWebAclInspection`. Real API Gateway evaluates the stage's web ACL ahead of resource
+policies, IAM policies, Lambda authorizers and Cognito authorizers. A blocked request is answered
+before the method is matched here too. The API reaches WAFv2 through the `SimWafProtection` port it holds on
+`SimRestApi`, beside the user pools it holds for the same reason. The request body is buffered from
+a clone, leaving the integration a body to send on, and only for a stage a web ACL protects.
+
+The client's own authorization runs next. A request presenting no credentials is refused whether or
 not the integration behind the method would have worked. Whether the API may invoke a function is a
 separate question, asked afterwards, and it is the API's rather than the client's.
 

--- a/src/service/apigateway/api/sim-rest-api.ts
+++ b/src/service/apigateway/api/sim-rest-api.ts
@@ -1,10 +1,12 @@
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimWafProtection } from "../../wafv2/association/sim-waf-protection.js";
 import { SimRestApiAuthorizerStore } from "./authorizer/sim-rest-api-authorizer-store.js";
 import type { SimRestApiUserPools } from "./authorizer/sim-rest-api-user-pools.js";
 import { SimRestApiDeploymentStore } from "./deployment/sim-rest-api-deployment-store.js";
 import { SimRestApiResourceStore } from "./resource/sim-rest-api-resource-store.js";
 import type { SimRestApiResource } from "./resource/sim-rest-api-resource.js";
 import { SimApiGatewayNotFound } from "../error/sim-api-gateway.error.js";
+import { simRestApiStageArn } from "./stage/sim-rest-api-stage-arn.js";
 import { SimRestApiStageStore } from "./stage/sim-rest-api-stage-store.js";
 import {
   type SimRestApiMatch,
@@ -22,6 +24,7 @@ interface SimRestApiProperties {
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly createdDate: Date;
   readonly userPools: SimRestApiUserPools;
+  readonly webAcls: SimWafProtection;
   readonly description?: string | undefined;
   readonly disableExecuteApiEndpoint?: boolean | undefined;
 }
@@ -50,6 +53,16 @@ export class SimRestApi {
   public readonly userPools: SimRestApiUserPools;
 
   /**
+   * The web ACLs this API's stages can be protected by.
+   *
+   * Held on the API for the reason the user pools are: a request is served
+   * without a command, and the serving layer reaches the API and nothing
+   * around it. Deleting a stage or the API lets go of what a web ACL was held
+   * against here too.
+   */
+  public readonly webAcls: SimWafProtection;
+
+  /**
    * The API's name and description, which `UpdateRestApi` can replace. Neither
    * identifies the API, and two APIs in one Account and Region may share both.
    */
@@ -69,6 +82,7 @@ export class SimRestApi {
     this.accountRegionScope = properties.accountRegionScope;
     this.createdDate = properties.createdDate;
     this.userPools = properties.userPools;
+    this.webAcls = properties.webAcls;
     this.description = properties.description;
     this.disableExecuteApiEndpoint =
       properties.disableExecuteApiEndpoint ?? false;
@@ -100,6 +114,20 @@ export class SimRestApi {
    */
   invokeUrl(stageName: string): string {
     return `https://${this.hostname}/${stageName}`;
+  }
+
+  /**
+   * The ARN naming one stage of this API, whether or not the stage exists.
+   *
+   * It is what a web ACL is associated with, and what a served request is
+   * looked up by. A name no stage carries simply has nothing held against it.
+   */
+  stageArn(stageName: string): string {
+    return simRestApiStageArn({
+      regionName: this.accountRegionScope.regionName,
+      restApiId: this.apiId,
+      stageName,
+    });
   }
 
   /**

--- a/src/service/apigateway/api/stage/sim-rest-api-stage-arn.ts
+++ b/src/service/apigateway/api/stage/sim-rest-api-stage-arn.ts
@@ -1,0 +1,22 @@
+import type { AwsRegionName } from "../../../aws/sim-aws-region.js";
+
+interface SimRestApiStageArnProperties {
+  readonly regionName: AwsRegionName;
+  readonly restApiId: string;
+  readonly stageName: string;
+}
+
+/**
+ * The ARN naming one stage of a REST API.
+ *
+ * API Gateway writes it with an empty Account and the control plane path of
+ * the stage, so it looks unlike the `execute-api` ARNs a request is authorized
+ * against. This is the form WAFv2 associates a web ACL with.
+ */
+export function simRestApiStageArn(
+  properties: SimRestApiStageArnProperties,
+): string {
+  const { regionName, restApiId, stageName } = properties;
+
+  return `arn:aws:apigateway:${regionName}::/restapis/${restApiId}/stages/${stageName}`;
+}

--- a/src/service/apigateway/command/api/sim-rest-api-commands.ts
+++ b/src/service/apigateway/command/api/sim-rest-api-commands.ts
@@ -1,6 +1,7 @@
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import type { SimRestApiUserPools } from "../../api/authorizer/sim-rest-api-user-pools.js";
+import type { SimWafProtection } from "../../../wafv2/association/sim-waf-protection.js";
 import type { SimRestApiStore } from "../../api/sim-rest-api-store.js";
 import { SimRestApi } from "../../api/sim-rest-api.js";
 import type { SimRestApiRegistry } from "../../registry/sim-rest-api-registry.js";
@@ -34,6 +35,7 @@ interface SimRestApiCommandsProperties {
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly clock: SimClock;
   readonly userPools: SimRestApiUserPools;
+  readonly webAcls: SimWafProtection;
 }
 
 /**
@@ -46,6 +48,7 @@ export class SimRestApiCommands {
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly clock: SimClock;
   private readonly userPools: SimRestApiUserPools;
+  private readonly webAcls: SimWafProtection;
 
   constructor(properties: SimRestApiCommandsProperties) {
     this.apis = properties.apis;
@@ -54,6 +57,7 @@ export class SimRestApiCommands {
     this.accountRegionScope = properties.accountRegionScope;
     this.clock = properties.clock;
     this.userPools = properties.userPools;
+    this.webAcls = properties.webAcls;
   }
 
   /**
@@ -79,6 +83,7 @@ export class SimRestApiCommands {
       accountRegionScope: this.accountRegionScope,
       createdDate: this.clock.now(),
       userPools: this.userPools,
+      webAcls: this.webAcls,
       description: input.description,
       disableExecuteApiEndpoint: input.disableExecuteApiEndpoint,
     });
@@ -171,6 +176,12 @@ export class SimRestApiCommands {
       restApiId,
       caller: options?.caller,
     });
+
+    // The API takes its stages with it, and a web ACL in front of one of them
+    // is let go of with the stage it was protecting.
+    for (const stage of restApi.stages.list()) {
+      restApi.webAcls.release(restApi.stageArn(stage.stageName));
+    }
 
     this.apis.remove(restApi.apiId);
     this.registry.deregisterApi(restApi.apiId);

--- a/src/service/apigateway/command/stage/sim-rest-api-stage-commands.ts
+++ b/src/service/apigateway/command/stage/sim-rest-api-stage-commands.ts
@@ -131,7 +131,8 @@ export class SimRestApiStageCommands {
    *
    * The stage stops serving, and a request addressed to it reaches nothing.
    * The API's resources and methods stay, because they belong to the API, and
-   * another stage still serves them.
+   * another stage still serves them. A web ACL in front of the stage is let go
+   * of, so a stage created again under the same name is unprotected.
    */
   deleteStage(
     command: SimDeleteStageCommand,
@@ -151,6 +152,7 @@ export class SimRestApiStageCommands {
     });
     this.rules.requireStage(restApi, stageName);
     restApi.stages.remove(stageName);
+    restApi.webAcls.release(restApi.stageArn(stageName));
 
     return { $metadata: {} };
   }

--- a/src/service/apigateway/serve/sim-api-gateway-controller.ts
+++ b/src/service/apigateway/serve/sim-api-gateway-controller.ts
@@ -14,6 +14,7 @@ import { SimApiGatewayErrorResponse } from "./sim-api-gateway-error-response.js"
 import { SimApiGatewayRouter } from "./sim-api-gateway-router.js";
 import { SimRestApiIntegrationInvocation } from "./sim-rest-api-integration-invocation.js";
 import { SimRestApiRefusalResponse } from "./sim-rest-api-refusal-response.js";
+import { SimRestApiWebAclInspection } from "./sim-rest-api-web-acl-inspection.js";
 
 interface SimApiGatewayServiceControllerProperties {
   readonly simAws?: SimAws;
@@ -33,6 +34,10 @@ interface SimApiGatewayServiceControllerProperties {
  * `CUSTOM` method's Lambda authorizer has to allow the request, or the request
  * is refused and the integration is never invoked. Whether the API may invoke a
  * function is a separate question, and the API's own rather than the client's.
+ *
+ * A web ACL in front of the stage comes ahead of all of it, as it does on real
+ * API Gateway. A request the web ACL blocks is answered before the method is
+ * matched, so neither the authorizer nor the integration sees it.
  */
 export class SimApiGatewayServiceController implements SimAwsServiceController {
   private readonly router: SimApiGatewayRouter;
@@ -40,6 +45,7 @@ export class SimApiGatewayServiceController implements SimAwsServiceController {
   private readonly integration: SimRestApiIntegrationInvocation;
   private readonly errorResponse = new SimApiGatewayErrorResponse();
   private readonly refusalResponse = new SimRestApiRefusalResponse();
+  private readonly webAcl = new SimRestApiWebAclInspection();
 
   constructor(properties: SimApiGatewayServiceControllerProperties = {}) {
     const { simAws = new SimAws() } = properties;
@@ -79,21 +85,32 @@ export class SimApiGatewayServiceController implements SimAwsServiceController {
     restApi: SimRestApi,
     serviceRequest: SimAwsServiceRequest,
   ): Promise<Response> {
-    const { request } = serviceRequest;
     // The whole request path, stage segment and all. The stage takes its own
     // segment off, and the event reports the path as the client sent it.
-    const match = restApi.match(
-      new SimRestApiRequest({
-        method: request.method,
-        path: new URL(request.url).pathname,
-      }),
-    );
+    const restApiRequest = new SimRestApiRequest({
+      method: serviceRequest.request.method,
+      path: new URL(serviceRequest.request.url).pathname,
+    });
+    // The stage's web ACL sees the request before anything the API does with
+    // it, which is why this comes before matching rather than after it.
+    const inspected = await this.webAcl.inspect({
+      restApi,
+      stageName: restApiRequest.segments[0] ?? "",
+      request: serviceRequest.request,
+    });
+
+    if (inspected.blocked !== undefined) {
+      return inspected.blocked;
+    }
+
+    const { request } = inspected;
+    const match = restApi.match(restApiRequest);
 
     if (!isSimRestApiMatch(match)) {
       return this.missResponse(match);
     }
 
-    // The client's own authorization comes first: a request with no
+    // The client's own authorization comes next: a request with no
     // credentials is refused whether or not the integration behind the method
     // would work.
     const authorization = await this.methodAuthorizer.authorize({

--- a/src/service/apigateway/serve/sim-rest-api-web-acl-inspection.ts
+++ b/src/service/apigateway/serve/sim-rest-api-web-acl-inspection.ts
@@ -1,0 +1,115 @@
+import { simWafBlockedHttpResponse } from "../../wafv2/evaluate/sim-waf-blocked-response.js";
+import type { SimWafHeader } from "../../wafv2/web-acl/sim-waf-custom-response.type.js";
+import type { SimRestApi } from "../api/sim-rest-api.js";
+
+interface SimRestApiInspectionInput {
+  readonly restApi: SimRestApi;
+  /** The first path segment of the request, which names the stage. */
+  readonly stageName: string;
+  readonly request: Request;
+}
+
+interface SimRestApiInspectedProperties {
+  readonly request: Request;
+  readonly blocked?: Response | undefined;
+}
+
+/**
+ * What the web ACL in front of a stage left of one request.
+ *
+ * A blocked request has a response to send and goes no further. An allowed one
+ * carries on, as the request the rules asked for rather than the one that
+ * arrived, since a rule can add headers to what is forwarded.
+ */
+export class SimRestApiInspected {
+  public readonly request: Request;
+  public readonly blocked: Response | undefined;
+
+  constructor(properties: SimRestApiInspectedProperties) {
+    this.request = properties.request;
+    this.blocked = properties.blocked;
+  }
+}
+
+/**
+ * Puts a request to the web ACL in front of the stage it reached.
+ *
+ * This runs before the method is matched and before any authorizer, which is
+ * the order real API Gateway evaluates in: the web ACL comes ahead of resource
+ * policies, IAM, a Lambda authorizer and a Cognito authorizer alike. A blocked
+ * request therefore reaches neither the authorizer nor the integration.
+ */
+export class SimRestApiWebAclInspection {
+  /**
+   * Put one request to whatever protects the stage it addressed.
+   */
+  async inspect(
+    input: SimRestApiInspectionInput,
+  ): Promise<SimRestApiInspected> {
+    const { request, restApi } = input;
+    const resourceArn = restApi.stageArn(input.stageName);
+
+    if (!restApi.webAcls.protects(resourceArn)) {
+      return new SimRestApiInspected({ request });
+    }
+
+    // The body is buffered only for a protected stage, because reading it is
+    // what a rule inspecting the body needs and every other request would pay
+    // for it.
+    const body = await inspectedBody(request);
+    const decision = restApi.webAcls.decide({ resourceArn, request, body });
+
+    // A decision carries a blocked response when its action was to block, and
+    // carries none when the request was allowed. That one reading is what
+    // decides the request here.
+    if (decision?.blocked !== undefined) {
+      return new SimRestApiInspected({
+        request,
+        blocked: simWafBlockedHttpResponse(decision.blocked),
+      });
+    }
+
+    return new SimRestApiInspected({
+      request: forwarded(request, decision?.insertedHeaders ?? []),
+    });
+  }
+}
+
+/**
+ * The request body a web ACL's rules are matched against.
+ *
+ * The request is cloned rather than read, so the integration still has a body
+ * to send on to the function behind the method.
+ */
+async function inspectedBody(
+  request: Request,
+): Promise<Uint8Array | undefined> {
+  const buffered = new Uint8Array(await request.clone().arrayBuffer());
+
+  return buffered.byteLength === 0 ? undefined : buffered;
+}
+
+/**
+ * The request as the web ACL asked for it to be forwarded.
+ *
+ * A rule with custom request handling adds headers to what reaches the origin,
+ * and API Gateway is the origin here. Only the headers are replaced, so the
+ * body carries over as the stream it arrived as: inspection read a clone of
+ * it rather than the request itself.
+ */
+function forwarded(
+  request: Request,
+  insertedHeaders: readonly SimWafHeader[],
+): Request {
+  if (insertedHeaders.length === 0) {
+    return request;
+  }
+
+  const headers = new Headers(request.headers);
+
+  for (const header of insertedHeaders) {
+    headers.set(header.name, header.value);
+  }
+
+  return new Request(request, { headers });
+}

--- a/src/service/apigateway/serve/sim-rest-api-web-acl.iso.test.ts
+++ b/src/service/apigateway/serve/sim-rest-api-web-acl.iso.test.ts
@@ -1,0 +1,310 @@
+import {
+  AssociateWebACLCommand,
+  CreateWebACLCommand,
+} from "@aws-sdk/client-wafv2";
+import {
+  assertFalse,
+  assertIdentical,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import type { SimPayload1Event } from "../../../serve/payload-1/sim-payload-1-event.type.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simRestApiLambdaProxyFactory } from "../api/sim-rest-api-lambda-proxy.factory.js";
+import type { SimRestApi } from "../api/sim-rest-api.js";
+
+/**
+ * A web ACL blocking whatever asks for an admin path, in front of one stage.
+ *
+ * Every test here is about what the stage does with a request once a web ACL
+ * is in front of it, and the ACL itself is the same one each time: one rule,
+ * blocking, over a default action of allow.
+ */
+async function protectStage(
+  simAws: SimAws,
+  restApi: SimRestApi,
+  stageName = "prod",
+): Promise<void> {
+  const waf = simAws.wafV2();
+  const created = await waf.createWebAcl(
+    new CreateWebACLCommand({
+      Name: "api-acl",
+      Scope: "REGIONAL",
+      DefaultAction: { Allow: {} },
+      VisibilityConfig: {
+        SampledRequestsEnabled: false,
+        CloudWatchMetricsEnabled: false,
+        MetricName: "api",
+      },
+      Rules: [
+        {
+          Name: "block-admin",
+          Priority: 0,
+          Action: { Block: {} },
+          Statement: {
+            ByteMatchStatement: {
+              FieldToMatch: { UriPath: {} },
+              PositionalConstraint: "CONTAINS",
+              SearchString: Buffer.from("/admin"),
+              TextTransformations: [{ Priority: 0, Type: "NONE" }],
+            },
+          },
+          VisibilityConfig: {
+            SampledRequestsEnabled: false,
+            CloudWatchMetricsEnabled: false,
+            MetricName: "block-admin",
+          },
+        },
+      ],
+    }),
+  );
+
+  await waf.associateWebAcl(
+    new AssociateWebACLCommand({
+      WebACLArn: created.Summary?.ARN,
+      ResourceArn: restApi.stageArn(stageName),
+    }),
+  );
+}
+
+function localUrl(restApi: SimRestApi, path: string, stage = "prod"): string {
+  return new SimAwsLocalUrl({
+    input: `${restApi.invokeUrl(stage)}${path}`,
+  }).toString();
+}
+
+describe("A web ACL in front of a sim REST API stage", () => {
+  it("blocks a request before the integration is invoked", async () => {
+    // Given a stage a web ACL protects, in front of a counting handler
+    const simAws = new SimAws();
+    let invocations = 0;
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      {
+        handler: (): unknown => {
+          invocations += 1;
+          return { statusCode: 200, body: "ok" };
+        },
+      },
+      simAws,
+    );
+    await protectStage(simAws, restApi);
+
+    // When a request the web ACL blocks is made
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/admin/users"),
+    );
+
+    // Then WAF answered it and the integration never ran
+    assertIdentical(response.status, 403);
+    assertStringIncludes(await response.text(), "Request blocked by AWS WAF");
+    assertIdentical(invocations, 0);
+  });
+
+  it("serves a request the web ACL allows as it always did", async () => {
+    // Given the same protected stage
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      { handler: (): unknown => ({ statusCode: 200, body: "orders" }) },
+      simAws,
+    );
+    await protectStage(simAws, restApi);
+
+    // When a request no rule claims is made
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/orders"),
+    );
+
+    // Then the integration answered it
+    assertIdentical(response.status, 200);
+    assertIdentical(await response.text(), "orders");
+  });
+
+  it("blocks before a Lambda authorizer is invoked", async () => {
+    // Given a protected stage whose methods are behind a TOKEN authorizer
+    const simAws = new SimAws();
+    let authorizations = 0;
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      {
+        handler: (): unknown => ({ statusCode: 200, body: "ok" }),
+        authorizerHandler: (): unknown => {
+          authorizations += 1;
+          return { principalId: "someone" };
+        },
+      },
+      simAws,
+    );
+    await protectStage(simAws, restApi);
+
+    // When a blocked request arrives carrying a token the authorizer would
+    // have been asked about
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/admin/users"),
+      { headers: { authorization: "let-me-in" } },
+    );
+
+    // Then the web ACL decided it and the authorizer was never invoked
+    assertIdentical(response.status, 403);
+    assertStringIncludes(await response.text(), "Request blocked by AWS WAF");
+    assertIdentical(authorizations, 0);
+  });
+
+  it("blocks before an AWS_IAM method's own check", async () => {
+    // Given a protected stage whose methods are behind IAM
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      {
+        handler: (): unknown => ({ statusCode: 200, body: "ok" }),
+        iamAuthorization: true,
+      },
+      simAws,
+    );
+    await protectStage(simAws, restApi);
+
+    // When an unsigned request the web ACL blocks is made
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/admin/users"),
+    );
+
+    // Then it is WAF's answer rather than the one IAM would have given
+    assertIdentical(response.status, 403);
+    assertStringIncludes(await response.text(), "Request blocked by AWS WAF");
+  });
+
+  it("inspects the body a request carried and leaves it for the integration", async () => {
+    // Given a stage protected by a web ACL with no rule about the body
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      {
+        handler: (event: SimPayload1Event): unknown => ({
+          statusCode: 200,
+          body: event.body ?? "",
+        }),
+      },
+      simAws,
+    );
+    await protectStage(simAws, restApi);
+
+    // When a request with a body is allowed through
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/orders"),
+      { method: "POST", body: "one large order" },
+    );
+
+    // Then the integration still received the body WAF read
+    assertIdentical(await response.text(), "one large order");
+  });
+
+  it("adds the headers a rule asked to insert to what is forwarded", async () => {
+    // Given a stage whose web ACL allows admin paths with a header added
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      {
+        handler: (event: SimPayload1Event): unknown => ({
+          statusCode: 200,
+          body: event.headers?.["x-amzn-waf-checked"] ?? "none",
+        }),
+      },
+      simAws,
+    );
+    const waf = simAws.wafV2();
+    const created = await waf.createWebAcl(
+      new CreateWebACLCommand({
+        Name: "api-acl",
+        Scope: "REGIONAL",
+        DefaultAction: { Allow: {} },
+        VisibilityConfig: {
+          SampledRequestsEnabled: false,
+          CloudWatchMetricsEnabled: false,
+          MetricName: "api",
+        },
+        Rules: [
+          {
+            Name: "note-admin",
+            Priority: 0,
+            Action: {
+              Allow: {
+                CustomRequestHandling: {
+                  InsertHeaders: [{ Name: "checked", Value: "yes" }],
+                },
+              },
+            },
+            Statement: {
+              ByteMatchStatement: {
+                FieldToMatch: { UriPath: {} },
+                PositionalConstraint: "CONTAINS",
+                SearchString: Buffer.from("/admin"),
+                TextTransformations: [{ Priority: 0, Type: "NONE" }],
+              },
+            },
+            VisibilityConfig: {
+              SampledRequestsEnabled: false,
+              CloudWatchMetricsEnabled: false,
+              MetricName: "note-admin",
+            },
+          },
+        ],
+      }),
+    );
+    await waf.associateWebAcl(
+      new AssociateWebACLCommand({
+        WebACLArn: created.Summary?.ARN,
+        ResourceArn: restApi.stageArn("prod"),
+      }),
+    );
+
+    // When the rule allows a request and asks for its header
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/admin/users"),
+    );
+
+    // Then the integration saw the header WAF inserted
+    assertIdentical(await response.text(), "yes");
+  });
+
+  it("stops protecting a stage that is deleted", async () => {
+    // Given a protected stage
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      { handler: (): unknown => ({ statusCode: 200, body: "ok" }) },
+      simAws,
+    );
+    await protectStage(simAws, restApi);
+
+    // When the stage is deleted and deployed again under the same name
+    await simAws
+      .apiGateway()
+      .deleteStage({ input: { restApiId: restApi.apiId, stageName: "prod" } });
+    await simAws.apiGateway().createDeployment({
+      input: { restApiId: restApi.apiId, stageName: "prod" },
+    });
+
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(restApi, "/admin/users"),
+    );
+
+    // Then nothing is in front of the new stage
+    assertIdentical(response.status, 200);
+  });
+
+  it("stops protecting the stages of an API that is deleted", async () => {
+    // Given a protected stage
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      { handler: (): unknown => ({ statusCode: 200, body: "ok" }) },
+      simAws,
+    );
+    await protectStage(simAws, restApi);
+    const stageArn = restApi.stageArn("prod");
+
+    // When the whole API is deleted
+    await simAws
+      .apiGateway()
+      .deleteRestApi({ input: { restApiId: restApi.apiId } });
+
+    // Then the web ACL is no longer in front of the stage it had
+    assertFalse(simAws.wafV2().protection().protects(stageArn));
+  });
+});

--- a/src/service/apigateway/sim-api-gateway-commands.ts
+++ b/src/service/apigateway/sim-api-gateway-commands.ts
@@ -12,6 +12,10 @@ import {
   SimRestApiNoUserPools,
   type SimRestApiUserPools,
 } from "./api/authorizer/sim-rest-api-user-pools.js";
+import {
+  SimWafNoProtection,
+  type SimWafProtection,
+} from "../wafv2/association/sim-waf-protection.js";
 import { SimRestApiStore } from "./api/sim-rest-api-store.js";
 import { SimRestApiCommands } from "./command/api/sim-rest-api-commands.js";
 import { SimRestApiImportCommands } from "./command/api/sim-rest-api-import-commands.js";
@@ -40,6 +44,12 @@ export interface SimApiGatewayProperties {
    * one it could not check.
    */
   readonly userPools?: SimRestApiUserPools;
+  /**
+   * The web ACLs this API Gateway's stages can be protected by. A standalone
+   * simulated API Gateway has none, so every stage serves the requests it
+   * always did.
+   */
+  readonly webAcls?: SimWafProtection;
 }
 
 /**
@@ -69,6 +79,7 @@ export class SimApiGatewayCommands {
       background = new BackgroundTasks(),
       registry = new SimRestApiRegistry(),
       userPools = new SimRestApiNoUserPools(),
+      webAcls = new SimWafNoProtection(),
     } = properties;
 
     const access = new SimRestApiAccess({
@@ -84,6 +95,7 @@ export class SimApiGatewayCommands {
       accountRegionScope,
       clock: background,
       userPools,
+      webAcls,
     });
     this.resources = new SimRestApiResourceCommands({ access });
     this.authorizers = new SimRestApiAuthorizerCommands({ access });

--- a/src/service/aws/factory/sim-aws-account-region-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-account-region-service-builder.ts
@@ -30,6 +30,8 @@ import { simAwsS3NotificationDestinations } from "./sim-aws-s3-notification-dest
 import { SimSns } from "../../sns/index.js";
 import { simAwsSnsDeliveryEndpoints } from "../../sns/delivery/sim-aws-sns-delivery-endpoints.js";
 import { SimSts } from "../../sts/sim-sts.js";
+import { SimWafV2 } from "../../wafv2/index.js";
+import { SimAwsWafProtectedResources } from "../../wafv2/association/sim-aws-waf-protected-resources.js";
 import type { SimAwsAccountServiceCache } from "./sim-aws-account-service-cache.js";
 import type { SimAwsScopedServiceProperties } from "./sim-aws-scoped-service-properties.js";
 import type { SimAwsScopedServiceRegistries } from "./sim-aws-scoped-service-registries.js";
@@ -221,6 +223,24 @@ export class SimAwsAccountRegionServiceBuilder {
     return new SimScheduler({
       ...this.scoped(scope),
       deliveryTargets: simAwsSchedulerDeliveryTargets(this.simAws),
+    });
+  }
+
+  /**
+   * Create simulated WAFv2 for an Account Region scope.
+   *
+   * Web ACLs are Region-scoped on real AWS, and the `CLOUDFRONT` scope is held
+   * in `us-east-1` because CloudFront is global. It reaches outside itself for
+   * the resources an association can name: a stage ARN carries no Account, so
+   * the resource it names is looked for in this same scope.
+   */
+  createWafV2(scope: SimAwsAccountRegionContainer): SimWafV2 {
+    return new SimWafV2({
+      ...this.scoped(scope),
+      protectedResources: new SimAwsWafProtectedResources({
+        simAws: this.simAws,
+        accountRegionScope: scope.accountRegionScope,
+      }),
     });
   }
 

--- a/src/service/aws/factory/sim-aws-registered-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-registered-service-builder.ts
@@ -67,6 +67,9 @@ export class SimAwsRegisteredServiceBuilder {
       // id alone from the serving layer, whichever scope created it.
       registry: this.registries.restApi,
       userPools: simAwsRestApiUserPools(this.registries),
+      // A web ACL protecting a stage is in the same Account and Region as the
+      // API, as it is on AWS, so this scope's own WAFv2 is the one to ask.
+      webAcls: scope.wafV2().protection(),
     });
   }
 

--- a/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
@@ -4,7 +4,6 @@ import { SimSecretsManager } from "../../secretsmanager/index.js";
 import { SimSesV2 } from "../../ses/index.js";
 import { SimSqs } from "../../sqs/index.js";
 import { SimSsm } from "../../ssm/index.js";
-import { SimWafV2 } from "../../wafv2/index.js";
 import type { SimAwsAccountServiceCache } from "./sim-aws-account-service-cache.js";
 import type { SimAwsScopedServiceProperties } from "./sim-aws-scoped-service-properties.js";
 
@@ -77,17 +76,6 @@ export class SimAwsSelfContainedServiceBuilder {
    */
   createSsm(scope: SimAwsAccountRegionContainer): SimSsm {
     return new SimSsm({ ...this.scoped(scope), kms: scope.kms() });
-  }
-
-  /**
-   * Create simulated WAFv2 for an Account Region scope.
-   *
-   * Web ACLs are Region-scoped on real AWS, and the `CLOUDFRONT` scope is held
-   * in `us-east-1` because CloudFront is global. Both fall out of the scope
-   * this is built in.
-   */
-  createWafV2(scope: SimAwsAccountRegionContainer): SimWafV2 {
-    return new SimWafV2(this.scoped(scope));
   }
 
   /**

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -279,6 +279,6 @@ export class SimAwsServiceFactory {
 
   /** Create simulated WAFv2 for an Account Region scope. */
   createWafV2(scope: SimAwsAccountRegionContainer): SimWafV2 {
-    return this.selfContainedServices.createWafV2(scope);
+    return this.accountRegionServices.createWafV2(scope);
   }
 }

--- a/src/service/wafv2/README.md
+++ b/src/service/wafv2/README.md
@@ -3,16 +3,16 @@
 This directory contains the simulated AWS WAFv2 implementation. It holds web ACLs, IP sets and
 regex pattern sets, and it evaluates a request against a web ACL's rules to reach a decision.
 
-Association comes later. A CloudFront distribution, an API Gateway REST API stage and a Cognito
-user pool each get a web ACL in the issues after the one this was built for.
-`SimWafV2.evaluateRequest` is the entry point those serving paths will call once they have a web ACL
-ARN to hand.
+A web ACL can be put in front of an API Gateway REST API stage. CloudFront distributions and
+Cognito user pools come later.
 
 ## Entry points
 
 - `sim-wafv2.ts` is the service facade for one Account and Region scope.
 - `sim-wafv2-commands.ts` is the wiring behind it, held apart because the facade grows by one method
   per SDK operation and the two would otherwise compete for room in one file.
+- `sim-wafv2-sets.ts` is the half of the facade holding the IP set and regex pattern set
+  operations, for the same reason.
 - `index.ts` exports the public WAFv2 simulator API for `@kensio/yulin/wafv2`.
 
 The service is scoped to an Account and Region, and within that to `CLOUDFRONT` or `REGIONAL`. The
@@ -53,8 +53,40 @@ it forwards. A custom response header keeps the name the rule gave it.
 
 `evaluate/sim-waf-blocked-response.ts` holds the default 403 body. Real WAF hands the blocking off
 to whatever the web ACL is in front of, and each of those writes its own page (CloudFront's error
-page, API Gateway's `{"message":"Forbidden"}`). This is Yulin's own body until there is a fronting
-service to ask, and it is documented as a divergence in `docs/services/wafv2`.
+page, API Gateway's `{"message":"Forbidden"}`). A blocked request to a protected stage gets this
+body here, which is documented as a divergence in `docs/services/wafv2`.
+
+## Association
+
+`association/` holds the web ACLs this scope has in front of things, and what an association may
+name:
+
+```text
+SimWafAssociations              resource ARN to web ACL, and what a fronting service asks it
+├── SimWafProtectedResource     what an association ARN names, read from the ARN
+│   └── SimWafRestApiStage      the one resource type so far
+├── SimWafProtectedResources    the port asking whether that resource is there
+└── SimWafProtection            the port a fronting service takes
+```
+
+The store holds the web ACL itself rather than its ARN. A request reaching a protected stage is then
+evaluated without a second lookup, and `DeleteWebACL` refuses a web ACL something still points at.
+Deleting the web ACL out from under a stage would leave the stage protected by rules nothing holds.
+
+Two ports run in opposite directions, and both are needed. `SimWafProtectedResources` is how
+WAFv2 asks whether a stage ARN names anything, since WAFv2 holds no API Gateway state of its own.
+`SimWafProtection` is how a simulated API Gateway reaches the web ACL in front of a stage it is
+about to serve, and how it lets go of one when the stage is deleted.
+`SimAwsWafProtectedResources` is the implementation reading a simulated AWS instance, and a
+standalone `SimWafV2` gets `SimWafNoProtectedResources`, which finds nothing. A standalone
+`SimApiGateway` gets `SimWafNoProtection` and serves every request the way it did before web ACLs.
+
+`sim-waf-protected-resource.ts` reads an ARN for what it names. The three refusals in it mean
+different things. An HTTP API stage is refused because AWS WAF protects no HTTP API, and an
+association accepted here would let a test cover protection AWS never applies. A load balancer and
+the other four resource types AWS does protect are refused as unsimulated. Anything else is refused
+as an ARN. A second target type joins the union and gains a branch in the reader, and everything
+holding an association goes on addressing a resource by its ARN.
 
 ## Compiling a statement
 

--- a/src/service/wafv2/association/sim-aws-waf-protected-resources.ts
+++ b/src/service/wafv2/association/sim-aws-waf-protected-resources.ts
@@ -1,0 +1,41 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimWafProtectedResource } from "./sim-waf-protected-resource.js";
+import type { SimWafProtectedResources } from "./sim-waf-protected-resources.js";
+
+interface SimAwsWafProtectedResourcesProperties {
+  readonly simAws: SimAws;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * The resources of one simulated AWS instance a web ACL can be put in front
+ * of.
+ *
+ * The lookup is made in the Account and Region the WAFv2 handling the request
+ * belongs to. A stage ARN names no Account, and AWS WAF associates within one
+ * Account, so a stage created elsewhere in the simulation is not there to be
+ * found.
+ */
+export class SimAwsWafProtectedResources implements SimWafProtectedResources {
+  readonly #simAws: SimAws;
+  readonly #accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimAwsWafProtectedResourcesProperties) {
+    this.#simAws = properties.simAws;
+    this.#accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Whether the REST API stage an ARN names is one this scope holds.
+   */
+  has(resource: SimWafProtectedResource): boolean {
+    const { accountId, regionName } = this.#accountRegionScope;
+    const restApi = this.#simAws
+      .accountRegionScope(accountId, regionName)
+      .apiGateway()
+      .findRestApi(resource.restApiId);
+
+    return restApi?.stages.find(resource.stageName) !== undefined;
+  }
+}

--- a/src/service/wafv2/association/sim-waf-associations.ts
+++ b/src/service/wafv2/association/sim-waf-associations.ts
@@ -1,0 +1,81 @@
+import type { SimWafDecision } from "../evaluate/sim-waf-decision.js";
+import { simWafInspectedRequest } from "../evaluate/sim-waf-inspected-request.js";
+import type { SimWafWebAcl } from "../web-acl/sim-waf-web-acl.js";
+import type {
+  SimWafProtectedRequest,
+  SimWafProtection,
+} from "./sim-waf-protection.js";
+
+/**
+ * The web ACLs one Account and Region has in front of things.
+ *
+ * A resource carries at most one web ACL, which is why this is keyed by
+ * resource ARN. The web ACL itself is held rather than its ARN, so a request
+ * reaching a protected resource is evaluated without a second lookup, and so a
+ * web ACL cannot be deleted out from under a resource still pointing at it.
+ */
+export class SimWafAssociations implements SimWafProtection {
+  readonly #webAcls = new Map<string, SimWafWebAcl>();
+
+  /**
+   * Put a web ACL in front of one resource, replacing whatever was there.
+   *
+   * AssociateWebACL overwrites rather than refusing, because a resource has
+   * one web ACL and pointing it at another is how it is changed.
+   */
+  associate(resourceArn: string, webAcl: SimWafWebAcl): void {
+    this.#webAcls.set(resourceArn, webAcl);
+  }
+
+  /**
+   * The web ACL in front of one resource, or nothing when it has none.
+   */
+  webAclFor(resourceArn: string): SimWafWebAcl | undefined {
+    return this.#webAcls.get(resourceArn);
+  }
+
+  /**
+   * The resources one web ACL is in front of, in the order they were
+   * associated.
+   */
+  resourceArnsFor(webAcl: SimWafWebAcl): readonly string[] {
+    return this.#webAcls
+      .entries()
+      .filter(([, associated]) => associated === webAcl)
+      .map(([resourceArn]) => resourceArn)
+      .toArray();
+  }
+
+  /**
+   * Whether a web ACL is in front of one resource.
+   */
+  protects(resourceArn: string): boolean {
+    return this.#webAcls.has(resourceArn);
+  }
+
+  /**
+   * What the web ACL in front of one resource decides about a request.
+   */
+  decide(request: SimWafProtectedRequest): SimWafDecision | undefined {
+    const webAcl = this.#webAcls.get(request.resourceArn);
+
+    if (webAcl === undefined) {
+      return undefined;
+    }
+
+    return webAcl.evaluate(
+      simWafInspectedRequest(request.request, request.body),
+    );
+  }
+
+  /**
+   * Forget whatever is in front of one resource.
+   *
+   * This is both what DisassociateWebACL does and what deleting the resource
+   * does. A stage that is deleted and created again under the same name is
+   * unprotected, as it is on AWS.
+   */
+  release(resourceArn: string): void {
+    this.#webAcls.delete(resourceArn);
+  }
+}

--- a/src/service/wafv2/association/sim-waf-protected-resource.ts
+++ b/src/service/wafv2/association/sim-waf-protected-resource.ts
@@ -1,0 +1,92 @@
+import {
+  SimWafInvalidParameterException,
+  SimWafUnsimulatedInputException,
+} from "../error/sim-wafv2.error.js";
+import { SimWafRestApiStage } from "./sim-waf-rest-api-stage.js";
+
+/**
+ * A resource a `REGIONAL` web ACL can be put in front of.
+ *
+ * One type is simulated so far. A second one joins this union and the reader
+ * below gains a branch for it, and everything that holds an association goes
+ * on addressing a resource by its ARN.
+ */
+export type SimWafProtectedResource = SimWafRestApiStage;
+
+/**
+ * The type ListResourcesForWebACL lists a simulated resource under.
+ */
+export const simWafApiGatewayResourceType = "API_GATEWAY";
+
+const restApiStagePattern =
+  /^arn:aws:apigateway:(?<regionName>[^:]+)::\/restapis\/(?<restApiId>[^/]+)\/stages\/(?<stageName>[^/]+)$/u;
+
+const httpApiStagePattern =
+  /^arn:aws:apigateway:[^:]+::\/apis\/[^/]+\/stages\/[^/]+$/u;
+
+/**
+ * The resource types real WAF protects that this simulation does not, by the
+ * service in their ARN.
+ */
+const unsimulatedResources = new Map<string, string>([
+  ["elasticloadbalancing", "an Application Load Balancer"],
+  ["appsync", "an AppSync GraphQL API"],
+  ["cognito-idp", "a Cognito user pool"],
+  ["apprunner", "an App Runner service"],
+  ["amplify", "an Amplify app"],
+  ["ec2", "a Verified Access instance"],
+]);
+
+/**
+ * Read the resource an association names, refusing anything a web ACL cannot
+ * be put in front of here.
+ *
+ * The three refusals mean different things. An HTTP API stage is refused
+ * because AWS WAF protects no HTTP API, so an association accepted here would
+ * let a test cover protection AWS never applies. A load balancer and the rest
+ * are resource types AWS does protect and this simulation does not, which is
+ * the ordinary unsimulated refusal. Anything else is not a resource ARN.
+ */
+export function simWafProtectedResource(arn: string): SimWafProtectedResource {
+  const { groups } = restApiStagePattern.exec(arn) ?? {};
+
+  if (groups !== undefined) {
+    return new SimWafRestApiStage({
+      arn,
+      regionName: groups["regionName"] ?? "",
+      restApiId: groups["restApiId"] ?? "",
+      stageName: groups["stageName"] ?? "",
+    });
+  }
+
+  if (httpApiStagePattern.test(arn)) {
+    throw new SimWafInvalidParameterException(
+      `AWS WAF does not protect an API Gateway HTTP API. The resource types ` +
+        `it protects cover a REST API stage and not an HTTP API stage, so ` +
+        `${arn} cannot be associated with a web ACL.`,
+    );
+  }
+
+  refuseUnsimulatedResource(arn);
+
+  throw new SimWafInvalidParameterException(
+    `Error reason: The ARN isn't valid. A valid ARN begins with arn: and ` +
+      `includes other information separated by colons or slashes., ` +
+      `field: RESOURCE_ARN, parameter: ${arn}`,
+  );
+}
+
+/**
+ * Refuse an ARN naming a resource type AWS WAF protects and Yulin does not.
+ */
+function refuseUnsimulatedResource(arn: string): void {
+  const described = unsimulatedResources.get(arn.split(":", 3)[2] ?? "");
+
+  if (described !== undefined) {
+    throw new SimWafUnsimulatedInputException(
+      `AWS WAF protects ${described}, and Yulin does not simulate a web ACL ` +
+        `in front of one, so ${arn} is refused rather than protected by ` +
+        `nothing.`,
+    );
+  }
+}

--- a/src/service/wafv2/association/sim-waf-protected-resources.ts
+++ b/src/service/wafv2/association/sim-waf-protected-resources.ts
@@ -1,0 +1,32 @@
+import type { SimWafProtectedResource } from "./sim-waf-protected-resource.js";
+
+/**
+ * The resources of one Account and Region a web ACL can be put in front of.
+ *
+ * An association names a resource that has to be there. WAFv2 holds no API
+ * Gateway state of its own, so this is how it asks whichever service owns the
+ * resource whether the ARN names anything.
+ */
+export interface SimWafProtectedResources {
+  /**
+   * Whether this simulation holds the resource an ARN names.
+   */
+  has(resource: SimWafProtectedResource): boolean;
+}
+
+/**
+ * The resources available to a WAFv2 with nothing around it to ask.
+ *
+ * Every ARN resolves to nothing, so a standalone simulated WAFv2 associates a
+ * web ACL with nothing at all. That is the safe answer: an association held
+ * against a resource no request will ever reach protects nothing, and saying
+ * so is better than reporting a web ACL in front of something imaginary.
+ */
+export class SimWafNoProtectedResources implements SimWafProtectedResources {
+  /**
+   * No resource is reachable here.
+   */
+  has(): boolean {
+    return false;
+  }
+}

--- a/src/service/wafv2/association/sim-waf-protection.iso.test.ts
+++ b/src/service/wafv2/association/sim-waf-protection.iso.test.ts
@@ -1,0 +1,55 @@
+import { assertFalse, assertUndefined } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import { SimApiGateway } from "../../apigateway/index.js";
+import { SimWafAssociations } from "./sim-waf-associations.js";
+
+const stageArn = "arn:aws:apigateway:eu-west-2::/restapis/abc123/stages/prod";
+
+describe("SimWafAssociations", () => {
+  it("decides nothing about a resource nothing is in front of", () => {
+    // Given a scope with no association in it.
+    const associations = new SimWafAssociations();
+
+    // When a request to an unprotected resource is put to it.
+    const decision = associations.decide({
+      resourceArn: stageArn,
+      request: new Request("https://example.test/orders"),
+    });
+
+    // Then no web ACL decided it.
+    assertFalse(associations.protects(stageArn));
+    assertUndefined(decision);
+  });
+});
+
+describe("SimWafNoProtection", () => {
+  it("puts nothing in front of a standalone API Gateway's stages", async () => {
+    // Given a simulated API Gateway with no simulated AWS around it.
+    const apiGateway = new SimApiGateway();
+    const created = await apiGateway.createRestApi({
+      input: { name: "orders" },
+    });
+    await apiGateway.createDeployment({
+      input: { restApiId: created.id, stageName: "prod" },
+    });
+
+    const restApi = apiGateway.findRestApi(created.id);
+    assertDefined(restApi, `Simulated API Gateway lost the API ${created.id}`);
+
+    // When the stage is deleted, which lets go of whatever protected it.
+    await apiGateway.deleteStage({
+      input: { restApiId: created.id, stageName: "prod" },
+    });
+
+    // Then nothing was in front of the stage at any point.
+    assertFalse(restApi.webAcls.protects(restApi.stageArn("prod")));
+    assertUndefined(
+      restApi.webAcls.decide({
+        resourceArn: restApi.stageArn("prod"),
+        request: new Request("https://example.test/prod/orders"),
+      }),
+    );
+  });
+});

--- a/src/service/wafv2/association/sim-waf-protection.ts
+++ b/src/service/wafv2/association/sim-waf-protection.ts
@@ -1,0 +1,74 @@
+import type { SimWafDecision } from "../evaluate/sim-waf-decision.js";
+
+/**
+ * One request put to whatever web ACL is in front of the resource it reached.
+ */
+export interface SimWafProtectedRequest {
+  /** The resource the request reached, by ARN. */
+  readonly resourceArn: string;
+
+  readonly request: Request;
+
+  /**
+   * The request body, when the rules might inspect it. A request body is a
+   * stream that cannot be read twice, so it is passed in already buffered.
+   */
+  readonly body?: Uint8Array | undefined;
+}
+
+/**
+ * The web ACLs a fronting service's resources are protected by.
+ *
+ * A service serving a request asks this what the web ACL in front of the
+ * resource decided, and tells it when a resource is deleted. That is how API
+ * Gateway reaches simulated WAFv2 without depending on it.
+ */
+export interface SimWafProtection {
+  /**
+   * Whether a web ACL is in front of one resource.
+   *
+   * Asked before a request is put to a web ACL, because inspecting one means
+   * buffering its body and a resource with no web ACL has no reason to.
+   */
+  protects(resourceArn: string): boolean;
+
+  /**
+   * What the web ACL in front of one resource decides about a request, or
+   * nothing when no web ACL is in front of it.
+   */
+  decide(request: SimWafProtectedRequest): SimWafDecision | undefined;
+
+  /**
+   * Forget whatever protects a resource, as deleting the resource does.
+   */
+  release(resourceArn: string): void;
+}
+
+/**
+ * The protection available to a service with no WAFv2 to ask.
+ *
+ * Nothing is in front of anything, so a standalone simulated API Gateway
+ * serves every request the way it did before web ACLs existed.
+ */
+export class SimWafNoProtection implements SimWafProtection {
+  /**
+   * Nothing is protected here.
+   */
+  protects(): boolean {
+    return false;
+  }
+
+  /**
+   * No web ACL decides anything here.
+   */
+  decide(): undefined {
+    return;
+  }
+
+  /**
+   * There is nothing held against a resource to let go of.
+   */
+  release(): void {
+    return;
+  }
+}

--- a/src/service/wafv2/association/sim-waf-rest-api-stage.ts
+++ b/src/service/wafv2/association/sim-waf-rest-api-stage.ts
@@ -1,0 +1,31 @@
+interface SimWafRestApiStageProperties {
+  readonly arn: string;
+  readonly regionName: string;
+  readonly restApiId: string;
+  readonly stageName: string;
+}
+
+/**
+ * One API Gateway REST API stage, as the ARN an association names it by.
+ *
+ * The ARN is written `arn:aws:apigateway:<region>::/restapis/<id>/stages/<name>`
+ * and carries no Account. A web ACL and the resource it protects are in the
+ * same Account on AWS, so the Account is the one the WAFv2 handling the
+ * request belongs to.
+ */
+export class SimWafRestApiStage {
+  /** The type this resource is listed under by ListResourcesForWebACL. */
+  public readonly resourceType = "API_GATEWAY";
+
+  public readonly arn: string;
+  public readonly regionName: string;
+  public readonly restApiId: string;
+  public readonly stageName: string;
+
+  constructor(properties: SimWafRestApiStageProperties) {
+    this.arn = properties.arn;
+    this.regionName = properties.regionName;
+    this.restApiId = properties.restApiId;
+    this.stageName = properties.stageName;
+  }
+}

--- a/src/service/wafv2/command/association/association.command.ts
+++ b/src/service/wafv2/command/association/association.command.ts
@@ -1,0 +1,74 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimWafWebAclOutput } from "../web-acl/web-acl.command.js";
+
+/**
+ * Minimal structural sim WAFv2 AssociateWebACL command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/wafv2/command/AssociateWebACLCommand/
+ */
+export interface SimAssociateWebAclCommand {
+  readonly input: SimAssociateWebAclCommandInput;
+}
+
+export interface SimAssociateWebAclCommandInput {
+  readonly WebACLArn?: string | undefined;
+  readonly ResourceArn?: string | undefined;
+}
+
+export interface SimAssociateWebAclCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim WAFv2 DisassociateWebACL command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/wafv2/command/DisassociateWebACLCommand/
+ */
+export interface SimDisassociateWebAclCommand {
+  readonly input: SimDisassociateWebAclCommandInput;
+}
+
+export interface SimDisassociateWebAclCommandInput {
+  readonly ResourceArn?: string | undefined;
+}
+
+export interface SimDisassociateWebAclCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim WAFv2 GetWebACLForResource command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/wafv2/command/GetWebACLForResourceCommand/
+ */
+export interface SimGetWebAclForResourceCommand {
+  readonly input: SimGetWebAclForResourceCommandInput;
+}
+
+export interface SimGetWebAclForResourceCommandInput {
+  readonly ResourceArn?: string | undefined;
+}
+
+export interface SimGetWebAclForResourceCommandOutput {
+  readonly WebACL?: SimWafWebAclOutput | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim WAFv2 ListResourcesForWebACL command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/wafv2/command/ListResourcesForWebACLCommand/
+ */
+export interface SimListResourcesForWebAclCommand {
+  readonly input: SimListResourcesForWebAclCommandInput;
+}
+
+export interface SimListResourcesForWebAclCommandInput {
+  readonly WebACLArn?: string | undefined;
+  readonly ResourceType?: string | undefined;
+}
+
+export interface SimListResourcesForWebAclCommandOutput {
+  readonly ResourceArns: readonly string[];
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/wafv2/command/association/sim-wafv2-association-access.ts
+++ b/src/service/wafv2/command/association/sim-wafv2-association-access.ts
@@ -1,0 +1,99 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimWafProtectedResource } from "../../association/sim-waf-protected-resource.js";
+import type { SimWafProtectedResources } from "../../association/sim-waf-protected-resources.js";
+import { SimWafUnavailableEntityException } from "../../error/sim-wafv2.error.js";
+import type { SimWafResourceStore } from "../../resource/sim-waf-resource-store.js";
+import type { SimWafWebAcl } from "../../web-acl/sim-waf-web-acl.js";
+import type { SimWafAuthorizer } from "../authorize/sim-wafv2-authorizer.js";
+import { simWafAssociationResource } from "./sim-wafv2-association-input.js";
+import { requireRegionalSimWafWebAcl } from "./sim-wafv2-regional-web-acl.js";
+
+interface SimWafAssociationAccessProperties {
+  readonly webAcls: SimWafResourceStore<SimWafWebAcl>;
+  readonly protectedResources: SimWafProtectedResources;
+  readonly authorizer: SimWafAuthorizer;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * Reaching the two things an association names, in the order AWS reaches them.
+ *
+ * Authorizing comes before the lookup here as it does everywhere else in this
+ * service. A caller with no permission for a stage never learns whether the
+ * stage is there.
+ */
+export class SimWafAssociationAccess {
+  readonly #webAcls: SimWafResourceStore<SimWafWebAcl>;
+  readonly #protectedResources: SimWafProtectedResources;
+  readonly #authorizer: SimWafAuthorizer;
+  readonly #accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimWafAssociationAccessProperties) {
+    this.#webAcls = properties.webAcls;
+    this.#protectedResources = properties.protectedResources;
+    this.#authorizer = properties.authorizer;
+    this.#accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Authorize a caller for an action naming one web ACL by ARN.
+   */
+  authorizeWebAcl(action: string, arn: string, caller?: SimAwsCaller): void {
+    this.#authorizer.authorizeResource(action, arn, caller);
+  }
+
+  /**
+   * Read the resource ARN a command carries, without authorizing for it.
+   *
+   * AssociateWebACL authorizes against the web ACL. The resource ARN is still
+   * read first, so a request naming both of them badly is refused for the ARN
+   * it wrote rather than for the one IAM happened to see.
+   */
+  resource(resourceArn: string | undefined): SimWafProtectedResource {
+    return simWafAssociationResource(resourceArn, this.#accountRegionScope);
+  }
+
+  /**
+   * Read a resource ARN, authorize the caller for it, and check it is there.
+   *
+   * This is for the two commands carrying only a resource ARN. The web ACL
+   * they are about is whatever the association turns out to hold, so the
+   * resource is the only thing IAM has to decide against.
+   */
+  authorizedResource(
+    resourceArn: string | undefined,
+    action: string,
+    caller?: SimAwsCaller,
+  ): SimWafProtectedResource {
+    const resource = this.resource(resourceArn);
+
+    this.#authorizer.authorizeResource(action, resource.arn, caller);
+    this.requireResource(resource);
+
+    return resource;
+  }
+
+  /**
+   * Ensure the resource an association names is one this simulation holds.
+   */
+  requireResource(resource: SimWafProtectedResource): void {
+    if (!this.#protectedResources.has(resource)) {
+      throw new SimWafUnavailableEntityException(
+        `AWS WAF couldn't retrieve the resource that you requested. Retry ` +
+          `your request: ${resource.arn}.`,
+      );
+    }
+  }
+
+  /**
+   * Get the `REGIONAL` web ACL an ARN names.
+   */
+  webAcl(webAclArn: string): SimWafWebAcl {
+    return requireRegionalSimWafWebAcl({
+      webAclArn,
+      webAcls: this.#webAcls,
+      accountRegionScope: this.#accountRegionScope,
+    });
+  }
+}

--- a/src/service/wafv2/command/association/sim-wafv2-association-commands.ts
+++ b/src/service/wafv2/command/association/sim-wafv2-association-commands.ts
@@ -1,0 +1,136 @@
+import type { SimWafAssociations } from "../../association/sim-waf-associations.js";
+import { requiredSimWafArn } from "../sim-wafv2-input.js";
+import type { SimWafRequestOptions } from "../sim-wafv2-request-options.js";
+import { simWafWebAclOutput } from "../web-acl/sim-waf-web-acl-output.js";
+import type { SimWafAssociationAccess } from "./sim-wafv2-association-access.js";
+import { refuseUnsimulatedSimWafResourceType } from "./sim-wafv2-association-input.js";
+import type {
+  SimAssociateWebAclCommand,
+  SimAssociateWebAclCommandOutput,
+  SimDisassociateWebAclCommand,
+  SimDisassociateWebAclCommandOutput,
+  SimGetWebAclForResourceCommand,
+  SimGetWebAclForResourceCommandOutput,
+  SimListResourcesForWebAclCommand,
+  SimListResourcesForWebAclCommandOutput,
+} from "./association.command.js";
+
+interface SimWafAssociationCommandsProperties {
+  readonly associations: SimWafAssociations;
+  readonly access: SimWafAssociationAccess;
+}
+
+/**
+ * The commands that put a web ACL in front of a resource and take it away
+ * again.
+ *
+ * A resource is named by ARN and nothing else. Reading that ARN for what it
+ * names, authorizing the caller and finding the web ACL are all in
+ * `sim-wafv2-association-access.ts`, which leaves these four as the operations
+ * themselves.
+ */
+export class SimWafAssociationCommands {
+  readonly #associations: SimWafAssociations;
+  readonly #access: SimWafAssociationAccess;
+
+  constructor(properties: SimWafAssociationCommandsProperties) {
+    this.#associations = properties.associations;
+    this.#access = properties.access;
+  }
+
+  /**
+   * Put a web ACL in front of one resource.
+   */
+  associateWebAcl(
+    command: SimAssociateWebAclCommand,
+    options?: SimWafRequestOptions,
+  ): SimAssociateWebAclCommandOutput {
+    const { input } = command;
+    const webAclArn = requiredSimWafArn(input.WebACLArn, "WebACLArn");
+    const resource = this.#access.resource(input.ResourceArn);
+
+    this.#access.authorizeWebAcl(
+      "wafv2:AssociateWebACL",
+      webAclArn,
+      options?.caller,
+    );
+
+    const webAcl = this.#access.webAcl(webAclArn);
+
+    this.#access.requireResource(resource);
+    this.#associations.associate(resource.arn, webAcl);
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * Take the web ACL in front of one resource away.
+   *
+   * A resource with no web ACL is left as it is. AWS reports a resource that
+   * is not there and says nothing about an association that was never made.
+   */
+  disassociateWebAcl(
+    command: SimDisassociateWebAclCommand,
+    options?: SimWafRequestOptions,
+  ): SimDisassociateWebAclCommandOutput {
+    const resource = this.#access.authorizedResource(
+      command.input.ResourceArn,
+      "wafv2:DisassociateWebACL",
+      options?.caller,
+    );
+
+    this.#associations.release(resource.arn);
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * Read the web ACL in front of one resource.
+   *
+   * A resource with no web ACL answers with nothing, as AWS does. The question
+   * has an answer, and reporting an error for it would be a different one.
+   */
+  getWebAclForResource(
+    command: SimGetWebAclForResourceCommand,
+    options?: SimWafRequestOptions,
+  ): SimGetWebAclForResourceCommandOutput {
+    const resource = this.#access.authorizedResource(
+      command.input.ResourceArn,
+      "wafv2:GetWebACLForResource",
+      options?.caller,
+    );
+    const webAcl = this.#associations.webAclFor(resource.arn);
+
+    if (webAcl === undefined) {
+      return { $metadata: {} };
+    }
+
+    return { $metadata: {}, WebACL: simWafWebAclOutput(webAcl) };
+  }
+
+  /**
+   * List the resources one web ACL is in front of.
+   */
+  listResourcesForWebAcl(
+    command: SimListResourcesForWebAclCommand,
+    options?: SimWafRequestOptions,
+  ): SimListResourcesForWebAclCommandOutput {
+    const { input } = command;
+    const webAclArn = requiredSimWafArn(input.WebACLArn, "WebACLArn");
+
+    refuseUnsimulatedSimWafResourceType(input.ResourceType);
+
+    this.#access.authorizeWebAcl(
+      "wafv2:ListResourcesForWebACL",
+      webAclArn,
+      options?.caller,
+    );
+
+    return {
+      $metadata: {},
+      ResourceArns: this.#associations.resourceArnsFor(
+        this.#access.webAcl(webAclArn),
+      ),
+    };
+  }
+}

--- a/src/service/wafv2/command/association/sim-wafv2-association-input.ts
+++ b/src/service/wafv2/command/association/sim-wafv2-association-input.ts
@@ -1,0 +1,66 @@
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import {
+  type SimWafProtectedResource,
+  simWafApiGatewayResourceType,
+  simWafProtectedResource,
+} from "../../association/sim-waf-protected-resource.js";
+import {
+  SimWafInvalidParameterException,
+  SimWafUnsimulatedInputException,
+} from "../../error/sim-wafv2.error.js";
+import { requiredSimWafArn } from "../sim-wafv2-input.js";
+
+/**
+ * What ListResourcesForWebACL lists when the request names no resource type.
+ *
+ * Real WAFv2 documents that default, and it is not the type simulated here. A
+ * listing that names nothing is refused, because the empty list a load
+ * balancer listing produces reads as a web ACL protecting nothing.
+ */
+const defaultResourceType = "APPLICATION_LOAD_BALANCER";
+
+/**
+ * Read the resource an association named, and hold it to one Region.
+ *
+ * A web ACL protects what is in its own Account and Region, as it does on AWS.
+ * The Account falls out of the lookup afterwards, since a REST API stage ARN
+ * carries none, and the Region has to be read out of the ARN here.
+ */
+export function simWafAssociationResource(
+  resourceArn: string | undefined,
+  accountRegionScope: SimAwsAccountRegionScope,
+): SimWafProtectedResource {
+  const resource = simWafProtectedResource(
+    requiredSimWafArn(resourceArn, "ResourceArn"),
+  );
+  const { regionName } = accountRegionScope;
+
+  if (resource.regionName !== regionName) {
+    throw new SimWafInvalidParameterException(
+      `Error reason: The resource ${resource.arn} is in ` +
+        `${resource.regionName}, and this request was made in ` +
+        `${regionName}., field: RESOURCE_ARN, parameter: ${resource.arn}`,
+    );
+  }
+
+  return resource;
+}
+
+/**
+ * Refuse a listing for a resource type this simulation does not hold.
+ */
+export function refuseUnsimulatedSimWafResourceType(
+  resourceType: string | undefined,
+): void {
+  const listed = resourceType ?? defaultResourceType;
+
+  if (listed !== simWafApiGatewayResourceType) {
+    throw new SimWafUnsimulatedInputException(
+      `AWS WAF lists ${listed} resources, and ` +
+        `${simWafApiGatewayResourceType} is the type Yulin simulates. ` +
+        `ListResourcesForWebACL lists ${defaultResourceType} when a request ` +
+        `names no ResourceType, so name ${simWafApiGatewayResourceType} to ` +
+        `list the REST API stages a web ACL protects.`,
+    );
+  }
+}

--- a/src/service/wafv2/command/association/sim-wafv2-regional-web-acl.ts
+++ b/src/service/wafv2/command/association/sim-wafv2-regional-web-acl.ts
@@ -1,0 +1,80 @@
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import {
+  SimWafInvalidParameterException,
+  SimWafNonexistentItemException,
+} from "../../error/sim-wafv2.error.js";
+import type { SimWafResourceStore } from "../../resource/sim-waf-resource-store.js";
+import { simWafArnParts } from "../../sim-wafv2-arn.js";
+import type { SimWafWebAcl } from "../../web-acl/sim-waf-web-acl.js";
+
+interface SimWafRegionalWebAclLookup {
+  readonly webAclArn: string;
+  readonly webAcls: SimWafResourceStore<SimWafWebAcl>;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * Get the `REGIONAL` web ACL an association's ARN names.
+ *
+ * Three things are checked before the store is asked, and each of them says
+ * something the store could not. A string that is not a WAFv2 ARN was never a
+ * web ACL. A `CLOUDFRONT` scope web ACL protects a CloudFront distribution,
+ * which takes its web ACL from the distribution and not from
+ * `AssociateWebACL`. A web ACL in another Account or Region belongs to a WAFv2
+ * this one has no reach into, and the caller is told where it is rather than
+ * that it does not exist.
+ */
+export function requireRegionalSimWafWebAcl(
+  lookup: SimWafRegionalWebAclLookup,
+): SimWafWebAcl {
+  const { webAclArn } = lookup;
+  const parts = simWafArnParts(webAclArn);
+  const { accountId, regionName } = lookup.accountRegionScope;
+
+  if (parts === undefined) {
+    throw invalidWebAclArn(
+      `The ARN isn't valid. A valid ARN begins with arn: and includes other ` +
+        `information separated by colons or slashes.`,
+      webAclArn,
+    );
+  }
+
+  if (parts.scope === "CLOUDFRONT") {
+    throw invalidWebAclArn(
+      `A CLOUDFRONT scope web ACL protects a CloudFront distribution, which ` +
+        `takes its web ACL from the distribution and not from AssociateWebACL.`,
+      webAclArn,
+    );
+  }
+
+  if (parts.regionName !== regionName || parts.accountId !== accountId) {
+    throw invalidWebAclArn(
+      `The web ACL is in ${parts.accountId} ${parts.regionName}, and this ` +
+        `request was made in ${accountId} ${regionName}.`,
+      webAclArn,
+    );
+  }
+
+  const webAcl = lookup.webAcls.findByArn(webAclArn);
+
+  if (webAcl === undefined) {
+    throw new SimWafNonexistentItemException(
+      `AWS WAF couldn't perform the operation because your resource ` +
+        `doesn't exist: web ACL ${webAclArn}.`,
+    );
+  }
+
+  return webAcl;
+}
+
+/**
+ * The refusal each of those checks reports, in the form WAFv2 writes.
+ */
+function invalidWebAclArn(
+  reason: string,
+  webAclArn: string,
+): SimWafInvalidParameterException {
+  return new SimWafInvalidParameterException(
+    `Error reason: ${reason}, field: WEB_ACL_ARN, parameter: ${webAclArn}`,
+  );
+}

--- a/src/service/wafv2/command/sim-wafv2-command.types.ts
+++ b/src/service/wafv2/command/sim-wafv2-command.types.ts
@@ -2,6 +2,20 @@
  * The sim WAFv2 Command types, gathered for the service facade.
  */
 export type {
+  SimAssociateWebAclCommand,
+  SimAssociateWebAclCommandInput,
+  SimAssociateWebAclCommandOutput,
+  SimDisassociateWebAclCommand,
+  SimDisassociateWebAclCommandInput,
+  SimDisassociateWebAclCommandOutput,
+  SimGetWebAclForResourceCommand,
+  SimGetWebAclForResourceCommandInput,
+  SimGetWebAclForResourceCommandOutput,
+  SimListResourcesForWebAclCommand,
+  SimListResourcesForWebAclCommandInput,
+  SimListResourcesForWebAclCommandOutput,
+} from "./association/association.command.js";
+export type {
   SimCreateIpSetCommand,
   SimCreateIpSetCommandInput,
   SimCreateIpSetCommandOutput,

--- a/src/service/wafv2/command/sim-wafv2-input.ts
+++ b/src/service/wafv2/command/sim-wafv2-input.ts
@@ -51,3 +51,23 @@ export function refuseSimWafTags(
     );
   }
 }
+
+/**
+ * Read an ARN a request named, refusing a request with none.
+ *
+ * An association names both the web ACL and the resource it goes in front of
+ * by ARN, and neither has anything else to fall back on.
+ */
+export function requiredSimWafArn(
+  arn: string | undefined,
+  parameter: string,
+): string {
+  if (arn === undefined || arn === "") {
+    throw new SimWafInvalidParameterException(
+      `Error reason: A WAFv2 association names an ARN, ` +
+        `field: RESOURCE_ARN, parameter: ${parameter}`,
+    );
+  }
+
+  return arn;
+}

--- a/src/service/wafv2/command/web-acl/sim-waf-web-acl-output.ts
+++ b/src/service/wafv2/command/web-acl/sim-waf-web-acl-output.ts
@@ -1,0 +1,23 @@
+import type { SimWafWebAcl } from "../../web-acl/sim-waf-web-acl.js";
+import type { SimWafWebAclOutput } from "./web-acl.command.js";
+
+/**
+ * What the API reports about one web ACL.
+ *
+ * GetWebACL and GetWebACLForResource both answer with the whole web ACL, so
+ * the shape is stated once here rather than in each of them.
+ */
+export function simWafWebAclOutput(webAcl: SimWafWebAcl): SimWafWebAclOutput {
+  const { configuration } = webAcl;
+
+  return {
+    Name: webAcl.name,
+    Id: webAcl.id,
+    ARN: webAcl.arn,
+    Description: webAcl.description,
+    DefaultAction: configuration.defaultAction,
+    Rules: configuration.rules ?? [],
+    VisibilityConfig: configuration.visibilityConfig,
+    CustomResponseBodies: configuration.customResponseBodies,
+  };
+}

--- a/src/service/wafv2/command/web-acl/sim-wafv2-web-acl-commands.ts
+++ b/src/service/wafv2/command/web-acl/sim-wafv2-web-acl-commands.ts
@@ -1,4 +1,6 @@
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimWafAssociations } from "../../association/sim-waf-associations.js";
+import { SimWafAssociatedItemException } from "../../error/sim-wafv2.error.js";
 import type { SimWafRegexPatternSet } from "../../regex-pattern-set/sim-waf-regex-pattern-set.js";
 import type { SimWafResourceStore } from "../../resource/sim-waf-resource-store.js";
 import { requiredSimWafScope } from "../../scope/sim-waf-scope.js";
@@ -13,6 +15,7 @@ import {
 } from "../sim-wafv2-resource-lookup.js";
 import type { SimWafRequestOptions } from "../sim-wafv2-request-options.js";
 import { refuseUnsimulatedSimWafWebAclInput } from "./sim-wafv2-unsimulated-web-acl-input.js";
+import { simWafWebAclOutput } from "./sim-waf-web-acl-output.js";
 import type {
   SimCreateWebAclCommand,
   SimCreateWebAclCommandOutput,
@@ -30,6 +33,7 @@ import type {
 interface SimWafWebAclCommandsProperties {
   readonly webAcls: SimWafResourceStore<SimWafWebAcl>;
   readonly regexPatternSets: SimWafResourceStore<SimWafRegexPatternSet>;
+  readonly associations: SimWafAssociations;
   readonly authorizer: SimWafAuthorizer;
   readonly accountRegionScope: SimAwsAccountRegionScope;
 }
@@ -44,12 +48,14 @@ interface SimWafWebAclCommandsProperties {
 export class SimWafWebAclCommands {
   readonly #webAcls: SimWafResourceStore<SimWafWebAcl>;
   readonly #regexPatternSets: SimWafResourceStore<SimWafRegexPatternSet>;
+  readonly #associations: SimWafAssociations;
   readonly #authorizer: SimWafAuthorizer;
   readonly #accountRegionScope: SimAwsAccountRegionScope;
 
   constructor(properties: SimWafWebAclCommandsProperties) {
     this.#webAcls = properties.webAcls;
     this.#regexPatternSets = properties.regexPatternSets;
+    this.#associations = properties.associations;
     this.#authorizer = properties.authorizer;
     this.#accountRegionScope = properties.accountRegionScope;
   }
@@ -96,21 +102,11 @@ export class SimWafWebAclCommands {
     options?: SimWafRequestOptions,
   ): SimGetWebAclCommandOutput {
     const webAcl = this.require(command.input, "wafv2:GetWebACL", options);
-    const { configuration } = webAcl;
 
     return {
       $metadata: {},
       LockToken: webAcl.lockToken,
-      WebACL: {
-        Name: webAcl.name,
-        Id: webAcl.id,
-        ARN: webAcl.arn,
-        Description: webAcl.description,
-        DefaultAction: configuration.defaultAction,
-        Rules: configuration.rules ?? [],
-        VisibilityConfig: configuration.visibilityConfig,
-        CustomResponseBodies: configuration.customResponseBodies,
-      },
+      WebACL: simWafWebAclOutput(webAcl),
     };
   }
 
@@ -165,12 +161,26 @@ export class SimWafWebAclCommands {
 
   /**
    * Remove a web ACL.
+   *
+   * A web ACL still in front of something is refused. Deleting one would
+   * otherwise leave a stage protected by rules nothing holds any more, so the
+   * resources it protects are disassociated first.
    */
   deleteWebAcl(
     command: SimDeleteWebAclCommand,
     options?: SimWafRequestOptions,
   ): SimDeleteWebAclCommandOutput {
     const webAcl = this.require(command.input, "wafv2:DeleteWebACL", options);
+    const associated = this.#associations.resourceArnsFor(webAcl);
+
+    if (associated.length > 0) {
+      throw new SimWafAssociatedItemException(
+        `AWS WAF couldn't perform the operation because your resource is ` +
+          `being used by another resource or it's associated with another ` +
+          `resource: web ACL ${webAcl.name} is associated with ` +
+          `${associated.join(", ")}.`,
+      );
+    }
 
     webAcl.takeLock(command.input.LockToken);
     this.#webAcls.remove(webAcl);

--- a/src/service/wafv2/error/sim-wafv2.error.ts
+++ b/src/service/wafv2/error/sim-wafv2.error.ts
@@ -92,3 +92,33 @@ export class SimWafUnsimulatedInputException extends SimWafError {
     super(message, { httpStatusCode: 400 });
   }
 }
+
+/**
+ * Simulated WAFv2 WAFUnavailableEntityException error.
+ *
+ * An association names the resource a web ACL goes in front of, and WAFv2
+ * reports a resource it cannot reach this way. Here that is a REST API stage
+ * this simulation has never held.
+ */
+export class SimWafUnavailableEntityException extends SimWafError {
+  public override readonly name = "WAFUnavailableEntityException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated WAFv2 WAFAssociatedItemException error.
+ *
+ * A web ACL in front of something cannot be deleted. Removing one that a stage
+ * still points at would leave the stage protected by rules nothing holds any
+ * more, so the association is disassociated first.
+ */
+export class SimWafAssociatedItemException extends SimWafError {
+  public override readonly name = "WAFAssociatedItemException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}

--- a/src/service/wafv2/evaluate/sim-waf-blocked-response.ts
+++ b/src/service/wafv2/evaluate/sim-waf-blocked-response.ts
@@ -14,10 +14,11 @@ export interface SimWafBlockedResponse {
  * The body a block action with no custom response of its own answers with.
  *
  * Real WAF hands the blocking off to whatever the web ACL is in front of, and
- * each of them writes its own page: CloudFront's error page, API Gateway's
- * `{"message":"Forbidden"}`. Nothing is associated with a web ACL yet, so this
- * is the simulator's own body until there is a fronting service to ask, and
- * the status is the 403 all of them answer with.
+ * each of them writes its own page. CloudFront writes an error page and API
+ * Gateway writes `{"message":"Forbidden"}`. This is the simulator's own body
+ * for all of them, which is a deliberate divergence recorded in
+ * `docs/services/wafv2`. The status is the 403 every one of them answers with,
+ * and a rule with a custom response replaces this whole thing anyway.
  */
 export function simWafDefaultBlockedResponse(): SimWafBlockedResponse {
   return {

--- a/src/service/wafv2/index.ts
+++ b/src/service/wafv2/index.ts
@@ -8,9 +8,28 @@ export {
 } from "./scope/sim-waf-scope.js";
 export {
   simWafArn,
+  type SimWafArnParts,
+  simWafArnParts,
   simWafArnPrefix,
   type SimWafResourceKind,
 } from "./sim-wafv2-arn.js";
+export { SimWafSets } from "./sim-wafv2-sets.js";
+export { SimWafAssociations } from "./association/sim-waf-associations.js";
+export {
+  simWafApiGatewayResourceType,
+  type SimWafProtectedResource,
+  simWafProtectedResource,
+} from "./association/sim-waf-protected-resource.js";
+export {
+  SimWafNoProtectedResources,
+  type SimWafProtectedResources,
+} from "./association/sim-waf-protected-resources.js";
+export {
+  SimWafNoProtection,
+  type SimWafProtectedRequest,
+  type SimWafProtection,
+} from "./association/sim-waf-protection.js";
+export { SimWafRestApiStage } from "./association/sim-waf-rest-api-stage.js";
 export {
   SimWafResource,
   type SimWafResourceSummary,
@@ -43,11 +62,13 @@ export {
 export { simWafInspectionLimitBytes } from "./statement/sim-waf-field-content.js";
 export type { SimWafStatementInput } from "./statement/sim-waf-statement.type.js";
 export {
+  SimWafAssociatedItemException,
   SimWafDuplicateItemException,
   SimWafError,
   type SimWafErrorMetadata,
   SimWafInvalidParameterException,
   SimWafNonexistentItemException,
   SimWafOptimisticLockException,
+  SimWafUnavailableEntityException,
   SimWafUnsimulatedInputException,
 } from "./error/sim-wafv2.error.js";

--- a/src/service/wafv2/sdk/sim-wafv2-sdk-command-router.ts
+++ b/src/service/wafv2/sdk/sim-wafv2-sdk-command-router.ts
@@ -134,6 +134,38 @@ export class SimWafSdkCommandRouter implements SimSdkCommandRouter {
             simSdkCallerOptions(context),
           ),
       ],
+      [
+        "AssociateWebACLCommand",
+        async (command, context): Promise<unknown> =>
+          await simWaf.associateWebAcl(
+            command as simWafCommands.SimAssociateWebAclCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DisassociateWebACLCommand",
+        async (command, context): Promise<unknown> =>
+          await simWaf.disassociateWebAcl(
+            command as simWafCommands.SimDisassociateWebAclCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetWebACLForResourceCommand",
+        async (command, context): Promise<unknown> =>
+          await simWaf.getWebAclForResource(
+            command as simWafCommands.SimGetWebAclForResourceCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListResourcesForWebACLCommand",
+        async (command, context): Promise<unknown> =>
+          await simWaf.listResourcesForWebAcl(
+            command as simWafCommands.SimListResourcesForWebAclCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
     ]);
   }
 

--- a/src/service/wafv2/sdk/sim-wafv2-sdk-routing.iso.test.ts
+++ b/src/service/wafv2/sdk/sim-wafv2-sdk-routing.iso.test.ts
@@ -6,16 +6,26 @@ import {
   DeleteIPSetCommand,
   DeleteRegexPatternSetCommand,
   DeleteWebACLCommand,
+  DisassociateWebACLCommand,
   GetIPSetCommand,
   GetRegexPatternSetCommand,
   GetWebACLCommand,
+  GetWebACLForResourceCommand,
   ListIPSetsCommand,
+  ListResourcesForWebACLCommand,
   ListRegexPatternSetsCommand,
   ListWebACLsCommand,
+  PutLoggingConfigurationCommand,
   UpdateWebACLCommand,
   WAFV2Client,
 } from "@aws-sdk/client-wafv2";
 import {
+  APIGatewayClient,
+  CreateDeploymentCommand,
+  CreateRestApiCommand,
+} from "@aws-sdk/client-api-gateway";
+import {
+  assertArrayEquals,
   assertArrayIncludesAll,
   assertArrayLength,
   assertIdentical,
@@ -73,6 +83,10 @@ describe("SimWafSdkCommandRouter", () => {
       "UpdateRegexPatternSetCommand",
       "ListRegexPatternSetsCommand",
       "DeleteRegexPatternSetCommand",
+      "AssociateWebACLCommand",
+      "DisassociateWebACLCommand",
+      "GetWebACLForResourceCommand",
+      "ListResourcesForWebACLCommand",
     ]);
   });
 
@@ -84,9 +98,9 @@ describe("SimWafSdkCommandRouter", () => {
     const route = simAws
       .wafV2()
       .sdkCommandRouter()
-      .route("AssociateWebACLCommand");
+      .route("PutLoggingConfigurationCommand");
 
-    // Then there is no route for it. Association follows in its own issues.
+    // Then there is no route for it. Logging is not simulated.
     assertUndefined(route);
   });
 });
@@ -221,6 +235,54 @@ describe("WAFv2 SDK interception", () => {
     assertArrayLength(afterDelete.WebACLs ?? [], 0);
   });
 
+  it("routes the association Commands through the intercepted client", async () => {
+    // Given an intercepted client, a web ACL and a deployed REST API stage.
+    using simSdk = new SimSdk();
+    simSdk.intercept(WAFV2Client);
+    simSdk.intercept(APIGatewayClient);
+
+    const client = new WAFV2Client({ region: "eu-west-2" });
+    const apiGateway = new APIGatewayClient({ region: "eu-west-2" });
+    const api = await apiGateway.send(
+      new CreateRestApiCommand({ name: "orders" }),
+    );
+    await apiGateway.send(
+      new CreateDeploymentCommand({ restApiId: api.id, stageName: "prod" }),
+    );
+
+    const stageArn = `arn:aws:apigateway:eu-west-2::/restapis/${api.id}/stages/prod`;
+    const created = await client.send(new CreateWebACLCommand(apiAclInput));
+
+    // When each association operation is used.
+    await client.send(
+      new AssociateWebACLCommand({
+        WebACLArn: created.Summary?.ARN,
+        ResourceArn: stageArn,
+      }),
+    );
+    const forResource = await client.send(
+      new GetWebACLForResourceCommand({ ResourceArn: stageArn }),
+    );
+    const listed = await client.send(
+      new ListResourcesForWebACLCommand({
+        WebACLArn: created.Summary?.ARN,
+        ResourceType: "API_GATEWAY",
+      }),
+    );
+    await client.send(new DisassociateWebACLCommand({ ResourceArn: stageArn }));
+    const afterDisassociate = await client.send(
+      new ListResourcesForWebACLCommand({
+        WebACLArn: created.Summary?.ARN,
+        ResourceType: "API_GATEWAY",
+      }),
+    );
+
+    // Then each one reached simulated WAFv2.
+    assertIdentical(forResource.WebACL?.Name, "api-acl");
+    assertArrayEquals(listed.ResourceArns ?? [], [stageArn]);
+    assertArrayLength(afterDisassociate.ResourceArns ?? [], 0);
+  });
+
   it("refuses a Command simulated WAFv2 does not handle", async () => {
     // Given an intercepted client.
     using simSdk = new SimSdk();
@@ -228,18 +290,23 @@ describe("WAFv2 SDK interception", () => {
 
     const client = new WAFV2Client({ region: "eu-west-2" });
 
-    // When it associates a web ACL with something.
+    // When it writes a logging configuration.
     const error = await assertThrowsErrorAsync(async () => {
       await client.send(
-        new AssociateWebACLCommand({
-          WebACLArn: "arn:aws:wafv2:eu-west-2:111111111111:regional/webacl/x/y",
-          ResourceArn: "arn:aws:elasticloadbalancing:eu-west-2:111111111111:x",
+        new PutLoggingConfigurationCommand({
+          LoggingConfiguration: {
+            ResourceArn:
+              "arn:aws:wafv2:eu-west-2:111111111111:regional/webacl/x/y",
+            LogDestinationConfigs: [
+              "arn:aws:logs:eu-west-2:111111111111:log-group:aws-waf-logs-x",
+            ],
+          },
         }),
       );
     });
 
     // Then it is refused by name rather than reaching real AWS.
     assertInstanceOf(error, SimSdkUnsupportedCommandError);
-    assertStringIncludes(error.message, "AssociateWebACLCommand");
+    assertStringIncludes(error.message, "PutLoggingConfigurationCommand");
   });
 });

--- a/src/service/wafv2/sim-wafv2-arn.ts
+++ b/src/service/wafv2/sim-wafv2-arn.ts
@@ -38,3 +38,44 @@ export function simWafArn(properties: {
 
   return `${simWafArnPrefix(accountRegionScope, scope)}${kind}/${name}/${id}`;
 }
+
+/**
+ * What a WAFv2 ARN says about the resource it names.
+ */
+export interface SimWafArnParts {
+  readonly regionName: string;
+  readonly accountId: string;
+  readonly scope: SimWafScope;
+  readonly kind: string;
+  readonly name: string;
+  readonly id: string;
+}
+
+const simWafArnPattern =
+  /^arn:aws:wafv2:(?<regionName>[^:]*):(?<accountId>[^:]*):(?<scopePath>global|regional)\/(?<kind>[^/]+)\/(?<name>[^/]+)\/(?<id>[^/]+)$/u;
+
+/**
+ * Read a WAFv2 ARN, or nothing when the string is not one.
+ *
+ * An association carries the web ACL as an ARN and nothing else, so the scope
+ * and the Region it was created in have to be read back out of it. A web ACL
+ * in the wrong scope or the wrong Region is refused before anything looks for
+ * it, which is what tells a caller the difference between an ACL that is
+ * elsewhere and one that was never created.
+ */
+export function simWafArnParts(arn: string): SimWafArnParts | undefined {
+  const { groups } = simWafArnPattern.exec(arn) ?? {};
+
+  if (groups === undefined) {
+    return undefined;
+  }
+
+  return {
+    regionName: groups["regionName"] ?? "",
+    accountId: groups["accountId"] ?? "",
+    scope: groups["scopePath"] === "global" ? "CLOUDFRONT" : "REGIONAL",
+    kind: groups["kind"] ?? "",
+    name: groups["name"] ?? "",
+    id: groups["id"] ?? "",
+  };
+}

--- a/src/service/wafv2/sim-wafv2-association-refusals.iso.test.ts
+++ b/src/service/wafv2/sim-wafv2-association-refusals.iso.test.ts
@@ -1,0 +1,349 @@
+import {
+  AssociateWebACLCommand,
+  GetWebACLForResourceCommand,
+  ListResourcesForWebACLCommand,
+} from "@aws-sdk/client-wafv2";
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { assertDefined } from "../../util/type-guard/defined.js";
+import type { SimAwsAccountId } from "../aws/sim-aws-account.js";
+import { SimAws } from "../aws/sim-aws.js";
+import { simWafCreateWebAclFactory } from "./command/web-acl/sim-waf-create-web-acl.factory.js";
+import {
+  SimWafInvalidParameterException,
+  SimWafNonexistentItemException,
+  SimWafUnavailableEntityException,
+  SimWafUnsimulatedInputException,
+} from "./error/sim-wafv2.error.js";
+import { SimWafV2 } from "./sim-wafv2.js";
+import { createSimWafWebAcl } from "./sim-wafv2.fixture.js";
+
+const accountIdTwoTwos = "222222222222" as SimAwsAccountId;
+
+/**
+ * A deployed REST API stage and a REGIONAL web ACL in the same scope.
+ *
+ * Every refusal here is about one of the two ARNs an association carries, so
+ * each test starts from a pair that would otherwise be associated.
+ */
+async function stageAndWebAcl(simAws: SimAws): Promise<{
+  readonly stageArn: string;
+  readonly webAclArn: string;
+}> {
+  const apiGateway = simAws.apiGateway();
+  const created = await apiGateway.createRestApi({ input: { name: "orders" } });
+  await apiGateway.createDeployment({
+    input: { restApiId: created.id, stageName: "prod" },
+  });
+
+  const restApi = apiGateway.findRestApi(created.id);
+  assertDefined(restApi, `Simulated API Gateway lost the API ${created.id}`);
+
+  const webAcl = await createSimWafWebAcl(
+    simAws.wafV2(),
+    simWafCreateWebAclFactory.make(),
+  );
+
+  return { stageArn: restApi.stageArn("prod"), webAclArn: webAcl.ARN };
+}
+
+describe("SimWafV2 association refusals", () => {
+  it("refuses a CLOUDFRONT scope web ACL", async () => {
+    // Given a stage and a CLOUDFRONT scope web ACL.
+    const simAws = new SimAws();
+    const { stageArn } = await stageAndWebAcl(simAws);
+    const webAcl = await createSimWafWebAcl(
+      simAws.wafV2(),
+      simWafCreateWebAclFactory.make({ Scope: "CLOUDFRONT" }),
+    );
+
+    // When it is associated with the stage.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.wafV2().associateWebAcl(
+        new AssociateWebACLCommand({
+          WebACLArn: webAcl.ARN,
+          ResourceArn: stageArn,
+        }),
+      );
+    });
+
+    // Then it is refused, because a distribution takes its own web ACL.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "CLOUDFRONT");
+  });
+
+  it("refuses a web ACL from another Region", async () => {
+    // Given a stage in one Region and a web ACL in another.
+    const simAws = new SimAws();
+    const { stageArn } = await stageAndWebAcl(simAws);
+    const elsewhere = await createSimWafWebAcl(
+      simAws.accountRegionScope(simAws.defaultAccountId, "eu-west-2").wafV2(),
+      simWafCreateWebAclFactory.make(),
+    );
+
+    // When the web ACL from elsewhere is associated with the stage.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.wafV2().associateWebAcl(
+        new AssociateWebACLCommand({
+          WebACLArn: elsewhere.ARN,
+          ResourceArn: stageArn,
+        }),
+      );
+    });
+
+    // Then it is refused before anything looks for it.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "eu-west-2");
+  });
+
+  it("refuses a web ACL from another Account", async () => {
+    // Given a stage in one Account and a web ACL in another.
+    const simAws = new SimAws();
+    const { stageArn } = await stageAndWebAcl(simAws);
+    const elsewhere = await createSimWafWebAcl(
+      simAws.accountRegionScope(accountIdTwoTwos, "us-east-1").wafV2(),
+      simWafCreateWebAclFactory.make(),
+    );
+
+    // When the other Account's web ACL is associated with the stage.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.wafV2().associateWebAcl(
+        new AssociateWebACLCommand({
+          WebACLArn: elsewhere.ARN,
+          ResourceArn: stageArn,
+        }),
+      );
+    });
+
+    // Then it is refused. A web ACL protects what is in its own Account.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, accountIdTwoTwos);
+  });
+
+  it("refuses a web ACL ARN that is not one", async () => {
+    // Given a stage.
+    const simAws = new SimAws();
+    const { stageArn } = await stageAndWebAcl(simAws);
+
+    // When something that is not a web ACL ARN is associated with it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.wafV2().associateWebAcl(
+        new AssociateWebACLCommand({
+          WebACLArn: "api-acl",
+          ResourceArn: stageArn,
+        }),
+      );
+    });
+
+    // Then it is refused as an ARN rather than as a missing web ACL.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "WEB_ACL_ARN");
+  });
+
+  it("refuses a web ACL that was never created", async () => {
+    // Given a stage and the ARN of a web ACL nothing holds.
+    const simAws = new SimAws();
+    const { stageArn, webAclArn } = await stageAndWebAcl(simAws);
+
+    // When an ARN in the right scope names no web ACL.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.wafV2().associateWebAcl(
+        new AssociateWebACLCommand({
+          WebACLArn: `${webAclArn}-gone`,
+          ResourceArn: stageArn,
+        }),
+      );
+    });
+
+    // Then it is refused as a resource that does not exist.
+    assertInstanceOf(error, SimWafNonexistentItemException);
+  });
+
+  it("refuses an API Gateway HTTP API stage", async () => {
+    // Given a web ACL and the ARN of an HTTP API stage.
+    const simAws = new SimAws();
+    const { webAclArn } = await stageAndWebAcl(simAws);
+
+    // When the HTTP API stage is associated with it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.wafV2().associateWebAcl(
+        new AssociateWebACLCommand({
+          WebACLArn: webAclArn,
+          ResourceArn:
+            "arn:aws:apigateway:us-east-1::/apis/abc123/stages/$default",
+        }),
+      );
+    });
+
+    // Then it is refused, naming HTTP APIs as outside what WAF protects.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "HTTP API");
+  });
+
+  it("refuses a resource type it does not simulate", async () => {
+    // Given a web ACL and the ARN of a load balancer.
+    const simAws = new SimAws();
+    const { webAclArn } = await stageAndWebAcl(simAws);
+
+    // When the load balancer is associated with it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.wafV2().associateWebAcl(
+        new AssociateWebACLCommand({
+          WebACLArn: webAclArn,
+          ResourceArn:
+            "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/orders/1",
+        }),
+      );
+    });
+
+    // Then it is refused as unsimulated rather than as an invalid ARN.
+    assertInstanceOf(error, SimWafUnsimulatedInputException);
+    assertStringIncludes(error.message, "Application Load Balancer");
+  });
+
+  it("refuses a resource ARN naming nothing WAF protects", async () => {
+    // Given a web ACL.
+    const simAws = new SimAws();
+    const { webAclArn } = await stageAndWebAcl(simAws);
+
+    // When something that is not a resource ARN is associated with it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.wafV2().associateWebAcl(
+        new AssociateWebACLCommand({
+          WebACLArn: webAclArn,
+          ResourceArn: "arn:aws:s3:::orders",
+        }),
+      );
+    });
+
+    // Then it is refused as an ARN.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "RESOURCE_ARN");
+  });
+
+  it("refuses an association naming no resource at all", async () => {
+    // Given a web ACL.
+    const simAws = new SimAws();
+    const { webAclArn } = await stageAndWebAcl(simAws);
+
+    // When the association names no resource.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.wafV2().associateWebAcl(
+        new AssociateWebACLCommand({
+          WebACLArn: webAclArn,
+          ResourceArn: undefined,
+        }),
+      );
+    });
+
+    // Then it is refused for the parameter it left out.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "ResourceArn");
+  });
+
+  it("refuses a stage in another Region", async () => {
+    // Given a web ACL and a stage ARN naming a different Region.
+    const simAws = new SimAws();
+    const { webAclArn } = await stageAndWebAcl(simAws);
+
+    // When the stage from elsewhere is associated with it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.wafV2().associateWebAcl(
+        new AssociateWebACLCommand({
+          WebACLArn: webAclArn,
+          ResourceArn:
+            "arn:aws:apigateway:eu-west-2::/restapis/abc/stages/prod",
+        }),
+      );
+    });
+
+    // Then it is refused for the Region it named.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "eu-west-2");
+  });
+
+  it("refuses a stage that is not there", async () => {
+    // Given a web ACL and an API with no such stage.
+    const simAws = new SimAws();
+    const { stageArn, webAclArn } = await stageAndWebAcl(simAws);
+
+    // When a stage name nothing was deployed under is associated with it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.wafV2().associateWebAcl(
+        new AssociateWebACLCommand({
+          WebACLArn: webAclArn,
+          ResourceArn: stageArn.replace("/prod", "/test"),
+        }),
+      );
+    });
+
+    // Then it is refused as a resource WAF cannot reach.
+    assertInstanceOf(error, SimWafUnavailableEntityException);
+  });
+
+  it("refuses reading the web ACL of a stage that is not there", async () => {
+    // Given an API with no such stage.
+    const simAws = new SimAws();
+    const { stageArn } = await stageAndWebAcl(simAws);
+
+    // When that stage's web ACL is asked for.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.wafV2().getWebAclForResource(
+        new GetWebACLForResourceCommand({
+          ResourceArn: stageArn.replace("/prod", "/test"),
+        }),
+      );
+    });
+
+    // Then it is refused rather than answering with nothing.
+    assertInstanceOf(error, SimWafUnavailableEntityException);
+  });
+
+  it("refuses a listing that names no resource type", async () => {
+    // Given a web ACL.
+    const simAws = new SimAws();
+    const { webAclArn } = await stageAndWebAcl(simAws);
+
+    // When its resources are listed without naming a type.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .wafV2()
+        .listResourcesForWebAcl(
+          new ListResourcesForWebACLCommand({ WebACLArn: webAclArn }),
+        );
+    });
+
+    // Then it is refused. Real WAFv2 defaults to load balancers, which are not
+    // simulated, so a listing that says nothing would answer with nothing.
+    assertInstanceOf(error, SimWafUnsimulatedInputException);
+    assertStringIncludes(error.message, "APPLICATION_LOAD_BALANCER");
+  });
+
+  it("has nothing to associate with when it stands on its own", async () => {
+    // Given a simulated WAFv2 with no simulated AWS around it.
+    const waf = new SimWafV2();
+    const webAcl = await createSimWafWebAcl(
+      waf,
+      simWafCreateWebAclFactory.make(),
+    );
+
+    // When a stage ARN is associated with its web ACL.
+    const error = await assertThrowsErrorAsync(async () => {
+      await waf.associateWebAcl(
+        new AssociateWebACLCommand({
+          WebACLArn: webAcl.ARN,
+          ResourceArn: `arn:aws:apigateway:${webAcl.ARN.split(":", 4)[3] ?? ""}::/restapis/abc/stages/prod`,
+        }),
+      );
+    });
+
+    // Then there is no such resource, because a standalone WAFv2 has no API
+    // Gateway to ask about one.
+    assertInstanceOf(error, SimWafUnavailableEntityException);
+  });
+});

--- a/src/service/wafv2/sim-wafv2-associations.iso.test.ts
+++ b/src/service/wafv2/sim-wafv2-associations.iso.test.ts
@@ -1,0 +1,250 @@
+import {
+  AssociateWebACLCommand,
+  DeleteWebACLCommand,
+  DisassociateWebACLCommand,
+  GetWebACLForResourceCommand,
+  ListResourcesForWebACLCommand,
+} from "@aws-sdk/client-wafv2";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { assertDefined } from "../../util/type-guard/defined.js";
+import type { SimRestApi } from "../apigateway/api/sim-rest-api.js";
+import { SimAws } from "../aws/sim-aws.js";
+import { simWafCreateWebAclFactory } from "./command/web-acl/sim-waf-create-web-acl.factory.js";
+import { SimWafAssociatedItemException } from "./error/sim-wafv2.error.js";
+import { createSimWafWebAcl } from "./sim-wafv2.fixture.js";
+
+/**
+ * A deployed REST API stage for a web ACL to be put in front of.
+ *
+ * The commands are the ordinary ones, because what the association needs from
+ * API Gateway is a stage that is really there.
+ */
+async function deployedRestApi(
+  simAws: SimAws,
+  stageName = "prod",
+): Promise<SimRestApi> {
+  const apiGateway = simAws.apiGateway();
+  const created = await apiGateway.createRestApi({ input: { name: "orders" } });
+
+  await apiGateway.createDeployment({
+    input: { restApiId: created.id, stageName },
+  });
+
+  const restApi = apiGateway.findRestApi(created.id);
+  assertDefined(restApi, `Simulated API Gateway lost the API ${created.id}`);
+
+  return restApi;
+}
+
+describe("SimWafV2 associations", () => {
+  it("puts a web ACL in front of a REST API stage and reads it back", async () => {
+    // Given a deployed stage and a REGIONAL web ACL.
+    const simAws = new SimAws();
+    const restApi = await deployedRestApi(simAws);
+    const waf = simAws.wafV2();
+    const webAcl = await createSimWafWebAcl(
+      waf,
+      simWafCreateWebAclFactory.make({ Name: "api-acl" }),
+    );
+
+    // When the web ACL is associated with the stage.
+    await waf.associateWebAcl(
+      new AssociateWebACLCommand({
+        WebACLArn: webAcl.ARN,
+        ResourceArn: restApi.stageArn("prod"),
+      }),
+    );
+    const read = await waf.getWebAclForResource(
+      new GetWebACLForResourceCommand({
+        ResourceArn: restApi.stageArn("prod"),
+      }),
+    );
+
+    // Then the stage reports the whole web ACL it now carries.
+    assertNonNullable(read.WebACL);
+    assertIdentical(read.WebACL.Name, "api-acl");
+    assertIdentical(read.WebACL.ARN, webAcl.ARN);
+  });
+
+  it("lists the resources one web ACL protects", async () => {
+    // Given one web ACL in front of two stages of an API.
+    const simAws = new SimAws();
+    const restApi = await deployedRestApi(simAws);
+    await simAws.apiGateway().createDeployment({
+      input: { restApiId: restApi.apiId, stageName: "test" },
+    });
+    const waf = simAws.wafV2();
+    const webAcl = await createSimWafWebAcl(
+      waf,
+      simWafCreateWebAclFactory.make(),
+    );
+
+    await waf.associateWebAcl(
+      new AssociateWebACLCommand({
+        WebACLArn: webAcl.ARN,
+        ResourceArn: restApi.stageArn("prod"),
+      }),
+    );
+    await waf.associateWebAcl(
+      new AssociateWebACLCommand({
+        WebACLArn: webAcl.ARN,
+        ResourceArn: restApi.stageArn("test"),
+      }),
+    );
+
+    // When the resources it protects are listed.
+    const listed = await waf.listResourcesForWebAcl(
+      new ListResourcesForWebACLCommand({
+        WebACLArn: webAcl.ARN,
+        ResourceType: "API_GATEWAY",
+      }),
+    );
+
+    // Then both stages are named, in the order they were associated.
+    assertArrayEquals(listed.ResourceArns, [
+      restApi.stageArn("prod"),
+      restApi.stageArn("test"),
+    ]);
+  });
+
+  it("reports no web ACL for a stage nothing is in front of", async () => {
+    // Given a deployed stage no web ACL was associated with.
+    const simAws = new SimAws();
+    const restApi = await deployedRestApi(simAws);
+
+    // When the stage's web ACL is asked for.
+    const read = await simAws.wafV2().getWebAclForResource(
+      new GetWebACLForResourceCommand({
+        ResourceArn: restApi.stageArn("prod"),
+      }),
+    );
+
+    // Then nothing comes back, rather than an error.
+    assertUndefined(read.WebACL);
+  });
+
+  it("takes a web ACL back off a stage", async () => {
+    // Given a stage a web ACL is in front of.
+    const simAws = new SimAws();
+    const restApi = await deployedRestApi(simAws);
+    const waf = simAws.wafV2();
+    const webAcl = await createSimWafWebAcl(
+      waf,
+      simWafCreateWebAclFactory.make(),
+    );
+    await waf.associateWebAcl(
+      new AssociateWebACLCommand({
+        WebACLArn: webAcl.ARN,
+        ResourceArn: restApi.stageArn("prod"),
+      }),
+    );
+
+    // When it is disassociated.
+    await waf.disassociateWebAcl(
+      new DisassociateWebACLCommand({
+        ResourceArn: restApi.stageArn("prod"),
+      }),
+    );
+    const read = await waf.getWebAclForResource(
+      new GetWebACLForResourceCommand({
+        ResourceArn: restApi.stageArn("prod"),
+      }),
+    );
+    const listed = await waf.listResourcesForWebAcl(
+      new ListResourcesForWebACLCommand({
+        WebACLArn: webAcl.ARN,
+        ResourceType: "API_GATEWAY",
+      }),
+    );
+
+    // Then the stage carries nothing and the web ACL protects nothing.
+    assertUndefined(read.WebACL);
+    assertArrayEquals(listed.ResourceArns, []);
+  });
+
+  it("moves a stage from one web ACL to another", async () => {
+    // Given a stage a first web ACL is in front of.
+    const simAws = new SimAws();
+    const restApi = await deployedRestApi(simAws);
+    const waf = simAws.wafV2();
+    const first = await createSimWafWebAcl(
+      waf,
+      simWafCreateWebAclFactory.make({ Name: "first-acl" }),
+    );
+    const second = await createSimWafWebAcl(
+      waf,
+      simWafCreateWebAclFactory.make({ Name: "second-acl" }),
+    );
+    const stageArn = restApi.stageArn("prod");
+
+    // When a second web ACL is associated with the same stage.
+    await waf.associateWebAcl(
+      new AssociateWebACLCommand({
+        WebACLArn: first.ARN,
+        ResourceArn: stageArn,
+      }),
+    );
+    await waf.associateWebAcl(
+      new AssociateWebACLCommand({
+        WebACLArn: second.ARN,
+        ResourceArn: stageArn,
+      }),
+    );
+
+    const read = await waf.getWebAclForResource(
+      new GetWebACLForResourceCommand({ ResourceArn: stageArn }),
+    );
+    const listedFirst = await waf.listResourcesForWebAcl(
+      new ListResourcesForWebACLCommand({
+        WebACLArn: first.ARN,
+        ResourceType: "API_GATEWAY",
+      }),
+    );
+
+    // Then the stage carries the second one, and the first is in front of
+    // nothing. A resource has one web ACL, so the second replaces the first.
+    assertIdentical(read.WebACL?.Name, "second-acl");
+    assertArrayEquals(listedFirst.ResourceArns, []);
+  });
+
+  it("refuses to delete a web ACL that is in front of a stage", async () => {
+    // Given a web ACL protecting a stage.
+    const simAws = new SimAws();
+    const restApi = await deployedRestApi(simAws);
+    const waf = simAws.wafV2();
+    const input = simWafCreateWebAclFactory.make();
+    const webAcl = await createSimWafWebAcl(waf, input);
+    await waf.associateWebAcl(
+      new AssociateWebACLCommand({
+        WebACLArn: webAcl.ARN,
+        ResourceArn: restApi.stageArn("prod"),
+      }),
+    );
+
+    // When the web ACL is deleted.
+    const error = await assertThrowsErrorAsync(async () => {
+      await waf.deleteWebAcl(
+        new DeleteWebACLCommand({
+          Name: input.Name,
+          Scope: "REGIONAL",
+          Id: webAcl.Id,
+          LockToken: webAcl.LockToken,
+        }),
+      );
+    });
+
+    // Then it is refused, naming the stage still pointing at it.
+    assertInstanceOf(error, SimWafAssociatedItemException);
+    assertStringIncludes(error.message, restApi.stageArn("prod"));
+  });
+});

--- a/src/service/wafv2/sim-wafv2-commands.ts
+++ b/src/service/wafv2/sim-wafv2-commands.ts
@@ -8,6 +8,13 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimWafAssociations } from "./association/sim-waf-associations.js";
+import {
+  SimWafNoProtectedResources,
+  type SimWafProtectedResources,
+} from "./association/sim-waf-protected-resources.js";
+import { SimWafAssociationAccess } from "./command/association/sim-wafv2-association-access.js";
+import { SimWafAssociationCommands } from "./command/association/sim-wafv2-association-commands.js";
 import { SimWafAuthorizer } from "./command/authorize/sim-wafv2-authorizer.js";
 import { SimWafIpSetCommands } from "./command/ip-set/sim-wafv2-ip-set-commands.js";
 import { SimWafRegexPatternSetCommands } from "./command/regex-pattern-set/sim-wafv2-regex-pattern-set-commands.js";
@@ -21,6 +28,12 @@ export interface SimWafV2Properties {
   readonly accountRegionScope?: SimAwsAccountRegionScope;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
+  /**
+   * The resources this WAFv2 can put a web ACL in front of. A standalone
+   * simulated WAFv2 has none, so an association names a resource that is not
+   * there rather than protecting something imaginary.
+   */
+  readonly protectedResources?: SimWafProtectedResources;
 }
 
 /**
@@ -38,7 +51,16 @@ export class SimWafCommands {
     "regex pattern set",
   );
 
+  /**
+   * The web ACLs this scope has in front of things.
+   *
+   * Held here rather than in the association commands because a served request
+   * reaches it without a Command, the way a fronting service reaches AWS WAF.
+   */
+  readonly associations = new SimWafAssociations();
+
   readonly webAclCommands: SimWafWebAclCommands;
+  readonly associationCommands: SimWafAssociationCommands;
   readonly ipSetCommands: SimWafIpSetCommands;
   readonly regexPatternSetCommands: SimWafRegexPatternSetCommands;
   readonly background: BackgroundScheduler;
@@ -48,6 +70,7 @@ export class SimWafCommands {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
       iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
+      protectedResources = new SimWafNoProtectedResources(),
     } = properties;
 
     const authorizer = new SimWafAuthorizer({ iam });
@@ -56,8 +79,18 @@ export class SimWafCommands {
     this.webAclCommands = new SimWafWebAclCommands({
       webAcls: this.webAcls,
       regexPatternSets: this.regexPatternSets,
+      associations: this.associations,
       authorizer,
       accountRegionScope,
+    });
+    this.associationCommands = new SimWafAssociationCommands({
+      associations: this.associations,
+      access: new SimWafAssociationAccess({
+        webAcls: this.webAcls,
+        protectedResources,
+        authorizer,
+        accountRegionScope,
+      }),
     });
     this.ipSetCommands = new SimWafIpSetCommands({
       ipSets: this.ipSets,

--- a/src/service/wafv2/sim-wafv2-sets.ts
+++ b/src/service/wafv2/sim-wafv2-sets.ts
@@ -1,0 +1,145 @@
+import type * as simWafCommands from "./command/sim-wafv2-command.types.js";
+import type { SimWafRequestOptions } from "./command/sim-wafv2-request-options.js";
+import type { SimWafCommands } from "./sim-wafv2-commands.js";
+
+/**
+ * The commands addressing the sets a web ACL's rules refer to, which are IP
+ * sets and regex pattern sets.
+ *
+ * `SimWafV2` extends this, so a caller reaches every operation on the one
+ * service object the way the real API presents them. They are split off
+ * because web ACLs, the sets beside them and association are separate
+ * concerns, and the facade grows by one method for every operation added.
+ */
+export abstract class SimWafSets {
+  protected readonly commands: SimWafCommands;
+
+  protected constructor(commands: SimWafCommands) {
+    this.commands = commands;
+  }
+
+  /**
+   * Handle a CreateIPSet Command from the SDK.
+   */
+  async createIpSet(
+    command: simWafCommands.SimCreateIpSetCommand,
+    options?: SimWafRequestOptions,
+  ): Promise<simWafCommands.SimCreateIpSetCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.ipSetCommands.createIpSet(command, options);
+  }
+
+  /**
+   * Handle a GetIPSet Command from the SDK.
+   */
+  async getIpSet(
+    command: simWafCommands.SimGetIpSetCommand,
+    options?: SimWafRequestOptions,
+  ): Promise<simWafCommands.SimGetIpSetCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.ipSetCommands.getIpSet(command, options);
+  }
+
+  /**
+   * Handle an UpdateIPSet Command from the SDK.
+   */
+  async updateIpSet(
+    command: simWafCommands.SimUpdateIpSetCommand,
+    options?: SimWafRequestOptions,
+  ): Promise<simWafCommands.SimUpdateIpSetCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.ipSetCommands.updateIpSet(command, options);
+  }
+
+  /**
+   * Handle a ListIPSets Command from the SDK.
+   */
+  async listIpSets(
+    command: simWafCommands.SimListIpSetsCommand,
+    options?: SimWafRequestOptions,
+  ): Promise<simWafCommands.SimListIpSetsCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.ipSetCommands.listIpSets(command, options);
+  }
+
+  /**
+   * Handle a DeleteIPSet Command from the SDK.
+   */
+  async deleteIpSet(
+    command: simWafCommands.SimDeleteIpSetCommand,
+    options?: SimWafRequestOptions,
+  ): Promise<simWafCommands.SimDeleteIpSetCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.ipSetCommands.deleteIpSet(command, options);
+  }
+
+  /**
+   * Handle a CreateRegexPatternSet Command from the SDK.
+   */
+  async createRegexPatternSet(
+    command: simWafCommands.SimCreateRegexPatternSetCommand,
+    options?: SimWafRequestOptions,
+  ): Promise<simWafCommands.SimCreateRegexPatternSetCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.regexPatternSetCommands.createRegexPatternSet(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Handle a GetRegexPatternSet Command from the SDK.
+   */
+  async getRegexPatternSet(
+    command: simWafCommands.SimGetRegexPatternSetCommand,
+    options?: SimWafRequestOptions,
+  ): Promise<simWafCommands.SimGetRegexPatternSetCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.regexPatternSetCommands.getRegexPatternSet(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Handle an UpdateRegexPatternSet Command from the SDK.
+   */
+  async updateRegexPatternSet(
+    command: simWafCommands.SimUpdateRegexPatternSetCommand,
+    options?: SimWafRequestOptions,
+  ): Promise<simWafCommands.SimUpdateRegexPatternSetCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.regexPatternSetCommands.updateRegexPatternSet(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Handle a ListRegexPatternSets Command from the SDK.
+   */
+  async listRegexPatternSets(
+    command: simWafCommands.SimListRegexPatternSetsCommand,
+    options?: SimWafRequestOptions,
+  ): Promise<simWafCommands.SimListRegexPatternSetsCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.regexPatternSetCommands.listRegexPatternSets(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Handle a DeleteRegexPatternSet Command from the SDK.
+   */
+  async deleteRegexPatternSet(
+    command: simWafCommands.SimDeleteRegexPatternSetCommand,
+    options?: SimWafRequestOptions,
+  ): Promise<simWafCommands.SimDeleteRegexPatternSetCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.regexPatternSetCommands.deleteRegexPatternSet(
+      command,
+      options,
+    );
+  }
+}

--- a/src/service/wafv2/sim-wafv2.ts
+++ b/src/service/wafv2/sim-wafv2.ts
@@ -1,4 +1,5 @@
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
+import type { SimWafProtection } from "./association/sim-waf-protection.js";
 import type * as simWafCommands from "./command/sim-wafv2-command.types.js";
 import type { SimWafRequestOptions } from "./command/sim-wafv2-request-options.js";
 import { SimWafNonexistentItemException } from "./error/sim-wafv2.error.js";
@@ -10,6 +11,7 @@ import {
   SimWafCommands,
   type SimWafV2Properties,
 } from "./sim-wafv2-commands.js";
+import { SimWafSets } from "./sim-wafv2-sets.js";
 import type { SimWafWebAcl } from "./web-acl/sim-waf-web-acl.js";
 
 /**
@@ -32,22 +34,32 @@ export interface SimWafEvaluationRequest {
  * Simulated AWS WAFv2. Handles SDK commands. Emulates AWS behaviour and state.
  *
  * A web ACL is a list of rules and a decision about the requests none of them
- * claims, and `evaluateRequest` is what that adds up to. Association with a
- * CloudFront distribution, an API Gateway stage or a Cognito user pool comes
- * separately: this holds the rules and reaches the verdict, and the fronting
- * services will ask it for one.
+ * claims, and `evaluateRequest` is what that adds up to. `AssociateWebACL`
+ * puts one in front of an API Gateway REST API stage, and the stage then asks
+ * for that decision itself on every request it serves.
  *
  * Resources are scoped to an Account and Region, and within that to
  * `CLOUDFRONT` or `REGIONAL`. The two scopes are separate namespaces rather
  * than a label, and `CLOUDFRONT` lives in `us-east-1` because CloudFront is
  * global and its web ACLs are held there.
  */
-export class SimWafV2 {
-  readonly #commands: SimWafCommands;
+export class SimWafV2 extends SimWafSets {
   readonly #sdkRouter = new SimWafSdkCommandRouter(this);
 
   constructor(properties: SimWafV2Properties = {}) {
-    this.#commands = new SimWafCommands(properties);
+    super(new SimWafCommands(properties));
+  }
+
+  /**
+   * The web ACLs this WAFv2 has in front of things, as a fronting service sees
+   * them.
+   *
+   * The simulator's own accessor rather than a WAFv2 operation. It is how a
+   * simulated API Gateway reaches the web ACL protecting a stage it is about
+   * to serve, and how it lets go of one when the stage is deleted.
+   */
+  protection(): SimWafProtection {
+    return this.commands.associations;
   }
 
   /**
@@ -57,7 +69,7 @@ export class SimWafV2 {
    * going through a Command and its authorization.
    */
   allWebAcls(scope: SimWafScope): readonly SimWafWebAcl[] {
-    return this.#commands.webAcls.all(scope);
+    return this.commands.webAcls.all(scope);
   }
 
   /**
@@ -67,7 +79,7 @@ export class SimWafV2 {
    * since an association carries the ARN and nothing else.
    */
   findWebAclByArn(webAclArn: string): SimWafWebAcl | undefined {
-    return this.#commands.webAcls.findByArn(webAclArn);
+    return this.commands.webAcls.findByArn(webAclArn);
   }
 
   /**
@@ -101,8 +113,8 @@ export class SimWafV2 {
     command: simWafCommands.SimCreateWebAclCommand,
     options?: SimWafRequestOptions,
   ): Promise<simWafCommands.SimCreateWebAclCommandOutput> {
-    await this.#commands.background.sequence();
-    return this.#commands.webAclCommands.createWebAcl(command, options);
+    await this.commands.background.sequence();
+    return this.commands.webAclCommands.createWebAcl(command, options);
   }
 
   /**
@@ -112,8 +124,8 @@ export class SimWafV2 {
     command: simWafCommands.SimGetWebAclCommand,
     options?: SimWafRequestOptions,
   ): Promise<simWafCommands.SimGetWebAclCommandOutput> {
-    await this.#commands.background.sequence();
-    return this.#commands.webAclCommands.getWebAcl(command, options);
+    await this.commands.background.sequence();
+    return this.commands.webAclCommands.getWebAcl(command, options);
   }
 
   /**
@@ -123,8 +135,8 @@ export class SimWafV2 {
     command: simWafCommands.SimUpdateWebAclCommand,
     options?: SimWafRequestOptions,
   ): Promise<simWafCommands.SimUpdateWebAclCommandOutput> {
-    await this.#commands.background.sequence();
-    return this.#commands.webAclCommands.updateWebAcl(command, options);
+    await this.commands.background.sequence();
+    return this.commands.webAclCommands.updateWebAcl(command, options);
   }
 
   /**
@@ -134,8 +146,8 @@ export class SimWafV2 {
     command: simWafCommands.SimListWebAclsCommand,
     options?: SimWafRequestOptions,
   ): Promise<simWafCommands.SimListWebAclsCommandOutput> {
-    await this.#commands.background.sequence();
-    return this.#commands.webAclCommands.listWebAcls(command, options);
+    await this.commands.background.sequence();
+    return this.commands.webAclCommands.listWebAcls(command, options);
   }
 
   /**
@@ -145,130 +157,58 @@ export class SimWafV2 {
     command: simWafCommands.SimDeleteWebAclCommand,
     options?: SimWafRequestOptions,
   ): Promise<simWafCommands.SimDeleteWebAclCommandOutput> {
-    await this.#commands.background.sequence();
-    return this.#commands.webAclCommands.deleteWebAcl(command, options);
+    await this.commands.background.sequence();
+    return this.commands.webAclCommands.deleteWebAcl(command, options);
   }
 
   /**
-   * Handle a CreateIPSet Command from the SDK.
+   * Handle an AssociateWebACL Command from the SDK.
    */
-  async createIpSet(
-    command: simWafCommands.SimCreateIpSetCommand,
+  async associateWebAcl(
+    command: simWafCommands.SimAssociateWebAclCommand,
     options?: SimWafRequestOptions,
-  ): Promise<simWafCommands.SimCreateIpSetCommandOutput> {
-    await this.#commands.background.sequence();
-    return this.#commands.ipSetCommands.createIpSet(command, options);
+  ): Promise<simWafCommands.SimAssociateWebAclCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.associationCommands.associateWebAcl(command, options);
   }
 
   /**
-   * Handle a GetIPSet Command from the SDK.
+   * Handle a DisassociateWebACL Command from the SDK.
    */
-  async getIpSet(
-    command: simWafCommands.SimGetIpSetCommand,
+  async disassociateWebAcl(
+    command: simWafCommands.SimDisassociateWebAclCommand,
     options?: SimWafRequestOptions,
-  ): Promise<simWafCommands.SimGetIpSetCommandOutput> {
-    await this.#commands.background.sequence();
-    return this.#commands.ipSetCommands.getIpSet(command, options);
-  }
-
-  /**
-   * Handle an UpdateIPSet Command from the SDK.
-   */
-  async updateIpSet(
-    command: simWafCommands.SimUpdateIpSetCommand,
-    options?: SimWafRequestOptions,
-  ): Promise<simWafCommands.SimUpdateIpSetCommandOutput> {
-    await this.#commands.background.sequence();
-    return this.#commands.ipSetCommands.updateIpSet(command, options);
-  }
-
-  /**
-   * Handle a ListIPSets Command from the SDK.
-   */
-  async listIpSets(
-    command: simWafCommands.SimListIpSetsCommand,
-    options?: SimWafRequestOptions,
-  ): Promise<simWafCommands.SimListIpSetsCommandOutput> {
-    await this.#commands.background.sequence();
-    return this.#commands.ipSetCommands.listIpSets(command, options);
-  }
-
-  /**
-   * Handle a DeleteIPSet Command from the SDK.
-   */
-  async deleteIpSet(
-    command: simWafCommands.SimDeleteIpSetCommand,
-    options?: SimWafRequestOptions,
-  ): Promise<simWafCommands.SimDeleteIpSetCommandOutput> {
-    await this.#commands.background.sequence();
-    return this.#commands.ipSetCommands.deleteIpSet(command, options);
-  }
-
-  /**
-   * Handle a CreateRegexPatternSet Command from the SDK.
-   */
-  async createRegexPatternSet(
-    command: simWafCommands.SimCreateRegexPatternSetCommand,
-    options?: SimWafRequestOptions,
-  ): Promise<simWafCommands.SimCreateRegexPatternSetCommandOutput> {
-    await this.#commands.background.sequence();
-    return this.#commands.regexPatternSetCommands.createRegexPatternSet(
+  ): Promise<simWafCommands.SimDisassociateWebAclCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.associationCommands.disassociateWebAcl(
       command,
       options,
     );
   }
 
   /**
-   * Handle a GetRegexPatternSet Command from the SDK.
+   * Handle a GetWebACLForResource Command from the SDK.
    */
-  async getRegexPatternSet(
-    command: simWafCommands.SimGetRegexPatternSetCommand,
+  async getWebAclForResource(
+    command: simWafCommands.SimGetWebAclForResourceCommand,
     options?: SimWafRequestOptions,
-  ): Promise<simWafCommands.SimGetRegexPatternSetCommandOutput> {
-    await this.#commands.background.sequence();
-    return this.#commands.regexPatternSetCommands.getRegexPatternSet(
+  ): Promise<simWafCommands.SimGetWebAclForResourceCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.associationCommands.getWebAclForResource(
       command,
       options,
     );
   }
 
   /**
-   * Handle an UpdateRegexPatternSet Command from the SDK.
+   * Handle a ListResourcesForWebACL Command from the SDK.
    */
-  async updateRegexPatternSet(
-    command: simWafCommands.SimUpdateRegexPatternSetCommand,
+  async listResourcesForWebAcl(
+    command: simWafCommands.SimListResourcesForWebAclCommand,
     options?: SimWafRequestOptions,
-  ): Promise<simWafCommands.SimUpdateRegexPatternSetCommandOutput> {
-    await this.#commands.background.sequence();
-    return this.#commands.regexPatternSetCommands.updateRegexPatternSet(
-      command,
-      options,
-    );
-  }
-
-  /**
-   * Handle a ListRegexPatternSets Command from the SDK.
-   */
-  async listRegexPatternSets(
-    command: simWafCommands.SimListRegexPatternSetsCommand,
-    options?: SimWafRequestOptions,
-  ): Promise<simWafCommands.SimListRegexPatternSetsCommandOutput> {
-    await this.#commands.background.sequence();
-    return this.#commands.regexPatternSetCommands.listRegexPatternSets(
-      command,
-      options,
-    );
-  }
-
-  /**
-   * Handle a DeleteRegexPatternSet Command from the SDK.
-   */
-  async deleteRegexPatternSet(
-    command: simWafCommands.SimDeleteRegexPatternSetCommand,
-    options?: SimWafRequestOptions,
-  ): Promise<simWafCommands.SimDeleteRegexPatternSetCommandOutput> {
-    await this.#commands.background.sequence();
-    return this.#commands.regexPatternSetCommands.deleteRegexPatternSet(
+  ): Promise<simWafCommands.SimListResourcesForWebAclCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.associationCommands.listResourcesForWebAcl(
       command,
       options,
     );


### PR DESCRIPTION
`AssociateWebACL`, `DisassociateWebACL`, `GetWebACLForResource` and `ListResourcesForWebACL` work against a simulated API Gateway REST API stage, named by an ARN of the form `arn:aws:apigateway:<region>::/restapis/<api-id>/stages/<stage-name>`. The stage puts every request through its web ACL before it matches the method and before any authorizer runs, which is the order real API Gateway evaluates in, so a blocked request gets 403 with WAF's body and reaches neither the authorizer nor the integration. A `CLOUDFRONT` scope web ACL is refused, and so is one from another Account or Region. An HTTP API stage is refused with a reason naming HTTP APIs as outside what AWS WAF protects. Deleting a stage or an API lets go of the web ACL that was in front of it, and a web ACL still in front of a stage cannot be deleted.

Resolves https://github.com/KensioSoftware/yulin/issues/811
