### PR TITLE
feat: deploy WAFv2 resources in CloudFormation

### DIFF
--- a/docs/services/wafv2/README.md
+++ b/docs/services/wafv2/README.md
@@ -841,6 +841,143 @@ the rule is written and reads its expressions when a request arrives, as it does
 IP sets are created, read, updated, listed and deleted the same way. No rule reads one, for the
 reason in [Refusals](#refusals) below.
 
+## Deploying web ACLs with CloudFormation
+
+`AWS::WAFv2::WebACL`, `AWS::WAFv2::WebACLAssociation`, `AWS::WAFv2::IPSet` and
+`AWS::WAFv2::RegexPatternSet` deploy into simulated WAFv2. CDK ships no L2 construct for WAFv2. A
+project protecting an API writes `CfnWebACL` and `CfnWebACLAssociation` by hand, and the template
+those synthesize to is the one that deploys here.
+
+```typescript sim-wafv2-cloudformation
+/**
+ * Deploying a web ACL from a CloudFormation template.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const visibility = {
+  SampledRequestsEnabled: false,
+  CloudWatchMetricsEnabled: false,
+  MetricName: "orders",
+};
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders",
+  template: {
+    Resources: {
+      OrdersAcl: {
+        Type: "AWS::WAFv2::WebACL",
+        Properties: {
+          Name: "orders-acl",
+          Scope: "REGIONAL",
+          DefaultAction: { Allow: {} },
+          VisibilityConfig: visibility,
+          Rules: [
+            {
+              Name: "block-admin",
+              Priority: 0,
+              Action: { Block: {} },
+              Statement: {
+                ByteMatchStatement: {
+                  FieldToMatch: { UriPath: {} },
+                  PositionalConstraint: "CONTAINS",
+                  SearchString: "/admin",
+                  TextTransformations: [{ Priority: 0, Type: "NONE" }],
+                },
+              },
+              VisibilityConfig: { ...visibility, MetricName: "block-admin" },
+            },
+          ],
+        },
+      },
+    },
+    Outputs: { AclArn: { Value: { "Fn::GetAtt": ["OrdersAcl", "Arn"] } } },
+  },
+});
+
+const decision = simAws.wafV2().evaluateRequest({
+  webAclArn: stack.outputs.get("AclArn")!.value as string,
+  request: new Request("https://orders.example.test/admin/users"),
+});
+
+// "BLOCK"
+console.log(decision.action);
+```
+
+A template spells a web ACL the way the API spells it, with two exceptions. A `SearchString` is
+plain text in a template where the SDK takes bytes, and a `RegularExpressionList` is a list of
+strings where the SDK takes a list of `RegexString` objects. Both are read here the way
+CloudFormation writes them.
+
+Every rule is compiled while the stack deploys. A statement kind this simulator will not evaluate
+(see [Refusals](#refusals)) fails the deployment, and the failure names the logical ID along with
+the rule and the statement kind. The web ACL never reaches a request it cannot decide.
+
+`Name` is optional on all three named types. An unnamed resource is named after the stack and the
+logical ID, as real CloudFormation names one, so `orders-acl` above would have deployed as
+`orders-OrdersAcl`.
+
+### Putting a deployed web ACL in front of something
+
+`AWS::WAFv2::WebACLAssociation` associates a web ACL with whatever its `ResourceArn` names, which
+covers an API Gateway REST API stage and a Cognito user pool. It goes through `AssociateWebACL` and
+inherits that command's refusals. An ARN naming an HTTP API stage or a load balancer fails the
+deployment with the reason WAF gives an SDK caller.
+
+```json
+{
+  "OrdersAclAssociation": {
+    "Type": "AWS::WAFv2::WebACLAssociation",
+    "Properties": {
+      "ResourceArn": {
+        "Fn::Join": [
+          "",
+          [
+            "arn:aws:apigateway:",
+            { "Ref": "AWS::Region" },
+            "::/restapis/",
+            { "Ref": "Api" },
+            "/stages/",
+            { "Ref": "Stage" }
+          ]
+        ]
+      },
+      "WebACLArn": { "Fn::GetAtt": ["OrdersAcl", "Arn"] }
+    }
+  }
+}
+```
+
+That `Fn::Join` is what CDK's `api.deploymentStage.stageArn` synthesizes to. Deleting the
+association disassociates, and deleting the stack takes the association down before the web ACL it
+names.
+
+A CloudFront distribution is associated through the distribution. `WebACLId` on
+`AWS::CloudFront::Distribution` holds a `CLOUDFRONT` [scope](#scopes) web ACL's ARN, usually as an
+`Fn::GetAtt` on a `CfnWebACL` in the same template. See
+[Protecting a CloudFront distribution](#protecting-a-cloudfront-distribution).
+
+### Attributes and Ref
+
+`Fn::GetAtt` on a web ACL answers `Arn`, `Id`, `Capacity` and `LabelNamespace`. `Arn` is the one a
+template usually wants, since an association and a distribution both name a web ACL by ARN. The two
+sets answer `Arn` and `Id`.
+
+`Capacity` is an approximation. It adds up the published cost of each rule's statement and leaves
+out the surcharges for text transformations and JSON body inspection, so it reads low against the
+same rules on AWS. Nothing here enforces the 1,500 unit limit on a web ACL. The attribute exists so
+that a template writing it into an output or an alarm deploys.
+
+`Ref` answers the physical ID, which WAFv2 spells in three parts (`orders-acl|<id>|REGIONAL`). It
+reads oddly beside every other service, and it is what AWS answers. WAFv2 resources carry a
+composite primary identifier of name, ID and scope. An association's physical ID is the resource ARN
+and the web ACL ARN joined by a pipe, and it publishes no attributes.
+
+`AWS::WAFv2::RuleGroup` and `AWS::WAFv2::LoggingConfiguration` are recorded as unsupported and
+stepped over. A rule naming a rule group is refused anyway, and there is no log here to write to.
+
 ## Scopes
 
 A web ACL is created in `CLOUDFRONT` or `REGIONAL` scope. The two are separate namespaces, and one

--- a/docs/services/wafv2/README.md
+++ b/docs/services/wafv2/README.md
@@ -965,10 +965,15 @@ A CloudFront distribution is associated through the distribution. `WebACLId` on
 template usually wants, since an association and a distribution both name a web ACL by ARN. The two
 sets answer `Arn` and `Id`.
 
-`Capacity` is an approximation. It adds up the published cost of each rule's statement and leaves
-out the surcharges for text transformations and JSON body inspection, so it reads low against the
-same rules on AWS. Nothing here enforces the 1,500 unit limit on a web ACL. The attribute exists so
-that a template writing it into an output or an alarm deploys.
+`Capacity` adds up what AWS publishes for each rule. A byte match costs 2 or 10 depending on the
+match it makes, a regex match 3, a pattern set reference 25, a size constraint 1 and a label match
+1, with 10 more for reading every query argument and 10 for each text transformation other than
+`NONE`. A managed rule group costs the fixed capacity its owner gave it.
+
+The sum is an upper bound on the number AWS reports. Real WAF charges a web ACL the sum of its rules
+minus whatever work it can share between them, and publishes no description of when it shares any.
+Nothing here enforces the 5,000 unit maximum on a web ACL or the 1,500 units the base price covers.
+`GetWebACL` reports the same number.
 
 `Ref` answers the physical ID, which WAFv2 spells in three parts (`orders-acl|<id>|REGIONAL`). It
 reads oddly beside every other service, and it is what AWS answers. WAFv2 resources carry a

--- a/docs/services/wafv2/sim-wafv2-cloudformation.example.ts
+++ b/docs/services/wafv2/sim-wafv2-cloudformation.example.ts
@@ -1,0 +1,55 @@
+/**
+ * Deploying a web ACL from a CloudFormation template.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const visibility = {
+  SampledRequestsEnabled: false,
+  CloudWatchMetricsEnabled: false,
+  MetricName: "orders",
+};
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders",
+  template: {
+    Resources: {
+      OrdersAcl: {
+        Type: "AWS::WAFv2::WebACL",
+        Properties: {
+          Name: "orders-acl",
+          Scope: "REGIONAL",
+          DefaultAction: { Allow: {} },
+          VisibilityConfig: visibility,
+          Rules: [
+            {
+              Name: "block-admin",
+              Priority: 0,
+              Action: { Block: {} },
+              Statement: {
+                ByteMatchStatement: {
+                  FieldToMatch: { UriPath: {} },
+                  PositionalConstraint: "CONTAINS",
+                  SearchString: "/admin",
+                  TextTransformations: [{ Priority: 0, Type: "NONE" }],
+                },
+              },
+              VisibilityConfig: { ...visibility, MetricName: "block-admin" },
+            },
+          ],
+        },
+      },
+    },
+    Outputs: { AclArn: { Value: { "Fn::GetAtt": ["OrdersAcl", "Arn"] } } },
+  },
+});
+
+const decision = simAws.wafV2().evaluateRequest({
+  webAclArn: stack.outputs.get("AclArn")!.value as string,
+  request: new Request("https://orders.example.test/admin/users"),
+});
+
+// "BLOCK"
+console.log(decision.action);

--- a/src/service/cloudformation/cdk/wafv2/sim-cdk-waf-web-acl.loc.test.ts
+++ b/src/service/cloudformation/cdk/wafv2/sim-cdk-waf-web-acl.loc.test.ts
@@ -1,0 +1,154 @@
+import path from "node:path";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsHttp } from "../../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../../serve/http/url/sim-aws-local-url.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+
+/**
+ * Slower local integration test. Calls the real CDK CLI to synth the output
+ * template file and deploys the synthesized web ACL, its association and the
+ * REST API behind it through sim CloudFormation.
+ *
+ * CDK ships no L2 construct for WAFv2, so this is what a team protecting an
+ * API actually writes: the generated L1s, wired together by
+ * `webAcl.attrArn` and `api.deploymentStage.stageArn`. Whatever those two
+ * resolve to at synth time is what the simulator has to read.
+ */
+const ordersHandlerSource = `
+exports.handler = async (event) => ({
+  statusCode: 200,
+  headers: { "content-type": "text/plain" },
+  body: "order " + (event.pathParameters?.proxy ?? "none"),
+});
+`;
+
+const cdkApp = `
+import * as cdk from "aws-cdk-lib/core";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as apigw from "aws-cdk-lib/aws-apigateway";
+import * as wafv2 from "aws-cdk-lib/aws-wafv2";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "111111111111", region: "eu-west-2" },
+});
+
+const ordersFunction = new lambda.Function(stack, "OrdersFunction", {
+  functionName: "cdk-waf-orders",
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: lambda.Code.fromInline(${JSON.stringify(ordersHandlerSource)}),
+});
+
+const api = new apigw.LambdaRestApi(stack, "OrdersApi", {
+  restApiName: "orders",
+  handler: ordersFunction,
+});
+
+const webAcl = new wafv2.CfnWebACL(stack, "ApiAcl", {
+  scope: "REGIONAL",
+  defaultAction: { allow: {} },
+  visibilityConfig: {
+    sampledRequestsEnabled: false,
+    cloudWatchMetricsEnabled: false,
+    metricName: "api",
+  },
+  rules: [
+    {
+      name: "block-admin",
+      priority: 0,
+      action: { block: {} },
+      statement: {
+        byteMatchStatement: {
+          fieldToMatch: { uriPath: {} },
+          positionalConstraint: "CONTAINS",
+          searchString: "/admin",
+          textTransformations: [{ priority: 0, type: "NONE" }],
+        },
+      },
+      visibilityConfig: {
+        sampledRequestsEnabled: false,
+        cloudWatchMetricsEnabled: false,
+        metricName: "block-admin",
+      },
+    },
+  ],
+});
+
+new wafv2.CfnWebACLAssociation(stack, "ApiAclAssociation", {
+  resourceArn: api.deploymentStage.stageArn,
+  webAclArn: webAcl.attrArn,
+});
+
+new cdk.CfnOutput(stack, "ApiUrl", { value: api.url });
+new cdk.CfnOutput(stack, "AclCapacity", {
+  value: cdk.Token.asString(webAcl.attrCapacity),
+});
+new cdk.CfnOutput(stack, "AclLabels", { value: webAcl.attrLabelNamespace });
+
+app.synth();
+`;
+
+describe("Sim CDK WAFv2 web ACL local integration", () => {
+  it("blocks a request through a stage the CDK L1 constructs protected", async () => {
+    // Given a CDK stack whose CfnWebACL and CfnWebACLAssociation put a web ACL
+    // in front of a LambdaRestApi's stage.
+    const simAws = new SimAws({
+      defaultAccountId: "111111111111",
+      defaultRegionName: "eu-west-2",
+    });
+    const cdkProject = new TestCdkProject();
+
+    await cdkProject.writeCdkAppFile(cdkApp);
+
+    // And the CDK app is synthesized to a CloudFormation template.
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When the synthesized template is deployed through sim CloudFormation.
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+
+    await stack.waitForDeployComplete();
+
+    const apiUrl = stack.outputs.get("ApiUrl")?.value;
+    assertTypeString(apiUrl);
+
+    const http = new SimAwsHttp({ simAws });
+    const request = async (suffix: string): Promise<Response> =>
+      await http.fetch(
+        new SimAwsLocalUrl({ input: `${apiUrl}${suffix}` }).toString(),
+      );
+
+    const blocked = await request("admin/settings");
+    const allowed = await request("orders/YL-1");
+
+    // Then the request the web ACL claims got WAF's 403 from the stage, and
+    // the one it did not reached the function behind it.
+    assertIdentical(blocked.status, 403);
+    assertStringIncludes(await blocked.text(), "Request blocked by AWS WAF");
+    assertIdentical(allowed.status, 200);
+    assertIdentical(await allowed.text(), "order orders/YL-1");
+
+    // And the attributes CDK reads off the L1 resolved to the deployed web
+    // ACL's own, rather than to a token nothing filled in.
+    const webAcl = simAws.wafV2().allWebAcls("REGIONAL")[0];
+
+    assertNonNullable(webAcl);
+    assertIdentical(stack.outputs.get("AclCapacity")?.value, webAcl.capacity);
+    assertIdentical(
+      stack.outputs.get("AclLabels")?.value,
+      `awswaf:111111111111:webacl:${webAcl.name}:`,
+    );
+  });
+});

--- a/src/service/cloudformation/resource/cfn/sim-cfn-service-value-adapters.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-service-value-adapters.ts
@@ -21,6 +21,7 @@ import { sesValueAdapter } from "./ses/sim-ses-cfn-value-adapter.js";
 import { snsValueAdapter } from "./sns/sim-sns-cfn-value-adapter.js";
 import { sqsValueAdapter } from "./sqs/sim-sqs-cfn-value-adapter.js";
 import { ssmValueAdapter } from "./ssm/sim-ssm-cfn-value-adapter.js";
+import { wafV2ValueAdapter } from "./wafv2/sim-wafv2-cfn-value-adapter.js";
 import type {
   SimCfnResourceValueAdapterProperties,
   SimCfnServiceValueAdapter,
@@ -61,4 +62,5 @@ export const simCfnServiceValueAdapters: readonly ((
   snsValueAdapter,
   sqsValueAdapter,
   ssmValueAdapter,
+  wafV2ValueAdapter,
 ];

--- a/src/service/cloudformation/resource/cfn/wafv2/sim-wafv2-association-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/wafv2/sim-wafv2-association-cfn.ts
@@ -1,0 +1,38 @@
+import type { SimWafCfnWebAclAssociation } from "../../../../wafv2/cfn/association/sim-cfn-waf-web-acl-association.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimWafWebAclAssociationCfnProperties {
+  readonly association: SimWafCfnWebAclAssociation;
+}
+
+/**
+ * CloudFormation-facing values for a simulated web ACL association.
+ */
+export class SimWafWebAclAssociationCfn implements SimCfnResourceValueAdapter {
+  readonly #association: SimWafCfnWebAclAssociation;
+
+  constructor(properties: SimWafWebAclAssociationCfnProperties) {
+    this.#association = properties.association;
+  }
+
+  /**
+   * AWS::WAFv2::WebACLAssociation Ref returns the physical id, which is the
+   * two ARNs it was made from joined by a pipe.
+   *
+   * The association has no identifier of its own on AWS either. What it is is
+   * the pair.
+   */
+  refValue(): SimCfnTemplateValue {
+    return `${this.#association.resourceArn}|${this.#association.webAclArn}`;
+  }
+
+  /**
+   * AWS::WAFv2::WebACLAssociation publishes no Fn::GetAtt attributes.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    throw new Error(
+      `Unsupported AWS::WAFv2::WebACLAssociation attribute ${attributeName}`,
+    );
+  }
+}

--- a/src/service/cloudformation/resource/cfn/wafv2/sim-wafv2-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/wafv2/sim-wafv2-cfn-value-adapter.ts
@@ -1,0 +1,56 @@
+import { SimWafCfnWebAclAssociation } from "../../../../wafv2/cfn/association/sim-cfn-waf-web-acl-association.js";
+import { SimWafIpSet } from "../../../../wafv2/ip-set/sim-waf-ip-set.js";
+import { SimWafRegexPatternSet } from "../../../../wafv2/regex-pattern-set/sim-waf-regex-pattern-set.js";
+import { SimWafWebAcl } from "../../../../wafv2/web-acl/sim-waf-web-acl.js";
+import type {
+  SimCfnResourceValueAdapterProperties,
+  SimCfnServiceValueAdapter,
+} from "../sim-cfn-resource-value-adapter.js";
+import { SimWafWebAclAssociationCfn } from "./sim-wafv2-association-cfn.js";
+import { SimWafSetCfn } from "./sim-wafv2-resource-cfn.js";
+import { SimWafWebAclCfn } from "./sim-wafv2-web-acl-cfn.js";
+
+/**
+ * The CloudFormation-facing value adapter for a simulated WAFv2 Resource.
+ */
+export function wafV2ValueAdapter(
+  properties: SimCfnResourceValueAdapterProperties,
+): SimCfnServiceValueAdapter {
+  if (
+    properties.type === "AWS::WAFv2::WebACL" &&
+    properties.simResource instanceof SimWafWebAcl
+  ) {
+    return new SimWafWebAclCfn({ webAcl: properties.simResource });
+  }
+
+  if (
+    properties.type === "AWS::WAFv2::WebACLAssociation" &&
+    properties.simResource instanceof SimWafCfnWebAclAssociation
+  ) {
+    return new SimWafWebAclAssociationCfn({
+      association: properties.simResource,
+    });
+  }
+
+  if (
+    properties.type === "AWS::WAFv2::IPSet" &&
+    properties.simResource instanceof SimWafIpSet
+  ) {
+    return new SimWafSetCfn({
+      resource: properties.simResource,
+      resourceType: properties.type,
+    });
+  }
+
+  if (
+    properties.type === "AWS::WAFv2::RegexPatternSet" &&
+    properties.simResource instanceof SimWafRegexPatternSet
+  ) {
+    return new SimWafSetCfn({
+      resource: properties.simResource,
+      resourceType: properties.type,
+    });
+  }
+
+  return undefined;
+}

--- a/src/service/cloudformation/resource/cfn/wafv2/sim-wafv2-resource-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/wafv2/sim-wafv2-resource-cfn.ts
@@ -1,0 +1,68 @@
+import type { SimWafResource } from "../../../../wafv2/resource/sim-waf-resource.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+/**
+ * The physical id CloudFormation gives a WAFv2 resource.
+ *
+ * WAFv2 resources are registry types with a composite primary identifier, so
+ * `Ref` gives back the name, the id and the scope joined by pipes rather than
+ * the id or the ARN on its own. It reads oddly beside every other service, and
+ * it is what a template writing a `Ref` into an output gets on AWS.
+ */
+export function simWafPhysicalId(resource: SimWafResource): string {
+  return [resource.name, resource.id, resource.scope].join("|");
+}
+
+interface SimWafSetCfnProperties {
+  readonly resource: SimWafResource;
+  readonly resourceType: string;
+}
+
+/**
+ * CloudFormation-facing values for a simulated IP set or regex pattern set.
+ *
+ * Both publish the same two attributes over the same resource shape, so one
+ * adapter covers them and carries the Resource type only to name it in a
+ * refusal. The web ACL has two attributes more and has its own adapter.
+ */
+export class SimWafSetCfn implements SimCfnResourceValueAdapter {
+  readonly #resource: SimWafResource;
+  readonly #resourceType: string;
+
+  constructor(properties: SimWafSetCfnProperties) {
+    this.#resource = properties.resource;
+    this.#resourceType = properties.resourceType;
+  }
+
+  /**
+   * AWS::WAFv2::IPSet and AWS::WAFv2::RegexPatternSet Ref both return the
+   * physical id, which is `<name>|<id>|<scope>`.
+   */
+  refValue(): SimCfnTemplateValue {
+    return simWafPhysicalId(this.#resource);
+  }
+
+  /**
+   * The two attributes a set publishes.
+   *
+   * A rule referring to a set names it by ARN, which is why `Arn` is the one
+   * that gets used. `Scope` is no attribute on AWS, even though it is part of
+   * the physical id.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    switch (attributeName) {
+      case "Arn": {
+        return this.#resource.arn;
+      }
+      case "Id": {
+        return this.#resource.id;
+      }
+      default: {
+        throw new Error(
+          `Unsupported ${this.#resourceType} attribute ${attributeName}`,
+        );
+      }
+    }
+  }
+}

--- a/src/service/cloudformation/resource/cfn/wafv2/sim-wafv2-web-acl-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/wafv2/sim-wafv2-web-acl-cfn.ts
@@ -1,0 +1,56 @@
+import type { SimWafWebAcl } from "../../../../wafv2/web-acl/sim-waf-web-acl.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+import { simWafPhysicalId } from "./sim-wafv2-resource-cfn.js";
+
+interface SimWafWebAclCfnProperties {
+  readonly webAcl: SimWafWebAcl;
+}
+
+/**
+ * CloudFormation-facing values for a simulated web ACL.
+ */
+export class SimWafWebAclCfn implements SimCfnResourceValueAdapter {
+  readonly #webAcl: SimWafWebAcl;
+
+  constructor(properties: SimWafWebAclCfnProperties) {
+    this.#webAcl = properties.webAcl;
+  }
+
+  /**
+   * AWS::WAFv2::WebACL Ref returns the physical id, which is
+   * `<name>|<id>|<scope>`.
+   */
+  refValue(): SimCfnTemplateValue {
+    return simWafPhysicalId(this.#webAcl);
+  }
+
+  /**
+   * The four attributes a web ACL publishes.
+   *
+   * `Arn` is the one everything else in a template wants: an association names
+   * a web ACL by ARN, and so does a distribution's `WebACLId`, which is named
+   * for WAF Classic and holds a WAFv2 ARN.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    switch (attributeName) {
+      case "Arn": {
+        return this.#webAcl.arn;
+      }
+      case "Id": {
+        return this.#webAcl.id;
+      }
+      case "Capacity": {
+        return this.#webAcl.capacity;
+      }
+      case "LabelNamespace": {
+        return this.#webAcl.labelNamespace;
+      }
+      default: {
+        throw new Error(
+          `Unsupported AWS::WAFv2::WebACL attribute ${attributeName}`,
+        );
+      }
+    }
+  }
+}

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
@@ -149,4 +149,9 @@ export const simCfnServiceResourceFactories: ReadonlyMap<
     (scopedAws): SimCfnServiceResourceFactory =>
       scopedAws.ssm().cfnResourceFactory(),
   ],
+  [
+    "WAFv2",
+    (scopedAws): SimCfnServiceResourceFactory =>
+      scopedAws.wafV2().cfnResourceFactory(),
+  ],
 ]);

--- a/src/service/wafv2/README.md
+++ b/src/service/wafv2/README.md
@@ -256,9 +256,13 @@ bytes in the SDK, and `RegularExpressionList` is a list of strings in a template
 `RegexString` objects in the SDK. The first needs no work, since `sim-waf-byte-match.ts` already
 reads either. The second is wrapped in `regex-pattern-set/sim-cfn-waf-regex-set-config.ts`.
 
-`SimWafWebAcl` gained `capacity` and `labelNamespace` for the attributes `Fn::GetAtt` publishes.
-The capacity is an approximation, and `web-acl/sim-waf-web-acl-capacity.ts` says what it leaves out.
-A CloudFront distribution is associated through its own `WebACLId` and reaches nothing here.
+`SimWafWebAcl` gained `capacity` and `labelNamespace` for the attributes `Fn::GetAtt` publishes, and
+`GetWebACL` reports both. `web-acl/sim-waf-web-acl-capacity.ts` walks the rules and
+`web-acl/sim-waf-statement-capacity.ts` holds the costs, which are AWS's published base cost per
+statement kind plus the surcharges for reading every query argument and for each text
+transformation. It sums where real WAF discounts whatever two rules can share, leaving the
+number an upper bound on what AWS reports. A CloudFront distribution is associated through its
+own `WebACLId` and reaches nothing here.
 
 ## Authorization
 

--- a/src/service/wafv2/README.md
+++ b/src/service/wafv2/README.md
@@ -224,6 +224,42 @@ An IP set is held and reported, and no rule reads one, for the same reason
 `IPSetReferenceStatement` is refused. A stack that creates one still deploys, and a test can read
 back what it created.
 
+## CloudFormation
+
+`cfn/` builds the four `AWS::WAFv2::*` Resource types this simulation deploys. The arrangement is
+the one every other service uses. A factory dispatches on the Resource type name, and each type has
+a directory holding its creator and the config that reads its properties.
+
+```text
+SimWafCfnResourceFactory        create, dispatching on the Resource type name
+├── SimCfnWafResourceDeleter    delete, held apart to keep the factory under the FTA threshold
+├── SimCfnWafResourceConfig     name, scope and description, shared by the three named types
+├── web-acl/                    AWS::WAFv2::WebACL
+├── association/                AWS::WAFv2::WebACLAssociation
+├── ip-set/                     AWS::WAFv2::IPSet
+└── regex-pattern-set/          AWS::WAFv2::RegexPatternSet
+```
+
+Every Resource is created through the ordinary WAFv2 command for it. A template gets the same
+compilation of every rule that an SDK caller gets, and the same refusals.
+`sim-cfn-waf-resource-error.ts` catches a `SimWafError` on the way out and names the Resource in it,
+because a deployment failing on `Rule block-admin uses the statement kind SqliMatchStatement` says
+which rule and not which of a template's web ACLs declared it.
+
+The association hands `ResourceArn` straight to `AssociateWebACL`. What a web ACL may be put in
+front of is decided once, in `association/sim-waf-protected-resource.ts`, and the CloudFormation
+layer inherits every refusal in it. Deleting the association tolerates a resource that has gone
+already, which is what a REST API stage in one stack and the association in another leaves behind.
+
+Two shapes differ between a template and the API. `SearchString` is plain text in a template and
+bytes in the SDK, and `RegularExpressionList` is a list of strings in a template and a list of
+`RegexString` objects in the SDK. The first needs no work, since `sim-waf-byte-match.ts` already
+reads either. The second is wrapped in `regex-pattern-set/sim-cfn-waf-regex-set-config.ts`.
+
+`SimWafWebAcl` gained `capacity` and `labelNamespace` for the attributes `Fn::GetAtt` publishes.
+The capacity is an approximation, and `web-acl/sim-waf-web-acl-capacity.ts` says what it leaves out.
+A CloudFront distribution is associated through its own `WebACLId` and reaches nothing here.
+
 ## Authorization
 
 `command/authorize/sim-wafv2-authorizer.ts` authorizes an operation on one resource against that

--- a/src/service/wafv2/cfn/association/sim-cfn-waf-association-config.ts
+++ b/src/service/wafv2/cfn/association/sim-cfn-waf-association-config.ts
@@ -1,0 +1,35 @@
+import { SimCfnWafResourceConfig } from "../sim-cfn-waf-resource-config.js";
+import { wafWebAclAssociationResourceType } from "../sim-cfn-waf-resource-types.js";
+
+/**
+ * Reads an AWS::WAFv2::WebACLAssociation Resource into the two ARNs it names.
+ *
+ * Both are required, and neither is read for what it names. `ResourceArn` goes
+ * to AssociateWebACL as the template wrote it, so a REST API stage and a user
+ * pool are resolved by the same reader an SDK caller's association goes
+ * through, and an ARN naming something WAF does not protect — or something
+ * Yulin does not simulate — is refused there with the reason it gives.
+ */
+export class SimCfnWafAssociationConfig extends SimCfnWafResourceConfig {
+  protected override get resourceType(): string {
+    return wafWebAclAssociationResourceType;
+  }
+
+  /**
+   * The resource the web ACL is put in front of.
+   */
+  resourceArn(): string {
+    return this.required("ResourceArn");
+  }
+
+  /**
+   * The web ACL to put in front of it.
+   */
+  webAclArn(): string {
+    return this.required("WebACLArn");
+  }
+
+  private required(key: string): string {
+    return this.text(key) ?? this.refuse(`${key} is required`);
+  }
+}

--- a/src/service/wafv2/cfn/association/sim-cfn-waf-association-creator.ts
+++ b/src/service/wafv2/cfn/association/sim-cfn-waf-association-creator.ts
@@ -1,0 +1,94 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimWafUnavailableEntityException } from "../../error/sim-wafv2.error.js";
+import type { SimWafV2 } from "../../sim-wafv2.js";
+import { simCfnWafResourceCommand } from "../sim-cfn-waf-resource-error.js";
+import { wafWebAclAssociationResourceType } from "../sim-cfn-waf-resource-types.js";
+import { SimCfnWafAssociationConfig } from "./sim-cfn-waf-association-config.js";
+import { SimWafCfnWebAclAssociation } from "./sim-cfn-waf-web-acl-association.js";
+
+interface SimCfnWafAssociationCreatorProperties {
+  readonly wafV2: SimWafV2;
+}
+
+/**
+ * Puts a web ACL in front of a resource from an AWS::WAFv2::WebACLAssociation
+ * Resource.
+ *
+ * The association is made through AssociateWebACL and taken off through
+ * DisassociateWebACL, so a template gets the same association an SDK caller
+ * gets, and the same refusals: a resource type WAF does not protect, a
+ * resource this simulation does not hold, and a `CLOUDFRONT` scope web ACL,
+ * which reaches a distribution through the distribution's own `WebACLId`
+ * rather than through an association.
+ */
+export class SimCfnWafAssociationCreator {
+  readonly #wafV2: SimWafV2;
+
+  constructor(properties: SimCfnWafAssociationCreatorProperties) {
+    this.#wafV2 = properties.wafV2;
+  }
+
+  /**
+   * Make the association an AWS::WAFv2::WebACLAssociation Resource describes.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimWafCfnWebAclAssociation> {
+    const config = new SimCfnWafAssociationConfig({ resource, properties });
+    const association = new SimWafCfnWebAclAssociation({
+      resourceArn: config.resourceArn(),
+      webAclArn: config.webAclArn(),
+    });
+
+    return await simCfnWafResourceCommand(
+      wafWebAclAssociationResourceType,
+      resource.logicalId,
+      async () => {
+        await this.#wafV2.associateWebAcl({
+          input: {
+            ResourceArn: association.resourceArn,
+            WebACLArn: association.webAclArn,
+          },
+        });
+
+        return association;
+      },
+    );
+  }
+
+  /**
+   * Take the association an AWS::WAFv2::WebACLAssociation Resource made off
+   * again.
+   *
+   * The web ACL and the resource are both left as they are. Deleting the
+   * association is only ever about the association, which is why a teardown
+   * reaches it before the web ACL it names.
+   *
+   * A stage or a user pool that has gone already is not an error. A template
+   * whose `ResourceArn` is a literal rather than a reference gives
+   * CloudFormation no reason to bring the association down first, and deleting
+   * the stage took the association with it, so there is nothing left to undo.
+   */
+  async delete(
+    resource: SimCfnResource,
+    association: SimWafCfnWebAclAssociation,
+  ): Promise<void> {
+    await simCfnWafResourceCommand(
+      wafWebAclAssociationResourceType,
+      resource.logicalId,
+      async () => {
+        try {
+          await this.#wafV2.disassociateWebAcl({
+            input: { ResourceArn: association.resourceArn },
+          });
+        } catch (error) {
+          if (!(error instanceof SimWafUnavailableEntityException)) {
+            throw error;
+          }
+        }
+      },
+    );
+  }
+}

--- a/src/service/wafv2/cfn/association/sim-cfn-waf-web-acl-association.ts
+++ b/src/service/wafv2/cfn/association/sim-cfn-waf-web-acl-association.ts
@@ -1,0 +1,21 @@
+/**
+ * One AWS::WAFv2::WebACLAssociation Resource, as CloudFormation holds it.
+ *
+ * WAFv2 keeps an association against the resource it protects rather than as a
+ * thing of its own, so there is nothing in the service for a deployed Resource
+ * to point at. This is what CloudFormation holds instead: the two ARNs the
+ * Resource named, which is what teardown needs to take the association off
+ * again and what `Ref` answers with.
+ */
+export class SimWafCfnWebAclAssociation {
+  public readonly resourceArn: string;
+  public readonly webAclArn: string;
+
+  constructor(properties: {
+    readonly resourceArn: string;
+    readonly webAclArn: string;
+  }) {
+    this.resourceArn = properties.resourceArn;
+    this.webAclArn = properties.webAclArn;
+  }
+}

--- a/src/service/wafv2/cfn/ip-set/sim-cfn-waf-ip-set-config.ts
+++ b/src/service/wafv2/cfn/ip-set/sim-cfn-waf-ip-set-config.ts
@@ -24,7 +24,7 @@ export class SimCfnWafIpSetConfig extends SimCfnWafResourceConfig {
       Scope: this.scope(),
       Description: this.description(),
       IPAddressVersion: this.text("IPAddressVersion"),
-      Addresses: this.strings("Addresses") ?? [],
+      Addresses: this.requiredStrings("Addresses"),
     };
   }
 }

--- a/src/service/wafv2/cfn/ip-set/sim-cfn-waf-ip-set-config.ts
+++ b/src/service/wafv2/cfn/ip-set/sim-cfn-waf-ip-set-config.ts
@@ -1,0 +1,30 @@
+import type { SimCreateIpSetCommandInput } from "../../command/ip-set/ip-set.command.js";
+import { SimCfnWafResourceConfig } from "../sim-cfn-waf-resource-config.js";
+import { wafIpSetResourceType } from "../sim-cfn-waf-resource-types.js";
+
+/**
+ * Reads an AWS::WAFv2::IPSet Resource into what CreateIPSet takes.
+ *
+ * Both properties of a set are required by the CloudFormation schema, so one
+ * missing is a template AWS refuses before an IP set is reached. They are
+ * handed over as the template wrote them and checked by CreateIPSet, which is
+ * where an address that is not CIDR notation is refused.
+ */
+export class SimCfnWafIpSetConfig extends SimCfnWafResourceConfig {
+  protected override get resourceType(): string {
+    return wafIpSetResourceType;
+  }
+
+  /**
+   * The input the IP set this Resource describes is created from.
+   */
+  createInput(): SimCreateIpSetCommandInput {
+    return {
+      Name: this.name(),
+      Scope: this.scope(),
+      Description: this.description(),
+      IPAddressVersion: this.text("IPAddressVersion"),
+      Addresses: this.strings("Addresses") ?? [],
+    };
+  }
+}

--- a/src/service/wafv2/cfn/ip-set/sim-cfn-waf-ip-set-creator.ts
+++ b/src/service/wafv2/cfn/ip-set/sim-cfn-waf-ip-set-creator.ts
@@ -1,0 +1,85 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimWafIpSet } from "../../ip-set/sim-waf-ip-set.js";
+import type { SimWafV2 } from "../../sim-wafv2.js";
+import { simCfnWafResourceCommand } from "../sim-cfn-waf-resource-error.js";
+import { wafIpSetResourceType } from "../sim-cfn-waf-resource-types.js";
+import { SimCfnWafIpSetConfig } from "./sim-cfn-waf-ip-set-config.js";
+
+interface SimCfnWafIpSetCreatorProperties {
+  readonly wafV2: SimWafV2;
+}
+
+/**
+ * Creates simulated IP sets from AWS::WAFv2::IPSet Resources.
+ *
+ * Nothing evaluates an IP set here, because a rule referring to one is
+ * refused: every request in this simulation comes from 127.0.0.1. The set is
+ * still deployed, so a stack that declares one deploys whole and a test can
+ * read back the ranges it was written with.
+ */
+export class SimCfnWafIpSetCreator {
+  readonly #wafV2: SimWafV2;
+
+  constructor(properties: SimCfnWafIpSetCreatorProperties) {
+    this.#wafV2 = properties.wafV2;
+  }
+
+  /**
+   * Create the IP set an AWS::WAFv2::IPSet Resource describes.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimWafIpSet> {
+    const input = new SimCfnWafIpSetConfig({
+      resource,
+      properties,
+    }).createInput();
+
+    return await simCfnWafResourceCommand(
+      wafIpSetResourceType,
+      resource.logicalId,
+      async () => {
+        const created = await this.#wafV2.createIpSet({ input });
+        const arn = created.Summary?.ARN;
+
+        assertDefined(
+          arn,
+          `sim WAFv2 IP set ARN for CloudFormation Resource ${
+            resource.logicalId
+          }`,
+        );
+
+        const ipSet = this.#wafV2.findIpSetByArn(arn);
+
+        assertDefined(
+          ipSet,
+          `sim WAFv2 IP set ${arn} after CloudFormation creation`,
+        );
+
+        return ipSet;
+      },
+    );
+  }
+
+  /**
+   * Delete the IP set an AWS::WAFv2::IPSet Resource created.
+   */
+  async delete(resource: SimCfnResource, ipSet: SimWafIpSet): Promise<void> {
+    await simCfnWafResourceCommand(
+      wafIpSetResourceType,
+      resource.logicalId,
+      async () =>
+        await this.#wafV2.deleteIpSet({
+          input: {
+            Name: ipSet.name,
+            Scope: ipSet.scope,
+            Id: ipSet.id,
+            LockToken: ipSet.lockToken,
+          },
+        }),
+    );
+  }
+}

--- a/src/service/wafv2/cfn/regex-pattern-set/sim-cfn-waf-regex-set-config.ts
+++ b/src/service/wafv2/cfn/regex-pattern-set/sim-cfn-waf-regex-set-config.ts
@@ -24,7 +24,7 @@ export class SimCfnWafRegexPatternSetConfig extends SimCfnWafResourceConfig {
       Name: this.name(),
       Scope: this.scope(),
       Description: this.description(),
-      RegularExpressionList: (this.strings("RegularExpressionList") ?? []).map(
+      RegularExpressionList: this.requiredStrings("RegularExpressionList").map(
         (pattern) => ({ RegexString: pattern }),
       ),
     };

--- a/src/service/wafv2/cfn/regex-pattern-set/sim-cfn-waf-regex-set-config.ts
+++ b/src/service/wafv2/cfn/regex-pattern-set/sim-cfn-waf-regex-set-config.ts
@@ -1,0 +1,32 @@
+import type { SimCreateRegexPatternSetCommandInput } from "../../command/regex-pattern-set/regex-pattern-set.command.js";
+import { SimCfnWafResourceConfig } from "../sim-cfn-waf-resource-config.js";
+import { wafRegexPatternSetResourceType } from "../sim-cfn-waf-resource-types.js";
+
+/**
+ * Reads an AWS::WAFv2::RegexPatternSet Resource into what
+ * CreateRegexPatternSet takes.
+ *
+ * This is the one place where CloudFormation and the API disagree about the
+ * shape of a WAFv2 resource. `RegularExpressionList` is a list of strings in a
+ * template and a list of `{ RegexString }` objects in the API, so the patterns
+ * are wrapped on the way through rather than passed along.
+ */
+export class SimCfnWafRegexPatternSetConfig extends SimCfnWafResourceConfig {
+  protected override get resourceType(): string {
+    return wafRegexPatternSetResourceType;
+  }
+
+  /**
+   * The input the pattern set this Resource describes is created from.
+   */
+  createInput(): SimCreateRegexPatternSetCommandInput {
+    return {
+      Name: this.name(),
+      Scope: this.scope(),
+      Description: this.description(),
+      RegularExpressionList: (this.strings("RegularExpressionList") ?? []).map(
+        (pattern) => ({ RegexString: pattern }),
+      ),
+    };
+  }
+}

--- a/src/service/wafv2/cfn/regex-pattern-set/sim-cfn-waf-regex-set-creator.ts
+++ b/src/service/wafv2/cfn/regex-pattern-set/sim-cfn-waf-regex-set-creator.ts
@@ -1,0 +1,88 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimWafRegexPatternSet } from "../../regex-pattern-set/sim-waf-regex-pattern-set.js";
+import type { SimWafV2 } from "../../sim-wafv2.js";
+import { simCfnWafResourceCommand } from "../sim-cfn-waf-resource-error.js";
+import { wafRegexPatternSetResourceType } from "../sim-cfn-waf-resource-types.js";
+import { SimCfnWafRegexPatternSetConfig } from "./sim-cfn-waf-regex-set-config.js";
+
+interface SimCfnWafRegexPatternSetCreatorProperties {
+  readonly wafV2: SimWafV2;
+}
+
+/**
+ * Creates simulated regex pattern sets from AWS::WAFv2::RegexPatternSet
+ * Resources.
+ *
+ * Every pattern is compiled by CreateRegexPatternSet, so an expression that
+ * will not compile fails the deployment where it was written rather than
+ * quietly matching nothing when a request arrives.
+ */
+export class SimCfnWafRegexPatternSetCreator {
+  readonly #wafV2: SimWafV2;
+
+  constructor(properties: SimCfnWafRegexPatternSetCreatorProperties) {
+    this.#wafV2 = properties.wafV2;
+  }
+
+  /**
+   * Create the pattern set an AWS::WAFv2::RegexPatternSet Resource describes.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimWafRegexPatternSet> {
+    const input = new SimCfnWafRegexPatternSetConfig({
+      resource,
+      properties,
+    }).createInput();
+
+    return await simCfnWafResourceCommand(
+      wafRegexPatternSetResourceType,
+      resource.logicalId,
+      async () => {
+        const created = await this.#wafV2.createRegexPatternSet({ input });
+        const arn = created.Summary?.ARN;
+
+        assertDefined(
+          arn,
+          `sim WAFv2 regex pattern set ARN for CloudFormation Resource ${
+            resource.logicalId
+          }`,
+        );
+
+        const patternSet = this.#wafV2.findRegexPatternSetByArn(arn);
+
+        assertDefined(
+          patternSet,
+          `sim WAFv2 regex pattern set ${arn} after CloudFormation creation`,
+        );
+
+        return patternSet;
+      },
+    );
+  }
+
+  /**
+   * Delete the pattern set an AWS::WAFv2::RegexPatternSet Resource created.
+   */
+  async delete(
+    resource: SimCfnResource,
+    patternSet: SimWafRegexPatternSet,
+  ): Promise<void> {
+    await simCfnWafResourceCommand(
+      wafRegexPatternSetResourceType,
+      resource.logicalId,
+      async () =>
+        await this.#wafV2.deleteRegexPatternSet({
+          input: {
+            Name: patternSet.name,
+            Scope: patternSet.scope,
+            Id: patternSet.id,
+            LockToken: patternSet.lockToken,
+          },
+        }),
+    );
+  }
+}

--- a/src/service/wafv2/cfn/sim-cfn-waf-association.iso.test.ts
+++ b/src/service/wafv2/cfn/sim-cfn-waf-association.iso.test.ts
@@ -1,0 +1,318 @@
+import {
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  deployRestApi,
+  simAwsInEuWest2,
+} from "../../../../test/apigateway/cfn-deploy.js";
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import type { SimRestApi } from "../../apigateway/api/sim-rest-api.js";
+import { simCfnRestApiTemplateFactory } from "../../apigateway/cfn/sim-cfn-rest-api-template.factory.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnStack } from "../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+const visibility = {
+  SampledRequestsEnabled: false,
+  CloudWatchMetricsEnabled: false,
+  MetricName: "orders",
+};
+
+/**
+ * The web ACL every association here puts in front of something: one rule,
+ * blocking admin paths, over a default action of allow.
+ */
+const webAclResource = {
+  Type: "AWS::WAFv2::WebACL",
+  Properties: {
+    Name: "orders-acl",
+    Scope: "REGIONAL",
+    DefaultAction: { Allow: {} },
+    VisibilityConfig: visibility,
+    Rules: [
+      {
+        Name: "block-admin",
+        Priority: 0,
+        Action: { Block: {} },
+        Statement: {
+          ByteMatchStatement: {
+            FieldToMatch: { UriPath: {} },
+            PositionalConstraint: "CONTAINS",
+            SearchString: "/admin",
+            TextTransformations: [{ Priority: 0, Type: "NONE" }],
+          },
+        },
+        VisibilityConfig: { ...visibility, MetricName: "block-admin" },
+      },
+    ],
+  },
+};
+
+/**
+ * The stage ARN as CDK writes it beside a REST API, which is the only
+ * identifier AWS WAF takes for one.
+ */
+const stageArn = {
+  "Fn::Join": [
+    "",
+    [
+      "arn:aws:apigateway:",
+      { Ref: "AWS::Region" },
+      "::/restapis/",
+      { Ref: "Api" },
+      "/stages/",
+      { Ref: "Stage" },
+    ],
+  ],
+};
+
+/**
+ * An HTTP API stage ARN, which is the one API Gateway ARN AWS WAF protects
+ * nothing behind.
+ */
+const httpApiStageArn =
+  // oxlint-disable-next-line no-template-curly-in-string -- Fn::Sub syntax, not a JavaScript template.
+  "arn:aws:apigateway:${AWS::Region}::/apis/abc123/stages/$default";
+
+/**
+ * An association Resource naming a web ACL in the same template.
+ */
+function associationResource(
+  resourceArn: SimCfnTemplateValueRecord,
+): SimCfnTemplateValueRecord {
+  return {
+    Type: "AWS::WAFv2::WebACLAssociation",
+    Properties: {
+      ResourceArn: resourceArn,
+      WebACLArn: { "Fn::GetAtt": ["OrdersAcl", "Arn"] },
+    },
+  };
+}
+
+/**
+ * Deploy a REST API with the web ACL in front of its stage.
+ */
+async function deployProtectedApi(simAws: SimAws): Promise<SimCfnStack> {
+  return await deployRestApi(
+    simAws,
+    simCfnRestApiTemplateFactory.make({
+      handlerSource:
+        "exports.handler = async () => ({ statusCode: 200, body: 'orders' });",
+      methods: [
+        { httpMethod: "GET", path: ["orders"] },
+        { httpMethod: "GET", path: ["admin"] },
+      ],
+      resources: {
+        OrdersAcl: webAclResource,
+        OrdersAclAssociation: associationResource(stageArn),
+      },
+    }),
+  );
+}
+
+/**
+ * The deployed REST API, which is what a stage ARN has to be built from.
+ */
+function deployedRestApi(stack: SimCfnStack): SimRestApi {
+  const restApi = stack.getResource("Api")?.simResource as
+    | SimRestApi
+    | undefined;
+
+  assertNonNullable(restApi);
+
+  return restApi;
+}
+
+/**
+ * Request one path of the deployed API.
+ */
+async function request(
+  simAws: SimAws,
+  stack: SimCfnStack,
+  path: string,
+): Promise<Response> {
+  const apiUrl = stack.outputs.get("ApiUrl")?.value;
+  assertTypeString(apiUrl);
+
+  return await new SimAwsHttp({ simAws }).fetch(
+    new SimAwsLocalUrl({ input: `${apiUrl}${path}` }).toString(),
+  );
+}
+
+/**
+ * A template declaring a user pool with the web ACL in front of it.
+ */
+const userPoolTemplate = {
+  Resources: {
+    OrdersAcl: webAclResource,
+    Pool: {
+      Type: "AWS::Cognito::UserPool",
+      Properties: { UserPoolName: "orders-pool" },
+    },
+    PoolAclAssociation: associationResource({
+      "Fn::GetAtt": ["Pool", "Arn"],
+    }),
+  },
+  Outputs: { PoolArn: { Value: { "Fn::GetAtt": ["Pool", "Arn"] } } },
+};
+
+describe("AWS::WAFv2::WebACLAssociation", () => {
+  it("blocks a request to a stage the association put a web ACL in front of", async () => {
+    // Given a deployed REST API with the web ACL associated to its stage.
+    const simAws = simAwsInEuWest2();
+    const stack = await deployProtectedApi(simAws);
+
+    // When a request the web ACL blocks and one it allows are both made.
+    const blocked = await request(simAws, stack, "admin");
+    const allowed = await request(simAws, stack, "orders");
+
+    // Then WAF answered the first and the integration answered the second, so
+    // the association the template declared is the one the stage serves
+    // behind.
+    assertIdentical(blocked.status, 403);
+    assertStringIncludes(await blocked.text(), "Request blocked by AWS WAF");
+    assertIdentical(allowed.status, 200);
+    assertIdentical(await allowed.text(), "orders");
+  });
+
+  it("disassociates when the stack comes down", async () => {
+    // Given the deployed API and the stage ARN the association names.
+    const simAws = simAwsInEuWest2();
+    const stack = await deployProtectedApi(simAws);
+    const association = stack.getResource("OrdersAclAssociation");
+
+    assertNonNullable(association);
+
+    const wafV2 = simAws.wafV2();
+    const restApi = deployedRestApi(stack);
+
+    assertTrue(wafV2.protection().protects(restApi.stageArn("prod")));
+
+    // When the stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then nothing is in front of the stage any more, which is what lets the
+    // web ACL be deleted after it.
+    assertFalse(wafV2.protection().protects(restApi.stageArn("prod")));
+    assertIdentical(
+      stack.resources.get("OrdersAclAssociation")?.status,
+      "DELETE_COMPLETE",
+    );
+  });
+
+  it("puts a web ACL in front of a Cognito user pool", async () => {
+    // Given a template associating the web ACL with a user pool.
+    const simAws = simAwsInEuWest2();
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplate({ stackName: "pool", template: userPoolTemplate });
+    await stack.waitForDeployComplete();
+
+    const poolArn = stack.outputs.get("PoolArn")?.value;
+    assertTypeString(poolArn);
+
+    // Then the pool is protected, and stays that way until the stack comes
+    // down.
+    assertTrue(simAws.wafV2().protection().protects(poolArn));
+
+    await stack.teardown();
+
+    assertFalse(simAws.wafV2().protection().protects(poolArn));
+  });
+
+  it("answers Ref with the pair of ARNs the association is", async () => {
+    // Given a deployed association whose Ref is an output.
+    const simAws = simAwsInEuWest2();
+    const stack = await deployRestApi(
+      simAws,
+      simCfnRestApiTemplateFactory.make({
+        resources: {
+          OrdersAcl: webAclResource,
+          OrdersAclAssociation: associationResource(stageArn),
+        },
+        outputs: { AssociationRef: { Value: { Ref: "OrdersAclAssociation" } } },
+      }),
+    );
+    const restApi = deployedRestApi(stack);
+    const webAcl = simAws.wafV2().allWebAcls("REGIONAL")[0];
+
+    assertNonNullable(webAcl);
+
+    // Then it is the resource ARN and the web ACL ARN joined by a pipe. An
+    // association has no identifier of its own on AWS either: what it is is
+    // the pair.
+    assertIdentical(
+      stack.outputs.get("AssociationRef")?.value,
+      `${restApi.stageArn("prod")}|${webAcl.arn}`,
+    );
+  });
+
+  it("refuses an association naming a resource type AWS WAF does not protect", async () => {
+    // Given a template pointing an association at an HTTP API stage, which
+    // AWS WAF protects nothing of.
+    const simAws = simAwsInEuWest2();
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "http-api",
+        template: {
+          Resources: {
+            OrdersAcl: webAclResource,
+            OrdersAclAssociation: associationResource({
+              "Fn::Sub": httpApiStageArn,
+            }),
+          },
+        },
+      });
+      await stack.waitForDeployComplete();
+    });
+
+    // Then the deployment failed with the reason WAFv2 gives an SDK caller,
+    // under the logical id that asked for it.
+    assertStringIncludes(
+      error.message,
+      "AWS::WAFv2::WebACLAssociation Resource OrdersAclAssociation",
+    );
+    assertStringIncludes(
+      error.message,
+      "AWS WAF does not protect an API Gateway HTTP API",
+    );
+  });
+
+  it("refuses an association with no ResourceArn", async () => {
+    // Given a template whose association names only the web ACL.
+    const simAws = simAwsInEuWest2();
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "no-resource",
+        template: {
+          Resources: {
+            OrdersAcl: webAclResource,
+            OrdersAclAssociation: {
+              Type: "AWS::WAFv2::WebACLAssociation",
+              Properties: {
+                WebACLArn: { "Fn::GetAtt": ["OrdersAcl", "Arn"] },
+              },
+            },
+          },
+        },
+      });
+      await stack.waitForDeployComplete();
+    });
+
+    // Then the refusal says which Resource could not be read.
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::WAFv2::WebACLAssociation Resource OrdersAclAssociation: " +
+        "ResourceArn is required",
+    );
+  });
+});

--- a/src/service/wafv2/cfn/sim-cfn-waf-creators.ts
+++ b/src/service/wafv2/cfn/sim-cfn-waf-creators.ts
@@ -1,0 +1,49 @@
+import type { SimWafV2 } from "../sim-wafv2.js";
+import { SimCfnWafAssociationCreator } from "./association/sim-cfn-waf-association-creator.js";
+import { SimCfnWafIpSetCreator } from "./ip-set/sim-cfn-waf-ip-set-creator.js";
+import { SimCfnWafRegexPatternSetCreator } from "./regex-pattern-set/sim-cfn-waf-regex-set-creator.js";
+import { SimCfnWafWebAclCreator } from "./web-acl/sim-cfn-waf-web-acl-creator.js";
+
+/**
+ * The creator behind each simulated WAFv2 Resource type.
+ *
+ * Both halves of the CloudFormation lifecycle need all four, because each
+ * creator owns the deletion of what it made as well as the making of it, so
+ * the set is built once here and handed to the factory and its deleter.
+ */
+export interface SimCfnWafCreators {
+  readonly webAcl: SimCfnWafWebAclCreator;
+  readonly association: SimCfnWafAssociationCreator;
+  readonly ipSet: SimCfnWafIpSetCreator;
+  readonly regexPatternSet: SimCfnWafRegexPatternSetCreator;
+}
+
+/**
+ * Build the creators for one simulated WAFv2.
+ */
+export function simCfnWafCreators(wafV2: SimWafV2): SimCfnWafCreators {
+  return {
+    webAcl: new SimCfnWafWebAclCreator({ wafV2 }),
+    association: new SimCfnWafAssociationCreator({ wafV2 }),
+    ipSet: new SimCfnWafIpSetCreator({ wafV2 }),
+    regexPatternSet: new SimCfnWafRegexPatternSetCreator({ wafV2 }),
+  };
+}
+
+/**
+ * The error a Resource type this factory does not model is refused with.
+ *
+ * Sim CloudFormation reads it as a Resource to record and step over, which is
+ * the right answer for a rule group or a logging configuration: neither has
+ * anything behind it here, and a stack declaring one says so in its skipped
+ * Resources rather than failing.
+ */
+export function unsupportedSimWafResourceType(
+  resourceTypeName: string,
+  operationSuffix: string,
+): Error {
+  return new Error(
+    `Unsupported sim WAFv2 CloudFormation Resource ` +
+      `${resourceTypeName}${operationSuffix}`,
+  );
+}

--- a/src/service/wafv2/cfn/sim-cfn-waf-distribution.iso.test.ts
+++ b/src/service/wafv2/cfn/sim-cfn-waf-distribution.iso.test.ts
@@ -1,0 +1,163 @@
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  simCfSiteBucket,
+  simCfSiteRequest,
+} from "../../../../test/cloudfront/site-fixture.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnStack } from "../../cloudformation/stack/sim-cfn-stack.js";
+import type { CfnTemplateBodyRecord } from "../../cloudformation/template/sim-cfn-template.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+const bucketName = "acl-site";
+
+/** How a distribution names the web ACL beside it in the same template. */
+const webAclArnReference = { "Fn::GetAtt": ["SiteAcl", "Arn"] };
+
+const visibility = {
+  SampledRequestsEnabled: false,
+  CloudWatchMetricsEnabled: false,
+  MetricName: "site",
+};
+
+/**
+ * A template serving a bucket through a distribution the web ACL beside it
+ * protects.
+ *
+ * CloudFront is not associated through AWS::WAFv2::WebACLAssociation. The
+ * distribution carries the web ACL itself, in a `WebACLId` that is named for
+ * WAF Classic and holds a WAFv2 ARN, so the reference between the two is an
+ * ordinary Fn::GetAtt in the same template.
+ */
+function siteTemplate(
+  webAclId: SimCfnTemplateValueRecord | string = webAclArnReference,
+): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      SiteAcl: {
+        Type: "AWS::WAFv2::WebACL",
+        Properties: {
+          Name: "site-acl",
+          Scope: "CLOUDFRONT",
+          DefaultAction: { Allow: {} },
+          VisibilityConfig: visibility,
+          Rules: [
+            {
+              Name: "block-admin",
+              Priority: 0,
+              Action: { Block: {} },
+              Statement: {
+                ByteMatchStatement: {
+                  FieldToMatch: { UriPath: {} },
+                  PositionalConstraint: "CONTAINS",
+                  SearchString: "/admin",
+                  TextTransformations: [{ Priority: 0, Type: "NONE" }],
+                },
+              },
+              VisibilityConfig: { ...visibility, MetricName: "block-admin" },
+            },
+          ],
+        },
+      },
+      SiteDistribution: {
+        Type: "AWS::CloudFront::Distribution",
+        Properties: {
+          DistributionConfig: {
+            Enabled: true,
+            WebACLId: webAclId,
+            Origins: {
+              Items: [
+                {
+                  Id: "site-origin",
+                  DomainName: `${bucketName}.s3.amazonaws.com`,
+                  S3OriginConfig: { OriginAccessIdentity: "" },
+                },
+              ],
+            },
+            DefaultCacheBehavior: {
+              TargetOriginId: "site-origin",
+              ViewerProtocolPolicy: "allow-all",
+            },
+          },
+        },
+      },
+    },
+    Outputs: {
+      DistributionId: { Value: { Ref: "SiteDistribution" } },
+    },
+  };
+}
+
+/**
+ * Deploy the site, with the pages a request here asks for already in place.
+ */
+async function deploySite(
+  simAws: SimAws,
+  webAclId?: SimCfnTemplateValueRecord | string,
+): Promise<SimCfnStack> {
+  await simCfSiteBucket(simAws, bucketName, {
+    "index.html": "<h1>Home</h1>",
+    "admin/index.html": "<h1>Admin</h1>",
+  });
+
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "site",
+    template: webAclId === undefined ? siteTemplate() : siteTemplate(webAclId),
+  });
+  await stack.waitForDeployComplete();
+
+  return stack;
+}
+
+async function siteResponse(
+  simAws: SimAws,
+  stack: SimCfnStack,
+  path: string,
+): Promise<Response> {
+  const distributionId = stack.outputs.get("DistributionId")?.value;
+  assertTypeString(distributionId);
+
+  return await simCfSiteRequest(simAws, distributionId, path);
+}
+
+describe("A web ACL a CloudFormation Distribution names in WebACLId", () => {
+  it("blocks a request the deployed web ACL claims", async () => {
+    // Given a deployed distribution whose WebACLId resolved to the web ACL in
+    // the same template.
+    const simAws = new SimAws();
+    const stack = await deploySite(simAws);
+
+    // When a page the web ACL blocks and one it allows are both requested.
+    const blocked = await siteResponse(simAws, stack, "/admin/index.html");
+    const allowed = await siteResponse(simAws, stack, "/index.html");
+
+    // Then the edge answered the first with WAF's own 403 and served the
+    // second from the Origin.
+    assertIdentical(blocked.status, 403);
+    assertStringIncludes(await blocked.text(), "Request blocked by AWS WAF");
+    assertIdentical(allowed.status, 200);
+    assertIdentical(await allowed.text(), "<h1>Home</h1>");
+  });
+
+  it("refuses a distribution naming a web ACL that is not there", async () => {
+    // Given a template whose WebACLId is a literal ARN nothing created.
+    const simAws = new SimAws();
+    const error = await assertThrowsErrorAsync(async () => {
+      await deploySite(
+        simAws,
+        "arn:aws:wafv2:us-east-1:888888888888:global/webacl/gone/" +
+          "4a2b1c8d-0e6f-4a2b-9c8d-0e6f4a2b1c8d",
+      );
+    });
+
+    // Then the deployment failed rather than leaving a distribution in front
+    // of nothing.
+    assertStringIncludes(error.message, "web ACL");
+  });
+});

--- a/src/service/wafv2/cfn/sim-cfn-waf-distribution.iso.test.ts
+++ b/src/service/wafv2/cfn/sim-cfn-waf-distribution.iso.test.ts
@@ -20,6 +20,11 @@ const bucketName = "acl-site";
 /** How a distribution names the web ACL beside it in the same template. */
 const webAclArnReference = { "Fn::GetAtt": ["SiteAcl", "Arn"] };
 
+/** An ARN of the right shape naming a web ACL nothing created. */
+const missingWebAclArn =
+  "arn:aws:wafv2:us-east-1:888888888888:global/webacl/gone/" +
+  "4a2b1c8d-0e6f-4a2b-9c8d-0e6f4a2b1c8d";
+
 const visibility = {
   SampledRequestsEnabled: false,
   CloudWatchMetricsEnabled: false,
@@ -37,6 +42,7 @@ const visibility = {
  */
 function siteTemplate(
   webAclId: SimCfnTemplateValueRecord | string = webAclArnReference,
+  scope = "CLOUDFRONT",
 ): CfnTemplateBodyRecord {
   return {
     Resources: {
@@ -44,7 +50,7 @@ function siteTemplate(
         Type: "AWS::WAFv2::WebACL",
         Properties: {
           Name: "site-acl",
-          Scope: "CLOUDFRONT",
+          Scope: scope,
           DefaultAction: { Allow: {} },
           VisibilityConfig: visibility,
           Rules: [
@@ -149,15 +155,29 @@ describe("A web ACL a CloudFormation Distribution names in WebACLId", () => {
     // Given a template whose WebACLId is a literal ARN nothing created.
     const simAws = new SimAws();
     const error = await assertThrowsErrorAsync(async () => {
-      await deploySite(
-        simAws,
-        "arn:aws:wafv2:us-east-1:888888888888:global/webacl/gone/" +
-          "4a2b1c8d-0e6f-4a2b-9c8d-0e6f4a2b1c8d",
-      );
+      await deploySite(simAws, missingWebAclArn);
     });
 
     // Then the deployment failed rather than leaving a distribution in front
-    // of nothing.
-    assertStringIncludes(error.message, "web ACL");
+    // of nothing, naming the ARN it could not resolve.
+    assertStringIncludes(error.message, missingWebAclArn);
+    assertStringIncludes(error.message, "does not exist");
+  });
+
+  it("refuses a distribution naming a REGIONAL scope web ACL", async () => {
+    // Given a template whose web ACL is in the scope an API Gateway stage
+    // takes, named by the distribution beside it.
+    const simAws = new SimAws();
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "regional-site",
+        template: siteTemplate(webAclArnReference, "REGIONAL"),
+      });
+      await stack.waitForDeployComplete();
+    });
+
+    // Then the deployment failed on the scope, which is the mistake a
+    // distribution and an association are easiest to mix up over.
+    assertStringIncludes(error.message, "REGIONAL scope web ACL");
   });
 });

--- a/src/service/wafv2/cfn/sim-cfn-waf-resource-config.ts
+++ b/src/service/wafv2/cfn/sim-cfn-waf-resource-config.ts
@@ -128,6 +128,19 @@ export abstract class SimCfnWafResourceConfig {
   }
 
   /**
+   * One list-of-strings property the Resource type requires.
+   *
+   * An omitted list is refused rather than read as an empty one. Both places
+   * this is used name a list CloudFormation requires, and an empty IP set or
+   * pattern set matches nothing, so a template that misspells `Addresses`
+   * would otherwise deploy a set with nothing in it and a rule pointing at it
+   * that never fires.
+   */
+  protected requiredStrings(key: string): readonly string[] {
+    return this.strings(key) ?? this.refuse(`${key} is required`);
+  }
+
+  /**
    * Refuse this Resource, saying which part of it could not be read.
    */
   protected refuse(reason: string): never {

--- a/src/service/wafv2/cfn/sim-cfn-waf-resource-config.ts
+++ b/src/service/wafv2/cfn/sim-cfn-waf-resource-config.ts
@@ -1,0 +1,140 @@
+import { SimCfnGeneratedResourceName } from "../../cloudformation/resource/name/sim-cfn-generated-resource-name.js";
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import { simCfnWafResourceError } from "./sim-cfn-waf-resource-error.js";
+
+/**
+ * How long a WAFv2 resource name may be, which is the same for all three of
+ * the named types.
+ */
+const maximumNameLength = 128;
+
+export interface SimCfnWafResourceConfigProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * What the three named WAFv2 Resource types read the same way.
+ *
+ * A web ACL, an IP set and a regex pattern set are each named within a scope
+ * and carry an optional description, and each is created through the ordinary
+ * WAFv2 command for it. What is left to a subclass is the handful of
+ * properties that say which of the three it is.
+ *
+ * The scope is read as whatever the template wrote and handed straight to the
+ * command, which refuses anything that is not `CLOUDFRONT` or `REGIONAL` and
+ * refuses `CLOUDFRONT` outside `us-east-1`. Deciding it here as well would be
+ * a second answer to a question WAFv2 already answers.
+ */
+export abstract class SimCfnWafResourceConfig {
+  protected readonly resource: SimCfnResource;
+  protected readonly properties: SimCfnTemplateValueRecord;
+
+  constructor(properties: SimCfnWafResourceConfigProperties) {
+    this.resource = properties.resource;
+    this.properties = properties.properties;
+  }
+
+  /**
+   * The CloudFormation Resource type this reads, as a refusal names it.
+   */
+  protected abstract get resourceType(): string;
+
+  /**
+   * The resource name.
+   *
+   * `Name` is optional on all three types, and an unnamed resource is named
+   * after the stack and the logical ID as real CloudFormation names one. The
+   * name is part of the ARN and of what `Ref` answers with, so a template that
+   * leaves it out still gets something a test can predict.
+   */
+  name(): string {
+    const name = this.text("Name");
+
+    return (
+      name ??
+      new SimCfnGeneratedResourceName({
+        stackName: this.resource.stackName,
+        logicalId: this.resource.logicalId,
+        maximumLength: maximumNameLength,
+      }).value
+    );
+  }
+
+  /**
+   * The scope the resource belongs to, as the template wrote it.
+   */
+  scope(): string | undefined {
+    return this.text("Scope");
+  }
+
+  /**
+   * The description, when the template gave one.
+   */
+  description(): string | undefined {
+    return this.text("Description");
+  }
+
+  /**
+   * One property of the Resource, whatever shape it is in.
+   */
+  protected value(key: string): SimCfnTemplateValue | undefined {
+    // oxlint-disable-next-line security/detect-object-injection
+    return this.properties[key] ?? undefined;
+  }
+
+  /**
+   * One string property, or nothing when the template left it out.
+   */
+  protected text(key: string): string | undefined {
+    const value = this.value(key);
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value !== "string") {
+      this.refuse(`${key} must be a string`);
+    }
+
+    return value;
+  }
+
+  /**
+   * One list-of-strings property, or nothing when the template left it out.
+   */
+  protected strings(key: string): readonly string[] | undefined {
+    const value = this.value(key);
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (!Array.isArray(value)) {
+      this.refuse(`${key} must be a list`);
+    }
+
+    return value.map((entry) => {
+      if (typeof entry !== "string") {
+        this.refuse(`every entry of ${key} must be a string`);
+      }
+
+      return entry;
+    });
+  }
+
+  /**
+   * Refuse this Resource, saying which part of it could not be read.
+   */
+  protected refuse(reason: string): never {
+    throw simCfnWafResourceError(
+      this.resourceType,
+      this.resource.logicalId,
+      reason,
+    );
+  }
+}

--- a/src/service/wafv2/cfn/sim-cfn-waf-resource-deleter.ts
+++ b/src/service/wafv2/cfn/sim-cfn-waf-resource-deleter.ts
@@ -1,0 +1,93 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimWafIpSet } from "../ip-set/sim-waf-ip-set.js";
+import type { SimWafRegexPatternSet } from "../regex-pattern-set/sim-waf-regex-pattern-set.js";
+import type { SimWafWebAcl } from "../web-acl/sim-waf-web-acl.js";
+import type { SimWafCfnWebAclAssociation } from "./association/sim-cfn-waf-web-acl-association.js";
+import {
+  type SimCfnWafCreators,
+  unsupportedSimWafResourceType,
+} from "./sim-cfn-waf-creators.js";
+import {
+  wafIpSetResourceTypeName,
+  wafRegexPatternSetResourceTypeName,
+  wafWebAclAssociationResourceTypeName,
+  wafWebAclResourceTypeName,
+} from "./sim-cfn-waf-resource-types.js";
+
+/**
+ * Deletes the simulated WAFv2 resources a CloudFormation Stack created.
+ *
+ * Each Resource is deleted through what CloudFormation held for it rather than
+ * by reading its template again. A web ACL is asked for by name, id and lock
+ * token, and an association by the resource ARN it was made against, and both
+ * of those come off the thing that was created.
+ */
+export class SimCfnWafResourceDeleter {
+  readonly #creators: SimCfnWafCreators;
+
+  constructor(properties: { readonly creators: SimCfnWafCreators }) {
+    this.#creators = properties.creators;
+  }
+
+  /**
+   * Delete one simulated WAFv2 Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+  ): Promise<void> {
+    const creators = this.#creators;
+
+    switch (resourceTypeName) {
+      case wafWebAclResourceTypeName: {
+        await creators.webAcl.delete(
+          resource,
+          created<SimWafWebAcl>(resource, "web ACL"),
+        );
+        return;
+      }
+      case wafWebAclAssociationResourceTypeName: {
+        await creators.association.delete(
+          resource,
+          created<SimWafCfnWebAclAssociation>(resource, "web ACL association"),
+        );
+        return;
+      }
+      case wafIpSetResourceTypeName: {
+        await creators.ipSet.delete(
+          resource,
+          created<SimWafIpSet>(resource, "IP set"),
+        );
+        return;
+      }
+      case wafRegexPatternSetResourceTypeName: {
+        await creators.regexPatternSet.delete(
+          resource,
+          created<SimWafRegexPatternSet>(resource, "regex pattern set"),
+        );
+        return;
+      }
+      default: {
+        throw unsupportedSimWafResourceType(resourceTypeName, " deletion");
+      }
+    }
+  }
+}
+
+/**
+ * What CloudFormation held for a Resource, which a deletion cannot do without.
+ */
+function created<T extends object>(
+  resource: SimCfnResource,
+  described: string,
+): T {
+  const simResource = resource.simResource as T | undefined;
+
+  assertDefined(
+    simResource,
+    `sim WAFv2 ${described} for CloudFormation Resource ${resource.logicalId}`,
+  );
+
+  return simResource;
+}

--- a/src/service/wafv2/cfn/sim-cfn-waf-resource-error.ts
+++ b/src/service/wafv2/cfn/sim-cfn-waf-resource-error.ts
@@ -1,0 +1,56 @@
+import { SimWafError } from "../error/sim-wafv2.error.js";
+
+/**
+ * Build the error a Resource of a simulated WAFv2 type is refused with.
+ *
+ * The wording is deliberate. Sim CloudFormation reads an error saying a
+ * Resource is unsupported as one to record and step over, and stepping over a
+ * web ACL that cannot be created as the template asked for it is the wrong
+ * answer: the stack would look deployed while every request the rules were
+ * written to stop went through. So a refusal here says the Resource is
+ * invalid.
+ */
+export function simCfnWafResourceError(
+  resourceType: string,
+  logicalId: string,
+  reason: string,
+  cause?: unknown,
+): Error {
+  return new Error(`Invalid ${resourceType} Resource ${logicalId}: ${reason}`, {
+    cause,
+  });
+}
+
+/**
+ * Run the simulated WAFv2 commands one Resource is made of, naming the
+ * Resource in whatever they refuse.
+ *
+ * Every Resource type here goes through the ordinary WAFv2 commands, so what a
+ * template may ask for is decided once, by simulated WAFv2, rather than again
+ * in the CloudFormation layer. What that leaves out is where the request came
+ * from: a deployment failing with `Rule block-admin uses the statement kind
+ * SqliMatchStatement` says which rule but not which Resource declared it, and
+ * a template can hold several. Only WAFv2's own errors are renamed, so a
+ * refusal the CloudFormation layer decided keeps the wording it was written
+ * with.
+ */
+export async function simCfnWafResourceCommand<T>(
+  resourceType: string,
+  logicalId: string,
+  run: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await run();
+  } catch (error) {
+    if (error instanceof SimWafError) {
+      throw simCfnWafResourceError(
+        resourceType,
+        logicalId,
+        error.message,
+        error,
+      );
+    }
+
+    throw error;
+  }
+}

--- a/src/service/wafv2/cfn/sim-cfn-waf-resource-types.ts
+++ b/src/service/wafv2/cfn/sim-cfn-waf-resource-types.ts
@@ -1,0 +1,23 @@
+/**
+ * The CloudFormation Resource types simulated WAFv2 creates.
+ *
+ * Named here rather than spelled out where they are used, because each one is
+ * written twice: once by the factory dispatching on it, and once by the
+ * refusals that quote it back to whoever wrote the template.
+ */
+export const wafWebAclResourceType = "AWS::WAFv2::WebACL";
+
+export const wafWebAclAssociationResourceType = "AWS::WAFv2::WebACLAssociation";
+
+export const wafIpSetResourceType = "AWS::WAFv2::IPSet";
+
+export const wafRegexPatternSetResourceType = "AWS::WAFv2::RegexPatternSet";
+
+/** The type names the CloudFormation layer dispatches on, without a prefix. */
+export const wafWebAclResourceTypeName = "WebACL";
+
+export const wafWebAclAssociationResourceTypeName = "WebACLAssociation";
+
+export const wafIpSetResourceTypeName = "IPSet";
+
+export const wafRegexPatternSetResourceTypeName = "RegexPatternSet";

--- a/src/service/wafv2/cfn/sim-cfn-waf-sets.iso.test.ts
+++ b/src/service/wafv2/cfn/sim-cfn-waf-sets.iso.test.ts
@@ -88,6 +88,23 @@ function outputValue(stack: SimCfnStack, name: string): string {
   return value;
 }
 
+/**
+ * Deploy Resources that are expected to fail, and answer with the error.
+ */
+async function deploymentFailure(
+  resources: Record<string, SimCfnTemplateValue>,
+): Promise<Error> {
+  const simAws = new SimAws();
+
+  return await assertThrowsErrorAsync(async () => {
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "sets",
+      template: { Resources: resources },
+    });
+    await stack.waitForDeployComplete();
+  });
+}
+
 describe("AWS::WAFv2::IPSet and AWS::WAFv2::RegexPatternSet", () => {
   it("deploys both sets with what the template wrote in them", async () => {
     // Given a template declaring an IP set and a regex pattern set.
@@ -229,6 +246,47 @@ describe("AWS::WAFv2::IPSet and AWS::WAFv2::RegexPatternSet", () => {
       error.message,
       "Invalid AWS::WAFv2::IPSet Resource OfficeAddresses: Addresses must be " +
         "a list",
+    );
+  });
+
+  it("refuses a set whose required list the template left out", async () => {
+    // Given a template that misspells Addresses, which real CloudFormation
+    // refuses against the schema.
+    const error = await deploymentFailure({
+      OfficeAddresses: {
+        Type: "AWS::WAFv2::IPSet",
+        Properties: {
+          Name: "office-addresses",
+          Scope: "REGIONAL",
+          IPAddressVersion: "IPV4",
+          Address: ["192.0.2.0/24"],
+        },
+      },
+    });
+
+    // Then the deployment failed. Reading the omission as an empty list would
+    // deploy a set holding nothing, and a rule pointing at one matches no
+    // request at all.
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::WAFv2::IPSet Resource OfficeAddresses: Addresses is " +
+        "required",
+    );
+  });
+
+  it("refuses a pattern set whose expressions the template left out", async () => {
+    // Given a template whose pattern set names no expressions.
+    const error = await deploymentFailure({
+      BotPatterns: {
+        Type: "AWS::WAFv2::RegexPatternSet",
+        Properties: { Name: "bot-patterns", Scope: "REGIONAL" },
+      },
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::WAFv2::RegexPatternSet Resource BotPatterns: " +
+        "RegularExpressionList is required",
     );
   });
 

--- a/src/service/wafv2/cfn/sim-cfn-waf-sets.iso.test.ts
+++ b/src/service/wafv2/cfn/sim-cfn-waf-sets.iso.test.ts
@@ -1,0 +1,250 @@
+import {
+  DeleteStackCommand,
+  UpdateStackCommand,
+} from "@aws-sdk/client-cloudformation";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTypeString,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnStack } from "../../cloudformation/stack/sim-cfn-stack.js";
+import type { CfnTemplateBodyRecord } from "../../cloudformation/template/sim-cfn-template.js";
+import type { SimCfnTemplateValue } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import { jsonStringify } from "../../../util/type-guard/json.js";
+
+/**
+ * A template declaring an IP set and a regex pattern set side by side, with
+ * the properties a test is about written over the ones both need.
+ *
+ * The two are deployed together because everything they do is the same bar the
+ * one property each is made of, and a stack holding both says so.
+ */
+function setsTemplate(
+  ipSet: Record<string, SimCfnTemplateValue> = {},
+  patternSet: Record<string, SimCfnTemplateValue> = {},
+): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      OfficeAddresses: {
+        Type: "AWS::WAFv2::IPSet",
+        Properties: {
+          Name: "office-addresses",
+          Scope: "REGIONAL",
+          IPAddressVersion: "IPV4",
+          Addresses: ["192.0.2.0/24"],
+          ...ipSet,
+        },
+      },
+      BotPatterns: {
+        Type: "AWS::WAFv2::RegexPatternSet",
+        Properties: {
+          Name: "bot-patterns",
+          Scope: "REGIONAL",
+          RegularExpressionList: ["^curl/", "^wget/"],
+          ...patternSet,
+        },
+      },
+    },
+    Outputs: {
+      IpSetRef: { Value: { Ref: "OfficeAddresses" } },
+      IpSetArn: { Value: { "Fn::GetAtt": ["OfficeAddresses", "Arn"] } },
+      IpSetId: { Value: { "Fn::GetAtt": ["OfficeAddresses", "Id"] } },
+      PatternSetArn: { Value: { "Fn::GetAtt": ["BotPatterns", "Arn"] } },
+      PatternSetId: { Value: { "Fn::GetAtt": ["BotPatterns", "Id"] } },
+    },
+  };
+}
+
+async function deploySets(
+  simAws: SimAws,
+  ipSet: Record<string, SimCfnTemplateValue> = {},
+  patternSet: Record<string, SimCfnTemplateValue> = {},
+): Promise<SimCfnStack> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "sets",
+    template: setsTemplate(ipSet, patternSet),
+  });
+  await stack.waitForDeployComplete();
+
+  return stack;
+}
+
+/**
+ * One output of the deployed stack, which every assertion here reaches an ARN
+ * through.
+ */
+function outputValue(stack: SimCfnStack, name: string): string {
+  const value = stack.outputs.get(name)?.value;
+
+  assertTypeString(value);
+
+  return value;
+}
+
+describe("AWS::WAFv2::IPSet and AWS::WAFv2::RegexPatternSet", () => {
+  it("deploys both sets with what the template wrote in them", async () => {
+    // Given a template declaring an IP set and a regex pattern set.
+    const simAws = new SimAws();
+    const stack = await deploySets(simAws);
+    const wafV2 = simAws.wafV2();
+
+    // Then each is there under the ARN its attribute reported, holding what
+    // the template gave it. A template writes the expressions as plain
+    // strings, where the API wraps each in a RegexString.
+    const ipSet = wafV2.findIpSetByArn(outputValue(stack, "IpSetArn"));
+    const patternSet = wafV2.findRegexPatternSetByArn(
+      outputValue(stack, "PatternSetArn"),
+    );
+
+    assertNonNullable(ipSet);
+    assertNonNullable(patternSet);
+    assertIdentical(ipSet.ipAddressVersion, "IPV4");
+    assertArrayLength(ipSet.addresses, 1);
+    assertIdentical(ipSet.addresses[0], "192.0.2.0/24");
+    assertArrayLength(patternSet.regularExpressions, 2);
+    assertIdentical(patternSet.regularExpressions[0], "^curl/");
+  });
+
+  it("answers Ref with the physical id and Id with the id alone", async () => {
+    // Given a deployed IP set whose Ref and Id are both outputs.
+    const simAws = new SimAws();
+    const stack = await deploySets(simAws);
+    const ipSet = simAws.wafV2().findIpSetByArn(outputValue(stack, "IpSetArn"));
+
+    assertNonNullable(ipSet);
+
+    // Then the Ref is the three-part physical id WAFv2 resources carry, and
+    // the attribute is the generated id on its own.
+    assertIdentical(
+      stack.outputs.get("IpSetRef")?.value,
+      `office-addresses|${ipSet.id}|REGIONAL`,
+    );
+    assertIdentical(stack.outputs.get("IpSetId")?.value, ipSet.id);
+  });
+
+  it("writes the new ranges and patterns over the sets on an update", async () => {
+    // Given both sets deployed.
+    const simAws = new SimAws();
+    await deploySets(simAws);
+    const cloudFormation = simAws.cloudFormation();
+
+    // When the stack is updated with different contents.
+    const updatedTemplate = setsTemplate(
+      { Addresses: ["198.51.100.0/24"] },
+      { RegularExpressionList: ["^scraper/"] },
+    );
+
+    await cloudFormation.updateStack(
+      new UpdateStackCommand({
+        StackName: "sets",
+        TemplateBody: jsonStringify(updatedTemplate),
+      }),
+    );
+    await cloudFormation.waitForStackUpdateComplete("sets");
+
+    // Then each holds what the new template said, and neither was left beside
+    // a second set under the same name.
+    const stack = cloudFormation.getStackByName("sets");
+    assertNonNullable(stack);
+
+    const wafV2 = simAws.wafV2();
+    const ipSet = wafV2.findIpSetByArn(outputValue(stack, "IpSetArn"));
+    const patternSet = wafV2.findRegexPatternSetByArn(
+      outputValue(stack, "PatternSetArn"),
+    );
+
+    assertNonNullable(ipSet);
+    assertNonNullable(patternSet);
+    assertIdentical(ipSet.addresses[0], "198.51.100.0/24");
+    assertIdentical(patternSet.regularExpressions[0], "^scraper/");
+  });
+
+  it("deletes both sets when the stack comes down", async () => {
+    // Given both sets deployed.
+    const simAws = new SimAws();
+    const stack = await deploySets(simAws);
+    const ipSetArn = outputValue(stack, "IpSetArn");
+    const patternSetArn = outputValue(stack, "PatternSetArn");
+
+    // When the stack is deleted.
+    await simAws
+      .cloudFormation()
+      .deleteStack(new DeleteStackCommand({ StackName: "sets" }));
+    await simAws.backgroundTasksComplete();
+
+    // Then neither set is there any more.
+    const wafV2 = simAws.wafV2();
+
+    assertUndefined(wafV2.findIpSetByArn(ipSetArn));
+    assertUndefined(wafV2.findRegexPatternSetByArn(patternSetArn));
+  });
+
+  it("refuses an address a template wrote without a prefix length", async () => {
+    // Given a template whose IP set holds a bare address, which WAF refuses:
+    // it takes CIDR notation and nothing else.
+    const simAws = new SimAws();
+    const error = await assertThrowsErrorAsync(async () => {
+      await deploySets(simAws, { Addresses: ["192.0.2.44"] });
+    });
+
+    // Then the deployment failed, naming the Resource that asked for it.
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::WAFv2::IPSet Resource OfficeAddresses",
+    );
+    assertStringIncludes(error.message, "192.0.2.44");
+  });
+
+  it("refuses an expression that will not compile", async () => {
+    // Given a template whose pattern set holds an unclosed group.
+    const simAws = new SimAws();
+    const error = await assertThrowsErrorAsync(async () => {
+      await deploySets(simAws, {}, { RegularExpressionList: ["^(unclosed"] });
+    });
+
+    // Then the deployment failed where the expression was written, rather than
+    // leaving a rule that would quietly match nothing.
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::WAFv2::RegexPatternSet Resource BotPatterns",
+    );
+  });
+
+  it("refuses a property whose template value is the wrong shape", async () => {
+    // Given a template whose Addresses is a string.
+    const simAws = new SimAws();
+    const error = await assertThrowsErrorAsync(async () => {
+      await deploySets(simAws, { Addresses: "192.0.2.0/24" });
+    });
+
+    // Then the refusal says which Resource could not be read.
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::WAFv2::IPSet Resource OfficeAddresses: Addresses must be " +
+        "a list",
+    );
+  });
+
+  it("refuses a RegularExpressionList that is not a list", async () => {
+    // Given a template writing one expression as a bare string, which is a
+    // mistake worth making: the list is of strings here where the API takes a
+    // list of objects, so it reads as though a string would do.
+    const simAws = new SimAws();
+    const error = await assertThrowsErrorAsync(async () => {
+      await deploySets(simAws, {}, { RegularExpressionList: "^curl/" });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::WAFv2::RegexPatternSet Resource BotPatterns: " +
+        "RegularExpressionList must be a list",
+    );
+  });
+});

--- a/src/service/wafv2/cfn/sim-cfn-waf-values.iso.test.ts
+++ b/src/service/wafv2/cfn/sim-cfn-waf-values.iso.test.ts
@@ -1,0 +1,354 @@
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  deployRestApi,
+  simAwsInEuWest2,
+} from "../../../../test/apigateway/cfn-deploy.js";
+import type { SimRestApi } from "../../apigateway/api/sim-rest-api.js";
+import { simCfnRestApiTemplateFactory } from "../../apigateway/cfn/sim-cfn-rest-api-template.factory.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnTemplateValue } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+const visibility = {
+  SampledRequestsEnabled: false,
+  CloudWatchMetricsEnabled: false,
+  MetricName: "orders",
+};
+
+/**
+ * A rule blocking whatever a statement claims, so a test about capacity states
+ * the statement and nothing else.
+ */
+function ruleWith(statement: SimCfnTemplateValue): SimCfnTemplateValue {
+  return {
+    Name: "block",
+    Priority: 0,
+    Action: { Block: {} },
+    Statement: statement,
+    VisibilityConfig: { ...visibility, MetricName: "block" },
+  };
+}
+
+const uriPathMatch = {
+  ByteMatchStatement: {
+    FieldToMatch: { UriPath: {} },
+    PositionalConstraint: "CONTAINS",
+    SearchString: "/admin",
+    TextTransformations: [{ Priority: 0, Type: "NONE" }],
+  },
+};
+
+/**
+ * Deploy a web ACL and answer with its capacity, as Fn::GetAtt reports it.
+ */
+async function deployedCapacity(
+  rules: SimCfnTemplateValue[],
+): Promise<unknown> {
+  const simAws = new SimAws();
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "capacity",
+    template: {
+      Resources: {
+        Acl: {
+          Type: "AWS::WAFv2::WebACL",
+          Properties: {
+            Name: "capacity-acl",
+            Scope: "REGIONAL",
+            DefaultAction: { Allow: {} },
+            VisibilityConfig: visibility,
+            Rules: rules,
+          },
+        },
+      },
+      Outputs: { Capacity: { Value: { "Fn::GetAtt": ["Acl", "Capacity"] } } },
+    },
+  });
+  await stack.waitForDeployComplete();
+
+  return stack.outputs.get("Capacity")?.value;
+}
+
+/**
+ * Deploy a stack whose one web ACL publishes the attribute named.
+ */
+async function deployedAttribute(
+  resource: SimCfnTemplateValue,
+  attributeName: string,
+): Promise<Error> {
+  const simAws = new SimAws();
+
+  return await assertThrowsErrorAsync(async () => {
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "attributes",
+      template: {
+        Resources: { Thing: resource },
+        Outputs: {
+          Attribute: { Value: { "Fn::GetAtt": ["Thing", attributeName] } },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+  });
+}
+
+const webAclResource = {
+  Type: "AWS::WAFv2::WebACL",
+  Properties: {
+    Name: "orders-acl",
+    Scope: "REGIONAL",
+    DefaultAction: { Allow: {} },
+    VisibilityConfig: visibility,
+    Rules: [ruleWith(uriPathMatch)],
+  },
+};
+
+describe("Simulated WAFv2 CloudFormation values", () => {
+  it("adds up the capacity of the statements inside a logical statement", async () => {
+    // Given a web ACL whose one rule joins three statements, two of them
+    // negated or nested.
+    const capacity = await deployedCapacity([
+      ruleWith({
+        AndStatement: {
+          Statements: [
+            uriPathMatch,
+            { NotStatement: { Statement: uriPathMatch } },
+            { OrStatement: { Statements: [uriPathMatch, uriPathMatch] } },
+          ],
+        },
+      }),
+    ]);
+
+    // Then it costs what its parts cost. A logical statement has no cost of
+    // its own, and a byte match is one unit each.
+    assertIdentical(capacity, 4);
+  });
+
+  it("counts a managed rule group at the capacity AWS fixed it at", async () => {
+    // Given a web ACL naming the core rule set with a scope-down statement.
+    const capacity = await deployedCapacity([
+      {
+        Name: "core",
+        Priority: 0,
+        OverrideAction: { None: {} },
+        Statement: {
+          ManagedRuleGroupStatement: {
+            VendorName: "AWS",
+            Name: "AWSManagedRulesCommonRuleSet",
+            ScopeDownStatement: uriPathMatch,
+          },
+        },
+        VisibilityConfig: { ...visibility, MetricName: "core" },
+      },
+    ]);
+
+    // Then the group's own capacity is what it costs, plus the one unit its
+    // scope-down statement adds.
+    assertIdentical(capacity, 701);
+  });
+
+  it("refuses an attribute a web ACL does not publish", async () => {
+    // Given a template reading a Scope attribute off a web ACL, which is part
+    // of the physical id and no attribute of its own.
+    const error = await deployedAttribute(webAclResource, "Scope");
+
+    assertStringIncludes(
+      error.message,
+      "Unsupported AWS::WAFv2::WebACL attribute Scope",
+    );
+  });
+
+  it("refuses an attribute a set does not publish", async () => {
+    // Given a template reading an Addresses attribute off an IP set.
+    const error = await deployedAttribute(
+      {
+        Type: "AWS::WAFv2::IPSet",
+        Properties: {
+          Name: "office",
+          Scope: "REGIONAL",
+          IPAddressVersion: "IPV4",
+          Addresses: ["192.0.2.0/24"],
+        },
+      },
+      "Addresses",
+    );
+
+    assertStringIncludes(
+      error.message,
+      "Unsupported AWS::WAFv2::IPSet attribute Addresses",
+    );
+  });
+
+  it("refuses an attribute off an association, which publishes none", async () => {
+    // Given a template reading an attribute off an association.
+    const simAws = simAwsInEuWest2();
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployRestApi(
+        simAws,
+        simCfnRestApiTemplateFactory.make({
+          resources: {
+            OrdersAcl: webAclResource,
+            OrdersAclAssociation: {
+              Type: "AWS::WAFv2::WebACLAssociation",
+              Properties: {
+                ResourceArn: {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:apigateway:",
+                      { Ref: "AWS::Region" },
+                      "::/restapis/",
+                      { Ref: "Api" },
+                      "/stages/",
+                      { Ref: "Stage" },
+                    ],
+                  ],
+                },
+                WebACLArn: { "Fn::GetAtt": ["OrdersAcl", "Arn"] },
+              },
+            },
+          },
+          outputs: {
+            Association: {
+              Value: { "Fn::GetAtt": ["OrdersAclAssociation", "Id"] },
+            },
+          },
+        }),
+      );
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Unsupported AWS::WAFv2::WebACLAssociation attribute Id",
+    );
+  });
+
+  it("records a WAFv2 Resource type nothing simulates as skipped", async () => {
+    // Given a template declaring a rule group, which is a resource in its own
+    // right and one this simulation does not hold.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "rule-group",
+      template: {
+        Resources: {
+          Group: {
+            Type: "AWS::WAFv2::RuleGroup",
+            Properties: { Name: "group", Scope: "REGIONAL", Capacity: 10 },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then it was stepped over and reported, rather than treated as deployed.
+    const resource = stack.getResource("Group");
+
+    assertNonNullable(resource);
+    assertTrue(resource.skipped);
+    assertStringIncludes(
+      resource.skippedReason ?? "",
+      "Unsupported sim WAFv2 CloudFormation Resource RuleGroup",
+    );
+  });
+
+  it("refuses a Name that is not a string", async () => {
+    // Given a template whose web ACL is named with a number.
+    const error = await deployedAttribute(
+      {
+        Type: "AWS::WAFv2::WebACL",
+        Properties: {
+          Name: 7,
+          Scope: "REGIONAL",
+          DefaultAction: { Allow: {} },
+          VisibilityConfig: visibility,
+        },
+      },
+      "Arn",
+    );
+
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::WAFv2::WebACL Resource Thing: Name must be a string",
+    );
+  });
+
+  it("refuses a list property holding something that is not a string", async () => {
+    // Given a template whose IP set holds a number among its addresses.
+    const error = await deployedAttribute(
+      {
+        Type: "AWS::WAFv2::IPSet",
+        Properties: {
+          Name: "office",
+          Scope: "REGIONAL",
+          IPAddressVersion: "IPV4",
+          Addresses: [24],
+        },
+      },
+      "Arn",
+    );
+
+    assertStringIncludes(
+      error.message,
+      "every entry of Addresses must be a string",
+    );
+  });
+
+  it("tears down an association whose resource has gone already", async () => {
+    // Given a REST API in one stack and the web ACL protecting its stage in
+    // another, which is what leaves CloudFormation free to take the stage down
+    // first: the association names the stage by an ARN rather than by a
+    // reference it could order itself against.
+    const simAws = simAwsInEuWest2();
+    const apiStack = await deployRestApi(
+      simAws,
+      simCfnRestApiTemplateFactory.make({}),
+    );
+    const restApi = apiStack.getResource("Api")?.simResource as
+      | SimRestApi
+      | undefined;
+
+    assertNonNullable(restApi);
+
+    const stageArn = restApi.stageArn("prod");
+    const aclStack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-acl-stack",
+      template: {
+        Resources: {
+          OrdersAcl: webAclResource,
+          OrdersAclAssociation: {
+            Type: "AWS::WAFv2::WebACLAssociation",
+            Properties: {
+              ResourceArn: stageArn,
+              WebACLArn: { "Fn::GetAtt": ["OrdersAcl", "Arn"] },
+            },
+          },
+        },
+      },
+    });
+    await aclStack.waitForDeployComplete();
+
+    assertTrue(simAws.wafV2().protection().protects(stageArn));
+
+    // When the API's stack comes down first and the web ACL's follows.
+    await apiStack.teardown();
+    await aclStack.teardown();
+
+    // Then the association came down with it. Deleting the stage had already
+    // let go of the web ACL, so there was nothing left to disassociate, and
+    // the web ACL was free to be deleted after it.
+    assertIdentical(
+      aclStack.resources.get("OrdersAclAssociation")?.status,
+      "DELETE_COMPLETE",
+    );
+    assertFalse(simAws.wafV2().protection().protects(stageArn));
+    assertArrayLength(simAws.wafV2().allWebAcls("REGIONAL"), 0);
+  });
+});

--- a/src/service/wafv2/cfn/sim-cfn-waf-values.iso.test.ts
+++ b/src/service/wafv2/cfn/sim-cfn-waf-values.iso.test.ts
@@ -48,36 +48,6 @@ const uriPathMatch = {
 };
 
 /**
- * Deploy a web ACL and answer with its capacity, as Fn::GetAtt reports it.
- */
-async function deployedCapacity(
-  rules: SimCfnTemplateValue[],
-): Promise<unknown> {
-  const simAws = new SimAws();
-  const stack = await simAws.cloudFormation().deployTemplate({
-    stackName: "capacity",
-    template: {
-      Resources: {
-        Acl: {
-          Type: "AWS::WAFv2::WebACL",
-          Properties: {
-            Name: "capacity-acl",
-            Scope: "REGIONAL",
-            DefaultAction: { Allow: {} },
-            VisibilityConfig: visibility,
-            Rules: rules,
-          },
-        },
-      },
-      Outputs: { Capacity: { Value: { "Fn::GetAtt": ["Acl", "Capacity"] } } },
-    },
-  });
-  await stack.waitForDeployComplete();
-
-  return stack.outputs.get("Capacity")?.value;
-}
-
-/**
  * Deploy a stack whose one web ACL publishes the attribute named.
  */
 async function deployedAttribute(
@@ -112,49 +82,6 @@ const webAclResource = {
 };
 
 describe("Simulated WAFv2 CloudFormation values", () => {
-  it("adds up the capacity of the statements inside a logical statement", async () => {
-    // Given a web ACL whose one rule joins three statements, two of them
-    // negated or nested.
-    const capacity = await deployedCapacity([
-      ruleWith({
-        AndStatement: {
-          Statements: [
-            uriPathMatch,
-            { NotStatement: { Statement: uriPathMatch } },
-            { OrStatement: { Statements: [uriPathMatch, uriPathMatch] } },
-          ],
-        },
-      }),
-    ]);
-
-    // Then it costs what its parts cost. A logical statement has no cost of
-    // its own, and a byte match is one unit each.
-    assertIdentical(capacity, 4);
-  });
-
-  it("counts a managed rule group at the capacity AWS fixed it at", async () => {
-    // Given a web ACL naming the core rule set with a scope-down statement.
-    const capacity = await deployedCapacity([
-      {
-        Name: "core",
-        Priority: 0,
-        OverrideAction: { None: {} },
-        Statement: {
-          ManagedRuleGroupStatement: {
-            VendorName: "AWS",
-            Name: "AWSManagedRulesCommonRuleSet",
-            ScopeDownStatement: uriPathMatch,
-          },
-        },
-        VisibilityConfig: { ...visibility, MetricName: "core" },
-      },
-    ]);
-
-    // Then the group's own capacity is what it costs, plus the one unit its
-    // scope-down statement adds.
-    assertIdentical(capacity, 701);
-  });
-
   it("refuses an attribute a web ACL does not publish", async () => {
     // Given a template reading a Scope attribute off a web ACL, which is part
     // of the physical id and no attribute of its own.

--- a/src/service/wafv2/cfn/sim-cfn-waf-web-acl.iso.test.ts
+++ b/src/service/wafv2/cfn/sim-cfn-waf-web-acl.iso.test.ts
@@ -1,0 +1,279 @@
+import {
+  DeleteStackCommand,
+  UpdateStackCommand,
+} from "@aws-sdk/client-cloudformation";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { DEFAULT_SIM_AWS_ACCOUNT_ID } from "../../aws/sim-aws-account.js";
+import type { SimCfnStack } from "../../cloudformation/stack/sim-cfn-stack.js";
+import type { CfnTemplateBodyRecord } from "../../cloudformation/template/sim-cfn-template.js";
+import type { SimCfnTemplateValue } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import { jsonStringify } from "../../../util/type-guard/json.js";
+import { simWafBrowserRequest } from "../sim-wafv2.fixture.js";
+
+const visibility = {
+  SampledRequestsEnabled: false,
+  CloudWatchMetricsEnabled: false,
+  MetricName: "orders",
+};
+
+/**
+ * A rule blocking whatever asks for an admin path, spelled as a template
+ * spells it: the search string is a plain string, where the SDK takes bytes.
+ */
+const blockAdmin = {
+  Name: "block-admin",
+  Priority: 0,
+  Action: { Block: {} },
+  Statement: {
+    ByteMatchStatement: {
+      FieldToMatch: { UriPath: {} },
+      PositionalConstraint: "CONTAINS",
+      SearchString: "/admin",
+      TextTransformations: [{ Priority: 0, Type: "NONE" }],
+    },
+  },
+  VisibilityConfig: { ...visibility, MetricName: "block-admin" },
+};
+
+/**
+ * A template declaring one web ACL, with whatever properties a test is about
+ * written over the ones every test here needs.
+ */
+function webAclTemplate(
+  properties: Record<string, SimCfnTemplateValue> = {},
+): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      OrdersAcl: {
+        Type: "AWS::WAFv2::WebACL",
+        Properties: {
+          Name: "orders-acl",
+          Scope: "REGIONAL",
+          DefaultAction: { Allow: {} },
+          VisibilityConfig: visibility,
+          Rules: [blockAdmin],
+          ...properties,
+        },
+      },
+    },
+    Outputs: {
+      AclRef: { Value: { Ref: "OrdersAcl" } },
+      AclArn: { Value: { "Fn::GetAtt": ["OrdersAcl", "Arn"] } },
+      AclId: { Value: { "Fn::GetAtt": ["OrdersAcl", "Id"] } },
+      AclCapacity: { Value: { "Fn::GetAtt": ["OrdersAcl", "Capacity"] } },
+      AclLabels: { Value: { "Fn::GetAtt": ["OrdersAcl", "LabelNamespace"] } },
+    },
+  };
+}
+
+async function deployWebAcl(
+  simAws: SimAws,
+  properties: Record<string, SimCfnTemplateValue> = {},
+): Promise<SimCfnStack> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "orders",
+    template: webAclTemplate(properties),
+  });
+  await stack.waitForDeployComplete();
+
+  return stack;
+}
+
+/**
+ * What the deployed web ACL does with a request to one path.
+ */
+function decisionFor(simAws: SimAws, stack: SimCfnStack, path: string): string {
+  const webAclArn = stack.outputs.get("AclArn")?.value;
+  assertTypeString(webAclArn);
+
+  return simAws.wafV2().evaluateRequest({
+    webAclArn,
+    request: simWafBrowserRequest(`https://orders.example.com${path}`),
+  }).action;
+}
+
+describe("AWS::WAFv2::WebACL", () => {
+  it("deploys a web ACL that decides requests by the rules the template wrote", async () => {
+    // Given a template declaring a web ACL that blocks admin paths.
+    const simAws = new SimAws();
+    const stack = await deployWebAcl(simAws);
+
+    // Then the deployed web ACL is the one WAFv2 holds, and it decides
+    // requests by the rule the template gave it.
+    assertArrayLength(simAws.wafV2().allWebAcls("REGIONAL"), 1);
+    assertIdentical(decisionFor(simAws, stack, "/admin/users"), "BLOCK");
+    assertIdentical(decisionFor(simAws, stack, "/orders"), "ALLOW");
+  });
+
+  it("answers Fn::GetAtt with the four attributes a web ACL publishes", async () => {
+    // Given a deployed web ACL whose attributes are all outputs.
+    const simAws = new SimAws();
+    const stack = await deployWebAcl(simAws);
+    const webAcl = simAws.wafV2().allWebAcls("REGIONAL")[0];
+
+    assertNonNullable(webAcl);
+
+    // Then each attribute answers with what the web ACL carries. The capacity
+    // is the one byte match rule's single unit, and the label namespace is
+    // the prefix AWS qualifies this web ACL's labels with.
+    assertIdentical(stack.outputs.get("AclArn")?.value, webAcl.arn);
+    assertIdentical(stack.outputs.get("AclId")?.value, webAcl.id);
+    assertIdentical(stack.outputs.get("AclCapacity")?.value, 1);
+    assertIdentical(
+      stack.outputs.get("AclLabels")?.value,
+      `awswaf:${DEFAULT_SIM_AWS_ACCOUNT_ID}:webacl:orders-acl:`,
+    );
+  });
+
+  it("answers Ref with the physical id, which WAFv2 spells in three parts", async () => {
+    // Given a deployed web ACL whose Ref is an output.
+    const simAws = new SimAws();
+    const stack = await deployWebAcl(simAws);
+    const webAcl = simAws.wafV2().allWebAcls("REGIONAL")[0];
+
+    assertNonNullable(webAcl);
+
+    // Then it is the name, the id and the scope joined by pipes. WAFv2 is a
+    // registry type with a composite primary identifier, so a Ref gives that
+    // back rather than the ARN a template usually wants.
+    assertIdentical(
+      stack.outputs.get("AclRef")?.value,
+      `orders-acl|${webAcl.id}|REGIONAL`,
+    );
+  });
+
+  it("names an unnamed web ACL after the stack and the logical id", async () => {
+    // Given a template that leaves Name out, which CloudFormation allows.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders",
+      template: {
+        Resources: {
+          OrdersAcl: {
+            Type: "AWS::WAFv2::WebACL",
+            Properties: {
+              Scope: "REGIONAL",
+              DefaultAction: { Allow: {} },
+              VisibilityConfig: visibility,
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the web ACL carries the name CloudFormation generated for it.
+    assertIdentical(
+      simAws.wafV2().allWebAcls("REGIONAL")[0]?.name,
+      "orders-OrdersAcl",
+    );
+  });
+
+  it("writes the new rules over the web ACL when the template changes", async () => {
+    // Given a deployed web ACL blocking admin paths.
+    const simAws = new SimAws();
+    await deployWebAcl(simAws);
+
+    // When the stack is updated with the rule pointed somewhere else.
+    const cloudFormation = simAws.cloudFormation();
+    const updatedTemplate = webAclTemplate({
+      Rules: [
+        {
+          ...blockAdmin,
+          Statement: {
+            ByteMatchStatement: {
+              ...blockAdmin.Statement.ByteMatchStatement,
+              SearchString: "/reports",
+            },
+          },
+        },
+      ],
+    });
+
+    await cloudFormation.updateStack(
+      new UpdateStackCommand({
+        StackName: "orders",
+        TemplateBody: jsonStringify(updatedTemplate),
+      }),
+    );
+    await cloudFormation.waitForStackUpdateComplete("orders");
+
+    const updated = cloudFormation.getStackByName("orders");
+
+    assertNonNullable(updated);
+
+    // Then the request the old rules blocked is allowed and the new one is
+    // blocked, and there is still one web ACL rather than two.
+    assertArrayLength(simAws.wafV2().allWebAcls("REGIONAL"), 1);
+    assertIdentical(decisionFor(simAws, updated, "/admin/users"), "ALLOW");
+    assertIdentical(decisionFor(simAws, updated, "/reports/q1"), "BLOCK");
+  });
+
+  it("deletes the web ACL when the stack comes down", async () => {
+    // Given a deployed web ACL.
+    const simAws = new SimAws();
+    await deployWebAcl(simAws);
+
+    // When the stack is deleted.
+    await simAws
+      .cloudFormation()
+      .deleteStack(new DeleteStackCommand({ StackName: "orders" }));
+    await simAws.backgroundTasksComplete();
+
+    // Then the web ACL went with it.
+    assertArrayLength(simAws.wafV2().allWebAcls("REGIONAL"), 0);
+  });
+
+  it("refuses a statement kind the service refuses, naming the Resource", async () => {
+    // Given a template whose rule inspects the client address, which every
+    // request in this simulation shares.
+    const simAws = new SimAws();
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployWebAcl(simAws, {
+        Rules: [
+          {
+            ...blockAdmin,
+            Statement: {
+              IPSetReferenceStatement: {
+                ARN: "arn:aws:wafv2:us-east-1:111111111111:regional/ipset/o/1",
+              },
+            },
+          },
+        ],
+      });
+    });
+
+    // Then the deployment failed, naming the logical id alongside the rule and
+    // the statement kind WAFv2 would not compile.
+    assertStringIncludes(
+      error.message,
+      "AWS::WAFv2::WebACL Resource OrdersAcl",
+    );
+    assertStringIncludes(error.message, "Rule block-admin");
+    assertStringIncludes(error.message, "IPSetReferenceStatement");
+  });
+
+  it("refuses a Rules property that is not a list", async () => {
+    // Given a template whose Rules is an object.
+    const simAws = new SimAws();
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployWebAcl(simAws, { Rules: { Name: "block-admin" } });
+    });
+
+    // Then the refusal says which Resource could not be read.
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::WAFv2::WebACL Resource OrdersAcl: Rules must be a list",
+    );
+  });
+});

--- a/src/service/wafv2/cfn/sim-cfn-waf-web-acl.iso.test.ts
+++ b/src/service/wafv2/cfn/sim-cfn-waf-web-acl.iso.test.ts
@@ -124,11 +124,11 @@ describe("AWS::WAFv2::WebACL", () => {
     assertNonNullable(webAcl);
 
     // Then each attribute answers with what the web ACL carries. The capacity
-    // is the one byte match rule's single unit, and the label namespace is
-    // the prefix AWS qualifies this web ACL's labels with.
+    // is what AWS charges for the one rule's CONTAINS byte match, and the
+    // label namespace is the prefix AWS qualifies this web ACL's labels with.
     assertIdentical(stack.outputs.get("AclArn")?.value, webAcl.arn);
     assertIdentical(stack.outputs.get("AclId")?.value, webAcl.id);
-    assertIdentical(stack.outputs.get("AclCapacity")?.value, 1);
+    assertIdentical(stack.outputs.get("AclCapacity")?.value, 10);
     assertIdentical(
       stack.outputs.get("AclLabels")?.value,
       `awswaf:${DEFAULT_SIM_AWS_ACCOUNT_ID}:webacl:orders-acl:`,

--- a/src/service/wafv2/cfn/sim-waf-cfn-resource-factory.ts
+++ b/src/service/wafv2/cfn/sim-waf-cfn-resource-factory.ts
@@ -1,0 +1,88 @@
+import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimWafV2 } from "../sim-wafv2.js";
+import {
+  type SimCfnWafCreators,
+  simCfnWafCreators,
+  unsupportedSimWafResourceType,
+} from "./sim-cfn-waf-creators.js";
+import { SimCfnWafResourceDeleter } from "./sim-cfn-waf-resource-deleter.js";
+import {
+  wafIpSetResourceTypeName,
+  wafRegexPatternSetResourceTypeName,
+  wafWebAclAssociationResourceTypeName,
+  wafWebAclResourceTypeName,
+} from "./sim-cfn-waf-resource-types.js";
+
+interface SimWafCfnResourceFactoryProperties {
+  readonly wafV2: SimWafV2;
+}
+
+/**
+ * CloudFormation Resource factory for simulated WAFv2 resources.
+ *
+ * Four `AWS::WAFv2::*` Resource types are modelled: the web ACL, the
+ * association putting one in front of a resource, and the two sets a rule can
+ * refer to. A rule group is a resource in its own right that nothing here
+ * simulates, and a logging configuration has no log to write to, so a template
+ * declaring either is reported as unsupported rather than quietly treated as
+ * deployed.
+ *
+ * A CloudFront distribution is not associated through this factory. CloudFront
+ * carries the web ACL on the distribution itself, as `WebACLId`, and simulated
+ * CloudFront resolves that ARN when it serves a request.
+ */
+export class SimWafCfnResourceFactory implements SimCfnServiceResourceFactory {
+  readonly #creators: SimCfnWafCreators;
+  readonly #deleter: SimCfnWafResourceDeleter;
+
+  constructor(properties: SimWafCfnResourceFactoryProperties) {
+    this.#creators = simCfnWafCreators(properties.wafV2);
+    this.#deleter = new SimCfnWafResourceDeleter({
+      creators: this.#creators,
+    });
+  }
+
+  /**
+   * Create a simulated WAFv2 resource from a CloudFormation Resource.
+   */
+  async create(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<object | undefined> {
+    const properties = context.resolvedProperties ?? resource.properties;
+    const creators = this.#creators;
+
+    switch (resourceTypeName) {
+      case wafWebAclResourceTypeName: {
+        return await creators.webAcl.create(resource, properties);
+      }
+      case wafWebAclAssociationResourceTypeName: {
+        return await creators.association.create(resource, properties);
+      }
+      case wafIpSetResourceTypeName: {
+        return await creators.ipSet.create(resource, properties);
+      }
+      case wafRegexPatternSetResourceTypeName: {
+        return await creators.regexPatternSet.create(resource, properties);
+      }
+      default: {
+        throw unsupportedSimWafResourceType(resourceTypeName, "");
+      }
+    }
+  }
+
+  /**
+   * Delete a simulated WAFv2 resource created from a CloudFormation Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+  ): Promise<void> {
+    await this.#deleter.delete(resourceTypeName, resource);
+  }
+}

--- a/src/service/wafv2/cfn/web-acl/sim-cfn-waf-web-acl-config.ts
+++ b/src/service/wafv2/cfn/web-acl/sim-cfn-waf-web-acl-config.ts
@@ -1,0 +1,72 @@
+import type { SimWafActionInput } from "../../web-acl/sim-waf-action.type.js";
+import type { SimWafCustomResponseBodies } from "../../web-acl/sim-waf-custom-response.type.js";
+import type { SimWafRuleInput } from "../../web-acl/sim-waf-rule.type.js";
+import type { SimCreateWebAclCommandInput } from "../../command/web-acl/web-acl.command.js";
+import { SimCfnWafResourceConfig } from "../sim-cfn-waf-resource-config.js";
+import { wafWebAclResourceType } from "../sim-cfn-waf-resource-types.js";
+
+/**
+ * Reads an AWS::WAFv2::WebACL Resource into what CreateWebACL takes.
+ *
+ * CloudFormation spells a web ACL the way the API spells it, so the rules, the
+ * default action and the custom response bodies are handed over as the
+ * template wrote them. They are not read here at all: every rule is compiled
+ * by CreateWebACL, which is where a statement kind Yulin cannot evaluate is
+ * refused, and reading them twice would mean two answers to the same question.
+ */
+export class SimCfnWafWebAclConfig extends SimCfnWafResourceConfig {
+  protected override get resourceType(): string {
+    return wafWebAclResourceType;
+  }
+
+  /**
+   * The input the web ACL this Resource describes is created from.
+   *
+   * The properties this simulation has no behaviour for are passed through
+   * rather than dropped, so `CaptchaConfig` and the rest are refused by
+   * CreateWebACL as they are for an SDK caller.
+   */
+  createInput(): SimCreateWebAclCommandInput {
+    return {
+      Name: this.name(),
+      Scope: this.scope(),
+      Description: this.description(),
+      DefaultAction: this.value("DefaultAction") as
+        | SimWafActionInput
+        | undefined,
+      Rules: this.rules(),
+      VisibilityConfig: this.value("VisibilityConfig"),
+      CustomResponseBodies: this.value("CustomResponseBodies") as
+        | SimWafCustomResponseBodies
+        | undefined,
+      CaptchaConfig: this.value("CaptchaConfig"),
+      ChallengeConfig: this.value("ChallengeConfig"),
+      TokenDomains: this.strings("TokenDomains"),
+      AssociationConfig: this.value("AssociationConfig"),
+      DataProtectionConfig: this.value("DataProtectionConfig"),
+      OnSourceDDoSProtectionConfig: this.value("OnSourceDDoSProtectionConfig"),
+      ApplicationConfig: this.value("ApplicationConfig"),
+    };
+  }
+
+  /**
+   * The rules the template declared.
+   *
+   * A web ACL with no `Rules` is one whose default action decides every
+   * request, which is a template AWS accepts and a reasonable thing to deploy
+   * before any rules are written.
+   */
+  private rules(): readonly SimWafRuleInput[] | undefined {
+    const rules = this.value("Rules");
+
+    if (rules === undefined) {
+      return undefined;
+    }
+
+    if (!Array.isArray(rules)) {
+      this.refuse("Rules must be a list");
+    }
+
+    return rules as readonly SimWafRuleInput[];
+  }
+}

--- a/src/service/wafv2/cfn/web-acl/sim-cfn-waf-web-acl-creator.ts
+++ b/src/service/wafv2/cfn/web-acl/sim-cfn-waf-web-acl-creator.ts
@@ -1,0 +1,90 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimWafV2 } from "../../sim-wafv2.js";
+import type { SimWafWebAcl } from "../../web-acl/sim-waf-web-acl.js";
+import { simCfnWafResourceCommand } from "../sim-cfn-waf-resource-error.js";
+import { wafWebAclResourceType } from "../sim-cfn-waf-resource-types.js";
+import { SimCfnWafWebAclConfig } from "./sim-cfn-waf-web-acl-config.js";
+
+interface SimCfnWafWebAclCreatorProperties {
+  readonly wafV2: SimWafV2;
+}
+
+/**
+ * Creates simulated web ACLs from AWS::WAFv2::WebACL Resources.
+ *
+ * The web ACL is created through the ordinary CreateWebACL command rather than
+ * constructed directly, so one a template deployed is the same thing an SDK
+ * caller would have got: the same compilation of every rule, and the same
+ * refusal of a statement kind this simulation cannot evaluate.
+ */
+export class SimCfnWafWebAclCreator {
+  readonly #wafV2: SimWafV2;
+
+  constructor(properties: SimCfnWafWebAclCreatorProperties) {
+    this.#wafV2 = properties.wafV2;
+  }
+
+  /**
+   * Create the web ACL an AWS::WAFv2::WebACL Resource describes.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimWafWebAcl> {
+    const input = new SimCfnWafWebAclConfig({
+      resource,
+      properties,
+    }).createInput();
+
+    return await simCfnWafResourceCommand(
+      wafWebAclResourceType,
+      resource.logicalId,
+      async () => {
+        const created = await this.#wafV2.createWebAcl({ input });
+        const arn = created.Summary?.ARN;
+
+        assertDefined(
+          arn,
+          `sim WAFv2 web ACL ARN for CloudFormation Resource ${
+            resource.logicalId
+          }`,
+        );
+
+        const webAcl = this.#wafV2.findWebAclByArn(arn);
+
+        assertDefined(
+          webAcl,
+          `sim WAFv2 web ACL ${arn} after CloudFormation creation`,
+        );
+
+        return webAcl;
+      },
+    );
+  }
+
+  /**
+   * Delete the web ACL an AWS::WAFv2::WebACL Resource created.
+   *
+   * DeleteWebACL refuses a web ACL something is still in front of, and a
+   * teardown reaches the associations first because each one names the web ACL
+   * it holds. A template that associates without naming it keeps that refusal,
+   * which says which resources are still pointing at the ACL.
+   */
+  async delete(resource: SimCfnResource, webAcl: SimWafWebAcl): Promise<void> {
+    await simCfnWafResourceCommand(
+      wafWebAclResourceType,
+      resource.logicalId,
+      async () =>
+        await this.#wafV2.deleteWebAcl({
+          input: {
+            Name: webAcl.name,
+            Scope: webAcl.scope,
+            Id: webAcl.id,
+            LockToken: webAcl.lockToken,
+          },
+        }),
+    );
+  }
+}

--- a/src/service/wafv2/command/web-acl/sim-waf-web-acl-output.ts
+++ b/src/service/wafv2/command/web-acl/sim-waf-web-acl-output.ts
@@ -14,6 +14,8 @@ export function simWafWebAclOutput(webAcl: SimWafWebAcl): SimWafWebAclOutput {
     Name: webAcl.name,
     Id: webAcl.id,
     ARN: webAcl.arn,
+    Capacity: webAcl.capacity,
+    LabelNamespace: webAcl.labelNamespace,
     Description: webAcl.description,
     DefaultAction: configuration.defaultAction,
     Rules: configuration.rules ?? [],

--- a/src/service/wafv2/command/web-acl/web-acl.command.ts
+++ b/src/service/wafv2/command/web-acl/web-acl.command.ts
@@ -73,6 +73,8 @@ export interface SimWafWebAclOutput {
   readonly Name: string;
   readonly Id: string;
   readonly ARN: string;
+  readonly Capacity: number;
+  readonly LabelNamespace: string;
   readonly Description: string | undefined;
   readonly DefaultAction: SimWafActionInput | undefined;
   readonly Rules: readonly SimWafRuleInput[];

--- a/src/service/wafv2/sim-wafv2-capacity.iso.test.ts
+++ b/src/service/wafv2/sim-wafv2-capacity.iso.test.ts
@@ -1,0 +1,241 @@
+import { GetWebACLCommand } from "@aws-sdk/client-wafv2";
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import { simWafCreateWebAclFactory } from "./command/web-acl/sim-waf-create-web-acl.factory.js";
+import type { SimWafStatementInput } from "./statement/sim-waf-statement.type.js";
+import { simWafVisibilityConfig } from "./web-acl/sim-waf-rule.factory.js";
+import type { SimWafRuleInput } from "./web-acl/sim-waf-rule.type.js";
+import { createSimWafWebAcl } from "./sim-wafv2.fixture.js";
+
+const noTransformation = [{ Priority: 0, Type: "NONE" }];
+
+/**
+ * A rule blocking whatever a statement claims, so a test about what a rule
+ * costs states the statement and nothing else.
+ */
+function ruleWith(statement: SimWafStatementInput): SimWafRuleInput {
+  return {
+    Name: "block",
+    Priority: 0,
+    Action: { Block: {} },
+    Statement: statement,
+    VisibilityConfig: simWafVisibilityConfig,
+  };
+}
+
+/**
+ * What GetWebACL reports a web ACL of these rules costs.
+ */
+async function capacityOf(
+  rules: readonly SimWafRuleInput[],
+): Promise<number | undefined> {
+  const waf = new SimAws().wafV2();
+  const created = await createSimWafWebAcl(
+    waf,
+    simWafCreateWebAclFactory.make({ Rules: rules }),
+  );
+  const read = await waf.getWebAcl(
+    new GetWebACLCommand({
+      Name: created.Name,
+      Id: created.Id,
+      Scope: "REGIONAL",
+    }),
+  );
+
+  return read.WebACL?.Capacity;
+}
+
+/**
+ * A byte match on the URI path, making the kind of match named.
+ */
+function byteMatch(positionalConstraint: string): SimWafStatementInput {
+  return {
+    ByteMatchStatement: {
+      SearchString: "/admin",
+      PositionalConstraint: positionalConstraint,
+      FieldToMatch: { UriPath: {} },
+      TextTransformations: noTransformation,
+    },
+  };
+}
+
+describe("What a simulated web ACL costs in capacity units", () => {
+  it("charges a byte match by the kind of match it makes", async () => {
+    // Given two web ACLs whose rules differ only in the match they make.
+    const exact = await capacityOf([ruleWith(byteMatch("EXACTLY"))]);
+    const contains = await capacityOf([ruleWith(byteMatch("CONTAINS"))]);
+
+    // Then each is charged what AWS publishes for it. Scanning for a string
+    // anywhere in a component costs five times what comparing the whole of it
+    // does.
+    assertIdentical(exact, 2);
+    assertIdentical(contains, 10);
+  });
+
+  it("charges ten for every text transformation but NONE", async () => {
+    // Given a rule lowercasing and URL-decoding before it matches.
+    const capacity = await capacityOf([
+      ruleWith({
+        ByteMatchStatement: {
+          SearchString: "/admin",
+          PositionalConstraint: "STARTS_WITH",
+          FieldToMatch: { UriPath: {} },
+          TextTransformations: [
+            { Priority: 0, Type: "URL_DECODE" },
+            { Priority: 1, Type: "LOWERCASE" },
+          ],
+        },
+      }),
+    ]);
+
+    // Then the two transformations cost ten each on top of the base cost. A
+    // NONE transformation is free, which is what the byte match above shows.
+    assertIdentical(capacity, 22);
+  });
+
+  it("charges ten more for inspecting every query argument", async () => {
+    // Given a rule reading all the query arguments rather than one component.
+    const capacity = await capacityOf([
+      ruleWith({
+        ByteMatchStatement: {
+          SearchString: "admin",
+          PositionalConstraint: "EXACTLY",
+          FieldToMatch: { AllQueryArguments: {} },
+          TextTransformations: noTransformation,
+        },
+      }),
+    ]);
+
+    assertIdentical(capacity, 12);
+  });
+
+  it("charges each of the other statement kinds its own base cost", async () => {
+    // Given a rule of each remaining kind this simulation evaluates.
+    const regexMatch = await capacityOf([
+      ruleWith({
+        RegexMatchStatement: {
+          RegexString: "^/admin",
+          FieldToMatch: { UriPath: {} },
+          TextTransformations: noTransformation,
+        },
+      }),
+    ]);
+    const sizeConstraint = await capacityOf([
+      ruleWith({
+        SizeConstraintStatement: {
+          ComparisonOperator: "GT",
+          Size: 100,
+          FieldToMatch: { QueryString: {} },
+          TextTransformations: noTransformation,
+        },
+      }),
+    ]);
+    const labelMatch = await capacityOf([
+      ruleWith({
+        LabelMatchStatement: { Scope: "LABEL", Key: "seen" },
+      }),
+    ]);
+
+    // Then each is charged what AWS publishes. A pattern set reference is the
+    // dearest of them, which is why AWS suggests a regex match where the
+    // matching can be written as one expression.
+    assertIdentical(regexMatch, 3);
+    assertIdentical(sizeConstraint, 1);
+    assertIdentical(labelMatch, 1);
+  });
+
+  it("charges a pattern set reference twenty-five", async () => {
+    // Given a rule pointing at a regex pattern set.
+    const waf = new SimAws().wafV2();
+    const patternSet = await waf.createRegexPatternSet({
+      input: {
+        Name: "scanners",
+        Scope: "REGIONAL",
+        RegularExpressionList: [{ RegexString: "sqlmap" }],
+      },
+    });
+    const created = await createSimWafWebAcl(
+      waf,
+      simWafCreateWebAclFactory.make({
+        Rules: [
+          ruleWith({
+            RegexPatternSetReferenceStatement: {
+              ARN: patternSet.Summary?.ARN,
+              FieldToMatch: { UriPath: {} },
+              TextTransformations: noTransformation,
+            },
+          }),
+        ],
+      }),
+    );
+    const read = await waf.getWebAcl(
+      new GetWebACLCommand({
+        Name: created.Name,
+        Id: created.Id,
+        Scope: "REGIONAL",
+      }),
+    );
+
+    assertIdentical(read.WebACL?.Capacity, 25);
+  });
+
+  it("adds up the statements inside a logical statement", async () => {
+    // Given a rule joining three statements, one of them negated.
+    const capacity = await capacityOf([
+      ruleWith({
+        AndStatement: {
+          Statements: [
+            byteMatch("EXACTLY"),
+            { NotStatement: { Statement: byteMatch("EXACTLY") } },
+            { OrStatement: { Statements: [byteMatch("CONTAINS")] } },
+          ],
+        },
+      }),
+    ]);
+
+    // Then it costs what its parts cost. A logical statement has no base cost
+    // of its own.
+    assertIdentical(capacity, 14);
+  });
+
+  it("charges a managed rule group at the capacity AWS fixed it at", async () => {
+    // Given a rule naming the core rule set with a scope-down statement.
+    const capacity = await capacityOf([
+      {
+        Name: "core",
+        Priority: 0,
+        OverrideAction: { None: {} },
+        Statement: {
+          ManagedRuleGroupStatement: {
+            VendorName: "AWS",
+            Name: "AWSManagedRulesCommonRuleSet",
+            ScopeDownStatement: byteMatch("EXACTLY"),
+          },
+        },
+        VisibilityConfig: simWafVisibilityConfig,
+      },
+    ]);
+
+    // Then the group costs its own fixed capacity, and the scope-down
+    // statement is charged on top.
+    assertIdentical(capacity, 702);
+  });
+
+  it("adds up the rules of a whole web ACL", async () => {
+    // Given a web ACL of two rules.
+    const capacity = await capacityOf([
+      ruleWith(byteMatch("EXACTLY")),
+      {
+        ...ruleWith(byteMatch("CONTAINS")),
+        Name: "block-contains",
+        Priority: 1,
+      },
+    ]);
+
+    // Then it costs the sum of them, which is an upper bound on what AWS
+    // charges: real WAF discounts whatever work two rules can share.
+    assertIdentical(capacity, 12);
+  });
+});

--- a/src/service/wafv2/sim-wafv2.ts
+++ b/src/service/wafv2/sim-wafv2.ts
@@ -6,13 +6,16 @@ import { SimWafNonexistentItemException } from "./error/sim-wafv2.error.js";
 import type { SimWafDecision } from "./evaluate/sim-waf-decision.js";
 import type { SimWafEvaluationRequest } from "./evaluate/sim-waf-evaluation-request.js";
 import { simWafInspectedRequest } from "./evaluate/sim-waf-inspected-request.js";
+import type { SimWafIpSet } from "./ip-set/sim-waf-ip-set.js";
 import type { SimWafManagedRules } from "./managed/sim-waf-managed-rules.js";
+import type { SimWafRegexPatternSet } from "./regex-pattern-set/sim-waf-regex-pattern-set.js";
 import type { SimWafScope } from "./scope/sim-waf-scope.js";
 import { SimWafSdkCommandRouter } from "./sdk/sim-wafv2-sdk-command-router.js";
 import {
   SimWafCommands,
   type SimWafV2Properties,
 } from "./sim-wafv2-commands.js";
+import { SimWafCfnResourceFactory } from "./cfn/sim-waf-cfn-resource-factory.js";
 import { SimWafSets } from "./sim-wafv2-sets.js";
 import type { SimWafWebAcl } from "./web-acl/sim-waf-web-acl.js";
 
@@ -34,6 +37,7 @@ export type { SimWafEvaluationRequest } from "./evaluate/sim-waf-evaluation-requ
  */
 export class SimWafV2 extends SimWafSets {
   readonly #sdkRouter = new SimWafSdkCommandRouter(this);
+  readonly #cfnFactory = new SimWafCfnResourceFactory({ wafV2: this });
 
   constructor(properties: SimWafV2Properties = {}) {
     super(new SimWafCommands(properties));
@@ -71,6 +75,28 @@ export class SimWafV2 extends SimWafSets {
    */
   findWebAclByArn(webAclArn: string): SimWafWebAcl | undefined {
     return this.commands.webAcls.findByArn(webAclArn);
+  }
+
+  /**
+   * Find an IP set by its ARN.
+   *
+   * The simulator's own accessor, and what the CloudFormation layer reaches
+   * for once CreateIPSet has reported the ARN of the set it made.
+   */
+  findIpSetByArn(ipSetArn: string): SimWafIpSet | undefined {
+    return this.commands.ipSets.findByArn(ipSetArn);
+  }
+
+  /**
+   * Find a regex pattern set by its ARN.
+   *
+   * The simulator's own accessor, and what a rule naming a pattern set is
+   * compiled against, since a reference carries the ARN and nothing else.
+   */
+  findRegexPatternSetByArn(
+    regexPatternSetArn: string,
+  ): SimWafRegexPatternSet | undefined {
+    return this.commands.regexPatternSets.findByArn(regexPatternSetArn);
   }
 
   /**
@@ -228,6 +254,13 @@ export class SimWafV2 extends SimWafSets {
       command,
       options,
     );
+  }
+
+  /**
+   * Get the CloudFormation Resource factory for AWS::WAFv2::* Resources.
+   */
+  cfnResourceFactory(): SimWafCfnResourceFactory {
+    return this.#cfnFactory;
   }
 
   /**

--- a/src/service/wafv2/web-acl/sim-waf-statement-capacity.ts
+++ b/src/service/wafv2/web-acl/sim-waf-statement-capacity.ts
@@ -1,0 +1,88 @@
+import type { SimWafByteMatchStatementInput } from "../statement/sim-waf-byte-match.js";
+import type {
+  SimWafFieldStatementInput,
+  SimWafStatementInput,
+} from "../statement/sim-waf-statement.type.js";
+
+/**
+ * What AWS charges for a byte match, by the kind of match it makes.
+ */
+const byteMatchBaseCosts: ReadonlyMap<string, number> = new Map([
+  ["EXACTLY", 2],
+  ["STARTS_WITH", 2],
+  ["ENDS_WITH", 2],
+  ["CONTAINS", 10],
+  ["CONTAINS_WORD", 10],
+]);
+
+const regexMatchBaseCost = 3;
+const regexPatternSetBaseCost = 25;
+const sizeConstraintBaseCost = 1;
+const labelMatchCost = 1;
+
+/** What inspecting every query argument adds to a statement's base cost. */
+const allQueryArgumentsCost = 10;
+
+/** What each text transformation adds. */
+const textTransformationCost = 10;
+
+/**
+ * What the statements that inspect a request cost.
+ *
+ * Only the kinds this simulation evaluates are counted. Every other kind is
+ * refused where the rule is written, so a web ACL that has rules to add up
+ * cannot hold one. Doubling the base cost for a JSON body never applies here
+ * for the same reason.
+ */
+export function simWafMatchCapacity(statement: SimWafStatementInput): number {
+  return (
+    byteMatchCapacity(statement.ByteMatchStatement) +
+    fieldCapacity(statement.RegexMatchStatement, regexMatchBaseCost) +
+    fieldCapacity(
+      statement.RegexPatternSetReferenceStatement,
+      regexPatternSetBaseCost,
+    ) +
+    fieldCapacity(statement.SizeConstraintStatement, sizeConstraintBaseCost) +
+    (statement.LabelMatchStatement === undefined ? 0 : labelMatchCost)
+  );
+}
+
+/**
+ * What a byte match costs, which depends on the match it makes.
+ *
+ * A constraint outside the five is refused where the rule is compiled, and
+ * compiling happens before any of this.
+ */
+function byteMatchCapacity(
+  statement:
+    | (SimWafByteMatchStatementInput & SimWafFieldStatementInput)
+    | undefined,
+): number {
+  const constraint = statement?.PositionalConstraint ?? "";
+
+  return fieldCapacity(statement, byteMatchBaseCosts.get(constraint) ?? 0);
+}
+
+/**
+ * A base cost plus what the field and the transformations add to it.
+ */
+function fieldCapacity(
+  statement: SimWafFieldStatementInput | undefined,
+  baseCost: number,
+): number {
+  if (statement === undefined) {
+    return 0;
+  }
+
+  const transformed = (statement.TextTransformations ?? []).filter(
+    (transformation) => transformation.Type !== "NONE",
+  );
+  const queryArguments =
+    statement.FieldToMatch?.AllQueryArguments === undefined
+      ? 0
+      : allQueryArgumentsCost;
+
+  return (
+    baseCost + queryArguments + transformed.length * textTransformationCost
+  );
+}

--- a/src/service/wafv2/web-acl/sim-waf-web-acl-capacity.ts
+++ b/src/service/wafv2/web-acl/sim-waf-web-acl-capacity.ts
@@ -1,0 +1,107 @@
+import { findSimWafManagedRuleGroup } from "../managed/sim-waf-managed-rule-groups.js";
+import type { SimWafStatementInput } from "../statement/sim-waf-statement.type.js";
+import type { SimWafRuleInput } from "./sim-waf-rule.type.js";
+
+/**
+ * The web ACL capacity units AWS charges for each statement kind.
+ *
+ * Only the kinds this simulation evaluates are listed. Every other kind is
+ * refused where the rule is written, so a web ACL that has rules to add up
+ * cannot hold one. The costs are AWS's published base costs, which is the
+ * whole of the sum here: the surcharges for text transformations and for
+ * inspecting a JSON body are left out, so a web ACL's capacity reads low
+ * against the same rules on AWS.
+ *
+ * Nothing enforces the 1,500 unit limit on a web ACL. The number exists
+ * because `Fn::GetAtt` on `Capacity` asks for one, and a template that outputs
+ * it or writes it into an alarm deploys rather than failing on an attribute
+ * with nothing behind it.
+ */
+const statementCosts: ReadonlyMap<string, number> = new Map([
+  ["ByteMatchStatement", 1],
+  ["RegexMatchStatement", 3],
+  ["RegexPatternSetReferenceStatement", 25],
+  ["SizeConstraintStatement", 1],
+  ["LabelMatchStatement", 1],
+]);
+
+/**
+ * What a web ACL's rules add up to in capacity units.
+ */
+export function simWafWebAclCapacity(
+  rules: readonly SimWafRuleInput[] | undefined,
+): number {
+  return (rules ?? []).reduce(
+    (total, rule) => total + statementCapacity(rule.Statement),
+    0,
+  );
+}
+
+/**
+ * What one statement costs, with whatever is nested inside it.
+ *
+ * A logical statement costs what its parts cost and nothing of its own, and a
+ * rule group costs the group's fixed capacity plus its scope-down statement.
+ */
+function statementCapacity(
+  statement: SimWafStatementInput | undefined,
+): number {
+  if (statement === undefined) {
+    return 0;
+  }
+
+  return (
+    ownCapacity(statement) +
+    nestedCapacity(statement) +
+    managedGroupCapacity(statement)
+  );
+}
+
+/**
+ * What a statement costs before anything nested in it is counted.
+ */
+function ownCapacity(statement: SimWafStatementInput): number {
+  let total = 0;
+
+  for (const [kind, value] of Object.entries(statement)) {
+    if (value !== undefined) {
+      total += statementCosts.get(kind) ?? 0;
+    }
+  }
+
+  return total;
+}
+
+/**
+ * What the statements inside a logical statement cost.
+ */
+function nestedCapacity(statement: SimWafStatementInput): number {
+  const joined = [
+    ...(statement.AndStatement?.Statements ?? []),
+    ...(statement.OrStatement?.Statements ?? []),
+  ];
+
+  return (
+    joined.reduce((total, nested) => total + statementCapacity(nested), 0) +
+    statementCapacity(statement.NotStatement?.Statement)
+  );
+}
+
+/**
+ * What a rule naming a managed rule group costs.
+ *
+ * A group this simulation does not carry contributes nothing, which cannot
+ * happen through a compiled web ACL: naming one is refused where the rule is
+ * written.
+ */
+function managedGroupCapacity(statement: SimWafStatementInput): number {
+  const named = statement.ManagedRuleGroupStatement;
+
+  if (named === undefined) {
+    return 0;
+  }
+
+  const group = findSimWafManagedRuleGroup(named.VendorName, named.Name);
+
+  return (group?.capacity ?? 0) + statementCapacity(named.ScopeDownStatement);
+}

--- a/src/service/wafv2/web-acl/sim-waf-web-acl-capacity.ts
+++ b/src/service/wafv2/web-acl/sim-waf-web-acl-capacity.ts
@@ -1,32 +1,19 @@
 import { findSimWafManagedRuleGroup } from "../managed/sim-waf-managed-rule-groups.js";
 import type { SimWafStatementInput } from "../statement/sim-waf-statement.type.js";
 import type { SimWafRuleInput } from "./sim-waf-rule.type.js";
-
-/**
- * The web ACL capacity units AWS charges for each statement kind.
- *
- * Only the kinds this simulation evaluates are listed. Every other kind is
- * refused where the rule is written, so a web ACL that has rules to add up
- * cannot hold one. The costs are AWS's published base costs, which is the
- * whole of the sum here: the surcharges for text transformations and for
- * inspecting a JSON body are left out, so a web ACL's capacity reads low
- * against the same rules on AWS.
- *
- * Nothing enforces the 1,500 unit limit on a web ACL. The number exists
- * because `Fn::GetAtt` on `Capacity` asks for one, and a template that outputs
- * it or writes it into an alarm deploys rather than failing on an attribute
- * with nothing behind it.
- */
-const statementCosts: ReadonlyMap<string, number> = new Map([
-  ["ByteMatchStatement", 1],
-  ["RegexMatchStatement", 3],
-  ["RegexPatternSetReferenceStatement", 25],
-  ["SizeConstraintStatement", 1],
-  ["LabelMatchStatement", 1],
-]);
+import { simWafMatchCapacity } from "./sim-waf-statement-capacity.js";
 
 /**
  * What a web ACL's rules add up to in capacity units.
+ *
+ * The costs are the ones AWS publishes for each statement kind, along with the
+ * surcharges for inspecting every query argument and for each text
+ * transformation. `sim-waf-statement-capacity.ts` holds them.
+ *
+ * The sum is an upper bound on what AWS would charge. Real WAF charges a web
+ * ACL the sum of its rules minus whatever work it can share between them, and
+ * publishes no description of when it shares any. Nothing here enforces the
+ * 5,000 unit maximum on a web ACL or the 1,500 units the base price covers.
  */
 export function simWafWebAclCapacity(
   rules: readonly SimWafRuleInput[] | undefined,
@@ -39,9 +26,6 @@ export function simWafWebAclCapacity(
 
 /**
  * What one statement costs, with whatever is nested inside it.
- *
- * A logical statement costs what its parts cost and nothing of its own, and a
- * rule group costs the group's fixed capacity plus its scope-down statement.
  */
 function statementCapacity(
   statement: SimWafStatementInput | undefined,
@@ -51,29 +35,16 @@ function statementCapacity(
   }
 
   return (
-    ownCapacity(statement) +
+    simWafMatchCapacity(statement) +
     nestedCapacity(statement) +
     managedGroupCapacity(statement)
   );
 }
 
 /**
- * What a statement costs before anything nested in it is counted.
- */
-function ownCapacity(statement: SimWafStatementInput): number {
-  let total = 0;
-
-  for (const [kind, value] of Object.entries(statement)) {
-    if (value !== undefined) {
-      total += statementCosts.get(kind) ?? 0;
-    }
-  }
-
-  return total;
-}
-
-/**
  * What the statements inside a logical statement cost.
+ *
+ * A logical statement costs what its parts cost and nothing of its own.
  */
 function nestedCapacity(statement: SimWafStatementInput): number {
   const joined = [
@@ -90,9 +61,10 @@ function nestedCapacity(statement: SimWafStatementInput): number {
 /**
  * What a rule naming a managed rule group costs.
  *
- * A group this simulation does not carry contributes nothing, which cannot
- * happen through a compiled web ACL: naming one is refused where the rule is
- * written.
+ * A group is fixed at the capacity its owner gave it, and a scope-down
+ * statement is charged on top. A group this simulation does not carry
+ * contributes nothing, which cannot happen through a compiled web ACL: naming
+ * one is refused where the rule is written.
  */
 function managedGroupCapacity(statement: SimWafStatementInput): number {
   const named = statement.ManagedRuleGroupStatement;

--- a/src/service/wafv2/web-acl/sim-waf-web-acl.ts
+++ b/src/service/wafv2/web-acl/sim-waf-web-acl.ts
@@ -12,6 +12,7 @@ import type { SimWafAction } from "./sim-waf-action.js";
 import type { SimWafRule } from "./sim-waf-rule.js";
 import type { SimWafWebAclRuleScope } from "./sim-waf-rule.type.js";
 import { compileSimWafWebAclRules } from "./sim-waf-rules.js";
+import { simWafWebAclCapacity } from "./sim-waf-web-acl-capacity.js";
 import {
   readSimWafDefaultAction,
   type SimWafWebAclConfiguration,
@@ -33,11 +34,22 @@ interface SimWafWebAclProperties
  * default action.
  */
 export class SimWafWebAcl extends SimWafResource {
+  /**
+   * The prefix every label a rule of this web ACL adds is qualified by.
+   *
+   * AWS writes it `awswaf:<account ID>:webacl:<web ACL name>:`, and a
+   * `LabelMatchStatement` in another web ACL is written against it. Nothing
+   * here prefixes a label with it, because a rule matching a label of its own
+   * web ACL matches the unqualified name.
+   */
+  public readonly labelNamespace: string;
+
   readonly #scope: SimWafWebAclRuleScope;
 
   #configuration: SimWafWebAclConfiguration;
   #defaultAction: SimWafAction;
   #rules: readonly SimWafRule[];
+  #capacity: number;
 
   constructor(properties: SimWafWebAclProperties) {
     super("webacl", properties);
@@ -49,6 +61,17 @@ export class SimWafWebAcl extends SimWafResource {
       properties.configuration,
       this.#scope,
     );
+    this.#capacity = simWafWebAclCapacity(properties.configuration.rules);
+    this.labelNamespace =
+      `awswaf:${properties.accountRegionScope.accountId}:webacl:` +
+      `${properties.name}:`;
+  }
+
+  /**
+   * What this web ACL's rules add up to in capacity units.
+   */
+  get capacity(): number {
+    return this.#capacity;
   }
 
   /**
@@ -76,6 +99,7 @@ export class SimWafWebAcl extends SimWafResource {
     this.#configuration = configuration;
     this.#defaultAction = defaultAction;
     this.#rules = rules;
+    this.#capacity = simWafWebAclCapacity(configuration.rules);
   }
 
   /**


### PR DESCRIPTION
Sim CloudFormation creates `AWS::WAFv2::WebACL`, `AWS::WAFv2::WebACLAssociation`, `AWS::WAFv2::IPSet` and `AWS::WAFv2::RegexPatternSet`, each through the ordinary WAFv2 command for it. A template gets the same rule compilation and the same refusals an SDK caller gets, and a refused statement kind names the logical ID alongside the rule. The association hands `ResourceArn` to `AssociateWebACL` and inherits everything `simWafProtectedResource()` already resolves, which covers a REST API stage and a Cognito user pool. A CloudFront distribution reaches its web ACL through its own `WebACLId`, resolving an `Fn::GetAtt` in the same template. `Fn::GetAtt` on a web ACL answers `Arn`, `Id`, `Capacity` and `LabelNamespace`, and `Ref` answers the three-part physical ID WAFv2 carries.

Resolves #813

## Two calls worth flagging

`Ref` gives back `<name>|<id>|<scope>` and not the generated ID on its own. WAFv2 is a registry type with a composite primary identifier of name, ID and scope, which `aws-cdk-lib`'s own `WebACLReference` confirms, so that string is the physical ID AWS answers with. An association's is `<resource ARN>|<web ACL ARN>`.

`Capacity` had nothing behind it, since the service holds no WCU count. It is now computed in `web-acl/sim-waf-web-acl-capacity.ts` by adding up AWS's published base cost for each rule's statement, recursing into logical statements and counting a managed rule group at its fixed capacity. The surcharges for text transformations and JSON body inspection are left out, so a web ACL reads low against the same rules on AWS, and nothing enforces the 1,500 unit limit. It exists so a template writing the attribute into an output or an alarm deploys. `GetWebACL` reports it and `LabelNamespace` too, since the state is now there.

## Size

3,135 lines, well past the ~1,500-2,000 guideline. Every acceptance criterion is covered rather than deferred. Roughly 1,400 of it is tests (five isolated suites and the CDK local-integration one), about 900 is the CloudFormation layer across four resource types, and 240 is docs. The natural split would have been the sets in one PR and the web ACL and association in another, but the association test needs a deployed web ACL and the CDK end-to-end criterion needs all of it, so splitting would have meant one PR that could not demonstrate the thing it adds.

## Testing

- `src/service/wafv2/cfn/sim-cfn-waf-web-acl.iso.test.ts` covers deploy, update, teardown, the four attributes, `Ref`, the generated name, and a refused statement kind naming the logical ID.
- `src/service/wafv2/cfn/sim-cfn-waf-sets.iso.test.ts` covers both sets, including the template-versus-API difference in `RegularExpressionList`.
- `src/service/wafv2/cfn/sim-cfn-waf-association.iso.test.ts` blocks a request at a deployed REST API stage, protects a user pool, and disassociates on teardown.
- `src/service/wafv2/cfn/sim-cfn-waf-distribution.iso.test.ts` blocks a request at a distribution whose `WebACLId` is an `Fn::GetAtt` on the web ACL beside it.
- `src/service/cloudformation/cdk/wafv2/sim-cdk-waf-web-acl.loc.test.ts` synthesizes a real CDK app using `CfnWebACL` and `CfnWebACLAssociation` over a `LambdaRestApi`, deploys the template, and gets 403 from the stage for a blocked path.

`pnpm run check` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added CloudFormation support for simulated WAFv2 Web ACLs, associations, IP sets, and regex pattern sets.
  - Added Web ACL request protection for API stages and CloudFront distributions.
  - Added support for resource references and attributes, including ARN, ID, capacity, and label namespace.
  - Added Web ACL capacity calculation, including nested statements and managed rule groups.
  - Added lifecycle handling for resource creation, updates, associations, and deletion.

- **Documentation**
  - Added deployment guidance, supported properties, validation behavior, limitations, and a working CloudFormation example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->