### PR TITLE
feat: supply values a Terraform plan drops

### DIFF
--- a/docs/terraform/README.md
+++ b/docs/terraform/README.md
@@ -95,6 +95,82 @@ naming a function the same plan creates carries the function's name as a plain s
 right and the edge CloudFormation orders from has gone with it. Every reference a resource declares
 becomes an ordering edge, whether or not the value resolved.
 
+## Supplying environment variables and role policies
+
+Terraform resolves nothing inside a value it could not build. A Lambda `environment.variables` map
+holding one reference to a queue of the same plan arrives unknown in its entirety, and the variable
+names go with it. An `aws_iam_role_policy` written with `jsonencode` around an ARN of the same plan
+arrives without its statements.
+
+Those two cost more than their count suggests (four attributes out of 154 on a hand-written
+application configuration). A handler reads its configuration out of environment variables, and
+simulated IAM evaluates authorization.
+
+`overrides` supplies them, matched on the name the plan carries, the way a binding is matched on a
+function name. An environment is matched on the function's name and an inline policy on the role's.
+
+```typescript terraform-plan-overrides
+/**
+ * Supplying the values a Terraform plan could not carry.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import { TerraformAdapter } from "@kensio/yulin/terraform";
+
+const simAws = new SimAws();
+
+const { report } = await new TerraformAdapter(simAws).deployPlan({
+  planPath: "terraform/orders.tfplan.json",
+  bindings: [
+    {
+      functionName: "orders-processor",
+      handler: (): string => process.env["QUEUE_URL"] ?? "",
+    },
+  ],
+  overrides: [
+    {
+      functionName: "orders-processor",
+      environment: {
+        TABLE_NAME: "orders-orders",
+        QUEUE_URL:
+          "https://sqs.eu-west-1.amazonaws.com/123456789012/orders-processing",
+      },
+    },
+    {
+      roleName: "orders-processor",
+      policy: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Action: [
+              "sqs:ReceiveMessage",
+              "sqs:DeleteMessage",
+              "sqs:GetQueueAttributes",
+            ],
+            Resource: "*",
+          },
+        ],
+      },
+    },
+  ],
+});
+
+// The attributes the plan lost that no override covered.
+console.log(report.lost);
+```
+
+An override fills a gap. Where Terraform resolved the value, the plan wins, and environment
+variables are merged one variable at a time. A configuration that stops collapsing a value stops
+needing the override written for it.
+
+A role whose policy no override supplies is created allowing everything, and `policy` is named on
+the report's `lost`. Simulated IAM evaluates authorization, and a role holding no policy would deny
+what the configuration allowed and fail the resources using it (an event source mapping is refused
+outright when its execution role cannot poll the queue). Supplying the policy takes that default
+off. The document is evaluated as it stands, and one omitting `sqs:ReceiveMessage` fails the mapping
+the way AWS fails it.
+
 ## What the report says
 
 The set of Terraform resource types the adapter maps is deliberately small. A type with no mapping,
@@ -126,15 +202,17 @@ console.log(report.skipped);
 // The aws_s3_bucket_versioning and friends that became bucket properties.
 console.log(report.folded);
 
-// Attributes a mapping could not carry, such as a Lambda's environment
-// variables, which Terraform collapses whole when one of them is unknown.
+// Attributes a mapping could not carry and no override supplied, such as a
+// Lambda's environment variables, which Terraform collapses whole when one of
+// them is unknown.
 console.log(report.lost);
 ```
 
 `mapped`, `folded` and `skipped` add up to the plan's managed resource count. `lost` names the
-attributes that did not survive the plan, per resource. A Terraform value that names a resource of
-the same plan and sits inside something Terraform builds in one go, such as a `jsonencode` document
-or a `for_each` map, is unknown in its entirety and its contents go with it.
+attributes that did not survive the plan and that no override covered, per resource. A Terraform
+value that names a resource of the same plan and sits inside something Terraform builds in one go,
+such as a `jsonencode` document or a `for_each` map, is unknown in its entirety and its contents go
+with it.
 
 ## The scope of what it reads
 

--- a/docs/terraform/terraform-plan-overrides.example.ts
+++ b/docs/terraform/terraform-plan-overrides.example.ts
@@ -1,0 +1,48 @@
+/**
+ * Supplying the values a Terraform plan could not carry.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import { TerraformAdapter } from "@kensio/yulin/terraform";
+
+const simAws = new SimAws();
+
+const { report } = await new TerraformAdapter(simAws).deployPlan({
+  planPath: "terraform/orders.tfplan.json",
+  bindings: [
+    {
+      functionName: "orders-processor",
+      handler: (): string => process.env["QUEUE_URL"] ?? "",
+    },
+  ],
+  overrides: [
+    {
+      functionName: "orders-processor",
+      environment: {
+        TABLE_NAME: "orders-orders",
+        QUEUE_URL:
+          "https://sqs.eu-west-1.amazonaws.com/123456789012/orders-processing",
+      },
+    },
+    {
+      roleName: "orders-processor",
+      policy: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Action: [
+              "sqs:ReceiveMessage",
+              "sqs:DeleteMessage",
+              "sqs:GetQueueAttributes",
+            ],
+            Resource: "*",
+          },
+        ],
+      },
+    },
+  ],
+});
+
+// The attributes the plan lost that no override covered.
+console.log(report.lost);

--- a/docs/terraform/terraform-plan-report.example.ts
+++ b/docs/terraform/terraform-plan-report.example.ts
@@ -22,6 +22,7 @@ console.log(report.skipped);
 // The aws_s3_bucket_versioning and friends that became bucket properties.
 console.log(report.folded);
 
-// Attributes a mapping could not carry, such as a Lambda's environment
-// variables, which Terraform collapses whole when one of them is unknown.
+// Attributes a mapping could not carry and no override supplied, such as a
+// Lambda's environment variables, which Terraform collapses whole when one of
+// them is unknown.
 console.log(report.lost);

--- a/src/service/iam/index.ts
+++ b/src/service/iam/index.ts
@@ -1,4 +1,11 @@
 export { SimIam } from "./sim-iam.js";
+export type {
+  SimIamConditionValue,
+  SimIamPolicyDocument,
+  SimIamPolicyDocumentCondition,
+  SimIamPolicyDocumentPrincipal,
+  SimIamPolicyDocumentStatement,
+} from "./policy/sim-iam-policy.js";
 export { SimIamAccessDenied, SimIamError } from "./error/sim-iam.error.js";
 export type { SimIamRequestOptions } from "./command/sim-iam-request-options.js";
 export type { SimIamCredentialIdentity } from "./credential/sim-aws-credentials.js";

--- a/src/terraform/README.md
+++ b/src/terraform/README.md
@@ -93,7 +93,9 @@ survives and becomes a `Ref` or an `Fn::GetAtt`.
 
 What goes missing is everything the unknown value was inside. A Lambda `environment.variables` map
 holding one reference to a queue URL arrives as `"variables": true`, and the variable names go with
-it. `TABLE_NAME`, `QUEUE_URL` and `TOPIC_ARN` appear nowhere in the document.
+it. `TABLE_NAME`, `QUEUE_URL` and `TOPIC_ARN` appear nowhere in the document. The map goes whole
+even where some of its values are literals (measured on Terraform 1.15.8 against AWS provider
+5.100.0), so there is no per-variable form of the unknown mark to read.
 
 The same happens to every `jsonencode` result. An `aws_iam_role_policy` built around an ARN of the
 same plan is unknown in its entirety, and its actions and resources are gone with it.

--- a/src/terraform/README.md
+++ b/src/terraform/README.md
@@ -96,11 +96,25 @@ holding one reference to a queue URL arrives as `"variables": true`, and the var
 it. `TABLE_NAME`, `QUEUE_URL` and `TOPIC_ARN` appear nowhere in the document.
 
 The same happens to every `jsonencode` result. An `aws_iam_role_policy` built around an ARN of the
-same plan is unknown in its entirety, and its actions and resources are gone with it. Simulated IAM
-evaluates authorization. A role created without the policy would deny what the configuration allowed
-and fail the resources using it. The role is created holding a policy that allows everything, and
-the attribute is recorded as lost. That is what keeps a plan carrying a Lambda event source mapping
-deployable. Supplying the real values is [#865](https://github.com/KensioSoftware/yulin/issues/865).
+same plan is unknown in its entirety, and its actions and resources are gone with it.
+
+A deployment supplies both through `overrides`, matched on the name the plan carries the way a
+binding is matched on a function name. `TerraformPlanOverrides` indexes what was supplied, and a
+mapping asks it for the resource's own name. A name the plan itself could not resolve gets nothing
+back. The plan is read first. A supplied value fills a gap and never replaces what Terraform
+resolved, and environment variables merge one variable at a time (a map the plan resolved in part
+keeps its own values and takes the supplied ones for the rest). What no override covered stays on
+the report's `lost`.
+
+A role whose policy no override supplies is created holding a policy that allows everything, and
+`policy` is recorded as lost. Simulated IAM evaluates authorization, and a role created without the
+policy would deny what the configuration allowed and fail the resources using it. Allowing
+everything is what keeps a plan carrying a Lambda event source mapping deployable with no override
+at all. It is the same answer sim CloudFormation gives a Resource type it cannot create. Carry on,
+and say what was stepped over.
+
+A supplied policy is evaluated as it stands. A document omitting `sqs:ReceiveMessage` fails the
+event source mapping the way real Lambda fails it.
 
 An SQS `redrive_policy` loses its `maxReceiveCount` the same way. That one is dropped. A policy
 carrying a made-up limit would give the queue different retry behaviour from the one the plan

--- a/src/terraform/index.ts
+++ b/src/terraform/index.ts
@@ -3,6 +3,12 @@ export type {
   TerraformPlanDeployment,
   TerraformPlanDeployProperties,
 } from "./sim-tf-adapter.js";
+export type { SimIamPolicyDocument } from "../service/iam/policy/sim-iam-policy.js";
+export type {
+  TerraformFunctionEnvironmentOverride,
+  TerraformPlanOverride,
+  TerraformRolePolicyOverride,
+} from "./sim-tf-override.type.js";
 export type {
   TerraformImportReport,
   TerraformImportedResource,

--- a/src/terraform/map/sim-tf-map-iam-policy.ts
+++ b/src/terraform/map/sim-tf-map-iam-policy.ts
@@ -94,14 +94,25 @@ function policyName(context: TerraformMappingContext): string {
  * CloudFormation as an object.
  *
  * A document built with `jsonencode` around an ARN of the same plan is unknown
- * in its entirety, so this returns nothing rather than a partial policy.
+ * in its entirety, so this returns nothing rather than a partial policy. A
+ * string that will not parse answers the same way. The plan is a file on disk
+ * and one unreadable document is one attribute, and failing the whole import
+ * over it would take every other resource of the plan with it.
  */
 export function jsonDocument(value: unknown): SimCfnTemplateValue | undefined {
   if (typeof value !== "string") {
     return undefined;
   }
 
-  const parsed: unknown = JSON.parse(value);
+  const parsed = parsedDocument(value);
 
   return isRecord(parsed) ? templateValue(parsed) : undefined;
+}
+
+function parsedDocument(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
 }

--- a/src/terraform/map/sim-tf-map-iam-policy.ts
+++ b/src/terraform/map/sim-tf-map-iam-policy.ts
@@ -1,0 +1,107 @@
+import { isRecord } from "../../util/type-guard/record.js";
+import type { SimCfnTemplateValue } from "../../service/cloudformation/template/value/sim-cfn-template-value.js";
+import {
+  attribute,
+  field,
+  templateValue,
+  type TerraformMappingContext,
+} from "../sim-tf-attributes.js";
+import { terraformReferencedResource } from "../sim-tf-referenced.js";
+
+/**
+ * An inline policy on the role it is attached to.
+ *
+ * A document built with `jsonencode` around an ARN of the same plan is unknown
+ * in its entirety, and its statements are gone with it, so a deployment can
+ * supply the document against the role's own name.
+ *
+ * With nothing supplied, the role is created holding a policy that allows
+ * everything and the attribute is recorded as lost. Simulated IAM evaluates
+ * authorization, so the alternative is a role that denies what the
+ * configuration allowed, which fails the resources that use it and takes the
+ * rest of the Stack with them. A role that is too permissive is the same
+ * answer sim CloudFormation gives a Resource type it cannot create: carry on,
+ * and say what was stepped over.
+ */
+export function inlinePolicy(
+  context: TerraformMappingContext,
+): Record<string, SimCfnTemplateValue> {
+  const document = policyDocument(context) ?? unknownPolicyDocument;
+
+  return {
+    Policies: [{ PolicyName: policyName(context), PolicyDocument: document }],
+  };
+}
+
+/** The attributes this fold could not carry, which is the document or none. */
+export function inlinePolicyLost(
+  context: TerraformMappingContext,
+): readonly string[] {
+  return policyDocument(context) === undefined ? ["policy"] : [];
+}
+
+/**
+ * What this policy allows, from the plan or from the deployment.
+ *
+ * The plan comes first, so a supplied document fills a gap rather than
+ * replacing a document Terraform resolved.
+ */
+function policyDocument(
+  context: TerraformMappingContext,
+): SimCfnTemplateValue | undefined {
+  return (
+    jsonDocument(field(context.resource.values, "policy")) ??
+    suppliedDocument(context)
+  );
+}
+
+/**
+ * The document a deployment supplied for the role this policy is attached to.
+ *
+ * The `role` attribute holds a reference rather than a name, because a role
+ * created by the same plan has no ID until it exists. The role behind the
+ * reference is what carries the name an override is matched on.
+ */
+function suppliedDocument(
+  context: TerraformMappingContext,
+): SimCfnTemplateValue | undefined {
+  const role = terraformReferencedResource(
+    context.resource,
+    "role",
+    context.resolver,
+  );
+
+  return templateValue(
+    context.overrides.policy(role && field(role.values, "name")),
+  );
+}
+
+/** What a role whose policy the plan collapsed is allowed to do. */
+const unknownPolicyDocument: SimCfnTemplateValue = {
+  Version: "2012-10-17",
+  Statement: [{ Effect: "Allow", Action: "*", Resource: "*" }],
+};
+
+/** The name of an inline role policy, which Terraform lets go unnamed. */
+function policyName(context: TerraformMappingContext): string {
+  const name = attribute(context, "name");
+
+  return typeof name === "string" && name.length > 0 ? name : "inline";
+}
+
+/**
+ * A policy document, which Terraform carries as a JSON string and
+ * CloudFormation as an object.
+ *
+ * A document built with `jsonencode` around an ARN of the same plan is unknown
+ * in its entirety, so this returns nothing rather than a partial policy.
+ */
+export function jsonDocument(value: unknown): SimCfnTemplateValue | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const parsed: unknown = JSON.parse(value);
+
+  return isRecord(parsed) ? templateValue(parsed) : undefined;
+}

--- a/src/terraform/map/sim-tf-map-iam.ts
+++ b/src/terraform/map/sim-tf-map-iam.ts
@@ -4,7 +4,6 @@
  * lookup. The records are parsed JSON with no prototype of their own.
  */
 // oxlint-disable security/detect-object-injection
-import { isRecord } from "../../util/type-guard/record.js";
 import type { SimCfnTemplateValue } from "../../service/cloudformation/template/value/sim-cfn-template-value.js";
 import {
   attribute,
@@ -12,9 +11,13 @@ import {
   properties,
   renamed,
   tags,
-  templateValue,
   type TerraformMappingContext,
 } from "../sim-tf-attributes.js";
+import {
+  inlinePolicy,
+  inlinePolicyLost,
+  jsonDocument,
+} from "./sim-tf-map-iam-policy.js";
 import type {
   TerraformMappedResource,
   TerraformResourceFold,
@@ -51,8 +54,7 @@ export const iamRoleFolds: ReadonlyMap<string, TerraformResourceFold> = new Map<
     {
       parentAttribute: "role",
       properties: inlinePolicy,
-      lost: (context) =>
-        inlineDocument(context) === undefined ? ["policy"] : [],
+      lost: inlinePolicyLost,
     },
   ],
   [
@@ -61,70 +63,10 @@ export const iamRoleFolds: ReadonlyMap<string, TerraformResourceFold> = new Map<
   ],
 ]);
 
-/**
- * An inline policy on the role it is attached to.
- *
- * A document built with `jsonencode` around an ARN of the same plan is unknown
- * in its entirety, and its statements are gone with it. What is left is a role
- * whose permissions this cannot know, so the role is created holding a policy
- * that allows everything and the attribute is recorded as lost.
- *
- * Simulated IAM evaluates authorization, so the alternative is a role that
- * denies what the configuration allowed, which fails the resources that use it
- * and takes the rest of the Stack with them. A role that is too permissive is
- * the same answer sim CloudFormation gives a Resource type it cannot create:
- * carry on, and say what was stepped over.
- */
-function inlinePolicy(
-  context: TerraformMappingContext,
-): Record<string, SimCfnTemplateValue> {
-  const document = inlineDocument(context) ?? unknownPolicyDocument;
-
-  return {
-    Policies: [{ PolicyName: policyName(context), PolicyDocument: document }],
-  };
-}
-
-function inlineDocument(
-  context: TerraformMappingContext,
-): SimCfnTemplateValue | undefined {
-  return jsonDocument(field(context.resource.values, "policy"));
-}
-
-/** What a role whose policy the plan collapsed is allowed to do. */
-const unknownPolicyDocument: SimCfnTemplateValue = {
-  Version: "2012-10-17",
-  Statement: [{ Effect: "Allow", Action: "*", Resource: "*" }],
-};
-
 function managedPolicy(
   context: TerraformMappingContext,
 ): Record<string, SimCfnTemplateValue> {
   const arn = attribute(context, "policy_arn");
 
   return arn === undefined ? {} : { ManagedPolicyArns: [arn] };
-}
-
-/** The name of an inline role policy, which Terraform lets go unnamed. */
-function policyName(context: TerraformMappingContext): string {
-  const name = attribute(context, "name");
-
-  return typeof name === "string" && name.length > 0 ? name : "inline";
-}
-
-/**
- * A policy document, which Terraform carries as a JSON string and
- * CloudFormation as an object.
- *
- * A document built with `jsonencode` around an ARN of the same plan is unknown
- * in its entirety, so this returns nothing rather than a partial policy.
- */
-function jsonDocument(value: unknown): SimCfnTemplateValue | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-
-  const parsed: unknown = JSON.parse(value);
-
-  return isRecord(parsed) ? templateValue(parsed) : undefined;
 }

--- a/src/terraform/map/sim-tf-map-lambda-environment.ts
+++ b/src/terraform/map/sim-tf-map-lambda-environment.ts
@@ -1,0 +1,72 @@
+/*
+ * Reading a plan means reading records whose keys come from the document
+ * rather than from this code, so the object-injection rule fires on every
+ * lookup. The records are parsed JSON with no prototype of their own.
+ */
+// oxlint-disable security/detect-object-injection
+import { isRecord } from "../../util/type-guard/record.js";
+import type { SimCfnTemplateValue } from "../../service/cloudformation/template/value/sim-cfn-template-value.js";
+import {
+  block,
+  field,
+  type TerraformMappingContext,
+} from "../sim-tf-attributes.js";
+
+/** What a function's environment came to, and what it cost to get there. */
+export interface TerraformLambdaEnvironment {
+  /** The CloudFormation property, or nothing to leave the property out. */
+  readonly property: SimCfnTemplateValue | undefined;
+  /** `environment.variables`, where the plan lost it and nothing filled it. */
+  readonly lost: readonly string[];
+}
+
+/**
+ * The environment variables a simulated function runs with.
+ *
+ * A map holding one reference to a resource of the same plan is unknown in its
+ * entirety, and the variable names go with it, so a deployment can supply the
+ * map against the function name the plan carries. What the plan resolved wins
+ * over what was supplied, variable by variable, which is what makes a
+ * configuration that later resolves the map stop needing the override.
+ */
+export function lambdaEnvironment(
+  context: TerraformMappingContext,
+): TerraformLambdaEnvironment {
+  const supplied = context.overrides.environment(
+    field(context.resource.values, "function_name"),
+  );
+  const variables = { ...supplied, ...plannedVariables(context) };
+
+  if (Object.keys(variables).length > 0) {
+    return { property: { Variables: variables }, lost: [] };
+  }
+
+  return {
+    property: undefined,
+    lost: collapsed(context) ? ["environment.variables"] : [],
+  };
+}
+
+/** The variables the plan itself resolved, which is usually none of them. */
+function plannedVariables(
+  context: TerraformMappingContext,
+): Readonly<Record<string, string>> {
+  const environment = block(context, "environment");
+  const variables = environment && field(environment, "variables");
+
+  return isRecord(variables) ? (variables as Record<string, string>) : {};
+}
+
+/**
+ * Whether Terraform marked the whole variables map unknown.
+ *
+ * A function declaring no environment at all has lost nothing. One whose map
+ * collapsed has lost names this cannot know, which is the case an override is
+ * for.
+ */
+function collapsed(context: TerraformMappingContext): boolean {
+  const declared = field(context.resource.unknown, "environment");
+  const entries: readonly unknown[] = Array.isArray(declared) ? declared : [];
+
+  return isRecord(entries[0]) && field(entries[0], "variables") === true;
+}

--- a/src/terraform/map/sim-tf-map-lambda-environment.ts
+++ b/src/terraform/map/sim-tf-map-lambda-environment.ts
@@ -63,6 +63,11 @@ function plannedVariables(
  * A function declaring no environment at all has lost nothing. One whose map
  * collapsed has lost names this cannot know, which is the case an override is
  * for.
+ *
+ * The map goes whole or not at all. Terraform 1.15.8 against AWS provider
+ * 5.100.0 writes `"variables": true` for a map holding one literal and one
+ * reference to a resource of the same plan, so there is no per-variable form
+ * of this to read.
  */
 function collapsed(context: TerraformMappingContext): boolean {
   const declared = field(context.resource.unknown, "environment");

--- a/src/terraform/map/sim-tf-map-lambda.ts
+++ b/src/terraform/map/sim-tf-map-lambda.ts
@@ -1,20 +1,10 @@
-/*
- * Reading a plan means reading records whose keys come from the document
- * rather than from this code, so the object-injection rule fires on every
- * lookup. The records are parsed JSON with no prototype of their own.
- */
-// oxlint-disable security/detect-object-injection
-import { isRecord } from "../../util/type-guard/record.js";
-import type { SimCfnTemplateValue } from "../../service/cloudformation/template/value/sim-cfn-template-value.js";
 import {
-  block,
-  field,
   properties,
   renamed,
   tags,
-  templateValue,
   type TerraformMappingContext,
 } from "../sim-tf-attributes.js";
+import { lambdaEnvironment } from "./sim-tf-map-lambda-environment.js";
 import type { TerraformMappedResource } from "../sim-tf-mapping.type.js";
 
 /**
@@ -28,7 +18,7 @@ import type { TerraformMappedResource } from "../sim-tf-mapping.type.js";
 export function lambdaFunction(
   context: TerraformMappingContext,
 ): TerraformMappedResource {
-  const variables = environmentVariables(context);
+  const environment = lambdaEnvironment(context);
 
   return {
     Type: "AWS::Lambda::Function",
@@ -42,11 +32,16 @@ export function lambdaFunction(
         MemorySize: "memory_size",
       }),
       ...properties({
-        Environment: variables && { Variables: variables },
+        Environment: environment.property,
         Tags: tags(context),
       }),
     },
-    lost: lost(context, variables),
+    /*
+     * The code is always lost, since a plan points at a zip, an S3 object or
+     * an image. The environment joins it only where the plan collapsed the
+     * variables map and no override supplied one.
+     */
+    lost: ["code", ...environment.lost],
     /*
      * A function whose execution role the plan does not create, such as one
      * read out of a data source, has no role for the template to name. Sim
@@ -55,43 +50,6 @@ export function lambdaFunction(
      */
     requires: ["Role"],
   };
-}
-
-function environmentVariables(
-  context: TerraformMappingContext,
-): Record<string, never> | undefined {
-  const environment = block(context, "environment");
-  const variables = environment && field(environment, "variables");
-
-  if (!isRecord(variables)) {
-    return undefined;
-  }
-
-  const value: SimCfnTemplateValue | undefined = templateValue(variables);
-
-  return value as Record<string, never> | undefined;
-}
-
-/**
- * What the mapping could not carry.
- *
- * The code is always one. The environment variables are another whenever any
- * value in the map names a resource of the same plan, because Terraform marks
- * the whole map unknown and the variable names go with it.
- */
-function lost(
-  context: TerraformMappingContext,
-  variables: Record<string, never> | undefined,
-): readonly string[] {
-  const declared = field(context.resource.unknown, "environment");
-  const entries: readonly unknown[] = Array.isArray(declared) ? declared : [];
-  const first = entries[0];
-  const collapsed =
-    isRecord(first) &&
-    field(first, "variables") === true &&
-    variables === undefined;
-
-  return collapsed ? ["code", "environment.variables"] : ["code"];
 }
 
 /** One permission to invoke a function. */

--- a/src/terraform/sim-tf-adapter.ts
+++ b/src/terraform/sim-tf-adapter.ts
@@ -7,6 +7,7 @@ import {
   readTerraformPlanFile,
   terraformStackNameFromPlanPath,
 } from "./sim-tf-plan-file.js";
+import type { TerraformPlanOverride } from "./sim-tf-override.type.js";
 import type { TerraformImportReport } from "./sim-tf-report.type.js";
 
 export interface TerraformPlanDeployProperties {
@@ -30,6 +31,20 @@ export interface TerraformPlanDeployProperties {
    * gets its behaviour.
    */
   readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
+
+  /**
+   * The values the plan could not carry.
+   *
+   * Terraform resolves nothing inside a value it could not build, so a Lambda
+   * `environment.variables` map holding one reference to a queue of the same
+   * plan arrives without its variable names, and an `aws_iam_role_policy`
+   * document built with `jsonencode` arrives without its statements. An
+   * override supplies one of those against the name the plan carries, and is
+   * used only where the plan resolved nothing.
+   *
+   * What no override covers is named on the report's `lost`.
+   */
+  readonly overrides?: readonly TerraformPlanOverride[] | undefined;
 }
 
 /** What one plan deployed as, and what reading the plan made of it. */
@@ -81,10 +96,11 @@ export class TerraformAdapter {
   ): Promise<TerraformPlanDeployment> {
     const deployment =
       typeof properties === "string" ? { planPath: properties } : properties;
-    const { planPath, bindings } = deployment;
+    const { planPath, bindings, overrides } = deployment;
 
     const { template, report } = cfnTemplateFromTerraformPlan(
       await readTerraformPlanFile(planPath),
+      overrides,
     );
 
     const stack = await this.simAws.cloudFormation().deployTemplate({

--- a/src/terraform/sim-tf-attributes.ts
+++ b/src/terraform/sim-tf-attributes.ts
@@ -8,15 +8,25 @@ import { isRecord } from "../util/type-guard/record.js";
 import type { SimCfnTemplateValue } from "../service/cloudformation/template/value/sim-cfn-template-value.js";
 import type { TerraformResource } from "./sim-tf-resource.type.js";
 import type { TerraformReferenceResolver } from "./sim-tf-reference.js";
+import type { TerraformPlanOverrides } from "./sim-tf-overrides.js";
 import { longestFirst } from "./sim-tf-reference-address.js";
 import type { TerraformExpression } from "./sim-tf-plan.type.js";
 
 /**
+ * What a mapping resolves against, which is the same for every resource of one
+ * plan. A settled plan carries these two, so it is one of these.
+ */
+export interface TerraformBuildContext {
+  readonly resolver: TerraformReferenceResolver;
+  /** What the deployment supplied for the values the plan could not carry. */
+  readonly overrides: TerraformPlanOverrides;
+}
+
+/**
  * What a mapping function is given to build one CloudFormation Resource.
  */
-export interface TerraformMappingContext {
+export interface TerraformMappingContext extends TerraformBuildContext {
   readonly resource: TerraformResource;
-  readonly resolver: TerraformReferenceResolver;
 }
 
 /**

--- a/src/terraform/sim-tf-declare.ts
+++ b/src/terraform/sim-tf-declare.ts
@@ -35,7 +35,11 @@ export function terraformDeclaredResources(
   const lost: TerraformLostAttribute[] = [];
 
   for (const { resource, mapping } of settled.declared) {
-    const built = mapping({ resource, resolver: settled.resolver });
+    const built = mapping({
+      resource,
+      resolver: settled.resolver,
+      overrides: settled.overrides,
+    });
     const logicalId = settled.resolver.logicalId(resource.address);
 
     templates.set(logicalId, {

--- a/src/terraform/sim-tf-deploy-overrides.iso.test.ts
+++ b/src/terraform/sim-tf-deploy-overrides.iso.test.ts
@@ -1,0 +1,225 @@
+import { describe, it } from "vitest";
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  assertArrayEquals,
+  assertArrayIncludes,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { terraformPlanResourceFactory } from "../../test/terraform/plan/terraform-plan.factory.js";
+import { terraformPlanFile } from "../../test/terraform/plan/terraform-plan-file.js";
+import { SimAws } from "../service/aws/sim-aws.js";
+import { TerraformAdapter } from "./sim-tf-adapter.js";
+import type { TerraformPlanOverride } from "./sim-tf-override.type.js";
+
+const assumeRolePolicy = JSON.stringify({
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Principal: { Service: "lambda.amazonaws.com" },
+      Action: "sts:AssumeRole",
+    },
+  ],
+});
+
+/**
+ * A plan of the shape the two lost attributes turn up in.
+ *
+ * The function reads a queue of the same plan into its environment and polls
+ * it through an event source mapping, and the role's inline policy is built
+ * with `jsonencode` around the queue's ARN. Terraform marks both unknown in
+ * their entirety.
+ */
+async function processingPlan(): Promise<string> {
+  return await terraformPlanFile({
+    resources: [
+      terraformPlanResourceFactory.make({
+        type: "aws_iam_role",
+        name: "processor",
+        values: {
+          name: "orders-processor",
+          assume_role_policy: assumeRolePolicy,
+        },
+      }),
+      terraformPlanResourceFactory.make({
+        type: "aws_iam_role_policy",
+        name: "processor",
+        values: { name: "polls-the-queue" },
+        unknown: { policy: true, role: true },
+        references: {
+          role: ["aws_iam_role.processor.id", "aws_iam_role.processor"],
+        },
+      }),
+      terraformPlanResourceFactory.make({
+        type: "aws_sqs_queue",
+        name: "processing",
+        values: { name: "orders-processing" },
+      }),
+      terraformPlanResourceFactory.make({
+        type: "aws_lambda_function",
+        name: "processor",
+        values: {
+          function_name: "orders-processor",
+          handler: "index.handler",
+          runtime: "nodejs20.x",
+        },
+        unknown: { role: true, environment: [{ variables: true }] },
+        references: {
+          role: ["aws_iam_role.processor.arn", "aws_iam_role.processor"],
+        },
+      }),
+      terraformPlanResourceFactory.make({
+        type: "aws_lambda_event_source_mapping",
+        name: "processing",
+        unknown: { event_source_arn: true, function_name: true },
+        references: {
+          event_source_arn: [
+            "aws_sqs_queue.processing.arn",
+            "aws_sqs_queue.processing",
+          ],
+          function_name: [
+            "aws_lambda_function.processor.arn",
+            "aws_lambda_function.processor",
+          ],
+        },
+      }),
+    ],
+  });
+}
+
+/** A handler that answers with what its environment was built with. */
+const readsItsEnvironment = (): { queueUrl: string | undefined } => ({
+  queueUrl: process.env["QUEUE_URL"],
+});
+
+const pollsTheQueue: TerraformPlanOverride = {
+  roleName: "orders-processor",
+  policy: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Action: [
+          "sqs:ReceiveMessage",
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes",
+        ],
+        Resource: "*",
+      },
+    ],
+  },
+};
+
+describe("deploying a plan with the values it could not carry", () => {
+  it("runs the function with the environment variables it was given", async () => {
+    // Given a plan whose function reads a queue URL out of its environment,
+    // which Terraform marks unknown along with the variable names
+    const planPath = await processingPlan();
+
+    // When it is deployed with that environment supplied against the function
+    // name the plan carries
+    const simAws = new SimAws();
+    const { report } = await new TerraformAdapter(simAws).deployPlan({
+      planPath,
+      overrides: [
+        {
+          functionName: "orders-processor",
+          environment: { QUEUE_URL: "http://sqs.test/orders-processing" },
+        },
+        pollsTheQueue,
+      ],
+      bindings: [
+        { functionName: "orders-processor", handler: readsItsEnvironment },
+      ],
+    });
+
+    // Then the handler reads them the way it would on AWS, and the report no
+    // longer names the map as lost
+    const invoked = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "orders-processor" }));
+
+    assertStringIncludes(
+      Buffer.from(invoked.Payload ?? new Uint8Array()).toString("utf8"),
+      "http://sqs.test/orders-processing",
+    );
+    assertArrayEquals(
+      report.lost.map((entry) => entry.attribute),
+      ["code"],
+    );
+  });
+
+  it("gives simulated IAM the role policy it was given", async () => {
+    // Given a plan whose inline role policy Terraform built with jsonencode
+    // around an ARN of the same plan, so its statements are gone
+    const planPath = await processingPlan();
+
+    // When it is deployed with the policy supplied against the role's name
+    const simAws = new SimAws();
+    const { stack, report } = await new TerraformAdapter(simAws).deployPlan({
+      planPath,
+      overrides: [pollsTheQueue],
+      bindings: [
+        { functionName: "orders-processor", handler: readsItsEnvironment },
+      ],
+    });
+
+    // Then the role holds those statements rather than a policy allowing
+    // everything, and the event source mapping simulated IAM checks the role
+    // against was created
+    const role = simAws
+      .iam()
+      .roles.values()
+      .find((candidate) => candidate.roleName === "orders-processor");
+
+    assertNonNullable(role);
+    assertIdentical(
+      role.inlinePolicies.get("polls-the-queue"),
+      JSON.stringify(pollsTheQueue.policy),
+    );
+    assertArrayIncludes(
+      report.mapped.map((entry) => entry.type),
+      "aws_lambda_event_source_mapping",
+    );
+    assertIdentical(stack.status, "CREATE_COMPLETE");
+  });
+
+  it("refuses a poller the supplied policy does not allow", async () => {
+    // Given the same plan, and a policy supplied for the role that says
+    // nothing about the queue the function is meant to poll
+    const planPath = await processingPlan();
+
+    // When it is deployed
+    const error = await assertThrowsErrorAsync(async () => {
+      await new TerraformAdapter(new SimAws()).deployPlan({
+        planPath,
+        overrides: [
+          {
+            roleName: "orders-processor",
+            policy: {
+              Version: "2012-10-17",
+              Statement: [
+                { Effect: "Allow", Action: "s3:GetObject", Resource: "*" },
+              ],
+            },
+          },
+        ],
+        bindings: [
+          { functionName: "orders-processor", handler: readsItsEnvironment },
+        ],
+      });
+    });
+
+    // Then the event source mapping is refused the way real Lambda refuses
+    // one, which is what a supplied policy being evaluated rather than
+    // recorded means. The permissive default is only for the role no override
+    // covered
+    assertStringIncludes(
+      error.message,
+      "does not have permissions to call ReceiveMessage on SQS",
+    );
+  });
+});

--- a/src/terraform/sim-tf-deploy.iso.test.ts
+++ b/src/terraform/sim-tf-deploy.iso.test.ts
@@ -7,30 +7,11 @@ import {
   assertThrowsErrorAsync,
   assertStringIncludes,
 } from "@kensio/smartass";
-import {
-  terraformPlanFactory,
-  terraformPlanResourceFactory,
-  type TerraformPlanFixture,
-} from "../../test/terraform/plan/terraform-plan.factory.js";
+import { terraformPlanResourceFactory } from "../../test/terraform/plan/terraform-plan.factory.js";
+import { terraformPlanFile as planFile } from "../../test/terraform/plan/terraform-plan-file.js";
 import { TemporaryDirectory } from "../util/filesystem/temporary-directory.js";
 import { SimAws } from "../service/aws/sim-aws.js";
 import { TerraformAdapter } from "./sim-tf-adapter.js";
-import { jsonStringify } from "../util/type-guard/json.js";
-
-/** Write a plan fixture out as the JSON `terraform show -json` writes. */
-async function planFile(
-  fixture: Partial<TerraformPlanFixture>,
-  fileName = "orders.tfplan.json",
-): Promise<string> {
-  const directory = new TemporaryDirectory();
-
-  await directory.writeFile(
-    fileName,
-    jsonStringify(terraformPlanFactory.make(fixture)),
-  );
-
-  return directory.join(fileName);
-}
 
 describe("deploying a Terraform plan into simulated AWS", () => {
   it("creates the resources of a plan file", async () => {

--- a/src/terraform/sim-tf-fold.ts
+++ b/src/terraform/sim-tf-fold.ts
@@ -6,13 +6,13 @@
 // oxlint-disable security/detect-object-injection
 import { isRecord } from "../util/type-guard/record.js";
 import type { SimCfnTemplateValueRecord } from "../service/cloudformation/template/value/sim-cfn-template-value.js";
-import type { TerraformExpression } from "./sim-tf-plan.type.js";
 import {
   terraformAwsProvider,
   type TerraformResource,
 } from "./sim-tf-resource.type.js";
 import type { TerraformReferenceResolver } from "./sim-tf-reference.js";
-import { longestFirst } from "./sim-tf-reference-address.js";
+import { terraformReferencedAddress } from "./sim-tf-referenced.js";
+import type { TerraformPlanOverrides } from "./sim-tf-overrides.js";
 import { terraformResourceFolds } from "./sim-tf-registry.js";
 import type {
   TerraformImportedResource,
@@ -44,6 +44,7 @@ export function terraformFoldedResources(
   resources: readonly TerraformResource[],
   templates: ReadonlyMap<string, SimCfnTemplateValueRecord>,
   resolver: TerraformReferenceResolver,
+  overrides: TerraformPlanOverrides,
 ): TerraformFoldedResources {
   const merged = new Map(templates);
   const folded: TerraformImportedResource[] = [];
@@ -57,11 +58,13 @@ export function terraformFoldedResources(
       continue;
     }
 
-    const parentId = foldTargetLogicalId(
+    const address = terraformReferencedAddress(
       resource,
       fold.parentAttribute,
       resolver,
     );
+    const parentId =
+      address === undefined ? undefined : resolver.logicalId(address);
     const parent = parentId === undefined ? undefined : merged.get(parentId);
 
     if (parentId === undefined || parent === undefined) {
@@ -73,13 +76,12 @@ export function terraformFoldedResources(
       continue;
     }
 
-    merged.set(
-      parentId,
-      mergedParent(parent, fold.properties({ resource, resolver })),
-    );
+    const context = { resource, resolver, overrides };
+
+    merged.set(parentId, mergedParent(parent, fold.properties(context)));
     folded.push({ address: resource.address, type: resource.type });
     lost.push(
-      ...(fold.lost?.({ resource, resolver }) ?? []).map((attribute) => ({
+      ...(fold.lost?.(context) ?? []).map((attribute) => ({
         address: resource.address,
         attribute,
       })),
@@ -87,39 +89,6 @@ export function terraformFoldedResources(
   }
 
   return { templates: merged, folded, skipped, lost };
-}
-
-/**
- * The logical ID of the resource a fold belongs to.
- *
- * The fold's parent attribute holds a reference rather than a value, because a
- * bucket or a role being created by the same plan has no name until it exists.
- * The reference names the resource directly, which is what a fold needs.
- */
-function foldTargetLogicalId(
-  resource: TerraformResource,
-  parentAttribute: string,
-  resolver: TerraformReferenceResolver,
-): string | undefined {
-  const expression = resource.expressions[parentAttribute];
-
-  if (!isRecord(expression)) {
-    return undefined;
-  }
-
-  const references = longestFirst(
-    (expression as TerraformExpression).references ?? [],
-  );
-
-  for (const reference of references) {
-    const address = resolver.targetAddress(reference, resource.modulePath);
-
-    if (address !== undefined) {
-      return resolver.logicalId(address);
-    }
-  }
-
-  return undefined;
 }
 
 /**

--- a/src/terraform/sim-tf-import.ts
+++ b/src/terraform/sim-tf-import.ts
@@ -5,6 +5,8 @@ import { settledTerraformPlan } from "./sim-tf-settle.js";
 import { terraformDeclaredResources } from "./sim-tf-declare.js";
 import { terraformFoldedResources } from "./sim-tf-fold.js";
 import { terraformImportReport } from "./sim-tf-report.js";
+import { TerraformPlanOverrides } from "./sim-tf-overrides.js";
+import type { TerraformPlanOverride } from "./sim-tf-override.type.js";
 import type { TerraformImportReport } from "./sim-tf-report.type.js";
 
 /** A CloudFormation template built from a plan, and what building it did. */
@@ -35,14 +37,17 @@ export interface TerraformImportResult {
  */
 export function cfnTemplateFromTerraformPlan(
   plan: TerraformPlan,
+  supplied: readonly TerraformPlanOverride[] = [],
 ): TerraformImportResult {
+  const overrides = new TerraformPlanOverrides(supplied);
   const resources = terraformPlanResources(plan);
-  const settled = settledTerraformPlan(plan, resources);
+  const settled = settledTerraformPlan(plan, resources, overrides);
   const declared = terraformDeclaredResources(settled);
   const folded = terraformFoldedResources(
     resources,
     declared.templates,
     settled.resolver,
+    overrides,
   );
 
   return {

--- a/src/terraform/sim-tf-override.type.ts
+++ b/src/terraform/sim-tf-override.type.ts
@@ -1,0 +1,40 @@
+import type { SimIamPolicyDocument } from "../service/iam/policy/sim-iam-policy.js";
+
+/**
+ * A value a deployment supplies because the plan could not carry it.
+ *
+ * Terraform resolves nothing inside a value it could not build, so an
+ * attribute holding one reference to a resource of the same plan arrives
+ * unknown along with everything around it. A Lambda `environment.variables`
+ * map loses its variable names, and an `aws_iam_role_policy` document built
+ * with `jsonencode` loses its statements.
+ *
+ * An override is matched the way a deploy binding is, on the name the plan
+ * carries. It fills a gap and never replaces what the plan resolved, so a
+ * configuration that later resolves the value on its own stops needing one.
+ */
+export type TerraformPlanOverride =
+  | TerraformFunctionEnvironmentOverride
+  | TerraformRolePolicyOverride;
+
+/** The environment variables of the function the plan names. */
+export interface TerraformFunctionEnvironmentOverride {
+  readonly functionName: string;
+  readonly environment: Readonly<Record<string, string>>;
+  readonly roleName?: never;
+  readonly policy?: never;
+}
+
+/**
+ * The inline policy of the role the plan names.
+ *
+ * The name is the role's own `name`, which is what a plan resolves for a role
+ * declared with one, rather than the name of the `aws_iam_role_policy`
+ * resource holding the document.
+ */
+export interface TerraformRolePolicyOverride {
+  readonly roleName: string;
+  readonly policy: SimIamPolicyDocument;
+  readonly functionName?: never;
+  readonly environment?: never;
+}

--- a/src/terraform/sim-tf-overrides.iso.test.ts
+++ b/src/terraform/sim-tf-overrides.iso.test.ts
@@ -127,6 +127,31 @@ describe("supplying the environment variables a plan could not carry", () => {
     });
   });
 
+  it("adds a variable to the ones the plan resolved", () => {
+    // Given a function whose variables the plan resolved, and a deployment
+    // supplying one the map does not name
+    const context = processor(
+      { environment: [{ variables: { STAGE: "production" } }] },
+      {},
+      [
+        {
+          functionName: "orders-processor",
+          environment: { QUEUE_URL: "http://sqs.test/orders" },
+        },
+      ],
+    );
+
+    // When the function is mapped
+    // Then the function runs with both, since the two are merged one variable
+    // at a time
+    assertObjectEquals(lambdaFunction(context).Properties["Environment"], {
+      Variables: {
+        STAGE: "production",
+        QUEUE_URL: "http://sqs.test/orders",
+      },
+    });
+  });
+
   it("records the variables no override covered", () => {
     // Given a function whose variables map collapsed, and a deployment
     // supplying an environment for a different function
@@ -176,6 +201,31 @@ describe("supplying the inline role policy a plan could not carry", () => {
     // When it is folded
     // Then the role is created permissive and the attribute is recorded, so a
     // deployment that would otherwise be useful still goes ahead
+    assertObjectEquals(fold.properties(context), {
+      Policies: [
+        {
+          PolicyName: "reads",
+          PolicyDocument: {
+            Version: "2012-10-17",
+            Statement: [{ Effect: "Allow", Action: "*", Resource: "*" }],
+          },
+        },
+      ],
+    });
+    assertArrayEquals(fold.lost?.(context) ?? [], ["policy"]);
+  });
+
+  it("falls back for a policy document the plan carries unparseable", () => {
+    // Given a plan whose policy attribute holds a string that will not parse,
+    // which a hand-edited or truncated plan file is how you get
+    const fold = iamRoleFolds.get("aws_iam_role_policy");
+    const context = inlinePolicy({ name: "reads", policy: "{not json" }, []);
+
+    assertDefined(fold, "The aws_iam_role_policy fold");
+
+    // When it is folded
+    // Then the one attribute is lost and the deployment goes ahead, rather
+    // than the parse taking the whole import with it
     assertObjectEquals(fold.properties(context), {
       Policies: [
         {

--- a/src/terraform/sim-tf-overrides.iso.test.ts
+++ b/src/terraform/sim-tf-overrides.iso.test.ts
@@ -1,0 +1,214 @@
+import { describe, it } from "vitest";
+import {
+  assertArrayEquals,
+  assertObjectEquals,
+  assertUndefined,
+} from "@kensio/smartass";
+import { assertDefined } from "../util/type-guard/defined.js";
+import { terraformPlanResourceFactory } from "../../test/terraform/plan/terraform-plan.factory.js";
+import { terraformMappingContext as contextFor } from "../../test/terraform/plan/terraform-mapping-context.js";
+import { iamRoleFolds } from "./map/sim-tf-map-iam.js";
+import { lambdaFunction } from "./map/sim-tf-map-lambda.js";
+import type { TerraformMappingContext } from "./sim-tf-attributes.js";
+import type { TerraformPlanOverride } from "./sim-tf-override.type.js";
+
+/**
+ * A function of a plan, mapped with what the deployment supplied.
+ *
+ * The values a test gives are the ones it cares about, and the unknown record
+ * is how Terraform marks what it could not resolve.
+ */
+function processor(
+  values: Record<string, unknown>,
+  unknown: Record<string, unknown>,
+  overrides: readonly TerraformPlanOverride[],
+): TerraformMappingContext {
+  return contextFor(
+    {
+      resources: [
+        terraformPlanResourceFactory.make({
+          type: "aws_lambda_function",
+          name: "processor",
+          values: {
+            function_name: "orders-processor",
+            role: "arn:aws:iam::1:role/orders",
+            ...values,
+          },
+          unknown,
+        }),
+      ],
+    },
+    overrides,
+  );
+}
+
+/**
+ * An inline policy of a plan, with the role it is attached to.
+ *
+ * The `role` attribute holds a reference rather than a name, the way it does
+ * in a plan that creates the role, so the role's own name is what an override
+ * has to be matched on.
+ */
+function inlinePolicy(
+  values: Record<string, unknown>,
+  overrides: readonly TerraformPlanOverride[],
+): TerraformMappingContext {
+  return contextFor(
+    {
+      resources: [
+        terraformPlanResourceFactory.make({
+          type: "aws_iam_role_policy",
+          name: "processor",
+          values,
+          unknown: { policy: true, role: true },
+          references: {
+            role: ["aws_iam_role.processor.id", "aws_iam_role.processor"],
+          },
+        }),
+        terraformPlanResourceFactory.make({
+          type: "aws_iam_role",
+          name: "processor",
+          values: { name: "orders-processor" },
+        }),
+      ],
+    },
+    overrides,
+  );
+}
+
+const readsTheQueue = {
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Action: "sqs:ReceiveMessage",
+      Resource: "arn:aws:sqs:eu-west-1:1:orders-processing",
+    },
+  ],
+} as const;
+
+describe("supplying the environment variables a plan could not carry", () => {
+  it("carries the variables supplied for the function the plan names", () => {
+    // Given a function whose variables map holds a reference to a queue of
+    // the same plan, which Terraform marks unknown in its entirety, and a
+    // deployment supplying the map against the function's own name
+    const context = processor({}, { environment: [{ variables: true }] }, [
+      {
+        functionName: "orders-processor",
+        environment: { QUEUE_URL: "http://sqs.test/orders", STAGE: "test" },
+      },
+    ]);
+
+    // When the function is mapped
+    const mapped = lambdaFunction(context);
+
+    // Then the function runs with what was supplied, and only the code is
+    // still recorded as lost
+    assertObjectEquals(mapped.Properties["Environment"], {
+      Variables: { QUEUE_URL: "http://sqs.test/orders", STAGE: "test" },
+    });
+    assertArrayEquals(mapped.lost ?? [], ["code"]);
+  });
+
+  it("leaves the variables the plan resolved alone", () => {
+    // Given a function whose variables the plan resolved, and a deployment
+    // supplying a different value for one of them
+    const context = processor(
+      { environment: [{ variables: { STAGE: "production" } }] },
+      {},
+      [{ functionName: "orders-processor", environment: { STAGE: "test" } }],
+    );
+
+    // When the function is mapped
+    // Then the plan wins, because an override fills a gap rather than
+    // replacing what the configuration says
+    assertObjectEquals(lambdaFunction(context).Properties["Environment"], {
+      Variables: { STAGE: "production" },
+    });
+  });
+
+  it("records the variables no override covered", () => {
+    // Given a function whose variables map collapsed, and a deployment
+    // supplying an environment for a different function
+    const context = processor({}, { environment: [{ variables: true }] }, [
+      { functionName: "orders-reporter", environment: { STAGE: "test" } },
+    ]);
+
+    // When the function is mapped
+    const mapped = lambdaFunction(context);
+
+    // Then the gap is still there and the report still names it
+    assertUndefined(mapped.Properties["Environment"]);
+    assertArrayEquals(mapped.lost ?? [], ["code", "environment.variables"]);
+  });
+});
+
+describe("supplying the inline role policy a plan could not carry", () => {
+  it("carries the policy supplied for the role the plan names", () => {
+    // Given an inline policy built with jsonencode around an ARN of the same
+    // plan, and a deployment supplying the document against the role's name
+    const fold = iamRoleFolds.get("aws_iam_role_policy");
+    const context = inlinePolicy({ name: "reads" }, [
+      { roleName: "orders-processor", policy: readsTheQueue },
+    ]);
+
+    assertDefined(fold, "The aws_iam_role_policy fold");
+
+    // When it is folded into its role
+    // Then simulated IAM has the statements the configuration meant, rather
+    // than a role that allows everything, and nothing is recorded as lost
+    assertObjectEquals(fold.properties(context), {
+      Policies: [{ PolicyName: "reads", PolicyDocument: readsTheQueue }],
+    });
+    assertArrayEquals(fold.lost?.(context) ?? [], []);
+  });
+
+  it("allows everything for a role no override covered", () => {
+    // Given a collapsed inline policy, and a deployment supplying a document
+    // for a different role
+    const fold = iamRoleFolds.get("aws_iam_role_policy");
+    const context = inlinePolicy({ name: "reads" }, [
+      { roleName: "orders-reporter", policy: readsTheQueue },
+    ]);
+
+    assertDefined(fold, "The aws_iam_role_policy fold");
+
+    // When it is folded
+    // Then the role is created permissive and the attribute is recorded, so a
+    // deployment that would otherwise be useful still goes ahead
+    assertObjectEquals(fold.properties(context), {
+      Policies: [
+        {
+          PolicyName: "reads",
+          PolicyDocument: {
+            Version: "2012-10-17",
+            Statement: [{ Effect: "Allow", Action: "*", Resource: "*" }],
+          },
+        },
+      ],
+    });
+    assertArrayEquals(fold.lost?.(context) ?? [], ["policy"]);
+  });
+
+  it("leaves the policy the plan resolved alone", () => {
+    // Given an inline policy Terraform rendered in full, and a deployment
+    // supplying a document for the same role
+    const fold = iamRoleFolds.get("aws_iam_role_policy");
+    const resolved = {
+      Version: "2012-10-17",
+      Statement: [{ Effect: "Allow", Action: "s3:GetObject", Resource: "*" }],
+    };
+    const context = inlinePolicy(
+      { name: "reads", policy: JSON.stringify(resolved) },
+      [{ roleName: "orders-processor", policy: readsTheQueue }],
+    );
+
+    assertDefined(fold, "The aws_iam_role_policy fold");
+
+    // When it is folded
+    // Then the document the plan carried is the one the role gets
+    assertObjectEquals(fold.properties(context), {
+      Policies: [{ PolicyName: "reads", PolicyDocument: resolved }],
+    });
+  });
+});

--- a/src/terraform/sim-tf-overrides.ts
+++ b/src/terraform/sim-tf-overrides.ts
@@ -1,0 +1,65 @@
+import type { SimIamPolicyDocument } from "../service/iam/policy/sim-iam-policy.js";
+import type {
+  TerraformFunctionEnvironmentOverride,
+  TerraformPlanOverride,
+  TerraformRolePolicyOverride,
+} from "./sim-tf-override.type.js";
+
+/**
+ * The values a deployment supplied for the gaps a plan left, by the name each
+ * one is matched on.
+ *
+ * A mapping asks this for the name the plan gave a resource and gets back what
+ * was supplied for it, or nothing. Asking with a name the plan itself could not
+ * resolve gets nothing back, which is the same answer as no override, so a
+ * mapping has one case to handle rather than two.
+ */
+export class TerraformPlanOverrides {
+  private readonly environments: ReadonlyMap<
+    string,
+    Readonly<Record<string, string>>
+  >;
+
+  private readonly policies: ReadonlyMap<string, SimIamPolicyDocument>;
+
+  constructor(overrides: readonly TerraformPlanOverride[] = []) {
+    this.environments = new Map(
+      overrides
+        .filter(isEnvironmentOverride)
+        .map((override) => [override.functionName, override.environment]),
+    );
+    this.policies = new Map(
+      overrides
+        .filter(isRolePolicyOverride)
+        .map((override) => [override.roleName, override.policy]),
+    );
+  }
+
+  /** The environment variables supplied for one function name. */
+  public environment(
+    functionName: unknown,
+  ): Readonly<Record<string, string>> | undefined {
+    return typeof functionName === "string"
+      ? this.environments.get(functionName)
+      : undefined;
+  }
+
+  /** The inline policy document supplied for one role name. */
+  public policy(roleName: unknown): SimIamPolicyDocument | undefined {
+    return typeof roleName === "string"
+      ? this.policies.get(roleName)
+      : undefined;
+  }
+}
+
+function isEnvironmentOverride(
+  override: TerraformPlanOverride,
+): override is TerraformFunctionEnvironmentOverride {
+  return override.functionName !== undefined;
+}
+
+function isRolePolicyOverride(
+  override: TerraformPlanOverride,
+): override is TerraformRolePolicyOverride {
+  return override.roleName !== undefined;
+}

--- a/src/terraform/sim-tf-plan-deploy.loc.test.ts
+++ b/src/terraform/sim-tf-plan-deploy.loc.test.ts
@@ -5,6 +5,7 @@ import {
   assertArrayMinLength,
   assertIdentical,
   assertNonNullable,
+  assertObjectEquals,
   assertObjectHasProperty,
 } from "@kensio/smartass";
 import { SimAws } from "../service/aws/sim-aws.js";
@@ -172,5 +173,54 @@ describe("deploying a plan Terraform itself produced", () => {
     // Then it is recorded as lost rather than guessed at, because Terraform
     // resolves nothing inside a value it could not build
     assertArrayIncludes(lost, "environment.variables");
+  });
+
+  it("takes the values a deployment supplies for what the plan collapsed", async () => {
+    // Given the same configuration, and a deployment supplying the two
+    // attributes Terraform could not carry: the function's environment and
+    // the role's inline policy
+    const planPath = await plannedPath("app");
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const { report } = await new TerraformAdapter(simAws).deployPlan({
+      planPath,
+      stackName: "supplied-app",
+      bindings: handlersFor("app"),
+      overrides: [
+        {
+          functionName: "orders-processor",
+          environment: { TABLE_NAME: "orders-orders", STAGE: "test" },
+        },
+        {
+          roleName: "orders-processor",
+          policy: {
+            Version: "2012-10-17",
+            Statement: [
+              { Effect: "Allow", Action: "dynamodb:*", Resource: "*" },
+              { Effect: "Allow", Action: "sqs:*", Resource: "*" },
+            ],
+          },
+        },
+      ],
+    });
+
+    // Then the function runs with the variables it was given, simulated IAM
+    // holds the statements the configuration meant, and neither attribute is
+    // named as lost any more
+    assertObjectEquals(
+      Object.fromEntries(
+        simAws.lambda().getSimFunctionByName("orders-processor")?.environment
+          .declaredVariables ?? [],
+      ),
+      { TABLE_NAME: "orders-orders", STAGE: "test" },
+    );
+
+    assertArrayLength(
+      report.lost.filter((entry) =>
+        ["environment.variables", "policy"].includes(entry.attribute),
+      ),
+      0,
+    );
   });
 });

--- a/src/terraform/sim-tf-reference.ts
+++ b/src/terraform/sim-tf-reference.ts
@@ -43,6 +43,15 @@ export class TerraformReferenceResolver {
   }
 
   /**
+   * The resource at one address, for a caller that needs the resource rather
+   * than a value read off it. A mapping reading a name out of the resource its
+   * own attribute refers to is what wants this.
+   */
+  public resource(address: string): TerraformResource | undefined {
+    return this.byAddress.get(address);
+  }
+
+  /**
    * The CloudFormation value one reference stands for.
    *
    * A reference to a resource the template does not declare returns undefined,

--- a/src/terraform/sim-tf-referenced.ts
+++ b/src/terraform/sim-tf-referenced.ts
@@ -1,0 +1,60 @@
+/*
+ * Reading a plan means reading records whose keys come from the document
+ * rather than from this code, so the object-injection rule fires on every
+ * lookup. The records are parsed JSON with no prototype of their own.
+ */
+// oxlint-disable security/detect-object-injection
+import { isRecord } from "../util/type-guard/record.js";
+import type { TerraformExpression } from "./sim-tf-plan.type.js";
+import type { TerraformResource } from "./sim-tf-resource.type.js";
+import type { TerraformReferenceResolver } from "./sim-tf-reference.js";
+import { longestFirst } from "./sim-tf-reference-address.js";
+
+/**
+ * The resource one attribute of a resource refers to.
+ *
+ * A fold reads the resource it configures this way, because its parent
+ * attribute holds a reference rather than a value. A bucket or a role being
+ * created by the same plan has no name until it exists, so the reference is
+ * all there is to go on.
+ *
+ * Terraform lists both the attribute form and the bare resource form of one
+ * reference, and both lead to the same resource, so the first that resolves
+ * wins.
+ */
+export function terraformReferencedResource(
+  resource: TerraformResource,
+  key: string,
+  resolver: TerraformReferenceResolver,
+): TerraformResource | undefined {
+  const address = terraformReferencedAddress(resource, key, resolver);
+
+  return address === undefined ? undefined : resolver.resource(address);
+}
+
+/** The address of the resource one attribute refers to. */
+export function terraformReferencedAddress(
+  resource: TerraformResource,
+  key: string,
+  resolver: TerraformReferenceResolver,
+): string | undefined {
+  const expression = resource.expressions[key];
+
+  if (!isRecord(expression)) {
+    return undefined;
+  }
+
+  const references = longestFirst(
+    (expression as TerraformExpression).references ?? [],
+  );
+
+  for (const reference of references) {
+    const address = resolver.targetAddress(reference, resource.modulePath);
+
+    if (address !== undefined) {
+      return address;
+    }
+  }
+
+  return undefined;
+}

--- a/src/terraform/sim-tf-refusal.ts
+++ b/src/terraform/sim-tf-refusal.ts
@@ -1,5 +1,5 @@
 import type { TerraformResource } from "./sim-tf-resource.type.js";
-import type { TerraformReferenceResolver } from "./sim-tf-reference.js";
+import type { TerraformBuildContext } from "./sim-tf-attributes.js";
 import { terraformResourceMappings } from "./sim-tf-registry.js";
 import type {
   TerraformDeclaration,
@@ -19,10 +19,10 @@ import type { TerraformSkipReason } from "./sim-tf-report.type.js";
  */
 export function terraformRefusal(
   declaration: TerraformDeclaration,
-  resolver: TerraformReferenceResolver,
+  build: TerraformBuildContext,
   unresolved: TerraformSkipReason,
 ): TerraformSkipReason | undefined {
-  const built = builtResource(declaration, resolver);
+  const built = builtResource(declaration, build);
 
   if (built.refused !== undefined) {
     return built.refused;
@@ -39,23 +39,24 @@ export function terraformRefusal(
  */
 export function terraformMissingProperties(
   resource: TerraformResource,
-  resolver: TerraformReferenceResolver,
+  build: TerraformBuildContext,
 ): readonly string[] {
   const mapping = terraformResourceMappings.get(resource.type);
 
   return mapping === undefined
     ? []
-    : missing(builtResource({ resource, mapping }, resolver));
+    : missing(builtResource({ resource, mapping }, build));
 }
 
-/** The Resource one declaration's mapping builds, against this resolver. */
+/** The Resource one declaration's mapping builds, against this plan. */
 function builtResource(
   declaration: TerraformDeclaration,
-  resolver: TerraformReferenceResolver,
+  build: TerraformBuildContext,
 ): TerraformMappedResource {
   return declaration.mapping({
     resource: declaration.resource,
-    resolver,
+    resolver: build.resolver,
+    overrides: build.overrides,
   });
 }
 

--- a/src/terraform/sim-tf-report.ts
+++ b/src/terraform/sim-tf-report.ts
@@ -83,8 +83,9 @@ function refusedAttributes(
   return resources
     .filter((resource) => settled.refused.has(resource.address))
     .flatMap((resource) =>
-      terraformMissingProperties(resource, settled.resolver).map(
-        (attribute) => ({ address: resource.address, attribute }),
-      ),
+      terraformMissingProperties(resource, settled).map((attribute) => ({
+        address: resource.address,
+        attribute,
+      })),
     );
 }

--- a/src/terraform/sim-tf-settle.iso.test.ts
+++ b/src/terraform/sim-tf-settle.iso.test.ts
@@ -15,12 +15,17 @@ import {
   settledTerraformPlan,
   type TerraformSettledPlan,
 } from "./sim-tf-settle.js";
+import { TerraformPlanOverrides } from "./sim-tf-overrides.js";
 
 /** What one plan fixture settles to. */
 function settled(fixture: Partial<TerraformPlanFixture>): TerraformSettledPlan {
   const plan = terraformPlanFactory.make(fixture);
 
-  return settledTerraformPlan(plan, terraformPlanResources(plan));
+  return settledTerraformPlan(
+    plan,
+    terraformPlanResources(plan),
+    new TerraformPlanOverrides(),
+  );
 }
 
 describe("settling which resources of a plan become Resources", () => {

--- a/src/terraform/sim-tf-settle.ts
+++ b/src/terraform/sim-tf-settle.ts
@@ -10,6 +10,7 @@ import {
   terraformResourceMappings,
 } from "./sim-tf-registry.js";
 import type { TerraformDeclaration } from "./sim-tf-mapping.type.js";
+import type { TerraformPlanOverrides } from "./sim-tf-overrides.js";
 import { terraformRefusal } from "./sim-tf-refusal.js";
 import type { TerraformSkipReason } from "./sim-tf-report.type.js";
 
@@ -22,6 +23,8 @@ export interface TerraformSettledPlan {
   readonly declared: readonly TerraformDeclaration[];
   /** A resolver that knows those resources and no others. */
   readonly resolver: TerraformReferenceResolver;
+  /** What the deployment supplied for the values the plan could not carry. */
+  readonly overrides: TerraformPlanOverrides;
   /** Why a resource is not one of them, by address. */
   readonly refused: ReadonlyMap<string, TerraformSkipReason>;
 }
@@ -43,6 +46,7 @@ export interface TerraformSettledPlan {
 export function settledTerraformPlan(
   plan: TerraformPlan,
   resources: readonly TerraformResource[],
+  overrides: TerraformPlanOverrides,
 ): TerraformSettledPlan {
   const moduleOutputs = terraformModuleOutputs(plan);
   const refused = new Map<string, TerraformSkipReason>();
@@ -57,14 +61,18 @@ export function settledTerraformPlan(
     );
     const dropped = new Map(
       candidates.flatMap((declaration) => {
-        const why = terraformRefusal(declaration, resolver, reason);
+        const why = terraformRefusal(
+          declaration,
+          { resolver, overrides },
+          reason,
+        );
 
         return why === undefined ? [] : [[declaration.resource.address, why]];
       }),
     );
 
     if (dropped.size === 0) {
-      return { declared: candidates, resolver, refused };
+      return { declared: candidates, resolver, overrides, refused };
     }
 
     for (const [address, why] of dropped) {

--- a/test/terraform/plan/terraform-mapping-context.ts
+++ b/test/terraform/plan/terraform-mapping-context.ts
@@ -2,6 +2,8 @@ import { assertNonNullable } from "@kensio/smartass";
 import { terraformPlanResources } from "../../../src/terraform/sim-tf-plan-resources.js";
 import { TerraformReferenceResolver } from "../../../src/terraform/sim-tf-reference.js";
 import type { TerraformMappingContext } from "../../../src/terraform/sim-tf-attributes.js";
+import { TerraformPlanOverrides } from "../../../src/terraform/sim-tf-overrides.js";
+import type { TerraformPlanOverride } from "../../../src/terraform/sim-tf-override.type.js";
 import {
   terraformPlanFactory,
   type TerraformPlanFixture,
@@ -15,14 +17,22 @@ import {
  * mapping says only what the resource was configured with, and that a
  * reference to another resource of the fixture resolves the way it does in a
  * template built from the whole plan.
+ *
+ * The overrides are what a deployment supplied for the values the plan could
+ * not carry, and default to none.
  */
 export function terraformMappingContext(
   fixture: Partial<TerraformPlanFixture>,
+  overrides: readonly TerraformPlanOverride[] = [],
 ): TerraformMappingContext {
   const resources = terraformPlanResources(terraformPlanFactory.make(fixture));
   const [resource] = resources;
 
   assertNonNullable(resource);
 
-  return { resource, resolver: new TerraformReferenceResolver(resources) };
+  return {
+    resource,
+    resolver: new TerraformReferenceResolver(resources),
+    overrides: new TerraformPlanOverrides(overrides),
+  };
 }

--- a/test/terraform/plan/terraform-plan-file.ts
+++ b/test/terraform/plan/terraform-plan-file.ts
@@ -1,0 +1,27 @@
+import { TemporaryDirectory } from "../../../src/util/filesystem/temporary-directory.js";
+import { jsonStringify } from "../../../src/util/type-guard/json.js";
+import {
+  terraformPlanFactory,
+  type TerraformPlanFixture,
+} from "./terraform-plan.factory.js";
+
+/**
+ * A plan fixture written out as the JSON `terraform show -json` writes.
+ *
+ * `TerraformAdapter.deployPlan` reads a path rather than a document, so a test
+ * of a deployment needs the JSON on disk. It goes to a temporary directory, so
+ * a run leaves the repository as it found it.
+ */
+export async function terraformPlanFile(
+  fixture: Partial<TerraformPlanFixture>,
+  fileName = "orders.tfplan.json",
+): Promise<string> {
+  const directory = new TemporaryDirectory();
+
+  await directory.writeFile(
+    fileName,
+    jsonStringify(terraformPlanFactory.make(fixture)),
+  );
+
+  return directory.join(fileName);
+}


### PR DESCRIPTION
A Terraform plan resolves nothing inside a value it could not build. A Lambda `environment.variables` map holding one reference to a queue of the same plan arrives without its variable names, and an `aws_iam_role_policy` written with `jsonencode` arrives without its statements. `deployPlan` now takes `overrides`, matching an environment on the function's name and an inline policy on the role's, the way a binding is matched on a function name. The plan is read first. A supplied value fills a gap and never replaces what Terraform resolved, and what no override covered stays on the report's `lost`. A role whose policy nothing supplies is still created allowing everything, and that default is what keeps a plan carrying a Lambda event source mapping deployable.

Resolves #865

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Terraform deployment overrides for unresolved Lambda environment variables and IAM inline policies.
  * Resolved plan values take precedence, while supplied overrides fill missing values.
  * Added support for policy evaluation, including event-source permission checks.
  * Added public types and examples for configuring overrides.

* **Documentation**
  * Expanded guidance on override matching, merging, fallback policies, and lost-attribute reporting.

* **Bug Fixes**
  * Improved reporting of unresolved Terraform attributes and composite unknown values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->