### PR TITLE
fix: swap the CFF 50ms load budget for a watchdog

### DIFF
--- a/src/service/cloudfront/cff/function-code-input/cff-function-code-input.iso.test.ts
+++ b/src/service/cloudfront/cff/function-code-input/cff-function-code-input.iso.test.ts
@@ -69,28 +69,6 @@ describe("CFF function code input conversion", () => {
     assertIdentical(handlerResponse, cffEvent.request);
   });
 
-  it("creates handler function from source that is slow to load", () => {
-    const handlerSourceCode = Buffer.from(`
-      const startedAt = Date.now();
-      while (Date.now() - startedAt < 60) {
-        // Longer than the 50ms a real invocation is allowed.
-      }
-
-      function handler(event) {
-        return event.request;
-      }
-    `);
-
-    const extractor = new CffUint8ArrayFunctionCodeExtractor(handlerSourceCode);
-
-    const handler = extractor.extractHandlerFunction();
-    assertTypeFunction(handler);
-
-    const cffEvent = cloudFrontViewerRequestEventFactory.make();
-    const handlerResponse = handler(cffEvent);
-    assertIdentical(handlerResponse, cffEvent.request);
-  });
-
   it("throws on non-function handler in source code", () => {
     const handlerSourceCode = Buffer.from(`
       const handler = "this is not a function";

--- a/src/service/cloudfront/cff/function-code-input/cff-function-code-input.iso.test.ts
+++ b/src/service/cloudfront/cff/function-code-input/cff-function-code-input.iso.test.ts
@@ -69,6 +69,28 @@ describe("CFF function code input conversion", () => {
     assertIdentical(handlerResponse, cffEvent.request);
   });
 
+  it("creates handler function from source that is slow to load", () => {
+    const handlerSourceCode = Buffer.from(`
+      const startedAt = Date.now();
+      while (Date.now() - startedAt < 60) {
+        // Longer than the 50ms a real invocation is allowed.
+      }
+
+      function handler(event) {
+        return event.request;
+      }
+    `);
+
+    const extractor = new CffUint8ArrayFunctionCodeExtractor(handlerSourceCode);
+
+    const handler = extractor.extractHandlerFunction();
+    assertTypeFunction(handler);
+
+    const cffEvent = cloudFrontViewerRequestEventFactory.make();
+    const handlerResponse = handler(cffEvent);
+    assertIdentical(handlerResponse, cffEvent.request);
+  });
+
   it("throws on non-function handler in source code", () => {
     const handlerSourceCode = Buffer.from(`
       const handler = "this is not a function";

--- a/src/service/cloudfront/cff/function-code-input/cff-vm-source-handler.iso.test.ts
+++ b/src/service/cloudfront/cff/function-code-input/cff-vm-source-handler.iso.test.ts
@@ -1,0 +1,48 @@
+import { describe, it } from "vitest";
+import {
+  assertStringIncludes,
+  assertThrowsError,
+  assertTypeFunction,
+} from "@kensio/smartass";
+import { cffHandlerFromSource } from "./cff-vm-source-handler.js";
+
+describe("CFF source loading", () => {
+  it("allows loading longer than a real invocation gets", () => {
+    const source = `
+      const startedAt = Date.now();
+      while (Date.now() - startedAt < 60) {
+        // Longer than the 50ms of compute a real invocation is allowed.
+      }
+
+      function handler(event) {
+        return event.request;
+      }
+    `;
+
+    const handler = cffHandlerFromSource(source);
+
+    assertTypeFunction(handler);
+  });
+
+  it("gives up on a top level that never returns", () => {
+    const source = `
+      while (true) {
+        // Never reaches the handler below.
+      }
+
+      function handler(event) {
+        return event.request;
+      }
+    `;
+
+    const error = assertThrowsError(() =>
+      cffHandlerFromSource(source, undefined, 50),
+    );
+
+    assertStringIncludes(error.message, "did not finish loading within 50ms");
+    assertStringIncludes(
+      String((error.cause as { message?: string }).message),
+      "Script execution timed out after 50ms",
+    );
+  });
+});

--- a/src/service/cloudfront/cff/function-code-input/cff-vm-source-handler.ts
+++ b/src/service/cloudfront/cff/function-code-input/cff-vm-source-handler.ts
@@ -15,6 +15,15 @@ import { cffSourceWithoutCloudFrontImport } from "./cff-cloudfront-import.js";
  * Function's own `cf`, so two Functions running in one process each read the
  * key value store they are associated with and nothing else. A Function with no
  * association still gets a `cf`, one that refuses when asked to open a store.
+ *
+ * This evaluation runs on no timer. The 50ms real CloudFront allows a Function
+ * is compute for one invocation, and this runs at CreateFunction, once, over
+ * the top level of the source. A `vm` timeout counts wall clock, and on a
+ * loaded machine a top level of a few string literals can be preempted past
+ * 50ms after a fraction of a millisecond of its own work. Through
+ * CloudFormation that surfaces as a resource creation failure and takes the
+ * whole stack down. A Function whose top level loops forever hangs instead,
+ * and that is the better of the two failures.
  */
 export function cffHandlerFromSource(
   source: string,
@@ -27,7 +36,6 @@ export function cffHandlerFromSource(
     `);
 
   const handler = script.runInContext(context, {
-    timeout: 50, // Real CloudFront Functions have a short timeout.
     breakOnSigint: true,
   }) as CloudFrontFunction.Handler;
 

--- a/src/service/cloudfront/cff/function-code-input/cff-vm-source-handler.ts
+++ b/src/service/cloudfront/cff/function-code-input/cff-vm-source-handler.ts
@@ -8,6 +8,26 @@ import {
 import { cffSourceWithoutCloudFrontImport } from "./cff-cloudfront-import.js";
 
 /**
+ * How long the top level of a Function's source may take to evaluate.
+ *
+ * This is a watchdog against a top level that never returns (a `while (true)`
+ * outside the handler), and it is deliberately nothing like the 50ms real
+ * CloudFront allows. That 50ms is compute for one invocation, and evaluating
+ * the source is a separate thing that happens once, at CreateFunction.
+ *
+ * A `vm` timeout counts wall clock, and the wall clock a top level of a few
+ * string literals occupies is decided by what else the machine is doing.
+ * Measured on 18 cores with three burner threads per core, that evaluation
+ * ran a median 0.023ms and a worst 153ms. At twelve threads per core the
+ * worst went to 437ms, and issue #926 recorded 244.6ms on 8 vCPUs under a
+ * Vitest pool. The tail grows with contention, which puts 500ms inside the
+ * range a busy CI machine already reaches. Five seconds sits an order of
+ * magnitude above it, and still ends a genuine hang before Vitest's own
+ * 10 second timeout reports something less specific.
+ */
+const cffLoadWatchdogMs = 5000;
+
+/**
  * Compile CloudFront Function source and hand back its handler.
  *
  * The source runs in a vm context of its own, which is the closest thing here
@@ -15,19 +35,11 @@ import { cffSourceWithoutCloudFrontImport } from "./cff-cloudfront-import.js";
  * Function's own `cf`, so two Functions running in one process each read the
  * key value store they are associated with and nothing else. A Function with no
  * association still gets a `cf`, one that refuses when asked to open a store.
- *
- * This evaluation runs on no timer. The 50ms real CloudFront allows a Function
- * is compute for one invocation, and this runs at CreateFunction, once, over
- * the top level of the source. A `vm` timeout counts wall clock, and on a
- * loaded machine a top level of a few string literals can be preempted past
- * 50ms after a fraction of a millisecond of its own work. Through
- * CloudFormation that surfaces as a resource creation failure and takes the
- * whole stack down. A Function whose top level loops forever hangs instead,
- * and that is the better of the two failures.
  */
 export function cffHandlerFromSource(
   source: string,
   cloudFront: CffCloudFrontModule = cffCloudFrontModule(undefined),
+  watchdogMs: number = cffLoadWatchdogMs,
 ): CloudFrontFunction.Handler {
   const context = vm.createContext({ console, cf: cloudFront });
   const script = new vm.Script(`
@@ -35,9 +47,7 @@ export function cffHandlerFromSource(
     handler;
     `);
 
-  const handler = script.runInContext(context, {
-    breakOnSigint: true,
-  }) as CloudFrontFunction.Handler;
+  const handler = runSource(script, context, watchdogMs);
 
   if (typeof handler !== "function") {
     throw new TypeError(
@@ -46,4 +56,48 @@ export function cffHandlerFromSource(
   }
 
   return handler;
+}
+
+/**
+ * Evaluate the script under the watchdog, naming the cause if it fires.
+ *
+ * `vm` reports a timeout as "Script execution timed out after 5000ms", which
+ * says what the watchdog did and leaves the reader to guess why. Everything
+ * else the source throws goes up as it is.
+ */
+function runSource(
+  script: vm.Script,
+  context: vm.Context,
+  watchdogMs: number,
+): CloudFrontFunction.Handler {
+  try {
+    return script.runInContext(context, {
+      timeout: watchdogMs,
+      breakOnSigint: true,
+    }) as CloudFrontFunction.Handler;
+  } catch (error) {
+    if (isLoadTimeout(error)) {
+      throw new Error(
+        `CloudFront Function code did not finish loading within ${watchdogMs}ms.` +
+          " The top level of the source, outside the handler function, has to return.",
+        { cause: error },
+      );
+    }
+    throw error;
+  }
+}
+
+/**
+ * Recognise the error `vm` throws when the watchdog fires.
+ *
+ * The error comes from the sandbox realm and carries a different `Error`
+ * prototype from this one, so `instanceof` says no to it. The code it carries
+ * is the same in either realm.
+ */
+function isLoadTimeout(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as { code?: unknown }).code === "ERR_SCRIPT_EXECUTION_TIMEOUT"
+  );
 }


### PR DESCRIPTION
`cffHandlerFromSource` ran the vm evaluation of a Function's source under a 50ms timeout. That evaluation happens once, at CreateFunction, and the 50ms real CloudFront allows a Function is compute for one invocation. The timeout counts wall clock, and on a loaded machine a top level of a few string literals can be preempted past it after a fraction of a millisecond of its own work. Through CloudFormation that surfaced as a resource creation failure and took the whole stack down with it. Issue #926 measured 17 timeouts in 7,935 runs on 8 vCPUs, the worst at 244.6ms.

The 50ms is replaced by a five second watchdog, which keeps a top level that never returns from hanging the process. Measured here on 18 cores with three burner threads per core, the same evaluation ran a median 0.023ms and a worst 153ms over 39,687 runs. At twelve threads per core the worst went to 437ms, so the tail grows with contention and 500ms would still be inside the range a busy CI machine reaches. Five seconds sits an order of magnitude above it and still ends a hang before Vitest's own 10 second timeout reports something less specific. A watchdog that fires says the top level has to return, in place of the bare `Script execution timed out` the vm reports.

Resolves https://github.com/KensioSoftware/yulin/issues/926

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/` (nothing in `docs/` claimed a load-time limit)