### PR TITLE
feat: answer Bedrock invocations from declared responses

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ behaviour and includes example code that can be copied into tests or local devel
 - [ACM](./services/acm/ "Simulated ACM usage docs")
 - [API Gateway HTTP APIs](./services/apigatewayv2/ "Simulated API Gateway HTTP API usage docs")
 - [API Gateway REST APIs](./services/apigateway/ "Simulated API Gateway REST API usage docs")
+- [Bedrock](./services/bedrock/ "Simulated Amazon Bedrock usage docs")
 - [CloudFormation](./services/cloudformation/ "Simulated CloudFormation usage docs")
 - [CloudFront](./services/cloudfront/ "Simulated CloudFront usage docs")
 - [CloudWatch metrics](./services/cloudwatch/ "Simulated CloudWatch metrics usage docs")

--- a/docs/services/bedrock/README.md
+++ b/docs/services/bedrock/README.md
@@ -1,0 +1,280 @@
+# Simulated Bedrock
+
+Simulated Bedrock answers model invocations from responses declared against a prompt or a model. A
+test says what the model says, and no model runs.
+
+Bedrock-specific types are imported from the `@kensio/yulin/bedrock` subpath.
+
+## Answering a conversation
+
+`Converse` answers with the response declared for the prompt it carries. The prompt is the text of
+the last user message.
+
+```typescript sim-bedrock-converse
+/**
+ * Declaring what a model answers one prompt with, and conversing with it.
+ */
+
+import { ConverseCommand } from "@aws-sdk/client-bedrock-runtime";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+simAws.bedrock().responses().onPrompt("Summarise entry 1042", {
+  text: "Entry 1042 covers the tone sandhi rules.",
+});
+
+const answered = await simAws.bedrock().converse(
+  new ConverseCommand({
+    modelId: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+    messages: [{ role: "user", content: [{ text: "Summarise entry 1042" }] }],
+  }),
+);
+
+console.log(answered.output.message.content.at(0)?.text);
+// "Entry 1042 covers the tone sandhi rules."
+console.log(answered.stopReason); // "end_turn"
+```
+
+A conversation with several turns matches on its last user message, so a rule keeps matching as the
+conversation grows.
+
+## Answering every call to one model
+
+`onModel` covers every invocation of a model that no prompt rule matched first. This is the rule for
+a test that cares about the code around the call rather than about one exchange.
+
+```typescript sim-bedrock-model-rule
+/**
+ * Declaring one answer for every call to a model.
+ */
+
+import { ConverseCommand } from "@aws-sdk/client-bedrock-runtime";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+simAws
+  .bedrock()
+  .responses()
+  .onModel("amazon.nova-pro-v1:0", { text: "A short summary." });
+
+const answered = await simAws.bedrock().converse(
+  new ConverseCommand({
+    modelId: "amazon.nova-pro-v1:0",
+    messages: [{ role: "user", content: [{ text: "Anything at all" }] }],
+  }),
+);
+
+console.log(answered.output.message.content.at(0)?.text); // "A short summary."
+```
+
+`byDefault` covers everything else again. An invocation matching no rule at all answers with a
+built-in line of text that says it is simulated.
+
+## Answering with a tool call
+
+A declared response carries content blocks as they were written, so a tool call reaches the code
+that handles one. The response stops for `tool_use` unless the declaration names another reason.
+
+```typescript sim-bedrock-tool-use
+/**
+ * Declaring a tool call for the code under test to handle.
+ */
+
+import { ConverseCommand } from "@aws-sdk/client-bedrock-runtime";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+simAws
+  .bedrock()
+  .responses()
+  .onPrompt("What is in entry 1042?", {
+    content: [
+      {
+        toolUse: {
+          toolUseId: "tooluse-1",
+          name: "lookUpEntry",
+          input: { entryId: "1042" },
+        },
+      },
+    ],
+  });
+
+const answered = await simAws.bedrock().converse(
+  new ConverseCommand({
+    modelId: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+    messages: [{ role: "user", content: [{ text: "What is in entry 1042?" }] }],
+  }),
+);
+
+console.log(answered.stopReason); // "tool_use"
+console.log(answered.output.message.content.at(0)?.toolUse?.name);
+// "lookUpEntry"
+```
+
+## Invoking a model directly
+
+`InvokeModel` answers with the body declared for the request, serialized as JSON. The body is the
+shape the model behind the id uses, which is why there is no built-in default for it.
+
+```typescript sim-bedrock-invoke-model
+/**
+ * Declaring a model-specific response body and invoking the model.
+ */
+
+import { InvokeModelCommand } from "@aws-sdk/client-bedrock-runtime";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+simAws
+  .bedrock()
+  .responses()
+  .onModel("amazon.titan-text-express-v1", {
+    body: { results: [{ outputText: "Entry 1042 covers tone sandhi." }] },
+  });
+
+const answered = await simAws.bedrock().invokeModel(
+  new InvokeModelCommand({
+    modelId: "amazon.titan-text-express-v1",
+    body: JSON.stringify({ inputText: "Summarise entry 1042" }),
+  }),
+);
+
+console.log(JSON.parse(new TextDecoder().decode(answered.body)));
+// { results: [ { outputText: "Entry 1042 covers tone sandhi." } ] }
+```
+
+An `InvokeModel` request matches a prompt rule on its request body decoded as UTF-8. A model rule is
+usually the one to reach for.
+
+## Reporting token counts
+
+`usage` comes from the declaration, and a response that declares none reports fixed counts.
+
+```typescript sim-bedrock-usage
+/**
+ * Declaring what a response cost, for code that meters token spend.
+ */
+
+import { ConverseCommand } from "@aws-sdk/client-bedrock-runtime";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+simAws
+  .bedrock()
+  .responses()
+  .byDefault({
+    text: "A short summary.",
+    usage: { inputTokens: 1400, outputTokens: 220 },
+  });
+
+const answered = await simAws.bedrock().converse(
+  new ConverseCommand({
+    modelId: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+    messages: [{ role: "user", content: [{ text: "Summarise entry 1042" }] }],
+  }),
+);
+
+console.log(answered.usage.totalTokens); // 1620
+```
+
+## Authorizing an invocation
+
+An invocation authorizes `bedrock:InvokeModel` against the model it names. A base model id becomes a
+foundation model ARN for the Region the call was made in, and an inference profile ARN or a
+provisioned model ARN is authorized against as it was written.
+
+## SDK interception
+
+An intercepted `BedrockRuntimeClient` reaches the simulated Bedrock of the Account and Region the
+client is configured for.
+
+```typescript sim-bedrock-sdk-interception
+/**
+ * Answering production code that holds its own Bedrock Runtime client.
+ */
+
+import {
+  BedrockRuntimeClient,
+  ConverseCommand,
+} from "@aws-sdk/client-bedrock-runtime";
+
+import { SimSdk } from "@kensio/yulin/sdk";
+
+const simSdk = new SimSdk();
+simSdk.intercept(BedrockRuntimeClient);
+
+simSdk.simAws
+  .account()
+  .region("eu-west-2")
+  .bedrock()
+  .responses()
+  .byDefault({ text: "Entry 1042 covers the tone sandhi rules." });
+
+const client = new BedrockRuntimeClient({ region: "eu-west-2" });
+
+const answered = await client.send(
+  new ConverseCommand({
+    modelId: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+    messages: [{ role: "user", content: [{ text: "Summarise entry 1042" }] }],
+  }),
+);
+
+console.log(answered.output?.message?.content?.at(0)?.text);
+// "Entry 1042 covers the tone sandhi rules."
+
+client.destroy();
+simSdk.restoreAll();
+```
+
+## Available functionality
+
+- `Converse` and `InvokeModel`, through `simAws.bedrock()` and through an intercepted
+  `BedrockRuntimeClient`.
+- Responses declared with `onPrompt`, `onModel` and `byDefault`. A prompt rule wins, then a model
+  rule, then the default.
+- A declared response carries `text` or `content` blocks for `Converse`, a `body` for `InvokeModel`,
+  and optionally a `stopReason` and a `usage`.
+- Tool calls, as a declared `toolUse` content block.
+- IAM authorization of `bedrock:InvokeModel` against the foundation model, inference profile or
+  provisioned model ARN the request names.
+- Rules held per Account and Region, so two Regions answer the same prompt differently.
+
+## Limitations
+
+- No model runs. A response is whatever the matching rule declared, and the prompt is read only as
+  a key to match on.
+- `ConverseStream` and `InvokeModelWithResponseStream` are unsimulated.
+- The Bedrock control plane is unsimulated. `ListFoundationModels`, guardrail management, inference
+  profile management and provisioned throughput all belong to `BedrockClient`.
+- Bedrock Agents and knowledge bases are unsimulated. `InvokeAgent`, `Retrieve` and
+  `RetrieveAndGenerate` arrive on a client of their own.
+- `ApplyGuardrail` is unsimulated, and a `guardrailConfig` or a `guardrailIdentifier` on an
+  invocation is refused outright. Answering without the guardrail would make one look applied here
+  and be applied in production.
+- `system`, `inferenceConfig`, `toolConfig` and `additionalModelRequestFields` are accepted and
+  decide nothing. `maxTokens` truncates no declared response, and a `toolConfig` naming no tools
+  still gets a declared tool call.
+- Token counts are fixed unless the declaration carries them. Counting them needs the tokenizer of
+  the model the request names. Declare a `usage` where the code under test meters spend.
+- `metrics.latencyMs` is always zero. No time passes during an invocation.
+- The model id goes unchecked. AWS publishes no enumerable table of model ids, so refusing one would
+  be failing closed against Yulin's own gaps.
+- `InvokeModel` has no built-in default response body, and an invocation matching a rule that
+  declares none is refused. A response body is model-specific, and one family's shape served for
+  every other one would parse into something the caller cannot read.
+- An `InvokeModel` body that arrives as a stream or a Blob matches no prompt rule. Reading it would
+  consume the caller's own request body, so such a request falls through to a model rule or to the
+  default.
+- A `Converse` call matching a response declared only as a body is refused for the same reason,
+  rather than falling back to the default.
+- There are no CloudFormation resource types for Bedrock, and Bedrock is absent from `serveSimAws`.

--- a/docs/services/bedrock/README.md
+++ b/docs/services/bedrock/README.md
@@ -267,6 +267,8 @@ simSdk.restoreAll();
 - Token counts are fixed unless the declaration carries them. Counting them needs the tokenizer of
   the model the request names. Declare a `usage` where the code under test meters spend.
 - `metrics.latencyMs` is always zero. No time passes during an invocation.
+- A `Converse` with no messages is refused. Real Bedrock accepts one where the `modelId` names a
+  prompt version from Prompt management, which is unsimulated.
 - The model id goes unchecked. AWS publishes no enumerable table of model ids, so refusing one would
   be failing closed against Yulin's own gaps.
 - `InvokeModel` has no built-in default response body, and an invocation matching a rule that

--- a/docs/services/bedrock/sim-bedrock-converse.example.ts
+++ b/docs/services/bedrock/sim-bedrock-converse.example.ts
@@ -1,0 +1,24 @@
+/**
+ * Declaring what a model answers one prompt with, and conversing with it.
+ */
+
+import { ConverseCommand } from "@aws-sdk/client-bedrock-runtime";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+simAws.bedrock().responses().onPrompt("Summarise entry 1042", {
+  text: "Entry 1042 covers the tone sandhi rules.",
+});
+
+const answered = await simAws.bedrock().converse(
+  new ConverseCommand({
+    modelId: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+    messages: [{ role: "user", content: [{ text: "Summarise entry 1042" }] }],
+  }),
+);
+
+console.log(answered.output.message.content.at(0)?.text);
+// "Entry 1042 covers the tone sandhi rules."
+console.log(answered.stopReason); // "end_turn"

--- a/docs/services/bedrock/sim-bedrock-invoke-model.example.ts
+++ b/docs/services/bedrock/sim-bedrock-invoke-model.example.ts
@@ -1,0 +1,26 @@
+/**
+ * Declaring a model-specific response body and invoking the model.
+ */
+
+import { InvokeModelCommand } from "@aws-sdk/client-bedrock-runtime";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+simAws
+  .bedrock()
+  .responses()
+  .onModel("amazon.titan-text-express-v1", {
+    body: { results: [{ outputText: "Entry 1042 covers tone sandhi." }] },
+  });
+
+const answered = await simAws.bedrock().invokeModel(
+  new InvokeModelCommand({
+    modelId: "amazon.titan-text-express-v1",
+    body: JSON.stringify({ inputText: "Summarise entry 1042" }),
+  }),
+);
+
+console.log(JSON.parse(new TextDecoder().decode(answered.body)));
+// { results: [ { outputText: "Entry 1042 covers tone sandhi." } ] }

--- a/docs/services/bedrock/sim-bedrock-model-rule.example.ts
+++ b/docs/services/bedrock/sim-bedrock-model-rule.example.ts
@@ -1,0 +1,23 @@
+/**
+ * Declaring one answer for every call to a model.
+ */
+
+import { ConverseCommand } from "@aws-sdk/client-bedrock-runtime";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+simAws
+  .bedrock()
+  .responses()
+  .onModel("amazon.nova-pro-v1:0", { text: "A short summary." });
+
+const answered = await simAws.bedrock().converse(
+  new ConverseCommand({
+    modelId: "amazon.nova-pro-v1:0",
+    messages: [{ role: "user", content: [{ text: "Anything at all" }] }],
+  }),
+);
+
+console.log(answered.output.message.content.at(0)?.text); // "A short summary."

--- a/docs/services/bedrock/sim-bedrock-sdk-interception.example.ts
+++ b/docs/services/bedrock/sim-bedrock-sdk-interception.example.ts
@@ -1,0 +1,35 @@
+/**
+ * Answering production code that holds its own Bedrock Runtime client.
+ */
+
+import {
+  BedrockRuntimeClient,
+  ConverseCommand,
+} from "@aws-sdk/client-bedrock-runtime";
+
+import { SimSdk } from "@kensio/yulin/sdk";
+
+const simSdk = new SimSdk();
+simSdk.intercept(BedrockRuntimeClient);
+
+simSdk.simAws
+  .account()
+  .region("eu-west-2")
+  .bedrock()
+  .responses()
+  .byDefault({ text: "Entry 1042 covers the tone sandhi rules." });
+
+const client = new BedrockRuntimeClient({ region: "eu-west-2" });
+
+const answered = await client.send(
+  new ConverseCommand({
+    modelId: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+    messages: [{ role: "user", content: [{ text: "Summarise entry 1042" }] }],
+  }),
+);
+
+console.log(answered.output?.message?.content?.at(0)?.text);
+// "Entry 1042 covers the tone sandhi rules."
+
+client.destroy();
+simSdk.restoreAll();

--- a/docs/services/bedrock/sim-bedrock-tool-use.example.ts
+++ b/docs/services/bedrock/sim-bedrock-tool-use.example.ts
@@ -1,0 +1,35 @@
+/**
+ * Declaring a tool call for the code under test to handle.
+ */
+
+import { ConverseCommand } from "@aws-sdk/client-bedrock-runtime";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+simAws
+  .bedrock()
+  .responses()
+  .onPrompt("What is in entry 1042?", {
+    content: [
+      {
+        toolUse: {
+          toolUseId: "tooluse-1",
+          name: "lookUpEntry",
+          input: { entryId: "1042" },
+        },
+      },
+    ],
+  });
+
+const answered = await simAws.bedrock().converse(
+  new ConverseCommand({
+    modelId: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+    messages: [{ role: "user", content: [{ text: "What is in entry 1042?" }] }],
+  }),
+);
+
+console.log(answered.stopReason); // "tool_use"
+console.log(answered.output.message.content.at(0)?.toolUse?.name);
+// "lookUpEntry"

--- a/docs/services/bedrock/sim-bedrock-usage.example.ts
+++ b/docs/services/bedrock/sim-bedrock-usage.example.ts
@@ -1,0 +1,26 @@
+/**
+ * Declaring what a response cost, for code that meters token spend.
+ */
+
+import { ConverseCommand } from "@aws-sdk/client-bedrock-runtime";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+simAws
+  .bedrock()
+  .responses()
+  .byDefault({
+    text: "A short summary.",
+    usage: { inputTokens: 1400, outputTokens: 220 },
+  });
+
+const answered = await simAws.bedrock().converse(
+  new ConverseCommand({
+    modelId: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+    messages: [{ role: "user", content: [{ text: "Summarise entry 1042" }] }],
+  }),
+);
+
+console.log(answered.usage.totalTokens); // 1620

--- a/package.json
+++ b/package.json
@@ -55,6 +55,10 @@
       "import": "./dist/service/apigatewayv2/index.js",
       "types": "./dist/service/apigatewayv2/index.d.ts"
     },
+    "./bedrock": {
+      "import": "./dist/service/bedrock/index.js",
+      "types": "./dist/service/bedrock/index.d.ts"
+    },
     "./cloudformation": {
       "import": "./dist/service/cloudformation/index.js",
       "types": "./dist/service/cloudformation/index.d.ts"
@@ -197,6 +201,7 @@
     "@aws-sdk/client-acm": "^3.1101.0",
     "@aws-sdk/client-api-gateway": "^3.1112.0",
     "@aws-sdk/client-apigatewayv2": "^3.1101.0",
+    "@aws-sdk/client-bedrock-runtime": "^3.1115.0",
     "@aws-sdk/client-cloudformation": "^3.1101.0",
     "@aws-sdk/client-cloudfront": "^3.1101.0",
     "@aws-sdk/client-cloudfront-keyvaluestore": "^3.1108.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@aws-sdk/client-apigatewayv2':
         specifier: ^3.1101.0
         version: 3.1110.0
+      '@aws-sdk/client-bedrock-runtime':
+        specifier: ^3.1115.0
+        version: 3.1115.0
       '@aws-sdk/client-cloudformation':
         specifier: ^3.1101.0
         version: 3.1110.0
@@ -301,6 +304,10 @@ packages:
     resolution: {integrity: sha512-Wr9ikmjcon7RtXqfWrNehqSGzjLVKwS9+jr3XDkv+be/cJh4A8v7KsguJ+O/AiLiKEBOpDl0CPl8lRufQglUTQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-bedrock-runtime@3.1115.0':
+    resolution: {integrity: sha512-nenJKAe6OB0R13xaHpogadyqJ6rogFZk++ahWNdlJDf5sM4a6KFsXU5Zh3l3ox2Y+8YZp4l4msz+IYWFiQ7Bzg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-cloudformation@3.1110.0':
     resolution: {integrity: sha512-lG5RRIAWUt9nkaFC64TsxUGCsZhhNgr/QGNG/IkZUgcTHzpELph6EdxiiRgmnI50eM8JwqkQGRnCfnhsUtlSiQ==}
     engines: {node: '>=20.0.0'}
@@ -493,6 +500,10 @@ packages:
     resolution: {integrity: sha512-8q1ICxcDjHId3bBryuu/j+1L9y5/3uQnwzLDt5j2ElcjZSoWmFtymdJy7OjLrluSMe0Z4mq5bcH4fxBXvlEHfw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/eventstream-handler-node@3.972.33':
+    resolution: {integrity: sha512-1Dd5WyEE2Kb3HvY44u7Ob16ST2W6iutOqsQ8Y2hUmsL2mAH/STlGS1dS9h3IOE6L7Ld3AR2HzKJ6XeCMOw8Peg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/lib-dynamodb@3.1110.0':
     resolution: {integrity: sha512-g8rWHa4ED8Dxz2iMNRfh3ZeCX1d6pcmY2Geaizmw/rC4Fw1meMZ8jYIFd0BbCzYzOGKimpZ2eKvYRU7a5b1K3A==}
     engines: {node: '>=20.0.0'}
@@ -507,6 +518,10 @@ packages:
 
   '@aws-sdk/middleware-endpoint-discovery@3.972.29':
     resolution: {integrity: sha512-cXW7QNIOhUSfccZmwJEjn9EdCAjzdOtt/+MtO5HWgxIZdhzyC1kNuQKIgGEDkgabxiXymWw0/VFWdqxqeLbgMA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-eventstream@3.972.28':
+    resolution: {integrity: sha512-Z1EDXnS01P7H5jVrUx+/dBqV0m7dta7bSxLclkOuDuS93pNNQm0IcT4YLUbuvWKPYNxbI8aTG0p5Br30GSKDgA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-sdk-api-gateway@3.972.28':
@@ -524,6 +539,10 @@ packages:
   '@aws-sdk/middleware-sdk-sqs@3.972.41':
     resolution: {integrity: sha512-07AbG/6LlaoC3YJ97vPgWVYFGWg3W3Bdr1ow3xjwti5u9/PjVD8+wB+qu2jDZnIvE6F7Y4ONWYCDQTPxiepdnA==}
     engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-websocket@3.972.51':
+    resolution: {integrity: sha512-jdgP3jR5Q96j1jjZ98GGwpGg1CBNFIO2YE+vXg8cg8PvNY4NvgQNYJsqDaRX2PYv5gSUX/+C0D58Fhspj9ELMQ==}
+    engines: {node: '>= 14.0.0'}
 
   '@aws-sdk/nested-clients@3.997.42':
     resolution: {integrity: sha512-XWRyon2MTHXD/zMoo0Mbge6Vwf+iE0qQaM/RyGO6NfZ9WukCFiQL27nQVZjYy2JwSIg+iXZxKOX95OBXqlSM4w==}
@@ -547,6 +566,10 @@ packages:
 
   '@aws-sdk/token-providers@3.1111.0':
     resolution: {integrity: sha512-JfljgoVtl+s3Qy21n9a7Z48uCQaOXcN74KJ3TEQfPoB293GrXFSt6HSQJF1sTZ8c/5QedEvd3NjJQMO4u9qa5A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1115.0':
+    resolution: {integrity: sha512-ZQ9LMRuMbaZTTX6SJE8c7uP0PHSxerzs2wHBF0URQLB8hLQbPqi8RUoD3/ZaBqwIUue3RIPnCTvZKaE2MInX5Q==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.974.2':
@@ -3650,6 +3673,21 @@ snapshots:
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
+  '@aws-sdk/client-bedrock-runtime@3.1115.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/credential-provider-node': 3.972.80
+      '@aws-sdk/eventstream-handler-node': 3.972.33
+      '@aws-sdk/middleware-eventstream': 3.972.28
+      '@aws-sdk/middleware-websocket': 3.972.51
+      '@aws-sdk/token-providers': 3.1115.0
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/client-cloudformation@3.1110.0':
     dependencies:
       '@aws-sdk/core': 3.977.8
@@ -4172,6 +4210,13 @@ snapshots:
       mnemonist: 0.38.3
       tslib: 2.8.1
 
+  '@aws-sdk/eventstream-handler-node@3.972.33':
+    dependencies:
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/lib-dynamodb@3.1110.0(@aws-sdk/client-dynamodb@3.1110.0)':
     dependencies:
       '@aws-sdk/client-dynamodb': 3.1110.0
@@ -4194,6 +4239,13 @@ snapshots:
   '@aws-sdk/middleware-endpoint-discovery@3.972.29':
     dependencies:
       '@aws-sdk/endpoint-cache': 3.972.11
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-eventstream@3.972.28':
+    dependencies:
       '@aws-sdk/types': 3.974.4
       '@smithy/core': 3.33.2
       '@smithy/types': 4.17.2
@@ -4225,6 +4277,16 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.974.4
       '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-websocket@3.972.51':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/signature-v4': 5.7.2
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
@@ -4276,6 +4338,15 @@ snapshots:
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1111.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/nested-clients': 3.997.43
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1115.0':
     dependencies:
       '@aws-sdk/core': 3.977.8
       '@aws-sdk/nested-clients': 3.997.43

--- a/src/sdk/router/resolve-sim-sdk-command-router.ts
+++ b/src/sdk/router/resolve-sim-sdk-command-router.ts
@@ -37,6 +37,10 @@ const scopedRouters: ReadonlyMap<string, SimSdkScopedRouter> = new Map<
     (scoped): SimSdkCommandRouter => scoped.apiGatewayV2().sdkCommandRouter(),
   ],
   [
+    "Bedrock Runtime",
+    (scoped): SimSdkCommandRouter => scoped.bedrock().sdkCommandRouter(),
+  ],
+  [
     "CloudFormation",
     (scoped): SimSdkCommandRouter => scoped.cloudFormation().sdkCommandRouter(),
   ],

--- a/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
@@ -1,4 +1,5 @@
 import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-scope.js";
+import { SimBedrock } from "../../bedrock/index.js";
 import { SimDynamoDb as SimDynamoDatabase } from "../../dynamodb/index.js";
 import { SimSecretsManager } from "../../secretsmanager/index.js";
 import { SimSqs } from "../../sqs/index.js";
@@ -30,6 +31,17 @@ export class SimAwsSelfContainedServiceBuilder {
 
   constructor(properties: SimAwsSelfContainedServiceBuilderProperties) {
     this.accountServices = properties.accountServices;
+  }
+
+  /**
+   * Create simulated Bedrock for an Account Region scope.
+   *
+   * Bedrock is Region-scoped because the responses declared against it are: an
+   * invocation made in one Region is answered by that Region's rules, as a
+   * real Bedrock endpoint answers for the Region it belongs to.
+   */
+  createBedrock(scope: SimAwsAccountRegionContainer): SimBedrock {
+    return new SimBedrock(this.scoped(scope));
   }
 
   /** Create simulated DynamoDB for an Account Region scope. */

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -15,6 +15,7 @@ import type { SimCloudWatch } from "../../cloudwatch/index.js";
 import type { SimDynamoDb as SimDynamoDatabase } from "../../dynamodb/index.js";
 import type { SimEcr } from "../../ecr/index.js";
 import type { SimEcs } from "../../ecs/index.js";
+import type { SimBedrock } from "../../bedrock/index.js";
 import type { SimPersonalize } from "../../personalize/index.js";
 import type { SimRekognition } from "../../rekognition/index.js";
 import type { SimRoute53 } from "../../route53/index.js";
@@ -232,6 +233,11 @@ export class SimAwsServiceFactory {
   /** Create simulated Lambda for an Account Region scope. */
   createLambda(scope: SimAwsAccountRegionContainer): SimLambda {
     return this.accountRegionServices.createLambda(scope);
+  }
+
+  /** Create simulated Bedrock for an Account Region scope. */
+  createBedrock(scope: SimAwsAccountRegionContainer): SimBedrock {
+    return this.selfContainedServices.createBedrock(scope);
   }
 
   /** Create simulated Personalize for an Account Region scope. */

--- a/src/service/aws/sim-aws-account-region-scope.ts
+++ b/src/service/aws/sim-aws-account-region-scope.ts
@@ -3,6 +3,7 @@ import type { AwsRegionName, SimAwsRegion } from "./sim-aws-region.js";
 import { Memo } from "../../util/memo/memo.js";
 import { isSimAwsClosing } from "./sim-aws-closing.js";
 import { SimAws } from "./sim-aws.js";
+import type { SimBedrock } from "../bedrock/index.js";
 import type { SimS3 } from "../s3/sim-s3.js";
 import type { SimScheduler } from "../scheduler/index.js";
 import type { SimCloudFront } from "../cloudfront/sim-cloudfront.js";
@@ -80,6 +81,13 @@ export class SimAwsAccountRegionContainer {
   /** Get simulated ACM for this account and region. */
   acm(): SimAcm {
     return this.memo.getOrCreate("acm", () => this.factory.createAcm(this));
+  }
+
+  /** Get simulated Bedrock for this account and region. */
+  bedrock(): SimBedrock {
+    return this.memo.getOrCreate("bedrock", () =>
+      this.factory.createBedrock(this),
+    );
   }
 
   /** Get simulated API Gateway REST APIs for this account and region. */

--- a/src/service/aws/sim-aws-service-accessors.ts
+++ b/src/service/aws/sim-aws-service-accessors.ts
@@ -1,5 +1,6 @@
 import type { SimAwsAccountRegionContainer } from "./sim-aws-account-region-scope.js";
 import type { SimAcm } from "../acm/sim-acm.js";
+import type { SimBedrock } from "../bedrock/index.js";
 import type { SimApiGateway } from "../apigateway/index.js";
 import type { SimApiGatewayV2 } from "../apigatewayv2/index.js";
 import type { SimCloudFormation } from "../cloudformation/index.js";
@@ -63,6 +64,11 @@ export abstract class SimAwsServiceAccessors {
   /** Get simulated API Gateway v2 in the default Account Region scope. */
   apiGatewayV2(): SimApiGatewayV2 {
     return this.defaultAccountRegionScope().apiGatewayV2();
+  }
+
+  /** Get simulated Bedrock in the default Account Region scope. */
+  bedrock(): SimBedrock {
+    return this.defaultAccountRegionScope().bedrock();
   }
 
   /** Get simulated CloudFormation in the default Account Region scope. */

--- a/src/service/bedrock/README.md
+++ b/src/service/bedrock/README.md
@@ -1,0 +1,120 @@
+# Simulated Bedrock implementation
+
+This directory contains the simulated Bedrock implementation. Two invocations are simulated,
+`Converse` and `InvokeModel`, each answered from a response a test declared.
+
+The guiding decision here is that no model runs. What matters about a Bedrock call is the answer,
+and the simulation reads the prompt only as a key to match on. Simulated Rekognition
+answers a detection the same way, without looking at an image. Everything else in this directory
+makes the parts around that answer behave the way AWS does. The request checking, the IAM decision
+and the response the SDK hands back are all real.
+
+## Entry points
+
+- `sim-bedrock.ts` is the service facade for one account/region scope.
+- `index.ts` exports the public Bedrock simulator API for `@kensio/yulin/bedrock`.
+
+`SimBedrock` owns one `SimBedrockResponses`, which both invocation handlers answer from. Rekognition
+groups its rules per operation, because a moderation result and a face are different shapes.
+Bedrock's two operations reach the same exchange through two request shapes. One rule set covers
+both, and a test declaring a response gets it whichever API the code under test calls.
+
+The service is scoped to an account and region because its rules are. An invocation made in one
+Region is answered by the rules registered in that Region, as a real Bedrock endpoint answers for
+the Region it belongs to.
+
+## The rule mechanism
+
+`response/sim-bedrock-responses.ts` is the whole of it. There is one kind of rule and one order
+between them. An exact prompt wins, then an exact model id, then the default. That ordering is
+`SimDeclaredResultRules`, which simulated Rekognition and simulated Personalize both match with.
+
+Rules name no resource. Simulated Personalize hangs its rules off a campaign, because a campaign is
+what a runtime call names and what a test creates first. A foundation model was there before the
+account was. A Bedrock rule hangs off the service itself.
+
+Matching is exact, with no pattern syntax, for the reason it is exact in Rekognition. A partial
+match forces a specificity rule, and a specificity rule is where a surprising answer comes from.
+
+The prompt of a `Converse` request is the text of its last user message, resolved in
+`command/converse/sim-bedrock-converse-prompt.ts`. Earlier turns are the conversation the model is
+answering in. A rule keyed on the whole history would stop matching as soon as the conversation grew
+by one exchange, which is the case a multi-turn test is about.
+
+The prompt of an `InvokeModel` request is its body decoded as UTF-8. The body is the whole request in
+the shape the model behind the id expects, and real Bedrock treats it as opaque. So does this. A test matching one usually wants a model rule instead, and the tier exists
+because the body is the only thing an `InvokeModel` request carries that identifies the exchange.
+
+## The response model
+
+`response/sim-bedrock-response-declaration.ts` holds the declared shape alone.
+`response/sim-bedrock-declared-content.ts` and `response/sim-bedrock-declared-usage.ts` are the
+checks over it, and `response/sim-bedrock-resolved-response.ts` is one resolved declaration. The
+checks sit apart from the class because holding all three in one file scores over the FTA threshold.
+
+A declaration is resolved when the rule is registered. A content block carrying both text and a tool
+use, a response carrying both `text` and `content`, and a negative token count are all refused where
+they were written.
+
+What a response can answer is resolved per call, because which operation reaches a rule is only
+known then. A `Converse` call reaching a declaration that carries a body alone is a declaration
+error. Answering it with the built-in default would leave a test reading the default text as the
+model's own answer.
+
+`response/sim-bedrock-response-defaults.ts` holds the built-in default. It is a single line of text
+saying what it is. A default that read like a real model answer would be asserted on by a test that
+meant to declare one, and the assertion would pass for the wrong reason.
+
+There is no default response body. A body is whatever shape the model behind the id uses, and one
+family's shape served for every other family would parse into something the caller cannot read. An `InvokeModel` call
+with no body declared for it is refused, naming the rule it reached.
+
+A response holding a tool use stops for `tool_use` unless the declaration named a reason of its own.
+Real Bedrock reports the same reason for the same response. Token counts are fixed, because counting
+them needs the tokenizer of the model the request names.
+
+## Authorization
+
+`command/authorize/sim-bedrock-authorizer.ts` authorizes against the model, and the resource is
+required. Every invocation names a model, and a policy allowing one foundation model and denying
+another is the policy worth being able to test.
+
+`model/sim-bedrock-model-arn.ts` turns a `modelId` into that resource. A base model id names a
+foundation model, which belongs to no account and carries an empty account field in its ARN. An
+inference profile, a provisioned model and a prompt version all arrive as ARNs already, and are
+authorized against as they were written.
+
+A denial is Bedrock's own `AccessDeniedException` with a 403 status. It follows the
+`SimS3AccessDenied` precedent over the shared IAM error, since the error name and status are part of
+what a caller has to handle.
+
+Both operations authorize `bedrock:InvokeModel`. Real Bedrock has no `bedrock:Converse` action to
+grant.
+
+The order in each handler is Rekognition's. The request is checked first, so a malformed one fails
+the same way whatever the caller is allowed to do. The declared response is read last. A caller with no permission is told about the permission.
+
+## Refusals
+
+`command/sim-bedrock-unsimulated-input.ts` refuses the request inputs this simulation leaves
+unmodelled. It works from the small accepted set. An option nobody thought about is refused, where
+an option missing from a denylist would be dropped.
+
+`guardrailConfig` is the one that matters, along with `guardrailIdentifier` on `InvokeModel`. A
+request naming a guardrail would be answered here without it and filtered for real in production,
+which is the failure that looks like a pass.
+
+`system`, `inferenceConfig`, `toolConfig` and `additionalModelRequestFields` are accepted and have
+no effect. They decide what a model generates, and no model generates anything here. Refusing them
+would refuse most production code on its first call. Which tools the model calls is decided by the
+declared response, which either carries a tool use block or leaves one out.
+
+The model id goes unresolved. Bedrock publishes no enumerable table of model ids, and a
+model this simulation refused to recognise would be a model Yulin decided did not exist. That is the
+reasoning that leaves simulated Rekognition without a label ontology.
+
+## Testing
+
+Tests are colocated with the code they exercise. `command/sim-bedrock-iam.iso.test.ts` and
+`command/sim-bedrock-validation.iso.test.ts` sit above the two command directories, because each
+covers both operations.

--- a/src/service/bedrock/command/authorize/sim-bedrock-authorizer.ts
+++ b/src/service/bedrock/command/authorize/sim-bedrock-authorizer.ts
@@ -1,0 +1,51 @@
+import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamCallerIdentifier } from "../../../iam/error/sim-iam-caller-identifier.js";
+import { SimBedrockAccessDeniedException } from "../../error/sim-bedrock.error.js";
+import type { SimBedrockRequestOptions } from "../sim-bedrock-request-options.js";
+
+interface SimBedrockAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * Applies simulated IAM authorization to Bedrock requests.
+ *
+ * Every invocation names a model, and real Bedrock authorizes it against that
+ * model's ARN. A policy allowing one foundation model and denying another is
+ * the policy worth being able to test, which is what makes the resource
+ * required here rather than optional.
+ */
+export class SimBedrockAuthorizer {
+  private readonly iam: SimIamInterServiceAuthZ;
+  private readonly callerIdentifier = new SimIamCallerIdentifier();
+
+  constructor(properties: SimBedrockAuthorizerProperties) {
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Ensure the caller may perform an action on a model.
+   */
+  authorize(
+    action: string,
+    resource: string,
+    options: SimBedrockRequestOptions = {},
+  ): SimAwsResolvedCaller {
+    const decision = this.iam.authorize({
+      action,
+      resource,
+      caller: options.caller,
+    });
+
+    if (decision.isDenied) {
+      throw new SimBedrockAccessDeniedException(
+        `User: ${this.callerIdentifier.format(decision.caller.principal)} is ` +
+          `not authorized to perform: ${action} on resource: ${resource} ` +
+          `because no identity-based policy allows the ${action} action`,
+      );
+    }
+
+    return decision.caller;
+  }
+}

--- a/src/service/bedrock/command/converse/converse.command.ts
+++ b/src/service/bedrock/command/converse/converse.command.ts
@@ -1,0 +1,56 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimBedrockResponseUsage } from "../../response/sim-bedrock-declared-usage.js";
+import type { SimBedrockResponseMessage } from "../../response/sim-bedrock-resolved-response.js";
+
+/**
+ * One content block of a message a request carries.
+ *
+ * Only the text of a block is read, which is what the prompt a rule matches on
+ * is made of. An image, a document or a tool result reaches the simulation
+ * whole and is answered from the same rules.
+ */
+export interface SimBedrockRequestContentBlock {
+  readonly text?: string | undefined;
+}
+
+/**
+ * One message of the conversation a request carries.
+ */
+export interface SimBedrockRequestMessage {
+  readonly role?: string | undefined;
+  readonly content?: readonly SimBedrockRequestContentBlock[] | undefined;
+}
+
+/**
+ * Minimal structural sim Bedrock Runtime Converse command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/bedrock-runtime/command/ConverseCommand/
+ */
+export interface SimConverseCommand {
+  readonly input: SimConverseCommandInput;
+}
+
+export interface SimConverseCommandInput {
+  readonly modelId?: string | undefined;
+  readonly messages?: readonly SimBedrockRequestMessage[] | undefined;
+  readonly system?: unknown;
+  readonly inferenceConfig?: unknown;
+  readonly toolConfig?: unknown;
+  readonly additionalModelRequestFields?: unknown;
+}
+
+export interface SimConverseOutput {
+  readonly message: SimBedrockResponseMessage;
+}
+
+export interface SimConverseMetrics {
+  readonly latencyMs: number;
+}
+
+export interface SimConverseCommandOutput {
+  readonly output: SimConverseOutput;
+  readonly stopReason: string;
+  readonly usage: SimBedrockResponseUsage;
+  readonly metrics: SimConverseMetrics;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/bedrock/command/converse/sim-bedrock-converse-prompt.ts
+++ b/src/service/bedrock/command/converse/sim-bedrock-converse-prompt.ts
@@ -1,0 +1,37 @@
+import { SimBedrockValidationException } from "../../error/sim-bedrock.error.js";
+import type { SimBedrockRequestMessage } from "./converse.command.js";
+
+const userRole = "user";
+
+/**
+ * The prompt a `Converse` request is matched on.
+ *
+ * It is the text of the last user message, which is the turn the model is
+ * answering. Earlier turns are the conversation it is answering in, and a rule
+ * keyed on the whole history would stop matching as soon as the conversation
+ * grew by one exchange.
+ *
+ * A message carrying several text blocks joins them with a newline, in the
+ * order they were sent. A message carrying none, such as one holding only a
+ * tool result, has no prompt, and the request falls through to a model rule or
+ * to the default.
+ */
+export function simBedrockConversePrompt(
+  messages: readonly SimBedrockRequestMessage[] | undefined,
+): string | undefined {
+  if (messages === undefined || messages.length === 0) {
+    throw new SimBedrockValidationException(
+      "Converse needs at least one message to send to the model",
+    );
+  }
+
+  const lastUserMessage = messages.findLast(
+    (message) => message.role === userRole,
+  );
+  const text = (lastUserMessage?.content ?? [])
+    .map((block) => block.text)
+    .filter((block) => block !== undefined)
+    .join("\n");
+
+  return text.length === 0 ? undefined : text;
+}

--- a/src/service/bedrock/command/converse/sim-bedrock-converse.iso.test.ts
+++ b/src/service/bedrock/command/converse/sim-bedrock-converse.iso.test.ts
@@ -1,0 +1,224 @@
+import { ConverseCommand } from "@aws-sdk/client-bedrock-runtime";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimConverseCommandOutput } from "./converse.command.js";
+import { simBedrockDefaultText } from "../../response/sim-bedrock-response-defaults.js";
+
+const sonnet = "anthropic.claude-3-5-sonnet-20241022-v2:0";
+
+/**
+ * A one turn conversation asking the model something.
+ */
+function askingAbout(prompt: string, modelId = sonnet): ConverseCommand {
+  return new ConverseCommand({
+    modelId,
+    messages: [{ role: "user", content: [{ text: prompt }] }],
+  });
+}
+
+/**
+ * The text of the first content block a Converse response carries.
+ */
+function answeredText(answered: SimConverseCommandOutput): string {
+  const text = answered.output.message.content.at(0)?.text;
+
+  assertNonNullable(text);
+
+  return text;
+}
+
+describe("Bedrock Converse", () => {
+  it("answers a conversation from a rule declared for its prompt", async () => {
+    // Given a response declared for one prompt.
+    const simAws = new SimAws();
+
+    simAws.bedrock().responses().onPrompt("Summarise entry 1042", {
+      text: "Entry 1042 covers the tone sandhi rules.",
+    });
+
+    // When the model is asked that.
+    const answered = await simAws
+      .bedrock()
+      .converse(askingAbout("Summarise entry 1042"));
+
+    // Then the declared text comes back.
+    assertIdentical(
+      answeredText(answered),
+      "Entry 1042 covers the tone sandhi rules.",
+    );
+    assertIdentical(answered.stopReason, "end_turn");
+  });
+
+  it("answers every other call to a model from its model rule", async () => {
+    // Given a response declared for one prompt and one for the model.
+    const simAws = new SimAws();
+
+    simAws
+      .bedrock()
+      .responses()
+      .onPrompt("Summarise entry 1042", { text: "The declared summary." });
+    simAws.bedrock().responses().onModel(sonnet, { text: "The model answer." });
+
+    // When the model is asked something else.
+    const answered = await simAws
+      .bedrock()
+      .converse(askingAbout("Summarise entry 2071"));
+
+    // Then the model rule answers it, and the prompt rule stays for its own
+    // prompt.
+    const asked = await simAws
+      .bedrock()
+      .converse(askingAbout("Summarise entry 1042"));
+
+    assertIdentical(answeredText(answered), "The model answer.");
+    assertIdentical(answeredText(asked), "The declared summary.");
+  });
+
+  it("answers a model no rule names with the built-in default", async () => {
+    // Given a response declared for one model.
+    const simAws = new SimAws();
+
+    simAws.bedrock().responses().onModel(sonnet, { text: "The model answer." });
+
+    // When another model is asked.
+    const answered = await simAws
+      .bedrock()
+      .converse(askingAbout("Summarise entry 1042", "amazon.nova-pro-v1:0"));
+
+    // Then the default answers, saying what it is.
+    assertIdentical(answeredText(answered), simBedrockDefaultText);
+  });
+
+  it("matches the last user turn of a longer conversation", async () => {
+    // Given a response declared for one prompt.
+    const simAws = new SimAws();
+
+    simAws
+      .bedrock()
+      .responses()
+      .onPrompt("And entry 2071?", { text: "Entry 2071 covers erhua." });
+
+    // When that prompt arrives at the end of a conversation.
+    const answered = await simAws.bedrock().converse(
+      new ConverseCommand({
+        modelId: sonnet,
+        messages: [
+          { role: "user", content: [{ text: "Summarise entry 1042" }] },
+          { role: "assistant", content: [{ text: "Tone sandhi." }] },
+          { role: "user", content: [{ text: "And entry 2071?" }] },
+        ],
+      }),
+    );
+
+    // Then the rule for the last turn answers it.
+    assertIdentical(answeredText(answered), "Entry 2071 covers erhua.");
+  });
+
+  it("hands back a declared tool use and stops for it", async () => {
+    // Given a response declared as a tool call.
+    const simAws = new SimAws();
+
+    simAws
+      .bedrock()
+      .responses()
+      .byDefault({
+        content: [
+          {
+            toolUse: {
+              toolUseId: "tooluse-1",
+              name: "lookUpEntry",
+              input: { entryId: "1042" },
+            },
+          },
+        ],
+      });
+
+    // When the model is asked anything.
+    const answered = await simAws.bedrock().converse(askingAbout("Anything"));
+
+    // Then the tool call reaches the caller as it was declared, and the stop
+    // reason follows it.
+    const [block] = answered.output.message.content;
+
+    assertNonNullable(block?.toolUse);
+    assertIdentical(block.toolUse.name, "lookUpEntry");
+    assertIdentical(answered.stopReason, "tool_use");
+  });
+
+  it("reports the token counts a response declares", async () => {
+    // Given a response declaring what it cost.
+    const simAws = new SimAws();
+
+    simAws
+      .bedrock()
+      .responses()
+      .byDefault({
+        text: "Short.",
+        usage: { inputTokens: 7, outputTokens: 3 },
+      });
+
+    // When the model is asked anything.
+    const answered = await simAws.bedrock().converse(askingAbout("Anything"));
+
+    // Then the counts come back with their total.
+    assertIdentical(answered.usage.inputTokens, 7);
+    assertIdentical(answered.usage.outputTokens, 3);
+    assertIdentical(answered.usage.totalTokens, 10);
+  });
+
+  it("refuses a conversation matching a response declared only as a body", async () => {
+    // Given a response declared for InvokeModel alone.
+    const simAws = new SimAws();
+
+    simAws
+      .bedrock()
+      .responses()
+      .onModel(sonnet, { body: { content: [{ text: "Raw." }] } });
+
+    // When Converse reaches it.
+    const error = await assertThrowsErrorAsync(
+      async () => await simAws.bedrock().converse(askingAbout("Anything")),
+    );
+
+    // Then it says which declaration it reached and what it needs.
+    assertIdentical(error.name, "SimBedrockDeclarationError");
+    assertStringIncludes(error.message, `the model '${sonnet}'`);
+    assertStringIncludes(error.message, "Declare text or content for Converse");
+  });
+
+  it("answers each Region from its own rules", async () => {
+    // Given different responses declared in two Regions.
+    const simAws = new SimAws();
+
+    simAws
+      .account()
+      .region("eu-west-2")
+      .bedrock()
+      .responses()
+      .byDefault({ text: "London." });
+    simAws
+      .account()
+      .region("us-east-1")
+      .bedrock()
+      .responses()
+      .byDefault({ text: "Virginia." });
+
+    // When each Region is asked.
+    const london = await simAws
+      .account()
+      .region("eu-west-2")
+      .bedrock()
+      .converse(askingAbout("Where am I?"));
+
+    // Then it answers with its own.
+    assertIdentical(answeredText(london), "London.");
+    assertArrayLength(london.output.message.content, 1);
+  });
+});

--- a/src/service/bedrock/command/converse/sim-bedrock-converse.ts
+++ b/src/service/bedrock/command/converse/sim-bedrock-converse.ts
@@ -1,0 +1,67 @@
+import { SimBedrockCommandGroup } from "../sim-bedrock-command-group.js";
+import type { SimBedrockRequestOptions } from "../sim-bedrock-request-options.js";
+import { SimBedrockUnsimulatedInput } from "../sim-bedrock-unsimulated-input.js";
+import type {
+  SimConverseCommand,
+  SimConverseCommandOutput,
+} from "./converse.command.js";
+import { simBedrockConversePrompt } from "./sim-bedrock-converse-prompt.js";
+
+const operation = "Converse";
+
+/**
+ * The inputs a simulated `Converse` reads or can honestly ignore.
+ *
+ * `system`, `inferenceConfig` and `additionalModelRequestFields` are accepted
+ * and have no effect, because they change what a model generates and no model
+ * generates anything here. `toolConfig` is accepted for the same reason: which
+ * tools the model may call is decided by the declared response, which either
+ * carries a tool use block or does not.
+ */
+const accepted = [
+  "modelId",
+  "messages",
+  "system",
+  "inferenceConfig",
+  "toolConfig",
+  "additionalModelRequestFields",
+];
+
+const unsimulated = new SimBedrockUnsimulatedInput(operation);
+
+/**
+ * Handles a Converse command.
+ *
+ * The response comes from the rule the request matches, and nothing in the
+ * conversation is read for meaning. A prompt rule answers the exchange it was
+ * declared for, a model rule answers every other call to that model, and a
+ * request matching neither is answered with the default.
+ */
+export class SimBedrockConverseHandler extends SimBedrockCommandGroup {
+  /**
+   * Answer a conversation with the response declared for it.
+   */
+  handle(
+    command: SimConverseCommand,
+    options?: SimBedrockRequestOptions,
+  ): SimConverseCommandOutput {
+    const { input } = command;
+
+    unsimulated.refuseUnaccepted(input, accepted);
+
+    const modelId = this.requireModelId(input.modelId, operation);
+    const prompt = simBedrockConversePrompt(input.messages);
+
+    this.authorizeModel(modelId, options);
+
+    const declared = this.responses.responseFor({ prompt, modelId });
+
+    return {
+      output: { message: declared.message() },
+      stopReason: declared.stopReason(),
+      usage: declared.usage(),
+      metrics: { latencyMs: 0 },
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/bedrock/command/invoke-model/invoke-model.command.ts
+++ b/src/service/bedrock/command/invoke-model/invoke-model.command.ts
@@ -1,0 +1,23 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim Bedrock Runtime InvokeModel command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/bedrock-runtime/command/InvokeModelCommand/
+ */
+export interface SimInvokeModelCommand {
+  readonly input: SimInvokeModelCommandInput;
+}
+
+export interface SimInvokeModelCommandInput {
+  readonly modelId?: string | undefined;
+  readonly body?: unknown;
+  readonly contentType?: string | undefined;
+  readonly accept?: string | undefined;
+}
+
+export interface SimInvokeModelCommandOutput {
+  readonly body: Uint8Array;
+  readonly contentType: string;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/bedrock/command/invoke-model/sim-bedrock-invoke-model-prompt.ts
+++ b/src/service/bedrock/command/invoke-model/sim-bedrock-invoke-model-prompt.ts
@@ -1,0 +1,37 @@
+/**
+ * Read the request body as the prompt a rule is matched on.
+ *
+ * The body is the whole request in the shape the model behind the id expects,
+ * and Bedrock reads nothing inside it, so neither does this. Matching on the
+ * bytes as they arrived is the only thing this simulation can do without
+ * knowing the model's own request shape, and a test matching a whole JSON body
+ * usually wants a model rule instead.
+ *
+ * The SDK accepts a body in every shape a payload can arrive in. A body that
+ * is a stream or a Blob has no prompt here, because reading it would consume
+ * the caller's own request body. Such a request falls through to a model rule
+ * or to the default.
+ */
+export function simBedrockInvokeModelPrompt(body: unknown): string | undefined {
+  const text = decoded(body);
+
+  return text === undefined || text.length === 0 ? undefined : text;
+}
+
+function decoded(body: unknown): string | undefined {
+  if (typeof body === "string") {
+    return body;
+  }
+
+  if (ArrayBuffer.isView(body)) {
+    return new TextDecoder().decode(
+      new Uint8Array(body.buffer, body.byteOffset, body.byteLength),
+    );
+  }
+
+  if (body instanceof ArrayBuffer) {
+    return new TextDecoder().decode(new Uint8Array(body));
+  }
+
+  return undefined;
+}

--- a/src/service/bedrock/command/invoke-model/sim-bedrock-invoke-model.iso.test.ts
+++ b/src/service/bedrock/command/invoke-model/sim-bedrock-invoke-model.iso.test.ts
@@ -1,0 +1,122 @@
+import { InvokeModelCommand } from "@aws-sdk/client-bedrock-runtime";
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimInvokeModelCommandOutput } from "./invoke-model.command.js";
+
+const titan = "amazon.titan-text-express-v1";
+
+/**
+ * An InvokeModel request carrying a model-specific request body.
+ */
+function invoking(body: unknown, modelId = titan): InvokeModelCommand {
+  return new InvokeModelCommand({
+    modelId,
+    body: new TextEncoder().encode(JSON.stringify(body)),
+  });
+}
+
+/**
+ * The response body a caller reads back, decoded the way production code
+ * decodes it.
+ */
+function answeredBody(answered: SimInvokeModelCommandOutput): unknown {
+  return JSON.parse(new TextDecoder().decode(answered.body));
+}
+
+describe("Bedrock InvokeModel", () => {
+  it("answers with the body declared for the model", async () => {
+    // Given a response body declared for one model.
+    const simAws = new SimAws();
+
+    simAws
+      .bedrock()
+      .responses()
+      .onModel(titan, { body: { results: [{ outputText: "Tone sandhi." }] } });
+
+    // When the model is invoked.
+    const answered = await simAws
+      .bedrock()
+      .invokeModel(invoking({ inputText: "Summarise entry 1042" }));
+
+    // Then the declared body comes back as bytes the caller decodes.
+    assertIdentical(
+      JSON.stringify(answeredBody(answered)),
+      JSON.stringify({ results: [{ outputText: "Tone sandhi." }] }),
+    );
+    assertIdentical(answered.contentType, "application/json");
+  });
+
+  it("matches a rule declared for the request body it was sent", async () => {
+    // Given a response declared for the exact body a caller sends.
+    const simAws = new SimAws();
+    const request = { inputText: "Summarise entry 1042" };
+
+    simAws
+      .bedrock()
+      .responses()
+      .onPrompt(JSON.stringify(request), { body: { matched: true } });
+    simAws
+      .bedrock()
+      .responses()
+      .onModel(titan, { body: { matched: false } });
+
+    // When that body is sent.
+    const answered = await simAws.bedrock().invokeModel(invoking(request));
+
+    // Then the body rule wins over the model rule.
+    assertIdentical(
+      JSON.stringify(answeredBody(answered)),
+      JSON.stringify({ matched: true }),
+    );
+  });
+
+  it("refuses an invocation matching a response with no body", async () => {
+    // Given only a Converse response declared.
+    const simAws = new SimAws();
+
+    simAws.bedrock().responses().onModel(titan, { text: "Tone sandhi." });
+
+    // When the model is invoked.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws
+          .bedrock()
+          .invokeModel(invoking({ inputText: "Summarise entry 1042" })),
+    );
+
+    // Then it says why there is no default to fall back on.
+    assertIdentical(error.name, "SimBedrockDeclarationError");
+    assertStringIncludes(error.message, "no default for it");
+  });
+
+  it("labels the answer as the accept header asked for", async () => {
+    // Given a declared response body.
+    const simAws = new SimAws();
+
+    simAws
+      .bedrock()
+      .responses()
+      .byDefault({ body: { outputText: "Yes." } });
+
+    // When the caller asks for a content type of its own.
+    const body = new TextEncoder().encode(JSON.stringify({ inputText: "Hi" }));
+    const answered = await simAws.bedrock().invokeModel(
+      new InvokeModelCommand({
+        modelId: titan,
+        body,
+        accept: "application/vnd.amazon.bedrock+json",
+      }),
+    );
+
+    // Then the answer is labelled with it.
+    assertIdentical(
+      answered.contentType,
+      "application/vnd.amazon.bedrock+json",
+    );
+  });
+});

--- a/src/service/bedrock/command/invoke-model/sim-bedrock-invoke-model.ts
+++ b/src/service/bedrock/command/invoke-model/sim-bedrock-invoke-model.ts
@@ -1,0 +1,58 @@
+import { SimBedrockCommandGroup } from "../sim-bedrock-command-group.js";
+import type { SimBedrockRequestOptions } from "../sim-bedrock-request-options.js";
+import { SimBedrockUnsimulatedInput } from "../sim-bedrock-unsimulated-input.js";
+import type {
+  SimInvokeModelCommand,
+  SimInvokeModelCommandOutput,
+} from "./invoke-model.command.js";
+import { simBedrockInvokeModelPrompt } from "./sim-bedrock-invoke-model-prompt.js";
+
+const operation = "InvokeModel";
+
+const defaultContentType = "application/json";
+
+/**
+ * The inputs a simulated `InvokeModel` reads.
+ *
+ * `contentType` and `accept` are accepted and only the latter is used, to say
+ * what the answer is labelled as. Everything a guardrail arrives through is
+ * absent from this list and refused.
+ */
+const accepted = ["modelId", "body", "contentType", "accept"];
+
+const unsimulated = new SimBedrockUnsimulatedInput(operation);
+
+/**
+ * Handles an InvokeModel command.
+ *
+ * The response body is the one declared for the request, serialized as JSON.
+ * There is no built-in default: a response body is whatever shape the model
+ * behind the id uses, and one family's shape served for every other family
+ * would be an answer that parses and means nothing.
+ */
+export class SimBedrockInvokeModelHandler extends SimBedrockCommandGroup {
+  /**
+   * Invoke a model and answer with the body declared for the request.
+   */
+  handle(
+    command: SimInvokeModelCommand,
+    options?: SimBedrockRequestOptions,
+  ): SimInvokeModelCommandOutput {
+    const { input } = command;
+
+    unsimulated.refuseUnaccepted(input, accepted);
+
+    const modelId = this.requireModelId(input.modelId, operation);
+
+    this.authorizeModel(modelId, options);
+
+    const prompt = simBedrockInvokeModelPrompt(input.body);
+    const declared = this.responses.responseFor({ prompt, modelId });
+
+    return {
+      body: new TextEncoder().encode(JSON.stringify(declared.body())),
+      contentType: input.accept ?? defaultContentType,
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/bedrock/command/sim-bedrock-command-group.ts
+++ b/src/service/bedrock/command/sim-bedrock-command-group.ts
@@ -1,0 +1,77 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { SimBedrockValidationException } from "../error/sim-bedrock.error.js";
+import { simBedrockModelArn } from "../model/sim-bedrock-model-arn.js";
+import type { SimBedrockResponses } from "../response/sim-bedrock-responses.js";
+import type { SimBedrockAuthorizer } from "./authorize/sim-bedrock-authorizer.js";
+import type { SimBedrockRequestOptions } from "./sim-bedrock-request-options.js";
+
+/**
+ * The action every model invocation authorizes against.
+ *
+ * Real Bedrock authorizes `Converse` with `bedrock:InvokeModel` too. There is
+ * no `bedrock:Converse` action to grant.
+ */
+export const simBedrockInvokeAction = "bedrock:InvokeModel";
+
+export interface SimBedrockCommandGroupProperties {
+  readonly responses: SimBedrockResponses;
+  readonly authorizer: SimBedrockAuthorizer;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * What both simulated Bedrock invocation handlers are built over.
+ *
+ * Each one names a model, authorizes against it and answers from the declared
+ * responses, so all three come from here and each handler is left with the
+ * shape of its own request and response.
+ */
+export abstract class SimBedrockCommandGroup {
+  protected readonly responses: SimBedrockResponses;
+  private readonly authorizer: SimBedrockAuthorizer;
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimBedrockCommandGroupProperties) {
+    this.responses = properties.responses;
+    this.authorizer = properties.authorizer;
+    this.accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Read the model a request names.
+   *
+   * The model id is not resolved against anything. Bedrock offers no
+   * enumerable table of model ids to resolve one against, and a model this
+   * simulation refused to recognise would be a model Yulin decided did not
+   * exist.
+   */
+  protected requireModelId(
+    modelId: string | undefined,
+    operation: string,
+  ): string {
+    if (modelId === undefined || modelId.length === 0) {
+      throw new SimBedrockValidationException(
+        `${operation} needs a modelId naming the model to invoke`,
+      );
+    }
+
+    return modelId;
+  }
+
+  /**
+   * Authorize the caller to invoke one model.
+   *
+   * This happens after the request has been checked, so a malformed request
+   * fails the same way whatever the caller is allowed to do.
+   */
+  protected authorizeModel(
+    modelId: string,
+    options: SimBedrockRequestOptions | undefined,
+  ): void {
+    this.authorizer.authorize(
+      simBedrockInvokeAction,
+      simBedrockModelArn(this.accountRegionScope, modelId),
+      options,
+    );
+  }
+}

--- a/src/service/bedrock/command/sim-bedrock-iam.iso.test.ts
+++ b/src/service/bedrock/command/sim-bedrock-iam.iso.test.ts
@@ -1,0 +1,156 @@
+import { ConverseCommand } from "@aws-sdk/client-bedrock-runtime";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simIamPolicyDocumentFactory } from "../../iam/policy/sim-iam-policy-document.factory.js";
+
+const accountIdOneOnes = "111111111111";
+
+const sonnet = "anthropic.claude-3-5-sonnet-20241022-v2:0";
+
+const sonnetArn = `arn:aws:bedrock:us-east-1::foundation-model/${sonnet}`;
+
+/**
+ * A Role whose policy allows one action on one resource.
+ */
+async function givenARoleAllowedTo(
+  simAws: SimAws,
+  action: string,
+  resource = "*",
+): Promise<string> {
+  const role = await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "BedrockCaller",
+      AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: {
+          Principal: { AWS: `arn:aws:iam::${accountIdOneOnes}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "BedrockCaller",
+      PolicyName: "BedrockPolicy",
+      PolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: { Action: action, Resource: resource },
+      }),
+    }),
+  );
+
+  assertNonNullable(role.Role.Arn);
+
+  return role.Role.Arn;
+}
+
+/**
+ * A one turn conversation with one model.
+ */
+function askingOf(modelId: string): ConverseCommand {
+  return new ConverseCommand({
+    modelId,
+    messages: [{ role: "user", content: [{ text: "Summarise entry 1042" }] }],
+  });
+}
+
+describe("Bedrock IAM authorization", () => {
+  it("allows an invocation the caller's policy permits on the model", async () => {
+    // Given a Role allowed to invoke one foundation model.
+    const simAws = new SimAws({ defaultAccountId: accountIdOneOnes });
+    const roleArn = await givenARoleAllowedTo(
+      simAws,
+      "bedrock:InvokeModel",
+      sonnetArn,
+    );
+
+    simAws.bedrock().responses().byDefault({ text: "Tone sandhi." });
+
+    // When it invokes that model.
+    const answered = await simAws
+      .bedrock()
+      .converse(askingOf(sonnet), { caller: { kind: "arn", arn: roleArn } });
+
+    // Then it goes through.
+    assertIdentical(
+      answered.output.message.content.at(0)?.text,
+      "Tone sandhi.",
+    );
+  });
+
+  it("denies an invocation of a model the policy leaves out", async () => {
+    // Given a Role allowed to invoke one model only.
+    const simAws = new SimAws({ defaultAccountId: accountIdOneOnes });
+    const roleArn = await givenARoleAllowedTo(
+      simAws,
+      "bedrock:InvokeModel",
+      sonnetArn,
+    );
+
+    // When it invokes another one.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.bedrock().converse(askingOf("amazon.nova-pro-v1:0"), {
+          caller: { kind: "arn", arn: roleArn },
+        }),
+    );
+
+    // Then Bedrock reports it in its own terms, naming the model.
+    assertIdentical(error.name, "AccessDeniedException");
+    assertStringIncludes(error.message, "bedrock:InvokeModel");
+    assertStringIncludes(error.message, "amazon.nova-pro-v1:0");
+  });
+
+  it("checks the request before it decides the caller", async () => {
+    // Given a Role allowed to invoke nothing at all.
+    const simAws = new SimAws({ defaultAccountId: accountIdOneOnes });
+    const roleArn = await givenARoleAllowedTo(
+      simAws,
+      "bedrock:ListTagsForResource",
+    );
+
+    // When it sends a conversation with no messages.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws
+          .bedrock()
+          .converse(new ConverseCommand({ modelId: sonnet, messages: [] }), {
+            caller: { kind: "arn", arn: roleArn },
+          }),
+    );
+
+    // Then the malformed request fails the same way it would for any caller.
+    assertIdentical(error.name, "ValidationException");
+  });
+
+  it("authorizes an inference profile against the ARN the request named", async () => {
+    // Given a Role allowed to invoke one inference profile.
+    const simAws = new SimAws({ defaultAccountId: accountIdOneOnes });
+    const profileArn = `arn:aws:bedrock:us-east-1:${accountIdOneOnes}:inference-profile/us.anthropic.claude-3-5-sonnet-20241022-v2:0`;
+    const roleArn = await givenARoleAllowedTo(
+      simAws,
+      "bedrock:InvokeModel",
+      profileArn,
+    );
+
+    simAws.bedrock().responses().byDefault({ text: "Tone sandhi." });
+
+    // When it invokes through that profile.
+    const answered = await simAws.bedrock().converse(askingOf(profileArn), {
+      caller: { kind: "arn", arn: roleArn },
+    });
+
+    // Then the ARN is authorized as it was written rather than wrapped in a
+    // foundation model ARN.
+    assertIdentical(
+      answered.output.message.content.at(0)?.text,
+      "Tone sandhi.",
+    );
+  });
+});

--- a/src/service/bedrock/command/sim-bedrock-request-options.ts
+++ b/src/service/bedrock/command/sim-bedrock-request-options.ts
@@ -1,0 +1,9 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+
+/**
+ * What a caller can say about itself when it reaches simulated Bedrock
+ * directly rather than through an intercepted SDK client.
+ */
+export interface SimBedrockRequestOptions {
+  readonly caller?: SimAwsCaller;
+}

--- a/src/service/bedrock/command/sim-bedrock-unsimulated-input.ts
+++ b/src/service/bedrock/command/sim-bedrock-unsimulated-input.ts
@@ -1,0 +1,35 @@
+import { SimBedrockUnsimulatedInputException } from "../error/sim-bedrock.error.js";
+
+/**
+ * Refuses the request inputs this simulation does not model.
+ *
+ * The refusal works from the small set of options each command accepts rather
+ * than from a list of everything Bedrock offers, so an option nobody thought
+ * about is refused rather than dropped. Dropping is the failure mode worth
+ * avoiding here: a `Converse` naming a `guardrailConfig` that blocks a prompt
+ * would be answered with the declared response, which is the one answer that
+ * looks right and is not.
+ */
+export class SimBedrockUnsimulatedInput {
+  private readonly operation: string;
+
+  constructor(operation: string) {
+    this.operation = operation;
+  }
+
+  /**
+   * Refuse every supplied input that is not one of the accepted options.
+   */
+  refuseUnaccepted(input: object, accepted: readonly string[]): void {
+    for (const [option, value] of Object.entries(input)) {
+      if (value === undefined || accepted.includes(option)) {
+        continue;
+      }
+
+      throw new SimBedrockUnsimulatedInputException(
+        `${this.operation} ${option} is not simulated: it would be ignored ` +
+          `here and applied on real AWS`,
+      );
+    }
+  }
+}

--- a/src/service/bedrock/command/sim-bedrock-validation.iso.test.ts
+++ b/src/service/bedrock/command/sim-bedrock-validation.iso.test.ts
@@ -1,0 +1,127 @@
+import {
+  ConverseCommand,
+  InvokeModelCommand,
+} from "@aws-sdk/client-bedrock-runtime";
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+
+const sonnet = "anthropic.claude-3-5-sonnet-20241022-v2:0";
+
+describe("Bedrock request validation", () => {
+  it("refuses a Converse naming a guardrail", async () => {
+    // Given a simulated Bedrock with a response declared.
+    const simAws = new SimAws();
+
+    simAws.bedrock().responses().byDefault({ text: "Tone sandhi." });
+
+    // When a conversation asks for a guardrail to be applied.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.bedrock().converse(
+          new ConverseCommand({
+            modelId: sonnet,
+            messages: [{ role: "user", content: [{ text: "Anything" }] }],
+            guardrailConfig: {
+              guardrailIdentifier: "entry-guardrail",
+              guardrailVersion: "1",
+            },
+          }),
+        ),
+    );
+
+    // Then it is refused rather than answered without the guardrail.
+    assertIdentical(error.name, "ValidationException");
+    assertStringIncludes(error.message, "guardrailConfig is not simulated");
+  });
+
+  it("refuses an InvokeModel naming a guardrail", async () => {
+    // Given a simulated Bedrock with a response body declared.
+    const simAws = new SimAws();
+
+    simAws
+      .bedrock()
+      .responses()
+      .byDefault({ body: { outputText: "Yes." } });
+
+    // When an invocation asks for a guardrail to be applied.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.bedrock().invokeModel(
+          new InvokeModelCommand({
+            modelId: sonnet,
+            body: new TextEncoder().encode("{}"),
+            guardrailIdentifier: "entry-guardrail",
+          }),
+        ),
+    );
+
+    // Then it is refused too.
+    assertIdentical(error.name, "ValidationException");
+    assertStringIncludes(error.message, "guardrailIdentifier is not simulated");
+  });
+
+  it("accepts the inference parameters a real caller sends", async () => {
+    // Given a simulated Bedrock with a response declared.
+    const simAws = new SimAws();
+
+    simAws.bedrock().responses().byDefault({ text: "Tone sandhi." });
+
+    // When a conversation carries a system prompt and inference settings.
+    const answered = await simAws.bedrock().converse(
+      new ConverseCommand({
+        modelId: sonnet,
+        messages: [{ role: "user", content: [{ text: "Anything" }] }],
+        system: [{ text: "You summarise entries." }],
+        inferenceConfig: { maxTokens: 512, temperature: 0 },
+      }),
+    );
+
+    // Then they go through, having decided nothing.
+    assertIdentical(
+      answered.output.message.content.at(0)?.text,
+      "Tone sandhi.",
+    );
+  });
+
+  it("refuses a conversation with no messages", async () => {
+    // Given a simulated Bedrock.
+    const simAws = new SimAws();
+
+    // When a conversation carries none.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws
+          .bedrock()
+          .converse(new ConverseCommand({ modelId: sonnet, messages: [] })),
+    );
+
+    // Then it is refused as real Bedrock refuses it.
+    assertIdentical(error.name, "ValidationException");
+    assertStringIncludes(error.message, "at least one message");
+  });
+
+  it("refuses a request naming no model", async () => {
+    // Given a simulated Bedrock.
+    const simAws = new SimAws();
+
+    // When a conversation names no model to invoke.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.bedrock().converse(
+          new ConverseCommand({
+            modelId: "",
+            messages: [{ role: "user", content: [{ text: "Anything" }] }],
+          }),
+        ),
+    );
+
+    // Then it says what is missing.
+    assertIdentical(error.name, "ValidationException");
+    assertStringIncludes(error.message, "needs a modelId");
+  });
+});

--- a/src/service/bedrock/error/sim-bedrock.error.ts
+++ b/src/service/bedrock/error/sim-bedrock.error.ts
@@ -1,0 +1,80 @@
+/**
+ * Minimal metadata shape for simulated Bedrock errors.
+ */
+export interface SimBedrockErrorMetadata {
+  readonly httpStatusCode?: number;
+}
+
+/**
+ * Base class for simulated Bedrock errors.
+ */
+export class SimBedrockError extends Error {
+  constructor(
+    message: string,
+    public readonly $metadata: SimBedrockErrorMetadata = {},
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Simulated Bedrock ValidationException error.
+ *
+ * This is the failure the request input produces on its own: a missing model
+ * id, a conversation with no messages, or a value outside the set the API
+ * accepts.
+ */
+export class SimBedrockValidationException extends SimBedrockError {
+  public override readonly name = "ValidationException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated Bedrock AccessDeniedException error.
+ *
+ * A caller simulated IAM denies is reported in Bedrock's own terms rather than
+ * through the shared IAM error, because that is the error name a real Bedrock
+ * caller has to handle. Real Bedrock answers it with a 403.
+ */
+export class SimBedrockAccessDeniedException extends SimBedrockError {
+  public override readonly name = "AccessDeniedException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 403 });
+  }
+}
+
+/**
+ * Simulated Bedrock error for a request input this simulation does not model.
+ *
+ * This is not an error real Bedrock has, and it is reported under the name
+ * real Bedrock refuses bad input with. The input is refused rather than
+ * ignored, because an ignored input looks applied to the request that sent it
+ * and unapplied to everything else. A `guardrailConfig` naming a guardrail
+ * that blocks a prompt is the case worth refusing: the response would come
+ * back whole here and come back blocked on AWS.
+ */
+export class SimBedrockUnsimulatedInputException extends SimBedrockError {
+  public override readonly name = "ValidationException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated Bedrock error for a response declared against this simulation that
+ * it cannot answer with.
+ *
+ * This is a simulator configuration error rather than an AWS one. A content
+ * block naming two kinds of content at once is refused where the declaration
+ * was written. A declaration carrying nothing the operation asking for it can
+ * use is refused where the call is made, since which operation reaches a rule
+ * is only known then.
+ */
+export class SimBedrockDeclarationError extends SimBedrockError {
+  public override readonly name = "SimBedrockDeclarationError";
+}

--- a/src/service/bedrock/index.ts
+++ b/src/service/bedrock/index.ts
@@ -1,0 +1,31 @@
+export { SimBedrock } from "./sim-bedrock.js";
+export type { SimBedrockRequestOptions } from "./command/sim-bedrock-request-options.js";
+export {
+  SimBedrockResponses,
+  type SimBedrockResponseRequest,
+} from "./response/sim-bedrock-responses.js";
+export type {
+  SimBedrockDeclaredContentBlock,
+  SimBedrockDeclaredResponse,
+  SimBedrockDeclaredToolUse,
+  SimBedrockDeclaredUsage,
+} from "./response/sim-bedrock-response-declaration.js";
+export {
+  simBedrockDefaultInputTokens,
+  simBedrockDefaultOutputTokens,
+  simBedrockDefaultResponse,
+  simBedrockDefaultStopReason,
+  simBedrockDefaultText,
+} from "./response/sim-bedrock-response-defaults.js";
+export type { SimBedrockResponseUsage } from "./response/sim-bedrock-declared-usage.js";
+export {
+  SimBedrockResolvedResponse,
+  type SimBedrockResponseMessage,
+} from "./response/sim-bedrock-resolved-response.js";
+export {
+  SimBedrockAccessDeniedException,
+  SimBedrockDeclarationError,
+  SimBedrockError,
+  SimBedrockUnsimulatedInputException,
+  SimBedrockValidationException,
+} from "./error/sim-bedrock.error.js";

--- a/src/service/bedrock/model/sim-bedrock-model-arn.ts
+++ b/src/service/bedrock/model/sim-bedrock-model-arn.ts
@@ -1,0 +1,21 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+
+/**
+ * The ARN a request authorizes against for the model it names.
+ *
+ * A `modelId` reaches Bedrock in several forms. A base model id such as
+ * `anthropic.claude-3-5-sonnet-20241022-v2:0` names a foundation model, which
+ * belongs to no account and carries an empty account field in its ARN. An
+ * inference profile, a provisioned model and a prompt version all arrive as
+ * ARNs already, and are authorized against as they were written.
+ */
+export function simBedrockModelArn(
+  accountRegionScope: SimAwsAccountRegionScope,
+  modelId: string,
+): string {
+  if (modelId.startsWith("arn:")) {
+    return modelId;
+  }
+
+  return `arn:aws:bedrock:${accountRegionScope.regionName}::foundation-model/${modelId}`;
+}

--- a/src/service/bedrock/response/sim-bedrock-declarations.iso.test.ts
+++ b/src/service/bedrock/response/sim-bedrock-declarations.iso.test.ts
@@ -1,0 +1,93 @@
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+
+describe("Bedrock response declarations", () => {
+  it("refuses a response carrying both text and content blocks", () => {
+    // Given a simulated Bedrock.
+    const simAws = new SimAws();
+
+    // When a response is declared twice over.
+    const error = assertThrowsError(() => {
+      simAws
+        .bedrock()
+        .responses()
+        .byDefault({
+          text: "Tone sandhi.",
+          content: [{ text: "Tone sandhi." }],
+        });
+    });
+
+    // Then it is refused where it was written.
+    assertIdentical(error.name, "SimBedrockDeclarationError");
+    assertStringIncludes(error.message, "declare one or the other");
+  });
+
+  it("refuses a content block carrying text and a tool use at once", () => {
+    // Given a simulated Bedrock.
+    const simAws = new SimAws();
+
+    // When a block says two things.
+    const error = assertThrowsError(() => {
+      simAws
+        .bedrock()
+        .responses()
+        .onPrompt("Anything", {
+          content: [{ text: "Looking it up.", toolUse: { name: "lookUp" } }],
+        });
+    });
+
+    // Then it names the rule it was declared for.
+    assertIdentical(error.name, "SimBedrockDeclarationError");
+    assertStringIncludes(error.message, "the prompt 'Anything'");
+  });
+
+  it("refuses a response with nothing to answer with", () => {
+    // Given a simulated Bedrock.
+    const simAws = new SimAws();
+
+    // When a response declares only why it stopped.
+    const error = assertThrowsError(() => {
+      simAws.bedrock().responses().byDefault({ stopReason: "max_tokens" });
+    });
+
+    // Then it says what to declare instead.
+    assertIdentical(error.name, "SimBedrockDeclarationError");
+    assertStringIncludes(error.message, "no text, no content and no body");
+  });
+
+  it("refuses a negative token count", () => {
+    // Given a simulated Bedrock.
+    const simAws = new SimAws();
+
+    // When a response reports fewer than no tokens.
+    const error = assertThrowsError(() => {
+      simAws
+        .bedrock()
+        .responses()
+        .byDefault({ text: "Short.", usage: { outputTokens: -1 } });
+    });
+
+    // Then it is refused where it was written.
+    assertIdentical(error.name, "SimBedrockDeclarationError");
+    assertStringIncludes(error.message, "never negative");
+  });
+
+  it("refuses a rule with no prompt to match", () => {
+    // Given a simulated Bedrock.
+    const simAws = new SimAws();
+
+    // When a rule is declared for an empty prompt.
+    const error = assertThrowsError(() => {
+      simAws.bedrock().responses().onPrompt("", { text: "Anything." });
+    });
+
+    // Then it says a rule needs something to match.
+    assertIdentical(error.name, "SimBedrockDeclarationError");
+    assertStringIncludes(error.message, "needs a prompt to match");
+  });
+});

--- a/src/service/bedrock/response/sim-bedrock-declared-content.ts
+++ b/src/service/bedrock/response/sim-bedrock-declared-content.ts
@@ -1,0 +1,74 @@
+import { SimBedrockDeclarationError } from "../error/sim-bedrock.error.js";
+import type {
+  SimBedrockDeclaredContentBlock,
+  SimBedrockDeclaredResponse,
+} from "./sim-bedrock-response-declaration.js";
+
+function checkedBlock(
+  subject: string,
+  block: SimBedrockDeclaredContentBlock,
+): SimBedrockDeclaredContentBlock {
+  const { text, toolUse } = block;
+
+  if (text !== undefined && toolUse !== undefined) {
+    throw new SimBedrockDeclarationError(
+      `A content block declared for ${subject} carries both text and a tool ` +
+        `use. A block is one or the other, as it is on real Bedrock.`,
+    );
+  }
+
+  if (text === undefined && toolUse === undefined) {
+    throw new SimBedrockDeclarationError(
+      `A content block declared for ${subject} carries neither text nor a ` +
+        `tool use, and there is nothing for a response to answer with.`,
+    );
+  }
+
+  return block;
+}
+
+function blocksOf(
+  subject: string,
+  declared: SimBedrockDeclaredResponse,
+): readonly SimBedrockDeclaredContentBlock[] | undefined {
+  const { text, content } = declared;
+
+  if (text !== undefined && content !== undefined) {
+    throw new SimBedrockDeclarationError(
+      `The response declared for ${subject} carries both text and content ` +
+        `blocks. Text is the short form of one text block, so declare one or ` +
+        `the other.`,
+    );
+  }
+
+  if (text !== undefined) {
+    return [{ text }];
+  }
+
+  return content?.map((block) => checkedBlock(subject, block));
+}
+
+/**
+ * The content blocks a declared response answers `Converse` with.
+ *
+ * A response declared as a body alone has none, which is the ordinary case
+ * rather than an error: it answers `InvokeModel`. A response with no content
+ * and no body has nothing to answer anything with, and is refused where it was
+ * written.
+ */
+export function simBedrockDeclaredContent(
+  subject: string,
+  declared: SimBedrockDeclaredResponse,
+): readonly SimBedrockDeclaredContentBlock[] | undefined {
+  const blocks = blocksOf(subject, declared);
+
+  if (blocks === undefined && declared.body === undefined) {
+    throw new SimBedrockDeclarationError(
+      `The response declared for ${subject} carries no text, no content and ` +
+        `no body. Declare text or content for Converse, or a body for ` +
+        `InvokeModel.`,
+    );
+  }
+
+  return blocks;
+}

--- a/src/service/bedrock/response/sim-bedrock-declared-usage.ts
+++ b/src/service/bedrock/response/sim-bedrock-declared-usage.ts
@@ -1,0 +1,68 @@
+import { SimBedrockDeclarationError } from "../error/sim-bedrock.error.js";
+import type { SimBedrockDeclaredResponse } from "./sim-bedrock-response-declaration.js";
+import {
+  simBedrockDefaultInputTokens,
+  simBedrockDefaultOutputTokens,
+} from "./sim-bedrock-response-defaults.js";
+
+/**
+ * The token counts one response reports.
+ */
+export interface SimBedrockResponseUsage {
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly totalTokens: number;
+}
+
+function countOf(
+  subject: string,
+  name: string,
+  count: number | undefined,
+  fallback: number,
+): number {
+  if (count === undefined) {
+    return fallback;
+  }
+
+  if (!Number.isSafeInteger(count) || count < 0) {
+    throw new SimBedrockDeclarationError(
+      `The response declared for ${subject} reports ${count} ${name}. A ` +
+        `token count is a whole number of tokens and never negative.`,
+    );
+  }
+
+  return count;
+}
+
+/**
+ * The token counts a declared response reports, with the built-in figures
+ * standing in for the ones it left out.
+ *
+ * Counting the tokens in a prompt needs the tokenizer of the model the request
+ * names, and simulated Bedrock runs no model. A test asserting on a count
+ * declares one.
+ */
+export function simBedrockDeclaredUsage(
+  subject: string,
+  declared: SimBedrockDeclaredResponse,
+): SimBedrockResponseUsage {
+  const { usage } = declared;
+  const inputTokens = countOf(
+    subject,
+    "input tokens",
+    usage?.inputTokens,
+    simBedrockDefaultInputTokens,
+  );
+  const outputTokens = countOf(
+    subject,
+    "output tokens",
+    usage?.outputTokens,
+    simBedrockDefaultOutputTokens,
+  );
+
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens: inputTokens + outputTokens,
+  };
+}

--- a/src/service/bedrock/response/sim-bedrock-resolved-response.ts
+++ b/src/service/bedrock/response/sim-bedrock-resolved-response.ts
@@ -1,0 +1,103 @@
+import { SimBedrockDeclarationError } from "../error/sim-bedrock.error.js";
+import { simBedrockDeclaredContent } from "./sim-bedrock-declared-content.js";
+import {
+  simBedrockDeclaredUsage,
+  type SimBedrockResponseUsage,
+} from "./sim-bedrock-declared-usage.js";
+import type {
+  SimBedrockDeclaredContentBlock,
+  SimBedrockDeclaredResponse,
+} from "./sim-bedrock-response-declaration.js";
+import { simBedrockDefaultStopReason } from "./sim-bedrock-response-defaults.js";
+
+/**
+ * The message one `Converse` call answers with.
+ */
+export interface SimBedrockResponseMessage {
+  readonly role: "assistant";
+  readonly content: readonly SimBedrockDeclaredContentBlock[];
+}
+
+const toolUseStopReason = "tool_use";
+
+/**
+ * One declared response, resolved from its declaration.
+ *
+ * The declaration is resolved when the rule is registered, so a content block
+ * carrying two kinds of content at once, or a negative token count, is refused
+ * where it was written. What the response can answer is resolved per call,
+ * because which operation reaches a rule is only known then.
+ */
+export class SimBedrockResolvedResponse {
+  private readonly subject: string;
+  private readonly declared: SimBedrockDeclaredResponse;
+  private readonly declaredUsage: SimBedrockResponseUsage;
+  private readonly content:
+    | readonly SimBedrockDeclaredContentBlock[]
+    | undefined;
+
+  constructor(subject: string, declared: SimBedrockDeclaredResponse) {
+    this.subject = subject;
+    this.declared = declared;
+    this.content = simBedrockDeclaredContent(subject, declared);
+    this.declaredUsage = simBedrockDeclaredUsage(subject, declared);
+  }
+
+  /**
+   * The message a `Converse` call answers with.
+   *
+   * A response declared for `InvokeModel` alone has no message, and reaching
+   * it from `Converse` is a declaration this simulation cannot answer with.
+   */
+  message(): SimBedrockResponseMessage {
+    if (this.content === undefined) {
+      throw new SimBedrockDeclarationError(
+        `A Converse call matched the response declared for ${this.subject}, ` +
+          `which carries a body and nothing else. A body answers InvokeModel. ` +
+          `Declare text or content for Converse.`,
+      );
+    }
+
+    return { role: "assistant", content: this.content };
+  }
+
+  /**
+   * The body an `InvokeModel` call answers with, before it is serialized.
+   */
+  body(): unknown {
+    if (this.declared.body === undefined) {
+      throw new SimBedrockDeclarationError(
+        `An InvokeModel call matched the response declared for ` +
+          `${this.subject}, which carries no body. A response body is the ` +
+          `shape the model behind the id uses, so simulated Bedrock has no ` +
+          `default for it. Declare one with a body.`,
+      );
+    }
+
+    return this.declared.body;
+  }
+
+  /**
+   * Why the model stopped generating.
+   *
+   * A response holding a tool use stops for that, as a real one does, unless
+   * the declaration named a reason of its own.
+   */
+  stopReason(): string {
+    return this.declared.stopReason ?? this.reachedStopReason();
+  }
+
+  /**
+   * The token counts the response reports.
+   */
+  usage(): SimBedrockResponseUsage {
+    return this.declaredUsage;
+  }
+
+  private reachedStopReason(): string {
+    const callsATool =
+      this.content?.some((block) => block.toolUse !== undefined) === true;
+
+    return callsATool ? toolUseStopReason : simBedrockDefaultStopReason;
+  }
+}

--- a/src/service/bedrock/response/sim-bedrock-response-declaration.ts
+++ b/src/service/bedrock/response/sim-bedrock-response-declaration.ts
@@ -1,0 +1,54 @@
+/**
+ * A tool call a declared response asks the caller to make.
+ *
+ * The input is whatever the declaration carried. Real Bedrock hands back the
+ * arguments the model generated, and simulated Bedrock has no model to
+ * generate them.
+ */
+export interface SimBedrockDeclaredToolUse {
+  readonly toolUseId?: string | undefined;
+  readonly name?: string | undefined;
+  readonly input?: unknown;
+}
+
+/**
+ * One content block of a declared response message.
+ *
+ * A block carries text or a tool call. Declaring both on one block, or
+ * neither, is refused where the rule is written.
+ */
+export interface SimBedrockDeclaredContentBlock {
+  readonly text?: string | undefined;
+  readonly toolUse?: SimBedrockDeclaredToolUse | undefined;
+}
+
+/**
+ * The token counts a declared response reports.
+ *
+ * Every count is optional and an absent one falls back to the built-in figure.
+ * Real Bedrock counts tokens with the model's own tokenizer, which simulated
+ * Bedrock has no way to run.
+ */
+export interface SimBedrockDeclaredUsage {
+  readonly inputTokens?: number | undefined;
+  readonly outputTokens?: number | undefined;
+}
+
+/**
+ * What simulated Bedrock answers one request with.
+ *
+ * The members an operation reads are the ones it can use. `Converse` answers
+ * from `text` or `content`, and `InvokeModel` answers from `body`. A
+ * declaration carrying nothing the operation asking for it can use is refused
+ * where the call is made rather than answered with the built-in default.
+ *
+ * `text` is the short form of a single text content block, and declaring both
+ * it and `content` is refused where the rule is written.
+ */
+export interface SimBedrockDeclaredResponse {
+  readonly text?: string | undefined;
+  readonly content?: readonly SimBedrockDeclaredContentBlock[] | undefined;
+  readonly body?: unknown;
+  readonly stopReason?: string | undefined;
+  readonly usage?: SimBedrockDeclaredUsage | undefined;
+}

--- a/src/service/bedrock/response/sim-bedrock-response-defaults.ts
+++ b/src/service/bedrock/response/sim-bedrock-response-defaults.ts
@@ -1,0 +1,37 @@
+import type { SimBedrockDeclaredResponse } from "./sim-bedrock-response-declaration.js";
+
+/**
+ * The text an undeclared `Converse` call answers with.
+ *
+ * It says what it is. A default that reads like a real model answer would be
+ * asserted on by a test that meant to declare one, and the assertion would
+ * pass for the wrong reason.
+ */
+export const simBedrockDefaultText =
+  "This is a simulated Amazon Bedrock model response.";
+
+/**
+ * The stop reason a response reports where the declaration named none.
+ */
+export const simBedrockDefaultStopReason = "end_turn";
+
+/**
+ * The token counts a response reports where the declaration named none.
+ *
+ * They are fixed. Counting the tokens in a prompt needs the tokenizer of the
+ * model the request names, and simulated Bedrock runs no model. A test that
+ * asserts on a count declares one.
+ */
+export const simBedrockDefaultInputTokens = 12;
+export const simBedrockDefaultOutputTokens = 24;
+
+/**
+ * What a `Converse` call answers with where no rule matches it.
+ *
+ * There is no equivalent for `InvokeModel`. Its response body is whatever
+ * shape the model behind the id uses, and a default would be one model
+ * family's shape served for every other one.
+ */
+export const simBedrockDefaultResponse: SimBedrockDeclaredResponse = {
+  text: simBedrockDefaultText,
+};

--- a/src/service/bedrock/response/sim-bedrock-responses.ts
+++ b/src/service/bedrock/response/sim-bedrock-responses.ts
@@ -1,0 +1,95 @@
+import { SimDeclaredResultRules } from "../../../util/rule/sim-declared-result-rules.js";
+import { SimBedrockDeclarationError } from "../error/sim-bedrock.error.js";
+import type { SimBedrockDeclaredResponse } from "./sim-bedrock-response-declaration.js";
+import { simBedrockDefaultResponse } from "./sim-bedrock-response-defaults.js";
+import { SimBedrockResolvedResponse } from "./sim-bedrock-resolved-response.js";
+
+/**
+ * The request a response rule is matched against.
+ */
+export interface SimBedrockResponseRequest {
+  readonly prompt?: string | undefined;
+  readonly modelId?: string | undefined;
+}
+
+function requireRuleKey(key: string, description: string): string {
+  if (key.length === 0) {
+    throw new SimBedrockDeclarationError(
+      `A simulated Bedrock rule needs ${description} to match`,
+    );
+  }
+
+  return key;
+}
+
+/**
+ * The responses one simulated Bedrock answers model invocations with.
+ *
+ * A rule for an exact prompt wins, then a rule for an exact model id, then the
+ * default. That ordering is `SimDeclaredResultRules`, which simulated
+ * Rekognition matches images with and simulated Personalize matches
+ * recommendation requests with. What is Bedrock's own is which key each tier
+ * holds.
+ *
+ * Prompt is the specific tier and model the broad one. A model rule covers
+ * every call to that model, which is what a test asserting on the code around
+ * the call wants. A prompt rule picks out the one exchange a test is about.
+ *
+ * Rules sit on the service and name no resource. Real Bedrock invokes a
+ * foundation model that was there before the account was, leaving a test
+ * nothing to create and a rule nothing to hang off.
+ */
+export class SimBedrockResponses {
+  private readonly rules =
+    new SimDeclaredResultRules<SimBedrockResolvedResponse>(
+      new SimBedrockResolvedResponse("any request", simBedrockDefaultResponse),
+    );
+
+  /**
+   * Answer with this response for any request no other rule matches.
+   */
+  byDefault(response: SimBedrockDeclaredResponse): void {
+    this.rules.byDefault(
+      new SimBedrockResolvedResponse("any request", response),
+    );
+  }
+
+  /**
+   * Answer with this response for a request carrying this exact prompt.
+   *
+   * The prompt of a `Converse` request is the text of its last user message.
+   * The prompt of an `InvokeModel` request is its body decoded as UTF-8, since
+   * the body is model-specific and Bedrock reads nothing inside it.
+   */
+  onPrompt(prompt: string, response: SimBedrockDeclaredResponse): void {
+    this.rules.onLeadingKey(
+      requireRuleKey(prompt, "a prompt"),
+      new SimBedrockResolvedResponse(`the prompt '${prompt}'`, response),
+    );
+  }
+
+  /**
+   * Answer with this response for a request naming this exact model, where no
+   * prompt rule matched it first.
+   *
+   * The model is matched as the request wrote it. A request naming an
+   * inference profile or a model ARN matches a rule declared under that same
+   * value.
+   */
+  onModel(modelId: string, response: SimBedrockDeclaredResponse): void {
+    this.rules.onTrailingKey(
+      requireRuleKey(modelId, "a model id"),
+      new SimBedrockResolvedResponse(`the model '${modelId}'`, response),
+    );
+  }
+
+  /**
+   * The response declared for one request.
+   */
+  responseFor(request: SimBedrockResponseRequest): SimBedrockResolvedResponse {
+    return this.rules.resultFor({
+      leading: request.prompt,
+      trailing: request.modelId,
+    });
+  }
+}

--- a/src/service/bedrock/sdk/sim-bedrock-sdk-command-router.ts
+++ b/src/service/bedrock/sdk/sim-bedrock-sdk-command-router.ts
@@ -1,0 +1,53 @@
+import {
+  simSdkCallerOptions,
+  type SimSdkCommandRoute,
+  type SimSdkCommandRouter,
+} from "../../../sdk/index.js";
+import type { SimConverseCommand } from "../command/converse/converse.command.js";
+import type { SimInvokeModelCommand } from "../command/invoke-model/invoke-model.command.js";
+import type { SimBedrock } from "../sim-bedrock.js";
+
+/**
+ * Routes intercepted SDK Commands to one scoped simulated Bedrock.
+ *
+ * An intercepted `BedrockRuntimeClient` reports the `Bedrock Runtime` service
+ * id, which is where the invocation commands arrive from.
+ */
+export class SimBedrockSdkCommandRouter implements SimSdkCommandRouter {
+  private readonly routes: ReadonlyMap<string, SimSdkCommandRoute>;
+
+  constructor(simBedrock: SimBedrock) {
+    this.routes = new Map<string, SimSdkCommandRoute>([
+      [
+        "ConverseCommand",
+        async (command, context): Promise<unknown> =>
+          await simBedrock.converse(
+            command as SimConverseCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "InvokeModelCommand",
+        async (command, context): Promise<unknown> =>
+          await simBedrock.invokeModel(
+            command as SimInvokeModelCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+    ]);
+  }
+
+  /**
+   * The SDK Command names simulated Bedrock can handle.
+   */
+  supportedCommandNames(): readonly string[] {
+    return this.routes.keys().toArray();
+  }
+
+  /**
+   * Get the route for an SDK Command name, if simulated Bedrock supports it.
+   */
+  route(commandName: string): SimSdkCommandRoute | undefined {
+    return this.routes.get(commandName);
+  }
+}

--- a/src/service/bedrock/sdk/sim-bedrock-sdk-routing.iso.test.ts
+++ b/src/service/bedrock/sdk/sim-bedrock-sdk-routing.iso.test.ts
@@ -1,0 +1,138 @@
+import {
+  BedrockRuntimeClient,
+  ConverseCommand,
+  InvokeModelCommand,
+} from "@aws-sdk/client-bedrock-runtime";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimSdk } from "../../../sdk/index.js";
+
+const sonnet = "anthropic.claude-3-5-sonnet-20241022-v2:0";
+
+describe("Bedrock SDK interception", () => {
+  it("answers an intercepted BedrockRuntimeClient from declared responses", async () => {
+    // Given an intercepted Bedrock Runtime client.
+    const simSdk = new SimSdk();
+    simSdk.intercept(BedrockRuntimeClient);
+
+    const client = new BedrockRuntimeClient({ region: "eu-west-2" });
+
+    try {
+      // And a response declared in the Region it calls.
+      simSdk.simAws
+        .account()
+        .region("eu-west-2")
+        .bedrock()
+        .responses()
+        .onPrompt("Summarise entry 1042", {
+          text: "Entry 1042 covers the tone sandhi rules.",
+        });
+
+      // When production code converses through the client.
+      const answered = await client.send(
+        new ConverseCommand({
+          modelId: sonnet,
+          messages: [
+            { role: "user", content: [{ text: "Summarise entry 1042" }] },
+          ],
+        }),
+      );
+
+      // Then the declared response comes back through the SDK's own types.
+      assertNonNullable(answered.output);
+      assertIdentical(
+        answered.output.message?.content?.at(0)?.text,
+        "Entry 1042 covers the tone sandhi rules.",
+      );
+      assertIdentical(answered.stopReason, "end_turn");
+    } finally {
+      client.destroy();
+      simSdk.restoreAll();
+    }
+  });
+
+  it("answers an intercepted InvokeModel with the declared body", async () => {
+    // Given an intercepted Bedrock Runtime client and a declared body.
+    const simSdk = new SimSdk();
+    simSdk.intercept(BedrockRuntimeClient);
+
+    const client = new BedrockRuntimeClient({ region: "eu-west-2" });
+
+    try {
+      simSdk.simAws
+        .account()
+        .region("eu-west-2")
+        .bedrock()
+        .responses()
+        .byDefault({ body: { results: [{ outputText: "Tone sandhi." }] } });
+
+      // When production code invokes a model through the client.
+      const answered = await client.send(
+        new InvokeModelCommand({
+          modelId: "amazon.titan-text-express-v1",
+          body: JSON.stringify({ inputText: "Summarise entry 1042" }),
+        }),
+      );
+
+      // Then the body decodes the way production code decodes it.
+      assertNonNullable(answered.body);
+      assertStringIncludes(
+        new TextDecoder().decode(answered.body),
+        "Tone sandhi.",
+      );
+    } finally {
+      client.destroy();
+      simSdk.restoreAll();
+    }
+  });
+
+  it("refuses a malformed request through the client rather than over the network", async () => {
+    // Given an intercepted Bedrock Runtime client.
+    const simSdk = new SimSdk();
+    simSdk.intercept(BedrockRuntimeClient);
+
+    const client = new BedrockRuntimeClient({ region: "eu-west-2" });
+
+    try {
+      // When production code streams a conversation.
+      const error = await assertThrowsErrorAsync(
+        async () =>
+          await client.send(
+            new ConverseCommand({
+              modelId: sonnet,
+              messages: [],
+            }),
+          ),
+      );
+
+      // Then the refusal comes from the simulation, in Bedrock's own terms.
+      assertIdentical(error.name, "ValidationException");
+    } finally {
+      client.destroy();
+      simSdk.restoreAll();
+    }
+  });
+
+  it("supports the Commands its router names and no others", () => {
+    // Given a simulated Bedrock.
+    const simSdk = new SimSdk();
+
+    // When its router is asked what it handles.
+    const supported = simSdk.simAws
+      .bedrock()
+      .sdkCommandRouter()
+      .supportedCommandNames();
+
+    // Then it names the two invocation commands.
+    assertArrayEquals(
+      supported.toSorted((a, b) => a.localeCompare(b)),
+      ["ConverseCommand", "InvokeModelCommand"],
+    );
+  });
+});

--- a/src/service/bedrock/sim-bedrock.ts
+++ b/src/service/bedrock/sim-bedrock.ts
@@ -1,0 +1,118 @@
+import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../util/background/background.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
+import { SimBedrockAuthorizer } from "./command/authorize/sim-bedrock-authorizer.js";
+import type {
+  SimConverseCommand,
+  SimConverseCommandOutput,
+} from "./command/converse/converse.command.js";
+import { SimBedrockConverseHandler } from "./command/converse/sim-bedrock-converse.js";
+import type {
+  SimInvokeModelCommand,
+  SimInvokeModelCommandOutput,
+} from "./command/invoke-model/invoke-model.command.js";
+import { SimBedrockInvokeModelHandler } from "./command/invoke-model/sim-bedrock-invoke-model.js";
+import type { SimBedrockRequestOptions } from "./command/sim-bedrock-request-options.js";
+import { SimBedrockResponses } from "./response/sim-bedrock-responses.js";
+import { SimBedrockSdkCommandRouter } from "./sdk/sim-bedrock-sdk-command-router.js";
+
+interface SimBedrockProperties {
+  readonly accountRegionScope?: SimAwsAccountRegionScope;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * Simulated Amazon Bedrock. Handles SDK commands. Emulates AWS behaviour and
+ * state.
+ *
+ * No model runs here. Bedrock is a service where the interesting behaviour is
+ * not the call but what the call answers with, so the simulation answers from
+ * responses declared against a prompt or a model, in the way simulated
+ * Rekognition answers a detection from results declared against an image. A
+ * test says what the model says, and the system under test makes the same
+ * calls it would make against AWS.
+ *
+ * One accessor covers Bedrock. The runtime commands are here, and the control
+ * plane reaches the same service when it arrives.
+ */
+export class SimBedrock {
+  private readonly responseRules = new SimBedrockResponses();
+  private readonly converseCommand: SimBedrockConverseHandler;
+  private readonly invokeModelCommand: SimBedrockInvokeModelHandler;
+  private readonly background: BackgroundScheduler;
+  private readonly sdkRouter = new SimBedrockSdkCommandRouter(this);
+
+  constructor(properties: SimBedrockProperties = {}) {
+    const {
+      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+    const commandProperties = {
+      responses: this.responseRules,
+      authorizer: new SimBedrockAuthorizer({ iam }),
+      accountRegionScope,
+    };
+
+    this.background = background;
+    this.converseCommand = new SimBedrockConverseHandler(commandProperties);
+    this.invokeModelCommand = new SimBedrockInvokeModelHandler(
+      commandProperties,
+    );
+  }
+
+  /**
+   * The responses this simulated Bedrock answers model invocations with.
+   *
+   * Every call answers with the built-in default until a rule says otherwise:
+   *
+   * ```typescript
+   * simAws.bedrock().responses().onPrompt("Summarise entry 1042", {
+   *   text: "Entry 1042 covers the tone sandhi rules.",
+   * });
+   * ```
+   */
+  responses(): SimBedrockResponses {
+    return this.responseRules;
+  }
+
+  /**
+   * Handle a Converse Command from the SDK.
+   */
+  async converse(
+    command: SimConverseCommand,
+    options?: SimBedrockRequestOptions,
+  ): Promise<SimConverseCommandOutput> {
+    await this.background.sequence();
+
+    return this.converseCommand.handle(command, options);
+  }
+
+  /**
+   * Handle an InvokeModel Command from the SDK.
+   */
+  async invokeModel(
+    command: SimInvokeModelCommand,
+    options?: SimBedrockRequestOptions,
+  ): Promise<SimInvokeModelCommandOutput> {
+    await this.background.sequence();
+
+    return this.invokeModelCommand.handle(command, options);
+  }
+
+  /**
+   * Get this service's SDK Command router for SDK client interception.
+   */
+  sdkCommandRouter(): SimSdkCommandRouter {
+    return this.sdkRouter;
+  }
+}


### PR DESCRIPTION
Simulated Amazon Bedrock answers `Converse` and `InvokeModel` from responses declared against a prompt or a model, with no model running and the prompt read only as a key to match on, in the way simulated Rekognition answers a detection without looking at an image. Both commands work through `simAws.bedrock()` and through an intercepted `BedrockRuntimeClient`, and each authorizes `bedrock:InvokeModel` through simulated IAM against the foundation model, inference profile or provisioned model ARN the request names. A prompt rule wins over a model rule, which wins over the default, on the same `SimDeclaredResultRules` matcher simulated Rekognition and simulated Personalize answer from. A declared response carries text or content blocks for `Converse` and a body for `InvokeModel`, along with an optional stop reason and token counts, and a `guardrailConfig` or `guardrailIdentifier` is refused rather than answered without the guardrail.

Resolves #912

## Decisions worth a second look

**One rule set, and rules that name no resource.** Simulated Personalize hangs its rules off a campaign, because a campaign is what a runtime call names and what a test creates first. A foundation model was there before the account was, so a Bedrock rule hangs off the service itself. One rule set covers both operations, so a test declaring a response gets it whichever API the code under test calls.

**No default response body for `InvokeModel`.** `Converse` answers an unconfigured call with a built-in line of text saying it is simulated. A response body is whatever shape the model behind the id uses, and one family's shape served for every other family would parse into something the caller cannot read. An invocation matching a rule that declares none is refused, naming the rule it reached. A `Converse` call matching a body-only declaration is refused for the same reason rather than falling back to the default.

**`inferenceConfig` and `toolConfig` are accepted and have no effect.** They decide what a model generates, and no model generates anything here. Refusing them would refuse most production code on its first call. `guardrailConfig` is the one refused, because a guardrail would be missing here and applied in production.

**The prompt of a `Converse` request is its last user message.** A rule keyed on the whole history would stop matching as soon as the conversation grew by one exchange, which is the case a multi-turn test is about.

**Token counts are fixed unless declared.** Counting them needs the tokenizer of the model the request names.

## What is left out

Streaming is #913 and builds on this. Also left out and refused rather than half-simulated: `ApplyGuardrail`, the control plane on `BedrockClient`, agents and knowledge bases, and the `AWS::Bedrock::*` CloudFormation types.
