### PR TITLE
feat: serve S3 CopyObject over the REST endpoint

### DIFF
--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -744,13 +744,37 @@ The destination Bucket raises `s3:ObjectCreated:Copy`, and `s3:ObjectCreated:*` 
 Copying an Object onto itself without `REPLACE` is refused with `InvalidRequest`, as real S3 refuses
 it. The copy would leave the Object exactly as it found it.
 
+### Over a served endpoint
+
+Real S3 states a copy as a `PUT` on the destination carrying an `x-amz-copy-source` header and an
+empty body. The served endpoint reads that header and runs the operation an in-process caller
+reaches. `aws s3 cp` and `aws s3 mv` between two served Buckets then behave as they do against real
+S3, for a file under the CLI's eight megabyte multipart threshold.
+
+```bash
+aws s3 cp ./report.pdf s3://inbox/report.pdf
+aws s3 mv s3://inbox/report.pdf s3://archive/2026/report.pdf
+aws s3 ls s3://archive/2026/
+```
+
+The source is decoded one key segment at a time, the way a key in the request path is, and
+`x-amz-metadata-directive` carries `MetadataDirective`. A finished copy answers with the
+`CopyObjectResult` document holding the ETag and the write time.
+
+Real S3 answers a failed copy with `200` and an error document in the body (it has to start sending
+the response while the bytes are still moving). Sim S3 copies in memory and answers with the status
+the error maps to, and an SDK raises it as it raises any other S3 failure.
+
+See [Serve simulated S3 on localhost](#serve-simulated-s3-on-localhost) for setting an endpoint up.
+
 ### Limitations
 
-- `UploadPartCopy` is left out. An Object cannot be copied into a multipart upload.
+- `UploadPartCopy` is left out. An Object cannot be copied into a multipart upload. A served
+  endpoint refuses one with `NotImplemented` rather than storing an empty part. The `aws` CLI
+  switches to it above eight megabytes, and a move of a file that size is refused.
 - Both Buckets have to belong to the same simulated S3. A copy across Accounts or Regions is left
   out.
-- The S3 REST endpoint does not serve a copy yet, which leaves `aws s3 mv` and
-  `aws s3 cp s3://a/k s3://b/k` unable to reach a served simulation.
+- A presigned copy is left out, and so is a copy reaching a Bucket through simulated CloudFront.
 - `CopySourceIfMatch`, `CopySourceIfNoneMatch`, `CopySourceIfModifiedSince` and
   `CopySourceIfUnmodifiedSince` are ignored. A conditional copy happens whatever the condition
   says.
@@ -2741,7 +2765,8 @@ Sim S3 currently supports:
 - `Range` on `GetObjectCommand`, answering with the bytes asked for and `206 Partial Content` over a
   served endpoint, so `aws s3 cp` downloads a file of real size unchanged
 - `CopyObjectCommand`, authorized as a read of the source and a write of the destination, with a
-  `MetadataDirective` deciding which metadata the copy carries
+  `MetadataDirective` deciding which metadata the copy carries, over the SDK and over a served
+  endpoint, letting `aws s3 cp` and `aws s3 mv` move an Object between two served Buckets
 - `DeleteObjectCommand` and `DeleteObjectsCommand`, authorized per Object by sim IAM
 - `PutBucketNotificationConfigurationCommand` and `GetBucketNotificationConfigurationCommand`, with
   Object events delivered to a simulated Lambda function, a simulated SQS queue or a simulated SNS

--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -749,7 +749,7 @@ it. The copy would leave the Object exactly as it found it.
 Real S3 states a copy as a `PUT` on the destination carrying an `x-amz-copy-source` header and an
 empty body. The served endpoint reads that header and runs the operation an in-process caller
 reaches. `aws s3 cp` and `aws s3 mv` between two served Buckets then behave as they do against real
-S3, for a file under the CLI's eight megabyte multipart threshold.
+S3, for a file under the CLI's eight-megabyte multipart threshold.
 
 ```bash
 aws s3 cp ./report.pdf s3://inbox/report.pdf

--- a/src/service/s3/serve/api/sim-s3-api-copy.loc.test.ts
+++ b/src/service/s3/serve/api/sim-s3-api-copy.loc.test.ts
@@ -1,0 +1,321 @@
+import {
+  CreateAccessKeyCommand,
+  CreateUserCommand,
+  PutUserPolicyCommand,
+} from "@aws-sdk/client-iam";
+import {
+  CopyObjectCommand,
+  CreateBucketCommand,
+  GetObjectCommand,
+  ListObjectsV2Command,
+  PutBucketPolicyCommand,
+  PutObjectCommand,
+  S3Client,
+  UploadPartCopyCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { afterAll, beforeAll, describe, it } from "vitest";
+
+import { SimAwsLocalServer } from "../../../../serve/index.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+
+/**
+ * Copying an Object over the served S3 REST endpoint.
+ *
+ * Real S3 states a copy as a `PUT` on the destination carrying the source in a
+ * header and no bytes at all, which is a request the endpoint would otherwise
+ * read as an upload of nothing. What these cover is the operation reached
+ * through that request rather than through the simulator: the header, the
+ * document the copy answers with, and what a refused copy leaves behind.
+ */
+describe("Copying an Object over the served S3 REST endpoint", () => {
+  const simAws = new SimAws();
+  const srv = new SimAwsLocalServer({ simAws });
+  const simS3 = simAws.s3();
+
+  const report = "the bytes a copy is supposed to move";
+
+  let client: S3Client;
+  let userArn: string;
+
+  beforeAll(async () => {
+    await srv.listen();
+
+    client = await s3ClientFor("Copier");
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "inbox" }));
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "archive" }));
+  });
+
+  afterAll(async () => {
+    await srv.close();
+  });
+
+  /**
+   * A client signing as a simulated IAM user allowed to do anything to S3, so
+   * a refusal in these comes from a Bucket policy rather than from the
+   * identity.
+   */
+  async function s3ClientFor(username: string): Promise<S3Client> {
+    const simIam = simAws.iam();
+
+    const user = await simIam.createUser(
+      new CreateUserCommand({ UserName: username }),
+    );
+    assertDefined(user.User.Arn, "the created user's ARN");
+    userArn = user.User.Arn;
+
+    await simIam.putUserPolicy(
+      new PutUserPolicyCommand({
+        UserName: username,
+        PolicyName: "Copies",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: { Effect: "Allow", Action: "s3:*", Resource: "*" },
+        }),
+      }),
+    );
+    const created = await simIam.createAccessKey(
+      new CreateAccessKeyCommand({ UserName: username }),
+    );
+
+    return new S3Client({
+      region: simAws.defaultRegionName,
+      endpoint: `http://localhost:${srv.port}`,
+      forcePathStyle: true,
+      credentials: {
+        accessKeyId: created.AccessKey.AccessKeyId,
+        secretAccessKey: created.AccessKey.SecretAccessKey,
+      },
+    });
+  }
+
+  /**
+   * Lay down an Object for one of these to copy, under a key of its own so the
+   * tests do not read each other's leftovers.
+   */
+  async function givenReport(key: string): Promise<void> {
+    await simS3.putObject(
+      new PutObjectCommand({ Bucket: "inbox", Key: key, Body: report }),
+    );
+  }
+
+  /**
+   * The text an Object holds, read through the simulator rather than through
+   * the endpoint under test.
+   */
+  async function storedText(bucketName: string, key: string): Promise<string> {
+    const read = await simS3.getObject(
+      new GetObjectCommand({ Bucket: bucketName, Key: key }),
+    );
+    assertDefined(read.Body, "the stored Object body");
+
+    return Buffer.concat(await Array.fromAsync(read.Body)).toString("utf8");
+  }
+
+  it("copies the bytes, and says what it wrote in the response body", async () => {
+    // Given an Object in one Bucket
+    await givenReport("plain.txt");
+
+    // When it is copied into another through the endpoint
+    const copy = await client.send(
+      new CopyObjectCommand({
+        Bucket: "archive",
+        Key: "2026/plain.txt",
+        CopySource: "/inbox/plain.txt",
+      }),
+    );
+
+    // Then the destination holds the source's bytes, rather than the empty
+    // body the request carried
+    assertIdentical(await storedText("archive", "2026/plain.txt"), report);
+
+    // And the ETag and write time came back in the document a copy answers
+    // with, which is the only place a client can read them, describing the
+    // Object that was written rather than being made up by the endpoint
+    const listed = await simS3.listObjectsV2(
+      new ListObjectsV2Command({ Bucket: "archive", Prefix: "2026/plain.txt" }),
+    );
+    const written = listed.Contents?.[0];
+    assertDefined(written, "the written Object");
+
+    const result = copy.CopyObjectResult;
+    assertDefined(result, "the copy result");
+    assertIdentical(result.ETag, written.ETag);
+    assertIdentical(
+      result.LastModified?.getTime(),
+      written.LastModified?.getTime(),
+    );
+  });
+
+  it("still reads a PUT carrying bytes as an upload", async () => {
+    // Given the request that shares its method and path with a copy and names
+    // no source
+    await client.send(
+      new PutObjectCommand({
+        Bucket: "archive",
+        Key: "uploaded.txt",
+        Body: "written directly",
+      }),
+    );
+
+    // Then it stored what it carried, rather than being read as a copy of
+    // nothing
+    assertIdentical(
+      await storedText("archive", "uploaded.txt"),
+      "written directly",
+    );
+  });
+
+  it("reads a source key holding a space and a slash", async () => {
+    // Given a key whose own text has to be encoded to travel in a header
+    await givenReport("quarterly report/q1 & q2.txt");
+
+    // When it is copied by that name
+    await client.send(
+      new CopyObjectCommand({
+        Bucket: "archive",
+        Key: "encoded.txt",
+        CopySource: "/inbox/quarterly report/q1 & q2.txt",
+      }),
+    );
+
+    // Then the encoded source named the Object it meant, rather than one whose
+    // key holds a literal `%20`
+    assertIdentical(await storedText("archive", "encoded.txt"), report);
+  });
+
+  it("carries the source's content type under the default directive", async () => {
+    // Given an Object written with a content type
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "inbox",
+        Key: "typed.pdf",
+        Body: report,
+        ContentType: "application/pdf",
+      }),
+    );
+
+    // When it is copied without asking for the metadata to be replaced
+    await client.send(
+      new CopyObjectCommand({
+        Bucket: "archive",
+        Key: "typed.pdf",
+        CopySource: "/inbox/typed.pdf",
+      }),
+    );
+
+    // Then the copy describes itself the way the source did
+    const read = await simS3.getObject(
+      new GetObjectCommand({ Bucket: "archive", Key: "typed.pdf" }),
+    );
+    assertIdentical(read.Metadata?.["content-type"], "application/pdf");
+  });
+
+  it("takes the destination's own metadata under REPLACE", async () => {
+    // Given an Object written as one thing
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "inbox",
+        Key: "retyped.bin",
+        Body: report,
+        ContentType: "application/octet-stream",
+      }),
+    );
+
+    // When it is copied asking for the request's metadata instead
+    await client.send(
+      new CopyObjectCommand({
+        Bucket: "archive",
+        Key: "retyped.txt",
+        CopySource: "/inbox/retyped.bin",
+        MetadataDirective: "REPLACE",
+        ContentType: "text/plain",
+      }),
+    );
+
+    // Then the directive reached the operation, which the header is the only
+    // way of stating over REST
+    const read = await simS3.getObject(
+      new GetObjectCommand({ Bucket: "archive", Key: "retyped.txt" }),
+    );
+    assertIdentical(read.Metadata?.["content-type"], "text/plain");
+  });
+
+  it("answers a copy a Bucket policy refuses with the S3 error document", async () => {
+    // Given a destination Bucket whose policy denies this caller a write
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "sealed" }));
+    await simS3.putBucketPolicy(
+      new PutBucketPolicyCommand({
+        Bucket: "sealed",
+        Policy: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Deny",
+              Principal: { AWS: userArn },
+              Action: "s3:PutObject",
+              Resource: "arn:aws:s3:::sealed/*",
+            },
+          ],
+        }),
+      }),
+    );
+    await givenReport("refused.txt");
+
+    // When a copy into it is attempted
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await client.send(
+          new CopyObjectCommand({
+            Bucket: "sealed",
+            Key: "refused.txt",
+            CopySource: "/inbox/refused.txt",
+          }),
+        ),
+    );
+
+    // Then the SDK read it as the S3 failure it is, rather than as a copy that
+    // worked
+    assertIdentical(error.name, "AccessDenied");
+    assertStringIncludes(error.message, "s3:PutObject");
+
+    // And nothing was stored, which is what real S3's 200-with-an-error-body
+    // makes easy to miss
+    const listed = await simS3.listObjectsV2(
+      new ListObjectsV2Command({ Bucket: "sealed" }),
+    );
+    assertArrayLength(listed.Contents ?? [], 0);
+  });
+
+  it("refuses a copy into a multipart part rather than storing an empty one", async () => {
+    // Given the upload the CLI switches to above its multipart threshold
+    await givenReport("large.bin");
+
+    // When a part of it is asked to come from another Object, which simulated
+    // S3 has no operation for
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await client.send(
+          new UploadPartCopyCommand({
+            Bucket: "archive",
+            Key: "large.bin",
+            UploadId: "no-such-upload",
+            PartNumber: 1,
+            CopySource: "/inbox/large.bin",
+          }),
+        ),
+    );
+
+    // Then it is refused by name, rather than read as the part upload it looks
+    // exactly like and stored as no bytes at all
+    assertIdentical(error.name, "NotImplemented");
+    assertStringIncludes(error.message, "UploadPartCopyCommand");
+  });
+});

--- a/src/service/s3/serve/api/sim-s3-api-object-input.ts
+++ b/src/service/s3/serve/api/sim-s3-api-object-input.ts
@@ -10,6 +10,12 @@ import type { SimS3ApiRequest } from "./sim-s3-api-request.js";
  */
 
 /**
+ * The header real S3 states a copy in, which is what separates a copy from the
+ * upload it shares a method and a path with.
+ */
+export const simS3CopySourceHeader = "x-amz-copy-source";
+
+/**
  * The input of an operation naming one Object.
  */
 export function objectInput(request: SimS3ApiRequest): object {
@@ -32,6 +38,25 @@ export function getObjectInput(request: SimS3ApiRequest): object {
  */
 export function putObjectInput(request: SimS3ApiRequest): object {
   return { ...createMultipartUploadInput(request), Body: request.body };
+}
+
+/**
+ * The input of a copy, which names its source in a header and carries no bytes
+ * of its own.
+ *
+ * The source is passed on as it arrived, percent-encoding and all, because the
+ * operation decodes it a key segment at a time the way the endpoint decodes a
+ * key out of a request path.
+ */
+export function copyObjectInput(request: SimS3ApiRequest): object {
+  return {
+    ...createMultipartUploadInput(request),
+    ...optional("CopySource", request.headers.get(simS3CopySourceHeader)),
+    ...optional(
+      "MetadataDirective",
+      request.headers.get("x-amz-metadata-directive"),
+    ),
+  };
 }
 
 /**

--- a/src/service/s3/serve/api/sim-s3-api-object-output.ts
+++ b/src/service/s3/serve/api/sim-s3-api-object-output.ts
@@ -1,4 +1,27 @@
+import { xmlDocument, xmlValue } from "../../../../util/xml/xml-writer.js";
 import { simS3ObjectResponseHeaders } from "../../object/s3-object-response-headers.js";
+
+interface CopyObjectOutput {
+  readonly CopyObjectResult?:
+    | { readonly ETag?: string; readonly LastModified?: Date }
+    | undefined;
+}
+
+/**
+ * Write a finished copy as the document real S3 answers it with.
+ *
+ * A copy says nothing in its headers about the Object it wrote, so a client
+ * reads the new ETag and write time out of this body and nowhere else.
+ */
+export function simS3CopyObjectXml(output: CopyObjectOutput): string {
+  const result = output.CopyObjectResult ?? {};
+
+  return xmlDocument(
+    "CopyObjectResult",
+    xmlValue("ETag", result.ETag) +
+      xmlValue("LastModified", result.LastModified),
+  );
+}
 
 /**
  * Answer a read with the Object itself, headers and all.

--- a/src/service/s3/serve/api/sim-s3-api-object-routes.ts
+++ b/src/service/s3/serve/api/sim-s3-api-object-routes.ts
@@ -1,8 +1,10 @@
 import {
+  copyObjectInput,
   createMultipartUploadInput,
   getObjectInput,
   objectInput,
   putObjectInput,
+  simS3CopySourceHeader,
 } from "./sim-s3-api-object-input.js";
 import {
   completeMultipartUploadInput,
@@ -49,11 +51,33 @@ export const simS3ObjectApiRoutes: readonly SimS3ApiRoute[] = [
     input: completeMultipartUploadInput,
   },
   {
+    // Copying an Object into a part of a multipart upload, which simulated S3
+    // has no operation for. Named so it is refused rather than read as the
+    // part upload it otherwise looks exactly like, which would store an empty
+    // part and lose the bytes the copy was moving.
+    method: "PUT",
+    target: "object",
+    subResource: "uploadId",
+    header: simS3CopySourceHeader,
+    commandName: "UploadPartCopyCommand",
+    input: uploadPartInput,
+  },
+  {
     method: "PUT",
     target: "object",
     subResource: "uploadId",
     commandName: "UploadPartCommand",
     input: uploadPartInput,
+  },
+  {
+    // A copy and an upload are both a `PUT` on an Object path, and the copy
+    // names its source in a header. Matched first, so an upload carrying no
+    // such header still reaches PutObject below.
+    method: "PUT",
+    target: "object",
+    header: simS3CopySourceHeader,
+    commandName: "CopyObjectCommand",
+    input: copyObjectInput,
   },
   {
     method: "PUT",

--- a/src/service/s3/serve/api/sim-s3-api-output.ts
+++ b/src/service/s3/serve/api/sim-s3-api-output.ts
@@ -12,7 +12,10 @@ import {
   simS3ListObjectsXml,
 } from "./sim-s3-api-listing.js";
 import { simS3MultipartResponse } from "./sim-s3-api-multipart-output.js";
-import { simS3GetObjectResponse } from "./sim-s3-api-object-output.js";
+import {
+  simS3CopyObjectXml,
+  simS3GetObjectResponse,
+} from "./sim-s3-api-object-output.js";
 
 const xmlContentType = { "content-type": "application/xml" };
 
@@ -67,6 +70,12 @@ export async function simS3ApiResponse(
     }
     case "HeadBucketCommand": {
       return simS3HeadBucketResponse(value);
+    }
+    case "CopyObjectCommand": {
+      // A copy answers in a document rather than in headers, because real S3
+      // holds the connection open while the bytes move and cannot know the
+      // ETag by the time it has to send them.
+      return xml(simS3CopyObjectXml(value));
     }
     case "PutObjectCommand":
     case "UploadPartCommand": {

--- a/src/service/s3/serve/api/sim-s3-api-route.type.ts
+++ b/src/service/s3/serve/api/sim-s3-api-route.type.ts
@@ -26,10 +26,10 @@ export interface SimS3ApiRoute {
    */
   readonly matches?: ((query: URLSearchParams) => boolean) | undefined;
   /**
-   * A header the request has to carry to reach this operation, for the one
-   * operation that shares a method, a path and a sub-resource with another and
-   * is told apart by a header. Only `CopyObject` is, and it is matched before
-   * the `PutObject` it would otherwise be read as.
+   * A header the request has to carry to reach this operation, for the
+   * operations that share a method, a path and a sub-resource with another and
+   * are told apart by a header. A copy is the only one, in both its forms, and
+   * each is matched before the upload it would otherwise be read as.
    */
   readonly header?: string | undefined;
   readonly commandName: string;

--- a/src/service/s3/serve/api/sim-s3-api-route.type.ts
+++ b/src/service/s3/serve/api/sim-s3-api-route.type.ts
@@ -4,9 +4,13 @@ import type { SimS3ApiRequest } from "./sim-s3-api-request.js";
  * One S3 REST operation, and how to read its input out of a request.
  *
  * S3 states its operation in the method, the shape of the path and a
- * sub-resource in the query string, so a route is matched on those three and
- * nothing else. Real S3 reads a request the same way, which is why `?policy`
- * and `?website` on the same `PUT /{Bucket}` reach different operations.
+ * sub-resource in the query string, so a route is matched on those three
+ * before anything else. Real S3 reads a request the same way, which is why
+ * `?policy` and `?website` on the same `PUT /{Bucket}` reach different
+ * operations.
+ *
+ * A copy is the one operation S3 states in a header instead, so a route can
+ * name a header the request has to carry as well.
  */
 export interface SimS3ApiRoute {
   readonly method: string;
@@ -21,6 +25,13 @@ export interface SimS3ApiRoute {
    * method, a path and a sub-resource with another. Only the two listings do.
    */
   readonly matches?: ((query: URLSearchParams) => boolean) | undefined;
+  /**
+   * A header the request has to carry to reach this operation, for the one
+   * operation that shares a method, a path and a sub-resource with another and
+   * is told apart by a header. Only `CopyObject` is, and it is matched before
+   * the `PutObject` it would otherwise be read as.
+   */
+  readonly header?: string | undefined;
   readonly commandName: string;
   readonly input: (request: SimS3ApiRequest) => object;
 }

--- a/src/service/s3/serve/api/sim-s3-api-routes.iso.test.ts
+++ b/src/service/s3/serve/api/sim-s3-api-routes.iso.test.ts
@@ -31,6 +31,24 @@ describe("Resolving an S3 REST operation from a request", () => {
     return resolveSimS3ApiRoute(apiRequest)?.input(apiRequest);
   }
 
+  function sent(
+    method: string,
+    path: string,
+    headers: Record<string, string>,
+  ): { command: string | undefined; input: object | undefined } {
+    const request = new Request(`http://localhost:1234${path}`, {
+      method,
+      headers,
+    });
+    const apiRequest = readSimS3ApiRequest(request, Buffer.alloc(0));
+    const matched = resolveSimS3ApiRoute(apiRequest);
+
+    return {
+      command: matched?.commandName,
+      input: matched?.input(apiRequest),
+    };
+  }
+
   it("reads the path depth as the level the request addressed", () => {
     assertIdentical(route("GET", "/"), "ListBucketsCommand");
     assertIdentical(route("GET", "/widgets"), "ListObjectsCommand");
@@ -140,6 +158,74 @@ describe("Resolving an S3 REST operation from a request", () => {
         ],
       },
     });
+  });
+
+  it("tells a copy apart from an upload by the source header", () => {
+    // Given the request real S3 states a copy as, which is a PUT on the
+    // destination naming the source in a header and carrying no bytes
+    assertIdentical(
+      sent("PUT", "/archive/2026/report.pdf", {
+        "x-amz-copy-source": "/inbox/report.pdf",
+      }).command,
+      "CopyObjectCommand",
+    );
+
+    // And the same PUT without that header is still the upload it has always
+    // been
+    assertIdentical(
+      route("PUT", "/archive/2026/report.pdf"),
+      "PutObjectCommand",
+    );
+  });
+
+  it("reads the source and the metadata directive a copy states", () => {
+    // Given a copy asking for the destination's own metadata rather than the
+    // source's
+    assertObjectEquals(
+      sent("PUT", "/archive/report.pdf", {
+        "x-amz-copy-source": "/inbox/a%20b/c%2Fd.pdf",
+        "x-amz-metadata-directive": "REPLACE",
+        "content-type": "application/pdf",
+      }).input,
+      {
+        Bucket: "archive",
+        Key: "report.pdf",
+        ContentType: "application/pdf",
+        CopySource: "/inbox/a%20b/c%2Fd.pdf",
+        MetadataDirective: "REPLACE",
+      },
+    );
+
+    // And a copy stating neither says nothing about a directive, so the
+    // operation's own default applies
+    assertObjectEquals(
+      sent("PUT", "/archive/report.pdf", {
+        "x-amz-copy-source": "inbox/report.pdf",
+      }).input,
+      {
+        Bucket: "archive",
+        Key: "report.pdf",
+        CopySource: "inbox/report.pdf",
+      },
+    );
+  });
+
+  it("refuses a copy into a part rather than reading it as a part upload", () => {
+    // Given the UploadPartCopy the CLI sends for a file over its multipart
+    // threshold, which is a part upload in every respect but the source header
+    assertIdentical(
+      sent("PUT", "/archive/big.bin?uploadId=U1&partNumber=2", {
+        "x-amz-copy-source": "/inbox/big.bin",
+      }).command,
+      "UploadPartCopyCommand",
+    );
+
+    // And the part upload it looks like is still reached without that header,
+    // rather than every part being refused
+    assertIdentical(
+      route("PUT", "/archive/big.bin?uploadId=U1&partNumber=2"),
+      "UploadPartCommand",
+    );
   });
 
   it("names no operation for a method S3 does not use here", () => {

--- a/src/service/s3/serve/api/sim-s3-api-routes.ts
+++ b/src/service/s3/serve/api/sim-s3-api-routes.ts
@@ -103,6 +103,7 @@ export function resolveSimS3ApiRoute(
       route.method === request.method &&
       route.target === target &&
       route.subResource === named &&
-      (route.matches?.(request.query) ?? true),
+      (route.matches?.(request.query) ?? true) &&
+      (route.header === undefined || request.headers.has(route.header)),
   );
 }

--- a/src/service/s3/serve/api/sim-s3-copy-cli.loc.test.ts
+++ b/src/service/s3/serve/api/sim-s3-copy-cli.loc.test.ts
@@ -80,7 +80,12 @@ describe("Moving an Object between simulated Buckets with the aws CLI", () => {
       new CreateAccessKeyCommand({ UserName: "Archivist" }),
     );
 
-    const { AWS_PROFILE: _profile, ...environment } = process.env;
+    // Every AWS variable the machine exports is dropped rather than only the
+    // profile. An inherited session token or endpoint would otherwise travel
+    // with the simulated access key and fail the signature.
+    const environment = Object.fromEntries(
+      Object.entries(process.env).filter(([name]) => !name.startsWith("AWS_")),
+    );
 
     return {
       ...environment,

--- a/src/service/s3/serve/api/sim-s3-copy-cli.loc.test.ts
+++ b/src/service/s3/serve/api/sim-s3-copy-cli.loc.test.ts
@@ -1,0 +1,211 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import {
+  CreateAccessKeyCommand,
+  CreateUserCommand,
+  PutUserPolicyCommand,
+} from "@aws-sdk/client-iam";
+import {
+  CreateBucketCommand,
+  GetObjectCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { afterAll, beforeAll, describe, it } from "vitest";
+
+import { SimAwsLocalServer } from "../../../../serve/index.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { TemporaryDirectory } from "../../../../util/filesystem/temporary-directory.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+
+const runFile = promisify(execFile);
+
+/**
+ * The `aws` CLI moving and copying an Object between two simulated Buckets.
+ *
+ * The CLI states a move as a copy and then a delete, so a copy the endpoint
+ * mishandles destroys the file rather than moving it. That is what this covers:
+ * a real client, two served Buckets, and the bytes read back afterwards.
+ */
+describe("Moving an Object between simulated Buckets with the aws CLI", () => {
+  const simAws = new SimAws();
+  const srv = new SimAwsLocalServer({ simAws });
+  const simS3 = simAws.s3();
+
+  const report = "a report of some length, in bytes that can be counted";
+
+  const files = new TemporaryDirectory();
+  let cliEnvironment: NodeJS.ProcessEnv;
+
+  beforeAll(async () => {
+    await srv.listen();
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "inbox" }));
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "archive" }));
+
+    cliEnvironment = await credentialEnvironment();
+  });
+
+  afterAll(async () => {
+    await srv.close();
+  });
+
+  /**
+   * The environment an `aws` invocation runs with: a simulated IAM user's
+   * access key, and nothing of whatever real AWS configuration the machine
+   * running the test happens to have.
+   */
+  async function credentialEnvironment(): Promise<NodeJS.ProcessEnv> {
+    const simIam = simAws.iam();
+
+    await files.resolvePath();
+
+    await simIam.createUser(new CreateUserCommand({ UserName: "Archivist" }));
+    await simIam.putUserPolicy(
+      new PutUserPolicyCommand({
+        UserName: "Archivist",
+        PolicyName: "Archives",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: { Effect: "Allow", Action: "s3:*", Resource: "*" },
+        }),
+      }),
+    );
+    const created = await simIam.createAccessKey(
+      new CreateAccessKeyCommand({ UserName: "Archivist" }),
+    );
+
+    const { AWS_PROFILE: _profile, ...environment } = process.env;
+
+    return {
+      ...environment,
+      AWS_ACCESS_KEY_ID: created.AccessKey.AccessKeyId,
+      AWS_SECRET_ACCESS_KEY: created.AccessKey.SecretAccessKey,
+      AWS_DEFAULT_REGION: simAws.defaultRegionName,
+      AWS_CONFIG_FILE: files.join("aws-config"),
+      AWS_SHARED_CREDENTIALS_FILE: files.join("aws-credentials"),
+      AWS_EC2_METADATA_DISABLED: "true",
+    };
+  }
+
+  async function aws(...commandArguments: string[]): Promise<string> {
+    const { stdout } = await runFile(
+      "aws",
+      [...commandArguments, "--endpoint-url", `http://localhost:${srv.port}`],
+      { env: cliEnvironment },
+    );
+
+    return stdout;
+  }
+
+  /**
+   * Lay down an Object for one of these to move, under a key of its own so the
+   * tests do not read each other's leftovers.
+   */
+  async function givenReport(key: string): Promise<void> {
+    await simS3.putObject(
+      new PutObjectCommand({ Bucket: "inbox", Key: key, Body: report }),
+    );
+  }
+
+  /**
+   * The text an Object holds, read through the simulator's own body stream.
+   */
+  async function bodyText(body: AsyncIterable<Uint8Array>): Promise<string> {
+    return Buffer.concat(await Array.fromAsync(body)).toString("utf8");
+  }
+
+  /**
+   * What one Bucket holds under a prefix, read through the simulator rather
+   * than through the endpoint under test.
+   */
+  async function stored(
+    bucketName: string,
+    prefix: string,
+  ): Promise<readonly { Key?: string; Size?: number }[]> {
+    const listed = await simS3.listObjectsV2(
+      new ListObjectsV2Command({ Bucket: bucketName, Prefix: prefix }),
+    );
+
+    return listed.Contents ?? [];
+  }
+
+  it("copies an Object between Buckets, leaving the source where it was", async () => {
+    // Given an Object in one Bucket
+    await givenReport("copied.pdf");
+
+    // When it is copied into another
+    await aws(
+      "s3",
+      "cp",
+      "s3://inbox/copied.pdf",
+      "s3://archive/2026/copied.pdf",
+    );
+
+    // Then the copy holds the bytes rather than nothing at all
+    const read = await simS3.getObject(
+      new GetObjectCommand({ Bucket: "archive", Key: "2026/copied.pdf" }),
+    );
+    assertDefined(read.Body, "the copied Object body");
+    assertIdentical(await bodyText(read.Body), report);
+
+    // And the original is still there, since a copy is not a move
+    assertArrayLength(await stored("inbox", "copied.pdf"), 1);
+  });
+
+  it("moves an Object, and the size the CLI lists is the size it moved", async () => {
+    // Given an Object in one Bucket
+    await givenReport("moved.pdf");
+
+    // When it is moved into another, which the CLI states as a copy and then a
+    // delete
+    await aws(
+      "s3",
+      "mv",
+      "s3://inbox/moved.pdf",
+      "s3://archive/2026/moved.pdf",
+    );
+
+    // Then the destination holds the file at its real size, rather than the
+    // zero-byte Object an empty PUT would have left
+    const listed = await aws("s3", "ls", "s3://archive/2026/");
+    assertStringIncludes(listed, `${report.length} moved.pdf`);
+
+    const read = await simS3.getObject(
+      new GetObjectCommand({ Bucket: "archive", Key: "2026/moved.pdf" }),
+    );
+    assertDefined(read.Body, "the moved Object body");
+    assertIdentical(await bodyText(read.Body), report);
+
+    // And the source is empty, which is the half of the move that made the
+    // first half worth checking
+    assertArrayLength(await stored("inbox", "moved.pdf"), 0);
+  });
+
+  it("moves an Object whose key is a path of its own", async () => {
+    // Given a key made of several segments, which the header has to carry
+    // whole rather than reading its first slash as the Bucket
+    await givenReport("2025/q4/report.pdf");
+
+    // When it is moved
+    await aws(
+      "s3",
+      "mv",
+      "s3://inbox/2025/q4/report.pdf",
+      "s3://archive/2025/q4/report.pdf",
+    );
+
+    // Then the destination holds the bytes and the source is empty
+    const read = await simS3.getObject(
+      new GetObjectCommand({ Bucket: "archive", Key: "2025/q4/report.pdf" }),
+    );
+    assertDefined(read.Body, "the moved Object body");
+    assertIdentical(await bodyText(read.Body), report);
+    assertArrayLength(await stored("inbox", "2025/q4/report.pdf"), 0);
+  });
+});

--- a/src/service/s3/serve/api/sim-s3-listing-cli.loc.test.ts
+++ b/src/service/s3/serve/api/sim-s3-listing-cli.loc.test.ts
@@ -80,7 +80,12 @@ describe("Listing simulated S3 a folder at a time with the aws CLI", () => {
       new CreateAccessKeyCommand({ UserName: "Browser" }),
     );
 
-    const { AWS_PROFILE: _profile, ...environment } = process.env;
+    // Every AWS variable the machine exports is dropped rather than only the
+    // profile. An inherited session token or endpoint would otherwise travel
+    // with the simulated access key and fail the signature.
+    const environment = Object.fromEntries(
+      Object.entries(process.env).filter(([name]) => !name.startsWith("AWS_")),
+    );
 
     return {
       ...environment,

--- a/src/service/s3/serve/api/sim-s3-multipart-cli.loc.test.ts
+++ b/src/service/s3/serve/api/sim-s3-multipart-cli.loc.test.ts
@@ -100,15 +100,18 @@ describe("Copying a large file in and out of simulated S3 with the aws CLI", () 
       new CreateAccessKeyCommand({ UserName: "Copier" }),
     );
 
-    const { AWS_PROFILE: _profile, ...environment } = process.env;
+    // Every AWS variable the machine exports is dropped rather than only the
+    // profile. An inherited session token or endpoint would otherwise travel
+    // with the simulated access key and fail the signature.
+    const environment = Object.fromEntries(
+      Object.entries(process.env).filter(([name]) => !name.startsWith("AWS_")),
+    );
 
     return {
       ...environment,
       AWS_ACCESS_KEY_ID: created.AccessKey.AccessKeyId,
       AWS_SECRET_ACCESS_KEY: created.AccessKey.SecretAccessKey,
       AWS_DEFAULT_REGION: simAws.defaultRegionName,
-      // Whatever real AWS configuration the machine running this happens to
-      // have is not this test's, so the CLI is pointed away from it.
       AWS_CONFIG_FILE: files.join("aws-config"),
       AWS_SHARED_CREDENTIALS_FILE: files.join("aws-credentials"),
       AWS_EC2_METADATA_DISABLED: "true",

--- a/test/cli/watch-project.ts
+++ b/test/cli/watch-project.ts
@@ -6,11 +6,14 @@ import { TemporaryDirectory } from "../../src/util/filesystem/temporary-director
  *
  * A run is a real process, spawned through `tsx`, importing whatever the dev
  * script imports. On a loaded CI runner that is seconds rather than the
- * fraction of one it takes on a developer machine. Two of these fit inside the
- * local test timeout, so a test that waited for a restart it never got fails
- * saying how many times the process ran rather than with a bare timeout.
+ * fraction of one it takes on a developer machine, and the first spawn in a
+ * file pays for a cold `tsx` transform cache on top of that. Twelve seconds
+ * was not enough for it once the rest of the local suite grew. Two of these
+ * fit inside the local test timeout, so a test that waited for a restart it
+ * never got fails saying how many times the process ran rather than with a
+ * bare timeout.
  */
-export const watchRunTimeoutMs = 12_000;
+export const watchRunTimeoutMs = 20_000;
 
 /**
  * A throwaway project for `yulin watch` to supervise.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -61,8 +61,10 @@ export default defineConfig({
           // Local tests spawn real processes, bind real ports and wait on real
           // filesystem events. On a loaded CI runner that is seconds where a
           // developer machine takes a fraction of one, so they get longer than
-          // an isolated test does before a slow run counts as a hang.
-          testTimeout: 30_000,
+          // an isolated test does before a slow run counts as a hang. This has
+          // to stay above twice `watchRunTimeoutMs`, since a supervised test
+          // waits for two runs of a spawned process inside one timeout.
+          testTimeout: 45_000,
           // globalSetup: ["./test/locTestGlobalSetUp.ts"],
         },
       },


### PR DESCRIPTION
A route can now name a header the request has to carry, and a `PUT` on an Object path with `x-amz-copy-source` reaches `CopyObjectCommand` while one without it still reaches `PutObjectCommand`. The endpoint reads `x-amz-metadata-directive` as `MetadataDirective` and answers with the `CopyObjectResult` document holding the ETag and the write time. The same header on a part upload names `UploadPartCopy`, which simulated S3 refuses with `NotImplemented` rather than storing an empty part. `aws s3 cp` and `aws s3 mv` between two served Buckets now move the bytes instead of destroying them.

Resolves #830

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for copying objects between served S3 buckets through the REST API.
  - Supports AWS CLI copy and move operations, encoded source keys, metadata inheritance, and metadata replacement.
  - Returns S3-compatible copy results and appropriate responses for denied or unsupported operations.

- **Documentation**
  - Documented REST API usage, CLI examples, metadata headers, response handling, limitations, and failure behavior.

- **Tests**
  - Added coverage for copy, move, direct uploads, permissions, metadata, multipart limitations, and path-based object keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->