### PR TITLE
feat: log simulated SES email to the console

### DIFF
--- a/docs/serve/README.md
+++ b/docs/serve/README.md
@@ -846,6 +846,10 @@ A text part is printed up to 2000 characters. What runs past that is counted and
     ... 4162 more characters, not printed
 ```
 
+A user pool sending its email through simulated SES prints twice, once for the SES send and once for
+the message the pool kept. Both services recorded it, and each block says what that service holds.
+See [Sending a pool's email through SES](../services/cognito/README.md#sending-a-pools-email-through-ses).
+
 `emailTextLimit` moves that limit. It sits beside the per-kind switches on the same option:
 
 ```typescript sim-serve-email-text-limit

--- a/docs/serve/README.md
+++ b/docs/serve/README.md
@@ -768,11 +768,11 @@ service can serve anything at that path.
 
 ## Messages on the console
 
-A simulated Cognito user pool records the verification message it would have sent, and simulated SNS
-records the text message it would have texted. Reading either back takes test code, or the pool's
-`/<userPoolId>/messages` listing, and both are a detour when the sign-up form is open in a browser
-and the confirmation code is the one thing you want. A served environment prints them as they are
-recorded:
+A simulated Cognito user pool records the verification message it would have sent, simulated SNS
+records the text message it would have texted, and simulated SES records the email it accepted.
+Reading any of them back takes test code, or the pool's `/<userPoolId>/messages` listing. Either is
+a detour when the sign-up form is open in a browser and the confirmation code is the one thing you
+want. A served environment prints them as they are recorded:
 
 ```
 sim Cognito eu-west-2_aBcDeFgHi: email to alice@example.com (SignUp)
@@ -780,6 +780,10 @@ sim Cognito eu-west-2_aBcDeFgHi: email to alice@example.com (SignUp)
   Your confirmation code is 483920
 sim SNS: SMS to +15550100
   Your one-time code is 118221
+sim SES: hello@example.com to alice@example.com
+  Subject: Welcome to Example
+  Text body:
+    Glad to have you here.
 ```
 
 Nothing has to ask for that. Narrow it with `messageLogging`, which holds one property per kind of
@@ -816,9 +820,57 @@ sim SNS: SMS to +15550100 (suppressed, number opted out)
   Your one-time code is 118221
 ```
 
+### What an email prints as
+
+An email is summarised. Printing an HTML part in full would run to kilobytes of markup and push the
+sender, the recipients and the subject off the screen, and those are what say which send this was.
+The first line carries the sender and the three recipient lists. The subject follows indented under
+it, then the template the message was rendered from (where a stored template was) and its data, then
+the text part. An HTML part is measured and left out:
+
+```
+sim SES: hello@example.com to alice@example.com, bcc audit@example.com
+  Subject: Reset your password
+  Template: password-reset {"code":"483920"}
+  Text body:
+    Follow this link to reset your password.
+    https://app.example.com/reset?token=abc123
+  HTML body: 4.1 kB, not printed
+```
+
+A text part is printed up to 2000 characters. What runs past that is counted and left out:
+
+```
+  Text body:
+    Here is your monthly statement in full.
+    ... 4162 more characters, not printed
+```
+
+`emailTextLimit` moves that limit. It sits beside the per-kind switches on the same option:
+
+```typescript sim-serve-email-text-limit
+/**
+ * Serving with a shorter limit on the email text that reaches the console.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({
+  simAws,
+  port: 8787,
+  messageLogging: { emailTextLimit: 500 },
+});
+
+// Serve the pages that send the email here.
+
+await srv.close();
+```
+
 Only what happens while the server is up reaches the console. A message recorded before it started
-listening, or after `close()`, is on the service's own record and nowhere else, and `sentMessages()`
-and `sentSmsMessages()` are still where the whole history is.
+listening, or after `close()`, is on the service's own record and nowhere else. `sentMessages()`,
+`sentSmsMessages()` and `sentEmails()` are still where the whole history is.
 
 ## Restarting on a file change
 

--- a/docs/serve/sim-serve-email-text-limit.example.ts
+++ b/docs/serve/sim-serve-email-text-limit.example.ts
@@ -1,0 +1,17 @@
+/**
+ * Serving with a shorter limit on the email text that reaches the console.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({
+  simAws,
+  port: 8787,
+  messageLogging: { emailTextLimit: 500 },
+});
+
+// Serve the pages that send the email here.
+
+await srv.close();

--- a/docs/services/ses/README.md
+++ b/docs/services/ses/README.md
@@ -693,7 +693,12 @@ bury the rest of the block.
 
 The text part is printed up to 2000 characters, and what runs past that is counted. Move the limit
 with `emailTextLimit`, and turn the SES lines off with `ses: false`, both on the `messageLogging`
-option. See [Messages on the console](../../serve#messages-on-the-console) for the rest of it.
+option. See [Messages on the console](../../serve/README.md#messages-on-the-console) for the rest of
+it.
+
+A user pool sending through SES prints twice, once for the SES send and once for the message the
+pool kept. Both services recorded it, and each block says what that service holds. See
+[Sending a pool's email through SES](../cognito/README.md#sending-a-pools-email-through-ses).
 
 ## Permissions
 

--- a/docs/services/ses/README.md
+++ b/docs/services/ses/README.md
@@ -671,6 +671,30 @@ called `SignUp`, so the permissions of that caller decide nothing about it. Noth
 send differs. The sender is checked, the sandbox checks the recipient, and the message is
 recorded.
 
+## Messages on the console
+
+`sentEmails()` is test code. A dev server has the same messages going past and nothing to read them
+with, so `serveSimAws` prints a summary of each one as SES accepts it:
+
+```
+sim SES: hello@example.com to alice@example.com, bcc audit@example.com
+  Subject: Reset your password
+  Template: password-reset {"code":"483920"}
+  Text body:
+    Follow this link to reset your password.
+    https://app.example.com/reset?token=abc123
+  HTML body: 4.1 kB, not printed
+```
+
+The first line holds the sender and the three recipient lists, with an empty list left out. Under it
+come the subject, the template the message was rendered from and the data it was filled with, and
+the text part. An HTML part is measured and left out, because kilobytes of markup on the console
+bury the rest of the block.
+
+The text part is printed up to 2000 characters, and what runs past that is counted. Move the limit
+with `emailTextLimit`, and turn the SES lines off with `ses: false`, both on the `messageLogging`
+option. See [Messages on the console](../../serve#messages-on-the-console) for the rest of it.
+
 ## Permissions
 
 Every command authorizes through simulated IAM. A send authorizes against the identity being sent

--- a/src/serve/http/local-server/sim-aws-local-server.ts
+++ b/src/serve/http/local-server/sim-aws-local-server.ts
@@ -225,11 +225,13 @@ interface ServeSimAwsProperties {
   /**
    * Which messages this server prints to the console while it serves.
    *
-   * A simulated Cognito confirmation code and a simulated SNS text message are
-   * printed as they are recorded, which is what makes a code readable in the
-   * terminal the dev server is running in. Both unless this narrows it:
-   * `{ sns: false }` keeps the pool messages and drops the text messages, and
-   * `false` prints neither.
+   * A simulated Cognito confirmation code, a simulated SNS text message and a
+   * message a simulated SES accepted are printed as they are recorded, which
+   * is what makes a code readable in the terminal the dev server is running
+   * in. All three unless this narrows it: `{ sns: false }` keeps the pool
+   * messages and the email and drops the text messages, and `false` prints
+   * none of them. `emailTextLimit` sets how much of an email's text is
+   * printed.
    */
   readonly messageLogging?: SimMessageLoggingOption | undefined;
 

--- a/src/serve/message/sim-email-log-block.iso.test.ts
+++ b/src/serve/message/sim-email-log-block.iso.test.ts
@@ -1,0 +1,218 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { recordingConsole } from "../../../test/serve/recording-console.js";
+import type { SimSesLoggedEmail } from "../../service/aws/message/sim-aws-logged-message.js";
+import { SimMessageLogConsole } from "./sim-message-log-console.js";
+
+/**
+ * A message with one recipient and a text part, which the tests below vary.
+ */
+const reset = {
+  kind: "ses",
+  fromEmailAddress: "hello@example.com",
+  destination: {
+    toAddresses: ["alice@example.com"],
+    ccAddresses: [],
+    bccAddresses: [],
+  },
+  subject: "Reset your password",
+  text: "Follow this link to reset your password.",
+  html: undefined,
+  templateName: undefined,
+  templateData: undefined,
+} satisfies SimSesLoggedEmail;
+
+describe("Printing an email a simulated SES accepted", () => {
+  it("prints the sender, the recipients, the subject and the text", () => {
+    // Given a console to print to.
+    const target = recordingConsole();
+
+    // When a message with all three recipient lists is printed.
+    new SimMessageLogConsole({ target }).print({
+      ...reset,
+      destination: {
+        toAddresses: ["alice@example.com"],
+        ccAddresses: ["bob@example.com"],
+        bccAddresses: ["audit@example.com"],
+      },
+    });
+
+    // Then the sender and the three lists introduce it, and the subject and
+    // the text follow indented under them.
+    assertIdentical(
+      target.lines[0],
+      [
+        "sim SES: hello@example.com to alice@example.com, cc bob@example.com, bcc audit@example.com",
+        "  Subject: Reset your password",
+        "  Text body:",
+        "    Follow this link to reset your password.",
+      ].join("\n"),
+    );
+  });
+
+  it("leaves out a recipient list nobody was on", () => {
+    // Given a console to print to.
+    const target = recordingConsole();
+
+    // When a message goes to a bcc recipient and nobody else.
+    new SimMessageLogConsole({ target }).print({
+      ...reset,
+      destination: {
+        toAddresses: [],
+        ccAddresses: [],
+        bccAddresses: ["audit@example.com"],
+      },
+    });
+
+    // Then the empty lists are absent, and the one recipient reads as a bcc.
+    assertIdentical(
+      target.lines[0],
+      [
+        "sim SES: hello@example.com bcc audit@example.com",
+        "  Subject: Reset your password",
+        "  Text body:",
+        "    Follow this link to reset your password.",
+      ].join("\n"),
+    );
+  });
+
+  it("reports an HTML part by its size", () => {
+    // Given a console to print to, and a message whose only body is markup.
+    const target = recordingConsole();
+    const html = `<p>${"x".repeat(4084)}</p>`;
+
+    // When it is printed.
+    new SimMessageLogConsole({ target }).print({
+      ...reset,
+      text: undefined,
+      html,
+    });
+
+    // Then the markup is measured and left out, since kilobytes of it would
+    // bury everything else on the console.
+    assertIdentical(
+      target.lines[0],
+      [
+        "sim SES: hello@example.com to alice@example.com",
+        "  Subject: Reset your password",
+        "  HTML body: 4.1 kB, not printed",
+      ].join("\n"),
+    );
+  });
+
+  it("measures a small HTML part in bytes", () => {
+    // Given a console to print to.
+    const target = recordingConsole();
+
+    // When a message carries a short HTML part.
+    new SimMessageLogConsole({ target }).print({
+      ...reset,
+      text: undefined,
+      html: "<p>Hi</p>",
+    });
+
+    // Then the size reads in the unit that fits it.
+    assertIdentical(
+      target.lines[0],
+      [
+        "sim SES: hello@example.com to alice@example.com",
+        "  Subject: Reset your password",
+        "  HTML body: 9 bytes, not printed",
+      ].join("\n"),
+    );
+  });
+
+  it("prints the template a message was rendered from, and its data", () => {
+    // Given a console to print to.
+    const target = recordingConsole();
+
+    // When a templated send is printed.
+    new SimMessageLogConsole({ target }).print({
+      ...reset,
+      templateName: "password-reset",
+      templateData: { code: "483920" },
+    });
+
+    // Then the template name and the data it was filled from are both there.
+    // That is what tells two sends of the same template apart.
+    assertIdentical(
+      target.lines[0],
+      [
+        "sim SES: hello@example.com to alice@example.com",
+        "  Subject: Reset your password",
+        '  Template: password-reset {"code":"483920"}',
+        "  Text body:",
+        "    Follow this link to reset your password.",
+      ].join("\n"),
+    );
+  });
+
+  it("cuts a long text body off and says how much was left out", () => {
+    // Given a console printing at most twenty characters of text.
+    const target = recordingConsole();
+
+    // When a message with a longer text part is printed.
+    new SimMessageLogConsole({ target, emailTextLimit: 20 }).print({
+      ...reset,
+      text: "0123456789012345678901234",
+    });
+
+    // Then the text stops at the limit and the rest is counted.
+    assertIdentical(
+      target.lines[0],
+      [
+        "sim SES: hello@example.com to alice@example.com",
+        "  Subject: Reset your password",
+        "  Text body:",
+        "    01234567890123456789",
+        "    ... 5 more characters, not printed",
+      ].join("\n"),
+    );
+  });
+
+  it("prints a text body that fits with nothing said about a cut", () => {
+    // Given a console printing at most twenty characters of text.
+    const target = recordingConsole();
+
+    // When a message just inside the limit is printed.
+    new SimMessageLogConsole({ target, emailTextLimit: 20 }).print({
+      ...reset,
+      text: "01234567890123456789",
+    });
+
+    // Then the whole text is there and nothing claims it was cut.
+    assertIdentical(
+      target.lines[0],
+      [
+        "sim SES: hello@example.com to alice@example.com",
+        "  Subject: Reset your password",
+        "  Text body:",
+        "    01234567890123456789",
+      ].join("\n"),
+    );
+  });
+
+  it("indents every line of a text body that runs to several", () => {
+    // Given a console to print to.
+    const target = recordingConsole();
+
+    // When the text has line breaks in it.
+    new SimMessageLogConsole({ target }).print({
+      ...reset,
+      text: "Follow this link to reset your password.\nhttps://app.example.com/reset?token=abc123",
+    });
+
+    // Then the whole text is one indented block under its label.
+    assertIdentical(
+      target.lines[0],
+      [
+        "sim SES: hello@example.com to alice@example.com",
+        "  Subject: Reset your password",
+        "  Text body:",
+        "    Follow this link to reset your password.",
+        "    https://app.example.com/reset?token=abc123",
+      ].join("\n"),
+    );
+  });
+});

--- a/src/serve/message/sim-email-log-block.ts
+++ b/src/serve/message/sim-email-log-block.ts
@@ -1,0 +1,138 @@
+import type { SimSesLoggedEmail } from "../../service/aws/message/sim-aws-logged-message.js";
+import type { SimSesSentEmailDestination } from "../../service/ses/email/sim-ses-sent-email.js";
+import { bodyIndent, indented } from "./sim-message-indent.js";
+
+/**
+ * How much of an email's text body is printed before it is cut off.
+ *
+ * A message written for a person to read fits well inside this. The limit is
+ * there for the ones written for a machine, where a signed link or an encoded
+ * payload runs on until it has pushed everything else off the screen.
+ */
+export const defaultEmailTextLimit = 2000;
+
+/**
+ * How far the body parts are indented, one step under the labels above them.
+ */
+const partIndent = `${bodyIndent}${bodyIndent}`;
+
+const bytesInAKilobyte = 1000;
+
+interface SimEmailLogBlockProperties {
+  readonly emailTextLimit?: number | undefined;
+}
+
+/**
+ * The console block for one email a simulated SES accepted.
+ *
+ * Printing the whole message is the obvious answer and the wrong one. An HTML
+ * part runs to kilobytes of markup and buries the sender, the recipients and
+ * the subject, which are what says which send this was. So the summary comes
+ * first, the text part follows it in full, and the HTML part is reported by
+ * its size.
+ */
+export class SimEmailLogBlock {
+  readonly #textLimit: number;
+
+  constructor(properties: SimEmailLogBlockProperties = {}) {
+    this.#textLimit = properties.emailTextLimit ?? defaultEmailTextLimit;
+  }
+
+  /**
+   * The lines this email prints as.
+   */
+  lines(email: SimSesLoggedEmail): readonly string[] {
+    return [
+      `sim SES: ${email.fromEmailAddress} ${addressed(email.destination)}`,
+      `${bodyIndent}Subject: ${email.subject}`,
+      ...template(email),
+      ...this.text(email),
+      ...html(email),
+    ];
+  }
+
+  /**
+   * The text part, cut off at the limit with the cut marked.
+   */
+  private text(email: SimSesLoggedEmail): readonly string[] {
+    if (email.text === undefined) {
+      return [];
+    }
+
+    const overrun = email.text.length - this.#textLimit;
+    const printed =
+      overrun > 0 ? email.text.slice(0, this.#textLimit) : email.text;
+    const cut =
+      overrun > 0
+        ? [`${partIndent}... ${overrun} more characters, not printed`]
+        : [];
+
+    return [
+      `${bodyIndent}Text body:`,
+      ...indented(printed, partIndent),
+      ...cut,
+    ];
+  }
+}
+
+/**
+ * Who the message went to, across the three lists, with each list named.
+ *
+ * A bcc that arrived as a bcc is part of what a reader is checking, and the
+ * three lists read the same way once they are run together.
+ */
+function addressed(destination: SimSesSentEmailDestination): string {
+  const lists: readonly [string, readonly string[]][] = [
+    ["to", destination.toAddresses],
+    ["cc", destination.ccAddresses],
+    ["bcc", destination.bccAddresses],
+  ];
+
+  return lists
+    .filter(([, addresses]) => addresses.length > 0)
+    .map(([label, addresses]) => `${label} ${addresses.join(", ")}`)
+    .join(", ");
+}
+
+/**
+ * The template the message was rendered from, where a stored one was.
+ *
+ * The data goes with the name because it is what tells two sends of the same
+ * template apart, and it is usually the thing being checked.
+ */
+function template(email: SimSesLoggedEmail): readonly string[] {
+  if (email.templateName === undefined) {
+    return [];
+  }
+
+  const data =
+    email.templateData === undefined
+      ? ""
+      : ` ${JSON.stringify(email.templateData)}`;
+
+  return [`${bodyIndent}Template: ${email.templateName}${data}`];
+}
+
+/**
+ * The HTML part, measured and left unprinted.
+ */
+function html(email: SimSesLoggedEmail): readonly string[] {
+  if (email.html === undefined) {
+    return [];
+  }
+
+  return [`${bodyIndent}HTML body: ${sized(email.html)}, not printed`];
+}
+
+/**
+ * How big a body is, in the units a reader thinks in.
+ */
+function sized(body: string): string {
+  const bytes = Buffer.byteLength(body, "utf8");
+
+  if (bytes < bytesInAKilobyte) {
+    return `${bytes} bytes`;
+  }
+
+  return `${(bytes / bytesInAKilobyte).toFixed(1)} kB`;
+}

--- a/src/serve/message/sim-local-message-logging.iso.test.ts
+++ b/src/serve/message/sim-local-message-logging.iso.test.ts
@@ -3,6 +3,7 @@ import {
   CreateUserPoolCommand,
   SignUpCommand,
 } from "@aws-sdk/client-cognito-identity-provider";
+import { SendEmailCommand } from "@aws-sdk/client-sesv2";
 import { PublishCommand } from "@aws-sdk/client-sns";
 import {
   assertArrayLength,
@@ -48,9 +49,33 @@ async function signUpPool(
 }
 
 /**
- * Sign a user up and text a code, which is one message of each kind.
+ * Send one welcome message through a simulated SES.
  */
-async function sendBothKinds(simAws: SimAws): Promise<void> {
+async function emailAWelcome(simAws: SimAws): Promise<void> {
+  const ses = simAws.sesV2();
+
+  ses.verifyIdentity("hello@example.com");
+  ses.verifyIdentity("alice@example.com");
+
+  await ses.sendEmail(
+    new SendEmailCommand({
+      FromEmailAddress: "hello@example.com",
+      Destination: { ToAddresses: ["alice@example.com"] },
+      Content: {
+        Simple: {
+          Subject: { Data: "Welcome" },
+          Body: { Text: { Data: "Glad to have you here." } },
+        },
+      },
+    }),
+  );
+}
+
+/**
+ * Sign a user up, text a code and email a welcome, which is one message of
+ * each kind.
+ */
+async function sendEachKind(simAws: SimAws): Promise<void> {
   const { clientId } = await signUpPool(simAws);
 
   await simAws.cognitoIdentityProvider().signUp(
@@ -66,25 +91,28 @@ async function sendBothKinds(simAws: SimAws): Promise<void> {
     .publish(
       new PublishCommand({ PhoneNumber: phoneNumber, Message: "code 12345" }),
     );
+  await emailAWelcome(simAws);
 }
 
 describe("Logging the messages a served environment records", () => {
-  it("prints a pool message and a text message as they happen", async () => {
+  it("prints a message of each kind as it happens", async () => {
     // Given a simulated environment being served with message logging on.
     const simAws = new SimAws();
     const target = recordingConsole();
     const logging = new SimLocalMessageLogging({ simAws, target });
     logging.serving();
 
-    // When a user signs itself up and a code is texted.
-    await sendBothKinds(simAws);
+    // When a user signs itself up, a code is texted and a welcome is emailed.
+    await sendEachKind(simAws);
 
-    // Then both messages were printed, the verification code among them.
-    assertArrayLength(target.lines, 2);
+    // Then all three were printed, the verification code among them.
+    assertArrayLength(target.lines, 3);
     assertStringIncludes(target.lines[0], "sim Cognito");
     assertStringIncludes(target.lines[0], "alice@example.com");
     assertStringIncludes(target.lines[1], "sim SNS");
     assertStringIncludes(target.lines[1], "code 12345");
+    assertStringIncludes(target.lines[2], "sim SES");
+    assertStringIncludes(target.lines[2], "Glad to have you here.");
   });
 
   it("prints the confirmation code the pool recorded", async () => {
@@ -134,10 +162,11 @@ describe("Logging the messages a served environment records", () => {
   });
 
   it.each<[string, SimMessageLoggingOption, readonly string[]]>([
-    ["one kind turned off", { sns: false }, ["sim Cognito"]],
-    ["the other turned off", { cognito: false }, ["sim SNS"]],
-    ["both turned off", false, []],
-    ["everything turned on", true, ["sim Cognito", "sim SNS"]],
+    ["one kind turned off", { sns: false }, ["sim Cognito", "sim SES"]],
+    ["another turned off", { cognito: false }, ["sim SNS", "sim SES"]],
+    ["the email turned off", { ses: false }, ["sim Cognito", "sim SNS"]],
+    ["all of them turned off", false, []],
+    ["everything turned on", true, ["sim Cognito", "sim SNS", "sim SES"]],
   ])("prints what %s asks for", async (_, option, expected) => {
     // Given a served environment asked for those kinds of message.
     const simAws = new SimAws();
@@ -145,7 +174,7 @@ describe("Logging the messages a served environment records", () => {
     new SimLocalMessageLogging({ simAws, option, target }).serving();
 
     // When a message of each kind is recorded.
-    await sendBothKinds(simAws);
+    await sendEachKind(simAws);
 
     // Then only the kinds asked for were printed, in that order.
     assertArrayLength(target.lines, expected.length);
@@ -157,6 +186,28 @@ describe("Logging the messages a served environment records", () => {
     }
   });
 
+  it("prints as much of an email as the limit it was given", async () => {
+    // Given a served environment printing ten characters of email text.
+    const simAws = new SimAws();
+    const target = recordingConsole();
+
+    new SimLocalMessageLogging({
+      simAws,
+      option: { emailTextLimit: 10 },
+      target,
+    }).serving();
+
+    // When a longer message is emailed.
+    await emailAWelcome(simAws);
+
+    // Then the text stopped at the limit and the rest was counted.
+    assertStringIncludes(target.lines[0], "    Glad to ha");
+    assertStringIncludes(
+      target.lines[0],
+      "... 12 more characters, not printed",
+    );
+  });
+
   it("prints nothing once the server has stopped", async () => {
     // Given a served environment that has stopped serving.
     const simAws = new SimAws();
@@ -166,7 +217,7 @@ describe("Logging the messages a served environment records", () => {
     logging.stopping();
 
     // When messages are recorded afterwards.
-    await sendBothKinds(simAws);
+    await sendEachKind(simAws);
 
     // Then nothing reached the console.
     assertArrayLength(target.lines, 0);

--- a/src/serve/message/sim-local-message-logging.iso.test.ts
+++ b/src/serve/message/sim-local-message-logging.iso.test.ts
@@ -208,6 +208,57 @@ describe("Logging the messages a served environment records", () => {
     );
   });
 
+  it("prints both blocks for a pool that sends through SES", async () => {
+    // Given a served environment, and a pool emailing through the account's
+    // SES.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    const target = recordingConsole();
+
+    new SimLocalMessageLogging({ simAws, target }).serving();
+    simAws.sesV2().verifyIdentity("example.com");
+    simAws.sesV2().verifyIdentity("alice@example.com");
+
+    const cognito = simAws.cognitoIdentityProvider();
+    const created = await cognito.createUserPool(
+      new CreateUserPoolCommand({
+        PoolName: "myapp-users",
+        AutoVerifiedAttributes: ["email"],
+        EmailConfiguration: {
+          EmailSendingAccount: "DEVELOPER",
+          From: "no-reply@example.com",
+          SourceArn: "arn:aws:ses:eu-west-2:111122223333:identity/example.com",
+        },
+      }),
+    );
+
+    assertNonNullable(created.UserPool?.Id);
+
+    const client = await cognito.createUserPoolClient(
+      new CreateUserPoolClientCommand({
+        UserPoolId: created.UserPool.Id,
+        ClientName: "web",
+      }),
+    );
+
+    assertNonNullable(client.UserPoolClient?.ClientId);
+
+    // When a user signs itself up.
+    await cognito.signUp(
+      new SignUpCommand({
+        ClientId: client.UserPoolClient.ClientId,
+        Username: "alice",
+        Password: "Sup3rSecret!",
+        UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+      }),
+    );
+
+    // Then both services printed it, SES first, because both recorded it and
+    // the console says what each one holds.
+    assertArrayLength(target.lines, 2);
+    assertStringIncludes(target.lines[0], "sim SES: no-reply@example.com");
+    assertStringIncludes(target.lines[1], "sim Cognito");
+  });
+
   it("prints nothing once the server has stopped", async () => {
     // Given a served environment that has stopped serving.
     const simAws = new SimAws();

--- a/src/serve/message/sim-local-message-logging.ts
+++ b/src/serve/message/sim-local-message-logging.ts
@@ -38,7 +38,10 @@ export class SimLocalMessageLogging {
   constructor(properties: SimLocalMessageLoggingProperties) {
     this.simAws = properties.simAws;
     this.logging = new SimMessageLogging(properties.option);
-    this.output = new SimMessageLogConsole(properties.target);
+    this.output = new SimMessageLogConsole({
+      target: properties.target,
+      emailTextLimit: this.logging.emailTextLimit,
+    });
   }
 
   /**

--- a/src/serve/message/sim-message-indent.ts
+++ b/src/serve/message/sim-message-indent.ts
@@ -1,0 +1,15 @@
+/**
+ * How far a message body is indented under the line that introduces it.
+ */
+export const bodyIndent = "  ";
+
+/**
+ * A body indented under the line introducing it, line by line, so a message
+ * running to several lines stays one readable block.
+ */
+export function indented(
+  body: string,
+  indent: string = bodyIndent,
+): readonly string[] {
+  return body.split("\n").map((line) => `${indent}${line}`);
+}

--- a/src/serve/message/sim-message-log-console.iso.test.ts
+++ b/src/serve/message/sim-message-log-console.iso.test.ts
@@ -10,7 +10,7 @@ describe("Printing the messages a served environment would have sent", () => {
     const target = recordingConsole();
 
     // When a user pool's verification email is printed.
-    new SimMessageLogConsole(target).print({
+    new SimMessageLogConsole({ target }).print({
       kind: "cognito",
       userPoolId: "us-east-1_AbCd1234",
       medium: "EMAIL",
@@ -37,7 +37,7 @@ describe("Printing the messages a served environment would have sent", () => {
     const target = recordingConsole();
 
     // When a message with no subject is printed, as a text message has none.
-    new SimMessageLogConsole(target).print({
+    new SimMessageLogConsole({ target }).print({
       kind: "cognito",
       userPoolId: "us-east-1_AbCd1234",
       medium: "SMS",
@@ -62,7 +62,7 @@ describe("Printing the messages a served environment would have sent", () => {
     const target = recordingConsole();
 
     // When the body has line breaks in it.
-    new SimMessageLogConsole(target).print({
+    new SimMessageLogConsole({ target }).print({
       kind: "cognito",
       userPoolId: "us-east-1_AbCd1234",
       medium: "EMAIL",
@@ -89,7 +89,7 @@ describe("Printing the messages a served environment would have sent", () => {
     const target = recordingConsole();
 
     // When an SMS simulated SNS recorded is printed.
-    new SimMessageLogConsole(target).print({
+    new SimMessageLogConsole({ target }).print({
       kind: "sns",
       phoneNumber: "+15550100",
       message: "Your one-time code is 118221",
@@ -110,7 +110,7 @@ describe("Printing the messages a served environment would have sent", () => {
     const target = recordingConsole();
 
     // When an SMS the opt-out list suppressed is printed.
-    new SimMessageLogConsole(target).print({
+    new SimMessageLogConsole({ target }).print({
       kind: "sns",
       phoneNumber: "+15550100",
       message: "Your one-time code is 118221",

--- a/src/serve/message/sim-message-log-console.ts
+++ b/src/serve/message/sim-message-log-console.ts
@@ -3,6 +3,8 @@ import type {
   SimCognitoLoggedMessage,
   SimSnsLoggedSms,
 } from "../../service/aws/message/sim-aws-logged-message.js";
+import { SimEmailLogBlock } from "./sim-email-log-block.js";
+import { bodyIndent, indented } from "./sim-message-indent.js";
 
 /**
  * The console a message is printed to, as much of it as printing needs.
@@ -11,10 +13,17 @@ export interface SimMessageConsole {
   log: (line: string) => void;
 }
 
-/**
- * How far a message body is indented under the line that introduces it.
- */
-const bodyIndent = "  ";
+interface SimMessageLogConsoleProperties {
+  /**
+   * Where the lines go. The process console unless a test wants to read them.
+   */
+  readonly target?: SimMessageConsole | undefined;
+
+  /**
+   * How much of an email's text body is printed. See `SimEmailLogBlock`.
+   */
+  readonly emailTextLimit?: number | undefined;
+}
 
 /**
  * Prints the messages a served environment would have sent.
@@ -29,21 +38,37 @@ const bodyIndent = "  ";
  */
 export class SimMessageLogConsole {
   private readonly console: SimMessageConsole;
+  private readonly email: SimEmailLogBlock;
 
-  constructor(target: SimMessageConsole = console) {
-    this.console = target;
+  constructor(properties: SimMessageLogConsoleProperties = {}) {
+    this.console = properties.target ?? console;
+    this.email = new SimEmailLogBlock({
+      emailTextLimit: properties.emailTextLimit,
+    });
   }
 
   /**
    * Print one message.
    */
   print(message: SimAwsLoggedMessage): void {
-    const block =
-      message.kind === "cognito"
-        ? this.cognitoBlock(message)
-        : this.smsBlock(message);
+    this.console.log(this.block(message).join("\n"));
+  }
 
-    this.console.log(block.join("\n"));
+  /**
+   * The lines one message prints as.
+   */
+  private block(message: SimAwsLoggedMessage): readonly string[] {
+    switch (message.kind) {
+      case "cognito": {
+        return this.cognitoBlock(message);
+      }
+      case "sns": {
+        return this.smsBlock(message);
+      }
+      case "ses": {
+        return this.email.lines(message);
+      }
+    }
   }
 
   /**
@@ -83,12 +108,4 @@ export class SimMessageLogConsole {
       ...indented(message.message),
     ];
   }
-}
-
-/**
- * A body indented under the line introducing it, line by line, so a message
- * running to several lines stays one readable block.
- */
-function indented(body: string): readonly string[] {
-  return body.split("\n").map((line) => `${bodyIndent}${line}`);
 }

--- a/src/serve/message/sim-message-logging-serve.loc.test.ts
+++ b/src/serve/message/sim-message-logging-serve.loc.test.ts
@@ -1,3 +1,4 @@
+import { SendEmailCommand } from "@aws-sdk/client-sesv2";
 import { PublishCommand } from "@aws-sdk/client-sns";
 import { assertArrayLength, assertStringIncludes } from "@kensio/smartass";
 import { describe, it } from "vitest";
@@ -19,6 +20,29 @@ async function textACode(simAws: SimAws): Promise<void> {
     );
 }
 
+/**
+ * Email one welcome message through a simulated SES.
+ */
+async function emailAWelcome(simAws: SimAws): Promise<void> {
+  const ses = simAws.sesV2();
+
+  ses.verifyIdentity("hello@example.com");
+  ses.verifyIdentity("alice@example.com");
+
+  await ses.sendEmail(
+    new SendEmailCommand({
+      FromEmailAddress: "hello@example.com",
+      Destination: { ToAddresses: ["alice@example.com"] },
+      Content: {
+        Simple: {
+          Subject: { Data: "Welcome" },
+          Body: { Text: { Data: "Glad to have you here." } },
+        },
+      },
+    }),
+  );
+}
+
 describe("Message logging on a served simulated AWS environment", () => {
   it("prints messages without being asked to", async () => {
     // Given an environment served with nothing said about message logging.
@@ -34,6 +58,22 @@ describe("Message logging on a served simulated AWS environment", () => {
     // worth seeing and asking for them means knowing the option is there.
     assertArrayLength(messageConsole.lines, 1);
     assertStringIncludes(messageConsole.lines[0], "code 12345");
+  });
+
+  it("prints the email a simulated SES accepted", async () => {
+    // Given an environment served with nothing said about message logging.
+    const simAws = new SimAws();
+    const messageConsole = recordingConsole();
+    const srv = await serveSimAws({ simAws, port: 0, messageConsole });
+
+    // When a welcome message is emailed.
+    await emailAWelcome(simAws);
+    await srv.close();
+
+    // Then the summary and the text reached the console.
+    assertArrayLength(messageConsole.lines, 1);
+    assertStringIncludes(messageConsole.lines[0], "sim SES: hello@example.com");
+    assertStringIncludes(messageConsole.lines[0], "Glad to have you here.");
   });
 
   it("prints nothing when the server was told not to", async () => {

--- a/src/serve/message/sim-message-logging.ts
+++ b/src/serve/message/sim-message-logging.ts
@@ -1,7 +1,9 @@
 import type { SimAwsLoggedMessageKind } from "../../service/aws/message/sim-aws-logged-message.js";
+import { defaultEmailTextLimit } from "./sim-email-log-block.js";
 
 /**
- * Which kinds of message a served environment prints.
+ * Which kinds of message a served environment prints, and how much of an
+ * email it prints.
  *
  * One property per kind, each on unless it is turned off, so naming one kind
  * says nothing about the others.
@@ -12,6 +14,15 @@ export interface SimMessageLoggingProperties {
 
   /** The text messages simulated SNS would have sent. */
   readonly sns?: boolean;
+
+  /** The email simulated SES has accepted. */
+  readonly ses?: boolean;
+
+  /**
+   * How many characters of an email's text body are printed before it is cut
+   * off, 2000 by default. The rest is reported as a count.
+   */
+  readonly emailTextLimit?: number;
 }
 
 /**
@@ -25,26 +36,47 @@ export type SimMessageLoggingOption = boolean | SimMessageLoggingProperties;
 /**
  * The message logging a server was asked for.
  *
- * The option arrives in three shapes and this is the one thing the rest of the
- * serving layer asks: whether to print a message of this kind.
+ * The option arrives in three shapes and this is what the rest of the serving
+ * layer asks of it: whether to print a message of this kind, and how much of
+ * an email's text to print.
  */
 export class SimMessageLogging {
+  /**
+   * How many characters of an email's text body are printed.
+   */
+  readonly emailTextLimit: number;
+
   readonly #cognito: boolean;
   readonly #sns: boolean;
+  readonly #ses: boolean;
 
   constructor(option: SimMessageLoggingOption = true) {
-    const kinds: SimMessageLoggingProperties =
-      typeof option === "boolean" ? { cognito: option, sns: option } : option;
+    const properties: SimMessageLoggingProperties =
+      typeof option === "boolean"
+        ? { cognito: option, sns: option, ses: option }
+        : option;
 
-    this.#cognito = kinds.cognito !== false;
-    this.#sns = kinds.sns !== false;
+    this.#cognito = properties.cognito !== false;
+    this.#sns = properties.sns !== false;
+    this.#ses = properties.ses !== false;
+    this.emailTextLimit = properties.emailTextLimit ?? defaultEmailTextLimit;
   }
 
   /**
    * Whether messages of this kind are printed.
    */
   prints(kind: SimAwsLoggedMessageKind): boolean {
-    return kind === "cognito" ? this.#cognito : this.#sns;
+    switch (kind) {
+      case "cognito": {
+        return this.#cognito;
+      }
+      case "sns": {
+        return this.#sns;
+      }
+      case "ses": {
+        return this.#ses;
+      }
+    }
   }
 
   /**
@@ -54,6 +86,6 @@ export class SimMessageLogging {
    * wants output from does no work for it.
    */
   get any(): boolean {
-    return this.#cognito || this.#sns;
+    return this.#cognito || this.#sns || this.#ses;
   }
 }

--- a/src/service/aws/factory/sim-aws-account-region-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-account-region-service-builder.ts
@@ -25,6 +25,7 @@ import type { SimLambdaUrlRegistry } from "../../lambda/registry/sim-lambda-url-
 import { SimRekognition } from "../../rekognition/index.js";
 import { SimS3 } from "../../s3/sim-s3.js";
 import { SimScheduler } from "../../scheduler/index.js";
+import { SimSesV2 } from "../../ses/index.js";
 import { simAwsEcsCollaborators } from "./sim-aws-ecs-collaborators.js";
 import { simAwsLambdaCollaborators } from "./sim-aws-lambda-collaborators.js";
 import { simAwsS3NotificationDestinations } from "./sim-aws-s3-notification-destinations.js";
@@ -213,6 +214,21 @@ export class SimAwsAccountRegionServiceBuilder {
       iam: this.accountServices.createIam(scope),
       background: this.background,
       notificationDestinations: simAwsS3NotificationDestinations(this.simAws),
+    });
+  }
+
+  /**
+   * Create simulated SES for an Account Region scope.
+   *
+   * Identities are Region-scoped on real SES: verifying an address in one
+   * Region verifies nothing in another, and a message sent through one Region
+   * is invisible from the next. Each message it accepts is announced to the
+   * simulation-wide message log, where a local server picks it up to print.
+   */
+  createSesV2(scope: SimAwsAccountRegionContainer): SimSesV2 {
+    return new SimSesV2({
+      ...this.scoped(scope),
+      messageLog: this.messageLog,
     });
   }
 

--- a/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
@@ -1,7 +1,6 @@
 import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-scope.js";
 import { SimDynamoDb as SimDynamoDatabase } from "../../dynamodb/index.js";
 import { SimSecretsManager } from "../../secretsmanager/index.js";
-import { SimSesV2 } from "../../ses/index.js";
 import { SimSqs } from "../../sqs/index.js";
 import { SimSsm } from "../../ssm/index.js";
 import type { SimAwsAccountServiceCache } from "./sim-aws-account-service-cache.js";
@@ -44,17 +43,6 @@ export class SimAwsSelfContainedServiceBuilder {
    */
   createSecretsManager(scope: SimAwsAccountRegionContainer): SimSecretsManager {
     return new SimSecretsManager({ ...this.scoped(scope), kms: scope.kms() });
-  }
-
-  /**
-   * Create simulated SES for an Account Region scope.
-   *
-   * Identities are Region-scoped on real SES: verifying an address in one
-   * Region verifies nothing in another, and a message sent through one Region
-   * is invisible from the next.
-   */
-  createSesV2(scope: SimAwsAccountRegionContainer): SimSesV2 {
-    return new SimSesV2(this.scoped(scope));
   }
 
   /**

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -265,7 +265,7 @@ export class SimAwsServiceFactory {
 
   /** Create simulated SES for an Account Region scope. */
   createSesV2(scope: SimAwsAccountRegionContainer): SimSesV2 {
-    return this.selfContainedServices.createSesV2(scope);
+    return this.accountRegionServices.createSesV2(scope);
   }
 
   /** Create simulated SNS for an Account Region scope. */

--- a/src/service/aws/message/sim-aws-logged-message.ts
+++ b/src/service/aws/message/sim-aws-logged-message.ts
@@ -1,5 +1,6 @@
 import type { SimCognitoMessageMedium } from "../../cognito/user-pool/message/sim-cognito-sent-message.js";
 import type { SimCognitoMessageOccasion } from "../../cognito/user-pool/message/sim-cognito-message-occasion.js";
+import type { SimSesSentEmailDestination } from "../../ses/email/sim-ses-sent-email.js";
 
 /**
  * One message a simulated user pool has just recorded.
@@ -33,15 +34,38 @@ export interface SimSnsLoggedSms {
 }
 
 /**
+ * One email a simulated SES has just accepted.
+ *
+ * The three recipient lists stay three lists, because who was bcc'd is part of
+ * what a reader is checking. Both body parts are carried whole. How much of
+ * them is printed is the serving layer's decision, and an HTML part is
+ * measured there rather than read out.
+ */
+export interface SimSesLoggedEmail {
+  readonly kind: "ses";
+  readonly fromEmailAddress: string;
+  readonly destination: SimSesSentEmailDestination;
+  readonly subject: string;
+  readonly text: string | undefined;
+  readonly html: string | undefined;
+  readonly templateName: string | undefined;
+  readonly templateData: Readonly<Record<string, unknown>> | undefined;
+}
+
+/**
  * A message a simulated service would have sent, in the shape the serving
  * layer prints it.
  *
- * Each kind carries its own fields because the two are different things. A
- * pool message has a subject and an occasion, and an SMS has neither and can
- * be suppressed. Flattening both into one shape would mean printing fields
- * that are always absent for half the messages.
+ * Each kind carries its own fields because the kinds are different things. A
+ * pool message has a subject and an occasion, an SMS has neither and can be
+ * suppressed, and an email has three recipient lists and two body parts.
+ * Flattening them into one shape would mean printing fields that are always
+ * absent for most of the messages.
  */
-export type SimAwsLoggedMessage = SimCognitoLoggedMessage | SimSnsLoggedSms;
+export type SimAwsLoggedMessage =
+  | SimCognitoLoggedMessage
+  | SimSnsLoggedSms
+  | SimSesLoggedEmail;
 
 /**
  * Which kinds of message the serving layer prints.

--- a/src/service/ses/email/sim-ses-sent-email-store.ts
+++ b/src/service/ses/email/sim-ses-sent-email-store.ts
@@ -1,7 +1,16 @@
+import { SimAwsMessageLog } from "../../aws/message/sim-aws-message-log.js";
 import type { SimSesSentEmail } from "./sim-ses-sent-email.js";
 
 const hoursInADay = 24;
 const millisecondsInAnHour = 60 * 60 * 1000;
+
+interface SimSesSentEmailStoreProperties {
+  /**
+   * Where each message is announced as it is kept, for a serving layer to
+   * print.
+   */
+  readonly messageLog?: SimAwsMessageLog;
+}
 
 /**
  * The messages one simulated SES scope has accepted.
@@ -17,6 +26,11 @@ const millisecondsInAnHour = 60 * 60 * 1000;
  */
 export class SimSesSentEmailStore {
   readonly #sent: SimSesSentEmail[] = [];
+  readonly #messageLog: SimAwsMessageLog;
+
+  constructor(properties: SimSesSentEmailStoreProperties = {}) {
+    this.#messageLog = properties.messageLog ?? new SimAwsMessageLog();
+  }
 
   /**
    * Every message this scope has accepted, oldest first.
@@ -27,9 +41,25 @@ export class SimSesSentEmailStore {
 
   /**
    * Keep a message SES has accepted.
+   *
+   * Both ways a message is accepted come through here, a `SendEmail` from the
+   * SDK and another simulated service sending on the account's behalf, so this
+   * is the one place a message is announced from.
    */
   add(email: SimSesSentEmail): void {
     this.#sent.push(email);
+    // Announced after it is kept, so a listener that goes and reads the store
+    // finds the message it was just told about.
+    this.#messageLog.record({
+      kind: "ses",
+      fromEmailAddress: email.fromEmailAddress,
+      destination: email.destination,
+      subject: email.subject,
+      text: email.body.text,
+      html: email.body.html,
+      templateName: email.templateName,
+      templateData: email.templateData,
+    });
   }
 
   /**

--- a/src/service/ses/sim-ses-commands.ts
+++ b/src/service/ses/sim-ses-commands.ts
@@ -3,6 +3,7 @@ import {
   BackgroundTasks,
 } from "../../util/background/background.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import { SimAwsMessageLog } from "../aws/message/sim-aws-message-log.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
 import {
   SimIamAllowAllAuth,
@@ -30,6 +31,11 @@ export interface SimSesV2Properties {
   readonly accountRegionScope?: SimAwsAccountRegionScope;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
+
+  /**
+   * Where each accepted message is announced, for a serving layer to print.
+   */
+  readonly messageLog?: SimAwsMessageLog;
 }
 
 /**
@@ -66,6 +72,7 @@ export class SimSesCommands {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
       iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
+      messageLog = new SimAwsMessageLog(),
     } = properties;
 
     const authorizer = new SimSesAuthorizer({ iam, accountRegionScope });
@@ -74,7 +81,7 @@ export class SimSesCommands {
     const configurationSets = new SimSesConfigurationSetStore({
       accountRegionScope,
     });
-    const sent = new SimSesSentEmailStore();
+    const sent = new SimSesSentEmailStore({ messageLog });
     const account = new SimSesAccount();
     const suppression = new SimSesSuppressionList();
 


### PR DESCRIPTION
A served environment prints a summary of each message a simulated SES accepts. The first line
carries the sender and the three recipient lists, with the subject, the template it was rendered
from and the text part indented under it. An HTML part is measured and left out, because kilobytes
of markup on the console bury the rest of the block. The text part is printed up to 2000 characters,
moved by `emailTextLimit` on the `messageLogging` option, and `ses: false` turns the lines off.

```
sim SES: hello@example.com to alice@example.com, bcc audit@example.com
  Subject: Reset your password
  Template: password-reset {"code":"483920"}
  Text body:
    Follow this link to reset your password.
    https://app.example.com/reset?token=abc123
  HTML body: 4.1 kB, not printed
```

Resolves #875