### PR TITLE
fix: say what Cognito refuses in the CFN record

### DIFF
--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -3174,6 +3174,19 @@ behaves differently to the template. A stack that forgets `ALLOW_ADMIN_USER_PASS
 fails at the sign-in here as it would in a deployment, the point of deploying the template at
 all.
 
+A property one of the Cognito commands refuses by name is recorded in that command's own words.
+`EmailConfiguration`, `SmsConfiguration` and `SmsAuthenticationMessage` on a pool, and
+`AnalyticsConfiguration`, `EnablePropagateAdditionalUserContextData`, `ReadAttributes` and
+`WriteAttributes` on a client, all read as the refusal reads:
+
+```
+AWS::Cognito::UserPool property EmailConfiguration is not simulated: email delivery would be ignored here and applied on real AWS. The Resource is created without it.
+```
+
+`CreateUserPool` refuses that same input outright, and the template deploys. The two paths say the
+same thing about the property and differ in what they do about it. A direct API call has one
+request to fail, and a template has every other resource in it to think about.
+
 `UserPoolName` and `ClientName` are optional. A template that sets neither gets
 `<stack name>-<logical id>`, as real CloudFormation generates a name, trimmed to the 128 characters
 Cognito allows if the two are longer than that together. Real CloudFormation adds random characters

--- a/src/service/cognito/README.md
+++ b/src/service/cognito/README.md
@@ -399,8 +399,8 @@ event makes to one.
 `AWS::Cognito::UserPoolGroup`, `AWS::Cognito::UserPoolDomain` and
 `AWS::Cognito::UserPoolIdentityProvider`, one creator per type behind
 `SimCognitoCfnResourceFactory`. Each creator goes through the ordinary Command rather than
-constructing the model, so a deployed pool is the same thing an SDK caller would have got, refusals
-included.
+constructing the model, so a deployed pool is the same thing an SDK caller would have got. A
+Command refusal fails the stack with the Resource's logical ID in front of it.
 
 A properties class per type turns the template's properties into that Command's input.
 `UserPoolName` is the one property whose CloudFormation name differs from the API's `PoolName`.
@@ -411,6 +411,17 @@ Each type states the properties it simulates, and every other property is record
 Resource and left out of what is created. That is an allow-list rather than a list of
 known-unsimulated properties, because CloudFormation has properties the Cognito API does not, and
 those would otherwise be dropped on the way to a Command that has nowhere to record them.
+
+A property never reaches the Command it would have been refused by, because the allow-list drops it
+first. What the record says about it comes from the Command anyway.
+`simCognitoUnsimulatedPoolMessaging` and `simCognitoUnsimulatedClientOptions` hold what each refused
+input would have done on AWS, `SimCognitoUnsimulatedInput` builds the refusal from it and
+`SimCfnCognitoPropertyParser` builds the ignored-property reason from the same phrase. A template's
+`EmailConfiguration` is recorded in the sentence `CreateUserPool` refuses the same input with.
+
+The Resource is still created without it. Failing a stack over one property would take every other
+Resource in the template with it. A pool missing a delivery configuration says so on the record, and
+a stack that never deployed says nothing at all.
 
 `SimCfnCognitoUserPoolSchema` reads the `Schema` property a CDK `UserPool` emits for its
 `customAttributes` and `standardAttributes`. It passes the declarations on rather than judging them,

--- a/src/service/cognito/cfn/client/sim-cfn-cognito-client-properties.ts
+++ b/src/service/cognito/cfn/client/sim-cfn-cognito-client-properties.ts
@@ -4,6 +4,7 @@ import type {
   SimCfnTemplateValueRecord,
 } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimCreateUserPoolClientCommandInput } from "../../command/client/user-pool-client.command.js";
+import { simCognitoUnsimulatedClientOptions } from "../../command/client/sim-cognito-unsimulated-client-options.js";
 import { SimCfnCognitoGeneratedName } from "../sim-cfn-cognito-generated-name.js";
 import { SimCfnCognitoPropertyParser } from "../sim-cfn-cognito-property-parser.js";
 import { SimCfnCognitoRefreshTokenRotation } from "./sim-cfn-cognito-refresh-token-rotation.js";
@@ -63,6 +64,7 @@ export class SimCfnCognitoClientProperties {
   private readonly propertyParser = new SimCfnCognitoPropertyParser({
     resourceType: "AWS::Cognito::UserPoolClient",
     simulated: simulatedProperties,
+    refused: simCognitoUnsimulatedClientOptions,
   });
 
   constructor(properties: SimCfnCognitoClientPropertiesProperties) {

--- a/src/service/cognito/cfn/sim-cfn-cognito-property-parser.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-property-parser.ts
@@ -3,11 +3,13 @@ import type {
   SimCfnTemplateValue,
   SimCfnTemplateValueRecord,
 } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import { simCognitoUnsimulatedFeatureReason } from "../command/sim-cognito-unsimulated-input.js";
 import { SimCfnCognitoValueParser } from "./sim-cfn-cognito-value-parser.js";
 
 interface SimCfnCognitoPropertyParserProperties {
   readonly resourceType: string;
   readonly simulated: readonly string[];
+  readonly refused?: Readonly<Record<string, string>>;
 }
 
 /**
@@ -26,10 +28,12 @@ interface SimCfnCognitoPropertyParserProperties {
  */
 export class SimCfnCognitoPropertyParser extends SimCfnCognitoValueParser {
   private readonly simulated: readonly string[];
+  private readonly refused: ReadonlyMap<string, string>;
 
   constructor(properties: SimCfnCognitoPropertyParserProperties) {
     super({ resourceType: properties.resourceType });
     this.simulated = properties.simulated;
+    this.refused = new Map(Object.entries(properties.refused ?? {}));
   }
 
   /**
@@ -116,11 +120,26 @@ export class SimCfnCognitoPropertyParser extends SimCfnCognitoValueParser {
    * The modelled names are listed because a Cognito Resource type has a lot of
    * properties and few of them are simulated, so what this can act on is
    * shorter and more useful to read than what it cannot.
+   *
+   * A property the Cognito command would have refused says what the refusal
+   * says instead. The full list is no use to a reader who declared a property
+   * Cognito itself takes: what they need is the one sentence naming what a
+   * deployment would do that this does not.
    */
   private unsimulatedPropertyReason(
     label: string,
     modelled: readonly string[],
   ): string {
+    const refusedFeature = this.refused.get(label);
+
+    if (refusedFeature !== undefined) {
+      return (
+        `${this.resourceType} property ${label} is not simulated: ` +
+        `${simCognitoUnsimulatedFeatureReason(refusedFeature)}. The ` +
+        `Resource is created without it.`
+      );
+    }
+
     return (
       `${this.resourceType} property ${label} is not simulated, so the ` +
       `Resource is created without it and behaves differently here than on ` +

--- a/src/service/cognito/cfn/sim-cfn-cognito-refused-client-properties.iso.test.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-refused-client-properties.iso.test.ts
@@ -1,0 +1,64 @@
+import { assertStringIncludes, assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  deploySuccess,
+  ignoredReason,
+  simAwsInEuWest2,
+} from "../../../../test/cognito/cfn-deploy.js";
+
+describe("Cognito CloudFormation client properties the Cognito commands refuse", () => {
+  it("says what CreateUserPoolClient says about a client WriteAttributes", async () => {
+    // Given a template asking for per-client attribute permissions.
+    const simAws = simAwsInEuWest2();
+
+    // When it is deployed.
+    const stack = await deploySuccess(simAws, {
+      AppPool: {
+        Type: "AWS::Cognito::UserPool",
+        Properties: { UserPoolName: "myapp-users" },
+      },
+      AppClient: {
+        Type: "AWS::Cognito::UserPoolClient",
+        Properties: {
+          UserPoolId: { Ref: "AppPool" },
+          ClientName: "browser",
+          WriteAttributes: ["email"],
+        },
+      },
+    });
+
+    // Then the client is deployed without it, and the record carries what
+    // CreateUserPoolClient refuses the same input with.
+    assertTrue(stack.getResource("AppClient")?.deployed);
+    assertStringIncludes(
+      ignoredReason(stack, "WriteAttributes"),
+      "WriteAttributes is not simulated: per-client attribute permissions " +
+        "would be ignored here and applied on real AWS",
+    );
+  });
+
+  it("keeps the list of simulated properties for one no command refuses", async () => {
+    // Given a template asking for a pool property the Cognito commands say
+    // nothing about.
+    const simAws = simAwsInEuWest2();
+
+    // When it is deployed.
+    const stack = await deploySuccess(simAws, {
+      AppPool: {
+        Type: "AWS::Cognito::UserPool",
+        Properties: {
+          UserPoolName: "myapp-users",
+          DeviceConfiguration: { ChallengeRequiredOnNewDevice: true },
+        },
+      },
+    });
+
+    // Then the record still lists what the Resource type can act on, which is
+    // the more useful answer where nothing more specific is known.
+    assertStringIncludes(
+      ignoredReason(stack, "DeviceConfiguration"),
+      "The simulated properties are",
+    );
+  });
+});

--- a/src/service/cognito/cfn/sim-cfn-cognito-refused-properties.iso.test.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-refused-properties.iso.test.ts
@@ -1,0 +1,78 @@
+import {
+  assertStringIncludes,
+  assertTrue,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import type { SimCfnTemplateValue } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import {
+  createUserPoolRefusal,
+  deploySuccess,
+  ignoredReason,
+  simAwsInEuWest2,
+} from "../../../../test/cognito/cfn-deploy.js";
+
+/**
+ * The AWS::Cognito::UserPool properties CreateUserPool refuses by name, and a
+ * value real Cognito would take for each.
+ */
+const refusedPoolProperties: Readonly<Record<string, SimCfnTemplateValue>> = {
+  EmailConfiguration: { EmailSendingAccount: "DEVELOPER" },
+  SmsConfiguration: { SnsCallerArn: "arn:aws:iam::111122223333:role/sms" },
+  SmsAuthenticationMessage: "Your code is {####}",
+};
+
+describe("Cognito CloudFormation properties the Cognito commands refuse", () => {
+  for (const [label, value] of Object.entries(refusedPoolProperties)) {
+    it(`says what CreateUserPool says about a pool ${label}`, async () => {
+      // Given a template asking for a pool messaging property real Cognito
+      // takes and this simulation delivers nothing through.
+      const simAws = simAwsInEuWest2();
+
+      // When it is deployed.
+      const stack = await deploySuccess(simAws, {
+        AppPool: {
+          Type: "AWS::Cognito::UserPool",
+          Properties: { UserPoolName: "myapp-users", [label]: value },
+        },
+      });
+
+      // Then the pool is deployed without it, as best effort deployment says.
+      assertTrue(stack.getResource("AppPool")?.deployed);
+
+      // And the record carries the sentence CreateUserPool refuses the same
+      // input with, in place of the generic list of simulated properties.
+      const refusal = await createUserPoolRefusal(label, value);
+      const [, feature] = refusal.split("is not simulated: ", 2);
+      assertTypeString(feature);
+
+      const reason = ignoredReason(stack, label);
+      assertStringIncludes(reason, `${label} is not simulated: ${feature}`);
+      assertStringIncludes(reason, "The Resource is created without it.");
+    });
+  }
+
+  it("deploys a pool asking for every one of them at once", async () => {
+    // Given the template a CDK pool moved onto SES and an SNS SMS role emits.
+    const simAws = simAwsInEuWest2();
+
+    // When it is deployed.
+    const stack = await deploySuccess(simAws, {
+      AppPool: {
+        Type: "AWS::Cognito::UserPool",
+        Properties: { UserPoolName: "myapp-users", ...refusedPoolProperties },
+      },
+    });
+
+    // Then the pool is there and every property is on the record.
+    assertTrue(stack.getResource("AppPool")?.deployed);
+
+    for (const label of Object.keys(refusedPoolProperties)) {
+      assertStringIncludes(
+        ignoredReason(stack, label),
+        "would be ignored here and applied on real AWS",
+      );
+    }
+  });
+});

--- a/src/service/cognito/cfn/user-pool/sim-cfn-cognito-user-pool-properties.ts
+++ b/src/service/cognito/cfn/user-pool/sim-cfn-cognito-user-pool-properties.ts
@@ -5,6 +5,7 @@ import type {
 } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimSetUserPoolMfaConfigCommandInput } from "../../command/user-pool/user-pool-mfa.command.js";
 import type { SimCreateUserPoolCommandInput } from "../../command/user-pool/user-pool.command.js";
+import { simCognitoUnsimulatedPoolMessaging } from "../../command/user-pool/sim-cognito-unsimulated-pool-messaging.js";
 import { SimCfnCognitoGeneratedName } from "../sim-cfn-cognito-generated-name.js";
 import { SimCfnCognitoPropertyParser } from "../sim-cfn-cognito-property-parser.js";
 import { SimCfnCognitoAccountRecovery } from "./sim-cfn-cognito-account-recovery.js";
@@ -104,6 +105,7 @@ export class SimCfnCognitoUserPoolProperties {
   private readonly propertyParser = new SimCfnCognitoPropertyParser({
     resourceType: "AWS::Cognito::UserPool",
     simulated: simulatedProperties,
+    refused: simCognitoUnsimulatedPoolMessaging,
   });
 
   constructor(properties: SimCfnCognitoUserPoolPropertiesProperties) {

--- a/src/service/cognito/command/client/sim-cognito-unsimulated-client-options.ts
+++ b/src/service/cognito/command/client/sim-cognito-unsimulated-client-options.ts
@@ -2,6 +2,27 @@ import { SimCognitoUnsimulatedInput } from "../sim-cognito-unsimulated-input.js"
 import type { SimCognitoUserPoolClientSettingsInput } from "./user-pool-client.command.js";
 
 /**
+ * The app client inputs this simulation does not model, and what each of them
+ * would have done on real AWS.
+ *
+ * `AWS::Cognito::UserPoolClient` carries all four under the same names, and
+ * the CloudFormation layer reads this to say the same thing about a property
+ * it drops as this says about an input it refuses.
+ *
+ * `ClientSecret` is absent because CloudFormation has no such property. A
+ * template asks for a generated secret with `GenerateSecret` and reads the
+ * secret back out. `EnableTokenRevocation` is absent because its refusal
+ * depends on the value: `true` is what this simulation does, and only `false`
+ * is refused.
+ */
+export const simCognitoUnsimulatedClientOptions = {
+  AnalyticsConfiguration: "Amazon Pinpoint analytics",
+  EnablePropagateAdditionalUserContextData: "threat protection context data",
+  ReadAttributes: "per-client attribute permissions",
+  WriteAttributes: "per-client attribute permissions",
+} as const;
+
+/**
  * Refuses the app client inputs this simulation does not model.
  *
  * Storing any of them would suggest an app client that works here would work
@@ -33,22 +54,22 @@ export class SimCognitoUnsimulatedUserPoolClientOptions {
     this.unsimulated.refuse(
       "AnalyticsConfiguration",
       input.AnalyticsConfiguration,
-      "Amazon Pinpoint analytics",
+      simCognitoUnsimulatedClientOptions.AnalyticsConfiguration,
     );
     this.unsimulated.refuse(
       "EnablePropagateAdditionalUserContextData",
       input.EnablePropagateAdditionalUserContextData,
-      "threat protection context data",
+      simCognitoUnsimulatedClientOptions.EnablePropagateAdditionalUserContextData,
     );
     this.unsimulated.refuse(
       "ReadAttributes",
       input.ReadAttributes,
-      "per-client attribute permissions",
+      simCognitoUnsimulatedClientOptions.ReadAttributes,
     );
     this.unsimulated.refuse(
       "WriteAttributes",
       input.WriteAttributes,
-      "per-client attribute permissions",
+      simCognitoUnsimulatedClientOptions.WriteAttributes,
     );
   }
 }

--- a/src/service/cognito/command/sim-cognito-unsimulated-input.ts
+++ b/src/service/cognito/command/sim-cognito-unsimulated-input.ts
@@ -1,6 +1,18 @@
 import { SimCognitoInvalidParameterException } from "../error/sim-cognito.error.js";
 
 /**
+ * Say what a request asking for an unsimulated input would have got on AWS.
+ *
+ * The CloudFormation layer records this same sentence against a property it
+ * drops, so a reader meets one wording for one limitation whichever path they
+ * came in on. It lives here because the refusal is what the wording was
+ * written for, and a second copy would drift.
+ */
+export function simCognitoUnsimulatedFeatureReason(feature: string): string {
+  return `${feature} would be ignored here and applied on real AWS`;
+}
+
+/**
  * Refuses a request input this simulation does not model.
  *
  * Both creation commands need the same two refusals, in the same words: one
@@ -28,8 +40,9 @@ export class SimCognitoUnsimulatedInput {
     }
 
     throw new SimCognitoInvalidParameterException(
-      `${this.operation} ${option} is not simulated: ${feature} would be ` +
-        `ignored here and applied on real AWS`,
+      `${this.operation} ${option} is not simulated: ${simCognitoUnsimulatedFeatureReason(
+        feature,
+      )}`,
     );
   }
 
@@ -48,7 +61,7 @@ export class SimCognitoUnsimulatedInput {
 
     throw new SimCognitoInvalidParameterException(
       `${this.operation} ${option} '${String(value)}' is not simulated: ` +
-        `${feature} would be ignored here and applied on real AWS. Only ` +
+        `${simCognitoUnsimulatedFeatureReason(feature)}. Only ` +
         `'${String(simulated)}' is supported.`,
     );
   }

--- a/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-messaging.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-messaging.ts
@@ -8,6 +8,20 @@ import type { SimCognitoUserPoolCommandInput } from "./user-pool.command.js";
 const linkVerification = "confirming a sign-up by following a link";
 
 /**
+ * The pool creation inputs nothing here delivers a message through, and what
+ * each of them would have done on real AWS.
+ *
+ * `AWS::Cognito::UserPool` carries all three under the same names, and the
+ * CloudFormation layer reads this to say the same thing about a property it
+ * drops as this says about an input it refuses.
+ */
+export const simCognitoUnsimulatedPoolMessaging = {
+  EmailConfiguration: "email delivery",
+  SmsConfiguration: "SMS delivery",
+  SmsAuthenticationMessage: "multi-factor authentication messages",
+} as const;
+
+/**
  * Refuses the message delivery inputs this simulation does not model.
  *
  * Nothing here delivers an email or a text message. A pool records the message
@@ -42,17 +56,17 @@ export class SimCognitoUnsimulatedUserPoolMessaging {
     this.unsimulated.refuse(
       "EmailConfiguration",
       input.EmailConfiguration,
-      "email delivery",
+      simCognitoUnsimulatedPoolMessaging.EmailConfiguration,
     );
     this.unsimulated.refuse(
       "SmsConfiguration",
       input.SmsConfiguration,
-      "SMS delivery",
+      simCognitoUnsimulatedPoolMessaging.SmsConfiguration,
     );
     this.unsimulated.refuse(
       "SmsAuthenticationMessage",
       input.SmsAuthenticationMessage,
-      "multi-factor authentication messages",
+      simCognitoUnsimulatedPoolMessaging.SmsAuthenticationMessage,
     );
 
     this.refuseLinkVerification(input.VerificationMessageTemplate);

--- a/test/cognito/cfn-deploy.ts
+++ b/test/cognito/cfn-deploy.ts
@@ -9,7 +9,12 @@
  * published build, not collected as a suite, and not counted in coverage.
  */
 
-import { assertInstanceOf, assertThrowsErrorAsync } from "@kensio/smartass";
+import { CreateUserPoolCommand } from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
 
 import { SimAws } from "../../src/service/aws/sim-aws.js";
 import type { SimCfnDeployedStack } from "../../src/service/cloudformation/stack/sim-cfn-deployed-stack.type.js";
@@ -74,4 +79,42 @@ export function ignoredReasons(stack: SimCfnDeployedStack): string[] {
   return stack.ignoredProperties.map((ignored) => {
     return `${ignored.logicalId} ${ignored.reason}`;
   });
+}
+
+/**
+ * The reason a deployed stack gave for one property it created a Resource
+ * without, found by the property's path.
+ */
+export function ignoredReason(
+  stack: SimCfnDeployedStack,
+  path: string,
+): string {
+  const ignored = stack.ignoredProperties.find(
+    (property) => property.path === path,
+  );
+  assertNonNullable(ignored);
+
+  return ignored.reason;
+}
+
+/**
+ * What CreateUserPool refuses one pool input with.
+ *
+ * A test comparing the CloudFormation record against this compares the two
+ * paths, rather than comparing both against a sentence the test wrote down.
+ */
+export async function createUserPoolRefusal(
+  option: string,
+  value: unknown,
+): Promise<string> {
+  const cognito = new SimAws().cognitoIdentityProvider();
+
+  const error = await assertThrowsErrorAsync(async () => {
+    await cognito.createUserPool(
+      new CreateUserPoolCommand({ PoolName: "myapp-users", [option]: value }),
+    );
+  });
+  assertInstanceOf(error, Error);
+
+  return error.message;
 }


### PR DESCRIPTION
A user pool template carrying `EmailConfiguration`, `SmsConfiguration` or `SmsAuthenticationMessage` deployed with the generic allow-list reason on `stack.ignoredProperties`, while `CreateUserPool` refuses all three by name. The record now carries the command's own sentence, built from the phrase the refusal is built from, and the same goes for the four app client inputs `CreateUserPoolClient` refuses. The Resource is still created without the property, because failing a stack over one property would take every other Resource in the template with it.

```
AWS::Cognito::UserPool property EmailConfiguration is not simulated: email delivery would be ignored here and applied on real AWS. The Resource is created without it.
```

`simCognitoUnsimulatedPoolMessaging` and `simCognitoUnsimulatedClientOptions` are the one place each refused input's wording lives. `SimCognitoUnsimulatedInput` builds the refusal from it and `SimCfnCognitoPropertyParser` builds the ignored-property reason from it, so the two paths cannot drift apart. The pool tests read the refusal out of `CreateUserPool` and assert the deployed record contains it, rather than asserting both against a sentence the test wrote down.

A property no Cognito command refuses keeps the list of what the Resource type simulates, which stays the more useful answer where nothing more specific is known.

Resolves #881
