### PR TITLE
docs: correct the S3 HeadObject limitation

### DIFF
--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -2642,6 +2642,7 @@ it.
 Sim S3 currently supports:
 
 - `CreateBucketCommand` and `ListBucketsCommand`
+- `HeadObjectCommand` and `HeadBucketCommand`, describing an Object or a Bucket without reading it
 - `PutObjectCommand`, `GetObjectCommand`, `ListObjectsV2Command` and `ListObjectsCommand`, with an
   ETag and a last-modified time on every Object
 - `Delimiter` on a listing, rolling keys up into `CommonPrefixes` so a Bucket can be walked as a
@@ -2695,9 +2696,6 @@ These apply across the page. The sections above each list what is specific to th
 - `GetObjectCommand` returns system metadata through `Metadata`, under the header name it is stored
   as, rather than through the `ContentType`, `CacheControl` and other response fields real S3 uses.
   See [Object system metadata](#object-system-metadata).
-- `HeadObjectCommand` is absent from the Commands simulated S3 answers, and SDK interception leaves
-  it alone. A `HEAD` over the S3 REST endpoint is served, answering with the Object's headers and no
-  body, as a presigned `HEAD` URL uses.
 - An upload over the S3 REST endpoint keeps its `content-type` and no other system metadata, leaving
   a presigned `PUT` unable to set the rest. A `PutObjectCommand` through the SDK keeps all of them.
 - A presigned `GetObject` ignores the `response-content-type`, `response-cache-control` and other


### PR DESCRIPTION
@coderabbitai ignore

The page-wide Limitations section of the sim S3 docs said `HeadObjectCommand` was absent from the
Commands simulated S3 answers and that SDK interception left it alone. Both stopped being true when
the command landed in aa6a612d, which added the router entry, the handler, the loader and the
tests, and wrote the "Asking whether something is there" section documenting it working. The
entry is removed, and `HeadObjectCommand` and `HeadBucketCommand` are named in the Available
functionality list, where neither appeared. The `Range` on `HeadObject` limitation further up the
page is a different claim and still holds.
