### PR TITLE
feat: enumerate a deployed Stack's Resources

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -2786,6 +2786,56 @@ console.log(bucketResource?.simResource);
 This is useful in tests when you want to assert that a specific template resource created the
 expected simulated service resource.
 
+### Listing a Stack's Resources
+
+`stack.resources` holds every Resource the template declared, in the order it declared them. Each
+entry is the same `SimCfnDeployedResource` that `getResource` answers with, and a caller after a
+group of them filters the array itself.
+
+```typescript sim-cloudformation-list-resources
+/**
+ * Counting the Resources of one type in a deployed Stack.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "list-resources-stack",
+  template: {
+    Resources: {
+      UploadsBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: "list-resources-uploads" },
+      },
+      ArchiveBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: "list-resources-archive" },
+      },
+      UploadsTopic: {
+        Type: "AWS::SNS::Topic",
+        Properties: { TopicName: "list-resources-uploads" },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+const buckets = stack.resources.filter(
+  (resource) => resource.type === "AWS::S3::Bucket",
+);
+
+console.log(buckets.map((bucket) => bucket.logicalId));
+// ["UploadsBucket", "ArchiveBucket"]
+```
+
+`getResource` covers the Resources a test can name. Counting them is the other question. CDK
+hashes the logical ID it synthesizes, and a test asserting how many Resources of a type a Stack
+declared has no name to ask for in advance. The array is where that assertion goes. Yulin ships no
+filtering helpers on top of it (the shapes a test filters on vary too much for an API to guess).
+
 ### Naming the deployed Stack type
 
 A deployment answers with a `SimCfnDeployedStack`, and `getResource(...)` with a
@@ -2834,7 +2884,7 @@ A deployed Stack holds what the caller that deployed it reads back:
 
 - `stackName`, `status` and `error`
 - `outputs` and `output(...)`, covered under [Reading stack Outputs](#reading-stack-outputs)
-- `getResource(...)`
+- `resources` and `getResource(...)`
 - `ignoredProperties`, `skippedResources`, `inertResources`, `skippedResourceDeletions` and
   `retainedResources`
 - `waitForDeployComplete()`, `waitForUpdateComplete()` and `waitForDeleteComplete()`

--- a/docs/services/cloudformation/sim-cloudformation-list-resources.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-list-resources.example.ts
@@ -1,0 +1,36 @@
+/**
+ * Counting the Resources of one type in a deployed Stack.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "list-resources-stack",
+  template: {
+    Resources: {
+      UploadsBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: "list-resources-uploads" },
+      },
+      ArchiveBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: "list-resources-archive" },
+      },
+      UploadsTopic: {
+        Type: "AWS::SNS::Topic",
+        Properties: { TopicName: "list-resources-uploads" },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+const buckets = stack.resources.filter(
+  (resource) => resource.type === "AWS::S3::Bucket",
+);
+
+console.log(buckets.map((bucket) => bucket.logicalId));
+// ["UploadsBucket", "ArchiveBucket"]

--- a/scripts/mts/verify-pack-consumer.mts
+++ b/scripts/mts/verify-pack-consumer.mts
@@ -63,6 +63,14 @@ export function stackHandle(
   return stack.getResource("Handle");
 }
 
+export function stackHandles(
+  stack: SimCfnDeployedStack,
+): readonly SimCfnDeployedResource[] {
+  return stack.resources.filter(
+    (resource) => resource.type === "AWS::CloudFormation::WaitConditionHandle",
+  );
+}
+
 const bindings: readonly SimCfnBinding[] = [
   { logicalId: "Greeter", handler: (): string => "hello" },
   { cdkPath: "Packed/Rewrite", handler: (): string => "rewritten" },

--- a/src/service/cloudformation/cdk/apigateway/sim-cdk-rest-api.loc.test.ts
+++ b/src/service/cloudformation/cdk/apigateway/sim-cdk-rest-api.loc.test.ts
@@ -18,7 +18,6 @@ import { serveSimAws } from "../../../../serve/index.js";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { TemporaryDirectory } from "../../../../util/filesystem/temporary-directory.js";
 import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
-import { deployedStackObject } from "../../stack/sim-cfn-stack.fixture.js";
 
 /**
  * Inline function code, as CDK packages Code.fromInline source. The handler
@@ -113,9 +112,9 @@ describe("Sim CDK REST API deployment local integration", () => {
 
     // And the invocation was gated by the AWS::Lambda::Permission CDK pairs
     // with the method, which is deployed rather than skipped.
-    const permissionResource = deployedStackObject(stack)
-      .resources.values()
-      .find((resource) => resource.type === "AWS::Lambda::Permission");
+    const permissionResource = stack.resources.find(
+      (resource) => resource.type === "AWS::Lambda::Permission",
+    );
     assertNonNullable(permissionResource);
     assertFalse(permissionResource.skipped);
 
@@ -127,9 +126,9 @@ describe("Sim CDK REST API deployment local integration", () => {
 
     // And the AWS::ApiGateway::Account CDK writes beside a default RestApi is
     // recorded rather than deployed, which is what leaves the rest served.
-    const accountResource = deployedStackObject(stack)
-      .resources.values()
-      .find((resource) => resource.type === "AWS::ApiGateway::Account");
+    const accountResource = stack.resources.find(
+      (resource) => resource.type === "AWS::ApiGateway::Account",
+    );
     assertNonNullable(accountResource);
     assertTrue(accountResource.skipped);
 

--- a/src/service/cloudformation/cdk/apigatewayv2/sim-cdk-http-api.loc.test.ts
+++ b/src/service/cloudformation/cdk/apigatewayv2/sim-cdk-http-api.loc.test.ts
@@ -17,7 +17,6 @@ import { serveSimAws } from "../../../../serve/index.js";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { TemporaryDirectory } from "../../../../util/filesystem/temporary-directory.js";
 import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
-import { deployedStackObject } from "../../stack/sim-cfn-stack.fixture.js";
 
 /**
  * Inline function code, as CDK packages Code.fromInline source. The handler
@@ -129,9 +128,9 @@ describe("Sim CDK HTTP API deployment local integration", () => {
 
     // And the invocation was gated by the AWS::Lambda::Permission CDK pairs
     // with the integration, which is deployed rather than skipped.
-    const permissionResource = deployedStackObject(stack)
-      .resources.values()
-      .find((resource) => resource.type === "AWS::Lambda::Permission");
+    const permissionResource = stack.resources.find(
+      (resource) => resource.type === "AWS::Lambda::Permission",
+    );
     assertNonNullable(permissionResource);
     assertFalse(permissionResource.skipped);
 

--- a/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-asset-code.loc.test.ts
+++ b/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-asset-code.loc.test.ts
@@ -19,7 +19,6 @@ import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { TemporaryDirectory } from "../../../../util/filesystem/temporary-directory.js";
 import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
-import { deployedStackObject } from "../../stack/sim-cfn-stack.fixture.js";
 
 /**
  * A multi-module handler directory, as `Code.fromAsset` bundles one: CDK
@@ -247,13 +246,11 @@ app.synth();
     // because sim CloudFormation simulates the BucketDeployment custom resource
     // directly rather than running its provider, so there is nothing left for
     // the function to have done.
-    const providerResource = deployedStackObject(stack)
-      .resources.values()
-      .find(
-        (resource) =>
-          resource.type === "AWS::Lambda::Function" &&
-          resource.logicalId.startsWith("CustomCDKBucketDeployment"),
-      );
+    const providerResource = stack.resources.find(
+      (resource) =>
+        resource.type === "AWS::Lambda::Function" &&
+        resource.logicalId.startsWith("CustomCDKBucketDeployment"),
+    );
     assertNonNullable(providerResource);
     assertFalse(providerResource.skipped);
     assertTrue(providerResource.inert);

--- a/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-function-url.loc.test.ts
+++ b/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-function-url.loc.test.ts
@@ -18,7 +18,6 @@ import { serveSimAws } from "../../../../serve/index.js";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { TemporaryDirectory } from "../../../../util/filesystem/temporary-directory.js";
 import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
-import { deployedStackObject } from "../../stack/sim-cfn-stack.fixture.js";
 
 /**
  * Inline function code, as CDK packages Code.fromInline source. The handler
@@ -146,9 +145,9 @@ app.synth();
     await simAws.backgroundTasksComplete();
 
     // Then the permission Resource is deployed rather than skipped.
-    const permissionResource = deployedStackObject(stack)
-      .resources.values()
-      .find((resource) => resource.type === "AWS::Lambda::Permission");
+    const permissionResource = stack.resources.find(
+      (resource) => resource.type === "AWS::Lambda::Permission",
+    );
     assertNonNullable(permissionResource);
     assertFalse(permissionResource.skipped);
     assertNonNullable(simAws.lambda().getSimFunctionUrl("cdk-greeter"));

--- a/src/service/cloudformation/command/create-stack/create-stack.iso.test.ts
+++ b/src/service/cloudformation/command/create-stack/create-stack.iso.test.ts
@@ -4,7 +4,6 @@ import {
   assertIdentical,
   assertNonNullable,
   assertThrowsErrorAsync,
-  assertMapSize,
   assertInstanceOf,
 } from "@kensio/smartass";
 import { SimAws } from "../../../aws/sim-aws.js";
@@ -14,10 +13,7 @@ import {
   DescribeStacksCommand,
 } from "@aws-sdk/client-cloudformation";
 import { jsonStringify } from "../../../../util/type-guard/json.js";
-import {
-  deployedResourceObject,
-  deployedStackObject,
-} from "../../stack/sim-cfn-stack.fixture.js";
+import { deployedResourceObject } from "../../stack/sim-cfn-stack.fixture.js";
 
 describe("CloudFormation CreateStackCommand", () => {
   it("creates a CloudFormation Stack from a template body", async () => {
@@ -81,7 +77,7 @@ describe("CloudFormation CreateStackCommand", () => {
     const stack = cloudFormation.getStackByName("test-stack");
 
     assertNonNullable(stack);
-    assertMapSize(deployedStackObject(stack).resources, 1);
+    assertArrayLength(stack.resources, 1);
 
     const resource = stack.getResource("ExampleResource");
 

--- a/src/service/cloudformation/stack/sim-cfn-deployed-stack.type.ts
+++ b/src/service/cloudformation/stack/sim-cfn-deployed-stack.type.ts
@@ -38,6 +38,15 @@ export interface SimCfnDeployedStack {
   output(outputKey: string): string;
 
   /**
+   * Every Stack Resource, in the order the template declared them.
+   *
+   * A caller after one Resource asks `getResource` for it by name. This is for
+   * the questions a name does not answer, such as how many Resources of a type
+   * the Stack declared, and the filtering is the caller's to do.
+   */
+  readonly resources: readonly SimCfnDeployedResource[];
+
+  /**
    * One Stack Resource, by logical ID or by the CDK construct ID a synthesized
    * logical ID was generated from.
    *

--- a/src/service/cloudformation/stack/sim-cfn-stack.iso.test.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack.iso.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "vitest";
 import {
   assertArrayLength,
+  assertArrayEquals,
   assertIdentical,
   assertNonNullable,
   assertStringIncludes,
@@ -182,6 +183,47 @@ describe("SimCfnStack", () => {
 
     assertNonNullable(resource);
     assertIdentical(resource.attributeValue("Arn"), "WaitHandle.Arn");
+  });
+
+  it("lists its Resources for a caller to filter", async () => {
+    // Given a Stack whose template declares two Resources of one type and one
+    // of another, which is what a caller counting a type has to sort out.
+    const simAws = new SimAws();
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "TestStack",
+      template: {
+        Resources: {
+          FirstHandle: {
+            Type: "AWS::CloudFormation::WaitConditionHandle",
+          },
+          SecondHandle: {
+            Type: "AWS::CloudFormation::WaitConditionHandle",
+          },
+          TestBucket: {
+            Type: "AWS::S3::Bucket",
+            Properties: {
+              BucketName: "list-resources-bucket",
+            },
+          },
+        },
+      },
+    });
+
+    // When the deployed Stack's Resources are read back.
+    const handles = stack.resources.filter(
+      (resource) =>
+        resource.type === "AWS::CloudFormation::WaitConditionHandle",
+    );
+
+    // Then every declared Resource is there, in the order the template wrote
+    // them, and each one carries the logical ID it was declared under.
+    assertArrayLength(stack.resources, 3);
+    assertArrayLength(handles, 2);
+    assertArrayEquals(
+      stack.resources.map((resource) => resource.logicalId),
+      ["FirstHandle", "SecondHandle", "TestBucket"],
+    );
   });
 
   it("throws when deploy is called while create is in progress", async () => {

--- a/src/service/cloudformation/stack/sim-cfn-stack.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack.ts
@@ -48,7 +48,7 @@ export class SimCfnStack implements SimCfnDeployedStack {
   public readonly updating: SimCfnStackUpdateLifecycle;
   public readonly deletion: SimCfnStackDeletionLifecycle;
   public readonly stackName: SimCloudFormationStackName;
-  public readonly resources: Map<string, SimCfnResource>;
+  public readonly resourceMap: Map<string, SimCfnResource>;
   public template: CfnTemplateBodyRecord;
   public outputs = new Map<string, SimCfnStackOutput>();
 
@@ -75,14 +75,14 @@ export class SimCfnStack implements SimCfnDeployedStack {
     this.stackOutputs = new SimCfnStackOutputs({ stackName, exports });
     this.cfnTemplate = template;
     this.template = this.cfnTemplate.template;
-    this.resources = makeSimCfnStackResourceMap({
+    this.resourceMap = makeSimCfnStackResourceMap({
       accountRegionScope,
       background,
       template: this.cfnTemplate,
     });
     validateSimCfnExecutableResourceBindings({
       stackName,
-      resources: this.resources,
+      resources: this.resourceMap,
       bindings,
     });
     this.operations = new SimCfnStackResourceOperations({
@@ -162,7 +162,7 @@ export class SimCfnStack implements SimCfnDeployedStack {
 
     const updater = this.operations.updater({
       background: this.background,
-      resources: this.resources,
+      resources: this.resourceMap,
       current: this.cfnTemplate,
       updated: template,
     });
@@ -218,29 +218,25 @@ export class SimCfnStack implements SimCfnDeployedStack {
    * the Stack name release that delete() puts on top of it.
    */
   async teardown(): Promise<void> {
-    await this.operations.deleteAll(this.resources);
+    await this.operations.deleteAll(this.resourceMap);
     this.stackOutputs.release();
+  }
+
+  /** Every Stack Resource, in the order the template declared them. */
+  public get resources(): readonly SimCfnResource[] {
+    return this.resourceMap.values().toArray();
   }
 
   /**
    * Get a Stack Resource by logical ID, or by the CDK construct ID a
    * synthesized logical ID was generated from.
-   *
-   * The construct ID is the identifier a binding takes. A caller that bound a
-   * handler by construct ID can ask the Stack what it bound, without holding
-   * the hash CDK appended.
    */
   getResource(logicalId: string): SimCfnResource | undefined {
-    return new SimCfnStackResourceLookup(this.resources).find(logicalId);
+    return new SimCfnStackResourceLookup(this.resourceMap).find(logicalId);
   }
 
   /**
    * Get one Stack Output's resolved value, as the string it is.
-   *
-   * The `outputs` map holds every resolved Output whole, including its
-   * description and its export name, typed as the union a parsed template can
-   * hold. A caller after the value alone wants the string CloudFormation would
-   * have answered with, and this hands it over already narrowed.
    *
    * An Output the template never declared throws, as does one that resolved to
    * something other than a string.
@@ -278,16 +274,19 @@ export class SimCfnStack implements SimCfnDeployedStack {
   }
 
   private get report(): SimCfnStackResourceReport {
-    return new SimCfnStackResourceReport(this.resources, this.cfnTemplate);
+    return new SimCfnStackResourceReport(this.resourceMap, this.cfnTemplate);
   }
 
   private async createResources(): Promise<void> {
-    await this.operations.createAll(this.resources);
+    await this.operations.createAll(this.resourceMap);
     this.resolveOutputs();
   }
 
   private resolveOutputs(): void {
-    this.outputs = this.stackOutputs.resolve(this.cfnTemplate, this.resources);
+    this.outputs = this.stackOutputs.resolve(
+      this.cfnTemplate,
+      this.resourceMap,
+    );
   }
 }
 

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro.iso.test.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro.iso.test.ts
@@ -152,7 +152,7 @@ describe("CloudFront CloudFormation Distribution", () => {
     const resolvedWaitHandleProperties = await deployedResourceObject(
       waitHandleResource,
     ).resolvedProperties({
-      resources: deployedStackObject(stack).resources,
+      resources: deployedStackObject(stack).resourceMap,
     });
 
     assertIdentical(

--- a/src/service/iam/cfn/managed-policy/sim-cfn-iam-managed-policy.iso.test.ts
+++ b/src/service/iam/cfn/managed-policy/sim-cfn-iam-managed-policy.iso.test.ts
@@ -228,7 +228,7 @@ describe("IAM CloudFormation ManagedPolicy", () => {
     const resolvedWaitHandleProperties = await deployedResourceObject(
       waitHandleResource,
     ).resolvedProperties({
-      resources: deployedStackObject(stack).resources,
+      resources: deployedStackObject(stack).resourceMap,
     });
 
     assertIdentical(resolvedWaitHandleProperties["PolicyArn"], policyArn);

--- a/src/service/iam/cfn/role/sim-cfn-iam-role.iso.test.ts
+++ b/src/service/iam/cfn/role/sim-cfn-iam-role.iso.test.ts
@@ -284,7 +284,7 @@ describe("IAM CloudFormation Role", () => {
     const resolvedWaitHandleProperties = await deployedResourceObject(
       waitHandleResource,
     ).resolvedProperties({
-      resources: deployedStackObject(stack).resources,
+      resources: deployedStackObject(stack).resourceMap,
     });
 
     assertIdentical(resolvedWaitHandleProperties["RoleName"], "OutputRole");

--- a/src/service/iam/cfn/user/sim-cfn-iam-user.iso.test.ts
+++ b/src/service/iam/cfn/user/sim-cfn-iam-user.iso.test.ts
@@ -275,7 +275,7 @@ describe("IAM CloudFormation User", () => {
     const resolvedWaitHandleProperties = await deployedResourceObject(
       waitHandleResource,
     ).resolvedProperties({
-      resources: deployedStackObject(stack).resources,
+      resources: deployedStackObject(stack).resourceMap,
     });
 
     assertIdentical(resolvedWaitHandleProperties["UserName"], "OutputUser");

--- a/src/service/lambda/cfn/sim-cfn-lambda-deploy.iso.test.ts
+++ b/src/service/lambda/cfn/sim-cfn-lambda-deploy.iso.test.ts
@@ -232,7 +232,7 @@ describe("Lambda CloudFormation Function deployment", () => {
     const resolvedWaitHandleProperties = await deployedResourceObject(
       waitHandleResource,
     ).resolvedProperties({
-      resources: deployedStackObject(stack).resources,
+      resources: deployedStackObject(stack).resourceMap,
     });
 
     assertIdentical(

--- a/src/service/route53/cfn/hosted-zone/sim-cfn-route53-zone.iso.test.ts
+++ b/src/service/route53/cfn/hosted-zone/sim-cfn-route53-zone.iso.test.ts
@@ -225,7 +225,7 @@ describe("Route53 CloudFormation HostedZone", () => {
     const resolvedWaitHandleProperties = await deployedResourceObject(
       waitHandleResource,
     ).resolvedProperties({
-      resources: deployedStackObject(stack).resources,
+      resources: deployedStackObject(stack).resourceMap,
     });
 
     assertIdentical(resolvedWaitHandleProperties["HostedZoneId"], hostedZoneId);

--- a/src/service/ses/cfn/sim-cfn-ses-resource-refusals.iso.test.ts
+++ b/src/service/ses/cfn/sim-cfn-ses-resource-refusals.iso.test.ts
@@ -98,7 +98,7 @@ describe("simulated SES CloudFormation refusals", () => {
         .cfnResourceFactory()
         .create("ContactList", deployedResourceObject(resource), {
           simAws,
-          resources: deployedStackObject(stack).resources,
+          resources: deployedStackObject(stack).resourceMap,
         });
     });
 


### PR DESCRIPTION
`SimCfnDeployedStack` narrowed to what a caller reads back, and the Resource map went with it, leaving a suite that counted the Resources of one type with nothing to ask. The interface now carries `resources` as a readonly array of `SimCfnDeployedResource`, in template order, and the caller filters it. `SimCfnStack` keeps its logical-ID map for the deployment to drive, under the name `resourceMap`. Three tests that reached past the public surface to find one Resource of a type now read it off the array instead. No filtering helpers go on the Stack, since the shapes a caller filters on vary more than an API here could guess.

Resolves #872