### PR TITLE
feat: print dev messages to the serve console

### DIFF
--- a/docs/serve/README.md
+++ b/docs/serve/README.md
@@ -766,6 +766,60 @@ The reload channel is served at `/__sim-aws/live-reload` on every hostname the s
 page can ask for it relative to wherever it was served from. While live reload is on, no simulated
 service can serve anything at that path.
 
+## Messages on the console
+
+A simulated Cognito user pool records the verification message it would have sent, and simulated SNS
+records the text message it would have texted. Reading either back takes test code, or the pool's
+`/<userPoolId>/messages` listing, and both are a detour when the sign-up form is open in a browser
+and the confirmation code is the one thing you want. A served environment prints them as they are
+recorded:
+
+```
+sim Cognito eu-west-2_aBcDeFgHi: email to alice@example.com (SignUp)
+  Subject: Your verification code
+  Your confirmation code is 483920
+sim SNS: SMS to +15550100
+  Your one-time code is 118221
+```
+
+Nothing has to ask for that. Narrow it with `messageLogging`, which holds one property per kind of
+message:
+
+```typescript sim-serve-message-logging
+/**
+ * Serving with the text messages left off, and the pool messages still
+ * printed.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({
+  simAws,
+  port: 8787,
+  messageLogging: { sns: false },
+});
+
+// Serve the pages that sign a user up here.
+
+await srv.close();
+```
+
+`messageLogging: false` prints none of them.
+
+An SMS the opt-out list stopped is printed with the suppression named. The publish succeeded, and a
+handset that will never see the code is worth being told about rather than waited on:
+
+```
+sim SNS: SMS to +15550100 (suppressed, number opted out)
+  Your one-time code is 118221
+```
+
+Only what happens while the server is up reaches the console. A message recorded before it started
+listening, or after `close()`, is on the service's own record and nowhere else, and `sentMessages()`
+and `sentSmsMessages()` are still where the whole history is.
+
 ## Restarting on a file change
 
 Live reload gets a page back on its feet after the process restarts. `yulin watch` is what restarts
@@ -994,6 +1048,9 @@ it is without watch mode.
   hostname in a page body, in a JSON response or in a cookie `Domain` is left as the service wrote
   it.
 - `/__sim-aws/live-reload` is shadowed on every served hostname while live reload is on.
+- Console message logging covers simulated Cognito messages and simulated SNS text messages. An
+  email accepted by simulated SES is recorded and left unprinted, because a body can run to
+  kilobytes of HTML.
 - Injection decodes the HTML as UTF-8. A page stored in another encoding would be corrupted, so
   serve HTML as UTF-8.
 - An open reload connection uses one of the browser's six connections per origin per tab.

--- a/docs/serve/sim-serve-message-logging.example.ts
+++ b/docs/serve/sim-serve-message-logging.example.ts
@@ -1,0 +1,18 @@
+/**
+ * Serving with the text messages left off, and the pool messages still
+ * printed.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({
+  simAws,
+  port: 8787,
+  messageLogging: { sns: false },
+});
+
+// Serve the pages that sign a user up here.
+
+await srv.close();

--- a/src/serve/http/local-server/sim-aws-local-server.ts
+++ b/src/serve/http/local-server/sim-aws-local-server.ts
@@ -9,6 +9,9 @@ import { SimAwsLocalLocation } from "./sim-aws-local-location.js";
 import { SimAwsLocalRequestHandler } from "./sim-aws-local-request-handler.js";
 import { SimAwsDnsServer } from "../../dns/sim-aws-dns-server.js";
 import { SimLocalLiveReload } from "../live-reload/sim-local-live-reload.js";
+import { SimLocalMessageLogging } from "../../message/sim-local-message-logging.js";
+import type { SimMessageLoggingOption } from "../../message/sim-message-logging.js";
+import type { SimMessageConsole } from "../../message/sim-message-log-console.js";
 import {
   closeOnSignal,
   type SimCloseOnSignalOptions,
@@ -17,6 +20,20 @@ import {
 interface SimAwsLocalServerProperties {
   readonly simAws?: SimAws;
   readonly liveReload?: boolean;
+
+  /**
+   * Which messages this server prints to the console while it serves.
+   *
+   * Every kind unless this narrows it. See `SimMessageLoggingProperties`.
+   */
+  readonly messageLogging?: SimMessageLoggingOption | undefined;
+
+  /**
+   * Where the message lines go. The process console unless something else is
+   * named, which is how a test reads what was printed.
+   * @internal
+   */
+  readonly messageConsole?: SimMessageConsole | undefined;
 }
 
 /**
@@ -30,11 +47,17 @@ export class SimAwsLocalServer {
   private readonly portBinder: NodeServerPortBinder;
   private readonly dnsServer: SimAwsDnsServer;
   private readonly liveReload: SimLocalLiveReload;
+  private readonly messageLogging: SimLocalMessageLogging;
 
   constructor(properties: SimAwsLocalServerProperties = {}) {
     const { simAws = new SimAws(), liveReload = false } = properties;
     this.simAws = simAws;
     this.liveReload = new SimLocalLiveReload({ enabled: liveReload });
+    this.messageLogging = new SimLocalMessageLogging({
+      simAws,
+      option: properties.messageLogging,
+      target: properties.messageConsole,
+    });
     const channel = this.liveReload.channel();
     this.requestHandler = new SimAwsLocalRequestHandler({
       simAwsHttp: new SimAwsHttp({ simAws }),
@@ -73,6 +96,7 @@ export class SimAwsLocalServer {
     await this.dnsServer.listen(Number(this.port));
 
     this.liveReload.serving(this.port);
+    this.messageLogging.serving();
 
     return this;
   }
@@ -131,6 +155,8 @@ export class SimAwsLocalServer {
   async close(): Promise<void> {
     this.server.close();
     this.dnsServer.close();
+
+    this.messageLogging.stopping();
 
     await this.simAws.close();
     await this.liveReload.stopping();
@@ -195,6 +221,24 @@ interface ServeSimAwsProperties {
   readonly simAws?: SimAws;
   readonly port?: number;
   readonly liveReload?: boolean;
+
+  /**
+   * Which messages this server prints to the console while it serves.
+   *
+   * A simulated Cognito confirmation code and a simulated SNS text message are
+   * printed as they are recorded, which is what makes a code readable in the
+   * terminal the dev server is running in. Both unless this narrows it:
+   * `{ sns: false }` keeps the pool messages and drops the text messages, and
+   * `false` prints neither.
+   */
+  readonly messageLogging?: SimMessageLoggingOption | undefined;
+
+  /**
+   * Where the message lines go. The process console unless something else is
+   * named.
+   * @internal
+   */
+  readonly messageConsole?: SimMessageConsole | undefined;
 }
 
 /**
@@ -208,6 +252,11 @@ export async function serveSimAws(
     port = simAwsLocalConfig.defaultPort,
     liveReload = false,
   } = properties;
-  const server = new SimAwsLocalServer({ simAws, liveReload });
+  const server = new SimAwsLocalServer({
+    simAws,
+    liveReload,
+    messageLogging: properties.messageLogging,
+    messageConsole: properties.messageConsole,
+  });
   return server.listen(port);
 }

--- a/src/serve/index.ts
+++ b/src/serve/index.ts
@@ -8,6 +8,10 @@ export {
 export { SimAwsLocalPortInUse } from "./http/local-server/sim-aws-local-port.error.js";
 export type { SimCloseOnSignalOptions } from "../util/process/close-on-signal.js";
 export { SimLiveReload } from "./http/live-reload/sim-live-reload.js";
+export type {
+  SimMessageLoggingOption,
+  SimMessageLoggingProperties,
+} from "./message/sim-message-logging.js";
 export {
   simLiveReloadConfig,
   simLiveReloadHeaderName,

--- a/src/serve/message/sim-local-message-logging.iso.test.ts
+++ b/src/serve/message/sim-local-message-logging.iso.test.ts
@@ -1,0 +1,193 @@
+import {
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  SignUpCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { PublishCommand } from "@aws-sdk/client-sns";
+import {
+  assertArrayLength,
+  assertNonNullable,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { recordingConsole } from "../../../test/serve/recording-console.js";
+import { SimAws } from "../../service/aws/sim-aws.js";
+import { SimLocalMessageLogging } from "./sim-local-message-logging.js";
+import type { SimMessageLoggingOption } from "./sim-message-logging.js";
+
+const phoneNumber = "+15550100";
+
+/**
+ * A pool a user can sign itself up to, with the email address verified.
+ */
+async function signUpPool(
+  simAws: SimAws,
+): Promise<{ userPoolId: string; clientId: string }> {
+  const cognito = simAws.cognitoIdentityProvider();
+  const created = await cognito.createUserPool(
+    new CreateUserPoolCommand({
+      PoolName: "myapp-users",
+      AutoVerifiedAttributes: ["email"],
+    }),
+  );
+  assertNonNullable(created.UserPool?.Id);
+
+  const client = await cognito.createUserPoolClient(
+    new CreateUserPoolClientCommand({
+      UserPoolId: created.UserPool.Id,
+      ClientName: "web",
+    }),
+  );
+  assertNonNullable(client.UserPoolClient?.ClientId);
+
+  return {
+    userPoolId: created.UserPool.Id,
+    clientId: client.UserPoolClient.ClientId,
+  };
+}
+
+/**
+ * Sign a user up and text a code, which is one message of each kind.
+ */
+async function sendBothKinds(simAws: SimAws): Promise<void> {
+  const { clientId } = await signUpPool(simAws);
+
+  await simAws.cognitoIdentityProvider().signUp(
+    new SignUpCommand({
+      ClientId: clientId,
+      Username: "alice",
+      Password: "Sup3rSecret!",
+      UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+    }),
+  );
+  await simAws
+    .sns()
+    .publish(
+      new PublishCommand({ PhoneNumber: phoneNumber, Message: "code 12345" }),
+    );
+}
+
+describe("Logging the messages a served environment records", () => {
+  it("prints a pool message and a text message as they happen", async () => {
+    // Given a simulated environment being served with message logging on.
+    const simAws = new SimAws();
+    const target = recordingConsole();
+    const logging = new SimLocalMessageLogging({ simAws, target });
+    logging.serving();
+
+    // When a user signs itself up and a code is texted.
+    await sendBothKinds(simAws);
+
+    // Then both messages were printed, the verification code among them.
+    assertArrayLength(target.lines, 2);
+    assertStringIncludes(target.lines[0], "sim Cognito");
+    assertStringIncludes(target.lines[0], "alice@example.com");
+    assertStringIncludes(target.lines[1], "sim SNS");
+    assertStringIncludes(target.lines[1], "code 12345");
+  });
+
+  it("prints the confirmation code the pool recorded", async () => {
+    // Given a simulated environment being served with message logging on.
+    const simAws = new SimAws();
+    const target = recordingConsole();
+    new SimLocalMessageLogging({ simAws, target }).serving();
+
+    // When a user signs itself up.
+    const { userPoolId, clientId } = await signUpPool(simAws);
+    await simAws.cognitoIdentityProvider().signUp(
+      new SignUpCommand({
+        ClientId: clientId,
+        Username: "alice",
+        Password: "Sup3rSecret!",
+        UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+      }),
+    );
+
+    // Then the code in the printed message is the one the pool recorded, which
+    // is the whole point of printing it.
+    const [recorded] = simAws
+      .cognitoIdentityProvider()
+      .userPool(userPoolId)
+      .sentMessages();
+
+    assertNonNullable(recorded);
+    assertStringIncludes(target.lines[0], recorded.body);
+  });
+
+  it("says when the opt-out list stopped a text message", async () => {
+    // Given a served environment, and a number that has opted out.
+    const simAws = new SimAws();
+    const target = recordingConsole();
+    new SimLocalMessageLogging({ simAws, target }).serving();
+    simAws.sns().optOutPhoneNumber(phoneNumber);
+
+    // When a code is published to it.
+    await simAws
+      .sns()
+      .publish(
+        new PublishCommand({ PhoneNumber: phoneNumber, Message: "code 12345" }),
+      );
+
+    // Then the line says nothing arrived.
+    assertStringIncludes(target.lines[0], "suppressed");
+  });
+
+  it.each<[string, SimMessageLoggingOption, readonly string[]]>([
+    ["one kind turned off", { sns: false }, ["sim Cognito"]],
+    ["the other turned off", { cognito: false }, ["sim SNS"]],
+    ["both turned off", false, []],
+    ["everything turned on", true, ["sim Cognito", "sim SNS"]],
+  ])("prints what %s asks for", async (_, option, expected) => {
+    // Given a served environment asked for those kinds of message.
+    const simAws = new SimAws();
+    const target = recordingConsole();
+    new SimLocalMessageLogging({ simAws, option, target }).serving();
+
+    // When a message of each kind is recorded.
+    await sendBothKinds(simAws);
+
+    // Then only the kinds asked for were printed, in that order.
+    assertArrayLength(target.lines, expected.length);
+
+    const printed = [...target.lines];
+
+    for (const prefix of expected) {
+      assertStringIncludes(String(printed.shift()), prefix);
+    }
+  });
+
+  it("prints nothing once the server has stopped", async () => {
+    // Given a served environment that has stopped serving.
+    const simAws = new SimAws();
+    const target = recordingConsole();
+    const logging = new SimLocalMessageLogging({ simAws, target });
+    logging.serving();
+    logging.stopping();
+
+    // When messages are recorded afterwards.
+    await sendBothKinds(simAws);
+
+    // Then nothing reached the console.
+    assertArrayLength(target.lines, 0);
+  });
+
+  it("leaves the messages recorded before it started unprinted", async () => {
+    // Given an environment that has already recorded a text message.
+    const simAws = new SimAws();
+    const target = recordingConsole();
+    await simAws
+      .sns()
+      .publish(
+        new PublishCommand({ PhoneNumber: phoneNumber, Message: "code 12345" }),
+      );
+
+    // When it starts being served.
+    new SimLocalMessageLogging({ simAws, target }).serving();
+
+    // Then the console has the messages from here on and no replay of the
+    // ones before, which the service's own record already holds.
+    assertArrayLength(target.lines, 0);
+    assertArrayLength(simAws.sns().sentSmsMessages(), 1);
+  });
+});

--- a/src/serve/message/sim-local-message-logging.ts
+++ b/src/serve/message/sim-local-message-logging.ts
@@ -1,0 +1,68 @@
+import type { SimAws } from "../../service/aws/sim-aws.js";
+import type { SimAwsMessageUnlisten } from "../../service/aws/message/sim-aws-message-log.js";
+import {
+  SimMessageLogConsole,
+  type SimMessageConsole,
+} from "./sim-message-log-console.js";
+import {
+  SimMessageLogging,
+  type SimMessageLoggingOption,
+} from "./sim-message-logging.js";
+
+interface SimLocalMessageLoggingProperties {
+  readonly simAws: SimAws;
+  readonly option?: SimMessageLoggingOption | undefined;
+
+  /**
+   * Where the lines go. The process console unless a test wants to read them.
+   */
+  readonly target?: SimMessageConsole | undefined;
+}
+
+/**
+ * Message logging as the local server has to hold it: which kinds are printed,
+ * and wired into the server's own lifecycle.
+ *
+ * Keeping it here leaves `SimAwsLocalServer` with sockets and ports, the same
+ * split live reload gets. The listener goes on when the server starts serving
+ * and comes off when it closes, so a message recorded before or after reaches
+ * no console.
+ */
+export class SimLocalMessageLogging {
+  private readonly simAws: SimAws;
+  private readonly logging: SimMessageLogging;
+  private readonly output: SimMessageLogConsole;
+
+  #unlisten: SimAwsMessageUnlisten | undefined;
+
+  constructor(properties: SimLocalMessageLoggingProperties) {
+    this.simAws = properties.simAws;
+    this.logging = new SimMessageLogging(properties.option);
+    this.output = new SimMessageLogConsole(properties.target);
+  }
+
+  /**
+   * Start printing the messages this environment records.
+   *
+   * A server asked for no kinds at all listens to nothing.
+   */
+  serving(): void {
+    if (!this.logging.any) {
+      return;
+    }
+
+    this.#unlisten = this.simAws.serviceFactory.messageLog.listen((message) => {
+      if (this.logging.prints(message.kind)) {
+        this.output.print(message);
+      }
+    });
+  }
+
+  /**
+   * Stop printing.
+   */
+  stopping(): void {
+    this.#unlisten?.();
+    this.#unlisten = undefined;
+  }
+}

--- a/src/serve/message/sim-message-log-console.iso.test.ts
+++ b/src/serve/message/sim-message-log-console.iso.test.ts
@@ -1,0 +1,130 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { recordingConsole } from "../../../test/serve/recording-console.js";
+import { SimMessageLogConsole } from "./sim-message-log-console.js";
+
+describe("Printing the messages a served environment would have sent", () => {
+  it("prints a pool email with its subject and its occasion", () => {
+    // Given a console to print to.
+    const target = recordingConsole();
+
+    // When a user pool's verification email is printed.
+    new SimMessageLogConsole(target).print({
+      kind: "cognito",
+      userPoolId: "us-east-1_AbCd1234",
+      medium: "EMAIL",
+      recipient: "alice@example.com",
+      occasion: "SignUp",
+      subject: "Verify your email",
+      body: "Your verification code is 483920",
+    });
+
+    // Then the pool, the recipient and the occasion introduce the message, and
+    // the subject and body follow indented under it.
+    assertIdentical(
+      target.lines[0],
+      [
+        "sim Cognito us-east-1_AbCd1234: email to alice@example.com (SignUp)",
+        "  Subject: Verify your email",
+        "  Your verification code is 483920",
+      ].join("\n"),
+    );
+  });
+
+  it("prints a pool text message without a subject line", () => {
+    // Given a console to print to.
+    const target = recordingConsole();
+
+    // When a message with no subject is printed, as a text message has none.
+    new SimMessageLogConsole(target).print({
+      kind: "cognito",
+      userPoolId: "us-east-1_AbCd1234",
+      medium: "SMS",
+      recipient: "+15550100",
+      occasion: "Authentication",
+      subject: undefined,
+      body: "Your code is 118221",
+    });
+
+    // Then the body follows the first line with no empty subject in between.
+    assertIdentical(
+      target.lines[0],
+      [
+        "sim Cognito us-east-1_AbCd1234: SMS to +15550100 (Authentication)",
+        "  Your code is 118221",
+      ].join("\n"),
+    );
+  });
+
+  it("indents every line of a message that runs to several", () => {
+    // Given a console to print to.
+    const target = recordingConsole();
+
+    // When the body has line breaks in it.
+    new SimMessageLogConsole(target).print({
+      kind: "cognito",
+      userPoolId: "us-east-1_AbCd1234",
+      medium: "EMAIL",
+      recipient: "alice@example.com",
+      occasion: "ForgotPassword",
+      subject: "Reset your password",
+      body: "Someone asked to reset your password.\nYour code is 771043",
+    });
+
+    // Then the whole body is one indented block under the first line.
+    assertIdentical(
+      target.lines[0],
+      [
+        "sim Cognito us-east-1_AbCd1234: email to alice@example.com (ForgotPassword)",
+        "  Subject: Reset your password",
+        "  Someone asked to reset your password.",
+        "  Your code is 771043",
+      ].join("\n"),
+    );
+  });
+
+  it("prints a text message with the number it went to", () => {
+    // Given a console to print to.
+    const target = recordingConsole();
+
+    // When an SMS simulated SNS recorded is printed.
+    new SimMessageLogConsole(target).print({
+      kind: "sns",
+      phoneNumber: "+15550100",
+      message: "Your one-time code is 118221",
+      suppressed: false,
+    });
+
+    // Then the number introduces it and the text follows indented.
+    assertIdentical(
+      target.lines[0],
+      ["sim SNS: SMS to +15550100", "  Your one-time code is 118221"].join(
+        "\n",
+      ),
+    );
+  });
+
+  it("says when the opt-out list stopped a text message", () => {
+    // Given a console to print to.
+    const target = recordingConsole();
+
+    // When an SMS the opt-out list suppressed is printed.
+    new SimMessageLogConsole(target).print({
+      kind: "sns",
+      phoneNumber: "+15550100",
+      message: "Your one-time code is 118221",
+      suppressed: true,
+    });
+
+    // Then the first line says nothing arrived, so a reader waiting for the
+    // code knows why it never came.
+    assertIdentical(
+      target.lines[0],
+      [
+        "sim SNS: SMS to +15550100 (suppressed, number opted out)",
+        "  Your one-time code is 118221",
+      ].join("\n"),
+    );
+  });
+});

--- a/src/serve/message/sim-message-log-console.ts
+++ b/src/serve/message/sim-message-log-console.ts
@@ -1,0 +1,94 @@
+import type {
+  SimAwsLoggedMessage,
+  SimCognitoLoggedMessage,
+  SimSnsLoggedSms,
+} from "../../service/aws/message/sim-aws-logged-message.js";
+
+/**
+ * The console a message is printed to, as much of it as printing needs.
+ */
+export interface SimMessageConsole {
+  log: (line: string) => void;
+}
+
+/**
+ * How far a message body is indented under the line that introduces it.
+ */
+const bodyIndent = "  ";
+
+/**
+ * Prints the messages a served environment would have sent.
+ *
+ * One block per message: a first line saying which service sent it and where
+ * it went, then the body indented under it. The body is what a reader is
+ * after, since the confirmation code is in it, and the first line is what
+ * tells two sign-ups apart.
+ *
+ * It goes to the console because the simulator has no logger of its own, the
+ * same as every warning it raises.
+ */
+export class SimMessageLogConsole {
+  private readonly console: SimMessageConsole;
+
+  constructor(target: SimMessageConsole = console) {
+    this.console = target;
+  }
+
+  /**
+   * Print one message.
+   */
+  print(message: SimAwsLoggedMessage): void {
+    const block =
+      message.kind === "cognito"
+        ? this.cognitoBlock(message)
+        : this.smsBlock(message);
+
+    this.console.log(block.join("\n"));
+  }
+
+  /**
+   * A pool message, with its subject where the medium has one.
+   *
+   * The occasion is on the first line because a pool sends the same wording on
+   * more than one of them, and a code that arrived from a resend looks exactly
+   * like the one from the sign-up otherwise.
+   */
+  private cognitoBlock(message: SimCognitoLoggedMessage): readonly string[] {
+    const medium = message.medium === "EMAIL" ? "email" : "SMS";
+    const lines = [
+      `sim Cognito ${message.userPoolId}: ${medium} to ${message.recipient} (${message.occasion})`,
+    ];
+
+    if (message.subject !== undefined) {
+      lines.push(`${bodyIndent}Subject: ${message.subject}`);
+    }
+
+    return [...lines, ...indented(message.body)];
+  }
+
+  /**
+   * One text message, marked where the opt-out list stopped it.
+   *
+   * A suppressed message is printed like any other. The publish succeeded and
+   * nothing arrived, and a reader waiting for a code that will never come
+   * needs to be told which of the two happened.
+   */
+  private smsBlock(message: SimSnsLoggedSms): readonly string[] {
+    const suppression = message.suppressed
+      ? " (suppressed, number opted out)"
+      : "";
+
+    return [
+      `sim SNS: SMS to ${message.phoneNumber}${suppression}`,
+      ...indented(message.message),
+    ];
+  }
+}
+
+/**
+ * A body indented under the line introducing it, line by line, so a message
+ * running to several lines stays one readable block.
+ */
+function indented(body: string): readonly string[] {
+  return body.split("\n").map((line) => `${bodyIndent}${line}`);
+}

--- a/src/serve/message/sim-message-logging-serve.loc.test.ts
+++ b/src/serve/message/sim-message-logging-serve.loc.test.ts
@@ -1,0 +1,72 @@
+import { PublishCommand } from "@aws-sdk/client-sns";
+import { assertArrayLength, assertStringIncludes } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { recordingConsole } from "../../../test/serve/recording-console.js";
+import { SimAws } from "../../service/aws/sim-aws.js";
+import { serveSimAws } from "../http/local-server/sim-aws-local-server.js";
+
+const phoneNumber = "+15550100";
+
+/**
+ * Text one code through a simulated SNS.
+ */
+async function textACode(simAws: SimAws): Promise<void> {
+  await simAws
+    .sns()
+    .publish(
+      new PublishCommand({ PhoneNumber: phoneNumber, Message: "code 12345" }),
+    );
+}
+
+describe("Message logging on a served simulated AWS environment", () => {
+  it("prints messages without being asked to", async () => {
+    // Given an environment served with nothing said about message logging.
+    const simAws = new SimAws();
+    const messageConsole = recordingConsole();
+    const srv = await serveSimAws({ simAws, port: 0, messageConsole });
+
+    // When a code is texted.
+    await textACode(simAws);
+    await srv.close();
+
+    // Then it reached the console, because a dev server is where these are
+    // worth seeing and asking for them means knowing the option is there.
+    assertArrayLength(messageConsole.lines, 1);
+    assertStringIncludes(messageConsole.lines[0], "code 12345");
+  });
+
+  it("prints nothing when the server was told not to", async () => {
+    // Given an environment served with message logging turned off.
+    const simAws = new SimAws();
+    const messageConsole = recordingConsole();
+    const srv = await serveSimAws({
+      simAws,
+      port: 0,
+      messageLogging: false,
+      messageConsole,
+    });
+
+    // When a code is texted.
+    await textACode(simAws);
+    await srv.close();
+
+    // Then nothing was printed, and the SMS was recorded as it always is.
+    assertArrayLength(messageConsole.lines, 0);
+    assertArrayLength(simAws.sns().sentSmsMessages(), 1);
+  });
+
+  it("stops printing once the server closes", async () => {
+    // Given a served environment that has been closed.
+    const simAws = new SimAws();
+    const messageConsole = recordingConsole();
+    const srv = await serveSimAws({ simAws, port: 0, messageConsole });
+    await srv.close();
+
+    // When a code is texted afterwards.
+    await textACode(simAws);
+
+    // Then the console the server was printing to is left alone.
+    assertArrayLength(messageConsole.lines, 0);
+  });
+});

--- a/src/serve/message/sim-message-logging.ts
+++ b/src/serve/message/sim-message-logging.ts
@@ -1,0 +1,59 @@
+import type { SimAwsLoggedMessageKind } from "../../service/aws/message/sim-aws-logged-message.js";
+
+/**
+ * Which kinds of message a served environment prints.
+ *
+ * One property per kind, each on unless it is turned off, so naming one kind
+ * says nothing about the others.
+ */
+export interface SimMessageLoggingProperties {
+  /** The messages a simulated Cognito user pool would have sent. */
+  readonly cognito?: boolean;
+
+  /** The text messages simulated SNS would have sent. */
+  readonly sns?: boolean;
+}
+
+/**
+ * What `serveSimAws` takes for `messageLogging`.
+ *
+ * Left out, every kind is printed. `false` prints none of them, and an object
+ * narrows it to the kinds it leaves on.
+ */
+export type SimMessageLoggingOption = boolean | SimMessageLoggingProperties;
+
+/**
+ * The message logging a server was asked for.
+ *
+ * The option arrives in three shapes and this is the one thing the rest of the
+ * serving layer asks: whether to print a message of this kind.
+ */
+export class SimMessageLogging {
+  readonly #cognito: boolean;
+  readonly #sns: boolean;
+
+  constructor(option: SimMessageLoggingOption = true) {
+    const kinds: SimMessageLoggingProperties =
+      typeof option === "boolean" ? { cognito: option, sns: option } : option;
+
+    this.#cognito = kinds.cognito !== false;
+    this.#sns = kinds.sns !== false;
+  }
+
+  /**
+   * Whether messages of this kind are printed.
+   */
+  prints(kind: SimAwsLoggedMessageKind): boolean {
+    return kind === "cognito" ? this.#cognito : this.#sns;
+  }
+
+  /**
+   * Whether any kind is printed at all.
+   *
+   * A server asked for none of them listens to nothing, so a simulation nobody
+   * wants output from does no work for it.
+   */
+  get any(): boolean {
+    return this.#cognito || this.#sns;
+  }
+}

--- a/src/service/aws/factory/sim-aws-account-region-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-account-region-service-builder.ts
@@ -32,6 +32,7 @@ import { simAwsSnsDeliveryEndpoints } from "../../sns/delivery/sim-aws-sns-deliv
 import { SimSts } from "../../sts/sim-sts.js";
 import { SimWafV2 } from "../../wafv2/index.js";
 import { SimAwsWafProtectedResources } from "../../wafv2/association/sim-aws-waf-protected-resources.js";
+import type { SimAwsMessageLog } from "../message/sim-aws-message-log.js";
 import type { SimAwsAccountServiceCache } from "./sim-aws-account-service-cache.js";
 import type { SimAwsScopedServiceProperties } from "./sim-aws-scoped-service-properties.js";
 import type { SimAwsScopedServiceRegistries } from "./sim-aws-scoped-service-registries.js";
@@ -43,6 +44,7 @@ interface SimAwsAccountRegionServiceBuilderProperties {
   readonly iamRegistry: SimIamRegistry;
   readonly lambdaUrlRegistry: SimLambdaUrlRegistry;
   readonly accountServices: SimAwsAccountServiceCache;
+  readonly messageLog: SimAwsMessageLog;
 }
 
 /**
@@ -74,6 +76,7 @@ export class SimAwsAccountRegionServiceBuilder {
   private readonly iamRegistry: SimIamRegistry;
   private readonly lambdaUrlRegistry: SimLambdaUrlRegistry;
   private readonly accountServices: SimAwsAccountServiceCache;
+  private readonly messageLog: SimAwsMessageLog;
 
   constructor(properties: SimAwsAccountRegionServiceBuilderProperties) {
     this.simAws = properties.simAws;
@@ -82,6 +85,7 @@ export class SimAwsAccountRegionServiceBuilder {
     this.iamRegistry = properties.iamRegistry;
     this.lambdaUrlRegistry = properties.lambdaUrlRegistry;
     this.accountServices = properties.accountServices;
+    this.messageLog = properties.messageLog;
   }
 
   /** Create simulated ACM for an Account Region scope. */
@@ -123,6 +127,7 @@ export class SimAwsAccountRegionServiceBuilder {
       userPoolRegistry: this.registries.cognito,
       domainRegistry: this.registries.cognitoDomains,
       triggerFunctions: simAwsCognitoTriggerFunctions(this.simAws),
+      messageLog: this.messageLog,
       // A web ACL protecting a pool is in the same Account and Region as the
       // pool, as it is on AWS, so this scope's own WAFv2 is the one to ask.
       webAcls: scope.wafV2().protection(),
@@ -218,7 +223,11 @@ export class SimAwsAccountRegionServiceBuilder {
   createSns(scope: SimAwsAccountRegionContainer): SimSns {
     const endpoints = simAwsSnsDeliveryEndpoints({ simAws: this.simAws });
 
-    return new SimSns({ ...this.scoped(scope), deliveryEndpoints: endpoints });
+    return new SimSns({
+      ...this.scoped(scope),
+      deliveryEndpoints: endpoints,
+      messageLog: this.messageLog,
+    });
   }
 
   /** Create simulated EventBridge Scheduler for an Account Region scope. */

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -40,6 +40,7 @@ import { SimAwsSelfContainedServiceBuilder } from "./sim-aws-self-contained-serv
 import { SimAwsAccountServiceCache } from "./sim-aws-account-service-cache.js";
 import { SimAwsRequestAuthWiring } from "./sim-aws-request-auth-wiring.js";
 import { SimAwsScopedServiceRegistries } from "./sim-aws-scoped-service-registries.js";
+import { SimAwsMessageLog } from "../message/sim-aws-message-log.js";
 
 interface SimAwsServiceFactoryProperties {
   readonly simAws: SimAws;
@@ -109,6 +110,15 @@ export class SimAwsServiceFactory {
    */
   public readonly registries = new SimAwsScopedServiceRegistries();
 
+  /**
+   * Where the services that would have sent a message announce one.
+   *
+   * Shared by every scope in this simulation, so a serving layer listens once
+   * and hears the Cognito messages and text messages of all of them.
+   * @internal
+   */
+  public readonly messageLog = new SimAwsMessageLog();
+
   private readonly accountServices: SimAwsAccountServiceCache;
   private readonly accountRegionServices: SimAwsAccountRegionServiceBuilder;
   private readonly registeredServices: SimAwsRegisteredServiceBuilder;
@@ -135,6 +145,7 @@ export class SimAwsServiceFactory {
       iamRegistry: this.iamRegistry,
       lambdaUrlRegistry: this.lambdaUrlRegistry,
       accountServices: this.accountServices,
+      messageLog: this.messageLog,
     });
     this.registeredServices = new SimAwsRegisteredServiceBuilder({
       registries: this.registries,

--- a/src/service/aws/message/sim-aws-logged-message.ts
+++ b/src/service/aws/message/sim-aws-logged-message.ts
@@ -1,0 +1,49 @@
+import type { SimCognitoMessageMedium } from "../../cognito/user-pool/message/sim-cognito-sent-message.js";
+import type { SimCognitoMessageOccasion } from "../../cognito/user-pool/message/sim-cognito-message-occasion.js";
+
+/**
+ * One message a simulated user pool has just recorded.
+ *
+ * The recipient and the body are what a local dev loop is after: the
+ * confirmation code is in the body, and the address or number it went to says
+ * which sign-up it belongs to.
+ */
+export interface SimCognitoLoggedMessage {
+  readonly kind: "cognito";
+  readonly userPoolId: string;
+  readonly medium: SimCognitoMessageMedium;
+  readonly recipient: string;
+  readonly occasion: SimCognitoMessageOccasion;
+  readonly subject: string | undefined;
+  readonly body: string;
+}
+
+/**
+ * One SMS a simulated SNS has just recorded.
+ *
+ * `suppressed` is the opt-out list having stopped this one. The publish
+ * succeeded and nothing arrived, and a reader watching for a code needs to be
+ * told that rather than left waiting.
+ */
+export interface SimSnsLoggedSms {
+  readonly kind: "sns";
+  readonly phoneNumber: string;
+  readonly message: string;
+  readonly suppressed: boolean;
+}
+
+/**
+ * A message a simulated service would have sent, in the shape the serving
+ * layer prints it.
+ *
+ * Each kind carries its own fields because the two are different things. A
+ * pool message has a subject and an occasion, and an SMS has neither and can
+ * be suppressed. Flattening both into one shape would mean printing fields
+ * that are always absent for half the messages.
+ */
+export type SimAwsLoggedMessage = SimCognitoLoggedMessage | SimSnsLoggedSms;
+
+/**
+ * Which kinds of message the serving layer prints.
+ */
+export type SimAwsLoggedMessageKind = SimAwsLoggedMessage["kind"];

--- a/src/service/aws/message/sim-aws-message-log.ts
+++ b/src/service/aws/message/sim-aws-message-log.ts
@@ -1,0 +1,54 @@
+import type { SimAwsLoggedMessage } from "./sim-aws-logged-message.js";
+
+/**
+ * Something told about each message as it is recorded.
+ */
+export type SimAwsMessageListener = (message: SimAwsLoggedMessage) => void;
+
+/**
+ * Takes a listener off again.
+ */
+export type SimAwsMessageUnlisten = () => void;
+
+/**
+ * Where the simulated services that would have sent a message say so.
+ *
+ * One of these belongs to a SimAws instance and is shared by every scope in it.
+ * The services record their own messages as they always did, and this is the
+ * announcement on top: a local server listens here to print a Cognito
+ * confirmation code or a text message to the console as it happens.
+ *
+ * A listener is added while a server is up and taken off when it closes, so a
+ * simulation nobody is serving does the recording and announces to nobody.
+ */
+export class SimAwsMessageLog {
+  readonly #listeners = new Set<SimAwsMessageListener>();
+
+  /**
+   * Be told about each message from now on, until the returned function is
+   * called.
+   *
+   * Messages already recorded are not replayed. A listener hears what happens
+   * while it is listening, and the record on the service is where the rest is.
+   */
+  listen(listener: SimAwsMessageListener): SimAwsMessageUnlisten {
+    this.#listeners.add(listener);
+
+    return (): void => {
+      this.#listeners.delete(listener);
+    };
+  }
+
+  /**
+   * Announce one message a simulated service would have sent.
+   *
+   * Called by the service that recorded it, after it is recorded, so a
+   * listener that reads the service back sees the message it was just told
+   * about.
+   */
+  record(message: SimAwsLoggedMessage): void {
+    for (const listener of this.#listeners) {
+      listener(message);
+    }
+  }
+}

--- a/src/service/cognito/command/sim-cognito-commands.ts
+++ b/src/service/cognito/command/sim-cognito-commands.ts
@@ -6,6 +6,7 @@ import { SimCognitoGroupFactory } from "../user-pool/group/sim-cognito-group-fac
 import { SimCognitoRegistrations } from "../user-pool/sim-cognito-registrations.js";
 import { SimCognitoUserPoolFactory } from "../user-pool/sim-cognito-user-pool-factory.js";
 import type { SimCognitoUserPoolStore } from "../user-pool/sim-cognito-user-pool-store.js";
+import type { SimAwsMessageLog } from "../../aws/message/sim-aws-message-log.js";
 import { SimCognitoPoolMessenger } from "../user-pool/message/sim-cognito-pool-messenger.js";
 import type { SimCognitoTriggerFunctions } from "../user-pool/trigger/sim-cognito-trigger-functions.js";
 import { SimCognitoUserPoolTriggers } from "../user-pool/trigger/sim-cognito-user-pool-triggers.js";
@@ -46,6 +47,7 @@ interface SimCognitoCommandsProperties {
   readonly domains: SimCognitoDomainRegistry;
   readonly triggerFunctions: SimCognitoTriggerFunctions;
   readonly webAcls: SimWafProtection;
+  readonly messageLog: SimAwsMessageLog;
 }
 
 /**
@@ -106,7 +108,11 @@ export class SimCognitoCommands {
     });
     // The messages a pool would have sent are recorded by the sign-up and user
     // commands alike, and both run the pool's CustomMessage trigger first.
-    const messenger = new SimCognitoPoolMessenger({ triggers, clock });
+    const messenger = new SimCognitoPoolMessenger({
+      triggers,
+      clock,
+      messageLog: properties.messageLog,
+    });
     // One token issuer serves the API sign-ins and the hosted endpoints, so a
     // token is the same thing however the user reached it.
     const tokenIssuer = new SimCognitoTokenIssuer({ clock, triggers });

--- a/src/service/cognito/sim-cognito-identity-provider.ts
+++ b/src/service/cognito/sim-cognito-identity-provider.ts
@@ -5,6 +5,7 @@ import {
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
+import { SimAwsMessageLog } from "../aws/message/sim-aws-message-log.js";
 import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
@@ -72,6 +73,13 @@ interface SimCognitoIdentityProviderProperties {
    * always did.
    */
   readonly webAcls?: SimWafProtection;
+
+  /**
+   * Where this scope announces the messages its pools would have sent, for a
+   * serving layer to print. A standalone simulated Cognito announces to a log
+   * nobody listens to.
+   */
+  readonly messageLog?: SimAwsMessageLog;
 }
 
 /**
@@ -108,6 +116,7 @@ export class SimCognitoIdentityProvider extends SimCognitoUserPools {
       domainRegistry = new SimCognitoDomainRegistry(),
       triggerFunctions = new SimCognitoNoTriggerFunctions(),
       webAcls = new SimWafNoProtection(),
+      messageLog = new SimAwsMessageLog(),
     } = properties;
     const pools = new SimCognitoUserPoolStore({
       registry: userPoolRegistry,
@@ -123,6 +132,7 @@ export class SimCognitoIdentityProvider extends SimCognitoUserPools {
         domains: domainRegistry,
         triggerFunctions,
         webAcls,
+        messageLog,
       }),
       background,
     });

--- a/src/service/cognito/user-pool/message/sim-cognito-pool-messenger.ts
+++ b/src/service/cognito/user-pool/message/sim-cognito-pool-messenger.ts
@@ -1,4 +1,5 @@
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import type { SimAwsMessageLog } from "../../../aws/message/sim-aws-message-log.js";
 import type { SimCognitoUserPoolClient } from "../client/sim-cognito-user-pool-client.js";
 import type { SimCognitoUserPool } from "../sim-cognito-user-pool.js";
 import { SimCognitoTriggerOccasion } from "../trigger/sim-cognito-trigger-occasion.js";
@@ -13,6 +14,7 @@ import { SimCognitoSentMessage } from "./sim-cognito-sent-message.js";
 interface SimCognitoPoolMessengerProperties {
   readonly triggers: SimCognitoUserPoolTriggers;
   readonly clock: SimClock;
+  readonly messageLog: SimAwsMessageLog;
 }
 
 /**
@@ -49,10 +51,12 @@ interface SimCognitoMessageRequest {
 export class SimCognitoPoolMessenger {
   private readonly triggers: SimCognitoUserPoolTriggers;
   private readonly clock: SimClock;
+  private readonly messageLog: SimAwsMessageLog;
 
   constructor(properties: SimCognitoPoolMessengerProperties) {
     this.triggers = properties.triggers;
     this.clock = properties.clock;
+    this.messageLog = properties.messageLog;
   }
 
   /**
@@ -100,16 +104,27 @@ export class SimCognitoPoolMessenger {
     });
     const wording = custom.wordingFor(medium, pooled);
 
-    request.pool.messages.record(
-      new SimCognitoSentMessage({
-        username: request.user.username,
-        recipient: delivery.recipient,
-        medium,
-        wording: wording.filledWith(placeholders),
-        occasion: request.occasion,
-        sentDate: this.clock.now(),
-      }),
-    );
+    const message = new SimCognitoSentMessage({
+      username: request.user.username,
+      recipient: delivery.recipient,
+      medium,
+      wording: wording.filledWith(placeholders),
+      occasion: request.occasion,
+      sentDate: this.clock.now(),
+    });
+
+    request.pool.messages.record(message);
+    // Announced after it is recorded, so a listener that goes and reads the
+    // pool finds the message it was just told about.
+    this.messageLog.record({
+      kind: "cognito",
+      userPoolId: request.pool.id,
+      medium,
+      recipient: message.recipient,
+      occasion: message.occasion,
+      subject: message.subject,
+      body: message.body,
+    });
 
     return delivery;
   }

--- a/src/service/sns/command/sim-sns-commands.ts
+++ b/src/service/sns/command/sim-sns-commands.ts
@@ -1,5 +1,6 @@
 import type { BackgroundScheduler } from "../../../util/background/background.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimAwsMessageLog } from "../../aws/message/sim-aws-message-log.js";
 import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimSnsDeliveryRequests } from "../delivery/sim-sns-delivery-request.js";
 import { SimSnsFanOut } from "../delivery/sim-sns-fan-out.js";
@@ -34,6 +35,7 @@ interface SimSnsCommandsProperties {
   readonly background: BackgroundScheduler;
   readonly deliveryEndpoints: SimSnsOutwardDeliveryEndpoints;
   readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly messageLog: SimAwsMessageLog;
 }
 
 /**
@@ -57,7 +59,7 @@ export class SimSnsCommands {
   public readonly signer: SimSnsMessageSigner;
 
   /** Every SMS this scope would have sent, delivered or suppressed. */
-  public readonly sentSms = new SimSnsSentSmsStore();
+  public readonly sentSms: SimSnsSentSmsStore;
 
   /** The numbers this scope will send no SMS to. */
   public readonly optOutList = new SimSnsOptOutList();
@@ -65,6 +67,10 @@ export class SimSnsCommands {
   constructor(properties: SimSnsCommandsProperties) {
     const { topics, subscriptions, accountRegionScope, background } =
       properties;
+
+    this.sentSms = new SimSnsSentSmsStore({
+      messageLog: properties.messageLog,
+    });
     const access = new SimSnsTopicAccess({
       topics,
       authorizer: new SimSnsAuthorizer({ iam: properties.iam }),

--- a/src/service/sns/sim-sns.ts
+++ b/src/service/sns/sim-sns.ts
@@ -5,6 +5,7 @@ import {
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
+import { SimAwsMessageLog } from "../aws/message/sim-aws-message-log.js";
 import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
@@ -36,6 +37,13 @@ interface SimSnsProperties {
    * needs nothing here, because simulated SNS records those itself.
    */
   readonly deliveryEndpoints?: SimSnsOutwardDeliveryEndpoints;
+
+  /**
+   * Where this scope announces the text messages it would have sent, for a
+   * serving layer to print. A SimSns built on its own announces to a log
+   * nobody listens to.
+   */
+  readonly messageLog?: SimAwsMessageLog;
 }
 
 /**
@@ -59,6 +67,7 @@ export class SimSns extends SimSnsSms {
       iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
       deliveryEndpoints = simSnsNoDeliveryEndpoints(),
+      messageLog = new SimAwsMessageLog(),
     } = properties;
     const topics = new SimSnsTopicStore();
     const subscriptions = new SimSnsSubscriptionStore();
@@ -72,6 +81,7 @@ export class SimSns extends SimSnsSms {
         background,
         deliveryEndpoints,
         accountRegionScope,
+        messageLog,
       }),
     });
 

--- a/src/service/sns/sms/sim-sns-sent-sms-store.ts
+++ b/src/service/sns/sms/sim-sns-sent-sms-store.ts
@@ -1,4 +1,12 @@
+import { SimAwsMessageLog } from "../../aws/message/sim-aws-message-log.js";
 import type { SimSnsSentSmsMessage } from "./sim-sns-sent-sms-message.js";
+
+interface SimSnsSentSmsStoreProperties {
+  /**
+   * Where each SMS is announced as it is kept, for a serving layer to print.
+   */
+  readonly messageLog?: SimAwsMessageLog;
+}
 
 /**
  * The SMS messages one simulated SNS scope has accepted.
@@ -14,6 +22,11 @@ import type { SimSnsSentSmsMessage } from "./sim-sns-sent-sms-message.js";
  */
 export class SimSnsSentSmsStore {
   readonly #sent: SimSnsSentSmsMessage[] = [];
+  readonly #messageLog: SimAwsMessageLog;
+
+  constructor(properties: SimSnsSentSmsStoreProperties = {}) {
+    this.#messageLog = properties.messageLog ?? new SimAwsMessageLog();
+  }
 
   /**
    * Every SMS this scope has accepted, oldest first.
@@ -24,8 +37,18 @@ export class SimSnsSentSmsStore {
 
   /**
    * Keep an SMS simulated SNS has accepted.
+   *
+   * Both ways an SMS is accepted come through here, a publish naming a phone
+   * number and a topic fanning out to an `sms` subscription, so this is the
+   * one place an SMS is announced from.
    */
   add(message: SimSnsSentSmsMessage): void {
     this.#sent.push(message);
+    this.#messageLog.record({
+      kind: "sns",
+      phoneNumber: message.phoneNumber,
+      message: message.message,
+      suppressed: message.suppressed,
+    });
   }
 }

--- a/test/serve/recording-console.ts
+++ b/test/serve/recording-console.ts
@@ -1,0 +1,25 @@
+import type { SimMessageConsole } from "../../src/serve/message/sim-message-log-console.js";
+
+/**
+ * A console that keeps what it was told to print.
+ *
+ * The message lines go to the process console in a real dev loop, and a test
+ * reads them here instead of watching its own output.
+ */
+export interface RecordingConsole extends SimMessageConsole {
+  readonly lines: readonly string[];
+}
+
+/**
+ * Make a console a test can read back.
+ */
+export function recordingConsole(): RecordingConsole {
+  const lines: string[] = [];
+
+  return {
+    lines,
+    log: (line: string): void => {
+      lines.push(line);
+    },
+  };
+}


### PR DESCRIPTION
A served environment now prints each message a simulated Cognito user pool records and each SMS simulated SNS records, as it happens, so a confirmation code is in the terminal the dev server runs in instead of behind a fetch of the pool's messages listing. It is on without asking, and `messageLogging` narrows it to the kinds a script wants or turns it off. The services announce a message on a shared log after recording it, and the listener goes on when the server starts serving and comes off when it closes, leaving what a test reads back off the service exactly where it was.

Resolves #874
