### PR TITLE
feat: copy an Object between simulated S3 Buckets

### DIFF
--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -586,8 +586,8 @@ A completed upload raises `s3:ObjectCreated:CompleteMultipartUpload`. A single-r
 
 ### Limitations
 
-- `UploadPartCopy` is left out. It copies a byte range from another Object, and `CopyObject` is left
-  out too.
+- `UploadPartCopy` is left out. It copies a byte range from another Object into an upload.
+  `CopyObject` copies a whole Object, and is simulated. See [Copying Objects](#copying-objects).
 - Parts are held in memory, whatever storage the Bucket uses. A Bucket backed by a mounted directory
   writes whole files and has nowhere to put half of one.
 - Real S3 requires every part except the last to be at least five megabytes, and answers
@@ -672,6 +672,94 @@ Both the S3 REST endpoint and an endpoint URL a client is pointed at answer the 
   tag or the date the client held.
 - `PartNumber` is left out. A read names the bytes it wants, and the part they were uploaded in is
   not something it can ask for.
+
+## Copying Objects
+
+`CopyObjectCommand` reads one Object and writes its bytes under another key, in the same Bucket or
+in another one. A move and a rename are both a copy followed by a `DeleteObjectCommand`, and an
+archive is a copy on its own.
+
+`CopySource` names the source as `sourceBucket/sourceKey`, URL-encoded, and a leading slash on it is
+accepted. Everything after the first slash is the key. A key with slashes of its own needs nothing
+done to it.
+
+```typescript sim-s3-copy-object
+/**
+ * Copying an Object between simulated S3 Buckets.
+ */
+
+import {
+  CopyObjectCommand,
+  CreateBucketCommand,
+  DeleteObjectCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simS3 = simAws.s3();
+
+await simS3.createBucket(new CreateBucketCommand({ Bucket: "inbox-bucket" }));
+await simS3.createBucket(new CreateBucketCommand({ Bucket: "archive-bucket" }));
+
+await simS3.putObject(
+  new PutObjectCommand({
+    Bucket: "inbox-bucket",
+    Key: "report.pdf",
+    Body: "quarterly figures",
+    ContentType: "application/pdf",
+  }),
+);
+
+const copy = await simS3.copyObject(
+  new CopyObjectCommand({
+    Bucket: "archive-bucket",
+    Key: "2026/report.pdf",
+    CopySource: "inbox-bucket/report.pdf",
+  }),
+);
+
+console.log(copy.CopyObjectResult?.ETag);
+console.log(copy.CopyObjectResult?.LastModified);
+
+// The copy carries the source's content type, because MetadataDirective
+// defaults to COPY. Deleting the source turns the copy into a move.
+await simS3.deleteObject(
+  new DeleteObjectCommand({ Bucket: "inbox-bucket", Key: "report.pdf" }),
+);
+```
+
+A copy authorizes as two decisions. `s3:GetObject` on the source Object and `s3:PutObject` on the
+destination Object, each against its own Bucket policy. A caller holding one and not the other gets
+`AccessDenied`.
+
+`MetadataDirective` says where the copy's metadata comes from. The default, `COPY`, carries the
+source's content type, cache control and user metadata across. `REPLACE` takes all of it from the
+request and leaves the source's behind. A copy of an Object onto itself under `REPLACE` is how an
+Object's metadata gets corrected without uploading its bytes again.
+
+The destination Bucket raises `s3:ObjectCreated:Copy`, and `s3:ObjectCreated:*` covers it. See
+[Event notifications](#event-notifications).
+
+Copying an Object onto itself without `REPLACE` is refused with `InvalidRequest`, as real S3 refuses
+it. The copy would leave the Object exactly as it found it.
+
+### Limitations
+
+- `UploadPartCopy` is left out. An Object cannot be copied into a multipart upload.
+- Both Buckets have to belong to the same simulated S3. A copy across Accounts or Regions is left
+  out.
+- The S3 REST endpoint does not serve a copy yet, which leaves `aws s3 mv` and
+  `aws s3 cp s3://a/k s3://b/k` unable to reach a served simulation.
+- `CopySourceIfMatch`, `CopySourceIfNoneMatch`, `CopySourceIfModifiedSince` and
+  `CopySourceIfUnmodifiedSince` are ignored. A conditional copy happens whatever the condition
+  says.
+- `TaggingDirective`, `StorageClass`, `ACL` and the server-side encryption members are ignored. Sim
+  S3 models none of what they describe.
+- A `versionId` in `CopySource` is refused with `NotImplemented`.
+- A copy of an Object that was uploaded in parts gets a plain ETag rather than the multipart form.
+  Real S3 does the same for a copy under five gigabytes, because it rewrites the bytes as one
+  part.
 
 ## Deleting Objects
 
@@ -1540,11 +1628,11 @@ writes fall outside it. Without that, the simulation stops after a thousand deli
 - A destination goes where the group it was declared in says, and its ARN has no say. A queue ARN
   under `LambdaFunctionConfigurations` is refused for failing to be a function ARN, and never
   delivered to as a queue.
-- Three event types are raised: `s3:ObjectCreated:Put`,
-  `s3:ObjectCreated:CompleteMultipartUpload` and `s3:ObjectRemoved:Delete`. `Copy`, `Post`,
+- Four event types are raised: `s3:ObjectCreated:Put`, `s3:ObjectCreated:Copy`,
+  `s3:ObjectCreated:CompleteMultipartUpload` and `s3:ObjectRemoved:Delete`. `Post`,
   `DeleteMarkerCreated`, the `ObjectRestore:*`, `Replication:*`, `LifecycleExpiration:*` and
   `ObjectTagging:*` families, `LifecycleTransition`, `IntelligentTiering`, `ObjectAcl:Put` and
-  `ReducedRedundancyLostObject` are refused by name. `s3:ObjectCreated:*` expands to the two
+  `ReducedRedundancyLostObject` are refused by name. `s3:ObjectCreated:*` expands to the three
   creations and `s3:ObjectRemoved:*` to the one removal.
 - `userIdentity.principalId` carries the caller's ARN rather than the `AIDA...` unique id real S3
   puts there. Simulated IAM has no unique-id namespace to draw one from, and an ARN is what a test
@@ -2651,6 +2739,8 @@ Sim S3 currently supports:
   and `@aws-sdk/lib-storage` can upload a file of real size
 - `Range` on `GetObjectCommand`, answering with the bytes asked for and `206 Partial Content` over a
   served endpoint, so `aws s3 cp` downloads a file of real size unchanged
+- `CopyObjectCommand`, authorized as a read of the source and a write of the destination, with a
+  `MetadataDirective` deciding which metadata the copy carries
 - `DeleteObjectCommand` and `DeleteObjectsCommand`, authorized per Object by sim IAM
 - `PutBucketNotificationConfigurationCommand` and `GetBucketNotificationConfigurationCommand`, with
   Object events delivered to a simulated Lambda function, a simulated SQS queue or a simulated SNS

--- a/docs/services/s3/sim-s3-copy-object.example.ts
+++ b/docs/services/s3/sim-s3-copy-object.example.ts
@@ -1,0 +1,43 @@
+/**
+ * Copying an Object between simulated S3 Buckets.
+ */
+
+import {
+  CopyObjectCommand,
+  CreateBucketCommand,
+  DeleteObjectCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simS3 = simAws.s3();
+
+await simS3.createBucket(new CreateBucketCommand({ Bucket: "inbox-bucket" }));
+await simS3.createBucket(new CreateBucketCommand({ Bucket: "archive-bucket" }));
+
+await simS3.putObject(
+  new PutObjectCommand({
+    Bucket: "inbox-bucket",
+    Key: "report.pdf",
+    Body: "quarterly figures",
+    ContentType: "application/pdf",
+  }),
+);
+
+const copy = await simS3.copyObject(
+  new CopyObjectCommand({
+    Bucket: "archive-bucket",
+    Key: "2026/report.pdf",
+    CopySource: "inbox-bucket/report.pdf",
+  }),
+);
+
+console.log(copy.CopyObjectResult?.ETag);
+console.log(copy.CopyObjectResult?.LastModified);
+
+// The copy carries the source's content type, because MetadataDirective
+// defaults to COPY. Deleting the source turns the copy into a move.
+await simS3.deleteObject(
+  new DeleteObjectCommand({ Bucket: "inbox-bucket", Key: "report.pdf" }),
+);

--- a/src/service/s3/bucket/notification/sim-s3-notification-event.ts
+++ b/src/service/s3/bucket/notification/sim-s3-notification-event.ts
@@ -13,6 +13,7 @@ import { SIM_S3_UNSIMULATED_NOTIFICATION_EVENTS } from "./sim-s3-unsimulated-not
  */
 export const SIM_S3_NOTIFICATION_EVENTS = [
   "s3:ObjectCreated:Put",
+  "s3:ObjectCreated:Copy",
   "s3:ObjectCreated:CompleteMultipartUpload",
   "s3:ObjectRemoved:Delete",
 ] as const;
@@ -35,9 +36,14 @@ export type SimS3NotificationEvent =
 const eventExpansions = new Map<string, readonly SimS3NotificationEvent[]>([
   [
     "s3:ObjectCreated:*",
-    ["s3:ObjectCreated:Put", "s3:ObjectCreated:CompleteMultipartUpload"],
+    [
+      "s3:ObjectCreated:Put",
+      "s3:ObjectCreated:Copy",
+      "s3:ObjectCreated:CompleteMultipartUpload",
+    ],
   ],
   ["s3:ObjectCreated:Put", ["s3:ObjectCreated:Put"]],
+  ["s3:ObjectCreated:Copy", ["s3:ObjectCreated:Copy"]],
   [
     "s3:ObjectCreated:CompleteMultipartUpload",
     ["s3:ObjectCreated:CompleteMultipartUpload"],

--- a/src/service/s3/bucket/notification/sim-s3-unsimulated-notification-events.ts
+++ b/src/service/s3/bucket/notification/sim-s3-unsimulated-notification-events.ts
@@ -17,7 +17,6 @@ export const SIM_S3_UNSIMULATED_NOTIFICATION_EVENTS: ReadonlySet<string> =
     "s3:LifecycleExpiration:DeleteMarkerCreated",
     "s3:LifecycleTransition",
     "s3:ObjectAcl:Put",
-    "s3:ObjectCreated:Copy",
     "s3:ObjectCreated:Post",
     "s3:ObjectRemoved:DeleteMarkerCreated",
     "s3:ObjectRestore:*",

--- a/src/service/s3/command/copy-object/copy-object-builder.ts
+++ b/src/service/s3/command/copy-object/copy-object-builder.ts
@@ -1,0 +1,53 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import { SimS3Object } from "../../object/s3-object.js";
+import { simS3WriteMetadata } from "../../object/s3-write-metadata.js";
+import type { SimCopyObjectCommandInput } from "./copy-object.command.js";
+
+interface CopyObjectBuilderProperties {
+  readonly clock: SimClock;
+}
+
+/**
+ * Builds the Object a copy stores at its destination.
+ *
+ * The command handler owns validation, both Bucket lookups, both
+ * authorizations and the write. This owns the one question of what the
+ * destination Object is made of. That is the source's bytes, and either the
+ * source's metadata or the request's.
+ */
+export class CopyObjectBuilder {
+  private readonly clock: SimClock;
+
+  constructor(properties: CopyObjectBuilderProperties) {
+    this.clock = properties.clock;
+  }
+
+  /**
+   * Build the destination Object from the source Object and the request.
+   *
+   * The bytes are copied into a Buffer of their own. Both Objects would
+   * otherwise share one, and a Bucket backed by memory hands out the Buffer it
+   * stores. A caller writing into the source's bytes would then change the
+   * copy as well.
+   *
+   * The destination is dated by the simulation's clock, and it gets no ETag of
+   * its own to carry. An Object uploaded in parts keeps the multipart ETag it
+   * was given, and real S3 rewrites a copy of one as a single part. The copy's
+   * ETag is therefore the plain digest of its bytes.
+   */
+  build(
+    input: SimCopyObjectCommandInput,
+    key: string,
+    source: SimS3Object,
+  ): SimS3Object {
+    return new SimS3Object({
+      key,
+      body: Buffer.from(source.body),
+      metadata:
+        input.MetadataDirective === "REPLACE"
+          ? simS3WriteMetadata(input)
+          : source.metadata,
+      lastModified: this.clock.now(),
+    });
+  }
+}

--- a/src/service/s3/command/copy-object/copy-object-iam.iso.test.ts
+++ b/src/service/s3/command/copy-object/copy-object-iam.iso.test.ts
@@ -1,0 +1,166 @@
+import {
+  CopyObjectCommand,
+  CreateBucketCommand,
+  GetObjectCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertBufferEqual,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { faker } from "@faker-js/faker";
+import { Readable } from "node:stream";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simIamRoleWithPolicyFactory } from "../../../iam/role/sim-iam-role-with-policy.factory.js";
+import { simS3BodyToBuffer } from "../../storage/s3-body-buffer.js";
+
+describe("S3 CopyObjectCommand IAM authorization", () => {
+  it("allows a Role holding both the read and the write", async () => {
+    // Given a Role allowed to read anything and write anything. A copy asks
+    // for both, across the two Buckets it touches.
+    const simAws = new SimAws();
+    const simS3 = simAws.s3();
+    const inbox = `inbox-${faker.string.uuid()}`;
+    const archive = `archive-${faker.string.uuid()}`;
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: inbox }));
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: archive }));
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: inbox,
+        Key: "report.pdf",
+        Body: "quarterly figures",
+      }),
+    );
+
+    const archiver = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "ArchiverRole",
+        actions: ["s3:GetObject", "s3:PutObject"],
+        resource: "arn:aws:s3:::*/*",
+      },
+      simAws,
+    );
+
+    // When that Role copies the Object into the archive.
+    await simS3.copyObject(
+      new CopyObjectCommand({
+        Bucket: archive,
+        Key: "2026/report.pdf",
+        CopySource: `${inbox}/report.pdf`,
+      }),
+      { caller: { kind: "arn", arn: archiver.Arn } },
+    );
+
+    // Then the copy is there.
+    const copied = await simS3.getObject(
+      new GetObjectCommand({ Bucket: archive, Key: "2026/report.pdf" }),
+    );
+
+    assertInstanceOf(copied.Body, Readable);
+    assertBufferEqual(
+      await simS3BodyToBuffer(copied.Body),
+      Buffer.from("quarterly figures"),
+    );
+  });
+
+  it("denies a Role that may write the destination but not read the source", async () => {
+    // Given a Role allowed to write into the archive and nothing else. A
+    // caller holding only this would have looked sufficient to code that
+    // copies by putting an Object.
+    const simAws = new SimAws();
+    const simS3 = simAws.s3();
+    const inbox = `inbox-${faker.string.uuid()}`;
+    const archive = `archive-${faker.string.uuid()}`;
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: inbox }));
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: archive }));
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: inbox,
+        Key: "report.pdf",
+        Body: "quarterly figures",
+      }),
+    );
+
+    const writer = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "ArchiveWriterRole",
+        actions: ["s3:PutObject"],
+        resource: `arn:aws:s3:::${archive}/*`,
+      },
+      simAws,
+    );
+
+    // When it tries to copy the Object it cannot read.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.copyObject(
+        new CopyObjectCommand({
+          Bucket: archive,
+          Key: "2026/report.pdf",
+          CopySource: `${inbox}/report.pdf`,
+        }),
+        { caller: { kind: "arn", arn: writer.Arn } },
+      ),
+    );
+
+    // Then the read is what refuses it.
+    assertIdentical(error.name, "AccessDenied");
+    assertStringIncludes(error.message, "s3:GetObject");
+  });
+
+  it("denies a Role that may read the source but not write the destination", async () => {
+    // Given a Role allowed to read the inbox and nothing else.
+    const simAws = new SimAws();
+    const simS3 = simAws.s3();
+    const inbox = `inbox-${faker.string.uuid()}`;
+    const archive = `archive-${faker.string.uuid()}`;
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: inbox }));
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: archive }));
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: inbox,
+        Key: "report.pdf",
+        Body: "quarterly figures",
+      }),
+    );
+
+    const reader = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "InboxReaderRole",
+        actions: ["s3:GetObject"],
+        resource: `arn:aws:s3:::${inbox}/*`,
+      },
+      simAws,
+    );
+
+    // When it tries to copy into the archive.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.copyObject(
+        new CopyObjectCommand({
+          Bucket: archive,
+          Key: "2026/report.pdf",
+          CopySource: `${inbox}/report.pdf`,
+        }),
+        { caller: { kind: "arn", arn: reader.Arn } },
+      ),
+    );
+
+    // Then the write is what refuses it, and the destination key was left
+    // empty rather than written before the decision.
+    assertIdentical(error.name, "AccessDenied");
+    assertStringIncludes(error.message, "s3:PutObject");
+
+    const stored = await simS3
+      .getSimBucketByName(archive)
+      ?.getObject("2026/report.pdf");
+    assertUndefined(stored);
+  });
+});

--- a/src/service/s3/command/copy-object/copy-object-refusals.iso.test.ts
+++ b/src/service/s3/command/copy-object/copy-object-refusals.iso.test.ts
@@ -146,7 +146,7 @@ describe("S3 CopyObjectCommand refusals", () => {
     assertIdentical(error.name, "InvalidArgument");
   });
 
-  it("refuses a source that is not URL-encoded", async () => {
+  it("refuses a source holding a malformed percent escape", async () => {
     // Given a Bucket a copy names a badly encoded key in.
     const simAws = new SimAws();
     const simS3 = simAws.s3();

--- a/src/service/s3/command/copy-object/copy-object-refusals.iso.test.ts
+++ b/src/service/s3/command/copy-object/copy-object-refusals.iso.test.ts
@@ -1,0 +1,172 @@
+import {
+  CopyObjectCommand,
+  CreateBucketCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { faker } from "@faker-js/faker";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+
+describe("S3 CopyObjectCommand refusals", () => {
+  it("reports a missing source Object as NoSuchKey", async () => {
+    // Given a Bucket that has never held the key the copy names.
+    const simAws = new SimAws();
+    const simS3 = simAws.s3();
+    const bucketName = `documents-${faker.string.uuid()}`;
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+
+    // When a copy names it as its source.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.copyObject(
+        new CopyObjectCommand({
+          Bucket: bucketName,
+          Key: "there.txt",
+          CopySource: `${bucketName}/missing.txt`,
+        }),
+      ),
+    );
+
+    // Then S3's missing-Object error is what comes back.
+    assertIdentical(error.name, "NoSuchKey");
+  });
+
+  it("reports a missing source Bucket as NoSuchBucket", async () => {
+    // Given a destination Bucket and a source Bucket that was never created.
+    const simAws = new SimAws();
+    const simS3 = simAws.s3();
+    const bucketName = `documents-${faker.string.uuid()}`;
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+
+    // When a copy reads from the Bucket that is not there.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.copyObject(
+        new CopyObjectCommand({
+          Bucket: bucketName,
+          Key: "there.txt",
+          CopySource: "no-such-bucket/anything.txt",
+        }),
+      ),
+    );
+
+    // Then it is the Bucket that is reported missing, not the key.
+    assertIdentical(error.name, "NoSuchBucket");
+  });
+
+  it("refuses a copy of an Object onto itself that changes nothing", async () => {
+    // Given an Object a caller is about to copy over itself.
+    const simAws = new SimAws();
+    const simS3 = simAws.s3();
+    const bucketName = `documents-${faker.string.uuid()}`;
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: bucketName,
+        Key: "same.txt",
+        Body: "unchanged",
+      }),
+    );
+
+    // When the copy names the same Bucket and key, with no metadata directive.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.copyObject(
+        new CopyObjectCommand({
+          Bucket: bucketName,
+          Key: "same.txt",
+          CopySource: `${bucketName}/same.txt`,
+        }),
+      ),
+    );
+
+    // Then real S3's refusal is what comes back, because the copy would leave
+    // the Object exactly as it found it.
+    assertIdentical(error.name, "InvalidRequest");
+    assertStringIncludes(error.message, "copy an object to itself");
+  });
+
+  it("refuses a source naming a versionId", async () => {
+    // Given a Bucket holding the Object a versioned copy would read.
+    const simAws = new SimAws();
+    const simS3 = simAws.s3();
+    const bucketName = `documents-${faker.string.uuid()}`;
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: bucketName,
+        Key: "versioned.txt",
+        Body: "one version",
+      }),
+    );
+
+    // When the copy asks for a particular version of it.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.copyObject(
+        new CopyObjectCommand({
+          Bucket: bucketName,
+          Key: "copy.txt",
+          CopySource: `${bucketName}/versioned.txt?versionId=abc123`,
+        }),
+      ),
+    );
+
+    // Then it is refused by name rather than copying the only version there is.
+    assertIdentical(error.name, "NotImplemented");
+    assertStringIncludes(error.message, "versionId");
+  });
+
+  it("refuses a source that names no Object key", async () => {
+    // Given a Bucket a malformed copy names as its whole source.
+    const simAws = new SimAws();
+    const simS3 = simAws.s3();
+    const bucketName = `documents-${faker.string.uuid()}`;
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+
+    // When the copy's source is a Bucket on its own.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.copyObject(
+        new CopyObjectCommand({
+          Bucket: bucketName,
+          Key: "copy.txt",
+          CopySource: bucketName,
+        }),
+      ),
+    );
+
+    // Then the argument is reported rather than read as a key.
+    assertIdentical(error.name, "InvalidArgument");
+  });
+
+  it("refuses a source that is not URL-encoded", async () => {
+    // Given a Bucket a copy names a badly encoded key in.
+    const simAws = new SimAws();
+    const simS3 = simAws.s3();
+    const bucketName = `documents-${faker.string.uuid()}`;
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+
+    // When the source carries a percent sign that starts no escape.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.copyObject(
+        new CopyObjectCommand({
+          Bucket: bucketName,
+          Key: "copy.txt",
+          CopySource: `${bucketName}/100%discount.txt`,
+        }),
+      ),
+    );
+
+    // Then the source is reported as unreadable rather than guessed at.
+    assertIdentical(error.name, "InvalidArgument");
+    assertStringIncludes(error.message, "URL-encoded");
+  });
+});

--- a/src/service/s3/command/copy-object/copy-object-source.ts
+++ b/src/service/s3/command/copy-object/copy-object-source.ts
@@ -1,0 +1,126 @@
+import type {
+  SimS3Bucket,
+  SimS3BucketName,
+} from "../../bucket/sim-s3-bucket.js";
+import {
+  SimS3InvalidArgument,
+  SimS3InvalidRequest,
+  SimS3NoSuchKey,
+  SimS3NotImplemented,
+} from "../../error/sim-s3.error.js";
+import type { SimS3Object } from "../../object/s3-object.js";
+
+/**
+ * The Object a copy reads from.
+ */
+export interface SimS3CopySource {
+  readonly bucketName: SimS3BucketName;
+  readonly key: string;
+}
+
+/**
+ * Read a `CopySource` as the Bucket and key it names.
+ *
+ * Real S3 takes the source as `sourceBucket/sourceKey`, URL-encoded, and
+ * accepts a leading slash on it. Everything after the first slash is the key,
+ * because a key can hold slashes of its own. Each segment is decoded on its
+ * own, the way the REST endpoint decodes a key out of a request path. A source
+ * with nothing encoded in it comes through unchanged.
+ *
+ * https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html
+ */
+export function simS3CopySource(source: string): SimS3CopySource {
+  const [path, versionId] = splitVersionId(source);
+
+  if (versionId !== undefined) {
+    throw new SimS3NotImplemented(
+      `The CopySource ${source} names a versionId. Simulated S3 does not ` +
+        `model Object versions.`,
+    );
+  }
+
+  const segments = path.replace(/^\//, "").split("/").map(decodeSegment);
+  const [bucketName, ...keySegments] = segments;
+  const key = keySegments.join("/");
+
+  if (bucketName === undefined || bucketName === "" || key === "") {
+    throw new SimS3InvalidArgument(
+      `The CopySource ${source} does not name a Bucket and an Object key.`,
+    );
+  }
+
+  return { bucketName: bucketName as SimS3BucketName, key };
+}
+
+/**
+ * Separate the version a source asks for from the Object it names.
+ */
+function splitVersionId(source: string): [string, string | undefined] {
+  const marker = source.indexOf("?versionId=");
+
+  if (marker === -1) {
+    return [source, undefined];
+  }
+
+  return [source.slice(0, marker), source.slice(marker + "?versionId=".length)];
+}
+
+/**
+ * Decode one segment of a source, leaving a segment that was never encoded as
+ * it is.
+ *
+ * A stray percent sign makes `decodeURIComponent` throw, and real S3 answers
+ * `InvalidArgument` for a source it cannot read.
+ */
+function decodeSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    throw new SimS3InvalidArgument(
+      `The CopySource segment ${segment} is not URL-encoded.`,
+    );
+  }
+}
+
+/**
+ * Read the Object a copy takes its bytes from.
+ *
+ * The caller has already been authorized to read it. That is what keeps a
+ * refused caller from learning whether the key exists.
+ */
+export async function simS3CopySourceObject(
+  bucket: SimS3Bucket,
+  key: string,
+): Promise<SimS3Object> {
+  const object = await bucket.getObject(key);
+
+  if (object === undefined) {
+    throw new SimS3NoSuchKey(`No S3 Object named ${key}`);
+  }
+
+  return object;
+}
+
+/**
+ * Refuse a copy that would write an Object back over itself unchanged.
+ *
+ * Real S3 treats this as a request that cannot mean what it says, because the
+ * copy would leave the Object exactly as it found it. `REPLACE` gives it a
+ * meaning. It rewrites the Object's metadata in place.
+ */
+export function simS3RefuseUnchangedSelfCopy(
+  source: SimS3CopySource,
+  destination: SimS3CopySource,
+  metadataDirective: string | undefined,
+): void {
+  const sameObject =
+    source.key === destination.key &&
+    source.bucketName === destination.bucketName;
+
+  if (sameObject && metadataDirective !== "REPLACE") {
+    throw new SimS3InvalidRequest(
+      `This copy request is illegal because it is trying to copy an object ` +
+        `to itself without changing the object's metadata.`,
+    );
+  }
+}

--- a/src/service/s3/command/copy-object/copy-object.command.ts
+++ b/src/service/s3/command/copy-object/copy-object.command.ts
@@ -1,0 +1,44 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimS3ObjectWriteMetadata } from "../../object/s3-write-metadata.js";
+
+/**
+ * Minimal structural sim S3 CopyObject command.
+ */
+export interface SimCopyObjectCommand {
+  readonly input: SimCopyObjectCommandInput;
+}
+
+/**
+ * Minimal structural sim S3 CopyObject input.
+ *
+ * The write metadata members are the same ones `PutObject` carries, and they
+ * apply to the destination Object under `MetadataDirective: REPLACE`. Under
+ * the default `COPY` they are ignored, as real S3 ignores them.
+ */
+export interface SimCopyObjectCommandInput extends SimS3ObjectWriteMetadata {
+  readonly Bucket?: string | undefined;
+  readonly Key?: string | undefined;
+  /** The source Object, as `sourceBucket/sourceKey`, URL-encoded. */
+  readonly CopySource?: string | undefined;
+  readonly MetadataDirective?: string | undefined;
+}
+
+/**
+ * Minimal structural sim S3 CopyObject output.
+ *
+ * The copy's own ETag and write time arrive nested in `CopyObjectResult`
+ * rather than at the top level, because real S3 sends them in the response
+ * body and the top-level headers describe the request.
+ */
+export interface SimCopyObjectCommandOutput {
+  readonly CopyObjectResult?: SimCopyObjectResult;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * What a copy says about the Object it wrote.
+ */
+export interface SimCopyObjectResult {
+  readonly ETag?: string;
+  readonly LastModified?: Date;
+}

--- a/src/service/s3/command/copy-object/copy-object.handler.ts
+++ b/src/service/s3/command/copy-object/copy-object.handler.ts
@@ -1,0 +1,135 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type {
+  SimS3Bucket,
+  SimS3BucketName,
+} from "../../bucket/sim-s3-bucket.js";
+import type { SimS3ObjectNotifier } from "../../notification/sim-s3-object-notifier.js";
+import { simS3QuotedETag } from "../../object/s3-object-etag.js";
+import { GetObjectAuthorizer } from "../get-object/get-object-authorizer.js";
+import { PutObjectAuthorizer } from "../put-object/put-object-authorizer.js";
+import { requireSimS3Bucket } from "../require-sim-s3-bucket.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
+import { CopyObjectBuilder } from "./copy-object-builder.js";
+import {
+  simS3CopySource,
+  simS3CopySourceObject,
+  simS3RefuseUnchangedSelfCopy,
+} from "./copy-object-source.js";
+import type {
+  SimCopyObjectCommand,
+  SimCopyObjectCommandOutput,
+} from "./copy-object.command.js";
+
+interface CopyObjectCommandHandlerProperties {
+  readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+  readonly notifications: SimS3ObjectNotifier;
+}
+
+/**
+ * Simulated S3 CopyObjectCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/s3/command/CopyObjectCommand/
+ */
+export class CopyObjectCommandHandler implements CommandHandler<
+  SimCopyObjectCommand,
+  SimCopyObjectCommandOutput
+> {
+  private readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  private readonly sourceAuthorizer: GetObjectAuthorizer;
+  private readonly destinationAuthorizer: PutObjectAuthorizer;
+  private readonly objectBuilder: CopyObjectBuilder;
+  private readonly background: BackgroundScheduler;
+  private readonly notifications: SimS3ObjectNotifier;
+
+  constructor(properties: CopyObjectCommandHandlerProperties) {
+    const {
+      buckets,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.buckets = buckets;
+    this.sourceAuthorizer = new GetObjectAuthorizer({ iam });
+    this.destinationAuthorizer = new PutObjectAuthorizer({ iam });
+    this.background = background;
+    this.objectBuilder = new CopyObjectBuilder({ clock: background });
+    this.notifications = properties.notifications;
+  }
+
+  /**
+   * Simulate copying one S3 Object to another.
+   *
+   * A copy is a read and a write in one request, and it authorizes as both.
+   * `s3:GetObject` on the source and `s3:PutObject` on the destination are
+   * separate decisions against separate Bucket policies. A caller holding one
+   * and not the other is refused.
+   *
+   * Both Buckets are found and the request checked for sense before either
+   * decision. That keeps a malformed request and a missing Bucket answering
+   * what real S3 answers. The source Object is read after authorization, which
+   * leaves a refused caller knowing nothing about which keys exist.
+   */
+  async handle(
+    command: SimCopyObjectCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimCopyObjectCommandOutput> {
+    assertDefined(command.input.Bucket, "CopyObjectCommand.input.Bucket");
+    assertDefined(command.input.Key, "CopyObjectCommand.input.Key");
+    assertDefined(
+      command.input.CopySource,
+      "CopyObjectCommand.input.CopySource",
+    );
+
+    const bucketName = command.input.Bucket as SimS3BucketName;
+    const key = command.input.Key;
+    const destination = requireSimS3Bucket(this.buckets, bucketName);
+    const from = simS3CopySource(command.input.CopySource);
+    const source = requireSimS3Bucket(this.buckets, from.bucketName);
+
+    simS3RefuseUnchangedSelfCopy(
+      from,
+      { bucketName, key },
+      command.input.MetadataDirective,
+    );
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    this.sourceAuthorizer.authorize(source, from.key, options);
+    const caller = this.destinationAuthorizer.authorize(
+      destination,
+      key,
+      options,
+    );
+
+    const stored = await simS3CopySourceObject(source, from.key);
+    const object = this.objectBuilder.build(command.input, key, stored);
+    await destination.putObject(object);
+
+    this.notifications.objectCreated({
+      bucket: destination,
+      object,
+      caller,
+      eventName: "s3:ObjectCreated:Copy",
+    });
+
+    return {
+      CopyObjectResult: {
+        ETag: simS3QuotedETag(object.etag),
+        LastModified: object.lastModified,
+      },
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/s3/command/copy-object/copy-object.iso.test.ts
+++ b/src/service/s3/command/copy-object/copy-object.iso.test.ts
@@ -1,0 +1,298 @@
+import {
+  CopyObjectCommand,
+  CreateBucketCommand,
+  GetObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import {
+  assertBufferEqual,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertUndefined,
+} from "@kensio/smartass";
+import { faker } from "@faker-js/faker";
+import { Readable } from "node:stream";
+import { describe, it } from "vitest";
+
+import { SimSdk } from "../../../../sdk/index.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simS3BodyToBuffer } from "../../storage/s3-body-buffer.js";
+
+describe("S3 CopyObjectCommand", () => {
+  it("copies an Object to another key in the same Bucket", async () => {
+    // Given an Object a caller wants to rename.
+    const simAws = new SimAws();
+    const simS3 = simAws.s3();
+    const bucketName = `documents-${faker.string.uuid()}`;
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: bucketName,
+        Key: "draft.txt",
+        Body: "the report",
+      }),
+    );
+
+    // When it is copied to the name it should have.
+    await simS3.copyObject(
+      new CopyObjectCommand({
+        Bucket: bucketName,
+        Key: "final.txt",
+        CopySource: `${bucketName}/draft.txt`,
+      }),
+    );
+
+    // Then both keys hold the same bytes, because a copy leaves the source.
+    const copied = await simS3.getObject(
+      new GetObjectCommand({ Bucket: bucketName, Key: "final.txt" }),
+    );
+    const original = await simS3.getObject(
+      new GetObjectCommand({ Bucket: bucketName, Key: "draft.txt" }),
+    );
+
+    assertInstanceOf(copied.Body, Readable);
+    assertInstanceOf(original.Body, Readable);
+    assertBufferEqual(
+      await simS3BodyToBuffer(copied.Body),
+      Buffer.from("the report"),
+    );
+    assertBufferEqual(
+      await simS3BodyToBuffer(original.Body),
+      Buffer.from("the report"),
+    );
+  });
+
+  it("copies an Object into another Bucket and reports its ETag", async () => {
+    // Given an Object in the Bucket an archive is taken from.
+    const simAws = new SimAws();
+    const simS3 = simAws.s3();
+    const inbox = `inbox-${faker.string.uuid()}`;
+    const archive = `archive-${faker.string.uuid()}`;
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: inbox }));
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: archive }));
+
+    const put = await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: inbox,
+        Key: "report.pdf",
+        Body: "quarterly figures",
+      }),
+    );
+
+    // When it is copied into the archive Bucket under a dated key.
+    const copy = await simS3.copyObject(
+      new CopyObjectCommand({
+        Bucket: archive,
+        Key: "2026/report.pdf",
+        CopySource: `${inbox}/report.pdf`,
+      }),
+    );
+
+    // Then the copy carries the same content ETag the source was stored under.
+    assertIdentical(copy.CopyObjectResult?.ETag, put.ETag);
+    assertInstanceOf(copy.CopyObjectResult?.LastModified, Date);
+
+    const copied = await simS3.getObject(
+      new GetObjectCommand({ Bucket: archive, Key: "2026/report.pdf" }),
+    );
+    assertInstanceOf(copied.Body, Readable);
+    assertBufferEqual(
+      await simS3BodyToBuffer(copied.Body),
+      Buffer.from("quarterly figures"),
+    );
+  });
+
+  it("carries the source's metadata across by default", async () => {
+    // Given an Object described by both user and system metadata.
+    const simAws = new SimAws();
+    const simS3 = simAws.s3();
+    const bucketName = `assets-${faker.string.uuid()}`;
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: bucketName,
+        Key: "logo.svg",
+        Body: "<svg />",
+        ContentType: "image/svg+xml",
+        Metadata: { designer: "in-house" },
+      }),
+    );
+
+    // When it is copied without saying what the copy's metadata should be.
+    await simS3.copyObject(
+      new CopyObjectCommand({
+        Bucket: bucketName,
+        Key: "logo-backup.svg",
+        CopySource: `${bucketName}/logo.svg`,
+      }),
+    );
+
+    // Then the copy is described the same way the source was.
+    const copied = await simS3.getObject(
+      new GetObjectCommand({ Bucket: bucketName, Key: "logo-backup.svg" }),
+    );
+
+    const metadata = copied.Metadata ?? {};
+    assertIdentical(metadata["content-type"], "image/svg+xml");
+    assertIdentical(metadata["designer"], "in-house");
+  });
+
+  it("takes the copy's metadata from the request under REPLACE", async () => {
+    // Given an Object whose metadata is about to be corrected in place.
+    const simAws = new SimAws();
+    const simS3 = simAws.s3();
+    const bucketName = `assets-${faker.string.uuid()}`;
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: bucketName,
+        Key: "page.html",
+        Body: "<p>hello</p>",
+        ContentType: "application/octet-stream",
+        Metadata: { stale: "yes" },
+      }),
+    );
+
+    // When it is copied over itself with a directive to replace the metadata.
+    await simS3.copyObject(
+      new CopyObjectCommand({
+        Bucket: bucketName,
+        Key: "page.html",
+        CopySource: `${bucketName}/page.html`,
+        MetadataDirective: "REPLACE",
+        ContentType: "text/html",
+        Metadata: { reviewed: "2026-08" },
+      }),
+    );
+
+    // Then the request's metadata is what the Object now carries, and the
+    // source's is gone rather than merged with it.
+    const copied = await simS3.getObject(
+      new GetObjectCommand({ Bucket: bucketName, Key: "page.html" }),
+    );
+
+    const metadata = copied.Metadata ?? {};
+    assertIdentical(metadata["content-type"], "text/html");
+    assertIdentical(metadata["reviewed"], "2026-08");
+    assertUndefined(metadata["stale"]);
+  });
+
+  it("copies a key holding a slash and a space", async () => {
+    // Given an Object under a key the SDK has to encode into the source.
+    const simAws = new SimAws();
+    const simS3 = simAws.s3();
+    const bucketName = `uploads-${faker.string.uuid()}`;
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: bucketName,
+        Key: "invoices/2026 Q1/summary.csv",
+        Body: "total,100",
+      }),
+    );
+
+    // When it is copied with the source URL-encoded, as real S3 requires.
+    await simS3.copyObject(
+      new CopyObjectCommand({
+        Bucket: bucketName,
+        Key: "invoices/latest.csv",
+        CopySource: `/${bucketName}/invoices/2026%20Q1/summary.csv`,
+      }),
+    );
+
+    // Then the encoded source named the Object it was meant to.
+    const copied = await simS3.getObject(
+      new GetObjectCommand({ Bucket: bucketName, Key: "invoices/latest.csv" }),
+    );
+
+    assertInstanceOf(copied.Body, Readable);
+    assertBufferEqual(
+      await simS3BodyToBuffer(copied.Body),
+      Buffer.from("total,100"),
+    );
+  });
+
+  it("leaves the copy unchanged when the source's bytes are written into", async () => {
+    // Given an Object that has been copied.
+    const simAws = new SimAws();
+    const simS3 = simAws.s3();
+    const bucketName = `uploads-${faker.string.uuid()}`;
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: bucketName,
+        Key: "source.bin",
+        Body: new Uint8Array([1, 2, 3]),
+      }),
+    );
+    await simS3.copyObject(
+      new CopyObjectCommand({
+        Bucket: bucketName,
+        Key: "copy.bin",
+        CopySource: `${bucketName}/source.bin`,
+      }),
+    );
+
+    // When the source Object is replaced with different bytes.
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: bucketName,
+        Key: "source.bin",
+        Body: new Uint8Array([9, 9, 9]),
+      }),
+    );
+
+    // Then the copy still holds what it was copied from.
+    const copied = await simS3.getObject(
+      new GetObjectCommand({ Bucket: bucketName, Key: "copy.bin" }),
+    );
+
+    assertInstanceOf(copied.Body, Readable);
+    assertBufferEqual(
+      await simS3BodyToBuffer(copied.Body),
+      Buffer.from([1, 2, 3]),
+    );
+  });
+
+  it("copies through an intercepted SDK client", async () => {
+    // Given an S3 client whose Commands reach the simulation.
+    using simSdk = new SimSdk();
+    const client = new S3Client({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    const bucketName = `intercepted-${faker.string.uuid()}`;
+    await client.send(new CreateBucketCommand({ Bucket: bucketName }));
+    await client.send(
+      new PutObjectCommand({
+        Bucket: bucketName,
+        Key: "one.txt",
+        Body: "intercepted",
+      }),
+    );
+
+    // When the client sends a copy.
+    const copy = await client.send(
+      new CopyObjectCommand({
+        Bucket: bucketName,
+        Key: "two.txt",
+        CopySource: `${bucketName}/one.txt`,
+      }),
+    );
+
+    // Then the Command was routed and the copy is readable.
+    assertStringIncludes(copy.CopyObjectResult?.ETag ?? "", '"');
+
+    const copied = await client.send(
+      new GetObjectCommand({ Bucket: bucketName, Key: "two.txt" }),
+    );
+    assertIdentical(await copied.Body?.transformToString(), "intercepted");
+  });
+});

--- a/src/service/s3/command/copy-object/copy-object.iso.test.ts
+++ b/src/service/s3/command/copy-object/copy-object.iso.test.ts
@@ -295,4 +295,43 @@ describe("S3 CopyObjectCommand", () => {
     );
     assertIdentical(await copied.Body?.transformToString(), "intercepted");
   });
+
+  it("copies from a source that was never encoded", async () => {
+    // Given an Object under a key with a space in it. Real S3 wants a source
+    // URL-encoded, and a caller reaching the simulator directly writes the key
+    // out as it is.
+    const simAws = new SimAws();
+    const simS3 = simAws.s3();
+    const bucketName = `uploads-${faker.string.uuid()}`;
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: bucketName,
+        Key: "invoices/100 discount.txt",
+        Body: "ten percent",
+      }),
+    );
+
+    // When the source carries that space unencoded.
+    await simS3.copyObject(
+      new CopyObjectCommand({
+        Bucket: bucketName,
+        Key: "invoices/latest.txt",
+        CopySource: `${bucketName}/invoices/100 discount.txt`,
+      }),
+    );
+
+    // Then it named the Object, because decoding a segment that holds no
+    // escape leaves it alone.
+    const copied = await simS3.getObject(
+      new GetObjectCommand({ Bucket: bucketName, Key: "invoices/latest.txt" }),
+    );
+
+    assertInstanceOf(copied.Body, Readable);
+    assertBufferEqual(
+      await simS3BodyToBuffer(copied.Body),
+      Buffer.from("ten percent"),
+    );
+  });
 });

--- a/src/service/s3/command/object/sim-s3-object-commands.ts
+++ b/src/service/s3/command/object/sim-s3-object-commands.ts
@@ -1,3 +1,4 @@
+import { CopyObjectCommandHandler } from "../copy-object/copy-object.handler.js";
 import { DeleteObjectCommandHandler } from "../delete-object/delete-object.handler.js";
 import { DeleteObjectsCommandHandler } from "../delete-objects/delete-objects.handler.js";
 import { GetObjectCommandHandler } from "../get-object/get-object.handler.js";
@@ -34,6 +35,19 @@ export class SimS3ObjectCommands {
     options?: SimS3RequestOptions,
   ): Promise<simS3Commands.SimPutObjectCommandOutput> {
     return await new PutObjectCommandHandler(this.state).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Copy an Object to another key, in this Bucket or another one.
+   */
+  async copy(
+    command: simS3Commands.SimCopyObjectCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimCopyObjectCommandOutput> {
+    return await new CopyObjectCommandHandler(this.state).handle(
       command,
       options,
     );

--- a/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-destination-refusals.iso.test.ts
+++ b/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-destination-refusals.iso.test.ts
@@ -135,7 +135,7 @@ describe("What a simulated S3 notification destination refuses", () => {
           NotificationConfiguration: {
             LambdaFunctionConfigurations: [
               {
-                Events: ["s3:ObjectCreated:Copy"],
+                Events: ["s3:ObjectCreated:Post"],
                 LambdaFunctionArn: thumbnailerArn,
               },
             ],
@@ -147,7 +147,7 @@ describe("What a simulated S3 notification destination refuses", () => {
     // Then it is refused as unsimulated rather than accepted and never
     // delivered
     assertIdentical(error.name, "NotImplemented");
-    assertStringIncludes(error.message, "s3:ObjectCreated:Copy");
+    assertStringIncludes(error.message, "s3:ObjectCreated:Post");
   });
 
   it("refuses an event type S3 does not have", async () => {

--- a/src/service/s3/command/sim-s3-command.types.ts
+++ b/src/service/s3/command/sim-s3-command.types.ts
@@ -20,6 +20,12 @@ export type {
   SimCreateBucketCommandOutput,
 } from "./create-bucket/create-bucket.command.js";
 export type {
+  SimCopyObjectCommand,
+  SimCopyObjectCommandInput,
+  SimCopyObjectCommandOutput,
+  SimCopyObjectResult,
+} from "./copy-object/copy-object.command.js";
+export type {
   SimDeleteBucketCommand,
   SimDeleteBucketCommandOutput,
 } from "./delete-bucket/delete-bucket.command.js";

--- a/src/service/s3/error/sim-s3.error.ts
+++ b/src/service/s3/error/sim-s3.error.ts
@@ -236,3 +236,18 @@ export class SimS3InvalidRange extends SimS3Error {
     super(message, { httpStatusCode: 416 });
   }
 }
+
+/**
+ * Simulated S3 InvalidRequest error.
+ *
+ * A request real S3 understands and refuses to carry out. A CopyObject naming
+ * the same Object as its source and its destination, with nothing about the
+ * Object being changed, is the one sim S3 raises it for.
+ */
+export class SimS3InvalidRequest extends SimS3Error {
+  public override readonly name = "InvalidRequest";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}

--- a/src/service/s3/notification/sim-s3-object-copied-notification.iso.test.ts
+++ b/src/service/s3/notification/sim-s3-object-copied-notification.iso.test.ts
@@ -1,0 +1,191 @@
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  CopyObjectCommand,
+  CreateBucketCommand,
+  type Event as S3NotificationEvent,
+  PutBucketNotificationConfigurationCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { assertArrayLength, assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../lambda/function/code/lambda-zip-file-input.js";
+
+const archiverArn = "arn:aws:lambda:us-east-1:888888888888:function:archiver";
+
+/**
+ * As much of the event document as these tests read.
+ */
+interface S3EventDocument {
+  readonly Records: readonly [
+    {
+      readonly eventName: string;
+      readonly s3: {
+        readonly bucket: { readonly name: string };
+        readonly object: { readonly key: string; readonly size?: number };
+      };
+    },
+  ];
+}
+
+describe("Notifying a simulated Lambda function of a copied Object", () => {
+  /**
+   * A Bucket that invokes a recording function for the events it is given.
+   *
+   * Both tests need the same wiring and differ only in the events they
+   * configure, so this stays here rather than becoming a shared factory.
+   */
+  const bucketNotifying = async (
+    simAws: SimAws,
+    bucketName: string,
+    events: S3NotificationEvent[],
+  ): Promise<S3EventDocument[]> => {
+    const received: S3EventDocument[] = [];
+
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "archiver",
+        Role: "arn:aws:iam::888888888888:role/ArchiverRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput((event: S3EventDocument) => {
+            received.push(event);
+
+            return "archived";
+          }),
+        },
+      }),
+    );
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "archiver",
+        StatementId: "AllowS3",
+        Action: "lambda:InvokeFunction",
+        Principal: "s3.amazonaws.com",
+        SourceArn: `arn:aws:s3:::${bucketName}`,
+        SourceAccount: simAws.defaultAccountId,
+      }),
+    );
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: bucketName,
+        NotificationConfiguration: {
+          LambdaFunctionConfigurations: [
+            { Events: events, LambdaFunctionArn: archiverArn },
+          ],
+        },
+      }),
+    );
+
+    return received;
+  };
+
+  it("raises ObjectCreated:Copy on the destination Bucket", async () => {
+    // Given an archive Bucket that notifies a function when an Object is
+    // copied into it, and an Object waiting to be copied.
+    const simAws = new SimAws();
+    const received = await bucketNotifying(simAws, "archive", [
+      "s3:ObjectCreated:Copy",
+    ]);
+
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "inbox" }));
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "inbox",
+        Key: "report.pdf",
+        Body: "quarterly figures",
+      }),
+    );
+
+    // When the Object is copied into the archive.
+    await simAws.s3().copyObject(
+      new CopyObjectCommand({
+        Bucket: "archive",
+        Key: "2026/report.pdf",
+        CopySource: "inbox/report.pdf",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the function was told about the copy, and told it was a copy rather
+    // than a put.
+    assertArrayLength(received, 1);
+    const record = received[0].Records[0];
+    const copiedBytes = record.s3.object.size;
+
+    assertIdentical(record.eventName, "ObjectCreated:Copy");
+    assertIdentical(record.s3.bucket.name, "archive");
+    assertIdentical(record.s3.object.key, "2026/report.pdf");
+    assertIdentical(copiedBytes, "quarterly figures".length);
+  });
+
+  it("covers a copy with the ObjectCreated wildcard", async () => {
+    // Given a Bucket configured for every kind of Object creation.
+    const simAws = new SimAws();
+    const received = await bucketNotifying(simAws, "archive", [
+      "s3:ObjectCreated:*",
+    ]);
+
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "inbox" }));
+    await simAws
+      .s3()
+      .putObject(
+        new PutObjectCommand({ Bucket: "inbox", Key: "one.txt", Body: "one" }),
+      );
+
+    // When an Object is copied into it.
+    await simAws.s3().copyObject(
+      new CopyObjectCommand({
+        Bucket: "archive",
+        Key: "one.txt",
+        CopySource: "inbox/one.txt",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the wildcard covered the copy, as it covers a put.
+    assertArrayLength(received, 1);
+    assertIdentical(received[0].Records[0].eventName, "ObjectCreated:Copy");
+  });
+
+  it("leaves a Bucket configured only for Put alone", async () => {
+    // Given a Bucket that asked for puts and nothing else.
+    const simAws = new SimAws();
+    const received = await bucketNotifying(simAws, "archive", [
+      "s3:ObjectCreated:Put",
+    ]);
+
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "inbox" }));
+    await simAws
+      .s3()
+      .putObject(
+        new PutObjectCommand({ Bucket: "inbox", Key: "one.txt", Body: "one" }),
+      );
+
+    // When an Object is copied into it.
+    await simAws.s3().copyObject(
+      new CopyObjectCommand({
+        Bucket: "archive",
+        Key: "one.txt",
+        CopySource: "inbox/one.txt",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then nothing was delivered, because real S3 keeps a copy and a put
+    // apart.
+    assertArrayLength(received, 0);
+  });
+});

--- a/src/service/s3/sdk/sim-s3-sdk-command-router.iso.test.ts
+++ b/src/service/s3/sdk/sim-s3-sdk-command-router.iso.test.ts
@@ -273,7 +273,8 @@ describe("simulated S3 SDK Command routing", () => {
 
     const supported = router.supportedCommandNames();
 
-    assertArrayLength(supported, 26);
+    assertArrayLength(supported, 27);
+    assertArrayIncludes(supported, "CopyObjectCommand");
     assertArrayIncludes(supported, "GetObjectCommand");
     assertArrayIncludes(supported, "ListObjectsV2Command");
     assertArrayIncludes(supported, "DeleteBucketCommand");

--- a/src/service/s3/sdk/sim-s3-sdk-command-router.ts
+++ b/src/service/s3/sdk/sim-s3-sdk-command-router.ts
@@ -6,6 +6,7 @@ import type {
 import { simSdkCallerOptions, simSdkStreamBody } from "../../../sdk/index.js";
 import type { SimAbortMultipartUploadCommand } from "../command/abort-multipart-upload/abort-multipart-upload.command.js";
 import type { SimCompleteMultipartUploadCommand } from "../command/complete-multipart-upload/complete-multipart-upload.command.js";
+import type { SimCopyObjectCommand } from "../command/copy-object/copy-object.command.js";
 import type { SimCreateBucketCommand } from "../command/create-bucket/create-bucket.command.js";
 import type { SimCreateMultipartUploadCommand } from "../command/create-multipart-upload/create-multipart-upload.command.js";
 import type { SimListMultipartUploadsCommand } from "../command/list-multipart-uploads/list-multipart-uploads.command.js";
@@ -48,6 +49,14 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simS3.createBucket(
             command as SimCreateBucketCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "CopyObjectCommand",
+        async (command, context): Promise<unknown> =>
+          await simS3.copyObject(
+            command as SimCopyObjectCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/s3/sim-s3-operations.ts
+++ b/src/service/s3/sim-s3-operations.ts
@@ -36,6 +36,14 @@ export abstract class SimS3Operations {
     return await this.commands.objects.head(command, options);
   }
 
+  /** Handle a Copy Object Command from the SDK. */
+  async copyObject(
+    command: simS3Commands.SimCopyObjectCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimCopyObjectCommandOutput> {
+    return await this.commands.objects.copy(command, options);
+  }
+
   /** Handle a Delete Bucket Command from the SDK. */
   async deleteBucket(
     command: simS3Commands.SimDeleteBucketCommand,


### PR DESCRIPTION
`CopyObjectCommand` reads the Object named by `CopySource` and writes its bytes under the destination `Bucket` and `Key`, within one Bucket or between two in the same simulated scope. It authorizes as two decisions, `s3:GetObject` on the source and `s3:PutObject` on the destination, each against its own Bucket policy, so a caller holding one and not the other is refused. `MetadataDirective` decides whether the copy carries the source's metadata or the request's. The destination raises `s3:ObjectCreated:Copy`, which moves out of the refused-event list and into the `s3:ObjectCreated:*` expansion. A copy of an Object onto itself that changes nothing is refused with `InvalidRequest`, and a `versionId` in `CopySource` with `NotImplemented`.

Resolves #829


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated S3 `CopyObject` support for same-bucket and cross-bucket copies.
  * Supports metadata preservation or replacement, URL-encoded source keys, ETags, and modification timestamps.
  * Added authorization checks for reading the source and writing the destination.
  * Added `s3:ObjectCreated:Copy` notifications, including wildcard event support.
  * Added documentation and an example demonstrating copy and move-like workflows.

* **Bug Fixes**
  * Added validation for missing resources, invalid sources, unsupported versions, and unchanged self-copies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->