### PR TITLE
feat: deploy Personalize CloudFormation Resources

### DIFF
--- a/docs/services/personalize/README.md
+++ b/docs/services/personalize/README.md
@@ -463,6 +463,142 @@ const group = await simAws.personalize().createDatasetGroup(
 console.log(group.domain);
 ```
 
+## Deploying Personalize resources with CloudFormation
+
+`AWS::Personalize::DatasetGroup`, `AWS::Personalize::Schema`, `AWS::Personalize::Dataset`,
+`AWS::Personalize::Solution` and `AWS::Personalize::EventTracker` deploy into simulated Personalize.
+A project that declares them in CDK or CloudFormation can deploy the same template its application
+deploys, with no hand-written test setup.
+
+Each one goes through the ordinary create command. A template and an SDK caller get the same
+validation, the same refusals and the same ARN.
+
+```typescript sim-personalize-cloudformation
+/**
+ * Deploying a Personalize dataset group, schema, dataset and solution.
+ */
+
+import {
+  CreateCampaignCommand,
+  CreateSolutionVersionCommand,
+} from "@aws-sdk/client-personalize";
+import { GetRecommendationsCommand } from "@aws-sdk/client-personalize-runtime";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "catalogue",
+  template: {
+    Resources: {
+      Catalogue: {
+        Type: "AWS::Personalize::DatasetGroup",
+        Properties: { Name: "catalogue" },
+      },
+      InteractionsSchema: {
+        Type: "AWS::Personalize::Schema",
+        Properties: {
+          Name: "interactions",
+          Schema: JSON.stringify({
+            type: "record",
+            name: "Interactions",
+            fields: [
+              { name: "USER_ID", type: "string" },
+              { name: "ITEM_ID", type: "string" },
+              { name: "TIMESTAMP", type: "long" },
+            ],
+          }),
+        },
+      },
+      Views: {
+        Type: "AWS::Personalize::Dataset",
+        Properties: {
+          Name: "views",
+          DatasetType: "Interactions",
+          DatasetGroupArn: { "Fn::GetAtt": ["Catalogue", "DatasetGroupArn"] },
+          SchemaArn: { "Fn::GetAtt": ["InteractionsSchema", "SchemaArn"] },
+        },
+      },
+      RelatedItems: {
+        Type: "AWS::Personalize::Solution",
+        Properties: {
+          Name: "related-items",
+          DatasetGroupArn: { "Fn::GetAtt": ["Catalogue", "DatasetGroupArn"] },
+          RecipeArn: "arn:aws:personalize:::recipe/aws-similar-items",
+        },
+      },
+    },
+    Outputs: {
+      SolutionArn: { Value: { "Fn::GetAtt": ["RelatedItems", "SolutionArn"] } },
+    },
+  },
+});
+
+// The stack stops at the solution. The version and the campaign are created
+// here, the way they are created outside a template on AWS.
+const version = await simAws.personalize().createSolutionVersion(
+  new CreateSolutionVersionCommand({
+    solutionArn: stack.outputs.get("SolutionArn")!.value as string,
+  }),
+);
+
+const campaign = await simAws.personalize().createCampaign(
+  new CreateCampaignCommand({
+    name: "related-items",
+    solutionVersionArn: version.solutionVersionArn,
+  }),
+);
+
+const campaignArn = campaign.campaignArn!;
+
+simAws
+  .personalize()
+  .recommendations(campaignArn)
+  .onItem("entry-1042", { itemIds: ["entry-2071"] });
+
+const recommended = await simAws
+  .personalizeRuntime()
+  .getRecommendations(
+    new GetRecommendationsCommand({ campaignArn, itemId: "entry-1042" }),
+  );
+
+// entry-2071
+console.log(recommended.itemList?.[0]?.itemId);
+```
+
+`Ref` answers with the resource name, and `Fn::GetAtt` with the ARN. The attribute is
+`DatasetGroupArn`, `SchemaArn`, `DatasetArn`, `SolutionArn` or `EventTrackerArn`, one per type. That
+is the way round real Personalize publishes them. Every Personalize API takes an ARN, and a template
+wiring one resource into another reads `Fn::GetAtt`. An event tracker publishes `TrackingId` too.
+`PutEvents` names that value, and a stack Output is where a test picks it up. An attribute a type
+does not publish fails the deploy, since answering one would let a template deploy here and fail on
+AWS.
+
+### A stack stops at the solution
+
+CloudFormation has no `AWS::Personalize::Campaign` type and no `AWS::Personalize::Recommender` type.
+A campaign is what every runtime call names, and it is always created out of band through the SDK,
+the CLI or the console. A deployed stack gets as far as a solution and stops there. A test creates
+the solution version and the campaign itself, as the example above does. This is real Personalize
+behaviour and worth knowing before reading it as a gap in the simulation.
+
+The domain path stops in the same place. `Domain` is a property of `AWS::Personalize::DatasetGroup`,
+and a template can declare a Domain dataset group. No `AWS::Personalize::Recommender` type exists to
+put a recommender on it.
+
+### Types a stack steps over
+
+`AWS::Personalize::BatchInferenceJob`, `AWS::Personalize::BatchSegmentJob`,
+`AWS::Personalize::DataDeletionJob`, `AWS::Personalize::MetricAttribution` and
+`AWS::Personalize::Recipe` all work over data simulated Personalize never reads. A template
+declaring one deploys, with that Resource in `stack.skippedResources` under a reason naming the
+type, and the rest of the stack around it.
+
+Deleting the stack removes the resources it made, in reverse dependency order. That order is what
+Personalize needs, since a dataset group holding a dataset, a solution or an event tracker refuses
+to be deleted.
+
 ## Reading state back
 
 `findDatasetGroup`, `findSolution` and `findCampaign` read resources by name without going through a
@@ -546,9 +682,9 @@ dataset ARN they name.
   `GetActionRecommendations`.
 - **No recommenders.** `CreateRecommender` and the ten domain use cases arrive with the domain
   path.
-- **No CloudFormation.** `AWS::Personalize::*` resource types arrive with their own issue. Real
-  CloudFormation has no `AWS::Personalize::Campaign` type at all. A campaign is always created
-  outside a template.
+- **Five CloudFormation types are stepped over.** `AWS::Personalize::BatchInferenceJob`,
+  `BatchSegmentJob`, `DataDeletionJob`, `MetricAttribution` and `Recipe` all work over data this
+  simulation never reads. A template declaring one deploys with the Resource skipped.
 - **No data import or metrics.** `CreateDatasetImportJob`, `GetSolutionMetrics` and the batch job
   operations describe work on data that simulated Personalize never reads.
 - **A solution version id is a count**, where real Personalize generates an opaque string.

--- a/docs/services/personalize/sim-personalize-cloudformation.example.ts
+++ b/docs/services/personalize/sim-personalize-cloudformation.example.ts
@@ -1,0 +1,91 @@
+/**
+ * Deploying a Personalize dataset group, schema, dataset and solution.
+ */
+
+import {
+  CreateCampaignCommand,
+  CreateSolutionVersionCommand,
+} from "@aws-sdk/client-personalize";
+import { GetRecommendationsCommand } from "@aws-sdk/client-personalize-runtime";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "catalogue",
+  template: {
+    Resources: {
+      Catalogue: {
+        Type: "AWS::Personalize::DatasetGroup",
+        Properties: { Name: "catalogue" },
+      },
+      InteractionsSchema: {
+        Type: "AWS::Personalize::Schema",
+        Properties: {
+          Name: "interactions",
+          Schema: JSON.stringify({
+            type: "record",
+            name: "Interactions",
+            fields: [
+              { name: "USER_ID", type: "string" },
+              { name: "ITEM_ID", type: "string" },
+              { name: "TIMESTAMP", type: "long" },
+            ],
+          }),
+        },
+      },
+      Views: {
+        Type: "AWS::Personalize::Dataset",
+        Properties: {
+          Name: "views",
+          DatasetType: "Interactions",
+          DatasetGroupArn: { "Fn::GetAtt": ["Catalogue", "DatasetGroupArn"] },
+          SchemaArn: { "Fn::GetAtt": ["InteractionsSchema", "SchemaArn"] },
+        },
+      },
+      RelatedItems: {
+        Type: "AWS::Personalize::Solution",
+        Properties: {
+          Name: "related-items",
+          DatasetGroupArn: { "Fn::GetAtt": ["Catalogue", "DatasetGroupArn"] },
+          RecipeArn: "arn:aws:personalize:::recipe/aws-similar-items",
+        },
+      },
+    },
+    Outputs: {
+      SolutionArn: { Value: { "Fn::GetAtt": ["RelatedItems", "SolutionArn"] } },
+    },
+  },
+});
+
+// The stack stops at the solution. The version and the campaign are created
+// here, the way they are created outside a template on AWS.
+const version = await simAws.personalize().createSolutionVersion(
+  new CreateSolutionVersionCommand({
+    solutionArn: stack.outputs.get("SolutionArn")!.value as string,
+  }),
+);
+
+const campaign = await simAws.personalize().createCampaign(
+  new CreateCampaignCommand({
+    name: "related-items",
+    solutionVersionArn: version.solutionVersionArn,
+  }),
+);
+
+const campaignArn = campaign.campaignArn!;
+
+simAws
+  .personalize()
+  .recommendations(campaignArn)
+  .onItem("entry-1042", { itemIds: ["entry-2071"] });
+
+const recommended = await simAws
+  .personalizeRuntime()
+  .getRecommendations(
+    new GetRecommendationsCommand({ campaignArn, itemId: "entry-1042" }),
+  );
+
+// entry-2071
+console.log(recommended.itemList?.[0]?.itemId);

--- a/src/service/cloudformation/resource/cfn/personalize/sim-personalize-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/personalize/sim-personalize-cfn-value-adapter.ts
@@ -1,0 +1,79 @@
+import {
+  personalizeDatasetGroupResourceType,
+  personalizeDatasetResourceType,
+  personalizeEventTrackerResourceType,
+  personalizeSchemaResourceType,
+  personalizeSolutionResourceType,
+} from "../../../../personalize/cfn/sim-cfn-personalize-resource-types.js";
+import { SimPersonalizeDatasetGroup } from "../../../../personalize/resource/sim-personalize-dataset-group.js";
+import type { SimPersonalizeResource } from "../../../../personalize/resource/sim-personalize-resource.js";
+import { SimPersonalizeDataset } from "../../../../personalize/resource/sim-personalize-dataset.js";
+import { SimPersonalizeEventTracker } from "../../../../personalize/resource/sim-personalize-event-tracker.js";
+import { SimPersonalizeSchema } from "../../../../personalize/resource/sim-personalize-schema.js";
+import { SimPersonalizeSolution } from "../../../../personalize/resource/sim-personalize-solution.js";
+import type {
+  SimCfnResourceValueAdapterProperties,
+  SimCfnServiceValueAdapter,
+} from "../sim-cfn-resource-value-adapter.js";
+import { SimPersonalizeResourceCfn } from "./sim-personalize-resource-cfn.js";
+
+/**
+ * The CloudFormation-facing value adapter for a simulated Personalize Resource.
+ */
+export function personalizeValueAdapter(
+  properties: SimCfnResourceValueAdapterProperties,
+): SimCfnServiceValueAdapter {
+  const { type, simResource } = properties;
+
+  if (
+    type === personalizeDatasetGroupResourceType &&
+    simResource instanceof SimPersonalizeDatasetGroup
+  ) {
+    return adapter(type, simResource, [["DatasetGroupArn", simResource.arn]]);
+  }
+
+  if (
+    type === personalizeSchemaResourceType &&
+    simResource instanceof SimPersonalizeSchema
+  ) {
+    return adapter(type, simResource, [["SchemaArn", simResource.arn]]);
+  }
+
+  if (
+    type === personalizeDatasetResourceType &&
+    simResource instanceof SimPersonalizeDataset
+  ) {
+    return adapter(type, simResource, [["DatasetArn", simResource.arn]]);
+  }
+
+  if (
+    type === personalizeSolutionResourceType &&
+    simResource instanceof SimPersonalizeSolution
+  ) {
+    return adapter(type, simResource, [["SolutionArn", simResource.arn]]);
+  }
+
+  if (
+    type === personalizeEventTrackerResourceType &&
+    simResource instanceof SimPersonalizeEventTracker
+  ) {
+    return adapter(type, simResource, [
+      ["EventTrackerArn", simResource.arn],
+      ["TrackingId", simResource.trackingId],
+    ]);
+  }
+
+  return undefined;
+}
+
+function adapter(
+  resourceType: string,
+  resource: SimPersonalizeResource,
+  attributes: readonly (readonly [string, string])[],
+): SimPersonalizeResourceCfn {
+  return new SimPersonalizeResourceCfn({
+    resource,
+    resourceType,
+    attributes: new Map(attributes),
+  });
+}

--- a/src/service/cloudformation/resource/cfn/personalize/sim-personalize-resource-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/personalize/sim-personalize-resource-cfn.ts
@@ -1,0 +1,57 @@
+import { assertDefined } from "../../../../../util/type-guard/defined.js";
+import type { SimPersonalizeResource } from "../../../../personalize/resource/sim-personalize-resource.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimPersonalizeResourceCfnProperties {
+  readonly resource: SimPersonalizeResource;
+  readonly resourceType: string;
+  readonly attributes: ReadonlyMap<string, string>;
+}
+
+/**
+ * CloudFormation-facing values for a simulated Personalize resource.
+ *
+ * One adapter covers all five Resource types. Every one of them answers a `Ref`
+ * with its name and publishes an ARN attribute, so what differs between them is
+ * the attribute name and not how either value is found.
+ */
+export class SimPersonalizeResourceCfn implements SimCfnResourceValueAdapter {
+  readonly #resource: SimPersonalizeResource;
+  readonly #resourceType: string;
+  readonly #attributes: ReadonlyMap<string, string>;
+
+  constructor(properties: SimPersonalizeResourceCfnProperties) {
+    this.#resource = properties.resource;
+    this.#resourceType = properties.resourceType;
+    this.#attributes = properties.attributes;
+  }
+
+  /**
+   * Every AWS::Personalize::* Ref returns the resource name.
+   *
+   * The ARN is the attribute rather than the Ref, which is the way round real
+   * Personalize publishes them. A template wiring one resource into another
+   * therefore reads `Fn::GetAtt`, since every Personalize API takes an ARN.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.#resource.name;
+  }
+
+  /**
+   * The attributes this Resource type publishes.
+   *
+   * Four of the five publish their ARN and nothing else. An event tracker
+   * publishes its tracking ID as well, which is the value PutEvents names.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    const value = this.#attributes.get(attributeName);
+
+    assertDefined(
+      value,
+      `Unsupported ${this.#resourceType} attribute ${attributeName}`,
+    );
+
+    return value;
+  }
+}

--- a/src/service/cloudformation/resource/cfn/sim-cfn-service-value-adapters.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-service-value-adapters.ts
@@ -13,6 +13,7 @@ import { eventBridgeValueAdapter } from "./events/sim-event-bridge-cfn-value-ada
 import { iamValueAdapter } from "./iam/sim-iam-cfn-value-adapter.js";
 import { kmsValueAdapter } from "./kms/sim-kms-cfn-value-adapter.js";
 import { lambdaValueAdapter } from "./lambda/sim-lambda-cfn-value-adapter.js";
+import { personalizeValueAdapter } from "./personalize/sim-personalize-cfn-value-adapter.js";
 import { route53ValueAdapter } from "./route53/sim-route53-cfn-value-adapter.js";
 import { s3ValueAdapter } from "./s3/sim-s3-cfn-value-adapter.js";
 import { schedulerValueAdapter } from "./scheduler/sim-scheduler-cfn-value-adapter.js";
@@ -54,6 +55,7 @@ export const simCfnServiceValueAdapters: readonly ((
   iamValueAdapter,
   kmsValueAdapter,
   lambdaValueAdapter,
+  personalizeValueAdapter,
   route53ValueAdapter,
   s3ValueAdapter,
   schedulerValueAdapter,

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
@@ -105,6 +105,11 @@ export const simCfnServiceResourceFactories: ReadonlyMap<
       scopedAws.logs().cfnResourceFactory(),
   ],
   [
+    "Personalize",
+    (scopedAws): SimCfnServiceResourceFactory =>
+      scopedAws.personalize().cfnResourceFactory(),
+  ],
+  [
     "Route53",
     (scopedAws): SimCfnServiceResourceFactory =>
       scopedAws.route53().cfnResourceFactory(),

--- a/src/service/personalize/README.md
+++ b/src/service/personalize/README.md
@@ -37,6 +37,7 @@ use case a recipe names decides which parameters a recommendation request has to
   through `events()` on the service. A third API over one service's state, alongside the runtime.
   What it is sent is recorded rather than trained on, and read back through the accessors on
   `sim-personalize.ts`.
+- `cfn/` builds the `AWS::Personalize::*` CloudFormation Resources a stack deploys.
 - `index.ts` exports the public Personalize simulator API for `@kensio/yulin/personalize`.
 
 ## Resource model
@@ -123,7 +124,35 @@ uses, and a solution a campaign still deploys are all reported as `ResourceInUse
 Deleting a solution takes its versions with it. Real Personalize has no `DeleteSolutionVersion`
 either.
 
+## CloudFormation Resources
+
+`cfn/` holds the CloudFormation Resource factory, reached through `cfnResourceFactory()` and
+registered under `Personalize` in `sim-cfn-service-factories.ts`. Five `AWS::Personalize::*` types
+deploy through it. The dataset group, the schema, the dataset, the solution and the event tracker.
+The other five CloudFormation has are batch inference, batch segments, data deletion, metric
+attribution and recipes, all of which work over data nothing here reads. A template declaring one is
+refused as unsupported, and sim CloudFormation records that as a skip and steps over it.
+
+Every creator goes through the ordinary command on `SimPersonalize`, in the way
+`SimCfnSesIdentityCreator` deploys an identity through `CreateEmailIdentity`. A template and an SDK
+caller are then validated in one place. What the creators read the stores for is the ARN the command
+answered with, turned back into the resource the Resource holds.
+
+`SimCfnPersonalizeProperties` reads the template properties for all five types. Every Personalize
+Resource property is a string or a boolean handed straight to a create command. The five types
+differ in which names they read and not in how any of them is read. A property with no behaviour
+behind it is recorded through `ignoreProperty` with the reason. That covers `Tags`,
+`DatasetImportJob` and `SolutionConfig`.
+
+The `Ref` and `Fn::GetAtt` values live with the other services' adapters, under
+`cloudformation/resource/cfn/personalize/`. `Ref` is the resource name and `Fn::GetAtt` the ARN. That
+is the way round real Personalize publishes them. One adapter class covers all five types on the
+strength of that shared shape, carrying the attribute names it answers.
+
+CloudFormation has no `AWS::Personalize::Campaign` or `AWS::Personalize::Recommender` type. A stack
+reaches a solution and stops there. Nothing in `cfn/` deploys the far end of the chain, and a test
+that wants recommendations builds the solution version and the campaign itself.
+
 ## What comes next
 
-CloudFormation resource types and domain recommenders are separate issues. Both build on what is
-here.
+Domain recommenders are a separate issue, building on what is here.

--- a/src/service/personalize/cfn/sim-cfn-personalize-created.ts
+++ b/src/service/personalize/cfn/sim-cfn-personalize-created.ts
@@ -1,0 +1,32 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimPersonalizeResourceStore } from "../resource/sim-personalize-resource-store.js";
+import type { SimPersonalizeResource } from "../resource/sim-personalize-resource.js";
+
+/**
+ * The resource a create command has just made, read back from the ARN it
+ * answered with.
+ *
+ * The command is what creates the resource, and this is what turns its answer
+ * into the object CloudFormation holds for the Resource. A `Ref` reads the name
+ * off it and an `Fn::GetAtt` the ARN, and a teardown hands it back to the
+ * delete command.
+ */
+export function simCfnPersonalizeCreated<T extends SimPersonalizeResource>(
+  store: SimPersonalizeResourceStore<T>,
+  arn: string | undefined,
+  described: string,
+): T {
+  assertDefined(
+    arn,
+    `sim Personalize ${described} ARN after CloudFormation creation`,
+  );
+
+  const created = store.find(arn);
+
+  assertDefined(
+    created,
+    `sim Personalize ${described} ${arn} after CloudFormation creation`,
+  );
+
+  return created;
+}

--- a/src/service/personalize/cfn/sim-cfn-personalize-dataset-creator.ts
+++ b/src/service/personalize/cfn/sim-cfn-personalize-dataset-creator.ts
@@ -1,0 +1,90 @@
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimPersonalizeDataset } from "../resource/sim-personalize-dataset.js";
+import type { SimPersonalizeResources } from "../resource/sim-personalize-resources.js";
+import type { SimPersonalize } from "../sim-personalize.js";
+import { simCfnPersonalizeCreated } from "./sim-cfn-personalize-created.js";
+import { SimCfnPersonalizeProperties } from "./sim-cfn-personalize-properties.js";
+import { simCfnPersonalizeResourceCreation } from "./sim-cfn-personalize-resource-error.js";
+import { personalizeDatasetResourceType } from "./sim-cfn-personalize-resource-types.js";
+
+const readProperties = new Set([
+  "Name",
+  "DatasetType",
+  "DatasetGroupArn",
+  "SchemaArn",
+]);
+
+const unreadProperties = new Map([
+  [
+    "DatasetImportJob",
+    "an import job reads data out of S3, and simulated Personalize reads no " +
+      "dataset",
+  ],
+]);
+
+interface SimCfnPersonalizeDatasetCreatorProperties {
+  readonly personalize: SimPersonalize;
+  readonly resources: SimPersonalizeResources;
+}
+
+/**
+ * Creates simulated datasets from AWS::Personalize::Dataset Resources.
+ *
+ * `DatasetGroupArn` and `SchemaArn` are usually `Fn::GetAtt` on the Resources
+ * that made them, which is what puts the three in dependency order. Both are
+ * resolved by CreateDataset, so a template naming a group that failed to
+ * deploy is refused the way an SDK caller passing the same ARN is.
+ */
+export class SimCfnPersonalizeDatasetCreator {
+  readonly #personalize: SimPersonalize;
+  readonly #resources: SimPersonalizeResources;
+
+  constructor(properties: SimCfnPersonalizeDatasetCreatorProperties) {
+    this.#personalize = properties.personalize;
+    this.#resources = properties.resources;
+  }
+
+  /** Create a dataset from an AWS::Personalize::Dataset Resource. */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimPersonalizeDataset> {
+    const read = new SimCfnPersonalizeProperties({
+      resourceType: personalizeDatasetResourceType,
+      resource,
+      properties,
+      read: readProperties,
+      unread: unreadProperties,
+    });
+    const input = {
+      name: read.string("Name"),
+      datasetType: read.string("DatasetType"),
+      datasetGroupArn: read.string("DatasetGroupArn"),
+      schemaArn: read.string("SchemaArn"),
+    };
+
+    read.recordUnreadProperties();
+
+    return await simCfnPersonalizeResourceCreation(
+      personalizeDatasetResourceType,
+      resource.logicalId,
+      async () => {
+        const created = await this.#personalize.createDataset({ input });
+
+        return simCfnPersonalizeCreated(
+          this.#resources.datasets,
+          created.datasetArn,
+          "dataset",
+        );
+      },
+    );
+  }
+
+  /** Delete a dataset an AWS::Personalize::Dataset Resource made. */
+  async delete(dataset: SimPersonalizeDataset): Promise<void> {
+    await this.#personalize.deleteDataset({
+      input: { datasetArn: dataset.arn },
+    });
+  }
+}

--- a/src/service/personalize/cfn/sim-cfn-personalize-dataset-group-creator.ts
+++ b/src/service/personalize/cfn/sim-cfn-personalize-dataset-group-creator.ts
@@ -1,0 +1,82 @@
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimPersonalizeDatasetGroup } from "../resource/sim-personalize-dataset-group.js";
+import type { SimPersonalizeResources } from "../resource/sim-personalize-resources.js";
+import type { SimPersonalize } from "../sim-personalize.js";
+import { simCfnPersonalizeCreated } from "./sim-cfn-personalize-created.js";
+import { SimCfnPersonalizeProperties } from "./sim-cfn-personalize-properties.js";
+import { simCfnPersonalizeResourceCreation } from "./sim-cfn-personalize-resource-error.js";
+import { personalizeDatasetGroupResourceType } from "./sim-cfn-personalize-resource-types.js";
+
+const readProperties = new Set(["Name", "Domain", "KmsKeyArn", "RoleArn"]);
+
+const unreadProperties = new Map([
+  ["Tags", "no simulated service reads a Personalize resource tag"],
+]);
+
+interface SimCfnPersonalizeDatasetGroupCreatorProperties {
+  readonly personalize: SimPersonalize;
+  readonly resources: SimPersonalizeResources;
+}
+
+/**
+ * Creates simulated dataset groups from AWS::Personalize::DatasetGroup
+ * Resources.
+ *
+ * The group is created through the ordinary CreateDatasetGroup command rather
+ * than constructed directly, so one a template deployed is the same thing an
+ * SDK caller would have got. The same name rules, the same refusal of a domain
+ * Personalize does not have, and the same ARN.
+ */
+export class SimCfnPersonalizeDatasetGroupCreator {
+  readonly #personalize: SimPersonalize;
+  readonly #resources: SimPersonalizeResources;
+
+  constructor(properties: SimCfnPersonalizeDatasetGroupCreatorProperties) {
+    this.#personalize = properties.personalize;
+    this.#resources = properties.resources;
+  }
+
+  /** Create a dataset group from an AWS::Personalize::DatasetGroup Resource. */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimPersonalizeDatasetGroup> {
+    const read = new SimCfnPersonalizeProperties({
+      resourceType: personalizeDatasetGroupResourceType,
+      resource,
+      properties,
+      read: readProperties,
+      unread: unreadProperties,
+    });
+    const input = {
+      name: read.string("Name"),
+      domain: read.string("Domain"),
+      kmsKeyArn: read.string("KmsKeyArn"),
+      roleArn: read.string("RoleArn"),
+    };
+
+    read.recordUnreadProperties();
+
+    return await simCfnPersonalizeResourceCreation(
+      personalizeDatasetGroupResourceType,
+      resource.logicalId,
+      async () => {
+        const created = await this.#personalize.createDatasetGroup({ input });
+
+        return simCfnPersonalizeCreated(
+          this.#resources.datasetGroups,
+          created.datasetGroupArn,
+          "dataset group",
+        );
+      },
+    );
+  }
+
+  /** Delete a dataset group an AWS::Personalize::DatasetGroup Resource made. */
+  async delete(datasetGroup: SimPersonalizeDatasetGroup): Promise<void> {
+    await this.#personalize.deleteDatasetGroup({
+      input: { datasetGroupArn: datasetGroup.arn },
+    });
+  }
+}

--- a/src/service/personalize/cfn/sim-cfn-personalize-event-tracker-creator.ts
+++ b/src/service/personalize/cfn/sim-cfn-personalize-event-tracker-creator.ts
@@ -1,0 +1,75 @@
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimPersonalizeEventTracker } from "../resource/sim-personalize-event-tracker.js";
+import type { SimPersonalizeResources } from "../resource/sim-personalize-resources.js";
+import type { SimPersonalize } from "../sim-personalize.js";
+import { simCfnPersonalizeCreated } from "./sim-cfn-personalize-created.js";
+import { SimCfnPersonalizeProperties } from "./sim-cfn-personalize-properties.js";
+import { simCfnPersonalizeResourceCreation } from "./sim-cfn-personalize-resource-error.js";
+import { personalizeEventTrackerResourceType } from "./sim-cfn-personalize-resource-types.js";
+
+const readProperties = new Set(["Name", "DatasetGroupArn"]);
+
+interface SimCfnPersonalizeEventTrackerCreatorProperties {
+  readonly personalize: SimPersonalize;
+  readonly resources: SimPersonalizeResources;
+}
+
+/**
+ * Creates simulated event trackers from AWS::Personalize::EventTracker
+ * Resources.
+ *
+ * The tracking ID a deployed tracker hands out is a fresh UUID, as it is on a
+ * tracker an SDK caller created. Read it from the `TrackingId` attribute in a
+ * Stack Output, or from `DescribeEventTracker`. A template cannot carry one it
+ * wrote down beforehand, and neither can a real one.
+ */
+export class SimCfnPersonalizeEventTrackerCreator {
+  readonly #personalize: SimPersonalize;
+  readonly #resources: SimPersonalizeResources;
+
+  constructor(properties: SimCfnPersonalizeEventTrackerCreatorProperties) {
+    this.#personalize = properties.personalize;
+    this.#resources = properties.resources;
+  }
+
+  /** Create a tracker from an AWS::Personalize::EventTracker Resource. */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimPersonalizeEventTracker> {
+    const read = new SimCfnPersonalizeProperties({
+      resourceType: personalizeEventTrackerResourceType,
+      resource,
+      properties,
+      read: readProperties,
+    });
+    const input = {
+      name: read.string("Name"),
+      datasetGroupArn: read.string("DatasetGroupArn"),
+    };
+
+    read.recordUnreadProperties();
+
+    return await simCfnPersonalizeResourceCreation(
+      personalizeEventTrackerResourceType,
+      resource.logicalId,
+      async () => {
+        const created = await this.#personalize.createEventTracker({ input });
+
+        return simCfnPersonalizeCreated(
+          this.#resources.eventTrackers,
+          created.eventTrackerArn,
+          "event tracker",
+        );
+      },
+    );
+  }
+
+  /** Delete a tracker an AWS::Personalize::EventTracker Resource made. */
+  async delete(eventTracker: SimPersonalizeEventTracker): Promise<void> {
+    await this.#personalize.deleteEventTracker({
+      input: { eventTrackerArn: eventTracker.arn },
+    });
+  }
+}

--- a/src/service/personalize/cfn/sim-cfn-personalize-properties.ts
+++ b/src/service/personalize/cfn/sim-cfn-personalize-properties.ts
@@ -1,0 +1,123 @@
+import type { SimCfnPropertyIgnorer } from "../../cloudformation/resource/ignore/sim-cfn-ignored-property.type.js";
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import { simCfnPersonalizeResourceError } from "./sim-cfn-personalize-resource-error.js";
+
+interface SimCfnPersonalizePropertiesProperties {
+  readonly resourceType: string;
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+
+  /** The properties this Resource type is created from. */
+  readonly read: ReadonlySet<string>;
+
+  /**
+   * The real properties of this Resource type that simulated Personalize has
+   * no behaviour for, and why each one is left out.
+   */
+  readonly unread?: ReadonlyMap<string, string> | undefined;
+}
+
+/**
+ * Reads the properties of an AWS::Personalize::* Resource.
+ *
+ * One reader serves all five types. Every Personalize Resource property is a
+ * string or a boolean handed straight to a create command, so what differs
+ * between the types is which names are read and not how any of them is read.
+ */
+export class SimCfnPersonalizeProperties {
+  readonly #resourceType: string;
+  readonly #resource: SimCfnResource;
+  readonly #properties: ReadonlyMap<string, SimCfnTemplateValue>;
+  readonly #read: ReadonlySet<string>;
+  readonly #unread: ReadonlyMap<string, string>;
+  readonly #ignorer: SimCfnPropertyIgnorer;
+
+  constructor(properties: SimCfnPersonalizePropertiesProperties) {
+    this.#resourceType = properties.resourceType;
+    this.#resource = properties.resource;
+    this.#properties = new Map(Object.entries(properties.properties));
+    this.#read = properties.read;
+    this.#unread = properties.unread ?? new Map();
+    this.#ignorer = properties.resource;
+  }
+
+  /**
+   * One string property, or nothing where the template left it out.
+   *
+   * A required property is left to the create command to insist on, so a
+   * template and an SDK caller are refused for the same reason in the same
+   * words.
+   */
+  string(name: string): string | undefined {
+    const value = this.#properties.get(name);
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value !== "string") {
+      throw this.error(`${name} must be a string`);
+    }
+
+    return value;
+  }
+
+  /**
+   * One boolean property, written as a boolean or as the string
+   * CloudFormation carried it in.
+   *
+   * A boolean written literally in a template arrives as a boolean, and the
+   * same boolean reaching a Resource through a String Parameter or an `Fn::Sub`
+   * arrives as `"true"`.
+   */
+  boolean(name: string): boolean | undefined {
+    const value = this.#properties.get(name);
+
+    if (value === undefined || typeof value === "boolean") {
+      return value;
+    }
+
+    if (value === "true" || value === "false") {
+      return value === "true";
+    }
+
+    throw this.error(`${name} must be a boolean`);
+  }
+
+  /**
+   * Record the properties the Resource is created without acting on.
+   *
+   * The named ones carry the reason simulated Personalize has no behaviour for
+   * them. Anything else is a misspelling, or a property AWS added after this
+   * was written. Real CloudFormation refuses the second one, and a stack
+   * failing over a property that arrived last week is a worse way to find out.
+   */
+  recordUnreadProperties(): void {
+    for (const name of this.#properties.keys()) {
+      if (this.#read.has(name)) {
+        continue;
+      }
+
+      this.#ignorer.ignoreProperty(
+        name,
+        this.#unread.get(name) ??
+          `${name} is not a property simulated Personalize reads from ${
+            this.#resourceType
+          }`,
+      );
+    }
+  }
+
+  /** Refuse this Resource, naming it and the type it was declared as. */
+  error(reason: string): Error {
+    return simCfnPersonalizeResourceError(
+      this.#resourceType,
+      this.#resource.logicalId,
+      reason,
+    );
+  }
+}

--- a/src/service/personalize/cfn/sim-cfn-personalize-resource-error.ts
+++ b/src/service/personalize/cfn/sim-cfn-personalize-resource-error.ts
@@ -1,0 +1,54 @@
+import { SimPersonalizeError } from "../error/sim-personalize.error.js";
+
+/**
+ * Build the error a Resource of a simulated Personalize type is refused with.
+ *
+ * The wording matters. Sim CloudFormation reads an error saying a Resource is
+ * unsupported as one to record and step over, and stepping over a dataset group
+ * or a solution that could not be created would leave the Stack looking
+ * deployed while every ARN pointing into it named nothing. So a refusal here
+ * says the Resource is invalid.
+ */
+export function simCfnPersonalizeResourceError(
+  resourceType: string,
+  logicalId: string,
+  reason: string,
+  cause?: unknown,
+): Error {
+  return new Error(`Invalid ${resourceType} Resource ${logicalId}: ${reason}`, {
+    cause,
+  });
+}
+
+/**
+ * Run the simulated Personalize commands one Resource is made of, naming the
+ * Resource in whatever they refuse.
+ *
+ * Every Resource type here goes through the ordinary Personalize commands, so
+ * what a template may ask for is decided once by simulated Personalize rather
+ * than again in the CloudFormation layer. What that leaves out is where the
+ * request came from. A deployment failing with `A dataset group needs a name`
+ * says nothing about which Resource asked for it. Only Personalize's own errors
+ * are renamed, so a refusal the CloudFormation layer decided keeps the wording
+ * it was written with.
+ */
+export async function simCfnPersonalizeResourceCreation<T>(
+  resourceType: string,
+  logicalId: string,
+  create: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await create();
+  } catch (error) {
+    if (error instanceof SimPersonalizeError) {
+      throw simCfnPersonalizeResourceError(
+        resourceType,
+        logicalId,
+        error.message,
+        error,
+      );
+    }
+
+    throw error;
+  }
+}

--- a/src/service/personalize/cfn/sim-cfn-personalize-resource-refusals.iso.test.ts
+++ b/src/service/personalize/cfn/sim-cfn-personalize-resource-refusals.iso.test.ts
@@ -1,0 +1,333 @@
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnDeployedResource } from "../../cloudformation/resource/sim-cfn-deployed-resource.type.js";
+import type { SimCfnDeployedStack } from "../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
+import {
+  deployedResourceObject,
+  deployedStackObject,
+} from "../../cloudformation/stack/sim-cfn-stack.fixture.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimPersonalizeResourceNotFoundException } from "../error/sim-personalize.error.js";
+import { simCfnPersonalizeResourceCreation } from "./sim-cfn-personalize-resource-error.js";
+
+/** The five real AWS::Personalize types this simulation has no machinery for. */
+const unsupportedResourceTypes = [
+  "BatchInferenceJob",
+  "BatchSegmentJob",
+  "DataDeletionJob",
+  "MetricAttribution",
+  "Recipe",
+];
+
+/** Deploy one dataset group, and the Resource record behind it. */
+async function deployedDatasetGroup(
+  properties?: SimCfnTemplateValueRecord,
+): Promise<{
+  readonly simAws: SimAws;
+  readonly stack: SimCfnDeployedStack;
+  readonly resource: SimCfnDeployedResource;
+}> {
+  const simAws = new SimAws();
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "catalogue-stack",
+    template: {
+      Resources: {
+        Catalogue: {
+          Type: "AWS::Personalize::DatasetGroup",
+          Properties: properties ?? { Name: "catalogue" },
+        },
+      },
+    },
+  });
+  const resource = stack.getResource("Catalogue");
+
+  assertNonNullable(resource);
+
+  return { simAws, stack, resource };
+}
+
+/** Deploy a dataset group whose stack reads one attribute off it. */
+async function deployWithAttribute(attributeName: string): Promise<void> {
+  await new SimAws().cloudFormation().deployTemplate({
+    stackName: "catalogue-stack",
+    template: {
+      Resources: {
+        Catalogue: {
+          Type: "AWS::Personalize::DatasetGroup",
+          Properties: { Name: "catalogue" },
+        },
+      },
+      Outputs: {
+        Read: { Value: { "Fn::GetAtt": ["Catalogue", attributeName] } },
+      },
+    },
+  });
+}
+
+describe("simulated Personalize CloudFormation refusals", () => {
+  it.each(unsupportedResourceTypes)(
+    "steps over an AWS::Personalize::%s it does not simulate",
+    async (resourceTypeName) => {
+      // Given a template declaring one of the job and metric types, which work
+      // over data simulated Personalize never reads.
+      const simAws = new SimAws();
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "catalogue-stack",
+        template: {
+          Resources: {
+            Catalogue: {
+              Type: "AWS::Personalize::DatasetGroup",
+              Properties: { Name: "catalogue" },
+            },
+            Unsupported: {
+              Type: `AWS::Personalize::${resourceTypeName}`,
+              Properties: { Name: "nightly" },
+            },
+          },
+        },
+      });
+
+      // Then the rest of the stack deployed, and the Resource is recorded as
+      // unsupported with the type named in the reason.
+      const resource = stack.getResource("Unsupported");
+
+      assertNonNullable(simAws.personalize().findDatasetGroup("catalogue"));
+      assertNonNullable(resource);
+      assertUndefined(resource.simResource);
+      assertArrayLength(stack.skippedResources, 1);
+      assertIdentical(
+        resource.skippedReason,
+        `Unsupported sim Personalize CloudFormation Resource ${
+          resourceTypeName
+        }`,
+      );
+    },
+  );
+
+  it("refuses creating a Personalize Resource type it does not simulate", async () => {
+    // Given a deployed dataset group, and the factory that made it.
+    const { simAws, stack, resource } = await deployedDatasetGroup();
+
+    // When the factory is asked to create a type it does not know.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .personalize()
+        .cfnResourceFactory()
+        .create("Recipe", deployedResourceObject(resource), {
+          simAws,
+          resources: deployedStackObject(stack).resourceMap,
+        });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Unsupported sim Personalize CloudFormation Resource Recipe",
+    );
+  });
+
+  it("refuses deleting a Personalize Resource type it does not simulate", async () => {
+    // Given a deployed dataset group, and the factory that made it.
+    const { simAws, resource } = await deployedDatasetGroup();
+
+    // When the factory is asked to delete a type it never creates.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .personalize()
+        .cfnResourceFactory()
+        .delete("MetricAttribution", deployedResourceObject(resource));
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Unsupported sim Personalize CloudFormation Resource " +
+        "MetricAttribution deletion",
+    );
+  });
+
+  it("names the Resource in a refusal simulated Personalize made", async () => {
+    // When a Personalize error is raised while a Resource is being created.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simCfnPersonalizeResourceCreation(
+        "AWS::Personalize::Solution",
+        "RelatedItems",
+        () => {
+          throw new SimPersonalizeResourceNotFoundException(
+            "Personalize can't find the dataset group 'catalogue'",
+          );
+        },
+      );
+    });
+
+    // Then it is renamed to say which Resource asked, since Personalize's own
+    // message says nothing about where the request came from.
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::Personalize::Solution Resource RelatedItems",
+    );
+    assertStringIncludes(error.message, "can't find the dataset group");
+  });
+
+  it("lets an error that is not Personalize's own through unchanged", async () => {
+    // Given something going wrong that simulated Personalize did not raise.
+    const raised = new TypeError("something else entirely");
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await simCfnPersonalizeResourceCreation(
+        "AWS::Personalize::Schema",
+        "Interactions",
+        () => {
+          throw raised;
+        },
+      );
+    });
+
+    // Then it is not renamed. Only Personalize's own refusals are worth
+    // attributing to a Resource, and anything else is a bug that should read
+    // like one.
+    assertInstanceOf(error, TypeError);
+    assertIdentical(error, raised);
+  });
+
+  it("refuses a dataset group with no Name, in Personalize's own words", async () => {
+    // Given a template leaving the Name off, which CloudFormation requires and
+    // has no way to generate for a Personalize resource.
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployedDatasetGroup({});
+    });
+
+    // Then the refusal is the one CreateDatasetGroup gives an SDK caller, with
+    // the Resource that asked named alongside it.
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::Personalize::DatasetGroup Resource Catalogue",
+    );
+    assertStringIncludes(error.message, "A dataset group needs a name");
+  });
+
+  it("refuses a domain Personalize does not have", async () => {
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployedDatasetGroup({ Name: "catalogue", Domain: "GROCERY" });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "'GROCERY' is not a Personalize domain",
+    );
+  });
+
+  it("refuses a Name that is not a string", async () => {
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployedDatasetGroup({ Name: 42 });
+    });
+
+    assertStringIncludes(error.message, "Name must be a string");
+  });
+
+  it("refuses an attribute AWS::Personalize::DatasetGroup does not have", async () => {
+    // Given a template reading the ARN off the group under the name another
+    // Personalize type publishes it as.
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployWithAttribute("SolutionArn");
+    });
+
+    // Then the deploy fails. Answering it would let a template deploy here and
+    // fail on AWS.
+    assertStringIncludes(
+      error.message,
+      "Unsupported AWS::Personalize::DatasetGroup attribute SolutionArn",
+    );
+  });
+
+  it("records a property no AWS::Personalize::Schema has", async () => {
+    // Given a template misspelling the only property that matters.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "catalogue-stack",
+      template: {
+        Resources: {
+          InteractionsSchema: {
+            Type: "AWS::Personalize::Schema",
+            Properties: { Name: "interactions", Schema: "{}", Domainn: "X" },
+          },
+        },
+      },
+    });
+
+    // Then the schema deployed with the stray property recorded. Real
+    // CloudFormation refuses it, and a stack failing over a property that
+    // arrived last week is a worse way to find out.
+    assertIdentical(
+      stack.ignoredProperties[0]?.reason,
+      "Domainn is not a property simulated Personalize reads from " +
+        "AWS::Personalize::Schema",
+    );
+  });
+});
+
+describe("AWS::Personalize::Solution property types", () => {
+  it("reads a boolean CloudFormation carried as a string", async () => {
+    // Given a template whose switches came through as strings, which is what a
+    // String Parameter or an Fn::Sub leaves behind.
+    const simAws = new SimAws();
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "catalogue-stack",
+      template: {
+        Resources: {
+          Catalogue: {
+            Type: "AWS::Personalize::DatasetGroup",
+            Properties: { Name: "catalogue" },
+          },
+          RelatedItems: {
+            Type: "AWS::Personalize::Solution",
+            Properties: {
+              Name: "related-items",
+              DatasetGroupArn: {
+                "Fn::GetAtt": ["Catalogue", "DatasetGroupArn"],
+              },
+              PerformAutoML: "false",
+              PerformHPO: true,
+            },
+          },
+        },
+      },
+    });
+
+    // Then each is the boolean it stands for. Storing the string would read
+    // back as configured and mean the opposite of what it says.
+    const solution = simAws.personalize().findSolution("related-items");
+
+    assertNonNullable(solution);
+    assertFalse(solution.performAutoML);
+    assertTrue(solution.performHPO);
+  });
+
+  it("refuses a switch that is neither a boolean nor true or false", async () => {
+    const error = await assertThrowsErrorAsync(async () => {
+      await new SimAws().cloudFormation().deployTemplate({
+        stackName: "catalogue-stack",
+        template: {
+          Resources: {
+            RelatedItems: {
+              Type: "AWS::Personalize::Solution",
+              Properties: { Name: "related-items", PerformHPO: 3 },
+            },
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(error.message, "PerformHPO must be a boolean");
+  });
+});

--- a/src/service/personalize/cfn/sim-cfn-personalize-resource-types.ts
+++ b/src/service/personalize/cfn/sim-cfn-personalize-resource-types.ts
@@ -1,0 +1,29 @@
+/**
+ * The CloudFormation Resource types simulated Personalize creates.
+ *
+ * Named here rather than spelled out where they are used, because each one is
+ * written twice. Once by the factory dispatching on it, and once by the creator
+ * that quotes it back to whoever wrote the template.
+ */
+export const personalizeDatasetGroupResourceType =
+  "AWS::Personalize::DatasetGroup";
+
+export const personalizeSchemaResourceType = "AWS::Personalize::Schema";
+
+export const personalizeDatasetResourceType = "AWS::Personalize::Dataset";
+
+export const personalizeSolutionResourceType = "AWS::Personalize::Solution";
+
+export const personalizeEventTrackerResourceType =
+  "AWS::Personalize::EventTracker";
+
+/** The type name the CloudFormation layer dispatches on, without its prefix. */
+export const personalizeDatasetGroupResourceTypeName = "DatasetGroup";
+
+export const personalizeSchemaResourceTypeName = "Schema";
+
+export const personalizeDatasetResourceTypeName = "Dataset";
+
+export const personalizeSolutionResourceTypeName = "Solution";
+
+export const personalizeEventTrackerResourceTypeName = "EventTracker";

--- a/src/service/personalize/cfn/sim-cfn-personalize-resources.iso.test.ts
+++ b/src/service/personalize/cfn/sim-cfn-personalize-resources.iso.test.ts
@@ -1,0 +1,325 @@
+import {
+  DeleteStackCommand,
+  UpdateStackCommand,
+} from "@aws-sdk/client-cloudformation";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { jsonStringify } from "../../../util/type-guard/json.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnDeployedStack } from "../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
+import type { CfnTemplateBodyRecord } from "../../cloudformation/template/sim-cfn-template.js";
+
+const similarItemsRecipe = "arn:aws:personalize:::recipe/aws-similar-items";
+
+const userPersonalizationRecipe =
+  "arn:aws:personalize:::recipe/aws-user-personalization-v2";
+
+const interactionsSchema = jsonStringify({
+  type: "record",
+  name: "Interactions",
+  fields: [
+    { name: "USER_ID", type: "string" },
+    { name: "ITEM_ID", type: "string" },
+    { name: "TIMESTAMP", type: "long" },
+  ],
+});
+
+/**
+ * The whole chain a template can declare, with the recipe left open so an
+ * update has something to change.
+ */
+function catalogueTemplate(recipeArn: string): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      Catalogue: {
+        Type: "AWS::Personalize::DatasetGroup",
+        Properties: { Name: "catalogue" },
+      },
+      InteractionsSchema: {
+        Type: "AWS::Personalize::Schema",
+        Properties: { Name: "interactions", Schema: interactionsSchema },
+      },
+      Views: {
+        Type: "AWS::Personalize::Dataset",
+        Properties: {
+          Name: "views",
+          DatasetType: "Interactions",
+          DatasetGroupArn: { "Fn::GetAtt": ["Catalogue", "DatasetGroupArn"] },
+          SchemaArn: { "Fn::GetAtt": ["InteractionsSchema", "SchemaArn"] },
+        },
+      },
+      RelatedItems: {
+        Type: "AWS::Personalize::Solution",
+        Properties: {
+          Name: "related-items",
+          DatasetGroupArn: { "Fn::GetAtt": ["Catalogue", "DatasetGroupArn"] },
+          RecipeArn: recipeArn,
+        },
+      },
+      CatalogueEvents: {
+        Type: "AWS::Personalize::EventTracker",
+        Properties: {
+          Name: "catalogue-events",
+          DatasetGroupArn: { "Fn::GetAtt": ["Catalogue", "DatasetGroupArn"] },
+        },
+      },
+    },
+    Outputs: {
+      GroupRef: { Value: { Ref: "Catalogue" } },
+      GroupArn: { Value: { "Fn::GetAtt": ["Catalogue", "DatasetGroupArn"] } },
+      SchemaRef: { Value: { Ref: "InteractionsSchema" } },
+      SchemaArn: {
+        Value: { "Fn::GetAtt": ["InteractionsSchema", "SchemaArn"] },
+      },
+      DatasetRef: { Value: { Ref: "Views" } },
+      DatasetArn: { Value: { "Fn::GetAtt": ["Views", "DatasetArn"] } },
+      SolutionRef: { Value: { Ref: "RelatedItems" } },
+      SolutionArn: { Value: { "Fn::GetAtt": ["RelatedItems", "SolutionArn"] } },
+      TrackerRef: { Value: { Ref: "CatalogueEvents" } },
+      TrackerArn: {
+        Value: { "Fn::GetAtt": ["CatalogueEvents", "EventTrackerArn"] },
+      },
+      TrackingId: {
+        Value: { "Fn::GetAtt": ["CatalogueEvents", "TrackingId"] },
+      },
+    },
+  };
+}
+
+/** One Stack Output, which every one in these templates is a string. */
+function outputValue(stack: SimCfnDeployedStack, name: string): string {
+  const value = stack.outputs.get(name)?.value;
+
+  assertTypeString(value);
+
+  return value;
+}
+
+async function deployCatalogue(): Promise<{
+  readonly simAws: SimAws;
+  readonly stack: SimCfnDeployedStack;
+}> {
+  const simAws = new SimAws();
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "catalogue-stack",
+    template: catalogueTemplate(similarItemsRecipe),
+  });
+
+  return { simAws, stack };
+}
+
+describe("AWS::Personalize Resources a template declares", () => {
+  it("deploys the whole chain a template declares", async () => {
+    // Given a template declaring a dataset group, a schema, a dataset, a
+    // solution and an event tracker.
+    const { simAws, stack } = await deployCatalogue();
+
+    // Then every one of them is simulated Personalize state, rather than a
+    // Resource the stack stepped over.
+    const personalize = simAws.personalize();
+
+    assertArrayLength(stack.skippedResources, 0);
+    assertNonNullable(personalize.findDatasetGroup("catalogue"));
+    assertNonNullable(personalize.findSolution("related-items"));
+
+    const listed = await personalize.listDatasets({ input: {} });
+
+    assertArrayLength(listed.datasets, 1);
+    assertIdentical(listed.datasets[0].name, "views");
+  });
+
+  it("answers a Ref with the name and a GetAtt with the ARN", async () => {
+    // Given the deployed chain, whose outputs read both off every Resource.
+    const { stack } = await deployCatalogue();
+
+    // Then each Ref is the resource name, which is the way round real
+    // Personalize publishes them.
+    assertIdentical(outputValue(stack, "GroupRef"), "catalogue");
+    assertIdentical(outputValue(stack, "SchemaRef"), "interactions");
+    assertIdentical(outputValue(stack, "DatasetRef"), "views");
+    assertIdentical(outputValue(stack, "SolutionRef"), "related-items");
+    assertIdentical(outputValue(stack, "TrackerRef"), "catalogue-events");
+
+    // And each GetAtt is the ARN of the resource that was created.
+    assertStringIncludes(
+      outputValue(stack, "GroupArn"),
+      ":dataset-group/catalogue",
+    );
+    assertStringIncludes(
+      outputValue(stack, "SchemaArn"),
+      ":schema/interactions",
+    );
+    assertStringIncludes(
+      outputValue(stack, "DatasetArn"),
+      ":dataset/catalogue/INTERACTIONS",
+    );
+    assertStringIncludes(
+      outputValue(stack, "SolutionArn"),
+      ":solution/related-items",
+    );
+    assertStringIncludes(
+      outputValue(stack, "TrackerArn"),
+      ":event-tracker/catalogue-events",
+    );
+  });
+
+  it("deploys a solution after the dataset group it names", async () => {
+    // Given the deployed chain, where the solution reaches its group through
+    // an Fn::GetAtt.
+    const { simAws } = await deployCatalogue();
+
+    // Then the solution is on the group the template pointed it at. A solution
+    // deployed before its group would have been refused outright, since
+    // CreateSolution resolves the ARN.
+    const datasetGroup = simAws.personalize().findDatasetGroup("catalogue");
+    const solution = simAws.personalize().findSolution("related-items");
+
+    assertNonNullable(datasetGroup);
+    assertNonNullable(solution);
+    assertIdentical(solution.datasetGroupArn, datasetGroup.arn);
+    assertIdentical(solution.recipeArn, similarItemsRecipe);
+  });
+
+  it("gives the event tracker a tracking ID PutEvents can name", async () => {
+    // Given the deployed chain, whose tracking ID is an output.
+    const { simAws, stack } = await deployCatalogue();
+    const trackingId = outputValue(stack, "TrackingId");
+
+    // Then it is the tracking ID of the tracker the stack made, which is what
+    // a PutEvents request carries.
+    const described = await simAws.personalize().describeEventTracker({
+      input: { eventTrackerArn: outputValue(stack, "TrackerArn") },
+    });
+
+    assertIdentical(described.eventTracker?.trackingId, trackingId);
+  });
+
+  it("deploys a dataset group declaring a domain as a domain group", async () => {
+    // Given a template declaring the domain, which is what makes a group a
+    // Domain dataset group rather than a custom one.
+    const simAws = new SimAws();
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "storefront-stack",
+      template: {
+        Resources: {
+          Storefront: {
+            Type: "AWS::Personalize::DatasetGroup",
+            Properties: {
+              Name: "storefront",
+              Domain: "ECOMMERCE",
+              RoleArn: "arn:aws:iam::123456789012:role/personalize",
+              KmsKeyArn: "arn:aws:kms:eu-west-2:123456789012:key/abc",
+            },
+          },
+        },
+      },
+    });
+
+    // Then the domain, the role and the key are all on the group.
+    const datasetGroup = simAws.personalize().findDatasetGroup("storefront");
+
+    assertNonNullable(datasetGroup);
+    assertIdentical(datasetGroup.domain, "ECOMMERCE");
+    assertIdentical(
+      datasetGroup.roleArn,
+      "arn:aws:iam::123456789012:role/personalize",
+    );
+    assertIdentical(
+      datasetGroup.kmsKeyArn,
+      "arn:aws:kms:eu-west-2:123456789012:key/abc",
+    );
+  });
+
+  it("records a Tags property rather than acting on it", async () => {
+    // Given a template tagging the dataset group it declares.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "catalogue-stack",
+      template: {
+        Resources: {
+          Catalogue: {
+            Type: "AWS::Personalize::DatasetGroup",
+            Properties: {
+              Name: "catalogue",
+              Tags: [{ Key: "team", Value: "search" }],
+            },
+          },
+        },
+      },
+    });
+
+    // Then the group deployed, with the tag recorded as something it was
+    // created without. No simulated service reads a Personalize tag, and a
+    // whole template should not sink over one.
+    assertNonNullable(simAws.personalize().findDatasetGroup("catalogue"));
+    assertArrayEquals(
+      stack.ignoredProperties.map((property) => property.path),
+      ["Tags"],
+    );
+    assertIdentical(
+      stack.ignoredProperties[0]?.reason,
+      "no simulated service reads a Personalize resource tag",
+    );
+  });
+
+  it("replaces a solution the updated template changes the recipe of", async () => {
+    // Given the deployed chain on the similar items recipe.
+    const { simAws } = await deployCatalogue();
+    const cloudFormation = simAws.cloudFormation();
+
+    // When the stack is updated onto a different recipe.
+    const updated = catalogueTemplate(userPersonalizationRecipe);
+
+    await cloudFormation.updateStack(
+      new UpdateStackCommand({
+        StackName: "catalogue-stack",
+        TemplateBody: jsonStringify(updated),
+      }),
+    );
+    await cloudFormation.waitForStackUpdateComplete("catalogue-stack");
+    await simAws.backgroundTasksComplete();
+
+    // Then one solution stands, on the recipe the new template names.
+    const listed = await simAws.personalize().listSolutions({ input: {} });
+    const solution = simAws.personalize().findSolution("related-items");
+
+    assertArrayLength(listed.solutions, 1);
+    assertNonNullable(solution);
+    assertIdentical(solution.recipeArn, userPersonalizationRecipe);
+  });
+
+  it("removes all five when the stack is deleted", async () => {
+    // Given the deployed chain.
+    const { simAws } = await deployCatalogue();
+
+    // When the stack is deleted.
+    await simAws
+      .cloudFormation()
+      .deleteStack(new DeleteStackCommand({ StackName: "catalogue-stack" }));
+    await simAws.backgroundTasksComplete();
+
+    // Then nothing is left. Teardown runs in reverse dependency order, which
+    // is what Personalize needs: a dataset group holding a dataset, a solution
+    // or a tracker refuses to be deleted.
+    const personalize = simAws.personalize();
+    const groups = await personalize.listDatasetGroups({ input: {} });
+    const schemas = await personalize.listSchemas({ input: {} });
+    const datasets = await personalize.listDatasets({ input: {} });
+    const solutions = await personalize.listSolutions({ input: {} });
+    const trackers = await personalize.listEventTrackers({ input: {} });
+
+    assertArrayLength(groups.datasetGroups, 0);
+    assertArrayLength(schemas.schemas, 0);
+    assertArrayLength(datasets.datasets, 0);
+    assertArrayLength(solutions.solutions, 0);
+    assertArrayLength(trackers.eventTrackers, 0);
+  });
+});

--- a/src/service/personalize/cfn/sim-cfn-personalize-schema-creator.ts
+++ b/src/service/personalize/cfn/sim-cfn-personalize-schema-creator.ts
@@ -1,0 +1,72 @@
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimPersonalizeResources } from "../resource/sim-personalize-resources.js";
+import type { SimPersonalizeSchema } from "../resource/sim-personalize-schema.js";
+import type { SimPersonalize } from "../sim-personalize.js";
+import { simCfnPersonalizeCreated } from "./sim-cfn-personalize-created.js";
+import { SimCfnPersonalizeProperties } from "./sim-cfn-personalize-properties.js";
+import { simCfnPersonalizeResourceCreation } from "./sim-cfn-personalize-resource-error.js";
+import { personalizeSchemaResourceType } from "./sim-cfn-personalize-resource-types.js";
+
+const readProperties = new Set(["Name", "Schema", "Domain"]);
+
+interface SimCfnPersonalizeSchemaCreatorProperties {
+  readonly personalize: SimPersonalize;
+  readonly resources: SimPersonalizeResources;
+}
+
+/**
+ * Creates simulated schemas from AWS::Personalize::Schema Resources.
+ *
+ * `Schema` is the Avro document, written in a template as a JSON string. It is
+ * held as the string it arrived as and never parsed, the same as one an SDK
+ * caller passes to CreateSchema.
+ */
+export class SimCfnPersonalizeSchemaCreator {
+  readonly #personalize: SimPersonalize;
+  readonly #resources: SimPersonalizeResources;
+
+  constructor(properties: SimCfnPersonalizeSchemaCreatorProperties) {
+    this.#personalize = properties.personalize;
+    this.#resources = properties.resources;
+  }
+
+  /** Create a schema from an AWS::Personalize::Schema Resource. */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimPersonalizeSchema> {
+    const read = new SimCfnPersonalizeProperties({
+      resourceType: personalizeSchemaResourceType,
+      resource,
+      properties,
+      read: readProperties,
+    });
+    const input = {
+      name: read.string("Name"),
+      schema: read.string("Schema"),
+      domain: read.string("Domain"),
+    };
+
+    read.recordUnreadProperties();
+
+    return await simCfnPersonalizeResourceCreation(
+      personalizeSchemaResourceType,
+      resource.logicalId,
+      async () => {
+        const created = await this.#personalize.createSchema({ input });
+
+        return simCfnPersonalizeCreated(
+          this.#resources.schemas,
+          created.schemaArn,
+          "schema",
+        );
+      },
+    );
+  }
+
+  /** Delete a schema an AWS::Personalize::Schema Resource made. */
+  async delete(schema: SimPersonalizeSchema): Promise<void> {
+    await this.#personalize.deleteSchema({ input: { schemaArn: schema.arn } });
+  }
+}

--- a/src/service/personalize/cfn/sim-cfn-personalize-solution-creator.ts
+++ b/src/service/personalize/cfn/sim-cfn-personalize-solution-creator.ts
@@ -1,0 +1,94 @@
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimPersonalizeResources } from "../resource/sim-personalize-resources.js";
+import type { SimPersonalizeSolution } from "../resource/sim-personalize-solution.js";
+import type { SimPersonalize } from "../sim-personalize.js";
+import { simCfnPersonalizeCreated } from "./sim-cfn-personalize-created.js";
+import { SimCfnPersonalizeProperties } from "./sim-cfn-personalize-properties.js";
+import { simCfnPersonalizeResourceCreation } from "./sim-cfn-personalize-resource-error.js";
+import { personalizeSolutionResourceType } from "./sim-cfn-personalize-resource-types.js";
+
+const readProperties = new Set([
+  "Name",
+  "DatasetGroupArn",
+  "RecipeArn",
+  "EventType",
+  "PerformAutoML",
+  "PerformHPO",
+]);
+
+const unreadProperties = new Map([
+  [
+    "SolutionConfig",
+    "solution configuration tunes a training run, and simulated Personalize " +
+      "fits no model",
+  ],
+]);
+
+interface SimCfnPersonalizeSolutionCreatorProperties {
+  readonly personalize: SimPersonalize;
+  readonly resources: SimPersonalizeResources;
+}
+
+/**
+ * Creates simulated solutions from AWS::Personalize::Solution Resources.
+ *
+ * A solution is as far as a template reaches. CloudFormation has no
+ * `AWS::Personalize::SolutionVersion` type and no `AWS::Personalize::Campaign`
+ * type, so training and the endpoint that serves recommendations are always
+ * done outside the stack.
+ */
+export class SimCfnPersonalizeSolutionCreator {
+  readonly #personalize: SimPersonalize;
+  readonly #resources: SimPersonalizeResources;
+
+  constructor(properties: SimCfnPersonalizeSolutionCreatorProperties) {
+    this.#personalize = properties.personalize;
+    this.#resources = properties.resources;
+  }
+
+  /** Create a solution from an AWS::Personalize::Solution Resource. */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimPersonalizeSolution> {
+    const read = new SimCfnPersonalizeProperties({
+      resourceType: personalizeSolutionResourceType,
+      resource,
+      properties,
+      read: readProperties,
+      unread: unreadProperties,
+    });
+    const input = {
+      name: read.string("Name"),
+      datasetGroupArn: read.string("DatasetGroupArn"),
+      recipeArn: read.string("RecipeArn"),
+      eventType: read.string("EventType"),
+      performAutoML: read.boolean("PerformAutoML"),
+      performHPO: read.boolean("PerformHPO"),
+    };
+
+    read.recordUnreadProperties();
+
+    return await simCfnPersonalizeResourceCreation(
+      personalizeSolutionResourceType,
+      resource.logicalId,
+      async () => {
+        const created = await this.#personalize.createSolution({ input });
+
+        return simCfnPersonalizeCreated(
+          this.#resources.solutions,
+          created.solutionArn,
+          "solution",
+        );
+      },
+    );
+  }
+
+  /** Delete a solution an AWS::Personalize::Solution Resource made. */
+  async delete(solution: SimPersonalizeSolution): Promise<void> {
+    await this.#personalize.deleteSolution({
+      input: { solutionArn: solution.arn },
+    });
+  }
+}

--- a/src/service/personalize/cfn/sim-personalize-cfn-resource-factory.ts
+++ b/src/service/personalize/cfn/sim-personalize-cfn-resource-factory.ts
@@ -1,0 +1,168 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimPersonalizeResources } from "../resource/sim-personalize-resources.js";
+import type { SimPersonalize } from "../sim-personalize.js";
+import { SimCfnPersonalizeDatasetCreator } from "./sim-cfn-personalize-dataset-creator.js";
+import { SimCfnPersonalizeDatasetGroupCreator } from "./sim-cfn-personalize-dataset-group-creator.js";
+import { SimCfnPersonalizeEventTrackerCreator } from "./sim-cfn-personalize-event-tracker-creator.js";
+import {
+  personalizeDatasetGroupResourceTypeName,
+  personalizeDatasetResourceTypeName,
+  personalizeEventTrackerResourceTypeName,
+  personalizeSchemaResourceTypeName,
+  personalizeSolutionResourceTypeName,
+} from "./sim-cfn-personalize-resource-types.js";
+import { SimCfnPersonalizeSchemaCreator } from "./sim-cfn-personalize-schema-creator.js";
+import { SimCfnPersonalizeSolutionCreator } from "./sim-cfn-personalize-solution-creator.js";
+
+interface SimPersonalizeCfnResourceFactoryProperties {
+  readonly personalize: SimPersonalize;
+  readonly resources: SimPersonalizeResources;
+}
+
+/**
+ * What this factory does with one AWS::Personalize::* Resource type.
+ *
+ * Creating and deleting are held together rather than dispatched apart,
+ * because a type this factory can make is exactly a type it has to be able to
+ * remove, and two switches would be two places to keep in step.
+ */
+interface SimCfnPersonalizeResourceHandler {
+  create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<object>;
+  delete(resource: SimCfnResource): Promise<void>;
+}
+
+/**
+ * CloudFormation Resource factory for simulated Personalize resources.
+ *
+ * Dataset groups, schemas, datasets, solutions and event trackers are the
+ * AWS::Personalize::* Resource types this simulation models. They are the five
+ * an application declares. The other five types CloudFormation has cover batch
+ * inference, batch segments, data deletion, metric attribution and recipes, all
+ * of which work over data simulated Personalize never reads. A template
+ * declaring one of those is recorded as unsupported and stepped over.
+ */
+export class SimPersonalizeCfnResourceFactory implements SimCfnServiceResourceFactory {
+  readonly #handlers: ReadonlyMap<string, SimCfnPersonalizeResourceHandler>;
+
+  constructor(properties: SimPersonalizeCfnResourceFactoryProperties) {
+    this.#handlers = new Map([
+      [
+        personalizeDatasetGroupResourceTypeName,
+        handler(
+          new SimCfnPersonalizeDatasetGroupCreator(properties),
+          "dataset group",
+        ),
+      ],
+      [
+        personalizeSchemaResourceTypeName,
+        handler(new SimCfnPersonalizeSchemaCreator(properties), "schema"),
+      ],
+      [
+        personalizeDatasetResourceTypeName,
+        handler(new SimCfnPersonalizeDatasetCreator(properties), "dataset"),
+      ],
+      [
+        personalizeSolutionResourceTypeName,
+        handler(new SimCfnPersonalizeSolutionCreator(properties), "solution"),
+      ],
+      [
+        personalizeEventTrackerResourceTypeName,
+        handler(
+          new SimCfnPersonalizeEventTrackerCreator(properties),
+          "event tracker",
+        ),
+      ],
+    ]);
+  }
+
+  /**
+   * Create a simulated Personalize resource from a CloudFormation Resource.
+   */
+  async create(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<object | undefined> {
+    return await this.handler(resourceTypeName, "").create(
+      resource,
+      context.resolvedProperties ?? resource.properties,
+    );
+  }
+
+  /**
+   * Delete a simulated Personalize resource created from a CloudFormation
+   * Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+  ): Promise<void> {
+    await this.handler(resourceTypeName, " deletion").delete(resource);
+  }
+
+  private handler(
+    resourceTypeName: string,
+    operationSuffix: string,
+  ): SimCfnPersonalizeResourceHandler {
+    const handler = this.#handlers.get(resourceTypeName);
+
+    assertDefined(
+      handler,
+      `Unsupported sim Personalize CloudFormation Resource ` +
+        `${resourceTypeName}${operationSuffix}`,
+    );
+
+    return handler;
+  }
+}
+
+/**
+ * Adapt one creator to the handler this factory dispatches to.
+ *
+ * The delete side is where the type comes back. A Resource carries whatever its
+ * creator made as an opaque object, and this is the one place that knows which
+ * creator made which.
+ */
+function handler<T extends object>(
+  creator: {
+    create(
+      resource: SimCfnResource,
+      properties: SimCfnTemplateValueRecord,
+    ): Promise<T>;
+    delete(created: T): Promise<void>;
+  },
+  described: string,
+): SimCfnPersonalizeResourceHandler {
+  return {
+    create: async (resource, properties): Promise<T> =>
+      await creator.create(resource, properties),
+    delete: async (resource): Promise<void> => {
+      await creator.delete(created<T>(resource, described));
+    },
+  };
+}
+
+function created<T extends object>(
+  resource: SimCfnResource,
+  described: string,
+): T {
+  const simResource = resource.simResource as T | undefined;
+
+  assertDefined(
+    simResource,
+    `sim Personalize ${described} for CloudFormation Resource ${
+      resource.logicalId
+    }`,
+  );
+
+  return simResource;
+}

--- a/src/service/personalize/sim-personalize.ts
+++ b/src/service/personalize/sim-personalize.ts
@@ -1,4 +1,5 @@
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
+import { SimPersonalizeCfnResourceFactory } from "./cfn/sim-personalize-cfn-resource-factory.js";
 import type { SimPersonalizeRecordedEvent } from "./event/sim-personalize-recorded-event.js";
 import type { SimPersonalizeRecordedItem } from "./event/sim-personalize-recorded-item.js";
 import type { SimPersonalizeRecordedUser } from "./event/sim-personalize-recorded-user.js";
@@ -33,6 +34,11 @@ import { SimPersonalizeRuntime } from "./sim-personalize-runtime.js";
  */
 export class SimPersonalize extends SimPersonalizeControlPlane {
   private readonly sdkRouter = new SimPersonalizeSdkCommandRouter(this);
+  private readonly cfnFactory = new SimPersonalizeCfnResourceFactory({
+    personalize: this,
+    resources: this.resources,
+  });
+
   private readonly runtimeApi = new SimPersonalizeRuntime({
     recommendations: this.commands.recommendations,
     rankings: this.commands.rankings,
@@ -125,6 +131,16 @@ export class SimPersonalize extends SimPersonalizeControlPlane {
   /** Find a campaign by name. */
   findCampaign(name: string): SimPersonalizeCampaign | undefined {
     return this.resources.campaigns.findByName(name);
+  }
+
+  /**
+   * The CloudFormation Resource factory for this simulated Personalize.
+   *
+   * It deploys through the commands above, so a Resource and an SDK caller
+   * asking for the same thing are answered the same way.
+   */
+  cfnResourceFactory(): SimPersonalizeCfnResourceFactory {
+    return this.cfnFactory;
   }
 
   /** The SDK Command router for this simulated Personalize. */


### PR DESCRIPTION
AWS::Personalize::DatasetGroup, Schema, Dataset, Solution and EventTracker now deploy into simulated Personalize through the same create commands an SDK caller reaches. A template and an SDK caller are validated in one place and get the same ARN. `Ref` answers with the resource name and `Fn::GetAtt` with the ARN each type publishes, which is the way round real Personalize has them, and an event tracker publishes its `TrackingId` too. The five job, metric and recipe types are recorded in `stack.skippedResources` under a reason naming the type rather than failing the stack. `AWS::Personalize::EventTracker` is folded in here rather than left for the events issue, which has since merged without covering CloudFormation. That left the type with no home, and it is one more entry over machinery the other four already needed. The docs now say plainly that CloudFormation has no `AWS::Personalize::Campaign` or `Recommender` type. A deployed stack stops at the solution, and a test creates the solution version and the campaign itself.

Resolves https://github.com/KensioSoftware/yulin/issues/901
