### PR TITLE
feat: read Amazon States Language data flow

### DIFF
--- a/src/service/stepfunctions/data/sim-states-data-flow.iso.test.ts
+++ b/src/service/stepfunctions/data/sim-states-data-flow.iso.test.ts
@@ -1,7 +1,9 @@
 import {
+  assertIdentical,
   assertObjectEquals,
   assertStringIncludes,
   assertThrowsError,
+  assertTrue,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import {
@@ -147,21 +149,40 @@ describe("Step Functions state data flow", () => {
     assertObjectEquals(output, { students: [{ name: "Wei", term: 3 }] });
   });
 
-  it("writes into an array position the input has not reached yet", () => {
+  it("refuses a ResultPath writing past the end of an array", () => {
     // Given an input holding a one element array.
-    // When a result is written past its end.
-    const output = simStatesEffectiveOutput(
-      { students: [{ name: "Wei" }] },
-      3,
-      {
+    // When a result is written to an index the array does not reach.
+    const error = assertThrowsError(() =>
+      simStatesEffectiveOutput({ students: [{ name: "Wei" }] }, 3, {
         ResultPath: "$.students[2].term",
-      },
+      }),
     );
 
-    // Then the gap is filled the way JavaScript fills a sparse array.
-    assertObjectEquals(output, {
-      students: [{ name: "Wei" }, undefined, { term: 3 }],
+    // Then it is refused rather than leaving a hole in the array.
+    assertStringIncludes(error.message, "array holding 1");
+  });
+
+  it("writes a field named __proto__ as an ordinary field", () => {
+    // Given a ResultPath naming a field JavaScript treats specially.
+    // When a result is written to it.
+    const output = simStatesEffectiveOutput({ term: 3 }, "written", {
+      ResultPath: "$['__proto__']",
     });
+
+    // Then it is an own field that serializes, and not a moved prototype.
+    assertTrue(Object.hasOwn(output as object, "__proto__"));
+    assertIdentical(JSON.stringify(output), '{"term":3,"__proto__":"written"}');
+  });
+
+  it("writes a field named toString without reading the one on the prototype", () => {
+    // Given a ResultPath through a field every object inherits.
+    // When a result is written underneath it.
+    const output = simStatesEffectiveOutput({ term: 3 }, "written", {
+      ResultPath: "$.toString.value",
+    });
+
+    // Then the inherited function was never treated as the value there.
+    assertObjectEquals(output, { term: 3, toString: { value: "written" } });
   });
 
   it("reshapes the result with ResultSelector before ResultPath", () => {

--- a/src/service/stepfunctions/data/sim-states-data-flow.iso.test.ts
+++ b/src/service/stepfunctions/data/sim-states-data-flow.iso.test.ts
@@ -1,0 +1,302 @@
+import {
+  assertObjectEquals,
+  assertStringIncludes,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  simStatesEffectiveInput,
+  simStatesEffectiveOutput,
+} from "./sim-states-data-flow.js";
+
+const rawInput = {
+  student: { name: "Wei", id: "s-1042" },
+  term: 3,
+};
+
+describe("Step Functions state data flow", () => {
+  it("passes the raw input through where no field narrows it", () => {
+    // Given a state with no data-flow fields.
+    // When its effective input is worked out.
+    const effective = simStatesEffectiveInput(rawInput, {});
+
+    // Then the state sees what it was given.
+    assertObjectEquals(effective, rawInput);
+  });
+
+  it("narrows the input to what InputPath selects", () => {
+    // Given a state reading one field.
+    // When its effective input is worked out.
+    const effective = simStatesEffectiveInput(rawInput, {
+      InputPath: "$.student",
+    });
+
+    // Then only that field reaches it.
+    assertObjectEquals(effective, { name: "Wei", id: "s-1042" });
+  });
+
+  it("gives a state nothing where InputPath is null", () => {
+    // Given a state asking for no input.
+    // When its effective input is worked out.
+    const effective = simStatesEffectiveInput(rawInput, { InputPath: null });
+
+    // Then it sees an empty object.
+    assertObjectEquals(effective, {});
+  });
+
+  it("builds the task input from Parameters after InputPath", () => {
+    // Given a state narrowing its input and then reshaping it.
+    // When its effective input is worked out.
+    const effective = simStatesEffectiveInput(rawInput, {
+      InputPath: "$.student",
+      Parameters: {
+        "studentId.$": "$.id",
+        source: "enrolment",
+        nested: { "greeting.$": "States.Format('Hello {}', $.name)" },
+      },
+    });
+
+    // Then Parameters read what InputPath had already left.
+    assertObjectEquals(effective, {
+      studentId: "s-1042",
+      source: "enrolment",
+      nested: { greeting: "Hello Wei" },
+    });
+  });
+
+  it("resolves a .$ field inside an array in Parameters", () => {
+    // Given Parameters holding an array.
+    // When its effective input is worked out.
+    const effective = simStatesEffectiveInput(rawInput, {
+      Parameters: { students: [{ "name.$": "$.student.name" }, "Mei"] },
+    });
+
+    // Then the array element was walked too.
+    assertObjectEquals(effective, { students: [{ name: "Wei" }, "Mei"] });
+  });
+
+  it("replaces the input with the result where no ResultPath is written", () => {
+    // Given a state that produced a result.
+    // When its effective output is worked out.
+    const output = simStatesEffectiveOutput(rawInput, { eligible: true }, {});
+
+    // Then the result is all that comes out.
+    assertObjectEquals(output, { eligible: true });
+  });
+
+  it("keeps the raw input and drops the result where ResultPath is null", () => {
+    // Given a state whose result is discarded.
+    // When its effective output is worked out.
+    const output = simStatesEffectiveOutput(
+      rawInput,
+      { eligible: true },
+      {
+        ResultPath: null,
+      },
+    );
+
+    // Then the input passes through untouched.
+    assertObjectEquals(output, rawInput);
+  });
+
+  it("writes the result into the raw input at ResultPath", () => {
+    // Given a state writing its result to a new field.
+    // When its effective output is worked out.
+    const output = simStatesEffectiveOutput(
+      rawInput,
+      { eligible: true },
+      {
+        ResultPath: "$.check",
+      },
+    );
+
+    // Then the input is carried through with the result added.
+    assertObjectEquals(output, {
+      student: { name: "Wei", id: "s-1042" },
+      term: 3,
+      check: { eligible: true },
+    });
+  });
+
+  it("builds the objects a ResultPath needs on the way down", () => {
+    // Given a path through fields the input does not have.
+    // When its effective output is worked out.
+    const output = simStatesEffectiveOutput({ term: 3 }, "done", {
+      ResultPath: "$.audit.check.status",
+    });
+
+    // Then each step of the path was created.
+    assertObjectEquals(output, {
+      term: 3,
+      audit: { check: { status: "done" } },
+    });
+  });
+
+  it("writes into an array element by index", () => {
+    // Given an input holding an array.
+    // When a result is written into one of its elements.
+    const output = simStatesEffectiveOutput(
+      { students: [{ name: "Wei" }] },
+      3,
+      {
+        ResultPath: "$.students[0].term",
+      },
+    );
+
+    // Then that element carries the result and the array is otherwise intact.
+    assertObjectEquals(output, { students: [{ name: "Wei", term: 3 }] });
+  });
+
+  it("writes into an array position the input has not reached yet", () => {
+    // Given an input holding a one element array.
+    // When a result is written past its end.
+    const output = simStatesEffectiveOutput(
+      { students: [{ name: "Wei" }] },
+      3,
+      {
+        ResultPath: "$.students[2].term",
+      },
+    );
+
+    // Then the gap is filled the way JavaScript fills a sparse array.
+    assertObjectEquals(output, {
+      students: [{ name: "Wei" }, undefined, { term: 3 }],
+    });
+  });
+
+  it("reshapes the result with ResultSelector before ResultPath", () => {
+    // Given a task answer wrapped the way lambda:invoke wraps one.
+    const taskResult = { StatusCode: 200, Payload: { eligible: true } };
+
+    // When the state unwraps it and writes it into the input.
+    const output = simStatesEffectiveOutput(rawInput, taskResult, {
+      ResultSelector: { "eligible.$": "$.Payload.eligible" },
+      ResultPath: "$.check",
+    });
+
+    // Then ResultSelector read the raw result and ResultPath read the input.
+    assertObjectEquals(output, {
+      student: { name: "Wei", id: "s-1042" },
+      term: 3,
+      check: { eligible: true },
+    });
+  });
+
+  it("narrows the output with OutputPath last", () => {
+    // Given a state writing a result and then narrowing to it.
+    // When its effective output is worked out.
+    const output = simStatesEffectiveOutput(
+      rawInput,
+      { eligible: true },
+      {
+        ResultPath: "$.check",
+        OutputPath: "$.check",
+      },
+    );
+
+    // Then only the narrowed part comes out.
+    assertObjectEquals(output, { eligible: true });
+  });
+
+  it("gives the next state nothing where OutputPath is null", () => {
+    // Given a state discarding its output.
+    // When its effective output is worked out.
+    const output = simStatesEffectiveOutput(
+      rawInput,
+      { eligible: true },
+      {
+        OutputPath: null,
+      },
+    );
+
+    // Then an empty object comes out.
+    assertObjectEquals(output, {});
+  });
+
+  it("lets ResultPath keep a field InputPath had taken away", () => {
+    // Given a state that saw only part of its input.
+    const fields = { InputPath: "$.student", ResultPath: "$.check" };
+
+    // When the effective input and then the effective output are worked out.
+    const effective = simStatesEffectiveInput(rawInput, fields);
+    const output = simStatesEffectiveOutput(
+      rawInput,
+      { seen: effective },
+      fields,
+    );
+
+    // Then the output holds the term the state itself never saw.
+    assertObjectEquals(output, {
+      student: { name: "Wei", id: "s-1042" },
+      term: 3,
+      check: { seen: { name: "Wei", id: "s-1042" } },
+    });
+  });
+
+  it("fails a state whose InputPath or OutputPath selects nothing", () => {
+    // Given paths the input has no value at.
+    // When the effective input and output are worked out.
+    const onInput = assertThrowsError(() =>
+      simStatesEffectiveInput(rawInput, { InputPath: "$.absent" }),
+    );
+    const onOutput = assertThrowsError(() =>
+      simStatesEffectiveOutput(rawInput, {}, { OutputPath: "$.absent" }),
+    );
+
+    // Then each names the field and the path.
+    assertStringIncludes(onInput.message, "InputPath reads $.absent");
+    assertStringIncludes(onOutput.message, "OutputPath reads $.absent");
+  });
+
+  it("fails a Parameters field whose path selects nothing", () => {
+    // Given Parameters reading a field that is not there.
+    // When the effective input is worked out.
+    const error = assertThrowsError(() =>
+      simStatesEffectiveInput(rawInput, {
+        Parameters: { "studentId.$": "$.student.absent" },
+      }),
+    );
+
+    // Then the failure names the field.
+    assertStringIncludes(error.message, "studentId.$");
+  });
+
+  it("refuses a .$ field whose value is not a string", () => {
+    // Given a field ending in .$ holding an object.
+    // When the effective input is worked out.
+    const error = assertThrowsError(() =>
+      simStatesEffectiveInput(rawInput, {
+        Parameters: { "studentId.$": { nested: true } },
+      }),
+    );
+
+    // Then it is refused when the value is read.
+    assertStringIncludes(error.message, "has to be a Reference Path");
+  });
+
+  it("fails a ResultPath writing a field into something that is not an object", () => {
+    // Given an input whose field holds a string.
+    // When a result is written underneath it.
+    const error = assertThrowsError(() =>
+      simStatesEffectiveOutput({ student: "Wei" }, 3, {
+        ResultPath: "$.student.term",
+      }),
+    );
+
+    // Then the failure says the result has nowhere to go.
+    assertStringIncludes(error.message, "not an object");
+  });
+
+  it("fails a ResultPath writing an index into something that is not an array", () => {
+    // Given an input whose field holds an object.
+    // When a result is written into it by index.
+    const error = assertThrowsError(() =>
+      simStatesEffectiveOutput({ students: { name: "Wei" } }, 3, {
+        ResultPath: "$.students[0]",
+      }),
+    );
+
+    // Then the failure says the result has nowhere to go.
+    assertStringIncludes(error.message, "not an array");
+  });
+});

--- a/src/service/stepfunctions/data/sim-states-data-flow.ts
+++ b/src/service/stepfunctions/data/sim-states-data-flow.ts
@@ -1,0 +1,122 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { SimStatesPathMatchFailure } from "../error/sim-step-functions.error.js";
+import { evaluateSimStatesPayloadTemplate } from "./sim-states-payload-template.js";
+import { selectSimStatesPath } from "./sim-states-path-segment.js";
+import { parseSimStatesReferencePath } from "./sim-states-reference-path.js";
+import { insertAtSimStatesPath } from "./sim-states-result-path.js";
+
+/**
+ * The data-flow fields one state carries.
+ *
+ * A field left out and a field written as `null` mean different things in
+ * Amazon States Language, so absent is `undefined` here and `null` is the JSON
+ * null the definition wrote.
+ */
+export interface SimStatesDataFlowFields {
+  readonly InputPath?: string | null;
+  readonly Parameters?: JSONValue;
+  readonly ResultSelector?: JSONValue;
+  readonly ResultPath?: string | null;
+  readonly OutputPath?: string | null;
+}
+
+/**
+ * The input a state's work receives.
+ *
+ * `InputPath` narrows the raw input and `Parameters` then builds a value from
+ * what is left, which is the order Amazon States Language applies them in.
+ */
+export function simStatesEffectiveInput(
+  rawInput: JSONValue,
+  fields: SimStatesDataFlowFields,
+): JSONValue {
+  const narrowed = applyPath(rawInput, fields.InputPath, "InputPath");
+
+  return fields.Parameters === undefined
+    ? narrowed
+    : evaluateSimStatesPayloadTemplate(fields.Parameters, narrowed);
+}
+
+/**
+ * The output a state passes to the next one.
+ *
+ * `ResultSelector` reshapes the result, `ResultPath` puts it back into the raw
+ * input, and `OutputPath` narrows what comes out. `ResultPath` reads the raw
+ * input rather than the effective one, so a state can keep fields `InputPath`
+ * had already taken away.
+ */
+export function simStatesEffectiveOutput(
+  rawInput: JSONValue,
+  result: JSONValue,
+  fields: SimStatesDataFlowFields,
+): JSONValue {
+  const selected =
+    fields.ResultSelector === undefined
+      ? result
+      : evaluateSimStatesPayloadTemplate(fields.ResultSelector, result);
+
+  return applyPath(
+    applyResultPath(rawInput, selected, fields.ResultPath),
+    fields.OutputPath,
+    "OutputPath",
+  );
+}
+
+/**
+ * Combine a result with the raw input, as `ResultPath` asks.
+ */
+function applyResultPath(
+  rawInput: JSONValue,
+  result: JSONValue,
+  resultPath: string | null | undefined,
+): JSONValue {
+  if (resultPath === null) {
+    return rawInput;
+  }
+
+  if (resultPath === undefined) {
+    return result;
+  }
+
+  return insertAtSimStatesPath(
+    rawInput,
+    parseSimStatesReferencePath(resultPath),
+    result,
+    resultPath,
+  );
+}
+
+/**
+ * Narrow a value by `InputPath` or `OutputPath`.
+ *
+ * Both read the same way. A path written as `null` answers with an empty
+ * object, an absent one passes the value through, and a path selecting nothing
+ * fails the state.
+ */
+function applyPath(
+  value: JSONValue,
+  path: string | null | undefined,
+  field: string,
+): JSONValue {
+  if (path === null) {
+    return {};
+  }
+
+  if (path === undefined) {
+    return value;
+  }
+
+  const selected = selectSimStatesPath(
+    value,
+    parseSimStatesReferencePath(path),
+  );
+
+  if (selected === undefined) {
+    throw new SimStatesPathMatchFailure(
+      `${field} reads ${path}, which selects nothing in the value the state ` +
+        "was given.",
+    );
+  }
+
+  return selected;
+}

--- a/src/service/stepfunctions/data/sim-states-intrinsic-argument.ts
+++ b/src/service/stepfunctions/data/sim-states-intrinsic-argument.ts
@@ -1,0 +1,116 @@
+// oxlint-disable security/detect-object-injection -- indexes walk the
+// expression string this function is parsing.
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { SimStatesIntrinsicFailure } from "../error/sim-step-functions.error.js";
+
+/**
+ * One argument to an intrinsic function.
+ *
+ * A nested call is held as the text it was written as. It is parsed when the
+ * outer call runs, which keeps parsing and evaluation from having to know
+ * about each other.
+ */
+export type SimStatesIntrinsicArgument =
+  | { readonly kind: "literal"; readonly value: JSONValue }
+  | { readonly kind: "path"; readonly path: string }
+  | { readonly kind: "call"; readonly expression: string };
+
+// oxlint-disable-next-line security/detect-unsafe-regex -- no nested quantifier.
+const numberPattern = /^-?\d+(?:\.\d+)?$/;
+
+/**
+ * Whether a Payload Template value is an intrinsic invocation.
+ *
+ * Amazon States Language gives a `.$` field two possible values, a Reference
+ * Path or an intrinsic, and tells them apart by this prefix.
+ */
+export function isSimStatesIntrinsic(value: string): boolean {
+  return value.startsWith("States.");
+}
+
+/**
+ * Read one argument, which is a literal, a Reference Path or a nested call.
+ */
+export function parseSimStatesIntrinsicArgument(
+  expression: string,
+  argument: string,
+): SimStatesIntrinsicArgument {
+  const trimmed = argument.trim();
+
+  if (trimmed.startsWith("'")) {
+    return { kind: "literal", value: parseStringLiteral(expression, trimmed) };
+  }
+
+  if (isSimStatesIntrinsic(trimmed)) {
+    return { kind: "call", expression: trimmed };
+  }
+
+  if (trimmed.startsWith("$")) {
+    return { kind: "path", path: trimmed };
+  }
+
+  return { kind: "literal", value: parseBareLiteral(expression, trimmed) };
+}
+
+/**
+ * Read a single quoted string, resolving its escapes.
+ *
+ * An escaped brace is left as it was written. Braces mean something to
+ * `States.Format` and nothing to the quoting, so resolving `\{` here would take
+ * away the only thing telling a literal brace apart from a placeholder.
+ * `States.Format` resolves them, and a brace escape reaching another intrinsic
+ * arrives with its backslash. The docs record that divergence.
+ */
+function parseStringLiteral(expression: string, argument: string): string {
+  if (!argument.endsWith("'")) {
+    throw new SimStatesIntrinsicFailure(
+      `${expression} has an unterminated string argument.`,
+    );
+  }
+
+  const body = argument.slice(1, -1);
+  let read = "";
+
+  for (let index = 0; index < body.length; index++) {
+    const character = body.charAt(index);
+
+    if (character === "\\") {
+      const escaped = body.charAt(index + 1);
+
+      read += escaped === "{" || escaped === "}" ? `\\${escaped}` : escaped;
+      index++;
+      continue;
+    }
+
+    read += character;
+  }
+
+  return read;
+}
+
+/**
+ * Read an unquoted argument, which is a number, a boolean or null.
+ */
+function parseBareLiteral(expression: string, argument: string): JSONValue {
+  if (argument === "true") {
+    return true;
+  }
+
+  if (argument === "false") {
+    return false;
+  }
+
+  if (argument === "null") {
+    return null;
+  }
+
+  if (numberPattern.test(argument)) {
+    return Number(argument);
+  }
+
+  throw new SimStatesIntrinsicFailure(
+    `${expression} has an argument this simulator cannot read (${argument}). ` +
+      "An argument is a quoted string, a number, a boolean, null, a " +
+      "Reference Path or another intrinsic.",
+  );
+}

--- a/src/service/stepfunctions/data/sim-states-intrinsic-functions.ts
+++ b/src/service/stepfunctions/data/sim-states-intrinsic-functions.ts
@@ -1,0 +1,115 @@
+// oxlint-disable security/detect-object-injection -- the index counts
+// placeholders in a template this function is reading.
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { SimStatesIntrinsicFailure } from "../error/sim-step-functions.error.js";
+
+/**
+ * What one intrinsic does with its resolved arguments.
+ */
+export type SimStatesIntrinsicFunction = (
+  values: readonly JSONValue[],
+  expression: string,
+) => JSONValue;
+
+/**
+ * The intrinsic functions this simulator answers.
+ *
+ * `States.UUID` and `States.MathRandom` are absent on purpose. Both answer
+ * differently on every call, and a test asserting on the output of a state
+ * machine that used one could only assert on its shape.
+ */
+export const simStatesIntrinsics = new Map<string, SimStatesIntrinsicFunction>([
+  ["States.Format", formatIntrinsic],
+  ["States.Array", (values): JSONValue => [...values]],
+  ["States.ArrayLength", arrayLengthIntrinsic],
+  ["States.StringToJson", stringToJsonIntrinsic],
+  ["States.JsonToString", jsonToStringIntrinsic],
+]);
+
+/**
+ * `States.Format`, which fills each {} placeholder from the arguments in order.
+ */
+function formatIntrinsic(
+  values: readonly JSONValue[],
+  expression: string,
+): JSONValue {
+  const [template, ...fillers] = values;
+
+  if (typeof template !== "string") {
+    throw new SimStatesIntrinsicFailure(
+      `${expression} needs a string as its first argument.`,
+    );
+  }
+
+  let index = 0;
+  const formatted = template.replaceAll(/\\[{}]|\{}/g, (token) => {
+    if (token.startsWith("\\")) {
+      return token.slice(1);
+    }
+
+    const filler = fillers[index];
+    index++;
+
+    return typeof filler === "string" ? filler : JSON.stringify(filler);
+  });
+
+  if (index !== fillers.length) {
+    throw new SimStatesIntrinsicFailure(
+      `${expression} has ${String(fillers.length)} values for ` +
+        `${String(index)} placeholders.`,
+    );
+  }
+
+  return formatted;
+}
+
+/**
+ * `States.ArrayLength`.
+ */
+function arrayLengthIntrinsic(
+  values: readonly JSONValue[],
+  expression: string,
+): JSONValue {
+  const [array] = values;
+
+  if (!Array.isArray(array)) {
+    throw new SimStatesIntrinsicFailure(
+      `${expression} needs an array as its argument.`,
+    );
+  }
+
+  return array.length;
+}
+
+/**
+ * `States.StringToJson`.
+ */
+function stringToJsonIntrinsic(
+  values: readonly JSONValue[],
+  expression: string,
+): JSONValue {
+  const [text] = values;
+
+  if (typeof text !== "string") {
+    throw new SimStatesIntrinsicFailure(
+      `${expression} needs a string as its argument.`,
+    );
+  }
+
+  try {
+    return JSON.parse(text) as JSONValue;
+  } catch {
+    throw new SimStatesIntrinsicFailure(
+      `${expression} was given a string that is not JSON.`,
+    );
+  }
+}
+
+/**
+ * `States.JsonToString`.
+ */
+function jsonToStringIntrinsic(values: readonly JSONValue[]): JSONValue {
+  const [value] = values;
+
+  return JSON.stringify(value ?? null);
+}

--- a/src/service/stepfunctions/data/sim-states-intrinsic-functions.ts
+++ b/src/service/stepfunctions/data/sim-states-intrinsic-functions.ts
@@ -64,13 +64,30 @@ function formatIntrinsic(
 }
 
 /**
+ * Take the one value a single-argument intrinsic was called with.
+ */
+function onlyArgument(
+  values: readonly JSONValue[],
+  expression: string,
+): JSONValue {
+  if (values.length !== 1) {
+    throw new SimStatesIntrinsicFailure(
+      `${expression} takes one argument and was given ` +
+        `${String(values.length)}.`,
+    );
+  }
+
+  return values[0] as JSONValue;
+}
+
+/**
  * `States.ArrayLength`.
  */
 function arrayLengthIntrinsic(
   values: readonly JSONValue[],
   expression: string,
 ): JSONValue {
-  const [array] = values;
+  const array = onlyArgument(values, expression);
 
   if (!Array.isArray(array)) {
     throw new SimStatesIntrinsicFailure(
@@ -88,7 +105,7 @@ function stringToJsonIntrinsic(
   values: readonly JSONValue[],
   expression: string,
 ): JSONValue {
-  const [text] = values;
+  const text = onlyArgument(values, expression);
 
   if (typeof text !== "string") {
     throw new SimStatesIntrinsicFailure(
@@ -108,8 +125,9 @@ function stringToJsonIntrinsic(
 /**
  * `States.JsonToString`.
  */
-function jsonToStringIntrinsic(values: readonly JSONValue[]): JSONValue {
-  const [value] = values;
-
-  return JSON.stringify(value ?? null);
+function jsonToStringIntrinsic(
+  values: readonly JSONValue[],
+  expression: string,
+): JSONValue {
+  return JSON.stringify(onlyArgument(values, expression));
 }

--- a/src/service/stepfunctions/data/sim-states-intrinsic-parse.ts
+++ b/src/service/stepfunctions/data/sim-states-intrinsic-parse.ts
@@ -1,0 +1,100 @@
+import { SimStatesIntrinsicFailure } from "../error/sim-step-functions.error.js";
+import {
+  type SimStatesIntrinsicArgument,
+  parseSimStatesIntrinsicArgument,
+} from "./sim-states-intrinsic-argument.js";
+
+/**
+ * A parsed intrinsic function invocation.
+ */
+export interface SimStatesIntrinsicCall {
+  readonly name: string;
+  readonly arguments: readonly SimStatesIntrinsicArgument[];
+}
+
+const bracketDepths = new Map([
+  ["(", 1],
+  [")", -1],
+]);
+
+/**
+ * Parse an intrinsic invocation into its name and arguments.
+ */
+export function parseSimStatesIntrinsic(
+  expression: string,
+): SimStatesIntrinsicCall {
+  const trimmed = expression.trim();
+  const open = trimmed.indexOf("(");
+
+  if (open === -1 || !trimmed.endsWith(")")) {
+    throw new SimStatesIntrinsicFailure(
+      `${expression} is not an intrinsic function call. One is written as ` +
+        "States.Name(arguments).",
+    );
+  }
+
+  return {
+    name: trimmed.slice(0, open),
+    arguments: splitArguments(expression, trimmed.slice(open + 1, -1)).map(
+      (argument) => parseSimStatesIntrinsicArgument(expression, argument),
+    ),
+  };
+}
+
+/**
+ * Split an argument list on the commas that separate arguments.
+ *
+ * A comma inside a quoted string or inside a nested call belongs to that
+ * argument, so depth and quoting are both tracked while scanning.
+ */
+function splitArguments(expression: string, inner: string): readonly string[] {
+  if (inner.trim() === "") {
+    return [];
+  }
+
+  const argumentTexts: string[] = [];
+  let current = "";
+  let depth = 0;
+  let quoted = false;
+
+  for (let index = 0; index < inner.length; index++) {
+    const character = inner.charAt(index);
+
+    if (quoted) {
+      current += character;
+
+      if (character === "\\") {
+        current += inner.charAt(index + 1);
+        index++;
+      } else if (character === "'") {
+        quoted = false;
+      }
+
+      continue;
+    }
+
+    if (character === "," && depth === 0) {
+      argumentTexts.push(current);
+      current = "";
+      continue;
+    }
+
+    if (character === "'") {
+      quoted = true;
+    } else {
+      depth += bracketDepths.get(character) ?? 0;
+    }
+
+    current += character;
+  }
+
+  if (quoted || depth !== 0) {
+    throw new SimStatesIntrinsicFailure(
+      `${expression} has an unclosed quote or bracket in its arguments.`,
+    );
+  }
+
+  argumentTexts.push(current);
+
+  return argumentTexts;
+}

--- a/src/service/stepfunctions/data/sim-states-intrinsic-refusals.iso.test.ts
+++ b/src/service/stepfunctions/data/sim-states-intrinsic-refusals.iso.test.ts
@@ -1,0 +1,79 @@
+import { assertStringIncludes, assertThrowsError } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { evaluateSimStatesIntrinsic } from "./sim-states-intrinsic.js";
+
+const enrolment = {
+  student: { name: "Wei", terms: [1, 2, 3] },
+  payload: '{"eligible":true}',
+};
+
+/**
+ * Run an intrinsic that is expected to fail, and answer with why it did.
+ */
+function refusalFor(expression: string): string {
+  return assertThrowsError(() =>
+    evaluateSimStatesIntrinsic(expression, enrolment),
+  ).message;
+}
+
+describe("Step Functions intrinsic function refusals", () => {
+  it("refuses an intrinsic this simulator does not answer", () => {
+    // Given a call to one left out on purpose.
+    // When it runs, the refusal lists what is answered.
+    assertStringIncludes(refusalFor("States.UUID()"), "States.Format");
+  });
+
+  it("refuses a call whose placeholders and arguments disagree", () => {
+    // Given two placeholders and one argument.
+    // When it runs, the count is refused.
+    assertStringIncludes(
+      refusalFor("States.Format('{} {}', 'one')"),
+      "placeholders",
+    );
+  });
+
+  it("refuses a path argument selecting nothing", () => {
+    // Given a path the document has no value at.
+    // When it runs, the failure names the path.
+    assertStringIncludes(
+      refusalFor("States.ArrayLength($.absent)"),
+      "$.absent",
+    );
+  });
+
+  it("refuses arguments of the wrong type", () => {
+    // Given calls given the wrong shape of value.
+    // When each runs, each says what it needed.
+    for (const expression of [
+      "States.Format($.student.terms)",
+      "States.ArrayLength($.student.name)",
+      "States.StringToJson($.student.terms)",
+    ]) {
+      assertStringIncludes(refusalFor(expression), "needs");
+    }
+  });
+
+  it("refuses a string that is not JSON", () => {
+    // Given a value that will not parse.
+    // When it is read as JSON, the failure says so.
+    assertStringIncludes(
+      refusalFor("States.StringToJson($.student.name)"),
+      "not JSON",
+    );
+  });
+
+  it("refuses a single-argument intrinsic given the wrong number", () => {
+    // Given calls with no argument and with two.
+    // When each runs, each says how many it takes.
+    for (const expression of [
+      "States.JsonToString()",
+      "States.StringToJson()",
+      "States.ArrayLength()",
+      "States.JsonToString($.student, $.payload)",
+      "States.StringToJson($.payload, $.payload)",
+      "States.ArrayLength($.student.terms, $.student.terms)",
+    ]) {
+      assertStringIncludes(refusalFor(expression), "takes one argument");
+    }
+  });
+});

--- a/src/service/stepfunctions/data/sim-states-intrinsic-syntax-refusals.iso.test.ts
+++ b/src/service/stepfunctions/data/sim-states-intrinsic-syntax-refusals.iso.test.ts
@@ -1,0 +1,58 @@
+import { assertStringIncludes, assertThrowsError } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { evaluateSimStatesIntrinsic } from "./sim-states-intrinsic.js";
+
+const enrolment = {
+  student: { name: "Wei", terms: [1, 2, 3] },
+  payload: '{"eligible":true}',
+};
+
+describe("Step Functions intrinsic syntax refusals", () => {
+  it("refuses an expression that is not a call at all", () => {
+    // Given text with no argument list.
+    // When it runs.
+    const error = assertThrowsError(() =>
+      evaluateSimStatesIntrinsic("States.Format", enrolment),
+    );
+
+    // Then it is refused by shape.
+    assertStringIncludes(error.message, "States.Name(arguments)");
+  });
+
+  it("refuses an unclosed argument list and an unreadable argument", () => {
+    // Given a call missing its closing bracket, and one given a bare word.
+    // When each runs.
+    const unclosed = assertThrowsError(() =>
+      evaluateSimStatesIntrinsic("States.Array('one'", enrolment),
+    );
+    const bare = assertThrowsError(() =>
+      evaluateSimStatesIntrinsic("States.Array(one)", enrolment),
+    );
+
+    // Then each is refused.
+    assertStringIncludes(unclosed.message, "States.Name(arguments)");
+    assertStringIncludes(bare.message, "cannot read");
+  });
+
+  it("refuses an argument list whose quote never closes", () => {
+    // Given a call whose closing bracket falls inside a string.
+    // When it runs.
+    const error = assertThrowsError(() =>
+      evaluateSimStatesIntrinsic("States.Array('one)", enrolment),
+    );
+
+    // Then the unclosed quote is refused.
+    assertStringIncludes(error.message, "unclosed quote or bracket");
+  });
+
+  it("refuses a string argument with trailing text after its quote", () => {
+    // Given an argument that stops being a string partway through.
+    // When it runs.
+    const error = assertThrowsError(() =>
+      evaluateSimStatesIntrinsic("States.Array('one'two)", enrolment),
+    );
+
+    // Then it is refused as unterminated.
+    assertStringIncludes(error.message, "unterminated string");
+  });
+});

--- a/src/service/stepfunctions/data/sim-states-intrinsic.iso.test.ts
+++ b/src/service/stepfunctions/data/sim-states-intrinsic.iso.test.ts
@@ -1,0 +1,276 @@
+import {
+  assertIdentical,
+  assertObjectEquals,
+  assertStringIncludes,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { evaluateSimStatesIntrinsic } from "./sim-states-intrinsic.js";
+
+const enrolment = {
+  student: { name: "Wei", terms: [1, 2, 3] },
+  payload: '{"eligible":true}',
+};
+
+describe("Step Functions intrinsic functions", () => {
+  it("fills States.Format placeholders from its arguments in order", () => {
+    // Given a document naming a student.
+    // When a message is formatted from a literal and a path.
+    const formatted = evaluateSimStatesIntrinsic(
+      "States.Format('Enrolled {} for term {}', $.student.name, 3)",
+      enrolment,
+    );
+
+    // Then each placeholder took the argument in its position.
+    assertIdentical(formatted, "Enrolled Wei for term 3");
+  });
+
+  it("writes a non-string States.Format argument as JSON", () => {
+    // Given a document holding an array.
+    // When it fills a placeholder.
+    const formatted = evaluateSimStatesIntrinsic(
+      "States.Format('Terms {}', $.student.terms)",
+      enrolment,
+    );
+
+    // Then it arrives as JSON rather than as a comma-joined string.
+    assertIdentical(formatted, "Terms [1,2,3]");
+  });
+
+  it("leaves an escaped placeholder alone", () => {
+    // Given a template escaping its braces.
+    // When it is formatted.
+    const formatted = evaluateSimStatesIntrinsic(
+      String.raw`States.Format('\{} is {}', $.student.name)`,
+      enrolment,
+    );
+
+    // Then the escaped braces are literal and the plain one is filled.
+    assertIdentical(formatted, "{} is Wei");
+  });
+
+  it("builds an array with States.Array", () => {
+    // Given literals and a path.
+    // When an array is built.
+    const built = evaluateSimStatesIntrinsic(
+      "States.Array($.student.name, 'Mei', true, null)",
+      enrolment,
+    );
+
+    // Then each argument is an element, in order.
+    assertObjectEquals(built, ["Wei", "Mei", true, null]);
+  });
+
+  it("counts an array with States.ArrayLength", () => {
+    // Given a document holding an array.
+    // When its length is taken.
+    const length = evaluateSimStatesIntrinsic(
+      "States.ArrayLength($.student.terms)",
+      enrolment,
+    );
+
+    // Then the count comes back.
+    assertIdentical(length, 3);
+  });
+
+  it("moves between JSON and strings both ways", () => {
+    // Given a document holding JSON as a string.
+    // When it is parsed and then written back.
+    const parsed = evaluateSimStatesIntrinsic(
+      "States.StringToJson($.payload)",
+      enrolment,
+    );
+    const written = evaluateSimStatesIntrinsic(
+      "States.JsonToString($.student.terms)",
+      enrolment,
+    );
+
+    // Then each answers in the other form.
+    assertObjectEquals(parsed, { eligible: true });
+    assertIdentical(written, "[1,2,3]");
+  });
+
+  it("runs an intrinsic nested inside another", () => {
+    // Given a call whose argument is itself a call.
+    // When it runs.
+    const formatted = evaluateSimStatesIntrinsic(
+      "States.Format('{} terms', States.ArrayLength($.student.terms))",
+      enrolment,
+    );
+
+    // Then the inner call answered first.
+    assertIdentical(formatted, "3 terms");
+  });
+
+  it("keeps a comma inside a quoted argument", () => {
+    // Given a template holding a comma.
+    // When it is formatted.
+    const formatted = evaluateSimStatesIntrinsic(
+      "States.Format('Wei, Mei and {}', 'Lan')",
+      enrolment,
+    );
+
+    // Then the comma stayed inside the one argument.
+    assertIdentical(formatted, "Wei, Mei and Lan");
+  });
+
+  it("reads an escaped quote inside a string argument", () => {
+    // Given an argument carrying a quote.
+    // When it is formatted.
+    const formatted = evaluateSimStatesIntrinsic(
+      String.raw`States.Format('it\'s {}', $.student.name)`,
+      enrolment,
+    );
+
+    // Then the quote is part of the string.
+    assertIdentical(formatted, "it's Wei");
+  });
+
+  it("refuses an intrinsic this simulator does not answer", () => {
+    // Given a call to one that is left out on purpose.
+    // When it runs.
+    const error = assertThrowsError(() =>
+      evaluateSimStatesIntrinsic("States.UUID()", enrolment),
+    );
+
+    // Then the refusal lists what is answered.
+    assertStringIncludes(error.message, "States.Format");
+  });
+
+  it("refuses a call whose placeholders and arguments disagree", () => {
+    // Given two placeholders and one argument.
+    // When it runs.
+    const error = assertThrowsError(() =>
+      evaluateSimStatesIntrinsic("States.Format('{} {}', 'one')", enrolment),
+    );
+
+    // Then the count is refused.
+    assertStringIncludes(error.message, "placeholders");
+  });
+
+  it("refuses a path argument selecting nothing", () => {
+    // Given a path the document has no value at.
+    // When it runs.
+    const error = assertThrowsError(() =>
+      evaluateSimStatesIntrinsic("States.ArrayLength($.absent)", enrolment),
+    );
+
+    // Then the failure names the path.
+    assertStringIncludes(error.message, "$.absent");
+  });
+
+  it("refuses arguments of the wrong type", () => {
+    // Given calls given the wrong shape of value.
+    const refused = [
+      "States.Format($.student.terms)",
+      "States.ArrayLength($.student.name)",
+      "States.StringToJson($.student.terms)",
+    ];
+
+    // When each runs.
+    const errors = refused.map((expression) =>
+      assertThrowsError(() =>
+        evaluateSimStatesIntrinsic(expression, enrolment),
+      ),
+    );
+
+    // Then each says what it needed.
+    for (const error of errors) {
+      assertStringIncludes(error.message, "needs");
+    }
+  });
+
+  it("refuses a string that is not JSON", () => {
+    // Given a document holding something that will not parse.
+    // When it is read as JSON.
+    const error = assertThrowsError(() =>
+      evaluateSimStatesIntrinsic("States.StringToJson($.student.name)", {
+        student: { name: "Wei" },
+      }),
+    );
+
+    // Then the failure says so.
+    assertStringIncludes(error.message, "not JSON");
+  });
+
+  it("refuses an expression that is not a call at all", () => {
+    // Given text with no argument list.
+    // When it runs.
+    const error = assertThrowsError(() =>
+      evaluateSimStatesIntrinsic("States.Format", enrolment),
+    );
+
+    // Then it is refused by shape.
+    assertStringIncludes(error.message, "States.Name(arguments)");
+  });
+
+  it("refuses an unclosed argument list and an unreadable argument", () => {
+    // Given a call missing its closing bracket, and one given a bare word.
+    // When each runs.
+    const unclosed = assertThrowsError(() =>
+      evaluateSimStatesIntrinsic("States.Array('one'", enrolment),
+    );
+    const bare = assertThrowsError(() =>
+      evaluateSimStatesIntrinsic("States.Array(one)", enrolment),
+    );
+
+    // Then each is refused.
+    assertStringIncludes(unclosed.message, "States.Name(arguments)");
+    assertStringIncludes(bare.message, "cannot read");
+  });
+
+  it("builds an empty array from a call with no arguments", () => {
+    // Given a call with an empty argument list.
+    // When it runs.
+    const built = evaluateSimStatesIntrinsic("States.Array()", enrolment);
+
+    // Then it answers with an empty array.
+    assertObjectEquals(built, []);
+  });
+
+  it("reads false as a literal argument", () => {
+    // Given a call given each bare literal.
+    // When it runs.
+    const built = evaluateSimStatesIntrinsic(
+      "States.Array(false, true, null, -2.5)",
+      enrolment,
+    );
+
+    // Then each arrives as the value it names.
+    assertObjectEquals(built, [false, true, null, -2.5]);
+  });
+
+  it("writes null for a States.JsonToString call given no argument", () => {
+    // Given a call with nothing to write.
+    // When it runs.
+    const written = evaluateSimStatesIntrinsic(
+      "States.JsonToString()",
+      enrolment,
+    );
+
+    // Then it answers with the JSON null.
+    assertIdentical(written, "null");
+  });
+
+  it("refuses an argument list whose quote never closes", () => {
+    // Given a call whose closing bracket falls inside a string.
+    // When it runs.
+    const error = assertThrowsError(() =>
+      evaluateSimStatesIntrinsic("States.Array('one)", enrolment),
+    );
+
+    // Then the unclosed quote is refused.
+    assertStringIncludes(error.message, "unclosed quote or bracket");
+  });
+
+  it("refuses a string argument with trailing text after its quote", () => {
+    // Given an argument that stops being a string partway through.
+    // When it runs.
+    const error = assertThrowsError(() =>
+      evaluateSimStatesIntrinsic("States.Array('one'two)", enrolment),
+    );
+
+    // Then it is refused as unterminated.
+    assertStringIncludes(error.message, "unterminated string");
+  });
+});

--- a/src/service/stepfunctions/data/sim-states-intrinsic.iso.test.ts
+++ b/src/service/stepfunctions/data/sim-states-intrinsic.iso.test.ts
@@ -1,9 +1,4 @@
-import {
-  assertIdentical,
-  assertObjectEquals,
-  assertStringIncludes,
-  assertThrowsError,
-} from "@kensio/smartass";
+import { assertIdentical, assertObjectEquals } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { evaluateSimStatesIntrinsic } from "./sim-states-intrinsic.js";
 
@@ -126,99 +121,6 @@ describe("Step Functions intrinsic functions", () => {
     assertIdentical(formatted, "it's Wei");
   });
 
-  it("refuses an intrinsic this simulator does not answer", () => {
-    // Given a call to one that is left out on purpose.
-    // When it runs.
-    const error = assertThrowsError(() =>
-      evaluateSimStatesIntrinsic("States.UUID()", enrolment),
-    );
-
-    // Then the refusal lists what is answered.
-    assertStringIncludes(error.message, "States.Format");
-  });
-
-  it("refuses a call whose placeholders and arguments disagree", () => {
-    // Given two placeholders and one argument.
-    // When it runs.
-    const error = assertThrowsError(() =>
-      evaluateSimStatesIntrinsic("States.Format('{} {}', 'one')", enrolment),
-    );
-
-    // Then the count is refused.
-    assertStringIncludes(error.message, "placeholders");
-  });
-
-  it("refuses a path argument selecting nothing", () => {
-    // Given a path the document has no value at.
-    // When it runs.
-    const error = assertThrowsError(() =>
-      evaluateSimStatesIntrinsic("States.ArrayLength($.absent)", enrolment),
-    );
-
-    // Then the failure names the path.
-    assertStringIncludes(error.message, "$.absent");
-  });
-
-  it("refuses arguments of the wrong type", () => {
-    // Given calls given the wrong shape of value.
-    const refused = [
-      "States.Format($.student.terms)",
-      "States.ArrayLength($.student.name)",
-      "States.StringToJson($.student.terms)",
-    ];
-
-    // When each runs.
-    const errors = refused.map((expression) =>
-      assertThrowsError(() =>
-        evaluateSimStatesIntrinsic(expression, enrolment),
-      ),
-    );
-
-    // Then each says what it needed.
-    for (const error of errors) {
-      assertStringIncludes(error.message, "needs");
-    }
-  });
-
-  it("refuses a string that is not JSON", () => {
-    // Given a document holding something that will not parse.
-    // When it is read as JSON.
-    const error = assertThrowsError(() =>
-      evaluateSimStatesIntrinsic("States.StringToJson($.student.name)", {
-        student: { name: "Wei" },
-      }),
-    );
-
-    // Then the failure says so.
-    assertStringIncludes(error.message, "not JSON");
-  });
-
-  it("refuses an expression that is not a call at all", () => {
-    // Given text with no argument list.
-    // When it runs.
-    const error = assertThrowsError(() =>
-      evaluateSimStatesIntrinsic("States.Format", enrolment),
-    );
-
-    // Then it is refused by shape.
-    assertStringIncludes(error.message, "States.Name(arguments)");
-  });
-
-  it("refuses an unclosed argument list and an unreadable argument", () => {
-    // Given a call missing its closing bracket, and one given a bare word.
-    // When each runs.
-    const unclosed = assertThrowsError(() =>
-      evaluateSimStatesIntrinsic("States.Array('one'", enrolment),
-    );
-    const bare = assertThrowsError(() =>
-      evaluateSimStatesIntrinsic("States.Array(one)", enrolment),
-    );
-
-    // Then each is refused.
-    assertStringIncludes(unclosed.message, "States.Name(arguments)");
-    assertStringIncludes(bare.message, "cannot read");
-  });
-
   it("builds an empty array from a call with no arguments", () => {
     // Given a call with an empty argument list.
     // When it runs.
@@ -238,39 +140,5 @@ describe("Step Functions intrinsic functions", () => {
 
     // Then each arrives as the value it names.
     assertObjectEquals(built, [false, true, null, -2.5]);
-  });
-
-  it("writes null for a States.JsonToString call given no argument", () => {
-    // Given a call with nothing to write.
-    // When it runs.
-    const written = evaluateSimStatesIntrinsic(
-      "States.JsonToString()",
-      enrolment,
-    );
-
-    // Then it answers with the JSON null.
-    assertIdentical(written, "null");
-  });
-
-  it("refuses an argument list whose quote never closes", () => {
-    // Given a call whose closing bracket falls inside a string.
-    // When it runs.
-    const error = assertThrowsError(() =>
-      evaluateSimStatesIntrinsic("States.Array('one)", enrolment),
-    );
-
-    // Then the unclosed quote is refused.
-    assertStringIncludes(error.message, "unclosed quote or bracket");
-  });
-
-  it("refuses a string argument with trailing text after its quote", () => {
-    // Given an argument that stops being a string partway through.
-    // When it runs.
-    const error = assertThrowsError(() =>
-      evaluateSimStatesIntrinsic("States.Array('one'two)", enrolment),
-    );
-
-    // Then it is refused as unterminated.
-    assertStringIncludes(error.message, "unterminated string");
   });
 });

--- a/src/service/stepfunctions/data/sim-states-intrinsic.ts
+++ b/src/service/stepfunctions/data/sim-states-intrinsic.ts
@@ -1,0 +1,70 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { SimStatesIntrinsicFailure } from "../error/sim-step-functions.error.js";
+import type { SimStatesIntrinsicArgument } from "./sim-states-intrinsic-argument.js";
+import { simStatesIntrinsics } from "./sim-states-intrinsic-functions.js";
+import { parseSimStatesIntrinsic } from "./sim-states-intrinsic-parse.js";
+import { selectSimStatesPath } from "./sim-states-path-segment.js";
+import { parseSimStatesReferencePath } from "./sim-states-reference-path.js";
+
+/**
+ * The names this simulator answers, for a message listing them.
+ */
+export const simStatesIntrinsicNames: readonly string[] = simStatesIntrinsics
+  .keys()
+  .toArray();
+
+/**
+ * Run an intrinsic function against the document its paths read from.
+ */
+export function evaluateSimStatesIntrinsic(
+  expression: string,
+  document: JSONValue,
+): JSONValue {
+  const call = parseSimStatesIntrinsic(expression);
+  const intrinsic = simStatesIntrinsics.get(call.name);
+
+  if (intrinsic === undefined) {
+    throw new SimStatesIntrinsicFailure(
+      `${call.name} is not an intrinsic function this simulator answers. It ` +
+        `answers ${simStatesIntrinsicNames.join(", ")}.`,
+    );
+  }
+
+  return intrinsic(
+    call.arguments.map((argument) =>
+      resolveArgument(argument, document, expression),
+    ),
+    expression,
+  );
+}
+
+/**
+ * Reduce one argument to the value the intrinsic receives.
+ */
+function resolveArgument(
+  argument: SimStatesIntrinsicArgument,
+  document: JSONValue,
+  expression: string,
+): JSONValue {
+  if (argument.kind === "literal") {
+    return argument.value;
+  }
+
+  if (argument.kind === "call") {
+    return evaluateSimStatesIntrinsic(argument.expression, document);
+  }
+
+  const selected = selectSimStatesPath(
+    document,
+    parseSimStatesReferencePath(argument.path),
+  );
+
+  if (selected === undefined) {
+    throw new SimStatesIntrinsicFailure(
+      `${expression} reads ${argument.path}, which selects nothing in the ` +
+        "value it was given.",
+    );
+  }
+
+  return selected;
+}

--- a/src/service/stepfunctions/data/sim-states-path-segment.ts
+++ b/src/service/stepfunctions/data/sim-states-path-segment.ts
@@ -1,0 +1,47 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { isRecord } from "../../../util/type-guard/record.js";
+
+/**
+ * One step along a Reference Path.
+ */
+export type SimStatesPathSegment =
+  | { readonly kind: "field"; readonly name: string }
+  | { readonly kind: "index"; readonly index: number };
+
+/**
+ * The value a Reference Path selects, or undefined where it selects nothing.
+ *
+ * Selecting nothing is the ordinary case rather than a fault. A `Choice` rule
+ * testing `IsPresent` wants to know, and only the callers that need a value
+ * turn the absence into a failure.
+ */
+export function selectSimStatesPath(
+  document: JSONValue,
+  segments: readonly SimStatesPathSegment[],
+): JSONValue | undefined {
+  let current: JSONValue | undefined = document;
+
+  for (const segment of segments) {
+    current = selectSegment(current, segment);
+
+    if (current === undefined) {
+      return undefined;
+    }
+  }
+
+  return current;
+}
+
+/**
+ * Step one segment into a value.
+ */
+function selectSegment(
+  current: JSONValue | undefined,
+  segment: SimStatesPathSegment,
+): JSONValue | undefined {
+  if (segment.kind === "index") {
+    return Array.isArray(current) ? current[segment.index] : undefined;
+  }
+
+  return isRecord(current) ? current[segment.name] : undefined;
+}

--- a/src/service/stepfunctions/data/sim-states-path-segment.ts
+++ b/src/service/stepfunctions/data/sim-states-path-segment.ts
@@ -34,6 +34,11 @@ export function selectSimStatesPath(
 
 /**
  * Step one segment into a value.
+ *
+ * A field is read only where the object owns it. A Reference Path identifies a
+ * node in JSON data, and `$.toString` names a field a JSON document either has
+ * or has not got. Reading the prototype chain would answer that path with a
+ * JavaScript function.
  */
 function selectSegment(
   current: JSONValue | undefined,
@@ -43,5 +48,9 @@ function selectSegment(
     return Array.isArray(current) ? current[segment.index] : undefined;
   }
 
-  return isRecord(current) ? current[segment.name] : undefined;
+  if (!isRecord(current) || !Object.hasOwn(current, segment.name)) {
+    return undefined;
+  }
+
+  return current[segment.name];
 }

--- a/src/service/stepfunctions/data/sim-states-payload-template.ts
+++ b/src/service/stepfunctions/data/sim-states-payload-template.ts
@@ -1,0 +1,89 @@
+// oxlint-disable security/detect-object-injection -- keys come from the
+// Payload Template being evaluated, into an object built here.
+import type { JSONObject, JSONValue } from "../../../util/type-guard/json.js";
+import { isRecord } from "../../../util/type-guard/record.js";
+import {
+  SimStatesPathMatchFailure,
+  SimStatesUnsimulatedInput,
+} from "../error/sim-step-functions.error.js";
+import { isSimStatesIntrinsic } from "./sim-states-intrinsic-argument.js";
+import { evaluateSimStatesIntrinsic } from "./sim-states-intrinsic.js";
+import { selectSimStatesPath } from "./sim-states-path-segment.js";
+import { parseSimStatesReferencePath } from "./sim-states-reference-path.js";
+
+const resolvedKeySuffix = ".$";
+
+/**
+ * Build a value from a Payload Template.
+ *
+ * `Parameters` and `ResultSelector` are both Payload Templates. A field whose
+ * name ends in `.$` takes its value from a Reference Path or an intrinsic
+ * function, and the `.$` comes off the name. Every other field is copied as it
+ * stands, with objects and arrays walked so a `.$` field nested inside one is
+ * still resolved.
+ */
+export function evaluateSimStatesPayloadTemplate(
+  template: JSONValue,
+  document: JSONValue,
+): JSONValue {
+  if (Array.isArray(template)) {
+    return template.map((element) =>
+      evaluateSimStatesPayloadTemplate(element, document),
+    );
+  }
+
+  if (!isRecord(template)) {
+    return template;
+  }
+
+  const built: JSONObject = {};
+
+  for (const [key, value] of Object.entries(template)) {
+    if (key.endsWith(resolvedKeySuffix)) {
+      built[key.slice(0, -resolvedKeySuffix.length)] = resolveField(
+        key,
+        value,
+        document,
+      );
+      continue;
+    }
+
+    built[key] = evaluateSimStatesPayloadTemplate(value, document);
+  }
+
+  return built;
+}
+
+/**
+ * Resolve one `.$` field to the value it names.
+ */
+function resolveField(
+  key: string,
+  value: JSONValue,
+  document: JSONValue,
+): JSONValue {
+  if (typeof value !== "string") {
+    throw new SimStatesUnsimulatedInput(
+      `${key} ends in .$, so its value has to be a Reference Path or an ` +
+        "intrinsic function written as a string.",
+    );
+  }
+
+  if (isSimStatesIntrinsic(value)) {
+    return evaluateSimStatesIntrinsic(value, document);
+  }
+
+  const selected = selectSimStatesPath(
+    document,
+    parseSimStatesReferencePath(value),
+  );
+
+  if (selected === undefined) {
+    throw new SimStatesPathMatchFailure(
+      `${key} reads ${value}, which selects nothing in the value the state ` +
+        "was given.",
+    );
+  }
+
+  return selected;
+}

--- a/src/service/stepfunctions/data/sim-states-payload-template.ts
+++ b/src/service/stepfunctions/data/sim-states-payload-template.ts
@@ -39,16 +39,19 @@ export function evaluateSimStatesPayloadTemplate(
   const built: JSONObject = {};
 
   for (const [key, value] of Object.entries(template)) {
-    if (key.endsWith(resolvedKeySuffix)) {
-      built[key.slice(0, -resolvedKeySuffix.length)] = resolveField(
-        key,
-        value,
-        document,
+    const resolved = key.endsWith(resolvedKeySuffix);
+    const field = resolved ? key.slice(0, -resolvedKeySuffix.length) : key;
+
+    if (Object.hasOwn(built, field)) {
+      throw new SimStatesUnsimulatedInput(
+        `${key} and another field of this Payload Template both build ` +
+          `${field}, so one of them would be lost.`,
       );
-      continue;
     }
 
-    built[key] = evaluateSimStatesPayloadTemplate(value, document);
+    built[field] = resolved
+      ? resolveField(key, value, document)
+      : evaluateSimStatesPayloadTemplate(value, document);
   }
 
   return built;

--- a/src/service/stepfunctions/data/sim-states-reference-path-refusals.iso.test.ts
+++ b/src/service/stepfunctions/data/sim-states-reference-path-refusals.iso.test.ts
@@ -1,0 +1,90 @@
+import { assertStringIncludes, assertThrowsError } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { parseSimStatesReferencePath } from "./sim-states-reference-path.js";
+
+describe("Step Functions Reference Path refusals", () => {
+  it("refuses a path that is not rooted at the document", () => {
+    // Given a path with no root.
+    // When it is parsed.
+    const error = assertThrowsError(() =>
+      parseSimStatesReferencePath("enrolment.student"),
+    );
+
+    // Then it is refused by name.
+    assertStringIncludes(error.message, "has to start with $");
+  });
+
+  it("refuses the context object by name", () => {
+    // Given a path reading the context object.
+    // When it is parsed.
+    const error = assertThrowsError(() =>
+      parseSimStatesReferencePath("$$.Execution.Name"),
+    );
+
+    // Then the refusal says what it is.
+    assertStringIncludes(error.message, "context object");
+  });
+
+  it("refuses the JSONPath grammar Amazon States Language does not use", () => {
+    // Given paths using a wildcard, a filter and a slice.
+    const refused = ["$.students[*].name", "$.students[?(@.age>3)]", "$[0:2]"];
+
+    // When each is parsed.
+    const errors = refused.map((path) =>
+      assertThrowsError(() => parseSimStatesReferencePath(path)),
+    );
+
+    // Then each is refused rather than read as something else.
+    for (const error of errors) {
+      assertStringIncludes(error.message, "does not read");
+    }
+  });
+
+  it("refuses a dotted field name holding punctuation", () => {
+    // Given names outside the member-name-shorthand rule.
+    const refused = ["$.a?b", "$.a-b", "$.a@b"];
+
+    // When each is parsed.
+    const errors = refused.map((path) =>
+      assertThrowsError(() => parseSimStatesReferencePath(path)),
+    );
+
+    // Then each points at bracket notation.
+    for (const error of errors) {
+      assertStringIncludes(error.message, "written in brackets");
+    }
+  });
+
+  it("refuses a root followed by something that is not a separator", () => {
+    // Given a path running a name straight on from the root.
+    // When it is parsed.
+    const error = assertThrowsError(() =>
+      parseSimStatesReferencePath("$enrolment"),
+    );
+
+    // Then it says what it expected.
+    assertStringIncludes(error.message, "Expected . or [");
+  });
+
+  it("refuses a dotted wildcard", () => {
+    // Given a path selecting every field of an object.
+    // When it is parsed.
+    const error = assertThrowsError(() =>
+      parseSimStatesReferencePath("$.students.*"),
+    );
+
+    // Then the wildcard is refused.
+    assertStringIncludes(error.message, "written in brackets");
+  });
+
+  it("refuses a path with nothing between its separators", () => {
+    // Given a path with an empty segment.
+    // When it is parsed.
+    const error = assertThrowsError(() =>
+      parseSimStatesReferencePath("$.enrolment..student"),
+    );
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "member-name-shorthand");
+  });
+});

--- a/src/service/stepfunctions/data/sim-states-reference-path.iso.test.ts
+++ b/src/service/stepfunctions/data/sim-states-reference-path.iso.test.ts
@@ -1,0 +1,173 @@
+import {
+  assertIdentical,
+  assertObjectEquals,
+  assertStringIncludes,
+  assertThrowsError,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { selectSimStatesPath } from "./sim-states-path-segment.js";
+import { parseSimStatesReferencePath } from "./sim-states-reference-path.js";
+
+/**
+ * Read a path against a document in one step, the way a state does.
+ */
+function select(document: JSONValue, path: string): JSONValue | undefined {
+  return selectSimStatesPath(document, parseSimStatesReferencePath(path));
+}
+
+describe("Step Functions Reference Paths", () => {
+  it("selects the whole document for the root", () => {
+    // Given a document.
+    const document = { student: "Wei", term: 3 };
+
+    // When the root is selected.
+    const selected = select(document, "$");
+
+    // Then the document itself comes back.
+    assertObjectEquals(selected, document);
+  });
+
+  it("selects a field by dot and by bracket alike", () => {
+    // Given a nested document.
+    const document = { enrolment: { student: { name: "Wei" } } };
+
+    // When the same field is read both ways.
+    const dotted = select(document, "$.enrolment.student.name");
+    const bracketed = select(document, "$['enrolment']['student']['name']");
+
+    // Then both select it.
+    assertIdentical(dotted, "Wei");
+    assertIdentical(bracketed, "Wei");
+  });
+
+  it("selects an array element by index", () => {
+    // Given a document holding an array.
+    const document = { students: [{ name: "Wei" }, { name: "Mei" }] };
+
+    // When the second element's field is read.
+    const selected = select(document, "$.students[1].name");
+
+    // Then that element answers.
+    assertIdentical(selected, "Mei");
+  });
+
+  it("reads a field name holding a dot when it is bracketed", () => {
+    // Given a document whose field name has a dot in it.
+    const document = { "student.name": "Wei" };
+
+    // When the bracketed form reads it.
+    const selected = select(document, "$['student.name']");
+
+    // Then the whole name is one segment.
+    assertIdentical(selected, "Wei");
+  });
+
+  it("reads an escaped quote inside a bracketed field name", () => {
+    // Given a field name carrying a quote.
+    const document = { "it's": "Wei" };
+
+    // When the escaped form reads it.
+    const selected = select(document, String.raw`$['it\'s']`);
+
+    // Then the quote is part of the name.
+    assertIdentical(selected, "Wei");
+  });
+
+  it("selects nothing where the document holds nothing at the path", () => {
+    // Given a document without the field.
+    const document = { enrolment: { student: "Wei" } };
+
+    // When a missing field, a missing index and a field of a string are read.
+    const missingField = select(document, "$.enrolment.term");
+    const missingIndex = select(document, "$.enrolment[3]");
+    const throughString = select(document, "$.enrolment.student.name");
+
+    // Then each answers with nothing rather than failing.
+    assertUndefined(missingField);
+    assertUndefined(missingIndex);
+    assertUndefined(throughString);
+  });
+
+  it("selects nothing for an index into something that is not an array", () => {
+    // Given a document whose field holds an object.
+    const document = { enrolment: { student: "Wei" } };
+
+    // When it is read as an array.
+    const selected = select(document, "$.enrolment[0]");
+
+    // Then nothing is selected.
+    assertUndefined(selected);
+  });
+
+  it("refuses a path that is not rooted at the document", () => {
+    // Given a path with no root.
+    // When it is parsed.
+    const error = assertThrowsError(() =>
+      parseSimStatesReferencePath("enrolment.student"),
+    );
+
+    // Then it is refused by name.
+    assertStringIncludes(error.message, "has to start with $");
+  });
+
+  it("refuses the context object by name", () => {
+    // Given a path reading the context object.
+    // When it is parsed.
+    const error = assertThrowsError(() =>
+      parseSimStatesReferencePath("$$.Execution.Name"),
+    );
+
+    // Then the refusal says what it is.
+    assertStringIncludes(error.message, "context object");
+  });
+
+  it("refuses the JSONPath grammar Amazon States Language does not use", () => {
+    // Given paths using a wildcard, a filter and a slice.
+    const refused = ["$.students[*].name", "$.students[?(@.age>3)]", "$[0:2]"];
+
+    // When each is parsed.
+    const errors = refused.map((path) =>
+      assertThrowsError(() => parseSimStatesReferencePath(path)),
+    );
+
+    // Then each is refused rather than read as something else.
+    for (const error of errors) {
+      assertStringIncludes(error.message, "does not read");
+    }
+  });
+
+  it("refuses a root followed by something that is not a separator", () => {
+    // Given a path running a name straight on from the root.
+    // When it is parsed.
+    const error = assertThrowsError(() =>
+      parseSimStatesReferencePath("$enrolment"),
+    );
+
+    // Then it says what it expected.
+    assertStringIncludes(error.message, "Expected . or [");
+  });
+
+  it("refuses a dotted wildcard", () => {
+    // Given a path selecting every field of an object.
+    // When it is parsed.
+    const error = assertThrowsError(() =>
+      parseSimStatesReferencePath("$.students.*"),
+    );
+
+    // Then the wildcard is refused.
+    assertStringIncludes(error.message, "wildcard");
+  });
+
+  it("refuses a path with nothing between its separators", () => {
+    // Given a path with an empty segment.
+    // When it is parsed.
+    const error = assertThrowsError(() =>
+      parseSimStatesReferencePath("$.enrolment..student"),
+    );
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "empty field name");
+  });
+});

--- a/src/service/stepfunctions/data/sim-states-reference-path.iso.test.ts
+++ b/src/service/stepfunctions/data/sim-states-reference-path.iso.test.ts
@@ -1,8 +1,6 @@
 import {
   assertIdentical,
   assertObjectEquals,
-  assertStringIncludes,
-  assertThrowsError,
   assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
@@ -101,73 +99,26 @@ describe("Step Functions Reference Paths", () => {
     assertUndefined(selected);
   });
 
-  it("refuses a path that is not rooted at the document", () => {
-    // Given a path with no root.
-    // When it is parsed.
-    const error = assertThrowsError(() =>
-      parseSimStatesReferencePath("enrolment.student"),
-    );
+  it("reads a bracketed name written after a dot", () => {
+    // Given the form the Amazon States Language docs use for a name with a
+    // space in it.
+    const document = { abc: { "def ghi": "Wei" } };
 
-    // Then it is refused by name.
-    assertStringIncludes(error.message, "has to start with $");
+    // When it is read.
+    const selected = select(document, "$.abc.['def ghi']");
+
+    // Then the bracketed name is one segment.
+    assertIdentical(selected, "Wei");
   });
 
-  it("refuses the context object by name", () => {
-    // Given a path reading the context object.
-    // When it is parsed.
-    const error = assertThrowsError(() =>
-      parseSimStatesReferencePath("$$.Execution.Name"),
-    );
+  it("selects nothing for a field the document inherits rather than owns", () => {
+    // Given a document with no such field of its own.
+    const document = { student: "Wei" };
 
-    // Then the refusal says what it is.
-    assertStringIncludes(error.message, "context object");
-  });
+    // When a name every JavaScript object carries is read.
+    const selected = select(document, "$.toString");
 
-  it("refuses the JSONPath grammar Amazon States Language does not use", () => {
-    // Given paths using a wildcard, a filter and a slice.
-    const refused = ["$.students[*].name", "$.students[?(@.age>3)]", "$[0:2]"];
-
-    // When each is parsed.
-    const errors = refused.map((path) =>
-      assertThrowsError(() => parseSimStatesReferencePath(path)),
-    );
-
-    // Then each is refused rather than read as something else.
-    for (const error of errors) {
-      assertStringIncludes(error.message, "does not read");
-    }
-  });
-
-  it("refuses a root followed by something that is not a separator", () => {
-    // Given a path running a name straight on from the root.
-    // When it is parsed.
-    const error = assertThrowsError(() =>
-      parseSimStatesReferencePath("$enrolment"),
-    );
-
-    // Then it says what it expected.
-    assertStringIncludes(error.message, "Expected . or [");
-  });
-
-  it("refuses a dotted wildcard", () => {
-    // Given a path selecting every field of an object.
-    // When it is parsed.
-    const error = assertThrowsError(() =>
-      parseSimStatesReferencePath("$.students.*"),
-    );
-
-    // Then the wildcard is refused.
-    assertStringIncludes(error.message, "wildcard");
-  });
-
-  it("refuses a path with nothing between its separators", () => {
-    // Given a path with an empty segment.
-    // When it is parsed.
-    const error = assertThrowsError(() =>
-      parseSimStatesReferencePath("$.enrolment..student"),
-    );
-
-    // Then it is refused.
-    assertStringIncludes(error.message, "empty field name");
+    // Then nothing is selected.
+    assertUndefined(selected);
   });
 });

--- a/src/service/stepfunctions/data/sim-states-reference-path.ts
+++ b/src/service/stepfunctions/data/sim-states-reference-path.ts
@@ -1,0 +1,116 @@
+import { SimStatesPathError } from "../error/sim-step-functions.error.js";
+import type { SimStatesPathSegment } from "./sim-states-path-segment.js";
+
+const bracketPattern = /^\[(?:'((?:[^'\\]|\\.)*)'|(\d+))]/;
+const fieldPattern = /^[^.[]+/;
+
+interface SimStatesReadSegment {
+  readonly segment: SimStatesPathSegment;
+  readonly rest: string;
+}
+
+/**
+ * Parse an Amazon States Language Reference Path into its segments.
+ *
+ * The subset read here is the one Amazon States Language itself uses. A
+ * document root, a child by dot or by bracketed name, and an array element by
+ * index. The wider JSONPath grammar (filters, wildcards, slices, recursive
+ * descent) is refused by name, since a path that silently selected the wrong
+ * node would answer a state with plausible data.
+ */
+export function parseSimStatesReferencePath(
+  path: string,
+): readonly SimStatesPathSegment[] {
+  if (path === "$") {
+    return [];
+  }
+
+  if (path.startsWith("$$")) {
+    throw new SimStatesPathError(
+      `${path} reads the context object, which is not simulated. Only paths ` +
+        "rooted at $ are read.",
+    );
+  }
+
+  if (!path.startsWith("$")) {
+    throw new SimStatesPathError(
+      `${path} is not a Reference Path. One has to start with $.`,
+    );
+  }
+
+  const segments: SimStatesPathSegment[] = [];
+  let rest = path.slice(1);
+
+  while (rest.length > 0) {
+    const read = readSegment(path, rest);
+
+    segments.push(read.segment);
+    rest = read.rest;
+  }
+
+  return segments;
+}
+
+/**
+ * Read the one segment at the front of what is left of a path.
+ */
+function readSegment(path: string, rest: string): SimStatesReadSegment {
+  if (rest.startsWith("[")) {
+    return readBracketSegment(path, rest);
+  }
+
+  if (rest.startsWith(".")) {
+    return readFieldSegment(path, rest.slice(1));
+  }
+
+  throw new SimStatesPathError(
+    `${path} is not a Reference Path this simulator reads. Expected . or [ ` +
+      `where it has ${rest.slice(0, 1)}.`,
+  );
+}
+
+/**
+ * Read a bracketed segment, either a quoted field name or an array index.
+ */
+function readBracketSegment(path: string, rest: string): SimStatesReadSegment {
+  const matched = bracketPattern.exec(rest);
+
+  if (matched === null) {
+    throw new SimStatesPathError(
+      `${path} uses a bracket this simulator does not read. Only ['name'] ` +
+        "and [0] are read, so wildcards, slices and filters are refused.",
+    );
+  }
+
+  const [whole, quotedName, index] = matched;
+  const segment: SimStatesPathSegment =
+    quotedName === undefined
+      ? { kind: "index", index: Number(index) }
+      : { kind: "field", name: quotedName.replaceAll(String.raw`\'`, "'") };
+
+  return { segment, rest: rest.slice(whole.length) };
+}
+
+/**
+ * Read a dotted field name.
+ */
+function readFieldSegment(path: string, rest: string): SimStatesReadSegment {
+  const matched = fieldPattern.exec(rest);
+
+  if (matched === null) {
+    throw new SimStatesPathError(
+      `${path} has an empty field name in it. A dot has to be followed by a ` +
+        "field name.",
+    );
+  }
+
+  const [name] = matched;
+
+  if (name === "*") {
+    throw new SimStatesPathError(
+      `${path} uses a wildcard, which this simulator does not read.`,
+    );
+  }
+
+  return { segment: { kind: "field", name }, rest: rest.slice(name.length) };
+}

--- a/src/service/stepfunctions/data/sim-states-reference-path.ts
+++ b/src/service/stepfunctions/data/sim-states-reference-path.ts
@@ -2,7 +2,10 @@ import { SimStatesPathError } from "../error/sim-step-functions.error.js";
 import type { SimStatesPathSegment } from "./sim-states-path-segment.js";
 
 const bracketPattern = /^\[(?:'((?:[^'\\]|\\.)*)'|(\d+))]/;
-const fieldPattern = /^[^.[]+/;
+// The JsonPath member-name-shorthand rule. Anything outside it, punctuation
+// apart from _ included, has to be written in brackets.
+// oxlint-disable-next-line security/detect-unsafe-regex -- no nested quantifier.
+const fieldPattern = /^[A-Za-z_\u{80}-\u{FFFF}][\w\u{80}-\u{FFFF}]*/u;
 
 interface SimStatesReadSegment {
   readonly segment: SimStatesPathSegment;
@@ -60,12 +63,19 @@ function readSegment(path: string, rest: string): SimStatesReadSegment {
   }
 
   if (rest.startsWith(".")) {
-    return readFieldSegment(path, rest.slice(1));
+    const afterDot = rest.slice(1);
+
+    // `$.abc.['def ghi']` is how the Amazon States Language docs write a field
+    // name holding a space, so a bracket is allowed to follow a dot.
+    return afterDot.startsWith("[")
+      ? readBracketSegment(path, afterDot)
+      : readFieldSegment(path, afterDot);
   }
 
   throw new SimStatesPathError(
     `${path} is not a Reference Path this simulator reads. Expected . or [ ` +
-      `where it has ${rest.slice(0, 1)}.`,
+      `where it has ${rest.slice(0, 1)}. A name holding punctuation or a ` +
+      "space has to be written in brackets, as in $.abc.['def ghi'].",
   );
 }
 
@@ -99,18 +109,13 @@ function readFieldSegment(path: string, rest: string): SimStatesReadSegment {
 
   if (matched === null) {
     throw new SimStatesPathError(
-      `${path} has an empty field name in it. A dot has to be followed by a ` +
-        "field name.",
+      `${path} has a dotted field name outside the JsonPath ` +
+        "member-name-shorthand rule. A name holding punctuation, a space or a " +
+        "wildcard has to be written in brackets, as in $.abc.['def ghi'].",
     );
   }
 
   const [name] = matched;
-
-  if (name === "*") {
-    throw new SimStatesPathError(
-      `${path} uses a wildcard, which this simulator does not read.`,
-    );
-  }
 
   return { segment: { kind: "field", name }, rest: rest.slice(name.length) };
 }

--- a/src/service/stepfunctions/data/sim-states-result-path.ts
+++ b/src/service/stepfunctions/data/sim-states-result-path.ts
@@ -1,0 +1,92 @@
+// oxlint-disable security/detect-object-injection -- keys come from a parsed
+// Reference Path, and the document being written is JSON the execution owns.
+import type { JSONObject, JSONValue } from "../../../util/type-guard/json.js";
+import { isRecord } from "../../../util/type-guard/record.js";
+import { SimStatesResultPathMatchFailure } from "../error/sim-step-functions.error.js";
+import type { SimStatesPathSegment } from "./sim-states-path-segment.js";
+
+/**
+ * Put a state's result into its raw input at a Reference Path.
+ *
+ * The document is copied down the path being written, so the value handed in
+ * is left as it was. Everything off the path is shared, since nothing in an
+ * execution mutates a value it has already produced.
+ */
+export function insertAtSimStatesPath(
+  document: JSONValue,
+  segments: readonly SimStatesPathSegment[],
+  result: JSONValue,
+  resultPath: string,
+): JSONValue {
+  const [segment, ...rest] = segments;
+
+  if (segment === undefined) {
+    return result;
+  }
+
+  if (segment.kind === "index") {
+    return insertIntoArray(document, segment.index, rest, result, resultPath);
+  }
+
+  return insertIntoObject(document, segment.name, rest, result, resultPath);
+}
+
+/**
+ * Write one field, building the object where the document holds nothing yet.
+ */
+function insertIntoObject(
+  document: JSONValue,
+  name: string,
+  rest: readonly SimStatesPathSegment[],
+  result: JSONValue,
+  resultPath: string,
+): JSONValue {
+  const target = document ?? {};
+
+  if (!isRecord(target)) {
+    throw new SimStatesResultPathMatchFailure(
+      `${resultPath} writes the field ${name} into a value that is not an ` +
+        "object, so the result has nowhere to go.",
+    );
+  }
+
+  const copy: JSONObject = { ...target };
+
+  copy[name] = insertAtSimStatesPath(
+    copy[name] ?? null,
+    rest,
+    result,
+    resultPath,
+  );
+
+  return copy;
+}
+
+/**
+ * Write one array element.
+ */
+function insertIntoArray(
+  document: JSONValue,
+  index: number,
+  rest: readonly SimStatesPathSegment[],
+  result: JSONValue,
+  resultPath: string,
+): JSONValue {
+  if (!Array.isArray(document)) {
+    throw new SimStatesResultPathMatchFailure(
+      `${resultPath} writes element ${String(index)} into a value that is ` +
+        "not an array, so the result has nowhere to go.",
+    );
+  }
+
+  const copy = [...document];
+
+  copy[index] = insertAtSimStatesPath(
+    copy[index] ?? null,
+    rest,
+    result,
+    resultPath,
+  );
+
+  return copy;
+}

--- a/src/service/stepfunctions/data/sim-states-result-path.ts
+++ b/src/service/stepfunctions/data/sim-states-result-path.ts
@@ -33,6 +33,11 @@ export function insertAtSimStatesPath(
 
 /**
  * Write one field, building the object where the document holds nothing yet.
+ *
+ * The field is defined rather than assigned, and the value underneath it is
+ * read only where the object owns it. A JSON document is free to hold a field
+ * called `__proto__`, and assigning that one would move the copy's prototype
+ * instead of writing the field the path named.
  */
 function insertIntoObject(
   document: JSONValue,
@@ -51,19 +56,24 @@ function insertIntoObject(
   }
 
   const copy: JSONObject = { ...target };
+  const existing = Object.hasOwn(copy, name) ? copy[name] : null;
 
-  copy[name] = insertAtSimStatesPath(
-    copy[name] ?? null,
-    rest,
-    result,
-    resultPath,
-  );
+  Object.defineProperty(copy, name, {
+    configurable: true,
+    enumerable: true,
+    value: insertAtSimStatesPath(existing ?? null, rest, result, resultPath),
+    writable: true,
+  });
 
   return copy;
 }
 
 /**
  * Write one array element.
+ *
+ * The index has to be one the array already reaches. Writing past the end
+ * would leave a hole, and a hole is not a JSON value: it serializes as null
+ * and the next state receives something the write never described.
  */
 function insertIntoArray(
   document: JSONValue,
@@ -76,6 +86,13 @@ function insertIntoArray(
     throw new SimStatesResultPathMatchFailure(
       `${resultPath} writes element ${String(index)} into a value that is ` +
         "not an array, so the result has nowhere to go.",
+    );
+  }
+
+  if (index >= document.length) {
+    throw new SimStatesResultPathMatchFailure(
+      `${resultPath} writes element ${String(index)} of an array holding ` +
+        `${String(document.length)}, so the result has nowhere to go.`,
     );
   }
 

--- a/src/service/stepfunctions/error/sim-step-functions.error.ts
+++ b/src/service/stepfunctions/error/sim-step-functions.error.ts
@@ -1,0 +1,82 @@
+/**
+ * Base class for simulated Step Functions errors.
+ *
+ * Every failure inside a state machine carries the name Amazon States Language
+ * gives it. That name is what a `Retry` or a `Catch` matches on, so it is held
+ * here rather than derived at the point one is evaluated.
+ */
+export class SimStepFunctionsError extends Error {
+  constructor(
+    message: string,
+    public readonly statesErrorName: string,
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * A Reference Path this simulator cannot read.
+ *
+ * Real Step Functions rejects a malformed path when the state machine is
+ * created. It is raised here as well for a path outside the subset this reads,
+ * which is a narrower thing and worth telling apart in the message.
+ */
+export class SimStatesPathError extends SimStepFunctionsError {
+  public override readonly name = "SimStatesPathError";
+
+  constructor(message: string) {
+    super(message, "States.QueryEvaluationError");
+  }
+}
+
+/**
+ * A path selecting nothing where the state needed a value.
+ *
+ * `InputPath`, `OutputPath` and a Payload Template field all fail this way when
+ * the document holds nothing at the path.
+ */
+export class SimStatesPathMatchFailure extends SimStepFunctionsError {
+  public override readonly name = "SimStatesPathMatchFailure";
+
+  constructor(message: string) {
+    super(message, "States.ParameterPathFailure");
+  }
+}
+
+/**
+ * A `ResultPath` that cannot be written into the state input.
+ */
+export class SimStatesResultPathMatchFailure extends SimStepFunctionsError {
+  public override readonly name = "SimStatesResultPathMatchFailure";
+
+  constructor(message: string) {
+    super(message, "States.ResultPathMatchFailure");
+  }
+}
+
+/**
+ * An intrinsic function that cannot be parsed, or that was called wrongly.
+ */
+export class SimStatesIntrinsicFailure extends SimStepFunctionsError {
+  public override readonly name = "SimStatesIntrinsicFailure";
+
+  constructor(message: string) {
+    super(message, "States.IntrinsicFailure");
+  }
+}
+
+/**
+ * An Amazon States Language construct this simulator does not run.
+ *
+ * Raised when a state machine is read rather than when a state runs. A
+ * definition using something unsimulated is refused whole, since a state
+ * machine missing one state runs wrong, and running wrong is worse than
+ * refusing.
+ */
+export class SimStatesUnsimulatedInput extends SimStepFunctionsError {
+  public override readonly name = "SimStatesUnsimulatedInput";
+
+  constructor(message: string) {
+    super(message, "States.QueryEvaluationError");
+  }
+}


### PR DESCRIPTION
Amazon States Language moves data through five fields on every state, and this repository had no way to read a path with. EventBridge refuses `InputPath` and `InputTransformer` for that reason. This adds the layer the rest of #918 rests on, and nothing here reaches a simulated service yet.

## What is in it

- **Reference Paths.** The subset Amazon States Language itself uses. A document root, a child by dot or by bracketed name, and an array element by index. The wider JSONPath grammar (wildcards, filters, slices, recursive descent) is refused by name.
- **Intrinsic functions.** `States.Format`, `States.Array`, `States.ArrayLength`, `States.StringToJson` and `States.JsonToString`, including nested calls and quoted arguments carrying commas. `States.UUID` and `States.MathRandom` are left out, since both answer differently on every call.
- **Payload Templates.** `Parameters` and `ResultSelector`, with `.$` fields resolved from a path or an intrinsic, and objects and arrays walked.
- **The five fields in order.** `InputPath` then `Parameters` for the effective input, and `ResultSelector` then `ResultPath` then `OutputPath` for the effective output. `ResultPath` reads the raw state input, so a state can keep fields `InputPath` had already taken away.
- **Failures carry their Amazon States Language error name.** `States.ParameterPathFailure` and the rest are held on the error, which is what a `Retry` or a `Catch` will match on in #920.

## Two decisions worth a look

An escaped brace survives the string-literal reader and is resolved by `States.Format`. Resolving `\{` when the quotes come off would take away the only thing telling a literal brace apart from a placeholder. A brace escape reaching another intrinsic arrives with its backslash, and the docs will record that divergence.

The context object is refused by name. `$$.Execution.Name` needs an execution to exist, and that arrives with the interpreter.

## Size

This is the first of the pull requests against #918, split the way that issue's implementation notes describe. The interpreter, the state types and the service surface follow. The data-flow layer is where a subtle mistake is most expensive, and it is worth reviewing on its own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added Amazon States Language data-flow simulation, including input/output paths, parameters, result selection, and result insertion.
- Added reference-path parsing and traversal for nested objects and arrays.
- Added intrinsic function evaluation for formatting, arrays, length checks, and JSON conversion.
- Added payload-template evaluation with path and intrinsic expressions.
- Added clearer errors for invalid paths, expressions, and unsupported simulation features.

## Tests
- Added comprehensive coverage for data flow, reference paths, intrinsic functions, nesting, escaping, arrays, and error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->