### PR TITLE
feat: evaluate a WAF RateBasedStatement

### DIFF
--- a/docs/services/wafv2/README.md
+++ b/docs/services/wafv2/README.md
@@ -284,8 +284,9 @@ scope-down statement leaves alone is neither counted nor limited. That is what k
 The counts belong to the rule. Writing a new set of rules over a web ACL with `UpdateWebACL` starts
 them from nothing, as it does on AWS.
 
-A rate limit is the whole of a rule's statement, as it is on real WAFv2. Joining one to an
-`AndStatement` or nesting it in a `NotStatement` is refused where the rule is written.
+A rate limit is the whole of a rule's statement, as it is on real WAFv2. A rule naming another
+statement kind beside it, and a rate limit nested inside an `AndStatement` or a `NotStatement`, are
+both refused where the rule is written.
 
 ## The AWS managed rule groups
 

--- a/docs/services/wafv2/README.md
+++ b/docs/services/wafv2/README.md
@@ -178,6 +178,115 @@ WAF stops reading a body, a header set or a cookie set at 8 KB. The rule's `Over
 what content past that point counts as. `MATCH` and `NO_MATCH` settle the statement without looking,
 and `CONTINUE` inspects as much as WAF would have read.
 
+## Rate limiting
+
+`RateBasedStatement` counts the requests one client makes and applies the rule's action once the
+count goes past `Limit`. A test sends requests until the rule trips, then moves the simulated clock
+past the window to watch it let go again.
+
+```typescript sim-wafv2-rate-limit
+/**
+ * Limiting how often one client may ask to create an account.
+ */
+
+import { CreateWebACLCommand } from "@aws-sdk/client-wafv2";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const waf = simAws.wafV2();
+
+const visibility = {
+  SampledRequestsEnabled: false,
+  CloudWatchMetricsEnabled: false,
+  MetricName: "pool",
+};
+
+const created = await waf.createWebAcl(
+  new CreateWebACLCommand({
+    Name: "pool-acl",
+    Scope: "REGIONAL",
+    DefaultAction: { Allow: {} },
+    VisibilityConfig: visibility,
+    Rules: [
+      {
+        Name: "sign-up-rate",
+        Priority: 0,
+        Action: { Block: {} },
+        Statement: {
+          RateBasedStatement: {
+            Limit: 10,
+            EvaluationWindowSec: 300,
+            AggregateKeyType: "IP",
+            ScopeDownStatement: {
+              ByteMatchStatement: {
+                FieldToMatch: { UriPath: {} },
+                PositionalConstraint: "STARTS_WITH",
+                SearchString: Buffer.from("/signup"),
+                TextTransformations: [{ Priority: 0, Type: "LOWERCASE" }],
+              },
+            },
+          },
+        },
+        VisibilityConfig: { ...visibility, MetricName: "sign-up-rate" },
+      },
+    ],
+  }),
+);
+
+const webAclArn = created.Summary!.ARN;
+
+const signUp = (): string =>
+  waf.evaluateRequest({
+    webAclArn,
+    request: new Request("https://pool.example.test/signup"),
+  }).action;
+
+const decisions = Array.from({ length: 11 }, signUp);
+
+// "ALLOW" "BLOCK"
+console.log(decisions[9], decisions[10]);
+
+const login = waf.evaluateRequest({
+  webAclArn,
+  request: new Request("https://pool.example.test/login"),
+});
+
+// "ALLOW"
+console.log(login.action);
+
+await simAws.clock().advanceBy({ minutes: 6 });
+
+// "ALLOW"
+console.log(signUp());
+```
+
+`Limit` is how many requests one aggregation instance may make inside the window. AWS holds it
+between 10 and 2,000,000,000. The request that takes the count past the limit gets the rule's
+action, and the ones under it carry on to the next rule. A `Count` action records the match and
+lets evaluation continue, the way it does for every other statement kind.
+
+`EvaluationWindowSec` is 60, 120, 300 or 600 seconds. A statement naming none counts over 300. The
+window is measured against [simulated time](../../time/README.md), so `advanceBy` past it drops
+what the rule counted.
+
+`AggregateKeyType` is `IP` or `CONSTANT`. `IP` counts each client address on its own. Every request
+in this simulation reports `127.0.0.1`, leaving a web ACL with one client for the whole simulation.
+That is the case a rate limiting test is written about anyway (one client, sending until the rule
+trips), and it behaves here as it does on AWS. `CONSTANT` counts every request the statement sees
+together, and AWS requires a `ScopeDownStatement` alongside it to say which requests those are.
+
+A `ScopeDownStatement` narrows what the rule counts. Every statement kind in
+[What a statement can inspect](#what-a-statement-can-inspect) nests inside one. A request the
+scope-down statement leaves alone is neither counted nor limited. That is what keeps a limit on
+`/signup` off the rest of a site.
+
+The counts belong to the rule. Writing a new set of rules over a web ACL with `UpdateWebACL` starts
+them from nothing, as it does on AWS.
+
+A rate limit is the whole of a rule's statement, as it is on real WAFv2. Joining one to an
+`AndStatement` or nesting it in a `NotStatement` is refused where the rule is written.
+
 ## The AWS managed rule groups
 
 Three of the AWS managed rule groups are simulated, so a stack that turns them on deploys and its
@@ -925,10 +1034,10 @@ declared it, and the reason is the one `CreateWebACL` gives an SDK caller.
 ```typescript
 const [dropped] = stack.ignoredProperties;
 
-// "OrdersAcl Rules.account-creation-rate"
+// "OrdersAcl Rules.block-countries"
 console.log(`${dropped.logicalId} ${dropped.path}`);
 
-// "Rule account-creation-rate uses the statement kind RateBasedStatement, which
+// "Rule block-countries uses the statement kind GeoMatchStatement, which
 //  Yulin does not simulate: ..."
 console.log(dropped.reason);
 ```
@@ -1210,13 +1319,17 @@ These statement kinds are refused:
 - `IPSetReferenceStatement`, `GeoMatchStatement` and `AsnMatchStatement`. Every request in this
   simulation reports a source address of `127.0.0.1`, and a rule on where a request came from would
   see one client for the whole simulation.
-- `RateBasedStatement`. Counting requests over a time window against the simulated clock is
-  feasible and is not part of this yet.
 - `SqliMatchStatement` and `XssMatchStatement`. AWS publishes no description of the detection they
   run.
 - `RuleGroupReferenceStatement`. A rule group of your own is a resource in its own right, and none
   is simulated. The three simulated AWS managed rule groups are named in a statement rather than
   created.
+
+A `RateBasedStatement` is evaluated (see [Rate limiting](#rate-limiting)). Two of its aggregation
+key types are refused. `FORWARDED_IP` and `ForwardedIPConfig` read the address from a forwarding
+header, which needs the source address variety an IP set is waiting on. `CUSTOM_KEYS` and
+`CustomKeys` aggregate on headers, cookies and query arguments, and are feasible and not part of
+this yet. `GetRateBasedStatementManagedKeys` is not simulated.
 
 `JsonBody`, `HeaderOrder`, `UriFragment`, `JA3Fingerprint` and `JA4Fingerprint` are refused as
 fields to match. The `Captcha` and `Challenge` actions are refused, along with the `CaptchaConfig`,

--- a/docs/services/wafv2/sim-wafv2-rate-limit.example.ts
+++ b/docs/services/wafv2/sim-wafv2-rate-limit.example.ts
@@ -1,0 +1,74 @@
+/**
+ * Limiting how often one client may ask to create an account.
+ */
+
+import { CreateWebACLCommand } from "@aws-sdk/client-wafv2";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const waf = simAws.wafV2();
+
+const visibility = {
+  SampledRequestsEnabled: false,
+  CloudWatchMetricsEnabled: false,
+  MetricName: "pool",
+};
+
+const created = await waf.createWebAcl(
+  new CreateWebACLCommand({
+    Name: "pool-acl",
+    Scope: "REGIONAL",
+    DefaultAction: { Allow: {} },
+    VisibilityConfig: visibility,
+    Rules: [
+      {
+        Name: "sign-up-rate",
+        Priority: 0,
+        Action: { Block: {} },
+        Statement: {
+          RateBasedStatement: {
+            Limit: 10,
+            EvaluationWindowSec: 300,
+            AggregateKeyType: "IP",
+            ScopeDownStatement: {
+              ByteMatchStatement: {
+                FieldToMatch: { UriPath: {} },
+                PositionalConstraint: "STARTS_WITH",
+                SearchString: Buffer.from("/signup"),
+                TextTransformations: [{ Priority: 0, Type: "LOWERCASE" }],
+              },
+            },
+          },
+        },
+        VisibilityConfig: { ...visibility, MetricName: "sign-up-rate" },
+      },
+    ],
+  }),
+);
+
+const webAclArn = created.Summary!.ARN;
+
+const signUp = (): string =>
+  waf.evaluateRequest({
+    webAclArn,
+    request: new Request("https://pool.example.test/signup"),
+  }).action;
+
+const decisions = Array.from({ length: 11 }, signUp);
+
+// "ALLOW" "BLOCK"
+console.log(decisions[9], decisions[10]);
+
+const login = waf.evaluateRequest({
+  webAclArn,
+  request: new Request("https://pool.example.test/login"),
+});
+
+// "ALLOW"
+console.log(login.action);
+
+await simAws.clock().advanceBy({ minutes: 6 });
+
+// "ALLOW"
+console.log(signUp());

--- a/src/service/cloudformation/cdk/wafv2/sim-cdk-waf-web-acl.loc.test.ts
+++ b/src/service/cloudformation/cdk/wafv2/sim-cdk-waf-web-acl.loc.test.ts
@@ -80,6 +80,31 @@ const webAcl = new wafv2.CfnWebACL(stack, "ApiAcl", {
         metricName: "block-admin",
       },
     },
+    {
+      name: "orders-rate",
+      priority: 1,
+      action: { block: {} },
+      statement: {
+        rateBasedStatement: {
+          limit: 10,
+          evaluationWindowSec: 300,
+          aggregateKeyType: "IP",
+          scopeDownStatement: {
+            byteMatchStatement: {
+              fieldToMatch: { uriPath: {} },
+              positionalConstraint: "CONTAINS",
+              searchString: "/orders",
+              textTransformations: [{ priority: 0, type: "NONE" }],
+            },
+          },
+        },
+      },
+      visibilityConfig: {
+        sampledRequestsEnabled: false,
+        cloudWatchMetricsEnabled: false,
+        metricName: "orders-rate",
+      },
+    },
   ],
 });
 
@@ -139,6 +164,21 @@ describe("Sim CDK WAFv2 web ACL local integration", () => {
     assertStringIncludes(await blocked.text(), "Request blocked by AWS WAF");
     assertIdentical(allowed.status, 200);
     assertIdentical(await allowed.text(), "order orders/YL-1");
+
+    // And the rate limit the same template wrote counts the requests it
+    // scoped itself down to, so the eleventh in the window gets WAF's 403
+    // where the tenth was served.
+    const rated: Response[] = [];
+
+    for (let sent = 0; sent < 10; sent += 1) {
+      // A rate limit counts what arrives in order, and requests sent together
+      // arrive in no order at all.
+      // oxlint-disable-next-line no-await-in-loop
+      rated.push(await request("orders/YL-1"));
+    }
+
+    assertIdentical(rated[8]?.status, 200);
+    assertIdentical(rated[9]?.status, 403);
 
     // And the attributes CDK reads off the L1 resolved to the deployed web
     // ACL's own, rather than to a token nothing filled in.

--- a/src/service/cloudformation/cdk/wafv2/sim-cdk-waf-web-acl.loc.test.ts
+++ b/src/service/cloudformation/cdk/wafv2/sim-cdk-waf-web-acl.loc.test.ts
@@ -166,8 +166,9 @@ describe("Sim CDK WAFv2 web ACL local integration", () => {
     assertIdentical(await allowed.text(), "order orders/YL-1");
 
     // And the rate limit the same template wrote counts the requests it
-    // scoped itself down to, so the eleventh in the window gets WAF's 403
-    // where the tenth was served.
+    // scoped itself down to. The `allowed` request above was the first of
+    // them, so the tenth of these ten is the eleventh in the window and the
+    // one that gets WAF's 403.
     const rated: Response[] = [];
 
     for (let sent = 0; sent < 10; sent += 1) {

--- a/src/service/wafv2/README.md
+++ b/src/service/wafv2/README.md
@@ -160,17 +160,19 @@ the key is read. The clock is the simulation's own, reaching a rule through
 `BackgroundScheduler` being a `SimClock` as well. Advancing simulated time past the window is
 therefore all a test needs to watch a limited client be served again.
 
-`sim-waf-rate-based-input.ts` reads `Limit`, `EvaluationWindowSec` and `AggregateKeyType`, and holds
-the refusals for the two aggregation key types that need something this simulation has none of.
-`IP` reads `simAwsProxiedSourceIp`, the address every request in this simulation reports, leaving a
+`sim-waf-rate-based-input.ts` reads `Limit`, `EvaluationWindowSec` and `AggregateKeyType`, and
+`sim-waf-unsimulated-rate-based.ts` beside it refuses the two aggregation key types that need
+something this simulation has none of. `IP` reads `simAwsProxiedSourceIp`, the address every request in this simulation reports, leaving a
 web ACL with one client. That is the case a rate limiting test covers, and the keyed counter is the
 seam if source addresses ever vary.
 
 A rate-based statement is compiled at the rule level (`web-acl/sim-waf-rule-evaluator.ts`) for the
 reason a managed rule group is. Both are the whole of a rule's statement on real WAFv2, and
-`compileSimWafStatement` refuses either one nested inside another statement. A rate limit narrows
-what it counts with its own `ScopeDownStatement`. That goes through the ordinary statement path and
-gets every kind above it.
+`compileSimWafStatement` refuses either one nested inside another statement. Being the whole of it
+is checked from the other side too. `refuseJoinedSimWafRateBased` refuses a rule naming a rate limit
+and another statement kind together, since dispatching on the member would otherwise read past the
+kind written beside it. A rate limit narrows what it counts with its own `ScopeDownStatement`. That
+goes through the ordinary statement path and gets every kind above it.
 
 ## The AWS managed rule groups
 
@@ -222,9 +224,10 @@ authorizes against `*` as the listings do.
 
 ## Refusals
 
-Three files hold them, one per level.
+Four files hold them, one per level.
 
 - `statement/sim-waf-unsimulated-statement.ts` for the statement kinds.
+- `statement/sim-waf-unsimulated-rate-based.ts` for the parts of a rate-based statement.
 - `statement/sim-waf-unsimulated-field.ts` for the field-to-match kinds.
 - `web-acl/sim-waf-rule-input.ts` and `command/web-acl/sim-wafv2-unsimulated-web-acl-input.ts` for
   the members of a rule and of a web ACL.
@@ -240,8 +243,8 @@ for the whole simulation. `SqliMatchStatement` and `XssMatchStatement` are refus
 publishes no description of the detection they run. `RuleGroupReferenceStatement` is refused because
 a rule group of the reader's own is a resource in its own right, and none is simulated.
 
-`statement/sim-waf-rate-based-input.ts` holds two more, for the same one-client-address reason and
-for scope. `FORWARDED_IP` and `ForwardedIPConfig` read the address from a forwarding header.
+`statement/sim-waf-unsimulated-rate-based.ts` holds two more, for the same one-client-address reason
+and for scope. `FORWARDED_IP` and `ForwardedIPConfig` read the address from a forwarding header.
 `CUSTOM_KEYS` and `CustomKeys` aggregate on headers, cookies and query arguments (feasible, and not
 part of this).
 

--- a/src/service/wafv2/README.md
+++ b/src/service/wafv2/README.md
@@ -147,6 +147,31 @@ read.
 Matching is case sensitive throughout, as it is on AWS. A rule that means to ignore case says so
 with a `LOWERCASE` transformation and a lower case search string.
 
+## Rate limiting
+
+`statement/sim-waf-rate-based.ts` compiles a rule that counts requests. It is the one statement
+kind carrying state of its own, and the state is a closure over the compiled rule, so writing a new
+set of rules over a web ACL starts the counting from nothing.
+
+`sim-waf-rate-counter.ts` holds the counts, keyed by aggregation instance. Each request records the
+instant it arrived, and the instants that have fallen out of the evaluation window are dropped as
+the key is read. The clock is the simulation's own, reaching a rule through
+`SimWafRuleScope.clock`. `sim-wafv2-commands.ts` wires it from the background scheduler, a
+`BackgroundScheduler` being a `SimClock` as well. Advancing simulated time past the window is
+therefore all a test needs to watch a limited client be served again.
+
+`sim-waf-rate-based-input.ts` reads `Limit`, `EvaluationWindowSec` and `AggregateKeyType`, and holds
+the refusals for the two aggregation key types that need something this simulation has none of.
+`IP` reads `simAwsProxiedSourceIp`, the address every request in this simulation reports, leaving a
+web ACL with one client. That is the case a rate limiting test covers, and the keyed counter is the
+seam if source addresses ever vary.
+
+A rate-based statement is compiled at the rule level (`web-acl/sim-waf-rule-evaluator.ts`) for the
+reason a managed rule group is. Both are the whole of a rule's statement on real WAFv2, and
+`compileSimWafStatement` refuses either one nested inside another statement. A rate limit narrows
+what it counts with its own `ScopeDownStatement`. That goes through the ordinary statement path and
+gets every kind above it.
+
 ## The AWS managed rule groups
 
 `managed/` carries `AWSManagedRulesCommonRuleSet`, `AWSManagedRulesKnownBadInputsRuleSet` and
@@ -212,10 +237,13 @@ The reasons are worth knowing. `IPSetReferenceStatement`, `GeoMatchStatement` an
 `AsnMatchStatement` are refused because every request in this simulation reports a source address of
 `127.0.0.1` (`simAwsProxiedSourceIp`), and a rule on where a request came from would see one client
 for the whole simulation. `SqliMatchStatement` and `XssMatchStatement` are refused because AWS
-publishes no description of the detection they run. `RateBasedStatement` needs request counting over
-a window against the simulated clock (feasible, and not part of this).
-`RuleGroupReferenceStatement` is refused because a rule group of the reader's own is a resource in
-its own right, and none is simulated.
+publishes no description of the detection they run. `RuleGroupReferenceStatement` is refused because
+a rule group of the reader's own is a resource in its own right, and none is simulated.
+
+`statement/sim-waf-rate-based-input.ts` holds two more, for the same one-client-address reason and
+for scope. `FORWARDED_IP` and `ForwardedIPConfig` read the address from a forwarding header.
+`CUSTOM_KEYS` and `CustomKeys` aggregate on headers, cookies and query arguments (feasible, and not
+part of this).
 
 `managed/sim-waf-managed-group-input.ts` refuses a managed rule group outside the three, naming the
 ones that are simulated. It also refuses `Version`, `ExcludedRules` and `ManagedRuleGroupConfigs`.
@@ -256,7 +284,7 @@ behind them go the same way, from `web-acl/sim-cfn-waf-web-acl-config.ts`.
 Issue #823 is the reasoning, and #391 is the principle it comes from. A web ACL that accepted a rule
 it cannot evaluate would allow a request AWS blocks, so `CreateWebACL` refuses one. Failing a whole
 stack over it is a different thing, and it cost one consumer twelve Resources and 25 test files over
-a single rate limiting rule. The unit is the rule, and everything larger than the rule deploys.
+a single rule. The unit is the rule, and everything larger than the rule deploys.
 
 `sim-cfn-waf-resource-error.ts` still sorts what is left. A `SimWafUnsimulatedInputException`
 reaching it skips the Resource, worded so sim CloudFormation records it and steps over it (see

--- a/src/service/wafv2/cfn/sim-cfn-waf-best-effort.iso.test.ts
+++ b/src/service/wafv2/cfn/sim-cfn-waf-best-effort.iso.test.ts
@@ -87,9 +87,9 @@ describe("A web ACL rule Yulin cannot evaluate", () => {
     const property = simWafIgnoredProperty(stack);
 
     assertIdentical(property.logicalId, "OrdersAcl");
-    assertIdentical(property.path, "Rules.account-creation-rate");
-    assertStringIncludes(property.reason, "Rule account-creation-rate");
-    assertStringIncludes(property.reason, "RateBasedStatement");
+    assertIdentical(property.path, "Rules.block-countries");
+    assertStringIncludes(property.reason, "Rule block-countries");
+    assertStringIncludes(property.reason, "GeoMatchStatement");
     assertStringIncludes(property.reason, "which Yulin does not simulate");
   });
 
@@ -131,10 +131,7 @@ describe("A web ACL rule Yulin cannot evaluate", () => {
     assertIdentical(blocked.status, 403);
     assertIdentical(allowed.status, 200);
     assertIdentical(await allowed.text(), "orders");
-    assertIdentical(
-      simWafIgnoredProperty(stack).path,
-      "Rules.account-creation-rate",
-    );
+    assertIdentical(simWafIgnoredProperty(stack).path, "Rules.block-countries");
   });
 
   it("records a web ACL member it has no behaviour for", async () => {

--- a/src/service/wafv2/cfn/sim-cfn-waf-distribution.iso.test.ts
+++ b/src/service/wafv2/cfn/sim-cfn-waf-distribution.iso.test.ts
@@ -53,14 +53,15 @@ const blockAdmin = {
 };
 
 /**
- * A rule counting requests over a time window, which Yulin does not evaluate.
+ * A rule blocking whole countries, which Yulin does not evaluate: every
+ * request in this simulation comes from one address.
  */
-const rateLimit = {
-  Name: "account-creation-rate",
+const blockCountries = {
+  Name: "block-countries",
   Priority: 0,
   Action: { Block: {} },
-  Statement: { RateBasedStatement: { Limit: 100, AggregateKeyType: "IP" } },
-  VisibilityConfig: { ...visibility, MetricName: "account-creation-rate" },
+  Statement: { GeoMatchStatement: { CountryCodes: ["CN", "RU"] } },
+  VisibilityConfig: { ...visibility, MetricName: "block-countries" },
 };
 
 /**
@@ -199,7 +200,7 @@ describe("A web ACL a CloudFormation Distribution names in WebACLId", () => {
     const stack = await simAws.cloudFormation().deployTemplate({
       stackName: "rate-limited-site",
       template: siteTemplate(webAclArnReference, "CLOUDFRONT", [
-        rateLimit,
+        blockCountries,
         blockAdmin,
       ]),
     });
@@ -211,10 +212,7 @@ describe("A web ACL a CloudFormation Distribution names in WebACLId", () => {
 
     assertArrayLength(stack.skippedResources, 0);
     assertIdentical(blocked.status, 403);
-    assertIdentical(
-      stack.ignoredProperties[0]?.path,
-      "Rules.account-creation-rate",
-    );
+    assertIdentical(stack.ignoredProperties[0]?.path, "Rules.block-countries");
   });
 
   it("refuses a distribution naming a REGIONAL scope web ACL", async () => {

--- a/src/service/wafv2/cfn/sim-cfn-waf-web-acl.iso.test.ts
+++ b/src/service/wafv2/cfn/sim-cfn-waf-web-acl.iso.test.ts
@@ -115,6 +115,53 @@ describe("AWS::WAFv2::WebACL", () => {
     assertIdentical(decisionFor(simAws, stack, "/orders"), "ALLOW");
   });
 
+  it("deploys a web ACL whose only rule limits a request rate", async () => {
+    // Given a template whose one rule counts sign-ups, which is what CDK's
+    // protection for a user pool writes and the whole of what such a web ACL
+    // holds.
+    const simAws = new SimAws();
+    const stack = await deployWebAcl(simAws, {
+      Rules: [
+        {
+          Name: "account-creation-rate",
+          Priority: 0,
+          Action: { Block: {} },
+          Statement: {
+            RateBasedStatement: {
+              Limit: 10,
+              EvaluationWindowSec: 300,
+              AggregateKeyType: "IP",
+              ScopeDownStatement: {
+                ByteMatchStatement: {
+                  FieldToMatch: { UriPath: {} },
+                  PositionalConstraint: "STARTS_WITH",
+                  SearchString: "/signup",
+                  TextTransformations: [{ Priority: 0, Type: "LOWERCASE" }],
+                },
+              },
+            },
+          },
+          VisibilityConfig: {
+            ...visibility,
+            MetricName: "account-creation-rate",
+          },
+        },
+      ],
+    });
+
+    // Then nothing was left out of the web ACL, and the rule limits what the
+    // template said it would.
+    assertArrayLength(stack.ignoredProperties, 0);
+
+    const decisions = Array.from({ length: 11 }, () =>
+      decisionFor(simAws, stack, "/signup"),
+    );
+
+    assertIdentical(decisions[9], "ALLOW");
+    assertIdentical(decisions[10], "BLOCK");
+    assertIdentical(decisionFor(simAws, stack, "/orders"), "ALLOW");
+  });
+
   it("answers Fn::GetAtt with the four attributes a web ACL publishes", async () => {
     // Given a deployed web ACL whose attributes are all outputs.
     const simAws = new SimAws();

--- a/src/service/wafv2/cfn/sim-cfn-waf-web-acl.iso.test.ts
+++ b/src/service/wafv2/cfn/sim-cfn-waf-web-acl.iso.test.ts
@@ -162,6 +162,40 @@ describe("AWS::WAFv2::WebACL", () => {
     assertIdentical(decisionFor(simAws, stack, "/orders"), "ALLOW");
   });
 
+  it("leaves out a rate limit aggregating on what it cannot read", async () => {
+    // Given a template whose rate limit counts by forwarded address, beside a
+    // rule this simulation does evaluate.
+    const simAws = new SimAws();
+    const stack = await deployWebAcl(simAws, {
+      Rules: [
+        {
+          Name: "forwarded-rate",
+          Priority: 1,
+          Action: { Block: {} },
+          Statement: {
+            RateBasedStatement: {
+              Limit: 100,
+              AggregateKeyType: "FORWARDED_IP",
+            },
+          },
+          VisibilityConfig: { ...visibility, MetricName: "forwarded-rate" },
+        },
+        blockAdmin,
+      ],
+    });
+
+    // Then the rate limit was left out and recorded, and the web ACL deployed
+    // with the rule beside it still deciding requests. A refused aggregation
+    // key costs the rule and nothing larger than the rule.
+    const [dropped] = stack.ignoredProperties;
+
+    assertNonNullable(dropped);
+    assertIdentical(dropped.path, "Rules.forwarded-rate");
+    assertStringIncludes(dropped.reason, "FORWARDED_IP");
+    assertArrayLength(stack.skippedResources, 0);
+    assertIdentical(decisionFor(simAws, stack, "/admin/users"), "BLOCK");
+  });
+
   it("answers Fn::GetAtt with the four attributes a web ACL publishes", async () => {
     // Given a deployed web ACL whose attributes are all outputs.
     const simAws = new SimAws();

--- a/src/service/wafv2/command/web-acl/sim-wafv2-web-acl-commands.ts
+++ b/src/service/wafv2/command/web-acl/sim-wafv2-web-acl-commands.ts
@@ -1,3 +1,4 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import type { SimWafAssociations } from "../../association/sim-waf-associations.js";
 import { SimWafAssociatedItemException } from "../../error/sim-wafv2.error.js";
@@ -38,6 +39,7 @@ interface SimWafWebAclCommandsProperties {
   readonly managedRules: SimWafManagedRules;
   readonly authorizer: SimWafAuthorizer;
   readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly clock: SimClock;
 }
 
 /**
@@ -54,6 +56,7 @@ export class SimWafWebAclCommands {
   readonly #managedRules: SimWafManagedRules;
   readonly #authorizer: SimWafAuthorizer;
   readonly #accountRegionScope: SimAwsAccountRegionScope;
+  readonly #clock: SimClock;
 
   constructor(properties: SimWafWebAclCommandsProperties) {
     this.#webAcls = properties.webAcls;
@@ -62,6 +65,7 @@ export class SimWafWebAclCommands {
     this.#managedRules = properties.managedRules;
     this.#authorizer = properties.authorizer;
     this.#accountRegionScope = properties.accountRegionScope;
+    this.#clock = properties.clock;
   }
 
   /**
@@ -88,6 +92,7 @@ export class SimWafWebAclCommands {
       configuration: configurationOf(input),
       regexPatternSets: this.#regexPatternSets,
       managedRules: this.#managedRules,
+      clock: this.#clock,
     });
 
     this.#authorizer.authorizeResource(

--- a/src/service/wafv2/index.ts
+++ b/src/service/wafv2/index.ts
@@ -80,6 +80,7 @@ export {
   simWafInspectedRequest,
 } from "./evaluate/sim-waf-inspected-request.js";
 export { simWafInspectionLimitBytes } from "./statement/sim-waf-field-content.js";
+export type { SimWafRateBasedStatementInput } from "./statement/sim-waf-rate-based.type.js";
 export type { SimWafStatementInput } from "./statement/sim-waf-statement.type.js";
 export {
   SimWafAssociatedItemException,

--- a/src/service/wafv2/managed/sim-waf-managed-group-statement.ts
+++ b/src/service/wafv2/managed/sim-waf-managed-group-statement.ts
@@ -56,6 +56,7 @@ export function compileSimWafManagedRuleGroup(
       ? undefined
       : compileSimWafStatement(statement.ScopeDownStatement, {
           regexPatternSets: scope.regexPatternSets,
+          clock: scope.clock,
           ruleName,
         });
 

--- a/src/service/wafv2/sim-wafv2-capacity.iso.test.ts
+++ b/src/service/wafv2/sim-wafv2-capacity.iso.test.ts
@@ -223,6 +223,23 @@ describe("What a simulated web ACL costs in capacity units", () => {
     assertIdentical(capacity, 702);
   });
 
+  it("charges a rate limit its base cost and its scope-down statement", async () => {
+    // Given a rule limiting the rate of requests to one path.
+    const capacity = await capacityOf([
+      ruleWith({
+        RateBasedStatement: {
+          Limit: 100,
+          AggregateKeyType: "IP",
+          ScopeDownStatement: byteMatch("EXACTLY"),
+        },
+      }),
+    ]);
+
+    // Then the counting costs two, and the scope-down statement is charged on
+    // top of it as it is for a managed rule group.
+    assertIdentical(capacity, 4);
+  });
+
   it("adds up the rules of a whole web ACL", async () => {
     // Given a web ACL of two rules.
     const capacity = await capacityOf([

--- a/src/service/wafv2/sim-wafv2-commands.ts
+++ b/src/service/wafv2/sim-wafv2-commands.ts
@@ -88,6 +88,9 @@ export class SimWafCommands {
       managedRules: this.managedRules,
       authorizer,
       accountRegionScope,
+      // The background scheduler is this simulation's source of time as well
+      // as its scheduler, and a rate-based rule counts against it.
+      clock: background,
     });
     this.managedRuleGroupCommands = new SimWafManagedRuleGroupCommands({
       authorizer,

--- a/src/service/wafv2/sim-wafv2-refusals.iso.test.ts
+++ b/src/service/wafv2/sim-wafv2-refusals.iso.test.ts
@@ -72,17 +72,26 @@ describe("SimWafV2 refusals", () => {
     assertStringIncludes(geo.message, "127.0.0.1");
   });
 
-  it("refuses a rate based rule", async () => {
-    // When a rule limits by request rate.
-    const error = await refusalForStatement({
-      RateBasedStatement: { Limit: 100, AggregateKeyType: "IP" },
+  it("refuses a rate based rule aggregating on what it cannot read", async () => {
+    // When a rule counts by forwarded address or by a custom key.
+    const forwarded = await refusalForStatement({
+      RateBasedStatement: { Limit: 100, AggregateKeyType: "FORWARDED_IP" },
+    });
+    const custom = await refusalForStatement({
+      RateBasedStatement: {
+        Limit: 100,
+        AggregateKeyType: "CUSTOM_KEYS",
+        CustomKeys: [{ Header: { Name: "x-tenant" } }],
+      },
     });
 
-    // Then it is refused rather than accepted and never enforced. Counting
-    // requests over a window against the simulated clock is feasible and is
-    // not part of this.
-    assertInstanceOf(error, SimWafUnsimulatedInputException);
-    assertStringIncludes(error.message, "RateBasedStatement");
+    // Then both are refused, and the rate limiting Yulin does evaluate is
+    // left alone. A forwarded address needs the source address variety an IP
+    // set is waiting on, and a custom key aggregates on request content.
+    assertInstanceOf(forwarded, SimWafUnsimulatedInputException);
+    assertStringIncludes(forwarded.message, "FORWARDED_IP");
+    assertInstanceOf(custom, SimWafUnsimulatedInputException);
+    assertStringIncludes(custom.message, "CustomKeys");
   });
 
   it("refuses the injection detections AWS does not document", async () => {

--- a/src/service/wafv2/sim-wafv2.ts
+++ b/src/service/wafv2/sim-wafv2.ts
@@ -154,6 +154,7 @@ export class SimWafV2 extends SimWafSets {
     return unevaluatableSimWafRules(input.Rules, {
       regexPatternSets: this.commands.regexPatternSets,
       managedRules: this.commands.managedRules,
+      clock: this.commands.background,
       customResponseBodies: input.CustomResponseBodies ?? {},
     });
   }

--- a/src/service/wafv2/statement/sim-waf-rate-based-input.ts
+++ b/src/service/wafv2/statement/sim-waf-rate-based-input.ts
@@ -1,10 +1,42 @@
 import { simAwsProxiedSourceIp } from "../../../serve/http/sim-aws-proxied-connection.js";
 import type { SimWafInspectedRequest } from "../evaluate/sim-waf-inspected-request.js";
 import type { SimWafRateBasedStatementInput } from "./sim-waf-rate-based.type.js";
-import {
-  invalidSimWafRule,
-  refuseSimWafRuleInput,
-} from "./sim-waf-rule-refusals.js";
+import type { SimWafStatementInput } from "./sim-waf-statement.type.js";
+import { invalidSimWafRule } from "./sim-waf-rule-refusals.js";
+import { refuseUnsimulatedSimWafRateKeyType } from "./sim-waf-unsimulated-rate-based.js";
+
+/**
+ * What a rule joining a rate limit to anything else is refused with.
+ *
+ * Real WAFv2 draws the line in both directions, and so does this. A
+ * `RateBasedStatement` beside another kind would leave that kind unread and
+ * the rate limit counting requests the rule meant to leave alone. Nesting one
+ * inside a logical statement would count only the requests that reached it. A
+ * rate limit narrows what it counts with its own `ScopeDownStatement`.
+ */
+export const simWafRateBasedIsWholeStatement =
+  "A RateBasedStatement is the whole of a rule's statement, and cannot be " +
+  "joined to or nested inside another one";
+
+/**
+ * Refuse a rule that names a rate limit and another statement kind together.
+ */
+export function refuseJoinedSimWafRateBased(
+  statement: SimWafStatementInput,
+  ruleName: string,
+): void {
+  if (statement.RateBasedStatement === undefined) {
+    return;
+  }
+
+  const joined = Object.entries(statement).some(
+    ([kind, value]) => kind !== "RateBasedStatement" && value !== undefined,
+  );
+
+  if (joined) {
+    invalidSimWafRule(ruleName, simWafRateBasedIsWholeStatement);
+  }
+}
 
 /**
  * Which aggregation instance one request is counted under.
@@ -22,46 +54,6 @@ const millisecondsPerSecond = 1000;
 /** The smallest and largest limits AWS takes. */
 const smallestLimit = 10;
 const largestLimit = 2_000_000_000;
-
-const forwardedAddress =
-  "it reads the address from a forwarding header, and needs the source " +
-  "address variety IPSetReferenceStatement is waiting on";
-
-const customAggregation =
-  "aggregating on headers, cookies and query arguments is feasible and is " +
-  "not part of this";
-
-/**
- * The aggregation key types real WAFv2 has and this simulation does not.
- */
-const refusedKeyTypes = new Map<string, string>([
-  ["FORWARDED_IP", forwardedAddress],
-  ["CUSTOM_KEYS", customAggregation],
-]);
-
-/**
- * The rate-based members real WAFv2 takes and this simulation does not.
- */
-const refusedMembers = new Map<string, string>([
-  ["CustomKeys", customAggregation],
-  ["ForwardedIPConfig", forwardedAddress],
-]);
-
-/**
- * Refuse the parts of a rate-based statement this simulation cannot evaluate.
- */
-export function refuseUnsimulatedSimWafRateMembers(
-  statement: SimWafRateBasedStatementInput,
-  ruleName: string,
-): void {
-  for (const [member, value] of Object.entries(statement)) {
-    const reason = refusedMembers.get(member);
-
-    if (reason !== undefined && value !== undefined) {
-      refuseSimWafRuleInput(ruleName, `RateBasedStatement ${member}`, reason);
-    }
-  }
-}
 
 /**
  * Read how many requests a rate-based statement counts up to.
@@ -130,15 +122,8 @@ export function simWafRateAggregation(
   ruleName: string,
 ): SimWafRateAggregation {
   const keyType = statement.AggregateKeyType;
-  const refused = refusedKeyTypes.get(keyType ?? "");
 
-  if (refused !== undefined) {
-    refuseSimWafRuleInput(
-      ruleName,
-      `the aggregation key type ${keyType}`,
-      refused,
-    );
-  }
+  refuseUnsimulatedSimWafRateKeyType(keyType, ruleName);
 
   if (keyType === "IP") {
     return (): string => simAwsProxiedSourceIp;

--- a/src/service/wafv2/statement/sim-waf-rate-based-input.ts
+++ b/src/service/wafv2/statement/sim-waf-rate-based-input.ts
@@ -1,0 +1,164 @@
+import { simAwsProxiedSourceIp } from "../../../serve/http/sim-aws-proxied-connection.js";
+import type { SimWafInspectedRequest } from "../evaluate/sim-waf-inspected-request.js";
+import type { SimWafRateBasedStatementInput } from "./sim-waf-rate-based.type.js";
+import {
+  invalidSimWafRule,
+  refuseSimWafRuleInput,
+} from "./sim-waf-rule-refusals.js";
+
+/**
+ * Which aggregation instance one request is counted under.
+ */
+export type SimWafRateAggregation = (request: SimWafInspectedRequest) => string;
+
+/** The windows AWS counts over, in seconds. */
+const evaluationWindows = new Set([60, 120, 300, 600]);
+
+/** What AWS counts over when a statement names no window. */
+const defaultEvaluationWindowSec = 300;
+
+const millisecondsPerSecond = 1000;
+
+/** The smallest and largest limits AWS takes. */
+const smallestLimit = 10;
+const largestLimit = 2_000_000_000;
+
+const forwardedAddress =
+  "it reads the address from a forwarding header, and needs the source " +
+  "address variety IPSetReferenceStatement is waiting on";
+
+const customAggregation =
+  "aggregating on headers, cookies and query arguments is feasible and is " +
+  "not part of this";
+
+/**
+ * The aggregation key types real WAFv2 has and this simulation does not.
+ */
+const refusedKeyTypes = new Map<string, string>([
+  ["FORWARDED_IP", forwardedAddress],
+  ["CUSTOM_KEYS", customAggregation],
+]);
+
+/**
+ * The rate-based members real WAFv2 takes and this simulation does not.
+ */
+const refusedMembers = new Map<string, string>([
+  ["CustomKeys", customAggregation],
+  ["ForwardedIPConfig", forwardedAddress],
+]);
+
+/**
+ * Refuse the parts of a rate-based statement this simulation cannot evaluate.
+ */
+export function refuseUnsimulatedSimWafRateMembers(
+  statement: SimWafRateBasedStatementInput,
+  ruleName: string,
+): void {
+  for (const [member, value] of Object.entries(statement)) {
+    const reason = refusedMembers.get(member);
+
+    if (reason !== undefined && value !== undefined) {
+      refuseSimWafRuleInput(ruleName, `RateBasedStatement ${member}`, reason);
+    }
+  }
+}
+
+/**
+ * Read how many requests a rate-based statement counts up to.
+ *
+ * AWS holds the limit to at least ten. A rule below that would limit a client
+ * that had barely arrived.
+ */
+export function simWafRateLimit(
+  statement: SimWafRateBasedStatementInput,
+  ruleName: string,
+): number {
+  const limit = statement.Limit;
+
+  if (limit === undefined || !Number.isSafeInteger(limit)) {
+    invalidSimWafRule(ruleName, "A RateBasedStatement needs a whole Limit");
+  }
+
+  if (limit < smallestLimit || limit > largestLimit) {
+    invalidSimWafRule(
+      ruleName,
+      `A RateBasedStatement Limit is between ${smallestLimit} and ` +
+        `${largestLimit}, and this one is ${limit}`,
+    );
+  }
+
+  return limit;
+}
+
+/**
+ * Read how long a rate-based statement counts over, in milliseconds.
+ *
+ * AWS takes four windows and no others, and a statement naming none counts
+ * over five minutes.
+ */
+export function simWafRateWindowMilliseconds(
+  statement: SimWafRateBasedStatementInput,
+  ruleName: string,
+): number {
+  const seconds = statement.EvaluationWindowSec ?? defaultEvaluationWindowSec;
+
+  if (!evaluationWindows.has(seconds)) {
+    invalidSimWafRule(
+      ruleName,
+      `A RateBasedStatement EvaluationWindowSec is one of ` +
+        `${[...evaluationWindows].join(", ")}, and this one is ${seconds}`,
+    );
+  }
+
+  return seconds * millisecondsPerSecond;
+}
+
+/**
+ * Read how a rate-based statement groups the requests it counts.
+ *
+ * `IP` counts each client address on its own. Every request in this simulation
+ * reports `simAwsProxiedSourceIp`, leaving one client for the whole
+ * simulation. A rate limiting test sends its requests from one client and
+ * expects the rule to trip, so that is the case anybody would write.
+ *
+ * `CONSTANT` counts every request the statement sees together, and AWS asks
+ * for a scope-down statement alongside it to say which requests those are. A
+ * rule without one would limit everything the web ACL serves.
+ */
+export function simWafRateAggregation(
+  statement: SimWafRateBasedStatementInput,
+  ruleName: string,
+): SimWafRateAggregation {
+  const keyType = statement.AggregateKeyType;
+  const refused = refusedKeyTypes.get(keyType ?? "");
+
+  if (refused !== undefined) {
+    refuseSimWafRuleInput(
+      ruleName,
+      `the aggregation key type ${keyType}`,
+      refused,
+    );
+  }
+
+  if (keyType === "IP") {
+    return (): string => simAwsProxiedSourceIp;
+  }
+
+  if (keyType === "CONSTANT") {
+    if (statement.ScopeDownStatement === undefined) {
+      invalidSimWafRule(
+        ruleName,
+        "A RateBasedStatement aggregating on CONSTANT needs a " +
+          "ScopeDownStatement to say which requests it counts",
+      );
+    }
+
+    return (): string => "CONSTANT";
+  }
+
+  invalidSimWafRule(
+    ruleName,
+    `A RateBasedStatement AggregateKeyType is IP or CONSTANT, and this one ` +
+      `is ${String(keyType)}`,
+  );
+}

--- a/src/service/wafv2/statement/sim-waf-rate-based.iso.test.ts
+++ b/src/service/wafv2/statement/sim-waf-rate-based.iso.test.ts
@@ -1,0 +1,217 @@
+import { assertArrayEquals, assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimWafDecision } from "../evaluate/sim-waf-decision.js";
+import {
+  type SimWafRequestDecision,
+  simWafWebAclDecisions,
+} from "../sim-wafv2.fixture.js";
+import type { SimWafRuleInput } from "../web-acl/sim-waf-rule.type.js";
+import { simWafRuleFactory } from "../web-acl/sim-waf-rule.factory.js";
+import type { SimWafRateBasedStatementInput } from "./sim-waf-rate-based.type.js";
+import type { SimWafStatementInput } from "./sim-waf-statement.type.js";
+
+/**
+ * A statement claiming the requests that ask to create an account.
+ */
+const signUpPath: SimWafStatementInput = {
+  ByteMatchStatement: {
+    FieldToMatch: { UriPath: {} },
+    PositionalConstraint: "STARTS_WITH",
+    SearchString: "/signup",
+    TextTransformations: [{ Priority: 0, Type: "NONE" }],
+  },
+};
+
+/**
+ * A rule limiting how many requests one client may make.
+ */
+function rateRule(
+  statement: SimWafRateBasedStatementInput,
+  rule: Partial<SimWafRuleInput> = {},
+): SimWafRuleInput {
+  return {
+    ...simWafRuleFactory.make({ Name: "sign-up-rate", Priority: 0 }),
+    ...rule,
+    Statement: { RateBasedStatement: statement },
+  };
+}
+
+/**
+ * Make a run of requests to one path, in the order they arrive.
+ */
+function requests(
+  decide: SimWafRequestDecision,
+  count: number,
+  path: string,
+): readonly SimWafDecision[] {
+  return Array.from({ length: count }, () =>
+    decide(new Request(`https://example.test${path}`)),
+  );
+}
+
+/**
+ * What a web ACL holding one rate limiting rule does with requests.
+ */
+async function rateLimited(
+  simAws: SimAws,
+  statement: SimWafRateBasedStatementInput,
+): Promise<SimWafRequestDecision> {
+  return await simWafWebAclDecisions(simAws.wafV2(), [rateRule(statement)]);
+}
+
+describe("SimWafV2 rate based statements", () => {
+  it("applies the rule's action once a client goes over the limit", async () => {
+    // Given a web ACL blocking a client that makes more than ten requests.
+    const decide = await rateLimited(new SimAws(), {
+      Limit: 10,
+      AggregateKeyType: "IP",
+    });
+
+    // When eleven requests arrive.
+    const decisions = requests(decide, 11, "/signup");
+
+    // Then the ten within the limit carried on to the default action, and the
+    // one that went over it was blocked by the rule.
+    assertArrayEquals(
+      decisions.slice(0, 10).map((decision) => decision.action),
+      Array.from({ length: 10 }, () => "ALLOW"),
+    );
+    assertIdentical(decisions[10]?.action, "BLOCK");
+    assertIdentical(decisions[10].terminatingRuleName, "sign-up-rate");
+  });
+
+  it("counts only what a scope down statement claims", async () => {
+    // Given a rate limit that only counts requests to the sign-up page.
+    const decide = await rateLimited(new SimAws(), {
+      Limit: 10,
+      AggregateKeyType: "IP",
+      ScopeDownStatement: signUpPath,
+    });
+
+    // When eleven requests go to another page and eleven to the sign-up page.
+    const elsewhere = requests(decide, 11, "/login");
+    const signUps = requests(decide, 11, "/signup");
+
+    // Then the other page was never counted and is never limited, and the
+    // sign-up page is limited on the request that went over.
+    assertIdentical(elsewhere[10]?.action, "ALLOW");
+    assertIdentical(signUps[10]?.action, "BLOCK");
+  });
+
+  it("counts requests together when it aggregates on CONSTANT", async () => {
+    // Given a rate limit counting every sign-up together rather than by
+    // client.
+    const decide = await rateLimited(new SimAws(), {
+      Limit: 10,
+      AggregateKeyType: "CONSTANT",
+      ScopeDownStatement: signUpPath,
+    });
+
+    // When eleven requests arrive.
+    const decisions = requests(decide, 11, "/signup");
+
+    // Then the one that went over the limit was blocked.
+    assertIdentical(decisions[10]?.action, "BLOCK");
+  });
+
+  it("drops what it counted once the window has passed", async () => {
+    // Given a client that has been limited on the sign-up page.
+    const simAws = new SimAws();
+    const decide = await rateLimited(simAws, {
+      Limit: 10,
+      EvaluationWindowSec: 300,
+      AggregateKeyType: "IP",
+    });
+
+    assertIdentical(requests(decide, 11, "/signup")[10]?.action, "BLOCK");
+
+    // When the simulated clock moves past the evaluation window.
+    await simAws.clock().advanceBy({ minutes: 6 });
+
+    // Then nothing it counted is still in the window, and the client is served
+    // again.
+    assertIdentical(requests(decide, 1, "/signup")[0]?.action, "ALLOW");
+  });
+
+  it("counts over the window the rule names", async () => {
+    // Given two rate limits over the same traffic, one counting over a minute
+    // and one over the five minutes AWS counts over when a rule names no
+    // window.
+    const simAws = new SimAws();
+    const perMinute = await rateLimited(simAws, {
+      Limit: 10,
+      EvaluationWindowSec: 60,
+      AggregateKeyType: "IP",
+    });
+    const byDefault = await rateLimited(simAws, {
+      Limit: 10,
+      AggregateKeyType: "IP",
+    });
+
+    requests(perMinute, 11, "/signup");
+    requests(byDefault, 11, "/signup");
+
+    // When the clock moves ninety seconds on.
+    await simAws.clock().advanceBy({ seconds: 90 });
+
+    // Then the shorter window has forgotten what it counted and the longer one
+    // has not.
+    assertIdentical(requests(perMinute, 1, "/signup")[0]?.action, "ALLOW");
+    assertIdentical(requests(byDefault, 1, "/signup")[0]?.action, "BLOCK");
+  });
+
+  it("records the match and carries on when the action is Count", async () => {
+    // Given a rate limit staged in count mode, over a rule that blocks the
+    // page outright.
+    const decide = await simWafWebAclDecisions(new SimAws().wafV2(), [
+      rateRule(
+        { Limit: 10, AggregateKeyType: "IP", ScopeDownStatement: signUpPath },
+        { Action: { Count: {} } },
+      ),
+      {
+        ...simWafRuleFactory.make({ Name: "block-signup", Priority: 1 }),
+        Statement: signUpPath,
+      },
+    ]);
+
+    // When eleven requests arrive.
+    const decisions = requests(decide, 11, "/signup");
+
+    // Then the rate limit recorded the one that went over and left the rule
+    // behind it to decide, which is what staging a limit before turning it on
+    // is for.
+    assertArrayEquals(decisions[10]?.countedRuleNames ?? [], ["sign-up-rate"]);
+    assertIdentical(decisions[10]?.terminatingRuleName, "block-signup");
+  });
+
+  it("counts from nothing again when the rules are written over", async () => {
+    // Given a client that has been limited on the sign-up page.
+    const simAws = new SimAws();
+    const decide = await rateLimited(simAws, {
+      Limit: 10,
+      AggregateKeyType: "IP",
+    });
+
+    assertIdentical(requests(decide, 11, "/signup")[10]?.action, "BLOCK");
+
+    // When the same rule is written over the web ACL by UpdateWebACL.
+    const [webAcl] = simAws.wafV2().allWebAcls("REGIONAL");
+
+    await simAws.wafV2().updateWebAcl({
+      input: {
+        Name: webAcl?.name,
+        Scope: "REGIONAL",
+        Id: webAcl?.id,
+        LockToken: webAcl?.lockToken,
+        DefaultAction: { Allow: {} },
+        VisibilityConfig: { MetricName: "sim" },
+        Rules: [rateRule({ Limit: 10, AggregateKeyType: "IP" })],
+      },
+    });
+
+    // Then the counts went with the rules they belonged to, as they do on AWS.
+    assertIdentical(requests(decide, 1, "/signup")[0]?.action, "ALLOW");
+  });
+});

--- a/src/service/wafv2/statement/sim-waf-rate-based.ts
+++ b/src/service/wafv2/statement/sim-waf-rate-based.ts
@@ -1,0 +1,58 @@
+import type { SimWafMatcher } from "./sim-waf-field-match.js";
+import {
+  refuseUnsimulatedSimWafRateMembers,
+  simWafRateAggregation,
+  simWafRateLimit,
+  simWafRateWindowMilliseconds,
+} from "./sim-waf-rate-based-input.js";
+import type { SimWafRateBasedStatementInput } from "./sim-waf-rate-based.type.js";
+import { SimWafRateCounter } from "./sim-waf-rate-counter.js";
+import {
+  compileSimWafStatement,
+  type SimWafStatementScope,
+} from "./sim-waf-statement.js";
+
+/**
+ * Compile a rule that limits how many requests one client may make.
+ *
+ * The statement counts the requests it sees against the aggregation instance
+ * their key selects, and claims a request once the count over the evaluation
+ * window has gone past `Limit`. The rule's own action then applies. A blocking
+ * rule blocks, and a counting rule records the match and lets the next rule
+ * have a look.
+ *
+ * A scope-down statement decides which requests the rule sees at all. One it
+ * leaves alone is neither counted nor limited. That is what keeps a rate limit
+ * on `/signup` off the rest of a site.
+ *
+ * Counting is against the simulated clock. A test that has sent enough
+ * requests to trip the rule is served again once time has moved past the
+ * window.
+ */
+export function compileSimWafRateBasedStatement(
+  statement: SimWafRateBasedStatementInput,
+  scope: SimWafStatementScope,
+): SimWafMatcher {
+  const { ruleName } = scope;
+
+  refuseUnsimulatedSimWafRateMembers(statement, ruleName);
+
+  const limit = simWafRateLimit(statement, ruleName);
+  const keyOf = simWafRateAggregation(statement, ruleName);
+  const counter = new SimWafRateCounter({
+    clock: scope.clock,
+    windowMilliseconds: simWafRateWindowMilliseconds(statement, ruleName),
+  });
+  const scopeDown =
+    statement.ScopeDownStatement === undefined
+      ? undefined
+      : compileSimWafStatement(statement.ScopeDownStatement, scope);
+
+  return (request): boolean => {
+    if (scopeDown !== undefined && !scopeDown(request)) {
+      return false;
+    }
+
+    return counter.count(keyOf(request)) > limit;
+  };
+}

--- a/src/service/wafv2/statement/sim-waf-rate-based.ts
+++ b/src/service/wafv2/statement/sim-waf-rate-based.ts
@@ -1,6 +1,5 @@
 import type { SimWafMatcher } from "./sim-waf-field-match.js";
 import {
-  refuseUnsimulatedSimWafRateMembers,
   simWafRateAggregation,
   simWafRateLimit,
   simWafRateWindowMilliseconds,
@@ -11,6 +10,7 @@ import {
   compileSimWafStatement,
   type SimWafStatementScope,
 } from "./sim-waf-statement.js";
+import { refuseUnsimulatedSimWafRateMembers } from "./sim-waf-unsimulated-rate-based.js";
 
 /**
  * Compile a rule that limits how many requests one client may make.

--- a/src/service/wafv2/statement/sim-waf-rate-based.type.ts
+++ b/src/service/wafv2/statement/sim-waf-rate-based.type.ts
@@ -1,0 +1,18 @@
+import type { SimWafStatementInput } from "./sim-waf-statement.type.js";
+
+/**
+ * Minimal structural WAFv2 RateBasedStatement.
+ *
+ * The members Yulin refuses are declared here rather than left out, so a
+ * statement that names one is refused by name.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/wafv2/Interface/RateBasedStatement/
+ */
+export interface SimWafRateBasedStatementInput {
+  readonly Limit?: number | undefined;
+  readonly EvaluationWindowSec?: number | undefined;
+  readonly AggregateKeyType?: string | undefined;
+  readonly ScopeDownStatement?: SimWafStatementInput | undefined;
+  readonly CustomKeys?: readonly unknown[] | undefined;
+  readonly ForwardedIPConfig?: unknown;
+}

--- a/src/service/wafv2/statement/sim-waf-rate-counter.ts
+++ b/src/service/wafv2/statement/sim-waf-rate-counter.ts
@@ -1,0 +1,45 @@
+import type { SimClock } from "../../../util/clock/sim-clock.js";
+
+interface SimWafRateCounterProperties {
+  readonly clock: SimClock;
+  readonly windowMilliseconds: number;
+}
+
+/**
+ * What one rate-based rule has counted, by aggregation instance.
+ *
+ * A count is a window over the simulated clock rather than a running total.
+ * The instant of each request is kept, and the instants that have fallen out
+ * of the window are dropped as the key is read, so a simulation whose clock
+ * has been advanced past the window finds the rule counting from nothing
+ * again.
+ *
+ * The counts belong to the compiled rule, so writing a new set of rules over a
+ * web ACL starts them again. Real WAF does the same with a rule it has just
+ * been given.
+ */
+export class SimWafRateCounter {
+  readonly #clock: SimClock;
+  readonly #windowMilliseconds: number;
+  readonly #counted = new Map<string, number[]>();
+
+  constructor(properties: SimWafRateCounterProperties) {
+    this.#clock = properties.clock;
+    this.#windowMilliseconds = properties.windowMilliseconds;
+  }
+
+  /**
+   * Count one request against an aggregation key, and answer with what the
+   * window holds for that key once it has been counted.
+   */
+  count(key: string): number {
+    const now = this.#clock.now().getTime();
+    const since = now - this.#windowMilliseconds;
+    const within = (this.#counted.get(key) ?? []).filter((at) => at > since);
+
+    within.push(now);
+    this.#counted.set(key, within);
+
+    return within.length;
+  }
+}

--- a/src/service/wafv2/statement/sim-waf-rate-refusals.iso.test.ts
+++ b/src/service/wafv2/statement/sim-waf-rate-refusals.iso.test.ts
@@ -100,6 +100,25 @@ describe("SimWafV2 rate based refusals", () => {
     assertStringIncludes(error.message, "ScopeDownStatement");
   });
 
+  it("refuses a rate based statement beside another one", async () => {
+    // When a rule names a rate limit and a byte match together.
+    const error = await refusalForStatement({
+      RateBasedStatement: { Limit: 100, AggregateKeyType: "IP" },
+      ByteMatchStatement: {
+        FieldToMatch: { UriPath: {} },
+        PositionalConstraint: "STARTS_WITH",
+        SearchString: "/signup",
+        TextTransformations: [{ Priority: 0, Type: "NONE" }],
+      },
+    });
+
+    // Then the rule is refused. Reading the rate limit and leaving the byte
+    // match unread would count every request the web ACL serves, which is not
+    // the rule that was written.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "whole of a rule's statement");
+  });
+
   it("refuses a rate based statement nested inside another one", async () => {
     // When a rule joins a rate limit to another statement.
     const error = await refusalForStatement({

--- a/src/service/wafv2/statement/sim-waf-rate-refusals.iso.test.ts
+++ b/src/service/wafv2/statement/sim-waf-rate-refusals.iso.test.ts
@@ -1,0 +1,128 @@
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { simWafCreateWebAclFactory } from "../command/web-acl/sim-waf-create-web-acl.factory.js";
+import { SimWafInvalidParameterException } from "../error/sim-wafv2.error.js";
+import { createSimWafWebAcl } from "../sim-wafv2.fixture.js";
+import { simWafRuleFactory } from "../web-acl/sim-waf-rule.factory.js";
+import type { SimWafRateBasedStatementInput } from "./sim-waf-rate-based.type.js";
+import type { SimWafStatementInput } from "./sim-waf-statement.type.js";
+
+/**
+ * Try to create a web ACL whose one rule carries a statement, and answer with
+ * what it was refused for.
+ */
+async function refusalForStatement(
+  statement: SimWafStatementInput,
+): Promise<Error> {
+  return await assertThrowsErrorAsync(async () => {
+    await createSimWafWebAcl(
+      new SimAws().wafV2(),
+      simWafCreateWebAclFactory.make({
+        Rules: [
+          {
+            ...simWafRuleFactory.make({ Name: "sign-up-rate" }),
+            Statement: statement,
+          },
+        ],
+      }),
+    );
+  });
+}
+
+/**
+ * Try to create a web ACL holding one rate limiting rule.
+ */
+async function refusalForRateStatement(
+  statement: SimWafRateBasedStatementInput,
+): Promise<Error> {
+  return await refusalForStatement({ RateBasedStatement: statement });
+}
+
+describe("SimWafV2 rate based refusals", () => {
+  it("refuses a limit real WAF would refuse", async () => {
+    // When a rule limits a client to fewer requests than AWS allows.
+    const tooFew = await refusalForRateStatement({
+      Limit: 9,
+      AggregateKeyType: "IP",
+    });
+    const none = await refusalForRateStatement({ AggregateKeyType: "IP" });
+
+    // Then both are refused where the rule is written, naming the rule.
+    assertInstanceOf(tooFew, SimWafInvalidParameterException);
+    assertStringIncludes(tooFew.message, "sign-up-rate");
+    assertStringIncludes(tooFew.message, "10");
+    assertInstanceOf(none, SimWafInvalidParameterException);
+    assertStringIncludes(none.message, "Limit");
+  });
+
+  it("refuses a window outside the four AWS counts over", async () => {
+    // When a rule counts over a window of its own choosing.
+    const error = await refusalForRateStatement({
+      Limit: 100,
+      EvaluationWindowSec: 90,
+      AggregateKeyType: "IP",
+    });
+
+    // Then it is refused, naming the windows that are there.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "60, 120, 300, 600");
+  });
+
+  it("refuses an aggregation key type real WAF does not have", async () => {
+    // When a rule aggregates on something that is not an aggregation key type.
+    const error = await refusalForRateStatement({
+      Limit: 100,
+      AggregateKeyType: "SESSION",
+    });
+
+    // Then it is refused, naming what this simulation does count by.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "IP or CONSTANT");
+  });
+
+  it("refuses aggregating on CONSTANT with nothing to scope it down", async () => {
+    // When a rule counts every request together and says nothing about which
+    // requests it means.
+    const error = await refusalForRateStatement({
+      Limit: 100,
+      AggregateKeyType: "CONSTANT",
+    });
+
+    // Then it is refused, as AWS refuses it. The rule would otherwise limit
+    // everything the web ACL serves.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "ScopeDownStatement");
+  });
+
+  it("refuses a rate based statement nested inside another one", async () => {
+    // When a rule joins a rate limit to another statement.
+    const error = await refusalForStatement({
+      AndStatement: {
+        Statements: [
+          { RateBasedStatement: { Limit: 100, AggregateKeyType: "IP" } },
+          {
+            ByteMatchStatement: {
+              FieldToMatch: { UriPath: {} },
+              PositionalConstraint: "STARTS_WITH",
+              SearchString: "/signup",
+              TextTransformations: [{ Priority: 0, Type: "NONE" }],
+            },
+          },
+        ],
+      },
+    });
+
+    // Then it is refused, as it is on AWS. A nested rate limit would count
+    // only the requests that reached it rather than the rate the rule is
+    // about, and a scope-down statement is how a rate limit narrows what it
+    // counts.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "whole of a rule's statement");
+  });
+});

--- a/src/service/wafv2/statement/sim-waf-statement.ts
+++ b/src/service/wafv2/statement/sim-waf-statement.ts
@@ -1,3 +1,4 @@
+import type { SimClock } from "../../../util/clock/sim-clock.js";
 import type { SimWafRegexPatternSet } from "../regex-pattern-set/sim-waf-regex-pattern-set.js";
 import type { SimWafResourceStore } from "../resource/sim-waf-resource-store.js";
 import { simWafByteMatchTest } from "./sim-waf-byte-match.js";
@@ -25,6 +26,12 @@ import { refuseUnsimulatedSimWafStatement } from "./sim-waf-unsimulated-statemen
 export interface SimWafStatementScope {
   readonly regexPatternSets: SimWafResourceStore<SimWafRegexPatternSet>;
   readonly ruleName: string;
+
+  /**
+   * The simulation's sense of time, which a rate-based statement counts
+   * against.
+   */
+  readonly clock: SimClock;
 }
 
 /**
@@ -55,6 +62,18 @@ export function compileSimWafStatement(
       ruleName,
       "A ManagedRuleGroupStatement is the whole of a rule's statement, and " +
         "cannot be joined to or nested inside another one",
+    );
+  }
+
+  if (statement.RateBasedStatement !== undefined) {
+    // A rate-based statement is the whole of a rule's statement on real WAFv2
+    // as well. One nested inside another statement would count only the
+    // requests that reached it, which is not the rate the rule was written
+    // about.
+    invalidSimWafRule(
+      ruleName,
+      "A RateBasedStatement is the whole of a rule's statement, and cannot " +
+        "be joined to or nested inside another one",
     );
   }
 

--- a/src/service/wafv2/statement/sim-waf-statement.ts
+++ b/src/service/wafv2/statement/sim-waf-statement.ts
@@ -12,6 +12,7 @@ import {
 } from "./sim-waf-regex-match.js";
 import { compileSimWafLabelMatch } from "./sim-waf-label-match.js";
 import { compileSimWafLogicalStatement } from "./sim-waf-logical-statement.js";
+import { simWafRateBasedIsWholeStatement } from "./sim-waf-rate-based-input.js";
 import { invalidSimWafRule } from "./sim-waf-rule-refusals.js";
 import { simWafSizeTest } from "./sim-waf-size-constraint.js";
 import type {
@@ -66,15 +67,7 @@ export function compileSimWafStatement(
   }
 
   if (statement.RateBasedStatement !== undefined) {
-    // A rate-based statement is the whole of a rule's statement on real WAFv2
-    // as well. One nested inside another statement would count only the
-    // requests that reached it, which is not the rate the rule was written
-    // about.
-    invalidSimWafRule(
-      ruleName,
-      "A RateBasedStatement is the whole of a rule's statement, and cannot " +
-        "be joined to or nested inside another one",
-    );
+    invalidSimWafRule(ruleName, simWafRateBasedIsWholeStatement);
   }
 
   if (statement.LabelMatchStatement !== undefined) {

--- a/src/service/wafv2/statement/sim-waf-statement.type.ts
+++ b/src/service/wafv2/statement/sim-waf-statement.type.ts
@@ -1,5 +1,6 @@
 import type { SimWafManagedRuleGroupStatementInput } from "../managed/sim-waf-managed-group.type.js";
 import type { SimWafByteMatchStatementInput } from "./sim-waf-byte-match.js";
+import type { SimWafRateBasedStatementInput } from "./sim-waf-rate-based.type.js";
 import type { SimWafLabelMatchStatementInput } from "./sim-waf-label-match.js";
 import type { SimWafFieldToMatchInput } from "./sim-waf-field-to-match.type.js";
 import type {
@@ -53,7 +54,7 @@ export interface SimWafStatementInput {
   readonly IPSetReferenceStatement?: unknown;
   readonly GeoMatchStatement?: unknown;
   readonly AsnMatchStatement?: unknown;
-  readonly RateBasedStatement?: unknown;
+  readonly RateBasedStatement?: SimWafRateBasedStatementInput | undefined;
   readonly SqliMatchStatement?: unknown;
   readonly XssMatchStatement?: unknown;
   readonly LabelMatchStatement?: SimWafLabelMatchStatementInput | undefined;

--- a/src/service/wafv2/statement/sim-waf-unsimulated-rate-based.ts
+++ b/src/service/wafv2/statement/sim-waf-unsimulated-rate-based.ts
@@ -1,0 +1,60 @@
+import type { SimWafRateBasedStatementInput } from "./sim-waf-rate-based.type.js";
+import { refuseSimWafRuleInput } from "./sim-waf-rule-refusals.js";
+
+const forwardedAddress =
+  "it reads the address from a forwarding header, and needs the source " +
+  "address variety IPSetReferenceStatement is waiting on";
+
+const customAggregation =
+  "aggregating on headers, cookies and query arguments is feasible and is " +
+  "not part of this";
+
+/**
+ * The aggregation key types real WAFv2 has and this simulation does not.
+ */
+const refusedKeyTypes = new Map<string, string>([
+  ["FORWARDED_IP", forwardedAddress],
+  ["CUSTOM_KEYS", customAggregation],
+]);
+
+/**
+ * The rate-based members real WAFv2 takes and this simulation does not.
+ */
+const refusedMembers = new Map<string, string>([
+  ["CustomKeys", customAggregation],
+  ["ForwardedIPConfig", forwardedAddress],
+]);
+
+/**
+ * Refuse the parts of a rate-based statement this simulation cannot evaluate.
+ */
+export function refuseUnsimulatedSimWafRateMembers(
+  statement: SimWafRateBasedStatementInput,
+  ruleName: string,
+): void {
+  for (const [member, value] of Object.entries(statement)) {
+    const reason = refusedMembers.get(member);
+
+    if (reason !== undefined && value !== undefined) {
+      refuseSimWafRuleInput(ruleName, `RateBasedStatement ${member}`, reason);
+    }
+  }
+}
+
+/**
+ * Refuse an aggregation key type this simulation cannot count by.
+ */
+export function refuseUnsimulatedSimWafRateKeyType(
+  keyType: string | undefined,
+  ruleName: string,
+): void {
+  const reason = refusedKeyTypes.get(keyType ?? "");
+
+  if (reason !== undefined) {
+    refuseSimWafRuleInput(
+      ruleName,
+      `the aggregation key type ${keyType}`,
+      reason,
+    );
+  }
+}

--- a/src/service/wafv2/statement/sim-waf-unsimulated-statement.ts
+++ b/src/service/wafv2/statement/sim-waf-unsimulated-statement.ts
@@ -21,11 +21,6 @@ const refusedStatements = new Map<string, string>([
   ["SqliMatchStatement", undocumentedDetection],
   ["XssMatchStatement", undocumentedDetection],
   [
-    "RateBasedStatement",
-    "counting requests over a time window against the simulated clock is " +
-      "feasible and is not part of this",
-  ],
-  [
     "RuleGroupReferenceStatement",
     "a rule group is a resource in its own right, and none is simulated",
   ],

--- a/src/service/wafv2/web-acl/sim-waf-rule-evaluator.ts
+++ b/src/service/wafv2/web-acl/sim-waf-rule-evaluator.ts
@@ -1,6 +1,12 @@
 import { compileSimWafManagedRuleGroup } from "../managed/sim-waf-managed-group-statement.js";
+import type { SimWafMatcher } from "../statement/sim-waf-field-match.js";
+import { compileSimWafRateBasedStatement } from "../statement/sim-waf-rate-based.js";
 import { invalidSimWafRule } from "../statement/sim-waf-rule-refusals.js";
-import { compileSimWafStatement } from "../statement/sim-waf-statement.js";
+import {
+  compileSimWafStatement,
+  type SimWafStatementScope,
+} from "../statement/sim-waf-statement.js";
+import type { SimWafStatementInput } from "../statement/sim-waf-statement.type.js";
 import { SimWafAction } from "./sim-waf-action.js";
 import type {
   SimWafRuleEvaluator,
@@ -54,11 +60,31 @@ export function compileSimWafRuleEvaluator(
     ruleName,
     scope.customResponseBodies,
   );
-  const matches = compileSimWafStatement(input.Statement, {
+  const matches = compileRuleStatement(input.Statement, {
     regexPatternSets: scope.regexPatternSets,
+    clock: scope.clock,
     ruleName,
   });
 
   return (request): SimWafAction | undefined =>
     matches(request) ? action : undefined;
+}
+
+/**
+ * Compile the statement a rule carries.
+ *
+ * A `RateBasedStatement` is compiled here rather than wherever a statement is
+ * met, because it is the whole of a rule's statement on real WAFv2 and holds
+ * the counts that rule has taken. Nesting one is refused where the nesting
+ * would have happened.
+ */
+function compileRuleStatement(
+  statement: SimWafStatementInput | undefined,
+  scope: SimWafStatementScope,
+): SimWafMatcher {
+  const rateBased = statement?.RateBasedStatement;
+
+  return rateBased === undefined
+    ? compileSimWafStatement(statement, scope)
+    : compileSimWafRateBasedStatement(rateBased, scope);
 }

--- a/src/service/wafv2/web-acl/sim-waf-rule-evaluator.ts
+++ b/src/service/wafv2/web-acl/sim-waf-rule-evaluator.ts
@@ -1,5 +1,6 @@
 import { compileSimWafManagedRuleGroup } from "../managed/sim-waf-managed-group-statement.js";
 import type { SimWafMatcher } from "../statement/sim-waf-field-match.js";
+import { refuseJoinedSimWafRateBased } from "../statement/sim-waf-rate-based-input.js";
 import { compileSimWafRateBasedStatement } from "../statement/sim-waf-rate-based.js";
 import { invalidSimWafRule } from "../statement/sim-waf-rule-refusals.js";
 import {
@@ -75,14 +76,22 @@ export function compileSimWafRuleEvaluator(
  *
  * A `RateBasedStatement` is compiled here rather than wherever a statement is
  * met, because it is the whole of a rule's statement on real WAFv2 and holds
- * the counts that rule has taken. Nesting one is refused where the nesting
- * would have happened.
+ * the counts that rule has taken. Being the whole of it is checked here too,
+ * since dispatching on the member would otherwise read past a statement kind
+ * written beside it. Nesting one is refused where the nesting would have
+ * happened.
  */
 function compileRuleStatement(
   statement: SimWafStatementInput | undefined,
   scope: SimWafStatementScope,
 ): SimWafMatcher {
-  const rateBased = statement?.RateBasedStatement;
+  if (statement === undefined) {
+    return compileSimWafStatement(statement, scope);
+  }
+
+  refuseJoinedSimWafRateBased(statement, scope.ruleName);
+
+  const rateBased = statement.RateBasedStatement;
 
   return rateBased === undefined
     ? compileSimWafStatement(statement, scope)

--- a/src/service/wafv2/web-acl/sim-waf-rule.type.ts
+++ b/src/service/wafv2/web-acl/sim-waf-rule.type.ts
@@ -1,3 +1,4 @@
+import type { SimClock } from "../../../util/clock/sim-clock.js";
 import type { SimWafOverrideActionInput } from "../managed/sim-waf-managed-group.type.js";
 import type { SimWafManagedRules } from "../managed/sim-waf-managed-rules.js";
 import type { SimWafRegexPatternSet } from "../regex-pattern-set/sim-waf-regex-pattern-set.js";
@@ -33,6 +34,12 @@ export interface SimWafRuleInput {
 export interface SimWafWebAclRuleScope {
   readonly regexPatternSets: SimWafResourceStore<SimWafRegexPatternSet>;
   readonly managedRules: SimWafManagedRules;
+
+  /**
+   * The simulation's sense of time. A rate-based rule counts against it, so
+   * advancing the clock past a rule's evaluation window drops what it counted.
+   */
+  readonly clock: SimClock;
 }
 
 /**

--- a/src/service/wafv2/web-acl/sim-waf-web-acl-capacity.ts
+++ b/src/service/wafv2/web-acl/sim-waf-web-acl-capacity.ts
@@ -3,6 +3,9 @@ import type { SimWafStatementInput } from "../statement/sim-waf-statement.type.j
 import type { SimWafRuleInput } from "./sim-waf-rule.type.js";
 import { simWafMatchCapacity } from "./sim-waf-statement-capacity.js";
 
+/** What AWS charges for counting requests, before any scope-down statement. */
+const rateBasedBaseCost = 2;
+
 /**
  * What a web ACL's rules add up to in capacity units.
  *
@@ -37,8 +40,23 @@ function statementCapacity(
   return (
     simWafMatchCapacity(statement) +
     nestedCapacity(statement) +
-    managedGroupCapacity(statement)
+    managedGroupCapacity(statement) +
+    rateBasedCapacity(statement)
   );
+}
+
+/**
+ * What a rule limiting a request rate costs.
+ *
+ * The base cost covers the counting, and a scope-down statement is charged on
+ * top of it as it is for a managed rule group.
+ */
+function rateBasedCapacity(statement: SimWafStatementInput): number {
+  const rateBased = statement.RateBasedStatement;
+
+  return rateBased === undefined
+    ? 0
+    : rateBasedBaseCost + statementCapacity(rateBased.ScopeDownStatement);
 }
 
 /**

--- a/test/wafv2/best-effort-fixture.ts
+++ b/test/wafv2/best-effort-fixture.ts
@@ -23,16 +23,16 @@ const visibility = {
 };
 
 /**
- * A rule counting requests over a time window, which is the statement kind
- * Yulin does not evaluate that a real stack is most likely to carry. CDK's
- * sign-up protection for a user pool writes one.
+ * A rule blocking whole countries, which is the statement kind Yulin does not
+ * evaluate that a real stack is most likely to carry. Every request in this
+ * simulation comes from one address, so there is no country to read.
  */
-export const simWafRateLimitSignUps = {
-  Name: "account-creation-rate",
+export const simWafBlockCountries = {
+  Name: "block-countries",
   Priority: 0,
   Action: { Block: {} },
-  Statement: { RateBasedStatement: { Limit: 100, AggregateKeyType: "IP" } },
-  VisibilityConfig: { ...visibility, MetricName: "account-creation-rate" },
+  Statement: { GeoMatchStatement: { CountryCodes: ["CN", "RU"] } },
+  VisibilityConfig: { ...visibility, MetricName: "block-countries" },
 };
 
 /**
@@ -63,7 +63,7 @@ export const simWafMixedAclResource = {
     Scope: "REGIONAL",
     DefaultAction: { Allow: {} },
     VisibilityConfig: visibility,
-    Rules: [simWafRateLimitSignUps, simWafBlockAdmin],
+    Rules: [simWafBlockCountries, simWafBlockAdmin],
   },
 };
 


### PR DESCRIPTION
CreateWebACL and UpdateWebACL take a RateBasedStatement, and a web ACL evaluates it. A request counts against the aggregation instance its key selects, and the one that takes the count past Limit gets the rule's action. Counting runs on the simulated clock, so advancing time past the evaluation window drops what a rule counted and the client is served again. IP and CONSTANT aggregation are simulated, along with the four evaluation windows AWS takes and a scope-down statement narrowing what is counted. FORWARDED_IP and CUSTOM_KEYS are refused by name, which leaves a rule using one out of a deployed web ACL and lets the rest of the stack deploy.

Resolves #822

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WAFv2 rate-based rules for IP and constant request aggregation.
  * Supports configurable request limits, evaluation windows, scope-down filtering, and simulated-time expiration.
  * Added validation and capacity reporting for rate-based rules.
  * Added examples demonstrating blocking behavior and automatic counter expiration.

* **Bug Fixes**
  * CloudFormation best-effort deployments now continue past unsupported geographic rules while preserving supported rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->