### PR TITLE
feat: walk a simulated S3 Bucket as a folder tree

### DIFF
--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -148,8 +148,8 @@ A HEAD response carries no body, so there is no document for an error code to tr
 ## Listing Objects
 
 Use `ListObjectsV2Command` to list the Objects in a Bucket. The simulator supports `Prefix`,
-`MaxKeys`, `ContinuationToken` and `StartAfter`, and answers with `Contents`, `KeyCount`,
-`IsTruncated` and `NextContinuationToken`.
+`Delimiter`, `MaxKeys`, `ContinuationToken` and `StartAfter`, and answers with `Contents`,
+`CommonPrefixes`, `KeyCount`, `IsTruncated` and `NextContinuationToken`.
 
 ```typescript sim-s3-list-objects-v2
 /**
@@ -296,6 +296,66 @@ const firstPage = await simS3.listObjectsV2(
 
 console.log(firstPage.IsTruncated, firstPage.KeyCount);
 ```
+
+### Walking a Bucket as a folder tree
+
+S3 stores keys flat and a `Delimiter` is what makes one look like a folder tree. Every key holding
+the delimiter somewhere after the `Prefix` is rolled up into a common prefix, running from the start
+of the key through the first delimiter. Those keys leave `Contents`, and the prefix appears once in
+`CommonPrefixes` however many keys sit beneath it.
+
+```typescript sim-s3-list-objects-v2-delimiter
+/**
+ * Walking a simulated S3 Bucket one folder at a time.
+ */
+
+import {
+  CreateBucketCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simS3 = simAws.s3();
+
+await simS3.createBucket(new CreateBucketCommand({ Bucket: "site-assets" }));
+
+for (const key of ["img/logo.png", "img/icons/tick.png", "index.html"]) {
+  await simS3.putObject(
+    new PutObjectCommand({ Bucket: "site-assets", Key: key, Body: key }),
+  );
+}
+
+const top = await simS3.listObjectsV2(
+  new ListObjectsV2Command({ Bucket: "site-assets", Delimiter: "/" }),
+);
+
+// One folder, and the one key that sits beside it.
+console.log(top.CommonPrefixes?.map((folder) => folder.Prefix)); // ["img/"]
+console.log(top.Contents?.map((object) => object.Key)); // ["index.html"]
+
+const folder = await simS3.listObjectsV2(
+  new ListObjectsV2Command({
+    Bucket: "site-assets",
+    Prefix: "img/",
+    Delimiter: "/",
+  }),
+);
+
+// A delimiter inside the Prefix is stepped over, so this lists what is
+// directly in `img/` rather than rolling the whole Bucket back up.
+console.log(folder.CommonPrefixes?.map((child) => child.Prefix)); // ["img/icons/"]
+console.log(folder.Contents?.map((object) => object.Key)); // ["img/logo.png"]
+```
+
+A listing that rolled nothing up has no `CommonPrefixes` at all, the way one that found no keys has
+no `Contents`. Reach for `CommonPrefixes ?? []`.
+
+A common prefix counts against `MaxKeys` as a key does, and `KeyCount` counts the two together. Keys
+and prefixes are ordered together, so a truncated page can end on either, and the continuation steps
+over the whole rolled-up prefix rather than listing its keys again. `aws s3 ls s3://bucket/` against
+[a simulation served on localhost](#serve-simulated-s3-on-localhost) prints these as `PRE` lines.
 
 ### The first version of the operation
 
@@ -2584,6 +2644,8 @@ Sim S3 currently supports:
 - `CreateBucketCommand` and `ListBucketsCommand`
 - `PutObjectCommand`, `GetObjectCommand`, `ListObjectsV2Command` and `ListObjectsCommand`, with an
   ETag and a last-modified time on every Object
+- `Delimiter` on a listing, rolling keys up into `CommonPrefixes` so a Bucket can be walked as a
+  folder tree, over the SDK and over a served endpoint
 - `CreateMultipartUploadCommand`, `UploadPartCommand`, `CompleteMultipartUploadCommand`,
   `AbortMultipartUploadCommand`, `ListMultipartUploadsCommand` and `ListPartsCommand`, so `aws s3 cp`
   and `@aws-sdk/lib-storage` can upload a file of real size
@@ -2626,8 +2688,7 @@ These apply across the page. The sections above each list what is specific to th
   any request or response.
 - A listing reports `StorageClass` as `STANDARD` for every Object. Storage classes themselves are
   left out, and every Object is in that one.
-- `Delimiter` and `CommonPrefixes` are left out, and a listing cannot be walked as a folder tree.
-  `EncodingType` is ignored, and keys come back unencoded.
+- `EncodingType` is ignored on a listing, and keys come back unencoded.
 - Object tags, ACLs, lifecycle rules, replication and server-side encryption are left out.
 - A Bucket using filesystem-backed storage cannot delete Objects, and raises no event
   notifications, because it swaps the whole storage backend in place of putting Objects.

--- a/docs/services/s3/sim-s3-list-objects-v2-delimiter.example.ts
+++ b/docs/services/s3/sim-s3-list-objects-v2-delimiter.example.ts
@@ -1,0 +1,42 @@
+/**
+ * Walking a simulated S3 Bucket one folder at a time.
+ */
+
+import {
+  CreateBucketCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simS3 = simAws.s3();
+
+await simS3.createBucket(new CreateBucketCommand({ Bucket: "site-assets" }));
+
+for (const key of ["img/logo.png", "img/icons/tick.png", "index.html"]) {
+  await simS3.putObject(
+    new PutObjectCommand({ Bucket: "site-assets", Key: key, Body: key }),
+  );
+}
+
+const top = await simS3.listObjectsV2(
+  new ListObjectsV2Command({ Bucket: "site-assets", Delimiter: "/" }),
+);
+
+// One folder, and the one key that sits beside it.
+console.log(top.CommonPrefixes?.map((folder) => folder.Prefix)); // ["img/"]
+console.log(top.Contents?.map((object) => object.Key)); // ["index.html"]
+
+const folder = await simS3.listObjectsV2(
+  new ListObjectsV2Command({
+    Bucket: "site-assets",
+    Prefix: "img/",
+    Delimiter: "/",
+  }),
+);
+
+// A delimiter inside the Prefix is stepped over, so this lists what is
+// directly in `img/` rather than rolling the whole Bucket back up.
+console.log(folder.CommonPrefixes?.map((child) => child.Prefix)); // ["img/icons/"]
+console.log(folder.Contents?.map((object) => object.Key)); // ["img/logo.png"]

--- a/src/service/s3/README.md
+++ b/src/service/s3/README.md
@@ -435,9 +435,10 @@ client reading in pieces compares the value across them.
 4. sequences background work
 5. lists objects from storage using optional `Prefix`
 6. sorts objects lexicographically by key
-7. applies marker-based pagination
-8. returns `Contents`, `Name`, `Prefix`, `Marker`, `MaxKeys`, `IsTruncated`,
-   `NextMarker`, and `$metadata`
+7. rolls keys up under an optional `Delimiter`
+8. applies marker-based pagination
+9. returns `Contents`, `CommonPrefixes`, `Name`, `Prefix`, `Delimiter`, `Marker`, `MaxKeys`,
+   `IsTruncated`, `NextMarker`, and `$metadata`
 
 ### ListObjectsV2
 
@@ -447,8 +448,8 @@ in how a caller says where to carry on from and in what the response reports:
 
 1. resumes after the key a `ContinuationToken` stands for, or after `StartAfter` when there is no
    token, since a token in hand means the listing is already under way
-2. returns `Contents`, `Name`, `Prefix`, `MaxKeys`, `KeyCount`, `IsTruncated`, `ContinuationToken`,
-   `NextContinuationToken`, `StartAfter`, and `$metadata`
+2. returns `Contents`, `CommonPrefixes`, `Name`, `Prefix`, `Delimiter`, `MaxKeys`, `KeyCount`,
+   `IsTruncated`, `ContinuationToken`, `NextContinuationToken`, `StartAfter`, and `$metadata`
 
 `list-objects-v2/list-objects-v2-continuation-token.ts` encodes the resume key so a token looks
 opaque, and refuses one that does not decode back to itself rather than listing from somewhere
@@ -460,14 +461,23 @@ arbitrary.
 `object/s3-object-summary.ts` describes each one. Both versions of the operation go through them, so
 they cannot disagree about which keys a page holds or how an Object in one is described.
 
+A `Delimiter` rolls keys up in the same place. `object/s3-object-listing.ts` turns the ordered keys
+into entries, where an entry is either an Object or a common prefix standing in for every key
+beneath it, and pages the entries rather than the keys. That is what makes a common prefix count
+against `MaxKeys` alongside a key, and it puts the two in one order, so a page can end on either.
+Resuming compares against the entry name, which steps a marker over a whole rolled-up prefix instead
+of grouping its keys again. `object/s3-common-prefix.ts` describes them for a response.
+
 `object/s3-object-listing-limits.ts` holds the page size, on the shared `SimS3BucketCommandState` so
 that both versions see the same one. Real S3 fixes it at a thousand keys with no way to change it;
 `SimS3.configureMaxKeysPerPage` exists anyway, because a caller that never continues a listing is a
 caller whose pagination has never run, and provoking one honestly would mean storing a thousand and
 one Objects first.
 
-`MaxKeys` defaults to `1000`. `NextMarker` is set to the last returned key only when the result is
-truncated.
+`MaxKeys` defaults to `1000`. `NextMarker` is set to the last returned entry only when the result is
+truncated. Real S3 sets it only for a listing that carried a `Delimiter`, leaving a caller to use the
+last key otherwise. Sim S3 sets it whenever the listing is truncated. Both answer the same key, and
+a caller that reads `NextMarker` needs no branch for the delimited case.
 
 ### DeleteObject
 

--- a/src/service/s3/command/list-objects-v2/list-objects-v2-delimiter.iso.test.ts
+++ b/src/service/s3/command/list-objects-v2/list-objects-v2-delimiter.iso.test.ts
@@ -1,0 +1,178 @@
+import {
+  CreateBucketCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimS3 } from "../../sim-s3.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+
+/**
+ * A Bucket whose keys read as a folder tree, which is what a Delimiter is for.
+ */
+async function bucketOfFolders(...keys: readonly string[]): Promise<SimS3> {
+  const simS3 = new SimS3();
+
+  await simS3.createBucket(new CreateBucketCommand({ Bucket: "widgets" }));
+  await Promise.all(
+    keys.map(async (key) =>
+      simS3.putObject(
+        new PutObjectCommand({ Bucket: "widgets", Key: key, Body: key }),
+      ),
+    ),
+  );
+
+  return simS3;
+}
+
+function prefixesOf(output: {
+  CommonPrefixes?: { Prefix?: string }[] | undefined;
+}): string {
+  return (output.CommonPrefixes ?? [])
+    .map((commonPrefix) => commonPrefix.Prefix)
+    .join(",");
+}
+
+describe("S3 ListObjectsV2Command with a Delimiter", () => {
+  it("walks the top of a Bucket as a folder tree", async () => {
+    // Given a Bucket holding keys at two levels.
+    const simS3 = await bucketOfFolders(
+      "img/a.png",
+      "img/b.png",
+      "index.html",
+      "js/app.js",
+    );
+
+    // When the Bucket is listed under a slash.
+    const output = await simS3.listObjectsV2(
+      new ListObjectsV2Command({ Bucket: "widgets", Delimiter: "/" }),
+    );
+
+    // Then each folder comes back once, the keys beneath them are left out of
+    // Contents, and the request's own Delimiter is echoed back.
+    assertIdentical(prefixesOf(output), "img/,js/");
+    assertArrayLength(output.Contents, 1);
+    assertIdentical(output.Contents[0].Key, "index.html");
+    assertIdentical(output.Delimiter, "/");
+    assertFalse(output.IsTruncated);
+  });
+
+  it("counts the folders and the keys together in KeyCount", async () => {
+    // Given a Bucket holding two folders and one key.
+    const simS3 = await bucketOfFolders("img/a.png", "index.html", "js/app.js");
+
+    // When the Bucket is listed under a slash.
+    const output = await simS3.listObjectsV2(
+      new ListObjectsV2Command({ Bucket: "widgets", Delimiter: "/" }),
+    );
+
+    // Then KeyCount counts a rolled-up folder as real S3 counts it, alongside
+    // the key, rather than counting Contents alone.
+    assertIdentical(output.KeyCount, 3);
+  });
+
+  it("leaves CommonPrefixes out when a listing rolls nothing up", async () => {
+    // Given a Bucket with no folders in it.
+    const simS3 = await bucketOfFolders("index.html", "robots.txt");
+
+    // When the Bucket is listed under a slash.
+    const output = await simS3.listObjectsV2(
+      new ListObjectsV2Command({ Bucket: "widgets", Delimiter: "/" }),
+    );
+
+    // Then CommonPrefixes is absent rather than empty, which is what a caller
+    // written against AWS guards for.
+    assertUndefined(output.CommonPrefixes);
+    assertIdentical(output.KeyCount, 2);
+  });
+
+  it("lists one folder's contents under a Prefix", async () => {
+    // Given a folder holding a key and a folder of its own.
+    const simS3 = await bucketOfFolders(
+      "img/icons/small.png",
+      "img/logo.png",
+      "index.html",
+    );
+
+    // When that folder is listed.
+    const output = await simS3.listObjectsV2(
+      new ListObjectsV2Command({
+        Bucket: "widgets",
+        Prefix: "img/",
+        Delimiter: "/",
+      }),
+    );
+
+    // Then the delimiter inside the Prefix is stepped over, and only what sits
+    // directly in the folder comes back.
+    assertIdentical(prefixesOf(output), "img/icons/");
+    assertArrayLength(output.Contents, 1);
+    assertIdentical(output.Contents[0].Key, "img/logo.png");
+  });
+
+  it("pages through a mixture of folders and keys in key order", async () => {
+    // Given more entries at the top of the tree than one page holds.
+    const simS3 = await bucketOfFolders(
+      "img/a.png",
+      "img/b.png",
+      "index.html",
+      "js/app.js",
+    );
+
+    // When the Bucket is listed a page at a time.
+    const first = await simS3.listObjectsV2(
+      new ListObjectsV2Command({
+        Bucket: "widgets",
+        Delimiter: "/",
+        MaxKeys: 2,
+      }),
+    );
+
+    assertTrue(first.IsTruncated);
+    assertDefined(first.NextContinuationToken, "the first page's token");
+
+    const second = await simS3.listObjectsV2(
+      new ListObjectsV2Command({
+        Bucket: "widgets",
+        Delimiter: "/",
+        MaxKeys: 2,
+        ContinuationToken: first.NextContinuationToken,
+      }),
+    );
+
+    // Then the pages carry on from each other without repeating the folder the
+    // first one ended before, and without listing the keys under it.
+    assertIdentical(prefixesOf(first), "img/");
+    assertArrayLength(first.Contents, 1);
+    assertIdentical(first.Contents[0].Key, "index.html");
+    assertIdentical(prefixesOf(second), "js/");
+    assertUndefined(second.Contents);
+    assertFalse(second.IsTruncated);
+  });
+
+  it("rolls up under a delimiter that is not a slash", async () => {
+    // Given keys separated by something else.
+    const simS3 = await bucketOfFolders(
+      "2024--q1.csv",
+      "2024--q2.csv",
+      "notes.md",
+    );
+
+    // When the Bucket is listed under that separator.
+    const output = await simS3.listObjectsV2(
+      new ListObjectsV2Command({ Bucket: "widgets", Delimiter: "--" }),
+    );
+
+    // Then the common prefix runs through the whole of it.
+    assertIdentical(prefixesOf(output), "2024--");
+    assertArrayLength(output.Contents, 1);
+    assertIdentical(output.Contents[0].Key, "notes.md");
+  });
+});

--- a/src/service/s3/command/list-objects-v2/list-objects-v2-iam.iso.test.ts
+++ b/src/service/s3/command/list-objects-v2/list-objects-v2-iam.iso.test.ts
@@ -148,4 +148,69 @@ describe("S3 ListObjectsV2Command IAM authorization", () => {
     assertIdentical(error.action, "s3:ListBucket");
     assertIdentical(error.resource, "arn:aws:s3:::v2-restricted-bucket");
   });
+  it("denies a Role a listing that walks past the folder its policy allows", async () => {
+    // Given a Role allowed to list one Bucket a folder at a time, which is the
+    // policy AWS documents for a console user browsing a Bucket.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws();
+    const simIam = simAws.account(accountId).iam();
+    const simS3 = simAws.account(accountId).region("eu-west-1").s3();
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "v2-browsable-bucket" }),
+    );
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "v2-browsable-bucket",
+        Key: "reports/a.json",
+      }),
+    );
+
+    const roleCreation = await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "V2Browser",
+        AssumeRolePolicyDocument: assumeRoleByAccountRoot(accountId),
+      }),
+    );
+    const roleArn = roleCreation.Role.Arn;
+
+    await simIam.putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "V2Browser",
+        PolicyName: "BrowseOnly",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "s3:ListBucket",
+            Resource: "arn:aws:s3:::v2-browsable-bucket",
+            Condition: { StringEquals: { "s3:delimiter": "/" } },
+          },
+        }),
+      }),
+    );
+
+    // When the Role browses one folder, and then lists the Bucket flat.
+    const browsed = await simS3.listObjectsV2(
+      new ListObjectsV2Command({
+        Bucket: "v2-browsable-bucket",
+        Delimiter: "/",
+      }),
+      { caller: { kind: "arn", arn: roleArn } },
+    );
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.listObjectsV2(
+        new ListObjectsV2Command({ Bucket: "v2-browsable-bucket" }),
+        { caller: { kind: "arn", arn: roleArn } },
+      ),
+    );
+
+    // Then the delimiter reaches IAM as its own condition key, which is what
+    // separates browsing a folder from listing every key in the Bucket.
+    assertArrayLength(browsed.CommonPrefixes, 1);
+    assertIdentical(browsed.CommonPrefixes[0].Prefix, "reports/");
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "s3:ListBucket");
+  });
 });

--- a/src/service/s3/command/list-objects-v2/list-objects-v2-page-builder.ts
+++ b/src/service/s3/command/list-objects-v2/list-objects-v2-page-builder.ts
@@ -1,4 +1,5 @@
 import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
+import { simS3CommonPrefixes } from "../../object/s3-common-prefix.js";
 import { simS3ObjectPage } from "../../object/s3-object-listing.js";
 import { simS3ObjectSummaries } from "../../object/s3-object-summary.js";
 import {
@@ -10,6 +11,7 @@ import type { SimListObjectsV2CommandOutput } from "./list-objects-v2.command.js
 interface ListObjectsV2PageInput {
   readonly bucket: SimS3Bucket;
   readonly prefix?: string | undefined;
+  readonly delimiter?: string | undefined;
   readonly continuationToken?: string | undefined;
   readonly startAfter?: string | undefined;
   readonly maxKeys: number;
@@ -37,16 +39,20 @@ export class ListObjectsV2PageBuilder {
   ): Promise<SimListObjectsV2CommandOutput> {
     const page = simS3ObjectPage({
       objects: await input.bucket.listObjects(input.prefix),
+      prefix: input.prefix,
+      delimiter: input.delimiter,
       startAfter: this.resumeAfter(input),
       maxKeys: input.maxKeys,
     });
 
     return {
       Contents: simS3ObjectSummaries(page.objects),
+      CommonPrefixes: simS3CommonPrefixes(page.commonPrefixes),
       Name: input.bucket.bucketName,
       Prefix: input.prefix,
+      Delimiter: input.delimiter,
       MaxKeys: input.maxKeys,
-      KeyCount: page.objects.length,
+      KeyCount: page.objects.length + page.commonPrefixes.length,
       IsTruncated: page.isTruncated,
       ContinuationToken: input.continuationToken,
       NextContinuationToken:

--- a/src/service/s3/command/list-objects-v2/list-objects-v2.command.ts
+++ b/src/service/s3/command/list-objects-v2/list-objects-v2.command.ts
@@ -1,4 +1,5 @@
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimS3CommonPrefix } from "../../object/s3-common-prefix.js";
 import type { SimS3ObjectSummary } from "../../object/s3-object-summary.js";
 
 /**
@@ -12,11 +13,13 @@ export interface SimListObjectsV2Command {
  * Minimal structural sim S3 ListObjectsV2 input.
  *
  * `ContinuationToken` resumes a truncated listing and takes precedence over
- * `StartAfter`, which only positions the first page.
+ * `StartAfter`, which only positions the first page. `Delimiter` rolls every
+ * key holding it after the `Prefix` up into a common prefix.
  */
 export interface SimListObjectsV2CommandInput {
   readonly Bucket?: string | undefined;
   readonly Prefix?: string | undefined;
+  readonly Delimiter?: string | undefined;
   readonly MaxKeys?: number | undefined;
   readonly ContinuationToken?: string | undefined;
   readonly StartAfter?: string | undefined;
@@ -27,12 +30,15 @@ export interface SimListObjectsV2CommandInput {
  *
  * `KeyCount` is what makes this version worth using over the first: it says how
  * many keys came back without the caller having to measure `Contents`, which
- * may be absent rather than empty.
+ * may be absent rather than empty. It counts the common prefixes alongside the
+ * keys, as real S3 counts them.
  */
 export interface SimListObjectsV2CommandOutput {
   readonly Contents?: SimS3ObjectSummary[] | undefined;
+  readonly CommonPrefixes?: SimS3CommonPrefix[] | undefined;
   readonly Name?: string;
   readonly Prefix?: string | undefined;
+  readonly Delimiter?: string | undefined;
   readonly MaxKeys?: number;
   readonly KeyCount?: number;
   readonly IsTruncated?: boolean;

--- a/src/service/s3/command/list-objects-v2/list-objects-v2.handler.ts
+++ b/src/service/s3/command/list-objects-v2/list-objects-v2.handler.ts
@@ -94,6 +94,7 @@ export class ListObjectsV2CommandHandler implements CommandHandler<
     this.authorizer.authorize({
       bucket,
       prefix: command.input.Prefix,
+      delimiter: command.input.Delimiter,
       maxKeys,
       options,
     });
@@ -101,6 +102,7 @@ export class ListObjectsV2CommandHandler implements CommandHandler<
     return await this.pageBuilder.build({
       bucket,
       prefix: command.input.Prefix,
+      delimiter: command.input.Delimiter,
       continuationToken: command.input.ContinuationToken,
       startAfter: command.input.StartAfter,
       maxKeys,

--- a/src/service/s3/command/list-objects/list-objects-authorizer.ts
+++ b/src/service/s3/command/list-objects/list-objects-authorizer.ts
@@ -11,6 +11,7 @@ interface ListObjectsAuthorizerProperties {
 interface ListObjectsAuthorizationInput {
   readonly bucket: SimS3Bucket;
   readonly prefix?: string | undefined;
+  readonly delimiter?: string | undefined;
   readonly maxKeys: number;
   readonly options?: SimS3RequestOptions | undefined;
 }
@@ -22,10 +23,11 @@ interface ListObjectsAuthorizationInput {
  * action. The resource is the Bucket ARN because listing examines a Bucket's
  * key namespace rather than reading any individual Object.
  *
- * Prefix and maximum-result constraints are request attributes used by IAM
- * policies to limit which listings a principal may perform. They are supplied
- * as S3 condition keys so policy evaluation can distinguish, for example, a
- * permitted app prefix from a restricted private prefix.
+ * Prefix, delimiter and maximum-result constraints are request attributes used
+ * by IAM policies to limit which listings a principal may perform. They are
+ * supplied as S3 condition keys so policy evaluation can distinguish, for
+ * example, a permitted app prefix from a restricted private prefix, or a
+ * listing of one folder from a listing of a whole Bucket.
  */
 export class ListObjectsAuthorizer {
   private static readonly action = "s3:ListBucket";
@@ -49,6 +51,7 @@ export class ListObjectsAuthorizer {
       conditionContext: {
         ...simS3ConditionContext(input.options),
         "s3:prefix": input.prefix ?? "",
+        "s3:delimiter": input.delimiter ?? "",
         "s3:max-keys": input.maxKeys,
       },
       resourcePolicies:

--- a/src/service/s3/command/list-objects/list-objects-page-builder.ts
+++ b/src/service/s3/command/list-objects/list-objects-page-builder.ts
@@ -1,4 +1,5 @@
 import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
+import { simS3CommonPrefixes } from "../../object/s3-common-prefix.js";
 import { simS3ObjectPage } from "../../object/s3-object-listing.js";
 import { simS3ObjectSummaries } from "../../object/s3-object-summary.js";
 import type { SimListObjectsCommandOutput } from "./list-objects.command.js";
@@ -6,6 +7,7 @@ import type { SimListObjectsCommandOutput } from "./list-objects.command.js";
 interface ListObjectsPageInput {
   readonly bucket: SimS3Bucket;
   readonly prefix?: string | undefined;
+  readonly delimiter?: string | undefined;
   readonly marker?: string | undefined;
   readonly maxKeys: number;
 }
@@ -21,8 +23,9 @@ interface ListObjectsPageInput {
  * operations differ in how a caller names where to resume rather than in which
  * keys a page holds. The marker is exclusive, so a page begins after it.
  *
- * NextMarker is returned only when another page exists and identifies the final
- * key in the current page.
+ * NextMarker is returned only when another page exists, and identifies the
+ * final entry in the current page. That entry is a common prefix where the
+ * page ended on one, and the marker steps over the whole rolled-up prefix.
  */
 export class ListObjectsPageBuilder {
   /**
@@ -33,14 +36,18 @@ export class ListObjectsPageBuilder {
   ): Promise<SimListObjectsCommandOutput> {
     const page = simS3ObjectPage({
       objects: await input.bucket.listObjects(input.prefix),
+      prefix: input.prefix,
+      delimiter: input.delimiter,
       startAfter: input.marker,
       maxKeys: input.maxKeys,
     });
 
     return {
       Contents: simS3ObjectSummaries(page.objects),
+      CommonPrefixes: simS3CommonPrefixes(page.commonPrefixes),
       Name: input.bucket.bucketName,
       Prefix: input.prefix,
+      Delimiter: input.delimiter,
       Marker: input.marker,
       MaxKeys: input.maxKeys,
       IsTruncated: page.isTruncated,

--- a/src/service/s3/command/list-objects/list-objects.command.ts
+++ b/src/service/s3/command/list-objects/list-objects.command.ts
@@ -1,4 +1,5 @@
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimS3CommonPrefix } from "../../object/s3-common-prefix.js";
 import type { SimS3ObjectSummary } from "../../object/s3-object-summary.js";
 
 export type { SimS3ObjectSummary } from "../../object/s3-object-summary.js";
@@ -12,10 +13,14 @@ export interface SimListObjectsCommand {
 
 /**
  * Minimal structural sim S3 ListObjects input.
+ *
+ * `Delimiter` rolls every key holding it after the `Prefix` up into a common
+ * prefix, which is how a Bucket is walked one folder at a time.
  */
 export interface SimListObjectsCommandInput {
   readonly Bucket?: string | undefined;
   readonly Prefix?: string | undefined;
+  readonly Delimiter?: string | undefined;
   readonly Marker?: string | undefined;
   readonly MaxKeys?: number | undefined;
 }
@@ -25,8 +30,10 @@ export interface SimListObjectsCommandInput {
  */
 export interface SimListObjectsCommandOutput {
   readonly Contents?: SimS3ObjectSummary[] | undefined;
+  readonly CommonPrefixes?: SimS3CommonPrefix[] | undefined;
   readonly Name?: string;
   readonly Prefix?: string | undefined;
+  readonly Delimiter?: string | undefined;
   readonly Marker?: string | undefined;
   readonly MaxKeys?: number;
   readonly IsTruncated?: boolean;

--- a/src/service/s3/command/list-objects/list-objects.handler.ts
+++ b/src/service/s3/command/list-objects/list-objects.handler.ts
@@ -89,6 +89,7 @@ export class ListObjectsCommandHandler implements CommandHandler<
     this.authorizer.authorize({
       bucket,
       prefix: command.input.Prefix,
+      delimiter: command.input.Delimiter,
       maxKeys,
       options,
     });
@@ -96,6 +97,7 @@ export class ListObjectsCommandHandler implements CommandHandler<
     return await this.pageBuilder.build({
       bucket,
       prefix: command.input.Prefix,
+      delimiter: command.input.Delimiter,
       marker: command.input.Marker,
       maxKeys,
     });

--- a/src/service/s3/command/list-objects/list-objects.iso.test.ts
+++ b/src/service/s3/command/list-objects/list-objects.iso.test.ts
@@ -231,3 +231,72 @@ describe("S3 ListObjectsCommand", () => {
     assertStringIncludes(error.message, "No S3 Bucket named bucket-a");
   });
 });
+
+describe("S3 ListObjectsCommand with a Delimiter", () => {
+  async function bucketOfFolders(...keys: readonly string[]): Promise<SimS3> {
+    const simS3 = new SimS3();
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "widgets" }));
+    await Promise.all(
+      keys.map(async (key) =>
+        simS3.putObject(
+          new PutObjectCommand({ Bucket: "widgets", Key: key, Body: key }),
+        ),
+      ),
+    );
+
+    return simS3;
+  }
+
+  it("rolls keys up into CommonPrefixes, as the second version does", async () => {
+    // Given a Bucket holding keys at two levels.
+    const simS3 = await bucketOfFolders("img/a.png", "img/b.png", "index.html");
+
+    // When the top of the tree is listed.
+    const output = await simS3.listObjects(
+      new ListObjectsCommand({ Bucket: "widgets", Delimiter: "/" }),
+    );
+
+    // Then the folder comes back once, its keys are left out of Contents, and
+    // the Delimiter is echoed back.
+    assertArrayLength(output.CommonPrefixes, 1);
+    assertIdentical(output.CommonPrefixes[0].Prefix, "img/");
+    assertArrayLength(output.Contents, 1);
+    assertIdentical(output.Contents[0].Key, "index.html");
+    assertIdentical(output.Delimiter, "/");
+  });
+
+  it("marks the next page with the folder a truncated page ended on", async () => {
+    // Given a page with room for the first folder alone.
+    const simS3 = await bucketOfFolders("img/a.png", "img/b.png", "index.html");
+
+    // When the first page is taken.
+    const first = await simS3.listObjects(
+      new ListObjectsCommand({
+        Bucket: "widgets",
+        Delimiter: "/",
+        MaxKeys: 1,
+      }),
+    );
+
+    // Then the marker names the folder rather than a key inside it, which a
+    // caller has no way to work out from Contents.
+    assertTrue(first.IsTruncated);
+    assertIdentical(first.NextMarker, "img/");
+
+    // When the listing carries on from that marker.
+    const second = await simS3.listObjects(
+      new ListObjectsCommand({
+        Bucket: "widgets",
+        Delimiter: "/",
+        Marker: first.NextMarker,
+      }),
+    );
+
+    // Then the whole folder is behind the listing rather than rolled up again.
+    assertUndefined(second.CommonPrefixes);
+    assertArrayLength(second.Contents, 1);
+    assertIdentical(second.Contents[0].Key, "index.html");
+    assertFalse(second.IsTruncated);
+  });
+});

--- a/src/service/s3/object/s3-common-prefix.ts
+++ b/src/service/s3/object/s3-common-prefix.ts
@@ -1,0 +1,28 @@
+/**
+ * One folder of a Bucket, as a listing under a delimiter describes it.
+ *
+ * Both list operations answer with these. A common prefix stands in for every
+ * key beneath it, and carries no size, entity tag or timestamp of its own,
+ * because S3 stores no such folder.
+ */
+export interface SimS3CommonPrefix {
+  readonly Prefix?: string;
+}
+
+/**
+ * Describe the prefixes a page rolled keys up into, or nothing when it rolled
+ * up none.
+ *
+ * Real S3 leaves `CommonPrefixes` out of a listing that rolled nothing up,
+ * matching the way it leaves `Contents` out of one that found no keys. A
+ * caller written against AWS reaches for `CommonPrefixes ?? []`, and answering
+ * with an empty array here would let one that skipped the guard pass a test
+ * and fail against AWS.
+ */
+export function simS3CommonPrefixes(
+  prefixes: readonly string[],
+): SimS3CommonPrefix[] | undefined {
+  return prefixes.length === 0
+    ? undefined
+    : prefixes.map((prefix) => ({ Prefix: prefix }));
+}

--- a/src/service/s3/object/s3-object-listing.iso.test.ts
+++ b/src/service/s3/object/s3-object-listing.iso.test.ts
@@ -122,6 +122,153 @@ describe("simS3ObjectPage", () => {
   });
 });
 
+describe("simS3ObjectPage under a delimiter", () => {
+  it("rolls keys holding the delimiter up into a common prefix", () => {
+    // Given a Bucket whose keys look like a folder tree.
+    const objects = objectsWithKeys(
+      "img/a.png",
+      "img/b.png",
+      "index.html",
+      "js/app.js",
+    );
+
+    // When the top of the tree is listed.
+    const page = simS3ObjectPage({ objects, delimiter: "/", maxKeys: 10 });
+
+    // Then each folder comes back once, and only the key at the top of the
+    // tree is listed as an Object.
+    assertIdentical(page.commonPrefixes.join(","), "img/,js/");
+    assertIdentical(keysOf(page.objects).join(","), "index.html");
+    assertFalse(page.isTruncated);
+  });
+
+  it("orders a common prefix among the keys rather than after them", () => {
+    // Given a folder whose name sorts in the middle of the keys beside it.
+    const objects = objectsWithKeys("a.txt", "m/one.txt", "z.txt");
+    const listing = { objects, delimiter: "/", maxKeys: 1 };
+
+    // When the top of the tree is listed one entry at a time.
+    const first = simS3ObjectPage(listing);
+    const second = simS3ObjectPage({
+      ...listing,
+      startAfter: first.resumeAfter,
+    });
+    const third = simS3ObjectPage({
+      ...listing,
+      startAfter: second.resumeAfter,
+    });
+
+    // Then the folder arrives in key order, between the two Objects.
+    assertIdentical(keysOf(first.objects).join(","), "a.txt");
+    assertIdentical(second.commonPrefixes.join(","), "m/");
+    assertIdentical(keysOf(third.objects).join(","), "z.txt");
+    assertFalse(third.isTruncated);
+  });
+
+  it("counts a common prefix against the page size, as a key counts", () => {
+    // Given two folders and a key, in a page with room for two entries.
+    const objects = objectsWithKeys("img/a.png", "index.html", "js/app.js");
+
+    // When the page is taken.
+    const page = simS3ObjectPage({ objects, delimiter: "/", maxKeys: 2 });
+
+    // Then the folder fills a place a key would have taken, and the listing is
+    // truncated after it.
+    assertIdentical(page.commonPrefixes.join(","), "img/");
+    assertIdentical(keysOf(page.objects).join(","), "index.html");
+    assertTrue(page.isTruncated);
+    assertIdentical(page.resumeAfter, "index.html");
+  });
+
+  it("resumes after a common prefix by stepping over the whole folder", () => {
+    // Given a page that ended on a folder holding more keys than it showed.
+    const objects = objectsWithKeys("img/a.png", "img/b.png", "index.html");
+    const first = simS3ObjectPage({ objects, delimiter: "/", maxKeys: 1 });
+
+    assertIdentical(first.resumeAfter, "img/");
+
+    // When the listing carries on from there.
+    const second = simS3ObjectPage({
+      objects,
+      delimiter: "/",
+      startAfter: first.resumeAfter,
+      maxKeys: 10,
+    });
+
+    // Then the folder's own keys are behind the listing rather than rolled up
+    // into the same folder again, which is what a marker compared against the
+    // key would do.
+    assertArrayLength(second.commonPrefixes, 0);
+    assertIdentical(keysOf(second.objects).join(","), "index.html");
+    assertFalse(second.isTruncated);
+  });
+
+  it("still rolls a folder up when resuming from a key inside it", () => {
+    // Given a listing resuming after a key a caller picked itself, which sits
+    // inside a folder rather than being a prefix a previous page ended on.
+    const objects = objectsWithKeys("img/a.png", "img/b.png", "index.html");
+
+    // When the page is taken.
+    const page = simS3ObjectPage({
+      objects,
+      delimiter: "/",
+      startAfter: "img/a.png",
+      maxKeys: 10,
+    });
+
+    // Then the folder still covers what is left of it, rather than vanishing
+    // because the folder's own name sorts before the key resumed from.
+    assertIdentical(page.commonPrefixes.join(","), "img/");
+    assertIdentical(keysOf(page.objects).join(","), "index.html");
+  });
+
+  it("rolls up beneath the prefix, past any delimiter inside it", () => {
+    // Given a listing of one folder, whose own name holds the delimiter.
+    const objects = objectsWithKeys(
+      "img/icons/small.png",
+      "img/icons/large.png",
+      "img/logo.png",
+    );
+
+    // When that folder is listed.
+    const page = simS3ObjectPage({
+      objects,
+      prefix: "img/",
+      delimiter: "/",
+      maxKeys: 10,
+    });
+
+    // Then the delimiter in the prefix is stepped over, and the folder inside
+    // is the one rolled up.
+    assertIdentical(page.commonPrefixes.join(","), "img/icons/");
+    assertIdentical(keysOf(page.objects).join(","), "img/logo.png");
+  });
+
+  it("rolls up under a delimiter of any length", () => {
+    // Given keys separated by something other than a slash.
+    const objects = objectsWithKeys("2024--q1.csv", "2024--q2.csv", "notes.md");
+
+    // When the Bucket is listed under that separator.
+    const page = simS3ObjectPage({ objects, delimiter: "--", maxKeys: 10 });
+
+    // Then the common prefix runs through the whole delimiter.
+    assertIdentical(page.commonPrefixes.join(","), "2024--");
+    assertIdentical(keysOf(page.objects).join(","), "notes.md");
+  });
+
+  it("lists flat for an empty delimiter, which appears in no key", () => {
+    // Given a caller passing an empty delimiter.
+    const objects = objectsWithKeys("img/a.png", "index.html");
+
+    // When the Bucket is listed.
+    const page = simS3ObjectPage({ objects, delimiter: "", maxKeys: 10 });
+
+    // Then every key comes back, and nothing is rolled up.
+    assertArrayLength(page.commonPrefixes, 0);
+    assertIdentical(keysOf(page.objects).join(","), "img/a.png,index.html");
+  });
+});
+
 describe("simS3EffectiveMaxKeys", () => {
   it("fills a page when the caller names no limit", () => {
     assertIdentical(simS3EffectiveMaxKeys(undefined, 1000), 1000);

--- a/src/service/s3/object/s3-object-listing.ts
+++ b/src/service/s3/object/s3-object-listing.ts
@@ -11,6 +11,10 @@ export const simS3DefaultMaxKeysPerPage = 1000;
 
 interface SimS3ObjectPageRequest {
   readonly objects: readonly SimS3Object[];
+  /** The prefix the listing asked for, which a delimiter rolls up beneath. */
+  readonly prefix?: string | undefined;
+  /** The delimiter to roll keys up under, or nothing to list them flat. */
+  readonly delimiter?: string | undefined;
   /** The key to resume after, exclusive, or nothing to start at the first. */
   readonly startAfter?: string | undefined;
   readonly maxKeys: number;
@@ -21,12 +25,27 @@ interface SimS3ObjectPageRequest {
  */
 export interface SimS3ObjectPage {
   readonly objects: readonly SimS3Object[];
+  /** The prefixes keys were rolled up into, empty without a delimiter. */
+  readonly commonPrefixes: readonly string[];
   readonly isTruncated: boolean;
   /**
-   * The key the next page resumes after, which is there exactly when the
-   * listing is truncated, so a caller cannot be offered one that goes nowhere.
+   * The key or common prefix the next page resumes after, which is there
+   * exactly when the listing is truncated, so a caller cannot be offered one
+   * that goes nowhere.
    */
   readonly resumeAfter: string | undefined;
+}
+
+/**
+ * One thing a page of a listing holds: an Object, or a rolled-up prefix.
+ *
+ * A common prefix stands in for the keys beneath it and has no Object of its
+ * own. Both kinds sort and page together under the same name, which is how S3
+ * counts a rolled-up prefix against MaxKeys alongside a key.
+ */
+interface SimS3ListingEntry {
+  readonly name: string;
+  readonly object?: SimS3Object | undefined;
 }
 
 /**
@@ -44,29 +63,26 @@ export interface SimS3ObjectPage {
 export function simS3ObjectPage(
   request: SimS3ObjectPageRequest,
 ): SimS3ObjectPage {
-  const ordered = request.objects.toSorted(compareObjectKeys);
-  const startAfter = request.startAfter;
-  const remaining =
-    startAfter === undefined
-      ? ordered
-      : ordered.filter((object) => object.key > startAfter);
+  const entries = listingEntries(request);
 
-  // A negative page size would slice keys off the end rather than take none,
-  // so a page with no room is empty rather than backwards.
-  const objects = remaining.slice(0, Math.max(0, request.maxKeys));
-  const lastKey = objects.at(-1)?.key;
+  // A negative page size would slice entries off the end rather than take
+  // none, so a page with no room is empty rather than backwards.
+  const page = entries.slice(0, Math.max(0, request.maxKeys));
+  const last = page.at(-1);
 
-  // A page that returned no keys has nowhere for a caller to carry on from, so
+  // A page that returned nothing has nowhere for a caller to carry on from, so
   // it is complete however much the Bucket still holds. Reporting it truncated
   // would offer a continuation that cannot exist, and a caller looping until
   // the listing is complete would never stop.
-  const isTruncated =
-    lastKey !== undefined && objects.length < remaining.length;
+  const isTruncated = last !== undefined && page.length < entries.length;
 
   return {
-    objects,
+    objects: page.filter(hasObject).map((entry) => entry.object),
+    commonPrefixes: page
+      .filter((entry) => entry.object === undefined)
+      .map((entry) => entry.name),
     isTruncated,
-    resumeAfter: isTruncated ? lastKey : undefined,
+    resumeAfter: isTruncated ? last.name : undefined,
   };
 }
 
@@ -90,6 +106,89 @@ export function simS3EffectiveMaxKeys(
   }
 
   return Math.min(requestedMaxKeys ?? maxKeysPerPage, maxKeysPerPage);
+}
+
+/**
+ * The prefix a delimiter rolls a key up into, or nothing when it holds none.
+ *
+ * The search starts past the listing's own prefix, because a delimiter inside
+ * the prefix a caller asked for has already been walked past. Everything from
+ * the start of the key through the first delimiter after that becomes the
+ * common prefix, so `img/` covers `img/a.png` and `img/b.png` alike.
+ */
+function simS3CommonPrefix(
+  key: string,
+  prefix: string | undefined,
+  delimiter: string | undefined,
+): string | undefined {
+  // An empty delimiter appears in no key, and real S3 lists flat for one.
+  if (delimiter === undefined || delimiter === "") {
+    return undefined;
+  }
+
+  const at = key.indexOf(delimiter, (prefix ?? "").length);
+
+  return at === -1 ? undefined : key.slice(0, at + delimiter.length);
+}
+
+/**
+ * Everything a listing would return, in order, before the page is taken.
+ *
+ * Keys arrive sorted, so the keys of one common prefix are neighbours and a
+ * rolled-up prefix is recognised by the one before it.
+ */
+function listingEntries(request: SimS3ObjectPageRequest): SimS3ListingEntry[] {
+  const entries: SimS3ListingEntry[] = [];
+  let rolledUp: string | undefined;
+
+  for (const object of request.objects.toSorted(compareObjectKeys)) {
+    const commonPrefix = simS3CommonPrefix(
+      object.key,
+      request.prefix,
+      request.delimiter,
+    );
+    if (isBehindTheListing(request.startAfter, object.key, commonPrefix)) {
+      continue;
+    }
+
+    if (commonPrefix === undefined) {
+      entries.push({ name: object.key, object });
+      continue;
+    }
+
+    if (commonPrefix !== rolledUp) {
+      rolledUp = commonPrefix;
+      entries.push({ name: commonPrefix });
+    }
+  }
+
+  return entries;
+}
+
+/**
+ * Whether a listing resuming after something has already passed a key.
+ *
+ * A page ending on a common prefix resumes after the prefix itself, and the
+ * whole of it is behind the listing however many keys it holds. Resuming after
+ * a key compares against the key, as a flat listing does, so a caller that
+ * picked its own StartAfter inside a folder still gets that folder back.
+ */
+function isBehindTheListing(
+  startAfter: string | undefined,
+  key: string,
+  commonPrefix: string | undefined,
+): boolean {
+  if (startAfter === undefined) {
+    return false;
+  }
+
+  return commonPrefix === startAfter || key <= startAfter;
+}
+
+function hasObject(
+  entry: SimS3ListingEntry,
+): entry is SimS3ListingEntry & { object: SimS3Object } {
+  return entry.object !== undefined;
 }
 
 function compareObjectKeys(a: SimS3Object, b: SimS3Object): number {

--- a/src/service/s3/serve/api/sim-s3-api-input.ts
+++ b/src/service/s3/serve/api/sim-s3-api-input.ts
@@ -44,6 +44,7 @@ export function listObjectsV2Input(request: SimS3ApiRequest): object {
   return {
     Bucket: request.bucketName,
     ...optional("Prefix", request.query.get("prefix")),
+    ...optional("Delimiter", request.query.get("delimiter")),
     ...optional("ContinuationToken", request.query.get("continuation-token")),
     ...optional("StartAfter", request.query.get("start-after")),
     ...optionalNumber("MaxKeys", request.query.get("max-keys")),
@@ -57,6 +58,7 @@ export function listObjectsInput(request: SimS3ApiRequest): object {
   return {
     Bucket: request.bucketName,
     ...optional("Prefix", request.query.get("prefix")),
+    ...optional("Delimiter", request.query.get("delimiter")),
     ...optional("Marker", request.query.get("marker")),
     ...optionalNumber("MaxKeys", request.query.get("max-keys")),
   };

--- a/src/service/s3/serve/api/sim-s3-api-listing.iso.test.ts
+++ b/src/service/s3/serve/api/sim-s3-api-listing.iso.test.ts
@@ -1,0 +1,58 @@
+import {
+  assertStringIncludes,
+  assertStringNotIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simS3ListObjectsXml } from "./sim-s3-api-listing.js";
+
+/**
+ * The document an Object listing answers with, which the SDK and the `aws` CLI
+ * both read a folder tree out of.
+ */
+describe("Writing an S3 Object listing as XML", () => {
+  it("writes each rolled-up folder as its own CommonPrefixes element", () => {
+    // Given a listing that rolled two folders up and kept one key.
+    const output = {
+      Name: "widgets",
+      Delimiter: "/",
+      MaxKeys: 1000,
+      KeyCount: 3,
+      Contents: [{ Key: "index.html", Size: 10 }],
+      CommonPrefixes: [{ Prefix: "img/" }, { Prefix: "js/" }],
+    };
+
+    // When it is written.
+    const xml = simS3ListObjectsXml(output, 2);
+
+    // Then each folder is its own element, as real S3 writes them, rather than
+    // one element holding both.
+    assertStringIncludes(
+      xml,
+      "<CommonPrefixes><Prefix>img/</Prefix></CommonPrefixes>",
+    );
+    assertStringIncludes(
+      xml,
+      "<CommonPrefixes><Prefix>js/</Prefix></CommonPrefixes>",
+    );
+    assertStringIncludes(xml, "<Delimiter>/</Delimiter>");
+    assertStringIncludes(xml, "<Key>index.html</Key>");
+  });
+
+  it("writes no delimiter or folders for a listing that had neither", () => {
+    // Given a flat listing.
+    const output = {
+      Name: "widgets",
+      MaxKeys: 1000,
+      Contents: [{ Key: "index.html", Size: 10 }],
+    };
+
+    // When it is written.
+    const xml = simS3ListObjectsXml(output, 1);
+
+    // Then the elements are absent rather than empty, which is the difference
+    // between a listing that rolled nothing up and one that rolled up nothing.
+    assertStringNotIncludes(xml, "CommonPrefixes");
+    assertStringNotIncludes(xml, "Delimiter");
+  });
+});

--- a/src/service/s3/serve/api/sim-s3-api-listing.ts
+++ b/src/service/s3/serve/api/sim-s3-api-listing.ts
@@ -17,10 +17,16 @@ interface ObjectSummary {
   readonly StorageClass?: string | undefined;
 }
 
+interface CommonPrefix {
+  readonly Prefix?: string | undefined;
+}
+
 interface ListObjectsOutput {
   readonly Contents?: readonly ObjectSummary[] | undefined;
+  readonly CommonPrefixes?: readonly CommonPrefix[] | undefined;
   readonly Name?: string | undefined;
   readonly Prefix?: string | undefined;
+  readonly Delimiter?: string | undefined;
   readonly MaxKeys?: number | undefined;
   readonly IsTruncated?: boolean | undefined;
   readonly KeyCount?: number | undefined;
@@ -71,15 +77,22 @@ export function simS3ListObjectsXml(
   version: 1 | 2,
 ): string {
   const contents = (output.Contents ?? []).map(objectSummaryXml).join("");
+  const commonPrefixes = (output.CommonPrefixes ?? [])
+    .map((commonPrefix) =>
+      xmlElement("CommonPrefixes", xmlValue("Prefix", commonPrefix.Prefix)),
+    )
+    .join("");
 
   return xmlDocument(
     "ListBucketResult",
     xmlValue("Name", output.Name) +
       xmlValue("Prefix", output.Prefix) +
+      xmlValue("Delimiter", output.Delimiter) +
       xmlValue("MaxKeys", output.MaxKeys) +
       xmlValue("IsTruncated", output.IsTruncated ?? false) +
       pagingXml(output, version) +
-      contents,
+      contents +
+      commonPrefixes,
   );
 }
 

--- a/src/service/s3/serve/api/sim-s3-api-routes.iso.test.ts
+++ b/src/service/s3/serve/api/sim-s3-api-routes.iso.test.ts
@@ -210,4 +210,24 @@ describe("Resolving an S3 REST operation from a request", () => {
       "ListObjectsV2Command",
     );
   });
+
+  it("carries a listing's delimiter through to the operation's input", () => {
+    // Given the listing `aws s3 ls s3://widgets/img/` sends, on either version
+    // of the operation.
+    assertObjectMatches(input("GET", "/widgets?prefix=img%2F&delimiter=%2F"), {
+      Bucket: "widgets",
+      Prefix: "img/",
+      Delimiter: "/",
+    });
+    assertObjectMatches(
+      input("GET", "/widgets?list-type=2&prefix=img%2F&delimiter=%2F"),
+      { Bucket: "widgets", Prefix: "img/", Delimiter: "/" },
+    );
+
+    // And a listing that named no delimiter says nothing about one, rather
+    // than asking for a rollup under an empty string.
+    assertObjectEquals(input("GET", "/widgets?list-type=2"), {
+      Bucket: "widgets",
+    });
+  });
 });

--- a/src/service/s3/serve/api/sim-s3-listing-cli.loc.test.ts
+++ b/src/service/s3/serve/api/sim-s3-listing-cli.loc.test.ts
@@ -1,0 +1,143 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import {
+  CreateAccessKeyCommand,
+  CreateUserCommand,
+  PutUserPolicyCommand,
+} from "@aws-sdk/client-iam";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+  assertStringIncludes,
+  assertStringNotIncludes,
+} from "@kensio/smartass";
+import { afterAll, beforeAll, describe, it } from "vitest";
+
+import { SimAwsLocalServer } from "../../../../serve/index.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { TemporaryDirectory } from "../../../../util/filesystem/temporary-directory.js";
+
+const runFile = promisify(execFile);
+
+/**
+ * The `aws` CLI walking a simulated Bucket as a folder tree.
+ *
+ * `aws s3 ls` sends a delimiter of its own accord and prints a `PRE` line for
+ * every prefix it gets back, so this covers the whole path a person browsing a
+ * Bucket takes: the query string, the rollup and the XML, driven by a real
+ * client rather than by a test's idea of one.
+ */
+describe("Listing simulated S3 a folder at a time with the aws CLI", () => {
+  const simAws = new SimAws();
+  const srv = new SimAwsLocalServer({ simAws });
+  const simS3 = simAws.s3();
+
+  const files = new TemporaryDirectory();
+  let cliEnvironment: NodeJS.ProcessEnv;
+
+  beforeAll(async () => {
+    await srv.listen();
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "widgets" }));
+
+    await Promise.all(
+      ["img/logo.png", "img/icons/small.png", "js/app.js", "index.html"].map(
+        async (key) =>
+          simS3.putObject(
+            new PutObjectCommand({ Bucket: "widgets", Key: key, Body: key }),
+          ),
+      ),
+    );
+
+    cliEnvironment = await credentialEnvironment();
+  });
+
+  afterAll(async () => {
+    await srv.close();
+  });
+
+  /**
+   * The environment an `aws` invocation runs with: a simulated IAM user's
+   * access key, and nothing of whatever real AWS configuration the machine
+   * running the test happens to have.
+   */
+  async function credentialEnvironment(): Promise<NodeJS.ProcessEnv> {
+    const simIam = simAws.iam();
+
+    await files.resolvePath();
+
+    await simIam.createUser(new CreateUserCommand({ UserName: "Browser" }));
+    await simIam.putUserPolicy(
+      new PutUserPolicyCommand({
+        UserName: "Browser",
+        PolicyName: "Browses",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: { Effect: "Allow", Action: "s3:*", Resource: "*" },
+        }),
+      }),
+    );
+    const created = await simIam.createAccessKey(
+      new CreateAccessKeyCommand({ UserName: "Browser" }),
+    );
+
+    const { AWS_PROFILE: _profile, ...environment } = process.env;
+
+    return {
+      ...environment,
+      AWS_ACCESS_KEY_ID: created.AccessKey.AccessKeyId,
+      AWS_SECRET_ACCESS_KEY: created.AccessKey.SecretAccessKey,
+      AWS_DEFAULT_REGION: simAws.defaultRegionName,
+      AWS_CONFIG_FILE: files.join("aws-config"),
+      AWS_SHARED_CREDENTIALS_FILE: files.join("aws-credentials"),
+      AWS_EC2_METADATA_DISABLED: "true",
+    };
+  }
+
+  async function aws(...commandArguments: string[]): Promise<string> {
+    const { stdout } = await runFile(
+      "aws",
+      [...commandArguments, "--endpoint-url", `http://localhost:${srv.port}`],
+      { env: cliEnvironment },
+    );
+
+    return stdout;
+  }
+
+  it("prints a PRE line for each folder at the top of the Bucket", async () => {
+    // Given a Bucket whose keys read as a folder tree
+    // When the top of it is listed
+    const listed = await aws("s3", "ls", "s3://widgets/");
+
+    // Then the folders are named once each and the key beside them is listed,
+    // rather than every key in the Bucket coming back flat
+    assertStringIncludes(listed, "PRE img/");
+    assertStringIncludes(listed, "PRE js/");
+    assertStringIncludes(listed, "index.html");
+    assertStringNotIncludes(listed, "logo.png");
+  });
+
+  it("walks into a folder", async () => {
+    // Given the folders the listing above named
+    // When one of them is listed
+    const listed = await aws("s3", "ls", "s3://widgets/img/");
+
+    // Then the folder inside it comes back as a prefix, and the key beside it
+    // as an Object
+    assertStringIncludes(listed, "PRE icons/");
+    assertStringIncludes(listed, "logo.png");
+    assertStringNotIncludes(listed, "app.js");
+  });
+
+  it("lists every key when asked to recurse", async () => {
+    // Given the same Bucket
+    // When it is listed recursively, which sends no delimiter
+    const listed = await aws("s3", "ls", "s3://widgets/", "--recursive");
+
+    // Then nothing is rolled up and every key comes back in full
+    assertStringNotIncludes(listed, "PRE ");
+    assertStringIncludes(listed, "img/icons/small.png");
+    assertStringIncludes(listed, "img/logo.png");
+    assertStringIncludes(listed, "js/app.js");
+    assertStringIncludes(listed, "index.html");
+  });
+});


### PR DESCRIPTION
ListObjects and ListObjectsV2 take a Delimiter and roll every key holding it after the Prefix up into a CommonPrefixes entry. A rolled-up prefix counts against MaxKeys as a key does, KeyCount counts the two together, and a truncated page can end on either. A continuation steps over the whole folder rather than grouping its keys again. The delimiter reaches IAM as `s3:delimiter`, alongside the prefix and page-size condition keys. The S3 REST endpoint reads the delimiter from the query string and writes the prefixes back into the listing XML. `aws s3 ls s3://bucket/` then prints PRE lines against a served simulation, which a local test drives with the real CLI.

The rollup lives in `object/s3-object-listing.ts` beside the ordering both versions of the operation already share. It turns the ordered keys into entries, where an entry is either an Object or a common prefix standing in for every key beneath it, and pages the entries rather than the keys.

Two calls worth flagging:

- Resuming compares against the common prefix when the marker is exactly one, and against the key otherwise. That steps a continuation over a whole folder while still returning the folder to a caller that picked its own `StartAfter` inside it.
- `NextMarker` is unchanged. Real S3 sets it only for a listing that carried a Delimiter, and sim S3 sets it whenever the listing is truncated. Both answer the same key, and a caller that reads it needs no branch for the delimited case. Noted in the module README.

Resolves #824
