### PR TITLE
feat: simulate Kinesis data streams

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ behaviour and includes example code that can be copied into tests or local devel
 - [Elastic Load Balancing](./services/elbv2/ "Simulated Application Load Balancer usage docs")
 - [EventBridge](./services/eventbridge/ "Simulated EventBridge usage docs")
 - [IAM](./services/iam/ "Simulated IAM usage docs")
+- [Kinesis Data Streams](./services/kinesis/ "Simulated Kinesis Data Streams usage docs")
 - [KMS](./services/kms/ "Simulated KMS usage docs")
 - [Lambda](./services/lambda/ "Simulated Lambda usage docs")
 - [CloudWatch Logs](./services/logs/ "Simulated CloudWatch Logs usage docs")

--- a/docs/services/kinesis/README.md
+++ b/docs/services/kinesis/README.md
@@ -1,0 +1,365 @@
+# Simulated Kinesis Data Streams
+
+Yulin includes a simulated Kinesis Data Streams for tests and local development. It creates streams,
+places records on shards the way real Kinesis does, and hands them back through shard iterators. A
+test can put an event and assert that the consumer read it, without an AWS account and without
+waiting on a real stream.
+
+Kinesis specific types are imported from the `@kensio/yulin/kinesis` subpath.
+
+## Putting a record and reading it back
+
+`simAws.kinesis()` gives the service for the default account and region. Records go on with
+`PutRecord`, and come off through a shard iterator, which is the walk every Kinesis consumer makes.
+
+```typescript sim-kinesis-put-and-read
+/**
+ * Putting an order event on a stream and reading it back.
+ */
+
+import {
+  CreateStreamCommand,
+  GetRecordsCommand,
+  GetShardIteratorCommand,
+  PutRecordCommand,
+} from "@aws-sdk/client-kinesis";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const kinesis = simAws.kinesis();
+
+await kinesis.createStream(
+  new CreateStreamCommand({ StreamName: "orders", ShardCount: 1 }),
+);
+
+const orderEvent = new TextEncoder().encode(JSON.stringify({ id: "order-1" }));
+
+await kinesis.putRecord(
+  new PutRecordCommand({
+    StreamName: "orders",
+    PartitionKey: "customer-1",
+    Data: orderEvent,
+  }),
+);
+
+const { ShardIterator } = await kinesis.getShardIterator(
+  new GetShardIteratorCommand({
+    StreamName: "orders",
+    ShardId: "shardId-000000000000",
+    ShardIteratorType: "TRIM_HORIZON",
+  }),
+);
+
+const { Records } = await kinesis.getRecords(
+  new GetRecordsCommand({ ShardIterator }),
+);
+
+// {"id":"order-1"}
+console.log(new TextDecoder().decode(Records[0]?.Data));
+```
+
+A record keeps the bytes it was given. Whatever the producer encoded is what the consumer decodes.
+
+## Shards and partition keys
+
+A stream is created with the shard count it asks for, and each shard owns a slice of a 128 bit hash
+key space. A record goes to the shard whose slice covers the MD5 hash of its partition key, which is
+the placement real Kinesis makes. Two records sharing a partition key therefore land on one shard,
+in the order they were put, and that per-key ordering is what most Kinesis consumers depend on.
+
+Records under different partition keys can land anywhere. A consumer that has to see every record
+reads every shard.
+
+```typescript sim-kinesis-shards
+/**
+ * Reading which shard a record landed on, and which slice each shard owns.
+ */
+
+import {
+  CreateStreamCommand,
+  DescribeStreamCommand,
+  PutRecordCommand,
+} from "@aws-sdk/client-kinesis";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const kinesis = simAws.kinesis();
+
+await kinesis.createStream(
+  new CreateStreamCommand({ StreamName: "orders", ShardCount: 2 }),
+);
+
+const first = await kinesis.putRecord(
+  new PutRecordCommand({
+    StreamName: "orders",
+    PartitionKey: "customer-1",
+    Data: new TextEncoder().encode("order-1"),
+  }),
+);
+
+const second = await kinesis.putRecord(
+  new PutRecordCommand({
+    StreamName: "orders",
+    PartitionKey: "customer-1",
+    Data: new TextEncoder().encode("order-2"),
+  }),
+);
+
+// true: one partition key means one shard.
+console.log(first.ShardId === second.ShardId);
+
+const { StreamDescription } = await kinesis.describeStream(
+  new DescribeStreamCommand({ StreamName: "orders" }),
+);
+
+// shardId-000000000000 0
+console.log(
+  StreamDescription.Shards[0]?.ShardId,
+  StreamDescription.Shards[0]?.HashKeyRange.StartingHashKey,
+);
+```
+
+An `ExplicitHashKey` on a record overrides the partition key for placement, and the record still
+carries the partition key the producer gave it. That is how a producer pins a record to a shard it
+picked.
+
+A stream created with `StreamModeDetails` of `ON_DEMAND` gets four shards, which is what real
+Kinesis starts an on-demand stream with. Nothing here grows or shrinks that count.
+
+## Where a read starts
+
+Every shard iterator type resolves to a place on the shard.
+
+| `ShardIteratorType`     | Starts at                                                     |
+| ----------------------- | ------------------------------------------------------------- |
+| `TRIM_HORIZON`          | The oldest record the shard still holds.                      |
+| `LATEST`                | After the newest record at the moment the iterator was taken. |
+| `AT_SEQUENCE_NUMBER`    | The record with that sequence number.                         |
+| `AFTER_SEQUENCE_NUMBER` | The record following that sequence number.                    |
+| `AT_TIMESTAMP`          | The first record that arrived at or after the instant given.  |
+
+`GetRecords` hands back a `NextShardIterator` pointing at where the read finished, which is what a
+polling consumer passes to its next call. A read that has caught up comes back empty with an
+iterator standing where it was.
+
+`MillisBehindLatest` reports how far behind the tip the reader is. Zero means caught up. Otherwise
+it is the age of the last record handed back, measured against simulated time.
+
+## Retention
+
+A stream keeps a record for 24 hours. Records older than that are gone from a read, and trimming is
+applied at the instant of the read rather than on a timer, so moving simulated time forward is all a
+test needs.
+
+```typescript sim-kinesis-retention
+/**
+ * Ageing a record out of a stream's retention window.
+ */
+
+import {
+  CreateStreamCommand,
+  GetRecordsCommand,
+  GetShardIteratorCommand,
+  PutRecordCommand,
+} from "@aws-sdk/client-kinesis";
+
+import { SimAws, SimFixedClock } from "@kensio/yulin";
+
+const simAws = new SimAws({
+  clock: new SimFixedClock(new Date("2026-08-22T09:00:00.000Z")),
+});
+const kinesis = simAws.kinesis();
+
+await kinesis.createStream(new CreateStreamCommand({ StreamName: "orders" }));
+
+await kinesis.putRecord(
+  new PutRecordCommand({
+    StreamName: "orders",
+    PartitionKey: "customer-1",
+    Data: new TextEncoder().encode("order-1"),
+  }),
+);
+
+await simAws.clock().advanceBy({ hours: 25 });
+
+const { ShardIterator } = await kinesis.getShardIterator(
+  new GetShardIteratorCommand({
+    StreamName: "orders",
+    ShardId: "shardId-000000000000",
+    ShardIteratorType: "TRIM_HORIZON",
+  }),
+);
+
+const { Records } = await kinesis.getRecords(
+  new GetRecordsCommand({ ShardIterator }),
+);
+
+// 0: the record aged out of the 24 hour window.
+console.log(Records.length);
+```
+
+## Permissions
+
+Every operation goes through simulated IAM. The action is the `kinesis:` name of the operation, and
+the resource is the stream ARN, `arn:aws:kinesis:<region>:<account>:stream/<name>`. `ListStreams`
+names no stream and authorizes against `*`.
+
+`GetRecords` authorizes against the stream the iterator was made on, which the iterator carries. A
+caller cannot reach a stream it lacks permission for by holding someone else's iterator.
+
+```typescript sim-kinesis-permissions
+/**
+ * Refusing a producer that has no permission on the stream.
+ */
+
+import { PutRecordCommand } from "@aws-sdk/client-kinesis";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+// A Role allowed to read the stream and nothing else.
+const { Role } = await simAws.iam().createRole({
+  input: {
+    RoleName: "OrderReader",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { AWS: `arn:aws:iam::${simAws.defaultAccountId}:root` },
+          Action: "sts:AssumeRole",
+        },
+      ],
+    }),
+  },
+});
+
+await simAws.iam().putRolePolicy({
+  input: {
+    RoleName: "OrderReader",
+    PolicyName: "ReadOrders",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        { Effect: "Allow", Action: "kinesis:GetRecords", Resource: "*" },
+      ],
+    }),
+  },
+});
+
+await simAws.kinesis().createStream({ input: { StreamName: "orders" } });
+
+try {
+  await simAws.kinesis().putRecord(
+    new PutRecordCommand({
+      StreamName: "orders",
+      PartitionKey: "customer-1",
+      Data: new TextEncoder().encode("order-1"),
+    }),
+    { caller: { kind: "arn", arn: Role.Arn } },
+  );
+} catch (error) {
+  // User: arn:aws:iam::...:role/OrderReader is not authorized to perform:
+  // kinesis:PutRecord on resource: arn:aws:kinesis:...:stream/orders
+  console.log((error as Error).message);
+}
+```
+
+## SDK interception
+
+A `KinesisClient` handed to `SimSdk` reaches the simulated service, so application code that builds
+its own client needs no change.
+
+```typescript sim-kinesis-sdk-interception
+/**
+ * Running unchanged Kinesis application code against the simulator.
+ */
+
+import {
+  CreateStreamCommand,
+  KinesisClient,
+  PutRecordCommand,
+} from "@aws-sdk/client-kinesis";
+
+import { SimSdk } from "@kensio/yulin/sdk";
+
+using simSdk = new SimSdk();
+simSdk.intercept(KinesisClient);
+
+// Ordinary application code, with nothing about it that knows it is simulated.
+const kinesis = new KinesisClient({ region: "eu-west-2" });
+
+await kinesis.send(
+  new CreateStreamCommand({ StreamName: "orders", ShardCount: 1 }),
+);
+
+const put = await kinesis.send(
+  new PutRecordCommand({
+    StreamName: "orders",
+    PartitionKey: "customer-1",
+    Data: new TextEncoder().encode("order-1"),
+  }),
+);
+
+// shardId-000000000000
+console.log(put.ShardId);
+```
+
+## Supported commands
+
+| Command                 | Notes                                                                  |
+| ----------------------- | ---------------------------------------------------------------------- |
+| `CreateStream`          | A name already in use raises `ResourceInUseException`.                 |
+| `DeleteStream`          | The name is free again at once. `EnforceConsumerDeletion` is accepted. |
+| `ListStreams`           | Sorted by name, paged with `Limit` and `NextToken`.                    |
+| `DescribeStream`        | Shards paged with `Limit` and `ExclusiveStartShardId`.                 |
+| `DescribeStreamSummary` | Reports the open shard count instead of the shards.                    |
+| `PutRecord`             | `SequenceNumberForOrdering` is accepted and already guaranteed.        |
+| `PutRecords`            | Up to 500 records and 5 MB. `FailedRecordCount` is always zero.        |
+| `GetShardIterator`      | Every iterator type resolves.                                          |
+| `GetRecords`            | `Limit` up to 10,000. Reports `MillisBehindLatest`.                    |
+
+Every operation takes `StreamName` or `StreamARN`, and reads the ARN when a request carries both.
+
+Anything else refuses on send with `SimSdkUnsupportedCommandError`.
+
+## Divergences and limitations
+
+- **A stream is `ACTIVE` as soon as it exists.** Real Kinesis reports `CREATING` while it brings the
+  shards up, and a status a test has to poll through earns nothing when there are no shards to bring
+  up. `DELETING` and `UPDATING` are absent for the same reason.
+- **Nothing reshards.** `UpdateShardCount`, `SplitShard` and `MergeShards` move the shard map
+  underneath consumers holding iterators, and they are left out. A shard is opened when the stream
+  is created and never closes, so no shard reports an ending sequence number and no read reports a
+  child shard.
+- **Enhanced fan-out is absent.** `RegisterStreamConsumer`, `DeregisterStreamConsumer`,
+  `ListStreamConsumers`, `DescribeStreamConsumer` and `SubscribeToShard` need an HTTP/2 event stream
+  that nothing here delivers. Every consumer reads through `GetRecords`.
+- **A shard iterator never expires.** Real Kinesis expires one after five minutes. An iterator this
+  simulation never issued is still refused, with the `ExpiredIteratorException` real Kinesis uses.
+- **Retention is fixed at 24 hours.** `IncreaseStreamRetentionPeriod` and
+  `DecreaseStreamRetentionPeriod` are absent.
+- **Throughput is unlimited.** Real Kinesis takes 1 MB or 1,000 records a second per shard for
+  writes and 2 MB a second for reads, and refuses past that with
+  `ProvisionedThroughputExceededException`. Nothing here counts. That is why `FailedRecordCount` on
+  `PutRecords` is always zero: the reasons real Kinesis fails one record of a batch are throughput
+  limits and internal faults, and neither is simulated. The per-record result shape is still what a
+  consumer of the response reads.
+- **Sequence numbers are 56 digit counters.** They are unique within a stream and increase within a
+  shard, as real Kinesis promises. They also increase across shards here, which real Kinesis does
+  not promise, so a consumer ordering two records from different shards would be relying on
+  something AWS does not offer.
+- **Server-side encryption is absent.** `StartStreamEncryption` and `StopStreamEncryption` are left
+  out, and no response carries an `EncryptionType`.
+- **Tags are kept and never listed.** A stream created with `Tags` holds them, readable through
+  `findStream`. `AddTagsToStream`, `ListTagsForStream` and `RemoveTagsFromStream` are absent.
+- **Nothing triggers a Lambda function.** An event source mapping naming a Kinesis stream is refused
+  at creation.
+- **`AWS::Kinesis::Stream` does not deploy.** A CloudFormation template holding one records the
+  resource as skipped.
+- **Kinesis Data Firehose is a separate service and is absent.** So is Kinesis Video Streams.
+- **`AWS::DynamoDB::Table` `KinesisStreamSpecification` stays unsimulated.** A table does not publish
+  its changes into a stream here.

--- a/docs/services/kinesis/sim-kinesis-permissions.example.ts
+++ b/docs/services/kinesis/sim-kinesis-permissions.example.ts
@@ -1,0 +1,56 @@
+/**
+ * Refusing a producer that has no permission on the stream.
+ */
+
+import { PutRecordCommand } from "@aws-sdk/client-kinesis";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+// A Role allowed to read the stream and nothing else.
+const { Role } = await simAws.iam().createRole({
+  input: {
+    RoleName: "OrderReader",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { AWS: `arn:aws:iam::${simAws.defaultAccountId}:root` },
+          Action: "sts:AssumeRole",
+        },
+      ],
+    }),
+  },
+});
+
+await simAws.iam().putRolePolicy({
+  input: {
+    RoleName: "OrderReader",
+    PolicyName: "ReadOrders",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        { Effect: "Allow", Action: "kinesis:GetRecords", Resource: "*" },
+      ],
+    }),
+  },
+});
+
+await simAws.kinesis().createStream({ input: { StreamName: "orders" } });
+
+try {
+  await simAws.kinesis().putRecord(
+    new PutRecordCommand({
+      StreamName: "orders",
+      PartitionKey: "customer-1",
+      Data: new TextEncoder().encode("order-1"),
+    }),
+    { caller: { kind: "arn", arn: Role.Arn } },
+  );
+} catch (error) {
+  // User: arn:aws:iam::...:role/OrderReader is not authorized to perform:
+  // kinesis:PutRecord on resource: arn:aws:kinesis:...:stream/orders
+  console.log((error as Error).message);
+}

--- a/docs/services/kinesis/sim-kinesis-put-and-read.example.ts
+++ b/docs/services/kinesis/sim-kinesis-put-and-read.example.ts
@@ -1,0 +1,44 @@
+/**
+ * Putting an order event on a stream and reading it back.
+ */
+
+import {
+  CreateStreamCommand,
+  GetRecordsCommand,
+  GetShardIteratorCommand,
+  PutRecordCommand,
+} from "@aws-sdk/client-kinesis";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const kinesis = simAws.kinesis();
+
+await kinesis.createStream(
+  new CreateStreamCommand({ StreamName: "orders", ShardCount: 1 }),
+);
+
+const orderEvent = new TextEncoder().encode(JSON.stringify({ id: "order-1" }));
+
+await kinesis.putRecord(
+  new PutRecordCommand({
+    StreamName: "orders",
+    PartitionKey: "customer-1",
+    Data: orderEvent,
+  }),
+);
+
+const { ShardIterator } = await kinesis.getShardIterator(
+  new GetShardIteratorCommand({
+    StreamName: "orders",
+    ShardId: "shardId-000000000000",
+    ShardIteratorType: "TRIM_HORIZON",
+  }),
+);
+
+const { Records } = await kinesis.getRecords(
+  new GetRecordsCommand({ ShardIterator }),
+);
+
+// {"id":"order-1"}
+console.log(new TextDecoder().decode(Records[0]?.Data));

--- a/docs/services/kinesis/sim-kinesis-retention.example.ts
+++ b/docs/services/kinesis/sim-kinesis-retention.example.ts
@@ -1,0 +1,44 @@
+/**
+ * Ageing a record out of a stream's retention window.
+ */
+
+import {
+  CreateStreamCommand,
+  GetRecordsCommand,
+  GetShardIteratorCommand,
+  PutRecordCommand,
+} from "@aws-sdk/client-kinesis";
+
+import { SimAws, SimFixedClock } from "@kensio/yulin";
+
+const simAws = new SimAws({
+  clock: new SimFixedClock(new Date("2026-08-22T09:00:00.000Z")),
+});
+const kinesis = simAws.kinesis();
+
+await kinesis.createStream(new CreateStreamCommand({ StreamName: "orders" }));
+
+await kinesis.putRecord(
+  new PutRecordCommand({
+    StreamName: "orders",
+    PartitionKey: "customer-1",
+    Data: new TextEncoder().encode("order-1"),
+  }),
+);
+
+await simAws.clock().advanceBy({ hours: 25 });
+
+const { ShardIterator } = await kinesis.getShardIterator(
+  new GetShardIteratorCommand({
+    StreamName: "orders",
+    ShardId: "shardId-000000000000",
+    ShardIteratorType: "TRIM_HORIZON",
+  }),
+);
+
+const { Records } = await kinesis.getRecords(
+  new GetRecordsCommand({ ShardIterator }),
+);
+
+// 0: the record aged out of the 24 hour window.
+console.log(Records.length);

--- a/docs/services/kinesis/sim-kinesis-sdk-interception.example.ts
+++ b/docs/services/kinesis/sim-kinesis-sdk-interception.example.ts
@@ -1,0 +1,32 @@
+/**
+ * Running unchanged Kinesis application code against the simulator.
+ */
+
+import {
+  CreateStreamCommand,
+  KinesisClient,
+  PutRecordCommand,
+} from "@aws-sdk/client-kinesis";
+
+import { SimSdk } from "@kensio/yulin/sdk";
+
+using simSdk = new SimSdk();
+simSdk.intercept(KinesisClient);
+
+// Ordinary application code, with nothing about it that knows it is simulated.
+const kinesis = new KinesisClient({ region: "eu-west-2" });
+
+await kinesis.send(
+  new CreateStreamCommand({ StreamName: "orders", ShardCount: 1 }),
+);
+
+const put = await kinesis.send(
+  new PutRecordCommand({
+    StreamName: "orders",
+    PartitionKey: "customer-1",
+    Data: new TextEncoder().encode("order-1"),
+  }),
+);
+
+// shardId-000000000000
+console.log(put.ShardId);

--- a/docs/services/kinesis/sim-kinesis-shards.example.ts
+++ b/docs/services/kinesis/sim-kinesis-shards.example.ts
@@ -1,0 +1,47 @@
+/**
+ * Reading which shard a record landed on, and which slice each shard owns.
+ */
+
+import {
+  CreateStreamCommand,
+  DescribeStreamCommand,
+  PutRecordCommand,
+} from "@aws-sdk/client-kinesis";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const kinesis = simAws.kinesis();
+
+await kinesis.createStream(
+  new CreateStreamCommand({ StreamName: "orders", ShardCount: 2 }),
+);
+
+const first = await kinesis.putRecord(
+  new PutRecordCommand({
+    StreamName: "orders",
+    PartitionKey: "customer-1",
+    Data: new TextEncoder().encode("order-1"),
+  }),
+);
+
+const second = await kinesis.putRecord(
+  new PutRecordCommand({
+    StreamName: "orders",
+    PartitionKey: "customer-1",
+    Data: new TextEncoder().encode("order-2"),
+  }),
+);
+
+// true: one partition key means one shard.
+console.log(first.ShardId === second.ShardId);
+
+const { StreamDescription } = await kinesis.describeStream(
+  new DescribeStreamCommand({ StreamName: "orders" }),
+);
+
+// shardId-000000000000 0
+console.log(
+  StreamDescription.Shards[0]?.ShardId,
+  StreamDescription.Shards[0]?.HashKeyRange.StartingHashKey,
+);

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -19,6 +19,7 @@
       "@kensio/yulin/elbv2": ["../src/service/elbv2/index.ts"],
       "@kensio/yulin/eslint": ["../src/config/eslint/index.ts"],
       "@kensio/yulin/iam": ["../src/service/iam/index.ts"],
+      "@kensio/yulin/kinesis": ["../src/service/kinesis/index.ts"],
       "@kensio/yulin/kms": ["../src/service/kms/index.ts"],
       "@kensio/yulin/lambda": ["../src/service/lambda/index.ts"],
       "@kensio/yulin/logs": ["../src/service/logs/index.ts"],

--- a/package.json
+++ b/package.json
@@ -103,6 +103,10 @@
       "import": "./dist/service/iam/index.js",
       "types": "./dist/service/iam/index.d.ts"
     },
+    "./kinesis": {
+      "import": "./dist/service/kinesis/index.js",
+      "types": "./dist/service/kinesis/index.d.ts"
+    },
     "./kms": {
       "import": "./dist/service/kms/index.js",
       "types": "./dist/service/kms/index.d.ts"
@@ -209,6 +213,7 @@
     "@aws-sdk/client-elastic-load-balancing-v2": "^3.1109.0",
     "@aws-sdk/client-eventbridge": "^3.1109.0",
     "@aws-sdk/client-iam": "^3.1101.0",
+    "@aws-sdk/client-kinesis": "^3.1115.0",
     "@aws-sdk/client-kms": "^3.1101.0",
     "@aws-sdk/client-lambda": "^3.1101.0",
     "@aws-sdk/client-personalize": "^3.1115.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       '@aws-sdk/client-iam':
         specifier: ^3.1101.0
         version: 3.1110.0
+      '@aws-sdk/client-kinesis':
+        specifier: ^3.1115.0
+        version: 3.1115.0
       '@aws-sdk/client-kms':
         specifier: ^3.1101.0
         version: 3.1110.0
@@ -347,6 +350,10 @@ packages:
 
   '@aws-sdk/client-iam@3.1110.0':
     resolution: {integrity: sha512-LVl/0wBusyjYXj7xu1aroj9wMO7c4r5KmpeLGrkXRa/3pv+K/j1ys3vT03kv3fKwCSVpMGzz6H1j4tg7fHn2tw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-kinesis@3.1115.0':
+    resolution: {integrity: sha512-6Xw4VdApquUgTyM3p2kGod0g9Fx7MulwoC6TwC+NU2FwPNzRu420cCdH7FfWX4pgIsZdtkW538sGJ2sm9wXKAQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-kms@3.1110.0':
@@ -3777,6 +3784,17 @@ snapshots:
       tslib: 2.8.1
 
   '@aws-sdk/client-iam@3.1110.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/credential-provider-node': 3.972.80
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/client-kinesis@3.1115.0':
     dependencies:
       '@aws-sdk/core': 3.977.8
       '@aws-sdk/credential-provider-node': 3.972.80

--- a/src/sdk/router/resolve-sim-sdk-command-router.ts
+++ b/src/sdk/router/resolve-sim-sdk-command-router.ts
@@ -77,6 +77,10 @@ const scopedRouters: ReadonlyMap<string, SimSdkScopedRouter> = new Map<
     (scoped): SimSdkCommandRouter => scoped.eventBridge().sdkCommandRouter(),
   ],
   ["IAM", (scoped): SimSdkCommandRouter => scoped.iam().sdkCommandRouter()],
+  [
+    "Kinesis",
+    (scoped): SimSdkCommandRouter => scoped.kinesis().sdkCommandRouter(),
+  ],
   ["KMS", (scoped): SimSdkCommandRouter => scoped.kms().sdkCommandRouter()],
   [
     "Lambda",

--- a/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
@@ -1,5 +1,6 @@
 import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-scope.js";
 import { SimDynamoDb as SimDynamoDatabase } from "../../dynamodb/index.js";
+import { SimKinesis } from "../../kinesis/index.js";
 import { SimSecretsManager } from "../../secretsmanager/index.js";
 import { SimSqs } from "../../sqs/index.js";
 import { SimSsm } from "../../ssm/index.js";
@@ -35,6 +36,16 @@ export class SimAwsSelfContainedServiceBuilder {
   /** Create simulated DynamoDB for an Account Region scope. */
   createDynamoDb(scope: SimAwsAccountRegionContainer): SimDynamoDatabase {
     return new SimDynamoDatabase(this.scoped(scope));
+  }
+
+  /**
+   * Create simulated Kinesis Data Streams for an Account Region scope.
+   *
+   * Streams are Region-scoped on real AWS: a stream ARN names the Region, and a
+   * stream cannot be reached from another one.
+   */
+  createKinesis(scope: SimAwsAccountRegionContainer): SimKinesis {
+    return new SimKinesis(this.scoped(scope));
   }
 
   /**

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -23,6 +23,7 @@ import type { SimScheduler } from "../../scheduler/index.js";
 import type { SimElbV2 } from "../../elbv2/index.js";
 import type { SimIam } from "../../iam/index.js";
 import { SimIamRegistry } from "../../iam/registry/sim-iam-registry.js";
+import type { SimKinesis } from "../../kinesis/index.js";
 import type { SimKms } from "../../kms/index.js";
 import type { SimLambda } from "../../lambda/index.js";
 import { SimLambdaUrlRegistry } from "../../lambda/registry/sim-lambda-url-registry.js";
@@ -227,6 +228,11 @@ export class SimAwsServiceFactory {
   /** Create simulated KMS for an Account Region scope. */
   createKms(scope: SimAwsAccountRegionContainer): SimKms {
     return this.registeredServices.createKms(scope);
+  }
+
+  /** Create simulated Kinesis Data Streams for an Account Region scope. */
+  createKinesis(scope: SimAwsAccountRegionContainer): SimKinesis {
+    return this.selfContainedServices.createKinesis(scope);
   }
 
   /** Create simulated Lambda for an Account Region scope. */

--- a/src/service/aws/sim-aws-account-region-scope.ts
+++ b/src/service/aws/sim-aws-account-region-scope.ts
@@ -29,6 +29,7 @@ import type { SimApiGateway } from "../apigateway/index.js";
 import type { SimApiGatewayV2 } from "../apigatewayv2/index.js";
 import type { SimElbV2 } from "../elbv2/index.js";
 import type { SimIam } from "../iam/index.js";
+import type { SimKinesis } from "../kinesis/index.js";
 import type { SimKms } from "../kms/index.js";
 import type { SimLambda } from "../lambda/index.js";
 import type { SimLogs } from "../logs/index.js";
@@ -185,6 +186,13 @@ export class SimAwsAccountRegionContainer {
   /** Get simulated IAM for this account. */
   iam(): SimIam {
     return this.memo.getOrCreate("iam", () => this.factory.createIam(this));
+  }
+
+  /** Get simulated Kinesis Data Streams for this account and region. */
+  kinesis(): SimKinesis {
+    return this.memo.getOrCreate("kinesis", () =>
+      this.factory.createKinesis(this),
+    );
   }
 
   /** Get simulated KMS for this account and region. */

--- a/src/service/aws/sim-aws-account.ts
+++ b/src/service/aws/sim-aws-account.ts
@@ -124,9 +124,8 @@ export class SimAwsAccount {
   }
 
   /**
-   * Get simulated KMS for this Account's default Region.
+   * Get simulated Kinesis Data Streams for this Account's default Region.
    */
-  /** Get simulated Kinesis Data Streams for this account. */
   kinesis(): SimKinesis {
     return this.region().kinesis();
   }

--- a/src/service/aws/sim-aws-account.ts
+++ b/src/service/aws/sim-aws-account.ts
@@ -13,6 +13,7 @@ import type { SimCloudFormation } from "../cloudformation/index.js";
 import type { SimAcm } from "../acm/sim-acm.js";
 import type { SimRoute53 } from "../route53/index.js";
 import type { SimIam } from "../iam/index.js";
+import type { SimKinesis } from "../kinesis/index.js";
 import type { SimKms } from "../kms/index.js";
 import type { SimLambda } from "../lambda/index.js";
 import type { SimAwsPrincipal } from "./caller/sim-aws-caller.js";
@@ -125,6 +126,12 @@ export class SimAwsAccount {
   /**
    * Get simulated KMS for this Account's default Region.
    */
+  /** Get simulated Kinesis Data Streams for this account. */
+  kinesis(): SimKinesis {
+    return this.region().kinesis();
+  }
+
+  /** Get simulated KMS for this account. */
   kms(): SimKms {
     return this.region().kms();
   }

--- a/src/service/aws/sim-aws-region.ts
+++ b/src/service/aws/sim-aws-region.ts
@@ -171,9 +171,8 @@ export class SimAwsRegion {
   }
 
   /**
-   * Get simulated KMS for this Region's default Account.
+   * Get simulated Kinesis Data Streams for this Region's default Account.
    */
-  /** Get simulated Kinesis Data Streams for this region. */
   kinesis(): SimKinesis {
     return this.account().kinesis();
   }

--- a/src/service/aws/sim-aws-region.ts
+++ b/src/service/aws/sim-aws-region.ts
@@ -11,6 +11,7 @@ import type {
 import { SimAws } from "./sim-aws.js";
 import type { SimCloudFormation } from "../cloudformation/index.js";
 import type { SimAcm } from "../acm/sim-acm.js";
+import type { SimKinesis } from "../kinesis/index.js";
 import type { SimKms } from "../kms/index.js";
 import type { SimLambda } from "../lambda/index.js";
 import type { SimRoute53 } from "../route53/index.js";
@@ -172,6 +173,12 @@ export class SimAwsRegion {
   /**
    * Get simulated KMS for this Region's default Account.
    */
+  /** Get simulated Kinesis Data Streams for this region. */
+  kinesis(): SimKinesis {
+    return this.account().kinesis();
+  }
+
+  /** Get simulated KMS for this region. */
   kms(): SimKms {
     return this.account().kms();
   }

--- a/src/service/aws/sim-aws-service-accessors.ts
+++ b/src/service/aws/sim-aws-service-accessors.ts
@@ -133,7 +133,6 @@ export abstract class SimAwsServiceAccessors {
     return this.defaultAccountRegionScope().iam();
   }
 
-  /** Get simulated KMS in the default Account Region scope. */
   /** Get simulated Kinesis Data Streams in the default Account Region scope. */
   kinesis(): SimKinesis {
     return this.defaultAccountRegionScope().kinesis();

--- a/src/service/aws/sim-aws-service-accessors.ts
+++ b/src/service/aws/sim-aws-service-accessors.ts
@@ -15,6 +15,7 @@ import type { SimEcr } from "../ecr/index.js";
 import type { SimEcs } from "../ecs/index.js";
 import type { SimElbV2 } from "../elbv2/index.js";
 import type { SimIam } from "../iam/index.js";
+import type { SimKinesis } from "../kinesis/index.js";
 import type { SimKms } from "../kms/index.js";
 import type { SimLambda } from "../lambda/index.js";
 import type { SimLogs } from "../logs/index.js";
@@ -130,6 +131,12 @@ export abstract class SimAwsServiceAccessors {
   /** Get simulated IAM in the default Account scope. */
   iam(): SimIam {
     return this.defaultAccountRegionScope().iam();
+  }
+
+  /** Get simulated KMS in the default Account Region scope. */
+  /** Get simulated Kinesis Data Streams in the default Account Region scope. */
+  kinesis(): SimKinesis {
+    return this.defaultAccountRegionScope().kinesis();
   }
 
   /** Get simulated KMS in the default Account Region scope. */

--- a/src/service/aws/sim-aws.iso.test.ts
+++ b/src/service/aws/sim-aws.iso.test.ts
@@ -113,6 +113,15 @@ describe("SimAws", () => {
     assertIdentical(simAws.account().region().personalizeEvents(), events);
   });
 
+  it("returns the same Kinesis from every scope", () => {
+    const simAws = new SimAws();
+    const kinesis = simAws.kinesis();
+
+    assertIdentical(simAws.account().kinesis(), kinesis);
+    assertIdentical(simAws.region().kinesis(), kinesis);
+    assertIdentical(simAws.account().region().kinesis(), kinesis);
+  });
+
   it("returns the Streams API of the DynamoDB in the same scope", () => {
     const simAws = new SimAws();
     const streams = simAws.dynamoDb().streams();

--- a/src/service/kinesis/README.md
+++ b/src/service/kinesis/README.md
@@ -1,0 +1,79 @@
+# Simulated Kinesis Data Streams implementation
+
+This directory holds the simulated Kinesis Data Streams service. Shared throughput only, with no
+enhanced fan-out and no resharding.
+
+A stream is a shard map and the records on it. Records go on through `PutRecord` and come off
+through the iterator walk every Kinesis consumer makes, which is `DescribeStream`,
+`GetShardIterator`, then `GetRecords` repeatedly.
+
+## Entry points
+
+- `sim-kinesis.ts` is the in-memory service object for one Account and Region scope.
+- `index.ts` exports the public API for `@kensio/yulin/kinesis`.
+
+A `SimKinesis` owns a `SimKinesisStreamStore` holding its streams. The simulator is scoped to an
+Account and Region because real streams are. A stream ARN names the Region, and a stream name is
+unique within one Account and Region rather than globally.
+
+## Stream model
+
+Stream state lives under `stream/`.
+
+`SimKinesisStream` is the stored resource. It holds its name, its ARN, its mode, its shard map and
+one counter handing out sequence numbers.
+
+`SimKinesisShardMap` divides the 128 bit hash key space between the shards, in equal adjacent slices
+covering the whole of it. `simKinesisPartitionKeyHash` is the MD5 hash real Kinesis places a record
+by, read as a big-endian unsigned integer. Using anything else would put a record on a different
+shard from the one AWS would have put it on, so the hash is a placement function rather than a
+security one and MD5 being broken is beside the point.
+
+`SimKinesisShard` holds the records whose hash keys fall in its slice. Nothing splits or merges one,
+so a record's shard is decided by its hash key alone and stays decidable for the life of the stream.
+That is also why no shard ever reports an ending sequence number.
+
+`SimKinesisSequenceNumbers` is one counter per stream rather than one per shard. Real Kinesis
+promises a sequence number is unique within a stream and increases within a shard, and a single
+counter gives both.
+
+`SimKinesisStreamPosition` is where a reader stands, in the four kinds the five iterator types come
+down to. `LATEST` has no kind of its own: it is resolved where the iterator is made, which is what
+pins it to that instant.
+
+`simKinesisShardIteratorToken` writes a position into an opaque base64url token and
+`readSimKinesisShardIteratorToken` reads one back. The place travels inside the token rather than in
+a table of handed-out iterators, which is what lets an iterator be used without the stream having to
+remember it, and why the five minute expiry is absent here rather than approximated.
+
+Retention is applied when a stream is read rather than on a timer. Whatever a read finds is what the
+window holds at the instant of that read, so nothing has to have run in between for that to be true.
+Compare `simDynamoDbStreamTrimPoint`, which is the same shape for the same reason. Unlike DynamoDB
+Streams, a position the window has outlived is not refused: real Kinesis moves the reader on to the
+trim horizon and reports how far behind it is.
+
+## Commands
+
+Command handlers live under `command/`, grouped by what they act on: `stream/` creates, lists,
+describes and deletes, `record/` puts, and `read/` hands out iterators and reads through them.
+
+`SimKinesisStreamAccess` is how every operation but `ListStreams` and `CreateStream` reaches its
+stream. It authorizes the action against the stream's ARN and then looks the stream up, in that
+order, because that is the order real IAM works in: a caller with no permission is refused for a
+stream that does not exist rather than told the stream is missing.
+
+`simKinesisRefLookupName` decides which stream a request meant. An ARN naming another Account or
+Region becomes its own lookup key, so nothing is found. Reading its name out and looking that up
+locally would let a test pass while the real call crossed a boundary it has no permission for.
+
+`GetRecords` names no stream. It authorizes against the stream its iterator carries, so a caller
+cannot reach a stream it lacks permission for by holding an iterator someone else made.
+
+## What is left out
+
+`sdk/sim-kinesis-sdk-command-router.ts` names the nine commands this service handles. Anything else
+an intercepted client sends is refused with `SimSdkUnsupportedCommandError`, which covers enhanced
+fan-out, resharding, encryption and the tag operations.
+
+`docs/services/kinesis/README.md` is the user-facing page, and its **Divergences and limitations**
+section is the full list.

--- a/src/service/kinesis/command/authorize/sim-kinesis-authorizer.ts
+++ b/src/service/kinesis/command/authorize/sim-kinesis-authorizer.ts
@@ -1,0 +1,71 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+
+interface SimKinesisAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * Applies simulated IAM authorization to Kinesis requests.
+ *
+ * AWS maps each Kinesis API operation to the `kinesis:` action of the same
+ * name, and the resource is the ARN of the stream the operation names.
+ * ListStreams is the exception. It names no stream, so it authorizes against
+ * `*`.
+ */
+export class SimKinesisAuthorizer {
+  private readonly iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: SimKinesisAuthorizerProperties) {
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Ensure the caller may perform an action on a stream, named by its ARN.
+   *
+   * The stream need not exist. Real IAM evaluates a request before the service
+   * handles it, so a caller with no permission is refused whether or not the
+   * stream is there, which also keeps an unauthorized caller from finding out
+   * which stream names are taken.
+   */
+  authorizeStream(
+    action: string,
+    streamArn: string,
+    caller?: SimAwsCaller,
+  ): SimAwsResolvedCaller {
+    return this.authorizeResource(action, streamArn, caller);
+  }
+
+  /**
+   * Ensure the caller may perform an action naming no particular stream.
+   *
+   * Authorization applies to the whole operation. A denied caller receives
+   * AccessDenied rather than an empty or filtered stream listing.
+   */
+  authorizeAnyStream(
+    action: string,
+    caller?: SimAwsCaller,
+  ): SimAwsResolvedCaller {
+    return this.authorizeResource(action, "*", caller);
+  }
+
+  private authorizeResource(
+    action: string,
+    resource: string,
+    caller: SimAwsCaller | undefined,
+  ): SimAwsResolvedCaller {
+    const decision = this.iam.authorize({ action, resource, caller });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action,
+        resource,
+      });
+    }
+
+    return decision.caller;
+  }
+}

--- a/src/service/kinesis/command/authorize/sim-kinesis-iam.iso.test.ts
+++ b/src/service/kinesis/command/authorize/sim-kinesis-iam.iso.test.ts
@@ -1,0 +1,211 @@
+import {
+  CreateStreamCommand,
+  DescribeStreamCommand,
+  GetRecordsCommand,
+  GetShardIteratorCommand,
+  ListStreamsCommand,
+  PutRecordCommand,
+} from "@aws-sdk/client-kinesis";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simIamRoleWithPolicyFactory } from "../../../iam/role/sim-iam-role-with-policy.factory.js";
+import { simKinesisStreamFactory } from "../../stream/sim-kinesis-stream.factory.js";
+
+/**
+ * The ARN of the stream every test here is about.
+ */
+function ordersArn(simAws: SimAws): string {
+  return `arn:aws:kinesis:${simAws.defaultRegionName}:${simAws.defaultAccountId}:stream/orders`;
+}
+
+describe("Authorizing simulated Kinesis requests", () => {
+  it("allows a caller whose policy permits putting to the stream", async () => {
+    // Given a stream, and a Role allowed to put records onto it.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+    const role = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "OrderProducer",
+        actions: ["kinesis:PutRecord"],
+        resource: ordersArn(simAws),
+      },
+      simAws,
+    );
+
+    // When that Role puts a record.
+    const put = await simAws.kinesis().putRecord(
+      new PutRecordCommand({
+        StreamName: "orders",
+        PartitionKey: "customer-1",
+        Data: new TextEncoder().encode("order-1"),
+      }),
+      { caller: { kind: "arn", arn: role.Arn } },
+    );
+
+    // Then the record goes on the stream.
+    assertIdentical(put.ShardId, "shardId-000000000000");
+  });
+
+  it("refuses a caller with no permission to put to the stream", async () => {
+    // Given a stream, and a Role allowed to describe it and nothing more.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+    const role = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "OrderReader",
+        actions: ["kinesis:DescribeStream"],
+        resource: ordersArn(simAws),
+      },
+      simAws,
+    );
+
+    // When that Role puts a record.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.kinesis().putRecord(
+        new PutRecordCommand({
+          StreamName: "orders",
+          PartitionKey: "customer-1",
+          Data: new TextEncoder().encode("order-1"),
+        }),
+        { caller: { kind: "arn", arn: role.Arn } },
+      );
+    });
+
+    // Then it is refused, naming the action and the stream it was refused on.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertStringIncludes(error.message, "kinesis:PutRecord");
+    assertStringIncludes(error.message, ordersArn(simAws));
+  });
+
+  it("refuses a caller whose policy names another stream", async () => {
+    // Given a stream, and a Role allowed to put onto a different one.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+    const role = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "EventProducer",
+        actions: ["kinesis:PutRecord"],
+        resource: `arn:aws:kinesis:${simAws.defaultRegionName}:${simAws.defaultAccountId}:stream/events`,
+      },
+      simAws,
+    );
+
+    // When that Role puts a record onto the orders stream.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.kinesis().putRecord(
+        new PutRecordCommand({
+          StreamName: "orders",
+          PartitionKey: "customer-1",
+          Data: new TextEncoder().encode("order-1"),
+        }),
+        { caller: { kind: "arn", arn: role.Arn } },
+      );
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("refuses a caller with no permission to create a stream", async () => {
+    // Given a Role allowed to list streams and nothing more.
+    const simAws = new SimAws();
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "Lister", actions: ["kinesis:ListStreams"] },
+      simAws,
+    );
+
+    // When that Role creates a stream.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .kinesis()
+        .createStream(new CreateStreamCommand({ StreamName: "orders" }), {
+          caller: { kind: "arn", arn: role.Arn },
+        });
+    });
+
+    // Then it is refused, and the Role can still list.
+    assertInstanceOf(error, SimIamAccessDenied);
+
+    const listed = await simAws
+      .kinesis()
+      .listStreams(new ListStreamsCommand({}), {
+        caller: { kind: "arn", arn: role.Arn },
+      });
+    assertArrayLength(listed.StreamNames, 0);
+  });
+
+  it("refuses a caller with no permission on a stream that does not exist", async () => {
+    // Given a simulated AWS with no streams, and a Role allowed nothing.
+    const simAws = new SimAws();
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "Nobody", actions: [] },
+      simAws,
+    );
+
+    // When that Role describes a stream that is not there.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .kinesis()
+        .describeStream(new DescribeStreamCommand({ StreamName: "orders" }), {
+          caller: { kind: "arn", arn: role.Arn },
+        });
+    });
+
+    // Then it is refused rather than told the stream is missing, which is what
+    // keeps an unauthorized caller from finding out which names are taken.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("authorizes a read against the stream the iterator was made on", async () => {
+    // Given a stream holding a record, and a Role allowed to take an iterator
+    // but not to read records.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+    await simAws.kinesis().putRecord(
+      new PutRecordCommand({
+        StreamName: "orders",
+        PartitionKey: "customer-1",
+        Data: new TextEncoder().encode("order-1"),
+      }),
+    );
+    const role = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "Iterating",
+        actions: ["kinesis:GetShardIterator"],
+        resource: ordersArn(simAws),
+      },
+      simAws,
+    );
+    const iterator = await simAws.kinesis().getShardIterator(
+      new GetShardIteratorCommand({
+        StreamName: "orders",
+        ShardId: "shardId-000000000000",
+        ShardIteratorType: "TRIM_HORIZON",
+      }),
+      { caller: { kind: "arn", arn: role.Arn } },
+    );
+
+    // When that Role reads records with the iterator it was given.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .kinesis()
+        .getRecords(
+          new GetRecordsCommand({ ShardIterator: iterator.ShardIterator }),
+          { caller: { kind: "arn", arn: role.Arn } },
+        );
+    });
+
+    // Then the read is refused on the stream the iterator names.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertStringIncludes(error.message, "kinesis:GetRecords");
+    assertStringIncludes(error.message, ordersArn(simAws));
+  });
+});

--- a/src/service/kinesis/command/read/read.command.ts
+++ b/src/service/kinesis/command/read/read.command.ts
@@ -1,0 +1,56 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim Kinesis GetShardIterator command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/kinesis/command/GetShardIteratorCommand/
+ */
+export interface SimGetShardIteratorCommand {
+  readonly input: SimGetShardIteratorCommandInput;
+}
+
+export interface SimGetShardIteratorCommandInput {
+  readonly StreamName?: string | undefined;
+  readonly StreamARN?: string | undefined;
+  readonly ShardId?: string | undefined;
+  readonly ShardIteratorType?: string | undefined;
+  readonly StartingSequenceNumber?: string | undefined;
+  readonly Timestamp?: Date | undefined;
+}
+
+export interface SimGetShardIteratorCommandOutput {
+  readonly ShardIterator: string;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * One record as GetRecords hands it back.
+ */
+export interface SimKinesisRecordOutput {
+  readonly SequenceNumber: string;
+  readonly ApproximateArrivalTimestamp: Date;
+  readonly Data: Uint8Array;
+  readonly PartitionKey: string;
+}
+
+/**
+ * Minimal structural sim Kinesis GetRecords command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/kinesis/command/GetRecordsCommand/
+ */
+export interface SimGetRecordsCommand {
+  readonly input: SimGetRecordsCommandInput;
+}
+
+export interface SimGetRecordsCommandInput {
+  readonly ShardIterator?: string | undefined;
+  readonly Limit?: number | undefined;
+  readonly StreamARN?: string | undefined;
+}
+
+export interface SimGetRecordsCommandOutput {
+  readonly Records: readonly SimKinesisRecordOutput[];
+  readonly NextShardIterator: string;
+  readonly MillisBehindLatest: number;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/kinesis/command/read/sim-kinesis-iterator-type.ts
+++ b/src/service/kinesis/command/read/sim-kinesis-iterator-type.ts
@@ -1,0 +1,104 @@
+import { SimKinesisInvalidArgumentException } from "../../error/sim-kinesis.error.js";
+import type { SimKinesisShard } from "../../stream/sim-kinesis-shard.js";
+import {
+  simKinesisStreamAfter,
+  simKinesisStreamStart,
+  type SimKinesisStreamPosition,
+} from "../../stream/sim-kinesis-stream-position.js";
+import type { SimGetShardIteratorCommandInput } from "./read.command.js";
+
+/**
+ * The shard iterator types real Kinesis hands out an iterator for.
+ */
+const iteratorTypes = new Set([
+  "AT_SEQUENCE_NUMBER",
+  "AFTER_SEQUENCE_NUMBER",
+  "AT_TIMESTAMP",
+  "TRIM_HORIZON",
+  "LATEST",
+]);
+
+/**
+ * The sequence number a request naming one has to carry.
+ */
+function requiredSequenceNumber(
+  input: SimGetShardIteratorCommandInput,
+): string {
+  const { StartingSequenceNumber, ShardIteratorType } = input;
+
+  if (StartingSequenceNumber === undefined || StartingSequenceNumber === "") {
+    throw new SimKinesisInvalidArgumentException(
+      `A ${ShardIteratorType} shard iterator requires a ` +
+        `StartingSequenceNumber`,
+    );
+  }
+
+  return StartingSequenceNumber;
+}
+
+/**
+ * The instant a request naming one has to carry.
+ */
+function requiredTimestamp(input: SimGetShardIteratorCommandInput): Date {
+  const { Timestamp } = input;
+
+  if (Timestamp === undefined) {
+    throw new SimKinesisInvalidArgumentException(
+      "An AT_TIMESTAMP shard iterator requires a Timestamp",
+    );
+  }
+
+  return Timestamp;
+}
+
+/**
+ * The place on a shard a requested iterator type stands for.
+ *
+ * LATEST is resolved here rather than carried into the iterator, which is what
+ * pins it to the instant the iterator was made. A shard holding nothing yet has
+ * no record to sit after, and starting from the beginning of an empty shard is
+ * the same place.
+ */
+export function simKinesisIteratorPosition(
+  input: SimGetShardIteratorCommandInput,
+  shard: SimKinesisShard,
+): SimKinesisStreamPosition {
+  const type = input.ShardIteratorType;
+
+  if (type === undefined || !iteratorTypes.has(type)) {
+    throw new SimKinesisInvalidArgumentException(
+      `ShardIteratorType '${type}' is not one of ${[...iteratorTypes].join(
+        ", ",
+      )}`,
+    );
+  }
+
+  switch (type) {
+    case "TRIM_HORIZON": {
+      return simKinesisStreamStart;
+    }
+
+    case "AT_SEQUENCE_NUMBER": {
+      return { kind: "at", sequenceNumber: requiredSequenceNumber(input) };
+    }
+
+    case "AFTER_SEQUENCE_NUMBER": {
+      return simKinesisStreamAfter(requiredSequenceNumber(input));
+    }
+
+    case "AT_TIMESTAMP": {
+      return {
+        kind: "timestamp",
+        epochMillis: requiredTimestamp(input).getTime(),
+      };
+    }
+
+    default: {
+      const latest = shard.latestSequenceNumber;
+
+      return latest === undefined
+        ? simKinesisStreamStart
+        : simKinesisStreamAfter(latest);
+    }
+  }
+}

--- a/src/service/kinesis/command/read/sim-kinesis-iterator-type.ts
+++ b/src/service/kinesis/command/read/sim-kinesis-iterator-type.ts
@@ -10,13 +10,33 @@ import type { SimGetShardIteratorCommandInput } from "./read.command.js";
 /**
  * The shard iterator types real Kinesis hands out an iterator for.
  */
-const iteratorTypes = new Set([
+const iteratorTypes = [
   "AT_SEQUENCE_NUMBER",
   "AFTER_SEQUENCE_NUMBER",
   "AT_TIMESTAMP",
   "TRIM_HORIZON",
   "LATEST",
-]);
+] as const;
+
+type SimKinesisIteratorType = (typeof iteratorTypes)[number];
+
+/**
+ * Read the iterator type a request asked for.
+ *
+ * Narrowing to the five here is what lets the switch below cover them all
+ * without a fallback branch standing in for whichever was left out.
+ */
+function readIteratorType(type: string | undefined): SimKinesisIteratorType {
+  const found = iteratorTypes.find((candidate) => candidate === type);
+
+  if (found === undefined) {
+    throw new SimKinesisInvalidArgumentException(
+      `ShardIteratorType '${type}' is not one of ${iteratorTypes.join(", ")}`,
+    );
+  }
+
+  return found;
+}
 
 /**
  * The sequence number a request naming one has to carry.
@@ -38,13 +58,17 @@ function requiredSequenceNumber(
 
 /**
  * The instant a request naming one has to carry.
+ *
+ * A date that is not a date is refused here rather than carried on as a
+ * position of `NaN` milliseconds, which nothing would ever compare true against
+ * and which would leave the read quietly finding nothing.
  */
 function requiredTimestamp(input: SimGetShardIteratorCommandInput): Date {
   const { Timestamp } = input;
 
-  if (Timestamp === undefined) {
+  if (Timestamp === undefined || Number.isNaN(Timestamp.getTime())) {
     throw new SimKinesisInvalidArgumentException(
-      "An AT_TIMESTAMP shard iterator requires a Timestamp",
+      "An AT_TIMESTAMP shard iterator requires a Timestamp that is a date",
     );
   }
 
@@ -52,28 +76,31 @@ function requiredTimestamp(input: SimGetShardIteratorCommandInput): Date {
 }
 
 /**
+ * Where a LATEST iterator stands.
+ *
+ * It means "after the newest record on the shard when the iterator was made".
+ * A shard holding nothing yet has no record to sit after, and starting from the
+ * beginning of an empty shard is the same place.
+ */
+function latestPosition(shard: SimKinesisShard): SimKinesisStreamPosition {
+  const latest = shard.latestSequenceNumber;
+
+  return latest === undefined
+    ? simKinesisStreamStart
+    : simKinesisStreamAfter(latest);
+}
+
+/**
  * The place on a shard a requested iterator type stands for.
  *
  * LATEST is resolved here rather than carried into the iterator, which is what
- * pins it to the instant the iterator was made. A shard holding nothing yet has
- * no record to sit after, and starting from the beginning of an empty shard is
- * the same place.
+ * pins it to the instant the iterator was made.
  */
 export function simKinesisIteratorPosition(
   input: SimGetShardIteratorCommandInput,
   shard: SimKinesisShard,
 ): SimKinesisStreamPosition {
-  const type = input.ShardIteratorType;
-
-  if (type === undefined || !iteratorTypes.has(type)) {
-    throw new SimKinesisInvalidArgumentException(
-      `ShardIteratorType '${type}' is not one of ${[...iteratorTypes].join(
-        ", ",
-      )}`,
-    );
-  }
-
-  switch (type) {
+  switch (readIteratorType(input.ShardIteratorType)) {
     case "TRIM_HORIZON": {
       return simKinesisStreamStart;
     }
@@ -93,12 +120,8 @@ export function simKinesisIteratorPosition(
       };
     }
 
-    default: {
-      const latest = shard.latestSequenceNumber;
-
-      return latest === undefined
-        ? simKinesisStreamStart
-        : simKinesisStreamAfter(latest);
+    case "LATEST": {
+      return latestPosition(shard);
     }
   }
 }

--- a/src/service/kinesis/command/read/sim-kinesis-read-commands.ts
+++ b/src/service/kinesis/command/read/sim-kinesis-read-commands.ts
@@ -1,0 +1,120 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import {
+  readSimKinesisShardIteratorToken,
+  simKinesisShardIteratorToken,
+} from "../../stream/sim-kinesis-shard-iterator.js";
+import { simKinesisShardRead } from "../../stream/sim-kinesis-stream-read.js";
+import type { SimKinesisStreamStore } from "../../stream/sim-kinesis-stream-store.js";
+import type { SimKinesisRequestOptions } from "../sim-kinesis-request-options.js";
+import type { SimKinesisStreamAccess } from "../sim-kinesis-stream-access.js";
+import { simKinesisIteratorPosition } from "./sim-kinesis-iterator-type.js";
+import {
+  simKinesisReadLimit,
+  simKinesisRequiredShardId,
+} from "./sim-kinesis-read-inputs.js";
+import {
+  simKinesisMillisBehindLatest,
+  simKinesisRecordOutput,
+} from "./sim-kinesis-read-output.js";
+import type {
+  SimGetRecordsCommand,
+  SimGetRecordsCommandOutput,
+  SimGetShardIteratorCommand,
+  SimGetShardIteratorCommandOutput,
+} from "./read.command.js";
+
+interface SimKinesisReadCommandsProperties {
+  readonly streams: SimKinesisStreamStore;
+  readonly access: SimKinesisStreamAccess;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * The commands that read records off a stream's shards.
+ */
+export class SimKinesisReadCommands {
+  private readonly streams: SimKinesisStreamStore;
+  private readonly access: SimKinesisStreamAccess;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: SimKinesisReadCommandsProperties) {
+    this.streams = properties.streams;
+    this.access = properties.access;
+    this.background = properties.background;
+  }
+
+  /**
+   * Hand out an iterator standing for a place on one shard of a stream.
+   */
+  getShardIterator(
+    command: SimGetShardIteratorCommand,
+    options?: SimKinesisRequestOptions,
+  ): SimGetShardIteratorCommandOutput {
+    const { input } = command;
+    const stream = this.access.require(
+      "kinesis:GetShardIterator",
+      input,
+      options,
+    );
+
+    this.streams.applyRetention(this.background.now());
+
+    const shard = stream.requireShard(simKinesisRequiredShardId(input.ShardId));
+
+    return {
+      $metadata: {},
+      ShardIterator: simKinesisShardIteratorToken({
+        streamArn: stream.arn,
+        shardId: shard.shardId,
+        position: simKinesisIteratorPosition(input, shard),
+      }),
+    };
+  }
+
+  /**
+   * Read records from wherever an iterator stands.
+   *
+   * The iterator carries the stream it was made against, so the action is
+   * authorized against that stream rather than against whatever the request
+   * separately claims. A caller cannot reach a stream it lacks permission for
+   * by holding an iterator someone else made.
+   */
+  getRecords(
+    command: SimGetRecordsCommand,
+    options?: SimKinesisRequestOptions,
+  ): SimGetRecordsCommandOutput {
+    const iterator = readSimKinesisShardIteratorToken(
+      command.input.ShardIterator,
+    );
+    const stream = this.access.require(
+      "kinesis:GetRecords",
+      { StreamARN: iterator.streamArn },
+      options,
+    );
+    const now = this.background.now();
+
+    this.streams.applyRetention(now);
+
+    const shard = stream.requireShard(iterator.shardId);
+    const read = simKinesisShardRead(
+      shard,
+      iterator.position,
+      simKinesisReadLimit(command.input.Limit),
+    );
+
+    return {
+      $metadata: {},
+      Records: read.records.map((record) => simKinesisRecordOutput(record)),
+      NextShardIterator: simKinesisShardIteratorToken({
+        streamArn: stream.arn,
+        shardId: shard.shardId,
+        position: read.next,
+      }),
+      MillisBehindLatest: simKinesisMillisBehindLatest(
+        shard.records,
+        read.records,
+        now,
+      ),
+    };
+  }
+}

--- a/src/service/kinesis/command/read/sim-kinesis-read-commands.ts
+++ b/src/service/kinesis/command/read/sim-kinesis-read-commands.ts
@@ -9,6 +9,7 @@ import type { SimKinesisRequestOptions } from "../sim-kinesis-request-options.js
 import type { SimKinesisStreamAccess } from "../sim-kinesis-stream-access.js";
 import { simKinesisIteratorPosition } from "./sim-kinesis-iterator-type.js";
 import {
+  assertSimKinesisStreamArnMatches,
   simKinesisReadLimit,
   simKinesisRequiredShardId,
 } from "./sim-kinesis-read-inputs.js";
@@ -87,6 +88,12 @@ export class SimKinesisReadCommands {
     const iterator = readSimKinesisShardIteratorToken(
       command.input.ShardIterator,
     );
+
+    assertSimKinesisStreamArnMatches(
+      command.input.StreamARN,
+      iterator.streamArn,
+    );
+
     const stream = this.access.require(
       "kinesis:GetRecords",
       { StreamARN: iterator.streamArn },

--- a/src/service/kinesis/command/read/sim-kinesis-read-commands.ts
+++ b/src/service/kinesis/command/read/sim-kinesis-read-commands.ts
@@ -45,6 +45,10 @@ export class SimKinesisReadCommands {
 
   /**
    * Hand out an iterator standing for a place on one shard of a stream.
+   *
+   * Retention is left to the read. An iterator is a place rather than a record,
+   * and every place it can stand at survives the records around it being
+   * trimmed.
    */
   getShardIterator(
     command: SimGetShardIteratorCommand,
@@ -56,9 +60,6 @@ export class SimKinesisReadCommands {
       input,
       options,
     );
-
-    this.streams.applyRetention(this.background.now());
-
     const shard = stream.requireShard(simKinesisRequiredShardId(input.ShardId));
 
     return {

--- a/src/service/kinesis/command/read/sim-kinesis-read-inputs.ts
+++ b/src/service/kinesis/command/read/sim-kinesis-read-inputs.ts
@@ -1,0 +1,37 @@
+import { SimKinesisInvalidArgumentException } from "../../error/sim-kinesis.error.js";
+
+/**
+ * The most records real Kinesis hands back from one GetRecords call.
+ */
+const maxRecordLimit = 10_000;
+
+/**
+ * The shard identifier a GetShardIterator request has to carry.
+ */
+export function simKinesisRequiredShardId(shardId: string | undefined): string {
+  if (shardId === undefined || shardId === "") {
+    throw new SimKinesisInvalidArgumentException(
+      "GetShardIterator requires a ShardId",
+    );
+  }
+
+  return shardId;
+}
+
+/**
+ * How many records a GetRecords request asked for.
+ */
+export function simKinesisReadLimit(limit: number | undefined): number {
+  if (limit === undefined) {
+    return maxRecordLimit;
+  }
+
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > maxRecordLimit) {
+    throw new SimKinesisInvalidArgumentException(
+      `Limit ${limit} is outside the 1 to ${maxRecordLimit} records Kinesis ` +
+        `hands back from one GetRecords call`,
+    );
+  }
+
+  return limit;
+}

--- a/src/service/kinesis/command/read/sim-kinesis-read-inputs.ts
+++ b/src/service/kinesis/command/read/sim-kinesis-read-inputs.ts
@@ -35,3 +35,27 @@ export function simKinesisReadLimit(limit: number | undefined): number {
 
   return limit;
 }
+
+/**
+ * Refuse a request whose StreamARN disagrees with the iterator it carries.
+ *
+ * GetRecords takes both, and the iterator is the one that decides which stream
+ * is read. A request naming a different stream is refused rather than answered
+ * from the iterator's, since a caller that believed the ARN would be reading
+ * somewhere other than where it thinks.
+ */
+export function assertSimKinesisStreamArnMatches(
+  streamArn: string | undefined,
+  iteratorStreamArn: string,
+): void {
+  if (
+    streamArn !== undefined &&
+    streamArn !== "" &&
+    streamArn !== iteratorStreamArn
+  ) {
+    throw new SimKinesisInvalidArgumentException(
+      `StreamARN ${streamArn} is not the stream the ShardIterator was made ` +
+        `on, which is ${iteratorStreamArn}`,
+    );
+  }
+}

--- a/src/service/kinesis/command/read/sim-kinesis-read-output.ts
+++ b/src/service/kinesis/command/read/sim-kinesis-read-output.ts
@@ -15,7 +15,10 @@ export function simKinesisMillisBehindLatest(
 ): number {
   const last = returned.at(-1);
 
-  if (last === undefined || last === available.at(-1)) {
+  if (
+    last === undefined ||
+    last.sequenceNumber === available.at(-1)?.sequenceNumber
+  ) {
     return 0;
   }
 
@@ -24,14 +27,18 @@ export function simKinesisMillisBehindLatest(
 
 /**
  * One record as GetRecords hands it back.
+ *
+ * The bytes and the instant are copies, as they would be coming off the wire.
+ * A consumer that decodes in place, or that shifts a timestamp to its own zone,
+ * would otherwise be editing what is still on the stream.
  */
 export function simKinesisRecordOutput(
   record: SimKinesisRecord,
 ): SimKinesisRecordOutput {
   return {
     SequenceNumber: record.sequenceNumber,
-    ApproximateArrivalTimestamp: record.arrivedAt,
-    Data: record.data,
+    ApproximateArrivalTimestamp: new Date(record.arrivedAt),
+    Data: Uint8Array.from(record.data),
     PartitionKey: record.partitionKey,
   };
 }

--- a/src/service/kinesis/command/read/sim-kinesis-read-output.ts
+++ b/src/service/kinesis/command/read/sim-kinesis-read-output.ts
@@ -1,0 +1,37 @@
+import type { SimKinesisRecord } from "../../stream/sim-kinesis-record.js";
+import type { SimKinesisRecordOutput } from "./read.command.js";
+
+/**
+ * How far behind the tip of the shard a read left the reader.
+ *
+ * Zero means caught up, which is what a reader that took everything the shard
+ * holds is. Otherwise it is the age of the last record handed back, which is
+ * how far the reader still has to travel in time to reach the newest one.
+ */
+export function simKinesisMillisBehindLatest(
+  available: readonly SimKinesisRecord[],
+  returned: readonly SimKinesisRecord[],
+  now: Date,
+): number {
+  const last = returned.at(-1);
+
+  if (last === undefined || last === available.at(-1)) {
+    return 0;
+  }
+
+  return now.getTime() - last.arrivedAt.getTime();
+}
+
+/**
+ * One record as GetRecords hands it back.
+ */
+export function simKinesisRecordOutput(
+  record: SimKinesisRecord,
+): SimKinesisRecordOutput {
+  return {
+    SequenceNumber: record.sequenceNumber,
+    ApproximateArrivalTimestamp: record.arrivedAt,
+    Data: record.data,
+    PartitionKey: record.partitionKey,
+  };
+}

--- a/src/service/kinesis/command/read/sim-kinesis-read-validation.iso.test.ts
+++ b/src/service/kinesis/command/read/sim-kinesis-read-validation.iso.test.ts
@@ -1,8 +1,10 @@
 import {
   GetRecordsCommand,
   GetShardIteratorCommand,
+  PutRecordCommand,
 } from "@aws-sdk/client-kinesis";
 import {
+  assertArrayLength,
   assertInstanceOf,
   assertStringIncludes,
   assertThrowsErrorAsync,
@@ -150,5 +152,86 @@ describe("What simulated Kinesis refuses of a read request", () => {
 
     // Then it is refused.
     assertStringIncludes(error.message, "Limit 10001");
+  });
+
+  it("refuses a timestamp that is not a date", async () => {
+    // Given a stream.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+
+    // When an AT_TIMESTAMP iterator is asked for with an unparseable date.
+    const error = await refusalFrom(async () => {
+      await simAws.kinesis().getShardIterator(
+        new GetShardIteratorCommand({
+          StreamName: "orders",
+          ShardId: "shardId-000000000000",
+          ShardIteratorType: "AT_TIMESTAMP",
+          Timestamp: new Date("the day before yesterday"),
+        }),
+      );
+    });
+
+    // Then it is refused, rather than standing at a position nothing compares
+    // true against and quietly reading nothing.
+    assertStringIncludes(error.message, "a date");
+  });
+
+  it("refuses a read naming a stream the iterator was not made on", async () => {
+    // Given two streams, and an iterator onto the first.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+    await simKinesisStreamFactory.make({ streamName: "events" }, simAws);
+    const iterator = await simAws.kinesis().getShardIterator(
+      new GetShardIteratorCommand({
+        StreamName: "orders",
+        ShardId: "shardId-000000000000",
+        ShardIteratorType: "TRIM_HORIZON",
+      }),
+    );
+
+    // When records are read with that iterator under the other stream's ARN.
+    const error = await refusalFrom(async () => {
+      await simAws.kinesis().getRecords(
+        new GetRecordsCommand({
+          ShardIterator: iterator.ShardIterator,
+          StreamARN: `arn:aws:kinesis:${simAws.defaultRegionName}:${simAws.defaultAccountId}:stream/events`,
+        }),
+      );
+    });
+
+    // Then it is refused, rather than reading the iterator's stream under a
+    // name the caller believed was a different one.
+    assertStringIncludes(error.message, "not the stream the ShardIterator");
+  });
+
+  it("reads through an iterator whose stream ARN agrees with it", async () => {
+    // Given a stream holding a record.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+    await simAws.kinesis().putRecord(
+      new PutRecordCommand({
+        StreamName: "orders",
+        PartitionKey: "customer-1",
+        Data: new TextEncoder().encode("order-1"),
+      }),
+    );
+    const iterator = await simAws.kinesis().getShardIterator(
+      new GetShardIteratorCommand({
+        StreamName: "orders",
+        ShardId: "shardId-000000000000",
+        ShardIteratorType: "TRIM_HORIZON",
+      }),
+    );
+
+    // When records are read naming that same stream.
+    const read = await simAws.kinesis().getRecords(
+      new GetRecordsCommand({
+        ShardIterator: iterator.ShardIterator,
+        StreamARN: `arn:aws:kinesis:${simAws.defaultRegionName}:${simAws.defaultAccountId}:stream/orders`,
+      }),
+    );
+
+    // Then the record comes back.
+    assertArrayLength(read.Records, 1);
   });
 });

--- a/src/service/kinesis/command/read/sim-kinesis-read-validation.iso.test.ts
+++ b/src/service/kinesis/command/read/sim-kinesis-read-validation.iso.test.ts
@@ -1,0 +1,154 @@
+import {
+  GetRecordsCommand,
+  GetShardIteratorCommand,
+} from "@aws-sdk/client-kinesis";
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimKinesisInvalidArgumentException,
+  SimKinesisResourceNotFoundException,
+} from "../../error/sim-kinesis.error.js";
+import { simKinesisStreamFactory } from "../../stream/sim-kinesis-stream.factory.js";
+
+/**
+ * The error a call raised, as the assertions here want it.
+ */
+async function refusalFrom(
+  call: () => Promise<unknown>,
+): Promise<SimKinesisInvalidArgumentException> {
+  const error = await assertThrowsErrorAsync(call);
+  assertInstanceOf(error, SimKinesisInvalidArgumentException);
+
+  return error;
+}
+
+describe("What simulated Kinesis refuses of a read request", () => {
+  it("refuses a shard iterator type Kinesis does not have", async () => {
+    // Given a stream.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+
+    // When an iterator of an unknown type is asked for. The SDK's own types
+    // refuse to build this command, so the request is made structurally.
+    const error = await refusalFrom(async () => {
+      await simAws.kinesis().getShardIterator({
+        input: {
+          StreamName: "orders",
+          ShardId: "shardId-000000000000",
+          ShardIteratorType: "AT_THE_BEGINNING",
+        },
+      });
+    });
+
+    // Then it is refused, listing the types it has.
+    assertStringIncludes(error.message, "TRIM_HORIZON");
+  });
+
+  it("refuses a sequence number iterator with no sequence number", async () => {
+    // Given a stream.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+
+    // When an AT_SEQUENCE_NUMBER iterator is asked for without one.
+    const error = await refusalFrom(async () => {
+      await simAws.kinesis().getShardIterator(
+        new GetShardIteratorCommand({
+          StreamName: "orders",
+          ShardId: "shardId-000000000000",
+          ShardIteratorType: "AT_SEQUENCE_NUMBER",
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "StartingSequenceNumber");
+  });
+
+  it("refuses a timestamp iterator with no timestamp", async () => {
+    // Given a stream.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+
+    // When an AT_TIMESTAMP iterator is asked for without one.
+    const error = await refusalFrom(async () => {
+      await simAws.kinesis().getShardIterator(
+        new GetShardIteratorCommand({
+          StreamName: "orders",
+          ShardId: "shardId-000000000000",
+          ShardIteratorType: "AT_TIMESTAMP",
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "Timestamp");
+  });
+
+  it("refuses a shard the stream does not have", async () => {
+    // Given a stream with one shard.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+
+    // When an iterator onto a second shard is asked for.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.kinesis().getShardIterator(
+        new GetShardIteratorCommand({
+          StreamName: "orders",
+          ShardId: "shardId-000000000001",
+          ShardIteratorType: "TRIM_HORIZON",
+        }),
+      );
+    });
+
+    // Then it is not found.
+    assertInstanceOf(error, SimKinesisResourceNotFoundException);
+  });
+
+  it("refuses an iterator request with no shard", async () => {
+    // Given a stream.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+
+    // When an iterator is asked for without naming a shard. The SDK requires
+    // one, so the request is made structurally.
+    const error = await refusalFrom(async () => {
+      await simAws.kinesis().getShardIterator({
+        input: { StreamName: "orders", ShardIteratorType: "TRIM_HORIZON" },
+      });
+    });
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "requires a ShardId");
+  });
+
+  it("refuses a read limit outside what one GetRecords call hands back", async () => {
+    // Given a stream, and an iterator onto its only shard.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+    const iterator = await simAws.kinesis().getShardIterator(
+      new GetShardIteratorCommand({
+        StreamName: "orders",
+        ShardId: "shardId-000000000000",
+        ShardIteratorType: "TRIM_HORIZON",
+      }),
+    );
+
+    // When records are read with a limit above what Kinesis hands back.
+    const error = await refusalFrom(async () => {
+      await simAws.kinesis().getRecords(
+        new GetRecordsCommand({
+          ShardIterator: iterator.ShardIterator,
+          Limit: 10_001,
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "Limit 10001");
+  });
+});

--- a/src/service/kinesis/command/read/sim-kinesis-shard-reads.iso.test.ts
+++ b/src/service/kinesis/command/read/sim-kinesis-shard-reads.iso.test.ts
@@ -1,0 +1,301 @@
+import {
+  DescribeStreamCommand,
+  GetRecordsCommand,
+  GetShardIteratorCommand,
+  PutRecordCommand,
+  type ShardIteratorType,
+} from "@aws-sdk/client-kinesis";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimFixedClock } from "../../../../util/clock/sim-clock.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimKinesisExpiredIteratorException } from "../../error/sim-kinesis.error.js";
+import { simKinesisStreamFactory } from "../../stream/sim-kinesis-stream.factory.js";
+
+const startedAt = new Date("2026-08-22T09:00:00.000Z");
+
+/**
+ * The single shard of a one shard stream.
+ */
+async function onlyShardId(simAws: SimAws): Promise<string> {
+  const described = await simAws
+    .kinesis()
+    .describeStream(new DescribeStreamCommand({ StreamName: "orders" }));
+
+  return described.StreamDescription.Shards[0]?.ShardId ?? "";
+}
+
+/**
+ * Put one record onto the stream, under a partition key of its own.
+ */
+async function putOrder(simAws: SimAws, id: string): Promise<string> {
+  const put = await simAws.kinesis().putRecord(
+    new PutRecordCommand({
+      StreamName: "orders",
+      PartitionKey: id,
+      Data: new TextEncoder().encode(id),
+    }),
+  );
+
+  return put.SequenceNumber;
+}
+
+/**
+ * Read whatever an iterator of a given type reaches.
+ */
+async function readFrom(
+  simAws: SimAws,
+  input: {
+    readonly ShardIteratorType: ShardIteratorType;
+    readonly StartingSequenceNumber?: string;
+    readonly Timestamp?: Date;
+    readonly Limit?: number;
+  },
+): Promise<readonly string[]> {
+  const iterator = await simAws.kinesis().getShardIterator(
+    new GetShardIteratorCommand({
+      StreamName: "orders",
+      ShardId: await onlyShardId(simAws),
+      ShardIteratorType: input.ShardIteratorType,
+      StartingSequenceNumber: input.StartingSequenceNumber,
+      Timestamp: input.Timestamp,
+    }),
+  );
+  const read = await simAws.kinesis().getRecords(
+    new GetRecordsCommand({
+      ShardIterator: iterator.ShardIterator,
+      Limit: input.Limit,
+    }),
+  );
+
+  return read.Records.map((record) => new TextDecoder().decode(record.Data));
+}
+
+describe("Reading records off a simulated Kinesis shard", () => {
+  it("reads everything on the shard from the trim horizon", async () => {
+    // Given a stream holding three records.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+    await putOrder(simAws, "order-1");
+    await putOrder(simAws, "order-2");
+    await putOrder(simAws, "order-3");
+
+    // When the shard is read from the trim horizon.
+    const read = await readFrom(simAws, { ShardIteratorType: "TRIM_HORIZON" });
+
+    // Then everything on it comes back, oldest first.
+    assertIdentical(read.join(","), "order-1,order-2,order-3");
+  });
+
+  it("reads only what arrives after a LATEST iterator was taken", async () => {
+    // Given a stream already holding a record.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+    await putOrder(simAws, "order-1");
+
+    // When an iterator is taken at the tip, and a record is put after it.
+    const iterator = await simAws.kinesis().getShardIterator(
+      new GetShardIteratorCommand({
+        StreamName: "orders",
+        ShardId: await onlyShardId(simAws),
+        ShardIteratorType: "LATEST",
+      }),
+    );
+    await putOrder(simAws, "order-2");
+    const read = await simAws
+      .kinesis()
+      .getRecords(
+        new GetRecordsCommand({ ShardIterator: iterator.ShardIterator }),
+      );
+
+    // Then only the later record comes back.
+    assertArrayLength(read.Records, 1);
+    assertIdentical(new TextDecoder().decode(read.Records[0].Data), "order-2");
+  });
+
+  it("reads at and after a sequence number a caller names", async () => {
+    // Given a stream holding three records.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+    await putOrder(simAws, "order-1");
+    const second = await putOrder(simAws, "order-2");
+    await putOrder(simAws, "order-3");
+
+    // When the shard is read at and then after the second record.
+    const at = await readFrom(simAws, {
+      ShardIteratorType: "AT_SEQUENCE_NUMBER",
+      StartingSequenceNumber: second,
+    });
+    const after = await readFrom(simAws, {
+      ShardIteratorType: "AFTER_SEQUENCE_NUMBER",
+      StartingSequenceNumber: second,
+    });
+
+    // Then the difference between the two is whether that record comes back.
+    assertIdentical(at.join(","), "order-2,order-3");
+    assertIdentical(after.join(","), "order-3");
+  });
+
+  it("reads from an instant a caller names", async () => {
+    // Given a stream holding a record put an hour before another.
+    const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+    await simKinesisStreamFactory.make({}, simAws);
+    await putOrder(simAws, "order-1");
+    await simAws.clock().advanceBy({ hours: 1 });
+    await putOrder(simAws, "order-2");
+
+    // When the shard is read from half an hour after the first.
+    const read = await readFrom(simAws, {
+      ShardIteratorType: "AT_TIMESTAMP",
+      Timestamp: new Date(startedAt.getTime() + 30 * 60 * 1000),
+    });
+
+    // Then only the later record comes back.
+    assertIdentical(read.join(","), "order-2");
+  });
+
+  it("carries on from the iterator the last read handed back", async () => {
+    // Given a stream holding one record, read from the trim horizon.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+    await putOrder(simAws, "order-1");
+    const iterator = await simAws.kinesis().getShardIterator(
+      new GetShardIteratorCommand({
+        StreamName: "orders",
+        ShardId: await onlyShardId(simAws),
+        ShardIteratorType: "TRIM_HORIZON",
+      }),
+    );
+    const first = await simAws
+      .kinesis()
+      .getRecords(
+        new GetRecordsCommand({ ShardIterator: iterator.ShardIterator }),
+      );
+
+    // When another record is put and the next iterator is read.
+    await putOrder(simAws, "order-2");
+    const second = await simAws
+      .kinesis()
+      .getRecords(
+        new GetRecordsCommand({ ShardIterator: first.NextShardIterator }),
+      );
+
+    // Then only the new record comes back, and the reader is caught up.
+    assertArrayLength(second.Records, 1);
+    assertIdentical(
+      new TextDecoder().decode(second.Records[0].Data),
+      "order-2",
+    );
+    assertIdentical(second.MillisBehindLatest, 0);
+  });
+
+  it("reports how far behind the tip a limited read left the reader", async () => {
+    // Given a stream holding two records, put five minutes apart.
+    const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+    await simKinesisStreamFactory.make({}, simAws);
+    await putOrder(simAws, "order-1");
+    await simAws.clock().advanceBy({ minutes: 5 });
+    await putOrder(simAws, "order-2");
+
+    // When one record is read.
+    const iterator = await simAws.kinesis().getShardIterator(
+      new GetShardIteratorCommand({
+        StreamName: "orders",
+        ShardId: await onlyShardId(simAws),
+        ShardIteratorType: "TRIM_HORIZON",
+      }),
+    );
+    const read = await simAws.kinesis().getRecords(
+      new GetRecordsCommand({
+        ShardIterator: iterator.ShardIterator,
+        Limit: 1,
+      }),
+    );
+
+    // Then the reader is behind by the age of the record it stopped at.
+    assertArrayLength(read.Records, 1);
+    assertIdentical(read.MillisBehindLatest, 5 * 60 * 1000);
+  });
+
+  it("gives an empty answer to a reader that has caught up", async () => {
+    // Given a stream with nothing on it.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+
+    // When the shard is read from the trim horizon.
+    const read = await readFrom(simAws, { ShardIteratorType: "TRIM_HORIZON" });
+
+    // Then nothing comes back, which is an ordinary answer.
+    assertArrayLength(read, 0);
+  });
+
+  it("refuses a shard iterator it never issued", async () => {
+    // Given a stream.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+
+    // When records are read with a token this simulation never made.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .kinesis()
+        .getRecords(
+          new GetRecordsCommand({ ShardIterator: "not-an-iterator" }),
+        );
+    });
+
+    // Then it is refused the way real Kinesis refuses one it will not take.
+    assertInstanceOf(error, SimKinesisExpiredIteratorException);
+  });
+
+  it("reads nothing from a LATEST iterator taken on an empty shard", async () => {
+    // Given a stream with nothing on it.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+
+    // When an iterator is taken at the tip, and a record is put after it.
+    const iterator = await simAws.kinesis().getShardIterator(
+      new GetShardIteratorCommand({
+        StreamName: "orders",
+        ShardId: await onlyShardId(simAws),
+        ShardIteratorType: "LATEST",
+      }),
+    );
+    await putOrder(simAws, "order-1");
+    const read = await simAws
+      .kinesis()
+      .getRecords(
+        new GetRecordsCommand({ ShardIterator: iterator.ShardIterator }),
+      );
+
+    // Then the record put afterwards comes back, since there was nothing on the
+    // shard for the iterator to sit after.
+    assertArrayLength(read.Records, 1);
+    assertIdentical(new TextDecoder().decode(read.Records[0].Data), "order-1");
+  });
+
+  it("reads nothing from a position past everything on the shard", async () => {
+    // Given a stream holding one record.
+    const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+    await simKinesisStreamFactory.make({}, simAws);
+    const only = await putOrder(simAws, "order-1");
+
+    // When the shard is read after that record, and from an hour later.
+    const afterEverything = await readFrom(simAws, {
+      ShardIteratorType: "AFTER_SEQUENCE_NUMBER",
+      StartingSequenceNumber: only,
+    });
+    const laterThanEverything = await readFrom(simAws, {
+      ShardIteratorType: "AT_TIMESTAMP",
+      Timestamp: new Date(startedAt.getTime() + 60 * 60 * 1000),
+    });
+
+    // Then both come back empty rather than wrapping round to the start.
+    assertArrayLength(afterEverything, 0);
+    assertArrayLength(laterThanEverything, 0);
+  });
+});

--- a/src/service/kinesis/command/record/record.command.ts
+++ b/src/service/kinesis/command/record/record.command.ts
@@ -1,0 +1,70 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim Kinesis PutRecord command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/kinesis/command/PutRecordCommand/
+ */
+export interface SimPutRecordCommand {
+  readonly input: SimPutRecordCommandInput;
+}
+
+export interface SimPutRecordCommandInput {
+  readonly StreamName?: string | undefined;
+  readonly StreamARN?: string | undefined;
+  readonly Data?: Uint8Array | undefined;
+  readonly PartitionKey?: string | undefined;
+  readonly ExplicitHashKey?: string | undefined;
+  readonly SequenceNumberForOrdering?: string | undefined;
+}
+
+export interface SimPutRecordCommandOutput {
+  readonly ShardId: string;
+  readonly SequenceNumber: string;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * One record as a PutRecords request carries it.
+ */
+export interface SimKinesisPutRecordsRequestEntry {
+  readonly Data?: Uint8Array | undefined;
+  readonly PartitionKey?: string | undefined;
+  readonly ExplicitHashKey?: string | undefined;
+}
+
+/**
+ * Minimal structural sim Kinesis PutRecords command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/kinesis/command/PutRecordsCommand/
+ */
+export interface SimPutRecordsCommand {
+  readonly input: SimPutRecordsCommandInput;
+}
+
+export interface SimPutRecordsCommandInput {
+  readonly StreamName?: string | undefined;
+  readonly StreamARN?: string | undefined;
+  readonly Records?: readonly SimKinesisPutRecordsRequestEntry[] | undefined;
+}
+
+/**
+ * What became of one record a PutRecords request carried.
+ *
+ * A record that went on the stream carries the shard it landed on and the
+ * sequence number it took. One that did not carries an error code and message
+ * instead, which is how real Kinesis reports a record it dropped while
+ * accepting the rest of the batch.
+ */
+export interface SimKinesisPutRecordsResultEntry {
+  readonly ShardId?: string | undefined;
+  readonly SequenceNumber?: string | undefined;
+  readonly ErrorCode?: string | undefined;
+  readonly ErrorMessage?: string | undefined;
+}
+
+export interface SimPutRecordsCommandOutput {
+  readonly FailedRecordCount: number;
+  readonly Records: readonly SimKinesisPutRecordsResultEntry[];
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/kinesis/command/record/sim-kinesis-put-batch.ts
+++ b/src/service/kinesis/command/record/sim-kinesis-put-batch.ts
@@ -40,7 +40,16 @@ export function simKinesisReadPutBatch(
   }
 
   const read = records.map((record) => simKinesisReadPutEntry(record));
-  const bytes = read.reduce((total, entry) => total + entry.data.byteLength, 0);
+
+  // AWS counts the partition keys towards the request limit, unlike the
+  // per-record one, which is on the data blob alone.
+  const bytes = read.reduce(
+    (total, entry) =>
+      total +
+      entry.data.byteLength +
+      Buffer.byteLength(entry.partitionKey, "utf8"),
+    0,
+  );
 
   if (bytes > maxBatchBytes) {
     throw new SimKinesisInvalidArgumentException(

--- a/src/service/kinesis/command/record/sim-kinesis-put-batch.ts
+++ b/src/service/kinesis/command/record/sim-kinesis-put-batch.ts
@@ -1,0 +1,53 @@
+import { SimKinesisInvalidArgumentException } from "../../error/sim-kinesis.error.js";
+import type { SimKinesisPutRecordsRequestEntry } from "./record.command.js";
+import {
+  simKinesisMaxRecordBytes,
+  simKinesisReadPutEntry,
+  type SimKinesisReadPutEntry,
+} from "./sim-kinesis-put-entry.js";
+
+/**
+ * The most records real Kinesis takes in one PutRecords request.
+ */
+const maxBatchRecords = 500;
+
+/**
+ * The most bytes real Kinesis takes across one PutRecords request.
+ */
+const maxBatchBytes = 5 * simKinesisMaxRecordBytes;
+
+/**
+ * Read the records a batch carried, refusing a batch Kinesis would refuse.
+ *
+ * The whole request is refused rather than the offending record, which is what
+ * real Kinesis does with a malformed batch. Its per-record failures are for
+ * records it could not take at that moment, not for records it will never take.
+ */
+export function simKinesisReadPutBatch(
+  records: readonly SimKinesisPutRecordsRequestEntry[] | undefined,
+): readonly SimKinesisReadPutEntry[] {
+  if (records === undefined || records.length === 0) {
+    throw new SimKinesisInvalidArgumentException(
+      "PutRecords requires at least one record",
+    );
+  }
+
+  if (records.length > maxBatchRecords) {
+    throw new SimKinesisInvalidArgumentException(
+      `PutRecords carries ${records.length} records, more than the ` +
+        `${maxBatchRecords} Kinesis accepts in one request`,
+    );
+  }
+
+  const read = records.map((record) => simKinesisReadPutEntry(record));
+  const bytes = read.reduce((total, entry) => total + entry.data.byteLength, 0);
+
+  if (bytes > maxBatchBytes) {
+    throw new SimKinesisInvalidArgumentException(
+      `PutRecords carries ${bytes} bytes, more than the ${maxBatchBytes} ` +
+        `bytes Kinesis accepts in one request`,
+    );
+  }
+
+  return read;
+}

--- a/src/service/kinesis/command/record/sim-kinesis-put-commands.ts
+++ b/src/service/kinesis/command/record/sim-kinesis-put-commands.ts
@@ -1,0 +1,85 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimKinesisRequestOptions } from "../sim-kinesis-request-options.js";
+import type { SimKinesisStreamAccess } from "../sim-kinesis-stream-access.js";
+import { simKinesisReadPutBatch } from "./sim-kinesis-put-batch.js";
+import { simKinesisReadPutEntry } from "./sim-kinesis-put-entry.js";
+import type {
+  SimPutRecordCommand,
+  SimPutRecordCommandOutput,
+  SimPutRecordsCommand,
+  SimPutRecordsCommandOutput,
+} from "./record.command.js";
+
+interface SimKinesisPutCommandsProperties {
+  readonly access: SimKinesisStreamAccess;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * The commands that put records onto a stream.
+ */
+export class SimKinesisPutCommands {
+  private readonly access: SimKinesisStreamAccess;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: SimKinesisPutCommandsProperties) {
+    this.access = properties.access;
+    this.background = properties.background;
+  }
+
+  /**
+   * Put one record onto a stream.
+   *
+   * `SequenceNumberForOrdering` is accepted and needs nothing done with it.
+   * Real Kinesis uses it to guarantee that this record's sequence number is
+   * higher than the one it names, and a single counter per stream gives that
+   * for every record here whether or not a request asks for it.
+   */
+  putRecord(
+    command: SimPutRecordCommand,
+    options?: SimKinesisRequestOptions,
+  ): SimPutRecordCommandOutput {
+    const { input } = command;
+    const stream = this.access.require("kinesis:PutRecord", input, options);
+    const entry = simKinesisReadPutEntry(input);
+    const placement = stream.put({ ...entry, at: this.background.now() });
+
+    return {
+      $metadata: {},
+      ShardId: placement.shardId,
+      SequenceNumber: placement.sequenceNumber,
+    };
+  }
+
+  /**
+   * Put a batch of records onto a stream.
+   *
+   * Every record that reaches the stream is reported back with the shard it
+   * landed on. Nothing here fails a record on its own, since the reasons real
+   * Kinesis does are throughput limits and internal faults, neither of which is
+   * simulated. `FailedRecordCount` is therefore zero, and the per-record shape
+   * is still what a consumer of the response reads.
+   */
+  putRecords(
+    command: SimPutRecordsCommand,
+    options?: SimKinesisRequestOptions,
+  ): SimPutRecordsCommandOutput {
+    const { input } = command;
+    const stream = this.access.require("kinesis:PutRecords", input, options);
+    const entries = simKinesisReadPutBatch(input.Records);
+    const at = this.background.now();
+
+    return {
+      $metadata: {},
+      FailedRecordCount: 0,
+      Records: entries.map((entry) => {
+        const placement = stream.put({ ...entry, at });
+
+        return {
+          ShardId: placement.shardId,
+          SequenceNumber: placement.sequenceNumber,
+        };
+      }),
+    };
+  }
+}

--- a/src/service/kinesis/command/record/sim-kinesis-put-entry.ts
+++ b/src/service/kinesis/command/record/sim-kinesis-put-entry.ts
@@ -50,6 +50,16 @@ function readPartitionKey(partitionKey: string | undefined): string {
 }
 
 /**
+ * The decimal Kinesis takes an explicit hash key as.
+ *
+ * Reading it with `BigInt` alone would take a good deal more than Kinesis does,
+ * including hexadecimal, a sign, surrounding whitespace and the empty string,
+ * each of which would silently place a record somewhere the producer never
+ * named.
+ */
+const explicitHashKeyPattern = /^(?:0|[1-9]\d{0,38})$/u;
+
+/**
  * Read the explicit hash key a record carries, when it carries one.
  *
  * Kinesis takes it as a decimal string because the hash key space runs to
@@ -62,17 +72,15 @@ function readExplicitHashKey(
     return undefined;
   }
 
-  let value: bigint;
-
-  try {
-    value = BigInt(explicitHashKey);
-  } catch {
+  if (!explicitHashKeyPattern.test(explicitHashKey)) {
     throw new SimKinesisInvalidArgumentException(
       `ExplicitHashKey '${explicitHashKey}' is not a whole number`,
     );
   }
 
-  if (value < 0n || value >= simKinesisHashKeySpace) {
+  const value = BigInt(explicitHashKey);
+
+  if (value >= simKinesisHashKeySpace) {
     throw new SimKinesisInvalidArgumentException(
       `ExplicitHashKey '${explicitHashKey}' is outside the 128 bit hash key ` +
         `space`,

--- a/src/service/kinesis/command/record/sim-kinesis-put-entry.ts
+++ b/src/service/kinesis/command/record/sim-kinesis-put-entry.ts
@@ -1,0 +1,116 @@
+import { SimKinesisInvalidArgumentException } from "../../error/sim-kinesis.error.js";
+import { simKinesisHashKeySpace } from "../../stream/sim-kinesis-hash-key.js";
+
+/**
+ * The largest record real Kinesis accepts, before base64 encoding.
+ */
+export const simKinesisMaxRecordBytes = 1024 * 1024;
+
+/**
+ * The longest partition key real Kinesis accepts.
+ */
+const maxPartitionKeyLength = 256;
+
+/**
+ * One record as any of the put operations carries it.
+ */
+export interface SimKinesisPutEntry {
+  readonly Data?: Uint8Array | undefined;
+  readonly PartitionKey?: string | undefined;
+  readonly ExplicitHashKey?: string | undefined;
+}
+
+/**
+ * One record, read out of a request and checked against what Kinesis accepts.
+ */
+export interface SimKinesisReadPutEntry {
+  readonly partitionKey: string;
+  readonly explicitHashKey: bigint | undefined;
+  readonly data: Uint8Array;
+}
+
+/**
+ * Read the partition key a record carries.
+ */
+function readPartitionKey(partitionKey: string | undefined): string {
+  if (partitionKey === undefined || partitionKey === "") {
+    throw new SimKinesisInvalidArgumentException(
+      "PartitionKey is required on every record and may not be empty",
+    );
+  }
+
+  if (partitionKey.length > maxPartitionKeyLength) {
+    throw new SimKinesisInvalidArgumentException(
+      `PartitionKey is longer than the ${maxPartitionKeyLength} characters ` +
+        `Kinesis accepts`,
+    );
+  }
+
+  return partitionKey;
+}
+
+/**
+ * Read the explicit hash key a record carries, when it carries one.
+ *
+ * Kinesis takes it as a decimal string because the hash key space runs to
+ * 2^128, which no JSON number can hold.
+ */
+function readExplicitHashKey(
+  explicitHashKey: string | undefined,
+): bigint | undefined {
+  if (explicitHashKey === undefined) {
+    return undefined;
+  }
+
+  let value: bigint;
+
+  try {
+    value = BigInt(explicitHashKey);
+  } catch {
+    throw new SimKinesisInvalidArgumentException(
+      `ExplicitHashKey '${explicitHashKey}' is not a whole number`,
+    );
+  }
+
+  if (value < 0n || value >= simKinesisHashKeySpace) {
+    throw new SimKinesisInvalidArgumentException(
+      `ExplicitHashKey '${explicitHashKey}' is outside the 128 bit hash key ` +
+        `space`,
+    );
+  }
+
+  return value;
+}
+
+/**
+ * Read the data a record carries.
+ */
+function readData(data: Uint8Array | undefined): Uint8Array {
+  if (data === undefined) {
+    throw new SimKinesisInvalidArgumentException(
+      "Data is required on every record",
+    );
+  }
+
+  if (data.byteLength > simKinesisMaxRecordBytes) {
+    throw new SimKinesisInvalidArgumentException(
+      `Data is ${data.byteLength} bytes, more than the ` +
+        `${simKinesisMaxRecordBytes} bytes Kinesis accepts in one record`,
+    );
+  }
+
+  return data;
+}
+
+/**
+ * Read one record out of a request, refusing anything Kinesis would refuse.
+ */
+export function simKinesisReadPutEntry(
+  entry: SimKinesisPutEntry,
+): SimKinesisReadPutEntry {
+  return {
+    partitionKey: readPartitionKey(entry.PartitionKey),
+    explicitHashKey: readExplicitHashKey(entry.ExplicitHashKey),
+    data: readData(entry.Data),
+  };
+}

--- a/src/service/kinesis/command/record/sim-kinesis-put-records.iso.test.ts
+++ b/src/service/kinesis/command/record/sim-kinesis-put-records.iso.test.ts
@@ -2,7 +2,6 @@ import { PutRecordsCommand } from "@aws-sdk/client-kinesis";
 import {
   assertArrayLength,
   assertIdentical,
-  assertSetSize,
   assertStringStartsWith,
   assertTrue,
   assertUndefined,
@@ -46,34 +45,5 @@ describe("Putting a batch of records onto a simulated Kinesis stream", () => {
       assertTrue((record.SequenceNumber ?? "").length > 0);
       assertUndefined(record.ErrorCode);
     }
-  });
-
-  it("gives every record on a stream its own increasing sequence number", async () => {
-    // Given a stream with two shards.
-    const simAws = new SimAws();
-    await simKinesisStreamFactory.make({ shardCount: 2 }, simAws);
-
-    // When a batch of records is put.
-    const put = await simAws.kinesis().putRecords(
-      new PutRecordsCommand({
-        StreamName: "orders",
-        Records: ["a", "b", "c", "d"].map((key) => ({
-          PartitionKey: key,
-          Data: orderBytes(key),
-        })),
-      }),
-    );
-
-    // Then the sequence numbers are distinct and each is higher than the last.
-    const sequenceNumbers = put.Records.map(
-      (record) => record.SequenceNumber ?? "",
-    );
-    assertSetSize(new Set(sequenceNumbers), 4);
-    assertIdentical(
-      sequenceNumbers.join(","),
-      [...sequenceNumbers]
-        .toSorted((left, right) => left.localeCompare(right))
-        .join(","),
-    );
   });
 });

--- a/src/service/kinesis/command/record/sim-kinesis-put-records.iso.test.ts
+++ b/src/service/kinesis/command/record/sim-kinesis-put-records.iso.test.ts
@@ -1,0 +1,79 @@
+import { PutRecordsCommand } from "@aws-sdk/client-kinesis";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertSetSize,
+  assertStringStartsWith,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simKinesisStreamFactory } from "../../stream/sim-kinesis-stream.factory.js";
+
+/**
+ * The bytes of one order event.
+ */
+function orderBytes(id: string): Uint8Array {
+  return new TextEncoder().encode(JSON.stringify({ id }));
+}
+
+describe("Putting a batch of records onto a simulated Kinesis stream", () => {
+  it("reports where every record of a batch landed", async () => {
+    // Given a stream with two shards.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({ shardCount: 2 }, simAws);
+
+    // When three records are put in one batch.
+    const put = await simAws.kinesis().putRecords(
+      new PutRecordsCommand({
+        StreamName: "orders",
+        Records: [
+          { PartitionKey: "customer-1", Data: orderBytes("order-1") },
+          { PartitionKey: "customer-2", Data: orderBytes("order-2") },
+          { PartitionKey: "customer-3", Data: orderBytes("order-3") },
+        ],
+      }),
+    );
+
+    // Then each one reports the shard it landed on and the sequence number it
+    // took, and nothing failed.
+    assertIdentical(put.FailedRecordCount, 0);
+    assertArrayLength(put.Records, 3);
+
+    for (const record of put.Records) {
+      assertStringStartsWith(record.ShardId ?? "", "shardId-");
+      assertTrue((record.SequenceNumber ?? "").length > 0);
+      assertUndefined(record.ErrorCode);
+    }
+  });
+
+  it("gives every record on a stream its own increasing sequence number", async () => {
+    // Given a stream with two shards.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({ shardCount: 2 }, simAws);
+
+    // When a batch of records is put.
+    const put = await simAws.kinesis().putRecords(
+      new PutRecordsCommand({
+        StreamName: "orders",
+        Records: ["a", "b", "c", "d"].map((key) => ({
+          PartitionKey: key,
+          Data: orderBytes(key),
+        })),
+      }),
+    );
+
+    // Then the sequence numbers are distinct and each is higher than the last.
+    const sequenceNumbers = put.Records.map(
+      (record) => record.SequenceNumber ?? "",
+    );
+    assertSetSize(new Set(sequenceNumbers), 4);
+    assertIdentical(
+      sequenceNumbers.join(","),
+      [...sequenceNumbers]
+        .toSorted((left, right) => left.localeCompare(right))
+        .join(","),
+    );
+  });
+});

--- a/src/service/kinesis/command/record/sim-kinesis-record-placement.iso.test.ts
+++ b/src/service/kinesis/command/record/sim-kinesis-record-placement.iso.test.ts
@@ -1,0 +1,137 @@
+import {
+  DescribeStreamCommand,
+  GetRecordsCommand,
+  GetShardIteratorCommand,
+  PutRecordCommand,
+} from "@aws-sdk/client-kinesis";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simKinesisHashKeySpace } from "../../stream/sim-kinesis-hash-key.js";
+import { simKinesisStreamFactory } from "../../stream/sim-kinesis-stream.factory.js";
+
+/**
+ * The bytes of one order event.
+ */
+function orderBytes(id: string): Uint8Array {
+  return new TextEncoder().encode(JSON.stringify({ id }));
+}
+
+/**
+ * Read everything on one shard of a stream, oldest first.
+ */
+async function readShard(
+  simAws: SimAws,
+  shardId: string,
+): Promise<readonly { PartitionKey: string; Data: Uint8Array }[]> {
+  const iterator = await simAws.kinesis().getShardIterator(
+    new GetShardIteratorCommand({
+      StreamName: "orders",
+      ShardId: shardId,
+      ShardIteratorType: "TRIM_HORIZON",
+    }),
+  );
+  const read = await simAws
+    .kinesis()
+    .getRecords(
+      new GetRecordsCommand({ ShardIterator: iterator.ShardIterator }),
+    );
+
+  return read.Records;
+}
+
+describe("Where a record lands on a simulated Kinesis stream", () => {
+  it("reads two records with one partition key back in the order they were put", async () => {
+    // Given a stream with two shards.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({ shardCount: 2 }, simAws);
+
+    // When two records are put under one partition key.
+    const first = await simAws.kinesis().putRecord(
+      new PutRecordCommand({
+        StreamName: "orders",
+        PartitionKey: "customer-1",
+        Data: orderBytes("order-1"),
+      }),
+    );
+    const second = await simAws.kinesis().putRecord(
+      new PutRecordCommand({
+        StreamName: "orders",
+        PartitionKey: "customer-1",
+        Data: orderBytes("order-2"),
+      }),
+    );
+
+    // Then both landed on one shard, and that shard holds them in order.
+    assertIdentical(first.ShardId, second.ShardId);
+
+    const records = await readShard(simAws, first.ShardId);
+    assertArrayLength(records, 2);
+    assertIdentical(
+      new TextDecoder().decode(records[0].Data),
+      '{"id":"order-1"}',
+    );
+    assertIdentical(
+      new TextDecoder().decode(records[1].Data),
+      '{"id":"order-2"}',
+    );
+  });
+
+  it("spreads records across the shards their partition keys hash onto", async () => {
+    // Given a stream with four shards.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({ shardCount: 4 }, simAws);
+
+    // When records are put under twenty different partition keys.
+    const shardIds = new Set<string>();
+    for (let index = 0; index < 20; index += 1) {
+      // oxlint-disable-next-line no-await-in-loop
+      const placement = await simAws.kinesis().putRecord(
+        new PutRecordCommand({
+          StreamName: "orders",
+          PartitionKey: `customer-${index}`,
+          Data: orderBytes(`order-${index}`),
+        }),
+      );
+      shardIds.add(placement.ShardId);
+    }
+
+    // Then they did not all land on one shard.
+    assertTrue(shardIds.size > 1);
+  });
+
+  it("places a record by its explicit hash key rather than its partition key", async () => {
+    // Given a stream with two shards, whose second shard owns the upper half of
+    // the hash key space.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({ shardCount: 2 }, simAws);
+    const upperHalf = (simKinesisHashKeySpace / 2n).toString();
+
+    // When a record is put with an explicit hash key in that upper half.
+    const placement = await simAws.kinesis().putRecord(
+      new PutRecordCommand({
+        StreamName: "orders",
+        PartitionKey: "customer-1",
+        ExplicitHashKey: upperHalf,
+        Data: orderBytes("order-1"),
+      }),
+    );
+
+    // Then it landed on the second shard, and it still carries the partition
+    // key the producer gave it.
+    const described = await simAws
+      .kinesis()
+      .describeStream(new DescribeStreamCommand({ StreamName: "orders" }));
+    assertIdentical(
+      placement.ShardId,
+      described.StreamDescription.Shards[1]?.ShardId,
+    );
+
+    const records = await readShard(simAws, placement.ShardId);
+    assertIdentical(records[0]?.PartitionKey, "customer-1");
+  });
+});

--- a/src/service/kinesis/command/record/sim-kinesis-record-placement.iso.test.ts
+++ b/src/service/kinesis/command/record/sim-kinesis-record-placement.iso.test.ts
@@ -134,4 +134,25 @@ describe("Where a record lands on a simulated Kinesis stream", () => {
     const records = await readShard(simAws, placement.ShardId);
     assertIdentical(records[0]?.PartitionKey, "customer-1");
   });
+
+  it("keeps the bytes a producer put, even after it reuses the buffer", async () => {
+    // Given a stream, and one buffer a producer fills for each record.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+    const buffer = new TextEncoder().encode("order-1");
+
+    // When a record is put and the producer refills that same buffer.
+    await simAws.kinesis().putRecord(
+      new PutRecordCommand({
+        StreamName: "orders",
+        PartitionKey: "customer-1",
+        Data: buffer,
+      }),
+    );
+    buffer.set(new TextEncoder().encode("order-2"));
+
+    // Then the record on the stream is the one that was put.
+    const records = await readShard(simAws, "shardId-000000000000");
+    assertIdentical(new TextDecoder().decode(records[0]?.Data), "order-1");
+  });
 });

--- a/src/service/kinesis/command/record/sim-kinesis-sequence-numbers.iso.test.ts
+++ b/src/service/kinesis/command/record/sim-kinesis-sequence-numbers.iso.test.ts
@@ -1,0 +1,68 @@
+import { PutRecordsCommand } from "@aws-sdk/client-kinesis";
+import { assertSetSize, assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simKinesisStreamFactory } from "../../stream/sim-kinesis-stream.factory.js";
+
+/**
+ * The bytes of one order event.
+ */
+function orderBytes(id: string): Uint8Array {
+  return new TextEncoder().encode(JSON.stringify({ id }));
+}
+
+describe("The sequence numbers a simulated Kinesis stream hands out", () => {
+  it("gives every record of a batch its own sequence number", async () => {
+    // Given a stream with two shards.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({ shardCount: 2 }, simAws);
+
+    // When a batch of records is put.
+    const put = await simAws.kinesis().putRecords(
+      new PutRecordsCommand({
+        StreamName: "orders",
+        Records: ["a", "b", "c", "d"].map((key) => ({
+          PartitionKey: key,
+          Data: orderBytes(key),
+        })),
+      }),
+    );
+
+    // Then no two records took the same one. Nothing is claimed about their
+    // order against each other, since records on different shards have none.
+    const sequenceNumbers = put.Records.map(
+      (record) => record.SequenceNumber ?? "",
+    );
+    assertSetSize(new Set(sequenceNumbers), 4);
+  });
+
+  it("increases the sequence number within one shard", async () => {
+    // Given a stream with two shards.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({ shardCount: 2 }, simAws);
+
+    // When four records are put under one partition key, which is one shard.
+    const put = await simAws.kinesis().putRecords(
+      new PutRecordsCommand({
+        StreamName: "orders",
+        Records: ["a", "b", "c", "d"].map((key) => ({
+          PartitionKey: "customer-1",
+          Data: orderBytes(key),
+        })),
+      }),
+    );
+
+    // Then each record's sequence number is higher than the one before it,
+    // which is the ordering Kinesis promises within a shard.
+    assertSetSize(new Set(put.Records.map((record) => record.ShardId)), 1);
+
+    const sequenceNumbers = put.Records.map((record) =>
+      BigInt(record.SequenceNumber ?? "0"),
+    );
+    const rising = sequenceNumbers.every(
+      (sequenceNumber, index) =>
+        index === 0 || sequenceNumber > (sequenceNumbers.at(index - 1) ?? 0n),
+    );
+    assertTrue(rising);
+  });
+});

--- a/src/service/kinesis/command/sim-kinesis-command.types.ts
+++ b/src/service/kinesis/command/sim-kinesis-command.types.ts
@@ -1,0 +1,47 @@
+/**
+ * The sim Kinesis Command types, gathered for the service facade.
+ */
+export type {
+  SimCreateStreamCommand,
+  SimCreateStreamCommandInput,
+  SimCreateStreamCommandOutput,
+  SimDeleteStreamCommand,
+  SimDeleteStreamCommandInput,
+  SimDeleteStreamCommandOutput,
+  SimDescribeStreamCommand,
+  SimDescribeStreamCommandInput,
+  SimDescribeStreamCommandOutput,
+  SimDescribeStreamSummaryCommand,
+  SimDescribeStreamSummaryCommandInput,
+  SimDescribeStreamSummaryCommandOutput,
+  SimKinesisHashKeyRangeOutput,
+  SimKinesisSequenceNumberRange,
+  SimKinesisShardOutput,
+  SimKinesisStreamDescription,
+  SimKinesisStreamDescriptionSummary,
+  SimKinesisStreamModeDetails,
+  SimKinesisStreamSummary,
+  SimKinesisTags,
+  SimListStreamsCommand,
+  SimListStreamsCommandInput,
+  SimListStreamsCommandOutput,
+} from "./stream/stream.command.js";
+export type {
+  SimKinesisPutRecordsRequestEntry,
+  SimKinesisPutRecordsResultEntry,
+  SimPutRecordCommand,
+  SimPutRecordCommandInput,
+  SimPutRecordCommandOutput,
+  SimPutRecordsCommand,
+  SimPutRecordsCommandInput,
+  SimPutRecordsCommandOutput,
+} from "./record/record.command.js";
+export type {
+  SimGetRecordsCommand,
+  SimGetRecordsCommandInput,
+  SimGetRecordsCommandOutput,
+  SimGetShardIteratorCommand,
+  SimGetShardIteratorCommandInput,
+  SimGetShardIteratorCommandOutput,
+  SimKinesisRecordOutput,
+} from "./read/read.command.js";

--- a/src/service/kinesis/command/sim-kinesis-commands.ts
+++ b/src/service/kinesis/command/sim-kinesis-commands.ts
@@ -44,11 +44,7 @@ export class SimKinesisCommands {
       accountRegionScope,
       background,
     });
-    this.streams = new SimKinesisStreamCommands({
-      streams,
-      access,
-      background,
-    });
+    this.streams = new SimKinesisStreamCommands({ streams, access });
     this.puts = new SimKinesisPutCommands({ access, background });
     this.reads = new SimKinesisReadCommands({ streams, access, background });
   }

--- a/src/service/kinesis/command/sim-kinesis-commands.ts
+++ b/src/service/kinesis/command/sim-kinesis-commands.ts
@@ -1,0 +1,55 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimKinesisStreamStore } from "../stream/sim-kinesis-stream-store.js";
+import { SimKinesisAuthorizer } from "./authorize/sim-kinesis-authorizer.js";
+import { SimKinesisPutCommands } from "./record/sim-kinesis-put-commands.js";
+import { SimKinesisReadCommands } from "./read/sim-kinesis-read-commands.js";
+import { SimKinesisCreateStream } from "./stream/sim-kinesis-create-stream.js";
+import { SimKinesisStreamCommands } from "./stream/sim-kinesis-stream-commands.js";
+import { SimKinesisStreamAccess } from "./sim-kinesis-stream-access.js";
+
+interface SimKinesisCommandsProperties {
+  readonly streams: SimKinesisStreamStore;
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly background: BackgroundScheduler;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * Every command handler one simulated Kinesis scope delegates to.
+ *
+ * The wiring lives here rather than in the facade so that `SimKinesis` stays
+ * what it is meant to be: state and delegation. Which handler shares which
+ * collaborator is a fact about the handlers, not about the service object in
+ * front of them.
+ */
+export class SimKinesisCommands {
+  public readonly streamCreation: SimKinesisCreateStream;
+  public readonly streams: SimKinesisStreamCommands;
+  public readonly puts: SimKinesisPutCommands;
+  public readonly reads: SimKinesisReadCommands;
+
+  constructor(properties: SimKinesisCommandsProperties) {
+    const { streams, background, accountRegionScope } = properties;
+    const access = new SimKinesisStreamAccess({
+      streams,
+      authorizer: new SimKinesisAuthorizer({ iam: properties.iam }),
+      accountRegionScope,
+    });
+
+    this.streamCreation = new SimKinesisCreateStream({
+      streams,
+      access,
+      accountRegionScope,
+      background,
+    });
+    this.streams = new SimKinesisStreamCommands({
+      streams,
+      access,
+      background,
+    });
+    this.puts = new SimKinesisPutCommands({ access, background });
+    this.reads = new SimKinesisReadCommands({ streams, access, background });
+  }
+}

--- a/src/service/kinesis/command/sim-kinesis-page.ts
+++ b/src/service/kinesis/command/sim-kinesis-page.ts
@@ -1,0 +1,26 @@
+/**
+ * A page of items cut out of a listing that is walked in order.
+ *
+ * Kinesis pages by naming the last item of the page before, so a page is
+ * whatever follows that item up to the limit. The next token is the last item
+ * of this page, and it is absent once the page reaches the end of the listing.
+ */
+export class SimKinesisPage<T> {
+  public readonly items: readonly T[];
+  public readonly hasMore: boolean;
+
+  constructor(
+    all: readonly T[],
+    keyOf: (item: T) => string,
+    after: string | undefined,
+    limit: number,
+  ) {
+    const start =
+      after === undefined
+        ? 0
+        : all.findIndex((item) => keyOf(item) === after) + 1;
+
+    this.items = all.slice(start, start + limit);
+    this.hasMore = start + this.items.length < all.length;
+  }
+}

--- a/src/service/kinesis/command/sim-kinesis-page.ts
+++ b/src/service/kinesis/command/sim-kinesis-page.ts
@@ -1,26 +1,49 @@
 /**
- * A page of items cut out of a listing that is walked in order.
+ * A page of items cut out of a listing that is walked in key order.
  *
- * Kinesis pages by naming the last item of the page before, so a page is
- * whatever follows that item up to the limit. The next token is the last item
- * of this page, and it is absent once the page reaches the end of the listing.
+ * Kinesis pages by naming the item to start after, so a page is whatever
+ * follows that key up to the limit. The next token is the last item of this
+ * page, and it is absent once the page reaches the end of the listing.
  */
 export class SimKinesisPage<T> {
   public readonly items: readonly T[];
   public readonly hasMore: boolean;
 
+  /**
+   * Cut a page out of a listing.
+   *
+   * The start is the first key after the one given rather than the position of
+   * that key itself, so a continuation key naming an item that has since gone,
+   * or one that was never there, lands where it belongs in the order. Searching
+   * for an exact match would fail to find it and quietly start again from the
+   * beginning, which is a repeated first page and a paging loop that never
+   * ends.
+   */
   constructor(
     all: readonly T[],
     keyOf: (item: T) => string,
     after: string | undefined,
     limit: number,
   ) {
-    const start =
-      after === undefined
-        ? 0
-        : all.findIndex((item) => keyOf(item) === after) + 1;
+    const start = after === undefined ? 0 : firstKeyAfter(all, keyOf, after);
 
     this.items = all.slice(start, start + limit);
     this.hasMore = start + this.items.length < all.length;
   }
+}
+
+/**
+ * Where in a key-ordered listing the items after a key begin.
+ *
+ * The listing runs past its end when every key is at or before the one given,
+ * which is an empty last page rather than anything wrong.
+ */
+function firstKeyAfter<T>(
+  all: readonly T[],
+  keyOf: (item: T) => string,
+  after: string,
+): number {
+  const found = all.findIndex((item) => keyOf(item) > after);
+
+  return found === -1 ? all.length : found;
 }

--- a/src/service/kinesis/command/sim-kinesis-record-validation.iso.test.ts
+++ b/src/service/kinesis/command/sim-kinesis-record-validation.iso.test.ts
@@ -105,13 +105,13 @@ describe("What simulated Kinesis refuses of a record request", () => {
     const simAws = new SimAws();
     await simKinesisStreamFactory.make({}, simAws);
 
-    // When a record is put with a negative explicit hash key.
+    // When a record is put with a hash key one past the top of the space.
     const error = await refusalFrom(async () => {
       await simAws.kinesis().putRecord(
         new PutRecordCommand({
           StreamName: "orders",
           PartitionKey: "customer-1",
-          ExplicitHashKey: "-1",
+          ExplicitHashKey: (2n ** 128n).toString(),
           Data: new TextEncoder().encode("order-1"),
         }),
       );
@@ -126,20 +126,27 @@ describe("What simulated Kinesis refuses of a record request", () => {
     const simAws = new SimAws();
     await simKinesisStreamFactory.make({}, simAws);
 
-    // When a record is put with a hash key that is not a number.
-    const error = await refusalFrom(async () => {
-      await simAws.kinesis().putRecord(
-        new PutRecordCommand({
-          StreamName: "orders",
-          PartitionKey: "customer-1",
-          ExplicitHashKey: "half way",
-          Data: new TextEncoder().encode("order-1"),
-        }),
-      );
-    });
+    // Given the shapes BigInt would happily read that Kinesis will not: words,
+    // a sign, hexadecimal, padding, a leading zero and the empty string.
+    const notWholeNumbers = ["half way", "-1", "0x10", " 5 ", "007", ""];
 
-    // Then it is refused.
-    assertStringIncludes(error.message, "not a whole number");
+    // When a record is put with each of them as its hash key.
+    // Then each is refused rather than placing the record somewhere the
+    // producer never named.
+    for (const explicitHashKey of notWholeNumbers) {
+      // oxlint-disable-next-line no-await-in-loop
+      const error = await refusalFrom(async () => {
+        await simAws.kinesis().putRecord(
+          new PutRecordCommand({
+            StreamName: "orders",
+            PartitionKey: "customer-1",
+            ExplicitHashKey: explicitHashKey,
+            Data: new TextEncoder().encode("order-1"),
+          }),
+        );
+      });
+      assertStringIncludes(error.message, "not a whole number");
+    }
   });
 
   it("refuses an empty batch", async () => {
@@ -201,6 +208,30 @@ describe("What simulated Kinesis refuses of a record request", () => {
     });
 
     // Then the whole request is refused.
+    assertStringIncludes(error.message, "in one request");
+  });
+
+  it("counts the partition keys towards the size of a batch", async () => {
+    // Given a stream, and five records whose data alone is exactly the five
+    // megabytes Kinesis takes in one request.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+    const records = Array.from({ length: 5 }, (_unused, index) => ({
+      PartitionKey: `customer-${index}`,
+      Data: new Uint8Array(simKinesisMaxRecordBytes),
+    }));
+
+    // When they are put together, with the partition keys taking it over.
+    const error = await refusalFrom(async () => {
+      await simAws
+        .kinesis()
+        .putRecords(
+          new PutRecordsCommand({ StreamName: "orders", Records: records }),
+        );
+    });
+
+    // Then the batch is refused, since AWS counts the keys towards the request
+    // limit even though the per-record limit is on the data alone.
     assertStringIncludes(error.message, "in one request");
   });
 });

--- a/src/service/kinesis/command/sim-kinesis-record-validation.iso.test.ts
+++ b/src/service/kinesis/command/sim-kinesis-record-validation.iso.test.ts
@@ -1,0 +1,206 @@
+import { PutRecordCommand, PutRecordsCommand } from "@aws-sdk/client-kinesis";
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimKinesisInvalidArgumentException } from "../error/sim-kinesis.error.js";
+import { simKinesisMaxRecordBytes } from "./record/sim-kinesis-put-entry.js";
+import { simKinesisStreamFactory } from "../stream/sim-kinesis-stream.factory.js";
+
+/**
+ * The error a call raised, as the assertions here want it.
+ */
+async function refusalFrom(
+  call: () => Promise<unknown>,
+): Promise<SimKinesisInvalidArgumentException> {
+  const error = await assertThrowsErrorAsync(call);
+  assertInstanceOf(error, SimKinesisInvalidArgumentException);
+
+  return error;
+}
+
+describe("What simulated Kinesis refuses of a record request", () => {
+  it("refuses a record with no partition key", async () => {
+    // Given a stream.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+
+    // When a record is put with an empty partition key.
+    const error = await refusalFrom(async () => {
+      await simAws.kinesis().putRecord(
+        new PutRecordCommand({
+          StreamName: "orders",
+          PartitionKey: "",
+          Data: new TextEncoder().encode("order-1"),
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "PartitionKey is required");
+  });
+
+  it("refuses a partition key longer than Kinesis accepts", async () => {
+    // Given a stream.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+
+    // When a record is put under a partition key of 257 characters.
+    const error = await refusalFrom(async () => {
+      await simAws.kinesis().putRecord(
+        new PutRecordCommand({
+          StreamName: "orders",
+          PartitionKey: "c".repeat(257),
+          Data: new TextEncoder().encode("order-1"),
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "256 characters");
+  });
+
+  it("refuses a record with no data", async () => {
+    // Given a stream.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+
+    // When a record is put with no data. The SDK requires it, so the request is
+    // made structurally.
+    const error = await refusalFrom(async () => {
+      await simAws.kinesis().putRecord({
+        input: { StreamName: "orders", PartitionKey: "customer-1" },
+      });
+    });
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "Data is required");
+  });
+
+  it("refuses a record larger than Kinesis accepts", async () => {
+    // Given a stream.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+
+    // When a record over a megabyte is put.
+    const error = await refusalFrom(async () => {
+      await simAws.kinesis().putRecord(
+        new PutRecordCommand({
+          StreamName: "orders",
+          PartitionKey: "customer-1",
+          Data: new Uint8Array(simKinesisMaxRecordBytes + 1),
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "in one record");
+  });
+
+  it("refuses an explicit hash key outside the hash key space", async () => {
+    // Given a stream.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+
+    // When a record is put with a negative explicit hash key.
+    const error = await refusalFrom(async () => {
+      await simAws.kinesis().putRecord(
+        new PutRecordCommand({
+          StreamName: "orders",
+          PartitionKey: "customer-1",
+          ExplicitHashKey: "-1",
+          Data: new TextEncoder().encode("order-1"),
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "hash key space");
+  });
+
+  it("refuses an explicit hash key that is not a number", async () => {
+    // Given a stream.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+
+    // When a record is put with a hash key that is not a number.
+    const error = await refusalFrom(async () => {
+      await simAws.kinesis().putRecord(
+        new PutRecordCommand({
+          StreamName: "orders",
+          PartitionKey: "customer-1",
+          ExplicitHashKey: "half way",
+          Data: new TextEncoder().encode("order-1"),
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "not a whole number");
+  });
+
+  it("refuses an empty batch", async () => {
+    // Given a stream.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+
+    // When a batch with no records in it is put.
+    const error = await refusalFrom(async () => {
+      await simAws
+        .kinesis()
+        .putRecords(
+          new PutRecordsCommand({ StreamName: "orders", Records: [] }),
+        );
+    });
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "at least one record");
+  });
+
+  it("refuses a batch of more records than Kinesis takes at once", async () => {
+    // Given a stream.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+
+    // When five hundred and one records are put in one batch.
+    const error = await refusalFrom(async () => {
+      await simAws.kinesis().putRecords(
+        new PutRecordsCommand({
+          StreamName: "orders",
+          Records: Array.from({ length: 501 }, (_unused, index) => ({
+            PartitionKey: `customer-${index}`,
+            Data: new TextEncoder().encode("order"),
+          })),
+        }),
+      );
+    });
+
+    // Then the whole request is refused, rather than the records past the limit.
+    assertStringIncludes(error.message, "501 records");
+  });
+
+  it("refuses a batch of more bytes than Kinesis takes at once", async () => {
+    // Given a stream.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+
+    // When six records of a megabyte each are put in one batch.
+    const error = await refusalFrom(async () => {
+      await simAws.kinesis().putRecords(
+        new PutRecordsCommand({
+          StreamName: "orders",
+          Records: Array.from({ length: 6 }, (_unused, index) => ({
+            PartitionKey: `customer-${index}`,
+            Data: new Uint8Array(simKinesisMaxRecordBytes),
+          })),
+        }),
+      );
+    });
+
+    // Then the whole request is refused.
+    assertStringIncludes(error.message, "in one request");
+  });
+});

--- a/src/service/kinesis/command/sim-kinesis-request-options.ts
+++ b/src/service/kinesis/command/sim-kinesis-request-options.ts
@@ -1,0 +1,12 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+
+/**
+ * What a Kinesis request carries besides its command input.
+ */
+export interface SimKinesisRequestOptions {
+  /**
+   * Who is making the request. An omitted caller is the Account root, as it is
+   * everywhere else in the simulation.
+   */
+  readonly caller?: SimAwsCaller;
+}

--- a/src/service/kinesis/command/sim-kinesis-stream-access.ts
+++ b/src/service/kinesis/command/sim-kinesis-stream-access.ts
@@ -1,0 +1,88 @@
+import type { SimAwsResolvedCaller } from "../../aws/caller/sim-aws-caller-resolver.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { simKinesisStreamArn } from "../stream/sim-kinesis-stream-arn.js";
+import type { SimKinesisStream } from "../stream/sim-kinesis-stream.js";
+import type { SimKinesisStreamStore } from "../stream/sim-kinesis-stream-store.js";
+import type { SimKinesisAuthorizer } from "./authorize/sim-kinesis-authorizer.js";
+import type { SimKinesisRequestOptions } from "./sim-kinesis-request-options.js";
+import {
+  simKinesisRefArn,
+  simKinesisRefLookupName,
+  type SimKinesisStreamRef,
+} from "./sim-kinesis-stream-ref.js";
+
+interface SimKinesisStreamAccessProperties {
+  readonly streams: SimKinesisStreamStore;
+  readonly authorizer: SimKinesisAuthorizer;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * How a request reaches the stream it names.
+ *
+ * Every operation but ListStreams and CreateStream starts the same way: work
+ * out which stream the request means, authorize the action against that
+ * stream's ARN, then require the stream to be there.
+ *
+ * Authorizing before the lookup is what real IAM does, and it is why a caller
+ * with no permission is refused for a stream that does not exist rather than
+ * being told the stream is missing.
+ */
+export class SimKinesisStreamAccess {
+  private readonly streams: SimKinesisStreamStore;
+  private readonly authorizer: SimKinesisAuthorizer;
+  private readonly scope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimKinesisStreamAccessProperties) {
+    this.streams = properties.streams;
+    this.authorizer = properties.authorizer;
+    this.scope = properties.accountRegionScope;
+  }
+
+  /**
+   * Ensure the caller may perform an action on the stream of a given name.
+   *
+   * The stream need not exist, which is what CreateStream needs. It authorizes
+   * against the ARN the stream is about to have.
+   */
+  authorizeName(
+    action: string,
+    name: string,
+    options?: SimKinesisRequestOptions,
+  ): SimAwsResolvedCaller {
+    return this.authorizer.authorizeStream(
+      action,
+      simKinesisStreamArn(this.scope, name),
+      options?.caller,
+    );
+  }
+
+  /**
+   * Ensure the caller may perform an action naming no particular stream.
+   */
+  authorizeAnyStream(
+    action: string,
+    options?: SimKinesisRequestOptions,
+  ): SimAwsResolvedCaller {
+    return this.authorizer.authorizeAnyStream(action, options?.caller);
+  }
+
+  /**
+   * Resolve the stream a request names, authorizing the action first.
+   */
+  require(
+    action: string,
+    ref: SimKinesisStreamRef,
+    options?: SimKinesisRequestOptions,
+  ): SimKinesisStream {
+    const name = simKinesisRefLookupName(ref, this.scope);
+
+    this.authorizer.authorizeStream(
+      action,
+      simKinesisRefArn(ref, this.scope),
+      options?.caller,
+    );
+
+    return this.streams.require(name);
+  }
+}

--- a/src/service/kinesis/command/sim-kinesis-stream-ref.ts
+++ b/src/service/kinesis/command/sim-kinesis-stream-ref.ts
@@ -1,0 +1,75 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { SimKinesisInvalidArgumentException } from "../error/sim-kinesis.error.js";
+import {
+  parseSimKinesisStreamArn,
+  simKinesisStreamArn,
+} from "../stream/sim-kinesis-stream-arn.js";
+
+/**
+ * How a request names the stream it is for.
+ *
+ * Every Kinesis operation but ListStreams takes either, and real Kinesis reads
+ * the ARN when a request carries both.
+ */
+export interface SimKinesisStreamRef {
+  readonly StreamName?: string | undefined;
+  readonly StreamARN?: string | undefined;
+}
+
+/**
+ * The stream name a request carried, refusing one that named neither a name nor
+ * an ARN.
+ */
+function requiredName(name: string | undefined): string {
+  if (name === undefined || name === "") {
+    throw new SimKinesisInvalidArgumentException(
+      "A request has to name a stream by StreamName or by StreamARN",
+    );
+  }
+
+  return name;
+}
+
+/**
+ * The ARN of the stream a request names, whichever way it named it.
+ */
+export function simKinesisRefArn(
+  ref: SimKinesisStreamRef,
+  scope: SimAwsAccountRegionScope,
+): string {
+  if (ref.StreamARN !== undefined && ref.StreamARN !== "") {
+    return ref.StreamARN;
+  }
+
+  return simKinesisStreamArn(scope, requiredName(ref.StreamName));
+}
+
+/**
+ * The name to look the stream a request names up by.
+ *
+ * An ARN naming another Account or Region reaches nothing here. Reading its
+ * name out and looking that up locally would let a test pass while the real
+ * call crossed a boundary it has no permission for, so the ARN itself becomes
+ * the lookup key. No stream name can hold a colon, so nothing is found, and the
+ * refusal names what the request asked for.
+ */
+export function simKinesisRefLookupName(
+  ref: SimKinesisStreamRef,
+  scope: SimAwsAccountRegionScope,
+): string {
+  if (ref.StreamARN === undefined || ref.StreamARN === "") {
+    return requiredName(ref.StreamName);
+  }
+
+  const location = parseSimKinesisStreamArn(ref.StreamARN);
+
+  if (
+    location === undefined ||
+    location.accountId !== scope.accountId ||
+    location.regionName !== scope.regionName
+  ) {
+    return ref.StreamARN;
+  }
+
+  return location.name;
+}

--- a/src/service/kinesis/command/sim-kinesis-stream-validation.iso.test.ts
+++ b/src/service/kinesis/command/sim-kinesis-stream-validation.iso.test.ts
@@ -1,0 +1,160 @@
+import {
+  CreateStreamCommand,
+  DeleteStreamCommand,
+} from "@aws-sdk/client-kinesis";
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimKinesisInvalidArgumentException } from "../error/sim-kinesis.error.js";
+import { simKinesisStreamFactory } from "../stream/sim-kinesis-stream.factory.js";
+
+/**
+ * The error a call raised, as the assertions here want it.
+ */
+async function refusalFrom(
+  call: () => Promise<unknown>,
+): Promise<SimKinesisInvalidArgumentException> {
+  const error = await assertThrowsErrorAsync(call);
+  assertInstanceOf(error, SimKinesisInvalidArgumentException);
+
+  return error;
+}
+
+describe("What simulated Kinesis refuses of a stream request", () => {
+  it("refuses a stream created with no name", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a stream is created with an empty name.
+    const error = await refusalFrom(async () => {
+      await simAws
+        .kinesis()
+        .createStream(new CreateStreamCommand({ StreamName: "" }));
+    });
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "StreamName is required");
+  });
+
+  it("refuses a stream name Kinesis would not accept", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a stream is created with a slash in its name.
+    const error = await refusalFrom(async () => {
+      await simAws
+        .kinesis()
+        .createStream(new CreateStreamCommand({ StreamName: "orders/live" }));
+    });
+
+    // Then it is refused, saying which characters a name may hold.
+    assertStringIncludes(error.message, "letters, digits");
+  });
+
+  it("refuses a stream name longer than Kinesis accepts", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a stream is created with a name of 129 characters.
+    const error = await refusalFrom(async () => {
+      await simAws
+        .kinesis()
+        .createStream(new CreateStreamCommand({ StreamName: "o".repeat(129) }));
+    });
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "128");
+  });
+
+  it("refuses a shard count that is not a whole number of shards", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a stream is created with no shards.
+    const error = await refusalFrom(async () => {
+      await simAws
+        .kinesis()
+        .createStream(
+          new CreateStreamCommand({ StreamName: "orders", ShardCount: 0 }),
+        );
+    });
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "ShardCount 0");
+  });
+
+  it("refuses more shards than Kinesis creates a stream with", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a stream is created with more than a hundred thousand shards.
+    const error = await refusalFrom(async () => {
+      await simAws.kinesis().createStream(
+        new CreateStreamCommand({
+          StreamName: "orders",
+          ShardCount: 100_001,
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "100000 shards");
+  });
+
+  it("refuses a stream mode Kinesis does not have", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a stream is created in a mode that is neither of the two. The SDK's
+    // own types refuse to build this command, so the request is made
+    // structurally.
+    const error = await refusalFrom(async () => {
+      await simAws.kinesis().createStream({
+        input: {
+          StreamName: "orders",
+          StreamModeDetails: { StreamMode: "SOMETIMES" },
+        },
+      });
+    });
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "PROVISIONED");
+  });
+
+  it("refuses a shard count on an on-demand stream", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a stream is created in on-demand mode with a shard count.
+    const error = await refusalFrom(async () => {
+      await simAws.kinesis().createStream(
+        new CreateStreamCommand({
+          StreamName: "orders",
+          ShardCount: 2,
+          StreamModeDetails: { StreamMode: "ON_DEMAND" },
+        }),
+      );
+    });
+
+    // Then it is refused, as real Kinesis refuses both together.
+    assertStringIncludes(error.message, "ON_DEMAND");
+  });
+
+  it("refuses a request naming neither a stream name nor a stream ARN", async () => {
+    // Given a stream.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+
+    // When a stream is deleted without being named.
+    const error = await refusalFrom(async () => {
+      await simAws.kinesis().deleteStream(new DeleteStreamCommand({}));
+    });
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "StreamName or by StreamARN");
+  });
+});

--- a/src/service/kinesis/command/stream/sim-kinesis-create-stream.ts
+++ b/src/service/kinesis/command/stream/sim-kinesis-create-stream.ts
@@ -1,0 +1,86 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import { SimKinesisResourceInUseException } from "../../error/sim-kinesis.error.js";
+import { simKinesisDefaultRetentionHours } from "../../stream/sim-kinesis-retention.js";
+import { SimKinesisStream } from "../../stream/sim-kinesis-stream.js";
+import {
+  simKinesisCreatedShardCount,
+  simKinesisStreamModeOf,
+} from "../../stream/sim-kinesis-stream-mode.js";
+import { SimKinesisStreamName } from "../../stream/sim-kinesis-stream-name.js";
+import type { SimKinesisStreamStore } from "../../stream/sim-kinesis-stream-store.js";
+import type { SimKinesisRequestOptions } from "../sim-kinesis-request-options.js";
+import type { SimKinesisStreamAccess } from "../sim-kinesis-stream-access.js";
+import type {
+  SimCreateStreamCommand,
+  SimCreateStreamCommandOutput,
+} from "./stream.command.js";
+
+interface SimKinesisCreateStreamProperties {
+  readonly streams: SimKinesisStreamStore;
+  readonly access: SimKinesisStreamAccess;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * The command that creates a stream.
+ */
+export class SimKinesisCreateStream {
+  private readonly streams: SimKinesisStreamStore;
+  private readonly access: SimKinesisStreamAccess;
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: SimKinesisCreateStreamProperties) {
+    this.streams = properties.streams;
+    this.access = properties.access;
+    this.accountRegionScope = properties.accountRegionScope;
+    this.background = properties.background;
+  }
+
+  /**
+   * Create a stream and open the shards it was asked for.
+   *
+   * A name this scope already holds is refused, as real Kinesis refuses it,
+   * rather than answering with the stream that is there. The stream is `ACTIVE`
+   * straight away: real Kinesis reports `CREATING` while it brings the shards
+   * up, and a status a test has to poll through earns nothing when there are no
+   * shards to bring up.
+   *
+   * Tags are kept on the stream. No command here reads them back, since the tag
+   * operations are unsimulated, and a test that cares reads them through the
+   * simulator's own accessor.
+   */
+  handle(
+    command: SimCreateStreamCommand,
+    options?: SimKinesisRequestOptions,
+  ): SimCreateStreamCommandOutput {
+    const { input } = command;
+    const name = new SimKinesisStreamName(input.StreamName);
+
+    this.access.authorizeName("kinesis:CreateStream", name.value, options);
+
+    if (this.streams.find(name.value) !== undefined) {
+      throw new SimKinesisResourceInUseException(
+        `Stream ${name.value} under this account and region already exists`,
+      );
+    }
+
+    const mode = simKinesisStreamModeOf(input.StreamModeDetails?.StreamMode);
+
+    this.streams.add(
+      new SimKinesisStream({
+        name,
+        accountRegionScope: this.accountRegionScope,
+        mode,
+        shardCount: simKinesisCreatedShardCount(mode, input.ShardCount),
+        retentionHours: simKinesisDefaultRetentionHours,
+        createdAt: this.background.now(),
+        tags: input.Tags ?? {},
+      }),
+    );
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/kinesis/command/stream/sim-kinesis-stream-commands.ts
+++ b/src/service/kinesis/command/stream/sim-kinesis-stream-commands.ts
@@ -1,4 +1,3 @@
-import type { BackgroundScheduler } from "../../../../util/background/background.js";
 import type { SimKinesisStreamStore } from "../../stream/sim-kinesis-stream-store.js";
 import { SimKinesisPage } from "../sim-kinesis-page.js";
 import type { SimKinesisRequestOptions } from "../sim-kinesis-request-options.js";
@@ -27,7 +26,6 @@ const defaultStreamLimit = 100;
 interface SimKinesisStreamCommandsProperties {
   readonly streams: SimKinesisStreamStore;
   readonly access: SimKinesisStreamAccess;
-  readonly background: BackgroundScheduler;
 }
 
 /**
@@ -36,12 +34,10 @@ interface SimKinesisStreamCommandsProperties {
 export class SimKinesisStreamCommands {
   private readonly streams: SimKinesisStreamStore;
   private readonly access: SimKinesisStreamAccess;
-  private readonly background: BackgroundScheduler;
 
   constructor(properties: SimKinesisStreamCommandsProperties) {
     this.streams = properties.streams;
     this.access = properties.access;
-    this.background = properties.background;
   }
 
   /**
@@ -76,10 +72,6 @@ export class SimKinesisStreamCommands {
 
   /**
    * Describe a stream and a page of its shards.
-   *
-   * Retention is applied first, so the shards a description reports are the
-   * shards as they are at the instant of the request rather than as they were
-   * when something last read them.
    */
   describeStream(
     command: SimDescribeStreamCommand,
@@ -91,8 +83,6 @@ export class SimKinesisStreamCommands {
       input,
       options,
     );
-
-    this.streams.applyRetention(this.background.now());
 
     return {
       $metadata: {},

--- a/src/service/kinesis/command/stream/sim-kinesis-stream-commands.ts
+++ b/src/service/kinesis/command/stream/sim-kinesis-stream-commands.ts
@@ -1,0 +1,147 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimKinesisStreamStore } from "../../stream/sim-kinesis-stream-store.js";
+import { SimKinesisPage } from "../sim-kinesis-page.js";
+import type { SimKinesisRequestOptions } from "../sim-kinesis-request-options.js";
+import type { SimKinesisStreamAccess } from "../sim-kinesis-stream-access.js";
+import {
+  streamDescription,
+  streamDescriptionSummary,
+  streamSummary,
+} from "./sim-kinesis-stream-descriptions.js";
+import type {
+  SimDeleteStreamCommand,
+  SimDeleteStreamCommandOutput,
+  SimDescribeStreamCommand,
+  SimDescribeStreamCommandOutput,
+  SimDescribeStreamSummaryCommand,
+  SimDescribeStreamSummaryCommandOutput,
+  SimListStreamsCommand,
+  SimListStreamsCommandOutput,
+} from "./stream.command.js";
+
+/**
+ * How many streams ListStreams reports when a request asks for no limit.
+ */
+const defaultStreamLimit = 100;
+
+interface SimKinesisStreamCommandsProperties {
+  readonly streams: SimKinesisStreamStore;
+  readonly access: SimKinesisStreamAccess;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * The commands that list, describe and delete streams.
+ */
+export class SimKinesisStreamCommands {
+  private readonly streams: SimKinesisStreamStore;
+  private readonly access: SimKinesisStreamAccess;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: SimKinesisStreamCommandsProperties) {
+    this.streams = properties.streams;
+    this.access = properties.access;
+    this.background = properties.background;
+  }
+
+  /**
+   * List the streams in this scope, by name.
+   *
+   * Real Kinesis gives this action no stream-level permission, so it authorizes
+   * against every stream in the Account and Region and does not filter the list
+   * by what the caller can reach.
+   */
+  listStreams(
+    command: SimListStreamsCommand,
+    options?: SimKinesisRequestOptions,
+  ): SimListStreamsCommandOutput {
+    this.access.authorizeAnyStream("kinesis:ListStreams", options);
+
+    const { input } = command;
+    const page = new SimKinesisPage(
+      this.streams.all,
+      (stream) => stream.name,
+      input.NextToken ?? input.ExclusiveStartStreamName,
+      input.Limit ?? defaultStreamLimit,
+    );
+
+    return {
+      $metadata: {},
+      StreamNames: page.items.map((stream) => stream.name),
+      StreamSummaries: page.items.map((stream) => streamSummary(stream)),
+      HasMoreStreams: page.hasMore,
+      NextToken: page.hasMore ? page.items.at(-1)?.name : undefined,
+    };
+  }
+
+  /**
+   * Describe a stream and a page of its shards.
+   *
+   * Retention is applied first, so the shards a description reports are the
+   * shards as they are at the instant of the request rather than as they were
+   * when something last read them.
+   */
+  describeStream(
+    command: SimDescribeStreamCommand,
+    options?: SimKinesisRequestOptions,
+  ): SimDescribeStreamCommandOutput {
+    const { input } = command;
+    const stream = this.access.require(
+      "kinesis:DescribeStream",
+      input,
+      options,
+    );
+
+    this.streams.applyRetention(this.background.now());
+
+    return {
+      $metadata: {},
+      StreamDescription: streamDescription(stream, input),
+    };
+  }
+
+  /**
+   * Describe a stream without listing its shards.
+   */
+  describeStreamSummary(
+    command: SimDescribeStreamSummaryCommand,
+    options?: SimKinesisRequestOptions,
+  ): SimDescribeStreamSummaryCommandOutput {
+    const stream = this.access.require(
+      "kinesis:DescribeStreamSummary",
+      command.input,
+      options,
+    );
+
+    return {
+      $metadata: {},
+      StreamDescriptionSummary: streamDescriptionSummary(stream),
+    };
+  }
+
+  /**
+   * Delete a stream, and the records on every one of its shards.
+   *
+   * The name is freed at once, so a stream can be recreated under the same name
+   * straight away. A stream that is not there is refused, as real Kinesis
+   * refuses it, unlike SNS where deleting a missing topic succeeds.
+   *
+   * `EnforceConsumerDeletion` is accepted and needs nothing done with it. It
+   * decides what happens to a stream's enhanced fan-out consumers, and no
+   * stream here has any.
+   */
+  deleteStream(
+    command: SimDeleteStreamCommand,
+    options?: SimKinesisRequestOptions,
+  ): SimDeleteStreamCommandOutput {
+    const stream = this.access.require(
+      "kinesis:DeleteStream",
+      command.input,
+      options,
+    );
+
+    this.streams.remove(stream);
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/kinesis/command/stream/sim-kinesis-stream-descriptions.ts
+++ b/src/service/kinesis/command/stream/sim-kinesis-stream-descriptions.ts
@@ -1,0 +1,100 @@
+import type { SimKinesisShard } from "../../stream/sim-kinesis-shard.js";
+import type { SimKinesisStream } from "../../stream/sim-kinesis-stream.js";
+import { SimKinesisPage } from "../sim-kinesis-page.js";
+import type {
+  SimDescribeStreamCommandInput,
+  SimKinesisShardOutput,
+  SimKinesisStreamDescription,
+  SimKinesisStreamDescriptionSummary,
+  SimKinesisStreamSummary,
+} from "./stream.command.js";
+
+/**
+ * How many shards DescribeStream reports when a request asks for no limit.
+ */
+const defaultShardLimit = 100;
+
+/**
+ * One shard, as DescribeStream reports it.
+ *
+ * The hash key bounds are decimal strings because the space runs to 2^128. The
+ * ending sequence number is absent, which is how a reader tells a shard that is
+ * still taking records from one it can finish with. Nothing here closes a
+ * shard.
+ */
+function shardOutput(shard: SimKinesisShard): SimKinesisShardOutput {
+  return {
+    ShardId: shard.shardId,
+    HashKeyRange: {
+      StartingHashKey: shard.hashKeyRange.startingHashKey.toString(),
+      EndingHashKey: shard.hashKeyRange.endingHashKey.toString(),
+    },
+    SequenceNumberRange: {
+      StartingSequenceNumber: shard.startingSequenceNumber,
+    },
+  };
+}
+
+/**
+ * One stream, as ListStreams reports it.
+ */
+export function streamSummary(
+  stream: SimKinesisStream,
+): SimKinesisStreamSummary {
+  return {
+    StreamName: stream.name,
+    StreamARN: stream.arn,
+    StreamStatus: stream.status,
+    StreamModeDetails: { StreamMode: stream.mode },
+    StreamCreationTimestamp: stream.createdAt,
+  };
+}
+
+/**
+ * One stream and a page of its shards, as DescribeStream reports them.
+ */
+export function streamDescription(
+  stream: SimKinesisStream,
+  input: SimDescribeStreamCommandInput,
+): SimKinesisStreamDescription {
+  const page = new SimKinesisPage(
+    stream.shards,
+    (shard) => shard.shardId,
+    input.ExclusiveStartShardId,
+    input.Limit ?? defaultShardLimit,
+  );
+
+  return {
+    StreamName: stream.name,
+    StreamARN: stream.arn,
+    StreamStatus: stream.status,
+    StreamModeDetails: { StreamMode: stream.mode },
+    Shards: page.items.map((shard) => shardOutput(shard)),
+    HasMoreShards: page.hasMore,
+    RetentionPeriodHours: stream.retentionHours,
+    StreamCreationTimestamp: stream.createdAt,
+    EnhancedMonitoring: [],
+  };
+}
+
+/**
+ * One stream without its shards, as DescribeStreamSummary reports it.
+ *
+ * The consumer count is zero because enhanced fan-out is unsimulated, so
+ * nothing here registers a consumer against a stream.
+ */
+export function streamDescriptionSummary(
+  stream: SimKinesisStream,
+): SimKinesisStreamDescriptionSummary {
+  return {
+    StreamName: stream.name,
+    StreamARN: stream.arn,
+    StreamStatus: stream.status,
+    StreamModeDetails: { StreamMode: stream.mode },
+    RetentionPeriodHours: stream.retentionHours,
+    StreamCreationTimestamp: stream.createdAt,
+    EnhancedMonitoring: [],
+    OpenShardCount: stream.shards.length,
+    ConsumerCount: 0,
+  };
+}

--- a/src/service/kinesis/command/stream/sim-kinesis-stream-lifecycle.iso.test.ts
+++ b/src/service/kinesis/command/stream/sim-kinesis-stream-lifecycle.iso.test.ts
@@ -10,9 +10,7 @@ import {
   assertIdentical,
   assertInstanceOf,
   assertStringIncludes,
-  assertFalse,
   assertThrowsErrorAsync,
-  assertTrue,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
@@ -152,28 +150,5 @@ describe("Simulated Kinesis stream lifecycle", () => {
 
     // Then it is not found, rather than answered by the local stream.
     assertInstanceOf(error, SimKinesisResourceNotFoundException);
-  });
-
-  it("pages a listing longer than the limit it was given", async () => {
-    // Given three streams.
-    const simAws = new SimAws();
-    for (const streamName of ["alpha", "beta", "gamma"]) {
-      // oxlint-disable-next-line no-await-in-loop
-      await simKinesisStreamFactory.make({ streamName }, simAws);
-    }
-
-    // When they are listed two at a time.
-    const first = await simAws
-      .kinesis()
-      .listStreams(new ListStreamsCommand({ Limit: 2 }));
-    const second = await simAws
-      .kinesis()
-      .listStreams(new ListStreamsCommand({ NextToken: first.NextToken }));
-
-    // Then the pages follow each other in name order, and the last one says so.
-    assertTrue(first.HasMoreStreams);
-    assertIdentical(first.StreamNames.join(","), "alpha,beta");
-    assertIdentical(second.StreamNames.join(","), "gamma");
-    assertFalse(second.HasMoreStreams);
   });
 });

--- a/src/service/kinesis/command/stream/sim-kinesis-stream-lifecycle.iso.test.ts
+++ b/src/service/kinesis/command/stream/sim-kinesis-stream-lifecycle.iso.test.ts
@@ -1,0 +1,179 @@
+import {
+  CreateStreamCommand,
+  DeleteStreamCommand,
+  DescribeStreamCommand,
+  DescribeStreamSummaryCommand,
+  ListStreamsCommand,
+} from "@aws-sdk/client-kinesis";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertFalse,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimKinesisResourceInUseException,
+  SimKinesisResourceNotFoundException,
+} from "../../error/sim-kinesis.error.js";
+import { simKinesisStreamFactory } from "../../stream/sim-kinesis-stream.factory.js";
+
+describe("Simulated Kinesis stream lifecycle", () => {
+  it("lists and describes a stream it created", async () => {
+    // Given a simulated AWS with no streams.
+    const simAws = new SimAws();
+
+    // When a stream is created.
+    await simAws
+      .kinesis()
+      .createStream(
+        new CreateStreamCommand({ StreamName: "orders", ShardCount: 2 }),
+      );
+
+    // Then it is listed, and it describes as active with the shards asked for.
+    const listed = await simAws
+      .kinesis()
+      .listStreams(new ListStreamsCommand({}));
+    assertArrayLength(listed.StreamNames, 1);
+    assertIdentical(listed.StreamNames[0], "orders");
+
+    const described = await simAws
+      .kinesis()
+      .describeStream(new DescribeStreamCommand({ StreamName: "orders" }));
+    assertIdentical(described.StreamDescription.StreamStatus, "ACTIVE");
+    assertIdentical(
+      described.StreamDescription.StreamARN,
+      `arn:aws:kinesis:${simAws.defaultRegionName}:${simAws.defaultAccountId}:stream/orders`,
+    );
+    assertArrayLength(described.StreamDescription.Shards, 2);
+  });
+
+  it("summarises a stream without listing its shards", async () => {
+    // Given a stream with three shards.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({ shardCount: 3 }, simAws);
+
+    // When it is summarised.
+    const summary = await simAws
+      .kinesis()
+      .describeStreamSummary(
+        new DescribeStreamSummaryCommand({ StreamName: "orders" }),
+      );
+
+    // Then the open shard count stands in for the shards themselves, and the
+    // retention is the default Kinesis gives a new stream.
+    const { StreamDescriptionSummary } = summary;
+    assertIdentical(StreamDescriptionSummary.OpenShardCount, 3);
+    assertIdentical(StreamDescriptionSummary.RetentionPeriodHours, 24);
+    assertIdentical(StreamDescriptionSummary.ConsumerCount, 0);
+    assertIdentical(
+      StreamDescriptionSummary.StreamModeDetails.StreamMode,
+      "PROVISIONED",
+    );
+  });
+
+  it("gives an on-demand stream the four shards Kinesis starts it with", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a stream is created in on-demand mode, which takes no shard count.
+    await simAws.kinesis().createStream(
+      new CreateStreamCommand({
+        StreamName: "events",
+        StreamModeDetails: { StreamMode: "ON_DEMAND" },
+      }),
+    );
+
+    // Then it has the four shards real Kinesis starts one with.
+    const described = await simAws
+      .kinesis()
+      .describeStream(new DescribeStreamCommand({ StreamName: "events" }));
+    assertArrayLength(described.StreamDescription.Shards, 4);
+    assertIdentical(
+      described.StreamDescription.StreamModeDetails.StreamMode,
+      "ON_DEMAND",
+    );
+  });
+
+  it("refuses a second stream under a name it already holds", async () => {
+    // Given a stream named orders.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+
+    // When a second stream is created under the same name.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .kinesis()
+        .createStream(new CreateStreamCommand({ StreamName: "orders" }));
+    });
+
+    // Then it is refused rather than answering with the stream that is there.
+    assertInstanceOf(error, SimKinesisResourceInUseException);
+    assertStringIncludes(error.message, "already exists");
+  });
+
+  it("frees the name of a deleted stream straight away", async () => {
+    // Given a stream named orders.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({ shardCount: 2 }, simAws);
+
+    // When it is deleted and a new one is created under the same name.
+    await simAws
+      .kinesis()
+      .deleteStream(new DeleteStreamCommand({ StreamName: "orders" }));
+    await simAws
+      .kinesis()
+      .createStream(new CreateStreamCommand({ StreamName: "orders" }));
+
+    // Then the new stream is the one that is there, with its own shards.
+    const described = await simAws
+      .kinesis()
+      .describeStream(new DescribeStreamCommand({ StreamName: "orders" }));
+    assertArrayLength(described.StreamDescription.Shards, 1);
+  });
+
+  it("refuses a stream ARN naming another account", async () => {
+    // Given a stream named orders in this account.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+
+    // When a stream of that name in another account is described.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.kinesis().describeStream(
+        new DescribeStreamCommand({
+          StreamARN: `arn:aws:kinesis:${simAws.defaultRegionName}:222222222222:stream/orders`,
+        }),
+      );
+    });
+
+    // Then it is not found, rather than answered by the local stream.
+    assertInstanceOf(error, SimKinesisResourceNotFoundException);
+  });
+
+  it("pages a listing longer than the limit it was given", async () => {
+    // Given three streams.
+    const simAws = new SimAws();
+    for (const streamName of ["alpha", "beta", "gamma"]) {
+      // oxlint-disable-next-line no-await-in-loop
+      await simKinesisStreamFactory.make({ streamName }, simAws);
+    }
+
+    // When they are listed two at a time.
+    const first = await simAws
+      .kinesis()
+      .listStreams(new ListStreamsCommand({ Limit: 2 }));
+    const second = await simAws
+      .kinesis()
+      .listStreams(new ListStreamsCommand({ NextToken: first.NextToken }));
+
+    // Then the pages follow each other in name order, and the last one says so.
+    assertTrue(first.HasMoreStreams);
+    assertIdentical(first.StreamNames.join(","), "alpha,beta");
+    assertIdentical(second.StreamNames.join(","), "gamma");
+    assertFalse(second.HasMoreStreams);
+  });
+});

--- a/src/service/kinesis/command/stream/sim-kinesis-stream-paging.iso.test.ts
+++ b/src/service/kinesis/command/stream/sim-kinesis-stream-paging.iso.test.ts
@@ -1,0 +1,74 @@
+import {
+  DeleteStreamCommand,
+  ListStreamsCommand,
+} from "@aws-sdk/client-kinesis";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simKinesisStreamFactory } from "../../stream/sim-kinesis-stream.factory.js";
+
+describe("Paging a simulated Kinesis stream listing", () => {
+  it("pages a listing longer than the limit it was given", async () => {
+    // Given three streams.
+    const simAws = new SimAws();
+    for (const streamName of ["alpha", "beta", "gamma"]) {
+      // oxlint-disable-next-line no-await-in-loop
+      await simKinesisStreamFactory.make({ streamName }, simAws);
+    }
+
+    // When they are listed two at a time.
+    const first = await simAws
+      .kinesis()
+      .listStreams(new ListStreamsCommand({ Limit: 2 }));
+    const second = await simAws
+      .kinesis()
+      .listStreams(new ListStreamsCommand({ NextToken: first.NextToken }));
+
+    // Then the pages follow each other in name order, and the last one says so.
+    assertTrue(first.HasMoreStreams);
+    assertIdentical(first.StreamNames.join(","), "alpha,beta");
+    assertIdentical(second.StreamNames.join(","), "gamma");
+    assertFalse(second.HasMoreStreams);
+  });
+
+  it("carries on in name order from a continuation key nothing holds", async () => {
+    // Given three streams, and a token naming one that has since been deleted.
+    const simAws = new SimAws();
+    for (const streamName of ["alpha", "beta", "gamma"]) {
+      // oxlint-disable-next-line no-await-in-loop
+      await simKinesisStreamFactory.make({ streamName }, simAws);
+    }
+    await simAws
+      .kinesis()
+      .deleteStream(new DeleteStreamCommand({ StreamName: "beta" }));
+
+    // When the listing carries on from that name.
+    const listed = await simAws
+      .kinesis()
+      .listStreams(new ListStreamsCommand({ NextToken: "beta" }));
+
+    // Then it picks up where that name belongs in the order, rather than
+    // starting again from the first page and looping forever.
+    assertIdentical(listed.StreamNames.join(","), "gamma");
+  });
+
+  it("gives an empty last page for a continuation key past the end", async () => {
+    // Given one stream.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+
+    // When the listing carries on from a name after every stream it holds.
+    const listed = await simAws
+      .kinesis()
+      .listStreams(new ListStreamsCommand({ NextToken: "zzz" }));
+
+    // Then the page is empty and says there is no more.
+    assertArrayLength(listed.StreamNames, 0);
+    assertFalse(listed.HasMoreStreams);
+  });
+});

--- a/src/service/kinesis/command/stream/stream.command.ts
+++ b/src/service/kinesis/command/stream/stream.command.ts
@@ -1,0 +1,182 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * One tag as a CreateStream request carries it.
+ */
+export type SimKinesisTags = Record<string, string>;
+
+/**
+ * How a stream's capacity is declared, as a request carries it.
+ */
+export interface SimKinesisStreamModeDetails {
+  readonly StreamMode?: string | undefined;
+}
+
+/**
+ * The bounds of one shard's slice of the hash key space, as a request reports
+ * them.
+ *
+ * They are decimal strings rather than numbers, because the space runs to 2^128
+ * and a JavaScript number cannot hold that.
+ */
+export interface SimKinesisHashKeyRangeOutput {
+  readonly StartingHashKey: string;
+  readonly EndingHashKey: string;
+}
+
+/**
+ * The sequence numbers one shard spans.
+ *
+ * An open shard has no ending sequence number, since the next record put would
+ * move it. Nothing here closes a shard, so this is always absent.
+ */
+export interface SimKinesisSequenceNumberRange {
+  readonly StartingSequenceNumber: string;
+  readonly EndingSequenceNumber?: string | undefined;
+}
+
+/**
+ * One shard, as DescribeStream reports it.
+ */
+export interface SimKinesisShardOutput {
+  readonly ShardId: string;
+  readonly HashKeyRange: SimKinesisHashKeyRangeOutput;
+  readonly SequenceNumberRange: SimKinesisSequenceNumberRange;
+}
+
+/**
+ * Minimal structural sim Kinesis CreateStream command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/kinesis/command/CreateStreamCommand/
+ */
+export interface SimCreateStreamCommand {
+  readonly input: SimCreateStreamCommandInput;
+}
+
+export interface SimCreateStreamCommandInput {
+  readonly StreamName?: string | undefined;
+  readonly ShardCount?: number | undefined;
+  readonly StreamModeDetails?: SimKinesisStreamModeDetails | undefined;
+  readonly Tags?: SimKinesisTags | undefined;
+}
+
+export interface SimCreateStreamCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Kinesis DeleteStream command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/kinesis/command/DeleteStreamCommand/
+ */
+export interface SimDeleteStreamCommand {
+  readonly input: SimDeleteStreamCommandInput;
+}
+
+export interface SimDeleteStreamCommandInput {
+  readonly StreamName?: string | undefined;
+  readonly StreamARN?: string | undefined;
+  readonly EnforceConsumerDeletion?: boolean | undefined;
+}
+
+export interface SimDeleteStreamCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Kinesis ListStreams command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/kinesis/command/ListStreamsCommand/
+ */
+export interface SimListStreamsCommand {
+  readonly input: SimListStreamsCommandInput;
+}
+
+export interface SimListStreamsCommandInput {
+  readonly Limit?: number | undefined;
+  readonly ExclusiveStartStreamName?: string | undefined;
+  readonly NextToken?: string | undefined;
+}
+
+/**
+ * One stream in a ListStreams response.
+ */
+export interface SimKinesisStreamSummary {
+  readonly StreamName: string;
+  readonly StreamARN: string;
+  readonly StreamStatus: string;
+  readonly StreamModeDetails: SimKinesisStreamModeDetails;
+  readonly StreamCreationTimestamp: Date;
+}
+
+export interface SimListStreamsCommandOutput {
+  readonly StreamNames: readonly string[];
+  readonly StreamSummaries: readonly SimKinesisStreamSummary[];
+  readonly HasMoreStreams: boolean;
+  readonly NextToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Kinesis DescribeStream command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/kinesis/command/DescribeStreamCommand/
+ */
+export interface SimDescribeStreamCommand {
+  readonly input: SimDescribeStreamCommandInput;
+}
+
+export interface SimDescribeStreamCommandInput {
+  readonly StreamName?: string | undefined;
+  readonly StreamARN?: string | undefined;
+  readonly Limit?: number | undefined;
+  readonly ExclusiveStartShardId?: string | undefined;
+}
+
+export interface SimKinesisStreamDescription {
+  readonly StreamName: string;
+  readonly StreamARN: string;
+  readonly StreamStatus: string;
+  readonly StreamModeDetails: SimKinesisStreamModeDetails;
+  readonly Shards: readonly SimKinesisShardOutput[];
+  readonly HasMoreShards: boolean;
+  readonly RetentionPeriodHours: number;
+  readonly StreamCreationTimestamp: Date;
+  readonly EnhancedMonitoring: readonly never[];
+}
+
+export interface SimDescribeStreamCommandOutput {
+  readonly StreamDescription: SimKinesisStreamDescription;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Kinesis DescribeStreamSummary command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/kinesis/command/DescribeStreamSummaryCommand/
+ */
+export interface SimDescribeStreamSummaryCommand {
+  readonly input: SimDescribeStreamSummaryCommandInput;
+}
+
+export interface SimDescribeStreamSummaryCommandInput {
+  readonly StreamName?: string | undefined;
+  readonly StreamARN?: string | undefined;
+}
+
+export interface SimKinesisStreamDescriptionSummary {
+  readonly StreamName: string;
+  readonly StreamARN: string;
+  readonly StreamStatus: string;
+  readonly StreamModeDetails: SimKinesisStreamModeDetails;
+  readonly RetentionPeriodHours: number;
+  readonly StreamCreationTimestamp: Date;
+  readonly EnhancedMonitoring: readonly never[];
+  readonly OpenShardCount: number;
+  readonly ConsumerCount: number;
+}
+
+export interface SimDescribeStreamSummaryCommandOutput {
+  readonly StreamDescriptionSummary: SimKinesisStreamDescriptionSummary;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/kinesis/error/sim-kinesis.error.ts
+++ b/src/service/kinesis/error/sim-kinesis.error.ts
@@ -1,0 +1,76 @@
+/**
+ * Minimal metadata shape for simulated Kinesis errors.
+ */
+export interface SimKinesisErrorMetadata {
+  readonly httpStatusCode?: number;
+}
+
+/**
+ * Base class for simulated Kinesis errors.
+ */
+export class SimKinesisError extends Error {
+  constructor(
+    message: string,
+    public readonly $metadata: SimKinesisErrorMetadata = {},
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Simulated Kinesis InvalidArgumentException error.
+ *
+ * Real Kinesis reports a malformed request this way: a stream name it will not
+ * accept, a shard count outside its range, a record over the size limit, or a
+ * shard iterator type it does not have.
+ */
+export class SimKinesisInvalidArgumentException extends SimKinesisError {
+  public override readonly name = "InvalidArgumentException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated Kinesis ResourceNotFoundException error.
+ *
+ * Real Kinesis reports a stream it does not hold this way, whichever operation
+ * asked for it, and reports a stream in another Account the same way.
+ */
+export class SimKinesisResourceNotFoundException extends SimKinesisError {
+  public override readonly name = "ResourceNotFoundException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated Kinesis ResourceInUseException error.
+ *
+ * Real Kinesis refuses a second stream under a name it already holds, and
+ * refuses an operation on a stream that has yet to become `ACTIVE`.
+ */
+export class SimKinesisResourceInUseException extends SimKinesisError {
+  public override readonly name = "ResourceInUseException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated Kinesis ExpiredIteratorException error.
+ *
+ * Real Kinesis reports a shard iterator older than five minutes this way.
+ * Nothing here expires an iterator, so this is raised for one the simulation
+ * never issued, which is the other case real Kinesis refuses.
+ */
+export class SimKinesisExpiredIteratorException extends SimKinesisError {
+  public override readonly name = "ExpiredIteratorException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}

--- a/src/service/kinesis/index.ts
+++ b/src/service/kinesis/index.ts
@@ -1,0 +1,25 @@
+export { SimKinesis } from "./sim-kinesis.js";
+export type { SimKinesisRequestOptions } from "./command/sim-kinesis-request-options.js";
+export type * from "./command/sim-kinesis-command.types.js";
+export { SimKinesisStream } from "./stream/sim-kinesis-stream.js";
+export type { SimKinesisStreamStatus } from "./stream/sim-kinesis-stream.js";
+export { SimKinesisShard } from "./stream/sim-kinesis-shard.js";
+export type { SimKinesisStreamMode } from "./stream/sim-kinesis-stream-mode.js";
+export {
+  parseSimKinesisStreamArn,
+  simKinesisStreamArn,
+} from "./stream/sim-kinesis-stream-arn.js";
+export type { SimKinesisStreamLocation } from "./stream/sim-kinesis-stream-arn.js";
+export {
+  simKinesisHashKeyRanges,
+  simKinesisPartitionKeyHash,
+} from "./stream/sim-kinesis-hash-key.js";
+export type { SimKinesisHashKeyRange } from "./stream/sim-kinesis-hash-key.js";
+export { simKinesisDefaultRetentionHours } from "./stream/sim-kinesis-retention.js";
+export {
+  SimKinesisError,
+  SimKinesisExpiredIteratorException,
+  SimKinesisInvalidArgumentException,
+  SimKinesisResourceInUseException,
+  SimKinesisResourceNotFoundException,
+} from "./error/sim-kinesis.error.js";

--- a/src/service/kinesis/sdk/sim-kinesis-sdk-command-router.ts
+++ b/src/service/kinesis/sdk/sim-kinesis-sdk-command-router.ts
@@ -1,0 +1,105 @@
+import {
+  simSdkCallerOptions,
+  type SimSdkCommandRoute,
+  type SimSdkCommandRouter,
+} from "../../../sdk/index.js";
+import type * as simKinesisCommands from "../command/sim-kinesis-command.types.js";
+import type { SimKinesis } from "../sim-kinesis.js";
+
+/**
+ * Routes intercepted SDK Commands to one scoped simulated Kinesis.
+ */
+export class SimKinesisSdkCommandRouter implements SimSdkCommandRouter {
+  private readonly routes: ReadonlyMap<string, SimSdkCommandRoute>;
+
+  constructor(simKinesis: SimKinesis) {
+    this.routes = new Map<string, SimSdkCommandRoute>([
+      [
+        "CreateStreamCommand",
+        async (command, context): Promise<unknown> =>
+          await simKinesis.createStream(
+            command as simKinesisCommands.SimCreateStreamCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteStreamCommand",
+        async (command, context): Promise<unknown> =>
+          await simKinesis.deleteStream(
+            command as simKinesisCommands.SimDeleteStreamCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListStreamsCommand",
+        async (command, context): Promise<unknown> =>
+          await simKinesis.listStreams(
+            command as simKinesisCommands.SimListStreamsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DescribeStreamCommand",
+        async (command, context): Promise<unknown> =>
+          await simKinesis.describeStream(
+            command as simKinesisCommands.SimDescribeStreamCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DescribeStreamSummaryCommand",
+        async (command, context): Promise<unknown> =>
+          await simKinesis.describeStreamSummary(
+            command as simKinesisCommands.SimDescribeStreamSummaryCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "PutRecordCommand",
+        async (command, context): Promise<unknown> =>
+          await simKinesis.putRecord(
+            command as simKinesisCommands.SimPutRecordCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "PutRecordsCommand",
+        async (command, context): Promise<unknown> =>
+          await simKinesis.putRecords(
+            command as simKinesisCommands.SimPutRecordsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetShardIteratorCommand",
+        async (command, context): Promise<unknown> =>
+          await simKinesis.getShardIterator(
+            command as simKinesisCommands.SimGetShardIteratorCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetRecordsCommand",
+        async (command, context): Promise<unknown> =>
+          await simKinesis.getRecords(
+            command as simKinesisCommands.SimGetRecordsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+    ]);
+  }
+
+  /**
+   * The SDK Command names simulated Kinesis can handle.
+   */
+  supportedCommandNames(): readonly string[] {
+    return this.routes.keys().toArray();
+  }
+
+  /**
+   * Get the route for an SDK Command name, if simulated Kinesis supports it.
+   */
+  route(commandName: string): SimSdkCommandRoute | undefined {
+    return this.routes.get(commandName);
+  }
+}

--- a/src/service/kinesis/sdk/sim-kinesis-sdk-routing.iso.test.ts
+++ b/src/service/kinesis/sdk/sim-kinesis-sdk-routing.iso.test.ts
@@ -1,0 +1,146 @@
+import {
+  CreateStreamCommand,
+  DeleteStreamCommand,
+  DescribeStreamCommand,
+  DescribeStreamSummaryCommand,
+  GetRecordsCommand,
+  GetShardIteratorCommand,
+  KinesisClient,
+  ListStreamsCommand,
+  PutRecordCommand,
+  PutRecordsCommand,
+} from "@aws-sdk/client-kinesis";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimSdk } from "../../../sdk/index.js";
+
+describe("Kinesis SDK interception", () => {
+  it("carries an event from an intercepted producer to an intercepted consumer", async () => {
+    // Given an intercepted Kinesis SDK client.
+    using simSdk = new SimSdk();
+    simSdk.intercept(KinesisClient);
+
+    const kinesis = new KinesisClient({ region: "eu-west-2" });
+
+    // When ordinary SDK code creates a stream, puts a record and reads it back.
+    await kinesis.send(
+      new CreateStreamCommand({ StreamName: "orders", ShardCount: 1 }),
+    );
+    await kinesis.send(
+      new PutRecordCommand({
+        StreamName: "orders",
+        PartitionKey: "customer-1",
+        Data: new TextEncoder().encode('{"id":"order-1"}'),
+      }),
+    );
+
+    const iterator = await kinesis.send(
+      new GetShardIteratorCommand({
+        StreamName: "orders",
+        ShardId: "shardId-000000000000",
+        ShardIteratorType: "TRIM_HORIZON",
+      }),
+    );
+    const read = await kinesis.send(
+      new GetRecordsCommand({ ShardIterator: iterator.ShardIterator }),
+    );
+
+    // Then the record comes back, with nothing touching the network.
+    assertArrayLength(read.Records ?? [], 1);
+    assertIdentical(
+      new TextDecoder().decode(read.Records?.[0]?.Data),
+      '{"id":"order-1"}',
+    );
+    assertIdentical(read.Records?.[0]?.PartitionKey, "customer-1");
+  });
+
+  it("routes every stream command an intercepted client sends", async () => {
+    // Given an intercepted Kinesis SDK client holding one stream.
+    using simSdk = new SimSdk();
+    simSdk.intercept(KinesisClient);
+
+    const kinesis = new KinesisClient({ region: "eu-west-2" });
+    await kinesis.send(
+      new CreateStreamCommand({ StreamName: "orders", ShardCount: 2 }),
+    );
+
+    // When ordinary SDK code lists, describes and summarises it.
+    const listed = await kinesis.send(new ListStreamsCommand({}));
+    const described = await kinesis.send(
+      new DescribeStreamCommand({ StreamName: "orders" }),
+    );
+    const summary = await kinesis.send(
+      new DescribeStreamSummaryCommand({ StreamName: "orders" }),
+    );
+
+    // Then each answers from the simulated stream.
+    assertIdentical(listed.StreamNames?.[0], "orders");
+    assertArrayLength(described.StreamDescription?.Shards ?? [], 2);
+    assertIdentical(summary.StreamDescriptionSummary?.OpenShardCount, 2);
+  });
+
+  it("routes a batch put an intercepted client sends", async () => {
+    // Given an intercepted Kinesis SDK client holding one stream.
+    using simSdk = new SimSdk();
+    simSdk.intercept(KinesisClient);
+
+    const kinesis = new KinesisClient({ region: "eu-west-2" });
+    await kinesis.send(new CreateStreamCommand({ StreamName: "orders" }));
+
+    // When ordinary SDK code puts a batch of records.
+    const put = await kinesis.send(
+      new PutRecordsCommand({
+        StreamName: "orders",
+        Records: [
+          {
+            PartitionKey: "customer-1",
+            Data: new TextEncoder().encode("order-1"),
+          },
+          {
+            PartitionKey: "customer-2",
+            Data: new TextEncoder().encode("order-2"),
+          },
+        ],
+      }),
+    );
+
+    // Then both records are on the stream.
+    assertIdentical(put.FailedRecordCount, 0);
+    assertArrayLength(put.Records ?? [], 2);
+    assertTrue((put.Records?.[0]?.SequenceNumber ?? "").length > 0);
+  });
+
+  it("routes a stream deletion an intercepted client sends", async () => {
+    // Given an intercepted Kinesis SDK client holding one stream.
+    using simSdk = new SimSdk();
+    simSdk.intercept(KinesisClient);
+
+    const kinesis = new KinesisClient({ region: "eu-west-2" });
+    await kinesis.send(new CreateStreamCommand({ StreamName: "orders" }));
+
+    // When ordinary SDK code deletes it.
+    await kinesis.send(new DeleteStreamCommand({ StreamName: "orders" }));
+
+    // Then nothing is left to list.
+    const listed = await kinesis.send(new ListStreamsCommand({}));
+    assertArrayLength(listed.StreamNames ?? [], 0);
+  });
+
+  it("names the commands it can handle", () => {
+    // Given a simulated Kinesis.
+    using simSdk = new SimSdk();
+
+    // When its SDK router is asked what it handles.
+    const supported = simSdk.simAws.kinesis().sdkCommandRouter();
+
+    // Then every command this service simulates is named, and one it does not
+    // is absent.
+    assertArrayLength(supported.supportedCommandNames(), 9);
+    assertUndefined(supported.route("RegisterStreamConsumerCommand"));
+  });
+});

--- a/src/service/kinesis/sim-kinesis.ts
+++ b/src/service/kinesis/sim-kinesis.ts
@@ -1,0 +1,160 @@
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../util/background/background.js";
+import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type * as simKinesisCommands from "./command/sim-kinesis-command.types.js";
+import { SimKinesisCommands } from "./command/sim-kinesis-commands.js";
+import type { SimKinesisRequestOptions } from "./command/sim-kinesis-request-options.js";
+import { SimKinesisSdkCommandRouter } from "./sdk/sim-kinesis-sdk-command-router.js";
+import type { SimKinesisStream } from "./stream/sim-kinesis-stream.js";
+import { SimKinesisStreamStore } from "./stream/sim-kinesis-stream-store.js";
+
+interface SimKinesisProperties {
+  readonly accountRegionScope?: SimAwsAccountRegionScope;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * Simulated Kinesis Data Streams. Handles SDK commands. Emulates AWS behaviour
+ * and state.
+ *
+ * Streams are scoped to an account and region, as they are on real AWS. A
+ * stream name is unique within one of those scopes, and the ARN a request
+ * reaches a stream by names the region.
+ *
+ * A stream's shards are opened when it is created and stay as they are. A
+ * record goes to the shard whose slice of the hash key space its partition key
+ * hashes into, which is how real Kinesis places one, and nothing here splits or
+ * merges a shard afterwards.
+ *
+ * Enhanced fan-out is unsimulated. A consumer reads through `GetRecords`, which
+ * is the shared throughput path every stream has.
+ */
+export class SimKinesis {
+  private readonly streams = new SimKinesisStreamStore();
+  private readonly commands: SimKinesisCommands;
+  private readonly background: BackgroundScheduler;
+  private readonly sdkRouter = new SimKinesisSdkCommandRouter(this);
+
+  constructor(properties: SimKinesisProperties = {}) {
+    const {
+      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.background = background;
+    this.commands = new SimKinesisCommands({
+      streams: this.streams,
+      iam,
+      background,
+      accountRegionScope,
+    });
+  }
+
+  /**
+   * Find a stream by name.
+   *
+   * This is the simulator's own accessor, for tests seeding or inspecting
+   * stream state without going through a Command and its authorization.
+   */
+  findStream(name: string): SimKinesisStream | undefined {
+    return this.streams.find(name);
+  }
+
+  /** Handle a CreateStream Command from the SDK. */
+  async createStream(
+    command: simKinesisCommands.SimCreateStreamCommand,
+    options?: SimKinesisRequestOptions,
+  ): Promise<simKinesisCommands.SimCreateStreamCommandOutput> {
+    await this.background.sequence();
+    return this.commands.streamCreation.handle(command, options);
+  }
+
+  /** Handle a DeleteStream Command from the SDK. */
+  async deleteStream(
+    command: simKinesisCommands.SimDeleteStreamCommand,
+    options?: SimKinesisRequestOptions,
+  ): Promise<simKinesisCommands.SimDeleteStreamCommandOutput> {
+    await this.background.sequence();
+    return this.commands.streams.deleteStream(command, options);
+  }
+
+  /** Handle a ListStreams Command from the SDK. */
+  async listStreams(
+    command: simKinesisCommands.SimListStreamsCommand,
+    options?: SimKinesisRequestOptions,
+  ): Promise<simKinesisCommands.SimListStreamsCommandOutput> {
+    await this.background.sequence();
+    return this.commands.streams.listStreams(command, options);
+  }
+
+  /** Handle a DescribeStream Command from the SDK. */
+  async describeStream(
+    command: simKinesisCommands.SimDescribeStreamCommand,
+    options?: SimKinesisRequestOptions,
+  ): Promise<simKinesisCommands.SimDescribeStreamCommandOutput> {
+    await this.background.sequence();
+    return this.commands.streams.describeStream(command, options);
+  }
+
+  /** Handle a DescribeStreamSummary Command from the SDK. */
+  async describeStreamSummary(
+    command: simKinesisCommands.SimDescribeStreamSummaryCommand,
+    options?: SimKinesisRequestOptions,
+  ): Promise<simKinesisCommands.SimDescribeStreamSummaryCommandOutput> {
+    await this.background.sequence();
+    return this.commands.streams.describeStreamSummary(command, options);
+  }
+
+  /** Handle a PutRecord Command from the SDK. */
+  async putRecord(
+    command: simKinesisCommands.SimPutRecordCommand,
+    options?: SimKinesisRequestOptions,
+  ): Promise<simKinesisCommands.SimPutRecordCommandOutput> {
+    await this.background.sequence();
+    return this.commands.puts.putRecord(command, options);
+  }
+
+  /** Handle a PutRecords Command from the SDK. */
+  async putRecords(
+    command: simKinesisCommands.SimPutRecordsCommand,
+    options?: SimKinesisRequestOptions,
+  ): Promise<simKinesisCommands.SimPutRecordsCommandOutput> {
+    await this.background.sequence();
+    return this.commands.puts.putRecords(command, options);
+  }
+
+  /** Handle a GetShardIterator Command from the SDK. */
+  async getShardIterator(
+    command: simKinesisCommands.SimGetShardIteratorCommand,
+    options?: SimKinesisRequestOptions,
+  ): Promise<simKinesisCommands.SimGetShardIteratorCommandOutput> {
+    await this.background.sequence();
+    return this.commands.reads.getShardIterator(command, options);
+  }
+
+  /** Handle a GetRecords Command from the SDK. */
+  async getRecords(
+    command: simKinesisCommands.SimGetRecordsCommand,
+    options?: SimKinesisRequestOptions,
+  ): Promise<simKinesisCommands.SimGetRecordsCommandOutput> {
+    await this.background.sequence();
+    return this.commands.reads.getRecords(command, options);
+  }
+
+  /**
+   * Get this service's SDK Command router for SDK client interception.
+   */
+  sdkCommandRouter(): SimSdkCommandRouter {
+    return this.sdkRouter;
+  }
+}

--- a/src/service/kinesis/stream/sim-kinesis-hash-key.ts
+++ b/src/service/kinesis/stream/sim-kinesis-hash-key.ts
@@ -1,0 +1,53 @@
+import { createHash } from "node:crypto";
+
+/**
+ * How many hash keys the space a stream's shards divide holds.
+ *
+ * Kinesis hashes a partition key to a 128 bit unsigned integer, so the space
+ * runs from zero to one less than this.
+ */
+export const simKinesisHashKeySpace = 2n ** 128n;
+
+/**
+ * The 128 bit hash key a partition key falls on.
+ *
+ * This is MD5 read as a big-endian unsigned integer, which is what real Kinesis
+ * does. The hash is a placement function rather than a security one, so MD5
+ * being broken is beside the point: using anything else would put a record on a
+ * different shard from the one AWS would have put it on.
+ */
+export function simKinesisPartitionKeyHash(partitionKey: string): bigint {
+  const digest = createHash("md5").update(partitionKey, "utf8").digest("hex");
+
+  return BigInt(`0x${digest}`);
+}
+
+/**
+ * The half-open bounds of one shard's slice of the hash key space.
+ */
+export interface SimKinesisHashKeyRange {
+  readonly startingHashKey: bigint;
+  readonly endingHashKey: bigint;
+}
+
+/**
+ * Divide the hash key space between a number of shards.
+ *
+ * The slices are equal and adjacent, with the last one taking whatever the
+ * division left over, so together they cover the whole space with no gap and no
+ * overlap. That is what real Kinesis gives a stream created with a shard count,
+ * before anything reshards it.
+ */
+export function simKinesisHashKeyRanges(
+  shardCount: number,
+): readonly SimKinesisHashKeyRange[] {
+  const span = simKinesisHashKeySpace / BigInt(shardCount);
+
+  return Array.from({ length: shardCount }, (_unused, index) => ({
+    startingHashKey: span * BigInt(index),
+    endingHashKey:
+      (index === shardCount - 1
+        ? simKinesisHashKeySpace
+        : span * BigInt(index + 1)) - 1n,
+  }));
+}

--- a/src/service/kinesis/stream/sim-kinesis-record.ts
+++ b/src/service/kinesis/stream/sim-kinesis-record.ts
@@ -9,9 +9,13 @@ interface SimKinesisRecordProperties {
 /**
  * One record on one shard of one stream.
  *
- * The data is held as the bytes the caller put, untouched. Real Kinesis carries
- * whatever it was given and hands the same bytes back, so a consumer decoding
- * JSON, Avro or anything else gets what the producer encoded.
+ * The data is a copy of the bytes the caller put. Real Kinesis serializes a
+ * record on the way in, so a producer reusing one buffer for record after
+ * record puts a different record each time. Holding the caller's array would
+ * make every record on the stream change together as that buffer was refilled.
+ *
+ * The bytes themselves are carried unchanged. A consumer decoding JSON, Avro or
+ * anything else gets what the producer encoded.
  */
 export class SimKinesisRecord {
   public readonly partitionKey: string;
@@ -23,8 +27,8 @@ export class SimKinesisRecord {
   constructor(properties: SimKinesisRecordProperties) {
     this.partitionKey = properties.partitionKey;
     this.explicitHashKey = properties.explicitHashKey;
-    this.data = properties.data;
+    this.data = Uint8Array.from(properties.data);
     this.sequenceNumber = properties.sequenceNumber;
-    this.arrivedAt = properties.arrivedAt;
+    this.arrivedAt = new Date(properties.arrivedAt);
   }
 }

--- a/src/service/kinesis/stream/sim-kinesis-record.ts
+++ b/src/service/kinesis/stream/sim-kinesis-record.ts
@@ -1,0 +1,30 @@
+interface SimKinesisRecordProperties {
+  readonly partitionKey: string;
+  readonly explicitHashKey: bigint | undefined;
+  readonly data: Uint8Array;
+  readonly sequenceNumber: string;
+  readonly arrivedAt: Date;
+}
+
+/**
+ * One record on one shard of one stream.
+ *
+ * The data is held as the bytes the caller put, untouched. Real Kinesis carries
+ * whatever it was given and hands the same bytes back, so a consumer decoding
+ * JSON, Avro or anything else gets what the producer encoded.
+ */
+export class SimKinesisRecord {
+  public readonly partitionKey: string;
+  public readonly explicitHashKey: bigint | undefined;
+  public readonly data: Uint8Array;
+  public readonly sequenceNumber: string;
+  public readonly arrivedAt: Date;
+
+  constructor(properties: SimKinesisRecordProperties) {
+    this.partitionKey = properties.partitionKey;
+    this.explicitHashKey = properties.explicitHashKey;
+    this.data = properties.data;
+    this.sequenceNumber = properties.sequenceNumber;
+    this.arrivedAt = properties.arrivedAt;
+  }
+}

--- a/src/service/kinesis/stream/sim-kinesis-retention.iso.test.ts
+++ b/src/service/kinesis/stream/sim-kinesis-retention.iso.test.ts
@@ -1,0 +1,94 @@
+import {
+  DescribeStreamCommand,
+  GetRecordsCommand,
+  GetShardIteratorCommand,
+  PutRecordCommand,
+} from "@aws-sdk/client-kinesis";
+import { assertArrayLength, assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimFixedClock } from "../../../util/clock/sim-clock.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simKinesisStreamFactory } from "./sim-kinesis-stream.factory.js";
+
+const startedAt = new Date("2026-08-22T09:00:00.000Z");
+
+/**
+ * Read everything the trim horizon of the stream's only shard still reaches.
+ */
+async function readFromTrimHorizon(simAws: SimAws): Promise<readonly string[]> {
+  const described = await simAws
+    .kinesis()
+    .describeStream(new DescribeStreamCommand({ StreamName: "orders" }));
+  const iterator = await simAws.kinesis().getShardIterator(
+    new GetShardIteratorCommand({
+      StreamName: "orders",
+      ShardId: described.StreamDescription.Shards[0]?.ShardId,
+      ShardIteratorType: "TRIM_HORIZON",
+    }),
+  );
+  const read = await simAws
+    .kinesis()
+    .getRecords(
+      new GetRecordsCommand({ ShardIterator: iterator.ShardIterator }),
+    );
+
+  return read.Records.map((record) => new TextDecoder().decode(record.Data));
+}
+
+/**
+ * Put one record onto the stream.
+ */
+async function putOrder(simAws: SimAws, id: string): Promise<void> {
+  await simAws.kinesis().putRecord(
+    new PutRecordCommand({
+      StreamName: "orders",
+      PartitionKey: id,
+      Data: new TextEncoder().encode(id),
+    }),
+  );
+}
+
+describe("Simulated Kinesis retention", () => {
+  it("keeps a record for the twenty four hours a new stream retains for", async () => {
+    // Given a stream holding one record.
+    const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+    await simKinesisStreamFactory.make({}, simAws);
+    await putOrder(simAws, "order-1");
+
+    // When simulated time moves on by less than the retention period.
+    await simAws.clock().advanceBy({ hours: 23 });
+
+    // Then the record is still there.
+    const read = await readFromTrimHorizon(simAws);
+    assertIdentical(read.join(","), "order-1");
+  });
+
+  it("drops a record the retention window has outlived", async () => {
+    // Given a stream holding one record.
+    const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+    await simKinesisStreamFactory.make({}, simAws);
+    await putOrder(simAws, "order-1");
+
+    // When simulated time moves past the retention period.
+    await simAws.clock().advanceBy({ hours: 25 });
+
+    // Then it has gone from a trim horizon read.
+    assertArrayLength(await readFromTrimHorizon(simAws), 0);
+  });
+
+  it("keeps a record put after the ones the window outlived", async () => {
+    // Given a stream holding a record put a day before another.
+    const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+    await simKinesisStreamFactory.make({}, simAws);
+    await putOrder(simAws, "order-1");
+    await simAws.clock().advanceBy({ hours: 23 });
+    await putOrder(simAws, "order-2");
+
+    // When simulated time moves past the retention of the first alone.
+    await simAws.clock().advanceBy({ hours: 2 });
+
+    // Then only the newer record is still readable.
+    const read = await readFromTrimHorizon(simAws);
+    assertIdentical(read.join(","), "order-2");
+  });
+});

--- a/src/service/kinesis/stream/sim-kinesis-retention.ts
+++ b/src/service/kinesis/stream/sim-kinesis-retention.ts
@@ -1,0 +1,22 @@
+/**
+ * How long a stream keeps a record when nothing says otherwise.
+ *
+ * Real Kinesis retains for 24 hours until IncreaseStreamRetentionPeriod or
+ * DecreaseStreamRetentionPeriod moves it, and neither of those is simulated, so
+ * every stream here retains for this long.
+ */
+export const simKinesisDefaultRetentionHours = 24;
+
+const millisecondsPerHour = 60 * 60 * 1000;
+
+/**
+ * The instant a stream's records have to be newer than to still be readable.
+ *
+ * Trimming is applied when a stream is read rather than scheduled, because it
+ * is a pure function of the current time. Whatever a read finds is what the
+ * retention window holds at the instant of that read, and nothing has to have
+ * run in between for that to be true.
+ */
+export function simKinesisTrimPoint(now: Date, retentionHours: number): Date {
+  return new Date(now.getTime() - retentionHours * millisecondsPerHour);
+}

--- a/src/service/kinesis/stream/sim-kinesis-sequence-numbers.ts
+++ b/src/service/kinesis/stream/sim-kinesis-sequence-numbers.ts
@@ -1,0 +1,57 @@
+/**
+ * The number the first record on a stream is given.
+ *
+ * A sequence number is compared as text by anything reading a stream, so the
+ * width has to be fixed and the first digit has to be something other than a
+ * zero. Real Kinesis hands out 56 digit numbers, and starting at 10^55 gives
+ * that width with room for more records than any simulation will write.
+ */
+const firstSequenceNumber = 10n ** 55n;
+
+/**
+ * The sequence numbers one stream hands out.
+ *
+ * This is a counter rather than a clock. Records are commonly put inside one
+ * millisecond, and a clock cannot tell those apart, which would leave two
+ * records claiming the same position on the stream.
+ *
+ * One counter serves the whole stream rather than one per shard. Real Kinesis
+ * promises a sequence number is unique within a stream and increases within a
+ * shard, and a single counter gives both. It also means two records on
+ * different shards can be ordered against each other here, which real Kinesis
+ * does not promise. A consumer relying on that would be relying on something
+ * AWS does not offer.
+ */
+export class SimKinesisSequenceNumbers {
+  private next = firstSequenceNumber;
+
+  /**
+   * Take the next sequence number, as the text a record carries.
+   */
+  take(): string {
+    const taken = this.next;
+    this.next += 1n;
+
+    return taken.toString();
+  }
+}
+
+/**
+ * Order two sequence numbers.
+ *
+ * They are compared as numbers rather than as text. The width is fixed while a
+ * simulation runs, so the two orders agree, and comparing the values keeps that
+ * true if the width ever changes.
+ */
+export function compareSimKinesisSequenceNumbers(
+  left: string,
+  right: string,
+): number {
+  const difference = BigInt(left) - BigInt(right);
+
+  if (difference === 0n) {
+    return 0;
+  }
+
+  return difference > 0n ? 1 : -1;
+}

--- a/src/service/kinesis/stream/sim-kinesis-shard-iterator-refusals.iso.test.ts
+++ b/src/service/kinesis/stream/sim-kinesis-shard-iterator-refusals.iso.test.ts
@@ -1,0 +1,64 @@
+import { assertInstanceOf, assertThrowsError } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimKinesisExpiredIteratorException } from "../error/sim-kinesis.error.js";
+import { readSimKinesisShardIteratorToken } from "./sim-kinesis-shard-iterator.js";
+
+const streamArn = "arn:aws:kinesis:eu-west-2:111111111111:stream/orders";
+
+const shardId = "shardId-000000000000";
+
+/**
+ * Read a token and require it to be refused.
+ *
+ * Real Kinesis reports an iterator it will not accept as expired, which is what
+ * an unreadable one is here.
+ */
+function assertRefused(token: string | undefined): void {
+  const error = assertThrowsError(() => {
+    readSimKinesisShardIteratorToken(token);
+  });
+  assertInstanceOf(error, SimKinesisExpiredIteratorException);
+}
+
+/**
+ * A token carrying whatever it is given, however unlike an iterator it is.
+ */
+function tokenOf(value: unknown): string {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64url");
+}
+
+describe("A shard iterator simulated Kinesis will not read", () => {
+  it("refuses a token that is missing or malformed", () => {
+    // When records are read with no token, and with one that is not a token.
+    // Then each is refused.
+    assertRefused(undefined);
+    assertRefused("");
+    assertRefused("not-an-iterator");
+  });
+
+  it("refuses a token carrying no stream or no shard", () => {
+    // When records are read with tokens that decode to the wrong shape.
+    // Then each is refused.
+    assertRefused(tokenOf({ shardId }));
+    assertRefused(tokenOf({ streamArn }));
+    assertRefused(tokenOf("a string"));
+  });
+
+  it("refuses a token carrying a position it cannot stand at", () => {
+    // Given positions of a kind Kinesis does not have, and positions missing
+    // the value their kind needs.
+    const positions = [
+      { kind: "somewhere" },
+      { kind: "at" },
+      { kind: "after" },
+      { kind: "timestamp" },
+      "not a position",
+    ];
+
+    // When records are read with a token carrying each.
+    // Then each is refused.
+    for (const position of positions) {
+      assertRefused(tokenOf({ streamArn, shardId, position }));
+    }
+  });
+});

--- a/src/service/kinesis/stream/sim-kinesis-shard-iterator.iso.test.ts
+++ b/src/service/kinesis/stream/sim-kinesis-shard-iterator.iso.test.ts
@@ -1,0 +1,35 @@
+import { assertIdentical, assertObjectEquals } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  readSimKinesisShardIteratorToken,
+  simKinesisShardIteratorToken,
+} from "./sim-kinesis-shard-iterator.js";
+import type { SimKinesisStreamPosition } from "./sim-kinesis-stream-position.js";
+
+const streamArn = "arn:aws:kinesis:eu-west-2:111111111111:stream/orders";
+
+const shardId = "shardId-000000000000";
+
+describe("A simulated Kinesis shard iterator", () => {
+  it("carries every position kind there and back", () => {
+    // Given the four positions an iterator can stand at.
+    const positions: readonly SimKinesisStreamPosition[] = [
+      { kind: "start" },
+      { kind: "at", sequenceNumber: "100" },
+      { kind: "after", sequenceNumber: "200" },
+      { kind: "timestamp", epochMillis: 1_756_000_000_000 },
+    ];
+
+    // When each one is written into a token and read back out.
+    for (const position of positions) {
+      const read = readSimKinesisShardIteratorToken(
+        simKinesisShardIteratorToken({ streamArn, shardId, position }),
+      );
+
+      // Then the place it stands for survives the round trip.
+      assertIdentical(read.streamArn, streamArn);
+      assertIdentical(read.shardId, shardId);
+      assertObjectEquals(read.position, position);
+    }
+  });
+});

--- a/src/service/kinesis/stream/sim-kinesis-shard-iterator.ts
+++ b/src/service/kinesis/stream/sim-kinesis-shard-iterator.ts
@@ -1,0 +1,118 @@
+import { isRecord } from "../../../util/type-guard/record.js";
+import { SimKinesisExpiredIteratorException } from "../error/sim-kinesis.error.js";
+import type { SimKinesisStreamPosition } from "./sim-kinesis-stream-position.js";
+
+/**
+ * What a shard iterator stands for: one place on one shard of one stream.
+ */
+export interface SimKinesisShardIterator {
+  readonly streamArn: string;
+  readonly shardId: string;
+  readonly position: SimKinesisStreamPosition;
+}
+
+/**
+ * The four position kinds, as a value read back out of a token has to be one of
+ * them before it is trusted.
+ */
+const positionKinds = new Set(["start", "at", "after", "timestamp"]);
+
+/**
+ * Refuse a shard iterator a request carries that this simulation never made.
+ *
+ * Real Kinesis reports an iterator it will not accept as expired, which is what
+ * an unreadable one is here: something that was never valid, or is no longer.
+ */
+function refuse(): never {
+  throw new SimKinesisExpiredIteratorException(
+    "The provided ShardIterator is not valid",
+  );
+}
+
+/**
+ * Read a position back out of a decoded token.
+ */
+function readPosition(value: unknown): SimKinesisStreamPosition {
+  if (!isRecord(value) || typeof value["kind"] !== "string") {
+    refuse();
+  }
+
+  const kind = value["kind"];
+
+  if (!positionKinds.has(kind)) {
+    refuse();
+  }
+
+  if (kind === "start") {
+    return { kind: "start" };
+  }
+
+  if (kind === "timestamp") {
+    const epochMillis = value["epochMillis"];
+
+    if (typeof epochMillis !== "number") {
+      refuse();
+    }
+
+    return { kind: "timestamp", epochMillis };
+  }
+
+  const sequenceNumber = value["sequenceNumber"];
+
+  if (typeof sequenceNumber !== "string") {
+    refuse();
+  }
+
+  return kind === "at"
+    ? { kind: "at", sequenceNumber }
+    : { kind: "after", sequenceNumber };
+}
+
+/**
+ * The opaque token a caller is handed to read on from a place.
+ *
+ * Real shard iterators are opaque strings a caller passes back unread, and this
+ * one is the same shape. The place it stands for travels inside it rather than
+ * in a table of handed-out iterators, which is what lets an iterator be used
+ * against the stream it names without the stream having to remember it. That is
+ * also why the five minute expiry is deliberately absent here rather than
+ * approximated.
+ */
+export function simKinesisShardIteratorToken(
+  iterator: SimKinesisShardIterator,
+): string {
+  return Buffer.from(JSON.stringify(iterator), "utf8").toString("base64url");
+}
+
+/**
+ * Read the place a shard iterator a request carries stands for.
+ */
+export function readSimKinesisShardIteratorToken(
+  token: string | undefined,
+): SimKinesisShardIterator {
+  if (token === undefined || token === "") {
+    refuse();
+  }
+
+  let decoded: unknown;
+
+  try {
+    decoded = JSON.parse(Buffer.from(token, "base64url").toString("utf8"));
+  } catch {
+    refuse();
+  }
+
+  if (
+    !isRecord(decoded) ||
+    typeof decoded["streamArn"] !== "string" ||
+    typeof decoded["shardId"] !== "string"
+  ) {
+    refuse();
+  }
+
+  return {
+    streamArn: decoded["streamArn"],
+    shardId: decoded["shardId"],
+    position: readPosition(decoded["position"]),
+  };
+}

--- a/src/service/kinesis/stream/sim-kinesis-shard-map.iso.test.ts
+++ b/src/service/kinesis/stream/sim-kinesis-shard-map.iso.test.ts
@@ -1,0 +1,106 @@
+import { DescribeStreamCommand } from "@aws-sdk/client-kinesis";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simKinesisHashKeySpace } from "./sim-kinesis-hash-key.js";
+import { simKinesisStreamFactory } from "./sim-kinesis-stream.factory.js";
+
+describe("The shard map of a simulated Kinesis stream", () => {
+  it("divides the whole hash key space between the shards with no gap", async () => {
+    // Given a stream with three shards, which divides unevenly.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({ shardCount: 3 }, simAws);
+
+    // When the stream is described.
+    const described = await simAws
+      .kinesis()
+      .describeStream(new DescribeStreamCommand({ StreamName: "orders" }));
+
+    // Then the shards start at zero, end at the top of the space, and each one
+    // picks up where the one before it left off.
+    const { Shards } = described.StreamDescription;
+    assertArrayLength(Shards, 3);
+    assertIdentical(Shards[0].HashKeyRange.StartingHashKey, "0");
+    assertIdentical(
+      Shards[2].HashKeyRange.EndingHashKey,
+      (simKinesisHashKeySpace - 1n).toString(),
+    );
+
+    for (const [index, shard] of Shards.slice(1).entries()) {
+      const previousEnd = BigInt(
+        Shards.at(index)?.HashKeyRange.EndingHashKey ?? "0",
+      );
+      assertIdentical(
+        BigInt(shard.HashKeyRange.StartingHashKey),
+        previousEnd + 1n,
+      );
+    }
+  });
+
+  it("numbers the shards the way Kinesis does", async () => {
+    // Given a stream with two shards.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({ shardCount: 2 }, simAws);
+
+    // When the stream is described.
+    const described = await simAws
+      .kinesis()
+      .describeStream(new DescribeStreamCommand({ StreamName: "orders" }));
+
+    // Then the identifiers are padded ordinals counting from zero.
+    const { Shards } = described.StreamDescription;
+    assertIdentical(Shards[0]?.ShardId, "shardId-000000000000");
+    assertIdentical(Shards[1]?.ShardId, "shardId-000000000001");
+  });
+
+  it("leaves an open shard with no ending sequence number", async () => {
+    // Given a stream with one shard.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+
+    // When the stream is described.
+    const described = await simAws
+      .kinesis()
+      .describeStream(new DescribeStreamCommand({ StreamName: "orders" }));
+
+    // Then the shard reports where it started and nothing about where it ends,
+    // which is how a reader tells a shard that is still taking records.
+    const range = described.StreamDescription.Shards[0]?.SequenceNumberRange;
+    assertTrue((range?.StartingSequenceNumber ?? "").length > 0);
+    assertUndefined(range?.EndingSequenceNumber);
+  });
+
+  it("pages the shards of a stream longer than the limit it was given", async () => {
+    // Given a stream with four shards.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({ shardCount: 4 }, simAws);
+
+    // When they are described two at a time.
+    const first = await simAws
+      .kinesis()
+      .describeStream(
+        new DescribeStreamCommand({ StreamName: "orders", Limit: 2 }),
+      );
+    const second = await simAws.kinesis().describeStream(
+      new DescribeStreamCommand({
+        StreamName: "orders",
+        ExclusiveStartShardId: first.StreamDescription.Shards[1]?.ShardId,
+      }),
+    );
+
+    // Then the pages follow each other, and the first one says there are more.
+    assertTrue(first.StreamDescription.HasMoreShards);
+    assertArrayLength(first.StreamDescription.Shards, 2);
+    assertIdentical(
+      second.StreamDescription.Shards[0]?.ShardId,
+      "shardId-000000000002",
+    );
+    assertFalse(second.StreamDescription.HasMoreShards);
+  });
+});

--- a/src/service/kinesis/stream/sim-kinesis-shard-map.ts
+++ b/src/service/kinesis/stream/sim-kinesis-shard-map.ts
@@ -1,0 +1,60 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import { simKinesisHashKeyRanges } from "./sim-kinesis-hash-key.js";
+import type { SimKinesisSequenceNumbers } from "./sim-kinesis-sequence-numbers.js";
+import { SimKinesisShard } from "./sim-kinesis-shard.js";
+
+interface SimKinesisShardMapProperties {
+  readonly shardCount: number;
+  readonly sequenceNumbers: SimKinesisSequenceNumbers;
+}
+
+/**
+ * The shards of one stream, and which slice of the hash key space each holds.
+ *
+ * The shards are opened together and stay as they are. Nothing here splits or
+ * merges one, so a record's shard is decided by its hash key alone and stays
+ * decidable for the life of the stream.
+ */
+export class SimKinesisShardMap {
+  public readonly shards: readonly SimKinesisShard[];
+
+  constructor(properties: SimKinesisShardMapProperties) {
+    this.shards = simKinesisHashKeyRanges(properties.shardCount).map(
+      (hashKeyRange, ordinal) =>
+        new SimKinesisShard({
+          ordinal,
+          hashKeyRange,
+          startingSequenceNumber: properties.sequenceNumbers.take(),
+        }),
+    );
+  }
+
+  /**
+   * Find a shard by its identifier.
+   */
+  find(shardId: string): SimKinesisShard | undefined {
+    return this.shards.find((shard) => shard.shardId === shardId);
+  }
+
+  /**
+   * The shard whose slice of the hash key space a key falls in.
+   *
+   * The ranges cover the whole space between them, so one of them always
+   * matches whatever a 128 bit hash lands on.
+   */
+  covering(hashKey: bigint): SimKinesisShard {
+    const shard = this.shards.find((candidate) => candidate.covers(hashKey));
+    assertDefined(shard, `Kinesis shard covering hash key ${hashKey}`);
+
+    return shard;
+  }
+
+  /**
+   * Drop the records put before an instant, on every shard.
+   */
+  trim(before: Date): void {
+    for (const shard of this.shards) {
+      shard.trim(before);
+    }
+  }
+}

--- a/src/service/kinesis/stream/sim-kinesis-shard.ts
+++ b/src/service/kinesis/stream/sim-kinesis-shard.ts
@@ -1,0 +1,98 @@
+import type { SimKinesisHashKeyRange } from "./sim-kinesis-hash-key.js";
+import type { SimKinesisRecord } from "./sim-kinesis-record.js";
+
+/**
+ * How many digits Kinesis pads a shard identifier's ordinal to.
+ */
+const shardOrdinalDigits = 12;
+
+/**
+ * The identifier the shard at an ordinal carries.
+ *
+ * Kinesis shapes these as `shardId-000000000000`, counting from zero, and a
+ * consumer that stores a shard identifier stores that string.
+ */
+export function simKinesisShardId(ordinal: number): string {
+  return `shardId-${ordinal.toString().padStart(shardOrdinalDigits, "0")}`;
+}
+
+interface SimKinesisShardProperties {
+  readonly ordinal: number;
+  readonly hashKeyRange: SimKinesisHashKeyRange;
+  readonly startingSequenceNumber: string;
+}
+
+/**
+ * One shard of one stream, and the records put onto it.
+ *
+ * A shard owns a slice of the hash key space, and it takes the records whose
+ * partition keys hash into that slice. Nothing here splits or merges: a shard
+ * is opened when the stream is created and stays open for the life of it.
+ */
+export class SimKinesisShard {
+  public readonly shardId: string;
+  public readonly hashKeyRange: SimKinesisHashKeyRange;
+
+  /**
+   * The sequence number this shard opened at.
+   *
+   * Real Kinesis gives a shard one when it is created, before any record is on
+   * it, and reports it in the shard's sequence number range. It stays where it
+   * is as records are put and trimmed, so it is a fact about the shard rather
+   * than about what the shard currently holds.
+   */
+  public readonly startingSequenceNumber: string;
+
+  private readonly written: SimKinesisRecord[] = [];
+
+  constructor(properties: SimKinesisShardProperties) {
+    this.shardId = simKinesisShardId(properties.ordinal);
+    this.hashKeyRange = properties.hashKeyRange;
+    this.startingSequenceNumber = properties.startingSequenceNumber;
+  }
+
+  /**
+   * The records on this shard, oldest first.
+   */
+  get records(): readonly SimKinesisRecord[] {
+    return this.written;
+  }
+
+  /**
+   * The sequence number of the newest record on this shard.
+   */
+  get latestSequenceNumber(): string | undefined {
+    return this.written.at(-1)?.sequenceNumber;
+  }
+
+  /**
+   * Whether a hash key falls in this shard's slice of the space.
+   */
+  covers(hashKey: bigint): boolean {
+    const { startingHashKey, endingHashKey } = this.hashKeyRange;
+
+    return hashKey >= startingHashKey && hashKey <= endingHashKey;
+  }
+
+  /**
+   * Put a record onto this shard.
+   */
+  append(record: SimKinesisRecord): void {
+    this.written.push(record);
+  }
+
+  /**
+   * Drop the records put before an instant.
+   *
+   * Real Kinesis moves a reader asking for a trimmed position on to the trim
+   * horizon rather than refusing it, so nothing here has to remember how far
+   * trimming got.
+   */
+  trim(before: Date): void {
+    const surviving = this.written.findIndex(
+      (record) => record.arrivedAt.getTime() >= before.getTime(),
+    );
+
+    this.written.splice(0, surviving === -1 ? this.written.length : surviving);
+  }
+}

--- a/src/service/kinesis/stream/sim-kinesis-stream-arn.iso.test.ts
+++ b/src/service/kinesis/stream/sim-kinesis-stream-arn.iso.test.ts
@@ -1,0 +1,59 @@
+import { assertIdentical, assertUndefined } from "@kensio/smartass";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import { describe, it } from "vitest";
+import {
+  parseSimKinesisStreamArn,
+  simKinesisStreamArn,
+} from "./sim-kinesis-stream-arn.js";
+
+const scope = {
+  accountId: "111111111111",
+  regionName: "eu-west-2",
+} as Parameters<typeof simKinesisStreamArn>[0];
+
+describe("A simulated Kinesis stream ARN", () => {
+  it("names the region, the account and the stream", () => {
+    // When an ARN is built for a stream in a scope.
+    const arn = simKinesisStreamArn(scope, "orders");
+
+    // Then it carries all three, with the resource type real Kinesis uses.
+    assertIdentical(
+      arn,
+      "arn:aws:kinesis:eu-west-2:111111111111:stream/orders",
+    );
+  });
+
+  it("reads the region, the account and the stream back out", () => {
+    // When a stream ARN is read.
+    const location = parseSimKinesisStreamArn(
+      "arn:aws:kinesis:eu-west-2:111111111111:stream/orders",
+    );
+
+    // Then all three come back.
+    assertDefined(location, "parsed Kinesis stream ARN");
+    assertIdentical(location.regionName, "eu-west-2");
+    assertIdentical(location.accountId, "111111111111");
+    assertIdentical(location.name, "orders");
+  });
+
+  it("reads nothing out of a string that is not a stream ARN", () => {
+    // Given strings that name no Kinesis stream, including a consumer ARN and
+    // an ARN of another service.
+    const notStreamArns = [
+      "orders",
+      "arn:aws:kinesis:eu-west-2:111111111111:orders",
+      "arn:aws:sqs:eu-west-2:111111111111:orders",
+      "arn:aws-cn:kinesis:eu-west-2:111111111111:stream/orders",
+      "arn:aws:kinesis::111111111111:stream/orders",
+      "arn:aws:kinesis:eu-west-2::stream/orders",
+      "arn:aws:kinesis:eu-west-2:111111111111:stream/",
+      "arn:aws:kinesis:eu-west-2:111111111111:stream/orders/consumer/live:1",
+    ];
+
+    // When each is read.
+    // Then nothing comes back, rather than a partly read location.
+    for (const value of notStreamArns) {
+      assertUndefined(parseSimKinesisStreamArn(value));
+    }
+  });
+});

--- a/src/service/kinesis/stream/sim-kinesis-stream-arn.ts
+++ b/src/service/kinesis/stream/sim-kinesis-stream-arn.ts
@@ -1,0 +1,78 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+
+const streamArnPartition = "aws";
+
+const streamArnService = "kinesis";
+
+const streamArnResourceType = "stream";
+
+/**
+ * Where one stream is, in the three facts its ARN carries.
+ *
+ * The strings are unbranded because the callers that have only read an ARN,
+ * rather than been handed a scope, have nothing but strings to offer.
+ */
+export interface SimKinesisStreamLocation {
+  readonly regionName: string;
+  readonly accountId: string;
+  readonly name: string;
+}
+
+/**
+ * The ARN of a stream of a given name in an Account and Region.
+ */
+export function simKinesisStreamArn(
+  accountRegionScope: SimAwsAccountRegionScope,
+  name: string,
+): string {
+  const { regionName, accountId } = accountRegionScope;
+
+  return `arn:${streamArnPartition}:${streamArnService}:${regionName}:${accountId}:${streamArnResourceType}/${name}`;
+}
+
+/**
+ * Read a stream ARN into the Region, Account and name it carries.
+ *
+ * All three matter. An ARN naming another Account or Region reaches nothing in
+ * a simulated Kinesis scope rather than having its name read out and looked up
+ * locally, since treating a foreign one as local would let a test pass while
+ * the real call crossed a boundary it has no permission for.
+ *
+ * Nothing is returned for a string that is not a stream ARN, including a
+ * consumer ARN, which carries the consumer name and creation time after the
+ * stream name.
+ */
+export function parseSimKinesisStreamArn(
+  value: string,
+): SimKinesisStreamLocation | undefined {
+  const parts = value.split(":");
+
+  if (parts.length !== 6) {
+    return undefined;
+  }
+
+  const [prefix, partition, service, regionName, accountId, resource] = parts;
+
+  if (
+    prefix !== "arn" ||
+    partition !== streamArnPartition ||
+    service !== streamArnService ||
+    regionName === undefined ||
+    regionName === "" ||
+    accountId === undefined ||
+    accountId === "" ||
+    resource === undefined
+  ) {
+    return undefined;
+  }
+
+  if (!resource.startsWith(`${streamArnResourceType}/`)) {
+    return undefined;
+  }
+
+  const name = resource.slice(`${streamArnResourceType}/`.length);
+
+  return name === "" || name.includes("/")
+    ? undefined
+    : { regionName, accountId, name };
+}

--- a/src/service/kinesis/stream/sim-kinesis-stream-mode.ts
+++ b/src/service/kinesis/stream/sim-kinesis-stream-mode.ts
@@ -1,0 +1,80 @@
+import { SimKinesisInvalidArgumentException } from "../error/sim-kinesis.error.js";
+
+/**
+ * How a stream's capacity is decided.
+ */
+export type SimKinesisStreamMode = "PROVISIONED" | "ON_DEMAND";
+
+/**
+ * How many shards an on-demand stream starts with.
+ *
+ * Real Kinesis gives an on-demand stream four shards and grows it with the
+ * traffic. Nothing here measures traffic, so the count stays where it starts.
+ */
+export const simKinesisOnDemandShardCount = 4;
+
+/**
+ * The most shards real Kinesis creates a stream with.
+ */
+const maxShardCount = 100_000;
+
+/**
+ * Read the stream mode a request asked for.
+ */
+export function simKinesisStreamModeOf(
+  mode: string | undefined,
+): SimKinesisStreamMode {
+  if (mode === undefined || mode === "PROVISIONED") {
+    return "PROVISIONED";
+  }
+
+  if (mode === "ON_DEMAND") {
+    return "ON_DEMAND";
+  }
+
+  throw new SimKinesisInvalidArgumentException(
+    `StreamModeDetails.StreamMode '${mode}' is neither PROVISIONED nor ` +
+      `ON_DEMAND`,
+  );
+}
+
+/**
+ * How many shards a stream is created with.
+ *
+ * An on-demand stream takes no shard count, and real Kinesis refuses a request
+ * carrying both. A provisioned stream created without one gets a single shard,
+ * which is what real Kinesis does.
+ */
+export function simKinesisCreatedShardCount(
+  mode: SimKinesisStreamMode,
+  shardCount: number | undefined,
+): number {
+  if (mode === "ON_DEMAND") {
+    if (shardCount !== undefined) {
+      throw new SimKinesisInvalidArgumentException(
+        "ShardCount may not be set on a stream created in ON_DEMAND mode",
+      );
+    }
+
+    return simKinesisOnDemandShardCount;
+  }
+
+  if (shardCount === undefined) {
+    return 1;
+  }
+
+  if (!Number.isSafeInteger(shardCount) || shardCount < 1) {
+    throw new SimKinesisInvalidArgumentException(
+      `ShardCount ${shardCount} is not a whole number of shards`,
+    );
+  }
+
+  if (shardCount > maxShardCount) {
+    throw new SimKinesisInvalidArgumentException(
+      `ShardCount ${shardCount} is more than the ${maxShardCount} shards ` +
+        `Kinesis creates a stream with`,
+    );
+  }
+
+  return shardCount;
+}

--- a/src/service/kinesis/stream/sim-kinesis-stream-name.ts
+++ b/src/service/kinesis/stream/sim-kinesis-stream-name.ts
@@ -1,0 +1,46 @@
+import { SimKinesisInvalidArgumentException } from "../error/sim-kinesis.error.js";
+
+/**
+ * The longest stream name real Kinesis accepts.
+ */
+const maxStreamNameLength = 128;
+
+/**
+ * The characters a stream name may be made of.
+ */
+const streamNamePattern = /^[a-zA-Z0-9_.-]+$/u;
+
+/**
+ * The name of one simulated Kinesis stream.
+ *
+ * A name is unique within one Account and Region, and it is the resource part
+ * of the stream's ARN. Branding it keeps a raw string from reaching the store
+ * without having been through the validation real Kinesis applies first.
+ */
+export class SimKinesisStreamName {
+  public readonly value: string;
+
+  constructor(value: string | undefined) {
+    if (value === undefined || value === "") {
+      throw new SimKinesisInvalidArgumentException(
+        "StreamName is required and may not be empty",
+      );
+    }
+
+    if (value.length > maxStreamNameLength) {
+      throw new SimKinesisInvalidArgumentException(
+        `StreamName '${value}' is longer than the ${maxStreamNameLength} ` +
+          `characters Kinesis accepts`,
+      );
+    }
+
+    if (!streamNamePattern.test(value)) {
+      throw new SimKinesisInvalidArgumentException(
+        `StreamName '${value}' may hold only letters, digits, underscores, ` +
+          `hyphens and full stops`,
+      );
+    }
+
+    this.value = value;
+  }
+}

--- a/src/service/kinesis/stream/sim-kinesis-stream-position.ts
+++ b/src/service/kinesis/stream/sim-kinesis-stream-position.ts
@@ -1,0 +1,39 @@
+/**
+ * Where on a shard a reader is, between one GetRecords and the next.
+ *
+ * The four kinds are what the five shard iterator types come down to.
+ * TRIM_HORIZON is the start of whatever the shard still holds.
+ * AT_SEQUENCE_NUMBER and AFTER_SEQUENCE_NUMBER are the two ways of naming a
+ * record, and the difference between them is whether that record is handed back
+ * or stepped over. AT_TIMESTAMP names an instant instead.
+ *
+ * LATEST has no kind of its own. It means "after the newest record on the shard
+ * when the iterator was made", which is either `after` that record or, on a
+ * shard holding nothing, `start`. Resolving it where the iterator is made is
+ * what pins it to that instant, as real Kinesis does.
+ *
+ * A position is a place rather than an index, so it survives the shard being
+ * trimmed underneath it. That is what lets a read tell "you are asking for
+ * records that have aged out" from "there is nothing new yet".
+ */
+export type SimKinesisStreamPosition =
+  | { readonly kind: "start" }
+  | { readonly kind: "at"; readonly sequenceNumber: string }
+  | { readonly kind: "after"; readonly sequenceNumber: string }
+  | { readonly kind: "timestamp"; readonly epochMillis: number };
+
+/**
+ * The position a reader starting from the oldest record it can reach is at.
+ */
+export const simKinesisStreamStart: SimKinesisStreamPosition = {
+  kind: "start",
+};
+
+/**
+ * The position a reader that has just taken a record is at.
+ */
+export function simKinesisStreamAfter(
+  sequenceNumber: string,
+): SimKinesisStreamPosition {
+  return { kind: "after", sequenceNumber };
+}

--- a/src/service/kinesis/stream/sim-kinesis-stream-read.ts
+++ b/src/service/kinesis/stream/sim-kinesis-stream-read.ts
@@ -1,0 +1,76 @@
+import type { SimKinesisRecord } from "./sim-kinesis-record.js";
+import {
+  simKinesisStreamAfter,
+  type SimKinesisStreamPosition,
+} from "./sim-kinesis-stream-position.js";
+import { compareSimKinesisSequenceNumbers } from "./sim-kinesis-sequence-numbers.js";
+import type { SimKinesisShard } from "./sim-kinesis-shard.js";
+
+/**
+ * What one read of a shard came back with.
+ */
+export interface SimKinesisShardRead {
+  readonly records: readonly SimKinesisRecord[];
+  readonly next: SimKinesisStreamPosition;
+}
+
+/**
+ * Where in the records a position starts reading from.
+ */
+function startIndexOf(
+  records: readonly SimKinesisRecord[],
+  position: SimKinesisStreamPosition,
+): number {
+  if (position.kind === "start") {
+    return 0;
+  }
+
+  if (position.kind === "timestamp") {
+    const found = records.findIndex(
+      (record) => record.arrivedAt.getTime() >= position.epochMillis,
+    );
+
+    return found === -1 ? records.length : found;
+  }
+
+  const wanted = position.kind === "at" ? 0 : 1;
+  const found = records.findIndex(
+    (record) =>
+      compareSimKinesisSequenceNumbers(
+        record.sequenceNumber,
+        position.sequenceNumber,
+      ) >= wanted,
+  );
+
+  return found === -1 ? records.length : found;
+}
+
+/**
+ * Read up to a limit of records from a shard, starting at a position.
+ *
+ * An empty result is an ordinary answer rather than a problem. A reader that
+ * has caught up gets nothing back and the position it already had, which is
+ * what makes polling each successive iterator work.
+ *
+ * A position the retention window has outlived is not refused, unlike DynamoDB
+ * Streams. Real Kinesis moves a reader on to the trim horizon and carries on,
+ * and it reports how far behind the reader is instead.
+ */
+export function simKinesisShardRead(
+  shard: SimKinesisShard,
+  position: SimKinesisStreamPosition,
+  limit: number,
+): SimKinesisShardRead {
+  const available = shard.records;
+  const start = startIndexOf(available, position);
+  const records = available.slice(start, start + limit);
+  const last = records.at(-1);
+
+  return {
+    records,
+    next:
+      last === undefined
+        ? position
+        : simKinesisStreamAfter(last.sequenceNumber),
+  };
+}

--- a/src/service/kinesis/stream/sim-kinesis-stream-store.ts
+++ b/src/service/kinesis/stream/sim-kinesis-stream-store.ts
@@ -1,0 +1,76 @@
+import { SimKinesisResourceNotFoundException } from "../error/sim-kinesis.error.js";
+import type { SimKinesisStream } from "./sim-kinesis-stream.js";
+
+/**
+ * The streams of one simulated Kinesis scope.
+ *
+ * Streams are keyed by name, which is the whole of their identity. The name is
+ * the resource part of the ARN, and it is unique within one Account and Region.
+ *
+ * Nothing holds a deleted stream's name. Real Kinesis frees a stream name as
+ * soon as the stream is gone, so a name can be reused straight away.
+ */
+export class SimKinesisStreamStore {
+  private readonly streams = new Map<string, SimKinesisStream>();
+
+  /**
+   * Every stream in this scope, in name order.
+   *
+   * ListStreams pages by name and reports them sorted, so the order a page is
+   * cut out of has to be the order the paging parameter walks.
+   */
+  get all(): readonly SimKinesisStream[] {
+    return this.streams
+      .values()
+      .toArray()
+      .toSorted((left, right) => left.name.localeCompare(right.name));
+  }
+
+  /**
+   * Store a newly created stream.
+   */
+  add(stream: SimKinesisStream): void {
+    this.streams.set(stream.name, stream);
+  }
+
+  /**
+   * Find a stream by name.
+   */
+  find(name: string): SimKinesisStream | undefined {
+    return this.streams.get(name);
+  }
+
+  /**
+   * Resolve a stream by name, or refuse.
+   */
+  require(name: string): SimKinesisStream {
+    const found = this.find(name);
+
+    if (found === undefined) {
+      throw new SimKinesisResourceNotFoundException(
+        `Stream ${name} under this account and region does not exist`,
+      );
+    }
+
+    return found;
+  }
+
+  /**
+   * Forget a deleted stream.
+   */
+  remove(stream: SimKinesisStream): void {
+    this.streams.delete(stream.name);
+  }
+
+  /**
+   * Bring every stream here up to date at an instant.
+   *
+   * All of them rather than the one being read, so that what a test sees of one
+   * stream never depends on which other streams it happened to read first.
+   */
+  applyRetention(instant: Date): void {
+    for (const stream of this.streams.values()) {
+      stream.applyRetention(instant);
+    }
+  }
+}

--- a/src/service/kinesis/stream/sim-kinesis-stream.factory.ts
+++ b/src/service/kinesis/stream/sim-kinesis-stream.factory.ts
@@ -1,0 +1,52 @@
+import { AsyncMappedFactory } from "@kensio/part-factory";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimKinesisStream } from "./sim-kinesis-stream.js";
+
+/**
+ * What a test asks for when it wants a stream to put records onto.
+ */
+export interface SimKinesisStreamInput {
+  readonly streamName: string;
+  readonly shardCount: number;
+}
+
+/**
+ * Creates a Kinesis data stream through CreateStream.
+ *
+ * The stream went through the ordinary command, so it is the stream an
+ * application would have rather than one built around the commands, and it is
+ * ACTIVE by the time this answers.
+ *
+ * ```typescript
+ * const stream = await simKinesisStreamFactory.make(
+ *   { streamName: "orders", shardCount: 2 },
+ *   simAws,
+ * );
+ * ```
+ */
+export const simKinesisStreamFactory = new AsyncMappedFactory<
+  SimKinesisStreamInput,
+  SimKinesisStream,
+  SimAws
+>(
+  () => ({ streamName: "orders", shardCount: 1 }),
+  async (input, simAws) => {
+    const kinesis = simAws.kinesis();
+
+    await kinesis.createStream({
+      input: { StreamName: input.streamName, ShardCount: input.shardCount },
+    });
+
+    // A name CreateStream accepted is a stream the store holds, so this is only
+    // missing if something is wrong with the simulator itself.
+    const stream = kinesis.findStream(input.streamName);
+    assertDefined(
+      stream,
+      `Simulated Kinesis created the stream ${input.streamName} and then did ` +
+        `not hold it`,
+    );
+
+    return stream;
+  },
+);

--- a/src/service/kinesis/stream/sim-kinesis-stream.ts
+++ b/src/service/kinesis/stream/sim-kinesis-stream.ts
@@ -1,0 +1,155 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { SimKinesisResourceNotFoundException } from "../error/sim-kinesis.error.js";
+import { simKinesisPartitionKeyHash } from "./sim-kinesis-hash-key.js";
+import { SimKinesisRecord } from "./sim-kinesis-record.js";
+import { simKinesisTrimPoint } from "./sim-kinesis-retention.js";
+import { SimKinesisSequenceNumbers } from "./sim-kinesis-sequence-numbers.js";
+import type { SimKinesisShard } from "./sim-kinesis-shard.js";
+import { SimKinesisShardMap } from "./sim-kinesis-shard-map.js";
+import { simKinesisStreamArn } from "./sim-kinesis-stream-arn.js";
+import type { SimKinesisStreamMode } from "./sim-kinesis-stream-mode.js";
+import type { SimKinesisStreamName } from "./sim-kinesis-stream-name.js";
+
+/**
+ * Where a stream is between being created and being deleted.
+ *
+ * Real Kinesis also has `CREATING`, `DELETING` and `UPDATING`, which it passes
+ * through while it brings shards up or takes them down. Nothing here takes any
+ * time over that, so a stream is `ACTIVE` from the moment it exists.
+ */
+export type SimKinesisStreamStatus = "ACTIVE";
+
+interface SimKinesisStreamProperties {
+  readonly name: SimKinesisStreamName;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly mode: SimKinesisStreamMode;
+  readonly shardCount: number;
+  readonly retentionHours: number;
+  readonly createdAt: Date;
+  readonly tags: Readonly<Record<string, string>>;
+}
+
+/**
+ * What one record a caller is putting carries.
+ */
+export interface SimKinesisPut {
+  readonly partitionKey: string;
+  readonly explicitHashKey: bigint | undefined;
+  readonly data: Uint8Array;
+  readonly at: Date;
+}
+
+/**
+ * Where a put record landed.
+ */
+export interface SimKinesisPutPlacement {
+  readonly shardId: string;
+  readonly sequenceNumber: string;
+}
+
+/**
+ * One simulated Kinesis data stream, and the shards its records are on.
+ */
+export class SimKinesisStream {
+  public readonly name: string;
+  public readonly arn: string;
+  public readonly mode: SimKinesisStreamMode;
+  public readonly createdAt: Date;
+  public readonly status: SimKinesisStreamStatus = "ACTIVE";
+
+  /**
+   * The tags the stream was created with.
+   *
+   * Nothing reads these back through a command, since the Kinesis tag
+   * operations are unsimulated. They are kept so that a stream created from a
+   * template carrying tags is the stream the template described, and so a test
+   * can check them through the simulator's own accessor.
+   */
+  public readonly tags: Readonly<Record<string, string>>;
+
+  private readonly sequenceNumbers = new SimKinesisSequenceNumbers();
+  private readonly shardMap: SimKinesisShardMap;
+  private readonly retention: number;
+
+  constructor(properties: SimKinesisStreamProperties) {
+    this.name = properties.name.value;
+    this.arn = simKinesisStreamArn(
+      properties.accountRegionScope,
+      properties.name.value,
+    );
+    this.mode = properties.mode;
+    this.createdAt = properties.createdAt;
+    this.tags = properties.tags;
+    this.retention = properties.retentionHours;
+    this.shardMap = new SimKinesisShardMap({
+      shardCount: properties.shardCount,
+      sequenceNumbers: this.sequenceNumbers,
+    });
+  }
+
+  /**
+   * The shards of this stream, in the order they were opened.
+   */
+  get shards(): readonly SimKinesisShard[] {
+    return this.shardMap.shards;
+  }
+
+  /**
+   * How long this stream keeps a record.
+   */
+  get retentionHours(): number {
+    return this.retention;
+  }
+
+  /**
+   * Resolve a shard of this stream, or refuse.
+   */
+  requireShard(shardId: string): SimKinesisShard {
+    const found = this.shardMap.find(shardId);
+
+    if (found === undefined) {
+      throw new SimKinesisResourceNotFoundException(
+        `Shard ${shardId} does not exist in stream ${this.name}`,
+      );
+    }
+
+    return found;
+  }
+
+  /**
+   * Put one record onto the shard its partition key falls on.
+   *
+   * An explicit hash key overrides the partition key for that placement, which
+   * is what real Kinesis does with one. The partition key is still carried on
+   * the record and handed back to whoever reads it.
+   */
+  put(record: SimKinesisPut): SimKinesisPutPlacement {
+    const shard = this.shardMap.covering(
+      record.explicitHashKey ?? simKinesisPartitionKeyHash(record.partitionKey),
+    );
+    const sequenceNumber = this.sequenceNumbers.take();
+
+    shard.append(
+      new SimKinesisRecord({
+        partitionKey: record.partitionKey,
+        explicitHashKey: record.explicitHashKey,
+        data: record.data,
+        sequenceNumber,
+        arrivedAt: record.at,
+      }),
+    );
+
+    return { shardId: shard.shardId, sequenceNumber };
+  }
+
+  /**
+   * Drop whatever the retention window has outlived, on every shard.
+   *
+   * This is applied when the stream is read rather than scheduled, which is
+   * what `simKinesisTrimPoint` explains. Running it twice at one instant does
+   * nothing the second time.
+   */
+  applyRetention(instant: Date): void {
+    this.shardMap.trim(simKinesisTrimPoint(instant, this.retention));
+  }
+}


### PR DESCRIPTION
Adds simulated Kinesis Data Streams behind `simAws.kinesis()`, with types on the `@kensio/yulin/kinesis` subpath and a `KinesisClient` reachable through SDK interception. A stream is created with the shard count it asks for, each shard owns a slice of the 128 bit hash key space, and a record lands on the shard covering the MD5 hash of its partition key, which is the placement real Kinesis makes and what per-key ordering depends on. Reading is the iterator walk a Kinesis consumer makes, with every shard iterator type resolving to a place on the shard, and retention applied at the instant of the read rather than on a timer. Every operation authorizes through simulated IAM against the stream ARN, and GetRecords authorizes against the stream its iterator carries rather than against whatever the request separately claims. Enhanced fan-out, resharding, encryption and the tag operations are left out and refused by name, and `docs/services/kinesis/README.md` records the full list.

Resolves #908


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated Kinesis Data Streams support, including stream creation, listing, descriptions, deletion, and shard management.
  * Added single and batch record production with partition-key routing, sequence numbers, and explicit hash-key support.
  * Added shard iterators and record consumption from trim horizon, latest, timestamp, or sequence positions.
  * Added 24-hour retention behavior, provisioned and on-demand stream modes, IAM authorization, and SDK interception.
* **Documentation**
  * Added comprehensive Kinesis documentation and runnable examples for production, consumption, permissions, retention, shards, and SDK interception.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->