### PR TITLE
Deploy a user pool that allows passkeys

### DIFF
--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -4371,15 +4371,17 @@ Current documented limitations:
   `SmsAuthenticationMessage`, a `UserPoolTier` other than `ESSENTIALS`, and a
   `PasswordHistorySize`.
 - `Policies.SignInPolicy` is recorded and reported back by `DescribeUserPool`. The four factor names
-  Cognito accepts are `PASSWORD`, `EMAIL_OTP`, `SMS_OTP` and `WEB_AUTHN`, and `WEB_AUTHN` on its own
-  is refused, as AWS states it must be accompanied by at least one other option. Nothing here
+  Cognito accepts are `PASSWORD`, `EMAIL_OTP`, `SMS_OTP` and `WEB_AUTHN`, a list names five at most,
+  and a policy offering `WEB_AUTHN` and nothing else is refused however many times it repeats the
+  name, as AWS states it must be accompanied by at least one other option. Nothing here
   presents a factor other than a password. Every other one is reached through the `USER_AUTH` flow,
   which is refused by name, so a pool that allows passkeys deploys and describes itself the way the
   deployed pool does while a passkey sign-in is refused where a sign-in asks for it.
 - `WebAuthnRelyingPartyID` and `WebAuthnUserVerification` deploy from an `AWS::Cognito::UserPool`
   Resource. Real CloudFormation configures both in a `SetUserPoolMfaConfig` call once the pool
   exists, and this deploys them the same way, so a stack declaring passkeys needs
-  `cognito-idp:SetUserPoolMfaConfig` as well as `cognito-idp:CreateUserPool`.
+  `cognito-idp:SetUserPoolMfaConfig` as well as `cognito-idp:CreateUserPool`. A relying party ID is
+  a domain of between one and 127 characters, and one outside that is refused.
 - `AccountRecoverySetting` is recorded and reported back by `DescribeUserPool`, and no code reads
   it. Any mechanisms Cognito has are accepted, in any order, and a setting outside the shape Cognito
   states is refused. `ForgotPassword` picks its destination from the pool's `AutoVerifiedAttributes`

--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -4293,8 +4293,10 @@ Current documented limitations:
   `SmsConfiguration` inside the latter is refused, in the same words `CreateUserPool` refuses the
   pool's own. No message is delivered here, and the IAM role Cognito would assume to send one is
   never assumed. `EmailMfaConfiguration` is refused because a pool here has no `EmailConfiguration`
-  to send that message with, and `WebAuthnConfiguration` because a passkey is presented through the
-  `USER_AUTH` flow, itself refused as a flow of its own.
+  to send that message with. A `WebAuthnConfiguration` is recorded and reported back by
+  `GetUserPoolMfaConfig`, and nothing reads it. Its two values decide what a passkey means rather
+  than how a sign-in runs, and presenting a passkey goes through the `USER_AUTH` flow, itself
+  refused as a flow of its own.
 - `AssociateSoftwareToken` and `VerifySoftwareToken` take an `AccessToken` and refuse a `Session`,
   because the `MFA_SETUP` challenge that would issue one is outside the simulation. A
   `FriendlyDeviceName` is refused for the same kind of reason. Device tracking is outside the
@@ -4366,8 +4368,18 @@ Current documented limitations:
 - Unsimulated `CreateUserPool` inputs are refused, never ignored: `AliasAttributes`,
   `UsernameConfiguration`, `UserAttributeUpdateSettings`, `DeviceConfiguration`, `UserPoolAddOns`,
   `KeyConfiguration`, `IssuerConfiguration`, `UserPoolTags`, the email and SMS configurations, an
-  `SmsAuthenticationMessage`, a `UserPoolTier` other than `ESSENTIALS`, a `SignInPolicy`, and a
+  `SmsAuthenticationMessage`, a `UserPoolTier` other than `ESSENTIALS`, and a
   `PasswordHistorySize`.
+- `Policies.SignInPolicy` is recorded and reported back by `DescribeUserPool`. The four factor names
+  Cognito accepts are `PASSWORD`, `EMAIL_OTP`, `SMS_OTP` and `WEB_AUTHN`, and `WEB_AUTHN` on its own
+  is refused, as AWS states it must be accompanied by at least one other option. Nothing here
+  presents a factor other than a password. Every other one is reached through the `USER_AUTH` flow,
+  which is refused by name, so a pool that allows passkeys deploys and describes itself the way the
+  deployed pool does while a passkey sign-in is refused where a sign-in asks for it.
+- `WebAuthnRelyingPartyID` and `WebAuthnUserVerification` deploy from an `AWS::Cognito::UserPool`
+  Resource. Real CloudFormation configures both in a `SetUserPoolMfaConfig` call once the pool
+  exists, and this deploys them the same way, so a stack declaring passkeys needs
+  `cognito-idp:SetUserPoolMfaConfig` as well as `cognito-idp:CreateUserPool`.
 - `AccountRecoverySetting` is recorded and reported back by `DescribeUserPool`, and no code reads
   it. Any mechanisms Cognito has are accepted, in any order, and a setting outside the shape Cognito
   states is refused. `ForgotPassword` picks its destination from the pool's `AutoVerifiedAttributes`

--- a/src/service/cognito/cfn/sim-cfn-cognito-passkeys.iso.test.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-passkeys.iso.test.ts
@@ -1,0 +1,135 @@
+import {
+  ConfirmSignUpCommand,
+  DescribeUserPoolCommand,
+  GetUserPoolMfaConfigCommand,
+  InitiateAuthCommand,
+  SignUpCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertObjectMatches,
+  assertNonNullable,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  deploySuccess,
+  simAwsInEuWest2,
+} from "../../../../test/cognito/cfn-deploy.js";
+
+const password = "Sup3rSecret!";
+
+/**
+ * The AWS::Cognito::UserPool properties `aws-cdk-lib` 2.264.0 emits for a
+ * `UserPool` construct with `signInPolicy`, `passkeyRelyingPartyId` and
+ * `passkeyUserVerification` set, alongside an app client whose `authFlows`
+ * include `user`.
+ *
+ * That is the stack AWS asks for under "Protect other secrets", where the best
+ * practice is passwordless authentication with WebAuthn passkeys. The relying
+ * party ID is the apex rather than the pool's own domain, because a passkey
+ * authenticates for the name it was registered against and the hosts under it.
+ */
+const passkeyPoolResources = {
+  SiteUserPool: {
+    Type: "AWS::Cognito::UserPool",
+    Properties: {
+      UserPoolName: "myapp-users",
+      AdminCreateUserConfig: { AllowAdminCreateUserOnly: false },
+      AutoVerifiedAttributes: ["email"],
+      MfaConfiguration: "OPTIONAL",
+      EnabledMfas: ["SOFTWARE_TOKEN_MFA"],
+      Policies: {
+        SignInPolicy: { AllowedFirstAuthFactors: ["PASSWORD", "WEB_AUTHN"] },
+      },
+      WebAuthnRelyingPartyID: "example.com",
+      WebAuthnUserVerification: "required",
+    },
+  },
+  SiteUserPoolClient: {
+    Type: "AWS::Cognito::UserPoolClient",
+    Properties: {
+      UserPoolId: { Ref: "SiteUserPool" },
+      ClientName: "web",
+      ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH", "ALLOW_USER_AUTH"],
+    },
+  },
+};
+
+const passkeyPoolOutputs = {
+  PoolId: { Value: { Ref: "SiteUserPool" } },
+  ClientId: { Value: { Ref: "SiteUserPoolClient" } },
+};
+
+describe("Cognito CloudFormation user pool passkeys", () => {
+  it("deploys a pool that allows passkeys and reports how it registers them", async () => {
+    // Given a stack whose pool allows a passkey beside a password.
+    const simAws = simAwsInEuWest2();
+
+    // When it is deployed.
+    const stack = await deploySuccess(
+      simAws,
+      passkeyPoolResources,
+      passkeyPoolOutputs,
+    );
+
+    // Then the pool deployed, rather than one passkey property taking the
+    // whole stack down, and nothing was created without.
+    const userPoolId = stack.outputs.get("PoolId")?.value;
+    const clientId = stack.outputs.get("ClientId")?.value;
+    assertTypeString(userPoolId);
+    assertTypeString(clientId);
+    assertArrayLength(stack.ignoredProperties, 0);
+
+    // And the pool reports the factors it allows at the first prompt.
+    const cognito = simAws.cognitoIdentityProvider();
+    const described = await cognito.describeUserPool(
+      new DescribeUserPoolCommand({ UserPoolId: userPoolId }),
+    );
+    assertArrayEquals(
+      described.UserPool?.Policies?.SignInPolicy?.AllowedFirstAuthFactors,
+      ["PASSWORD", "WEB_AUTHN"],
+    );
+
+    // And it reports how a passkey would be registered, which real
+    // CloudFormation configures in a second call once the pool exists.
+    const mfa = await cognito.getUserPoolMfaConfig(
+      new GetUserPoolMfaConfigCommand({ UserPoolId: userPoolId }),
+    );
+    assertObjectMatches(mfa.WebAuthnConfiguration, {
+      RelyingPartyId: "example.com",
+      UserVerification: "required",
+    });
+
+    // And the password half of that policy goes on working: a user signs
+    // itself up, confirms, and signs in.
+    await cognito.signUp(
+      new SignUpCommand({
+        ClientId: clientId,
+        Username: "alice",
+        Password: password,
+        UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+      }),
+    );
+    await cognito.confirmSignUp(
+      new ConfirmSignUpCommand({
+        ClientId: clientId,
+        Username: "alice",
+        ConfirmationCode: cognito
+          .userPool(userPoolId)
+          .confirmationCode("alice"),
+      }),
+    );
+
+    const signedIn = await cognito.initiateAuth(
+      new InitiateAuthCommand({
+        ClientId: clientId,
+        AuthFlow: "USER_PASSWORD_AUTH",
+        AuthParameters: { USERNAME: "alice", PASSWORD: password },
+      }),
+    );
+    assertNonNullable(signedIn.AuthenticationResult?.AccessToken);
+  });
+});

--- a/src/service/cognito/cfn/sim-cfn-cognito-properties.iso.test.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-properties.iso.test.ts
@@ -84,8 +84,10 @@ describe("Cognito CloudFormation property shapes", () => {
     assertIdentical(pool.findGroup("admins")?.precedence, 5);
   });
 
-  it("passes a sign-in policy through to the refusal that explains it", async () => {
-    // Given a template asking for a pool that chooses its first auth factor.
+  it("passes a factor name the pool refuses through to that refusal", async () => {
+    // Given a template naming a first auth factor Cognito does not have. The
+    // pool is what checks the names, so a template and an SDK caller are held
+    // to one rule.
     const simAws = simAwsInEuWest2();
 
     // When it is deployed.
@@ -95,7 +97,7 @@ describe("Cognito CloudFormation property shapes", () => {
         Properties: {
           UserPoolName: "myapp-users",
           Policies: {
-            SignInPolicy: { AllowedFirstAuthFactors: ["PASSWORD"] },
+            SignInPolicy: { AllowedFirstAuthFactors: ["FINGER_CROSSING"] },
           },
         },
       },
@@ -105,7 +107,8 @@ describe("Cognito CloudFormation property shapes", () => {
     // property being dropped on the way there.
     assertStringIncludes(
       error.message,
-      "CreateUserPool Policies SignInPolicy is not simulated",
+      "AllowedFirstAuthFactors 'FINGER_CROSSING' is not a Cognito first " +
+        "authentication factor",
     );
   });
 

--- a/src/service/cognito/cfn/user-pool/sim-cfn-cognito-sign-in-policy.ts
+++ b/src/service/cognito/cfn/user-pool/sim-cfn-cognito-sign-in-policy.ts
@@ -1,10 +1,10 @@
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
-import type { SimCognitoSignInPolicyType } from "../../user-pool/sim-cognito-password-policy.js";
+import type { SimCognitoSignInPolicyType } from "../../user-pool/sim-cognito-sign-in-policy.js";
 import type { SimCfnCognitoPropertyParser } from "../sim-cfn-cognito-property-parser.js";
 
 /**
- * The `SignInPolicy` fields, which reach CreateUserPool to be refused there.
+ * The `SignInPolicy` fields this simulation reads, which are all of them.
  */
 const modelledFields = ["AllowedFirstAuthFactors"];
 
@@ -14,10 +14,11 @@ interface SimCfnCognitoSignInPolicyProperties {
 }
 
 /**
- * Reads the `Policies SignInPolicy` of an AWS::Cognito::UserPool Resource.
+ * Reads the `Policies SignInPolicy` of an AWS::Cognito::UserPool Resource
+ * into the shape CreateUserPool takes.
  *
- * Nothing here chooses a first authentication factor, so this is read only so
- * that CreateUserPool receives it and refuses it in the words that say why.
+ * The factor names are checked by the pool rather than here, so a template and
+ * an SDK caller are held to the same rule in the same words.
  */
 export class SimCfnCognitoSignInPolicy {
   private readonly resource: SimCfnResource;

--- a/src/service/cognito/cfn/user-pool/sim-cfn-cognito-user-pool-mfa.ts
+++ b/src/service/cognito/cfn/user-pool/sim-cfn-cognito-user-pool-mfa.ts
@@ -4,6 +4,7 @@ import type {
   SimCfnTemplateValueRecord,
 } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimSetUserPoolMfaConfigCommandInput } from "../../command/user-pool/user-pool-mfa.command.js";
+import type { SimCognitoWebAuthnConfigurationType } from "../../user-pool/mfa/sim-cognito-web-authn-configuration.js";
 import type { SimCfnCognitoPropertyParser } from "../sim-cfn-cognito-property-parser.js";
 
 /**
@@ -16,7 +17,7 @@ const enabledMfaValues = ["SMS_MFA", "SOFTWARE_TOKEN_MFA", "EMAIL_OTP"];
  */
 type SimCfnCognitoMfaFactors = Omit<
   SimSetUserPoolMfaConfigCommandInput,
-  "UserPoolId" | "MfaConfiguration"
+  "UserPoolId" | "MfaConfiguration" | "WebAuthnConfiguration"
 >;
 
 interface SimCfnCognitoUserPoolMfaProperties {
@@ -38,6 +39,11 @@ interface SimCfnCognitoUserPoolMfaProperties {
  * list into those configurations is what lets `SetUserPoolMfaConfig` decide
  * which of them are simulated, so the two factors this simulation cannot
  * deliver a message for are refused in one place rather than two.
+ *
+ * `WebAuthnRelyingPartyID` and `WebAuthnUserVerification` travel the same
+ * way. CloudFormation carries them as two flat properties of the pool and the
+ * Cognito API takes them as one `WebAuthnConfiguration`, so they are gathered
+ * here into the call that configures them.
  */
 export class SimCfnCognitoUserPoolMfa {
   private readonly resource: SimCfnResource;
@@ -63,8 +69,13 @@ export class SimCfnCognitoUserPoolMfa {
       "MfaConfiguration",
     );
     const factors = this.factors(properties["EnabledMfas"]);
+    const webAuthn = this.webAuthn(properties);
 
-    if (configuration === undefined && Object.keys(factors).length === 0) {
+    if (
+      configuration === undefined &&
+      webAuthn === undefined &&
+      Object.keys(factors).length === 0
+    ) {
       return undefined;
     }
 
@@ -72,6 +83,40 @@ export class SimCfnCognitoUserPoolMfa {
       UserPoolId: userPoolId,
       ...(configuration !== undefined && { MfaConfiguration: configuration }),
       ...factors,
+      ...(webAuthn !== undefined && { WebAuthnConfiguration: webAuthn }),
+    };
+  }
+
+  /**
+   * How the template asks for passkeys to be registered, or nothing where it
+   * names neither property.
+   *
+   * The user verification value is checked by the pool rather than here, so a
+   * template and an SDK caller are refused in the same words.
+   */
+  private webAuthn(
+    properties: SimCfnTemplateValueRecord,
+  ): SimCognitoWebAuthnConfigurationType | undefined {
+    const relyingPartyId = this.propertyParser.optionalString(
+      this.resource,
+      properties["WebAuthnRelyingPartyID"],
+      "WebAuthnRelyingPartyID",
+    );
+    const userVerification = this.propertyParser.optionalString(
+      this.resource,
+      properties["WebAuthnUserVerification"],
+      "WebAuthnUserVerification",
+    );
+
+    if (relyingPartyId === undefined && userVerification === undefined) {
+      return undefined;
+    }
+
+    return {
+      ...(relyingPartyId !== undefined && { RelyingPartyId: relyingPartyId }),
+      ...(userVerification !== undefined && {
+        UserVerification: userVerification,
+      }),
     };
   }
 

--- a/src/service/cognito/cfn/user-pool/sim-cfn-cognito-user-pool-properties.ts
+++ b/src/service/cognito/cfn/user-pool/sim-cfn-cognito-user-pool-properties.ts
@@ -21,6 +21,13 @@ import { SimCfnCognitoPolicies } from "./sim-cfn-cognito-policies.js";
  * CloudFormation sets a pool's MFA in a SetUserPoolMfaConfig call after the
  * pool exists, and this deploys them the same way.
  *
+ * `WebAuthnRelyingPartyID` and `WebAuthnUserVerification` reach the pool
+ * through that same second call, which is where the Cognito API takes them.
+ * They decide which hosts a passkey authenticates for and whether an
+ * authenticator that checks nobody may register one, and a pool that reports
+ * them describes itself the way the deployed pool does. No passkey is
+ * registered or presented here.
+ *
  * `UserPoolTier` is here because CreateUserPool accepts it at its AWS default
  * and refuses it otherwise, in words that say why. A CDK stack states it
  * routinely, and a pool created without it would be reported as behaving
@@ -64,6 +71,8 @@ const simulatedProperties = [
   "LambdaConfig",
   "MfaConfiguration",
   "EnabledMfas",
+  "WebAuthnRelyingPartyID",
+  "WebAuthnUserVerification",
   "UserPoolTier",
   "AdminCreateUserConfig",
   "AutoVerifiedAttributes",

--- a/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-options.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-options.ts
@@ -17,6 +17,11 @@ import type { SimCognitoUserPoolCommandInput } from "./user-pool.command.js";
  * and reports it back, and the sign-in that would have to answer a challenge
  * is what refuses instead, where the refusal can say what it was that could
  * not be done.
+ *
+ * `Policies SignInPolicy` is absent for the same reason. A pool records the
+ * factors it allows at the first prompt and reports them back, and every
+ * factor beside a password is presented through the `USER_AUTH` flow, which
+ * `SimCognitoAuthFlows` refuses by name. See `SimCognitoSignInPolicy`.
  */
 export class SimCognitoUnsimulatedUserPoolOptions {
   private readonly unsimulated: SimCognitoUnsimulatedInput;
@@ -38,11 +43,6 @@ export class SimCognitoUnsimulatedUserPoolOptions {
       input.UserPoolTier,
       "ESSENTIALS",
       "the Lite and Plus feature plans",
-    );
-    this.unsimulated.refuse(
-      "Policies SignInPolicy",
-      input.Policies?.SignInPolicy,
-      "choosing which factors a user may sign in with first",
     );
     this.unsimulated.refuse(
       "Policies PasswordPolicy PasswordHistorySize",

--- a/src/service/cognito/command/user-pool/sim-cognito-update-user-pool-validation.iso.test.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-update-user-pool-validation.iso.test.ts
@@ -41,13 +41,6 @@ const refusedInputs: readonly RefusedInput[] = [
     says: "the Lite and Plus feature plans",
   },
   {
-    label: "SignInPolicy",
-    input: {
-      Policies: { SignInPolicy: { AllowedFirstAuthFactors: ["EMAIL_OTP"] } },
-    },
-    says: "which factors a user may sign in with first",
-  },
-  {
     label: "PasswordHistorySize",
     input: { Policies: { PasswordPolicy: { PasswordHistorySize: 3 } } },
     says: "a password the user has used before",

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-mfa-commands.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-mfa-commands.ts
@@ -103,9 +103,13 @@ export class SimCognitoUserPoolMfaCommands {
    *
    * A pool here has no `EmailConfiguration` either, because `CreateUserPool`
    * refuses that, so real Cognito would refuse a code sent by email on a pool
-   * built the same way. A passkey is presented through the `USER_AUTH` flow,
-   * which is refused as a flow of its own, so a pool configured for one here
-   * would never be asked for it.
+   * built the same way.
+   *
+   * A `WebAuthnConfiguration` is accepted and recorded rather than refused.
+   * The two values in it decide what a passkey means rather than how a
+   * sign-in runs, and a pool that reports them describes itself the way the
+   * deployed pool does. Presenting a passkey goes through the `USER_AUTH`
+   * flow, which is refused where a sign-in asks for it.
    */
   private refuseUnsimulatedFactors(
     input: SimSetUserPoolMfaConfigCommandInput,
@@ -120,11 +124,6 @@ export class SimCognitoUserPoolMfaCommands {
       "EmailMfaConfiguration",
       input.EmailMfaConfiguration,
       "a second factor sent by email, which needs the pool's EmailConfiguration",
-    );
-    this.unsimulated.refuse(
-      "WebAuthnConfiguration",
-      input.WebAuthnConfiguration,
-      "signing in with a passkey, which the unsimulated USER_AUTH flow presents",
     );
   }
 }

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-mfa.iso.test.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-mfa.iso.test.ts
@@ -310,26 +310,6 @@ describe("sim Cognito user pool MFA configuration", () => {
     assertStringIncludes(email.message, "EmailConfiguration");
   });
 
-  it("refuses a passkey, which no flow here would ask for", async () => {
-    // Given a pool. A passkey is presented through the USER_AUTH flow, which
-    // this simulation refuses as a flow of its own.
-    const { cognito, userPoolId } = await poolWithMfa();
-
-    // When the pool is configured for one.
-    const error = await assertThrowsErrorAsync(async () => {
-      await cognito.setUserPoolMfaConfig(
-        new SetUserPoolMfaConfigCommand({
-          UserPoolId: userPoolId,
-          MfaConfiguration: "OPTIONAL",
-          WebAuthnConfiguration: { RelyingPartyId: "example.com" },
-        }),
-      );
-    });
-
-    // Then it is refused rather than accepted and never asked for.
-    assertStringIncludes(error.message, "signing in with a passkey");
-  });
-
   it("refuses a request naming no pool", async () => {
     // Given simulated Cognito.
     const cognito = new SimAws().cognitoIdentityProvider();

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-validation.iso.test.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-validation.iso.test.ts
@@ -34,13 +34,6 @@ const refusedInputs: readonly RefusedInput[] = [
     says: "the Lite and Plus feature plans",
   },
   {
-    label: "SignInPolicy",
-    input: {
-      Policies: { SignInPolicy: { AllowedFirstAuthFactors: ["EMAIL_OTP"] } },
-    },
-    says: "which factors a user may sign in with first",
-  },
-  {
     label: "PasswordHistorySize",
     input: { Policies: { PasswordPolicy: { PasswordHistorySize: 3 } } },
     says: "a password the user has used before",

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-view.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-view.ts
@@ -21,6 +21,10 @@ export class SimCognitoUserPoolView {
    * `LambdaConfig` is reported only by a pool that was created with one, and
    * carries the triggers that pool runs.
    *
+   * `Policies` carries the pool's `SignInPolicy` only where it was created
+   * with one, as real Cognito reports it. A pool that named no policy signs
+   * its users in with a password.
+   *
    * `MfaConfiguration` is what the pool was asked for, and no pool here
    * challenges for a second factor whatever it says. Which factors a pool
    * offers is not reported here on real Cognito either:
@@ -42,12 +46,17 @@ export class SimCognitoUserPoolView {
    * it is what decides whether `SignUp` is allowed at all.
    */
   describe(pool: SimCognitoUserPool): SimCognitoUserPoolType {
+    const signInPolicy = pool.settings.signInPolicy.toOutput();
+
     return {
       Id: pool.id,
       Name: pool.name,
       Arn: pool.arn.value,
       AccountRecoverySetting: pool.settings.accountRecovery.toOutput(),
-      Policies: { PasswordPolicy: pool.settings.passwordPolicy.toOutput() },
+      Policies: {
+        PasswordPolicy: pool.settings.passwordPolicy.toOutput(),
+        ...(signInPolicy !== undefined && { SignInPolicy: signInPolicy }),
+      },
       DeletionProtection: pool.settings.deletionProtection.value,
       LambdaConfig: pool.settings.lambdaConfig.toOutput(),
       MfaConfiguration: pool.settings.mfa.configuration.value,

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-web-authn.iso.test.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-web-authn.iso.test.ts
@@ -1,0 +1,121 @@
+import {
+  CreateUserPoolCommand,
+  GetUserPoolMfaConfigCommand,
+  SetUserPoolMfaConfigCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertObjectEquals,
+  assertObjectMatches,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
+
+interface SimCognitoWithPool {
+  readonly cognito: SimCognitoIdentityProvider;
+  readonly userPoolId: string;
+}
+
+/**
+ * How a pool registers passkeys, which is the half of a passkey that is
+ * configuration rather than a sign-in.
+ *
+ * Both values arrive through `SetUserPoolMfaConfig`, because that is where the
+ * Cognito API takes them, and a pool records them and reports them back the
+ * way it records its MFA configuration. Nothing here registers or presents a
+ * passkey. Both go through the `USER_AUTH` flow, which is refused where a
+ * sign-in asks for it, and `sim-cognito-sign-in-policy.iso.test.ts` is where
+ * that refusal is covered.
+ */
+describe("sim Cognito user pool passkey registration", () => {
+  async function poolWithMfa(): Promise<SimCognitoWithPool> {
+    const cognito = new SimAws().cognitoIdentityProvider();
+    const created = await cognito.createUserPool(
+      new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+    );
+    const userPoolId = created.UserPool?.Id;
+
+    assertTypeString(userPoolId);
+
+    return { cognito, userPoolId };
+  }
+
+  it("records how a passkey would be registered", async () => {
+    // Given a pool. Nothing here registers or presents a passkey, and these
+    // two values are what a passkey would mean rather than how a sign-in runs.
+    const { cognito, userPoolId } = await poolWithMfa();
+
+    // When the pool is configured for one.
+    await cognito.setUserPoolMfaConfig(
+      new SetUserPoolMfaConfigCommand({
+        UserPoolId: userPoolId,
+        MfaConfiguration: "OPTIONAL",
+        WebAuthnConfiguration: {
+          RelyingPartyId: "example.com",
+          UserVerification: "required",
+        },
+      }),
+    );
+
+    // Then the pool reports it back, the way the deployed pool would.
+    const read = await cognito.getUserPoolMfaConfig(
+      new GetUserPoolMfaConfigCommand({ UserPoolId: userPoolId }),
+    );
+
+    assertObjectMatches(read.WebAuthnConfiguration, {
+      RelyingPartyId: "example.com",
+      UserVerification: "required",
+    });
+  });
+
+  it("records a relying party ID on its own", async () => {
+    // Given a pool. Cognito defaults the user verification preference, and a
+    // template that names only the relying party ID is what a CDK `UserPool`
+    // with `passkeyRelyingPartyId` and no `passkeyUserVerification` emits.
+    const { cognito, userPoolId } = await poolWithMfa();
+
+    // When it is configured with that one value.
+    await cognito.setUserPoolMfaConfig(
+      new SetUserPoolMfaConfigCommand({
+        UserPoolId: userPoolId,
+        MfaConfiguration: "OPTIONAL",
+        WebAuthnConfiguration: { RelyingPartyId: "example.com" },
+      }),
+    );
+
+    // Then the pool reports the ID, and no preference it was never given.
+    const read = await cognito.getUserPoolMfaConfig(
+      new GetUserPoolMfaConfigCommand({ UserPoolId: userPoolId }),
+    );
+
+    assertObjectEquals(read.WebAuthnConfiguration, {
+      RelyingPartyId: "example.com",
+    });
+  });
+
+  it("refuses a user verification preference Cognito does not have", async () => {
+    // Given a pool.
+    const { cognito, userPoolId } = await poolWithMfa();
+
+    // When it is configured to register passkeys under a preference that is
+    // neither of the two Cognito accepts. The SDK's own types disallow it, so
+    // the request is written the way it reaches the simulator.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.setUserPoolMfaConfig({
+        input: {
+          UserPoolId: userPoolId,
+          MfaConfiguration: "OPTIONAL",
+          WebAuthnConfiguration: { UserVerification: "whenever" },
+        },
+      });
+    });
+
+    // Then it is refused naming the two.
+    assertStringIncludes(error.message, "UserVerification 'whenever'");
+    assertStringIncludes(error.message, "required or preferred");
+  });
+});

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-web-authn.iso.test.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-web-authn.iso.test.ts
@@ -4,6 +4,7 @@ import {
   SetUserPoolMfaConfigCommand,
 } from "@aws-sdk/client-cognito-identity-provider";
 import {
+  assertInstanceOf,
   assertObjectEquals,
   assertObjectMatches,
   assertStringIncludes,
@@ -13,12 +14,32 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
+import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
 import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
 
 interface SimCognitoWithPool {
   readonly cognito: SimCognitoIdentityProvider;
   readonly userPoolId: string;
 }
+
+/**
+ * A relying party ID a request could name that real Cognito refuses. It takes
+ * a domain of between one and 127 characters.
+ */
+interface RefusedRelyingParty {
+  readonly label: string;
+  readonly relyingPartyId: string;
+}
+
+const longestRelyingPartyId = `${"a".repeat(123)}.com`;
+
+const refusedRelyingParties: readonly RefusedRelyingParty[] = [
+  { label: "no relying party at all", relyingPartyId: "" },
+  {
+    label: "a relying party longer than Cognito takes",
+    relyingPartyId: `a${longestRelyingPartyId}`,
+  },
+];
 
 /**
  * How a pool registers passkeys, which is the half of a passkey that is
@@ -96,6 +117,58 @@ describe("sim Cognito user pool passkey registration", () => {
       RelyingPartyId: "example.com",
     });
   });
+
+  it("records the longest relying party ID Cognito takes", async () => {
+    // Given a pool. 127 characters is the limit, so the domain of exactly that
+    // length is the one either side of the limit has to be told apart from.
+    const { cognito, userPoolId } = await poolWithMfa();
+
+    // When it is configured with that domain.
+    await cognito.setUserPoolMfaConfig(
+      new SetUserPoolMfaConfigCommand({
+        UserPoolId: userPoolId,
+        MfaConfiguration: "OPTIONAL",
+        WebAuthnConfiguration: { RelyingPartyId: longestRelyingPartyId },
+      }),
+    );
+
+    // Then the pool records it rather than refusing it.
+    const read = await cognito.getUserPoolMfaConfig(
+      new GetUserPoolMfaConfigCommand({ UserPoolId: userPoolId }),
+    );
+
+    assertObjectEquals(read.WebAuthnConfiguration, {
+      RelyingPartyId: longestRelyingPartyId,
+    });
+  });
+
+  it.each(refusedRelyingParties)(
+    "refuses $label",
+    async ({ relyingPartyId }) => {
+      // Given a pool.
+      const { cognito, userPoolId } = await poolWithMfa();
+
+      // When it is configured to register passkeys against that domain, which
+      // is no domain a passkey provider could trust.
+      const error = await assertThrowsErrorAsync(async () => {
+        await cognito.setUserPoolMfaConfig(
+          new SetUserPoolMfaConfigCommand({
+            UserPoolId: userPoolId,
+            MfaConfiguration: "OPTIONAL",
+            WebAuthnConfiguration: { RelyingPartyId: relyingPartyId },
+          }),
+        );
+      });
+
+      // Then it is refused as an invalid parameter, saying what a relying
+      // party ID has to be.
+      assertInstanceOf(error, SimCognitoInvalidParameterException);
+      assertStringIncludes(
+        error.message,
+        "RelyingPartyId must be between 1 and 127 characters long",
+      );
+    },
+  );
 
   it("refuses a user verification preference Cognito does not have", async () => {
     // Given a pool.

--- a/src/service/cognito/command/user-pool/user-pool-mfa.command.ts
+++ b/src/service/cognito/command/user-pool/user-pool-mfa.command.ts
@@ -12,15 +12,15 @@ import type { SimCognitoUserPoolMfaType } from "../../user-pool/mfa/sim-cognito-
  * message is delivered here, so the IAM role that would send one is never
  * assumed.
  *
- * `WebAuthnConfiguration` is refused because a passkey is presented through
- * the `USER_AUTH` flow, which this simulation refuses as a flow of its own.
+ * `WebAuthnConfiguration` is read and recorded. Nothing here registers or
+ * presents a passkey, and the refusal for that is on the `USER_AUTH` flow
+ * rather than on the pool's configuration.
  *
  * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cognito-identity-provider/command/SetUserPoolMfaConfigCommand/
  */
 export interface SimSetUserPoolMfaConfigCommandInput extends SimCognitoUserPoolMfaType {
   readonly UserPoolId?: string | undefined;
   readonly EmailMfaConfiguration?: object | undefined;
-  readonly WebAuthnConfiguration?: object | undefined;
 }
 
 /**

--- a/src/service/cognito/index.ts
+++ b/src/service/cognito/index.ts
@@ -29,13 +29,22 @@ export {
   type SimCognitoSoftwareTokenMfaConfigType,
   type SimCognitoUserPoolMfaType,
 } from "./user-pool/mfa/sim-cognito-user-pool-mfa.js";
+export {
+  SimCognitoWebAuthnConfiguration,
+  type SimCognitoWebAuthnConfigurationType,
+  type SimCognitoWebAuthnUserVerification,
+} from "./user-pool/mfa/sim-cognito-web-authn-configuration.js";
 export { SimCognitoAutoVerifiedAttributes } from "./user-pool/sim-cognito-auto-verified-attributes.js";
 export {
   SimCognitoPasswordPolicy,
   type SimCognitoPasswordPolicyType,
-  type SimCognitoSignInPolicyType,
   type SimCognitoUserPoolPoliciesType,
 } from "./user-pool/sim-cognito-password-policy.js";
+export {
+  SimCognitoSignInPolicy,
+  type SimCognitoFirstAuthFactor,
+  type SimCognitoSignInPolicyType,
+} from "./user-pool/sim-cognito-sign-in-policy.js";
 export { SimCognitoUserPoolClient } from "./user-pool/client/sim-cognito-user-pool-client.js";
 export type { SimCognitoUserPoolClientId } from "./user-pool/client/sim-cognito-user-pool-client-id.js";
 export { SimCognitoExplicitAuthFlows } from "./user-pool/client/sim-cognito-explicit-auth-flows.js";

--- a/src/service/cognito/user-pool/mfa/sim-cognito-user-pool-mfa.ts
+++ b/src/service/cognito/user-pool/mfa/sim-cognito-user-pool-mfa.ts
@@ -3,6 +3,10 @@ import {
   simCognitoLongestSmsMessage,
 } from "../message/sim-cognito-verification-wording.js";
 import { SimCognitoMfaConfiguration } from "./sim-cognito-mfa-configuration.js";
+import {
+  SimCognitoWebAuthnConfiguration,
+  type SimCognitoWebAuthnConfigurationType,
+} from "./sim-cognito-web-authn-configuration.js";
 
 /**
  * Whether a pool offers a time-based one-time password as a second factor.
@@ -40,6 +44,19 @@ export interface SimCognitoUserPoolMfaType {
     | SimCognitoSoftwareTokenMfaConfigType
     | undefined;
   readonly SmsMfaConfiguration?: SimCognitoSmsMfaConfigType | undefined;
+
+  /**
+   * How the pool registers passkeys, which is the relying party ID they are
+   * registered against and whether an authenticator has to check who is
+   * holding it.
+   *
+   * It sits among the MFA settings because that is where real Cognito puts
+   * it, and a passkey with user verification is what counts towards MFA
+   * there. Nothing here presents one.
+   */
+  readonly WebAuthnConfiguration?:
+    | SimCognitoWebAuthnConfigurationType
+    | undefined;
 }
 
 /**
@@ -56,6 +73,22 @@ function softwareTokenIn(
   }
 
   return requested.Enabled ?? false;
+}
+
+/**
+ * How a request asked for passkeys to be registered, and nothing where it
+ * configured them at all.
+ */
+function webAuthnIn(
+  input: SimCognitoUserPoolMfaType,
+): SimCognitoWebAuthnConfiguration | undefined {
+  const requested = input.WebAuthnConfiguration;
+
+  if (requested === undefined) {
+    return undefined;
+  }
+
+  return new SimCognitoWebAuthnConfiguration(requested);
 }
 
 /**
@@ -120,6 +153,12 @@ export class SimCognitoUserPoolMfa {
    */
   #sms: SimCognitoSmsMfaConfigType | undefined;
 
+  /**
+   * How the pool would register a passkey, where a request configured that at
+   * all.
+   */
+  #webAuthn: SimCognitoWebAuthnConfiguration | undefined;
+
   constructor(configuration: SimCognitoMfaConfiguration) {
     this.#configuration = configuration;
   }
@@ -144,6 +183,7 @@ export class SimCognitoUserPoolMfa {
     );
     this.#softwareToken = softwareTokenIn(input);
     this.#sms = smsIn(input);
+    this.#webAuthn = webAuthnIn(input);
   }
 
   /**
@@ -163,6 +203,15 @@ export class SimCognitoUserPoolMfa {
   keepFactorsOf(replaced: SimCognitoUserPoolMfa): void {
     this.#softwareToken = replaced.#softwareToken;
     this.#sms = replaced.#sms;
+    this.#webAuthn = replaced.#webAuthn;
+  }
+
+  /**
+   * How the pool registers passkeys, where a `SetUserPoolMfaConfig` request
+   * said. A pool no such request has reached has no answer to give.
+   */
+  get webAuthn(): SimCognitoWebAuthnConfiguration | undefined {
+    return this.#webAuthn;
   }
 
   /**
@@ -175,6 +224,9 @@ export class SimCognitoUserPoolMfa {
         SoftwareTokenMfaConfiguration: { Enabled: this.#softwareToken },
       }),
       ...(this.#sms !== undefined && { SmsMfaConfiguration: this.#sms }),
+      ...(this.#webAuthn !== undefined && {
+        WebAuthnConfiguration: this.#webAuthn.toOutput(),
+      }),
     };
   }
 }

--- a/src/service/cognito/user-pool/mfa/sim-cognito-web-authn-configuration.ts
+++ b/src/service/cognito/user-pool/mfa/sim-cognito-web-authn-configuration.ts
@@ -1,0 +1,89 @@
+import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
+
+/**
+ * How a pool registers passkeys, in the shape `SetUserPoolMfaConfig` and
+ * `GetUserPoolMfaConfig` carry it.
+ *
+ * https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_WebAuthnConfigurationType.html
+ */
+export interface SimCognitoWebAuthnConfigurationType {
+  readonly RelyingPartyId?: string | undefined;
+  readonly UserVerification?: string | undefined;
+}
+
+export type SimCognitoWebAuthnUserVerification = "required" | "preferred";
+
+const userVerificationValues: readonly SimCognitoWebAuthnUserVerification[] = [
+  "required",
+  "preferred",
+];
+
+/**
+ * The passkey configuration of one simulated user pool.
+ *
+ * Two values, both of which decide what a passkey means rather than how a
+ * sign-in runs. The relying party ID is the name a passkey is registered
+ * against, and it authenticates for that name and the hosts under it. The user
+ * verification preference decides whether an authenticator that checks nobody
+ * may register at all, and `required` is what makes a passkey count towards
+ * MFA on real Cognito.
+ *
+ * They arrive through `SetUserPoolMfaConfig` rather than `CreateUserPool`,
+ * which is why an `AWS::Cognito::UserPool` Resource carrying
+ * `WebAuthnRelyingPartyID` is deployed in two calls here as it is on real
+ * CloudFormation.
+ *
+ * Recorded and reported. No passkey is registered or presented in this
+ * simulation, because both go through the `USER_AUTH` flow that
+ * `SimCognitoAuthFlows` refuses by name.
+ */
+export class SimCognitoWebAuthnConfiguration {
+  public readonly relyingPartyId: string | undefined;
+  public readonly userVerification:
+    | SimCognitoWebAuthnUserVerification
+    | undefined;
+
+  constructor(configuration: SimCognitoWebAuthnConfigurationType) {
+    this.relyingPartyId = configuration.RelyingPartyId;
+    this.userVerification = SimCognitoWebAuthnConfiguration.verificationIn(
+      configuration.UserVerification,
+    );
+  }
+
+  private static verificationIn(
+    requested: string | undefined,
+  ): SimCognitoWebAuthnUserVerification | undefined {
+    if (requested === undefined) {
+      return undefined;
+    }
+
+    if (
+      !userVerificationValues.includes(
+        requested as SimCognitoWebAuthnUserVerification,
+      )
+    ) {
+      throw new SimCognitoInvalidParameterException(
+        `WebAuthnConfiguration UserVerification '${requested}' is not a ` +
+          `Cognito user verification preference: use one of ${userVerificationValues.join(
+            " or ",
+          )}`,
+      );
+    }
+
+    return requested as SimCognitoWebAuthnUserVerification;
+  }
+
+  /**
+   * The configuration as `GetUserPoolMfaConfig` reports it.
+   */
+  toOutput(): SimCognitoWebAuthnConfigurationType {
+    return {
+      ...(this.relyingPartyId !== undefined && {
+        RelyingPartyId: this.relyingPartyId,
+      }),
+      ...(this.userVerification !== undefined && {
+        UserVerification: this.userVerification,
+      }),
+    };
+  }
+}

--- a/src/service/cognito/user-pool/mfa/sim-cognito-web-authn-configuration.ts
+++ b/src/service/cognito/user-pool/mfa/sim-cognito-web-authn-configuration.ts
@@ -18,6 +18,8 @@ const userVerificationValues: readonly SimCognitoWebAuthnUserVerification[] = [
   "preferred",
 ];
 
+const relyingPartyIdLength = { least: 1, most: 127 };
+
 /**
  * The passkey configuration of one simulated user pool.
  *
@@ -44,10 +46,38 @@ export class SimCognitoWebAuthnConfiguration {
     | undefined;
 
   constructor(configuration: SimCognitoWebAuthnConfigurationType) {
-    this.relyingPartyId = configuration.RelyingPartyId;
+    this.relyingPartyId = SimCognitoWebAuthnConfiguration.relyingPartyIn(
+      configuration.RelyingPartyId,
+    );
     this.userVerification = SimCognitoWebAuthnConfiguration.verificationIn(
       configuration.UserVerification,
     );
+  }
+
+  /**
+   * A relying party ID is a domain, and Cognito takes one of between one and
+   * 127 characters. A pool configured with an empty one would register
+   * passkeys against nothing.
+   */
+  private static relyingPartyIn(
+    requested: string | undefined,
+  ): string | undefined {
+    if (requested === undefined) {
+      return undefined;
+    }
+
+    if (
+      requested.length < relyingPartyIdLength.least ||
+      requested.length > relyingPartyIdLength.most
+    ) {
+      throw new SimCognitoInvalidParameterException(
+        "WebAuthnConfiguration RelyingPartyId must be between " +
+          `${String(relyingPartyIdLength.least)} and ` +
+          `${String(relyingPartyIdLength.most)} characters long`,
+      );
+    }
+
+    return requested;
   }
 
   private static verificationIn(

--- a/src/service/cognito/user-pool/sim-cognito-password-policy.ts
+++ b/src/service/cognito/user-pool/sim-cognito-password-policy.ts
@@ -1,4 +1,5 @@
 import { SimCognitoInvalidParameterException } from "../error/sim-cognito.error.js";
+import type { SimCognitoSignInPolicyType } from "./sim-cognito-sign-in-policy.js";
 
 /**
  * A user pool password policy, in the shape Cognito reports it.
@@ -13,16 +14,6 @@ export interface SimCognitoPasswordPolicyType {
   readonly RequireSymbols?: boolean | undefined;
   readonly PasswordHistorySize?: number | undefined;
   readonly TemporaryPasswordValidityDays?: number | undefined;
-}
-
-/**
- * The sign-in policy of a user pool, which chooses the first factor a user
- * may authenticate with.
- *
- * https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_SignInPolicyType.html
- */
-export interface SimCognitoSignInPolicyType {
-  readonly AllowedFirstAuthFactors?: readonly string[] | undefined;
 }
 
 /**

--- a/src/service/cognito/user-pool/sim-cognito-sign-in-policy.iso.test.ts
+++ b/src/service/cognito/user-pool/sim-cognito-sign-in-policy.iso.test.ts
@@ -1,0 +1,196 @@
+import {
+  CreateUserPoolCommand,
+  CreateUserPoolClientCommand,
+  DescribeUserPoolCommand,
+  InitiateAuthCommand,
+  UpdateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import type { CreateUserPoolCommandInput } from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertArrayEquals,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertStringNotIncludes,
+  assertThrowsErrorAsync,
+  assertTypeString,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimCognitoInvalidParameterException } from "../error/sim-cognito.error.js";
+import type { SimCognitoIdentityProvider } from "../sim-cognito-identity-provider.js";
+
+/**
+ * A policy a request could name that real Cognito refuses, with what the
+ * refusal has to say about it.
+ */
+interface RefusedPolicy {
+  readonly label: string;
+  readonly factors: readonly string[];
+  readonly says: string;
+}
+
+const refusedPolicies: readonly RefusedPolicy[] = [
+  {
+    label: "a factor Cognito does not have",
+    factors: ["PASSWORD", "CARRIER_PIGEON"],
+    says: "'CARRIER_PIGEON' is not a Cognito first authentication factor",
+  },
+  {
+    label: "passkeys and nothing else",
+    factors: ["WEB_AUTHN"],
+    says: "WEB_AUTHN has to be accompanied by at least one other factor",
+  },
+  {
+    label: "no factor at all",
+    factors: [],
+    says: "must name at least one factor",
+  },
+];
+
+describe("sim Cognito sign-in policy", () => {
+  function simCognito(): SimCognitoIdentityProvider {
+    return new SimAws().cognitoIdentityProvider();
+  }
+
+  async function createdPoolId(
+    cognito: SimCognitoIdentityProvider,
+    input: Partial<CreateUserPoolCommandInput> = {},
+  ): Promise<string> {
+    const created = await cognito.createUserPool(
+      new CreateUserPoolCommand({ PoolName: "myapp-users", ...input }),
+    );
+    const userPoolId = created.UserPool?.Id;
+    assertTypeString(userPoolId);
+
+    return userPoolId;
+  }
+
+  async function describedFactors(
+    cognito: SimCognitoIdentityProvider,
+    userPoolId: string,
+  ): Promise<readonly string[] | undefined> {
+    const described = await cognito.describeUserPool(
+      new DescribeUserPoolCommand({ UserPoolId: userPoolId }),
+    );
+
+    return described.UserPool?.Policies?.SignInPolicy?.AllowedFirstAuthFactors;
+  }
+
+  it("creates a pool that allows a password and a passkey", async () => {
+    // Given simulated Cognito.
+    const cognito = simCognito();
+
+    // When a pool is created with the policy AWS asks for under "Protect
+    // other secrets", which is a password beside a passkey.
+    const userPoolId = await createdPoolId(cognito, {
+      Policies: {
+        SignInPolicy: { AllowedFirstAuthFactors: ["PASSWORD", "WEB_AUTHN"] },
+      },
+    });
+
+    // Then the pool reports both back, in the order the request listed them.
+    assertArrayEquals(await describedFactors(cognito, userPoolId), [
+      "PASSWORD",
+      "WEB_AUTHN",
+    ]);
+  });
+
+  it("reports no policy for a pool that named none", async () => {
+    // Given a pool created saying nothing about its first auth factors, which
+    // signs its users in with a password.
+    const cognito = simCognito();
+    const userPoolId = await createdPoolId(cognito);
+
+    // When it is described.
+    // Then it reports no sign-in policy, as real Cognito reports one.
+    assertUndefined(await describedFactors(cognito, userPoolId));
+  });
+
+  it("replaces the policy when the pool is updated", async () => {
+    // Given a pool that allows passkeys.
+    const cognito = simCognito();
+    const userPoolId = await createdPoolId(cognito, {
+      Policies: {
+        SignInPolicy: { AllowedFirstAuthFactors: ["PASSWORD", "WEB_AUTHN"] },
+      },
+    });
+
+    // When an update names a password alone, as it would to turn passkeys
+    // back off.
+    await cognito.updateUserPool(
+      new UpdateUserPoolCommand({
+        UserPoolId: userPoolId,
+        Policies: { SignInPolicy: { AllowedFirstAuthFactors: ["PASSWORD"] } },
+      }),
+    );
+
+    // Then the passkey has gone rather than the two being merged.
+    assertArrayEquals(await describedFactors(cognito, userPoolId), [
+      "PASSWORD",
+    ]);
+  });
+
+  it.each(refusedPolicies)("refuses $label", async ({ factors, says }) => {
+    // Given simulated Cognito.
+    const cognito = simCognito();
+
+    // When a pool is created with the policy. The SDK's own types allow none
+    // of these, so the request is written the way it reaches the simulator.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.createUserPool({
+        input: {
+          PoolName: "myapp-users",
+          Policies: { SignInPolicy: { AllowedFirstAuthFactors: factors } },
+        },
+      });
+    });
+
+    // Then it is refused as an invalid parameter, saying what was wrong with
+    // it, rather than a pool being created that signs nobody in.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, says);
+  });
+
+  /*
+   * The guard on everything above. A pool that allows passkeys deploys and
+   * describes itself, and nothing here can sign in with one. The refusal is on
+   * the flow every factor beside a password is presented through, so it says
+   * what could not be done rather than leaving a test to believe a passkey
+   * sign-in ran.
+   */
+  it("goes on refusing the flow those factors are presented through", async () => {
+    // Given a pool allowing passkeys, with a client that permits the flow.
+    const cognito = simCognito();
+    const userPoolId = await createdPoolId(cognito, {
+      Policies: {
+        SignInPolicy: { AllowedFirstAuthFactors: ["PASSWORD", "WEB_AUTHN"] },
+      },
+    });
+    const client = await cognito.createUserPoolClient(
+      new CreateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientName: "web",
+        ExplicitAuthFlows: ["ALLOW_USER_AUTH"],
+      }),
+    );
+
+    // When a sign-in asks for choice-based authentication.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.initiateAuth(
+        new InitiateAuthCommand({
+          ClientId: client.UserPoolClient?.ClientId,
+          AuthFlow: "USER_AUTH",
+          AuthParameters: { USERNAME: "someone@example.com" },
+        }),
+      );
+    });
+
+    // Then it is refused naming the flow, and the pool's own policy is left
+    // out of it.
+    assertStringIncludes(error.message, "'USER_AUTH' is not simulated");
+    assertStringIncludes(error.message, "choice-based sign-in");
+    assertStringNotIncludes(error.message, "SignInPolicy");
+  });
+});

--- a/src/service/cognito/user-pool/sim-cognito-sign-in-policy.iso.test.ts
+++ b/src/service/cognito/user-pool/sim-cognito-sign-in-policy.iso.test.ts
@@ -47,6 +47,23 @@ const refusedPolicies: readonly RefusedPolicy[] = [
     factors: [],
     says: "must name at least one factor",
   },
+  {
+    label: "passkeys standing in for their own companion",
+    factors: ["WEB_AUTHN", "WEB_AUTHN"],
+    says: "WEB_AUTHN has to be accompanied by at least one other factor",
+  },
+  {
+    label: "more factors than Cognito takes",
+    factors: [
+      "PASSWORD",
+      "EMAIL_OTP",
+      "SMS_OTP",
+      "WEB_AUTHN",
+      "PASSWORD",
+      "EMAIL_OTP",
+    ],
+    says: "must name no more than 5 factors",
+  },
 ];
 
 describe("sim Cognito sign-in policy", () => {

--- a/src/service/cognito/user-pool/sim-cognito-sign-in-policy.ts
+++ b/src/service/cognito/user-pool/sim-cognito-sign-in-policy.ts
@@ -1,0 +1,126 @@
+import { SimCognitoInvalidParameterException } from "../error/sim-cognito.error.js";
+
+/**
+ * The sign-in policy of a user pool, which chooses the factors a user may
+ * authenticate with first.
+ *
+ * https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_SignInPolicyType.html
+ */
+export interface SimCognitoSignInPolicyType {
+  readonly AllowedFirstAuthFactors?: readonly string[] | undefined;
+}
+
+/**
+ * A factor a user pool can offer at the first authentication prompt.
+ *
+ * `PASSWORD` covers both the plain-password and the SRP flows, which is what
+ * AWS says about the value.
+ */
+export type SimCognitoFirstAuthFactor =
+  | "PASSWORD"
+  | "EMAIL_OTP"
+  | "SMS_OTP"
+  | "WEB_AUTHN";
+
+const firstAuthFactors: readonly SimCognitoFirstAuthFactor[] = [
+  "PASSWORD",
+  "EMAIL_OTP",
+  "SMS_OTP",
+  "WEB_AUTHN",
+];
+
+/**
+ * The factors one simulated user pool allows at the first prompt.
+ *
+ * A pool created without a sign-in policy allows a password and says nothing
+ * about it, which is how real Cognito reports one. A pool created with a
+ * policy carries the factors it named, and reports them back under `Policies`.
+ *
+ * **Nothing here presents a factor other than a password.** The factors are
+ * recorded the way an `MfaConfiguration` is recorded, and the sign-in that
+ * would have to present one is where the refusal happens. Every factor beside
+ * `PASSWORD` is reached through the `USER_AUTH` flow, and
+ * `SimCognitoAuthFlows` refuses that flow by name. So a pool configured for
+ * passkeys here deploys, describes itself the way the deployed pool does, and
+ * refuses a passkey sign-in in words that say what could not be done.
+ *
+ * The validation is real Cognito's. The four factor names are the ones it
+ * accepts, and `WEB_AUTHN` on its own is refused because AWS states that it
+ * "must be accompanied by at least one other option".
+ */
+export class SimCognitoSignInPolicy {
+  /**
+   * The factors the policy named, in the order it named them, and nothing
+   * where the pool was created without a policy at all.
+   */
+  readonly #allowedFirstAuthFactors:
+    | readonly SimCognitoFirstAuthFactor[]
+    | undefined;
+
+  constructor(policy?: SimCognitoSignInPolicyType) {
+    const requested = policy?.AllowedFirstAuthFactors;
+
+    if (requested === undefined) {
+      this.#allowedFirstAuthFactors = undefined;
+      return;
+    }
+
+    this.#allowedFirstAuthFactors = SimCognitoSignInPolicy.factorsIn(requested);
+  }
+
+  private static factorsIn(
+    requested: readonly string[],
+  ): readonly SimCognitoFirstAuthFactor[] {
+    if (requested.length === 0) {
+      throw new SimCognitoInvalidParameterException(
+        "SignInPolicy AllowedFirstAuthFactors must name at least one factor: " +
+          `use one or more of ${firstAuthFactors.join(", ")}`,
+      );
+    }
+
+    const factors = requested.map((factor) => this.requireKnown(factor));
+
+    this.requireCompanionForPasskeys(factors);
+
+    return factors;
+  }
+
+  private static requireKnown(factor: string): SimCognitoFirstAuthFactor {
+    if (!firstAuthFactors.includes(factor as SimCognitoFirstAuthFactor)) {
+      throw new SimCognitoInvalidParameterException(
+        `SignInPolicy AllowedFirstAuthFactors '${factor}' is not a Cognito ` +
+          `first authentication factor: use one of ${firstAuthFactors.join(", ")}`,
+      );
+    }
+
+    return factor as SimCognitoFirstAuthFactor;
+  }
+
+  /**
+   * Refuse a policy offering passkeys and nothing else, as real Cognito
+   * refuses one. A passkey has to be registered from a session that already
+   * exists, so a pool with no other way in would have nobody able to register.
+   */
+  private static requireCompanionForPasskeys(
+    factors: readonly SimCognitoFirstAuthFactor[],
+  ): void {
+    if (factors.includes("WEB_AUTHN") && factors.length === 1) {
+      throw new SimCognitoInvalidParameterException(
+        "SignInPolicy AllowedFirstAuthFactors WEB_AUTHN has to be " +
+          "accompanied by at least one other factor",
+      );
+    }
+  }
+
+  /**
+   * The policy as Cognito reports it on the pool, and nothing where the pool
+   * was created without one.
+   */
+  toOutput(): SimCognitoSignInPolicyType | undefined {
+    if (this.#allowedFirstAuthFactors === undefined) {
+      return undefined;
+    }
+
+    return { AllowedFirstAuthFactors: [...this.#allowedFirstAuthFactors] };
+  }
+}

--- a/src/service/cognito/user-pool/sim-cognito-sign-in-policy.ts
+++ b/src/service/cognito/user-pool/sim-cognito-sign-in-policy.ts
@@ -29,6 +29,8 @@ const firstAuthFactors: readonly SimCognitoFirstAuthFactor[] = [
   "WEB_AUTHN",
 ];
 
+const mostFactors = 5;
+
 /**
  * The factors one simulated user pool allows at the first prompt.
  *
@@ -45,7 +47,8 @@ const firstAuthFactors: readonly SimCognitoFirstAuthFactor[] = [
  * refuses a passkey sign-in in words that say what could not be done.
  *
  * The validation is real Cognito's. The four factor names are the ones it
- * accepts, and `WEB_AUTHN` on its own is refused because AWS states that it
+ * accepts, a list may name five of them at most, and a policy offering
+ * passkeys and nothing else is refused because AWS states that `WEB_AUTHN`
  * "must be accompanied by at least one other option".
  */
 export class SimCognitoSignInPolicy {
@@ -71,6 +74,16 @@ export class SimCognitoSignInPolicy {
   private static factorsIn(
     requested: readonly string[],
   ): readonly SimCognitoFirstAuthFactor[] {
+    this.requireCount(requested);
+
+    const factors = requested.map((factor) => this.requireKnown(factor));
+
+    this.requireCompanionForPasskeys(factors);
+
+    return factors;
+  }
+
+  private static requireCount(requested: readonly string[]): void {
     if (requested.length === 0) {
       throw new SimCognitoInvalidParameterException(
         "SignInPolicy AllowedFirstAuthFactors must name at least one factor: " +
@@ -78,11 +91,12 @@ export class SimCognitoSignInPolicy {
       );
     }
 
-    const factors = requested.map((factor) => this.requireKnown(factor));
-
-    this.requireCompanionForPasskeys(factors);
-
-    return factors;
+    if (requested.length > mostFactors) {
+      throw new SimCognitoInvalidParameterException(
+        "SignInPolicy AllowedFirstAuthFactors must name no more than " +
+          `${String(mostFactors)} factors`,
+      );
+    }
   }
 
   private static requireKnown(factor: string): SimCognitoFirstAuthFactor {
@@ -100,11 +114,14 @@ export class SimCognitoSignInPolicy {
    * Refuse a policy offering passkeys and nothing else, as real Cognito
    * refuses one. A passkey has to be registered from a session that already
    * exists, so a pool with no other way in would have nobody able to register.
+   *
+   * The companion has to be a different factor, so naming `WEB_AUTHN` twice
+   * leaves the pool as shut as naming it once does.
    */
   private static requireCompanionForPasskeys(
     factors: readonly SimCognitoFirstAuthFactor[],
   ): void {
-    if (factors.includes("WEB_AUTHN") && factors.length === 1) {
+    if (factors.every((factor) => factor === "WEB_AUTHN")) {
       throw new SimCognitoInvalidParameterException(
         "SignInPolicy AllowedFirstAuthFactors WEB_AUTHN has to be " +
           "accompanied by at least one other factor",

--- a/src/service/cognito/user-pool/sim-cognito-user-pool-settings.ts
+++ b/src/service/cognito/user-pool/sim-cognito-user-pool-settings.ts
@@ -20,6 +20,7 @@ import {
 } from "./message/sim-cognito-verification-messages.js";
 import type { SimCognitoSchemaAttributeType } from "./schema/sim-cognito-schema-attribute.js";
 import { SimCognitoUserPoolSchema } from "./schema/sim-cognito-user-pool-schema.js";
+import { SimCognitoSignInPolicy } from "./sim-cognito-sign-in-policy.js";
 import { SimCognitoUsernameAttributes } from "./sim-cognito-username-attributes.js";
 import { SimCognitoLambdaConfig } from "./trigger/sim-cognito-lambda-config.js";
 
@@ -74,7 +75,8 @@ interface SimCognitoUserPoolSettingsProperties {
 
 /**
  * The settings of one simulated user pool that a request can change: the
- * password policy, the deletion protection, whether users may sign themselves
+ * password policy, the factors it allows at the first prompt, the deletion
+ * protection, whether users may sign themselves
  * up, what confirming a sign-up verifies, the Lambda triggers the pool runs,
  * whether it asks for a second factor, how it recovers an account and what its
  * messages say.
@@ -95,6 +97,17 @@ interface SimCognitoUserPoolSettingsProperties {
  */
 export class SimCognitoUserPoolSettings {
   public readonly passwordPolicy: SimCognitoPasswordPolicy;
+
+  /**
+   * The factors the pool allows at the first authentication prompt.
+   *
+   * A pool created without a `SignInPolicy` allows a password and reports no
+   * policy, as real Cognito reports one. Every factor beside a password is
+   * presented through the `USER_AUTH` flow, which is refused where a sign-in
+   * asks for it.
+   */
+  public readonly signInPolicy: SimCognitoSignInPolicy;
+
   public readonly deletionProtection: SimCognitoDeletionProtection;
   public readonly adminCreateUserConfig: SimCognitoAdminCreateUserConfig;
   public readonly autoVerifiedAttributes: SimCognitoAutoVerifiedAttributes;
@@ -135,6 +148,9 @@ export class SimCognitoUserPoolSettings {
 
     this.passwordPolicy = new SimCognitoPasswordPolicy(
       input.Policies?.PasswordPolicy,
+    );
+    this.signInPolicy = new SimCognitoSignInPolicy(
+      input.Policies?.SignInPolicy,
     );
     this.deletionProtection = new SimCognitoDeletionProtection(
       input.DeletionProtection,


### PR DESCRIPTION
A user pool that allows passkeys could not be created at all. `SimCognitoUnsimulatedUserPoolOptions` refused `Policies SignInPolicy` outright, and a CloudFormation deployment carrying it failed the whole stack. ChineseBoost hit that turning passkey sign-in on, where one line of CDK emits `AllowedFirstAuthFactors: ["PASSWORD", "WEB_AUTHN"]` and the user stack then stopped deploying, taking local dev and every isolated test with it.

`CreateUserPool` and `UpdateUserPool` now accept the policy and record the factors it names, the way `MfaConfiguration` is recorded, and `DescribeUserPool` reports them back. `SimCognitoSignInPolicy` holds the four names Cognito accepts and refuses `WEB_AUTHN` on its own, which AWS states must be accompanied by at least one other option.

`WebAuthnRelyingPartyID` and `WebAuthnUserVerification` deploy from an `AWS::Cognito::UserPool` Resource, where both used to land on `stack.ignoredProperties`. CloudFormation carries them as two flat properties and the Cognito API takes them as one `WebAuthnConfiguration`, so `SimCfnCognitoUserPoolMfa` gathers them into the `SetUserPoolMfaConfig` call that already configures a pool's MFA. `GetUserPoolMfaConfig` reports the result, and `SetUserPoolMfaConfig` stops refusing a `WebAuthnConfiguration` from an SDK caller.

## What is still refused

Nothing registers or presents a passkey. Every first authentication factor beside a password is reached through the `USER_AUTH` flow, and `SimCognitoAuthFlows` goes on refusing that flow by name, so a test cannot mistake an unsimulated passkey sign-in for one that worked. #849 is the rest of it.

`sim-cognito-sign-in-policy.iso.test.ts` covers that boundary directly. A pool allowing passkeys is created, described, and then asked for a `USER_AUTH` sign-in. The refusal names the flow rather than the pool's policy.

Three validation cases went from the refused-input tables, because the input they named is now simulated. The passkey cases moved out of `sim-cognito-user-pool-mfa.iso.test.ts` into a file of their own to stay under `max-lines`.

Resolves #848


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WebAuthn/passkey configuration support for Cognito user pools.
  * Added support for configuring relying-party IDs and user-verification preferences.
  * Sign-in policies now support password, email OTP, SMS OTP, and WebAuthn factors with validation.
  * Configured MFA and sign-in policies are preserved and returned in pool details.

* **Bug Fixes**
  * Improved validation messages for unsupported authentication factors and invalid WebAuthn settings.

* **Documentation**
  * Updated Cognito documentation to clarify WebAuthn and sign-in policy limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->