### PR TITLE
test: save the polled file the way a synth does

### DIFF
--- a/test/watch/polled-file.ts
+++ b/test/watch/polled-file.ts
@@ -1,7 +1,9 @@
+import { rename } from "node:fs/promises";
 import { SimWatchFilePoll } from "../../src/watch/sim-watch-file-poll.js";
 import { TemporaryDirectory } from "../../src/util/filesystem/temporary-directory.js";
 
 const fileName = "Site.template.json";
+const pendingName = "Site.template.json.pending";
 
 /**
  * A real file with a real read on it.
@@ -49,15 +51,24 @@ export class PolledFile {
   }
 
   /**
-   * Save the file.
+   * Save the file, in one move.
    *
    * Every save is a different length. A read comparing what the file looks like
    * has that to go on wherever the timestamps behind it are coarser than the
    * gap between two saves.
+   *
+   * The bytes go to a file beside it and are renamed over it, the way an editor
+   * saves. Writing in place empties the file and fills it a moment later, and a
+   * read landing between the two finds two changes in the one save.
    */
   async write(): Promise<void> {
     this.saves++;
-    await this.directory.writeFile(fileName, "save".repeat(this.saves));
+    await this.directory.writeFile(pendingName, "save".repeat(this.saves));
+    // oxlint-disable-next-line security/detect-non-literal-fs-filename
+    await rename(
+      this.directory.join(pendingName),
+      this.directory.join(fileName),
+    );
   }
 
   /**
@@ -127,6 +138,26 @@ export class PolledFile {
       await this.pause(20);
     }
 
+    await this.quiet();
     this.changed = 0;
+  }
+
+  /**
+   * Wait for the read to catch up with the saves that started it.
+   *
+   * The loop above saves faster than the read looks. The look that reports a
+   * save can be one taken before the last of them, leaving a save for the look
+   * after it to find. That one arrives in the middle of the test, as a change
+   * the test did nothing to cause. Waiting for the count to hold still leaves
+   * the read level with the file.
+   */
+  private async quiet(): Promise<void> {
+    let seen = -1;
+
+    while (seen !== this.changed) {
+      seen = this.changed;
+      // oxlint-disable-next-line no-await-in-loop -- waiting on a real read
+      await this.pause(300);
+    }
   }
 }


### PR DESCRIPTION
The file poll test wrote its saves in place, and `writeFile` opens a file empty before it fills it. A read landing between the two finds two changes in the one save. That is how the release run saw a change reported for a save `reported()` had already covered. Sampling the file as fast as the loop allows caught it empty in around 1.5% of stats, and running the failing scenario against a 1ms read reproduced it 22 times in 200 runs. The helper now writes beside the file and renames over it, the way a CDK synthesis writes a template (which is what the watch reads in a real project), and one save is one change again. It also waits for the read to catch up with the saves it was started on before counting from zero, because a startup save the read had yet to find would arrive in the middle of a test as a change the test never made.