### PR TITLE
feat: replace a simulated Lambda function's code

### DIFF
--- a/docs/serve/README.md
+++ b/docs/serve/README.md
@@ -479,9 +479,10 @@ aws lambda create-function --function-name orders \
   --zip-file fileb://orders.zip
 ```
 
-The operations served are sixteen of the ones simulated Lambda implements:
+The operations served are eighteen of the ones simulated Lambda implements:
 
-- **Functions** — `CreateFunction`, `GetFunction`, `DeleteFunction`, `Invoke`
+- **Functions** — `CreateFunction`, `GetFunction`, `UpdateFunctionCode`, `ListFunctions`,
+  `DeleteFunction`, `Invoke`
 - **Function URLs** — `CreateFunctionUrlConfig`, `GetFunctionUrlConfig`,
   `UpdateFunctionUrlConfig`, `DeleteFunctionUrlConfig`, `ListFunctionUrlConfigs`
 - **Permissions** — `AddPermission`, `RemovePermission`, `GetPolicy`
@@ -492,9 +493,9 @@ The version and alias operations have no route here yet, and reach the simulatio
 or SDK interception instead.
 
 Anything else is refused as `NotImplemented`, which an SDK raises under that name. The refusal names
-the path it arrived at. `aws lambda list-functions` reports that `GET /2015-03-31/functions` is
-unserved, and an unimplemented operation sharing a method with one that is served gets the same
-answer.
+the path it arrived at. `aws lambda update-function-configuration` reports that
+`PUT /2015-03-31/functions/{name}/configuration` is unserved, and an unimplemented operation sharing
+a method with one that is served gets the same answer.
 
 Simulated Lambda also answers its own Function URL hostnames, covered above. That path is unchanged,
 and it is what a browser and a webhook reach.

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -327,6 +327,96 @@ yet. A standalone `SimLambda` (constructed directly, outside `SimAws`) has no si
 fetch from. `SimAws`-created Lambda wires the same-scope sim S3 automatically, matching real
 Lambda's requirement for a same-region code bucket.
 
+## Replacing a function's code
+
+`UpdateFunctionCodeCommand` replaces the code `$LATEST` runs, taking the same four code shapes `CreateFunction` takes. It carries them at the top level of its input rather than under `Code`, as real Lambda does. A test that redeploys part-way through, or that wants a function to start failing after a few invocations, changes what runs without deleting the function.
+
+The function keeps everything else it holds. Its name, ARN, execution Role, environment variables, timeout, memory, [resource-based policy](#resource-based-policies), [Function URL](#function-urls), published versions and aliases all survive, which is what separates this from deleting the function and creating it again.
+
+```typescript sim-lambda-update-function-code
+/**
+ * Replacing the code a simulated Lambda function runs, part-way through.
+ */
+
+import {
+  CreateFunctionCommand,
+  InvokeCommand,
+  UpdateFunctionCodeCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "orders",
+    Role: "arn:aws:iam::111111111111:role/OrdersRole",
+    Code: { ZipFile: makeLambdaZipFileInput(() => ({ ok: true })) },
+  }),
+);
+
+await lambda.updateFunctionCode(
+  new UpdateFunctionCodeCommand({
+    FunctionName: "orders",
+    ZipFile: makeLambdaZipFileInput(() => {
+      throw new Error("the order service is down");
+    }),
+  }),
+);
+
+const invoked = await lambda.invoke(
+  new InvokeCommand({ FunctionName: "orders" }),
+);
+console.log(invoked.FunctionError);
+
+await simAws.backgroundTasksComplete();
+```
+
+Zip code runs under the `Handler` the function already has, because `UpdateFunctionCode` carries none of its own. Replacing a handler-reference function's code with a zip archive is refused for that reason, naming `UpdateFunctionConfiguration` as where a `Handler` would be set. That command is not simulated yet.
+
+A published version keeps the code it was published with, so a version published before an update goes on running it while `$LATEST` runs the replacement. `Publish: true` publishes a version of the replacement code and answers with that version rather than with `$LATEST`. See [Versions and aliases](#versions-and-aliases).
+
+## Listing the functions
+
+`ListFunctionsCommand` reports every function in the Account and Region, each described as `GetFunction` describes it. `FunctionVersion: "ALL"` adds each function's published versions to the listing.
+
+```typescript sim-lambda-list-functions
+/**
+ * Listing the simulated Lambda functions an Account and Region holds.
+ */
+
+import {
+  CreateFunctionCommand,
+  ListFunctionsCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+
+for (const functionName of ["orders", "invoices"]) {
+  await lambda.createFunction(
+    new CreateFunctionCommand({
+      FunctionName: functionName,
+      Role: "arn:aws:iam::111111111111:role/OrdersRole",
+      Code: { ZipFile: makeLambdaZipFileInput(() => functionName) },
+    }),
+  );
+}
+
+const listed = await lambda.listFunctions(new ListFunctionsCommand({}));
+console.log(listed.Functions.map((simFunction) => simFunction.FunctionName));
+
+await simAws.backgroundTasksComplete();
+```
+
+The listing is authorized as a whole, against `lambda:ListFunctions` on `*`, the way AWS documents the permission. A caller without it is denied rather than given a filtered list.
+
 ## The runtime-provided AWS SDK
 
 Like the real Lambda Node.js runtime, the simulated runtime provides AWS SDK v3 packages without
@@ -2812,6 +2902,10 @@ Sim Lambda currently supports:
 
 - `CreateFunctionCommand` and `GetFunctionCommand`, including a function created from the
   [simulated ECR](../ecr/ "Simulated ECR usage docs") image its `Code.ImageUri` names
+- `UpdateFunctionCodeCommand`, replacing the code `$LATEST` runs while the function keeps its
+  policy, Function URL, versions and aliases
+- `ListFunctionsCommand`, reporting every function in the Account and Region, and their published
+  versions with `FunctionVersion: "ALL"`
 - `InvokeCommand`, with the `RequestResponse`, `Event` and `DryRun` invocation types
 - Function URLs, created with `CreateFunctionUrlConfigCommand` and served over HTTP on localhost
   with `serveSimAws`
@@ -2866,10 +2960,15 @@ Sim Lambda currently supports:
 
 Current documented limitations:
 
-- Only `CreateFunctionCommand`, `GetFunctionCommand`, `DeleteFunctionCommand`, `InvokeCommand`, the
-  permission commands (`AddPermissionCommand`, `RemovePermissionCommand`, `GetPolicyCommand`), the
-  version and alias commands, the Function URL config commands and the event source mapping
-  commands are supported. `UpdateFunctionCode` and function listing are absent so far.
+- Only `CreateFunctionCommand`, `GetFunctionCommand`, `UpdateFunctionCodeCommand`,
+  `ListFunctionsCommand`, `DeleteFunctionCommand`, `InvokeCommand`, the permission commands
+  (`AddPermissionCommand`, `RemovePermissionCommand`, `GetPolicyCommand`), the version and alias
+  commands, the Function URL config commands and the event source mapping commands are supported.
+  `UpdateFunctionConfiguration` is absent so far, so a function's Role, Handler, Runtime,
+  Description, Timeout, MemorySize and Environment are fixed at creation.
+- `UpdateFunctionCode` leaves out the `RevisionId` and `DryRun` preconditions real Lambda takes,
+  along with `Architectures` and `SourceKMSKeyArn`. `ListFunctions` leaves out `Marker`/`MaxItems`
+  paging and `MasterRegion`.
 - A cross-account grant is only half of what admits a call. The caller's own Account has to allow
   the action too, and its IAM has to be part of the same `SimAws` instance for its policies to be
   found. A caller from an Account outside the simulation is denied.
@@ -2889,10 +2988,10 @@ Current documented limitations:
   buffered.
 - A function has at most one Function URL, and qualified (version or alias) Function URLs are left
   out.
-- A published version keeps what it was published with, and `UpdateFunctionCode` is absent, so
-  `$LATEST` has no way to drift from it yet. The `CodeSha256` and `RevisionId` checks
-  `PublishVersion` makes are left out, along with alias `RoutingConfig` weights, provisioned
-  concurrency, and the `Marker`/`MaxItems` paging on the two listings. `CodeSha256`, `RuntimePolicy`
+- A published version keeps what it was published with, so `UpdateFunctionCode` moves `$LATEST`
+  alone. The `CodeSha256` and `RevisionId` checks `PublishVersion` makes are left out, along with
+  alias `RoutingConfig` weights, provisioned concurrency, and the `Marker`/`MaxItems` paging on the
+  two listings. `CodeSha256`, `RuntimePolicy`
   and `ProvisionedConcurrencyConfig` on `AWS::Lambda::Version`, and `RoutingConfig` and
   `ProvisionedConcurrencyConfig` on `AWS::Lambda::Alias`, are accepted and ignored. SAM's
   `AutoPublishAlias` is left out.

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -2943,8 +2943,9 @@ Sim Lambda currently supports:
   `UpdateAlias`, `GetAlias`, `ListAliases` and `DeleteAlias`, and a `Qualifier` on `Invoke`,
   `GetFunction` and the permission commands, each qualified resource holding its own policy
 - IAM authorization of the Lambda commands themselves (`lambda:CreateFunction`,
-  `lambda:GetFunction`, `lambda:InvokeFunction`, the Function URL config actions, and the version
-  and alias actions)
+  `lambda:GetFunction`, `lambda:UpdateFunctionCode`, `lambda:InvokeFunction`, the Function URL
+  config actions, and the version and alias actions), and `lambda:ListFunctions` on `*` for the
+  listing
 - AWS-like validation and errors, such as `ResourceConflictException` for a duplicate function name
 - The `AWS::Lambda::Function`, `AWS::Lambda::Url`, `AWS::Lambda::Permission`,
   `AWS::Lambda::Version`, `AWS::Lambda::Alias` and `AWS::Lambda::EventSourceMapping`
@@ -3037,7 +3038,10 @@ Current documented limitations:
 - A time read at module scope, like an environment variable read there, is read before any
   invocation and sees the host clock. See [The time inside a handler](#the-time-inside-a-handler).
 - `Event` invocation retries and failure destinations are left out, and handler errors are dropped.
-- `Code.S3ObjectVersion` is accepted but ignored, as sim S3 has no object versioning yet.
+- The S3 object version a code location names is accepted but ignored, as sim S3 has no object
+  versioning yet. That covers `Code.S3ObjectVersion` on `CreateFunction` and on a template
+  function, and `S3ObjectVersion` on `UpdateFunctionCode`. A versioned location loads the object as
+  it stands.
 - SQS queues and DynamoDB streams are the only event sources. Kinesis, Kafka and DocumentDB sources
   are refused outright, and so are `FilterCriteria`,
   `ScalingConfig`, `DestinationConfig`, `MaximumRetryAttempts`, `BisectBatchOnFunctionError`,
@@ -3076,7 +3080,7 @@ Current documented limitations:
 - The `vm` context is a namespacing convenience rather than a security boundary. Function code runs
   in-process with the same trust as the test suite itself. Do not run untrusted code through the
   simulator.
-- `serveSimAws` serves sixteen of these operations over HTTP, listed in the
+- `serveSimAws` serves eighteen of these operations over HTTP, listed in the
   [serving docs](../../serve/README.md#lambda-over-the-endpoint). The version and alias operations have no
   route there yet, and reach the simulation through `SimAws` or
   [SDK interception](../../sdk/) instead.

--- a/docs/services/lambda/sim-lambda-list-functions.example.ts
+++ b/docs/services/lambda/sim-lambda-list-functions.example.ts
@@ -1,0 +1,29 @@
+/**
+ * Listing the simulated Lambda functions an Account and Region holds.
+ */
+
+import {
+  CreateFunctionCommand,
+  ListFunctionsCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+
+for (const functionName of ["orders", "invoices"]) {
+  await lambda.createFunction(
+    new CreateFunctionCommand({
+      FunctionName: functionName,
+      Role: "arn:aws:iam::111111111111:role/OrdersRole",
+      Code: { ZipFile: makeLambdaZipFileInput(() => functionName) },
+    }),
+  );
+}
+
+const listed = await lambda.listFunctions(new ListFunctionsCommand({}));
+console.log(listed.Functions.map((simFunction) => simFunction.FunctionName));
+
+await simAws.backgroundTasksComplete();

--- a/docs/services/lambda/sim-lambda-update-function-code.example.ts
+++ b/docs/services/lambda/sim-lambda-update-function-code.example.ts
@@ -1,0 +1,39 @@
+/**
+ * Replacing the code a simulated Lambda function runs, part-way through.
+ */
+
+import {
+  CreateFunctionCommand,
+  InvokeCommand,
+  UpdateFunctionCodeCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "orders",
+    Role: "arn:aws:iam::111111111111:role/OrdersRole",
+    Code: { ZipFile: makeLambdaZipFileInput(() => ({ ok: true })) },
+  }),
+);
+
+await lambda.updateFunctionCode(
+  new UpdateFunctionCodeCommand({
+    FunctionName: "orders",
+    ZipFile: makeLambdaZipFileInput(() => {
+      throw new Error("the order service is down");
+    }),
+  }),
+);
+
+const invoked = await lambda.invoke(
+  new InvokeCommand({ FunctionName: "orders" }),
+);
+console.log(invoked.FunctionError);
+
+await simAws.backgroundTasksComplete();

--- a/src/serve/http/api/sim-aws-api-endpoint.loc.test.ts
+++ b/src/serve/http/api/sim-aws-api-endpoint.loc.test.ts
@@ -18,7 +18,10 @@ import {
   ListQueuesCommand,
   SQSClient,
 } from "@aws-sdk/client-sqs";
-import { LambdaClient, ListFunctionsCommand } from "@aws-sdk/client-lambda";
+import {
+  LambdaClient,
+  UpdateFunctionConfigurationCommand,
+} from "@aws-sdk/client-lambda";
 import {
   assertIdentical,
   assertStringIncludes,
@@ -243,9 +246,9 @@ describe("Serving the general AWS API on one endpoint", () => {
     assertIdentical(written.Item?.["id"]?.S, "by-session");
   });
 
-  it("refuses a protocol it cannot read without asking the client to retry", async () => {
-    // Given a request signed for the Lambda control plane, which speaks
-    // REST-JSON rather than any protocol this endpoint reads
+  it("refuses an operation it does not serve without asking the client to retry", async () => {
+    // Given a request signed for the Lambda control plane, whose REST-JSON
+    // endpoint serves the operations simulated Lambda implements
     const client = new LambdaClient({
       region: simAws.defaultRegionName,
       endpoint,
@@ -253,9 +256,12 @@ describe("Serving the general AWS API on one endpoint", () => {
       maxAttempts: 1,
     });
 
-    // When it asks for something only REST-JSON could express
+    // When it asks for one this simulation has not implemented
     const error = await assertThrowsErrorAsync(
-      async () => await client.send(new ListFunctionsCommand({})),
+      async () =>
+        await client.send(
+          new UpdateFunctionConfigurationCommand({ FunctionName: "orders" }),
+        ),
     );
 
     // Then it is refused as unimplemented, which an SDK does not retry, and

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -747,11 +747,14 @@ and are skipped by the CloudFormation engine with an "Unsupported" diagnostic.
 - running a container image: nothing reads one, so a function naming `Code.ImageUri` runs the real
   in-process handler an executable binding or a simulated ECR repository stands in with, and is
   skipped or refused where neither does
-- `UpdateFunctionCode` and function listing
+- `UpdateFunctionConfiguration`, so a function's Role, Handler, Runtime, Description, Timeout,
+  MemorySize and Environment are fixed at creation
+- `RevisionId`, `DryRun`, `Architectures` and `SourceKMSKeyArn` on `UpdateFunctionCode`, and
+  `Marker`/`MaxItems` paging and `MasterRegion` on `ListFunctions`
 - `RevisionId` and `EventSourceToken` on the permission commands, qualified Function URLs, alias
   `RoutingConfig` weights, and provisioned concurrency, including `RoutingConfig`,
   `ProvisionedConcurrencyConfig`, `CodeSha256` and `RuntimePolicy` on the two template resources
-- version and alias operations over the served HTTP API endpoint, which routes the other sixteen
+- version and alias operations over the served HTTP API endpoint, which routes the other eighteen
 - Lambda Layers
 - environment variables reaching a real in-process handler's module scope (see "Environment
   variables" above), and the same limitation for a time read there or a request made there

--- a/src/service/lambda/command/function/sim-lambda-function-commands.ts
+++ b/src/service/lambda/command/function/sim-lambda-function-commands.ts
@@ -10,6 +10,7 @@ import type { SimLogsServiceWriter } from "../../../logs/write/sim-logs-service-
 import type { SimLambdaOutboundHttp } from "../../function/outbound/sim-lambda-outbound-http.js";
 import type { SimLambdaEnvironmentConflicts } from "../../function/environment/sim-lambda-environment-conflicts.js";
 import type { SimLambdaFunctionMap } from "../../function/sim-lambda-function.js";
+import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
 import type { SimLambdaFunctionUrlStore } from "../../function/url/sim-lambda-function-url-store.js";
 import type { SimLambdaFunctionVersionStore } from "../../function/version/sim-lambda-function-version-store.js";
 import { CreateFunctionCommandHandler } from "../create-function/create-function.handler.js";
@@ -32,10 +33,21 @@ import type {
   SimInvokeCommand,
   SimInvokeCommandOutput,
 } from "../invoke/invoke.command.js";
+import { ListFunctionsCommandHandler } from "../list-functions/list-functions.handler.js";
+import type {
+  SimListFunctionsCommand,
+  SimListFunctionsCommandOutput,
+} from "../list-functions/list-functions.command.js";
+import { UpdateFunctionCodeCommandHandler } from "../update-function-code/update-function-code.handler.js";
+import type {
+  SimUpdateFunctionCodeCommand,
+  SimUpdateFunctionCodeCommandOutput,
+} from "../update-function-code/update-function-code.command.js";
 
 interface SimLambdaFunctionCommandsProperties {
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly functions: SimLambdaFunctionMap;
+  readonly functionLookup: SimLambdaFunctionLookup;
   readonly iam: SimIamInterServiceAuthZ;
   readonly background: BackgroundScheduler;
   readonly runAsOwner: SimAwsRunAsOwner;
@@ -88,6 +100,51 @@ export class SimLambdaFunctionCommands {
     options?: SimLambdaFunctionCommandOptions,
   ): Promise<SimGetFunctionCommandOutput> {
     return await new GetFunctionCommandHandler(this.properties).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Replace the code a function runs.
+   */
+  async updateCode(
+    command: SimUpdateFunctionCodeCommand,
+    options?: SimLambdaFunctionCommandOptions,
+  ): Promise<SimUpdateFunctionCodeCommandOutput> {
+    const {
+      functionLookup,
+      versions,
+      iam,
+      background,
+      codeStore,
+      containerImages,
+      vmSdkModuleProvider,
+      outboundHttp,
+    } = this.properties;
+
+    return await new UpdateFunctionCodeCommandHandler({
+      // The lookup rather than the map itself, because this command resolves
+      // a name that may arrive as a function ARN.
+      functions: functionLookup,
+      versions,
+      iam,
+      background,
+      codeStore,
+      containerImages,
+      vmSdkModuleProvider,
+      outboundHttp,
+    }).handle(command, options);
+  }
+
+  /**
+   * List the functions that exist in this Account and Region.
+   */
+  async list(
+    command: SimListFunctionsCommand,
+    options?: SimLambdaFunctionCommandOptions,
+  ): Promise<SimListFunctionsCommandOutput> {
+    return await new ListFunctionsCommandHandler(this.properties).handle(
       command,
       options,
     );

--- a/src/service/lambda/command/list-functions/list-functions-authorizer.ts
+++ b/src/service/lambda/command/list-functions/list-functions-authorizer.ts
@@ -1,0 +1,51 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+
+interface ListFunctionsAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * Applies IAM authorization to a Lambda ListFunctions request.
+ *
+ * AWS maps the ListFunctions API operation to the lambda:ListFunctions IAM
+ * action. The operation reaches every function in the Account and Region, so
+ * AWS documents its resource as "*" rather than any one function ARN.
+ *
+ * Authorization therefore applies to the whole operation. A denied caller
+ * receives AccessDenied rather than a filtered listing.
+ */
+export class ListFunctionsAuthorizer {
+  private static readonly action = "lambda:ListFunctions";
+  private static readonly resource = "*";
+
+  private readonly iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: ListFunctionsAuthorizerProperties) {
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Ensure the caller may list the simulated Account's Lambda functions.
+   *
+   * The caller is passed through unchanged so sim IAM can distinguish an
+   * omitted caller, which defaults to Account root, from an explicit anonymous
+   * caller.
+   */
+  authorize(caller?: SimAwsCaller): void {
+    const decision = this.iam.authorize({
+      action: ListFunctionsAuthorizer.action,
+      resource: ListFunctionsAuthorizer.resource,
+      caller,
+    });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action: ListFunctionsAuthorizer.action,
+        resource: ListFunctionsAuthorizer.resource,
+      });
+    }
+  }
+}

--- a/src/service/lambda/command/list-functions/list-functions.command.ts
+++ b/src/service/lambda/command/list-functions/list-functions.command.ts
@@ -1,0 +1,37 @@
+/**
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/ListFunctionsCommand/
+ */
+
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimLambdaFunctionConfiguration } from "../../function/sim-lambda-function-configuration.js";
+
+/**
+ * Minimal structural sim Lambda ListFunctions command.
+ */
+export interface SimListFunctionsCommand {
+  readonly input: SimListFunctionsCommandInput;
+}
+
+/**
+ * Minimal structural sim Lambda ListFunctions input.
+ *
+ * `FunctionVersion` is the only member simulated Lambda reads. `"ALL"` adds
+ * each function's published versions to the listing, and anything else lists
+ * the functions themselves.
+ *
+ * Real Lambda pages the listing with `Marker` and `MaxItems`, and reaches
+ * another Region's functions with `MasterRegion`. Neither is simulated, so
+ * all three are left out rather than accepted and ignored, matching the other
+ * simulated Lambda listings.
+ */
+export interface SimListFunctionsCommandInput {
+  readonly FunctionVersion?: string | undefined;
+}
+
+/**
+ * Minimal structural sim Lambda ListFunctions output.
+ */
+export interface SimListFunctionsCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+  readonly Functions: readonly SimLambdaFunctionConfiguration[];
+}

--- a/src/service/lambda/command/list-functions/list-functions.handler.ts
+++ b/src/service/lambda/command/list-functions/list-functions.handler.ts
@@ -1,0 +1,95 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
+import type { SimLambdaFunctionMap } from "../../function/sim-lambda-function.js";
+import type { SimLambdaFunctionConfiguration } from "../../function/sim-lambda-function-configuration.js";
+import type { SimLambdaFunctionVersionStore } from "../../function/version/sim-lambda-function-version-store.js";
+import { ListFunctionsAuthorizer } from "./list-functions-authorizer.js";
+import type {
+  SimListFunctionsCommand,
+  SimListFunctionsCommandOutput,
+} from "./list-functions.command.js";
+
+/**
+ * What a caller asks for to have published versions listed alongside the
+ * functions themselves.
+ */
+const allVersions = "ALL";
+
+interface ListFunctionsCommandHandlerProperties {
+  readonly functions: SimLambdaFunctionMap;
+  readonly versions: SimLambdaFunctionVersionStore;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+interface ListFunctionsCommandHandlerOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * Simulated Lambda ListFunctionsCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/ListFunctionsCommand/
+ */
+export class ListFunctionsCommandHandler implements CommandHandler<
+  SimListFunctionsCommand,
+  SimListFunctionsCommandOutput
+> {
+  private readonly functions: SimLambdaFunctionMap;
+  private readonly versions: SimLambdaFunctionVersionStore;
+  private readonly authorizer: ListFunctionsAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: ListFunctionsCommandHandlerProperties) {
+    const {
+      functions,
+      versions,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+    this.functions = functions;
+    this.versions = versions;
+    this.authorizer = new ListFunctionsAuthorizer({ iam });
+    this.background = background;
+  }
+
+  /**
+   * List the configuration of every sim Lambda function in this Account and
+   * Region, as GetFunction reports one.
+   */
+  async handle(
+    command: SimListFunctionsCommand,
+    options?: ListFunctionsCommandHandlerOptions,
+  ): Promise<SimListFunctionsCommandOutput> {
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    this.authorizer.authorize(options?.caller);
+
+    const listed = this.functions
+      .values()
+      .flatMap(
+        (simFunction: SimLambdaFunction): readonly SimLambdaFunction[] =>
+          command.input.FunctionVersion === allVersions
+            ? this.versions.all(simFunction)
+            : [simFunction],
+      )
+      .toArray();
+
+    return {
+      $metadata: {},
+      Functions: listed.map((simFunction): SimLambdaFunctionConfiguration =>
+        simFunction.configuration(),
+      ),
+    };
+  }
+}

--- a/src/service/lambda/command/list-functions/list-functions.iso.test.ts
+++ b/src/service/lambda/command/list-functions/list-functions.iso.test.ts
@@ -1,0 +1,171 @@
+import {
+  CreateFunctionCommand,
+  ListFunctionsCommand,
+  PublishVersionCommand,
+} from "@aws-sdk/client-lambda";
+import { CreateRoleCommand } from "@aws-sdk/client-iam";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringEndsWith,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
+import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
+import { SimLambda } from "../../sim-lambda.js";
+
+async function createFunction(
+  simLambda: SimLambda,
+  functionName: string,
+): Promise<void> {
+  await simLambda.createFunction(
+    new CreateFunctionCommand({
+      FunctionName: functionName,
+      Role: "arn:aws:iam::111111111111:role/OrdersRole",
+      Code: { ZipFile: makeLambdaZipFileInput(() => functionName) },
+    }),
+  );
+}
+
+describe("Lambda ListFunctionsCommand", () => {
+  it("lists nothing when no function has been created", async () => {
+    const simLambda = new SimLambda();
+
+    const listed = await simLambda.listFunctions(new ListFunctionsCommand({}));
+
+    assertArrayLength(listed.Functions, 0);
+  });
+
+  it("lists every function created in the Account and Region", async () => {
+    // Given three functions.
+    const simLambda = new SimLambda();
+    await createFunction(simLambda, "orders");
+    await createFunction(simLambda, "invoices");
+    await createFunction(simLambda, "shipments");
+
+    // When the functions are listed.
+    const listed = await simLambda.listFunctions(new ListFunctionsCommand({}));
+
+    // Then each one is reported, in the order they were created.
+    assertArrayEquals(
+      listed.Functions.map((simFunction) => simFunction.FunctionName),
+      ["orders", "invoices", "shipments"],
+    );
+  });
+
+  it("reports each function as GetFunction reports it", async () => {
+    // Given a function described at creation.
+    const simLambda = new SimLambda();
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "orders",
+        Role: "arn:aws:iam::111111111111:role/OrdersRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "handled") },
+        Handler: "index.handler",
+        Runtime: "nodejs22.x",
+        Description: "Takes orders",
+        MemorySize: 512,
+        Timeout: 30,
+      }),
+    );
+
+    // When the functions are listed.
+    const listed = await simLambda.listFunctions(new ListFunctionsCommand({}));
+
+    // Then the listing carries the whole configuration.
+    const [orders] = listed.Functions;
+    assertNonNullable(orders);
+    assertIdentical(orders.FunctionName, "orders");
+    assertStringEndsWith(orders.FunctionArn, ":function:orders");
+    assertIdentical(orders.Version, "$LATEST");
+    assertIdentical(orders.Handler, "index.handler");
+    assertIdentical(orders.Runtime, "nodejs22.x");
+    assertIdentical(orders.Description, "Takes orders");
+    assertIdentical(orders.MemorySize, 512);
+    assertIdentical(orders.Timeout, 30);
+  });
+
+  it("lists the functions themselves without a FunctionVersion", async () => {
+    // Given a function with two published versions.
+    const simLambda = new SimLambda();
+    await createFunction(simLambda, "orders");
+    await simLambda.publishVersion(
+      new PublishVersionCommand({ FunctionName: "orders" }),
+    );
+    await simLambda.publishVersion(
+      new PublishVersionCommand({ FunctionName: "orders" }),
+    );
+
+    // When the functions are listed.
+    const listed = await simLambda.listFunctions(new ListFunctionsCommand({}));
+
+    // Then only $LATEST is reported.
+    assertArrayEquals(
+      listed.Functions.map((simFunction) => simFunction.Version),
+      ["$LATEST"],
+    );
+  });
+
+  it("adds published versions for a FunctionVersion of ALL", async () => {
+    // Given a function with two published versions.
+    const simLambda = new SimLambda();
+    await createFunction(simLambda, "orders");
+    await simLambda.publishVersion(
+      new PublishVersionCommand({ FunctionName: "orders" }),
+    );
+    await simLambda.publishVersion(
+      new PublishVersionCommand({ FunctionName: "orders" }),
+    );
+
+    // When every version is asked for.
+    const listed = await simLambda.listFunctions(
+      new ListFunctionsCommand({ FunctionVersion: "ALL" }),
+    );
+
+    // Then each version joins the function itself.
+    assertArrayEquals(
+      listed.Functions.map((simFunction) => simFunction.Version),
+      ["$LATEST", "1", "2"],
+    );
+  });
+
+  it("denies a caller without lambda:ListFunctions", async () => {
+    // Given a Role with no Lambda permissions, and a function to list.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    await createFunction(simAws.lambda(), "orders");
+
+    const roleCreation = await simAws.iam().createRole(
+      new CreateRoleCommand({
+        RoleName: "NoPermissionsRole",
+        AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+
+    // When that Role lists the functions.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.lambda().listFunctions(new ListFunctionsCommand({}), {
+        caller: { kind: "arn", arn: roleCreation.Role.Arn },
+      }),
+    );
+
+    // Then the whole listing is denied rather than filtered.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "lambda:ListFunctions");
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/service/lambda/command/sim-lambda-command.types.ts
+++ b/src/service/lambda/command/sim-lambda-command.types.ts
@@ -74,6 +74,10 @@ export type {
   SimListAliasesCommandOutput,
 } from "./list-aliases/list-aliases.command.js";
 export type {
+  SimListFunctionsCommand,
+  SimListFunctionsCommandOutput,
+} from "./list-functions/list-functions.command.js";
+export type {
   SimListFunctionUrlConfigsCommand,
   SimListFunctionUrlConfigsCommandOutput,
 } from "./list-function-url-configs/list-function-url-configs.command.js";
@@ -93,6 +97,10 @@ export type {
   SimUpdateAliasCommand,
   SimUpdateAliasCommandOutput,
 } from "./update-alias/update-alias.command.js";
+export type {
+  SimUpdateFunctionCodeCommand,
+  SimUpdateFunctionCodeCommandOutput,
+} from "./update-function-code/update-function-code.command.js";
 export type {
   SimUpdateFunctionUrlConfigCommand,
   SimUpdateFunctionUrlConfigCommandOutput,

--- a/src/service/lambda/command/update-function-code/update-function-code-authorizer.ts
+++ b/src/service/lambda/command/update-function-code/update-function-code-authorizer.ts
@@ -1,0 +1,47 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+
+interface UpdateFunctionCodeAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * Applies IAM authorization to a Lambda UpdateFunctionCode request.
+ *
+ * AWS maps the UpdateFunctionCode API operation to the
+ * lambda:UpdateFunctionCode IAM action. The resource is the ARN of the
+ * function whose code is being replaced.
+ */
+export class UpdateFunctionCodeAuthorizer {
+  private static readonly action = "lambda:UpdateFunctionCode";
+
+  private readonly iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: UpdateFunctionCodeAuthorizerProperties) {
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Ensure the caller may replace the code of the function with the given ARN.
+   *
+   * The caller is passed through unchanged so sim IAM can distinguish an
+   * omitted caller, which defaults to Account root, from an explicit anonymous
+   * caller.
+   */
+  authorize(functionArn: string, caller?: SimAwsCaller): void {
+    const decision = this.iam.authorize({
+      action: UpdateFunctionCodeAuthorizer.action,
+      resource: functionArn,
+      caller,
+    });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action: UpdateFunctionCodeAuthorizer.action,
+        resource: functionArn,
+      });
+    }
+  }
+}

--- a/src/service/lambda/command/update-function-code/update-function-code-iam.iso.test.ts
+++ b/src/service/lambda/command/update-function-code/update-function-code-iam.iso.test.ts
@@ -1,0 +1,114 @@
+import {
+  CreateFunctionCommand,
+  UpdateFunctionCodeCommand,
+} from "@aws-sdk/client-lambda";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
+import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
+
+async function createOrdersFunction(
+  simAws: SimAws,
+  accountId: string,
+): Promise<void> {
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: "orders",
+      Role: `arn:aws:iam::${accountId}:role/ExecutionRole`,
+      Code: { ZipFile: makeLambdaZipFileInput(() => "first") },
+    }),
+  );
+}
+
+async function createRole(
+  simAws: SimAws,
+  accountId: string,
+  roleName: string,
+): Promise<string> {
+  const roleCreation = await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: roleName,
+      AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: {
+          Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  return roleCreation.Role.Arn;
+}
+
+describe("Lambda UpdateFunctionCodeCommand IAM authorization", () => {
+  it("allows a Role whose policy permits lambda:UpdateFunctionCode", async () => {
+    // Given a Role allowed to update one function's code.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    await createOrdersFunction(simAws, accountId);
+    const roleArn = await createRole(simAws, accountId, "CodeDeployer");
+
+    await simAws.iam().putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "CodeDeployer",
+        PolicyName: "UpdateOrdersCode",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Action: "lambda:UpdateFunctionCode",
+            Resource:
+              `arn:aws:lambda:${simAws.defaultRegionName}:` +
+              `${accountId}:function:orders`,
+          },
+        }),
+      }),
+    );
+
+    // When that Role replaces the function's code.
+    const updated = await simAws.lambda().updateFunctionCode(
+      new UpdateFunctionCodeCommand({
+        FunctionName: "orders",
+        ZipFile: makeLambdaZipFileInput(() => "second"),
+      }),
+      { caller: { kind: "arn", arn: roleArn } },
+    );
+
+    // Then IAM allows it.
+    assertIdentical(updated.FunctionName, "orders");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("implicitly denies a Role with no matching policy", async () => {
+    // Given a Role with no Lambda permissions.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    await createOrdersFunction(simAws, accountId);
+    const roleArn = await createRole(simAws, accountId, "NoPermissionsRole");
+
+    // When that Role replaces the function's code.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.lambda().updateFunctionCode(
+        new UpdateFunctionCodeCommand({
+          FunctionName: "orders",
+          ZipFile: makeLambdaZipFileInput(() => "second"),
+        }),
+        { caller: { kind: "arn", arn: roleArn } },
+      ),
+    );
+
+    // Then IAM implicitly denies it.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "lambda:UpdateFunctionCode");
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/service/lambda/command/update-function-code/update-function-code-input.ts
+++ b/src/service/lambda/command/update-function-code/update-function-code-input.ts
@@ -1,0 +1,54 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import {
+  type SimLambdaCodeInputNaming,
+  requireLambdaCodeSource,
+  type SimLambdaCodeSource,
+} from "../../function/code/lambda-code-source.js";
+import type { SimUpdateFunctionCodeCommand } from "./update-function-code.command.js";
+
+/**
+ * Where UpdateFunctionCode carries its code members, which is the top level
+ * of its input.
+ */
+const updateFunctionCodeNaming: SimLambdaCodeInputNaming = {
+  path: "UpdateFunctionCodeCommand.input",
+  memberPrefix: "",
+};
+
+/**
+ * Validated UpdateFunctionCode input, in sim Lambda function model terms.
+ */
+export interface UpdateFunctionCodeInput {
+  name: string;
+  codeSource: SimLambdaCodeSource;
+  publish: boolean;
+}
+
+/**
+ * Require the AWS-required UpdateFunctionCode input fields, and validate the
+ * function code input into a sim Lambda code source.
+ */
+export function requireUpdateFunctionCodeInput(
+  command: SimUpdateFunctionCodeCommand,
+): UpdateFunctionCodeInput {
+  const { input } = command;
+  assertDefined(
+    input.FunctionName,
+    "UpdateFunctionCodeCommand.input.FunctionName required",
+  );
+
+  return {
+    name: input.FunctionName,
+    codeSource: requireLambdaCodeSource(
+      {
+        ZipFile: input.ZipFile,
+        S3Bucket: input.S3Bucket,
+        S3Key: input.S3Key,
+        S3ObjectVersion: input.S3ObjectVersion,
+        ImageUri: input.ImageUri,
+      },
+      updateFunctionCodeNaming,
+    ),
+    publish: input.Publish ?? false,
+  };
+}

--- a/src/service/lambda/command/update-function-code/update-function-code-sources.iso.test.ts
+++ b/src/service/lambda/command/update-function-code/update-function-code-sources.iso.test.ts
@@ -1,0 +1,215 @@
+import {
+  CreateFunctionCommand,
+  InvokeCommand,
+  UpdateFunctionCodeCommand,
+} from "@aws-sdk/client-lambda";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
+import { makeLambdaCodeZip } from "../../function/code/make-lambda-code-zip.js";
+import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
+import { SimLambda } from "../../sim-lambda.js";
+
+const ordersRepositoryUri =
+  "888888888888.dkr.ecr.us-east-1.amazonaws.com/orders";
+
+function parsePayload(payload: Uint8Array | undefined): unknown {
+  assertNonNullable(payload);
+  return JSON.parse(Buffer.from(payload).toString()) as unknown;
+}
+
+async function createHandlerFunction(simAws: SimAws): Promise<void> {
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: "orders",
+      Role: `arn:aws:iam::${simAws.defaultAccountId}:role/OrdersRole`,
+      Code: { ZipFile: makeLambdaZipFileInput(() => "first") },
+    }),
+  );
+}
+
+describe("Lambda UpdateFunctionCodeCommand code sources", () => {
+  it("replaces code with a zip archive stored in sim S3", async () => {
+    // Given a zip code function, and replacement code stored in sim S3 the way
+    // SAM and CDK deploy it.
+    const simAws = new SimAws();
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "orders",
+        Role: `arn:aws:iam::${simAws.defaultAccountId}:role/OrdersRole`,
+        Handler: "index.handler",
+        Runtime: "nodejs22.x",
+        Code: {
+          ZipFile: makeLambdaCodeZip("exports.handler = async () => 1;"),
+        },
+      }),
+    );
+    const simS3 = simAws.s3();
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "code-bucket" }),
+    );
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "code-bucket",
+        Key: "artifacts/orders.zip",
+        Body: makeLambdaCodeZip("exports.handler = async () => 'from S3';"),
+      }),
+    );
+
+    // When the function's code is replaced from that object.
+    await simAws.lambda().updateFunctionCode(
+      new UpdateFunctionCodeCommand({
+        FunctionName: "orders",
+        S3Bucket: "code-bucket",
+        S3Key: "artifacts/orders.zip",
+      }),
+    );
+
+    // Then the stored archive is what runs, under the Handler the function
+    // already had. UpdateFunctionCode carries no Handler of its own.
+    const invoked = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "orders" }));
+    assertIdentical(parsePayload(invoked.Payload), "from S3");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("replaces code with the image a simulated ECR repository holds", async () => {
+    // Given a container image function, and another handler registered as a
+    // second repository's image.
+    const simAws = new SimAws();
+    simAws
+      .ecr()
+      .repository("orders")
+      .simulateImage({ handler: () => "first image" });
+    simAws
+      .ecr()
+      .repository("orders-next")
+      .simulateImage({ handler: () => "second image" });
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "orders",
+        Role: "arn:aws:iam::888888888888:role/OrdersRole",
+        PackageType: "Image",
+        Code: { ImageUri: `${ordersRepositoryUri}:latest` },
+      }),
+    );
+
+    // When the function is pointed at the second image.
+    await simAws.lambda().updateFunctionCode(
+      new UpdateFunctionCodeCommand({
+        FunctionName: "orders",
+        ImageUri:
+          "888888888888.dkr.ecr.us-east-1.amazonaws.com/orders-next:latest",
+      }),
+    );
+
+    // Then the handler that repository holds is what runs.
+    const invoked = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "orders" }));
+    assertIdentical(parsePayload(invoked.Payload), "second image");
+  });
+
+  it("refuses an image URI no simulated repository holds an image for", async () => {
+    const simAws = new SimAws();
+    await createHandlerFunction(simAws);
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.lambda().updateFunctionCode(
+        new UpdateFunctionCodeCommand({
+          FunctionName: "orders",
+          ImageUri: `${ordersRepositoryUri}:latest`,
+        }),
+      ),
+    );
+
+    assertInstanceOf(error, SimLambdaInvalidParameterValueException);
+    assertStringIncludes(error.message, "cannot be run");
+  });
+
+  it("requires one of ZipFile, an S3 location or an ImageUri", async () => {
+    const simLambda = new SimLambda();
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "orders",
+        Role: "arn:aws:iam::111111111111:role/OrdersRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "first") },
+      }),
+    );
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simLambda.updateFunctionCode(
+        new UpdateFunctionCodeCommand({ FunctionName: "orders" }),
+      ),
+    );
+
+    // Then the refusal names the members as UpdateFunctionCode carries them,
+    // at the top level rather than under Code.
+    assertInstanceOf(error, SimLambdaInvalidParameterValueException);
+    assertStringIncludes(
+      error.message,
+      "UpdateFunctionCodeCommand.input requires either ZipFile bytes",
+    );
+  });
+
+  it("refuses both ZipFile bytes and an S3 location at once", async () => {
+    const simLambda = new SimLambda();
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "orders",
+        Role: "arn:aws:iam::111111111111:role/OrdersRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "first") },
+      }),
+    );
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simLambda.updateFunctionCode(
+        new UpdateFunctionCodeCommand({
+          FunctionName: "orders",
+          ZipFile: makeLambdaZipFileInput(() => "second"),
+          S3Bucket: "code-bucket",
+          S3Key: "artifacts/orders.zip",
+        }),
+      ),
+    );
+
+    assertInstanceOf(error, SimLambdaInvalidParameterValueException);
+    assertStringIncludes(error.message, "when using ZipFile");
+  });
+
+  it("refuses an S3 bucket with no key", async () => {
+    const simLambda = new SimLambda();
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "orders",
+        Role: "arn:aws:iam::111111111111:role/OrdersRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "first") },
+      }),
+    );
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simLambda.updateFunctionCode(
+        new UpdateFunctionCodeCommand({
+          FunctionName: "orders",
+          S3Bucket: "code-bucket",
+        }),
+      ),
+    );
+
+    assertStringIncludes(
+      error.message,
+      "UpdateFunctionCodeCommand.input.S3Key required with S3Bucket",
+    );
+  });
+});

--- a/src/service/lambda/command/update-function-code/update-function-code-versions.iso.test.ts
+++ b/src/service/lambda/command/update-function-code/update-function-code-versions.iso.test.ts
@@ -1,0 +1,201 @@
+import {
+  AddPermissionCommand,
+  CreateAliasCommand,
+  CreateFunctionCommand,
+  CreateFunctionUrlConfigCommand,
+  GetFunctionUrlConfigCommand,
+  GetPolicyCommand,
+  InvokeCommand,
+  ListVersionsByFunctionCommand,
+  PublishVersionCommand,
+  UpdateFunctionCodeCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
+import { SimLambda } from "../../sim-lambda.js";
+
+function parsePayload(payload: Uint8Array | undefined): unknown {
+  assertNonNullable(payload);
+  return JSON.parse(Buffer.from(payload).toString()) as unknown;
+}
+
+describe("Lambda UpdateFunctionCodeCommand and published versions", () => {
+  it("leaves a version published beforehand running its own code", async () => {
+    // Given a function with a version published from its first code.
+    const simLambda = new SimLambda();
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "orders",
+        Role: "arn:aws:iam::111111111111:role/OrdersRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "first") },
+      }),
+    );
+    await simLambda.publishVersion(
+      new PublishVersionCommand({ FunctionName: "orders" }),
+    );
+
+    // When the function's code is replaced.
+    await simLambda.updateFunctionCode(
+      new UpdateFunctionCodeCommand({
+        FunctionName: "orders",
+        ZipFile: makeLambdaZipFileInput(() => "second"),
+      }),
+    );
+
+    // Then $LATEST runs the replacement while version 1 runs what it was
+    // published with.
+    const latest = await simLambda.invoke(
+      new InvokeCommand({ FunctionName: "orders" }),
+    );
+    const version = await simLambda.invoke(
+      new InvokeCommand({ FunctionName: "orders", Qualifier: "1" }),
+    );
+    assertIdentical(parsePayload(latest.Payload), "second");
+    assertIdentical(parsePayload(version.Payload), "first");
+  });
+
+  it("publishes a version of the replacement code when asked to", async () => {
+    // Given a function whose code is about to be replaced.
+    const simLambda = new SimLambda();
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "orders",
+        Role: "arn:aws:iam::111111111111:role/OrdersRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "first") },
+      }),
+    );
+
+    // When the update asks for a version.
+    const published = await simLambda.updateFunctionCode(
+      new UpdateFunctionCodeCommand({
+        FunctionName: "orders",
+        ZipFile: makeLambdaZipFileInput(() => "second"),
+        Publish: true,
+      }),
+    );
+
+    // Then the answer is that version, and it runs the replacement code.
+    assertIdentical(published.Version, "1");
+    assertStringIncludes(published.FunctionArn, ":function:orders:1");
+    const invoked = await simLambda.invoke(
+      new InvokeCommand({ FunctionName: "orders", Qualifier: "1" }),
+    );
+    assertIdentical(parsePayload(invoked.Payload), "second");
+  });
+
+  it("answers with $LATEST when the update asks for no version", async () => {
+    // Given a function whose code is about to be replaced.
+    const simLambda = new SimLambda();
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "orders",
+        Role: "arn:aws:iam::111111111111:role/OrdersRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "first") },
+      }),
+    );
+
+    // When the update leaves Publish out.
+    const updated = await simLambda.updateFunctionCode(
+      new UpdateFunctionCodeCommand({
+        FunctionName: "orders",
+        ZipFile: makeLambdaZipFileInput(() => "second"),
+      }),
+    );
+
+    // Then nothing was published.
+    assertIdentical(updated.Version, "$LATEST");
+    const versions = await simLambda.listVersionsByFunction(
+      new ListVersionsByFunctionCommand({ FunctionName: "orders" }),
+    );
+    assertArrayLength(versions.Versions, 1);
+  });
+
+  it("keeps an alias pointing at the version it already pointed at", async () => {
+    // Given an alias on a version published from the function's first code.
+    const simLambda = new SimLambda();
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "orders",
+        Role: "arn:aws:iam::111111111111:role/OrdersRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "first") },
+      }),
+    );
+    await simLambda.publishVersion(
+      new PublishVersionCommand({ FunctionName: "orders" }),
+    );
+    await simLambda.createAlias(
+      new CreateAliasCommand({
+        FunctionName: "orders",
+        Name: "live",
+        FunctionVersion: "1",
+      }),
+    );
+
+    // When the function's code is replaced.
+    await simLambda.updateFunctionCode(
+      new UpdateFunctionCodeCommand({
+        FunctionName: "orders",
+        ZipFile: makeLambdaZipFileInput(() => "second"),
+      }),
+    );
+
+    // Then the alias still reaches the code its version was published with.
+    const invoked = await simLambda.invoke(
+      new InvokeCommand({ FunctionName: "orders", Qualifier: "live" }),
+    );
+    assertIdentical(parsePayload(invoked.Payload), "first");
+  });
+
+  it("keeps the function's resource policy and Function URL", async () => {
+    // Given a function with a Function URL and a resource-based grant.
+    const simAws = new SimAws();
+    const lambda = simAws.lambda();
+    await lambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "orders",
+        Role: "arn:aws:iam::111111111111:role/OrdersRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "first") },
+      }),
+    );
+    const created = await lambda.createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "orders",
+        AuthType: "NONE",
+      }),
+    );
+    await lambda.addPermission(
+      new AddPermissionCommand({
+        FunctionName: "orders",
+        StatementId: "public-invoke",
+        Action: "lambda:InvokeFunction",
+        Principal: "*",
+      }),
+    );
+
+    // When the function's code is replaced.
+    await lambda.updateFunctionCode(
+      new UpdateFunctionCodeCommand({
+        FunctionName: "orders",
+        ZipFile: makeLambdaZipFileInput(() => "second"),
+      }),
+    );
+
+    // Then both survive, unlike deleting the function and creating it again.
+    const url = await lambda.getFunctionUrlConfig(
+      new GetFunctionUrlConfigCommand({ FunctionName: "orders" }),
+    );
+    const policy = await lambda.getPolicy(
+      new GetPolicyCommand({ FunctionName: "orders" }),
+    );
+    assertIdentical(url.FunctionUrl, created.FunctionUrl);
+    assertStringIncludes(policy.Policy, "public-invoke");
+  });
+});

--- a/src/service/lambda/command/update-function-code/update-function-code.command.ts
+++ b/src/service/lambda/command/update-function-code/update-function-code.command.ts
@@ -1,0 +1,44 @@
+/**
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/UpdateFunctionCodeCommand/
+ */
+
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimLambdaFunctionConfiguration } from "../../function/sim-lambda-function-configuration.js";
+
+/**
+ * Minimal structural sim Lambda UpdateFunctionCode command.
+ */
+export interface SimUpdateFunctionCodeCommand {
+  readonly input: SimUpdateFunctionCodeCommandInput;
+}
+
+/**
+ * Minimal structural sim Lambda UpdateFunctionCode input.
+ *
+ * The code members sit at the top level here, unlike CreateFunction, which
+ * nests the same members under `Code`.
+ *
+ * Real Lambda takes a `RevisionId` and a `DryRun` to update only code the
+ * caller has already seen, and `Architectures` and `SourceKMSKeyArn` to
+ * describe how the code was built and encrypted. None of those are simulated,
+ * so all four are left out rather than accepted and ignored.
+ */
+export interface SimUpdateFunctionCodeCommandInput {
+  readonly FunctionName?: string | undefined;
+  readonly ZipFile?: Uint8Array | undefined;
+  readonly S3Bucket?: string | undefined;
+  readonly S3Key?: string | undefined;
+  readonly S3ObjectVersion?: string | undefined;
+  readonly ImageUri?: string | undefined;
+  readonly Publish?: boolean | undefined;
+}
+
+/**
+ * Minimal structural sim Lambda UpdateFunctionCode output.
+ *
+ * The configuration is the updated function's, or the published version's
+ * where `Publish` asked for one, as real Lambda answers.
+ */
+export interface SimUpdateFunctionCodeCommandOutput extends SimLambdaFunctionConfiguration {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/lambda/command/update-function-code/update-function-code.handler.ts
+++ b/src/service/lambda/command/update-function-code/update-function-code.handler.ts
@@ -1,0 +1,136 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimLambdaCodeResolver } from "../../function/code/sim-lambda-code-resolver.js";
+import type { SimLambdaContainerImages } from "../../function/code/image/sim-lambda-container-images.js";
+import type { SimLambdaCodeStore } from "../../function/code/store/sim-lambda-code-store.js";
+import type { SimLambdaVmSdkModuleProvider } from "../../function/code/vm/sdk/sim-lambda-vm-sdk-module-provider.js";
+import type { SimLambdaOutboundHttp } from "../../function/outbound/sim-lambda-outbound-http.js";
+import { simLambdaUnqualifiedFunctionOf } from "../../function/sim-lambda-function-reference.js";
+import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
+import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
+import type { SimLambdaFunctionVersionStore } from "../../function/version/sim-lambda-function-version-store.js";
+import { UpdateFunctionCodeAuthorizer } from "./update-function-code-authorizer.js";
+import { requireUpdateFunctionCodeInput } from "./update-function-code-input.js";
+import type {
+  SimUpdateFunctionCodeCommand,
+  SimUpdateFunctionCodeCommandOutput,
+} from "./update-function-code.command.js";
+
+interface UpdateFunctionCodeCommandHandlerProperties {
+  readonly functions: SimLambdaFunctionLookup;
+  readonly versions: SimLambdaFunctionVersionStore;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+  readonly codeStore?: SimLambdaCodeStore | undefined;
+  readonly containerImages?: SimLambdaContainerImages | undefined;
+  readonly vmSdkModuleProvider?: SimLambdaVmSdkModuleProvider | undefined;
+  readonly outboundHttp?: SimLambdaOutboundHttp | undefined;
+}
+
+interface UpdateFunctionCodeCommandHandlerOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * Simulated Lambda UpdateFunctionCodeCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/UpdateFunctionCodeCommand/
+ */
+export class UpdateFunctionCodeCommandHandler implements CommandHandler<
+  SimUpdateFunctionCodeCommand,
+  SimUpdateFunctionCodeCommandOutput
+> {
+  private readonly functions: SimLambdaFunctionLookup;
+  private readonly versions: SimLambdaFunctionVersionStore;
+  private readonly authorizer: UpdateFunctionCodeAuthorizer;
+  private readonly background: BackgroundScheduler;
+  private readonly codeResolver: SimLambdaCodeResolver;
+
+  constructor(properties: UpdateFunctionCodeCommandHandlerProperties) {
+    const {
+      functions,
+      versions,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+      codeStore,
+      containerImages,
+      vmSdkModuleProvider,
+      outboundHttp,
+    } = properties;
+    this.functions = functions;
+    this.versions = versions;
+    this.authorizer = new UpdateFunctionCodeAuthorizer({ iam });
+    this.background = background;
+    this.codeResolver = new SimLambdaCodeResolver({
+      codeStore,
+      containerImages,
+      vmSdkModuleProvider,
+      outboundHttp,
+      // The background scheduler is this simulation's clock, and the same one
+      // the function being updated was given.
+      clock: background,
+    });
+  }
+
+  /**
+   * Replace the code a sim Lambda function runs.
+   *
+   * The function keeps its name, ARN, execution Role, resource-based policy,
+   * Function URL, published versions and aliases. A version published before
+   * this still runs the code it was published with.
+   */
+  async handle(
+    command: SimUpdateFunctionCodeCommand,
+    options?: UpdateFunctionCodeCommandHandlerOptions,
+  ): Promise<SimUpdateFunctionCodeCommandOutput> {
+    const input = requireUpdateFunctionCodeInput(command);
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    const functionName = simLambdaUnqualifiedFunctionOf(input.name);
+    this.authorizer.authorize(
+      this.functions.functionArn(functionName),
+      options?.caller,
+    );
+
+    const simFunction = this.functions.require(functionName);
+    const code = await this.codeResolver.resolve(input.codeSource, {
+      // The function's own handler name and environment stand, because
+      // UpdateFunctionCode carries neither. UpdateFunctionConfiguration is
+      // where those change.
+      handlerName: simFunction.handlerName,
+      environment: simFunction.environment,
+      caller: options?.caller,
+      missingHandlerMessage:
+        `Function ${functionName} has no Handler to find zip code's export ` +
+        "in. Set one with UpdateFunctionConfiguration first.",
+    });
+
+    simFunction.updateCode(code);
+
+    return {
+      $metadata: {},
+      ...this.publishedOrUpdated(simFunction, input.publish).configuration(),
+    };
+  }
+
+  /**
+   * What the caller is answered with, which is a version of the updated code
+   * where `Publish` asked for one.
+   */
+  private publishedOrUpdated(
+    simFunction: SimLambdaFunction,
+    publish: boolean,
+  ): SimLambdaFunction {
+    return publish ? this.versions.publish(simFunction) : simFunction;
+  }
+}

--- a/src/service/lambda/command/update-function-code/update-function-code.iso.test.ts
+++ b/src/service/lambda/command/update-function-code/update-function-code.iso.test.ts
@@ -1,0 +1,214 @@
+import {
+  CreateFunctionCommand,
+  InvokeCommand,
+  UpdateFunctionCodeCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimLambdaInvalidParameterValueException,
+  SimLambdaResourceNotFoundException,
+} from "../../error/sim-lambda.error.js";
+import { makeLambdaCodeZip } from "../../function/code/make-lambda-code-zip.js";
+import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
+import { SimLambda } from "../../sim-lambda.js";
+
+function parsePayload(payload: Uint8Array | undefined): unknown {
+  assertNonNullable(payload);
+  return JSON.parse(Buffer.from(payload).toString()) as unknown;
+}
+
+describe("Lambda UpdateFunctionCodeCommand", () => {
+  it("replaces what an invocation runs", async () => {
+    // Given a function created with one handler.
+    const simLambda = new SimLambda();
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "orders",
+        Role: "arn:aws:iam::111111111111:role/OrdersRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "first") },
+      }),
+    );
+
+    // When its code is replaced with another handler.
+    await simLambda.updateFunctionCode(
+      new UpdateFunctionCodeCommand({
+        FunctionName: "orders",
+        ZipFile: makeLambdaZipFileInput(() => "second"),
+      }),
+    );
+
+    // Then an invocation runs the replacement.
+    const invoked = await simLambda.invoke(
+      new InvokeCommand({ FunctionName: "orders" }),
+    );
+    assertIdentical(parsePayload(invoked.Payload), "second");
+  });
+
+  it("answers with the updated function's configuration", async () => {
+    // Given a function described at creation.
+    const simLambda = new SimLambda();
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "orders",
+        Role: "arn:aws:iam::111111111111:role/OrdersRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "first") },
+        MemorySize: 512,
+        Timeout: 30,
+        Description: "Takes orders",
+      }),
+    );
+
+    // When its code is replaced.
+    const updated = await simLambda.updateFunctionCode(
+      new UpdateFunctionCodeCommand({
+        FunctionName: "orders",
+        ZipFile: makeLambdaZipFileInput(() => "second"),
+      }),
+    );
+
+    // Then everything the function was created with still describes it.
+    assertIdentical(updated.Version, "$LATEST");
+    assertIdentical(updated.MemorySize, 512);
+    assertIdentical(updated.Timeout, 30);
+    assertIdentical(updated.Description, "Takes orders");
+    assertIdentical(updated.Role, "arn:aws:iam::111111111111:role/OrdersRole");
+  });
+
+  it("keeps the environment variables the function was created with", async () => {
+    // Given a function whose handler reads a declared variable.
+    const simLambda = new SimLambda();
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "orders",
+        Role: "arn:aws:iam::111111111111:role/OrdersRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "first") },
+        Environment: { Variables: { ORDERS_TABLE: "orders-v1" } },
+      }),
+    );
+
+    // When its code is replaced with a handler that reads the same variable.
+    await simLambda.updateFunctionCode(
+      new UpdateFunctionCodeCommand({
+        FunctionName: "orders",
+        ZipFile: makeLambdaZipFileInput(() => process.env["ORDERS_TABLE"]),
+      }),
+    );
+
+    // Then the replacement reads the value the function already had.
+    const invoked = await simLambda.invoke(
+      new InvokeCommand({ FunctionName: "orders" }),
+    );
+    assertIdentical(parsePayload(invoked.Payload), "orders-v1");
+  });
+
+  it("runs replacement zip code under the function's own Handler", async () => {
+    // Given a function created from zip source code with a named handler.
+    const simAws = new SimAws();
+    const lambda = simAws.lambda();
+    await lambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "orders",
+        Role: `arn:aws:iam::${simAws.defaultAccountId}:role/OrdersRole`,
+        Handler: "index.handler",
+        Runtime: "nodejs22.x",
+        Code: {
+          ZipFile: makeLambdaCodeZip("exports.handler = async () => 1;"),
+        },
+      }),
+    );
+
+    // When the zip is replaced, without naming a Handler again.
+    await lambda.updateFunctionCode(
+      new UpdateFunctionCodeCommand({
+        FunctionName: "orders",
+        ZipFile: makeLambdaCodeZip("exports.handler = async () => 2;"),
+      }),
+    );
+
+    // Then the new source ran under the handler the function already had.
+    const invoked = await lambda.invoke(
+      new InvokeCommand({ FunctionName: "orders" }),
+    );
+    assertIdentical(parsePayload(invoked.Payload), 2);
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses zip code for a function with no Handler to run it under", async () => {
+    // Given a function created from a real in-process handler, which needs no
+    // Handler name of its own.
+    const simLambda = new SimLambda();
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "orders",
+        Role: "arn:aws:iam::111111111111:role/OrdersRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "first") },
+      }),
+    );
+
+    // When its code is replaced with zip source code.
+    const error = await assertThrowsErrorAsync(async () =>
+      simLambda.updateFunctionCode(
+        new UpdateFunctionCodeCommand({
+          FunctionName: "orders",
+          ZipFile: makeLambdaCodeZip("exports.handler = async () => 1;"),
+        }),
+      ),
+    );
+
+    // Then the refusal says which command sets a Handler.
+    assertStringIncludes(error.message, "has no Handler");
+    assertStringIncludes(error.message, "UpdateFunctionConfiguration");
+  });
+
+  it("fails for a function name that belongs to no function", async () => {
+    const simLambda = new SimLambda();
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simLambda.updateFunctionCode(
+        new UpdateFunctionCodeCommand({
+          FunctionName: "absent",
+          ZipFile: makeLambdaZipFileInput(() => "second"),
+        }),
+      ),
+    );
+
+    assertInstanceOf(error, SimLambdaResourceNotFoundException);
+    assertStringIncludes(error.message, "Function not found");
+  });
+
+  it("refuses a qualified function name", async () => {
+    // Given a function with a published version.
+    const simLambda = new SimLambda();
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "orders",
+        Role: "arn:aws:iam::111111111111:role/OrdersRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "first") },
+      }),
+    );
+
+    // When an update names that version.
+    const error = await assertThrowsErrorAsync(async () =>
+      simLambda.updateFunctionCode(
+        new UpdateFunctionCodeCommand({
+          FunctionName: "orders:1",
+          ZipFile: makeLambdaZipFileInput(() => "second"),
+        }),
+      ),
+    );
+
+    // Then it is refused, because a published version's code never changes.
+    assertInstanceOf(error, SimLambdaInvalidParameterValueException);
+    assertStringIncludes(error.message, "not permitted on a qualified");
+  });
+});

--- a/src/service/lambda/function/code/lambda-code-source.ts
+++ b/src/service/lambda/function/code/lambda-code-source.ts
@@ -65,7 +65,26 @@ export type SimLambdaCodeSource =
   | SimLambdaContainerImageSource;
 
 /**
- * Validate CreateFunction code input into a sim Lambda code source.
+ * Where a command carries its code members, for validation failures to point
+ * at the request the caller actually made.
+ *
+ * CreateFunction nests them under `Code`, while UpdateFunctionCode carries
+ * them at the top level of its input.
+ */
+export interface SimLambdaCodeInputNaming {
+  /** The path to the members, such as `CreateFunctionCommand.input.Code`. */
+  readonly path: string;
+  /** What prefixes a member name, such as `Code.` or nothing at all. */
+  readonly memberPrefix: string;
+}
+
+const createFunctionCodeNaming: SimLambdaCodeInputNaming = {
+  path: "CreateFunctionCommand.input.Code",
+  memberPrefix: "Code.",
+};
+
+/**
+ * Validate function code input into a sim Lambda code source.
  *
  * Exactly one of ZipFile, an S3 object location or a container image URI must
  * be given, as on real AWS. S3ObjectVersion is accepted but ignored, as sim S3
@@ -73,20 +92,21 @@ export type SimLambdaCodeSource =
  */
 export function requireLambdaCodeSource(
   code: SimLambdaCodeInput | undefined,
+  naming: SimLambdaCodeInputNaming = createFunctionCodeNaming,
 ): SimLambdaCodeSource {
-  assertDefined(code, "CreateFunctionCommand.input.Code required");
+  assertDefined(code, `${naming.path} required`);
 
   if (code.ImageUri !== undefined) {
-    return containerImageSource(code.ImageUri, code);
+    return containerImageSource(code.ImageUri, code, naming);
   }
   if (code.ZipFile !== undefined) {
-    return zipFileSource(code.ZipFile, code);
+    return zipFileSource(code.ZipFile, code, naming);
   }
   if (code.S3Bucket !== undefined || code.S3Key !== undefined) {
-    return s3LocationSource(code);
+    return s3LocationSource(code, naming);
   }
   throw new SimLambdaInvalidParameterValueException(
-    "CreateFunctionCommand.input.Code requires either ZipFile bytes, an " +
+    `${naming.path} requires either ZipFile bytes, an ` +
       "S3Bucket and S3Key object location, or an ImageUri",
   );
 }
@@ -98,6 +118,7 @@ export function requireLambdaCodeSource(
 function containerImageSource(
   imageUri: string,
   code: SimLambdaCodeInput,
+  naming: SimLambdaCodeInputNaming,
 ): SimLambdaContainerImageSource {
   if (
     code.ZipFile !== undefined ||
@@ -106,7 +127,7 @@ function containerImageSource(
   ) {
     throw new SimLambdaInvalidParameterValueException(
       "Please do not provide ZipFile bytes or an S3 object location when " +
-        "using Code.ImageUri",
+        `using ${naming.memberPrefix}ImageUri`,
     );
   }
 
@@ -116,10 +137,12 @@ function containerImageSource(
 function zipFileSource(
   zipFile: Uint8Array,
   code: SimLambdaCodeInput,
+  naming: SimLambdaCodeInputNaming,
 ): SimLambdaCodeSource {
   if (code.S3Bucket !== undefined || code.S3Key !== undefined) {
     throw new SimLambdaInvalidParameterValueException(
-      "Please do not provide an S3 object location when using Code.ZipFile",
+      "Please do not provide an S3 object location when using " +
+        `${naming.memberPrefix}ZipFile`,
     );
   }
   if (zipFile instanceof LambdaZipFileStowaway) {
@@ -131,15 +154,12 @@ function zipFileSource(
   return { kind: "zip-bytes", zipBytes: zipFile };
 }
 
-function s3LocationSource(code: SimLambdaCodeInput): SimLambdaS3LocationSource {
-  assertDefined(
-    code.S3Bucket,
-    "CreateFunctionCommand.input.Code.S3Bucket required with S3Key",
-  );
-  assertDefined(
-    code.S3Key,
-    "CreateFunctionCommand.input.Code.S3Key required with S3Bucket",
-  );
+function s3LocationSource(
+  code: SimLambdaCodeInput,
+  naming: SimLambdaCodeInputNaming,
+): SimLambdaS3LocationSource {
+  assertDefined(code.S3Bucket, `${naming.path}.S3Bucket required with S3Key`);
+  assertDefined(code.S3Key, `${naming.path}.S3Key required with S3Bucket`);
   return {
     kind: "s3-location",
     bucketName: code.S3Bucket,

--- a/src/service/lambda/function/code/sim-lambda-code-resolver.ts
+++ b/src/service/lambda/function/code/sim-lambda-code-resolver.ts
@@ -49,6 +49,12 @@ export interface SimLambdaCodeResolveContext {
   readonly handlerName: string | undefined;
   readonly environment: SimLambdaEnvironment;
   readonly caller?: SimAwsCaller | undefined;
+  /**
+   * What to say when zip code arrives with no handler name to find its export
+   * in. CreateFunction takes the name on the request, while UpdateFunctionCode
+   * has only whatever the function was created with.
+   */
+  readonly missingHandlerMessage?: string | undefined;
 }
 
 /**

--- a/src/service/lambda/function/code/sim-lambda-vm-zip-code-factory.ts
+++ b/src/service/lambda/function/code/sim-lambda-vm-zip-code-factory.ts
@@ -42,7 +42,8 @@ export class SimLambdaVmZipCodeFactory {
   ): SimLambdaVmZipCode {
     assertDefined(
       context.handlerName,
-      "CreateFunctionCommand.input.Handler required for zip function code",
+      context.missingHandlerMessage ??
+        "CreateFunctionCommand.input.Handler required for zip function code",
     );
 
     return new SimLambdaVmZipCode({

--- a/src/service/lambda/function/sim-lambda-function.ts
+++ b/src/service/lambda/function/sim-lambda-function.ts
@@ -1,4 +1,3 @@
-import type { Brand } from "../../../util/brand.type.js";
 import type { SimAwsRunAsOwner } from "../../aws/caller/sim-aws-run-as-context.js";
 import { simAwsRunAsContext } from "../../aws/caller/sim-aws-run-as-context.js";
 import { simAwsAccountRegionScopeFactory } from "../../aws/sim-aws-account-region-scope.factory.js";
@@ -18,64 +17,22 @@ import {
 } from "./code/sim-lambda-executable-code.js";
 import { SimLambdaEnvironment } from "./environment/sim-lambda-environment.js";
 import { SimLambdaFunctionLogging } from "./logging/sim-lambda-function-logging.js";
-import type { SimLogsServiceWriter } from "../../logs/write/sim-logs-service-writer.js";
 import { SimLambdaFunctionPolicy } from "./policy/sim-lambda-function-policy.js";
 import { SimLambdaHandlerRunner } from "./invoke/sim-lambda-handler-runner.js";
 import { SimLambdaInvokeContextBuilder } from "./invoke/sim-lambda-invoke-context-builder.js";
 import { runSimLambdaInHostScope } from "./invoke/sim-lambda-host-scope.js";
 import type { SimLambdaOutboundHttp } from "./outbound/sim-lambda-outbound-http.js";
 import { type SimClock, SimRealClock } from "../../../util/clock/sim-clock.js";
-import {
-  defaultLambdaHandler,
-  type SimLambdaHandler,
-} from "./sim-lambda-handler.type.js";
-
-export type SimLambdaFunctionName = Brand<string, "SimLambdaFunctionName">;
-
-export type SimLambdaFunctionMap = Map<
+import { defaultLambdaHandler } from "./sim-lambda-handler.type.js";
+import type {
   SimLambdaFunctionName,
-  SimLambdaFunction
->;
+  SimLambdaFunctionProperties,
+} from "./sim-lambda-function.type.js";
 
-interface SimLambdaFunctionProperties {
-  name: SimLambdaFunctionName | string;
-  roleArn: string;
-  readonly accountRegionScope?: SimAwsAccountRegionScope;
-  handlerFunction?: SimLambdaHandler;
-  code?: SimLambdaExecutableCode | undefined;
-  state?: SimLambdaFunctionState;
-  handlerName?: string | undefined;
-  runtimeName?: string | undefined;
-  description?: string | undefined;
-  timeoutSeconds?: number | undefined;
-  memorySizeMb?: number | undefined;
-  environment?: SimLambdaEnvironment | undefined;
-  runAsOwner?: SimAwsRunAsOwner;
-  /**
-   * The version this is. A function is `$LATEST`, and a version published
-   * from one is a copy of it under the number it was published as.
-   */
-  version?: string | undefined;
-  /**
-   * Clock this function's invocations measure their remaining time against. A
-   * function built standalone, outside a SimAws instance, falls back to the
-   * real clock.
-   */
-  clock?: SimClock | undefined;
-  /**
-   * Where this function's handler output is recorded. A function built
-   * standalone, outside a SimAws instance, has nowhere to record to and writes
-   * only to the host streams.
-   */
-  logs?: SimLogsServiceWriter | undefined;
-  /**
-   * Where the HTTP requests this function's code makes to hostnames the
-   * simulation serves are answered. A function built standalone, outside a
-   * SimAws instance, has no simulation to answer them and reaches the network
-   * as any other code would.
-   */
-  outboundHttp?: SimLambdaOutboundHttp | undefined;
-}
+export type {
+  SimLambdaFunctionName,
+  SimLambdaFunctionMap,
+} from "./sim-lambda-function.type.js";
 
 /**
  * Simulated Lambda function resource.
@@ -107,8 +64,8 @@ export class SimLambdaFunction {
   public readonly resourcePolicy = new SimLambdaFunctionPolicy();
 
   #state: SimLambdaFunctionState;
+  #code: SimLambdaExecutableCode;
   private readonly properties: SimLambdaFunctionProperties;
-  private readonly code: SimLambdaExecutableCode;
   private readonly runAsOwner: SimAwsRunAsOwner;
   private readonly runner = new SimLambdaHandlerRunner();
   private readonly clock: SimClock;
@@ -141,7 +98,7 @@ export class SimLambdaFunction {
     this.name = name as SimLambdaFunctionName;
     this.roleArn = roleArn;
     this.accountRegionScope = accountRegionScope;
-    this.code = code ?? new SimLambdaHandlerReferenceCode(handlerFunction);
+    this.#code = code ?? new SimLambdaHandlerReferenceCode(handlerFunction);
     this.#state = state;
     this.handlerName = handlerName;
     this.runtimeName = runtimeName;
@@ -199,13 +156,25 @@ export class SimLambdaFunction {
   publishedAs(version: string, description?: string): SimLambdaFunction {
     return new SimLambdaFunction({
       ...this.properties,
-      code: this.code,
+      code: this.#code,
       environment: this.environment,
       runAsOwner: this.runAsOwner,
       state: "Active",
       description: description ?? this.description,
       version,
     });
+  }
+
+  /**
+   * Replace the code this function runs, keeping everything else about it.
+   *
+   * The function object survives the change. Its resource-based policy lives
+   * on the object, and the version, alias and Function URL stores hold it
+   * under its name. A version published beforehand keeps its own reference to
+   * the code it was published with.
+   */
+  updateCode(code: SimLambdaExecutableCode): void {
+    this.#code = code;
   }
 
   /**
@@ -259,7 +228,7 @@ export class SimLambdaFunction {
       logStreamName: this.logging.logStreamName(),
     });
 
-    this.logging.recordFrom(this.code);
+    this.logging.recordFrom(this.#code);
 
     return await simAwsRunAsContext.run(
       this.runAsOwner,
@@ -272,7 +241,7 @@ export class SimLambdaFunction {
                 await this.logging.around(
                   async () =>
                     await this.runner.run(
-                      this.code.handlerFunction(),
+                      this.#code.handlerFunction(),
                       event,
                       contextBuilder,
                     ),
@@ -288,7 +257,7 @@ export class SimLambdaFunction {
    * and the console and streams it prints through.
    */
   private async runInHostScope<T>(run: () => Promise<T>): Promise<T> {
-    if (!this.code.runsInHostScope) {
+    if (!this.#code.runsInHostScope) {
       return await run();
     }
 

--- a/src/service/lambda/function/sim-lambda-function.type.ts
+++ b/src/service/lambda/function/sim-lambda-function.type.ts
@@ -1,0 +1,58 @@
+import type { Brand } from "../../../util/brand.type.js";
+import type { SimClock } from "../../../util/clock/sim-clock.js";
+import type { SimAwsRunAsOwner } from "../../aws/caller/sim-aws-run-as-context.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimLogsServiceWriter } from "../../logs/write/sim-logs-service-writer.js";
+import type { SimLambdaExecutableCode } from "./code/sim-lambda-executable-code.js";
+import type { SimLambdaEnvironment } from "./environment/sim-lambda-environment.js";
+import type { SimLambdaOutboundHttp } from "./outbound/sim-lambda-outbound-http.js";
+import type { SimLambdaFunctionState } from "./sim-lambda-function-configuration.js";
+import type { SimLambdaHandler } from "./sim-lambda-handler.type.js";
+import type { SimLambdaFunction } from "./sim-lambda-function.js";
+
+export type SimLambdaFunctionName = Brand<string, "SimLambdaFunctionName">;
+
+export type SimLambdaFunctionMap = Map<
+  SimLambdaFunctionName,
+  SimLambdaFunction
+>;
+
+export interface SimLambdaFunctionProperties {
+  name: SimLambdaFunctionName | string;
+  roleArn: string;
+  readonly accountRegionScope?: SimAwsAccountRegionScope;
+  handlerFunction?: SimLambdaHandler;
+  code?: SimLambdaExecutableCode | undefined;
+  state?: SimLambdaFunctionState;
+  handlerName?: string | undefined;
+  runtimeName?: string | undefined;
+  description?: string | undefined;
+  timeoutSeconds?: number | undefined;
+  memorySizeMb?: number | undefined;
+  environment?: SimLambdaEnvironment | undefined;
+  runAsOwner?: SimAwsRunAsOwner;
+  /**
+   * The version this is. A function is `$LATEST`, and a version published
+   * from one is a copy of it under the number it was published as.
+   */
+  version?: string | undefined;
+  /**
+   * Clock this function's invocations measure their remaining time against. A
+   * function built standalone, outside a SimAws instance, falls back to the
+   * real clock.
+   */
+  clock?: SimClock | undefined;
+  /**
+   * Where this function's handler output is recorded. A function built
+   * standalone, outside a SimAws instance, has nowhere to record to and writes
+   * only to the host streams.
+   */
+  logs?: SimLogsServiceWriter | undefined;
+  /**
+   * Where the HTTP requests this function's code makes to hostnames the
+   * simulation serves are answered. A function built standalone, outside a
+   * SimAws instance, has no simulation to answer them and reaches the network
+   * as any other code would.
+   */
+  outboundHttp?: SimLambdaOutboundHttp | undefined;
+}

--- a/src/service/lambda/sdk/sim-lambda-sdk-command-router.iso.test.ts
+++ b/src/service/lambda/sdk/sim-lambda-sdk-command-router.iso.test.ts
@@ -5,8 +5,11 @@ import {
   InvokeCommand,
   LambdaClient,
   ListFunctionsCommand,
+  UpdateFunctionCodeCommand,
+  UpdateFunctionConfigurationCommand,
 } from "@aws-sdk/client-lambda";
 import {
+  assertArrayLength,
   assertIdentical,
   assertNonNullable,
   assertObjectEquals,
@@ -106,16 +109,51 @@ describe("simulated Lambda SDK Command routing", () => {
     await simSdk.simAws.backgroundTasksComplete();
   });
 
+  it("routes UpdateFunctionCode and ListFunctions through an intercepted client", async () => {
+    using simSdk = new SimSdk();
+    const client = new LambdaClient({ region: "eu-west-2" });
+    simSdk.intercept(client);
+
+    await client.send(
+      new CreateFunctionCommand({
+        FunctionName: "intercepted",
+        Role: "arn:aws:iam::111111111111:role/InterceptedRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "first") },
+      }),
+    );
+    await client.send(
+      new UpdateFunctionCodeCommand({
+        FunctionName: "intercepted",
+        ZipFile: makeLambdaZipFileInput(() => "second"),
+      }),
+    );
+
+    const invoked = await client.send(
+      new InvokeCommand({ FunctionName: "intercepted" }),
+    );
+    assertNonNullable(invoked.Payload);
+    assertIdentical(Buffer.from(invoked.Payload).toString(), '"second"');
+
+    const listed = await client.send(new ListFunctionsCommand({}));
+    assertNonNullable(listed.Functions);
+    assertArrayLength(listed.Functions, 1);
+    assertIdentical(listed.Functions[0].FunctionName, "intercepted");
+
+    await simSdk.simAws.backgroundTasksComplete();
+  });
+
   it("rejects a Command simulated Lambda does not support", async () => {
     using simSdk = new SimSdk();
     const client = new LambdaClient({ region: "eu-west-2" });
     simSdk.intercept(client);
 
     const error = await assertThrowsErrorAsync(async () => {
-      await client.send(new ListFunctionsCommand({}));
+      await client.send(
+        new UpdateFunctionConfigurationCommand({ FunctionName: "orders" }),
+      );
     });
 
-    assertStringIncludes(error.message, "ListFunctionsCommand");
+    assertStringIncludes(error.message, "UpdateFunctionConfigurationCommand");
     assertStringIncludes(error.message, "InvokeCommand");
   });
 });

--- a/src/service/lambda/sdk/sim-lambda-sdk-command-router.ts
+++ b/src/service/lambda/sdk/sim-lambda-sdk-command-router.ts
@@ -12,6 +12,8 @@ import type { SimListVersionsByFunctionCommand } from "../command/list-versions-
 import type { SimPublishVersionCommand } from "../command/publish-version/publish-version.command.js";
 import type { SimUpdateAliasCommand } from "../command/update-alias/update-alias.command.js";
 import type { SimCreateFunctionCommand } from "../command/create-function/create-function.command.js";
+import type { SimListFunctionsCommand } from "../command/list-functions/list-functions.command.js";
+import type { SimUpdateFunctionCodeCommand } from "../command/update-function-code/update-function-code.command.js";
 import type {
   SimCreateEventSourceMappingCommand,
   SimDeleteEventSourceMappingCommand,
@@ -51,6 +53,22 @@ export class SimLambdaSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simLambda.getFunction(
             command as SimGetFunctionCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "UpdateFunctionCodeCommand",
+        async (command, context): Promise<unknown> =>
+          await simLambda.updateFunctionCode(
+            command as SimUpdateFunctionCodeCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListFunctionsCommand",
+        async (command, context): Promise<unknown> =>
+          await simLambda.listFunctions(
+            command as SimListFunctionsCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/lambda/serve/api/sim-lambda-api-function-input.ts
+++ b/src/service/lambda/serve/api/sim-lambda-api-function-input.ts
@@ -1,0 +1,84 @@
+import { isRecord } from "../../../../util/type-guard/record.js";
+import type { SimRestJsonInput } from "../../../../serve/http/api/rest-json/sim-rest-json-input.js";
+import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
+
+/**
+ * The invocation types real Lambda accepts, which it names in a header rather
+ * than in the body.
+ */
+const invocationTypes: readonly string[] = [
+  "RequestResponse",
+  "Event",
+  "DryRun",
+];
+
+/**
+ * Read a CreateFunction request, whose members are all in the body.
+ *
+ * The one member JSON cannot carry as it is is the code, which travels base64
+ * encoded and reaches the simulation as the bytes of a zip.
+ */
+export function createFunctionInput(
+  input: SimRestJsonInput,
+): Record<string, unknown> {
+  const members = input.json();
+  const code = members["Code"];
+
+  return isRecord(code)
+    ? { ...members, Code: functionCode(code) }
+    : { ...members };
+}
+
+/**
+ * Read an UpdateFunctionCode request, which names the function in the path and
+ * carries the code members in the body rather than under a `Code` member.
+ */
+export function updateFunctionCodeInput(
+  input: SimRestJsonInput,
+): Record<string, unknown> {
+  return {
+    ...functionCode(input.json()),
+    FunctionName: input.label("FunctionName"),
+  };
+}
+
+function functionCode(code: Record<string, unknown>): Record<string, unknown> {
+  const zipFile = code["ZipFile"];
+
+  return typeof zipFile === "string"
+    ? { ...code, ZipFile: Buffer.from(zipFile, "base64") }
+    : code;
+}
+
+/**
+ * Read an Invoke request, which states its members in three different places.
+ *
+ * The body is the payload itself rather than a JSON object holding it, so it
+ * is passed on as the bytes that arrived. That is what lets `aws lambda
+ * invoke --payload` send a document the handler receives unchanged.
+ */
+export function invokeInput(input: SimRestJsonInput): Record<string, unknown> {
+  return {
+    FunctionName: input.label("FunctionName"),
+    InvocationType: invocationType(input.header("x-amz-invocation-type")),
+    Qualifier: input.query("Qualifier"),
+    Payload: input.body,
+  };
+}
+
+/**
+ * Check the invocation type a request asked for.
+ *
+ * An unrecognised one is refused the way real Lambda refuses it, rather than
+ * passed on to a dispatcher that has nothing to do with it.
+ */
+function invocationType(value: string | undefined): string | undefined {
+  if (value !== undefined && !invocationTypes.includes(value)) {
+    throw new SimLambdaInvalidParameterValueException(
+      `Unrecognized invocation type ${value}. Valid invocation types are ` +
+        `${invocationTypes.join(", ")}.`,
+    );
+  }
+
+  return value;
+}

--- a/src/service/lambda/serve/api/sim-lambda-api-function-routes.ts
+++ b/src/service/lambda/serve/api/sim-lambda-api-function-routes.ts
@@ -1,18 +1,10 @@
-import { isRecord } from "../../../../util/type-guard/record.js";
-import type { SimRestJsonInput } from "../../../../serve/http/api/rest-json/sim-rest-json-input.js";
 import type { SimRestJsonRoute } from "../../../../serve/http/api/rest-json/sim-rest-json-route.type.js";
-import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
+import {
+  createFunctionInput,
+  invokeInput,
+  updateFunctionCodeInput,
+} from "./sim-lambda-api-function-input.js";
 import { simLambdaInvokeResponse } from "./sim-lambda-api-invoke-output.js";
-
-/**
- * The invocation types real Lambda accepts, which it names in a header rather
- * than in the body.
- */
-const invocationTypes: readonly string[] = [
-  "RequestResponse",
-  "Event",
-  "DryRun",
-];
 
 /**
  * The function operations this endpoint serves.
@@ -27,9 +19,21 @@ export const simLambdaFunctionApiRoutes: readonly SimRestJsonRoute[] = [
   },
   {
     method: "GET",
+    path: "/2015-03-31/functions",
+    commandName: "ListFunctionsCommand",
+    input: (input) => ({ FunctionVersion: input.query("FunctionVersion") }),
+  },
+  {
+    method: "GET",
     path: "/2015-03-31/functions/{FunctionName}",
     commandName: "GetFunctionCommand",
     input: (input) => ({ FunctionName: input.label("FunctionName") }),
+  },
+  {
+    method: "PUT",
+    path: "/2015-03-31/functions/{FunctionName}/code",
+    commandName: "UpdateFunctionCodeCommand",
+    input: updateFunctionCodeInput,
   },
   {
     method: "DELETE",
@@ -45,59 +49,3 @@ export const simLambdaFunctionApiRoutes: readonly SimRestJsonRoute[] = [
     output: simLambdaInvokeResponse,
   },
 ];
-
-/**
- * Read a CreateFunction request, whose members are all in the body.
- *
- * The one member JSON cannot carry as it is is the code, which travels base64
- * encoded and reaches the simulation as the bytes of a zip.
- */
-function createFunctionInput(input: SimRestJsonInput): Record<string, unknown> {
-  const members = input.json();
-  const code = members["Code"];
-
-  return isRecord(code)
-    ? { ...members, Code: functionCode(code) }
-    : { ...members };
-}
-
-function functionCode(code: Record<string, unknown>): Record<string, unknown> {
-  const zipFile = code["ZipFile"];
-
-  return typeof zipFile === "string"
-    ? { ...code, ZipFile: Buffer.from(zipFile, "base64") }
-    : code;
-}
-
-/**
- * Read an Invoke request, which states its members in three different places.
- *
- * The body is the payload itself rather than a JSON object holding it, so it
- * is passed on as the bytes that arrived. That is what lets `aws lambda
- * invoke --payload` send a document the handler receives unchanged.
- */
-function invokeInput(input: SimRestJsonInput): Record<string, unknown> {
-  return {
-    FunctionName: input.label("FunctionName"),
-    InvocationType: invocationType(input.header("x-amz-invocation-type")),
-    Qualifier: input.query("Qualifier"),
-    Payload: input.body,
-  };
-}
-
-/**
- * Check the invocation type a request asked for.
- *
- * An unrecognised one is refused the way real Lambda refuses it, rather than
- * passed on to a dispatcher that has nothing to do with it.
- */
-function invocationType(value: string | undefined): string | undefined {
-  if (value !== undefined && !invocationTypes.includes(value)) {
-    throw new SimLambdaInvalidParameterValueException(
-      `Unrecognized invocation type ${value}. Valid invocation types are ` +
-        `${invocationTypes.join(", ")}.`,
-    );
-  }
-
-  return value;
-}

--- a/src/service/lambda/serve/api/sim-lambda-api-routes.iso.test.ts
+++ b/src/service/lambda/serve/api/sim-lambda-api-routes.iso.test.ts
@@ -1,4 +1,5 @@
 import {
+  assertBufferEqual,
   assertIdentical,
   assertObjectEquals,
   assertObjectMatches,
@@ -87,6 +88,14 @@ describe("Resolving a Lambda operation from a served request", () => {
       command("POST", "/2015-03-31/functions/orders/invocations"),
       "InvokeCommand",
     );
+    assertIdentical(
+      command("GET", "/2015-03-31/functions"),
+      "ListFunctionsCommand",
+    );
+    assertIdentical(
+      command("PUT", "/2015-03-31/functions/orders/code"),
+      "UpdateFunctionCodeCommand",
+    );
   });
 
   it("routes the Function URL configuration operations", () => {
@@ -140,9 +149,10 @@ describe("Resolving a Lambda operation from a served request", () => {
     // Given the paths of Lambda operations this simulation has not
     // implemented, each sharing its method with one it has
     // Then none of them resolves to the operation beside it
-    assertUndefined(command("GET", "/2015-03-31/functions"));
     assertUndefined(command("POST", "/2015-03-31/functions/orders/versions"));
-    assertUndefined(command("PUT", "/2015-03-31/functions/orders/code"));
+    assertUndefined(
+      command("PUT", "/2015-03-31/functions/orders/configuration"),
+    );
     assertUndefined(
       command("GET", "/2015-03-31/functions/orders/configuration"),
     );
@@ -182,6 +192,29 @@ describe("Resolving a Lambda operation from a served request", () => {
       input("DELETE", "/2015-03-31/event-source-mappings/a-uuid"),
       mapping,
     );
+  });
+
+  it("reads the version listing a query asked for", () => {
+    // Given a listing whose only member travels in the query string
+    assertObjectEquals(input("GET", "/2015-03-31/functions"), {
+      FunctionVersion: undefined,
+    });
+    assertObjectEquals(
+      input("GET", "/2015-03-31/functions?FunctionVersion=ALL"),
+      { FunctionVersion: "ALL" },
+    );
+  });
+
+  it("reads replacement code from both the path and the body", () => {
+    // Given an UpdateFunctionCode request, whose zip travels base64 encoded
+    // the way JSON has to carry bytes
+    const zipFile = Buffer.from("a zip archive");
+    const read = input("PUT", "/2015-03-31/functions/orders/code", {
+      body: JSON.stringify({ ZipFile: zipFile.toString("base64") }),
+    });
+
+    assertIdentical(read["FunctionName"], "orders");
+    assertBufferEqual(read["ZipFile"] as Uint8Array, zipFile);
   });
 
   it("reads a write from both the path and the body", () => {

--- a/src/service/lambda/serve/api/sim-lambda-api.iso.test.ts
+++ b/src/service/lambda/serve/api/sim-lambda-api.iso.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../../../../../test/lambda/served-lambda-api.js";
 import { SimRestJsonApiEndpoint } from "../../../../serve/http/api/rest-json/sim-rest-json-endpoint.js";
 import { SimAws } from "../../../aws/sim-aws.js";
+import { makeLambdaCodeZip } from "../../function/code/make-lambda-code-zip.js";
 
 /**
  * What the served Lambda endpoint does with a request, once the protocol has
@@ -73,6 +74,56 @@ describe("Serving the simulated Lambda control plane", () => {
     assertObjectMatches((await response.json()) as object, { ok: true });
   });
 
+  it("lists the functions the simulation holds", async () => {
+    // Given a served simulation
+    const { send } = await servedLambdaApi();
+
+    // When the functions are listed, as `aws lambda list-functions` lists them
+    const response = await send("GET", "/2015-03-31/functions");
+
+    // Then the one function the simulation holds is reported
+    assertIdentical(response.status, 200);
+    assertObjectMatches((await response.json()) as object, {
+      Functions: [{ FunctionName: "orders" }],
+    });
+  });
+
+  it("replaces a function's code from a base64 zip in the body", async () => {
+    // Given a served simulation holding a zip code function
+    const { send } = await servedLambdaApi({
+      Handler: "index.handler",
+      Runtime: "nodejs22.x",
+      Code: {
+        ZipFile: makeLambdaCodeZip("exports.handler = async () => 'replaced';"),
+      },
+    });
+
+    // When replacement code arrives the way JSON has to carry bytes
+    const replacement = makeLambdaCodeZip(
+      "exports.handler = async () => 'again';",
+    );
+    const response = await send("PUT", "/2015-03-31/functions/orders/code", {
+      body: JSON.stringify({
+        ZipFile: Buffer.from(replacement).toString("base64"),
+      }),
+    });
+
+    // Then the function is reported updated, and an invocation runs the
+    // replacement
+    assertIdentical(response.status, 200);
+    assertObjectMatches((await response.json()) as object, {
+      FunctionName: "orders",
+      Version: "$LATEST",
+    });
+
+    const invoked = await send(
+      "POST",
+      "/2015-03-31/functions/orders/invocations",
+      { body: "{}" },
+    );
+    assertIdentical(await invoked.text(), '"again"');
+  });
+
   it("reports a body that states itself as JSON and is not", async () => {
     // Given a served simulation
     const { send } = await servedLambdaApi();
@@ -102,7 +153,7 @@ describe("Serving the simulated Lambda control plane", () => {
         {
           method: "POST",
           path: "/2015-03-31/functions/{FunctionName}/code",
-          commandName: "UpdateFunctionCodeCommand",
+          commandName: "UpdateFunctionConfigurationCommand",
           input: (input) => ({ FunctionName: input.label("FunctionName") }),
         },
       ],
@@ -122,6 +173,9 @@ describe("Serving the simulated Lambda control plane", () => {
     // Then the endpoint says so rather than answering with a server error
     assertIdentical(response.status, 501);
     assertIdentical(response.headers.get("x-amzn-errortype"), "NotImplemented");
-    assertStringIncludes(await response.text(), "UpdateFunctionCodeCommand");
+    assertStringIncludes(
+      await response.text(),
+      "UpdateFunctionConfigurationCommand",
+    );
   });
 });

--- a/src/service/lambda/sim-lambda-commands.ts
+++ b/src/service/lambda/sim-lambda-commands.ts
@@ -172,6 +172,7 @@ export class SimLambdaCommands {
     this.functions = new SimLambdaFunctionCommands({
       accountRegionScope,
       functions: properties.functions,
+      functionLookup: this.functionLookup,
       functionUrls: this.functionUrlStore,
       versions: this.versionStore,
       iam,

--- a/src/service/lambda/sim-lambda.ts
+++ b/src/service/lambda/sim-lambda.ts
@@ -75,6 +75,22 @@ export class SimLambda extends SimLambdaInspection {
     return await this.commands.functions.get(command, options);
   }
 
+  /** Handle an Update Function Code Command from the SDK. */
+  async updateFunctionCode(
+    command: simLambdaCommands.SimUpdateFunctionCodeCommand,
+    options?: SimLambdaRequestOptions,
+  ): Promise<simLambdaCommands.SimUpdateFunctionCodeCommandOutput> {
+    return await this.commands.functions.updateCode(command, options);
+  }
+
+  /** Handle a List Functions Command from the SDK. */
+  async listFunctions(
+    command: simLambdaCommands.SimListFunctionsCommand,
+    options?: SimLambdaRequestOptions,
+  ): Promise<simLambdaCommands.SimListFunctionsCommandOutput> {
+    return await this.commands.functions.list(command, options);
+  }
+
   /** Handle a Delete Function Command from the SDK. */
   async deleteFunction(
     command: simLambdaCommands.SimDeleteFunctionCommand,


### PR DESCRIPTION
UpdateFunctionCode replaces the code `$LATEST` runs, taking the four code shapes CreateFunction takes at the top level of its input. The function object survives the change, so its name, ARN, execution Role, environment, resource-based policy, Function URL, published versions and aliases all carry over, and a version published beforehand goes on running the code it was published with. Zip code runs under the Handler the function already has, because the command carries none of its own. ListFunctions comes along with it, reporting every function in the Account and Region and adding their published versions for `FunctionVersion: "ALL"`. Both are routed for SDK interception and served over the HTTP control plane, which makes `aws lambda update-function-code` and `aws lambda list-functions` reach the simulation.

Resolves #833

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for listing simulated Lambda functions, including published versions.
  * Added support for replacing Lambda function code using ZIP, S3, or container image sources.
  * Added optional publishing of updated code as a new version while preserving existing versions, aliases, configuration, and URLs.
  * Added IAM authorization for listing functions and updating function code.
  * Added executable examples demonstrating both operations.

* **Documentation**
  * Expanded Lambda API documentation, supported-operation lists, limitations, and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->