### PR TITLE
test: stop two tests racing the clock

### DIFF
--- a/src/service/lambda/command/update-function-configuration/update-function-configuration.iso.test.ts
+++ b/src/service/lambda/command/update-function-configuration/update-function-configuration.iso.test.ts
@@ -14,6 +14,8 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
+import { BackgroundTasks } from "../../../../util/background/background.js";
+import { SimFixedClock } from "../../../../util/clock/sim-clock.js";
 import {
   SimLambdaInvalidParameterValueException,
   SimLambdaResourceNotFoundException,
@@ -101,8 +103,13 @@ describe("Lambda UpdateFunctionConfigurationCommand", () => {
   });
 
   it("runs the next invocation under the new timeout and memory", async () => {
-    // Given a function whose handler reports what its context says.
-    const simLambda = new SimLambda();
+    // Given a function whose handler reports what its context says, on a
+    // simulation whose time is stopped so the remaining budget cannot drain
+    // between the invocation starting and the handler reading it.
+    const instant = new Date("2026-08-12T09:30:00.000Z");
+    const simLambda = new SimLambda({
+      background: new BackgroundTasks({ clock: new SimFixedClock(instant) }),
+    });
     await simLambda.createFunction(
       new CreateFunctionCommand({
         FunctionName: "orders",

--- a/src/service/sts/serve/sim-sts-api-assume-role.loc.test.ts
+++ b/src/service/sts/serve/sim-sts-api-assume-role.loc.test.ts
@@ -108,9 +108,11 @@ describe("Assuming a Role over the STS endpoint", () => {
   });
 
   it("expires the session on simulated time rather than on the host clock", async () => {
-    // Given a simulation whose clock has been moved days away from this machine's
+    // Given a simulation whose clock has been moved days away from this
+    // machine's, and stopped there so the expiry can be named exactly
     await createRole("Weekly", userArn);
     await simAws.clock().advanceBy({ days: 3 });
+    simAws.clock().freeze();
 
     // When a fifteen minute session is assumed over the endpoint
     const assumed = await client.send(


### PR DESCRIPTION
Brief, concise description of the change:

Two tests measured a simulated instant against a clock that was still running, and both could fail by a millisecond. The Lambda UpdateFunctionConfiguration test asserted an exact 5000 ms of remaining invocation budget on a simulation reading the host clock, and it failed once in a full `pnpm run check` run when a millisecond passed between the invocation starting and the handler calling `getRemainingTimeInMillis()`. It now builds its `SimLambda` on a `SimFixedClock`, which the create-function handler hands to the function and the invoke context builder measures the budget against, following the existing `s3-object-etag-surfaces` pattern. The STS assume-role test carried the same defect, advancing simulated time without stopping it and then comparing the returned expiry against a fresh read of the clock taken after the command had returned, and it now freezes the clock after advancing. I swept the other Lambda invocation tests for the same shape and found none. The remaining `getRemainingTimeInMillis()` assertion uses `assertNumberBetween`, the clock and vm tests already run on a `SimFixedClock`, and the SQS and DynamoDB stream event source tests already freeze before asserting a timestamp.

- [x] Conventional commit message, used as the title

- [ ] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [ ] User-facing behaviour is documented in `docs/`

Both unchecked boxes are deliberate. The branch name came from the session harness, and the change is test-only with nothing for `docs/` to describe.
