### PR TITLE
fix: route a presigned URL by its query credential

### DIFF
--- a/docs/serve/README.md
+++ b/docs/serve/README.md
@@ -411,7 +411,9 @@ const client = new S3Client({
 
 The operations served are the ones simulated S3 implements: `CreateBucket`, `DeleteBucket`, `HeadBucket`, `ListBuckets`, `ListObjects`, `ListObjectsV2`, `GetObject`, `HeadObject`, `PutObject`, `DeleteObject`, `DeleteObjects`, the six multipart upload operations, and the Bucket policy, website, Block Public Access and event notification configurations. `aws s3 cp` works in both directions, and for a file above the CLI's 8MB multipart threshold. A `GetObject` carrying a `Range` is answered `206 Partial Content` with the bytes it asked for, and that is how the CLI takes a large file back out. Anything else is refused as `NotImplemented`, which an SDK raises under that name rather than leaving a client to guess.
 
-Simulated S3 also answers its own Bucket hostnames, covered above. That path is unchanged, and it is what a presigned URL and a website visitor use.
+Simulated S3 also answers its own Bucket hostnames, covered above. That path is unchanged, and it is what a website visitor uses.
+
+A presigned URL reaches an Object either way. `getSignedUrl` signs for whatever endpoint its client was configured with, and a URL signed for this one states its credential scope in an `X-Amz-Credential` parameter. The endpoint reads the scope from there for a request carrying no `Authorization` header, which is every presigned URL. Set `forcePathStyle` on the presigning client for the same reason an ordinary request needs it.
 
 ### SNS over the endpoint
 

--- a/docs/serve/README.md
+++ b/docs/serve/README.md
@@ -413,7 +413,7 @@ The operations served are the ones simulated S3 implements: `CreateBucket`, `Del
 
 Simulated S3 also answers its own Bucket hostnames, covered above. That path is unchanged, and it is what a website visitor uses.
 
-A presigned URL reaches an Object either way. `getSignedUrl` signs for whatever endpoint its client was configured with, and a URL signed for this one states its credential scope in an `X-Amz-Credential` parameter. The endpoint reads the scope from there for a request carrying no `Authorization` header, which is every presigned URL. Set `forcePathStyle` on the presigning client for the same reason an ordinary request needs it.
+A presigned URL reaches an Object either way. `getSignedUrl` signs for whatever endpoint its client was configured with, and a URL signed for this one states its credential scope in an `X-Amz-Credential` parameter. The endpoint reads the scope from there whenever a URL states one, since a presigned URL carries no `Authorization` header of its own. Set `forcePathStyle` on the presigning client for the same reason an ordinary request needs it.
 
 ### SNS over the endpoint
 

--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -2101,6 +2101,11 @@ npm install --save-dev @aws-sdk/s3-request-presigner
 `getBucketUrl(...)` for the virtual-hosted endpoint of one Bucket, though a client adds the Bucket
 to the service endpoint for itself.
 
+A client pointed at an endpoint URL presigns too, the `http://localhost:<port>` form that
+`--endpoint-url` and `AWS_ENDPOINT_URL` take. Such a URL names no service in its hostname and is
+routed by the credential scope it carries, so sign it with `forcePathStyle` and the Bucket goes in
+the path. See [S3 over the endpoint](../../serve/README.md#s3-over-the-endpoint).
+
 ```typescript sim-s3-presigned-url
 /**
  * Downloading a simulated S3 Object through a presigned URL.

--- a/src/sdk/wire/sim-sdk-wire-operation.iso.test.ts
+++ b/src/sdk/wire/sim-sdk-wire-operation.iso.test.ts
@@ -7,6 +7,7 @@ import { describe, it } from "vitest";
 import {
   readSimSdkWireCredentialScope,
   readSimSdkWireOperation,
+  readSimSdkWirePresignedCredentialScope,
 } from "./sim-sdk-wire-operation.js";
 import type { SimSdkWireRequest } from "./sim-sdk-wire.types.js";
 
@@ -87,6 +88,54 @@ describe("simulated AWS SDK wire operation", () => {
     assertUndefined(readSimSdkWireCredentialScope(requestWithHeaders({})));
     assertUndefined(
       readSimSdkWireCredentialScope(requestWithHeaders(bearerHeaders)),
+    );
+  });
+
+  it("reads the Region and service a presigned URL was signed for", () => {
+    // Given the path of a presigned URL, which carries its credential in the
+    // query string and no Authorization header anywhere.
+    // When its credential scope is read.
+    const scope = readSimSdkWirePresignedCredentialScope(
+      "/reports/q3/report.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256" +
+        "&X-Amz-Credential=AKIAEXAMPLE%2F20260817%2Feu-west-2%2Fs3" +
+        "%2Faws4_request&X-Amz-Signature=abc123",
+    );
+
+    // Then it says which Region and which service the signature covers, the
+    // same as the header form would for the same signature.
+    assertNonNullable(scope);
+    assertIdentical(scope.regionName, "eu-west-2");
+    assertIdentical(scope.signingName, "s3");
+  });
+
+  it("reads a presigned credential parameter whatever case it is written in", () => {
+    // Given a presigned URL whose parameter names are lower-cased, as a client
+    // that built the URL for itself may write them.
+    // When its credential scope is read.
+    const scope = readSimSdkWirePresignedCredentialScope(
+      "/reports/q3/report.pdf?x-amz-credential=" +
+        "AKIAEXAMPLE%2F20260817%2Fus-east-1%2Fsqs%2Faws4_request",
+    );
+
+    // Then the signing name still comes back.
+    assertNonNullable(scope);
+    assertIdentical(scope.signingName, "sqs");
+  });
+
+  it("reads nothing from a path that presigns nothing", () => {
+    // Given paths carrying no usable presigned credential.
+    // Then none of them yields a scope.
+    assertUndefined(readSimSdkWirePresignedCredentialScope("/reports"));
+    assertUndefined(
+      readSimSdkWirePresignedCredentialScope("/reports?x-id=Get"),
+    );
+    assertUndefined(
+      readSimSdkWirePresignedCredentialScope("/reports?X-Amz-Credential=AKIA"),
+    );
+    assertUndefined(
+      readSimSdkWirePresignedCredentialScope(
+        "/reports?X-Amz-Credential=AKIA%2Feu-west-2",
+      ),
     );
   });
 });

--- a/src/sdk/wire/sim-sdk-wire-operation.iso.test.ts
+++ b/src/sdk/wire/sim-sdk-wire-operation.iso.test.ts
@@ -27,6 +27,24 @@ function requestForTarget(target: string): SimSdkWireRequest {
   return requestWithHeaders(Object.fromEntries([["x-amz-target", target]]));
 }
 
+function requestSignedWith(credential: string): SimSdkWireRequest {
+  return requestWithHeaders(
+    Object.fromEntries([
+      [
+        "authorization",
+        `AWS4-HMAC-SHA256 Credential=${credential}, ` +
+          "SignedHeaders=host;x-amz-date, Signature=abc123",
+      ],
+    ]),
+  );
+}
+
+function presignedPathFor(credential: string): string {
+  return `/reports/q3/report.pdf?X-Amz-Credential=${encodeURIComponent(
+    credential,
+  )}`;
+}
+
 describe("simulated AWS SDK wire operation", () => {
   it("reads the service and Command a JSON protocol request names", () => {
     // Given a request as an AWS JSON protocol service is sent.
@@ -137,5 +155,37 @@ describe("simulated AWS SDK wire operation", () => {
         "/reports?X-Amz-Credential=AKIA%2Feu-west-2",
       ),
     );
+  });
+
+  it("reads nothing from a scope naming no Region or no service", () => {
+    // Given signatures whose scope leaves the Region or the service empty,
+    // saying nothing about where the request should go.
+    const emptyRegion = requestSignedWith("ASIA/20260817//sqs/aws4_request");
+    const emptyService = requestSignedWith(
+      "ASIA/20260817/us-east-1//aws4_request",
+    );
+
+    // Then none of them routes anywhere, in either form.
+    assertUndefined(readSimSdkWireCredentialScope(emptyRegion));
+    assertUndefined(readSimSdkWireCredentialScope(emptyService));
+    assertUndefined(
+      readSimSdkWirePresignedCredentialScope(
+        presignedPathFor("ASIA/20260817//s3/aws4_request"),
+      ),
+    );
+  });
+
+  it("routes a scope whose shape simulated IAM will refuse", () => {
+    // Given a signature scoped to a real Region and service, and terminated
+    // with something SigV4 never writes.
+    // When it is read for routing.
+    const scope = readSimSdkWirePresignedCredentialScope(
+      presignedPathFor("ASIA/20260817/eu-west-2/s3/not_aws4_request"),
+    );
+
+    // Then it still says which service to route to. Refusing it is signature
+    // verification's to do, and that names what was wrong with it.
+    assertNonNullable(scope);
+    assertIdentical(scope.signingName, "s3");
   });
 });

--- a/src/sdk/wire/sim-sdk-wire-operation.ts
+++ b/src/sdk/wire/sim-sdk-wire-operation.ts
@@ -165,15 +165,20 @@ export function readSimSdkWirePresignedCredentialScope(
  * Read the Region and the signing name out of a credential scope value.
  *
  * The scope is `<date>/<region>/<signing name>/aws4_request` wherever it is
- * written. Anything of another shape yields nothing, since this answers a
- * routing question and a request that fails to say where it is going is one to
- * decline rather than one to fail.
+ * written. A value naming neither yields nothing, since a request that fails
+ * to say where it is going is one to decline.
+ *
+ * The rest of the shape goes unchecked here. Simulated IAM parses the same
+ * value again to verify the signature, and refuses a bad date or a missing
+ * `aws4_request` terminator by name. Refusing it here instead would answer a
+ * malformed signature with a 501 naming a hostname, which says nothing about
+ * what was actually wrong with it.
  */
 function simSdkWireCredentialScope(
   scope: string | undefined,
 ): SimSdkWireCredentialScope | undefined {
-  const [, regionName, signingName] = scope?.split("/") ?? [];
-  if (regionName === undefined || signingName === undefined) {
+  const [, regionName = "", signingName = ""] = scope?.split("/") ?? [];
+  if (regionName.length === 0 || signingName.length === 0) {
     return undefined;
   }
 

--- a/src/sdk/wire/sim-sdk-wire-operation.ts
+++ b/src/sdk/wire/sim-sdk-wire-operation.ts
@@ -115,7 +115,64 @@ export function readSimSdkWireCredentialScope(
     authorization ?? "",
   )?.groups?.["scope"];
 
-  const [, regionName, signingName] = credential?.split("/") ?? [];
+  return simSdkWireCredentialScope(credential);
+}
+
+/**
+ * The query parameter a presigned URL states its credential in, lower-cased.
+ *
+ * Signers emit the `X-Amz-` spelling. Names are compared without regard to
+ * case, matching how the signature verifier reads the same parameter.
+ */
+const presignedCredentialParameter = "x-amz-credential";
+
+/**
+ * Read the credential scope a presigned URL states in its query string.
+ *
+ * A presigned URL is fetched by whatever holds it, over plain HTTP and with no
+ * Authorization header to read. It states the same access key and scope in
+ * `X-Amz-Credential`, and that parameter is the only place such a request says
+ * which service and Region it was signed for.
+ *
+ * This is separate from the header form because the two answer different
+ * questions. A request carrying an Authorization header came from an AWS SDK.
+ * A presigned URL came from anything that can make an HTTP request, so a
+ * caller asking whether it holds a serialized Command wants the header form
+ * alone.
+ */
+export function readSimSdkWirePresignedCredentialScope(
+  path: string,
+): SimSdkWireCredentialScope | undefined {
+  const query = path.indexOf("?");
+  if (query === -1) {
+    return undefined;
+  }
+
+  const parameters = new URLSearchParams(path.slice(query + 1));
+
+  for (const [name, value] of parameters) {
+    if (name.toLowerCase() === presignedCredentialParameter) {
+      // The value is `<access key id>/<scope>`, as an Authorization header
+      // writes it.
+      return simSdkWireCredentialScope(value.slice(value.indexOf("/") + 1));
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Read the Region and the signing name out of a credential scope value.
+ *
+ * The scope is `<date>/<region>/<signing name>/aws4_request` wherever it is
+ * written. Anything of another shape yields nothing, since this answers a
+ * routing question and a request that fails to say where it is going is one to
+ * decline rather than one to fail.
+ */
+function simSdkWireCredentialScope(
+  scope: string | undefined,
+): SimSdkWireCredentialScope | undefined {
+  const [, regionName, signingName] = scope?.split("/") ?? [];
   if (regionName === undefined || signingName === undefined) {
     return undefined;
   }

--- a/src/serve/http/api/sim-aws-api-endpoint.ts
+++ b/src/serve/http/api/sim-aws-api-endpoint.ts
@@ -1,6 +1,9 @@
 import { SimSdkUnbridgedWireRequestError } from "../../../sdk/error/sim-sdk.error.js";
 import { SimSdkWireDispatcher } from "../../../sdk/wire/sim-sdk-wire-dispatcher.js";
-import { readSimSdkWireCredentialScope } from "../../../sdk/wire/sim-sdk-wire-operation.js";
+import {
+  readSimSdkWireCredentialScope,
+  readSimSdkWirePresignedCredentialScope,
+} from "../../../sdk/wire/sim-sdk-wire-operation.js";
 import type { SimSdkWireRequest } from "../../../sdk/wire/sim-sdk-wire.types.js";
 import type { SimAws } from "../../../service/aws/sim-aws.js";
 import { SimAwsReceivedRequest } from "../request/sim-aws-received-request.js";
@@ -26,6 +29,9 @@ interface SimAwsApiEndpointProperties {
  *
  * So this endpoint routes on the credential scope. One endpoint URL then
  * serves every simulated service, which is the shape `--endpoint-url` wants.
+ * A presigned URL signed for the same endpoint states its scope in the query
+ * string, since it travels with no Authorization header, and it routes here on
+ * that.
  *
  * The scope also says which protocol to read the request with. Most simulated
  * services speak the AWS JSON protocol and name their operation in a header.
@@ -54,7 +60,9 @@ export class SimAwsApiEndpoint {
     const received = await SimAwsReceivedRequest.receive(request);
     const wireRequest = simAwsApiWireRequest(request, received.body);
 
-    const scope = readSimSdkWireCredentialScope(wireRequest);
+    const scope =
+      readSimSdkWireCredentialScope(wireRequest) ??
+      readSimSdkWirePresignedCredentialScope(wireRequest.path);
     if (scope === undefined) {
       return undefined;
     }

--- a/src/serve/http/api/sim-aws-api-endpoint.ts
+++ b/src/serve/http/api/sim-aws-api-endpoint.ts
@@ -30,8 +30,8 @@ interface SimAwsApiEndpointProperties {
  * So this endpoint routes on the credential scope. One endpoint URL then
  * serves every simulated service, which is the shape `--endpoint-url` wants.
  * A presigned URL signed for the same endpoint states its scope in the query
- * string, since it travels with no Authorization header, and it routes here on
- * that.
+ * string, since it carries no Authorization header of its own, and it routes
+ * here on that.
  *
  * The scope also says which protocol to read the request with. Most simulated
  * services speak the AWS JSON protocol and name their operation in a header.
@@ -60,9 +60,13 @@ export class SimAwsApiEndpoint {
     const received = await SimAwsReceivedRequest.receive(request);
     const wireRequest = simAwsApiWireRequest(request, received.body);
 
+    // A presigned query signature is read first, because that is the order
+    // simulated IAM verifies the two in. Routing a request by one signature
+    // and checking its scope against the other would refuse a request over a
+    // disagreement the caller never stated.
     const scope =
-      readSimSdkWireCredentialScope(wireRequest) ??
-      readSimSdkWirePresignedCredentialScope(wireRequest.path);
+      readSimSdkWirePresignedCredentialScope(wireRequest.path) ??
+      readSimSdkWireCredentialScope(wireRequest);
     if (scope === undefined) {
       return undefined;
     }

--- a/src/service/s3/serve/sim-s3-presigned-url.iso.test.ts
+++ b/src/service/s3/serve/sim-s3-presigned-url.iso.test.ts
@@ -59,6 +59,33 @@ describe("Presigned simulated S3 URLs", () => {
     assertIdentical(await response.text(), presignObjectBody);
   });
 
+  it("serves a presigned URL fetched with an application bearer token", async () => {
+    // Given a presigned URL signed for an endpoint URL
+    const { http, credentials } = await presignSimulation();
+    const url = await getSignedUrl(
+      presignClient({
+        endpoint: "http://localhost:4566",
+        credentials,
+        forcePathStyle: true,
+      }),
+      new GetObjectCommand({
+        Bucket: presignBucketName,
+        Key: presignObjectKey,
+      }),
+      { expiresIn: 900 },
+    );
+
+    // When it is fetched by a client that sends an Authorization header of its
+    // own, which is the application's business and not a signature
+    const response = await http.fetch(url, {
+      headers: { authorization: "Bearer an-application-token" },
+    });
+
+    // Then the URL is still routed and verified by the signature it carries
+    assertIdentical(response.status, 200);
+    assertIdentical(await response.text(), presignObjectBody);
+  });
+
   it("stores an upload made to an endpoint URL through a presigned PUT", async () => {
     // Given a presigned PUT URL signed for an endpoint URL
     const { http, simAws, credentials } = await presignSimulation();

--- a/src/service/s3/serve/sim-s3-presigned-url.iso.test.ts
+++ b/src/service/s3/serve/sim-s3-presigned-url.iso.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   presignBucketName,
+  presignClient,
   presignObjectBody,
   presignObjectKey,
   presignSimulation,
@@ -30,6 +31,63 @@ describe("Presigned simulated S3 URLs", () => {
     assertIdentical(response.status, 200);
     assertIdentical(await response.text(), presignObjectBody);
     assertIdentical(response.headers.get("content-type"), "application/pdf");
+  });
+
+  it("serves an Object through a URL signed for an endpoint URL", async () => {
+    // Given a client pointed at an endpoint URL, the form --endpoint-url and
+    // AWS_ENDPOINT_URL take, which names no service in its hostname
+    const { http, credentials } = await presignSimulation();
+    const url = await getSignedUrl(
+      presignClient({
+        endpoint: "http://localhost:4566",
+        credentials,
+        forcePathStyle: true,
+      }),
+      new GetObjectCommand({
+        Bucket: presignBucketName,
+        Key: presignObjectKey,
+      }),
+      { expiresIn: 900 },
+    );
+
+    // When the presigned URL is fetched
+    const response = await http.fetch(url);
+
+    // Then simulated S3 serves the Object, having read which service the URL
+    // was signed for out of its X-Amz-Credential parameter
+    assertIdentical(response.status, 200);
+    assertIdentical(await response.text(), presignObjectBody);
+  });
+
+  it("stores an upload made to an endpoint URL through a presigned PUT", async () => {
+    // Given a presigned PUT URL signed for an endpoint URL
+    const { http, simAws, credentials } = await presignSimulation();
+    const url = await getSignedUrl(
+      presignClient({
+        endpoint: "http://localhost:4566",
+        credentials,
+        forcePathStyle: true,
+      }),
+      new PutObjectCommand({
+        Bucket: presignBucketName,
+        Key: "uploads/to-endpoint.txt",
+      }),
+      { expiresIn: 900 },
+    );
+
+    // When something is uploaded to it
+    const response = await http.fetch(url, {
+      method: "PUT",
+      body: "uploaded to an endpoint URL",
+    });
+
+    // Then it is stored in the simulated Bucket
+    assertIdentical(response.status, 200);
+    const stored = await simAws
+      .s3()
+      .getSimBucketByName(presignBucketName)
+      ?.getObject("uploads/to-endpoint.txt");
+    assertIdentical(stored?.body.toString(), "uploaded to an endpoint URL");
   });
 
   it("attributes the request to the principal that signed the URL", async () => {

--- a/src/service/s3/serve/sim-s3-presigned-url.loc.test.ts
+++ b/src/service/s3/serve/sim-s3-presigned-url.loc.test.ts
@@ -61,6 +61,30 @@ describe("Presigned simulated S3 URLs over a local server", () => {
     assertIdentical(await response.text(), presignObjectBody);
   });
 
+  it("downloads through a URL signed for an endpoint URL", async () => {
+    // Given a URL presigned by a client pointed at the local server as an
+    // endpoint URL, the form --endpoint-url and AWS_ENDPOINT_URL take
+    const url = await getSignedUrl(
+      presignClient({
+        endpoint: `http://localhost:${srv.port}`,
+        credentials: simulation.credentials,
+        forcePathStyle: true,
+      }),
+      new GetObjectCommand({
+        Bucket: presignBucketName,
+        Key: presignObjectKey,
+      }),
+      { expiresIn: 900 },
+    );
+
+    // When it is fetched over real HTTP
+    const response = await fetch(url);
+
+    // Then the Object comes back, with no hostname naming the service
+    assertIdentical(response.status, 200);
+    assertIdentical(await response.text(), presignObjectBody);
+  });
+
   it("uploads an Object through a presigned URL", async () => {
     // Given a presigned upload URL
     const url = await getSignedUrl(

--- a/test/cli/watch-project.ts
+++ b/test/cli/watch-project.ts
@@ -5,15 +5,24 @@ import { TemporaryDirectory } from "../../src/util/filesystem/temporary-director
  * How long one run of a supervised process is waited for.
  *
  * A run is a real process, spawned through `tsx`, importing whatever the dev
- * script imports. On a loaded CI runner that is seconds rather than the
- * fraction of one it takes on a developer machine, and the first spawn in a
- * file pays for a cold `tsx` transform cache on top of that. Twelve seconds
- * was not enough for it once the rest of the local suite grew. Two of these
- * fit inside the local test timeout, so a test that waited for a restart it
- * never got fails saying how many times the process ran rather than with a
- * bare timeout.
+ * script imports. A dev script that imports Yulin costs about 1.5 seconds of
+ * that on an idle developer machine, nearly all of it transforming and
+ * executing the module graph. A bare script costs 0.3.
+ *
+ * What the budget has to cover is contention rather than that cost. The tests
+ * run on an eight vCPU runner, with the suite running files in parallel and
+ * each supervised test spawning processes of its own, so the machine is
+ * saturated and one spawn stretches by an order of magnitude. Measured under
+ * load, the same spawn takes over twice as long on eighteen cores, and a
+ * runner with eight has further to fall.
+ *
+ * So this has been raised twice, from twelve seconds, then from twenty after a
+ * first spawn failed to land inside it. Forty is roughly twenty-five times the
+ * unloaded cost. Two of these fit inside the local test timeout, so a test
+ * that waited for a restart it never got fails saying how many times the
+ * process ran rather than with a bare timeout.
  */
-export const watchRunTimeoutMs = 20_000;
+export const watchRunTimeoutMs = 40_000;
 
 /**
  * A throwaway project for `yulin watch` to supervise.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -64,7 +64,7 @@ export default defineConfig({
           // an isolated test does before a slow run counts as a hang. This has
           // to stay above twice `watchRunTimeoutMs`, since a supervised test
           // waits for two runs of a spawned process inside one timeout.
-          testTimeout: 45_000,
+          testTimeout: 90_000,
           // globalSetup: ["./test/locTestGlobalSetUp.ts"],
         },
       },


### PR DESCRIPTION
A presigned S3 URL signed against an endpoint URL was answered 501. That endpoint routes on the SigV4 credential scope, and it read the scope out of the Authorization header alone. A presigned URL carries no such header and states the same scope in its `X-Amz-Credential` parameter, which the endpoint now falls back to. Everything downstream already handled the presigned form, including signature verification, caller resolution and the S3 REST endpoint.

Resolves https://github.com/KensioSoftware/yulin/issues/847

The new reader is separate from the header one because the two answer different questions. A request carrying an Authorization header came from an AWS SDK, and `isSimAwsApiRequest` on the sim Lambda outbound path uses that to tell a serialized Command from an ordinary fetch. A presigned URL is an ordinary fetch by construction, so it stays out of that test and only the endpoint routing consults it.

Virtual-hosted presigning against an endpoint URL answers 404, since the Bucket is in a hostname the endpoint does not route on. That matches what the docs already say about ordinary SDK requests over the endpoint, which is that a client needs `forcePathStyle`. Issue #847 listed the virtual-hosted case in its acceptance criteria, and it is left as it is.

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for routing S3 presigned URLs using credential-scope information in the URL.
  - Presigned URLs now work with shared localhost endpoints and path-style addressing.
  - Bucket-hostname requests remain supported.

- **Documentation**
  - Updated S3 endpoint guidance, including presigned URL configuration and behavior.

- **Tests**
  - Added coverage for presigned GET and PUT requests, credential parsing, invalid parameters, and real HTTP access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->