### PR TITLE
feat: export a public type for deploy bindings

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -1904,6 +1904,67 @@ function's execution Role as the ambient simulated caller, so downstream calls m
 `SimSdk`-intercepted clients are authorized by simulated IAM as on real Lambda. Functions without
 a matching binding keep their template code, running in the simulated vm runtime.
 
+### Naming the binding type
+
+One entry of a `bindings` list is a `SimCfnBinding`, exported from `@kensio/yulin/cloudformation`. A
+test that builds its bindings in a fixture, or a factory that returns one, names the type from the
+import. The same list passes to `deployTemplate`, `deployTemplateFile` and the per-Stack `bindings`
+of `deployCdkOut`.
+
+```typescript sim-cloudformation-binding-type
+/**
+ * Naming the bindings a deployment takes, for a list built somewhere else.
+ */
+
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import { SimAws } from "@kensio/yulin";
+import type { SimCfnBinding } from "@kensio/yulin/cloudformation";
+
+const orders: string[] = [];
+
+const bindings: readonly SimCfnBinding[] = [
+  {
+    logicalId: "PlaceOrderFunction",
+    handler: (event: { item: string }): void => {
+      orders.push(event.item);
+    },
+  },
+];
+
+const simAws = new SimAws();
+
+await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Resources: {
+      PlaceOrderFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "place-order",
+          Role: "arn:aws:iam::111111111111:role/PlaceOrderRole",
+        },
+      },
+    },
+  },
+  bindings,
+});
+
+await simAws.lambda().invoke(
+  new InvokeCommand({
+    FunctionName: "place-order",
+    Payload: JSON.stringify({ item: "sourdough" }),
+  }),
+);
+
+console.log(orders);
+```
+
+A binding names one of five targets. `logicalId`, `functionName`, `arn`, `cdkPath` and
+`imageRepository` are the five, and a literal naming two of them fails to compile. The same type
+covers a binding to a container an `AWS::ECS::TaskDefinition` declares, which carries `run`, `http`
+or `consumes` in place of `handler`. See
+[Deploying ECS from CloudFormation](../ecs/README.md#deploying-ecs-from-cloudformation) for those.
+
 ## SAM templates
 
 A template naming the `AWS::Serverless-2016-10-31` transform has its SAM resources expanded before

--- a/docs/services/cloudformation/sim-cloudformation-binding-type.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-binding-type.example.ts
@@ -1,0 +1,45 @@
+/**
+ * Naming the bindings a deployment takes, for a list built somewhere else.
+ */
+
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import { SimAws } from "@kensio/yulin";
+import type { SimCfnBinding } from "@kensio/yulin/cloudformation";
+
+const orders: string[] = [];
+
+const bindings: readonly SimCfnBinding[] = [
+  {
+    logicalId: "PlaceOrderFunction",
+    handler: (event: { item: string }): void => {
+      orders.push(event.item);
+    },
+  },
+];
+
+const simAws = new SimAws();
+
+await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Resources: {
+      PlaceOrderFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "place-order",
+          Role: "arn:aws:iam::111111111111:role/PlaceOrderRole",
+        },
+      },
+    },
+  },
+  bindings,
+});
+
+await simAws.lambda().invoke(
+  new InvokeCommand({
+    FunctionName: "place-order",
+    Payload: JSON.stringify({ item: "sourdough" }),
+  }),
+);
+
+console.log(orders);

--- a/scripts/mts/verify-pack-consumer.mts
+++ b/scripts/mts/verify-pack-consumer.mts
@@ -35,6 +35,8 @@ const typeUsageSource = `import {
 } from "@kensio/yulin";
 import type {
   CfnTemplateBodyRecord,
+  SimCfnBinding,
+  SimCfnCdkOutStackOptions,
   SimCfnCdkOutTemplateTransform,
   SimCfnDeployedResource,
   SimCfnDeployedStack,
@@ -60,6 +62,24 @@ export function stackHandle(
 ): SimCfnDeployedResource | undefined {
   return stack.getResource("Handle");
 }
+
+const bindings: readonly SimCfnBinding[] = [
+  { logicalId: "Greeter", handler: (): string => "hello" },
+  { cdkPath: "Packed/Rewrite", handler: (): string => "rewritten" },
+];
+
+export function deployWithBindings(): Promise<SimCfnDeployedStack> {
+  return new SimAws()
+    .account(accountId)
+    .cloudFormation()
+    .deployTemplateFile({
+      stackName: "packed-stack",
+      templatePath: "cdk.out/PackedStack.template.json",
+      bindings,
+    });
+}
+
+export const packedStackOptions: SimCfnCdkOutStackOptions = { bindings };
 
 export const substituteFromDeployed: SimCfnCdkOutTemplateTransform = (
   body: CfnTemplateBodyRecord,

--- a/src/service/cloudformation/README.md
+++ b/src/service/cloudformation/README.md
@@ -167,12 +167,19 @@ The deployer is also where extra deployment context can enter the stack creation
 - executable resource bindings, used by custom-resource simulation that needs to connect a template
   resource to local executable behaviour.
 
-`SimCfnDeployBinding` is what one entry of that list may be, and there are two kinds because there
-are two kinds of thing a Stack declares that Yulin can run. An executable Resource, which is a Lambda
+`SimCfnBinding` is what one entry of that list may be, and there are two kinds because there are two
+kinds of thing a Stack declares that Yulin can run. An executable Resource, which is a Lambda
 function or a CloudFront Function, is one handler and carries it as `handler`. An ECS task definition
 declares containers, so its binding names a container and carries what that container does. They are
 one list because a Stack is deployed once and a realistic Stack holds both, and the handler is what
 tells them apart, since the two kinds share some of their target names.
+
+A binding is data the consumer writes. `SimCfnBinding` is exported from `./cloudformation` along
+with `SimCfnExecutableResourceBinding`, `SimCfnExecutableTargets`, `SimCfnExecutableResource` and
+`SimCfnEcsContainerBinding`. The five ways an executable binding names its Resource are the keys of
+`SimCfnExecutableTargets`, and `ExactlyOne` in `util/` turns those five keys into the union that
+gives one of them and refuses the rest. A sixth way to name a Resource is a sixth key on that
+interface.
 
 `validateSimCfnExecutableResourceBindings` checks every binding resolves to a Resource of the Stack
 before anything is created, sending each kind to its own matcher. The container matcher lives with

--- a/src/service/cloudformation/bind/sim-cfn-binding.iso.test.ts
+++ b/src/service/cloudformation/bind/sim-cfn-binding.iso.test.ts
@@ -1,0 +1,68 @@
+import { assertArrayLength, assertFalse, assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  simCfnIsContainerBinding,
+  simCfnIsExecutableBinding,
+  type SimCfnBinding,
+} from "./sim-cfn-binding.js";
+
+const orders: string[] = [];
+const ordersHandler = (): string => "ordered";
+const processOrders = (): void => {
+  orders.push("processed");
+};
+const serveOrders = (): Response => new Response();
+
+describe("Sim CloudFormation binding", () => {
+  it("holds both kinds of binding in one list", () => {
+    // Given a list of bindings a consumer built away from the deploy call.
+    const bindings: readonly SimCfnBinding[] = [
+      { logicalId: "OrdersFunction", handler: ordersHandler },
+      { cdkPath: "Orders/RewriteFunction", handler: ordersHandler },
+      { family: "orders-worker", containerName: "app", run: processOrders },
+      { imageRepository: "example/orders-web", http: serveOrders },
+    ];
+
+    // When the deployment sorts them into the two kinds.
+    const executable = bindings.filter((binding) =>
+      simCfnIsExecutableBinding(binding),
+    );
+    const containers = bindings.filter((binding) =>
+      simCfnIsContainerBinding(binding),
+    );
+
+    // Then both kinds came out of the one list.
+    assertArrayLength(executable, 2);
+    assertArrayLength(containers, 2);
+  });
+
+  it("reads a Lambda image repository binding as executable", () => {
+    // Given a binding naming the repository a container image function runs.
+    const binding: SimCfnBinding = {
+      imageRepository: "example/orders",
+      handler: ordersHandler,
+    };
+
+    // When the deployment asks which kind it is.
+    // Then the handler makes it an executable Resource binding, even though a
+    // container binding may name a repository too.
+    assertTrue(simCfnIsExecutableBinding(binding));
+    assertFalse(simCfnIsContainerBinding(binding));
+  });
+
+  it("refuses a binding naming two targets at once", () => {
+    // Given a binding literal that names a Resource two ways.
+    // @ts-expect-error a binding names one target, and this one names two.
+    const binding: SimCfnBinding = {
+      logicalId: "OrdersFunction",
+      functionName: "orders",
+      handler: ordersHandler,
+    };
+
+    // When it is read at run time.
+    // Then the compile step is what refused it, and the object itself is an
+    // ordinary executable binding.
+    assertTrue(simCfnIsExecutableBinding(binding));
+  });
+});

--- a/src/service/cloudformation/bind/sim-cfn-binding.ts
+++ b/src/service/cloudformation/bind/sim-cfn-binding.ts
@@ -12,8 +12,15 @@ import type { SimCfnExecutableResourceBinding } from "./sim-cfn-exec-binding.typ
  *
  * They are one list because a Stack is deployed once, and a realistic Stack
  * holds both.
+ *
+ * ```typescript
+ * const bindings: readonly SimCfnBinding[] = [
+ *   { logicalId: "OrdersFunction", handler: ordersHandler },
+ *   { family: "orders-worker", containerName: "app", run: processOrders },
+ * ];
+ * ```
  */
-export type SimCfnDeployBinding =
+export type SimCfnBinding =
   | SimCfnExecutableResourceBinding
   | SimCfnEcsContainerBinding;
 
@@ -25,7 +32,7 @@ export type SimCfnDeployBinding =
  * the two kinds share some of their target names.
  */
 export function simCfnIsExecutableBinding(
-  binding: SimCfnDeployBinding,
+  binding: SimCfnBinding,
 ): binding is SimCfnExecutableResourceBinding {
   return "handler" in binding;
 }
@@ -34,7 +41,7 @@ export function simCfnIsExecutableBinding(
  * Whether a binding targets a container an ECS task definition declares.
  */
 export function simCfnIsContainerBinding(
-  binding: SimCfnDeployBinding,
+  binding: SimCfnBinding,
 ): binding is SimCfnEcsContainerBinding {
   return !simCfnIsExecutableBinding(binding);
 }

--- a/src/service/cloudformation/bind/sim-cfn-exec-binding.type.ts
+++ b/src/service/cloudformation/bind/sim-cfn-exec-binding.type.ts
@@ -1,10 +1,12 @@
+import type { ExactlyOne } from "../../../util/exactly-one.type.js";
 import type { CloudFrontFunction } from "../../cloudfront/index.js";
 import type { SimLambdaHandler } from "../../lambda/function/sim-lambda-handler.type.js";
 
 /**
  * A real in-process handler function that can back an executable
- * CloudFormation Resource: a CloudFront Function handler or a Lambda handler.
- * The plain Function member keeps room for other executable resource kinds.
+ * CloudFormation Resource, which is a CloudFront Function handler or a Lambda
+ * handler. The plain Function member keeps room for other executable resource
+ * kinds.
  */
 export type SimCfnExecutableResource =
   | CloudFrontFunction.Handler
@@ -12,54 +14,50 @@ export type SimCfnExecutableResource =
   // oxlint-disable-next-line typescript/no-unsafe-function-type
   | Function;
 
-export type SimCfnExecutableResourceBinding<
-  H extends SimCfnExecutableResource = SimCfnExecutableResource,
-> =
-  | {
-      readonly logicalId: string;
-      readonly functionName?: never;
-      readonly arn?: never;
-      readonly cdkPath?: never;
-      readonly imageRepository?: never;
-      readonly handler: H;
-    }
-  | {
-      readonly functionName: string;
-      readonly logicalId?: never;
-      readonly arn?: never;
-      readonly cdkPath?: never;
-      readonly imageRepository?: never;
-      readonly handler: H;
-    }
-  | {
-      readonly arn: string;
-      readonly logicalId?: never;
-      readonly functionName?: never;
-      readonly cdkPath?: never;
-      readonly imageRepository?: never;
-      readonly handler: H;
-    }
-  | {
-      readonly cdkPath: string;
-      readonly logicalId?: never;
-      readonly functionName?: never;
-      readonly arn?: never;
-      readonly imageRepository?: never;
-      readonly handler: H;
-    }
+/**
+ * The ways a binding can name the executable Resource it backs.
+ *
+ * A binding gives one of these. The rest are refused, because a Resource named
+ * two ways may be two Resources.
+ */
+export interface SimCfnExecutableTargets {
+  /** The name the template gives the Resource. */
+  readonly logicalId: string;
+
+  /** The function name the Resource's properties declare. */
+  readonly functionName: string;
+
+  /** The function ARN the Resource's properties declare. */
+  readonly arn: string;
+
+  /** The CDK construct path a synthesized logical ID was generated from. */
+  readonly cdkPath: string;
+
   /**
    * A container image repository, matching any AWS::Lambda::Function whose
-   * `Code.ImageUri` names it. The image tag is ignored, so one binding covers
+   * `Code.ImageUri` names it. The image tag is ignored, and one binding covers
    * every stack that runs that image.
    */
-  | {
-      readonly imageRepository: string;
-      readonly logicalId?: never;
-      readonly functionName?: never;
-      readonly arn?: never;
-      readonly cdkPath?: never;
-      readonly handler: H;
-    };
+  readonly imageRepository: string;
+}
+
+/**
+ * A real in-process handler bound at deploy time to one executable Resource of
+ * a Stack, and which Resource it backs.
+ *
+ * ```typescript
+ * await simAws.cloudFormation().deployTemplateFile({
+ *   stackName: "orders",
+ *   templatePath: "cdk.out/OrdersStack.template.json",
+ *   bindings: [{ logicalId: "OrdersFunction", handler: ordersHandler }],
+ * });
+ * ```
+ */
+export type SimCfnExecutableResourceBinding<
+  H extends SimCfnExecutableResource = SimCfnExecutableResource,
+> = ExactlyOne<SimCfnExecutableTargets> & {
+  readonly handler: H;
+};
 
 export type SimCfnCfBinding =
   SimCfnExecutableResourceBinding<CloudFrontFunction.Handler>;

--- a/src/service/cloudformation/bind/validate/sim-cfn-exec-binding-finder.ts
+++ b/src/service/cloudformation/bind/validate/sim-cfn-exec-binding-finder.ts
@@ -1,7 +1,7 @@
 import {
-  type SimCfnDeployBinding,
+  type SimCfnBinding,
   simCfnIsExecutableBinding,
-} from "../sim-cfn-deploy-binding.js";
+} from "../sim-cfn-binding.js";
 import type {
   SimCfnExecutableResource,
   SimCfnExecutableResourceBinding,
@@ -12,7 +12,7 @@ import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
 
 interface SimCfnExecBindingFinderProperties {
   readonly resource: SimCfnResource;
-  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
+  readonly bindings?: readonly SimCfnBinding[] | undefined;
 }
 
 /**

--- a/src/service/cloudformation/bind/validate/sim-cfn-exec-binding-validator.ts
+++ b/src/service/cloudformation/bind/validate/sim-cfn-exec-binding-validator.ts
@@ -1,8 +1,8 @@
 import { SimCfnEcsContainerBindingMatcher } from "../../../ecs/cfn/bind/sim-cfn-ecs-container-binding-matcher.js";
 import {
-  type SimCfnDeployBinding,
+  type SimCfnBinding,
   simCfnIsExecutableBinding,
-} from "../sim-cfn-deploy-binding.js";
+} from "../sim-cfn-binding.js";
 import type { SimCfnExecutableResourceBinding } from "../sim-cfn-exec-binding.type.js";
 import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
 import { SimCfnExecutableResourceBindingMatcher } from "./sim-cfn-exec-binding-matcher.js";
@@ -22,7 +22,7 @@ import { SimCfnExecutableResourceBindingMatcher } from "./sim-cfn-exec-binding-m
 export function validateSimCfnExecutableResourceBindings(properties: {
   readonly stackName: string;
   readonly resources: ReadonlyMap<string, SimCfnResource>;
-  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
+  readonly bindings?: readonly SimCfnBinding[] | undefined;
 }): void {
   const bindings = properties.bindings ?? [];
   const matcher = new SimCfnExecutableResourceBindingMatcher(

--- a/src/service/cloudformation/command/create-stack/create-stack.handler.ts
+++ b/src/service/cloudformation/command/create-stack/create-stack.handler.ts
@@ -19,7 +19,7 @@ import { SimCfnTemplate } from "../../template/sim-cfn-template.js";
 import { SimCfnParameters } from "../../parameters/sim-cfn-parameters.js";
 import { makeSimCfnParameterStore } from "../../parameters/store/sim-cfn-parameter-store.js";
 import type { SimCdkOutContext } from "../../cdk/sim-cdk-out-context.js";
-import type { SimCfnDeployBinding } from "../../bind/sim-cfn-deploy-binding.js";
+import type { SimCfnBinding } from "../../bind/sim-cfn-binding.js";
 import type { SimCfnExports } from "../../export/sim-cfn-exports.js";
 
 interface CreateStackCommandHandlerProperties {
@@ -28,7 +28,7 @@ interface CreateStackCommandHandlerProperties {
   readonly stacks: Map<SimCloudFormationStackName, SimCfnStack>;
   readonly background: BackgroundScheduler & BackgroundCompleter;
   readonly cdkOutContext?: SimCdkOutContext | undefined;
-  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
+  readonly bindings?: readonly SimCfnBinding[] | undefined;
   readonly exports?: SimCfnExports | undefined;
 }
 
@@ -46,7 +46,7 @@ export class CreateStackCommandHandler implements CommandHandler<
   private readonly stacks: Map<SimCloudFormationStackName, SimCfnStack>;
   private readonly background: BackgroundScheduler & BackgroundCompleter;
   private readonly cdkOutContext: SimCdkOutContext | undefined;
-  private readonly bindings: readonly SimCfnDeployBinding[] | undefined;
+  private readonly bindings: readonly SimCfnBinding[] | undefined;
   private readonly exports: SimCfnExports | undefined;
 
   constructor(properties: CreateStackCommandHandlerProperties) {

--- a/src/service/cloudformation/deploy/sim-cfn-cdk-out-stack-options.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-cdk-out-stack-options.ts
@@ -1,5 +1,5 @@
 import type { SimCdkAssemblyStack } from "../cdk/sim-cdk-assembly-manifest.js";
-import type { SimCfnDeployBinding } from "../bind/sim-cfn-deploy-binding.js";
+import type { SimCfnBinding } from "../bind/sim-cfn-binding.js";
 import type { SimCfnDeployedStack } from "../stack/sim-cfn-deployed-stack.type.js";
 import type { CfnTemplateBodyRecord } from "../template/sim-cfn-template.js";
 import type { SimCfnTemplateFileTransform } from "./sim-cfn-template-file-transform.js";
@@ -30,7 +30,7 @@ export type SimCfnCdkOutTemplateTransform = (
  */
 export interface SimCfnCdkOutStackOptions {
   readonly parameters?: Record<string, string> | undefined;
-  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
+  readonly bindings?: readonly SimCfnBinding[] | undefined;
   readonly transform?: SimCfnCdkOutTemplateTransform | undefined;
 }
 

--- a/src/service/cloudformation/deploy/sim-cfn-template-deployer.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-template-deployer.ts
@@ -21,7 +21,7 @@ import {
 } from "./sim-cfn-cdk-out-deployer.js";
 import { simCfnTemplateFileDeployment } from "./sim-cfn-template-file-deployment.js";
 import { SimCfnTemplateFileWatches } from "../watch/sim-cfn-template-file-watches.js";
-import type { SimCfnDeployBinding } from "../bind/sim-cfn-deploy-binding.js";
+import type { SimCfnBinding } from "../bind/sim-cfn-binding.js";
 import type { SimAws } from "../../aws/sim-aws.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type {
@@ -37,7 +37,7 @@ export interface SimCloudFormationCreateStackProperties {
   readonly stackName?: SimCloudFormationStackName | string;
   readonly template: CfnTemplateBodyRecord;
   readonly parameters?: Record<string, string> | undefined;
-  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
+  readonly bindings?: readonly SimCfnBinding[] | undefined;
 
   /**
    * The synthesized CDK template file this in-memory template stands in for.
@@ -180,7 +180,7 @@ export class SimCloudFormationTemplateDeployer {
     readonly stackName: SimCloudFormationStackName | string;
     readonly template: CfnTemplateBodyRecord;
     readonly parameters?: Record<string, string> | undefined;
-    readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
+    readonly bindings?: readonly SimCfnBinding[] | undefined;
     readonly cdkOutContext?: SimCdkOutContext | undefined;
   }): Promise<SimCfnDeployedStack> {
     await this.createStackWithContext(
@@ -225,7 +225,7 @@ export class SimCloudFormationTemplateDeployer {
       };
     },
     cdkOutContext?: SimCdkOutContext,
-    bindings?: readonly SimCfnDeployBinding[],
+    bindings?: readonly SimCfnBinding[],
   ): Promise<SimCreateStackCommandOutput> {
     const handler = new CreateStackCommandHandler({
       simAws: this.simAws,

--- a/src/service/cloudformation/deploy/sim-cfn-template-file-loader.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-template-file-loader.ts
@@ -5,7 +5,7 @@ import {
   loadSiblingCdkAssetsManifest,
   type SimCdkOutContext,
 } from "../cdk/sim-cdk-out-context.js";
-import type { SimCfnDeployBinding } from "../bind/sim-cfn-deploy-binding.js";
+import type { SimCfnBinding } from "../bind/sim-cfn-binding.js";
 import { simWatch } from "../../../watch/sim-watch-runtime.js";
 import type { SimCfnTemplateFileWatchOptions } from "../watch/sim-cfn-template-watch.type.js";
 import { simCfnTemplateFileDeployment } from "./sim-cfn-template-file-deployment.js";
@@ -20,7 +20,7 @@ export interface SimCloudFormationDeployTemplateFileProperties {
   readonly templatePath: string;
   readonly stackName?: SimCloudFormationStackName | string | undefined;
   readonly parameters?: Record<string, string> | undefined;
-  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
+  readonly bindings?: readonly SimCfnBinding[] | undefined;
 
   /**
    * Adapt the parsed template before it is deployed, and again every time a
@@ -56,7 +56,7 @@ export interface SimCfnLoadedTemplateFile {
   readonly stackName: SimCloudFormationStackName | string;
   readonly template: CfnTemplateBodyRecord;
   readonly parameters?: Record<string, string> | undefined;
-  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
+  readonly bindings?: readonly SimCfnBinding[] | undefined;
   readonly cdkOutContext?: SimCdkOutContext | undefined;
 }
 

--- a/src/service/cloudformation/index.ts
+++ b/src/service/cloudformation/index.ts
@@ -5,6 +5,13 @@ export type { SimCfnStackOutput } from "./stack/output/sim-cfn-stack-output.js";
 export type { SimCloudFormationStackStatus } from "./stack/sim-cfn-stack.type.js";
 export type { SimCloudFormationResourceStatus } from "./resource/sim-cfn-resource.type.js";
 export type { SimCfnIgnoredProperty } from "./resource/ignore/sim-cfn-ignored-property.type.js";
+export type { SimCfnBinding } from "./bind/sim-cfn-binding.js";
+export type {
+  SimCfnExecutableResource,
+  SimCfnExecutableResourceBinding,
+  SimCfnExecutableTargets,
+} from "./bind/sim-cfn-exec-binding.type.js";
+export type { SimCfnEcsContainerBinding } from "../ecs/cfn/bind/sim-cfn-ecs-container-binding.type.js";
 export type {
   SimCfnTemplateValue,
   SimCfnTemplateValueRecord,

--- a/src/service/cloudformation/resource/sim-cfn-resource.type.ts
+++ b/src/service/cloudformation/resource/sim-cfn-resource.type.ts
@@ -5,7 +5,7 @@ import type { SimCfnServiceResourceFactory } from "./factory/sim-cfn-resource-fa
 import type { SimCfnTemplateValueRecord } from "../template/value/sim-cfn-template-value.js";
 import type { SimCfnParameters } from "../parameters/sim-cfn-parameters.js";
 import type { SimCdkOutContext } from "../cdk/sim-cdk-out-context.js";
-import type { SimCfnDeployBinding } from "../bind/sim-cfn-deploy-binding.js";
+import type { SimCfnBinding } from "../bind/sim-cfn-binding.js";
 import type { SimCfnResource } from "./sim-cfn-resource.js";
 import type { SimCfnExports } from "../export/sim-cfn-exports.js";
 
@@ -62,7 +62,7 @@ export interface SimCloudFormationResourceCreateContext {
   readonly resources: ReadonlyMap<string, SimCfnResource>;
   readonly resolvedProperties?: SimCfnTemplateValueRecord | undefined;
   readonly cdkOutContext?: SimCdkOutContext | undefined;
-  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
+  readonly bindings?: readonly SimCfnBinding[] | undefined;
 }
 
 /**

--- a/src/service/cloudformation/stack/deploy/sim-cfn-stack-resource-batch-creator.ts
+++ b/src/service/cloudformation/stack/deploy/sim-cfn-stack-resource-batch-creator.ts
@@ -1,5 +1,5 @@
 import type { SimAws } from "../../../aws/sim-aws.js";
-import type { SimCfnDeployBinding } from "../../bind/sim-cfn-deploy-binding.js";
+import type { SimCfnBinding } from "../../bind/sim-cfn-binding.js";
 import type { SimCdkOutContext } from "../../cdk/sim-cdk-out-context.js";
 import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
 
@@ -7,7 +7,7 @@ interface SimCfnStackResourceBatchCreatorProperties {
   readonly simAws: SimAws;
   readonly resources: ReadonlyMap<string, SimCfnResource>;
   readonly cdkOutContext?: SimCdkOutContext | undefined;
-  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
+  readonly bindings?: readonly SimCfnBinding[] | undefined;
 }
 
 /**
@@ -28,7 +28,7 @@ export class SimCfnStackResourceBatchCreator {
   private readonly simAws: SimAws;
   private readonly resources: ReadonlyMap<string, SimCfnResource>;
   private readonly cdkOutContext: SimCdkOutContext | undefined;
-  private readonly bindings: readonly SimCfnDeployBinding[] | undefined;
+  private readonly bindings: readonly SimCfnBinding[] | undefined;
 
   constructor(properties: SimCfnStackResourceBatchCreatorProperties) {
     const { simAws, resources, cdkOutContext, bindings } = properties;

--- a/src/service/cloudformation/stack/deploy/sim-cfn-stack-resource-creator.ts
+++ b/src/service/cloudformation/stack/deploy/sim-cfn-stack-resource-creator.ts
@@ -1,7 +1,7 @@
 import type { SimAws } from "../../../aws/sim-aws.js";
 import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
 import type { SimCdkOutContext } from "../../cdk/sim-cdk-out-context.js";
-import type { SimCfnDeployBinding } from "../../bind/sim-cfn-deploy-binding.js";
+import type { SimCfnBinding } from "../../bind/sim-cfn-binding.js";
 import { SimCfnStackResourceBatchCreator } from "./sim-cfn-stack-resource-batch-creator.js";
 import { SimCfnStackPendingResources } from "./sim-cfn-stack-pending-resources.js";
 
@@ -10,7 +10,7 @@ interface SimCfnStackResourceCreatorProperties {
   readonly resources: ReadonlyMap<string, SimCfnResource>;
   readonly stackName: string;
   readonly cdkOutContext?: SimCdkOutContext | undefined;
-  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
+  readonly bindings?: readonly SimCfnBinding[] | undefined;
 }
 
 /**

--- a/src/service/cloudformation/stack/sim-cfn-stack-resource-operations.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack-resource-operations.ts
@@ -1,7 +1,7 @@
 import type { BackgroundScheduler } from "../../../util/background/background.js";
 import type { SimAws } from "../../aws/sim-aws.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
-import type { SimCfnDeployBinding } from "../bind/sim-cfn-deploy-binding.js";
+import type { SimCfnBinding } from "../bind/sim-cfn-binding.js";
 import type { SimCdkOutContext } from "../cdk/sim-cdk-out-context.js";
 import { SimCdkAssetsPublisher } from "../cdk/assets/sim-cdk-assets-publisher.js";
 import type { SimCfnResource } from "../resource/sim-cfn-resource.js";
@@ -23,7 +23,7 @@ interface SimCfnStackResourceOperationsProperties {
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly stackName: SimCloudFormationStackName;
   readonly cdkOutContext?: SimCdkOutContext | undefined;
-  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
+  readonly bindings?: readonly SimCfnBinding[] | undefined;
 }
 
 /**
@@ -43,7 +43,7 @@ export class SimCfnStackResourceOperations {
   private readonly simAws: SimAws;
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly stackName: SimCloudFormationStackName;
-  private readonly bindings: readonly SimCfnDeployBinding[] | undefined;
+  private readonly bindings: readonly SimCfnBinding[] | undefined;
   private cdkOutContext: SimCdkOutContext | undefined;
 
   constructor(properties: SimCfnStackResourceOperationsProperties) {

--- a/src/service/cloudformation/stack/sim-cfn-stack.type.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack.type.ts
@@ -4,7 +4,7 @@ import type { BackgroundScheduler } from "../../../util/background/background.js
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type { SimCfnTemplate } from "../template/sim-cfn-template.js";
 import type { SimCdkOutContext } from "../cdk/sim-cdk-out-context.js";
-import type { SimCfnDeployBinding } from "../bind/sim-cfn-deploy-binding.js";
+import type { SimCfnBinding } from "../bind/sim-cfn-binding.js";
 import type { SimCfnExports } from "../export/sim-cfn-exports.js";
 
 export type SimCloudFormationStackName = Brand<
@@ -41,7 +41,7 @@ export interface SimCloudFormationStackProperties {
   readonly stackName: SimCloudFormationStackName;
   readonly template: SimCfnTemplate;
   readonly cdkOutContext?: SimCdkOutContext | undefined;
-  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
+  readonly bindings?: readonly SimCfnBinding[] | undefined;
 
   /**
    * The export names published in the Account and Region this Stack deploys

--- a/src/service/cloudfront/cfn/cff/sim-cfn-cff-binding-lookup.ts
+++ b/src/service/cloudfront/cfn/cff/sim-cfn-cff-binding-lookup.ts
@@ -1,4 +1,4 @@
-import type { SimCfnDeployBinding } from "../../../cloudformation/bind/sim-cfn-deploy-binding.js";
+import type { SimCfnBinding } from "../../../cloudformation/bind/sim-cfn-binding.js";
 import type { SimCfnCfBinding } from "../../../cloudformation/bind/sim-cfn-exec-binding.type.js";
 import { SimCfnExecBindingFinder } from "../../../cloudformation/bind/validate/sim-cfn-exec-binding-finder.js";
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
@@ -6,7 +6,7 @@ import type { CloudFrontFunction } from "../../index.js";
 
 interface SimCfnCffBindingLookupProperties {
   readonly resource: SimCfnResource;
-  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
+  readonly bindings?: readonly SimCfnBinding[] | undefined;
   readonly cffName: string;
 }
 

--- a/src/service/cloudfront/cfn/cff/sim-cfn-cff-create-input-builder.ts
+++ b/src/service/cloudfront/cfn/cff/sim-cfn-cff-create-input-builder.ts
@@ -2,7 +2,7 @@ import {
   assertDefined,
   assertNotNull,
 } from "../../../../util/type-guard/defined.js";
-import type { SimCfnDeployBinding } from "../../../cloudformation/bind/sim-cfn-deploy-binding.js";
+import type { SimCfnBinding } from "../../../cloudformation/bind/sim-cfn-binding.js";
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import { makeCffFunctionCodeInput } from "../../cff/function-code-input/cff-function-code-input.js";
@@ -15,7 +15,7 @@ import { findSimCfnCffBinding } from "./sim-cfn-cff-binding-lookup.js";
 interface SimCfnCfFunctionCreateInputBuilderProperties {
   readonly resource: SimCfnResource;
   readonly properties: SimCfnTemplateValueRecord;
-  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
+  readonly bindings?: readonly SimCfnBinding[] | undefined;
 }
 
 interface SimCfnCfFunctionCreateInput {
@@ -43,7 +43,7 @@ interface SimCfnCfFunctionCreateInput {
 export class SimCfnCffCreateInputBuilder {
   private readonly resource: SimCfnResource;
   private readonly properties: SimCfnTemplateValueRecord;
-  private readonly bindings: readonly SimCfnDeployBinding[] | undefined;
+  private readonly bindings: readonly SimCfnBinding[] | undefined;
 
   constructor(properties: SimCfnCfFunctionCreateInputBuilderProperties) {
     this.resource = properties.resource;

--- a/src/service/ecs/cfn/bind/sim-cfn-ecs-container-binding.type.ts
+++ b/src/service/ecs/cfn/bind/sim-cfn-ecs-container-binding.type.ts
@@ -37,7 +37,7 @@ export type SimCfnEcsContainerBindingTarget =
  * ```typescript
  * await simAws.cloudFormation().deployTemplateFile({
  *   stackName: "orders",
- *   templateFile: "cdk.out/OrdersStack.template.json",
+ *   templatePath: "cdk.out/OrdersStack.template.json",
  *   bindings: [
  *     {
  *       family: "orders-worker",

--- a/src/service/ecs/cfn/bind/sim-cfn-ecs-container-bindings.ts
+++ b/src/service/ecs/cfn/bind/sim-cfn-ecs-container-bindings.ts
@@ -1,7 +1,7 @@
 import {
-  type SimCfnDeployBinding,
+  type SimCfnBinding,
   simCfnIsContainerBinding,
-} from "../../../cloudformation/bind/sim-cfn-deploy-binding.js";
+} from "../../../cloudformation/bind/sim-cfn-binding.js";
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimEcs } from "../../sim-ecs.js";
 import { simCfnEcsPropertyError } from "../property/sim-cfn-ecs-property-error.js";
@@ -12,7 +12,7 @@ import type { SimCfnEcsContainerBinding } from "./sim-cfn-ecs-container-binding.
 
 interface SimCfnEcsContainerBindingsProperties {
   readonly resource: SimCfnResource;
-  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
+  readonly bindings?: readonly SimCfnBinding[] | undefined;
 }
 
 /**

--- a/src/service/ecs/cfn/task-definition/sim-cfn-ecs-task-definition-creator.ts
+++ b/src/service/ecs/cfn/task-definition/sim-cfn-ecs-task-definition-creator.ts
@@ -1,5 +1,5 @@
 import { assertDefined } from "../../../../util/type-guard/defined.js";
-import type { SimCfnDeployBinding } from "../../../cloudformation/bind/sim-cfn-deploy-binding.js";
+import type { SimCfnBinding } from "../../../cloudformation/bind/sim-cfn-binding.js";
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimRegisterTaskDefinitionCommandInput } from "../../command/register-task-definition/register-task-definition.command.js";
@@ -45,7 +45,7 @@ export class SimCfnEcsTaskDefinitionCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
-    bindings?: readonly SimCfnDeployBinding[],
+    bindings?: readonly SimCfnBinding[],
   ): Promise<SimEcsTaskDefinition> {
     const taskDefinitionProperties = new SimCfnEcsTaskDefinitionProperties({
       resource,

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-code-input.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-code-input.ts
@@ -1,4 +1,4 @@
-import type { SimCfnDeployBinding } from "../../../cloudformation/bind/sim-cfn-deploy-binding.js";
+import type { SimCfnBinding } from "../../../cloudformation/bind/sim-cfn-binding.js";
 import { SimCfnExecBindingFinder } from "../../../cloudformation/bind/validate/sim-cfn-exec-binding-finder.js";
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimLambdaFunctionCode } from "../../command/create-function/create-function.command.js";
@@ -11,7 +11,7 @@ import type { SimCfnLambdaFunctionProperties } from "./sim-cfn-lambda-function-p
 interface SimCfnLambdaCodeInputProperties {
   readonly resource: SimCfnResource;
   readonly functionProperties: SimCfnLambdaFunctionProperties;
-  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
+  readonly bindings?: readonly SimCfnBinding[] | undefined;
   readonly containerImages: SimLambdaContainerImages;
 }
 

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-function-creator.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-function-creator.ts
@@ -1,4 +1,4 @@
-import type { SimCfnDeployBinding } from "../../../cloudformation/bind/sim-cfn-deploy-binding.js";
+import type { SimCfnBinding } from "../../../cloudformation/bind/sim-cfn-binding.js";
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
@@ -40,7 +40,7 @@ export class SimCfnLambdaFunctionCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
-    bindings?: readonly SimCfnDeployBinding[],
+    bindings?: readonly SimCfnBinding[],
   ): Promise<SimLambdaFunction> {
     const functionProperties = this.propertiesParser.parse(
       resource,

--- a/src/terraform/sim-tf-adapter.ts
+++ b/src/terraform/sim-tf-adapter.ts
@@ -1,5 +1,5 @@
 import type { SimAws } from "../service/aws/sim-aws.js";
-import type { SimCfnDeployBinding } from "../service/cloudformation/bind/sim-cfn-deploy-binding.js";
+import type { SimCfnBinding } from "../service/cloudformation/bind/sim-cfn-binding.js";
 import type { SimCfnDeployedStack } from "../service/cloudformation/stack/sim-cfn-deployed-stack.type.js";
 import type { SimCloudFormationStackName } from "../service/cloudformation/stack/sim-cfn-stack.type.js";
 import { cfnTemplateFromTerraformPlan } from "./sim-tf-import.js";
@@ -30,7 +30,7 @@ export interface TerraformPlanDeployProperties {
    * matching on the function name the plan carries is how a simulated function
    * gets its behaviour.
    */
-  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
+  readonly bindings?: readonly SimCfnBinding[] | undefined;
 
   /**
    * The values the plan could not carry.

--- a/src/util/exactly-one.type.ts
+++ b/src/util/exactly-one.type.ts
@@ -1,0 +1,14 @@
+/**
+ * A union over the keys of `T`, where one key is given and the rest refused.
+ *
+ * Writing such a union out by hand means every member declares every other
+ * member's key as `?: never`, and a key's documentation lands once per member.
+ * `T` names each key once, and this builds the union from it.
+ *
+ * The optional `never` keys are what keep the members exclusive. An object
+ * literal naming two of the keys satisfies no member at all.
+ */
+export type ExactlyOne<T> = {
+  [K in keyof T]: Readonly<Pick<T, K>> &
+    Readonly<Partial<Record<Exclude<keyof T, K>, never>>>;
+}[keyof T];


### PR DESCRIPTION
Resolves #869.

## What changed

`bindings` on `deployTemplate`, `deployTemplateFile` and `SimCfnCdkOutStackOptions` holds a `SimCfnBinding`, exported from `@kensio/yulin/cloudformation` along with `SimCfnExecutableResourceBinding`, `SimCfnExecutableTargets`, `SimCfnExecutableResource` and `SimCfnEcsContainerBinding`. A consumer that builds its bindings in a fixture, or returns one from a factory, names the type from the import rather than reaching back through `NonNullable<SimCfnCdkOutStackOptions["bindings"]>[number]`.

## The rename

`SimCfnDeployBinding` became `SimCfnBinding`, and `bind/sim-cfn-deploy-binding.ts` became `bind/sim-cfn-binding.ts`. There was nothing to trim from the old type on the way out, since a binding is data the consumer already writes, so this publishes the type rather than introducing a public interface alongside it. The rename touches 20 files and each one is an import and a type name.

## The five target shapes

The issue asked whether the exclusivity could come from somewhere quieter. It can. `SimCfnExecutableTargets` now names `logicalId`, `functionName`, `arn`, `cdkPath` and `imageRepository` once each, and `ExactlyOne` in `util/` builds the union that gives one key and refuses the rest. That replaces five hand-written members which each declared the other four as `?: never`, and it puts a key's documentation on the key. Hovering `imageRepository` in an editor now shows what it matches. A sixth way to name a Resource is a sixth key on the interface.

The refusal reads better too. Naming two targets used to fail against five union members at once, and now fails as `Type 'string' is not assignable to type 'undefined'` against the one key that does not belong.

## Checks

`verify:pack` imports `SimCfnBinding` and `SimCfnCdkOutStackOptions` from the tarball, builds a `readonly SimCfnBinding[]` away from the deploy call, and passes the same list to `deployTemplateFile` and to `SimCfnCdkOutStackOptions.bindings`. The compile-time refusal is pinned by a `@ts-expect-error` in `sim-cfn-binding.iso.test.ts`, which fails the build if the type stops refusing. `pnpm check` passes, with the suite at 1561 files and 9780 tests.

Two doc comments said `templateFile` where the option is `templatePath`, and they are fixed here.