### PR TITLE
feat: trigger a Lambda from a Kinesis stream

### DIFF
--- a/docs/services/kinesis/README.md
+++ b/docs/services/kinesis/README.md
@@ -200,6 +200,13 @@ const { Records } = await kinesis.getRecords(
 console.log(Records.length);
 ```
 
+## Triggering a Lambda function
+
+A [Lambda event source mapping](../lambda/#triggering-a-function-from-a-kinesis-stream "Simulated Lambda Kinesis event source docs")
+polls a stream and invokes a function with the records it reads. Every shard is read by a processor
+of its own, as real Lambda reads one, and the function's execution role is what the polling is done
+as.
+
 ## Permissions
 
 Every operation goes through simulated IAM. The action is the `kinesis:` name of the operation, and
@@ -356,8 +363,6 @@ Anything else refuses on send with `SimSdkUnsupportedCommandError`.
   out, and no response carries an `EncryptionType`.
 - **Tags are kept and never listed.** A stream created with `Tags` holds them, readable through
   `findStream`. `AddTagsToStream`, `ListTagsForStream` and `RemoveTagsFromStream` are absent.
-- **Nothing triggers a Lambda function.** An event source mapping naming a Kinesis stream is refused
-  at creation.
 - **`AWS::Kinesis::Stream` does not deploy.** A CloudFormation template holding one records the
   resource as skipped.
 - **Kinesis Data Firehose is a separate service and is absent.** So is Kinesis Video Streams.

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -1477,7 +1477,7 @@ the `Records` shape real Lambda uses.
 `StartingPosition` is required for a stream and is `TRIM_HORIZON` or `LATEST`. `TRIM_HORIZON` reads
 what the stream still holds, so changes made before the mapping existed are delivered too. `LATEST`
 reads only what the table changes from the moment the mapping starts reading. `AT_TIMESTAMP` is for
-a Kinesis stream and is refused by name.
+[a Kinesis stream](#triggering-a-function-from-a-kinesis-stream) and is refused by name here.
 
 `BatchSize` says how many records one invocation may be given, and defaults to 100, the number
 CDK's `DynamoEventSource` also asks for. The table and the function have to be in the same account
@@ -1930,6 +1930,162 @@ A hand-written template or a SAM application usually gives the function the AWS 
 that role reaches the mapping with no stream permissions and the mapping is refused when it is
 created.
 Write the grant as an inline policy, as the example above and CDK both do.
+
+## Triggering a function from a Kinesis stream
+
+An event source mapping also connects a [simulated Kinesis stream](../kinesis/ "Simulated Kinesis Data Streams docs")
+to a function. Records put onto the stream are delivered to the handler as a Kinesis event, with the
+`Records` shape real Lambda uses.
+
+A Kinesis stream has as many shards as it was created with, and every one of them is read. Real
+Lambda runs a processor per shard, and so does this: each shard keeps its own place on the stream,
+delivers its own batches and backs off on its own when a batch fails. One invocation is given
+records from one shard, so a handler that has to see records in order should put them under one
+partition key, which is what puts them on one shard.
+
+`StartingPosition` is required for a stream. A Kinesis stream takes all three positions.
+`TRIM_HORIZON` reads what the stream still holds, `LATEST` reads only what arrives from the moment
+the mapping starts reading, and `AT_TIMESTAMP` reads from the instant `StartingPositionTimestamp`
+names.
+
+`BatchSize` says how many records one invocation may be given, and defaults to 100, the number CDK's
+`KinesisEventSource` also asks for. The stream and the function have to be in the same account and
+region, as they do on real AWS.
+
+```typescript sim-lambda-kinesis-event-source
+/**
+ * Delivering a simulated Kinesis stream's records to a simulated function.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateStreamCommand, PutRecordCommand } from "@aws-sdk/client-kinesis";
+import {
+  CreateEventSourceMappingCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import {
+  makeLambdaZipFileInput,
+  type SimLambdaKinesisStreamEvent,
+} from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+
+await simAws
+  .kinesis()
+  .createStream(new CreateStreamCommand({ StreamName: "orders" }));
+
+const streamArn = `arn:aws:kinesis:${simAws.defaultRegionName}:${simAws.defaultAccountId}:stream/orders`;
+
+const { Role } = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "OrderProjectorRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "OrderProjectorRole",
+    PolicyName: "ReadOrders",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Action: [
+            "kinesis:DescribeStream",
+            "kinesis:GetRecords",
+            "kinesis:GetShardIterator",
+          ],
+          Resource: streamArn,
+        },
+        { Effect: "Allow", Action: "kinesis:ListStreams", Resource: "*" },
+      ],
+    }),
+  }),
+);
+
+const projected: string[] = [];
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "order-projector",
+    Role: Role.Arn,
+    Code: {
+      ZipFile: makeLambdaZipFileInput(
+        (event: SimLambdaKinesisStreamEvent): void => {
+          for (const record of event.Records) {
+            // The payload arrives base64 encoded, as it does on AWS.
+            projected.push(
+              Buffer.from(record.kinesis.data, "base64").toString("utf8"),
+            );
+          }
+        },
+      ),
+    },
+  }),
+);
+
+await simAws.lambda().createEventSourceMapping(
+  new CreateEventSourceMappingCommand({
+    EventSourceArn: streamArn,
+    FunctionName: "order-projector",
+    StartingPosition: "TRIM_HORIZON",
+  }),
+);
+
+await simAws.kinesis().putRecord(
+  new PutRecordCommand({
+    StreamName: "orders",
+    PartitionKey: "customer-1",
+    Data: new TextEncoder().encode('{"id":"order-1"}'),
+  }),
+);
+
+// Delivery happens in the background, so wait for the simulation to settle.
+await simAws.backgroundTasksComplete();
+
+console.log(projected[0]); // {"id":"order-1"}
+```
+
+Each record carries `eventID`, `eventName`, `eventVersion`, `eventSource`, `awsRegion`,
+`eventSourceARN`, `invokeIdentityArn` and a `kinesis` body holding `kinesisSchemaVersion`,
+`partitionKey`, `sequenceNumber`, `data` and `approximateArrivalTimestamp`. `eventID` is the shard
+identifier and the sequence number joined by a colon, so it is unique across the whole stream rather
+than within one shard. `invokeIdentityArn` is the execution role the records were read with.
+
+The two translations worth knowing are the payload and the instant. `data` is base64 of the bytes
+that were put, because the event is JSON and JSON has no bytes, and `approximateArrivalTimestamp` is
+seconds since the epoch where
+[the Kinesis API](../kinesis/#putting-a-record-and-reading-it-back "Simulated Kinesis docs") hands
+out a `Date`. Both are what a deployed function receives.
+
+`SimLambdaKinesisStreamEvent` and `SimLambdaKinesisStreamEventRecord` are exported from
+`@kensio/yulin/lambda` for typing a handler, and are minimal structural equivalents of the
+`KinesisStreamEvent` and `KinesisStreamRecord` types from the `aws-lambda` typings package.
+
+Creating the mapping checks what real Lambda checks. The stream has to exist, and the function's
+execution role has to be allowed `kinesis:DescribeStream`, `kinesis:GetRecords` and
+`kinesis:GetShardIterator` on it, plus `kinesis:ListStreams` on `*`. Those four are what both the
+AWS managed policy and CDK's own grant give a stream consumer. A role missing one of them fails with
+`InvalidParameterValueException` naming the operation.
+
+`FunctionResponseTypes: ["ReportBatchItemFailures"]` works as it does for a DynamoDB stream. A
+handler names a record by its `sequenceNumber`, and the mapping goes back to the lowest one the
+report names, so that record and everything after it on that shard is delivered again. A failing
+batch blocks its own shard and no other.
+
+A mapping naming an enhanced fan-out consumer ARN is refused, since consumers are unsimulated.
+`AWS::Lambda::EventSourceMapping` deploys a Kinesis mapping the same way it deploys a DynamoDB one.
 
 ## Function URLs
 
@@ -3265,12 +3421,13 @@ Sim Lambda currently supports:
   handler directly
 - `AddPermissionCommand`, `RemovePermissionCommand` and `GetPolicyCommand`, for resource-based
   policies evaluated alongside identity policies
-- SQS and DynamoDB stream event source mappings, created with `CreateEventSourceMappingCommand` and
-  read with `GetEventSourceMappingCommand`, `ListEventSourceMappingsCommand` and
-  `DeleteEventSourceMappingCommand`, delivering real-shaped SQS and DynamoDB stream events and
-  honouring `BatchSize`
-- `StartingPosition: "TRIM_HORIZON"` and `"LATEST"` on a stream mapping, with a failing batch
-  blocking its shard until it is through or discarded
+- SQS, DynamoDB stream and Kinesis stream event source mappings, created with
+  `CreateEventSourceMappingCommand` and read with `GetEventSourceMappingCommand`,
+  `ListEventSourceMappingsCommand` and `DeleteEventSourceMappingCommand`, delivering real-shaped SQS,
+  DynamoDB stream and Kinesis events and honouring `BatchSize`
+- `StartingPosition: "TRIM_HORIZON"` and `"LATEST"` on a stream mapping, and `"AT_TIMESTAMP"` on a
+  Kinesis one, with a failing batch blocking its shard until it is through or discarded
+- Every shard of a Kinesis stream read by a processor of its own, as real Lambda reads one
 - `FunctionResponseTypes: ["ReportBatchItemFailures"]` on a queue mapping, returning only the
   message ids the handler reported, and on a stream mapping, rewinding to the lowest sequence number
   the handler reported
@@ -3412,8 +3569,8 @@ Current documented limitations:
   versioning yet. That covers `Code.S3ObjectVersion` on `CreateFunction` and on a template
   function, and `S3ObjectVersion` on `UpdateFunctionCode`. A versioned location loads the object as
   it stands.
-- SQS queues and DynamoDB streams are the only event sources. Kinesis, Kafka and DocumentDB sources
-  are refused outright, and so are `FilterCriteria`,
+- SQS queues, DynamoDB streams and Kinesis streams are the only event sources. Kafka, DocumentDB and
+  Kinesis enhanced fan-out consumers are refused outright, and so are `FilterCriteria`,
   `ScalingConfig`, `DestinationConfig`, `MaximumRetryAttempts`, `BisectBatchOnFunctionError`,
   `ParallelizationFactor`, `TumblingWindowInSeconds` and the other mapping inputs this simulation
   has no behaviour for.

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -3460,9 +3460,9 @@ Sim Lambda currently supports:
 - A CDK app built on `fn.currentVersion` or a `lambda.Alias`, which deploys with the alias its
   integrations point at, and where an `AWS::Lambda::Permission` naming that alias grants on the
   alias
-- `AWS::Lambda::EventSourceMapping` on a queue or on a table's stream, including the
-  `StartingPosition` a stream mapping needs, so a CDK `SqsEventSource` or `DynamoEventSource`
-  deploys as it is synthesised
+- `AWS::Lambda::EventSourceMapping` on a queue, on a table's stream or on a Kinesis stream,
+  including the `StartingPosition` a stream mapping needs, so a CDK `SqsEventSource`,
+  `DynamoEventSource` or `KinesisEventSource` deploys as it is synthesised
 - A CDK function given `onFailure`, `onSuccess`, `retryAttempts`, `maxEventAge` or
   `deadLetterQueue`, which deploys the `AWS::Lambda::EventInvokeConfig` and the `DeadLetterConfig`
   those synthesise
@@ -3597,10 +3597,11 @@ Current documented limitations:
   Write the grant inline to deploy either.
 - `UpdateEventSourceMapping` is absent, and a mapping's batch size or enabled state is fixed once it
   is created. `Enabled: false` at creation is simulated.
-- One poll delivers one batch. Real Lambda runs several pollers at once and scales them with the
-  event source, and what that concurrency does to ordering or to a downstream service is invisible
-  here. A simulated stream has one shard and never splits, so a stream mapping has one thing to read
-  either way.
+- One poll of one shard delivers one batch. Real Lambda runs several pollers at once and scales them
+  with the event source, and what that concurrency does to ordering or to a downstream service is
+  invisible here. A simulated DynamoDB stream has one shard and never splits, so a mapping on one has
+  a single thing to read either way. A Kinesis stream has the shards it was created with, each read
+  by a processor of its own, and none of them ever splits or merges.
 - CloudFormation resource types other than `AWS::Lambda::Function`, `AWS::Lambda::Url`,
   `AWS::Lambda::Permission`, `AWS::Lambda::Version`, `AWS::Lambda::Alias`,
   `AWS::Lambda::EventSourceMapping` and `AWS::Lambda::EventInvokeConfig` (`LayerVersion`,

--- a/docs/services/lambda/sim-lambda-kinesis-event-source.example.ts
+++ b/docs/services/lambda/sim-lambda-kinesis-event-source.example.ts
@@ -1,0 +1,102 @@
+/**
+ * Delivering a simulated Kinesis stream's records to a simulated function.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateStreamCommand, PutRecordCommand } from "@aws-sdk/client-kinesis";
+import {
+  CreateEventSourceMappingCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import {
+  makeLambdaZipFileInput,
+  type SimLambdaKinesisStreamEvent,
+} from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+
+await simAws
+  .kinesis()
+  .createStream(new CreateStreamCommand({ StreamName: "orders" }));
+
+const streamArn = `arn:aws:kinesis:${simAws.defaultRegionName}:${simAws.defaultAccountId}:stream/orders`;
+
+const { Role } = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "OrderProjectorRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "OrderProjectorRole",
+    PolicyName: "ReadOrders",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Action: [
+            "kinesis:DescribeStream",
+            "kinesis:GetRecords",
+            "kinesis:GetShardIterator",
+          ],
+          Resource: streamArn,
+        },
+        { Effect: "Allow", Action: "kinesis:ListStreams", Resource: "*" },
+      ],
+    }),
+  }),
+);
+
+const projected: string[] = [];
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "order-projector",
+    Role: Role.Arn,
+    Code: {
+      ZipFile: makeLambdaZipFileInput(
+        (event: SimLambdaKinesisStreamEvent): void => {
+          for (const record of event.Records) {
+            // The payload arrives base64 encoded, as it does on AWS.
+            projected.push(
+              Buffer.from(record.kinesis.data, "base64").toString("utf8"),
+            );
+          }
+        },
+      ),
+    },
+  }),
+);
+
+await simAws.lambda().createEventSourceMapping(
+  new CreateEventSourceMappingCommand({
+    EventSourceArn: streamArn,
+    FunctionName: "order-projector",
+    StartingPosition: "TRIM_HORIZON",
+  }),
+);
+
+await simAws.kinesis().putRecord(
+  new PutRecordCommand({
+    StreamName: "orders",
+    PartitionKey: "customer-1",
+    Data: new TextEncoder().encode('{"id":"order-1"}'),
+  }),
+);
+
+// Delivery happens in the background, so wait for the simulation to settle.
+await simAws.backgroundTasksComplete();
+
+console.log(projected[0]); // {"id":"order-1"}

--- a/src/service/aws/factory/sim-aws-lambda-collaborators.ts
+++ b/src/service/aws/factory/sim-aws-lambda-collaborators.ts
@@ -1,4 +1,5 @@
 import { SimAwsLambdaDestinations } from "../../lambda/destination/sim-aws-lambda-destinations.js";
+import { SimKinesisEventSourceStreams } from "../../lambda/event-source/stream/kinesis/sim-kinesis-event-source-streams.js";
 import { SimDynamoDbEventSourceStreams } from "../../lambda/event-source/stream/sim-dynamodb-event-source-streams.js";
 import { SimSqsEventSourceQueues } from "../../lambda/event-source/queue/sim-sqs-event-source-queues.js";
 import { SimEcrLambdaContainerImages } from "../../lambda/function/code/image/sim-ecr-lambda-container-images.js";
@@ -29,6 +30,7 @@ interface SimAwsLambdaCollaborators {
   readonly containerImages: SimEcrLambdaContainerImages;
   readonly eventSourceQueues: SimSqsEventSourceQueues;
   readonly eventSourceStreams: SimDynamoDbEventSourceStreams;
+  readonly kinesisStreams: SimKinesisEventSourceStreams;
   readonly vmSdkModuleProvider: SimSdkLambdaVmModuleProvider;
   readonly outboundHttp: SimLambdaOutboundHttp;
   readonly logs: SimLogsServiceWriter;
@@ -44,9 +46,9 @@ interface SimAwsLambdaCollaborators {
  * code running in the vm runtime is provided host-installed AWS SDK packages
  * intercepted into this SimAws, as the real Lambda runtime provides the SDK.
  *
- * Event source mappings poll the same scope's simulated SQS and DynamoDB, as a
- * queue or a table's stream can only be an event source for a function in its
- * own Account and Region.
+ * Event source mappings poll the same scope's simulated SQS, DynamoDB and
+ * Kinesis, as a queue or a stream can only be an event source for a function in
+ * its own Account and Region.
  *
  * A container image function's image is resolved in the whole simulation's ECR
  * rather than this scope's, because an image URI names the Account and Region
@@ -88,6 +90,9 @@ export function simAwsLambdaCollaborators(
     eventSourceQueues: new SimSqsEventSourceQueues({ sqs: scope.sqs() }),
     eventSourceStreams: new SimDynamoDbEventSourceStreams({
       dynamoDb: scope.dynamoDb(),
+    }),
+    kinesisStreams: new SimKinesisEventSourceStreams({
+      kinesis: scope.kinesis(),
     }),
     vmSdkModuleProvider: new SimSdkLambdaVmModuleProvider({
       simAws,

--- a/src/service/cloudformation/sam/function/event/sim-cfn-sam-event-source-mapping-event.iso.test.ts
+++ b/src/service/cloudformation/sam/function/event/sim-cfn-sam-event-source-mapping-event.iso.test.ts
@@ -217,7 +217,7 @@ describe("SAM SQS and DynamoDB event expansion", () => {
 
     // Then the mapping started where the event said, and the write reached the
     // bound handler as a stream record
-    assertIdentical(deployedMapping(stack).startingPosition, "TRIM_HORIZON");
+    assertIdentical(deployedMapping(stack).start?.position, "TRIM_HORIZON");
     assertArrayLength(events, 1);
 
     const record = events[0].Records[0];

--- a/src/service/dynamodb/stream/sim-dynamodb-stream-activity.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream-activity.ts
@@ -38,10 +38,20 @@ export class SimDynamoDbStreamActivity {
    * Stop watching a stream.
    */
   unwatch(streamArn: string, watcher: SimDynamoDbStreamWatcher): void {
-    this.watchers.set(
-      streamArn,
-      this.watchersOf(streamArn).filter((held) => held !== watcher),
+    const remaining = this.watchersOf(streamArn).filter(
+      (held) => held !== watcher,
     );
+
+    if (remaining.length === 0) {
+      // A stream nothing watches any more is forgotten. Keeping the empty list
+      // would grow one entry per stream ever watched, for the life of the
+      // simulation.
+      this.watchers.delete(streamArn);
+
+      return;
+    }
+
+    this.watchers.set(streamArn, [...remaining]);
   }
 
   /**

--- a/src/service/kinesis/README.md
+++ b/src/service/kinesis/README.md
@@ -75,5 +75,10 @@ cannot reach a stream it lacks permission for by holding an iterator someone els
 an intercepted client sends is refused with `SimSdkUnsupportedCommandError`, which covers enhanced
 fan-out, resharding, encryption and the tag operations.
 
+A Lambda event source mapping reads a stream through those same commands, as the function's
+execution role. The adapter is `SimKinesisEventSourceStreams` under
+`src/service/lambda/event-source/stream/kinesis/`, and `streamActivity()` is what tells a poller
+there is something to read.
+
 `docs/services/kinesis/README.md` is the user-facing page, and its **Divergences and limitations**
 section is the full list.

--- a/src/service/kinesis/command/record/sim-kinesis-put-commands.ts
+++ b/src/service/kinesis/command/record/sim-kinesis-put-commands.ts
@@ -1,4 +1,5 @@
 import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimKinesisStreamActivity } from "../../stream/sim-kinesis-stream-activity.js";
 import type { SimKinesisRequestOptions } from "../sim-kinesis-request-options.js";
 import type { SimKinesisStreamAccess } from "../sim-kinesis-stream-access.js";
 import { simKinesisReadPutBatch } from "./sim-kinesis-put-batch.js";
@@ -12,6 +13,7 @@ import type {
 
 interface SimKinesisPutCommandsProperties {
   readonly access: SimKinesisStreamAccess;
+  readonly activity: SimKinesisStreamActivity;
   readonly background: BackgroundScheduler;
 }
 
@@ -20,10 +22,12 @@ interface SimKinesisPutCommandsProperties {
  */
 export class SimKinesisPutCommands {
   private readonly access: SimKinesisStreamAccess;
+  private readonly activity: SimKinesisStreamActivity;
   private readonly background: BackgroundScheduler;
 
   constructor(properties: SimKinesisPutCommandsProperties) {
     this.access = properties.access;
+    this.activity = properties.activity;
     this.background = properties.background;
   }
 
@@ -43,6 +47,8 @@ export class SimKinesisPutCommands {
     const stream = this.access.require("kinesis:PutRecord", input, options);
     const entry = simKinesisReadPutEntry(input);
     const placement = stream.put({ ...entry, at: this.background.now() });
+
+    this.activity.recordsAvailable(stream.arn);
 
     return {
       $metadata: {},
@@ -68,18 +74,19 @@ export class SimKinesisPutCommands {
     const stream = this.access.require("kinesis:PutRecords", input, options);
     const entries = simKinesisReadPutBatch(input.Records);
     const at = this.background.now();
+    const placements = entries.map((entry) => stream.put({ ...entry, at }));
+
+    // Once, for the batch, rather than once per record. A poller woken by the
+    // first record would read the rest of the batch in the same turn anyway.
+    this.activity.recordsAvailable(stream.arn);
 
     return {
       $metadata: {},
       FailedRecordCount: 0,
-      Records: entries.map((entry) => {
-        const placement = stream.put({ ...entry, at });
-
-        return {
-          ShardId: placement.shardId,
-          SequenceNumber: placement.sequenceNumber,
-        };
-      }),
+      Records: placements.map((placement) => ({
+        ShardId: placement.shardId,
+        SequenceNumber: placement.sequenceNumber,
+      })),
     };
   }
 }

--- a/src/service/kinesis/command/sim-kinesis-commands.ts
+++ b/src/service/kinesis/command/sim-kinesis-commands.ts
@@ -1,6 +1,7 @@
 import type { BackgroundScheduler } from "../../../util/background/background.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimKinesisStreamActivity } from "../stream/sim-kinesis-stream-activity.js";
 import type { SimKinesisStreamStore } from "../stream/sim-kinesis-stream-store.js";
 import { SimKinesisAuthorizer } from "./authorize/sim-kinesis-authorizer.js";
 import { SimKinesisPutCommands } from "./record/sim-kinesis-put-commands.js";
@@ -11,6 +12,7 @@ import { SimKinesisStreamAccess } from "./sim-kinesis-stream-access.js";
 
 interface SimKinesisCommandsProperties {
   readonly streams: SimKinesisStreamStore;
+  readonly activity: SimKinesisStreamActivity;
   readonly iam: SimIamInterServiceAuthZ;
   readonly background: BackgroundScheduler;
   readonly accountRegionScope: SimAwsAccountRegionScope;
@@ -45,7 +47,11 @@ export class SimKinesisCommands {
       background,
     });
     this.streams = new SimKinesisStreamCommands({ streams, access });
-    this.puts = new SimKinesisPutCommands({ access, background });
+    this.puts = new SimKinesisPutCommands({
+      access,
+      activity: properties.activity,
+      background,
+    });
     this.reads = new SimKinesisReadCommands({ streams, access, background });
   }
 }

--- a/src/service/kinesis/index.ts
+++ b/src/service/kinesis/index.ts
@@ -4,6 +4,8 @@ export type * from "./command/sim-kinesis-command.types.js";
 export { SimKinesisStream } from "./stream/sim-kinesis-stream.js";
 export type { SimKinesisStreamStatus } from "./stream/sim-kinesis-stream.js";
 export { SimKinesisShard } from "./stream/sim-kinesis-shard.js";
+export { SimKinesisStreamActivity } from "./stream/sim-kinesis-stream-activity.js";
+export type { SimKinesisStreamWatcher } from "./stream/sim-kinesis-stream-activity.js";
 export type { SimKinesisStreamMode } from "./stream/sim-kinesis-stream-mode.js";
 export {
   parseSimKinesisStreamArn,

--- a/src/service/kinesis/sim-kinesis.ts
+++ b/src/service/kinesis/sim-kinesis.ts
@@ -14,6 +14,7 @@ import { SimKinesisCommands } from "./command/sim-kinesis-commands.js";
 import type { SimKinesisRequestOptions } from "./command/sim-kinesis-request-options.js";
 import { SimKinesisSdkCommandRouter } from "./sdk/sim-kinesis-sdk-command-router.js";
 import type { SimKinesisStream } from "./stream/sim-kinesis-stream.js";
+import { SimKinesisStreamActivity } from "./stream/sim-kinesis-stream-activity.js";
 import { SimKinesisStreamStore } from "./stream/sim-kinesis-stream-store.js";
 
 interface SimKinesisProperties {
@@ -40,6 +41,7 @@ interface SimKinesisProperties {
  */
 export class SimKinesis {
   private readonly streams = new SimKinesisStreamStore();
+  private readonly activity = new SimKinesisStreamActivity();
   private readonly commands: SimKinesisCommands;
   private readonly background: BackgroundScheduler;
   private readonly sdkRouter = new SimKinesisSdkCommandRouter(this);
@@ -54,6 +56,7 @@ export class SimKinesis {
     this.background = background;
     this.commands = new SimKinesisCommands({
       streams: this.streams,
+      activity: this.activity,
       iam,
       background,
       accountRegionScope,
@@ -68,6 +71,17 @@ export class SimKinesis {
    */
   findStream(name: string): SimKinesisStream | undefined {
     return this.streams.find(name);
+  }
+
+  /**
+   * Get the streams of this service, for a consumer that cannot poll them
+   * continuously.
+   *
+   * A Lambda event source mapping is what this exists for. It says when a
+   * record has been put, so a poller has something to wake on.
+   */
+  streamActivity(): SimKinesisStreamActivity {
+    return this.activity;
   }
 
   /** Handle a CreateStream Command from the SDK. */

--- a/src/service/kinesis/stream/sim-kinesis-stream-activity.ts
+++ b/src/service/kinesis/stream/sim-kinesis-stream-activity.ts
@@ -1,0 +1,59 @@
+/**
+ * Something outside Kinesis waiting for records on a stream.
+ *
+ * A Lambda event source mapping is the one this exists for. Real Lambda polls a
+ * stream continuously, and nothing in this simulation runs continuously, so the
+ * stream says when there is something to poll for instead.
+ */
+export interface SimKinesisStreamWatcher {
+  /**
+   * A record has been put, and can be read now.
+   *
+   * There is no instant here, unlike the queue watcher this mirrors. A stream
+   * record is readable the moment it is put: nothing delays one, and nothing
+   * hides one that has been handed out.
+   */
+  recordsAvailable(): void;
+}
+
+/**
+ * What a consumer that cannot poll continuously needs from the streams of one
+ * simulated Kinesis: to be told when a record has been put.
+ *
+ * Watchers are held by stream ARN rather than on the stream itself, so a
+ * watcher survives whatever the stream does, and so the stream model stays a
+ * log rather than a subscription list.
+ */
+export class SimKinesisStreamActivity {
+  private readonly watchers = new Map<string, SimKinesisStreamWatcher[]>();
+
+  /**
+   * Watch a stream for the records put onto it.
+   */
+  watch(streamArn: string, watcher: SimKinesisStreamWatcher): void {
+    this.watchers.set(streamArn, [...this.watchersOf(streamArn), watcher]);
+  }
+
+  /**
+   * Stop watching a stream.
+   */
+  unwatch(streamArn: string, watcher: SimKinesisStreamWatcher): void {
+    this.watchers.set(
+      streamArn,
+      this.watchersOf(streamArn).filter((held) => held !== watcher),
+    );
+  }
+
+  /**
+   * Tell a stream's watchers that there is something to read.
+   */
+  recordsAvailable(streamArn: string): void {
+    for (const watcher of this.watchersOf(streamArn)) {
+      watcher.recordsAvailable();
+    }
+  }
+
+  private watchersOf(streamArn: string): readonly SimKinesisStreamWatcher[] {
+    return this.watchers.get(streamArn) ?? [];
+  }
+}

--- a/src/service/kinesis/stream/sim-kinesis-stream-activity.ts
+++ b/src/service/kinesis/stream/sim-kinesis-stream-activity.ts
@@ -38,10 +38,20 @@ export class SimKinesisStreamActivity {
    * Stop watching a stream.
    */
   unwatch(streamArn: string, watcher: SimKinesisStreamWatcher): void {
-    this.watchers.set(
-      streamArn,
-      this.watchersOf(streamArn).filter((held) => held !== watcher),
+    const remaining = this.watchersOf(streamArn).filter(
+      (held) => held !== watcher,
     );
+
+    if (remaining.length === 0) {
+      // A stream nothing watches any more is forgotten. Keeping the empty list
+      // would grow one entry per stream ever watched, for the life of the
+      // simulation.
+      this.watchers.delete(streamArn);
+
+      return;
+    }
+
+    this.watchers.set(streamArn, [...remaining]);
   }
 
   /**

--- a/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-kinesis-event-source-mapping.iso.test.ts
+++ b/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-kinesis-event-source-mapping.iso.test.ts
@@ -1,0 +1,131 @@
+import { PutRecordCommand } from "@aws-sdk/client-kinesis";
+import { assertArrayLength, assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../../cloudformation/template/sim-cfn-template.js";
+import { simKinesisStreamFactory } from "../../../kinesis/stream/sim-kinesis-stream.factory.js";
+import type { SimLambdaKinesisStreamEvent } from "../../event-source/poll/kinesis/sim-lambda-kinesis-stream-event.types.js";
+
+const assumeRolePolicyDocument = {
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Principal: { Service: "lambda.amazonaws.com" },
+      Action: "sts:AssumeRole",
+    },
+  ],
+};
+
+/**
+ * A template with a projector function whose role may read a stream, and a
+ * mapping between them.
+ *
+ * The stream itself is made through the SDK rather than declared, because
+ * `AWS::Kinesis::Stream` is a separate piece of work. The mapping names it by
+ * the ARN it already has, which is what a template referring to a stream in
+ * another stack does anyway.
+ *
+ * The role's grant is split the way CDK's own `grantRead` splits it: the three
+ * stream operations on the stream ARN, and `ListStreams` on every stream.
+ */
+function projectorTemplate(streamArn: string): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      ProjectorRole: {
+        Type: "AWS::IAM::Role",
+        Properties: {
+          RoleName: "OrderProjectorRole",
+          AssumeRolePolicyDocument: assumeRolePolicyDocument,
+          Policies: [
+            {
+              PolicyName: "ReadOrdersStream",
+              PolicyDocument: {
+                Version: "2012-10-17",
+                Statement: [
+                  {
+                    Effect: "Allow",
+                    Action: [
+                      "kinesis:DescribeStream",
+                      "kinesis:GetRecords",
+                      "kinesis:GetShardIterator",
+                    ],
+                    Resource: streamArn,
+                  },
+                  {
+                    Effect: "Allow",
+                    Action: "kinesis:ListStreams",
+                    Resource: "*",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      ProjectorFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "order-projector",
+          Role: { "Fn::GetAtt": ["ProjectorRole", "Arn"] },
+        },
+      },
+      OrderProjectorMapping: {
+        Type: "AWS::Lambda::EventSourceMapping",
+        Properties: {
+          EventSourceArn: streamArn,
+          FunctionName: { Ref: "ProjectorFunction" },
+          BatchSize: 100,
+          StartingPosition: "TRIM_HORIZON",
+        },
+      },
+    },
+  };
+}
+
+describe("deployed Kinesis stream event source mappings", () => {
+  it("polls the stream a deployed mapping names", async () => {
+    // Given a stream, and a stack mapping it to a projector function.
+    const simAws = new SimAws();
+    const stream = await simKinesisStreamFactory.make({}, simAws);
+    const events: SimLambdaKinesisStreamEvent[] = [];
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: projectorTemplate(stream.arn),
+      bindings: [
+        {
+          logicalId: "ProjectorFunction",
+          handler: (event: SimLambdaKinesisStreamEvent): undefined => {
+            events.push(event);
+
+            return undefined;
+          },
+        },
+      ],
+    });
+    await stack.waitForDeployComplete();
+
+    // When a record is put onto the stream.
+    await simAws.kinesis().putRecord(
+      new PutRecordCommand({
+        StreamName: "orders",
+        PartitionKey: "customer-1",
+        Data: new TextEncoder().encode("order-1"),
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the deployed mapping delivered it, so the mapping the template
+    // described is one that actually polls.
+    assertArrayLength(events, 1);
+    assertArrayLength(events[0].Records, 1);
+    const record = events[0].Records[0];
+    assertIdentical(record.eventSourceARN, stream.arn);
+    assertIdentical(
+      Buffer.from(record.kinesis.data, "base64").toString(),
+      "order-1",
+    );
+  });
+});

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-input.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-input.ts
@@ -4,7 +4,7 @@ import {
   simLambdaEventSourceArnOf,
 } from "../../event-source/sim-lambda-event-source-arn.js";
 import type { SimLambdaFunctionResponseType } from "../../event-source/sim-lambda-event-source-mapping.js";
-import type { SimLambdaEventSourceStartingPosition } from "../../event-source/sim-lambda-event-source-starting-position.js";
+import type { SimLambdaEventSourceStart } from "../../event-source/sim-lambda-event-source-starting-position.js";
 import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
 import { simLambdaFunctionReferenceOf } from "../../function/sim-lambda-function-reference.js";
 import {
@@ -22,7 +22,7 @@ interface SimLambdaEventSourceMappingInputProperties {
   readonly functionName: string;
   readonly qualifier: string | undefined;
   readonly batchSize: number;
-  readonly startingPosition: SimLambdaEventSourceStartingPosition | undefined;
+  readonly start: SimLambdaEventSourceStart | undefined;
   readonly enabled: boolean;
   readonly functionResponseTypes: readonly SimLambdaFunctionResponseType[];
 }
@@ -50,9 +50,7 @@ export class SimLambdaEventSourceMappingInput {
    */
   public readonly qualifier: string | undefined;
   public readonly batchSize: number;
-  public readonly startingPosition:
-    | SimLambdaEventSourceStartingPosition
-    | undefined;
+  public readonly start: SimLambdaEventSourceStart | undefined;
   public readonly enabled: boolean;
   public readonly functionResponseTypes: readonly SimLambdaFunctionResponseType[];
 
@@ -61,7 +59,7 @@ export class SimLambdaEventSourceMappingInput {
     this.functionName = properties.functionName;
     this.qualifier = properties.qualifier;
     this.batchSize = properties.batchSize;
-    this.startingPosition = properties.startingPosition;
+    this.start = properties.start;
     this.enabled = properties.enabled;
     this.functionResponseTypes = properties.functionResponseTypes;
   }
@@ -85,7 +83,7 @@ export class SimLambdaEventSourceMappingInput {
         requiredString(input.FunctionName, "functionName"),
       ),
       batchSize: eventSourceArn.batchRules.sizeIn(input.BatchSize),
-      startingPosition: eventSourceArn.startingPositionRules.positionIn({
+      start: eventSourceArn.startingPositionRules.startIn({
         startingPosition: input.StartingPosition,
         startingPositionTimestamp: input.StartingPositionTimestamp,
       }),

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-refusals.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-refusals.ts
@@ -31,8 +31,8 @@ const unsimulatedInputs: ReadonlyMap<string, string> = new Map([
   ],
   [
     "ParallelizationFactor",
-    "polling concurrency is not simulated, and a simulated stream has one " +
-      "shard",
+    "polling concurrency is not simulated, so each shard of a stream is read " +
+      "by one reader",
   ],
   ["TumblingWindowInSeconds", "tumbling windows are not simulated"],
   [

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-validation.iso.test.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-validation.iso.test.ts
@@ -85,9 +85,11 @@ describe("sim Lambda CreateEventSourceMapping validation", () => {
     // Given a queue and a function.
     const ready = await simAwsReadyToMap();
 
-    // When a mapping names a Kinesis stream.
+    // When a mapping names an MSK cluster, which is a real Lambda event source
+    // this simulation has no broker for.
     const error = await refusedMapping(ready, {
-      EventSourceArn: "arn:aws:kinesis:eu-west-2:111111111111:stream/orders",
+      EventSourceArn:
+        "arn:aws:kafka:eu-west-2:111111111111:cluster/orders/a1b2c3d4-1",
     });
 
     // Then it is refused rather than accepted and never delivered from, and
@@ -99,7 +101,7 @@ describe("sim Lambda CreateEventSourceMapping validation", () => {
     );
     assertStringIncludes(
       error.message,
-      "SQS queues and DynamoDB streams are the simulated event sources",
+      "SQS queues, DynamoDB streams and Kinesis streams are the simulated",
     );
     assertStringIncludes(
       error.message,
@@ -119,7 +121,7 @@ describe("sim Lambda CreateEventSourceMapping validation", () => {
     assertStringIncludes(error.message, "Topics");
     assertStringIncludes(
       error.message,
-      "SQS queues and DynamoDB streams are the simulated event sources",
+      "SQS queues, DynamoDB streams and Kinesis streams are the simulated",
     );
   });
 

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping.handler.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping.handler.ts
@@ -10,6 +10,7 @@ import type { SimLambdaEventSourceMappingStore } from "../../event-source/sim-la
 import type { SimLambdaEventSourcePollers } from "../../event-source/sim-lambda-event-source-pollers.js";
 import { SimLambdaEventSourceReachable } from "../../event-source/sim-lambda-event-source-reachable.js";
 import { SimLambdaEventSourceRolePermissions } from "../../event-source/sim-lambda-event-source-role-permissions.js";
+import type { SimLambdaKinesisStreams } from "../../event-source/stream/kinesis/sim-lambda-kinesis-streams.js";
 import type { SimLambdaEventSourceStreams } from "../../event-source/stream/sim-lambda-event-source-streams.js";
 import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
 import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
@@ -27,6 +28,7 @@ interface CreateEventSourceMappingCommandHandlerProperties {
   readonly pollers: SimLambdaEventSourcePollers;
   readonly queues: SimSqsPollQueues;
   readonly streams: SimLambdaEventSourceStreams;
+  readonly kinesisStreams: SimLambdaKinesisStreams;
   readonly functions: SimLambdaFunctionLookup;
   readonly iam: SimIamInterServiceAuthZ;
   readonly background: BackgroundScheduler;
@@ -67,6 +69,7 @@ export class CreateEventSourceMappingCommandHandler implements CommandHandler<
     this.reachable = new SimLambdaEventSourceReachable({
       queues: properties.queues,
       streams: properties.streams,
+      kinesisStreams: properties.kinesisStreams,
     });
   }
 
@@ -138,7 +141,7 @@ export class CreateEventSourceMappingCommandHandler implements CommandHandler<
       // it, as real Lambda does.
       functionArn: target.resource.arn,
       batchSize: input.batchSize,
-      startingPosition: input.startingPosition,
+      start: input.start,
       enabled: input.enabled,
       functionResponseTypes: input.functionResponseTypes,
       createdAt: this.properties.background.now(),

--- a/src/service/lambda/command/event-source-mapping/sim-lambda-event-source-mapping-commands.ts
+++ b/src/service/lambda/command/event-source-mapping/sim-lambda-event-source-mapping-commands.ts
@@ -3,6 +3,7 @@ import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import type { SimSqsPollQueues } from "../../../sqs/poll/sim-sqs-poll-queues.js";
+import type { SimLambdaKinesisStreams } from "../../event-source/stream/kinesis/sim-lambda-kinesis-streams.js";
 import type { SimLambdaEventSourceStreams } from "../../event-source/stream/sim-lambda-event-source-streams.js";
 import type { SimLambdaEventSourceMapping } from "../../event-source/sim-lambda-event-source-mapping.js";
 import { SimLambdaEventSourceMappingStore } from "../../event-source/sim-lambda-event-source-mapping-store.js";
@@ -30,6 +31,7 @@ interface SimLambdaEventSourceMappingCommandsProperties {
   readonly pollers: SimLambdaEventSourcePollers;
   readonly queues: SimSqsPollQueues;
   readonly streams: SimLambdaEventSourceStreams;
+  readonly kinesisStreams: SimLambdaKinesisStreams;
   readonly functions: SimLambdaFunctionLookup;
   readonly iam: SimIamInterServiceAuthZ;
   readonly background: BackgroundScheduler;

--- a/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-polled-shard.ts
+++ b/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-polled-shard.ts
@@ -1,0 +1,50 @@
+import type { SimLambdaEventSourceStreamPosition } from "../../stream/sim-lambda-event-source-streams.js";
+import type {
+  SimLambdaKinesisStreamBatch,
+  SimLambdaKinesisStreams,
+} from "../../stream/kinesis/sim-lambda-kinesis-streams.js";
+
+interface SimLambdaKinesisPolledShardProperties {
+  readonly streams: SimLambdaKinesisStreams;
+  readonly streamArn: string;
+  readonly shardId: string;
+  readonly roleArn: string;
+}
+
+/**
+ * The one shard a shard poller reads.
+ *
+ * Every call names the same stream and the same shard, and all of them are made
+ * as the function's execution role, so all three are fixed here rather than
+ * written out at each call. Simulated IAM still decides each one, exactly as
+ * real IAM does.
+ */
+export class SimLambdaKinesisPolledShard {
+  private readonly streams: SimLambdaKinesisStreams;
+  private readonly streamArn: string;
+  private readonly shardId: string;
+  private readonly roleArn: string;
+
+  constructor(properties: SimLambdaKinesisPolledShardProperties) {
+    this.streams = properties.streams;
+    this.streamArn = properties.streamArn;
+    this.shardId = properties.shardId;
+    this.roleArn = properties.roleArn;
+  }
+
+  /**
+   * Read up to a batch of records from where the mapping left off.
+   */
+  async read(
+    position: SimLambdaEventSourceStreamPosition,
+    batchSize: number,
+  ): Promise<SimLambdaKinesisStreamBatch> {
+    return await this.streams.read({
+      streamArn: this.streamArn,
+      caller: { kind: "arn", arn: this.roleArn },
+      shardId: this.shardId,
+      position,
+      batchSize,
+    });
+  }
+}

--- a/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-shard-poller.ts
+++ b/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-shard-poller.ts
@@ -1,0 +1,117 @@
+import type { BackgroundScheduler } from "../../../../../util/background/background.js";
+import type { SimLambdaFunction } from "../../../function/sim-lambda-function.js";
+import type { SimLambdaFunctionLookup } from "../../../function/url/sim-lambda-function-lookup.js";
+import type { SimLambdaEventSourceMapping } from "../../sim-lambda-event-source-mapping.js";
+import { simLambdaEventSourceFunction } from "../sim-lambda-event-source-function.js";
+import {
+  type SimLambdaEventSourcePolls,
+  SimLambdaEventSourcePollTurn,
+} from "../sim-lambda-event-source-poll-turn.js";
+import { SimLambdaStreamProgress } from "../sim-lambda-stream-progress.js";
+import type { SimLambdaKinesisPolledShard } from "./sim-lambda-kinesis-polled-shard.js";
+import type { SimLambdaKinesisStreamDelivery } from "./sim-lambda-kinesis-stream-delivery.js";
+
+interface SimLambdaKinesisShardPollerProperties {
+  readonly mapping: SimLambdaEventSourceMapping;
+  readonly functions: SimLambdaFunctionLookup;
+  readonly shard: SimLambdaKinesisPolledShard;
+  readonly delivery: SimLambdaKinesisStreamDelivery;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * Polls one shard of one mapping's Kinesis stream and invokes its function.
+ *
+ * A shard is what a stream mapping actually reads, and real Lambda runs one
+ * processor per shard: each keeps its own place, delivers its own batches, and
+ * backs off on its own when a batch fails. That is why the checkpoint, the
+ * retry backoff and the turn all live here rather than on the stream poller
+ * above, which owns one of these per shard.
+ *
+ * Nothing else may read this shard while a delivery is in flight. A read record
+ * stays where it is, unlike a received message, so a second poll overlapping
+ * the first would hand the same records to the function twice.
+ */
+export class SimLambdaKinesisShardPoller implements SimLambdaEventSourcePolls {
+  private readonly mapping: SimLambdaEventSourceMapping;
+  private readonly functions: SimLambdaFunctionLookup;
+  private readonly shard: SimLambdaKinesisPolledShard;
+  private readonly delivery: SimLambdaKinesisStreamDelivery;
+  private readonly progress: SimLambdaStreamProgress;
+  private readonly turn = new SimLambdaEventSourcePollTurn(this);
+
+  private stopped = false;
+
+  constructor(properties: SimLambdaKinesisShardPollerProperties) {
+    this.mapping = properties.mapping;
+    this.functions = properties.functions;
+    this.shard = properties.shard;
+    this.delivery = properties.delivery;
+    this.progress = new SimLambdaStreamProgress({
+      mapping: properties.mapping,
+      background: properties.background,
+      poll: async (): Promise<void> => {
+        await this.turn.take();
+      },
+    });
+  }
+
+  /** Poll this shard as soon as the simulation gets to it. */
+  pollNow(): void {
+    this.progress.pollNow();
+  }
+
+  /** Stop polling this shard. */
+  stop(): void {
+    this.stopped = true;
+  }
+
+  /**
+   * Note a record put onto the stream, answering with whether this mapping's
+   * own function put it.
+   */
+  noteRecordWritten(): boolean {
+    return this.delivery.noteRecordWritten();
+  }
+
+  /**
+   * Read one batch off this shard, deliver it, and decide what happens next.
+   *
+   * Only ever called through the turn, which is what keeps two polls from
+   * reading the same records.
+   */
+  async poll(): Promise<void> {
+    const simFunction = this.pollingFunction();
+
+    if (simFunction === undefined) {
+      return;
+    }
+
+    const { progress } = this;
+    // Reading is done as the function's execution role, as on real Lambda, so
+    // simulated IAM decides whether this mapping may read its stream.
+    const batch = await this.shard.read(
+      progress.position,
+      this.mapping.batchSize,
+    );
+
+    if (batch.records.length === 0) {
+      progress.caughtUp(batch);
+
+      return;
+    }
+
+    progress.after(await this.delivery.to(simFunction, batch.records), batch);
+  }
+
+  /**
+   * The function this mapping delivers to, while it should be delivering.
+   */
+  private pollingFunction(): SimLambdaFunction | undefined {
+    if (this.stopped || !this.mapping.isPolling) {
+      return undefined;
+    }
+
+    return simLambdaEventSourceFunction(this.functions, this.mapping);
+  }
+}

--- a/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-shard-pollers.iso.test.ts
+++ b/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-shard-pollers.iso.test.ts
@@ -1,0 +1,107 @@
+import { assertArrayLength } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { BackgroundTasks } from "../../../../../util/background/background.js";
+import type { SimLambdaFunctionLookup } from "../../../function/url/sim-lambda-function-lookup.js";
+import type { SimLambdaEventSourceMapping } from "../../sim-lambda-event-source-mapping.js";
+import { SimLambdaKinesisEventSourceArn } from "../../stream/kinesis/sim-lambda-kinesis-event-source-arn.js";
+import type {
+  SimLambdaKinesisStreamBatch,
+  SimLambdaKinesisStreams,
+} from "../../stream/kinesis/sim-lambda-kinesis-streams.js";
+import { SimLambdaKinesisShardPollers } from "./sim-lambda-kinesis-shard-pollers.js";
+
+const eventSourceArn = SimLambdaKinesisEventSourceArn.of(
+  "arn:aws:kinesis:eu-west-2:111111111111:stream/orders",
+);
+
+/**
+ * A mapping that is polling and delivers to a function that is there.
+ */
+const mapping = {
+  isPolling: true,
+  functionName: "order-projector",
+  batchSize: 10,
+  reportsBatchItemFailures: false,
+  start: { position: "TRIM_HORIZON" },
+} as unknown as SimLambdaEventSourceMapping;
+
+const functions = {
+  findTarget: (): unknown => ({
+    simFunction: { roleArn: "arn:aws:iam::111111111111:role/Projector" },
+  }),
+} as unknown as SimLambdaFunctionLookup;
+
+/**
+ * Streams whose DescribeStream waits until a test lets it answer.
+ *
+ * That pause is the whole point: it is the window a mapping can be deleted in,
+ * which is what a real DescribeStream call leaves open too.
+ */
+class PausedStreams implements SimLambdaKinesisStreams {
+  readonly described: Promise<void>;
+
+  private release: (() => void) | undefined;
+  private answer: (() => void) | undefined;
+
+  constructor() {
+    this.described = new Promise<void>((resolve) => {
+      this.release = resolve;
+    });
+  }
+
+  /**
+   * Let the DescribeStream call answer.
+   */
+  answerNow(): void {
+    this.answer?.();
+  }
+
+  async shardIds(): Promise<readonly string[]> {
+    this.release?.();
+
+    await new Promise<void>((resolve) => {
+      this.answer = resolve;
+    });
+
+    return ["shardId-000000000000"];
+  }
+
+  read(): Promise<SimLambdaKinesisStreamBatch> {
+    return Promise.reject(new Error("nothing should read after stopping"));
+  }
+
+  watch(): void {
+    //
+  }
+
+  unwatch(): void {
+    //
+  }
+}
+
+describe("the shard pollers of a Kinesis stream mapping", () => {
+  it("makes none once it has been stopped mid-discovery", async () => {
+    // Given shard pollers part way through finding the shards of their stream.
+    const streams = new PausedStreams();
+    const shardPollers = new SimLambdaKinesisShardPollers({
+      mapping,
+      eventSourceArn,
+      functions,
+      kinesisStreams: streams,
+      background: new BackgroundTasks(),
+    });
+
+    const polling = shardPollers.polling();
+    await streams.described;
+
+    // When the mapping is stopped before that call answers.
+    shardPollers.stop();
+    streams.answerNow();
+
+    // Then the pollers the call would have made are dropped, so nothing is
+    // left polling a mapping that has gone.
+    assertArrayLength(await polling, 0);
+    assertArrayLength(shardPollers.made, 0);
+  });
+});

--- a/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-shard-pollers.ts
+++ b/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-shard-pollers.ts
@@ -1,0 +1,112 @@
+import type { BackgroundScheduler } from "../../../../../util/background/background.js";
+import type { SimLambdaFunctionLookup } from "../../../function/url/sim-lambda-function-lookup.js";
+import type { SimLambdaEventSourceMapping } from "../../sim-lambda-event-source-mapping.js";
+import type { SimLambdaKinesisEventSourceArn } from "../../stream/kinesis/sim-lambda-kinesis-event-source-arn.js";
+import type { SimLambdaKinesisStreams } from "../../stream/kinesis/sim-lambda-kinesis-streams.js";
+import { simLambdaEventSourceFunction } from "../sim-lambda-event-source-function.js";
+import { SimLambdaKinesisPolledShard } from "./sim-lambda-kinesis-polled-shard.js";
+import { SimLambdaKinesisShardPoller } from "./sim-lambda-kinesis-shard-poller.js";
+import { SimLambdaKinesisStreamDelivery } from "./sim-lambda-kinesis-stream-delivery.js";
+
+interface SimLambdaKinesisShardPollersProperties {
+  readonly mapping: SimLambdaEventSourceMapping;
+  readonly eventSourceArn: SimLambdaKinesisEventSourceArn;
+  readonly functions: SimLambdaFunctionLookup;
+  readonly kinesisStreams: SimLambdaKinesisStreams;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * The shard pollers of one mapping's stream, found once and kept.
+ *
+ * The shards are found on the first poll rather than when the mapping is
+ * created, because finding them is a DescribeStream call made as the function's
+ * execution role, and the function is what a poll starts from. Nothing here
+ * reshards, so the answer never changes.
+ */
+export class SimLambdaKinesisShardPollers {
+  private readonly properties: SimLambdaKinesisShardPollersProperties;
+  private held: readonly SimLambdaKinesisShardPoller[] | undefined;
+
+  constructor(properties: SimLambdaKinesisShardPollersProperties) {
+    this.properties = properties;
+  }
+
+  /**
+   * The shard pollers made so far, which is none until the first poll.
+   */
+  get made(): readonly SimLambdaKinesisShardPoller[] {
+    return this.held ?? [];
+  }
+
+  /**
+   * The shard pollers of this stream, making them if this is the first poll.
+   *
+   * A mapping that is not polling yet, or whose function has gone, has none:
+   * there is nothing to poll as, and the poll that follows activation makes
+   * them.
+   */
+  async polling(): Promise<readonly SimLambdaKinesisShardPoller[]> {
+    const held = this.held;
+
+    if (held !== undefined) {
+      return held;
+    }
+
+    const { mapping, functions } = this.properties;
+
+    if (!mapping.isPolling) {
+      return [];
+    }
+
+    const simFunction = simLambdaEventSourceFunction(functions, mapping);
+
+    if (simFunction === undefined) {
+      return [];
+    }
+
+    const made = await this.forRole(simFunction.roleArn);
+    this.held ??= made;
+
+    return this.held;
+  }
+
+  /**
+   * One poller for each shard the stream reports.
+   *
+   * Each gets its own shard to read and its own delivery, because the event a
+   * function receives names the shard its records came from and each shard's
+   * batches are answered for on their own.
+   */
+  private async forRole(
+    roleArn: string,
+  ): Promise<readonly SimLambdaKinesisShardPoller[]> {
+    const { mapping, eventSourceArn, kinesisStreams, background, functions } =
+      this.properties;
+    const shardIds = await kinesisStreams.shardIds({
+      streamArn: eventSourceArn.value,
+      caller: { kind: "arn", arn: roleArn },
+    });
+
+    return shardIds.map(
+      (shardId) =>
+        new SimLambdaKinesisShardPoller({
+          mapping,
+          functions,
+          background,
+          shard: new SimLambdaKinesisPolledShard({
+            streams: kinesisStreams,
+            streamArn: eventSourceArn.value,
+            shardId,
+            roleArn,
+          }),
+          delivery: new SimLambdaKinesisStreamDelivery({
+            mapping,
+            eventSourceArn,
+            shardId,
+            roleArn,
+          }),
+        }),
+    );
+  }
+}

--- a/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-shard-pollers.ts
+++ b/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-shard-pollers.ts
@@ -40,6 +40,23 @@ export class SimLambdaKinesisShardPollers {
   }
 
   /**
+   * Stop every shard poller, and make no more.
+   *
+   * Stopping settles this collection on having none, which is what the empty
+   * list means here. Finding the shards is a DescribeStream call, so a mapping
+   * stopped while that call is in flight would otherwise come back to shard
+   * pollers made after it stopped, which nothing would ever stop and which
+   * would go on delivering. Settling it now is what the read below finds.
+   */
+  stop(): void {
+    for (const shardPoller of this.made) {
+      shardPoller.stop();
+    }
+
+    this.held = [];
+  }
+
+  /**
    * The shard pollers of this stream, making them if this is the first poll.
    *
    * A mapping that is not polling yet, or whose function has gone, has none:
@@ -66,6 +83,10 @@ export class SimLambdaKinesisShardPollers {
     }
 
     const made = await this.forRole(simFunction.roleArn);
+
+    // Stopping may have happened while the shards were being asked for, and it
+    // settles this collection on the empty list. Keeping whatever is already
+    // settled is what drops the pollers that arrived too late.
     this.held ??= made;
 
     return this.held;

--- a/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-stream-delivery.ts
+++ b/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-stream-delivery.ts
@@ -1,0 +1,110 @@
+import type { SimLambdaFunction } from "../../../function/sim-lambda-function.js";
+import type { SimLambdaEventSourceMapping } from "../../sim-lambda-event-source-mapping.js";
+import type { SimLambdaKinesisEventSourceArn } from "../../stream/kinesis/sim-lambda-kinesis-event-source-arn.js";
+import type { SimLambdaKinesisStreamRecord } from "../../stream/kinesis/sim-lambda-kinesis-streams.js";
+import { SimLambdaStreamCascadeGuard } from "../../stream/sim-lambda-stream-cascade-guard.js";
+import type { SimLambdaStreamBatchOutcome } from "../sim-lambda-stream-batch-outcome.js";
+import { SimLambdaStreamBatchResponse } from "../sim-lambda-stream-batch-response.js";
+import { SimLambdaKinesisStreamEventBuilder } from "./sim-lambda-kinesis-stream-event.js";
+
+interface SimLambdaKinesisStreamDeliveryProperties {
+  readonly mapping: SimLambdaEventSourceMapping;
+  readonly eventSourceArn: SimLambdaKinesisEventSourceArn;
+  readonly shardId: string;
+  readonly roleArn: string;
+}
+
+/**
+ * Hands one shard's batch of records to a function and says what became of it.
+ *
+ * The batch is invoked directly rather than through the Invoke command because
+ * the handler's error has to be seen: an asynchronous invocation drops it, and
+ * this is what decides whether the mapping's checkpoint moves.
+ *
+ * There is one of these per shard, because the event a function receives names
+ * the shard its records were read from and each shard's batches are answered
+ * for on their own.
+ */
+export class SimLambdaKinesisStreamDelivery {
+  private readonly eventBuilder: SimLambdaKinesisStreamEventBuilder;
+  private readonly batchResponse: SimLambdaStreamBatchResponse;
+  private readonly cascade: SimLambdaStreamCascadeGuard;
+
+  constructor(properties: SimLambdaKinesisStreamDeliveryProperties) {
+    const { eventSourceArn } = properties;
+
+    this.eventBuilder = new SimLambdaKinesisStreamEventBuilder({
+      eventSourceArn,
+      shardId: properties.shardId,
+      roleArn: properties.roleArn,
+    });
+    this.batchResponse = new SimLambdaStreamBatchResponse(
+      properties.mapping.reportsBatchItemFailures,
+    );
+    this.cascade = new SimLambdaStreamCascadeGuard({
+      mapping: properties.mapping,
+      source: {
+        streamArn: eventSourceArn.value,
+        wroteTo: `put a record onto the stream ${eventSourceArn.streamName}`,
+        sourceRelation: "that same stream",
+        advice: "Put the result onto a different stream.",
+      },
+    });
+  }
+
+  /**
+   * Deliver a batch, answering with what became of it.
+   */
+  async to(
+    simFunction: SimLambdaFunction,
+    records: readonly SimLambdaKinesisStreamRecord[],
+  ): Promise<SimLambdaStreamBatchOutcome> {
+    return await this.cascade.around(
+      async () => await this.handled(simFunction, records),
+    );
+  }
+
+  /**
+   * Note a record put onto the polled stream, answering with whether this
+   * mapping's own function put it.
+   */
+  noteRecordWritten(): boolean {
+    return this.cascade.noteRecordWritten();
+  }
+
+  private async handled(
+    simFunction: SimLambdaFunction,
+    records: readonly SimLambdaKinesisStreamRecord[],
+  ): Promise<SimLambdaStreamBatchOutcome> {
+    try {
+      return this.batchResponse.handled(
+        sequenceNumbersOf(records),
+        await simFunction.invoke(this.eventBuilder.of(records)),
+      );
+    } catch {
+      // As on real Lambda, the handler error goes to the function's logs. What
+      // the stream sees is the batch being tried again.
+      return this.batchResponse.failed();
+    }
+  }
+}
+
+/**
+ * The sequence numbers a batch's records can be named by, in stream order.
+ *
+ * A Kinesis batch item failure names a record by its sequence number, the way a
+ * DynamoDB one does, rather than by the `eventID` the event carried.
+ */
+function sequenceNumbersOf(
+  records: readonly SimLambdaKinesisStreamRecord[],
+): readonly string[] {
+  return records.flatMap((record) => {
+    const sequenceNumber = record.SequenceNumber;
+
+    if (sequenceNumber === undefined || sequenceNumber === "") {
+      return [];
+    }
+
+    return [sequenceNumber];
+  });
+}

--- a/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-stream-event-source-poller.ts
+++ b/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-stream-event-source-poller.ts
@@ -1,0 +1,115 @@
+import type { BackgroundScheduler } from "../../../../../util/background/background.js";
+import { PollSchedule } from "../../../../../util/background/poll-schedule.js";
+import type { SimLambdaFunctionLookup } from "../../../function/url/sim-lambda-function-lookup.js";
+import type { SimLambdaEventSourceMapping } from "../../sim-lambda-event-source-mapping.js";
+import type { SimLambdaKinesisEventSourceArn } from "../../stream/kinesis/sim-lambda-kinesis-event-source-arn.js";
+import type { SimLambdaKinesisStreams } from "../../stream/kinesis/sim-lambda-kinesis-streams.js";
+import type { SimLambdaEventSourcePoller } from "../sim-lambda-event-source-poller.js";
+import { SimLambdaKinesisShardPollers } from "./sim-lambda-kinesis-shard-pollers.js";
+
+interface SimLambdaKinesisStreamEventSourcePollerProperties {
+  readonly mapping: SimLambdaEventSourceMapping;
+  readonly eventSourceArn: SimLambdaKinesisEventSourceArn;
+  readonly functions: SimLambdaFunctionLookup;
+  readonly kinesisStreams: SimLambdaKinesisStreams;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * Polls one event source mapping's Kinesis stream and invokes its function.
+ *
+ * A Kinesis stream has as many shards as it was created with, and real Lambda
+ * reads every one of them with a processor of its own. This owns one shard
+ * poller per shard and does nothing itself but pass the wake-ups on. Everything
+ * that makes a stream mapping what it is, the checkpoint, the backoff and the
+ * one-poll-at-a-time turn, belongs to a shard rather than to the stream.
+ *
+ * That is the difference from the DynamoDB stream poller, which is the whole of
+ * itself because a simulated table's stream has one shard.
+ */
+export class SimLambdaKinesisStreamEventSourcePoller implements SimLambdaEventSourcePoller {
+  private readonly streamArn: string;
+  private readonly kinesisStreams: SimLambdaKinesisStreams;
+  private readonly shardPollers: SimLambdaKinesisShardPollers;
+  private readonly schedule: PollSchedule;
+
+  constructor(properties: SimLambdaKinesisStreamEventSourcePollerProperties) {
+    this.streamArn = properties.eventSourceArn.value;
+    this.kinesisStreams = properties.kinesisStreams;
+    this.shardPollers = new SimLambdaKinesisShardPollers(properties);
+    this.schedule = new PollSchedule({
+      background: properties.background,
+      poll: async (): Promise<void> => {
+        await this.pollShards();
+      },
+    });
+  }
+
+  /**
+   * Watch the stream this mapping polls.
+   *
+   * Watching starts as soon as the mapping is created, before it has finished
+   * creating, so a record put in between is not missed. The poll it wakes finds
+   * a mapping that is not polling yet and does nothing, and the poll that
+   * follows activation reads from the starting position.
+   */
+  watch(): void {
+    this.kinesisStreams.watch(this.streamArn, this);
+  }
+
+  /**
+   * Poll as soon as the simulation gets to it, which is what a newly enabled
+   * mapping does with whatever its stream already holds.
+   */
+  pollNow(): void {
+    this.schedule.now();
+  }
+
+  /**
+   * Stop polling, as deleting the mapping does.
+   */
+  stop(): void {
+    this.schedule.stop();
+    this.kinesisStreams.unwatch(this.streamArn, this);
+
+    for (const shardPoller of this.shardPollers.made) {
+      shardPoller.stop();
+    }
+  }
+
+  /**
+   * Take a record arriving on the stream as something to poll for.
+   *
+   * A record put while this mapping's own function is running is the function
+   * writing back into its own source stream. That never settles, so the mapping
+   * stops here and the delivery refuses once it is over. Only the shard that is
+   * mid-delivery answers, since only it is inside the delivery.
+   */
+  recordsAvailable(): void {
+    const cascading = this.shardPollers.made.some((shardPoller) =>
+      shardPoller.noteRecordWritten(),
+    );
+
+    if (cascading) {
+      this.stop();
+
+      return;
+    }
+
+    this.schedule.now();
+  }
+
+  /**
+   * Poll every shard of the stream.
+   *
+   * Each shard takes its own turn from here, so a shard that is mid-delivery
+   * notes the wake-up and comes back to it rather than reading twice.
+   */
+  private async pollShards(): Promise<void> {
+    const polling = await this.shardPollers.polling();
+
+    for (const shardPoller of polling) {
+      shardPoller.pollNow();
+    }
+  }
+}

--- a/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-stream-event-source-poller.ts
+++ b/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-stream-event-source-poller.ts
@@ -71,10 +71,7 @@ export class SimLambdaKinesisStreamEventSourcePoller implements SimLambdaEventSo
   stop(): void {
     this.schedule.stop();
     this.kinesisStreams.unwatch(this.streamArn, this);
-
-    for (const shardPoller of this.shardPollers.made) {
-      shardPoller.stop();
-    }
+    this.shardPollers.stop();
   }
 
   /**

--- a/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-stream-event.ts
+++ b/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-stream-event.ts
@@ -1,0 +1,105 @@
+import type { SimLambdaKinesisEventSourceArn } from "../../stream/kinesis/sim-lambda-kinesis-event-source-arn.js";
+import type { SimLambdaKinesisStreamRecord } from "../../stream/kinesis/sim-lambda-kinesis-streams.js";
+import type {
+  SimLambdaKinesisStreamEvent,
+  SimLambdaKinesisStreamEventRecord,
+  SimLambdaKinesisStreamEventRecordBody,
+} from "./sim-lambda-kinesis-stream-event.types.js";
+
+const millisecondsPerSecond = 1000;
+
+/**
+ * The schema version every Kinesis event record carries.
+ *
+ * Real Lambda has only ever sent 1.0, and a function that reads it is reading a
+ * constant.
+ */
+const kinesisSchemaVersion = "1.0";
+
+interface SimLambdaKinesisStreamEventBuilderProperties {
+  readonly eventSourceArn: SimLambdaKinesisEventSourceArn;
+  readonly shardId: string;
+  readonly roleArn: string;
+}
+
+/**
+ * Builds the Kinesis stream event for one batch of polled records.
+ *
+ * The casing here is the event's own and is not a tidy scheme: `eventID` has a
+ * capital ID, `kinesis` has none, `eventSourceARN` has a capital ARN, and the
+ * block inside `kinesis` is lower-cased where the DynamoDB one is capitalized.
+ * All of it is what a function actually receives, so all of it is written out.
+ *
+ * The two real translations are the payload and the instant. Kinesis hands a
+ * poller raw bytes and a `Date`, and a function receives base64 text and epoch
+ * seconds, which is what makes the event JSON a handler can be given.
+ */
+export class SimLambdaKinesisStreamEventBuilder {
+  private readonly eventSourceArn: SimLambdaKinesisEventSourceArn;
+  private readonly shardId: string;
+  private readonly roleArn: string;
+
+  constructor(properties: SimLambdaKinesisStreamEventBuilderProperties) {
+    this.eventSourceArn = properties.eventSourceArn;
+    this.shardId = properties.shardId;
+    this.roleArn = properties.roleArn;
+  }
+
+  /**
+   * The event for a batch of records.
+   */
+  of(
+    records: readonly SimLambdaKinesisStreamRecord[],
+  ): SimLambdaKinesisStreamEvent {
+    return { Records: records.map((record) => this.record(record)) };
+  }
+
+  /**
+   * The identifier one record is named by in the event.
+   *
+   * Real Lambda joins the shard the record was read from to the record's own
+   * sequence number, so it is unique across the whole stream rather than within
+   * one shard.
+   */
+  eventIdOf(record: SimLambdaKinesisStreamRecord): string {
+    return `${this.shardId}:${record.SequenceNumber ?? ""}`;
+  }
+
+  private record(
+    record: SimLambdaKinesisStreamRecord,
+  ): SimLambdaKinesisStreamEventRecord {
+    return {
+      eventID: this.eventIdOf(record),
+      eventName: "aws:kinesis:record",
+      eventVersion: kinesisSchemaVersion,
+      eventSource: "aws:kinesis",
+      awsRegion: this.eventSourceArn.regionName,
+      kinesis: eventRecordBody(record),
+      eventSourceARN: this.eventSourceArn.value,
+      // Real Lambda names the execution role it read the record with, which is
+      // the role this poll was made as.
+      invokeIdentityArn: this.roleArn,
+    };
+  }
+}
+
+/**
+ * The Kinesis block of one event record.
+ */
+function eventRecordBody(
+  record: SimLambdaKinesisStreamRecord,
+): SimLambdaKinesisStreamEventRecordBody {
+  const arrivedAt = record.ApproximateArrivalTimestamp;
+
+  return {
+    kinesisSchemaVersion,
+    partitionKey: record.PartitionKey ?? "",
+    sequenceNumber: record.SequenceNumber ?? "",
+    data: Buffer.from(record.Data ?? new Uint8Array()).toString("base64"),
+    // Epoch seconds, where the API gives an instant. Real Lambda sends
+    // fractional seconds, which is what keeps two records put in the same
+    // second apart.
+    approximateArrivalTimestamp:
+      arrivedAt === undefined ? 0 : arrivedAt.getTime() / millisecondsPerSecond,
+  };
+}

--- a/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-stream-event.types.ts
+++ b/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-stream-event.types.ts
@@ -1,0 +1,35 @@
+/**
+ * The Kinesis part of one event record.
+ *
+ * The casing here is the event's own. Everything inside `kinesis` is
+ * lower-cased, unlike the DynamoDB stream event, whose inner block is
+ * capitalized.
+ */
+export interface SimLambdaKinesisStreamEventRecordBody {
+  readonly kinesisSchemaVersion: string;
+  readonly partitionKey: string;
+  readonly sequenceNumber: string;
+  readonly data: string;
+  readonly approximateArrivalTimestamp: number;
+}
+
+/**
+ * One record as a function receives it from a Kinesis event source.
+ */
+export interface SimLambdaKinesisStreamEventRecord {
+  readonly eventID: string;
+  readonly eventName: string;
+  readonly eventVersion: string;
+  readonly eventSource: "aws:kinesis";
+  readonly awsRegion: string;
+  readonly kinesis: SimLambdaKinesisStreamEventRecordBody;
+  readonly eventSourceARN: string;
+  readonly invokeIdentityArn: string;
+}
+
+/**
+ * The event a function receives from a Kinesis event source mapping.
+ */
+export interface SimLambdaKinesisStreamEvent {
+  readonly Records: readonly SimLambdaKinesisStreamEventRecord[];
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-delivery.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-delivery.ts
@@ -39,7 +39,15 @@ export class SimLambdaDynamoDbStreamDelivery {
     this.batchResponse = new SimLambdaStreamBatchResponse(
       properties.mapping.reportsBatchItemFailures,
     );
-    this.cascade = new SimLambdaStreamCascadeGuard(properties);
+    this.cascade = new SimLambdaStreamCascadeGuard({
+      mapping: properties.mapping,
+      source: {
+        streamArn: properties.eventSourceArn.value,
+        wroteTo: `wrote to the table ${properties.eventSourceArn.tableName}`,
+        sourceRelation: "that table's own stream",
+        advice: "Write the result to a different table.",
+      },
+    });
   }
 
   /**
@@ -68,7 +76,7 @@ export class SimLambdaDynamoDbStreamDelivery {
   ): Promise<SimLambdaStreamBatchOutcome> {
     try {
       return this.batchResponse.handled(
-        records,
+        sequenceNumbersOf(records),
         await simFunction.invoke(this.eventBuilder.of(records)),
       );
     } catch {
@@ -77,4 +85,21 @@ export class SimLambdaDynamoDbStreamDelivery {
       return this.batchResponse.failed();
     }
   }
+}
+
+/**
+ * The sequence numbers a batch's records can be named by, in stream order.
+ */
+function sequenceNumbersOf(
+  records: readonly SimLambdaEventSourceStreamRecord[],
+): readonly string[] {
+  return records.flatMap((record) => {
+    const sequenceNumber = record.dynamodb?.SequenceNumber;
+
+    if (sequenceNumber === undefined || sequenceNumber === "") {
+      return [];
+    }
+
+    return [sequenceNumber];
+  });
 }

--- a/src/service/lambda/event-source/poll/sim-lambda-event-source-poller-factory.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-event-source-poller-factory.ts
@@ -3,8 +3,10 @@ import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-func
 import type { SimSqsPollQueues } from "../../../sqs/poll/sim-sqs-poll-queues.js";
 import type { SimLambdaEventSourceArn } from "../sim-lambda-event-source-arn.js";
 import type { SimLambdaEventSourceMapping } from "../sim-lambda-event-source-mapping.js";
+import type { SimLambdaKinesisStreams } from "../stream/kinesis/sim-lambda-kinesis-streams.js";
 import type { SimLambdaEventSourceStreams } from "../stream/sim-lambda-event-source-streams.js";
 import { SimSqsQueuePoller } from "../../../sqs/poll/sim-sqs-queue-poller.js";
+import { SimLambdaKinesisStreamEventSourcePoller } from "./kinesis/sim-lambda-kinesis-stream-event-source-poller.js";
 import { SimLambdaDynamoDbStreamEventSourcePoller } from "./sim-lambda-dynamodb-stream-event-source-poller.js";
 import type { SimLambdaEventSourcePoller } from "./sim-lambda-event-source-poller.js";
 import { SimLambdaSqsEventSourceConsumer } from "./sim-lambda-sqs-event-source-consumer.js";
@@ -15,6 +17,7 @@ export interface SimLambdaEventSourcePollerProperties {
   readonly functions: SimLambdaFunctionLookup;
   readonly queues: SimSqsPollQueues;
   readonly streams: SimLambdaEventSourceStreams;
+  readonly kinesisStreams: SimLambdaKinesisStreams;
   readonly background: BackgroundScheduler;
 }
 
@@ -50,6 +53,13 @@ export function makeSimLambdaEventSourcePoller(
 
     case "dynamodb-stream": {
       return new SimLambdaDynamoDbStreamEventSourcePoller({
+        ...properties,
+        eventSourceArn,
+      });
+    }
+
+    case "kinesis-stream": {
+      return new SimLambdaKinesisStreamEventSourcePoller({
         ...properties,
         eventSourceArn,
       });

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-batch-response.iso.test.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-batch-response.iso.test.ts
@@ -1,10 +1,7 @@
 import { assertIdentical, assertTrue } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
-import type {
-  SimLambdaEventSourceStreamPosition,
-  SimLambdaEventSourceStreamRecord,
-} from "../stream/sim-lambda-event-source-streams.js";
+import type { SimLambdaEventSourceStreamPosition } from "../stream/sim-lambda-event-source-streams.js";
 import { SimLambdaStreamBatchResponse } from "./sim-lambda-stream-batch-response.js";
 
 /**
@@ -16,11 +13,10 @@ const readFrom: SimLambdaEventSourceStreamPosition = {
   shardIterator: "iterator-1",
 };
 
-const records: readonly SimLambdaEventSourceStreamRecord[] = [
-  { eventID: "event-1", dynamodb: { SequenceNumber: "100" } },
-  { eventID: "event-2", dynamodb: { SequenceNumber: "200" } },
-  { eventID: "event-3", dynamodb: { SequenceNumber: "300" } },
-];
+/**
+ * The sequence numbers one batch carried, in stream order.
+ */
+const records: readonly string[] = ["100", "200", "300"];
 
 /**
  * The sequence number the next read starts at, or the iterator it starts from
@@ -111,12 +107,12 @@ describe("sim Lambda stream batch responses", () => {
   });
 
   it("names no record for a batch whose records carry no sequence number", () => {
-    // Given a mapping expecting a failure report, and a batch of records the
-    // stream handed over without sequence numbers.
+    // Given a mapping expecting a failure report, and a batch whose records the
+    // stream handed over without sequence numbers, so none can be named.
     const response = new SimLambdaStreamBatchResponse(true);
 
     // When the function reports an entry naming nothing.
-    const outcome = response.handled([{ eventID: "event-1" }], {
+    const outcome = response.handled([], {
       batchItemFailures: [{ itemIdentifier: "" }],
     });
 

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-batch-response.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-batch-response.ts
@@ -1,4 +1,3 @@
-import type { SimLambdaEventSourceStreamRecord } from "../stream/sim-lambda-event-source-streams.js";
 import { SimLambdaBatchItemFailures } from "./sim-lambda-batch-item-failures.js";
 import { SimLambdaStreamBatchOutcome } from "./sim-lambda-stream-batch-outcome.js";
 
@@ -26,9 +25,14 @@ export class SimLambdaStreamBatchResponse {
 
   /**
    * What became of a batch the function returned from.
+   *
+   * The sequence numbers are the batch's own, in stream order, and each source
+   * cuts them out of its own record shape. A record carrying none is left out
+   * rather than given an empty name, so a report entry with no identifier names
+   * nothing and the whole batch goes back.
    */
   handled(
-    records: readonly SimLambdaEventSourceStreamRecord[],
+    sequenceNumbers: readonly string[],
     result: unknown,
   ): SimLambdaStreamBatchOutcome {
     const failedIds = this.batchItemFailures.idsIn(result);
@@ -37,7 +41,7 @@ export class SimLambdaStreamBatchResponse {
       return SimLambdaStreamBatchOutcome.handled();
     }
 
-    const rewindTo = rewindPoint(failedIds, sequenceNumbersOf(records));
+    const rewindTo = rewindPoint(failedIds, sequenceNumbers);
 
     if (rewindTo === undefined) {
       return this.failed();
@@ -53,26 +57,6 @@ export class SimLambdaStreamBatchResponse {
   failed(): SimLambdaStreamBatchOutcome {
     return SimLambdaStreamBatchOutcome.failed();
   }
-}
-
-/**
- * The sequence numbers a batch's records can be named by, in stream order.
- *
- * A record carrying none is left out rather than given an empty name, so a
- * report entry with no identifier names nothing and the whole batch goes back.
- */
-function sequenceNumbersOf(
-  records: readonly SimLambdaEventSourceStreamRecord[],
-): readonly string[] {
-  return records.flatMap((record) => {
-    const sequenceNumber = record.dynamodb?.SequenceNumber;
-
-    if (sequenceNumber === undefined || sequenceNumber === "") {
-      return [];
-    }
-
-    return [sequenceNumber];
-  });
 }
 
 /**

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-checkpoint.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-checkpoint.ts
@@ -1,4 +1,4 @@
-import type { SimLambdaEventSourceStartingPosition } from "../sim-lambda-event-source-starting-position.js";
+import type { SimLambdaEventSourceStart } from "../sim-lambda-event-source-starting-position.js";
 import type { SimLambdaEventSourceStreamPosition } from "../stream/sim-lambda-event-source-streams.js";
 import type { SimLambdaStreamBatchOutcome } from "./sim-lambda-stream-batch-outcome.js";
 
@@ -15,8 +15,8 @@ import type { SimLambdaStreamBatchOutcome } from "./sim-lambda-stream-batch-outc
 export class SimLambdaStreamCheckpoint {
   #position: SimLambdaEventSourceStreamPosition;
 
-  constructor(startingPosition: SimLambdaEventSourceStartingPosition) {
-    this.#position = { kind: "starting", startingPosition };
+  constructor(start: SimLambdaEventSourceStart) {
+    this.#position = { kind: "starting", start };
   }
 
   /**

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-progress.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-progress.ts
@@ -5,8 +5,8 @@ import type {
 import { assertDefined } from "../../../../util/type-guard/defined.js";
 import type { SimLambdaEventSourceMapping } from "../sim-lambda-event-source-mapping.js";
 import type {
-  SimLambdaEventSourceStreamBatch,
   SimLambdaEventSourceStreamPosition,
+  SimLambdaEventSourceStreamProgressBatch,
 } from "../stream/sim-lambda-event-source-streams.js";
 import { PollSchedule } from "../../../../util/background/poll-schedule.js";
 import type { SimLambdaStreamBatchOutcome } from "./sim-lambda-stream-batch-outcome.js";
@@ -39,10 +39,10 @@ export class SimLambdaStreamProgress {
     // A stream mapping is refused at creation unless it names a starting
     // position, so one that has got this far without one is the simulator
     // having gone wrong rather than a request having been wrong.
-    const { startingPosition } = properties.mapping;
-    assertDefined(startingPosition, "DynamoDB stream mapping start position");
+    const { start } = properties.mapping;
+    assertDefined(start, "stream mapping start position");
 
-    this.checkpoint = new SimLambdaStreamCheckpoint(startingPosition);
+    this.checkpoint = new SimLambdaStreamCheckpoint(start);
     this.schedule = new PollSchedule(properties);
   }
 
@@ -67,7 +67,7 @@ export class SimLambdaStreamProgress {
    * resolves to, so the mapping settles on one place to read on from rather
    * than working out a new one each time.
    */
-  caughtUp(batch: SimLambdaEventSourceStreamBatch): void {
+  caughtUp(batch: SimLambdaEventSourceStreamProgressBatch): void {
     this.checkpoint.advanceTo(batch.next);
   }
 
@@ -76,7 +76,7 @@ export class SimLambdaStreamProgress {
    */
   after(
     outcome: SimLambdaStreamBatchOutcome,
-    batch: SimLambdaEventSourceStreamBatch,
+    batch: SimLambdaEventSourceStreamProgressBatch,
   ): void {
     if (outcome.isHandled) {
       this.handled(batch);
@@ -90,7 +90,7 @@ export class SimLambdaStreamProgress {
   /**
    * Move past a batch the function took, and read on.
    */
-  handled(batch: SimLambdaEventSourceStreamBatch): void {
+  handled(batch: SimLambdaEventSourceStreamProgressBatch): void {
     this.backoff.reset();
     this.checkpoint.advanceTo(batch.next);
 
@@ -113,7 +113,7 @@ export class SimLambdaStreamProgress {
    */
   failed(
     outcome: SimLambdaStreamBatchOutcome,
-    batch: SimLambdaEventSourceStreamBatch,
+    batch: SimLambdaEventSourceStreamProgressBatch,
   ): void {
     if (this.backoff.isExhausted) {
       this.handled(batch);

--- a/src/service/lambda/event-source/sim-lambda-event-source-arn.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-arn.ts
@@ -1,5 +1,6 @@
 import { SimLambdaInvalidParameterValueException } from "../error/sim-lambda.error.js";
 import { SimLambdaSqsEventSourceArn } from "./queue/sim-lambda-sqs-event-source-arn.js";
+import { SimLambdaKinesisEventSourceArn } from "./stream/kinesis/sim-lambda-kinesis-event-source-arn.js";
 import { SimLambdaDynamoDbStreamEventSourceArn } from "./stream/sim-lambda-dynamodb-stream-event-source-arn.js";
 
 /**
@@ -12,14 +13,16 @@ import { SimLambdaDynamoDbStreamEventSourceArn } from "./stream/sim-lambda-dynam
  */
 export type SimLambdaEventSourceArn =
   | SimLambdaSqsEventSourceArn
-  | SimLambdaDynamoDbStreamEventSourceArn;
+  | SimLambdaDynamoDbStreamEventSourceArn
+  | SimLambdaKinesisEventSourceArn;
 
 /**
  * What this simulation polls, said in one place so every refusal that mentions
  * it says the same thing.
  */
 export const simulatedEventSourcesDescription =
-  "SQS queues and DynamoDB streams are the simulated event sources";
+  "SQS queues, DynamoDB streams and Kinesis streams are the simulated event " +
+  "sources";
 
 /**
  * The ARN shapes those event sources are named by.
@@ -27,6 +30,7 @@ export const simulatedEventSourcesDescription =
 const simulatedEventSourceArnShapes: readonly string[] = [
   SimLambdaSqsEventSourceArn.arnShape,
   SimLambdaDynamoDbStreamEventSourceArn.arnShape,
+  SimLambdaKinesisEventSourceArn.arnShape,
 ];
 
 /**
@@ -41,7 +45,8 @@ export function simLambdaEventSourceArnOf(
 ): SimLambdaEventSourceArn {
   const parsed =
     SimLambdaSqsEventSourceArn.parse(eventSourceArn) ??
-    SimLambdaDynamoDbStreamEventSourceArn.parse(eventSourceArn);
+    SimLambdaDynamoDbStreamEventSourceArn.parse(eventSourceArn) ??
+    SimLambdaKinesisEventSourceArn.parse(eventSourceArn);
 
   if (parsed === undefined) {
     const arnShapes = simulatedEventSourceArnShapes.join(". ");

--- a/src/service/lambda/event-source/sim-lambda-event-source-mapping.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-mapping.ts
@@ -2,7 +2,10 @@ import { randomUUID } from "node:crypto";
 
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type { SimLambdaFunctionArn } from "../function/sim-lambda-function-configuration.js";
-import type { SimLambdaEventSourceStartingPosition } from "./sim-lambda-event-source-starting-position.js";
+import type {
+  SimLambdaEventSourceStart,
+  SimLambdaEventSourceStartingPosition,
+} from "./sim-lambda-event-source-starting-position.js";
 
 /**
  * Event source mapping ARNs address the mapping by its UUID.
@@ -36,7 +39,7 @@ interface SimLambdaEventSourceMappingProperties {
   readonly qualifier?: string | undefined;
   readonly functionArn: SimLambdaFunctionArn;
   readonly batchSize: number;
-  readonly startingPosition?: SimLambdaEventSourceStartingPosition | undefined;
+  readonly start?: SimLambdaEventSourceStart | undefined;
   readonly enabled?: boolean | undefined;
   readonly functionResponseTypes?:
     | readonly SimLambdaFunctionResponseType[]
@@ -56,6 +59,7 @@ export interface SimLambdaEventSourceMappingConfiguration {
   readonly FunctionArn: SimLambdaFunctionArn;
   readonly BatchSize: number;
   readonly StartingPosition?: SimLambdaEventSourceStartingPosition | undefined;
+  readonly StartingPositionTimestamp?: Date | undefined;
   readonly MaximumBatchingWindowInSeconds: number;
   readonly FunctionResponseTypes: readonly SimLambdaFunctionResponseType[];
   readonly State: SimLambdaEventSourceMappingState;
@@ -93,9 +97,7 @@ export class SimLambdaEventSourceMapping {
    *
    * A queue mapping has none, because a queue only has a front.
    */
-  public readonly startingPosition:
-    | SimLambdaEventSourceStartingPosition
-    | undefined;
+  public readonly start: SimLambdaEventSourceStart | undefined;
   public readonly functionResponseTypes: readonly SimLambdaFunctionResponseType[];
 
   private readonly accountRegionScope: SimAwsAccountRegionScope;
@@ -110,7 +112,7 @@ export class SimLambdaEventSourceMapping {
     this.qualifier = properties.qualifier;
     this.functionArn = properties.functionArn;
     this.batchSize = properties.batchSize;
-    this.startingPosition = properties.startingPosition;
+    this.start = properties.start;
     // Copied rather than held, so a caller keeping the list it passed in
     // cannot change what this mapping does with a batch afterwards.
     this.functionResponseTypes = [...(properties.functionResponseTypes ?? [])];
@@ -170,7 +172,8 @@ export class SimLambdaEventSourceMapping {
       EventSourceArn: this.eventSourceArn,
       FunctionArn: this.functionArn,
       BatchSize: this.batchSize,
-      StartingPosition: this.startingPosition,
+      StartingPosition: this.start?.position,
+      StartingPositionTimestamp: this.start?.timestamp,
       // Partial batches are delivered as soon as anything is available, so the
       // batching window is always zero. Anything else is refused at creation.
       MaximumBatchingWindowInSeconds: 0,

--- a/src/service/lambda/event-source/sim-lambda-event-source-pollers.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-pollers.ts
@@ -5,12 +5,14 @@ import type { SimLambdaEventSourcePoller } from "./poll/sim-lambda-event-source-
 import type { SimSqsPollQueues } from "../../sqs/poll/sim-sqs-poll-queues.js";
 import type { SimLambdaEventSourceArn } from "./sim-lambda-event-source-arn.js";
 import type { SimLambdaEventSourceMapping } from "./sim-lambda-event-source-mapping.js";
+import type { SimLambdaKinesisStreams } from "./stream/kinesis/sim-lambda-kinesis-streams.js";
 import type { SimLambdaEventSourceStreams } from "./stream/sim-lambda-event-source-streams.js";
 
 interface SimLambdaEventSourcePollersProperties {
   readonly functions: SimLambdaFunctionLookup;
   readonly queues: SimSqsPollQueues;
   readonly streams: SimLambdaEventSourceStreams;
+  readonly kinesisStreams: SimLambdaKinesisStreams;
   readonly background: BackgroundScheduler;
 }
 

--- a/src/service/lambda/event-source/sim-lambda-event-source-reachable.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-reachable.ts
@@ -1,10 +1,12 @@
 import type { SimSqsPollQueues } from "../../sqs/poll/sim-sqs-poll-queues.js";
 import type { SimLambdaEventSourceArn } from "./sim-lambda-event-source-arn.js";
+import type { SimLambdaKinesisStreams } from "./stream/kinesis/sim-lambda-kinesis-streams.js";
 import type { SimLambdaEventSourceStreams } from "./stream/sim-lambda-event-source-streams.js";
 
 interface SimLambdaEventSourceReachableProperties {
   readonly queues: SimSqsPollQueues;
   readonly streams: SimLambdaEventSourceStreams;
+  readonly kinesisStreams: SimLambdaKinesisStreams;
 }
 
 /**
@@ -19,10 +21,12 @@ interface SimLambdaEventSourceReachableProperties {
 export class SimLambdaEventSourceReachable {
   private readonly queues: SimSqsPollQueues;
   private readonly streams: SimLambdaEventSourceStreams;
+  private readonly kinesisStreams: SimLambdaKinesisStreams;
 
   constructor(properties: SimLambdaEventSourceReachableProperties) {
     this.queues = properties.queues;
     this.streams = properties.streams;
+    this.kinesisStreams = properties.kinesisStreams;
   }
 
   /**
@@ -46,6 +50,15 @@ export class SimLambdaEventSourceReachable {
 
       case "dynamodb-stream": {
         await this.streams.tableName({
+          streamArn: eventSourceArn.value,
+          caller,
+        });
+
+        return;
+      }
+
+      case "kinesis-stream": {
+        await this.kinesisStreams.shardIds({
           streamArn: eventSourceArn.value,
           caller,
         });

--- a/src/service/lambda/event-source/sim-lambda-event-source-starting-position.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-starting-position.ts
@@ -4,10 +4,24 @@ import { SimLambdaInvalidParameterValueException } from "../error/sim-lambda.err
  * Where on a stream a mapping starts reading.
  *
  * `AT_TIMESTAMP` is the third position real Lambda takes, and it is for a
- * Kinesis stream rather than a DynamoDB one, so it is refused by name rather
- * than left out of this type quietly.
+ * Kinesis stream rather than a DynamoDB one.
  */
-export type SimLambdaEventSourceStartingPosition = "TRIM_HORIZON" | "LATEST";
+export type SimLambdaEventSourceStartingPosition =
+  | "TRIM_HORIZON"
+  | "LATEST"
+  | "AT_TIMESTAMP";
+
+/**
+ * Where a mapping starts reading, and when, for the position that needs an
+ * instant.
+ *
+ * The two travel together because `AT_TIMESTAMP` means nothing without the
+ * instant, and every other position means nothing with one.
+ */
+export interface SimLambdaEventSourceStart {
+  readonly position: SimLambdaEventSourceStartingPosition;
+  readonly timestamp?: Date | undefined;
+}
 
 /**
  * The parts of a request that say where a mapping starts reading.
@@ -33,12 +47,12 @@ export interface SimLambdaEventSourceStartingPositionInput {
  */
 export interface SimLambdaEventSourceStartingPositionRules {
   /**
-   * The position a mapping on this source starts from, refusing a request that
-   * asks for one this source does not have.
+   * Where a mapping on this source starts, refusing a request that asks for a
+   * position this source does not have.
    */
-  positionIn(
+  startIn(
     input: SimLambdaEventSourceStartingPositionInput,
-  ): SimLambdaEventSourceStartingPosition | undefined;
+  ): SimLambdaEventSourceStart | undefined;
 }
 
 /**
@@ -54,9 +68,9 @@ export class SimLambdaNoStartingPosition implements SimLambdaEventSourceStarting
   /**
    * Refuse a starting position, since this source has nowhere else to start.
    */
-  positionIn(
+  startIn(
     input: SimLambdaEventSourceStartingPositionInput,
-  ): SimLambdaEventSourceStartingPosition | undefined {
+  ): SimLambdaEventSourceStart | undefined {
     if (
       input.startingPosition === undefined &&
       input.startingPositionTimestamp === undefined
@@ -71,44 +85,98 @@ export class SimLambdaNoStartingPosition implements SimLambdaEventSourceStarting
   }
 }
 
+interface SimLambdaStreamStartingPositionProperties {
+  /**
+   * The positions this stream takes, which is the pair every stream takes plus
+   * `AT_TIMESTAMP` for the streams that have it.
+   */
+  readonly positions: readonly SimLambdaEventSourceStartingPosition[];
+  readonly sourceDescription: string;
+
+  /**
+   * Where a position this stream lacks does belong, for a refusal to say so.
+   *
+   * `AT_TIMESTAMP` is a real Lambda starting position that a DynamoDB stream
+   * does not take, and a caller that names it has picked the wrong source
+   * rather than made something up.
+   */
+  readonly positionElsewhere?: string | undefined;
+}
+
 /**
- * The rules for a DynamoDB stream, which takes one of two positions.
+ * The rules for a stream, which has to be told where to start.
  */
 export class SimLambdaStreamStartingPosition implements SimLambdaEventSourceStartingPositionRules {
+  private readonly positions: readonly SimLambdaEventSourceStartingPosition[];
+  private readonly sourceDescription: string;
+  private readonly positionElsewhere: string | undefined;
+
+  constructor(properties: SimLambdaStreamStartingPositionProperties) {
+    this.positions = properties.positions;
+    this.sourceDescription = properties.sourceDescription;
+    this.positionElsewhere = properties.positionElsewhere;
+  }
+
   /**
-   * The position a mapping on a stream starts from.
+   * Where a mapping on this stream starts.
    *
    * `StartingPositionTimestamp` only goes with `AT_TIMESTAMP`, so it is refused
-   * along with it rather than being accepted and ignored.
+   * alongside any other position rather than being accepted and ignored.
    */
-  positionIn(
+  startIn(
     input: SimLambdaEventSourceStartingPositionInput,
-  ): SimLambdaEventSourceStartingPosition {
-    const requested = input.startingPosition;
+  ): SimLambdaEventSourceStart {
+    const position = this.readPosition(input.startingPosition);
+    const timestamp = input.startingPositionTimestamp;
 
-    if (requested === undefined) {
-      throw new SimLambdaInvalidParameterValueException(
-        "StartingPosition is required for a DynamoDB stream event source " +
-          "mapping. TRIM_HORIZON reads what the stream still holds, LATEST " +
-          "reads only what the table changes from now on",
-      );
+    if (position === "AT_TIMESTAMP") {
+      return { position, timestamp: this.requiredTimestamp(timestamp) };
     }
 
-    if (requested !== "TRIM_HORIZON" && requested !== "LATEST") {
-      throw new SimLambdaInvalidParameterValueException(
-        `StartingPosition ${requested} is not valid for a DynamoDB stream: ` +
-          "TRIM_HORIZON and LATEST are the two a DynamoDB stream takes, and " +
-          "AT_TIMESTAMP is for a Kinesis stream",
-      );
-    }
-
-    if (input.startingPositionTimestamp !== undefined) {
+    if (timestamp !== undefined) {
       throw new SimLambdaInvalidParameterValueException(
         "StartingPositionTimestamp only goes with the StartingPosition " +
-          "AT_TIMESTAMP, which is for a Kinesis stream",
+          "AT_TIMESTAMP",
       );
     }
 
-    return requested;
+    return { position };
+  }
+
+  private readPosition(
+    requested: string | undefined,
+  ): SimLambdaEventSourceStartingPosition {
+    if (requested === undefined) {
+      throw new SimLambdaInvalidParameterValueException(
+        `StartingPosition is required for ${this.sourceDescription} event ` +
+          "source mapping. TRIM_HORIZON reads what the stream still holds, " +
+          "LATEST reads only what arrives from now on",
+      );
+    }
+
+    const found = this.positions.find((position) => position === requested);
+
+    if (found === undefined) {
+      const elsewhere = this.positionElsewhere;
+
+      throw new SimLambdaInvalidParameterValueException(
+        `StartingPosition ${requested} is not valid for ${this.sourceDescription}: ${this.positions.join(" and ")} are the ones it takes${
+          elsewhere === undefined ? "" : `, and ${elsewhere}`
+        }`,
+      );
+    }
+
+    return found;
+  }
+
+  private requiredTimestamp(timestamp: Date | undefined): Date {
+    if (timestamp === undefined || Number.isNaN(timestamp.getTime())) {
+      throw new SimLambdaInvalidParameterValueException(
+        "StartingPosition AT_TIMESTAMP requires a StartingPositionTimestamp " +
+          "that is a date",
+      );
+    }
+
+    return timestamp;
   }
 }

--- a/src/service/lambda/event-source/sim-lambda-kinesis-batch-failures.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-kinesis-batch-failures.iso.test.ts
@@ -1,0 +1,160 @@
+import { PutRecordsCommand } from "@aws-sdk/client-kinesis";
+import { assertArrayEquals, assertArrayLength } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simAwsWithKinesisEventSource } from "../../../../test/lambda/kinesis-event-source-fixture.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import type {
+  SimLambdaKinesisStreamEvent,
+  SimLambdaKinesisStreamEventRecord,
+} from "./poll/kinesis/sim-lambda-kinesis-stream-event.types.js";
+
+/**
+ * The orders one batch carries.
+ */
+const orderIds = ["order-1", "order-2", "order-3"];
+
+/**
+ * The whole batch, as one delivery of it reads.
+ */
+const wholeBatch = orderIds.join(", ");
+
+/**
+ * What one report entry names, which is a sequence number for a stream.
+ */
+interface BatchItemFailure {
+  readonly itemIdentifier: unknown;
+}
+
+/**
+ * The order one delivered record carried.
+ */
+function orderIn(record: SimLambdaKinesisStreamEventRecord): string {
+  return Buffer.from(record.kinesis.data, "base64").toString("utf8");
+}
+
+/**
+ * What each delivery carried, as a line per delivery.
+ */
+function deliveries(
+  events: readonly SimLambdaKinesisStreamEvent[],
+): readonly string[] {
+  return events.map((event) =>
+    event.Records.map((record) => orderIn(record)).join(", "),
+  );
+}
+
+/**
+ * A handler reporting a batch item failure the first time it is given the
+ * batch, and handling everything it is given after that.
+ *
+ * The retry is the interesting part of every test here, so the failure has to
+ * stop: a handler that always reported would be delivered the same records
+ * until the mapping gave up on them.
+ */
+function reportingOnce(
+  failures: (event: SimLambdaKinesisStreamEvent) => readonly BatchItemFailure[],
+): (event: SimLambdaKinesisStreamEvent) => unknown {
+  let reported = false;
+
+  return (event: SimLambdaKinesisStreamEvent): unknown => {
+    if (reported) {
+      return undefined;
+    }
+
+    reported = true;
+
+    return { batchItemFailures: failures(event) };
+  };
+}
+
+/**
+ * Put the batch onto one shard, by giving every record one partition key, and
+ * let the mapping get through its first delivery and the retry after it.
+ *
+ * The retry waits a second on the simulation's clock, so advancing time is what
+ * brings the failed batch back.
+ */
+async function putBatch(simAws: SimAws): Promise<void> {
+  await simAws.kinesis().putRecords(
+    new PutRecordsCommand({
+      StreamName: "orders",
+      Records: orderIds.map((orderId) => ({
+        PartitionKey: "customer-1",
+        Data: new TextEncoder().encode(orderId),
+      })),
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+  await simAws.clock().advanceBy({ seconds: 1 });
+}
+
+describe("sim Lambda Kinesis stream batch item failures", () => {
+  it("goes back to the record a report names", async () => {
+    // Given a mapping expecting a failure report, whose handler reports the
+    // second record of its first batch.
+    const { simAws, events } = await simAwsWithKinesisEventSource({
+      functionResponseTypes: ["ReportBatchItemFailures"],
+      handlerResult: reportingOnce((event) => [
+        { itemIdentifier: event.Records[1]?.kinesis.sequenceNumber },
+      ]),
+    });
+
+    // When a batch of three records is put onto one shard.
+    await putBatch(simAws);
+
+    // Then the batch went over again from the record the report named, so the
+    // record after it was delivered a second time even though the function did
+    // not name it.
+    assertArrayEquals(deliveries(events), [wholeBatch, "order-2, order-3"]);
+  });
+
+  it("goes back to the lowest record of several a report names", async () => {
+    // Given a handler reporting the last two records, out of order.
+    const { simAws, events } = await simAwsWithKinesisEventSource({
+      functionResponseTypes: ["ReportBatchItemFailures"],
+      handlerResult: reportingOnce((event) => [
+        { itemIdentifier: event.Records[2]?.kinesis.sequenceNumber },
+        { itemIdentifier: event.Records[1]?.kinesis.sequenceNumber },
+      ]),
+    });
+
+    // When the batch is put.
+    await putBatch(simAws);
+
+    // Then reading went back to the earlier of the two.
+    assertArrayEquals(deliveries(events), [wholeBatch, "order-2, order-3"]);
+  });
+
+  it("takes the whole batch back for a report naming a record it did not hold", async () => {
+    // Given a handler reporting a sequence number that was not in the batch.
+    const { simAws, events } = await simAwsWithKinesisEventSource({
+      functionResponseTypes: ["ReportBatchItemFailures"],
+      handlerResult: reportingOnce(() => [{ itemIdentifier: "1" }]),
+    });
+
+    // When the batch is put.
+    await putBatch(simAws);
+
+    // Then the whole batch went over again, rather than guessing which record
+    // was meant. Guessing wrong on a stream skips records.
+    assertArrayEquals(deliveries(events), [wholeBatch, wholeBatch]);
+  });
+
+  it("ignores a report from a mapping that was not told to expect one", async () => {
+    // Given a mapping with no ReportBatchItemFailures, whose handler reports
+    // one anyway.
+    const { simAws, events } = await simAwsWithKinesisEventSource({
+      handlerResult: reportingOnce((event) => [
+        { itemIdentifier: event.Records[1]?.kinesis.sequenceNumber },
+      ]),
+    });
+
+    // When the batch is put.
+    await putBatch(simAws);
+
+    // Then the batch counts as handled, since nothing was reading the report.
+    assertArrayLength(events, 1);
+    assertArrayEquals(deliveries(events), [wholeBatch]);
+  });
+});

--- a/src/service/lambda/event-source/sim-lambda-kinesis-cascade.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-kinesis-cascade.iso.test.ts
@@ -1,0 +1,87 @@
+import { PutRecordCommand } from "@aws-sdk/client-kinesis";
+import { assertStringIncludes, assertThrowsErrorAsync } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simAwsWithKinesisEventSource } from "../../../../test/lambda/kinesis-event-source-fixture.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simKinesisStreamFactory } from "../../kinesis/stream/sim-kinesis-stream.factory.js";
+import type { SimLambdaKinesisStreamEvent } from "./poll/kinesis/sim-lambda-kinesis-stream-event.types.js";
+
+/**
+ * A record carrying how many records the batch before it held.
+ */
+function totalRecord(
+  streamName: string,
+  event: SimLambdaKinesisStreamEvent,
+): PutRecordCommand {
+  return new PutRecordCommand({
+    StreamName: streamName,
+    PartitionKey: "totals",
+    Data: new TextEncoder().encode(`total-${String(event.Records.length)}`),
+  });
+}
+
+describe("sim Lambda Kinesis stream event source write cascades", () => {
+  it("refuses a function that puts records back onto its own source stream", async () => {
+    // Given a function whose handler puts an aggregate onto the stream that
+    // invoked it, which is a loop rather than a projection.
+    const simAws = new SimAws();
+    await simAwsWithKinesisEventSource({
+      simAws,
+      handlerResult: (event: SimLambdaKinesisStreamEvent): Promise<unknown> =>
+        simAws.kinesis().putRecord(totalRecord("orders", event)),
+    });
+
+    // When a record is put onto the stream.
+    await simAws.kinesis().putRecord(
+      new PutRecordCommand({
+        StreamName: "orders",
+        PartitionKey: "customer-1",
+        Data: new TextEncoder().encode("order-1"),
+      }),
+    );
+
+    // Then the simulation refuses rather than going round forever, naming the
+    // function and the stream.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.backgroundTasksComplete();
+    });
+
+    assertStringIncludes(error.message, "order-projector");
+    assertStringIncludes(error.message, "the stream orders");
+    assertStringIncludes(error.message, "that same stream");
+    assertStringIncludes(error.message, "Put the result onto a different");
+  });
+
+  it("allows a function that puts records onto a second stream", async () => {
+    // Given a function whose handler puts its projection somewhere else.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({ streamName: "order-totals" }, simAws);
+    await simAwsWithKinesisEventSource({
+      simAws,
+      handlerResult: (event: SimLambdaKinesisStreamEvent): Promise<unknown> =>
+        simAws.kinesis().putRecord(totalRecord("order-totals", event)),
+    });
+
+    // When a record is put onto the source stream.
+    await simAws.kinesis().putRecord(
+      new PutRecordCommand({
+        StreamName: "orders",
+        PartitionKey: "customer-1",
+        Data: new TextEncoder().encode("order-1"),
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the projection is on the second stream, and nothing refused it.
+    const totals = simAws.kinesis().findStream("order-totals");
+    const records = (totals?.shards ?? []).flatMap((shard) => [
+      ...shard.records,
+    ]);
+
+    assertStringIncludes(
+      records.map((record) => new TextDecoder().decode(record.data)).join(","),
+      "total-1",
+    );
+  });
+});

--- a/src/service/lambda/event-source/sim-lambda-kinesis-event-source-disabled.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-kinesis-event-source-disabled.iso.test.ts
@@ -1,0 +1,96 @@
+import { PutRecordCommand } from "@aws-sdk/client-kinesis";
+import {
+  CreateEventSourceMappingCommand,
+  DeleteFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import { assertArrayLength } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  makeKinesisPollingRole,
+  simAwsWithKinesisEventSource,
+} from "../../../../test/lambda/kinesis-event-source-fixture.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simKinesisStreamFactory } from "../../kinesis/stream/sim-kinesis-stream.factory.js";
+import { makeLambdaZipFileInput } from "../function/code/lambda-zip-file-input.js";
+import type { SimLambdaKinesisStreamEvent } from "./poll/kinesis/sim-lambda-kinesis-stream-event.types.js";
+
+describe("a sim Lambda Kinesis mapping with nothing to deliver to", () => {
+  it("delivers nothing while the mapping is disabled", async () => {
+    // Given a stream, a role that may read it, and a function.
+    const simAws = new SimAws();
+    const stream = await simKinesisStreamFactory.make({}, simAws);
+    const roleArn = await makeKinesisPollingRole(simAws, stream.arn);
+    const events: SimLambdaKinesisStreamEvent[] = [];
+
+    await simAws.lambda().createFunction({
+      input: {
+        FunctionName: "order-projector",
+        Role: roleArn,
+        Code: {
+          ZipFile: makeLambdaZipFileInput(
+            (event: SimLambdaKinesisStreamEvent): undefined => {
+              events.push(event);
+
+              return undefined;
+            },
+          ),
+        },
+      },
+    });
+
+    // When a mapping is created disabled, and a record is put.
+    await simAws.lambda().createEventSourceMapping(
+      new CreateEventSourceMappingCommand({
+        EventSourceArn: stream.arn,
+        FunctionName: "order-projector",
+        StartingPosition: "TRIM_HORIZON",
+        Enabled: false,
+      }),
+    );
+    await simAws.kinesis().putRecord(
+      new PutRecordCommand({
+        StreamName: "orders",
+        PartitionKey: "customer-1",
+        Data: new TextEncoder().encode("order-1"),
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then nothing was delivered, since a disabled mapping does not poll.
+    assertArrayLength(events, 0);
+  });
+
+  it("delivers nothing once the function it maps to has gone", async () => {
+    // Given a mapping that has delivered a record.
+    const { simAws, events } = await simAwsWithKinesisEventSource();
+    await simAws.kinesis().putRecord(
+      new PutRecordCommand({
+        StreamName: "orders",
+        PartitionKey: "customer-1",
+        Data: new TextEncoder().encode("order-1"),
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+    assertArrayLength(events, 1);
+
+    // When the function is deleted and another record is put.
+    await simAws
+      .lambda()
+      .deleteFunction(
+        new DeleteFunctionCommand({ FunctionName: "order-projector" }),
+      );
+    await simAws.kinesis().putRecord(
+      new PutRecordCommand({
+        StreamName: "orders",
+        PartitionKey: "customer-2",
+        Data: new TextEncoder().encode("order-2"),
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the poll found nothing to deliver to and did nothing, rather than
+    // raising at whoever was waiting for the simulation to settle.
+    assertArrayLength(events, 1);
+  });
+});

--- a/src/service/lambda/event-source/sim-lambda-kinesis-event-source-lifecycle.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-kinesis-event-source-lifecycle.iso.test.ts
@@ -1,0 +1,68 @@
+import { PutRecordCommand } from "@aws-sdk/client-kinesis";
+import { DeleteEventSourceMappingCommand } from "@aws-sdk/client-lambda";
+import { assertArrayLength } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simAwsWithKinesisEventSource } from "../../../../test/lambda/kinesis-event-source-fixture.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+
+/**
+ * Put one order onto the stream and let the simulation settle.
+ */
+async function putOrder(simAws: SimAws, id: string): Promise<void> {
+  await simAws.kinesis().putRecord(
+    new PutRecordCommand({
+      StreamName: "orders",
+      PartitionKey: id,
+      Data: new TextEncoder().encode(id),
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+}
+
+describe("the life of a sim Lambda Kinesis stream event source mapping", () => {
+  it("stops delivering once the mapping is deleted", async () => {
+    // Given a mapping that has delivered a record.
+    const { simAws, uuid, events } = await simAwsWithKinesisEventSource();
+    await putOrder(simAws, "order-1");
+    assertArrayLength(events, 1);
+
+    // When the mapping is deleted and another record is put.
+    await simAws
+      .lambda()
+      .deleteEventSourceMapping(
+        new DeleteEventSourceMappingCommand({ UUID: uuid }),
+      );
+    await putOrder(simAws, "order-2");
+
+    // Then nothing more reached the function.
+    assertArrayLength(events, 1);
+  });
+
+  it("delivers nothing while a handler keeps throwing, then carries on", async () => {
+    // Given a mapping whose handler always throws.
+    const { simAws, events } = await simAwsWithKinesisEventSource({
+      handlerResult: (): unknown => {
+        throw new Error("the projector is broken");
+      },
+    });
+
+    // When a record is put and the mapping is given every attempt it gets.
+    await putOrder(simAws, "order-1");
+
+    for (const seconds of [1, 2, 4, 8, 16]) {
+      // oxlint-disable-next-line no-await-in-loop
+      await simAws.clock().advanceBy({ seconds });
+    }
+
+    // Then the batch was handed over once and then retried the five times the
+    // mapping allows, and the mapping gave up on it rather than blocking the
+    // shard forever.
+    assertArrayLength(events, 6);
+
+    // And a record put afterwards is delivered, since the shard moved past the
+    // batch it discarded.
+    await putOrder(simAws, "order-2");
+    assertArrayLength(events, 7);
+  });
+});

--- a/src/service/lambda/event-source/sim-lambda-kinesis-event-source-lifecycle.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-kinesis-event-source-lifecycle.iso.test.ts
@@ -65,4 +65,21 @@ describe("the life of a sim Lambda Kinesis stream event source mapping", () => {
     await putOrder(simAws, "order-2");
     assertArrayLength(events, 7);
   });
+
+  it("delivers nothing from a mapping deleted before it ever polled", async () => {
+    // Given a mapping that has delivered nothing yet.
+    const { simAws, uuid, events } = await simAwsWithKinesisEventSource();
+
+    // When it is deleted before the simulation has settled, and a record is
+    // put afterwards.
+    await simAws
+      .lambda()
+      .deleteEventSourceMapping(
+        new DeleteEventSourceMappingCommand({ UUID: uuid }),
+      );
+    await putOrder(simAws, "order-1");
+
+    // Then nothing reached the function.
+    assertArrayLength(events, 0);
+  });
 });

--- a/src/service/lambda/event-source/sim-lambda-kinesis-event-source-validation.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-kinesis-event-source-validation.iso.test.ts
@@ -1,0 +1,138 @@
+import { assertStringIncludes, assertThrowsErrorAsync } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  kinesisPollingActions,
+  makeKinesisPollingRole,
+} from "../../../../test/lambda/kinesis-event-source-fixture.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simKinesisStreamFactory } from "../../kinesis/stream/sim-kinesis-stream.factory.js";
+import { makeLambdaZipFileInput } from "../function/code/lambda-zip-file-input.js";
+
+/**
+ * A simulated AWS with a stream and a function whose role may poll it.
+ */
+async function simAwsWithStreamAndFunction(
+  roleActions: readonly string[] = kinesisPollingActions,
+  roleResource?: string,
+): Promise<{ readonly simAws: SimAws; readonly streamArn: string }> {
+  const simAws = new SimAws();
+  const stream = await simKinesisStreamFactory.make({}, simAws);
+  const roleArn = await makeKinesisPollingRole(
+    simAws,
+    roleResource ?? stream.arn,
+    roleActions,
+  );
+
+  await simAws.lambda().createFunction({
+    input: {
+      FunctionName: "order-projector",
+      Role: roleArn,
+      Code: { ZipFile: makeLambdaZipFileInput((): undefined => undefined) },
+    },
+  });
+
+  return { simAws, streamArn: stream.arn };
+}
+
+/**
+ * Create a mapping, giving back whatever it was refused with.
+ */
+async function refusalFrom(
+  simAws: SimAws,
+  input: {
+    readonly EventSourceArn: string;
+    readonly StartingPosition?: string;
+  },
+): Promise<Error> {
+  return await assertThrowsErrorAsync(async () => {
+    await simAws.lambda().createEventSourceMapping({
+      input: { ...input, FunctionName: "order-projector" },
+    });
+  });
+}
+
+describe("sim Lambda Kinesis stream event source mapping validation", () => {
+  it("refuses a mapping whose role may not read the stream", async () => {
+    // Given a function whose role may describe the stream but not read it.
+    const { simAws, streamArn } = await simAwsWithStreamAndFunction([
+      "kinesis:DescribeStream",
+      "kinesis:GetShardIterator",
+    ]);
+
+    // When a mapping is created on that stream.
+    const error = await refusalFrom(simAws, {
+      EventSourceArn: streamArn,
+      StartingPosition: "TRIM_HORIZON",
+    });
+
+    // Then it is refused at creation, naming the operation it cannot call,
+    // rather than being created and delivering nothing.
+    assertStringIncludes(
+      error.message,
+      "does not have permissions to call GetRecords on Kinesis Data Streams",
+    );
+  });
+
+  it("refuses a mapping to a stream that is not there", async () => {
+    // Given a function whose role may read any stream in the Account.
+    const { simAws } = await simAwsWithStreamAndFunction(
+      kinesisPollingActions,
+      "*",
+    );
+
+    // When a mapping is created on a stream nothing made.
+    const error = await refusalFrom(simAws, {
+      EventSourceArn: `arn:aws:kinesis:${simAws.defaultRegionName}:${simAws.defaultAccountId}:stream/nowhere`,
+      StartingPosition: "TRIM_HORIZON",
+    });
+
+    // Then it is refused rather than left subscribed to nothing.
+    assertStringIncludes(error.message, "does not exist");
+  });
+
+  it("refuses a mapping on a stream with no starting position", async () => {
+    // Given a stream and a function.
+    const { simAws, streamArn } = await simAwsWithStreamAndFunction();
+
+    // When a mapping is created without saying where to start.
+    const error = await refusalFrom(simAws, { EventSourceArn: streamArn });
+
+    // Then it is refused, since replaying the stream and taking only what
+    // arrives next are both reasonable and neither is a default.
+    assertStringIncludes(
+      error.message,
+      "StartingPosition is required for a Kinesis stream",
+    );
+  });
+
+  it("refuses an AT_TIMESTAMP mapping with no timestamp", async () => {
+    // Given a stream and a function.
+    const { simAws, streamArn } = await simAwsWithStreamAndFunction();
+
+    // When a mapping is created to start at an instant it does not name.
+    const error = await refusalFrom(simAws, {
+      EventSourceArn: streamArn,
+      StartingPosition: "AT_TIMESTAMP",
+    });
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "requires a StartingPositionTimestamp");
+  });
+
+  it("refuses a mapping naming an enhanced fan-out consumer", async () => {
+    // Given a stream and a function.
+    const { simAws, streamArn } = await simAwsWithStreamAndFunction();
+
+    // When a mapping is created on a consumer of that stream.
+    const error = await refusalFrom(simAws, {
+      EventSourceArn: `${streamArn}/consumer/projector:1756000000`,
+      StartingPosition: "TRIM_HORIZON",
+    });
+
+    // Then it is refused, since enhanced fan-out is unsimulated and a consumer
+    // ARN is not the stream ARN with something harmless on the end.
+    assertStringIncludes(error.message, "names no simulated Lambda event");
+    assertStringIncludes(error.message, "Kinesis stream ARN is");
+  });
+});

--- a/src/service/lambda/event-source/sim-lambda-kinesis-event-source.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-kinesis-event-source.iso.test.ts
@@ -1,0 +1,180 @@
+import { PutRecordCommand, PutRecordsCommand } from "@aws-sdk/client-kinesis";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertSetSize,
+  assertStringStartsWith,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simAwsWithKinesisEventSource } from "../../../../test/lambda/kinesis-event-source-fixture.js";
+import { SimFixedClock } from "../../../util/clock/sim-clock.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimLambdaKinesisStreamEvent } from "./poll/kinesis/sim-lambda-kinesis-stream-event.types.js";
+
+const startedAt = new Date("2026-08-22T09:00:00.000Z");
+
+/**
+ * Put one order onto the stream, under a partition key of its own.
+ */
+async function putOrder(simAws: SimAws, id: string): Promise<void> {
+  await simAws.kinesis().putRecord(
+    new PutRecordCommand({
+      StreamName: "orders",
+      PartitionKey: id,
+      Data: new TextEncoder().encode(id),
+    }),
+  );
+}
+
+/**
+ * What every delivered record carried, in the order the function saw it.
+ */
+function deliveredData(
+  events: readonly SimLambdaKinesisStreamEvent[],
+): readonly string[] {
+  return events
+    .flatMap((event) => event.Records)
+    .map((record) => Buffer.from(record.kinesis.data, "base64").toString());
+}
+
+describe("sim Lambda Kinesis stream event source mappings", () => {
+  it("delivers a record put on the stream as a Kinesis event", async () => {
+    // Given a Kinesis stream mapped to a function.
+    const { simAws, streamArn, events } = await simAwsWithKinesisEventSource({
+      simAws: new SimAws({ clock: new SimFixedClock(startedAt) }),
+    });
+
+    // When a record is put onto the stream.
+    await simAws.kinesis().putRecord(
+      new PutRecordCommand({
+        StreamName: "orders",
+        PartitionKey: "customer-1",
+        Data: new TextEncoder().encode('{"id":"order-1"}'),
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the handler was given one real-shaped Kinesis record.
+    assertArrayLength(events, 1);
+
+    const record = events[0].Records[0];
+    assertNonNullable(record);
+    assertIdentical(record.eventSource, "aws:kinesis");
+    assertIdentical(record.eventName, "aws:kinesis:record");
+    assertIdentical(record.eventSourceARN, streamArn);
+    assertIdentical(record.awsRegion, simAws.defaultRegionName);
+    assertStringStartsWith(record.eventID, "shardId-000000000000:");
+
+    // And the payload is base64 of what was put, with the arrival in epoch
+    // seconds rather than as an instant.
+    const { kinesis } = record;
+    assertIdentical(kinesis.kinesisSchemaVersion, "1.0");
+    assertIdentical(kinesis.partitionKey, "customer-1");
+    assertIdentical(
+      Buffer.from(kinesis.data, "base64").toString("utf8"),
+      '{"id":"order-1"}',
+    );
+    assertIdentical(
+      kinesis.approximateArrivalTimestamp,
+      startedAt.getTime() / 1000,
+    );
+  });
+
+  it("delivers every record of a stream with more than one shard", async () => {
+    // Given a stream with four shards mapped to a function.
+    const { simAws, events } = await simAwsWithKinesisEventSource({
+      shardCount: 4,
+    });
+
+    // When twenty records are put under different partition keys, which spreads
+    // them across the shards.
+    await simAws.kinesis().putRecords(
+      new PutRecordsCommand({
+        StreamName: "orders",
+        Records: Array.from({ length: 20 }, (_unused, index) => ({
+          PartitionKey: `customer-${index}`,
+          Data: new TextEncoder().encode(`order-${index}`),
+        })),
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then every record reached the function, whichever shard it landed on.
+    const delivered = events
+      .flatMap((event) => event.Records)
+      .map((record) => Buffer.from(record.kinesis.data, "base64").toString());
+    assertArrayLength(delivered, 20);
+    assertSetSize(new Set(delivered), 20);
+  });
+
+  it("delivers a batch of records in one invocation up to the batch size", async () => {
+    // Given a stream mapped to a function taking three records at a time.
+    const { simAws, events } = await simAwsWithKinesisEventSource({
+      batchSize: 3,
+    });
+
+    // When five records are put under one partition key, so all are on one
+    // shard and their order is fixed.
+    await simAws.kinesis().putRecords(
+      new PutRecordsCommand({
+        StreamName: "orders",
+        Records: Array.from({ length: 5 }, (_unused, index) => ({
+          PartitionKey: "customer-1",
+          Data: new TextEncoder().encode(`order-${index}`),
+        })),
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then they arrived as a batch of three and then a batch of two, in the
+    // order they were put.
+    assertArrayLength(events, 2);
+    assertArrayLength(events[0].Records, 3);
+    assertArrayLength(events[1].Records, 2);
+
+    const delivered = events
+      .flatMap((event) => event.Records)
+      .map((record) => Buffer.from(record.kinesis.data, "base64").toString());
+    assertIdentical(
+      delivered.join(","),
+      "order-0,order-1,order-2,order-3,order-4",
+    );
+  });
+
+  it("delivers only what arrives next to a LATEST mapping", async () => {
+    // Given a mapping created to read only what the stream takes from now on.
+    const { simAws, events } = await simAwsWithKinesisEventSource({
+      startingPosition: "LATEST",
+    });
+
+    // When a record the stream already holds is followed by a new one.
+    await putOrder(simAws, "order-1");
+    await simAws.backgroundTasksComplete();
+    await putOrder(simAws, "order-2");
+    await simAws.backgroundTasksComplete();
+
+    // Then only the one put after the mapping started reading is delivered.
+    assertIdentical(deliveredData(events).join(","), "order-2");
+  });
+
+  it("delivers from an instant to an AT_TIMESTAMP mapping", async () => {
+    // Given a stream holding a record put an hour before the mapping starts.
+    const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+    const { events } = await simAwsWithKinesisEventSource({
+      simAws,
+      startingPosition: "AT_TIMESTAMP",
+      startingPositionTimestamp: new Date(startedAt.getTime() + 30 * 60 * 1000),
+    });
+
+    // When a record is put before that instant and another after it.
+    await putOrder(simAws, "order-1");
+    await simAws.clock().advanceBy({ hours: 1 });
+    await putOrder(simAws, "order-2");
+    await simAws.backgroundTasksComplete();
+
+    // Then only the later one is delivered.
+    assertIdentical(deliveredData(events).join(","), "order-2");
+  });
+});

--- a/src/service/lambda/event-source/stream/kinesis/sim-kinesis-event-source-positions.ts
+++ b/src/service/lambda/event-source/stream/kinesis/sim-kinesis-event-source-positions.ts
@@ -1,0 +1,44 @@
+import type { SimLambdaEventSourceStreamPosition } from "../sim-lambda-event-source-streams.js";
+
+/**
+ * A place named as something other than an iterator, which is what an iterator
+ * has to be asked for.
+ */
+export type SimLambdaKinesisNamedPosition = Exclude<
+  SimLambdaEventSourceStreamPosition,
+  { readonly kind: "iterator" }
+>;
+
+/**
+ * What GetShardIterator is asked for a named place with.
+ */
+export interface SimKinesisEventSourceIteratorType {
+  readonly ShardIteratorType: string;
+  readonly StartingSequenceNumber?: string;
+  readonly Timestamp?: Date;
+}
+
+/**
+ * The GetShardIterator input fields a named place asks for.
+ *
+ * A sequence number is asked for with `AT_SEQUENCE_NUMBER` rather than
+ * `AFTER_SEQUENCE_NUMBER`: the record named is one the function is to be given
+ * again, not one it is finished with.
+ */
+export function simKinesisEventSourceIteratorTypeOf(
+  position: SimLambdaKinesisNamedPosition,
+): SimKinesisEventSourceIteratorType {
+  if (position.kind === "sequence") {
+    return {
+      ShardIteratorType: "AT_SEQUENCE_NUMBER",
+      StartingSequenceNumber: position.sequenceNumber,
+    };
+  }
+
+  const { start } = position;
+
+  return {
+    ShardIteratorType: start.position,
+    ...(start.timestamp !== undefined && { Timestamp: start.timestamp }),
+  };
+}

--- a/src/service/lambda/event-source/stream/kinesis/sim-kinesis-event-source-shards.ts
+++ b/src/service/lambda/event-source/stream/kinesis/sim-kinesis-event-source-shards.ts
@@ -1,0 +1,88 @@
+import { SimLambdaError } from "../../../error/sim-lambda.error.js";
+import type { SimLambdaEventSourceStreamRequest } from "../sim-lambda-event-source-streams.js";
+import type { SimLambdaKinesisStreamCommands } from "./sim-lambda-kinesis-stream-service.js";
+
+/**
+ * How many shards one DescribeStream page asks for.
+ *
+ * The stream is walked to the end rather than read one page deep, so a mapping
+ * on a stream with more shards than a page holds still reads all of them.
+ */
+const shardPageSize = 100;
+
+/**
+ * The shards of the stream a mapping polls.
+ *
+ * This is a DescribeStream call, which is also how a mapping finds out whether
+ * the stream it names is there at all. Real Lambda needs the same permission
+ * for the same reason.
+ */
+export class SimKinesisEventSourceShards {
+  private readonly commands: SimLambdaKinesisStreamCommands;
+
+  constructor(commands: SimLambdaKinesisStreamCommands) {
+    this.commands = commands;
+  }
+
+  /**
+   * Every shard of a stream, in the order the stream reports them.
+   */
+  async shardIds(
+    request: SimLambdaEventSourceStreamRequest,
+  ): Promise<readonly string[]> {
+    const { streamArn, caller } = request;
+    const shardIds: string[] = [];
+    let after: string | undefined;
+
+    do {
+      // oxlint-disable-next-line no-await-in-loop
+      const described = await this.commands.describeStream(
+        {
+          input: {
+            StreamARN: streamArn,
+            Limit: shardPageSize,
+            ...(after !== undefined && { ExclusiveStartShardId: after }),
+          },
+        },
+        { caller },
+      );
+      const page = described.StreamDescription;
+
+      shardIds.push(...namedShardsOf(page.Shards, streamArn));
+      after = page.HasMoreShards === true ? shardIds.at(-1) : undefined;
+    } while (after !== undefined);
+
+    if (shardIds.length === 0) {
+      throw new SimLambdaError(
+        `Stream ${streamArn} reports no shards to poll records from`,
+      );
+    }
+
+    return shardIds;
+  }
+}
+
+/**
+ * The identifiers a page of shards carries.
+ *
+ * A shard with no identifier is one nothing can ask for a place on, so it is
+ * refused here rather than skipped: a mapping quietly reading fewer shards than
+ * the stream has would drop records with nothing to point at.
+ */
+function namedShardsOf(
+  shards: readonly { readonly ShardId?: string | undefined }[] | undefined,
+  streamArn: string,
+): readonly string[] {
+  return (shards ?? []).map((shard) => {
+    const { ShardId } = shard;
+
+    if (ShardId === undefined || ShardId === "") {
+      throw new SimLambdaError(
+        `Stream ${streamArn} reports a shard with no ShardId, which nothing ` +
+          "can read from",
+      );
+    }
+
+    return ShardId;
+  });
+}

--- a/src/service/lambda/event-source/stream/kinesis/sim-kinesis-event-source-streams.ts
+++ b/src/service/lambda/event-source/stream/kinesis/sim-kinesis-event-source-streams.ts
@@ -1,0 +1,119 @@
+import { SimKinesisEventSourceShards } from "./sim-kinesis-event-source-shards.js";
+import { simKinesisEventSourceIteratorTypeOf } from "./sim-kinesis-event-source-positions.js";
+import type {
+  SimLambdaKinesisStreamActivity,
+  SimLambdaKinesisStreamCommands,
+  SimLambdaKinesisStreamService,
+} from "./sim-lambda-kinesis-stream-service.js";
+import type {
+  SimLambdaKinesisShardReadRequest,
+  SimLambdaKinesisStreamBatch,
+  SimLambdaKinesisStreams,
+} from "./sim-lambda-kinesis-streams.js";
+import type {
+  SimLambdaEventSourceStreamRequest,
+  SimLambdaEventSourceStreamWatcher,
+} from "../sim-lambda-event-source-streams.js";
+
+interface SimKinesisEventSourceStreamsProperties {
+  readonly kinesis: SimLambdaKinesisStreamService;
+}
+
+/**
+ * Simulated Kinesis as the streams a Lambda event source mapping polls.
+ *
+ * Every call goes through the Kinesis command it would go through on real AWS,
+ * as the function's execution role, so a role without `kinesis:DescribeStream`,
+ * `kinesis:GetShardIterator` or `kinesis:GetRecords` on the stream is refused
+ * here rather than quietly polling anyway.
+ */
+export class SimKinesisEventSourceStreams implements SimLambdaKinesisStreams {
+  private readonly commands: SimLambdaKinesisStreamCommands;
+  private readonly activity: SimLambdaKinesisStreamActivity;
+  private readonly shards: SimKinesisEventSourceShards;
+
+  constructor(properties: SimKinesisEventSourceStreamsProperties) {
+    const { kinesis } = properties;
+
+    this.commands = kinesis;
+    this.activity = kinesis.streamActivity();
+    this.shards = new SimKinesisEventSourceShards(kinesis);
+  }
+
+  /**
+   * Every shard of a stream, which is what a mapping reads across.
+   */
+  async shardIds(
+    request: SimLambdaEventSourceStreamRequest,
+  ): Promise<readonly string[]> {
+    return await this.shards.shardIds(request);
+  }
+
+  /**
+   * Read up to a batch of records from where a position left off on one shard.
+   *
+   * A Kinesis shard never closes here, since nothing reshards, so a read always
+   * hands back somewhere to carry on from and a shard is never drained.
+   */
+  async read(
+    request: SimLambdaKinesisShardReadRequest,
+  ): Promise<SimLambdaKinesisStreamBatch> {
+    const { batchSize, caller } = request;
+    const output = await this.commands.getRecords(
+      {
+        input: {
+          ShardIterator: await this.iteratorOf(request),
+          Limit: batchSize,
+        },
+      },
+      { caller },
+    );
+
+    return {
+      records: output.Records,
+      next: { kind: "iterator", shardIterator: output.NextShardIterator },
+      drained: false,
+    };
+  }
+
+  /**
+   * Watch a stream for the records put onto it.
+   */
+  watch(streamArn: string, watcher: SimLambdaEventSourceStreamWatcher): void {
+    this.activity.watch(streamArn, watcher);
+  }
+
+  /**
+   * Stop watching a stream.
+   */
+  unwatch(streamArn: string, watcher: SimLambdaEventSourceStreamWatcher): void {
+    this.activity.unwatch(streamArn, watcher);
+  }
+
+  /**
+   * The place a read starts from: the one the caller already has, or one the
+   * stream is asked for when the caller names a place instead.
+   */
+  private async iteratorOf(
+    request: SimLambdaKinesisShardReadRequest,
+  ): Promise<string> {
+    const { position } = request;
+
+    if (position.kind === "iterator") {
+      return position.shardIterator;
+    }
+
+    const iterator = await this.commands.getShardIterator(
+      {
+        input: {
+          StreamARN: request.streamArn,
+          ShardId: request.shardId,
+          ...simKinesisEventSourceIteratorTypeOf(position),
+        },
+      },
+      { caller: request.caller },
+    );
+
+    return iterator.ShardIterator;
+  }
+}

--- a/src/service/lambda/event-source/stream/kinesis/sim-lambda-kinesis-event-source-arn.iso.test.ts
+++ b/src/service/lambda/event-source/stream/kinesis/sim-lambda-kinesis-event-source-arn.iso.test.ts
@@ -1,0 +1,77 @@
+import {
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsError,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimLambdaInvalidParameterValueException } from "../../../error/sim-lambda.error.js";
+import { SimLambdaKinesisEventSourceArn } from "./sim-lambda-kinesis-event-source-arn.js";
+
+const streamArn = "arn:aws:kinesis:eu-west-2:111111111111:stream/orders";
+
+describe("a Kinesis stream event source ARN", () => {
+  it("reads the Region, the Account and the stream out of one", () => {
+    // When a stream ARN is read.
+    const parsed = SimLambdaKinesisEventSourceArn.of(streamArn);
+
+    // Then everything a poller needs comes out of it.
+    assertIdentical(parsed.kind, "kinesis-stream");
+    assertIdentical(parsed.regionName, "eu-west-2");
+    assertIdentical(parsed.accountId, "111111111111");
+    assertIdentical(parsed.streamName, "orders");
+    assertTrue(parsed.isIn("111111111111", "eu-west-2"));
+    assertFalse(parsed.isIn("222222222222", "eu-west-2"));
+  });
+
+  it("asks for the three operations a poller performs, and ListStreams", () => {
+    // When a stream ARN is read.
+    const parsed = SimLambdaKinesisEventSourceArn.of(streamArn);
+
+    // Then the execution role is checked for the operations AWS's own managed
+    // policy grants, with ListStreams on every stream rather than on one.
+    assertIdentical(
+      parsed.pollingPermissions
+        .map((permission) => `${permission.action} ${permission.resource}`)
+        .join(", "),
+      [
+        `kinesis:DescribeStream ${streamArn}`,
+        `kinesis:GetRecords ${streamArn}`,
+        `kinesis:GetShardIterator ${streamArn}`,
+        "kinesis:ListStreams *",
+      ].join(", "),
+    );
+  });
+
+  it("reads nothing out of a string that names something else", () => {
+    // Given ARNs that name no Kinesis stream, including a consumer of one.
+    const notStreamArns = [
+      "orders",
+      "arn:aws:kinesis:eu-west-2:111111111111:orders",
+      "arn:aws:dynamodb:eu-west-2:111111111111:table/orders/stream/2026",
+      `${streamArn}/consumer/projector:1756000000`,
+    ];
+
+    // When each is read.
+    // Then nothing comes back, so the dispatcher can try the next parser.
+    for (const value of notStreamArns) {
+      assertUndefined(SimLambdaKinesisEventSourceArn.parse(value));
+    }
+  });
+
+  it("refuses a string that is not a stream ARN, saying what one looks like", () => {
+    // When something that is not a stream ARN is required to be one.
+    const error = assertThrowsError(() => {
+      SimLambdaKinesisEventSourceArn.of("orders");
+    });
+
+    // Then the refusal says the shape it wanted.
+    assertInstanceOf(error, SimLambdaInvalidParameterValueException);
+    assertStringIncludes(error.message, "is not a Kinesis stream ARN");
+    assertStringIncludes(error.message, "stream/<stream-name>");
+  });
+});

--- a/src/service/lambda/event-source/stream/kinesis/sim-lambda-kinesis-event-source-arn.ts
+++ b/src/service/lambda/event-source/stream/kinesis/sim-lambda-kinesis-event-source-arn.ts
@@ -1,0 +1,116 @@
+import { SimLambdaInvalidParameterValueException } from "../../../error/sim-lambda.error.js";
+import type { SimLambdaEventSourceBatchRules } from "../../sim-lambda-event-source-batch-rules.js";
+import { SimLambdaEventSourcePollingPermission } from "../../sim-lambda-event-source-polling-permission.js";
+import type { SimLambdaEventSourceStartingPositionRules } from "../../sim-lambda-event-source-starting-position.js";
+import {
+  kinesisStreamBatchRules,
+  kinesisStreamPollingOperations,
+  kinesisStreamStartingPositionRules,
+} from "./sim-lambda-kinesis-event-source-rules.js";
+
+/**
+ * A Kinesis stream ARN carries the stream name after a `stream/` separator, and
+ * a stream name holds no colon and no slash, so the ARN is read in one piece.
+ *
+ * A consumer ARN carries the consumer name and its creation time after the
+ * stream name, which is why the name is anchored to the end here: enhanced
+ * fan-out is unsimulated, and a mapping naming a consumer has to be refused
+ * rather than polled as though it named the stream.
+ */
+const streamArnPattern =
+  /^arn:aws:kinesis:(?<region>[a-z0-9-]+):(?<account>\d{12}):stream\/(?<stream>[\w.-]{1,128})$/u;
+
+/**
+ * The Kinesis stream ARN an event source mapping is created for.
+ *
+ * Everything a poller needs comes out of it: the ARN the Kinesis calls name,
+ * the Region the event records report, and the stream name, which is what a
+ * refusal names when a function writes back into its own source.
+ */
+export class SimLambdaKinesisEventSourceArn {
+  /**
+   * How an ARN naming this kind of event source is written, for a refusal to
+   * say what it wanted instead.
+   */
+  static readonly arnShape =
+    "A Kinesis stream ARN is " +
+    "arn:aws:kinesis:<region>:<account-id>:stream/<stream-name>";
+
+  public readonly kind = "kinesis-stream" as const;
+  public readonly serviceLabel = "Kinesis Data Streams";
+  public readonly value: string;
+  public readonly regionName: string;
+  public readonly accountId: string;
+  public readonly streamName: string;
+  public readonly pollingPermissions: readonly SimLambdaEventSourcePollingPermission[];
+
+  private constructor(value: string, parts: Record<string, string>) {
+    this.value = value;
+    this.regionName = parts["region"] ?? "";
+    this.accountId = parts["account"] ?? "";
+    this.streamName = parts["stream"] ?? "";
+    this.pollingPermissions = [
+      ...kinesisStreamPollingOperations.map(
+        (operation) =>
+          new SimLambdaEventSourcePollingPermission(
+            `kinesis:${operation}`,
+            value,
+          ),
+      ),
+      new SimLambdaEventSourcePollingPermission("kinesis:ListStreams", "*"),
+    ];
+  }
+
+  /**
+   * Read a stream ARN, answering with nothing when the ARN names something
+   * else.
+   *
+   * This is what the event source ARN dispatcher asks, so that deciding what a
+   * mapping may name stays in one place rather than in each parser.
+   */
+  static parse(streamArn: string): SimLambdaKinesisEventSourceArn | undefined {
+    const parts = streamArnPattern.exec(streamArn)?.groups;
+
+    if (parts === undefined) {
+      return undefined;
+    }
+
+    return new this(streamArn, parts);
+  }
+
+  /**
+   * Read a stream ARN, refusing one that is not a stream ARN at all.
+   */
+  static of(streamArn: string): SimLambdaKinesisEventSourceArn {
+    const parsed = this.parse(streamArn);
+
+    if (parsed === undefined) {
+      throw new SimLambdaInvalidParameterValueException(
+        `${streamArn} is not a Kinesis stream ARN. ${this.arnShape}`,
+      );
+    }
+
+    return parsed;
+  }
+
+  /**
+   * The batch sizes a mapping on this stream may deliver with.
+   */
+  get batchRules(): SimLambdaEventSourceBatchRules {
+    return kinesisStreamBatchRules;
+  }
+
+  /**
+   * The starting positions a mapping on this stream may be created with.
+   */
+  get startingPositionRules(): SimLambdaEventSourceStartingPositionRules {
+    return kinesisStreamStartingPositionRules;
+  }
+
+  /**
+   * Whether this stream is in an Account and Region.
+   */
+  isIn(accountId: string, regionName: string): boolean {
+    return this.accountId === accountId && this.regionName === regionName;
+  }
+}

--- a/src/service/lambda/event-source/stream/kinesis/sim-lambda-kinesis-event-source-rules.ts
+++ b/src/service/lambda/event-source/stream/kinesis/sim-lambda-kinesis-event-source-rules.ts
@@ -1,0 +1,43 @@
+import { SimLambdaEventSourceBatchRules } from "../../sim-lambda-event-source-batch-rules.js";
+import { SimLambdaStreamStartingPosition } from "../../sim-lambda-event-source-starting-position.js";
+
+/**
+ * What a function's execution role has to be allowed to do on a stream for
+ * Lambda to poll it.
+ *
+ * These are the three operations a poller performs on the stream itself.
+ * `ListStreams` goes with them, on every stream rather than on one: nothing
+ * here ever calls it, and both the AWS managed policy and CDK's own grant
+ * include it, so a role that would work on AWS is a role that works here.
+ */
+export const kinesisStreamPollingOperations = [
+  "DescribeStream",
+  "GetRecords",
+  "GetShardIterator",
+] as const;
+
+/**
+ * The batch sizes a Kinesis stream event source delivers with.
+ *
+ * A hundred is what real Lambda uses when the mapping names none, and what CDK
+ * puts on every `KinesisEventSource`. Ten thousand is the largest a mapping may
+ * ask for, which is also the most one GetRecords call hands back.
+ */
+export const kinesisStreamBatchRules = new SimLambdaEventSourceBatchRules({
+  defaultSize: 100,
+  maximumSize: 10_000,
+  sourceDescription: "a Kinesis stream",
+  unitName: "records",
+});
+
+/**
+ * A stream mapping has to say where it starts reading from.
+ *
+ * A Kinesis stream takes all three positions, unlike a DynamoDB stream, since
+ * its records carry the instant they arrived.
+ */
+export const kinesisStreamStartingPositionRules =
+  new SimLambdaStreamStartingPosition({
+    positions: ["TRIM_HORIZON", "LATEST", "AT_TIMESTAMP"],
+    sourceDescription: "a Kinesis stream",
+  });

--- a/src/service/lambda/event-source/stream/kinesis/sim-lambda-kinesis-stream-service.ts
+++ b/src/service/lambda/event-source/stream/kinesis/sim-lambda-kinesis-stream-service.ts
@@ -1,0 +1,78 @@
+import type { SimLambdaKinesisCallerOptions } from "./sim-lambda-kinesis-streams.js";
+import type { SimLambdaKinesisStreamRecord } from "./sim-lambda-kinesis-streams.js";
+import type { SimLambdaEventSourceStreamWatcher } from "../sim-lambda-event-source-streams.js";
+
+/**
+ * One shard of a stream, as DescribeStream reports it.
+ */
+interface KinesisShardDescription {
+  readonly ShardId?: string | undefined;
+}
+
+/**
+ * A stream, as DescribeStream reports it.
+ */
+export interface SimLambdaKinesisStreamDescription {
+  readonly Shards?: readonly KinesisShardDescription[] | undefined;
+  readonly HasMoreShards?: boolean | undefined;
+}
+
+/**
+ * The Kinesis commands a poller reads a stream with.
+ *
+ * These are the SDK operations a real poller performs, in the order it performs
+ * them: find the shards, ask for a place on one, then read from there. Going
+ * through the commands rather than through a read interface of Yulin's own is
+ * what makes each call authorize as the function's execution role.
+ */
+export interface SimLambdaKinesisStreamCommands {
+  describeStream(
+    command: {
+      input: {
+        StreamARN: string;
+        Limit?: number;
+        ExclusiveStartShardId?: string;
+      };
+    },
+    options?: SimLambdaKinesisCallerOptions,
+  ): Promise<{
+    StreamDescription: SimLambdaKinesisStreamDescription;
+  }>;
+
+  getShardIterator(
+    command: {
+      input: {
+        StreamARN: string;
+        ShardId: string;
+        ShardIteratorType: string;
+        StartingSequenceNumber?: string;
+        Timestamp?: Date;
+      };
+    },
+    options?: SimLambdaKinesisCallerOptions,
+  ): Promise<{ ShardIterator: string }>;
+
+  getRecords(
+    command: { input: { ShardIterator: string; Limit: number } },
+    options?: SimLambdaKinesisCallerOptions,
+  ): Promise<{
+    Records: readonly SimLambdaKinesisStreamRecord[];
+    NextShardIterator: string;
+  }>;
+}
+
+/**
+ * The part of simulated Kinesis that says when a record has been put.
+ */
+export interface SimLambdaKinesisStreamActivity {
+  watch(streamArn: string, watcher: SimLambdaEventSourceStreamWatcher): void;
+  unwatch(streamArn: string, watcher: SimLambdaEventSourceStreamWatcher): void;
+}
+
+/**
+ * The narrow slice of simulated Kinesis that event source polling needs.
+ * SimKinesis structurally implements this interface.
+ */
+export interface SimLambdaKinesisStreamService extends SimLambdaKinesisStreamCommands {
+  streamActivity(): SimLambdaKinesisStreamActivity;
+}

--- a/src/service/lambda/event-source/stream/kinesis/sim-lambda-kinesis-streams.ts
+++ b/src/service/lambda/event-source/stream/kinesis/sim-lambda-kinesis-streams.ts
@@ -1,0 +1,87 @@
+import type { SimAwsCaller } from "../../../../aws/caller/sim-aws-caller.js";
+import type {
+  SimLambdaEventSourceStreamPosition,
+  SimLambdaEventSourceStreamProgressBatch,
+  SimLambdaEventSourceStreamRequest,
+  SimLambdaEventSourceStreamWatcher,
+} from "../sim-lambda-event-source-streams.js";
+
+/**
+ * One record as a Kinesis stream hands it to a poller.
+ *
+ * These are the Kinesis API's own names for the parts of a record. Turning them
+ * into the event a function sees is the event builder's job, and it is a real
+ * translation rather than a copy: the API gives raw bytes and an instant where
+ * the event gives base64 and epoch seconds.
+ */
+export interface SimLambdaKinesisStreamRecord {
+  readonly SequenceNumber?: string | undefined;
+  readonly ApproximateArrivalTimestamp?: Date | undefined;
+  readonly Data?: Uint8Array | undefined;
+  readonly PartitionKey?: string | undefined;
+}
+
+/**
+ * A poller's read of one shard, made as the function's execution role.
+ *
+ * A Kinesis stream has as many shards as it was created with, so which shard is
+ * being read is part of the request. That is the difference from the DynamoDB
+ * stream reader, where the stream has one shard and the poller never names it.
+ */
+export interface SimLambdaKinesisShardReadRequest extends SimLambdaEventSourceStreamRequest {
+  readonly shardId: string;
+  readonly position: SimLambdaEventSourceStreamPosition;
+  readonly batchSize: number;
+}
+
+/**
+ * What one read of a shard came back with.
+ */
+export interface SimLambdaKinesisStreamBatch extends SimLambdaEventSourceStreamProgressBatch {
+  readonly records: readonly SimLambdaKinesisStreamRecord[];
+}
+
+/**
+ * The Kinesis streams a simulated Lambda event source mapping polls.
+ *
+ * This is the narrow slice of simulated Kinesis that polling needs, kept as an
+ * interface so Lambda depends on what it does with a stream rather than on the
+ * Kinesis service object. Every operation carries the caller, because polling
+ * on real Lambda is done with the function's execution role and is refused when
+ * that role has no permission for it.
+ */
+export interface SimLambdaKinesisStreams {
+  /**
+   * The shards of a stream, and by asking, whether the stream is there to be
+   * polled at all.
+   *
+   * A mapping reads every shard, so it needs all of them rather than one.
+   */
+  shardIds(
+    request: SimLambdaEventSourceStreamRequest,
+  ): Promise<readonly string[]>;
+
+  /**
+   * Read up to a batch of records from where a position left off on one shard.
+   */
+  read(
+    request: SimLambdaKinesisShardReadRequest,
+  ): Promise<SimLambdaKinesisStreamBatch>;
+
+  /**
+   * Watch a stream for the records put onto it.
+   */
+  watch(streamArn: string, watcher: SimLambdaEventSourceStreamWatcher): void;
+
+  /**
+   * Stop watching a stream.
+   */
+  unwatch(streamArn: string, watcher: SimLambdaEventSourceStreamWatcher): void;
+}
+
+/**
+ * What a Kinesis request carries besides its command input.
+ */
+export interface SimLambdaKinesisCallerOptions {
+  readonly caller: SimAwsCaller;
+}

--- a/src/service/lambda/event-source/stream/kinesis/sim-lambda-no-kinesis-streams.iso.test.ts
+++ b/src/service/lambda/event-source/stream/kinesis/sim-lambda-no-kinesis-streams.iso.test.ts
@@ -1,0 +1,59 @@
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimLambdaError } from "../../../error/sim-lambda.error.js";
+import { SimLambdaNoKinesisStreams } from "./sim-lambda-no-kinesis-streams.js";
+
+const streamArn = "arn:aws:kinesis:eu-west-2:111111111111:stream/orders";
+
+const request = { streamArn, caller: { kind: "arn", arn: "role" } } as const;
+
+describe("a sim Lambda with no simulated Kinesis behind it", () => {
+  it("says how to reach a stream when asked for its shards", async () => {
+    // Given a SimLambda built on its own, outside SimAws.
+    const streams = new SimLambdaNoKinesisStreams();
+
+    // When a mapping asks which shards the stream has.
+    const error = await assertThrowsErrorAsync(async () => {
+      await streams.shardIds(request);
+    });
+
+    // Then it says what is missing and how to supply it, rather than reporting
+    // a stream with no shards.
+    assertInstanceOf(error, SimLambdaError);
+    assertStringIncludes(error.message, "no simulated Kinesis to poll");
+    assertStringIncludes(error.message, "Create the event source mapping");
+  });
+
+  it("says how to reach a stream when asked to read one", async () => {
+    // Given a SimLambda built on its own.
+    const streams = new SimLambdaNoKinesisStreams();
+
+    // When a poll reads a shard.
+    const error = await assertThrowsErrorAsync(async () => {
+      await streams.read({
+        ...request,
+        shardId: "shardId-000000000000",
+        position: { kind: "starting", start: { position: "TRIM_HORIZON" } },
+        batchSize: 10,
+      });
+    });
+
+    // Then it says the same thing.
+    assertStringIncludes(error.message, streamArn);
+  });
+
+  it("watches nothing, since there is no stream to watch", () => {
+    // Given a SimLambda built on its own.
+    const streams = new SimLambdaNoKinesisStreams();
+
+    // When a poller watches and stops watching.
+    // Then neither does anything, and neither raises.
+    streams.watch();
+    streams.unwatch();
+  });
+});

--- a/src/service/lambda/event-source/stream/kinesis/sim-lambda-no-kinesis-streams.ts
+++ b/src/service/lambda/event-source/stream/kinesis/sim-lambda-no-kinesis-streams.ts
@@ -1,0 +1,53 @@
+import { SimLambdaError } from "../../../error/sim-lambda.error.js";
+import type { SimLambdaEventSourceStreamRequest } from "../sim-lambda-event-source-streams.js";
+import type {
+  SimLambdaKinesisShardReadRequest,
+  SimLambdaKinesisStreamBatch,
+  SimLambdaKinesisStreams,
+} from "./sim-lambda-kinesis-streams.js";
+
+/**
+ * Kinesis event source streams used when no simulated Kinesis is wired up, such
+ * as for a standalone SimLambda constructed outside SimAws.
+ */
+export class SimLambdaNoKinesisStreams implements SimLambdaKinesisStreams {
+  /**
+   * Refuse to look at a stream, explaining how to reach one.
+   */
+  shardIds(
+    request: SimLambdaEventSourceStreamRequest,
+  ): Promise<readonly string[]> {
+    return Promise.reject(this.noStreams(request.streamArn));
+  }
+
+  /**
+   * Refuse to poll, explaining how to reach a stream.
+   */
+  read(
+    request: SimLambdaKinesisShardReadRequest,
+  ): Promise<SimLambdaKinesisStreamBatch> {
+    return Promise.reject(this.noStreams(request.streamArn));
+  }
+
+  /**
+   * Watch nothing: there is no stream to watch.
+   */
+  watch(): void {
+    //
+  }
+
+  /**
+   * Stop watching nothing.
+   */
+  unwatch(): void {
+    //
+  }
+
+  private noStreams(streamArn: string): SimLambdaError {
+    return new SimLambdaError(
+      `Cannot poll ${streamArn}: this SimLambda has no simulated Kinesis to ` +
+        "poll. Create the event source mapping through SimAws, or construct " +
+        "SimLambda with kinesisStreams.",
+    );
+  }
+}

--- a/src/service/lambda/event-source/stream/sim-dynamodb-event-source-stream-positions.ts
+++ b/src/service/lambda/event-source/stream/sim-dynamodb-event-source-stream-positions.ts
@@ -15,6 +15,7 @@ export type SimLambdaEventSourceStreamNamedPosition = Exclude<
 export interface SimDynamoDbEventSourceIteratorType {
   readonly ShardIteratorType: string;
   readonly SequenceNumber?: string;
+  readonly Timestamp?: Date;
 }
 
 /**
@@ -28,7 +29,12 @@ export function simDynamoDbEventSourceIteratorTypeOf(
   position: SimLambdaEventSourceStreamNamedPosition,
 ): SimDynamoDbEventSourceIteratorType {
   if (position.kind === "starting") {
-    return { ShardIteratorType: position.startingPosition };
+    const { start } = position;
+
+    return {
+      ShardIteratorType: start.position,
+      ...(start.timestamp !== undefined && { Timestamp: start.timestamp }),
+    };
   }
 
   return {

--- a/src/service/lambda/event-source/stream/sim-dynamodb-event-source-stream-shard.iso.test.ts
+++ b/src/service/lambda/event-source/stream/sim-dynamodb-event-source-stream-shard.iso.test.ts
@@ -86,7 +86,7 @@ describe("sim DynamoDB event source stream shard", () => {
     const error = await assertThrowsErrorAsync(async () => {
       await shard.iteratorFor(request, {
         kind: "starting",
-        startingPosition: "TRIM_HORIZON",
+        start: { position: "TRIM_HORIZON" },
       });
     });
 

--- a/src/service/lambda/event-source/stream/sim-lambda-dynamodb-stream-event-source-rules.ts
+++ b/src/service/lambda/event-source/stream/sim-lambda-dynamodb-stream-event-source-rules.ts
@@ -32,6 +32,13 @@ export const dynamoDbStreamBatchRules = new SimLambdaEventSourceBatchRules({
 
 /**
  * A stream mapping has to say where it starts reading from.
+ *
+ * A DynamoDB stream takes two of the three positions. `AT_TIMESTAMP` is for a
+ * Kinesis stream, and real Lambda refuses it here.
  */
 export const dynamoDbStreamStartingPositionRules =
-  new SimLambdaStreamStartingPosition();
+  new SimLambdaStreamStartingPosition({
+    positions: ["TRIM_HORIZON", "LATEST"],
+    sourceDescription: "a DynamoDB stream",
+    positionElsewhere: "AT_TIMESTAMP is for a Kinesis stream",
+  });

--- a/src/service/lambda/event-source/stream/sim-lambda-event-source-streams.ts
+++ b/src/service/lambda/event-source/stream/sim-lambda-event-source-streams.ts
@@ -1,6 +1,6 @@
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import { SimLambdaError } from "../../error/sim-lambda.error.js";
-import type { SimLambdaEventSourceStartingPosition } from "../sim-lambda-event-source-starting-position.js";
+import type { SimLambdaEventSourceStart } from "../sim-lambda-event-source-starting-position.js";
 import type { SimLambdaDynamoDbImage } from "./sim-lambda-dynamodb-attribute-value.js";
 
 /**
@@ -54,10 +54,7 @@ export interface SimLambdaEventSourceStreamRecord {
  * than after it.
  */
 export type SimLambdaEventSourceStreamPosition =
-  | {
-      readonly kind: "starting";
-      readonly startingPosition: SimLambdaEventSourceStartingPosition;
-    }
+  | { readonly kind: "starting"; readonly start: SimLambdaEventSourceStart }
   | { readonly kind: "iterator"; readonly shardIterator: string }
   | { readonly kind: "sequence"; readonly sequenceNumber: string };
 
@@ -76,16 +73,26 @@ export interface SimLambdaEventSourceStreamReadRequest extends SimLambdaEventSou
 }
 
 /**
- * What one read of a stream came back with.
+ * Where a read left the reader, apart from what it read.
+ *
+ * This is all the progress of a mapping depends on, and it is the same for
+ * every stream service. The records a batch carried are the service's own
+ * shape, so they stay with the batch types below.
  *
  * `drained` is only true of a shard the reader has reached the end of, which
  * happens when the table's stream has been switched off. An empty batch from an
  * open shard is the ordinary answer for a mapping that has caught up.
  */
-export interface SimLambdaEventSourceStreamBatch {
-  readonly records: readonly SimLambdaEventSourceStreamRecord[];
+export interface SimLambdaEventSourceStreamProgressBatch {
   readonly next: SimLambdaEventSourceStreamPosition;
   readonly drained: boolean;
+}
+
+/**
+ * What one read of a DynamoDB stream came back with.
+ */
+export interface SimLambdaEventSourceStreamBatch extends SimLambdaEventSourceStreamProgressBatch {
+  readonly records: readonly SimLambdaEventSourceStreamRecord[];
 }
 
 /**

--- a/src/service/lambda/event-source/stream/sim-lambda-no-event-source-streams.iso.test.ts
+++ b/src/service/lambda/event-source/stream/sim-lambda-no-event-source-streams.iso.test.ts
@@ -23,7 +23,7 @@ describe("sim Lambda event source streams with no simulated DynamoDB", () => {
       assertThrowsErrorAsync(async () => {
         await streams.read({
           ...request,
-          position: { kind: "starting", startingPosition: "TRIM_HORIZON" },
+          position: { kind: "starting", start: { position: "TRIM_HORIZON" } },
           batchSize: 100,
         });
       }),

--- a/src/service/lambda/event-source/stream/sim-lambda-stream-cascade-guard.ts
+++ b/src/service/lambda/event-source/stream/sim-lambda-stream-cascade-guard.ts
@@ -1,21 +1,42 @@
 import type { SimLambdaEventSourceMapping } from "../sim-lambda-event-source-mapping.js";
-import type { SimLambdaDynamoDbStreamEventSourceArn } from "./sim-lambda-dynamodb-stream-event-source-arn.js";
 import { simLambdaEventSourceDeliveryContext } from "./sim-lambda-event-source-delivery-context.js";
 import { SimLambdaStreamCascadeError } from "./sim-lambda-stream-cascade.error.js";
 
+/**
+ * The source a guard watches, said in the terms its own service uses.
+ */
+export interface SimLambdaStreamCascadeSource {
+  readonly streamArn: string;
+
+  /**
+   * What the function did, as a clause a sentence can hold.
+   */
+  readonly wroteTo: string;
+
+  /**
+   * How the stream it was invoked from relates to what it wrote to.
+   */
+  readonly sourceRelation: string;
+
+  /**
+   * What to do instead of feeding the source that invoked the function.
+   */
+  readonly advice: string;
+}
+
 interface SimLambdaStreamCascadeGuardProperties {
   readonly mapping: SimLambdaEventSourceMapping;
-  readonly eventSourceArn: SimLambdaDynamoDbStreamEventSourceArn;
+  readonly source: SimLambdaStreamCascadeSource;
 }
 
 /**
- * Watches one mapping's deliveries for the function writing back into the table
- * whose stream invoked it.
+ * Watches one mapping's deliveries for the function writing back into the
+ * source whose stream invoked it.
  *
  * The delivery runs inside its own asynchronous context, so a record written by
  * the handler is told apart from one written by anything else that happened to
  * be running at the same time. That distinction is the whole point: several
- * items written at once are an ordinary batch, and a handler feeding its own
+ * records written at once are an ordinary batch, and a handler feeding its own
  * source is a loop.
  */
 export class SimLambdaStreamCascadeGuard {
@@ -40,12 +61,14 @@ export class SimLambdaStreamCascadeGuard {
     );
 
     if (this.cascaded) {
-      const { mapping, eventSourceArn } = this.properties;
+      const { mapping, source } = this.properties;
 
       throw new SimLambdaStreamCascadeError({
         functionName: mapping.functionName,
-        streamArn: eventSourceArn.value,
-        tableName: eventSourceArn.tableName,
+        streamArn: source.streamArn,
+        wroteTo: source.wroteTo,
+        sourceRelation: source.sourceRelation,
+        advice: source.advice,
       });
     }
 

--- a/src/service/lambda/event-source/stream/sim-lambda-stream-cascade.error.ts
+++ b/src/service/lambda/event-source/stream/sim-lambda-stream-cascade.error.ts
@@ -3,11 +3,28 @@ import { SimLambdaError } from "../../error/sim-lambda.error.js";
 interface SimLambdaStreamCascadeErrorProperties {
   readonly functionName: string;
   readonly streamArn: string;
-  readonly tableName: string;
+
+  /**
+   * What the function did, as a clause a sentence can hold, such as
+   * "wrote to the table orders".
+   */
+  readonly wroteTo: string;
+
+  /**
+   * How the stream it was invoked from relates to what it wrote to, such as
+   * "that table's own stream".
+   */
+  readonly sourceRelation: string;
+
+  /**
+   * What to do instead, which differs by source: a DynamoDB projection belongs
+   * in a second table, and a Kinesis result belongs on a second stream.
+   */
+  readonly advice: string;
 }
 
 /**
- * A function writing back into the table whose stream invoked it.
+ * A function writing back into the source whose stream invoked it.
  *
  * Every one of those writes is another stream record, which is another
  * delivery, which is another write. Real Lambda runs that loop for as long as
@@ -15,19 +32,19 @@ interface SimLambdaStreamCascadeErrorProperties {
  * simulation would go round until the test timed out with nothing to point at.
  *
  * This is a simulator guard rather than AWS behaviour, and it is deliberately
- * not silent: a projection or an aggregate belongs in a second table, and a
- * test whose handler writes to its own source table is testing a loop.
+ * not silent: a projection or an aggregate belongs in a second table or on a
+ * second stream, and a test whose handler writes to its own source is testing a
+ * loop.
  */
 export class SimLambdaStreamCascadeError extends SimLambdaError {
   public override readonly name = "SimLambdaStreamCascadeError";
 
   constructor(properties: SimLambdaStreamCascadeErrorProperties) {
     super(
-      `Function ${properties.functionName} wrote to the table ` +
-        `${properties.tableName} while handling records from that table's ` +
-        `own stream ${properties.streamArn}. Each write would be delivered ` +
-        "back to the function, so the simulation would never settle. Write " +
-        "the result to a different table.",
+      `Function ${properties.functionName} ${properties.wroteTo} while ` +
+        `handling records from ${properties.sourceRelation} ` +
+        `${properties.streamArn}. Each write would be delivered back to the ` +
+        `function, so the simulation would never settle. ${properties.advice}`,
     );
   }
 }

--- a/src/service/lambda/index.ts
+++ b/src/service/lambda/index.ts
@@ -41,6 +41,11 @@ export type {
   SimLambdaDynamoDbStreamEventUserIdentity,
 } from "./event-source/poll/sim-lambda-dynamodb-stream-event.types.js";
 export type {
+  SimLambdaKinesisStreamEvent,
+  SimLambdaKinesisStreamEventRecord,
+  SimLambdaKinesisStreamEventRecordBody,
+} from "./event-source/poll/kinesis/sim-lambda-kinesis-stream-event.types.js";
+export type {
   SimLambdaDynamoDbAttributeValue,
   SimLambdaDynamoDbImage,
 } from "./event-source/stream/sim-lambda-dynamodb-attribute-value.js";

--- a/src/service/lambda/sim-lambda-commands.ts
+++ b/src/service/lambda/sim-lambda-commands.ts
@@ -23,6 +23,8 @@ import {
   type SimLambdaEventSourceStreams,
   SimLambdaNoEventSourceStreams,
 } from "./event-source/stream/sim-lambda-event-source-streams.js";
+import type { SimLambdaKinesisStreams } from "./event-source/stream/kinesis/sim-lambda-kinesis-streams.js";
+import { SimLambdaNoKinesisStreams } from "./event-source/stream/kinesis/sim-lambda-no-kinesis-streams.js";
 import {
   type SimLambdaContainerImages,
   SimLambdaNoContainerImages,
@@ -66,6 +68,7 @@ export interface SimLambdaProperties {
   readonly urlRegistry?: SimLambdaUrlRegistry;
   readonly eventSourceQueues?: SimSqsPollQueues;
   readonly eventSourceStreams?: SimLambdaEventSourceStreams;
+  readonly kinesisStreams?: SimLambdaKinesisStreams;
   /**
    * Where a function's asynchronous invocation results are sent. A standalone
    * SimLambda has no simulated SQS, SNS or EventBridge beside it, so a
@@ -128,6 +131,7 @@ export class SimLambdaCommands {
       // delivering.
       eventSourceQueues = new SimLambdaNoEventSourceQueues(),
       eventSourceStreams = new SimLambdaNoEventSourceStreams(),
+      kinesisStreams = new SimLambdaNoKinesisStreams(),
       // A standalone SimLambda has no simulated ECR beside it, so a container
       // image function created on one has nothing to resolve its image in.
       containerImages = new SimLambdaNoContainerImages(),
@@ -179,10 +183,12 @@ export class SimLambdaCommands {
         functions: this.functionLookup,
         queues: eventSourceQueues,
         streams: eventSourceStreams,
+        kinesisStreams,
         background,
       }),
       queues: eventSourceQueues,
       streams: eventSourceStreams,
+      kinesisStreams,
       functions: this.functionLookup,
       iam,
       background,

--- a/test/lambda/kinesis-event-source-fixture.ts
+++ b/test/lambda/kinesis-event-source-fixture.ts
@@ -1,0 +1,181 @@
+/**
+ * The parts a Kinesis stream event source mapping test needs before it can say
+ * anything about delivery: a stream, a role that may read it, a function to
+ * deliver to, and the mapping between them.
+ *
+ * A sibling of the DynamoDB stream fixture rather than part of it: the
+ * recording handler is shared from the queue fixture, and everything about
+ * which source is being read differs.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateEventSourceMappingCommand,
+  CreateFunctionCommand,
+  type EventSourcePosition,
+} from "@aws-sdk/client-lambda";
+import { assertNonNullable } from "@kensio/smartass";
+
+import { SimAws } from "../../src/service/aws/sim-aws.js";
+import { simKinesisStreamFactory } from "../../src/service/kinesis/stream/sim-kinesis-stream.factory.js";
+import type { SimLambdaKinesisStreamEvent } from "../../src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-stream-event.types.js";
+import { makeLambdaZipFileInput } from "../../src/service/lambda/function/code/lambda-zip-file-input.js";
+import type { SimLambdaHandler } from "../../src/service/lambda/function/sim-lambda-handler.type.js";
+import { recordingHandler } from "./event-source-fixture.js";
+
+/**
+ * The Kinesis operations real Lambda requires an execution role to be allowed
+ * before it will create an event source mapping on a stream.
+ */
+export const kinesisPollingActions: readonly string[] = [
+  "kinesis:DescribeStream",
+  "kinesis:GetRecords",
+  "kinesis:GetShardIterator",
+];
+
+/**
+ * Make an execution role allowed to read a stream.
+ *
+ * `kinesis:ListStreams` is on every stream rather than on one, which is what
+ * both the AWS managed policy and CDK's own grant do.
+ */
+export async function makeKinesisPollingRole(
+  simAws: SimAws,
+  streamArn: string,
+  actions: readonly string[] = kinesisPollingActions,
+): Promise<string> {
+  const role = await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "OrderProjectorRole",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { Service: "lambda.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "OrderProjectorRole",
+      PolicyName: "ProjectOrders",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [
+          { Effect: "Allow", Action: actions, Resource: streamArn },
+          { Effect: "Allow", Action: "kinesis:ListStreams", Resource: "*" },
+          { Effect: "Allow", Action: "kinesis:PutRecord", Resource: "*" },
+        ],
+      }),
+    }),
+  );
+
+  const roleArn = role.Role.Arn;
+  assertNonNullable(roleArn, "CreateRole answered with a role ARN");
+
+  return roleArn;
+}
+
+/**
+ * One simulated AWS with a Kinesis stream delivering to a function.
+ */
+export interface SimKinesisEventSourceFixture {
+  readonly simAws: SimAws;
+  readonly streamName: string;
+  readonly streamArn: string;
+  readonly functionName: string;
+  readonly roleArn: string;
+  readonly events: SimLambdaKinesisStreamEvent[];
+  readonly uuid: string;
+}
+
+interface KinesisEventSourceOptions {
+  readonly simAws?: SimAws;
+  readonly streamName?: string;
+  readonly shardCount?: number;
+  readonly roleActions?: readonly string[];
+  readonly handlerResult?: (event: SimLambdaKinesisStreamEvent) => unknown;
+  readonly batchSize?: number;
+  readonly startingPosition?: EventSourcePosition;
+  readonly startingPositionTimestamp?: Date;
+  readonly functionResponseTypes?: readonly "ReportBatchItemFailures"[];
+}
+
+/**
+ * Make a simulated AWS with a Kinesis stream, a projector function, and a
+ * mapping from one to the other.
+ */
+export async function simAwsWithKinesisEventSource(
+  options: KinesisEventSourceOptions = {},
+): Promise<SimKinesisEventSourceFixture> {
+  const simAws = options.simAws ?? new SimAws();
+  const streamName = options.streamName ?? "orders";
+  const stream = await simKinesisStreamFactory.make(
+    {
+      streamName,
+      ...(options.shardCount !== undefined && {
+        shardCount: options.shardCount,
+      }),
+    },
+    simAws,
+  );
+  const roleArn = await makeKinesisPollingRole(
+    simAws,
+    stream.arn,
+    options.roleActions,
+  );
+  const { handler, events } = recordingHandler<SimLambdaKinesisStreamEvent>(
+    options.handlerResult,
+  );
+  const functionName = await makeProjectorFunction(simAws, roleArn, handler);
+
+  const mapping = await simAws.lambda().createEventSourceMapping(
+    new CreateEventSourceMappingCommand({
+      EventSourceArn: stream.arn,
+      FunctionName: functionName,
+      StartingPosition: options.startingPosition ?? "TRIM_HORIZON",
+      ...(options.startingPositionTimestamp !== undefined && {
+        StartingPositionTimestamp: options.startingPositionTimestamp,
+      }),
+      ...(options.batchSize !== undefined && { BatchSize: options.batchSize }),
+      ...(options.functionResponseTypes !== undefined && {
+        FunctionResponseTypes: [...options.functionResponseTypes],
+      }),
+    }),
+  );
+
+  assertNonNullable(mapping.UUID, "The mapping has a UUID");
+
+  return {
+    simAws,
+    streamName,
+    streamArn: stream.arn,
+    functionName,
+    roleArn,
+    events,
+    uuid: mapping.UUID,
+  };
+}
+
+/**
+ * Make a function backed by a real in-process handler, so a test can watch what
+ * the handler was given.
+ */
+async function makeProjectorFunction(
+  simAws: SimAws,
+  roleArn: string,
+  handler: SimLambdaHandler,
+): Promise<string> {
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: "order-projector",
+      Role: roleArn,
+      Code: { ZipFile: makeLambdaZipFileInput(handler) },
+    }),
+  );
+
+  return "order-projector";
+}


### PR DESCRIPTION
An event source mapping can now name a Kinesis stream, and the records put onto it reach the function as a Kinesis event with the shape real Lambda sends: the payload base64 encoded under `kinesis.data`, the arrival as epoch seconds, and an `eventID` joining the shard to the sequence number. A stream is read by one processor per shard, as real Lambda reads one, so each shard keeps its own place, delivers its own batches and backs off on its own when one fails, and a failing batch blocks its own shard and no other. Polling authorizes as the function's execution role through DescribeStream, GetShardIterator and GetRecords, so a role missing one of them is refused when the mapping is created rather than left subscribed to nothing. A handler that puts records back onto the stream that invoked it is refused, the way one writing back into its own source table already was.

Getting there generalised three pieces that were DynamoDB-shaped. A starting position is now a position and, for AT_TIMESTAMP, the instant it needs, which is what lets a Kinesis mapping take the third position real Lambda offers. The batch response reads a failure report against the sequence numbers a batch held rather than against DynamoDB records, and the stream progress takes where a read left the reader rather than the records it read. The cascade guard describes whichever source fed itself. `AWS::Lambda::EventSourceMapping` needed no change and deploys a Kinesis mapping as it stands.

Resolves #909


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for connecting Kinesis streams to Lambda event source mappings.
  * Added shard-based polling, batch delivery, ordering, retries, partial batch failures, and payload decoding.
  * Added support for `TRIM_HORIZON`, `LATEST`, and `AT_TIMESTAMP` starting positions.
  * Added validation for stream availability, permissions, configuration, and unsupported consumer ARNs.
  * Added safeguards against recursive stream-triggered invocations.

* **Documentation**
  * Expanded Kinesis and Lambda documentation with configuration, limitations, IAM, CloudFormation, and event payload details.

* **Bug Fixes**
  * Clarified DynamoDB starting-position behavior and standardized event-source mapping configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->