### PR TITLE
feat: retry async invokes to a destination or DLQ

### DIFF
--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -875,7 +875,10 @@ import {
 import { CreateQueueCommand, ReceiveMessageCommand } from "@aws-sdk/client-sqs";
 
 import { SimAws } from "@kensio/yulin";
-import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+import {
+  makeLambdaZipFileInput,
+  type SimLambdaDestinationRecord,
+} from "@kensio/yulin/lambda";
 
 const simAws = new SimAws();
 const lambda = simAws.lambda();
@@ -929,10 +932,9 @@ console.log(attempts.length);
 const received = await sqs.receiveMessage(
   new ReceiveMessageCommand({ QueueUrl: created.QueueUrl }),
 );
-const record = JSON.parse(String(received.Messages?.[0]?.Body)) as {
-  requestContext: { condition: string; approximateInvokeCount: number };
-  requestPayload: unknown;
-};
+const record = JSON.parse(
+  String(received.Messages?.[0]?.Body),
+) as SimLambdaDestinationRecord;
 console.log(record.requestContext.condition);
 console.log(record.requestContext.approximateInvokeCount);
 console.log(record.requestPayload);

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -847,8 +847,169 @@ const dryRunOutput = await lambda.invoke(
 console.log(dryRunOutput.StatusCode);
 ```
 
-`Event` invocation handler errors are dropped. Asynchronous retries and failure destinations are
-left out so far.
+`Event` invocation handler errors never reach the caller, who has already been answered. Where the
+handler keeps failing they reach the function's destinations instead, which is what the next section
+covers.
+
+## Asynchronous retries and destinations
+
+An `Event` invocation whose handler throws is retried twice, as real Lambda retries one. The retries
+wait on the simulated clock, about a minute before the first and two before the second, so a test
+reaches them by advancing time rather than by waiting for it.
+
+`PutFunctionEventInvokeConfigCommand` changes how many retries a function makes and where its
+results go. An invocation that fails its last attempt is sent to the `OnFailure` destination, and
+one whose handler returns is sent to `OnSuccess`. A destination ARN can name a simulated SQS queue,
+SNS topic, EventBridge event bus or Lambda function.
+
+```typescript sim-lambda-async-destinations
+/**
+ * Asynchronous invocation retries and an OnFailure destination.
+ */
+
+import {
+  CreateFunctionCommand,
+  InvokeCommand,
+  PutFunctionEventInvokeConfigCommand,
+} from "@aws-sdk/client-lambda";
+import { CreateQueueCommand, ReceiveMessageCommand } from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+const sqs = simAws.sqs();
+
+const created = await sqs.createQueue(
+  new CreateQueueCommand({ QueueName: "order-failures" }),
+);
+
+const attempts: string[] = [];
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "orders",
+    Role: "arn:aws:iam::111111111111:role/OrdersRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: { id: number }) => {
+        attempts.push(`tried order ${event.id}`);
+        throw new Error("orders handler failed");
+      }),
+    },
+  }),
+);
+
+await lambda.putFunctionEventInvokeConfig(
+  new PutFunctionEventInvokeConfigCommand({
+    FunctionName: "orders",
+    MaximumRetryAttempts: 1,
+    DestinationConfig: {
+      OnFailure: {
+        Destination: "arn:aws:sqs:us-east-1:888888888888:order-failures",
+      },
+    },
+  }),
+);
+
+await lambda.invoke(
+  new InvokeCommand({
+    FunctionName: "orders",
+    InvocationType: "Event",
+    Payload: JSON.stringify({ id: 7 }),
+  }),
+);
+
+// The first attempt runs behind the caller. The retry waits on the clock.
+await simAws.backgroundTasksComplete();
+console.log(attempts.length);
+
+await simAws.clock().advanceBy({ minutes: 2 });
+console.log(attempts.length);
+
+const received = await sqs.receiveMessage(
+  new ReceiveMessageCommand({ QueueUrl: created.QueueUrl }),
+);
+const record = JSON.parse(String(received.Messages?.[0]?.Body)) as {
+  requestContext: { condition: string; approximateInvokeCount: number };
+  requestPayload: unknown;
+};
+console.log(record.requestContext.condition);
+console.log(record.requestContext.approximateInvokeCount);
+console.log(record.requestPayload);
+```
+
+The queue receives the record real Lambda sends, carrying the event that was invoked as
+`requestPayload`, the handler error as `responsePayload`, how many attempts were made, and a
+`condition` of `Success`, `RetriesExhausted` or `EventAgeExceeded`. An event that outlives
+`MaximumEventAgeInSeconds` is given up on before its next attempt and reported under that last
+condition.
+
+`GetFunctionEventInvokeConfigCommand`, `UpdateFunctionEventInvokeConfigCommand`,
+`DeleteFunctionEventInvokeConfigCommand` and `ListFunctionEventInvokeConfigsCommand` read and change
+what was written. `Put` writes the whole config, returning a setting it leaves out to its default,
+and `Update` changes only the settings it names. A `Qualifier` gives a published version or an alias
+a config of its own, and an invocation of a qualifier with no config of its own uses the function's.
+
+### Dead-letter targets
+
+`DeadLetterConfig` is the older way to keep a failed asynchronous invocation, and simulated Lambda
+takes it on `CreateFunction` and `UpdateFunctionConfiguration`. Its `TargetArn` names a simulated
+SQS queue or SNS topic, which receives the event as it was invoked rather than the destination
+record around it.
+
+```typescript sim-lambda-dead-letter-queue
+/**
+ * A simulated Lambda function with a dead-letter queue.
+ */
+
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import { CreateQueueCommand, ReceiveMessageCommand } from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+const sqs = simAws.sqs();
+
+const created = await sqs.createQueue(
+  new CreateQueueCommand({ QueueName: "orders-dlq" }),
+);
+
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "orders",
+    Role: "arn:aws:iam::111111111111:role/OrdersRole",
+    DeadLetterConfig: {
+      TargetArn: "arn:aws:sqs:us-east-1:888888888888:orders-dlq",
+    },
+    Code: {
+      ZipFile: makeLambdaZipFileInput(() => {
+        throw new Error("orders handler failed");
+      }),
+    },
+  }),
+);
+
+await lambda.invoke(
+  new InvokeCommand({
+    FunctionName: "orders",
+    InvocationType: "Event",
+    Payload: JSON.stringify({ id: 7 }),
+  }),
+);
+
+// Past both retries, so the invocation has been given up on.
+await simAws.backgroundTasksComplete();
+await simAws.clock().advanceBy({ minutes: 5 });
+
+const received = await sqs.receiveMessage(
+  new ReceiveMessageCommand({ QueueUrl: created.QueueUrl }),
+);
+console.log(received.Messages?.[0]?.Body);
+```
+
+A function carrying both a dead-letter target and an `OnFailure` destination sends to both.
 
 ## Versions and aliases
 
@@ -2967,6 +3128,14 @@ Sim Lambda currently supports:
 - `ListFunctionsCommand`, reporting every function in the Account and Region, and their published
   versions with `FunctionVersion: "ALL"`
 - `InvokeCommand`, with the `RequestResponse`, `Event` and `DryRun` invocation types
+- Asynchronous invocation retries on the simulated clock, and `OnSuccess`/`OnFailure` destinations
+  written with `PutFunctionEventInvokeConfigCommand`, delivering the AWS destination record to a
+  simulated SQS queue, SNS topic, EventBridge event bus or Lambda function
+- `GetFunctionEventInvokeConfigCommand`, `UpdateFunctionEventInvokeConfigCommand`,
+  `DeleteFunctionEventInvokeConfigCommand` and `ListFunctionEventInvokeConfigsCommand`, each taking
+  a `Qualifier` for a version's or an alias's own config
+- `DeadLetterConfig` on `CreateFunction` and `UpdateFunctionConfiguration`, sending an abandoned
+  event to a simulated SQS queue or SNS topic
 - Function URLs, created with `CreateFunctionUrlConfigCommand` and served over HTTP on localhost
   with `serveSimAws`
 - `AuthType: "AWS_IAM"` Function URLs, authorizing `lambda:InvokeFunctionUrl` against the caller
@@ -3029,9 +3198,21 @@ Current documented limitations:
   tagging commands are absent so far.
 - `UpdateFunctionCode` leaves out the `RevisionId` and `DryRun` preconditions real Lambda takes,
   along with `Architectures` and `SourceKMSKeyArn`. `UpdateFunctionConfiguration` takes only the
-  settings simulated Lambda models, leaving out `Layers`, `VpcConfig`, `DeadLetterConfig`,
-  `TracingConfig`, `KMSKeyArn`, `EphemeralStorage`, `SnapStart`, `LoggingConfig` and `RevisionId`.
-  `ListFunctions` leaves out `Marker`/`MaxItems` paging and `MasterRegion`.
+  settings simulated Lambda models, leaving out `Layers`, `VpcConfig`, `TracingConfig`, `KMSKeyArn`,
+  `EphemeralStorage`, `SnapStart`, `LoggingConfig` and `RevisionId`. `ListFunctions` leaves out
+  `Marker`/`MaxItems` paging and `MasterRegion`.
+- A destination is delivered to without checking that the function's execution role may write to it.
+  Real Lambda delivers under that role and drops the record where the role cannot, which would be
+  silent, so simulated Lambda delivers instead. Nothing else about the destination has to be set up,
+  since a destination needs no resource policy on real AWS either.
+- `AWS::Lambda::EventInvokeConfig` and the `DeadLetterConfig` property of `AWS::Lambda::Function`
+  are not deployed from a template yet, so a CDK function's `onFailure`, `onSuccess` and
+  `deadLetterQueue` are left out of the simulated function. See
+  [issue 845](https://github.com/KensioSoftware/yulin/issues/845).
+- Throttling and timeouts do not drive a retry. A retry follows a handler that threw, and the
+  `MaximumEventAgeInSeconds` a config carries is measured from when the invocation was accepted.
+- `DestinationConfig` on an event source mapping is left out. It is a different mechanism from the
+  asynchronous invocation destinations above.
 - A settings change takes effect at once. Real Lambda reports `LastUpdateStatus: "InProgress"` while
   it rolls the change out, and neither that member nor the wait it implies is simulated.
 - A cross-account grant is only half of what admits a call. The caller's own Account has to allow

--- a/docs/services/lambda/sim-lambda-async-destinations.example.ts
+++ b/docs/services/lambda/sim-lambda-async-destinations.example.ts
@@ -10,7 +10,10 @@ import {
 import { CreateQueueCommand, ReceiveMessageCommand } from "@aws-sdk/client-sqs";
 
 import { SimAws } from "@kensio/yulin";
-import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+import {
+  makeLambdaZipFileInput,
+  type SimLambdaDestinationRecord,
+} from "@kensio/yulin/lambda";
 
 const simAws = new SimAws();
 const lambda = simAws.lambda();
@@ -64,10 +67,9 @@ console.log(attempts.length);
 const received = await sqs.receiveMessage(
   new ReceiveMessageCommand({ QueueUrl: created.QueueUrl }),
 );
-const record = JSON.parse(String(received.Messages?.[0]?.Body)) as {
-  requestContext: { condition: string; approximateInvokeCount: number };
-  requestPayload: unknown;
-};
+const record = JSON.parse(
+  String(received.Messages?.[0]?.Body),
+) as SimLambdaDestinationRecord;
 console.log(record.requestContext.condition);
 console.log(record.requestContext.approximateInvokeCount);
 console.log(record.requestPayload);

--- a/docs/services/lambda/sim-lambda-async-destinations.example.ts
+++ b/docs/services/lambda/sim-lambda-async-destinations.example.ts
@@ -1,0 +1,73 @@
+/**
+ * Asynchronous invocation retries and an OnFailure destination.
+ */
+
+import {
+  CreateFunctionCommand,
+  InvokeCommand,
+  PutFunctionEventInvokeConfigCommand,
+} from "@aws-sdk/client-lambda";
+import { CreateQueueCommand, ReceiveMessageCommand } from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+const sqs = simAws.sqs();
+
+const created = await sqs.createQueue(
+  new CreateQueueCommand({ QueueName: "order-failures" }),
+);
+
+const attempts: string[] = [];
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "orders",
+    Role: "arn:aws:iam::111111111111:role/OrdersRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: { id: number }) => {
+        attempts.push(`tried order ${event.id}`);
+        throw new Error("orders handler failed");
+      }),
+    },
+  }),
+);
+
+await lambda.putFunctionEventInvokeConfig(
+  new PutFunctionEventInvokeConfigCommand({
+    FunctionName: "orders",
+    MaximumRetryAttempts: 1,
+    DestinationConfig: {
+      OnFailure: {
+        Destination: "arn:aws:sqs:us-east-1:888888888888:order-failures",
+      },
+    },
+  }),
+);
+
+await lambda.invoke(
+  new InvokeCommand({
+    FunctionName: "orders",
+    InvocationType: "Event",
+    Payload: JSON.stringify({ id: 7 }),
+  }),
+);
+
+// The first attempt runs behind the caller. The retry waits on the clock.
+await simAws.backgroundTasksComplete();
+console.log(attempts.length);
+
+await simAws.clock().advanceBy({ minutes: 2 });
+console.log(attempts.length);
+
+const received = await sqs.receiveMessage(
+  new ReceiveMessageCommand({ QueueUrl: created.QueueUrl }),
+);
+const record = JSON.parse(String(received.Messages?.[0]?.Body)) as {
+  requestContext: { condition: string; approximateInvokeCount: number };
+  requestPayload: unknown;
+};
+console.log(record.requestContext.condition);
+console.log(record.requestContext.approximateInvokeCount);
+console.log(record.requestPayload);

--- a/docs/services/lambda/sim-lambda-dead-letter-queue.example.ts
+++ b/docs/services/lambda/sim-lambda-dead-letter-queue.example.ts
@@ -1,0 +1,49 @@
+/**
+ * A simulated Lambda function with a dead-letter queue.
+ */
+
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import { CreateQueueCommand, ReceiveMessageCommand } from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+const sqs = simAws.sqs();
+
+const created = await sqs.createQueue(
+  new CreateQueueCommand({ QueueName: "orders-dlq" }),
+);
+
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "orders",
+    Role: "arn:aws:iam::111111111111:role/OrdersRole",
+    DeadLetterConfig: {
+      TargetArn: "arn:aws:sqs:us-east-1:888888888888:orders-dlq",
+    },
+    Code: {
+      ZipFile: makeLambdaZipFileInput(() => {
+        throw new Error("orders handler failed");
+      }),
+    },
+  }),
+);
+
+await lambda.invoke(
+  new InvokeCommand({
+    FunctionName: "orders",
+    InvocationType: "Event",
+    Payload: JSON.stringify({ id: 7 }),
+  }),
+);
+
+// Past both retries, so the invocation has been given up on.
+await simAws.backgroundTasksComplete();
+await simAws.clock().advanceBy({ minutes: 5 });
+
+const received = await sqs.receiveMessage(
+  new ReceiveMessageCommand({ QueueUrl: created.QueueUrl }),
+);
+console.log(received.Messages?.[0]?.Body);

--- a/src/service/aws/factory/sim-aws-lambda-collaborators.ts
+++ b/src/service/aws/factory/sim-aws-lambda-collaborators.ts
@@ -1,3 +1,4 @@
+import { SimAwsLambdaDestinations } from "../../lambda/destination/sim-aws-lambda-destinations.js";
 import { SimDynamoDbEventSourceStreams } from "../../lambda/event-source/stream/sim-dynamodb-event-source-streams.js";
 import { SimSqsEventSourceQueues } from "../../lambda/event-source/queue/sim-sqs-event-source-queues.js";
 import { SimEcrLambdaContainerImages } from "../../lambda/function/code/image/sim-ecr-lambda-container-images.js";
@@ -31,6 +32,7 @@ interface SimAwsLambdaCollaborators {
   readonly vmSdkModuleProvider: SimSdkLambdaVmModuleProvider;
   readonly outboundHttp: SimLambdaOutboundHttp;
   readonly logs: SimLogsServiceWriter;
+  readonly destinations: SimAwsLambdaDestinations;
 }
 
 /**
@@ -49,6 +51,10 @@ interface SimAwsLambdaCollaborators {
  * A container image function's image is resolved in the whole simulation's ECR
  * rather than this scope's, because an image URI names the Account and Region
  * its registry is in, which need not be this one.
+ *
+ * An asynchronous invocation result is sent through the whole simulation
+ * rather than through this scope, because a destination ARN names the Account
+ * and Region it lives in, and real Lambda delivers across both.
  *
  * Handler output is recorded to the same Account/Region scope's simulated
  * CloudWatch Logs, since that is where `/aws/lambda/<name>` lives for a
@@ -72,6 +78,7 @@ export function simAwsLambdaCollaborators(
   return {
     outboundHttp,
     runAsOwner: simAws,
+    destinations: new SimAwsLambdaDestinations({ simAws }),
     logs: scope.logs().serviceWriter(),
     urlRegistry: properties.urlRegistry,
     codeStore: new SimS3LambdaCodeStore({ s3: scope.s3() }),

--- a/src/service/lambda/command/create-function/create-function-input.ts
+++ b/src/service/lambda/command/create-function/create-function-input.ts
@@ -4,6 +4,7 @@ import {
   type SimLambdaCodeSource,
 } from "../../function/code/lambda-code-source.js";
 import { requireLambdaEnvironmentVariables } from "../../function/environment/lambda-environment-variables.js";
+import { requireLambdaDeadLetterTarget } from "../../function/event-invoke/lambda-dead-letter-target.js";
 import type { SimCreateFunctionCommand } from "./create-function.command.js";
 
 /**
@@ -19,6 +20,7 @@ export interface CreateFunctionInput {
   timeoutSeconds: number | undefined;
   memorySizeMb: number | undefined;
   environmentVariables: ReadonlyMap<string, string>;
+  deadLetterTargetArn: string | undefined;
 }
 
 /**
@@ -45,5 +47,6 @@ export function requireCreateFunctionInput(
     timeoutSeconds: input.Timeout,
     memorySizeMb: input.MemorySize,
     environmentVariables: requireLambdaEnvironmentVariables(input.Environment),
+    deadLetterTargetArn: requireLambdaDeadLetterTarget(input.DeadLetterConfig),
   };
 }

--- a/src/service/lambda/command/create-function/create-function.command.ts
+++ b/src/service/lambda/command/create-function/create-function.command.ts
@@ -3,6 +3,7 @@
  */
 
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimLambdaDeadLetterConfigInput } from "../../function/event-invoke/lambda-dead-letter-target.js";
 import type { SimLambdaFunctionConfiguration } from "../../function/sim-lambda-function-configuration.js";
 
 /**
@@ -47,6 +48,7 @@ export interface SimCreateFunctionCommandInput {
   readonly Timeout?: number | undefined;
   readonly MemorySize?: number | undefined;
   readonly Environment?: SimLambdaFunctionEnvironment | undefined;
+  readonly DeadLetterConfig?: SimLambdaDeadLetterConfigInput | undefined;
 }
 
 /**

--- a/src/service/lambda/command/delete-function-event-invoke-config/delete-function-event-invoke-config.command.ts
+++ b/src/service/lambda/command/delete-function-event-invoke-config/delete-function-event-invoke-config.command.ts
@@ -1,0 +1,27 @@
+/**
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/DeleteFunctionEventInvokeConfigCommand/
+ */
+
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim Lambda DeleteFunctionEventInvokeConfig command.
+ */
+export interface SimDeleteFunctionEventInvokeConfigCommand {
+  readonly input: SimDeleteFunctionEventInvokeConfigCommandInput;
+}
+
+/**
+ * Minimal structural sim Lambda DeleteFunctionEventInvokeConfig input.
+ */
+export interface SimDeleteFunctionEventInvokeConfigCommandInput {
+  readonly FunctionName?: string | undefined;
+  readonly Qualifier?: string | undefined;
+}
+
+/**
+ * Minimal structural sim Lambda DeleteFunctionEventInvokeConfig output.
+ */
+export interface SimDeleteFunctionEventInvokeConfigCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/lambda/command/delete-function-event-invoke-config/delete-function-event-invoke-config.handler.ts
+++ b/src/service/lambda/command/delete-function-event-invoke-config/delete-function-event-invoke-config.handler.ts
@@ -1,0 +1,56 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import type { SimLambdaEventInvokeConfigStore } from "../../function/event-invoke/sim-lambda-event-invoke-config-store.js";
+import {
+  type EventInvokeConfigCommandOptions,
+  type EventInvokeConfigCommandProperties,
+  EventInvokeConfigRequest,
+} from "../event-invoke-config/event-invoke-config-request.js";
+import type {
+  SimDeleteFunctionEventInvokeConfigCommand,
+  SimDeleteFunctionEventInvokeConfigCommandOutput,
+} from "./delete-function-event-invoke-config.command.js";
+
+interface DeleteFunctionEventInvokeConfigCommandHandlerProperties extends EventInvokeConfigCommandProperties {
+  readonly eventInvokeConfigs: SimLambdaEventInvokeConfigStore;
+}
+
+/**
+ * Simulated Lambda DeleteFunctionEventInvokeConfigCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/DeleteFunctionEventInvokeConfigCommand/
+ */
+export class DeleteFunctionEventInvokeConfigCommandHandler implements CommandHandler<
+  SimDeleteFunctionEventInvokeConfigCommand,
+  SimDeleteFunctionEventInvokeConfigCommandOutput
+> {
+  private readonly eventInvokeConfigs: SimLambdaEventInvokeConfigStore;
+  private readonly request: EventInvokeConfigRequest;
+
+  constructor(
+    properties: DeleteFunctionEventInvokeConfigCommandHandlerProperties,
+  ) {
+    this.eventInvokeConfigs = properties.eventInvokeConfigs;
+    this.request = new EventInvokeConfigRequest({
+      ...properties,
+      action: "lambda:DeleteFunctionEventInvokeConfig",
+    });
+  }
+
+  /**
+   * Delete a function's event invoke config, so its asynchronous invocations
+   * go back to the defaults.
+   */
+  async handle(
+    command: SimDeleteFunctionEventInvokeConfigCommand,
+    options?: EventInvokeConfigCommandOptions,
+  ): Promise<SimDeleteFunctionEventInvokeConfigCommandOutput> {
+    const resolved = await this.request.resolve(
+      command.input,
+      "DeleteFunctionEventInvokeConfigCommand",
+      options,
+    );
+    this.eventInvokeConfigs.delete(resolved, resolved.functionArn);
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/lambda/command/delete-function/delete-function.handler.ts
+++ b/src/service/lambda/command/delete-function/delete-function.handler.ts
@@ -16,6 +16,7 @@ import type {
   SimLambdaFunctionName,
 } from "../../function/sim-lambda-function.js";
 import { simLambdaFunctionArn } from "../../function/sim-lambda-function-configuration.js";
+import type { SimLambdaEventInvokeConfigStore } from "../../function/event-invoke/sim-lambda-event-invoke-config-store.js";
 import type { SimLambdaFunctionUrlStore } from "../../function/url/sim-lambda-function-url-store.js";
 import type { SimLambdaFunctionVersionStore } from "../../function/version/sim-lambda-function-version-store.js";
 import { DeleteFunctionAuthorizer } from "./delete-function-authorizer.js";
@@ -29,6 +30,7 @@ interface DeleteFunctionCommandHandlerProperties {
   readonly functions: SimLambdaFunctionMap;
   readonly functionUrls: SimLambdaFunctionUrlStore;
   readonly versions: SimLambdaFunctionVersionStore;
+  readonly eventInvokeConfigs?: SimLambdaEventInvokeConfigStore | undefined;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
 }
@@ -50,6 +52,10 @@ export class DeleteFunctionCommandHandler implements CommandHandler<
   private readonly functions: SimLambdaFunctionMap;
   private readonly functionUrls: SimLambdaFunctionUrlStore;
   private readonly versions: SimLambdaFunctionVersionStore;
+  private readonly eventInvokeConfigs:
+    | SimLambdaEventInvokeConfigStore
+    | undefined;
+
   private readonly authorizer: DeleteFunctionAuthorizer;
   private readonly background: BackgroundScheduler;
 
@@ -67,6 +73,7 @@ export class DeleteFunctionCommandHandler implements CommandHandler<
     this.functions = functions;
     this.functionUrls = functionUrls;
     this.versions = versions;
+    this.eventInvokeConfigs = properties.eventInvokeConfigs;
     this.authorizer = new DeleteFunctionAuthorizer({ iam });
     this.background = background;
   }
@@ -81,7 +88,8 @@ export class DeleteFunctionCommandHandler implements CommandHandler<
    *
    * The resource policy the Add Permission command builds is held on the
    * function itself, so it goes at the same time. So do the versions published
-   * from it and the aliases pointing at those, as they do on real Lambda.
+   * from it, the aliases pointing at those, and the event invoke configs held
+   * under each qualifier, as they do on real Lambda.
    */
   async handle(
     command: SimDeleteFunctionCommand,
@@ -112,6 +120,7 @@ export class DeleteFunctionCommandHandler implements CommandHandler<
 
     this.functionUrls.deleteIfPresent(simFunction);
     this.versions.forget(simFunction);
+    this.eventInvokeConfigs?.deleteForFunction(functionName);
     this.functions.delete(functionName);
 
     return { $metadata: {} };

--- a/src/service/lambda/command/event-invoke-config/event-invoke-config-authorizer.ts
+++ b/src/service/lambda/command/event-invoke-config/event-invoke-config-authorizer.ts
@@ -1,0 +1,49 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+
+interface EventInvokeConfigAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly action: string;
+}
+
+/**
+ * Applies IAM authorization to a Lambda event invoke config request.
+ *
+ * AWS maps each of these operations to the IAM action of the same name,
+ * always against the ARN of the function the config belongs to. The action
+ * varies but nothing else does, so one authorizer serves all five rather than
+ * a near-identical class per command.
+ */
+export class EventInvokeConfigAuthorizer {
+  private readonly iam: SimIamInterServiceAuthZ;
+  private readonly action: string;
+
+  constructor(properties: EventInvokeConfigAuthorizerProperties) {
+    this.iam = properties.iam;
+    this.action = properties.action;
+  }
+
+  /**
+   * Ensure the caller may perform this action on the function.
+   *
+   * The caller is passed through unchanged so sim IAM can distinguish an
+   * omitted caller, which defaults to Account root, from an explicit
+   * anonymous caller.
+   */
+  authorize(functionArn: string, caller?: SimAwsCaller): void {
+    const decision = this.iam.authorize({
+      action: this.action,
+      resource: functionArn,
+      caller,
+    });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action: this.action,
+        resource: functionArn,
+      });
+    }
+  }
+}

--- a/src/service/lambda/command/event-invoke-config/event-invoke-config-input.ts
+++ b/src/service/lambda/command/event-invoke-config/event-invoke-config-input.ts
@@ -1,0 +1,99 @@
+import { SimLambdaDestinationArn } from "../../destination/sim-lambda-destination-arn.js";
+import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
+import {
+  MAX_SIM_LAMBDA_MAXIMUM_EVENT_AGE_SECONDS,
+  MAX_SIM_LAMBDA_MAXIMUM_RETRY_ATTEMPTS,
+  MIN_SIM_LAMBDA_MAXIMUM_EVENT_AGE_SECONDS,
+  type SimLambdaDestination,
+  type SimLambdaDestinationConfiguration,
+  type SimLambdaEventInvokeConfigUpdate,
+} from "../../function/event-invoke/sim-lambda-event-invoke-config.js";
+
+/**
+ * What both commands that write an event invoke config carry.
+ */
+export interface SimLambdaEventInvokeConfigInput {
+  readonly MaximumRetryAttempts?: number | undefined;
+  readonly MaximumEventAgeInSeconds?: number | undefined;
+  readonly DestinationConfig?: SimLambdaDestinationConfiguration | undefined;
+}
+
+/**
+ * Reads the settings of an event invoke config request.
+ *
+ * A destination is read here so an ARN naming something the simulation cannot
+ * send to is refused while the caller is still there to see it, rather than
+ * when an invocation first fails hours later.
+ */
+export class EventInvokeConfigInputParser {
+  /**
+   * Read a request's settings, refusing values real Lambda refuses.
+   */
+  parse(
+    input: SimLambdaEventInvokeConfigInput,
+  ): SimLambdaEventInvokeConfigUpdate {
+    return {
+      maximumRetryAttempts: this.retryAttempts(input.MaximumRetryAttempts),
+      maximumEventAgeInSeconds: this.eventAge(input.MaximumEventAgeInSeconds),
+      onSuccessArn: this.destination(input.DestinationConfig?.OnSuccess),
+      onFailureArn: this.destination(input.DestinationConfig?.OnFailure),
+    };
+  }
+
+  private retryAttempts(value: number | undefined): number | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (
+      !Number.isSafeInteger(value) ||
+      value < 0 ||
+      value > MAX_SIM_LAMBDA_MAXIMUM_RETRY_ATTEMPTS
+    ) {
+      throw new SimLambdaInvalidParameterValueException(
+        `MaximumRetryAttempts must be a whole number between 0 and ` +
+          `${MAX_SIM_LAMBDA_MAXIMUM_RETRY_ATTEMPTS}, and ${value} is not.`,
+      );
+    }
+
+    return value;
+  }
+
+  private eventAge(value: number | undefined): number | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (
+      !Number.isSafeInteger(value) ||
+      value < MIN_SIM_LAMBDA_MAXIMUM_EVENT_AGE_SECONDS ||
+      value > MAX_SIM_LAMBDA_MAXIMUM_EVENT_AGE_SECONDS
+    ) {
+      throw new SimLambdaInvalidParameterValueException(
+        "MaximumEventAgeInSeconds must be a whole number between " +
+          `${MIN_SIM_LAMBDA_MAXIMUM_EVENT_AGE_SECONDS} and ` +
+          `${MAX_SIM_LAMBDA_MAXIMUM_EVENT_AGE_SECONDS}, and ${value} is not.`,
+      );
+    }
+
+    return value;
+  }
+
+  /**
+   * The destination a request named, if it named one.
+   *
+   * A member sent with nothing in it is how AWS takes a destination away, and
+   * reads here as no destination at all.
+   */
+  private destination(
+    destination: SimLambdaDestination | undefined,
+  ): string | undefined {
+    const arn = destination?.Destination;
+
+    if (arn === undefined || arn === "") {
+      return undefined;
+    }
+
+    return SimLambdaDestinationArn.of(arn).value;
+  }
+}

--- a/src/service/lambda/command/event-invoke-config/event-invoke-config-request.ts
+++ b/src/service/lambda/command/event-invoke-config/event-invoke-config-request.ts
@@ -1,0 +1,97 @@
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simLambdaQualifiedFunctionOf } from "../../function/sim-lambda-function-reference.js";
+import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
+import { EventInvokeConfigAuthorizer } from "./event-invoke-config-authorizer.js";
+
+export interface EventInvokeConfigCommandProperties {
+  readonly functions: SimLambdaFunctionLookup;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+export interface EventInvokeConfigCommandOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+interface EventInvokeConfigRequestProperties extends EventInvokeConfigCommandProperties {
+  readonly action: string;
+}
+
+/**
+ * What every event invoke config command resolved from its request.
+ */
+export interface ResolvedEventInvokeConfigRequest {
+  readonly functionName: string;
+  readonly qualifier: string | undefined;
+  readonly functionArn: string;
+}
+
+/**
+ * The opening of every event invoke config command.
+ *
+ * All five name a function the same way, authorize the same way and fail the
+ * same way when the function is missing. Only the action name differs, so the
+ * five handlers share this rather than repeating it.
+ */
+export class EventInvokeConfigRequest {
+  private readonly functions: SimLambdaFunctionLookup;
+  private readonly background: BackgroundScheduler;
+  private readonly authorizer: EventInvokeConfigAuthorizer;
+
+  constructor(properties: EventInvokeConfigRequestProperties) {
+    const {
+      functions,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+    this.functions = functions;
+    this.background = background;
+    this.authorizer = new EventInvokeConfigAuthorizer({
+      iam,
+      action: properties.action,
+    });
+  }
+
+  /**
+   * Name the function this request is about, and check the caller may reach
+   * it.
+   *
+   * The qualifier comes from the request's own `Qualifier` or from the
+   * function name it was addressed to, as it does on Invoke.
+   */
+  async resolve(
+    input: {
+      FunctionName?: string | undefined;
+      Qualifier?: string | undefined;
+    },
+    commandName: string,
+    options?: EventInvokeConfigCommandOptions,
+  ): Promise<ResolvedEventInvokeConfigRequest> {
+    assertDefined(
+      input.FunctionName,
+      `${commandName}.input.FunctionName required`,
+    );
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    const { functionName, qualifier } = simLambdaQualifiedFunctionOf(
+      input.FunctionName,
+      input.Qualifier,
+    );
+    const functionArn = this.functions.functionArn(functionName, qualifier);
+    this.authorizer.authorize(functionArn, options?.caller);
+    this.functions.require(functionName);
+
+    return { functionName, qualifier, functionArn };
+  }
+}

--- a/src/service/lambda/command/event-invoke-config/sim-lambda-event-invoke-config-commands.ts
+++ b/src/service/lambda/command/event-invoke-config/sim-lambda-event-invoke-config-commands.ts
@@ -1,0 +1,112 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimLambdaEventInvokeConfigStore } from "../../function/event-invoke/sim-lambda-event-invoke-config-store.js";
+import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
+import { DeleteFunctionEventInvokeConfigCommandHandler } from "../delete-function-event-invoke-config/delete-function-event-invoke-config.handler.js";
+import type {
+  SimDeleteFunctionEventInvokeConfigCommand,
+  SimDeleteFunctionEventInvokeConfigCommandOutput,
+} from "../delete-function-event-invoke-config/delete-function-event-invoke-config.command.js";
+import { GetFunctionEventInvokeConfigCommandHandler } from "../get-function-event-invoke-config/get-function-event-invoke-config.handler.js";
+import type {
+  SimGetFunctionEventInvokeConfigCommand,
+  SimGetFunctionEventInvokeConfigCommandOutput,
+} from "../get-function-event-invoke-config/get-function-event-invoke-config.command.js";
+import { ListFunctionEventInvokeConfigsCommandHandler } from "../list-function-event-invoke-configs/list-function-event-invoke-configs.handler.js";
+import type {
+  SimListFunctionEventInvokeConfigsCommand,
+  SimListFunctionEventInvokeConfigsCommandOutput,
+} from "../list-function-event-invoke-configs/list-function-event-invoke-configs.command.js";
+import { PutFunctionEventInvokeConfigCommandHandler } from "../put-function-event-invoke-config/put-function-event-invoke-config.handler.js";
+import type {
+  SimPutFunctionEventInvokeConfigCommand,
+  SimPutFunctionEventInvokeConfigCommandOutput,
+} from "../put-function-event-invoke-config/put-function-event-invoke-config.command.js";
+import { UpdateFunctionEventInvokeConfigCommandHandler } from "../update-function-event-invoke-config/update-function-event-invoke-config.handler.js";
+import type {
+  SimUpdateFunctionEventInvokeConfigCommand,
+  SimUpdateFunctionEventInvokeConfigCommandOutput,
+} from "../update-function-event-invoke-config/update-function-event-invoke-config.command.js";
+import type { EventInvokeConfigCommandOptions } from "./event-invoke-config-request.js";
+
+interface SimLambdaEventInvokeConfigCommandsProperties {
+  readonly eventInvokeConfigs: SimLambdaEventInvokeConfigStore;
+  readonly functions: SimLambdaFunctionLookup;
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * The event invoke config commands of one simulated Lambda scope.
+ *
+ * These five commands share the same collaborators and differ only in the
+ * handler they run, so grouping them here keeps the SimLambda facade a thin
+ * delegation rather than five near-identical wiring blocks.
+ */
+export class SimLambdaEventInvokeConfigCommands {
+  private readonly properties: SimLambdaEventInvokeConfigCommandsProperties;
+
+  constructor(properties: SimLambdaEventInvokeConfigCommandsProperties) {
+    this.properties = properties;
+  }
+
+  /**
+   * Write a function's whole event invoke config.
+   */
+  async put(
+    command: SimPutFunctionEventInvokeConfigCommand,
+    options?: EventInvokeConfigCommandOptions,
+  ): Promise<SimPutFunctionEventInvokeConfigCommandOutput> {
+    return await new PutFunctionEventInvokeConfigCommandHandler(
+      this.properties,
+    ).handle(command, options);
+  }
+
+  /**
+   * Read a function's event invoke config.
+   */
+  async get(
+    command: SimGetFunctionEventInvokeConfigCommand,
+    options?: EventInvokeConfigCommandOptions,
+  ): Promise<SimGetFunctionEventInvokeConfigCommandOutput> {
+    return await new GetFunctionEventInvokeConfigCommandHandler(
+      this.properties,
+    ).handle(command, options);
+  }
+
+  /**
+   * Change part of a function's event invoke config.
+   */
+  async update(
+    command: SimUpdateFunctionEventInvokeConfigCommand,
+    options?: EventInvokeConfigCommandOptions,
+  ): Promise<SimUpdateFunctionEventInvokeConfigCommandOutput> {
+    return await new UpdateFunctionEventInvokeConfigCommandHandler(
+      this.properties,
+    ).handle(command, options);
+  }
+
+  /**
+   * Delete a function's event invoke config.
+   */
+  async delete(
+    command: SimDeleteFunctionEventInvokeConfigCommand,
+    options?: EventInvokeConfigCommandOptions,
+  ): Promise<SimDeleteFunctionEventInvokeConfigCommandOutput> {
+    return await new DeleteFunctionEventInvokeConfigCommandHandler(
+      this.properties,
+    ).handle(command, options);
+  }
+
+  /**
+   * List every event invoke config a function holds.
+   */
+  async list(
+    command: SimListFunctionEventInvokeConfigsCommand,
+    options?: EventInvokeConfigCommandOptions,
+  ): Promise<SimListFunctionEventInvokeConfigsCommandOutput> {
+    return await new ListFunctionEventInvokeConfigsCommandHandler(
+      this.properties,
+    ).handle(command, options);
+  }
+}

--- a/src/service/lambda/command/event-invoke-config/sim-lambda-event-invoke-config.iso.test.ts
+++ b/src/service/lambda/command/event-invoke-config/sim-lambda-event-invoke-config.iso.test.ts
@@ -1,0 +1,259 @@
+import {
+  DeleteFunctionCommand,
+  DeleteFunctionEventInvokeConfigCommand,
+  GetFunctionEventInvokeConfigCommand,
+  ListFunctionEventInvokeConfigsCommand,
+  PublishVersionCommand,
+  PutFunctionEventInvokeConfigCommand,
+  UpdateFunctionEventInvokeConfigCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  simAwsWithAsyncFunction,
+  simLambdaAsyncFunctionName,
+  simLambdaQueueArn,
+} from "../../../../../test/lambda/async-destination-fixture.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+
+const failuresArn = simLambdaQueueArn("failures");
+const resultsArn = simLambdaQueueArn("results");
+
+describe("Lambda event invoke config commands", () => {
+  it("writes a config and reads it back with the defaults filled in", async () => {
+    // Given a function.
+    const { simAws } = await simAwsWithAsyncFunction();
+
+    // When a config naming only a failure destination is written.
+    await simAws.lambda().putFunctionEventInvokeConfig(
+      new PutFunctionEventInvokeConfigCommand({
+        FunctionName: simLambdaAsyncFunctionName,
+        DestinationConfig: { OnFailure: { Destination: failuresArn } },
+      }),
+    );
+
+    // Then Get reports it, with the retry settings AWS defaults to.
+    const config = await simAws.lambda().getFunctionEventInvokeConfig(
+      new GetFunctionEventInvokeConfigCommand({
+        FunctionName: simLambdaAsyncFunctionName,
+      }),
+    );
+    assertIdentical(config.MaximumRetryAttempts, 2);
+    assertIdentical(config.MaximumEventAgeInSeconds, 21_600);
+    assertIdentical(
+      config.DestinationConfig.OnFailure?.Destination,
+      failuresArn,
+    );
+  });
+
+  it("changes the settings an update names and leaves the rest", async () => {
+    // Given a config with a failure destination and one retry.
+    const { simAws } = await simAwsWithAsyncFunction();
+    await simAws.lambda().putFunctionEventInvokeConfig(
+      new PutFunctionEventInvokeConfigCommand({
+        FunctionName: simLambdaAsyncFunctionName,
+        MaximumRetryAttempts: 1,
+        DestinationConfig: { OnFailure: { Destination: failuresArn } },
+      }),
+    );
+
+    // When only the success destination is updated.
+    const updated = await simAws.lambda().updateFunctionEventInvokeConfig(
+      new UpdateFunctionEventInvokeConfigCommand({
+        FunctionName: simLambdaAsyncFunctionName,
+        DestinationConfig: { OnSuccess: { Destination: resultsArn } },
+      }),
+    );
+
+    // Then the retry count and the failure destination stand.
+    assertIdentical(updated.MaximumRetryAttempts, 1);
+    assertIdentical(
+      updated.DestinationConfig.OnFailure?.Destination,
+      failuresArn,
+    );
+    assertIdentical(
+      updated.DestinationConfig.OnSuccess?.Destination,
+      resultsArn,
+    );
+  });
+
+  it("returns a setting a put leaves out to its default", async () => {
+    // Given a config with one retry.
+    const { simAws } = await simAwsWithAsyncFunction();
+    await simAws.lambda().putFunctionEventInvokeConfig(
+      new PutFunctionEventInvokeConfigCommand({
+        FunctionName: simLambdaAsyncFunctionName,
+        MaximumRetryAttempts: 1,
+        DestinationConfig: { OnFailure: { Destination: failuresArn } },
+      }),
+    );
+
+    // When the config is written again without it.
+    const written = await simAws.lambda().putFunctionEventInvokeConfig(
+      new PutFunctionEventInvokeConfigCommand({
+        FunctionName: simLambdaAsyncFunctionName,
+      }),
+    );
+
+    // Then the whole config was replaced rather than merged into.
+    assertIdentical(written.MaximumRetryAttempts, 2);
+    assertUndefined(written.DestinationConfig.OnFailure);
+  });
+
+  it("deletes a config, leaving nothing to read", async () => {
+    // Given a function with a config.
+    const { simAws } = await simAwsWithAsyncFunction();
+    await simAws.lambda().putFunctionEventInvokeConfig(
+      new PutFunctionEventInvokeConfigCommand({
+        FunctionName: simLambdaAsyncFunctionName,
+        MaximumRetryAttempts: 0,
+      }),
+    );
+
+    // When it is deleted.
+    await simAws.lambda().deleteFunctionEventInvokeConfig(
+      new DeleteFunctionEventInvokeConfigCommand({
+        FunctionName: simLambdaAsyncFunctionName,
+      }),
+    );
+
+    // Then reading it fails as AWS fails.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.lambda().getFunctionEventInvokeConfig(
+        new GetFunctionEventInvokeConfigCommand({
+          FunctionName: simLambdaAsyncFunctionName,
+        }),
+      );
+    });
+    assertStringIncludes(error.message, "doesn't have an EventInvokeConfig");
+  });
+
+  it("lists the config of each qualifier a function holds", async () => {
+    // Given a function with a config of its own and one on a version.
+    const { simAws } = await simAwsWithAsyncFunction();
+    await simAws.lambda().publishVersion(
+      new PublishVersionCommand({
+        FunctionName: simLambdaAsyncFunctionName,
+      }),
+    );
+    await simAws.lambda().putFunctionEventInvokeConfig(
+      new PutFunctionEventInvokeConfigCommand({
+        FunctionName: simLambdaAsyncFunctionName,
+        MaximumRetryAttempts: 0,
+      }),
+    );
+    await simAws.lambda().putFunctionEventInvokeConfig(
+      new PutFunctionEventInvokeConfigCommand({
+        FunctionName: simLambdaAsyncFunctionName,
+        Qualifier: "1",
+        MaximumRetryAttempts: 1,
+      }),
+    );
+
+    // When the function's configs are listed.
+    const listed = await simAws.lambda().listFunctionEventInvokeConfigs(
+      new ListFunctionEventInvokeConfigsCommand({
+        FunctionName: simLambdaAsyncFunctionName,
+      }),
+    );
+
+    // Then both are there.
+    assertArrayLength(listed.FunctionEventInvokeConfigs, 2);
+  });
+
+  it("forgets a function's configs when the function goes", async () => {
+    // Given a function with a config.
+    const { simAws } = await simAwsWithAsyncFunction();
+    await simAws.lambda().putFunctionEventInvokeConfig(
+      new PutFunctionEventInvokeConfigCommand({
+        FunctionName: simLambdaAsyncFunctionName,
+        MaximumRetryAttempts: 0,
+      }),
+    );
+
+    // When the function is deleted and made again.
+    await simAws.lambda().deleteFunction(
+      new DeleteFunctionCommand({
+        FunctionName: simLambdaAsyncFunctionName,
+      }),
+    );
+    const { simAws: remade } = await simAwsWithAsyncFunction();
+
+    // Then the new function starts without one.
+    const error = await assertThrowsErrorAsync(async () => {
+      await remade.lambda().getFunctionEventInvokeConfig(
+        new GetFunctionEventInvokeConfigCommand({
+          FunctionName: simLambdaAsyncFunctionName,
+        }),
+      );
+    });
+    assertStringIncludes(error.message, "doesn't have an EventInvokeConfig");
+  });
+
+  it("refuses more retries than real Lambda makes", async () => {
+    // Given a function.
+    const { simAws } = await simAwsWithAsyncFunction();
+
+    // When a config asks for three retries.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.lambda().putFunctionEventInvokeConfig(
+        new PutFunctionEventInvokeConfigCommand({
+          FunctionName: simLambdaAsyncFunctionName,
+          MaximumRetryAttempts: 3,
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertStringIncludes(
+      error.message,
+      "MaximumRetryAttempts must be a whole number between 0 and 2",
+    );
+  });
+
+  it("refuses a destination this simulation cannot send to", async () => {
+    // Given a function.
+    const { simAws } = await simAwsWithAsyncFunction();
+
+    // When a config names a destination in a service that is not one.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.lambda().putFunctionEventInvokeConfig(
+        new PutFunctionEventInvokeConfigCommand({
+          FunctionName: simLambdaAsyncFunctionName,
+          DestinationConfig: {
+            OnFailure: {
+              Destination: "arn:aws:s3:us-east-1:888888888888:failures",
+            },
+          },
+        }),
+      );
+    });
+
+    // Then it is refused while the caller is there to see it.
+    assertStringIncludes(error.message, "names s3");
+  });
+
+  it("fails for a function that does not exist", async () => {
+    // Given a simulated AWS with no functions.
+    const simAws = new SimAws();
+
+    // When a config is written for one.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .lambda()
+        .putFunctionEventInvokeConfig(
+          new PutFunctionEventInvokeConfigCommand({ FunctionName: "missing" }),
+        );
+    });
+
+    // Then it fails as AWS fails.
+    assertStringIncludes(error.message, "Function not found");
+  });
+});

--- a/src/service/lambda/command/function/sim-lambda-function-commands.ts
+++ b/src/service/lambda/command/function/sim-lambda-function-commands.ts
@@ -8,7 +8,9 @@ import type { SimLambdaCodeStore } from "../../function/code/store/sim-lambda-co
 import type { SimLambdaVmSdkModuleProvider } from "../../function/code/vm/sdk/sim-lambda-vm-sdk-module-provider.js";
 import type { SimLogsServiceWriter } from "../../../logs/write/sim-logs-service-writer.js";
 import type { SimLambdaOutboundHttp } from "../../function/outbound/sim-lambda-outbound-http.js";
+import type { SimLambdaDestinationTargets } from "../../destination/sim-lambda-destination-targets.js";
 import type { SimLambdaEnvironmentConflicts } from "../../function/environment/sim-lambda-environment-conflicts.js";
+import type { SimLambdaEventInvokeConfigStore } from "../../function/event-invoke/sim-lambda-event-invoke-config-store.js";
 import type { SimLambdaFunctionMap } from "../../function/sim-lambda-function.js";
 import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
 import type { SimLambdaFunctionUrlStore } from "../../function/url/sim-lambda-function-url-store.js";
@@ -59,6 +61,8 @@ interface SimLambdaFunctionCommandsProperties {
   readonly functionUrls: SimLambdaFunctionUrlStore;
   readonly versions: SimLambdaFunctionVersionStore;
   readonly environmentConflicts: SimLambdaEnvironmentConflicts;
+  readonly eventInvokeConfigs: SimLambdaEventInvokeConfigStore;
+  readonly destinations: SimLambdaDestinationTargets;
   readonly codeStore?: SimLambdaCodeStore | undefined;
   readonly containerImages?: SimLambdaContainerImages | undefined;
   readonly vmSdkModuleProvider?: SimLambdaVmSdkModuleProvider | undefined;

--- a/src/service/lambda/command/get-function-event-invoke-config/get-function-event-invoke-config.command.ts
+++ b/src/service/lambda/command/get-function-event-invoke-config/get-function-event-invoke-config.command.ts
@@ -1,0 +1,28 @@
+/**
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/GetFunctionEventInvokeConfigCommand/
+ */
+
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimLambdaEventInvokeConfiguration } from "../../function/event-invoke/sim-lambda-event-invoke-config.js";
+
+/**
+ * Minimal structural sim Lambda GetFunctionEventInvokeConfig command.
+ */
+export interface SimGetFunctionEventInvokeConfigCommand {
+  readonly input: SimGetFunctionEventInvokeConfigCommandInput;
+}
+
+/**
+ * Minimal structural sim Lambda GetFunctionEventInvokeConfig input.
+ */
+export interface SimGetFunctionEventInvokeConfigCommandInput {
+  readonly FunctionName?: string | undefined;
+  readonly Qualifier?: string | undefined;
+}
+
+/**
+ * Minimal structural sim Lambda GetFunctionEventInvokeConfig output.
+ */
+export interface SimGetFunctionEventInvokeConfigCommandOutput extends SimLambdaEventInvokeConfiguration {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/lambda/command/get-function-event-invoke-config/get-function-event-invoke-config.handler.ts
+++ b/src/service/lambda/command/get-function-event-invoke-config/get-function-event-invoke-config.handler.ts
@@ -1,0 +1,59 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import type { SimLambdaEventInvokeConfigStore } from "../../function/event-invoke/sim-lambda-event-invoke-config-store.js";
+import { simLambdaEventInvokeConfiguration } from "../../function/event-invoke/sim-lambda-event-invoke-settings.js";
+import {
+  type EventInvokeConfigCommandOptions,
+  type EventInvokeConfigCommandProperties,
+  EventInvokeConfigRequest,
+} from "../event-invoke-config/event-invoke-config-request.js";
+import type {
+  SimGetFunctionEventInvokeConfigCommand,
+  SimGetFunctionEventInvokeConfigCommandOutput,
+} from "./get-function-event-invoke-config.command.js";
+
+interface GetFunctionEventInvokeConfigCommandHandlerProperties extends EventInvokeConfigCommandProperties {
+  readonly eventInvokeConfigs: SimLambdaEventInvokeConfigStore;
+}
+
+/**
+ * Simulated Lambda GetFunctionEventInvokeConfigCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/GetFunctionEventInvokeConfigCommand/
+ */
+export class GetFunctionEventInvokeConfigCommandHandler implements CommandHandler<
+  SimGetFunctionEventInvokeConfigCommand,
+  SimGetFunctionEventInvokeConfigCommandOutput
+> {
+  private readonly eventInvokeConfigs: SimLambdaEventInvokeConfigStore;
+  private readonly request: EventInvokeConfigRequest;
+
+  constructor(
+    properties: GetFunctionEventInvokeConfigCommandHandlerProperties,
+  ) {
+    this.eventInvokeConfigs = properties.eventInvokeConfigs;
+    this.request = new EventInvokeConfigRequest({
+      ...properties,
+      action: "lambda:GetFunctionEventInvokeConfig",
+    });
+  }
+
+  /**
+   * Read a function's event invoke config.
+   */
+  async handle(
+    command: SimGetFunctionEventInvokeConfigCommand,
+    options?: EventInvokeConfigCommandOptions,
+  ): Promise<SimGetFunctionEventInvokeConfigCommandOutput> {
+    const resolved = await this.request.resolve(
+      command.input,
+      "GetFunctionEventInvokeConfigCommand",
+      options,
+    );
+    const config = this.eventInvokeConfigs.require(
+      resolved,
+      resolved.functionArn,
+    );
+
+    return { $metadata: {}, ...simLambdaEventInvokeConfiguration(config) };
+  }
+}

--- a/src/service/lambda/command/invoke/async/sim-lambda-async-destinations.iso.test.ts
+++ b/src/service/lambda/command/invoke/async/sim-lambda-async-destinations.iso.test.ts
@@ -1,0 +1,226 @@
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import { PutRuleCommand, PutTargetsCommand } from "@aws-sdk/client-eventbridge";
+import { CreateTopicCommand } from "@aws-sdk/client-sns";
+import { SetQueueAttributesCommand } from "@aws-sdk/client-sqs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertObjectEquals,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  invokeAsyncAndSettle,
+  makeQueue,
+  putEventInvokeConfig,
+  receivedBodies,
+  receivedRecord,
+  simAwsWithAsyncFunction,
+  simLambdaAsyncFunctionArn,
+  simLambdaAsyncFunctionName,
+  simLambdaQueueArn,
+} from "../../../../../../test/lambda/async-destination-fixture.js";
+import {
+  simSnsDeliveredMessage,
+  simSnsSubscribedQueue,
+} from "../../../../../../test/sns/subscription-fixture.js";
+import type { SimAws } from "../../../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../../index.js";
+import type { SimLambdaDestinationRecord } from "../../../destination/sim-lambda-destination-record.js";
+
+/**
+ * A rule on the default bus sending the invocation results Lambda puts there
+ * on to a queue, with the queue policy EventBridge delivery needs.
+ */
+async function ruleToQueue(
+  simAws: SimAws,
+  queueUrl: string,
+  queueName: string,
+): Promise<void> {
+  const policy = JSON.stringify({
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: { Service: "events.amazonaws.com" },
+        Action: "sqs:SendMessage",
+        Resource: simLambdaQueueArn(queueName),
+      },
+    ],
+  });
+  await simAws.sqs().setQueueAttributes(
+    new SetQueueAttributesCommand({
+      QueueUrl: queueUrl,
+      Attributes: { Policy: policy },
+    }),
+  );
+  await simAws.eventBridge().putRule(
+    new PutRuleCommand({
+      Name: "invocation-results",
+      EventPattern: JSON.stringify({ source: ["lambda"] }),
+    }),
+  );
+  await simAws.eventBridge().putTargets(
+    new PutTargetsCommand({
+      Rule: "invocation-results",
+      Targets: [{ Id: "results", Arn: simLambdaQueueArn(queueName) }],
+    }),
+  );
+}
+
+describe("Lambda asynchronous invocation destinations", () => {
+  it("sends a record to an OnFailure queue once the retries are exhausted", async () => {
+    // Given a failing function sending its failures to a queue.
+    const { simAws } = await simAwsWithAsyncFunction();
+    const queueUrl = await makeQueue(simAws, "failures");
+    await putEventInvokeConfig(simAws, {
+      MaximumRetryAttempts: 1,
+      OnFailure: simLambdaQueueArn("failures"),
+    });
+
+    // When it is invoked asynchronously and every retry falls due.
+    await invokeAsyncAndSettle(simAws);
+
+    // Then the queue holds the record real Lambda would have sent.
+    const record = await receivedRecord(simAws, queueUrl);
+    assertIdentical(record.version, "1.0");
+    assertIdentical(record.requestContext.condition, "RetriesExhausted");
+    assertIdentical(record.requestContext.approximateInvokeCount, 2);
+    assertIdentical(
+      record.requestContext.functionArn,
+      simLambdaAsyncFunctionArn,
+    );
+    assertObjectEquals(record.requestPayload as object, { id: 7 });
+    assertIdentical(record.responseContext?.functionError, "Unhandled");
+  });
+
+  it("sends a record to an OnSuccess topic when the handler returns", async () => {
+    // Given a function that works, publishing its successes to a topic.
+    const { simAws } = await simAwsWithAsyncFunction({
+      failuresBeforeSuccess: 0,
+    });
+    const created = await simAws
+      .sns()
+      .createTopic(new CreateTopicCommand({ Name: "results" }));
+    assertNonNullable(created.TopicArn, "CreateTopic answered with an ARN");
+    const { queueUrl } = await simSnsSubscribedQueue(
+      simAws,
+      "results-queue",
+      created.TopicArn,
+    );
+    await putEventInvokeConfig(simAws, { OnSuccess: created.TopicArn });
+
+    // When it is invoked asynchronously.
+    await invokeAsyncAndSettle(simAws);
+
+    // Then the record reached the topic's subscriber.
+    const body = await simSnsDeliveredMessage(simAws, queueUrl);
+    assertNonNullable(body, "the topic delivered a message");
+    const envelope = JSON.parse(body) as { readonly Message: string };
+    const record = JSON.parse(envelope.Message) as SimLambdaDestinationRecord;
+    assertIdentical(record.requestContext.condition, "Success");
+    assertObjectEquals(record.responsePayload as object, { handled: 7 });
+  });
+
+  it("invokes a function destination with the record", async () => {
+    // Given a failing function sending its failures to another function.
+    const { simAws } = await simAwsWithAsyncFunction();
+    const handled: unknown[] = [];
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "repairs",
+        Role: "arn:aws:iam::888888888888:role/RepairsRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput((event: unknown) => {
+            handled.push(event);
+            return null;
+          }),
+        },
+      }),
+    );
+    await putEventInvokeConfig(simAws, {
+      MaximumRetryAttempts: 0,
+      OnFailure: "arn:aws:lambda:us-east-1:888888888888:function:repairs",
+    });
+
+    // When the failing function is invoked asynchronously.
+    await invokeAsyncAndSettle(simAws);
+
+    // Then the destination function ran with the record.
+    assertArrayLength(handled, 1);
+    const record = handled[0] as SimLambdaDestinationRecord;
+    assertIdentical(record.requestContext.condition, "RetriesExhausted");
+  });
+
+  it("puts a record on an event bus destination", async () => {
+    // Given a failing function sending its failures to the default bus, and a
+    // rule carrying what lands there on to a queue.
+    const { simAws } = await simAwsWithAsyncFunction();
+    const queueUrl = await makeQueue(simAws, "results-queue");
+    await ruleToQueue(simAws, queueUrl, "results-queue");
+    await putEventInvokeConfig(simAws, {
+      MaximumRetryAttempts: 0,
+      OnFailure: "arn:aws:events:us-east-1:888888888888:event-bus/default",
+    });
+
+    // When the function is invoked asynchronously.
+    await invokeAsyncAndSettle(simAws);
+    await simAws.backgroundTasksComplete();
+
+    // Then the event carried the record in its detail.
+    const [body] = await receivedBodies(simAws, queueUrl);
+    assertNonNullable(body, "the rule delivered an event");
+    const event = JSON.parse(body) as {
+      readonly "detail-type": string;
+      readonly detail: SimLambdaDestinationRecord;
+    };
+    assertIdentical(
+      event["detail-type"],
+      "Lambda Function Invocation Result - Failure",
+    );
+    assertIdentical(event.detail.requestContext.condition, "RetriesExhausted");
+  });
+
+  it("sends nothing anywhere for a RequestResponse invocation", async () => {
+    // Given a failing function with both destinations configured.
+    const { simAws } = await simAwsWithAsyncFunction();
+    const queueUrl = await makeQueue(simAws, "failures");
+    await putEventInvokeConfig(simAws, {
+      OnFailure: simLambdaQueueArn("failures"),
+      OnSuccess: simLambdaQueueArn("failures"),
+    });
+
+    // When it is invoked and waited on rather than left to run.
+    const output = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: simLambdaAsyncFunctionName }));
+    await simAws.clock().advanceBy({ minutes: 5 });
+
+    // Then the caller was told about the failure and the queue holds nothing,
+    // because destinations belong to asynchronous invocation alone.
+    assertIdentical(output.FunctionError, "Unhandled");
+    assertArrayLength(await receivedBodies(simAws, queueUrl), 0);
+  });
+
+  it("abandons an event that outlives its maximum age", async () => {
+    // Given a failing function that keeps an event for a minute.
+    const { simAws, attemptCount } = await simAwsWithAsyncFunction();
+    const queueUrl = await makeQueue(simAws, "failures");
+    await putEventInvokeConfig(simAws, {
+      MaximumEventAgeInSeconds: 60,
+      OnFailure: simLambdaQueueArn("failures"),
+    });
+
+    // When it is invoked asynchronously and the retries fall due.
+    await invokeAsyncAndSettle(simAws);
+
+    // Then the event was given up on at the first retry, which is where the
+    // minute ran out, and the record says why.
+    assertIdentical(attemptCount(), 1);
+    const record = await receivedRecord(simAws, queueUrl);
+    assertIdentical(record.requestContext.condition, "EventAgeExceeded");
+    assertUndefined(record.responseContext);
+  });
+});

--- a/src/service/lambda/command/invoke/async/sim-lambda-async-invocation-settings.ts
+++ b/src/service/lambda/command/invoke/async/sim-lambda-async-invocation-settings.ts
@@ -1,0 +1,45 @@
+import type { SimLambdaEventInvokeConfigStore } from "../../../function/event-invoke/sim-lambda-event-invoke-config-store.js";
+import type { SimLambdaEventInvokeSettings } from "../../../function/event-invoke/sim-lambda-event-invoke-config.js";
+import { defaultSimLambdaEventInvokeSettings } from "../../../function/event-invoke/sim-lambda-event-invoke-settings.js";
+import type { SimLambdaFunction } from "../../../function/sim-lambda-function.js";
+
+/**
+ * Everything one asynchronous invocation needs to know about how its function
+ * handles failure.
+ */
+export interface SimLambdaAsyncInvocationSettings extends SimLambdaEventInvokeSettings {
+  readonly deadLetterArn?: string | undefined;
+}
+
+interface SimLambdaAsyncInvocationSettingsProperties {
+  readonly simFunction: SimLambdaFunction;
+  readonly qualifier: string | undefined;
+  readonly configs: SimLambdaEventInvokeConfigStore | undefined;
+}
+
+/**
+ * Read what an invocation should do from the function and the event invoke
+ * config the qualifier it ran under holds.
+ *
+ * A qualified invocation uses the config of the version or alias it named, and
+ * falls back to the function's own where that qualifier has none, so a
+ * function configured once behaves the same however it is addressed. A
+ * function with no config at all is retried the default number of times and
+ * sends its results nowhere.
+ *
+ * The dead-letter target comes from the function itself, since that is where
+ * AWS keeps it.
+ */
+export function simLambdaAsyncInvocationSettings(
+  properties: SimLambdaAsyncInvocationSettingsProperties,
+): SimLambdaAsyncInvocationSettings {
+  const { simFunction, qualifier, configs } = properties;
+  const functionName = simFunction.name;
+  const config =
+    configs?.get({ functionName, qualifier }) ?? configs?.get({ functionName });
+
+  return {
+    ...(config?.settings ?? defaultSimLambdaEventInvokeSettings()),
+    deadLetterArn: simFunction.deadLetterTargetArn,
+  };
+}

--- a/src/service/lambda/command/invoke/async/sim-lambda-async-invocation.ts
+++ b/src/service/lambda/command/invoke/async/sim-lambda-async-invocation.ts
@@ -1,0 +1,102 @@
+import type { BackgroundScheduler } from "../../../../../util/background/background.js";
+import type { SimLambdaDestinationTargets } from "../../../destination/sim-lambda-destination-targets.js";
+import {
+  simLambdaEventTooOld,
+  simLambdaRetryDueTime,
+} from "../../../function/event-invoke/sim-lambda-event-invoke-settings.js";
+import type { SimLambdaFunction } from "../../../function/sim-lambda-function.js";
+import type { SimLambdaAsyncInvocationSettings } from "./sim-lambda-async-invocation-settings.js";
+import {
+  simLambdaAbandonedOutcome,
+  SimLambdaAsyncOutcomeDelivery,
+  simLambdaSuccessOutcome,
+} from "./sim-lambda-async-outcome.js";
+
+interface SimLambdaAsyncInvocationProperties {
+  readonly simFunction: SimLambdaFunction;
+  readonly event: unknown;
+  readonly settings: SimLambdaAsyncInvocationSettings;
+  readonly background: BackgroundScheduler;
+  readonly destinations: SimLambdaDestinationTargets;
+}
+
+/**
+ * One asynchronous invocation of a simulated Lambda function, from the first
+ * attempt to wherever its result ends up.
+ *
+ * A handler error is kept from the caller, as real Lambda keeps it: nobody is
+ * waiting on an Event invocation. Retries wait on the simulated clock, so a
+ * test is in charge of when they happen.
+ */
+export class SimLambdaAsyncInvocation {
+  private readonly properties: SimLambdaAsyncInvocationProperties;
+  private readonly outcomes: SimLambdaAsyncOutcomeDelivery;
+  private readonly startedAt: Date;
+  private attemptCount = 0;
+
+  constructor(properties: SimLambdaAsyncInvocationProperties) {
+    this.properties = properties;
+    this.startedAt = properties.background.now();
+    this.outcomes = new SimLambdaAsyncOutcomeDelivery(properties);
+  }
+
+  /**
+   * Accept the invocation and let it run behind the caller.
+   */
+  start(): void {
+    this.properties.background.schedule(async () => {
+      await this.attempt();
+    });
+  }
+
+  private async attempt(): Promise<void> {
+    const { simFunction, event } = this.properties;
+    this.attemptCount += 1;
+
+    try {
+      await this.outcomes.deliver(
+        simLambdaSuccessOutcome(await simFunction.invoke(event)),
+        this.attemptCount,
+      );
+    } catch (error) {
+      await this.failed(error);
+    }
+  }
+
+  /**
+   * Retry the attempt that threw, or give up where the last one has been
+   * made.
+   */
+  private async failed(error: unknown): Promise<void> {
+    const { background, settings } = this.properties;
+
+    if (this.attemptCount > settings.maximumRetryAttempts) {
+      await this.abandon(error, "RetriesExhausted");
+      return;
+    }
+
+    background.scheduleAt(
+      simLambdaRetryDueTime(background.now(), this.attemptCount),
+      async () => {
+        await (simLambdaEventTooOld(this.startedAt, background.now(), settings)
+          ? this.abandon(error, "EventAgeExceeded")
+          : this.attempt());
+      },
+    );
+  }
+
+  /**
+   * Give up on the invocation, telling its failure destination why and
+   * dead-lettering the event.
+   */
+  private async abandon(
+    error: unknown,
+    condition: "RetriesExhausted" | "EventAgeExceeded",
+  ): Promise<void> {
+    await this.outcomes.deliver(
+      simLambdaAbandonedOutcome(error, condition),
+      this.attemptCount,
+    );
+    await this.outcomes.deadLetter();
+  }
+}

--- a/src/service/lambda/command/invoke/async/sim-lambda-async-invocations.ts
+++ b/src/service/lambda/command/invoke/async/sim-lambda-async-invocations.ts
@@ -1,0 +1,50 @@
+import type { BackgroundScheduler } from "../../../../../util/background/background.js";
+import type { SimLambdaDestinationTargets } from "../../../destination/sim-lambda-destination-targets.js";
+import type { SimLambdaEventInvokeConfigStore } from "../../../function/event-invoke/sim-lambda-event-invoke-config-store.js";
+import type { SimLambdaFunction } from "../../../function/sim-lambda-function.js";
+import { SimLambdaAsyncInvocation } from "./sim-lambda-async-invocation.js";
+import { simLambdaAsyncInvocationSettings } from "./sim-lambda-async-invocation-settings.js";
+
+interface SimLambdaAsyncInvocationsProperties {
+  readonly background: BackgroundScheduler;
+  readonly destinations: SimLambdaDestinationTargets;
+  readonly eventInvokeConfigs: SimLambdaEventInvokeConfigStore | undefined;
+}
+
+/**
+ * Where an accepted Event invocation goes to be run.
+ *
+ * The retry and destination settings are read at the moment the invocation
+ * starts, so a config written afterwards leaves an invocation already running
+ * under the one it began with.
+ */
+export class SimLambdaAsyncInvocations {
+  private readonly properties: SimLambdaAsyncInvocationsProperties;
+
+  constructor(properties: SimLambdaAsyncInvocationsProperties) {
+    this.properties = properties;
+  }
+
+  /**
+   * Start one asynchronous invocation behind the caller who asked for it.
+   */
+  start(
+    simFunction: SimLambdaFunction,
+    event: unknown,
+    qualifier: string | undefined,
+  ): void {
+    const { background, destinations, eventInvokeConfigs } = this.properties;
+
+    new SimLambdaAsyncInvocation({
+      simFunction,
+      event,
+      settings: simLambdaAsyncInvocationSettings({
+        simFunction,
+        qualifier,
+        configs: eventInvokeConfigs,
+      }),
+      background,
+      destinations,
+    }).start();
+  }
+}

--- a/src/service/lambda/command/invoke/async/sim-lambda-async-outcome.ts
+++ b/src/service/lambda/command/invoke/async/sim-lambda-async-outcome.ts
@@ -1,0 +1,136 @@
+import { randomUUID } from "node:crypto";
+import type { SimClock } from "../../../../../util/clock/sim-clock.js";
+import { SimLambdaDestinationArn } from "../../../destination/sim-lambda-destination-arn.js";
+import { functionErrorDocument } from "../invoke-payload.js";
+import { makeSimLambdaDestinationRecord } from "../../../destination/sim-lambda-destination-record.js";
+import type { SimLambdaDestinationTargets } from "../../../destination/sim-lambda-destination-targets.js";
+import type { SimLambdaInvocationCondition } from "../../../function/event-invoke/sim-lambda-event-invoke-config.js";
+import type { SimLambdaFunction } from "../../../function/sim-lambda-function.js";
+import type { SimLambdaAsyncInvocationSettings } from "./sim-lambda-async-invocation-settings.js";
+
+/**
+ * How one asynchronous invocation ended.
+ */
+export interface SimLambdaAsyncOutcome {
+  readonly condition: SimLambdaInvocationCondition;
+  readonly responsePayload: unknown;
+  readonly functionError?: string | undefined;
+
+  /**
+   * Whether an attempt ran to produce this. An event abandoned for age never
+   * reached one, so it carries no response context.
+   */
+  readonly ran: boolean;
+}
+
+/**
+ * The outcome of an invocation whose handler returned.
+ */
+export function simLambdaSuccessOutcome(
+  result: unknown,
+): SimLambdaAsyncOutcome {
+  return {
+    condition: "Success",
+    responsePayload: result ?? null,
+    ran: true,
+  };
+}
+
+/**
+ * The outcome of an invocation nobody is waiting on any more.
+ *
+ * An event given up on for age never reached a final attempt, so it reports no
+ * error and carries no response context.
+ */
+export function simLambdaAbandonedOutcome(
+  error: unknown,
+  condition: "RetriesExhausted" | "EventAgeExceeded",
+): SimLambdaAsyncOutcome {
+  const ran = condition === "RetriesExhausted";
+
+  return {
+    condition,
+    responsePayload: ran ? functionErrorDocument(error) : null,
+    functionError: ran ? "Unhandled" : undefined,
+    ran,
+  };
+}
+
+interface SimLambdaAsyncOutcomeDeliveryProperties {
+  readonly simFunction: SimLambdaFunction;
+  readonly settings: SimLambdaAsyncInvocationSettings;
+  readonly destinations: SimLambdaDestinationTargets;
+  readonly background: SimClock;
+  readonly event: unknown;
+}
+
+/**
+ * Where one asynchronous invocation's outcome is sent.
+ *
+ * A destination that cannot be delivered to is left to reach whoever advanced
+ * the clock, since a record that silently goes nowhere is the harder failure
+ * to find.
+ */
+export class SimLambdaAsyncOutcomeDelivery {
+  /**
+   * The id every record of this invocation carries, which is the one AWS gives
+   * the request rather than one per attempt.
+   */
+  private readonly requestId = randomUUID();
+
+  private readonly properties: SimLambdaAsyncOutcomeDeliveryProperties;
+
+  constructor(properties: SimLambdaAsyncOutcomeDeliveryProperties) {
+    this.properties = properties;
+  }
+
+  /**
+   * Send the outcome to the destination it belongs to, if there is one.
+   */
+  async deliver(
+    outcome: SimLambdaAsyncOutcome,
+    attemptCount: number,
+  ): Promise<void> {
+    const { simFunction, settings, destinations, event } = this.properties;
+    const destination =
+      outcome.condition === "Success"
+        ? settings.onSuccessArn
+        : settings.onFailureArn;
+
+    if (destination === undefined) {
+      return;
+    }
+
+    await destinations.deliver({
+      destinationArn: SimLambdaDestinationArn.of(destination),
+      sourceFunctionArn: simFunction.arn,
+      record: makeSimLambdaDestinationRecord({
+        requestId: this.requestId,
+        functionArn: simFunction.arn,
+        executedVersion: simFunction.version,
+        approximateInvokeCount: attemptCount,
+        requestPayload: event,
+        timestamp: this.properties.background.now(),
+        ...outcome,
+      }),
+    });
+  }
+
+  /**
+   * Send the invoked event to the function's dead-letter target, if it has
+   * one.
+   */
+  async deadLetter(): Promise<void> {
+    const { simFunction, settings, destinations, event } = this.properties;
+
+    if (settings.deadLetterArn === undefined) {
+      return;
+    }
+
+    await destinations.deadLetter({
+      targetArn: SimLambdaDestinationArn.of(settings.deadLetterArn),
+      payload: event,
+      sourceFunctionArn: simFunction.arn,
+    });
+  }
+}

--- a/src/service/lambda/command/invoke/async/sim-lambda-async-retries.iso.test.ts
+++ b/src/service/lambda/command/invoke/async/sim-lambda-async-retries.iso.test.ts
@@ -1,0 +1,70 @@
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  invokeAsyncAndSettle,
+  putEventInvokeConfig,
+  simAwsWithAsyncFunction,
+  simLambdaAsyncFunctionName,
+} from "../../../../../../test/lambda/async-destination-fixture.js";
+
+describe("Lambda asynchronous invocation retries", () => {
+  it("retries a failing handler twice when nothing says otherwise", async () => {
+    // Given a function whose handler always throws.
+    const { simAws, attemptCount } = await simAwsWithAsyncFunction();
+
+    // When it is invoked asynchronously and every retry falls due.
+    await invokeAsyncAndSettle(simAws);
+
+    // Then the handler ran three times, which is the first attempt and the
+    // two retries real Lambda makes by default.
+    assertIdentical(attemptCount(), 3);
+  });
+
+  it("runs the handler once when the config asks for no retries", async () => {
+    // Given a failing function configured to retry nothing.
+    const { simAws, attemptCount } = await simAwsWithAsyncFunction();
+    await putEventInvokeConfig(simAws, { MaximumRetryAttempts: 0 });
+
+    // When it is invoked asynchronously.
+    await invokeAsyncAndSettle(simAws);
+
+    // Then only the first attempt happened.
+    assertIdentical(attemptCount(), 1);
+  });
+
+  it("waits on the simulated clock before a retry", async () => {
+    // Given a failing function.
+    const { simAws, attemptCount } = await simAwsWithAsyncFunction();
+
+    // When it is invoked asynchronously and the clock is left alone.
+    await simAws.lambda().invoke(
+      new InvokeCommand({
+        FunctionName: simLambdaAsyncFunctionName,
+        InvocationType: "Event",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the first attempt has happened and the retries have not.
+    assertIdentical(attemptCount(), 1);
+
+    // And the first retry arrives once time reaches it.
+    await simAws.clock().advanceBy({ minutes: 1 });
+    assertIdentical(attemptCount(), 2);
+  });
+
+  it("stops retrying once the handler returns", async () => {
+    // Given a function that fails once and then works.
+    const { simAws, attemptCount } = await simAwsWithAsyncFunction({
+      failuresBeforeSuccess: 1,
+    });
+
+    // When it is invoked asynchronously and every retry falls due.
+    await invokeAsyncAndSettle(simAws);
+
+    // Then the retry that succeeded was the last one.
+    assertIdentical(attemptCount(), 2);
+  });
+});

--- a/src/service/lambda/command/invoke/async/sim-lambda-dead-letter.iso.test.ts
+++ b/src/service/lambda/command/invoke/async/sim-lambda-dead-letter.iso.test.ts
@@ -1,0 +1,162 @@
+import {
+  CreateFunctionCommand,
+  GetFunctionCommand,
+  UpdateFunctionConfigurationCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertObjectEquals,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  invokeAsyncAndSettle,
+  makeQueue,
+  putEventInvokeConfig,
+  receivedBodies,
+  receivedRecord,
+  simAwsWithAsyncFunction,
+  simLambdaAsyncFunctionName,
+  simLambdaQueueArn,
+} from "../../../../../../test/lambda/async-destination-fixture.js";
+import { SimAws } from "../../../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../../index.js";
+
+describe("Lambda dead-letter config", () => {
+  it("sends the invoked event to a dead-letter queue when every attempt fails", async () => {
+    // Given a failing function with a dead-letter queue.
+    const { simAws } = await simAwsWithAsyncFunction({
+      deadLetterTargetArn: simLambdaQueueArn("orders-dlq"),
+    });
+    const queueUrl = await makeQueue(simAws, "orders-dlq");
+    await putEventInvokeConfig(simAws, { MaximumRetryAttempts: 0 });
+
+    // When it is invoked asynchronously and the retries fall due.
+    await invokeAsyncAndSettle(simAws);
+
+    // Then the queue holds the event as it was invoked, with none of the
+    // envelope a destination record carries.
+    const [body] = await receivedBodies(simAws, queueUrl);
+    assertNonNullable(body, "the dead-letter queue received the event");
+    assertObjectEquals(JSON.parse(body) as object, { id: 7 });
+  });
+
+  it("leaves the dead-letter queue empty when a retry succeeds", async () => {
+    // Given a function that fails once and then works.
+    const { simAws } = await simAwsWithAsyncFunction({
+      failuresBeforeSuccess: 1,
+      deadLetterTargetArn: simLambdaQueueArn("orders-dlq"),
+    });
+    const queueUrl = await makeQueue(simAws, "orders-dlq");
+
+    // When it is invoked asynchronously and the retry falls due.
+    await invokeAsyncAndSettle(simAws);
+
+    // Then nothing was dead-lettered.
+    assertArrayLength(await receivedBodies(simAws, queueUrl), 0);
+  });
+
+  it("tells both a failure destination and a dead-letter target", async () => {
+    // Given a failing function carrying both.
+    const { simAws } = await simAwsWithAsyncFunction({
+      deadLetterTargetArn: simLambdaQueueArn("orders-dlq"),
+    });
+    const deadLetterUrl = await makeQueue(simAws, "orders-dlq");
+    const failuresUrl = await makeQueue(simAws, "failures");
+    await putEventInvokeConfig(simAws, {
+      MaximumRetryAttempts: 0,
+      OnFailure: simLambdaQueueArn("failures"),
+    });
+
+    // When it is invoked asynchronously and the retries fall due.
+    await invokeAsyncAndSettle(simAws);
+
+    // Then each mechanism answered for itself.
+    const record = await receivedRecord(simAws, failuresUrl);
+    assertIdentical(record.requestContext.condition, "RetriesExhausted");
+    assertArrayLength(await receivedBodies(simAws, deadLetterUrl), 1);
+  });
+
+  it("reports and changes a function's dead-letter target", async () => {
+    // Given a function created with a dead-letter queue.
+    const { simAws } = await simAwsWithAsyncFunction({
+      deadLetterTargetArn: simLambdaQueueArn("orders-dlq"),
+    });
+
+    // Then GetFunction reports it.
+    const before = await simAws
+      .lambda()
+      .getFunction(
+        new GetFunctionCommand({ FunctionName: simLambdaAsyncFunctionName }),
+      );
+    assertIdentical(
+      before.Configuration.DeadLetterConfig?.TargetArn,
+      simLambdaQueueArn("orders-dlq"),
+    );
+
+    // When the target is moved to a topic.
+    const after = await simAws.lambda().updateFunctionConfiguration(
+      new UpdateFunctionConfigurationCommand({
+        FunctionName: simLambdaAsyncFunctionName,
+        DeadLetterConfig: {
+          TargetArn: "arn:aws:sns:us-east-1:888888888888:orders-failures",
+        },
+      }),
+    );
+
+    // Then the function dead-letters there instead.
+    assertIdentical(
+      after.DeadLetterConfig?.TargetArn,
+      "arn:aws:sns:us-east-1:888888888888:orders-failures",
+    );
+  });
+
+  it("takes a dead-letter target away when the config arrives empty", async () => {
+    // Given a function with a dead-letter queue.
+    const { simAws } = await simAwsWithAsyncFunction({
+      deadLetterTargetArn: simLambdaQueueArn("orders-dlq"),
+    });
+
+    // When the target is cleared.
+    const updated = await simAws.lambda().updateFunctionConfiguration(
+      new UpdateFunctionConfigurationCommand({
+        FunctionName: simLambdaAsyncFunctionName,
+        DeadLetterConfig: { TargetArn: "" },
+      }),
+    );
+
+    // Then the function has none.
+    assertUndefined(updated.DeadLetterConfig);
+  });
+
+  it("refuses a dead-letter target that is not a queue or a topic", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a function is created dead-lettering to a function.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.lambda().createFunction(
+        new CreateFunctionCommand({
+          FunctionName: "orders",
+          Role: "arn:aws:iam::888888888888:role/OrdersRole",
+          DeadLetterConfig: {
+            TargetArn: "arn:aws:lambda:us-east-1:888888888888:function:other",
+          },
+          Code: { ZipFile: makeLambdaZipFileInput(() => null) },
+        }),
+      );
+    });
+
+    // Then it is refused where the caller can see it.
+    assertIdentical(
+      error.message,
+      "The dead-letter target arn:aws:lambda:us-east-1:888888888888:" +
+        "function:other names lambda. A dead-letter target is an SQS queue " +
+        "or an SNS topic.",
+    );
+  });
+});

--- a/src/service/lambda/command/invoke/invoke-dispatcher.ts
+++ b/src/service/lambda/command/invoke/invoke-dispatcher.ts
@@ -2,7 +2,13 @@ import {
   type BackgroundScheduler,
   BackgroundTasks,
 } from "../../../../util/background/background.js";
+import {
+  type SimLambdaDestinationTargets,
+  SimLambdaNoDestinationTargets,
+} from "../../destination/sim-lambda-destination-targets.js";
+import type { SimLambdaEventInvokeConfigStore } from "../../function/event-invoke/sim-lambda-event-invoke-config-store.js";
 import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
+import { SimLambdaAsyncInvocations } from "./async/sim-lambda-async-invocations.js";
 import {
   functionErrorPayload,
   parseInvokeEvent,
@@ -15,6 +21,8 @@ import type {
 
 interface SimLambdaInvocationDispatcherProperties {
   background?: BackgroundScheduler;
+  eventInvokeConfigs?: SimLambdaEventInvokeConfigStore | undefined;
+  destinations?: SimLambdaDestinationTargets | undefined;
 }
 
 /**
@@ -25,19 +33,28 @@ interface SimLambdaInvocationDispatcherProperties {
  * for a published version reports that version as the one it ran.
  */
 export class SimLambdaInvocationDispatcher {
-  private readonly background: BackgroundScheduler;
+  private readonly asyncInvocations: SimLambdaAsyncInvocations;
 
   constructor(properties: SimLambdaInvocationDispatcherProperties = {}) {
-    const { background = new BackgroundTasks() } = properties;
-    this.background = background;
+    this.asyncInvocations = new SimLambdaAsyncInvocations({
+      background: properties.background ?? new BackgroundTasks(),
+      destinations:
+        properties.destinations ?? new SimLambdaNoDestinationTargets(),
+      eventInvokeConfigs: properties.eventInvokeConfigs,
+    });
   }
 
   /**
    * Dispatch the invocation and build the AWS-like Invoke output.
+   *
+   * An Event invocation is answered as soon as it is accepted, and how it goes
+   * from there reaches its destinations rather than its caller, as on real
+   * Lambda.
    */
   async dispatch(
     simFunction: SimLambdaFunction,
     command: SimInvokeCommand,
+    qualifier?: string,
   ): Promise<SimInvokeCommandOutput> {
     const invocationType = command.input.InvocationType ?? "RequestResponse";
 
@@ -46,7 +63,11 @@ export class SimLambdaInvocationDispatcher {
         return await this.requestResponse(simFunction, command);
       }
       case "Event": {
-        this.scheduleEventInvocation(simFunction, command);
+        this.asyncInvocations.start(
+          simFunction,
+          parseInvokeEvent(command.input.Payload),
+          qualifier,
+        );
         return { $metadata: {}, StatusCode: 202 };
       }
       case "DryRun": {
@@ -59,6 +80,8 @@ export class SimLambdaInvocationDispatcher {
     simFunction: SimLambdaFunction,
     command: SimInvokeCommand,
   ): Promise<SimInvokeCommandOutput> {
+    // Read before the attempt, so a payload that is not JSON reaches the
+    // caller as a request error rather than as a handler failure.
     const event = parseInvokeEvent(command.input.Payload);
 
     try {
@@ -78,21 +101,5 @@ export class SimLambdaInvocationDispatcher {
         Payload: functionErrorPayload(error),
       };
     }
-  }
-
-  private scheduleEventInvocation(
-    simFunction: SimLambdaFunction,
-    command: SimInvokeCommand,
-  ): void {
-    const event = parseInvokeEvent(command.input.Payload);
-
-    this.background.schedule(async () => {
-      try {
-        await simFunction.invoke(event);
-      } catch {
-        // As on real Lambda, asynchronous invocation errors are not surfaced
-        // to the caller. Failure destinations are not simulated yet.
-      }
-    });
   }
 }

--- a/src/service/lambda/command/invoke/invoke-payload.ts
+++ b/src/service/lambda/command/invoke/invoke-payload.ts
@@ -4,6 +4,15 @@ import {
 } from "../../error/sim-lambda.error.js";
 import type { SimInvokePayload } from "./invoke.command.js";
 
+/**
+ * How a handler error is described to a caller and to a destination.
+ */
+export interface SimLambdaErrorDocument {
+  readonly errorType: string;
+  readonly errorMessage: string;
+  readonly trace: readonly string[];
+}
+
 function payloadText(payload: SimInvokePayload): string {
   if (typeof payload === "string") {
     return payload;
@@ -54,17 +63,26 @@ export function resultPayload(result: unknown): Uint8Array {
 }
 
 /**
- * Serialise a handler error into an AWS-like Invoke error response payload.
+ * Describe a handler error the way AWS reports one.
+ *
+ * Both the Invoke response payload and the record sent to a failure
+ * destination carry this, so it is built once and serialised where it is
+ * needed.
  */
-export function functionErrorPayload(error: unknown): Uint8Array {
+export function functionErrorDocument(error: unknown): SimLambdaErrorDocument {
   const handlerError =
     error instanceof Error ? error : new Error(String(error));
 
-  return Buffer.from(
-    JSON.stringify({
-      errorType: handlerError.name,
-      errorMessage: handlerError.message,
-      trace: (handlerError.stack ?? "").split("\n"),
-    }),
-  );
+  return {
+    errorType: handlerError.name,
+    errorMessage: handlerError.message,
+    trace: (handlerError.stack ?? "").split("\n"),
+  };
+}
+
+/**
+ * Serialise a handler error into an AWS-like Invoke error response payload.
+ */
+export function functionErrorPayload(error: unknown): Uint8Array {
+  return Buffer.from(JSON.stringify(functionErrorDocument(error)));
 }

--- a/src/service/lambda/command/invoke/invoke.handler.ts
+++ b/src/service/lambda/command/invoke/invoke.handler.ts
@@ -10,7 +10,9 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimLambdaDestinationTargets } from "../../destination/sim-lambda-destination-targets.js";
 import { SimLambdaResourceNotFoundException } from "../../error/sim-lambda.error.js";
+import type { SimLambdaEventInvokeConfigStore } from "../../function/event-invoke/sim-lambda-event-invoke-config-store.js";
 import { simLambdaQualifiedFunctionOf } from "../../function/sim-lambda-function-reference.js";
 import type { SimLambdaFunctionVersionStore } from "../../function/version/sim-lambda-function-version-store.js";
 import type {
@@ -31,6 +33,8 @@ interface InvokeCommandHandlerProperties {
   versions: SimLambdaFunctionVersionStore;
   iam?: SimIamInterServiceAuthZ;
   background?: BackgroundScheduler;
+  eventInvokeConfigs?: SimLambdaEventInvokeConfigStore | undefined;
+  destinations?: SimLambdaDestinationTargets | undefined;
 }
 
 interface InvokeCommandHandlerOptions {
@@ -66,7 +70,11 @@ export class InvokeCommandHandler implements CommandHandler<
     this.versions = versions;
     this.authorizer = new InvokeAuthorizer({ iam });
     this.background = background;
-    this.dispatcher = new SimLambdaInvocationDispatcher({ background });
+    this.dispatcher = new SimLambdaInvocationDispatcher({
+      background,
+      eventInvokeConfigs: properties.eventInvokeConfigs,
+      destinations: properties.destinations,
+    });
   }
 
   /**
@@ -121,6 +129,7 @@ export class InvokeCommandHandler implements CommandHandler<
     return await this.dispatcher.dispatch(
       this.versions.require(simFunction, qualifier),
       command,
+      qualifier,
     );
   }
 }

--- a/src/service/lambda/command/list-function-event-invoke-configs/list-function-event-invoke-configs.command.ts
+++ b/src/service/lambda/command/list-function-event-invoke-configs/list-function-event-invoke-configs.command.ts
@@ -1,0 +1,31 @@
+/**
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/ListFunctionEventInvokeConfigsCommand/
+ */
+
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimLambdaEventInvokeConfiguration } from "../../function/event-invoke/sim-lambda-event-invoke-config.js";
+
+/**
+ * Minimal structural sim Lambda ListFunctionEventInvokeConfigs command.
+ */
+export interface SimListFunctionEventInvokeConfigsCommand {
+  readonly input: SimListFunctionEventInvokeConfigsCommandInput;
+}
+
+/**
+ * Minimal structural sim Lambda ListFunctionEventInvokeConfigs input.
+ */
+export interface SimListFunctionEventInvokeConfigsCommandInput {
+  readonly FunctionName?: string | undefined;
+  readonly Marker?: string | undefined;
+  readonly MaxItems?: number | undefined;
+}
+
+/**
+ * Minimal structural sim Lambda ListFunctionEventInvokeConfigs output.
+ */
+export interface SimListFunctionEventInvokeConfigsCommandOutput {
+  readonly FunctionEventInvokeConfigs: readonly SimLambdaEventInvokeConfiguration[];
+  readonly NextMarker?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/lambda/command/list-function-event-invoke-configs/list-function-event-invoke-configs.handler.ts
+++ b/src/service/lambda/command/list-function-event-invoke-configs/list-function-event-invoke-configs.handler.ts
@@ -1,0 +1,60 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import type { SimLambdaEventInvokeConfigStore } from "../../function/event-invoke/sim-lambda-event-invoke-config-store.js";
+import { simLambdaEventInvokeConfiguration } from "../../function/event-invoke/sim-lambda-event-invoke-settings.js";
+import {
+  type EventInvokeConfigCommandOptions,
+  type EventInvokeConfigCommandProperties,
+  EventInvokeConfigRequest,
+} from "../event-invoke-config/event-invoke-config-request.js";
+import type {
+  SimListFunctionEventInvokeConfigsCommand,
+  SimListFunctionEventInvokeConfigsCommandOutput,
+} from "./list-function-event-invoke-configs.command.js";
+
+interface ListFunctionEventInvokeConfigsCommandHandlerProperties extends EventInvokeConfigCommandProperties {
+  readonly eventInvokeConfigs: SimLambdaEventInvokeConfigStore;
+}
+
+/**
+ * Simulated Lambda ListFunctionEventInvokeConfigsCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/ListFunctionEventInvokeConfigsCommand/
+ */
+export class ListFunctionEventInvokeConfigsCommandHandler implements CommandHandler<
+  SimListFunctionEventInvokeConfigsCommand,
+  SimListFunctionEventInvokeConfigsCommandOutput
+> {
+  private readonly eventInvokeConfigs: SimLambdaEventInvokeConfigStore;
+  private readonly request: EventInvokeConfigRequest;
+
+  constructor(
+    properties: ListFunctionEventInvokeConfigsCommandHandlerProperties,
+  ) {
+    this.eventInvokeConfigs = properties.eventInvokeConfigs;
+    this.request = new EventInvokeConfigRequest({
+      ...properties,
+      action: "lambda:ListFunctionEventInvokeConfigs",
+    });
+  }
+
+  /**
+   * List every event invoke config a function holds, across its qualifiers.
+   */
+  async handle(
+    command: SimListFunctionEventInvokeConfigsCommand,
+    options?: EventInvokeConfigCommandOptions,
+  ): Promise<SimListFunctionEventInvokeConfigsCommandOutput> {
+    const resolved = await this.request.resolve(
+      command.input,
+      "ListFunctionEventInvokeConfigsCommand",
+      options,
+    );
+
+    return {
+      $metadata: {},
+      FunctionEventInvokeConfigs: this.eventInvokeConfigs
+        .allForFunction(resolved.functionName)
+        .map(simLambdaEventInvokeConfiguration),
+    };
+  }
+}

--- a/src/service/lambda/command/put-function-event-invoke-config/put-function-event-invoke-config.command.ts
+++ b/src/service/lambda/command/put-function-event-invoke-config/put-function-event-invoke-config.command.ts
@@ -1,0 +1,37 @@
+/**
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/PutFunctionEventInvokeConfigCommand/
+ */
+
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type {
+  SimLambdaDestinationConfiguration,
+  SimLambdaEventInvokeConfiguration,
+} from "../../function/event-invoke/sim-lambda-event-invoke-config.js";
+
+/**
+ * Minimal structural sim Lambda PutFunctionEventInvokeConfig command.
+ */
+export interface SimPutFunctionEventInvokeConfigCommand {
+  readonly input: SimPutFunctionEventInvokeConfigCommandInput;
+}
+
+/**
+ * Minimal structural sim Lambda PutFunctionEventInvokeConfig input.
+ *
+ * A setting left out goes back to its default, since this command writes the
+ * whole config.
+ */
+export interface SimPutFunctionEventInvokeConfigCommandInput {
+  readonly FunctionName?: string | undefined;
+  readonly Qualifier?: string | undefined;
+  readonly MaximumRetryAttempts?: number | undefined;
+  readonly MaximumEventAgeInSeconds?: number | undefined;
+  readonly DestinationConfig?: SimLambdaDestinationConfiguration | undefined;
+}
+
+/**
+ * Minimal structural sim Lambda PutFunctionEventInvokeConfig output.
+ */
+export interface SimPutFunctionEventInvokeConfigCommandOutput extends SimLambdaEventInvokeConfiguration {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/lambda/command/put-function-event-invoke-config/put-function-event-invoke-config.handler.ts
+++ b/src/service/lambda/command/put-function-event-invoke-config/put-function-event-invoke-config.handler.ts
@@ -1,0 +1,62 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import type { SimLambdaEventInvokeConfigStore } from "../../function/event-invoke/sim-lambda-event-invoke-config-store.js";
+import { simLambdaEventInvokeConfiguration } from "../../function/event-invoke/sim-lambda-event-invoke-settings.js";
+import {
+  type EventInvokeConfigCommandOptions,
+  type EventInvokeConfigCommandProperties,
+  EventInvokeConfigRequest,
+} from "../event-invoke-config/event-invoke-config-request.js";
+import { EventInvokeConfigInputParser } from "../event-invoke-config/event-invoke-config-input.js";
+import type {
+  SimPutFunctionEventInvokeConfigCommand,
+  SimPutFunctionEventInvokeConfigCommandOutput,
+} from "./put-function-event-invoke-config.command.js";
+
+interface PutFunctionEventInvokeConfigCommandHandlerProperties extends EventInvokeConfigCommandProperties {
+  readonly eventInvokeConfigs: SimLambdaEventInvokeConfigStore;
+}
+
+/**
+ * Simulated Lambda PutFunctionEventInvokeConfigCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/PutFunctionEventInvokeConfigCommand/
+ */
+export class PutFunctionEventInvokeConfigCommandHandler implements CommandHandler<
+  SimPutFunctionEventInvokeConfigCommand,
+  SimPutFunctionEventInvokeConfigCommandOutput
+> {
+  private readonly eventInvokeConfigs: SimLambdaEventInvokeConfigStore;
+  private readonly request: EventInvokeConfigRequest;
+
+  private readonly inputParser = new EventInvokeConfigInputParser();
+
+  constructor(
+    properties: PutFunctionEventInvokeConfigCommandHandlerProperties,
+  ) {
+    this.eventInvokeConfigs = properties.eventInvokeConfigs;
+    this.request = new EventInvokeConfigRequest({
+      ...properties,
+      action: "lambda:PutFunctionEventInvokeConfig",
+    });
+  }
+
+  /**
+   * Write a function's whole event invoke config, replacing any it had.
+   */
+  async handle(
+    command: SimPutFunctionEventInvokeConfigCommand,
+    options?: EventInvokeConfigCommandOptions,
+  ): Promise<SimPutFunctionEventInvokeConfigCommandOutput> {
+    const resolved = await this.request.resolve(
+      command.input,
+      "PutFunctionEventInvokeConfigCommand",
+      options,
+    );
+    const config = this.eventInvokeConfigs.put({
+      ...resolved,
+      update: this.inputParser.parse(command.input),
+    });
+
+    return { $metadata: {}, ...simLambdaEventInvokeConfiguration(config) };
+  }
+}

--- a/src/service/lambda/command/sim-lambda-command.types.ts
+++ b/src/service/lambda/command/sim-lambda-command.types.ts
@@ -109,3 +109,23 @@ export type {
   SimUpdateFunctionUrlConfigCommand,
   SimUpdateFunctionUrlConfigCommandOutput,
 } from "./update-function-url-config/update-function-url-config.command.js";
+export type {
+  SimPutFunctionEventInvokeConfigCommand,
+  SimPutFunctionEventInvokeConfigCommandOutput,
+} from "./put-function-event-invoke-config/put-function-event-invoke-config.command.js";
+export type {
+  SimGetFunctionEventInvokeConfigCommand,
+  SimGetFunctionEventInvokeConfigCommandOutput,
+} from "./get-function-event-invoke-config/get-function-event-invoke-config.command.js";
+export type {
+  SimUpdateFunctionEventInvokeConfigCommand,
+  SimUpdateFunctionEventInvokeConfigCommandOutput,
+} from "./update-function-event-invoke-config/update-function-event-invoke-config.command.js";
+export type {
+  SimDeleteFunctionEventInvokeConfigCommand,
+  SimDeleteFunctionEventInvokeConfigCommandOutput,
+} from "./delete-function-event-invoke-config/delete-function-event-invoke-config.command.js";
+export type {
+  SimListFunctionEventInvokeConfigsCommand,
+  SimListFunctionEventInvokeConfigsCommandOutput,
+} from "./list-function-event-invoke-configs/list-function-event-invoke-configs.command.js";

--- a/src/service/lambda/command/update-function-configuration/update-function-configuration-input.ts
+++ b/src/service/lambda/command/update-function-configuration/update-function-configuration-input.ts
@@ -1,5 +1,6 @@
 import { assertDefined } from "../../../../util/type-guard/defined.js";
 import { requireLambdaEnvironmentVariables } from "../../function/environment/lambda-environment-variables.js";
+import { requireLambdaDeadLetterTarget } from "../../function/event-invoke/lambda-dead-letter-target.js";
 import type { SimLambdaFunctionConfigurationUpdate } from "../../function/sim-lambda-function-reconfiguration.js";
 import type { SimUpdateFunctionConfigurationCommand } from "./update-function-configuration.command.js";
 
@@ -45,6 +46,9 @@ export function requireUpdateFunctionConfigurationInput(
         input.Environment === undefined
           ? undefined
           : requireLambdaEnvironmentVariables(input.Environment),
+      deadLetterTargetArn: requireLambdaDeadLetterTarget(
+        input.DeadLetterConfig,
+      ),
     },
   };
 }

--- a/src/service/lambda/command/update-function-configuration/update-function-configuration.command.ts
+++ b/src/service/lambda/command/update-function-configuration/update-function-configuration.command.ts
@@ -3,6 +3,7 @@
  */
 
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimLambdaDeadLetterConfigInput } from "../../function/event-invoke/lambda-dead-letter-target.js";
 import type { SimLambdaFunctionConfiguration } from "../../function/sim-lambda-function-configuration.js";
 import type { SimLambdaFunctionEnvironment } from "../create-function/create-function.command.js";
 
@@ -20,10 +21,10 @@ export interface SimUpdateFunctionConfigurationCommand {
  * value the function has, and `Environment` replaces the whole variable map
  * rather than merging into it, as on real AWS.
  *
- * Real Lambda also takes `Layers`, `VpcConfig`, `DeadLetterConfig`,
- * `TracingConfig`, `KMSKeyArn`, `EphemeralStorage`, `SnapStart`,
- * `LoggingConfig` and a `RevisionId` precondition. None of those are
- * simulated, so all of them are left out rather than accepted and ignored.
+ * Real Lambda also takes `Layers`, `VpcConfig`, `TracingConfig`, `KMSKeyArn`,
+ * `EphemeralStorage`, `SnapStart`, `LoggingConfig` and a `RevisionId`
+ * precondition. None of those are simulated, so all of them are left out
+ * rather than accepted and ignored.
  */
 export interface SimUpdateFunctionConfigurationCommandInput {
   readonly FunctionName?: string | undefined;
@@ -34,6 +35,7 @@ export interface SimUpdateFunctionConfigurationCommandInput {
   readonly Timeout?: number | undefined;
   readonly MemorySize?: number | undefined;
   readonly Environment?: SimLambdaFunctionEnvironment | undefined;
+  readonly DeadLetterConfig?: SimLambdaDeadLetterConfigInput | undefined;
 }
 
 /**

--- a/src/service/lambda/command/update-function-event-invoke-config/update-function-event-invoke-config.command.ts
+++ b/src/service/lambda/command/update-function-event-invoke-config/update-function-event-invoke-config.command.ts
@@ -1,0 +1,36 @@
+/**
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/UpdateFunctionEventInvokeConfigCommand/
+ */
+
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type {
+  SimLambdaDestinationConfiguration,
+  SimLambdaEventInvokeConfiguration,
+} from "../../function/event-invoke/sim-lambda-event-invoke-config.js";
+
+/**
+ * Minimal structural sim Lambda UpdateFunctionEventInvokeConfig command.
+ */
+export interface SimUpdateFunctionEventInvokeConfigCommand {
+  readonly input: SimUpdateFunctionEventInvokeConfigCommandInput;
+}
+
+/**
+ * Minimal structural sim Lambda UpdateFunctionEventInvokeConfig input.
+ *
+ * A setting left out keeps the value the config already holds.
+ */
+export interface SimUpdateFunctionEventInvokeConfigCommandInput {
+  readonly FunctionName?: string | undefined;
+  readonly Qualifier?: string | undefined;
+  readonly MaximumRetryAttempts?: number | undefined;
+  readonly MaximumEventAgeInSeconds?: number | undefined;
+  readonly DestinationConfig?: SimLambdaDestinationConfiguration | undefined;
+}
+
+/**
+ * Minimal structural sim Lambda UpdateFunctionEventInvokeConfig output.
+ */
+export interface SimUpdateFunctionEventInvokeConfigCommandOutput extends SimLambdaEventInvokeConfiguration {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/lambda/command/update-function-event-invoke-config/update-function-event-invoke-config.handler.ts
+++ b/src/service/lambda/command/update-function-event-invoke-config/update-function-event-invoke-config.handler.ts
@@ -1,0 +1,63 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import type { SimLambdaEventInvokeConfigStore } from "../../function/event-invoke/sim-lambda-event-invoke-config-store.js";
+import { simLambdaEventInvokeConfiguration } from "../../function/event-invoke/sim-lambda-event-invoke-settings.js";
+import {
+  type EventInvokeConfigCommandOptions,
+  type EventInvokeConfigCommandProperties,
+  EventInvokeConfigRequest,
+} from "../event-invoke-config/event-invoke-config-request.js";
+import { EventInvokeConfigInputParser } from "../event-invoke-config/event-invoke-config-input.js";
+import type {
+  SimUpdateFunctionEventInvokeConfigCommand,
+  SimUpdateFunctionEventInvokeConfigCommandOutput,
+} from "./update-function-event-invoke-config.command.js";
+
+interface UpdateFunctionEventInvokeConfigCommandHandlerProperties extends EventInvokeConfigCommandProperties {
+  readonly eventInvokeConfigs: SimLambdaEventInvokeConfigStore;
+}
+
+/**
+ * Simulated Lambda UpdateFunctionEventInvokeConfigCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/UpdateFunctionEventInvokeConfigCommand/
+ */
+export class UpdateFunctionEventInvokeConfigCommandHandler implements CommandHandler<
+  SimUpdateFunctionEventInvokeConfigCommand,
+  SimUpdateFunctionEventInvokeConfigCommandOutput
+> {
+  private readonly eventInvokeConfigs: SimLambdaEventInvokeConfigStore;
+  private readonly request: EventInvokeConfigRequest;
+
+  private readonly inputParser = new EventInvokeConfigInputParser();
+
+  constructor(
+    properties: UpdateFunctionEventInvokeConfigCommandHandlerProperties,
+  ) {
+    this.eventInvokeConfigs = properties.eventInvokeConfigs;
+    this.request = new EventInvokeConfigRequest({
+      ...properties,
+      action: "lambda:UpdateFunctionEventInvokeConfig",
+    });
+  }
+
+  /**
+   * Change the settings a request named, leaving the rest of the config as it
+   * stands.
+   */
+  async handle(
+    command: SimUpdateFunctionEventInvokeConfigCommand,
+    options?: EventInvokeConfigCommandOptions,
+  ): Promise<SimUpdateFunctionEventInvokeConfigCommandOutput> {
+    const resolved = await this.request.resolve(
+      command.input,
+      "UpdateFunctionEventInvokeConfigCommand",
+      options,
+    );
+    const config = this.eventInvokeConfigs.update({
+      ...resolved,
+      update: this.inputParser.parse(command.input),
+    });
+
+    return { $metadata: {}, ...simLambdaEventInvokeConfiguration(config) };
+  }
+}

--- a/src/service/lambda/destination/deliver/sim-lambda-destination-bus.ts
+++ b/src/service/lambda/destination/deliver/sim-lambda-destination-bus.ts
@@ -1,0 +1,38 @@
+import type { SimAwsAccountRegionContainer } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimLambdaDestinationDeliveryRequest } from "../sim-lambda-destination-targets.js";
+
+/**
+ * An event bus a function is sending an asynchronous invocation result to, in
+ * the Account and Region the destination ARN names.
+ *
+ * Real Lambda puts the record in the detail of an event of its own, under the
+ * detail type that says whether the invocation succeeded.
+ */
+export class SimLambdaDestinationBus {
+  /**
+   * Put the record on the bus as one event.
+   */
+  async deliver(
+    scope: SimAwsAccountRegionContainer,
+    request: SimLambdaDestinationDeliveryRequest,
+  ): Promise<void> {
+    const outcome =
+      request.record.requestContext.condition === "Success"
+        ? "Success"
+        : "Failure";
+
+    await scope.eventBridge().putEvents({
+      input: {
+        Entries: [
+          {
+            Source: "lambda",
+            DetailType: `Lambda Function Invocation Result - ${outcome}`,
+            Detail: JSON.stringify(request.record),
+            EventBusName: request.destinationArn.eventBusName,
+            Resources: [request.sourceFunctionArn],
+          },
+        ],
+      },
+    });
+  }
+}

--- a/src/service/lambda/destination/deliver/sim-lambda-destination-function.ts
+++ b/src/service/lambda/destination/deliver/sim-lambda-destination-function.ts
@@ -1,0 +1,34 @@
+import type { SimAwsAccountRegionContainer } from "../../../aws/sim-aws-account-region-scope.js";
+import { SimLambdaError } from "../../error/sim-lambda.error.js";
+import type { SimLambdaDestinationDeliveryRequest } from "../sim-lambda-destination-targets.js";
+
+/**
+ * A function a function is sending an asynchronous invocation result to, in
+ * the Account and Region the destination ARN names.
+ */
+export class SimLambdaDestinationFunction {
+  /**
+   * Invoke the destination function with the record.
+   */
+  async deliver(
+    scope: SimAwsAccountRegionContainer,
+    request: SimLambdaDestinationDeliveryRequest,
+  ): Promise<void> {
+    const { destinationArn: arn } = request;
+    const target = scope
+      .lambda()
+      .getSimFunctionTarget(arn.functionName, arn.functionQualifier);
+
+    if (target === undefined) {
+      throw new SimLambdaError(
+        `${arn.value} is not a simulated Lambda function.`,
+      );
+    }
+
+    // Invoked directly rather than through an Invoke command, because this is
+    // already inside the background task standing for the asynchronous
+    // invocation, and because a delivery failure has to reach the caller who
+    // advanced the clock rather than being swallowed a second time.
+    await target.simFunction.invoke(request.record);
+  }
+}

--- a/src/service/lambda/destination/deliver/sim-lambda-destination-queue.ts
+++ b/src/service/lambda/destination/deliver/sim-lambda-destination-queue.ts
@@ -1,0 +1,33 @@
+import { SimLambdaError } from "../../error/sim-lambda.error.js";
+import type { SimLambdaDestinationSend } from "./sim-lambda-destination-send.js";
+
+/**
+ * A queue a function is sending an asynchronous invocation result to, in the
+ * Account and Region the destination ARN names.
+ *
+ * The message body is the record, as JSON, which is what real Lambda puts on a
+ * queue destination.
+ */
+export class SimLambdaDestinationQueue {
+  /**
+   * Put the document on the queue.
+   */
+  async deliver(send: SimLambdaDestinationSend): Promise<void> {
+    const queue = send.scope.sqs().findQueue(send.arn.resource);
+
+    if (queue === undefined) {
+      throw new SimLambdaError(
+        `${send.arn.value} is not a simulated SQS queue.`,
+      );
+    }
+
+    // Sent through the ordinary SendMessage path, so what arrives is the same
+    // thing an SDK caller would have sent.
+    await send.scope
+      .sqs()
+      .sendMessage(
+        { input: { QueueUrl: queue.arn.url, MessageBody: send.body } },
+        { sourceArn: send.sourceFunctionArn },
+      );
+  }
+}

--- a/src/service/lambda/destination/deliver/sim-lambda-destination-send.ts
+++ b/src/service/lambda/destination/deliver/sim-lambda-destination-send.ts
@@ -1,0 +1,16 @@
+import type { SimAwsAccountRegionContainer } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimLambdaDestinationArn } from "../sim-lambda-destination-arn.js";
+
+/**
+ * One document on its way to one queue or topic.
+ */
+export interface SimLambdaDestinationSend {
+  readonly scope: SimAwsAccountRegionContainer;
+  readonly arn: SimLambdaDestinationArn;
+  readonly body: string;
+
+  /**
+   * The function this came from, supplied to IAM as `aws:SourceArn`.
+   */
+  readonly sourceFunctionArn: string;
+}

--- a/src/service/lambda/destination/deliver/sim-lambda-destination-topic.ts
+++ b/src/service/lambda/destination/deliver/sim-lambda-destination-topic.ts
@@ -1,0 +1,31 @@
+import { SimLambdaError } from "../../error/sim-lambda.error.js";
+import type { SimLambdaDestinationSend } from "./sim-lambda-destination-send.js";
+
+/**
+ * A topic a function is sending an asynchronous invocation result to, in the
+ * Account and Region the destination ARN names.
+ *
+ * The topic then fans the record out to its own subscriptions, so each
+ * subscriber sees it inside SNS's envelope.
+ */
+export class SimLambdaDestinationTopic {
+  /**
+   * Publish the document to the topic.
+   */
+  async deliver(send: SimLambdaDestinationSend): Promise<void> {
+    const topic = send.scope.sns().findTopic(send.arn.resource);
+
+    if (topic === undefined) {
+      throw new SimLambdaError(
+        `${send.arn.value} is not a simulated SNS topic.`,
+      );
+    }
+
+    await send.scope
+      .sns()
+      .publish(
+        { input: { TopicArn: topic.arn.value, Message: send.body } },
+        { sourceArn: send.sourceFunctionArn },
+      );
+  }
+}

--- a/src/service/lambda/destination/sim-aws-lambda-destinations.ts
+++ b/src/service/lambda/destination/sim-aws-lambda-destinations.ts
@@ -1,0 +1,100 @@
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsAccountRegionContainer } from "../../aws/sim-aws-account-region-scope.js";
+import { SimLambdaDestinationBus } from "./deliver/sim-lambda-destination-bus.js";
+import { SimLambdaDestinationFunction } from "./deliver/sim-lambda-destination-function.js";
+import { SimLambdaDestinationQueue } from "./deliver/sim-lambda-destination-queue.js";
+import type { SimLambdaDestinationSend } from "./deliver/sim-lambda-destination-send.js";
+import { SimLambdaDestinationTopic } from "./deliver/sim-lambda-destination-topic.js";
+import type { SimLambdaDestinationArn } from "./sim-lambda-destination-arn.js";
+import type {
+  SimLambdaDeadLetterRequest,
+  SimLambdaDestinationDeliveryRequest,
+  SimLambdaDestinationTargets,
+} from "./sim-lambda-destination-targets.js";
+
+interface SimAwsLambdaDestinationsProperties {
+  readonly simAws: SimAws;
+}
+
+/**
+ * Everywhere the functions of one simulated AWS instance send their
+ * asynchronous invocation results.
+ *
+ * The destination is looked up when a result is delivered, never when this is
+ * built: reaching another service while this one is being constructed is a
+ * cycle with no bottom to it.
+ *
+ * Real Lambda delivers under the function's own execution role, and delivers
+ * nothing when that role cannot write to the destination. The permission is
+ * left unchecked here, so a delivery is made as the destination Account's own
+ * root. A record that silently goes nowhere is the harder failure to find, and
+ * a destination needs no resource policy on real AWS either, so nothing about
+ * the destination itself has to be set up for a record to arrive.
+ */
+export class SimAwsLambdaDestinations implements SimLambdaDestinationTargets {
+  private readonly simAws: SimAws;
+  private readonly queue = new SimLambdaDestinationQueue();
+  private readonly topic = new SimLambdaDestinationTopic();
+
+  constructor(properties: SimAwsLambdaDestinationsProperties) {
+    this.simAws = properties.simAws;
+  }
+
+  /**
+   * Send one invocation record to the destination its ARN names.
+   */
+  async deliver(request: SimLambdaDestinationDeliveryRequest): Promise<void> {
+    const { destinationArn: arn } = request;
+    const scope = this.scopeOf(arn);
+
+    switch (arn.service) {
+      case "sqs": {
+        await this.queue.deliver(this.send(request));
+        return;
+      }
+      case "sns": {
+        await this.topic.deliver(this.send(request));
+        return;
+      }
+      case "events": {
+        await new SimLambdaDestinationBus().deliver(scope, request);
+        return;
+      }
+      case "lambda": {
+        await new SimLambdaDestinationFunction().deliver(scope, request);
+        return;
+      }
+    }
+  }
+
+  /**
+   * Send one abandoned event to a dead-letter queue or topic.
+   */
+  async deadLetter(request: SimLambdaDeadLetterRequest): Promise<void> {
+    const send: SimLambdaDestinationSend = {
+      scope: this.scopeOf(request.targetArn),
+      arn: request.targetArn,
+      body: JSON.stringify(request.payload),
+      sourceFunctionArn: request.sourceFunctionArn,
+    };
+
+    await (request.targetArn.service === "sqs"
+      ? this.queue.deliver(send)
+      : this.topic.deliver(send));
+  }
+
+  private send(
+    request: SimLambdaDestinationDeliveryRequest,
+  ): SimLambdaDestinationSend {
+    return {
+      scope: this.scopeOf(request.destinationArn),
+      arn: request.destinationArn,
+      body: JSON.stringify(request.record),
+      sourceFunctionArn: request.sourceFunctionArn,
+    };
+  }
+
+  private scopeOf(arn: SimLambdaDestinationArn): SimAwsAccountRegionContainer {
+    return this.simAws.accountRegionScope(arn.accountId, arn.regionName);
+  }
+}

--- a/src/service/lambda/destination/sim-lambda-destination-arn.ts
+++ b/src/service/lambda/destination/sim-lambda-destination-arn.ts
@@ -1,0 +1,168 @@
+import type { SimAwsAccountId } from "../../aws/sim-aws-account-id.js";
+import type { AwsRegionName } from "../../aws/sim-aws-region.js";
+import { SimLambdaInvalidParameterValueException } from "../error/sim-lambda.error.js";
+
+/**
+ * The services an asynchronous invocation result can be sent to.
+ */
+export const simLambdaDestinationServices = [
+  "sqs",
+  "sns",
+  "events",
+  "lambda",
+] as const;
+
+export type SimLambdaDestinationService =
+  (typeof simLambdaDestinationServices)[number];
+
+/**
+ * The fewest colon separated parts any destination ARN has.
+ */
+const minimumArnParts = 6;
+
+const destinationServices: ReadonlySet<string> = new Set(
+  simLambdaDestinationServices,
+);
+
+function isDestinationService(
+  value: string,
+): value is SimLambdaDestinationService {
+  return destinationServices.has(value);
+}
+
+interface SimLambdaDestinationArnProperties {
+  readonly value: string;
+  readonly service: SimLambdaDestinationService;
+  readonly regionName: AwsRegionName;
+  readonly accountId: SimAwsAccountId;
+  readonly resource: string;
+}
+
+/**
+ * The ARN of somewhere an asynchronous invocation result is sent.
+ *
+ * Destination ARNs are read here rather than by `parseSimArn`, because the four
+ * services write their resource part three ways. A queue and a topic put the
+ * name straight after the Account, a function writes `function:<name>`, and an
+ * event bus writes `event-bus/<name>`.
+ */
+export class SimLambdaDestinationArn {
+  public readonly value: string;
+  public readonly service: SimLambdaDestinationService;
+  public readonly regionName: AwsRegionName;
+  public readonly accountId: SimAwsAccountId;
+
+  /**
+   * The resource part of the ARN, with no type separator taken off it.
+   */
+  public readonly resource: string;
+
+  private constructor(properties: SimLambdaDestinationArnProperties) {
+    this.value = properties.value;
+    this.service = properties.service;
+    this.regionName = properties.regionName;
+    this.accountId = properties.accountId;
+    this.resource = properties.resource;
+  }
+
+  /**
+   * Read a destination ARN, refusing one this simulation cannot send to.
+   *
+   * A destination naming an unsimulated service is refused when the config is
+   * written rather than when an invocation first fails, so a function that
+   * could never deliver says so at the point it was set up.
+   */
+  static of(value: string): SimLambdaDestinationArn {
+    const parts = value.split(":");
+    const [prefix, partition, service, regionName, accountId] = parts;
+    const resource = parts.slice(minimumArnParts - 1).join(":");
+
+    if (
+      prefix !== "arn" ||
+      partition !== "aws" ||
+      service === undefined ||
+      regionName === undefined ||
+      regionName === "" ||
+      accountId === undefined ||
+      accountId === "" ||
+      resource === "" ||
+      parts.length < minimumArnParts
+    ) {
+      throw new SimLambdaInvalidParameterValueException(
+        `The destination ARN ${value} is not an ARN.`,
+      );
+    }
+
+    if (!isDestinationService(service)) {
+      throw new SimLambdaInvalidParameterValueException(
+        `The destination ARN ${value} names ${service}, and a simulated ` +
+          "Lambda invocation result is sent to " +
+          `${simLambdaDestinationServices.join(", ")} destinations only.`,
+      );
+    }
+
+    const arn = new this({
+      value,
+      service,
+      regionName: regionName as AwsRegionName,
+      accountId: accountId as SimAwsAccountId,
+      resource,
+    });
+    this.refuseUnnamedResource(arn);
+
+    return arn;
+  }
+
+  /**
+   * Refuse an ARN of the right service that names nothing in it.
+   */
+  private static refuseUnnamedResource(arn: SimLambdaDestinationArn): void {
+    if (arn.service === "lambda" && arn.functionName === "") {
+      throw new SimLambdaInvalidParameterValueException(
+        `The destination ARN ${arn.value} names no function. A function ` +
+          "destination is " +
+          "arn:aws:lambda:<region>:<account-id>:function:<function-name>",
+      );
+    }
+
+    if (arn.service === "events" && arn.eventBusName === "") {
+      throw new SimLambdaInvalidParameterValueException(
+        `The destination ARN ${arn.value} names no event bus. An ` +
+          "EventBridge destination is " +
+          "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>",
+      );
+    }
+  }
+  /**
+   * The name of a Lambda function this ARN names, or nothing when it names
+   * something else in Lambda.
+   */
+  get functionName(): string {
+    const [resourceType, name = ""] = this.resource.split(":", 3);
+
+    return resourceType === "function" ? name : "";
+  }
+
+  /**
+   * The version or alias this ARN qualified the function with.
+   */
+  get functionQualifier(): string | undefined {
+    const [resourceType, , qualifier] = this.resource.split(":", 3);
+
+    return resourceType === "function" ? qualifier : undefined;
+  }
+
+  /**
+   * The name of the event bus this ARN names, or nothing when it names
+   * something else in EventBridge.
+   */
+  get eventBusName(): string {
+    const [resourceType, name = "", beyond] = this.resource.split("/", 3);
+
+    if (resourceType !== "event-bus" || beyond !== undefined) {
+      return "";
+    }
+
+    return name;
+  }
+}

--- a/src/service/lambda/destination/sim-lambda-destination-record.ts
+++ b/src/service/lambda/destination/sim-lambda-destination-record.ts
@@ -1,0 +1,81 @@
+import type { SimLambdaInvocationCondition } from "../function/event-invoke/sim-lambda-event-invoke-config.js";
+
+/**
+ * What Lambda reports about the invocation that produced a destination
+ * record.
+ */
+export interface SimLambdaDestinationRequestContext {
+  requestId: string;
+  functionArn: string;
+  condition: SimLambdaInvocationCondition;
+  approximateInvokeCount: number;
+}
+
+/**
+ * What Lambda reports about the attempt that ended the invocation.
+ *
+ * An invocation abandoned for age never ran a final attempt, so it carries no
+ * response context.
+ */
+export interface SimLambdaDestinationResponseContext {
+  statusCode: number;
+  executedVersion: string;
+  functionError?: string | undefined;
+}
+
+/**
+ * The document Lambda sends to an OnSuccess or OnFailure destination.
+ *
+ * https://docs.aws.amazon.com/lambda/latest/dg/invocation-async-retain-records.html
+ */
+export interface SimLambdaDestinationRecord {
+  version: string;
+  timestamp: string;
+  requestContext: SimLambdaDestinationRequestContext;
+  requestPayload: unknown;
+  responseContext?: SimLambdaDestinationResponseContext | undefined;
+  responsePayload: unknown;
+}
+
+interface MakeSimLambdaDestinationRecordProperties {
+  readonly requestId: string;
+  readonly functionArn: string;
+  readonly executedVersion: string;
+  readonly condition: SimLambdaInvocationCondition;
+  readonly approximateInvokeCount: number;
+  readonly timestamp: Date;
+  readonly requestPayload: unknown;
+  readonly responsePayload: unknown;
+  readonly functionError?: string | undefined;
+  readonly ran: boolean;
+}
+
+/**
+ * Build the record one asynchronous invocation sends to its destination.
+ */
+export function makeSimLambdaDestinationRecord(
+  properties: MakeSimLambdaDestinationRecordProperties,
+): SimLambdaDestinationRecord {
+  const record: SimLambdaDestinationRecord = {
+    version: "1.0",
+    timestamp: properties.timestamp.toISOString(),
+    requestContext: {
+      requestId: properties.requestId,
+      functionArn: properties.functionArn,
+      condition: properties.condition,
+      approximateInvokeCount: properties.approximateInvokeCount,
+    },
+    requestPayload: properties.requestPayload,
+    responsePayload: properties.responsePayload,
+  };
+
+  if (properties.ran) {
+    record.responseContext = {
+      statusCode: 200,
+      executedVersion: properties.executedVersion,
+      functionError: properties.functionError,
+    };
+  }
+
+  return record;
+}

--- a/src/service/lambda/destination/sim-lambda-destination-targets.ts
+++ b/src/service/lambda/destination/sim-lambda-destination-targets.ts
@@ -1,0 +1,66 @@
+import { SimLambdaError } from "../error/sim-lambda.error.js";
+import type { SimLambdaDestinationArn } from "./sim-lambda-destination-arn.js";
+import type { SimLambdaDestinationRecord } from "./sim-lambda-destination-record.js";
+
+/**
+ * One asynchronous invocation result on its way to one destination.
+ */
+export interface SimLambdaDestinationDeliveryRequest {
+  readonly destinationArn: SimLambdaDestinationArn;
+  readonly record: SimLambdaDestinationRecord;
+
+  /**
+   * The function whose invocation produced this record, which is what the
+   * delivery is attributed to.
+   */
+  readonly sourceFunctionArn: string;
+}
+
+/**
+ * One asynchronous invocation's event on its way to a dead-letter target.
+ *
+ * A dead-letter target receives the event as it was invoked. The destination
+ * record's envelope belongs to the newer mechanism, and real Lambda leaves it
+ * off here.
+ */
+export interface SimLambdaDeadLetterRequest {
+  readonly targetArn: SimLambdaDestinationArn;
+  readonly payload: unknown;
+  readonly sourceFunctionArn: string;
+}
+
+/**
+ * Everywhere a simulated function's asynchronous invocation results can go.
+ */
+export interface SimLambdaDestinationTargets {
+  deliver(request: SimLambdaDestinationDeliveryRequest): Promise<void>;
+  deadLetter(request: SimLambdaDeadLetterRequest): Promise<void>;
+}
+
+/**
+ * Destinations used when no wider simulation is wired up, such as for a
+ * standalone SimLambda constructed outside SimAws.
+ */
+export class SimLambdaNoDestinationTargets implements SimLambdaDestinationTargets {
+  /**
+   * Say that this SimLambda has nowhere to send an invocation result.
+   */
+  deliver(request: SimLambdaDestinationDeliveryRequest): Promise<never> {
+    throw this.unreachable(request.destinationArn);
+  }
+
+  /**
+   * Say that this SimLambda has nowhere to dead-letter an event.
+   */
+  deadLetter(request: SimLambdaDeadLetterRequest): Promise<never> {
+    throw this.unreachable(request.targetArn);
+  }
+
+  private unreachable(arn: SimLambdaDestinationArn): Error {
+    return new SimLambdaError(
+      `Cannot deliver to ${arn.value}: this SimLambda has no wider ` +
+        "simulation to send an invocation result to. Create the function " +
+        "through SimAws, or construct SimLambda with destinations.",
+    );
+  }
+}

--- a/src/service/lambda/function/event-invoke/lambda-dead-letter-target.ts
+++ b/src/service/lambda/function/event-invoke/lambda-dead-letter-target.ts
@@ -1,0 +1,41 @@
+import { SimLambdaDestinationArn } from "../../destination/sim-lambda-destination-arn.js";
+import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
+
+/**
+ * Where a function sends the asynchronous events it gave up on.
+ */
+export interface SimLambdaDeadLetterConfigInput {
+  readonly TargetArn?: string | undefined;
+}
+
+/**
+ * Read a function's dead-letter target, refusing one that cannot receive.
+ *
+ * Real Lambda dead-letters to a queue or a topic and nowhere else, so an ARN
+ * naming anything else is refused while the caller is still there to see it.
+ * An empty `TargetArn` is how AWS takes a dead-letter target away, and it
+ * comes back as an empty string so a caller clearing one is told apart from a
+ * caller saying nothing about it.
+ */
+export function requireLambdaDeadLetterTarget(
+  config: SimLambdaDeadLetterConfigInput | undefined,
+): string | undefined {
+  if (config?.TargetArn === undefined) {
+    return undefined;
+  }
+
+  if (config.TargetArn === "") {
+    return "";
+  }
+
+  const arn = SimLambdaDestinationArn.of(config.TargetArn);
+
+  if (arn.service !== "sqs" && arn.service !== "sns") {
+    throw new SimLambdaInvalidParameterValueException(
+      `The dead-letter target ${arn.value} names ${arn.service}. A ` +
+        "dead-letter target is an SQS queue or an SNS topic.",
+    );
+  }
+
+  return arn.value;
+}

--- a/src/service/lambda/function/event-invoke/sim-lambda-event-invoke-config-store.ts
+++ b/src/service/lambda/function/event-invoke/sim-lambda-event-invoke-config-store.ts
@@ -1,0 +1,124 @@
+import {
+  type SimClock,
+  SimRealClock,
+} from "../../../../util/clock/sim-clock.js";
+import type { SimLambdaFunctionName } from "../sim-lambda-function.type.js";
+import type {
+  SimLambdaEventInvokeConfig,
+  SimLambdaEventInvokeConfigKey,
+  SimLambdaEventInvokeConfigWrite,
+  SimLambdaEventInvokeSettings,
+} from "./sim-lambda-event-invoke-config.js";
+import { simLambdaEventInvokeStoreKey } from "./sim-lambda-event-invoke-config.js";
+import {
+  defaultSimLambdaEventInvokeSettings,
+  requireSimLambdaEventInvokeConfig,
+  writtenSimLambdaEventInvokeSettings,
+} from "./sim-lambda-event-invoke-settings.js";
+
+interface SimLambdaEventInvokeConfigStoreProperties {
+  readonly clock?: SimClock | undefined;
+}
+
+/**
+ * Event invoke config state for one Account/Region scope of simulated Lambda.
+ *
+ * A function has one config per qualifier, so `$LATEST`, a published version
+ * and an alias each hold their own.
+ */
+export class SimLambdaEventInvokeConfigStore {
+  private readonly configs = new Map<string, SimLambdaEventInvokeConfig>();
+  private readonly clock: SimClock;
+
+  constructor(properties: SimLambdaEventInvokeConfigStoreProperties = {}) {
+    this.clock = properties.clock ?? new SimRealClock();
+  }
+
+  /**
+   * Get the config a function name and qualifier together name, if there is
+   * one.
+   */
+  get(
+    key: SimLambdaEventInvokeConfigKey,
+  ): SimLambdaEventInvokeConfig | undefined {
+    return this.configs.get(simLambdaEventInvokeStoreKey(key));
+  }
+
+  /**
+   * Get a config, or fail as AWS does when the qualifier has none.
+   */
+  require(
+    key: SimLambdaEventInvokeConfigKey,
+    functionArn: string,
+  ): SimLambdaEventInvokeConfig {
+    return requireSimLambdaEventInvokeConfig(this.get(key), functionArn);
+  }
+
+  /**
+   * Every config a function holds, across its qualifiers.
+   */
+  allForFunction(
+    functionName: SimLambdaFunctionName | string,
+  ): readonly SimLambdaEventInvokeConfig[] {
+    return this.configs
+      .values()
+      .filter((config) => config.functionName === functionName)
+      .toArray();
+  }
+
+  /**
+   * Write a whole config, as PutFunctionEventInvokeConfig does.
+   *
+   * A setting the caller left out goes back to its default, since Put writes
+   * the whole config rather than part of it.
+   */
+  put(write: SimLambdaEventInvokeConfigWrite): SimLambdaEventInvokeConfig {
+    return this.written(write, defaultSimLambdaEventInvokeSettings());
+  }
+
+  /**
+   * Change the settings a request named, as UpdateFunctionEventInvokeConfig
+   * does, leaving the rest alone and failing when there is no config to
+   * change.
+   */
+  update(write: SimLambdaEventInvokeConfigWrite): SimLambdaEventInvokeConfig {
+    return this.written(write, this.require(write, write.functionArn).settings);
+  }
+
+  /**
+   * Delete a config, failing as AWS does when the qualifier has none.
+   */
+  delete(key: SimLambdaEventInvokeConfigKey, functionArn: string): void {
+    this.require(key, functionArn);
+    this.configs.delete(simLambdaEventInvokeStoreKey(key));
+  }
+
+  /**
+   * Forget every config a function holds.
+   *
+   * Deleting a function takes its configs with it, and a function that never
+   * had one is nothing to fail over, unlike a DeleteFunctionEventInvokeConfig
+   * request.
+   */
+  deleteForFunction(functionName: SimLambdaFunctionName | string): void {
+    for (const config of this.allForFunction(functionName)) {
+      this.configs.delete(simLambdaEventInvokeStoreKey(config));
+    }
+  }
+
+  private written(
+    write: SimLambdaEventInvokeConfigWrite,
+    base: SimLambdaEventInvokeSettings,
+  ): SimLambdaEventInvokeConfig {
+    const config: SimLambdaEventInvokeConfig = {
+      functionName: write.functionName,
+      qualifier: write.qualifier,
+      functionArn: write.functionArn,
+      settings: writtenSimLambdaEventInvokeSettings(base, write.update),
+      lastModified: this.clock.now(),
+    };
+    this.configs.set(simLambdaEventInvokeStoreKey(write), config);
+
+    return config;
+  }
+}

--- a/src/service/lambda/function/event-invoke/sim-lambda-event-invoke-config.ts
+++ b/src/service/lambda/function/event-invoke/sim-lambda-event-invoke-config.ts
@@ -1,0 +1,139 @@
+import { SIM_LAMBDA_LATEST_VERSION } from "../sim-lambda-function-configuration.js";
+import type { SimLambdaFunctionName } from "../sim-lambda-function.type.js";
+
+/**
+ * How many times real Lambda retries a failed asynchronous invocation when
+ * nothing says otherwise.
+ */
+export const DEFAULT_SIM_LAMBDA_MAXIMUM_RETRY_ATTEMPTS = 2;
+
+/**
+ * The most retries real Lambda will make, which is also the most an event
+ * invoke config may ask for.
+ */
+export const MAX_SIM_LAMBDA_MAXIMUM_RETRY_ATTEMPTS = 2;
+
+/**
+ * How long real Lambda keeps trying an asynchronous event by default, which is
+ * six hours.
+ */
+export const DEFAULT_SIM_LAMBDA_MAXIMUM_EVENT_AGE_SECONDS = 21_600;
+
+export const MIN_SIM_LAMBDA_MAXIMUM_EVENT_AGE_SECONDS = 60;
+export const MAX_SIM_LAMBDA_MAXIMUM_EVENT_AGE_SECONDS = 21_600;
+
+/**
+ * How long each retry of a failed asynchronous invocation waits before it
+ * runs.
+ *
+ * Real Lambda leaves about a minute before the first retry and about two
+ * before the second. The waits happen on the simulation's own clock, so a test
+ * reaches a retry by advancing time rather than by waiting for it.
+ */
+export const SIM_LAMBDA_RETRY_DELAYS_SECONDS: readonly number[] = [60, 120];
+
+/**
+ * Why an asynchronous invocation ended up at the destination it did.
+ */
+export type SimLambdaInvocationCondition =
+  | "Success"
+  | "RetriesExhausted"
+  | "EventAgeExceeded";
+
+/**
+ * One end of a destination config, which is a destination or the absence of
+ * one.
+ *
+ * `Destination` is optional because AWS takes a destination away by sending
+ * the member with nothing in it.
+ */
+export interface SimLambdaDestination {
+  Destination?: string | undefined;
+}
+
+/**
+ * Where the results of a function's asynchronous invocations are sent.
+ */
+export interface SimLambdaDestinationConfiguration {
+  OnSuccess?: SimLambdaDestination | undefined;
+  OnFailure?: SimLambdaDestination | undefined;
+}
+
+/**
+ * How a function handles one asynchronous invocation.
+ */
+export interface SimLambdaEventInvokeSettings {
+  readonly maximumRetryAttempts: number;
+  readonly maximumEventAgeInSeconds: number;
+  readonly onSuccessArn?: string | undefined;
+  readonly onFailureArn?: string | undefined;
+}
+
+/**
+ * What a caller may set on an event invoke config.
+ *
+ * Every setting is optional because both commands that write one may leave any
+ * of them out. Put takes the ones it was given and returns the rest to their
+ * defaults, and Update leaves an omitted one as it stands.
+ */
+export interface SimLambdaEventInvokeConfigUpdate {
+  readonly maximumRetryAttempts?: number | undefined;
+  readonly maximumEventAgeInSeconds?: number | undefined;
+  readonly onSuccessArn?: string | undefined;
+  readonly onFailureArn?: string | undefined;
+}
+
+/**
+ * How one function, version or alias handles its asynchronous invocations.
+ *
+ * The retry settings and the destinations live together because that is how
+ * AWS holds them: one config per qualifier, written by one command.
+ */
+export interface SimLambdaEventInvokeConfig {
+  readonly functionName: SimLambdaFunctionName | string;
+  readonly qualifier: string | undefined;
+  readonly functionArn: string;
+  readonly settings: SimLambdaEventInvokeSettings;
+  readonly lastModified: Date;
+}
+
+/**
+ * Minimal structural event invoke configuration, as returned by the
+ * PutFunctionEventInvokeConfig, GetFunctionEventInvokeConfig and
+ * UpdateFunctionEventInvokeConfig commands.
+ */
+export interface SimLambdaEventInvokeConfiguration {
+  FunctionArn: string;
+  MaximumRetryAttempts: number;
+  MaximumEventAgeInSeconds: number;
+  DestinationConfig: SimLambdaDestinationConfiguration;
+  LastModified: Date;
+}
+
+/**
+ * Which function and qualifier a config belongs to.
+ */
+export interface SimLambdaEventInvokeConfigKey {
+  readonly functionName: SimLambdaFunctionName | string;
+  readonly qualifier?: string | undefined;
+}
+
+/**
+ * One config to write, and what to write into it.
+ */
+export interface SimLambdaEventInvokeConfigWrite extends SimLambdaEventInvokeConfigKey {
+  readonly functionArn: string;
+  readonly update: SimLambdaEventInvokeConfigUpdate;
+}
+
+/**
+ * What one config is held under, which is its function and its qualifier.
+ *
+ * A config written without a qualifier belongs to `$LATEST`, which is how AWS
+ * addresses the function itself.
+ */
+export function simLambdaEventInvokeStoreKey(
+  key: SimLambdaEventInvokeConfigKey,
+): string {
+  return `${key.functionName}:${key.qualifier ?? SIM_LAMBDA_LATEST_VERSION}`;
+}

--- a/src/service/lambda/function/event-invoke/sim-lambda-event-invoke-settings.ts
+++ b/src/service/lambda/function/event-invoke/sim-lambda-event-invoke-settings.ts
@@ -1,0 +1,108 @@
+import { SimLambdaResourceNotFoundException } from "../../error/sim-lambda.error.js";
+import {
+  DEFAULT_SIM_LAMBDA_MAXIMUM_EVENT_AGE_SECONDS,
+  DEFAULT_SIM_LAMBDA_MAXIMUM_RETRY_ATTEMPTS,
+  type SimLambdaEventInvokeConfig,
+  type SimLambdaEventInvokeConfigUpdate,
+  type SimLambdaEventInvokeConfiguration,
+  type SimLambdaEventInvokeSettings,
+  SIM_LAMBDA_RETRY_DELAYS_SECONDS,
+} from "./sim-lambda-event-invoke-config.js";
+
+const millisecondsPerSecond = 1000;
+
+/**
+ * How a function with no event invoke config of its own behaves.
+ */
+export function defaultSimLambdaEventInvokeSettings(): SimLambdaEventInvokeSettings {
+  return {
+    maximumRetryAttempts: DEFAULT_SIM_LAMBDA_MAXIMUM_RETRY_ATTEMPTS,
+    maximumEventAgeInSeconds: DEFAULT_SIM_LAMBDA_MAXIMUM_EVENT_AGE_SECONDS,
+  };
+}
+
+/**
+ * Write settings over the ones a config holds now.
+ *
+ * A setting the caller left out arrives as `undefined`, and spreading that
+ * over what is there would take it away rather than leave it alone, so the
+ * absent ones are dropped first.
+ */
+export function writtenSimLambdaEventInvokeSettings(
+  base: SimLambdaEventInvokeSettings,
+  update: SimLambdaEventInvokeConfigUpdate,
+): SimLambdaEventInvokeSettings {
+  const named = Object.entries(update).filter(
+    ([, value]) => value !== undefined,
+  );
+
+  return { ...base, ...Object.fromEntries(named) };
+}
+
+/**
+ * One config as the SDK commands report it.
+ */
+export function simLambdaEventInvokeConfiguration(
+  config: SimLambdaEventInvokeConfig,
+): SimLambdaEventInvokeConfiguration {
+  const { onSuccessArn, onFailureArn } = config.settings;
+
+  return {
+    FunctionArn: config.functionArn,
+    MaximumRetryAttempts: config.settings.maximumRetryAttempts,
+    MaximumEventAgeInSeconds: config.settings.maximumEventAgeInSeconds,
+    DestinationConfig: {
+      OnSuccess:
+        onSuccessArn === undefined ? undefined : { Destination: onSuccessArn },
+      OnFailure:
+        onFailureArn === undefined ? undefined : { Destination: onFailureArn },
+    },
+    LastModified: config.lastModified,
+  };
+}
+
+/**
+ * Answer with a config, or fail as AWS does when there is none.
+ */
+export function requireSimLambdaEventInvokeConfig(
+  config: SimLambdaEventInvokeConfig | undefined,
+  functionArn: string,
+): SimLambdaEventInvokeConfig {
+  if (config === undefined) {
+    throw new SimLambdaResourceNotFoundException(
+      `The function ${functionArn} doesn't have an EventInvokeConfig`,
+    );
+  }
+
+  return config;
+}
+
+/**
+ * When the next retry of a failed asynchronous invocation falls due.
+ *
+ * Real Lambda leaves about a minute before the first retry and about two
+ * before the second. An attempt past those waits as long as the last one,
+ * which is only reachable where a config asks for more retries than AWS
+ * allows.
+ */
+export function simLambdaRetryDueTime(now: Date, attemptCount: number): Date {
+  const seconds =
+    SIM_LAMBDA_RETRY_DELAYS_SECONDS[attemptCount - 1] ??
+    SIM_LAMBDA_RETRY_DELAYS_SECONDS.at(-1) ??
+    0;
+
+  return new Date(now.getTime() + seconds * millisecondsPerSecond);
+}
+
+/**
+ * Whether an event has been waiting longer than its function keeps trying.
+ */
+export function simLambdaEventTooOld(
+  startedAt: Date,
+  now: Date,
+  settings: SimLambdaEventInvokeSettings,
+): boolean {
+  const waited = (now.getTime() - startedAt.getTime()) / millisecondsPerSecond;
+
+  return waited >= settings.maximumEventAgeInSeconds;
+}

--- a/src/service/lambda/function/sim-lambda-function-configuration.factory.ts
+++ b/src/service/lambda/function/sim-lambda-function-configuration.factory.ts
@@ -1,0 +1,33 @@
+import type { SimLambdaFunctionConfiguration } from "./sim-lambda-function-configuration.js";
+import type { SimLambdaFunction } from "./sim-lambda-function.js";
+
+/**
+ * The AWS-like configuration a function reports.
+ *
+ * Built here rather than on the function, which is at the length this codebase
+ * allows, and which holds behaviour worth more of that length than a mapping
+ * from its own public members to the shape AWS answers with.
+ */
+export function simLambdaFunctionConfigurationOf(
+  simFunction: SimLambdaFunction,
+): SimLambdaFunctionConfiguration {
+  const { deadLetterTargetArn } = simFunction;
+
+  return {
+    FunctionName: simFunction.name,
+    FunctionArn: simFunction.arn,
+    Role: simFunction.roleArn,
+    State: simFunction.state,
+    Version: simFunction.version,
+    Timeout: simFunction.timeoutSeconds,
+    MemorySize: simFunction.memorySizeMb,
+    Handler: simFunction.handlerName,
+    Runtime: simFunction.runtimeName,
+    Description: simFunction.description,
+    Environment: simFunction.environment.configuration(),
+    DeadLetterConfig:
+      deadLetterTargetArn === undefined
+        ? undefined
+        : { TargetArn: deadLetterTargetArn },
+  };
+}

--- a/src/service/lambda/function/sim-lambda-function-configuration.ts
+++ b/src/service/lambda/function/sim-lambda-function-configuration.ts
@@ -59,4 +59,5 @@ export interface SimLambdaFunctionConfiguration {
   Runtime?: string | undefined;
   Description?: string | undefined;
   Environment?: { Variables: Record<string, string> } | undefined;
+  DeadLetterConfig?: { TargetArn: string } | undefined;
 }

--- a/src/service/lambda/function/sim-lambda-function-reconfiguration.ts
+++ b/src/service/lambda/function/sim-lambda-function-reconfiguration.ts
@@ -23,6 +23,11 @@ export interface SimLambdaFunctionConfigurationUpdate {
    * leaving this out, and real Lambda tells the two apart the same way.
    */
   readonly environmentVariables?: ReadonlyMap<string, string> | undefined;
+  /**
+   * The queue or topic to dead-letter to, or an empty string to stop
+   * dead-lettering, which is how AWS takes a target away.
+   */
+  readonly deadLetterTargetArn?: string | undefined;
 }
 
 /**
@@ -52,6 +57,10 @@ export function reconfigureSimLambdaFunction(
     update.timeoutSeconds ?? simFunction.timeoutSeconds;
   simFunction.memorySizeMb = update.memorySizeMb ?? simFunction.memorySizeMb;
   simFunction.environment = updatedEnvironment(simFunction, update);
+  simFunction.deadLetterTargetArn = updatedDeadLetterTarget(
+    simFunction,
+    update,
+  );
 
   if (
     simFunction.environment === previous.environment &&
@@ -92,4 +101,20 @@ function updatedEnvironment(
     declaredVariables:
       environmentVariables ?? simFunction.environment.declaredVariables,
   });
+}
+
+/**
+ * The dead-letter target a function has after a settings change.
+ */
+function updatedDeadLetterTarget(
+  simFunction: SimLambdaFunction,
+  update: SimLambdaFunctionConfigurationUpdate,
+): string | undefined {
+  if (update.deadLetterTargetArn === undefined) {
+    return simFunction.deadLetterTargetArn;
+  }
+
+  return update.deadLetterTargetArn === ""
+    ? undefined
+    : update.deadLetterTargetArn;
 }

--- a/src/service/lambda/function/sim-lambda-function.ts
+++ b/src/service/lambda/function/sim-lambda-function.ts
@@ -11,6 +11,7 @@ import {
   type SimLambdaFunctionConfiguration,
   type SimLambdaFunctionState,
 } from "./sim-lambda-function-configuration.js";
+import { simLambdaFunctionConfigurationOf } from "./sim-lambda-function-configuration.factory.js";
 import {
   type SimLambdaExecutableCode,
   SimLambdaHandlerReferenceCode,
@@ -65,6 +66,9 @@ export class SimLambdaFunction {
   public timeoutSeconds: number;
   public memorySizeMb: number;
   public environment: SimLambdaEnvironment;
+
+  /** Where this function's abandoned asynchronous events go, if anywhere. */
+  public deadLetterTargetArn: string | undefined;
   /**
    * This function's resource-based policy, which says who may act on it.
    *
@@ -98,6 +102,7 @@ export class SimLambdaFunction {
       timeoutSeconds = DEFAULT_SIM_LAMBDA_TIMEOUT_SECONDS,
       memorySizeMb = DEFAULT_SIM_LAMBDA_MEMORY_SIZE_MB,
       environment,
+      deadLetterTargetArn,
       runAsOwner = this,
       version = SIM_LAMBDA_LATEST_VERSION,
       clock = new SimRealClock(),
@@ -124,6 +129,7 @@ export class SimLambdaFunction {
         regionName: accountRegionScope.regionName,
         memorySizeMb,
       });
+    this.deadLetterTargetArn = deadLetterTargetArn;
     this.runAsOwner = runAsOwner;
     this.outboundHttp = outboundHttp;
     this.logging = new SimLambdaFunctionLogging({
@@ -175,6 +181,7 @@ export class SimLambdaFunction {
       memorySizeMb: this.memorySizeMb,
       code: this.#code,
       environment: this.environment,
+      deadLetterTargetArn: this.deadLetterTargetArn,
       runAsOwner: this.runAsOwner,
       state: "Active",
       description: description ?? this.description,
@@ -217,19 +224,7 @@ export class SimLambdaFunction {
    * Get the AWS-like function configuration for this sim Lambda function.
    */
   configuration(): SimLambdaFunctionConfiguration {
-    return {
-      FunctionName: this.name,
-      FunctionArn: this.arn,
-      Role: this.roleArn,
-      State: this.state,
-      Version: this.version,
-      Timeout: this.timeoutSeconds,
-      MemorySize: this.memorySizeMb,
-      Handler: this.handlerName,
-      Runtime: this.runtimeName,
-      Description: this.description,
-      Environment: this.environment.configuration(),
-    };
+    return simLambdaFunctionConfigurationOf(this);
   }
 
   /**

--- a/src/service/lambda/function/sim-lambda-function.type.ts
+++ b/src/service/lambda/function/sim-lambda-function.type.ts
@@ -30,6 +30,11 @@ export interface SimLambdaFunctionProperties {
   timeoutSeconds?: number | undefined;
   memorySizeMb?: number | undefined;
   environment?: SimLambdaEnvironment | undefined;
+  /**
+   * The queue or topic this function's abandoned asynchronous events are sent
+   * to, which is what `DeadLetterConfig.TargetArn` names.
+   */
+  deadLetterTargetArn?: string | undefined;
   runAsOwner?: SimAwsRunAsOwner;
   /**
    * The version this is. A function is `$LATEST`, and a version published

--- a/src/service/lambda/index.ts
+++ b/src/service/lambda/index.ts
@@ -45,3 +45,9 @@ export type {
   SimLambdaDynamoDbImage,
 } from "./event-source/stream/sim-lambda-dynamodb-attribute-value.js";
 export { SimLambdaStreamCascadeError } from "./event-source/stream/sim-lambda-stream-cascade.error.js";
+export type {
+  SimLambdaDestinationRecord,
+  SimLambdaDestinationRequestContext,
+  SimLambdaDestinationResponseContext,
+} from "./destination/sim-lambda-destination-record.js";
+export type { SimLambdaInvocationCondition } from "./function/event-invoke/sim-lambda-event-invoke-config.js";

--- a/src/service/lambda/sdk/sim-lambda-event-invoke-config-routes.ts
+++ b/src/service/lambda/sdk/sim-lambda-event-invoke-config-routes.ts
@@ -1,0 +1,61 @@
+import type { SimSdkCommandRoute } from "../../../sdk/index.js";
+import { simSdkCallerOptions } from "../../../sdk/index.js";
+import type { SimPutFunctionEventInvokeConfigCommand } from "../command/put-function-event-invoke-config/put-function-event-invoke-config.command.js";
+import type { SimGetFunctionEventInvokeConfigCommand } from "../command/get-function-event-invoke-config/get-function-event-invoke-config.command.js";
+import type { SimUpdateFunctionEventInvokeConfigCommand } from "../command/update-function-event-invoke-config/update-function-event-invoke-config.command.js";
+import type { SimDeleteFunctionEventInvokeConfigCommand } from "../command/delete-function-event-invoke-config/delete-function-event-invoke-config.command.js";
+import type { SimListFunctionEventInvokeConfigsCommand } from "../command/list-function-event-invoke-configs/list-function-event-invoke-configs.command.js";
+import type { SimLambda } from "../sim-lambda.js";
+
+/**
+ * The routes for the five event invoke config Commands.
+ *
+ * They are built here rather than in the router's own constructor, which holds
+ * every other Lambda Command and is at the length this codebase allows.
+ */
+export function simLambdaEventInvokeConfigRoutes(
+  simLambda: SimLambda,
+): readonly (readonly [string, SimSdkCommandRoute])[] {
+  return [
+    [
+      "PutFunctionEventInvokeConfigCommand",
+      async (command, context): Promise<unknown> =>
+        await simLambda.putFunctionEventInvokeConfig(
+          command as SimPutFunctionEventInvokeConfigCommand,
+          simSdkCallerOptions(context),
+        ),
+    ],
+    [
+      "GetFunctionEventInvokeConfigCommand",
+      async (command, context): Promise<unknown> =>
+        await simLambda.getFunctionEventInvokeConfig(
+          command as SimGetFunctionEventInvokeConfigCommand,
+          simSdkCallerOptions(context),
+        ),
+    ],
+    [
+      "UpdateFunctionEventInvokeConfigCommand",
+      async (command, context): Promise<unknown> =>
+        await simLambda.updateFunctionEventInvokeConfig(
+          command as SimUpdateFunctionEventInvokeConfigCommand,
+          simSdkCallerOptions(context),
+        ),
+    ],
+    [
+      "DeleteFunctionEventInvokeConfigCommand",
+      async (command, context): Promise<unknown> =>
+        await simLambda.deleteFunctionEventInvokeConfig(
+          command as SimDeleteFunctionEventInvokeConfigCommand,
+          simSdkCallerOptions(context),
+        ),
+    ],
+    [
+      "ListFunctionEventInvokeConfigsCommand",
+      async (command, context): Promise<unknown> =>
+        await simLambda.listFunctionEventInvokeConfigs(
+          command as SimListFunctionEventInvokeConfigsCommand,
+          simSdkCallerOptions(context),
+        ),
+    ],
+  ];
+}

--- a/src/service/lambda/sdk/sim-lambda-sdk-command-router.ts
+++ b/src/service/lambda/sdk/sim-lambda-sdk-command-router.ts
@@ -32,6 +32,7 @@ import type { SimListFunctionUrlConfigsCommand } from "../command/list-function-
 import type { SimRemovePermissionCommand } from "../command/remove-permission/remove-permission.command.js";
 import type { SimUpdateFunctionUrlConfigCommand } from "../command/update-function-url-config/update-function-url-config.command.js";
 import type { SimLambda } from "../sim-lambda.js";
+import { simLambdaEventInvokeConfigRoutes } from "./sim-lambda-event-invoke-config-routes.js";
 
 /**
  * Routes intercepted SDK Commands to one scoped simulated Lambda instance.
@@ -249,6 +250,7 @@ export class SimLambdaSdkCommandRouter implements SimSdkCommandRouter {
             simSdkCallerOptions(context),
           ),
       ],
+      ...simLambdaEventInvokeConfigRoutes(simLambda),
     ]);
   }
 

--- a/src/service/lambda/sim-lambda-commands.ts
+++ b/src/service/lambda/sim-lambda-commands.ts
@@ -11,6 +11,7 @@ import {
   type SimIamInterServiceAuthZ,
 } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimLambdaAliasCommands } from "./command/alias/sim-lambda-alias-commands.js";
+import { SimLambdaEventInvokeConfigCommands } from "./command/event-invoke-config/sim-lambda-event-invoke-config-commands.js";
 import { SimLambdaEventSourceMappingCommands } from "./command/event-source-mapping/sim-lambda-event-source-mapping-commands.js";
 import { SimLambdaFunctionCommands } from "./command/function/sim-lambda-function-commands.js";
 import { SimLambdaFunctionUrlCommands } from "./command/function-url/sim-lambda-function-url-commands.js";
@@ -31,6 +32,11 @@ import type { SimLambdaVmSdkModuleProvider } from "./function/code/vm/sdk/sim-la
 import type { SimLogsServiceWriter } from "../logs/write/sim-logs-service-writer.js";
 import type { SimLambdaOutboundHttp } from "./function/outbound/sim-lambda-outbound-http.js";
 import { SimLambdaEnvironmentConflicts } from "./function/environment/sim-lambda-environment-conflicts.js";
+import { SimLambdaEventInvokeConfigStore } from "./function/event-invoke/sim-lambda-event-invoke-config-store.js";
+import {
+  type SimLambdaDestinationTargets,
+  SimLambdaNoDestinationTargets,
+} from "./destination/sim-lambda-destination-targets.js";
 import type { SimLambdaFunctionMap } from "./function/sim-lambda-function.js";
 import { SimLambdaFunctionLookup } from "./function/url/sim-lambda-function-lookup.js";
 import { SimLambdaFunctionUrlStore } from "./function/url/sim-lambda-function-url-store.js";
@@ -60,6 +66,12 @@ export interface SimLambdaProperties {
   readonly urlRegistry?: SimLambdaUrlRegistry;
   readonly eventSourceQueues?: SimSqsPollQueues;
   readonly eventSourceStreams?: SimLambdaEventSourceStreams;
+  /**
+   * Where a function's asynchronous invocation results are sent. A standalone
+   * SimLambda has no simulated SQS, SNS or EventBridge beside it, so a
+   * destination configured on one has nowhere to deliver.
+   */
+  readonly destinations?: SimLambdaDestinationTargets;
 }
 
 interface SimLambdaCommandsProperties extends SimLambdaProperties {
@@ -89,12 +101,14 @@ export class SimLambdaCommands {
     versions: this.versionStore,
   });
   public readonly functionLookup: SimLambdaFunctionLookup;
+  public readonly eventInvokeConfigStore: SimLambdaEventInvokeConfigStore;
   public readonly functions: SimLambdaFunctionCommands;
   public readonly functionUrls: SimLambdaFunctionUrlCommands;
   public readonly permissions: SimLambdaPermissionCommands;
   public readonly versions: SimLambdaVersionCommands;
   public readonly aliases: SimLambdaAliasCommands;
   public readonly eventSourceMappings: SimLambdaEventSourceMappingCommands;
+  public readonly eventInvokeConfigs: SimLambdaEventInvokeConfigCommands;
 
   constructor(properties: SimLambdaCommandsProperties) {
     const {
@@ -117,9 +131,13 @@ export class SimLambdaCommands {
       // A standalone SimLambda has no simulated ECR beside it, so a container
       // image function created on one has nothing to resolve its image in.
       containerImages = new SimLambdaNoContainerImages(),
+      destinations = new SimLambdaNoDestinationTargets(),
     } = properties;
 
     this.containerImages = containerImages;
+    this.eventInvokeConfigStore = new SimLambdaEventInvokeConfigStore({
+      clock: background,
+    });
 
     this.functionLookup = new SimLambdaFunctionLookup({
       accountRegionScope,
@@ -169,6 +187,12 @@ export class SimLambdaCommands {
       iam,
       background,
     });
+    this.eventInvokeConfigs = new SimLambdaEventInvokeConfigCommands({
+      eventInvokeConfigs: this.eventInvokeConfigStore,
+      functions: this.functionLookup,
+      iam,
+      background,
+    });
     this.functions = new SimLambdaFunctionCommands({
       accountRegionScope,
       functions: properties.functions,
@@ -181,6 +205,8 @@ export class SimLambdaCommands {
       // Shared across function creations so a conflicting environment variable
       // is only reported once for this simulated Lambda.
       environmentConflicts: new SimLambdaEnvironmentConflicts(),
+      eventInvokeConfigs: this.eventInvokeConfigStore,
+      destinations,
       codeStore,
       containerImages,
       vmSdkModuleProvider,

--- a/src/service/lambda/sim-lambda-event-invoke-operations.ts
+++ b/src/service/lambda/sim-lambda-event-invoke-operations.ts
@@ -1,0 +1,52 @@
+import type * as simLambdaCommands from "./command/sim-lambda-command.types.js";
+import { SimLambdaInspection } from "./sim-lambda-inspection.js";
+import type { SimLambdaRequestOptions } from "./sim-lambda-request-options.js";
+
+/**
+ * The event invoke config commands of the simulated Lambda facade.
+ *
+ * They sit here rather than on SimLambda itself because that file grows by one
+ * delegating method per simulated operation and is at the length this codebase
+ * allows. The five belong together, so they are the group that moved.
+ */
+export abstract class SimLambdaEventInvokeOperations extends SimLambdaInspection {
+  /** Handle a Put Function Event Invoke Config Command from the SDK. */
+  async putFunctionEventInvokeConfig(
+    command: simLambdaCommands.SimPutFunctionEventInvokeConfigCommand,
+    options?: SimLambdaRequestOptions,
+  ): Promise<simLambdaCommands.SimPutFunctionEventInvokeConfigCommandOutput> {
+    return await this.commands.eventInvokeConfigs.put(command, options);
+  }
+
+  /** Handle a Get Function Event Invoke Config Command from the SDK. */
+  async getFunctionEventInvokeConfig(
+    command: simLambdaCommands.SimGetFunctionEventInvokeConfigCommand,
+    options?: SimLambdaRequestOptions,
+  ): Promise<simLambdaCommands.SimGetFunctionEventInvokeConfigCommandOutput> {
+    return await this.commands.eventInvokeConfigs.get(command, options);
+  }
+
+  /** Handle an Update Function Event Invoke Config Command from the SDK. */
+  async updateFunctionEventInvokeConfig(
+    command: simLambdaCommands.SimUpdateFunctionEventInvokeConfigCommand,
+    options?: SimLambdaRequestOptions,
+  ): Promise<simLambdaCommands.SimUpdateFunctionEventInvokeConfigCommandOutput> {
+    return await this.commands.eventInvokeConfigs.update(command, options);
+  }
+
+  /** Handle a Delete Function Event Invoke Config Command from the SDK. */
+  async deleteFunctionEventInvokeConfig(
+    command: simLambdaCommands.SimDeleteFunctionEventInvokeConfigCommand,
+    options?: SimLambdaRequestOptions,
+  ): Promise<simLambdaCommands.SimDeleteFunctionEventInvokeConfigCommandOutput> {
+    return await this.commands.eventInvokeConfigs.delete(command, options);
+  }
+
+  /** Handle a List Function Event Invoke Configs Command from the SDK. */
+  async listFunctionEventInvokeConfigs(
+    command: simLambdaCommands.SimListFunctionEventInvokeConfigsCommand,
+    options?: SimLambdaRequestOptions,
+  ): Promise<simLambdaCommands.SimListFunctionEventInvokeConfigsCommandOutput> {
+    return await this.commands.eventInvokeConfigs.list(command, options);
+  }
+}

--- a/src/service/lambda/sim-lambda-request-options.ts
+++ b/src/service/lambda/sim-lambda-request-options.ts
@@ -1,0 +1,8 @@
+import type { SimAwsCaller } from "../aws/caller/sim-aws-caller.js";
+
+/**
+ * What a request to simulated Lambda carries beyond the command itself.
+ */
+export interface SimLambdaRequestOptions {
+  readonly caller?: SimAwsCaller;
+}

--- a/src/service/lambda/sim-lambda.ts
+++ b/src/service/lambda/sim-lambda.ts
@@ -1,5 +1,4 @@
 import type { SimSdkCommandRouter } from "../../sdk/index.js";
-import type { SimAwsCaller } from "../aws/caller/sim-aws-caller.js";
 import type { SimCfnServiceResourceFactory } from "../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
 import { SimLambdaCloudFormationResourceFactory } from "./cfn/sim-cfn-lambda-resource-factory.js";
 import type { SimLambdaContainerImages } from "./function/code/image/sim-lambda-container-images.js";
@@ -9,12 +8,11 @@ import {
   SimLambdaCommands,
   type SimLambdaProperties,
 } from "./sim-lambda-commands.js";
-import { SimLambdaInspection } from "./sim-lambda-inspection.js";
+import { SimLambdaEventInvokeOperations } from "./sim-lambda-event-invoke-operations.js";
+import type { SimLambdaRequestOptions } from "./sim-lambda-request-options.js";
 import { SimLambdaSdkCommandRouter } from "./sdk/sim-lambda-sdk-command-router.js";
 
-export interface SimLambdaRequestOptions {
-  readonly caller?: SimAwsCaller;
-}
+export type { SimLambdaRequestOptions } from "./sim-lambda-request-options.js";
 
 /**
  * Simulated Lambda. Handles SDK commands. Emulates AWS behaviour and state.
@@ -22,10 +20,11 @@ export interface SimLambdaRequestOptions {
  * Each command below carries a one line doc comment rather than a block. This
  * file grows by one delegating method per simulated operation and is close to
  * the max-lines limit, which is the same reason `SimDynamoDb` reads that way.
- * The simulator's own accessors are held apart in `SimLambdaInspection`, which
+ * The simulator's own accessors are held apart in `SimLambdaInspection`, and
+ * the event invoke config commands in `SimLambdaEventInvokeOperations`, which
  * this extends.
  */
-export class SimLambda extends SimLambdaInspection {
+export class SimLambda extends SimLambdaEventInvokeOperations {
   protected readonly functions: SimLambdaFunctionMap = new Map();
   protected readonly commands: SimLambdaCommands;
 

--- a/test/lambda/async-destination-fixture.ts
+++ b/test/lambda/async-destination-fixture.ts
@@ -1,0 +1,179 @@
+/**
+ * Setup shared by the asynchronous invocation tests, which all need a function
+ * that fails a chosen number of times and somewhere for its result to go.
+ *
+ * This lives under `test/` for the same reasons as `test/sns/topic-fixture.ts`:
+ * eslint rejects a test file that exports helpers alongside its own `describe`
+ * calls, and `test/**` is type-checked with everything else, excluded from the
+ * published build, not collected as a suite, and not counted in coverage.
+ */
+
+import {
+  CreateFunctionCommand,
+  InvokeCommand,
+  PutFunctionEventInvokeConfigCommand,
+} from "@aws-sdk/client-lambda";
+import { CreateQueueCommand, ReceiveMessageCommand } from "@aws-sdk/client-sqs";
+import { assertNonNullable } from "@kensio/smartass";
+
+import { SimAws } from "../../src/service/aws/sim-aws.js";
+import type { SimLambdaDestinationRecord } from "../../src/service/lambda/destination/sim-lambda-destination-record.js";
+import { makeLambdaZipFileInput } from "../../src/service/lambda/index.js";
+
+export const simLambdaAsyncFunctionName = "orders";
+export const simLambdaAsyncFunctionArn =
+  "arn:aws:lambda:us-east-1:888888888888:function:orders";
+
+/**
+ * The ARN of a queue of a name in the default Account and Region.
+ */
+export function simLambdaQueueArn(queueName: string): string {
+  return `arn:aws:sqs:us-east-1:888888888888:${queueName}`;
+}
+
+/**
+ * One simulated AWS, and how many times the function it holds has run.
+ */
+export interface SimLambdaAsyncFixture {
+  readonly simAws: SimAws;
+  readonly attemptCount: () => number;
+}
+
+interface SimLambdaAsyncFunctionProperties {
+  /**
+   * How many attempts throw before one returns. Every attempt throws when this
+   * is left out.
+   */
+  readonly failuresBeforeSuccess?: number | undefined;
+  readonly deadLetterTargetArn?: string | undefined;
+}
+
+/**
+ * Make a simulated AWS holding one function that fails as often as asked.
+ */
+export async function simAwsWithAsyncFunction(
+  properties: SimLambdaAsyncFunctionProperties = {},
+): Promise<SimLambdaAsyncFixture> {
+  const { failuresBeforeSuccess = Infinity } = properties;
+  const simAws = new SimAws();
+  let attempts = 0;
+
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: simLambdaAsyncFunctionName,
+      Role: "arn:aws:iam::888888888888:role/OrdersRole",
+      DeadLetterConfig:
+        properties.deadLetterTargetArn === undefined
+          ? undefined
+          : { TargetArn: properties.deadLetterTargetArn },
+      Code: {
+        ZipFile: makeLambdaZipFileInput((event: { readonly id?: number }) => {
+          attempts += 1;
+
+          if (attempts <= failuresBeforeSuccess) {
+            throw new Error("orders handler failed");
+          }
+
+          return { handled: event.id };
+        }),
+      },
+    }),
+  );
+
+  return { simAws, attemptCount: (): number => attempts };
+}
+
+/**
+ * Write the event invoke config the function runs its asynchronous
+ * invocations under.
+ */
+export async function putEventInvokeConfig(
+  simAws: SimAws,
+  input: {
+    readonly MaximumRetryAttempts?: number;
+    readonly MaximumEventAgeInSeconds?: number;
+    readonly OnSuccess?: string;
+    readonly OnFailure?: string;
+  },
+): Promise<void> {
+  await simAws.lambda().putFunctionEventInvokeConfig(
+    new PutFunctionEventInvokeConfigCommand({
+      FunctionName: simLambdaAsyncFunctionName,
+      MaximumRetryAttempts: input.MaximumRetryAttempts,
+      MaximumEventAgeInSeconds: input.MaximumEventAgeInSeconds,
+      DestinationConfig: {
+        OnSuccess:
+          input.OnSuccess === undefined
+            ? undefined
+            : { Destination: input.OnSuccess },
+        OnFailure:
+          input.OnFailure === undefined
+            ? undefined
+            : { Destination: input.OnFailure },
+      },
+    }),
+  );
+}
+
+/**
+ * Invoke the function asynchronously and let every retry it makes fall due.
+ *
+ * Five simulated minutes is past both of the delays real Lambda leaves before
+ * a retry, so an invocation has finished with by the time this returns.
+ */
+export async function invokeAsyncAndSettle(simAws: SimAws): Promise<void> {
+  await simAws.lambda().invoke(
+    new InvokeCommand({
+      FunctionName: simLambdaAsyncFunctionName,
+      InvocationType: "Event",
+      Payload: JSON.stringify({ id: 7 }),
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+  await simAws.clock().advanceBy({ minutes: 5 });
+}
+
+/**
+ * Make a queue and answer with its URL.
+ */
+export async function makeQueue(
+  simAws: SimAws,
+  queueName: string,
+): Promise<string> {
+  const created = await simAws
+    .sqs()
+    .createQueue(new CreateQueueCommand({ QueueName: queueName }));
+  assertNonNullable(created.QueueUrl, "CreateQueue answered with a URL");
+
+  return created.QueueUrl;
+}
+
+/**
+ * Every message body waiting on a queue.
+ */
+export async function receivedBodies(
+  simAws: SimAws,
+  queueUrl: string,
+): Promise<readonly string[]> {
+  const received = await simAws.sqs().receiveMessage(
+    new ReceiveMessageCommand({
+      QueueUrl: queueUrl,
+      MaxNumberOfMessages: 10,
+    }),
+  );
+
+  return (received.Messages ?? []).map((message) => message.Body);
+}
+
+/**
+ * The one destination record waiting on a queue.
+ */
+export async function receivedRecord(
+  simAws: SimAws,
+  queueUrl: string,
+): Promise<SimLambdaDestinationRecord> {
+  const [body] = await receivedBodies(simAws, queueUrl);
+  assertNonNullable(body, "a destination record arrived");
+
+  return JSON.parse(body) as SimLambdaDestinationRecord;
+}


### PR DESCRIPTION
An Event invocation used to run once and drop whatever the handler threw, which left event-driven error handling with nothing to test against. It is now retried on the simulated clock, twice by default, and what survives the retries goes to the OnFailure destination an event invoke config names, while a handler that returns goes to OnSuccess. A destination can be a simulated SQS queue, SNS topic, EventBridge bus or Lambda function, and each receives the AWS destination record. PutFunctionEventInvokeConfig writes the config and the other four commands read, merge, remove and list it. DeadLetterConfig on CreateFunction and UpdateFunctionConfiguration sends the invoked event to a queue or topic, and a function carrying both a dead-letter target and a failure destination reaches both.

Two calls worth flagging. A destination is delivered to without checking that the function's execution role may write to it, because real Lambda drops the record silently when the role cannot, and a record that goes nowhere is the harder failure to find in a test. Retries wait on the clock at the delays real Lambda uses, a minute then two, so a test reaches them with `advanceBy(...)` rather than by waiting.

Resolves #844
