### PR TITLE
feat: stream Bedrock responses through ConverseStream

### DIFF
--- a/docs/services/bedrock/README.md
+++ b/docs/services/bedrock/README.md
@@ -117,6 +117,62 @@ console.log(answered.output.message.content.at(0)?.toolUse?.name);
 // "lookUpEntry"
 ```
 
+## Streaming a conversation
+
+`ConverseStream` answers from the same rules, and sends the response as the events real Bedrock
+sends. Declaring `chunks` says where the deltas fall.
+
+```typescript sim-bedrock-converse-stream
+/**
+ * Declaring a response in chunks and accumulating the stream.
+ */
+
+import { ConverseStreamCommand } from "@aws-sdk/client-bedrock-runtime";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+simAws
+  .bedrock()
+  .responses()
+  .onPrompt("Summarise entry 1042", {
+    chunks: ["Entry 1042 covers ", "the tone sandhi rules."],
+  });
+
+const answered = await simAws.bedrock().converseStream(
+  new ConverseStreamCommand({
+    modelId: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+    messages: [{ role: "user", content: [{ text: "Summarise entry 1042" }] }],
+  }),
+);
+
+let accumulated = "";
+
+for await (const event of answered.stream) {
+  accumulated += event.contentBlockDelta?.delta.text ?? "";
+}
+
+console.log(accumulated); // "Entry 1042 covers the tone sandhi rules."
+```
+
+The events arrive in the order real Bedrock sends them. `messageStart`, then one
+`contentBlockDelta` per chunk, then `contentBlockStop`, `messageStop` carrying the stop reason, and
+`metadata` carrying the token counts. A tool call adds a `contentBlockStart` before its delta,
+carrying the tool use id and name.
+
+The same declaration serves both APIs. `Converse` answers with the chunks joined, and a response
+declared as `text` streams as a single delta. A stream is readable once, and reading it again
+raises.
+
+`InvokeModelWithResponseStream` streams the declared body as a single `chunk`:
+
+```typescript
+for await (const event of answered.body) {
+  accumulated += new TextDecoder().decode(event.chunk?.bytes);
+}
+```
+
 ## Invoking a model directly
 
 `InvokeModel` answers with the body declared for the request, serialized as JSON. The body is the
@@ -238,12 +294,14 @@ simSdk.restoreAll();
 
 ## Available functionality
 
-- `Converse` and `InvokeModel`, through `simAws.bedrock()` and through an intercepted
-  `BedrockRuntimeClient`.
+- `Converse`, `ConverseStream`, `InvokeModel` and `InvokeModelWithResponseStream`, through
+  `simAws.bedrock()` and through an intercepted `BedrockRuntimeClient`.
 - Responses declared with `onPrompt`, `onModel` and `byDefault`. A prompt rule wins, then a model
   rule, then the default.
-- A declared response carries `text` or `content` blocks for `Converse`, a `body` for `InvokeModel`,
-  and optionally a `stopReason` and a `usage`.
+- A declared response carries `text`, `chunks` or `content` blocks for `Converse`, a `body` for
+  `InvokeModel`, and optionally a `stopReason` and a `usage`.
+- Streamed responses, with `chunks` deciding where the deltas fall and one declaration serving the
+  streaming and non-streaming APIs alike.
 - Tool calls, as a declared `toolUse` content block.
 - IAM authorization of `bedrock:InvokeModel` against the foundation model, inference profile or
   provisioned model ARN the request names.
@@ -253,7 +311,17 @@ simSdk.restoreAll();
 
 - No model runs. A response is whatever the matching rule declared, and the prompt is read only as
   a key to match on.
-- `ConverseStream` and `InvokeModelWithResponseStream` are unsimulated.
+- Every event of a stream is ready as soon as the call returns. Real Bedrock sends them as the model
+  generates them. No simulated clock advance separates them here.
+- A response is split into deltas only where the declaration says so. Text declared any other way
+  arrives in one delta. The split a real model streams comes from its own tokenizer.
+- A streamed tool call sends its arguments in one delta. Real `ConverseStream` sends them as
+  fragments of JSON to be concatenated. A tool call with no declared arguments sends `{}`.
+- `InvokeModelWithResponseStream` sends the declared body as a single chunk. Real Bedrock sends a
+  chunk per generated fragment, in the shape the model behind the id uses.
+- A serialized Bedrock request is refused. Bedrock speaks REST-JSON, and the wire path answers only
+  the AWS JSON protocol services. A function bundling its own SDK reaches Bedrock through module
+  interception. S3 and every other non-JSON-protocol service are reached the same way.
 - The Bedrock control plane is unsimulated. `ListFoundationModels`, guardrail management, inference
   profile management and provisioned throughput all belong to `BedrockClient`.
 - Bedrock Agents and knowledge bases are unsimulated. `InvokeAgent`, `Retrieve` and
@@ -277,6 +345,6 @@ simSdk.restoreAll();
 - An `InvokeModel` body that arrives as a stream or a Blob matches no prompt rule. Reading it would
   consume the caller's own request body, so such a request falls through to a model rule or to the
   default.
-- A `Converse` call matching a response declared only as a body is refused for the same reason,
-  rather than falling back to the default.
+- A `Converse` call matching a response declared only as a body is refused for the same reason. It
+  does not fall back to the default.
 - There are no CloudFormation resource types for Bedrock, and Bedrock is absent from `serveSimAws`.

--- a/docs/services/bedrock/sim-bedrock-converse-stream.example.ts
+++ b/docs/services/bedrock/sim-bedrock-converse-stream.example.ts
@@ -1,0 +1,31 @@
+/**
+ * Declaring a response in chunks and accumulating the stream.
+ */
+
+import { ConverseStreamCommand } from "@aws-sdk/client-bedrock-runtime";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+simAws
+  .bedrock()
+  .responses()
+  .onPrompt("Summarise entry 1042", {
+    chunks: ["Entry 1042 covers ", "the tone sandhi rules."],
+  });
+
+const answered = await simAws.bedrock().converseStream(
+  new ConverseStreamCommand({
+    modelId: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+    messages: [{ role: "user", content: [{ text: "Summarise entry 1042" }] }],
+  }),
+);
+
+let accumulated = "";
+
+for await (const event of answered.stream) {
+  accumulated += event.contentBlockDelta?.delta.text ?? "";
+}
+
+console.log(accumulated); // "Entry 1042 covers the tone sandhi rules."

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -13,6 +13,10 @@ export type {
 } from "./router/sim-sdk-command-router.type.js";
 export { simSdkCallerOptions } from "./router/sim-sdk-caller-options.js";
 export type { SimSdkCallerOptions } from "./router/sim-sdk-caller-options.js";
+export {
+  simSdkEventStream,
+  type SimSdkEventStream,
+} from "./stream/sim-sdk-event-stream.js";
 export { simSdkStreamBody } from "./stream/sim-sdk-stream-body.js";
 export type {
   SimSdkStreamBody,

--- a/src/sdk/stream/sim-sdk-event-stream.iso.test.ts
+++ b/src/sdk/stream/sim-sdk-event-stream.iso.test.ts
@@ -1,0 +1,75 @@
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { simSdkEventStream } from "./sim-sdk-event-stream.js";
+
+/**
+ * Read a stream the way production code reads one.
+ */
+async function collected<TEvent>(
+  stream: AsyncIterable<TEvent>,
+): Promise<TEvent[]> {
+  const read: TEvent[] = await Array.fromAsync(stream);
+
+  return read;
+}
+
+describe("Simulated SDK event stream", () => {
+  it("yields its events in the order they were given", async () => {
+    // Given a stream over three events.
+    const stream = simSdkEventStream(["first", "second", "third"]);
+
+    // When it is read.
+    const read = await collected(stream);
+
+    // Then the order is the one the operation built.
+    assertArrayEquals(read, ["first", "second", "third"]);
+  });
+
+  it("refuses a second reading", async () => {
+    // Given a stream that has been read.
+    const stream = simSdkEventStream(["first"]);
+
+    await collected(stream);
+
+    // When it is read again.
+    const error = await assertThrowsErrorAsync(
+      async () => await collected(stream),
+    );
+
+    // Then it raises, as a socket read to the end would.
+    assertIdentical(error.name, "SimSdkStreamAlreadyConsumedError");
+  });
+
+  it("counts an abandoned reading as a reading", async () => {
+    // Given a stream whose reader stopped after one event.
+    const stream = simSdkEventStream(["first", "second"]);
+    const reader = stream[Symbol.asyncIterator]();
+
+    const first = await reader.next();
+
+    assertIdentical(first.value, "first");
+
+    // When it is read again.
+    const error = await assertThrowsErrorAsync(
+      async () => await collected(stream),
+    );
+
+    // Then the events already consumed are gone, as they would be on a socket.
+    assertIdentical(error.name, "SimSdkStreamAlreadyConsumedError");
+  });
+
+  it("yields nothing for an operation with no events", async () => {
+    // Given a stream over no events.
+    const stream = simSdkEventStream([]);
+
+    // When it is read.
+    const read = await collected(stream);
+
+    // Then it ends immediately rather than waiting for something to arrive.
+    assertArrayEquals(read, []);
+  });
+});

--- a/src/sdk/stream/sim-sdk-event-stream.ts
+++ b/src/sdk/stream/sim-sdk-event-stream.ts
@@ -1,0 +1,53 @@
+import { SimSdkStreamAlreadyConsumedError } from "../error/sim-sdk.error.js";
+
+/**
+ * A simulated SDK event stream: the async iterable an operation modelled on
+ * `application/vnd.amazon.eventstream` answers with.
+ *
+ * The SDK hands one of these to calling code as `ConverseStream`'s `stream`
+ * and `InvokeModelWithResponseStream`'s `body`.
+ */
+export type SimSdkEventStream<TEvent> = AsyncIterable<TEvent>;
+
+/**
+ * Build a simulated SDK event stream over the events it yields.
+ *
+ * Every event is available as soon as the stream is made. Real AWS sends them
+ * as the model generates them, and a simulation with no model has nothing to
+ * wait for. What the stream keeps is the order and the one-shot reading, which
+ * is what code accumulating a response depends on.
+ *
+ * The stream is consumable once, matching `simSdkStreamBody`. Iterating a
+ * second time raises rather than replaying, because a real event stream is a
+ * socket that has already been read to the end.
+ */
+export function simSdkEventStream<TEvent>(
+  events: readonly TEvent[],
+): SimSdkEventStream<TEvent> {
+  let consumed = false;
+
+  return {
+    [Symbol.asyncIterator](): AsyncIterator<TEvent> {
+      if (consumed) {
+        throw new SimSdkStreamAlreadyConsumedError(
+          "Simulated SDK event stream was already consumed and cannot be " +
+            "read again",
+        );
+      }
+
+      consumed = true;
+
+      return iterate(events);
+    },
+  };
+}
+
+function iterate<TEvent>(events: readonly TEvent[]): AsyncIterator<TEvent> {
+  const pending = events.values();
+
+  return {
+    next(): Promise<IteratorResult<TEvent>> {
+      return Promise.resolve(pending.next());
+    },
+  };
+}

--- a/src/service/bedrock/README.md
+++ b/src/service/bedrock/README.md
@@ -1,7 +1,8 @@
 # Simulated Bedrock implementation
 
-This directory contains the simulated Bedrock implementation. Two invocations are simulated,
-`Converse` and `InvokeModel`, each answered from a response a test declared.
+This directory contains the simulated Bedrock implementation. Four invocations are simulated,
+`Converse` and `InvokeModel` with their streaming forms, each answered from a response a test
+declared.
 
 The guiding decision here is that no model runs. What matters about a Bedrock call is the answer,
 and the simulation reads the prompt only as a key to match on. Simulated Rekognition
@@ -14,10 +15,11 @@ and the response the SDK hands back are all real.
 - `sim-bedrock.ts` is the service facade for one account/region scope.
 - `index.ts` exports the public Bedrock simulator API for `@kensio/yulin/bedrock`.
 
-`SimBedrock` owns one `SimBedrockResponses`, which both invocation handlers answer from. Rekognition
+`SimBedrock` owns one `SimBedrockResponses`, which all four invocation handlers answer from. Rekognition
 groups its rules per operation, because a moderation result and a face are different shapes.
-Bedrock's two operations reach the same exchange through two request shapes. One rule set covers
-both, and a test declaring a response gets it whichever API the code under test calls.
+Bedrock's operations reach the same exchange through four request shapes. One rule set covers them
+all, and a test declaring a response gets it whichever API the code under test calls. Code moving
+from `Converse` to `ConverseStream` keeps its declarations.
 
 The service is scoped to an account and region because its rules are. An invocation made in one
 Region is answered by the rules registered in that Region, as a real Bedrock endpoint answers for
@@ -44,6 +46,37 @@ by one exchange, which is the case a multi-turn test is about.
 The prompt of an `InvokeModel` request is its body decoded as UTF-8. The body is the whole request in
 the shape the model behind the id expects, and real Bedrock treats it as opaque. So does this. A test matching one usually wants a model rule instead, and the tier exists
 because the body is the only thing an `InvokeModel` request carries that identifies the exchange.
+
+## The streaming model
+
+`src/sdk/stream/sim-sdk-event-stream.ts` is the machinery, and it is in the SDK layer because an
+event stream belongs to the SDK rather than to Bedrock. It holds the events, yields them in order
+and refuses a second reading, matching `simSdkStreamBody`. Every event is ready as soon as the
+stream is made, since a simulation with no model has nothing to wait for.
+
+`response/sim-bedrock-streamed-content.ts` turns a declaration into blocks, and
+`command/converse/sim-bedrock-converse-stream-events.ts` turns those into the event sequence. The
+sequence is real Bedrock's, and a test accumulating deltas reads here what it reads in production.
+
+`chunks` is where the deltas fall. A response declared any other way streams its text in one delta,
+because the split a real model streams comes from its own tokenizer and inventing one would give a
+test something to depend on that means nothing. The chunks are joined for `Converse`, so one
+declaration serves both APIs.
+
+A text block opens with no event of its own, as it does on real Bedrock. Only a tool call announces
+itself, with `contentBlockStart` carrying the id and name the caller needs before the arguments
+arrive. Those arguments come in one delta. Real Bedrock sends them as JSON fragments, and this
+is the one place the sequence is shorter than the real one.
+
+## The wire path
+
+A serialized Bedrock request never reaches `SimSdkWireDispatcher`. That path reads the operation
+from `x-amz-target`, which only the AWS JSON protocol services send, and Bedrock speaks REST-JSON.
+Such a request is already refused by `simSdkUnbridgedWireRequest`, which names the service and says
+to intercept the client instead.
+
+That leaves nothing here to frame as `application/vnd.amazon.eventstream`. Interception answers with
+the output object itself, so a stream reaches calling code intact without any framing.
 
 ## The response model
 
@@ -117,4 +150,4 @@ reasoning that leaves simulated Rekognition without a label ontology.
 
 Tests are colocated with the code they exercise. `command/sim-bedrock-iam.iso.test.ts` and
 `command/sim-bedrock-validation.iso.test.ts` sit above the two command directories, because each
-covers both operations.
+covers more than one operation.

--- a/src/service/bedrock/command/converse/converse-stream.command.ts
+++ b/src/service/bedrock/command/converse/converse-stream.command.ts
@@ -1,0 +1,77 @@
+import type { SimSdkEventStream } from "../../../../sdk/index.js";
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimBedrockDeclaredToolUse } from "../../response/sim-bedrock-response-declaration.js";
+import type { SimBedrockResponseUsage } from "../../response/sim-bedrock-declared-usage.js";
+import type {
+  SimConverseCommandInput,
+  SimConverseMetrics,
+} from "./converse.command.js";
+
+/**
+ * Minimal structural sim Bedrock Runtime ConverseStream command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/bedrock-runtime/command/ConverseStreamCommand/
+ */
+export interface SimConverseStreamCommand {
+  readonly input: SimConverseStreamCommandInput;
+}
+
+export type SimConverseStreamCommandInput = SimConverseCommandInput;
+
+export interface SimBedrockMessageStartEvent {
+  readonly role: "assistant";
+}
+
+export interface SimBedrockContentBlockStartEvent {
+  readonly contentBlockIndex: number;
+  readonly start: { readonly toolUse: SimBedrockDeclaredToolUse };
+}
+
+/**
+ * What one delta carries.
+ *
+ * A text block sends its text. A tool call sends its arguments as the JSON a
+ * real stream sends them in, in one delta rather than in fragments.
+ */
+export interface SimBedrockContentBlockDelta {
+  readonly text?: string | undefined;
+  readonly toolUse?: { readonly input: string } | undefined;
+}
+
+export interface SimBedrockContentBlockDeltaEvent {
+  readonly contentBlockIndex: number;
+  readonly delta: SimBedrockContentBlockDelta;
+}
+
+export interface SimBedrockContentBlockStopEvent {
+  readonly contentBlockIndex: number;
+}
+
+export interface SimBedrockMessageStopEvent {
+  readonly stopReason: string;
+}
+
+export interface SimBedrockStreamMetadataEvent {
+  readonly usage: SimBedrockResponseUsage;
+  readonly metrics: SimConverseMetrics;
+}
+
+/**
+ * One event of a `ConverseStream` response.
+ *
+ * Each event names its own kind, as the SDK's own union does, so calling code
+ * reads `event.contentBlockDelta` and gets nothing for every other kind.
+ */
+export interface SimConverseStreamOutput {
+  readonly messageStart?: SimBedrockMessageStartEvent | undefined;
+  readonly contentBlockStart?: SimBedrockContentBlockStartEvent | undefined;
+  readonly contentBlockDelta?: SimBedrockContentBlockDeltaEvent | undefined;
+  readonly contentBlockStop?: SimBedrockContentBlockStopEvent | undefined;
+  readonly messageStop?: SimBedrockMessageStopEvent | undefined;
+  readonly metadata?: SimBedrockStreamMetadataEvent | undefined;
+}
+
+export interface SimConverseStreamCommandOutput {
+  readonly stream: SimSdkEventStream<SimConverseStreamOutput>;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/bedrock/command/converse/sim-bedrock-converse-prompt.ts
+++ b/src/service/bedrock/command/converse/sim-bedrock-converse-prompt.ts
@@ -4,6 +4,27 @@ import type { SimBedrockRequestMessage } from "./converse.command.js";
 const userRole = "user";
 
 /**
+ * The inputs a simulated conversation reads or can honestly ignore.
+ *
+ * `system`, `inferenceConfig` and `additionalModelRequestFields` are accepted
+ * and have no effect, because they change what a model generates and no model
+ * generates anything here. `toolConfig` is accepted for the same reason: which
+ * tools the model may call is decided by the declared response, which either
+ * carries a tool use block or leaves one out.
+ *
+ * `Converse` and `ConverseStream` take the same request, so they accept the
+ * same inputs.
+ */
+export const simBedrockConverseAccepted = [
+  "modelId",
+  "messages",
+  "system",
+  "inferenceConfig",
+  "toolConfig",
+  "additionalModelRequestFields",
+];
+
+/**
  * The prompt a `Converse` request is matched on.
  *
  * It is the text of the last user message, which is the turn the model is
@@ -18,10 +39,11 @@ const userRole = "user";
  */
 export function simBedrockConversePrompt(
   messages: readonly SimBedrockRequestMessage[] | undefined,
+  operation: string,
 ): string | undefined {
   if (messages === undefined || messages.length === 0) {
     throw new SimBedrockValidationException(
-      "Converse needs at least one message to send to the model",
+      `${operation} needs at least one message to send to the model`,
     );
   }
 

--- a/src/service/bedrock/command/converse/sim-bedrock-converse-stream-events.ts
+++ b/src/service/bedrock/command/converse/sim-bedrock-converse-stream-events.ts
@@ -1,0 +1,72 @@
+import type { SimBedrockResolvedResponse } from "../../response/sim-bedrock-resolved-response.js";
+import type { SimBedrockStreamedBlock } from "../../response/sim-bedrock-streamed-content.js";
+import type { SimConverseStreamOutput } from "./converse-stream.command.js";
+
+/**
+ * The arguments of a tool call with nothing declared for them.
+ *
+ * A real stream always sends JSON here, so an empty object is what a call
+ * taking no arguments looks like.
+ */
+const noToolInput = "{}";
+
+function toolInputOf(input: unknown): string {
+  return input === undefined ? noToolInput : JSON.stringify(input);
+}
+
+function blockEvents(
+  block: SimBedrockStreamedBlock,
+  contentBlockIndex: number,
+): readonly SimConverseStreamOutput[] {
+  if (block.kind === "toolUse") {
+    return [
+      {
+        contentBlockStart: {
+          contentBlockIndex,
+          start: { toolUse: block.toolUse },
+        },
+      },
+      {
+        contentBlockDelta: {
+          contentBlockIndex,
+          delta: { toolUse: { input: toolInputOf(block.toolUse.input) } },
+        },
+      },
+      { contentBlockStop: { contentBlockIndex } },
+    ];
+  }
+
+  return [
+    ...block.deltas.map((text) => ({
+      contentBlockDelta: { contentBlockIndex, delta: { text } },
+    })),
+    { contentBlockStop: { contentBlockIndex } },
+  ];
+}
+
+/**
+ * The events one declared response arrives as over `ConverseStream`.
+ *
+ * The order is real Bedrock's: the message opens, each content block sends its
+ * deltas and closes, the message closes with its stop reason, and the metadata
+ * carrying the token counts comes last. Code accumulating a response reads the
+ * same sequence here as it does in production.
+ *
+ * A text block opens with no event of its own, which is what real Bedrock
+ * does. Only a tool call announces itself, because the caller needs its id and
+ * name before the arguments arrive.
+ */
+export function simBedrockConverseStreamEvents(
+  declared: SimBedrockResolvedResponse,
+): readonly SimConverseStreamOutput[] {
+  const blocks = declared.streamedContent();
+
+  return [
+    { messageStart: { role: "assistant" } },
+    ...blocks.flatMap((block, index) => blockEvents(block, index)),
+    { messageStop: { stopReason: declared.stopReason() } },
+    {
+      metadata: { usage: declared.usage(), metrics: { latencyMs: 0 } },
+    },
+  ];
+}

--- a/src/service/bedrock/command/converse/sim-bedrock-converse-stream.iso.test.ts
+++ b/src/service/bedrock/command/converse/sim-bedrock-converse-stream.iso.test.ts
@@ -1,0 +1,331 @@
+import {
+  ConverseCommand,
+  ConverseStreamCommand,
+} from "@aws-sdk/client-bedrock-runtime";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simBedrockDefaultText } from "../../response/sim-bedrock-response-defaults.js";
+import type { SimConverseStreamOutput } from "./converse-stream.command.js";
+
+const sonnet = "anthropic.claude-3-5-sonnet-20241022-v2:0";
+
+/**
+ * A one turn conversation asking the model something.
+ */
+function askingAbout(prompt: string): ConverseStreamCommand {
+  return new ConverseStreamCommand({
+    modelId: sonnet,
+    messages: [{ role: "user", content: [{ text: prompt }] }],
+  });
+}
+
+/**
+ * Read a stream the way production code reads one.
+ */
+async function collected(
+  stream: AsyncIterable<SimConverseStreamOutput>,
+): Promise<readonly SimConverseStreamOutput[]> {
+  const events: SimConverseStreamOutput[] = await Array.fromAsync(stream);
+
+  return events;
+}
+
+/**
+ * The kind each event names, in the order they arrived.
+ */
+function kinds(events: readonly SimConverseStreamOutput[]): readonly string[] {
+  return events.flatMap((event) => Object.keys(event));
+}
+
+describe("Bedrock ConverseStream", () => {
+  it("streams a declared response as the event sequence AWS sends", async () => {
+    // Given a response declared for one prompt.
+    const simAws = new SimAws();
+
+    simAws.bedrock().responses().onPrompt("Summarise entry 1042", {
+      text: "Entry 1042 covers the tone sandhi rules.",
+    });
+
+    // When the conversation is streamed.
+    const answered = await simAws
+      .bedrock()
+      .converseStream(askingAbout("Summarise entry 1042"));
+    const events = await collected(answered.stream);
+
+    // Then the events arrive in the order real Bedrock sends them.
+    assertArrayEquals(kinds(events), [
+      "messageStart",
+      "contentBlockDelta",
+      "contentBlockStop",
+      "messageStop",
+      "metadata",
+    ]);
+    assertIdentical(events.at(0)?.messageStart?.role, "assistant");
+    assertIdentical(
+      events.at(1)?.contentBlockDelta?.delta.text,
+      "Entry 1042 covers the tone sandhi rules.",
+    );
+    assertIdentical(events.at(3)?.messageStop?.stopReason, "end_turn");
+  });
+
+  it("sends one delta per declared chunk, in order", async () => {
+    // Given a response declared as three chunks.
+    const simAws = new SimAws();
+
+    simAws
+      .bedrock()
+      .responses()
+      .onPrompt("Summarise entry 1042", {
+        chunks: ["Entry 1042 ", "covers the ", "tone sandhi rules."],
+      });
+
+    // When the conversation is streamed.
+    const answered = await simAws
+      .bedrock()
+      .converseStream(askingAbout("Summarise entry 1042"));
+    const events = await collected(answered.stream);
+
+    // Then each chunk is its own delta, and they carry the text in order.
+    assertArrayEquals(
+      events
+        .map((event) => event.contentBlockDelta?.delta.text)
+        .filter((text) => text !== undefined),
+      ["Entry 1042 ", "covers the ", "tone sandhi rules."],
+    );
+  });
+
+  it("answers Converse with the chunks of the same declaration joined", async () => {
+    // Given a response declared as chunks.
+    const simAws = new SimAws();
+
+    simAws
+      .bedrock()
+      .responses()
+      .byDefault({ chunks: ["Entry 1042 ", "covers tone sandhi."] });
+
+    // When the non-streaming API asks for it.
+    const answered = await simAws.bedrock().converse(
+      new ConverseCommand({
+        modelId: sonnet,
+        messages: [{ role: "user", content: [{ text: "Anything" }] }],
+      }),
+    );
+
+    // Then one declaration serves both APIs.
+    assertIdentical(
+      answered.output.message.content.at(0)?.text,
+      "Entry 1042 covers tone sandhi.",
+    );
+  });
+
+  it("sends an undeclared response as a single delta", async () => {
+    // Given nothing declared.
+    const simAws = new SimAws();
+
+    // When a conversation is streamed.
+    const answered = await simAws
+      .bedrock()
+      .converseStream(askingAbout("Anything"));
+    const events = await collected(answered.stream);
+
+    // Then the built-in default arrives whole, in one delta.
+    assertArrayEquals(
+      events
+        .map((event) => event.contentBlockDelta?.delta.text)
+        .filter((text) => text !== undefined),
+      [simBedrockDefaultText],
+    );
+  });
+
+  it("announces a tool call before its arguments", async () => {
+    // Given a response declared as a tool call.
+    const simAws = new SimAws();
+
+    simAws
+      .bedrock()
+      .responses()
+      .byDefault({
+        content: [
+          {
+            toolUse: {
+              toolUseId: "tooluse-1",
+              name: "lookUpEntry",
+              input: { entryId: "1042" },
+            },
+          },
+        ],
+      });
+
+    // When the conversation is streamed.
+    const answered = await simAws
+      .bedrock()
+      .converseStream(askingAbout("What is in entry 1042?"));
+    const events = await collected(answered.stream);
+
+    // Then the block opens with the tool's id and name, and the arguments
+    // follow as the JSON a real stream sends.
+    assertArrayEquals(kinds(events), [
+      "messageStart",
+      "contentBlockStart",
+      "contentBlockDelta",
+      "contentBlockStop",
+      "messageStop",
+      "metadata",
+    ]);
+    assertIdentical(
+      events.at(1)?.contentBlockStart?.start.toolUse.name,
+      "lookUpEntry",
+    );
+    assertIdentical(
+      events.at(2)?.contentBlockDelta?.delta.toolUse?.input,
+      '{"entryId":"1042"}',
+    );
+    assertIdentical(events.at(4)?.messageStop?.stopReason, "tool_use");
+  });
+
+  it("numbers each content block of a longer response", async () => {
+    // Given a response declared as two blocks.
+    const simAws = new SimAws();
+
+    simAws
+      .bedrock()
+      .responses()
+      .byDefault({
+        content: [
+          { text: "Looking it up." },
+          { toolUse: { toolUseId: "tooluse-1", name: "lookUpEntry" } },
+        ],
+      });
+
+    // When the conversation is streamed.
+    const answered = await simAws
+      .bedrock()
+      .converseStream(askingAbout("Anything"));
+    const events = await collected(answered.stream);
+
+    // Then each block carries its own index.
+    assertArrayEquals(
+      events
+        .map(
+          (event) =>
+            event.contentBlockStop?.contentBlockIndex ??
+            event.contentBlockDelta?.contentBlockIndex,
+        )
+        .filter((index) => index !== undefined),
+      [0, 0, 1, 1],
+    );
+  });
+
+  it("carries a tool call with no arguments as empty JSON", async () => {
+    // Given a tool call declared with no input.
+    const simAws = new SimAws();
+
+    simAws
+      .bedrock()
+      .responses()
+      .byDefault({
+        content: [{ toolUse: { toolUseId: "tooluse-1", name: "listEntries" } }],
+      });
+
+    // When the conversation is streamed.
+    const answered = await simAws
+      .bedrock()
+      .converseStream(askingAbout("Anything"));
+    const events = await collected(answered.stream);
+
+    // Then the delta still carries JSON, as a real stream always does.
+    assertIdentical(
+      events.at(2)?.contentBlockDelta?.delta.toolUse?.input,
+      "{}",
+    );
+  });
+
+  it("reports the token counts in the metadata event", async () => {
+    // Given a response declaring what it cost.
+    const simAws = new SimAws();
+
+    simAws
+      .bedrock()
+      .responses()
+      .byDefault({
+        text: "Short.",
+        usage: { inputTokens: 7, outputTokens: 3 },
+      });
+
+    // When the conversation is streamed.
+    const answered = await simAws
+      .bedrock()
+      .converseStream(askingAbout("Anything"));
+    const events = await collected(answered.stream);
+    const metadata = events.at(-1)?.metadata;
+
+    // Then the counts arrive last, where code metering spend reads them.
+    assertNonNullable(metadata);
+    assertIdentical(metadata.usage.totalTokens, 10);
+    assertIdentical(metadata.metrics.latencyMs, 0);
+  });
+
+  it("refuses a second reading of a stream", async () => {
+    // Given a streamed response that has been read.
+    const simAws = new SimAws();
+    const answered = await simAws
+      .bedrock()
+      .converseStream(askingAbout("Anything"));
+
+    await collected(answered.stream);
+
+    // When it is read again.
+    const error = await assertThrowsErrorAsync(
+      async () => await collected(answered.stream),
+    );
+
+    // Then it raises, as a socket read to the end would.
+    assertIdentical(error.name, "SimSdkStreamAlreadyConsumedError");
+  });
+
+  it("refuses a stream matching a response declared only as a body", async () => {
+    // Given a response declared for InvokeModel alone.
+    const simAws = new SimAws();
+
+    simAws
+      .bedrock()
+      .responses()
+      .onModel(sonnet, { body: { raw: true } });
+
+    // When ConverseStream reaches it.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.bedrock().converseStream(askingAbout("Anything")),
+    );
+
+    // Then it says what to declare, as Converse does.
+    assertIdentical(error.name, "SimBedrockDeclarationError");
+    assertStringIncludes(error.message, "Declare text, chunks or content");
+  });
+
+  it("refuses a streamed conversation with no messages", async () => {
+    // Given a simulated Bedrock.
+    const simAws = new SimAws();
+
+    // When a streamed conversation carries none.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws
+          .bedrock()
+          .converseStream(
+            new ConverseStreamCommand({ modelId: sonnet, messages: [] }),
+          ),
+    );
+
+    // Then the refusal names the operation that was called.
+    assertIdentical(error.name, "ValidationException");
+    assertStringIncludes(error.message, "ConverseStream needs at least one");
+  });
+});

--- a/src/service/bedrock/command/converse/sim-bedrock-converse-stream.ts
+++ b/src/service/bedrock/command/converse/sim-bedrock-converse-stream.ts
@@ -1,35 +1,36 @@
+import { simSdkEventStream } from "../../../../sdk/index.js";
 import { SimBedrockCommandGroup } from "../sim-bedrock-command-group.js";
 import type { SimBedrockRequestOptions } from "../sim-bedrock-request-options.js";
 import { SimBedrockUnsimulatedInput } from "../sim-bedrock-unsimulated-input.js";
-import type {
-  SimConverseCommand,
-  SimConverseCommandOutput,
-} from "./converse.command.js";
 import {
   simBedrockConverseAccepted,
   simBedrockConversePrompt,
 } from "./sim-bedrock-converse-prompt.js";
+import type {
+  SimConverseStreamCommand,
+  SimConverseStreamCommandOutput,
+} from "./converse-stream.command.js";
+import { simBedrockConverseStreamEvents } from "./sim-bedrock-converse-stream-events.js";
 
-const operation = "Converse";
+const operation = "ConverseStream";
 
 const unsimulated = new SimBedrockUnsimulatedInput(operation);
 
 /**
- * Handles a Converse command.
+ * Handles a ConverseStream command.
  *
- * The response comes from the rule the request matches, and nothing in the
- * conversation is read for meaning. A prompt rule answers the exchange it was
- * declared for, a model rule answers every other call to that model, and a
- * request matching neither is answered with the default.
+ * It answers from the rules `Converse` answers from, so a test declaring a
+ * response covers both APIs and code moving from one to the other keeps its
+ * declarations. What differs is the shape it arrives in.
  */
-export class SimBedrockConverseHandler extends SimBedrockCommandGroup {
+export class SimBedrockConverseStreamHandler extends SimBedrockCommandGroup {
   /**
-   * Answer a conversation with the response declared for it.
+   * Stream the response declared for a conversation.
    */
   handle(
-    command: SimConverseCommand,
+    command: SimConverseStreamCommand,
     options?: SimBedrockRequestOptions,
-  ): SimConverseCommandOutput {
+  ): SimConverseStreamCommandOutput {
     const { input } = command;
 
     unsimulated.refuseUnaccepted(input, simBedrockConverseAccepted);
@@ -42,10 +43,7 @@ export class SimBedrockConverseHandler extends SimBedrockCommandGroup {
     const declared = this.responses.responseFor({ prompt, modelId });
 
     return {
-      output: { message: declared.message() },
-      stopReason: declared.stopReason(),
-      usage: declared.usage(),
-      metrics: { latencyMs: 0 },
+      stream: simSdkEventStream(simBedrockConverseStreamEvents(declared)),
       $metadata: {},
     };
   }

--- a/src/service/bedrock/command/converse/sim-bedrock-converse.iso.test.ts
+++ b/src/service/bedrock/command/converse/sim-bedrock-converse.iso.test.ts
@@ -190,7 +190,7 @@ describe("Bedrock Converse", () => {
     // Then it says which declaration it reached and what it needs.
     assertIdentical(error.name, "SimBedrockDeclarationError");
     assertStringIncludes(error.message, `the model '${sonnet}'`);
-    assertStringIncludes(error.message, "Declare text or content for Converse");
+    assertStringIncludes(error.message, "Declare text, chunks or content");
   });
 
   it("answers each Region from its own rules", async () => {

--- a/src/service/bedrock/command/invoke-model/invoke-model.command.ts
+++ b/src/service/bedrock/command/invoke-model/invoke-model.command.ts
@@ -1,3 +1,4 @@
+import type { SimSdkEventStream } from "../../../../sdk/index.js";
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
 
 /**
@@ -18,6 +19,29 @@ export interface SimInvokeModelCommandInput {
 
 export interface SimInvokeModelCommandOutput {
   readonly body: Uint8Array;
+  readonly contentType: string;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Bedrock Runtime InvokeModelWithResponseStream
+ * command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/bedrock-runtime/command/InvokeModelWithResponseStreamCommand/
+ */
+export interface SimInvokeModelWithResponseStreamCommand {
+  readonly input: SimInvokeModelCommandInput;
+}
+
+/**
+ * One event of an `InvokeModelWithResponseStream` response.
+ */
+export interface SimInvokeModelResponseStreamOutput {
+  readonly chunk?: { readonly bytes: Uint8Array } | undefined;
+}
+
+export interface SimInvokeModelWithResponseStreamCommandOutput {
+  readonly body: SimSdkEventStream<SimInvokeModelResponseStreamOutput>;
   readonly contentType: string;
   readonly $metadata: SimResponseMetadata;
 }

--- a/src/service/bedrock/command/invoke-model/sim-bedrock-invoke-model-stream.iso.test.ts
+++ b/src/service/bedrock/command/invoke-model/sim-bedrock-invoke-model-stream.iso.test.ts
@@ -1,0 +1,140 @@
+import { InvokeModelWithResponseStreamCommand } from "@aws-sdk/client-bedrock-runtime";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimInvokeModelResponseStreamOutput } from "./invoke-model.command.js";
+
+const titan = "amazon.titan-text-express-v1";
+
+/**
+ * A streamed invocation carrying a model-specific request body.
+ */
+function invoking(body: unknown): InvokeModelWithResponseStreamCommand {
+  return new InvokeModelWithResponseStreamCommand({
+    modelId: titan,
+    body: new TextEncoder().encode(JSON.stringify(body)),
+  });
+}
+
+/**
+ * Read a stream the way production code reads one.
+ */
+async function collected(
+  stream: AsyncIterable<SimInvokeModelResponseStreamOutput>,
+): Promise<readonly SimInvokeModelResponseStreamOutput[]> {
+  const events: SimInvokeModelResponseStreamOutput[] =
+    await Array.fromAsync(stream);
+
+  return events;
+}
+
+describe("Bedrock InvokeModelWithResponseStream", () => {
+  it("streams the declared body as chunk bytes", async () => {
+    // Given a response body declared for one model.
+    const simAws = new SimAws();
+
+    simAws
+      .bedrock()
+      .responses()
+      .onModel(titan, { body: { results: [{ outputText: "Tone sandhi." }] } });
+
+    // When the model is invoked for a stream.
+    const answered = await simAws
+      .bedrock()
+      .invokeModelWithResponseStream(
+        invoking({ inputText: "Summarise entry 1042" }),
+      );
+    const events = await collected(answered.body);
+
+    // Then the body arrives as chunk bytes the caller decodes.
+    assertArrayLength(events, 1);
+
+    const chunk = events.at(0)?.chunk;
+
+    assertNonNullable(chunk);
+    assertIdentical(
+      new TextDecoder().decode(chunk.bytes),
+      JSON.stringify({ results: [{ outputText: "Tone sandhi." }] }),
+    );
+    assertIdentical(answered.contentType, "application/json");
+  });
+
+  it("answers from the rules the non-streaming invocation answers from", async () => {
+    // Given a body declared for the exact request a caller sends.
+    const simAws = new SimAws();
+    const request = { inputText: "Summarise entry 1042" };
+
+    simAws
+      .bedrock()
+      .responses()
+      .onPrompt(JSON.stringify(request), { body: { matched: true } });
+    simAws
+      .bedrock()
+      .responses()
+      .onModel(titan, { body: { matched: false } });
+
+    // When that body is streamed.
+    const answered = await simAws
+      .bedrock()
+      .invokeModelWithResponseStream(invoking(request));
+    const events = await collected(answered.body);
+
+    // Then the prompt rule wins here too.
+    const chunk = events.at(0)?.chunk;
+
+    assertNonNullable(chunk);
+    assertStringIncludes(
+      new TextDecoder().decode(chunk.bytes),
+      '"matched":true',
+    );
+  });
+
+  it("refuses a second reading of a stream", async () => {
+    // Given a streamed body that has been read.
+    const simAws = new SimAws();
+
+    simAws
+      .bedrock()
+      .responses()
+      .byDefault({ body: { outputText: "Yes." } });
+
+    const answered = await simAws
+      .bedrock()
+      .invokeModelWithResponseStream(invoking({ inputText: "Hi" }));
+
+    await collected(answered.body);
+
+    // When it is read again.
+    const error = await assertThrowsErrorAsync(
+      async () => await collected(answered.body),
+    );
+
+    // Then it raises, as a socket read to the end would.
+    assertIdentical(error.name, "SimSdkStreamAlreadyConsumedError");
+  });
+
+  it("refuses a streamed invocation matching a response with no body", async () => {
+    // Given only a Converse response declared.
+    const simAws = new SimAws();
+
+    simAws.bedrock().responses().onModel(titan, { text: "Tone sandhi." });
+
+    // When the model is invoked for a stream.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws
+          .bedrock()
+          .invokeModelWithResponseStream(invoking({ inputText: "Hi" })),
+    );
+
+    // Then it says why there is no default to fall back on.
+    assertIdentical(error.name, "SimBedrockDeclarationError");
+    assertStringIncludes(error.message, "no default for it");
+  });
+});

--- a/src/service/bedrock/command/invoke-model/sim-bedrock-invoke-model-stream.ts
+++ b/src/service/bedrock/command/invoke-model/sim-bedrock-invoke-model-stream.ts
@@ -1,37 +1,38 @@
+import { simSdkEventStream } from "../../../../sdk/index.js";
 import { SimBedrockCommandGroup } from "../sim-bedrock-command-group.js";
 import type { SimBedrockRequestOptions } from "../sim-bedrock-request-options.js";
 import { SimBedrockUnsimulatedInput } from "../sim-bedrock-unsimulated-input.js";
 import type {
-  SimInvokeModelCommand,
-  SimInvokeModelCommandOutput,
+  SimInvokeModelWithResponseStreamCommand,
+  SimInvokeModelWithResponseStreamCommandOutput,
 } from "./invoke-model.command.js";
+import { simBedrockInvokeModelPrompt } from "./sim-bedrock-invoke-model-prompt.js";
 import {
   simBedrockInvokeAccepted,
   simBedrockInvokedBody,
   simBedrockInvokedContentType,
 } from "./sim-bedrock-invoked-body.js";
-import { simBedrockInvokeModelPrompt } from "./sim-bedrock-invoke-model-prompt.js";
 
-const operation = "InvokeModel";
+const operation = "InvokeModelWithResponseStream";
 
 const unsimulated = new SimBedrockUnsimulatedInput(operation);
 
 /**
- * Handles an InvokeModel command.
+ * Handles an InvokeModelWithResponseStream command.
  *
- * The response body is the one declared for the request, serialized as JSON.
- * There is no built-in default: a response body is whatever shape the model
- * behind the id uses, and one family's shape served for every other family
- * would be an answer that parses and means nothing.
+ * The declared body arrives in one chunk. Real Bedrock sends a chunk per
+ * generated fragment, in the shape the model behind the id uses, and splitting
+ * a declared body into fragments means knowing that shape well enough to cut
+ * it up. A caller accumulating chunks reads the same bytes either way.
  */
-export class SimBedrockInvokeModelHandler extends SimBedrockCommandGroup {
+export class SimBedrockInvokeModelStreamHandler extends SimBedrockCommandGroup {
   /**
-   * Invoke a model and answer with the body declared for the request.
+   * Stream the body declared for an invocation.
    */
   handle(
-    command: SimInvokeModelCommand,
+    command: SimInvokeModelWithResponseStreamCommand,
     options?: SimBedrockRequestOptions,
-  ): SimInvokeModelCommandOutput {
+  ): SimInvokeModelWithResponseStreamCommandOutput {
     const { input } = command;
 
     unsimulated.refuseUnaccepted(input, simBedrockInvokeAccepted);
@@ -44,7 +45,9 @@ export class SimBedrockInvokeModelHandler extends SimBedrockCommandGroup {
     const declared = this.responses.responseFor({ prompt, modelId });
 
     return {
-      body: simBedrockInvokedBody(declared),
+      body: simSdkEventStream([
+        { chunk: { bytes: simBedrockInvokedBody(declared) } },
+      ]),
       contentType: simBedrockInvokedContentType(input.accept),
       $metadata: {},
     };

--- a/src/service/bedrock/command/invoke-model/sim-bedrock-invoked-body.ts
+++ b/src/service/bedrock/command/invoke-model/sim-bedrock-invoked-body.ts
@@ -1,0 +1,37 @@
+import type { SimBedrockResolvedResponse } from "../../response/sim-bedrock-resolved-response.js";
+
+const defaultContentType = "application/json";
+
+/**
+ * The inputs a simulated model invocation reads.
+ *
+ * `contentType` and `accept` are accepted and only the latter is used, to say
+ * what the answer is labelled as. Everything a guardrail arrives through is
+ * absent from this list and refused. `InvokeModel` and
+ * `InvokeModelWithResponseStream` take the same request, so they accept the
+ * same inputs.
+ */
+export const simBedrockInvokeAccepted = [
+  "modelId",
+  "body",
+  "contentType",
+  "accept",
+];
+
+/**
+ * The declared response body, serialized the way a caller reads it back.
+ */
+export function simBedrockInvokedBody(
+  declared: SimBedrockResolvedResponse,
+): Uint8Array {
+  return new TextEncoder().encode(JSON.stringify(declared.body()));
+}
+
+/**
+ * What the answer is labelled as.
+ */
+export function simBedrockInvokedContentType(
+  accept: string | undefined,
+): string {
+  return accept ?? defaultContentType;
+}

--- a/src/service/bedrock/index.ts
+++ b/src/service/bedrock/index.ts
@@ -1,5 +1,21 @@
 export { SimBedrock } from "./sim-bedrock.js";
 export type { SimBedrockRequestOptions } from "./command/sim-bedrock-request-options.js";
+export type {
+  SimBedrockContentBlockDelta,
+  SimBedrockContentBlockDeltaEvent,
+  SimBedrockContentBlockStartEvent,
+  SimBedrockContentBlockStopEvent,
+  SimBedrockMessageStartEvent,
+  SimBedrockMessageStopEvent,
+  SimBedrockStreamMetadataEvent,
+  SimConverseStreamOutput,
+} from "./command/converse/converse-stream.command.js";
+export type { SimInvokeModelResponseStreamOutput } from "./command/invoke-model/invoke-model.command.js";
+export type {
+  SimBedrockStreamedBlock,
+  SimBedrockStreamedTextBlock,
+  SimBedrockStreamedToolUseBlock,
+} from "./response/sim-bedrock-streamed-content.js";
 export {
   SimBedrockResponses,
   type SimBedrockResponseRequest,

--- a/src/service/bedrock/response/sim-bedrock-declarations.iso.test.ts
+++ b/src/service/bedrock/response/sim-bedrock-declarations.iso.test.ts
@@ -24,7 +24,24 @@ describe("Bedrock response declarations", () => {
 
     // Then it is refused where it was written.
     assertIdentical(error.name, "SimBedrockDeclarationError");
-    assertStringIncludes(error.message, "declare one or the other");
+    assertStringIncludes(error.message, "carries text and content");
+  });
+
+  it("refuses a response carrying both chunks and text", () => {
+    // Given a simulated Bedrock.
+    const simAws = new SimAws();
+
+    // When a response says what the message holds two ways.
+    const error = assertThrowsError(() => {
+      simAws
+        .bedrock()
+        .responses()
+        .byDefault({ text: "Tone sandhi.", chunks: ["Tone ", "sandhi."] });
+    });
+
+    // Then it is refused where it was written.
+    assertIdentical(error.name, "SimBedrockDeclarationError");
+    assertStringIncludes(error.message, "declare one of them");
   });
 
   it("refuses a content block carrying text and a tool use at once", () => {
@@ -58,6 +75,7 @@ describe("Bedrock response declarations", () => {
     // Then it says what to declare instead.
     assertIdentical(error.name, "SimBedrockDeclarationError");
     assertStringIncludes(error.message, "no text, no content and no body");
+    assertStringIncludes(error.message, "Declare text, chunks or content");
   });
 
   it("refuses a negative token count", () => {

--- a/src/service/bedrock/response/sim-bedrock-declared-content.ts
+++ b/src/service/bedrock/response/sim-bedrock-declared-content.ts
@@ -27,22 +27,61 @@ function checkedBlock(
   return block;
 }
 
+/**
+ * The members a response used to say what the message holds.
+ *
+ * One response says it one way. `text` is a single block, `chunks` is that
+ * block written as the deltas a stream sends, and `content` is the blocks
+ * themselves.
+ */
+function namedMessageMembers(
+  declared: SimBedrockDeclaredResponse,
+): readonly string[] {
+  const named: string[] = [];
+
+  if (declared.text !== undefined) {
+    named.push("text");
+  }
+
+  if (declared.chunks !== undefined) {
+    named.push("chunks");
+  }
+
+  if (declared.content !== undefined) {
+    named.push("content");
+  }
+
+  return named;
+}
+
+function requireOneMessageMember(
+  subject: string,
+  declared: SimBedrockDeclaredResponse,
+): void {
+  const named = namedMessageMembers(declared);
+
+  if (named.length > 1) {
+    throw new SimBedrockDeclarationError(
+      `The response declared for ${subject} carries ${named.join(" and ")}. ` +
+        `Each of those says what the message holds, so declare one of them.`,
+    );
+  }
+}
+
 function blocksOf(
   subject: string,
   declared: SimBedrockDeclaredResponse,
 ): readonly SimBedrockDeclaredContentBlock[] | undefined {
-  const { text, content } = declared;
+  const { text, chunks, content } = declared;
 
-  if (text !== undefined && content !== undefined) {
-    throw new SimBedrockDeclarationError(
-      `The response declared for ${subject} carries both text and content ` +
-        `blocks. Text is the short form of one text block, so declare one or ` +
-        `the other.`,
-    );
-  }
+  requireOneMessageMember(subject, declared);
 
   if (text !== undefined) {
     return [{ text }];
+  }
+
+  if (chunks !== undefined) {
+    return [{ text: chunks.join("") }];
   }
 
   return content?.map((block) => checkedBlock(subject, block));
@@ -51,10 +90,14 @@ function blocksOf(
 /**
  * The content blocks a declared response answers `Converse` with.
  *
- * A response declared as a body alone has none, which is the ordinary case
- * rather than an error: it answers `InvokeModel`. A response with no content
- * and no body has nothing to answer anything with, and is refused where it was
- * written.
+ * A response declared as chunks holds them joined, so the same declaration
+ * answers `Converse` with the whole text and `ConverseStream` with the deltas
+ * it was written in.
+ *
+ * A response declared as a body alone has no content, which is the ordinary
+ * case rather than an error: it answers `InvokeModel`. A response with no
+ * content and no body has nothing to answer anything with, and is refused
+ * where it was written.
  */
 export function simBedrockDeclaredContent(
   subject: string,
@@ -65,8 +108,8 @@ export function simBedrockDeclaredContent(
   if (blocks === undefined && declared.body === undefined) {
     throw new SimBedrockDeclarationError(
       `The response declared for ${subject} carries no text, no content and ` +
-        `no body. Declare text or content for Converse, or a body for ` +
-        `InvokeModel.`,
+        `no body. Declare text, chunks or content for Converse, or a body ` +
+        `for InvokeModel.`,
     );
   }
 

--- a/src/service/bedrock/response/sim-bedrock-resolved-response.ts
+++ b/src/service/bedrock/response/sim-bedrock-resolved-response.ts
@@ -9,6 +9,10 @@ import type {
   SimBedrockDeclaredResponse,
 } from "./sim-bedrock-response-declaration.js";
 import { simBedrockDefaultStopReason } from "./sim-bedrock-response-defaults.js";
+import {
+  simBedrockStreamedContent,
+  type SimBedrockStreamedBlock,
+} from "./sim-bedrock-streamed-content.js";
 
 /**
  * The message one `Converse` call answers with.
@@ -50,15 +54,14 @@ export class SimBedrockResolvedResponse {
    * it from `Converse` is a declaration this simulation cannot answer with.
    */
   message(): SimBedrockResponseMessage {
-    if (this.content === undefined) {
-      throw new SimBedrockDeclarationError(
-        `A Converse call matched the response declared for ${this.subject}, ` +
-          `which carries a body and nothing else. A body answers InvokeModel. ` +
-          `Declare text or content for Converse.`,
-      );
-    }
+    return { role: "assistant", content: this.requireContent() };
+  }
 
-    return { role: "assistant", content: this.content };
+  /**
+   * How the message arrives over `ConverseStream`, block by block.
+   */
+  streamedContent(): readonly SimBedrockStreamedBlock[] {
+    return simBedrockStreamedContent(this.declared, this.requireContent());
   }
 
   /**
@@ -92,6 +95,18 @@ export class SimBedrockResolvedResponse {
    */
   usage(): SimBedrockResponseUsage {
     return this.declaredUsage;
+  }
+
+  private requireContent(): readonly SimBedrockDeclaredContentBlock[] {
+    if (this.content === undefined) {
+      throw new SimBedrockDeclarationError(
+        `A Converse call matched the response declared for ${this.subject}, ` +
+          `which carries a body and nothing else. A body answers InvokeModel. ` +
+          `Declare text, chunks or content for Converse.`,
+      );
+    }
+
+    return this.content;
   }
 
   private reachedStopReason(): string {

--- a/src/service/bedrock/response/sim-bedrock-response-declaration.ts
+++ b/src/service/bedrock/response/sim-bedrock-response-declaration.ts
@@ -38,15 +38,18 @@ export interface SimBedrockDeclaredUsage {
  * What simulated Bedrock answers one request with.
  *
  * The members an operation reads are the ones it can use. `Converse` answers
- * from `text` or `content`, and `InvokeModel` answers from `body`. A
+ * from `text`, `chunks` or `content`, and `InvokeModel` answers from `body`. A
  * declaration carrying nothing the operation asking for it can use is refused
  * where the call is made rather than answered with the built-in default.
  *
- * `text` is the short form of a single text content block, and declaring both
- * it and `content` is refused where the rule is written.
+ * `text` is the short form of a single text content block, and `chunks` is
+ * that same text written as the deltas `ConverseStream` sends it in. All three
+ * of `text`, `chunks` and `content` say what the message holds, so declaring
+ * more than one of them is refused where the rule is written.
  */
 export interface SimBedrockDeclaredResponse {
   readonly text?: string | undefined;
+  readonly chunks?: readonly string[] | undefined;
   readonly content?: readonly SimBedrockDeclaredContentBlock[] | undefined;
   readonly body?: unknown;
   readonly stopReason?: string | undefined;

--- a/src/service/bedrock/response/sim-bedrock-streamed-content.ts
+++ b/src/service/bedrock/response/sim-bedrock-streamed-content.ts
@@ -1,0 +1,63 @@
+import type {
+  SimBedrockDeclaredContentBlock,
+  SimBedrockDeclaredResponse,
+  SimBedrockDeclaredToolUse,
+} from "./sim-bedrock-response-declaration.js";
+
+/**
+ * One text block of a streamed response, and the deltas it arrives in.
+ *
+ * A block declared as chunks streams one delta each. Any other text block
+ * streams as a single delta. Splitting text into plausible token deltas would
+ * invent behaviour no test could rely on, since the split a real model streams
+ * comes from its own tokenizer.
+ */
+export interface SimBedrockStreamedTextBlock {
+  readonly kind: "text";
+  readonly deltas: readonly string[];
+}
+
+/**
+ * One tool call of a streamed response.
+ *
+ * Real `ConverseStream` opens the block, streams the arguments as fragments of
+ * JSON and closes it. The fragments are the part this leaves out: the
+ * arguments arrive in one delta, because a declaration holds them whole.
+ */
+export interface SimBedrockStreamedToolUseBlock {
+  readonly kind: "toolUse";
+  readonly toolUse: SimBedrockDeclaredToolUse;
+}
+
+export type SimBedrockStreamedBlock =
+  | SimBedrockStreamedTextBlock
+  | SimBedrockStreamedToolUseBlock;
+
+function streamedBlock(
+  block: SimBedrockDeclaredContentBlock,
+): SimBedrockStreamedBlock {
+  if (block.toolUse !== undefined) {
+    return { kind: "toolUse", toolUse: block.toolUse };
+  }
+
+  return { kind: "text", deltas: [block.text ?? ""] };
+}
+
+/**
+ * How a declared response arrives over `ConverseStream`.
+ *
+ * The blocks are the ones `Converse` answers with, in the same order. Only the
+ * deltas differ, and only for a response declared as chunks.
+ */
+export function simBedrockStreamedContent(
+  declared: SimBedrockDeclaredResponse,
+  content: readonly SimBedrockDeclaredContentBlock[],
+): readonly SimBedrockStreamedBlock[] {
+  const { chunks } = declared;
+
+  if (chunks !== undefined) {
+    return [{ kind: "text", deltas: chunks }];
+  }
+
+  return content.map((block) => streamedBlock(block));
+}

--- a/src/service/bedrock/sdk/sim-bedrock-converse-stream-sdk.iso.test.ts
+++ b/src/service/bedrock/sdk/sim-bedrock-converse-stream-sdk.iso.test.ts
@@ -1,0 +1,50 @@
+import {
+  BedrockRuntimeClient,
+  ConverseStreamCommand,
+} from "@aws-sdk/client-bedrock-runtime";
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimSdk } from "../../../sdk/index.js";
+
+const region = "eu-west-2";
+
+describe("Bedrock ConverseStream through SDK interception", () => {
+  it("streams to the code accumulating it", async () => {
+    // Given an intercepted Bedrock Runtime client and a chunked response.
+    const simSdk = new SimSdk();
+    simSdk.intercept(BedrockRuntimeClient);
+
+    const client = new BedrockRuntimeClient({ region });
+
+    try {
+      simSdk.simAws
+        .account()
+        .region(region)
+        .bedrock()
+        .responses()
+        .byDefault({ chunks: ["Entry 1042 ", "covers tone sandhi."] });
+
+      // When production code accumulates the stream.
+      const answered = await client.send(
+        new ConverseStreamCommand({
+          modelId: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+          messages: [{ role: "user", content: [{ text: "Anything" }] }],
+        }),
+      );
+
+      const streamed = answered.stream ?? [];
+
+      let accumulated = "";
+
+      for await (const event of streamed) {
+        accumulated += event.contentBlockDelta?.delta?.text ?? "";
+      }
+
+      // Then it reads the whole text through the SDK's own types.
+      assertIdentical(accumulated, "Entry 1042 covers tone sandhi.");
+    } finally {
+      client.destroy();
+      simSdk.restoreAll();
+    }
+  });
+});

--- a/src/service/bedrock/sdk/sim-bedrock-invoke-stream-sdk.iso.test.ts
+++ b/src/service/bedrock/sdk/sim-bedrock-invoke-stream-sdk.iso.test.ts
@@ -1,0 +1,50 @@
+import {
+  BedrockRuntimeClient,
+  InvokeModelWithResponseStreamCommand,
+} from "@aws-sdk/client-bedrock-runtime";
+import { assertStringIncludes } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimSdk } from "../../../sdk/index.js";
+
+const region = "eu-west-2";
+
+describe("Bedrock InvokeModelWithResponseStream through SDK interception", () => {
+  it("streams the declared body as chunks the caller decodes", async () => {
+    // Given an intercepted Bedrock Runtime client and a declared body.
+    const simSdk = new SimSdk();
+    simSdk.intercept(BedrockRuntimeClient);
+
+    const client = new BedrockRuntimeClient({ region });
+
+    try {
+      simSdk.simAws
+        .account()
+        .region(region)
+        .bedrock()
+        .responses()
+        .byDefault({ body: { outputText: "Tone sandhi." } });
+
+      // When production code reads the chunks.
+      const answered = await client.send(
+        new InvokeModelWithResponseStreamCommand({
+          modelId: "amazon.titan-text-express-v1",
+          body: JSON.stringify({ inputText: "Summarise entry 1042" }),
+        }),
+      );
+
+      const streamed = answered.body ?? [];
+
+      let accumulated = "";
+
+      for await (const event of streamed) {
+        accumulated += new TextDecoder().decode(event.chunk?.bytes);
+      }
+
+      // Then the bytes decode the way production code decodes them.
+      assertStringIncludes(accumulated, "Tone sandhi.");
+    } finally {
+      client.destroy();
+      simSdk.restoreAll();
+    }
+  });
+});

--- a/src/service/bedrock/sdk/sim-bedrock-sdk-command-router.ts
+++ b/src/service/bedrock/sdk/sim-bedrock-sdk-command-router.ts
@@ -3,8 +3,12 @@ import {
   type SimSdkCommandRoute,
   type SimSdkCommandRouter,
 } from "../../../sdk/index.js";
+import type { SimConverseStreamCommand } from "../command/converse/converse-stream.command.js";
 import type { SimConverseCommand } from "../command/converse/converse.command.js";
-import type { SimInvokeModelCommand } from "../command/invoke-model/invoke-model.command.js";
+import type {
+  SimInvokeModelCommand,
+  SimInvokeModelWithResponseStreamCommand,
+} from "../command/invoke-model/invoke-model.command.js";
 import type { SimBedrock } from "../sim-bedrock.js";
 
 /**
@@ -27,10 +31,26 @@ export class SimBedrockSdkCommandRouter implements SimSdkCommandRouter {
           ),
       ],
       [
+        "ConverseStreamCommand",
+        async (command, context): Promise<unknown> =>
+          await simBedrock.converseStream(
+            command as SimConverseStreamCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
         "InvokeModelCommand",
         async (command, context): Promise<unknown> =>
           await simBedrock.invokeModel(
             command as SimInvokeModelCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "InvokeModelWithResponseStreamCommand",
+        async (command, context): Promise<unknown> =>
+          await simBedrock.invokeModelWithResponseStream(
+            command as SimInvokeModelWithResponseStreamCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/bedrock/sdk/sim-bedrock-sdk-routing.iso.test.ts
+++ b/src/service/bedrock/sdk/sim-bedrock-sdk-routing.iso.test.ts
@@ -129,10 +129,15 @@ describe("Bedrock SDK interception", () => {
       .sdkCommandRouter()
       .supportedCommandNames();
 
-    // Then it names the two invocation commands.
+    // Then it names the four invocation commands.
     assertArrayEquals(
       supported.toSorted((a, b) => a.localeCompare(b)),
-      ["ConverseCommand", "InvokeModelCommand"],
+      [
+        "ConverseCommand",
+        "ConverseStreamCommand",
+        "InvokeModelCommand",
+        "InvokeModelWithResponseStreamCommand",
+      ],
     );
   });
 });

--- a/src/service/bedrock/sdk/sim-bedrock-wire-request.iso.test.ts
+++ b/src/service/bedrock/sdk/sim-bedrock-wire-request.iso.test.ts
@@ -1,0 +1,47 @@
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimSdkWireDispatcher } from "../../../sdk/wire/sim-sdk-wire-dispatcher.js";
+import { SimAws } from "../../aws/sim-aws.js";
+
+const region = "eu-west-2";
+
+describe("Bedrock over the wire path", () => {
+  it("refuses a serialized Bedrock request rather than answering it unframed", async () => {
+    // Given a simulation reached through the wire path, as a function bundling
+    // its own SDK reaches it.
+    const simAws = new SimAws({ defaultRegionName: region });
+    const dispatcher = new SimSdkWireDispatcher(simAws);
+
+    // When a serialized ConverseStream request arrives.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await dispatcher.dispatch({
+          method: "POST",
+          hostname: `bedrock-runtime.${region}.amazonaws.com`,
+          path: "/model/anthropic.claude-3-5-sonnet-20241022-v2:0/converse-stream",
+          headers: Object.fromEntries([
+            ["content-type", "application/json"],
+            [
+              "authorization",
+              `AWS4-HMAC-SHA256 Credential=ASIAEXAMPLE/20260822/${region}/` +
+                "bedrock/aws4_request, SignedHeaders=host, Signature=abc123",
+            ],
+          ]),
+          body: Buffer.from("{}"),
+        }),
+    );
+
+    // Then it is refused for the reason every Bedrock request is. The request
+    // carries no operation header to read it back from, so nothing here has to
+    // frame an event stream.
+    assertIdentical(error.name, "SimSdkUnbridgedWireRequestError");
+    assertStringIncludes(error.message, "bedrock");
+    assertStringIncludes(error.message, "AWS JSON protocol");
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/service/bedrock/sim-bedrock.ts
+++ b/src/service/bedrock/sim-bedrock.ts
@@ -14,12 +14,20 @@ import type {
   SimConverseCommand,
   SimConverseCommandOutput,
 } from "./command/converse/converse.command.js";
+import type {
+  SimConverseStreamCommand,
+  SimConverseStreamCommandOutput,
+} from "./command/converse/converse-stream.command.js";
 import { SimBedrockConverseHandler } from "./command/converse/sim-bedrock-converse.js";
+import { SimBedrockConverseStreamHandler } from "./command/converse/sim-bedrock-converse-stream.js";
 import type {
   SimInvokeModelCommand,
   SimInvokeModelCommandOutput,
+  SimInvokeModelWithResponseStreamCommand,
+  SimInvokeModelWithResponseStreamCommandOutput,
 } from "./command/invoke-model/invoke-model.command.js";
 import { SimBedrockInvokeModelHandler } from "./command/invoke-model/sim-bedrock-invoke-model.js";
+import { SimBedrockInvokeModelStreamHandler } from "./command/invoke-model/sim-bedrock-invoke-model-stream.js";
 import type { SimBedrockRequestOptions } from "./command/sim-bedrock-request-options.js";
 import { SimBedrockResponses } from "./response/sim-bedrock-responses.js";
 import { SimBedrockSdkCommandRouter } from "./sdk/sim-bedrock-sdk-command-router.js";
@@ -47,7 +55,9 @@ interface SimBedrockProperties {
 export class SimBedrock {
   private readonly responseRules = new SimBedrockResponses();
   private readonly converseCommand: SimBedrockConverseHandler;
+  private readonly converseStreamCommand: SimBedrockConverseStreamHandler;
   private readonly invokeModelCommand: SimBedrockInvokeModelHandler;
+  private readonly invokeModelStreamCommand: SimBedrockInvokeModelStreamHandler;
   private readonly background: BackgroundScheduler;
   private readonly sdkRouter = new SimBedrockSdkCommandRouter(this);
 
@@ -65,7 +75,13 @@ export class SimBedrock {
 
     this.background = background;
     this.converseCommand = new SimBedrockConverseHandler(commandProperties);
+    this.converseStreamCommand = new SimBedrockConverseStreamHandler(
+      commandProperties,
+    );
     this.invokeModelCommand = new SimBedrockInvokeModelHandler(
+      commandProperties,
+    );
+    this.invokeModelStreamCommand = new SimBedrockInvokeModelStreamHandler(
       commandProperties,
     );
   }
@@ -98,6 +114,18 @@ export class SimBedrock {
   }
 
   /**
+   * Handle a ConverseStream Command from the SDK.
+   */
+  async converseStream(
+    command: SimConverseStreamCommand,
+    options?: SimBedrockRequestOptions,
+  ): Promise<SimConverseStreamCommandOutput> {
+    await this.background.sequence();
+
+    return this.converseStreamCommand.handle(command, options);
+  }
+
+  /**
    * Handle an InvokeModel Command from the SDK.
    */
   async invokeModel(
@@ -107,6 +135,18 @@ export class SimBedrock {
     await this.background.sequence();
 
     return this.invokeModelCommand.handle(command, options);
+  }
+
+  /**
+   * Handle an InvokeModelWithResponseStream Command from the SDK.
+   */
+  async invokeModelWithResponseStream(
+    command: SimInvokeModelWithResponseStreamCommand,
+    options?: SimBedrockRequestOptions,
+  ): Promise<SimInvokeModelWithResponseStreamCommandOutput> {
+    await this.background.sequence();
+
+    return this.invokeModelStreamCommand.handle(command, options);
   }
 
   /**


### PR DESCRIPTION
`ConverseStream` and `InvokeModelWithResponseStream` answer from the same declared responses the non-streaming commands answer from, through `simAws.bedrock()` and through an intercepted `BedrockRuntimeClient`. A conversation arrives as the events real Bedrock sends: `messageStart`, one `contentBlockDelta` per declared chunk, `contentBlockStop`, `messageStop` carrying the stop reason and `metadata` carrying the token counts, with a `contentBlockStart` ahead of a tool call. Declaring `chunks` says where the deltas fall, and the same declaration answers `Converse` with the chunks joined, so code moving between the two APIs keeps its declarations. The stream itself is `simSdkEventStream` in the SDK layer, which yields its events in order and refuses a second reading as `simSdkStreamBody` does.

Resolves #913

## Decisions worth a second look

**The wire path needed no change, and the issue's premise there was wrong.** `SimSdkWireDispatcher` reads the operation from `x-amz-target`, which only the AWS JSON protocol services send. Bedrock speaks REST-JSON, so a serialized Bedrock request never reaches a Command at all and is already refused by `simSdkUnbridgedWireRequest`, naming the service and pointing at module interception. Nothing here has to frame `application/vnd.amazon.eventstream`. I wrote the guard the issue asked for, then deleted it: it was untestable defensive code for a case no service can reach today. `sim-bedrock-wire-request.iso.test.ts` pins the real behaviour instead.

**Chunks are the only splitting.** A response declared as `text` or `content` streams in one delta. The split a real model streams comes from its own tokenizer, and inventing one would give a test something to depend on that means nothing.

**One declaration serves both APIs.** `chunks` joined is what `Converse` answers with, so moving code from `Converse` to `ConverseStream` needs no new declarations. Declaring more than one of `text`, `chunks` and `content` is refused where the rule is written.

**A streamed tool call sends its arguments in one delta**, and `{}` where none were declared. Real `ConverseStream` sends JSON fragments to be concatenated. This is the one place the sequence is shorter than the real one.

**Three small test files rather than one.** Two streaming interception tests in one file scored 51 on FTA and 11 apart, which is a sharp knee rather than a gradual one. Each file now covers one command.

## What is left out

Guardrail trace events, which follow whatever `ApplyGuardrail` gets. Timing between events: every event is ready as soon as the call returns, since nothing here generates anything to wait for.
