### PR TITLE
feat: map twelve more Terraform types into sim AWS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -315,4 +315,6 @@ tmp/
 # test/terraform are in the repository; what terraform makes from them is not.
 test/terraform/**/.terraform/
 test/terraform/**/builds/
+test/terraform/**/terraform.tfstate*
+test/terraform/**/.terraform.tfstate.lock.info
 *.tfplan

--- a/docs/terraform/README.md
+++ b/docs/terraform/README.md
@@ -171,11 +171,21 @@ outright when its execution role cannot poll the queue). Supplying the policy ta
 off. The document is evaluated as it stands, and one omitting `sqs:ReceiveMessage` fails the mapping
 the way AWS fails it.
 
+## What it maps
+
+The adapter maps 24 Terraform resource types and folds 11 more into the resource they configure. The
+set covers API Gateway, CloudWatch (log groups, metric alarms and EventBridge rules), Cognito,
+DynamoDB, ECR, IAM, KMS, Lambda, S3, Secrets Manager, SNS, SQS and SSM Parameter Store.
+
+A hand-written application configuration of 46 resources deploys whole. A configuration built out of
+published `terraform-aws-modules` modules reaches 21 of its 25. Of the four it leaves, the Lambda
+module uses `null_resource` and `local_file` to package a zip, and an integration and a route read
+their values through a `for_each` hop the adapter steps over.
+
 ## What the report says
 
-The set of Terraform resource types the adapter maps is deliberately small. A type with no mapping,
-and a resource from a provider other than AWS, are recorded and stepped over rather than failing the
-deployment.
+A type with no mapping, and a resource from a provider other than AWS, are recorded and stepped over
+rather than failing the deployment.
 
 ```typescript terraform-plan-report
 /**

--- a/src/service/cloudformation/cdk/s3/bucket-notifications/property/sim-cdk-bucket-notification-properties.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-notifications/property/sim-cdk-bucket-notification-properties.ts
@@ -22,9 +22,10 @@ const knownPropertyNames: ReadonlySet<string> = new Set([
 /**
  * Reads the properties of one Custom::S3BucketNotifications Resource.
  *
- * A property name CDK does not emit is refused rather than ignored. This
- * Resource is a private contract between CDK and its own provider function, so
- * a name that turns up here is a version of CDK asking for something this
+ * A property name neither CDK nor the Terraform plan import emits is refused
+ * rather than ignored. This Resource is a private contract between CDK and its
+ * own provider function, and the import writes into that same contract, so a
+ * name that turns up here is a version of CDK asking for something this
  * simulator has not been told about, and quietly dropping it would leave the
  * Bucket configured differently from the app that was deployed.
  */

--- a/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications.ts
@@ -20,6 +20,11 @@ import { SimCdkBucketNotificationsRemover } from "./sim-cdk-bucket-notifications
  * call through the ordinary command path, so a CDK app and an SDK caller are
  * validated identically.
  *
+ * The Terraform plan import builds one too. Terraform declares a bucket's
+ * notification as a resource of its own, and a template carrying it on the
+ * bucket alongside the function's `AWS::Lambda::Permission` is the circular
+ * dependency this Resource type exists to break.
+ *
  * `ServiceToken` is read for the provider function it names, and otherwise
  * ignored. That function is declined on its runtime, as CDK's BucketDeployment
  * provider is, and recorded as inert rather than as a gap, since this factory

--- a/src/terraform/README.md
+++ b/src/terraform/README.md
@@ -153,13 +153,26 @@ to merge. A Secret whose `aws_secretsmanager_secret_version` is missing or unres
 without a value, and simulated Secrets Manager refuses that. Closing it means settling the folds
 along with the Resources they configure, which is the same fixed point run over a wider set.
 
+### CloudFormation cannot always hold what Terraform holds
+
+A bucket's event notification is a resource of its own in Terraform. The function's
+`aws_lambda_permission` names the bucket whose events it admits, and the notification names the
+function, so the three form a line. CloudFormation carries the notification on the `AWS::S3::Bucket`
+itself, and the bucket and the permission then wait for each other.
+
+CDK hits the same wall and answers it with `Custom::S3BucketNotifications`, a Resource that sits
+between the two and applies the configuration with one
+`PutBucketNotificationConfiguration` call. Simulated CloudFormation creates one, so
+`aws_s3_bucket_notification` maps onto that Resource and keeps the ordering Terraform describes. An
+uploaded object reaches the function the plan named.
+
 ## Adding a resource type
 
 A mapping is a function from one `TerraformResource` to one CloudFormation Resource, registered by
-Terraform type in `sim-tf-registry.ts`. The mappings live under `map/`, a file to a service. S3 and
-the HTTP API run to more than one file each, because FTA scores density and a file of mapping
-literals reaches the threshold of 50 at around 100 lines. Where that forced a split, the line drawn
-was between the flat renames and the sections CloudFormation holds as lists of rules.
+Terraform type in `sim-tf-registry.ts`. The mappings live under `map/`, a file to a service. S3,
+Cognito and the HTTP API run to more than one file each, because FTA scores density and a file of
+mapping literals reaches the threshold of 50 at around 100 lines. Where that forced a split, the
+line drawn was between the flat renames and the sections CloudFormation holds as lists of rules.
 
 Most of a mapping is the rename table `renamed()` applies. What needs more than a rename is added to
 what that returns. `attribute()` reads one attribute, answering with the value the plan resolved or
@@ -167,11 +180,39 @@ with the intrinsic that reads it off the Resource producing it. `requires` names
 target service will refuse the Resource without, and `lost` names the attributes the mapping could
 not carry.
 
+Two attribute shapes `attribute()` cannot read have readers of their own in
+`sim-tf-nested-attributes.ts`. A list whose entries name other resources arrives marked unknown as a
+whole list, and `attributeList()` puts the intrinsics back (an alarm's `alarm_actions` holding one
+topic ARN is the case it was written for). An attribute inside a repeating nested block has its own
+position in a list mirroring the block, and `blockAttribute()` reads the mark and the reference
+together from that position (a bucket notification's `lambda_function_arn` is that case).
+
 A resource that configures another resource is a fold. It names the attribute holding its parent's
-address and returns the properties to merge in.
+address and returns the properties to merge in. It is also handed the properties the parent already
+carries, for the fold whose property is a list. An EventBridge rule's targets are one Terraform
+resource each and one `Targets` list on the Resource, so the second target of a rule has to find the
+first.
 
 Measured over the two configurations below, a mapped type is about 35 lines. Finding out what the
 target service refuses takes longer than writing the mapping.
+
+Three questions are worth answering before the rename table.
+
+What does the target service do with a property it does not model? Most record it against the
+Resource and create it anyway, and a mapping can send those. Some refuse the Resource outright, and
+a mapping has to leave those off and name them under `lost`. Simulated EventBridge refuses `Tags` on
+a rule, simulated SNS refuses them on a topic, and simulated ECR and CloudWatch record them.
+
+What does it require? Simulated DynamoDB refuses a `PROVISIONED` table carrying no
+`ProvisionedThroughput`, and PutMetricAlarm requires seven properties before it will evaluate
+anything. Naming them under `requires` is also what steps over the shapes this simulation does not
+model, since an alarm built out of `metric_query` blocks carries no namespace, metric name or
+statistic of its own.
+
+Does the provider write an absent value or an empty one? An absent optional string inside a nested
+block arrives as `""` and an absent top-level one arrives as `null`. Taking the empty string at face
+value declares a secondary index with a nameless range key, a lifecycle rule whose prefix matches
+every object, and a notification filter that filters nothing.
 
 ## Testing
 
@@ -181,10 +222,17 @@ across. A test says each thing once, and the reader is still tested against the 
 plan. Those tests are isolated tests and need no Terraform installed.
 
 Two whole configurations are committed under `test/terraform/app` and `test/terraform/modules`, and
-`sim-tf-plan-deploy.loc.test.ts` plans them with `TestTerraformProject` and deploys the result. They
-cover the one thing a fixture cannot say. The format being read is the format Terraform writes. Run
-`pnpm tf:init` once before them. It downloads the AWS provider (one 648MB binary) and takes a few
-minutes the first time.
+the three `.loc.test.ts` files beside the import plan them with `TestTerraformProject` and deploy
+the result. They cover the one thing a fixture cannot say. The format being read is the format
+Terraform writes. `sim-tf-plan-deploy.loc.test.ts` covers the deployment, `-services` covers what
+each simulated service made of it, and `-report` asserts the fraction of each plan the import
+reaches. Run `pnpm tf:init` once before them. It downloads the AWS provider (one 648MB binary) and
+takes a few minutes the first time.
+
+Planning takes the state lock, and a configuration planned by three test files at once would fail on
+its own lock. These configurations have no state and are never applied, so `TestTerraformProject`
+plans with `-lock=false`, and each test file plans a configuration once however many of its tests
+deploy it.
 
 `test/terraform/app` is an application config written by hand. `test/terraform/modules` is built
 from published `terraform-aws-modules` modules, and it is the honest one. Every provider and module
@@ -201,18 +249,19 @@ Two plans, both produced by Terraform 1.15.8 against AWS provider 5.100.0.
 
 |                   | resources | mapped | folded | skipped | reached |
 | ----------------- | --------- | ------ | ------ | ------- | ------- |
-| hand-written app  | 41        | 23     | 7      | 11      | 73%     |
-| community modules | 25        | 12     | 6      | 7       | 72%     |
+| hand-written app  | 46        | 35     | 11     | 0       | 100%    |
+| community modules | 25        | 12     | 9      | 4       | 84%     |
 
 Reached means a simulated resource was created for it, either as a Resource of its own or as
-properties folded into one. The import maps 16 Terraform resource types and folds 7 more.
+properties folded into one. The import maps 24 Terraform resource types and folds 11 more.
 
-Most of what it skips is the size of the mapped set, which grows in
-[#866](https://github.com/KensioSoftware/yulin/issues/866). Cross-referencing every resource type in
-both plans against the 61 CloudFormation types Yulin models puts the ceiling at 41 of 41 for the
-application plan and 23 of 25 for the module plan. The two out of reach are `null_resource` and
-`local_file`, which the Lambda module uses to package a zip. Between 72% measured and that ceiling
-sits the `each.value` hop described above, worth 2 more resources on the module plan.
+The application plan is at its ceiling. Four resources of the module plan are left. `null_resource`
+and `local_file` package a zip and belong to no AWS service. The integration and the route read
+their values through the `each.value` hop described above, which is
+[#867](https://github.com/KensioSoftware/yulin/issues/867) and worth 2 more resources.
+
+Both figures are asserted in `sim-tf-plan-report.loc.test.ts`, by the resource types each plan
+leaves unreached. A mapping that stops reaching a type fails there.
 
 Planning offline fails every `data` block that reaches AWS. Both community modules read
 `aws_caller_identity`, and `terraform plan` reports an error and exits non-zero for each. It still

--- a/src/terraform/map/sim-tf-map-cloudwatch-dimensions.ts
+++ b/src/terraform/map/sim-tf-map-cloudwatch-dimensions.ts
@@ -1,0 +1,51 @@
+/*
+ * The dimensions an alarm's metric is identified by, which Terraform states as
+ * a map and CloudFormation as a list of name and value pairs.
+ *
+ * Reading a plan means reading records whose keys come from the document
+ * rather than from this code, so the object-injection rule fires on every
+ * lookup. The records are parsed JSON with no prototype of their own.
+ */
+// oxlint-disable security/detect-object-injection
+import { isRecord } from "../../util/type-guard/record.js";
+import type { SimCfnTemplateValue } from "../../service/cloudformation/template/value/sim-cfn-template-value.js";
+import { field, type TerraformMappingContext } from "../sim-tf-attributes.js";
+
+/** An alarm's dimensions, and what it could not carry across. */
+interface AlarmDimensions {
+  readonly value: SimCfnTemplateValue | undefined;
+  readonly lost: readonly string[];
+}
+
+/**
+ * The dimensions the alarm's metric is identified by.
+ *
+ * Terraform states them as a map and CloudFormation as a list of name and
+ * value pairs. A dimension whose value the plan could not resolve is dropped
+ * and the map recorded: the references survive, but they survive for the map
+ * rather than per key, so which dimension a resolved value belongs to is not
+ * in the plan. An alarm carrying a dimension with no value is one PutMetricAlarm
+ * refuses.
+ */
+export function alarmDimensions(
+  context: TerraformMappingContext,
+): AlarmDimensions {
+  const value = field(context.resource.values, "dimensions");
+
+  if (!isRecord(value)) {
+    return { value: undefined, lost: [] };
+  }
+
+  const entries = Object.entries(value).filter(
+    (entry): entry is [string, string] => typeof entry[1] === "string",
+  );
+  const dropped = entries.length < Object.keys(value).length;
+
+  return {
+    value:
+      entries.length === 0
+        ? undefined
+        : entries.map(([Name, Value]) => ({ Name, Value })),
+    lost: dropped ? ["dimensions"] : [],
+  };
+}

--- a/src/terraform/map/sim-tf-map-cloudwatch.ts
+++ b/src/terraform/map/sim-tf-map-cloudwatch.ts
@@ -1,0 +1,82 @@
+/*
+ * Reading a plan means reading records whose keys come from the document
+ * rather than from this code, so the object-injection rule fires on every
+ * lookup. The records are parsed JSON with no prototype of their own.
+ */
+// oxlint-disable security/detect-object-injection
+import {
+  properties,
+  renamed,
+  tags,
+  type TerraformMappingContext,
+} from "../sim-tf-attributes.js";
+import { attributeList } from "../sim-tf-nested-attributes.js";
+import { alarmDimensions } from "./sim-tf-map-cloudwatch-dimensions.js";
+import type { TerraformMappedResource } from "../sim-tf-mapping.type.js";
+
+/**
+ * The properties simulated CloudWatch will not create an alarm without.
+ *
+ * They are the same seven PutMetricAlarm requires, and an alarm missing one
+ * fails the Stack around it rather than only itself. Naming them here is also
+ * what steps over the two alarm shapes this simulation does not evaluate: an
+ * alarm built out of `metric_query` blocks carries no namespace, metric name
+ * or statistic of its own, and one watching a percentile carries an
+ * `extended_statistic` in place of its `statistic`.
+ */
+const required = [
+  "Namespace",
+  "MetricName",
+  "Statistic",
+  "Period",
+  "EvaluationPeriods",
+  "Threshold",
+  "ComparisonOperator",
+];
+
+/**
+ * A metric alarm.
+ *
+ * Tags go across as they were written. The CloudFormation layer records them
+ * against the Resource and never passes them to PutMetricAlarm, which is the
+ * one place they would be refused, so a tagged alarm deploys and says that
+ * nothing reads its tags.
+ */
+export function metricAlarm(
+  context: TerraformMappingContext,
+): TerraformMappedResource {
+  const identified = alarmDimensions(context);
+
+  return {
+    Type: "AWS::CloudWatch::Alarm",
+    Properties: {
+      ...renamed(context, {
+        AlarmName: "alarm_name",
+        AlarmDescription: "alarm_description",
+        Namespace: "namespace",
+        MetricName: "metric_name",
+        Statistic: "statistic",
+        Unit: "unit",
+        Period: "period",
+        EvaluationPeriods: "evaluation_periods",
+        DatapointsToAlarm: "datapoints_to_alarm",
+        Threshold: "threshold",
+        ComparisonOperator: "comparison_operator",
+        TreatMissingData: "treat_missing_data",
+        ActionsEnabled: "actions_enabled",
+      }),
+      ...properties({
+        Dimensions: identified.value,
+        AlarmActions: attributeList(context, "alarm_actions"),
+        OKActions: attributeList(context, "ok_actions"),
+        InsufficientDataActions: attributeList(
+          context,
+          "insufficient_data_actions",
+        ),
+        Tags: tags(context),
+      }),
+    },
+    requires: required,
+    lost: identified.lost,
+  };
+}

--- a/src/terraform/map/sim-tf-map-cognito-client.ts
+++ b/src/terraform/map/sim-tf-map-cognito-client.ts
@@ -1,0 +1,40 @@
+import { renamed, type TerraformMappingContext } from "../sim-tf-attributes.js";
+import type { TerraformMappedResource } from "../sim-tf-mapping.type.js";
+
+/**
+ * A user pool client.
+ *
+ * The pool is required, as it is on real CloudFormation: a client belongs to
+ * one pool and there is nowhere to create one without it. A plan whose pool
+ * this import left out therefore leaves the client out too.
+ *
+ * Nothing else is required. The token lifetimes and the OAuth settings arrive
+ * unknown on a client that states none, because AWS decides them, and a client
+ * created without them gets the same defaults here.
+ */
+export function cognitoUserPoolClient(
+  context: TerraformMappingContext,
+): TerraformMappedResource {
+  return {
+    Type: "AWS::Cognito::UserPoolClient",
+    Properties: renamed(context, {
+      UserPoolId: "user_pool_id",
+      ClientName: "name",
+      GenerateSecret: "generate_secret",
+      ExplicitAuthFlows: "explicit_auth_flows",
+      PreventUserExistenceErrors: "prevent_user_existence_errors",
+      AccessTokenValidity: "access_token_validity",
+      IdTokenValidity: "id_token_validity",
+      RefreshTokenValidity: "refresh_token_validity",
+      AuthSessionValidity: "auth_session_validity",
+      AllowedOAuthFlows: "allowed_oauth_flows",
+      AllowedOAuthFlowsUserPoolClient: "allowed_oauth_flows_user_pool_client",
+      AllowedOAuthScopes: "allowed_oauth_scopes",
+      CallbackURLs: "callback_urls",
+      LogoutURLs: "logout_urls",
+      DefaultRedirectURI: "default_redirect_uri",
+      SupportedIdentityProviders: "supported_identity_providers",
+    }),
+    requires: ["UserPoolId"],
+  };
+}

--- a/src/terraform/map/sim-tf-map-cognito-pool.ts
+++ b/src/terraform/map/sim-tf-map-cognito-pool.ts
@@ -1,0 +1,124 @@
+/*
+ * The parts of a user pool that need more than a rename: the password policy
+ * and the attribute schema, which Terraform states as nested blocks, and the
+ * tags, which CloudFormation carries as a map rather than as the list of key
+ * and value pairs it uses everywhere else.
+ *
+ * Reading a plan means reading records whose keys come from the document
+ * rather than from this code, so the object-injection rule fires on every
+ * lookup. The records are parsed JSON with no prototype of their own.
+ */
+// oxlint-disable security/detect-object-injection
+import type { SimCfnTemplateValue } from "../../service/cloudformation/template/value/sim-cfn-template-value.js";
+import {
+  block,
+  blocks,
+  field,
+  properties,
+  templateValue,
+  type TerraformMappingContext,
+} from "../sim-tf-attributes.js";
+import { blockFields } from "../sim-tf-nested-attributes.js";
+
+/**
+ * The attributes the pool holds, one Terraform `schema` block each.
+ *
+ * A custom attribute's constraints are a nested block of their own, and the
+ * provider writes both kinds on every entry, so the one that does not belong
+ * to the attribute's type is an empty list and comes back undefined.
+ */
+export function userPoolSchema(
+  context: TerraformMappingContext,
+): SimCfnTemplateValue | undefined {
+  const declared = blocks(context, "schema");
+
+  if (declared.length === 0) {
+    return undefined;
+  }
+
+  return declared.map((attributeSchema) =>
+    properties({
+      Name: field(attributeSchema, "name") as string,
+      AttributeDataType: field(
+        attributeSchema,
+        "attribute_data_type",
+      ) as string,
+      Mutable: field(attributeSchema, "mutable") as boolean,
+      Required: field(attributeSchema, "required") as boolean,
+      StringAttributeConstraints: constraints(
+        attributeSchema,
+        "string_attribute_constraints",
+        { MinLength: "min_length", MaxLength: "max_length" },
+      ),
+      NumberAttributeConstraints: constraints(
+        attributeSchema,
+        "number_attribute_constraints",
+        { MinValue: "min_value", MaxValue: "max_value" },
+      ),
+    }),
+  );
+}
+
+/** One attribute's constraints, where the block holding them was written. */
+function constraints(
+  attributeSchema: Record<string, unknown>,
+  key: string,
+  names: Readonly<Record<string, string>>,
+): SimCfnTemplateValue | undefined {
+  const declared = field(attributeSchema, key);
+  const [first] = Array.isArray(declared) ? (declared as unknown[]) : [];
+
+  if (first === undefined || typeof first !== "object" || first === null) {
+    return undefined;
+  }
+
+  const bounds = blockFields(first as Record<string, unknown>, names);
+
+  return Object.keys(bounds).length === 0 ? undefined : bounds;
+}
+
+/**
+ * The pool's tags, which CloudFormation carries as a map rather than as the
+ * list of key and value pairs it uses everywhere else.
+ *
+ * `tags_all` is `tags` merged with the provider's default tags, and it is the
+ * one that ends up on the pool.
+ */
+export function userPoolTags(
+  context: TerraformMappingContext,
+): SimCfnTemplateValue | undefined {
+  const values = context.resource.values;
+  const declared = field(values, "tags_all") ?? field(values, "tags");
+
+  return templateValue(declared);
+}
+
+/**
+ * The pool's password policy, which CloudFormation nests under `Policies`.
+ *
+ * A policy of nothing but nulls is a pool that stated the block and configured
+ * nothing in it, so an empty result is left off rather than sent.
+ */
+export function userPoolPolicies(
+  context: TerraformMappingContext,
+): SimCfnTemplateValue | undefined {
+  const policy = block(context, "password_policy");
+
+  if (policy === undefined) {
+    return undefined;
+  }
+
+  const password = blockFields(policy, {
+    MinimumLength: "minimum_length",
+    RequireUppercase: "require_uppercase",
+    RequireLowercase: "require_lowercase",
+    RequireNumbers: "require_numbers",
+    RequireSymbols: "require_symbols",
+    TemporaryPasswordValidityDays: "temporary_password_validity_days",
+    PasswordHistorySize: "password_history_size",
+  });
+
+  return Object.keys(password).length === 0
+    ? undefined
+    : { PasswordPolicy: password };
+}

--- a/src/terraform/map/sim-tf-map-cognito.ts
+++ b/src/terraform/map/sim-tf-map-cognito.ts
@@ -1,0 +1,50 @@
+/*
+ * Reading a plan means reading records whose keys come from the document
+ * rather than from this code, so the object-injection rule fires on every
+ * lookup. The records are parsed JSON with no prototype of their own.
+ */
+// oxlint-disable security/detect-object-injection
+import {
+  properties,
+  renamed,
+  type TerraformMappingContext,
+} from "../sim-tf-attributes.js";
+import type { TerraformMappedResource } from "../sim-tf-mapping.type.js";
+import {
+  userPoolPolicies,
+  userPoolSchema,
+  userPoolTags,
+} from "./sim-tf-map-cognito-pool.js";
+
+/**
+ * A user pool.
+ *
+ * `UserPoolTags` is CloudFormation's name for a pool's tags, and unlike almost
+ * everywhere else it is a map rather than a list of key and value pairs.
+ * Simulated Cognito records every property it does not model against the
+ * Resource rather than refusing it, so the pool deploys and says what it is
+ * not doing.
+ */
+export function cognitoUserPool(
+  context: TerraformMappingContext,
+): TerraformMappedResource {
+  return {
+    Type: "AWS::Cognito::UserPool",
+    Properties: {
+      ...renamed(context, {
+        UserPoolName: "name",
+        MfaConfiguration: "mfa_configuration",
+        DeletionProtection: "deletion_protection",
+        AutoVerifiedAttributes: "auto_verified_attributes",
+        UsernameAttributes: "username_attributes",
+        AliasAttributes: "alias_attributes",
+        SmsAuthenticationMessage: "sms_authentication_message",
+      }),
+      ...properties({
+        Policies: userPoolPolicies(context),
+        Schema: userPoolSchema(context),
+        UserPoolTags: userPoolTags(context),
+      }),
+    },
+  };
+}

--- a/src/terraform/map/sim-tf-map-compute.iso.test.ts
+++ b/src/terraform/map/sim-tf-map-compute.iso.test.ts
@@ -13,6 +13,7 @@ import { lambdaFunction } from "./sim-tf-map-lambda.js";
 import { logGroup } from "./sim-tf-map-logs.js";
 import { httpApi } from "./sim-tf-map-http-api.js";
 import { httpApiRoute } from "./sim-tf-map-http-api-routes.js";
+import { ecrRepository } from "./sim-tf-map-ecr.js";
 import type { TerraformMappingContext } from "../sim-tf-attributes.js";
 
 const assumeRolePolicy = JSON.stringify({
@@ -365,6 +366,34 @@ describe("mapping an HTTP API", () => {
         "",
         ["integrations/", { Ref: "AwsApigatewayv2IntegrationProcessor" }],
       ],
+    });
+  });
+});
+
+describe("mapping an ECR repository", () => {
+  it("carries the image settings simulated ECR records rather than acts on", () => {
+    // Given a repository scanning on push and refusing tag moves
+    const context = contextFor({
+      resources: [
+        terraformPlanResourceFactory.make({
+          type: "aws_ecr_repository",
+          name: "processor",
+          values: {
+            name: "orders-processor",
+            image_tag_mutability: "IMMUTABLE",
+            image_scanning_configuration: [{ scan_on_push: true }],
+          },
+        }),
+      ],
+    });
+
+    // When it is mapped
+    // Then both go across, so the record simulated ECR keeps against the
+    // Resource names what the repository was asked for and is not doing
+    assertObjectEquals(ecrRepository(context).Properties, {
+      RepositoryName: "orders-processor",
+      ImageTagMutability: "IMMUTABLE",
+      ImageScanningConfiguration: { ScanOnPush: true },
     });
   });
 });

--- a/src/terraform/map/sim-tf-map-dynamodb-keys.ts
+++ b/src/terraform/map/sim-tf-map-dynamodb-keys.ts
@@ -1,0 +1,106 @@
+/*
+ * The parts of a table CloudFormation holds as lists of key and index
+ * declarations, where Terraform holds them as attributes and repeating blocks.
+ *
+ * Reading a plan means reading records whose keys come from the document
+ * rather than from this code, so the object-injection rule fires on every
+ * lookup. The records are parsed JSON with no prototype of their own.
+ */
+// oxlint-disable security/detect-object-injection
+import type { SimCfnTemplateValue } from "../../service/cloudformation/template/value/sim-cfn-template-value.js";
+import {
+  blocks,
+  field,
+  properties,
+  type TerraformMappingContext,
+} from "../sim-tf-attributes.js";
+
+/** The attribute types a table declares, one `attribute` block each. */
+export function attributeDefinitions(
+  context: TerraformMappingContext,
+): SimCfnTemplateValue {
+  return blocks(context, "attribute").map((entry) => ({
+    AttributeName: field(entry, "name") as string,
+    AttributeType: field(entry, "type") as string,
+  }));
+}
+
+/**
+ * A key schema, from the hash and range key attribute names.
+ *
+ * An optional string inside a nested block arrives as an empty string rather
+ * than as null, which is how a top-level optional attribute arrives. A range
+ * key that was never declared reads as `""`, and taking it at face value
+ * declares an index with a nameless RANGE element.
+ */
+export function keySchema(
+  hashKey: unknown,
+  rangeKey: unknown,
+): SimCfnTemplateValue | undefined {
+  if (!named(hashKey)) {
+    return undefined;
+  }
+
+  const range = named(rangeKey)
+    ? [{ AttributeName: rangeKey, KeyType: "RANGE" }]
+    : [];
+
+  return [{ AttributeName: hashKey, KeyType: "HASH" }, ...range];
+}
+
+function named(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+/**
+ * The global secondary indexes, each provisioned the way the table is.
+ *
+ * An index of a provisioned table carries a capacity pair of its own, under
+ * the same attribute names the table uses, and an index of an on-demand table
+ * carries the pair at zero. So the property follows the table's billing mode
+ * rather than the presence of the attributes.
+ */
+export function secondaryIndexes(
+  context: TerraformMappingContext,
+  provisioned: boolean,
+): SimCfnTemplateValue | undefined {
+  const indexes = blocks(context, "global_secondary_index");
+
+  if (indexes.length === 0) {
+    return undefined;
+  }
+
+  return indexes.map((index) => ({
+    IndexName: field(index, "name") as string,
+    KeySchema:
+      keySchema(field(index, "hash_key"), field(index, "range_key")) ?? [],
+    Projection: properties({
+      ProjectionType: field(index, "projection_type") as string,
+      NonKeyAttributes: nonEmptyList(field(index, "non_key_attributes")),
+    }),
+    ...(provisioned && { ProvisionedThroughput: throughput(index) }),
+  }));
+}
+
+/**
+ * The capacity a provisioned table or index is created with.
+ *
+ * Simulated DynamoDB requires `ProvisionedThroughput` under `PROVISIONED`
+ * billing and refuses it under `PAY_PER_REQUEST`, as real DynamoDB does either
+ * way, so a table that leaves it off is refused along with the Stack around it.
+ */
+export function throughput(
+  values: Record<string, unknown>,
+): SimCfnTemplateValue {
+  return {
+    ReadCapacityUnits: field(values, "read_capacity") as number,
+    WriteCapacityUnits: field(values, "write_capacity") as number,
+  };
+}
+
+/** A Terraform list attribute, where the provider left anything in it. */
+function nonEmptyList(value: unknown): SimCfnTemplateValue | undefined {
+  return Array.isArray(value) && value.length > 0
+    ? (value as SimCfnTemplateValue)
+    : undefined;
+}

--- a/src/terraform/map/sim-tf-map-dynamodb.ts
+++ b/src/terraform/map/sim-tf-map-dynamodb.ts
@@ -7,7 +7,6 @@
 import type { SimCfnTemplateValue } from "../../service/cloudformation/template/value/sim-cfn-template-value.js";
 import {
   block,
-  blocks,
   field,
   properties,
   renamed,
@@ -15,6 +14,12 @@ import {
   type TerraformMappingContext,
 } from "../sim-tf-attributes.js";
 import type { TerraformMappedResource } from "../sim-tf-mapping.type.js";
+import {
+  attributeDefinitions,
+  keySchema,
+  secondaryIndexes,
+  throughput,
+} from "./sim-tf-map-dynamodb-keys.js";
 
 /** A table, with the key schema rebuilt from its key attribute names. */
 export function dynamodbTable(
@@ -22,6 +27,7 @@ export function dynamodbTable(
 ): TerraformMappedResource {
   const values = context.resource.values;
   const ttl = block(context, "ttl");
+  const provisioned = field(values, "billing_mode") === "PROVISIONED";
 
   return {
     Type: "AWS::DynamoDB::Table",
@@ -33,21 +39,13 @@ export function dynamodbTable(
           field(values, "hash_key"),
           field(values, "range_key"),
         ),
-        GlobalSecondaryIndexes: secondaryIndexes(context),
+        GlobalSecondaryIndexes: secondaryIndexes(context, provisioned),
+        ProvisionedThroughput: provisioned ? throughput(values) : undefined,
         TimeToLiveSpecification: timeToLive(ttl),
         Tags: tags(context),
       }),
     },
   };
-}
-
-function attributeDefinitions(
-  context: TerraformMappingContext,
-): SimCfnTemplateValue {
-  return blocks(context, "attribute").map((entry) => ({
-    AttributeName: field(entry, "name") as string,
-    AttributeType: field(entry, "type") as string,
-  }));
 }
 
 function timeToLive(
@@ -59,58 +57,4 @@ function timeToLive(
         AttributeName: field(ttl, "attribute_name") as string,
         Enabled: field(ttl, "enabled") === true,
       };
-}
-
-/**
- * A key schema, from the hash and range key attribute names.
- *
- * An optional string inside a nested block arrives as an empty string rather
- * than as null, which is how a top-level optional attribute arrives. A range
- * key that was never declared reads as `""`, and taking it at face value
- * declares an index with a nameless RANGE element.
- */
-export function keySchema(
-  hashKey: unknown,
-  rangeKey: unknown,
-): SimCfnTemplateValue | undefined {
-  if (!named(hashKey)) {
-    return undefined;
-  }
-
-  const range = named(rangeKey)
-    ? [{ AttributeName: rangeKey, KeyType: "RANGE" }]
-    : [];
-
-  return [{ AttributeName: hashKey, KeyType: "HASH" }, ...range];
-}
-
-function named(value: unknown): value is string {
-  return typeof value === "string" && value.length > 0;
-}
-
-function secondaryIndexes(
-  context: TerraformMappingContext,
-): SimCfnTemplateValue | undefined {
-  const indexes = blocks(context, "global_secondary_index");
-
-  if (indexes.length === 0) {
-    return undefined;
-  }
-
-  return indexes.map((index) => ({
-    IndexName: field(index, "name") as string,
-    KeySchema:
-      keySchema(field(index, "hash_key"), field(index, "range_key")) ?? [],
-    Projection: properties({
-      ProjectionType: field(index, "projection_type") as string,
-      NonKeyAttributes: nonEmptyList(field(index, "non_key_attributes")),
-    }),
-  }));
-}
-
-/** A Terraform list attribute, where the provider left anything in it. */
-function nonEmptyList(value: unknown): SimCfnTemplateValue | undefined {
-  return Array.isArray(value) && value.length > 0
-    ? (value as SimCfnTemplateValue)
-    : undefined;
 }

--- a/src/terraform/map/sim-tf-map-ecr.ts
+++ b/src/terraform/map/sim-tf-map-ecr.ts
@@ -1,0 +1,46 @@
+/*
+ * Reading a plan means reading records whose keys come from the document
+ * rather than from this code, so the object-injection rule fires on every
+ * lookup. The records are parsed JSON with no prototype of their own.
+ */
+// oxlint-disable security/detect-object-injection
+import {
+  block,
+  field,
+  properties,
+  renamed,
+  tags,
+  type TerraformMappingContext,
+} from "../sim-tf-attributes.js";
+import type { TerraformMappedResource } from "../sim-tf-mapping.type.js";
+
+/**
+ * A repository.
+ *
+ * The name is the only property simulated ECR acts on. The rest describe image
+ * content, and nothing here pulls or inspects an image, so they are carried
+ * across and recorded against the Resource rather than left off. A repository
+ * scanning on push says on its Resource that no image is ever scanned.
+ */
+export function ecrRepository(
+  context: TerraformMappingContext,
+): TerraformMappedResource {
+  const scanning = block(context, "image_scanning_configuration");
+
+  return {
+    Type: "AWS::ECR::Repository",
+    Properties: {
+      ...renamed(context, {
+        RepositoryName: "name",
+        ImageTagMutability: "image_tag_mutability",
+      }),
+      ...properties({
+        ImageScanningConfiguration:
+          scanning === undefined
+            ? undefined
+            : { ScanOnPush: field(scanning, "scan_on_push") === true },
+        Tags: tags(context),
+      }),
+    },
+  };
+}

--- a/src/terraform/map/sim-tf-map-events.ts
+++ b/src/terraform/map/sim-tf-map-events.ts
@@ -1,0 +1,195 @@
+/*
+ * Reading a plan means reading records whose keys come from the document
+ * rather than from this code, so the object-injection rule fires on every
+ * lookup. The records are parsed JSON with no prototype of their own.
+ */
+// oxlint-disable security/detect-object-injection
+import { isRecord } from "../../util/type-guard/record.js";
+import type { SimCfnTemplateValue } from "../../service/cloudformation/template/value/sim-cfn-template-value.js";
+import {
+  attribute,
+  properties,
+  renamed,
+  tags,
+  type TerraformMappingContext,
+} from "../sim-tf-attributes.js";
+import type {
+  TerraformMappedResource,
+  TerraformResourceFold,
+} from "../sim-tf-mapping.type.js";
+
+/**
+ * A rule.
+ *
+ * Tags are left off. Simulated EventBridge refuses a `Tags` property outright,
+ * because a rule's tags never reach PutRule and a tagged rule would otherwise
+ * deploy and lose them without a word, so a rule carrying tags fails the Stack
+ * around it rather than only itself.
+ *
+ * Terraform carries the enabled state twice. `state` is the current spelling
+ * and `is_enabled` is the boolean the provider deprecated in favour of it.
+ */
+export function eventRule(
+  context: TerraformMappingContext,
+): TerraformMappedResource {
+  const state = ruleState(context);
+
+  return {
+    Type: "AWS::Events::Rule",
+    Properties: {
+      ...renamed(context, {
+        Name: "name",
+        Description: "description",
+        ScheduleExpression: "schedule_expression",
+        EventBusName: "event_bus_name",
+      }),
+      ...properties({ State: state, EventPattern: eventPattern(context) }),
+    },
+    lost: [
+      ...(tags(context) === undefined ? [] : ["tags"]),
+      ...(state === undefined && attribute(context, "state") !== undefined
+        ? ["state"]
+        : []),
+    ],
+  };
+}
+
+/**
+ * Whether the rule matches events.
+ *
+ * `ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS` is left off and recorded.
+ * Simulated EventBridge refuses it, because nothing here delivers CloudTrail
+ * management events, and a rule in that state behaves exactly like an enabled
+ * one. Enabled is what it gets.
+ *
+ * `is_enabled` is read where the configuration used the older spelling. A rule
+ * deployed enabled that the plan disabled would fire on a schedule the
+ * configuration turned off.
+ */
+function ruleState(
+  context: TerraformMappingContext,
+): SimCfnTemplateValue | undefined {
+  const state = attribute(context, "state");
+
+  if (state === "ENABLED" || state === "DISABLED") {
+    return state;
+  }
+
+  if (state === undefined && attribute(context, "is_enabled") === false) {
+    return "DISABLED";
+  }
+
+  return undefined;
+}
+
+/**
+ * The pattern the rule matches events against, which Terraform carries as a
+ * JSON string and CloudFormation as an object.
+ *
+ * Simulated EventBridge takes either, so a pattern the plan resolved goes
+ * across as it stands. One built around a resource of the same plan is unknown
+ * whole, and there is no pattern to send.
+ */
+function eventPattern(
+  context: TerraformMappingContext,
+): SimCfnTemplateValue | undefined {
+  const pattern = attribute(context, "event_pattern");
+
+  return typeof pattern === "string" ? pattern : undefined;
+}
+
+/**
+ * The target resources, which Terraform declares apart from the rule they
+ * belong to.
+ *
+ * CloudFormation holds them as one `Targets` list on the rule, so each fold
+ * adds an entry to what is already there rather than replacing it. A rule with
+ * three targets is three Terraform resources and one `AWS::Events::Rule`.
+ */
+export const eventTargetFolds: ReadonlyMap<string, TerraformResourceFold> =
+  new Map([
+    [
+      "aws_cloudwatch_event_target",
+      { parentAttribute: "rule", properties: target, lost: targetLost },
+    ],
+  ]);
+
+/**
+ * The ways a target can be configured that this fold does not carry.
+ *
+ * Simulated EventBridge refuses each of them by name on a Resource, so a
+ * target declaring one is added without it and the attribute recorded. Every
+ * one changes what the target receives or what happens when a delivery fails,
+ * which is the kind of difference a test would otherwise read as working.
+ */
+const unsimulatedTargetAttributes = [
+  "input_path",
+  "input_transformer",
+  "dead_letter_config",
+  "retry_policy",
+  "role_arn",
+];
+
+/**
+ * One entry of the rule's `Targets` list.
+ *
+ * A target whose ARN the plan could not resolve contributes nothing rather
+ * than an entry with no ARN, which is one simulated EventBridge refuses along
+ * with the whole rule. `target_id` is optional in Terraform and generated at
+ * apply time when it is left out, so a target with no id of its own is named
+ * after the resource declaring it, which is the identifier the plan does carry.
+ */
+function target(
+  context: TerraformMappingContext,
+  parent: Record<string, SimCfnTemplateValue> = {},
+): Record<string, SimCfnTemplateValue> {
+  const arn = attribute(context, "arn");
+
+  if (arn === undefined) {
+    return {};
+  }
+
+  const entry = properties({
+    Id: attribute(context, "target_id") ?? context.resource.name,
+    Arn: arn,
+    Input: attribute(context, "input"),
+  });
+
+  return { Targets: [...existingTargets(parent), entry] };
+}
+
+/** The attributes of one target this fold could not carry across. */
+function targetLost(context: TerraformMappingContext): readonly string[] {
+  const configured = unsimulatedTargetAttributes.filter((name) =>
+    configuredValue(context.resource.values[name]),
+  );
+
+  return attribute(context, "arn") === undefined
+    ? ["arn", ...configured]
+    : configured;
+}
+
+/**
+ * Whether an attribute holds anything.
+ *
+ * The provider writes an absent nested block as an empty list and an absent
+ * top-level optional as null, so both spellings of "not configured" are here.
+ */
+function configuredValue(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+
+  return value !== null && value !== undefined;
+}
+
+/** The targets an earlier fold on the same rule already added. */
+function existingTargets(
+  parent: Record<string, SimCfnTemplateValue>,
+): readonly SimCfnTemplateValue[] {
+  const targets = parent["Targets"];
+
+  return Array.isArray(targets)
+    ? targets.filter((entry) => isRecord(entry))
+    : [];
+}

--- a/src/terraform/map/sim-tf-map-kms.ts
+++ b/src/terraform/map/sim-tf-map-kms.ts
@@ -1,0 +1,102 @@
+/*
+ * Reading a plan means reading records whose keys come from the document
+ * rather than from this code, so the object-injection rule fires on every
+ * lookup. The records are parsed JSON with no prototype of their own.
+ */
+// oxlint-disable security/detect-object-injection
+import type { SimCfnTemplateValue } from "../../service/cloudformation/template/value/sim-cfn-template-value.js";
+import {
+  field,
+  properties,
+  renamed,
+  tags,
+  type TerraformMappingContext,
+} from "../sim-tf-attributes.js";
+import type { TerraformMappedResource } from "../sim-tf-mapping.type.js";
+
+/**
+ * A key.
+ *
+ * Terraform spells the key spec `customer_master_key_spec`, which is the name
+ * the KMS API used before AWS renamed it, and CloudFormation carries the new
+ * one. `is_enabled` is CloudFormation's `Enabled`.
+ *
+ * Rotation and tags go across as they were written. Simulated KMS records both
+ * as properties a key is created without, rather than refusing them, so a key
+ * asking for rotation deploys and says on the Resource that its material never
+ * changes.
+ */
+export function kmsKey(
+  context: TerraformMappingContext,
+): TerraformMappedResource {
+  const policy = keyPolicy(context);
+
+  return {
+    Type: "AWS::KMS::Key",
+    Properties: {
+      ...renamed(context, {
+        Description: "description",
+        Enabled: "is_enabled",
+        KeySpec: "customer_master_key_spec",
+        KeyUsage: "key_usage",
+        EnableKeyRotation: "enable_key_rotation",
+      }),
+      ...properties({ KeyPolicy: policy, Tags: tags(context) }),
+    },
+    lost: policy === undefined && declaredPolicy(context) ? ["policy"] : [],
+  };
+}
+
+/**
+ * The key policy, which Terraform carries as a JSON string.
+ *
+ * A policy written with `jsonencode` around an ARN of the same plan is unknown
+ * in its entirety, and its statements are gone with it. The reference behind it
+ * resolves to the ARN rather than to a document, so there is nothing to send
+ * and the attribute is recorded instead. A key created without a policy gets
+ * the default root delegation KMS applies, which is what a key declaring no
+ * policy gets anyway, so the key still exists and still encrypts.
+ */
+function keyPolicy(
+  context: TerraformMappingContext,
+): SimCfnTemplateValue | undefined {
+  const policy = field(context.resource.values, "policy");
+
+  return typeof policy === "string" ? policy : undefined;
+}
+
+/**
+ * Whether the configuration wrote a policy the plan could not resolve.
+ *
+ * A key declaring no policy at all is unknown in the plan too, because KMS is
+ * the one that writes the default. That one is not lost: a key created here
+ * without a policy gets the same root delegation, so only a policy the
+ * configuration stated and the plan could not build is worth recording.
+ */
+function declaredPolicy(context: TerraformMappingContext): boolean {
+  return (
+    context.resource.unknown["policy"] === true &&
+    context.resource.expressions["policy"] !== undefined
+  );
+}
+
+/**
+ * An alias.
+ *
+ * Both properties are required, as they are on real CloudFormation. An alias
+ * with no name names nothing and one with no target points at nothing, so an
+ * alias whose key the template does not declare is left out rather than
+ * deployed into a failure that would take the Stack with it.
+ */
+export function kmsAlias(
+  context: TerraformMappingContext,
+): TerraformMappedResource {
+  return {
+    Type: "AWS::KMS::Alias",
+    Properties: renamed(context, {
+      AliasName: "name",
+      TargetKeyId: "target_key_id",
+    }),
+    requires: ["AliasName", "TargetKeyId"],
+  };
+}

--- a/src/terraform/map/sim-tf-map-monitoring.iso.test.ts
+++ b/src/terraform/map/sim-tf-map-monitoring.iso.test.ts
@@ -1,0 +1,340 @@
+import { describe, it } from "vitest";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertObjectEquals,
+  assertUndefined,
+} from "@kensio/smartass";
+import { assertDefined } from "../../util/type-guard/defined.js";
+import type { SimCfnTemplateValue } from "../../service/cloudformation/template/value/sim-cfn-template-value.js";
+import { terraformPlanResourceFactory } from "../../../test/terraform/plan/terraform-plan.factory.js";
+import { terraformMappingContext as contextFor } from "../../../test/terraform/plan/terraform-mapping-context.js";
+import type { TerraformMappingContext } from "../sim-tf-attributes.js";
+import { terraformResourceFolds } from "../sim-tf-registry.js";
+import { metricAlarm } from "./sim-tf-map-cloudwatch.js";
+import { eventRule } from "./sim-tf-map-events.js";
+
+/** The properties one fold contributes to the resource it configures. */
+function foldedProperties(
+  type: string,
+  context: TerraformMappingContext,
+  parent: Record<string, SimCfnTemplateValue> = {},
+): Record<string, SimCfnTemplateValue> {
+  const fold = terraformResourceFolds.get(type);
+
+  assertDefined(fold, `A fold for ${type}`);
+
+  return fold.properties(context, parent);
+}
+
+/** An alarm watching a queue, with everything CloudWatch requires stated. */
+function alarmValues(values: Record<string, unknown>): Record<string, unknown> {
+  return {
+    alarm_name: "orders-dlq-depth",
+    namespace: "AWS/SQS",
+    metric_name: "ApproximateNumberOfMessagesVisible",
+    statistic: "Maximum",
+    period: 300,
+    evaluation_periods: 1,
+    threshold: 0,
+    comparison_operator: "GreaterThanThreshold",
+    ...values,
+  };
+}
+
+describe("mapping a CloudWatch metric alarm", () => {
+  it("rebuilds the dimensions as the list CloudFormation holds", () => {
+    // Given an alarm whose dimensions Terraform states as a map
+    const context = contextFor({
+      resources: [
+        terraformPlanResourceFactory.make({
+          type: "aws_cloudwatch_metric_alarm",
+          name: "dlq_depth",
+          values: alarmValues({
+            dimensions: { QueueName: "orders-processing-dlq" },
+          }),
+        }),
+      ],
+    });
+
+    // When it is mapped
+    // Then each entry is a name and value pair
+    assertObjectEquals(metricAlarm(context).Properties["Dimensions"], [
+      { Name: "QueueName", Value: "orders-processing-dlq" },
+    ]);
+  });
+
+  it("drops a dimension whose value the plan could not resolve", () => {
+    // Given an alarm one of whose dimension values stayed unknown. The
+    // references survive for the map rather than per key, so which dimension a
+    // resolved value belongs to is not in the plan
+    const context = contextFor({
+      resources: [
+        terraformPlanResourceFactory.make({
+          type: "aws_cloudwatch_metric_alarm",
+          name: "dlq_depth",
+          values: alarmValues({
+            dimensions: { QueueName: undefined, Stage: "test" },
+          }),
+        }),
+      ],
+    });
+    const mapped = metricAlarm(context);
+
+    // When it is mapped
+    // Then the dimension with no value is left out, since PutMetricAlarm
+    // refuses one, and the map is recorded
+    assertObjectEquals(mapped.Properties["Dimensions"], [
+      { Name: "Stage", Value: "test" },
+    ]);
+    assertArrayEquals(mapped.lost ?? [], ["dimensions"]);
+  });
+
+  it("resolves the topic an alarm notifies into a list of one", () => {
+    // Given an alarm whose actions name a topic of the same plan, so the
+    // whole list arrives unknown
+    const context = contextFor({
+      resources: [
+        terraformPlanResourceFactory.make({
+          type: "aws_cloudwatch_metric_alarm",
+          name: "dlq_depth",
+          values: alarmValues({}),
+          unknown: { alarm_actions: true },
+          references: {
+            alarm_actions: ["aws_sns_topic.alerts.arn", "aws_sns_topic.alerts"],
+          },
+        }),
+        terraformPlanResourceFactory.make({
+          type: "aws_sns_topic",
+          name: "alerts",
+          values: { name: "orders-alerts" },
+        }),
+      ],
+    });
+
+    // When it is mapped
+    // Then the actions are a list holding what the reference resolves to.
+    // Terraform lists the attribute form and the bare resource form of one
+    // reference, and both give the same topic ARN, so the alarm notifies one
+    // topic rather than the same topic twice
+    assertObjectEquals(metricAlarm(context).Properties["AlarmActions"], [
+      { Ref: "AwsSnsTopicAlerts" },
+    ]);
+  });
+
+  it("requires what PutMetricAlarm requires", () => {
+    // Given an alarm built out of metric_query blocks, which carries no
+    // namespace, metric name or statistic of its own
+    const context = contextFor({
+      resources: [
+        terraformPlanResourceFactory.make({
+          type: "aws_cloudwatch_metric_alarm",
+          name: "composite",
+          values: {
+            alarm_name: "orders-composite",
+            evaluation_periods: 1,
+            threshold: 1,
+            comparison_operator: "GreaterThanThreshold",
+          },
+        }),
+      ],
+    });
+    const mapped = metricAlarm(context);
+
+    // When it is mapped
+    // Then the properties it could not fill are named, so settling leaves the
+    // alarm out rather than failing the Stack around it
+    assertUndefined(mapped.Properties["Namespace"]);
+    assertArrayEquals(mapped.requires ?? [], [
+      "Namespace",
+      "MetricName",
+      "Statistic",
+      "Period",
+      "EvaluationPeriods",
+      "Threshold",
+      "ComparisonOperator",
+    ]);
+  });
+});
+
+describe("mapping an EventBridge rule", () => {
+  it("records the tags simulated EventBridge refuses", () => {
+    // Given a tagged rule. Rule tags never reach PutRule, so a tagged rule
+    // would otherwise deploy and lose them without a word, and simulated
+    // EventBridge refuses the property rather than let that happen
+    const context = contextFor({
+      resources: [
+        terraformPlanResourceFactory.make({
+          type: "aws_cloudwatch_event_rule",
+          name: "nightly",
+          values: {
+            name: "orders-nightly",
+            schedule_expression: "cron(0 2 * * ? *)",
+            tags_all: { Application: "orders" },
+          },
+        }),
+      ],
+    });
+    const mapped = eventRule(context);
+
+    // When it is mapped
+    // Then no Tags property is sent and the attribute is recorded
+    assertUndefined(mapped.Properties["Tags"]);
+    assertArrayEquals(mapped.lost ?? [], ["tags"]);
+  });
+
+  it("records a rule state simulated EventBridge refuses", () => {
+    // Given a rule matching CloudTrail management events, which nothing here
+    // delivers
+    const context = contextFor({
+      resources: [
+        terraformPlanResourceFactory.make({
+          type: "aws_cloudwatch_event_rule",
+          name: "audit",
+          values: {
+            name: "orders-audit",
+            state: "ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS",
+          },
+        }),
+      ],
+    });
+    const mapped = eventRule(context);
+
+    // When it is mapped
+    // Then no State is sent and the attribute is recorded. The rule is enabled,
+    // which is what simulated EventBridge says the state amounts to here
+    assertUndefined(mapped.Properties["State"]);
+    assertArrayEquals(mapped.lost ?? [], ["state"]);
+  });
+
+  it("disables a rule the configuration turned off by the older attribute", () => {
+    // Given a rule using `is_enabled`, which the provider deprecated in favour
+    // of `state`
+    const context = contextFor({
+      resources: [
+        terraformPlanResourceFactory.make({
+          type: "aws_cloudwatch_event_rule",
+          name: "nightly",
+          values: {
+            name: "orders-nightly",
+            schedule_expression: "cron(0 2 * * ? *)",
+            is_enabled: false,
+          },
+        }),
+      ],
+    });
+
+    // When it is mapped
+    // Then the rule is disabled, rather than firing on a schedule the
+    // configuration turned off
+    assertIdentical(eventRule(context).Properties["State"], "DISABLED");
+  });
+
+  it("adds each target to the list the rule already carries", () => {
+    // Given two targets of one rule, which Terraform declares as two
+    // resources and CloudFormation holds as one Targets list
+    const context = contextFor({
+      resources: [
+        terraformPlanResourceFactory.make({
+          type: "aws_cloudwatch_event_target",
+          name: "reporter",
+          values: { rule: "orders-nightly", target_id: "reporter", arn: "b" },
+        }),
+      ],
+    });
+
+    // When the second is folded into a rule the first already contributed to
+    // Then it is added rather than replacing what is there
+    assertObjectEquals(
+      foldedProperties("aws_cloudwatch_event_target", context, {
+        Targets: [{ Id: "processor", Arn: "a" }],
+      }),
+      {
+        Targets: [
+          { Id: "processor", Arn: "a" },
+          { Id: "reporter", Arn: "b" },
+        ],
+      },
+    );
+  });
+
+  it("names a target after the resource declaring it when it has no id", () => {
+    // Given a target with no target_id, which Terraform generates at apply
+    // time and the plan therefore leaves unknown
+    const context = contextFor({
+      resources: [
+        terraformPlanResourceFactory.make({
+          type: "aws_cloudwatch_event_target",
+          name: "nightly_processor",
+          values: { rule: "orders-nightly", arn: "a" },
+          unknown: { target_id: true },
+        }),
+      ],
+    });
+
+    // When it is folded
+    // Then it is named after the resource, since simulated EventBridge refuses
+    // a target with no Id and the resource name is the identifier the plan
+    // does carry
+    assertObjectEquals(
+      foldedProperties("aws_cloudwatch_event_target", context),
+      { Targets: [{ Id: "nightly_processor", Arn: "a" }] },
+    );
+  });
+
+  it("contributes no target whose ARN the plan could not resolve", () => {
+    // Given a target naming a function the template does not declare
+    const context = contextFor({
+      resources: [
+        terraformPlanResourceFactory.make({
+          type: "aws_cloudwatch_event_target",
+          name: "nightly_processor",
+          values: { rule: "orders-nightly", target_id: "processor" },
+          unknown: { arn: true },
+          references: { arn: ["aws_lambda_function.processor.arn"] },
+        }),
+      ],
+    });
+    const fold = terraformResourceFolds.get("aws_cloudwatch_event_target");
+
+    assertDefined(fold, "A fold for aws_cloudwatch_event_target");
+
+    // When it is folded
+    // Then nothing is added, since a target with no Arn is one simulated
+    // EventBridge refuses along with the rule holding it, and the attribute is
+    // recorded
+    assertObjectEquals(fold.properties(context, {}), {});
+    assertArrayEquals(fold.lost?.(context) ?? [], ["arn"]);
+  });
+
+  it("records the target settings simulated EventBridge does not act on", () => {
+    // Given a target transforming the event before it is delivered
+    const context = contextFor({
+      resources: [
+        terraformPlanResourceFactory.make({
+          type: "aws_cloudwatch_event_target",
+          name: "nightly_processor",
+          values: {
+            rule: "orders-nightly",
+            target_id: "processor",
+            arn: "a",
+            input_path: "$.detail",
+            input_transformer: [],
+            dead_letter_config: [],
+            retry_policy: [],
+            role_arn: null,
+          },
+        }),
+      ],
+    });
+    const fold = terraformResourceFolds.get("aws_cloudwatch_event_target");
+
+    assertDefined(fold, "A fold for aws_cloudwatch_event_target");
+
+    // When it is folded
+    // Then the target is added without it and the attribute recorded, since a
+    // target receiving the whole event where the plan asked for one field of
+    // it is the kind of difference a test reads as working
+    assertArrayEquals(fold.lost?.(context) ?? [], ["input_path"]);
+  });
+});

--- a/src/terraform/map/sim-tf-map-s3-lifecycle.ts
+++ b/src/terraform/map/sim-tf-map-s3-lifecycle.ts
@@ -1,0 +1,132 @@
+/*
+ * The bucket lifecycle configuration, which the provider declares as a
+ * resource of its own and CloudFormation carries on the bucket.
+ *
+ * Simulated S3 expires and transitions nothing, and records the whole
+ * `LifecycleConfiguration` property against the Resource as one it does not act
+ * on. The rules are carried across so that record names what the bucket was
+ * asked for, rather than the resource being skipped and the configuration
+ * disappearing from the report.
+ *
+ * Reading a plan means reading records whose keys come from the document
+ * rather than from this code, so the object-injection rule fires on every
+ * lookup. The records are parsed JSON with no prototype of their own.
+ */
+// oxlint-disable security/detect-object-injection
+import { isRecord } from "../../util/type-guard/record.js";
+import type { SimCfnTemplateValue } from "../../service/cloudformation/template/value/sim-cfn-template-value.js";
+import {
+  blocks,
+  field,
+  properties,
+  type TerraformMappingContext,
+} from "../sim-tf-attributes.js";
+import type { TerraformResourceFold } from "../sim-tf-mapping.type.js";
+
+/** The resource that configures a bucket's lifecycle rules. */
+export const s3LifecycleFolds: ReadonlyMap<string, TerraformResourceFold> =
+  new Map([
+    [
+      "aws_s3_bucket_lifecycle_configuration",
+      { parentAttribute: "bucket", properties: bucketLifecycle },
+    ],
+  ]);
+
+/** The lifecycle rules a bucket is deployed with. */
+function bucketLifecycle(
+  context: TerraformMappingContext,
+): Record<string, SimCfnTemplateValue> {
+  const rules = blocks(context, "rule").map((rule) => lifecycleRule(rule));
+
+  return rules.length === 0 ? {} : { LifecycleConfiguration: { Rules: rules } };
+}
+
+function lifecycleRule(rule: Record<string, unknown>): SimCfnTemplateValue {
+  const expiration = firstBlock(rule, "expiration");
+  const noncurrent = firstBlock(rule, "noncurrent_version_expiration");
+  const abortAfter = number(
+    firstBlock(rule, "abort_incomplete_multipart_upload"),
+    "days_after_initiation",
+  );
+
+  return properties({
+    Id: text(rule, "id"),
+    Status: text(rule, "status"),
+    Prefix: text(rule, "prefix") ?? filterPrefix(rule),
+    ExpirationInDays: number(expiration, "days"),
+    ExpirationDate: text(expiration, "date"),
+    NoncurrentVersionExpirationInDays: number(noncurrent, "noncurrent_days"),
+    AbortIncompleteMultipartUpload:
+      abortAfter === undefined
+        ? undefined
+        : { DaysAfterInitiation: abortAfter },
+    Transitions: transitions(rule),
+  });
+}
+
+/**
+ * The prefix a rule matches on, where it was written as a filter.
+ *
+ * The provider takes a prefix either as the rule's own deprecated attribute or
+ * inside a `filter` block, and CloudFormation has the one `Prefix`.
+ */
+function filterPrefix(rule: Record<string, unknown>): string | undefined {
+  return text(firstBlock(rule, "filter"), "prefix");
+}
+
+/** The storage class changes a rule asks for, as CloudFormation lists them. */
+function transitions(
+  rule: Record<string, unknown>,
+): SimCfnTemplateValue | undefined {
+  const declared = field(rule, "transition");
+  const entries = (Array.isArray(declared) ? declared : [])
+    .filter((entry) => isRecord(entry))
+    .map((entry) =>
+      properties({
+        StorageClass: text(entry, "storage_class"),
+        TransitionInDays: number(entry, "days"),
+        TransitionDate: text(entry, "date"),
+      }),
+    );
+
+  return entries.length === 0 ? undefined : entries;
+}
+
+/**
+ * One entry of a nested block, which the plan represents as a list even where
+ * the schema allows only one.
+ */
+function firstBlock(
+  record: Record<string, unknown> | undefined,
+  key: string,
+): Record<string, unknown> | undefined {
+  const declared = record === undefined ? undefined : field(record, key);
+  const [first] = Array.isArray(declared) ? (declared as unknown[]) : [];
+
+  return isRecord(first) ? first : undefined;
+}
+
+/**
+ * A string field of a block, where the provider wrote one.
+ *
+ * An absent optional string inside a nested block arrives as an empty string
+ * rather than as null, and a rule carrying an empty `Prefix` matches every
+ * object rather than none.
+ */
+function text(
+  record: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const value = record === undefined ? undefined : field(record, key);
+
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function number(
+  record: Record<string, unknown> | undefined,
+  key: string,
+): number | undefined {
+  const value = record === undefined ? undefined : field(record, key);
+
+  return typeof value === "number" ? value : undefined;
+}

--- a/src/terraform/map/sim-tf-map-s3-notification-destinations.ts
+++ b/src/terraform/map/sim-tf-map-s3-notification-destinations.ts
@@ -1,0 +1,71 @@
+/*
+ * The three places a bucket can send an event, and what each of them is called
+ * in the request a notification configuration becomes.
+ *
+ * Reading a plan means reading records whose keys come from the document
+ * rather than from this code, so the object-injection rule fires on every
+ * lookup. The records are parsed JSON with no prototype of their own.
+ */
+// oxlint-disable security/detect-object-injection
+import type { SimCfnTemplateValue } from "../../service/cloudformation/template/value/sim-cfn-template-value.js";
+import {
+  blocks,
+  field,
+  properties,
+  type TerraformMappingContext,
+} from "../sim-tf-attributes.js";
+import { blockAttribute } from "../sim-tf-nested-attributes.js";
+import {
+  notificationDestinations,
+  type NotificationDestination,
+} from "./sim-tf-map-s3-notification.js";
+import {
+  notificationKeyFilter,
+  notificationText,
+} from "./sim-tf-map-s3-notification-filter.js";
+
+/** Every destination the bucket sends to, grouped by the service it names. */
+export function notificationConfiguration(
+  context: TerraformMappingContext,
+): SimCfnTemplateValue | undefined {
+  const configuration = properties(
+    Object.fromEntries(
+      notificationDestinations.map((destination) => [
+        destination.property,
+        entries(context, destination),
+      ]),
+    ),
+  );
+
+  return Object.keys(configuration).length === 0 ? undefined : configuration;
+}
+
+/** One destination's entries, each naming the events it wants. */
+function entries(
+  context: TerraformMappingContext,
+  destination: NotificationDestination,
+): SimCfnTemplateValue | undefined {
+  const declared = blocks(context, destination.block).flatMap(
+    (entry, index) => {
+      const arn = blockAttribute(
+        context,
+        destination.block,
+        index,
+        destination.destination,
+      );
+
+      return arn === undefined
+        ? []
+        : [
+            properties({
+              Id: notificationText(entry, "id"),
+              [destination.arn]: arn,
+              Events: field(entry, "events") as SimCfnTemplateValue,
+              Filter: notificationKeyFilter(entry),
+            }),
+          ];
+    },
+  );
+
+  return declared.length === 0 ? undefined : declared;
+}

--- a/src/terraform/map/sim-tf-map-s3-notification-filter.ts
+++ b/src/terraform/map/sim-tf-map-s3-notification-filter.ts
@@ -1,0 +1,40 @@
+/*
+ * The object key filter one notification destination is narrowed by.
+ *
+ * Reading a plan means reading records whose keys come from the document
+ * rather than from this code, so the object-injection rule fires on every
+ * lookup. The records are parsed JSON with no prototype of their own.
+ */
+// oxlint-disable security/detect-object-injection
+import type { SimCfnTemplateValue } from "../../service/cloudformation/template/value/sim-cfn-template-value.js";
+import { field } from "../sim-tf-attributes.js";
+
+/**
+ * The object key filter, from the prefix and suffix Terraform states apart.
+ *
+ * An absent optional string inside a nested block arrives as an empty string
+ * rather than as null, and a rule matching the empty prefix matches every
+ * object, which is what a filter is written to stop.
+ */
+export function notificationKeyFilter(
+  entry: Record<string, unknown>,
+): SimCfnTemplateValue | undefined {
+  const rules = [
+    { Name: "prefix", Value: notificationText(entry, "filter_prefix") },
+    { Name: "suffix", Value: notificationText(entry, "filter_suffix") },
+  ].filter(
+    (rule): rule is { Name: string; Value: string } => rule.Value !== undefined,
+  );
+
+  return rules.length === 0 ? undefined : { Key: { FilterRules: rules } };
+}
+
+/** A string field of a block, where the provider wrote anything in it. */
+export function notificationText(
+  entry: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const value = field(entry, key);
+
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/src/terraform/map/sim-tf-map-s3-notification.ts
+++ b/src/terraform/map/sim-tf-map-s3-notification.ts
@@ -1,0 +1,109 @@
+/*
+ * Where a bucket sends its events, which the provider declares as a resource
+ * of its own.
+ */
+import {
+  attribute,
+  blocks,
+  field,
+  properties,
+  type TerraformMappingContext,
+} from "../sim-tf-attributes.js";
+import type { TerraformMappedResource } from "../sim-tf-mapping.type.js";
+import { blockAttribute } from "../sim-tf-nested-attributes.js";
+import { notificationConfiguration } from "./sim-tf-map-s3-notification-destinations.js";
+
+/**
+ * The three destination blocks, and what the request calls each of them.
+ *
+ * `destination` is the Terraform attribute holding the ARN, and `arn` is the
+ * key it is written under, which repeats the service's name on all three.
+ */
+export const notificationDestinations = [
+  {
+    block: "lambda_function",
+    destination: "lambda_function_arn",
+    property: "LambdaFunctionConfigurations",
+    arn: "LambdaFunctionArn",
+  },
+  {
+    block: "queue",
+    destination: "queue_arn",
+    property: "QueueConfigurations",
+    arn: "QueueArn",
+  },
+  {
+    block: "topic",
+    destination: "topic_arn",
+    property: "TopicConfigurations",
+    arn: "TopicArn",
+  },
+] as const;
+
+export interface NotificationDestination {
+  readonly block: string;
+  readonly destination: string;
+  readonly property: string;
+  readonly arn: string;
+}
+
+/**
+ * The notification configuration a bucket is deployed with.
+ *
+ * This is a Resource of its own rather than a bucket property, for the reason
+ * CDK gives it one as well. A function's `AWS::Lambda::Permission` names the
+ * bucket whose events it admits, so a bucket naming the function back is a
+ * circular dependency CloudFormation refuses. Terraform declares the same three
+ * resources and has no cycle, because the notification sits between them, and
+ * `Custom::S3BucketNotifications` is that resource here. Simulated
+ * CloudFormation applies one with a single
+ * PutBucketNotificationConfiguration call, after everything the plan declared
+ * it to come after.
+ *
+ * The Resource carries the SDK request shape rather than the CloudFormation
+ * one, which is what CDK's own provider function is handed, and it is the
+ * closer of the two to what Terraform writes: a list of events per destination
+ * rather than one configuration per event.
+ */
+export function bucketNotification(
+  context: TerraformMappingContext,
+): TerraformMappedResource {
+  return {
+    Type: "Custom::S3BucketNotifications",
+    Properties: properties({
+      BucketName: attribute(context, "bucket"),
+      NotificationConfiguration: notificationConfiguration(context),
+    }),
+    requires: ["BucketName", "NotificationConfiguration"],
+    lost: notificationLost(context),
+  };
+}
+
+/**
+ * What the notification configuration could not carry across.
+ *
+ * A destination whose ARN the plan left unresolvable is dropped, since a
+ * configuration naming nothing would raise its events at nothing. EventBridge
+ * delivery is dropped too: simulated S3 refuses an `EventBridgeConfiguration`
+ * by name rather than accepting one it would never deliver through.
+ */
+function notificationLost(context: TerraformMappingContext): readonly string[] {
+  const dropped = notificationDestinations.filter((destination) =>
+    blocks(context, destination.block).some(
+      (_, index) =>
+        blockAttribute(
+          context,
+          destination.block,
+          index,
+          destination.destination,
+        ) === undefined,
+    ),
+  );
+
+  return [
+    ...dropped.map((destination) => destination.block),
+    ...(field(context.resource.values, "eventbridge") === true
+      ? ["eventbridge"]
+      : []),
+  ];
+}

--- a/src/terraform/map/sim-tf-map-security.iso.test.ts
+++ b/src/terraform/map/sim-tf-map-security.iso.test.ts
@@ -1,0 +1,247 @@
+import { describe, it } from "vitest";
+import {
+  assertArrayEquals,
+  assertObjectEquals,
+  assertUndefined,
+} from "@kensio/smartass";
+import { terraformPlanResourceFactory } from "../../../test/terraform/plan/terraform-plan.factory.js";
+import { terraformMappingContext as contextFor } from "../../../test/terraform/plan/terraform-mapping-context.js";
+import { kmsAlias, kmsKey } from "./sim-tf-map-kms.js";
+import { cognitoUserPool } from "./sim-tf-map-cognito.js";
+import { cognitoUserPoolClient } from "./sim-tf-map-cognito-client.js";
+
+describe("mapping a KMS key", () => {
+  it("carries the key spec under the name CloudFormation gives it", () => {
+    // Given a key stating the spec, the usage and whether it is enabled, which
+    // Terraform names differently from CloudFormation in all three places
+    const context = contextFor({
+      resources: [
+        terraformPlanResourceFactory.make({
+          type: "aws_kms_key",
+          name: "app",
+          values: {
+            description: "Application data key",
+            customer_master_key_spec: "SYMMETRIC_DEFAULT",
+            key_usage: "ENCRYPT_DECRYPT",
+            is_enabled: true,
+          },
+        }),
+      ],
+    });
+
+    // When it is mapped
+    // Then each one arrives under the CloudFormation name for it
+    assertObjectEquals(kmsKey(context).Properties, {
+      Description: "Application data key",
+      KeySpec: "SYMMETRIC_DEFAULT",
+      KeyUsage: "ENCRYPT_DECRYPT",
+      Enabled: true,
+    });
+  });
+
+  it("records a key policy the plan could not build", () => {
+    // Given a key whose policy was written with jsonencode around an ARN of
+    // the same plan, so the whole string stayed unknown
+    const context = contextFor({
+      resources: [
+        terraformPlanResourceFactory.make({
+          type: "aws_kms_key",
+          name: "app",
+          values: { description: "Application data key" },
+          unknown: { policy: true },
+          references: { policy: ["aws_iam_role.processor.arn"] },
+        }),
+        terraformPlanResourceFactory.make({
+          type: "aws_iam_role",
+          name: "processor",
+          values: { name: "processor" },
+        }),
+      ],
+    });
+    const mapped = kmsKey(context);
+
+    // When it is mapped
+    // Then no policy is sent, since the reference behind it resolves to an ARN
+    // rather than to a document, and the attribute is recorded
+    assertUndefined(mapped.Properties["KeyPolicy"]);
+    assertArrayEquals(mapped.lost ?? [], ["policy"]);
+  });
+
+  it("says nothing about the policy KMS writes for a key that states none", () => {
+    // Given a key with no policy of its own, which the plan marks unknown
+    // because KMS is the one that writes the default
+    const context = contextFor({
+      resources: [
+        terraformPlanResourceFactory.make({
+          type: "aws_kms_key",
+          name: "app",
+          values: {},
+          unknown: { policy: true },
+        }),
+      ],
+    });
+
+    // When it is mapped
+    // Then nothing is recorded as lost: a key created here without a policy
+    // gets the same root delegation a deployed one gets
+    assertArrayEquals(kmsKey(context).lost ?? [], []);
+  });
+
+  it("requires the key an alias points at", () => {
+    // Given an alias whose target the template does not declare
+    const context = contextFor({
+      resources: [
+        terraformPlanResourceFactory.make({
+          type: "aws_kms_alias",
+          name: "app",
+          values: { name: "alias/orders" },
+          unknown: { target_key_id: true },
+        }),
+      ],
+    });
+    const mapped = kmsAlias(context);
+
+    // When it is mapped
+    // Then the target is named as required, so settling leaves the alias out
+    // rather than deploying one pointing at nothing
+    assertArrayEquals(mapped.requires ?? [], ["AliasName", "TargetKeyId"]);
+    assertUndefined(mapped.Properties["TargetKeyId"]);
+  });
+});
+
+describe("mapping a Cognito user pool", () => {
+  it("nests the password policy where CloudFormation holds it", () => {
+    // Given a pool whose password policy states three of its fields and
+    // leaves the rest as the nulls the provider writes for them
+    const context = contextFor({
+      resources: [
+        terraformPlanResourceFactory.make({
+          type: "aws_cognito_user_pool",
+          name: "users",
+          values: {
+            name: "orders-users",
+            password_policy: [
+              {
+                minimum_length: 12,
+                require_numbers: true,
+                require_uppercase: true,
+                require_lowercase: null,
+                require_symbols: false,
+                password_history_size: null,
+                temporary_password_validity_days: null,
+              },
+            ],
+          },
+        }),
+      ],
+    });
+
+    // When it is mapped
+    // Then the fields the configuration stated are under Policies, and the
+    // nulls are gone rather than sent as values the pool never asked for
+    assertObjectEquals(cognitoUserPool(context).Properties["Policies"], {
+      PasswordPolicy: {
+        MinimumLength: 12,
+        RequireNumbers: true,
+        RequireUppercase: true,
+        RequireSymbols: false,
+      },
+    });
+  });
+
+  it("carries the pool's tags as the map CloudFormation takes", () => {
+    // Given a tagged pool. UserPoolTags is a map, where almost every other
+    // CloudFormation Resource takes a list of key and value pairs
+    const context = contextFor({
+      resources: [
+        terraformPlanResourceFactory.make({
+          type: "aws_cognito_user_pool",
+          name: "users",
+          values: {
+            name: "orders-users",
+            tags_all: { Application: "orders" },
+          },
+        }),
+      ],
+    });
+
+    // When it is mapped
+    // Then the tags arrive as a map
+    assertObjectEquals(cognitoUserPool(context).Properties["UserPoolTags"], {
+      Application: "orders",
+    });
+  });
+
+  it("builds a custom attribute's constraints from the block holding them", () => {
+    // Given a schema entry for a string attribute, where the provider writes
+    // both kinds of constraint block and leaves the other one empty
+    const context = contextFor({
+      resources: [
+        terraformPlanResourceFactory.make({
+          type: "aws_cognito_user_pool",
+          name: "users",
+          values: {
+            name: "orders-users",
+            schema: [
+              {
+                name: "tenantId",
+                attribute_data_type: "String",
+                mutable: true,
+                required: false,
+                string_attribute_constraints: [
+                  { min_length: "1", max_length: "64" },
+                ],
+                number_attribute_constraints: [],
+              },
+            ],
+          },
+        }),
+      ],
+    });
+
+    // When it is mapped
+    // Then only the constraints belonging to the attribute's type are declared
+    assertObjectEquals(cognitoUserPool(context).Properties["Schema"], [
+      {
+        Name: "tenantId",
+        AttributeDataType: "String",
+        Mutable: true,
+        Required: false,
+        StringAttributeConstraints: { MinLength: "1", MaxLength: "64" },
+      },
+    ]);
+  });
+
+  it("requires the pool a client belongs to", () => {
+    // Given a client whose pool is created by the same plan
+    const context = contextFor({
+      resources: [
+        terraformPlanResourceFactory.make({
+          type: "aws_cognito_user_pool_client",
+          name: "web",
+          values: {
+            name: "orders-web",
+            generate_secret: false,
+            explicit_auth_flows: ["ALLOW_USER_SRP_AUTH"],
+          },
+          unknown: { user_pool_id: true },
+          references: { user_pool_id: ["aws_cognito_user_pool.users.id"] },
+        }),
+        terraformPlanResourceFactory.make({
+          type: "aws_cognito_user_pool",
+          name: "users",
+          values: { name: "orders-users" },
+        }),
+      ],
+    });
+    const mapped = cognitoUserPoolClient(context);
+
+    // When it is mapped
+    // Then the pool is a Ref rather than a name the plan never resolved, and
+    // it is named as required so a client without one is left out
+    assertObjectEquals(mapped.Properties["UserPoolId"], {
+      Ref: "AwsCognitoUserPoolUsers",
+    });
+    assertArrayEquals(mapped.requires ?? [], ["UserPoolId"]);
+  });
+});

--- a/src/terraform/map/sim-tf-map-sqs-redrive.ts
+++ b/src/terraform/map/sim-tf-map-sqs-redrive.ts
@@ -1,0 +1,96 @@
+/*
+ * The two ways a queue names its dead-letter arrangement as a resource of its
+ * own, rather than inline on the queue.
+ *
+ * Reading a plan means reading records whose keys come from the document
+ * rather than from this code, so the object-injection rule fires on every
+ * lookup. The records are parsed JSON with no prototype of their own.
+ */
+// oxlint-disable security/detect-object-injection
+import { isRecord } from "../../util/type-guard/record.js";
+import type { SimCfnTemplateValue } from "../../service/cloudformation/template/value/sim-cfn-template-value.js";
+import {
+  field,
+  properties,
+  templateValue,
+  type TerraformMappingContext,
+} from "../sim-tf-attributes.js";
+import type { TerraformResourceFold } from "../sim-tf-mapping.type.js";
+
+/** A policy document read out of the JSON string Terraform carries it in. */
+export interface TerraformJsonDocument {
+  readonly value: SimCfnTemplateValue | undefined;
+  readonly lost: readonly string[];
+}
+
+/**
+ * One attribute Terraform holds as a JSON string and CloudFormation as an
+ * object.
+ *
+ * The string is usually built with `jsonencode` around a queue ARN, so the
+ * whole string is unknown whenever that queue is created by the same plan. What
+ * survives is the reference to the queue, and everything the document said
+ * beside it was inside the string that never got built. A policy carrying a
+ * made-up receive limit would give the queue different retry behaviour from the
+ * one the plan describes, so the document is dropped whole and recorded.
+ */
+export function jsonDocument(
+  context: TerraformMappingContext,
+  key: string,
+): TerraformJsonDocument {
+  const known = field(context.resource.values, key);
+
+  if (typeof known === "string") {
+    const parsed: unknown = JSON.parse(known);
+
+    return {
+      value: isRecord(parsed) ? templateValue(parsed) : undefined,
+      lost: [],
+    };
+  }
+
+  return {
+    value: undefined,
+    lost: context.resource.unknown[key] === true ? [key] : [],
+  };
+}
+
+/**
+ * The `aws_sqs_queue_redrive_*` resources that configure a queue declared
+ * elsewhere.
+ *
+ * Each names its queue in a `queue_url` attribute, which the queue resolves to
+ * whether or not the URL itself was known at plan time. CloudFormation carries
+ * both as properties of the `AWS::SQS::Queue`, and simulated SQS records each
+ * one against the Resource: no message moves to a dead-letter queue here, and
+ * nothing enforces which queues may name one as theirs.
+ */
+export const sqsRedriveFolds: ReadonlyMap<string, TerraformResourceFold> =
+  new Map([
+    [
+      "aws_sqs_queue_redrive_policy",
+      {
+        parentAttribute: "queue_url",
+        properties: (context) =>
+          redrive(context, "redrive_policy", "RedrivePolicy"),
+        lost: (context) => jsonDocument(context, "redrive_policy").lost,
+      },
+    ],
+    [
+      "aws_sqs_queue_redrive_allow_policy",
+      {
+        parentAttribute: "queue_url",
+        properties: (context) =>
+          redrive(context, "redrive_allow_policy", "RedriveAllowPolicy"),
+        lost: (context) => jsonDocument(context, "redrive_allow_policy").lost,
+      },
+    ],
+  ]);
+
+function redrive(
+  context: TerraformMappingContext,
+  attribute: string,
+  property: string,
+): Record<string, SimCfnTemplateValue> {
+  return properties({ [property]: jsonDocument(context, attribute).value });
+}

--- a/src/terraform/map/sim-tf-map-sqs.ts
+++ b/src/terraform/map/sim-tf-map-sqs.ts
@@ -1,26 +1,23 @@
-/*
- * Reading a plan means reading records whose keys come from the document
- * rather than from this code, so the object-injection rule fires on every
- * lookup. The records are parsed JSON with no prototype of their own.
- */
-// oxlint-disable security/detect-object-injection
-import { isRecord } from "../../util/type-guard/record.js";
-import type { SimCfnTemplateValue } from "../../service/cloudformation/template/value/sim-cfn-template-value.js";
 import {
-  field,
   properties,
   renamed,
   tags,
-  templateValue,
   type TerraformMappingContext,
 } from "../sim-tf-attributes.js";
 import type { TerraformMappedResource } from "../sim-tf-mapping.type.js";
+import { jsonDocument } from "./sim-tf-map-sqs-redrive.js";
 
-/** A queue, with the redrive policy read out of the JSON string it lives in. */
+/**
+ * A queue, with the redrive policy read out of the JSON string it lives in.
+ *
+ * A queue can also state its redrive settings as resources of their own, and
+ * those fold in beside this. The queue's own attribute is the older spelling
+ * and the two never appear together on one queue.
+ */
 export function sqsQueue(
   context: TerraformMappingContext,
 ): TerraformMappedResource {
-  const redrive = redrivePolicy(context);
+  const redrive = jsonDocument(context, "redrive_policy");
 
   return {
     Type: "AWS::SQS::Queue",
@@ -34,45 +31,5 @@ export function sqsQueue(
       ...properties({ RedrivePolicy: redrive.value, Tags: tags(context) }),
     },
     lost: redrive.lost,
-  };
-}
-
-interface RedriveResult {
-  readonly value: SimCfnTemplateValue | undefined;
-  readonly lost: readonly string[];
-}
-
-/**
- * The queue's redrive policy, which Terraform carries as a JSON string.
- *
- * The string is built with `jsonencode` around the dead-letter queue's ARN, so
- * the whole string is unknown whenever that queue is created by the same plan.
- * What survives is the reference. The `maxReceiveCount` beside it was inside
- * the string that never got built.
- */
-function redrivePolicy(context: TerraformMappingContext): RedriveResult {
-  const known = field(context.resource.values, "redrive_policy");
-
-  if (typeof known === "string") {
-    const parsed: unknown = JSON.parse(known);
-
-    return {
-      value: isRecord(parsed) ? templateValue(parsed) : undefined,
-      lost: [],
-    };
-  }
-
-  /*
-   * The dead-letter queue is recoverable from the reference and the receive
-   * limit is not, and a redrive policy carrying a made-up limit would give the
-   * queue different retry behaviour from the one the plan describes. The whole
-   * policy is dropped and recorded instead.
-   */
-  return {
-    value: undefined,
-    lost:
-      context.resource.unknown["redrive_policy"] === true
-        ? ["redrive_policy"]
-        : [],
   };
 }

--- a/src/terraform/map/sim-tf-map-storage-configuration.iso.test.ts
+++ b/src/terraform/map/sim-tf-map-storage-configuration.iso.test.ts
@@ -1,0 +1,296 @@
+import { describe, it } from "vitest";
+import {
+  assertArrayEquals,
+  assertObjectEquals,
+  assertUndefined,
+} from "@kensio/smartass";
+import { assertDefined } from "../../util/type-guard/defined.js";
+import { terraformPlanResourceFactory } from "../../../test/terraform/plan/terraform-plan.factory.js";
+import { terraformMappingContext as contextFor } from "../../../test/terraform/plan/terraform-mapping-context.js";
+import type { TerraformMappingContext } from "../sim-tf-attributes.js";
+import { terraformResourceFolds } from "../sim-tf-registry.js";
+import { dynamodbTable } from "./sim-tf-map-dynamodb.js";
+import { bucketNotification } from "./sim-tf-map-s3-notification.js";
+
+/** One resource of a fixture, as the context a mapping is given for it. */
+function resourceContext(
+  type: string,
+  values: Record<string, unknown>,
+  overrides: Record<string, unknown> = {},
+): TerraformMappingContext {
+  return contextFor({
+    resources: [
+      terraformPlanResourceFactory.make({
+        type,
+        name: "uploads",
+        values,
+        ...overrides,
+      }),
+    ],
+  });
+}
+
+/** The properties one registered fold contributes to its parent. */
+function registeredFold(
+  type: string,
+  values: Record<string, unknown>,
+): Record<string, unknown> {
+  const fold = terraformResourceFolds.get(type);
+
+  assertDefined(fold, `A fold for ${type}`);
+
+  return fold.properties(resourceContext(type, values), {});
+}
+
+describe("mapping a provisioned DynamoDB table", () => {
+  it("provisions the table and each of its indexes", () => {
+    // Given a table billed by provisioned capacity, which Terraform states on
+    // the table and again on each global secondary index
+    const context = resourceContext("aws_dynamodb_table", {
+      name: "reports",
+      billing_mode: "PROVISIONED",
+      hash_key: "reportId",
+      read_capacity: 5,
+      write_capacity: 2,
+      global_secondary_index: [
+        {
+          name: "byGeneratedAt",
+          hash_key: "generatedAt",
+          range_key: "",
+          projection_type: "KEYS_ONLY",
+          read_capacity: 3,
+          write_capacity: 1,
+        },
+      ],
+    });
+    const mapped = dynamodbTable(context);
+
+    // When it is mapped
+    // Then both carry the capacity CloudFormation holds them under, without
+    // which simulated DynamoDB refuses the table
+    assertObjectEquals(mapped.Properties["ProvisionedThroughput"], {
+      ReadCapacityUnits: 5,
+      WriteCapacityUnits: 2,
+    });
+    assertObjectEquals(mapped.Properties["GlobalSecondaryIndexes"], [
+      {
+        IndexName: "byGeneratedAt",
+        KeySchema: [{ AttributeName: "generatedAt", KeyType: "HASH" }],
+        Projection: { ProjectionType: "KEYS_ONLY" },
+        ProvisionedThroughput: { ReadCapacityUnits: 3, WriteCapacityUnits: 1 },
+      },
+    ]);
+  });
+
+  it("provisions nothing on an on-demand table", () => {
+    // Given an on-demand table, which the provider still writes a capacity
+    // pair of zeroes on
+    const context = resourceContext("aws_dynamodb_table", {
+      name: "orders",
+      billing_mode: "PAY_PER_REQUEST",
+      hash_key: "pk",
+      read_capacity: 0,
+      write_capacity: 0,
+    });
+
+    // When it is mapped
+    // Then no throughput is declared, since simulated DynamoDB refuses one
+    // alongside PAY_PER_REQUEST the way real DynamoDB does
+    assertUndefined(dynamodbTable(context).Properties["ProvisionedThroughput"]);
+  });
+});
+
+describe("mapping a bucket notification", () => {
+  it("resolves the function an event is delivered to", () => {
+    // Given a notification naming a function of the same plan, so the ARN
+    // inside the block arrived unknown
+    const context = contextFor({
+      resources: [
+        terraformPlanResourceFactory.make({
+          type: "aws_s3_bucket_notification",
+          name: "uploads",
+          values: {
+            lambda_function: [
+              {
+                events: ["s3:ObjectCreated:*"],
+                filter_prefix: null,
+                filter_suffix: ".jpg",
+              },
+            ],
+          },
+          unknown: {
+            bucket: true,
+            lambda_function: [{ lambda_function_arn: true }],
+          },
+          references: {
+            bucket: ["aws_s3_bucket.uploads.id"],
+            lambda_function: [
+              { lambda_function_arn: ["aws_lambda_function.processor.arn"] },
+            ],
+          },
+        }),
+        terraformPlanResourceFactory.make({
+          type: "aws_s3_bucket",
+          name: "uploads",
+          values: { bucket: "orders-uploads" },
+        }),
+        terraformPlanResourceFactory.make({
+          type: "aws_lambda_function",
+          name: "processor",
+          values: { function_name: "orders-processor" },
+        }),
+      ],
+    });
+
+    // When it is mapped
+    // Then the configuration names the bucket and the function by what the
+    // references resolve to, and the suffix filter is in the shape the request
+    // takes
+    assertObjectEquals(bucketNotification(context).Properties, {
+      BucketName: { Ref: "AwsS3BucketUploads" },
+      NotificationConfiguration: {
+        LambdaFunctionConfigurations: [
+          {
+            LambdaFunctionArn: {
+              "Fn::GetAtt": ["AwsLambdaFunctionProcessor", "Arn"],
+            },
+            Events: ["s3:ObjectCreated:*"],
+            Filter: {
+              Key: { FilterRules: [{ Name: "suffix", Value: ".jpg" }] },
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it("records a destination the plan could not resolve", () => {
+    // Given a notification naming a queue the template does not declare
+    const context = resourceContext(
+      "aws_s3_bucket_notification",
+      { queue: [{ events: ["s3:ObjectCreated:*"] }] },
+      {
+        unknown: { bucket: true, queue: [{ queue_arn: true }] },
+        references: {
+          bucket: ["aws_s3_bucket.uploads.id"],
+          queue: [{ queue_arn: ["aws_sqs_queue.absent.arn"] }],
+        },
+      },
+    );
+    const mapped = bucketNotification(context);
+
+    // When it is mapped
+    // Then the destination is dropped rather than declared naming nothing, and
+    // the block is recorded
+    assertUndefined(mapped.Properties["NotificationConfiguration"]);
+    assertArrayEquals(mapped.lost ?? [], ["queue"]);
+  });
+
+  it("records the EventBridge delivery simulated S3 refuses", () => {
+    // Given a bucket asking for its events on the default event bus
+    const context = resourceContext(
+      "aws_s3_bucket_notification",
+      { eventbridge: true },
+      {
+        unknown: { bucket: true },
+        references: { bucket: ["aws_s3_bucket.uploads.id"] },
+      },
+    );
+
+    // When it is mapped
+    // Then the attribute is recorded, since simulated S3 refuses an
+    // EventBridgeConfiguration rather than accepting one it never delivers
+    // through
+    assertArrayEquals(bucketNotification(context).lost ?? [], ["eventbridge"]);
+  });
+});
+
+describe("mapping a bucket lifecycle configuration", () => {
+  it("builds the rules CloudFormation holds on the bucket", () => {
+    // Given a rule abandoning incomplete uploads and expiring what is left,
+    // where the provider wrote an empty prefix for the one the rule states none
+    // When it is folded into its bucket
+    // Then the rule is carried as CloudFormation names each part of it, with
+    // no Prefix matching every object
+    assertObjectEquals(
+      registeredFold("aws_s3_bucket_lifecycle_configuration", {
+        rule: [
+          {
+            id: "expire-incomplete",
+            status: "Enabled",
+            prefix: "",
+            expiration: [{ days: 30 }],
+            abort_incomplete_multipart_upload: [{ days_after_initiation: 7 }],
+            transition: [{ storage_class: "GLACIER", days: 90 }],
+          },
+        ],
+      }),
+      {
+        LifecycleConfiguration: {
+          Rules: [
+            {
+              Id: "expire-incomplete",
+              Status: "Enabled",
+              ExpirationInDays: 30,
+              AbortIncompleteMultipartUpload: { DaysAfterInitiation: 7 },
+              Transitions: [{ StorageClass: "GLACIER", TransitionInDays: 90 }],
+            },
+          ],
+        },
+      },
+    );
+  });
+});
+
+describe("mapping the resources that configure a queue's redrive", () => {
+  it("reads a redrive policy the plan resolved", () => {
+    // Given a redrive policy naming a dead-letter queue by literal ARN
+    // When it is folded into the queue it configures
+    // Then it arrives as the object CloudFormation carries
+    assertObjectEquals(
+      registeredFold("aws_sqs_queue_redrive_policy", {
+        redrive_policy: JSON.stringify({
+          deadLetterTargetArn: "arn:aws:sqs:eu-west-1:1:orders-dlq",
+          maxReceiveCount: 5,
+        }),
+      }),
+      {
+        RedrivePolicy: {
+          deadLetterTargetArn: "arn:aws:sqs:eu-west-1:1:orders-dlq",
+          maxReceiveCount: 5,
+        },
+      },
+    );
+  });
+
+  it("carries which queues a dead-letter queue accepts", () => {
+    // Given an allow policy admitting any queue
+    // When it is folded
+    // Then it arrives under the property CloudFormation holds it in
+    assertObjectEquals(
+      registeredFold("aws_sqs_queue_redrive_allow_policy", {
+        redrive_allow_policy: JSON.stringify({ redrivePermission: "allowAll" }),
+      }),
+      { RedriveAllowPolicy: { redrivePermission: "allowAll" } },
+    );
+  });
+
+  it("contributes nothing for a policy built around an ARN of the same plan", () => {
+    // Given a policy written with jsonencode around a queue ARN, so the whole
+    // string stayed unknown and the receive limit went with it
+    const context = resourceContext(
+      "aws_sqs_queue_redrive_policy",
+      {},
+      { unknown: { redrive_policy: true } },
+    );
+    const fold = terraformResourceFolds.get("aws_sqs_queue_redrive_policy");
+
+    assertDefined(fold, "A fold for aws_sqs_queue_redrive_policy");
+
+    // When it is folded
+    // Then nothing is contributed, since a policy carrying a made-up limit
+    // would give the queue different retry behaviour, and it is recorded
+    assertObjectEquals(fold.properties(context, {}), {});
+    assertArrayEquals(fold.lost?.(context) ?? [], ["redrive_policy"]);
+  });
+});

--- a/src/terraform/sim-tf-fold.ts
+++ b/src/terraform/sim-tf-fold.ts
@@ -77,8 +77,10 @@ export function terraformFoldedResources(
     }
 
     const context = { resource, resolver, overrides };
+    const existing = parent["Properties"];
+    const added = fold.properties(context, isRecord(existing) ? existing : {});
 
-    merged.set(parentId, mergedParent(parent, fold.properties(context)));
+    merged.set(parentId, mergedParent(parent, added));
     folded.push({ address: resource.address, type: resource.type });
     lost.push(
       ...(fold.lost?.(context) ?? []).map((attribute) => ({
@@ -96,7 +98,9 @@ export function terraformFoldedResources(
  *
  * The fold contributes whole CloudFormation properties, so a later fold on the
  * same parent replaces a property an earlier one set rather than merging into
- * it. No two folds of one resource type write the same property.
+ * it. Two folds writing the same property are two of one Terraform type, and a
+ * fold whose property is a list is handed what the parent already carries so
+ * it can add to it.
  */
 function mergedParent(
   parent: SimCfnTemplateValueRecord,

--- a/src/terraform/sim-tf-mapping.type.ts
+++ b/src/terraform/sim-tf-mapping.type.ts
@@ -59,12 +59,19 @@ export interface TerraformDeclaration {
  * and CloudFormation carries all six as properties of one `AWS::S3::Bucket`.
  * A fold names the attribute holding the parent's address, and returns the
  * properties to merge into the parent.
+ *
+ * The properties the parent already carries are given along with the resource,
+ * for the fold that adds to a list rather than setting a property outright. An
+ * EventBridge rule's targets are one Terraform resource each and one `Targets`
+ * list on the Resource, so the second target of a rule has to find the first.
+ * A fold writing a property of its own ignores them.
  */
 export interface TerraformResourceFold {
   /** The attribute naming the resource these properties belong to. */
   readonly parentAttribute: string;
   readonly properties: (
     context: TerraformMappingContext,
+    parent?: Record<string, SimCfnTemplateValue>,
   ) => Record<string, SimCfnTemplateValue>;
 
   /**

--- a/src/terraform/sim-tf-nested-attributes.ts
+++ b/src/terraform/sim-tf-nested-attributes.ts
@@ -1,0 +1,138 @@
+/*
+ * The two attribute shapes `attribute()` cannot read: a list whose entries name
+ * other resources, and an attribute inside a repeating nested block.
+ *
+ * `after_unknown` mirrors the shape of the value it marks, so a list of ARNs
+ * built from one resource is marked `true` whole, and a block whose one field
+ * is unknown is marked as a list of records. `configuration` mirrors the same
+ * shape with its `references`, and reading the two together is what puts the
+ * intrinsic back where the value was.
+ *
+ * Reading a plan means reading records whose keys come from the document
+ * rather than from this code, so the object-injection rule fires on every
+ * lookup. The records are parsed JSON with no prototype of their own.
+ */
+// oxlint-disable security/detect-object-injection
+import { isRecord } from "../util/type-guard/record.js";
+import type { SimCfnTemplateValue } from "../service/cloudformation/template/value/sim-cfn-template-value.js";
+import {
+  properties,
+  templateValue,
+  type TerraformMappingContext,
+} from "./sim-tf-attributes.js";
+import type { TerraformExpression } from "./sim-tf-plan.type.js";
+import { longestFirst } from "./sim-tf-reference-address.js";
+
+/**
+ * A list attribute whose entries name other resources.
+ *
+ * An alarm's `alarm_actions` holding one topic ARN of the same plan is marked
+ * unknown as a whole list, and the entries are gone with it. What survives is
+ * the reference behind each entry, and Terraform lists both the attribute form
+ * and the bare resource form of one reference. Both forms of a topic resolve to
+ * the same `Ref`, so the resolved values are deduplicated rather than the
+ * references, which is the only place the two forms can be told apart.
+ *
+ * A list the plan resolved is carried across as it stands.
+ */
+export function attributeList(
+  context: TerraformMappingContext,
+  key: string,
+): SimCfnTemplateValue | undefined {
+  const { resource, resolver } = context;
+
+  if (resource.unknown[key] !== true) {
+    const value = resource.values[key];
+
+    return Array.isArray(value) ? templateValue(value) : undefined;
+  }
+
+  const resolved = new Map<string, SimCfnTemplateValue>();
+  const declared = longestFirst(references(resource.expressions[key]));
+
+  for (const reference of declared) {
+    const value = resolver.resolve(reference, resource.modulePath);
+
+    if (value !== undefined) {
+      resolved.set(JSON.stringify(value), value);
+    }
+  }
+
+  return resolved.size === 0 ? undefined : resolved.values().toArray();
+}
+
+/**
+ * One attribute of one entry of a repeating nested block.
+ *
+ * A bucket notification names the function it calls inside a `lambda_function`
+ * block, and the function's ARN is unknown whenever the same plan creates it.
+ * The mark and the references both sit at the same position in a list mirroring
+ * the block, so the entry's index is what finds them.
+ */
+export function blockAttribute(
+  context: TerraformMappingContext,
+  key: string,
+  index: number,
+  name: string,
+): SimCfnTemplateValue | undefined {
+  const { resource, resolver } = context;
+
+  if (entry(resource.unknown[key], index)?.[name] !== true) {
+    return templateValue(entry(resource.values[key], index)?.[name]);
+  }
+
+  const expression = entry(resource.expressions[key], index)?.[name];
+  const declared = longestFirst(references(expression));
+
+  for (const reference of declared) {
+    const value = resolver.resolve(reference, resource.modulePath);
+
+    if (value !== undefined) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * The fields of one nested block, under the names CloudFormation gives them.
+ *
+ * The provider writes every field of a block that was declared, filling the
+ * ones the configuration left out with null, so the table says what each field
+ * is called on either side and `properties` takes the nulls back out.
+ */
+export function blockFields(
+  record: Record<string, unknown>,
+  names: Readonly<Record<string, string>>,
+): Record<string, SimCfnTemplateValue> {
+  return properties(
+    Object.fromEntries(
+      Object.entries(names).map(([property, name]) => [
+        property,
+        templateValue(record[name]),
+      ]),
+    ),
+  );
+}
+
+/** One entry of a list mirroring a repeating block. */
+function entry(
+  value: unknown,
+  index: number,
+): Record<string, unknown> | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const found: unknown = value[index];
+
+  return isRecord(found) ? found : undefined;
+}
+
+/** The references one expression records, or none where it holds no expression. */
+function references(expression: unknown): readonly string[] {
+  return isRecord(expression)
+    ? ((expression as TerraformExpression).references ?? [])
+    : [];
+}

--- a/src/terraform/sim-tf-plan-deploy.loc.test.ts
+++ b/src/terraform/sim-tf-plan-deploy.loc.test.ts
@@ -2,14 +2,15 @@ import { describe, it } from "vitest";
 import {
   assertArrayIncludes,
   assertArrayLength,
-  assertArrayMinLength,
-  assertIdentical,
   assertNonNullable,
   assertObjectEquals,
   assertObjectHasProperty,
 } from "@kensio/smartass";
 import { SimAws } from "../service/aws/sim-aws.js";
-import { TestTerraformProject } from "../util/filesystem/test-terraform-project.js";
+import {
+  terraformPlanHandlers as handlersFor,
+  terraformPlannedPath as plannedPath,
+} from "../../test/terraform/plan/terraform-planned-configuration.js";
 import { TerraformAdapter } from "./sim-tf-adapter.js";
 import { deployedStackObject } from "../service/cloudformation/stack/sim-cfn-stack.fixture.js";
 
@@ -19,45 +20,7 @@ import { deployedStackObject } from "../service/cloudformation/stack/sim-cfn-sta
  * import has a fixture of its own beside it. These cover the one thing a
  * fixture cannot say, which is that the format being read is the format
  * Terraform writes.
- *
- * The community modules read `aws_caller_identity`, which cannot be read
- * without credentials, so planning that configuration offline reports those
- * data sources as errors and still plans the managed resources.
  */
-const toleratedDataSourceFailures = new Set(["modules"]);
-
-/** The function each configuration declares, by configuration name. */
-const functionNames: Record<string, string> = {
-  app: "orders-processor",
-  modules: "orders-processor-independent",
-};
-
-/**
- * What the functions of one configuration run.
- *
- * A plan points a function at a zip, an S3 object or a container image, and
- * none of the three is a handler Yulin can run, so a plan holding a function
- * is deployed with a binding matched on the name the plan declares.
- */
-function handlersFor(
-  name: string,
-): readonly { functionName: string; handler: () => { ok: boolean } }[] {
-  return [
-    {
-      // oxlint-disable-next-line security/detect-object-injection
-      functionName: functionNames[name] ?? "",
-      handler: (): { ok: boolean } => ({ ok: true }),
-    },
-  ];
-}
-
-async function plannedPath(name: string): Promise<string> {
-  const project = new TestTerraformProject(name, {
-    toleratesDataSourceErrors: toleratedDataSourceFailures.has(name),
-  });
-
-  return await project.planJsonPath();
-}
 
 describe("deploying a plan Terraform itself produced", () => {
   it("deploys an application configuration into simulated AWS", async () => {
@@ -99,30 +62,6 @@ describe("deploying a plan Terraform itself produced", () => {
     );
     assertNonNullable(simAws.dynamoDb().findTable("orders-independent"));
     assertArrayLength(stack.skippedResources, 0);
-  });
-
-  it("accounts for every managed resource of a plan", async () => {
-    // Given both plans deployed
-    const adapter = new TerraformAdapter(new SimAws());
-    const deployments = await Promise.all(
-      ["app", "modules"].map(async (name) =>
-        adapter.deployPlan({
-          planPath: await plannedPath(name),
-          stackName: `counted-${name}`,
-          bindings: handlersFor(name),
-        }),
-      ),
-    );
-
-    // When each resource is mapped, folded into another, or skipped
-    // Then the three add up to the plan's managed resource count
-    for (const { report } of deployments) {
-      assertIdentical(
-        report.mapped.length + report.folded.length + report.skipped.length,
-        report.total,
-      );
-      assertArrayMinLength(report.mapped, 10);
-    }
   });
 
   it("folds the aws_s3_bucket_ resources into the bucket they configure", async () => {

--- a/src/terraform/sim-tf-plan-report.loc.test.ts
+++ b/src/terraform/sim-tf-plan-report.loc.test.ts
@@ -1,0 +1,97 @@
+import { describe, it } from "vitest";
+import {
+  assertArrayEquals,
+  assertArrayMinLength,
+  assertIdentical,
+} from "@kensio/smartass";
+import { SimAws } from "../service/aws/sim-aws.js";
+import {
+  terraformPlanHandlers as handlersFor,
+  terraformPlannedPath as plannedPath,
+} from "../../test/terraform/plan/terraform-planned-configuration.js";
+import { TerraformAdapter } from "./sim-tf-adapter.js";
+import type { TerraformImportReport } from "./sim-tf-report.type.js";
+
+/*
+ * What an import makes of the two configurations committed under
+ * `test/terraform`.
+ *
+ * The resources a plan does not reach are asserted rather than reported, so a
+ * mapping that stops reaching a resource type shows up as a failure here
+ * rather than as a number nobody reads.
+ */
+
+/**
+ * What each configuration leaves unreached, by configuration name.
+ *
+ * The application configuration leaves nothing. The modules configuration
+ * packages its zip with `null_resource` and `local_file`, which belong to no
+ * AWS service, and its integration and route read their values through an
+ * `each.value` hop this import does not follow.
+ */
+const unreachedTypes: Record<string, readonly string[]> = {
+  app: [],
+  modules: [
+    "aws_apigatewayv2_integration",
+    "aws_apigatewayv2_route",
+    "local_file",
+    "null_resource",
+  ],
+};
+
+/** The report each committed configuration's plan deploys to. */
+async function reports(): Promise<Record<string, TerraformImportReport>> {
+  const adapter = new TerraformAdapter(new SimAws());
+  const deployed = await Promise.all(
+    Object.keys(unreachedTypes).map(async (name) => {
+      const { report } = await adapter.deployPlan({
+        planPath: await plannedPath(name),
+        stackName: `reported-${name}`,
+        bindings: handlersFor(name),
+      });
+
+      return [name, report] as const;
+    }),
+  );
+
+  return Object.fromEntries(deployed);
+}
+
+/** Type name order by code unit, so a machine's locale cannot move it. */
+function byName(one: string, other: string): number {
+  return one < other ? -1 : 1;
+}
+
+describe("reading what a plan holds", () => {
+  it("accounts for every managed resource of a plan", async () => {
+    // Given both plans deployed
+    const deployed = await reports();
+
+    // When each resource is mapped, folded into another, or skipped
+    // Then the three add up to the plan's managed resource count
+    for (const report of Object.values(deployed)) {
+      assertIdentical(
+        report.mapped.length + report.folded.length + report.skipped.length,
+        report.total,
+      );
+      assertArrayMinLength(report.mapped, 10);
+    }
+  });
+
+  it("reaches every resource of a plan that a mapping can reach", async () => {
+    // Given both plans deployed
+    const deployed = await reports();
+
+    // When each resource is mapped, folded or skipped
+    // Then what was skipped is what has nowhere to go
+    for (const [name, expected] of Object.entries(unreachedTypes)) {
+      assertArrayEquals(
+        // oxlint-disable-next-line security/detect-object-injection
+        (deployed[name]?.skipped ?? [])
+          .map((entry) => entry.type)
+          .toSorted(byName),
+        expected,
+      );
+    }
+  });
+});

--- a/src/terraform/sim-tf-plan-services.loc.test.ts
+++ b/src/terraform/sim-tf-plan-services.loc.test.ts
@@ -1,0 +1,110 @@
+import { describe, it } from "vitest";
+import {
+  assertArrayEquals,
+  assertArrayIncludes,
+  assertIdentical,
+  assertNonNullable,
+  assertTrue,
+} from "@kensio/smartass";
+import { SimAws } from "../service/aws/sim-aws.js";
+import {
+  terraformPlanHandlers as handlersFor,
+  terraformPlannedPath as plannedPath,
+} from "../../test/terraform/plan/terraform-planned-configuration.js";
+import { TerraformAdapter } from "./sim-tf-adapter.js";
+
+/*
+ * What the application configuration under `test/terraform/app` reaches, one
+ * simulated service at a time.
+ *
+ * The deployment itself is covered beside this. These say that a resource the
+ * import mapped is a resource the service it belongs to went on to create, and
+ * that it behaves as the configuration described.
+ */
+
+describe("deploying a plan into the services it names", () => {
+  it("deploys the encryption, auth and alerting an application declares", async () => {
+    // Given the same application configuration, whose KMS key, user pool,
+    // alarms, schedule and repository are each a service of their own
+    const simAws = new SimAws();
+
+    // When it is deployed
+    await new TerraformAdapter(simAws).deployPlan({
+      planPath: await plannedPath("app"),
+      stackName: "services-app",
+      bindings: handlersFor("app"),
+    });
+
+    // Then each one exists in the simulator it belongs to
+    const pools = await simAws
+      .cognitoIdentityProvider()
+      .listUserPools({ input: { MaxResults: 10 } });
+
+    assertNonNullable(simAws.kms().findAlias("alias/orders"));
+    assertArrayIncludes(
+      (pools.UserPools ?? []).map((pool) => pool.Name),
+      "orders-users",
+    );
+    assertNonNullable(simAws.cloudWatch().findAlarm("orders-dlq-depth"));
+    assertNonNullable(simAws.eventBridge().findRule("orders-nightly"));
+    assertTrue(simAws.ecr().hasRepository("orders-processor"));
+  });
+
+  it("delivers a bucket event to the function the plan named", async () => {
+    // Given a configuration whose bucket notifies a function on upload. The
+    // notification is a resource of its own in Terraform, and the function's
+    // permission names the bucket, which is a circular dependency where
+    // CloudFormation carries the notification on the bucket
+    const simAws = new SimAws();
+    const uploaded: string[] = [];
+
+    // When the plan is deployed and an object is put in the bucket
+    await new TerraformAdapter(simAws).deployPlan({
+      planPath: await plannedPath("app"),
+      stackName: "notified-app",
+      bindings: [
+        {
+          functionName: "orders-processor",
+          handler: (event: {
+            Records?: { s3: { object: { key: string } } }[];
+          }) => {
+            const records = event.Records ?? [];
+
+            for (const record of records) {
+              uploaded.push(record.s3.object.key);
+            }
+
+            return { ok: true };
+          },
+        },
+      ],
+    });
+
+    await simAws.s3().putObject({
+      input: { Bucket: "orders-uploads", Key: "receipt.jpg", Body: "bytes" },
+    });
+    await simAws.backgroundTasksComplete();
+
+    // Then the function ran for it
+    assertArrayEquals(uploaded, ["receipt.jpg"]);
+  });
+
+  it("provisions a table the configuration billed by capacity", async () => {
+    // Given a table declaring PROVISIONED billing, which simulated DynamoDB
+    // refuses without the capacity to go with it
+    const simAws = new SimAws();
+
+    // When the plan is deployed
+    await new TerraformAdapter(simAws).deployPlan({
+      planPath: await plannedPath("app"),
+      stackName: "provisioned-app",
+      bindings: handlersFor("app"),
+    });
+
+    // Then the table exists with the capacity the configuration named
+    const table = simAws.dynamoDb().findTable("orders-reports");
+
+    assertNonNullable(table);
+    assertIdentical(table.billing.mode, "PROVISIONED");
+  });
+});

--- a/src/terraform/sim-tf-registry.ts
+++ b/src/terraform/sim-tf-registry.ts
@@ -2,13 +2,19 @@ import type {
   TerraformResourceFold,
   TerraformResourceMapping,
 } from "./sim-tf-mapping.type.js";
+import { metricAlarm } from "./map/sim-tf-map-cloudwatch.js";
+import { cognitoUserPool } from "./map/sim-tf-map-cognito.js";
+import { cognitoUserPoolClient } from "./map/sim-tf-map-cognito-client.js";
 import { dynamodbTable } from "./map/sim-tf-map-dynamodb.js";
+import { ecrRepository } from "./map/sim-tf-map-ecr.js";
+import { eventRule, eventTargetFolds } from "./map/sim-tf-map-events.js";
 import { httpApi, httpApiStage } from "./map/sim-tf-map-http-api.js";
 import {
   httpApiIntegration,
   httpApiRoute,
 } from "./map/sim-tf-map-http-api-routes.js";
 import { iamRole, iamRoleFolds } from "./map/sim-tf-map-iam.js";
+import { kmsAlias, kmsKey } from "./map/sim-tf-map-kms.js";
 import {
   lambdaEventSourceMapping,
   lambdaFunction,
@@ -17,12 +23,15 @@ import {
 import { logGroup } from "./map/sim-tf-map-logs.js";
 import { s3Bucket } from "./map/sim-tf-map-s3.js";
 import { s3BucketFolds } from "./map/sim-tf-map-s3-folds.js";
+import { s3LifecycleFolds } from "./map/sim-tf-map-s3-lifecycle.js";
+import { bucketNotification } from "./map/sim-tf-map-s3-notification.js";
 import {
   secretsManagerFolds,
   secretsManagerSecret,
 } from "./map/sim-tf-map-secretsmanager.js";
 import { snsSubscription, snsTopic } from "./map/sim-tf-map-sns.js";
 import { sqsQueue } from "./map/sim-tf-map-sqs.js";
+import { sqsRedriveFolds } from "./map/sim-tf-map-sqs-redrive.js";
 import { ssmParameter } from "./map/sim-tf-map-ssm.js";
 
 /**
@@ -30,7 +39,7 @@ import { ssmParameter } from "./map/sim-tf-map-ssm.js";
  *
  * A type with no entry is recorded as skipped, which is what the stack already
  * does with a CloudFormation Resource type no simulated service models. The
- * set is deliberately small, and grows a service at a time.
+ * set grows a service at a time.
  */
 export const terraformResourceMappings: ReadonlyMap<
   string,
@@ -40,13 +49,21 @@ export const terraformResourceMappings: ReadonlyMap<
   ["aws_apigatewayv2_integration", httpApiIntegration],
   ["aws_apigatewayv2_route", httpApiRoute],
   ["aws_apigatewayv2_stage", httpApiStage],
+  ["aws_cloudwatch_event_rule", eventRule],
   ["aws_cloudwatch_log_group", logGroup],
+  ["aws_cloudwatch_metric_alarm", metricAlarm],
+  ["aws_cognito_user_pool", cognitoUserPool],
+  ["aws_cognito_user_pool_client", cognitoUserPoolClient],
   ["aws_dynamodb_table", dynamodbTable],
+  ["aws_ecr_repository", ecrRepository],
   ["aws_iam_role", iamRole],
+  ["aws_kms_alias", kmsAlias],
+  ["aws_kms_key", kmsKey],
   ["aws_lambda_event_source_mapping", lambdaEventSourceMapping],
   ["aws_lambda_function", lambdaFunction],
   ["aws_lambda_permission", lambdaPermission],
   ["aws_s3_bucket", s3Bucket],
+  ["aws_s3_bucket_notification", bucketNotification],
   ["aws_secretsmanager_secret", secretsManagerSecret],
   ["aws_sns_topic", snsTopic],
   ["aws_sns_topic_subscription", snsSubscription],
@@ -61,4 +78,11 @@ export const terraformResourceMappings: ReadonlyMap<
 export const terraformResourceFolds: ReadonlyMap<
   string,
   TerraformResourceFold
-> = new Map([...s3BucketFolds, ...iamRoleFolds, ...secretsManagerFolds]);
+> = new Map([
+  ...s3BucketFolds,
+  ...s3LifecycleFolds,
+  ...iamRoleFolds,
+  ...secretsManagerFolds,
+  ...eventTargetFolds,
+  ...sqsRedriveFolds,
+]);

--- a/src/util/filesystem/test-terraform-project.ts
+++ b/src/util/filesystem/test-terraform-project.ts
@@ -89,11 +89,24 @@ export class TestTerraformProject {
    * still writes a plan covering the managed resources, which are what an
    * import reads. A configuration expecting that says so. Every other failure
    * is a failure, so a broken configuration cannot pass as a partial plan.
+   *
+   * The state lock is not taken. These configurations have no state and are
+   * never applied, and several test files plan the same one at once.
    */
   private async plan(planFile: string): Promise<void> {
     const result = await execa(
       "terraform",
-      [`-chdir=${this.directory}`, "plan", "-input=false", "-out", planFile],
+      [
+        `-chdir=${this.directory}`,
+        "plan",
+        "-input=false",
+        // There is no state to protect. Nothing is ever applied here, and two
+        // test files planning the same configuration at once would otherwise
+        // fail on each other's state lock rather than on the configuration.
+        "-lock=false",
+        "-out",
+        planFile,
+      ],
       { env: { TF_IN_AUTOMATION: "1" }, reject: false },
     );
 

--- a/test/terraform/app/main.tf
+++ b/test/terraform/app/main.tf
@@ -140,6 +140,35 @@ resource "aws_dynamodb_table" "orders" {
   tags = local.tags
 }
 
+# ---------- Reporting table, provisioned rather than on demand ----------
+
+resource "aws_dynamodb_table" "reports" {
+  name           = "${var.app}-reports"
+  billing_mode   = "PROVISIONED"
+  read_capacity  = 5
+  write_capacity = 2
+  hash_key       = "reportId"
+
+  attribute {
+    name = "reportId"
+    type = "S"
+  }
+  attribute {
+    name = "generatedAt"
+    type = "S"
+  }
+
+  global_secondary_index {
+    name            = "byGeneratedAt"
+    hash_key        = "generatedAt"
+    projection_type = "KEYS_ONLY"
+    read_capacity   = 3
+    write_capacity  = 1
+  }
+
+  tags = local.tags
+}
+
 # ---------- Queues and topics ----------
 
 resource "aws_sqs_queue" "dlq" {
@@ -155,6 +184,34 @@ resource "aws_sqs_queue" "processing" {
     maxReceiveCount     = 3
   })
   tags = local.tags
+}
+
+# The reporting queue states its redrive settings as resources of their own,
+# which is the other way the provider lets a queue name a dead-letter queue.
+
+resource "aws_sqs_queue" "reports_dlq" {
+  name = "${var.app}-reports-dlq"
+  tags = local.tags
+}
+
+resource "aws_sqs_queue" "reports" {
+  name = "${var.app}-reports"
+  tags = local.tags
+}
+
+resource "aws_sqs_queue_redrive_policy" "reports" {
+  queue_url = aws_sqs_queue.reports.id
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.reports_dlq.arn
+    maxReceiveCount     = 5
+  })
+}
+
+resource "aws_sqs_queue_redrive_allow_policy" "reports_dlq" {
+  queue_url = aws_sqs_queue.reports_dlq.id
+  redrive_allow_policy = jsonencode({
+    redrivePermission = "allowAll"
+  })
 }
 
 resource "aws_sns_topic" "order_events" {

--- a/test/terraform/plan/terraform-plan.factory.ts
+++ b/test/terraform/plan/terraform-plan.factory.ts
@@ -29,8 +29,17 @@ export interface TerraformPlanResourceFixture {
   readonly values: Record<string, unknown>;
   /** Attributes the plan could not resolve, as `after_unknown` marks them. */
   readonly unknown: Record<string, unknown>;
-  /** What each attribute refers to, keyed by attribute name. */
-  readonly references: Record<string, readonly string[]>;
+  /**
+   * What each attribute refers to, keyed by attribute name.
+   *
+   * An attribute inside a repeating nested block is given as a list of
+   * records, one entry per block, which is the shape `configuration` mirrors
+   * the block with.
+   */
+  readonly references: Record<
+    string,
+    readonly string[] | readonly Record<string, readonly string[]>[]
+  >;
   /** Addresses named by an explicit `depends_on`. */
   readonly dependsOn: readonly string[];
 }
@@ -226,15 +235,38 @@ function configResource(
     type: resource.type,
     name: resource.name,
     expressions: Object.fromEntries(
-      Object.entries(resource.references).map(
-        ([attribute, references]): [string, TerraformExpression] => [
-          attribute,
-          { references },
-        ],
-      ),
+      Object.entries(resource.references).map(([attribute, references]) => [
+        attribute,
+        referenceExpression(references),
+      ]),
     ),
     depends_on: resource.dependsOn,
   };
+}
+
+/**
+ * The expression one attribute's references become.
+ *
+ * A nested block's references sit at the same position in a list as the block
+ * they were written in, so a fixture giving a list of records makes a list of
+ * expression records rather than one expression.
+ */
+function referenceExpression(
+  references: readonly string[] | readonly Record<string, readonly string[]>[],
+): TerraformExpression | readonly Record<string, TerraformExpression>[] {
+  if (references.every((entry) => typeof entry === "string")) {
+    return { references };
+  }
+
+  return (references as readonly Record<string, readonly string[]>[]).map(
+    (entry) =>
+      Object.fromEntries(
+        Object.entries(entry).map(([name, nested]) => [
+          name,
+          { references: nested },
+        ]),
+      ),
+  );
 }
 
 /**

--- a/test/terraform/plan/terraform-planned-configuration.ts
+++ b/test/terraform/plan/terraform-planned-configuration.ts
@@ -1,0 +1,68 @@
+import { TestTerraformProject } from "../../../src/util/filesystem/test-terraform-project.js";
+
+/*
+ * The two configurations committed under `test/terraform`, planned on demand.
+ *
+ * A test deploying one needs the plan on disk and a handler for the function
+ * the configuration declares, and both are the same wherever the plan is
+ * deployed, so they are said once here.
+ */
+
+/**
+ * The configuration whose `data` blocks cannot be read offline.
+ *
+ * The community modules read `aws_caller_identity`, so planning that
+ * configuration reports those data sources as errors and still plans the
+ * managed resources, which are what an import reads.
+ */
+const toleratedDataSourceFailures = new Set(["modules"]);
+
+/** The function each configuration declares, by configuration name. */
+const functionNames: Record<string, string> = {
+  app: "orders-processor",
+  modules: "orders-processor-independent",
+};
+
+/**
+ * What the functions of one configuration run.
+ *
+ * A plan points a function at a zip, an S3 object or a container image, and
+ * none of the three is a handler Yulin can run, so a plan holding a function
+ * is deployed with a binding matched on the name the plan declares.
+ */
+export function terraformPlanHandlers(
+  name: string,
+): readonly { functionName: string; handler: () => { ok: boolean } }[] {
+  return [
+    {
+      // oxlint-disable-next-line security/detect-object-injection
+      functionName: functionNames[name] ?? "",
+      handler: (): { ok: boolean } => ({ ok: true }),
+    },
+  ];
+}
+
+/**
+ * The path of the plan JSON for one committed configuration.
+ *
+ * Planning takes a second or so and gives the same plan every time, so one
+ * test file plans a configuration once however many of its tests deploy it.
+ */
+const planned = new Map<string, Promise<string>>();
+
+export async function terraformPlannedPath(name: string): Promise<string> {
+  const existing = planned.get(name);
+
+  if (existing !== undefined) {
+    return await existing;
+  }
+
+  const project = new TestTerraformProject(name, {
+    toleratesDataSourceErrors: toleratedDataSourceFailures.has(name),
+  });
+  const path = project.planJsonPath();
+
+  planned.set(name, path);
+
+  return await path;
+}


### PR DESCRIPTION
The plan reader mapped 16 Terraform resource types and reached about 73% of a realistic plan. It now maps 24 and folds 11 more, covering KMS keys and aliases, Cognito user pools and clients, CloudWatch metric alarms, EventBridge rules and targets, ECR repositories, S3 lifecycle and notification configuration, and the two resources that state a queue's redrive settings apart from the queue. A provisioned DynamoDB table carries the capacity simulated DynamoDB refuses it without, on the table and on each global secondary index. The application configuration under `test/terraform` now deploys whole, and the module configuration reaches 21 of its 25 resources, which is every one an expression evaluator is not needed for. Both fractions are asserted, so a mapping that stops reaching a type fails rather than quietly dropping it.

Three things cost more than the rename. Each target service was read to find out what it refuses, since a refused property fails the whole Stack: simulated EventBridge refuses `Tags` on a rule and refuses the CloudTrail rule state, PutMetricAlarm requires seven properties, and simulated DynamoDB refuses a provisioned table with no throughput. Two attribute shapes `attribute()` could not read now have readers of their own in `sim-tf-nested-attributes.ts`, for a list whose entries name other resources (an alarm's actions) and for an attribute inside a repeating nested block (a notification's function ARN). And `aws_s3_bucket_notification` maps onto `Custom::S3BucketNotifications` rather than folding into the bucket, because the function's permission names the bucket and a bucket naming the function back is the circular dependency that Resource type exists to break. An uploaded object reaches the function the plan named.

Resolves #866