### PR TITLE
feat: return a public deployed Stack type

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -913,7 +913,7 @@ const consumer = await cloudFormation.deployTemplate({
 await consumer.waitForDeployComplete();
 
 // shared-uploads, read from the export the producer Stack published
-console.log(consumer.resources.get("UploadsTopic")?.properties["DisplayName"]);
+console.log(consumer.getResource("UploadsTopic")?.properties["DisplayName"]);
 ```
 
 Deploy the producer first. An export is published once the producer's Outputs have resolved, which
@@ -994,7 +994,7 @@ await stack.waitForDeployComplete();
 console.log(simAws.s3().getSimBucketByName("site-dev")?.bucketName);
 
 // false, because IsProd is false
-console.log(stack.resources.has("Backups"));
+console.log(stack.getResource("Backups") !== undefined);
 ```
 
 ### Writing a condition
@@ -1032,7 +1032,7 @@ resource this deployment never creates.
 ### The resource `Condition` attribute
 
 A resource carrying a `Condition` attribute whose condition is false is never created. It is absent
-from `stack.resources`. A resource sim CloudFormation skips behaves differently. A skipped resource
+from `stack.getResource(...)`. A resource sim CloudFormation skips behaves differently. A skipped resource
 stays in the stack and answers `Ref` and `Fn::GetAtt` with
 [stand-in values](#values-from-a-skipped-resource).
 
@@ -2725,6 +2725,63 @@ console.log(bucketResource?.simResource);
 This is useful in tests when you want to assert that a specific template resource created the
 expected simulated service resource.
 
+### Naming the deployed Stack type
+
+A deployment answers with a `SimCfnDeployedStack`, and `getResource(...)` with a
+`SimCfnDeployedResource`. A helper written away from the deploy call names both from
+`@kensio/yulin/cloudformation`.
+
+```typescript sim-cloudformation-deployed-stack-type
+/**
+ * Naming what a deployment answers with, for a helper written somewhere else.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import type {
+  SimCfnDeployedResource,
+  SimCfnDeployedStack,
+} from "@kensio/yulin/cloudformation";
+
+function deployedBucket(
+  stack: SimCfnDeployedStack,
+): SimCfnDeployedResource | undefined {
+  return stack.getResource("SiteBucket");
+}
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "named-stack",
+  template: {
+    Resources: {
+      SiteBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: {
+          BucketName: "named-site-bucket",
+        },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+console.log(deployedBucket(stack)?.type);
+```
+
+A deployed Stack holds what the caller that deployed it reads back:
+
+- `stackName`, `status` and `error`
+- `outputs` and `output(...)`, covered under [Reading stack Outputs](#reading-stack-outputs)
+- `getResource(...)`
+- `ignoredProperties`, `skippedResources`, `inertResources`, `skippedResourceDeletions` and
+  `retainedResources`
+- `waitForDeployComplete()`, `waitForUpdateComplete()` and `waitForDeleteComplete()`
+- `delete()` and `teardown()`
+
+The same type is what a `deployCdkOut` transform is handed for the Stacks in front of the one it is
+adapting, as `ReadonlyMap<string, SimCfnDeployedStack>`.
+
 ### Looking a Resource up by CDK construct ID
 
 `getResource` takes the CDK construct ID as well as the synthesized logical ID. A construct named
@@ -2809,7 +2866,7 @@ console.log(stack.getResource("AlarmRule")?.skippedReason);
 // "Unsupported sim CloudFormation Resource service CloudWatch"
 ```
 
-A skipped Resource is still in `stack.resources`, and still answers `Ref` and `Fn::GetAtt` with
+A skipped Resource is still there for `stack.getResource(...)`, and still answers `Ref` and `Fn::GetAtt` with
 [stand-in values](#values-from-a-skipped-resource).
 
 A skip is more than a whole Resource type nothing simulates. A service can decline one Resource of a
@@ -2871,7 +2928,7 @@ console.log(stack.getResource("AwsCliLayer")?.inertReason);
 //  module path"
 ```
 
-An inert Resource behaves in every other way like a skipped one. It is still in `stack.resources`,
+An inert Resource behaves in every other way like a skipped one. It is still there for `stack.getResource(...)`,
 it answers `Ref` and `Fn::GetAtt` with the same [stand-in values](#values-from-a-skipped-resource),
 and a teardown steps over it.
 

--- a/docs/services/cloudformation/sim-cloudformation-conditions.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-conditions.example.ts
@@ -41,4 +41,4 @@ await stack.waitForDeployComplete();
 console.log(simAws.s3().getSimBucketByName("site-dev")?.bucketName);
 
 // false, because IsProd is false
-console.log(stack.resources.has("Backups"));
+console.log(stack.getResource("Backups") !== undefined);

--- a/docs/services/cloudformation/sim-cloudformation-deployed-stack-type.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-deployed-stack-type.example.ts
@@ -1,0 +1,35 @@
+/**
+ * Naming what a deployment answers with, for a helper written somewhere else.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import type {
+  SimCfnDeployedResource,
+  SimCfnDeployedStack,
+} from "@kensio/yulin/cloudformation";
+
+function deployedBucket(
+  stack: SimCfnDeployedStack,
+): SimCfnDeployedResource | undefined {
+  return stack.getResource("SiteBucket");
+}
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "named-stack",
+  template: {
+    Resources: {
+      SiteBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: {
+          BucketName: "named-site-bucket",
+        },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+console.log(deployedBucket(stack)?.type);

--- a/docs/services/cloudformation/sim-cloudformation-fn-import-value.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-fn-import-value.example.ts
@@ -43,4 +43,4 @@ const consumer = await cloudFormation.deployTemplate({
 await consumer.waitForDeployComplete();
 
 // shared-uploads, read from the export the producer Stack published
-console.log(consumer.resources.get("UploadsTopic")?.properties["DisplayName"]);
+console.log(consumer.getResource("UploadsTopic")?.properties["DisplayName"]);

--- a/docs/services/ecs/README.md
+++ b/docs/services/ecs/README.md
@@ -1628,7 +1628,7 @@ definition, and a service's `NetworkConfiguration`, `CapacityProviderStrategy`,
 stack deploys, and each one is reported on the Resource:
 
 ```typescript
-console.log(stack.resources.get("OrdersCluster")?.ignoredProperties);
+console.log(stack.getResource("OrdersCluster")?.ignoredProperties);
 ```
 
 ## Authorization

--- a/docs/services/elbv2/README.md
+++ b/docs/services/elbv2/README.md
@@ -1645,7 +1645,7 @@ authentication and health check configuration are all in that group. Each one is
 Resource, where a reader can see which parts of the deployed load balancer are inert:
 
 ```typescript
-const ignored = stack.resources.get("ShopAlb")?.ignoredProperties;
+const ignored = stack.getResource("ShopAlb")?.ignoredProperties;
 ```
 
 Tearing the stack down removes all four in reverse dependency order. A rule comes down before its

--- a/scripts/mts/verify-pack-consumer.mts
+++ b/scripts/mts/verify-pack-consumer.mts
@@ -33,7 +33,12 @@ const typeUsageSource = `import {
   simAwsAccountId,
   type SimAwsAccountId,
 } from "@kensio/yulin";
-import type { CfnTemplateBodyRecord } from "@kensio/yulin/cloudformation";
+import type {
+  CfnTemplateBodyRecord,
+  SimCfnCdkOutTemplateTransform,
+  SimCfnDeployedResource,
+  SimCfnDeployedStack,
+} from "@kensio/yulin/cloudformation";
 
 const accountId: SimAwsAccountId = simAwsAccountId("111111111111");
 
@@ -43,12 +48,27 @@ const template: CfnTemplateBodyRecord = {
   },
 };
 
-export function deployStack(): Promise<unknown> {
+export function deployStack(): Promise<SimCfnDeployedStack> {
   return new SimAws()
     .account(accountId)
     .cloudFormation()
     .deployTemplate({ stackName: "packed-stack", template });
 }
+
+export function stackHandle(
+  stack: SimCfnDeployedStack,
+): SimCfnDeployedResource | undefined {
+  return stack.getResource("Handle");
+}
+
+export const substituteFromDeployed: SimCfnCdkOutTemplateTransform = (
+  body: CfnTemplateBodyRecord,
+  deployed: ReadonlyMap<string, SimCfnDeployedStack>,
+): CfnTemplateBodyRecord => {
+  deployed.get("packed-stack")?.output("Handle");
+
+  return body;
+};
 `;
 
 /**

--- a/src/service/acm/cfn/sim-cfn-acm-cert.iso.test.ts
+++ b/src/service/acm/cfn/sim-cfn-acm-cert.iso.test.ts
@@ -258,7 +258,7 @@ describe("Sim ACM CloudFormation Certificate", () => {
     // Then the Stack completes, but records the unsupported resource as skipped.
     const skippedResource = stack.skippedResources[0];
 
-    assertIdentical(stack.lifecycle.status, "CREATE_COMPLETE");
+    assertIdentical(stack.status, "CREATE_COMPLETE");
     assertArrayLength(stack.skippedResources, 1);
     assertNonNullable(skippedResource);
     assertIdentical(skippedResource.logicalId, "UnsupportedAcmResource");

--- a/src/service/acm/cfn/sim-cfn-acm-teardown.iso.test.ts
+++ b/src/service/acm/cfn/sim-cfn-acm-teardown.iso.test.ts
@@ -36,7 +36,7 @@ describe("ACM CloudFormation Resource teardown", () => {
 
     assertArrayLength(listed.CertificateSummaryList, 0);
     assertIdentical(
-      stack.resources.get("SiteCertificate")?.status,
+      stack.getResource("SiteCertificate")?.status,
       "DELETE_COMPLETE",
     );
   });

--- a/src/service/apigateway/cfn/sim-cfn-rest-api-authorizer.iso.test.ts
+++ b/src/service/apigateway/cfn/sim-cfn-rest-api-authorizer.iso.test.ts
@@ -135,7 +135,7 @@ describe("Deploying a REST API authorizer from CloudFormation", () => {
     // Given a deployed API whose method names an AWS::ApiGateway::Authorizer
     const simAws = simAwsInEuWest2();
     const stack = await deployRestApi(simAws, gatedTemplate());
-    const restApi = stack.resources.get("Api")?.simResource as
+    const restApi = stack.getResource("Api")?.simResource as
       | SimRestApi
       | undefined;
     assertNonNullable(restApi);
@@ -164,7 +164,7 @@ describe("Deploying a REST API authorizer from CloudFormation", () => {
     // Given a deployed API gated by an authorizer
     const simAws = simAwsInEuWest2();
     const stack = await deployRestApi(simAws, gatedTemplate());
-    const restApi = stack.resources.get("Api")?.simResource as
+    const restApi = stack.getResource("Api")?.simResource as
       | SimRestApi
       | undefined;
     assertNonNullable(restApi);
@@ -192,7 +192,7 @@ describe("Deploying a REST API authorizer from CloudFormation", () => {
       simAws,
       gatedTemplate({ AuthorizerResultTtlInSeconds: "300" }),
     );
-    const restApi = stack.resources.get("Api")?.simResource as
+    const restApi = stack.getResource("Api")?.simResource as
       | SimRestApi
       | undefined;
     assertNonNullable(restApi);
@@ -218,10 +218,7 @@ describe("Deploying a REST API authorizer from CloudFormation", () => {
 
     // Then the API deploys and the record says which of its parts behaves
     // differently to the template
-    assertIdentical(
-      stack.resources.get("Authorizer")?.status,
-      "CREATE_COMPLETE",
-    );
+    assertIdentical(stack.getResource("Authorizer")?.status, "CREATE_COMPLETE");
     assertStringIncludes(
       ignoredReasons(stack).join("\n"),
       "AWS::ApiGateway::Authorizer property IdentityValidationExpression is " +
@@ -233,7 +230,7 @@ describe("Deploying a REST API authorizer from CloudFormation", () => {
     // Given a deployed API gated by an authorizer
     const simAws = simAwsInEuWest2();
     const stack = await deployRestApi(simAws, gatedTemplate());
-    const restApi = stack.resources.get("Api")?.simResource as
+    const restApi = stack.getResource("Api")?.simResource as
       | SimRestApi
       | undefined;
     assertNonNullable(restApi);
@@ -242,10 +239,7 @@ describe("Deploying a REST API authorizer from CloudFormation", () => {
     await stack.teardown();
 
     // Then the authorizer went through DeleteAuthorizer, and the API is gone
-    assertIdentical(
-      stack.resources.get("Authorizer")?.status,
-      "DELETE_COMPLETE",
-    );
+    assertIdentical(stack.getResource("Authorizer")?.status, "DELETE_COMPLETE");
     assertUndefined(simAws.apiGateway().findRestApi(restApi.apiId));
   });
 

--- a/src/service/apigateway/cfn/sim-cfn-rest-api-cognito-authorizer.iso.test.ts
+++ b/src/service/apigateway/cfn/sim-cfn-rest-api-cognito-authorizer.iso.test.ts
@@ -88,7 +88,7 @@ async function deployGatedApi(
     simAws,
     gatedTemplate(signedIn.userPoolArn, methodProperties),
   );
-  const restApi = stack.resources.get("Api")?.simResource as
+  const restApi = stack.getResource("Api")?.simResource as
     | SimRestApi
     | undefined;
   assertNonNullable(restApi);

--- a/src/service/apigateway/cfn/sim-cfn-rest-api-request-authorizer.iso.test.ts
+++ b/src/service/apigateway/cfn/sim-cfn-rest-api-request-authorizer.iso.test.ts
@@ -122,7 +122,7 @@ describe("Deploying a REST API REQUEST authorizer from CloudFormation", () => {
     // of type REQUEST
     const simAws = simAwsInEuWest2();
     const stack = await deployRestApi(simAws, gatedTemplate());
-    const restApi = stack.resources.get("Api")?.simResource as
+    const restApi = stack.getResource("Api")?.simResource as
       | SimRestApi
       | undefined;
     assertNonNullable(restApi);
@@ -153,7 +153,7 @@ describe("Deploying a REST API REQUEST authorizer from CloudFormation", () => {
     // Given a deployed API gated by a REQUEST authorizer
     const simAws = simAwsInEuWest2();
     const stack = await deployRestApi(simAws, gatedTemplate());
-    const restApi = stack.resources.get("Api")?.simResource as
+    const restApi = stack.getResource("Api")?.simResource as
       | SimRestApi
       | undefined;
     assertNonNullable(restApi);

--- a/src/service/apigateway/cfn/sim-cfn-rest-api-teardown.iso.test.ts
+++ b/src/service/apigateway/cfn/sim-cfn-rest-api-teardown.iso.test.ts
@@ -30,7 +30,7 @@ describe("REST API CloudFormation Resource teardown", () => {
       }),
     );
 
-    const restApi = stack.resources.get("Api")?.simResource as
+    const restApi = stack.getResource("Api")?.simResource as
       | SimRestApi
       | undefined;
     assertNonNullable(restApi);
@@ -52,7 +52,7 @@ describe("REST API CloudFormation Resource teardown", () => {
       "Api",
     ]) {
       assertIdentical(
-        stack.resources.get(logicalId)?.status,
+        stack.getResource(logicalId)?.status,
         "DELETE_COMPLETE",
         `${logicalId} status`,
       );
@@ -75,7 +75,7 @@ describe("REST API CloudFormation Resource teardown", () => {
     // Then the deployment is reported rather than deleted, because API Gateway
     // deletes one and this simulation has no command for it. The deployment
     // goes with its API a moment later in the same teardown.
-    const deployment = stack.resources.get("Deployment");
+    const deployment = stack.getResource("Deployment");
     assertNonNullable(deployment);
     assertTrue(deployment.deletionSkipped);
     assertStringIncludes(
@@ -104,7 +104,7 @@ describe("REST API CloudFormation Resource teardown", () => {
     assertUndefined(simAws.lambda().getSimFunctionByName("orders"));
     assertUndefined(simAws.iam().roles.get("orders-role" as never));
     assertIdentical(
-      stack.resources.get("HandlerPermission")?.status,
+      stack.getResource("HandlerPermission")?.status,
       "DELETE_COMPLETE",
     );
   });

--- a/src/service/apigateway/cfn/sim-cfn-rest-api-validation.iso.test.ts
+++ b/src/service/apigateway/cfn/sim-cfn-rest-api-validation.iso.test.ts
@@ -185,7 +185,7 @@ describe("API Gateway REST API CloudFormation Resource types left out", () => {
     assertTypeString(apiId);
     assertNonNullable(simAws.apiGateway().findRestApi(apiId));
 
-    const account = stack.resources.get("ApiAccount");
+    const account = stack.getResource("ApiAccount");
     assertNonNullable(account);
     assertTrue(account.skipped);
     assertStringIncludes(

--- a/src/service/apigatewayv2/cfn/sim-cfn-http-api-request-authorizer.iso.test.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-http-api-request-authorizer.iso.test.ts
@@ -13,7 +13,7 @@ import {
 import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
 import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
 import type { SimAws } from "../../aws/sim-aws.js";
-import type { SimCfnStack } from "../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
 import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
 import { simCfnHttpApiTemplateFactory } from "./sim-cfn-http-api-template.factory.js";
 
@@ -136,7 +136,7 @@ function requestAuthorizerTemplate(
 
 function get(
   simAws: SimAws,
-  stack: SimCfnStack,
+  stack: SimCfnDeployedStack,
   cookie: string,
 ): Promise<Response> {
   const apiEndpoint = stack.outputs.get("ApiEndpoint")?.value as string;

--- a/src/service/apigatewayv2/cfn/sim-cfn-http-api-teardown.iso.test.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-http-api-teardown.iso.test.ts
@@ -25,9 +25,7 @@ describe("HTTP API CloudFormation Resource teardown", () => {
     });
     await stack.waitForDeployComplete();
 
-    const api = stack.resources.get("Api")?.simResource as
-      | SimHttpApi
-      | undefined;
+    const api = stack.getResource("Api")?.simResource as SimHttpApi | undefined;
     assertNonNullable(api);
 
     // When the Stack's Resources are torn down.
@@ -44,7 +42,7 @@ describe("HTTP API CloudFormation Resource teardown", () => {
       "Api",
     ]) {
       assertIdentical(
-        stack.resources.get(logicalId)?.status,
+        stack.getResource(logicalId)?.status,
         "DELETE_COMPLETE",
         `${logicalId} status`,
       );
@@ -72,7 +70,7 @@ describe("HTTP API CloudFormation Resource teardown", () => {
     assertUndefined(simAws.lambda().getSimFunctionByName("orders"));
     assertUndefined(simAws.iam().roles.get("orders-role" as never));
     assertIdentical(
-      stack.resources.get("HandlerPermission")?.status,
+      stack.getResource("HandlerPermission")?.status,
       "DELETE_COMPLETE",
     );
   });

--- a/src/service/cloudformation/cdk/apigateway/sim-cdk-rest-api.loc.test.ts
+++ b/src/service/cloudformation/cdk/apigateway/sim-cdk-rest-api.loc.test.ts
@@ -18,6 +18,7 @@ import { serveSimAws } from "../../../../serve/index.js";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { TemporaryDirectory } from "../../../../util/filesystem/temporary-directory.js";
 import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+import { deployedStackObject } from "../../stack/sim-cfn-stack.fixture.js";
 
 /**
  * Inline function code, as CDK packages Code.fromInline source. The handler
@@ -112,8 +113,8 @@ describe("Sim CDK REST API deployment local integration", () => {
 
     // And the invocation was gated by the AWS::Lambda::Permission CDK pairs
     // with the method, which is deployed rather than skipped.
-    const permissionResource = stack.resources
-      .values()
+    const permissionResource = deployedStackObject(stack)
+      .resources.values()
       .find((resource) => resource.type === "AWS::Lambda::Permission");
     assertNonNullable(permissionResource);
     assertFalse(permissionResource.skipped);
@@ -126,8 +127,8 @@ describe("Sim CDK REST API deployment local integration", () => {
 
     // And the AWS::ApiGateway::Account CDK writes beside a default RestApi is
     // recorded rather than deployed, which is what leaves the rest served.
-    const accountResource = stack.resources
-      .values()
+    const accountResource = deployedStackObject(stack)
+      .resources.values()
       .find((resource) => resource.type === "AWS::ApiGateway::Account");
     assertNonNullable(accountResource);
     assertTrue(accountResource.skipped);

--- a/src/service/cloudformation/cdk/apigatewayv2/sim-cdk-http-api.loc.test.ts
+++ b/src/service/cloudformation/cdk/apigatewayv2/sim-cdk-http-api.loc.test.ts
@@ -17,6 +17,7 @@ import { serveSimAws } from "../../../../serve/index.js";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { TemporaryDirectory } from "../../../../util/filesystem/temporary-directory.js";
 import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+import { deployedStackObject } from "../../stack/sim-cfn-stack.fixture.js";
 
 /**
  * Inline function code, as CDK packages Code.fromInline source. The handler
@@ -128,8 +129,8 @@ describe("Sim CDK HTTP API deployment local integration", () => {
 
     // And the invocation was gated by the AWS::Lambda::Permission CDK pairs
     // with the integration, which is deployed rather than skipped.
-    const permissionResource = stack.resources
-      .values()
+    const permissionResource = deployedStackObject(stack)
+      .resources.values()
       .find((resource) => resource.type === "AWS::Lambda::Permission");
     assertNonNullable(permissionResource);
     assertFalse(permissionResource.skipped);

--- a/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-asset-code.loc.test.ts
+++ b/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-asset-code.loc.test.ts
@@ -19,6 +19,7 @@ import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { TemporaryDirectory } from "../../../../util/filesystem/temporary-directory.js";
 import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+import { deployedStackObject } from "../../stack/sim-cfn-stack.fixture.js";
 
 /**
  * A multi-module handler directory, as `Code.fromAsset` bundles one: CDK
@@ -246,8 +247,8 @@ app.synth();
     // because sim CloudFormation simulates the BucketDeployment custom resource
     // directly rather than running its provider, so there is nothing left for
     // the function to have done.
-    const providerResource = stack.resources
-      .values()
+    const providerResource = deployedStackObject(stack)
+      .resources.values()
       .find(
         (resource) =>
           resource.type === "AWS::Lambda::Function" &&

--- a/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-function-url.loc.test.ts
+++ b/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-function-url.loc.test.ts
@@ -18,6 +18,7 @@ import { serveSimAws } from "../../../../serve/index.js";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { TemporaryDirectory } from "../../../../util/filesystem/temporary-directory.js";
 import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+import { deployedStackObject } from "../../stack/sim-cfn-stack.fixture.js";
 
 /**
  * Inline function code, as CDK packages Code.fromInline source. The handler
@@ -145,8 +146,8 @@ app.synth();
     await simAws.backgroundTasksComplete();
 
     // Then the permission Resource is deployed rather than skipped.
-    const permissionResource = stack.resources
-      .values()
+    const permissionResource = deployedStackObject(stack)
+      .resources.values()
       .find((resource) => resource.type === "AWS::Lambda::Permission");
     assertNonNullable(permissionResource);
     assertFalse(permissionResource.skipped);

--- a/src/service/cloudformation/cdk/provider/sim-cdk-provider-scaffolding.iso.test.ts
+++ b/src/service/cloudformation/cdk/provider/sim-cdk-provider-scaffolding.iso.test.ts
@@ -2,8 +2,8 @@ import { assertArrayEquals, assertStringIncludes } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
 import type { CfnTemplateBodyRecord } from "../../template/sim-cfn-template.js";
-import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
-import type { SimCfnStack } from "../../stack/sim-cfn-stack.js";
+import type { SimCfnDeployedResource } from "../../resource/sim-cfn-deployed-resource.type.js";
+import type { SimCfnDeployedStack } from "../../stack/sim-cfn-deployed-stack.type.js";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { TemporaryDirectory } from "../../../../util/filesystem/temporary-directory.js";
 import { jsonStringify } from "../../../../util/type-guard/json.js";
@@ -142,7 +142,7 @@ describe("CDK custom Resource provider scaffolding [iso]", () => {
  */
 async function deployScaffoldedStack(
   resources: CfnTemplateBodyRecord["Resources"] = {},
-): Promise<SimCfnStack> {
+): Promise<SimCfnDeployedStack> {
   const temporaryDirectory = new TemporaryDirectory();
   const siteAsset = "asset.aaaa1111";
   const fontsAsset = "asset.bbbb2222";
@@ -191,7 +191,7 @@ async function deployScaffoldedStack(
     .deployTemplateFile(temporaryDirectory.join(...templatePathParts));
 }
 
-function logicalIdsOf(resources: readonly SimCfnResource[]): string[] {
+function logicalIdsOf(resources: readonly SimCfnDeployedResource[]): string[] {
   return resources
     .map((resource) => resource.logicalId)
     .toSorted((left, right) => left.localeCompare(right));

--- a/src/service/cloudformation/cdk/provider/sim-cdk-provider-scaffolding.loc.test.ts
+++ b/src/service/cloudformation/cdk/provider/sim-cdk-provider-scaffolding.loc.test.ts
@@ -2,7 +2,7 @@ import { assertArrayEquals, assertNonNullable } from "@kensio/smartass";
 import path from "node:path";
 import { describe, it } from "vitest";
 
-import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
+import type { SimCfnDeployedResource } from "../../resource/sim-cfn-deployed-resource.type.js";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { TemporaryDirectory } from "../../../../util/filesystem/temporary-directory.js";
 import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
@@ -93,7 +93,9 @@ app.synth();
   });
 });
 
-function resourceTypesOf(resources: readonly SimCfnResource[]): string[] {
+function resourceTypesOf(
+  resources: readonly SimCfnDeployedResource[],
+): string[] {
   return resources
     .map((resource) => resource.type ?? "")
     .toSorted((left, right) => left.localeCompare(right));

--- a/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications-teardown.iso.test.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications-teardown.iso.test.ts
@@ -30,7 +30,7 @@ describe("CDK Bucket notifications teardown", () => {
     // takes it off on its own Delete event.
     assertArrayLength(bucket.getNotifications().lambdaNotifications, 0);
     assertIdentical(
-      stack.resources.get("BucketNotifications")?.status,
+      stack.getResource("BucketNotifications")?.status,
       "DELETE_COMPLETE",
     );
   });

--- a/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications.loc.test.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications.loc.test.ts
@@ -107,7 +107,7 @@ app.synth();
       );
     await simAws.backgroundTasksComplete();
 
-    assertIdentical(stack.lifecycle.status, "CREATE_COMPLETE");
+    assertIdentical(stack.status, "CREATE_COMPLETE");
 
     // Then putting an Object into the deployed Bucket runs the deployed
     // function.

--- a/src/service/cloudformation/command/create-stack/create-stack.iso.test.ts
+++ b/src/service/cloudformation/command/create-stack/create-stack.iso.test.ts
@@ -14,6 +14,10 @@ import {
   DescribeStacksCommand,
 } from "@aws-sdk/client-cloudformation";
 import { jsonStringify } from "../../../../util/type-guard/json.js";
+import {
+  deployedResourceObject,
+  deployedStackObject,
+} from "../../stack/sim-cfn-stack.fixture.js";
 
 describe("CloudFormation CreateStackCommand", () => {
   it("creates a CloudFormation Stack from a template body", async () => {
@@ -77,14 +81,14 @@ describe("CloudFormation CreateStackCommand", () => {
     const stack = cloudFormation.getStackByName("test-stack");
 
     assertNonNullable(stack);
-    assertMapSize(stack.resources, 1);
+    assertMapSize(deployedStackObject(stack).resources, 1);
 
-    const resource = stack.resources.get("ExampleResource");
+    const resource = stack.getResource("ExampleResource");
 
     assertNonNullable(resource);
     assertIdentical(resource.logicalId, "ExampleResource");
     assertIdentical(
-      resource.template["Type"],
+      deployedResourceObject(resource).template["Type"],
       "AWS::CloudFormation::WaitConditionHandle",
     );
   });

--- a/src/service/cloudformation/command/delete-stack/delete-stack.iso.test.ts
+++ b/src/service/cloudformation/command/delete-stack/delete-stack.iso.test.ts
@@ -250,10 +250,7 @@ describe("CloudFormation DeleteStackCommand", () => {
     // CloudFormation reports one it stepped over, and the other has gone.
     assertNonNullable(simAws.s3().getSimBucketByName("kept"));
     assertUndefined(simAws.s3().getSimBucketByName("gone"));
-    assertIdentical(
-      stack.resources.get("KeptBucket")?.status,
-      "DELETE_SKIPPED",
-    );
+    assertIdentical(stack.getResource("KeptBucket")?.status, "DELETE_SKIPPED");
     assertArrayLength(stack.retainedResources, 1);
 
     // And the Stack itself is still gone, so its name is free again.

--- a/src/service/cloudformation/command/update-stack/update-stack.iso.test.ts
+++ b/src/service/cloudformation/command/update-stack/update-stack.iso.test.ts
@@ -17,6 +17,7 @@ import { SimAws } from "../../../aws/sim-aws.js";
 import { simS3BodyToBuffer } from "../../../s3/storage/s3-body-buffer.js";
 import { jsonStringify } from "../../../../util/type-guard/json.js";
 import type { CfnTemplateBodyRecord } from "../../template/sim-cfn-template.js";
+import { deployedStackObject } from "../../stack/sim-cfn-stack.fixture.js";
 
 const reportsBucket = {
   Type: "AWS::S3::Bucket",
@@ -224,7 +225,7 @@ describe("CloudFormation UpdateStackCommand", () => {
     const stack = cloudFormation.getStackByName("reports-stack");
     assertNonNullable(stack);
     assertIdentical(
-      jsonStringify(stack.template),
+      jsonStringify(deployedStackObject(stack).template),
       jsonStringify(updatedTemplate),
     );
 

--- a/src/service/cloudformation/deploy/sim-cfn-cdk-out-deployer.iso.test.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-cdk-out-deployer.iso.test.ts
@@ -290,7 +290,7 @@ describe("Deploying a CDK cloud assembly [iso]", () => {
     // Then the producer had published its export by the time the consumer
     // imported it, so the import resolved to the value the producer exported.
     assertIdentical(
-      stacks.get("ConsumerStack")?.resources.get("ConsumerTopic")?.properties[
+      stacks.get("ConsumerStack")?.getResource("ConsumerTopic")?.properties[
         "DisplayName"
       ],
       assemblyStackBucketName("ProducerStack"),

--- a/src/service/cloudformation/deploy/sim-cfn-cdk-out-deployer.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-cdk-out-deployer.ts
@@ -1,6 +1,6 @@
 import type { SimAws } from "../../aws/sim-aws.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
-import type { SimCfnStack } from "../stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../stack/sim-cfn-deployed-stack.type.js";
 import {
   cdkOutBoundTransform,
   cdkOutOptionsFor,
@@ -35,13 +35,13 @@ export class SimCfnCdkOutDeployer {
 
   async deploy(
     request: SimCloudFormationDeployCdkOutProperties | string,
-  ): Promise<ReadonlyMap<string, SimCfnStack>> {
+  ): Promise<ReadonlyMap<string, SimCfnDeployedStack>> {
     const plan = await planCdkOutDeployment({
       request,
       defaultRegionName: this.scope.accountRegionScope.regionName,
     });
 
-    const deployed = new Map<string, SimCfnStack>();
+    const deployed = new Map<string, SimCfnDeployedStack>();
 
     for (const stack of plan.stacks) {
       // oxlint-disable-next-line no-await-in-loop -- one Stack at a time, since a later one may depend on an earlier one
@@ -56,8 +56,8 @@ export class SimCfnCdkOutDeployer {
   private async deployStack(
     stack: SimCfnCdkOutPlannedStack,
     plan: SimCfnCdkOutPlan,
-    deployed: ReadonlyMap<string, SimCfnStack>,
-  ): Promise<SimCfnStack> {
+    deployed: ReadonlyMap<string, SimCfnDeployedStack>,
+  ): Promise<SimCfnDeployedStack> {
     const { simAws, accountRegionScope } = this.scope;
     const { transform, ...options } = cdkOutOptionsFor(
       stack,

--- a/src/service/cloudformation/deploy/sim-cfn-cdk-out-stack-options.iso.test.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-cdk-out-stack-options.iso.test.ts
@@ -13,7 +13,7 @@ import {
   assemblyStackBucketName,
   simCdkCloudAssemblyFactory,
 } from "../cdk/sim-cdk-cloud-assembly.factory.js";
-import type { SimCfnStack } from "../stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../stack/sim-cfn-deployed-stack.type.js";
 import type { CfnTemplateBodyRecord } from "../template/sim-cfn-template.js";
 import type { SimCfnTemplateValueRecord } from "../template/value/sim-cfn-template-value.js";
 import type { SimCfnCdkOutTemplateTransform } from "./sim-cfn-cdk-out-stack-options.js";
@@ -176,7 +176,7 @@ describe("Deploying a CDK cloud assembly with per-Stack options [iso]", () => {
 
     // Then the Stack deployed the value the DNS Stack had just created.
     assertIdentical(
-      stacks.get("SiteStack")?.resources.get("SiteTopic")?.properties[
+      stacks.get("SiteStack")?.getResource("SiteTopic")?.properties[
         "DisplayName"
       ],
       assemblyStackBucketName("DnsStack"),
@@ -192,7 +192,10 @@ describe("Deploying a CDK cloud assembly with per-Stack options [iso]", () => {
       ],
     });
 
-    const deployments = new Map<string, ReadonlyMap<string, SimCfnStack>>();
+    const deployments = new Map<
+      string,
+      ReadonlyMap<string, SimCfnDeployedStack>
+    >();
 
     // When both Stacks record the deployment their transform was handed.
     const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
@@ -245,7 +248,7 @@ describe("Deploying a CDK cloud assembly with per-Stack options [iso]", () => {
 });
 
 function deployedOutput(
-  deployed: ReadonlyMap<string, SimCfnStack>,
+  deployed: ReadonlyMap<string, SimCfnDeployedStack>,
   stackName: string,
   outputKey: string,
 ): string {
@@ -271,7 +274,7 @@ function withTopicDisplayName(
 }
 
 function recordingTransform(
-  deployments: Map<string, ReadonlyMap<string, SimCfnStack>>,
+  deployments: Map<string, ReadonlyMap<string, SimCfnDeployedStack>>,
   stackName: string,
 ): SimCfnCdkOutTemplateTransform {
   return (template, deployed) => {
@@ -282,9 +285,9 @@ function recordingTransform(
 }
 
 function assertedDeployment(
-  deployments: ReadonlyMap<string, ReadonlyMap<string, SimCfnStack>>,
+  deployments: ReadonlyMap<string, ReadonlyMap<string, SimCfnDeployedStack>>,
   stackName: string,
-): ReadonlyMap<string, SimCfnStack> {
+): ReadonlyMap<string, SimCfnDeployedStack> {
   const deployment = deployments.get(stackName);
   assertNonNullable(deployment);
 

--- a/src/service/cloudformation/deploy/sim-cfn-cdk-out-stack-options.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-cdk-out-stack-options.ts
@@ -1,6 +1,6 @@
 import type { SimCdkAssemblyStack } from "../cdk/sim-cdk-assembly-manifest.js";
 import type { SimCfnDeployBinding } from "../bind/sim-cfn-deploy-binding.js";
-import type { SimCfnStack } from "../stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../stack/sim-cfn-deployed-stack.type.js";
 import type { CfnTemplateBodyRecord } from "../template/sim-cfn-template.js";
 import type { SimCfnTemplateFileTransform } from "./sim-cfn-template-file-transform.js";
 
@@ -18,7 +18,7 @@ import type { SimCfnTemplateFileTransform } from "./sim-cfn-template-file-transf
  */
 export type SimCfnCdkOutTemplateTransform = (
   template: CfnTemplateBodyRecord,
-  deployed: ReadonlyMap<string, SimCfnStack>,
+  deployed: ReadonlyMap<string, SimCfnDeployedStack>,
 ) => CfnTemplateBodyRecord;
 
 /**
@@ -59,7 +59,7 @@ export function cdkOutOptionsFor(
  */
 export function cdkOutBoundTransform(
   transform: SimCfnCdkOutTemplateTransform | undefined,
-  deployed: ReadonlyMap<string, SimCfnStack>,
+  deployed: ReadonlyMap<string, SimCfnDeployedStack>,
 ): SimCfnTemplateFileTransform | undefined {
   if (transform === undefined) {
     return undefined;

--- a/src/service/cloudformation/deploy/sim-cfn-template-deployer.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-template-deployer.ts
@@ -2,6 +2,7 @@ import type {
   SimCfnStack,
   SimCloudFormationStackName,
 } from "../stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../stack/sim-cfn-deployed-stack.type.js";
 import type { CfnTemplateBodyRecord } from "../template/sim-cfn-template.js";
 import { jsonStringify } from "../../../util/type-guard/json.js";
 import { assertDefined } from "../../../util/type-guard/defined.js";
@@ -145,7 +146,7 @@ export class SimCloudFormationTemplateDeployer {
    */
   async deployCdkOut(
     properties: SimCloudFormationDeployCdkOutProperties | string,
-  ): Promise<ReadonlyMap<string, SimCfnStack>> {
+  ): Promise<ReadonlyMap<string, SimCfnDeployedStack>> {
     return await this.cdkOutDeployer.deploy(properties);
   }
 

--- a/src/service/cloudformation/deploy/sim-cfn-template-deployer.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-template-deployer.ts
@@ -108,7 +108,7 @@ export class SimCloudFormationTemplateDeployer {
    */
   async deployTemplate(
     properties: SimCloudFormationCreateStackProperties,
-  ): Promise<SimCfnStack> {
+  ): Promise<SimCfnDeployedStack> {
     return await this.deployTemplateWithContext({
       stackName: properties.stackName ?? makeSimCloudFormationStackName(),
       template: properties.template,
@@ -130,7 +130,7 @@ export class SimCloudFormationTemplateDeployer {
    */
   async deployTemplateFile(
     properties: SimCloudFormationDeployTemplateFileProperties | string,
-  ): Promise<SimCfnStack> {
+  ): Promise<SimCfnDeployedStack> {
     const deployment = simCfnTemplateFileDeployment(properties);
     const stack = await this.deployTemplateWithContext(
       await this.templateFileLoader.load(deployment),
@@ -156,7 +156,7 @@ export class SimCloudFormationTemplateDeployer {
    */
   async updateTemplateFile(
     properties: SimCloudFormationDeployTemplateFileProperties | string,
-  ): Promise<SimCfnStack> {
+  ): Promise<SimCfnDeployedStack> {
     return await this.templateFileUpdater.update(
       simCfnTemplateFileDeployment(properties),
     );
@@ -182,7 +182,7 @@ export class SimCloudFormationTemplateDeployer {
     readonly parameters?: Record<string, string> | undefined;
     readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
     readonly cdkOutContext?: SimCdkOutContext | undefined;
-  }): Promise<SimCfnStack> {
+  }): Promise<SimCfnDeployedStack> {
     await this.createStackWithContext(
       {
         input: {

--- a/src/service/cloudformation/export/sim-cfn-stack-import-value.iso.test.ts
+++ b/src/service/cloudformation/export/sim-cfn-stack-import-value.iso.test.ts
@@ -58,9 +58,9 @@ describe("Fn::ImportValue between simulated Stacks", () => {
     });
 
     // Then the consumer's Resource was created holding the producer's value.
-    assertIdentical(consumer.lifecycle.status, "CREATE_COMPLETE");
+    assertIdentical(consumer.status, "CREATE_COMPLETE");
     assertIdentical(
-      consumer.resources.get("Consumer")?.properties["DisplayName"],
+      consumer.getResource("Consumer")?.properties["DisplayName"],
       exportedUrl,
     );
   });
@@ -164,7 +164,7 @@ describe("Fn::ImportValue between simulated Stacks", () => {
       template: producerTemplate("SharedQueueUrl", "replacement"),
     });
 
-    assertIdentical(replacement.lifecycle.status, "CREATE_COMPLETE");
+    assertIdentical(replacement.status, "CREATE_COMPLETE");
     assertNonNullable(replacement.outputs.get("SharedQueueUrl")?.exportName);
   });
 });

--- a/src/service/cloudformation/index.ts
+++ b/src/service/cloudformation/index.ts
@@ -1,4 +1,14 @@
 export { SimCloudFormation } from "./sim-cloudformation.js";
+export type { SimCfnDeployedStack } from "./stack/sim-cfn-deployed-stack.type.js";
+export type { SimCfnDeployedResource } from "./resource/sim-cfn-deployed-resource.type.js";
+export type { SimCfnStackOutput } from "./stack/output/sim-cfn-stack-output.js";
+export type { SimCloudFormationStackStatus } from "./stack/sim-cfn-stack.type.js";
+export type { SimCloudFormationResourceStatus } from "./resource/sim-cfn-resource.type.js";
+export type { SimCfnIgnoredProperty } from "./resource/ignore/sim-cfn-ignored-property.type.js";
+export type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "./template/value/sim-cfn-template-value.js";
 export type { CfnTemplateBodyRecord } from "./template/sim-cfn-template.js";
 export type { SimCfnTemplateFileTransform } from "./deploy/sim-cfn-template-file-transform.js";
 export type { SimCloudFormationDeployCdkOutProperties } from "./deploy/sim-cfn-cdk-out-deployer.js";

--- a/src/service/cloudformation/resource/ref/sim-cfn-resource-ref-value.iso.test.ts
+++ b/src/service/cloudformation/resource/ref/sim-cfn-resource-ref-value.iso.test.ts
@@ -41,8 +41,8 @@ describe("CloudFormation Resource Ref value", () => {
     // refValue(), so the derived Bucket name is based on the source Bucket
     // name.
     const sourceBucket = simAws.s3().getSimBucketByName("source-bucket");
-    const sourceResource = stack.resources.get("SourceBucket");
-    const derivedResource = stack.resources.get("DerivedBucket");
+    const sourceResource = stack.getResource("SourceBucket");
+    const derivedResource = stack.getResource("DerivedBucket");
 
     assertNonNullable(sourceBucket);
     assertInstanceOf(sourceBucket, SimS3Bucket);
@@ -80,8 +80,8 @@ describe("CloudFormation Resource Ref value", () => {
 
     // Then Ref resolves to the logical ID fallback.
     const bucket = simAws.s3().getSimBucketByName("handle");
-    const handleResource = stack.resources.get("handle");
-    const bucketResource = stack.resources.get("bucket");
+    const handleResource = stack.getResource("handle");
+    const bucketResource = stack.getResource("bucket");
 
     assertNonNullable(bucket);
     assertInstanceOf(bucket, SimS3Bucket);
@@ -127,8 +127,8 @@ describe("CloudFormation Resource Ref value", () => {
 
     // Then the Resource Ref contributes the logical ID fallback to the joined value.
     const bucket = simAws.s3().getSimBucketByName("handle-bucket");
-    const handleResource = stack.resources.get("handle");
-    const bucketResource = stack.resources.get("bucket");
+    const handleResource = stack.getResource("handle");
+    const bucketResource = stack.getResource("bucket");
 
     assertNonNullable(bucket);
     assertInstanceOf(bucket, SimS3Bucket);

--- a/src/service/cloudformation/resource/sim-cfn-deployed-resource.type.ts
+++ b/src/service/cloudformation/resource/sim-cfn-deployed-resource.type.ts
@@ -1,0 +1,84 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../template/value/sim-cfn-template-value.js";
+import type { SimCfnIgnoredProperty } from "./ignore/sim-cfn-ignored-property.type.js";
+import type { SimCloudFormationResourceStatus } from "./sim-cfn-resource.type.js";
+
+/**
+ * One Resource of a deployed Stack, as the caller that deployed it reads one.
+ *
+ * Everything here answers a question about the Resource. Creating and deleting
+ * a Resource belongs to the deployment that owns it, and those members stay
+ * inside the package with the class implementing this.
+ */
+export interface SimCfnDeployedResource {
+  /** The logical ID the template declared this Resource under. */
+  readonly logicalId: string;
+
+  /** The Stack this Resource was deployed as part of. */
+  readonly stackName: string | undefined;
+
+  /** The Resource type, e.g. `AWS::S3::Bucket`. */
+  readonly type: string | undefined;
+
+  /** The Resource's template properties, with references resolved. */
+  readonly properties: SimCfnTemplateValueRecord;
+
+  /** Properties the deployment created this Resource without acting on. */
+  readonly ignoredProperties: readonly SimCfnIgnoredProperty[];
+
+  /** The Resource's `DeletionPolicy`, where the template declared one. */
+  readonly deletionPolicy: string | undefined;
+
+  /** Whether a Stack teardown leaves this Resource where it is. */
+  readonly retainedOnDelete: boolean;
+
+  /** What `Ref` on this Resource resolves to. */
+  readonly refValue: SimCfnTemplateValue;
+
+  /** The simulated AWS object this Resource created, once it has one. */
+  readonly simResource: object | undefined;
+
+  /** What CloudFormation last did to this Resource. */
+  readonly status: SimCloudFormationResourceStatus;
+
+  /** Whether the Resource reached simulated AWS. */
+  readonly deployed: boolean;
+
+  /** Whether the deployment skipped this Resource for want of a simulation. */
+  readonly skipped: boolean;
+
+  /** Why the Resource was skipped, where it was. */
+  readonly skippedReason: string | undefined;
+
+  /** Whether the Resource was created as nothing, because nothing reads it. */
+  readonly inert: boolean;
+
+  /** Why the Resource was created inert, where it was. */
+  readonly inertReason: string | undefined;
+
+  /** Whether creation finished. */
+  readonly createComplete: boolean;
+
+  /** Whether deletion finished. */
+  readonly deleteComplete: boolean;
+
+  /** Whether the Resource has been deleted from simulated AWS. */
+  readonly deleted: boolean;
+
+  /** Whether a teardown recorded this Resource in place of deleting it. */
+  readonly deletionSkipped: boolean;
+
+  /** Why the deletion was skipped, where it was. */
+  readonly deletionSkippedReason: string | undefined;
+
+  /** Whether a teardown left this Resource in simulated AWS. */
+  readonly retained: boolean;
+
+  /** What stopped this Resource, where something did. */
+  readonly error: Error | undefined;
+
+  /** What `Fn::GetAtt` for this attribute resolves to. */
+  attributeValue(attributeName: string): SimCfnTemplateValue;
+}

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-api-event.iso.test.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-api-event.iso.test.ts
@@ -10,7 +10,7 @@ import { SimAwsHttp } from "../../../../../serve/http/sim-aws-http.js";
 import { SimAwsLocalUrl } from "../../../../../serve/http/url/sim-aws-local-url.js";
 import type { SimRestApi } from "../../../../apigateway/api/sim-rest-api.js";
 import { SimAws } from "../../../../aws/sim-aws.js";
-import type { SimCfnStack } from "../../../stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../../stack/sim-cfn-deployed-stack.type.js";
 import type { SimCfnTemplateValueRecord } from "../../../template/value/sim-cfn-template-value.js";
 import {
   samFunctionTemplateLogicalId,
@@ -48,7 +48,7 @@ function ratesHandler(request: RatesRequest): SimCfnTemplateValueRecord {
 /**
  * The implicit API the stack deployed, under the logical ID SAM gives it.
  */
-function implicitApi(stack: SimCfnStack): SimRestApi {
+function implicitApi(stack: SimCfnDeployedStack): SimRestApi {
   const api = stack.getResource(samImplicitRestApiLogicalId)
     ?.simResource as SimRestApi;
   assertNonNullable(api);

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-event-bridge-rule-event.iso.test.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-event-bridge-rule-event.iso.test.ts
@@ -10,7 +10,7 @@ import { describe, it } from "vitest";
 
 import { SimAws } from "../../../../aws/sim-aws.js";
 import type { SimEventRule } from "../../../../eventbridge/rule/sim-event-rule.js";
-import type { SimCfnStack } from "../../../stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../../stack/sim-cfn-deployed-stack.type.js";
 import type { SimCfnTemplateValueRecord } from "../../../template/value/sim-cfn-template-value.js";
 import {
   samFunctionTemplateLogicalId,
@@ -28,7 +28,7 @@ async function deployMatching(properties: {
   readonly events: SimCfnTemplateValueRecord;
   readonly resources?: SimCfnTemplateValueRecord;
   readonly received: unknown[];
-}): Promise<SimCfnStack> {
+}): Promise<SimCfnDeployedStack> {
   const stack = await properties.simAws.cloudFormation().deployTemplate({
     stackName: "rates-stack",
     template: simCfnSamFunctionTemplateFactory.make({

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-function-events.iso.test.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-function-events.iso.test.ts
@@ -7,7 +7,7 @@ import { describe, it } from "vitest";
 
 import { SimAws } from "../../../../aws/sim-aws.js";
 import type { SimCfnTemplateValueRecord } from "../../../template/value/sim-cfn-template-value.js";
-import type { SimCfnStack } from "../../../stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../../stack/sim-cfn-deployed-stack.type.js";
 import {
   samFunctionTemplateLogicalId,
   simCfnSamFunctionTemplateFactory,
@@ -21,7 +21,7 @@ async function deployedEvents(
   stackName: string,
   events: SimCfnTemplateValueRecord,
   resources: SimCfnTemplateValueRecord = {},
-): Promise<SimCfnStack> {
+): Promise<SimCfnDeployedStack> {
   const stack = await new SimAws().cloudFormation().deployTemplate({
     stackName,
     template: simCfnSamFunctionTemplateFactory.make({

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-schedule-event.iso.test.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-schedule-event.iso.test.ts
@@ -11,7 +11,7 @@ import { describe, it } from "vitest";
 import { SimFixedClock } from "../../../../../util/clock/sim-clock.js";
 import { SimAws } from "../../../../aws/sim-aws.js";
 import type { SimEventRule } from "../../../../eventbridge/rule/sim-event-rule.js";
-import type { SimCfnStack } from "../../../stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../../stack/sim-cfn-deployed-stack.type.js";
 import type { SimCfnTemplateValueRecord } from "../../../template/value/sim-cfn-template-value.js";
 import {
   samFunctionTemplateLogicalId,
@@ -36,7 +36,7 @@ async function deployScheduled(properties: {
   readonly simAws: SimAws;
   readonly events: SimCfnTemplateValueRecord;
   readonly received: unknown[];
-}): Promise<SimCfnStack> {
+}): Promise<SimCfnDeployedStack> {
   const stack = await properties.simAws.cloudFormation().deployTemplate({
     stackName: "reconciliation-stack",
     template: simCfnSamFunctionTemplateFactory.make({

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-schedule-v2-event.iso.test.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-schedule-v2-event.iso.test.ts
@@ -9,7 +9,7 @@ import { describe, it } from "vitest";
 
 import { SimFixedClock } from "../../../../../util/clock/sim-clock.js";
 import { SimAws } from "../../../../aws/sim-aws.js";
-import type { SimCfnStack } from "../../../stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../../stack/sim-cfn-deployed-stack.type.js";
 import type { SimCfnTemplateValueRecord } from "../../../template/value/sim-cfn-template-value.js";
 import {
   samFunctionTemplateLogicalId,
@@ -27,7 +27,7 @@ async function deployScheduled(properties: {
   readonly events: SimCfnTemplateValueRecord;
   readonly resources?: SimCfnTemplateValueRecord;
   readonly received: unknown[];
-}): Promise<SimCfnStack> {
+}): Promise<SimCfnDeployedStack> {
   const stack = await properties.simAws.cloudFormation().deployTemplate({
     stackName: "reporting-stack",
     template: simCfnSamFunctionTemplateFactory.make({

--- a/src/service/cloudformation/sam/sim-cfn-sam-http-api.iso.test.ts
+++ b/src/service/cloudformation/sam/sim-cfn-sam-http-api.iso.test.ts
@@ -13,7 +13,7 @@ import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
 import type { SimHttpApiStage } from "../../apigatewayv2/api/stage/sim-http-api-stage.js";
 import type { SimHttpApi } from "../../apigatewayv2/api/sim-http-api.js";
 import { SimAws } from "../../aws/sim-aws.js";
-import type { SimCfnStack } from "../stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../stack/sim-cfn-deployed-stack.type.js";
 import type { CfnTemplateBodyRecord } from "../template/sim-cfn-template.js";
 import {
   samHttpApiTemplateLogicalId,
@@ -38,7 +38,7 @@ const documentIntegration = {
 async function deployHttpApi(
   simAws: SimAws,
   template: CfnTemplateBodyRecord,
-): Promise<SimCfnStack> {
+): Promise<SimCfnDeployedStack> {
   const stack = await simAws
     .cloudFormation()
     .deployTemplate({ stackName: "orders-stack", template });
@@ -53,7 +53,7 @@ async function deployHttpApi(
  */
 async function requestApi(
   simAws: SimAws,
-  stack: SimCfnStack,
+  stack: SimCfnDeployedStack,
   path: string,
 ): Promise<Response> {
   const apiEndpoint = stack.outputs.get("ApiEndpoint")?.value;

--- a/src/service/cloudformation/sam/sim-cfn-sam-rest-api.iso.test.ts
+++ b/src/service/cloudformation/sam/sim-cfn-sam-rest-api.iso.test.ts
@@ -13,7 +13,7 @@ import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
 import type { SimRestApi } from "../../apigateway/api/sim-rest-api.js";
 import type { SimRestApiStage } from "../../apigateway/api/stage/sim-rest-api-stage.js";
 import { SimAws } from "../../aws/sim-aws.js";
-import type { SimCfnStack } from "../stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../stack/sim-cfn-deployed-stack.type.js";
 import type { CfnTemplateBodyRecord } from "../template/sim-cfn-template.js";
 import {
   samRestApiTemplateLogicalId,
@@ -28,7 +28,7 @@ import {
 async function deployRestApi(
   simAws: SimAws,
   template: CfnTemplateBodyRecord,
-): Promise<SimCfnStack> {
+): Promise<SimCfnDeployedStack> {
   const stack = await simAws
     .cloudFormation()
     .deployTemplate({ stackName: "orders-stack", template });
@@ -40,7 +40,7 @@ async function deployRestApi(
 /**
  * The API the stack deployed under the SAM logical ID.
  */
-function deployedApi(stack: SimCfnStack): SimRestApi {
+function deployedApi(stack: SimCfnDeployedStack): SimRestApi {
   const api = stack.getResource(samRestApiTemplateLogicalId)
     ?.simResource as SimRestApi;
   assertNonNullable(api);
@@ -53,7 +53,7 @@ function deployedApi(stack: SimCfnStack): SimRestApi {
  */
 async function requestApi(
   simAws: SimAws,
-  stack: SimCfnStack,
+  stack: SimCfnDeployedStack,
   path: string,
   stageName = samRestApiTemplateStageName,
 ): Promise<Response> {

--- a/src/service/cloudformation/sam/sim-cfn-sam-simple-table.iso.test.ts
+++ b/src/service/cloudformation/sam/sim-cfn-sam-simple-table.iso.test.ts
@@ -17,7 +17,7 @@ import { describe, it } from "vitest";
 import { SimAws } from "../../aws/sim-aws.js";
 import type { SimDynamoDbTableDescription } from "../../dynamodb/command/table/table.types.js";
 import type { CfnTemplateBodyRecord } from "../template/sim-cfn-template.js";
-import type { SimCfnStack } from "../stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../stack/sim-cfn-deployed-stack.type.js";
 import {
   samSimpleTableTemplateLogicalId,
   samSimpleTableTemplateTableName,
@@ -31,7 +31,7 @@ import {
 async function deploySimpleTable(
   simAws: SimAws,
   template: CfnTemplateBodyRecord,
-): Promise<SimCfnStack> {
+): Promise<SimCfnDeployedStack> {
   const stack = await simAws
     .cloudFormation()
     .deployTemplate({ stackName: "rates-stack", template });

--- a/src/service/cloudformation/sim-cloudformation.ts
+++ b/src/service/cloudformation/sim-cloudformation.ts
@@ -4,6 +4,7 @@ import type {
   SimCfnStack,
   SimCloudFormationStackName,
 } from "./stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "./stack/sim-cfn-deployed-stack.type.js";
 import type {
   BackgroundCompleter,
   BackgroundScheduler,
@@ -98,12 +99,10 @@ export class SimCloudFormation {
     });
   }
 
-  /**
-   * Get a simulated CloudFormation Stack by name.
-   */
+  /** Get a deployed simulated CloudFormation Stack by name. */
   getStackByName(
     stackName: SimCloudFormationStackName | string,
-  ): SimCfnStack | undefined {
+  ): SimCfnDeployedStack | undefined {
     return this.stacks.get(stackName as SimCloudFormationStackName);
   }
 
@@ -215,7 +214,7 @@ export class SimCloudFormation {
    */
   async deployTemplate(
     properties: SimCloudFormationCreateStackProperties,
-  ): Promise<SimCfnStack> {
+  ): Promise<SimCfnDeployedStack> {
     return await this.templateDeployer.deployTemplate(properties);
   }
 
@@ -225,7 +224,7 @@ export class SimCloudFormation {
    */
   async deployTemplateFile(
     properties: SimCloudFormationDeployTemplateFileProperties | string,
-  ): Promise<SimCfnStack> {
+  ): Promise<SimCfnDeployedStack> {
     return await this.templateDeployer.deployTemplateFile(properties);
   }
 
@@ -235,7 +234,7 @@ export class SimCloudFormation {
    */
   async deployCdkOut(
     properties: SimCloudFormationDeployCdkOutProperties | string,
-  ): Promise<ReadonlyMap<string, SimCfnStack>> {
+  ): Promise<ReadonlyMap<string, SimCfnDeployedStack>> {
     return await this.templateDeployer.deployCdkOut(properties);
   }
 
@@ -254,7 +253,7 @@ export class SimCloudFormation {
    */
   async updateTemplateFile(
     properties: SimCloudFormationDeployTemplateFileProperties | string,
-  ): Promise<SimCfnStack> {
+  ): Promise<SimCfnDeployedStack> {
     return await this.templateDeployer.updateTemplateFile(properties);
   }
 

--- a/src/service/cloudformation/stack/output/sim-cfn-stack-output.iso.test.ts
+++ b/src/service/cloudformation/stack/output/sim-cfn-stack-output.iso.test.ts
@@ -3,10 +3,11 @@ import { describe, it } from "vitest";
 /* oxlint-disable no-template-curly-in-string */
 import { assertIdentical, assertThrowsError } from "@kensio/smartass";
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimCfnStack } from "../sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../sim-cfn-deployed-stack.type.js";
 import type { CfnTemplateBodyRecord } from "../../template/sim-cfn-template.js";
 import type { SimCfnTemplateValue } from "../../template/value/sim-cfn-template-value.js";
 import { SimCfnTemplate } from "../../template/sim-cfn-template.js";
+import { deployedStackObject } from "../sim-cfn-stack.fixture.js";
 
 const stackName = "OutputAccessorStack";
 
@@ -47,7 +48,7 @@ describe("reading one sim CloudFormation Stack Output", () => {
     });
 
     // When an update resolves that Output to something else
-    await stack.update(
+    await deployedStackObject(stack).update(
       new SimCfnTemplate({
         stackName,
         template: templateBody({
@@ -177,7 +178,7 @@ function templateBody(
 /** A deployed Stack holding one Bucket and the Outputs a test declares. */
 async function deployedStack(
   outputs: OutputTemplates | undefined,
-): Promise<SimCfnStack> {
+): Promise<SimCfnDeployedStack> {
   const stack = await new SimAws()
     .cloudFormation()
     .deployTemplate({ stackName, template: templateBody(outputs) });

--- a/src/service/cloudformation/stack/sim-cfn-deployed-stack.type.ts
+++ b/src/service/cloudformation/stack/sim-cfn-deployed-stack.type.ts
@@ -1,0 +1,83 @@
+import type { SimCfnDeployedResource } from "../resource/sim-cfn-deployed-resource.type.js";
+import type { SimCfnIgnoredProperty } from "../resource/ignore/sim-cfn-ignored-property.type.js";
+import type { SimCfnStackOutput } from "./output/sim-cfn-stack-output.js";
+import type { SimCloudFormationStackStatus } from "./sim-cfn-stack.type.js";
+
+/**
+ * A Stack a deployment has put into simulated AWS.
+ *
+ * This is what `deployTemplate`, `deployTemplateFile`, `updateTemplateFile` and
+ * `deployCdkOut` answer with, and it holds what the caller that deployed a
+ * Stack reads back from it: its Outputs, its Resources, and the report of what
+ * the deployment skipped, made inert or retained.
+ *
+ * Driving the Stack through another CloudFormation operation belongs to the
+ * simulation. The class implementing this owns creating, updating and deleting
+ * a Stack, and it stays inside the package.
+ */
+export interface SimCfnDeployedStack {
+  /** What the Stack was deployed as. */
+  readonly stackName: string;
+
+  /** What CloudFormation last did to the Stack. */
+  readonly status: SimCloudFormationStackStatus;
+
+  /** What the operation the status reports failed with, where it failed. */
+  readonly error: Error | undefined;
+
+  /** Every resolved Stack Output whole, keyed by Output name. */
+  readonly outputs: ReadonlyMap<string, SimCfnStackOutput>;
+
+  /**
+   * One Stack Output's resolved value, as the string it is.
+   *
+   * An Output the template never declared throws, as does one that resolved to
+   * something other than a string. Read `outputs` for an Output whose value is
+   * a list, or for its description and export name.
+   */
+  output(outputKey: string): string;
+
+  /**
+   * One Stack Resource, by logical ID or by the CDK construct ID a synthesized
+   * logical ID was generated from.
+   *
+   * A caller that bound a handler by construct ID can ask the Stack what it
+   * bound, without holding the hash CDK appended.
+   */
+  getResource(logicalId: string): SimCfnDeployedResource | undefined;
+
+  /** Properties the deployment created Resources without acting on. */
+  readonly ignoredProperties: readonly SimCfnIgnoredProperty[];
+
+  /** Resources skipped because their sim implementation is unavailable. */
+  readonly skippedResources: readonly SimCfnDeployedResource[];
+
+  /** Resources deliberately created as nothing, because nothing reads them. */
+  readonly inertResources: readonly SimCfnDeployedResource[];
+
+  /** Resources a teardown recorded in place of deleting them. */
+  readonly skippedResourceDeletions: readonly SimCfnDeployedResource[];
+
+  /** Resources a teardown left in simulated AWS, as their policy says to. */
+  readonly retainedResources: readonly SimCfnDeployedResource[];
+
+  /** Wait for the deployment to reach `CREATE_COMPLETE` or fail. */
+  waitForDeployComplete(): Promise<void>;
+
+  /** Wait for an update to reach `UPDATE_COMPLETE` or fail. */
+  waitForUpdateComplete(): Promise<void>;
+
+  /** Wait for a delete to reach `DELETE_COMPLETE` or fail. */
+  waitForDeleteComplete(): Promise<void>;
+
+  /**
+   * Start deleting the Stack and everything it deployed.
+   *
+   * Returns once the deletion has been asked for. Wait for it with
+   * `waitForDeleteComplete()`, or use `teardown()` for both at once.
+   */
+  delete(): Promise<void>;
+
+  /** Delete the Stack and everything it deployed, and wait for it to finish. */
+  teardown(): Promise<void>;
+}

--- a/src/service/cloudformation/stack/sim-cfn-deployed-stack.type.ts
+++ b/src/service/cloudformation/stack/sim-cfn-deployed-stack.type.ts
@@ -7,13 +7,13 @@ import type { SimCloudFormationStackStatus } from "./sim-cfn-stack.type.js";
  * A Stack a deployment has put into simulated AWS.
  *
  * This is what `deployTemplate`, `deployTemplateFile`, `updateTemplateFile` and
- * `deployCdkOut` answer with, and it holds what the caller that deployed a
- * Stack reads back from it: its Outputs, its Resources, and the report of what
- * the deployment skipped, made inert or retained.
+ * `deployCdkOut` answer with. It holds the Stack's Outputs, its Resources, the
+ * report of what the deployment skipped, made inert or retained, and the two
+ * operations a caller asks for itself, which are deleting and tearing down.
  *
- * Driving the Stack through another CloudFormation operation belongs to the
- * simulation. The class implementing this owns creating, updating and deleting
- * a Stack, and it stays inside the package.
+ * Deploying a Stack and applying a changed template to one belong to the
+ * simulation. The class implementing this owns both, along with the Resource
+ * map and the parsed template, and it stays inside the package.
  */
 export interface SimCfnDeployedStack {
   /** What the Stack was deployed as. */

--- a/src/service/cloudformation/stack/sim-cfn-stack.fixture.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack.fixture.ts
@@ -1,0 +1,28 @@
+import type { SimCfnDeployedResource } from "../resource/sim-cfn-deployed-resource.type.js";
+import type { SimCfnResource } from "../resource/sim-cfn-resource.js";
+import type { SimCfnDeployedStack } from "./sim-cfn-deployed-stack.type.js";
+import type { SimCfnStack } from "./sim-cfn-stack.js";
+
+/**
+ * The Stack object behind what a deployment answered with.
+ *
+ * A deployment answers with `SimCfnDeployedStack`, the surface a consumer of
+ * this package reads. A test in this package that drives the Stack's own
+ * lifecycle, or reads the Resource map the deployment builds, wants the object
+ * itself, and this says so where it happens.
+ */
+export function deployedStackObject(stack: SimCfnDeployedStack): SimCfnStack {
+  return stack as SimCfnStack;
+}
+
+/**
+ * The Resource object behind one a deployed Stack answered with.
+ *
+ * The counterpart of `deployedStackObject`, for a test reaching the Resource
+ * members the deployment drives.
+ */
+export function deployedResourceObject(
+  resource: SimCfnDeployedResource,
+): SimCfnResource {
+  return resource as SimCfnResource;
+}

--- a/src/service/cloudformation/stack/sim-cfn-stack.iso.test.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack.iso.test.ts
@@ -10,6 +10,7 @@ import {
 import { SimAws } from "../../aws/sim-aws.js";
 import { CreateStackCommand } from "@aws-sdk/client-cloudformation";
 import { jsonStringify } from "../../../util/type-guard/json.js";
+import { deployedStackObject } from "./sim-cfn-stack.fixture.js";
 
 describe("SimCfnStack", () => {
   it("deploys an empty Stack from the default SimAws CloudFormation scope", async () => {
@@ -25,11 +26,11 @@ describe("SimCfnStack", () => {
     const stack = cloudFormation.getStackByName("TestStack");
 
     assertIdentical(stackCreation.StackId, "TestStack");
-    assertIdentical(stack?.lifecycle.status, "CREATE_IN_PROGRESS");
+    assertIdentical(stack?.status, "CREATE_IN_PROGRESS");
 
     await simAws.backgroundTasksComplete();
 
-    assertIdentical(stack.lifecycle.status, "CREATE_COMPLETE");
+    assertIdentical(stack.status, "CREATE_COMPLETE");
   });
 
   it("deploys a template through SimCloudFormation", async () => {
@@ -39,7 +40,7 @@ describe("SimCfnStack", () => {
       template: { Resources: {} },
     });
 
-    assertIdentical(stack.lifecycle.status, "CREATE_COMPLETE");
+    assertIdentical(stack.status, "CREATE_COMPLETE");
   });
 
   it("deploys a template through SimCloudFormation with Parameter values", async () => {
@@ -69,10 +70,10 @@ describe("SimCfnStack", () => {
       },
     });
 
-    const resource = stack.resources.get("TestBucket");
+    const resource = stack.getResource("TestBucket");
     assertNonNullable(resource);
     assertIdentical(resource.properties["BucketName"], "override-bucket-name");
-    assertIdentical(stack.lifecycle.status, "CREATE_COMPLETE");
+    assertIdentical(stack.status, "CREATE_COMPLETE");
   });
 
   it("deploys a template in a specific Account's default Region scope", async () => {
@@ -91,7 +92,7 @@ describe("SimCfnStack", () => {
       cloudFormation.accountRegionScope.regionName,
       simAws.defaultRegionName,
     );
-    assertIdentical(stack.lifecycle.status, "CREATE_COMPLETE");
+    assertIdentical(stack.status, "CREATE_COMPLETE");
   });
 
   it("deploys a template in a specific Region scope", async () => {
@@ -103,7 +104,7 @@ describe("SimCfnStack", () => {
     });
 
     assertIdentical(cloudFormation.accountRegionScope.regionName, "eu-west-1");
-    assertIdentical(stack.lifecycle.status, "CREATE_COMPLETE");
+    assertIdentical(stack.status, "CREATE_COMPLETE");
   });
 
   it("deploys a template in a specific Account and Region scope", async () => {
@@ -125,7 +126,7 @@ describe("SimCfnStack", () => {
       cloudFormation.accountRegionScope.regionName,
       "ap-southeast-2",
     );
-    assertIdentical(stack.lifecycle.status, "CREATE_COMPLETE");
+    assertIdentical(stack.status, "CREATE_COMPLETE");
   });
 
   it("fails deployment when Resource dependencies cannot be resolved", async () => {
@@ -155,10 +156,10 @@ describe("SimCfnStack", () => {
 
     await simAws.backgroundTasksComplete();
 
-    assertIdentical(stack.lifecycle.status, "CREATE_FAILED");
-    assertNonNullable(stack.lifecycle.error);
+    assertIdentical(stack.status, "CREATE_FAILED");
+    assertNonNullable(stack.error);
     assertIdentical(
-      stack.lifecycle.error.message,
+      stack.error.message,
       "Could not resolve simulated CloudFormation Resource dependencies in Stack TestStack",
     );
   });
@@ -177,7 +178,7 @@ describe("SimCfnStack", () => {
       },
     });
 
-    const resource = stack.resources.get("WaitHandle");
+    const resource = stack.getResource("WaitHandle");
 
     assertNonNullable(resource);
     assertIdentical(resource.attributeValue("Arn"), "WaitHandle.Arn");
@@ -205,10 +206,10 @@ describe("SimCfnStack", () => {
 
     const stack = cloudFormation.getStackByName("TestStack");
     assertNonNullable(stack);
-    assertIdentical(stack.lifecycle.status, "CREATE_IN_PROGRESS");
+    assertIdentical(stack.status, "CREATE_IN_PROGRESS");
 
     const error = await assertThrowsErrorAsync(async () => {
-      await stack.deploy();
+      await deployedStackObject(stack).deploy();
     });
 
     assertIdentical(
@@ -218,7 +219,7 @@ describe("SimCfnStack", () => {
 
     await simAws.backgroundTasksComplete();
 
-    assertIdentical(stack.lifecycle.status, "CREATE_COMPLETE");
+    assertIdentical(stack.status, "CREATE_COMPLETE");
   });
 
   it("records unsupported Resources as skipped", async () => {
@@ -237,7 +238,7 @@ describe("SimCfnStack", () => {
 
     const skippedResource = stack.skippedResources[0];
 
-    assertIdentical(stack.lifecycle.status, "CREATE_COMPLETE");
+    assertIdentical(stack.status, "CREATE_COMPLETE");
     assertArrayLength(stack.skippedResources, 1);
     assertNonNullable(skippedResource);
     assertIdentical(skippedResource.logicalId, "TestInstance");

--- a/src/service/cloudformation/stack/sim-cfn-stack.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack.ts
@@ -15,6 +15,7 @@ import { SimCfnStackDeploymentLifecycle } from "./deploy/sim-cfn-stack-deploymen
 import { SimCfnStackResourceOperations } from "./sim-cfn-stack-resource-operations.js";
 import { SimCfnStackUpdateLifecycle } from "./update/sim-cfn-stack-update-lifecycle.js";
 import type { SimCfnStackOutput } from "./output/sim-cfn-stack-output.js";
+import type { SimCfnDeployedStack } from "./sim-cfn-deployed-stack.type.js";
 import { SimCfnStackOutputs } from "./output/sim-cfn-stack-outputs.js";
 import { SimCfnStackOutputLookup } from "./output/sim-cfn-stack-output-lookup.js";
 import { SimCfnStackResourceReport } from "./report/sim-cfn-stack-resource-report.js";
@@ -42,7 +43,7 @@ import type {
  *   simulated AWS, and SimCfnStackUpdater does some of each at once against a
  *   changed template.
  */
-export class SimCfnStack {
+export class SimCfnStack implements SimCfnDeployedStack {
   public readonly lifecycle: SimCfnStackDeploymentLifecycle;
   public readonly updating: SimCfnStackUpdateLifecycle;
   public readonly deletion: SimCfnStackDeletionLifecycle;

--- a/src/service/cloudformation/stack/teardown/sim-cfn-stack-teardown.iso.test.ts
+++ b/src/service/cloudformation/stack/teardown/sim-cfn-stack-teardown.iso.test.ts
@@ -10,6 +10,7 @@ import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { SimCfnResource } from "../../resource/sim-cfn-resource.js";
 import { SimCfnStackResourceDeleter } from "./sim-cfn-stack-resource-deleter.js";
+import { deployedResourceObject } from "../sim-cfn-stack.fixture.js";
 
 describe("SimCfnStack teardown", () => {
   it("deletes Resources in reverse dependency order", async () => {
@@ -40,7 +41,7 @@ describe("SimCfnStack teardown", () => {
     // Then every Resource reports a completed deletion.
     for (const logicalId of ["First", "Second", "Third"]) {
       assertIdentical(
-        stack.resources.get(logicalId)?.status,
+        stack.getResource(logicalId)?.status,
         "DELETE_COMPLETE",
         `${logicalId} status`,
       );
@@ -89,13 +90,10 @@ describe("SimCfnStack teardown", () => {
     // Then both are gone, which only happens if the policy went first: taking
     // a policy off a Bucket that is not there is refused by S3.
     assertIdentical(
-      stack.resources.get("DataBucketPolicy")?.status,
+      stack.getResource("DataBucketPolicy")?.status,
       "DELETE_COMPLETE",
     );
-    assertIdentical(
-      stack.resources.get("DataBucket")?.status,
-      "DELETE_COMPLETE",
-    );
+    assertIdentical(stack.getResource("DataBucket")?.status, "DELETE_COMPLETE");
   });
 
   it("steps over a Resource whose type was never created", async () => {
@@ -119,7 +117,7 @@ describe("SimCfnStack teardown", () => {
 
     // Then the skipped Resource is delete-complete without any service being
     // asked to delete something it never made.
-    assertIdentical(stack.resources.get("Network")?.status, "DELETE_COMPLETE");
+    assertIdentical(stack.getResource("Network")?.status, "DELETE_COMPLETE");
     assertArrayLength(stack.skippedResourceDeletions, 0);
   });
 
@@ -137,11 +135,13 @@ describe("SimCfnStack teardown", () => {
     });
     await stack.waitForDeployComplete();
 
-    const resource = stack.resources.get("Handle");
+    const resource = stack.getResource("Handle");
     assertNonNullable(resource);
 
     // When that Resource records a skipped deletion.
-    resource.markDeleteSkipped("nothing deletes a WaitConditionHandle");
+    deployedResourceObject(resource).markDeleteSkipped(
+      "nothing deletes a WaitConditionHandle",
+    );
 
     // Then the Stack reports it, so a teardown says what it left behind.
     assertArrayLength(stack.skippedResourceDeletions, 1);

--- a/src/service/cloudformation/stack/update/sim-cfn-stack-update.iso.test.ts
+++ b/src/service/cloudformation/stack/update/sim-cfn-stack-update.iso.test.ts
@@ -14,6 +14,7 @@ import {
 import { SimAws } from "../../../aws/sim-aws.js";
 import { jsonStringify } from "../../../../util/type-guard/json.js";
 import { SimCloudFormationValidationError } from "../../error/sim-cloudformation.error.js";
+import { deployedStackObject } from "../sim-cfn-stack.fixture.js";
 
 const parameterisedTemplate = {
   Parameters: { BucketSuffix: { Type: "String", Default: "one" } },
@@ -173,7 +174,10 @@ describe("simulated CloudFormation Stack update", () => {
     assertNonNullable(stack);
 
     assertIdentical(stack.status, "UPDATE_COMPLETE");
-    assertIdentical(stack.template["Description"], "Where the reports go");
+    assertIdentical(
+      deployedStackObject(stack).template["Description"],
+      "Where the reports go",
+    );
     assertNonNullable(simAws.s3().getSimBucketByName("reports-one"));
   });
 

--- a/src/service/cloudformation/template/condition/sim-cfn-resource-conditions.iso.test.ts
+++ b/src/service/cloudformation/template/condition/sim-cfn-resource-conditions.iso.test.ts
@@ -1,6 +1,6 @@
 import {
   assertArrayLength,
-  assertFalse,
+  assertUndefined,
   assertIdentical,
   assertNonNullable,
   assertThrowsErrorAsync,
@@ -23,11 +23,11 @@ describe("SimCfnStack Resource Condition", () => {
     });
 
     // Then that Resource is not in the Stack at all, unlike a skipped one.
-    assertFalse(stack.resources.has("Backups"));
+    assertUndefined(stack.getResource("Backups"));
     assertArrayLength(stack.skippedResources, 0);
 
     // And the Resource the Condition kept is created and named for dev.
-    const site = stack.resources.get("Site");
+    const site = stack.getResource("Site");
     assertNonNullable(site, "Site Resource");
     assertTrue(site.deployed);
     assertIdentical(
@@ -48,7 +48,7 @@ describe("SimCfnStack Resource Condition", () => {
     });
 
     // Then both Buckets are created, and the Fn::If took its true branch.
-    assertTrue(stack.resources.has("Backups"));
+    assertTrue(stack.getResource("Backups") !== undefined);
     assertIdentical(simAws.s3().getSimBucketByName("site")?.bucketName, "site");
   });
 
@@ -133,7 +133,7 @@ describe("SimCfnStack Resource Condition", () => {
     });
 
     // Then the branch that was not taken never had to resolve.
-    assertIdentical(stack.lifecycle.status, "CREATE_COMPLETE");
+    assertIdentical(stack.status, "CREATE_COMPLETE");
     assertIdentical(
       simAws.s3().getSimBucketByName("site-dev")?.bucketName,
       "site-dev",

--- a/src/service/cloudformation/template/node/fn/get-att/sim-cfn-fn-get-att.iso.test.ts
+++ b/src/service/cloudformation/template/node/fn/get-att/sim-cfn-fn-get-att.iso.test.ts
@@ -53,8 +53,8 @@ describe("CloudFormation Fn::GetAtt Resource value", () => {
     assertIdentical(sourceBucket.bucketName, "source-bucket");
     assertIdentical(derivedBucket.bucketName, "source-bucket.foo-derived");
 
-    const sourceResource = stack.resources.get("SourceBucket");
-    const derivedResource = stack.resources.get("DerivedBucket");
+    const sourceResource = stack.getResource("SourceBucket");
+    const derivedResource = stack.getResource("DerivedBucket");
 
     assertNonNullable(sourceResource);
     assertNonNullable(derivedResource);
@@ -138,8 +138,8 @@ describe("CloudFormation Fn::GetAtt Resource value", () => {
     });
 
     // Then dependency discovery waits for SourceBucket before DerivedBucket.
-    const sourceResource = stack.resources.get("SourceBucket");
-    const derivedResource = stack.resources.get("DerivedBucket");
+    const sourceResource = stack.getResource("SourceBucket");
+    const derivedResource = stack.getResource("DerivedBucket");
     const derivedBucket = simAws
       .s3()
       .getSimBucketByName("source-bucket.foo-derived");

--- a/src/service/cloudformation/template/node/fn/join/sim-cfn-fn-join.iso.test.ts
+++ b/src/service/cloudformation/template/node/fn/join/sim-cfn-fn-join.iso.test.ts
@@ -38,7 +38,7 @@ describe("CloudFormation Fn::Join Resource value", () => {
     assertInstanceOf(bucket, SimS3Bucket);
     assertIdentical(bucket.bucketName, "my-test-bucket");
 
-    const resource = stack.resources.get("TestBucket");
+    const resource = stack.getResource("TestBucket");
 
     assertNonNullable(resource);
     assertIdentical(resource.status, "CREATE_COMPLETE");
@@ -206,7 +206,7 @@ describe("CloudFormation Fn::Join Resource value", () => {
     });
 
     // Then the Resource is created with the Fn::Join value already resolved.
-    const resource = stack.resources.get("WaitHandle");
+    const resource = stack.getResource("WaitHandle");
 
     assertNonNullable(resource);
     assertIdentical(resource.status, "CREATE_COMPLETE");

--- a/src/service/cloudformation/template/node/fn/select/sim-cfn-fn-select.iso.test.ts
+++ b/src/service/cloudformation/template/node/fn/select/sim-cfn-fn-select.iso.test.ts
@@ -7,6 +7,7 @@ import { describe, it } from "vitest";
 import { SimAws } from "../../../../../aws/sim-aws.js";
 import { SimCfnTemplate } from "../../../sim-cfn-template.js";
 import type { SimCfnTemplateValue } from "../../../value/sim-cfn-template-value.js";
+import { deployedStackObject } from "../../../../stack/sim-cfn-stack.fixture.js";
 
 describe("SimCfnTemplate Fn::Select", () => {
   it("picks a value from a literal list", () => {
@@ -205,9 +206,10 @@ describe("SimCfnTemplate Fn::Select", () => {
     await stack.waitForDeployComplete();
 
     // Then the Fn::GetAtt inside made the read Resource a dependency.
-    assertArrayEquals(stack.getResource("LogsBucket")?.dependencies(), [
-      "SiteBucket",
-    ]);
+    assertArrayEquals(
+      deployedStackObject(stack).getResource("LogsBucket")?.dependencies(),
+      ["SiteBucket"],
+    );
 
     // And the Bucket was created with the selected part of the domain name.
     assertNonNullable(

--- a/src/service/cloudformation/template/node/fn/sub/sim-cfn-fn-sub-literal.iso.test.ts
+++ b/src/service/cloudformation/template/node/fn/sub/sim-cfn-fn-sub-literal.iso.test.ts
@@ -101,7 +101,7 @@ describe("CloudFormation Fn::Sub literals", () => {
       template: subTemplate,
     });
 
-    const resource = stack.resources.get("WaitHandle");
+    const resource = stack.getResource("WaitHandle");
 
     assertNonNullable(resource);
     assertIdentical(resource.status, "CREATE_COMPLETE");

--- a/src/service/cloudformation/template/node/fn/sub/sim-cfn-fn-sub-referential.iso.test.ts
+++ b/src/service/cloudformation/template/node/fn/sub/sim-cfn-fn-sub-referential.iso.test.ts
@@ -45,7 +45,7 @@ describe("CloudFormation Fn::Sub Resource referential", () => {
     assertInstanceOf(bucket, SimS3Bucket);
     assertIdentical(bucket.bucketName, "my-prod-bucket");
 
-    const resource = stack.resources.get("TestBucket");
+    const resource = stack.getResource("TestBucket");
 
     assertNonNullable(resource);
     assertIdentical(resource.status, "CREATE_COMPLETE");
@@ -93,8 +93,8 @@ describe("CloudFormation Fn::Sub Resource referential", () => {
     assertIdentical(sourceBucket.bucketName, "source-bucket");
     assertIdentical(derivedBucket.bucketName, "source-bucket-derived");
 
-    const sourceResource = stack.resources.get("SourceBucket");
-    const derivedResource = stack.resources.get("DerivedBucket");
+    const sourceResource = stack.getResource("SourceBucket");
+    const derivedResource = stack.getResource("DerivedBucket");
 
     assertIdentical(sourceResource?.status, "CREATE_COMPLETE");
     assertIdentical(derivedResource?.status, "CREATE_COMPLETE");
@@ -152,8 +152,8 @@ describe("CloudFormation Fn::Sub Resource referential", () => {
     assertIdentical(sourceBucket.bucketName, "source-bucket");
     assertIdentical(derivedBucket.bucketName, "source-bucket-derived");
 
-    const sourceResource = stack.resources.get("SourceBucket");
-    const derivedResource = stack.resources.get("DerivedBucket");
+    const sourceResource = stack.getResource("SourceBucket");
+    const derivedResource = stack.getResource("DerivedBucket");
 
     assertNonNullable(sourceResource);
     assertNonNullable(derivedResource);
@@ -206,8 +206,8 @@ describe("CloudFormation Fn::Sub Resource referential", () => {
     assertIdentical(sourceBucket.bucketName, "source-bucket");
     assertIdentical(derivedBucket.bucketName, "source-bucket.foo-derived");
 
-    const sourceResource = stack.resources.get("SourceBucket");
-    const derivedResource = stack.resources.get("DerivedBucket");
+    const sourceResource = stack.getResource("SourceBucket");
+    const derivedResource = stack.getResource("DerivedBucket");
 
     assertNonNullable(sourceResource);
     assertNonNullable(derivedResource);

--- a/src/service/cloudformation/template/node/sim-cfn-ref.iso.test.ts
+++ b/src/service/cloudformation/template/node/sim-cfn-ref.iso.test.ts
@@ -45,8 +45,8 @@ describe("CloudFormation Ref Resource value", () => {
     assertInstanceOf(bucket, SimS3Bucket);
     assertIdentical(bucket.bucketName, "source-bucket");
 
-    const sourceResource = stack.resources.get("SourceBucket");
-    const waitHandleResource = stack.resources.get("WaitHandle");
+    const sourceResource = stack.getResource("SourceBucket");
+    const waitHandleResource = stack.getResource("WaitHandle");
 
     assertNonNullable(sourceResource);
     assertNonNullable(waitHandleResource);
@@ -108,8 +108,8 @@ describe("CloudFormation Ref Resource value", () => {
     assertIdentical(sourceBucket.bucketName, "source-bucket");
     assertIdentical(derivedBucket.bucketName, "source-bucket-derived");
 
-    const sourceResource = stack.resources.get("SourceBucket");
-    const derivedResource = stack.resources.get("DerivedBucket");
+    const sourceResource = stack.getResource("SourceBucket");
+    const derivedResource = stack.getResource("DerivedBucket");
 
     assertNonNullable(sourceResource);
     assertNonNullable(derivedResource);
@@ -173,8 +173,8 @@ describe("CloudFormation Ref Resource value", () => {
     assertIdentical(sourceBucket.bucketName, "source-bucket");
     assertIdentical(derivedBucket.bucketName, "prefix-source-bucket-derived");
 
-    const sourceResource = stack.resources.get("SourceBucket");
-    const derivedResource = stack.resources.get("DerivedBucket");
+    const sourceResource = stack.getResource("SourceBucket");
+    const derivedResource = stack.getResource("DerivedBucket");
 
     assertNonNullable(sourceResource);
     assertNonNullable(derivedResource);
@@ -238,9 +238,9 @@ describe("CloudFormation Ref Resource value", () => {
     assertIdentical(secondBucket.bucketName, "bucket-a-b");
     assertIdentical(combinedBucket.bucketName, "bucket-a-bucket-a-b");
 
-    const firstResource = stack.resources.get("FirstBucket");
-    const secondResource = stack.resources.get("SecondBucket");
-    const combinedResource = stack.resources.get("CombinedBucket");
+    const firstResource = stack.getResource("FirstBucket");
+    const secondResource = stack.getResource("SecondBucket");
+    const combinedResource = stack.getResource("CombinedBucket");
 
     assertNonNullable(firstResource);
     assertNonNullable(secondResource);

--- a/src/service/cloudformation/template/parse/fn/get-att/sim-cfn-fn-get-att-parser.iso.test.ts
+++ b/src/service/cloudformation/template/parse/fn/get-att/sim-cfn-fn-get-att-parser.iso.test.ts
@@ -51,8 +51,8 @@ describe("CloudFormation Fn::GetAtt parser", () => {
     assertIdentical(sourceBucket.bucketName, "source-bucket");
     assertIdentical(derivedBucket.bucketName, "source-bucket.foo-derived");
 
-    const sourceResource = stack.resources.get("SourceBucket");
-    const derivedResource = stack.resources.get("DerivedBucket");
+    const sourceResource = stack.getResource("SourceBucket");
+    const derivedResource = stack.getResource("DerivedBucket");
 
     assertNonNullable(sourceResource);
     assertNonNullable(derivedResource);
@@ -94,8 +94,8 @@ describe("CloudFormation Fn::GetAtt parser", () => {
     const derivedBucket = simAws
       .s3()
       .getSimBucketByName("source-bucket.foo-derived");
-    const sourceResource = stack.resources.get("SourceBucket");
-    const derivedResource = stack.resources.get("DerivedBucket");
+    const sourceResource = stack.getResource("SourceBucket");
+    const derivedResource = stack.getResource("DerivedBucket");
 
     assertNonNullable(derivedBucket);
     assertInstanceOf(derivedBucket, SimS3Bucket);

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro.iso.test.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro.iso.test.ts
@@ -11,6 +11,10 @@ import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
 import { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
+import {
+  deployedResourceObject,
+  deployedStackObject,
+} from "../../../cloudformation/stack/sim-cfn-stack.fixture.js";
 
 describe("CloudFront CloudFormation Distribution", () => {
   it("creates a CloudFront Distribution from AWS::CloudFront::Distribution", async () => {
@@ -145,10 +149,11 @@ describe("CloudFront CloudFormation Distribution", () => {
 
     assertTypeString(distributionId);
 
-    const resolvedWaitHandleProperties =
-      await waitHandleResource.resolvedProperties({
-        resources: stack.resources,
-      });
+    const resolvedWaitHandleProperties = await deployedResourceObject(
+      waitHandleResource,
+    ).resolvedProperties({
+      resources: deployedStackObject(stack).resources,
+    });
 
     assertIdentical(
       resolvedWaitHandleProperties["DistributionId"],

--- a/src/service/cloudfront/cfn/origin-access-control/sim-cfn-cf-oac-refusals.iso.test.ts
+++ b/src/service/cloudfront/cfn/origin-access-control/sim-cfn-cf-oac-refusals.iso.test.ts
@@ -88,7 +88,7 @@ describe("AWS::CloudFront::OriginAccessControl refusals", () => {
     });
     await stack.waitForDeployComplete();
 
-    const originAccessControl = stack.resources.get("SiteOac")?.simResource;
+    const originAccessControl = stack.getResource("SiteOac")?.simResource;
     assertInstanceOf(originAccessControl, SimCloudFrontOriginAccessControl);
 
     // When a Distribution attaches it to a custom Origin.

--- a/src/service/cloudfront/cfn/origin-access-control/sim-cfn-cf-oac.iso.test.ts
+++ b/src/service/cloudfront/cfn/origin-access-control/sim-cfn-cf-oac.iso.test.ts
@@ -74,7 +74,7 @@ describe("AWS::CloudFront::OriginAccessControl", () => {
 
     // Then the Resource made a simulated origin access control, which sim
     // CloudFront holds by ID.
-    const originAccessControl = stack.resources.get("SiteOac")?.simResource;
+    const originAccessControl = stack.getResource("SiteOac")?.simResource;
     assertInstanceOf(originAccessControl, SimCloudFrontOriginAccessControl);
     assertIdentical(
       simAws.cloudFront().getOriginAccessControlById(originAccessControl.id),
@@ -92,7 +92,7 @@ describe("AWS::CloudFront::OriginAccessControl", () => {
       .deployTemplate({ stackName: "site-stack", template });
     await stack.waitForDeployComplete();
 
-    const originAccessControl = stack.resources.get("SiteOac")?.simResource;
+    const originAccessControl = stack.getResource("SiteOac")?.simResource;
     assertInstanceOf(originAccessControl, SimCloudFrontOriginAccessControl);
 
     // Then both Outputs carry the origin access control's ID, which is what an
@@ -109,13 +109,14 @@ describe("AWS::CloudFront::OriginAccessControl", () => {
       .deployTemplate({ stackName: "site-stack", template });
     await stack.waitForDeployComplete();
 
-    const originAccessControl = stack.resources.get("SiteOac")?.simResource;
+    const originAccessControl = stack.getResource("SiteOac")?.simResource;
     assertInstanceOf(originAccessControl, SimCloudFrontOriginAccessControl);
 
     // Then the Origin holds the origin access control itself, rather than the
     // ID the template wrote.
-    const distribution = stack.resources.get("SiteDistribution")
-      ?.simResource as SimCloudFrontDistribution | undefined;
+    const distribution = stack.getResource("SiteDistribution")?.simResource as
+      | SimCloudFrontDistribution
+      | undefined;
     assertNonNullable(distribution);
 
     const origin = distribution.getOrigin("SiteOrigin");
@@ -131,11 +132,12 @@ describe("AWS::CloudFront::OriginAccessControl", () => {
       .deployTemplate({ stackName: "site-stack", template });
     await stack.waitForDeployComplete();
 
-    const originAccessControl = stack.resources.get("SiteOac")?.simResource;
+    const originAccessControl = stack.getResource("SiteOac")?.simResource;
     assertInstanceOf(originAccessControl, SimCloudFrontOriginAccessControl);
 
-    const distribution = stack.resources.get("SiteDistribution")
-      ?.simResource as SimCloudFrontDistribution | undefined;
+    const distribution = stack.getResource("SiteDistribution")?.simResource as
+      | SimCloudFrontDistribution
+      | undefined;
     assertNonNullable(distribution);
 
     // When GetDistribution is called.
@@ -191,8 +193,9 @@ describe("AWS::CloudFront::OriginAccessControl", () => {
 
     // Then the Origin is created with none, rather than the empty ID being
     // looked up and refused.
-    const distribution = stack.resources.get("SiteDistribution")
-      ?.simResource as SimCloudFrontDistribution | undefined;
+    const distribution = stack.getResource("SiteDistribution")?.simResource as
+      | SimCloudFrontDistribution
+      | undefined;
     assertNonNullable(distribution);
 
     const origin = distribution.getOrigin("SiteOrigin");
@@ -208,7 +211,7 @@ describe("AWS::CloudFront::OriginAccessControl", () => {
       .deployTemplate({ stackName: "site-stack", template });
     await stack.waitForDeployComplete();
 
-    const originAccessControl = stack.resources.get("SiteOac")?.simResource;
+    const originAccessControl = stack.getResource("SiteOac")?.simResource;
     assertInstanceOf(originAccessControl, SimCloudFrontOriginAccessControl);
 
     // When the Stack's Resources are torn down.
@@ -218,6 +221,6 @@ describe("AWS::CloudFront::OriginAccessControl", () => {
     assertUndefined(
       simAws.cloudFront().getOriginAccessControlById(originAccessControl.id),
     );
-    assertIdentical(stack.resources.get("SiteOac")?.status, "DELETE_COMPLETE");
+    assertIdentical(stack.getResource("SiteOac")?.status, "DELETE_COMPLETE");
   });
 });

--- a/src/service/cloudfront/cfn/sim-cfn-cloudfront-teardown.iso.test.ts
+++ b/src/service/cloudfront/cfn/sim-cfn-cloudfront-teardown.iso.test.ts
@@ -68,8 +68,9 @@ describe("CloudFront CloudFormation Resource teardown", () => {
       .deployTemplate({ stackName: "site-stack", template });
     await stack.waitForDeployComplete();
 
-    const distribution = stack.resources.get("SiteDistribution")
-      ?.simResource as SimCloudFrontDistribution | undefined;
+    const distribution = stack.getResource("SiteDistribution")?.simResource as
+      | SimCloudFrontDistribution
+      | undefined;
     assertNonNullable(distribution);
     // The template asked for an enabled Distribution, so a teardown that only
     // called DeleteDistribution would be refused.
@@ -83,7 +84,7 @@ describe("CloudFront CloudFormation Resource teardown", () => {
       simAws.cloudFront().getSimDistributionById(distribution.distributionId),
     );
     assertIdentical(
-      stack.resources.get("SiteDistribution")?.status,
+      stack.getResource("SiteDistribution")?.status,
       "DELETE_COMPLETE",
     );
   });
@@ -110,7 +111,7 @@ describe("CloudFront CloudFormation Resource teardown", () => {
       simAws.cloudFront().getCloudFrontFunctionByName(functionName),
     );
     assertIdentical(
-      stack.resources.get("SiteFunction")?.status,
+      stack.getResource("SiteFunction")?.status,
       "DELETE_COMPLETE",
     );
   });

--- a/src/service/cloudwatch/cfn/sim-cfn-alarm.iso.test.ts
+++ b/src/service/cloudwatch/cfn/sim-cfn-alarm.iso.test.ts
@@ -18,7 +18,7 @@ import { describe, it } from "vitest";
 
 import { BackgroundTasks } from "../../../util/background/background.js";
 import { SimAws } from "../../aws/sim-aws.js";
-import type { SimCfnStack } from "../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
 import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
 
 const startedAt = new Date("2026-08-16T09:00:00.000Z");
@@ -45,7 +45,7 @@ const failingOrders: SimCfnTemplateValueRecord = {
 async function deployAlarm(
   properties: SimCfnTemplateValueRecord,
   simAws: SimAws = new SimAws(),
-): Promise<{ readonly simAws: SimAws; readonly stack: SimCfnStack }> {
+): Promise<{ readonly simAws: SimAws; readonly stack: SimCfnDeployedStack }> {
   const stack = await simAws.cloudFormation().deployTemplate({
     stackName: "orders",
     template: {

--- a/src/service/cognito/cfn/sim-cfn-cognito-teardown.iso.test.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-teardown.iso.test.ts
@@ -39,7 +39,7 @@ describe("Cognito CloudFormation Resource teardown", () => {
     });
     await stack.waitForDeployComplete();
 
-    const userPoolId = stack.resources.get("AppPool")?.refValue;
+    const userPoolId = stack.getResource("AppPool")?.refValue;
     assertTypeString(userPoolId);
 
     // When the Stack's Resources are torn down.
@@ -55,7 +55,7 @@ describe("Cognito CloudFormation Resource teardown", () => {
     );
     for (const logicalId of ["AdminsGroup", "AppClient", "AppPool"]) {
       assertIdentical(
-        stack.resources.get(logicalId)?.status,
+        stack.getResource(logicalId)?.status,
         "DELETE_COMPLETE",
         `${logicalId} status`,
       );

--- a/src/service/cognito/cfn/sim-cfn-cognito-user-pool.iso.test.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-user-pool.iso.test.ts
@@ -18,7 +18,7 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../aws/sim-aws.js";
-import type { SimCfnStack } from "../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
 
 const accountIdOneOnes = "111111111111";
 
@@ -67,7 +67,9 @@ const userPoolTemplate = {
   },
 };
 
-async function deployUserPoolStack(simAws: SimAws): Promise<SimCfnStack> {
+async function deployUserPoolStack(
+  simAws: SimAws,
+): Promise<SimCfnDeployedStack> {
   const stack = await simAws.cloudFormation().deployTemplate({
     stackName: "app-stack",
     template: userPoolTemplate,
@@ -80,7 +82,7 @@ async function deployUserPoolStack(simAws: SimAws): Promise<SimCfnStack> {
 /**
  * A resolved Stack Output, which every Output in this template is a string.
  */
-function output(stack: SimCfnStack, outputKey: string): string {
+function output(stack: SimCfnDeployedStack, outputKey: string): string {
   const value = stack.outputs.get(outputKey)?.value;
   assertTypeString(value);
 

--- a/src/service/dynamodb/cfn/sim-cfn-dynamodb-table-stream.iso.test.ts
+++ b/src/service/dynamodb/cfn/sim-cfn-dynamodb-table-stream.iso.test.ts
@@ -19,7 +19,7 @@ import { describe, it } from "vitest";
 import { SimAws } from "../../aws/sim-aws.js";
 import type { SimDynamoDbStreamsRecord } from "../command/stream/stream.types.js";
 import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
-import type { SimCfnStack } from "../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
 import { simCfnDynamoDbTableResourceFactory } from "./table/sim-cfn-dynamodb-table-resource.factory.js";
 
 /**
@@ -32,7 +32,7 @@ async function deployTable(
   simAws: SimAws,
   properties: SimCfnTemplateValueRecord,
   outputs: SimCfnTemplateValueRecord = {},
-): Promise<SimCfnStack> {
+): Promise<SimCfnDeployedStack> {
   const stack = await simAws.cloudFormation().deployTemplate({
     stackName: "orders-stack",
     template: {

--- a/src/service/dynamodb/cfn/sim-cfn-dynamodb-teardown.iso.test.ts
+++ b/src/service/dynamodb/cfn/sim-cfn-dynamodb-teardown.iso.test.ts
@@ -34,7 +34,7 @@ describe("DynamoDB CloudFormation Resource teardown", () => {
         .describeTable(new DescribeTableCommand({ TableName: "orders" })),
     );
     assertIdentical(
-      stack.resources.get("OrdersTable")?.status,
+      stack.getResource("OrdersTable")?.status,
       "DELETE_COMPLETE",
     );
   });

--- a/src/service/ecr/cfn/sim-cfn-ecr-repository.iso.test.ts
+++ b/src/service/ecr/cfn/sim-cfn-ecr-repository.iso.test.ts
@@ -204,7 +204,7 @@ describe("AWS::ECR::Repository", () => {
     // Then the repository goes with it, since nothing was holding on to it.
     assertFalse(simAws.ecr().hasRepository("orders"));
     assertIdentical(
-      stack.resources.get("OrdersRepository")?.status,
+      stack.getResource("OrdersRepository")?.status,
       "DELETE_COMPLETE",
     );
   });
@@ -233,7 +233,7 @@ describe("AWS::ECR::Repository", () => {
     // is recorded rather than failing the teardown.
     assertTrue(simAws.ecr().repository("orders").hasImage);
 
-    const resource = stack.resources.get("OrdersRepository");
+    const resource = stack.getResource("OrdersRepository");
 
     assertTrue(resource?.deletionSkipped ?? false);
     assertNonNullable(resource?.deletionSkippedReason);

--- a/src/service/ecs/cfn/sim-cfn-ecs-bindings.iso.test.ts
+++ b/src/service/ecs/cfn/sim-cfn-ecs-bindings.iso.test.ts
@@ -206,7 +206,7 @@ describe("ECS CloudFormation container bindings", () => {
     await stack.waitForDeployComplete();
 
     assertIdentical(
-      stack.resources.get("WorkerTaskDefinition")?.status,
+      stack.getResource("WorkerTaskDefinition")?.status,
       "CREATE_COMPLETE",
     );
 

--- a/src/service/ecs/cfn/sim-cfn-ecs-cluster.iso.test.ts
+++ b/src/service/ecs/cfn/sim-cfn-ecs-cluster.iso.test.ts
@@ -141,7 +141,7 @@ describe("AWS::ECS::Cluster", () => {
     // reader can see what the deployed cluster is not doing.
     assertTrue(simAws.ecs().cluster("orders").isActive());
 
-    const ignored = stack.resources.get("OrdersCluster")?.ignoredProperties;
+    const ignored = stack.getResource("OrdersCluster")?.ignoredProperties;
     assertNonNullable(ignored);
     assertArrayLength(ignored, 2);
     assertStringIncludes(

--- a/src/service/ecs/cfn/sim-cfn-ecs-properties.iso.test.ts
+++ b/src/service/ecs/cfn/sim-cfn-ecs-properties.iso.test.ts
@@ -156,7 +156,7 @@ describe("ECS CloudFormation property reading", () => {
     await stack.waitForDeployComplete();
 
     // Then the revision is registered without it, and it is recorded.
-    const ignored = stack.resources.get(
+    const ignored = stack.getResource(
       "WorkerTaskDefinition",
     )?.ignoredProperties;
     assertNonNullable(ignored);
@@ -189,7 +189,7 @@ describe("ECS CloudFormation property reading", () => {
     await stack.waitForDeployComplete();
 
     // Then the cluster is created without it, and it is recorded.
-    const ignored = stack.resources.get("OrdersCluster")?.ignoredProperties;
+    const ignored = stack.getResource("OrdersCluster")?.ignoredProperties;
     assertNonNullable(ignored);
     assertArrayLength(ignored, 1);
     assertStringIncludes(
@@ -314,14 +314,14 @@ describe("ECS CloudFormation property reading", () => {
     // teardown steps over it.
     assertArrayLength(stack.skippedResources, 1);
     assertStringIncludes(
-      stack.resources.get("OrdersCapacity")?.skippedReason ?? "",
+      stack.getResource("OrdersCapacity")?.skippedReason ?? "",
       "Unsupported sim ECS CloudFormation Resource CapacityProvider",
     );
 
     await stack.teardown();
 
     assertIdentical(
-      stack.resources.get("OrdersCapacity")?.status,
+      stack.getResource("OrdersCapacity")?.status,
       "DELETE_COMPLETE",
     );
   });

--- a/src/service/ecs/cfn/sim-cfn-ecs-service-properties.iso.test.ts
+++ b/src/service/ecs/cfn/sim-cfn-ecs-service-properties.iso.test.ts
@@ -200,7 +200,7 @@ describe("AWS::ECS::Service properties", () => {
     // reader can see what the deployed service is not doing.
     assertTrue(simAws.ecs().service("orders-worker", "orders").isActive());
 
-    const ignored = stack.resources.get("WorkerService")?.ignoredProperties;
+    const ignored = stack.getResource("WorkerService")?.ignoredProperties;
 
     assertNonNullable(ignored);
     assertArrayLength(ignored, 3);

--- a/src/service/ecs/cfn/sim-cfn-ecs-task-definition.iso.test.ts
+++ b/src/service/ecs/cfn/sim-cfn-ecs-task-definition.iso.test.ts
@@ -273,7 +273,7 @@ describe("AWS::ECS::TaskDefinition", () => {
     // than failing the stack.
     assertIdentical(simAws.ecs().taskDefinition("orders-worker").revision, 1);
 
-    const ignored = stack.resources.get(
+    const ignored = stack.getResource(
       "WorkerTaskDefinition",
     )?.ignoredProperties;
     assertNonNullable(ignored);

--- a/src/service/elbv2/cfn/sim-cfn-elbv2-listener-rule.iso.test.ts
+++ b/src/service/elbv2/cfn/sim-cfn-elbv2-listener-rule.iso.test.ts
@@ -297,7 +297,7 @@ describe("AWS::ElasticLoadBalancingV2::ListenerRule", () => {
     await stack.waitForDeployComplete();
 
     // Then it is created without it, and the record says so.
-    const ignored = stack.resources.get("OrdersRule")?.ignoredProperties;
+    const ignored = stack.getResource("OrdersRule")?.ignoredProperties;
     assertNonNullable(ignored);
     assertArrayLength(ignored, 1);
     assertStringIncludes(

--- a/src/service/elbv2/cfn/sim-cfn-elbv2-listener.iso.test.ts
+++ b/src/service/elbv2/cfn/sim-cfn-elbv2-listener.iso.test.ts
@@ -231,7 +231,7 @@ describe("AWS::ElasticLoadBalancingV2::Listener", () => {
     await stack.waitForDeployComplete();
 
     // Then the listener is created without them, and both are recorded.
-    const ignored = stack.resources.get("HttpListener")?.ignoredProperties;
+    const ignored = stack.getResource("HttpListener")?.ignoredProperties;
     assertNonNullable(ignored);
     assertArrayLength(ignored, 2);
     assertStringIncludes(

--- a/src/service/elbv2/cfn/sim-cfn-elbv2-load-balancer.iso.test.ts
+++ b/src/service/elbv2/cfn/sim-cfn-elbv2-load-balancer.iso.test.ts
@@ -181,7 +181,7 @@ describe("AWS::ElasticLoadBalancingV2::LoadBalancer", () => {
     // see what the deployed load balancer is not doing.
     assertNonNullable(simAws.elbV2().findLoadBalancerByName("shop-alb"));
 
-    const ignored = stack.resources.get("ShopAlb")?.ignoredProperties;
+    const ignored = stack.getResource("ShopAlb")?.ignoredProperties;
     assertNonNullable(ignored);
     assertArrayLength(ignored, 3);
     assertStringIncludes(
@@ -211,7 +211,7 @@ describe("AWS::ElasticLoadBalancingV2::LoadBalancer", () => {
     await stack.waitForDeployComplete();
 
     // Then the load balancer is created without it, and the record says so.
-    const ignored = stack.resources.get("ShopAlb")?.ignoredProperties;
+    const ignored = stack.getResource("ShopAlb")?.ignoredProperties;
     assertNonNullable(ignored);
     assertArrayLength(ignored, 1);
     assertStringIncludes(

--- a/src/service/elbv2/cfn/sim-cfn-elbv2-target-group.iso.test.ts
+++ b/src/service/elbv2/cfn/sim-cfn-elbv2-target-group.iso.test.ts
@@ -214,7 +214,7 @@ describe("AWS::ElasticLoadBalancingV2::TargetGroup", () => {
     await stack.waitForDeployComplete();
 
     // Then the group is created without them, and the record says why.
-    const ignored = stack.resources.get("CheckoutTargets")?.ignoredProperties;
+    const ignored = stack.getResource("CheckoutTargets")?.ignoredProperties;
     assertNonNullable(ignored);
     assertArrayLength(ignored, 1);
     assertStringIncludes(ignored[0].reason, "invokes the target instead");

--- a/src/service/elbv2/cfn/sim-cfn-elbv2.fixture.ts
+++ b/src/service/elbv2/cfn/sim-cfn-elbv2.fixture.ts
@@ -1,6 +1,6 @@
 import { assertTypeString } from "@kensio/smartass";
 
-import type { SimCfnStack } from "../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
 
 /**
  * One stack Output, as the string an ELBv2 Resource answers with.
@@ -9,7 +9,10 @@ import type { SimCfnStack } from "../../cloudformation/stack/sim-cfn-stack.js";
  * asking for it as a string here keeps each assertion about the value rather
  * than about what shape it came out in.
  */
-export function simCfnElbV2Output(stack: SimCfnStack, name: string): string {
+export function simCfnElbV2Output(
+  stack: SimCfnDeployedStack,
+  name: string,
+): string {
   const value = stack.outputs.get(name)?.value;
 
   assertTypeString(value);

--- a/src/service/iam/cfn/managed-policy/sim-cfn-iam-managed-policy.iso.test.ts
+++ b/src/service/iam/cfn/managed-policy/sim-cfn-iam-managed-policy.iso.test.ts
@@ -10,6 +10,10 @@ import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
 import type { SimIamManagedPolicy } from "../../policy/sim-iam-policy.js";
 import type { SimArn } from "../../../aws/arn.js";
+import {
+  deployedResourceObject,
+  deployedStackObject,
+} from "../../../cloudformation/stack/sim-cfn-stack.fixture.js";
 
 describe("IAM CloudFormation ManagedPolicy", () => {
   it("creates an IAM Managed Policy from AWS::IAM::ManagedPolicy", async () => {
@@ -221,10 +225,11 @@ describe("IAM CloudFormation ManagedPolicy", () => {
       `arn:aws:iam::${simAws.defaultAccountId}:policy/OutputPolicy`,
     );
 
-    const resolvedWaitHandleProperties =
-      await waitHandleResource.resolvedProperties({
-        resources: stack.resources,
-      });
+    const resolvedWaitHandleProperties = await deployedResourceObject(
+      waitHandleResource,
+    ).resolvedProperties({
+      resources: deployedStackObject(stack).resources,
+    });
 
     assertIdentical(resolvedWaitHandleProperties["PolicyArn"], policyArn);
     assertIdentical(stack.outputs.get("PolicyArn")?.value, policyArn);

--- a/src/service/iam/cfn/role/sim-cfn-iam-role.iso.test.ts
+++ b/src/service/iam/cfn/role/sim-cfn-iam-role.iso.test.ts
@@ -8,6 +8,10 @@ import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
 import type { SimIamRole } from "../../role/sim-iam-role.js";
+import {
+  deployedResourceObject,
+  deployedStackObject,
+} from "../../../cloudformation/stack/sim-cfn-stack.fixture.js";
 
 const assumeRolePolicyDocument = {
   Version: "2012-10-17",
@@ -277,10 +281,11 @@ describe("IAM CloudFormation Role", () => {
 
     assertIdentical(roleResource.refValue, "OutputRole");
 
-    const resolvedWaitHandleProperties =
-      await waitHandleResource.resolvedProperties({
-        resources: stack.resources,
-      });
+    const resolvedWaitHandleProperties = await deployedResourceObject(
+      waitHandleResource,
+    ).resolvedProperties({
+      resources: deployedStackObject(stack).resources,
+    });
 
     assertIdentical(resolvedWaitHandleProperties["RoleName"], "OutputRole");
     assertIdentical(resolvedWaitHandleProperties["RoleArn"], role.arn);

--- a/src/service/iam/cfn/sim-cfn-iam-teardown.iso.test.ts
+++ b/src/service/iam/cfn/sim-cfn-iam-teardown.iso.test.ts
@@ -98,7 +98,7 @@ describe("IAM CloudFormation Resource teardown", () => {
       .cloudFormation()
       .deployTemplate({ stackName: "handler-stack", template });
 
-    const role = stack.resources.get("HandlerRole")?.simResource as
+    const role = stack.getResource("HandlerRole")?.simResource as
       | SimIamRole
       | undefined;
     assertIdentical(role?.roleName, "handler-role");
@@ -113,10 +113,7 @@ describe("IAM CloudFormation Resource teardown", () => {
       simAws.iam().getRole({ input: { RoleName: "handler-role" } }),
     );
     assertUndefined(simAws.iam().roles.get(role.roleName));
-    assertIdentical(
-      stack.resources.get("ReadPolicy")?.status,
-      "DELETE_COMPLETE",
-    );
+    assertIdentical(stack.getResource("ReadPolicy")?.status, "DELETE_COMPLETE");
   });
 
   it("takes a User's policies off it before deleting the User", async () => {
@@ -128,7 +125,7 @@ describe("IAM CloudFormation Resource teardown", () => {
       template: userTemplate,
     });
 
-    const user = stack.resources.get("PublisherUser")?.simResource as
+    const user = stack.getResource("PublisherUser")?.simResource as
       | SimIamUser
       | undefined;
     assertIdentical(user?.userName, "publisher-user");
@@ -142,7 +139,7 @@ describe("IAM CloudFormation Resource teardown", () => {
     assertUndefined(simAws.iam().users.get(user.userName));
     assertMapSize(simAws.iam().policies, 0);
     assertIdentical(
-      stack.resources.get("PublisherUser")?.status,
+      stack.getResource("PublisherUser")?.status,
       "DELETE_COMPLETE",
     );
   });
@@ -163,7 +160,7 @@ describe("IAM CloudFormation Resource teardown", () => {
     });
 
     // Then the Stack reaches its User, with the name free to take again.
-    const user = second.resources.get("PublisherUser")?.simResource as
+    const user = second.getResource("PublisherUser")?.simResource as
       | SimIamUser
       | undefined;
     assertIdentical(user?.userName, "publisher-user");
@@ -209,7 +206,7 @@ describe("IAM CloudFormation Resource teardown", () => {
     // Then the inline policy is off the Role, which is still there.
     assertMapSize(role.inlinePolicies, 0);
     assertIdentical(
-      stack.resources.get("StandingPolicy")?.status,
+      stack.getResource("StandingPolicy")?.status,
       "DELETE_COMPLETE",
     );
   });
@@ -242,7 +239,7 @@ describe("IAM CloudFormation Resource teardown", () => {
       },
     });
 
-    const role = stack.resources.get("WorkerRole")?.simResource as
+    const role = stack.getResource("WorkerRole")?.simResource as
       | SimIamRole
       | undefined;
     assertSetSize(role?.attachedPolicyArns, 1);
@@ -252,7 +249,7 @@ describe("IAM CloudFormation Resource teardown", () => {
 
     // Then both the Managed Policy and the Role it was attached to are gone.
     assertIdentical(
-      stack.resources.get("WorkerReadPolicy")?.status,
+      stack.getResource("WorkerReadPolicy")?.status,
       "DELETE_COMPLETE",
     );
     assertUndefined(simAws.iam().roles.get(role.roleName));
@@ -296,7 +293,7 @@ describe("IAM CloudFormation Resource teardown", () => {
     // Managed Policy is deleted.
     assertSetSize(role.attachedPolicyArns, 0);
     assertIdentical(
-      stack.resources.get("StandingReadPolicy")?.status,
+      stack.getResource("StandingReadPolicy")?.status,
       "DELETE_COMPLETE",
     );
     assertMapSize(simAws.iam().policies, 0);

--- a/src/service/iam/cfn/user/sim-cfn-iam-user.iso.test.ts
+++ b/src/service/iam/cfn/user/sim-cfn-iam-user.iso.test.ts
@@ -9,6 +9,10 @@ import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
 import type { SimIamUser } from "../../user/sim-iam-user.js";
+import {
+  deployedResourceObject,
+  deployedStackObject,
+} from "../../../cloudformation/stack/sim-cfn-stack.fixture.js";
 
 describe("IAM CloudFormation User", () => {
   it("creates an IAM User from AWS::IAM::User", async () => {
@@ -268,10 +272,11 @@ describe("IAM CloudFormation User", () => {
 
     assertIdentical(userResource.refValue, "OutputUser");
 
-    const resolvedWaitHandleProperties =
-      await waitHandleResource.resolvedProperties({
-        resources: stack.resources,
-      });
+    const resolvedWaitHandleProperties = await deployedResourceObject(
+      waitHandleResource,
+    ).resolvedProperties({
+      resources: deployedStackObject(stack).resources,
+    });
 
     assertIdentical(resolvedWaitHandleProperties["UserName"], "OutputUser");
     assertIdentical(resolvedWaitHandleProperties["UserArn"], user.arn);

--- a/src/service/kms/cfn/sim-cfn-kms-teardown.iso.test.ts
+++ b/src/service/kms/cfn/sim-cfn-kms-teardown.iso.test.ts
@@ -30,7 +30,7 @@ describe("KMS CloudFormation Resource teardown", () => {
     });
     await stack.waitForDeployComplete();
 
-    const key = stack.resources.get("AppKey")?.simResource as
+    const key = stack.getResource("AppKey")?.simResource as
       | SimKmsKey
       | undefined;
     assertNonNullable(key);
@@ -43,6 +43,6 @@ describe("KMS CloudFormation Resource teardown", () => {
     assertUndefined(simAws.kms().findAlias("alias/app-key"));
     assertIdentical(simAws.kms().findKey(key.keyId), key);
     assertIdentical(key.keyState, "PendingDeletion");
-    assertIdentical(stack.resources.get("AppKey")?.status, "DELETE_COMPLETE");
+    assertIdentical(stack.getResource("AppKey")?.status, "DELETE_COMPLETE");
   });
 });

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-dead-letter-config.iso.test.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-dead-letter-config.iso.test.ts
@@ -11,7 +11,7 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimCfnStack } from "../../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
 import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 
 const ordersQueueArn = "arn:aws:sqs:us-east-1:888888888888:orders-dlq";
@@ -35,7 +35,7 @@ const assumeRolePolicyDocument = {
 async function deployOrders(
   simAws: SimAws,
   deadLetterConfig: SimCfnTemplateValue,
-): Promise<SimCfnStack> {
+): Promise<SimCfnDeployedStack> {
   const stack = await simAws.cloudFormation().deployTemplate({
     stackName: "orders-stack",
     template: {

--- a/src/service/lambda/cfn/sim-cfn-lambda-deploy.iso.test.ts
+++ b/src/service/lambda/cfn/sim-cfn-lambda-deploy.iso.test.ts
@@ -14,6 +14,10 @@ import { SimAws } from "../../aws/sim-aws.js";
 import type { SimIamRole } from "../../iam/role/sim-iam-role.js";
 import { makeLambdaCodeZip } from "../function/code/make-lambda-code-zip.js";
 import type { SimLambdaFunction } from "../function/sim-lambda-function.js";
+import {
+  deployedResourceObject,
+  deployedStackObject,
+} from "../../cloudformation/stack/sim-cfn-stack.fixture.js";
 
 const assumeRolePolicyDocument = {
   Version: "2012-10-17",
@@ -225,10 +229,11 @@ describe("Lambda CloudFormation Function deployment", () => {
 
     assertIdentical(functionResource.refValue, "output-function");
 
-    const resolvedWaitHandleProperties =
-      await waitHandleResource.resolvedProperties({
-        resources: stack.resources,
-      });
+    const resolvedWaitHandleProperties = await deployedResourceObject(
+      waitHandleResource,
+    ).resolvedProperties({
+      resources: deployedStackObject(stack).resources,
+    });
 
     assertIdentical(
       resolvedWaitHandleProperties["FunctionName"],

--- a/src/service/lambda/cfn/sim-cfn-lambda-teardown.iso.test.ts
+++ b/src/service/lambda/cfn/sim-cfn-lambda-teardown.iso.test.ts
@@ -132,7 +132,7 @@ describe("Lambda CloudFormation Resource teardown", () => {
     });
     await stack.waitForDeployComplete();
 
-    const mapping = stack.resources.get("OrderConsumerMapping")?.simResource as
+    const mapping = stack.getResource("OrderConsumerMapping")?.simResource as
       | SimLambdaEventSourceMapping
       | undefined;
     assertNonNullable(mapping);
@@ -146,7 +146,7 @@ describe("Lambda CloudFormation Resource teardown", () => {
     assertUndefined(simAws.lambda().getSimFunctionByName("order-consumer"));
     assertArrayLength(stack.skippedResourceDeletions, 0);
     assertIdentical(
-      stack.resources.get("OrderConsumerMapping")?.status,
+      stack.getResource("OrderConsumerMapping")?.status,
       "DELETE_COMPLETE",
     );
   });

--- a/src/service/logs/cfn/sim-cfn-log-group.iso.test.ts
+++ b/src/service/logs/cfn/sim-cfn-log-group.iso.test.ts
@@ -16,7 +16,7 @@ import {
 import { describe, it } from "vitest";
 
 import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
-import type { SimCfnStack } from "../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
 import { SimAws } from "../../aws/sim-aws.js";
 import { jsonStringify } from "../../../util/type-guard/json.js";
 
@@ -25,7 +25,7 @@ const logGroupName = "/aws/lambda/orders";
 async function deployLogGroup(
   properties: SimCfnTemplateValueRecord,
   simAws: SimAws = new SimAws(),
-): Promise<{ readonly simAws: SimAws; readonly stack: SimCfnStack }> {
+): Promise<{ readonly simAws: SimAws; readonly stack: SimCfnDeployedStack }> {
   const stack = await simAws.cloudFormation().deployTemplate({
     stackName: "orders",
     template: {

--- a/src/service/route53/cfn/dnssec/sim-cfn-r53-dnssec.iso.test.ts
+++ b/src/service/route53/cfn/dnssec/sim-cfn-r53-dnssec.iso.test.ts
@@ -13,10 +13,12 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimCfnStack } from "../../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
 import { simCfnDnssecTemplate } from "../../../../../test/route53/dnssec-template.js";
 
-async function deployedDnssecStack(simAws: SimAws): Promise<SimCfnStack> {
+async function deployedDnssecStack(
+  simAws: SimAws,
+): Promise<SimCfnDeployedStack> {
   const stack = await simAws.cloudFormation().deployTemplate({
     stackName: "dns-stack",
     template: simCfnDnssecTemplate(),
@@ -26,7 +28,7 @@ async function deployedDnssecStack(simAws: SimAws): Promise<SimCfnStack> {
   return stack;
 }
 
-function output(stack: SimCfnStack, name: string): string {
+function output(stack: SimCfnDeployedStack, name: string): string {
   const value = stack.outputs.get(name)?.value;
   assertTypeString(value);
 
@@ -44,9 +46,9 @@ describe("Route53 DNSSEC CloudFormation Resources", () => {
 
     // Then all three Resources were created rather than skipped, so the DNSSEC
     // half of the Stack is actually simulated.
-    assertFalse(stack.resources.get("ZoneSigningKey")?.skipped);
-    assertFalse(stack.resources.get("ZoneKeySigningKey")?.skipped);
-    assertFalse(stack.resources.get("ZoneDnssec")?.skipped);
+    assertFalse(stack.getResource("ZoneSigningKey")?.skipped);
+    assertFalse(stack.getResource("ZoneKeySigningKey")?.skipped);
+    assertFalse(stack.getResource("ZoneDnssec")?.skipped);
 
     // And the zone reports itself as signed, with a key a registrar could be
     // given the DS record for.
@@ -192,8 +194,8 @@ describe("Route53 DNSSEC CloudFormation Resources", () => {
 
     // Then every DNSSEC Resource came off, which only happens if signing
     // stopped before the key did and the key was deactivated before deletion.
-    assertTrue(stack.resources.get("ZoneDnssec")?.deleteComplete);
-    assertTrue(stack.resources.get("ZoneKeySigningKey")?.deleteComplete);
+    assertTrue(stack.getResource("ZoneDnssec")?.deleteComplete);
+    assertTrue(stack.getResource("ZoneKeySigningKey")?.deleteComplete);
     assertMapSize(simAws.route53().hostedZones, 0);
   });
 });

--- a/src/service/route53/cfn/hosted-zone/sim-cfn-route53-zone.iso.test.ts
+++ b/src/service/route53/cfn/hosted-zone/sim-cfn-route53-zone.iso.test.ts
@@ -11,6 +11,10 @@ import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
 import { SimRoute53HostedZone } from "../../hosted-zone/sim-route53-hosted-zone.js";
+import {
+  deployedResourceObject,
+  deployedStackObject,
+} from "../../../cloudformation/stack/sim-cfn-stack.fixture.js";
 
 describe("Route53 CloudFormation HostedZone", () => {
   it("creates a Route53 Hosted Zone from AWS::Route53::HostedZone", async () => {
@@ -218,10 +222,11 @@ describe("Route53 CloudFormation HostedZone", () => {
 
     assertTypeString(hostedZoneId);
 
-    const resolvedWaitHandleProperties =
-      await waitHandleResource.resolvedProperties({
-        resources: stack.resources,
-      });
+    const resolvedWaitHandleProperties = await deployedResourceObject(
+      waitHandleResource,
+    ).resolvedProperties({
+      resources: deployedStackObject(stack).resources,
+    });
 
     assertIdentical(resolvedWaitHandleProperties["HostedZoneId"], hostedZoneId);
     assertIdentical(

--- a/src/service/route53/cfn/record-set/sim-cfn-r53-mail-record-set.iso.test.ts
+++ b/src/service/route53/cfn/record-set/sim-cfn-r53-mail-record-set.iso.test.ts
@@ -41,10 +41,7 @@ describe("Route53 CloudFormation RecordSets for stored-only record types", () =>
 
     // Then the RecordSet deployed rather than failing the Stack, and the record
     // is on the Hosted Zone with its preference numbers intact.
-    assertIdentical(
-      stack.resources.get("MailRecord")?.status,
-      "CREATE_COMPLETE",
-    );
+    assertIdentical(stack.getResource("MailRecord")?.status, "CREATE_COMPLETE");
     const hostedZone = stack.getResource("MailZone")?.simResource;
     assertInstanceOf(hostedZone, SimRoute53HostedZone);
     assertObjectMatches(hostedZone.records.get("example.test", "MX"), {

--- a/src/service/route53/cfn/record-set/sim-cfn-r53-skipped-record-type.iso.test.ts
+++ b/src/service/route53/cfn/record-set/sim-cfn-r53-skipped-record-type.iso.test.ts
@@ -76,10 +76,7 @@ describe("Route53 CloudFormation RecordSets with an unmodelled record type", () 
     );
 
     // And the records the test is about were created.
-    assertIdentical(
-      stack.resources.get("SiteRecord")?.status,
-      "CREATE_COMPLETE",
-    );
+    assertIdentical(stack.getResource("SiteRecord")?.status, "CREATE_COMPLETE");
     const hostedZone = stack.getResource("SiteZone")?.simResource;
     assertInstanceOf(hostedZone, SimRoute53HostedZone);
     assertObjectMatches(hostedZone.records.get("www.example.test", "A"), {
@@ -136,18 +133,15 @@ describe("Route53 CloudFormation RecordSets with an unmodelled record type", () 
     // Then the teardown ran to the end, taking the created record and its zone
     // with it. The zone only goes if its records went first, because
     // DeleteHostedZone refuses a zone that still holds records.
-    assertIdentical(
-      stack.resources.get("SiteRecord")?.status,
-      "DELETE_COMPLETE",
-    );
-    assertIdentical(stack.resources.get("SiteZone")?.status, "DELETE_COMPLETE");
+    assertIdentical(stack.getResource("SiteRecord")?.status, "DELETE_COMPLETE");
+    assertIdentical(stack.getResource("SiteZone")?.status, "DELETE_COMPLETE");
     assertMapSize(simAws.route53().hostedZones, 0);
 
     // And the skipped record is delete-complete without a service being asked
     // to remove a record it never stored, so nothing was left behind. The skip
     // is still on the Stack to be read after the teardown.
     assertIdentical(
-      stack.resources.get("DelegationSigner")?.status,
+      stack.getResource("DelegationSigner")?.status,
       "DELETE_COMPLETE",
     );
     assertArrayLength(stack.skippedResourceDeletions, 0);

--- a/src/service/route53/cfn/sim-cfn-route53-teardown.iso.test.ts
+++ b/src/service/route53/cfn/sim-cfn-route53-teardown.iso.test.ts
@@ -39,10 +39,7 @@ describe("Route53 CloudFormation Resource teardown", () => {
 
     // Then the zone is gone, which only happens once its record went first.
     assertMapSize(simAws.route53().hostedZones, 0);
-    assertIdentical(
-      stack.resources.get("SiteRecord")?.status,
-      "DELETE_COMPLETE",
-    );
-    assertIdentical(stack.resources.get("SiteZone")?.status, "DELETE_COMPLETE");
+    assertIdentical(stack.getResource("SiteRecord")?.status, "DELETE_COMPLETE");
+    assertIdentical(stack.getResource("SiteZone")?.status, "DELETE_COMPLETE");
   });
 });

--- a/src/service/s3/cfn/bucket-policy/sim-cfn-s3-bucket-policy.iso.test.ts
+++ b/src/service/s3/cfn/bucket-policy/sim-cfn-s3-bucket-policy.iso.test.ts
@@ -67,7 +67,7 @@ describe("S3 CloudFormation BucketPolicy Resource", () => {
       Statement: [publicReadStatement],
     });
 
-    const resource = stack.resources.get("ReportsBucketPolicy");
+    const resource = stack.getResource("ReportsBucketPolicy");
     assertNonNullable(resource);
     assertIdentical(resource.status, "CREATE_COMPLETE");
     assertArrayLength(stack.skippedResources, 0);
@@ -175,7 +175,7 @@ describe("S3 CloudFormation BucketPolicy Resource", () => {
     });
 
     // Then the policy still reaches the Bucket.
-    const resource = stack.resources.get("ReportsBucketPolicy");
+    const resource = stack.getResource("ReportsBucketPolicy");
     assertNonNullable(resource);
     assertIdentical(resource.status, "CREATE_COMPLETE");
 

--- a/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-property-rules.iso.test.ts
+++ b/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-property-rules.iso.test.ts
@@ -9,7 +9,7 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimCfnStack } from "../../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 
 /**
@@ -41,7 +41,7 @@ async function deployFailing(
 async function deployBucket(
   simAws: SimAws,
   properties: SimCfnTemplateValueRecord,
-): Promise<SimCfnStack> {
+): Promise<SimCfnDeployedStack> {
   const stack = await simAws.cloudFormation().deployTemplate({
     stackName: "uploads-stack",
     template: {

--- a/src/service/s3/cfn/bucket/sim-cfn-s3-bucket.iso.test.ts
+++ b/src/service/s3/cfn/bucket/sim-cfn-s3-bucket.iso.test.ts
@@ -51,7 +51,7 @@ describe("S3 CloudFormation Bucket Resource", () => {
     assertNonNullable(bucket);
     assertInstanceOf(bucket, SimS3Bucket);
 
-    const resource = stack.resources.get("TestBucket");
+    const resource = stack.getResource("TestBucket");
 
     assertNonNullable(resource);
     assertIdentical(resource.status, "CREATE_COMPLETE");
@@ -83,7 +83,7 @@ describe("S3 CloudFormation Bucket Resource", () => {
     assertInstanceOf(bucket, SimS3Bucket);
     assertIdentical(bucket.bucketName, "testbucket");
 
-    const resource = stack.resources.get("TestBucket");
+    const resource = stack.getResource("TestBucket");
 
     assertNonNullable(resource);
     assertIdentical(resource.status, "CREATE_COMPLETE");
@@ -180,7 +180,7 @@ describe("S3 CloudFormation Bucket Resource", () => {
     );
 
     // When the Resource's WebsiteURL attribute is read.
-    const bucketResource = stack.resources.get("WebsiteBucket");
+    const bucketResource = stack.getResource("WebsiteBucket");
     const bucket = simS3.getSimBucketByName("website-bucket");
 
     assertNonNullable(bucketResource);
@@ -216,7 +216,7 @@ describe("S3 CloudFormation Bucket Resource", () => {
       });
 
     // When the Resource's S3 Bucket attributes are read.
-    const bucketResource = stack.resources.get("AttributeBucket");
+    const bucketResource = stack.getResource("AttributeBucket");
 
     assertNonNullable(bucketResource);
 

--- a/src/service/s3/cfn/bucket/sim-cfn-s3-public-access-block.iso.test.ts
+++ b/src/service/s3/cfn/bucket/sim-cfn-s3-public-access-block.iso.test.ts
@@ -156,7 +156,7 @@ describe("S3 CloudFormation PublicAccessBlockConfiguration", () => {
     });
 
     // Then the Stack deploys and the policy is attached.
-    const resource = stack.resources.get("SiteBucketPolicy");
+    const resource = stack.getResource("SiteBucketPolicy");
     assertStringIncludes(resource?.status ?? "", "CREATE_COMPLETE");
   });
 });

--- a/src/service/s3/cfn/sim-cfn-s3-teardown.iso.test.ts
+++ b/src/service/s3/cfn/sim-cfn-s3-teardown.iso.test.ts
@@ -60,11 +60,11 @@ describe("S3 CloudFormation Resource teardown", () => {
 
     // And both Resources report a completed deletion.
     assertIdentical(
-      stack.resources.get("ReportsBucketPolicy")?.status,
+      stack.getResource("ReportsBucketPolicy")?.status,
       "DELETE_COMPLETE",
     );
     assertIdentical(
-      stack.resources.get("ReportsBucket")?.status,
+      stack.getResource("ReportsBucket")?.status,
       "DELETE_COMPLETE",
     );
   });
@@ -134,7 +134,7 @@ describe("S3 CloudFormation Resource teardown", () => {
     assertStringIncludes(error.message, "ReportsBucket");
     assertNonNullable(simAws.s3().getSimBucketByName("reports"));
     assertIdentical(
-      stack.resources.get("ReportsBucket")?.status,
+      stack.getResource("ReportsBucket")?.status,
       "DELETE_FAILED",
     );
   });

--- a/src/service/secretsmanager/cfn/dynamic/sim-cfn-secrets-manager-dynamic-reference-best-effort.iso.test.ts
+++ b/src/service/secretsmanager/cfn/dynamic/sim-cfn-secrets-manager-dynamic-reference-best-effort.iso.test.ts
@@ -7,7 +7,7 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimCfnStack } from "../../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
 
 const accountIdOneOnes = "111111111111";
 
@@ -21,7 +21,7 @@ function simAwsInEuWest2(): SimAws {
 async function deployReading(
   simAws: SimAws,
   value: string,
-): Promise<SimCfnStack> {
+): Promise<SimCfnDeployedStack> {
   const stack = await simAws.cloudFormation().deployTemplate({
     stackName: "config-stack",
     template: {
@@ -51,7 +51,7 @@ function readValue(simAws: SimAws): string {
  * A Resource can record properties of its own alongside this, so the reference
  * is picked out by what its reason quotes.
  */
-function dynamicReferenceRecord(stack: SimCfnStack): {
+function dynamicReferenceRecord(stack: SimCfnDeployedStack): {
   path: string;
   reason: string;
 } {

--- a/src/service/secretsmanager/cfn/sim-cfn-secrets-manager-teardown.iso.test.ts
+++ b/src/service/secretsmanager/cfn/sim-cfn-secrets-manager-teardown.iso.test.ts
@@ -29,7 +29,7 @@ describe("Secrets Manager CloudFormation Resource teardown", () => {
     });
     await stack.waitForDeployComplete();
 
-    const secret = stack.resources.get("ApiSecret")?.simResource as
+    const secret = stack.getResource("ApiSecret")?.simResource as
       | SimSecretsManagerSecret
       | undefined;
     assertNonNullable(secret);
@@ -39,9 +39,6 @@ describe("Secrets Manager CloudFormation Resource teardown", () => {
 
     // Then the secret is waiting out its recovery window.
     assertTrue(secret.isScheduledForDeletion);
-    assertIdentical(
-      stack.resources.get("ApiSecret")?.status,
-      "DELETE_COMPLETE",
-    );
+    assertIdentical(stack.getResource("ApiSecret")?.status, "DELETE_COMPLETE");
   });
 });

--- a/src/service/ses/cfn/sim-cfn-ses-cdk-defaults.iso.test.ts
+++ b/src/service/ses/cfn/sim-cfn-ses-cdk-defaults.iso.test.ts
@@ -9,7 +9,7 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../aws/sim-aws.js";
-import type { SimCfnStack } from "../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
 
 /**
  * What `aws-cdk-lib` emits for an SES construct set.
@@ -61,7 +61,7 @@ const cdkResources = {
 
 async function deployCdkStack(): Promise<{
   readonly simAws: SimAws;
-  readonly stack: SimCfnStack;
+  readonly stack: SimCfnDeployedStack;
 }> {
   const simAws = new SimAws();
   const stack = await simAws.cloudFormation().deployTemplate({

--- a/src/service/ses/cfn/sim-cfn-ses-email-identity.iso.test.ts
+++ b/src/service/ses/cfn/sim-cfn-ses-email-identity.iso.test.ts
@@ -13,12 +13,12 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../aws/sim-aws.js";
-import type { SimCfnStack } from "../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
 import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
 
 interface DeployedIdentity {
   readonly simAws: SimAws;
-  readonly stack: SimCfnStack;
+  readonly stack: SimCfnDeployedStack;
 }
 
 async function deployIdentity(

--- a/src/service/ses/cfn/sim-cfn-ses-resource-refusals.iso.test.ts
+++ b/src/service/ses/cfn/sim-cfn-ses-resource-refusals.iso.test.ts
@@ -9,16 +9,20 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../aws/sim-aws.js";
-import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
-import type { SimCfnStack } from "../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnDeployedResource } from "../../cloudformation/resource/sim-cfn-deployed-resource.type.js";
+import type { SimCfnDeployedStack } from "../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
 import { SimSesNotFoundException } from "../error/sim-ses.error.js";
 import { simCfnSesResourceCreation } from "./sim-cfn-ses-resource-error.js";
+import {
+  deployedResourceObject,
+  deployedStackObject,
+} from "../../cloudformation/stack/sim-cfn-stack.fixture.js";
 
 /** A stack with one deployed identity, and the Resource record behind it. */
 async function deployedIdentity(): Promise<{
   readonly simAws: SimAws;
-  readonly stack: SimCfnStack;
-  readonly resource: SimCfnResource;
+  readonly stack: SimCfnDeployedStack;
+  readonly resource: SimCfnDeployedResource;
 }> {
   const simAws = new SimAws();
   const stack = await simAws.cloudFormation().deployTemplate({
@@ -32,7 +36,7 @@ async function deployedIdentity(): Promise<{
       },
     },
   });
-  const resource = stack.resources.get("SenderIdentity");
+  const resource = stack.getResource("SenderIdentity");
 
   assertNonNullable(resource);
 
@@ -59,7 +63,7 @@ describe("simulated SES CloudFormation refusals", () => {
     // Then the stack deployed with the Resource recorded as unsupported rather
     // than treated as deployed, which is how CloudFormation here handles every
     // Resource type no service claims.
-    const resource = stack.resources.get("Transactional");
+    const resource = stack.getResource("Transactional");
 
     assertNonNullable(resource);
     assertUndefined(resource.simResource);
@@ -74,7 +78,7 @@ describe("simulated SES CloudFormation refusals", () => {
       await simAws
         .sesV2()
         .cfnResourceFactory()
-        .delete("ConfigurationSet", resource);
+        .delete("ConfigurationSet", deployedResourceObject(resource));
     });
 
     assertStringIncludes(
@@ -92,9 +96,9 @@ describe("simulated SES CloudFormation refusals", () => {
       await simAws
         .sesV2()
         .cfnResourceFactory()
-        .create("ContactList", resource, {
+        .create("ContactList", deployedResourceObject(resource), {
           simAws,
-          resources: stack.resources,
+          resources: deployedStackObject(stack).resources,
         });
     });
 

--- a/src/service/ses/cfn/sim-cfn-ses-template.iso.test.ts
+++ b/src/service/ses/cfn/sim-cfn-ses-template.iso.test.ts
@@ -11,12 +11,12 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../aws/sim-aws.js";
-import type { SimCfnStack } from "../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
 import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
 
 interface DeployedTemplate {
   readonly simAws: SimAws;
-  readonly stack: SimCfnStack;
+  readonly stack: SimCfnDeployedStack;
 }
 
 const welcomeWording = {

--- a/src/service/sns/cfn/sim-cfn-sns-teardown.iso.test.ts
+++ b/src/service/sns/cfn/sim-cfn-sns-teardown.iso.test.ts
@@ -9,6 +9,7 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../aws/sim-aws.js";
+import { deployedResourceObject } from "../../cloudformation/stack/sim-cfn-stack.fixture.js";
 
 const policyDocument = {
   Version: "2012-10-17",
@@ -64,11 +65,11 @@ describe("SNS CloudFormation Resource teardown", () => {
     assertUndefined(simAws.sns().findTopic("orders"));
     assertArrayLength(simAws.sns().topicSubscriptions("orders"), 0);
     assertIdentical(
-      stack.resources.get("OrdersTopic")?.status,
+      stack.getResource("OrdersTopic")?.status,
       "DELETE_COMPLETE",
     );
     assertIdentical(
-      stack.resources.get("FulfilmentSubscription")?.status,
+      stack.getResource("FulfilmentSubscription")?.status,
       "DELETE_COMPLETE",
     );
   });
@@ -174,7 +175,7 @@ describe("SNS CloudFormation Resource teardown", () => {
       simAws
         .sns()
         .cfnResourceFactory()
-        .delete("PlatformApplication", resource, {
+        .delete("PlatformApplication", deployedResourceObject(resource), {
           simAws,
           resources: new Map(),
         }),

--- a/src/service/sqs/cfn/sim-cfn-sqs-teardown.iso.test.ts
+++ b/src/service/sqs/cfn/sim-cfn-sqs-teardown.iso.test.ts
@@ -49,7 +49,7 @@ describe("SQS CloudFormation Resource teardown", () => {
     // Then the queue is gone.
     assertUndefined(simAws.sqs().findQueue("orders"));
     assertIdentical(
-      stack.resources.get("OrdersQueue")?.status,
+      stack.getResource("OrdersQueue")?.status,
       "DELETE_COMPLETE",
     );
   });

--- a/src/service/ssm/cfn/dynamic/sim-cfn-ssm-dynamic-reference-best-effort.iso.test.ts
+++ b/src/service/ssm/cfn/dynamic/sim-cfn-ssm-dynamic-reference-best-effort.iso.test.ts
@@ -7,7 +7,7 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimCfnStack } from "../../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
 
 const accountIdOneOnes = "111111111111";
 
@@ -21,7 +21,7 @@ function simAwsInEuWest2(): SimAws {
 async function deployReading(
   simAws: SimAws,
   value: string,
-): Promise<SimCfnStack> {
+): Promise<SimCfnDeployedStack> {
   const stack = await simAws.cloudFormation().deployTemplate({
     stackName: "config-stack",
     template: {
@@ -51,7 +51,7 @@ function readValue(simAws: SimAws): string {
  * A Resource can record properties of its own alongside this, such as a queue
  * tag nothing simulated reads, so the reference is picked out by name.
  */
-function dynamicReferenceRecord(stack: SimCfnStack): {
+function dynamicReferenceRecord(stack: SimCfnDeployedStack): {
   path: string;
   reason: string;
 } {

--- a/src/service/ssm/cfn/dynamic/sim-cfn-ssm-dynamic-reference.iso.test.ts
+++ b/src/service/ssm/cfn/dynamic/sim-cfn-ssm-dynamic-reference.iso.test.ts
@@ -2,7 +2,7 @@ import { assertIdentical, assertNonNullable } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimCfnStack } from "../../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
 import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 
 const accountIdOneOnes = "111111111111";
@@ -22,7 +22,7 @@ async function deployReading(
   simAws: SimAws,
   value: SimCfnTemplateValue,
   parameters: Record<string, { Type: string; Default?: string }> = {},
-): Promise<SimCfnStack> {
+): Promise<SimCfnDeployedStack> {
   const stack = await simAws.cloudFormation().deployTemplate({
     stackName: "config-stack",
     template: {

--- a/src/service/ssm/cfn/dynamic/sim-cfn-ssm-secure-dynamic-reference-best-effort.iso.test.ts
+++ b/src/service/ssm/cfn/dynamic/sim-cfn-ssm-secure-dynamic-reference-best-effort.iso.test.ts
@@ -7,7 +7,7 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimCfnStack } from "../../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
 import type { SimIamUser } from "../../../iam/user/sim-iam-user.js";
 
 const accountIdOneOnes = "111111111111";
@@ -22,7 +22,7 @@ function simAwsInEuWest2(): SimAws {
 async function deployConsoleUser(
   simAws: SimAws,
   password: string,
-): Promise<SimCfnStack> {
+): Promise<SimCfnDeployedStack> {
   const stack = await simAws.cloudFormation().deployTemplate({
     stackName: "console-stack",
     template: {
@@ -42,7 +42,7 @@ async function deployConsoleUser(
   return stack;
 }
 
-function consolePassword(stack: SimCfnStack): string {
+function consolePassword(stack: SimCfnDeployedStack): string {
   const user = stack.getResource("ConsoleUser")?.simResource as
     | SimIamUser
     | undefined;
@@ -57,7 +57,7 @@ function consolePassword(stack: SimCfnStack): string {
  * A Resource can record properties of its own alongside this, so the reference
  * is picked out by what its reason quotes.
  */
-function dynamicReferenceRecord(stack: SimCfnStack): {
+function dynamicReferenceRecord(stack: SimCfnDeployedStack): {
   path: string;
   reason: string;
 } {

--- a/src/service/ssm/cfn/dynamic/sim-cfn-ssm-secure-dynamic-reference.iso.test.ts
+++ b/src/service/ssm/cfn/dynamic/sim-cfn-ssm-secure-dynamic-reference.iso.test.ts
@@ -3,7 +3,7 @@ import { assertIdentical, assertNonNullable } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimCfnStack } from "../../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
 import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimIamUser } from "../../../iam/user/sim-iam-user.js";
 
@@ -27,7 +27,7 @@ async function deployConsoleUser(
   simAws: SimAws,
   password: SimCfnTemplateValue,
   parameters: Record<string, { Type: string; Default?: string }> = {},
-): Promise<SimCfnStack> {
+): Promise<SimCfnDeployedStack> {
   const stack = await simAws.cloudFormation().deployTemplate({
     stackName: "console-stack",
     template: {
@@ -51,7 +51,7 @@ async function deployConsoleUser(
 /**
  * The password the deployed User was created with.
  */
-function consolePassword(stack: SimCfnStack): string {
+function consolePassword(stack: SimCfnDeployedStack): string {
   const user = stack.getResource("ConsoleUser")?.simResource as
     | SimIamUser
     | undefined;

--- a/src/service/ssm/cfn/parameter/sim-cfn-ssm-parameter-value-best-effort.iso.test.ts
+++ b/src/service/ssm/cfn/parameter/sim-cfn-ssm-parameter-value-best-effort.iso.test.ts
@@ -8,7 +8,7 @@ import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
 import type { SimCfnIgnoredProperty } from "../../../cloudformation/resource/ignore/sim-cfn-ignored-property.type.js";
-import type { SimCfnStack } from "../../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
 import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 
 const accountIdOneOnes = "111111111111";
@@ -25,7 +25,7 @@ async function deployReading(properties: {
   readonly type: string;
   readonly name: string;
   readonly value: SimCfnTemplateValue;
-}): Promise<SimCfnStack> {
+}): Promise<SimCfnDeployedStack> {
   const stack = await properties.simAws.cloudFormation().deployTemplate({
     stackName: "config-stack",
     template: {
@@ -59,7 +59,7 @@ function readValue(simAws: SimAws): string {
 /**
  * The one record the Stack made about a template Parameter.
  */
-function parameterRecord(stack: SimCfnStack): SimCfnIgnoredProperty {
+function parameterRecord(stack: SimCfnDeployedStack): SimCfnIgnoredProperty {
   const [ignored, ...rest] = stack.ignoredProperties;
   assertNonNullable(ignored, "a recorded template Parameter");
   assertArrayLength(rest, 0, "no second record");

--- a/src/service/ssm/cfn/parameter/sim-cfn-ssm-parameter-value-type.iso.test.ts
+++ b/src/service/ssm/cfn/parameter/sim-cfn-ssm-parameter-value-type.iso.test.ts
@@ -3,7 +3,7 @@ import { describe, it } from "vitest";
 
 import { jsonStringify } from "../../../../util/type-guard/json.js";
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimCfnStack } from "../../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
 import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 
 const accountIdOneOnes = "111111111111";
@@ -26,7 +26,7 @@ async function deployReading(properties: {
   readonly parameters: Record<string, { Type: string; Default?: string }>;
   readonly value: SimCfnTemplateValue;
   readonly names?: Record<string, string> | undefined;
-}): Promise<SimCfnStack> {
+}): Promise<SimCfnDeployedStack> {
   const stack = await properties.simAws.cloudFormation().deployTemplate({
     stackName: "config-stack",
     template: {

--- a/src/service/ssm/cfn/sim-cfn-ssm-teardown.iso.test.ts
+++ b/src/service/ssm/cfn/sim-cfn-ssm-teardown.iso.test.ts
@@ -35,7 +35,7 @@ describe("SSM CloudFormation Resource teardown", () => {
         .getParameter(new GetParameterCommand({ Name: "/app/api-url" })),
     );
     assertIdentical(
-      stack.resources.get("ApiUrlParameter")?.status,
+      stack.getResource("ApiUrlParameter")?.status,
       "DELETE_COMPLETE",
     );
   });

--- a/src/service/wafv2/cfn/sim-cfn-waf-absent-web-acl.iso.test.ts
+++ b/src/service/wafv2/cfn/sim-cfn-waf-absent-web-acl.iso.test.ts
@@ -21,7 +21,7 @@ import {
 import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
 import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
 import { simCfnRestApiTemplateFactory } from "../../apigateway/cfn/sim-cfn-rest-api-template.factory.js";
-import type { SimCfnStack } from "../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
 
 /**
  * The reason a skipped association gives, as far as it is worth asserting.
@@ -31,7 +31,7 @@ const absent = "which this simulation does not hold";
 /**
  * The one Resource a deployment skipped, and why.
  */
-function skippedReason(stack: SimCfnStack): string {
+function skippedReason(stack: SimCfnDeployedStack): string {
   assertArrayLength(stack.skippedResources, 1);
 
   return stack.skippedResources[0].skippedReason ?? "";
@@ -101,7 +101,7 @@ describe("An association naming a web ACL that is not here", () => {
     assertTypeString(poolArn);
 
     // Then the pool deployed with nothing in front of it.
-    assertIdentical(stack.resources.get("Pool")?.status, "CREATE_COMPLETE");
+    assertIdentical(stack.getResource("Pool")?.status, "CREATE_COMPLETE");
     assertFalse(simAws.wafV2().protection().protects(poolArn));
     assertStringIncludes(skippedReason(stack), simWafRealAccountAclArn);
   });

--- a/src/service/wafv2/cfn/sim-cfn-waf-association.iso.test.ts
+++ b/src/service/wafv2/cfn/sim-cfn-waf-association.iso.test.ts
@@ -18,7 +18,7 @@ import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
 import type { SimRestApi } from "../../apigateway/api/sim-rest-api.js";
 import { simCfnRestApiTemplateFactory } from "../../apigateway/cfn/sim-cfn-rest-api-template.factory.js";
 import type { SimAws } from "../../aws/sim-aws.js";
-import type { SimCfnStack } from "../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
 import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
 
 const visibility = {
@@ -101,7 +101,9 @@ function associationResource(
 /**
  * Deploy a REST API with the web ACL in front of its stage.
  */
-async function deployProtectedApi(simAws: SimAws): Promise<SimCfnStack> {
+async function deployProtectedApi(
+  simAws: SimAws,
+): Promise<SimCfnDeployedStack> {
   return await deployRestApi(
     simAws,
     simCfnRestApiTemplateFactory.make({
@@ -122,7 +124,7 @@ async function deployProtectedApi(simAws: SimAws): Promise<SimCfnStack> {
 /**
  * The deployed REST API, which is what a stage ARN has to be built from.
  */
-function deployedRestApi(stack: SimCfnStack): SimRestApi {
+function deployedRestApi(stack: SimCfnDeployedStack): SimRestApi {
   const restApi = stack.getResource("Api")?.simResource as
     | SimRestApi
     | undefined;
@@ -137,7 +139,7 @@ function deployedRestApi(stack: SimCfnStack): SimRestApi {
  */
 async function request(
   simAws: SimAws,
-  stack: SimCfnStack,
+  stack: SimCfnDeployedStack,
   path: string,
 ): Promise<Response> {
   const apiUrl = stack.outputs.get("ApiUrl")?.value;
@@ -204,7 +206,7 @@ describe("AWS::WAFv2::WebACLAssociation", () => {
     // web ACL be deleted after it.
     assertFalse(wafV2.protection().protects(restApi.stageArn("prod")));
     assertIdentical(
-      stack.resources.get("OrdersAclAssociation")?.status,
+      stack.getResource("OrdersAclAssociation")?.status,
       "DELETE_COMPLETE",
     );
   });

--- a/src/service/wafv2/cfn/sim-cfn-waf-best-effort.iso.test.ts
+++ b/src/service/wafv2/cfn/sim-cfn-waf-best-effort.iso.test.ts
@@ -22,7 +22,7 @@ import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
 import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
 import { simCfnRestApiTemplateFactory } from "../../apigateway/cfn/sim-cfn-rest-api-template.factory.js";
 import type { SimAws } from "../../aws/sim-aws.js";
-import type { SimCfnStack } from "../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
 import type { CfnTemplateBodyRecord } from "../../cloudformation/template/sim-cfn-template.js";
 
 /**
@@ -52,7 +52,7 @@ const poolTemplate: CfnTemplateBodyRecord = {
   Outputs: { PoolArn: { Value: { "Fn::GetAtt": ["Pool", "Arn"] } } },
 };
 
-async function deployPool(simAws: SimAws): Promise<SimCfnStack> {
+async function deployPool(simAws: SimAws): Promise<SimCfnDeployedStack> {
   const stack = await simAws
     .cloudFormation()
     .deployTemplate({ stackName: "pool", template: poolTemplate });
@@ -70,8 +70,8 @@ describe("A web ACL rule Yulin cannot evaluate", () => {
 
     // Then everything deployed. One rule went missing rather than the web ACL,
     // and rather than the Resources that had nothing to do with it.
-    assertIdentical(stack.resources.get("Pool")?.status, "CREATE_COMPLETE");
-    assertIdentical(stack.resources.get("Orders")?.status, "CREATE_COMPLETE");
+    assertIdentical(stack.getResource("Pool")?.status, "CREATE_COMPLETE");
+    assertIdentical(stack.getResource("Orders")?.status, "CREATE_COMPLETE");
     assertArrayLength(stack.skippedResources, 0);
     assertArrayLength(simAws.wafV2().allWebAcls("REGIONAL"), 1);
   });

--- a/src/service/wafv2/cfn/sim-cfn-waf-distribution.iso.test.ts
+++ b/src/service/wafv2/cfn/sim-cfn-waf-distribution.iso.test.ts
@@ -13,7 +13,7 @@ import {
   simCfSiteRequest,
 } from "../../../../test/cloudfront/site-fixture.js";
 import { SimAws } from "../../aws/sim-aws.js";
-import type { SimCfnStack } from "../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
 import type { CfnTemplateBodyRecord } from "../../cloudformation/template/sim-cfn-template.js";
 import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
 
@@ -125,7 +125,7 @@ function siteTemplate(
 async function deploySite(
   simAws: SimAws,
   webAclId?: SimCfnTemplateValueRecord | string,
-): Promise<SimCfnStack> {
+): Promise<SimCfnDeployedStack> {
   await simCfSiteBucket(simAws, bucketName, {
     "index.html": "<h1>Home</h1>",
     "admin/index.html": "<h1>Admin</h1>",
@@ -142,7 +142,7 @@ async function deploySite(
 
 async function siteResponse(
   simAws: SimAws,
-  stack: SimCfnStack,
+  stack: SimCfnDeployedStack,
   path: string,
 ): Promise<Response> {
   const distributionId = stack.outputs.get("DistributionId")?.value;

--- a/src/service/wafv2/cfn/sim-cfn-waf-sets.iso.test.ts
+++ b/src/service/wafv2/cfn/sim-cfn-waf-sets.iso.test.ts
@@ -14,7 +14,7 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../aws/sim-aws.js";
-import type { SimCfnStack } from "../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
 import type { CfnTemplateBodyRecord } from "../../cloudformation/template/sim-cfn-template.js";
 import type { SimCfnTemplateValue } from "../../cloudformation/template/value/sim-cfn-template-value.js";
 import { jsonStringify } from "../../../util/type-guard/json.js";
@@ -66,7 +66,7 @@ async function deploySets(
   simAws: SimAws,
   ipSet: Record<string, SimCfnTemplateValue> = {},
   patternSet: Record<string, SimCfnTemplateValue> = {},
-): Promise<SimCfnStack> {
+): Promise<SimCfnDeployedStack> {
   const stack = await simAws.cloudFormation().deployTemplate({
     stackName: "sets",
     template: setsTemplate(ipSet, patternSet),
@@ -80,7 +80,7 @@ async function deploySets(
  * One output of the deployed stack, which every assertion here reaches an ARN
  * through.
  */
-function outputValue(stack: SimCfnStack, name: string): string {
+function outputValue(stack: SimCfnDeployedStack, name: string): string {
   const value = stack.outputs.get(name)?.value;
 
   assertTypeString(value);

--- a/src/service/wafv2/cfn/sim-cfn-waf-values.iso.test.ts
+++ b/src/service/wafv2/cfn/sim-cfn-waf-values.iso.test.ts
@@ -272,7 +272,7 @@ describe("Simulated WAFv2 CloudFormation values", () => {
     // let go of the web ACL, so there was nothing left to disassociate, and
     // the web ACL was free to be deleted after it.
     assertIdentical(
-      aclStack.resources.get("OrdersAclAssociation")?.status,
+      aclStack.getResource("OrdersAclAssociation")?.status,
       "DELETE_COMPLETE",
     );
     assertFalse(simAws.wafV2().protection().protects(stageArn));

--- a/src/service/wafv2/cfn/sim-cfn-waf-web-acl.iso.test.ts
+++ b/src/service/wafv2/cfn/sim-cfn-waf-web-acl.iso.test.ts
@@ -14,7 +14,7 @@ import { describe, it } from "vitest";
 
 import { SimAws } from "../../aws/sim-aws.js";
 import { DEFAULT_SIM_AWS_ACCOUNT_ID } from "../../aws/sim-aws-account.js";
-import type { SimCfnStack } from "../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
 import type { CfnTemplateBodyRecord } from "../../cloudformation/template/sim-cfn-template.js";
 import type { SimCfnTemplateValue } from "../../cloudformation/template/value/sim-cfn-template-value.js";
 import { jsonStringify } from "../../../util/type-guard/json.js";
@@ -79,7 +79,7 @@ function webAclTemplate(
 async function deployWebAcl(
   simAws: SimAws,
   properties: Record<string, SimCfnTemplateValue> = {},
-): Promise<SimCfnStack> {
+): Promise<SimCfnDeployedStack> {
   const stack = await simAws.cloudFormation().deployTemplate({
     stackName: "orders",
     template: webAclTemplate(properties),
@@ -92,7 +92,11 @@ async function deployWebAcl(
 /**
  * What the deployed web ACL does with a request to one path.
  */
-function decisionFor(simAws: SimAws, stack: SimCfnStack, path: string): string {
+function decisionFor(
+  simAws: SimAws,
+  stack: SimCfnDeployedStack,
+  path: string,
+): string {
   const webAclArn = stack.outputs.get("AclArn")?.value;
   assertTypeString(webAclArn);
 

--- a/test/apigateway/cfn-deploy.ts
+++ b/test/apigateway/cfn-deploy.ts
@@ -12,7 +12,7 @@
 import { assertInstanceOf, assertThrowsErrorAsync } from "@kensio/smartass";
 
 import { SimAws } from "../../src/service/aws/sim-aws.js";
-import type { SimCfnStack } from "../../src/service/cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../src/service/cloudformation/stack/sim-cfn-deployed-stack.type.js";
 import type { CfnTemplateBodyRecord } from "../../src/service/cloudformation/template/sim-cfn-template.js";
 
 /**
@@ -30,7 +30,7 @@ export function simAwsInEuWest2(): SimAws {
 export async function deployRestApi(
   simAws: SimAws,
   template: CfnTemplateBodyRecord,
-): Promise<SimCfnStack> {
+): Promise<SimCfnDeployedStack> {
   const stack = await simAws
     .cloudFormation()
     .deployTemplate({ stackName: "orders-stack", template });
@@ -59,7 +59,7 @@ export async function deployRestApiFailure(
  * The reasons a deployed stack gave for the properties it created Resources
  * without, as one string per ignored property.
  */
-export function ignoredReasons(stack: SimCfnStack): string[] {
+export function ignoredReasons(stack: SimCfnDeployedStack): string[] {
   return stack.ignoredProperties.map((ignored) => {
     return `${ignored.logicalId} ${ignored.reason}`;
   });

--- a/test/apigatewayv2/cfn-deploy.ts
+++ b/test/apigatewayv2/cfn-deploy.ts
@@ -12,7 +12,7 @@
 import { assertInstanceOf, assertThrowsErrorAsync } from "@kensio/smartass";
 
 import { SimAws } from "../../src/service/aws/sim-aws.js";
-import type { SimCfnStack } from "../../src/service/cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../src/service/cloudformation/stack/sim-cfn-deployed-stack.type.js";
 import type { CfnTemplateBodyRecord } from "../../src/service/cloudformation/template/sim-cfn-template.js";
 
 /**
@@ -30,7 +30,7 @@ export function simAwsInEuWest2(): SimAws {
 export async function deployHttpApi(
   simAws: SimAws,
   template: CfnTemplateBodyRecord,
-): Promise<SimCfnStack> {
+): Promise<SimCfnDeployedStack> {
   const stack = await simAws
     .cloudFormation()
     .deployTemplate({ stackName: "orders-stack", template });
@@ -59,7 +59,7 @@ export async function deployHttpApiFailure(
  * The reasons a deployed stack gave for the properties it created Resources
  * without, as one string per ignored property.
  */
-export function ignoredReasons(stack: SimCfnStack): string[] {
+export function ignoredReasons(stack: SimCfnDeployedStack): string[] {
   return stack.ignoredProperties.map((ignored) => {
     return `${ignored.logicalId} ${ignored.reason}`;
   });

--- a/test/cloudformation/sam-cli.ts
+++ b/test/cloudformation/sam-cli.ts
@@ -10,7 +10,7 @@
 import { assertNonNullable } from "@kensio/smartass";
 
 import type { SimRestApi } from "../../src/service/apigateway/api/sim-rest-api.js";
-import type { SimCfnStack } from "../../src/service/cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../src/service/cloudformation/stack/sim-cfn-deployed-stack.type.js";
 import type { CfnTemplateBodyRecord } from "../../src/service/cloudformation/template/sim-cfn-template.js";
 import { testSamCliVersion } from "../../src/util/filesystem/test-sam-project.js";
 
@@ -114,7 +114,10 @@ export function stageLogicalIds(logicalIds: readonly string[]): string[] {
  * The methods one deployed API serves, as one `GET /rates/{currency}` per
  * method, which is the shape the SAM CLI reports its own in.
  */
-export function servedMethods(stack: SimCfnStack, logicalId: string): string[] {
+export function servedMethods(
+  stack: SimCfnDeployedStack,
+  logicalId: string,
+): string[] {
   const api = stack.getResource(logicalId)?.simResource as SimRestApi;
   assertNonNullable(api, `${logicalId} was not deployed as a REST API`);
 

--- a/test/cognito/cfn-deploy.ts
+++ b/test/cognito/cfn-deploy.ts
@@ -12,7 +12,7 @@
 import { assertInstanceOf, assertThrowsErrorAsync } from "@kensio/smartass";
 
 import { SimAws } from "../../src/service/aws/sim-aws.js";
-import type { SimCfnStack } from "../../src/service/cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../src/service/cloudformation/stack/sim-cfn-deployed-stack.type.js";
 import type { SimCfnTemplateValueRecord } from "../../src/service/cloudformation/template/value/sim-cfn-template-value.js";
 
 /**
@@ -53,7 +53,7 @@ export async function deploySuccess(
   simAws: SimAws,
   resources: SimCfnTemplateValueRecord,
   outputs?: SimCfnTemplateValueRecord,
-): Promise<SimCfnStack> {
+): Promise<SimCfnDeployedStack> {
   const stack = await simAws.cloudFormation().deployTemplate({
     stackName: "app-stack",
     template: {
@@ -70,7 +70,7 @@ export async function deploySuccess(
  * The reasons a deployed stack gave for the properties it created Resources
  * without, as one string per ignored property.
  */
-export function ignoredReasons(stack: SimCfnStack): string[] {
+export function ignoredReasons(stack: SimCfnDeployedStack): string[] {
   return stack.ignoredProperties.map((ignored) => {
     return `${ignored.logicalId} ${ignored.reason}`;
   });

--- a/test/lambda/cfn-event-invoke-config-fixture.ts
+++ b/test/lambda/cfn-event-invoke-config-fixture.ts
@@ -15,7 +15,7 @@ import { ReceiveMessageCommand } from "@aws-sdk/client-sqs";
 import { assertArrayLength, assertNonNullable } from "@kensio/smartass";
 
 import type { SimAws } from "../../src/service/aws/sim-aws.js";
-import type { SimCfnStack } from "../../src/service/cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../src/service/cloudformation/stack/sim-cfn-deployed-stack.type.js";
 import type { CfnTemplateBodyRecord } from "../../src/service/cloudformation/template/sim-cfn-template.js";
 import type { SimCfnTemplateValueRecord } from "../../src/service/cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimLambdaDestinationRecord } from "../../src/service/lambda/destination/sim-lambda-destination-record.js";
@@ -107,7 +107,7 @@ export function failingOrdersBinding(): {
 export async function deployOrders(
   simAws: SimAws,
   configProperties: SimCfnTemplateValueRecord,
-): Promise<SimCfnStack> {
+): Promise<SimCfnDeployedStack> {
   const stack = await simAws.cloudFormation().deployTemplate({
     stackName: "orders-stack",
     template: ordersTemplate(configProperties),

--- a/test/orders-service/orders-service.factory.ts
+++ b/test/orders-service/orders-service.factory.ts
@@ -1,7 +1,7 @@
 import { AsyncMappedFactory } from "@kensio/part-factory";
 
 import type { SimAws } from "../../src/service/aws/sim-aws.js";
-import type { SimCfnStack } from "../../src/service/cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../src/service/cloudformation/stack/sim-cfn-deployed-stack.type.js";
 import { handleOrdersRequest } from "./orders-service-handler.js";
 import { ordersServiceNames } from "./orders-service-names.js";
 import { ordersServiceTemplate } from "./orders-service-template.js";
@@ -19,7 +19,7 @@ export type OrdersServiceInput = Record<string, never>;
  */
 export interface OrdersService {
   readonly simAws: SimAws;
-  readonly stack: SimCfnStack;
+  readonly stack: SimCfnDeployedStack;
   /** The Route53 name the load balancer answers on. */
   readonly hostname: string;
 }

--- a/test/wafv2/best-effort-fixture.ts
+++ b/test/wafv2/best-effort-fixture.ts
@@ -13,7 +13,7 @@
 import { assertNonNullable } from "@kensio/smartass";
 
 import type { SimCfnIgnoredProperty } from "../../src/service/cloudformation/resource/ignore/sim-cfn-ignored-property.type.js";
-import type { SimCfnStack } from "../../src/service/cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnDeployedStack } from "../../src/service/cloudformation/stack/sim-cfn-deployed-stack.type.js";
 import type { SimCfnTemplateValueRecord } from "../../src/service/cloudformation/template/value/sim-cfn-template-value.js";
 
 const visibility = {
@@ -107,7 +107,7 @@ export function simWafAssociationResource(
  * The one property a deployment recorded as ignored.
  */
 export function simWafIgnoredProperty(
-  stack: SimCfnStack,
+  stack: SimCfnDeployedStack,
 ): SimCfnIgnoredProperty {
   const [property] = stack.ignoredProperties;
 


### PR DESCRIPTION
Closes #868.

## What changed

`deployTemplate`, `deployTemplateFile`, `updateTemplateFile` and `deployCdkOut` answer with `SimCfnDeployedStack`, and `getResource(...)` with `SimCfnDeployedResource`. Both are exported from `@kensio/yulin/cloudformation`, along with the types their members reach (`SimCfnStackOutput`, `SimCloudFormationStackStatus`, `SimCloudFormationResourceStatus`, `SimCfnIgnoredProperty`, `SimCfnTemplateValue` and `SimCfnTemplateValueRecord`). `SimCfnCdkOutTemplateTransform` takes `ReadonlyMap<string, SimCfnDeployedStack>` for the Stacks in front of the one it adapts.

`SimCfnStack` and `SimCfnResource` stay inside the package with `deploy()`, `update()`, the three lifecycle collaborators, the raw `template` and the Resource map.

## Where the surface came from

The members were counted across `docs/` and the test suite. `docs/` never puts a deployed Stack through `teardown`, `delete`, `update`, `waitForDeleteComplete`, `waitForUpdateComplete`, `lifecycle` or `template`, which is what marks the lifecycle as internal. The issue's sketch left out `outputs`, `ignoredProperties` and `skippedResourceDeletions`, and the documentation promises all three, so they are in.

`status` and `error` are on the interface as well. Both are documented on the class as externally visible, and having them means `stack.lifecycle.status` in the tests collapses to `stack.status`.

## The Resource map

`resources` is the documented member that went. `getResource(...)` covers the lookups and takes a CDK construct ID as well as a logical ID. Every `stack.resources.get(...)` in `docs/` and the suite becomes `getResource(...)`, and the two `stack.resources.has(...)` calls become an `undefined` check.

## Reaching past the public surface

A test in this package that drives the Stack lifecycle, or reads the Resource map, goes through `deployedStackObject(...)` or `deployedResourceObject(...)` from `sim-cfn-stack.fixture.ts`. Naming the cast keeps every such place greppable.

## Conformance

`SimCfnStack implements SimCfnDeployedStack`. `SimCfnResource` carries no `implements` clause of its own, because `sim-cfn-resource.ts` sits on the 300-line ceiling and the check already happens through `getResource()` and the Resource reports. Renaming a member of `SimCfnResource` fails the build at `SimCloudFormation`, which was checked by breaking `skippedReason` on purpose.

## Checks

`verify:pack` names the new types and compiles a transform written as a named function, which is the acceptance criterion for a consumer being able to annotate both parameters from imports alone. `pnpm fmt`, `build:check`, `examples:check` and `fta` pass, and the suite is green at 1521 files and 9471 tests.

The binding type is #869 and is untouched here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public APIs for inspecting deployed CloudFormation stacks and resources, including statuses, outputs, lifecycle operations, resource lookup, and attribute values.
  * CloudFormation deployment methods now return deployed stack information.
  * Added examples demonstrating deployed stack and resource inspection.

* **Documentation**
  * Updated CloudFormation, ECS, and load balancing examples to use the supported resource lookup API.

* **Tests**
  * Updated integration and teardown coverage to use the public deployed-stack and resource APIs across supported services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->