### PR TITLE
fix: serve S3 keys holding reserved characters

### DIFF
--- a/src/service/iam/sigv4/canonical/sim-iam-sigv4-canonical-path.ts
+++ b/src/service/iam/sigv4/canonical/sim-iam-sigv4-canonical-path.ts
@@ -1,6 +1,16 @@
 import { escapeSigV4Uri } from "../sigv4-uri-escape.js";
 
 /**
+ * The signing services that sign a path encoded once, as it arrived.
+ *
+ * SigV4 encodes the canonical path a second time, and real S3 is the exception
+ * to that. The name comes from the credential scope the request was signed
+ * under. The client picked its own rule from that same scope. Any further
+ * exception is one more entry here.
+ */
+const singlyEncodedServices = new Set(["s3"]);
+
+/**
  * Build the canonical URI of a signed request.
  *
  * The path is normalized, dropping empty and `.` segments and resolving `..`,
@@ -8,11 +18,19 @@ import { escapeSigV4Uri } from "../sigv4-uri-escape.js";
  * request is the first encoding, which is why a literal `/` in a path segment
  * and a separator are still distinguishable here.
  *
- * S3 is the exception on real AWS: it signs the path singly encoded. Only
- * doubly encoded services are supported for now, which is every service the
- * simulator serves.
+ * A request signed for S3 gets neither step, and is signed over the path it
+ * arrived with. An Object key holds any byte S3 accepts (a space, an
+ * ampersand, a `.` segment, a doubled slash), and the path naming it survives
+ * to the signature untouched.
  */
-export function simIamSigV4CanonicalPath(path: string): string {
+export function simIamSigV4CanonicalPath(
+  path: string,
+  serviceName: string,
+): string {
+  if (singlyEncodedServices.has(serviceName)) {
+    return path.length === 0 ? "/" : path;
+  }
+
   const segments: string[] = [];
 
   for (const segment of path.split("/")) {

--- a/src/service/iam/sigv4/canonical/sim-iam-sigv4-canonical-request.ts
+++ b/src/service/iam/sigv4/canonical/sim-iam-sigv4-canonical-request.ts
@@ -1,3 +1,4 @@
+import type { SimIamSigV4SignatureStatement } from "../sim-iam-sigv4-signature-statement.js";
 import type { SimIamSigV4SignedRequest } from "../sim-iam-sigv4-signed-request.js";
 import { SimIamSigV4CanonicalHeaders } from "./sim-iam-sigv4-canonical-headers.js";
 import { simIamSigV4CanonicalPath } from "./sim-iam-sigv4-canonical-path.js";
@@ -12,24 +13,31 @@ import { SimIamSigV4PayloadDeclaration } from "./sim-iam-sigv4-payload-hash.js";
  * out, is the whole of SigV4 verification. Anything the canonical form covers
  * cannot be altered in transit without detection, and anything it leaves out
  * can be.
+ *
+ * The statement the request carries says which headers are signed and which
+ * service the signature is scoped to. Both belong to the canonical form. S3
+ * canonicalizes its path by a rule of its own, and the client read that rule
+ * from the scope it signed under.
  */
 export class SimIamSigV4CanonicalRequest {
   private readonly canonicalHeaders: SimIamSigV4CanonicalHeaders;
   private readonly signedRequest: SimIamSigV4SignedRequest;
+  private readonly statement: SimIamSigV4SignatureStatement;
   private readonly payload: SimIamSigV4PayloadDeclaration;
 
   constructor(
     signedRequest: SimIamSigV4SignedRequest,
-    signedHeaderNames: readonly string[],
+    statement: SimIamSigV4SignatureStatement,
     payload: SimIamSigV4PayloadDeclaration = SimIamSigV4PayloadDeclaration.fromHeaders(
       signedRequest.headers,
     ),
   ) {
     this.signedRequest = signedRequest;
+    this.statement = statement;
     this.payload = payload;
     this.canonicalHeaders = new SimIamSigV4CanonicalHeaders(
       signedRequest.headers,
-      signedHeaderNames,
+      statement.signedHeaderNames,
       signedRequest.url,
     );
   }
@@ -42,7 +50,7 @@ export class SimIamSigV4CanonicalRequest {
 
     return [
       method.toUpperCase(),
-      simIamSigV4CanonicalPath(url.pathname),
+      simIamSigV4CanonicalPath(url.pathname, this.statement.scope.serviceName),
       simIamSigV4CanonicalQuery(url.search),
       `${this.canonicalHeaders.toString()}\n`,
       this.canonicalHeaders.signedHeaderList(),

--- a/src/service/iam/sigv4/canonical/sim-iam-sigv4-canonical.iso.test.ts
+++ b/src/service/iam/sigv4/canonical/sim-iam-sigv4-canonical.iso.test.ts
@@ -37,26 +37,47 @@ describe("SigV4 byte ordering", () => {
 
 describe("SigV4 canonical path", () => {
   it("uses a single slash for an empty path", () => {
-    expect(simIamSigV4CanonicalPath("/")).toBe("/");
+    expect(simIamSigV4CanonicalPath("/", "lambda")).toBe("/");
+    expect(simIamSigV4CanonicalPath("", "s3")).toBe("/");
   });
 
   it("encodes the path a second time", () => {
     // Given a path whose slash is already encoded, so it is part of a segment
     // When it is canonicalized
     // Then the encoding is encoded again, keeping it distinct from a separator
-    expect(simIamSigV4CanonicalPath("/orders/a%2Fb")).toBe("/orders/a%252Fb");
+    expect(simIamSigV4CanonicalPath("/orders/a%2Fb", "lambda")).toBe(
+      "/orders/a%252Fb",
+    );
   });
 
   it("resolves dot segments before encoding", () => {
     // Given a path stepping down and back up again
     // When it is canonicalized
     // Then it names the same resource as the direct path would
-    expect(simIamSigV4CanonicalPath("/a/b/../c/./d")).toBe("/a/c/d");
+    expect(simIamSigV4CanonicalPath("/a/b/../c/./d", "lambda")).toBe("/a/c/d");
   });
 
   it("keeps a trailing slash but not an empty one", () => {
-    expect(simIamSigV4CanonicalPath("/a/b/")).toBe("/a/b/");
-    expect(simIamSigV4CanonicalPath("//")).toBe("/");
+    expect(simIamSigV4CanonicalPath("/a/b/", "lambda")).toBe("/a/b/");
+    expect(simIamSigV4CanonicalPath("//", "lambda")).toBe("/");
+  });
+
+  it("signs an S3 path with the single encoding it arrived in", () => {
+    // Given an Object key holding a space, which the S3 client encoded once
+    // When the path is canonicalized under an S3 credential scope
+    // Then it is signed as it arrived, matching what that client signed
+    expect(
+      simIamSigV4CanonicalPath("/reports/quarterly%20report.pdf", "s3"),
+    ).toBe("/reports/quarterly%20report.pdf");
+  });
+
+  it("leaves an S3 path unnormalized", () => {
+    // Given a key whose own characters read as path navigation. S3 stores it
+    // under those characters, and normalizing here would sign a different key
+    // from the one asked for.
+    expect(simIamSigV4CanonicalPath("/reports/a/../b//c.pdf", "s3")).toBe(
+      "/reports/a/../b//c.pdf",
+    );
   });
 });
 

--- a/src/service/iam/sigv4/sim-iam-sigv4-signature-check.ts
+++ b/src/service/iam/sigv4/sim-iam-sigv4-signature-check.ts
@@ -36,7 +36,7 @@ export function simIamSigV4CheckSignature(
 
   const canonicalRequest = new SimIamSigV4CanonicalRequest(
     signedRequest,
-    statement.signedHeaderNames,
+    statement,
     payload,
   ).toString();
 

--- a/src/service/s3/serve/api/sim-s3-api-reserved-keys.loc.test.ts
+++ b/src/service/s3/serve/api/sim-s3-api-reserved-keys.loc.test.ts
@@ -1,0 +1,117 @@
+import {
+  CreateAccessKeyCommand,
+  CreateUserCommand,
+  PutUserPolicyCommand,
+} from "@aws-sdk/client-iam";
+import {
+  CreateBucketCommand,
+  DeleteObjectCommand,
+  GetObjectCommand,
+  HeadObjectCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { assertIdentical } from "@kensio/smartass";
+import { afterAll, beforeAll, describe, it } from "vitest";
+
+import { SimAwsLocalServer } from "../../../../serve/index.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+
+/**
+ * Object keys holding the characters a real Bucket is full of: a space in a
+ * filename someone typed, an ampersand, a percent sign of the key's own.
+ *
+ * These reach the endpoint percent-encoded, and the encoding is what the
+ * client signed over. The path has to survive verification exactly as it
+ * arrived for any of these operations to be reachable at all.
+ */
+describe("Serving Objects whose keys hold reserved characters", () => {
+  const simAws = new SimAws();
+  const srv = new SimAwsLocalServer({ simAws });
+
+  let client: S3Client;
+
+  beforeAll(async () => {
+    await srv.listen();
+
+    const simIam = simAws.iam();
+
+    await simIam.createUser(new CreateUserCommand({ UserName: "Archivist" }));
+    await simIam.putUserPolicy(
+      new PutUserPolicyCommand({
+        UserName: "Archivist",
+        PolicyName: "Served",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: { Effect: "Allow", Action: "s3:*", Resource: "*" },
+        }),
+      }),
+    );
+    const created = await simIam.createAccessKey(
+      new CreateAccessKeyCommand({ UserName: "Archivist" }),
+    );
+
+    client = new S3Client({
+      region: simAws.defaultRegionName,
+      endpoint: `http://localhost:${srv.port}`,
+      forcePathStyle: true,
+      credentials: {
+        accessKeyId: created.AccessKey.AccessKeyId,
+        secretAccessKey: created.AccessKey.SecretAccessKey,
+      },
+    });
+
+    await client.send(new CreateBucketCommand({ Bucket: "reserved" }));
+  });
+
+  afterAll(async () => {
+    await srv.close();
+  });
+
+  it.each([
+    ["quarterly report.pdf"],
+    ["plus+key.txt"],
+    ["sales&marketing.txt"],
+    ["report(1).txt"],
+    ["width=100.txt"],
+    ["someone@example.com.txt"],
+    ["pct%20literal.txt"],
+    ["2026/q1 results/final draft.txt"],
+  ])("writes, reads, describes and deletes %s", async (key) => {
+    // Given an Object written to the served endpoint under the key
+    await client.send(
+      new PutObjectCommand({ Bucket: "reserved", Key: key, Body: key }),
+    );
+
+    // When it is described and read back
+    const head = await client.send(
+      new HeadObjectCommand({ Bucket: "reserved", Key: key }),
+    );
+    const read = await client.send(
+      new GetObjectCommand({ Bucket: "reserved", Key: key }),
+    );
+
+    // Then both found the Object the key names
+    assertIdentical(head.ContentLength, key.length);
+    assertIdentical(await read.Body?.transformToString(), key);
+
+    // And the listing reports the key with the characters it was written with
+    const listed = await client.send(
+      new ListObjectsV2Command({ Bucket: "reserved", Prefix: key }),
+    );
+    assertDefined(listed.Contents, "the listed Objects");
+    assertIdentical(listed.Contents[0]?.Key, key);
+
+    // And deleting it takes that same Object away again
+    await client.send(
+      new DeleteObjectCommand({ Bucket: "reserved", Key: key }),
+    );
+
+    const remaining = await client.send(
+      new ListObjectsV2Command({ Bucket: "reserved", Prefix: key }),
+    );
+    assertIdentical(remaining.KeyCount, 0);
+  });
+});

--- a/src/service/s3/serve/api/sim-s3-copy-cli.loc.test.ts
+++ b/src/service/s3/serve/api/sim-s3-copy-cli.loc.test.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
 import { promisify } from "node:util";
 
 import {
@@ -190,6 +191,40 @@ describe("Moving an Object between simulated Buckets with the aws CLI", () => {
     // And the source is empty, which is the half of the move that made the
     // first half worth checking
     assertArrayLength(await stored("inbox", "moved.pdf"), 0);
+  });
+
+  it("copies a file to and from a key holding a space", async () => {
+    // Given a report under a key someone typed rather than a program generated
+    await givenReport("quarterly report.pdf");
+
+    // When the CLI downloads it and uploads it again under another such key
+    await aws(
+      "s3",
+      "cp",
+      "s3://inbox/quarterly report.pdf",
+      files.join("q.pdf"),
+    );
+    await aws(
+      "s3",
+      "cp",
+      files.join("q.pdf"),
+      "s3://archive/2026/quarterly report.pdf",
+    );
+
+    // Then the download and the upload both hold the report, having travelled
+    // a path carrying the space percent-encoded
+    // oxlint-disable-next-line security/detect-non-literal-fs-filename -- a temporary directory this test just made
+    const downloaded = await readFile(files.join("q.pdf"), "utf8");
+    assertIdentical(downloaded, report);
+
+    const read = await simS3.getObject(
+      new GetObjectCommand({
+        Bucket: "archive",
+        Key: "2026/quarterly report.pdf",
+      }),
+    );
+    assertDefined(read.Body, "the uploaded Object body");
+    assertIdentical(await bodyText(read.Body), report);
   });
 
   it("moves an Object whose key is a path of its own", async () => {

--- a/src/service/s3/serve/sim-s3-presigned-url.iso.test.ts
+++ b/src/service/s3/serve/sim-s3-presigned-url.iso.test.ts
@@ -81,6 +81,35 @@ describe("Presigned simulated S3 URLs", () => {
     assertIdentical(stored?.body.toString(), "uploaded through a link");
   });
 
+  it("serves an Object whose key holds a space", async () => {
+    // Given an Object under a key with a space in it, and a URL presigned for
+    // it. The space reaches the simulator percent-encoded, and S3 signs a path
+    // in the encoding it arrived in.
+    const { client, http, simAws } = await presignSimulation();
+    const key = "q3/quarterly report.pdf";
+
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: presignBucketName,
+        Key: key,
+        Body: presignObjectBody,
+      }),
+    );
+
+    const url = await getSignedUrl(
+      client,
+      new GetObjectCommand({ Bucket: presignBucketName, Key: key }),
+      { expiresIn: 900 },
+    );
+
+    // When it is fetched
+    const response = await http.fetch(url);
+
+    // Then the Object comes back, as it does for a key of plain characters
+    assertIdentical(response.status, 200);
+    assertIdentical(await response.text(), presignObjectBody);
+  });
+
   it("refuses a URL whose signature was tampered with", async () => {
     // Given a presigned URL for one Object, edited to name another
     const { client, http } = await presignSimulation();


### PR DESCRIPTION
Verification rebuilt the canonical request with the path encoded a second time. SigV4 specifies that for every service except S3, whose clients encode the path once and sign it as it stands. An Object key holding a space or an ampersand therefore arrived carrying two signatures that could never agree, and the endpoint answered 403 to reads, writes, presigned URLs and the aws CLI alike. The canonicalization rule now comes from the credential scope the request was signed under, the same place the client took it from, and every other service keeps the double encoding SigV4 asks for.

Resolves #841