### PR TITLE
feat: record Personalize events through a tracker

### DIFF
--- a/docs/services/personalize/README.md
+++ b/docs/services/personalize/README.md
@@ -287,6 +287,153 @@ names one case insensitively and Personalize upper-cases it. `ACTIONS` and `ACTI
 belong to Next-Best-Action, and real Personalize allows them only in a custom dataset group. A
 domain dataset group refuses them here too.
 
+## Recording events
+
+An event tracker is where `PutEvents` sends item interactions. It is created against a dataset
+group and reports a tracking ID back, and every `PutEvents` names that ID.
+
+```typescript sim-personalize-event-tracker
+/**
+ * Recording an item interaction through an event tracker.
+ */
+
+import {
+  CreateDatasetGroupCommand,
+  CreateEventTrackerCommand,
+} from "@aws-sdk/client-personalize";
+import { PutEventsCommand } from "@aws-sdk/client-personalize-events";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const group = await simAws
+  .personalize()
+  .createDatasetGroup(new CreateDatasetGroupCommand({ name: "catalogue" }));
+
+const tracker = await simAws.personalize().createEventTracker(
+  new CreateEventTrackerCommand({
+    name: "catalogue-events",
+    datasetGroupArn: group.datasetGroupArn,
+  }),
+);
+
+await simAws.personalizeEvents().putEvents(
+  new PutEventsCommand({
+    trackingId: tracker.trackingId,
+    userId: "visitor-7",
+    sessionId: "session-1",
+    eventList: [
+      { eventType: "view", itemId: "entry-1042", sentAt: new Date() },
+    ],
+  }),
+);
+
+const [event] = simAws.personalize().recordedEvents();
+
+// view entry-1042 visitor-7
+console.log(event?.eventType, event?.itemId, event?.userId);
+```
+
+The three events operations live on `simAws.personalizeEvents()`, and an intercepted
+`PersonalizeEventsClient` reaches the same place. They arrive from a third SDK package
+(`@aws-sdk/client-personalize-events`), as they do on AWS.
+
+`recordedEvents()` reads the interactions back, oldest first. A batch is recorded in the order the
+request listed it. Each record carries the `eventType`, `sentAt`, `itemId`, `properties`, `userId`
+and `sessionId` the request gave, along with the tracking ID it named and the ARN of the tracker
+behind it. `eventValue`, `eventId`, `recommendationId` and `impression` are recorded too.
+
+The `properties` of an event are held as the JSON string the wire would carry. The SDK turns an
+object into one on its way out. An object handed to the client is serialised here before it is
+recorded, and a test asserting on one field parses it back.
+
+An event that leaves `sentAt` out is stamped from the simulated clock. Moving the clock therefore
+decides what a later event records:
+
+```typescript sim-personalize-event-clock
+/**
+ * Timestamping an event from the simulated clock.
+ */
+
+import { PutEventsCommand } from "@aws-sdk/client-personalize-events";
+
+import type { SimAws } from "@kensio/yulin";
+
+declare const simAws: SimAws;
+declare const trackingId: string;
+
+simAws.clock().freeze();
+await simAws.clock().setTo(new Date("2026-03-04T10:00:00.000Z"));
+
+await simAws.personalizeEvents().putEvents(
+  new PutEventsCommand({
+    trackingId,
+    sessionId: "session-1",
+    // The SDK types make sentAt a required property, so it is passed as
+    // undefined rather than left off.
+    eventList: [{ eventType: "view", itemId: "entry-1042", sentAt: undefined }],
+  }),
+);
+
+// 2026-03-04T10:00:00.000Z
+console.log(simAws.personalize().recordedEvents()[0]?.sentAt.toISOString());
+```
+
+A `PutEvents` naming a tracking ID no tracker holds raises `ResourceNotFoundException`, and nothing
+is recorded. One request carries up to ten events. Real Personalize applies the same limit.
+
+### Items and users
+
+`PutItems` and `PutUsers` are how a catalogue update reaches Personalize between import jobs. Each
+one names the dataset it adds to, an Items dataset or a Users dataset.
+
+```typescript sim-personalize-put-items
+/**
+ * Adding an item and a user through the events API.
+ */
+
+import {
+  PutItemsCommand,
+  PutUsersCommand,
+} from "@aws-sdk/client-personalize-events";
+
+import type { SimAws } from "@kensio/yulin";
+
+declare const simAws: SimAws;
+declare const itemsDatasetArn: string;
+declare const usersDatasetArn: string;
+
+await simAws.personalizeEvents().putItems(
+  new PutItemsCommand({
+    datasetArn: itemsDatasetArn,
+    items: [
+      { itemId: "entry-1042", properties: { category: "Horror|Action" } },
+    ],
+  }),
+);
+
+await simAws.personalizeEvents().putUsers(
+  new PutUsersCommand({
+    datasetArn: usersDatasetArn,
+    users: [{ userId: "visitor-7", properties: { membership: "Frequent" } }],
+  }),
+);
+
+// entry-1042 visitor-7
+console.log(
+  simAws.personalize().recordedItems()[0]?.itemId,
+  simAws.personalize().recordedUsers()[0]?.userId,
+);
+```
+
+`recordedItems()` and `recordedUsers()` read them back the way `recordedEvents()` does. The
+datasets themselves stay empty, as every simulated dataset does.
+
+A dataset ARN of the wrong type is refused as invalid input. Sending items to the Interactions
+dataset of the same group is the mistake this catches. Both operations take up to ten records in
+one request.
+
 ## Domain dataset groups
 
 A dataset group created with a domain of `ECOMMERCE` or `VIDEO_ON_DEMAND` is a Domain dataset group.
@@ -319,7 +466,8 @@ console.log(group.domain);
 ## Reading state back
 
 `findDatasetGroup`, `findSolution` and `findCampaign` read resources by name without going through a
-Command or its authorization.
+Command or its authorization. `recordedEvents()`, `recordedItems()` and `recordedUsers()` read back
+what the events API was sent.
 
 ```typescript sim-personalize-accessors
 /**
@@ -344,17 +492,20 @@ console.log(group?.name, group?.status);
 
 ## Deleting resources
 
-Deletion follows real Personalize. A dataset group holding datasets or solutions is reported as
-`ResourceInUseException`, and so is a solution a campaign still deploys. Tear a chain down from the
-campaign end.
+Deletion follows real Personalize. A dataset group holding datasets, solutions or an event tracker
+is reported as `ResourceInUseException`, and so is a solution a campaign still deploys. Tear a chain
+down from the campaign end.
+
+Deleting an event tracker leaves the events it accepted recorded, as real Personalize leaves the
+interactions it wrote in the dataset behind it.
 
 Deleting a solution takes its versions with it. Real Personalize has no `DeleteSolutionVersion`
 either.
 
 ## Supported commands
 
-Dataset groups, schemas, datasets, solutions and campaigns each have `Create`, `Describe`, `List`
-and `Delete`. Solution versions have `Create`, `Describe` and `List`.
+Dataset groups, schemas, datasets, solutions, campaigns and event trackers each have `Create`,
+`Describe`, `List` and `Delete`. Solution versions have `Create`, `Describe` and `List`.
 
 Every command works through `simAws.personalize()` and through an intercepted `PersonalizeClient`.
 Each one authorizes through simulated IAM, against the resource ARN where the request names one and
@@ -363,6 +514,11 @@ against `*` on a create.
 The runtime API has `GetRecommendations` and `GetPersonalizedRanking`. Both work through
 `simAws.personalizeRuntime()` and through an intercepted `PersonalizeRuntimeClient`, and both
 authorize against the campaign ARN the request names.
+
+The events API has `PutEvents`, `PutItems` and `PutUsers`. All three work through
+`simAws.personalizeEvents()` and through an intercepted `PersonalizeEventsClient`. `PutEvents`
+authorizes against the ARN of the tracker its tracking ID belongs to, and the other two against the
+dataset ARN they name.
 
 ## Divergences and limitations
 
@@ -379,7 +535,15 @@ authorize against the campaign ARN the request names.
   simulation leaves out by design. A runtime request naming a `filterArn` is refused by name.
 - **No `GetActionRecommendations`.** Actions are a dataset type with interactions of their own, and
   the Next-Best-Action operations arrive with them.
-- **No events.** `PutEvents`, `PutItems`, `PutUsers` and event trackers arrive with the events API.
+- **A recorded event trains nothing.** Real Personalize puts the interaction into the Interactions
+  dataset behind the tracker, and a later training run reads it. A campaign here answers with what
+  was declared against it however many events it has been sent.
+- **A tracking ID is a UUID that changes every run.** Real Personalize generates one too. Read it
+  from the `CreateEventTracker` response rather than writing it down.
+- **No `metricAttribution` on an event.** It ties an event to a metric attribution report, and
+  `CreateMetricAttribution` is absent. An event carrying one is refused by name.
+- **No `PutActions` or `PutActionInteractions`.** They belong with Next-Best-Action, alongside
+  `GetActionRecommendations`.
 - **No recommenders.** `CreateRecommender` and the ten domain use cases arrive with the domain
   path.
 - **No CloudFormation.** `AWS::Personalize::*` resource types arrive with their own issue. Real

--- a/docs/services/personalize/sim-personalize-event-clock.example.ts
+++ b/docs/services/personalize/sim-personalize-event-clock.example.ts
@@ -1,0 +1,26 @@
+/**
+ * Timestamping an event from the simulated clock.
+ */
+
+import { PutEventsCommand } from "@aws-sdk/client-personalize-events";
+
+import type { SimAws } from "@kensio/yulin";
+
+declare const simAws: SimAws;
+declare const trackingId: string;
+
+simAws.clock().freeze();
+await simAws.clock().setTo(new Date("2026-03-04T10:00:00.000Z"));
+
+await simAws.personalizeEvents().putEvents(
+  new PutEventsCommand({
+    trackingId,
+    sessionId: "session-1",
+    // The SDK types make sentAt a required property, so it is passed as
+    // undefined rather than left off.
+    eventList: [{ eventType: "view", itemId: "entry-1042", sentAt: undefined }],
+  }),
+);
+
+// 2026-03-04T10:00:00.000Z
+console.log(simAws.personalize().recordedEvents()[0]?.sentAt.toISOString());

--- a/docs/services/personalize/sim-personalize-event-tracker.example.ts
+++ b/docs/services/personalize/sim-personalize-event-tracker.example.ts
@@ -1,0 +1,40 @@
+/**
+ * Recording an item interaction through an event tracker.
+ */
+
+import {
+  CreateDatasetGroupCommand,
+  CreateEventTrackerCommand,
+} from "@aws-sdk/client-personalize";
+import { PutEventsCommand } from "@aws-sdk/client-personalize-events";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const group = await simAws
+  .personalize()
+  .createDatasetGroup(new CreateDatasetGroupCommand({ name: "catalogue" }));
+
+const tracker = await simAws.personalize().createEventTracker(
+  new CreateEventTrackerCommand({
+    name: "catalogue-events",
+    datasetGroupArn: group.datasetGroupArn,
+  }),
+);
+
+await simAws.personalizeEvents().putEvents(
+  new PutEventsCommand({
+    trackingId: tracker.trackingId,
+    userId: "visitor-7",
+    sessionId: "session-1",
+    eventList: [
+      { eventType: "view", itemId: "entry-1042", sentAt: new Date() },
+    ],
+  }),
+);
+
+const [event] = simAws.personalize().recordedEvents();
+
+// view entry-1042 visitor-7
+console.log(event?.eventType, event?.itemId, event?.userId);

--- a/docs/services/personalize/sim-personalize-put-items.example.ts
+++ b/docs/services/personalize/sim-personalize-put-items.example.ts
@@ -1,0 +1,36 @@
+/**
+ * Adding an item and a user through the events API.
+ */
+
+import {
+  PutItemsCommand,
+  PutUsersCommand,
+} from "@aws-sdk/client-personalize-events";
+
+import type { SimAws } from "@kensio/yulin";
+
+declare const simAws: SimAws;
+declare const itemsDatasetArn: string;
+declare const usersDatasetArn: string;
+
+await simAws.personalizeEvents().putItems(
+  new PutItemsCommand({
+    datasetArn: itemsDatasetArn,
+    items: [
+      { itemId: "entry-1042", properties: { category: "Horror|Action" } },
+    ],
+  }),
+);
+
+await simAws.personalizeEvents().putUsers(
+  new PutUsersCommand({
+    datasetArn: usersDatasetArn,
+    users: [{ userId: "visitor-7", properties: { membership: "Frequent" } }],
+  }),
+);
+
+// entry-1042 visitor-7
+console.log(
+  simAws.personalize().recordedItems()[0]?.itemId,
+  simAws.personalize().recordedUsers()[0]?.userId,
+);

--- a/package.json
+++ b/package.json
@@ -212,6 +212,7 @@
     "@aws-sdk/client-kms": "^3.1101.0",
     "@aws-sdk/client-lambda": "^3.1101.0",
     "@aws-sdk/client-personalize": "^3.1115.0",
+    "@aws-sdk/client-personalize-events": "^3.1115.0",
     "@aws-sdk/client-personalize-runtime": "^3.1115.0",
     "@aws-sdk/client-rekognition": "^3.1101.0",
     "@aws-sdk/client-route-53": "^3.1101.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       '@aws-sdk/client-personalize':
         specifier: ^3.1115.0
         version: 3.1115.0
+      '@aws-sdk/client-personalize-events':
+        specifier: ^3.1115.0
+        version: 3.1115.0
       '@aws-sdk/client-personalize-runtime':
         specifier: ^3.1115.0
         version: 3.1115.0
@@ -352,6 +355,10 @@ packages:
 
   '@aws-sdk/client-lambda@3.1110.0':
     resolution: {integrity: sha512-1YI5iNhtJmTV0KAXAsUylPS1958o04a7sBlryMqJsdJUyRL6viot3aKRUMNbRgLdRReSiD5Cl5uVlT8dnpJe7g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-personalize-events@3.1115.0':
+    resolution: {integrity: sha512-qhV4a6gVxMBhHaKgs6tidtOJqOT3KngNuwfGQCUPEs4LvvpommRq9Xepa2qMY7VblpKBUKoHRdaApsf/13HoLA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-personalize-runtime@3.1115.0':
@@ -3792,6 +3799,17 @@ snapshots:
       tslib: 2.8.1
 
   '@aws-sdk/client-lambda@3.1110.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/credential-provider-node': 3.972.80
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/client-personalize-events@3.1115.0':
     dependencies:
       '@aws-sdk/core': 3.977.8
       '@aws-sdk/credential-provider-node': 3.972.80

--- a/src/sdk/router/resolve-sim-sdk-command-router.ts
+++ b/src/sdk/router/resolve-sim-sdk-command-router.ts
@@ -91,6 +91,11 @@ const scopedRouters: ReadonlyMap<string, SimSdkScopedRouter> = new Map<
     (scoped): SimSdkCommandRouter => scoped.personalize().sdkCommandRouter(),
   ],
   [
+    "Personalize Events",
+    (scoped): SimSdkCommandRouter =>
+      scoped.personalizeEvents().sdkCommandRouter(),
+  ],
+  [
     "Personalize Runtime",
     (scoped): SimSdkCommandRouter =>
       scoped.personalizeRuntime().sdkCommandRouter(),

--- a/src/service/aws/sim-aws-account-region-scope.ts
+++ b/src/service/aws/sim-aws-account-region-scope.ts
@@ -19,6 +19,7 @@ import type { SimEventBridge } from "../eventbridge/index.js";
 import type { SimCognitoIdentityProvider } from "../cognito/index.js";
 import type {
   SimPersonalize,
+  SimPersonalizeEvents,
   SimPersonalizeRuntime,
 } from "../personalize/index.js";
 import type { SimRekognition } from "../rekognition/index.js";
@@ -214,6 +215,16 @@ export class SimAwsAccountRegionContainer {
    */
   personalizeRuntime(): SimPersonalizeRuntime {
     return this.personalize().runtime();
+  }
+
+  /**
+   * Get the simulated Personalize Events API for this account and region.
+   *
+   * Reached through this scope's Personalize, as the runtime API is. The event
+   * trackers it accepts interactions for belong to that service.
+   */
+  personalizeEvents(): SimPersonalizeEvents {
+    return this.personalize().events();
   }
 
   /** Get simulated Rekognition for this account and region. */

--- a/src/service/aws/sim-aws-service-accessors.ts
+++ b/src/service/aws/sim-aws-service-accessors.ts
@@ -20,6 +20,7 @@ import type { SimLambda } from "../lambda/index.js";
 import type { SimLogs } from "../logs/index.js";
 import type {
   SimPersonalize,
+  SimPersonalizeEvents,
   SimPersonalizeRuntime,
 } from "../personalize/index.js";
 import type { SimRekognition } from "../rekognition/index.js";
@@ -157,6 +158,14 @@ export abstract class SimAwsServiceAccessors {
    */
   personalizeRuntime(): SimPersonalizeRuntime {
     return this.defaultAccountRegionScope().personalizeRuntime();
+  }
+
+  /**
+   * Get the simulated Personalize Events API in the default Account Region
+   * scope.
+   */
+  personalizeEvents(): SimPersonalizeEvents {
+    return this.defaultAccountRegionScope().personalizeEvents();
   }
 
   /** Get simulated Rekognition in the default Account Region scope. */

--- a/src/service/aws/sim-aws.iso.test.ts
+++ b/src/service/aws/sim-aws.iso.test.ts
@@ -105,6 +105,14 @@ describe("SimAws", () => {
     assertIdentical(simAws.account().region().personalizeRuntime(), runtime);
   });
 
+  it("returns the events API of the Personalize in the same scope", () => {
+    const simAws = new SimAws();
+    const events = simAws.personalize().events();
+
+    assertIdentical(simAws.personalizeEvents(), events);
+    assertIdentical(simAws.account().region().personalizeEvents(), events);
+  });
+
   it("returns the Streams API of the DynamoDB in the same scope", () => {
     const simAws = new SimAws();
     const streams = simAws.dynamoDb().streams();

--- a/src/service/personalize/README.md
+++ b/src/service/personalize/README.md
@@ -9,8 +9,9 @@ CloudFormation templates actually touch.
 ## Resources without models
 
 A dataset group holds schemas and datasets. A solution names a recipe on that group. A solution
-version stands for the trained model, and a campaign is the endpoint a runtime call names. All six
-exist here as state, reach `ACTIVE` on creation, and report back what the request gave them.
+version stands for the trained model, and a campaign is the endpoint a runtime call names. An event
+tracker is where interactions arrive. All seven exist here as state, reach `ACTIVE` on creation, and
+report back what the request gave them.
 
 The recipe ARN is recorded and never looked up. There is no catalogue of recipes, because no model
 is fitted and one recipe would behave like another. That changes with domain recommenders, where the
@@ -21,22 +22,31 @@ use case a recipe names decides which parameters a recommendation request has to
 - `sim-personalize.ts` is the main in-memory service object for one account/region scope. It holds
   the runtime API, the rules declared against campaigns, and the accessors a test reads state back
   through.
-- `sim-personalize-control-plane.ts` is the abstract base it extends, carrying the twenty-two
-  control plane operations. The split keeps `sim-personalize.ts` from being that list and nothing
-  else, and it is the split AWS makes between the `personalize` endpoint and `personalize-runtime`.
+- `sim-personalize-control-plane.ts` and `sim-personalize-data-operations.ts` are the abstract
+  bases it extends, carrying the twenty-six control plane operations between them. The data
+  operations file holds dataset groups, schemas, datasets and event trackers along with the
+  constructor, and the control plane file extends it with solutions, solution versions and
+  campaigns. The split keeps `sim-personalize.ts` from being that list and nothing else, and it
+  keeps both files under the line limit. The control plane and the runtime are split the way AWS
+  splits the `personalize` endpoint from `personalize-runtime`.
 - `sim-personalize-runtime.ts` is the runtime API, reached through `simAws.personalizeRuntime()` or
   through `runtime()` on the service. It is a second API over one service's state, in the way
   simulated DynamoDB Streams is over simulated DynamoDB. The Account/Region scope builds no service
   for it, and reaches it through the Personalize it already holds.
+- `sim-personalize-events.ts` is the events API, reached through `simAws.personalizeEvents()` or
+  through `events()` on the service. A third API over one service's state, alongside the runtime.
+  What it is sent is recorded rather than trained on, and read back through the accessors on
+  `sim-personalize.ts`.
 - `index.ts` exports the public Personalize simulator API for `@kensio/yulin/personalize`.
 
 ## Resource model
 
 Resource state lives under `resource/`. Every resource carries an ARN, a name, a status and a pair
-of timestamps, gathered as `SimPersonalizeResource`. One generic `SimPersonalizeResourceStore` serves
-all six types on the strength of that shared shape, keyed by ARN with a secondary lookup by name.
+of timestamps, gathered as `SimPersonalizeResource`. One generic `SimPersonalizeResourceStore`
+serves all seven types on the strength of that shared shape, keyed by ARN with a secondary lookup
+by name.
 
-`SimPersonalizeResources` gathers the six stores. The stores sit together, away from the service
+`SimPersonalizeResources` gathers the seven stores. The stores sit together, away from the service
 facade, because most commands read more than one of them. Creating a dataset reaches its dataset
 group and its schema, and creating a campaign reaches a solution version and through it a solution.
 
@@ -50,17 +60,22 @@ A solution version ARN is the solution's with a version on the end. That is why
 `simPersonalizeSolutionVersionArn` takes a solution ARN where the other builders take a name and a
 scope.
 
+An event tracker is the seventh resource type and the one a request reaches by something other than
+its ARN. `PutEvents` names the tracking ID, so the events handlers look a tracker up by that and
+authorize against the ARN they find. One dataset group takes one tracker, as on real Personalize.
+
 ## Commands
 
 Command handlers live under `command/`, grouped by the resource they are about.
-`SimPersonalizeCommands` builds all six groups over one set of resources and one authorizer. The
+`SimPersonalizeCommands` builds all seven groups over one set of resources and one authorizer. The
 service facade stays a list of operations because of it.
 
 Every group follows the same order. Read the ARN from the input, authorize against it, resolve the
 resource, then act. Authorizing before resolving is deliberate. A caller with no permission learns
 only that it has no permission, and the existence of the resource stays hidden.
 
-`command/list/sim-personalize-page.ts` is shared by all six list operations. The pagination token is
+`command/list/sim-personalize-page.ts` is shared by all seven list operations. The pagination token
+is
 the index the next page starts at, where real Personalize hands out an opaque string.
 
 ## Declared results
@@ -84,16 +99,31 @@ A campaign is required to exist before anything is declared against it. An ARN n
 deployed at raises `SimPersonalizeDeclarationError`, which follows simulated Rekognition's
 `SimRekognitionDeclarationError`. The ARN would otherwise be a typo nothing reported.
 
+## Recorded events
+
+`event/` holds what the events API has been sent. `SimPersonalizeEventRecords` gathers three lists,
+one per operation, and the handlers under `command/events/` append to it. `SimPersonalize` reads
+them back through `recordedEvents()`, `recordedItems()` and `recordedUsers()`, following
+`sesV2().sentEmails()`.
+
+The record is the whole of the observable behaviour. Real Personalize writes the interaction into
+the Interactions dataset behind the tracker, and a training run reads it weeks later. Nothing here
+trains, and a declared campaign result stays what it was declared as.
+
+Properties arrive as either a JSON string or the object the caller passed the SDK, because
+interception reads the Command before the client serialises it. `readSimPersonalizeProperties`
+turns both into the string the wire would have carried.
+
 ## Deletion rules
 
 Real Personalize refuses to delete a resource other resources still depend on, and these do the
-same. A dataset group holding datasets or solutions, a schema a dataset still uses, and a solution a
-campaign still deploys are all reported as `ResourceInUseException`.
+same. A dataset group holding datasets, solutions or an event tracker, a schema a dataset still
+uses, and a solution a campaign still deploys are all reported as `ResourceInUseException`.
 
 Deleting a solution takes its versions with it. Real Personalize has no `DeleteSolutionVersion`
 either.
 
 ## What comes next
 
-The events API, CloudFormation resource types and domain recommenders are all separate issues. Each
-of them builds on what is here.
+CloudFormation resource types and domain recommenders are separate issues. Both build on what is
+here.

--- a/src/service/personalize/README.md
+++ b/src/service/personalize/README.md
@@ -23,7 +23,7 @@ use case a recipe names decides which parameters a recommendation request has to
   the runtime API, the rules declared against campaigns, and the accessors a test reads state back
   through.
 - `sim-personalize-control-plane.ts` and `sim-personalize-data-operations.ts` are the abstract
-  bases it extends, carrying the twenty-six control plane operations between them. The data
+  bases it extends, carrying the twenty-seven control plane operations between them. The data
   operations file holds dataset groups, schemas, datasets and event trackers along with the
   constructor, and the control plane file extends it with solutions, solution versions and
   campaigns. The split keeps `sim-personalize.ts` from being that list and nothing else, and it

--- a/src/service/personalize/command/event-tracker/event-tracker.command.ts
+++ b/src/service/personalize/command/event-tracker/event-tracker.command.ts
@@ -1,0 +1,109 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimPersonalizeTag } from "../dataset-group/dataset-group.command.js";
+
+/**
+ * Minimal structural sim Personalize CreateEventTracker command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/personalize/command/CreateEventTrackerCommand/
+ */
+export interface SimCreateEventTrackerCommand {
+  readonly input: SimCreateEventTrackerCommandInput;
+}
+
+export interface SimCreateEventTrackerCommandInput {
+  readonly name?: string | undefined;
+  readonly datasetGroupArn?: string | undefined;
+  readonly tags?: readonly SimPersonalizeTag[] | undefined;
+}
+
+export interface SimCreateEventTrackerCommandOutput {
+  readonly eventTrackerArn?: string | undefined;
+  readonly trackingId?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * An event tracker as Describe reports it.
+ */
+export interface SimPersonalizeEventTrackerDetail {
+  readonly name?: string | undefined;
+  readonly eventTrackerArn?: string | undefined;
+  readonly accountId?: string | undefined;
+  readonly trackingId?: string | undefined;
+  readonly datasetGroupArn?: string | undefined;
+  readonly status?: string | undefined;
+  readonly creationDateTime?: Date | undefined;
+  readonly lastUpdatedDateTime?: Date | undefined;
+}
+
+/**
+ * Minimal structural sim Personalize DescribeEventTracker command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/personalize/command/DescribeEventTrackerCommand/
+ */
+export interface SimDescribeEventTrackerCommand {
+  readonly input: SimDescribeEventTrackerCommandInput;
+}
+
+export interface SimDescribeEventTrackerCommandInput {
+  readonly eventTrackerArn?: string | undefined;
+}
+
+export interface SimDescribeEventTrackerCommandOutput {
+  readonly eventTracker?: SimPersonalizeEventTrackerDetail | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * An event tracker as List reports it.
+ *
+ * Real Personalize leaves the tracking ID out of the summary. Only Describe
+ * reports it.
+ */
+export interface SimPersonalizeEventTrackerSummary {
+  readonly name?: string | undefined;
+  readonly eventTrackerArn?: string | undefined;
+  readonly status?: string | undefined;
+  readonly creationDateTime?: Date | undefined;
+  readonly lastUpdatedDateTime?: Date | undefined;
+}
+
+/**
+ * Minimal structural sim Personalize ListEventTrackers command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/personalize/command/ListEventTrackersCommand/
+ */
+export interface SimListEventTrackersCommand {
+  readonly input?: SimListEventTrackersCommandInput | undefined;
+}
+
+export interface SimListEventTrackersCommandInput {
+  readonly datasetGroupArn?: string | undefined;
+  readonly nextToken?: string | undefined;
+  readonly maxResults?: number | undefined;
+}
+
+export interface SimListEventTrackersCommandOutput {
+  readonly eventTrackers?:
+    | readonly SimPersonalizeEventTrackerSummary[]
+    | undefined;
+  readonly nextToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Personalize DeleteEventTracker command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/personalize/command/DeleteEventTrackerCommand/
+ */
+export interface SimDeleteEventTrackerCommand {
+  readonly input: SimDeleteEventTrackerCommandInput;
+}
+
+export interface SimDeleteEventTrackerCommandInput {
+  readonly eventTrackerArn?: string | undefined;
+}
+
+export interface SimDeleteEventTrackerCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/personalize/command/event-tracker/sim-personalize-event-tracker-read-commands.ts
+++ b/src/service/personalize/command/event-tracker/sim-personalize-event-tracker-read-commands.ts
@@ -1,0 +1,63 @@
+import {
+  simPersonalizeEventTrackerDetail,
+  simPersonalizeEventTrackerSummary,
+} from "../../view/sim-personalize-event-tracker-view.js";
+import { simPersonalizePageOf } from "../list/sim-personalize-page.js";
+import { SimPersonalizeCommandGroup } from "../sim-personalize-command-group.js";
+import type { SimPersonalizeRequestOptions } from "../sim-personalize-request-options.js";
+import type {
+  SimDescribeEventTrackerCommand,
+  SimDescribeEventTrackerCommandOutput,
+  SimListEventTrackersCommand,
+  SimListEventTrackersCommandOutput,
+} from "./event-tracker.command.js";
+
+/**
+ * The simulated Personalize event tracker commands that only read.
+ */
+export class SimPersonalizeEventTrackerReadCommands extends SimPersonalizeCommandGroup {
+  /** Handle a DescribeEventTracker command. */
+  describe(
+    command: SimDescribeEventTrackerCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): SimDescribeEventTrackerCommandOutput {
+    const eventTracker = this.resolve(
+      this.resources.eventTrackers,
+      command.input.eventTrackerArn,
+      "personalize:DescribeEventTracker",
+      options,
+    );
+
+    return {
+      eventTracker: simPersonalizeEventTrackerDetail(
+        eventTracker,
+        this.accountRegionScope.accountId,
+      ),
+      $metadata: {},
+    };
+  }
+
+  /** Handle a ListEventTrackers command. */
+  list(
+    command: SimListEventTrackersCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): SimListEventTrackersCommandOutput {
+    this.authorizer.authorize("personalize:ListEventTrackers", options);
+
+    const datasetGroupArn = command.input?.datasetGroupArn;
+    const matching = this.resources.eventTrackers.all.filter(
+      (eventTracker) =>
+        datasetGroupArn === undefined ||
+        eventTracker.datasetGroupArn === datasetGroupArn,
+    );
+    const page = simPersonalizePageOf(matching, command.input);
+
+    return {
+      eventTrackers: page.items.map((eventTracker) =>
+        simPersonalizeEventTrackerSummary(eventTracker),
+      ),
+      nextToken: page.nextToken,
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/personalize/command/event-tracker/sim-personalize-event-tracker-write-commands.ts
+++ b/src/service/personalize/command/event-tracker/sim-personalize-event-tracker-write-commands.ts
@@ -1,0 +1,96 @@
+import { randomUUID } from "node:crypto";
+import { SimPersonalizeResourceAlreadyExistsException } from "../../error/sim-personalize.error.js";
+import { simPersonalizeEventTrackerArn } from "../../resource/sim-personalize-arn.js";
+import { SimPersonalizeEventTracker } from "../../resource/sim-personalize-event-tracker.js";
+import { requireSimPersonalizeName } from "../../resource/sim-personalize-name.js";
+import { simPersonalizeActiveStatus } from "../../resource/sim-personalize-status.js";
+import { SimPersonalizeCommandGroup } from "../sim-personalize-command-group.js";
+import type { SimPersonalizeRequestOptions } from "../sim-personalize-request-options.js";
+import type {
+  SimCreateEventTrackerCommand,
+  SimCreateEventTrackerCommandOutput,
+  SimDeleteEventTrackerCommand,
+  SimDeleteEventTrackerCommandOutput,
+} from "./event-tracker.command.js";
+
+/**
+ * The simulated Personalize event tracker commands that change state.
+ */
+export class SimPersonalizeEventTrackerWriteCommands extends SimPersonalizeCommandGroup {
+  /**
+   * Handle a CreateEventTracker command.
+   *
+   * Real Personalize allows one event tracker per dataset group and refuses a
+   * second against the same group.
+   */
+  create(
+    command: SimCreateEventTrackerCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): SimCreateEventTrackerCommandOutput {
+    this.authorizer.authorize("personalize:CreateEventTracker", options);
+
+    const { input } = command;
+    const name = requireSimPersonalizeName(input.name, "event tracker");
+    const datasetGroup = this.resources.datasetGroups.require(
+      input.datasetGroupArn,
+    );
+
+    this.resources.eventTrackers.requireNameAvailable(name);
+    this.requireDatasetGroupUntracked(datasetGroup.arn);
+
+    const eventTracker = new SimPersonalizeEventTracker({
+      arn: simPersonalizeEventTrackerArn(name, this.accountRegionScope),
+      name,
+      status: simPersonalizeActiveStatus,
+      creationDateTime: this.clock.now(),
+      datasetGroupArn: datasetGroup.arn,
+      // Real Personalize hands out an opaque id here, and so does this.
+      trackingId: randomUUID(),
+    });
+
+    this.resources.eventTrackers.add(eventTracker);
+
+    return {
+      eventTrackerArn: eventTracker.arn,
+      trackingId: eventTracker.trackingId,
+      $metadata: {},
+    };
+  }
+
+  /**
+   * Handle a DeleteEventTracker command.
+   *
+   * The events the tracker accepted stay recorded. Deleting a tracker on real
+   * Personalize leaves the interactions it wrote in the dataset behind it.
+   */
+  delete(
+    command: SimDeleteEventTrackerCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): SimDeleteEventTrackerCommandOutput {
+    this.resources.eventTrackers.remove(
+      this.resolve(
+        this.resources.eventTrackers,
+        command.input.eventTrackerArn,
+        "personalize:DeleteEventTracker",
+        options,
+      ),
+    );
+
+    return { $metadata: {} };
+  }
+
+  private requireDatasetGroupUntracked(datasetGroupArn: string): void {
+    const tracked = this.resources.eventTrackers.all.find(
+      (eventTracker) => eventTracker.datasetGroupArn === datasetGroupArn,
+    );
+
+    if (tracked === undefined) {
+      return;
+    }
+
+    throw new SimPersonalizeResourceAlreadyExistsException(
+      `The dataset group '${datasetGroupArn}' already has the event tracker ` +
+        `'${tracked.arn}'. Personalize allows one per dataset group.`,
+    );
+  }
+}

--- a/src/service/personalize/command/event-tracker/sim-personalize-event-tracker.iso.test.ts
+++ b/src/service/personalize/command/event-tracker/sim-personalize-event-tracker.iso.test.ts
@@ -9,10 +9,12 @@ import {
 import {
   assertArrayEquals,
   assertArrayLength,
+  assertFalse,
   assertIdentical,
   assertNonNullable,
   assertStringIncludes,
   assertThrowsErrorAsync,
+  assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
@@ -186,6 +188,46 @@ describe("Personalize ListEventTrackers", () => {
 
     // Then both come back.
     assertArrayLength(listed.eventTrackers ?? [], 2);
+  });
+
+  it("pages through the trackers and leaves the tracking ID out", async () => {
+    // Given three dataset groups with a tracker each.
+    const simAws = new SimAws();
+    await Promise.all(
+      ["catalogue", "storefront", "lessons"].map(async (name) => {
+        const datasetGroupArn = await givenADatasetGroup(simAws, name);
+
+        await simAws.personalize().createEventTracker(
+          new CreateEventTrackerCommand({
+            name: `${name}-events`,
+            datasetGroupArn,
+          }),
+        );
+      }),
+    );
+
+    // When they are listed two at a time.
+    const first = await simAws
+      .personalize()
+      .listEventTrackers(new ListEventTrackersCommand({ maxResults: 2 }));
+    const second = await simAws.personalize().listEventTrackers(
+      new ListEventTrackersCommand({
+        maxResults: 2,
+        nextToken: first.nextToken,
+      }),
+    );
+
+    // Then the two pages carry the three between them, and the second one ends
+    // the listing.
+    assertArrayLength(first.eventTrackers ?? [], 2);
+    assertArrayLength(second.eventTrackers ?? [], 1);
+    assertUndefined(second.nextToken);
+
+    // And a summary reports no tracking ID. Real Personalize reports one from
+    // Describe alone.
+    const [summary] = first.eventTrackers ?? [];
+    assertNonNullable(summary);
+    assertFalse("trackingId" in summary);
   });
 });
 

--- a/src/service/personalize/command/event-tracker/sim-personalize-event-tracker.iso.test.ts
+++ b/src/service/personalize/command/event-tracker/sim-personalize-event-tracker.iso.test.ts
@@ -1,0 +1,248 @@
+import {
+  CreateDatasetGroupCommand,
+  CreateEventTrackerCommand,
+  DeleteDatasetGroupCommand,
+  DeleteEventTrackerCommand,
+  DescribeEventTrackerCommand,
+  ListEventTrackersCommand,
+} from "@aws-sdk/client-personalize";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+
+const accountIdOneOnes = "111111111111";
+
+async function givenADatasetGroup(
+  simAws: SimAws,
+  name = "catalogue",
+): Promise<string> {
+  const group = await simAws
+    .personalize()
+    .createDatasetGroup(new CreateDatasetGroupCommand({ name }));
+
+  assertNonNullable(group.datasetGroupArn);
+
+  return group.datasetGroupArn;
+}
+
+describe("Personalize CreateEventTracker", () => {
+  it("reports a tracking ID and its own ARN back", async () => {
+    // Given a simulated AWS holding a dataset group.
+    const simAws = new SimAws({ defaultAccountId: accountIdOneOnes });
+    const datasetGroupArn = await givenADatasetGroup(simAws);
+
+    // When an event tracker is created against it.
+    const created = await simAws.personalize().createEventTracker(
+      new CreateEventTrackerCommand({
+        name: "catalogue-events",
+        datasetGroupArn,
+      }),
+    );
+
+    // Then it carries both handles, and the ARN names the tracker.
+    assertNonNullable(created.trackingId);
+    assertNonNullable(created.eventTrackerArn);
+    assertStringIncludes(
+      created.eventTrackerArn,
+      `arn:aws:personalize:us-east-1:${accountIdOneOnes}:event-tracker/` +
+        `catalogue-events`,
+    );
+  });
+
+  it("refuses a second tracker on the same dataset group", async () => {
+    // Given a dataset group that already has an event tracker.
+    const simAws = new SimAws();
+    const datasetGroupArn = await givenADatasetGroup(simAws);
+    await simAws
+      .personalize()
+      .createEventTracker(
+        new CreateEventTrackerCommand({ name: "first", datasetGroupArn }),
+      );
+
+    // When a second one is created against it.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws
+          .personalize()
+          .createEventTracker(
+            new CreateEventTrackerCommand({ name: "second", datasetGroupArn }),
+          ),
+    );
+
+    // Then Personalize refuses it. One dataset group takes one tracker.
+    assertIdentical(error.name, "ResourceAlreadyExistsException");
+  });
+
+  it("refuses a dataset group nothing holds", async () => {
+    // Given a simulated AWS with no dataset groups at all.
+    const simAws = new SimAws();
+
+    // When a tracker is created against an ARN naming nothing.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.personalize().createEventTracker(
+          new CreateEventTrackerCommand({
+            name: "catalogue-events",
+            datasetGroupArn:
+              "arn:aws:personalize:eu-west-2:000000000000:dataset-group/gone",
+          }),
+        ),
+    );
+
+    // Then the missing dataset group is what is reported.
+    assertIdentical(error.name, "ResourceNotFoundException");
+  });
+});
+
+describe("Personalize DescribeEventTracker", () => {
+  it("reports the dataset group, the tracking ID and the account", async () => {
+    // Given an event tracker on a dataset group.
+    const simAws = new SimAws({ defaultAccountId: accountIdOneOnes });
+    const datasetGroupArn = await givenADatasetGroup(simAws);
+    const created = await simAws.personalize().createEventTracker(
+      new CreateEventTrackerCommand({
+        name: "catalogue-events",
+        datasetGroupArn,
+      }),
+    );
+
+    // When it is described.
+    const described = await simAws.personalize().describeEventTracker(
+      new DescribeEventTrackerCommand({
+        eventTrackerArn: created.eventTrackerArn,
+      }),
+    );
+
+    // Then everything the create decided comes back.
+    assertNonNullable(described.eventTracker);
+    assertIdentical(described.eventTracker.name, "catalogue-events");
+    assertIdentical(described.eventTracker.datasetGroupArn, datasetGroupArn);
+    assertIdentical(described.eventTracker.trackingId, created.trackingId);
+    assertIdentical(described.eventTracker.accountId, accountIdOneOnes);
+    assertIdentical(described.eventTracker.status, "ACTIVE");
+  });
+});
+
+describe("Personalize ListEventTrackers", () => {
+  it("lists only the trackers of the dataset group named", async () => {
+    // Given two dataset groups with a tracker each.
+    const simAws = new SimAws();
+    const catalogue = await givenADatasetGroup(simAws, "catalogue");
+    const storefront = await givenADatasetGroup(simAws, "storefront");
+    await simAws.personalize().createEventTracker(
+      new CreateEventTrackerCommand({
+        name: "catalogue-events",
+        datasetGroupArn: catalogue,
+      }),
+    );
+    await simAws.personalize().createEventTracker(
+      new CreateEventTrackerCommand({
+        name: "storefront-events",
+        datasetGroupArn: storefront,
+      }),
+    );
+
+    // When one group's trackers are listed.
+    const listed = await simAws
+      .personalize()
+      .listEventTrackers(
+        new ListEventTrackersCommand({ datasetGroupArn: storefront }),
+      );
+
+    // Then the other group's tracker is left out.
+    assertArrayEquals(
+      (listed.eventTrackers ?? []).map((tracker) => tracker.name),
+      ["storefront-events"],
+    );
+  });
+
+  it("lists every tracker where no dataset group is named", async () => {
+    // Given trackers on two dataset groups.
+    const simAws = new SimAws();
+    await Promise.all(
+      ["catalogue", "storefront"].map(async (name) => {
+        const datasetGroupArn = await givenADatasetGroup(simAws, name);
+
+        await simAws.personalize().createEventTracker(
+          new CreateEventTrackerCommand({
+            name: `${name}-events`,
+            datasetGroupArn,
+          }),
+        );
+      }),
+    );
+
+    // When they are listed without a filter.
+    const listed = await simAws
+      .personalize()
+      .listEventTrackers(new ListEventTrackersCommand({}));
+
+    // Then both come back.
+    assertArrayLength(listed.eventTrackers ?? [], 2);
+  });
+});
+
+describe("Personalize DeleteEventTracker", () => {
+  it("leaves the tracker unfindable afterwards", async () => {
+    // Given an event tracker.
+    const simAws = new SimAws();
+    const datasetGroupArn = await givenADatasetGroup(simAws);
+    const created = await simAws.personalize().createEventTracker(
+      new CreateEventTrackerCommand({
+        name: "catalogue-events",
+        datasetGroupArn,
+      }),
+    );
+
+    // When it is deleted.
+    await simAws.personalize().deleteEventTracker(
+      new DeleteEventTrackerCommand({
+        eventTrackerArn: created.eventTrackerArn,
+      }),
+    );
+
+    // Then describing it reports it missing.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.personalize().describeEventTracker(
+          new DescribeEventTrackerCommand({
+            eventTrackerArn: created.eventTrackerArn,
+          }),
+        ),
+    );
+    assertIdentical(error.name, "ResourceNotFoundException");
+  });
+
+  it("has to happen before the dataset group can be deleted", async () => {
+    // Given a dataset group with an event tracker on it.
+    const simAws = new SimAws();
+    const datasetGroupArn = await givenADatasetGroup(simAws);
+    await simAws.personalize().createEventTracker(
+      new CreateEventTrackerCommand({
+        name: "catalogue-events",
+        datasetGroupArn,
+      }),
+    );
+
+    // When the dataset group is deleted first.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws
+          .personalize()
+          .deleteDatasetGroup(
+            new DeleteDatasetGroupCommand({ datasetGroupArn }),
+          ),
+    );
+
+    // Then Personalize reports the group as in use.
+    assertIdentical(error.name, "ResourceInUseException");
+    assertStringIncludes(error.message, "event tracker(s) on it");
+  });
+});

--- a/src/service/personalize/command/events/events.command.ts
+++ b/src/service/personalize/command/events/events.command.ts
@@ -1,0 +1,98 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * The metadata an event, an item or a user carries.
+ *
+ * Real Personalize takes a JSON string here. The SDK serialises an object into
+ * one before the request leaves the client, so an intercepted Command can
+ * arrive carrying either, and both are accepted.
+ */
+export type SimPersonalizeProperties =
+  | string
+  | Readonly<Record<string, unknown>>;
+
+/**
+ * One item interaction within a PutEvents request.
+ */
+export interface SimPersonalizeEventInput {
+  readonly eventId?: string | undefined;
+  readonly eventType?: string | undefined;
+  readonly eventValue?: number | undefined;
+  readonly itemId?: string | undefined;
+  readonly properties?: SimPersonalizeProperties | undefined;
+  readonly sentAt?: Date | undefined;
+  readonly recommendationId?: string | undefined;
+  readonly impression?: readonly string[] | undefined;
+}
+
+/**
+ * Minimal structural sim Personalize Events PutEvents command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/personalize-events/command/PutEventsCommand/
+ */
+export interface SimPutEventsCommand {
+  readonly input: SimPutEventsCommandInput;
+}
+
+export interface SimPutEventsCommandInput {
+  readonly trackingId?: string | undefined;
+  readonly userId?: string | undefined;
+  readonly sessionId?: string | undefined;
+  readonly eventList?: readonly SimPersonalizeEventInput[] | undefined;
+}
+
+export interface SimPutEventsCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * One item within a PutItems request.
+ */
+export interface SimPersonalizeItemInput {
+  readonly itemId?: string | undefined;
+  readonly properties?: SimPersonalizeProperties | undefined;
+}
+
+/**
+ * Minimal structural sim Personalize Events PutItems command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/personalize-events/command/PutItemsCommand/
+ */
+export interface SimPutItemsCommand {
+  readonly input: SimPutItemsCommandInput;
+}
+
+export interface SimPutItemsCommandInput {
+  readonly datasetArn?: string | undefined;
+  readonly items?: readonly SimPersonalizeItemInput[] | undefined;
+}
+
+export interface SimPutItemsCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * One user within a PutUsers request.
+ */
+export interface SimPersonalizeUserInput {
+  readonly userId?: string | undefined;
+  readonly properties?: SimPersonalizeProperties | undefined;
+}
+
+/**
+ * Minimal structural sim Personalize Events PutUsers command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/personalize-events/command/PutUsersCommand/
+ */
+export interface SimPutUsersCommand {
+  readonly input: SimPutUsersCommandInput;
+}
+
+export interface SimPutUsersCommandInput {
+  readonly datasetArn?: string | undefined;
+  readonly users?: readonly SimPersonalizeUserInput[] | undefined;
+}
+
+export interface SimPutUsersCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/personalize/command/events/sim-personalize-event-command-group.ts
+++ b/src/service/personalize/command/events/sim-personalize-event-command-group.ts
@@ -1,0 +1,92 @@
+import type { SimPersonalizeEventRecords } from "../../event/sim-personalize-event-records.js";
+import {
+  SimPersonalizeInvalidInputException,
+  SimPersonalizeResourceNotFoundException,
+} from "../../error/sim-personalize.error.js";
+import type { SimPersonalizeDataset } from "../../resource/sim-personalize-dataset.js";
+import type { SimPersonalizeDatasetType } from "../../resource/sim-personalize-dataset-type.js";
+import type { SimPersonalizeEventTracker } from "../../resource/sim-personalize-event-tracker.js";
+import {
+  SimPersonalizeCommandGroup,
+  type SimPersonalizeCommandGroupProperties,
+} from "../sim-personalize-command-group.js";
+import type { SimPersonalizeRequestOptions } from "../sim-personalize-request-options.js";
+
+export interface SimPersonalizeEventCommandGroupProperties extends SimPersonalizeCommandGroupProperties {
+  readonly records: SimPersonalizeEventRecords;
+}
+
+/**
+ * What the three simulated Personalize Events handlers are built over.
+ *
+ * All three record what they are sent, and two of them address a dataset of a
+ * particular type, so the records and that lookup live here.
+ */
+export abstract class SimPersonalizeEventCommandGroup extends SimPersonalizeCommandGroup {
+  protected readonly records: SimPersonalizeEventRecords;
+
+  constructor(properties: SimPersonalizeEventCommandGroupProperties) {
+    super(properties);
+    this.records = properties.records;
+  }
+
+  /**
+   * Read the event tracker a tracking ID names, authorizing against it first.
+   *
+   * The request carries an ID rather than an ARN, so the tracker has to be
+   * found before the caller can be authorized against it. Authorization still
+   * comes first in what the caller learns. An ID no tracker holds authorizes
+   * against `*`, and a caller a policy allows nothing on is told it has no
+   * permission rather than told the tracker is missing.
+   */
+  protected eventTracker(
+    trackingId: string,
+    action: string,
+    options: SimPersonalizeRequestOptions | undefined,
+  ): SimPersonalizeEventTracker {
+    const found = this.resources.eventTrackers.all.find(
+      (eventTracker) => eventTracker.trackingId === trackingId,
+    );
+
+    this.authorizer.authorize(action, options, found?.arn);
+
+    if (found === undefined) {
+      throw new SimPersonalizeResourceNotFoundException(
+        `Personalize can't find an event tracker with the tracking ID ` +
+          `'${trackingId}'`,
+      );
+    }
+
+    return found;
+  }
+
+  /**
+   * Read the dataset a request names, refusing one of the wrong type.
+   *
+   * `PutItems` addresses an Items dataset and `PutUsers` a Users dataset. An
+   * ARN naming the Interactions dataset of the same group is the mistake worth
+   * catching, and it would otherwise record metadata nothing would ever read.
+   */
+  protected datasetOfType(
+    datasetArn: string | undefined,
+    datasetType: SimPersonalizeDatasetType,
+    action: string,
+    options: SimPersonalizeRequestOptions | undefined,
+  ): SimPersonalizeDataset {
+    const dataset = this.resolve(
+      this.resources.datasets,
+      datasetArn,
+      action,
+      options,
+    );
+
+    if (dataset.datasetType !== datasetType) {
+      throw new SimPersonalizeInvalidInputException(
+        `'${dataset.arn}' is a ${dataset.datasetType} dataset. ` +
+          `${action.replace("personalize:", "")} needs a ${datasetType} one.`,
+      );
+    }
+
+    return dataset;
+  }
+}

--- a/src/service/personalize/command/events/sim-personalize-event-input.ts
+++ b/src/service/personalize/command/events/sim-personalize-event-input.ts
@@ -1,0 +1,71 @@
+import { SimPersonalizeInvalidInputException } from "../../error/sim-personalize.error.js";
+import type { SimPersonalizeProperties } from "./events.command.js";
+
+/**
+ * The most records real Personalize accepts in one PutEvents, PutItems or
+ * PutUsers request.
+ */
+const maximumBatchSize = 10;
+
+/**
+ * Read the records of one request, refusing a batch real Personalize would
+ * refuse.
+ *
+ * The limit is worth keeping. Code that batches without counting works in a
+ * test and fails on AWS at the eleventh record.
+ */
+export function requireSimPersonalizeBatch<T>(
+  records: readonly T[] | undefined,
+  fieldName: string,
+): readonly T[] {
+  if (records === undefined || records.length === 0) {
+    throw new SimPersonalizeInvalidInputException(
+      `A ${fieldName} of at least one record is required`,
+    );
+  }
+
+  if (records.length > maximumBatchSize) {
+    throw new SimPersonalizeInvalidInputException(
+      `${fieldName} carries ${records.length} records. Personalize accepts ` +
+        `up to ${maximumBatchSize} in one request.`,
+    );
+  }
+
+  return records;
+}
+
+/**
+ * Read a required field of a record, naming it in the refusal.
+ */
+export function requireSimPersonalizeField(
+  value: string | undefined,
+  fieldName: string,
+): string {
+  if (value === undefined || value === "") {
+    throw new SimPersonalizeInvalidInputException(`A ${fieldName} is required`);
+  }
+
+  return value;
+}
+
+/**
+ * Read the metadata of an event, an item or a user as the JSON string the wire
+ * would have carried.
+ *
+ * The SDK turns an object into a JSON string on its way out. An intercepted
+ * Command is read before that happens, so the object arrives whole and is
+ * serialised here.
+ */
+export function readSimPersonalizeProperties(
+  properties: SimPersonalizeProperties | undefined,
+): string | undefined {
+  if (properties === undefined) {
+    return undefined;
+  }
+
+  if (typeof properties === "string") {
+    return properties;
+  }
+
+  return JSON.stringify(properties);
+}

--- a/src/service/personalize/command/events/sim-personalize-events-iam.iso.test.ts
+++ b/src/service/personalize/command/events/sim-personalize-events-iam.iso.test.ts
@@ -1,0 +1,166 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateDatasetGroupCommand,
+  CreateEventTrackerCommand,
+} from "@aws-sdk/client-personalize";
+import { PutEventsCommand } from "@aws-sdk/client-personalize-events";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
+
+const accountIdOneOnes = "111111111111";
+
+interface EventTracker {
+  readonly arn: string;
+  readonly trackingId: string;
+}
+
+/**
+ * An event tracker to send interactions to.
+ */
+async function givenAnEventTracker(simAws: SimAws): Promise<EventTracker> {
+  const group = await simAws
+    .personalize()
+    .createDatasetGroup(new CreateDatasetGroupCommand({ name: "catalogue" }));
+  const tracker = await simAws.personalize().createEventTracker(
+    new CreateEventTrackerCommand({
+      name: "catalogue-events",
+      datasetGroupArn: group.datasetGroupArn,
+    }),
+  );
+
+  assertNonNullable(tracker.eventTrackerArn);
+  assertNonNullable(tracker.trackingId);
+
+  return { arn: tracker.eventTrackerArn, trackingId: tracker.trackingId };
+}
+
+/**
+ * A Role whose policy allows one action on one resource.
+ */
+async function givenARoleAllowedTo(
+  simAws: SimAws,
+  action: string,
+  resource = "*",
+): Promise<string> {
+  const role = await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "PersonalizeEventsCaller",
+      AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: {
+          Principal: { AWS: `arn:aws:iam::${accountIdOneOnes}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "PersonalizeEventsCaller",
+      PolicyName: "PersonalizeEventsPolicy",
+      PolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: { Action: action, Resource: resource },
+      }),
+    }),
+  );
+
+  assertNonNullable(role.Role.Arn);
+
+  return role.Role.Arn;
+}
+
+describe("Personalize Events IAM authorization", () => {
+  it("allows a PutEvents the caller's policy permits on the tracker", async () => {
+    // Given a Role allowed to send events to one event tracker.
+    const simAws = new SimAws({ defaultAccountId: accountIdOneOnes });
+    const tracker = await givenAnEventTracker(simAws);
+    const roleArn = await givenARoleAllowedTo(
+      simAws,
+      "personalize:PutEvents",
+      tracker.arn,
+    );
+
+    // When it sends an interaction.
+    await simAws.personalizeEvents().putEvents(
+      new PutEventsCommand({
+        trackingId: tracker.trackingId,
+        sessionId: "session-1",
+        eventList: [
+          { eventType: "view", itemId: "entry-1042", sentAt: new Date() },
+        ],
+      }),
+      { caller: { kind: "arn", arn: roleArn } },
+    );
+
+    // Then the interaction is recorded.
+    assertArrayLength(simAws.personalize().recordedEvents(), 1);
+  });
+
+  it("denies a PutEvents against a tracker the policy leaves out", async () => {
+    // Given a Role allowed to send events to some other tracker.
+    const simAws = new SimAws({ defaultAccountId: accountIdOneOnes });
+    const tracker = await givenAnEventTracker(simAws);
+    const roleArn = await givenARoleAllowedTo(
+      simAws,
+      "personalize:PutEvents",
+      `arn:aws:personalize:us-east-1:${accountIdOneOnes}:event-tracker/other`,
+    );
+
+    // When it sends an interaction to this one.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.personalizeEvents().putEvents(
+          new PutEventsCommand({
+            trackingId: tracker.trackingId,
+            sessionId: "session-1",
+            eventList: [
+              { eventType: "view", itemId: "entry-1042", sentAt: new Date() },
+            ],
+          }),
+          { caller: { kind: "arn", arn: roleArn } },
+        ),
+    );
+
+    // Then Personalize reports it in its own terms, and records nothing.
+    assertIdentical(error.name, "AccessDeniedException");
+    assertStringIncludes(error.message, "personalize:PutEvents");
+    assertArrayLength(simAws.personalize().recordedEvents(), 0);
+  });
+
+  it("tells a denied caller nothing about a tracking ID nothing holds", async () => {
+    // Given a Role allowed to send events to one event tracker only.
+    const simAws = new SimAws({ defaultAccountId: accountIdOneOnes });
+    const tracker = await givenAnEventTracker(simAws);
+    const roleArn = await givenARoleAllowedTo(
+      simAws,
+      "personalize:PutEvents",
+      tracker.arn,
+    );
+
+    // When it sends an interaction to a tracking ID nothing holds.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.personalizeEvents().putEvents(
+          new PutEventsCommand({
+            trackingId: "0e5c47d8-0000-0000-0000-000000000000",
+            sessionId: "session-1",
+            eventList: [
+              { eventType: "view", itemId: "entry-1042", sentAt: new Date() },
+            ],
+          }),
+          { caller: { kind: "arn", arn: roleArn } },
+        ),
+    );
+
+    // Then it learns it has no permission. Whether the tracker exists stays
+    // hidden, as it does on every other Personalize operation.
+    assertIdentical(error.name, "AccessDeniedException");
+  });
+});

--- a/src/service/personalize/command/events/sim-personalize-put-events.iso.test.ts
+++ b/src/service/personalize/command/events/sim-personalize-put-events.iso.test.ts
@@ -182,6 +182,35 @@ describe("Personalize PutEvents", () => {
     assertIdentical(event.sessionId, "session-1");
   });
 
+  it("keeps what it recorded when the caller reuses the values it sent", async () => {
+    // Given a request built from a Date and an impression list the caller
+    // holds on to.
+    const simAws = new SimAws();
+    const trackingId = await givenAnEventTracker(simAws);
+    const sentAt = new Date("2026-03-04T10:00:00.000Z");
+    const impression = ["entry-1042", "entry-2071"];
+
+    await simAws.personalizeEvents().putEvents(
+      new PutEventsCommand({
+        trackingId,
+        sessionId: "session-1",
+        eventList: [
+          { eventType: "view", itemId: "entry-1042", sentAt, impression },
+        ],
+      }),
+    );
+
+    // When the caller reuses both of them for the next interaction.
+    sentAt.setFullYear(2030);
+    impression.push("entry-3388");
+
+    // Then the recorded interaction still reads as it was sent.
+    const [event] = simAws.personalize().recordedEvents();
+    assertNonNullable(event);
+    assertIdentical(event.sentAt.toISOString(), "2026-03-04T10:00:00.000Z");
+    assertArrayEquals(event.impression ?? [], ["entry-1042", "entry-2071"]);
+  });
+
   it("refuses a tracking ID no tracker holds", async () => {
     // Given an event tracker, and a tracking ID that is not its own.
     const simAws = new SimAws();

--- a/src/service/personalize/command/events/sim-personalize-put-events.iso.test.ts
+++ b/src/service/personalize/command/events/sim-personalize-put-events.iso.test.ts
@@ -1,0 +1,297 @@
+import {
+  CreateDatasetGroupCommand,
+  CreateEventTrackerCommand,
+} from "@aws-sdk/client-personalize";
+import { PutEventsCommand } from "@aws-sdk/client-personalize-events";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+
+async function givenAnEventTracker(simAws: SimAws): Promise<string> {
+  const group = await simAws
+    .personalize()
+    .createDatasetGroup(new CreateDatasetGroupCommand({ name: "catalogue" }));
+  const tracker = await simAws.personalize().createEventTracker(
+    new CreateEventTrackerCommand({
+      name: "catalogue-events",
+      datasetGroupArn: group.datasetGroupArn,
+    }),
+  );
+
+  assertNonNullable(tracker.trackingId);
+
+  return tracker.trackingId;
+}
+
+describe("Personalize PutEvents", () => {
+  it("records what the request carried", async () => {
+    // Given an event tracker on a dataset group.
+    const simAws = new SimAws();
+    const trackingId = await givenAnEventTracker(simAws);
+
+    // When a visitor views an entry.
+    await simAws.personalizeEvents().putEvents(
+      new PutEventsCommand({
+        trackingId,
+        userId: "visitor-7",
+        sessionId: "session-1",
+        eventList: [
+          {
+            eventType: "view",
+            itemId: "entry-1042",
+            sentAt: new Date("2026-03-04T10:00:00.000Z"),
+          },
+        ],
+      }),
+    );
+
+    // Then the interaction is there with the user, the item and the tracker.
+    const [event] = simAws.personalize().recordedEvents();
+    assertNonNullable(event);
+    assertIdentical(event.eventType, "view");
+    assertIdentical(event.itemId, "entry-1042");
+    assertIdentical(event.userId, "visitor-7");
+    assertIdentical(event.sessionId, "session-1");
+    assertIdentical(event.trackingId, trackingId);
+    assertIdentical(event.sentAt.toISOString(), "2026-03-04T10:00:00.000Z");
+  });
+
+  it("records the properties an event carries as a JSON string", async () => {
+    // Given an event tracker.
+    const simAws = new SimAws();
+    const trackingId = await givenAnEventTracker(simAws);
+
+    // When an event carries data of its own.
+    await simAws.personalizeEvents().putEvents(
+      new PutEventsCommand({
+        trackingId,
+        sessionId: "session-1",
+        eventList: [
+          {
+            eventType: "rate",
+            itemId: "entry-1042",
+            eventValue: 4,
+            properties: { numberOfRatings: 12 },
+            sentAt: new Date(),
+          },
+        ],
+      }),
+    );
+
+    // Then the properties are held as the string the wire would carry.
+    const [event] = simAws.personalize().recordedEvents();
+    assertNonNullable(event);
+    assertIdentical(event.properties, '{"numberOfRatings":12}');
+    assertIdentical(event.eventValue, 4);
+  });
+
+  it("stamps an event with the simulated clock where it omits sentAt", async () => {
+    // Given a simulated AWS with time standing still.
+    const simAws = new SimAws();
+    const trackingId = await givenAnEventTracker(simAws);
+    simAws.clock().freeze();
+    await simAws.clock().setTo(new Date("2026-03-04T10:00:00.000Z"));
+
+    // When an event arrives, time moves on, and a second one arrives.
+    await simAws.personalizeEvents().putEvents(
+      new PutEventsCommand({
+        trackingId,
+        sessionId: "session-1",
+        eventList: [
+          { eventType: "view", itemId: "entry-1", sentAt: undefined },
+        ],
+      }),
+    );
+    await simAws.clock().advanceBy({ minutes: 20 });
+    await simAws.personalizeEvents().putEvents(
+      new PutEventsCommand({
+        trackingId,
+        sessionId: "session-1",
+        eventList: [
+          { eventType: "view", itemId: "entry-2", sentAt: undefined },
+        ],
+      }),
+    );
+
+    // Then each one records the instant it arrived at.
+    assertArrayEquals(
+      simAws
+        .personalize()
+        .recordedEvents()
+        .map((event) => event.sentAt.toISOString()),
+      ["2026-03-04T10:00:00.000Z", "2026-03-04T10:20:00.000Z"],
+    );
+  });
+
+  it("records a batch in the order the request listed it", async () => {
+    // Given an event tracker.
+    const simAws = new SimAws();
+    const trackingId = await givenAnEventTracker(simAws);
+
+    // When one request carries a session's worth of interactions.
+    await simAws.personalizeEvents().putEvents(
+      new PutEventsCommand({
+        trackingId,
+        sessionId: "session-1",
+        eventList: [
+          { eventType: "view", itemId: "entry-1", sentAt: new Date() },
+          { eventType: "view", itemId: "entry-2", sentAt: new Date() },
+          { eventType: "purchase", itemId: "entry-2", sentAt: new Date() },
+        ],
+      }),
+    );
+
+    // Then they are recorded in that order.
+    assertArrayEquals(
+      simAws
+        .personalize()
+        .recordedEvents()
+        .map((event) => `${event.eventType}:${event.itemId ?? ""}`),
+      ["view:entry-1", "view:entry-2", "purchase:entry-2"],
+    );
+  });
+
+  it("records an anonymous session with no user", async () => {
+    // Given an event tracker.
+    const simAws = new SimAws();
+    const trackingId = await givenAnEventTracker(simAws);
+
+    // When a visitor who has not signed in views an entry.
+    await simAws.personalizeEvents().putEvents(
+      new PutEventsCommand({
+        trackingId,
+        sessionId: "session-1",
+        eventList: [
+          { eventType: "view", itemId: "entry-1042", sentAt: new Date() },
+        ],
+      }),
+    );
+
+    // Then the interaction is recorded against the session alone.
+    const [event] = simAws.personalize().recordedEvents();
+    assertNonNullable(event);
+    assertUndefined(event.userId);
+    assertIdentical(event.sessionId, "session-1");
+  });
+
+  it("refuses a tracking ID no tracker holds", async () => {
+    // Given an event tracker, and a tracking ID that is not its own.
+    const simAws = new SimAws();
+    await givenAnEventTracker(simAws);
+
+    // When an event names the wrong tracking ID.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.personalizeEvents().putEvents(
+          new PutEventsCommand({
+            trackingId: "0e5c47d8-0000-0000-0000-000000000000",
+            sessionId: "session-1",
+            eventList: [
+              { eventType: "view", itemId: "entry-1042", sentAt: new Date() },
+            ],
+          }),
+        ),
+    );
+
+    // Then Personalize reports the tracker as missing, and records nothing.
+    assertIdentical(error.name, "ResourceNotFoundException");
+    assertArrayLength(simAws.personalize().recordedEvents(), 0);
+  });
+
+  it("refuses more events than one request may carry", async () => {
+    // Given an event tracker.
+    const simAws = new SimAws();
+    const trackingId = await givenAnEventTracker(simAws);
+
+    // When a request batches eleven interactions.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.personalizeEvents().putEvents(
+          new PutEventsCommand({
+            trackingId,
+            sessionId: "session-1",
+            eventList: Array.from({ length: 11 }, (_, index) => ({
+              eventType: "view",
+              itemId: `entry-${String(index)}`,
+              sentAt: new Date(),
+            })),
+          }),
+        ),
+    );
+
+    // Then it is refused, as real Personalize refuses it at ten.
+    assertIdentical(error.name, "InvalidInputException");
+    assertStringIncludes(error.message, "up to 10");
+  });
+
+  it("refuses a metric attribution it has nothing to attribute to", async () => {
+    // Given an event tracker.
+    const simAws = new SimAws();
+    const trackingId = await givenAnEventTracker(simAws);
+
+    // When an event names a metric attribution source.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.personalizeEvents().putEvents(
+          new PutEventsCommand({
+            trackingId,
+            sessionId: "session-1",
+            eventList: [
+              {
+                eventType: "view",
+                itemId: "entry-1042",
+                sentAt: new Date(),
+                metricAttribution: { eventAttributionSource: "storefront" },
+              },
+            ],
+          }),
+        ),
+    );
+
+    // Then it is refused by name rather than dropped.
+    assertIdentical(error.name, "InvalidInputException");
+    assertStringIncludes(error.message, "metricAttribution is not simulated");
+  });
+
+  it("requires a session and an event type", async () => {
+    // Given an event tracker.
+    const simAws = new SimAws();
+    const trackingId = await givenAnEventTracker(simAws);
+
+    // When a request leaves the session out.
+    const sessionless = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.personalizeEvents().putEvents(
+          new PutEventsCommand({
+            trackingId,
+            sessionId: undefined,
+            eventList: [{ eventType: "view", sentAt: new Date() }],
+          }),
+        ),
+    );
+
+    // And when an event leaves its type out.
+    const typeless = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.personalizeEvents().putEvents(
+          new PutEventsCommand({
+            trackingId,
+            sessionId: "session-1",
+            eventList: [{ eventType: undefined, sentAt: new Date() }],
+          }),
+        ),
+    );
+
+    // Then both are refused as invalid input.
+    assertIdentical(sessionless.name, "InvalidInputException");
+    assertIdentical(typeless.name, "InvalidInputException");
+  });
+});

--- a/src/service/personalize/command/events/sim-personalize-put-events.ts
+++ b/src/service/personalize/command/events/sim-personalize-put-events.ts
@@ -1,0 +1,109 @@
+import { SimPersonalizeRecordedEvent } from "../../event/sim-personalize-recorded-event.js";
+import { SimPersonalizeUnsimulatedInput } from "../sim-personalize-unsimulated-input.js";
+import type { SimPersonalizeRequestOptions } from "../sim-personalize-request-options.js";
+import type {
+  SimPersonalizeEventInput,
+  SimPutEventsCommand,
+  SimPutEventsCommandOutput,
+} from "./events.command.js";
+import { SimPersonalizeEventCommandGroup } from "./sim-personalize-event-command-group.js";
+import {
+  readSimPersonalizeProperties,
+  requireSimPersonalizeBatch,
+  requireSimPersonalizeField,
+} from "./sim-personalize-event-input.js";
+
+const action = "personalize:PutEvents";
+
+const accepted = ["trackingId", "userId", "sessionId", "eventList"];
+
+/**
+ * Everything an event carries that simulated Personalize records.
+ *
+ * `metricAttribution` is left out. It ties an event to a metric attribution
+ * report, and simulated Personalize has no `CreateMetricAttribution` and no
+ * reports to tie it to.
+ */
+const acceptedEvent = [
+  "eventId",
+  "eventType",
+  "eventValue",
+  "itemId",
+  "properties",
+  "sentAt",
+  "recommendationId",
+  "impression",
+];
+
+const unsimulated = new SimPersonalizeUnsimulatedInput("PutEvents");
+
+/**
+ * Handles a PutEvents command.
+ *
+ * Real Personalize appends the interactions to the Interactions dataset behind
+ * the tracker, and a later training run reads them. Simulated Personalize
+ * records them and reads them back through `personalize().recordedEvents()`.
+ * No recommendation moves as a result.
+ */
+export class SimPersonalizePutEventsHandler extends SimPersonalizeEventCommandGroup {
+  /**
+   * Record the interactions a request carries.
+   */
+  handle(
+    command: SimPutEventsCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): SimPutEventsCommandOutput {
+    const { input } = command;
+
+    unsimulated.refuseUnaccepted(input, accepted);
+
+    const trackingId = requireSimPersonalizeField(
+      input.trackingId,
+      "trackingId",
+    );
+    const sessionId = requireSimPersonalizeField(input.sessionId, "sessionId");
+    const eventTracker = this.eventTracker(trackingId, action, options);
+    const eventList = requireSimPersonalizeBatch(input.eventList, "eventList");
+
+    this.records.addEvents(
+      eventList.map((event) =>
+        this.recorded(event, {
+          trackingId,
+          eventTrackerArn: eventTracker.arn,
+          sessionId,
+          userId: input.userId,
+        }),
+      ),
+    );
+
+    return { $metadata: {} };
+  }
+
+  private recorded(
+    event: SimPersonalizeEventInput,
+    session: {
+      readonly trackingId: string;
+      readonly eventTrackerArn: string;
+      readonly sessionId: string;
+      readonly userId: string | undefined;
+    },
+  ): SimPersonalizeRecordedEvent {
+    unsimulated.refuseUnaccepted(event, acceptedEvent);
+
+    return new SimPersonalizeRecordedEvent({
+      ...session,
+      eventId: event.eventId,
+      eventType: requireSimPersonalizeField(event.eventType, "eventType"),
+      eventValue: event.eventValue,
+      itemId: event.itemId,
+      properties: readSimPersonalizeProperties(event.properties),
+      // Real Personalize requires the client to timestamp every event. A
+      // request that leaves it out is stamped from the simulated clock, so a
+      // test asserting on when an interaction happened controls it the same
+      // way it controls every other simulated timestamp.
+      sentAt: event.sentAt ?? this.clock.now(),
+      recommendationId: event.recommendationId,
+      impression: event.impression,
+    });
+  }
+}

--- a/src/service/personalize/command/events/sim-personalize-put-items-users.iso.test.ts
+++ b/src/service/personalize/command/events/sim-personalize-put-items-users.iso.test.ts
@@ -1,0 +1,216 @@
+import {
+  CreateDatasetCommand,
+  CreateDatasetGroupCommand,
+  CreateSchemaCommand,
+} from "@aws-sdk/client-personalize";
+import {
+  PutItemsCommand,
+  PutUsersCommand,
+} from "@aws-sdk/client-personalize-events";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+
+interface Datasets {
+  readonly items: string;
+  readonly users: string;
+  readonly interactions: string;
+}
+
+async function givenTheThreeDatasets(simAws: SimAws): Promise<Datasets> {
+  const group = await simAws
+    .personalize()
+    .createDatasetGroup(new CreateDatasetGroupCommand({ name: "catalogue" }));
+  const schema = await simAws.personalize().createSchema(
+    new CreateSchemaCommand({
+      name: "catalogue-schema",
+      schema: JSON.stringify({ type: "record", name: "Items", fields: [] }),
+    }),
+  );
+
+  const created = await Promise.all(
+    ["ITEMS", "USERS", "INTERACTIONS"].map(
+      async (datasetType) =>
+        await simAws.personalize().createDataset(
+          new CreateDatasetCommand({
+            name: datasetType.toLowerCase(),
+            datasetGroupArn: group.datasetGroupArn,
+            schemaArn: schema.schemaArn,
+            datasetType,
+          }),
+        ),
+    ),
+  );
+  const [items, users, interactions] = created.map(
+    (dataset) => dataset.datasetArn,
+  );
+
+  assertNonNullable(items);
+  assertNonNullable(users);
+  assertNonNullable(interactions);
+
+  return { items, users, interactions };
+}
+
+describe("Personalize PutItems", () => {
+  it("records the items a catalogue update carries", async () => {
+    // Given an Items dataset.
+    const simAws = new SimAws();
+    const datasets = await givenTheThreeDatasets(simAws);
+
+    // When two items are added to it.
+    await simAws.personalizeEvents().putItems(
+      new PutItemsCommand({
+        datasetArn: datasets.items,
+        items: [
+          { itemId: "entry-1042", properties: { category: "Horror|Action" } },
+          { itemId: "entry-2071" },
+        ],
+      }),
+    );
+
+    // Then both are recorded in the order the request listed them.
+    const recorded = simAws.personalize().recordedItems();
+    assertArrayEquals(
+      recorded.map((item) => item.itemId),
+      ["entry-1042", "entry-2071"],
+    );
+    const [first] = recorded;
+    assertNonNullable(first);
+    assertIdentical(first.properties, '{"category":"Horror|Action"}');
+    assertIdentical(first.datasetArn, datasets.items);
+  });
+
+  it("refuses a dataset of the wrong type", async () => {
+    // Given the Interactions dataset of the same group.
+    const simAws = new SimAws();
+    const datasets = await givenTheThreeDatasets(simAws);
+
+    // When items are added to it by mistake.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.personalizeEvents().putItems(
+          new PutItemsCommand({
+            datasetArn: datasets.interactions,
+            items: [{ itemId: "entry-1042" }],
+          }),
+        ),
+    );
+
+    // Then Personalize refuses it rather than recording metadata nothing
+    // would read.
+    assertIdentical(error.name, "InvalidInputException");
+    assertStringIncludes(error.message, "is a INTERACTIONS dataset");
+  });
+
+  it("refuses a dataset ARN nothing holds", async () => {
+    // Given a simulated AWS with no datasets at all.
+    const simAws = new SimAws();
+
+    // When items are added to an ARN naming nothing.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.personalizeEvents().putItems(
+          new PutItemsCommand({
+            datasetArn:
+              "arn:aws:personalize:us-east-1:000000000000:dataset/gone/ITEMS",
+            items: [{ itemId: "entry-1042" }],
+          }),
+        ),
+    );
+
+    // Then the missing dataset is what is reported.
+    assertIdentical(error.name, "ResourceNotFoundException");
+  });
+
+  it("requires an item id on every item", async () => {
+    // Given an Items dataset.
+    const simAws = new SimAws();
+    const datasets = await givenTheThreeDatasets(simAws);
+
+    // When an item arrives without one.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.personalizeEvents().putItems(
+          new PutItemsCommand({
+            datasetArn: datasets.items,
+            items: [{ itemId: undefined }],
+          }),
+        ),
+    );
+
+    // Then it is refused as invalid input.
+    assertIdentical(error.name, "InvalidInputException");
+  });
+});
+
+describe("Personalize PutUsers", () => {
+  it("records the users a request carries", async () => {
+    // Given a Users dataset.
+    const simAws = new SimAws();
+    const datasets = await givenTheThreeDatasets(simAws);
+
+    // When a user is added to it.
+    await simAws.personalizeEvents().putUsers(
+      new PutUsersCommand({
+        datasetArn: datasets.users,
+        users: [
+          { userId: "visitor-7", properties: { membership: "Frequent" } },
+        ],
+      }),
+    );
+
+    // Then the user is recorded against that dataset.
+    const [user] = simAws.personalize().recordedUsers();
+    assertNonNullable(user);
+    assertIdentical(user.userId, "visitor-7");
+    assertIdentical(user.properties, '{"membership":"Frequent"}');
+    assertIdentical(user.datasetArn, datasets.users);
+  });
+
+  it("refuses a dataset of the wrong type", async () => {
+    // Given the Items dataset of the same group.
+    const simAws = new SimAws();
+    const datasets = await givenTheThreeDatasets(simAws);
+
+    // When users are added to it by mistake.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.personalizeEvents().putUsers(
+          new PutUsersCommand({
+            datasetArn: datasets.items,
+            users: [{ userId: "visitor-7" }],
+          }),
+        ),
+    );
+
+    // Then Personalize refuses it.
+    assertIdentical(error.name, "InvalidInputException");
+    assertStringIncludes(error.message, "PutUsers needs a USERS one");
+  });
+
+  it("refuses an empty batch", async () => {
+    // Given a Users dataset.
+    const simAws = new SimAws();
+    const datasets = await givenTheThreeDatasets(simAws);
+
+    // When a request carries no users at all.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws
+          .personalizeEvents()
+          .putUsers(
+            new PutUsersCommand({ datasetArn: datasets.users, users: [] }),
+          ),
+    );
+
+    // Then it is refused as invalid input.
+    assertIdentical(error.name, "InvalidInputException");
+  });
+});

--- a/src/service/personalize/command/events/sim-personalize-put-items-users.iso.test.ts
+++ b/src/service/personalize/command/events/sim-personalize-put-items-users.iso.test.ts
@@ -195,6 +195,42 @@ describe("Personalize PutUsers", () => {
     assertStringIncludes(error.message, "PutUsers needs a USERS one");
   });
 
+  it("refuses more records than one request may carry", async () => {
+    // Given an Items dataset and a Users dataset.
+    const simAws = new SimAws();
+    const datasets = await givenTheThreeDatasets(simAws);
+
+    // When each operation batches eleven records.
+    const tooManyItems = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.personalizeEvents().putItems(
+          new PutItemsCommand({
+            datasetArn: datasets.items,
+            items: Array.from({ length: 11 }, (_, index) => ({
+              itemId: `entry-${String(index)}`,
+            })),
+          }),
+        ),
+    );
+    const tooManyUsers = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.personalizeEvents().putUsers(
+          new PutUsersCommand({
+            datasetArn: datasets.users,
+            users: Array.from({ length: 11 }, (_, index) => ({
+              userId: `visitor-${String(index)}`,
+            })),
+          }),
+        ),
+    );
+
+    // Then both are refused, as real Personalize refuses them at ten.
+    assertIdentical(tooManyItems.name, "InvalidInputException");
+    assertStringIncludes(tooManyItems.message, "items carries 11 records");
+    assertIdentical(tooManyUsers.name, "InvalidInputException");
+    assertStringIncludes(tooManyUsers.message, "users carries 11 records");
+  });
+
   it("refuses an empty batch", async () => {
     // Given a Users dataset.
     const simAws = new SimAws();

--- a/src/service/personalize/command/events/sim-personalize-put-items.ts
+++ b/src/service/personalize/command/events/sim-personalize-put-items.ts
@@ -1,0 +1,66 @@
+import { SimPersonalizeRecordedItem } from "../../event/sim-personalize-recorded-item.js";
+import { SimPersonalizeUnsimulatedInput } from "../sim-personalize-unsimulated-input.js";
+import type { SimPersonalizeRequestOptions } from "../sim-personalize-request-options.js";
+import type {
+  SimPutItemsCommand,
+  SimPutItemsCommandOutput,
+} from "./events.command.js";
+import { SimPersonalizeEventCommandGroup } from "./sim-personalize-event-command-group.js";
+import {
+  readSimPersonalizeProperties,
+  requireSimPersonalizeBatch,
+  requireSimPersonalizeField,
+} from "./sim-personalize-event-input.js";
+
+const action = "personalize:PutItems";
+
+const accepted = ["datasetArn", "items"];
+
+const acceptedItem = ["itemId", "properties"];
+
+const unsimulated = new SimPersonalizeUnsimulatedInput("PutItems");
+
+/**
+ * Handles a PutItems command.
+ *
+ * This is how a catalogue update reaches Personalize between import jobs. The
+ * items are recorded and read back through `personalize().recordedItems()`.
+ * The Items dataset itself stays empty, as every simulated dataset does.
+ */
+export class SimPersonalizePutItemsHandler extends SimPersonalizeEventCommandGroup {
+  /**
+   * Record the items a request carries.
+   */
+  handle(
+    command: SimPutItemsCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): SimPutItemsCommandOutput {
+    const { input } = command;
+
+    unsimulated.refuseUnaccepted(input, accepted);
+
+    const dataset = this.datasetOfType(
+      input.datasetArn,
+      "ITEMS",
+      action,
+      options,
+    );
+    const items = requireSimPersonalizeBatch(input.items, "items");
+    const recordedAt = this.clock.now();
+
+    this.records.addItems(
+      items.map((item) => {
+        unsimulated.refuseUnaccepted(item, acceptedItem);
+
+        return new SimPersonalizeRecordedItem({
+          datasetArn: dataset.arn,
+          itemId: requireSimPersonalizeField(item.itemId, "itemId"),
+          properties: readSimPersonalizeProperties(item.properties),
+          recordedAt,
+        });
+      }),
+    );
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/personalize/command/events/sim-personalize-put-users.ts
+++ b/src/service/personalize/command/events/sim-personalize-put-users.ts
@@ -1,0 +1,65 @@
+import { SimPersonalizeRecordedUser } from "../../event/sim-personalize-recorded-user.js";
+import { SimPersonalizeUnsimulatedInput } from "../sim-personalize-unsimulated-input.js";
+import type { SimPersonalizeRequestOptions } from "../sim-personalize-request-options.js";
+import type {
+  SimPutUsersCommand,
+  SimPutUsersCommandOutput,
+} from "./events.command.js";
+import { SimPersonalizeEventCommandGroup } from "./sim-personalize-event-command-group.js";
+import {
+  readSimPersonalizeProperties,
+  requireSimPersonalizeBatch,
+  requireSimPersonalizeField,
+} from "./sim-personalize-event-input.js";
+
+const action = "personalize:PutUsers";
+
+const accepted = ["datasetArn", "users"];
+
+const acceptedUser = ["userId", "properties"];
+
+const unsimulated = new SimPersonalizeUnsimulatedInput("PutUsers");
+
+/**
+ * Handles a PutUsers command.
+ *
+ * It follows PutItems. The users are recorded and read back through
+ * `personalize().recordedUsers()`, and the Users dataset stays empty.
+ */
+export class SimPersonalizePutUsersHandler extends SimPersonalizeEventCommandGroup {
+  /**
+   * Record the users a request carries.
+   */
+  handle(
+    command: SimPutUsersCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): SimPutUsersCommandOutput {
+    const { input } = command;
+
+    unsimulated.refuseUnaccepted(input, accepted);
+
+    const dataset = this.datasetOfType(
+      input.datasetArn,
+      "USERS",
+      action,
+      options,
+    );
+    const users = requireSimPersonalizeBatch(input.users, "users");
+    const recordedAt = this.clock.now();
+
+    this.records.addUsers(
+      users.map((user) => {
+        unsimulated.refuseUnaccepted(user, acceptedUser);
+
+        return new SimPersonalizeRecordedUser({
+          datasetArn: dataset.arn,
+          userId: requireSimPersonalizeField(user.userId, "userId"),
+          properties: readSimPersonalizeProperties(user.properties),
+          recordedAt,
+        });
+      }),
+    );
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/personalize/command/sim-personalize-command.types.ts
+++ b/src/service/personalize/command/sim-personalize-command.types.ts
@@ -51,6 +51,37 @@ export type {
   SimPersonalizeDatasetSummary,
 } from "./dataset/dataset.command.js";
 export type {
+  SimCreateEventTrackerCommand,
+  SimCreateEventTrackerCommandInput,
+  SimCreateEventTrackerCommandOutput,
+  SimDeleteEventTrackerCommand,
+  SimDeleteEventTrackerCommandInput,
+  SimDeleteEventTrackerCommandOutput,
+  SimDescribeEventTrackerCommand,
+  SimDescribeEventTrackerCommandInput,
+  SimDescribeEventTrackerCommandOutput,
+  SimListEventTrackersCommand,
+  SimListEventTrackersCommandInput,
+  SimListEventTrackersCommandOutput,
+  SimPersonalizeEventTrackerDetail,
+  SimPersonalizeEventTrackerSummary,
+} from "./event-tracker/event-tracker.command.js";
+export type {
+  SimPersonalizeEventInput,
+  SimPersonalizeItemInput,
+  SimPersonalizeProperties,
+  SimPersonalizeUserInput,
+  SimPutEventsCommand,
+  SimPutEventsCommandInput,
+  SimPutEventsCommandOutput,
+  SimPutItemsCommand,
+  SimPutItemsCommandInput,
+  SimPutItemsCommandOutput,
+  SimPutUsersCommand,
+  SimPutUsersCommandInput,
+  SimPutUsersCommandOutput,
+} from "./events/events.command.js";
+export type {
   SimCreateSchemaCommand,
   SimCreateSchemaCommandInput,
   SimCreateSchemaCommandOutput,

--- a/src/service/personalize/command/sim-personalize-commands.ts
+++ b/src/service/personalize/command/sim-personalize-commands.ts
@@ -1,6 +1,7 @@
 import type { SimClock } from "../../../util/clock/sim-clock.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimPersonalizeEventRecords } from "../event/sim-personalize-event-records.js";
 import { SimPersonalizeCampaignRules } from "../recommendation/sim-personalize-campaign-rules.js";
 import type { SimPersonalizeResources } from "../resource/sim-personalize-resources.js";
 import { SimPersonalizeAuthorizer } from "./authorize/sim-personalize-authorizer.js";
@@ -10,6 +11,11 @@ import { SimPersonalizeDatasetGroupReadCommands } from "./dataset-group/sim-pers
 import { SimPersonalizeDatasetGroupWriteCommands } from "./dataset-group/sim-personalize-dataset-group-write-commands.js";
 import { SimPersonalizeDatasetReadCommands } from "./dataset/sim-personalize-dataset-read-commands.js";
 import { SimPersonalizeDatasetWriteCommands } from "./dataset/sim-personalize-dataset-write-commands.js";
+import { SimPersonalizeEventTrackerReadCommands } from "./event-tracker/sim-personalize-event-tracker-read-commands.js";
+import { SimPersonalizeEventTrackerWriteCommands } from "./event-tracker/sim-personalize-event-tracker-write-commands.js";
+import { SimPersonalizePutEventsHandler } from "./events/sim-personalize-put-events.js";
+import { SimPersonalizePutItemsHandler } from "./events/sim-personalize-put-items.js";
+import { SimPersonalizePutUsersHandler } from "./events/sim-personalize-put-users.js";
 import { SimPersonalizeGetPersonalizedRankingHandler } from "./runtime/sim-personalize-get-personalized-ranking.js";
 import { SimPersonalizeGetRecommendationsHandler } from "./runtime/sim-personalize-get-recommendations.js";
 import { SimPersonalizeSchemaReadCommands } from "./schema/sim-personalize-schema-read-commands.js";
@@ -36,8 +42,12 @@ interface SimPersonalizeCommandsProperties {
  *
  * The two runtime handlers are built here as well, over the same resources
  * and the same authorizer. What they answer with is declared against a
- * campaign through the rules, which is why those are held here too: the
- * declaration and the request that reads it have to reach the same rules.
+ * campaign through the rules, so those are held here too. The declaration and
+ * the request that reads it have to reach the same rules.
+ *
+ * The three events handlers are here for the same reason. They record what
+ * they are sent, and `SimPersonalize` reads that record back through its own
+ * accessors, so both ends have to reach the same records.
  */
 export class SimPersonalizeCommands {
   public readonly datasetGroupWrites: SimPersonalizeDatasetGroupWriteCommands;
@@ -52,6 +62,12 @@ export class SimPersonalizeCommands {
   public readonly solutionVersionReads: SimPersonalizeSolutionVersionReadCommands;
   public readonly campaignWrites: SimPersonalizeCampaignWriteCommands;
   public readonly campaignReads: SimPersonalizeCampaignReadCommands;
+  public readonly eventTrackerWrites: SimPersonalizeEventTrackerWriteCommands;
+  public readonly eventTrackerReads: SimPersonalizeEventTrackerReadCommands;
+  public readonly records = new SimPersonalizeEventRecords();
+  public readonly putEvents: SimPersonalizePutEventsHandler;
+  public readonly putItems: SimPersonalizePutItemsHandler;
+  public readonly putUsers: SimPersonalizePutUsersHandler;
   public readonly rules: SimPersonalizeCampaignRules;
   public readonly recommendations: SimPersonalizeGetRecommendationsHandler;
   public readonly rankings: SimPersonalizeGetPersonalizedRankingHandler;
@@ -79,6 +95,16 @@ export class SimPersonalizeCommands {
     );
     this.campaignWrites = new SimPersonalizeCampaignWriteCommands(shared);
     this.campaignReads = new SimPersonalizeCampaignReadCommands(shared);
+    this.eventTrackerWrites = new SimPersonalizeEventTrackerWriteCommands(
+      shared,
+    );
+    this.eventTrackerReads = new SimPersonalizeEventTrackerReadCommands(shared);
+
+    const events = { ...shared, records: this.records };
+
+    this.putEvents = new SimPersonalizePutEventsHandler(events);
+    this.putItems = new SimPersonalizePutItemsHandler(events);
+    this.putUsers = new SimPersonalizePutUsersHandler(events);
 
     this.rules = new SimPersonalizeCampaignRules({
       campaigns: resources.campaigns,

--- a/src/service/personalize/event/sim-personalize-event-records.ts
+++ b/src/service/personalize/event/sim-personalize-event-records.ts
@@ -1,0 +1,50 @@
+import type { SimPersonalizeRecordedEvent } from "./sim-personalize-recorded-event.js";
+import type { SimPersonalizeRecordedItem } from "./sim-personalize-recorded-item.js";
+import type { SimPersonalizeRecordedUser } from "./sim-personalize-recorded-user.js";
+
+/**
+ * Everything the events API of one simulated Personalize scope has been sent.
+ *
+ * The three lists are kept apart because the three operations are. An
+ * interaction, a catalogue item and a user go to different datasets on real
+ * Personalize, and a test asserting on one of them should find only that one.
+ *
+ * Each list keeps its records in arrival order, and a batch keeps the order
+ * the request listed it in. Nothing is ever discarded. A real account offers
+ * no way to read any of this back, which is why a test needs it here.
+ */
+export class SimPersonalizeEventRecords {
+  readonly #events: SimPersonalizeRecordedEvent[] = [];
+  readonly #items: SimPersonalizeRecordedItem[] = [];
+  readonly #users: SimPersonalizeRecordedUser[] = [];
+
+  /** Every interaction this scope has accepted, oldest first. */
+  get events(): readonly SimPersonalizeRecordedEvent[] {
+    return [...this.#events];
+  }
+
+  /** Every item this scope has accepted, oldest first. */
+  get items(): readonly SimPersonalizeRecordedItem[] {
+    return [...this.#items];
+  }
+
+  /** Every user this scope has accepted, oldest first. */
+  get users(): readonly SimPersonalizeRecordedUser[] {
+    return [...this.#users];
+  }
+
+  /** Keep the interactions of one PutEvents, in the order it listed them. */
+  addEvents(events: readonly SimPersonalizeRecordedEvent[]): void {
+    this.#events.push(...events);
+  }
+
+  /** Keep the items of one PutItems, in the order it listed them. */
+  addItems(items: readonly SimPersonalizeRecordedItem[]): void {
+    this.#items.push(...items);
+  }
+
+  /** Keep the users of one PutUsers, in the order it listed them. */
+  addUsers(users: readonly SimPersonalizeRecordedUser[]): void {
+    this.#users.push(...users);
+  }
+}

--- a/src/service/personalize/event/sim-personalize-recorded-event.ts
+++ b/src/service/personalize/event/sim-personalize-recorded-event.ts
@@ -62,7 +62,11 @@ export class SimPersonalizeRecordedEvent {
 
   public readonly recommendationId: string | undefined;
 
-  /** The items shown to the user, where the request recorded impressions. */
+  /**
+   * The items shown to the user, where the request recorded impressions.
+   *
+   * Copied on the way in, as `sentAt` is. The SDK takes a mutable array here.
+   */
   public readonly impression: readonly string[] | undefined;
 
   constructor(properties: SimPersonalizeRecordedEventProperties) {
@@ -75,8 +79,11 @@ export class SimPersonalizeRecordedEvent {
     this.eventValue = properties.eventValue;
     this.itemId = properties.itemId;
     this.properties = properties.properties;
-    this.sentAt = properties.sentAt;
+    this.sentAt = new Date(properties.sentAt);
     this.recommendationId = properties.recommendationId;
-    this.impression = properties.impression;
+    this.impression =
+      properties.impression === undefined
+        ? undefined
+        : [...properties.impression];
   }
 }

--- a/src/service/personalize/event/sim-personalize-recorded-event.ts
+++ b/src/service/personalize/event/sim-personalize-recorded-event.ts
@@ -1,0 +1,82 @@
+export interface SimPersonalizeRecordedEventProperties {
+  readonly trackingId: string;
+  readonly eventTrackerArn: string;
+  readonly userId: string | undefined;
+  readonly sessionId: string;
+  readonly eventId: string | undefined;
+  readonly eventType: string;
+  readonly eventValue: number | undefined;
+  readonly itemId: string | undefined;
+  readonly properties: string | undefined;
+  readonly sentAt: Date;
+  readonly recommendationId: string | undefined;
+  readonly impression: readonly string[] | undefined;
+}
+
+/**
+ * One item interaction a simulated event tracker has accepted.
+ *
+ * Real Personalize puts the event into the Interactions dataset behind the
+ * tracker, where later training reads it. Simulated Personalize trains
+ * nothing, so the event is kept here as the request carried it. That record is
+ * what a test asserts against.
+ */
+export class SimPersonalizeRecordedEvent {
+  /** The tracking ID the request named, and through it the tracker. */
+  public readonly trackingId: string;
+
+  /** The ARN of the tracker that tracking ID belongs to. */
+  public readonly eventTrackerArn: string;
+
+  /** The user the interaction belongs to, absent on an anonymous session. */
+  public readonly userId: string | undefined;
+
+  public readonly sessionId: string;
+
+  /**
+   * The ID the request gave the event. Real Personalize generates one where
+   * the request omits it, and this one leaves it absent.
+   */
+  public readonly eventId: string | undefined;
+
+  public readonly eventType: string;
+
+  public readonly eventValue: number | undefined;
+
+  public readonly itemId: string | undefined;
+
+  /**
+   * The event's own data, as the JSON string the request carried.
+   *
+   * The SDK serialises an object here before it leaves the client, so this is
+   * the string the wire would have carried. A test asserting on one property
+   * parses it.
+   */
+  public readonly properties: string | undefined;
+
+  /**
+   * When the interaction happened, from the simulated clock where the
+   * request omitted it.
+   */
+  public readonly sentAt: Date;
+
+  public readonly recommendationId: string | undefined;
+
+  /** The items shown to the user, where the request recorded impressions. */
+  public readonly impression: readonly string[] | undefined;
+
+  constructor(properties: SimPersonalizeRecordedEventProperties) {
+    this.trackingId = properties.trackingId;
+    this.eventTrackerArn = properties.eventTrackerArn;
+    this.userId = properties.userId;
+    this.sessionId = properties.sessionId;
+    this.eventId = properties.eventId;
+    this.eventType = properties.eventType;
+    this.eventValue = properties.eventValue;
+    this.itemId = properties.itemId;
+    this.properties = properties.properties;
+    this.sentAt = properties.sentAt;
+    this.recommendationId = properties.recommendationId;
+    this.impression = properties.impression;
+  }
+}

--- a/src/service/personalize/event/sim-personalize-recorded-item.ts
+++ b/src/service/personalize/event/sim-personalize-recorded-item.ts
@@ -1,0 +1,33 @@
+export interface SimPersonalizeRecordedItemProperties {
+  readonly datasetArn: string;
+  readonly itemId: string;
+  readonly properties: string | undefined;
+  readonly recordedAt: Date;
+}
+
+/**
+ * One item a `PutItems` has added to a simulated Items dataset.
+ *
+ * The dataset itself stays empty. Simulated Personalize reads no dataset, so
+ * the item is kept here instead and read back through
+ * `personalize().recordedItems()`.
+ */
+export class SimPersonalizeRecordedItem {
+  /** The Items dataset the request named. */
+  public readonly datasetArn: string;
+
+  public readonly itemId: string;
+
+  /** The item's metadata, as the JSON string the request carried. */
+  public readonly properties: string | undefined;
+
+  /** When simulated Personalize accepted the item, from the simulated clock. */
+  public readonly recordedAt: Date;
+
+  constructor(properties: SimPersonalizeRecordedItemProperties) {
+    this.datasetArn = properties.datasetArn;
+    this.itemId = properties.itemId;
+    this.properties = properties.properties;
+    this.recordedAt = properties.recordedAt;
+  }
+}

--- a/src/service/personalize/event/sim-personalize-recorded-user.ts
+++ b/src/service/personalize/event/sim-personalize-recorded-user.ts
@@ -1,0 +1,32 @@
+export interface SimPersonalizeRecordedUserProperties {
+  readonly datasetArn: string;
+  readonly userId: string;
+  readonly properties: string | undefined;
+  readonly recordedAt: Date;
+}
+
+/**
+ * One user a `PutUsers` has added to a simulated Users dataset.
+ *
+ * It follows the recorded item. The dataset stays empty and the user is read
+ * back through `personalize().recordedUsers()`.
+ */
+export class SimPersonalizeRecordedUser {
+  /** The Users dataset the request named. */
+  public readonly datasetArn: string;
+
+  public readonly userId: string;
+
+  /** The user's metadata, as the JSON string the request carried. */
+  public readonly properties: string | undefined;
+
+  /** When simulated Personalize accepted the user, from the simulated clock. */
+  public readonly recordedAt: Date;
+
+  constructor(properties: SimPersonalizeRecordedUserProperties) {
+    this.datasetArn = properties.datasetArn;
+    this.userId = properties.userId;
+    this.properties = properties.properties;
+    this.recordedAt = properties.recordedAt;
+  }
+}

--- a/src/service/personalize/index.ts
+++ b/src/service/personalize/index.ts
@@ -1,5 +1,6 @@
 export { SimPersonalize } from "./sim-personalize.js";
 export { SimPersonalizeRuntime } from "./sim-personalize-runtime.js";
+export { SimPersonalizeEvents } from "./sim-personalize-events.js";
 export { SimPersonalizeRecommendations } from "./recommendation/sim-personalize-recommendations.js";
 export { SimPersonalizeRankings } from "./recommendation/sim-personalize-rankings.js";
 export type {
@@ -8,6 +9,13 @@ export type {
   SimPersonalizeItemDeclaration,
 } from "./recommendation/sim-personalize-item-declaration.js";
 export type { SimPersonalizeRequestOptions } from "./command/sim-personalize-request-options.js";
+export { SimPersonalizeRecordedEvent } from "./event/sim-personalize-recorded-event.js";
+export { SimPersonalizeRecordedItem } from "./event/sim-personalize-recorded-item.js";
+export { SimPersonalizeRecordedUser } from "./event/sim-personalize-recorded-user.js";
+export {
+  SimPersonalizeEventTracker,
+  type SimPersonalizeEventTrackerProperties,
+} from "./resource/sim-personalize-event-tracker.js";
 export {
   SimPersonalizeDatasetGroup,
   type SimPersonalizeDatasetGroupProperties,

--- a/src/service/personalize/resource/sim-personalize-arn.ts
+++ b/src/service/personalize/resource/sim-personalize-arn.ts
@@ -15,6 +15,7 @@ export const simPersonalizeResourceTypes = {
   dataset: "dataset",
   solution: "solution",
   campaign: "campaign",
+  eventTracker: "event-tracker",
 } as const;
 
 export type SimPersonalizeResourceType =
@@ -102,6 +103,16 @@ export function simPersonalizeCampaignArn(
   scope: SimAwsAccountRegionScope,
 ): string {
   return personalizeArn(simPersonalizeResourceTypes.campaign, name, scope);
+}
+
+/**
+ * The ARN of one simulated event tracker.
+ */
+export function simPersonalizeEventTrackerArn(
+  name: string,
+  scope: SimAwsAccountRegionScope,
+): string {
+  return personalizeArn(simPersonalizeResourceTypes.eventTracker, name, scope);
 }
 
 /**

--- a/src/service/personalize/resource/sim-personalize-event-tracker.ts
+++ b/src/service/personalize/resource/sim-personalize-event-tracker.ts
@@ -1,0 +1,37 @@
+import type { SimPersonalizeResource } from "./sim-personalize-resource.js";
+
+export interface SimPersonalizeEventTrackerProperties {
+  readonly arn: string;
+  readonly name: string;
+  readonly status: string;
+  readonly creationDateTime: Date;
+  readonly datasetGroupArn: string;
+  readonly trackingId: string;
+}
+
+/**
+ * A simulated Personalize event tracker: where `PutEvents` sends interactions.
+ *
+ * The tracking ID is the handle. A tracker is created against a dataset group
+ * and reports an ID back, and every `PutEvents` names that ID in place of an
+ * ARN. Real Personalize allows one tracker per dataset group.
+ */
+export class SimPersonalizeEventTracker implements SimPersonalizeResource {
+  public readonly arn: string;
+  public readonly name: string;
+  public readonly status: string;
+  public readonly creationDateTime: Date;
+  public readonly lastUpdatedDateTime: Date;
+  public readonly datasetGroupArn: string;
+  public readonly trackingId: string;
+
+  constructor(properties: SimPersonalizeEventTrackerProperties) {
+    this.arn = properties.arn;
+    this.name = properties.name;
+    this.status = properties.status;
+    this.creationDateTime = properties.creationDateTime;
+    this.lastUpdatedDateTime = properties.creationDateTime;
+    this.datasetGroupArn = properties.datasetGroupArn;
+    this.trackingId = properties.trackingId;
+  }
+}

--- a/src/service/personalize/resource/sim-personalize-in-use.ts
+++ b/src/service/personalize/resource/sim-personalize-in-use.ts
@@ -16,7 +16,8 @@ function refuse(arn: string, count: number, holders: string): never {
 }
 
 /**
- * Refuse a dataset group that still holds datasets or solutions.
+ * Refuse a dataset group that still holds datasets, solutions or an event
+ * tracker.
  */
 export function requireDatasetGroupEmpty(
   resources: SimPersonalizeResources,
@@ -36,6 +37,14 @@ export function requireDatasetGroupEmpty(
 
   if (solutions.length > 0) {
     refuse(datasetGroupArn, solutions.length, "solution(s) in it");
+  }
+
+  const eventTrackers = resources.eventTrackers.all.filter(
+    (eventTracker) => eventTracker.datasetGroupArn === datasetGroupArn,
+  );
+
+  if (eventTrackers.length > 0) {
+    refuse(datasetGroupArn, eventTrackers.length, "event tracker(s) on it");
   }
 }
 

--- a/src/service/personalize/resource/sim-personalize-resource-store.ts
+++ b/src/service/personalize/resource/sim-personalize-resource-store.ts
@@ -12,6 +12,12 @@ interface SimPersonalizeResourceStoreProperties {
    * "solution", "campaign".
    */
   readonly description: string;
+
+  /**
+   * The indefinite article the description takes, where "A" is wrong. "event
+   * tracker" is the only one so far.
+   */
+  readonly article?: string;
 }
 
 /**
@@ -24,9 +30,11 @@ interface SimPersonalizeResourceStoreProperties {
 export class SimPersonalizeResourceStore<T extends SimPersonalizeResource> {
   private readonly resources = new Map<string, T>();
   private readonly description: string;
+  private readonly article: string;
 
   constructor(properties: SimPersonalizeResourceStoreProperties) {
     this.description = properties.description;
+    this.article = properties.article ?? "A";
   }
 
   /**
@@ -103,7 +111,7 @@ export class SimPersonalizeResourceStore<T extends SimPersonalizeResource> {
     }
 
     throw new SimPersonalizeResourceAlreadyExistsException(
-      `A ${this.description} named '${name}' already exists`,
+      `${this.article} ${this.description} named '${name}' already exists`,
     );
   }
 

--- a/src/service/personalize/resource/sim-personalize-resources.ts
+++ b/src/service/personalize/resource/sim-personalize-resources.ts
@@ -1,6 +1,7 @@
 import type { SimPersonalizeCampaign } from "./sim-personalize-campaign.js";
 import type { SimPersonalizeDatasetGroup } from "./sim-personalize-dataset-group.js";
 import type { SimPersonalizeDataset } from "./sim-personalize-dataset.js";
+import type { SimPersonalizeEventTracker } from "./sim-personalize-event-tracker.js";
 import { SimPersonalizeResourceStore } from "./sim-personalize-resource-store.js";
 import type { SimPersonalizeSchema } from "./sim-personalize-schema.js";
 import type { SimPersonalizeSolutionVersion } from "./sim-personalize-solution-version.js";
@@ -43,5 +44,10 @@ export class SimPersonalizeResources {
   public readonly campaigns =
     new SimPersonalizeResourceStore<SimPersonalizeCampaign>({
       description: "campaign",
+    });
+
+  public readonly eventTrackers =
+    new SimPersonalizeResourceStore<SimPersonalizeEventTracker>({
+      description: "event tracker",
     });
 }

--- a/src/service/personalize/resource/sim-personalize-resources.ts
+++ b/src/service/personalize/resource/sim-personalize-resources.ts
@@ -49,5 +49,6 @@ export class SimPersonalizeResources {
   public readonly eventTrackers =
     new SimPersonalizeResourceStore<SimPersonalizeEventTracker>({
       description: "event tracker",
+      article: "An",
     });
 }

--- a/src/service/personalize/sdk/sim-personalize-events-sdk-command-router.ts
+++ b/src/service/personalize/sdk/sim-personalize-events-sdk-command-router.ts
@@ -1,0 +1,67 @@
+import {
+  simSdkCallerOptions,
+  type SimSdkCommandRoute,
+  type SimSdkCommandRouter,
+} from "../../../sdk/index.js";
+import type {
+  SimPutEventsCommand,
+  SimPutItemsCommand,
+  SimPutUsersCommand,
+} from "../command/events/events.command.js";
+import type { SimPersonalizeEvents } from "../sim-personalize-events.js";
+
+/**
+ * Routes intercepted SDK Commands to one scoped simulated Personalize Events.
+ *
+ * The events commands have a router of their own because they arrive on a
+ * client of their own. An intercepted `PersonalizeEventsClient` reports the
+ * `Personalize Events` service id, which is neither the `PersonalizeClient`
+ * one nor the `PersonalizeRuntimeClient` one.
+ */
+export class SimPersonalizeEventsSdkCommandRouter implements SimSdkCommandRouter {
+  private readonly routes: ReadonlyMap<string, SimSdkCommandRoute>;
+
+  constructor(simPersonalizeEvents: SimPersonalizeEvents) {
+    this.routes = new Map<string, SimSdkCommandRoute>([
+      [
+        "PutEventsCommand",
+        async (command, context): Promise<unknown> =>
+          await simPersonalizeEvents.putEvents(
+            command as SimPutEventsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "PutItemsCommand",
+        async (command, context): Promise<unknown> =>
+          await simPersonalizeEvents.putItems(
+            command as SimPutItemsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "PutUsersCommand",
+        async (command, context): Promise<unknown> =>
+          await simPersonalizeEvents.putUsers(
+            command as SimPutUsersCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+    ]);
+  }
+
+  /**
+   * The SDK Command names simulated Personalize Events can handle.
+   */
+  supportedCommandNames(): readonly string[] {
+    return this.routes.keys().toArray();
+  }
+
+  /**
+   * Get the route for an SDK Command name, if simulated Personalize Events
+   * supports it.
+   */
+  route(commandName: string): SimSdkCommandRoute | undefined {
+    return this.routes.get(commandName);
+  }
+}

--- a/src/service/personalize/sdk/sim-personalize-events-sdk-routing.iso.test.ts
+++ b/src/service/personalize/sdk/sim-personalize-events-sdk-routing.iso.test.ts
@@ -1,0 +1,163 @@
+import {
+  CreateDatasetCommand,
+  CreateDatasetGroupCommand,
+  CreateEventTrackerCommand,
+  CreateSchemaCommand,
+  DescribeEventTrackerCommand,
+  PersonalizeClient,
+} from "@aws-sdk/client-personalize";
+import {
+  PersonalizeEventsClient,
+  PutEventsCommand,
+  PutItemsCommand,
+  PutUsersCommand,
+} from "@aws-sdk/client-personalize-events";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimSdk } from "../../../sdk/index.js";
+import { SimAws } from "../../aws/sim-aws.js";
+
+describe("Personalize Events SDK interception", () => {
+  it("records what an intercepted PersonalizeEventsClient sends", async () => {
+    // Given an intercepted Personalize client and events client.
+    const simSdk = new SimSdk();
+    simSdk.intercept(PersonalizeClient);
+    simSdk.intercept(PersonalizeEventsClient);
+
+    const client = new PersonalizeClient({ region: "eu-west-2" });
+    const events = new PersonalizeEventsClient({ region: "eu-west-2" });
+
+    try {
+      // And an event tracker with an Items and a Users dataset beside it.
+      const group = await client.send(
+        new CreateDatasetGroupCommand({ name: "catalogue" }),
+      );
+      const schema = await client.send(
+        new CreateSchemaCommand({
+          name: "catalogue-schema",
+          schema: JSON.stringify({ type: "record", name: "Items", fields: [] }),
+        }),
+      );
+      const items = await client.send(
+        new CreateDatasetCommand({
+          name: "items",
+          datasetGroupArn: group.datasetGroupArn,
+          schemaArn: schema.schemaArn,
+          datasetType: "ITEMS",
+        }),
+      );
+      const users = await client.send(
+        new CreateDatasetCommand({
+          name: "users",
+          datasetGroupArn: group.datasetGroupArn,
+          schemaArn: schema.schemaArn,
+          datasetType: "USERS",
+        }),
+      );
+      const tracker = await client.send(
+        new CreateEventTrackerCommand({
+          name: "catalogue-events",
+          datasetGroupArn: group.datasetGroupArn,
+        }),
+      );
+
+      // When ordinary SDK code sends all three events operations.
+      await events.send(
+        new PutEventsCommand({
+          trackingId: tracker.trackingId,
+          userId: "visitor-7",
+          sessionId: "session-1",
+          eventList: [
+            { eventType: "view", itemId: "entry-1042", sentAt: new Date() },
+          ],
+        }),
+      );
+      await events.send(
+        new PutItemsCommand({
+          datasetArn: items.datasetArn,
+          items: [{ itemId: "entry-1042" }],
+        }),
+      );
+      await events.send(
+        new PutUsersCommand({
+          datasetArn: users.datasetArn,
+          users: [{ userId: "visitor-7" }],
+        }),
+      );
+
+      // Then all three are recorded, with nothing touching the network.
+      const personalize = simSdk.simAws
+        .account()
+        .region("eu-west-2")
+        .personalize();
+      assertArrayEquals(
+        personalize.recordedEvents().map((event) => event.itemId),
+        ["entry-1042"],
+      );
+      assertArrayEquals(
+        personalize.recordedItems().map((item) => item.itemId),
+        ["entry-1042"],
+      );
+      assertArrayEquals(
+        personalize.recordedUsers().map((user) => user.userId),
+        ["visitor-7"],
+      );
+    } finally {
+      simSdk.restoreAll();
+    }
+  });
+
+  it("describes an event tracker created through an intercepted client", async () => {
+    // Given an intercepted Personalize client.
+    const simSdk = new SimSdk();
+    simSdk.intercept(PersonalizeClient);
+
+    const client = new PersonalizeClient({ region: "eu-west-2" });
+
+    try {
+      // When a tracker is created and then described.
+      const group = await client.send(
+        new CreateDatasetGroupCommand({ name: "catalogue" }),
+      );
+      const created = await client.send(
+        new CreateEventTrackerCommand({
+          name: "catalogue-events",
+          datasetGroupArn: group.datasetGroupArn,
+        }),
+      );
+      const described = await client.send(
+        new DescribeEventTrackerCommand({
+          eventTrackerArn: created.eventTrackerArn,
+        }),
+      );
+
+      // Then the tracking ID the create handed out is the one it reports.
+      assertNonNullable(described.eventTracker);
+      assertIdentical(described.eventTracker.trackingId, created.trackingId);
+    } finally {
+      simSdk.restoreAll();
+    }
+  });
+
+  it("supports the Commands its router names and no others", () => {
+    // Given a simulated Personalize Events.
+    const simAws = new SimAws();
+
+    // When its router is asked what it handles.
+    const supported = simAws.personalizeEvents().sdkCommandRouter();
+
+    // Then every name is one the router has a route for.
+    for (const commandName of supported.supportedCommandNames()) {
+      assertNonNullable(supported.route(commandName));
+    }
+
+    assertUndefined(supported.route("PutActionsCommand"));
+    assertArrayLength(supported.supportedCommandNames(), 3);
+  });
+});

--- a/src/service/personalize/sdk/sim-personalize-sdk-command-router.ts
+++ b/src/service/personalize/sdk/sim-personalize-sdk-command-router.ts
@@ -22,6 +22,12 @@ import type {
   SimListDatasetsCommand,
 } from "../command/dataset/dataset.command.js";
 import type {
+  SimCreateEventTrackerCommand,
+  SimDeleteEventTrackerCommand,
+  SimDescribeEventTrackerCommand,
+  SimListEventTrackersCommand,
+} from "../command/event-tracker/event-tracker.command.js";
+import type {
   SimCreateSchemaCommand,
   SimDeleteSchemaCommand,
   SimDescribeSchemaCommand,
@@ -139,6 +145,38 @@ export class SimPersonalizeSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simPersonalize.deleteDataset(
             command as SimDeleteDatasetCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "CreateEventTrackerCommand",
+        async (command, context): Promise<unknown> =>
+          await simPersonalize.createEventTracker(
+            command as SimCreateEventTrackerCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DescribeEventTrackerCommand",
+        async (command, context): Promise<unknown> =>
+          await simPersonalize.describeEventTracker(
+            command as SimDescribeEventTrackerCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListEventTrackersCommand",
+        async (command, context): Promise<unknown> =>
+          await simPersonalize.listEventTrackers(
+            command as SimListEventTrackersCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteEventTrackerCommand",
+        async (command, context): Promise<unknown> =>
+          await simPersonalize.deleteEventTracker(
+            command as SimDeleteEventTrackerCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/personalize/sdk/sim-personalize-sdk-routing.iso.test.ts
+++ b/src/service/personalize/sdk/sim-personalize-sdk-routing.iso.test.ts
@@ -198,6 +198,6 @@ describe("Personalize SDK interception", () => {
     }
 
     assertUndefined(supported.route("CreateRecommenderCommand"));
-    assertArrayLength(supported.supportedCommandNames(), 23);
+    assertArrayLength(supported.supportedCommandNames(), 27);
   });
 });

--- a/src/service/personalize/sim-personalize-control-plane.ts
+++ b/src/service/personalize/sim-personalize-control-plane.ts
@@ -6,7 +6,7 @@ import { SimPersonalizeDataOperations } from "./sim-personalize-data-operations.
  * The operations of the Personalize control plane API that are about models.
  *
  * A solution names a recipe on a dataset group, a solution version stands for
- * the trained model, and a campaign deploys that version. These ten calls
+ * the trained model, and a campaign deploys that version. These eleven calls
  * build the chain a recommendation is served from, on top of the data
  * operations this extends.
  *

--- a/src/service/personalize/sim-personalize-control-plane.ts
+++ b/src/service/personalize/sim-personalize-control-plane.ts
@@ -1,167 +1,26 @@
-import {
-  type BackgroundScheduler,
-  BackgroundTasks,
-} from "../../util/background/background.js";
-import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
-import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
-import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
 import type * as simPersonalizeCommands from "./command/sim-personalize-command.types.js";
-import { SimPersonalizeCommands } from "./command/sim-personalize-commands.js";
 import type { SimPersonalizeRequestOptions } from "./command/sim-personalize-request-options.js";
-import { SimPersonalizeResources } from "./resource/sim-personalize-resources.js";
-
-export interface SimPersonalizeProperties {
-  readonly accountRegionScope?: SimAwsAccountRegionScope;
-  readonly iam?: SimIamInterServiceAuthZ;
-  readonly background?: BackgroundScheduler;
-}
+import { SimPersonalizeDataOperations } from "./sim-personalize-data-operations.js";
 
 /**
- * The operations of the Personalize control plane API.
+ * The operations of the Personalize control plane API that are about models.
  *
- * These are the twenty-two calls that build the chain a recommendation is
- * served from, and they are here rather than on `SimPersonalize` itself
- * because that class would otherwise be this list and nothing else. What is
- * left there is what a simulated Personalize is beyond its control plane: the
- * runtime API over it, the results declared against its campaigns, and the
+ * A solution names a recipe on a dataset group, a solution version stands for
+ * the trained model, and a campaign deploys that version. These ten calls
+ * build the chain a recommendation is served from, on top of the data
+ * operations this extends.
+ *
+ * The whole control plane sits apart from `SimPersonalize` because that class
+ * would otherwise be this list and nothing else. What is left there is what a
+ * simulated Personalize is beyond its control plane. The runtime API over it,
+ * the events API over it, the results declared against its campaigns, and the
  * state a test reads back directly.
  *
- * The split is the one AWS makes. The control plane is the `personalize`
- * endpoint and the `PersonalizeClient`; the runtime is the
+ * The split from the runtime is the one AWS makes. The control plane is the
+ * `personalize` endpoint and the `PersonalizeClient`. The runtime is the
  * `personalize-runtime` endpoint and a client of its own.
  */
-export abstract class SimPersonalizeControlPlane {
-  protected readonly resources = new SimPersonalizeResources();
-  protected readonly commands: SimPersonalizeCommands;
-  protected readonly background: BackgroundScheduler;
-
-  constructor(properties: SimPersonalizeProperties = {}) {
-    const {
-      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      iam = new SimIamAllowAllAuth(),
-      background = new BackgroundTasks(),
-    } = properties;
-
-    this.background = background;
-    this.commands = new SimPersonalizeCommands({
-      resources: this.resources,
-      iam,
-      accountRegionScope,
-      clock: background,
-    });
-  }
-
-  /** Handle a CreateDatasetGroup Command from the SDK. */
-  async createDatasetGroup(
-    command: simPersonalizeCommands.SimCreateDatasetGroupCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimCreateDatasetGroupCommandOutput> {
-    await this.background.sequence();
-    return this.commands.datasetGroupWrites.create(command, options);
-  }
-
-  /** Handle a DescribeDatasetGroup Command from the SDK. */
-  async describeDatasetGroup(
-    command: simPersonalizeCommands.SimDescribeDatasetGroupCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimDescribeDatasetGroupCommandOutput> {
-    await this.background.sequence();
-    return this.commands.datasetGroupReads.describe(command, options);
-  }
-
-  /** Handle a ListDatasetGroups Command from the SDK. */
-  async listDatasetGroups(
-    command: simPersonalizeCommands.SimListDatasetGroupsCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimListDatasetGroupsCommandOutput> {
-    await this.background.sequence();
-    return this.commands.datasetGroupReads.list(command, options);
-  }
-
-  /** Handle a DeleteDatasetGroup Command from the SDK. */
-  async deleteDatasetGroup(
-    command: simPersonalizeCommands.SimDeleteDatasetGroupCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimDeleteDatasetGroupCommandOutput> {
-    await this.background.sequence();
-    return this.commands.datasetGroupWrites.delete(command, options);
-  }
-
-  /** Handle a CreateSchema Command from the SDK. */
-  async createSchema(
-    command: simPersonalizeCommands.SimCreateSchemaCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimCreateSchemaCommandOutput> {
-    await this.background.sequence();
-    return this.commands.schemaWrites.create(command, options);
-  }
-
-  /** Handle a DescribeSchema Command from the SDK. */
-  async describeSchema(
-    command: simPersonalizeCommands.SimDescribeSchemaCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimDescribeSchemaCommandOutput> {
-    await this.background.sequence();
-    return this.commands.schemaReads.describe(command, options);
-  }
-
-  /** Handle a ListSchemas Command from the SDK. */
-  async listSchemas(
-    command: simPersonalizeCommands.SimListSchemasCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimListSchemasCommandOutput> {
-    await this.background.sequence();
-    return this.commands.schemaReads.list(command, options);
-  }
-
-  /** Handle a DeleteSchema Command from the SDK. */
-  async deleteSchema(
-    command: simPersonalizeCommands.SimDeleteSchemaCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimDeleteSchemaCommandOutput> {
-    await this.background.sequence();
-    return this.commands.schemaWrites.delete(command, options);
-  }
-
-  /** Handle a CreateDataset Command from the SDK. */
-  async createDataset(
-    command: simPersonalizeCommands.SimCreateDatasetCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimCreateDatasetCommandOutput> {
-    await this.background.sequence();
-    return this.commands.datasetWrites.create(command, options);
-  }
-
-  /** Handle a DescribeDataset Command from the SDK. */
-  async describeDataset(
-    command: simPersonalizeCommands.SimDescribeDatasetCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimDescribeDatasetCommandOutput> {
-    await this.background.sequence();
-    return this.commands.datasetReads.describe(command, options);
-  }
-
-  /** Handle a ListDatasets Command from the SDK. */
-  async listDatasets(
-    command: simPersonalizeCommands.SimListDatasetsCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimListDatasetsCommandOutput> {
-    await this.background.sequence();
-    return this.commands.datasetReads.list(command, options);
-  }
-
-  /** Handle a DeleteDataset Command from the SDK. */
-  async deleteDataset(
-    command: simPersonalizeCommands.SimDeleteDatasetCommand,
-    options?: SimPersonalizeRequestOptions,
-  ): Promise<simPersonalizeCommands.SimDeleteDatasetCommandOutput> {
-    await this.background.sequence();
-    return this.commands.datasetWrites.delete(command, options);
-  }
-
+export abstract class SimPersonalizeControlPlane extends SimPersonalizeDataOperations {
   /** Handle a CreateSolution Command from the SDK. */
   async createSolution(
     command: simPersonalizeCommands.SimCreateSolutionCommand,

--- a/src/service/personalize/sim-personalize-data-operations.ts
+++ b/src/service/personalize/sim-personalize-data-operations.ts
@@ -28,7 +28,7 @@ export interface SimPersonalizeProperties {
  * control plane.
  *
  * The rest of the control plane is on `SimPersonalizeControlPlane`, which
- * extends this. The two are split because one class carrying all twenty-six
+ * extends this. The two are split because one class carrying all twenty-seven
  * operations is a list and nothing else, and because a file has a line limit.
  */
 export abstract class SimPersonalizeDataOperations {

--- a/src/service/personalize/sim-personalize-data-operations.ts
+++ b/src/service/personalize/sim-personalize-data-operations.ts
@@ -1,0 +1,198 @@
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../util/background/background.js";
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type * as simPersonalizeCommands from "./command/sim-personalize-command.types.js";
+import { SimPersonalizeCommands } from "./command/sim-personalize-commands.js";
+import type { SimPersonalizeRequestOptions } from "./command/sim-personalize-request-options.js";
+import { SimPersonalizeResources } from "./resource/sim-personalize-resources.js";
+
+export interface SimPersonalizeProperties {
+  readonly accountRegionScope?: SimAwsAccountRegionScope;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * The operations of the Personalize control plane API that are about data.
+ *
+ * A dataset group is the container everything else hangs off. It holds the
+ * schemas, the datasets those schemas describe, and the event tracker that
+ * feeds interactions into them. These sixteen calls are that side of the
+ * control plane.
+ *
+ * The rest of the control plane is on `SimPersonalizeControlPlane`, which
+ * extends this. The two are split because one class carrying all twenty-six
+ * operations is a list and nothing else, and because a file has a line limit.
+ */
+export abstract class SimPersonalizeDataOperations {
+  protected readonly resources = new SimPersonalizeResources();
+  protected readonly commands: SimPersonalizeCommands;
+  protected readonly background: BackgroundScheduler;
+
+  constructor(properties: SimPersonalizeProperties = {}) {
+    const {
+      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.background = background;
+    this.commands = new SimPersonalizeCommands({
+      resources: this.resources,
+      iam,
+      accountRegionScope,
+      clock: background,
+    });
+  }
+
+  /** Handle a CreateDatasetGroup Command from the SDK. */
+  async createDatasetGroup(
+    command: simPersonalizeCommands.SimCreateDatasetGroupCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimCreateDatasetGroupCommandOutput> {
+    await this.background.sequence();
+    return this.commands.datasetGroupWrites.create(command, options);
+  }
+
+  /** Handle a DescribeDatasetGroup Command from the SDK. */
+  async describeDatasetGroup(
+    command: simPersonalizeCommands.SimDescribeDatasetGroupCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimDescribeDatasetGroupCommandOutput> {
+    await this.background.sequence();
+    return this.commands.datasetGroupReads.describe(command, options);
+  }
+
+  /** Handle a ListDatasetGroups Command from the SDK. */
+  async listDatasetGroups(
+    command: simPersonalizeCommands.SimListDatasetGroupsCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimListDatasetGroupsCommandOutput> {
+    await this.background.sequence();
+    return this.commands.datasetGroupReads.list(command, options);
+  }
+
+  /** Handle a DeleteDatasetGroup Command from the SDK. */
+  async deleteDatasetGroup(
+    command: simPersonalizeCommands.SimDeleteDatasetGroupCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimDeleteDatasetGroupCommandOutput> {
+    await this.background.sequence();
+    return this.commands.datasetGroupWrites.delete(command, options);
+  }
+
+  /** Handle a CreateSchema Command from the SDK. */
+  async createSchema(
+    command: simPersonalizeCommands.SimCreateSchemaCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimCreateSchemaCommandOutput> {
+    await this.background.sequence();
+    return this.commands.schemaWrites.create(command, options);
+  }
+
+  /** Handle a DescribeSchema Command from the SDK. */
+  async describeSchema(
+    command: simPersonalizeCommands.SimDescribeSchemaCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimDescribeSchemaCommandOutput> {
+    await this.background.sequence();
+    return this.commands.schemaReads.describe(command, options);
+  }
+
+  /** Handle a ListSchemas Command from the SDK. */
+  async listSchemas(
+    command: simPersonalizeCommands.SimListSchemasCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimListSchemasCommandOutput> {
+    await this.background.sequence();
+    return this.commands.schemaReads.list(command, options);
+  }
+
+  /** Handle a DeleteSchema Command from the SDK. */
+  async deleteSchema(
+    command: simPersonalizeCommands.SimDeleteSchemaCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimDeleteSchemaCommandOutput> {
+    await this.background.sequence();
+    return this.commands.schemaWrites.delete(command, options);
+  }
+
+  /** Handle a CreateDataset Command from the SDK. */
+  async createDataset(
+    command: simPersonalizeCommands.SimCreateDatasetCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimCreateDatasetCommandOutput> {
+    await this.background.sequence();
+    return this.commands.datasetWrites.create(command, options);
+  }
+
+  /** Handle a DescribeDataset Command from the SDK. */
+  async describeDataset(
+    command: simPersonalizeCommands.SimDescribeDatasetCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimDescribeDatasetCommandOutput> {
+    await this.background.sequence();
+    return this.commands.datasetReads.describe(command, options);
+  }
+
+  /** Handle a ListDatasets Command from the SDK. */
+  async listDatasets(
+    command: simPersonalizeCommands.SimListDatasetsCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimListDatasetsCommandOutput> {
+    await this.background.sequence();
+    return this.commands.datasetReads.list(command, options);
+  }
+
+  /** Handle a DeleteDataset Command from the SDK. */
+  async deleteDataset(
+    command: simPersonalizeCommands.SimDeleteDatasetCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimDeleteDatasetCommandOutput> {
+    await this.background.sequence();
+    return this.commands.datasetWrites.delete(command, options);
+  }
+
+  /** Handle a CreateEventTracker Command from the SDK. */
+  async createEventTracker(
+    command: simPersonalizeCommands.SimCreateEventTrackerCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimCreateEventTrackerCommandOutput> {
+    await this.background.sequence();
+    return this.commands.eventTrackerWrites.create(command, options);
+  }
+
+  /** Handle a DescribeEventTracker Command from the SDK. */
+  async describeEventTracker(
+    command: simPersonalizeCommands.SimDescribeEventTrackerCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimDescribeEventTrackerCommandOutput> {
+    await this.background.sequence();
+    return this.commands.eventTrackerReads.describe(command, options);
+  }
+
+  /** Handle a ListEventTrackers Command from the SDK. */
+  async listEventTrackers(
+    command: simPersonalizeCommands.SimListEventTrackersCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimListEventTrackersCommandOutput> {
+    await this.background.sequence();
+    return this.commands.eventTrackerReads.list(command, options);
+  }
+
+  /** Handle a DeleteEventTracker Command from the SDK. */
+  async deleteEventTracker(
+    command: simPersonalizeCommands.SimDeleteEventTrackerCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simPersonalizeCommands.SimDeleteEventTrackerCommandOutput> {
+    await this.background.sequence();
+    return this.commands.eventTrackerWrites.delete(command, options);
+  }
+}

--- a/src/service/personalize/sim-personalize-events.ts
+++ b/src/service/personalize/sim-personalize-events.ts
@@ -1,0 +1,79 @@
+import type { BackgroundScheduler } from "../../util/background/background.js";
+import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
+import type * as simEventsCommands from "./command/events/events.command.js";
+import type { SimPersonalizePutEventsHandler } from "./command/events/sim-personalize-put-events.js";
+import type { SimPersonalizePutItemsHandler } from "./command/events/sim-personalize-put-items.js";
+import type { SimPersonalizePutUsersHandler } from "./command/events/sim-personalize-put-users.js";
+import type { SimPersonalizeRequestOptions } from "./command/sim-personalize-request-options.js";
+import { SimPersonalizeEventsSdkCommandRouter } from "./sdk/sim-personalize-events-sdk-command-router.js";
+
+export interface SimPersonalizeEventsProperties {
+  readonly putEvents: SimPersonalizePutEventsHandler;
+  readonly putItems: SimPersonalizePutItemsHandler;
+  readonly putUsers: SimPersonalizePutUsersHandler;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * Simulated Amazon Personalize Events. Handles SDK commands from the separate
+ * Personalize Events client.
+ *
+ * It is never built alone. The event trackers it accepts interactions for and
+ * the datasets it accepts items and users for belong to one simulated
+ * Personalize, and so does the record of everything it has been sent. It is a
+ * second API over that service's state, in the way simulated DynamoDB Streams
+ * is over simulated DynamoDB.
+ *
+ * What arrives here changes no recommendation. Real Personalize feeds the
+ * interactions into the dataset a later training run reads, and simulated
+ * Personalize trains nothing. A campaign answers with what a test declared it
+ * would answer with however many events it has been sent. The record is the
+ * observable behaviour, and it is read back through
+ * `personalize().recordedEvents()`.
+ */
+export class SimPersonalizeEvents {
+  readonly #putEvents: SimPersonalizePutEventsHandler;
+  readonly #putItems: SimPersonalizePutItemsHandler;
+  readonly #putUsers: SimPersonalizePutUsersHandler;
+  readonly #background: BackgroundScheduler;
+  readonly #sdkRouter = new SimPersonalizeEventsSdkCommandRouter(this);
+
+  constructor(properties: SimPersonalizeEventsProperties) {
+    this.#putEvents = properties.putEvents;
+    this.#putItems = properties.putItems;
+    this.#putUsers = properties.putUsers;
+    this.#background = properties.background;
+  }
+
+  /** Handle a PutEvents Command from the SDK. */
+  async putEvents(
+    command: simEventsCommands.SimPutEventsCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simEventsCommands.SimPutEventsCommandOutput> {
+    await this.#background.sequence();
+    return this.#putEvents.handle(command, options);
+  }
+
+  /** Handle a PutItems Command from the SDK. */
+  async putItems(
+    command: simEventsCommands.SimPutItemsCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simEventsCommands.SimPutItemsCommandOutput> {
+    await this.#background.sequence();
+    return this.#putItems.handle(command, options);
+  }
+
+  /** Handle a PutUsers Command from the SDK. */
+  async putUsers(
+    command: simEventsCommands.SimPutUsersCommand,
+    options?: SimPersonalizeRequestOptions,
+  ): Promise<simEventsCommands.SimPutUsersCommandOutput> {
+    await this.#background.sequence();
+    return this.#putUsers.handle(command, options);
+  }
+
+  /** The SDK Command router for this simulated Personalize Events. */
+  sdkCommandRouter(): SimSdkCommandRouter {
+    return this.#sdkRouter;
+  }
+}

--- a/src/service/personalize/sim-personalize.ts
+++ b/src/service/personalize/sim-personalize.ts
@@ -1,4 +1,7 @@
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
+import type { SimPersonalizeRecordedEvent } from "./event/sim-personalize-recorded-event.js";
+import type { SimPersonalizeRecordedItem } from "./event/sim-personalize-recorded-item.js";
+import type { SimPersonalizeRecordedUser } from "./event/sim-personalize-recorded-user.js";
 import type { SimPersonalizeRankings } from "./recommendation/sim-personalize-rankings.js";
 import type { SimPersonalizeRecommendations } from "./recommendation/sim-personalize-recommendations.js";
 import type { SimPersonalizeCampaign } from "./resource/sim-personalize-campaign.js";
@@ -6,6 +9,7 @@ import type { SimPersonalizeDatasetGroup } from "./resource/sim-personalize-data
 import type { SimPersonalizeSolution } from "./resource/sim-personalize-solution.js";
 import { SimPersonalizeSdkCommandRouter } from "./sdk/sim-personalize-sdk-command-router.js";
 import { SimPersonalizeControlPlane } from "./sim-personalize-control-plane.js";
+import { SimPersonalizeEvents } from "./sim-personalize-events.js";
 import { SimPersonalizeRuntime } from "./sim-personalize-runtime.js";
 
 /**
@@ -22,12 +26,23 @@ import { SimPersonalizeRuntime } from "./sim-personalize-runtime.js";
  * to a campaign. The runtime operations a campaign answers are on `runtime()`,
  * as they are on a client of their own in the SDK, and what they answer with
  * is declared through `recommendations()` and `rankings()`.
+ *
+ * The events API is on `events()`, on a client of its own again. What it is
+ * sent is read back through `recordedEvents()`, `recordedItems()` and
+ * `recordedUsers()`.
  */
 export class SimPersonalize extends SimPersonalizeControlPlane {
   private readonly sdkRouter = new SimPersonalizeSdkCommandRouter(this);
   private readonly runtimeApi = new SimPersonalizeRuntime({
     recommendations: this.commands.recommendations,
     rankings: this.commands.rankings,
+    background: this.background,
+  });
+
+  private readonly eventsApi = new SimPersonalizeEvents({
+    putEvents: this.commands.putEvents,
+    putItems: this.commands.putItems,
+    putUsers: this.commands.putUsers,
     background: this.background,
   });
 
@@ -41,6 +56,38 @@ export class SimPersonalize extends SimPersonalizeControlPlane {
    */
   runtime(): SimPersonalizeRuntime {
     return this.runtimeApi;
+  }
+
+  /**
+   * The Personalize Events API over this simulated Personalize.
+   *
+   * A third API over one service's state. `PutEvents` names a tracking
+   * ID this Account and Region holds an event tracker for, and what it records
+   * is read back here.
+   */
+  events(): SimPersonalizeEvents {
+    return this.eventsApi;
+  }
+
+  /**
+   * Every item interaction the events API has accepted, oldest first.
+   *
+   * This is the simulator's own accessor rather than a Personalize operation.
+   * Real Personalize puts the interactions into a dataset a later training run
+   * reads, and offers no way to read them back.
+   */
+  recordedEvents(): readonly SimPersonalizeRecordedEvent[] {
+    return this.commands.records.events;
+  }
+
+  /** Every item PutItems has added, oldest first. */
+  recordedItems(): readonly SimPersonalizeRecordedItem[] {
+    return this.commands.records.items;
+  }
+
+  /** Every user PutUsers has added, oldest first. */
+  recordedUsers(): readonly SimPersonalizeRecordedUser[] {
+    return this.commands.records.users;
   }
 
   /**

--- a/src/service/personalize/view/sim-personalize-event-tracker-view.ts
+++ b/src/service/personalize/view/sim-personalize-event-tracker-view.ts
@@ -1,0 +1,35 @@
+import type {
+  SimPersonalizeEventTrackerDetail,
+  SimPersonalizeEventTrackerSummary,
+} from "../command/event-tracker/event-tracker.command.js";
+import type { SimPersonalizeEventTracker } from "../resource/sim-personalize-event-tracker.js";
+
+/**
+ * An event tracker as Describe reports it.
+ */
+export function simPersonalizeEventTrackerDetail(
+  eventTracker: SimPersonalizeEventTracker,
+  accountId: string,
+): SimPersonalizeEventTrackerDetail {
+  return {
+    ...simPersonalizeEventTrackerSummary(eventTracker),
+    accountId,
+    trackingId: eventTracker.trackingId,
+    datasetGroupArn: eventTracker.datasetGroupArn,
+  };
+}
+
+/**
+ * An event tracker as List reports it.
+ */
+export function simPersonalizeEventTrackerSummary(
+  eventTracker: SimPersonalizeEventTracker,
+): SimPersonalizeEventTrackerSummary {
+  return {
+    name: eventTracker.name,
+    eventTrackerArn: eventTracker.arn,
+    status: eventTracker.status,
+    creationDateTime: eventTracker.creationDateTime,
+    lastUpdatedDateTime: eventTracker.lastUpdatedDateTime,
+  };
+}


### PR DESCRIPTION
An event tracker is created against a dataset group and reports a tracking ID back, and PutEvents, PutItems and PutUsers record what they are sent through `simAws.personalizeEvents()` or an intercepted `PersonalizeEventsClient`. `personalize().recordedEvents()`, `recordedItems()` and `recordedUsers()` read the records back, following `sesV2().sentEmails()`. An event that leaves `sentAt` out is stamped from the simulated clock, and a tracking ID no tracker holds raises `ResourceNotFoundException`. Nothing trains, so a declared campaign result stays what it was declared as however many events arrive.

Resolves https://github.com/KensioSoftware/yulin/issues/900

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated Personalize Events support for recording events, items, and users.
  * Added event tracker creation, description, listing, and deletion.
  * Added SDK support for Personalize Events commands.
  * Added accessors for recorded Personalize data and timestamp control.
* **Documentation**
  * Expanded Personalize documentation with supported operations, authorization, retention behavior, limitations, and usage examples.
* **Bug Fixes**
  * Prevented deletion of dataset groups that still contain event trackers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->