### PR TITLE
fix: sign in with a passkey by an email alias

### DIFF
--- a/src/service/cognito/command/hosted/sim-cognito-hosted-passkey-sign-in.ts
+++ b/src/service/cognito/command/hosted/sim-cognito-hosted-passkey-sign-in.ts
@@ -86,21 +86,26 @@ export class SimCognitoHostedPasskeySignIn {
   /**
    * The user the presented credential signs in, having checked that this
    * user's passkey signed the challenge the pool issued.
+   *
+   * The user is resolved before the session is, because the form posts back
+   * whatever the page carried, and on a pool with `UsernameAttributes` that is
+   * the address the person signed in by rather than the username the pool
+   * generated. The session belongs to the user, so the username it is looked
+   * up by has to be the resolved one.
    */
   present(
     pool: SimCognitoUserPool,
     client: SimCognitoUserPoolClient,
     presented: SimCognitoPresentedPasskey,
   ): SimCognitoUser {
-    const { username } = presented;
+    const user = this.signingIn(pool, client, presented.username);
     const session = pool.auth.requireSession({
       sessionId: presented.session,
-      username,
+      username: user.username,
       clientId: client.id,
       challengeName: simCognitoWebAuthnChallenge,
       now: this.clock.now(),
     });
-    const user = this.signingIn(pool, client, username);
 
     requireSimCognitoWebAuthnAssertion(
       user.webAuthn.credentials,

--- a/src/service/cognito/serve/sim-cognito-passkey-managed-login.iso.test.ts
+++ b/src/service/cognito/serve/sim-cognito-passkey-managed-login.iso.test.ts
@@ -21,8 +21,11 @@ import {
 import {
   simCognitoExchangedTokens,
   simCognitoHostedAddress,
+  simCognitoPasskeyAsked,
   simCognitoPasskeyPosted,
+  simCognitoPasskeyPresented,
   simCognitoPasskeySessionIn,
+  simCognitoPasskeyUsernameIn,
   simCognitoWithHostedPasskey,
 } from "../../../../test/cognito/hosted-passkey-fixture.js";
 
@@ -84,20 +87,20 @@ describe("Signing in with a passkey at sim Cognito managed login", () => {
       username: simCognitoHostedAddress,
     });
 
-    // When the browser signs in with the passkey, posting the address back as
-    // the passkey page carried it.
-    const posted = await simCognitoPasskeyPosted(
-      setUp,
-      simCognitoHostedAddress,
-    );
+    // When the browser asks for the passkey and presents the credential,
+    // posting back what the passkey page carried.
+    const page = await simCognitoPasskeyAsked(setUp, simCognitoHostedAddress);
+    const posted = await simCognitoPasskeyPresented(setUp, page);
     const code = simCognitoRedirectedTo(posted).searchParams.get("code");
 
     assertNonNullable(code);
 
     const tokens = await simCognitoExchangedTokens(setUp, code);
 
-    // Then the address resolved to the user the challenge was issued for, so
-    // the sign-in finished and the code exchanged for tokens.
+    // Then the page carried the address the person signed in by, and the
+    // address resolved to the user the challenge was issued for, so the
+    // sign-in finished and the code exchanged for tokens.
+    assertIdentical(simCognitoPasskeyUsernameIn(page), simCognitoHostedAddress);
     assertIdentical(posted.status, 302);
     assertTypeString(tokens["access_token"]);
     assertTypeString(tokens["id_token"]);

--- a/src/service/cognito/serve/sim-cognito-passkey-managed-login.iso.test.ts
+++ b/src/service/cognito/serve/sim-cognito-passkey-managed-login.iso.test.ts
@@ -1,10 +1,4 @@
 import {
-  AdminInitiateAuthCommand,
-  CompleteWebAuthnRegistrationCommand,
-  StartWebAuthnRegistrationCommand,
-  UpdateUserPoolCommand,
-} from "@aws-sdk/client-cognito-identity-provider";
-import {
   assertIdentical,
   assertNonNullable,
   assertStringIncludes,
@@ -14,81 +8,23 @@ import {
 import { describe, it } from "vitest";
 
 import {
-  simCognitoCallbackUrl,
   simCognitoHosted,
-  simCognitoLocalPassword,
   simCognitoLocalUser,
   simCognitoLocalUsername,
-  type SimCognitoHostedSetUp,
 } from "../../../../test/cognito/federation-fixture.js";
 import {
   simCognitoAuthorizeParameters,
   simCognitoGetPage,
-  simCognitoPageUrl,
   simCognitoPostForm,
   simCognitoRedirectedTo,
 } from "../../../../test/cognito/managed-login-fixture.js";
-import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
-
-/**
- * The challenge session the passkey page carries, out of its hidden input.
- */
-function passkeySessionIn(page: string): string {
-  const session = /name="passkey_session" value="([^"]+)"/u.exec(page)?.[1];
-
-  assertTypeString(session);
-
-  return session;
-}
-
-/**
- * A pool that allows a passkey at the first prompt, with a user holding one.
- *
- * The pool has a hosted domain and no `WebAuthnConfiguration`, so the passkey
- * is registered against the domain, which is what real Cognito falls back to.
- */
-async function simCognitoWithHostedPasskey(): Promise<SimCognitoHostedSetUp> {
-  const setUp = await simCognitoHosted();
-
-  await simCognitoLocalUser(setUp);
-  await setUp.cognito.updateUserPool(
-    new UpdateUserPoolCommand({
-      UserPoolId: setUp.userPoolId,
-      Policies: {
-        SignInPolicy: { AllowedFirstAuthFactors: ["PASSWORD", "WEB_AUTHN"] },
-      },
-    }),
-  );
-
-  const signedIn = await setUp.cognito.adminInitiateAuth(
-    new AdminInitiateAuthCommand({
-      UserPoolId: setUp.userPoolId,
-      ClientId: setUp.clientId,
-      AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
-      AuthParameters: {
-        USERNAME: simCognitoLocalUsername,
-        PASSWORD: simCognitoLocalPassword,
-      },
-    }),
-  );
-  const AccessToken = signedIn.AuthenticationResult?.AccessToken;
-
-  assertTypeString(AccessToken);
-
-  await setUp.cognito.startWebAuthnRegistration(
-    new StartWebAuthnRegistrationCommand({ AccessToken }),
-  );
-  await setUp.cognito.completeWebAuthnRegistration(
-    new CompleteWebAuthnRegistrationCommand({
-      AccessToken,
-      Credential: setUp.cognito
-        .userPool(setUp.userPoolId)
-        .webAuthnCredential(simCognitoLocalUsername),
-    }),
-  );
-
-  return setUp;
-}
+import {
+  simCognitoExchangedTokens,
+  simCognitoHostedAddress,
+  simCognitoPasskeyPosted,
+  simCognitoPasskeySessionIn,
+  simCognitoWithHostedPasskey,
+} from "../../../../test/cognito/hosted-passkey-fixture.js";
 
 describe("Signing in with a passkey at sim Cognito managed login", () => {
   it("offers a passkey where the pool allows one", async () => {
@@ -119,39 +55,16 @@ describe("Signing in with a passkey at sim Cognito managed login", () => {
 
     // When the browser posts the sign-in form with the passkey button, and
     // presents the credential the page then asks for.
-    const asked = await simCognitoPostForm(setUp, "/oauth2/authorize", {
-      ...simCognitoAuthorizeParameters(setUp),
-      username: simCognitoLocalUsername,
-      passkey: "passkey",
-    });
-    const session = passkeySessionIn(await asked.text());
-    const posted = await simCognitoPostForm(setUp, "/oauth2/authorize", {
-      ...simCognitoAuthorizeParameters(setUp),
-      username: simCognitoLocalUsername,
-      passkey_session: session,
-      credential: JSON.stringify(
-        setUp.cognito.userPool(setUp.userPoolId).webAuthnAssertion(session),
-      ),
-    });
+    const posted = await simCognitoPasskeyPosted(
+      setUp,
+      simCognitoLocalUsername,
+    );
     const redirect = simCognitoRedirectedTo(posted);
     const code = redirect.searchParams.get("code");
 
     assertNonNullable(code);
 
-    const exchanged = await new SimAwsHttp({ simAws: setUp.simAws }).fetch(
-      simCognitoPageUrl("/oauth2/token"),
-      {
-        method: "POST",
-        headers: { "content-type": "application/x-www-form-urlencoded" },
-        body: new URLSearchParams({
-          grant_type: "authorization_code",
-          client_id: setUp.clientId,
-          code,
-          redirect_uri: simCognitoCallbackUrl,
-        }).toString(),
-      },
-    );
-    const tokens = (await exchanged.json()) as Record<string, unknown>;
+    const tokens = await simCognitoExchangedTokens(setUp, code);
 
     // Then the browser went back to the application with a code, and the code
     // exchanged for the tokens a password sign-in would have earned.
@@ -160,6 +73,34 @@ describe("Signing in with a passkey at sim Cognito managed login", () => {
     assertTypeString(tokens["access_token"]);
     assertTypeString(tokens["id_token"]);
     assertIdentical(tokens["token_type"], "Bearer");
+  });
+
+  it("signs in by the address a pool signs its users in by", async () => {
+    // Given a pool that signs its users in by email, allowing a passkey, with
+    // a user holding one. The username that user holds is a UUID the pool
+    // generated, and the address is all the browser knows it by.
+    const setUp = await simCognitoWithHostedPasskey({
+      usernameAttributes: ["email"],
+      username: simCognitoHostedAddress,
+    });
+
+    // When the browser signs in with the passkey, posting the address back as
+    // the passkey page carried it.
+    const posted = await simCognitoPasskeyPosted(
+      setUp,
+      simCognitoHostedAddress,
+    );
+    const code = simCognitoRedirectedTo(posted).searchParams.get("code");
+
+    assertNonNullable(code);
+
+    const tokens = await simCognitoExchangedTokens(setUp, code);
+
+    // Then the address resolved to the user the challenge was issued for, so
+    // the sign-in finished and the code exchanged for tokens.
+    assertIdentical(posted.status, 302);
+    assertTypeString(tokens["access_token"]);
+    assertTypeString(tokens["id_token"]);
   });
 
   it("shows the refusal on the form where the user has no passkey", async () => {
@@ -213,13 +154,13 @@ describe("Signing in with a passkey at sim Cognito managed login", () => {
       username: simCognitoLocalUsername,
       passkey: "passkey",
     });
-    const session = passkeySessionIn(await asked.text());
+    const session = simCognitoPasskeySessionIn(await asked.text());
     const otherAsked = await simCognitoPostForm(other, "/oauth2/authorize", {
       ...simCognitoAuthorizeParameters(other),
       username: simCognitoLocalUsername,
       passkey: "passkey",
     });
-    const otherSession = passkeySessionIn(await otherAsked.text());
+    const otherSession = simCognitoPasskeySessionIn(await otherAsked.text());
 
     // When the first pool is answered with the other user's credential.
     const posted = await simCognitoPostForm(setUp, "/oauth2/authorize", {

--- a/test/cognito/federation-fixture.ts
+++ b/test/cognito/federation-fixture.ts
@@ -13,6 +13,7 @@ import type {
   AttributeType,
   PreventUserExistenceErrorTypes,
   SchemaAttributeType,
+  UsernameAttributeType,
   UserPoolMfaType,
   VerifiedAttributeType,
 } from "@aws-sdk/client-cognito-identity-provider";
@@ -94,6 +95,13 @@ export interface SimCognitoHostedSetUpOptions {
 
   /** What the app client does about a username the pool lacks. */
   readonly preventUserExistenceErrors?: PreventUserExistenceErrorTypes;
+
+  /**
+   * What the pool signs its users in by, its own usernames by default. A pool
+   * given one of these generates a username for every user and signs it in by
+   * the attribute instead.
+   */
+  readonly usernameAttributes?: readonly UsernameAttributeType[];
 }
 
 /**
@@ -138,6 +146,9 @@ export async function simCognitoHosted(
       PoolName: "myapp-users",
       ...(options.mfaConfiguration !== undefined && {
         MfaConfiguration: options.mfaConfiguration,
+      }),
+      ...(options.usernameAttributes !== undefined && {
+        UsernameAttributes: [...options.usernameAttributes],
       }),
       ...(options.schema !== undefined && { Schema: options.schema }),
       ...(options.autoVerifiedAttributes !== undefined && {

--- a/test/cognito/hosted-passkey-fixture.ts
+++ b/test/cognito/hosted-passkey-fixture.ts
@@ -1,0 +1,184 @@
+/**
+ * The arrangement the passkey managed login tests share: a pool with a hosted
+ * domain that allows a passkey at the first prompt, a user holding one, and
+ * the two requests a browser signs in with it over.
+ *
+ * The pool has no `WebAuthnConfiguration`, so the passkey is registered
+ * against the domain, which is what real Cognito falls back to. That is what
+ * separates this from `test/cognito/passkey-fixture.ts`, which arranges the
+ * pool the API sign-ins present a passkey to.
+ *
+ * It lives under `test/` for the same reasons as `test/cognito/cfn-deploy.ts`:
+ * a test file cannot export helpers alongside its own `describe` calls, and
+ * `test/**` is type-checked with everything else and excluded from the
+ * published build.
+ */
+
+import type { UsernameAttributeType } from "@aws-sdk/client-cognito-identity-provider";
+import {
+  AdminInitiateAuthCommand,
+  CompleteWebAuthnRegistrationCommand,
+  StartWebAuthnRegistrationCommand,
+  UpdateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { assertTypeString } from "@kensio/smartass";
+
+import { SimAwsHttp } from "../../src/serve/http/sim-aws-http.js";
+import {
+  simCognitoCallbackUrl,
+  simCognitoHosted,
+  simCognitoLocalPassword,
+  simCognitoLocalUser,
+  simCognitoLocalUsername,
+  type SimCognitoHostedSetUp,
+} from "./federation-fixture.js";
+import {
+  simCognitoAuthorizeParameters,
+  simCognitoPageUrl,
+  simCognitoPostForm,
+} from "./managed-login-fixture.js";
+
+/**
+ * The address a user of a pool that signs its users in by email holds.
+ */
+export const simCognitoHostedAddress = "alice@example.com";
+
+export interface SimCognitoHostedPasskeyOptions {
+  /** What the pool signs its users in by, its own usernames by default. */
+  readonly usernameAttributes?: readonly UsernameAttributeType[];
+
+  /** The name the user is created and signs in by, `alice` by default. */
+  readonly username?: string;
+}
+
+/**
+ * A pool served on a hosted domain that allows a passkey at the first prompt,
+ * with a user holding one.
+ */
+export async function simCognitoWithHostedPasskey(
+  options: SimCognitoHostedPasskeyOptions = {},
+): Promise<SimCognitoHostedSetUp> {
+  const { usernameAttributes, username = simCognitoLocalUsername } = options;
+  const byAttribute = usernameAttributes !== undefined;
+  const setUp = await simCognitoHosted({
+    ...(byAttribute && { usernameAttributes }),
+  });
+
+  // A pool signing users in by an attribute puts the name a user is created
+  // with into that attribute itself, so there is nothing to pass here.
+  await simCognitoLocalUser(setUp, {
+    username,
+    ...(byAttribute && { attributes: [] }),
+  });
+  await setUp.cognito.updateUserPool(
+    new UpdateUserPoolCommand({
+      UserPoolId: setUp.userPoolId,
+      Policies: {
+        SignInPolicy: { AllowedFirstAuthFactors: ["PASSWORD", "WEB_AUTHN"] },
+      },
+    }),
+  );
+
+  const signedIn = await setUp.cognito.adminInitiateAuth(
+    new AdminInitiateAuthCommand({
+      UserPoolId: setUp.userPoolId,
+      ClientId: setUp.clientId,
+      AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+      AuthParameters: { USERNAME: username, PASSWORD: simCognitoLocalPassword },
+    }),
+  );
+  const AccessToken = signedIn.AuthenticationResult?.AccessToken;
+
+  assertTypeString(AccessToken);
+
+  await setUp.cognito.startWebAuthnRegistration(
+    new StartWebAuthnRegistrationCommand({ AccessToken }),
+  );
+  await setUp.cognito.completeWebAuthnRegistration(
+    new CompleteWebAuthnRegistrationCommand({
+      AccessToken,
+      Credential: setUp.cognito
+        .userPool(setUp.userPoolId)
+        .webAuthnCredential(username),
+    }),
+  );
+
+  return setUp;
+}
+
+/**
+ * The challenge session the passkey page carries, out of its hidden input.
+ */
+export function simCognitoPasskeySessionIn(page: string): string {
+  const session = /name="passkey_session" value="([^"]+)"/u.exec(page)?.[1];
+
+  assertTypeString(session);
+
+  return session;
+}
+
+/**
+ * The username the passkey page carries, out of its hidden input.
+ */
+export function simCognitoPasskeyUsernameIn(page: string): string {
+  const username = /name="username" value="([^"]+)"/u.exec(page)?.[1];
+
+  assertTypeString(username);
+
+  return username;
+}
+
+/**
+ * Ask for a passkey and present the credential answering it, in the two
+ * requests managed login takes, and answer with what came back from the
+ * second.
+ *
+ * The second request carries the fields the passkey page carried, because
+ * those are all a browser posting that page has.
+ */
+export async function simCognitoPasskeyPosted(
+  setUp: SimCognitoHostedSetUp,
+  username: string,
+): Promise<Response> {
+  const parameters = simCognitoAuthorizeParameters(setUp);
+  const asked = await simCognitoPostForm(setUp, "/oauth2/authorize", {
+    ...parameters,
+    username,
+    passkey: "passkey",
+  });
+  const page = await asked.text();
+  const session = simCognitoPasskeySessionIn(page);
+
+  return await simCognitoPostForm(setUp, "/oauth2/authorize", {
+    ...parameters,
+    username: simCognitoPasskeyUsernameIn(page),
+    passkey_session: session,
+    credential: JSON.stringify(
+      setUp.cognito.userPool(setUp.userPoolId).webAuthnAssertion(session),
+    ),
+  });
+}
+
+/**
+ * Exchange an authorization code for the tokens it earned.
+ */
+export async function simCognitoExchangedTokens(
+  setUp: SimCognitoHostedSetUp,
+  code: string,
+): Promise<Record<string, unknown>> {
+  const exchanged = await new SimAwsHttp({ simAws: setUp.simAws }).fetch(
+    simCognitoPageUrl("/oauth2/token"),
+    {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        client_id: setUp.clientId,
+        code,
+        redirect_uri: simCognitoCallbackUrl,
+      }).toString(),
+    },
+  );
+
+  return (await exchanged.json()) as Record<string, unknown>;
+}

--- a/test/cognito/hosted-passkey-fixture.ts
+++ b/test/cognito/hosted-passkey-fixture.ts
@@ -129,34 +129,57 @@ export function simCognitoPasskeyUsernameIn(page: string): string {
 }
 
 /**
- * Ask for a passkey and present the credential answering it, in the two
- * requests managed login takes, and answer with what came back from the
- * second.
- *
- * The second request carries the fields the passkey page carried, because
- * those are all a browser posting that page has.
+ * Post the sign-in form with the passkey button, and answer with the passkey
+ * page that comes back.
  */
-export async function simCognitoPasskeyPosted(
+export async function simCognitoPasskeyAsked(
   setUp: SimCognitoHostedSetUp,
   username: string,
-): Promise<Response> {
-  const parameters = simCognitoAuthorizeParameters(setUp);
+): Promise<string> {
   const asked = await simCognitoPostForm(setUp, "/oauth2/authorize", {
-    ...parameters,
+    ...simCognitoAuthorizeParameters(setUp),
     username,
     passkey: "passkey",
   });
-  const page = await asked.text();
+
+  return await asked.text();
+}
+
+/**
+ * Present the credential answering the challenge a passkey page carries.
+ *
+ * The request carries the fields that page carried, because those are all a
+ * browser posting it has.
+ */
+export async function simCognitoPasskeyPresented(
+  setUp: SimCognitoHostedSetUp,
+  page: string,
+): Promise<Response> {
   const session = simCognitoPasskeySessionIn(page);
 
   return await simCognitoPostForm(setUp, "/oauth2/authorize", {
-    ...parameters,
+    ...simCognitoAuthorizeParameters(setUp),
     username: simCognitoPasskeyUsernameIn(page),
     passkey_session: session,
     credential: JSON.stringify(
       setUp.cognito.userPool(setUp.userPoolId).webAuthnAssertion(session),
     ),
   });
+}
+
+/**
+ * Ask for a passkey and present the credential answering it, in the two
+ * requests managed login takes, and answer with what came back from the
+ * second.
+ */
+export async function simCognitoPasskeyPosted(
+  setUp: SimCognitoHostedSetUp,
+  username: string,
+): Promise<Response> {
+  return await simCognitoPasskeyPresented(
+    setUp,
+    await simCognitoPasskeyAsked(setUp, username),
+  );
 }
 
 /**


### PR DESCRIPTION
A passkey sign-in at managed login could not complete on a pool with `UsernameAttributes`. The challenge was issued against the user the form resolved to, while the second request looked its session up by the address the page carried back, and the pool answered `Invalid session for the user.` The presented username is now resolved to its user before the session is read. The page goes on showing the address the person typed.

Resolves https://github.com/KensioSoftware/yulin/issues/859

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved hosted passkey sign-in reliability when users are identified by email addresses instead of generated usernames.
  - Ensured authentication sessions are matched to the correctly resolved user, reducing sign-in failures.

- **Improvements**
  - Strengthened passkey sign-in and token exchange coverage across hosted authentication flows.
  - Added support for configuring supported username attributes in hosted sign-in scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->