### PR TITLE
feat: recommend from declared campaign results

### DIFF
--- a/docs/services/personalize/README.md
+++ b/docs/services/personalize/README.md
@@ -216,6 +216,9 @@ A ranking no rule matches comes back as the `inputList` in the order it arrived,
 descend and sum to one across the list. A test that cares about the order declares a rule for it,
 and every other test gets a stable answer.
 
+A rule says exactly what comes back. Declaring two of the three items a request carries answers with
+those two, where real Personalize ranks everything it was given.
+
 ### Declaring against a campaign
 
 The campaign has to exist first. `recommendations()` and `rankings()` raise

--- a/docs/services/personalize/README.md
+++ b/docs/services/personalize/README.md
@@ -71,6 +71,158 @@ A solution version ARN is the solution's with a version number on the end, count
 Personalize generates an opaque id there. This one counts so a test can write down the ARN it
 expects.
 
+## Recommendations from a campaign
+
+A campaign answers the runtime API from results declared against it. No model is fitted and no
+interaction history is held. A test says what one campaign recommends for one item, and the code
+under test makes the calls it would make against AWS.
+
+The two runtime operations live on `simAws.personalizeRuntime()`, and an intercepted
+`PersonalizeRuntimeClient` reaches the same place. They arrive from a separate SDK package
+(`@aws-sdk/client-personalize-runtime`), as they do on AWS.
+
+```typescript sim-personalize-recommendations
+/**
+ * Answering a related items request from declared recommendations.
+ */
+
+import {
+  CreateCampaignCommand,
+  CreateDatasetGroupCommand,
+  CreateSolutionCommand,
+  CreateSolutionVersionCommand,
+} from "@aws-sdk/client-personalize";
+import { GetRecommendationsCommand } from "@aws-sdk/client-personalize-runtime";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const group = await simAws
+  .personalize()
+  .createDatasetGroup(new CreateDatasetGroupCommand({ name: "catalogue" }));
+const solution = await simAws.personalize().createSolution(
+  new CreateSolutionCommand({
+    name: "related-entries",
+    datasetGroupArn: group.datasetGroupArn,
+    recipeArn: "arn:aws:personalize:::recipe/aws-similar-items",
+  }),
+);
+const version = await simAws
+  .personalize()
+  .createSolutionVersion(
+    new CreateSolutionVersionCommand({ solutionArn: solution.solutionArn }),
+  );
+const campaign = await simAws.personalize().createCampaign(
+  new CreateCampaignCommand({
+    name: "related-entries",
+    solutionVersionArn: version.solutionVersionArn,
+  }),
+);
+
+const campaignArn = campaign.campaignArn!;
+
+// What this campaign recommends for one entry.
+simAws
+  .personalize()
+  .recommendations(campaignArn)
+  .onItem("entry-1042", { itemIds: ["entry-2071", "entry-3388"] });
+
+const recommended = await simAws.personalizeRuntime().getRecommendations(
+  new GetRecommendationsCommand({
+    campaignArn,
+    itemId: "entry-1042",
+    numResults: 2,
+  }),
+);
+
+// entry-2071 entry-3388
+console.log(recommended.itemList?.map((item) => item.itemId).join(" "));
+```
+
+Results are declared per campaign, through `recommendations()` and `rankings()`. A campaign serves
+one solution version trained on one recipe, and two campaigns in a dataset group answer the same
+entry differently.
+
+An item rule is read first where the request carries an item, then a user rule, then the default.
+That order follows the recipes. `aws-similar-items` requires an `itemId` and looks at no user, and
+the user personalization recipes require a `userId`. Each request reaches the tier its own recipe
+would have used. Matching is exact, with no pattern syntax.
+
+`numResults` cuts a declared list to length. A request no rule matches gets the campaign's default,
+and an empty `itemList` where no default is declared.
+
+An item is declared as an id on its own, or as an id with a score for a test to assert on. The
+number comes from the declaration, and a rule that leaves it out answers with an item carrying no
+score.
+
+```typescript sim-personalize-recommendation-scores
+/**
+ * Declaring the scores a campaign reports with its recommendations.
+ */
+
+import type { SimAws } from "@kensio/yulin";
+
+declare const simAws: SimAws;
+declare const campaignArn: string;
+
+simAws
+  .personalize()
+  .recommendations(campaignArn)
+  .onItem("entry-1042", {
+    itemIds: [
+      { itemId: "entry-2071", score: 0.62 },
+      { itemId: "entry-3388", score: 0.38 },
+    ],
+    recommendationId: "RID-related-entries",
+  });
+```
+
+### Rankings
+
+`GetPersonalizedRanking` carries the items in the request and asks for an order to put them in.
+Rules are declared against the user, because that is what a ranking request names.
+
+```typescript sim-personalize-rankings
+/**
+ * Ranking a list of entries for one user.
+ */
+
+import { GetPersonalizedRankingCommand } from "@aws-sdk/client-personalize-runtime";
+
+import type { SimAws } from "@kensio/yulin";
+
+declare const simAws: SimAws;
+declare const campaignArn: string;
+
+simAws
+  .personalize()
+  .rankings(campaignArn)
+  .onUser("user-77", { itemIds: ["entry-3", "entry-1", "entry-2"] });
+
+const ranked = await simAws.personalizeRuntime().getPersonalizedRanking(
+  new GetPersonalizedRankingCommand({
+    campaignArn,
+    userId: "user-77",
+    inputList: ["entry-1", "entry-2", "entry-3"],
+  }),
+);
+
+// entry-3 entry-1 entry-2
+console.log(ranked.personalizedRanking?.map((item) => item.itemId).join(" "));
+```
+
+A ranking no rule matches comes back as the `inputList` in the order it arrived, with scores that
+descend and sum to one across the list. A test that cares about the order declares a rule for it,
+and every other test gets a stable answer.
+
+### Declaring against a campaign
+
+The campaign has to exist first. `recommendations()` and `rankings()` raise
+`SimPersonalizeDeclarationError` for an ARN no campaign is deployed at. A typo is reported where it
+was typed. A runtime call naming one raises `ResourceNotFoundException`, as real Personalize
+Runtime does.
+
 ## Datasets and schemas
 
 A dataset belongs to a dataset group and has one of five types. The dataset ARN carries the group
@@ -205,12 +357,25 @@ Every command works through `simAws.personalize()` and through an intercepted `P
 Each one authorizes through simulated IAM, against the resource ARN where the request names one and
 against `*` on a create.
 
+The runtime API has `GetRecommendations` and `GetPersonalizedRanking`. Both work through
+`simAws.personalizeRuntime()` and through an intercepted `PersonalizeRuntimeClient`, and both
+authorize against the campaign ARN the request names.
+
 ## Divergences and limitations
 
 - **Training is skipped.** `CreateSolutionVersion` gives an `ACTIVE` version immediately. Real
   Personalize spends tens of minutes fitting a model and reports `CREATE PENDING` first.
-- **Recommendations come later.** `GetRecommendations` and `GetPersonalizedRanking` belong to the
-  Personalize Runtime API, which has its own issue.
+- **A recommendation is declared, never computed.** A campaign answers with the items a rule gives
+  it. A score comes from the declaration as well, and an item declared without one comes back
+  without one.
+- **An unknown item gets the default.** Real Personalize answers an `itemId` it does not recognise
+  with popular items, worked out from the interaction history. Simulated Personalize holds no
+  interactions. It answers with the campaign's declared default, and with an empty `itemList` where
+  nothing is declared.
+- **No filters.** `CreateFilter` takes an expression over item and interaction metadata that this
+  simulation leaves out by design. A runtime request naming a `filterArn` is refused by name.
+- **No `GetActionRecommendations`.** Actions are a dataset type with interactions of their own, and
+  the Next-Best-Action operations arrive with them.
 - **No events.** `PutEvents`, `PutItems`, `PutUsers` and event trackers arrive with the events API.
 - **No recommenders.** `CreateRecommender` and the ten domain use cases arrive with the domain
   path.

--- a/docs/services/personalize/README.md
+++ b/docs/services/personalize/README.md
@@ -371,10 +371,10 @@ authorize against the campaign ARN the request names.
 - **A recommendation is declared, never computed.** A campaign answers with the items a rule gives
   it. A score comes from the declaration as well, and an item declared without one comes back
   without one.
-- **An unknown item gets the default.** Real Personalize answers an `itemId` it does not recognise
-  with popular items, worked out from the interaction history. Simulated Personalize holds no
-  interactions. It answers with the campaign's declared default, and with an empty `itemList` where
-  nothing is declared.
+- **A request no rule matches gets the default.** Real Personalize answers an `itemId` it does not
+  recognise with popular items, worked out from the interaction history. Simulated Personalize
+  holds no interactions. A request carrying an unknown item falls to the user rule where it names a
+  user and one is declared, then to the campaign's default, and then to an empty `itemList`.
 - **No filters.** `CreateFilter` takes an expression over item and interaction metadata that this
   simulation leaves out by design. A runtime request naming a `filterArn` is refused by name.
 - **No `GetActionRecommendations`.** Actions are a dataset type with interactions of their own, and

--- a/docs/services/personalize/sim-personalize-rankings.example.ts
+++ b/docs/services/personalize/sim-personalize-rankings.example.ts
@@ -1,0 +1,26 @@
+/**
+ * Ranking a list of entries for one user.
+ */
+
+import { GetPersonalizedRankingCommand } from "@aws-sdk/client-personalize-runtime";
+
+import type { SimAws } from "@kensio/yulin";
+
+declare const simAws: SimAws;
+declare const campaignArn: string;
+
+simAws
+  .personalize()
+  .rankings(campaignArn)
+  .onUser("user-77", { itemIds: ["entry-3", "entry-1", "entry-2"] });
+
+const ranked = await simAws.personalizeRuntime().getPersonalizedRanking(
+  new GetPersonalizedRankingCommand({
+    campaignArn,
+    userId: "user-77",
+    inputList: ["entry-1", "entry-2", "entry-3"],
+  }),
+);
+
+// entry-3 entry-1 entry-2
+console.log(ranked.personalizedRanking?.map((item) => item.itemId).join(" "));

--- a/docs/services/personalize/sim-personalize-recommendation-scores.example.ts
+++ b/docs/services/personalize/sim-personalize-recommendation-scores.example.ts
@@ -1,0 +1,19 @@
+/**
+ * Declaring the scores a campaign reports with its recommendations.
+ */
+
+import type { SimAws } from "@kensio/yulin";
+
+declare const simAws: SimAws;
+declare const campaignArn: string;
+
+simAws
+  .personalize()
+  .recommendations(campaignArn)
+  .onItem("entry-1042", {
+    itemIds: [
+      { itemId: "entry-2071", score: 0.62 },
+      { itemId: "entry-3388", score: 0.38 },
+    ],
+    recommendationId: "RID-related-entries",
+  });

--- a/docs/services/personalize/sim-personalize-recommendations.example.ts
+++ b/docs/services/personalize/sim-personalize-recommendations.example.ts
@@ -1,0 +1,56 @@
+/**
+ * Answering a related items request from declared recommendations.
+ */
+
+import {
+  CreateCampaignCommand,
+  CreateDatasetGroupCommand,
+  CreateSolutionCommand,
+  CreateSolutionVersionCommand,
+} from "@aws-sdk/client-personalize";
+import { GetRecommendationsCommand } from "@aws-sdk/client-personalize-runtime";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const group = await simAws
+  .personalize()
+  .createDatasetGroup(new CreateDatasetGroupCommand({ name: "catalogue" }));
+const solution = await simAws.personalize().createSolution(
+  new CreateSolutionCommand({
+    name: "related-entries",
+    datasetGroupArn: group.datasetGroupArn,
+    recipeArn: "arn:aws:personalize:::recipe/aws-similar-items",
+  }),
+);
+const version = await simAws
+  .personalize()
+  .createSolutionVersion(
+    new CreateSolutionVersionCommand({ solutionArn: solution.solutionArn }),
+  );
+const campaign = await simAws.personalize().createCampaign(
+  new CreateCampaignCommand({
+    name: "related-entries",
+    solutionVersionArn: version.solutionVersionArn,
+  }),
+);
+
+const campaignArn = campaign.campaignArn!;
+
+// What this campaign recommends for one entry.
+simAws
+  .personalize()
+  .recommendations(campaignArn)
+  .onItem("entry-1042", { itemIds: ["entry-2071", "entry-3388"] });
+
+const recommended = await simAws.personalizeRuntime().getRecommendations(
+  new GetRecommendationsCommand({
+    campaignArn,
+    itemId: "entry-1042",
+    numResults: 2,
+  }),
+);
+
+// entry-2071 entry-3388
+console.log(recommended.itemList?.map((item) => item.itemId).join(" "));

--- a/package.json
+++ b/package.json
@@ -212,6 +212,7 @@
     "@aws-sdk/client-kms": "^3.1101.0",
     "@aws-sdk/client-lambda": "^3.1101.0",
     "@aws-sdk/client-personalize": "^3.1115.0",
+    "@aws-sdk/client-personalize-runtime": "^3.1115.0",
     "@aws-sdk/client-rekognition": "^3.1101.0",
     "@aws-sdk/client-route-53": "^3.1101.0",
     "@aws-sdk/client-s3": "^3.1101.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       '@aws-sdk/client-personalize':
         specifier: ^3.1115.0
         version: 3.1115.0
+      '@aws-sdk/client-personalize-runtime':
+        specifier: ^3.1115.0
+        version: 3.1115.0
       '@aws-sdk/client-rekognition':
         specifier: ^3.1101.0
         version: 3.1110.0
@@ -349,6 +352,10 @@ packages:
 
   '@aws-sdk/client-lambda@3.1110.0':
     resolution: {integrity: sha512-1YI5iNhtJmTV0KAXAsUylPS1958o04a7sBlryMqJsdJUyRL6viot3aKRUMNbRgLdRReSiD5Cl5uVlT8dnpJe7g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-personalize-runtime@3.1115.0':
+    resolution: {integrity: sha512-x2lPen9vdo1YsODYJEX9o/z4fYTDf1k7DXcPqyahVcOW7PT62VSPW7+lGcAL16BAUHq32C5jK5XCKwHinaXgWw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-personalize@3.1115.0':
@@ -3785,6 +3792,17 @@ snapshots:
       tslib: 2.8.1
 
   '@aws-sdk/client-lambda@3.1110.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/credential-provider-node': 3.972.80
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/client-personalize-runtime@3.1115.0':
     dependencies:
       '@aws-sdk/core': 3.977.8
       '@aws-sdk/credential-provider-node': 3.972.80

--- a/src/sdk/router/resolve-sim-sdk-command-router.ts
+++ b/src/sdk/router/resolve-sim-sdk-command-router.ts
@@ -91,6 +91,11 @@ const scopedRouters: ReadonlyMap<string, SimSdkScopedRouter> = new Map<
     (scoped): SimSdkCommandRouter => scoped.personalize().sdkCommandRouter(),
   ],
   [
+    "Personalize Runtime",
+    (scoped): SimSdkCommandRouter =>
+      scoped.personalizeRuntime().sdkCommandRouter(),
+  ],
+  [
     "Rekognition",
     (scoped): SimSdkCommandRouter => scoped.rekognition().sdkCommandRouter(),
   ],

--- a/src/service/aws/sim-aws-account-region-scope.ts
+++ b/src/service/aws/sim-aws-account-region-scope.ts
@@ -17,7 +17,10 @@ import type { SimEcr } from "../ecr/index.js";
 import type { SimEcs } from "../ecs/index.js";
 import type { SimEventBridge } from "../eventbridge/index.js";
 import type { SimCognitoIdentityProvider } from "../cognito/index.js";
-import type { SimPersonalize } from "../personalize/index.js";
+import type {
+  SimPersonalize,
+  SimPersonalizeRuntime,
+} from "../personalize/index.js";
 import type { SimRekognition } from "../rekognition/index.js";
 import type { SimRoute53 } from "../route53/index.js";
 import type { SimAcm } from "../acm/sim-acm.js";
@@ -200,6 +203,17 @@ export class SimAwsAccountRegionContainer {
     return this.memo.getOrCreate("personalize", () =>
       this.factory.createPersonalize(this),
     );
+  }
+
+  /**
+   * Get the simulated Personalize Runtime API for this account and region.
+   *
+   * It is not made here, unlike the services around it. The campaigns it
+   * answers for are the ones this scope's Personalize holds, so it belongs to
+   * that service and is reached through it.
+   */
+  personalizeRuntime(): SimPersonalizeRuntime {
+    return this.personalize().runtime();
   }
 
   /** Get simulated Rekognition for this account and region. */

--- a/src/service/aws/sim-aws-service-accessors.ts
+++ b/src/service/aws/sim-aws-service-accessors.ts
@@ -18,7 +18,10 @@ import type { SimIam } from "../iam/index.js";
 import type { SimKms } from "../kms/index.js";
 import type { SimLambda } from "../lambda/index.js";
 import type { SimLogs } from "../logs/index.js";
-import type { SimPersonalize } from "../personalize/index.js";
+import type {
+  SimPersonalize,
+  SimPersonalizeRuntime,
+} from "../personalize/index.js";
 import type { SimRekognition } from "../rekognition/index.js";
 import type { SimRoute53 } from "../route53/index.js";
 import type { SimS3 } from "../s3/sim-s3.js";
@@ -146,6 +149,14 @@ export abstract class SimAwsServiceAccessors {
   /** Get simulated Personalize in the default Account Region scope. */
   personalize(): SimPersonalize {
     return this.defaultAccountRegionScope().personalize();
+  }
+
+  /**
+   * Get the simulated Personalize Runtime API in the default Account Region
+   * scope.
+   */
+  personalizeRuntime(): SimPersonalizeRuntime {
+    return this.defaultAccountRegionScope().personalizeRuntime();
   }
 
   /** Get simulated Rekognition in the default Account Region scope. */

--- a/src/service/aws/sim-aws.iso.test.ts
+++ b/src/service/aws/sim-aws.iso.test.ts
@@ -97,6 +97,14 @@ describe("SimAws", () => {
     assertIdentical(simAws.dynamoDb(), simAws.region().account().dynamoDb());
   });
 
+  it("returns the runtime API of the Personalize in the same scope", () => {
+    const simAws = new SimAws();
+    const runtime = simAws.personalize().runtime();
+
+    assertIdentical(simAws.personalizeRuntime(), runtime);
+    assertIdentical(simAws.account().region().personalizeRuntime(), runtime);
+  });
+
   it("returns the Streams API of the DynamoDB in the same scope", () => {
     const simAws = new SimAws();
     const streams = simAws.dynamoDb().streams();

--- a/src/service/personalize/README.md
+++ b/src/service/personalize/README.md
@@ -80,7 +80,8 @@ list to rank, and an item rule would be one nothing could match. A ranking no ru
 answered from the request's own `inputList`. The default there starts as `undefined` to leave room
 for that case.
 
-A campaign is required to exist before anything is declared against it, following
+A campaign is required to exist before anything is declared against it. An ARN no campaign is
+deployed at raises `SimPersonalizeDeclarationError`, which follows simulated Rekognition's
 `SimRekognitionDeclarationError`. The ARN would otherwise be a typo nothing reported.
 
 ## Deletion rules

--- a/src/service/personalize/README.md
+++ b/src/service/personalize/README.md
@@ -18,8 +18,16 @@ use case a recipe names decides which parameters a recommendation request has to
 
 ## Entry points
 
-- `sim-personalize.ts` is the main in-memory service object for one account/region scope. It is a
-  list of the operations Personalize answers, with the work delegated to the command groups.
+- `sim-personalize.ts` is the main in-memory service object for one account/region scope. It holds
+  the runtime API, the rules declared against campaigns, and the accessors a test reads state back
+  through.
+- `sim-personalize-control-plane.ts` is the abstract base it extends, carrying the twenty-two
+  control plane operations. The split keeps `sim-personalize.ts` from being that list and nothing
+  else, and it is the split AWS makes between the `personalize` endpoint and `personalize-runtime`.
+- `sim-personalize-runtime.ts` is the runtime API, reached through `simAws.personalizeRuntime()` or
+  through `runtime()` on the service. It is a second API over one service's state, in the way
+  simulated DynamoDB Streams is over simulated DynamoDB. The Account/Region scope builds no service
+  for it, and reaches it through the Personalize it already holds.
 - `index.ts` exports the public Personalize simulator API for `@kensio/yulin/personalize`.
 
 ## Resource model
@@ -55,6 +63,26 @@ only that it has no permission, and the existence of the resource stays hidden.
 `command/list/sim-personalize-page.ts` is shared by all six list operations. The pagination token is
 the index the next page starts at, where real Personalize hands out an opaque string.
 
+## Declared results
+
+The runtime API answers from rules held per campaign under `recommendation/`. That is the resource
+real Personalize answers a runtime call from. A campaign serves one solution version trained on one
+recipe, and two campaigns answer the same item differently.
+
+`SimDeclaredResultRules` in `util/rule/` does the matching, and simulated Rekognition matches images
+with it too. It holds a leading key, a trailing key and a default, matched exactly and in that
+order. Personalize puts the item id in the leading tier and the user id in the trailing one. That
+order follows the recipes. `aws-similar-items` requires an `itemId` and looks at no user, and the
+user personalization recipes require a `userId`.
+
+Rankings carry a user rule and a default, and no item rule. A ranking request names a user and the
+list to rank, and an item rule would be one nothing could match. A ranking no rule matches is
+answered from the request's own `inputList`. The default there starts as `undefined` to leave room
+for that case.
+
+A campaign is required to exist before anything is declared against it, following
+`SimRekognitionDeclarationError`. The ARN would otherwise be a typo nothing reported.
+
 ## Deletion rules
 
 Real Personalize refuses to delete a resource other resources still depend on, and these do the
@@ -66,5 +94,5 @@ either.
 
 ## What comes next
 
-The runtime API, the events API, CloudFormation resource types and domain recommenders are all
-separate issues. Each of them builds on what is here.
+The events API, CloudFormation resource types and domain recommenders are all separate issues. Each
+of them builds on what is here.

--- a/src/service/personalize/command/runtime/runtime.command.ts
+++ b/src/service/personalize/command/runtime/runtime.command.ts
@@ -1,0 +1,58 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * One item a runtime call answers with.
+ *
+ * A score is reported only where the declaration carried one. Real
+ * Personalize scores every item it returns, from the model behind the
+ * campaign, and simulated Personalize has no model to score from.
+ */
+export interface SimPersonalizePredictedItem {
+  readonly itemId?: string | undefined;
+  readonly score?: number | undefined;
+}
+
+/**
+ * Minimal structural sim Personalize Runtime GetRecommendations command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/personalize-runtime/command/GetRecommendationsCommand/
+ */
+export interface SimGetRecommendationsCommand {
+  readonly input: SimGetRecommendationsCommandInput;
+}
+
+export interface SimGetRecommendationsCommandInput {
+  readonly campaignArn?: string | undefined;
+  readonly itemId?: string | undefined;
+  readonly userId?: string | undefined;
+  readonly numResults?: number | undefined;
+}
+
+export interface SimGetRecommendationsCommandOutput {
+  readonly itemList?: readonly SimPersonalizePredictedItem[] | undefined;
+  readonly recommendationId?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Personalize Runtime GetPersonalizedRanking command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/personalize-runtime/command/GetPersonalizedRankingCommand/
+ */
+export interface SimGetPersonalizedRankingCommand {
+  readonly input: SimGetPersonalizedRankingCommandInput;
+}
+
+export interface SimGetPersonalizedRankingCommandInput {
+  readonly campaignArn?: string | undefined;
+  readonly inputList?: readonly string[] | undefined;
+  readonly userId?: string | undefined;
+}
+
+export interface SimGetPersonalizedRankingCommandOutput {
+  readonly personalizedRanking?:
+    | readonly SimPersonalizePredictedItem[]
+    | undefined;
+  readonly recommendationId?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/personalize/command/runtime/sim-personalize-get-personalized-ranking.ts
+++ b/src/service/personalize/command/runtime/sim-personalize-get-personalized-ranking.ts
@@ -1,0 +1,59 @@
+import {
+  simPersonalizeItemList,
+  simPersonalizeRankedInputList,
+} from "../../view/sim-personalize-item-list-view.js";
+import { SimPersonalizeUnsimulatedInput } from "../sim-personalize-unsimulated-input.js";
+import type { SimPersonalizeRequestOptions } from "../sim-personalize-request-options.js";
+import type {
+  SimGetPersonalizedRankingCommand,
+  SimGetPersonalizedRankingCommandOutput,
+} from "./runtime.command.js";
+import { SimPersonalizeRuntimeCommandGroup } from "./sim-personalize-runtime-command-group.js";
+import {
+  requireSimPersonalizeInputList,
+  requireSimPersonalizeUserId,
+} from "./sim-personalize-runtime-input.js";
+
+const action = "personalize:GetPersonalizedRanking";
+
+const accepted = ["campaignArn", "inputList", "userId"];
+
+const unsimulated = new SimPersonalizeUnsimulatedInput(
+  "GetPersonalizedRanking",
+);
+
+/**
+ * Handles a GetPersonalizedRanking command.
+ *
+ * A user rule declared against the campaign says what order the items come
+ * back in. Where no rule matches, the request's own list comes back in the
+ * order it arrived, so a test that is not about the ranking still gets a
+ * stable answer.
+ */
+export class SimPersonalizeGetPersonalizedRankingHandler extends SimPersonalizeRuntimeCommandGroup {
+  /**
+   * Rank the items a request carries as the campaign is declared to rank them.
+   */
+  handle(
+    command: SimGetPersonalizedRankingCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): SimGetPersonalizedRankingCommandOutput {
+    const { input } = command;
+
+    unsimulated.refuseUnaccepted(input, accepted);
+
+    const campaign = this.campaign(input.campaignArn, action, options);
+    const inputList = requireSimPersonalizeInputList(input.inputList);
+    const userId = requireSimPersonalizeUserId(input.userId);
+    const declared = this.rules.rankings(campaign.arn).itemsFor(userId);
+
+    return {
+      personalizedRanking:
+        declared === undefined
+          ? simPersonalizeRankedInputList(inputList)
+          : simPersonalizeItemList(declared.itemIds),
+      recommendationId: declared?.recommendationId,
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/personalize/command/runtime/sim-personalize-get-recommendations.ts
+++ b/src/service/personalize/command/runtime/sim-personalize-get-recommendations.ts
@@ -1,0 +1,49 @@
+import { simPersonalizeItemList } from "../../view/sim-personalize-item-list-view.js";
+import { SimPersonalizeUnsimulatedInput } from "../sim-personalize-unsimulated-input.js";
+import type { SimPersonalizeRequestOptions } from "../sim-personalize-request-options.js";
+import type {
+  SimGetRecommendationsCommand,
+  SimGetRecommendationsCommandOutput,
+} from "./runtime.command.js";
+import { SimPersonalizeRuntimeCommandGroup } from "./sim-personalize-runtime-command-group.js";
+import { requireSimPersonalizeResultCount } from "./sim-personalize-runtime-input.js";
+
+const action = "personalize:GetRecommendations";
+
+const accepted = ["campaignArn", "itemId", "userId", "numResults"];
+
+const unsimulated = new SimPersonalizeUnsimulatedInput("GetRecommendations");
+
+/**
+ * Handles a GetRecommendations command.
+ *
+ * The recommendations come from what is declared against the campaign the
+ * request names, and nothing else is read. An item rule answers a request
+ * carrying an item, a user rule answers one carrying a user, and a request
+ * matching neither is answered with the campaign's default.
+ */
+export class SimPersonalizeGetRecommendationsHandler extends SimPersonalizeRuntimeCommandGroup {
+  /**
+   * Recommend the items a campaign is declared to recommend.
+   */
+  handle(
+    command: SimGetRecommendationsCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): SimGetRecommendationsCommandOutput {
+    const { input } = command;
+
+    unsimulated.refuseUnaccepted(input, accepted);
+
+    const campaign = this.campaign(input.campaignArn, action, options);
+    const resultCount = requireSimPersonalizeResultCount(input.numResults);
+    const declared = this.rules
+      .recommendations(campaign.arn)
+      .itemsFor({ itemId: input.itemId, userId: input.userId });
+
+    return {
+      itemList: simPersonalizeItemList(declared.itemIds).slice(0, resultCount),
+      recommendationId: declared.recommendationId,
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/personalize/command/runtime/sim-personalize-rankings.iso.test.ts
+++ b/src/service/personalize/command/runtime/sim-personalize-rankings.iso.test.ts
@@ -1,0 +1,198 @@
+import {
+  CreateCampaignCommand,
+  CreateDatasetGroupCommand,
+  CreateSolutionCommand,
+  CreateSolutionVersionCommand,
+} from "@aws-sdk/client-personalize";
+import { GetPersonalizedRankingCommand } from "@aws-sdk/client-personalize-runtime";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+
+const rankingRecipe = "arn:aws:personalize:::recipe/aws-personalized-ranking";
+
+/**
+ * Deploy a campaign, which is what a runtime call names and what results are
+ * declared against.
+ */
+async function givenACampaign(
+  simAws: SimAws,
+  name = "ranked-entries",
+): Promise<string> {
+  const group = await simAws
+    .personalize()
+    .createDatasetGroup(
+      new CreateDatasetGroupCommand({ name: `${name}-group` }),
+    );
+  const solution = await simAws.personalize().createSolution(
+    new CreateSolutionCommand({
+      name,
+      datasetGroupArn: group.datasetGroupArn,
+      recipeArn: rankingRecipe,
+    }),
+  );
+  const version = await simAws
+    .personalize()
+    .createSolutionVersion(
+      new CreateSolutionVersionCommand({ solutionArn: solution.solutionArn }),
+    );
+  const campaign = await simAws.personalize().createCampaign(
+    new CreateCampaignCommand({
+      name,
+      solutionVersionArn: version.solutionVersionArn,
+    }),
+  );
+
+  assertNonNullable(campaign.campaignArn);
+
+  return campaign.campaignArn;
+}
+
+describe("Personalize GetPersonalizedRanking", () => {
+  it("ranks the input list as a user rule declares", async () => {
+    // Given a campaign ranking three entries for one user.
+    const simAws = new SimAws();
+    const campaignArn = await givenACampaign(simAws);
+
+    simAws
+      .personalize()
+      .rankings(campaignArn)
+      .onUser("user-77", { itemIds: ["entry-3", "entry-1", "entry-2"] });
+
+    // When that user's list is ranked.
+    const ranked = await simAws.personalizeRuntime().getPersonalizedRanking(
+      new GetPersonalizedRankingCommand({
+        campaignArn,
+        userId: "user-77",
+        inputList: ["entry-1", "entry-2", "entry-3"],
+      }),
+    );
+
+    // Then the declared order is the one that came back.
+    assertArrayEquals(
+      (ranked.personalizedRanking ?? []).map((item) => item.itemId),
+      ["entry-3", "entry-1", "entry-2"],
+    );
+  });
+
+  it("keeps the input order where no rule matches", async () => {
+    // Given a campaign with nothing declared against it.
+    const simAws = new SimAws();
+    const campaignArn = await givenACampaign(simAws);
+
+    // When a list is ranked.
+    const ranked = await simAws.personalizeRuntime().getPersonalizedRanking(
+      new GetPersonalizedRankingCommand({
+        campaignArn,
+        userId: "user-77",
+        inputList: ["entry-1", "entry-2", "entry-3"],
+      }),
+    );
+
+    // Then it comes back in the order it arrived, scored downwards.
+    assertNonNullable(ranked.personalizedRanking);
+    assertArrayEquals(
+      ranked.personalizedRanking.map((item) => item.itemId),
+      ["entry-1", "entry-2", "entry-3"],
+    );
+    assertArrayEquals(
+      ranked.personalizedRanking.map((item) => item.score),
+      [3 / 6, 2 / 6, 1 / 6],
+    );
+  });
+
+  it("scores a ranking it was not told about to one", async () => {
+    // Given a campaign with nothing declared against it.
+    const simAws = new SimAws();
+    const campaignArn = await givenACampaign(simAws);
+
+    // When a list is ranked.
+    const ranked = await simAws.personalizeRuntime().getPersonalizedRanking(
+      new GetPersonalizedRankingCommand({
+        campaignArn,
+        userId: "user-77",
+        inputList: ["entry-1", "entry-2", "entry-3", "entry-4"],
+      }),
+    );
+
+    // Then the scores sum to one across the list, as a real ranking's do.
+    const total = (ranked.personalizedRanking ?? []).reduce(
+      (sum, item) => sum + (item.score ?? 0),
+      0,
+    );
+    assertTrue(Math.abs(total - 1) < 0.000001);
+  });
+
+  it("answers a user no rule matches from the default", async () => {
+    // Given a campaign with a default ranking and a rule for one user.
+    const simAws = new SimAws();
+    const campaignArn = await givenACampaign(simAws);
+    const rankings = simAws.personalize().rankings(campaignArn);
+
+    rankings.byDefault({ itemIds: ["entry-2", "entry-1"] });
+    rankings.onUser("user-77", { itemIds: ["entry-1", "entry-2"] });
+
+    // When another user's list is ranked.
+    const ranked = await simAws.personalizeRuntime().getPersonalizedRanking(
+      new GetPersonalizedRankingCommand({
+        campaignArn,
+        userId: "user-99",
+        inputList: ["entry-1", "entry-2"],
+      }),
+    );
+
+    // Then the default answered it.
+    assertArrayEquals(
+      (ranked.personalizedRanking ?? []).map((item) => item.itemId),
+      ["entry-2", "entry-1"],
+    );
+  });
+
+  it("requires a user to rank for", async () => {
+    // Given a campaign.
+    const simAws = new SimAws();
+    const campaignArn = await givenACampaign(simAws);
+
+    // When a ranking names no user. The SDK's own types require one, so the
+    // request is written out as the command the simulator takes.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.personalizeRuntime().getPersonalizedRanking({
+          input: { campaignArn, inputList: ["entry-1"] },
+        }),
+    );
+
+    // Then it is refused as invalid input, as real Personalize refuses it.
+    assertIdentical(error.name, "InvalidInputException");
+    assertStringIncludes(error.message, "userId");
+  });
+
+  it("requires a list to rank", async () => {
+    // Given a campaign.
+    const simAws = new SimAws();
+    const campaignArn = await givenACampaign(simAws);
+
+    // When a ranking carries no items.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.personalizeRuntime().getPersonalizedRanking(
+          new GetPersonalizedRankingCommand({
+            campaignArn,
+            userId: "user-77",
+            inputList: [],
+          }),
+        ),
+    );
+
+    // Then it is refused as invalid input.
+    assertIdentical(error.name, "InvalidInputException");
+    assertStringIncludes(error.message, "inputList");
+  });
+});

--- a/src/service/personalize/command/runtime/sim-personalize-rankings.iso.test.ts
+++ b/src/service/personalize/command/runtime/sim-personalize-rankings.iso.test.ts
@@ -9,6 +9,7 @@ import {
   assertArrayEquals,
   assertIdentical,
   assertNonNullable,
+  assertObjectEquals,
   assertStringIncludes,
   assertThrowsErrorAsync,
   assertTrue,
@@ -80,6 +81,67 @@ describe("Personalize GetPersonalizedRanking", () => {
       (ranked.personalizedRanking ?? []).map((item) => item.itemId),
       ["entry-3", "entry-1", "entry-2"],
     );
+  });
+
+  it("reports the scores a ranking rule declares", async () => {
+    // Given a campaign ranking two entries with scores of their own.
+    const simAws = new SimAws();
+    const campaignArn = await givenACampaign(simAws);
+
+    simAws
+      .personalize()
+      .rankings(campaignArn)
+      .onUser("user-77", {
+        itemIds: [
+          { itemId: "entry-2", score: 0.7 },
+          { itemId: "entry-1", score: 0.3 },
+        ],
+      });
+
+    // When that user's list is ranked.
+    const ranked = await simAws.personalizeRuntime().getPersonalizedRanking(
+      new GetPersonalizedRankingCommand({
+        campaignArn,
+        userId: "user-77",
+        inputList: ["entry-1", "entry-2"],
+      }),
+    );
+
+    // Then the declaration's own numbers come back with the order.
+    assertNonNullable(ranked.personalizedRanking);
+    assertArrayEquals(
+      ranked.personalizedRanking.map((item) => item.itemId),
+      ["entry-2", "entry-1"],
+    );
+    assertArrayEquals(
+      ranked.personalizedRanking.map((item) => item.score),
+      [0.7, 0.3],
+    );
+  });
+
+  it("leaves the score out where a rule declares none", async () => {
+    // Given a campaign ranking entries with no scores declared.
+    const simAws = new SimAws();
+    const campaignArn = await givenACampaign(simAws);
+
+    simAws
+      .personalize()
+      .rankings(campaignArn)
+      .onUser("user-77", { itemIds: ["entry-2", "entry-1"] });
+
+    // When that user's list is ranked.
+    const ranked = await simAws.personalizeRuntime().getPersonalizedRanking(
+      new GetPersonalizedRankingCommand({
+        campaignArn,
+        userId: "user-77",
+        inputList: ["entry-1", "entry-2"],
+      }),
+    );
+
+    // Then each item carries an id and nothing else, as real Personalize
+    // reports an item its recipe scores no number for.
+    assertNonNullable(ranked.personalizedRanking);
+    assertObjectEquals(ranked.personalizedRanking[0], { itemId: "entry-2" });
   });
 
   it("keeps the input order where no rule matches", async () => {

--- a/src/service/personalize/command/runtime/sim-personalize-recommendations.iso.test.ts
+++ b/src/service/personalize/command/runtime/sim-personalize-recommendations.iso.test.ts
@@ -1,0 +1,314 @@
+import {
+  CreateCampaignCommand,
+  CreateDatasetGroupCommand,
+  CreateSolutionCommand,
+  CreateSolutionVersionCommand,
+} from "@aws-sdk/client-personalize";
+import { GetRecommendationsCommand } from "@aws-sdk/client-personalize-runtime";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+
+const similarItemsRecipe = "arn:aws:personalize:::recipe/aws-similar-items";
+
+/**
+ * Deploy a campaign, which is what a runtime call names and what results are
+ * declared against.
+ */
+async function givenACampaign(
+  simAws: SimAws,
+  name = "related-entries",
+): Promise<string> {
+  const group = await simAws
+    .personalize()
+    .createDatasetGroup(
+      new CreateDatasetGroupCommand({ name: `${name}-group` }),
+    );
+  const solution = await simAws.personalize().createSolution(
+    new CreateSolutionCommand({
+      name,
+      datasetGroupArn: group.datasetGroupArn,
+      recipeArn: similarItemsRecipe,
+    }),
+  );
+  const version = await simAws
+    .personalize()
+    .createSolutionVersion(
+      new CreateSolutionVersionCommand({ solutionArn: solution.solutionArn }),
+    );
+  const campaign = await simAws.personalize().createCampaign(
+    new CreateCampaignCommand({
+      name,
+      solutionVersionArn: version.solutionVersionArn,
+    }),
+  );
+
+  assertNonNullable(campaign.campaignArn);
+
+  return campaign.campaignArn;
+}
+
+describe("Personalize GetRecommendations", () => {
+  it("answers a related items request from an item rule", async () => {
+    // Given a campaign with recommendations declared for one entry.
+    const simAws = new SimAws();
+    const campaignArn = await givenACampaign(simAws);
+
+    simAws
+      .personalize()
+      .recommendations(campaignArn)
+      .onItem("entry-1042", { itemIds: ["entry-2071", "entry-3388"] });
+
+    // When the runtime is asked what is similar to that entry.
+    const recommended = await simAws
+      .personalizeRuntime()
+      .getRecommendations(
+        new GetRecommendationsCommand({ campaignArn, itemId: "entry-1042" }),
+      );
+
+    // Then the declared items come back in the order they were declared.
+    assertArrayEquals(
+      (recommended.itemList ?? []).map((item) => item.itemId),
+      ["entry-2071", "entry-3388"],
+    );
+  });
+
+  it("answers a personalization request from a user rule", async () => {
+    // Given a campaign with recommendations declared for one user.
+    const simAws = new SimAws();
+    const campaignArn = await givenACampaign(simAws);
+
+    simAws
+      .personalize()
+      .recommendations(campaignArn)
+      .onUser("user-77", { itemIds: ["entry-9001"] });
+
+    // When the runtime is asked what to show that user.
+    const recommended = await simAws
+      .personalizeRuntime()
+      .getRecommendations(
+        new GetRecommendationsCommand({ campaignArn, userId: "user-77" }),
+      );
+
+    // Then the user's declared items come back.
+    assertArrayEquals(
+      (recommended.itemList ?? []).map((item) => item.itemId),
+      ["entry-9001"],
+    );
+  });
+
+  it("prefers the item rule where a request carries both", async () => {
+    // Given a campaign with a rule for an item and a rule for a user.
+    const simAws = new SimAws();
+    const campaignArn = await givenACampaign(simAws);
+    const recommendations = simAws.personalize().recommendations(campaignArn);
+
+    recommendations.onItem("entry-1042", { itemIds: ["by-item"] });
+    recommendations.onUser("user-77", { itemIds: ["by-user"] });
+
+    // When a request names both.
+    const recommended = await simAws.personalizeRuntime().getRecommendations(
+      new GetRecommendationsCommand({
+        campaignArn,
+        itemId: "entry-1042",
+        userId: "user-77",
+      }),
+    );
+
+    // Then the item rule is the one that answered.
+    assertArrayEquals(
+      (recommended.itemList ?? []).map((item) => item.itemId),
+      ["by-item"],
+    );
+  });
+
+  it("answers two campaigns from their own rules", async () => {
+    // Given two campaigns carrying different recommendations for one entry.
+    const simAws = new SimAws();
+    const relatedArn = await givenACampaign(simAws, "related-entries");
+    const trendingArn = await givenACampaign(simAws, "trending-entries");
+
+    simAws
+      .personalize()
+      .recommendations(relatedArn)
+      .onItem("entry-1042", { itemIds: ["entry-2071"] });
+    simAws
+      .personalize()
+      .recommendations(trendingArn)
+      .onItem("entry-1042", { itemIds: ["entry-5555"] });
+
+    // When each is asked about the same entry.
+    const related = await simAws.personalizeRuntime().getRecommendations(
+      new GetRecommendationsCommand({
+        campaignArn: relatedArn,
+        itemId: "entry-1042",
+      }),
+    );
+    const trending = await simAws.personalizeRuntime().getRecommendations(
+      new GetRecommendationsCommand({
+        campaignArn: trendingArn,
+        itemId: "entry-1042",
+      }),
+    );
+
+    // Then each answers with its own.
+    assertArrayEquals(
+      (related.itemList ?? []).map((item) => item.itemId),
+      ["entry-2071"],
+    );
+    assertArrayEquals(
+      (trending.itemList ?? []).map((item) => item.itemId),
+      ["entry-5555"],
+    );
+  });
+
+  it("falls back to the declared default", async () => {
+    // Given a campaign with a default and a rule for another entry.
+    const simAws = new SimAws();
+    const campaignArn = await givenACampaign(simAws);
+    const recommendations = simAws.personalize().recommendations(campaignArn);
+
+    recommendations.byDefault({ itemIds: ["entry-popular"] });
+    recommendations.onItem("entry-1042", { itemIds: ["entry-2071"] });
+
+    // When an entry no rule matches is asked about.
+    const recommended = await simAws
+      .personalizeRuntime()
+      .getRecommendations(
+        new GetRecommendationsCommand({ campaignArn, itemId: "entry-0000" }),
+      );
+
+    // Then the default answered it.
+    assertArrayEquals(
+      (recommended.itemList ?? []).map((item) => item.itemId),
+      ["entry-popular"],
+    );
+  });
+
+  it("recommends nothing where nothing is declared", async () => {
+    // Given a campaign with no recommendations declared against it.
+    const simAws = new SimAws();
+    const campaignArn = await givenACampaign(simAws);
+
+    // When the runtime is asked about an entry.
+    const recommended = await simAws
+      .personalizeRuntime()
+      .getRecommendations(
+        new GetRecommendationsCommand({ campaignArn, itemId: "entry-1042" }),
+      );
+
+    // Then the item list is empty rather than invented.
+    assertArrayLength(recommended.itemList ?? [], 0);
+    assertUndefined(recommended.recommendationId);
+  });
+
+  it("reports the scores and recommendation id a rule declares", async () => {
+    // Given recommendations declared with scores and a recommendation id.
+    const simAws = new SimAws();
+    const campaignArn = await givenACampaign(simAws);
+
+    simAws
+      .personalize()
+      .recommendations(campaignArn)
+      .onItem("entry-1042", {
+        itemIds: [
+          { itemId: "entry-2071", score: 0.62 },
+          { itemId: "entry-3388", score: 0.38 },
+        ],
+        recommendationId: "RID-declared",
+      });
+
+    // When the runtime answers from that rule.
+    const recommended = await simAws
+      .personalizeRuntime()
+      .getRecommendations(
+        new GetRecommendationsCommand({ campaignArn, itemId: "entry-1042" }),
+      );
+
+    // Then the declaration's own numbers come back.
+    assertNonNullable(recommended.itemList);
+    assertIdentical(recommended.itemList[0]?.score, 0.62);
+    assertIdentical(recommended.itemList[1]?.score, 0.38);
+    assertIdentical(recommended.recommendationId, "RID-declared");
+  });
+
+  it("truncates a declared list to numResults", async () => {
+    // Given a campaign declaring three items for one entry.
+    const simAws = new SimAws();
+    const campaignArn = await givenACampaign(simAws);
+
+    simAws
+      .personalize()
+      .recommendations(campaignArn)
+      .onItem("entry-1042", {
+        itemIds: ["entry-2071", "entry-3388", "entry-4499"],
+      });
+
+    // When two are asked for.
+    const recommended = await simAws.personalizeRuntime().getRecommendations(
+      new GetRecommendationsCommand({
+        campaignArn,
+        itemId: "entry-1042",
+        numResults: 2,
+      }),
+    );
+
+    // Then the list is cut to the first two.
+    assertArrayEquals(
+      (recommended.itemList ?? []).map((item) => item.itemId),
+      ["entry-2071", "entry-3388"],
+    );
+  });
+
+  it("refuses a number of results Personalize would not return", async () => {
+    // Given a campaign.
+    const simAws = new SimAws();
+    const campaignArn = await givenACampaign(simAws);
+
+    // When more results are asked for than Personalize will return.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.personalizeRuntime().getRecommendations(
+          new GetRecommendationsCommand({
+            campaignArn,
+            itemId: "entry-1042",
+            numResults: 501,
+          }),
+        ),
+    );
+
+    // Then it is refused as invalid input.
+    assertIdentical(error.name, "InvalidInputException");
+    assertStringIncludes(error.message, "numResults");
+  });
+
+  it("refuses a filter it cannot apply", async () => {
+    // Given a campaign.
+    const simAws = new SimAws();
+    const campaignArn = await givenACampaign(simAws);
+
+    // When a request names a filter.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.personalizeRuntime().getRecommendations(
+          new GetRecommendationsCommand({
+            campaignArn,
+            itemId: "entry-1042",
+            filterArn: "arn:aws:personalize:eu-west-2:123456789012:filter/f",
+          }),
+        ),
+    );
+
+    // Then it is refused by name rather than ignored.
+    assertIdentical(error.name, "InvalidInputException");
+    assertStringIncludes(error.message, "filterArn is not simulated");
+  });
+});

--- a/src/service/personalize/command/runtime/sim-personalize-runtime-command-group.ts
+++ b/src/service/personalize/command/runtime/sim-personalize-runtime-command-group.ts
@@ -1,0 +1,41 @@
+import type { SimPersonalizeCampaignRules } from "../../recommendation/sim-personalize-campaign-rules.js";
+import type { SimPersonalizeCampaign } from "../../resource/sim-personalize-campaign.js";
+import {
+  SimPersonalizeCommandGroup,
+  type SimPersonalizeCommandGroupProperties,
+} from "../sim-personalize-command-group.js";
+import type { SimPersonalizeRequestOptions } from "../sim-personalize-request-options.js";
+
+export interface SimPersonalizeRuntimeCommandGroupProperties extends SimPersonalizeCommandGroupProperties {
+  readonly rules: SimPersonalizeCampaignRules;
+}
+
+/**
+ * What both simulated Personalize Runtime command handlers are built over.
+ *
+ * A runtime request names a campaign and is answered from what is declared
+ * against that campaign, so both handlers reach a campaign the same way and
+ * both read the same rules.
+ */
+export abstract class SimPersonalizeRuntimeCommandGroup extends SimPersonalizeCommandGroup {
+  protected readonly rules: SimPersonalizeCampaignRules;
+
+  constructor(properties: SimPersonalizeRuntimeCommandGroupProperties) {
+    super(properties);
+    this.rules = properties.rules;
+  }
+
+  /**
+   * Read the campaign a runtime request names, authorizing against it first.
+   *
+   * A campaign ARN naming nothing is a missing resource, which is what real
+   * Personalize Runtime calls it too.
+   */
+  protected campaign(
+    campaignArn: string | undefined,
+    action: string,
+    options: SimPersonalizeRequestOptions | undefined,
+  ): SimPersonalizeCampaign {
+    return this.resolve(this.resources.campaigns, campaignArn, action, options);
+  }
+}

--- a/src/service/personalize/command/runtime/sim-personalize-runtime-iam.iso.test.ts
+++ b/src/service/personalize/command/runtime/sim-personalize-runtime-iam.iso.test.ts
@@ -1,0 +1,170 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateCampaignCommand,
+  CreateDatasetGroupCommand,
+  CreateSolutionCommand,
+  CreateSolutionVersionCommand,
+} from "@aws-sdk/client-personalize";
+import {
+  GetPersonalizedRankingCommand,
+  GetRecommendationsCommand,
+} from "@aws-sdk/client-personalize-runtime";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
+
+const accountIdOneOnes = "111111111111";
+
+const similarItemsRecipe = "arn:aws:personalize:::recipe/aws-similar-items";
+
+/**
+ * Deploy a campaign to call the runtime against.
+ */
+async function givenACampaign(simAws: SimAws): Promise<string> {
+  const group = await simAws
+    .personalize()
+    .createDatasetGroup(new CreateDatasetGroupCommand({ name: "entries" }));
+  const solution = await simAws.personalize().createSolution(
+    new CreateSolutionCommand({
+      name: "related-entries",
+      datasetGroupArn: group.datasetGroupArn,
+      recipeArn: similarItemsRecipe,
+    }),
+  );
+  const version = await simAws
+    .personalize()
+    .createSolutionVersion(
+      new CreateSolutionVersionCommand({ solutionArn: solution.solutionArn }),
+    );
+  const campaign = await simAws.personalize().createCampaign(
+    new CreateCampaignCommand({
+      name: "related-entries",
+      solutionVersionArn: version.solutionVersionArn,
+    }),
+  );
+
+  assertNonNullable(campaign.campaignArn);
+
+  return campaign.campaignArn;
+}
+
+/**
+ * A Role whose policy allows one action on one resource.
+ */
+async function givenARoleAllowedTo(
+  simAws: SimAws,
+  action: string,
+  resource = "*",
+): Promise<string> {
+  const role = await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "PersonalizeRuntimeCaller",
+      AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: {
+          Principal: { AWS: `arn:aws:iam::${accountIdOneOnes}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "PersonalizeRuntimeCaller",
+      PolicyName: "PersonalizeRuntimePolicy",
+      PolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: { Action: action, Resource: resource },
+      }),
+    }),
+  );
+
+  assertNonNullable(role.Role.Arn);
+
+  return role.Role.Arn;
+}
+
+describe("Personalize Runtime IAM authorization", () => {
+  it("allows a recommendation the caller's policy permits on the campaign", async () => {
+    // Given a Role allowed to recommend from one campaign.
+    const simAws = new SimAws({ defaultAccountId: accountIdOneOnes });
+    const campaignArn = await givenACampaign(simAws);
+    const roleArn = await givenARoleAllowedTo(
+      simAws,
+      "personalize:GetRecommendations",
+      campaignArn,
+    );
+
+    simAws
+      .personalize()
+      .recommendations(campaignArn)
+      .byDefault({ itemIds: ["entry-2071"] });
+
+    // When it asks for recommendations.
+    const recommended = await simAws
+      .personalizeRuntime()
+      .getRecommendations(
+        new GetRecommendationsCommand({ campaignArn, itemId: "entry-1042" }),
+        { caller: { kind: "arn", arn: roleArn } },
+      );
+
+    // Then it goes through.
+    assertArrayLength(recommended.itemList ?? [], 1);
+  });
+
+  it("denies a recommendation the caller's policy leaves out", async () => {
+    // Given a Role allowed only to rank.
+    const simAws = new SimAws({ defaultAccountId: accountIdOneOnes });
+    const campaignArn = await givenACampaign(simAws);
+    const roleArn = await givenARoleAllowedTo(
+      simAws,
+      "personalize:GetPersonalizedRanking",
+    );
+
+    // When it asks for recommendations.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws
+          .personalizeRuntime()
+          .getRecommendations(new GetRecommendationsCommand({ campaignArn }), {
+            caller: { kind: "arn", arn: roleArn },
+          }),
+    );
+
+    // Then Personalize reports it in its own terms, naming the action.
+    assertIdentical(error.name, "AccessDeniedException");
+    assertStringIncludes(error.message, "personalize:GetRecommendations");
+  });
+
+  it("denies a ranking against a campaign the policy does not name", async () => {
+    // Given a Role allowed to rank against another campaign's ARN.
+    const simAws = new SimAws({ defaultAccountId: accountIdOneOnes });
+    const campaignArn = await givenACampaign(simAws);
+    const roleArn = await givenARoleAllowedTo(
+      simAws,
+      "personalize:GetPersonalizedRanking",
+      `${campaignArn}-other`,
+    );
+
+    // When it ranks against this one.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.personalizeRuntime().getPersonalizedRanking(
+          new GetPersonalizedRankingCommand({
+            campaignArn,
+            userId: "user-77",
+            inputList: ["entry-1"],
+          }),
+          { caller: { kind: "arn", arn: roleArn } },
+        ),
+    );
+
+    // Then the resource in the policy is what decides it.
+    assertIdentical(error.name, "AccessDeniedException");
+  });
+});

--- a/src/service/personalize/command/runtime/sim-personalize-runtime-input.ts
+++ b/src/service/personalize/command/runtime/sim-personalize-runtime-input.ts
@@ -1,0 +1,65 @@
+import { SimPersonalizeInvalidInputException } from "../../error/sim-personalize.error.js";
+
+/**
+ * How many recommendations a request asking for no particular number gets.
+ */
+const defaultResultCount = 25;
+
+/**
+ * The most real Personalize will return from one GetRecommendations.
+ */
+const maxResultCount = 500;
+
+/**
+ * Read how many recommendations a request asks for.
+ */
+export function requireSimPersonalizeResultCount(
+  requested: number | undefined,
+): number {
+  if (requested === undefined) {
+    return defaultResultCount;
+  }
+
+  if (
+    !Number.isSafeInteger(requested) ||
+    requested < 0 ||
+    requested > maxResultCount
+  ) {
+    throw new SimPersonalizeInvalidInputException(
+      `numResults must be a whole number between 0 and ${maxResultCount}`,
+    );
+  }
+
+  return requested;
+}
+
+/**
+ * Read the items a ranking request is to rank.
+ */
+export function requireSimPersonalizeInputList(
+  inputList: readonly string[] | undefined,
+): readonly string[] {
+  if (inputList === undefined || inputList.length === 0) {
+    throw new SimPersonalizeInvalidInputException(
+      "An inputList of item ids is required",
+    );
+  }
+
+  return inputList;
+}
+
+/**
+ * Read the user a ranking request is personalized for.
+ *
+ * Real Personalize requires one on every GetPersonalizedRanking, whatever the
+ * recipe behind the campaign.
+ */
+export function requireSimPersonalizeUserId(
+  userId: string | undefined,
+): string {
+  if (userId === undefined || userId === "") {
+    throw new SimPersonalizeInvalidInputException("A userId is required");
+  }
+
+  return userId;
+}

--- a/src/service/personalize/command/sim-personalize-commands.ts
+++ b/src/service/personalize/command/sim-personalize-commands.ts
@@ -1,6 +1,7 @@
 import type { SimClock } from "../../../util/clock/sim-clock.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimPersonalizeCampaignRules } from "../recommendation/sim-personalize-campaign-rules.js";
 import type { SimPersonalizeResources } from "../resource/sim-personalize-resources.js";
 import { SimPersonalizeAuthorizer } from "./authorize/sim-personalize-authorizer.js";
 import { SimPersonalizeCampaignReadCommands } from "./campaign/sim-personalize-campaign-read-commands.js";
@@ -9,6 +10,8 @@ import { SimPersonalizeDatasetGroupReadCommands } from "./dataset-group/sim-pers
 import { SimPersonalizeDatasetGroupWriteCommands } from "./dataset-group/sim-personalize-dataset-group-write-commands.js";
 import { SimPersonalizeDatasetReadCommands } from "./dataset/sim-personalize-dataset-read-commands.js";
 import { SimPersonalizeDatasetWriteCommands } from "./dataset/sim-personalize-dataset-write-commands.js";
+import { SimPersonalizeGetPersonalizedRankingHandler } from "./runtime/sim-personalize-get-personalized-ranking.js";
+import { SimPersonalizeGetRecommendationsHandler } from "./runtime/sim-personalize-get-recommendations.js";
 import { SimPersonalizeSchemaReadCommands } from "./schema/sim-personalize-schema-read-commands.js";
 import { SimPersonalizeSchemaWriteCommands } from "./schema/sim-personalize-schema-write-commands.js";
 import { SimPersonalizeSolutionReadCommands } from "./solution/sim-personalize-solution-read-commands.js";
@@ -30,6 +33,11 @@ interface SimPersonalizeCommandsProperties {
  * The handlers are grouped by the resource they are about and then split by
  * whether they change anything, and gathered here so the service facade stays
  * a list of the operations it answers.
+ *
+ * The two runtime handlers are built here as well, over the same resources
+ * and the same authorizer. What they answer with is declared against a
+ * campaign through the rules, which is why those are held here too: the
+ * declaration and the request that reads it have to reach the same rules.
  */
 export class SimPersonalizeCommands {
   public readonly datasetGroupWrites: SimPersonalizeDatasetGroupWriteCommands;
@@ -44,6 +52,9 @@ export class SimPersonalizeCommands {
   public readonly solutionVersionReads: SimPersonalizeSolutionVersionReadCommands;
   public readonly campaignWrites: SimPersonalizeCampaignWriteCommands;
   public readonly campaignReads: SimPersonalizeCampaignReadCommands;
+  public readonly rules: SimPersonalizeCampaignRules;
+  public readonly recommendations: SimPersonalizeGetRecommendationsHandler;
+  public readonly rankings: SimPersonalizeGetPersonalizedRankingHandler;
 
   constructor(properties: SimPersonalizeCommandsProperties) {
     const { resources, accountRegionScope, clock } = properties;
@@ -68,5 +79,14 @@ export class SimPersonalizeCommands {
     );
     this.campaignWrites = new SimPersonalizeCampaignWriteCommands(shared);
     this.campaignReads = new SimPersonalizeCampaignReadCommands(shared);
+
+    this.rules = new SimPersonalizeCampaignRules({
+      campaigns: resources.campaigns,
+    });
+
+    const runtime = { ...shared, rules: this.rules };
+
+    this.recommendations = new SimPersonalizeGetRecommendationsHandler(runtime);
+    this.rankings = new SimPersonalizeGetPersonalizedRankingHandler(runtime);
   }
 }

--- a/src/service/personalize/command/sim-personalize-unsimulated-input.ts
+++ b/src/service/personalize/command/sim-personalize-unsimulated-input.ts
@@ -1,0 +1,35 @@
+import { SimPersonalizeUnsimulatedInputException } from "../error/sim-personalize.error.js";
+
+/**
+ * Refuses the request inputs this simulation does not model.
+ *
+ * The refusal works from the small set of options each command accepts rather
+ * than from a list of everything Personalize offers, so an option nobody
+ * thought about is refused rather than dropped. Dropping is the failure mode
+ * worth avoiding here: a `GetRecommendations` naming a `filterArn` that keeps
+ * out-of-stock items out would be answered with the whole declared list, which
+ * is the one answer that looks right and is not.
+ */
+export class SimPersonalizeUnsimulatedInput {
+  private readonly operation: string;
+
+  constructor(operation: string) {
+    this.operation = operation;
+  }
+
+  /**
+   * Refuse every supplied input that is not one of the accepted options.
+   */
+  refuseUnaccepted(input: object, accepted: readonly string[]): void {
+    for (const [option, value] of Object.entries(input)) {
+      if (value === undefined || accepted.includes(option)) {
+        continue;
+      }
+
+      throw new SimPersonalizeUnsimulatedInputException(
+        `${this.operation} ${option} is not simulated: it would be ignored ` +
+          `here and applied on real AWS`,
+      );
+    }
+  }
+}

--- a/src/service/personalize/error/sim-personalize.error.ts
+++ b/src/service/personalize/error/sim-personalize.error.ts
@@ -102,3 +102,36 @@ export class SimPersonalizeInvalidNextTokenException extends SimPersonalizeError
     super(message, { httpStatusCode: 400 });
   }
 }
+
+/**
+ * Simulated Personalize error for a request input this simulation does not
+ * model.
+ *
+ * This is not an error real Personalize has, and it is reported under the name
+ * real Personalize refuses bad input with. The input is refused rather than
+ * ignored, because an ignored input looks applied to the request that sent it
+ * and unapplied to everything else. A `filterArn` naming a filter that keeps
+ * out-of-stock items out is the case worth refusing: the recommendations would
+ * come back whole here and come back filtered on AWS.
+ */
+export class SimPersonalizeUnsimulatedInputException extends SimPersonalizeError {
+  public override readonly name = "InvalidInputException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated Personalize error for a result declared against this simulation
+ * that it cannot answer with.
+ *
+ * This is a simulator configuration error rather than an AWS one, so it is
+ * raised where the declaration is made rather than where the recommendation is
+ * served. Recommendations declared against a campaign ARN nothing holds would
+ * otherwise sit there unanswered, and the test would read the empty item list
+ * as the system under test asking for the wrong item.
+ */
+export class SimPersonalizeDeclarationError extends SimPersonalizeError {
+  public override readonly name = "SimPersonalizeDeclarationError";
+}

--- a/src/service/personalize/index.ts
+++ b/src/service/personalize/index.ts
@@ -1,4 +1,12 @@
 export { SimPersonalize } from "./sim-personalize.js";
+export { SimPersonalizeRuntime } from "./sim-personalize-runtime.js";
+export { SimPersonalizeRecommendations } from "./recommendation/sim-personalize-recommendations.js";
+export { SimPersonalizeRankings } from "./recommendation/sim-personalize-rankings.js";
+export type {
+  SimPersonalizeDeclaredItem,
+  SimPersonalizeDeclaredItems,
+  SimPersonalizeItemDeclaration,
+} from "./recommendation/sim-personalize-item-declaration.js";
 export type { SimPersonalizeRequestOptions } from "./command/sim-personalize-request-options.js";
 export {
   SimPersonalizeDatasetGroup,
@@ -10,10 +18,12 @@ export {
 } from "./resource/sim-personalize-domain.js";
 export {
   SimPersonalizeAccessDeniedException,
+  SimPersonalizeDeclarationError,
   SimPersonalizeError,
   SimPersonalizeInvalidInputException,
   SimPersonalizeInvalidNextTokenException,
   SimPersonalizeResourceAlreadyExistsException,
   SimPersonalizeResourceInUseException,
   SimPersonalizeResourceNotFoundException,
+  SimPersonalizeUnsimulatedInputException,
 } from "./error/sim-personalize.error.js";

--- a/src/service/personalize/recommendation/sim-personalize-campaign-rules.ts
+++ b/src/service/personalize/recommendation/sim-personalize-campaign-rules.ts
@@ -1,0 +1,81 @@
+import type { SimPersonalizeCampaign } from "../resource/sim-personalize-campaign.js";
+import type { SimPersonalizeResourceStore } from "../resource/sim-personalize-resource-store.js";
+import { requireSimPersonalizeDeclaredCampaign } from "./sim-personalize-declared-campaign.js";
+import { SimPersonalizeRankings } from "./sim-personalize-rankings.js";
+import { SimPersonalizeRecommendations } from "./sim-personalize-recommendations.js";
+
+export interface SimPersonalizeCampaignRulesProperties {
+  readonly campaigns: SimPersonalizeResourceStore<SimPersonalizeCampaign>;
+}
+
+/**
+ * What one campaign answers the two runtime operations with.
+ *
+ * The campaign it was declared against is held with it. A campaign deleted and
+ * created again under the same name is a new campaign at the same ARN, and it
+ * starts with nothing declared against it.
+ */
+interface SimPersonalizeCampaignRuleSet {
+  readonly campaign: SimPersonalizeCampaign;
+  readonly recommendations: SimPersonalizeRecommendations;
+  readonly rankings: SimPersonalizeRankings;
+}
+
+/**
+ * The results declared against the campaigns of one simulated Personalize.
+ *
+ * Rules are held per campaign because that is the resource real Personalize
+ * answers a runtime call from. A campaign serves one solution version trained
+ * on one recipe, so two campaigns in a dataset group answer the same item
+ * differently, and rules that sat on the service would have to pretend
+ * otherwise.
+ *
+ * A campaign is required to exist before anything is declared against it.
+ */
+export class SimPersonalizeCampaignRules {
+  private readonly campaigns: SimPersonalizeResourceStore<SimPersonalizeCampaign>;
+  private readonly byCampaignArn = new Map<
+    string,
+    SimPersonalizeCampaignRuleSet
+  >();
+
+  constructor(properties: SimPersonalizeCampaignRulesProperties) {
+    this.campaigns = properties.campaigns;
+  }
+
+  /**
+   * The recommendations one campaign answers GetRecommendations with.
+   */
+  recommendations(campaignArn: string): SimPersonalizeRecommendations {
+    return this.declaredAgainst(campaignArn).recommendations;
+  }
+
+  /**
+   * The rankings one campaign answers GetPersonalizedRanking with.
+   */
+  rankings(campaignArn: string): SimPersonalizeRankings {
+    return this.declaredAgainst(campaignArn).rankings;
+  }
+
+  private declaredAgainst(campaignArn: string): SimPersonalizeCampaignRuleSet {
+    const campaign = requireSimPersonalizeDeclaredCampaign(
+      this.campaigns,
+      campaignArn,
+    );
+    const held = this.byCampaignArn.get(campaignArn);
+
+    if (held?.campaign === campaign) {
+      return held;
+    }
+
+    const declared = {
+      campaign,
+      recommendations: new SimPersonalizeRecommendations(),
+      rankings: new SimPersonalizeRankings(),
+    };
+
+    this.byCampaignArn.set(campaignArn, declared);
+
+    return declared;
+  }
+}

--- a/src/service/personalize/recommendation/sim-personalize-declarations.iso.test.ts
+++ b/src/service/personalize/recommendation/sim-personalize-declarations.iso.test.ts
@@ -1,0 +1,156 @@
+import {
+  CreateCampaignCommand,
+  CreateDatasetGroupCommand,
+  CreateSolutionCommand,
+  CreateSolutionVersionCommand,
+  DeleteCampaignCommand,
+  DescribeCampaignCommand,
+} from "@aws-sdk/client-personalize";
+import { GetRecommendationsCommand } from "@aws-sdk/client-personalize-runtime";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsError,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+
+const similarItemsRecipe = "arn:aws:personalize:::recipe/aws-similar-items";
+
+const absentCampaignArn =
+  "arn:aws:personalize:eu-west-2:123456789012:campaign/absent";
+
+/**
+ * Deploy a campaign, which is what results are declared against.
+ */
+async function givenACampaign(simAws: SimAws): Promise<string> {
+  const group = await simAws
+    .personalize()
+    .createDatasetGroup(new CreateDatasetGroupCommand({ name: "entries" }));
+  const solution = await simAws.personalize().createSolution(
+    new CreateSolutionCommand({
+      name: "related-entries",
+      datasetGroupArn: group.datasetGroupArn,
+      recipeArn: similarItemsRecipe,
+    }),
+  );
+  const version = await simAws
+    .personalize()
+    .createSolutionVersion(
+      new CreateSolutionVersionCommand({ solutionArn: solution.solutionArn }),
+    );
+  const campaign = await simAws.personalize().createCampaign(
+    new CreateCampaignCommand({
+      name: "related-entries",
+      solutionVersionArn: version.solutionVersionArn,
+    }),
+  );
+
+  assertNonNullable(campaign.campaignArn);
+
+  return campaign.campaignArn;
+}
+
+describe("Personalize declared results", () => {
+  it("refuses recommendations declared against a campaign that is not there", async () => {
+    // Given a simulated Personalize holding no campaign.
+    const simAws = new SimAws();
+
+    // When recommendations are declared against an ARN.
+    const declared = assertThrowsError(() =>
+      simAws.personalize().recommendations(absentCampaignArn),
+    );
+
+    // And when the runtime is called with the same ARN.
+    const called = await assertThrowsErrorAsync(
+      async () =>
+        await simAws
+          .personalizeRuntime()
+          .getRecommendations(
+            new GetRecommendationsCommand({ campaignArn: absentCampaignArn }),
+          ),
+    );
+
+    // Then the declaration is a mistake in the test, and the call is a missing
+    // resource, as it is on real Personalize Runtime.
+    assertIdentical(declared.name, "SimPersonalizeDeclarationError");
+    assertStringIncludes(declared.message, absentCampaignArn);
+    assertIdentical(called.name, "ResourceNotFoundException");
+  });
+
+  it("refuses rankings declared against a campaign that is not there", () => {
+    // Given a simulated Personalize holding no campaign.
+    const simAws = new SimAws();
+
+    // When rankings are declared against an ARN.
+    const error = assertThrowsError(() =>
+      simAws.personalize().rankings(absentCampaignArn),
+    );
+
+    // Then the mistake is reported where it was made.
+    assertIdentical(error.name, "SimPersonalizeDeclarationError");
+  });
+
+  it("refuses a rule with no id to match", async () => {
+    // Given a campaign.
+    const simAws = new SimAws();
+    const campaignArn = await givenACampaign(simAws);
+
+    // When rules are declared against an empty item id and user id.
+    const onItem = assertThrowsError(() => {
+      simAws
+        .personalize()
+        .recommendations(campaignArn)
+        .onItem("", { itemIds: ["entry-2071"] });
+    });
+    const onUser = assertThrowsError(() => {
+      simAws
+        .personalize()
+        .rankings(campaignArn)
+        .onUser("", { itemIds: ["entry-1"] });
+    });
+
+    // Then both are refused where the declaration is made.
+    assertIdentical(onItem.name, "SimPersonalizeDeclarationError");
+    assertStringIncludes(onItem.message, "an item id");
+    assertIdentical(onUser.name, "SimPersonalizeDeclarationError");
+    assertStringIncludes(onUser.message, "a user id");
+  });
+
+  it("forgets what was declared against a campaign that was deleted", async () => {
+    // Given a campaign with recommendations declared against it.
+    const simAws = new SimAws();
+    const campaignArn = await givenACampaign(simAws);
+
+    simAws
+      .personalize()
+      .recommendations(campaignArn)
+      .onItem("entry-1042", { itemIds: ["entry-2071"] });
+
+    // When it is deleted and deployed again under the same name.
+    const described = await simAws
+      .personalize()
+      .describeCampaign(new DescribeCampaignCommand({ campaignArn }));
+    await simAws
+      .personalize()
+      .deleteCampaign(new DeleteCampaignCommand({ campaignArn }));
+    const replacement = await simAws.personalize().createCampaign(
+      new CreateCampaignCommand({
+        name: "related-entries",
+        solutionVersionArn: described.campaign?.solutionVersionArn,
+      }),
+    );
+    assertIdentical(replacement.campaignArn, campaignArn);
+
+    // Then the new campaign starts with nothing declared against it.
+    const recommended = await simAws
+      .personalizeRuntime()
+      .getRecommendations(
+        new GetRecommendationsCommand({ campaignArn, itemId: "entry-1042" }),
+      );
+    assertArrayLength(recommended.itemList ?? [], 0);
+  });
+});

--- a/src/service/personalize/recommendation/sim-personalize-declared-campaign.ts
+++ b/src/service/personalize/recommendation/sim-personalize-declared-campaign.ts
@@ -1,0 +1,28 @@
+import { SimPersonalizeDeclarationError } from "../error/sim-personalize.error.js";
+import type { SimPersonalizeCampaign } from "../resource/sim-personalize-campaign.js";
+import type { SimPersonalizeResourceStore } from "../resource/sim-personalize-resource-store.js";
+
+/**
+ * Read the campaign a result is declared against, refusing an ARN no campaign
+ * is deployed at.
+ *
+ * The refusal is what makes a mistyped ARN visible. A declaration left against
+ * an ARN nothing holds would go unanswered, and the empty item list the runtime
+ * came back with would read as the system under test asking for the wrong item.
+ */
+export function requireSimPersonalizeDeclaredCampaign(
+  campaigns: SimPersonalizeResourceStore<SimPersonalizeCampaign>,
+  campaignArn: string,
+): SimPersonalizeCampaign {
+  const campaign = campaigns.find(campaignArn);
+
+  if (campaign === undefined) {
+    throw new SimPersonalizeDeclarationError(
+      `No simulated Personalize campaign is deployed at '${campaignArn}'. ` +
+        `Results are declared against the campaign a runtime call names, so ` +
+        `the campaign is created first.`,
+    );
+  }
+
+  return campaign;
+}

--- a/src/service/personalize/recommendation/sim-personalize-item-declaration.ts
+++ b/src/service/personalize/recommendation/sim-personalize-item-declaration.ts
@@ -1,0 +1,44 @@
+/**
+ * An item declared against a campaign, with what the runtime is to report
+ * alongside it.
+ *
+ * The score is the declaration's own. Nothing here computes one, because
+ * there is no model behind it to compute one from, so an item declared
+ * without a score comes back without a score.
+ */
+export interface SimPersonalizeDeclaredItem {
+  readonly itemId: string;
+  readonly score?: number | undefined;
+}
+
+/**
+ * An item as a rule declares it: an item id on its own, or an id with what is
+ * to be reported with it.
+ */
+export type SimPersonalizeItemDeclaration = string | SimPersonalizeDeclaredItem;
+
+/**
+ * What one runtime call answers with: the items, in the order they are to
+ * come back in.
+ *
+ * Both runtime operations answer with an ordered list of items, so both
+ * declare one. `GetRecommendations` reports it as `itemList` and
+ * `GetPersonalizedRanking` as `personalizedRanking`.
+ */
+export interface SimPersonalizeDeclaredItems {
+  readonly itemIds: readonly SimPersonalizeItemDeclaration[];
+  readonly recommendationId?: string | undefined;
+}
+
+/**
+ * Read a declaration that may be a bare item id.
+ */
+export function simPersonalizeDeclaredItem(
+  declaration: SimPersonalizeItemDeclaration,
+): SimPersonalizeDeclaredItem {
+  if (typeof declaration === "string") {
+    return { itemId: declaration };
+  }
+
+  return declaration;
+}

--- a/src/service/personalize/recommendation/sim-personalize-rankings.ts
+++ b/src/service/personalize/recommendation/sim-personalize-rankings.ts
@@ -1,0 +1,46 @@
+import { SimDeclaredResultRules } from "../../../util/rule/sim-declared-result-rules.js";
+import type { SimPersonalizeDeclaredItems } from "./sim-personalize-item-declaration.js";
+import { requireSimPersonalizeRuleKey } from "./sim-personalize-rule-key.js";
+
+/**
+ * The rankings one campaign answers GetPersonalizedRanking with.
+ *
+ * A rule for an exact user wins, then the default. There is no item rule
+ * here, unlike the recommendations beside it: a ranking request names a user
+ * and the list to rank, never one item, so an item rule would be a rule
+ * nothing could ever match.
+ *
+ * Nothing declared at all is the case worth having. The request already
+ * carries the items, and a ranking with no rule answers with them in the
+ * order they arrived, so a test that does not care about the order does not
+ * have to write one down.
+ */
+export class SimPersonalizeRankings {
+  private readonly rules = new SimDeclaredResultRules<
+    SimPersonalizeDeclaredItems | undefined
+  >(undefined);
+
+  /**
+   * Answer with these items for any request no other rule matches.
+   */
+  byDefault(result: SimPersonalizeDeclaredItems): void {
+    this.rules.byDefault(result);
+  }
+
+  /**
+   * Answer with these items for a request naming this exact user.
+   */
+  onUser(userId: string, result: SimPersonalizeDeclaredItems): void {
+    this.rules.onTrailingKey(
+      requireSimPersonalizeRuleKey(userId, "a user id"),
+      result,
+    );
+  }
+
+  /**
+   * The items declared for one ranking request, where any are.
+   */
+  itemsFor(userId: string): SimPersonalizeDeclaredItems | undefined {
+    return this.rules.resultFor({ trailing: userId });
+  }
+}

--- a/src/service/personalize/recommendation/sim-personalize-recommendations.ts
+++ b/src/service/personalize/recommendation/sim-personalize-recommendations.ts
@@ -1,0 +1,76 @@
+import { SimDeclaredResultRules } from "../../../util/rule/sim-declared-result-rules.js";
+import type { SimPersonalizeDeclaredItems } from "./sim-personalize-item-declaration.js";
+import { requireSimPersonalizeRuleKey } from "./sim-personalize-rule-key.js";
+
+/**
+ * The request a recommendation rule is matched against.
+ */
+export interface SimPersonalizeRecommendationRequest {
+  readonly itemId?: string | undefined;
+  readonly userId?: string | undefined;
+}
+
+/**
+ * What GetRecommendations answers with where nothing is declared.
+ *
+ * Real Personalize answers an item it does not recognise with popular items,
+ * which it knows from the interaction history. Simulated Personalize holds no
+ * interactions, so it answers with nothing rather than inventing a catalogue
+ * to be popular in.
+ */
+const nothingRecommended: SimPersonalizeDeclaredItems = { itemIds: [] };
+
+/**
+ * The recommendations one campaign answers GetRecommendations with.
+ *
+ * A rule for an exact item wins, then a rule for an exact user, then the
+ * default. Item first because the related-items recipes are the ones whose
+ * requests name an item at all: `aws-similar-items` requires `itemId` and
+ * ignores `userId`, where the user-personalization recipes require `userId`
+ * and name no item. A request therefore reaches the tier its own recipe
+ * would have used.
+ */
+export class SimPersonalizeRecommendations {
+  private readonly rules =
+    new SimDeclaredResultRules<SimPersonalizeDeclaredItems>(nothingRecommended);
+
+  /**
+   * Answer with these items for any request no other rule matches.
+   */
+  byDefault(result: SimPersonalizeDeclaredItems): void {
+    this.rules.byDefault(result);
+  }
+
+  /**
+   * Answer with these items for a request naming this exact item.
+   */
+  onItem(itemId: string, result: SimPersonalizeDeclaredItems): void {
+    this.rules.onLeadingKey(
+      requireSimPersonalizeRuleKey(itemId, "an item id"),
+      result,
+    );
+  }
+
+  /**
+   * Answer with these items for a request naming this exact user, where no
+   * item rule matched it first.
+   */
+  onUser(userId: string, result: SimPersonalizeDeclaredItems): void {
+    this.rules.onTrailingKey(
+      requireSimPersonalizeRuleKey(userId, "a user id"),
+      result,
+    );
+  }
+
+  /**
+   * The items declared for one recommendation request.
+   */
+  itemsFor(
+    request: SimPersonalizeRecommendationRequest,
+  ): SimPersonalizeDeclaredItems {
+    return this.rules.resultFor({
+      leading: request.itemId,
+      trailing: request.userId,
+    });
+  }
+}

--- a/src/service/personalize/recommendation/sim-personalize-rule-key.ts
+++ b/src/service/personalize/recommendation/sim-personalize-rule-key.ts
@@ -1,0 +1,20 @@
+import { SimPersonalizeDeclarationError } from "../error/sim-personalize.error.js";
+
+/**
+ * Read the id a rule matches on, refusing one there is nothing to match.
+ *
+ * An empty id would match a request that named no item or no user at all,
+ * which is the rule the default is already there for.
+ */
+export function requireSimPersonalizeRuleKey(
+  key: string,
+  description: string,
+): string {
+  if (key.length === 0) {
+    throw new SimPersonalizeDeclarationError(
+      `A simulated Personalize rule needs ${description} to match`,
+    );
+  }
+
+  return key;
+}

--- a/src/service/personalize/sdk/sim-personalize-runtime-sdk-command-router.ts
+++ b/src/service/personalize/sdk/sim-personalize-runtime-sdk-command-router.ts
@@ -1,0 +1,59 @@
+import {
+  simSdkCallerOptions,
+  type SimSdkCommandRoute,
+  type SimSdkCommandRouter,
+} from "../../../sdk/index.js";
+import type {
+  SimGetPersonalizedRankingCommand,
+  SimGetRecommendationsCommand,
+} from "../command/runtime/runtime.command.js";
+import type { SimPersonalizeRuntime } from "../sim-personalize-runtime.js";
+
+/**
+ * Routes intercepted SDK Commands to one scoped simulated Personalize
+ * Runtime.
+ *
+ * The runtime commands have a router of their own because they arrive on a
+ * client of their own. An intercepted `PersonalizeRuntimeClient` reports the
+ * `Personalize Runtime` service id, which is not the one a
+ * `PersonalizeClient` reports.
+ */
+export class SimPersonalizeRuntimeSdkCommandRouter implements SimSdkCommandRouter {
+  private readonly routes: ReadonlyMap<string, SimSdkCommandRoute>;
+
+  constructor(simPersonalizeRuntime: SimPersonalizeRuntime) {
+    this.routes = new Map<string, SimSdkCommandRoute>([
+      [
+        "GetRecommendationsCommand",
+        async (command, context): Promise<unknown> =>
+          await simPersonalizeRuntime.getRecommendations(
+            command as SimGetRecommendationsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetPersonalizedRankingCommand",
+        async (command, context): Promise<unknown> =>
+          await simPersonalizeRuntime.getPersonalizedRanking(
+            command as SimGetPersonalizedRankingCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+    ]);
+  }
+
+  /**
+   * The SDK Command names simulated Personalize Runtime can handle.
+   */
+  supportedCommandNames(): readonly string[] {
+    return this.routes.keys().toArray();
+  }
+
+  /**
+   * Get the route for an SDK Command name, if simulated Personalize Runtime
+   * supports it.
+   */
+  route(commandName: string): SimSdkCommandRoute | undefined {
+    return this.routes.get(commandName);
+  }
+}

--- a/src/service/personalize/sdk/sim-personalize-runtime-sdk-routing.iso.test.ts
+++ b/src/service/personalize/sdk/sim-personalize-runtime-sdk-routing.iso.test.ts
@@ -1,0 +1,109 @@
+import {
+  CreateCampaignCommand,
+  CreateDatasetGroupCommand,
+  CreateSolutionCommand,
+  CreateSolutionVersionCommand,
+  PersonalizeClient,
+} from "@aws-sdk/client-personalize";
+import {
+  GetPersonalizedRankingCommand,
+  GetRecommendationsCommand,
+  PersonalizeRuntimeClient,
+} from "@aws-sdk/client-personalize-runtime";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimSdk } from "../../../sdk/index.js";
+import { SimAws } from "../../aws/sim-aws.js";
+
+const similarItemsRecipe = "arn:aws:personalize:::recipe/aws-similar-items";
+
+describe("Personalize Runtime SDK interception", () => {
+  it("answers an intercepted PersonalizeRuntimeClient from declared results", async () => {
+    // Given an intercepted Personalize client and runtime client.
+    const simSdk = new SimSdk();
+    simSdk.intercept(PersonalizeClient);
+    simSdk.intercept(PersonalizeRuntimeClient);
+
+    const client = new PersonalizeClient({ region: "eu-west-2" });
+    const runtime = new PersonalizeRuntimeClient({ region: "eu-west-2" });
+
+    try {
+      // And a campaign with recommendations declared against it.
+      const group = await client.send(
+        new CreateDatasetGroupCommand({ name: "entries" }),
+      );
+      const solution = await client.send(
+        new CreateSolutionCommand({
+          name: "related-entries",
+          datasetGroupArn: group.datasetGroupArn,
+          recipeArn: similarItemsRecipe,
+        }),
+      );
+      const version = await client.send(
+        new CreateSolutionVersionCommand({ solutionArn: solution.solutionArn }),
+      );
+      const campaign = await client.send(
+        new CreateCampaignCommand({
+          name: "related-entries",
+          solutionVersionArn: version.solutionVersionArn,
+        }),
+      );
+      assertNonNullable(campaign.campaignArn);
+
+      simSdk.simAws
+        .account()
+        .region("eu-west-2")
+        .personalize()
+        .recommendations(campaign.campaignArn)
+        .onItem("entry-1042", { itemIds: ["entry-2071"] });
+
+      // When ordinary SDK code asks both runtime operations.
+      const recommended = await runtime.send(
+        new GetRecommendationsCommand({
+          campaignArn: campaign.campaignArn,
+          itemId: "entry-1042",
+        }),
+      );
+      const ranked = await runtime.send(
+        new GetPersonalizedRankingCommand({
+          campaignArn: campaign.campaignArn,
+          userId: "user-77",
+          inputList: ["entry-1", "entry-2"],
+        }),
+      );
+
+      // Then both are answered with nothing touching the network.
+      assertArrayEquals(
+        (recommended.itemList ?? []).map((item) => item.itemId),
+        ["entry-2071"],
+      );
+      assertArrayEquals(
+        (ranked.personalizedRanking ?? []).map((item) => item.itemId),
+        ["entry-1", "entry-2"],
+      );
+    } finally {
+      simSdk.restoreAll();
+    }
+  });
+
+  it("supports the Commands its router names and no others", () => {
+    // Given a simulated Personalize Runtime.
+    const simAws = new SimAws();
+
+    // When its router is asked what it handles.
+    const supported = simAws.personalizeRuntime().sdkCommandRouter();
+
+    // Then every name is one the router has a route for.
+    for (const commandName of supported.supportedCommandNames()) {
+      assertNonNullable(supported.route(commandName));
+    }
+
+    assertUndefined(supported.route("GetActionRecommendationsCommand"));
+    assertArrayLength(supported.supportedCommandNames(), 2);
+  });
+});

--- a/src/service/personalize/sim-personalize-control-plane.ts
+++ b/src/service/personalize/sim-personalize-control-plane.ts
@@ -1,0 +1,263 @@
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../util/background/background.js";
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type * as simPersonalizeCommands from "./command/sim-personalize-command.types.js";
+import { SimPersonalizeCommands } from "./command/sim-personalize-commands.js";
+import type { SimPersonalizeRequestOptions } from "./command/sim-personalize-request-options.js";
+import { SimPersonalizeResources } from "./resource/sim-personalize-resources.js";
+
+export interface SimPersonalizeProperties {
+  readonly accountRegionScope?: SimAwsAccountRegionScope;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * The operations of the Personalize control plane API.
+ *
+ * These are the twenty-two calls that build the chain a recommendation is
+ * served from, and they are here rather than on `SimPersonalize` itself
+ * because that class would otherwise be this list and nothing else. What is
+ * left there is what a simulated Personalize is beyond its control plane: the
+ * runtime API over it, the results declared against its campaigns, and the
+ * state a test reads back directly.
+ *
+ * The split is the one AWS makes. The control plane is the `personalize`
+ * endpoint and the `PersonalizeClient`; the runtime is the
+ * `personalize-runtime` endpoint and a client of its own.
+ */
+export abstract class SimPersonalizeControlPlane {
+  protected readonly resources = new SimPersonalizeResources();
+  protected readonly commands: SimPersonalizeCommands;
+  protected readonly background: BackgroundScheduler;
+
+  constructor(properties: SimPersonalizeProperties = {}) {
+    const {
+      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.background = background;
+    this.commands = new SimPersonalizeCommands({
+      resources: this.resources,
+      iam,
+      accountRegionScope,
+      clock: background,
+    });
+  }
+
+  /** Handle a CreateDatasetGroup Command from the SDK. */
+  async createDatasetGroup(
+    command: simPersonalizeCommands.SimCreateDatasetGroupCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimCreateDatasetGroupCommandOutput> {
+    await this.background.sequence();
+    return this.commands.datasetGroupWrites.create(command, options);
+  }
+
+  /** Handle a DescribeDatasetGroup Command from the SDK. */
+  async describeDatasetGroup(
+    command: simPersonalizeCommands.SimDescribeDatasetGroupCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimDescribeDatasetGroupCommandOutput> {
+    await this.background.sequence();
+    return this.commands.datasetGroupReads.describe(command, options);
+  }
+
+  /** Handle a ListDatasetGroups Command from the SDK. */
+  async listDatasetGroups(
+    command: simPersonalizeCommands.SimListDatasetGroupsCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimListDatasetGroupsCommandOutput> {
+    await this.background.sequence();
+    return this.commands.datasetGroupReads.list(command, options);
+  }
+
+  /** Handle a DeleteDatasetGroup Command from the SDK. */
+  async deleteDatasetGroup(
+    command: simPersonalizeCommands.SimDeleteDatasetGroupCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimDeleteDatasetGroupCommandOutput> {
+    await this.background.sequence();
+    return this.commands.datasetGroupWrites.delete(command, options);
+  }
+
+  /** Handle a CreateSchema Command from the SDK. */
+  async createSchema(
+    command: simPersonalizeCommands.SimCreateSchemaCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimCreateSchemaCommandOutput> {
+    await this.background.sequence();
+    return this.commands.schemaWrites.create(command, options);
+  }
+
+  /** Handle a DescribeSchema Command from the SDK. */
+  async describeSchema(
+    command: simPersonalizeCommands.SimDescribeSchemaCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimDescribeSchemaCommandOutput> {
+    await this.background.sequence();
+    return this.commands.schemaReads.describe(command, options);
+  }
+
+  /** Handle a ListSchemas Command from the SDK. */
+  async listSchemas(
+    command: simPersonalizeCommands.SimListSchemasCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimListSchemasCommandOutput> {
+    await this.background.sequence();
+    return this.commands.schemaReads.list(command, options);
+  }
+
+  /** Handle a DeleteSchema Command from the SDK. */
+  async deleteSchema(
+    command: simPersonalizeCommands.SimDeleteSchemaCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimDeleteSchemaCommandOutput> {
+    await this.background.sequence();
+    return this.commands.schemaWrites.delete(command, options);
+  }
+
+  /** Handle a CreateDataset Command from the SDK. */
+  async createDataset(
+    command: simPersonalizeCommands.SimCreateDatasetCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimCreateDatasetCommandOutput> {
+    await this.background.sequence();
+    return this.commands.datasetWrites.create(command, options);
+  }
+
+  /** Handle a DescribeDataset Command from the SDK. */
+  async describeDataset(
+    command: simPersonalizeCommands.SimDescribeDatasetCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimDescribeDatasetCommandOutput> {
+    await this.background.sequence();
+    return this.commands.datasetReads.describe(command, options);
+  }
+
+  /** Handle a ListDatasets Command from the SDK. */
+  async listDatasets(
+    command: simPersonalizeCommands.SimListDatasetsCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimListDatasetsCommandOutput> {
+    await this.background.sequence();
+    return this.commands.datasetReads.list(command, options);
+  }
+
+  /** Handle a DeleteDataset Command from the SDK. */
+  async deleteDataset(
+    command: simPersonalizeCommands.SimDeleteDatasetCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimDeleteDatasetCommandOutput> {
+    await this.background.sequence();
+    return this.commands.datasetWrites.delete(command, options);
+  }
+
+  /** Handle a CreateSolution Command from the SDK. */
+  async createSolution(
+    command: simPersonalizeCommands.SimCreateSolutionCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimCreateSolutionCommandOutput> {
+    await this.background.sequence();
+    return this.commands.solutionWrites.create(command, options);
+  }
+
+  /** Handle a DescribeSolution Command from the SDK. */
+  async describeSolution(
+    command: simPersonalizeCommands.SimDescribeSolutionCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimDescribeSolutionCommandOutput> {
+    await this.background.sequence();
+    return this.commands.solutionReads.describe(command, options);
+  }
+
+  /** Handle a ListSolutions Command from the SDK. */
+  async listSolutions(
+    command: simPersonalizeCommands.SimListSolutionsCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimListSolutionsCommandOutput> {
+    await this.background.sequence();
+    return this.commands.solutionReads.list(command, options);
+  }
+
+  /** Handle a DeleteSolution Command from the SDK. */
+  async deleteSolution(
+    command: simPersonalizeCommands.SimDeleteSolutionCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimDeleteSolutionCommandOutput> {
+    await this.background.sequence();
+    return this.commands.solutionWrites.delete(command, options);
+  }
+
+  /** Handle a CreateSolutionVersion Command from the SDK. */
+  async createSolutionVersion(
+    command: simPersonalizeCommands.SimCreateSolutionVersionCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimCreateSolutionVersionCommandOutput> {
+    await this.background.sequence();
+    return this.commands.solutionVersionWrites.create(command, options);
+  }
+
+  /** Handle a DescribeSolutionVersion Command from the SDK. */
+  async describeSolutionVersion(
+    command: simPersonalizeCommands.SimDescribeSolutionVersionCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimDescribeSolutionVersionCommandOutput> {
+    await this.background.sequence();
+    return this.commands.solutionVersionReads.describe(command, options);
+  }
+
+  /** Handle a ListSolutionVersions Command from the SDK. */
+  async listSolutionVersions(
+    command: simPersonalizeCommands.SimListSolutionVersionsCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimListSolutionVersionsCommandOutput> {
+    await this.background.sequence();
+    return this.commands.solutionVersionReads.list(command, options);
+  }
+
+  /** Handle a CreateCampaign Command from the SDK. */
+  async createCampaign(
+    command: simPersonalizeCommands.SimCreateCampaignCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimCreateCampaignCommandOutput> {
+    await this.background.sequence();
+    return this.commands.campaignWrites.create(command, options);
+  }
+
+  /** Handle a DescribeCampaign Command from the SDK. */
+  async describeCampaign(
+    command: simPersonalizeCommands.SimDescribeCampaignCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimDescribeCampaignCommandOutput> {
+    await this.background.sequence();
+    return this.commands.campaignReads.describe(command, options);
+  }
+
+  /** Handle a ListCampaigns Command from the SDK. */
+  async listCampaigns(
+    command: simPersonalizeCommands.SimListCampaignsCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimListCampaignsCommandOutput> {
+    await this.background.sequence();
+    return this.commands.campaignReads.list(command, options);
+  }
+
+  /** Handle a DeleteCampaign Command from the SDK. */
+  async deleteCampaign(
+    command: simPersonalizeCommands.SimDeleteCampaignCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimDeleteCampaignCommandOutput> {
+    await this.background.sequence();
+    return this.commands.campaignWrites.delete(command, options);
+  }
+}

--- a/src/service/personalize/sim-personalize-runtime.ts
+++ b/src/service/personalize/sim-personalize-runtime.ts
@@ -1,0 +1,63 @@
+import type { BackgroundScheduler } from "../../util/background/background.js";
+import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
+import type { SimPersonalizeGetPersonalizedRankingHandler } from "./command/runtime/sim-personalize-get-personalized-ranking.js";
+import type { SimPersonalizeGetRecommendationsHandler } from "./command/runtime/sim-personalize-get-recommendations.js";
+import type * as simRuntimeCommands from "./command/runtime/runtime.command.js";
+import type { SimPersonalizeRequestOptions } from "./command/sim-personalize-request-options.js";
+import { SimPersonalizeRuntimeSdkCommandRouter } from "./sdk/sim-personalize-runtime-sdk-command-router.js";
+
+export interface SimPersonalizeRuntimeProperties {
+  readonly recommendations: SimPersonalizeGetRecommendationsHandler;
+  readonly rankings: SimPersonalizeGetPersonalizedRankingHandler;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * Simulated Amazon Personalize Runtime. Handles SDK commands from the
+ * separate Personalize Runtime client.
+ *
+ * It is never built alone. The campaigns it answers for are the ones one
+ * simulated Personalize holds, and the results are the ones declared against
+ * those campaigns, so both come from there rather than being made here.
+ *
+ * No model is consulted and no interaction history is held. A campaign
+ * answers with what a test declared it would answer with, which is the point:
+ * a recommendation from a real trained model moves as the model and the data
+ * move, and code branching on what came back has nothing stable to test
+ * against.
+ */
+export class SimPersonalizeRuntime {
+  private readonly recommendations: SimPersonalizeGetRecommendationsHandler;
+  private readonly rankings: SimPersonalizeGetPersonalizedRankingHandler;
+  private readonly background: BackgroundScheduler;
+  private readonly sdkRouter = new SimPersonalizeRuntimeSdkCommandRouter(this);
+
+  constructor(properties: SimPersonalizeRuntimeProperties) {
+    this.recommendations = properties.recommendations;
+    this.rankings = properties.rankings;
+    this.background = properties.background;
+  }
+
+  /** Handle a GetRecommendations Command from the SDK. */
+  async getRecommendations(
+    command: simRuntimeCommands.SimGetRecommendationsCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simRuntimeCommands.SimGetRecommendationsCommandOutput> {
+    await this.background.sequence();
+    return this.recommendations.handle(command, options);
+  }
+
+  /** Handle a GetPersonalizedRanking Command from the SDK. */
+  async getPersonalizedRanking(
+    command: simRuntimeCommands.SimGetPersonalizedRankingCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simRuntimeCommands.SimGetPersonalizedRankingCommandOutput> {
+    await this.background.sequence();
+    return this.rankings.handle(command, options);
+  }
+
+  /** The SDK Command router for this simulated Personalize Runtime. */
+  sdkCommandRouter(): SimSdkCommandRouter {
+    return this.sdkRouter;
+  }
+}

--- a/src/service/personalize/sim-personalize.ts
+++ b/src/service/personalize/sim-personalize.ts
@@ -1,28 +1,12 @@
-import {
-  type BackgroundScheduler,
-  BackgroundTasks,
-} from "../../util/background/background.js";
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
-import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
-import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
-import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
-import type * as simPersonalizeCommands from "./command/sim-personalize-command.types.js";
-import { SimPersonalizeCommands } from "./command/sim-personalize-commands.js";
-import type { SimPersonalizeRequestOptions } from "./command/sim-personalize-request-options.js";
+import type { SimPersonalizeRankings } from "./recommendation/sim-personalize-rankings.js";
+import type { SimPersonalizeRecommendations } from "./recommendation/sim-personalize-recommendations.js";
 import type { SimPersonalizeCampaign } from "./resource/sim-personalize-campaign.js";
 import type { SimPersonalizeDatasetGroup } from "./resource/sim-personalize-dataset-group.js";
-import { SimPersonalizeResources } from "./resource/sim-personalize-resources.js";
 import type { SimPersonalizeSolution } from "./resource/sim-personalize-solution.js";
 import { SimPersonalizeSdkCommandRouter } from "./sdk/sim-personalize-sdk-command-router.js";
-
-interface SimPersonalizeProperties {
-  readonly accountRegionScope?: SimAwsAccountRegionScope;
-  readonly iam?: SimIamInterServiceAuthZ;
-  readonly background?: BackgroundScheduler;
-}
+import { SimPersonalizeControlPlane } from "./sim-personalize-control-plane.js";
+import { SimPersonalizeRuntime } from "./sim-personalize-runtime.js";
 
 /**
  * Simulated Amazon Personalize. Handles SDK commands. Emulates AWS behaviour
@@ -33,27 +17,47 @@ interface SimPersonalizeProperties {
  * the way simulated ACM issues certificates without producing real TLS
  * certificates. What a campaign then recommends is declared against it rather
  * than learned.
+ *
+ * The control plane operations it inherits are the ones that build the chain
+ * to a campaign. The runtime operations a campaign answers are on `runtime()`,
+ * as they are on a client of their own in the SDK, and what they answer with
+ * is declared through `recommendations()` and `rankings()`.
  */
-export class SimPersonalize {
-  private readonly resources = new SimPersonalizeResources();
-  private readonly commands: SimPersonalizeCommands;
-  private readonly background: BackgroundScheduler;
+export class SimPersonalize extends SimPersonalizeControlPlane {
   private readonly sdkRouter = new SimPersonalizeSdkCommandRouter(this);
+  private readonly runtimeApi = new SimPersonalizeRuntime({
+    recommendations: this.commands.recommendations,
+    rankings: this.commands.rankings,
+    background: this.background,
+  });
 
-  constructor(properties: SimPersonalizeProperties = {}) {
-    const {
-      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      iam = new SimIamAllowAllAuth(),
-      background = new BackgroundTasks(),
-    } = properties;
+  /**
+   * The Personalize Runtime API over this simulated Personalize.
+   *
+   * It is a second API over one service's state rather than a service of its
+   * own, which is what AWS has too. A runtime call names a campaign this
+   * Account and Region holds, and is answered from what is declared against
+   * that campaign here.
+   */
+  runtime(): SimPersonalizeRuntime {
+    return this.runtimeApi;
+  }
 
-    this.background = background;
-    this.commands = new SimPersonalizeCommands({
-      resources: this.resources,
-      iam,
-      accountRegionScope,
-      clock: background,
-    });
+  /**
+   * The recommendations one campaign answers GetRecommendations with.
+   *
+   * Declaring against a campaign ARN this scope does not hold raises, rather
+   * than leaving the declaration somewhere no request will reach it.
+   */
+  recommendations(campaignArn: string): SimPersonalizeRecommendations {
+    return this.commands.rules.recommendations(campaignArn);
+  }
+
+  /**
+   * The rankings one campaign answers GetPersonalizedRanking with.
+   */
+  rankings(campaignArn: string): SimPersonalizeRankings {
+    return this.commands.rules.rankings(campaignArn);
   }
 
   /**
@@ -74,213 +78,6 @@ export class SimPersonalize {
   /** Find a campaign by name. */
   findCampaign(name: string): SimPersonalizeCampaign | undefined {
     return this.resources.campaigns.findByName(name);
-  }
-
-  /** Handle a CreateDatasetGroup Command from the SDK. */
-  async createDatasetGroup(
-    command: simPersonalizeCommands.SimCreateDatasetGroupCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimCreateDatasetGroupCommandOutput> {
-    await this.background.sequence();
-    return this.commands.datasetGroupWrites.create(command, options);
-  }
-
-  /** Handle a DescribeDatasetGroup Command from the SDK. */
-  async describeDatasetGroup(
-    command: simPersonalizeCommands.SimDescribeDatasetGroupCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimDescribeDatasetGroupCommandOutput> {
-    await this.background.sequence();
-    return this.commands.datasetGroupReads.describe(command, options);
-  }
-
-  /** Handle a ListDatasetGroups Command from the SDK. */
-  async listDatasetGroups(
-    command: simPersonalizeCommands.SimListDatasetGroupsCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimListDatasetGroupsCommandOutput> {
-    await this.background.sequence();
-    return this.commands.datasetGroupReads.list(command, options);
-  }
-
-  /** Handle a DeleteDatasetGroup Command from the SDK. */
-  async deleteDatasetGroup(
-    command: simPersonalizeCommands.SimDeleteDatasetGroupCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimDeleteDatasetGroupCommandOutput> {
-    await this.background.sequence();
-    return this.commands.datasetGroupWrites.delete(command, options);
-  }
-
-  /** Handle a CreateSchema Command from the SDK. */
-  async createSchema(
-    command: simPersonalizeCommands.SimCreateSchemaCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimCreateSchemaCommandOutput> {
-    await this.background.sequence();
-    return this.commands.schemaWrites.create(command, options);
-  }
-
-  /** Handle a DescribeSchema Command from the SDK. */
-  async describeSchema(
-    command: simPersonalizeCommands.SimDescribeSchemaCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimDescribeSchemaCommandOutput> {
-    await this.background.sequence();
-    return this.commands.schemaReads.describe(command, options);
-  }
-
-  /** Handle a ListSchemas Command from the SDK. */
-  async listSchemas(
-    command: simPersonalizeCommands.SimListSchemasCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimListSchemasCommandOutput> {
-    await this.background.sequence();
-    return this.commands.schemaReads.list(command, options);
-  }
-
-  /** Handle a DeleteSchema Command from the SDK. */
-  async deleteSchema(
-    command: simPersonalizeCommands.SimDeleteSchemaCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimDeleteSchemaCommandOutput> {
-    await this.background.sequence();
-    return this.commands.schemaWrites.delete(command, options);
-  }
-
-  /** Handle a CreateDataset Command from the SDK. */
-  async createDataset(
-    command: simPersonalizeCommands.SimCreateDatasetCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimCreateDatasetCommandOutput> {
-    await this.background.sequence();
-    return this.commands.datasetWrites.create(command, options);
-  }
-
-  /** Handle a DescribeDataset Command from the SDK. */
-  async describeDataset(
-    command: simPersonalizeCommands.SimDescribeDatasetCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimDescribeDatasetCommandOutput> {
-    await this.background.sequence();
-    return this.commands.datasetReads.describe(command, options);
-  }
-
-  /** Handle a ListDatasets Command from the SDK. */
-  async listDatasets(
-    command: simPersonalizeCommands.SimListDatasetsCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimListDatasetsCommandOutput> {
-    await this.background.sequence();
-    return this.commands.datasetReads.list(command, options);
-  }
-
-  /** Handle a DeleteDataset Command from the SDK. */
-  async deleteDataset(
-    command: simPersonalizeCommands.SimDeleteDatasetCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimDeleteDatasetCommandOutput> {
-    await this.background.sequence();
-    return this.commands.datasetWrites.delete(command, options);
-  }
-
-  /** Handle a CreateSolution Command from the SDK. */
-  async createSolution(
-    command: simPersonalizeCommands.SimCreateSolutionCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimCreateSolutionCommandOutput> {
-    await this.background.sequence();
-    return this.commands.solutionWrites.create(command, options);
-  }
-
-  /** Handle a DescribeSolution Command from the SDK. */
-  async describeSolution(
-    command: simPersonalizeCommands.SimDescribeSolutionCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimDescribeSolutionCommandOutput> {
-    await this.background.sequence();
-    return this.commands.solutionReads.describe(command, options);
-  }
-
-  /** Handle a ListSolutions Command from the SDK. */
-  async listSolutions(
-    command: simPersonalizeCommands.SimListSolutionsCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimListSolutionsCommandOutput> {
-    await this.background.sequence();
-    return this.commands.solutionReads.list(command, options);
-  }
-
-  /** Handle a DeleteSolution Command from the SDK. */
-  async deleteSolution(
-    command: simPersonalizeCommands.SimDeleteSolutionCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimDeleteSolutionCommandOutput> {
-    await this.background.sequence();
-    return this.commands.solutionWrites.delete(command, options);
-  }
-
-  /** Handle a CreateSolutionVersion Command from the SDK. */
-  async createSolutionVersion(
-    command: simPersonalizeCommands.SimCreateSolutionVersionCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimCreateSolutionVersionCommandOutput> {
-    await this.background.sequence();
-    return this.commands.solutionVersionWrites.create(command, options);
-  }
-
-  /** Handle a DescribeSolutionVersion Command from the SDK. */
-  async describeSolutionVersion(
-    command: simPersonalizeCommands.SimDescribeSolutionVersionCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimDescribeSolutionVersionCommandOutput> {
-    await this.background.sequence();
-    return this.commands.solutionVersionReads.describe(command, options);
-  }
-
-  /** Handle a ListSolutionVersions Command from the SDK. */
-  async listSolutionVersions(
-    command: simPersonalizeCommands.SimListSolutionVersionsCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimListSolutionVersionsCommandOutput> {
-    await this.background.sequence();
-    return this.commands.solutionVersionReads.list(command, options);
-  }
-
-  /** Handle a CreateCampaign Command from the SDK. */
-  async createCampaign(
-    command: simPersonalizeCommands.SimCreateCampaignCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimCreateCampaignCommandOutput> {
-    await this.background.sequence();
-    return this.commands.campaignWrites.create(command, options);
-  }
-
-  /** Handle a DescribeCampaign Command from the SDK. */
-  async describeCampaign(
-    command: simPersonalizeCommands.SimDescribeCampaignCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimDescribeCampaignCommandOutput> {
-    await this.background.sequence();
-    return this.commands.campaignReads.describe(command, options);
-  }
-
-  /** Handle a ListCampaigns Command from the SDK. */
-  async listCampaigns(
-    command: simPersonalizeCommands.SimListCampaignsCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimListCampaignsCommandOutput> {
-    await this.background.sequence();
-    return this.commands.campaignReads.list(command, options);
-  }
-
-  /** Handle a DeleteCampaign Command from the SDK. */
-  async deleteCampaign(
-    command: simPersonalizeCommands.SimDeleteCampaignCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimDeleteCampaignCommandOutput> {
-    await this.background.sequence();
-    return this.commands.campaignWrites.delete(command, options);
   }
 
   /** The SDK Command router for this simulated Personalize. */

--- a/src/service/personalize/view/sim-personalize-item-list-view.ts
+++ b/src/service/personalize/view/sim-personalize-item-list-view.ts
@@ -6,12 +6,21 @@ import {
 
 /**
  * The items a runtime call answers with, as they were declared.
+ *
+ * An item declared without a score comes back without the field at all. Real
+ * Personalize leaves `score` out where the recipe behind the campaign reports
+ * none, and a `score` of `undefined` reads as a score to a test comparing the
+ * whole item.
  */
 export function simPersonalizeItemList(
   declarations: readonly SimPersonalizeItemDeclaration[],
 ): readonly SimPersonalizePredictedItem[] {
   return declarations.map((declaration) => {
     const item = simPersonalizeDeclaredItem(declaration);
+
+    if (item.score === undefined) {
+      return { itemId: item.itemId };
+    }
 
     return { itemId: item.itemId, score: item.score };
   });

--- a/src/service/personalize/view/sim-personalize-item-list-view.ts
+++ b/src/service/personalize/view/sim-personalize-item-list-view.ts
@@ -1,0 +1,39 @@
+import type { SimPersonalizePredictedItem } from "../command/runtime/runtime.command.js";
+import {
+  simPersonalizeDeclaredItem,
+  type SimPersonalizeItemDeclaration,
+} from "../recommendation/sim-personalize-item-declaration.js";
+
+/**
+ * The items a runtime call answers with, as they were declared.
+ */
+export function simPersonalizeItemList(
+  declarations: readonly SimPersonalizeItemDeclaration[],
+): readonly SimPersonalizePredictedItem[] {
+  return declarations.map((declaration) => {
+    const item = simPersonalizeDeclaredItem(declaration);
+
+    return { itemId: item.itemId, score: item.score };
+  });
+}
+
+/**
+ * The items a ranking no rule matched answers with: the list the request
+ * carried, in the order it arrived.
+ *
+ * The scores descend so that the first item is the one ranked highest, as a
+ * caller sorting by score would expect, and they sum to one across the list
+ * as a real ranking's do. What they do not do is say anything about the
+ * items. A test that cares which item ranks where declares a rule.
+ */
+export function simPersonalizeRankedInputList(
+  inputList: readonly string[],
+): readonly SimPersonalizePredictedItem[] {
+  const places = inputList.length;
+  const total = (places * (places + 1)) / 2;
+
+  return inputList.map((itemId, index) => ({
+    itemId,
+    score: (places - index) / total,
+  }));
+}

--- a/src/service/rekognition/rule/sim-rekognition-result-rules.ts
+++ b/src/service/rekognition/rule/sim-rekognition-result-rules.ts
@@ -1,3 +1,4 @@
+import { SimDeclaredResultRules } from "../../../util/rule/sim-declared-result-rules.js";
 import { SimRekognitionDeclarationError } from "../error/sim-rekognition.error.js";
 import { isSimRekognitionImageHash } from "../image/sim-rekognition-image-hash.js";
 import type { SimRekognitionImage } from "../image/sim-rekognition-image.js";
@@ -11,26 +12,25 @@ import type { SimRekognitionImage } from "../image/sim-rekognition-image.js";
  *
  * There are three kinds of rule and one order between them: a rule for an
  * exact content hash wins, then a rule for an exact S3 object name, then the
- * default. Matching is exact, with no pattern syntax, so which rule applies
- * never depends on how specific a pattern is thought to be.
+ * default. That ordering is `SimDeclaredResultRules`, which simulated
+ * Personalize matches recommendation requests with too. What is Rekognition's
+ * own is which key each tier holds and what makes one well formed.
  *
  * An image passed as `Image.Bytes` has no name, so it consults hash rules and
  * then the default.
  */
 export class SimRekognitionResultRules<TResult> {
-  private defaultResult: TResult;
-  private readonly resultsByName = new Map<string, TResult>();
-  private readonly resultsByHash = new Map<string, TResult>();
+  private readonly rules: SimDeclaredResultRules<TResult>;
 
   constructor(defaultResult: TResult) {
-    this.defaultResult = defaultResult;
+    this.rules = new SimDeclaredResultRules<TResult>(defaultResult);
   }
 
   /**
    * Answer with this result for any image no other rule matches.
    */
   byDefault(result: TResult): void {
-    this.defaultResult = result;
+    this.rules.byDefault(result);
   }
 
   /**
@@ -48,7 +48,7 @@ export class SimRekognitionResultRules<TResult> {
       );
     }
 
-    this.resultsByName.set(name, result);
+    this.rules.onTrailingKey(name, result);
   }
 
   /**
@@ -71,27 +71,16 @@ export class SimRekognitionResultRules<TResult> {
       );
     }
 
-    this.resultsByHash.set(digest, result);
+    this.rules.onLeadingKey(digest, result);
   }
 
   /**
    * The result for one image.
    */
   resultFor(image: SimRekognitionImage): TResult {
-    const byHash = this.resultsByHash.get(image.hash());
-
-    if (byHash !== undefined) {
-      return byHash;
-    }
-
-    return this.byNameOrDefault(image);
-  }
-
-  private byNameOrDefault(image: SimRekognitionImage): TResult {
-    if (image.name === undefined) {
-      return this.defaultResult;
-    }
-
-    return this.resultsByName.get(image.name) ?? this.defaultResult;
+    return this.rules.resultFor({
+      leading: image.hash(),
+      trailing: image.name,
+    });
   }
 }

--- a/src/util/rule/sim-declared-result-rules.ts
+++ b/src/util/rule/sim-declared-result-rules.ts
@@ -1,0 +1,84 @@
+/**
+ * The keys one request is matched on, in the order the tiers are tried.
+ *
+ * A request carrying nothing for a tier skips it. That is the ordinary case
+ * rather than an edge: a Rekognition image passed as bytes has no S3 object
+ * name, and a Personalize related-items request names no user.
+ */
+export interface SimDeclaredResultKeys {
+  readonly leading?: string | undefined;
+  readonly trailing?: string | undefined;
+}
+
+/**
+ * The results a simulated operation answers with, by the keys a request
+ * carries.
+ *
+ * A service that answers from declarations rather than from data needs the
+ * same matcher each time. A request carries one or two identifying keys, a
+ * test declares what each of them answers with, and everything else gets the
+ * default. Simulated Rekognition matches an image by content hash and then by
+ * S3 object name; simulated Personalize matches a recommendation request by
+ * item and then by user.
+ *
+ * There are three kinds of rule and one order between them: a leading key rule
+ * wins, then a trailing key rule, then the default. Matching is exact, with no
+ * pattern syntax, so which rule applies never depends on how specific a
+ * pattern is thought to be.
+ *
+ * The keys are matched, not validated. What counts as a key at all belongs to
+ * the service declaring the rule, which is where a malformed one is refused.
+ */
+export class SimDeclaredResultRules<TResult> {
+  private defaultResult: TResult;
+  private readonly byLeadingKey = new Map<string, TResult>();
+  private readonly byTrailingKey = new Map<string, TResult>();
+
+  constructor(defaultResult: TResult) {
+    this.defaultResult = defaultResult;
+  }
+
+  /**
+   * Answer with this result for any request no other rule matches.
+   */
+  byDefault(result: TResult): void {
+    this.defaultResult = result;
+  }
+
+  /**
+   * Answer with this result for a request carrying this exact leading key.
+   */
+  onLeadingKey(key: string, result: TResult): void {
+    this.byLeadingKey.set(key, result);
+  }
+
+  /**
+   * Answer with this result for a request carrying this exact trailing key,
+   * where no leading key rule matched it first.
+   */
+  onTrailingKey(key: string, result: TResult): void {
+    this.byTrailingKey.set(key, result);
+  }
+
+  /**
+   * The result for one request.
+   */
+  resultFor(keys: SimDeclaredResultKeys): TResult {
+    return (
+      this.declaredFor(this.byLeadingKey, keys.leading) ??
+      this.declaredFor(this.byTrailingKey, keys.trailing) ??
+      this.defaultResult
+    );
+  }
+
+  private declaredFor(
+    rules: ReadonlyMap<string, TResult>,
+    key: string | undefined,
+  ): TResult | undefined {
+    if (key === undefined) {
+      return undefined;
+    }
+
+    return rules.get(key);
+  }
+}


### PR DESCRIPTION
Simulated Personalize answers `GetRecommendations` and `GetPersonalizedRanking` from the results
declared against a campaign, reached through `simAws.personalizeRuntime()` and through an
intercepted `PersonalizeRuntimeClient`. No model is fitted and no interaction history is held. A
test says what one campaign recommends for one item, and the code under test makes the calls it
would make against AWS.

Rules are declared per campaign with `recommendations()` and `rankings()`. An item rule is read
first where the request carries one, then a user rule, then the default. That order follows the
recipes, since `aws-similar-items` requires an `itemId` and looks at no user, and the user
personalization recipes require a `userId`. `numResults` cuts a declared list to length. A ranking
no rule matches comes back as the input list in the order it arrived, with scores that descend and
sum to one, so a test that is not about the ranking still gets a stable answer. Declaring against
an ARN no campaign is deployed at raises `SimPersonalizeDeclarationError`, and calling the runtime
with one raises `ResourceNotFoundException`.

Three decisions in here are worth a look.

The three tier matcher moved. The issue asks for the rules to be built on
`SimRekognitionResultRules`, which takes a `SimRekognitionImage` and cannot serve Personalize as it
stands. The generic part is now `util/rule/sim-declared-result-rules.ts`, holding a leading key, a
trailing key and a default. Rekognition's class keeps its own API and its own validation over it,
and its tests are unchanged.

Rankings carry no item rule. A `GetPersonalizedRanking` request names a user and the list to rank,
never one item, so an `onItem` there would be a rule nothing could match. `rankings()` has `onUser`
and `byDefault`.

The runtime is reached through Personalize rather than built by the service factory, following
simulated DynamoDB Streams over simulated DynamoDB. It is a second API over one service's state,
and its types are exported from the existing `@kensio/yulin/personalize` subpath. Adding it also
pushed `sim-personalize.ts` past the 300 line cap, so the twenty-two control plane operations moved
to an abstract `SimPersonalizeControlPlane` it extends.

Out of scope, as the issue sets out: `GetActionRecommendations`, filters (`filterArn` is refused by
name along with every other runtime input this simulation does not model), and computed scores. The
divergence over popular items is recorded in the docs.

Resolves #899

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated Amazon Personalize Runtime support for recommendations and personalized rankings.
  * Configure campaign-specific results for users and items, including scores and recommendation IDs.
  * Added default and fallback behavior, result limits, input validation, campaign checks, and authorization handling.
  * Added SDK command support through standard service access paths.

* **Documentation**
  * Added usage guides and executable examples for recommendations, recommendation scores, and personalized rankings.

* **Tests**
  * Added coverage for matching rules, fallback behavior, validation, authorization, campaign isolation, and SDK routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->