### PR TITLE
feat: follow a Terraform each.value reference

### DIFF
--- a/docs/terraform/README.md
+++ b/docs/terraform/README.md
@@ -224,6 +224,24 @@ value that names a resource of the same plan and sits inside something Terraform
 such as a `jsonencode` document or a `for_each` map, is unknown in its entirety and its contents go
 with it.
 
+## What a reference cannot reach
+
+A value a plan resolved arrives as a value. A value the plan could not resolve arrives as a
+reference, and the import follows that reference to the resource that will produce it, through
+module outputs, module variables, `each.value` and `each.key`. That covers what a community module
+such as `terraform-aws-modules/apigateway-v2/aws` does with a `routes` map.
+
+Two shapes stop it, and both are recorded as `unresolved required attribute` on `report.skipped`.
+
+A plan records the references of a whole collection in one list, and the list says what the
+collection was built from without saying which entry holds which. A `routes` map naming one function
+is unambiguous. A `routes` map naming two functions leaves `each.value.uri` able to mean either, and
+the import declines. Setting the value with a resource of its own, or with one module call per
+function, gives each reference a collection to itself.
+
+A value reaching a resource through a `local` is out of range whatever it holds. A plan carries the
+locals' effects and none of their definitions, so there is nothing to follow.
+
 ## The scope of what it reads
 
 One plan JSON file, already produced. Reading HCL, reading `terraform.tfstate`, and running

--- a/src/terraform/README.md
+++ b/src/terraform/README.md
@@ -82,7 +82,7 @@ template would carry `{"Ref": "Processor"}`. The value is correct and the edge C
 from has gone with it.
 
 The edge survives in `configuration`, which records the reference whether or not the value resolved.
-`terraformDependsOn` in `sim-tf-declare.ts` walks every `references` array a resource declares and
+`terraformDependsOn` in `sim-tf-depends-on.ts` walks every `references` array a resource declares and
 turns them back into `DependsOn`. That pass is what puts the Stack in a deployable order.
 
 ### An unknown value takes its structure with it
@@ -122,19 +122,46 @@ An SQS `redrive_policy` loses its `maxReceiveCount` the same way. That one is dr
 carrying a made-up limit would give the queue different retry behaviour from the one the plan
 describes.
 
-### A reference can need an expression evaluator
+### A reference can name no address at all
 
-Resolving a reference to a resource works. Resolving one through a module sometimes needs more.
+A reference to a resource is a lookup. Some references name a scope Terraform resolves for itself,
+and finding the resource behind one of those takes several lookups in a row.
 
 The API module's integration URI reads `each.value.uri`. `each` iterates the module's `routes`
 variable, the module call sets that variable from `module.processor.lambda_function_arn`, and the
-processor module's output reads it off `aws_lambda_function.this[0].arn`. Following that means
-evaluating Terraform expressions, which is a step past reading references.
+processor module's output reads it off `aws_lambda_function.this[0].arn`. Four hops, and a plan
+records every one of them somewhere.
 
-`sim-tf-module-outputs.ts` follows the module-output hop. That one is tractable and worth having.
-The `each.value` hop needs an evaluator, and it is why the module plan skips its integration and its
-route. Community modules are how most Terraform is written, and `for_each` over a routes map is a
-normal thing for one to do. That is [#867](https://github.com/KensioSoftware/yulin/issues/867).
+`sim-tf-module-outputs.ts` indexes what a module publishes and `sim-tf-module-variables.ts` indexes
+what a call sets. Those are the two ways a value crosses a module boundary. A resource's
+`for_each_expression` says what `each` was iterating.
+`TerraformReferenceResolver` rewrites a reference under one of these scopes into the reference
+written where the scope was set, and asks again. `sim-tf-reference-scope.ts` holds that rewrite.
+
+None of this evaluates a Terraform expression, and a plan holds no expression to evaluate. The
+`configuration` section carries `references` arrays and no source. An attribute marked unknown
+stays unknown whatever is done to it, because the value has yet to exist. What the hops recover is
+the edge, and the edge is what an `Fn::GetAtt` is made of.
+
+A bare reference to a `for_each` resource is the same shape. Terraform writes
+`aws_apigatewayv2_integration.this[each.key]` into a plan as a reference to the resource and a
+separate reference to `each.key`, and the address in hand names no instance. The instance meant is
+the one keyed like the resource doing the reading (or the only one, where the reader carries no key
+of its own), and `sim-tf-reference-addresses.ts` holds that search.
+
+Two things the hops cannot recover are worth knowing about.
+
+A plan records the references of a whole collection in one list, and the list says what the
+collection was built from without saying which entry holds which. A `routes` map built from one
+function ARN gives one answer, and a map built from two gives two, where `each.value.uri` could be
+either. Two answers is treated as no answer, and the resource is left out with `unresolved required
+attribute` the way it was before any of this. A guess would put a plausible logical ID into a
+property naming the wrong resource.
+
+Anything reached through a `local.` is out of range. A plan carries no local definitions.
+`configuration.root_module` holds `module_calls`, and one module holds `outputs`, `resources`,
+`module_calls` and `variables`. Recovering a local means reading the module source beside the plan,
+which is a wider input than the plan path `deployPlan` takes.
 
 ### A service refuses properties it cannot act on
 
@@ -250,15 +277,13 @@ Two plans, both produced by Terraform 1.15.8 against AWS provider 5.100.0.
 |                   | resources | mapped | folded | skipped | reached |
 | ----------------- | --------- | ------ | ------ | ------- | ------- |
 | hand-written app  | 46        | 35     | 11     | 0       | 100%    |
-| community modules | 25        | 12     | 9      | 4       | 84%     |
+| community modules | 27        | 16     | 9      | 2       | 93%     |
 
 Reached means a simulated resource was created for it, either as a Resource of its own or as
 properties folded into one. The import maps 24 Terraform resource types and folds 11 more.
 
-The application plan is at its ceiling. Four resources of the module plan are left. `null_resource`
-and `local_file` package a zip and belong to no AWS service. The integration and the route read
-their values through the `each.value` hop described above, which is
-[#867](https://github.com/KensioSoftware/yulin/issues/867) and worth 2 more resources.
+Both plans are at their ceiling. The two resources the module plan leaves are `null_resource` and
+`local_file`, which package a zip and belong to no AWS service.
 
 Both figures are asserted in `sim-tf-plan-report.loc.test.ts`, by the resource types each plan
 leaves unreached. A mapping that stops reaching a type fails there.

--- a/src/terraform/sim-tf-attribute-intrinsic.ts
+++ b/src/terraform/sim-tf-attribute-intrinsic.ts
@@ -1,0 +1,31 @@
+import type { SimCfnTemplateValue } from "../service/cloudformation/template/value/sim-cfn-template-value.js";
+import { terraformAttributeReads } from "./sim-tf-attribute-reads.js";
+
+/**
+ * The CloudFormation intrinsic that reads one Terraform attribute off the
+ * Resource standing in for the resource producing it.
+ *
+ * A reference naming a resource and no attribute is the resource itself, and
+ * a `Ref` is what CloudFormation answers that with. An attribute is read
+ * through whichever of `Ref` and `Fn::GetAtt` carries that value, which the
+ * read table says and the two services often disagree about. An attribute the
+ * table has no entry for answers with nothing.
+ */
+export function terraformAttributeIntrinsic(
+  type: string,
+  attribute: string | undefined,
+  logicalId: string,
+): SimCfnTemplateValue | undefined {
+  const read =
+    attribute === undefined
+      ? "Ref"
+      : terraformAttributeReads.get(`${type}.${attribute}`);
+
+  if (read === undefined) {
+    return undefined;
+  }
+
+  return read === "Ref"
+    ? { Ref: logicalId }
+    : { "Fn::GetAtt": [logicalId, read] };
+}

--- a/src/terraform/sim-tf-attributes.ts
+++ b/src/terraform/sim-tf-attributes.ts
@@ -75,7 +75,7 @@ function referencedValue(
   );
 
   for (const reference of references) {
-    const resolved = resolver.resolve(reference, resource.modulePath);
+    const resolved = resolver.resolve(reference, resource);
 
     if (resolved !== undefined) {
       return resolved;

--- a/src/terraform/sim-tf-declare.ts
+++ b/src/terraform/sim-tf-declare.ts
@@ -4,10 +4,8 @@
  * lookup. The records are parsed JSON with no prototype of their own.
  */
 // oxlint-disable security/detect-object-injection
-import { isRecord } from "../util/type-guard/record.js";
 import type { SimCfnTemplateValueRecord } from "../service/cloudformation/template/value/sim-cfn-template-value.js";
-import type { TerraformResource } from "./sim-tf-resource.type.js";
-import type { TerraformReferenceResolver } from "./sim-tf-reference.js";
+import { terraformDependsOn } from "./sim-tf-depends-on.js";
 import type { TerraformSettledPlan } from "./sim-tf-settle.js";
 import type {
   TerraformImportedResource,
@@ -62,56 +60,4 @@ export function terraformDeclaredResources(
   }
 
   return { templates, mapped, lost };
-}
-
-/**
- * The Resources one Resource has to be created after.
- *
- * A CloudFormation template orders itself, because a property that needs
- * another Resource holds a `Ref` or an `Fn::GetAtt` naming it. A plan holds no
- * such thing. Terraform resolves what it can before writing the plan, so a
- * Lambda permission naming a function it creates in the same plan carries the
- * function's name as a plain string, and the edge that ordering depends on is
- * gone from the value.
- *
- * The edge survives in `configuration`, which records every reference the
- * resource declares whether or not the value was resolved. Turning those back
- * into `DependsOn` gives the Stack the graph it would have read off a template
- * written by hand.
- */
-export function terraformDependsOn(
-  resource: TerraformResource,
-  resolver: TerraformReferenceResolver,
-): { DependsOn?: string[] } {
-  const own = resolver.logicalId(resource.address);
-
-  const referenced = [
-    ...resource.dependsOn,
-    ...expressionReferences(resource.expressions),
-  ]
-    .map((reference) => resolver.targetAddress(reference, resource.modulePath))
-    .filter((address): address is string => address !== undefined)
-    .map((address) => resolver.logicalId(address))
-    .filter((logicalId) => logicalId !== own);
-
-  const declared = [...new Set(referenced)];
-
-  return declared.length === 0 ? {} : { DependsOn: declared };
-}
-
-/** Every `references` entry anywhere inside a resource's expressions. */
-function expressionReferences(value: unknown): readonly string[] {
-  if (Array.isArray(value)) {
-    return value.flatMap((entry) => expressionReferences(entry));
-  }
-
-  if (!isRecord(value)) {
-    return [];
-  }
-
-  return Object.entries(value).flatMap(([key, nested]) =>
-    key === "references" && Array.isArray(nested)
-      ? nested.filter((entry): entry is string => typeof entry === "string")
-      : expressionReferences(nested),
-  );
 }

--- a/src/terraform/sim-tf-depends-on.ts
+++ b/src/terraform/sim-tf-depends-on.ts
@@ -1,0 +1,38 @@
+import type { TerraformResource } from "./sim-tf-resource.type.js";
+import type { TerraformReferenceResolver } from "./sim-tf-reference.js";
+import { terraformExpressionReferences } from "./sim-tf-expression-references.js";
+
+/**
+ * The Resources one Resource has to be created after.
+ *
+ * A CloudFormation template orders itself, because a property that needs
+ * another Resource holds a `Ref` or an `Fn::GetAtt` naming it. A plan holds no
+ * such thing. Terraform resolves what it can before writing the plan, so a
+ * Lambda permission naming a function it creates in the same plan carries the
+ * function's name as a plain string, and the edge that ordering depends on is
+ * gone from the value.
+ *
+ * The edge survives in `configuration`, which records every reference the
+ * resource declares whether or not the value was resolved. Turning those back
+ * into `DependsOn` gives the Stack the graph it would have read off a template
+ * written by hand.
+ */
+export function terraformDependsOn(
+  resource: TerraformResource,
+  resolver: TerraformReferenceResolver,
+): { DependsOn?: string[] } {
+  const own = resolver.logicalId(resource.address);
+
+  const referenced = [
+    ...resource.dependsOn,
+    ...terraformExpressionReferences(resource.expressions),
+  ]
+    .map((reference) => resolver.targetAddress(reference, resource))
+    .filter((address): address is string => address !== undefined)
+    .map((address) => resolver.logicalId(address))
+    .filter((logicalId) => logicalId !== own);
+
+  const declared = [...new Set(referenced)];
+
+  return declared.length === 0 ? {} : { DependsOn: declared };
+}

--- a/src/terraform/sim-tf-expression-references.ts
+++ b/src/terraform/sim-tf-expression-references.ts
@@ -1,0 +1,28 @@
+import { isRecord } from "../util/type-guard/record.js";
+
+/**
+ * Every `references` entry anywhere inside an expression.
+ *
+ * A plan writes an expression as a record holding `references`, and nests
+ * that record wherever the configuration nested the expression. A nested block
+ * becomes a list of records, and a block inside a block becomes a list inside
+ * a record, so reaching every reference means walking whatever shape the
+ * configuration had rather than reading one key.
+ */
+export function terraformExpressionReferences(
+  value: unknown,
+): readonly string[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => terraformExpressionReferences(entry));
+  }
+
+  if (!isRecord(value)) {
+    return [];
+  }
+
+  return Object.entries(value).flatMap(([key, nested]) =>
+    key === "references" && Array.isArray(nested)
+      ? nested.filter((entry): entry is string => typeof entry === "string")
+      : terraformExpressionReferences(nested),
+  );
+}

--- a/src/terraform/sim-tf-module-outputs.ts
+++ b/src/terraform/sim-tf-module-outputs.ts
@@ -2,6 +2,14 @@ import type {
   TerraformConfigModule,
   TerraformPlan,
 } from "./sim-tf-plan.type.js";
+import type { TerraformResource } from "./sim-tf-resource.type.js";
+import type { TerraformResourceAddresses } from "./sim-tf-reference-addresses.js";
+import {
+  longestFirst,
+  moduleOutputPath,
+  qualifiedReference,
+  withoutInstanceKeys,
+} from "./sim-tf-reference-address.js";
 
 /**
  * Every module output a plan declares, keyed by the address that reads it.
@@ -48,5 +56,82 @@ function collect(
     }
 
     collect(child, childPath, outputs);
+  }
+}
+
+/** How far a chain of outputs is followed before it is taken to be a loop. */
+const outputLimit = 8;
+
+/**
+ * Following a reference that names a module output.
+ *
+ * `module.processor.lambda_function_arn` is an address no resource has. The
+ * output's own expression names what it reads, in terms of the module
+ * declaring it, so following one is resolving that expression again a module
+ * down.
+ */
+export class TerraformModuleOutputWalk {
+  constructor(
+    private readonly outputs: ReadonlyMap<string, readonly string[]>,
+    private readonly resources: TerraformResourceAddresses,
+  ) {}
+
+  /**
+   * The resource a module output leads to.
+   *
+   * An output built out of several resources answers with the first that
+   * resolves, and the depth limit stops a module whose outputs refer to each
+   * other from looping.
+   */
+  public target(qualified: string, depth = 0): TerraformResource | undefined {
+    const output = this.references(qualified);
+
+    if (output === undefined || depth >= outputLimit) {
+      return undefined;
+    }
+
+    // The path the output was read through rather than the one it was
+    // declared under, so an output reached inside a `for_each` instance
+    // follows its own instance's resources.
+    const instance = moduleOutputPath(qualified);
+
+    for (const reference of longestFirst(output)) {
+      const nested = qualifiedReference(reference, instance);
+      const target =
+        this.resources.longestMatch(nested) ?? this.target(nested, depth + 1);
+
+      if (target !== undefined) {
+        return target;
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
+   * The attribute a reference through an output reads.
+   *
+   * The reference names the output, and the output's own expression is what
+   * says which attribute of the resource behind it was being read.
+   */
+  public attributeOf(qualified: string): string | undefined {
+    const [longest] = longestFirst(this.references(qualified) ?? []);
+
+    return longest?.split(".").pop();
+  }
+
+  /**
+   * The references one output declares.
+   *
+   * The index is keyed by module call path, since a module declares its
+   * outputs once however many instances of the call there are. A reference
+   * made from inside one instance carries that instance's key, so the key
+   * comes off when the qualified form finds nothing.
+   */
+  private references(qualified: string): readonly string[] | undefined {
+    return (
+      this.outputs.get(qualified) ??
+      this.outputs.get(withoutInstanceKeys(qualified))
+    );
   }
 }

--- a/src/terraform/sim-tf-module-variables.iso.test.ts
+++ b/src/terraform/sim-tf-module-variables.iso.test.ts
@@ -1,0 +1,102 @@
+import { describe, it } from "vitest";
+import {
+  assertArrayEquals,
+  assertMapSize,
+  assertUndefined,
+} from "@kensio/smartass";
+import { terraformModuleVariables } from "./sim-tf-module-variables.js";
+
+describe("indexing the variables a plan's module calls set", () => {
+  it("indexes nothing for a plan holding no configuration", () => {
+    // Given a plan document with no configuration section
+    // When its module variables are indexed
+    // Then there are none, rather than an error
+    assertMapSize(terraformModuleVariables({}), 0);
+  });
+
+  it("indexes what a call set a variable to", () => {
+    // Given a call setting a variable from another module's output
+    const plan = {
+      configuration: {
+        root_module: {
+          module_calls: {
+            api: {
+              module: {},
+              expressions: {
+                routes: {
+                  references: [
+                    "module.processor.lambda_function_arn",
+                    "module.processor",
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    // When the variables are indexed
+    // Then the references the caller wrote are filed under the call path, so a
+    // resource inside the module can find what its own `var.routes` holds
+    assertArrayEquals(
+      terraformModuleVariables(plan).get("module.api.var.routes"),
+      ["module.processor.lambda_function_arn", "module.processor"],
+    );
+  });
+
+  it("indexes a variable set to a constant as referring to nothing", () => {
+    // Given a call setting a variable to a literal
+    const plan = {
+      configuration: {
+        root_module: {
+          module_calls: {
+            api: { expressions: { name: { constant_value: "orders-api" } } },
+          },
+        },
+      },
+    };
+
+    // When the variables are indexed
+    // Then the variable is there and refers to nothing. Terraform resolved the
+    // value itself, and a resource reading it needs no reference followed
+    assertArrayEquals(
+      terraformModuleVariables(plan).get("module.api.var.name"),
+      [],
+    );
+  });
+
+  it("indexes a variable of a call made by another module", () => {
+    // Given a module whose own call sets a variable of the module below it
+    const plan = {
+      configuration: {
+        root_module: {
+          module_calls: {
+            platform: {
+              module: {
+                module_calls: {
+                  api: {
+                    expressions: { routes: { references: ["var.routes"] } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    // When the variables are indexed
+    // Then the nested call is filed under its full path, and what it was set
+    // from is itself a variable of the module making the call
+    assertArrayEquals(
+      terraformModuleVariables(plan).get(
+        "module.platform.module.api.var.routes",
+      ),
+      ["var.routes"],
+    );
+    assertUndefined(
+      terraformModuleVariables(plan).get("module.api.var.routes"),
+    );
+  });
+});

--- a/src/terraform/sim-tf-module-variables.ts
+++ b/src/terraform/sim-tf-module-variables.ts
@@ -1,0 +1,57 @@
+import type {
+  TerraformConfigModule,
+  TerraformPlan,
+} from "./sim-tf-plan.type.js";
+import { terraformExpressionReferences } from "./sim-tf-expression-references.js";
+
+/**
+ * Every variable a module call sets, keyed by the address that names it.
+ *
+ * A resource inside a module reads its module's own variables, and the value
+ * behind one was written by the caller. `var.routes` is not an address any
+ * resource has and the plan resolves nothing for it, so following it means
+ * reading the call's own expression and continuing from the module that made
+ * the call.
+ *
+ * This is the mirror of `terraformModuleOutputs`. An output carries a value up
+ * out of a module and a variable carries one down into it, and the two are the
+ * only ways a plan lets a reference cross a module boundary.
+ */
+export function terraformModuleVariables(
+  plan: TerraformPlan,
+): ReadonlyMap<string, readonly string[]> {
+  const variables = new Map<string, readonly string[]>();
+  const root = plan.configuration?.root_module;
+
+  if (root !== undefined) {
+    collect(root, [], variables);
+  }
+
+  return variables;
+}
+
+function collect(
+  config: TerraformConfigModule,
+  modulePath: readonly string[],
+  variables: Map<string, readonly string[]>,
+): void {
+  const calls = Object.entries(config.module_calls ?? {});
+
+  for (const [callName, call] of calls) {
+    const childPath = [...modulePath, callName];
+    const address = childPath.map((name) => `module.${name}`).join(".");
+
+    const set = Object.entries(call.expressions ?? {});
+
+    for (const [name, expression] of set) {
+      variables.set(
+        `${address}.var.${name}`,
+        terraformExpressionReferences(expression),
+      );
+    }
+
+    if (call.module !== undefined) {
+      collect(call.module, childPath, variables);
+    }
+  }
+}

--- a/src/terraform/sim-tf-nested-attributes.ts
+++ b/src/terraform/sim-tf-nested-attributes.ts
@@ -51,7 +51,7 @@ export function attributeList(
   const declared = longestFirst(references(resource.expressions[key]));
 
   for (const reference of declared) {
-    const value = resolver.resolve(reference, resource.modulePath);
+    const value = resolver.resolve(reference, resource);
 
     if (value !== undefined) {
       resolved.set(JSON.stringify(value), value);
@@ -85,7 +85,7 @@ export function blockAttribute(
   const declared = longestFirst(references(expression));
 
   for (const reference of declared) {
-    const value = resolver.resolve(reference, resource.modulePath);
+    const value = resolver.resolve(reference, resource);
 
     if (value !== undefined) {
       return value;

--- a/src/terraform/sim-tf-plan-report.loc.test.ts
+++ b/src/terraform/sim-tf-plan-report.loc.test.ts
@@ -24,19 +24,13 @@ import type { TerraformImportReport } from "./sim-tf-report.type.js";
 /**
  * What each configuration leaves unreached, by configuration name.
  *
- * The application configuration leaves nothing. The modules configuration
- * packages its zip with `null_resource` and `local_file`, which belong to no
- * AWS service, and its integration and route read their values through an
- * `each.value` hop this import does not follow.
+ * Both are at their ceiling. The application configuration leaves nothing, and
+ * the modules configuration packages its zip with `null_resource` and
+ * `local_file`, which belong to no AWS service and no import can reach.
  */
 const unreachedTypes: Record<string, readonly string[]> = {
   app: [],
-  modules: [
-    "aws_apigatewayv2_integration",
-    "aws_apigatewayv2_route",
-    "local_file",
-    "null_resource",
-  ],
+  modules: ["local_file", "null_resource"],
 };
 
 /** The report each committed configuration's plan deploys to. */

--- a/src/terraform/sim-tf-plan-resources.ts
+++ b/src/terraform/sim-tf-plan-resources.ts
@@ -12,6 +12,7 @@ import type {
   TerraformPlannedResource,
 } from "./sim-tf-plan.type.js";
 import type { TerraformResource } from "./sim-tf-resource.type.js";
+import { terraformExpressionReferences } from "./sim-tf-expression-references.js";
 import {
   childModuleCallName,
   childModuleSegment,
@@ -98,6 +99,7 @@ function joined(
     unknown: unknown.get(resource.address) ?? {},
     expressions: config?.expressions ?? {},
     dependsOn: config?.depends_on ?? [],
+    forEach: terraformExpressionReferences(config?.for_each_expression),
     modulePath,
   };
 }

--- a/src/terraform/sim-tf-plan-services.loc.test.ts
+++ b/src/terraform/sim-tf-plan-services.loc.test.ts
@@ -11,11 +11,13 @@ import {
   terraformPlanHandlers as handlersFor,
   terraformPlannedPath as plannedPath,
 } from "../../test/terraform/plan/terraform-planned-configuration.js";
+import { GetApisCommand } from "@aws-sdk/client-apigatewayv2";
+import { serveSimAws } from "../serve/index.js";
 import { TerraformAdapter } from "./sim-tf-adapter.js";
 
 /*
- * What the application configuration under `test/terraform/app` reaches, one
- * simulated service at a time.
+ * What the configurations under `test/terraform` reach, one simulated service
+ * at a time.
  *
  * The deployment itself is covered beside this. These say that a resource the
  * import mapped is a resource the service it belongs to went on to create, and
@@ -106,5 +108,59 @@ describe("deploying a plan into the services it names", () => {
 
     assertNonNullable(table);
     assertIdentical(table.billing.mode, "PROVISIONED");
+  });
+
+  it("routes a request through the HTTP API a community module built", async () => {
+    // Given the community-module configuration, whose API module builds its
+    // integration and its route with for_each over a routes variable the
+    // caller set from the Lambda module's own output. Nothing in the plan
+    // resolves that URI, because the function has yet to exist
+    const simAws = new SimAws();
+    const received: string[] = [];
+
+    // When the plan is deployed and the API is served on localhost
+    await new TerraformAdapter(simAws).deployPlan({
+      planPath: await plannedPath("modules"),
+      stackName: "routed-modules",
+      bindings: [
+        {
+          functionName: "orders-processor-independent",
+          handler: (event: { rawPath?: string }) => {
+            received.push(event.rawPath ?? "");
+
+            return {
+              statusCode: 201,
+              headers: { "content-type": "text/plain" },
+              body: "ordered",
+            };
+          },
+        },
+      ],
+    });
+
+    const { Items } = await simAws
+      .apiGatewayV2()
+      .getApis(new GetApisCommand({}));
+    const endpoint = Items.find(
+      (item) => item.Name === "orders-api-independent",
+    )?.ApiEndpoint;
+
+    assertNonNullable(endpoint);
+
+    const srv = await serveSimAws({ simAws });
+
+    try {
+      // And a request is made to the route the module declared
+      const response = await fetch(srv.localUrl(`${endpoint}/orders`), {
+        method: "POST",
+      });
+
+      // Then it reached the function the routes variable named
+      assertIdentical(response.status, 201);
+      assertIdentical(await response.text(), "ordered");
+      assertArrayEquals(received, ["/orders"]);
+    } finally {
+      await srv.close();
+    }
   });
 });

--- a/src/terraform/sim-tf-plan.type.ts
+++ b/src/terraform/sim-tf-plan.type.ts
@@ -69,10 +69,20 @@ export interface TerraformResourceChange {
 export interface TerraformConfigModule {
   readonly resources?: readonly TerraformConfigResource[];
   readonly outputs?: Record<string, TerraformConfigOutput>;
-  readonly module_calls?: Record<
-    string,
-    { readonly module?: TerraformConfigModule }
-  >;
+  readonly module_calls?: Record<string, TerraformConfigModuleCall>;
+}
+
+/**
+ * One `module` block, holding the module it calls and what it sets on it.
+ *
+ * `expressions` is keyed by variable name and holds what the caller wrote for
+ * each one, in the same shape a resource attribute's expression takes. A
+ * variable set from a resource of the calling module carries the reference
+ * rather than a value.
+ */
+export interface TerraformConfigModuleCall {
+  readonly module?: TerraformConfigModule;
+  readonly expressions?: Record<string, unknown>;
 }
 
 export interface TerraformConfigResource {
@@ -82,6 +92,13 @@ export interface TerraformConfigResource {
   readonly name: string;
   readonly expressions?: Record<string, unknown>;
   readonly depends_on?: readonly string[];
+  /**
+   * What `for_each` iterates, as the references its expression holds.
+   *
+   * `planned_values` carries the instances rather than the collection, so this
+   * is the only place a plan says what `each` was iterating.
+   */
+  readonly for_each_expression?: unknown;
 }
 
 export interface TerraformConfigOutput {

--- a/src/terraform/sim-tf-reference-addresses.ts
+++ b/src/terraform/sim-tf-reference-addresses.ts
@@ -1,0 +1,105 @@
+import type { TerraformResource } from "./sim-tf-resource.type.js";
+
+/**
+ * The resources a template will declare, looked up by the addresses that name
+ * them.
+ *
+ * A reference is text, and finding the resource behind it is a search over
+ * addresses rather than a lookup, because the reference carries the attribute
+ * being read and may leave out the instance key. Both searches are here, away
+ * from the resolver deciding what to do with what they find.
+ */
+export class TerraformResourceAddresses {
+  private readonly byAddress: ReadonlyMap<string, TerraformResource>;
+
+  constructor(resources: readonly TerraformResource[]) {
+    this.byAddress = new Map(
+      resources.map((resource) => [resource.address, resource]),
+    );
+  }
+
+  /**
+   *
+   */
+  /** Every address this template will declare a Resource under. */
+  public addresses(): Iterable<string> {
+    return this.byAddress.keys();
+  }
+
+  /**
+   *
+   */
+  /** The resource one address names exactly. */
+  public get(address: string): TerraformResource | undefined {
+    return this.byAddress.get(address);
+  }
+
+  /**
+   * The resource whose address is the longest prefix of this reference.
+   *
+   * `aws_iam_role.processor.arn` has to find `aws_iam_role.processor` and leave
+   * `arn` behind, and a `for_each` instance address carries a bracketed key
+   * that is part of the address rather than an attribute.
+   */
+  public longestMatch(qualified: string): TerraformResource | undefined {
+    let best: TerraformResource | undefined;
+
+    for (const [address, resource] of this.byAddress) {
+      if (qualified !== address && !qualified.startsWith(`${address}.`)) {
+        continue;
+      }
+
+      if (best === undefined || address.length > best.address.length) {
+        best = resource;
+      }
+    }
+
+    return best;
+  }
+
+  /**
+   * One instance of a resource a reference named without its key.
+   *
+   * `aws_apigatewayv2_integration.this[each.key]` is written into a plan as a
+   * reference to `aws_apigatewayv2_integration.this` and a separate reference
+   * to `each.key`, so the address in hand names no instance. The instance
+   * meant is the one keyed like the resource doing the reading, since that is
+   * what `each.key` holds there, and a resource with one instance and no key
+   * to go on has only the one it could mean.
+   */
+  public instance(
+    qualified: string,
+    index: string | number | undefined,
+  ): string | undefined {
+    const keyed = instanceAddress(qualified, index);
+
+    if (keyed !== undefined && this.byAddress.has(keyed)) {
+      return keyed;
+    }
+
+    return this.soleInstance(qualified);
+  }
+
+  private soleInstance(qualified: string): string | undefined {
+    const instances = this.byAddress
+      .keys()
+      .filter((address) => address.startsWith(`${qualified}[`))
+      .toArray();
+
+    return instances.length === 1 ? instances[0] : undefined;
+  }
+}
+
+/** One address written with the `count` or `for_each` key of an instance. */
+function instanceAddress(
+  qualified: string,
+  index: string | number | undefined,
+): string | undefined {
+  if (index === undefined) {
+    return undefined;
+  }
+
+  return typeof index === "number"
+    ? `${qualified}[${index}]`
+    : `${qualified}["${index}"]`;
+}

--- a/src/terraform/sim-tf-reference-scope.iso.test.ts
+++ b/src/terraform/sim-tf-reference-scope.iso.test.ts
@@ -1,0 +1,236 @@
+import { describe, it } from "vitest";
+import { assertObjectEquals, assertUndefined } from "@kensio/smartass";
+import {
+  terraformPlanFactory,
+  terraformPlanModuleFactory,
+  terraformPlanResourceFactory,
+  type TerraformPlanFixture,
+} from "../../test/terraform/plan/terraform-plan.factory.js";
+import { terraformResourceFactory } from "../../test/terraform/plan/terraform-resource.factory.js";
+import type { TerraformResource } from "./sim-tf-resource.type.js";
+import { terraformPlanResources } from "./sim-tf-plan-resources.js";
+import { terraformModuleOutputs } from "./sim-tf-module-outputs.js";
+import { terraformModuleVariables } from "./sim-tf-module-variables.js";
+import { TerraformReferenceResolver } from "./sim-tf-reference.js";
+
+/*
+ * Resolving a reference that names no address of its own.
+ *
+ * A reference under `each` or `var` is written somewhere else in the plan, and
+ * an instance key left to `each.key` is written nowhere at all. These are the
+ * hops that find the resource behind one, and the shapes where a plan holds
+ * too little to say which resource that is.
+ */
+
+/** A resolver over the resources one plan fixture declares. */
+function resolverFor(
+  fixture: Partial<TerraformPlanFixture>,
+): TerraformReferenceResolver {
+  const plan = terraformPlanFactory.make(fixture);
+
+  return new TerraformReferenceResolver(
+    terraformPlanResources(plan),
+    terraformModuleOutputs(plan),
+    terraformModuleVariables(plan),
+  );
+}
+
+/** The resource a reference is read from. */
+function readingFrom(
+  modulePath: readonly string[] = [],
+  properties: Partial<TerraformResource> = {},
+): TerraformResource {
+  return terraformResourceFactory.make({ modulePath, ...properties });
+}
+
+describe("following a reference through a scope the plan resolves itself", () => {
+  it("follows each.value to what the collection was built from", () => {
+    // Given a module whose caller set its routes variable from a sibling
+    // module's function ARN, and a resource inside it expanded by for_each
+    // over that variable. Nothing in the plan resolves each.value.uri, because
+    // the function has yet to exist
+    const resolver = resolverFor({
+      modules: [processorModule(), apiModule("processor")],
+    });
+
+    // When the integration's URI is resolved
+    const resolved = resolver.resolve(
+      "each.value.uri",
+      readingFrom(["api"], { forEach: ["var.routes"] }),
+    );
+
+    // Then it reaches the function, through the for_each collection, the
+    // module variable and the module output behind it
+    assertObjectEquals(resolved, {
+      "Fn::GetAtt": ["ModuleProcessorAwsLambdaFunctionThis", "Arn"],
+    });
+  });
+
+  it("refuses a collection that names more than one resource", () => {
+    // Given the same shape, with the routes variable set from two functions.
+    // A plan records the references of a whole collection as one list, and
+    // says nothing about which route holds which of them
+    const resolver = resolverFor({
+      modules: [
+        processorModule(),
+        processorModule("reporter"),
+        apiModule("processor", "reporter"),
+      ],
+    });
+
+    // When the integration's URI is resolved
+    // Then nothing comes back. Either function is plausible and the plan does
+    // not say which, and a property naming the wrong one is worse than a
+    // property that is not there
+    assertUndefined(
+      resolver.resolve(
+        "each.value.uri",
+        readingFrom(["api"], { forEach: ["var.routes"] }),
+      ),
+    );
+  });
+
+  it("leaves each alone for a resource iterating nothing", () => {
+    // Given a resource that was not expanded by for_each
+    const resolver = resolverFor({
+      modules: [processorModule(), apiModule("processor")],
+    });
+
+    // When a reference under each is resolved from it
+    // Then nothing comes back, because there is no collection to read
+    assertUndefined(resolver.resolve("each.value.uri", readingFrom(["api"])));
+  });
+
+  it("resolves nothing for a variable of the root module", () => {
+    // Given a resource of the root module reading a variable. A root variable
+    // was set on the command line or in a tfvars file, and no module call
+    // holds what it was set from
+    const resolver = resolverFor({ modules: [processorModule()] });
+
+    // When the reference is resolved
+    // Then nothing comes back
+    assertUndefined(resolver.resolve("var.uri", readingFrom()));
+  });
+
+  it("stops following a variable a module sets from itself", () => {
+    // Given a call setting a module's own variable from a variable of the
+    // same name, which is the shape that leads nowhere new
+    const resolver = resolverFor({
+      modules: [
+        terraformPlanModuleFactory.make({
+          name: "api",
+          variables: { routes: ["var.routes"] },
+        }),
+      ],
+    });
+
+    // When it is resolved
+    // Then it stops rather than following itself forever
+    assertUndefined(resolver.resolve("var.routes", readingFrom(["api"])));
+  });
+});
+
+describe("resolving a reference to an instance named without its key", () => {
+  it("reads the instance keyed like the resource doing the reading", () => {
+    // Given two integrations expanded by for_each over a routes map, and a
+    // route expanded over the same map. Terraform writes
+    // `integration.this[each.key]` into a plan as a reference to the resource
+    // and a separate reference to each.key, so the address names no instance
+    const resolver = resolverFor({
+      resources: [
+        integrationInstance("POST /orders"),
+        integrationInstance("GET /orders"),
+      ],
+    });
+
+    // When the route resolves it from its own instance
+    const resolved = resolver.resolve(
+      "aws_apigatewayv2_integration.this",
+      readingFrom([], { index: "GET /orders" }),
+    );
+
+    // Then it is the integration of the same key, rather than either of them
+    assertObjectEquals(resolved, {
+      Ref: "AwsApigatewayv2IntegrationThisGETOrders",
+    });
+  });
+
+  it("reads the only instance where the reader has no key of its own", () => {
+    // Given a module created with count = 1, whose one resource carries the
+    // index in its address, referred to by a resource that has no index
+    const resolver = resolverFor({
+      resources: [integrationInstance("POST /orders")],
+    });
+
+    // When the reference is resolved
+    // Then it reaches the one instance it could mean
+    assertObjectEquals(
+      resolver.resolve("aws_apigatewayv2_integration.this", readingFrom()),
+      { Ref: "AwsApigatewayv2IntegrationThisPOSTOrders" },
+    );
+  });
+
+  it("resolves nothing where more than one instance could be meant", () => {
+    // Given two instances and a reader whose own key matches neither
+    const resolver = resolverFor({
+      resources: [
+        integrationInstance("POST /orders"),
+        integrationInstance("GET /orders"),
+      ],
+    });
+
+    // When the reference is resolved
+    // Then nothing comes back rather than whichever instance came first
+    assertUndefined(
+      resolver.resolve(
+        "aws_apigatewayv2_integration.this",
+        readingFrom([], { index: "DELETE /orders" }),
+      ),
+    );
+  });
+});
+
+/** A Lambda module publishing its function's ARN, as the community one does. */
+function processorModule(
+  name = "processor",
+): ReturnType<typeof terraformPlanModuleFactory.make> {
+  return terraformPlanModuleFactory.make({
+    name,
+    resources: [
+      terraformPlanResourceFactory.make({
+        type: "aws_lambda_function",
+        name: "this",
+        address: "aws_lambda_function.this",
+      }),
+    ],
+    outputs: { lambda_function_arn: ["aws_lambda_function.this.arn"] },
+  });
+}
+
+/**
+ * An API module whose caller set its routes variable, from the functions
+ * named. One function is the shape a plan can answer for, and two is the shape
+ * it cannot.
+ */
+function apiModule(
+  ...functions: readonly string[]
+): ReturnType<typeof terraformPlanModuleFactory.make> {
+  return terraformPlanModuleFactory.make({
+    name: "api",
+    variables: {
+      routes: functions.map((name) => `module.${name}.lambda_function_arn`),
+    },
+  });
+}
+
+/** One integration of a resource expanded by for_each over a routes map. */
+function integrationInstance(
+  key: string,
+): ReturnType<typeof terraformPlanResourceFactory.make> {
+  return terraformPlanResourceFactory.make({
+    type: "aws_apigatewayv2_integration",
+    name: "this",
+    index: key,
+    address: `aws_apigatewayv2_integration.this["${key}"]`,
+  });
+}

--- a/src/terraform/sim-tf-reference-scope.ts
+++ b/src/terraform/sim-tf-reference-scope.ts
@@ -1,0 +1,102 @@
+import type { TerraformResource } from "./sim-tf-resource.type.js";
+import {
+  longestFirst,
+  withoutInstanceKeys,
+} from "./sim-tf-reference-address.js";
+
+/** One reference to follow, and the module its own references are written in. */
+export interface TerraformScopeHop {
+  readonly reference: string;
+  readonly modulePath: readonly string[];
+}
+
+/**
+ * What a reference Terraform resolves for itself stands in for.
+ *
+ * `each.value.uri` and `var.routes` name no address, and a plan resolves
+ * neither to a value where the value is not known yet. What a plan does record
+ * is where each one was written from. A `for_each` expression says what the
+ * collection was built out of, and a module call says what the caller set each
+ * variable to, so following one of these is following a reference written
+ * somewhere else.
+ *
+ * The step is a rewrite rather than an evaluation. `each.value.uri` becomes
+ * the references of the collection `each` iterates, in the module that
+ * declared the resource, and `var.routes` becomes the references of the module
+ * call, in the module that made it.
+ *
+ * What is lost either way is which part of the collection was being read.
+ * A plan records the references of a `routes` map as one list, with nothing to
+ * say which route or which of its keys each one belongs to, so `each.value.uri`
+ * and `each.value.timeout_milliseconds` are written down identically. The
+ * caller is what decides that an ambiguous answer is no answer.
+ */
+export function terraformScopeHops(
+  reference: string,
+  modulePath: readonly string[],
+  from: TerraformResource,
+  moduleVariables: ReadonlyMap<string, readonly string[]>,
+  depth: number,
+): readonly TerraformScopeHop[] {
+  if (reference.startsWith("each.")) {
+    return eachHops(modulePath, from, depth);
+  }
+
+  if (reference.startsWith("var.")) {
+    return variableHops(reference, modulePath, moduleVariables);
+  }
+
+  return [];
+}
+
+/**
+ * The collection `each` iterates, read from the resource doing the reading.
+ *
+ * Only the resource whose own expression held the reference has an `each` to
+ * read, which is the reference at depth zero. A reference reached by an
+ * earlier hop was written in another module, against another resource's
+ * collection, and is left alone.
+ */
+function eachHops(
+  modulePath: readonly string[],
+  from: TerraformResource,
+  depth: number,
+): readonly TerraformScopeHop[] {
+  if (depth > 0) {
+    return [];
+  }
+
+  return longestFirst(from.forEach).map((reference) => ({
+    reference,
+    modulePath,
+  }));
+}
+
+/**
+ * What the caller set one of a module's variables to.
+ *
+ * The index is keyed by call path, since a module declares its variables once
+ * however many instances of the call there are, and the references the caller
+ * wrote are relative to the module holding the call.
+ */
+function variableHops(
+  reference: string,
+  modulePath: readonly string[],
+  moduleVariables: ReadonlyMap<string, readonly string[]>,
+): readonly TerraformScopeHop[] {
+  if (modulePath.length === 0) {
+    return [];
+  }
+
+  const call = modulePath
+    .map((name) => `module.${withoutInstanceKeys(name)}`)
+    .join(".");
+  const name = reference.split(".", 2)[1] ?? "";
+  const set = moduleVariables.get(`${call}.var.${name}`) ?? [];
+  const caller = modulePath.slice(0, -1);
+
+  return longestFirst(set).map((written) => ({
+    reference: written,
+    modulePath: caller,
+  }));
+}

--- a/src/terraform/sim-tf-reference.iso.test.ts
+++ b/src/terraform/sim-tf-reference.iso.test.ts
@@ -10,10 +10,25 @@ import {
   terraformPlanResourceFactory,
   type TerraformPlanFixture,
 } from "../../test/terraform/plan/terraform-plan.factory.js";
+import { terraformResourceFactory } from "../../test/terraform/plan/terraform-resource.factory.js";
+import type { TerraformResource } from "./sim-tf-resource.type.js";
 import { terraformPlanResources } from "./sim-tf-plan-resources.js";
 import { terraformModuleOutputs } from "./sim-tf-module-outputs.js";
+import { terraformModuleVariables } from "./sim-tf-module-variables.js";
 import { TerraformReferenceResolver } from "./sim-tf-reference.js";
 import { qualifiedReference } from "./sim-tf-reference-address.js";
+
+/**
+ * The resource a reference is read from, where only the module it sits in
+ * matters. Every reference is written somewhere, and the resolver reads what
+ * `each` iterates and which instance is meant off the resource that wrote it.
+ */
+function readingFrom(
+  modulePath: readonly string[] = [],
+  properties: Partial<TerraformResource> = {},
+): TerraformResource {
+  return terraformResourceFactory.make({ modulePath, ...properties });
+}
 
 /** A resolver over the resources one plan fixture declares. */
 function resolverFor(
@@ -24,6 +39,7 @@ function resolverFor(
   return new TerraformReferenceResolver(
     terraformPlanResources(plan),
     terraformModuleOutputs(plan),
+    terraformModuleVariables(plan),
   );
 }
 
@@ -66,7 +82,10 @@ describe("resolving a Terraform reference against the resources of a plan", () =
     });
 
     // When a reference to the queue's ARN is resolved
-    const resolved = resolver.resolve("aws_sqs_queue.orders.arn", []);
+    const resolved = resolver.resolve(
+      "aws_sqs_queue.orders.arn",
+      readingFrom(),
+    );
 
     // Then it is the Fn::GetAtt CloudFormation reads that ARN with
     assertObjectEquals(resolved, {
@@ -82,9 +101,12 @@ describe("resolving a Terraform reference against the resources of a plan", () =
 
     // When a reference naming the resource itself is resolved
     // Then it is the Ref, which for a queue is its URL
-    assertObjectEquals(resolver.resolve("aws_sqs_queue.orders", []), {
-      Ref: "AwsSqsQueueOrders",
-    });
+    assertObjectEquals(
+      resolver.resolve("aws_sqs_queue.orders", readingFrom()),
+      {
+        Ref: "AwsSqsQueueOrders",
+      },
+    );
   });
 
   it("reads an attribute whose Ref is not the same value as CloudFormation's", () => {
@@ -102,9 +124,12 @@ describe("resolving a Terraform reference against the resources of a plan", () =
     // When the ARN is resolved
     // Then it comes back as a Ref rather than an Fn::GetAtt, because the two
     // services disagree about which value a Ref answers with
-    assertObjectEquals(resolver.resolve("aws_sns_topic.events.arn", []), {
-      Ref: "AwsSnsTopicEvents",
-    });
+    assertObjectEquals(
+      resolver.resolve("aws_sns_topic.events.arn", readingFrom()),
+      {
+        Ref: "AwsSnsTopicEvents",
+      },
+    );
   });
 
   it("resolves a reference made inside a module against that module", () => {
@@ -127,7 +152,7 @@ describe("resolving a Terraform reference against the resources of a plan", () =
     // When the reference is resolved from inside that module
     // Then it reaches the resource planned_values addressed with the prefix
     assertObjectEquals(
-      resolver.resolve("aws_sqs_queue.this.arn", ["processing"]),
+      resolver.resolve("aws_sqs_queue.this.arn", readingFrom(["processing"])),
       { "Fn::GetAtt": ["ModuleProcessingAwsSqsQueueThis", "Arn"] },
     );
   });
@@ -150,7 +175,10 @@ describe("resolving a Terraform reference against the resources of a plan", () =
     });
 
     // When the root module's reference to that output is resolved
-    const resolved = resolver.resolve("module.processing.queue_arn", []);
+    const resolved = resolver.resolve(
+      "module.processing.queue_arn",
+      readingFrom(),
+    );
 
     // Then it reads the attribute the output's own expression names, off the
     // Resource the module's queue became. No address of the plan is
@@ -178,9 +206,10 @@ describe("resolving a Terraform reference against the resources of a plan", () =
     });
 
     // When a sibling of that queue resolves a reference to it
-    const resolved = resolver.resolve("aws_sqs_queue.this.arn", [
-      'workers["blue"]',
-    ]);
+    const resolved = resolver.resolve(
+      "aws_sqs_queue.this.arn",
+      readingFrom(['workers["blue"]']),
+    );
 
     // Then it reaches the instance's own queue. Every address under the module
     // carries the key, so a reference qualified without it reaches nothing
@@ -196,8 +225,12 @@ describe("resolving a Terraform reference against the resources of a plan", () =
     // When a reference to it is resolved
     // Then nothing comes back, rather than an intrinsic naming a logical ID
     // the template never declares
-    assertUndefined(resolver.resolve("aws_sqs_queue.orders.arn", []));
-    assertUndefined(resolver.targetAddress("aws_sqs_queue.orders.arn", []));
+    assertUndefined(
+      resolver.resolve("aws_sqs_queue.orders.arn", readingFrom()),
+    );
+    assertUndefined(
+      resolver.targetAddress("aws_sqs_queue.orders.arn", readingFrom()),
+    );
   });
 
   it("resolves nothing for an attribute with no way to read it", () => {
@@ -209,7 +242,9 @@ describe("resolving a Terraform reference against the resources of a plan", () =
 
     // When the reference is resolved
     // Then nothing comes back, and the mapping decides what that means
-    assertUndefined(resolver.resolve("aws_sqs_queue.orders.policy", []));
+    assertUndefined(
+      resolver.resolve("aws_sqs_queue.orders.policy", readingFrom()),
+    );
   });
 
   it("names the resource a reference points at, for a caller that wants it", () => {
@@ -222,7 +257,7 @@ describe("resolving a Terraform reference against the resources of a plan", () =
     // Then the address comes back, which is what a fold merging into that
     // resource needs rather than the value read off it
     assertIdentical(
-      resolver.targetAddress("aws_sqs_queue.orders.arn", []),
+      resolver.targetAddress("aws_sqs_queue.orders.arn", readingFrom()),
       "aws_sqs_queue.orders",
     );
   });
@@ -242,7 +277,9 @@ describe("resolving a reference through module outputs", () => {
 
     // When the output is resolved
     // Then nothing comes back, since no resource of the plan is behind it
-    assertUndefined(resolver.resolve("module.processing.queue_name", []));
+    assertUndefined(
+      resolver.resolve("module.processing.queue_name", readingFrom()),
+    );
   });
 
   it("follows an output read from inside a for_each module instance", () => {
@@ -269,9 +306,10 @@ describe("resolving a reference through module outputs", () => {
     });
 
     // When the output is resolved from inside the instance
-    const resolved = resolver.resolve("module.queue.queue_arn", [
-      'workers["blue"]',
-    ]);
+    const resolved = resolver.resolve(
+      "module.queue.queue_arn",
+      readingFrom(['workers["blue"]']),
+    );
 
     // Then it is found. A module declares its outputs once however many
     // instances the call has, so the index is keyed without the key
@@ -296,6 +334,8 @@ describe("resolving a reference through module outputs", () => {
 
     // When it is resolved
     // Then it stops rather than following itself forever
-    assertUndefined(resolver.resolve("module.processing.queue_arn", []));
+    assertUndefined(
+      resolver.resolve("module.processing.queue_arn", readingFrom()),
+    );
   });
 });

--- a/src/terraform/sim-tf-reference.ts
+++ b/src/terraform/sim-tf-reference.ts
@@ -1,13 +1,14 @@
 import type { SimCfnTemplateValue } from "../service/cloudformation/template/value/sim-cfn-template-value.js";
 import type { TerraformResource } from "./sim-tf-resource.type.js";
-import { terraformAttributeReads } from "./sim-tf-attribute-reads.js";
+import { terraformAttributeIntrinsic } from "./sim-tf-attribute-intrinsic.js";
 import { TerraformLogicalIds } from "./sim-tf-logical-id.js";
-import {
-  longestFirst,
-  moduleOutputPath,
-  qualifiedReference,
-  withoutInstanceKeys,
-} from "./sim-tf-reference-address.js";
+import { TerraformResourceAddresses } from "./sim-tf-reference-addresses.js";
+import { TerraformModuleOutputWalk } from "./sim-tf-module-outputs.js";
+import { terraformScopeHops } from "./sim-tf-reference-scope.js";
+import { qualifiedReference } from "./sim-tf-reference-address.js";
+
+/** How far a chain of hops is followed before it is taken to be a loop. */
+const hopLimit = 8;
 
 /**
  * Resolves a Terraform reference against the resources a template declares.
@@ -16,25 +17,36 @@ import {
  * Terraform lists both forms for the same reference, so the longest address
  * matching a resource wins and what is left over is the attribute.
  *
+ * A reference naming no address at all is followed to one that does. Module
+ * outputs, module variables, `each` and an instance key left to `each.key` are
+ * each recorded somewhere else in the plan, and following them is a rewrite
+ * from one reference to another rather than an evaluation. Nothing here reads
+ * a Terraform expression, and a value the plan marked unknown stays unknown.
+ * What comes back is the resource that will produce it.
+ *
  * The resources given are the ones the template will hold, rather than every
  * resource of the plan. A reference to a resource the template does not
  * declare resolves to nothing, so no property can come out of this naming a
  * logical ID that is not there.
  */
 export class TerraformReferenceResolver {
-  private readonly byAddress: ReadonlyMap<string, TerraformResource>;
-  private readonly moduleOutputs: ReadonlyMap<string, readonly string[]>;
+  private readonly resources: TerraformResourceAddresses;
+  private readonly moduleOutputs: TerraformModuleOutputWalk;
+  private readonly moduleVariables: ReadonlyMap<string, readonly string[]>;
   private readonly logicalIds: TerraformLogicalIds;
 
   constructor(
     resources: readonly TerraformResource[],
     moduleOutputs: ReadonlyMap<string, readonly string[]> = new Map(),
+    moduleVariables: ReadonlyMap<string, readonly string[]> = new Map(),
   ) {
-    this.byAddress = new Map(
-      resources.map((resource) => [resource.address, resource]),
+    this.resources = new TerraformResourceAddresses(resources);
+    this.moduleOutputs = new TerraformModuleOutputWalk(
+      moduleOutputs,
+      this.resources,
     );
-    this.moduleOutputs = moduleOutputs;
-    this.logicalIds = new TerraformLogicalIds(this.byAddress.keys());
+    this.moduleVariables = moduleVariables;
+    this.logicalIds = new TerraformLogicalIds(this.resources.addresses());
   }
 
   /** The logical ID the template declares one address under. */
@@ -48,7 +60,7 @@ export class TerraformReferenceResolver {
    * own attribute refers to is what wants this.
    */
   public resource(address: string): TerraformResource | undefined {
-    return this.byAddress.get(address);
+    return this.resources.get(address);
   }
 
   /**
@@ -60,30 +72,20 @@ export class TerraformReferenceResolver {
    */
   public resolve(
     reference: string,
-    modulePath: readonly string[],
+    from: TerraformResource,
   ): SimCfnTemplateValue | undefined {
-    const qualified = qualifiedReference(reference, modulePath);
-    const target = this.target(qualified);
+    const qualified = this.named(reference, from.modulePath, from, 0);
+    const target = qualified === undefined ? undefined : this.target(qualified);
 
-    if (target === undefined) {
+    if (qualified === undefined || target === undefined) {
       return undefined;
     }
 
-    const attribute = this.attributeName(qualified, target.address);
-    const read =
-      attribute === undefined
-        ? "Ref"
-        : terraformAttributeReads.get(`${target.type}.${attribute}`);
-
-    if (read === undefined) {
-      return undefined;
-    }
-
-    const logicalId = this.logicalId(target.address);
-
-    return read === "Ref"
-      ? { Ref: logicalId }
-      : { "Fn::GetAtt": [logicalId, read] };
+    return terraformAttributeIntrinsic(
+      target.type,
+      this.attributeName(qualified, target.address),
+      this.logicalId(target.address),
+    );
   }
 
   /**
@@ -95,9 +97,83 @@ export class TerraformReferenceResolver {
    */
   public targetAddress(
     reference: string,
-    modulePath: readonly string[],
+    from: TerraformResource,
   ): string | undefined {
-    return this.target(qualifiedReference(reference, modulePath))?.address;
+    const qualified = this.named(reference, from.modulePath, from, 0);
+
+    return qualified === undefined
+      ? undefined
+      : this.target(qualified)?.address;
+  }
+
+  /**
+   * The same reference, written so that it names a resource of this plan.
+   *
+   * A reference that already names one is itself. One that names an instance
+   * without its key gains the key. One under a scope the plan resolves for
+   * itself is replaced by what was written where that scope was set, and then
+   * asked again.
+   */
+  private named(
+    reference: string,
+    modulePath: readonly string[],
+    from: TerraformResource,
+    depth: number,
+  ): string | undefined {
+    const qualified = qualifiedReference(reference, modulePath);
+
+    if (this.target(qualified) !== undefined) {
+      return qualified;
+    }
+
+    const keyed = this.resources.instance(qualified, from.index);
+
+    if (keyed !== undefined) {
+      return keyed;
+    }
+
+    return depth >= hopLimit
+      ? undefined
+      : this.throughScope(reference, modulePath, from, depth);
+  }
+
+  /**
+   * The one resource a scoped reference leads to, where there is only one.
+   *
+   * A plan records the references of a whole collection as one list and says
+   * nothing about which part of it a reader was reading, so a collection built
+   * out of two resources cannot say which of them `each.value.uri` holds.
+   * Guessing there would put a plausible logical ID into a property that names
+   * the wrong resource, which is worse than the property being absent. Two
+   * answers is therefore no answer, and the resource is left out and reported
+   * the way it is today.
+   */
+  private throughScope(
+    reference: string,
+    modulePath: readonly string[],
+    from: TerraformResource,
+    depth: number,
+  ): string | undefined {
+    const hops = terraformScopeHops(
+      reference,
+      modulePath,
+      from,
+      this.moduleVariables,
+      depth,
+    );
+    const found = new Map<string, string>();
+
+    for (const hop of hops) {
+      const named = this.named(hop.reference, hop.modulePath, from, depth + 1);
+      const address =
+        named === undefined ? undefined : this.target(named)?.address;
+
+      if (named !== undefined && address !== undefined && !found.has(address)) {
+        found.set(address, named);
+      }
+    }
+
+    return found.size === 1 ? found.values().next().value : undefined;
   }
 
   /**
@@ -116,92 +192,15 @@ export class TerraformReferenceResolver {
       return undefined;
     }
 
-    if (qualified.startsWith(`${address}.`)) {
-      return qualified.slice(address.length + 1);
-    }
-
-    const [longest] = longestFirst(this.moduleOutput(qualified) ?? []);
-
-    return longest?.split(".").pop();
+    return qualified.startsWith(`${address}.`)
+      ? qualified.slice(address.length + 1)
+      : this.moduleOutputs.attributeOf(qualified);
   }
 
   private target(qualified: string): TerraformResource | undefined {
-    return this.longestMatch(qualified) ?? this.throughModuleOutput(qualified);
-  }
-
-  /**
-   * The module output one reference names.
-   *
-   * The index is keyed by module call path, since a module declares its
-   * outputs once however many instances of the call there are. A reference
-   * made from inside one instance carries that instance's key, so the key
-   * comes off when the qualified form finds nothing.
-   */
-  private moduleOutput(qualified: string): readonly string[] | undefined {
     return (
-      this.moduleOutputs.get(qualified) ??
-      this.moduleOutputs.get(withoutInstanceKeys(qualified))
+      this.resources.longestMatch(qualified) ??
+      this.moduleOutputs.target(qualified)
     );
-  }
-
-  /**
-   * The resource a module output leads to.
-   *
-   * The output's own expression names it, in terms of the module declaring the
-   * output, so following one is resolving that expression again one module
-   * down. An output built out of several resources returns the first that
-   * resolves, and the depth limit stops a module whose outputs refer to each
-   * other from looping.
-   */
-  private throughModuleOutput(
-    qualified: string,
-    depth = 0,
-  ): TerraformResource | undefined {
-    const output = this.moduleOutput(qualified);
-
-    if (output === undefined || depth > 8) {
-      return undefined;
-    }
-
-    // The path the output was read through rather than the one it was
-    // declared under, so an output reached inside a `for_each` instance
-    // follows its own instance's resources.
-    const instance = moduleOutputPath(qualified);
-
-    for (const reference of longestFirst(output)) {
-      const nested = qualifiedReference(reference, instance);
-      const target =
-        this.longestMatch(nested) ??
-        this.throughModuleOutput(nested, depth + 1);
-
-      if (target !== undefined) {
-        return target;
-      }
-    }
-
-    return undefined;
-  }
-
-  /**
-   * The resource whose address is the longest prefix of this reference.
-   *
-   * `aws_iam_role.processor.arn` has to find `aws_iam_role.processor` and leave
-   * `arn` behind, and a `for_each` instance address carries a bracketed key
-   * that is part of the address rather than an attribute.
-   */
-  private longestMatch(qualified: string): TerraformResource | undefined {
-    let best: TerraformResource | undefined;
-
-    for (const [address, resource] of this.byAddress) {
-      if (qualified !== address && !qualified.startsWith(`${address}.`)) {
-        continue;
-      }
-
-      if (best === undefined || address.length > best.address.length) {
-        best = resource;
-      }
-    }
-
-    return best;
   }
 }

--- a/src/terraform/sim-tf-referenced.ts
+++ b/src/terraform/sim-tf-referenced.ts
@@ -49,7 +49,7 @@ export function terraformReferencedAddress(
   );
 
   for (const reference of references) {
-    const address = resolver.targetAddress(reference, resource.modulePath);
+    const address = resolver.targetAddress(reference, resource);
 
     if (address !== undefined) {
       return address;

--- a/src/terraform/sim-tf-resource.type.ts
+++ b/src/terraform/sim-tf-resource.type.ts
@@ -28,6 +28,14 @@ export interface TerraformResource {
   readonly expressions: Record<string, unknown>;
   /** Explicit `depends_on` addresses, relative to the declaring module. */
   readonly dependsOn: readonly string[];
+  /**
+   * What `for_each` iterates, as the references its expression holds.
+   *
+   * A resource expanded by `for_each` reads `each.value` and `each.key`, and
+   * neither names anything the plan resolved. What the collection was built
+   * from is the only thing behind them.
+   */
+  readonly forEach: readonly string[];
   /** The module call path this resource was declared under. */
   readonly modulePath: readonly string[];
 }

--- a/src/terraform/sim-tf-settle.iso.test.ts
+++ b/src/terraform/sim-tf-settle.iso.test.ts
@@ -5,6 +5,7 @@ import {
   assertMapSize,
   assertUndefined,
 } from "@kensio/smartass";
+import { terraformResourceFactory } from "../../test/terraform/plan/terraform-resource.factory.js";
 import {
   terraformPlanFactory,
   terraformPlanResourceFactory,
@@ -209,7 +210,7 @@ describe("settling which resources of a plan become Resources", () => {
     assertUndefined(
       plan.resolver.targetAddress(
         "aws_apigatewayv2_integration.processor.id",
-        [],
+        terraformResourceFactory.make({}),
       ),
     );
   });

--- a/src/terraform/sim-tf-settle.ts
+++ b/src/terraform/sim-tf-settle.ts
@@ -4,6 +4,7 @@ import {
   type TerraformResource,
 } from "./sim-tf-resource.type.js";
 import { terraformModuleOutputs } from "./sim-tf-module-outputs.js";
+import { terraformModuleVariables } from "./sim-tf-module-variables.js";
 import { TerraformReferenceResolver } from "./sim-tf-reference.js";
 import {
   terraformResourceFolds,
@@ -49,6 +50,7 @@ export function settledTerraformPlan(
   overrides: TerraformPlanOverrides,
 ): TerraformSettledPlan {
   const moduleOutputs = terraformModuleOutputs(plan);
+  const moduleVariables = terraformModuleVariables(plan);
   const refused = new Map<string, TerraformSkipReason>();
 
   let candidates = resources.flatMap((resource) => mappable(resource, refused));
@@ -58,6 +60,7 @@ export function settledTerraformPlan(
     const resolver = new TerraformReferenceResolver(
       candidates.map((declaration) => declaration.resource),
       moduleOutputs,
+      moduleVariables,
     );
     const dropped = new Map(
       candidates.flatMap((declaration) => {

--- a/test/terraform/modules/main.tf
+++ b/test/terraform/modules/main.tf
@@ -112,6 +112,10 @@ module "processor" {
       principal  = "sqs.amazonaws.com"
       source_arn = module.processing_queue.queue_arn
     }
+    api = {
+      principal  = "apigateway.amazonaws.com"
+      source_arn = "${module.api.api_execution_arn}/*/*"
+    }
   }
 }
 

--- a/test/terraform/plan/terraform-plan.factory.ts
+++ b/test/terraform/plan/terraform-plan.factory.ts
@@ -42,6 +42,13 @@ export interface TerraformPlanResourceFixture {
   >;
   /** Addresses named by an explicit `depends_on`. */
   readonly dependsOn: readonly string[];
+  /**
+   * What `for_each` iterates, as the references its expression holds.
+   *
+   * A plan carries the instances rather than the collection, so this is the
+   * only place it says what `each.value` and `each.key` were reading.
+   */
+  readonly forEach: readonly string[];
 }
 
 /**
@@ -54,6 +61,8 @@ export interface TerraformPlanModuleFixture {
   readonly resources: readonly TerraformPlanResourceFixture[];
   /** Output name to the references the output's own expression holds. */
   readonly outputs: Record<string, readonly string[]>;
+  /** Variable name to the references the caller set it from. */
+  readonly variables: Record<string, readonly string[]>;
   readonly modules: readonly TerraformPlanModuleFixture[];
 }
 
@@ -93,6 +102,7 @@ export const terraformPlanResourceFactory =
       unknown: {},
       references: {},
       dependsOn: [],
+      forEach: [],
     };
   });
 
@@ -105,6 +115,7 @@ export const terraformPlanModuleFactory =
     index: undefined,
     resources: [],
     outputs: {},
+    variables: {},
     modules: [],
   }));
 
@@ -220,7 +231,15 @@ function configModule(
     module_calls: Object.fromEntries(
       fixture.modules.map((module) => [
         module.name,
-        { module: configModule(module, module.outputs) },
+        {
+          module: configModule(module, module.outputs),
+          expressions: Object.fromEntries(
+            Object.entries(module.variables).map(([name, references]) => [
+              name,
+              { references },
+            ]),
+          ),
+        },
       ]),
     ),
   };
@@ -241,6 +260,10 @@ function configResource(
       ]),
     ),
     depends_on: resource.dependsOn,
+    for_each_expression:
+      resource.forEach.length === 0
+        ? undefined
+        : { references: resource.forEach },
   };
 }
 

--- a/test/terraform/plan/terraform-resource.factory.ts
+++ b/test/terraform/plan/terraform-resource.factory.ts
@@ -1,0 +1,41 @@
+import { DynamicFactory } from "@kensio/part-factory";
+import type { TerraformResource } from "../../../src/terraform/sim-tf-resource.type.js";
+
+/**
+ * Makes the joined form of one resource, as `terraformPlanResources` reads it
+ * out of the three sections a plan splits it across.
+ *
+ * A test of the reader builds a plan and reads it. This is for a test of what
+ * happens afterwards, where a resource is what a reference is read from rather
+ * than what is being read:
+ *
+ * ```typescript
+ * resolver.resolve(
+ *   "each.value.uri",
+ *   terraformResourceFactory.make({
+ *     modulePath: ["api"],
+ *     forEach: ["var.routes"],
+ *   }),
+ * );
+ * ```
+ */
+export const terraformResourceFactory = new DynamicFactory<TerraformResource>(
+  (overrides = {}) => {
+    const type = overrides.type ?? "aws_sqs_queue";
+    const name = overrides.name ?? "orders";
+
+    return {
+      address: `${type}.${name}`,
+      type,
+      name,
+      index: undefined,
+      provider: "hashicorp/aws",
+      values: {},
+      unknown: {},
+      expressions: {},
+      dependsOn: [],
+      forEach: [],
+      modulePath: [],
+    };
+  },
+);


### PR DESCRIPTION
Resolves #867.

The issue asked for a decision before any building. The decision turned on one fact about the plan format. `configuration` carries `references` arrays and no expression source, and it holds no local definitions at all, so an HCL interpreter has nothing in a plan to interpret. Nothing else Terraform emits helps either. `relevant_attributes` is a flat plan-wide list with no consumer named, `terraform graph` gives edges without attributes, and `terraform console` answers `(known after apply)` for exactly this value. The value does not exist until apply, and the thing actually missing is the edge, which the plan does record.

So this follows the reference graph. `each.value.uri` becomes the references of the collection `each` iterates, `var.routes` becomes the references of the module call that set it, and each rewrite is asked again. The module-output hop that was already there finishes the chain. A bare reference to a `for_each` resource, which is how a plan writes `integration.this[each.key]`, takes the instance keyed like the resource doing the reading. A plan records a whole collection's references in one list without saying which entry holds which, so a collection naming two resources is treated as no answer and the resource is left out with `unresolved required attribute` the way it was before. Guessing there would put a plausible logical ID into a property naming the wrong resource. Anything reaching a resource through a `local` stays out of range, and the READMEs now say why.

The community-module plan goes from 84% to 93%, with `null_resource` and `local_file` the only resources left. Its `allowed_triggers` granted SQS and never API Gateway, so the fixture gained the trigger a Lambda behind an HTTP API needs. A new local test serves the imported API on localhost and fetches the route, and the function the module's `routes` variable named answers it.

`sim-tf-reference.ts` had no room for any of this at the FTA threshold, so the address lookups, the module-output walk, the scope rewrite and the intrinsic builder are files of their own, and the ordering pass moved out of `sim-tf-declare.ts` for the same reason.