### PR TITLE
feat: deploy Lambda destinations from a template

### DIFF
--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -2600,6 +2600,9 @@ Supported function properties:
 - `Description`
 - `Timeout`
 - `MemorySize`
+- `Environment`
+- `DeadLetterConfig`, whose `TargetArn` names a queue or a topic. See
+  [retries and destinations in templates](#retries-and-destinations-in-templates)
 
 Code in a missing bucket fails the deploy AWS-style with a `NoSuchBucket` diagnostic.
 
@@ -2909,6 +2912,121 @@ Deleting the Stack deletes the alias. Lambda has no operation that deletes one p
 The version Resource has nothing of its own to do on teardown, and the version it published goes
 when the function does.
 
+## Retries and destinations in templates
+
+`AWS::Lambda::EventInvokeConfig` writes the event invoke config of the function, version or alias
+its `FunctionName` and `Qualifier` name. CDK emits one for `onFailure`, `onSuccess`, `retryAttempts`
+and `maxEventAge` on a function. `DeadLetterConfig` on `AWS::Lambda::Function` is what CDK's
+`deadLetterQueue` emits, and it sets the same dead-letter target `CreateFunction` takes.
+
+```typescript sim-lambda-cloudformation-event-invoke-config
+/**
+ * Deploying a Lambda failure destination and a dead-letter queue from a
+ * CloudFormation template.
+ */
+
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import { ReceiveMessageCommand } from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+import type { SimLambdaDestinationRecord } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Resources: {
+      OrderFailures: {
+        Type: "AWS::SQS::Queue",
+        Properties: { QueueName: "order-failures" },
+      },
+      OrderDeadLetters: {
+        Type: "AWS::SQS::Queue",
+        Properties: { QueueName: "orders-dlq" },
+      },
+      OrdersFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "orders",
+          Role: "arn:aws:iam::111111111111:role/OrdersRole",
+          Handler: "index.handler",
+          Runtime: "nodejs22.x",
+          Code: {
+            ZipFile:
+              "exports.handler = async () => { throw new Error('failed'); };",
+          },
+          DeadLetterConfig: {
+            TargetArn: { "Fn::GetAtt": ["OrderDeadLetters", "Arn"] },
+          },
+        },
+      },
+      OrdersInvokeConfig: {
+        Type: "AWS::Lambda::EventInvokeConfig",
+        Properties: {
+          FunctionName: { Ref: "OrdersFunction" },
+          Qualifier: "$LATEST",
+          MaximumRetryAttempts: 0,
+          DestinationConfig: {
+            OnFailure: {
+              Destination: { "Fn::GetAtt": ["OrderFailures", "Arn"] },
+            },
+          },
+        },
+      },
+    },
+    Outputs: {
+      FailuresQueueUrl: {
+        Value: { "Fn::GetAtt": ["OrderFailures", "QueueUrl"] },
+      },
+    },
+  },
+});
+await stack.waitForDeployComplete();
+
+await simAws.lambda().invoke(
+  new InvokeCommand({
+    FunctionName: "orders",
+    InvocationType: "Event",
+    Payload: JSON.stringify({ id: 7 }),
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+const received = await simAws
+  .sqs()
+  .receiveMessage(
+    new ReceiveMessageCommand({ QueueUrl: stack.output("FailuresQueueUrl") }),
+  );
+const record = JSON.parse(
+  String(received.Messages?.[0]?.Body),
+) as SimLambdaDestinationRecord;
+
+console.log(record.requestContext.condition);
+console.log(record.requestPayload);
+```
+
+Supported `AWS::Lambda::EventInvokeConfig` properties:
+
+- `FunctionName`, as a `Ref` to the function giving its name or an `Fn::GetAtt` on it giving the ARN
+- `Qualifier`, naming a published version or an alias. `$LATEST` addresses the function itself
+- `MaximumRetryAttempts`
+- `MaximumEventAgeInSeconds`
+- `DestinationConfig`, holding `OnSuccess` and `OnFailure`
+
+A destination and a `DeadLetterConfig.TargetArn` name a queue or a topic by `Fn::GetAtt` on its ARN
+or by `Ref`. `Ref` on an `AWS::SQS::Queue` resolves to the queue URL, and both forms reach the same
+queue.
+
+Where a destination names something simulated Lambda has nowhere to send to, such as a service
+outside the template or a Resource the deployment skipped, the Resource is deployed without that
+destination and the omission is recorded in `stack.ignoredProperties` under the property that named
+it. The function still deploys, and a stack keeps the destination it can reach when the other end
+names one it cannot. Refusing a whole stack over one destination would leave a test with nothing to
+run.
+
+Deleting the Stack takes the config off the function, ahead of the function itself.
+
 ## Executable bindings
 
 Deploy-time `bindings` let a template function be backed by a real in-process handler instead of its
@@ -3179,14 +3297,18 @@ Sim Lambda currently supports:
   listing
 - AWS-like validation and errors, such as `ResourceConflictException` for a duplicate function name
 - The `AWS::Lambda::Function`, `AWS::Lambda::Url`, `AWS::Lambda::Permission`,
-  `AWS::Lambda::Version`, `AWS::Lambda::Alias` and `AWS::Lambda::EventSourceMapping`
-  CloudFormation resources, with `Ref`/`Fn::GetAtt` support and deploy-time executable bindings
+  `AWS::Lambda::Version`, `AWS::Lambda::Alias`, `AWS::Lambda::EventSourceMapping` and
+  `AWS::Lambda::EventInvokeConfig` CloudFormation resources, with `Ref`/`Fn::GetAtt` support and
+  deploy-time executable bindings
 - A CDK app built on `fn.currentVersion` or a `lambda.Alias`, which deploys with the alias its
   integrations point at, and where an `AWS::Lambda::Permission` naming that alias grants on the
   alias
 - `AWS::Lambda::EventSourceMapping` on a queue or on a table's stream, including the
   `StartingPosition` a stream mapping needs, so a CDK `SqsEventSource` or `DynamoEventSource`
   deploys as it is synthesised
+- A CDK function given `onFailure`, `onSuccess`, `retryAttempts`, `maxEventAge` or
+  `deadLetterQueue`, which deploys the `AWS::Lambda::EventInvokeConfig` and the `DeadLetterConfig`
+  those synthesise
 
 ## Limitations
 
@@ -3207,10 +3329,11 @@ Current documented limitations:
   Real Lambda delivers under that role and drops the record where the role cannot, which would be
   silent, so simulated Lambda delivers instead. Nothing else about the destination has to be set up,
   since a destination needs no resource policy on real AWS either.
-- `AWS::Lambda::EventInvokeConfig` and the `DeadLetterConfig` property of `AWS::Lambda::Function`
-  are not deployed from a template yet, so a CDK function's `onFailure`, `onSuccess` and
-  `deadLetterQueue` are left out of the simulated function. See
-  [issue 845](https://github.com/KensioSoftware/yulin/issues/845).
+- SAM's `EventInvokeConfig` and `DeadLetterQueue` on `AWS::Serverless::Function` are left out. A
+  SAM application declaring either deploys a function with the default retries, no destinations and
+  no dead-letter target. The `AWS::Lambda::EventInvokeConfig` Resource and the `DeadLetterConfig`
+  property a CloudFormation or CDK template writes are both deployed. See
+  [retries and destinations in templates](#retries-and-destinations-in-templates).
 - Throttling and timeouts do not drive a retry. A retry follows a handler that threw, and the
   `MaximumEventAgeInSeconds` a config carries is measured from when the invocation was accepted.
 - `DestinationConfig` on an event source mapping is left out. It is a different mechanism from the
@@ -3322,8 +3445,9 @@ Current documented limitations:
   here. A simulated stream has one shard and never splits, so a stream mapping has one thing to read
   either way.
 - CloudFormation resource types other than `AWS::Lambda::Function`, `AWS::Lambda::Url`,
-  `AWS::Lambda::Permission` and `AWS::Lambda::EventSourceMapping` (`Version`, `Alias`, ...) are
-  skipped with an "Unsupported" diagnostic.
+  `AWS::Lambda::Permission`, `AWS::Lambda::Version`, `AWS::Lambda::Alias`,
+  `AWS::Lambda::EventSourceMapping` and `AWS::Lambda::EventInvokeConfig` (`LayerVersion`,
+  `CodeSigningConfig`, ...) are skipped with an "Unsupported" diagnostic.
 - The `vm` context is a namespacing convenience rather than a security boundary. Function code runs
   in-process with the same trust as the test suite itself. Do not run untrusted code through the
   simulator.

--- a/docs/services/lambda/sim-lambda-cloudformation-event-invoke-config.example.ts
+++ b/docs/services/lambda/sim-lambda-cloudformation-event-invoke-config.example.ts
@@ -1,0 +1,84 @@
+/**
+ * Deploying a Lambda failure destination and a dead-letter queue from a
+ * CloudFormation template.
+ */
+
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import { ReceiveMessageCommand } from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+import type { SimLambdaDestinationRecord } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Resources: {
+      OrderFailures: {
+        Type: "AWS::SQS::Queue",
+        Properties: { QueueName: "order-failures" },
+      },
+      OrderDeadLetters: {
+        Type: "AWS::SQS::Queue",
+        Properties: { QueueName: "orders-dlq" },
+      },
+      OrdersFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "orders",
+          Role: "arn:aws:iam::111111111111:role/OrdersRole",
+          Handler: "index.handler",
+          Runtime: "nodejs22.x",
+          Code: {
+            ZipFile:
+              "exports.handler = async () => { throw new Error('failed'); };",
+          },
+          DeadLetterConfig: {
+            TargetArn: { "Fn::GetAtt": ["OrderDeadLetters", "Arn"] },
+          },
+        },
+      },
+      OrdersInvokeConfig: {
+        Type: "AWS::Lambda::EventInvokeConfig",
+        Properties: {
+          FunctionName: { Ref: "OrdersFunction" },
+          Qualifier: "$LATEST",
+          MaximumRetryAttempts: 0,
+          DestinationConfig: {
+            OnFailure: {
+              Destination: { "Fn::GetAtt": ["OrderFailures", "Arn"] },
+            },
+          },
+        },
+      },
+    },
+    Outputs: {
+      FailuresQueueUrl: {
+        Value: { "Fn::GetAtt": ["OrderFailures", "QueueUrl"] },
+      },
+    },
+  },
+});
+await stack.waitForDeployComplete();
+
+await simAws.lambda().invoke(
+  new InvokeCommand({
+    FunctionName: "orders",
+    InvocationType: "Event",
+    Payload: JSON.stringify({ id: 7 }),
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+const received = await simAws
+  .sqs()
+  .receiveMessage(
+    new ReceiveMessageCommand({ QueueUrl: stack.output("FailuresQueueUrl") }),
+  );
+const record = JSON.parse(
+  String(received.Messages?.[0]?.Body),
+) as SimLambdaDestinationRecord;
+
+console.log(record.requestContext.condition);
+console.log(record.requestPayload);

--- a/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-async-destinations.loc.test.ts
+++ b/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-async-destinations.loc.test.ts
@@ -1,0 +1,145 @@
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import { ReceiveMessageCommand } from "@aws-sdk/client-sqs";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertTypeString,
+} from "@kensio/smartass";
+import path from "node:path";
+import { describe, it } from "vitest";
+
+/**
+ * Slower local integration test. Calls the real CDK CLI to synth the output
+ * template file to pass to sim CloudFormation, so the template under test is
+ * one CDK actually produced rather than one written by hand.
+ */
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimLambdaDestinationRecord } from "../../../lambda/destination/sim-lambda-destination-record.js";
+import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+
+const accountIdOneOnes = "111111111111";
+
+/**
+ * A handler that always throws, so every asynchronous invocation of it runs
+ * out of attempts.
+ */
+const ordersHandlerSource = `
+exports.handler = async () => {
+  throw new Error("orders handler failed");
+};
+`;
+
+/**
+ * The one message body waiting on a queue.
+ */
+async function receivedBody(simAws: SimAws, queueUrl: string): Promise<string> {
+  const received = await simAws
+    .account(accountIdOneOnes)
+    .region("eu-west-2")
+    .sqs()
+    .receiveMessage(
+      new ReceiveMessageCommand({
+        QueueUrl: queueUrl,
+        MaxNumberOfMessages: 10,
+      }),
+    );
+  const body = received.Messages?.at(0)?.Body;
+  assertTypeString(body);
+
+  return body;
+}
+
+describe("Sim CDK Lambda asynchronous destinations local integration", () => {
+  it("deploys a CDK onFailure destination and deadLetterQueue", async () => {
+    // Given a CDK stack with a function that always throws, an onFailure
+    // destination queue and a dead-letter queue, retrying nothing.
+    const cdkProject = new TestCdkProject();
+    await cdkProject.writeCdkAppFile(
+      `
+import * as cdk from "aws-cdk-lib/core";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as destinations from "aws-cdk-lib/aws-lambda-destinations";
+import * as sqs from "aws-cdk-lib/aws-sqs";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "111111111111", region: "eu-west-2" },
+});
+
+const failuresQueue = new sqs.Queue(stack, "FailuresQueue");
+const deadLetterQueue = new sqs.Queue(stack, "DeadLetterQueue");
+
+new lambda.Function(stack, "OrdersFunction", {
+  functionName: "cdk-orders",
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: lambda.Code.fromInline(${JSON.stringify(ordersHandlerSource)}),
+  retryAttempts: 0,
+  onFailure: new destinations.SqsDestination(failuresQueue),
+  deadLetterQueue,
+});
+
+new cdk.CfnOutput(stack, "FailuresQueueUrl", {
+  value: failuresQueue.queueUrl,
+});
+
+new cdk.CfnOutput(stack, "DeadLetterQueueUrl", {
+  value: deadLetterQueue.queueUrl,
+});
+
+app.synth();
+      `,
+    );
+
+    // And we synth the CDK template.
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When we deploy the synthesized template into the account and region the
+    // CDK app declares, with no hand-editing of the
+    // AWS::Lambda::EventInvokeConfig Resource or the DeadLetterConfig property
+    // CDK emits.
+    const simAws = new SimAws();
+    const scoped = simAws.account(accountIdOneOnes).region("eu-west-2");
+    const stack = await scoped
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // Then an asynchronous invocation the handler throws on runs out of
+    // attempts.
+    await scoped.lambda().invoke(
+      new InvokeCommand({
+        FunctionName: "cdk-orders",
+        InvocationType: "Event",
+        Payload: JSON.stringify({ id: 7 }),
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+    await simAws.clock().advanceBy({ minutes: 5 });
+
+    // And the destination CDK's onFailure named holds the record real Lambda
+    // sends, naming the event that was invoked.
+    const failuresQueueUrl = stack.outputs.get("FailuresQueueUrl")?.value;
+    assertTypeString(failuresQueueUrl);
+
+    const record = JSON.parse(
+      await receivedBody(simAws, failuresQueueUrl),
+    ) as SimLambdaDestinationRecord;
+
+    assertIdentical(record.requestContext.condition, "RetriesExhausted");
+    assertIdentical(record.requestContext.approximateInvokeCount, 1);
+
+    // And the queue CDK's deadLetterQueue named holds the event itself.
+    const deadLetterQueueUrl = stack.outputs.get("DeadLetterQueueUrl")?.value;
+    assertTypeString(deadLetterQueueUrl);
+    assertIdentical(await receivedBody(simAws, deadLetterQueueUrl), '{"id":7}');
+
+    assertNonNullable(
+      scoped.lambda().getSimEventInvokeConfig("cdk-orders", "$LATEST"),
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -663,9 +663,9 @@ reachable afterwards through `simAws.lambda()` and invokable via the SDK `Invoke
 
 Supported `AWS::Lambda::Function` properties: `FunctionName` (defaults to the logical ID), `Role`
 (typically a `Ref`/`Fn::GetAtt` to a same-stack `AWS::IAM::Role`), `Code`, `Handler`, `Runtime`,
-`Description`, `Timeout`, `MemorySize`, and `Environment`. Malformed property values fail AWS-style
-with a `TypeError` naming the property and logical ID, down to the individual variable for
-`Environment.Variables`.
+`Description`, `Timeout`, `MemorySize`, `Environment`, and `DeadLetterConfig`. Malformed property
+values fail AWS-style with a `TypeError` naming the property and logical ID, down to the individual
+variable for `Environment.Variables`.
 
 Template `Code` supports two source forms:
 
@@ -708,6 +708,25 @@ rule. `StartingPosition` and `StartingPositionTimestamp` are read and passed on 
 here, since a stream mapping has to have a position and a queue mapping is refused for naming one,
 and only `CreateEventSourceMapping` knows which source the ARN names.
 
+### Retries and destinations
+
+`cfn/event-invoke-config/` writes `AWS::Lambda::EventInvokeConfig` through
+`PutFunctionEventInvokeConfig`, and `cfn/function/sim-cfn-lambda-dead-letter-parser.ts` reads
+`DeadLetterConfig` off the function. CDK emits the first for `onFailure`, `onSuccess`,
+`retryAttempts` and `maxEventAge`, and the second for `deadLetterQueue`.
+
+Both name a queue or a topic, and both read it through `SimCfnLambdaTargetArn`. A `Ref` to an
+`AWS::SQS::Queue` resolves to the queue URL where everything downstream names a queue by ARN, so
+the URL form is converted there. A destination the simulation has nowhere to send to is recorded
+with `resource.ignoreProperty` and left off the Resource. That is what the reader's catch of
+`SimLambdaInvalidParameterValueException` is for. Failing the Resource would take a whole stack
+down over one destination, the outcome issue #823 was about, and the function itself is still worth
+deploying.
+
+`simCfnLambdaRemoveEventInvokeConfig` takes the config off on teardown. It checks the config is
+still there first, since deleting a function takes its configs with it and a Stack that reached the
+function first would otherwise fail a deletion over work it had already done.
+
 ### Versions and aliases
 
 `cfn/version/` publishes `AWS::Lambda::Version` through `PublishVersion`, and `cfn/alias/` creates
@@ -740,8 +759,8 @@ and are skipped by the CloudFormation engine with an "Unsupported" diagnostic.
 ## Not simulated yet
 
 - `AWS::Lambda::*` CloudFormation resource types other than `AWS::Lambda::Function`,
-  `AWS::Lambda::Url`, `AWS::Lambda::Permission`, `AWS::Lambda::Version`, `AWS::Lambda::Alias` and
-  `AWS::Lambda::EventSourceMapping`
+  `AWS::Lambda::Url`, `AWS::Lambda::Permission`, `AWS::Lambda::Version`, `AWS::Lambda::Alias`,
+  `AWS::Lambda::EventSourceMapping` and `AWS::Lambda::EventInvokeConfig`
 - event sources other than SQS queues and DynamoDB streams, `FilterCriteria`,
   `UpdateEventSourceMapping`, and polling concurrency
 - Function URL `Cors` configuration and OPTIONS preflight handling
@@ -753,9 +772,8 @@ and are skipped by the CloudFormation engine with an "Unsupported" diagnostic.
 - `GetFunctionConfiguration`, and the concurrency and tagging commands
 - `RevisionId`, `DryRun`, `Architectures` and `SourceKMSKeyArn` on `UpdateFunctionCode`, the
   settings simulated Lambda does not model on `UpdateFunctionConfiguration` (`Layers`, `VpcConfig`,
-  `DeadLetterConfig`, `TracingConfig`, `KMSKeyArn`, `EphemeralStorage`, `SnapStart`,
-  `LoggingConfig`, `RevisionId`), and `Marker`/`MaxItems` paging and `MasterRegion` on
-  `ListFunctions`
+  `TracingConfig`, `KMSKeyArn`, `EphemeralStorage`, `SnapStart`, `LoggingConfig`, `RevisionId`),
+  and `Marker`/`MaxItems` paging and `MasterRegion` on `ListFunctions`
 - `LastUpdateStatus`, so a settings change takes effect at once, with no roll-out to wait on
 - `RevisionId` and `EventSourceToken` on the permission commands, qualified Function URLs, alias
   `RoutingConfig` weights, and provisioned concurrency, including `RoutingConfig`,
@@ -768,4 +786,4 @@ and are skipped by the CloudFormation engine with an "Unsupported" diagnostic.
   redirect the simulation answered with
 - timers: `setTimeout` inside a handler is a host timer, not one the simulation's clock releases
 - timeouts interrupting handler execution
-- asynchronous invocation retries and failure destinations
+- SAM's `EventInvokeConfig` and `DeadLetterQueue` on `AWS::Serverless::Function`

--- a/src/service/lambda/cfn/event-invoke-config/sim-cfn-lambda-event-invoke-config-creator.ts
+++ b/src/service/lambda/cfn/event-invoke-config/sim-cfn-lambda-event-invoke-config-creator.ts
@@ -1,0 +1,53 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimLambdaEventInvokeConfig } from "../../function/event-invoke/sim-lambda-event-invoke-config.js";
+import type { SimLambda } from "../../sim-lambda.js";
+import { SimCfnLambdaEventInvokeConfigProperties } from "./sim-cfn-lambda-event-invoke-config-properties.js";
+
+interface SimCfnLambdaEventInvokeConfigCreatorProperties {
+  readonly lambda: SimLambda;
+}
+
+/**
+ * Creates simulated event invoke configs from CloudFormation Resources.
+ *
+ * This is what CDK emits for `onFailure`, `onSuccess`, `retryAttempts` and
+ * `maxEventAge` on a function, so a synthesized template is the usual way a
+ * config comes into existence outside a direct SDK call. It is written through
+ * the ordinary PutFunctionEventInvokeConfig command, so a template deploying
+ * one gets the same validation and the same authorization an SDK caller would.
+ */
+export class SimCfnLambdaEventInvokeConfigCreator {
+  private readonly lambda: SimLambda;
+
+  constructor(properties: SimCfnLambdaEventInvokeConfigCreatorProperties) {
+    this.lambda = properties.lambda;
+  }
+
+  /**
+   * Create a config from an AWS::Lambda::EventInvokeConfig Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimLambdaEventInvokeConfig> {
+    const { functionName, qualifier, input } =
+      new SimCfnLambdaEventInvokeConfigProperties({
+        resource,
+        properties,
+      }).createInput();
+
+    await this.lambda.putFunctionEventInvokeConfig({ input });
+
+    const config = this.lambda.getSimEventInvokeConfig(functionName, qualifier);
+
+    assertDefined(
+      config,
+      `Sim Lambda event invoke config ${resource.logicalId} after ` +
+        "CloudFormation creation",
+    );
+
+    return config;
+  }
+}

--- a/src/service/lambda/cfn/event-invoke-config/sim-cfn-lambda-event-invoke-config-properties.ts
+++ b/src/service/lambda/cfn/event-invoke-config/sim-cfn-lambda-event-invoke-config-properties.ts
@@ -1,0 +1,88 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimPutFunctionEventInvokeConfigCommandInput } from "../../command/put-function-event-invoke-config/put-function-event-invoke-config.command.js";
+import { SimCfnLambdaPropertyParser } from "../function/sim-cfn-lambda-property-parser.js";
+import { simCfnLambdaTargetFunctionName } from "../function/sim-cfn-lambda-target-function.js";
+import { recordUnreadEventInvokeConfigProperties } from "./sim-cfn-lambda-event-invoke-config-property-rules.js";
+import { SimCfnLambdaEventInvokeDestinations } from "./sim-cfn-lambda-event-invoke-destinations.js";
+
+interface SimCfnLambdaEventInvokeConfigPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * The PutFunctionEventInvokeConfig input, and which function it is for.
+ *
+ * The function and qualifier are carried beside the input because they are
+ * what the config is held under, and the creator reads the config back with
+ * them once the command has written it.
+ */
+export interface SimCfnLambdaEventInvokeConfigInput {
+  readonly functionName: string;
+  readonly qualifier: string | undefined;
+  readonly input: SimPutFunctionEventInvokeConfigCommandInput;
+}
+
+/**
+ * Reads an AWS::Lambda::EventInvokeConfig Resource into the input
+ * PutFunctionEventInvokeConfig takes.
+ *
+ * Nothing about retry counts or event ages is decided here. The command
+ * refuses what real Lambda refuses, so a config a template deployed is the
+ * same thing an SDK caller would have got.
+ */
+export class SimCfnLambdaEventInvokeConfigProperties {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly parser = new SimCfnLambdaPropertyParser();
+  private readonly destinations = new SimCfnLambdaEventInvokeDestinations();
+
+  constructor(properties: SimCfnLambdaEventInvokeConfigPropertiesProperties) {
+    this.resource = properties.resource;
+    this.properties = properties.properties;
+  }
+
+  /**
+   * The put input this Resource asks for.
+   */
+  createInput(): SimCfnLambdaEventInvokeConfigInput {
+    recordUnreadEventInvokeConfigProperties(this.resource, this.properties);
+
+    const functionName = simCfnLambdaTargetFunctionName(
+      this.parser.requiredString(
+        this.resource,
+        this.properties["FunctionName"],
+        "FunctionName",
+      ),
+    );
+    const qualifier = this.parser.optionalString(
+      this.resource,
+      this.properties["Qualifier"],
+      "Qualifier",
+    );
+
+    return {
+      functionName,
+      qualifier,
+      input: {
+        FunctionName: functionName,
+        Qualifier: qualifier,
+        MaximumRetryAttempts: this.parser.optionalNumber(
+          this.resource,
+          this.properties["MaximumRetryAttempts"],
+          "MaximumRetryAttempts",
+        ),
+        MaximumEventAgeInSeconds: this.parser.optionalNumber(
+          this.resource,
+          this.properties["MaximumEventAgeInSeconds"],
+          "MaximumEventAgeInSeconds",
+        ),
+        DestinationConfig: this.destinations.parse(
+          this.resource,
+          this.properties["DestinationConfig"],
+        ),
+      },
+    };
+  }
+}

--- a/src/service/lambda/cfn/event-invoke-config/sim-cfn-lambda-event-invoke-config-property-rules.ts
+++ b/src/service/lambda/cfn/event-invoke-config/sim-cfn-lambda-event-invoke-config-property-rules.ts
@@ -1,0 +1,38 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+/**
+ * The whole of AWS::Lambda::EventInvokeConfig, every one of which is read.
+ */
+const readPropertyNames: ReadonlySet<string> = new Set([
+  "DestinationConfig",
+  "FunctionName",
+  "MaximumEventAgeInSeconds",
+  "MaximumRetryAttempts",
+  "Qualifier",
+]);
+
+/**
+ * Record a property of an AWS::Lambda::EventInvokeConfig Resource that nothing
+ * reads, rather than failing the Resource over it.
+ *
+ * Every real property of this Resource type is read, so an unread one is a
+ * typo or something AWS has added since. Either way a config carrying the
+ * settings it does state is worth more than a stack that will not deploy.
+ */
+export function recordUnreadEventInvokeConfigProperties(
+  resource: SimCfnResource,
+  properties: SimCfnTemplateValueRecord,
+): void {
+  const unread = Object.keys(properties).filter(
+    (name) => !readPropertyNames.has(name),
+  );
+
+  for (const name of unread) {
+    resource.ignoreProperty(
+      name,
+      `${name} is not an AWS::Lambda::EventInvokeConfig property, so the ` +
+        `event invoke config is deployed without it`,
+    );
+  }
+}

--- a/src/service/lambda/cfn/event-invoke-config/sim-cfn-lambda-event-invoke-config-remover.ts
+++ b/src/service/lambda/cfn/event-invoke-config/sim-cfn-lambda-event-invoke-config-remover.ts
@@ -1,0 +1,32 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimLambdaEventInvokeConfig } from "../../function/event-invoke/sim-lambda-event-invoke-config.js";
+import type { SimLambda } from "../../sim-lambda.js";
+import { simCfnLambdaCreatedResource } from "../sim-cfn-lambda-created-resource.js";
+
+/**
+ * Take an AWS::Lambda::EventInvokeConfig off the function it was written on,
+ * so what is left of the function retries the default number of times and
+ * sends its results nowhere.
+ *
+ * A config that has already gone is nothing to delete. Deleting a function
+ * takes its configs with it, so a teardown that reached the function first
+ * would otherwise fail here over work it had already done.
+ */
+export async function simCfnLambdaRemoveEventInvokeConfig(
+  lambda: SimLambda,
+  resource: SimCfnResource,
+): Promise<void> {
+  const { functionName, qualifier } =
+    simCfnLambdaCreatedResource<SimLambdaEventInvokeConfig>(
+      resource,
+      "event invoke config",
+    );
+
+  if (lambda.getSimEventInvokeConfig(functionName, qualifier) === undefined) {
+    return;
+  }
+
+  await lambda.deleteFunctionEventInvokeConfig({
+    input: { FunctionName: functionName, Qualifier: qualifier },
+  });
+}

--- a/src/service/lambda/cfn/event-invoke-config/sim-cfn-lambda-event-invoke-config-skips.iso.test.ts
+++ b/src/service/lambda/cfn/event-invoke-config/sim-cfn-lambda-event-invoke-config-skips.iso.test.ts
@@ -1,0 +1,160 @@
+import { DeleteFunctionEventInvokeConfigCommand } from "@aws-sdk/client-lambda";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  deployOrders,
+  failingOrdersBinding,
+  failureConfigProperties,
+  ordersFailuresQueueArn,
+  ordersTemplate,
+} from "../../../../../test/lambda/cfn-event-invoke-config-fixture.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+
+describe("Lambda CloudFormation event invoke config best effort", () => {
+  it("deploys the config without a destination it cannot send to", async () => {
+    // Given a template sending failures to a service outside the simulation.
+    const simAws = new SimAws();
+    const stack = await deployOrders(simAws, {
+      FunctionName: { Ref: "OrdersFunction" },
+      Qualifier: "$LATEST",
+      MaximumRetryAttempts: 0,
+      DestinationConfig: {
+        OnSuccess: { Destination: { "Fn::GetAtt": ["OrderFailures", "Arn"] } },
+        OnFailure: {
+          Destination: "arn:aws:kinesis:us-east-1:888888888888:stream/orders",
+        },
+      },
+    });
+
+    // Then the config is deployed with the destination it can reach, and the
+    // one it cannot is recorded rather than taking the Resource down.
+    const config = simAws.lambda().getSimEventInvokeConfig("orders");
+
+    assertNonNullable(config);
+    assertUndefined(config.settings.onFailureArn);
+    assertIdentical(config.settings.onSuccessArn, ordersFailuresQueueArn);
+
+    const [ignored, ...rest] = stack.ignoredProperties;
+
+    assertNonNullable(ignored, "a recorded destination");
+    assertArrayLength(rest, 0, "no second record");
+    assertIdentical(ignored.logicalId, "OrdersInvokeConfig");
+    assertIdentical(ignored.path, "DestinationConfig.OnFailure.Destination");
+    assertStringIncludes(ignored.reason, "kinesis");
+  });
+
+  it("deploys the config without a destination the Stack skipped", async () => {
+    // Given a template sending failures to a Resource type simulated
+    // CloudFormation has no implementation for, whose Fn::GetAtt resolves to
+    // nothing that names anything.
+    const simAws = new SimAws();
+    const template = ordersTemplate({
+      FunctionName: { Ref: "OrdersFunction" },
+      Qualifier: "$LATEST",
+      DestinationConfig: {
+        OnFailure: { Destination: { "Fn::GetAtt": ["OrderSigning", "Arn"] } },
+      },
+    });
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          ...template.Resources,
+          OrderSigning: {
+            Type: "AWS::Lambda::CodeSigningConfig",
+            Properties: {
+              AllowedPublishers: { SigningProfileVersionArns: [] },
+            },
+          },
+        },
+      },
+      bindings: [failingOrdersBinding()],
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the skipped Resource has taken its destination with it, and the
+    // config and the function are deployed anyway.
+    assertArrayLength(stack.skippedResources, 1);
+
+    const config = simAws.lambda().getSimEventInvokeConfig("orders");
+
+    assertNonNullable(config);
+    assertUndefined(config.settings.onFailureArn);
+
+    const [ignored] = stack.ignoredProperties;
+
+    assertNonNullable(ignored, "a recorded destination");
+    assertIdentical(ignored.path, "DestinationConfig.OnFailure.Destination");
+  });
+
+  it("records a property it does not read", async () => {
+    // Given a template with a made-up property on the Resource.
+    const simAws = new SimAws();
+    const stack = await deployOrders(simAws, {
+      ...failureConfigProperties(),
+      Nonsense: "true",
+    });
+
+    // Then the config still deploys, with the property recorded against it.
+    assertNonNullable(simAws.lambda().getSimEventInvokeConfig("orders"));
+
+    const [ignored] = stack.ignoredProperties;
+
+    assertNonNullable(ignored, "a recorded property");
+    assertIdentical(ignored.path, "Nonsense");
+    assertStringIncludes(
+      ignored.reason,
+      "Nonsense is not an AWS::Lambda::EventInvokeConfig property",
+    );
+  });
+
+  it("leaves a config something else removed alone", async () => {
+    // Given a deployed config that has since been deleted through the SDK.
+    const simAws = new SimAws();
+    const stack = await deployOrders(simAws, failureConfigProperties());
+    await simAws
+      .lambda()
+      .deleteFunctionEventInvokeConfig(
+        new DeleteFunctionEventInvokeConfigCommand({ FunctionName: "orders" }),
+      );
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then the teardown carries on rather than failing over a config that has
+    // already gone.
+    assertIdentical(
+      stack.getResource("OrdersInvokeConfig")?.status,
+      "DELETE_COMPLETE",
+    );
+    assertUndefined(simAws.lambda().getSimFunctionByName("orders"));
+  });
+
+  it("fails a Resource whose settings are malformed", async () => {
+    // Given a template asking for a retry count that is not a number.
+    const simAws = new SimAws();
+
+    // When the Stack is deployed, then the Resource fails with a diagnostic
+    // naming the property, rather than deploying a config that ignores it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployOrders(simAws, {
+        ...failureConfigProperties(),
+        MaximumRetryAttempts: "none",
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::Lambda::EventInvokeConfig OrdersInvokeConfig: " +
+        "MaximumRetryAttempts must be a number",
+    );
+  });
+});

--- a/src/service/lambda/cfn/event-invoke-config/sim-cfn-lambda-event-invoke-config.iso.test.ts
+++ b/src/service/lambda/cfn/event-invoke-config/sim-cfn-lambda-event-invoke-config.iso.test.ts
@@ -1,0 +1,389 @@
+import {
+  DeleteFunctionEventInvokeConfigCommand,
+  InvokeCommand,
+} from "@aws-sdk/client-lambda";
+import { ReceiveMessageCommand } from "@aws-sdk/client-sqs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCfnStack } from "../../../cloudformation/stack/sim-cfn-stack.js";
+import type { CfnTemplateBodyRecord } from "../../../cloudformation/template/sim-cfn-template.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimLambdaDestinationRecord } from "../../destination/sim-lambda-destination-record.js";
+
+const assumeRolePolicyDocument = {
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Principal: { Service: "lambda.amazonaws.com" },
+      Action: "sts:AssumeRole",
+    },
+  ],
+};
+
+/**
+ * A template with a queue for the failures, an orders function, and an event
+ * invoke config sending the function's failures to the queue, as CDK
+ * synthesizes for `onFailure`.
+ */
+function ordersTemplate(
+  configProperties: SimCfnTemplateValueRecord,
+): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      OrderFailures: {
+        Type: "AWS::SQS::Queue",
+        Properties: { QueueName: "order-failures" },
+      },
+      OrdersRole: {
+        Type: "AWS::IAM::Role",
+        Properties: {
+          RoleName: "OrdersRole",
+          AssumeRolePolicyDocument: assumeRolePolicyDocument,
+        },
+      },
+      OrdersFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "orders",
+          Role: { "Fn::GetAtt": ["OrdersRole", "Arn"] },
+        },
+      },
+      OrdersInvokeConfig: {
+        Type: "AWS::Lambda::EventInvokeConfig",
+        Properties: configProperties,
+      },
+    },
+  };
+}
+
+/**
+ * The properties of a config on the function itself, sending failures to the
+ * template's queue and giving up after the first attempt.
+ */
+function failureConfigProperties(): SimCfnTemplateValueRecord {
+  return {
+    FunctionName: { Ref: "OrdersFunction" },
+    Qualifier: "$LATEST",
+    MaximumRetryAttempts: 0,
+    DestinationConfig: {
+      OnFailure: { Destination: { "Fn::GetAtt": ["OrderFailures", "Arn"] } },
+    },
+  };
+}
+
+/**
+ * Deploy the orders template with a handler that always throws.
+ */
+async function deployOrders(
+  simAws: SimAws,
+  configProperties: SimCfnTemplateValueRecord,
+): Promise<SimCfnStack> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "orders-stack",
+    template: ordersTemplate(configProperties),
+    bindings: [
+      {
+        logicalId: "OrdersFunction",
+        handler: (): never => {
+          throw new Error("orders handler failed");
+        },
+      },
+    ],
+  });
+  await stack.waitForDeployComplete();
+
+  return stack;
+}
+
+/**
+ * Invoke the deployed function asynchronously and let every retry it makes
+ * fall due.
+ */
+async function invokeOrders(simAws: SimAws, qualifier?: string): Promise<void> {
+  await simAws.lambda().invoke(
+    new InvokeCommand({
+      FunctionName: "orders",
+      Qualifier: qualifier,
+      InvocationType: "Event",
+      Payload: JSON.stringify({ id: 7 }),
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+  await simAws.clock().advanceBy({ minutes: 5 });
+}
+
+/**
+ * The one destination record waiting on the failures queue.
+ */
+async function failureRecord(
+  simAws: SimAws,
+): Promise<SimLambdaDestinationRecord> {
+  const received = await simAws.sqs().receiveMessage(
+    new ReceiveMessageCommand({
+      QueueUrl: simAws.sqs().findQueue("order-failures")?.url,
+      MaxNumberOfMessages: 10,
+    }),
+  );
+
+  assertArrayLength(received.Messages ?? [], 1);
+  const body = received.Messages?.[0]?.Body;
+  assertNonNullable(body, "a destination record arrived");
+
+  return JSON.parse(body) as SimLambdaDestinationRecord;
+}
+
+describe("Lambda CloudFormation event invoke config deployment", () => {
+  it("sends a failure to the destination AWS::Lambda::EventInvokeConfig names", async () => {
+    // Given a template with a queue, a failing function and a config between
+    // them.
+    const simAws = new SimAws();
+    const stack = await deployOrders(simAws, failureConfigProperties());
+
+    // Then the Resource is backed by the config the function now holds.
+    const resource = stack.getResource("OrdersInvokeConfig");
+    const config = simAws.lambda().getSimEventInvokeConfig("orders");
+
+    assertNonNullable(resource);
+    assertNonNullable(config);
+    assertIdentical(resource.simResource, config);
+    assertIdentical(config.settings.maximumRetryAttempts, 0);
+    assertIdentical(
+      config.settings.onFailureArn,
+      "arn:aws:sqs:us-east-1:888888888888:order-failures",
+    );
+
+    // And an asynchronous invocation the handler throws on reaches the queue
+    // the template named.
+    await invokeOrders(simAws);
+
+    const record = await failureRecord(simAws);
+
+    assertIdentical(record.requestContext.condition, "RetriesExhausted");
+    assertIdentical(record.requestContext.approximateInvokeCount, 1);
+    assertIdentical(JSON.stringify(record.requestPayload), '{"id":7}');
+  });
+
+  it("carries MaximumEventAgeInSeconds and OnSuccess through", async () => {
+    // Given a template stating every setting the Resource takes.
+    const simAws = new SimAws();
+    await deployOrders(simAws, {
+      FunctionName: { Ref: "OrdersFunction" },
+      Qualifier: "$LATEST",
+      MaximumRetryAttempts: 1,
+      MaximumEventAgeInSeconds: 120,
+      DestinationConfig: {
+        OnSuccess: { Destination: { "Fn::GetAtt": ["OrderFailures", "Arn"] } },
+        OnFailure: { Destination: { Ref: "OrderFailures" } },
+      },
+    });
+
+    // Then the deployed config carries all of them, with the queue a Ref
+    // named by URL read as the same queue.
+    const config = simAws.lambda().getSimEventInvokeConfig("orders");
+
+    assertNonNullable(config);
+    assertIdentical(config.settings.maximumRetryAttempts, 1);
+    assertIdentical(config.settings.maximumEventAgeInSeconds, 120);
+    assertIdentical(
+      config.settings.onSuccessArn,
+      "arn:aws:sqs:us-east-1:888888888888:order-failures",
+    );
+    assertIdentical(
+      config.settings.onFailureArn,
+      "arn:aws:sqs:us-east-1:888888888888:order-failures",
+    );
+  });
+
+  it("points a Qualifier at the alias it names", async () => {
+    // Given a template publishing a version, aliasing it, and configuring the
+    // alias rather than the function.
+    const simAws = new SimAws();
+    const template = ordersTemplate({
+      FunctionName: { Ref: "OrdersFunction" },
+      Qualifier: "live",
+      MaximumRetryAttempts: 0,
+      DestinationConfig: {
+        OnFailure: { Destination: { "Fn::GetAtt": ["OrderFailures", "Arn"] } },
+      },
+    });
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          ...template.Resources,
+          OrdersVersion: {
+            Type: "AWS::Lambda::Version",
+            Properties: { FunctionName: { Ref: "OrdersFunction" } },
+          },
+          OrdersAlias: {
+            Type: "AWS::Lambda::Alias",
+            Properties: {
+              FunctionName: { Ref: "OrdersFunction" },
+              Name: "live",
+              FunctionVersion: {
+                "Fn::GetAtt": ["OrdersVersion", "Version"],
+              },
+            },
+          },
+        },
+      },
+      bindings: [
+        {
+          logicalId: "OrdersFunction",
+          handler: (): never => {
+            throw new Error("orders handler failed");
+          },
+        },
+      ],
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the config belongs to the alias, and the function itself has none.
+    assertNonNullable(
+      simAws.lambda().getSimEventInvokeConfig("orders", "live"),
+    );
+    assertUndefined(simAws.lambda().getSimEventInvokeConfig("orders"));
+
+    // And an invocation of the alias is the one that reaches the destination.
+    await invokeOrders(simAws, "live");
+
+    const record = await failureRecord(simAws);
+
+    assertIdentical(record.requestContext.approximateInvokeCount, 1);
+  });
+
+  it("deploys the config without a destination it cannot send to", async () => {
+    // Given a template sending failures to a service outside the simulation.
+    const simAws = new SimAws();
+    const stack = await deployOrders(simAws, {
+      FunctionName: { Ref: "OrdersFunction" },
+      Qualifier: "$LATEST",
+      MaximumRetryAttempts: 0,
+      DestinationConfig: {
+        OnSuccess: { Destination: { "Fn::GetAtt": ["OrderFailures", "Arn"] } },
+        OnFailure: {
+          Destination: "arn:aws:kinesis:us-east-1:888888888888:stream/orders",
+        },
+      },
+    });
+
+    // Then the config is deployed with the destination it can reach, and the
+    // one it cannot is recorded rather than taking the Resource down.
+    const config = simAws.lambda().getSimEventInvokeConfig("orders");
+
+    assertNonNullable(config);
+    assertUndefined(config.settings.onFailureArn);
+    assertIdentical(
+      config.settings.onSuccessArn,
+      "arn:aws:sqs:us-east-1:888888888888:order-failures",
+    );
+
+    const [ignored, ...rest] = stack.ignoredProperties;
+    assertNonNullable(ignored, "a recorded destination");
+    assertArrayLength(rest, 0, "no second record");
+    assertIdentical(ignored.logicalId, "OrdersInvokeConfig");
+    assertIdentical(ignored.path, "DestinationConfig.OnFailure.Destination");
+    assertStringIncludes(ignored.reason, "kinesis");
+  });
+
+  it("records a property it does not read", async () => {
+    // Given a template with a made-up property on the Resource.
+    const simAws = new SimAws();
+    const stack = await deployOrders(simAws, {
+      ...failureConfigProperties(),
+      Nonsense: "true",
+    });
+
+    // Then the config still deploys, with the property recorded against it.
+    assertNonNullable(simAws.lambda().getSimEventInvokeConfig("orders"));
+
+    const [ignored] = stack.ignoredProperties;
+
+    assertNonNullable(ignored, "a recorded property");
+    assertIdentical(ignored.path, "Nonsense");
+    assertStringIncludes(
+      ignored.reason,
+      "Nonsense is not an AWS::Lambda::EventInvokeConfig property",
+    );
+  });
+
+  it("removes the config with the Stack that deployed it", async () => {
+    // Given a deployed function and a config on it.
+    const simAws = new SimAws();
+    const stack = await deployOrders(simAws, failureConfigProperties());
+
+    assertNonNullable(simAws.lambda().getSimEventInvokeConfig("orders"));
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then the config has gone, ahead of the function it was on.
+    assertUndefined(simAws.lambda().getSimEventInvokeConfig("orders"));
+    assertUndefined(simAws.lambda().getSimFunctionByName("orders"));
+    assertArrayLength(stack.skippedResourceDeletions, 0);
+    assertIdentical(
+      stack.getResource("OrdersInvokeConfig")?.status,
+      "DELETE_COMPLETE",
+    );
+  });
+
+  it("leaves a config something else removed alone", async () => {
+    // Given a deployed config that has since been deleted through the SDK.
+    const simAws = new SimAws();
+    const stack = await deployOrders(simAws, failureConfigProperties());
+    await simAws
+      .lambda()
+      .deleteFunctionEventInvokeConfig(
+        new DeleteFunctionEventInvokeConfigCommand({ FunctionName: "orders" }),
+      );
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then the teardown carries on rather than failing over a config that has
+    // already gone.
+    assertIdentical(
+      stack.getResource("OrdersInvokeConfig")?.status,
+      "DELETE_COMPLETE",
+    );
+    assertUndefined(simAws.lambda().getSimFunctionByName("orders"));
+  });
+
+  it("fails a Resource whose settings are malformed", async () => {
+    // Given a template asking for a retry count that is not a number.
+    const simAws = new SimAws();
+
+    // When the Stack is deployed, then the Resource fails with a diagnostic
+    // naming the property, rather than deploying a config that ignores it.
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: ordersTemplate({
+          ...failureConfigProperties(),
+          MaximumRetryAttempts: "none",
+        }),
+        bindings: [
+          { logicalId: "OrdersFunction", handler: (): string => "ordered" },
+        ],
+      });
+
+      await stack.waitForDeployComplete();
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::Lambda::EventInvokeConfig OrdersInvokeConfig: " +
+        "MaximumRetryAttempts must be a number",
+    );
+  });
+});

--- a/src/service/lambda/cfn/event-invoke-config/sim-cfn-lambda-event-invoke-config.iso.test.ts
+++ b/src/service/lambda/cfn/event-invoke-config/sim-cfn-lambda-event-invoke-config.iso.test.ts
@@ -1,146 +1,21 @@
 import {
-  DeleteFunctionEventInvokeConfigCommand,
-  InvokeCommand,
-} from "@aws-sdk/client-lambda";
-import { ReceiveMessageCommand } from "@aws-sdk/client-sqs";
-import {
   assertArrayLength,
   assertIdentical,
   assertNonNullable,
-  assertStringIncludes,
-  assertThrowsErrorAsync,
   assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
+import {
+  deployOrders,
+  failingOrdersBinding,
+  failureConfigProperties,
+  failureRecord,
+  invokeOrders,
+  ordersFailuresQueueArn,
+  ordersTemplate,
+} from "../../../../../test/lambda/cfn-event-invoke-config-fixture.js";
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimCfnStack } from "../../../cloudformation/stack/sim-cfn-stack.js";
-import type { CfnTemplateBodyRecord } from "../../../cloudformation/template/sim-cfn-template.js";
-import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
-import type { SimLambdaDestinationRecord } from "../../destination/sim-lambda-destination-record.js";
-
-const assumeRolePolicyDocument = {
-  Version: "2012-10-17",
-  Statement: [
-    {
-      Effect: "Allow",
-      Principal: { Service: "lambda.amazonaws.com" },
-      Action: "sts:AssumeRole",
-    },
-  ],
-};
-
-/**
- * A template with a queue for the failures, an orders function, and an event
- * invoke config sending the function's failures to the queue, as CDK
- * synthesizes for `onFailure`.
- */
-function ordersTemplate(
-  configProperties: SimCfnTemplateValueRecord,
-): CfnTemplateBodyRecord {
-  return {
-    Resources: {
-      OrderFailures: {
-        Type: "AWS::SQS::Queue",
-        Properties: { QueueName: "order-failures" },
-      },
-      OrdersRole: {
-        Type: "AWS::IAM::Role",
-        Properties: {
-          RoleName: "OrdersRole",
-          AssumeRolePolicyDocument: assumeRolePolicyDocument,
-        },
-      },
-      OrdersFunction: {
-        Type: "AWS::Lambda::Function",
-        Properties: {
-          FunctionName: "orders",
-          Role: { "Fn::GetAtt": ["OrdersRole", "Arn"] },
-        },
-      },
-      OrdersInvokeConfig: {
-        Type: "AWS::Lambda::EventInvokeConfig",
-        Properties: configProperties,
-      },
-    },
-  };
-}
-
-/**
- * The properties of a config on the function itself, sending failures to the
- * template's queue and giving up after the first attempt.
- */
-function failureConfigProperties(): SimCfnTemplateValueRecord {
-  return {
-    FunctionName: { Ref: "OrdersFunction" },
-    Qualifier: "$LATEST",
-    MaximumRetryAttempts: 0,
-    DestinationConfig: {
-      OnFailure: { Destination: { "Fn::GetAtt": ["OrderFailures", "Arn"] } },
-    },
-  };
-}
-
-/**
- * Deploy the orders template with a handler that always throws.
- */
-async function deployOrders(
-  simAws: SimAws,
-  configProperties: SimCfnTemplateValueRecord,
-): Promise<SimCfnStack> {
-  const stack = await simAws.cloudFormation().deployTemplate({
-    stackName: "orders-stack",
-    template: ordersTemplate(configProperties),
-    bindings: [
-      {
-        logicalId: "OrdersFunction",
-        handler: (): never => {
-          throw new Error("orders handler failed");
-        },
-      },
-    ],
-  });
-  await stack.waitForDeployComplete();
-
-  return stack;
-}
-
-/**
- * Invoke the deployed function asynchronously and let every retry it makes
- * fall due.
- */
-async function invokeOrders(simAws: SimAws, qualifier?: string): Promise<void> {
-  await simAws.lambda().invoke(
-    new InvokeCommand({
-      FunctionName: "orders",
-      Qualifier: qualifier,
-      InvocationType: "Event",
-      Payload: JSON.stringify({ id: 7 }),
-    }),
-  );
-  await simAws.backgroundTasksComplete();
-  await simAws.clock().advanceBy({ minutes: 5 });
-}
-
-/**
- * The one destination record waiting on the failures queue.
- */
-async function failureRecord(
-  simAws: SimAws,
-): Promise<SimLambdaDestinationRecord> {
-  const received = await simAws.sqs().receiveMessage(
-    new ReceiveMessageCommand({
-      QueueUrl: simAws.sqs().findQueue("order-failures")?.url,
-      MaxNumberOfMessages: 10,
-    }),
-  );
-
-  assertArrayLength(received.Messages ?? [], 1);
-  const body = received.Messages?.[0]?.Body;
-  assertNonNullable(body, "a destination record arrived");
-
-  return JSON.parse(body) as SimLambdaDestinationRecord;
-}
 
 describe("Lambda CloudFormation event invoke config deployment", () => {
   it("sends a failure to the destination AWS::Lambda::EventInvokeConfig names", async () => {
@@ -157,10 +32,7 @@ describe("Lambda CloudFormation event invoke config deployment", () => {
     assertNonNullable(config);
     assertIdentical(resource.simResource, config);
     assertIdentical(config.settings.maximumRetryAttempts, 0);
-    assertIdentical(
-      config.settings.onFailureArn,
-      "arn:aws:sqs:us-east-1:888888888888:order-failures",
-    );
+    assertIdentical(config.settings.onFailureArn, ordersFailuresQueueArn);
 
     // And an asynchronous invocation the handler throws on reaches the queue
     // the template named.
@@ -194,14 +66,8 @@ describe("Lambda CloudFormation event invoke config deployment", () => {
     assertNonNullable(config);
     assertIdentical(config.settings.maximumRetryAttempts, 1);
     assertIdentical(config.settings.maximumEventAgeInSeconds, 120);
-    assertIdentical(
-      config.settings.onSuccessArn,
-      "arn:aws:sqs:us-east-1:888888888888:order-failures",
-    );
-    assertIdentical(
-      config.settings.onFailureArn,
-      "arn:aws:sqs:us-east-1:888888888888:order-failures",
-    );
+    assertIdentical(config.settings.onSuccessArn, ordersFailuresQueueArn);
+    assertIdentical(config.settings.onFailureArn, ordersFailuresQueueArn);
   });
 
   it("points a Qualifier at the alias it names", async () => {
@@ -230,21 +96,12 @@ describe("Lambda CloudFormation event invoke config deployment", () => {
             Properties: {
               FunctionName: { Ref: "OrdersFunction" },
               Name: "live",
-              FunctionVersion: {
-                "Fn::GetAtt": ["OrdersVersion", "Version"],
-              },
+              FunctionVersion: { "Fn::GetAtt": ["OrdersVersion", "Version"] },
             },
           },
         },
       },
-      bindings: [
-        {
-          logicalId: "OrdersFunction",
-          handler: (): never => {
-            throw new Error("orders handler failed");
-          },
-        },
-      ],
+      bindings: [failingOrdersBinding()],
     });
     await stack.waitForDeployComplete();
 
@@ -260,61 +117,6 @@ describe("Lambda CloudFormation event invoke config deployment", () => {
     const record = await failureRecord(simAws);
 
     assertIdentical(record.requestContext.approximateInvokeCount, 1);
-  });
-
-  it("deploys the config without a destination it cannot send to", async () => {
-    // Given a template sending failures to a service outside the simulation.
-    const simAws = new SimAws();
-    const stack = await deployOrders(simAws, {
-      FunctionName: { Ref: "OrdersFunction" },
-      Qualifier: "$LATEST",
-      MaximumRetryAttempts: 0,
-      DestinationConfig: {
-        OnSuccess: { Destination: { "Fn::GetAtt": ["OrderFailures", "Arn"] } },
-        OnFailure: {
-          Destination: "arn:aws:kinesis:us-east-1:888888888888:stream/orders",
-        },
-      },
-    });
-
-    // Then the config is deployed with the destination it can reach, and the
-    // one it cannot is recorded rather than taking the Resource down.
-    const config = simAws.lambda().getSimEventInvokeConfig("orders");
-
-    assertNonNullable(config);
-    assertUndefined(config.settings.onFailureArn);
-    assertIdentical(
-      config.settings.onSuccessArn,
-      "arn:aws:sqs:us-east-1:888888888888:order-failures",
-    );
-
-    const [ignored, ...rest] = stack.ignoredProperties;
-    assertNonNullable(ignored, "a recorded destination");
-    assertArrayLength(rest, 0, "no second record");
-    assertIdentical(ignored.logicalId, "OrdersInvokeConfig");
-    assertIdentical(ignored.path, "DestinationConfig.OnFailure.Destination");
-    assertStringIncludes(ignored.reason, "kinesis");
-  });
-
-  it("records a property it does not read", async () => {
-    // Given a template with a made-up property on the Resource.
-    const simAws = new SimAws();
-    const stack = await deployOrders(simAws, {
-      ...failureConfigProperties(),
-      Nonsense: "true",
-    });
-
-    // Then the config still deploys, with the property recorded against it.
-    assertNonNullable(simAws.lambda().getSimEventInvokeConfig("orders"));
-
-    const [ignored] = stack.ignoredProperties;
-
-    assertNonNullable(ignored, "a recorded property");
-    assertIdentical(ignored.path, "Nonsense");
-    assertStringIncludes(
-      ignored.reason,
-      "Nonsense is not an AWS::Lambda::EventInvokeConfig property",
-    );
   });
 
   it("removes the config with the Stack that deployed it", async () => {
@@ -334,56 +136,6 @@ describe("Lambda CloudFormation event invoke config deployment", () => {
     assertIdentical(
       stack.getResource("OrdersInvokeConfig")?.status,
       "DELETE_COMPLETE",
-    );
-  });
-
-  it("leaves a config something else removed alone", async () => {
-    // Given a deployed config that has since been deleted through the SDK.
-    const simAws = new SimAws();
-    const stack = await deployOrders(simAws, failureConfigProperties());
-    await simAws
-      .lambda()
-      .deleteFunctionEventInvokeConfig(
-        new DeleteFunctionEventInvokeConfigCommand({ FunctionName: "orders" }),
-      );
-
-    // When the Stack's Resources are torn down.
-    await stack.teardown();
-
-    // Then the teardown carries on rather than failing over a config that has
-    // already gone.
-    assertIdentical(
-      stack.getResource("OrdersInvokeConfig")?.status,
-      "DELETE_COMPLETE",
-    );
-    assertUndefined(simAws.lambda().getSimFunctionByName("orders"));
-  });
-
-  it("fails a Resource whose settings are malformed", async () => {
-    // Given a template asking for a retry count that is not a number.
-    const simAws = new SimAws();
-
-    // When the Stack is deployed, then the Resource fails with a diagnostic
-    // naming the property, rather than deploying a config that ignores it.
-    const error = await assertThrowsErrorAsync(async () => {
-      const stack = await simAws.cloudFormation().deployTemplate({
-        stackName: "orders-stack",
-        template: ordersTemplate({
-          ...failureConfigProperties(),
-          MaximumRetryAttempts: "none",
-        }),
-        bindings: [
-          { logicalId: "OrdersFunction", handler: (): string => "ordered" },
-        ],
-      });
-
-      await stack.waitForDeployComplete();
-    });
-
-    assertStringIncludes(
-      error.message,
-      "Invalid AWS::Lambda::EventInvokeConfig OrdersInvokeConfig: " +
-        "MaximumRetryAttempts must be a number",
     );
   });
 });

--- a/src/service/lambda/cfn/event-invoke-config/sim-cfn-lambda-event-invoke-destinations.ts
+++ b/src/service/lambda/cfn/event-invoke-config/sim-cfn-lambda-event-invoke-destinations.ts
@@ -1,0 +1,80 @@
+import { isRecord } from "../../../../util/type-guard/record.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type {
+  SimLambdaDestination,
+  SimLambdaDestinationConfiguration,
+} from "../../function/event-invoke/sim-lambda-event-invoke-config.js";
+import { SimCfnLambdaPropertyParser } from "../function/sim-cfn-lambda-property-parser.js";
+import { SimCfnLambdaTargetArn } from "../sim-cfn-lambda-target-arn.js";
+
+/**
+ * Parses the nested AWS::Lambda::EventInvokeConfig DestinationConfig
+ * property.
+ *
+ * Its own parser because DestinationConfig is the one property of the
+ * Resource with a shape rather than a scalar: two ends, each an object holding
+ * somewhere to send to, and each read on its own so a config keeps the end it
+ * can reach when the other names somewhere it cannot.
+ */
+export class SimCfnLambdaEventInvokeDestinations {
+  private readonly propertyParser = new SimCfnLambdaPropertyParser();
+  private readonly targetArn = new SimCfnLambdaTargetArn();
+
+  /**
+   * Parse the DestinationConfig property into where results are sent.
+   */
+  parse(
+    resource: SimCfnResource,
+    config: SimCfnTemplateValue | undefined,
+  ): SimLambdaDestinationConfiguration | undefined {
+    if (config === undefined) {
+      return undefined;
+    }
+
+    if (!isRecord(config)) {
+      throw this.propertyParser.invalidPropertyError(
+        resource,
+        "DestinationConfig",
+        "an object",
+      );
+    }
+
+    return {
+      OnSuccess: this.destination(resource, config["OnSuccess"], "OnSuccess"),
+      OnFailure: this.destination(resource, config["OnFailure"], "OnFailure"),
+    };
+  }
+
+  /**
+   * One end of the config, left off where the simulation has nowhere to send
+   * it.
+   */
+  private destination(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    name: string,
+  ): SimLambdaDestination | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    const path = `DestinationConfig.${name}`;
+
+    if (!isRecord(value)) {
+      throw this.propertyParser.invalidPropertyError(
+        resource,
+        path,
+        "an object",
+      );
+    }
+
+    const destination = this.targetArn.destination(
+      resource,
+      value["Destination"],
+      `${path}.Destination`,
+    );
+
+    return destination === undefined ? undefined : { Destination: destination };
+  }
+}

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-dead-letter-config.iso.test.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-dead-letter-config.iso.test.ts
@@ -1,0 +1,195 @@
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import { ReceiveMessageCommand } from "@aws-sdk/client-sqs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCfnStack } from "../../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+const ordersQueueArn = "arn:aws:sqs:us-east-1:888888888888:orders-dlq";
+const ordersTopicArn = "arn:aws:sns:us-east-1:888888888888:orders-dead-letters";
+
+const assumeRolePolicyDocument = {
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Principal: { Service: "lambda.amazonaws.com" },
+      Action: "sts:AssumeRole",
+    },
+  ],
+};
+
+/**
+ * Deploy a failing orders function dead-lettering to whatever the given
+ * `DeadLetterConfig` names, beside a queue and a topic it could name.
+ */
+async function deployOrders(
+  simAws: SimAws,
+  deadLetterConfig: SimCfnTemplateValue,
+): Promise<SimCfnStack> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "orders-stack",
+    template: {
+      Resources: {
+        OrdersDeadLetterQueue: {
+          Type: "AWS::SQS::Queue",
+          Properties: { QueueName: "orders-dlq" },
+        },
+        OrdersDeadLetterTopic: {
+          Type: "AWS::SNS::Topic",
+          Properties: { TopicName: "orders-dead-letters" },
+        },
+        OrdersRole: {
+          Type: "AWS::IAM::Role",
+          Properties: {
+            RoleName: "OrdersRole",
+            AssumeRolePolicyDocument: assumeRolePolicyDocument,
+          },
+        },
+        OrdersFunction: {
+          Type: "AWS::Lambda::Function",
+          Properties: {
+            FunctionName: "orders",
+            Role: { "Fn::GetAtt": ["OrdersRole", "Arn"] },
+            DeadLetterConfig: deadLetterConfig,
+          },
+        },
+      },
+    },
+    bindings: [
+      {
+        logicalId: "OrdersFunction",
+        handler: (): never => {
+          throw new Error("orders handler failed");
+        },
+      },
+    ],
+  });
+  await stack.waitForDeployComplete();
+
+  return stack;
+}
+
+/**
+ * The dead-letter target the deployed function ended up with.
+ */
+function deadLetterTargetArn(simAws: SimAws): string | undefined {
+  const simFunction = simAws.lambda().getSimFunctionByName("orders");
+  assertNonNullable(simFunction, "the deployed function");
+
+  return simFunction.deadLetterTargetArn;
+}
+
+describe("Lambda CloudFormation Function DeadLetterConfig", () => {
+  it("dead-letters to the queue Fn::GetAtt names", async () => {
+    // Given a deployed function dead-lettering to a queue in the same
+    // template, as CDK's deadLetterQueue synthesizes.
+    const simAws = new SimAws();
+    await deployOrders(simAws, {
+      TargetArn: { "Fn::GetAtt": ["OrdersDeadLetterQueue", "Arn"] },
+    });
+
+    assertIdentical(deadLetterTargetArn(simAws), ordersQueueArn);
+
+    // When an asynchronous invocation fails every attempt it is given.
+    await simAws.lambda().invoke(
+      new InvokeCommand({
+        FunctionName: "orders",
+        InvocationType: "Event",
+        Payload: JSON.stringify({ id: 7 }),
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+    await simAws.clock().advanceBy({ minutes: 5 });
+
+    // Then the event as it was invoked is waiting on the deployed queue.
+    const received = await simAws.sqs().receiveMessage(
+      new ReceiveMessageCommand({
+        QueueUrl: simAws.sqs().findQueue("orders-dlq")?.url,
+        MaxNumberOfMessages: 10,
+      }),
+    );
+
+    assertArrayLength(received.Messages ?? [], 1);
+    assertIdentical(received.Messages?.[0]?.Body, '{"id":7}');
+  });
+
+  it("reads a Ref to a queue as the queue it names", async () => {
+    // Given a template naming its dead-letter queue by Ref, which resolves to
+    // the queue URL rather than the ARN.
+    const simAws = new SimAws();
+    await deployOrders(simAws, { TargetArn: { Ref: "OrdersDeadLetterQueue" } });
+
+    // Then the function dead-letters to that same queue.
+    assertIdentical(deadLetterTargetArn(simAws), ordersQueueArn);
+  });
+
+  it("reads a Ref to a topic as the topic it names", async () => {
+    // Given a template dead-lettering to a topic instead.
+    const simAws = new SimAws();
+    await deployOrders(simAws, { TargetArn: { Ref: "OrdersDeadLetterTopic" } });
+
+    // Then the function dead-letters to the topic.
+    assertIdentical(deadLetterTargetArn(simAws), ordersTopicArn);
+  });
+
+  it("deploys the function without a target it cannot dead-letter to", async () => {
+    // Given a template naming a target real Lambda would refuse.
+    const simAws = new SimAws();
+    const stack = await deployOrders(simAws, {
+      TargetArn: "arn:aws:kinesis:us-east-1:888888888888:stream/orders",
+    });
+
+    // Then the function is deployed without a dead-letter target, and the
+    // omission is recorded rather than taking the function down with it.
+    assertUndefined(deadLetterTargetArn(simAws));
+
+    const [ignored, ...rest] = stack.ignoredProperties;
+
+    assertNonNullable(ignored, "a recorded dead-letter target");
+    assertArrayLength(rest, 0, "no second record");
+    assertIdentical(ignored.logicalId, "OrdersFunction");
+    assertIdentical(ignored.path, "DeadLetterConfig.TargetArn");
+    assertStringIncludes(ignored.reason, "kinesis");
+  });
+
+  it("rejects a DeadLetterConfig that is not an object", async () => {
+    // Given a template whose DeadLetterConfig is a bare ARN string.
+    const simAws = new SimAws();
+
+    // When the Stack is deployed, then it fails naming the property.
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployOrders(simAws, ordersQueueArn);
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::Lambda::Function OrdersFunction: DeadLetterConfig must " +
+        "be an object",
+    );
+  });
+
+  it("rejects a TargetArn that is not a string", async () => {
+    // Given a template whose TargetArn is a number.
+    const simAws = new SimAws();
+
+    // When the Stack is deployed, then it fails naming the property.
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployOrders(simAws, { TargetArn: 7 });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "DeadLetterConfig.TargetArn must be a string",
+    );
+  });
+});

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-dead-letter-parser.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-dead-letter-parser.ts
@@ -1,0 +1,47 @@
+import { isRecord } from "../../../../util/type-guard/record.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimLambdaDeadLetterConfigInput } from "../../function/event-invoke/lambda-dead-letter-target.js";
+import { SimCfnLambdaTargetArn } from "../sim-cfn-lambda-target-arn.js";
+import { SimCfnLambdaPropertyParser } from "./sim-cfn-lambda-property-parser.js";
+
+/**
+ * Parses the nested AWS::Lambda::Function DeadLetterConfig property.
+ *
+ * This is what CDK's `deadLetterQueue` synthesizes, and a template names the
+ * queue or topic by `Fn::GetAtt` on its ARN or by `Ref`, so both are read the
+ * way an event source mapping reads the source it polls.
+ */
+export class SimCfnLambdaDeadLetterParser {
+  private readonly propertyParser = new SimCfnLambdaPropertyParser();
+  private readonly targetArn = new SimCfnLambdaTargetArn();
+
+  /**
+   * Parse the DeadLetterConfig property into the dead-letter target the
+   * function is created with.
+   */
+  parse(
+    resource: SimCfnResource,
+    config: SimCfnTemplateValue | undefined,
+  ): SimLambdaDeadLetterConfigInput | undefined {
+    if (config === undefined) {
+      return undefined;
+    }
+
+    if (!isRecord(config)) {
+      throw this.propertyParser.invalidPropertyError(
+        resource,
+        "DeadLetterConfig",
+        "an object",
+      );
+    }
+
+    const targetArn = this.targetArn.deadLetter(
+      resource,
+      config["TargetArn"],
+      "DeadLetterConfig.TargetArn",
+    );
+
+    return targetArn === undefined ? undefined : { TargetArn: targetArn };
+  }
+}

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-function-properties-parser.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-function-properties-parser.ts
@@ -2,11 +2,13 @@ import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-re
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import { makeSimRoleArn } from "../../../iam/role/arn/sim-iam-role-arn.js";
 import type { SimIamRoleName } from "../../../iam/role/sim-iam-role.js";
+import type { SimLambdaDeadLetterConfigInput } from "../../function/event-invoke/lambda-dead-letter-target.js";
 import type {
   SimCreateFunctionCommandInput,
   SimLambdaFunctionCode,
   SimLambdaFunctionEnvironment,
 } from "../../command/create-function/create-function.command.js";
+import { SimCfnLambdaDeadLetterParser } from "./sim-cfn-lambda-dead-letter-parser.js";
 import { SimCfnLambdaEnvironmentParser } from "./sim-cfn-lambda-environment-parser.js";
 import { SimCfnLambdaFunctionCodeParser } from "./sim-cfn-lambda-function-code-parser.js";
 import { SimCfnLambdaPropertyParser } from "./sim-cfn-lambda-property-parser.js";
@@ -23,6 +25,7 @@ export interface SimCfnLambdaFunctionProperties {
   readonly timeoutSeconds: number | undefined;
   readonly memorySizeMb: number | undefined;
   readonly environment: SimLambdaFunctionEnvironment | undefined;
+  readonly deadLetterConfig: SimLambdaDeadLetterConfigInput | undefined;
 }
 
 /**
@@ -44,6 +47,7 @@ export function simCfnLambdaCreateFunctionInput(
     Timeout: functionProperties.timeoutSeconds,
     MemorySize: functionProperties.memorySizeMb,
     Environment: functionProperties.environment,
+    DeadLetterConfig: functionProperties.deadLetterConfig,
   };
 }
 
@@ -58,6 +62,7 @@ export class SimCfnLambdaFunctionPropertiesParser {
   private readonly propertyParser = new SimCfnLambdaPropertyParser();
   private readonly codeParser = new SimCfnLambdaFunctionCodeParser();
   private readonly environmentParser = new SimCfnLambdaEnvironmentParser();
+  private readonly deadLetterParser = new SimCfnLambdaDeadLetterParser();
 
   /**
    * Parse the resolved CloudFormation properties for an AWS::Lambda::Function.
@@ -106,6 +111,10 @@ export class SimCfnLambdaFunctionPropertiesParser {
       environment: this.environmentParser.parse(
         resource,
         properties["Environment"],
+      ),
+      deadLetterConfig: this.deadLetterParser.parse(
+        resource,
+        properties["DeadLetterConfig"],
       ),
     };
   }

--- a/src/service/lambda/cfn/sim-cfn-lambda-resource-deleter.ts
+++ b/src/service/lambda/cfn/sim-cfn-lambda-resource-deleter.ts
@@ -5,6 +5,7 @@ import type { SimLambdaFunctionUrl } from "../function/url/sim-lambda-function-u
 import type { SimLambdaEventSourceMapping } from "../event-source/sim-lambda-event-source-mapping.js";
 import type { SimLambdaFunctionAlias } from "../function/version/sim-lambda-function-alias.js";
 import { simCfnLambdaCreatedResource } from "./sim-cfn-lambda-created-resource.js";
+import { simCfnLambdaRemoveEventInvokeConfig } from "./event-invoke-config/sim-cfn-lambda-event-invoke-config-remover.js";
 import { simCfnLambdaRevokePermission } from "./permission/sim-cfn-lambda-permission-revoker.js";
 import { simCfnLambdaTargetFunctionName } from "./function/sim-cfn-lambda-target-function.js";
 
@@ -44,6 +45,10 @@ export class SimCfnLambdaResourceDeleter {
       }
       case "EventSourceMapping": {
         await this.deleteEventSourceMapping(resource);
+        return;
+      }
+      case "EventInvokeConfig": {
+        await simCfnLambdaRemoveEventInvokeConfig(this.lambda, resource);
         return;
       }
       case "Permission": {

--- a/src/service/lambda/cfn/sim-cfn-lambda-resource-factory.ts
+++ b/src/service/lambda/cfn/sim-cfn-lambda-resource-factory.ts
@@ -5,6 +5,7 @@ import type {
 import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
 import type { SimLambda } from "../sim-lambda.js";
 import { SimCfnLambdaAliasCreator } from "./alias/sim-cfn-lambda-alias-creator.js";
+import { SimCfnLambdaEventInvokeConfigCreator } from "./event-invoke-config/sim-cfn-lambda-event-invoke-config-creator.js";
 import { SimCfnLambdaEventSourceMappingCreator } from "./event-source-mapping/sim-cfn-lambda-event-source-mapping-creator.js";
 import { SimCfnLambdaFunctionCreator } from "./function/sim-cfn-lambda-function-creator.js";
 import { SimCfnLambdaPermissionCreator } from "./permission/sim-cfn-lambda-permission-creator.js";
@@ -22,6 +23,7 @@ export class SimLambdaCloudFormationResourceFactory implements SimCfnServiceReso
   private readonly versionCreator: SimCfnLambdaVersionCreator;
   private readonly aliasCreator: SimCfnLambdaAliasCreator;
   private readonly eventSourceMappingCreator: SimCfnLambdaEventSourceMappingCreator;
+  private readonly eventInvokeConfigCreator: SimCfnLambdaEventInvokeConfigCreator;
   private readonly deleter: SimCfnLambdaResourceDeleter;
 
   constructor(lambda: SimLambda) {
@@ -32,6 +34,9 @@ export class SimLambdaCloudFormationResourceFactory implements SimCfnServiceReso
     this.versionCreator = new SimCfnLambdaVersionCreator({ lambda });
     this.aliasCreator = new SimCfnLambdaAliasCreator({ lambda });
     this.eventSourceMappingCreator = new SimCfnLambdaEventSourceMappingCreator({
+      lambda,
+    });
+    this.eventInvokeConfigCreator = new SimCfnLambdaEventInvokeConfigCreator({
       lambda,
     });
   }
@@ -60,6 +65,12 @@ export class SimLambdaCloudFormationResourceFactory implements SimCfnServiceReso
       }
       case "EventSourceMapping": {
         return await this.eventSourceMappingCreator.create(
+          resource,
+          context.resolvedProperties ?? resource.properties,
+        );
+      }
+      case "EventInvokeConfig": {
+        return await this.eventInvokeConfigCreator.create(
           resource,
           context.resolvedProperties ?? resource.properties,
         );

--- a/src/service/lambda/cfn/sim-cfn-lambda-target-arn.ts
+++ b/src/service/lambda/cfn/sim-cfn-lambda-target-arn.ts
@@ -1,0 +1,112 @@
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValue } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import { sqsQueueArn } from "../../sqs/queue/sim-sqs-queue-arn.js";
+import { SimSqsQueueUrl } from "../../sqs/queue/sim-sqs-queue-url.js";
+import { SimLambdaDestinationArn } from "../destination/sim-lambda-destination-arn.js";
+import { SimLambdaInvalidParameterValueException } from "../error/sim-lambda.error.js";
+import { requireLambdaDeadLetterTarget } from "../function/event-invoke/lambda-dead-letter-target.js";
+import { SimCfnLambdaPropertyParser } from "./function/sim-cfn-lambda-property-parser.js";
+
+/**
+ * How an ARN a template property names is read, which is by the same reader
+ * the SDK path uses.
+ */
+type SimCfnLambdaTargetReader = (arn: string) => string | undefined;
+
+/**
+ * Reads the template properties naming where a function's asynchronous
+ * invocations end up.
+ *
+ * A destination and a dead-letter target are named the same way and go wrong
+ * the same way, so they are read here rather than beside each of the two
+ * Resources carrying one.
+ *
+ * Neither takes the Resource down with it. A destination naming a Resource
+ * simulated CloudFormation skipped, or a service outside the template, is
+ * recorded against the Resource and left off it, so the function still
+ * deploys and a test can find out where its failures are not going. A stack
+ * refusing to deploy a function over one destination is the outcome issue
+ * #823 was about.
+ */
+export class SimCfnLambdaTargetArn {
+  private readonly parser = new SimCfnLambdaPropertyParser();
+
+  /**
+   * Where an asynchronous invocation result is sent, if it can be sent there.
+   */
+  destination(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    path: string,
+  ): string | undefined {
+    return this.usable(
+      resource,
+      value,
+      path,
+      (arn) => SimLambdaDestinationArn.of(arn).value,
+    );
+  }
+
+  /**
+   * Where an asynchronous event that was given up on is kept, if it can be
+   * kept there.
+   */
+  deadLetter(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    path: string,
+  ): string | undefined {
+    return this.usable(resource, value, path, (arn) =>
+      requireLambdaDeadLetterTarget({ TargetArn: arn }),
+    );
+  }
+
+  /**
+   * The ARN this property names, or nothing when the simulation will not send
+   * there and has recorded why.
+   */
+  private usable(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    path: string,
+    read: SimCfnLambdaTargetReader,
+  ): string | undefined {
+    const named = this.parser.optionalString(resource, value, path);
+
+    if (named === undefined || named === "") {
+      return undefined;
+    }
+
+    try {
+      return read(queueUrlAsArn(named));
+    } catch (error) {
+      if (error instanceof SimLambdaInvalidParameterValueException) {
+        resource.ignoreProperty(
+          path,
+          `${path} names ${named}, which simulated Lambda has nowhere to ` +
+            `send to, so the Resource is deployed without it: ${error.message}`,
+        );
+
+        return undefined;
+      }
+
+      /* v8 ignore next 2 -- unreachable: reading an ARN refuses one it cannot
+         use and does nothing else that throws. */
+      throw error;
+    }
+  }
+}
+
+/**
+ * A queue named by its URL, read as the ARN every other way of naming a queue
+ * gives.
+ *
+ * `Ref` on an `AWS::SQS::Queue` resolves to the queue's URL, since that is
+ * what an SDK request names a queue by, while everything here names a queue by
+ * ARN. A template pointing at a queue either way means the same queue.
+ */
+function queueUrlAsArn(named: string): string {
+  const queue = SimSqsQueueUrl.parse(named);
+
+  return queue === undefined ? named : sqsQueueArn(queue);
+}

--- a/src/service/lambda/sim-lambda-inspection.ts
+++ b/src/service/lambda/sim-lambda-inspection.ts
@@ -1,4 +1,5 @@
 import type { SimLambdaEventSourceMapping } from "./event-source/sim-lambda-event-source-mapping.js";
+import type { SimLambdaEventInvokeConfig } from "./function/event-invoke/sim-lambda-event-invoke-config.js";
 import type {
   SimLambdaFunction,
   SimLambdaFunctionMap,
@@ -30,6 +31,23 @@ export abstract class SimLambdaInspection {
     uuid: string,
   ): SimLambdaEventSourceMapping | undefined {
     return this.commands.eventSourceMappings.find(uuid);
+  }
+
+  /**
+   * Get the event invoke config one function name and qualifier hold, if they
+   * hold one.
+   *
+   * A config written without a qualifier belongs to `$LATEST`, which is how a
+   * function's own config is addressed.
+   */
+  getSimEventInvokeConfig(
+    functionName: SimLambdaFunctionName | string,
+    qualifier?: string,
+  ): SimLambdaEventInvokeConfig | undefined {
+    return this.commands.eventInvokeConfigStore.get({
+      functionName,
+      qualifier,
+    });
   }
 
   /** Get a simulated Lambda function instance by name. */

--- a/test/lambda/cfn-event-invoke-config-fixture.ts
+++ b/test/lambda/cfn-event-invoke-config-fixture.ts
@@ -1,0 +1,159 @@
+/**
+ * Setup shared by the AWS::Lambda::EventInvokeConfig deployment tests, which
+ * all need a template holding a failing function and somewhere for its results
+ * to go.
+ *
+ * This lives under `test/` for the same reasons as
+ * `test/lambda/async-destination-fixture.ts`: eslint rejects a test file that
+ * exports helpers alongside its own `describe` calls, and `test/**` is
+ * type-checked with everything else, excluded from the published build, not
+ * collected as a suite, and not counted in coverage.
+ */
+
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import { ReceiveMessageCommand } from "@aws-sdk/client-sqs";
+import { assertArrayLength, assertNonNullable } from "@kensio/smartass";
+
+import type { SimAws } from "../../src/service/aws/sim-aws.js";
+import type { SimCfnStack } from "../../src/service/cloudformation/stack/sim-cfn-stack.js";
+import type { CfnTemplateBodyRecord } from "../../src/service/cloudformation/template/sim-cfn-template.js";
+import type { SimCfnTemplateValueRecord } from "../../src/service/cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimLambdaDestinationRecord } from "../../src/service/lambda/destination/sim-lambda-destination-record.js";
+
+export const ordersFailuresQueueArn =
+  "arn:aws:sqs:us-east-1:888888888888:order-failures";
+
+const assumeRolePolicyDocument = {
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Principal: { Service: "lambda.amazonaws.com" },
+      Action: "sts:AssumeRole",
+    },
+  ],
+};
+
+/**
+ * A template with a queue for the failures, an orders function, and an event
+ * invoke config sending the function's failures to the queue, as CDK
+ * synthesizes for `onFailure`.
+ */
+export function ordersTemplate(
+  configProperties: SimCfnTemplateValueRecord,
+): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      OrderFailures: {
+        Type: "AWS::SQS::Queue",
+        Properties: { QueueName: "order-failures" },
+      },
+      OrdersRole: {
+        Type: "AWS::IAM::Role",
+        Properties: {
+          RoleName: "OrdersRole",
+          AssumeRolePolicyDocument: assumeRolePolicyDocument,
+        },
+      },
+      OrdersFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "orders",
+          Role: { "Fn::GetAtt": ["OrdersRole", "Arn"] },
+        },
+      },
+      OrdersInvokeConfig: {
+        Type: "AWS::Lambda::EventInvokeConfig",
+        Properties: configProperties,
+      },
+    },
+  };
+}
+
+/**
+ * The properties of a config on the function itself, sending failures to the
+ * template's queue and giving up after the first attempt.
+ */
+export function failureConfigProperties(): SimCfnTemplateValueRecord {
+  return {
+    FunctionName: { Ref: "OrdersFunction" },
+    Qualifier: "$LATEST",
+    MaximumRetryAttempts: 0,
+    DestinationConfig: {
+      OnFailure: { Destination: { "Fn::GetAtt": ["OrderFailures", "Arn"] } },
+    },
+  };
+}
+
+/**
+ * The binding backing the template's function with a handler that always
+ * throws.
+ */
+export function failingOrdersBinding(): {
+  logicalId: string;
+  handler: () => never;
+} {
+  return {
+    logicalId: "OrdersFunction",
+    handler: (): never => {
+      throw new Error("orders handler failed");
+    },
+  };
+}
+
+/**
+ * Deploy the orders template with a handler that always throws.
+ */
+export async function deployOrders(
+  simAws: SimAws,
+  configProperties: SimCfnTemplateValueRecord,
+): Promise<SimCfnStack> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "orders-stack",
+    template: ordersTemplate(configProperties),
+    bindings: [failingOrdersBinding()],
+  });
+  await stack.waitForDeployComplete();
+
+  return stack;
+}
+
+/**
+ * Invoke the deployed function asynchronously and let every retry it makes
+ * fall due.
+ */
+export async function invokeOrders(
+  simAws: SimAws,
+  qualifier?: string,
+): Promise<void> {
+  await simAws.lambda().invoke(
+    new InvokeCommand({
+      FunctionName: "orders",
+      Qualifier: qualifier,
+      InvocationType: "Event",
+      Payload: JSON.stringify({ id: 7 }),
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+  await simAws.clock().advanceBy({ minutes: 5 });
+}
+
+/**
+ * The one destination record waiting on the failures queue.
+ */
+export async function failureRecord(
+  simAws: SimAws,
+): Promise<SimLambdaDestinationRecord> {
+  const received = await simAws.sqs().receiveMessage(
+    new ReceiveMessageCommand({
+      QueueUrl: simAws.sqs().findQueue("order-failures")?.url,
+      MaxNumberOfMessages: 10,
+    }),
+  );
+
+  assertArrayLength(received.Messages ?? [], 1);
+  const body = received.Messages?.[0]?.Body;
+  assertNonNullable(body, "a destination record arrived");
+
+  return JSON.parse(body) as SimLambdaDestinationRecord;
+}


### PR DESCRIPTION
A CDK stack that sets `onFailure`, `deadLetterQueue` or `retryAttempts` on a function synthesizes an `AWS::Lambda::EventInvokeConfig` that simulated CloudFormation skipped, and a `DeadLetterConfig` property it never read. Both are now deployed. The event invoke config is written through `PutFunctionEventInvokeConfig` against the function or the qualifier its `FunctionName` and `Qualifier` name, carrying `MaximumRetryAttempts`, `MaximumEventAgeInSeconds` and `DestinationConfig`, and a teardown takes it off the function again. A destination and a dead-letter target both name their queue or topic by `Fn::GetAtt` on the ARN or by `Ref`. One naming somewhere the simulation has nowhere to send to is recorded against the Resource and left off it, and the function deploys without it.

Resolves #845