### PR TITLE
Register a passkey for a signed-in user

### DIFF
--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -4038,9 +4038,10 @@ Cognito evaluates no IAM policy for any of them. That is what makes a passkey so
 to an account it is already signed in to. The first one has to be registered from a session some
 other factor started.
 
-The pool needs a relying party ID before it can register anything. It arrives as
+The pool needs a relying party before it can register anything. It arrives as
 `WebAuthnConfiguration.RelyingPartyId` on `SetUserPoolMfaConfig`, or as `WebAuthnRelyingPartyID` on
-an `AWS::Cognito::UserPool` Resource. A pool that names none refuses the registration with
+an `AWS::Cognito::UserPool` Resource. A pool that names none falls back to its own hosted domain,
+which is what real Cognito falls back to, and a pool with neither refuses the registration with
 `WebAuthnConfigurationMissingException`.
 
 `StartWebAuthnRegistration` answers with the `CredentialCreationOptions` a browser passes to
@@ -4146,20 +4147,23 @@ console.log(listed.Credentials?.[0]?.RelyingPartyId); // "myapp.example.com"
 
 The keys are real. Every passkey is an ECDSA key pair over P-256, and the credential carries the
 public half as base64url of its SubjectPublicKeyInfo, where a browser's own
-`PublicKeyCredential.toJSON()` puts it. The pool stores that key against the credential id and
-checks signatures with it. A test that would rather hold its own key can build the credential
-document by hand, because nothing here reads a field a browser leaves out.
+`PublicKeyCredential.toJSON()` puts it. The pool reads the key itself rather than the algorithm the
+credential names beside it, so an RSA key labelled `-7` is refused. A test that would rather hold
+its own key can build the credential document by hand, because nothing here reads a field a browser
+leaves out.
 
 What the pool was sent is read rather than trusted. The client data has to name the ceremony, answer
 the challenge the pool issued and carry the relying party's own origin, and the authenticator data
 has to hash to the relying party the pool registers against. A spent or unknown challenge is refused
 with `WebAuthnChallengeNotFoundException`, another origin with
 `WebAuthnOriginNotAllowedException`, another domain with `WebAuthnRelyingPartyMismatchException`,
-and a key the pool cannot read with `WebAuthnCredentialNotSupportedException`.
+and a key the pool cannot use with `WebAuthnCredentialNotSupportedException`. A refusal spends the
+challenge, so a registration that was refused is started again rather than retried.
 
 `ListWebAuthnCredentials` reports each passkey with the credential id, the relying party, how the
 authenticator says it is attached and how it can be reached, and when it was registered. It pages by
-`MaxResults` and `NextToken`, twenty to a page at most. `FriendlyCredentialName` is the relying
+`MaxResults` and `NextToken`, twenty to a page at most, and a `MaxResults` of zero is read as the
+whole page, which is what Cognito documents as its minimum. `FriendlyCredentialName` is the relying
 party ID. Real Cognito reads the authenticator's own model out of the attestation and names the
 credential after it, and this simulation parses no attestation.
 
@@ -4294,8 +4298,11 @@ Current documented limitations:
 - A passkey's `attestationObject` is stored by nobody and parsed by nothing. The public key is read
   from `response.publicKey`, where a browser's own JSON serialization puts it, and the credential is
   named after the relying party because the authenticator model real Cognito names it after lives in
-  the attestation. `ES256` is the only algorithm accepted, and a credential naming another is
-  refused with `WebAuthnCredentialNotSupportedException`.
+  the attestation. `ES256` is the only algorithm accepted, and a key of another kind is refused with
+  `WebAuthnCredentialNotSupportedException` whatever the credential labels it.
+- `ListWebAuthnCredentials` reads a `MaxResults` of zero as the whole page. Cognito documents zero
+  as the minimum for this listing and says nothing about what it answers with, and what a real pool
+  does with it was not checked against a live account.
 - The private half of a passkey lives in the simulator, because a test has no authenticator to hold
   it. `SimCognitoUserPool.webAuthnCredential` is what reads a credential out of it, and it is a
   deliberate divergence rather than an operation to write application code against. The signatures

--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -1053,6 +1053,11 @@ Token lifetimes default to an hour for access and ID tokens and thirty days for 
 units are separate inputs, so `AccessTokenValidity: 1` means an hour and `RefreshTokenValidity: 1`
 means a day unless `TokenValidityUnits` says otherwise.
 
+`AuthSessionValidity` is how long a challenge issued through the client can be answered for. It is
+counted in whole minutes, between three and fifteen, and a client that asked for none gets the
+three minutes real Cognito gives it. A test with anything to say about a challenge session running
+out is quicker to write against a client that asked for fifteen.
+
 The legacy authentication flows (`ADMIN_NO_SRP_AUTH`, `CUSTOM_AUTH_FLOW_ONLY` and
 `USER_PASSWORD_AUTH`) work on their own, and a request mixing them with the `ALLOW_` prefixed values
 is refused, as real Cognito refuses it. A client holding `ADMIN_NO_SRP_AUTH` can run
@@ -3148,7 +3153,8 @@ The properties each type reads are the ones this simulation models:
   records.
 - `AWS::Cognito::UserPoolClient`: `UserPoolId`, `ClientName`, `GenerateSecret`, `ExplicitAuthFlows`,
   `PreventUserExistenceErrors`, `AccessTokenValidity`, `IdTokenValidity`, `RefreshTokenValidity`,
-  `RefreshTokenRotation`, `TokenValidityUnits`, `AllowedOAuthFlowsUserPoolClient`,
+  `AuthSessionValidity`, `RefreshTokenRotation`, `TokenValidityUnits`,
+  `AllowedOAuthFlowsUserPoolClient`,
   `AllowedOAuthFlows`, `AllowedOAuthScopes`, `CallbackURLs`, `LogoutURLs`, `DefaultRedirectURI` and
   `SupportedIdentityProviders`.
 - `AWS::Cognito::UserPoolGroup`: `UserPoolId`, `GroupName`, `Description`, `Precedence` and
@@ -3914,10 +3920,9 @@ the phone number, not the email address, of a user that has both, because the ph
 factor.
 
 A wrong code is refused with `CodeMismatchException` and leaves the challenge standing. The user can
-be asked to type it again. Every session lasts three minutes, what real Cognito gives
-an app client that names no `AuthSessionValidity` of its own, and that input is refused here. A
-session that has run out, one already spent, and one issued for a different challenge are each
-refused with `NotAuthorizedException`.
+be asked to type it again. How long a session lasts is the app client's `AuthSessionValidity`,
+three minutes on a client that asked for none. A session that has run out, one already spent, and
+one issued for a different challenge are each refused with `NotAuthorizedException`.
 
 `PostAuthentication` runs where the tokens are issued, the response rather than the sign-in that
 was challenged. `PreTokenGeneration` runs there too, reporting
@@ -4024,6 +4029,143 @@ const signedIn = await cognito.respondToAuthChallenge(
 console.log(typeof signedIn.AuthenticationResult?.AccessToken); // "string"
 ```
 
+## Registering a passkey
+
+`StartWebAuthnRegistration` and `CompleteWebAuthnRegistration` register a passkey for the user whose
+access token authorized the call. `ListWebAuthnCredentials` reads back what that user has, and
+`DeleteWebAuthnCredential` forgets one. All four are authorized by the access token alone, and real
+Cognito evaluates no IAM policy for any of them. That is what makes a passkey something a user adds
+to an account it is already signed in to. The first one has to be registered from a session some
+other factor started.
+
+The pool needs a relying party ID before it can register anything. It arrives as
+`WebAuthnConfiguration.RelyingPartyId` on `SetUserPoolMfaConfig`, or as `WebAuthnRelyingPartyID` on
+an `AWS::Cognito::UserPool` Resource. A pool that names none refuses the registration with
+`WebAuthnConfigurationMissingException`.
+
+`StartWebAuthnRegistration` answers with the `CredentialCreationOptions` a browser passes to
+`navigator.credentials.create()`. They carry a fresh challenge, the relying party, the user handle
+(the user's `sub`), the ECDSA P-256 algorithm the pool takes, and the passkeys the user already has
+under `excludeCredentials`. Starting a second registration replaces the first, and the challenge the
+browser was part way through answering is spent.
+
+A test has no browser and no phone. The simulator plays the authenticator instead, and
+`SimCognitoUserPool.webAuthnCredential` hands back the credential the user's own device would have
+made from the options it was just given, in the way `softwareTokenCode` hands back the code an
+authenticator app would be showing. Pass that credential to `CompleteWebAuthnRegistration`.
+
+```typescript sim-cognito-passkey-registration
+/**
+ * Registering a passkey for a signed-in user.
+ */
+
+import {
+  AdminCreateUserCommand,
+  AdminSetUserPasswordCommand,
+  CompleteWebAuthnRegistrationCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  InitiateAuthCommand,
+  ListWebAuthnCredentialsCommand,
+  SetUserPoolMfaConfigCommand,
+  StartWebAuthnRegistrationCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const cognito = new SimAws().cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+);
+const userPoolId = pool.UserPool!.Id!;
+
+// A passkey belongs to a domain, and the pool has to name the one it registers
+// against.
+await cognito.setUserPoolMfaConfig(
+  new SetUserPoolMfaConfigCommand({
+    UserPoolId: userPoolId,
+    MfaConfiguration: "OPTIONAL",
+    WebAuthnConfiguration: {
+      RelyingPartyId: "myapp.example.com",
+      UserVerification: "required",
+    },
+  }),
+);
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: userPoolId,
+    ClientName: "web",
+    ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH"],
+  }),
+);
+
+await cognito.adminCreateUser(
+  new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+);
+await cognito.adminSetUserPassword(
+  new AdminSetUserPasswordCommand({
+    UserPoolId: userPoolId,
+    Username: "alice",
+    Password: "Sup3rSecret!",
+    Permanent: true,
+  }),
+);
+
+// A passkey is added from a session that already exists, so the user signs in
+// with its password first.
+const signedIn = await cognito.initiateAuth(
+  new InitiateAuthCommand({
+    ClientId: appClient.UserPoolClient!.ClientId!,
+    AuthFlow: "USER_PASSWORD_AUTH",
+    AuthParameters: { USERNAME: "alice", PASSWORD: "Sup3rSecret!" },
+  }),
+);
+const AccessToken = signedIn.AuthenticationResult!.AccessToken!;
+
+// The options a browser would hand to navigator.credentials.create().
+await cognito.startWebAuthnRegistration(
+  new StartWebAuthnRegistrationCommand({ AccessToken }),
+);
+
+// The credential that browser's authenticator would have handed back.
+await cognito.completeWebAuthnRegistration(
+  new CompleteWebAuthnRegistrationCommand({
+    AccessToken,
+    Credential: cognito.userPool(userPoolId).webAuthnCredential("alice"),
+  }),
+);
+
+const listed = await cognito.listWebAuthnCredentials(
+  new ListWebAuthnCredentialsCommand({ AccessToken }),
+);
+
+console.log(listed.Credentials?.[0]?.RelyingPartyId); // "myapp.example.com"
+```
+
+The keys are real. Every passkey is an ECDSA key pair over P-256, and the credential carries the
+public half as base64url of its SubjectPublicKeyInfo, where a browser's own
+`PublicKeyCredential.toJSON()` puts it. The pool stores that key against the credential id and
+checks signatures with it. A test that would rather hold its own key can build the credential
+document by hand, because nothing here reads a field a browser leaves out.
+
+What the pool was sent is read rather than trusted. The client data has to name the ceremony, answer
+the challenge the pool issued and carry the relying party's own origin, and the authenticator data
+has to hash to the relying party the pool registers against. A spent or unknown challenge is refused
+with `WebAuthnChallengeNotFoundException`, another origin with
+`WebAuthnOriginNotAllowedException`, another domain with `WebAuthnRelyingPartyMismatchException`,
+and a key the pool cannot read with `WebAuthnCredentialNotSupportedException`.
+
+`ListWebAuthnCredentials` reports each passkey with the credential id, the relying party, how the
+authenticator says it is attached and how it can be reached, and when it was registered. It pages by
+`MaxResults` and `NextToken`, twenty to a page at most. `FriendlyCredentialName` is the relying
+party ID. Real Cognito reads the authenticator's own model out of the attestation and names the
+credential after it, and this simulation parses no attestation.
+
+Presenting a registered passkey at a sign-in is still refused. That goes through the `USER_AUTH`
+flow, and `SimCognitoAuthFlows` refuses it by name.
+
 ## Available functionality
 
 Sim Cognito currently supports:
@@ -4044,6 +4186,10 @@ Sim Cognito currently supports:
 - The `SMS_MFA` and `SOFTWARE_TOKEN_MFA` challenges, issued to a user that has registered the
   factor and answered through `RespondToAuthChallengeCommand` or
   `AdminRespondToAuthChallengeCommand`, with the texted code recorded as a message on the pool
+- `StartWebAuthnRegistrationCommand`, `CompleteWebAuthnRegistrationCommand`,
+  `ListWebAuthnCredentialsCommand` and `DeleteWebAuthnCredentialCommand`, which register and manage
+  the signed-in user's passkeys, with the credential the user's own authenticator would have made
+  read back off the pool
 - `SignUpCommand`, `ConfirmSignUpCommand` and `ResendConfirmationCodeCommand`, authorized by no IAM
   policy as they are on real Cognito, and `AdminConfirmSignUpCommand`, authorized like the other
   admin operations
@@ -4140,8 +4286,20 @@ Current documented limitations:
   simulation, and an `AuthFlow` naming one of them is refused, never run as a flow that is.
   `GetTokensFromRefreshToken` runs beside them and is not a flow, as it is not one on real Cognito.
 - `NEW_PASSWORD_REQUIRED`, `SMS_MFA` and `SOFTWARE_TOKEN_MFA` are the challenges issued, so
-  `MFA_SETUP`, `SELECT_MFA_TYPE` and the custom authentication challenges cannot be reached. A
-  `ChallengeName` this simulation never issues is refused, never answered as one it does.
+  `MFA_SETUP`, `SELECT_MFA_TYPE`, `WEB_AUTHN` and the custom authentication challenges cannot be
+  reached. A `ChallengeName` this simulation never issues is refused, never answered as one it does.
+- A passkey is registered and never presented. Signing in with one goes through `USER_AUTH`, which
+  is refused as a flow of its own, so a pool that allows passkeys registers them and refuses the
+  sign-in that would use one.
+- A passkey's `attestationObject` is stored by nobody and parsed by nothing. The public key is read
+  from `response.publicKey`, where a browser's own JSON serialization puts it, and the credential is
+  named after the relying party because the authenticator model real Cognito names it after lives in
+  the attestation. `ES256` is the only algorithm accepted, and a credential naming another is
+  refused with `WebAuthnCredentialNotSupportedException`.
+- The private half of a passkey lives in the simulator, because a test has no authenticator to hold
+  it. `SimCognitoUserPool.webAuthnCredential` is what reads a credential out of it, and it is a
+  deliberate divergence rather than an operation to write application code against. The signatures
+  are real, and a credential built from another key is refused.
 - `RevokeToken` is unimplemented. A refresh token is revoked by signing the user out, or by the
   rotation that replaces it.
 - `GetTokensFromRefreshToken` refuses a `DeviceKey`, because device remembering is unsimulated, and
@@ -4293,10 +4451,9 @@ Current documented limitations:
   `SmsConfiguration` inside the latter is refused, in the same words `CreateUserPool` refuses the
   pool's own. No message is delivered here, and the IAM role Cognito would assume to send one is
   never assumed. `EmailMfaConfiguration` is refused because a pool here has no `EmailConfiguration`
-  to send that message with. A `WebAuthnConfiguration` is recorded and reported back by
-  `GetUserPoolMfaConfig`, and nothing reads it. Its two values decide what a passkey means rather
-  than how a sign-in runs, and presenting a passkey goes through the `USER_AUTH` flow, itself
-  refused as a flow of its own.
+  to send that message with. A `WebAuthnConfiguration` is reported back by `GetUserPoolMfaConfig`
+  and read by `StartWebAuthnRegistration`, which registers a passkey against the relying party it
+  names.
 - `AssociateSoftwareToken` and `VerifySoftwareToken` take an `AccessToken` and refuse a `Session`,
   because the `MFA_SETUP` challenge that would issue one is outside the simulation. A
   `FriendlyDeviceName` is refused for the same kind of reason. Device tracking is outside the
@@ -4373,10 +4530,11 @@ Current documented limitations:
 - `Policies.SignInPolicy` is recorded and reported back by `DescribeUserPool`. The four factor names
   Cognito accepts are `PASSWORD`, `EMAIL_OTP`, `SMS_OTP` and `WEB_AUTHN`, a list names five at most,
   and a policy offering `WEB_AUTHN` and nothing else is refused however many times it repeats the
-  name, as AWS states it must be accompanied by at least one other option. Nothing here
-  presents a factor other than a password. Every other one is reached through the `USER_AUTH` flow,
-  which is refused by name, so a pool that allows passkeys deploys and describes itself the way the
-  deployed pool does while a passkey sign-in is refused where a sign-in asks for it.
+  name, as AWS states it must be accompanied by at least one other option. The policy is recorded
+  and no sign-in reads it yet. A password is the only factor presented here, and every other one is
+  reached through the `USER_AUTH` flow, which is still refused by name. A pool that allows passkeys
+  registers them and describes itself the way the deployed pool does, and presenting one at a
+  sign-in is refused where a sign-in asks for it.
 - `WebAuthnRelyingPartyID` and `WebAuthnUserVerification` deploy from an `AWS::Cognito::UserPool`
   Resource. Real CloudFormation configures both in a `SetUserPoolMfaConfig` call once the pool
   exists, and this deploys them the same way, so a stack declaring passkeys needs
@@ -4398,9 +4556,9 @@ Current documented limitations:
 - A `UsernameAttributes` pool resolves the address for its admin operations and its sign-ins, and
   refuses a second user holding an address another user already signs in by.
 - Unsimulated `CreateUserPoolClient` inputs are refused the same way. They are a `ClientSecret` of
-  your own, `AnalyticsConfiguration`, `AuthSessionValidity`, `EnablePropagateAdditionalUserContextData`,
-  `ReadAttributes`, `WriteAttributes`, and an `EnableTokenRevocation` of
-  `false`. `UpdateUserPoolClient` refuses the same inputs, in the same words.
+  your own, `AnalyticsConfiguration`, `EnablePropagateAdditionalUserContextData`, `ReadAttributes`,
+  `WriteAttributes`, and an `EnableTokenRevocation` of `false`. `UpdateUserPoolClient` refuses the
+  same inputs, in the same words.
 - The OAuth settings need `AllowedOAuthFlowsUserPoolClient` to be true before they can be set, as
   they do on real Cognito. `AllowedOAuthFlows` takes `code` alone: `implicit` hands tokens to the
   browser, and `client_credentials` needs the resource servers that define its scopes, so both are

--- a/docs/services/cognito/sim-cognito-passkey-registration.example.ts
+++ b/docs/services/cognito/sim-cognito-passkey-registration.example.ts
@@ -1,0 +1,87 @@
+/**
+ * Registering a passkey for a signed-in user.
+ */
+
+import {
+  AdminCreateUserCommand,
+  AdminSetUserPasswordCommand,
+  CompleteWebAuthnRegistrationCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  InitiateAuthCommand,
+  ListWebAuthnCredentialsCommand,
+  SetUserPoolMfaConfigCommand,
+  StartWebAuthnRegistrationCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const cognito = new SimAws().cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+);
+const userPoolId = pool.UserPool!.Id!;
+
+// A passkey belongs to a domain, and the pool has to name the one it registers
+// against.
+await cognito.setUserPoolMfaConfig(
+  new SetUserPoolMfaConfigCommand({
+    UserPoolId: userPoolId,
+    MfaConfiguration: "OPTIONAL",
+    WebAuthnConfiguration: {
+      RelyingPartyId: "myapp.example.com",
+      UserVerification: "required",
+    },
+  }),
+);
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: userPoolId,
+    ClientName: "web",
+    ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH"],
+  }),
+);
+
+await cognito.adminCreateUser(
+  new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+);
+await cognito.adminSetUserPassword(
+  new AdminSetUserPasswordCommand({
+    UserPoolId: userPoolId,
+    Username: "alice",
+    Password: "Sup3rSecret!",
+    Permanent: true,
+  }),
+);
+
+// A passkey is added from a session that already exists, so the user signs in
+// with its password first.
+const signedIn = await cognito.initiateAuth(
+  new InitiateAuthCommand({
+    ClientId: appClient.UserPoolClient!.ClientId!,
+    AuthFlow: "USER_PASSWORD_AUTH",
+    AuthParameters: { USERNAME: "alice", PASSWORD: "Sup3rSecret!" },
+  }),
+);
+const AccessToken = signedIn.AuthenticationResult!.AccessToken!;
+
+// The options a browser would hand to navigator.credentials.create().
+await cognito.startWebAuthnRegistration(
+  new StartWebAuthnRegistrationCommand({ AccessToken }),
+);
+
+// The credential that browser's authenticator would have handed back.
+await cognito.completeWebAuthnRegistration(
+  new CompleteWebAuthnRegistrationCommand({
+    AccessToken,
+    Credential: cognito.userPool(userPoolId).webAuthnCredential("alice"),
+  }),
+);
+
+const listed = await cognito.listWebAuthnCredentials(
+  new ListWebAuthnCredentialsCommand({ AccessToken }),
+);
+
+console.log(listed.Credentials?.[0]?.RelyingPartyId); // "myapp.example.com"

--- a/src/service/cognito/README.md
+++ b/src/service/cognito/README.md
@@ -674,6 +674,8 @@ resource, here or on real AWS.
   the options to a browser and the browser hands back what its authenticator made of them.
 - A passkey is registered and never presented. `USER_AUTH` is what presents one, and
   `SimCognitoAuthFlows` refuses that flow by name.
+- A pool that configured no `RelyingPartyId` registers passkeys against its own hosted domain, which
+  is what real Cognito falls back to. A pool with neither refuses the registration.
 - `AdminConfirmSignUp` verifies nothing, whatever the pool's `AutoVerifiedAttributes` say, as it
   verifies nothing on real Cognito. `ConfirmSignUp` sets `email_verified` and
   `phone_number_verified` where the user has the attribute to verify, and a `PreSignUp` trigger sets

--- a/src/service/cognito/README.md
+++ b/src/service/cognito/README.md
@@ -157,6 +157,20 @@ it offers and the user decides what it has. `SetUserMFAPreference` is what enabl
 verifying a token only registers it. `challengeFactor` is what a sign-in reads: the preferred
 factor, or the single enabled one where the user named no preference.
 
+`SimCognitoUserWebAuthn` under `user-pool/user/web-authn/` is the passkeys one user has registered,
+and the registration it is part way through. A passkey is a first factor, so it sits beside
+`SimCognitoUserMfa` rather than inside it, which is where real Cognito puts it too: the pool's
+`AllowedFirstAuthFactors` decide whether one can be presented and its `WebAuthnConfiguration`
+decides what it is registered against. `SimCognitoWebAuthnCredential` is one registered passkey as
+the pool holds it, which is the public half. `sim-cognito-web-authn-authenticator.ts` stands in for
+the user's own phone or laptop and makes the credential a browser would have handed back.
+
+`sim-cognito-web-authn-signing.ts` does the cryptography, `sim-cognito-web-authn-ceremony.ts` reads
+a credential a request carried, and `sim-cognito-web-authn-client-data.ts` holds it to the challenge
+the pool issued and the origin it was collected at. The key pairs are real ECDSA pairs over P-256,
+and the public half travels in the credential as base64url of its SubjectPublicKeyInfo, where a
+browser's own `PublicKeyCredential.toJSON()` puts it.
+
 `SimCognitoSoftwareToken` is one shared secret, and `sim-cognito-totp.ts` computes the code from it.
 The codes are real RFC 6238 time-based one-time passwords rather than a stand-in, so an
 authenticator library handed the `SecretCode` produces codes this accepts, and a secret from another
@@ -493,7 +507,10 @@ holding its contents.
 
 `SimCognitoAuthSession` is what an unfinished authentication carries between the request that started
 it and the response that completes it. A session is opaque, single use, tied to its user, its app
-client and the one challenge it was issued for, and lasts the three minutes real Cognito gives one.
+client and the one challenge it was issued for, and lasts the app client's `AuthSessionValidity`.
+`SimCognitoAuthSessionValidity` under `user-pool/client/` is that setting, three minutes on a client
+that asked for none. A session settles its own expiry when it is issued, so an app client updated
+mid-sign-in leaves the deadline of a challenge already issued where it was.
 It also holds the code an `SMS_MFA` challenge texted, because that code belongs to that challenge:
 it goes when the session goes.
 
@@ -573,8 +590,8 @@ rather than one class per command, so the `SimCognitoIdentityProvider` facade st
   `SimCognitoUserPoolMfaCommands`, because what they act on is not one of the pool's settings
 - `command/client/`: the same for app clients
 - `command/user/`: the same for users, split between the commands that create, read and delete one,
-  the commands that change one afterwards, the commands a user signs itself up with, and the
-  commands that register a second factor for one. The sign-up ones resolve their pool through an app
+  the commands that change one afterwards, the commands a user signs itself up with, the commands
+  that register a second factor for one, and the four that register and manage its passkeys. The sign-up ones resolve their pool through an app
   client id the way the client-side sign-in commands do, so they share `SimCognitoAuthResolver` with
   them, and the ones a signed-in user performs on itself resolve theirs through
   `SimCognitoTokenUser`, which is what `SimCognitoRequestResolver` is for an administrative request:
@@ -651,6 +668,12 @@ resource, here or on real AWS.
 - A user pool reports the confirmation code a signed-up user was issued, through
   `SimCognitoUserPool.confirmationCode`. Real Cognito sends it and never reports it to anyone.
   Nothing here delivers a message, so this is what makes a sign-up flow testable at all.
+- A user pool reports the credential a user's authenticator would have made for the passkey
+  registration it started, through `SimCognitoUserPool.webAuthnCredential`. The simulator holds the
+  private half of every passkey because a test has neither a browser nor a phone. Real Cognito hands
+  the options to a browser and the browser hands back what its authenticator made of them.
+- A passkey is registered and never presented. `USER_AUTH` is what presents one, and
+  `SimCognitoAuthFlows` refuses that flow by name.
 - `AdminConfirmSignUp` verifies nothing, whatever the pool's `AutoVerifiedAttributes` say, as it
   verifies nothing on real Cognito. `ConfirmSignUp` sets `email_verified` and
   `phone_number_verified` where the user has the attribute to verify, and a `PreSignUp` trigger sets

--- a/src/service/cognito/cfn/client/sim-cfn-cognito-client-properties.ts
+++ b/src/service/cognito/cfn/client/sim-cfn-cognito-client-properties.ts
@@ -21,6 +21,9 @@ import { SimCfnCognitoTokenValidityUnits } from "./sim-cfn-cognito-token-validit
  * renews a session: a client deployed with rotation is renewed with
  * `GetTokensFromRefreshToken` rather than `REFRESH_TOKEN_AUTH`.
  *
+ * `AuthSessionValidity` is among them, because it decides how long a user
+ * answering a challenge has before its session runs out.
+ *
  * The managed login branding properties are not, because managed login is a
  * set of web pages rather than anything this simulation answers.
  */
@@ -33,6 +36,7 @@ const simulatedProperties = [
   "AccessTokenValidity",
   "IdTokenValidity",
   "RefreshTokenValidity",
+  "AuthSessionValidity",
   "RefreshTokenRotation",
   "TokenValidityUnits",
   "AllowedOAuthFlows",
@@ -112,6 +116,10 @@ export class SimCfnCognitoClientProperties {
       RefreshTokenValidity: this.number(
         this.properties["RefreshTokenValidity"],
         "RefreshTokenValidity",
+      ),
+      AuthSessionValidity: this.number(
+        this.properties["AuthSessionValidity"],
+        "AuthSessionValidity",
       ),
       RefreshTokenRotation: new SimCfnCognitoRefreshTokenRotation({
         resource: this.resource,

--- a/src/service/cognito/cfn/sim-cfn-cognito-properties.iso.test.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-properties.iso.test.ts
@@ -51,6 +51,7 @@ describe("Cognito CloudFormation property shapes", () => {
               ClientName: "web",
               GenerateSecret: "true",
               AccessTokenValidity: "30",
+              AuthSessionValidity: "10",
               TokenValidityUnits: { AccessToken: "minutes" },
             },
           },
@@ -80,6 +81,7 @@ describe("Cognito CloudFormation property shapes", () => {
     assertNonNullable(client);
     assertTrue(client.hasSecret);
     assertIdentical(client.tokenValidity.accessToken.seconds, 30 * 60);
+    assertIdentical(client.authSessionValidity.minutes, 10);
 
     assertIdentical(pool.findGroup("admins")?.precedence, 5);
   });

--- a/src/service/cognito/command/auth/sim-cognito-mfa-challenge.ts
+++ b/src/service/cognito/command/auth/sim-cognito-mfa-challenge.ts
@@ -96,7 +96,7 @@ export class SimCognitoMfaChallenge {
     const code = factor === simCognitoSmsMfa ? simCognitoMfaCode() : undefined;
     const session = new SimCognitoAuthSession({
       username: user.username,
-      clientId: client.id,
+      client,
       challengeName: factor,
       code,
       issuedAt: this.clock.now(),

--- a/src/service/cognito/command/auth/sim-cognito-new-password-challenge.ts
+++ b/src/service/cognito/command/auth/sim-cognito-new-password-challenge.ts
@@ -1,5 +1,6 @@
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import { SimCognitoAuthSession } from "../../user-pool/auth/sim-cognito-auth-session.js";
+import type { SimCognitoUserPoolClient } from "../../user-pool/client/sim-cognito-user-pool-client.js";
 import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
 import type { SimCognitoUser } from "../../user-pool/user/sim-cognito-user.js";
 import { newPasswordRequiredChallenge } from "./sim-cognito-auth-challenge.js";
@@ -11,7 +12,7 @@ interface SimCognitoNewPasswordChallengeProperties {
 
 interface SimCognitoChallengeProperties {
   readonly pool: SimCognitoUserPool;
-  readonly clientId: string;
+  readonly client: SimCognitoUserPoolClient;
   readonly user: SimCognitoUser;
 }
 
@@ -34,10 +35,10 @@ export class SimCognitoNewPasswordChallenge {
   issue(
     properties: SimCognitoChallengeProperties,
   ): SimCognitoAuthenticationOutput {
-    const { pool, clientId, user } = properties;
+    const { pool, client, user } = properties;
     const session = new SimCognitoAuthSession({
       username: user.username,
-      clientId,
+      client,
       challengeName: newPasswordRequiredChallenge,
       issuedAt: this.clock.now(),
     });

--- a/src/service/cognito/command/auth/sim-cognito-password-sign-in.ts
+++ b/src/service/cognito/command/auth/sim-cognito-password-sign-in.ts
@@ -90,7 +90,7 @@ export class SimCognitoPasswordSignIn {
     requireSimCognitoPasswordSet(user);
 
     if (user.status.mustChangePassword) {
-      return this.challenge.issue({ pool, clientId: client.id, user });
+      return this.challenge.issue({ pool, client, user });
     }
 
     // A user that has registered a second factor is challenged for it here

--- a/src/service/cognito/command/client/sim-cognito-auth-session-validity.iso.test.ts
+++ b/src/service/cognito/command/client/sim-cognito-auth-session-validity.iso.test.ts
@@ -1,0 +1,229 @@
+import {
+  AdminCreateUserCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  DescribeUserPoolClientCommand,
+  InitiateAuthCommand,
+  RespondToAuthChallengeCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimCognitoInvalidParameterException,
+  SimCognitoNotAuthorizedException,
+} from "../../error/sim-cognito.error.js";
+import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
+
+const temporaryPassword = "Temp0rary!";
+const newPassword = "Sup3rSecret!";
+
+interface SimCognitoChallengedUser {
+  readonly simAws: SimAws;
+  readonly cognito: SimCognitoIdentityProvider;
+  readonly clientId: string;
+  readonly session: string;
+}
+
+/**
+ * A user holding a temporary password, answered with the new password
+ * challenge and the session that challenge carries.
+ */
+async function simCognitoChallenged(
+  authSessionValidity?: number,
+): Promise<SimCognitoChallengedUser> {
+  const simAws = new SimAws();
+  const cognito = simAws.cognitoIdentityProvider();
+  const pool = await cognito.createUserPool(
+    new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+  );
+
+  assertNonNullable(pool.UserPool?.Id);
+
+  const userPoolId = pool.UserPool.Id;
+  const client = await cognito.createUserPoolClient(
+    new CreateUserPoolClientCommand({
+      UserPoolId: userPoolId,
+      ClientName: "web",
+      ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH"],
+      ...(authSessionValidity !== undefined && {
+        AuthSessionValidity: authSessionValidity,
+      }),
+    }),
+  );
+
+  assertNonNullable(client.UserPoolClient?.ClientId);
+
+  const clientId = client.UserPoolClient.ClientId;
+
+  await cognito.adminCreateUser(
+    new AdminCreateUserCommand({
+      UserPoolId: userPoolId,
+      Username: "alice",
+      TemporaryPassword: temporaryPassword,
+    }),
+  );
+
+  const challenged = await cognito.initiateAuth(
+    new InitiateAuthCommand({
+      ClientId: clientId,
+      AuthFlow: "USER_PASSWORD_AUTH",
+      AuthParameters: { USERNAME: "alice", PASSWORD: temporaryPassword },
+    }),
+  );
+
+  assertNonNullable(challenged.Session);
+
+  return { simAws, cognito, clientId, session: challenged.Session };
+}
+
+/**
+ * Answer the new password challenge, which is what the session is for.
+ */
+async function respond(
+  cognito: SimCognitoIdentityProvider,
+  clientId: string,
+  session: string,
+): Promise<unknown> {
+  return await cognito.respondToAuthChallenge(
+    new RespondToAuthChallengeCommand({
+      ClientId: clientId,
+      ChallengeName: "NEW_PASSWORD_REQUIRED",
+      Session: session,
+      ChallengeResponses: { USERNAME: "alice", NEW_PASSWORD: newPassword },
+    }),
+  );
+}
+
+describe("sim Cognito app client AuthSessionValidity", () => {
+  it("gives a client that asked for none three minutes", async () => {
+    // Given a user challenged through an app client that named no session
+    // validity.
+    const { simAws, cognito, clientId, session } = await simCognitoChallenged();
+
+    // When it answers three minutes later.
+    await simAws.clock().advanceBy({ minutes: 3 });
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await respond(cognito, clientId, session);
+    });
+
+    // Then the session has run out, which is the default real Cognito applies.
+    assertInstanceOf(error, SimCognitoNotAuthorizedException);
+    assertStringIncludes(error.message, "Invalid session for the user");
+  });
+
+  it("keeps a session open for the minutes the client asked for", async () => {
+    // Given a user challenged through a client with a ten minute validity.
+    const { simAws, cognito, clientId, session } =
+      await simCognitoChallenged(10);
+
+    // When it answers after the three minutes a client would otherwise get.
+    await simAws.clock().advanceBy({ minutes: 9 });
+
+    const answered = await respond(cognito, clientId, session);
+
+    // Then the challenge is completed, because the client said longer.
+    assertNonNullable(answered);
+  });
+
+  it("runs a longer session out once its own minutes are up", async () => {
+    // Given a user challenged through a client with a ten minute validity.
+    const { simAws, cognito, clientId, session } =
+      await simCognitoChallenged(10);
+
+    // When it answers eleven minutes later.
+    await simAws.clock().advanceBy({ minutes: 11 });
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await respond(cognito, clientId, session);
+    });
+
+    // Then the session has run out, as a shorter one would have.
+    assertInstanceOf(error, SimCognitoNotAuthorizedException);
+  });
+
+  it("reports the validity on the client, defaulted to three", async () => {
+    // Given a pool with one client that asked for a validity and one that did
+    // not.
+    const cognito = new SimAws().cognitoIdentityProvider();
+    const pool = await cognito.createUserPool(
+      new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+    );
+
+    assertNonNullable(pool.UserPool?.Id);
+
+    const userPoolId = pool.UserPool.Id;
+    const asked = await cognito.createUserPoolClient(
+      new CreateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientName: "long",
+        AuthSessionValidity: 15,
+      }),
+    );
+    const quiet = await cognito.createUserPoolClient(
+      new CreateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientName: "web",
+      }),
+    );
+
+    assertNonNullable(quiet.UserPoolClient?.ClientId);
+
+    // When each is described.
+    const described = await cognito.describeUserPoolClient(
+      new DescribeUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientId: quiet.UserPoolClient.ClientId,
+      }),
+    );
+
+    // Then the one that asked reports what it asked for, and the one that did
+    // not reports the three minutes Cognito gave it.
+    assertIdentical(asked.UserPoolClient?.AuthSessionValidity, 15);
+    assertIdentical(described.UserPoolClient?.AuthSessionValidity, 3);
+  });
+
+  it("refuses a validity outside the range Cognito allows", async () => {
+    // Given a pool.
+    const cognito = new SimAws().cognitoIdentityProvider();
+    const pool = await cognito.createUserPool(
+      new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+    );
+
+    assertNonNullable(pool.UserPool?.Id);
+
+    // When a client asks for two minutes, or for a fraction of one.
+    const short = await assertThrowsErrorAsync(async () => {
+      await cognito.createUserPoolClient(
+        new CreateUserPoolClientCommand({
+          UserPoolId: pool.UserPool?.Id,
+          ClientName: "web",
+          AuthSessionValidity: 2,
+        }),
+      );
+    });
+    const fractional = await assertThrowsErrorAsync(async () => {
+      await cognito.createUserPoolClient(
+        new CreateUserPoolClientCommand({
+          UserPoolId: pool.UserPool?.Id,
+          ClientName: "web",
+          AuthSessionValidity: 3.5,
+        }),
+      );
+    });
+
+    // Then both are refused, as real Cognito refuses them.
+    assertInstanceOf(short, SimCognitoInvalidParameterException);
+    assertStringIncludes(short.message, "between 3 and 15 minutes");
+    assertInstanceOf(fractional, SimCognitoInvalidParameterException);
+    assertStringIncludes(fractional.message, "whole number of minutes");
+  });
+});

--- a/src/service/cognito/command/client/sim-cognito-client-unsimulated-options.iso.test.ts
+++ b/src/service/cognito/command/client/sim-cognito-client-unsimulated-options.iso.test.ts
@@ -44,11 +44,6 @@ const refusedInputs: readonly RefusedInput[] = [
     says: "Amazon Pinpoint analytics",
   },
   {
-    label: "AuthSessionValidity",
-    input: { AuthSessionValidity: 5 },
-    says: "the authentication session lifetime",
-  },
-  {
     label: "EnablePropagateAdditionalUserContextData",
     input: { EnablePropagateAdditionalUserContextData: true },
     says: "threat protection context data",

--- a/src/service/cognito/command/client/sim-cognito-unsimulated-client-options.ts
+++ b/src/service/cognito/command/client/sim-cognito-unsimulated-client-options.ts
@@ -36,11 +36,6 @@ export class SimCognitoUnsimulatedUserPoolClientOptions {
       "Amazon Pinpoint analytics",
     );
     this.unsimulated.refuse(
-      "AuthSessionValidity",
-      input.AuthSessionValidity,
-      "the authentication session lifetime",
-    );
-    this.unsimulated.refuse(
       "EnablePropagateAdditionalUserContextData",
       input.EnablePropagateAdditionalUserContextData,
       "threat protection context data",

--- a/src/service/cognito/command/client/sim-cognito-update-client-unsimulated-options.iso.test.ts
+++ b/src/service/cognito/command/client/sim-cognito-update-client-unsimulated-options.iso.test.ts
@@ -36,11 +36,6 @@ const refusedInputs: readonly RefusedInput[] = [
     says: "Amazon Pinpoint analytics",
   },
   {
-    label: "AuthSessionValidity",
-    input: { AuthSessionValidity: 5 },
-    says: "the authentication session lifetime",
-  },
-  {
     label: "EnablePropagateAdditionalUserContextData",
     input: { EnablePropagateAdditionalUserContextData: true },
     says: "threat protection context data",

--- a/src/service/cognito/command/client/sim-cognito-user-pool-client-view.ts
+++ b/src/service/cognito/command/client/sim-cognito-user-pool-client-view.ts
@@ -36,6 +36,7 @@ export class SimCognitoUserPoolClientView {
       AccessTokenValidity: tokenValidity.accessToken.validity,
       IdTokenValidity: tokenValidity.idToken.validity,
       RefreshTokenValidity: tokenValidity.refreshToken.validity,
+      AuthSessionValidity: client.authSessionValidity.minutes,
       RefreshTokenRotation: client.refreshTokenRotation.toOutput(),
       TokenValidityUnits: tokenValidity.unitsOutput(),
       CreationDate: client.creationDate,

--- a/src/service/cognito/command/client/user-pool-client.command.ts
+++ b/src/service/cognito/command/client/user-pool-client.command.ts
@@ -22,6 +22,7 @@ export interface SimCognitoUserPoolClientType extends SimCognitoOAuthSettingsTyp
   readonly AccessTokenValidity?: number | undefined;
   readonly IdTokenValidity?: number | undefined;
   readonly RefreshTokenValidity?: number | undefined;
+  readonly AuthSessionValidity?: number | undefined;
   readonly RefreshTokenRotation?:
     | SimCognitoRefreshTokenRotationType
     | undefined;

--- a/src/service/cognito/command/sim-cognito-command.types.ts
+++ b/src/service/cognito/command/sim-cognito-command.types.ts
@@ -106,6 +106,20 @@ export type {
   SimVerifySoftwareTokenCommandOutput,
 } from "./user/user-mfa.command.js";
 export type {
+  SimCompleteWebAuthnRegistrationCommand,
+  SimCompleteWebAuthnRegistrationCommandInput,
+  SimCompleteWebAuthnRegistrationCommandOutput,
+  SimDeleteWebAuthnCredentialCommand,
+  SimDeleteWebAuthnCredentialCommandInput,
+  SimDeleteWebAuthnCredentialCommandOutput,
+  SimListWebAuthnCredentialsCommand,
+  SimListWebAuthnCredentialsCommandInput,
+  SimListWebAuthnCredentialsCommandOutput,
+  SimStartWebAuthnRegistrationCommand,
+  SimStartWebAuthnRegistrationCommandInput,
+  SimStartWebAuthnRegistrationCommandOutput,
+} from "./user/web-authn.command.js";
+export type {
   SimListUsersCommand,
   SimListUsersCommandInput,
   SimListUsersCommandOutput,

--- a/src/service/cognito/command/sim-cognito-commands.ts
+++ b/src/service/cognito/command/sim-cognito-commands.ts
@@ -30,6 +30,7 @@ import { SimCognitoSignUpCommands } from "./user/sim-cognito-sign-up-commands.js
 import { SimCognitoTokenUser } from "./user/sim-cognito-token-user.js";
 import { SimCognitoUserCommands } from "./user/sim-cognito-user-commands.js";
 import { SimCognitoUserMfaCommands } from "./user/sim-cognito-user-mfa-commands.js";
+import { SimCognitoWebAuthnCommands } from "./user/sim-cognito-web-authn-commands.js";
 import { SimCognitoRequestResolver } from "./sim-cognito-request-resolver.js";
 import { SimCognitoUserUpdateCommands } from "./user/sim-cognito-user-update-commands.js";
 import { SimCognitoListUserPools } from "./user-pool/sim-cognito-list-user-pools.js";
@@ -61,6 +62,7 @@ export class SimCognitoCommands {
   public readonly listClients: SimCognitoListUserPoolClients;
   public readonly users: SimCognitoUserCommands;
   public readonly userMfa: SimCognitoUserMfaCommands;
+  public readonly webAuthn: SimCognitoWebAuthnCommands;
   public readonly signUp: SimCognitoSignUpCommands;
   public readonly passwordReset: SimCognitoPasswordResetCommands;
   public readonly userUpdates: SimCognitoUserUpdateCommands;
@@ -152,6 +154,7 @@ export class SimCognitoCommands {
       tokenUser,
       clock,
     });
+    this.webAuthn = new SimCognitoWebAuthnCommands({ tokenUser, clock });
     this.signUp = new SimCognitoSignUpCommands({
       authResolver,
       resolver,

--- a/src/service/cognito/command/sim-cognito-page.ts
+++ b/src/service/cognito/command/sim-cognito-page.ts
@@ -24,6 +24,12 @@ interface SimCognitoPageProperties {
    * most of them allow. `ListWebAuthnCredentials` stops at twenty.
    */
   readonly mostResults?: number;
+
+  /**
+   * The smallest page size this operation takes, where it is not one.
+   * `ListWebAuthnCredentials` documents a minimum of zero.
+   */
+  readonly leastResults?: number;
 }
 
 /**
@@ -41,6 +47,7 @@ export class SimCognitoPage<TItem> {
     const maxResults = SimCognitoPage.maxResults(
       properties.maxResults,
       properties.maxResultsField ?? "MaxResults",
+      properties.leastResults ?? 1,
       properties.mostResults ?? maxMaxResults,
     );
     const startIndex = SimCognitoPage.startIndex(
@@ -57,15 +64,26 @@ export class SimCognitoPage<TItem> {
   private static maxResults(
     requested: number,
     field: string,
+    least: number,
     most: number,
   ): number {
-    if (!Number.isSafeInteger(requested) || requested < 1 || requested > most) {
+    if (
+      !Number.isSafeInteger(requested) ||
+      requested < least ||
+      requested > most
+    ) {
       throw new SimCognitoInvalidParameterException(
-        `${field} must be a whole number between 1 and ${String(most)}`,
+        `${field} must be a whole number between ${String(least)} and ${String(
+          most,
+        )}`,
       );
     }
 
-    return requested;
+    // A page size of zero is the whole page. Real Cognito documents zero as a
+    // valid MaxResults for ListWebAuthnCredentials and says nothing about what
+    // it answers with, so this reads it the way a refresh token validity of
+    // zero is read, as the default rather than as none at all.
+    return requested === 0 ? most : requested;
   }
 
   /**

--- a/src/service/cognito/command/sim-cognito-page.ts
+++ b/src/service/cognito/command/sim-cognito-page.ts
@@ -1,7 +1,7 @@
 import { SimCognitoInvalidParameterException } from "../error/sim-cognito.error.js";
 
 /**
- * The most Cognito will return in one page of either listing.
+ * The most Cognito will return in one page of most listings.
  */
 const maxMaxResults = 60;
 
@@ -18,6 +18,12 @@ interface SimCognitoPageProperties {
    * `PaginationToken`.
    */
   readonly nextTokenField?: string;
+
+  /**
+   * The largest page this operation will hand back, where it is not the sixty
+   * most of them allow. `ListWebAuthnCredentials` stops at twenty.
+   */
+  readonly mostResults?: number;
 }
 
 /**
@@ -35,6 +41,7 @@ export class SimCognitoPage<TItem> {
     const maxResults = SimCognitoPage.maxResults(
       properties.maxResults,
       properties.maxResultsField ?? "MaxResults",
+      properties.mostResults ?? maxMaxResults,
     );
     const startIndex = SimCognitoPage.startIndex(
       properties.nextToken,
@@ -47,14 +54,14 @@ export class SimCognitoPage<TItem> {
     this.nextToken = SimCognitoPage.tokenFor(nextIndex, listed.length);
   }
 
-  private static maxResults(requested: number, field: string): number {
-    if (
-      !Number.isSafeInteger(requested) ||
-      requested < 1 ||
-      requested > maxMaxResults
-    ) {
+  private static maxResults(
+    requested: number,
+    field: string,
+    most: number,
+  ): number {
+    if (!Number.isSafeInteger(requested) || requested < 1 || requested > most) {
       throw new SimCognitoInvalidParameterException(
-        `${field} must be a whole number between 1 and ${String(maxMaxResults)}`,
+        `${field} must be a whole number between 1 and ${String(most)}`,
       );
     }
 

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-web-authn.iso.test.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-web-authn.iso.test.ts
@@ -47,10 +47,8 @@ const refusedRelyingParties: readonly RefusedRelyingParty[] = [
  *
  * Both values arrive through `SetUserPoolMfaConfig`, because that is where the
  * Cognito API takes them, and a pool records them and reports them back the
- * way it records its MFA configuration. Nothing here registers or presents a
- * passkey. Both go through the `USER_AUTH` flow, which is refused where a
- * sign-in asks for it, and `sim-cognito-sign-in-policy.iso.test.ts` is where
- * that refusal is covered.
+ * way it records its MFA configuration. Registering a passkey against them is
+ * covered in `sim-cognito-web-authn-registration.iso.test.ts`.
  */
 describe("sim Cognito user pool passkey registration", () => {
   async function poolWithMfa(): Promise<SimCognitoWithPool> {
@@ -66,8 +64,8 @@ describe("sim Cognito user pool passkey registration", () => {
   }
 
   it("records how a passkey would be registered", async () => {
-    // Given a pool. Nothing here registers or presents a passkey, and these
-    // two values are what a passkey would mean rather than how a sign-in runs.
+    // Given a pool. These two values are what a passkey means rather than how
+    // a sign-in runs, and both arrive before either is registered.
     const { cognito, userPoolId } = await poolWithMfa();
 
     // When the pool is configured for one.

--- a/src/service/cognito/command/user/sim-cognito-web-authn-commands.ts
+++ b/src/service/cognito/command/user/sim-cognito-web-authn-commands.ts
@@ -1,0 +1,169 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import { SimCognitoWebAuthnConfigurationMissingException } from "../../error/sim-cognito-web-authn.error.js";
+import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
+import { SimCognitoPage } from "../sim-cognito-page.js";
+import type { SimCognitoTokenUser } from "./sim-cognito-token-user.js";
+import type {
+  SimCompleteWebAuthnRegistrationCommand,
+  SimCompleteWebAuthnRegistrationCommandOutput,
+  SimDeleteWebAuthnCredentialCommand,
+  SimDeleteWebAuthnCredentialCommandOutput,
+  SimListWebAuthnCredentialsCommand,
+  SimListWebAuthnCredentialsCommandOutput,
+  SimStartWebAuthnRegistrationCommand,
+  SimStartWebAuthnRegistrationCommandOutput,
+} from "./web-authn.command.js";
+
+interface SimCognitoWebAuthnCommandsProperties {
+  readonly tokenUser: SimCognitoTokenUser;
+  readonly clock: SimClock;
+}
+
+/**
+ * How many credentials a page holds when the request does not say, which is
+ * also the most Cognito will return.
+ */
+const defaultMaxResults = 20;
+
+/**
+ * What an authenticator is asked to check when the pool has said nothing,
+ * which is the value real Cognito applies.
+ */
+const defaultUserVerification = "preferred";
+
+/**
+ * The relying party a pool registers passkeys against.
+ *
+ * A passkey belongs to a domain, so a pool that names none has nothing to
+ * register one against. Real Cognito falls back to the pool's own hosted
+ * domain, and refuses with `WebAuthnConfigurationMissingException` where there
+ * is neither.
+ */
+function requireRelyingParty(pool: SimCognitoUserPool): string {
+  const relyingPartyId = pool.settings.mfa.webAuthn?.relyingPartyId;
+
+  if (relyingPartyId === undefined) {
+    throw new SimCognitoWebAuthnConfigurationMissingException(
+      `The user pool ${pool.id} registers passkeys against no relying party: ` +
+        `set one with SetUserPoolMfaConfig WebAuthnConfiguration ` +
+        `RelyingPartyId, which an AWS::Cognito::UserPool Resource deploys as ` +
+        `WebAuthnRelyingPartyID.`,
+    );
+  }
+
+  return relyingPartyId;
+}
+
+/**
+ * The commands a signed-in user registers and manages its passkeys with.
+ *
+ * All four are authorized by the user's own access token and evaluate no IAM
+ * policy, as real Cognito evaluates none for them. That is what makes a
+ * passkey a thing a user adds to an account it is already signed in to: the
+ * first one has to be registered from a session some other factor started.
+ *
+ * The pool's `WebAuthnConfiguration` is what a credential is registered
+ * against, and the pool's `AllowedFirstAuthFactors` are what decide whether it
+ * can then be presented at a sign-in.
+ */
+export class SimCognitoWebAuthnCommands {
+  private readonly tokenUser: SimCognitoTokenUser;
+  private readonly clock: SimClock;
+
+  constructor(properties: SimCognitoWebAuthnCommandsProperties) {
+    this.tokenUser = properties.tokenUser;
+    this.clock = properties.clock;
+  }
+
+  /**
+   * Answer the signed-in user with the options its authenticator creates a
+   * passkey from.
+   *
+   * Calling this again issues another challenge, as real Cognito does, and the
+   * one the user was part way through answering is spent.
+   */
+  startWebAuthnRegistration(
+    command: SimStartWebAuthnRegistrationCommand,
+  ): SimStartWebAuthnRegistrationCommandOutput {
+    const { pool, user } = this.tokenUser.require(
+      command.input.AccessToken,
+      "StartWebAuthnRegistration",
+    );
+
+    return {
+      $metadata: {},
+      CredentialCreationOptions: user.webAuthn.startRegistration({
+        relyingPartyId: requireRelyingParty(pool),
+        relyingPartyName: pool.name,
+        userHandle: user.sub,
+        username: user.username,
+        userVerification:
+          pool.settings.mfa.webAuthn?.userVerification ??
+          defaultUserVerification,
+      }),
+    };
+  }
+
+  /**
+   * Register the passkey the user's authenticator created.
+   */
+  completeWebAuthnRegistration(
+    command: SimCompleteWebAuthnRegistrationCommand,
+  ): SimCompleteWebAuthnRegistrationCommandOutput {
+    const { user } = this.tokenUser.require(
+      command.input.AccessToken,
+      "CompleteWebAuthnRegistration",
+    );
+
+    user.webAuthn.completeRegistration(
+      command.input.Credential,
+      this.clock.now(),
+    );
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * List the passkeys the signed-in user has registered, oldest first.
+   *
+   * Real Cognito chooses its own order and does not promise one, so nothing
+   * should depend on this order beyond a test reading back what it registered.
+   */
+  listWebAuthnCredentials(
+    command: SimListWebAuthnCredentialsCommand,
+  ): SimListWebAuthnCredentialsCommandOutput {
+    const { input } = command;
+    const { user } = this.tokenUser.require(
+      input.AccessToken,
+      "ListWebAuthnCredentials",
+    );
+    const page = new SimCognitoPage(user.webAuthn.credentials, {
+      maxResults: input.MaxResults ?? defaultMaxResults,
+      mostResults: defaultMaxResults,
+      nextToken: input.NextToken,
+    });
+
+    return {
+      $metadata: {},
+      Credentials: page.items.map((credential) => credential.toOutput()),
+      NextToken: page.nextToken,
+    };
+  }
+
+  /**
+   * Forget one of the signed-in user's passkeys.
+   */
+  deleteWebAuthnCredential(
+    command: SimDeleteWebAuthnCredentialCommand,
+  ): SimDeleteWebAuthnCredentialCommandOutput {
+    const { input } = command;
+    const { user } = this.tokenUser.require(
+      input.AccessToken,
+      "DeleteWebAuthnCredential",
+    );
+
+    user.webAuthn.remove(input.CredentialId);
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/cognito/command/user/sim-cognito-web-authn-commands.ts
+++ b/src/service/cognito/command/user/sim-cognito-web-authn-commands.ts
@@ -21,7 +21,9 @@ interface SimCognitoWebAuthnCommandsProperties {
 
 /**
  * How many credentials a page holds when the request does not say, which is
- * also the most Cognito will return.
+ * also the most Cognito will return. Cognito documents this listing as taking
+ * a `MaxResults` of between zero and twenty, and a zero is read as the whole
+ * page.
  */
 const defaultMaxResults = 20;
 
@@ -34,20 +36,22 @@ const defaultUserVerification = "preferred";
 /**
  * The relying party a pool registers passkeys against.
  *
- * A passkey belongs to a domain, so a pool that names none has nothing to
- * register one against. Real Cognito falls back to the pool's own hosted
- * domain, and refuses with `WebAuthnConfigurationMissingException` where there
- * is neither.
+ * A passkey belongs to a domain. A pool that configured a `RelyingPartyId`
+ * uses that, and one that did not falls back to its own hosted domain, which
+ * is what real Cognito falls back to. A pool with neither has nothing to
+ * register a passkey against, and real Cognito refuses that with
+ * `WebAuthnConfigurationMissingException`.
  */
 function requireRelyingParty(pool: SimCognitoUserPool): string {
-  const relyingPartyId = pool.settings.mfa.webAuthn?.relyingPartyId;
+  const relyingPartyId =
+    pool.settings.mfa.webAuthn?.relyingPartyId ?? pool.auth.domain?.hostname;
 
   if (relyingPartyId === undefined) {
     throw new SimCognitoWebAuthnConfigurationMissingException(
       `The user pool ${pool.id} registers passkeys against no relying party: ` +
-        `set one with SetUserPoolMfaConfig WebAuthnConfiguration ` +
-        `RelyingPartyId, which an AWS::Cognito::UserPool Resource deploys as ` +
-        `WebAuthnRelyingPartyID.`,
+        `give it a hosted domain with CreateUserPoolDomain, or set one with ` +
+        `SetUserPoolMfaConfig WebAuthnConfiguration RelyingPartyId, which an ` +
+        `AWS::Cognito::UserPool Resource deploys as WebAuthnRelyingPartyID.`,
     );
   }
 
@@ -139,6 +143,7 @@ export class SimCognitoWebAuthnCommands {
     );
     const page = new SimCognitoPage(user.webAuthn.credentials, {
       maxResults: input.MaxResults ?? defaultMaxResults,
+      leastResults: 0,
       mostResults: defaultMaxResults,
       nextToken: input.NextToken,
     });

--- a/src/service/cognito/command/user/sim-cognito-web-authn-credential.iso.test.ts
+++ b/src/service/cognito/command/user/sim-cognito-web-authn-credential.iso.test.ts
@@ -1,0 +1,302 @@
+import { generateKeyPairSync } from "node:crypto";
+
+import {
+  CompleteWebAuthnRegistrationCommand,
+  StartWebAuthnRegistrationCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  simCognitoAuthenticatorDataFor,
+  simCognitoBase64urlJson,
+  simCognitoClientDataOf,
+  simCognitoCredentialWith,
+  simCognitoPasskeyCredential,
+  simCognitoRelyingPartyId,
+  simCognitoWithPasskeyPool,
+} from "../../../../../test/cognito/passkey-fixture.js";
+import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
+import {
+  SimCognitoWebAuthnCredentialNotSupportedException,
+  SimCognitoWebAuthnOriginNotAllowedException,
+  SimCognitoWebAuthnRelyingPartyMismatchException,
+} from "../../error/sim-cognito-web-authn.error.js";
+
+/**
+ * A credential arrives as the JSON a browser serializes a
+ * `PublicKeyCredential` to, so a test can build one by hand. These are the
+ * ones a real browser would never produce.
+ */
+describe("sim Cognito passkey credential refusals", () => {
+  it("refuses a credential that is not one a browser serialized", async () => {
+    // Given a user part way through a registration.
+    const setUp = await simCognitoWithPasskeyPool();
+
+    await setUp.cognito.startWebAuthnRegistration(
+      new StartWebAuthnRegistrationCommand({ AccessToken: setUp.accessToken }),
+    );
+
+    // When something else is sent as the credential.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.completeWebAuthnRegistration(
+        new CompleteWebAuthnRegistrationCommand({
+          AccessToken: setUp.accessToken,
+          Credential: "a-passkey-honest",
+        }),
+      );
+    });
+
+    // Then it is refused for what it is rather than read as a credential.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "navigator.credentials");
+  });
+
+  it("refuses a credential whose client data is not the JSON a browser collects", async () => {
+    // Given a user part way through a registration.
+    const setUp = await simCognitoWithPasskeyPool();
+
+    await setUp.cognito.startWebAuthnRegistration(
+      new StartWebAuthnRegistrationCommand({ AccessToken: setUp.accessToken }),
+    );
+
+    const garbled = simCognitoCredentialWith(
+      simCognitoPasskeyCredential(setUp),
+      {
+        clientDataJSON: Buffer.from("not json at all").toString("base64url"),
+      },
+    );
+
+    // When a credential carrying something else as its client data is sent.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.completeWebAuthnRegistration(
+        new CompleteWebAuthnRegistrationCommand({
+          AccessToken: setUp.accessToken,
+          Credential: garbled,
+        }),
+      );
+    });
+
+    // Then it is refused for what the client data is.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "response.clientDataJSON is not");
+  });
+
+  it("refuses a credential collected for the other half of the ceremony", async () => {
+    // Given a user part way through a registration.
+    const setUp = await simCognitoWithPasskeyPool();
+
+    await setUp.cognito.startWebAuthnRegistration(
+      new StartWebAuthnRegistrationCommand({ AccessToken: setUp.accessToken }),
+    );
+
+    const credential = simCognitoPasskeyCredential(setUp);
+    const presented = simCognitoCredentialWith(credential, {
+      clientDataJSON: simCognitoBase64urlJson({
+        ...simCognitoClientDataOf(credential),
+        type: "webauthn.get",
+      }),
+    });
+
+    // When a credential presenting a passkey is sent to the registration.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.completeWebAuthnRegistration(
+        new CompleteWebAuthnRegistrationCommand({
+          AccessToken: setUp.accessToken,
+          Credential: presented,
+        }),
+      );
+    });
+
+    // Then the ceremony it answers is the wrong one.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "rather than 'webauthn.create'");
+  });
+
+  it("refuses a credential with no authenticator data to read", async () => {
+    // Given a user part way through a registration.
+    const setUp = await simCognitoWithPasskeyPool();
+
+    await setUp.cognito.startWebAuthnRegistration(
+      new StartWebAuthnRegistrationCommand({ AccessToken: setUp.accessToken }),
+    );
+
+    const bare = simCognitoCredentialWith(simCognitoPasskeyCredential(setUp), {
+      authenticatorData: "",
+    });
+
+    // When a credential missing what the authenticator signed is sent.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.completeWebAuthnRegistration(
+        new CompleteWebAuthnRegistrationCommand({
+          AccessToken: setUp.accessToken,
+          Credential: bare,
+        }),
+      );
+    });
+
+    // Then it is refused for the member it is missing.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "authenticatorData must be");
+  });
+
+  it("refuses a credential collected at another origin", async () => {
+    // Given a user part way through a registration.
+    const setUp = await simCognitoWithPasskeyPool();
+
+    await setUp.cognito.startWebAuthnRegistration(
+      new StartWebAuthnRegistrationCommand({ AccessToken: setUp.accessToken }),
+    );
+
+    const credential = simCognitoPasskeyCredential(setUp);
+    const elsewhere = simCognitoCredentialWith(credential, {
+      clientDataJSON: simCognitoBase64urlJson({
+        ...simCognitoClientDataOf(credential),
+        origin: "https://phish.test",
+      }),
+    });
+
+    // When a credential collected somewhere else is sent.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.completeWebAuthnRegistration(
+        new CompleteWebAuthnRegistrationCommand({
+          AccessToken: setUp.accessToken,
+          Credential: elsewhere,
+        }),
+      );
+    });
+
+    // Then the origin is not one the relying party covers.
+    assertInstanceOf(error, SimCognitoWebAuthnOriginNotAllowedException);
+    assertStringIncludes(error.message, simCognitoRelyingPartyId);
+  });
+
+  it("refuses a credential signed for another relying party", async () => {
+    // Given a user part way through a registration.
+    const setUp = await simCognitoWithPasskeyPool();
+
+    await setUp.cognito.startWebAuthnRegistration(
+      new StartWebAuthnRegistrationCommand({ AccessToken: setUp.accessToken }),
+    );
+
+    const misdirected = simCognitoCredentialWith(
+      simCognitoPasskeyCredential(setUp),
+      {
+        authenticatorData: simCognitoAuthenticatorDataFor(
+          "elsewhere.example.com",
+        ),
+      },
+    );
+
+    // When a credential whose authenticator data names another domain is sent.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.completeWebAuthnRegistration(
+        new CompleteWebAuthnRegistrationCommand({
+          AccessToken: setUp.accessToken,
+          Credential: misdirected,
+        }),
+      );
+    });
+
+    // Then the relying party inside what was signed is not this pool's.
+    assertInstanceOf(error, SimCognitoWebAuthnRelyingPartyMismatchException);
+  });
+
+  it("refuses a credential the pool cannot read a public key from", async () => {
+    // Given a user part way through a registration.
+    const setUp = await simCognitoWithPasskeyPool();
+
+    await setUp.cognito.startWebAuthnRegistration(
+      new StartWebAuthnRegistrationCommand({ AccessToken: setUp.accessToken }),
+    );
+
+    const unusable = simCognitoCredentialWith(
+      simCognitoPasskeyCredential(setUp),
+      {
+        publicKeyAlgorithm: -257,
+      },
+    );
+
+    // When a credential naming another algorithm is sent.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.completeWebAuthnRegistration(
+        new CompleteWebAuthnRegistrationCommand({
+          AccessToken: setUp.accessToken,
+          Credential: unusable,
+        }),
+      );
+    });
+
+    // Then the pool cannot use the key, and says which algorithm it asked for.
+    assertInstanceOf(error, SimCognitoWebAuthnCredentialNotSupportedException);
+    assertStringIncludes(error.message, "ECDSA over P-256");
+  });
+
+  it("refuses a credential whose public key is not a key at all", async () => {
+    // Given a user part way through a registration.
+    const setUp = await simCognitoWithPasskeyPool();
+
+    await setUp.cognito.startWebAuthnRegistration(
+      new StartWebAuthnRegistrationCommand({ AccessToken: setUp.accessToken }),
+    );
+
+    const unreadable = simCognitoCredentialWith(
+      simCognitoPasskeyCredential(setUp),
+      {
+        publicKey: Buffer.from("not a key").toString("base64url"),
+        transports: "internal",
+      },
+    );
+
+    // When a credential carrying something else as its public key is sent.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.completeWebAuthnRegistration(
+        new CompleteWebAuthnRegistrationCommand({
+          AccessToken: setUp.accessToken,
+          Credential: unreadable,
+        }),
+      );
+    });
+
+    // Then the pool has no key to check this passkey's signatures against.
+    assertInstanceOf(error, SimCognitoWebAuthnCredentialNotSupportedException);
+  });
+
+  it("refuses a credential carrying a key of another kind", async () => {
+    // Given a user part way through a registration, and an RSA key passed off
+    // as the ECDSA one the registration asked for.
+    const setUp = await simCognitoWithPasskeyPool();
+
+    await setUp.cognito.startWebAuthnRegistration(
+      new StartWebAuthnRegistrationCommand({ AccessToken: setUp.accessToken }),
+    );
+
+    const rsa = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const wrongKind = simCognitoCredentialWith(
+      simCognitoPasskeyCredential(setUp),
+      {
+        publicKey: rsa.publicKey
+          .export({ format: "der", type: "spki" })
+          .toString("base64url"),
+      },
+    );
+
+    // When that credential is sent.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.completeWebAuthnRegistration(
+        new CompleteWebAuthnRegistrationCommand({
+          AccessToken: setUp.accessToken,
+          Credential: wrongKind,
+        }),
+      );
+    });
+
+    // Then the key itself is what the pool reads, and this is not one it can
+    // use however the credential labels it.
+    assertInstanceOf(error, SimCognitoWebAuthnCredentialNotSupportedException);
+  });
+});

--- a/src/service/cognito/command/user/sim-cognito-web-authn-refusals.iso.test.ts
+++ b/src/service/cognito/command/user/sim-cognito-web-authn-refusals.iso.test.ts
@@ -1,5 +1,3 @@
-import { createHash } from "node:crypto";
-
 import {
   CompleteWebAuthnRegistrationCommand,
   DeleteWebAuthnCredentialCommand,
@@ -13,75 +11,19 @@ import {
 import { describe, it } from "vitest";
 
 import {
+  simCognitoBase64urlJson,
+  simCognitoClientDataOf,
+  simCognitoCredentialWith,
   simCognitoPasskeyCredential,
   simCognitoRegisterPasskey,
-  simCognitoRelyingPartyId,
   simCognitoWithPasskeyPool,
 } from "../../../../../test/cognito/passkey-fixture.js";
 import { simCognitoSignedIn } from "../../../../../test/cognito/signed-in-fixture.js";
-import {
-  SimCognitoInvalidParameterException,
-  SimCognitoResourceNotFoundException,
-} from "../../error/sim-cognito.error.js";
+import { SimCognitoResourceNotFoundException } from "../../error/sim-cognito.error.js";
 import {
   SimCognitoWebAuthnChallengeNotFoundException,
   SimCognitoWebAuthnConfigurationMissingException,
-  SimCognitoWebAuthnCredentialNotSupportedException,
-  SimCognitoWebAuthnOriginNotAllowedException,
-  SimCognitoWebAuthnRelyingPartyMismatchException,
 } from "../../error/sim-cognito-web-authn.error.js";
-import type {
-  SimCognitoWebAuthnCredentialDocument,
-  SimCognitoWebAuthnDocumentValue,
-} from "../../user-pool/user/web-authn/sim-cognito-web-authn-document.js";
-
-/**
- * The authenticator data a credential would carry if it had been signed for
- * another domain, which is the hash of that domain and the same flags.
- */
-function authenticatorDataFor(relyingPartyId: string): string {
-  const flags = Buffer.alloc(5);
-
-  flags.writeUInt8(0x05, 0);
-  flags.writeUInt32BE(0, 1);
-
-  return Buffer.concat([
-    createHash("sha256").update(relyingPartyId).digest(),
-    flags,
-  ]).toString("base64url");
-}
-
-/**
- * A JSON value as a credential carries one, which is base64url of its bytes.
- */
-function base64urlJson(value: unknown): string {
-  return Buffer.from(JSON.stringify(value)).toString("base64url");
-}
-
-/**
- * The client data a credential was signed over, read back as the JSON it is.
- */
-function clientDataOf(
-  credential: SimCognitoWebAuthnCredentialDocument,
-): Record<string, unknown> {
-  const encoded = credential.response.clientDataJSON;
-  const decoded = Buffer.from(encoded, "base64url").toString("utf8");
-
-  return JSON.parse(decoded) as Record<string, unknown>;
-}
-
-/**
- * The credential a real authenticator made, with one member of it changed.
- */
-function credentialWith(
-  credential: SimCognitoWebAuthnCredentialDocument,
-  response: Record<string, SimCognitoWebAuthnDocumentValue>,
-): Record<string, SimCognitoWebAuthnDocumentValue> {
-  return {
-    ...credential,
-    response: { ...credential.response, ...response },
-  };
-}
 
 describe("sim Cognito passkey registration refusals", () => {
   it("refuses a registration against a pool that names no relying party", async () => {
@@ -155,8 +97,8 @@ describe("sim Cognito passkey registration refusals", () => {
     assertInstanceOf(error, SimCognitoWebAuthnChallengeNotFoundException);
   });
 
-  it("refuses a credential collected at another origin", async () => {
-    // Given a user part way through a registration.
+  it("spends the challenge on a refused credential", async () => {
+    // Given a registration whose credential was refused for its origin.
     const setUp = await simCognitoWithPasskeyPool();
 
     await setUp.cognito.startWebAuthnRegistration(
@@ -164,15 +106,14 @@ describe("sim Cognito passkey registration refusals", () => {
     );
 
     const credential = simCognitoPasskeyCredential(setUp);
-    const elsewhere = credentialWith(credential, {
-      clientDataJSON: base64urlJson({
-        ...clientDataOf(credential),
+    const elsewhere = simCognitoCredentialWith(credential, {
+      clientDataJSON: simCognitoBase64urlJson({
+        ...simCognitoClientDataOf(credential),
         origin: "https://phish.test",
       }),
     });
 
-    // When a credential collected somewhere else is sent.
-    const error = await assertThrowsErrorAsync(async () => {
+    await assertThrowsErrorAsync(async () => {
       await setUp.cognito.completeWebAuthnRegistration(
         new CompleteWebAuthnRegistrationCommand({
           AccessToken: setUp.accessToken,
@@ -181,85 +122,20 @@ describe("sim Cognito passkey registration refusals", () => {
       );
     });
 
-    // Then the origin is not one the relying party covers.
-    assertInstanceOf(error, SimCognitoWebAuthnOriginNotAllowedException);
-    assertStringIncludes(error.message, simCognitoRelyingPartyId);
-  });
-
-  it("refuses a credential signed for another relying party", async () => {
-    // Given a user part way through a registration.
-    const setUp = await simCognitoWithPasskeyPool();
-
-    await setUp.cognito.startWebAuthnRegistration(
-      new StartWebAuthnRegistrationCommand({ AccessToken: setUp.accessToken }),
-    );
-
-    const misdirected = credentialWith(simCognitoPasskeyCredential(setUp), {
-      authenticatorData: authenticatorDataFor("elsewhere.example.com"),
-    });
-
-    // When a credential whose authenticator data names another domain is sent.
+    // When the credential the authenticator really made is sent for the same
+    // challenge.
     const error = await assertThrowsErrorAsync(async () => {
       await setUp.cognito.completeWebAuthnRegistration(
         new CompleteWebAuthnRegistrationCommand({
           AccessToken: setUp.accessToken,
-          Credential: misdirected,
+          Credential: credential,
         }),
       );
     });
 
-    // Then the relying party inside what was signed is not this pool's.
-    assertInstanceOf(error, SimCognitoWebAuthnRelyingPartyMismatchException);
-  });
-
-  it("refuses a credential the pool cannot read a public key from", async () => {
-    // Given a user part way through a registration.
-    const setUp = await simCognitoWithPasskeyPool();
-
-    await setUp.cognito.startWebAuthnRegistration(
-      new StartWebAuthnRegistrationCommand({ AccessToken: setUp.accessToken }),
-    );
-
-    const unusable = credentialWith(simCognitoPasskeyCredential(setUp), {
-      publicKeyAlgorithm: -257,
-    });
-
-    // When a credential naming another algorithm is sent.
-    const error = await assertThrowsErrorAsync(async () => {
-      await setUp.cognito.completeWebAuthnRegistration(
-        new CompleteWebAuthnRegistrationCommand({
-          AccessToken: setUp.accessToken,
-          Credential: unusable,
-        }),
-      );
-    });
-
-    // Then the pool cannot use the key, and says which algorithm it asked for.
-    assertInstanceOf(error, SimCognitoWebAuthnCredentialNotSupportedException);
-    assertStringIncludes(error.message, "ECDSA over P-256");
-  });
-
-  it("refuses a credential that is not one a browser serialized", async () => {
-    // Given a user part way through a registration.
-    const setUp = await simCognitoWithPasskeyPool();
-
-    await setUp.cognito.startWebAuthnRegistration(
-      new StartWebAuthnRegistrationCommand({ AccessToken: setUp.accessToken }),
-    );
-
-    // When something else is sent as the credential.
-    const error = await assertThrowsErrorAsync(async () => {
-      await setUp.cognito.completeWebAuthnRegistration(
-        new CompleteWebAuthnRegistrationCommand({
-          AccessToken: setUp.accessToken,
-          Credential: "a-passkey-honest",
-        }),
-      );
-    });
-
-    // Then it is refused for what it is rather than read as a credential.
-    assertInstanceOf(error, SimCognitoInvalidParameterException);
-    assertStringIncludes(error.message, "navigator.credentials");
+    // Then the challenge went with the refusal, and the registration has to be
+    // started again.
+    assertInstanceOf(error, SimCognitoWebAuthnChallengeNotFoundException);
   });
 
   it("refuses deleting a passkey the user does not have", async () => {
@@ -280,117 +156,5 @@ describe("sim Cognito passkey registration refusals", () => {
 
     // Then the pool has no such passkey to forget.
     assertInstanceOf(error, SimCognitoResourceNotFoundException);
-  });
-
-  it("refuses a credential whose client data is not the JSON a browser collects", async () => {
-    // Given a user part way through a registration.
-    const setUp = await simCognitoWithPasskeyPool();
-
-    await setUp.cognito.startWebAuthnRegistration(
-      new StartWebAuthnRegistrationCommand({ AccessToken: setUp.accessToken }),
-    );
-
-    const garbled = credentialWith(simCognitoPasskeyCredential(setUp), {
-      clientDataJSON: Buffer.from("not json at all").toString("base64url"),
-    });
-
-    // When a credential carrying something else as its client data is sent.
-    const error = await assertThrowsErrorAsync(async () => {
-      await setUp.cognito.completeWebAuthnRegistration(
-        new CompleteWebAuthnRegistrationCommand({
-          AccessToken: setUp.accessToken,
-          Credential: garbled,
-        }),
-      );
-    });
-
-    // Then it is refused for what the client data is.
-    assertInstanceOf(error, SimCognitoInvalidParameterException);
-    assertStringIncludes(error.message, "response.clientDataJSON is not");
-  });
-
-  it("refuses a credential collected for the other half of the ceremony", async () => {
-    // Given a user part way through a registration.
-    const setUp = await simCognitoWithPasskeyPool();
-
-    await setUp.cognito.startWebAuthnRegistration(
-      new StartWebAuthnRegistrationCommand({ AccessToken: setUp.accessToken }),
-    );
-
-    const credential = simCognitoPasskeyCredential(setUp);
-    const presented = credentialWith(credential, {
-      clientDataJSON: base64urlJson({
-        ...clientDataOf(credential),
-        type: "webauthn.get",
-      }),
-    });
-
-    // When a credential presenting a passkey is sent to the registration.
-    const error = await assertThrowsErrorAsync(async () => {
-      await setUp.cognito.completeWebAuthnRegistration(
-        new CompleteWebAuthnRegistrationCommand({
-          AccessToken: setUp.accessToken,
-          Credential: presented,
-        }),
-      );
-    });
-
-    // Then the ceremony it answers is the wrong one.
-    assertInstanceOf(error, SimCognitoInvalidParameterException);
-    assertStringIncludes(error.message, "rather than 'webauthn.create'");
-  });
-
-  it("refuses a credential with no authenticator data to read", async () => {
-    // Given a user part way through a registration.
-    const setUp = await simCognitoWithPasskeyPool();
-
-    await setUp.cognito.startWebAuthnRegistration(
-      new StartWebAuthnRegistrationCommand({ AccessToken: setUp.accessToken }),
-    );
-
-    const bare = credentialWith(simCognitoPasskeyCredential(setUp), {
-      authenticatorData: "",
-    });
-
-    // When a credential missing what the authenticator signed is sent.
-    const error = await assertThrowsErrorAsync(async () => {
-      await setUp.cognito.completeWebAuthnRegistration(
-        new CompleteWebAuthnRegistrationCommand({
-          AccessToken: setUp.accessToken,
-          Credential: bare,
-        }),
-      );
-    });
-
-    // Then it is refused for the member it is missing.
-    assertInstanceOf(error, SimCognitoInvalidParameterException);
-    assertStringIncludes(error.message, "authenticatorData must be");
-  });
-
-  it("refuses a credential whose public key is not a key at all", async () => {
-    // Given a user part way through a registration.
-    const setUp = await simCognitoWithPasskeyPool();
-
-    await setUp.cognito.startWebAuthnRegistration(
-      new StartWebAuthnRegistrationCommand({ AccessToken: setUp.accessToken }),
-    );
-
-    const unreadable = credentialWith(simCognitoPasskeyCredential(setUp), {
-      publicKey: Buffer.from("not a key").toString("base64url"),
-      transports: "internal",
-    });
-
-    // When a credential carrying something else as its public key is sent.
-    const error = await assertThrowsErrorAsync(async () => {
-      await setUp.cognito.completeWebAuthnRegistration(
-        new CompleteWebAuthnRegistrationCommand({
-          AccessToken: setUp.accessToken,
-          Credential: unreadable,
-        }),
-      );
-    });
-
-    // Then the pool has no key to check this passkey's signatures against.
-    assertInstanceOf(error, SimCognitoWebAuthnCredentialNotSupportedException);
   });
 });

--- a/src/service/cognito/command/user/sim-cognito-web-authn-refusals.iso.test.ts
+++ b/src/service/cognito/command/user/sim-cognito-web-authn-refusals.iso.test.ts
@@ -1,0 +1,396 @@
+import { createHash } from "node:crypto";
+
+import {
+  CompleteWebAuthnRegistrationCommand,
+  DeleteWebAuthnCredentialCommand,
+  StartWebAuthnRegistrationCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  simCognitoPasskeyCredential,
+  simCognitoRegisterPasskey,
+  simCognitoRelyingPartyId,
+  simCognitoWithPasskeyPool,
+} from "../../../../../test/cognito/passkey-fixture.js";
+import { simCognitoSignedIn } from "../../../../../test/cognito/signed-in-fixture.js";
+import {
+  SimCognitoInvalidParameterException,
+  SimCognitoResourceNotFoundException,
+} from "../../error/sim-cognito.error.js";
+import {
+  SimCognitoWebAuthnChallengeNotFoundException,
+  SimCognitoWebAuthnConfigurationMissingException,
+  SimCognitoWebAuthnCredentialNotSupportedException,
+  SimCognitoWebAuthnOriginNotAllowedException,
+  SimCognitoWebAuthnRelyingPartyMismatchException,
+} from "../../error/sim-cognito-web-authn.error.js";
+import type {
+  SimCognitoWebAuthnCredentialDocument,
+  SimCognitoWebAuthnDocumentValue,
+} from "../../user-pool/user/web-authn/sim-cognito-web-authn-document.js";
+
+/**
+ * The authenticator data a credential would carry if it had been signed for
+ * another domain, which is the hash of that domain and the same flags.
+ */
+function authenticatorDataFor(relyingPartyId: string): string {
+  const flags = Buffer.alloc(5);
+
+  flags.writeUInt8(0x05, 0);
+  flags.writeUInt32BE(0, 1);
+
+  return Buffer.concat([
+    createHash("sha256").update(relyingPartyId).digest(),
+    flags,
+  ]).toString("base64url");
+}
+
+/**
+ * A JSON value as a credential carries one, which is base64url of its bytes.
+ */
+function base64urlJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+/**
+ * The client data a credential was signed over, read back as the JSON it is.
+ */
+function clientDataOf(
+  credential: SimCognitoWebAuthnCredentialDocument,
+): Record<string, unknown> {
+  const encoded = credential.response.clientDataJSON;
+  const decoded = Buffer.from(encoded, "base64url").toString("utf8");
+
+  return JSON.parse(decoded) as Record<string, unknown>;
+}
+
+/**
+ * The credential a real authenticator made, with one member of it changed.
+ */
+function credentialWith(
+  credential: SimCognitoWebAuthnCredentialDocument,
+  response: Record<string, SimCognitoWebAuthnDocumentValue>,
+): Record<string, SimCognitoWebAuthnDocumentValue> {
+  return {
+    ...credential,
+    response: { ...credential.response, ...response },
+  };
+}
+
+describe("sim Cognito passkey registration refusals", () => {
+  it("refuses a registration against a pool that names no relying party", async () => {
+    // Given a signed-in user of a pool that was never configured for
+    // passkeys.
+    const setUp = await simCognitoSignedIn();
+
+    // When it starts registering one.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.startWebAuthnRegistration(
+        new StartWebAuthnRegistrationCommand({
+          AccessToken: setUp.accessToken,
+        }),
+      );
+    });
+
+    // Then the pool has nothing to register the passkey against, and says
+    // where the relying party comes from.
+    assertInstanceOf(error, SimCognitoWebAuthnConfigurationMissingException);
+    assertStringIncludes(error.message, "SetUserPoolMfaConfig");
+    assertStringIncludes(error.message, "WebAuthnRelyingPartyID");
+  });
+
+  it("refuses a credential for a registration nobody started", async () => {
+    // Given a user that has registered a passkey, spending the challenge it
+    // was issued.
+    const setUp = await simCognitoWithPasskeyPool();
+    const credential = await simCognitoRegisterPasskey(setUp);
+
+    // When the same credential is sent again.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.completeWebAuthnRegistration(
+        new CompleteWebAuthnRegistrationCommand({
+          AccessToken: setUp.accessToken,
+          Credential: credential,
+        }),
+      );
+    });
+
+    // Then there is no registration in progress to complete.
+    assertInstanceOf(error, SimCognitoWebAuthnChallengeNotFoundException);
+    assertStringIncludes(error.message, "StartWebAuthnRegistration");
+  });
+
+  it("refuses a credential answering a challenge that was replaced", async () => {
+    // Given a user part way through a registration, whose authenticator made a
+    // credential for it.
+    const setUp = await simCognitoWithPasskeyPool();
+
+    await setUp.cognito.startWebAuthnRegistration(
+      new StartWebAuthnRegistrationCommand({ AccessToken: setUp.accessToken }),
+    );
+
+    const stale = simCognitoPasskeyCredential(setUp);
+
+    // When another registration is started, and the first credential is sent.
+    await setUp.cognito.startWebAuthnRegistration(
+      new StartWebAuthnRegistrationCommand({ AccessToken: setUp.accessToken }),
+    );
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.completeWebAuthnRegistration(
+        new CompleteWebAuthnRegistrationCommand({
+          AccessToken: setUp.accessToken,
+          Credential: stale,
+        }),
+      );
+    });
+
+    // Then it answers a challenge the pool has already replaced.
+    assertInstanceOf(error, SimCognitoWebAuthnChallengeNotFoundException);
+  });
+
+  it("refuses a credential collected at another origin", async () => {
+    // Given a user part way through a registration.
+    const setUp = await simCognitoWithPasskeyPool();
+
+    await setUp.cognito.startWebAuthnRegistration(
+      new StartWebAuthnRegistrationCommand({ AccessToken: setUp.accessToken }),
+    );
+
+    const credential = simCognitoPasskeyCredential(setUp);
+    const elsewhere = credentialWith(credential, {
+      clientDataJSON: base64urlJson({
+        ...clientDataOf(credential),
+        origin: "https://phish.test",
+      }),
+    });
+
+    // When a credential collected somewhere else is sent.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.completeWebAuthnRegistration(
+        new CompleteWebAuthnRegistrationCommand({
+          AccessToken: setUp.accessToken,
+          Credential: elsewhere,
+        }),
+      );
+    });
+
+    // Then the origin is not one the relying party covers.
+    assertInstanceOf(error, SimCognitoWebAuthnOriginNotAllowedException);
+    assertStringIncludes(error.message, simCognitoRelyingPartyId);
+  });
+
+  it("refuses a credential signed for another relying party", async () => {
+    // Given a user part way through a registration.
+    const setUp = await simCognitoWithPasskeyPool();
+
+    await setUp.cognito.startWebAuthnRegistration(
+      new StartWebAuthnRegistrationCommand({ AccessToken: setUp.accessToken }),
+    );
+
+    const misdirected = credentialWith(simCognitoPasskeyCredential(setUp), {
+      authenticatorData: authenticatorDataFor("elsewhere.example.com"),
+    });
+
+    // When a credential whose authenticator data names another domain is sent.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.completeWebAuthnRegistration(
+        new CompleteWebAuthnRegistrationCommand({
+          AccessToken: setUp.accessToken,
+          Credential: misdirected,
+        }),
+      );
+    });
+
+    // Then the relying party inside what was signed is not this pool's.
+    assertInstanceOf(error, SimCognitoWebAuthnRelyingPartyMismatchException);
+  });
+
+  it("refuses a credential the pool cannot read a public key from", async () => {
+    // Given a user part way through a registration.
+    const setUp = await simCognitoWithPasskeyPool();
+
+    await setUp.cognito.startWebAuthnRegistration(
+      new StartWebAuthnRegistrationCommand({ AccessToken: setUp.accessToken }),
+    );
+
+    const unusable = credentialWith(simCognitoPasskeyCredential(setUp), {
+      publicKeyAlgorithm: -257,
+    });
+
+    // When a credential naming another algorithm is sent.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.completeWebAuthnRegistration(
+        new CompleteWebAuthnRegistrationCommand({
+          AccessToken: setUp.accessToken,
+          Credential: unusable,
+        }),
+      );
+    });
+
+    // Then the pool cannot use the key, and says which algorithm it asked for.
+    assertInstanceOf(error, SimCognitoWebAuthnCredentialNotSupportedException);
+    assertStringIncludes(error.message, "ECDSA over P-256");
+  });
+
+  it("refuses a credential that is not one a browser serialized", async () => {
+    // Given a user part way through a registration.
+    const setUp = await simCognitoWithPasskeyPool();
+
+    await setUp.cognito.startWebAuthnRegistration(
+      new StartWebAuthnRegistrationCommand({ AccessToken: setUp.accessToken }),
+    );
+
+    // When something else is sent as the credential.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.completeWebAuthnRegistration(
+        new CompleteWebAuthnRegistrationCommand({
+          AccessToken: setUp.accessToken,
+          Credential: "a-passkey-honest",
+        }),
+      );
+    });
+
+    // Then it is refused for what it is rather than read as a credential.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "navigator.credentials");
+  });
+
+  it("refuses deleting a passkey the user does not have", async () => {
+    // Given a user with one registered passkey.
+    const setUp = await simCognitoWithPasskeyPool();
+
+    await simCognitoRegisterPasskey(setUp);
+
+    // When another credential id is deleted.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.deleteWebAuthnCredential(
+        new DeleteWebAuthnCredentialCommand({
+          AccessToken: setUp.accessToken,
+          CredentialId: "not-a-credential-of-this-user",
+        }),
+      );
+    });
+
+    // Then the pool has no such passkey to forget.
+    assertInstanceOf(error, SimCognitoResourceNotFoundException);
+  });
+
+  it("refuses a credential whose client data is not the JSON a browser collects", async () => {
+    // Given a user part way through a registration.
+    const setUp = await simCognitoWithPasskeyPool();
+
+    await setUp.cognito.startWebAuthnRegistration(
+      new StartWebAuthnRegistrationCommand({ AccessToken: setUp.accessToken }),
+    );
+
+    const garbled = credentialWith(simCognitoPasskeyCredential(setUp), {
+      clientDataJSON: Buffer.from("not json at all").toString("base64url"),
+    });
+
+    // When a credential carrying something else as its client data is sent.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.completeWebAuthnRegistration(
+        new CompleteWebAuthnRegistrationCommand({
+          AccessToken: setUp.accessToken,
+          Credential: garbled,
+        }),
+      );
+    });
+
+    // Then it is refused for what the client data is.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "response.clientDataJSON is not");
+  });
+
+  it("refuses a credential collected for the other half of the ceremony", async () => {
+    // Given a user part way through a registration.
+    const setUp = await simCognitoWithPasskeyPool();
+
+    await setUp.cognito.startWebAuthnRegistration(
+      new StartWebAuthnRegistrationCommand({ AccessToken: setUp.accessToken }),
+    );
+
+    const credential = simCognitoPasskeyCredential(setUp);
+    const presented = credentialWith(credential, {
+      clientDataJSON: base64urlJson({
+        ...clientDataOf(credential),
+        type: "webauthn.get",
+      }),
+    });
+
+    // When a credential presenting a passkey is sent to the registration.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.completeWebAuthnRegistration(
+        new CompleteWebAuthnRegistrationCommand({
+          AccessToken: setUp.accessToken,
+          Credential: presented,
+        }),
+      );
+    });
+
+    // Then the ceremony it answers is the wrong one.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "rather than 'webauthn.create'");
+  });
+
+  it("refuses a credential with no authenticator data to read", async () => {
+    // Given a user part way through a registration.
+    const setUp = await simCognitoWithPasskeyPool();
+
+    await setUp.cognito.startWebAuthnRegistration(
+      new StartWebAuthnRegistrationCommand({ AccessToken: setUp.accessToken }),
+    );
+
+    const bare = credentialWith(simCognitoPasskeyCredential(setUp), {
+      authenticatorData: "",
+    });
+
+    // When a credential missing what the authenticator signed is sent.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.completeWebAuthnRegistration(
+        new CompleteWebAuthnRegistrationCommand({
+          AccessToken: setUp.accessToken,
+          Credential: bare,
+        }),
+      );
+    });
+
+    // Then it is refused for the member it is missing.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "authenticatorData must be");
+  });
+
+  it("refuses a credential whose public key is not a key at all", async () => {
+    // Given a user part way through a registration.
+    const setUp = await simCognitoWithPasskeyPool();
+
+    await setUp.cognito.startWebAuthnRegistration(
+      new StartWebAuthnRegistrationCommand({ AccessToken: setUp.accessToken }),
+    );
+
+    const unreadable = credentialWith(simCognitoPasskeyCredential(setUp), {
+      publicKey: Buffer.from("not a key").toString("base64url"),
+      transports: "internal",
+    });
+
+    // When a credential carrying something else as its public key is sent.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.completeWebAuthnRegistration(
+        new CompleteWebAuthnRegistrationCommand({
+          AccessToken: setUp.accessToken,
+          Credential: unreadable,
+        }),
+      );
+    });
+
+    // Then the pool has no key to check this passkey's signatures against.
+    assertInstanceOf(error, SimCognitoWebAuthnCredentialNotSupportedException);
+  });
+});

--- a/src/service/cognito/command/user/sim-cognito-web-authn-registration.iso.test.ts
+++ b/src/service/cognito/command/user/sim-cognito-web-authn-registration.iso.test.ts
@@ -1,0 +1,179 @@
+import {
+  CompleteWebAuthnRegistrationCommand,
+  DeleteWebAuthnCredentialCommand,
+  ListWebAuthnCredentialsCommand,
+  StartWebAuthnRegistrationCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertObjectMatches,
+  assertTypeString,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  simCognitoPasskeyCredential,
+  simCognitoRegisterPasskey,
+  simCognitoRelyingPartyId,
+  simCognitoWithPasskeyPool,
+} from "../../../../../test/cognito/passkey-fixture.js";
+import { simCognitoUsername } from "../../../../../test/cognito/signed-in-fixture.js";
+
+describe("sim Cognito passkey registration", () => {
+  it("answers a signed-in user with the options a passkey is made from", async () => {
+    // Given a pool that registers passkeys against a relying party, with a
+    // user signed in with its password.
+    const setUp = await simCognitoWithPasskeyPool();
+
+    // When that user starts registering one.
+    const started = await setUp.cognito.startWebAuthnRegistration(
+      new StartWebAuthnRegistrationCommand({ AccessToken: setUp.accessToken }),
+    );
+
+    // Then it is answered with what a browser passes to
+    // navigator.credentials.create(): the relying party, the user handle, the
+    // algorithm the pool will take, and a challenge to sign.
+    const options = started.CredentialCreationOptions;
+
+    assertNonNullable(options);
+    assertObjectMatches(options, {
+      rp: { id: simCognitoRelyingPartyId, name: "myapp-users" },
+      user: { name: simCognitoUsername, displayName: simCognitoUsername },
+      pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+      authenticatorSelection: { userVerification: "required" },
+      excludeCredentials: [],
+    });
+    assertTypeString(options.challenge);
+  });
+
+  it("registers the passkey the user's authenticator made", async () => {
+    // Given a signed-in user of a pool that registers passkeys.
+    const setUp = await simCognitoWithPasskeyPool();
+
+    // When it registers one, and reads back what it has.
+    const credential = await simCognitoRegisterPasskey(setUp);
+    const listed = await setUp.cognito.listWebAuthnCredentials(
+      new ListWebAuthnCredentialsCommand({ AccessToken: setUp.accessToken }),
+    );
+
+    // Then the pool holds the credential the authenticator created, against
+    // the relying party the pool names.
+    assertArrayLength(listed.Credentials ?? [], 1);
+    assertObjectMatches(listed.Credentials?.[0] ?? {}, {
+      CredentialId: credential.id,
+      RelyingPartyId: simCognitoRelyingPartyId,
+      FriendlyCredentialName: simCognitoRelyingPartyId,
+      AuthenticatorAttachment: "platform",
+      AuthenticatorTransports: ["internal", "hybrid"],
+    });
+  });
+
+  it("excludes a registered passkey from the next registration", async () => {
+    // Given a user that has registered one passkey.
+    const setUp = await simCognitoWithPasskeyPool();
+    const first = await simCognitoRegisterPasskey(setUp);
+
+    // When it starts registering another.
+    const started = await setUp.cognito.startWebAuthnRegistration(
+      new StartWebAuthnRegistrationCommand({ AccessToken: setUp.accessToken }),
+    );
+
+    // Then the one it has is excluded, so an authenticator already holding it
+    // makes a second rather than replacing the first.
+    assertObjectMatches(started.CredentialCreationOptions ?? {}, {
+      excludeCredentials: [
+        {
+          type: "public-key",
+          id: first.id,
+          transports: ["internal", "hybrid"],
+        },
+      ],
+    });
+  });
+
+  it("holds more than one passkey for a user, a page at a time", async () => {
+    // Given a user that has registered two passkeys.
+    const setUp = await simCognitoWithPasskeyPool();
+    const first = await simCognitoRegisterPasskey(setUp);
+    const second = await simCognitoRegisterPasskey(setUp);
+
+    // When they are listed one to a page.
+    const firstPage = await setUp.cognito.listWebAuthnCredentials(
+      new ListWebAuthnCredentialsCommand({
+        AccessToken: setUp.accessToken,
+        MaxResults: 1,
+      }),
+    );
+    const secondPage = await setUp.cognito.listWebAuthnCredentials(
+      new ListWebAuthnCredentialsCommand({
+        AccessToken: setUp.accessToken,
+        MaxResults: 1,
+        NextToken: firstPage.NextToken,
+      }),
+    );
+
+    // Then both come back, oldest first, and the second page ends the listing.
+    assertIdentical(firstPage.Credentials?.[0]?.CredentialId, first.id);
+    assertIdentical(secondPage.Credentials?.[0]?.CredentialId, second.id);
+    assertUndefined(secondPage.NextToken);
+  });
+
+  it("forgets a passkey the user deletes", async () => {
+    // Given a user with two registered passkeys.
+    const setUp = await simCognitoWithPasskeyPool();
+    const first = await simCognitoRegisterPasskey(setUp);
+    const second = await simCognitoRegisterPasskey(setUp);
+
+    // When it deletes the first.
+    await setUp.cognito.deleteWebAuthnCredential(
+      new DeleteWebAuthnCredentialCommand({
+        AccessToken: setUp.accessToken,
+        CredentialId: first.id,
+      }),
+    );
+
+    const listed = await setUp.cognito.listWebAuthnCredentials(
+      new ListWebAuthnCredentialsCommand({ AccessToken: setUp.accessToken }),
+    );
+
+    // Then only the other one is left.
+    assertArrayLength(listed.Credentials ?? [], 1);
+    assertIdentical(listed.Credentials?.[0]?.CredentialId, second.id);
+  });
+
+  it("registers a passkey whose authenticator named no transports", async () => {
+    // Given a user part way through a registration, whose authenticator says
+    // nothing usable about how the passkey can be reached.
+    const setUp = await simCognitoWithPasskeyPool();
+
+    await setUp.cognito.startWebAuthnRegistration(
+      new StartWebAuthnRegistrationCommand({ AccessToken: setUp.accessToken }),
+    );
+
+    const credential = simCognitoPasskeyCredential(setUp);
+
+    // When that credential is registered.
+    await setUp.cognito.completeWebAuthnRegistration(
+      new CompleteWebAuthnRegistrationCommand({
+        AccessToken: setUp.accessToken,
+        Credential: {
+          ...credential,
+          response: { ...credential.response, transports: "internal" },
+        },
+      }),
+    );
+
+    const listed = await setUp.cognito.listWebAuthnCredentials(
+      new ListWebAuthnCredentialsCommand({ AccessToken: setUp.accessToken }),
+    );
+
+    // Then the passkey is registered with no transports at all.
+    assertArrayLength(
+      listed.Credentials?.[0]?.AuthenticatorTransports ?? [],
+      0,
+    );
+  });
+});

--- a/src/service/cognito/command/user/sim-cognito-web-authn-registration.iso.test.ts
+++ b/src/service/cognito/command/user/sim-cognito-web-authn-registration.iso.test.ts
@@ -1,5 +1,6 @@
 import {
   CompleteWebAuthnRegistrationCommand,
+  CreateUserPoolDomainCommand,
   DeleteWebAuthnCredentialCommand,
   ListWebAuthnCredentialsCommand,
   StartWebAuthnRegistrationCommand,
@@ -9,6 +10,7 @@ import {
   assertIdentical,
   assertNonNullable,
   assertObjectMatches,
+  assertTrue,
   assertTypeString,
   assertUndefined,
 } from "@kensio/smartass";
@@ -20,7 +22,10 @@ import {
   simCognitoRelyingPartyId,
   simCognitoWithPasskeyPool,
 } from "../../../../../test/cognito/passkey-fixture.js";
-import { simCognitoUsername } from "../../../../../test/cognito/signed-in-fixture.js";
+import {
+  simCognitoSignedIn,
+  simCognitoUsername,
+} from "../../../../../test/cognito/signed-in-fixture.js";
 
 describe("sim Cognito passkey registration", () => {
   it("answers a signed-in user with the options a passkey is made from", async () => {
@@ -175,5 +180,67 @@ describe("sim Cognito passkey registration", () => {
       listed.Credentials?.[0]?.AuthenticatorTransports ?? [],
       0,
     );
+  });
+
+  it("registers against the pool's hosted domain where it names no relying party", async () => {
+    // Given a signed-in user of a pool with a hosted domain and no
+    // WebAuthnConfiguration of its own.
+    const setUp = await simCognitoSignedIn();
+
+    await setUp.cognito.createUserPoolDomain(
+      new CreateUserPoolDomainCommand({
+        UserPoolId: setUp.userPoolId,
+        Domain: "myapp-login",
+      }),
+    );
+
+    // When it registers a passkey.
+    await simCognitoRegisterPasskey(setUp);
+
+    const listed = await setUp.cognito.listWebAuthnCredentials(
+      new ListWebAuthnCredentialsCommand({ AccessToken: setUp.accessToken }),
+    );
+
+    // Then the passkey is registered against the domain, which is what real
+    // Cognito falls back to.
+    assertIdentical(
+      listed.Credentials?.[0]?.RelyingPartyId,
+      "myapp-login.auth.eu-west-2.amazoncognito.com",
+    );
+  });
+
+  it("takes a page size of zero as the whole page", async () => {
+    // Given a user with one registered passkey.
+    const setUp = await simCognitoWithPasskeyPool();
+    const registered = await simCognitoRegisterPasskey(setUp);
+
+    // When they are listed with the zero Cognito documents as a valid page
+    // size.
+    const listed = await setUp.cognito.listWebAuthnCredentials(
+      new ListWebAuthnCredentialsCommand({
+        AccessToken: setUp.accessToken,
+        MaxResults: 0,
+      }),
+    );
+
+    // Then the passkey comes back rather than the request being refused.
+    assertIdentical(listed.Credentials?.[0]?.CredentialId, registered.id);
+  });
+
+  it("moves the user's last modified date on when its passkeys change", async () => {
+    // Given a signed-in user of a pool that registers passkeys.
+    const setUp = await simCognitoWithPasskeyPool();
+    const user = setUp.cognito.userPool(setUp.userPoolId).users[0];
+
+    assertNonNullable(user);
+
+    const before = user.lastModifiedDate;
+
+    // When a passkey is registered a minute later.
+    await setUp.simAws.clock().advanceBy({ minutes: 1 });
+    await simCognitoRegisterPasskey(setUp);
+
+    // Then the user has changed, as it does for every other change to it.
+    assertTrue(user.lastModifiedDate > before);
   });
 });

--- a/src/service/cognito/command/user/web-authn.command.ts
+++ b/src/service/cognito/command/user/web-authn.command.ts
@@ -1,0 +1,102 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimCognitoWebAuthnCredentialDescription } from "../../user-pool/user/web-authn/sim-cognito-web-authn-credential.js";
+import type { SimCognitoWebAuthnCreationOptions } from "../../user-pool/user/web-authn/sim-cognito-web-authn-document.js";
+
+/**
+ * The StartWebAuthnRegistration inputs this simulation reads.
+ *
+ * The access token is the whole of the authorization, as it is on real
+ * Cognito: a passkey is registered by the user it belongs to, from a session
+ * that already exists, and no IAM policy is evaluated for it.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cognito-identity-provider/command/StartWebAuthnRegistrationCommand/
+ */
+export interface SimStartWebAuthnRegistrationCommandInput {
+  readonly AccessToken?: string | undefined;
+}
+
+/**
+ * Minimal structural sim Cognito StartWebAuthnRegistration command.
+ */
+export interface SimStartWebAuthnRegistrationCommand {
+  readonly input: SimStartWebAuthnRegistrationCommandInput;
+}
+
+export interface SimStartWebAuthnRegistrationCommandOutput {
+  readonly CredentialCreationOptions?:
+    | SimCognitoWebAuthnCreationOptions
+    | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * The CompleteWebAuthnRegistration inputs this simulation reads.
+ *
+ * `Credential` is the JSON a browser serializes the `PublicKeyCredential` from
+ * `navigator.credentials.create()` to, which is why it is a document rather
+ * than a shape the API names.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cognito-identity-provider/command/CompleteWebAuthnRegistrationCommand/
+ */
+export interface SimCompleteWebAuthnRegistrationCommandInput {
+  readonly AccessToken?: string | undefined;
+  readonly Credential?: unknown;
+}
+
+/**
+ * Minimal structural sim Cognito CompleteWebAuthnRegistration command.
+ */
+export interface SimCompleteWebAuthnRegistrationCommand {
+  readonly input: SimCompleteWebAuthnRegistrationCommandInput;
+}
+
+export interface SimCompleteWebAuthnRegistrationCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * The ListWebAuthnCredentials inputs this simulation reads.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cognito-identity-provider/command/ListWebAuthnCredentialsCommand/
+ */
+export interface SimListWebAuthnCredentialsCommandInput {
+  readonly AccessToken?: string | undefined;
+  readonly MaxResults?: number | undefined;
+  readonly NextToken?: string | undefined;
+}
+
+/**
+ * Minimal structural sim Cognito ListWebAuthnCredentials command.
+ */
+export interface SimListWebAuthnCredentialsCommand {
+  readonly input: SimListWebAuthnCredentialsCommandInput;
+}
+
+export interface SimListWebAuthnCredentialsCommandOutput {
+  readonly Credentials?:
+    | readonly SimCognitoWebAuthnCredentialDescription[]
+    | undefined;
+  readonly NextToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * The DeleteWebAuthnCredential inputs this simulation reads.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cognito-identity-provider/command/DeleteWebAuthnCredentialCommand/
+ */
+export interface SimDeleteWebAuthnCredentialCommandInput {
+  readonly AccessToken?: string | undefined;
+  readonly CredentialId?: string | undefined;
+}
+
+/**
+ * Minimal structural sim Cognito DeleteWebAuthnCredential command.
+ */
+export interface SimDeleteWebAuthnCredentialCommand {
+  readonly input: SimDeleteWebAuthnCredentialCommandInput;
+}
+
+export interface SimDeleteWebAuthnCredentialCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/cognito/error/sim-cognito-web-authn.error.ts
+++ b/src/service/cognito/error/sim-cognito-web-authn.error.ts
@@ -1,0 +1,75 @@
+import { SimCognitoError } from "./sim-cognito.error.js";
+
+/**
+ * Simulated Cognito WebAuthnConfigurationMissingException error.
+ *
+ * Real Cognito reports a passkey operation against a pool that has no relying
+ * party id this way. A passkey is registered against a domain, so a pool that
+ * names none has nothing to register one against.
+ */
+export class SimCognitoWebAuthnConfigurationMissingException extends SimCognitoError {
+  public override readonly name = "WebAuthnConfigurationMissingException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated Cognito WebAuthnChallengeNotFoundException error.
+ *
+ * Real Cognito reports a credential answering a challenge it never issued this
+ * way, which covers a registration nobody started and one already completed.
+ */
+export class SimCognitoWebAuthnChallengeNotFoundException extends SimCognitoError {
+  public override readonly name = "WebAuthnChallengeNotFoundException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated Cognito WebAuthnRelyingPartyMismatchException error.
+ *
+ * Real Cognito reports a credential signed for another relying party this way.
+ * The relying party is inside what the authenticator signed, so a credential
+ * made for one domain cannot be replayed at another.
+ */
+export class SimCognitoWebAuthnRelyingPartyMismatchException extends SimCognitoError {
+  public override readonly name = "WebAuthnRelyingPartyMismatchException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated Cognito WebAuthnOriginNotAllowedException error.
+ *
+ * Real Cognito reports a credential collected at an origin the pool does not
+ * allow this way. The origin is in the client data the authenticator signed
+ * over, and a passkey is presented from the relying party's own site.
+ */
+export class SimCognitoWebAuthnOriginNotAllowedException extends SimCognitoError {
+  public override readonly name = "WebAuthnOriginNotAllowedException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated Cognito WebAuthnCredentialNotSupportedException error.
+ *
+ * Real Cognito reports a credential it cannot use this way. Here that is one
+ * whose public key it cannot read, or one signed with an algorithm other than
+ * the ECDSA over P-256 the registration asked for.
+ */
+export class SimCognitoWebAuthnCredentialNotSupportedException extends SimCognitoError {
+  public override readonly name = "WebAuthnCredentialNotSupportedException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}

--- a/src/service/cognito/index.ts
+++ b/src/service/cognito/index.ts
@@ -47,6 +47,7 @@ export {
 } from "./user-pool/sim-cognito-sign-in-policy.js";
 export { SimCognitoUserPoolClient } from "./user-pool/client/sim-cognito-user-pool-client.js";
 export type { SimCognitoUserPoolClientId } from "./user-pool/client/sim-cognito-user-pool-client-id.js";
+export { SimCognitoAuthSessionValidity } from "./user-pool/client/sim-cognito-auth-session-validity.js";
 export { SimCognitoExplicitAuthFlows } from "./user-pool/client/sim-cognito-explicit-auth-flows.js";
 export { SimCognitoPreventUserExistenceErrors } from "./user-pool/client/sim-cognito-prevent-user-existence-errors.js";
 export {
@@ -66,6 +67,16 @@ export { SimCognitoUserDirectory } from "./sim-cognito-user-directory.js";
 export { SimCognitoFederation } from "./sim-cognito-federation.js";
 export { SimCognitoAuthentication } from "./sim-cognito-authentication.js";
 export { SimCognitoUser } from "./user-pool/user/sim-cognito-user.js";
+export { SimCognitoUserWebAuthn } from "./user-pool/user/web-authn/sim-cognito-user-web-authn.js";
+export {
+  SimCognitoWebAuthnCredential,
+  type SimCognitoWebAuthnCredentialDescription,
+} from "./user-pool/user/web-authn/sim-cognito-web-authn-credential.js";
+export type {
+  SimCognitoWebAuthnCreationOptions,
+  SimCognitoWebAuthnCredentialDescriptor,
+  SimCognitoWebAuthnCredentialDocument,
+} from "./user-pool/user/web-authn/sim-cognito-web-authn-document.js";
 export { SimCognitoConfirmationCode } from "./user-pool/user/sim-cognito-confirmation-code.js";
 export { SimCognitoUserPasswordReset } from "./user-pool/user/sim-cognito-user-password-reset.js";
 export type { SimCognitoUsername } from "./user-pool/user/sim-cognito-username.js";
@@ -150,6 +161,13 @@ export { SimCognitoTriggerOccasion } from "./user-pool/trigger/sim-cognito-trigg
 export { SimCognitoAuthSession } from "./user-pool/auth/sim-cognito-auth-session.js";
 export { SimCognitoIssuedToken } from "./user-pool/auth/sim-cognito-issued-token.js";
 export { SimCognitoPoolAuth } from "./user-pool/auth/sim-cognito-pool-auth.js";
+export {
+  SimCognitoWebAuthnChallengeNotFoundException,
+  SimCognitoWebAuthnConfigurationMissingException,
+  SimCognitoWebAuthnCredentialNotSupportedException,
+  SimCognitoWebAuthnOriginNotAllowedException,
+  SimCognitoWebAuthnRelyingPartyMismatchException,
+} from "./error/sim-cognito-web-authn.error.js";
 export {
   isSimCognitoOAuthError,
   SimCognitoOAuthError,

--- a/src/service/cognito/index.ts
+++ b/src/service/cognito/index.ts
@@ -74,6 +74,7 @@ export {
 } from "./user-pool/user/web-authn/sim-cognito-web-authn-credential.js";
 export type {
   SimCognitoWebAuthnCreationOptions,
+  SimCognitoWebAuthnDocumentValue,
   SimCognitoWebAuthnCredentialDescriptor,
   SimCognitoWebAuthnCredentialDocument,
 } from "./user-pool/user/web-authn/sim-cognito-web-authn-document.js";

--- a/src/service/cognito/sdk/sim-cognito-sdk-command-router.ts
+++ b/src/service/cognito/sdk/sim-cognito-sdk-command-router.ts
@@ -7,14 +7,15 @@ import { simCognitoSdkAuthRoutes } from "./sim-cognito-sdk-auth-routes.js";
 import { simCognitoSdkDirectoryRoutes } from "./sim-cognito-sdk-directory-routes.js";
 import { simCognitoSdkFederationRoutes } from "./sim-cognito-sdk-federation-routes.js";
 import { simCognitoSdkPoolRoutes } from "./sim-cognito-sdk-pool-routes.js";
+import { simCognitoSdkWebAuthnRoutes } from "./sim-cognito-sdk-web-authn-routes.js";
 
 /**
  * Routes intercepted SDK Commands to one scoped simulated Cognito.
  *
  * The routes are grouped the way the operations themselves are, into pools and
  * their app clients, the users and groups in them, the domain and identity
- * providers they federate through, and signing in, so that adding an operation
- * touches the group it belongs to.
+ * providers they federate through, signing in, and the passkeys a user
+ * registers, so that adding an operation touches the group it belongs to.
  */
 export class SimCognitoSdkCommandRouter implements SimSdkCommandRouter {
   private readonly routes: ReadonlyMap<string, SimSdkCommandRoute>;
@@ -25,6 +26,7 @@ export class SimCognitoSdkCommandRouter implements SimSdkCommandRouter {
       ...simCognitoSdkDirectoryRoutes(simCognito),
       ...simCognitoSdkAuthRoutes(simCognito),
       ...simCognitoSdkFederationRoutes(simCognito),
+      ...simCognitoSdkWebAuthnRoutes(simCognito),
     ]);
   }
 

--- a/src/service/cognito/sdk/sim-cognito-sdk-web-authn-routes.ts
+++ b/src/service/cognito/sdk/sim-cognito-sdk-web-authn-routes.ts
@@ -1,0 +1,50 @@
+import type { SimSdkCommandRoute } from "../../../sdk/index.js";
+import type {
+  SimCompleteWebAuthnRegistrationCommand,
+  SimDeleteWebAuthnCredentialCommand,
+  SimListWebAuthnCredentialsCommand,
+  SimStartWebAuthnRegistrationCommand,
+} from "../command/user/web-authn.command.js";
+import type { SimCognitoIdentityProvider } from "../sim-cognito-identity-provider.js";
+
+/**
+ * The SDK Command routes for a user's passkeys.
+ *
+ * None of them reads a caller from the SDK context, because real Cognito
+ * authorizes all four with the user's own access token and no IAM policy at
+ * all.
+ */
+export function simCognitoSdkWebAuthnRoutes(
+  simCognito: SimCognitoIdentityProvider,
+): readonly (readonly [string, SimSdkCommandRoute])[] {
+  return [
+    [
+      "StartWebAuthnRegistrationCommand",
+      async (command): Promise<unknown> =>
+        await simCognito.startWebAuthnRegistration(
+          command as SimStartWebAuthnRegistrationCommand,
+        ),
+    ],
+    [
+      "CompleteWebAuthnRegistrationCommand",
+      async (command): Promise<unknown> =>
+        await simCognito.completeWebAuthnRegistration(
+          command as SimCompleteWebAuthnRegistrationCommand,
+        ),
+    ],
+    [
+      "ListWebAuthnCredentialsCommand",
+      async (command): Promise<unknown> =>
+        await simCognito.listWebAuthnCredentials(
+          command as SimListWebAuthnCredentialsCommand,
+        ),
+    ],
+    [
+      "DeleteWebAuthnCredentialCommand",
+      async (command): Promise<unknown> =>
+        await simCognito.deleteWebAuthnCredential(
+          command as SimDeleteWebAuthnCredentialCommand,
+        ),
+    ],
+  ];
+}

--- a/src/service/cognito/sdk/sim-cognito-sdk-web-authn-routing.iso.test.ts
+++ b/src/service/cognito/sdk/sim-cognito-sdk-web-authn-routing.iso.test.ts
@@ -1,0 +1,114 @@
+import {
+  AdminCreateUserCommand,
+  AdminSetUserPasswordCommand,
+  CognitoIdentityProviderClient,
+  CompleteWebAuthnRegistrationCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  DeleteWebAuthnCredentialCommand,
+  InitiateAuthCommand,
+  ListWebAuthnCredentialsCommand,
+  SetUserPoolMfaConfigCommand,
+  StartWebAuthnRegistrationCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimSdk } from "../../../sdk/index.js";
+import { SimAws } from "../../aws/sim-aws.js";
+
+describe("Cognito passkey SDK interception", () => {
+  it("routes every passkey Command through the intercepted client", async () => {
+    // Given an intercepted Cognito SDK client, and a pool that registers
+    // passkeys against a relying party.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    using simSdk = new SimSdk({ simAws });
+    simSdk.intercept(CognitoIdentityProviderClient);
+
+    const client = new CognitoIdentityProviderClient({ region: "eu-west-2" });
+    const pool = await client.send(
+      new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+    );
+    const userPoolId = pool.UserPool?.Id;
+    assertTypeString(userPoolId);
+
+    await client.send(
+      new SetUserPoolMfaConfigCommand({
+        UserPoolId: userPoolId,
+        MfaConfiguration: "OPTIONAL",
+        WebAuthnConfiguration: { RelyingPartyId: "myapp.example.com" },
+      }),
+    );
+
+    const appClient = await client.send(
+      new CreateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientName: "web",
+        ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH"],
+      }),
+    );
+
+    await client.send(
+      new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+    await client.send(
+      new AdminSetUserPasswordCommand({
+        UserPoolId: userPoolId,
+        Username: "alice",
+        Password: "Sup3rSecret!",
+        Permanent: true,
+      }),
+    );
+
+    const signedIn = await client.send(
+      new InitiateAuthCommand({
+        ClientId: appClient.UserPoolClient?.ClientId,
+        AuthFlow: "USER_PASSWORD_AUTH",
+        AuthParameters: { USERNAME: "alice", PASSWORD: "Sup3rSecret!" },
+      }),
+    );
+    const AccessToken = signedIn.AuthenticationResult?.AccessToken;
+
+    // When ordinary SDK code registers a passkey, lists it and deletes it.
+    const started = await client.send(
+      new StartWebAuthnRegistrationCommand({ AccessToken }),
+    );
+    const credential = simAws
+      .cognitoIdentityProvider()
+      .userPool(userPoolId)
+      .webAuthnCredential("alice");
+
+    await client.send(
+      new CompleteWebAuthnRegistrationCommand({
+        AccessToken,
+        Credential: credential,
+      }),
+    );
+
+    const listed = await client.send(
+      new ListWebAuthnCredentialsCommand({ AccessToken }),
+    );
+
+    await client.send(
+      new DeleteWebAuthnCredentialCommand({
+        AccessToken,
+        CredentialId: credential.id,
+      }),
+    );
+
+    const emptied = await client.send(
+      new ListWebAuthnCredentialsCommand({ AccessToken }),
+    );
+
+    // Then each Command reached simulated Cognito.
+    assertNonNullable(started.CredentialCreationOptions);
+    assertArrayLength(listed.Credentials ?? [], 1);
+    assertIdentical(listed.Credentials?.[0]?.CredentialId, credential.id);
+    assertArrayLength(emptied.Credentials ?? [], 0);
+  });
+});

--- a/src/service/cognito/sim-cognito-user-factors.ts
+++ b/src/service/cognito/sim-cognito-user-factors.ts
@@ -22,6 +22,10 @@ interface SimCognitoUserFactorsProperties {
  * `AdminSetUserMFAPreference` is the administrative one, and authorizes
  * against the pool like every other admin operation.
  *
+ * The passkey operations are here for the same reason: a passkey is
+ * registered by the user it belongs to, from a session that already exists,
+ * and the access token is the whole of the authorization.
+ *
  * `SimCognitoUserDirectory` extends this, which extends
  * `SimCognitoAuthentication`.
  */
@@ -70,6 +74,51 @@ export abstract class SimCognitoUserFactors extends SimCognitoAuthentication {
   ): Promise<simCognitoCommands.SimSetUserMFAPreferenceCommandOutput> {
     await this.background.sequence();
     return this.commands.userMfa.setUserMfaPreference(command);
+  }
+
+  /**
+   * Handle a StartWebAuthnRegistration Command from the SDK.
+   *
+   * The options this answers with are what a browser passes to
+   * `navigator.credentials.create()`. A test with no browser reads the
+   * credential its own authenticator would have made off the pool, through
+   * `SimCognitoUserPool.webAuthnCredential`.
+   */
+  async startWebAuthnRegistration(
+    command: simCognitoCommands.SimStartWebAuthnRegistrationCommand,
+  ): Promise<simCognitoCommands.SimStartWebAuthnRegistrationCommandOutput> {
+    await this.background.sequence();
+    return this.commands.webAuthn.startWebAuthnRegistration(command);
+  }
+
+  /**
+   * Handle a CompleteWebAuthnRegistration Command from the SDK.
+   */
+  async completeWebAuthnRegistration(
+    command: simCognitoCommands.SimCompleteWebAuthnRegistrationCommand,
+  ): Promise<simCognitoCommands.SimCompleteWebAuthnRegistrationCommandOutput> {
+    await this.background.sequence();
+    return this.commands.webAuthn.completeWebAuthnRegistration(command);
+  }
+
+  /**
+   * Handle a ListWebAuthnCredentials Command from the SDK.
+   */
+  async listWebAuthnCredentials(
+    command: simCognitoCommands.SimListWebAuthnCredentialsCommand,
+  ): Promise<simCognitoCommands.SimListWebAuthnCredentialsCommandOutput> {
+    await this.background.sequence();
+    return this.commands.webAuthn.listWebAuthnCredentials(command);
+  }
+
+  /**
+   * Handle a DeleteWebAuthnCredential Command from the SDK.
+   */
+  async deleteWebAuthnCredential(
+    command: simCognitoCommands.SimDeleteWebAuthnCredentialCommand,
+  ): Promise<simCognitoCommands.SimDeleteWebAuthnCredentialCommandOutput> {
+    await this.background.sequence();
+    return this.commands.webAuthn.deleteWebAuthnCredential(command);
   }
 
   /**

--- a/src/service/cognito/user-pool/auth/sim-cognito-auth-session.ts
+++ b/src/service/cognito/user-pool/auth/sim-cognito-auth-session.ts
@@ -1,19 +1,16 @@
 import { randomBytes } from "node:crypto";
-
-/**
- * How long a challenge session lasts.
- *
- * Real Cognito gives an app client an `AuthSessionValidity` of three minutes
- * unless the client says otherwise, and `CreateUserPoolClient` refuses that
- * input here, so three minutes is what every session gets.
- */
-const sessionMinutes = 3;
+import type { SimCognitoUserPoolClient } from "../client/sim-cognito-user-pool-client.js";
 
 const sessionBytes = 48;
 
 interface SimCognitoAuthSessionProperties {
   readonly username: string;
-  readonly clientId: string;
+
+  /**
+   * The app client the sign-in is running through, which is what says how
+   * long the session lasts: its `AuthSessionValidity`.
+   */
+  readonly client: SimCognitoUserPoolClient;
   readonly challengeName: string;
   readonly issuedAt: Date;
 
@@ -34,7 +31,9 @@ interface SimCognitoAuthSessionProperties {
  * between the request that started it and the response that completes it.
  *
  * The session is opaque, single use, and tied to the user and app client that
- * got it: a session from one sign-in cannot complete another.
+ * got it: a session from one sign-in cannot complete another. How long it can
+ * be answered for is the app client's `AuthSessionValidity`, which is three
+ * minutes on a client that asked for none.
  */
 export class SimCognitoAuthSession {
   public readonly id: string;
@@ -43,15 +42,26 @@ export class SimCognitoAuthSession {
   public readonly challengeName: string;
   public readonly issuedAt: Date;
 
+  /**
+   * When this session runs out, which the app client's `AuthSessionValidity`
+   * decides. It is settled here rather than read back off the client, so a
+   * client updated mid-sign-in does not move the deadline of a challenge it
+   * has already issued.
+   */
+  public readonly expiresAt: Date;
+
   /** The code this challenge sent, where it sent one. */
   public readonly code: string | undefined;
 
   constructor(properties: SimCognitoAuthSessionProperties) {
     this.id = randomBytes(sessionBytes).toString("base64url");
     this.username = properties.username;
-    this.clientId = properties.clientId;
+    this.clientId = properties.client.id;
     this.challengeName = properties.challengeName;
     this.issuedAt = properties.issuedAt;
+    this.expiresAt = properties.client.authSessionValidity.expiryOf(
+      properties.issuedAt,
+    );
     this.code = properties.code;
   }
 
@@ -59,11 +69,7 @@ export class SimCognitoAuthSession {
    * Whether this session has run out by a given moment.
    */
   isExpiredAt(now: Date): boolean {
-    const expiresAt = new Date(
-      this.issuedAt.getTime() + sessionMinutes * 60 * 1000,
-    );
-
-    return now.getTime() >= expiresAt.getTime();
+    return now.getTime() >= this.expiresAt.getTime();
   }
 
   /**

--- a/src/service/cognito/user-pool/client/sim-cognito-auth-session-validity.ts
+++ b/src/service/cognito/user-pool/client/sim-cognito-auth-session-validity.ts
@@ -1,0 +1,70 @@
+import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
+
+/**
+ * How long a challenge session lasts when the app client says nothing, which
+ * is the default real Cognito applies.
+ */
+const defaultMinutes = 3;
+
+const leastMinutes = 3;
+const mostMinutes = 15;
+
+const secondsPerMinute = 60;
+const millisecondsPerSecond = 1000;
+
+/**
+ * How long the challenge sessions of one simulated app client last.
+ *
+ * A sign-in that is answered with a challenge carries a session between the
+ * request that started it and the response that finishes it, and this is the
+ * window the response has to arrive in. Cognito counts it in whole minutes,
+ * gives a client that asked for none three of them, and takes between three
+ * and fifteen.
+ *
+ * It is worth setting in a test that has anything to say about a session
+ * running out: three minutes of simulated time is quick to pass, and a
+ * fifteen-minute client is what makes the expiry visible as a choice rather
+ * than a constant.
+ */
+export class SimCognitoAuthSessionValidity {
+  /**
+   * The validity in minutes, as Cognito reports it on the client.
+   */
+  public readonly minutes: number;
+
+  constructor(requested?: number) {
+    this.minutes = SimCognitoAuthSessionValidity.minutesIn(requested);
+  }
+
+  private static minutesIn(requested: number | undefined): number {
+    if (requested === undefined) {
+      return defaultMinutes;
+    }
+
+    if (!Number.isSafeInteger(requested)) {
+      throw new SimCognitoInvalidParameterException(
+        "AuthSessionValidity must be a whole number of minutes",
+      );
+    }
+
+    if (requested < leastMinutes || requested > mostMinutes) {
+      throw new SimCognitoInvalidParameterException(
+        `AuthSessionValidity of ${String(requested)} minutes is outside the ` +
+          `range Cognito allows: between ${String(leastMinutes)} and ` +
+          `${String(mostMinutes)} minutes`,
+      );
+    }
+
+    return requested;
+  }
+
+  /**
+   * When a session issued at a moment runs out.
+   */
+  expiryOf(issuedAt: Date): Date {
+    return new Date(
+      issuedAt.getTime() +
+        this.minutes * secondsPerMinute * millisecondsPerSecond,
+    );
+  }
+}

--- a/src/service/cognito/user-pool/client/sim-cognito-user-pool-client-settings.ts
+++ b/src/service/cognito/user-pool/client/sim-cognito-user-pool-client-settings.ts
@@ -1,4 +1,5 @@
 import { SimCognitoName } from "../sim-cognito-name.js";
+import { SimCognitoAuthSessionValidity } from "./sim-cognito-auth-session-validity.js";
 import { SimCognitoExplicitAuthFlows } from "./sim-cognito-explicit-auth-flows.js";
 import {
   SimCognitoOAuthSettings,
@@ -24,6 +25,7 @@ import {
 export interface SimCognitoUserPoolClientSettingsProperties
   extends SimCognitoTokenValidityInput, SimCognitoOAuthSettingsType {
   readonly ClientName?: string | undefined;
+  readonly AuthSessionValidity?: number | undefined;
   readonly ExplicitAuthFlows?: readonly string[] | undefined;
   readonly PreventUserExistenceErrors?: string | undefined;
   readonly RefreshTokenRotation?:
@@ -45,6 +47,11 @@ export class SimCognitoUserPoolClientSettings {
   public readonly explicitAuthFlows: SimCognitoExplicitAuthFlows;
   public readonly preventUserExistenceErrors: SimCognitoPreventUserExistenceErrors;
   public readonly tokenValidity: SimCognitoTokenValidity;
+
+  /**
+   * How long a challenge this client issued can be answered for.
+   */
+  public readonly authSessionValidity: SimCognitoAuthSessionValidity;
 
   /**
    * Whether this client rotates its refresh tokens, which decides what
@@ -69,6 +76,9 @@ export class SimCognitoUserPoolClientSettings {
       properties.PreventUserExistenceErrors,
     );
     this.tokenValidity = new SimCognitoTokenValidity(properties);
+    this.authSessionValidity = new SimCognitoAuthSessionValidity(
+      properties.AuthSessionValidity,
+    );
     this.refreshTokenRotation = new SimCognitoRefreshTokenRotation(
       properties.RefreshTokenRotation,
     );

--- a/src/service/cognito/user-pool/client/sim-cognito-user-pool-client.ts
+++ b/src/service/cognito/user-pool/client/sim-cognito-user-pool-client.ts
@@ -1,5 +1,6 @@
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import type { SimCognitoUserPoolId } from "../sim-cognito-user-pool-id.js";
+import type { SimCognitoAuthSessionValidity } from "./sim-cognito-auth-session-validity.js";
 import type { SimCognitoExplicitAuthFlows } from "./sim-cognito-explicit-auth-flows.js";
 import type { SimCognitoPreventUserExistenceErrors } from "./sim-cognito-prevent-user-existence-errors.js";
 import type { SimCognitoRefreshTokenRotation } from "./sim-cognito-refresh-token-rotation.js";
@@ -75,6 +76,14 @@ export class SimCognitoUserPoolClient {
    */
   get tokenValidity(): SimCognitoTokenValidity {
     return this.clientSettings.tokenValidity;
+  }
+
+  /**
+   * How long a challenge this client issued can be answered for, which is
+   * what decides when an unfinished sign-in through it runs out.
+   */
+  get authSessionValidity(): SimCognitoAuthSessionValidity {
+    return this.clientSettings.authSessionValidity;
   }
 
   /**

--- a/src/service/cognito/user-pool/mfa/sim-cognito-user-pool-mfa.ts
+++ b/src/service/cognito/user-pool/mfa/sim-cognito-user-pool-mfa.ts
@@ -52,7 +52,7 @@ export interface SimCognitoUserPoolMfaType {
    *
    * It sits among the MFA settings because that is where real Cognito puts
    * it, and a passkey with user verification is what counts towards MFA
-   * there. Nothing here presents one.
+   * there.
    */
   readonly WebAuthnConfiguration?:
     | SimCognitoWebAuthnConfigurationType

--- a/src/service/cognito/user-pool/mfa/sim-cognito-web-authn-configuration.ts
+++ b/src/service/cognito/user-pool/mfa/sim-cognito-web-authn-configuration.ts
@@ -35,9 +35,8 @@ const relyingPartyIdLength = { least: 1, most: 127 };
  * `WebAuthnRelyingPartyID` is deployed in two calls here as it is on real
  * CloudFormation.
  *
- * Recorded and reported. No passkey is registered or presented in this
- * simulation, because both go through the `USER_AUTH` flow that
- * `SimCognitoAuthFlows` refuses by name.
+ * `StartWebAuthnRegistration` reads both, and a pool that names no relying
+ * party has nothing to register a passkey against.
  */
 export class SimCognitoWebAuthnConfiguration {
   public readonly relyingPartyId: string | undefined;

--- a/src/service/cognito/user-pool/sim-cognito-sign-in-policy.ts
+++ b/src/service/cognito/user-pool/sim-cognito-sign-in-policy.ts
@@ -38,13 +38,13 @@ const mostFactors = 5;
  * about it, which is how real Cognito reports one. A pool created with a
  * policy carries the factors it named, and reports them back under `Policies`.
  *
- * **Nothing here presents a factor other than a password.** The factors are
- * recorded the way an `MfaConfiguration` is recorded, and the sign-in that
- * would have to present one is where the refusal happens. Every factor beside
- * `PASSWORD` is reached through the `USER_AUTH` flow, and
- * `SimCognitoAuthFlows` refuses that flow by name. So a pool configured for
- * passkeys here deploys, describes itself the way the deployed pool does, and
- * refuses a passkey sign-in in words that say what could not be done.
+ * **The factor a sign-in presents is not settled here.** These are recorded
+ * the way an `MfaConfiguration` is recorded, and the sign-in that presents one
+ * is where they are read. Every factor beside `PASSWORD` is reached through
+ * the `USER_AUTH` flow, and `SimCognitoAuthFlows` still refuses that flow by
+ * name, so a pool configured for a code sent by email deploys, describes
+ * itself the way the deployed pool does, and refuses that sign-in in words
+ * that say what could not be done.
  *
  * The validation is real Cognito's. The four factor names are the ones it
  * accepts, a list may name five of them at most, and a policy offering

--- a/src/service/cognito/user-pool/sim-cognito-user-pool.ts
+++ b/src/service/cognito/user-pool/sim-cognito-user-pool.ts
@@ -22,6 +22,7 @@ import type {
   SimCognitoSigningKey,
 } from "./token/sim-cognito-signing-key.js";
 import type { SimCognitoUser } from "./user/sim-cognito-user.js";
+import type { SimCognitoWebAuthnCredentialDocument } from "./user/web-authn/sim-cognito-web-authn-document.js";
 import { SimCognitoUserStore } from "./user/sim-cognito-user-store.js";
 import {
   requireSimCognitoUsername,
@@ -95,10 +96,9 @@ export class SimCognitoUserPool {
   /**
    * Replace this pool's settings with the ones an update asked for.
    *
-   * `UpdateUserPool` replaces rather than merges, as real Cognito does: the
-   * settings object is built from the update's own request, so a setting the
-   * request left out goes back to the default `CreateUserPool` would have
-   * given it rather than staying as it was.
+   * `UpdateUserPool` replaces rather than merges, as real Cognito does, so a
+   * setting the request left out goes back to the default `CreateUserPool`
+   * would have given it rather than staying as it was.
    */
   update(settings: SimCognitoUserPoolSettings): void {
     this.#settings = settings;
@@ -126,87 +126,65 @@ export class SimCognitoUserPool {
   }
 
   /**
-   * When the pool's settings last changed.
-   *
-   * A pool that no `UpdateUserPool` request has reached reports its creation
-   * date, as a real one does.
+   * When the pool's settings last changed, which is its creation date until
+   * an `UpdateUserPool` request reaches it.
    */
   get lastModifiedDate(): Date {
     return this.#modifiedDate;
   }
 
-  /**
-   * Every app client of this pool, in creation order.
-   */
+  /** Every app client of this pool, in creation order. */
   get clients(): readonly SimCognitoUserPoolClient[] {
     return this.clientStore.all;
   }
 
-  /**
-   * The app client ids already in use in this pool.
-   */
+  /** The app client ids already in use in this pool. */
   get clientIds(): Set<string> {
     return this.clientStore.ids;
   }
 
-  /**
-   * Store a newly created app client.
-   */
+  /** Store a newly created app client. */
   addClient(client: SimCognitoUserPoolClient): void {
     this.clientStore.add(client);
   }
 
-  /**
-   * Forget a deleted app client.
-   */
+  /** Forget a deleted app client. */
   removeClient(client: SimCognitoUserPoolClient): void {
     this.clientStore.remove(client);
   }
 
-  /**
-   * Find an app client of this pool by id.
-   */
+  /** Find an app client of this pool by id. */
   findClient(clientId: string): SimCognitoUserPoolClient | undefined {
     return this.clientStore.find(clientId);
   }
 
-  /**
-   * Resolve an app client of this pool by id, or refuse.
-   */
+  /** Resolve an app client of this pool by id, or refuse. */
   requireClient(
     clientId: SimCognitoUserPoolClientId,
   ): SimCognitoUserPoolClient {
     return this.clientStore.require(clientId);
   }
 
-  /**
-   * Every user in this pool, in creation order.
-   */
+  /** Every user in this pool, in creation order. */
   get users(): readonly SimCognitoUser[] {
     return this.userStore.all;
   }
 
-  /**
-   * How many users this pool holds.
-   */
+  /** How many users this pool holds. */
   get userCount(): number {
     return this.userStore.count;
   }
 
-  /**
-   * Store a newly created user, refusing a username already in this pool.
-   */
+  /** Store a newly created user, refusing a username already in this pool. */
   addUser(user: SimCognitoUser): void {
     this.userStore.add(user);
   }
 
   /**
    * Forget a deleted user, take them out of every group, and forget the
-   * tokens they hold.
-   *
-   * A group holding a user that no longer exists would answer `ListUsersInGroup`
-   * with a member this pool cannot describe, and a refresh token outliving its
-   * user would sign in someone the pool cannot describe either.
+   * tokens they hold. A group holding a user that no longer exists, or a
+   * refresh token outliving one, would reach a user this pool cannot
+   * describe.
    */
   removeUser(user: SimCognitoUser): void {
     this.userStore.remove(user);
@@ -214,16 +192,12 @@ export class SimCognitoUserPool {
     this.auth.signOut(user.username);
   }
 
-  /**
-   * Find a user of this pool by username.
-   */
+  /** Find a user of this pool by username. */
   findUser(username: string): SimCognitoUser | undefined {
     return this.userStore.find(username);
   }
 
-  /**
-   * Resolve a user of this pool by username, or refuse.
-   */
+  /** Resolve a user of this pool by username, or refuse. */
   requireUser(username: SimCognitoUsername): SimCognitoUser {
     return this.userStore.require(username);
   }
@@ -231,24 +205,31 @@ export class SimCognitoUserPool {
   /**
    * The confirmation code a user of this pool has outstanding, if it has one.
    *
-   * This and `softwareTokenCode` are the simulator's own accessors, for a test
-   * that has nowhere else to read a code from: nothing here delivers a message
-   * or holds the user's phone. Real Cognito reports either code to nobody.
+   * This, `softwareTokenCode` and `webAuthnCredential` are the simulator's own
+   * accessors, for a test with nowhere else to read a secret from: nothing
+   * here delivers a message, holds the user's phone or runs a browser. Real
+   * Cognito reports none of them to anybody.
    */
   confirmationCode(username: string): string | undefined {
-    return this.requireUser(requireSimCognitoUsername(username))
-      .confirmationCode;
+    return this.userNamed(username).confirmationCode;
   }
 
   /**
-   * The code a user's authenticator app is showing now, for a user that has
-   * been given a software token secret. A test that would rather compute the
-   * code itself can do so from the `SecretCode`, which is a real shared secret.
+   * The code a user's authenticator app is showing now. A test that would
+   * rather compute it can do so from the `SecretCode`, which is a real shared
+   * secret.
    */
   softwareTokenCode(username: string): string | undefined {
-    return this.requireUser(requireSimCognitoUsername(username)).mfa.codeAt(
-      this.clock.now(),
-    );
+    return this.userNamed(username).mfa.codeAt(this.clock.now());
+  }
+
+  /**
+   * The credential a user's authenticator would have created for the passkey
+   * registration it has been given options for, which is what
+   * `CompleteWebAuthnRegistration` takes as its `Credential`.
+   */
+  webAuthnCredential(username: string): SimCognitoWebAuthnCredentialDocument {
+    return this.userNamed(username).webAuthn.registrationCredential();
   }
 
   /** Every message this pool would have sent, oldest first. */
@@ -256,45 +237,37 @@ export class SimCognitoUserPool {
     return this.messages.all;
   }
 
-  /**
-   * Every group in this pool, in creation order.
-   */
+  /** Every group in this pool, in creation order. */
   get groups(): readonly SimCognitoGroup[] {
     return this.groupStore.all;
   }
 
-  /**
-   * Store a newly created group, refusing a name already in this pool.
-   */
+  /** Store a newly created group, refusing a name already in this pool. */
   addGroup(group: SimCognitoGroup): void {
     this.groupStore.add(group);
   }
 
-  /**
-   * Forget a deleted group, and with it the membership of its users.
-   */
+  /** Forget a deleted group, and with it the membership of its users. */
   removeGroup(group: SimCognitoGroup): void {
     this.groupStore.remove(group);
   }
 
-  /**
-   * Find a group of this pool by name.
-   */
+  /** Find a group of this pool by name. */
   findGroup(groupName: string): SimCognitoGroup | undefined {
     return this.groupStore.find(groupName);
   }
 
-  /**
-   * Resolve a group of this pool by name, or refuse.
-   */
+  /** Resolve a group of this pool by name, or refuse. */
   requireGroup(groupName: SimCognitoGroupName): SimCognitoGroup {
     return this.groupStore.require(groupName);
   }
 
-  /**
-   * The groups a user of this pool belongs to, strongest precedence first.
-   */
+  /** The groups a user of this pool belongs to, strongest precedence first. */
   groupsOf(username: string): readonly SimCognitoGroup[] {
     return this.groupStore.forUser(username);
+  }
+
+  private userNamed(username: string): SimCognitoUser {
+    return this.requireUser(requireSimCognitoUsername(username));
   }
 }

--- a/src/service/cognito/user-pool/user/sim-cognito-user.ts
+++ b/src/service/cognito/user-pool/user/sim-cognito-user.ts
@@ -3,6 +3,7 @@ import type { SimCognitoFederatedIdentity } from "../idp/sim-cognito-federated-i
 import { SimCognitoUserMfa } from "./mfa/sim-cognito-user-mfa.js";
 import { SimCognitoUserConfirmation } from "./sim-cognito-user-confirmation.js";
 import { SimCognitoUserPasswordReset } from "./sim-cognito-user-password-reset.js";
+import { SimCognitoUserWebAuthn } from "./web-authn/sim-cognito-user-web-authn.js";
 import type {
   SimCognitoAttributeType,
   SimCognitoUserAttributes,
@@ -53,6 +54,7 @@ export class SimCognitoUser {
   private readonly userAttributes: SimCognitoUserAttributes;
   private readonly confirmation: SimCognitoUserConfirmation;
   private readonly userMfa: SimCognitoUserMfa;
+  private readonly userWebAuthn: SimCognitoUserWebAuthn;
   private readonly reset: SimCognitoUserPasswordReset;
   private readonly federatedIdentity: SimCognitoFederatedIdentity | undefined;
   private userStatus: SimCognitoUserStatus;
@@ -72,12 +74,17 @@ export class SimCognitoUser {
     this.clock = properties.clock;
     this.creationDate = this.clock.now();
     this.modifiedDate = this.creationDate;
+    // Everything a user holds separately tells it when it has changed, so the
+    // user's last modified date moves on wherever the change was made.
+    const changed = (): void => {
+      this.touch();
+    };
+
     this.userMfa = new SimCognitoUserMfa({
       attributes: this.userAttributes.values,
-      changed: (): void => {
-        this.touch();
-      },
+      changed,
     });
+    this.userWebAuthn = new SimCognitoUserWebAuthn();
     this.reset = new SimCognitoUserPasswordReset({
       confirmation: this.confirmation,
       status: (): SimCognitoUserStatus => this.userStatus,
@@ -87,22 +94,16 @@ export class SimCognitoUser {
       chosen: (password): void => {
         this.setPassword(password, true);
       },
-      changed: (): void => {
-        this.touch();
-      },
+      changed,
     });
   }
 
-  /**
-   * When the user last changed.
-   */
+  /** When the user last changed. */
   get lastModifiedDate(): Date {
     return this.modifiedDate;
   }
 
-  /**
-   * Where the user is in the status lifecycle.
-   */
+  /** Where the user is in the status lifecycle. */
   get status(): SimCognitoUserStatus {
     return this.userStatus;
   }
@@ -177,6 +178,14 @@ export class SimCognitoUser {
   }
 
   /**
+   * The passkeys this user has registered. A passkey is a first factor rather
+   * than a second one, so it sits beside `mfa` rather than among it.
+   */
+  get webAuthn(): SimCognitoUserWebAuthn {
+    return this.userWebAuthn;
+  }
+
+  /**
    * The password reset this user can go through, which is what a forgotten
    * password is replaced by and what an administrator can force.
    */
@@ -221,9 +230,7 @@ export class SimCognitoUser {
     this.moveTo(SimCognitoUserStatus.confirmed);
   }
 
-  /**
-   * Confirm the sign-up without a code, as `AdminConfirmSignUp` does.
-   */
+  /** Confirm the sign-up without a code, as `AdminConfirmSignUp` does. */
   confirm(): void {
     this.userStatus.requireConfirmable();
     this.moveTo(SimCognitoUserStatus.confirmed);
@@ -253,9 +260,7 @@ export class SimCognitoUser {
     return this.userPassword?.matches(candidate) ?? false;
   }
 
-  /**
-   * Apply an attribute update to this user.
-   */
+  /** Apply an attribute update to this user. */
   updateAttributes(
     requested: readonly SimCognitoAttributeType[] | undefined,
   ): void {
@@ -263,17 +268,13 @@ export class SimCognitoUser {
     this.touch();
   }
 
-  /**
-   * Let the user authenticate again.
-   */
+  /** Let the user authenticate again. */
   enable(): void {
     this.isEnabled = true;
     this.touch();
   }
 
-  /**
-   * Stop the user authenticating.
-   */
+  /** Stop the user authenticating. */
   disable(): void {
     this.isEnabled = false;
     this.touch();

--- a/src/service/cognito/user-pool/user/sim-cognito-user.ts
+++ b/src/service/cognito/user-pool/user/sim-cognito-user.ts
@@ -84,7 +84,7 @@ export class SimCognitoUser {
       attributes: this.userAttributes.values,
       changed,
     });
-    this.userWebAuthn = new SimCognitoUserWebAuthn();
+    this.userWebAuthn = new SimCognitoUserWebAuthn({ changed });
     this.reset = new SimCognitoUserPasswordReset({
       confirmation: this.confirmation,
       status: (): SimCognitoUserStatus => this.userStatus,

--- a/src/service/cognito/user-pool/user/web-authn/sim-cognito-user-web-authn.ts
+++ b/src/service/cognito/user-pool/user/web-authn/sim-cognito-user-web-authn.ts
@@ -1,0 +1,136 @@
+import { SimCognitoResourceNotFoundException } from "../../../error/sim-cognito.error.js";
+import { SimCognitoWebAuthnChallengeNotFoundException } from "../../../error/sim-cognito-web-authn.error.js";
+import { simCognitoWebAuthnAttested } from "./sim-cognito-web-authn-attested-key.js";
+import {
+  simCognitoWebAuthnCreationOptions,
+  type SimCognitoWebAuthnRegistrationRequest,
+} from "./sim-cognito-web-authn-creation-options.js";
+import { requireSimCognitoWebAuthnCeremony } from "./sim-cognito-web-authn-ceremony.js";
+import type { SimCognitoWebAuthnCredential } from "./sim-cognito-web-authn-credential.js";
+import { simCognitoWebAuthnCreated } from "./sim-cognito-web-authn-authenticator.js";
+import type {
+  SimCognitoWebAuthnCreationOptions,
+  SimCognitoWebAuthnCredentialDocument,
+} from "./sim-cognito-web-authn-document.js";
+
+/**
+ * The passkeys one simulated user has, and the registration it is part way
+ * through.
+ *
+ * `StartWebAuthnRegistration` issues the challenge a passkey is created
+ * against, and `CompleteWebAuthnRegistration` hands back the credential the
+ * authenticator made from it. The challenge is spent either way, so a
+ * credential cannot be replayed into a second registration.
+ *
+ * What the pool keeps of a registration is the public key, the relying party
+ * and the identifier, and all of it is checked before any of it is stored.
+ *
+ * Registering or deleting a passkey leaves the user's own
+ * `UserLastModifiedDate` where it was, unlike registering a second factor. A
+ * passkey is a credential of its own rather than a setting on the user, and
+ * what real Cognito does to that date was not checked against a live account.
+ */
+export class SimCognitoUserWebAuthn {
+  readonly #credentials = new Map<string, SimCognitoWebAuthnCredential>();
+
+  /**
+   * The options the registration this user is part way through was issued
+   * with, which carry both the challenge and the relying party it answers to.
+   */
+  #pending: SimCognitoWebAuthnCreationOptions | undefined;
+
+  /**
+   * The passkeys this user has registered, oldest first.
+   */
+  get credentials(): readonly SimCognitoWebAuthnCredential[] {
+    return this.#credentials.values().toArray();
+  }
+
+  /**
+   * Ask for a passkey, and remember the challenge it has to be created
+   * against.
+   *
+   * A second call replaces the first, as real Cognito replaces one: the
+   * challenge a browser was part way through answering is spent whether or not
+   * a credential ever came back for it.
+   */
+  startRegistration(
+    request: SimCognitoWebAuthnRegistrationRequest,
+  ): SimCognitoWebAuthnCreationOptions {
+    const options = simCognitoWebAuthnCreationOptions(
+      request,
+      this.credentials.map((each) => each.descriptor()),
+    );
+
+    this.#pending = options;
+
+    return options;
+  }
+
+  /**
+   * Register the passkey a browser created, having checked it answers the
+   * challenge this user was issued.
+   */
+  completeRegistration(credential: unknown, now: Date): void {
+    const pending = this.requirePending();
+    const relyingPartyId = pending.rp.id;
+    const ceremony = requireSimCognitoWebAuthnCeremony({
+      credential,
+      field: "Credential",
+      type: "webauthn.create",
+      challenge: pending.challenge,
+      relyingPartyId,
+    });
+
+    // The challenge is spent whether or not the rest of the credential is
+    // usable, so a refused one cannot be retried against the same challenge.
+    this.#pending = undefined;
+
+    this.#credentials.set(
+      ceremony.credentialId,
+      simCognitoWebAuthnAttested(ceremony, relyingPartyId, now),
+    );
+  }
+
+  /**
+   * Forget a passkey, or refuse an identifier this user has none for.
+   */
+  remove(credentialId: string | undefined): void {
+    if (credentialId === undefined || !this.#credentials.has(credentialId)) {
+      throw new SimCognitoResourceNotFoundException(
+        `This user has no registered passkey with the credential id ` +
+          `'${String(credentialId)}'`,
+      );
+    }
+
+    this.#credentials.delete(credentialId);
+  }
+
+  /**
+   * The credential this user's authenticator would have made for the
+   * registration it has been given options for.
+   *
+   * This is the simulator's own accessor, for a test that has no browser to
+   * run the ceremony in. Real Cognito hands the options to a browser and the
+   * browser hands back the credential.
+   */
+  registrationCredential(): SimCognitoWebAuthnCredentialDocument {
+    return simCognitoWebAuthnCreated(this.requirePending());
+  }
+
+  /**
+   * The registration this user is part way through, or a refusal saying it is
+   * part way through none.
+   */
+  private requirePending(): SimCognitoWebAuthnCreationOptions {
+    if (this.#pending === undefined) {
+      throw new SimCognitoWebAuthnChallengeNotFoundException(
+        "No passkey registration is in progress for this user: call " +
+          "StartWebAuthnRegistration for the challenge a credential is " +
+          "created against.",
+      );
+    }
+
+    return this.#pending;
+  }
+}

--- a/src/service/cognito/user-pool/user/web-authn/sim-cognito-user-web-authn.ts
+++ b/src/service/cognito/user-pool/user/web-authn/sim-cognito-user-web-authn.ts
@@ -1,17 +1,21 @@
 import { SimCognitoResourceNotFoundException } from "../../../error/sim-cognito.error.js";
 import { SimCognitoWebAuthnChallengeNotFoundException } from "../../../error/sim-cognito-web-authn.error.js";
-import { simCognitoWebAuthnAttested } from "./sim-cognito-web-authn-attested-key.js";
+import { simCognitoWebAuthnRegistered } from "./sim-cognito-web-authn-attested-key.js";
 import {
   simCognitoWebAuthnCreationOptions,
   type SimCognitoWebAuthnRegistrationRequest,
 } from "./sim-cognito-web-authn-creation-options.js";
-import { requireSimCognitoWebAuthnCeremony } from "./sim-cognito-web-authn-ceremony.js";
 import type { SimCognitoWebAuthnCredential } from "./sim-cognito-web-authn-credential.js";
 import { simCognitoWebAuthnCreated } from "./sim-cognito-web-authn-authenticator.js";
 import type {
   SimCognitoWebAuthnCreationOptions,
   SimCognitoWebAuthnCredentialDocument,
 } from "./sim-cognito-web-authn-document.js";
+
+interface SimCognitoUserWebAuthnProperties {
+  /** What to call when the user's passkeys change. */
+  readonly changed: () => void;
+}
 
 /**
  * The passkeys one simulated user has, and the registration it is part way
@@ -25,10 +29,9 @@ import type {
  * What the pool keeps of a registration is the public key, the relying party
  * and the identifier, and all of it is checked before any of it is stored.
  *
- * Registering or deleting a passkey leaves the user's own
- * `UserLastModifiedDate` where it was, unlike registering a second factor. A
- * passkey is a credential of its own rather than a setting on the user, and
- * what real Cognito does to that date was not checked against a live account.
+ * Registering or deleting a passkey moves the user's `UserLastModifiedDate`
+ * on, as every other change to a user does. Whether real Cognito moves it for
+ * a passkey was not checked against a live account.
  */
 export class SimCognitoUserWebAuthn {
   readonly #credentials = new Map<string, SimCognitoWebAuthnCredential>();
@@ -38,6 +41,13 @@ export class SimCognitoUserWebAuthn {
    * with, which carry both the challenge and the relying party it answers to.
    */
   #pending: SimCognitoWebAuthnCreationOptions | undefined;
+
+  /** What to tell the user when its passkeys change. */
+  readonly #changed: () => void;
+
+  constructor(properties: SimCognitoUserWebAuthnProperties) {
+    this.#changed = properties.changed;
+  }
 
   /**
    * The passkeys this user has registered, oldest first.
@@ -72,38 +82,32 @@ export class SimCognitoUserWebAuthn {
    * challenge this user was issued.
    */
   completeRegistration(credential: unknown, now: Date): void {
+    // The challenge is spent before the credential is read, so a refused one
+    // cannot be retried against the same challenge. Real Cognito issues one
+    // challenge per registration, and StartWebAuthnRegistration is what issues
+    // another.
     const pending = this.requirePending();
-    const relyingPartyId = pending.rp.id;
-    const ceremony = requireSimCognitoWebAuthnCeremony({
-      credential,
-      field: "Credential",
-      type: "webauthn.create",
-      challenge: pending.challenge,
-      relyingPartyId,
-    });
 
-    // The challenge is spent whether or not the rest of the credential is
-    // usable, so a refused one cannot be retried against the same challenge.
     this.#pending = undefined;
 
-    this.#credentials.set(
-      ceremony.credentialId,
-      simCognitoWebAuthnAttested(ceremony, relyingPartyId, now),
-    );
+    const registered = simCognitoWebAuthnRegistered(pending, credential, now);
+
+    this.#credentials.set(registered.credentialId, registered);
+    this.#changed();
   }
 
   /**
    * Forget a passkey, or refuse an identifier this user has none for.
    */
   remove(credentialId: string | undefined): void {
-    if (credentialId === undefined || !this.#credentials.has(credentialId)) {
+    if (credentialId === undefined || !this.#credentials.delete(credentialId)) {
       throw new SimCognitoResourceNotFoundException(
         `This user has no registered passkey with the credential id ` +
           `'${String(credentialId)}'`,
       );
     }
 
-    this.#credentials.delete(credentialId);
+    this.#changed();
   }
 
   /**

--- a/src/service/cognito/user-pool/user/web-authn/sim-cognito-web-authn-attested-key.ts
+++ b/src/service/cognito/user-pool/user/web-authn/sim-cognito-web-authn-attested-key.ts
@@ -1,0 +1,80 @@
+import type { KeyObject } from "node:crypto";
+
+import { SimCognitoWebAuthnCredentialNotSupportedException } from "../../../error/sim-cognito-web-authn.error.js";
+import type { SimCognitoWebAuthnCeremony } from "./sim-cognito-web-authn-ceremony.js";
+import { SimCognitoWebAuthnCredential } from "./sim-cognito-web-authn-credential.js";
+import {
+  simCognitoWebAuthnAlgorithm,
+  simCognitoWebAuthnKeyFrom,
+} from "./sim-cognito-web-authn-signing.js";
+
+/**
+ * How a credential says it is attached when it says nothing, which is what a
+ * phone or a laptop reports.
+ */
+const defaultAttachment = "platform";
+
+/**
+ * The public key a credential carries, or a refusal where the pool cannot read
+ * one.
+ */
+function publicKeyOf(response: Readonly<Record<string, unknown>>): KeyObject {
+  const encoded = response["publicKey"];
+  const publicKey =
+    typeof encoded === "string"
+      ? simCognitoWebAuthnKeyFrom(encoded)
+      : undefined;
+
+  if (
+    publicKey === undefined ||
+    response["publicKeyAlgorithm"] !== simCognitoWebAuthnAlgorithm
+  ) {
+    throw new SimCognitoWebAuthnCredentialNotSupportedException(
+      "The credential carries no public key this user pool can use: the " +
+        "registration asked for ECDSA over P-256, which a browser reports " +
+        "as response.publicKey with a publicKeyAlgorithm of " +
+        `${String(simCognitoWebAuthnAlgorithm)}.`,
+    );
+  }
+
+  return publicKey;
+}
+
+/**
+ * The strings of a credential member that is meant to be a list of them.
+ */
+function stringsOf(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return (value as readonly unknown[]).filter(
+    (each): each is string => typeof each === "string",
+  );
+}
+
+/**
+ * The passkey a pool keeps out of the credential a registration carried.
+ *
+ * A browser reports the public key as `response.publicKey`, base64url of its
+ * SubjectPublicKeyInfo, and names the algorithm beside it. That is what is
+ * read here rather than the attestation object, which a real relying party
+ * parses out of CBOR and this simulation does not.
+ */
+export function simCognitoWebAuthnAttested(
+  ceremony: SimCognitoWebAuthnCeremony,
+  relyingPartyId: string,
+  createdAt: Date,
+): SimCognitoWebAuthnCredential {
+  const attachment = ceremony.document["authenticatorAttachment"];
+
+  return new SimCognitoWebAuthnCredential({
+    credentialId: ceremony.credentialId,
+    publicKey: publicKeyOf(ceremony.response),
+    relyingPartyId,
+    authenticatorAttachment:
+      typeof attachment === "string" ? attachment : defaultAttachment,
+    transports: stringsOf(ceremony.response["transports"]),
+    createdAt,
+  });
+}

--- a/src/service/cognito/user-pool/user/web-authn/sim-cognito-web-authn-attested-key.ts
+++ b/src/service/cognito/user-pool/user/web-authn/sim-cognito-web-authn-attested-key.ts
@@ -1,12 +1,11 @@
 import type { KeyObject } from "node:crypto";
 
 import { SimCognitoWebAuthnCredentialNotSupportedException } from "../../../error/sim-cognito-web-authn.error.js";
-import type { SimCognitoWebAuthnCeremony } from "./sim-cognito-web-authn-ceremony.js";
+import { requireSimCognitoWebAuthnCeremony } from "./sim-cognito-web-authn-ceremony.js";
 import { SimCognitoWebAuthnCredential } from "./sim-cognito-web-authn-credential.js";
-import {
-  simCognitoWebAuthnAlgorithm,
-  simCognitoWebAuthnKeyFrom,
-} from "./sim-cognito-web-authn-signing.js";
+import type { SimCognitoWebAuthnCreationOptions } from "./sim-cognito-web-authn-document.js";
+import { simCognitoWebAuthnKeyFrom } from "./sim-cognito-web-authn-public-key.js";
+import { simCognitoWebAuthnAlgorithm } from "./sim-cognito-web-authn-signing.js";
 
 /**
  * How a credential says it is attached when it says nothing, which is what a
@@ -56,16 +55,27 @@ function stringsOf(value: unknown): readonly string[] {
 /**
  * The passkey a pool keeps out of the credential a registration carried.
  *
- * A browser reports the public key as `response.publicKey`, base64url of its
- * SubjectPublicKeyInfo, and names the algorithm beside it. That is what is
- * read here rather than the attestation object, which a real relying party
- * parses out of CBOR and this simulation does not.
+ * The credential is read against the options the registration was issued with,
+ * which say which challenge it has to answer and which relying party it has to
+ * have been signed for. A browser reports the public key as
+ * `response.publicKey`, base64url of its SubjectPublicKeyInfo, and names the
+ * algorithm beside it. That is what is read here rather than the attestation
+ * object, which a real relying party parses out of CBOR and this simulation
+ * does not.
  */
-export function simCognitoWebAuthnAttested(
-  ceremony: SimCognitoWebAuthnCeremony,
-  relyingPartyId: string,
+export function simCognitoWebAuthnRegistered(
+  pending: SimCognitoWebAuthnCreationOptions,
+  credential: unknown,
   createdAt: Date,
 ): SimCognitoWebAuthnCredential {
+  const relyingPartyId = pending.rp.id;
+  const ceremony = requireSimCognitoWebAuthnCeremony({
+    credential,
+    field: "Credential",
+    type: "webauthn.create",
+    challenge: pending.challenge,
+    relyingPartyId,
+  });
   const attachment = ceremony.document["authenticatorAttachment"];
 
   return new SimCognitoWebAuthnCredential({

--- a/src/service/cognito/user-pool/user/web-authn/sim-cognito-web-authn-authenticator.ts
+++ b/src/service/cognito/user-pool/user/web-authn/sim-cognito-web-authn-authenticator.ts
@@ -1,0 +1,76 @@
+import type {
+  SimCognitoWebAuthnCreationOptions,
+  SimCognitoWebAuthnCredentialDocument,
+} from "./sim-cognito-web-authn-document.js";
+import {
+  simCognitoWebAuthnAlgorithm,
+  simCognitoWebAuthnAuthenticatorData,
+  simCognitoWebAuthnClientData,
+  simCognitoWebAuthnCredentialId,
+  simCognitoWebAuthnKeyPair,
+  simCognitoWebAuthnPublicKey,
+} from "./sim-cognito-web-authn-signing.js";
+
+/**
+ * How a passkey made here says it is attached, which is what a platform
+ * authenticator such as a phone or a laptop reports.
+ */
+const attachment = "platform";
+
+/**
+ * How a passkey made here says it can be reached.
+ */
+const transports: readonly string[] = ["internal", "hybrid"];
+
+/**
+ * Create a passkey for a registration's options, as a browser running
+ * `navigator.credentials.create()` would.
+ *
+ * WebAuthn has two sides. The pool holds public keys and checks signatures,
+ * and a phone or a laptop holds the private keys and produces them. There is
+ * neither in a test, so this stands in for the device, in the way
+ * `SimCognitoUserPool.softwareTokenCode` reads the code a user's authenticator
+ * app would be showing.
+ *
+ * The key pair is a real ECDSA pair over P-256 and the public half travels in
+ * `publicKey`, the field a browser's own JSON serialization carries it in. The
+ * private half is dropped, because nothing presents a passkey yet.
+ *
+ * `attestationObject` is where a real authenticator states which device it is,
+ * wrapped in CBOR. Nothing reads one here, and the public key is read from
+ * `publicKey` instead, so the attestation is the signed authenticator data and
+ * no more.
+ *
+ * A test that would rather hold its own key can build the credential document
+ * itself. It is the JSON a browser serializes a `PublicKeyCredential` to, and
+ * nothing here reads a field a browser leaves out.
+ */
+export function simCognitoWebAuthnCreated(
+  options: SimCognitoWebAuthnCreationOptions,
+): SimCognitoWebAuthnCredentialDocument {
+  const credentialId = simCognitoWebAuthnCredentialId();
+  const signed = simCognitoWebAuthnAuthenticatorData(options.rp.id, 0);
+  const collected = simCognitoWebAuthnClientData(
+    "webauthn.create",
+    options.challenge,
+    options.rp.id,
+  );
+
+  return {
+    id: credentialId,
+    rawId: credentialId,
+    type: "public-key",
+    authenticatorAttachment: attachment,
+    response: {
+      clientDataJSON: collected.toString("base64url"),
+      attestationObject: signed.toString("base64url"),
+      authenticatorData: signed.toString("base64url"),
+      publicKey: simCognitoWebAuthnPublicKey(
+        simCognitoWebAuthnKeyPair().publicKey,
+      ),
+      publicKeyAlgorithm: simCognitoWebAuthnAlgorithm,
+      transports: [...transports],
+    },
+    clientExtensionResults: {},
+  };
+}

--- a/src/service/cognito/user-pool/user/web-authn/sim-cognito-web-authn-authenticator.ts
+++ b/src/service/cognito/user-pool/user/web-authn/sim-cognito-web-authn-authenticator.ts
@@ -2,13 +2,13 @@ import type {
   SimCognitoWebAuthnCreationOptions,
   SimCognitoWebAuthnCredentialDocument,
 } from "./sim-cognito-web-authn-document.js";
+import { simCognitoWebAuthnPublicKey } from "./sim-cognito-web-authn-public-key.js";
 import {
   simCognitoWebAuthnAlgorithm,
   simCognitoWebAuthnAuthenticatorData,
   simCognitoWebAuthnClientData,
   simCognitoWebAuthnCredentialId,
   simCognitoWebAuthnKeyPair,
-  simCognitoWebAuthnPublicKey,
 } from "./sim-cognito-web-authn-signing.js";
 
 /**

--- a/src/service/cognito/user-pool/user/web-authn/sim-cognito-web-authn-ceremony.ts
+++ b/src/service/cognito/user-pool/user/web-authn/sim-cognito-web-authn-ceremony.ts
@@ -1,0 +1,123 @@
+import { createHash } from "node:crypto";
+
+import { SimCognitoInvalidParameterException } from "../../../error/sim-cognito.error.js";
+import { SimCognitoWebAuthnRelyingPartyMismatchException } from "../../../error/sim-cognito-web-authn.error.js";
+import {
+  requireSimCognitoWebAuthnClientData,
+  type SimCognitoWebAuthnClientDataRequest,
+} from "./sim-cognito-web-authn-client-data.js";
+
+/**
+ * How many bytes of authenticator data come before the flags, which is the
+ * hash of the relying party id.
+ */
+const relyingPartyHashBytes = 32;
+
+/**
+ * What a caller sent, once it has been read as a credential.
+ */
+export interface SimCognitoWebAuthnCeremony {
+  readonly credentialId: string;
+  readonly clientDataJson: Buffer;
+  readonly authenticatorData: Buffer;
+
+  /** The credential document itself, once it has been read as an object. */
+  readonly document: Readonly<Record<string, unknown>>;
+
+  /** The `response` half of it, which holds what the authenticator produced. */
+  readonly response: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * What a request carried, and what the pool expects it to answer.
+ */
+export interface SimCognitoWebAuthnCeremonyRequest extends SimCognitoWebAuthnClientDataRequest {
+  /** The credential document the request carried, as it arrived. */
+  readonly credential: unknown;
+}
+
+/**
+ * A member of a credential that has to be there, as the base64url it is.
+ */
+function requireMember(value: unknown, member: string, field: string): string {
+  if (typeof value !== "string" || value === "") {
+    throw new SimCognitoInvalidParameterException(
+      `${field} ${member} must be the base64url string a browser's own ` +
+        `credential serialization carries it as`,
+    );
+  }
+
+  return value;
+}
+
+/**
+ * Refuse authenticator data signed for another relying party.
+ */
+function requireRelyingParty(
+  authenticatorData: Buffer,
+  relyingPartyId: string,
+): void {
+  const signedFor = authenticatorData.subarray(0, relyingPartyHashBytes);
+
+  if (!signedFor.equals(createHash("sha256").update(relyingPartyId).digest())) {
+    throw new SimCognitoWebAuthnRelyingPartyMismatchException(
+      `The credential was signed for another relying party, and this user ` +
+        `pool registers passkeys against ${relyingPartyId}.`,
+    );
+  }
+}
+
+/**
+ * The credential document a request carried, or a refusal where it is not one.
+ */
+function requireDocument(
+  value: unknown,
+  field: string,
+): Readonly<Record<string, unknown>> {
+  if (typeof value !== "object" || value === null) {
+    throw new SimCognitoInvalidParameterException(
+      `${field} must be the credential a browser serializes from ` +
+        `navigator.credentials, carrying an id and a response`,
+    );
+  }
+
+  return value as Record<string, unknown>;
+}
+
+/**
+ * Read the credential a request carried, and hold it to the ceremony the pool
+ * is part way through.
+ *
+ * A credential arrives as the JSON a browser produces from a
+ * `PublicKeyCredential`, so it is read rather than trusted: the client data
+ * says which ceremony it answers, which challenge, and where it was collected,
+ * and the authenticator data says which relying party it was signed for. What
+ * this leaves to the caller is the signature, which needs the public key of
+ * the credential being presented.
+ */
+export function requireSimCognitoWebAuthnCeremony(
+  request: SimCognitoWebAuthnCeremonyRequest,
+): SimCognitoWebAuthnCeremony {
+  const { field } = request;
+  const document = requireDocument(request.credential, field);
+  const response = requireDocument(document["response"], field);
+  const clientDataJson = Buffer.from(
+    requireMember(response["clientDataJSON"], "clientDataJSON", field),
+    "base64url",
+  );
+  const authenticatorData = Buffer.from(
+    requireMember(response["authenticatorData"], "authenticatorData", field),
+    "base64url",
+  );
+
+  requireSimCognitoWebAuthnClientData(clientDataJson, request);
+  requireRelyingParty(authenticatorData, request.relyingPartyId);
+
+  return {
+    credentialId: requireMember(document["id"], "id", field),
+    clientDataJson,
+    authenticatorData,
+    document,
+    response,
+  };
+}

--- a/src/service/cognito/user-pool/user/web-authn/sim-cognito-web-authn-client-data.ts
+++ b/src/service/cognito/user-pool/user/web-authn/sim-cognito-web-authn-client-data.ts
@@ -1,0 +1,84 @@
+import { SimCognitoInvalidParameterException } from "../../../error/sim-cognito.error.js";
+import {
+  SimCognitoWebAuthnChallengeNotFoundException,
+  SimCognitoWebAuthnOriginNotAllowedException,
+} from "../../../error/sim-cognito-web-authn.error.js";
+
+/**
+ * What the client data of a ceremony has to say.
+ */
+export interface SimCognitoWebAuthnClientDataRequest {
+  /** The input the credential arrived in, which a refusal names. */
+  readonly field: string;
+
+  /** Which half of the ceremony this is. */
+  readonly type: "webauthn.create" | "webauthn.get";
+
+  /** The challenge the pool issued, which the credential has to answer. */
+  readonly challenge: string;
+
+  /** The domain the credential has to have been collected for. */
+  readonly relyingPartyId: string;
+}
+
+/**
+ * The client data a credential carries, parsed as the JSON it is.
+ */
+function clientDataOf(
+  clientDataJson: Buffer,
+  field: string,
+): Record<string, unknown> {
+  try {
+    const parsed: unknown = JSON.parse(clientDataJson.toString("utf8"));
+
+    if (typeof parsed === "object" && parsed !== null) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // Falls through to the refusal below, which says the same thing about an
+    // unparseable client data as about one that is not an object.
+  }
+
+  throw new SimCognitoInvalidParameterException(
+    `${field} response.clientDataJSON is not the JSON object a browser ` +
+      `collects for a WebAuthn ceremony`,
+  );
+}
+
+/**
+ * Refuse client data that answers something other than the challenge this pool
+ * issued, or that was collected somewhere the relying party does not cover.
+ *
+ * The client data is what the authenticator signed over, so what it says about
+ * the ceremony is worth as much as the signature that covers it. A credential
+ * collected at another origin is what a relying party check is for, and one
+ * carrying another challenge is a replay.
+ */
+export function requireSimCognitoWebAuthnClientData(
+  clientDataJson: Buffer,
+  request: SimCognitoWebAuthnClientDataRequest,
+): void {
+  const { field, type, challenge, relyingPartyId } = request;
+  const clientData = clientDataOf(clientDataJson, field);
+
+  if (clientData["type"] !== type) {
+    throw new SimCognitoInvalidParameterException(
+      `${field} response.clientDataJSON is for ` +
+        `'${String(clientData["type"])}' rather than '${type}'`,
+    );
+  }
+
+  if (clientData["challenge"] !== challenge) {
+    throw new SimCognitoWebAuthnChallengeNotFoundException(
+      "The credential answers a challenge this user pool did not issue, or " +
+        "one it has already spent.",
+    );
+  }
+
+  if (clientData["origin"] !== `https://${relyingPartyId}`) {
+    throw new SimCognitoWebAuthnOriginNotAllowedException(
+      `The credential was collected at '${String(clientData["origin"])}', ` +
+        `which is not an origin of the relying party ${relyingPartyId}.`,
+    );
+  }
+}

--- a/src/service/cognito/user-pool/user/web-authn/sim-cognito-web-authn-creation-options.ts
+++ b/src/service/cognito/user-pool/user/web-authn/sim-cognito-web-authn-creation-options.ts
@@ -1,0 +1,72 @@
+import type {
+  SimCognitoWebAuthnCreationOptions,
+  SimCognitoWebAuthnCredentialDescriptor,
+} from "./sim-cognito-web-authn-document.js";
+import {
+  simCognitoWebAuthnAlgorithm,
+  simCognitoWebAuthnChallenge,
+} from "./sim-cognito-web-authn-signing.js";
+
+/**
+ * How long a browser is given to finish a ceremony, in milliseconds.
+ *
+ * This is the authenticator's own prompt timeout rather than the app client's
+ * `AuthSessionValidity`, which is what bounds the sign-in around it.
+ */
+const ceremonyTimeout = 60_000;
+
+/**
+ * What a pool needs to know before it can ask for a passkey.
+ */
+export interface SimCognitoWebAuthnRegistrationRequest {
+  /** The domain the passkey is registered against. */
+  readonly relyingPartyId: string;
+
+  /** The pool's own name, which a browser shows the person. */
+  readonly relyingPartyName: string;
+
+  /** The user handle the authenticator stores, which is the user's `sub`. */
+  readonly userHandle: string;
+
+  /** The name the authenticator shows for the account. */
+  readonly username: string;
+
+  /** Whether the authenticator has to check who is holding it. */
+  readonly userVerification: string;
+}
+
+/**
+ * The options a passkey is created from, which a browser passes straight to
+ * `navigator.credentials.create()`.
+ *
+ * The challenge is fresh for every registration, and is what the authenticator
+ * signs over. The passkeys the user already has are excluded, so an
+ * authenticator already holding one makes another rather than replacing it,
+ * and the key is asked to be discoverable so a later sign-in can present it
+ * without being told which user is signing in.
+ */
+export function simCognitoWebAuthnCreationOptions(
+  request: SimCognitoWebAuthnRegistrationRequest,
+  excluded: readonly SimCognitoWebAuthnCredentialDescriptor[],
+): SimCognitoWebAuthnCreationOptions {
+  return {
+    challenge: simCognitoWebAuthnChallenge(),
+    rp: { id: request.relyingPartyId, name: request.relyingPartyName },
+    user: {
+      id: Buffer.from(request.userHandle).toString("base64url"),
+      name: request.username,
+      displayName: request.username,
+    },
+    pubKeyCredParams: [
+      { type: "public-key", alg: simCognitoWebAuthnAlgorithm },
+    ],
+    timeout: ceremonyTimeout,
+    excludeCredentials: excluded,
+    authenticatorSelection: {
+      residentKey: "required",
+      requireResidentKey: true,
+      userVerification: request.userVerification,
+    },
+    attestation: "none",
+  };
+}

--- a/src/service/cognito/user-pool/user/web-authn/sim-cognito-web-authn-credential.ts
+++ b/src/service/cognito/user-pool/user/web-authn/sim-cognito-web-authn-credential.ts
@@ -1,0 +1,88 @@
+import type { KeyObject } from "node:crypto";
+
+import type { SimCognitoWebAuthnCredentialDescriptor } from "./sim-cognito-web-authn-document.js";
+
+/**
+ * One registered passkey as `ListWebAuthnCredentials` reports it.
+ *
+ * https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_WebAuthnCredentialDescription.html
+ */
+export interface SimCognitoWebAuthnCredentialDescription {
+  readonly CredentialId?: string | undefined;
+  readonly FriendlyCredentialName?: string | undefined;
+  readonly RelyingPartyId?: string | undefined;
+  readonly AuthenticatorAttachment?: string | undefined;
+  readonly AuthenticatorTransports?: readonly string[] | undefined;
+  readonly CreatedAt?: Date | undefined;
+}
+
+interface SimCognitoWebAuthnCredentialProperties {
+  readonly credentialId: string;
+  readonly publicKey: KeyObject;
+  readonly relyingPartyId: string;
+  readonly authenticatorAttachment: string;
+  readonly transports: readonly string[];
+  readonly createdAt: Date;
+}
+
+/**
+ * One passkey a user has registered, as the pool holds it.
+ *
+ * What the pool keeps is the public half: an identifier the authenticator
+ * allocated, the key that identifier's signatures can be checked against, and
+ * the relying party the pair was registered for. The private half never
+ * reaches a pool, on real Cognito or here.
+ *
+ * `FriendlyCredentialName` is the relying party id. Real Cognito reads the
+ * authenticator's own model out of the attestation and names the credential
+ * after it, which needs a device this simulation does not have.
+ */
+export class SimCognitoWebAuthnCredential {
+  public readonly credentialId: string;
+  public readonly relyingPartyId: string;
+  public readonly authenticatorAttachment: string;
+  public readonly transports: readonly string[];
+  public readonly createdAt: Date;
+
+  /**
+   * The key this credential's signatures are checked against. It is the public
+   * half of the pair the authenticator made, and it is what a sign-in
+   * presenting the passkey reads.
+   */
+  public readonly publicKey: KeyObject;
+
+  constructor(properties: SimCognitoWebAuthnCredentialProperties) {
+    this.credentialId = properties.credentialId;
+    this.relyingPartyId = properties.relyingPartyId;
+    this.authenticatorAttachment = properties.authenticatorAttachment;
+    this.transports = properties.transports;
+    this.createdAt = properties.createdAt;
+    this.publicKey = properties.publicKey;
+  }
+
+  /**
+   * This credential as a ceremony's options name it, which is what a
+   * registration excludes and a sign-in allows.
+   */
+  descriptor(): SimCognitoWebAuthnCredentialDescriptor {
+    return {
+      type: "public-key",
+      id: this.credentialId,
+      transports: this.transports,
+    };
+  }
+
+  /**
+   * This credential as `ListWebAuthnCredentials` reports it.
+   */
+  toOutput(): SimCognitoWebAuthnCredentialDescription {
+    return {
+      CredentialId: this.credentialId,
+      FriendlyCredentialName: this.relyingPartyId,
+      RelyingPartyId: this.relyingPartyId,
+      AuthenticatorAttachment: this.authenticatorAttachment,
+      AuthenticatorTransports: this.transports,
+      CreatedAt: this.createdAt,
+    };
+  }
+}

--- a/src/service/cognito/user-pool/user/web-authn/sim-cognito-web-authn-document.ts
+++ b/src/service/cognito/user-pool/user/web-authn/sim-cognito-web-authn-document.ts
@@ -1,0 +1,99 @@
+/**
+ * A value as an SDK document input carries one, which is JSON and no more.
+ *
+ * `Credential` on `CompleteWebAuthnRegistration` is a document rather than a
+ * shape the API names, so a credential built here is written to be assignable
+ * to one. That is what lets a test pass the credential straight to the SDK
+ * Command without casting it first.
+ */
+export type SimCognitoWebAuthnDocumentValue =
+  | null
+  | boolean
+  | number
+  | string
+  | SimCognitoWebAuthnDocumentValue[]
+  | { [member: string]: SimCognitoWebAuthnDocumentValue };
+
+/**
+ * The relying party a credential is created for.
+ */
+export interface SimCognitoWebAuthnRelyingParty {
+  readonly id: string;
+  readonly name: string;
+}
+
+/**
+ * The user a credential is created for, as WebAuthn names one: an opaque
+ * handle the authenticator stores, and the names it shows a person.
+ */
+export interface SimCognitoWebAuthnUserEntity {
+  readonly id: string;
+  readonly name: string;
+  readonly displayName: string;
+}
+
+/**
+ * One credential named in a ceremony's options, either to exclude from a
+ * registration or to allow at a sign-in.
+ */
+export interface SimCognitoWebAuthnCredentialDescriptor {
+  readonly type: "public-key";
+  readonly id: string;
+  readonly transports: readonly string[];
+}
+
+/**
+ * What `StartWebAuthnRegistration` answers with, which a browser passes
+ * straight to `navigator.credentials.create()`.
+ *
+ * https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_StartWebAuthnRegistration.html
+ */
+export interface SimCognitoWebAuthnCreationOptions {
+  readonly challenge: string;
+  readonly rp: SimCognitoWebAuthnRelyingParty;
+  readonly user: SimCognitoWebAuthnUserEntity;
+  readonly pubKeyCredParams: readonly {
+    readonly type: "public-key";
+    readonly alg: number;
+  }[];
+  readonly timeout: number;
+  readonly excludeCredentials: readonly SimCognitoWebAuthnCredentialDescriptor[];
+  readonly authenticatorSelection: {
+    readonly residentKey: string;
+    readonly requireResidentKey: boolean;
+    readonly userVerification: string;
+  };
+  readonly attestation: string;
+}
+
+/**
+ * The half of a credential an authenticator fills in when it creates one.
+ *
+ * `attestationObject` is where a real authenticator states what kind of device
+ * it is. Nothing here reads one, and the public key is read from `publicKey`
+ * instead, which is the field a browser's own JSON serialization carries it
+ * in.
+ */
+export interface SimCognitoWebAuthnAttestationResponse {
+  [member: string]: SimCognitoWebAuthnDocumentValue;
+  readonly clientDataJSON: string;
+  readonly attestationObject: string;
+  readonly authenticatorData: string;
+  readonly publicKey: string;
+  readonly publicKeyAlgorithm: number;
+  readonly transports: string[];
+}
+
+/**
+ * A credential as a browser serializes one, which is what
+ * `CompleteWebAuthnRegistration` carries.
+ */
+export interface SimCognitoWebAuthnCredentialDocument {
+  [member: string]: SimCognitoWebAuthnDocumentValue;
+  readonly id: string;
+  readonly rawId: string;
+  readonly type: "public-key";
+  readonly authenticatorAttachment: string;
+  readonly response: SimCognitoWebAuthnAttestationResponse;
+  readonly clientExtensionResults: Record<string, never>;
+}

--- a/src/service/cognito/user-pool/user/web-authn/sim-cognito-web-authn-public-key.ts
+++ b/src/service/cognito/user-pool/user/web-authn/sim-cognito-web-authn-public-key.ts
@@ -1,0 +1,52 @@
+import { createPublicKey, type KeyObject } from "node:crypto";
+
+/**
+ * The curve an ES256 key is over, as `node:crypto` names it.
+ */
+const namedCurve = "prime256v1";
+
+/**
+ * The public key as it travels in a credential, which is base64url of its
+ * SubjectPublicKeyInfo.
+ *
+ * This is the encoding `PublicKeyCredential.toJSON()` uses for the `publicKey`
+ * a browser reports, so a credential built here carries the key in the shape a
+ * real one carries it.
+ */
+export function simCognitoWebAuthnPublicKey(publicKey: KeyObject): string {
+  return publicKey
+    .export({ format: "der", type: "spki" })
+    .toString("base64url");
+}
+
+/**
+ * Read a public key back out of a credential, or nothing where the value is
+ * not a key this pool can use.
+ *
+ * A registration asks for ECDSA over P-256 and nothing else, so a key of
+ * another kind is no more usable than a value that is not a key at all. The
+ * algorithm a credential names is the caller's word for it, and this is the
+ * key itself.
+ */
+export function simCognitoWebAuthnKeyFrom(
+  encoded: string,
+): KeyObject | undefined {
+  try {
+    const publicKey = createPublicKey({
+      key: Buffer.from(encoded, "base64url"),
+      format: "der",
+      type: "spki",
+    });
+
+    if (
+      publicKey.asymmetricKeyType !== "ec" ||
+      publicKey.asymmetricKeyDetails?.namedCurve !== namedCurve
+    ) {
+      return undefined;
+    }
+
+    return publicKey;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/service/cognito/user-pool/user/web-authn/sim-cognito-web-authn-signing.ts
+++ b/src/service/cognito/user-pool/user/web-authn/sim-cognito-web-authn-signing.ts
@@ -1,6 +1,5 @@
 import {
   createHash,
-  createPublicKey,
   generateKeyPairSync,
   randomBytes,
   type KeyObject,
@@ -62,38 +61,6 @@ export function simCognitoWebAuthnChallenge(): string {
  */
 export function simCognitoWebAuthnCredentialId(): string {
   return randomBytes(credentialIdBytes).toString("base64url");
-}
-
-/**
- * The public key as it travels in a credential, which is base64url of its
- * SubjectPublicKeyInfo.
- *
- * This is the encoding `PublicKeyCredential.toJSON()` uses for the `publicKey`
- * a browser reports, so a credential built here carries the key in the shape a
- * real one carries it.
- */
-export function simCognitoWebAuthnPublicKey(publicKey: KeyObject): string {
-  return publicKey
-    .export({ format: "der", type: "spki" })
-    .toString("base64url");
-}
-
-/**
- * Read a public key back out of a credential, or nothing where the value is
- * not a key at all.
- */
-export function simCognitoWebAuthnKeyFrom(
-  encoded: string,
-): KeyObject | undefined {
-  try {
-    return createPublicKey({
-      key: Buffer.from(encoded, "base64url"),
-      format: "der",
-      type: "spki",
-    });
-  } catch {
-    return undefined;
-  }
 }
 
 /**

--- a/src/service/cognito/user-pool/user/web-authn/sim-cognito-web-authn-signing.ts
+++ b/src/service/cognito/user-pool/user/web-authn/sim-cognito-web-authn-signing.ts
@@ -1,0 +1,139 @@
+import {
+  createHash,
+  createPublicKey,
+  generateKeyPairSync,
+  randomBytes,
+  type KeyObject,
+} from "node:crypto";
+
+/**
+ * The COSE algorithm identifier for ECDSA over P-256 with SHA-256, which every
+ * platform authenticator supports and which Cognito asks for.
+ */
+export const simCognitoWebAuthnAlgorithm = -7;
+
+/**
+ * How many bytes of challenge a ceremony is given.
+ */
+const challengeBytes = 32;
+
+/**
+ * How many bytes of credential id an authenticator allocates.
+ */
+const credentialIdBytes = 16;
+
+/**
+ * The authenticator data flags this simulation sets, which say the user was
+ * present and the authenticator verified who was holding it.
+ *
+ * Real flags also say whether attested credential data follows. Nothing here
+ * reads a registration's authenticator data beyond the relying party it names.
+ */
+const presentAndVerified = 0x05;
+
+/**
+ * A key pair standing in for the one a passkey lives as.
+ */
+export interface SimCognitoWebAuthnKeyPair {
+  readonly publicKey: KeyObject;
+  readonly privateKey: KeyObject;
+}
+
+/**
+ * Issue the key pair a new passkey is made of.
+ *
+ * The private half is what an authenticator would keep and never hand over,
+ * and the public half is what the pool stores against the credential.
+ */
+export function simCognitoWebAuthnKeyPair(): SimCognitoWebAuthnKeyPair {
+  return generateKeyPairSync("ec", { namedCurve: "P-256" });
+}
+
+/**
+ * A run of random bytes as base64url, which is how a challenge and a
+ * credential id both travel.
+ */
+export function simCognitoWebAuthnChallenge(): string {
+  return randomBytes(challengeBytes).toString("base64url");
+}
+
+/**
+ * The identifier an authenticator gives a credential it has just created.
+ */
+export function simCognitoWebAuthnCredentialId(): string {
+  return randomBytes(credentialIdBytes).toString("base64url");
+}
+
+/**
+ * The public key as it travels in a credential, which is base64url of its
+ * SubjectPublicKeyInfo.
+ *
+ * This is the encoding `PublicKeyCredential.toJSON()` uses for the `publicKey`
+ * a browser reports, so a credential built here carries the key in the shape a
+ * real one carries it.
+ */
+export function simCognitoWebAuthnPublicKey(publicKey: KeyObject): string {
+  return publicKey
+    .export({ format: "der", type: "spki" })
+    .toString("base64url");
+}
+
+/**
+ * Read a public key back out of a credential, or nothing where the value is
+ * not a key at all.
+ */
+export function simCognitoWebAuthnKeyFrom(
+  encoded: string,
+): KeyObject | undefined {
+  try {
+    return createPublicKey({
+      key: Buffer.from(encoded, "base64url"),
+      format: "der",
+      type: "spki",
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The client data a browser would have collected, as the JSON bytes an
+ * authenticator signs over.
+ *
+ * The origin is the relying party's own, because a passkey registered against
+ * a domain is presented from that domain and nowhere else.
+ */
+export function simCognitoWebAuthnClientData(
+  type: "webauthn.create" | "webauthn.get",
+  challenge: string,
+  relyingPartyId: string,
+): Buffer {
+  return Buffer.from(
+    JSON.stringify({
+      type,
+      challenge,
+      origin: `https://${relyingPartyId}`,
+      crossOrigin: false,
+    }),
+  );
+}
+
+/**
+ * The authenticator data of one ceremony: the relying party the credential
+ * answers for, what the authenticator checked, and how many times it has
+ * signed.
+ */
+export function simCognitoWebAuthnAuthenticatorData(
+  relyingPartyId: string,
+  signCount: number,
+): Buffer {
+  const flags = Buffer.alloc(5);
+
+  flags.writeUInt8(presentAndVerified, 0);
+  flags.writeUInt32BE(signCount, 1);
+
+  return Buffer.concat([
+    createHash("sha256").update(relyingPartyId).digest(),
+    flags,
+  ]);
+}

--- a/test/cognito/passkey-fixture.ts
+++ b/test/cognito/passkey-fixture.ts
@@ -1,0 +1,82 @@
+/**
+ * The arrangement the passkey test files share: a pool that registers passkeys
+ * against a relying party, and a user signed in with a password.
+ *
+ * A passkey is registered from a session that already exists, so the password
+ * sign-in is not incidental: it is what a first passkey is added from.
+ *
+ * It lives under `test/` for the same reasons as `test/cognito/cfn-deploy.ts`:
+ * a test file cannot export helpers alongside its own `describe` calls, and
+ * `test/**` is type-checked with everything else and excluded from the
+ * published build.
+ */
+
+import {
+  CompleteWebAuthnRegistrationCommand,
+  SetUserPoolMfaConfigCommand,
+  StartWebAuthnRegistrationCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import type { SimCognitoWebAuthnCredentialDocument } from "../../src/service/cognito/index.js";
+import type { SimCognitoSignedInSetUp } from "./signed-in-fixture.js";
+import { simCognitoSignedIn, simCognitoUsername } from "./signed-in-fixture.js";
+
+/**
+ * The domain the pool in these tests registers passkeys against.
+ */
+export const simCognitoRelyingPartyId = "myapp.example.com";
+
+/**
+ * A signed-in user of a pool configured to register passkeys.
+ */
+export async function simCognitoWithPasskeyPool(): Promise<SimCognitoSignedInSetUp> {
+  const setUp = await simCognitoSignedIn();
+
+  await setUp.cognito.setUserPoolMfaConfig(
+    new SetUserPoolMfaConfigCommand({
+      UserPoolId: setUp.userPoolId,
+      MfaConfiguration: "OPTIONAL",
+      WebAuthnConfiguration: {
+        RelyingPartyId: simCognitoRelyingPartyId,
+        UserVerification: "required",
+      },
+    }),
+  );
+
+  return setUp;
+}
+
+/**
+ * The credential the user's own authenticator would have made for the
+ * registration it has been given options for.
+ */
+export function simCognitoPasskeyCredential(
+  setUp: SimCognitoSignedInSetUp,
+): SimCognitoWebAuthnCredentialDocument {
+  return setUp.cognito
+    .userPool(setUp.userPoolId)
+    .webAuthnCredential(simCognitoUsername);
+}
+
+/**
+ * Register a passkey for the signed-in user, in the two calls real Cognito
+ * takes.
+ */
+export async function simCognitoRegisterPasskey(
+  setUp: SimCognitoSignedInSetUp,
+): Promise<SimCognitoWebAuthnCredentialDocument> {
+  await setUp.cognito.startWebAuthnRegistration(
+    new StartWebAuthnRegistrationCommand({ AccessToken: setUp.accessToken }),
+  );
+
+  const credential = simCognitoPasskeyCredential(setUp);
+
+  await setUp.cognito.completeWebAuthnRegistration(
+    new CompleteWebAuthnRegistrationCommand({
+      AccessToken: setUp.accessToken,
+      Credential: credential,
+    }),
+  );
+
+  return credential;
+}

--- a/test/cognito/passkey-fixture.ts
+++ b/test/cognito/passkey-fixture.ts
@@ -11,13 +11,18 @@
  * published build.
  */
 
+import { createHash } from "node:crypto";
+
 import {
   CompleteWebAuthnRegistrationCommand,
   SetUserPoolMfaConfigCommand,
   StartWebAuthnRegistrationCommand,
 } from "@aws-sdk/client-cognito-identity-provider";
 
-import type { SimCognitoWebAuthnCredentialDocument } from "../../src/service/cognito/index.js";
+import type {
+  SimCognitoWebAuthnCredentialDocument,
+  SimCognitoWebAuthnDocumentValue,
+} from "../../src/service/cognito/index.js";
 import type { SimCognitoSignedInSetUp } from "./signed-in-fixture.js";
 import { simCognitoSignedIn, simCognitoUsername } from "./signed-in-fixture.js";
 
@@ -79,4 +84,52 @@ export async function simCognitoRegisterPasskey(
   );
 
   return credential;
+}
+
+/**
+ * A JSON value as a credential carries one, which is base64url of its bytes.
+ */
+export function simCognitoBase64urlJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+/**
+ * The client data a credential was signed over, read back as the JSON it is.
+ */
+export function simCognitoClientDataOf(
+  credential: SimCognitoWebAuthnCredentialDocument,
+): Record<string, unknown> {
+  const encoded = credential.response.clientDataJSON;
+  const decoded = Buffer.from(encoded, "base64url").toString("utf8");
+
+  return JSON.parse(decoded) as Record<string, unknown>;
+}
+
+/**
+ * The authenticator data a credential would carry if it had been signed for
+ * another domain, which is the hash of that domain and the same flags.
+ */
+export function simCognitoAuthenticatorDataFor(relyingPartyId: string): string {
+  const flags = Buffer.alloc(5);
+
+  flags.writeUInt8(0x05, 0);
+  flags.writeUInt32BE(0, 1);
+
+  return Buffer.concat([
+    createHash("sha256").update(relyingPartyId).digest(),
+    flags,
+  ]).toString("base64url");
+}
+
+/**
+ * The credential a real authenticator made, with one member of it changed.
+ */
+export function simCognitoCredentialWith(
+  credential: SimCognitoWebAuthnCredentialDocument,
+  response: Record<string, SimCognitoWebAuthnDocumentValue>,
+): Record<string, SimCognitoWebAuthnDocumentValue> {
+  return {
+    ...credential,
+    response: { ...credential.response, ...response },
+  };
 }


### PR DESCRIPTION
`StartWebAuthnRegistration` and `CompleteWebAuthnRegistration` register a passkey against the user
whose access token authorized the call, and `ListWebAuthnCredentials` and
`DeleteWebAuthnCredential` read and remove it. All four are authorized by the token alone, as real
Cognito authorizes them. The key pairs are real ECDSA pairs over P-256, the credential carries the
public half where a browser's own `PublicKeyCredential.toJSON()` puts it, and a test with no browser
reads the credential its own authenticator would have made off the pool through
`SimCognitoUserPool.webAuthnCredential`, the way it reads a software token code. What the pool was
sent is read rather than trusted, so a credential answering a spent challenge, one collected at
another origin, one signed for another relying party and one carrying a key the pool cannot use are
each refused by name. `AuthSessionValidity` deploys on an `AWS::Cognito::UserPoolClient` and decides
how long a challenge session lasts, replacing the fixed three minutes every session used to get.
Presenting a registered passkey at a sign-in is still refused, because `USER_AUTH` is the flow that
presents one.

The first of two stages towards https://github.com/KensioSoftware/yulin/issues/849. The second adds
the `USER_AUTH` flow, the `WEB_AUTHN` challenge and the passkey option on managed login, and closes
the issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added simulated Cognito passkey registration and credential management, including listing and deletion.
  - Added WebAuthn configuration, relying-party settings, validation, pagination, and SDK command support.
  - Added configurable authentication-session validity from 3–15 minutes, with expiry reporting and CloudFormation support.
  - Added an end-to-end passkey registration example.

- **Documentation**
  - Expanded Cognito documentation with passkey setup, usage, limitations, and session-validity details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->