### PR TITLE
feat: deploy AWS::Kinesis::Stream from a template

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -3252,6 +3252,7 @@ The resource types it creates are:
 - `AWS::ECR::Repository`
 - `AWS::Events::EventBus` and `AWS::Events::Rule`, with the rule's inline `Targets`
 - `AWS::IAM::Role`, `AWS::IAM::User`, `AWS::IAM::ManagedPolicy` and `AWS::IAM::Policy`
+- `AWS::Kinesis::Stream`
 - `AWS::KMS::Key` and `AWS::KMS::Alias`
 - `AWS::Lambda::Function`, `AWS::Lambda::Url` and `AWS::Lambda::Permission`
 - `AWS::Logs::LogGroup`

--- a/docs/services/kinesis/README.md
+++ b/docs/services/kinesis/README.md
@@ -153,6 +153,12 @@ A stream keeps a record for 24 hours. Records older than that are gone from a re
 applied at the instant of the read rather than on a timer, so moving simulated time forward is all a
 test needs.
 
+`IncreaseStreamRetentionPeriod` and `DecreaseStreamRetentionPeriod` move it, up to the 8760 hours
+Kinesis keeps at most. Each refuses a request that goes the other way, including one asking for what
+the stream already keeps, which is what real Kinesis does with a caller that has the wrong idea of
+what the stream is set to. Shortening the window drops whatever it has already outlived from the
+next read.
+
 ```typescript sim-kinesis-retention
 /**
  * Ageing a record out of a stream's retention window.
@@ -206,6 +212,78 @@ A [Lambda event source mapping](../lambda/#triggering-a-function-from-a-kinesis-
 polls a stream and invokes a function with the records it reads. Every shard is read by a processor
 of its own, as real Lambda reads one, and the function's execution role is what the polling is done
 as.
+
+## Deploying a stream
+
+`AWS::Kinesis::Stream` creates a simulated stream, which is what a CDK `Stream` synthesizes. The
+stream goes through the ordinary `CreateStream` command, so a stream a template deployed is the same
+thing an SDK caller would have got, and a template asking for something Kinesis will not take is
+refused in the words `CreateStream` refuses it in.
+
+`Ref` gives the stream name and `Fn::GetAtt` on `Arn` gives the stream ARN, which is the way round
+real CloudFormation publishes them. Every Kinesis API and every grant names the ARN, so a template
+wiring a stream into a Lambda event source mapping or an IAM policy reads the attribute.
+
+```typescript sim-kinesis-cloudformation
+/**
+ * Deploying a Kinesis stream and putting a record onto it.
+ */
+
+import { PutRecordCommand } from "@aws-sdk/client-kinesis";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Resources: {
+      OrdersStream: {
+        Type: "AWS::Kinesis::Stream",
+        Properties: {
+          Name: "orders",
+          ShardCount: 2,
+          RetentionPeriodHours: 168,
+        },
+      },
+    },
+    Outputs: {
+      StreamArn: { Value: { "Fn::GetAtt": ["OrdersStream", "Arn"] } },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+// arn:aws:kinesis:us-east-1:<account>:stream/orders
+console.log(stack.outputs.get("StreamArn")?.value);
+
+await simAws.kinesis().putRecord(
+  new PutRecordCommand({
+    StreamName: "orders",
+    PartitionKey: "customer-1",
+    Data: new TextEncoder().encode("order-1"),
+  }),
+);
+```
+
+`Name`, `ShardCount`, `RetentionPeriodHours`, `StreamModeDetails` and `Tags` are read. A stream the
+template does not name is named after the stack and the logical ID, as real CloudFormation names
+one.
+
+`RetentionPeriodHours` is applied after the stream is created, because `CreateStream` takes no
+retention on real Kinesis either. It only ever goes up: a new stream keeps records for 24 hours,
+which is also the least Kinesis accepts, so a template can ask for more or for the same and never
+for less.
+
+`StreamEncryption` and `DesiredShardLevelMetrics` are recorded against the resource as unsimulated
+and the stream is created anyway, so a template that encrypts its streams still deploys and the
+omission is somewhere a test can find it. Deleting the stack deletes the stream.
+
+`AWS::Kinesis::StreamConsumer` and `AWS::Kinesis::ResourcePolicy` are reported as unsupported and
+skipped. One registers an enhanced fan-out consumer and the other admits a caller from another
+account, and neither has anything to act on here.
 
 ## Permissions
 
@@ -317,17 +395,19 @@ console.log(put.ShardId);
 
 ## Supported commands
 
-| Command                 | Notes                                                                  |
-| ----------------------- | ---------------------------------------------------------------------- |
-| `CreateStream`          | A name already in use raises `ResourceInUseException`.                 |
-| `DeleteStream`          | The name is free again at once. `EnforceConsumerDeletion` is accepted. |
-| `ListStreams`           | Sorted by name, paged with `Limit` and `NextToken`.                    |
-| `DescribeStream`        | Shards paged with `Limit` and `ExclusiveStartShardId`.                 |
-| `DescribeStreamSummary` | Reports the open shard count instead of the shards.                    |
-| `PutRecord`             | `SequenceNumberForOrdering` is accepted and already guaranteed.        |
-| `PutRecords`            | Up to 500 records and 5 MB. `FailedRecordCount` is always zero.        |
-| `GetShardIterator`      | Every iterator type resolves.                                          |
-| `GetRecords`            | `Limit` up to 10,000. Reports `MillisBehindLatest`.                    |
+| Command                         | Notes                                                                  |
+| ------------------------------- | ---------------------------------------------------------------------- |
+| `CreateStream`                  | A name already in use raises `ResourceInUseException`.                 |
+| `DeleteStream`                  | The name is free again at once. `EnforceConsumerDeletion` is accepted. |
+| `ListStreams`                   | Sorted by name, paged with `Limit` and `NextToken`.                    |
+| `DescribeStream`                | Shards paged with `Limit` and `ExclusiveStartShardId`.                 |
+| `DescribeStreamSummary`         | Reports the open shard count instead of the shards.                    |
+| `IncreaseStreamRetentionPeriod` | Refused unless it asks for more than the stream keeps now.             |
+| `DecreaseStreamRetentionPeriod` | Refused unless it asks for less than the stream keeps now.             |
+| `PutRecord`                     | `SequenceNumberForOrdering` is accepted and already guaranteed.        |
+| `PutRecords`                    | Up to 500 records and 5 MB. `FailedRecordCount` is always zero.        |
+| `GetShardIterator`              | Every iterator type resolves.                                          |
+| `GetRecords`                    | `Limit` up to 10,000. Reports `MillisBehindLatest`.                    |
 
 Every operation takes `StreamName` or `StreamARN`, and reads the ARN when a request carries both.
 
@@ -347,8 +427,6 @@ Anything else refuses on send with `SimSdkUnsupportedCommandError`.
   that nothing here delivers. Every consumer reads through `GetRecords`.
 - **A shard iterator never expires.** Real Kinesis expires one after five minutes. An iterator this
   simulation never issued is still refused, with the `ExpiredIteratorException` real Kinesis uses.
-- **Retention is fixed at 24 hours.** `IncreaseStreamRetentionPeriod` and
-  `DecreaseStreamRetentionPeriod` are absent.
 - **Throughput is unlimited.** Real Kinesis takes 1 MB or 1,000 records a second per shard for
   writes and 2 MB a second for reads, and refuses past that with
   `ProvisionedThroughputExceededException`. Nothing here counts. That is why `FailedRecordCount` on
@@ -363,8 +441,6 @@ Anything else refuses on send with `SimSdkUnsupportedCommandError`.
   out, and no response carries an `EncryptionType`.
 - **Tags are kept and never listed.** A stream created with `Tags` holds them, readable through
   `findStream`. `AddTagsToStream`, `ListTagsForStream` and `RemoveTagsFromStream` are absent.
-- **`AWS::Kinesis::Stream` does not deploy.** A CloudFormation template holding one records the
-  resource as skipped.
 - **Kinesis Data Firehose is a separate service and is absent.** So is Kinesis Video Streams.
 - **`AWS::DynamoDB::Table` `KinesisStreamSpecification` stays unsimulated.** A table does not publish
   its changes into a stream here.

--- a/docs/services/kinesis/sim-kinesis-cloudformation.example.ts
+++ b/docs/services/kinesis/sim-kinesis-cloudformation.example.ts
@@ -1,0 +1,41 @@
+/**
+ * Deploying a Kinesis stream and putting a record onto it.
+ */
+
+import { PutRecordCommand } from "@aws-sdk/client-kinesis";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Resources: {
+      OrdersStream: {
+        Type: "AWS::Kinesis::Stream",
+        Properties: {
+          Name: "orders",
+          ShardCount: 2,
+          RetentionPeriodHours: 168,
+        },
+      },
+    },
+    Outputs: {
+      StreamArn: { Value: { "Fn::GetAtt": ["OrdersStream", "Arn"] } },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+// arn:aws:kinesis:us-east-1:<account>:stream/orders
+console.log(stack.outputs.get("StreamArn")?.value);
+
+await simAws.kinesis().putRecord(
+  new PutRecordCommand({
+    StreamName: "orders",
+    PartitionKey: "customer-1",
+    Data: new TextEncoder().encode("order-1"),
+  }),
+);

--- a/src/service/cloudformation/resource/cfn/kinesis/sim-kinesis-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/kinesis/sim-kinesis-cfn-value-adapter.ts
@@ -1,0 +1,25 @@
+import { kinesisStreamResourceType } from "../../../../kinesis/cfn/sim-cfn-kinesis-resource-types.js";
+import { SimKinesisStream } from "../../../../kinesis/stream/sim-kinesis-stream.js";
+import type {
+  SimCfnResourceValueAdapterProperties,
+  SimCfnServiceValueAdapter,
+} from "../sim-cfn-resource-value-adapter.js";
+import { SimKinesisStreamCfn } from "./sim-kinesis-stream-cfn.js";
+
+/**
+ * The CloudFormation-facing value adapter for a simulated Kinesis Resource.
+ */
+export function kinesisValueAdapter(
+  properties: SimCfnResourceValueAdapterProperties,
+): SimCfnServiceValueAdapter {
+  const { type, simResource } = properties;
+
+  if (
+    type === kinesisStreamResourceType &&
+    simResource instanceof SimKinesisStream
+  ) {
+    return new SimKinesisStreamCfn(simResource);
+  }
+
+  return undefined;
+}

--- a/src/service/cloudformation/resource/cfn/kinesis/sim-kinesis-stream-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/kinesis/sim-kinesis-stream-cfn.ts
@@ -1,0 +1,39 @@
+import { assertDefined } from "../../../../../util/type-guard/defined.js";
+import type { SimKinesisStream } from "../../../../kinesis/stream/sim-kinesis-stream.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+/**
+ * CloudFormation-facing values for a simulated Kinesis stream.
+ */
+export class SimKinesisStreamCfn implements SimCfnResourceValueAdapter {
+  readonly #stream: SimKinesisStream;
+
+  constructor(stream: SimKinesisStream) {
+    this.#stream = stream;
+  }
+
+  /**
+   * A Ref to an AWS::Kinesis::Stream returns the stream name.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.#stream.name;
+  }
+
+  /**
+   * The one attribute the Resource publishes, which is the stream ARN.
+   *
+   * That is what every Kinesis API and every grant names, so a template wiring
+   * a stream into a Lambda event source mapping or an IAM policy reads it.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    const value = attributeName === "Arn" ? this.#stream.arn : undefined;
+
+    assertDefined(
+      value,
+      `Unsupported AWS::Kinesis::Stream attribute ${attributeName}`,
+    );
+
+    return value;
+  }
+}

--- a/src/service/cloudformation/resource/cfn/sim-cfn-service-value-adapters.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-service-value-adapters.ts
@@ -11,6 +11,7 @@ import { ecsValueAdapter } from "./ecs/sim-ecs-cfn-value-adapter.js";
 import { elbV2ValueAdapter } from "./elasticloadbalancingv2/sim-elbv2-cfn-value-adapter.js";
 import { eventBridgeValueAdapter } from "./events/sim-event-bridge-cfn-value-adapter.js";
 import { iamValueAdapter } from "./iam/sim-iam-cfn-value-adapter.js";
+import { kinesisValueAdapter } from "./kinesis/sim-kinesis-cfn-value-adapter.js";
 import { kmsValueAdapter } from "./kms/sim-kms-cfn-value-adapter.js";
 import { lambdaValueAdapter } from "./lambda/sim-lambda-cfn-value-adapter.js";
 import { personalizeValueAdapter } from "./personalize/sim-personalize-cfn-value-adapter.js";
@@ -53,6 +54,7 @@ export const simCfnServiceValueAdapters: readonly ((
   elbV2ValueAdapter,
   eventBridgeValueAdapter,
   iamValueAdapter,
+  kinesisValueAdapter,
   kmsValueAdapter,
   lambdaValueAdapter,
   personalizeValueAdapter,

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
@@ -90,6 +90,11 @@ export const simCfnServiceResourceFactories: ReadonlyMap<
       scopedAws.iam().cfnResourceFactory(),
   ],
   [
+    "Kinesis",
+    (scopedAws): SimCfnServiceResourceFactory =>
+      scopedAws.kinesis().cfnResourceFactory(),
+  ],
+  [
     "KMS",
     (scopedAws): SimCfnServiceResourceFactory =>
       scopedAws.kms().cfnResourceFactory(),

--- a/src/service/kinesis/README.md
+++ b/src/service/kinesis/README.md
@@ -75,6 +75,12 @@ cannot reach a stream it lacks permission for by holding an iterator someone els
 an intercepted client sends is refused with `SimSdkUnsupportedCommandError`, which covers enhanced
 fan-out, resharding, encryption and the tag operations.
 
+`cfn/` deploys `AWS::Kinesis::Stream`. It goes through `CreateStream` like everything else, so a
+template and an SDK caller reach the same stream, and `RetentionPeriodHours` is a second call
+afterwards because `CreateStream` takes no retention on real Kinesis either. That call is always an
+increase: 24 hours is both the default a stream is created with and the least Kinesis accepts, so a
+template can never ask for less.
+
 A Lambda event source mapping reads a stream through those same commands, as the function's
 execution role. The adapter is `SimKinesisEventSourceStreams` under
 `src/service/lambda/event-source/stream/kinesis/`, and `streamActivity()` is what tells a poller

--- a/src/service/kinesis/cfn/sim-cfn-kinesis-resource-deleter.ts
+++ b/src/service/kinesis/cfn/sim-cfn-kinesis-resource-deleter.ts
@@ -1,0 +1,41 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimKinesis } from "../sim-kinesis.js";
+import type { SimKinesisStream } from "../stream/sim-kinesis-stream.js";
+
+interface SimCfnKinesisResourceDeleterProperties {
+  readonly kinesis: SimKinesis;
+}
+
+/**
+ * Deletes the simulated Kinesis resources a CloudFormation Stack created.
+ */
+export class SimCfnKinesisResourceDeleter {
+  private readonly kinesis: SimKinesis;
+
+  constructor(properties: SimCfnKinesisResourceDeleterProperties) {
+    this.kinesis = properties.kinesis;
+  }
+
+  /**
+   * Delete a simulated Kinesis resource created from a CloudFormation Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+  ): Promise<void> {
+    if (resourceTypeName !== "Stream") {
+      throw new Error(
+        `Unsupported sim Kinesis CloudFormation Resource ${resourceTypeName} deletion`,
+      );
+    }
+
+    const stream = resource.simResource as SimKinesisStream | undefined;
+    assertDefined(
+      stream,
+      `sim Kinesis stream for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    await this.kinesis.deleteStream({ input: { StreamARN: stream.arn } });
+  }
+}

--- a/src/service/kinesis/cfn/sim-cfn-kinesis-resource-error.ts
+++ b/src/service/kinesis/cfn/sim-cfn-kinesis-resource-error.ts
@@ -1,0 +1,54 @@
+import { SimKinesisError } from "../error/sim-kinesis.error.js";
+
+/**
+ * Build the error a Resource of a simulated Kinesis type is refused with.
+ *
+ * The wording is deliberate. Sim CloudFormation reads an error saying a
+ * Resource is unsupported as one to record and step over, and stepping over a
+ * stream that cannot be created as the template asked for it is the wrong
+ * answer: the Stack would look deployed while nothing could be put anywhere. So
+ * a refusal here says the Resource is invalid.
+ */
+export function simCfnKinesisResourceError(
+  resourceType: string,
+  logicalId: string,
+  reason: string,
+  cause?: unknown,
+): Error {
+  return new Error(`Invalid ${resourceType} Resource ${logicalId}: ${reason}`, {
+    cause,
+  });
+}
+
+/**
+ * Run the simulated Kinesis commands one Resource is made of, naming the
+ * Resource in whatever they refuse.
+ *
+ * Every Resource type here goes through the ordinary Kinesis commands, so what
+ * a template may ask for is decided once, by simulated Kinesis, rather than
+ * again in the CloudFormation layer. What that leaves out is where the request
+ * came from: a deployment failing with `ShardCount 0 is not a whole number of
+ * shards` says nothing about which Resource asked for it. Only Kinesis's own
+ * errors are renamed, so a refusal the CloudFormation layer decided keeps the
+ * wording it was written with.
+ */
+export async function simCfnKinesisResourceCreation<T>(
+  resourceType: string,
+  logicalId: string,
+  create: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await create();
+  } catch (error) {
+    if (error instanceof SimKinesisError) {
+      throw simCfnKinesisResourceError(
+        resourceType,
+        logicalId,
+        error.message,
+        error,
+      );
+    }
+
+    throw error;
+  }
+}

--- a/src/service/kinesis/cfn/sim-cfn-kinesis-resource-refusals.iso.test.ts
+++ b/src/service/kinesis/cfn/sim-cfn-kinesis-resource-refusals.iso.test.ts
@@ -1,0 +1,109 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnDeployedResource } from "../../cloudformation/resource/sim-cfn-deployed-resource.type.js";
+import type { SimCfnDeployedStack } from "../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
+import {
+  deployedResourceObject,
+  deployedStackObject,
+} from "../../cloudformation/stack/sim-cfn-stack.fixture.js";
+import { simCfnKinesisResourceCreation } from "./sim-cfn-kinesis-resource-error.js";
+
+/**
+ * A deployed stream, the stack that holds it and the simulation it is in.
+ */
+async function deployedStream(): Promise<{
+  readonly simAws: SimAws;
+  readonly stack: SimCfnDeployedStack;
+  readonly resource: SimCfnDeployedResource;
+}> {
+  const simAws = new SimAws();
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "orders-stack",
+    template: {
+      Resources: {
+        OrdersStream: {
+          Type: "AWS::Kinesis::Stream",
+          Properties: { Name: "orders" },
+        },
+      },
+    },
+  });
+  await stack.waitForDeployComplete();
+
+  const resource = stack.getResource("OrdersStream");
+  assertNonNullable(resource);
+
+  return { simAws, stack, resource };
+}
+
+describe("What the simulated Kinesis CloudFormation factory refuses", () => {
+  it("refuses creating a Kinesis Resource type it does not simulate", async () => {
+    // Given a deployed stream, and the factory that made it.
+    const { simAws, stack, resource } = await deployedStream();
+
+    // When the factory is asked for a stream consumer, which is enhanced
+    // fan-out.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .kinesis()
+        .cfnResourceFactory()
+        .create("StreamConsumer", deployedResourceObject(resource), {
+          simAws,
+          resources: deployedStackObject(stack).resourceMap,
+        });
+    });
+
+    // Then it says so, which sim CloudFormation records and steps over.
+    assertStringIncludes(
+      error.message,
+      "Unsupported sim Kinesis CloudFormation Resource StreamConsumer",
+    );
+  });
+
+  it("refuses deleting a Kinesis Resource type it never creates", async () => {
+    // Given a deployed stream, and the factory that made it.
+    const { simAws, stack, resource } = await deployedStream();
+
+    // When the factory is asked to delete a resource policy.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .kinesis()
+        .cfnResourceFactory()
+        .delete("ResourcePolicy", deployedResourceObject(resource), {
+          simAws,
+          resources: deployedStackObject(stack).resourceMap,
+        });
+    });
+
+    // Then it says so.
+    assertStringIncludes(
+      error.message,
+      "Unsupported sim Kinesis CloudFormation Resource ResourcePolicy deletion",
+    );
+  });
+
+  it("passes through an error that did not come from simulated Kinesis", async () => {
+    // Given a creation that fails for a reason of its own.
+    const thrown = new TypeError("the template reader broke");
+
+    // When it runs inside the wrapper that renames Kinesis refusals.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simCfnKinesisResourceCreation(
+        "AWS::Kinesis::Stream",
+        "OrdersStream",
+        () => Promise.reject(thrown),
+      );
+    });
+
+    // Then it comes back as it was, since only Kinesis's own refusals are
+    // reworded to name the Resource.
+    assertIdentical(error, thrown);
+  });
+});

--- a/src/service/kinesis/cfn/sim-cfn-kinesis-resource-types.ts
+++ b/src/service/kinesis/cfn/sim-cfn-kinesis-resource-types.ts
@@ -1,0 +1,8 @@
+/**
+ * The CloudFormation Resource types simulated Kinesis creates.
+ *
+ * Named here rather than spelled out where they are used, because each one is
+ * written twice: once by the factory dispatching on it, and once by the
+ * refusals that quote it back to whoever wrote the template.
+ */
+export const kinesisStreamResourceType = "AWS::Kinesis::Stream";

--- a/src/service/kinesis/cfn/sim-cfn-kinesis-stream-refusals.iso.test.ts
+++ b/src/service/kinesis/cfn/sim-cfn-kinesis-stream-refusals.iso.test.ts
@@ -1,0 +1,112 @@
+import { assertStringIncludes, assertThrowsErrorAsync } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+/**
+ * Deploy a stream declared with the given properties, giving back whatever the
+ * deployment was refused with.
+ */
+async function refusalFrom(
+  properties: SimCfnTemplateValueRecord,
+): Promise<Error> {
+  const simAws = new SimAws();
+
+  return await assertThrowsErrorAsync(async () => {
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersStream: {
+            Type: "AWS::Kinesis::Stream",
+            Properties: properties,
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+  });
+}
+
+describe("What a deployed AWS::Kinesis::Stream refuses", () => {
+  it("refuses a shard count Kinesis would not accept", async () => {
+    // When a template declares a stream with no shards.
+    const error = await refusalFrom({ Name: "orders", ShardCount: 0 });
+
+    // Then the deployment is refused in the words CreateStream refuses it in,
+    // with the Resource named so the template can be found.
+    assertStringIncludes(error.message, "OrdersStream");
+    assertStringIncludes(error.message, "ShardCount 0");
+  });
+
+  it("refuses a stream name Kinesis would not accept", async () => {
+    // When a template declares a stream with a slash in its name.
+    const error = await refusalFrom({ Name: "orders/live" });
+
+    // Then the deployment is refused rather than deploying a stream nothing
+    // could reach by the name the template used.
+    assertStringIncludes(error.message, "OrdersStream");
+    assertStringIncludes(error.message, "letters, digits");
+  });
+
+  it("refuses a retention Kinesis would not accept", async () => {
+    // When a template declares more retention than Kinesis keeps.
+    const error = await refusalFrom({
+      Name: "orders",
+      RetentionPeriodHours: 8761,
+    });
+
+    // Then the deployment is refused.
+    assertStringIncludes(error.message, "8760 hours Kinesis accepts");
+  });
+
+  it("refuses a shard count on an on-demand stream", async () => {
+    // When a template declares both, which real Kinesis refuses together.
+    const error = await refusalFrom({
+      Name: "orders",
+      ShardCount: 2,
+      StreamModeDetails: { StreamMode: "ON_DEMAND" },
+    });
+
+    // Then the deployment is refused.
+    assertStringIncludes(error.message, "ON_DEMAND");
+  });
+
+  it("refuses a property whose shape the template got wrong", async () => {
+    // Given templates that put the wrong kind of value in each place.
+    const wrongShapes: readonly (readonly [
+      SimCfnTemplateValueRecord,
+      string,
+    ])[] = [
+      [{ Name: { Ref: "Elsewhere" } }, "Name must be a string"],
+      [{ Name: "orders", ShardCount: "two" }, "ShardCount must be a number"],
+      [
+        { Name: "orders", RetentionPeriodHours: "a week" },
+        "RetentionPeriodHours must be a number",
+      ],
+      [
+        { Name: "orders", StreamModeDetails: "ON_DEMAND" },
+        "StreamModeDetails must be an object",
+      ],
+      [
+        { Name: "orders", StreamModeDetails: { StreamMode: 1 } },
+        "StreamModeDetails.StreamMode must be a string",
+      ],
+      [{ Name: "orders", Tags: { team: "orders" } }, "Tags must be a list"],
+      [
+        { Name: "orders", Tags: [{ Key: "team" }] },
+        "Tags entries must each carry a string Key and Value",
+      ],
+    ];
+
+    // When each is deployed.
+    // Then each is refused saying which property is wrong, rather than
+    // reaching CreateStream with something it cannot explain.
+    for (const [properties, expected] of wrongShapes) {
+      // oxlint-disable-next-line no-await-in-loop
+      const error = await refusalFrom(properties);
+      assertStringIncludes(error.message, expected);
+    }
+  });
+});

--- a/src/service/kinesis/cfn/sim-cfn-kinesis-stream.iso.test.ts
+++ b/src/service/kinesis/cfn/sim-cfn-kinesis-stream.iso.test.ts
@@ -1,0 +1,229 @@
+import { DescribeStreamCommand } from "@aws-sdk/client-kinesis";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../cloudformation/template/sim-cfn-template.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimKinesisResourceNotFoundException } from "../error/sim-kinesis.error.js";
+
+/**
+ * A stack holding one stream, and outputs reading it both ways.
+ */
+function streamTemplate(
+  properties: SimCfnTemplateValueRecord,
+): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      OrdersStream: { Type: "AWS::Kinesis::Stream", Properties: properties },
+    },
+    Outputs: {
+      StreamRef: { Value: { Ref: "OrdersStream" } },
+      StreamArn: { Value: { "Fn::GetAtt": ["OrdersStream", "Arn"] } },
+    },
+  };
+}
+
+describe("deployed AWS::Kinesis::Stream Resources", () => {
+  it("creates a stream with the shard count the template declared", async () => {
+    // Given a template declaring a stream with two shards.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: streamTemplate({ Name: "orders", ShardCount: 2 }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the stream is there, with the shards it asked for.
+    const described = await simAws
+      .kinesis()
+      .describeStream(new DescribeStreamCommand({ StreamName: "orders" }));
+    assertArrayLength(described.StreamDescription.Shards, 2);
+    assertIdentical(described.StreamDescription.StreamStatus, "ACTIVE");
+  });
+
+  it("answers a Ref with the name and Arn with the stream ARN", async () => {
+    // Given a template reading its stream both ways.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: streamTemplate({ Name: "orders" }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the Ref is the name and the attribute is the ARN, which is the way
+    // round real CloudFormation publishes them.
+    assertIdentical(stack.outputs.get("StreamRef")?.value, "orders");
+    assertIdentical(
+      stack.outputs.get("StreamArn")?.value,
+      `arn:aws:kinesis:${simAws.defaultRegionName}:${simAws.defaultAccountId}:stream/orders`,
+    );
+  });
+
+  it("names an unnamed stream after the stack and the logical ID", async () => {
+    // Given a template that names no stream.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: streamTemplate({ ShardCount: 1 }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then CloudFormation named it, as real CloudFormation does.
+    assertIdentical(
+      stack.outputs.get("StreamRef")?.value,
+      "orders-stack-OrdersStream",
+    );
+  });
+
+  it("gives an on-demand stream the four shards Kinesis starts it with", async () => {
+    // Given a template declaring an on-demand stream, which takes no shard
+    // count.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: streamTemplate({
+        Name: "orders",
+        StreamModeDetails: { StreamMode: "ON_DEMAND" },
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then it has the four shards real Kinesis starts one with.
+    const described = await simAws
+      .kinesis()
+      .describeStream(new DescribeStreamCommand({ StreamName: "orders" }));
+    assertArrayLength(described.StreamDescription.Shards, 4);
+    assertIdentical(
+      described.StreamDescription.StreamModeDetails.StreamMode,
+      "ON_DEMAND",
+    );
+  });
+
+  it("keeps records for the retention the template declared", async () => {
+    // Given a template declaring a week of retention, which is more than the
+    // default a stream is created with.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: streamTemplate({ Name: "orders", RetentionPeriodHours: 168 }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the stream keeps records for that long.
+    const described = await simAws
+      .kinesis()
+      .describeStream(new DescribeStreamCommand({ StreamName: "orders" }));
+    assertIdentical(described.StreamDescription.RetentionPeriodHours, 168);
+  });
+
+  it("leaves retention alone when the template declares the default", async () => {
+    // Given a template declaring the retention a new stream already has, which
+    // is also the least Kinesis accepts, so a template can never ask for less.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: streamTemplate({ Name: "orders", RetentionPeriodHours: 24 }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the stream keeps records for that long, and nothing tried to change
+    // it, which real Kinesis would have refused as a change to what it already
+    // keeps.
+    const described = await simAws
+      .kinesis()
+      .describeStream(new DescribeStreamCommand({ StreamName: "orders" }));
+    assertIdentical(described.StreamDescription.RetentionPeriodHours, 24);
+  });
+
+  it("keeps the tags the template declared", async () => {
+    // Given a template tagging its stream.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: streamTemplate({
+        Name: "orders",
+        Tags: [{ Key: "team", Value: "orders" }],
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the stream carries them, readable through the simulator's own
+    // accessor since the Kinesis tag operations are unsimulated.
+    assertIdentical(
+      simAws.kinesis().findStream("orders")?.tags["team"],
+      "orders",
+    );
+  });
+
+  it("records encryption as unsimulated and creates the stream anyway", async () => {
+    // Given a template asking for a stream encrypted with a KMS key.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: streamTemplate({
+        Name: "orders",
+        StreamEncryption: { EncryptionType: "KMS", KeyId: "alias/aws/kinesis" },
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the stream is there, and the property it could not act on is
+    // recorded where a test can find it rather than failing the stack.
+    assertIdentical(simAws.kinesis().findStream("orders")?.name, "orders");
+
+    const ignored = stack.resources
+      .flatMap((resource) => [...resource.ignoredProperties])
+      .filter((property) => property.path === "StreamEncryption");
+    assertArrayLength(ignored, 1);
+    assertStringIncludes(ignored[0].reason, "encryption is not simulated");
+  });
+
+  it("deletes the stream when the stack is deleted", async () => {
+    // Given a deployed stream.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: streamTemplate({ Name: "orders" }),
+    });
+    await stack.waitForDeployComplete();
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then the stream has gone with it, and the Resource says so.
+    assertIdentical(
+      stack.getResource("OrdersStream")?.status,
+      "DELETE_COMPLETE",
+    );
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .kinesis()
+        .describeStream(new DescribeStreamCommand({ StreamName: "orders" }));
+    });
+    assertInstanceOf(error, SimKinesisResourceNotFoundException);
+  });
+});

--- a/src/service/kinesis/cfn/sim-kinesis-cfn-resource-factory.ts
+++ b/src/service/kinesis/cfn/sim-kinesis-cfn-resource-factory.ts
@@ -1,0 +1,67 @@
+import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCloudFormationResourceDeleteContext } from "../../cloudformation/resource/sim-cfn-resource.type.js";
+import type { SimKinesis } from "../sim-kinesis.js";
+import { SimCfnKinesisResourceDeleter } from "./sim-cfn-kinesis-resource-deleter.js";
+import { SimCfnKinesisStreamCreator } from "./stream/sim-cfn-kinesis-stream-creator.js";
+
+interface SimKinesisCfnResourceFactoryProperties {
+  readonly kinesis: SimKinesis;
+}
+
+/**
+ * CloudFormation Resource factory for simulated Kinesis resources.
+ */
+export class SimKinesisCfnResourceFactory implements SimCfnServiceResourceFactory {
+  private readonly streamCreator: SimCfnKinesisStreamCreator;
+  private readonly deleter: SimCfnKinesisResourceDeleter;
+
+  constructor(properties: SimKinesisCfnResourceFactoryProperties) {
+    this.streamCreator = new SimCfnKinesisStreamCreator({
+      kinesis: properties.kinesis,
+    });
+    this.deleter = new SimCfnKinesisResourceDeleter({
+      kinesis: properties.kinesis,
+    });
+  }
+
+  /**
+   * Create a simulated Kinesis resource from a CloudFormation Resource.
+   *
+   * The stream is the one AWS::Kinesis::* Resource type this simulation models.
+   * `StreamConsumer` registers an enhanced fan-out consumer and `ResourcePolicy`
+   * admits a caller from another Account, and neither has anything to act on
+   * here, so both are reported as unsupported and skipped rather than quietly
+   * treated as deployed.
+   */
+  async create(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<object | undefined> {
+    if (resourceTypeName !== "Stream") {
+      throw new Error(
+        `Unsupported sim Kinesis CloudFormation Resource ${resourceTypeName}`,
+      );
+    }
+
+    return await this.streamCreator.create(
+      resource,
+      context.resolvedProperties ?? resource.properties,
+    );
+  }
+
+  /**
+   * Delete a simulated Kinesis resource created from a CloudFormation Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    _context: SimCloudFormationResourceDeleteContext,
+  ): Promise<void> {
+    await this.deleter.delete(resourceTypeName, resource);
+  }
+}

--- a/src/service/kinesis/cfn/stream/sim-cfn-kinesis-stream-creator.ts
+++ b/src/service/kinesis/cfn/stream/sim-cfn-kinesis-stream-creator.ts
@@ -1,0 +1,103 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimKinesis } from "../../sim-kinesis.js";
+import { simKinesisDefaultRetentionHours } from "../../stream/sim-kinesis-retention.js";
+import type { SimKinesisStream } from "../../stream/sim-kinesis-stream.js";
+import { simCfnKinesisResourceCreation } from "../sim-cfn-kinesis-resource-error.js";
+import { kinesisStreamResourceType } from "../sim-cfn-kinesis-resource-types.js";
+import { SimCfnKinesisStreamProperties } from "./sim-cfn-kinesis-stream-properties.js";
+
+interface SimCfnKinesisStreamCreatorProperties {
+  readonly kinesis: SimKinesis;
+}
+
+/**
+ * Creates simulated streams from AWS::Kinesis::Stream Resources.
+ *
+ * The stream goes through the ordinary CreateStream command rather than being
+ * constructed directly, so a stream a template deployed is the same thing an
+ * SDK caller would have got: the same name validation, the same shard map, the
+ * same refusals for what this simulation does not model.
+ *
+ * Retention goes the same way. CreateStream takes no retention, on real Kinesis
+ * or here, so a template asking for more than the default is a second call, as
+ * it is for CloudFormation itself.
+ */
+export class SimCfnKinesisStreamCreator {
+  private readonly kinesis: SimKinesis;
+
+  constructor(properties: SimCfnKinesisStreamCreatorProperties) {
+    this.kinesis = properties.kinesis;
+  }
+
+  /**
+   * Create a stream from an AWS::Kinesis::Stream Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimKinesisStream> {
+    const streamProperties = new SimCfnKinesisStreamProperties({
+      resource,
+      properties,
+    });
+    const name = streamProperties.name();
+    const shardCount = streamProperties.shardCount();
+    const streamMode = streamProperties.streamMode();
+    const tags = streamProperties.tags();
+    const retentionHours = streamProperties.retentionHours();
+
+    return await simCfnKinesisResourceCreation(
+      kinesisStreamResourceType,
+      resource.logicalId,
+      async () => {
+        await this.kinesis.createStream({
+          input: {
+            StreamName: name,
+            ...(shardCount !== undefined && { ShardCount: shardCount }),
+            ...(streamMode !== undefined && {
+              StreamModeDetails: { StreamMode: streamMode },
+            }),
+            ...(tags !== undefined && { Tags: tags }),
+          },
+        });
+
+        await this.applyRetention(name, retentionHours);
+
+        const stream = this.kinesis.findStream(name);
+        assertDefined(
+          stream,
+          `sim Kinesis stream ${name} after CloudFormation creation`,
+        );
+
+        return stream;
+      },
+    );
+  }
+
+  /**
+   * Move the stream's retention up to what the template asked for.
+   *
+   * Only ever upwards. A new stream keeps records for 24 hours, and that is
+   * also the least Kinesis accepts, so a template can ask for more or for the
+   * same and never for less. A template asking for the same asks for no change,
+   * which is just as well: real Kinesis refuses an increase to what the stream
+   * already keeps.
+   */
+  private async applyRetention(
+    name: string,
+    retentionHours: number | undefined,
+  ): Promise<void> {
+    if (
+      retentionHours === undefined ||
+      retentionHours <= simKinesisDefaultRetentionHours
+    ) {
+      return;
+    }
+
+    await this.kinesis.increaseStreamRetentionPeriod({
+      input: { StreamName: name, RetentionPeriodHours: retentionHours },
+    });
+  }
+}

--- a/src/service/kinesis/cfn/stream/sim-cfn-kinesis-stream-name.ts
+++ b/src/service/kinesis/cfn/stream/sim-cfn-kinesis-stream-name.ts
@@ -1,0 +1,35 @@
+import { SimCfnGeneratedResourceName } from "../../../cloudformation/resource/name/sim-cfn-generated-resource-name.js";
+
+const maximumNameLength = 128;
+
+interface SimCfnKinesisStreamNameProperties {
+  readonly stackName: string | undefined;
+  readonly logicalId: string;
+}
+
+/**
+ * The name CloudFormation gives a stream whose template does not name it.
+ *
+ * A stream name is at most 128 characters, so a long stack name and logical ID
+ * together are trimmed to fit. How a generated name is put together and trimmed
+ * is the same for every service, and lives in
+ * {@link SimCfnGeneratedResourceName}.
+ */
+export class SimCfnKinesisStreamName {
+  private readonly generated: SimCfnGeneratedResourceName;
+
+  constructor(properties: SimCfnKinesisStreamNameProperties) {
+    this.generated = new SimCfnGeneratedResourceName({
+      stackName: properties.stackName,
+      logicalId: properties.logicalId,
+      maximumLength: maximumNameLength,
+    });
+  }
+
+  /**
+   * The generated stream name.
+   */
+  get value(): string {
+    return this.generated.value;
+  }
+}

--- a/src/service/kinesis/cfn/stream/sim-cfn-kinesis-stream-properties.ts
+++ b/src/service/kinesis/cfn/stream/sim-cfn-kinesis-stream-properties.ts
@@ -1,0 +1,183 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { isRecord } from "../../../../util/type-guard/record.js";
+import type { SimKinesisTags } from "../../command/stream/stream.command.js";
+import { simCfnKinesisResourceError } from "../sim-cfn-kinesis-resource-error.js";
+import { kinesisStreamResourceType } from "../sim-cfn-kinesis-resource-types.js";
+import { SimCfnKinesisStreamName } from "./sim-cfn-kinesis-stream-name.js";
+import {
+  retentionPropertyName,
+  shardCountPropertyName,
+  streamModeDetailsPropertyName,
+  streamNamePropertyName,
+  tagsPropertyName,
+  unsimulatedPropertyReasons,
+} from "./sim-cfn-kinesis-stream-property-names.js";
+
+interface SimCfnKinesisStreamPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::Kinesis::Stream CloudFormation properties into the shapes the
+ * Kinesis commands take.
+ *
+ * What a template may ask for is decided by simulated Kinesis rather than here,
+ * so a shard count or a retention it will not take is refused by the command
+ * that reads it. What this reads is the shape: a property that has to be a
+ * string, a number or a record is checked for being one, since a template that
+ * put an object where a name goes has made a mistake CreateStream cannot
+ * explain.
+ */
+export class SimCfnKinesisStreamProperties {
+  private readonly resource: SimCfnResource;
+  private readonly properties: ReadonlyMap<string, SimCfnTemplateValue>;
+
+  constructor(properties: SimCfnKinesisStreamPropertiesProperties) {
+    this.resource = properties.resource;
+    this.properties = new Map(Object.entries(properties.properties));
+
+    this.recordUnsimulated();
+  }
+
+  /**
+   * The stream name.
+   *
+   * An unnamed stream is named after the stack and the logical ID, as real
+   * CloudFormation names one.
+   */
+  name(): string {
+    const name = this.properties.get(streamNamePropertyName);
+
+    if (name === undefined) {
+      return new SimCfnKinesisStreamName({
+        stackName: this.resource.stackName,
+        logicalId: this.resource.logicalId,
+      }).value;
+    }
+
+    if (typeof name !== "string") {
+      throw this.propertyError(`${streamNamePropertyName} must be a string`);
+    }
+
+    return name;
+  }
+
+  /**
+   * How many shards the stream is created with, when the template says.
+   */
+  shardCount(): number | undefined {
+    return this.optionalNumber(shardCountPropertyName);
+  }
+
+  /**
+   * How long the stream keeps a record, when the template says.
+   */
+  retentionHours(): number | undefined {
+    return this.optionalNumber(retentionPropertyName);
+  }
+
+  /**
+   * The capacity mode the stream is created in, when the template says.
+   */
+  streamMode(): string | undefined {
+    const details = this.properties.get(streamModeDetailsPropertyName);
+
+    if (details === undefined) {
+      return undefined;
+    }
+
+    if (!isRecord(details)) {
+      throw this.propertyError(
+        `${streamModeDetailsPropertyName} must be an object`,
+      );
+    }
+
+    const mode = details["StreamMode"];
+
+    if (mode !== undefined && typeof mode !== "string") {
+      throw this.propertyError(
+        `${streamModeDetailsPropertyName}.StreamMode must be a string`,
+      );
+    }
+
+    return mode;
+  }
+
+  /**
+   * The tags the stream is created with, as CreateStream takes them.
+   *
+   * A template writes them as a list of key and value pairs, and the Kinesis
+   * API takes a record, so they are turned over here.
+   */
+  tags(): SimKinesisTags | undefined {
+    const tags = this.properties.get(tagsPropertyName);
+
+    if (tags === undefined) {
+      return undefined;
+    }
+
+    if (!Array.isArray(tags)) {
+      throw this.propertyError(`${tagsPropertyName} must be a list`);
+    }
+
+    return Object.fromEntries(tags.map((tag) => this.tagEntry(tag)));
+  }
+
+  /**
+   * One tag, as the key and value a template wrote it as.
+   */
+  private tagEntry(tag: unknown): readonly [string, string] {
+    if (
+      !isRecord(tag) ||
+      typeof tag["Key"] !== "string" ||
+      typeof tag["Value"] !== "string"
+    ) {
+      throw this.propertyError(
+        `${tagsPropertyName} entries must each carry a string Key and Value`,
+      );
+    }
+
+    return [tag["Key"], tag["Value"]];
+  }
+
+  /**
+   * A property that has to be a number, when the template carries one.
+   */
+  private optionalNumber(name: string): number | undefined {
+    const value = this.properties.get(name);
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value !== "number") {
+      throw this.propertyError(`${name} must be a number`);
+    }
+
+    return value;
+  }
+
+  /**
+   * Record the properties this simulation gives no behaviour to.
+   */
+  private recordUnsimulated(): void {
+    for (const [name, reason] of unsimulatedPropertyReasons) {
+      if (this.properties.has(name)) {
+        this.resource.ignoreProperty(name, reason);
+      }
+    }
+  }
+
+  private propertyError(reason: string): Error {
+    return simCfnKinesisResourceError(
+      kinesisStreamResourceType,
+      this.resource.logicalId,
+      reason,
+    );
+  }
+}

--- a/src/service/kinesis/cfn/stream/sim-cfn-kinesis-stream-property-names.ts
+++ b/src/service/kinesis/cfn/stream/sim-cfn-kinesis-stream-property-names.ts
@@ -1,0 +1,32 @@
+/**
+ * The AWS::Kinesis::Stream properties this simulation acts on.
+ */
+export const streamNamePropertyName = "Name";
+
+export const shardCountPropertyName = "ShardCount";
+
+export const retentionPropertyName = "RetentionPeriodHours";
+
+export const streamModeDetailsPropertyName = "StreamModeDetails";
+
+export const tagsPropertyName = "Tags";
+
+/**
+ * Real AWS::Kinesis::Stream properties this simulation does not model, and why.
+ *
+ * Encryption changes nothing a test can observe here: every record is handed
+ * back as it was put, and no key is ever asked for. The property is recorded
+ * against the Resource rather than refused, so a template that encrypts its
+ * streams still deploys and the omission is somewhere a test can find it.
+ */
+export const unsimulatedPropertyReasons: ReadonlyMap<string, string> = new Map([
+  [
+    "StreamEncryption",
+    "server-side encryption is not simulated, and records are handed back as " +
+      "they were put",
+  ],
+  [
+    "DesiredShardLevelMetrics",
+    "shard-level CloudWatch metrics are not simulated",
+  ],
+]);

--- a/src/service/kinesis/command/sim-kinesis-command.types.ts
+++ b/src/service/kinesis/command/sim-kinesis-command.types.ts
@@ -5,6 +5,7 @@ export type {
   SimCreateStreamCommand,
   SimCreateStreamCommandInput,
   SimCreateStreamCommandOutput,
+  SimDecreaseStreamRetentionPeriodCommand,
   SimDeleteStreamCommand,
   SimDeleteStreamCommandInput,
   SimDeleteStreamCommandOutput,
@@ -14,6 +15,7 @@ export type {
   SimDescribeStreamSummaryCommand,
   SimDescribeStreamSummaryCommandInput,
   SimDescribeStreamSummaryCommandOutput,
+  SimIncreaseStreamRetentionPeriodCommand,
   SimKinesisHashKeyRangeOutput,
   SimKinesisSequenceNumberRange,
   SimKinesisShardOutput,
@@ -25,6 +27,8 @@ export type {
   SimListStreamsCommand,
   SimListStreamsCommandInput,
   SimListStreamsCommandOutput,
+  SimStreamRetentionPeriodCommandInput,
+  SimStreamRetentionPeriodCommandOutput,
 } from "./stream/stream.command.js";
 export type {
   SimKinesisPutRecordsRequestEntry,

--- a/src/service/kinesis/command/sim-kinesis-commands.ts
+++ b/src/service/kinesis/command/sim-kinesis-commands.ts
@@ -7,6 +7,7 @@ import { SimKinesisAuthorizer } from "./authorize/sim-kinesis-authorizer.js";
 import { SimKinesisPutCommands } from "./record/sim-kinesis-put-commands.js";
 import { SimKinesisReadCommands } from "./read/sim-kinesis-read-commands.js";
 import { SimKinesisCreateStream } from "./stream/sim-kinesis-create-stream.js";
+import { SimKinesisRetentionCommands } from "./stream/sim-kinesis-retention-commands.js";
 import { SimKinesisStreamCommands } from "./stream/sim-kinesis-stream-commands.js";
 import { SimKinesisStreamAccess } from "./sim-kinesis-stream-access.js";
 
@@ -29,6 +30,7 @@ interface SimKinesisCommandsProperties {
 export class SimKinesisCommands {
   public readonly streamCreation: SimKinesisCreateStream;
   public readonly streams: SimKinesisStreamCommands;
+  public readonly retention: SimKinesisRetentionCommands;
   public readonly puts: SimKinesisPutCommands;
   public readonly reads: SimKinesisReadCommands;
 
@@ -47,6 +49,7 @@ export class SimKinesisCommands {
       background,
     });
     this.streams = new SimKinesisStreamCommands({ streams, access });
+    this.retention = new SimKinesisRetentionCommands({ access });
     this.puts = new SimKinesisPutCommands({
       access,
       activity: properties.activity,

--- a/src/service/kinesis/command/stream/sim-kinesis-retention-commands.iso.test.ts
+++ b/src/service/kinesis/command/stream/sim-kinesis-retention-commands.iso.test.ts
@@ -1,0 +1,195 @@
+import {
+  DecreaseStreamRetentionPeriodCommand,
+  DescribeStreamSummaryCommand,
+  GetRecordsCommand,
+  GetShardIteratorCommand,
+  IncreaseStreamRetentionPeriodCommand,
+  PutRecordCommand,
+} from "@aws-sdk/client-kinesis";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimFixedClock } from "../../../../util/clock/sim-clock.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimKinesisInvalidArgumentException } from "../../error/sim-kinesis.error.js";
+import { simKinesisStreamFactory } from "../../stream/sim-kinesis-stream.factory.js";
+
+const startedAt = new Date("2026-08-22T09:00:00.000Z");
+
+/**
+ * How long the stream keeps a record now.
+ */
+async function retentionOf(simAws: SimAws): Promise<number> {
+  const summary = await simAws
+    .kinesis()
+    .describeStreamSummary(
+      new DescribeStreamSummaryCommand({ StreamName: "orders" }),
+    );
+
+  return summary.StreamDescriptionSummary.RetentionPeriodHours;
+}
+
+/**
+ * Everything the stream's only shard still holds.
+ */
+async function readFromTrimHorizon(simAws: SimAws): Promise<readonly string[]> {
+  const iterator = await simAws.kinesis().getShardIterator(
+    new GetShardIteratorCommand({
+      StreamName: "orders",
+      ShardId: "shardId-000000000000",
+      ShardIteratorType: "TRIM_HORIZON",
+    }),
+  );
+  const read = await simAws
+    .kinesis()
+    .getRecords(
+      new GetRecordsCommand({ ShardIterator: iterator.ShardIterator }),
+    );
+
+  return read.Records.map((record) => new TextDecoder().decode(record.Data));
+}
+
+describe("Changing how long a simulated Kinesis stream keeps a record", () => {
+  it("keeps records for longer once the retention is increased", async () => {
+    // Given a stream holding a record, retaining for the default day.
+    const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+    await simKinesisStreamFactory.make({}, simAws);
+    await simAws.kinesis().putRecord(
+      new PutRecordCommand({
+        StreamName: "orders",
+        PartitionKey: "customer-1",
+        Data: new TextEncoder().encode("order-1"),
+      }),
+    );
+
+    // When the retention is increased to a week and two days pass.
+    await simAws.kinesis().increaseStreamRetentionPeriod(
+      new IncreaseStreamRetentionPeriodCommand({
+        StreamName: "orders",
+        RetentionPeriodHours: 168,
+      }),
+    );
+    await simAws.clock().advanceBy({ hours: 48 });
+
+    // Then the record is still there, where the default would have dropped it.
+    assertIdentical(await retentionOf(simAws), 168);
+
+    const read = await readFromTrimHorizon(simAws);
+    assertIdentical(read.join(","), "order-1");
+  });
+
+  it("drops records the shortened retention has already outlived", async () => {
+    // Given a stream retaining for a week, holding a record two days old.
+    const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+    await simKinesisStreamFactory.make({}, simAws);
+    await simAws.kinesis().increaseStreamRetentionPeriod(
+      new IncreaseStreamRetentionPeriodCommand({
+        StreamName: "orders",
+        RetentionPeriodHours: 168,
+      }),
+    );
+    await simAws.kinesis().putRecord(
+      new PutRecordCommand({
+        StreamName: "orders",
+        PartitionKey: "customer-1",
+        Data: new TextEncoder().encode("order-1"),
+      }),
+    );
+    await simAws.clock().advanceBy({ hours: 48 });
+
+    // When the retention is shortened back to a day.
+    await simAws.kinesis().decreaseStreamRetentionPeriod(
+      new DecreaseStreamRetentionPeriodCommand({
+        StreamName: "orders",
+        RetentionPeriodHours: 24,
+      }),
+    );
+
+    // Then the record is gone from the next read, since retention is applied
+    // when a stream is read rather than when it is changed.
+    assertIdentical(await retentionOf(simAws), 24);
+    assertArrayLength(await readFromTrimHorizon(simAws), 0);
+  });
+
+  it("refuses a change that goes the other way from the command", async () => {
+    // Given a stream retaining for the default day.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+
+    // When an increase asks for no more than the stream already keeps.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.kinesis().increaseStreamRetentionPeriod(
+        new IncreaseStreamRetentionPeriodCommand({
+          StreamName: "orders",
+          RetentionPeriodHours: 24,
+        }),
+      );
+    });
+
+    // Then it is refused, since the caller believed the stream was set to
+    // something it was not.
+    assertInstanceOf(error, SimKinesisInvalidArgumentException);
+    assertStringIncludes(error.message, "Cannot increase the retention");
+  });
+
+  it("refuses a decrease asking for no less than the stream keeps", async () => {
+    // Given a stream retaining for the default day.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+
+    // When a decrease asks for more than that.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.kinesis().decreaseStreamRetentionPeriod(
+        new DecreaseStreamRetentionPeriodCommand({
+          StreamName: "orders",
+          RetentionPeriodHours: 48,
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "Cannot decrease the retention");
+  });
+
+  it("refuses a retention outside the range Kinesis accepts", async () => {
+    // Given a stream.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+
+    // When the retention is set beyond the year Kinesis takes, and below the
+    // day it takes.
+    for (const hours of [8761, 23]) {
+      // oxlint-disable-next-line no-await-in-loop
+      const error = await assertThrowsErrorAsync(async () => {
+        await simAws.kinesis().increaseStreamRetentionPeriod(
+          new IncreaseStreamRetentionPeriodCommand({
+            StreamName: "orders",
+            RetentionPeriodHours: hours,
+          }),
+        );
+      });
+      assertStringIncludes(error.message, "8760 hours Kinesis accepts");
+    }
+  });
+
+  it("refuses a change that names no retention", async () => {
+    // Given a stream.
+    const simAws = new SimAws();
+    await simKinesisStreamFactory.make({}, simAws);
+
+    // When the retention is changed without saying what to.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .kinesis()
+        .increaseStreamRetentionPeriod({ input: { StreamName: "orders" } });
+    });
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "RetentionPeriodHours is required");
+  });
+});

--- a/src/service/kinesis/command/stream/sim-kinesis-retention-commands.ts
+++ b/src/service/kinesis/command/stream/sim-kinesis-retention-commands.ts
@@ -1,0 +1,112 @@
+import { SimKinesisInvalidArgumentException } from "../../error/sim-kinesis.error.js";
+import { simKinesisRetentionHours } from "../../stream/sim-kinesis-retention.js";
+import type { SimKinesisStream } from "../../stream/sim-kinesis-stream.js";
+import type { SimKinesisRequestOptions } from "../sim-kinesis-request-options.js";
+import type { SimKinesisStreamAccess } from "../sim-kinesis-stream-access.js";
+import type {
+  SimDecreaseStreamRetentionPeriodCommand,
+  SimIncreaseStreamRetentionPeriodCommand,
+  SimStreamRetentionPeriodCommandOutput,
+} from "./stream.command.js";
+
+interface SimKinesisRetentionCommandsProperties {
+  readonly access: SimKinesisStreamAccess;
+}
+
+/**
+ * The commands that move how long a stream keeps a record.
+ *
+ * They are two commands rather than one because real Kinesis refuses the wrong
+ * direction: increasing to less than the stream already keeps, or decreasing to
+ * more, is a mistake about what the caller believed the stream was set to.
+ */
+export class SimKinesisRetentionCommands {
+  private readonly access: SimKinesisStreamAccess;
+
+  constructor(properties: SimKinesisRetentionCommandsProperties) {
+    this.access = properties.access;
+  }
+
+  /**
+   * Keep records for longer than the stream keeps them now.
+   */
+  increase(
+    command: SimIncreaseStreamRetentionPeriodCommand,
+    options?: SimKinesisRequestOptions,
+  ): SimStreamRetentionPeriodCommandOutput {
+    const { input } = command;
+    const stream = this.access.require(
+      "kinesis:IncreaseStreamRetentionPeriod",
+      input,
+      options,
+    );
+    const hours = requiredHours(input.RetentionPeriodHours);
+
+    assertDirection(stream, hours, "increase");
+    stream.setRetentionHours(hours);
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * Keep records for less time than the stream keeps them now.
+   *
+   * A record already older than the new window is gone from the next read,
+   * since retention is applied when a stream is read.
+   */
+  decrease(
+    command: SimDecreaseStreamRetentionPeriodCommand,
+    options?: SimKinesisRequestOptions,
+  ): SimStreamRetentionPeriodCommandOutput {
+    const { input } = command;
+    const stream = this.access.require(
+      "kinesis:DecreaseStreamRetentionPeriod",
+      input,
+      options,
+    );
+    const hours = requiredHours(input.RetentionPeriodHours);
+
+    assertDirection(stream, hours, "decrease");
+    stream.setRetentionHours(hours);
+
+    return { $metadata: {} };
+  }
+}
+
+/**
+ * The retention a request has to carry, in the range Kinesis accepts.
+ */
+function requiredHours(hours: number | undefined): number {
+  if (hours === undefined) {
+    throw new SimKinesisInvalidArgumentException(
+      "RetentionPeriodHours is required to change how long a stream keeps a " +
+        "record",
+    );
+  }
+
+  return simKinesisRetentionHours(hours);
+}
+
+/**
+ * Refuse a change that does not go the way the command asking for it goes.
+ *
+ * Real Kinesis wants the new period to be strictly more for an increase and
+ * strictly less for a decrease, so asking for what the stream already keeps is
+ * refused as well. A caller doing that has the wrong idea of what the stream is
+ * set to, which is the mistake both commands exist to catch.
+ */
+function assertDirection(
+  stream: SimKinesisStream,
+  hours: number,
+  direction: "increase" | "decrease",
+): void {
+  const held = stream.retentionHours;
+  const wrongWay = direction === "increase" ? hours <= held : hours >= held;
+
+  if (wrongWay) {
+    throw new SimKinesisInvalidArgumentException(
+      `Cannot ${direction} the retention of stream ${stream.name} from ` +
+        `${held} hours to ${hours}`,
+    );
+  }
+}

--- a/src/service/kinesis/command/stream/stream.command.ts
+++ b/src/service/kinesis/command/stream/stream.command.ts
@@ -180,3 +180,31 @@ export interface SimDescribeStreamSummaryCommandOutput {
   readonly StreamDescriptionSummary: SimKinesisStreamDescriptionSummary;
   readonly $metadata: SimResponseMetadata;
 }
+
+/**
+ * Minimal structural sim Kinesis IncreaseStreamRetentionPeriod command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/kinesis/command/IncreaseStreamRetentionPeriodCommand/
+ */
+export interface SimIncreaseStreamRetentionPeriodCommand {
+  readonly input: SimStreamRetentionPeriodCommandInput;
+}
+
+/**
+ * Minimal structural sim Kinesis DecreaseStreamRetentionPeriod command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/kinesis/command/DecreaseStreamRetentionPeriodCommand/
+ */
+export interface SimDecreaseStreamRetentionPeriodCommand {
+  readonly input: SimStreamRetentionPeriodCommandInput;
+}
+
+export interface SimStreamRetentionPeriodCommandInput {
+  readonly StreamName?: string | undefined;
+  readonly StreamARN?: string | undefined;
+  readonly RetentionPeriodHours?: number | undefined;
+}
+
+export interface SimStreamRetentionPeriodCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/kinesis/sdk/sim-kinesis-sdk-command-router.ts
+++ b/src/service/kinesis/sdk/sim-kinesis-sdk-command-router.ts
@@ -55,6 +55,22 @@ export class SimKinesisSdkCommandRouter implements SimSdkCommandRouter {
           ),
       ],
       [
+        "IncreaseStreamRetentionPeriodCommand",
+        async (command, context): Promise<unknown> =>
+          await simKinesis.increaseStreamRetentionPeriod(
+            command as simKinesisCommands.SimIncreaseStreamRetentionPeriodCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DecreaseStreamRetentionPeriodCommand",
+        async (command, context): Promise<unknown> =>
+          await simKinesis.decreaseStreamRetentionPeriod(
+            command as simKinesisCommands.SimDecreaseStreamRetentionPeriodCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
         "PutRecordCommand",
         async (command, context): Promise<unknown> =>
           await simKinesis.putRecord(

--- a/src/service/kinesis/sdk/sim-kinesis-sdk-routing.iso.test.ts
+++ b/src/service/kinesis/sdk/sim-kinesis-sdk-routing.iso.test.ts
@@ -1,10 +1,12 @@
 import {
   CreateStreamCommand,
+  DecreaseStreamRetentionPeriodCommand,
   DeleteStreamCommand,
   DescribeStreamCommand,
   DescribeStreamSummaryCommand,
   GetRecordsCommand,
   GetShardIteratorCommand,
+  IncreaseStreamRetentionPeriodCommand,
   KinesisClient,
   ListStreamsCommand,
   PutRecordCommand,
@@ -140,7 +142,37 @@ describe("Kinesis SDK interception", () => {
 
     // Then every command this service simulates is named, and one it does not
     // is absent.
-    assertArrayLength(supported.supportedCommandNames(), 9);
+    assertArrayLength(supported.supportedCommandNames(), 11);
     assertUndefined(supported.route("RegisterStreamConsumerCommand"));
+  });
+
+  it("routes a retention change an intercepted client sends", async () => {
+    // Given an intercepted Kinesis SDK client holding one stream.
+    using simSdk = new SimSdk();
+    simSdk.intercept(KinesisClient);
+
+    const kinesis = new KinesisClient({ region: "eu-west-2" });
+    await kinesis.send(new CreateStreamCommand({ StreamName: "orders" }));
+
+    // When ordinary SDK code lengthens and then shortens how long the stream
+    // keeps a record.
+    await kinesis.send(
+      new IncreaseStreamRetentionPeriodCommand({
+        StreamName: "orders",
+        RetentionPeriodHours: 168,
+      }),
+    );
+    await kinesis.send(
+      new DecreaseStreamRetentionPeriodCommand({
+        StreamName: "orders",
+        RetentionPeriodHours: 48,
+      }),
+    );
+
+    // Then the stream reports what it was left set to.
+    const summary = await kinesis.send(
+      new DescribeStreamSummaryCommand({ StreamName: "orders" }),
+    );
+    assertIdentical(summary.StreamDescriptionSummary?.RetentionPeriodHours, 48);
   });
 });

--- a/src/service/kinesis/sim-kinesis.ts
+++ b/src/service/kinesis/sim-kinesis.ts
@@ -12,6 +12,7 @@ import {
 import type * as simKinesisCommands from "./command/sim-kinesis-command.types.js";
 import { SimKinesisCommands } from "./command/sim-kinesis-commands.js";
 import type { SimKinesisRequestOptions } from "./command/sim-kinesis-request-options.js";
+import { SimKinesisCfnResourceFactory } from "./cfn/sim-kinesis-cfn-resource-factory.js";
 import { SimKinesisSdkCommandRouter } from "./sdk/sim-kinesis-sdk-command-router.js";
 import type { SimKinesisStream } from "./stream/sim-kinesis-stream.js";
 import { SimKinesisStreamActivity } from "./stream/sim-kinesis-stream-activity.js";
@@ -45,6 +46,9 @@ export class SimKinesis {
   private readonly commands: SimKinesisCommands;
   private readonly background: BackgroundScheduler;
   private readonly sdkRouter = new SimKinesisSdkCommandRouter(this);
+  private readonly cfnFactory = new SimKinesisCfnResourceFactory({
+    kinesis: this,
+  });
 
   constructor(properties: SimKinesisProperties = {}) {
     const {
@@ -129,6 +133,24 @@ export class SimKinesis {
     return this.commands.streams.describeStreamSummary(command, options);
   }
 
+  /** Handle an IncreaseStreamRetentionPeriod Command from the SDK. */
+  async increaseStreamRetentionPeriod(
+    command: simKinesisCommands.SimIncreaseStreamRetentionPeriodCommand,
+    options?: SimKinesisRequestOptions,
+  ): Promise<simKinesisCommands.SimStreamRetentionPeriodCommandOutput> {
+    await this.background.sequence();
+    return this.commands.retention.increase(command, options);
+  }
+
+  /** Handle a DecreaseStreamRetentionPeriod Command from the SDK. */
+  async decreaseStreamRetentionPeriod(
+    command: simKinesisCommands.SimDecreaseStreamRetentionPeriodCommand,
+    options?: SimKinesisRequestOptions,
+  ): Promise<simKinesisCommands.SimStreamRetentionPeriodCommandOutput> {
+    await this.background.sequence();
+    return this.commands.retention.decrease(command, options);
+  }
+
   /** Handle a PutRecord Command from the SDK. */
   async putRecord(
     command: simKinesisCommands.SimPutRecordCommand,
@@ -170,5 +192,12 @@ export class SimKinesis {
    */
   sdkCommandRouter(): SimSdkCommandRouter {
     return this.sdkRouter;
+  }
+
+  /**
+   * Get this service's CloudFormation Resource factory.
+   */
+  cfnResourceFactory(): SimKinesisCfnResourceFactory {
+    return this.cfnFactory;
   }
 }

--- a/src/service/kinesis/stream/sim-kinesis-retention.ts
+++ b/src/service/kinesis/stream/sim-kinesis-retention.ts
@@ -1,11 +1,39 @@
+import { SimKinesisInvalidArgumentException } from "../error/sim-kinesis.error.js";
+
 /**
  * How long a stream keeps a record when nothing says otherwise.
- *
- * Real Kinesis retains for 24 hours until IncreaseStreamRetentionPeriod or
- * DecreaseStreamRetentionPeriod moves it, and neither of those is simulated, so
- * every stream here retains for this long.
  */
 export const simKinesisDefaultRetentionHours = 24;
+
+/**
+ * The shortest retention real Kinesis accepts.
+ */
+export const simKinesisMinimumRetentionHours = 24;
+
+/**
+ * The longest retention real Kinesis accepts, which is 365 days.
+ */
+export const simKinesisMaximumRetentionHours = 8760;
+
+/**
+ * Read the retention a request asked for, refusing one outside the range real
+ * Kinesis accepts.
+ */
+export function simKinesisRetentionHours(hours: number): number {
+  if (
+    !Number.isSafeInteger(hours) ||
+    hours < simKinesisMinimumRetentionHours ||
+    hours > simKinesisMaximumRetentionHours
+  ) {
+    throw new SimKinesisInvalidArgumentException(
+      `RetentionPeriodHours ${hours} is outside the ` +
+        `${simKinesisMinimumRetentionHours} to ` +
+        `${simKinesisMaximumRetentionHours} hours Kinesis accepts`,
+    );
+  }
+
+  return hours;
+}
 
 const millisecondsPerHour = 60 * 60 * 1000;
 

--- a/src/service/kinesis/stream/sim-kinesis-stream-activity.iso.test.ts
+++ b/src/service/kinesis/stream/sim-kinesis-stream-activity.iso.test.ts
@@ -1,0 +1,77 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimKinesisStreamActivity } from "./sim-kinesis-stream-activity.js";
+
+const streamArn = "arn:aws:kinesis:eu-west-2:111111111111:stream/orders";
+
+/**
+ * A watcher counting how many times it was told there is something to read.
+ */
+function countingWatcher(): { readonly told: () => number } & {
+  recordsAvailable: () => void;
+} {
+  let count = 0;
+
+  return {
+    recordsAvailable: (): void => {
+      count += 1;
+    },
+    told: (): number => count,
+  };
+}
+
+describe("What a simulated Kinesis stream tells its watchers", () => {
+  it("tells every watcher of the stream", () => {
+    // Given two watchers on one stream, which is two mappings polling it.
+    const activity = new SimKinesisStreamActivity();
+    const first = countingWatcher();
+    const second = countingWatcher();
+
+    activity.watch(streamArn, first);
+    activity.watch(streamArn, second);
+
+    // When a record is put.
+    activity.recordsAvailable(streamArn);
+
+    // Then both are told.
+    assertIdentical(first.told(), 1);
+    assertIdentical(second.told(), 1);
+  });
+
+  it("stops telling a watcher that has stopped, and keeps telling the rest", () => {
+    // Given two watchers on one stream.
+    const activity = new SimKinesisStreamActivity();
+    const staying = countingWatcher();
+    const leaving = countingWatcher();
+
+    activity.watch(streamArn, staying);
+    activity.watch(streamArn, leaving);
+
+    // When one of them stops watching and a record is put.
+    activity.unwatch(streamArn, leaving);
+    activity.recordsAvailable(streamArn);
+
+    // Then only the one still watching is told.
+    assertIdentical(staying.told(), 1);
+    assertIdentical(leaving.told(), 0);
+  });
+
+  it("tells nobody about a stream nothing watches", () => {
+    // Given a stream whose only watcher has stopped.
+    const activity = new SimKinesisStreamActivity();
+    const watcher = countingWatcher();
+
+    activity.watch(streamArn, watcher);
+    activity.unwatch(streamArn, watcher);
+
+    // When a record is put, and when one is put onto a stream never watched.
+    activity.recordsAvailable(streamArn);
+    activity.recordsAvailable(
+      "arn:aws:kinesis:eu-west-2:111111111111:stream/x",
+    );
+
+    // Then nothing is told, and neither call raises.
+    assertIdentical(watcher.told(), 0);
+  });
+});

--- a/src/service/kinesis/stream/sim-kinesis-stream.ts
+++ b/src/service/kinesis/stream/sim-kinesis-stream.ts
@@ -69,7 +69,7 @@ export class SimKinesisStream {
 
   private readonly sequenceNumbers = new SimKinesisSequenceNumbers();
   private readonly shardMap: SimKinesisShardMap;
-  private readonly retention: number;
+  private retention: number;
 
   constructor(properties: SimKinesisStreamProperties) {
     this.name = properties.name.value;
@@ -99,6 +99,17 @@ export class SimKinesisStream {
    */
   get retentionHours(): number {
     return this.retention;
+  }
+
+  /**
+   * Change how long this stream keeps a record.
+   *
+   * Real Kinesis moves it with IncreaseStreamRetentionPeriod and
+   * DecreaseStreamRetentionPeriod, and a record already older than the new
+   * window is gone from the next read.
+   */
+  setRetentionHours(hours: number): void {
+    this.retention = hours;
   }
 
   /**

--- a/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-kinesis-event-source-mapping.iso.test.ts
+++ b/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-kinesis-event-source-mapping.iso.test.ts
@@ -4,7 +4,6 @@ import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
 import type { CfnTemplateBodyRecord } from "../../../cloudformation/template/sim-cfn-template.js";
-import { simKinesisStreamFactory } from "../../../kinesis/stream/sim-kinesis-stream.factory.js";
 import type { SimLambdaKinesisStreamEvent } from "../../event-source/poll/kinesis/sim-lambda-kinesis-stream-event.types.js";
 
 const assumeRolePolicyDocument = {
@@ -19,20 +18,23 @@ const assumeRolePolicyDocument = {
 };
 
 /**
- * A template with a projector function whose role may read a stream, and a
+ * A template with a stream, a projector function whose role may read it, and a
  * mapping between them.
  *
- * The stream itself is made through the SDK rather than declared, because
- * `AWS::Kinesis::Stream` is a separate piece of work. The mapping names it by
- * the ARN it already has, which is what a template referring to a stream in
- * another stack does anyway.
+ * This is the shape a CDK `KinesisEventSource` synthesizes: the mapping and the
+ * grant both reach the stream by `Fn::GetAtt`, and that reference is also what
+ * makes them wait for it.
  *
  * The role's grant is split the way CDK's own `grantRead` splits it: the three
  * stream operations on the stream ARN, and `ListStreams` on every stream.
  */
-function projectorTemplate(streamArn: string): CfnTemplateBodyRecord {
+function projectorTemplate(): CfnTemplateBodyRecord {
   return {
     Resources: {
+      OrdersStream: {
+        Type: "AWS::Kinesis::Stream",
+        Properties: { Name: "orders", ShardCount: 2 },
+      },
       ProjectorRole: {
         Type: "AWS::IAM::Role",
         Properties: {
@@ -51,7 +53,7 @@ function projectorTemplate(streamArn: string): CfnTemplateBodyRecord {
                       "kinesis:GetRecords",
                       "kinesis:GetShardIterator",
                     ],
-                    Resource: streamArn,
+                    Resource: { "Fn::GetAtt": ["OrdersStream", "Arn"] },
                   },
                   {
                     Effect: "Allow",
@@ -74,7 +76,7 @@ function projectorTemplate(streamArn: string): CfnTemplateBodyRecord {
       OrderProjectorMapping: {
         Type: "AWS::Lambda::EventSourceMapping",
         Properties: {
-          EventSourceArn: streamArn,
+          EventSourceArn: { "Fn::GetAtt": ["OrdersStream", "Arn"] },
           FunctionName: { Ref: "ProjectorFunction" },
           BatchSize: 100,
           StartingPosition: "TRIM_HORIZON",
@@ -86,14 +88,13 @@ function projectorTemplate(streamArn: string): CfnTemplateBodyRecord {
 
 describe("deployed Kinesis stream event source mappings", () => {
   it("polls the stream a deployed mapping names", async () => {
-    // Given a stream, and a stack mapping it to a projector function.
+    // Given a stack declaring a stream and mapping it to a projector function.
     const simAws = new SimAws();
-    const stream = await simKinesisStreamFactory.make({}, simAws);
     const events: SimLambdaKinesisStreamEvent[] = [];
 
     const stack = await simAws.cloudFormation().deployTemplate({
       stackName: "orders-stack",
-      template: projectorTemplate(stream.arn),
+      template: projectorTemplate(),
       bindings: [
         {
           logicalId: "ProjectorFunction",
@@ -122,7 +123,10 @@ describe("deployed Kinesis stream event source mappings", () => {
     assertArrayLength(events, 1);
     assertArrayLength(events[0].Records, 1);
     const record = events[0].Records[0];
-    assertIdentical(record.eventSourceARN, stream.arn);
+    assertIdentical(
+      record.eventSourceARN,
+      `arn:aws:kinesis:${simAws.defaultRegionName}:${simAws.defaultAccountId}:stream/orders`,
+    );
     assertIdentical(
       Buffer.from(record.kinesis.data, "base64").toString(),
       "order-1",


### PR DESCRIPTION
A template declaring a Kinesis stream now creates one, which is what a CDK `Stream` synthesizes. `Ref` gives the stream name and `Fn::GetAtt` on `Arn` gives the ARN, the way round real CloudFormation publishes them, so a mapping or a grant reaching a stream by `Fn::GetAtt` resolves and waits for it. `Name`, `ShardCount`, `StreamModeDetails` and `Tags` go through the ordinary CreateStream command, so a template and an SDK caller reach the same stream and a template asking for something Kinesis will not take is refused in the words CreateStream refuses it in. An unnamed stream is named after the stack and the logical ID. `StreamEncryption` and `DesiredShardLevelMetrics` are recorded against the Resource as unsimulated and the stream is created anyway, and deleting the stack deletes it.

`RetentionPeriodHours` needed IncreaseStreamRetentionPeriod and DecreaseStreamRetentionPeriod, since CreateStream takes no retention on real Kinesis either and CloudFormation reaches it with a second call. Both are now commands an SDK caller can send as well, each refusing a request that goes the other way. The CloudFormation path only ever increases: 24 hours is both the default a new stream has and the least Kinesis accepts, so a template can ask for more or the same and never for less.

Resolves #910
