### PR TITLE
feat: put a web ACL in front of a user pool

### DIFF
--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -2019,10 +2019,10 @@ that only the matching `code_verifier` exchanges. `plain` is refused, as it is b
 
 ### Putting a web ACL in front of the domain
 
-`AssociateWebACL` on simulated WAFv2 attaches a `REGIONAL` web ACL to a pool by its ARN, and every
-request the pool answers over HTTP is then evaluated against it. A blocked request gets 403 and the
-endpoint behind it never runs. A blocked sign-up creates no user. The two `.well-known` documents
-are covered along with the hosted domain pages. See
+`AssociateWebACL` on simulated WAFv2 attaches a `REGIONAL` web ACL to a pool by its ARN, and the
+pool's endpoints are then evaluated against it. A blocked request gets 403 and the endpoint behind
+it never runs. A blocked sign-up creates no user. The two `.well-known` documents are covered along
+with the hosted domain pages, and the `/<pool-id>/messages` listing is left outside. See
 [protecting a Cognito user pool](../wafv2/README.md#protecting-a-cognito-user-pool) for the whole
 example, including the request body that Cognito withholds from AWS WAF at a hosted domain.
 

--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -2017,6 +2017,15 @@ out here is still signed in at Google.
 An authorize request carrying a `code_challenge` and a `code_challenge_method` of `S256` gets a code
 that only the matching `code_verifier` exchanges. `plain` is refused, as it is by real Cognito.
 
+### Putting a web ACL in front of the domain
+
+`AssociateWebACL` on simulated WAFv2 attaches a `REGIONAL` web ACL to a pool by its ARN, and every
+request the pool answers over HTTP is then evaluated against it. A blocked request gets 403 and the
+endpoint behind it never runs. A blocked sign-up creates no user. The two `.well-known` documents
+are covered along with the hosted domain pages. See
+[protecting a Cognito user pool](../wafv2/README.md#protecting-a-cognito-user-pool) for the whole
+example, including the request body that Cognito withholds from AWS WAF at a hosted domain.
+
 ## Lambda triggers
 
 A pool created with a `LambdaConfig` runs the functions it names as part of a sign-up, a sign-in or
@@ -3968,6 +3977,8 @@ Sim Cognito currently supports:
 - The pool user a federated sign-in creates, named `<ProviderName>_<subject>`, in the
   `EXTERNAL_PROVIDER` status, carrying the `identities` attribute and claim and the attributes the
   provider's `AttributeMapping` named
+- A `REGIONAL` web ACL in front of the pool, attached by `AssociateWebACL` on simulated WAFv2 and
+  evaluated against every request the hosted domain and the two `.well-known` documents answer
 - App client OAuth settings: `AllowedOAuthFlowsUserPoolClient`, `AllowedOAuthFlows`,
   `AllowedOAuthScopes`, `CallbackURLs`, `LogoutURLs`, `DefaultRedirectURI` and
   `SupportedIdentityProviders`, each of which an authorize or token request is checked against
@@ -4269,6 +4280,13 @@ Current documented limitations:
   form, and they start a reset rather than finishing one an administrator forced.
 - The implicit grant is refused, and so is the client credentials grant, which needs resource
   servers.
+- A web ACL in front of a pool sees the endpoints this simulation serves and no others. The
+  user-interactive endpoints real Cognito also has at `/login`, `/resendcode`, `/confirmUser` and
+  `/passkeys/add` are unserved here, so a rule written for one of them is never reached. The
+  `/<pool-id>/messages` listing is outside the web ACL, because real Cognito serves nothing there.
+- The public user pool API operations reached over the SDK, `SignUp` and `InitiateAuth` among them,
+  are evaluated against no web ACL. Real WAF inspects them, including their bodies. They arrive here
+  as SDK Commands and carry no HTTP request for a rule to read.
 - The served OpenID configuration names its `authorization_endpoint`, `token_endpoint` and
   `end_session_endpoint` once the pool has a domain, at that domain's local hostname. It carries no
   `userinfo_endpoint`, where real Cognito names one.

--- a/docs/services/wafv2/README.md
+++ b/docs/services/wafv2/README.md
@@ -7,8 +7,8 @@ and without a distribution in front of anything.
 
 A web ACL can also go in front of what serves the requests. A simulated API Gateway REST API stage
 and a simulated Cognito user pool each take one through `AssociateWebACL`, and a simulated
-CloudFront distribution takes one through its own `WebACLId`. Every request they serve is then put
-through the web ACL's rules.
+CloudFront distribution takes one through its own `WebACLId`. The requests that stage, pool or
+distribution serves are then put through the web ACL's rules.
 
 WAFv2 specific types are imported from the `@kensio/yulin/wafv2` subpath.
 
@@ -605,12 +605,14 @@ what it would have protected.
 ARN. That ARN takes the form `arn:aws:cognito-idp:<region>:<account>:userpool/<pool-id>`, and
 `SimCognitoIdentityProvider.userPool(id).arn.value` is where to read it from.
 
-Every request the pool answers over HTTP then goes through the web ACL before the endpoint behind it
-runs. That covers the hosted domain (the authorize and token endpoints, `/logout`, and the managed
-login pages at `/signup`, `/confirm`, `/forgotPassword` and `/confirmForgotPassword`) along with the
-two documents the pool publishes at `/<pool-id>/.well-known/jwks.json` and
-`/<pool-id>/.well-known/openid-configuration`. A blocked request gets 403 with WAF's body. A blocked
-sign-up creates no user and records no message.
+The pool's endpoints then go through the web ACL before the one a request named runs. Those are the
+hosted domain (the authorize and token endpoints, `/logout`, and the managed login pages at
+`/signup`, `/confirm`, `/forgotPassword` and `/confirmForgotPassword`) and the two documents the
+pool publishes at `/<pool-id>/.well-known/jwks.json` and
+`/<pool-id>/.well-known/openid-configuration`. The `/<pool-id>/messages` listing is Yulin's own and
+sits outside the web ACL, as [below](#the-request-body-is-withheld-at-a-hosted-domain) says. A
+blocked request gets 403 with WAF's body, whatever method it used. A blocked sign-up creates no user
+and records no message.
 
 The pages are usually the point. `/signup`, `/confirm` and `/forgotPassword` are the ones that
 create an account or send an email, and a real web ACL on a user pool is usually written for them.
@@ -747,9 +749,9 @@ reach Yulin as SDK Commands and carry no HTTP request for a rule to read. No web
 for them at all. A test covering an API operation should reach for
 [`evaluateRequest`](#deciding-what-happens-to-a-request) with a request of its own.
 
-Two more paths are outside what the web ACL sees. `/<pool-id>/messages` is Yulin's own listing of
-the messages a pool would have sent, and real Cognito has no such endpoint. Managed login branding
-and its assets are outside the simulation.
+Two paths are outside what the web ACL sees. `/<pool-id>/messages` is Yulin's own listing of the
+messages a pool would have sent, and real Cognito has no such endpoint. Managed login branding and
+its assets are outside the simulation.
 
 ## Protecting a CloudFront distribution
 

--- a/docs/services/wafv2/README.md
+++ b/docs/services/wafv2/README.md
@@ -6,9 +6,9 @@ can assert that a request to `/admin` is blocked and one to `/` is allowed, with
 and without a distribution in front of anything.
 
 A web ACL can also go in front of what serves the requests. A simulated API Gateway REST API stage
-takes one through `AssociateWebACL`, and a simulated CloudFront distribution takes one through its
-own `WebACLId`. Every request that stage or distribution serves is then put through the web ACL's
-rules. Cognito user pools arrive later.
+and a simulated Cognito user pool each take one through `AssociateWebACL`, and a simulated
+CloudFront distribution takes one through its own `WebACLId`. Every request they serve is then put
+through the web ACL's rules.
 
 WAFv2 specific types are imported from the `@kensio/yulin/wafv2` subpath.
 
@@ -598,6 +598,158 @@ An API Gateway HTTP API stage is refused. AWS WAF has no resource type for one, 
 accepted here would let a test cover protection AWS never applies. Application Load Balancer,
 AppSync, App Runner, Amplify and Verified Access resources are refused as unsimulated, each naming
 what it would have protected.
+
+## Protecting a Cognito user pool
+
+`AssociateWebACL` puts a `REGIONAL` web ACL in front of a simulated user pool, named by the pool's
+ARN. That ARN takes the form `arn:aws:cognito-idp:<region>:<account>:userpool/<pool-id>`, and
+`SimCognitoIdentityProvider.userPool(id).arn.value` is where to read it from.
+
+Every request the pool answers over HTTP then goes through the web ACL before the endpoint behind it
+runs. That covers the hosted domain (the authorize and token endpoints, `/logout`, and the managed
+login pages at `/signup`, `/confirm`, `/forgotPassword` and `/confirmForgotPassword`) along with the
+two documents the pool publishes at `/<pool-id>/.well-known/jwks.json` and
+`/<pool-id>/.well-known/openid-configuration`. A blocked request gets 403 with WAF's body. A blocked
+sign-up creates no user and records no message.
+
+The pages are usually the point. `/signup`, `/confirm` and `/forgotPassword` are the ones that
+create an account or send an email, and a real web ACL on a user pool is usually written for them.
+
+```typescript sim-wafv2-cognito-user-pool
+/**
+ * Blocking a request to a pool's hosted domain with a web ACL in front of it.
+ */
+
+import {
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  CreateUserPoolDomainCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  AssociateWebACLCommand,
+  CreateWebACLCommand,
+} from "@aws-sdk/client-wafv2";
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+const cognito = simAws.cognitoIdentityProvider();
+const waf = simAws.wafV2();
+
+const created = await cognito.createUserPool(
+  new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+);
+const userPoolId = created.UserPool!.Id!;
+
+await cognito.createUserPoolDomain(
+  new CreateUserPoolDomainCommand({
+    UserPoolId: userPoolId,
+    Domain: "myapp-login",
+  }),
+);
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: userPoolId,
+    ClientName: "web",
+    AllowedOAuthFlowsUserPoolClient: true,
+    AllowedOAuthFlows: ["code"],
+    AllowedOAuthScopes: ["openid"],
+    CallbackURLs: ["https://www.example.com/user/callback"],
+    SupportedIdentityProviders: ["COGNITO"],
+  }),
+);
+
+const visibility = {
+  SampledRequestsEnabled: false,
+  CloudWatchMetricsEnabled: false,
+  MetricName: "pool",
+};
+
+const webAcl = await waf.createWebAcl(
+  new CreateWebACLCommand({
+    Name: "pool-acl",
+    Scope: "REGIONAL",
+    DefaultAction: { Allow: {} },
+    VisibilityConfig: visibility,
+    Rules: [
+      {
+        Name: "block-scraper",
+        Priority: 0,
+        Action: { Block: {} },
+        Statement: {
+          ByteMatchStatement: {
+            FieldToMatch: { SingleHeader: { Name: "user-agent" } },
+            PositionalConstraint: "CONTAINS",
+            SearchString: Buffer.from("scraper"),
+            TextTransformations: [{ Priority: 0, Type: "NONE" }],
+          },
+        },
+        VisibilityConfig: { ...visibility, MetricName: "block-scraper" },
+      },
+    ],
+  }),
+);
+
+await waf.associateWebAcl(
+  new AssociateWebACLCommand({
+    WebACLArn: webAcl.Summary?.ARN,
+    ResourceArn: cognito.userPool(userPoolId).arn.value,
+  }),
+);
+
+const srv = await serveSimAws({ simAws });
+const parameters = new URLSearchParams({
+  response_type: "code",
+  client_id: appClient.UserPoolClient!.ClientId!,
+  redirect_uri: "https://www.example.com/user/callback",
+  scope: "openid",
+});
+const signInUrl = srv.localUrl(
+  `https://myapp-login.auth.eu-west-2.amazoncognito.com/oauth2/authorize?${parameters.toString()}`,
+);
+
+const blocked = await fetch(signInUrl, {
+  headers: { "user-agent": "scraper/1.0" },
+});
+const allowed = await fetch(signInUrl);
+
+console.log(blocked.status, allowed.status);
+// 403 200
+
+await srv.close();
+```
+
+`DisassociateWebACL` takes the web ACL back off. `GetWebACLForResource` reports the web ACL one pool
+carries, and `ListResourcesForWebACL` reports the pools one web ACL protects under a `ResourceType`
+of `COGNITO_USER_POOL`. Deleting the pool takes the association with it, and a web ACL still in
+front of a pool cannot be deleted.
+
+The web ACL and the pool belong to one Account and Region. A `CLOUDFRONT` scope web ACL is refused,
+because a distribution takes its web ACL from the distribution. A pool in another Account or another
+Region is refused as well.
+
+AWS also refuses a web ACL carrying `AWSManagedRulesATPRuleSet`, and it refuses the whole web ACL
+over the one rule group. Yulin turns that group away earlier, at `CreateWebACL`, along with every
+managed rule group outside the [three that are simulated](#the-aws-managed-rule-groups).
+
+### The request body is withheld at a hosted domain
+
+Cognito sends AWS WAF the headers and the path of a managed login request and none of its body. A
+`ByteMatchStatement`, `RegexMatchStatement` or `SizeConstraintStatement` on `Body` therefore
+inspects an empty field at a hosted domain, however well formed the rule is. Keying a rule on a
+username or a password is out for the same reason. Yulin withholds the body the same way. A rule
+written against it fails here as it fails on AWS.
+
+Real WAF does read the body of a user pool API request such as `SignUp` or `InitiateAuth`. Those
+reach Yulin as SDK Commands and carry no HTTP request for a rule to read. No web ACL is evaluated
+for them at all. A test covering an API operation should reach for
+[`evaluateRequest`](#deciding-what-happens-to-a-request) with a request of its own.
+
+Two more paths are outside what the web ACL sees. `/<pool-id>/messages` is Yulin's own listing of
+the messages a pool would have sent, and real Cognito has no such endpoint. Managed login branding
+and its assets are outside the simulation.
 
 ## Protecting a CloudFront distribution
 

--- a/docs/services/wafv2/sim-wafv2-cognito-user-pool.example.ts
+++ b/docs/services/wafv2/sim-wafv2-cognito-user-pool.example.ts
@@ -1,0 +1,103 @@
+/**
+ * Blocking a request to a pool's hosted domain with a web ACL in front of it.
+ */
+
+import {
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  CreateUserPoolDomainCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  AssociateWebACLCommand,
+  CreateWebACLCommand,
+} from "@aws-sdk/client-wafv2";
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+const cognito = simAws.cognitoIdentityProvider();
+const waf = simAws.wafV2();
+
+const created = await cognito.createUserPool(
+  new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+);
+const userPoolId = created.UserPool!.Id!;
+
+await cognito.createUserPoolDomain(
+  new CreateUserPoolDomainCommand({
+    UserPoolId: userPoolId,
+    Domain: "myapp-login",
+  }),
+);
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: userPoolId,
+    ClientName: "web",
+    AllowedOAuthFlowsUserPoolClient: true,
+    AllowedOAuthFlows: ["code"],
+    AllowedOAuthScopes: ["openid"],
+    CallbackURLs: ["https://www.example.com/user/callback"],
+    SupportedIdentityProviders: ["COGNITO"],
+  }),
+);
+
+const visibility = {
+  SampledRequestsEnabled: false,
+  CloudWatchMetricsEnabled: false,
+  MetricName: "pool",
+};
+
+const webAcl = await waf.createWebAcl(
+  new CreateWebACLCommand({
+    Name: "pool-acl",
+    Scope: "REGIONAL",
+    DefaultAction: { Allow: {} },
+    VisibilityConfig: visibility,
+    Rules: [
+      {
+        Name: "block-scraper",
+        Priority: 0,
+        Action: { Block: {} },
+        Statement: {
+          ByteMatchStatement: {
+            FieldToMatch: { SingleHeader: { Name: "user-agent" } },
+            PositionalConstraint: "CONTAINS",
+            SearchString: Buffer.from("scraper"),
+            TextTransformations: [{ Priority: 0, Type: "NONE" }],
+          },
+        },
+        VisibilityConfig: { ...visibility, MetricName: "block-scraper" },
+      },
+    ],
+  }),
+);
+
+await waf.associateWebAcl(
+  new AssociateWebACLCommand({
+    WebACLArn: webAcl.Summary?.ARN,
+    ResourceArn: cognito.userPool(userPoolId).arn.value,
+  }),
+);
+
+const srv = await serveSimAws({ simAws });
+const parameters = new URLSearchParams({
+  response_type: "code",
+  client_id: appClient.UserPoolClient!.ClientId!,
+  redirect_uri: "https://www.example.com/user/callback",
+  scope: "openid",
+});
+const signInUrl = srv.localUrl(
+  `https://myapp-login.auth.eu-west-2.amazoncognito.com/oauth2/authorize?${parameters.toString()}`,
+);
+
+const blocked = await fetch(signInUrl, {
+  headers: { "user-agent": "scraper/1.0" },
+});
+const allowed = await fetch(signInUrl);
+
+console.log(blocked.status, allowed.status);
+// 403 200
+
+await srv.close();

--- a/src/service/apigateway/serve/sim-rest-api-web-acl-inspection.ts
+++ b/src/service/apigateway/serve/sim-rest-api-web-acl-inspection.ts
@@ -1,5 +1,7 @@
-import { simWafBlockedHttpResponse } from "../../wafv2/evaluate/sim-waf-blocked-response.js";
-import type { SimWafHeader } from "../../wafv2/web-acl/sim-waf-custom-response.type.js";
+import {
+  type SimWafInspected,
+  SimWafRequestInspection,
+} from "../../wafv2/association/sim-waf-request-inspection.js";
 import type { SimRestApi } from "../api/sim-rest-api.js";
 
 interface SimRestApiInspectionInput {
@@ -7,28 +9,6 @@ interface SimRestApiInspectionInput {
   /** The first path segment of the request, which names the stage. */
   readonly stageName: string;
   readonly request: Request;
-}
-
-interface SimRestApiInspectedProperties {
-  readonly request: Request;
-  readonly blocked?: Response | undefined;
-}
-
-/**
- * What the web ACL in front of a stage left of one request.
- *
- * A blocked request has a response to send and goes no further. An allowed one
- * carries on, as the request the rules asked for rather than the one that
- * arrived, since a rule can add headers to what is forwarded.
- */
-export class SimRestApiInspected {
-  public readonly request: Request;
-  public readonly blocked: Response | undefined;
-
-  constructor(properties: SimRestApiInspectedProperties) {
-    this.request = properties.request;
-    this.blocked = properties.blocked;
-  }
 }
 
 /**
@@ -40,76 +20,21 @@ export class SimRestApiInspected {
  * request therefore reaches neither the authorizer nor the integration.
  */
 export class SimRestApiWebAclInspection {
+  private readonly inspection = new SimWafRequestInspection();
+
   /**
    * Put one request to whatever protects the stage it addressed.
    */
-  async inspect(
-    input: SimRestApiInspectionInput,
-  ): Promise<SimRestApiInspected> {
+  async inspect(input: SimRestApiInspectionInput): Promise<SimWafInspected> {
     const { request, restApi } = input;
-    const resourceArn = restApi.stageArn(input.stageName);
 
-    if (!restApi.webAcls.protects(resourceArn)) {
-      return new SimRestApiInspected({ request });
-    }
-
-    // The body is buffered only for a protected stage, because reading it is
-    // what a rule inspecting the body needs and every other request would pay
-    // for it.
-    const body = await inspectedBody(request);
-    const decision = restApi.webAcls.decide({ resourceArn, request, body });
-
-    // A decision carries a blocked response when its action was to block, and
-    // carries none when the request was allowed. That one reading is what
-    // decides the request here.
-    if (decision?.blocked !== undefined) {
-      return new SimRestApiInspected({
-        request,
-        blocked: simWafBlockedHttpResponse(decision.blocked),
-      });
-    }
-
-    return new SimRestApiInspected({
-      request: forwarded(request, decision?.insertedHeaders ?? []),
+    // API Gateway forwards the request body to AWS WAF, so a rule inspecting
+    // the body of a request to a stage sees it.
+    return await this.inspection.inspect({
+      protection: restApi.webAcls,
+      resourceArn: restApi.stageArn(input.stageName),
+      request,
+      forwardBody: true,
     });
   }
-}
-
-/**
- * The request body a web ACL's rules are matched against.
- *
- * The request is cloned rather than read, so the integration still has a body
- * to send on to the function behind the method.
- */
-async function inspectedBody(
-  request: Request,
-): Promise<Uint8Array | undefined> {
-  const buffered = new Uint8Array(await request.clone().arrayBuffer());
-
-  return buffered.byteLength === 0 ? undefined : buffered;
-}
-
-/**
- * The request as the web ACL asked for it to be forwarded.
- *
- * A rule with custom request handling adds headers to what reaches the origin,
- * and API Gateway is the origin here. Only the headers are replaced, so the
- * body carries over as the stream it arrived as: inspection read a clone of
- * it rather than the request itself.
- */
-function forwarded(
-  request: Request,
-  insertedHeaders: readonly SimWafHeader[],
-): Request {
-  if (insertedHeaders.length === 0) {
-    return request;
-  }
-
-  const headers = new Headers(request.headers);
-
-  for (const header of insertedHeaders) {
-    headers.set(header.name, header.value);
-  }
-
-  return new Request(request, { headers });
 }

--- a/src/service/aws/factory/sim-aws-account-region-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-account-region-service-builder.ts
@@ -123,6 +123,9 @@ export class SimAwsAccountRegionServiceBuilder {
       userPoolRegistry: this.registries.cognito,
       domainRegistry: this.registries.cognitoDomains,
       triggerFunctions: simAwsCognitoTriggerFunctions(this.simAws),
+      // A web ACL protecting a pool is in the same Account and Region as the
+      // pool, as it is on AWS, so this scope's own WAFv2 is the one to ask.
+      webAcls: scope.wafV2().protection(),
     });
   }
 

--- a/src/service/cognito/README.md
+++ b/src/service/cognito/README.md
@@ -12,8 +12,10 @@ login's own pages and device tracking are not.
 ## Entry points
 
 - `sim-cognito-identity-provider.ts` is the main in-memory service object for one account/region
-  scope. It holds the pool operations, and extends `sim-cognito-app-clients.ts`, which holds the
-  app client ones, and extends `sim-cognito-federation.ts`,
+  scope. It holds the wiring the whole service is built from and the simulator's own accessors, and
+  extends `sim-cognito-user-pools.ts`, which holds the pool operations, and extends
+  `sim-cognito-app-clients.ts`, which holds the app client ones, and extends
+  `sim-cognito-federation.ts`,
   which holds the domain and identity provider ones and the three hosted endpoints, and extends
   `sim-cognito-user-directory.ts`, which holds the user and group ones and extends
   `sim-cognito-user-factors.ts`, which holds the operations a signed-in user performs on itself, and
@@ -460,6 +462,19 @@ caused is answered as any other authorize refusal is.
 `/<userPoolId>/messages` is served alongside them, and real Cognito has no such endpoint. It is the
 serving side of `SimCognitoUserPool.sentMessages`, so a browser or a curl can read what a pool would
 have sent during local development, and it is a divergence for the same reason that accessor is one.
+
+`serve/sim-cognito-web-acl-inspection.ts` puts every one of those requests to whatever web ACL is in
+front of the pool, before the endpoint answers. `AssociateWebACL` on the WAFv2 side is what puts one
+there, named by the pool ARN. `SimCognitoIdentityProvider.webAcls()` is where the serving layer
+reaches it. `simCognitoPoolScope` resolves the pool's own Account and Region first, because a
+request finds a pool by hostname or by id and both of those leave the scope open. The two
+`.well-known` documents are covered along with the hosted domain, since AWS WAF inspects every user
+pool endpoint. The messages listing is left alone, because real Cognito has no such endpoint for a
+web ACL on AWS to cover.
+
+The request body is withheld from the web ACL. Cognito forwards the headers and the path of a
+managed login request to AWS WAF and none of its body. A `ByteMatchStatement` on `Body` therefore
+inspects an empty field here, and a rule has nowhere to read a username or a password from.
 
 The request hostname is `cognito-idp.<region>`, which names the regional endpoint rather than one
 pool, so the pool id comes from the path. That id says nothing about the Account that owns the pool,

--- a/src/service/cognito/README.md
+++ b/src/service/cognito/README.md
@@ -463,9 +463,9 @@ caused is answered as any other authorize refusal is.
 serving side of `SimCognitoUserPool.sentMessages`, so a browser or a curl can read what a pool would
 have sent during local development, and it is a divergence for the same reason that accessor is one.
 
-`serve/sim-cognito-web-acl-inspection.ts` puts every one of those requests to whatever web ACL is in
-front of the pool, before the endpoint answers. `AssociateWebACL` on the WAFv2 side is what puts one
-there, named by the pool ARN. `SimCognitoIdentityProvider.webAcls()` is where the serving layer
+`serve/sim-cognito-web-acl-inspection.ts` puts a request to whatever web ACL is in front of the
+pool, before the endpoint answers and before the method is judged. `AssociateWebACL` on the WAFv2
+side is what puts one there, named by the pool ARN. `SimCognitoIdentityProvider.webAcls()` is where the serving layer
 reaches it. `simCognitoPoolScope` resolves the pool's own Account and Region first, because a
 request finds a pool by hostname or by id and both of those leave the scope open. The two
 `.well-known` documents are covered along with the hosted domain, since AWS WAF inspects every user

--- a/src/service/cognito/command/sim-cognito-commands.ts
+++ b/src/service/cognito/command/sim-cognito-commands.ts
@@ -11,6 +11,7 @@ import type { SimCognitoTriggerFunctions } from "../user-pool/trigger/sim-cognit
 import { SimCognitoUserPoolTriggers } from "../user-pool/trigger/sim-cognito-user-pool-triggers.js";
 import { SimCognitoUserFactory } from "../user-pool/user/sim-cognito-user-factory.js";
 import type { SimCognitoDomainRegistry } from "../registry/sim-cognito-domain-registry.js";
+import type { SimWafProtection } from "../../wafv2/association/sim-waf-protection.js";
 import { SimCognitoTokenIssuer } from "../user-pool/token/sim-cognito-token-issuer.js";
 import { SimCognitoAuthCommands } from "./auth/sim-cognito-auth-commands.js";
 import { SimCognitoDomainCommands } from "./domain/sim-cognito-domain-commands.js";
@@ -42,6 +43,7 @@ interface SimCognitoCommandsProperties {
   readonly pools: SimCognitoUserPoolStore;
   readonly domains: SimCognitoDomainRegistry;
   readonly triggerFunctions: SimCognitoTriggerFunctions;
+  readonly webAcls: SimWafProtection;
 }
 
 /**
@@ -77,9 +79,19 @@ export class SimCognitoCommands {
    */
   public readonly registrations: SimCognitoRegistrations;
 
+  /**
+   * The web ACLs in front of this scope's pools. Held here because a request
+   * to a hosted domain reaches it without a Command, the way a fronting
+   * service reaches AWS WAF.
+   */
+  public readonly webAcls: SimWafProtection;
+
   constructor(properties: SimCognitoCommandsProperties) {
     const { accountRegionScope, iam, clock, pools, domains, triggerFunctions } =
       properties;
+
+    this.webAcls = properties.webAcls;
+
     const authorizer = new SimCognitoAuthorizer({ iam, accountRegionScope });
     const resolver = new SimCognitoRequestResolver({ pools, authorizer });
     const authResolver = new SimCognitoAuthResolver({ resolver, pools });
@@ -112,6 +124,7 @@ export class SimCognitoCommands {
       pools,
       poolFactory,
       authorizer,
+      webAcls: properties.webAcls,
     });
     this.userPoolMfa = new SimCognitoUserPoolMfaCommands({ pools, authorizer });
     this.listUserPools = new SimCognitoListUserPools({ pools, authorizer });

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-commands.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-commands.ts
@@ -4,6 +4,7 @@ import type { SimCognitoUserPoolFactory } from "../../user-pool/sim-cognito-user
 import { requireSimCognitoUserPoolId } from "../../user-pool/sim-cognito-user-pool-id.js";
 import { SimCognitoUserPoolSettings } from "../../user-pool/sim-cognito-user-pool-settings.js";
 import type { SimCognitoUserPoolStore } from "../../user-pool/sim-cognito-user-pool-store.js";
+import type { SimWafProtection } from "../../../wafv2/association/sim-waf-protection.js";
 import type { SimCognitoAuthorizer } from "../authorize/sim-cognito-authorizer.js";
 import { SimCognitoUnsimulatedUserPoolIdentity } from "./sim-cognito-unsimulated-pool-identity.js";
 import { SimCognitoUnsimulatedUserPoolOptions } from "./sim-cognito-unsimulated-pool-options.js";
@@ -24,6 +25,7 @@ interface SimCognitoUserPoolCommandsProperties {
   readonly pools: SimCognitoUserPoolStore;
   readonly poolFactory: SimCognitoUserPoolFactory;
   readonly authorizer: SimCognitoAuthorizer;
+  readonly webAcls: SimWafProtection;
 }
 
 interface SimCognitoCommandOptions {
@@ -38,6 +40,7 @@ export class SimCognitoUserPoolCommands {
   private readonly pools: SimCognitoUserPoolStore;
   private readonly poolFactory: SimCognitoUserPoolFactory;
   private readonly authorizer: SimCognitoAuthorizer;
+  private readonly webAcls: SimWafProtection;
   private readonly view = new SimCognitoUserPoolView();
   private readonly unsimulatedOptions =
     new SimCognitoUnsimulatedUserPoolOptions("CreateUserPool");
@@ -50,6 +53,7 @@ export class SimCognitoUserPoolCommands {
     this.pools = properties.pools;
     this.poolFactory = properties.poolFactory;
     this.authorizer = properties.authorizer;
+    this.webAcls = properties.webAcls;
   }
 
   /**
@@ -148,6 +152,10 @@ export class SimCognitoUserPoolCommands {
 
   /**
    * Delete a user pool, and with it every app client in it.
+   *
+   * A web ACL in front of the pool is let go of, as it is on AWS: the
+   * association names a pool that no longer exists, and nothing is left
+   * holding it.
    */
   delete(
     command: SimDeleteUserPoolCommand,
@@ -172,6 +180,7 @@ export class SimCognitoUserPoolCommands {
     }
 
     this.pools.remove(pool);
+    this.webAcls.release(pool.arn.value);
 
     return { $metadata: {} };
   }

--- a/src/service/cognito/serve/sim-cognito-controller.ts
+++ b/src/service/cognito/serve/sim-cognito-controller.ts
@@ -7,27 +7,13 @@ import { SimAws } from "../../aws/sim-aws.js";
 import type { SimCognitoUserPool } from "../user-pool/sim-cognito-user-pool.js";
 import { SimCognitoDomainController } from "./sim-cognito-domain-controller.js";
 import { SimCognitoEndpointResponse } from "./sim-cognito-endpoint-response.js";
-import { SimCognitoOpenIdConfiguration } from "./sim-cognito-openid-configuration.js";
-
-/**
- * The path segment both public pool endpoints sit under.
- */
-const wellKnownSegment = ".well-known";
-
-/**
- * The path segment the recorded messages are listed under.
- *
- * Real Cognito serves nothing here. It is the serving side of
- * `SimCognitoUserPool.sentMessages`, so that a browser or a curl can read what
- * a pool would have sent during local development, and it is a divergence for
- * the same reason that accessor is one: nothing here delivers a message.
- */
-const messagesSegment = "messages";
-
-/**
- * The segments a request can name after the pool id.
- */
-const servedSegments = new Set([wellKnownSegment, messagesSegment]);
+import { simCognitoPoolScope } from "./sim-cognito-pool-scope.js";
+import {
+  SimCognitoPoolDocuments,
+  simCognitoProtectedSegment,
+  simCognitoServesSegment,
+} from "./sim-cognito-pool-documents.js";
+import { SimCognitoWebAclInspection } from "./sim-cognito-web-acl-inspection.js";
 
 /**
  * The methods a published document is read with.
@@ -39,41 +25,29 @@ interface SimCognitoServiceControllerProperties {
 }
 
 /**
- * The parts of a request that decide which document it is asking for.
- */
-interface SimCognitoServedRequest {
-  readonly segment: string;
-  readonly document: string | undefined;
-  readonly url: URL;
-  readonly method: string;
-}
-
-/**
  * Localhost HTTP controller for the public endpoints of a simulated user pool,
  * and for the messages the pool would have sent.
  *
- * Real Cognito serves a pool's JWKS and its OpenID configuration to anyone,
- * with no SigV4 signature, because a token verifier holding no AWS credentials
- * has to be able to fetch them. Both are anonymous here for the same reason,
- * so a verifier pointed at the local URL fetches keys the way it does against
- * real Cognito rather than being handed them.
- *
- * The recorded messages are listed at `/<userPoolId>/messages`, which real
- * Cognito serves nothing at. Nothing here delivers a message, so this is where
- * one is read during local development.
+ * `SimCognitoPoolDocuments` answers with the pool's JWKS, its OpenID
+ * configuration and the messages listing, and this is the routing in front of
+ * it: the method, the path and the pool the path names.
  *
  * A pool's hosted domain is served too, on its own hostname rather than on the
  * regional endpoint, and `SimCognitoDomainController` answers those requests.
  * That is where the OAuth endpoints of an authorization code grant live.
+ *
+ * A web ACL in front of the pool decides a request to either of the
+ * `.well-known` documents before the document is read.
  *
  * The Cognito API itself is not served. An SDK client reaches the simulator
  * through `SimSdk` rather than through an endpoint override.
  */
 export class SimCognitoServiceController implements SimAwsServiceController {
   private readonly simAws: SimAws;
-  private readonly openIdConfiguration = new SimCognitoOpenIdConfiguration();
+  private readonly documents = new SimCognitoPoolDocuments();
   private readonly response = new SimCognitoEndpointResponse();
   private readonly domainController: SimCognitoDomainController;
+  private readonly webAcl = new SimCognitoWebAclInspection();
 
   constructor(properties: SimCognitoServiceControllerProperties = {}) {
     const { simAws = new SimAws() } = properties;
@@ -90,10 +64,12 @@ export class SimCognitoServiceController implements SimAwsServiceController {
     const domainResponse =
       await this.domainController.handleRequest(serviceRequest);
 
-    return domainResponse ?? this.respond(serviceRequest);
+    return domainResponse ?? (await this.respond(serviceRequest));
   }
 
-  private respond(serviceRequest: SimAwsServiceRequest): Response {
+  private async respond(
+    serviceRequest: SimAwsServiceRequest,
+  ): Promise<Response> {
     const { request } = serviceRequest;
     const url = new URL(request.url);
 
@@ -112,7 +88,7 @@ export class SimCognitoServiceController implements SimAwsServiceController {
       userPoolId === undefined ||
       userPoolId === "" ||
       segment === undefined ||
-      !servedSegments.has(segment) ||
+      !simCognitoServesSegment(segment) ||
       rest.length > 0
     ) {
       return this.response.noSuchEndpoint(url.pathname);
@@ -124,49 +100,42 @@ export class SimCognitoServiceController implements SimAwsServiceController {
       return this.response.noSuchUserPool(userPoolId);
     }
 
-    return this.served(pool, {
-      segment,
-      document,
-      url,
-      method: request.method,
-    });
+    const blocked = await this.blocked(pool, segment, request);
+
+    return (
+      blocked ??
+      this.documents.serve(pool, {
+        segment,
+        document,
+        url,
+        method: request.method,
+      })
+    );
   }
 
   /**
-   * The document a request names, or nothing served at that path.
+   * What the web ACL in front of a pool answers a request with, when it blocks
+   * it.
+   *
+   * A blocked request is answered before the document is read, so a verifier
+   * the rules turn away gets 403 and no keys.
    */
-  private served(
+  private async blocked(
     pool: SimCognitoUserPool,
-    request: SimCognitoServedRequest,
-  ): Response {
-    const { segment, document, url, method } = request;
-
-    // The listing is the whole of what the messages segment serves, and the
-    // two published documents sit under `.well-known` and nowhere else, so a
-    // path that mixes the two reaches neither.
-    if (segment === messagesSegment && document === undefined) {
-      return this.response.document(
-        { messages: pool.sentMessages().map((message) => message.toOutput()) },
-        method,
-      );
+    segment: string,
+    request: Request,
+  ): Promise<Response | undefined> {
+    if (!simCognitoProtectedSegment(segment)) {
+      return undefined;
     }
 
-    if (segment !== wellKnownSegment) {
-      return this.response.noSuchEndpoint(url.pathname);
-    }
+    const inspected = await this.webAcl.inspect({
+      pool,
+      cognito: simCognitoPoolScope(this.simAws, pool),
+      request,
+    });
 
-    if (document === "jwks.json") {
-      return this.response.document(pool.jwks(), method);
-    }
-
-    if (document === "openid-configuration") {
-      return this.response.document(
-        this.openIdConfiguration.document(pool, url.origin),
-        method,
-      );
-    }
-
-    return this.response.noSuchEndpoint(url.pathname);
+    return inspected.blocked;
   }
 
   /**

--- a/src/service/cognito/serve/sim-cognito-controller.ts
+++ b/src/service/cognito/serve/sim-cognito-controller.ts
@@ -73,10 +73,6 @@ export class SimCognitoServiceController implements SimAwsServiceController {
     const { request } = serviceRequest;
     const url = new URL(request.url);
 
-    if (!readMethods.has(request.method)) {
-      return this.response.notRead(request.method);
-    }
-
     // A path is exactly '<userPoolId>/.well-known/<document>' or
     // '<userPoolId>/messages'. Anything longer is a path nothing is served at,
     // rather than a prefix of one that is.
@@ -100,17 +96,25 @@ export class SimCognitoServiceController implements SimAwsServiceController {
       return this.response.noSuchUserPool(userPoolId);
     }
 
+    // The web ACL sits in front of the endpoint rather than behind it, so a
+    // request it blocks is answered before the method is judged. A write the
+    // rules turned away gets WAF's 403 and never learns the endpoint reads.
     const blocked = await this.blocked(pool, segment, request);
 
-    return (
-      blocked ??
-      this.documents.serve(pool, {
-        segment,
-        document,
-        url,
-        method: request.method,
-      })
-    );
+    if (blocked !== undefined) {
+      return blocked;
+    }
+
+    if (!readMethods.has(request.method)) {
+      return this.response.notRead(request.method);
+    }
+
+    return this.documents.serve(pool, {
+      segment,
+      document,
+      url,
+      method: request.method,
+    });
   }
 
   /**

--- a/src/service/cognito/serve/sim-cognito-domain-controller.ts
+++ b/src/service/cognito/serve/sim-cognito-domain-controller.ts
@@ -1,12 +1,11 @@
 import { assertDefined } from "../../../util/type-guard/defined.js";
-import type { SimAwsServiceRequest } from "../../../serve/controller/sim-service-controller.js";
-import type { AwsRegionName } from "../../aws/sim-aws-region.js";
+import { SimAwsServiceRequest } from "../../../serve/controller/sim-service-controller.js";
 import type { SimAws } from "../../aws/sim-aws.js";
 import type { SimCognitoUserPoolDomain } from "../user-pool/domain/sim-cognito-user-pool-domain.js";
 import type { SimCognitoUserPool } from "../user-pool/sim-cognito-user-pool.js";
-import { simCognitoUserPoolRegionName } from "../user-pool/sim-cognito-user-pool-id.js";
-import type { SimCognitoIdentityProvider } from "../sim-cognito-identity-provider.js";
 import { SimCognitoDomainEndpoints } from "./sim-cognito-domain-endpoints.js";
+import { simCognitoPoolScope } from "./sim-cognito-pool-scope.js";
+import { SimCognitoWebAclInspection } from "./sim-cognito-web-acl-inspection.js";
 
 interface SimCognitoDomainControllerProperties {
   readonly simAws: SimAws;
@@ -23,10 +22,15 @@ interface SimCognitoDomainControllerProperties {
  * The pool's own scope answers each request, found from the domain rather than
  * assumed to be the default one, because a domain names a pool that any
  * Account and Region of the simulation could have created.
+ *
+ * A web ACL in front of the pool sees the request before any of the endpoints
+ * do, as it does on real Cognito. A blocked request is answered with 403 and
+ * reaches no endpoint.
  */
 export class SimCognitoDomainController {
   private readonly simAws: SimAws;
   private readonly endpoints = new SimCognitoDomainEndpoints();
+  private readonly webAcl = new SimCognitoWebAclInspection();
 
   constructor(properties: SimCognitoDomainControllerProperties) {
     this.simAws = properties.simAws;
@@ -48,14 +52,23 @@ export class SimCognitoDomainController {
       return undefined;
     }
 
-    const url = new URL(serviceRequest.request.url);
     const pool = this.pool(domain);
+    const cognito = simCognitoPoolScope(this.simAws, pool);
+    const inspected = await this.webAcl.inspect({
+      pool,
+      cognito,
+      request: serviceRequest.request,
+    });
+
+    if (inspected.blocked !== undefined) {
+      return inspected.blocked;
+    }
 
     return await this.endpoints.handleRequest({
       pool,
-      cognito: this.cognitoFor(pool),
-      serviceRequest,
-      url,
+      cognito,
+      serviceRequest: forwarded(serviceRequest, inspected.request),
+      url: new URL(inspected.request.url),
     });
   }
 
@@ -91,18 +104,29 @@ export class SimCognitoDomainController {
 
     return pool;
   }
+}
 
-  /**
-   * The simulated Cognito scope that owns a pool.
-   *
-   * The Account comes from the pool's ARN and the Region from its id, and each
-   * scope's services are made once and kept, so this is the same service
-   * object that created the pool rather than another view of it.
-   */
-  private cognitoFor(pool: SimCognitoUserPool): SimCognitoIdentityProvider {
-    return this.simAws
-      .account(pool.arn.accountId)
-      .region(simCognitoUserPoolRegionName(pool.id) as AwsRegionName)
-      .cognitoIdentityProvider();
+/**
+ * The request the endpoints answer, as the web ACL asked for it to be
+ * forwarded.
+ *
+ * A rule with custom request handling adds headers to what reaches the origin,
+ * and the hosted domain is the origin here. An allowed request no rule touched
+ * is the one that arrived.
+ */
+function forwarded(
+  serviceRequest: SimAwsServiceRequest,
+  request: Request,
+): SimAwsServiceRequest {
+  if (request === serviceRequest.request) {
+    return serviceRequest;
   }
+
+  return new SimAwsServiceRequest({
+    target: serviceRequest.target,
+    request,
+    caller: serviceRequest.caller,
+    source: serviceRequest.source,
+    body: serviceRequest.body,
+  });
 }

--- a/src/service/cognito/serve/sim-cognito-pool-documents.ts
+++ b/src/service/cognito/serve/sim-cognito-pool-documents.ts
@@ -1,0 +1,96 @@
+import type { SimCognitoUserPool } from "../user-pool/sim-cognito-user-pool.js";
+import { SimCognitoEndpointResponse } from "./sim-cognito-endpoint-response.js";
+import { SimCognitoOpenIdConfiguration } from "./sim-cognito-openid-configuration.js";
+
+/**
+ * The path segment both public pool endpoints sit under.
+ */
+const wellKnownSegment = ".well-known";
+
+/**
+ * The path segment the recorded messages are listed under.
+ *
+ * Real Cognito serves nothing here. It is the serving side of
+ * `SimCognitoUserPool.sentMessages`, so that a browser or a curl can read what
+ * a pool would have sent during local development, and it is a divergence for
+ * the same reason that accessor is one: nothing here delivers a message.
+ */
+const messagesSegment = "messages";
+
+const servedSegments = new Set([wellKnownSegment, messagesSegment]);
+
+/**
+ * The parts of a request that decide which document it is asking for.
+ */
+export interface SimCognitoServedRequest {
+  readonly segment: string;
+  readonly document: string | undefined;
+  readonly url: URL;
+  readonly method: string;
+}
+
+/**
+ * Whether a path segment after the pool id names anything this endpoint
+ * serves.
+ */
+export function simCognitoServesSegment(segment: string): boolean {
+  return servedSegments.has(segment);
+}
+
+/**
+ * Whether a web ACL in front of the pool is evaluated for a path segment.
+ *
+ * AWS WAF inspects every user pool endpoint, and the two `.well-known`
+ * documents are user pool endpoints. The recorded messages are a path of this
+ * simulation's own, and no web ACL on AWS has an opinion about it.
+ */
+export function simCognitoProtectedSegment(segment: string): boolean {
+  return segment === wellKnownSegment;
+}
+
+/**
+ * The documents a pool publishes on the regional endpoint.
+ *
+ * Real Cognito serves the JWKS and the OpenID configuration to anyone, with no
+ * SigV4 signature, because a token verifier holding no AWS credentials has to
+ * be able to fetch them. Both are anonymous here for the same reason. The
+ * messages listing sits beside them and is Yulin's own.
+ */
+export class SimCognitoPoolDocuments {
+  private readonly openIdConfiguration = new SimCognitoOpenIdConfiguration();
+  private readonly response = new SimCognitoEndpointResponse();
+
+  /**
+   * The document a request names, or nothing served at that path.
+   */
+  serve(pool: SimCognitoUserPool, request: SimCognitoServedRequest): Response {
+    const { segment, document, url, method } = request;
+
+    // The listing is the whole of what the messages segment serves, and the
+    // two published documents sit under `.well-known` and nowhere else, so a
+    // path that mixes the two reaches neither.
+    if (segment === messagesSegment && document === undefined) {
+      return this.response.document(
+        { messages: pool.sentMessages().map((message) => message.toOutput()) },
+        method,
+      );
+    }
+
+    if (segment !== wellKnownSegment) {
+      return this.response.noSuchEndpoint(url.pathname);
+    }
+
+    if (document === "jwks.json") {
+      return this.response.document(pool.jwks(), method);
+    }
+
+    if (document === "openid-configuration") {
+      return this.response.document(
+        this.openIdConfiguration.document(pool, url.origin),
+        method,
+      );
+    }
+
+    return this.response.noSuchEndpoint(url.pathname);
+  }
+}

--- a/src/service/cognito/serve/sim-cognito-pool-scope.ts
+++ b/src/service/cognito/serve/sim-cognito-pool-scope.ts
@@ -1,0 +1,24 @@
+import type { AwsRegionName } from "../../aws/sim-aws-region.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimCognitoIdentityProvider } from "../sim-cognito-identity-provider.js";
+import { simCognitoUserPoolRegionName } from "../user-pool/sim-cognito-user-pool-id.js";
+import type { SimCognitoUserPool } from "../user-pool/sim-cognito-user-pool.js";
+
+/**
+ * The simulated Cognito scope that owns a pool.
+ *
+ * The Account comes from the pool's ARN and the Region from its id, and each
+ * scope's services are made once and kept, so this is the same service object
+ * that created the pool rather than another view of it. A served request finds
+ * the pool by id or by hostname, neither of which says which scope it came
+ * from, so this is how the serving layer gets back to it.
+ */
+export function simCognitoPoolScope(
+  simAws: SimAws,
+  pool: SimCognitoUserPool,
+): SimCognitoIdentityProvider {
+  return simAws
+    .account(pool.arn.accountId)
+    .region(simCognitoUserPoolRegionName(pool.id) as AwsRegionName)
+    .cognitoIdentityProvider();
+}

--- a/src/service/cognito/serve/sim-cognito-web-acl-documents.iso.test.ts
+++ b/src/service/cognito/serve/sim-cognito-web-acl-documents.iso.test.ts
@@ -68,19 +68,35 @@ async function protectedPool(simAws: SimAws): Promise<string> {
 }
 
 /**
+ * Fetch one of the pool's endpoints, sending headers of the caller's choosing.
+ */
+async function fetchPoolPath(
+  simAws: SimAws,
+  userPoolId: string,
+  path: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  return await new SimAwsHttp({ simAws }).fetch(
+    new SimAwsLocalUrl({
+      input: `https://cognito-idp.eu-west-2.amazonaws.com/${userPoolId}${path}`,
+    }).toString(),
+    init,
+  );
+}
+
+/**
  * Fetch one of the pool's endpoints as the scraper.
  */
 async function fetchAsScraper(
   simAws: SimAws,
   userPoolId: string,
   path: string,
+  method = "GET",
 ): Promise<Response> {
-  return await new SimAwsHttp({ simAws }).fetch(
-    new SimAwsLocalUrl({
-      input: `https://cognito-idp.eu-west-2.amazonaws.com/${userPoolId}${path}`,
-    }).toString(),
-    { headers: { "user-agent": scraperUserAgent } },
-  );
+  return await fetchPoolPath(simAws, userPoolId, path, {
+    method,
+    headers: { "user-agent": scraperUserAgent },
+  });
 }
 
 describe("A web ACL in front of a sim Cognito user pool's documents", () => {
@@ -105,6 +121,26 @@ describe("A web ACL in front of a sim Cognito user pool's documents", () => {
     // pool covers every endpoint the pool serves.
     assertIdentical(jwks.status, 403);
     assertIdentical(configuration.status, 403);
+  });
+
+  it("blocks a write before the endpoint reports the methods it reads", async () => {
+    // Given a pool with a web ACL in front of it.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    const userPoolId = await protectedPool(simAws);
+    const jwksPath = "/.well-known/jwks.json";
+
+    // When the scraper posts to the JWKS endpoint, and when a browser does.
+    const blocked = await fetchAsScraper(simAws, userPoolId, jwksPath, "POST");
+    const allowed = await fetchPoolPath(simAws, userPoolId, jwksPath, {
+      method: "POST",
+    });
+
+    // Then the web ACL decided the blocked one first, as it sits in front of
+    // the endpoint. The allowed one reaches the endpoint and is told what it
+    // reads.
+    assertIdentical(blocked.status, 403);
+    assertIdentical(allowed.status, 405);
+    assertIdentical(allowed.headers.get("allow"), "GET, HEAD");
   });
 
   it("leaves the recorded messages listing alone", async () => {

--- a/src/service/cognito/serve/sim-cognito-web-acl-documents.iso.test.ts
+++ b/src/service/cognito/serve/sim-cognito-web-acl-documents.iso.test.ts
@@ -1,0 +1,123 @@
+import { CreateUserPoolCommand } from "@aws-sdk/client-cognito-identity-provider";
+import {
+  AssociateWebACLCommand,
+  CreateWebACLCommand,
+} from "@aws-sdk/client-wafv2";
+import { assertIdentical, assertNonNullable } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import { SimAws } from "../../aws/sim-aws.js";
+
+const visibility = {
+  SampledRequestsEnabled: false,
+  CloudWatchMetricsEnabled: false,
+  MetricName: "pool",
+};
+
+/**
+ * The user agent the rule below turns away.
+ */
+const scraperUserAgent = "scraper/1.0";
+
+/**
+ * A pool of its own with a web ACL in front of it that blocks the scraper.
+ */
+async function protectedPool(simAws: SimAws): Promise<string> {
+  const cognito = simAws.cognitoIdentityProvider();
+  const created = await cognito.createUserPool(
+    new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+  );
+  assertNonNullable(created.UserPool?.Id);
+
+  const waf = simAws.wafV2();
+  const webAcl = await waf.createWebAcl(
+    new CreateWebACLCommand({
+      Name: "pool-acl",
+      Scope: "REGIONAL",
+      DefaultAction: { Allow: {} },
+      VisibilityConfig: visibility,
+      Rules: [
+        {
+          Name: "block-scraper",
+          Priority: 0,
+          Action: { Block: {} },
+          Statement: {
+            ByteMatchStatement: {
+              FieldToMatch: { SingleHeader: { Name: "user-agent" } },
+              PositionalConstraint: "CONTAINS",
+              SearchString: Buffer.from("scraper"),
+              TextTransformations: [{ Priority: 0, Type: "NONE" }],
+            },
+          },
+          VisibilityConfig: { ...visibility, MetricName: "block-scraper" },
+        },
+      ],
+    }),
+  );
+
+  await waf.associateWebAcl(
+    new AssociateWebACLCommand({
+      WebACLArn: webAcl.Summary?.ARN,
+      ResourceArn: cognito.userPool(created.UserPool.Id).arn.value,
+    }),
+  );
+
+  return created.UserPool.Id;
+}
+
+/**
+ * Fetch one of the pool's endpoints as the scraper.
+ */
+async function fetchAsScraper(
+  simAws: SimAws,
+  userPoolId: string,
+  path: string,
+): Promise<Response> {
+  return await new SimAwsHttp({ simAws }).fetch(
+    new SimAwsLocalUrl({
+      input: `https://cognito-idp.eu-west-2.amazonaws.com/${userPoolId}${path}`,
+    }).toString(),
+    { headers: { "user-agent": scraperUserAgent } },
+  );
+}
+
+describe("A web ACL in front of a sim Cognito user pool's documents", () => {
+  it("blocks the JWKS and the OpenID configuration", async () => {
+    // Given a pool with a web ACL in front of it.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    const userPoolId = await protectedPool(simAws);
+
+    // When the scraper reads the two documents the pool publishes.
+    const jwks = await fetchAsScraper(
+      simAws,
+      userPoolId,
+      "/.well-known/jwks.json",
+    );
+    const configuration = await fetchAsScraper(
+      simAws,
+      userPoolId,
+      "/.well-known/openid-configuration",
+    );
+
+    // Then both are refused. They are user pool endpoints, and a web ACL on a
+    // pool covers every endpoint the pool serves.
+    assertIdentical(jwks.status, 403);
+    assertIdentical(configuration.status, 403);
+  });
+
+  it("leaves the recorded messages listing alone", async () => {
+    // Given a pool with the same web ACL in front of it.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    const userPoolId = await protectedPool(simAws);
+
+    // When the messages the pool would have sent are listed.
+    const response = await fetchAsScraper(simAws, userPoolId, "/messages");
+
+    // Then the listing is served. Real Cognito serves nothing at that path, so
+    // no web ACL on AWS has an opinion about it, and it is Yulin's own view of
+    // what a pool would have sent.
+    assertIdentical(response.status, 200);
+  });
+});

--- a/src/service/cognito/serve/sim-cognito-web-acl-inspection.ts
+++ b/src/service/cognito/serve/sim-cognito-web-acl-inspection.ts
@@ -1,0 +1,45 @@
+import {
+  type SimWafInspected,
+  SimWafRequestInspection,
+} from "../../wafv2/association/sim-waf-request-inspection.js";
+import type { SimCognitoIdentityProvider } from "../sim-cognito-identity-provider.js";
+import type { SimCognitoUserPool } from "../user-pool/sim-cognito-user-pool.js";
+
+interface SimCognitoInspectionInput {
+  readonly pool: SimCognitoUserPool;
+
+  /** The simulated Cognito scope the pool belongs to. */
+  readonly cognito: SimCognitoIdentityProvider;
+
+  readonly request: Request;
+}
+
+/**
+ * Puts a request to the web ACL in front of the pool it reached.
+ *
+ * This runs before the endpoint the request named answers it, so a blocked
+ * request gets 403 and the endpoint does not run. Everything the pool serves
+ * over HTTP goes through it, which is what real AWS WAF covers: managed login,
+ * the classic hosted UI and the pool's own OIDC documents.
+ *
+ * The body is not forwarded. Cognito sends AWS WAF the headers and the path of
+ * a managed login request and none of its body, so a rule inspecting the body
+ * matches nothing at a hosted domain, however well formed it is. Body rules do
+ * reach the user pool API operations, which arrive here as SDK Commands rather
+ * than as HTTP requests and carry no web ACL evaluation at all.
+ */
+export class SimCognitoWebAclInspection {
+  private readonly inspection = new SimWafRequestInspection();
+
+  /**
+   * Put one request to whatever protects the pool it addressed.
+   */
+  async inspect(input: SimCognitoInspectionInput): Promise<SimWafInspected> {
+    return await this.inspection.inspect({
+      protection: input.cognito.webAcls(),
+      resourceArn: input.pool.arn.value,
+      request: input.request,
+      forwardBody: false,
+    });
+  }
+}

--- a/src/service/cognito/serve/sim-cognito-web-acl.iso.test.ts
+++ b/src/service/cognito/serve/sim-cognito-web-acl.iso.test.ts
@@ -215,7 +215,7 @@ describe("A web ACL in front of a sim Cognito hosted domain", () => {
     assertNonNullable(pool.findUser(simCognitoLocalUsername));
   });
 
-  it("forwards the headers an allow rule inserted to the endpoint", async () => {
+  it("serves a request an allow rule claimed with custom request handling", async () => {
     // Given a pool protected by an allow rule with custom request handling.
     const setUp = await simCognitoHosted();
     await protect(setUp, [
@@ -244,8 +244,11 @@ describe("A web ACL in front of a sim Cognito hosted domain", () => {
     // When the sign-in page is fetched.
     const response = await get(setUp, "/oauth2/authorize");
 
-    // Then the endpoint answers the forwarded request, which carries the
-    // header the rule added under WAF's own prefix.
+    // Then the endpoint answers the request the rule asked to be forwarded.
+    // The header itself is asserted nowhere, because WAF prefixes an inserted
+    // request header with `x-amzn-waf-` and no endpoint a pool serves reads
+    // one. A REST API stage is where an inserted header is observable, since
+    // the integration hands the headers to the function behind the method.
     assertIdentical(response.status, 200);
     assertStringIncludes(await response.text(), 'name="username"');
   });

--- a/src/service/cognito/serve/sim-cognito-web-acl.iso.test.ts
+++ b/src/service/cognito/serve/sim-cognito-web-acl.iso.test.ts
@@ -1,0 +1,265 @@
+import {
+  AssociateWebACLCommand,
+  CreateWebACLCommand,
+  type Rule,
+} from "@aws-sdk/client-wafv2";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import {
+  simCognitoHosted,
+  simCognitoLocalPassword,
+  simCognitoLocalUsername,
+  type SimCognitoHostedSetUp,
+} from "../../../../test/cognito/federation-fixture.js";
+import {
+  simCognitoAuthorizeParameters,
+  simCognitoPageUrl,
+} from "../../../../test/cognito/managed-login-fixture.js";
+
+const visibility = {
+  SampledRequestsEnabled: false,
+  CloudWatchMetricsEnabled: false,
+  MetricName: "pool",
+};
+
+/**
+ * The user agent the rules below turn away.
+ */
+const scraperUserAgent = "scraper/1.0";
+
+/**
+ * A rule blocking whatever sends the scraper's User-Agent header.
+ */
+const blockScraper: Rule = {
+  Name: "block-scraper",
+  Priority: 0,
+  Action: { Block: {} },
+  Statement: {
+    ByteMatchStatement: {
+      FieldToMatch: { SingleHeader: { Name: "user-agent" } },
+      PositionalConstraint: "CONTAINS",
+      SearchString: Buffer.from("scraper"),
+      TextTransformations: [{ Priority: 0, Type: "NONE" }],
+    },
+  },
+  VisibilityConfig: { ...visibility, MetricName: "block-scraper" },
+};
+
+/**
+ * Put a web ACL holding some rules in front of the pool's hosted domain.
+ */
+async function protect(
+  setUp: SimCognitoHostedSetUp,
+  rules: readonly Rule[],
+): Promise<void> {
+  const waf = setUp.simAws.wafV2();
+  const created = await waf.createWebAcl(
+    new CreateWebACLCommand({
+      Name: "pool-acl",
+      Scope: "REGIONAL",
+      DefaultAction: { Allow: {} },
+      VisibilityConfig: visibility,
+      Rules: [...rules],
+    }),
+  );
+
+  await waf.associateWebAcl(
+    new AssociateWebACLCommand({
+      WebACLArn: created.Summary?.ARN,
+      ResourceArn: setUp.cognito.userPool(setUp.userPoolId).arn.value,
+    }),
+  );
+}
+
+/**
+ * Fetch a hosted domain page, sending headers of the caller's choosing.
+ */
+async function get(
+  setUp: SimCognitoHostedSetUp,
+  path: string,
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  return await new SimAwsHttp({ simAws: setUp.simAws }).fetch(
+    simCognitoPageUrl(path, simCognitoAuthorizeParameters(setUp)),
+    { headers },
+  );
+}
+
+/**
+ * Post a form to a hosted domain page, sending headers of the caller's choosing.
+ */
+async function post(
+  setUp: SimCognitoHostedSetUp,
+  path: string,
+  fields: Record<string, string>,
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  return await new SimAwsHttp({ simAws: setUp.simAws }).fetch(
+    simCognitoPageUrl(path),
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        ...headers,
+      },
+      body: new URLSearchParams(fields).toString(),
+    },
+  );
+}
+
+describe("A web ACL in front of a sim Cognito hosted domain", () => {
+  it("blocks a request to the sign-in page and lets an allowed one through", async () => {
+    // Given a pool whose hosted domain has a web ACL in front of it.
+    const setUp = await simCognitoHosted();
+    await protect(setUp, [blockScraper]);
+
+    // When the sign-in page is fetched by the scraper and by a browser.
+    const blocked = await get(setUp, "/oauth2/authorize", {
+      "user-agent": scraperUserAgent,
+    });
+    const allowed = await get(setUp, "/oauth2/authorize");
+
+    // Then the blocked request gets 403 with WAF's body, and the allowed one
+    // gets the sign-in form the endpoint serves.
+    assertIdentical(blocked.status, 403);
+    assertStringIncludes(await blocked.text(), "Request blocked by AWS WAF");
+    assertIdentical(allowed.status, 200);
+    assertStringIncludes(await allowed.text(), 'name="username"');
+  });
+
+  it("blocks a sign-up before the endpoint creates the user", async () => {
+    // Given a protected pool with nobody in it.
+    const setUp = await simCognitoHosted();
+    await protect(setUp, [blockScraper]);
+    const pool = setUp.cognito.userPool(setUp.userPoolId);
+
+    // When the scraper posts the sign-up form.
+    const blocked = await post(
+      setUp,
+      "/signup",
+      {
+        ...simCognitoAuthorizeParameters(setUp),
+        username: simCognitoLocalUsername,
+        password: simCognitoLocalPassword,
+      },
+      { "user-agent": scraperUserAgent },
+    );
+
+    // Then it is turned away and the pool gained no user.
+    assertIdentical(blocked.status, 403);
+    assertIdentical(pool.userCount, 0);
+    assertUndefined(pool.findUser(simCognitoLocalUsername));
+  });
+
+  it("covers the token endpoint and the password reset pages too", async () => {
+    // Given a protected pool.
+    const setUp = await simCognitoHosted();
+    await protect(setUp, [blockScraper]);
+    const headers = { "user-agent": scraperUserAgent };
+
+    // When the scraper reaches each of the other endpoints the domain serves.
+    const token = await post(setUp, "/oauth2/token", {}, headers);
+    const logout = await get(setUp, "/logout", headers);
+    const forgot = await get(setUp, "/forgotPassword", headers);
+    const reset = await get(setUp, "/confirmForgotPassword", headers);
+    const confirm = await get(setUp, "/confirm", headers);
+
+    // Then every one of them is blocked, because the web ACL is in front of
+    // the domain rather than in front of one page of it.
+    assertIdentical(token.status, 403);
+    assertIdentical(logout.status, 403);
+    assertIdentical(forgot.status, 403);
+    assertIdentical(reset.status, 403);
+    assertIdentical(confirm.status, 403);
+  });
+
+  it("matches nothing on the body of a hosted domain request", async () => {
+    // Given a pool protected by a rule inspecting the request body.
+    const setUp = await simCognitoHosted();
+    await protect(setUp, [
+      {
+        Name: "block-body",
+        Priority: 0,
+        Action: { Block: {} },
+        Statement: {
+          ByteMatchStatement: {
+            FieldToMatch: { Body: { OversizeHandling: "CONTINUE" } },
+            PositionalConstraint: "CONTAINS",
+            SearchString: Buffer.from(simCognitoLocalUsername),
+            TextTransformations: [{ Priority: 0, Type: "NONE" }],
+          },
+        },
+        VisibilityConfig: { ...visibility, MetricName: "block-body" },
+      },
+    ]);
+    const pool = setUp.cognito.userPool(setUp.userPoolId);
+
+    // When a sign-up carrying that username in its body is posted.
+    const response = await post(setUp, "/signup", {
+      ...simCognitoAuthorizeParameters(setUp),
+      username: simCognitoLocalUsername,
+      password: simCognitoLocalPassword,
+    });
+
+    // Then the rule never sees it. Cognito forwards the headers and the path
+    // of a managed login request to AWS WAF and none of its body, so the
+    // sign-up runs and the user is in the pool.
+    assertIdentical(response.status, 303);
+    assertNonNullable(pool.findUser(simCognitoLocalUsername));
+  });
+
+  it("forwards the headers an allow rule inserted to the endpoint", async () => {
+    // Given a pool protected by an allow rule with custom request handling.
+    const setUp = await simCognitoHosted();
+    await protect(setUp, [
+      {
+        Name: "allow-browser",
+        Priority: 0,
+        Action: {
+          Allow: {
+            CustomRequestHandling: {
+              InsertHeaders: [{ Name: "verified", Value: "yes" }],
+            },
+          },
+        },
+        Statement: {
+          ByteMatchStatement: {
+            FieldToMatch: { UriPath: {} },
+            PositionalConstraint: "CONTAINS",
+            SearchString: Buffer.from("/oauth2/authorize"),
+            TextTransformations: [{ Priority: 0, Type: "NONE" }],
+          },
+        },
+        VisibilityConfig: { ...visibility, MetricName: "allow-browser" },
+      },
+    ]);
+
+    // When the sign-in page is fetched.
+    const response = await get(setUp, "/oauth2/authorize");
+
+    // Then the endpoint answers the forwarded request, which carries the
+    // header the rule added under WAF's own prefix.
+    assertIdentical(response.status, 200);
+    assertStringIncludes(await response.text(), 'name="username"');
+  });
+
+  it("leaves a pool nothing is in front of serving as it did", async () => {
+    // Given a pool with no web ACL associated with it.
+    const setUp = await simCognitoHosted();
+
+    // When the sign-in page is fetched by the scraper.
+    const response = await get(setUp, "/oauth2/authorize", {
+      "user-agent": scraperUserAgent,
+    });
+
+    // Then it is served, because nothing is there to turn it away.
+    assertIdentical(response.status, 200);
+  });
+});

--- a/src/service/cognito/sim-cognito-identity-provider.ts
+++ b/src/service/cognito/sim-cognito-identity-provider.ts
@@ -9,14 +9,16 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import {
+  SimWafNoProtection,
+  type SimWafProtection,
+} from "../wafv2/association/sim-waf-protection.js";
 import { SimCognitoCfnResourceFactory } from "./cfn/sim-cfn-cognito-resource-factory.js";
-import type * as simCognitoCommands from "./command/sim-cognito-command.types.js";
 import { SimCognitoCommands } from "./command/sim-cognito-commands.js";
 import { SimCognitoDomainRegistry } from "./registry/sim-cognito-domain-registry.js";
 import { SimCognitoUserPoolRegistry } from "./registry/sim-cognito-user-pool-registry.js";
 import { SimCognitoSdkCommandRouter } from "./sdk/sim-cognito-sdk-command-router.js";
-import { SimCognitoAppClients } from "./sim-cognito-app-clients.js";
-import type { SimCognitoIdentityProviderRequestOptions } from "./sim-cognito-user-directory.js";
+import { SimCognitoUserPools } from "./sim-cognito-user-pools.js";
 import type { SimCognitoUserPoolClient } from "./user-pool/client/sim-cognito-user-pool-client.js";
 import type { SimCognitoUserPoolDomain } from "./user-pool/domain/sim-cognito-user-pool-domain.js";
 import type {
@@ -63,6 +65,13 @@ interface SimCognitoIdentityProviderProperties {
    * ARN, and that ARN can name any Account and Region.
    */
   readonly triggerFunctions?: SimCognitoTriggerFunctions;
+
+  /**
+   * The web ACLs this scope's pools can be protected by. A standalone
+   * simulated Cognito has none, so a hosted domain serves the requests it
+   * always did.
+   */
+  readonly webAcls?: SimWafProtection;
 }
 
 /**
@@ -81,7 +90,7 @@ interface SimCognitoIdentityProviderProperties {
  * Only user pools are simulated. Cognito identity pools, which hand out AWS
  * credentials, are a different service and are not simulated at all.
  */
-export class SimCognitoIdentityProvider extends SimCognitoAppClients {
+export class SimCognitoIdentityProvider extends SimCognitoUserPools {
   private readonly pools: SimCognitoUserPoolStore;
   private readonly userPoolRegistry: SimCognitoUserPoolRegistry;
   private readonly domainRegistry: SimCognitoDomainRegistry;
@@ -98,6 +107,7 @@ export class SimCognitoIdentityProvider extends SimCognitoAppClients {
       userPoolRegistry = new SimCognitoUserPoolRegistry(),
       domainRegistry = new SimCognitoDomainRegistry(),
       triggerFunctions = new SimCognitoNoTriggerFunctions(),
+      webAcls = new SimWafNoProtection(),
     } = properties;
     const pools = new SimCognitoUserPoolStore({
       registry: userPoolRegistry,
@@ -112,6 +122,7 @@ export class SimCognitoIdentityProvider extends SimCognitoAppClients {
         pools,
         domains: domainRegistry,
         triggerFunctions,
+        webAcls,
       }),
       background,
     });
@@ -199,84 +210,15 @@ export class SimCognitoIdentityProvider extends SimCognitoAppClients {
   }
 
   /**
-   * Handle a CreateUserPool Command from the SDK.
-   */
-  async createUserPool(
-    command: simCognitoCommands.SimCreateUserPoolCommand,
-    options?: SimCognitoIdentityProviderRequestOptions,
-  ): Promise<simCognitoCommands.SimCreateUserPoolCommandOutput> {
-    await this.background.sequence();
-    return this.commands.userPools.create(command, options);
-  }
-
-  /**
-   * Handle a DescribeUserPool Command from the SDK.
-   */
-  async describeUserPool(
-    command: simCognitoCommands.SimDescribeUserPoolCommand,
-    options?: SimCognitoIdentityProviderRequestOptions,
-  ): Promise<simCognitoCommands.SimDescribeUserPoolCommandOutput> {
-    await this.background.sequence();
-    return this.commands.userPools.describe(command, options);
-  }
-
-  /**
-   * Handle an UpdateUserPool Command from the SDK.
-   */
-  async updateUserPool(
-    command: simCognitoCommands.SimUpdateUserPoolCommand,
-    options?: SimCognitoIdentityProviderRequestOptions,
-  ): Promise<simCognitoCommands.SimUpdateUserPoolCommandOutput> {
-    await this.background.sequence();
-    return this.commands.userPools.update(command, options);
-  }
-
-  /**
-   * Handle a DeleteUserPool Command from the SDK.
-   */
-  async deleteUserPool(
-    command: simCognitoCommands.SimDeleteUserPoolCommand,
-    options?: SimCognitoIdentityProviderRequestOptions,
-  ): Promise<simCognitoCommands.SimDeleteUserPoolCommandOutput> {
-    await this.background.sequence();
-    return this.commands.userPools.delete(command, options);
-  }
-
-  /**
-   * Handle a SetUserPoolMfaConfig Command from the SDK.
+   * The web ACLs in front of this scope's pools, as a served request sees
+   * them.
    *
-   * This is the second call real CloudFormation makes when a template declares
-   * a pool with MFA, and the only place the factors behind an `MfaConfiguration`
-   * are set.
+   * The simulator's own accessor rather than a Cognito operation: a request to
+   * a pool's hosted domain is served without a Command, so this is how the
+   * serving layer reaches whatever a web ACL decided about it.
    */
-  async setUserPoolMfaConfig(
-    command: simCognitoCommands.SimSetUserPoolMfaConfigCommand,
-    options?: SimCognitoIdentityProviderRequestOptions,
-  ): Promise<simCognitoCommands.SimSetUserPoolMfaConfigCommandOutput> {
-    await this.background.sequence();
-    return this.commands.userPoolMfa.set(command, options);
-  }
-
-  /**
-   * Handle a GetUserPoolMfaConfig Command from the SDK.
-   */
-  async getUserPoolMfaConfig(
-    command: simCognitoCommands.SimGetUserPoolMfaConfigCommand,
-    options?: SimCognitoIdentityProviderRequestOptions,
-  ): Promise<simCognitoCommands.SimGetUserPoolMfaConfigCommandOutput> {
-    await this.background.sequence();
-    return this.commands.userPoolMfa.get(command, options);
-  }
-
-  /**
-   * Handle a ListUserPools Command from the SDK.
-   */
-  async listUserPools(
-    command: simCognitoCommands.SimListUserPoolsCommand,
-    options?: SimCognitoIdentityProviderRequestOptions,
-  ): Promise<simCognitoCommands.SimListUserPoolsCommandOutput> {
-    await this.background.sequence();
-    return this.commands.listUserPools.handle(command, options);
+  webAcls(): SimWafProtection {
+    return this.commands.webAcls;
   }
 
   /**

--- a/src/service/cognito/sim-cognito-user-pools.ts
+++ b/src/service/cognito/sim-cognito-user-pools.ts
@@ -1,0 +1,108 @@
+import type { BackgroundScheduler } from "../../util/background/background.js";
+import type * as simCognitoCommands from "./command/sim-cognito-command.types.js";
+import type { SimCognitoCommands } from "./command/sim-cognito-commands.js";
+import { SimCognitoAppClients } from "./sim-cognito-app-clients.js";
+import type { SimCognitoIdentityProviderRequestOptions } from "./sim-cognito-user-directory.js";
+
+export type { SimCognitoIdentityProviderRequestOptions } from "./sim-cognito-user-directory.js";
+
+interface SimCognitoUserPoolsProperties {
+  readonly commands: SimCognitoCommands;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * The pool operations of simulated Cognito: creating a pool, reading and
+ * changing its settings, deleting it, and listing the pools a scope holds.
+ *
+ * They are a class of their own for the reason the rest of the chain is: one
+ * class holding every Cognito operation had outgrown reading in one sitting,
+ * and `SimCognitoIdentityProvider` above this holds the wiring the whole
+ * service is built from.
+ */
+export abstract class SimCognitoUserPools extends SimCognitoAppClients {
+  protected constructor(properties: SimCognitoUserPoolsProperties) {
+    super(properties);
+  }
+
+  /**
+   * Handle a CreateUserPool Command from the SDK.
+   */
+  async createUserPool(
+    command: simCognitoCommands.SimCreateUserPoolCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimCreateUserPoolCommandOutput> {
+    await this.background.sequence();
+    return this.commands.userPools.create(command, options);
+  }
+
+  /**
+   * Handle a DescribeUserPool Command from the SDK.
+   */
+  async describeUserPool(
+    command: simCognitoCommands.SimDescribeUserPoolCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimDescribeUserPoolCommandOutput> {
+    await this.background.sequence();
+    return this.commands.userPools.describe(command, options);
+  }
+
+  /**
+   * Handle an UpdateUserPool Command from the SDK.
+   */
+  async updateUserPool(
+    command: simCognitoCommands.SimUpdateUserPoolCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimUpdateUserPoolCommandOutput> {
+    await this.background.sequence();
+    return this.commands.userPools.update(command, options);
+  }
+
+  /**
+   * Handle a DeleteUserPool Command from the SDK.
+   */
+  async deleteUserPool(
+    command: simCognitoCommands.SimDeleteUserPoolCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimDeleteUserPoolCommandOutput> {
+    await this.background.sequence();
+    return this.commands.userPools.delete(command, options);
+  }
+
+  /**
+   * Handle a SetUserPoolMfaConfig Command from the SDK.
+   *
+   * This is the second call real CloudFormation makes when a template declares
+   * a pool with MFA, and the only place the factors behind an `MfaConfiguration`
+   * are set.
+   */
+  async setUserPoolMfaConfig(
+    command: simCognitoCommands.SimSetUserPoolMfaConfigCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimSetUserPoolMfaConfigCommandOutput> {
+    await this.background.sequence();
+    return this.commands.userPoolMfa.set(command, options);
+  }
+
+  /**
+   * Handle a GetUserPoolMfaConfig Command from the SDK.
+   */
+  async getUserPoolMfaConfig(
+    command: simCognitoCommands.SimGetUserPoolMfaConfigCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimGetUserPoolMfaConfigCommandOutput> {
+    await this.background.sequence();
+    return this.commands.userPoolMfa.get(command, options);
+  }
+
+  /**
+   * Handle a ListUserPools Command from the SDK.
+   */
+  async listUserPools(
+    command: simCognitoCommands.SimListUserPoolsCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimListUserPoolsCommandOutput> {
+    await this.background.sequence();
+    return this.commands.listUserPools.handle(command, options);
+  }
+}

--- a/src/service/wafv2/README.md
+++ b/src/service/wafv2/README.md
@@ -5,9 +5,9 @@ regex pattern sets, and it evaluates a request against a web ACL's rules to reac
 of the AWS managed rule groups are carried here, approximated to a tier each rule declares.
 
 `SimWafV2.evaluateRequest` is the entry point a fronting service calls once it has a web ACL ARN to
-hand. An API Gateway REST API stage reaches it through `AssociateWebACL`. Simulated CloudFront calls
-it in `cloudfront/controller/web-acl/`, for every request to a distribution whose `WebACLId` names
-one. Cognito user pools come later.
+hand. An API Gateway REST API stage and a Cognito user pool both reach it through
+`AssociateWebACL`. Simulated CloudFront calls it in `cloudfront/controller/web-acl/`, for every
+request to a distribution whose `WebACLId` names one.
 
 ## Entry points
 
@@ -79,28 +79,42 @@ name:
 ```text
 SimWafAssociations              resource ARN to web ACL, and what a fronting service asks it
 ├── SimWafProtectedResource     what an association ARN names, read from the ARN
-│   └── SimWafRestApiStage      the one resource type so far
+│   ├── SimWafRestApiStage      an API Gateway REST API stage
+│   └── SimWafUserPool          a Cognito user pool
 ├── SimWafProtectedResources    the port asking whether that resource is there
-└── SimWafProtection            the port a fronting service takes
+├── SimWafProtection            the port a fronting service takes
+└── SimWafRequestInspection     the serving half, shared by both fronting services
 ```
 
-The store holds the web ACL itself rather than its ARN. A request reaching a protected stage is then
-evaluated without a second lookup, and `DeleteWebACL` refuses a web ACL something still points at.
-Deleting the web ACL out from under a stage would leave the stage protected by rules nothing holds.
+The store holds the web ACL itself rather than its ARN. A request reaching a protected resource is
+then evaluated without a second lookup, and `DeleteWebACL` refuses a web ACL something still points
+at. Deleting the web ACL out from under a stage would leave the stage protected by rules nothing
+holds. Each association records the resource type alongside the web ACL, because
+`ListResourcesForWebACL` lists one type at a time and the ARN would otherwise have to be read again
+to say which type it named.
 
 Two ports run in opposite directions, and both are needed. `SimWafProtectedResources` is how
-WAFv2 asks whether a stage ARN names anything, since WAFv2 holds no API Gateway state of its own.
-`SimWafProtection` is how a simulated API Gateway reaches the web ACL in front of a stage it is
-about to serve, and how it lets go of one when the stage is deleted.
+WAFv2 asks whether a resource ARN names anything, since WAFv2 holds no API Gateway or Cognito state
+of its own. `SimWafProtection` is how a fronting service reaches the web ACL in front of the
+resource it is about to serve, and how it lets go of one when the resource is deleted.
 `SimAwsWafProtectedResources` is the implementation reading a simulated AWS instance, and a
 standalone `SimWafV2` gets `SimWafNoProtectedResources`, which finds nothing. A standalone
-`SimApiGateway` gets `SimWafNoProtection` and serves every request the way it did before web ACLs.
+`SimApiGateway` or `SimCognitoIdentityProvider` gets `SimWafNoProtection` and serves every request
+the way it did before web ACLs.
+
+`association/sim-waf-request-inspection.ts` is the serving half both fronting services share. It
+short-circuits on an unprotected resource, evaluates the rules, turns a block into the 403 response
+and adds an `Allow` rule's inserted headers to what is forwarded. Two things differ between the
+services and are asked for there. Where the resource ARN comes from, and whether the body is
+forwarded. API Gateway forwards it. Cognito forwards it for the user pool API and withholds it for
+managed login. `forwardBody` is `false` on the Cognito path, which leaves a `ByteMatchStatement` on
+`Body` inspecting an empty field at a hosted domain, as it inspects one on AWS.
 
 `sim-waf-protected-resource.ts` reads an ARN for what it names. The three refusals in it mean
 different things. An HTTP API stage is refused because AWS WAF protects no HTTP API, and an
 association accepted here would let a test cover protection AWS never applies. A load balancer and
-the other four resource types AWS does protect are refused as unsimulated. Anything else is refused
-as an ARN. A second target type joins the union and gains a branch in the reader, and everything
+the other three resource types AWS does protect are refused as unsimulated. Anything else is refused
+as an ARN. A third target type joins the union and gains a branch in the reader, and everything
 holding an association goes on addressing a resource by its ARN.
 
 ## Compiling a statement

--- a/src/service/wafv2/association/sim-aws-waf-protected-resources.ts
+++ b/src/service/wafv2/association/sim-aws-waf-protected-resources.ts
@@ -1,7 +1,12 @@
-import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type {
+  SimAwsAccountRegionContainer,
+  SimAwsAccountRegionScope,
+} from "../../aws/sim-aws-account-region-scope.js";
 import type { SimAws } from "../../aws/sim-aws.js";
 import type { SimWafProtectedResource } from "./sim-waf-protected-resource.js";
 import type { SimWafProtectedResources } from "./sim-waf-protected-resources.js";
+import type { SimWafRestApiStage } from "./sim-waf-rest-api-stage.js";
+import type { SimWafUserPool } from "./sim-waf-user-pool.js";
 
 interface SimAwsWafProtectedResourcesProperties {
   readonly simAws: SimAws;
@@ -15,7 +20,8 @@ interface SimAwsWafProtectedResourcesProperties {
  * The lookup is made in the Account and Region the WAFv2 handling the request
  * belongs to. A stage ARN names no Account, and AWS WAF associates within one
  * Account, so a stage created elsewhere in the simulation is not there to be
- * found.
+ * found. A user pool ARN does name an Account, and one naming another Account
+ * was already refused before the lookup.
  */
 export class SimAwsWafProtectedResources implements SimWafProtectedResources {
   readonly #simAws: SimAws;
@@ -27,15 +33,47 @@ export class SimAwsWafProtectedResources implements SimWafProtectedResources {
   }
 
   /**
-   * Whether the REST API stage an ARN names is one this scope holds.
+   * Whether the resource an ARN names is one this scope holds.
    */
   has(resource: SimWafProtectedResource): boolean {
-    const { accountId, regionName } = this.#accountRegionScope;
-    const restApi = this.#simAws
-      .accountRegionScope(accountId, regionName)
-      .apiGateway()
-      .findRestApi(resource.restApiId);
+    if (resource.resourceType === "COGNITO_USER_POOL") {
+      return this.hasUserPool(resource);
+    }
+
+    return this.hasRestApiStage(resource);
+  }
+
+  /**
+   * Whether this scope holds the REST API stage an ARN names.
+   */
+  private hasRestApiStage(resource: SimWafRestApiStage): boolean {
+    const restApi = this.scope().apiGateway().findRestApi(resource.restApiId);
 
     return restApi?.stages.find(resource.stageName) !== undefined;
+  }
+
+  /**
+   * Whether this scope holds the user pool an ARN names.
+   *
+   * The ARN is compared rather than the id alone. A pool id is unique across
+   * the whole simulation, so a pool this scope does not hold is simply not
+   * found, and comparing the ARN says the same thing about a pool id that is
+   * there under a different Account.
+   */
+  private hasUserPool(resource: SimWafUserPool): boolean {
+    const pool = this.scope()
+      .cognitoIdentityProvider()
+      .findUserPool(resource.userPoolId);
+
+    return pool?.arn.value === resource.arn;
+  }
+
+  /**
+   * The simulated services of the Account and Region this WAFv2 belongs to.
+   */
+  private scope(): SimAwsAccountRegionContainer {
+    const { accountId, regionName } = this.#accountRegionScope;
+
+    return this.#simAws.accountRegionScope(accountId, regionName);
   }
 }

--- a/src/service/wafv2/association/sim-waf-associations.ts
+++ b/src/service/wafv2/association/sim-waf-associations.ts
@@ -2,9 +2,25 @@ import type { SimWafDecision } from "../evaluate/sim-waf-decision.js";
 import { simWafInspectedRequest } from "../evaluate/sim-waf-inspected-request.js";
 import type { SimWafWebAcl } from "../web-acl/sim-waf-web-acl.js";
 import type {
+  SimWafProtectedResource,
+  SimWafProtectedResourceType,
+} from "./sim-waf-protected-resource.js";
+import type {
   SimWafProtectedRequest,
   SimWafProtection,
 } from "./sim-waf-protection.js";
+
+/**
+ * One web ACL in front of one resource.
+ *
+ * The resource type is held with it because `ListResourcesForWebACL` lists one
+ * type at a time, and the ARN alone would have to be read again to say which
+ * type it named.
+ */
+interface SimWafAssociation {
+  readonly webAcl: SimWafWebAcl;
+  readonly resourceType: SimWafProtectedResourceType;
+}
 
 /**
  * The web ACLs one Account and Region has in front of things.
@@ -15,7 +31,7 @@ import type {
  * web ACL cannot be deleted out from under a resource still pointing at it.
  */
 export class SimWafAssociations implements SimWafProtection {
-  readonly #webAcls = new Map<string, SimWafWebAcl>();
+  readonly #associations = new Map<string, SimWafAssociation>();
 
   /**
    * Put a web ACL in front of one resource, replacing whatever was there.
@@ -23,25 +39,40 @@ export class SimWafAssociations implements SimWafProtection {
    * AssociateWebACL overwrites rather than refusing, because a resource has
    * one web ACL and pointing it at another is how it is changed.
    */
-  associate(resourceArn: string, webAcl: SimWafWebAcl): void {
-    this.#webAcls.set(resourceArn, webAcl);
+  associate(resource: SimWafProtectedResource, webAcl: SimWafWebAcl): void {
+    this.#associations.set(resource.arn, {
+      webAcl,
+      resourceType: resource.resourceType,
+    });
   }
 
   /**
    * The web ACL in front of one resource, or nothing when it has none.
    */
   webAclFor(resourceArn: string): SimWafWebAcl | undefined {
-    return this.#webAcls.get(resourceArn);
+    return this.#associations.get(resourceArn)?.webAcl;
   }
 
   /**
    * The resources one web ACL is in front of, in the order they were
    * associated.
+   *
+   * A resource type narrows the answer to the resources of that type, as
+   * `ListResourcesForWebACL` does. Naming none answers with all of them, which
+   * is what `DeleteWebACL` asks for when it refuses a web ACL still in use.
    */
-  resourceArnsFor(webAcl: SimWafWebAcl): readonly string[] {
-    return this.#webAcls
+  resourceArnsFor(
+    webAcl: SimWafWebAcl,
+    resourceType?: SimWafProtectedResourceType,
+  ): readonly string[] {
+    return this.#associations
       .entries()
-      .filter(([, associated]) => associated === webAcl)
+      .filter(([, association]) => association.webAcl === webAcl)
+      .filter(
+        ([, association]) =>
+          resourceType === undefined ||
+          association.resourceType === resourceType,
+      )
       .map(([resourceArn]) => resourceArn)
       .toArray();
   }
@@ -50,20 +81,20 @@ export class SimWafAssociations implements SimWafProtection {
    * Whether a web ACL is in front of one resource.
    */
   protects(resourceArn: string): boolean {
-    return this.#webAcls.has(resourceArn);
+    return this.#associations.has(resourceArn);
   }
 
   /**
    * What the web ACL in front of one resource decides about a request.
    */
   decide(request: SimWafProtectedRequest): SimWafDecision | undefined {
-    const webAcl = this.#webAcls.get(request.resourceArn);
+    const association = this.#associations.get(request.resourceArn);
 
-    if (webAcl === undefined) {
+    if (association === undefined) {
       return undefined;
     }
 
-    return webAcl.evaluate(
+    return association.webAcl.evaluate(
       simWafInspectedRequest(request.request, request.body),
     );
   }
@@ -76,6 +107,6 @@ export class SimWafAssociations implements SimWafProtection {
    * unprotected, as it is on AWS.
    */
   release(resourceArn: string): void {
-    this.#webAcls.delete(resourceArn);
+    this.#associations.delete(resourceArn);
   }
 }

--- a/src/service/wafv2/association/sim-waf-protected-resource.ts
+++ b/src/service/wafv2/association/sim-waf-protected-resource.ts
@@ -3,26 +3,47 @@ import {
   SimWafUnsimulatedInputException,
 } from "../error/sim-wafv2.error.js";
 import { SimWafRestApiStage } from "./sim-waf-rest-api-stage.js";
+import { SimWafUserPool } from "./sim-waf-user-pool.js";
 
 /**
  * A resource a `REGIONAL` web ACL can be put in front of.
  *
- * One type is simulated so far. A second one joins this union and the reader
- * below gains a branch for it, and everything that holds an association goes
- * on addressing a resource by its ARN.
+ * Two types are simulated. A third one joins this union and the reader below
+ * gains a branch for it, and everything that holds an association goes on
+ * addressing a resource by its ARN.
  */
-export type SimWafProtectedResource = SimWafRestApiStage;
+export type SimWafProtectedResource = SimWafRestApiStage | SimWafUserPool;
 
 /**
- * The type ListResourcesForWebACL lists a simulated resource under.
+ * The type ListResourcesForWebACL lists one simulated resource under.
+ */
+export type SimWafProtectedResourceType =
+  SimWafProtectedResource["resourceType"];
+
+/**
+ * The type ListResourcesForWebACL lists a simulated REST API stage under.
  */
 export const simWafApiGatewayResourceType = "API_GATEWAY";
+
+/**
+ * The type ListResourcesForWebACL lists a simulated user pool under.
+ */
+export const simWafUserPoolResourceType = "COGNITO_USER_POOL";
+
+/**
+ * The resource types this simulation holds, as a refusal names them.
+ */
+export const simWafProtectedResourceTypes: readonly SimWafProtectedResourceType[] =
+  [simWafApiGatewayResourceType, simWafUserPoolResourceType];
 
 const restApiStagePattern =
   /^arn:aws:apigateway:(?<regionName>[^:]+)::\/restapis\/(?<restApiId>[^/]+)\/stages\/(?<stageName>[^/]+)$/u;
 
 const httpApiStagePattern =
   /^arn:aws:apigateway:[^:]+::\/apis\/[^/]+\/stages\/[^/]+$/u;
+
+const userPoolPattern =
+  /^arn:aws:cognito-idp:(?<regionName>[^:]+):(?<accountId>[^:]+):userpool\/(?<userPoolId>[^/]+)$/u;
 
 /**
  * The resource types real WAF protects that this simulation does not, by the
@@ -31,7 +52,6 @@ const httpApiStagePattern =
 const unsimulatedResources = new Map<string, string>([
   ["elasticloadbalancing", "an Application Load Balancer"],
   ["appsync", "an AppSync GraphQL API"],
-  ["cognito-idp", "a Cognito user pool"],
   ["apprunner", "an App Runner service"],
   ["amplify", "an Amplify app"],
   ["ec2", "a Verified Access instance"],
@@ -48,15 +68,16 @@ const unsimulatedResources = new Map<string, string>([
  * the ordinary unsimulated refusal. Anything else is not a resource ARN.
  */
 export function simWafProtectedResource(arn: string): SimWafProtectedResource {
-  const { groups } = restApiStagePattern.exec(arn) ?? {};
+  const stage = restApiStage(arn);
 
-  if (groups !== undefined) {
-    return new SimWafRestApiStage({
-      arn,
-      regionName: groups["regionName"] ?? "",
-      restApiId: groups["restApiId"] ?? "",
-      stageName: groups["stageName"] ?? "",
-    });
+  if (stage !== undefined) {
+    return stage;
+  }
+
+  const userPool = simWafUserPool(arn);
+
+  if (userPool !== undefined) {
+    return userPool;
   }
 
   if (httpApiStagePattern.test(arn)) {
@@ -74,6 +95,42 @@ export function simWafProtectedResource(arn: string): SimWafProtectedResource {
       `includes other information separated by colons or slashes., ` +
       `field: RESOURCE_ARN, parameter: ${arn}`,
   );
+}
+
+/**
+ * The REST API stage an ARN names, or nothing when it names no stage.
+ */
+function restApiStage(arn: string): SimWafRestApiStage | undefined {
+  const { groups } = restApiStagePattern.exec(arn) ?? {};
+
+  if (groups === undefined) {
+    return undefined;
+  }
+
+  return new SimWafRestApiStage({
+    arn,
+    regionName: groups["regionName"] ?? "",
+    restApiId: groups["restApiId"] ?? "",
+    stageName: groups["stageName"] ?? "",
+  });
+}
+
+/**
+ * The user pool an ARN names, or nothing when it names no pool.
+ */
+function simWafUserPool(arn: string): SimWafUserPool | undefined {
+  const { groups } = userPoolPattern.exec(arn) ?? {};
+
+  if (groups === undefined) {
+    return undefined;
+  }
+
+  return new SimWafUserPool({
+    arn,
+    regionName: groups["regionName"] ?? "",
+    accountId: groups["accountId"] ?? "",
+    userPoolId: groups["userPoolId"] ?? "",
+  });
 }
 
 /**

--- a/src/service/wafv2/association/sim-waf-request-inspection.ts
+++ b/src/service/wafv2/association/sim-waf-request-inspection.ts
@@ -1,0 +1,120 @@
+import { simWafBlockedHttpResponse } from "../evaluate/sim-waf-blocked-response.js";
+import type { SimWafHeader } from "../web-acl/sim-waf-custom-response.type.js";
+import type { SimWafProtection } from "./sim-waf-protection.js";
+
+interface SimWafInspectionInput {
+  /** The web ACLs the fronting service's resources are protected by. */
+  readonly protection: SimWafProtection;
+
+  /** The resource the request reached, by ARN. */
+  readonly resourceArn: string;
+
+  readonly request: Request;
+
+  /**
+   * Whether the fronting service forwards the request body to AWS WAF.
+   *
+   * API Gateway forwards it. Cognito forwards it for the user pool API and not
+   * for managed login, so a rule inspecting the body of a hosted domain
+   * request matches nothing, as it matches nothing on AWS.
+   */
+  readonly forwardBody: boolean;
+}
+
+interface SimWafInspectedProperties {
+  readonly request: Request;
+  readonly blocked?: Response | undefined;
+}
+
+/**
+ * What the web ACL in front of a resource left of one request.
+ *
+ * A blocked request has a response to send and goes no further. An allowed one
+ * carries on, as the request the rules asked for rather than the one that
+ * arrived, since a rule can add headers to what is forwarded.
+ */
+export class SimWafInspected {
+  public readonly request: Request;
+  public readonly blocked: Response | undefined;
+
+  constructor(properties: SimWafInspectedProperties) {
+    this.request = properties.request;
+    this.blocked = properties.blocked;
+  }
+}
+
+/**
+ * Puts a served request to the web ACL in front of the resource it reached.
+ *
+ * This is the serving half of an association, shared by every service that
+ * answers HTTP requests for a protected resource. What differs between them is
+ * where the resource ARN comes from and whether the body is forwarded, so both
+ * are asked for rather than worked out here.
+ */
+export class SimWafRequestInspection {
+  /**
+   * Put one request to whatever protects the resource it addressed.
+   */
+  async inspect(input: SimWafInspectionInput): Promise<SimWafInspected> {
+    const { protection, resourceArn, request } = input;
+
+    if (!protection.protects(resourceArn)) {
+      return new SimWafInspected({ request });
+    }
+
+    const body = input.forwardBody ? await inspectedBody(request) : undefined;
+    const decision = protection.decide({ resourceArn, request, body });
+
+    // A decision carries a blocked response when its action was to block, and
+    // carries none when the request was allowed. That one reading is what
+    // decides the request here.
+    if (decision?.blocked !== undefined) {
+      return new SimWafInspected({
+        request,
+        blocked: simWafBlockedHttpResponse(decision.blocked),
+      });
+    }
+
+    return new SimWafInspected({
+      request: forwarded(request, decision?.insertedHeaders ?? []),
+    });
+  }
+}
+
+/**
+ * The request body a web ACL's rules are matched against.
+ *
+ * The request is cloned rather than read, so whatever the request goes on to
+ * reach still has a body to send.
+ */
+async function inspectedBody(
+  request: Request,
+): Promise<Uint8Array | undefined> {
+  const buffered = new Uint8Array(await request.clone().arrayBuffer());
+
+  return buffered.byteLength === 0 ? undefined : buffered;
+}
+
+/**
+ * The request as the web ACL asked for it to be forwarded.
+ *
+ * A rule with custom request handling adds headers to what reaches the origin.
+ * Only the headers are replaced, so the body carries over as the stream it
+ * arrived as: inspection read a clone of it rather than the request itself.
+ */
+function forwarded(
+  request: Request,
+  insertedHeaders: readonly SimWafHeader[],
+): Request {
+  if (insertedHeaders.length === 0) {
+    return request;
+  }
+
+  const headers = new Headers(request.headers);
+
+  for (const header of insertedHeaders) {
+    headers.set(header.name, header.value);
+  }
+
+  return new Request(request, { headers });
+}

--- a/src/service/wafv2/association/sim-waf-rest-api-stage.ts
+++ b/src/service/wafv2/association/sim-waf-rest-api-stage.ts
@@ -9,13 +9,18 @@ interface SimWafRestApiStageProperties {
  * One API Gateway REST API stage, as the ARN an association names it by.
  *
  * The ARN is written `arn:aws:apigateway:<region>::/restapis/<id>/stages/<name>`
- * and carries no Account. A web ACL and the resource it protects are in the
- * same Account on AWS, so the Account is the one the WAFv2 handling the
- * request belongs to.
+ * and carries no Account.
  */
 export class SimWafRestApiStage {
   /** The type this resource is listed under by ListResourcesForWebACL. */
   public readonly resourceType = "API_GATEWAY";
+
+  /**
+   * The Account the stage is in, which its ARN does not name. A web ACL and
+   * the resource it protects are in the same Account on AWS, so the Account is
+   * the one the WAFv2 handling the request belongs to.
+   */
+  public readonly accountId: string | undefined = undefined;
 
   public readonly arn: string;
   public readonly regionName: string;

--- a/src/service/wafv2/association/sim-waf-user-pool.ts
+++ b/src/service/wafv2/association/sim-waf-user-pool.ts
@@ -1,0 +1,30 @@
+interface SimWafUserPoolProperties {
+  readonly arn: string;
+  readonly regionName: string;
+  readonly accountId: string;
+  readonly userPoolId: string;
+}
+
+/**
+ * One Cognito user pool, as the ARN an association names it by.
+ *
+ * The ARN is written `arn:aws:cognito-idp:<region>:<account>:userpool/<pool-id>`
+ * and names both the Account and the Region, where a REST API stage ARN names
+ * neither. The pool id repeats the Region, as a real pool id does.
+ */
+export class SimWafUserPool {
+  /** The type this resource is listed under by ListResourcesForWebACL. */
+  public readonly resourceType = "COGNITO_USER_POOL";
+
+  public readonly arn: string;
+  public readonly regionName: string;
+  public readonly accountId: string;
+  public readonly userPoolId: string;
+
+  constructor(properties: SimWafUserPoolProperties) {
+    this.arn = properties.arn;
+    this.regionName = properties.regionName;
+    this.accountId = properties.accountId;
+    this.userPoolId = properties.userPoolId;
+  }
+}

--- a/src/service/wafv2/command/association/sim-wafv2-association-commands.ts
+++ b/src/service/wafv2/command/association/sim-wafv2-association-commands.ts
@@ -3,7 +3,7 @@ import { requiredSimWafArn } from "../sim-wafv2-input.js";
 import type { SimWafRequestOptions } from "../sim-wafv2-request-options.js";
 import { simWafWebAclOutput } from "../web-acl/sim-waf-web-acl-output.js";
 import type { SimWafAssociationAccess } from "./sim-wafv2-association-access.js";
-import { refuseUnsimulatedSimWafResourceType } from "./sim-wafv2-association-input.js";
+import { simWafListedResourceType } from "./sim-wafv2-association-input.js";
 import type {
   SimAssociateWebAclCommand,
   SimAssociateWebAclCommandOutput,
@@ -58,7 +58,7 @@ export class SimWafAssociationCommands {
     const webAcl = this.#access.webAcl(webAclArn);
 
     this.#access.requireResource(resource);
-    this.#associations.associate(resource.arn, webAcl);
+    this.#associations.associate(resource, webAcl);
 
     return { $metadata: {} };
   }
@@ -117,8 +117,7 @@ export class SimWafAssociationCommands {
   ): SimListResourcesForWebAclCommandOutput {
     const { input } = command;
     const webAclArn = requiredSimWafArn(input.WebACLArn, "WebACLArn");
-
-    refuseUnsimulatedSimWafResourceType(input.ResourceType);
+    const resourceType = simWafListedResourceType(input.ResourceType);
 
     this.#access.authorizeWebAcl(
       "wafv2:ListResourcesForWebACL",
@@ -130,6 +129,7 @@ export class SimWafAssociationCommands {
       $metadata: {},
       ResourceArns: this.#associations.resourceArnsFor(
         this.#access.webAcl(webAclArn),
+        resourceType,
       ),
     };
   }

--- a/src/service/wafv2/command/association/sim-wafv2-association-input.ts
+++ b/src/service/wafv2/command/association/sim-wafv2-association-input.ts
@@ -1,8 +1,9 @@
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import {
   type SimWafProtectedResource,
-  simWafApiGatewayResourceType,
+  type SimWafProtectedResourceType,
   simWafProtectedResource,
+  simWafProtectedResourceTypes,
 } from "../../association/sim-waf-protected-resource.js";
 import {
   SimWafInvalidParameterException,
@@ -13,18 +14,20 @@ import { requiredSimWafArn } from "../sim-wafv2-input.js";
 /**
  * What ListResourcesForWebACL lists when the request names no resource type.
  *
- * Real WAFv2 documents that default, and it is not the type simulated here. A
- * listing that names nothing is refused, because the empty list a load
+ * Real WAFv2 documents that default, and it is not one of the types simulated
+ * here. A listing that names nothing is refused, because the empty list a load
  * balancer listing produces reads as a web ACL protecting nothing.
  */
 const defaultResourceType = "APPLICATION_LOAD_BALANCER";
 
 /**
- * Read the resource an association named, and hold it to one Region.
+ * Read the resource an association named, and hold it to one Account and
+ * Region.
  *
  * A web ACL protects what is in its own Account and Region, as it does on AWS.
- * The Account falls out of the lookup afterwards, since a REST API stage ARN
- * carries none, and the Region has to be read out of the ARN here.
+ * A REST API stage ARN carries neither, so the Region is read out of the ARN
+ * and the Account falls out of the lookup afterwards. A user pool ARN carries
+ * both, and one naming another Account is refused here.
  */
 export function simWafAssociationResource(
   resourceArn: string | undefined,
@@ -33,13 +36,21 @@ export function simWafAssociationResource(
   const resource = simWafProtectedResource(
     requiredSimWafArn(resourceArn, "ResourceArn"),
   );
-  const { regionName } = accountRegionScope;
+  const { accountId, regionName } = accountRegionScope;
 
   if (resource.regionName !== regionName) {
-    throw new SimWafInvalidParameterException(
-      `Error reason: The resource ${resource.arn} is in ` +
-        `${resource.regionName}, and this request was made in ` +
-        `${regionName}., field: RESOURCE_ARN, parameter: ${resource.arn}`,
+    throw refusedResourceArn(
+      `The resource ${resource.arn} is in ${resource.regionName}, and this ` +
+        `request was made in ${regionName}.`,
+      resource.arn,
+    );
+  }
+
+  if (resource.accountId !== undefined && resource.accountId !== accountId) {
+    throw refusedResourceArn(
+      `The resource ${resource.arn} is in Account ${resource.accountId}, and ` +
+        `this request was made in ${accountId}.`,
+      resource.arn,
     );
   }
 
@@ -47,20 +58,38 @@ export function simWafAssociationResource(
 }
 
 /**
- * Refuse a listing for a resource type this simulation does not hold.
+ * Read the resource type a listing named, refusing one this simulation does
+ * not hold.
  */
-export function refuseUnsimulatedSimWafResourceType(
+export function simWafListedResourceType(
   resourceType: string | undefined,
-): void {
+): SimWafProtectedResourceType {
   const listed = resourceType ?? defaultResourceType;
+  const simulated = simWafProtectedResourceTypes.find(
+    (candidate) => candidate === listed,
+  );
 
-  if (listed !== simWafApiGatewayResourceType) {
+  if (simulated === undefined) {
     throw new SimWafUnsimulatedInputException(
       `AWS WAF lists ${listed} resources, and ` +
-        `${simWafApiGatewayResourceType} is the type Yulin simulates. ` +
-        `ListResourcesForWebACL lists ${defaultResourceType} when a request ` +
-        `names no ResourceType, so name ${simWafApiGatewayResourceType} to ` +
-        `list the REST API stages a web ACL protects.`,
+        `${simWafProtectedResourceTypes.join(" and ")} are the types Yulin ` +
+        `simulates. ListResourcesForWebACL lists ${defaultResourceType} when ` +
+        `a request names no ResourceType, so name one of the simulated types ` +
+        `to list the resources a web ACL protects.`,
     );
   }
+
+  return simulated;
+}
+
+/**
+ * The refusal a bad resource ARN reports, in the form WAFv2 writes.
+ */
+function refusedResourceArn(
+  reason: string,
+  resourceArn: string,
+): SimWafInvalidParameterException {
+  return new SimWafInvalidParameterException(
+    `Error reason: ${reason}, field: RESOURCE_ARN, parameter: ${resourceArn}`,
+  );
 }

--- a/src/service/wafv2/index.ts
+++ b/src/service/wafv2/index.ts
@@ -19,6 +19,9 @@ export {
   simWafApiGatewayResourceType,
   type SimWafProtectedResource,
   simWafProtectedResource,
+  type SimWafProtectedResourceType,
+  simWafProtectedResourceTypes,
+  simWafUserPoolResourceType,
 } from "./association/sim-waf-protected-resource.js";
 export {
   SimWafNoProtectedResources,
@@ -29,7 +32,12 @@ export {
   type SimWafProtectedRequest,
   type SimWafProtection,
 } from "./association/sim-waf-protection.js";
+export {
+  SimWafInspected,
+  SimWafRequestInspection,
+} from "./association/sim-waf-request-inspection.js";
 export { SimWafRestApiStage } from "./association/sim-waf-rest-api-stage.js";
+export { SimWafUserPool } from "./association/sim-waf-user-pool.js";
 export {
   SimWafResource,
   type SimWafResourceSummary,

--- a/src/service/wafv2/sim-wafv2-user-pool-associations.iso.test.ts
+++ b/src/service/wafv2/sim-wafv2-user-pool-associations.iso.test.ts
@@ -1,0 +1,206 @@
+import { CreateUserPoolCommand } from "@aws-sdk/client-cognito-identity-provider";
+import { DeleteUserPoolCommand } from "@aws-sdk/client-cognito-identity-provider";
+import {
+  AssociateWebACLCommand,
+  DeleteWebACLCommand,
+  DisassociateWebACLCommand,
+  GetWebACLForResourceCommand,
+  ListResourcesForWebACLCommand,
+} from "@aws-sdk/client-wafv2";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import { simWafCreateWebAclFactory } from "./command/web-acl/sim-waf-create-web-acl.factory.js";
+import { SimWafAssociatedItemException } from "./error/sim-wafv2.error.js";
+import { createSimWafWebAcl } from "./sim-wafv2.fixture.js";
+
+interface SimWafPoolSetUp {
+  readonly userPoolId: string;
+  readonly poolArn: string;
+  readonly webAclArn: string;
+}
+
+/**
+ * A user pool and a REGIONAL web ACL in the same scope.
+ *
+ * The pool is made with the ordinary command, because what an association
+ * needs from Cognito is a pool that is really there.
+ */
+async function poolAndWebAcl(
+  simAws: SimAws,
+  webAclName = "pool-acl",
+): Promise<SimWafPoolSetUp> {
+  const cognito = simAws.cognitoIdentityProvider();
+  const created = await cognito.createUserPool(
+    new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+  );
+  assertNonNullable(created.UserPool?.Id);
+
+  const webAcl = await createSimWafWebAcl(
+    simAws.wafV2(),
+    simWafCreateWebAclFactory.make({ Name: webAclName }),
+  );
+
+  return {
+    userPoolId: created.UserPool.Id,
+    poolArn: cognito.userPool(created.UserPool.Id).arn.value,
+    webAclArn: webAcl.ARN,
+  };
+}
+
+describe("SimWafV2 user pool associations", () => {
+  it("puts a web ACL in front of a user pool and reads it back", async () => {
+    // Given a user pool and a REGIONAL web ACL.
+    const simAws = new SimAws();
+    const { poolArn, webAclArn } = await poolAndWebAcl(simAws);
+    const waf = simAws.wafV2();
+
+    // When the web ACL is associated with the pool by its ARN.
+    await waf.associateWebAcl(
+      new AssociateWebACLCommand({
+        WebACLArn: webAclArn,
+        ResourceArn: poolArn,
+      }),
+    );
+    const read = await waf.getWebAclForResource(
+      new GetWebACLForResourceCommand({ ResourceArn: poolArn }),
+    );
+
+    // Then the pool reports the whole web ACL it now carries.
+    assertNonNullable(read.WebACL);
+    assertIdentical(read.WebACL.Name, "pool-acl");
+    assertIdentical(read.WebACL.ARN, webAclArn);
+  });
+
+  it("lists the user pools one web ACL protects", async () => {
+    // Given one web ACL in front of a user pool.
+    const simAws = new SimAws();
+    const { poolArn, webAclArn } = await poolAndWebAcl(simAws);
+    const waf = simAws.wafV2();
+
+    await waf.associateWebAcl(
+      new AssociateWebACLCommand({
+        WebACLArn: webAclArn,
+        ResourceArn: poolArn,
+      }),
+    );
+
+    // When the pools it protects are listed, and then the REST API stages.
+    const pools = await waf.listResourcesForWebAcl(
+      new ListResourcesForWebACLCommand({
+        WebACLArn: webAclArn,
+        ResourceType: "COGNITO_USER_POOL",
+      }),
+    );
+    const stages = await waf.listResourcesForWebAcl(
+      new ListResourcesForWebACLCommand({
+        WebACLArn: webAclArn,
+        ResourceType: "API_GATEWAY",
+      }),
+    );
+
+    // Then the pool is listed under its own type and under no other.
+    assertArrayEquals(pools.ResourceArns, [poolArn]);
+    assertArrayEquals(stages.ResourceArns, []);
+  });
+
+  it("takes the web ACL back off a user pool", async () => {
+    // Given a web ACL in front of a user pool.
+    const simAws = new SimAws();
+    const { poolArn, webAclArn } = await poolAndWebAcl(simAws);
+    const waf = simAws.wafV2();
+
+    await waf.associateWebAcl(
+      new AssociateWebACLCommand({
+        WebACLArn: webAclArn,
+        ResourceArn: poolArn,
+      }),
+    );
+
+    // When it is disassociated.
+    await waf.disassociateWebAcl(
+      new DisassociateWebACLCommand({ ResourceArn: poolArn }),
+    );
+
+    // Then the pool carries nothing, and the web ACL can be deleted.
+    const read = await waf.getWebAclForResource(
+      new GetWebACLForResourceCommand({ ResourceArn: poolArn }),
+    );
+    assertUndefined(read.WebACL);
+  });
+
+  it("refuses to delete a web ACL still in front of a user pool", async () => {
+    // Given a web ACL in front of a user pool.
+    const simAws = new SimAws();
+    const { poolArn, webAclArn } = await poolAndWebAcl(simAws);
+    const waf = simAws.wafV2();
+    const created = await waf.getWebAclForResource(
+      new GetWebACLForResourceCommand({ ResourceArn: poolArn }),
+    );
+    assertUndefined(created.WebACL);
+
+    await waf.associateWebAcl(
+      new AssociateWebACLCommand({
+        WebACLArn: webAclArn,
+        ResourceArn: poolArn,
+      }),
+    );
+    const webAcl = await waf.getWebAclForResource(
+      new GetWebACLForResourceCommand({ ResourceArn: poolArn }),
+    );
+    assertNonNullable(webAcl.WebACL);
+
+    // When the web ACL is deleted.
+    const error = await assertThrowsErrorAsync(async () => {
+      await waf.deleteWebAcl(
+        new DeleteWebACLCommand({
+          Name: webAcl.WebACL?.Name,
+          Id: webAcl.WebACL?.Id,
+          Scope: "REGIONAL",
+          LockToken: "any",
+        }),
+      );
+    });
+
+    // Then it is refused, naming the pool still pointing at it.
+    assertInstanceOf(error, SimWafAssociatedItemException);
+    assertStringIncludes(error.message, poolArn);
+  });
+
+  it("lets go of the web ACL when the user pool is deleted", async () => {
+    // Given a web ACL in front of a user pool.
+    const simAws = new SimAws();
+    const { userPoolId, poolArn, webAclArn } = await poolAndWebAcl(simAws);
+    const waf = simAws.wafV2();
+
+    await waf.associateWebAcl(
+      new AssociateWebACLCommand({
+        WebACLArn: webAclArn,
+        ResourceArn: poolArn,
+      }),
+    );
+
+    // When the pool is deleted.
+    await simAws
+      .cognitoIdentityProvider()
+      .deleteUserPool(new DeleteUserPoolCommand({ UserPoolId: userPoolId }));
+
+    // Then the web ACL is in front of nothing at all.
+    const listed = await waf.listResourcesForWebAcl(
+      new ListResourcesForWebACLCommand({
+        WebACLArn: webAclArn,
+        ResourceType: "COGNITO_USER_POOL",
+      }),
+    );
+    assertArrayEquals(listed.ResourceArns, []);
+  });
+});

--- a/src/service/wafv2/sim-wafv2-user-pool-refusals.iso.test.ts
+++ b/src/service/wafv2/sim-wafv2-user-pool-refusals.iso.test.ts
@@ -1,0 +1,199 @@
+import { CreateUserPoolCommand } from "@aws-sdk/client-cognito-identity-provider";
+import {
+  AssociateWebACLCommand,
+  GetWebACLForResourceCommand,
+  ListResourcesForWebACLCommand,
+} from "@aws-sdk/client-wafv2";
+import {
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  DEFAULT_SIM_AWS_ACCOUNT_ID,
+  type SimAwsAccountId,
+} from "../aws/sim-aws-account.js";
+import { SimAws } from "../aws/sim-aws.js";
+import { simWafCreateWebAclFactory } from "./command/web-acl/sim-waf-create-web-acl.factory.js";
+import {
+  SimWafInvalidParameterException,
+  SimWafUnavailableEntityException,
+  SimWafUnsimulatedInputException,
+} from "./error/sim-wafv2.error.js";
+import { createSimWafWebAcl } from "./sim-wafv2.fixture.js";
+
+const accountIdTwoTwos = "222222222222" as SimAwsAccountId;
+
+/**
+ * A user pool and a REGIONAL web ACL in the same scope.
+ *
+ * Every refusal here is about one of the two ARNs an association carries, so
+ * each test starts from a pair that would otherwise be associated.
+ */
+async function poolAndWebAcl(simAws: SimAws): Promise<{
+  readonly poolArn: string;
+  readonly webAclArn: string;
+}> {
+  const cognito = simAws.cognitoIdentityProvider();
+  const created = await cognito.createUserPool(
+    new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+  );
+  assertNonNullable(created.UserPool?.Id);
+
+  const webAcl = await createSimWafWebAcl(
+    simAws.wafV2(),
+    simWafCreateWebAclFactory.make(),
+  );
+
+  return {
+    poolArn: cognito.userPool(created.UserPool.Id).arn.value,
+    webAclArn: webAcl.ARN,
+  };
+}
+
+describe("SimWafV2 user pool association refusals", () => {
+  it("refuses a CLOUDFRONT scope web ACL", async () => {
+    // Given a user pool and a CLOUDFRONT scope web ACL.
+    const simAws = new SimAws();
+    const { poolArn } = await poolAndWebAcl(simAws);
+    const webAcl = await createSimWafWebAcl(
+      simAws.wafV2(),
+      simWafCreateWebAclFactory.make({ Scope: "CLOUDFRONT" }),
+    );
+
+    // When it is associated with the pool.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.wafV2().associateWebAcl(
+        new AssociateWebACLCommand({
+          WebACLArn: webAcl.ARN,
+          ResourceArn: poolArn,
+        }),
+      );
+    });
+
+    // Then it is refused. A user pool takes a REGIONAL web ACL, and a
+    // CLOUDFRONT one belongs to a distribution.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "CLOUDFRONT");
+  });
+
+  it("refuses a user pool in another Region", async () => {
+    // Given a web ACL in one Region and a pool in another.
+    const simAws = new SimAws();
+    const { webAclArn } = await poolAndWebAcl(simAws);
+    const elsewhere = simAws
+      .accountRegionScope(simAws.defaultAccountId, "eu-west-2")
+      .cognitoIdentityProvider();
+    const created = await elsewhere.createUserPool(
+      new CreateUserPoolCommand({ PoolName: "elsewhere-users" }),
+    );
+    assertNonNullable(created.UserPool?.Id);
+
+    // When the pool from elsewhere is associated with the web ACL.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.wafV2().associateWebAcl(
+        new AssociateWebACLCommand({
+          WebACLArn: webAclArn,
+          ResourceArn: elsewhere.userPool(created.UserPool?.Id ?? "").arn.value,
+        }),
+      );
+    });
+
+    // Then it is refused before anything looks for it.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "eu-west-2");
+  });
+
+  it("refuses a user pool in another Account", async () => {
+    // Given a web ACL in one Account and a pool in another.
+    const simAws = new SimAws();
+    const { webAclArn } = await poolAndWebAcl(simAws);
+    const elsewhere = simAws
+      .accountRegionScope(accountIdTwoTwos, "us-east-1")
+      .cognitoIdentityProvider();
+    const created = await elsewhere.createUserPool(
+      new CreateUserPoolCommand({ PoolName: "elsewhere-users" }),
+    );
+    assertNonNullable(created.UserPool?.Id);
+
+    // When the other Account's pool is associated with the web ACL.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.wafV2().associateWebAcl(
+        new AssociateWebACLCommand({
+          WebACLArn: webAclArn,
+          ResourceArn: elsewhere.userPool(created.UserPool?.Id ?? "").arn.value,
+        }),
+      );
+    });
+
+    // Then it is refused. A web ACL protects what is in its own Account.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, accountIdTwoTwos);
+  });
+
+  it("refuses a user pool that is not there", async () => {
+    // Given a web ACL and the ARN of a pool nothing created.
+    const simAws = new SimAws();
+    const { webAclArn } = await poolAndWebAcl(simAws);
+    const missing =
+      `arn:aws:cognito-idp:us-east-1:${DEFAULT_SIM_AWS_ACCOUNT_ID}:` +
+      `userpool/us-east-1_aBcDeFgHi`;
+
+    // When that pool is associated with the web ACL.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.wafV2().associateWebAcl(
+        new AssociateWebACLCommand({
+          WebACLArn: webAclArn,
+          ResourceArn: missing,
+        }),
+      );
+    });
+
+    // Then WAF reports a resource it could not retrieve.
+    assertInstanceOf(error, SimWafUnavailableEntityException);
+    assertStringIncludes(error.message, missing);
+  });
+
+  it("reports no web ACL for a pool that is not there", async () => {
+    // Given a simulation holding one pool.
+    const simAws = new SimAws();
+    await poolAndWebAcl(simAws);
+
+    // When the web ACL of a pool nothing created is read.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.wafV2().getWebAclForResource(
+        new GetWebACLForResourceCommand({
+          ResourceArn:
+            `arn:aws:cognito-idp:us-east-1:${DEFAULT_SIM_AWS_ACCOUNT_ID}:` +
+            `userpool/us-east-1_zZyYxXwWv`,
+        }),
+      );
+    });
+
+    // Then the pool is reported as the thing that is missing.
+    assertInstanceOf(error, SimWafUnavailableEntityException);
+  });
+
+  it("names both simulated types when a listing names no resource type", async () => {
+    // Given a web ACL.
+    const simAws = new SimAws();
+    const { webAclArn } = await poolAndWebAcl(simAws);
+
+    // When its resources are listed without naming a type.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .wafV2()
+        .listResourcesForWebAcl(
+          new ListResourcesForWebACLCommand({ WebACLArn: webAclArn }),
+        );
+    });
+
+    // Then the refusal names the types that can be listed here.
+    assertInstanceOf(error, SimWafUnsimulatedInputException);
+    assertStringIncludes(error.message, "API_GATEWAY");
+    assertStringIncludes(error.message, "COGNITO_USER_POOL");
+  });
+});

--- a/src/service/wafv2/sim-wafv2.ts
+++ b/src/service/wafv2/sim-wafv2.ts
@@ -23,8 +23,9 @@ export type { SimWafEvaluationRequest } from "./evaluate/sim-waf-evaluation-requ
  *
  * A web ACL is a list of rules and a decision about the requests none of them
  * claims, and `evaluateRequest` is what that adds up to. `AssociateWebACL`
- * puts one in front of an API Gateway REST API stage, and the stage then asks
- * for that decision itself on every request it serves.
+ * puts one in front of an API Gateway REST API stage or a Cognito user pool,
+ * and the stage or the pool's hosted domain then asks for that decision itself
+ * on every request it serves.
  *
  * Resources are scoped to an Account and Region, and within that to
  * `CLOUDFRONT` or `REGIONAL`. The two scopes are separate namespaces rather
@@ -44,7 +45,9 @@ export class SimWafV2 extends SimWafSets {
    *
    * The simulator's own accessor rather than a WAFv2 operation. It is how a
    * simulated API Gateway reaches the web ACL protecting a stage it is about
-   * to serve, and how it lets go of one when the stage is deleted.
+   * to serve, and how a simulated Cognito reaches the one protecting a pool's
+   * hosted domain. It is also how each lets go of one when the resource is
+   * deleted.
    */
   protection(): SimWafProtection {
     return this.commands.associations;


### PR DESCRIPTION
AssociateWebACL, DisassociateWebACL and GetWebACLForResource work against a
simulated Cognito user pool, named by an ARN of the form
`arn:aws:cognito-idp:<region>:<account>:userpool/<pool-id>`. Every request the
pool answers over HTTP goes through the web ACL before the endpoint behind it
runs, which covers the hosted domain's authorize, token and logout endpoints,
the managed login pages at `/signup`, `/confirm`, `/forgotPassword` and
`/confirmForgotPassword`, and the JWKS and OpenID configuration documents the
pool publishes. A blocked request gets 403 and the endpoint never runs, and a
blocked sign-up creates no user. The request body is withheld from the web ACL,
as Cognito withholds it for managed login and the classic hosted UI, leaving a
`ByteMatchStatement` on `Body` inspecting an empty field at a hosted domain the
way it does on AWS. The rest of the user-interactive set from the issue comment
goes uncovered because this simulation serves none of it, and `/login`,
`/resendcode`, `/confirmUser` and `/passkeys/add` are recorded in the Cognito
limitations as unserved. A CLOUDFRONT scope web ACL is refused, and so is a pool
in another Account or Region, while `AWSManagedRulesATPRuleSet` is turned away
earlier at CreateWebACL along with every managed rule group outside the three
that are simulated. Deleting a pool lets go of the web ACL in front of it, and
ListResourcesForWebACL now lists one resource type at a time under
`COGNITO_USER_POOL` or `API_GATEWAY`.

Resolves #812


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added AWS WAF protection for simulated Cognito user pools and hosted domains.
  - Web ACLs can inspect hosted-domain pages and `.well-known` endpoints, blocking matching requests with HTTP 403 responses.
  - Added support for associating, listing, disassociating, and automatically releasing protections when pools are deleted.
  - Added an end-to-end example demonstrating blocked and allowed authorization requests.

- **Documentation**
  - Documented configuration, validation rules, supported scopes, limitations, and endpoint coverage.

- **Tests**
  - Added coverage for blocked requests, allowed requests, associations, lifecycle behavior, and unsupported configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->