### PR TITLE
perf: advance the clock without one timer per task

### DIFF
--- a/src/service/cloudwatch/sim-cloudwatch-alarm-evaluation.iso.test.ts
+++ b/src/service/cloudwatch/sim-cloudwatch-alarm-evaluation.iso.test.ts
@@ -7,6 +7,7 @@ import {
   assertArrayLength,
   assertIdentical,
   assertNonNullable,
+  assertNumberBetween,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
@@ -75,6 +76,27 @@ describe("SimCloudWatch alarm evaluation", () => {
     // When its state is read.
     // Then it has not evaluated anything yet, as on real CloudWatch.
     assertIdentical(await stateOf(simAws), "INSUFFICIENT_DATA");
+  });
+
+  it("skips a month of five-minute periods without costing seconds", async () => {
+    // Given an alarm on a five-minute period, watching a metric nothing ever
+    // publishes to.
+    const simAws = await withAlarm({
+      Period: 300,
+      EvaluationPeriods: 1,
+      DatapointsToAlarm: 1,
+    });
+
+    // When the clock is advanced by thirty days, crossing 8,640 of its
+    // period boundaries.
+    const realBefore = Date.now();
+
+    await simAws.clock().advanceBy({ days: 30 });
+
+    // Then it evaluated its way to the end of the interval, in a fraction of
+    // the host time a real timer per boundary used to cost.
+    assertIdentical(await stateOf(simAws), "INSUFFICIENT_DATA");
+    assertNumberBetween(Date.now() - realBefore, 0, 5000);
   });
 
   it("evaluates nothing while the clock stands still", async () => {

--- a/src/util/clock/sim-clock-control.iso.test.ts
+++ b/src/util/clock/sim-clock-control.iso.test.ts
@@ -158,6 +158,31 @@ describe("SimClockControl", () => {
     expect(background.dueTaskCount).toBe(0);
   });
 
+  it("crosses a long interval without waiting on a real timer per turn", async () => {
+    // Given work that takes a turn every simulated minute
+    const { control, background } = simulatedTime();
+    let turns = 0;
+    const everyMinute = async (): Promise<void> => {
+      turns += 1;
+      background.scheduleAt(
+        new Date(control.now().getTime() + 60_000),
+        everyMinute,
+      );
+
+      await Promise.resolve();
+    };
+    background.scheduleAt(new Date(start.getTime() + 60_000), everyMinute);
+
+    // When simulated time is advanced by a week
+    const realBefore = Date.now();
+    await control.advanceBy({ days: 7 });
+
+    // Then it took every one of its turns, in less host time than one real
+    // timer apiece would have cost
+    expect(turns).toBe(7 * 24 * 60);
+    expect(Date.now() - realBefore).toBeLessThan(5000);
+  });
+
   it("runs overdue work without dragging simulated time backwards", async () => {
     // Given work whose due time has already passed
     const { control, background } = simulatedTime();

--- a/src/util/clock/sim-clock-control.ts
+++ b/src/util/clock/sim-clock-control.ts
@@ -122,13 +122,23 @@ export class SimClockControl implements SimClock {
    * draining does generally: a task that endlessly reschedules itself inside
    * the interval is asking for endless work, and cutting it off part way would
    * report a settled simulation that is nothing of the kind.
+   *
+   * Each due task is run here rather than handed to the scheduler's `schedule`.
+   * That defers by a real timer, and Node holds a zero millisecond `setTimeout`
+   * for about a millisecond. Every instant the interval steps through would
+   * then cost a millisecond of host time, and thirty simulated days over an
+   * alarm evaluating every five minutes steps through 8,640 of them. The timer
+   * buys nothing here, because the loop waits for each task to finish before it
+   * takes the next one.
    */
   private async runDueTasksUpTo(instant: Date): Promise<void> {
     let due = this.background.takeNextDueBy(instant);
 
     while (due !== undefined) {
       this.clock.setTo(this.laterOfNow(due.dueTime));
-      this.background.schedule(due.task);
+
+      // oxlint-disable-next-line no-await-in-loop
+      await due.task();
 
       // oxlint-disable-next-line no-await-in-loop
       await this.background.complete();


### PR DESCRIPTION
Advancing simulated time handed each due task to the background scheduler, and that defers by a real timer. Node holds a zero millisecond `setTimeout` for about a millisecond, putting a millisecond of host time on every instant an interval stepped through. Thirty simulated days over two alarms on a five-minute period steps through 17,280 of them, and that advance took 20.6 seconds. The wait bought nothing, because the loop already waits for each task to finish before it takes the next one. Running the task in the loop instead brings the same advance down to 24.8 milliseconds.

The issue proposed a cheap path for an evaluation window holding no datapoints, or coalescing the boundaries an advance crosses. Neither turned out to be needed. All 17,280 evaluations of the alarm arithmetic run inside those 24.8 milliseconds, so every one of the original 20.6 seconds was the timer. Everything a test can see is unchanged, and the fix covers anything else that polls on the simulated clock as well.

Resolves #836