### PR TITLE
feat: attach an SES configuration set to a send

### DIFF
--- a/docs/services/ses/README.md
+++ b/docs/services/ses/README.md
@@ -123,9 +123,11 @@ it once worked.
 ## How an identity is configured
 
 An identity holds the DKIM signing, custom MAIL FROM domain, feedback forwarding, configuration set
-and tags it was created with, and `GetEmailIdentity` reads them back. None of it is acted on. Every
-one of these settings decides what happens to a message after it leaves AWS, which a test process
-has no way to watch.
+and tags it was created with, and `GetEmailIdentity` reads them back. The configuration set is the
+one setting a send acts on, covered under
+[Sending through a configuration set](#sending-through-a-configuration-set). The others are held and
+reported. Each of them decides what happens to a message after it leaves AWS, where a test process
+cannot watch.
 
 A test can ask one question of it. Is the identity configured the way the stack said? That catches a
 stack declaring DKIM wrongly, and a stack that stops declaring it.
@@ -301,8 +303,8 @@ sending switch, the delivery options and the reputation switch are all declared 
 SES holds a set as state. A test can then assert what a stack declared, with no AWS account to read
 it back from.
 
-Nothing acts on a set yet. A send naming one keeps the name on its record and goes no further, as it
-did before sets existed. The name now points at something a test can find.
+A set is attached to an identity, or named on a send. `SendingEnabled` is the one option a send acts
+on. The rest are held for a test to read back.
 
 ```typescript sim-ses-configuration-sets
 /**
@@ -353,6 +355,75 @@ back rather than leaving the groups out of the answer.
 
 `findConfigurationSet` reaches one set by name and `allConfigurationSets` hands over every set in
 the scope, oldest first.
+
+### Sending through a configuration set
+
+An identity carries a configuration set from `CreateEmailIdentity`, and `AWS::SES::EmailIdentity`
+attaches one through `ConfigurationSetAttributes`. A send that names no set of its own goes through
+the set its sending identity carries, and the recorded message names whichever set applied. A test
+can then assert a message went through the right set without the code under test naming it at every
+send.
+
+A send that does name a set goes through that one. Where the sending address is an identity with a
+set of its own and its domain is another, the address's set applies, as the more specific identity
+does everywhere else here.
+
+```typescript sim-ses-configuration-set-attachment
+/**
+ * Attaching a configuration set to an identity, and sending through it.
+ */
+
+import {
+  CreateConfigurationSetCommand,
+  CreateEmailIdentityCommand,
+  SendEmailCommand,
+} from "@aws-sdk/client-sesv2";
+
+import { SimAws } from "@kensio/yulin";
+
+const ses = new SimAws().sesV2();
+
+await ses.createConfigurationSet(
+  new CreateConfigurationSetCommand({ ConfigurationSetName: "transactional" }),
+);
+
+await ses.createEmailIdentity(
+  new CreateEmailIdentityCommand({
+    EmailIdentity: "example.com",
+    ConfigurationSetName: "transactional",
+  }),
+);
+
+// Standing in for the DNS records a real domain identity waits on.
+ses.verifyIdentity("example.com");
+ses.verifyIdentity("someone@example.org");
+
+await ses.sendEmail(
+  new SendEmailCommand({
+    FromEmailAddress: "hello@example.com",
+    Destination: { ToAddresses: ["someone@example.org"] },
+    Content: {
+      Simple: {
+        Subject: { Data: "Welcome" },
+        Body: { Text: { Data: "Hi there" } },
+      },
+    },
+  }),
+);
+
+// "transactional", off the identity, with the send naming nothing.
+console.log(ses.sentEmails()[0]?.configurationSetName);
+```
+
+A name that `CreateConfigurationSet` never created is accepted on both paths, and the record keeps
+it. Real SES refuses one. Refusing here would fail a test over a set the developer left out of their
+local setup. A test that wants the strict reading asks `findConfigurationSet` for the set and finds
+nothing.
+
+A set created with `SendingOptions.SendingEnabled` set to `false` refuses every send made through
+it, with `SendingPausedException`. That switch is a declaration the developer wrote deliberately, and
+a send through the set honours it. The refusal reaches a send that named the set and a send that
+picked it up off its identity.
 
 Sets are managed with `CreateConfigurationSet`, `GetConfigurationSet`, `ListConfigurationSets` and
 `DeleteConfigurationSet`. There is no update. Real SES changes a set through a `Put` command per
@@ -906,11 +977,13 @@ Anything else refuses on send with `SimSdkUnsupportedCommandError`.
   where real Handlebars would render `[object Object]`.
 - **`SendBulkEmail` is absent**, along with its per-recipient replacement data.
 - **Nothing is delivered, and nothing bounces.** There are no bounce or complaint events and no
-  event destinations. A configuration set named on a send is kept on the record so a test can assert
-  the right one was used, and goes no further.
-- **A configuration set is state, and no behaviour.** Its suppression reasons, sending switch,
-  delivery options and reputation switch are all held and read back. Every one of them is inert,
-  `SendingEnabled` included, and a send naming a set that was never created still succeeds.
+  event destinations.
+- **A configuration set acts on one send.** `SendingEnabled` refuses a send made through the set.
+  The suppression reasons, delivery options and reputation switch are held and read back, and
+  nothing acts on those.
+- **A set name nothing created is still accepted.** Real SES refuses one on an identity and on a
+  send. Both stand here and the name is recorded, because a test failing over a set missing from a
+  local setup fails for a reason unrelated to what it asserts.
 - **A configuration set holds what it was created with.** The `Put` commands that change one group
   of options are absent. A set cannot be changed once it exists.
 - **The suppression list fills only by hand.** Every address on it was put there by a caller,

--- a/docs/services/ses/sim-ses-configuration-set-attachment.example.ts
+++ b/docs/services/ses/sim-ses-configuration-set-attachment.example.ts
@@ -1,0 +1,44 @@
+/**
+ * Attaching a configuration set to an identity, and sending through it.
+ */
+
+import {
+  CreateConfigurationSetCommand,
+  CreateEmailIdentityCommand,
+  SendEmailCommand,
+} from "@aws-sdk/client-sesv2";
+
+import { SimAws } from "@kensio/yulin";
+
+const ses = new SimAws().sesV2();
+
+await ses.createConfigurationSet(
+  new CreateConfigurationSetCommand({ ConfigurationSetName: "transactional" }),
+);
+
+await ses.createEmailIdentity(
+  new CreateEmailIdentityCommand({
+    EmailIdentity: "example.com",
+    ConfigurationSetName: "transactional",
+  }),
+);
+
+// Standing in for the DNS records a real domain identity waits on.
+ses.verifyIdentity("example.com");
+ses.verifyIdentity("someone@example.org");
+
+await ses.sendEmail(
+  new SendEmailCommand({
+    FromEmailAddress: "hello@example.com",
+    Destination: { ToAddresses: ["someone@example.org"] },
+    Content: {
+      Simple: {
+        Subject: { Data: "Welcome" },
+        Body: { Text: { Data: "Hi there" } },
+      },
+    },
+  }),
+);
+
+// "transactional", off the identity, with the send naming nothing.
+console.log(ses.sentEmails()[0]?.configurationSetName);

--- a/src/service/ses/README.md
+++ b/src/service/ses/README.md
@@ -76,6 +76,28 @@ the text of an HTML-only message finds nothing rather than the markup.
 subject or body and a recorded message with nothing in it would make a test pass for a reason
 unrelated to what it asserts.
 
+## Configuration set model
+
+Configuration set state lives under `configuration-set/`, and the send-side resolution under
+`command/send/sim-ses-configuration-set-check.ts`.
+
+`SimSesConfigurationSet` holds the suppression reasons, the sending switch, the delivery options and
+the reputation options a set was created with. The sending switch is the only one of them a send
+acts on. The others have nothing here to act on, because no message is delivered and no bounce is
+recorded.
+
+`SimSesConfigurationSetCheck` answers two questions about a send. Which set it goes through, and
+whether that set will carry it. The set is the one the send names, or the one the sending identity
+was created with. `SimSesIdentityStore.covering` picks the identity, giving an address's own set precedence over its
+domain's. That is the precedence IAM authorizes an address under.
+
+A name no `CreateConfigurationSet` created is accepted and recorded. Real SES refuses one, and
+refusing here would fail a test over a set the developer left out of their local setup.
+`SimSesV2.findConfigurationSet` is where a test wanting the strict reading goes.
+
+Both send paths go through the check. `SimSesSendEmail` throws `SimSesSendingPausedException`, and
+`SimSesServiceSend` hands the reason back for the calling service to report in its own vocabulary.
+
 ## Template model
 
 Template state lives under `template/`, and the send-side rendering under `command/send/`.

--- a/src/service/ses/cfn/sim-cfn-ses-identity-settings.iso.test.ts
+++ b/src/service/ses/cfn/sim-cfn-ses-identity-settings.iso.test.ts
@@ -1,4 +1,7 @@
-import { GetEmailIdentityCommand } from "@aws-sdk/client-sesv2";
+import {
+  GetEmailIdentityCommand,
+  SendEmailCommand,
+} from "@aws-sdk/client-sesv2";
 import {
   assertArrayLength,
   assertFalse,
@@ -164,6 +167,41 @@ describe("AWS::SES::EmailIdentity settings", () => {
 
     assertArrayLength(identity.Tags, 1);
     assertIdentical(identity.Tags[0].Key, "team");
+  });
+
+  it("sends through the configuration set its template attached", async () => {
+    // Given an identity deployed with a configuration set on it, as CDK's
+    // `configurationSet` prop writes one.
+    const { simAws, stack } = await deployIdentity({
+      EmailIdentity: "example.com",
+      ConfigurationSetAttributes: { ConfigurationSetName: "transactional" },
+    });
+    const ses = simAws.sesV2();
+
+    ses.verifyIdentity("example.com");
+    ses.verifyIdentity("someone@example.org");
+
+    // When a message is sent from the identity, naming no set of its own.
+    await ses.sendEmail(
+      new SendEmailCommand({
+        FromEmailAddress: "hello@example.com",
+        Destination: { ToAddresses: ["someone@example.org"] },
+        Content: {
+          Simple: {
+            Subject: { Data: "Welcome" },
+            Body: { Text: { Data: "Hi there" } },
+          },
+        },
+      }),
+    );
+
+    // Then the message went through the set the stack attached, and the
+    // property is nowhere on the ignored list.
+    const [email] = ses.sentEmails();
+
+    assertNonNullable(email);
+    assertIdentical(email.configurationSetName, "transactional");
+    assertArrayLength(stack.ignoredProperties, 0);
   });
 
   it("records a property this Resource type does not have", async () => {

--- a/src/service/ses/command/send/sim-ses-configuration-set-check.ts
+++ b/src/service/ses/command/send/sim-ses-configuration-set-check.ts
@@ -1,0 +1,94 @@
+import { simSesBareAddress } from "../../email/sim-ses-address.js";
+import type { SimSesConfigurationSetStore } from "../../configuration-set/sim-ses-configuration-set-store.js";
+import { SimSesSendingPausedException } from "../../error/sim-ses.error.js";
+import type { SimSesIdentityStore } from "../../identity/sim-ses-identity-store.js";
+
+interface SimSesConfigurationSetCheckProperties {
+  readonly identities: SimSesIdentityStore;
+  readonly configurationSets: SimSesConfigurationSetStore;
+}
+
+interface SimSesConfiguredSend {
+  readonly fromEmailAddress: string;
+  readonly configurationSetName: string | undefined;
+}
+
+/**
+ * Which configuration set a send goes through, and whether it may.
+ *
+ * A send names its own set, and one that names none falls back to the set the
+ * sending identity was created with. That fallback is how an application
+ * attaching a set to an identity behaves, and it lets a test assert a message
+ * went through the right set without the send naming it.
+ *
+ * A name nothing created is still accepted. Real SES refuses one, and refusing
+ * here would fail a test over a set the developer left out of their local
+ * setup. A test wanting the strict reading asks `findConfigurationSet` for the
+ * set and finds nothing.
+ *
+ * `SendingEnabled` is the one option acted on. It is a switch the caller wrote
+ * deliberately. A send through a set that has it off is refused the way SES
+ * refuses one.
+ */
+export class SimSesConfigurationSetCheck {
+  readonly #identities: SimSesIdentityStore;
+  readonly #configurationSets: SimSesConfigurationSetStore;
+
+  constructor(properties: SimSesConfigurationSetCheckProperties) {
+    this.#identities = properties.identities;
+    this.#configurationSets = properties.configurationSets;
+  }
+
+  /**
+   * The set this send is made through, or nothing where neither the send nor
+   * the identity names one.
+   *
+   * Which identity's set counts follows the rule IAM authorizes an address
+   * against. An address identity's set wins over its domain's.
+   */
+  applying(send: SimSesConfiguredSend): string | undefined {
+    if (send.configurationSetName !== undefined) {
+      return send.configurationSetName;
+    }
+
+    const address = simSesBareAddress(send.fromEmailAddress);
+
+    return this.#identities.find(this.#identities.covering(address))?.settings
+      .configurationSetName;
+  }
+
+  /**
+   * Refuse a send through a set whose sending is switched off.
+   */
+  check(configurationSetName: string | undefined): void {
+    const refusal = this.refusal(configurationSetName);
+
+    if (refusal !== undefined) {
+      throw new SimSesSendingPausedException(refusal);
+    }
+  }
+
+  /**
+   * Why SES would turn this send down, or nothing where it would take it.
+   *
+   * The identity check offers a reason alongside its exception, and this
+   * offers both for the same purpose. A service sending on the account's
+   * behalf reports the refusal in its own vocabulary.
+   */
+  refusal(configurationSetName: string | undefined): string | undefined {
+    if (configurationSetName === undefined) {
+      return undefined;
+    }
+
+    const configurationSet = this.#configurationSets.find(configurationSetName);
+
+    if (configurationSet === undefined || configurationSet.sendingEnabled) {
+      return undefined;
+    }
+
+    return (
+      `Email sending is disabled for configuration set ` +
+      `${configurationSetName}.`
+    );
+  }
+}

--- a/src/service/ses/command/send/sim-ses-send-email.ts
+++ b/src/service/ses/command/send/sim-ses-send-email.ts
@@ -17,6 +17,7 @@ import type {
   SimSendEmailCommandOutput,
   SimSesDestination,
 } from "./send.command.js";
+import type { SimSesConfigurationSetCheck } from "./sim-ses-configuration-set-check.js";
 import type { SimSesContentReader } from "./sim-ses-content.js";
 import type { SimSesSuppressionCheck } from "./sim-ses-suppression-check.js";
 import { refuseUnsimulatedSendInput } from "./sim-ses-unsimulated-send-input.js";
@@ -27,6 +28,7 @@ interface SimSesSendEmailProperties {
   readonly content: SimSesContentReader;
   readonly sent: SimSesSentEmailStore;
   readonly identityCheck: SimSesVerifiedIdentityCheck;
+  readonly configurationSetCheck: SimSesConfigurationSetCheck;
   readonly suppressionCheck: SimSesSuppressionCheck;
   readonly authorizer: SimSesAuthorizer;
   readonly clock: SimClock;
@@ -38,9 +40,9 @@ interface SimSesSendEmailProperties {
  * Nothing is delivered, so what this does is decide whether SES would have
  * accepted the message and, if it would, keep what it would have sent. The
  * order matters and follows real SES: IAM decides the request before the
- * service looks at it, then the identity check, then the message is recorded.
- * A caller with no permission is therefore refused whether or not its
- * identities are verified.
+ * service looks at it, then the identity check, then the configuration set's
+ * sending switch, then the message is recorded. A caller with no permission is
+ * therefore refused whether or not its identities are verified.
  *
  * The suppression list refuses nothing. SES accepts a message addressed to a
  * suppressed recipient and holds it back from that recipient, so the check
@@ -51,6 +53,7 @@ export class SimSesSendEmail {
   readonly #content: SimSesContentReader;
   readonly #sent: SimSesSentEmailStore;
   readonly #identityCheck: SimSesVerifiedIdentityCheck;
+  readonly #configurationSetCheck: SimSesConfigurationSetCheck;
   readonly #suppressionCheck: SimSesSuppressionCheck;
   readonly #authorizer: SimSesAuthorizer;
   readonly #clock: SimClock;
@@ -60,6 +63,7 @@ export class SimSesSendEmail {
     this.#content = properties.content;
     this.#sent = properties.sent;
     this.#identityCheck = properties.identityCheck;
+    this.#configurationSetCheck = properties.configurationSetCheck;
     this.#suppressionCheck = properties.suppressionCheck;
     this.#authorizer = properties.authorizer;
     this.#clock = properties.clock;
@@ -97,6 +101,13 @@ export class SimSesSendEmail {
 
     this.#identityCheck.check({ fromEmailAddress, recipients });
 
+    const configurationSetName = this.#configurationSetCheck.applying({
+      fromEmailAddress,
+      configurationSetName: input.ConfigurationSetName,
+    });
+
+    this.#configurationSetCheck.check(configurationSetName);
+
     const messageId = randomUUID();
 
     this.#sent.add(
@@ -109,7 +120,7 @@ export class SimSesSendEmail {
         body: content.body,
         templateName: content.templateName,
         templateData: content.templateData,
-        configurationSetName: input.ConfigurationSetName,
+        configurationSetName,
         suppressedRecipients: this.#suppressionCheck.withheldFrom(recipients),
         sentDate: this.#clock.now(),
       }),

--- a/src/service/ses/command/send/sim-ses-service-send.ts
+++ b/src/service/ses/command/send/sim-ses-service-send.ts
@@ -4,6 +4,7 @@ import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import { simSesBareAddress } from "../../email/sim-ses-address.js";
 import { SimSesSentEmail } from "../../email/sim-ses-sent-email.js";
 import type { SimSesSentEmailStore } from "../../email/sim-ses-sent-email-store.js";
+import type { SimSesConfigurationSetCheck } from "./sim-ses-configuration-set-check.js";
 import type { SimSesSuppressionCheck } from "./sim-ses-suppression-check.js";
 import type { SimSesVerifiedIdentityCheck } from "./sim-ses-verified-identities.js";
 
@@ -40,6 +41,7 @@ export interface SimSesServiceSendResult {
 interface SimSesServiceSendProperties {
   readonly sent: SimSesSentEmailStore;
   readonly identityCheck: SimSesVerifiedIdentityCheck;
+  readonly configurationSetCheck: SimSesConfigurationSetCheck;
   readonly suppressionCheck: SimSesSuppressionCheck;
   readonly clock: SimClock;
 }
@@ -63,16 +65,22 @@ interface SimSesServiceSendProperties {
  * The suppression list applies too, and refuses nothing. A pool's message to a
  * suppressed recipient is accepted and recorded as held back, exactly as one
  * an SDK caller sent would be.
+ *
+ * The configuration set applies as it does to any other send. A pool that
+ * names none sends through the set its identity carries, and a set with
+ * sending switched off turns the message down.
  */
 export class SimSesServiceSend {
   readonly #sent: SimSesSentEmailStore;
   readonly #identityCheck: SimSesVerifiedIdentityCheck;
+  readonly #configurationSetCheck: SimSesConfigurationSetCheck;
   readonly #suppressionCheck: SimSesSuppressionCheck;
   readonly #clock: SimClock;
 
   constructor(properties: SimSesServiceSendProperties) {
     this.#sent = properties.sent;
     this.#identityCheck = properties.identityCheck;
+    this.#configurationSetCheck = properties.configurationSetCheck;
     this.#suppressionCheck = properties.suppressionCheck;
     this.#clock = properties.clock;
   }
@@ -81,10 +89,13 @@ export class SimSesServiceSend {
    * Accept the message, or say why SES would have refused it.
    */
   send(request: SimSesServiceSendRequest): SimSesServiceSendResult {
-    const refusedBecause = this.#identityCheck.refusal({
-      fromEmailAddress: simSesBareAddress(request.fromEmailAddress),
-      recipients: [request.toAddress],
-    });
+    const configurationSetName = this.#configurationSetCheck.applying(request);
+
+    const refusedBecause =
+      this.#identityCheck.refusal({
+        fromEmailAddress: simSesBareAddress(request.fromEmailAddress),
+        recipients: [request.toAddress],
+      }) ?? this.#configurationSetCheck.refusal(configurationSetName);
 
     if (refusedBecause !== undefined) {
       return { refusedBecause };
@@ -106,7 +117,7 @@ export class SimSesServiceSend {
         body: { text: request.body, html: undefined },
         templateName: undefined,
         templateData: undefined,
-        configurationSetName: request.configurationSetName,
+        configurationSetName,
         suppressedRecipients: this.#suppressionCheck.withheldFrom([
           request.toAddress,
         ]),

--- a/src/service/ses/error/sim-ses.error.ts
+++ b/src/service/ses/error/sim-ses.error.ts
@@ -92,3 +92,19 @@ export class SimSesUnsupportedOperationException extends SimSesError {
     super(message, { httpStatusCode: 400 });
   }
 }
+
+/**
+ * Simulated SES SendingPausedException error.
+ *
+ * SES reports a send it will not make because sending is switched off. Here
+ * that means a configuration set created with `SendingEnabled: false`. That
+ * switch is a declaration the caller wrote deliberately, and this simulation
+ * follows it.
+ */
+export class SimSesSendingPausedException extends SimSesError {
+  public override readonly name = "SendingPausedException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}

--- a/src/service/ses/index.ts
+++ b/src/service/ses/index.ts
@@ -69,5 +69,6 @@ export {
   type SimSesErrorMetadata,
   SimSesMessageRejected,
   SimSesNotFoundException,
+  SimSesSendingPausedException,
   SimSesUnsupportedOperationException,
 } from "./error/sim-ses.error.js";

--- a/src/service/ses/sim-ses-commands.ts
+++ b/src/service/ses/sim-ses-commands.ts
@@ -14,6 +14,7 @@ import { SimSesAccountCommands } from "./command/account/sim-ses-account-command
 import { SimSesAuthorizer } from "./command/authorize/sim-ses-authorizer.js";
 import { SimSesConfigurationSetCommands } from "./command/configuration-set/sim-ses-configuration-set-commands.js";
 import { SimSesIdentityCommands } from "./command/identity/sim-ses-identity-commands.js";
+import { SimSesConfigurationSetCheck } from "./command/send/sim-ses-configuration-set-check.js";
 import { SimSesContentReader } from "./command/send/sim-ses-content.js";
 import { SimSesSendEmail } from "./command/send/sim-ses-send-email.js";
 import { SimSesServiceSend } from "./command/send/sim-ses-service-send.js";
@@ -118,11 +119,17 @@ export class SimSesCommands {
       account,
     });
 
+    const configurationSetCheck = new SimSesConfigurationSetCheck({
+      identities,
+      configurationSets,
+    });
+
     this.sendEmail = new SimSesSendEmail({
       identities,
       content: new SimSesContentReader({ templates }),
       sent,
       identityCheck,
+      configurationSetCheck,
       suppressionCheck,
       authorizer,
       clock: background,
@@ -130,6 +137,7 @@ export class SimSesCommands {
     this.serviceSend = new SimSesServiceSend({
       sent,
       identityCheck,
+      configurationSetCheck,
       suppressionCheck,
       clock: background,
     });

--- a/src/service/ses/sim-ses-send-configuration-set.iso.test.ts
+++ b/src/service/ses/sim-ses-send-configuration-set.iso.test.ts
@@ -1,0 +1,290 @@
+import {
+  CreateConfigurationSetCommand,
+  CreateEmailIdentityCommand,
+  SendEmailCommand,
+  type SendEmailCommandInput,
+} from "@aws-sdk/client-sesv2";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import { SimSesSendingPausedException } from "./error/sim-ses.error.js";
+import type { SimSesV2 } from "./sim-ses-v2.js";
+
+/** The smallest send that SES would accept, naming no configuration set. */
+const welcome = {
+  FromEmailAddress: "hello@example.com",
+  Destination: { ToAddresses: ["someone@example.org"] },
+  Content: {
+    Simple: {
+      Subject: { Data: "Welcome" },
+      Body: { Text: { Data: "Hi there" } },
+    },
+  },
+} satisfies SendEmailCommandInput;
+
+/**
+ * A simulated SES with both ends of the welcome message verified, and a
+ * configuration set for a send or an identity to name.
+ */
+async function sendingSes(): Promise<SimSesV2> {
+  const ses = new SimAws().sesV2();
+
+  ses.verifyIdentity("someone@example.org");
+
+  await ses.createConfigurationSet(
+    new CreateConfigurationSetCommand({
+      ConfigurationSetName: "transactional",
+    }),
+  );
+
+  return ses;
+}
+
+/**
+ * Create the sending identity with a configuration set attached, then treat it
+ * as verified the way a test standing in for the confirmation link does.
+ */
+async function attachedSender(
+  ses: SimSesV2,
+  emailIdentity: string,
+  configurationSetName: string,
+): Promise<void> {
+  await ses.createEmailIdentity(
+    new CreateEmailIdentityCommand({
+      EmailIdentity: emailIdentity,
+      ConfigurationSetName: configurationSetName,
+    }),
+  );
+
+  ses.verifyIdentity(emailIdentity);
+}
+
+describe("SimSesV2 sending through a configuration set", () => {
+  it("sends through the set the identity was created with", async () => {
+    // Given a sending identity carrying a configuration set.
+    const ses = await sendingSes();
+
+    await attachedSender(ses, "hello@example.com", "transactional");
+
+    // When a message names no set of its own.
+    await ses.sendEmail(new SendEmailCommand(welcome));
+
+    // Then the record carries the identity's set, so a test asserts the
+    // message went through the right one without the send naming it.
+    const [email] = ses.sentEmails();
+
+    assertNonNullable(email);
+    assertIdentical(email.configurationSetName, "transactional");
+  });
+
+  it("prefers the set the send names over the identity's", async () => {
+    // Given an identity attached to one set and a second set beside it.
+    const ses = await sendingSes();
+
+    await attachedSender(ses, "hello@example.com", "transactional");
+    await ses.createConfigurationSet(
+      new CreateConfigurationSetCommand({ ConfigurationSetName: "marketing" }),
+    );
+
+    // When a message names the second one.
+    await ses.sendEmail(
+      new SendEmailCommand({ ...welcome, ConfigurationSetName: "marketing" }),
+    );
+
+    // Then that is the set the message went through.
+    const [email] = ses.sentEmails();
+
+    assertNonNullable(email);
+    assertIdentical(email.configurationSetName, "marketing");
+  });
+
+  it("falls back to the set the sending domain carries", async () => {
+    // Given a domain identity with a set, and an address at it that is no
+    // identity of its own.
+    const ses = await sendingSes();
+
+    await attachedSender(ses, "example.com", "transactional");
+
+    // When a message is sent from that address.
+    await ses.sendEmail(new SendEmailCommand(welcome));
+
+    // Then it went through the domain's set, as a message from any mailbox at
+    // a domain identity does.
+    const [email] = ses.sentEmails();
+
+    assertNonNullable(email);
+    assertIdentical(email.configurationSetName, "transactional");
+  });
+
+  it("prefers the sending address's set over its domain's", async () => {
+    // Given both the address and its domain as identities, each with its own
+    // set.
+    const ses = await sendingSes();
+
+    await ses.createConfigurationSet(
+      new CreateConfigurationSetCommand({ ConfigurationSetName: "marketing" }),
+    );
+    await attachedSender(ses, "example.com", "marketing");
+    await attachedSender(ses, "hello@example.com", "transactional");
+
+    // When a message is sent from the address.
+    await ses.sendEmail(new SendEmailCommand(welcome));
+
+    // Then the address's own set wins, which is the rule the more specific
+    // identity wins under everywhere else.
+    const [email] = ses.sentEmails();
+
+    assertNonNullable(email);
+    assertIdentical(email.configurationSetName, "transactional");
+  });
+
+  it("records no set where neither the send nor the identity names one", async () => {
+    // Given a sending identity with nothing attached.
+    const ses = await sendingSes();
+
+    ses.verifyIdentity("hello@example.com");
+
+    // When a message names no set either.
+    await ses.sendEmail(new SendEmailCommand(welcome));
+
+    // Then the record says so, rather than naming a set nothing declared.
+    const [email] = ses.sentEmails();
+
+    assertNonNullable(email);
+    assertUndefined(email.configurationSetName);
+  });
+
+  it("accepts a set name that was never created", async () => {
+    // Given a sending identity attached to a set nobody made.
+    const ses = await sendingSes();
+
+    await attachedSender(ses, "hello@example.com", "never-created");
+
+    // When a message is sent through it.
+    await ses.sendEmail(new SendEmailCommand(welcome));
+
+    // Then the send stands and the name is on the record. Real SES refuses
+    // one, and refusing here would fail a test over a set the developer left
+    // out of their local setup. A test wanting the strict reading asks the
+    // simulator for the set instead.
+    const [email] = ses.sentEmails();
+
+    assertNonNullable(email);
+    assertIdentical(email.configurationSetName, "never-created");
+    assertUndefined(ses.findConfigurationSet("never-created"));
+  });
+
+  it("refuses a send through a set with sending switched off", async () => {
+    // Given a set that declares sending off.
+    const ses = await sendingSes();
+
+    ses.verifyIdentity("hello@example.com");
+
+    await ses.createConfigurationSet(
+      new CreateConfigurationSetCommand({
+        ConfigurationSetName: "paused",
+        SendingOptions: { SendingEnabled: false },
+      }),
+    );
+
+    // When a message names it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(
+        new SendEmailCommand({ ...welcome, ConfigurationSetName: "paused" }),
+      );
+    });
+
+    // Then SES turned the message down and recorded nothing, because the
+    // switch is a declaration the caller wrote deliberately.
+    assertInstanceOf(error, SimSesSendingPausedException);
+    assertStringIncludes(error.message, "paused");
+    assertArrayLength(ses.sentEmails(), 0);
+  });
+
+  it("refuses a send the identity's own set has switched off", async () => {
+    // Given an identity attached to a set with sending off.
+    const ses = await sendingSes();
+
+    await ses.createConfigurationSet(
+      new CreateConfigurationSetCommand({
+        ConfigurationSetName: "paused",
+        SendingOptions: { SendingEnabled: false },
+      }),
+    );
+    await attachedSender(ses, "hello@example.com", "paused");
+
+    // When a message names no set of its own.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(new SendEmailCommand(welcome));
+    });
+
+    // Then it is refused just the same, since it went through that set.
+    assertInstanceOf(error, SimSesSendingPausedException);
+    assertArrayLength(ses.sentEmails(), 0);
+  });
+
+  it("sends a service message through the identity's set", async () => {
+    // Given the seam another simulated service sends through, and a sending
+    // identity with a set attached.
+    const ses = await sendingSes();
+
+    await attachedSender(ses, "hello@example.com", "transactional");
+
+    // When a service sends a message naming no set.
+    const result = ses.acceptServiceEmail({
+      fromEmailAddress: "hello@example.com",
+      toAddress: "someone@example.org",
+      replyToAddresses: [],
+      subject: "Your code",
+      body: "123456",
+      configurationSetName: undefined,
+    });
+
+    // Then it went through the identity's set, as a message from an SDK caller
+    // would have.
+    const [email] = ses.sentEmails();
+
+    assertNonNullable(result.messageId);
+    assertNonNullable(email);
+    assertIdentical(email.configurationSetName, "transactional");
+  });
+
+  it("turns a service message down where its set has sending off", async () => {
+    // Given a service sending through a set that declares sending off.
+    const ses = await sendingSes();
+
+    ses.verifyIdentity("hello@example.com");
+
+    await ses.createConfigurationSet(
+      new CreateConfigurationSetCommand({
+        ConfigurationSetName: "paused",
+        SendingOptions: { SendingEnabled: false },
+      }),
+    );
+
+    // When the message is offered.
+    const result = ses.acceptServiceEmail({
+      fromEmailAddress: "hello@example.com",
+      toAddress: "someone@example.org",
+      replyToAddresses: [],
+      subject: "Your code",
+      body: "123456",
+      configurationSetName: "paused",
+    });
+
+    // Then the refusal comes back for the sending service to report in its own
+    // vocabulary, and nothing is recorded.
+    assertNonNullable(result.refusedBecause);
+    assertStringIncludes(result.refusedBecause, "paused");
+    assertArrayLength(ses.sentEmails(), 0);
+  });
+});


### PR DESCRIPTION
An identity created with a configuration set lends it to any send that names none of its own, and the recorded message carries whichever set applied. A set whose `SendingOptions` turn sending off refuses a send made through it, on the SDK path and on the seam another simulated service sends through. A name `CreateConfigurationSet` never created is still accepted and still recorded, because failing a test over a set missing from a local setup fails for a reason unrelated to what the test asserts.

`SimSesConfigurationSetCheck` holds both halves. It resolves the set a send goes through, taking the one the send names or the one its sending identity carries, and it refuses a send through a set with `SendingEnabled` off. `SimSesIdentityStore.covering` picks the identity, giving an address's own set precedence over its domain's.

Resolves #883