### PR TITLE
fix: refuse a logical statement joining one

### DIFF
--- a/docs/services/wafv2/README.md
+++ b/docs/services/wafv2/README.md
@@ -171,6 +171,10 @@ The tests are `ByteMatchStatement` (with `EXACTLY`, `STARTS_WITH`, `ENDS_WITH`, 
 `SizeConstraintStatement`. `AndStatement`, `OrStatement` and `NotStatement` join and negate them,
 and they nest.
 
+An `AndStatement` or an `OrStatement` needs at least two statements to join. Real WAF answers a web
+ACL holding one that joins fewer with `OR_STATEMENT` and a minimum threshold, refusing the whole
+resource, and `CreateWebACL` here refuses it too.
+
 Matching is case sensitive, as it is on AWS. A rule that means to ignore case says so with a
 `LOWERCASE` transformation and a lower case search string.
 

--- a/src/service/wafv2/README.md
+++ b/src/service/wafv2/README.md
@@ -137,7 +137,10 @@ The pieces underneath it each answer one question about a statement:
 - `sim-waf-match-pattern.ts` reads which headers or cookies a rule selects.
 - `sim-waf-byte-match.ts`, `sim-waf-regex-match.ts` and `sim-waf-size-constraint.ts` are the three
   tests a field is put through.
-- `sim-waf-logical-statement.ts` joins and negates the others.
+- `sim-waf-logical-statement.ts` joins and negates the others. Fewer than two statements to
+  join is refused, and so is a `NotStatement` with nothing to negate. Real WAF refuses the
+  whole web ACL for a one-statement `OrStatement`, and a simulation that evaluated it would
+  pass a shape no deployment takes (#907).
 
 `sim-waf-field-content.ts` is where the inspection limit lives. WAF stops reading a body, a header
 set or a cookie set at 8 KB, and the rule says what content past that point counts as. `MATCH` and

--- a/src/service/wafv2/sim-wafv2-capacity.iso.test.ts
+++ b/src/service/wafv2/sim-wafv2-capacity.iso.test.ts
@@ -182,14 +182,19 @@ describe("What a simulated web ACL costs in capacity units", () => {
   });
 
   it("adds up the statements inside a logical statement", async () => {
-    // Given a rule joining three statements, one of them negated.
+    // Given a rule joining three statements, one of them negated and one of
+    // them joining two more.
     const capacity = await capacityOf([
       ruleWith({
         AndStatement: {
           Statements: [
             byteMatch("EXACTLY"),
             { NotStatement: { Statement: byteMatch("EXACTLY") } },
-            { OrStatement: { Statements: [byteMatch("CONTAINS")] } },
+            {
+              OrStatement: {
+                Statements: [byteMatch("CONTAINS"), byteMatch("EXACTLY")],
+              },
+            },
           ],
         },
       }),
@@ -197,7 +202,7 @@ describe("What a simulated web ACL costs in capacity units", () => {
 
     // Then it costs what its parts cost. A logical statement has no base cost
     // of its own.
-    assertIdentical(capacity, 14);
+    assertIdentical(capacity, 16);
   });
 
   it("charges a managed rule group at the capacity AWS fixed it at", async () => {

--- a/src/service/wafv2/statement/sim-waf-logical-statement.ts
+++ b/src/service/wafv2/statement/sim-waf-logical-statement.ts
@@ -17,22 +17,39 @@ export function compileSimWafLogicalStatement(
   scope: SimWafStatementScope,
 ): SimWafMatcher {
   if (statement.AndStatement !== undefined) {
-    const matchers = compileAll(statement.AndStatement.Statements, scope);
+    const matchers = compileAll(
+      "AndStatement",
+      statement.AndStatement.Statements,
+      scope,
+    );
 
     return (request): boolean => matchers.every((matches) => matches(request));
   }
 
   if (statement.OrStatement !== undefined) {
-    const matchers = compileAll(statement.OrStatement.Statements, scope);
+    const matchers = compileAll(
+      "OrStatement",
+      statement.OrStatement.Statements,
+      scope,
+    );
 
     return (request): boolean => matchers.some((matches) => matches(request));
   }
 
   if (statement.NotStatement !== undefined) {
-    const matches = compileSimWafStatement(
-      statement.NotStatement.Statement,
-      scope,
-    );
+    const negated = statement.NotStatement.Statement;
+
+    // Named here rather than left to `compileSimWafStatement`, which would
+    // report the rule as having no statement at all and send the reader to the
+    // wrong place in a rule holding several.
+    if (negated === undefined) {
+      invalidSimWafRule(
+        scope.ruleName,
+        "A NotStatement needs the one statement it negates",
+      );
+    }
+
+    const matches = compileSimWafStatement(negated, scope);
 
     return (request): boolean => !matches(request);
   }
@@ -41,23 +58,27 @@ export function compileSimWafLogicalStatement(
 }
 
 /**
- * Compile the statements a logical statement joins, refusing an empty list.
+ * Compile the statements a logical statement joins, refusing fewer than two.
  *
- * Real WAF requires at least two, and an `AndStatement` with none would
- * otherwise match every request while looking like it narrowed one.
+ * Real WAF holds this minimum hard enough to refuse the whole web ACL over it,
+ * answering `OR_STATEMENT` and a threshold setting. A rule joining one
+ * statement evaluates as that statement on its own, and an `AndStatement` with
+ * an empty list would match every request while looking like it narrowed one.
  */
 function compileAll(
+  kind: "AndStatement" | "OrStatement",
   statements: readonly SimWafStatementInput[] | undefined,
   scope: SimWafStatementScope,
 ): readonly SimWafMatcher[] {
-  if (statements === undefined || statements.length === 0) {
+  const joined = statements ?? [];
+
+  if (joined.length < 2) {
     invalidSimWafRule(
       scope.ruleName,
-      "An AndStatement or OrStatement needs statements to join",
+      `An ${kind} needs at least two statements to join, and this one has ` +
+        `${joined.length}`,
     );
   }
 
-  return statements.map((statement) =>
-    compileSimWafStatement(statement, scope),
-  );
+  return joined.map((statement) => compileSimWafStatement(statement, scope));
 }

--- a/src/service/wafv2/statement/sim-waf-statements.iso.test.ts
+++ b/src/service/wafv2/statement/sim-waf-statements.iso.test.ts
@@ -238,15 +238,59 @@ describe("SimWafV2 statement kinds", () => {
     // Given a simulated WAFv2.
     const waf = new SimAws().wafV2();
 
-    // When a rule joins an empty list of statements.
-    const error = await assertThrowsErrorAsync(async () => {
+    // When one rule joins an empty list of statements and another leaves the
+    // list out altogether.
+    const empty = await assertThrowsErrorAsync(async () => {
       await simWafStatementMatches(waf, { AndStatement: { Statements: [] } });
     });
+    const absent = await assertThrowsErrorAsync(async () => {
+      await simWafStatementMatches(waf, { AndStatement: {} });
+    });
 
-    // Then it is refused rather than claiming every request, which is what an
-    // empty `every` would do.
+    // Then both are refused rather than claiming every request, which is what
+    // an empty `every` would do.
+    assertInstanceOf(empty, SimWafInvalidParameterException);
+    assertInstanceOf(absent, SimWafInvalidParameterException);
+    assertStringIncludes(empty.message, "statements to join");
+    assertStringIncludes(absent.message, "has 0");
+  });
+
+  it.each([
+    ["AndStatement", { AndStatement: { Statements: [pathIs("/admin")] } }],
+    ["OrStatement", { OrStatement: { Statements: [pathIs("/admin")] } }],
+  ] as const)(
+    "refuses a %s joining only one statement",
+    async (kind, statement) => {
+      // Given a simulated WAFv2.
+      const waf = new SimAws().wafV2();
+
+      // When a rule joins a single statement.
+      const error = await assertThrowsErrorAsync(async () => {
+        await simWafStatementMatches(waf, statement);
+      });
+
+      // Then it is refused, as real WAF refuses the whole web ACL for it. A
+      // rule evaluating the one statement would pass a shape no deployment
+      // takes.
+      assertInstanceOf(error, SimWafInvalidParameterException);
+      assertStringIncludes(error.message, `An ${kind} needs at least two`);
+      assertStringIncludes(error.message, "has 1");
+    },
+  );
+
+  it("refuses a NotStatement with nothing to negate", async () => {
+    // Given a simulated WAFv2.
+    const waf = new SimAws().wafV2();
+
+    // When a rule negates a statement it left out.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simWafStatementMatches(waf, { NotStatement: {} });
+    });
+
+    // Then the refusal names the NotStatement, which is where the reader has
+    // to go and look.
     assertInstanceOf(error, SimWafInvalidParameterException);
-    assertStringIncludes(error.message, "statements to join");
+    assertStringIncludes(error.message, "NotStatement needs the one statement");
   });
 
   it("refuses a rule whose statement names no kind", async () => {


### PR DESCRIPTION
An `AndStatement` or an `OrStatement` joining one statement is now refused where the empty-list case already was, in `compileAll`. Real WAF refuses the whole web ACL for that shape, answering `OR_STATEMENT` and a minimum threshold setting, and a simulation that evaluated the rule passed a shape no deployment takes.

The refusal names the statement kind and the count it found, because a web ACL is a list of rules that look alike from the outside. A `NotStatement` with nothing to negate is refused under its own wording too. Before this it fell through to `compileSimWafStatement`, which reported the rule as having no statement at all and sent the reader to the wrong place in a rule holding several.

One existing case moved. The capacity test nested a one-statement `OrStatement` inside an `AndStatement`, which the new refusal rejects. That nested statement gained a second byte match, and the expected capacity went from 14 to 16. What the case asserts is unchanged. A logical statement costs what its parts cost and carries no base cost of its own.

Resolves https://github.com/KensioSoftware/yulin/issues/907

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for web ACL logical statements.
  * `AndStatement` and `OrStatement` now require at least two nested statements.
  * `NotStatement` now requires a nested statement.
  * Invalid configurations produce clearer validation errors.

* **Documentation**
  * Updated WAF documentation to describe logical statement requirements and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->