### PR TITLE
feat: run a simulated Step Functions state machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ npm i -D @kensio/yulin
 - [SNS](./docs/services/sns "Simulated SNS docs")
 - [SQS](./docs/services/sqs "Simulated SQS docs")
 - [SSM Parameter Store](./docs/services/ssm "Simulated SSM Parameter Store docs")
+- [Step Functions](./docs/services/stepfunctions "Simulated Step Functions docs")
 - [STS](./docs/services/sts "Simulated STS docs")
 - [WAFv2](./docs/services/wafv2 "Simulated WAFv2 docs")
 

--- a/docs/services/stepfunctions/README.md
+++ b/docs/services/stepfunctions/README.md
@@ -4,7 +4,7 @@ Simulated Step Functions interprets Amazon States Language and runs a state mach
 process as the code under test. A workflow held in a template as data becomes something a test can
 run and assert on.
 
-Step Functions specific types are imported from the `@kensio/yulin/stepfunctions` subpath.
+Types for simulated Step Functions are imported from the `@kensio/yulin/stepfunctions` subpath.
 
 ## What runs today
 
@@ -179,11 +179,25 @@ A test asserting on the output of a state machine that used one could only asser
 - **An `EXPRESS` state machine runs the standard way.** The type is carried and read back, and
   `StartSyncExecution` is unsimulated.
 - **An unnamed execution is named by a counter.** Real Step Functions uses a UUID. A counter means a
-  simulation answers the same way twice.
+  simulation answers the same way twice. The counter steps over any name a caller has already used.
+- **A running execution is not yet idempotent by name.** Real `StartExecution` answers a repeat of a
+  running Standard execution carrying the same name and input with that execution's own response.
+  Every execution here finishes before `StartExecution` answers, so there is never a running one to
+  match, and a repeated name raises `ExecutionAlreadyExists`. This arrives with the `Wait` state.
+  Reusing a name 90 days after an execution closes is unsimulated as well.
 - **A brace escape outside `States.Format` keeps its backslash.** A brace is a placeholder to
   `States.Format` alone, so `States.Format` is where `\{` is resolved. An escaped brace reaching
   another intrinsic arrives as it was written.
 - **`GetExecutionHistory` is unsimulated.** The inspection accessor answers the same question.
+- **A cycle in the states fails the execution** after 25,000 transitions, with `States.Runtime`. Real
+  Step Functions stops one when it runs out of execution history events.
+
+`CreateStateMachine` is idempotent, as it is on AWS. A second request carrying the same name,
+definition and type answers with the state machine already there, and one carrying a different
+definition raises `StateMachineAlreadyExists`. A differing `roleArn` is ignored. The AWS API
+reference contradicts itself here, listing a differing role ARN under `StateMachineAlreadyExists`
+while the operation's own note says the difference is ignored. The note is the more specific of the
+two and is what this follows.
 
 ## Still to come
 

--- a/docs/services/stepfunctions/README.md
+++ b/docs/services/stepfunctions/README.md
@@ -1,0 +1,195 @@
+# Simulated Step Functions
+
+Simulated Step Functions interprets Amazon States Language and runs a state machine in the same
+process as the code under test. A workflow held in a template as data becomes something a test can
+run and assert on.
+
+Step Functions specific types are imported from the `@kensio/yulin/stepfunctions` subpath.
+
+## What runs today
+
+Three state types run. `Pass`, `Succeed` and `Fail`. A definition using any other is refused when the
+state machine is created, naming the state and its type. `Task`, `Choice`, `Wait`, `Parallel` and
+`Map` are on the way.
+
+The data-flow fields run in full. `InputPath`, `Parameters`, `ResultSelector`, `ResultPath` and
+`OutputPath` apply in that order, reading Reference Paths and the intrinsic functions.
+
+## Running a state machine
+
+```typescript sim-step-functions-run
+/**
+ * Creating a state machine and running an execution against it.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const created = await simAws.stepFunctions().createStateMachine({
+  input: {
+    name: "Enrolment",
+    roleArn: "arn:aws:iam::123456789012:role/WorkflowRole",
+    definition: JSON.stringify({
+      StartAt: "Record",
+      States: {
+        Record: {
+          Type: "Pass",
+          Result: { enrolled: true },
+          ResultPath: "$.outcome",
+          Next: "Done",
+        },
+        Done: { Type: "Succeed" },
+      },
+    }),
+  },
+});
+
+const started = await simAws.stepFunctions().startExecution({
+  input: {
+    stateMachineArn: created.stateMachineArn,
+    input: JSON.stringify({ student: "Wei" }),
+  },
+});
+
+const described = await simAws
+  .stepFunctions()
+  .describeExecution({ input: { executionArn: started.executionArn } });
+
+console.log(described.status); // SUCCEEDED
+console.log(described.output); // {"student":"Wei","outcome":{"enrolled":true}}
+```
+
+## Asserting on the states an execution visited
+
+`DescribeExecution` says how an execution ended. The route it took is read from the simulator's own
+inspection accessor:
+
+```typescript sim-step-functions-visited-states
+/**
+ * Reading back which states an execution went through.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const created = await simAws.stepFunctions().createStateMachine({
+  input: {
+    name: "Enrolment",
+    roleArn: "arn:aws:iam::123456789012:role/WorkflowRole",
+    definition: JSON.stringify({
+      StartAt: "Check",
+      States: {
+        Check: { Type: "Pass", Next: "Decline" },
+        Decline: { Type: "Fail", Error: "NotEligible", Cause: "No place left" },
+      },
+    }),
+  },
+});
+
+const started = await simAws
+  .stepFunctions()
+  .startExecution({ input: { stateMachineArn: created.stateMachineArn } });
+
+console.log(
+  simAws.stepFunctions().inspection().visitedStates(started.executionArn),
+); // [ 'Check', 'Decline' ]
+
+const described = await simAws
+  .stepFunctions()
+  .describeExecution({ input: { executionArn: started.executionArn } });
+
+console.log(described.status); // FAILED
+console.log(described.error); // NotEligible
+```
+
+A failing execution is recorded on the execution, and the call returns as it would for one that
+succeeded. Simulated EventBridge treats an undeliverable event the same way. An execution failing is
+as often the thing under test as it is a fault, and raising it would fail an unrelated `advanceBy`
+elsewhere in the same test.
+
+## Through an intercepted SDK client
+
+An `SFNClient` handed to `SimSdk` reaches the same simulated service:
+
+```typescript sim-step-functions-sdk
+/**
+ * Running a state machine through an intercepted SFNClient.
+ */
+
+import {
+  CreateStateMachineCommand,
+  SFNClient,
+  StartExecutionCommand,
+} from "@aws-sdk/client-sfn";
+
+import { SimAws } from "@kensio/yulin";
+import { SimSdk } from "@kensio/yulin/sdk";
+
+const simAws = new SimAws();
+const client = new SFNClient({ region: simAws.defaultRegionName });
+
+using _intercepted = new SimSdk({ simAws }).intercept(client);
+
+const created = await client.send(
+  new CreateStateMachineCommand({
+    name: "Enrolment",
+    roleArn: "arn:aws:iam::123456789012:role/WorkflowRole",
+    definition: JSON.stringify({
+      StartAt: "Done",
+      States: { Done: { Type: "Succeed" } },
+    }),
+  }),
+);
+
+const started = await client.send(
+  new StartExecutionCommand({ stateMachineArn: created.stateMachineArn }),
+);
+
+console.log(started.executionArn);
+```
+
+## Reference Paths
+
+The path subset read here is the one Amazon States Language itself uses. A document root, a child by
+dot or by bracketed name, and an array element by index. `$.abc.['def ghi']` works, which is how the
+Amazon States Language docs write a field name holding a space.
+
+The wider JSONPath grammar is refused by name. Wildcards, filters, slices and recursive descent all
+raise. A path that would have selected the wrong node fails, and no state is answered with plausible
+data. A dotted field name is held to the JsonPath `member-name-shorthand` rule. `$.a-b` is refused,
+and `$['a-b']` is the way to write it.
+
+`$$`, the context object, arrives with the `Task` state.
+
+## Intrinsic functions
+
+`States.Format`, `States.Array`, `States.ArrayLength`, `States.StringToJson` and
+`States.JsonToString` all run, including calls nested inside one another.
+
+`States.UUID` and `States.MathRandom` are left out on purpose. Both answer differently on every call.
+A test asserting on the output of a state machine that used one could only assert on its shape.
+
+## Where this differs from real Step Functions
+
+- **`StartExecution` settles before it answers.** Real Step Functions answers before the execution
+  has run, and a caller there sees `RUNNING` first. An execution here has finished by the time the
+  caller reads it back. That spares every test a wait for work that is already done.
+- **An `EXPRESS` state machine runs the standard way.** The type is carried and read back, and
+  `StartSyncExecution` is unsimulated.
+- **An unnamed execution is named by a counter.** Real Step Functions uses a UUID. A counter means a
+  simulation answers the same way twice.
+- **A brace escape outside `States.Format` keeps its backslash.** A brace is a placeholder to
+  `States.Format` alone, so `States.Format` is where `\{` is resolved. An escaped brace reaching
+  another intrinsic arrives as it was written.
+- **`GetExecutionHistory` is unsimulated.** The inspection accessor answers the same question.
+
+## Still to come
+
+- `Task`, `Choice`, `Wait`, `Parallel` and `Map` states.
+- `Retry` and `Catch`.
+- Service integrations, task tokens and activities.
+- `AWS::StepFunctions::StateMachine` CloudFormation resources.
+- JSONata as a query language, and the `Assign` variables that go with it.
+- IAM authorization of what a state machine's role may do.

--- a/docs/services/stepfunctions/sim-step-functions-run.example.ts
+++ b/docs/services/stepfunctions/sim-step-functions-run.example.ts
@@ -1,0 +1,40 @@
+/**
+ * Creating a state machine and running an execution against it.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const created = await simAws.stepFunctions().createStateMachine({
+  input: {
+    name: "Enrolment",
+    roleArn: "arn:aws:iam::123456789012:role/WorkflowRole",
+    definition: JSON.stringify({
+      StartAt: "Record",
+      States: {
+        Record: {
+          Type: "Pass",
+          Result: { enrolled: true },
+          ResultPath: "$.outcome",
+          Next: "Done",
+        },
+        Done: { Type: "Succeed" },
+      },
+    }),
+  },
+});
+
+const started = await simAws.stepFunctions().startExecution({
+  input: {
+    stateMachineArn: created.stateMachineArn,
+    input: JSON.stringify({ student: "Wei" }),
+  },
+});
+
+const described = await simAws
+  .stepFunctions()
+  .describeExecution({ input: { executionArn: started.executionArn } });
+
+console.log(described.status); // SUCCEEDED
+console.log(described.output); // {"student":"Wei","outcome":{"enrolled":true}}

--- a/docs/services/stepfunctions/sim-step-functions-sdk.example.ts
+++ b/docs/services/stepfunctions/sim-step-functions-sdk.example.ts
@@ -1,0 +1,34 @@
+/**
+ * Running a state machine through an intercepted SFNClient.
+ */
+
+import {
+  CreateStateMachineCommand,
+  SFNClient,
+  StartExecutionCommand,
+} from "@aws-sdk/client-sfn";
+
+import { SimAws } from "@kensio/yulin";
+import { SimSdk } from "@kensio/yulin/sdk";
+
+const simAws = new SimAws();
+const client = new SFNClient({ region: simAws.defaultRegionName });
+
+using _intercepted = new SimSdk({ simAws }).intercept(client);
+
+const created = await client.send(
+  new CreateStateMachineCommand({
+    name: "Enrolment",
+    roleArn: "arn:aws:iam::123456789012:role/WorkflowRole",
+    definition: JSON.stringify({
+      StartAt: "Done",
+      States: { Done: { Type: "Succeed" } },
+    }),
+  }),
+);
+
+const started = await client.send(
+  new StartExecutionCommand({ stateMachineArn: created.stateMachineArn }),
+);
+
+console.log(started.executionArn);

--- a/docs/services/stepfunctions/sim-step-functions-visited-states.example.ts
+++ b/docs/services/stepfunctions/sim-step-functions-visited-states.example.ts
@@ -1,0 +1,36 @@
+/**
+ * Reading back which states an execution went through.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const created = await simAws.stepFunctions().createStateMachine({
+  input: {
+    name: "Enrolment",
+    roleArn: "arn:aws:iam::123456789012:role/WorkflowRole",
+    definition: JSON.stringify({
+      StartAt: "Check",
+      States: {
+        Check: { Type: "Pass", Next: "Decline" },
+        Decline: { Type: "Fail", Error: "NotEligible", Cause: "No place left" },
+      },
+    }),
+  },
+});
+
+const started = await simAws
+  .stepFunctions()
+  .startExecution({ input: { stateMachineArn: created.stateMachineArn } });
+
+console.log(
+  simAws.stepFunctions().inspection().visitedStates(started.executionArn),
+); // [ 'Check', 'Decline' ]
+
+const described = await simAws
+  .stepFunctions()
+  .describeExecution({ input: { executionArn: started.executionArn } });
+
+console.log(described.status); // FAILED
+console.log(described.error); // NotEligible

--- a/package.json
+++ b/package.json
@@ -169,6 +169,10 @@
       "import": "./dist/service/sqs/index.js",
       "types": "./dist/service/sqs/index.d.ts"
     },
+    "./stepfunctions": {
+      "import": "./dist/service/stepfunctions/index.js",
+      "types": "./dist/service/stepfunctions/index.d.ts"
+    },
     "./ssm": {
       "import": "./dist/service/ssm/index.js",
       "types": "./dist/service/ssm/index.d.ts"
@@ -230,6 +234,7 @@
     "@aws-sdk/client-scheduler": "^3.1109.0",
     "@aws-sdk/client-secrets-manager": "^3.1101.0",
     "@aws-sdk/client-sesv2": "^3.1111.0",
+    "@aws-sdk/client-sfn": "^3.1115.0",
     "@aws-sdk/client-sns": "^3.1104.0",
     "@aws-sdk/client-sqs": "^3.1101.0",
     "@aws-sdk/client-ssm": "^3.1101.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       '@aws-sdk/client-sesv2':
         specifier: ^3.1111.0
         version: 3.1111.0
+      '@aws-sdk/client-sfn':
+        specifier: ^3.1115.0
+        version: 3.1115.0
       '@aws-sdk/client-sns':
         specifier: ^3.1104.0
         version: 3.1110.0
@@ -405,6 +408,10 @@ packages:
 
   '@aws-sdk/client-sesv2@3.1111.0':
     resolution: {integrity: sha512-RLraobtxTBIGOVNQzf9q6Irsx6OUSdLgmRw6cGTCoRZ5o8xrHbxA8KUgXLnoDRnVobSfxJaarqd+dS4DQl11rA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-sfn@3.1115.0':
+    resolution: {integrity: sha512-XNTNQYX5N1rurhRsSR46HdFOJXcU0j+UDpqTz6iWOn7mgcQBYs0zFC62wrl+2pkV0gVHiXh9eVplg+yPtOXT4g==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-sns@3.1110.0':
@@ -3966,6 +3973,17 @@ snapshots:
       '@smithy/core': 3.32.0
       '@smithy/fetch-http-handler': 5.7.0
       '@smithy/node-http-handler': 4.10.0
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/client-sfn@3.1115.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/credential-provider-node': 3.972.80
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.2
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 

--- a/src/sdk/router/resolve-sim-sdk-command-router.ts
+++ b/src/sdk/router/resolve-sim-sdk-command-router.ts
@@ -87,6 +87,10 @@ const scopedRouters: ReadonlyMap<string, SimSdkScopedRouter> = new Map<
   ],
   ["KMS", (scoped): SimSdkCommandRouter => scoped.kms().sdkCommandRouter()],
   [
+    "SFN",
+    (scoped): SimSdkCommandRouter => scoped.stepFunctions().sdkCommandRouter(),
+  ],
+  [
     "Lambda",
     (scoped): SimSdkCommandRouter => scoped.lambda().sdkCommandRouter(),
   ],

--- a/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
@@ -2,6 +2,7 @@ import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-sco
 import { SimBedrock } from "../../bedrock/index.js";
 import { SimDynamoDb as SimDynamoDatabase } from "../../dynamodb/index.js";
 import { SimKinesis } from "../../kinesis/index.js";
+import { SimStepFunctions } from "../../stepfunctions/index.js";
 import { SimSecretsManager } from "../../secretsmanager/index.js";
 import { SimSqs } from "../../sqs/index.js";
 import { SimSsm } from "../../ssm/index.js";
@@ -58,6 +59,16 @@ export class SimAwsSelfContainedServiceBuilder {
    */
   createKinesis(scope: SimAwsAccountRegionContainer): SimKinesis {
     return new SimKinesis(this.scoped(scope));
+  }
+
+  /**
+   * Create simulated Step Functions for an Account Region scope.
+   *
+   * State machines are Region-scoped on real AWS: a state machine ARN names
+   * the Region, and one cannot be reached from another.
+   */
+  createStepFunctions(scope: SimAwsAccountRegionContainer): SimStepFunctions {
+    return new SimStepFunctions(this.scoped(scope));
   }
 
   /**

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -25,6 +25,7 @@ import type { SimElbV2 } from "../../elbv2/index.js";
 import type { SimIam } from "../../iam/index.js";
 import { SimIamRegistry } from "../../iam/registry/sim-iam-registry.js";
 import type { SimKinesis } from "../../kinesis/index.js";
+import type { SimStepFunctions } from "../../stepfunctions/index.js";
 import type { SimKms } from "../../kms/index.js";
 import type { SimLambda } from "../../lambda/index.js";
 import { SimLambdaUrlRegistry } from "../../lambda/registry/sim-lambda-url-registry.js";
@@ -234,6 +235,11 @@ export class SimAwsServiceFactory {
   /** Create simulated Kinesis Data Streams for an Account Region scope. */
   createKinesis(scope: SimAwsAccountRegionContainer): SimKinesis {
     return this.selfContainedServices.createKinesis(scope);
+  }
+
+  /** Create simulated Step Functions for an Account Region scope. */
+  createStepFunctions(scope: SimAwsAccountRegionContainer): SimStepFunctions {
+    return this.selfContainedServices.createStepFunctions(scope);
   }
 
   /** Create simulated Lambda for an Account Region scope. */

--- a/src/service/aws/sim-aws-account-region-scope.ts
+++ b/src/service/aws/sim-aws-account-region-scope.ts
@@ -31,6 +31,7 @@ import type { SimApiGatewayV2 } from "../apigatewayv2/index.js";
 import type { SimElbV2 } from "../elbv2/index.js";
 import type { SimIam } from "../iam/index.js";
 import type { SimKinesis } from "../kinesis/index.js";
+import type { SimStepFunctions } from "../stepfunctions/index.js";
 import type { SimKms } from "../kms/index.js";
 import type { SimLambda } from "../lambda/index.js";
 import type { SimLogs } from "../logs/index.js";
@@ -200,6 +201,13 @@ export class SimAwsAccountRegionContainer {
   kinesis(): SimKinesis {
     return this.memo.getOrCreate("kinesis", () =>
       this.factory.createKinesis(this),
+    );
+  }
+
+  /** Get simulated Step Functions for this account and region. */
+  stepFunctions(): SimStepFunctions {
+    return this.memo.getOrCreate("stepFunctions", () =>
+      this.factory.createStepFunctions(this),
     );
   }
 

--- a/src/service/aws/sim-aws-service-accessors.ts
+++ b/src/service/aws/sim-aws-service-accessors.ts
@@ -17,6 +17,7 @@ import type { SimEcs } from "../ecs/index.js";
 import type { SimElbV2 } from "../elbv2/index.js";
 import type { SimIam } from "../iam/index.js";
 import type { SimKinesis } from "../kinesis/index.js";
+import type { SimStepFunctions } from "../stepfunctions/index.js";
 import type { SimKms } from "../kms/index.js";
 import type { SimLambda } from "../lambda/index.js";
 import type { SimLogs } from "../logs/index.js";
@@ -142,6 +143,11 @@ export abstract class SimAwsServiceAccessors {
   /** Get simulated Kinesis Data Streams in the default Account Region scope. */
   kinesis(): SimKinesis {
     return this.defaultAccountRegionScope().kinesis();
+  }
+
+  /** Get simulated Step Functions in the default Account Region scope. */
+  stepFunctions(): SimStepFunctions {
+    return this.defaultAccountRegionScope().stepFunctions();
   }
 
   /** Get simulated KMS in the default Account Region scope. */

--- a/src/service/stepfunctions/command/execution/execution.command.ts
+++ b/src/service/stepfunctions/command/execution/execution.command.ts
@@ -1,0 +1,37 @@
+import type { SimStatesExecutionStatus } from "../../execution/sim-states-execution.js";
+
+export interface SimStartExecutionCommandInput {
+  readonly stateMachineArn?: string;
+  readonly name?: string;
+  readonly input?: string;
+}
+
+export interface SimStartExecutionCommand {
+  readonly input: SimStartExecutionCommandInput;
+}
+
+export interface SimStartExecutionCommandOutput {
+  readonly executionArn: string;
+  readonly startDate: Date;
+}
+
+export interface SimDescribeExecutionCommandInput {
+  readonly executionArn?: string;
+}
+
+export interface SimDescribeExecutionCommand {
+  readonly input: SimDescribeExecutionCommandInput;
+}
+
+export interface SimDescribeExecutionCommandOutput {
+  readonly executionArn: string;
+  readonly stateMachineArn: string;
+  readonly name: string;
+  readonly status: SimStatesExecutionStatus;
+  readonly startDate: Date;
+  readonly stopDate?: Date;
+  readonly input: string;
+  readonly output?: string;
+  readonly error?: string;
+  readonly cause?: string;
+}

--- a/src/service/stepfunctions/command/execution/sim-states-execution-describe.ts
+++ b/src/service/stepfunctions/command/execution/sim-states-execution-describe.ts
@@ -1,6 +1,6 @@
 import {
+  SimStatesExecutionNotFound,
   SimStatesInvalidRequest,
-  SimStatesResourceNotFound,
 } from "../../error/sim-step-functions.error.js";
 import type { SimStatesExecutionStore } from "../../execution/sim-states-execution-store.js";
 import type {
@@ -33,7 +33,7 @@ export class SimStatesExecutionDescribe {
     const execution = this.#executions.find(executionArn);
 
     if (execution === undefined) {
-      throw new SimStatesResourceNotFound(
+      throw new SimStatesExecutionNotFound(
         `${executionArn} is not a simulated execution in this Account and Region.`,
       );
     }

--- a/src/service/stepfunctions/command/execution/sim-states-execution-describe.ts
+++ b/src/service/stepfunctions/command/execution/sim-states-execution-describe.ts
@@ -1,0 +1,43 @@
+import {
+  SimStatesInvalidRequest,
+  SimStatesResourceNotFound,
+} from "../../error/sim-step-functions.error.js";
+import type { SimStatesExecutionStore } from "../../execution/sim-states-execution-store.js";
+import type {
+  SimDescribeExecutionCommand,
+  SimDescribeExecutionCommandOutput,
+} from "./execution.command.js";
+import { simStatesExecutionView } from "./sim-states-execution-view.js";
+
+/**
+ * The command that reads an execution back.
+ */
+export class SimStatesExecutionDescribe {
+  readonly #executions: SimStatesExecutionStore;
+
+  constructor(executions: SimStatesExecutionStore) {
+    this.#executions = executions;
+  }
+
+  handle(
+    command: SimDescribeExecutionCommand,
+  ): SimDescribeExecutionCommandOutput {
+    const { executionArn } = command.input;
+
+    if (executionArn === undefined) {
+      throw new SimStatesInvalidRequest(
+        "DescribeExecution needs an executionArn.",
+      );
+    }
+
+    const execution = this.#executions.find(executionArn);
+
+    if (execution === undefined) {
+      throw new SimStatesResourceNotFound(
+        `${executionArn} is not a simulated execution in this Account and Region.`,
+      );
+    }
+
+    return simStatesExecutionView(execution);
+  }
+}

--- a/src/service/stepfunctions/command/execution/sim-states-execution-name.ts
+++ b/src/service/stepfunctions/command/execution/sim-states-execution-name.ts
@@ -1,0 +1,31 @@
+import type { SimStatesExecutionStore } from "../../execution/sim-states-execution-store.js";
+import { checkSimStatesName } from "../../machine/sim-states-name.js";
+
+/**
+ * The name an execution runs under.
+ *
+ * Real Step Functions generates a UUID for an unnamed execution. A counter is
+ * used here because a simulation answering the same way twice is worth more
+ * than a name that looks right, and nothing reads meaning out of it. It steps
+ * over a name a caller has already used, so an unnamed start never fails over
+ * a name its caller never wrote.
+ */
+export function chooseSimStatesExecutionName(
+  executions: SimStatesExecutionStore,
+  stateMachineArn: string,
+  name: string | undefined,
+): string {
+  if (name !== undefined) {
+    return checkSimStatesName(name, "The execution name");
+  }
+
+  let index = executions.forStateMachine(stateMachineArn).length;
+  let candidate: string;
+
+  do {
+    index += 1;
+    candidate = `execution-${String(index)}`;
+  } while (executions.hasName(stateMachineArn, candidate));
+
+  return candidate;
+}

--- a/src/service/stepfunctions/command/execution/sim-states-execution-start.ts
+++ b/src/service/stepfunctions/command/execution/sim-states-execution-start.ts
@@ -1,0 +1,106 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import { SimStatesExecutionAlreadyExists } from "../../error/sim-step-functions.error.js";
+import { SimStatesExecution } from "../../execution/sim-states-execution.js";
+import type { SimStatesExecutionStore } from "../../execution/sim-states-execution-store.js";
+import { SimStatesInterpreter } from "../../execution/sim-states-interpreter.js";
+import { simStatesExecutionArn } from "../../machine/sim-state-machine-arn.js";
+import type { SimStateMachineStore } from "../../machine/sim-state-machine-store.js";
+import { requireSimStateMachine } from "../machine/sim-state-machine-lookup.js";
+import type {
+  SimStartExecutionCommand,
+  SimStartExecutionCommandOutput,
+} from "./execution.command.js";
+import { readSimStatesExecutionInput } from "./sim-states-execution-view.js";
+
+interface SimStatesExecutionStartProperties {
+  readonly stateMachines: SimStateMachineStore;
+  readonly executions: SimStatesExecutionStore;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * The command that starts an execution.
+ */
+export class SimStatesExecutionStart {
+  readonly #stateMachines: SimStateMachineStore;
+  readonly #executions: SimStatesExecutionStore;
+  readonly #accountRegionScope: SimAwsAccountRegionScope;
+  readonly #background: BackgroundScheduler;
+  #started = 0;
+
+  constructor(properties: SimStatesExecutionStartProperties) {
+    this.#stateMachines = properties.stateMachines;
+    this.#executions = properties.executions;
+    this.#accountRegionScope = properties.accountRegionScope;
+    this.#background = properties.background;
+  }
+
+  /**
+   * Start an execution and answer with its ARN.
+   *
+   * The walk runs as far as it can before this answers. An execution with
+   * nothing to wait for has finished by the time the caller reads it back, and
+   * one reaching a state that waits on the clock is left `RUNNING` for
+   * `advanceBy` to move on.
+   *
+   * Real `StartExecution` answers before the execution has run at all, so a
+   * caller there sees `RUNNING` first. Settling here instead spares every test
+   * a wait for something that has no work left to do, and the docs record the
+   * divergence.
+   */
+  async handle(
+    command: SimStartExecutionCommand,
+  ): Promise<SimStartExecutionCommandOutput> {
+    const { stateMachineArn, name, input } = command.input;
+    const stateMachine = requireSimStateMachine(
+      this.#stateMachines,
+      stateMachineArn,
+      "StartExecution",
+    );
+    const executionName = name ?? this.#nextName();
+
+    if (this.#executions.hasName(stateMachine.arn, executionName)) {
+      throw new SimStatesExecutionAlreadyExists(
+        `${stateMachine.name} already has an execution called ${executionName}.`,
+      );
+    }
+
+    const startDate = this.#background.now();
+    const execution = new SimStatesExecution({
+      arn: simStatesExecutionArn(
+        this.#accountRegionScope,
+        stateMachine.name,
+        executionName,
+      ),
+      name: executionName,
+      stateMachineArn: stateMachine.arn,
+      input: readSimStatesExecutionInput(input),
+      startDate,
+    });
+
+    this.#executions.add(execution);
+
+    await new SimStatesInterpreter({
+      definition: stateMachine.parsedDefinition,
+      execution,
+      background: this.#background,
+    }).run();
+
+    return { executionArn: execution.arn, startDate };
+  }
+
+  /**
+   * A name for an execution the caller did not name.
+   *
+   * Real Step Functions uses a UUID. A counter is used here because a
+   * simulation answering the same way twice is worth more than a name that
+   * looks right, and nothing reads meaning out of it.
+   */
+  #nextName(): string {
+    this.#started += 1;
+
+    return `execution-${String(this.#started)}`;
+  }
+}

--- a/src/service/stepfunctions/command/execution/sim-states-execution-start.ts
+++ b/src/service/stepfunctions/command/execution/sim-states-execution-start.ts
@@ -11,6 +11,7 @@ import type {
   SimStartExecutionCommand,
   SimStartExecutionCommandOutput,
 } from "./execution.command.js";
+import { chooseSimStatesExecutionName } from "./sim-states-execution-name.js";
 import { readSimStatesExecutionInput } from "./sim-states-execution-view.js";
 
 interface SimStatesExecutionStartProperties {
@@ -28,7 +29,6 @@ export class SimStatesExecutionStart {
   readonly #executions: SimStatesExecutionStore;
   readonly #accountRegionScope: SimAwsAccountRegionScope;
   readonly #background: BackgroundScheduler;
-  #started = 0;
 
   constructor(properties: SimStatesExecutionStartProperties) {
     this.#stateMachines = properties.stateMachines;
@@ -59,7 +59,11 @@ export class SimStatesExecutionStart {
       stateMachineArn,
       "StartExecution",
     );
-    const executionName = name ?? this.#nextName();
+    const executionName = chooseSimStatesExecutionName(
+      this.#executions,
+      stateMachine.arn,
+      name,
+    );
 
     if (this.#executions.hasName(stateMachine.arn, executionName)) {
       throw new SimStatesExecutionAlreadyExists(
@@ -89,18 +93,5 @@ export class SimStatesExecutionStart {
     }).run();
 
     return { executionArn: execution.arn, startDate };
-  }
-
-  /**
-   * A name for an execution the caller did not name.
-   *
-   * Real Step Functions uses a UUID. A counter is used here because a
-   * simulation answering the same way twice is worth more than a name that
-   * looks right, and nothing reads meaning out of it.
-   */
-  #nextName(): string {
-    this.#started += 1;
-
-    return `execution-${String(this.#started)}`;
   }
 }

--- a/src/service/stepfunctions/command/execution/sim-states-execution-view.ts
+++ b/src/service/stepfunctions/command/execution/sim-states-execution-view.ts
@@ -1,0 +1,51 @@
+import type { JSONValue } from "../../../../util/type-guard/json.js";
+import { SimStatesInvalidRequest } from "../../error/sim-step-functions.error.js";
+import type { SimStatesExecution } from "../../execution/sim-states-execution.js";
+import type * as commands from "./execution.command.js";
+
+/**
+ * Read the JSON an execution was started with.
+ *
+ * Real Step Functions takes the input as a JSON string and gives an execution
+ * an empty object where the request carried nothing.
+ */
+export function readSimStatesExecutionInput(
+  input: string | undefined,
+): JSONValue {
+  if (input === undefined) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(input) as JSONValue;
+  } catch {
+    throw new SimStatesInvalidRequest(
+      "The execution input is not JSON. StartExecution takes it as a JSON string.",
+    );
+  }
+}
+
+/**
+ * What `DescribeExecution` answers with.
+ *
+ * The fields an execution has not got are left off rather than sent as
+ * undefined, which is how the SDK shapes an answer from real Step Functions.
+ */
+export function simStatesExecutionView(
+  execution: SimStatesExecution,
+): commands.SimDescribeExecutionCommandOutput {
+  return {
+    executionArn: execution.arn,
+    stateMachineArn: execution.stateMachineArn,
+    name: execution.name,
+    status: execution.status,
+    startDate: execution.startDate,
+    input: JSON.stringify(execution.input),
+    ...(execution.stopDate !== undefined && { stopDate: execution.stopDate }),
+    ...(execution.output !== undefined && {
+      output: JSON.stringify(execution.output),
+    }),
+    ...(execution.error !== undefined && { error: execution.error }),
+    ...(execution.cause !== undefined && { cause: execution.cause }),
+  };
+}

--- a/src/service/stepfunctions/command/machine/machine.command.ts
+++ b/src/service/stepfunctions/command/machine/machine.command.ts
@@ -1,0 +1,78 @@
+import type { SimStateMachineType } from "../../machine/sim-state-machine.js";
+
+export interface SimCreateStateMachineCommandInput {
+  readonly name?: string;
+  readonly definition?: string;
+  readonly roleArn?: string;
+  readonly type?: string;
+}
+
+export interface SimCreateStateMachineCommand {
+  readonly input: SimCreateStateMachineCommandInput;
+}
+
+export interface SimCreateStateMachineCommandOutput {
+  readonly stateMachineArn: string;
+  readonly creationDate: Date;
+}
+
+export interface SimDescribeStateMachineCommandInput {
+  readonly stateMachineArn?: string;
+}
+
+export interface SimDescribeStateMachineCommand {
+  readonly input: SimDescribeStateMachineCommandInput;
+}
+
+export interface SimDescribeStateMachineCommandOutput {
+  readonly stateMachineArn: string;
+  readonly name: string;
+  readonly status: "ACTIVE";
+  readonly definition: string;
+  readonly roleArn: string;
+  readonly type: SimStateMachineType;
+  readonly creationDate: Date;
+}
+
+export interface SimUpdateStateMachineCommandInput {
+  readonly stateMachineArn?: string;
+  readonly definition?: string;
+  readonly roleArn?: string;
+}
+
+export interface SimUpdateStateMachineCommand {
+  readonly input: SimUpdateStateMachineCommandInput;
+}
+
+export interface SimUpdateStateMachineCommandOutput {
+  readonly updateDate: Date;
+}
+
+export interface SimDeleteStateMachineCommandInput {
+  readonly stateMachineArn?: string;
+}
+
+export interface SimDeleteStateMachineCommand {
+  readonly input: SimDeleteStateMachineCommandInput;
+}
+
+export type SimDeleteStateMachineCommandOutput = Record<string, never>;
+
+export interface SimStateMachineListItem {
+  readonly stateMachineArn: string;
+  readonly name: string;
+  readonly type: SimStateMachineType;
+  readonly creationDate: Date;
+}
+
+export interface SimListStateMachinesCommandInput {
+  readonly maxResults?: number;
+}
+
+export interface SimListStateMachinesCommand {
+  readonly input: SimListStateMachinesCommandInput;
+}
+
+export interface SimListStateMachinesCommandOutput {
+  readonly stateMachines: readonly SimStateMachineListItem[];
+}

--- a/src/service/stepfunctions/command/machine/sim-state-machine-create.ts
+++ b/src/service/stepfunctions/command/machine/sim-state-machine-create.ts
@@ -8,7 +8,10 @@ import type {
   SimCreateStateMachineCommand,
   SimCreateStateMachineCommandOutput,
 } from "./machine.command.js";
-import { readSimStateMachineCreateInput } from "./sim-state-machine-input.js";
+import {
+  type SimStateMachineCreateInput,
+  readSimStateMachineCreateInput,
+} from "./sim-state-machine-input.js";
 
 interface SimStateMachineCreateProperties {
   readonly stateMachines: SimStateMachineStore;
@@ -36,16 +39,19 @@ export class SimStateMachineCreate {
    * A definition using something this simulator does not run is refused here
    * rather than when an execution reaches the state, which is where real Step
    * Functions refuses a malformed one too.
+   *
+   * `CreateStateMachine` is idempotent. A second request carrying the same
+   * name, definition and type answers with the state machine that is already
+   * there.
    */
   handle(
     command: SimCreateStateMachineCommand,
   ): SimCreateStateMachineCommandOutput {
     const read = readSimStateMachineCreateInput(command.input);
+    const existing = this.#stateMachines.findByName(read.name);
 
-    if (this.#stateMachines.findByName(read.name) !== undefined) {
-      throw new SimStateMachineAlreadyExists(
-        `A state machine called ${read.name} is already there.`,
-      );
+    if (existing !== undefined) {
+      return answerForExisting(existing, read);
     }
 
     const creationDate = this.#background.now();
@@ -59,4 +65,31 @@ export class SimStateMachineCreate {
 
     return { stateMachineArn: stateMachine.arn, creationDate };
   }
+}
+
+/**
+ * Answer a repeat request for a state machine that is already there.
+ *
+ * The idempotency check reads the name, the definition and the type. A request
+ * differing only in its `roleArn` is idempotent too, and real Step Functions
+ * leaves the role as it was. Its API reference contradicts itself on that
+ * point, listing a differing role ARN under `StateMachineAlreadyExists` while
+ * the operation's own note says the difference is ignored. The note is the
+ * more specific of the two and is followed here.
+ */
+function answerForExisting(
+  existing: SimStateMachine,
+  read: SimStateMachineCreateInput,
+): SimCreateStateMachineCommandOutput {
+  if (existing.definition !== read.definition || existing.type !== read.type) {
+    throw new SimStateMachineAlreadyExists(
+      `A state machine called ${read.name} is already there, with a ` +
+        "different definition or type.",
+    );
+  }
+
+  return {
+    stateMachineArn: existing.arn,
+    creationDate: existing.creationDate,
+  };
 }

--- a/src/service/stepfunctions/command/machine/sim-state-machine-create.ts
+++ b/src/service/stepfunctions/command/machine/sim-state-machine-create.ts
@@ -1,0 +1,62 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import { SimStateMachineAlreadyExists } from "../../error/sim-step-functions.error.js";
+import { SimStateMachine } from "../../machine/sim-state-machine.js";
+import { simStateMachineArn } from "../../machine/sim-state-machine-arn.js";
+import type { SimStateMachineStore } from "../../machine/sim-state-machine-store.js";
+import type {
+  SimCreateStateMachineCommand,
+  SimCreateStateMachineCommandOutput,
+} from "./machine.command.js";
+import { readSimStateMachineCreateInput } from "./sim-state-machine-input.js";
+
+interface SimStateMachineCreateProperties {
+  readonly stateMachines: SimStateMachineStore;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * The command that creates a state machine.
+ */
+export class SimStateMachineCreate {
+  readonly #stateMachines: SimStateMachineStore;
+  readonly #accountRegionScope: SimAwsAccountRegionScope;
+  readonly #background: BackgroundScheduler;
+
+  constructor(properties: SimStateMachineCreateProperties) {
+    this.#stateMachines = properties.stateMachines;
+    this.#accountRegionScope = properties.accountRegionScope;
+    this.#background = properties.background;
+  }
+
+  /**
+   * Create a state machine, checking its definition as it is read.
+   *
+   * A definition using something this simulator does not run is refused here
+   * rather than when an execution reaches the state, which is where real Step
+   * Functions refuses a malformed one too.
+   */
+  handle(
+    command: SimCreateStateMachineCommand,
+  ): SimCreateStateMachineCommandOutput {
+    const read = readSimStateMachineCreateInput(command.input);
+
+    if (this.#stateMachines.findByName(read.name) !== undefined) {
+      throw new SimStateMachineAlreadyExists(
+        `A state machine called ${read.name} is already there.`,
+      );
+    }
+
+    const creationDate = this.#background.now();
+    const stateMachine = new SimStateMachine({
+      arn: simStateMachineArn(this.#accountRegionScope, read.name),
+      creationDate,
+      ...read,
+    });
+
+    this.#stateMachines.add(stateMachine);
+
+    return { stateMachineArn: stateMachine.arn, creationDate };
+  }
+}

--- a/src/service/stepfunctions/command/machine/sim-state-machine-input.ts
+++ b/src/service/stepfunctions/command/machine/sim-state-machine-input.ts
@@ -1,0 +1,64 @@
+import { parseSimStatesDefinition } from "../../definition/sim-states-definition-parse.js";
+import type { SimStatesDefinition } from "../../definition/sim-states-definition.js";
+import { SimStatesInvalidRequest } from "../../error/sim-step-functions.error.js";
+import type { SimStateMachineType } from "../../machine/sim-state-machine.js";
+import type * as commands from "./machine.command.js";
+
+/**
+ * What a CreateStateMachine request has to carry, once it has been checked.
+ */
+export interface SimStateMachineCreateInput {
+  readonly name: string;
+  readonly definition: string;
+  readonly parsed: SimStatesDefinition;
+  readonly roleArn: string;
+  readonly type: SimStateMachineType;
+}
+
+/**
+ * Check a CreateStateMachine request and read its definition.
+ */
+export function readSimStateMachineCreateInput(
+  input: commands.SimCreateStateMachineCommandInput,
+): SimStateMachineCreateInput {
+  const { name, definition, roleArn, type } = input;
+
+  if (name === undefined || name === "") {
+    throw new SimStatesInvalidRequest("CreateStateMachine needs a name.");
+  }
+
+  if (definition === undefined) {
+    throw new SimStatesInvalidRequest("CreateStateMachine needs a definition.");
+  }
+
+  if (roleArn === undefined) {
+    throw new SimStatesInvalidRequest("CreateStateMachine needs a roleArn.");
+  }
+
+  return {
+    name,
+    definition,
+    parsed: parseSimStatesDefinition(definition),
+    roleArn,
+    type: readSimStateMachineType(type),
+  };
+}
+
+/**
+ * Read the state machine type a request asked for.
+ */
+export function readSimStateMachineType(
+  type: string | undefined,
+): SimStateMachineType {
+  if (type === undefined || type === "STANDARD") {
+    return "STANDARD";
+  }
+
+  if (type === "EXPRESS") {
+    return "EXPRESS";
+  }
+
+  throw new SimStatesInvalidRequest(
+    `${type} is not a state machine type. It is STANDARD or EXPRESS.`,
+  );
+}

--- a/src/service/stepfunctions/command/machine/sim-state-machine-input.ts
+++ b/src/service/stepfunctions/command/machine/sim-state-machine-input.ts
@@ -2,6 +2,7 @@ import { parseSimStatesDefinition } from "../../definition/sim-states-definition
 import type { SimStatesDefinition } from "../../definition/sim-states-definition.js";
 import { SimStatesInvalidRequest } from "../../error/sim-step-functions.error.js";
 import type { SimStateMachineType } from "../../machine/sim-state-machine.js";
+import { checkSimStatesName } from "../../machine/sim-states-name.js";
 import type * as commands from "./machine.command.js";
 
 /**
@@ -36,7 +37,7 @@ export function readSimStateMachineCreateInput(
   }
 
   return {
-    name,
+    name: checkSimStatesName(name, "The state machine name"),
     definition,
     parsed: parseSimStatesDefinition(definition),
     roleArn,

--- a/src/service/stepfunctions/command/machine/sim-state-machine-lookup.ts
+++ b/src/service/stepfunctions/command/machine/sim-state-machine-lookup.ts
@@ -1,0 +1,31 @@
+import {
+  SimStatesInvalidRequest,
+  SimStatesResourceNotFound,
+} from "../../error/sim-step-functions.error.js";
+import type { SimStateMachine } from "../../machine/sim-state-machine.js";
+import type { SimStateMachineStore } from "../../machine/sim-state-machine-store.js";
+
+/**
+ * Find the state machine a request's ARN names, or say why it could not be.
+ */
+export function requireSimStateMachine(
+  stateMachines: SimStateMachineStore,
+  arn: string | undefined,
+  commandName: string,
+): SimStateMachine {
+  if (arn === undefined) {
+    throw new SimStatesInvalidRequest(
+      `${commandName} needs a stateMachineArn.`,
+    );
+  }
+
+  const stateMachine = stateMachines.find(arn);
+
+  if (stateMachine === undefined) {
+    throw new SimStatesResourceNotFound(
+      `${arn} is not a simulated state machine in this Account and Region.`,
+    );
+  }
+
+  return stateMachine;
+}

--- a/src/service/stepfunctions/command/machine/sim-state-machine-reads.ts
+++ b/src/service/stepfunctions/command/machine/sim-state-machine-reads.ts
@@ -1,0 +1,65 @@
+import type { SimStateMachineStore } from "../../machine/sim-state-machine-store.js";
+import type {
+  SimDescribeStateMachineCommand,
+  SimDescribeStateMachineCommandOutput,
+  SimListStateMachinesCommand,
+  SimListStateMachinesCommandOutput,
+} from "./machine.command.js";
+import { requireSimStateMachine } from "./sim-state-machine-lookup.js";
+
+/**
+ * The commands that read state machines back.
+ */
+export class SimStateMachineReads {
+  readonly #stateMachines: SimStateMachineStore;
+
+  constructor(stateMachines: SimStateMachineStore) {
+    this.#stateMachines = stateMachines;
+  }
+
+  /**
+   * Read one state machine back.
+   */
+  describe(
+    command: SimDescribeStateMachineCommand,
+  ): SimDescribeStateMachineCommandOutput {
+    const found = requireSimStateMachine(
+      this.#stateMachines,
+      command.input.stateMachineArn,
+      "DescribeStateMachine",
+    );
+
+    return {
+      stateMachineArn: found.arn,
+      name: found.name,
+      status: "ACTIVE",
+      definition: found.definition,
+      roleArn: found.roleArn,
+      type: found.type,
+      creationDate: found.creationDate,
+    };
+  }
+
+  /**
+   * List the state machines this scope holds.
+   */
+  list(
+    command: SimListStateMachinesCommand,
+  ): SimListStateMachinesCommandOutput {
+    const { maxResults } = command.input;
+    const all = this.#stateMachines.all();
+    const wanted =
+      maxResults === undefined || maxResults === 0
+        ? all
+        : all.slice(0, maxResults);
+
+    return {
+      stateMachines: wanted.map((found) => ({
+        stateMachineArn: found.arn,
+        name: found.name,
+        type: found.type,
+        creationDate: found.creationDate,
+      })),
+    };
+  }
+}

--- a/src/service/stepfunctions/command/machine/sim-state-machine-reads.ts
+++ b/src/service/stepfunctions/command/machine/sim-state-machine-reads.ts
@@ -5,6 +5,7 @@ import type {
   SimListStateMachinesCommand,
   SimListStateMachinesCommandOutput,
 } from "./machine.command.js";
+import { SimStatesInvalidRequest } from "../../error/sim-step-functions.error.js";
 import { requireSimStateMachine } from "./sim-state-machine-lookup.js";
 
 /**
@@ -47,6 +48,16 @@ export class SimStateMachineReads {
     command: SimListStateMachinesCommand,
   ): SimListStateMachinesCommandOutput {
     const { maxResults } = command.input;
+
+    if (
+      maxResults !== undefined &&
+      (!Number.isSafeInteger(maxResults) || maxResults < 0 || maxResults > 1000)
+    ) {
+      throw new SimStatesInvalidRequest(
+        `maxResults is ${String(maxResults)}. It is a whole number from 0 to 1000.`,
+      );
+    }
+
     const all = this.#stateMachines.all();
     const wanted =
       maxResults === undefined || maxResults === 0

--- a/src/service/stepfunctions/command/machine/sim-state-machine-writes.ts
+++ b/src/service/stepfunctions/command/machine/sim-state-machine-writes.ts
@@ -1,5 +1,6 @@
 import type { BackgroundScheduler } from "../../../../util/background/background.js";
 import { parseSimStatesDefinition } from "../../definition/sim-states-definition-parse.js";
+import { SimStatesInvalidRequest } from "../../error/sim-step-functions.error.js";
 import type { SimStatesExecutionStore } from "../../execution/sim-states-execution-store.js";
 import type { SimStateMachineStore } from "../../machine/sim-state-machine-store.js";
 import type {
@@ -37,6 +38,13 @@ export class SimStateMachineWrites {
     command: SimUpdateStateMachineCommand,
   ): SimUpdateStateMachineCommandOutput {
     const { stateMachineArn, definition, roleArn } = command.input;
+
+    if (definition === undefined && roleArn === undefined) {
+      throw new SimStatesInvalidRequest(
+        "UpdateStateMachine needs a definition or a roleArn to change.",
+      );
+    }
+
     const found = requireSimStateMachine(
       this.#stateMachines,
       stateMachineArn,

--- a/src/service/stepfunctions/command/machine/sim-state-machine-writes.ts
+++ b/src/service/stepfunctions/command/machine/sim-state-machine-writes.ts
@@ -1,0 +1,75 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import { parseSimStatesDefinition } from "../../definition/sim-states-definition-parse.js";
+import type { SimStatesExecutionStore } from "../../execution/sim-states-execution-store.js";
+import type { SimStateMachineStore } from "../../machine/sim-state-machine-store.js";
+import type {
+  SimDeleteStateMachineCommand,
+  SimDeleteStateMachineCommandOutput,
+  SimUpdateStateMachineCommand,
+  SimUpdateStateMachineCommandOutput,
+} from "./machine.command.js";
+import { requireSimStateMachine } from "./sim-state-machine-lookup.js";
+
+interface SimStateMachineWritesProperties {
+  readonly stateMachines: SimStateMachineStore;
+  readonly executions: SimStatesExecutionStore;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * The commands that change and delete state machines.
+ */
+export class SimStateMachineWrites {
+  readonly #stateMachines: SimStateMachineStore;
+  readonly #executions: SimStatesExecutionStore;
+  readonly #background: BackgroundScheduler;
+
+  constructor(properties: SimStateMachineWritesProperties) {
+    this.#stateMachines = properties.stateMachines;
+    this.#executions = properties.executions;
+    this.#background = properties.background;
+  }
+
+  /**
+   * Change a state machine's definition or role.
+   */
+  update(
+    command: SimUpdateStateMachineCommand,
+  ): SimUpdateStateMachineCommandOutput {
+    const { stateMachineArn, definition, roleArn } = command.input;
+    const found = requireSimStateMachine(
+      this.#stateMachines,
+      stateMachineArn,
+      "UpdateStateMachine",
+    );
+
+    found.update({
+      roleArn,
+      definition,
+      parsed:
+        definition === undefined
+          ? undefined
+          : parseSimStatesDefinition(definition),
+    });
+
+    return { updateDate: this.#background.now() };
+  }
+
+  /**
+   * Delete a state machine and forget its executions.
+   */
+  delete(
+    command: SimDeleteStateMachineCommand,
+  ): SimDeleteStateMachineCommandOutput {
+    const found = requireSimStateMachine(
+      this.#stateMachines,
+      command.input.stateMachineArn,
+      "DeleteStateMachine",
+    );
+
+    this.#stateMachines.remove(found.arn);
+    this.#executions.removeForStateMachine(found.arn);
+
+    return {};
+  }
+}

--- a/src/service/stepfunctions/command/sim-step-functions-command.types.ts
+++ b/src/service/stepfunctions/command/sim-step-functions-command.types.ts
@@ -1,0 +1,29 @@
+/**
+ * The sim Step Functions Command types, gathered for the service facade.
+ */
+export type {
+  SimCreateStateMachineCommand,
+  SimCreateStateMachineCommandInput,
+  SimCreateStateMachineCommandOutput,
+  SimDeleteStateMachineCommand,
+  SimDeleteStateMachineCommandInput,
+  SimDeleteStateMachineCommandOutput,
+  SimDescribeStateMachineCommand,
+  SimDescribeStateMachineCommandInput,
+  SimDescribeStateMachineCommandOutput,
+  SimListStateMachinesCommand,
+  SimListStateMachinesCommandInput,
+  SimListStateMachinesCommandOutput,
+  SimStateMachineListItem,
+  SimUpdateStateMachineCommand,
+  SimUpdateStateMachineCommandInput,
+  SimUpdateStateMachineCommandOutput,
+} from "./machine/machine.command.js";
+export type {
+  SimDescribeExecutionCommand,
+  SimDescribeExecutionCommandInput,
+  SimDescribeExecutionCommandOutput,
+  SimStartExecutionCommand,
+  SimStartExecutionCommandInput,
+  SimStartExecutionCommandOutput,
+} from "./execution/execution.command.js";

--- a/src/service/stepfunctions/command/sim-step-functions-input-refusals.iso.test.ts
+++ b/src/service/stepfunctions/command/sim-step-functions-input-refusals.iso.test.ts
@@ -1,0 +1,83 @@
+import { assertStringIncludes, assertThrowsErrorAsync } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+
+const roleArn = "arn:aws:iam::123456789012:role/WorkflowRole";
+
+const passThrough = JSON.stringify({
+  StartAt: "Only",
+  States: { Only: { Type: "Pass", End: true } },
+});
+
+/**
+ * Answer with why a CreateStateMachine was refused.
+ */
+async function creationRefusalFor(
+  simAws: SimAws,
+  input: { readonly name: string; readonly type?: string },
+): Promise<string> {
+  return await refusalFor(
+    async () =>
+      await simAws.stepFunctions().createStateMachine({
+        input: { roleArn, definition: passThrough, ...input },
+      }),
+  );
+}
+
+/**
+ * Answer with why a call was refused.
+ */
+async function refusalFor(call: () => Promise<unknown>): Promise<string> {
+  const error = await assertThrowsErrorAsync(call);
+
+  return error.message;
+}
+
+describe("Simulated Step Functions input refusals", () => {
+  it("refuses a CreateStateMachine input Step Functions would not take", async () => {
+    // Given names carrying a colon, a space and more than 80 characters, and a
+    // state machine type that does not exist.
+    const simAws = new SimAws();
+
+    // When each is used to create a state machine.
+    const names = await Promise.all(
+      ["Orders:Blue", "Two Words", "E".repeat(81), ""].map(
+        async (name) => await creationRefusalFor(simAws, { name }),
+      ),
+    );
+    const type = await creationRefusalFor(simAws, {
+      name: "Enrolment",
+      type: "SYNCHRONOUS",
+    });
+
+    // Then no ARN is built that cannot be read back, and the type is refused
+    // for what it is.
+    for (const refusal of names) {
+      assertStringIncludes(refusal, "name");
+    }
+
+    assertStringIncludes(type, "is not a state machine type");
+  });
+
+  it("refuses a maxResults outside the range Step Functions allows", async () => {
+    // Given values below, above and between whole numbers.
+    const simAws = new SimAws();
+
+    // When each is listed with.
+    const refusals = await Promise.all(
+      [-1, 1001, 1.5].map(
+        async (maxResults) =>
+          await refusalFor(
+            async () =>
+              await simAws
+                .stepFunctions()
+                .listStateMachines({ input: { maxResults } }),
+          ),
+      ),
+    );
+
+    for (const refusal of refusals) {
+      assertStringIncludes(refusal, "whole number from 0 to 1000");
+    }
+  });
+});

--- a/src/service/stepfunctions/command/sim-step-functions-refusals.iso.test.ts
+++ b/src/service/stepfunctions/command/sim-step-functions-refusals.iso.test.ts
@@ -1,0 +1,171 @@
+import { assertStringIncludes, assertThrowsErrorAsync } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimStepFunctions } from "../sim-step-functions.js";
+
+const roleArn = "arn:aws:iam::123456789012:role/WorkflowRole";
+
+const passThrough = JSON.stringify({
+  StartAt: "Only",
+  States: { Only: { Type: "Pass", End: true } },
+});
+
+const absentArn = "arn:aws:states:eu-west-2:123456789012:stateMachine:Absent";
+
+/**
+ * Answer with why a call was refused.
+ */
+async function refusalFor(call: () => Promise<unknown>): Promise<string> {
+  const error = await assertThrowsErrorAsync(call);
+
+  return error.message;
+}
+
+describe("Simulated Step Functions request refusals", () => {
+  it("refuses a CreateStateMachine missing what it needs", async () => {
+    // Given a simulated Step Functions.
+    const simAws = new SimAws();
+    const stepFunctions: SimStepFunctions = simAws.stepFunctions();
+
+    // When each required field is left out.
+    const noName = await refusalFor(
+      async () =>
+        await stepFunctions.createStateMachine({
+          input: { roleArn, definition: passThrough },
+        }),
+    );
+    const noDefinition = await refusalFor(
+      async () =>
+        await stepFunctions.createStateMachine({
+          input: { name: "Enrolment", roleArn },
+        }),
+    );
+    const noRole = await refusalFor(
+      async () =>
+        await stepFunctions.createStateMachine({
+          input: { name: "Enrolment", definition: passThrough },
+        }),
+    );
+
+    // Then each names what was missing.
+    assertStringIncludes(noName, "needs a name");
+    assertStringIncludes(noDefinition, "needs a definition");
+    assertStringIncludes(noRole, "needs a roleArn");
+  });
+
+  it("refuses a state machine type that is neither STANDARD nor EXPRESS", async () => {
+    // Given a request naming another type.
+    const simAws = new SimAws();
+
+    // When it is created.
+    const refusal = await refusalFor(
+      async () =>
+        await simAws.stepFunctions().createStateMachine({
+          input: {
+            name: "Enrolment",
+            roleArn,
+            definition: passThrough,
+            type: "SYNCHRONOUS",
+          },
+        }),
+    );
+
+    // Then the type is refused.
+    assertStringIncludes(refusal, "is not a state machine type");
+  });
+
+  it("accepts an EXPRESS state machine and runs it the standard way", async () => {
+    // Given an EXPRESS state machine.
+    const simAws = new SimAws();
+    const created = await simAws.stepFunctions().createStateMachine({
+      input: {
+        name: "Enrolment",
+        roleArn,
+        definition: passThrough,
+        type: "EXPRESS",
+      },
+    });
+
+    // When it is read back.
+    const described = await simAws.stepFunctions().describeStateMachine({
+      input: { stateMachineArn: created.stateMachineArn },
+    });
+
+    // Then the type is carried, and nothing else about it differs here.
+    assertStringIncludes(described.type, "EXPRESS");
+  });
+
+  it("refuses a request carrying no ARN, and one naming nothing", async () => {
+    // Given a simulated Step Functions holding nothing.
+    const simAws = new SimAws();
+    const stepFunctions = simAws.stepFunctions();
+
+    // When commands are called without an ARN and with an absent one.
+    const noArn = await refusalFor(
+      async () => await stepFunctions.describeStateMachine({ input: {} }),
+    );
+    const absent = await refusalFor(
+      async () =>
+        await stepFunctions.deleteStateMachine({
+          input: { stateMachineArn: absentArn },
+        }),
+    );
+    const noStart = await refusalFor(
+      async () => await stepFunctions.startExecution({ input: {} }),
+    );
+    const absentStart = await refusalFor(
+      async () =>
+        await stepFunctions.startExecution({
+          input: { stateMachineArn: absentArn },
+        }),
+    );
+    const noExecution = await refusalFor(
+      async () => await stepFunctions.describeExecution({ input: {} }),
+    );
+
+    // Then each says what was wrong with the request.
+    assertStringIncludes(noArn, "needs a stateMachineArn");
+    assertStringIncludes(absent, "not a simulated state machine");
+    assertStringIncludes(noStart, "StartExecution needs a stateMachineArn");
+    assertStringIncludes(absentStart, "not a simulated state machine");
+    assertStringIncludes(noExecution, "needs an executionArn");
+  });
+
+  it("refuses an execution input that is not JSON", async () => {
+    // Given a state machine.
+    const simAws = new SimAws();
+    const created = await simAws.stepFunctions().createStateMachine({
+      input: { name: "Enrolment", roleArn, definition: passThrough },
+    });
+
+    // When an execution is started with something that will not parse.
+    const refusal = await refusalFor(
+      async () =>
+        await simAws.stepFunctions().startExecution({
+          input: {
+            stateMachineArn: created.stateMachineArn,
+            input: "not json",
+          },
+        }),
+    );
+
+    // Then it is refused before the execution begins.
+    assertStringIncludes(refusal, "is not JSON");
+  });
+
+  it("refuses an update naming a state machine that is not there", async () => {
+    // Given a simulated Step Functions holding nothing.
+    const simAws = new SimAws();
+
+    // When an absent state machine is updated.
+    const refusal = await refusalFor(
+      async () =>
+        await simAws
+          .stepFunctions()
+          .updateStateMachine({ input: { stateMachineArn: absentArn } }),
+    );
+
+    // Then it is refused.
+    assertStringIncludes(refusal, "not a simulated state machine");
+  });
+});

--- a/src/service/stepfunctions/command/sim-step-functions-refusals.iso.test.ts
+++ b/src/service/stepfunctions/command/sim-step-functions-refusals.iso.test.ts
@@ -1,7 +1,6 @@
 import { assertStringIncludes, assertThrowsErrorAsync } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../aws/sim-aws.js";
-import type { SimStepFunctions } from "../sim-step-functions.js";
 
 const roleArn = "arn:aws:iam::123456789012:role/WorkflowRole";
 
@@ -10,7 +9,16 @@ const passThrough = JSON.stringify({
   States: { Only: { Type: "Pass", End: true } },
 });
 
-const absentArn = "arn:aws:states:eu-west-2:123456789012:stateMachine:Absent";
+/**
+ * Create a state machine, for the calls that need one to exist.
+ */
+async function givenAStateMachine(simAws: SimAws): Promise<string> {
+  const created = await simAws.stepFunctions().createStateMachine({
+    input: { name: "Enrolment", roleArn, definition: passThrough },
+  });
+
+  return created.stateMachineArn;
+}
 
 /**
  * Answer with why a call was refused.
@@ -25,7 +33,7 @@ describe("Simulated Step Functions request refusals", () => {
   it("refuses a CreateStateMachine missing what it needs", async () => {
     // Given a simulated Step Functions.
     const simAws = new SimAws();
-    const stepFunctions: SimStepFunctions = simAws.stepFunctions();
+    const stepFunctions = simAws.stepFunctions();
 
     // When each required field is left out.
     const noName = await refusalFor(
@@ -53,99 +61,16 @@ describe("Simulated Step Functions request refusals", () => {
     assertStringIncludes(noRole, "needs a roleArn");
   });
 
-  it("refuses a state machine type that is neither STANDARD nor EXPRESS", async () => {
-    // Given a request naming another type.
-    const simAws = new SimAws();
-
-    // When it is created.
-    const refusal = await refusalFor(
-      async () =>
-        await simAws.stepFunctions().createStateMachine({
-          input: {
-            name: "Enrolment",
-            roleArn,
-            definition: passThrough,
-            type: "SYNCHRONOUS",
-          },
-        }),
-    );
-
-    // Then the type is refused.
-    assertStringIncludes(refusal, "is not a state machine type");
-  });
-
-  it("accepts an EXPRESS state machine and runs it the standard way", async () => {
-    // Given an EXPRESS state machine.
-    const simAws = new SimAws();
-    const created = await simAws.stepFunctions().createStateMachine({
-      input: {
-        name: "Enrolment",
-        roleArn,
-        definition: passThrough,
-        type: "EXPRESS",
-      },
-    });
-
-    // When it is read back.
-    const described = await simAws.stepFunctions().describeStateMachine({
-      input: { stateMachineArn: created.stateMachineArn },
-    });
-
-    // Then the type is carried, and nothing else about it differs here.
-    assertStringIncludes(described.type, "EXPRESS");
-  });
-
-  it("refuses a request carrying no ARN, and one naming nothing", async () => {
-    // Given a simulated Step Functions holding nothing.
-    const simAws = new SimAws();
-    const stepFunctions = simAws.stepFunctions();
-
-    // When commands are called without an ARN and with an absent one.
-    const noArn = await refusalFor(
-      async () => await stepFunctions.describeStateMachine({ input: {} }),
-    );
-    const absent = await refusalFor(
-      async () =>
-        await stepFunctions.deleteStateMachine({
-          input: { stateMachineArn: absentArn },
-        }),
-    );
-    const noStart = await refusalFor(
-      async () => await stepFunctions.startExecution({ input: {} }),
-    );
-    const absentStart = await refusalFor(
-      async () =>
-        await stepFunctions.startExecution({
-          input: { stateMachineArn: absentArn },
-        }),
-    );
-    const noExecution = await refusalFor(
-      async () => await stepFunctions.describeExecution({ input: {} }),
-    );
-
-    // Then each says what was wrong with the request.
-    assertStringIncludes(noArn, "needs a stateMachineArn");
-    assertStringIncludes(absent, "not a simulated state machine");
-    assertStringIncludes(noStart, "StartExecution needs a stateMachineArn");
-    assertStringIncludes(absentStart, "not a simulated state machine");
-    assertStringIncludes(noExecution, "needs an executionArn");
-  });
-
   it("refuses an execution input that is not JSON", async () => {
     // Given a state machine.
     const simAws = new SimAws();
-    const created = await simAws.stepFunctions().createStateMachine({
-      input: { name: "Enrolment", roleArn, definition: passThrough },
-    });
+    const stateMachineArn = await givenAStateMachine(simAws);
 
     // When an execution is started with something that will not parse.
     const refusal = await refusalFor(
       async () =>
         await simAws.stepFunctions().startExecution({
-          input: {
-            stateMachineArn: created.stateMachineArn,
-            input: "not json",
-          },
+          input: { stateMachineArn, input: "not json" },
         }),
     );
 
@@ -153,19 +78,20 @@ describe("Simulated Step Functions request refusals", () => {
     assertStringIncludes(refusal, "is not JSON");
   });
 
-  it("refuses an update naming a state machine that is not there", async () => {
-    // Given a simulated Step Functions holding nothing.
+  it("refuses an update with nothing to change", async () => {
+    // Given a state machine.
     const simAws = new SimAws();
+    const stateMachineArn = await givenAStateMachine(simAws);
 
-    // When an absent state machine is updated.
+    // When it is updated with neither a definition nor a role.
     const refusal = await refusalFor(
       async () =>
         await simAws
           .stepFunctions()
-          .updateStateMachine({ input: { stateMachineArn: absentArn } }),
+          .updateStateMachine({ input: { stateMachineArn } }),
     );
 
-    // Then it is refused.
-    assertStringIncludes(refusal, "not a simulated state machine");
+    // Then the request is refused before anything is looked up.
+    assertStringIncludes(refusal, "needs a definition or a roleArn");
   });
 });

--- a/src/service/stepfunctions/command/sim-step-functions-request-options.ts
+++ b/src/service/stepfunctions/command/sim-step-functions-request-options.ts
@@ -1,0 +1,12 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+
+/**
+ * What a Step Functions request carries besides its command input.
+ */
+export interface SimStepFunctionsRequestOptions {
+  /**
+   * Who is making the request. An omitted caller is the Account root, as it is
+   * everywhere else in the simulation.
+   */
+  readonly caller?: SimAwsCaller;
+}

--- a/src/service/stepfunctions/command/sim-step-functions-resources.iso.test.ts
+++ b/src/service/stepfunctions/command/sim-step-functions-resources.iso.test.ts
@@ -1,0 +1,167 @@
+import {
+  assertFalse,
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+
+const roleArn = "arn:aws:iam::123456789012:role/WorkflowRole";
+
+const passThrough = JSON.stringify({
+  StartAt: "Only",
+  States: { Only: { Type: "Pass", End: true } },
+});
+
+const absentArn = "arn:aws:states:eu-west-2:123456789012:stateMachine:Absent";
+
+/**
+ * Answer with why a call was refused.
+ */
+async function refusalFor(call: () => Promise<unknown>): Promise<string> {
+  const error = await assertThrowsErrorAsync(call);
+
+  return error.message;
+}
+
+describe("Simulated Step Functions resource handling", () => {
+  it("accepts an EXPRESS state machine and runs it the standard way", async () => {
+    // Given an EXPRESS state machine.
+    const simAws = new SimAws();
+    const created = await simAws.stepFunctions().createStateMachine({
+      input: {
+        name: "Enrolment",
+        roleArn,
+        definition: passThrough,
+        type: "EXPRESS",
+      },
+    });
+
+    // When it is read back.
+    const described = await simAws.stepFunctions().describeStateMachine({
+      input: { stateMachineArn: created.stateMachineArn },
+    });
+
+    // Then the type is carried, and nothing else about it differs here.
+    assertStringIncludes(described.type, "EXPRESS");
+  });
+
+  it("refuses a request carrying no ARN, and one naming nothing", async () => {
+    // Given a simulated Step Functions holding nothing.
+    const simAws = new SimAws();
+    const stepFunctions = simAws.stepFunctions();
+
+    // When commands are called without an ARN and with an absent one.
+    const noArn = await refusalFor(
+      async () => await stepFunctions.describeStateMachine({ input: {} }),
+    );
+    const absent = await refusalFor(
+      async () =>
+        await stepFunctions.deleteStateMachine({
+          input: { stateMachineArn: absentArn },
+        }),
+    );
+    const noStart = await refusalFor(
+      async () => await stepFunctions.startExecution({ input: {} }),
+    );
+    const absentStart = await refusalFor(
+      async () =>
+        await stepFunctions.startExecution({
+          input: { stateMachineArn: absentArn },
+        }),
+    );
+    const noExecution = await refusalFor(
+      async () => await stepFunctions.describeExecution({ input: {} }),
+    );
+
+    // Then each says what was wrong with the request.
+    assertStringIncludes(noArn, "needs a stateMachineArn");
+    assertStringIncludes(absent, "not a simulated state machine");
+    assertStringIncludes(noStart, "StartExecution needs a stateMachineArn");
+    assertStringIncludes(absentStart, "not a simulated state machine");
+    assertStringIncludes(noExecution, "needs an executionArn");
+  });
+
+  it("refuses an update naming a state machine that is not there", async () => {
+    // Given a simulated Step Functions holding nothing.
+    const simAws = new SimAws();
+
+    // When an absent state machine is given a new role.
+    const refusal = await refusalFor(
+      async () =>
+        await simAws.stepFunctions().updateStateMachine({
+          input: { stateMachineArn: absentArn, roleArn },
+        }),
+    );
+
+    // Then it is refused.
+    assertStringIncludes(refusal, "not a simulated state machine");
+  });
+
+  it("steps a generated execution name over one a caller has used", async () => {
+    // Given a state machine whose first execution was named execution-1.
+    const simAws = new SimAws();
+    const created = await simAws.stepFunctions().createStateMachine({
+      input: { name: "Enrolment", roleArn, definition: passThrough },
+    });
+    const stateMachineArn = created.stateMachineArn;
+
+    await simAws
+      .stepFunctions()
+      .startExecution({ input: { stateMachineArn, name: "execution-1" } });
+
+    // When an unnamed execution is started.
+    const unnamed = await simAws
+      .stepFunctions()
+      .startExecution({ input: { stateMachineArn } });
+
+    // Then it took the next free name rather than failing on one its caller
+    // never wrote.
+    assertStringIncludes(unnamed.executionArn, ":execution-2");
+  });
+
+  it("tells a missing execution apart from a missing state machine", async () => {
+    // Given a simulated Step Functions holding nothing.
+    const simAws = new SimAws();
+
+    // When each absent resource is asked for.
+    const machine = await assertThrowsErrorAsync(
+      async () =>
+        await simAws
+          .stepFunctions()
+          .describeStateMachine({ input: { stateMachineArn: absentArn } }),
+    );
+    const execution = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.stepFunctions().describeExecution({
+          input: {
+            executionArn:
+              "arn:aws:states:eu-west-2:123456789012:execution:Absent:one",
+          },
+        }),
+    );
+
+    // Then each carries the error name real Step Functions uses.
+    assertIdentical(machine.name, "StateMachineDoesNotExist");
+    assertIdentical(execution.name, "ExecutionDoesNotExist");
+  });
+
+  it("answers DescribeStateMachine with a creationDate a caller cannot move", async () => {
+    // Given a state machine.
+    const simAws = new SimAws();
+    const created = await simAws.stepFunctions().createStateMachine({
+      input: { name: "Enrolment", roleArn, definition: passThrough },
+    });
+
+    // When the date it answered with is moved.
+    created.creationDate.setFullYear(1999);
+
+    const described = await simAws.stepFunctions().describeStateMachine({
+      input: { stateMachineArn: created.stateMachineArn },
+    });
+
+    // Then the state machine kept its own.
+    assertFalse(described.creationDate.getFullYear() === 1999);
+  });
+});

--- a/src/service/stepfunctions/data/sim-states-data-flow.iso.test.ts
+++ b/src/service/stepfunctions/data/sim-states-data-flow.iso.test.ts
@@ -321,3 +321,18 @@ describe("Step Functions state data flow", () => {
     assertStringIncludes(error.message, "not an array");
   });
 });
+
+describe("Step Functions Payload Template collisions", () => {
+  it("refuses a template building the same field twice", () => {
+    // Given a template naming one field plainly and again with .$.
+    // When the effective input is worked out.
+    const error = assertThrowsError(() =>
+      simStatesEffectiveInput(rawInput, {
+        Parameters: { studentId: "fixed", "studentId.$": "$.student.id" },
+      }),
+    );
+
+    // Then it is refused rather than one value silently winning.
+    assertStringIncludes(error.message, "both build studentId");
+  });
+});

--- a/src/service/stepfunctions/data/sim-states-result-path.ts
+++ b/src/service/stepfunctions/data/sim-states-result-path.ts
@@ -99,7 +99,7 @@ function insertIntoArray(
   const copy = [...document];
 
   copy[index] = insertAtSimStatesPath(
-    copy[index] ?? null,
+    copy[index] as JSONValue,
     rest,
     result,
     resultPath,

--- a/src/service/stepfunctions/definition/sim-states-definition-parse.ts
+++ b/src/service/stepfunctions/definition/sim-states-definition-parse.ts
@@ -1,0 +1,91 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { isRecord } from "../../../util/type-guard/record.js";
+import { SimStatesInvalidDefinition } from "../error/sim-step-functions.error.js";
+import type { SimStatesDefinition } from "./sim-states-definition.js";
+import type { SimStatesState } from "./sim-states-state.js";
+import { parseSimStatesState } from "./sim-states-state-parse.js";
+import { checkSimStatesTransitions } from "./sim-states-transitions.js";
+
+/**
+ * Read a state machine definition from the JSON string it was written as.
+ *
+ * A definition using anything this simulator does not run is refused whole,
+ * naming the state and what it used. A state machine missing one state runs
+ * wrong, and running wrong gives a passing test that lies.
+ */
+export function parseSimStatesDefinition(
+  definition: string,
+): SimStatesDefinition {
+  const document = readDocument(definition);
+  const states = readStates(document);
+  const startAt = document["StartAt"];
+
+  if (typeof startAt !== "string") {
+    throw new SimStatesInvalidDefinition(
+      "A state machine definition needs a StartAt naming the state it begins at.",
+    );
+  }
+
+  if (!states.has(startAt)) {
+    throw new SimStatesInvalidDefinition(
+      `StartAt names ${startAt}, which is not one of this state machine's states.`,
+    );
+  }
+
+  checkSimStatesTransitions(states);
+
+  const comment = document["Comment"];
+
+  return {
+    ...(typeof comment === "string" && { Comment: comment }),
+    StartAt: startAt,
+    States: states,
+  };
+}
+
+/**
+ * Read the definition string as the JSON object it has to be.
+ */
+function readDocument(definition: string): Record<string, JSONValue> {
+  let document: JSONValue;
+
+  try {
+    document = JSON.parse(definition) as JSONValue;
+  } catch {
+    throw new SimStatesInvalidDefinition(
+      "The state machine definition is not JSON.",
+    );
+  }
+
+  if (!isRecord(document)) {
+    throw new SimStatesInvalidDefinition(
+      "A state machine definition is a JSON object.",
+    );
+  }
+
+  return document;
+}
+
+/**
+ * Read every state, refusing the ones this simulator has no implementation
+ * for.
+ */
+function readStates(
+  document: Record<string, JSONValue>,
+): ReadonlyMap<string, SimStatesState> {
+  const declared = document["States"];
+
+  if (!isRecord(declared) || Object.keys(declared).length === 0) {
+    throw new SimStatesInvalidDefinition(
+      "A state machine definition needs a States object holding at least one state.",
+    );
+  }
+
+  const states = new Map<string, SimStatesState>();
+
+  for (const [name, state] of Object.entries(declared)) {
+    states.set(name, parseSimStatesState(name, state));
+  }
+
+  return states;
+}

--- a/src/service/stepfunctions/definition/sim-states-definition-refusals.iso.test.ts
+++ b/src/service/stepfunctions/definition/sim-states-definition-refusals.iso.test.ts
@@ -83,4 +83,29 @@ describe("Step Functions definition refusals", () => {
       "ends the execution",
     );
   });
+
+  it("refuses a terminal state carrying an End", () => {
+    // Given a Succeed state that also says it ends.
+    // When it is read, the field it does not have is refused.
+    assertStringIncludes(
+      refusalFor({
+        StartAt: "Only",
+        States: { Only: { Type: "Succeed", End: true } },
+      }),
+      "carries End",
+    );
+  });
+
+  it("refuses an End that is not a boolean", () => {
+    // Given a Pass state whose End is a string.
+    // When it is read, it is refused for what it is rather than for being
+    // absent.
+    assertStringIncludes(
+      refusalFor({
+        StartAt: "Only",
+        States: { Only: { Type: "Pass", End: "true" } },
+      }),
+      "End that is not a boolean",
+    );
+  });
 });

--- a/src/service/stepfunctions/definition/sim-states-definition-refusals.iso.test.ts
+++ b/src/service/stepfunctions/definition/sim-states-definition-refusals.iso.test.ts
@@ -1,0 +1,86 @@
+import { assertStringIncludes, assertThrowsError } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { parseSimStatesDefinition } from "./sim-states-definition-parse.js";
+
+/**
+ * Read a definition that is expected to be refused, and answer with why.
+ */
+function refusalFor(definition: object | string): string {
+  return assertThrowsError(() =>
+    parseSimStatesDefinition(
+      typeof definition === "string" ? definition : JSON.stringify(definition),
+    ),
+  ).message;
+}
+
+describe("Step Functions definition refusals", () => {
+  it("refuses a definition that is not a JSON object", () => {
+    // Given text that will not parse, and JSON that is not an object.
+    // When each is read, each is refused.
+    assertStringIncludes(refusalFor("not json"), "not JSON");
+    assertStringIncludes(refusalFor("[]"), "a JSON object");
+  });
+
+  it("refuses a definition with no states or no StartAt", () => {
+    // Given definitions missing what every state machine needs.
+    // When each is read, each names what is missing.
+    assertStringIncludes(
+      refusalFor({ StartAt: "Only", States: {} }),
+      "at least one state",
+    );
+    assertStringIncludes(
+      refusalFor({ States: { Only: { Type: "Succeed" } } }),
+      "needs a StartAt",
+    );
+  });
+
+  it("refuses a StartAt or a Next naming a state that is not there", () => {
+    // Given transitions pointing at nothing.
+    // When each is read, each names the state it could not find.
+    assertStringIncludes(
+      refusalFor({ StartAt: "Absent", States: { Only: { Type: "Succeed" } } }),
+      "StartAt names Absent",
+    );
+    assertStringIncludes(
+      refusalFor({
+        StartAt: "Only",
+        States: { Only: { Type: "Pass", Next: "Absent" } },
+      }),
+      "moves to Absent",
+    );
+  });
+
+  it("refuses a state that says nothing about what happens after it", () => {
+    // Given a Pass state carrying neither Next nor End, and one carrying both.
+    // When each is read, each is refused.
+    assertStringIncludes(
+      refusalFor({ StartAt: "Only", States: { Only: { Type: "Pass" } } }),
+      "neither Next nor End",
+    );
+    assertStringIncludes(
+      refusalFor({
+        StartAt: "Only",
+        States: {
+          Only: { Type: "Pass", Next: "Other", End: true },
+          Other: { Type: "Succeed" },
+        },
+      }),
+      "both Next and End",
+    );
+  });
+
+  it("refuses a terminal state carrying a Next", () => {
+    // Given a Succeed state that also moves on.
+    // When it is read, the contradiction is refused.
+    assertStringIncludes(
+      refusalFor({
+        StartAt: "Only",
+        States: {
+          Only: { Type: "Succeed", Next: "Other" },
+          Other: { Type: "Succeed" },
+        },
+      }),
+      "ends the execution",
+    );
+  });
+});

--- a/src/service/stepfunctions/definition/sim-states-definition.ts
+++ b/src/service/stepfunctions/definition/sim-states-definition.ts
@@ -1,0 +1,15 @@
+import type { SimStatesState } from "./sim-states-state.js";
+
+/**
+ * One state machine's Amazon States Language definition, after it has been
+ * read and checked.
+ *
+ * A definition is checked once, when the state machine is created. An
+ * execution walks a definition it can rely on, which keeps the state types
+ * out of the interpreter's error handling.
+ */
+export interface SimStatesDefinition {
+  readonly Comment?: string;
+  readonly StartAt: string;
+  readonly States: ReadonlyMap<string, SimStatesState>;
+}

--- a/src/service/stepfunctions/definition/sim-states-state-parse.ts
+++ b/src/service/stepfunctions/definition/sim-states-state-parse.ts
@@ -52,6 +52,7 @@ export function parseSimStatesState(
   }
 
   checkRefusedFields(name, type, state);
+  checkTransitionFields(name, state);
 
   return state as unknown as SimStatesState;
 }
@@ -74,6 +75,35 @@ function checkRefusedFields(
     throw new SimStatesInvalidDefinition(
       `The ${type} state ${name} carries ${present.join(", ")}, which a ` +
         `${type} state does not have.`,
+    );
+  }
+}
+
+/**
+ * Check the two fields that say what happens after a state.
+ *
+ * This runs on the state as it was written, before it is read as one of the
+ * state types. Once it has been, `End` is a boolean as far as the compiler is
+ * concerned, and a definition carrying `"true"` would be taken at its word.
+ */
+function checkTransitionFields(
+  name: string,
+  state: Record<string, JSONValue>,
+): void {
+  const end = state["End"];
+
+  if (end !== undefined && typeof end !== "boolean") {
+    throw new SimStatesInvalidDefinition(
+      `The state ${name} has an End that is not a boolean. Only true ends an ` +
+        "execution there.",
+    );
+  }
+
+  const next = state["Next"];
+
+  if (next !== undefined && typeof next !== "string") {
+    throw new SimStatesInvalidDefinition(
+      `The state ${name} has a Next that is not a state name.`,
     );
   }
 }

--- a/src/service/stepfunctions/definition/sim-states-state-parse.ts
+++ b/src/service/stepfunctions/definition/sim-states-state-parse.ts
@@ -1,0 +1,79 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { isRecord } from "../../../util/type-guard/record.js";
+import {
+  SimStatesInvalidDefinition,
+  SimStatesUnsimulatedInput,
+} from "../error/sim-step-functions.error.js";
+import {
+  type SimStatesState,
+  simStatesRunnableTypes,
+  simStatesStateTypes,
+} from "./sim-states-state.js";
+
+// Real Step Functions gives a Fail state no input or output processing at all,
+// and gives a Succeed state only the two paths.
+const stateFieldsRefused = new Map<string, readonly string[]>([
+  [
+    "Fail",
+    ["InputPath", "OutputPath", "Parameters", "ResultPath", "ResultSelector"],
+  ],
+  ["Succeed", ["Parameters", "ResultPath", "ResultSelector"]],
+]);
+
+/**
+ * Check one state's type, and the fields that type is allowed.
+ */
+export function parseSimStatesState(
+  name: string,
+  state: JSONValue,
+): SimStatesState {
+  if (!isRecord(state)) {
+    throw new SimStatesInvalidDefinition(`The state ${name} is not an object.`);
+  }
+
+  const type = state["Type"];
+
+  if (typeof type !== "string") {
+    throw new SimStatesInvalidDefinition(`The state ${name} has no Type.`);
+  }
+
+  if (!simStatesStateTypes.includes(type as never)) {
+    throw new SimStatesInvalidDefinition(
+      `The state ${name} has a Type of ${type}, which Amazon States Language ` +
+        "does not define.",
+    );
+  }
+
+  if (!simStatesRunnableTypes.includes(type as never)) {
+    throw new SimStatesUnsimulatedInput(
+      `The state ${name} is a ${type} state, which this simulator does not ` +
+        `run yet. It runs ${simStatesRunnableTypes.join(", ")}.`,
+    );
+  }
+
+  checkRefusedFields(name, type, state);
+
+  return state as unknown as SimStatesState;
+}
+
+/**
+ * Refuse the fields a state's type does not have.
+ *
+ * A definition carrying one of these would behave differently here than it
+ * does on AWS, where the field is simply not part of the state.
+ */
+function checkRefusedFields(
+  name: string,
+  type: string,
+  state: Record<string, JSONValue>,
+): void {
+  const refused = stateFieldsRefused.get(type) ?? [];
+  const present = refused.filter((field) => Object.hasOwn(state, field));
+
+  if (present.length > 0) {
+    throw new SimStatesInvalidDefinition(
+      `The ${type} state ${name} carries ${present.join(", ")}, which a ` +
+        `${type} state does not have.`,
+    );
+  }
+}

--- a/src/service/stepfunctions/definition/sim-states-state-refusals.iso.test.ts
+++ b/src/service/stepfunctions/definition/sim-states-state-refusals.iso.test.ts
@@ -1,0 +1,72 @@
+import { assertStringIncludes, assertThrowsError } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { parseSimStatesDefinition } from "./sim-states-definition-parse.js";
+
+/**
+ * Read a definition that is expected to be refused, and answer with why.
+ */
+function refusalFor(definition: object | string): string {
+  return assertThrowsError(() =>
+    parseSimStatesDefinition(
+      typeof definition === "string" ? definition : JSON.stringify(definition),
+    ),
+  ).message;
+}
+
+describe("Step Functions state refusals", () => {
+  it("refuses a state with no Type, a Type that is not an object", () => {
+    // Given malformed states.
+    // When each is read, each is refused.
+    assertStringIncludes(
+      refusalFor({ StartAt: "Only", States: { Only: {} } }),
+      "has no Type",
+    );
+    assertStringIncludes(
+      refusalFor({ StartAt: "Only", States: { Only: "Pass" } }),
+      "is not an object",
+    );
+  });
+
+  it("refuses a Type Amazon States Language does not define", () => {
+    // Given a state type that does not exist.
+    // When it is read, it is told apart from one that is merely unsimulated.
+    assertStringIncludes(
+      refusalFor({ StartAt: "Only", States: { Only: { Type: "Wander" } } }),
+      "does not define",
+    );
+  });
+
+  it("refuses a state type this simulator does not run yet, by name", () => {
+    // Given the state types still to come.
+    // When each is read, each names itself and what does run.
+    for (const type of ["Task", "Choice", "Wait", "Parallel", "Map"]) {
+      const refusal = refusalFor({
+        StartAt: "Only",
+        States: { Only: { Type: type, End: true } },
+      });
+
+      assertStringIncludes(refusal, `is a ${type} state`);
+      assertStringIncludes(refusal, "Pass, Succeed, Fail");
+    }
+  });
+
+  it("refuses the fields a Fail or a Succeed state does not have", () => {
+    // Given data-flow fields on states that have no input or output
+    // processing.
+    // When each is read, each names the field and the type.
+    assertStringIncludes(
+      refusalFor({
+        StartAt: "Only",
+        States: { Only: { Type: "Fail", InputPath: "$.student" } },
+      }),
+      "The Fail state Only carries InputPath",
+    );
+    assertStringIncludes(
+      refusalFor({
+        StartAt: "Only",
+        States: { Only: { Type: "Succeed", ResultPath: "$.check" } },
+      }),
+      "The Succeed state Only carries ResultPath",
+    );
+  });
+});

--- a/src/service/stepfunctions/definition/sim-states-state.ts
+++ b/src/service/stepfunctions/definition/sim-states-state.ts
@@ -1,0 +1,77 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import type { SimStatesDataFlowFields } from "../data/sim-states-data-flow.js";
+
+/**
+ * Every state type Amazon States Language defines.
+ *
+ * The ones this simulator has no implementation for are named here so a
+ * definition using one can be refused by its own name.
+ */
+export const simStatesStateTypes = [
+  "Pass",
+  "Succeed",
+  "Fail",
+  "Task",
+  "Choice",
+  "Wait",
+  "Parallel",
+  "Map",
+] as const;
+
+export type SimStatesStateType = (typeof simStatesStateTypes)[number];
+
+/**
+ * The state types this simulator runs.
+ */
+export const simStatesRunnableTypes = ["Pass", "Succeed", "Fail"] as const;
+
+export type SimStatesRunnableType = (typeof simStatesRunnableTypes)[number];
+
+/**
+ * What every state carries, whatever its type.
+ */
+interface SimStatesCommonState extends SimStatesDataFlowFields {
+  readonly Comment?: string;
+  readonly Next?: string;
+  readonly End?: boolean;
+}
+
+/**
+ * A `Pass` state, which produces a result without doing any work.
+ */
+export interface SimStatesPassState extends SimStatesCommonState {
+  readonly Type: "Pass";
+  readonly Result?: JSONValue;
+}
+
+/**
+ * A `Succeed` state, which ends an execution successfully.
+ */
+export interface SimStatesSucceedState extends SimStatesCommonState {
+  readonly Type: "Succeed";
+}
+
+/**
+ * A `Fail` state, which ends an execution with an error.
+ *
+ * Real Step Functions gives `Fail` no input or output processing, so the
+ * data-flow fields on it are refused when the definition is read.
+ */
+export interface SimStatesFailState {
+  readonly Type: "Fail";
+  readonly Comment?: string;
+  readonly Error?: string;
+  readonly Cause?: string;
+}
+
+export type SimStatesState =
+  | SimStatesPassState
+  | SimStatesSucceedState
+  | SimStatesFailState;
+
+/**
+ * Whether a state ends the execution when it is reached.
+ */
+export function isSimStatesTerminal(state: SimStatesState): boolean {
+  return state.Type === "Succeed" || state.Type === "Fail";
+}

--- a/src/service/stepfunctions/definition/sim-states-transitions.ts
+++ b/src/service/stepfunctions/definition/sim-states-transitions.ts
@@ -25,14 +25,16 @@ export function checkSimStatesTransitions(
 }
 
 /**
- * A terminal state ends the execution, so it names nothing to go to.
+ * A terminal state ends the execution, so it carries neither field.
  */
 function checkTerminal(name: string, state: SimStatesState): void {
-  if ("Next" in state) {
-    throw new SimStatesInvalidDefinition(
-      `The ${state.Type} state ${name} carries a Next. A ${state.Type} state ` +
-        "ends the execution.",
-    );
+  for (const field of ["Next", "End"]) {
+    if (Object.hasOwn(state, field)) {
+      throw new SimStatesInvalidDefinition(
+        `The ${state.Type} state ${name} carries ${field}. A ${state.Type} ` +
+          "state ends the execution and carries neither.",
+      );
+    }
   }
 }
 
@@ -45,6 +47,8 @@ function checkTransition(
   states: ReadonlyMap<string, SimStatesState>,
 ): void {
   const next = "Next" in state ? state.Next : undefined;
+  // `End` is already known to be a boolean: the state was checked as it was
+  // read, before it was taken as one of the state types.
   const ends = "End" in state && state.End;
 
   if (next === undefined && !ends) {

--- a/src/service/stepfunctions/definition/sim-states-transitions.ts
+++ b/src/service/stepfunctions/definition/sim-states-transitions.ts
@@ -1,0 +1,69 @@
+import { SimStatesInvalidDefinition } from "../error/sim-step-functions.error.js";
+import {
+  type SimStatesState,
+  isSimStatesTerminal,
+} from "./sim-states-state.js";
+
+/**
+ * Check that every state either ends the execution or moves to one that
+ * exists.
+ *
+ * A `Next` naming a state that is not there is a definition fault rather than
+ * a runtime one, and real Step Functions refuses it at creation too.
+ */
+export function checkSimStatesTransitions(
+  states: ReadonlyMap<string, SimStatesState>,
+): void {
+  for (const [name, state] of states) {
+    if (isSimStatesTerminal(state)) {
+      checkTerminal(name, state);
+      continue;
+    }
+
+    checkTransition(name, state, states);
+  }
+}
+
+/**
+ * A terminal state ends the execution, so it names nothing to go to.
+ */
+function checkTerminal(name: string, state: SimStatesState): void {
+  if ("Next" in state) {
+    throw new SimStatesInvalidDefinition(
+      `The ${state.Type} state ${name} carries a Next. A ${state.Type} state ` +
+        "ends the execution.",
+    );
+  }
+}
+
+/**
+ * Every other state moves on, by Next or by ending the execution itself.
+ */
+function checkTransition(
+  name: string,
+  state: SimStatesState,
+  states: ReadonlyMap<string, SimStatesState>,
+): void {
+  const next = "Next" in state ? state.Next : undefined;
+  const ends = "End" in state && state.End;
+
+  if (next === undefined && !ends) {
+    throw new SimStatesInvalidDefinition(
+      `The state ${name} carries neither Next nor End, so nothing says what ` +
+        "happens after it.",
+    );
+  }
+
+  if (next !== undefined && ends) {
+    throw new SimStatesInvalidDefinition(
+      `The state ${name} carries both Next and End.`,
+    );
+  }
+
+  if (next !== undefined && !states.has(next)) {
+    throw new SimStatesInvalidDefinition(
+      `The state ${name} moves to ${next}, which is not one of this state ` +
+        "machine's states.",
+    );
+  }
+}

--- a/src/service/stepfunctions/error/sim-step-functions.error.ts
+++ b/src/service/stepfunctions/error/sim-step-functions.error.ts
@@ -66,6 +66,21 @@ export class SimStatesIntrinsicFailure extends SimStepFunctionsError {
 }
 
 /**
+ * A state machine definition that Amazon States Language itself refuses.
+ *
+ * A malformed definition, a state type that does not exist, a transition to a
+ * state that is not there. Real Step Functions rejects each of these when the
+ * state machine is created, and so does this.
+ */
+export class SimStatesInvalidDefinition extends SimStepFunctionsError {
+  public override readonly name = "InvalidDefinition";
+
+  constructor(message: string) {
+    super(message, "States.QueryEvaluationError");
+  }
+}
+
+/**
  * An Amazon States Language construct this simulator does not run.
  *
  * Raised when a state machine is read rather than when a state runs. A
@@ -78,5 +93,49 @@ export class SimStatesUnsimulatedInput extends SimStepFunctionsError {
 
   constructor(message: string) {
     super(message, "States.QueryEvaluationError");
+  }
+}
+
+/**
+ * A state machine or an execution an ARN names nothing for.
+ */
+export class SimStatesResourceNotFound extends SimStepFunctionsError {
+  public override readonly name = "StateMachineDoesNotExist";
+
+  constructor(message: string) {
+    super(message, "States.Runtime");
+  }
+}
+
+/**
+ * A state machine of that name is already there.
+ */
+export class SimStateMachineAlreadyExists extends SimStepFunctionsError {
+  public override readonly name = "StateMachineAlreadyExists";
+
+  constructor(message: string) {
+    super(message, "States.Runtime");
+  }
+}
+
+/**
+ * An execution of that name has already been started.
+ */
+export class SimStatesExecutionAlreadyExists extends SimStepFunctionsError {
+  public override readonly name = "ExecutionAlreadyExists";
+
+  constructor(message: string) {
+    super(message, "States.Runtime");
+  }
+}
+
+/**
+ * A request whose own input is wrong, before anything is looked up.
+ */
+export class SimStatesInvalidRequest extends SimStepFunctionsError {
+  public override readonly name = "InvalidArn";
+
+  constructor(message: string) {
+    super(message, "States.Runtime");
   }
 }

--- a/src/service/stepfunctions/error/sim-step-functions.error.ts
+++ b/src/service/stepfunctions/error/sim-step-functions.error.ts
@@ -97,10 +97,35 @@ export class SimStatesUnsimulatedInput extends SimStepFunctionsError {
 }
 
 /**
- * A state machine or an execution an ARN names nothing for.
+ * A state machine an ARN names nothing for.
  */
 export class SimStatesResourceNotFound extends SimStepFunctionsError {
   public override readonly name = "StateMachineDoesNotExist";
+
+  constructor(message: string) {
+    super(message, "States.Runtime");
+  }
+}
+
+/**
+ * An execution an ARN names nothing for.
+ *
+ * Real Step Functions tells this apart from a missing state machine, and a
+ * caller branching on the error name needs the same two names.
+ */
+export class SimStatesExecutionNotFound extends SimStepFunctionsError {
+  public override readonly name = "ExecutionDoesNotExist";
+
+  constructor(message: string) {
+    super(message, "States.Runtime");
+  }
+}
+
+/**
+ * A name outside what Step Functions allows.
+ */
+export class SimStatesInvalidName extends SimStepFunctionsError {
+  public override readonly name = "InvalidName";
 
   constructor(message: string) {
     super(message, "States.Runtime");

--- a/src/service/stepfunctions/execution/sim-states-execution-store.ts
+++ b/src/service/stepfunctions/execution/sim-states-execution-store.ts
@@ -1,0 +1,58 @@
+import type { SimStatesExecution } from "./sim-states-execution.js";
+
+/**
+ * The executions one simulated Step Functions holds, by ARN.
+ *
+ * Executions are kept after they end. `DescribeExecution` answers for a
+ * finished one, and real Step Functions keeps a standard execution's history
+ * for 90 days.
+ */
+export class SimStatesExecutionStore {
+  readonly #byArn = new Map<string, SimStatesExecution>();
+
+  add(execution: SimStatesExecution): void {
+    this.#byArn.set(execution.arn, execution);
+  }
+
+  find(arn: string): SimStatesExecution | undefined {
+    return this.#byArn.get(arn);
+  }
+
+  /**
+   * Every execution of one state machine, most recently started first.
+   */
+  forStateMachine(stateMachineArn: string): readonly SimStatesExecution[] {
+    return this.#byArn
+      .values()
+      .filter((execution) => execution.stateMachineArn === stateMachineArn)
+      .toArray()
+      .toReversed();
+  }
+
+  /**
+   * Whether one state machine already has an execution of this name.
+   *
+   * Real Step Functions refuses a second execution of the same name within 90
+   * days, which is what makes a name usable for idempotency.
+   */
+  hasName(stateMachineArn: string, name: string): boolean {
+    return this.#byArn
+      .values()
+      .some(
+        (execution) =>
+          execution.stateMachineArn === stateMachineArn &&
+          execution.name === name,
+      );
+  }
+
+  /**
+   * Forget every execution of one state machine.
+   */
+  removeForStateMachine(stateMachineArn: string): void {
+    for (const [arn, execution] of this.#byArn) {
+      if (execution.stateMachineArn === stateMachineArn) {
+        this.#byArn.delete(arn);
+      }
+    }
+  }
+}

--- a/src/service/stepfunctions/execution/sim-states-execution.ts
+++ b/src/service/stepfunctions/execution/sim-states-execution.ts
@@ -1,0 +1,104 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+
+export type SimStatesExecutionStatus =
+  | "RUNNING"
+  | "SUCCEEDED"
+  | "FAILED"
+  | "TIMED_OUT"
+  | "ABORTED";
+
+interface SimStatesExecutionProperties {
+  readonly arn: string;
+  readonly name: string;
+  readonly stateMachineArn: string;
+  readonly input: JSONValue;
+  readonly startDate: Date;
+}
+
+/**
+ * One run of a state machine.
+ *
+ * An execution holds what it has done as well as where it got to, because the
+ * states it visited are what a test asserts on. Real Step Functions keeps the
+ * same record and answers it through `GetExecutionHistory`.
+ */
+export class SimStatesExecution {
+  readonly arn: string;
+  readonly name: string;
+  readonly stateMachineArn: string;
+  readonly input: JSONValue;
+  readonly startDate: Date;
+
+  #status: SimStatesExecutionStatus = "RUNNING";
+  #output: JSONValue | undefined;
+  #error: string | undefined;
+  #cause: string | undefined;
+  #stopDate: Date | undefined;
+  readonly #visited: string[] = [];
+
+  constructor(properties: SimStatesExecutionProperties) {
+    this.arn = properties.arn;
+    this.name = properties.name;
+    this.stateMachineArn = properties.stateMachineArn;
+    this.input = properties.input;
+    this.startDate = properties.startDate;
+  }
+
+  get status(): SimStatesExecutionStatus {
+    return this.#status;
+  }
+
+  get output(): JSONValue | undefined {
+    return this.#output;
+  }
+
+  get error(): string | undefined {
+    return this.#error;
+  }
+
+  get cause(): string | undefined {
+    return this.#cause;
+  }
+
+  get stopDate(): Date | undefined {
+    return this.#stopDate;
+  }
+
+  /**
+   * The states this execution has entered, in the order it entered them.
+   */
+  get visitedStates(): readonly string[] {
+    return [...this.#visited];
+  }
+
+  /**
+   * Record that the execution has entered a state.
+   */
+  enter(stateName: string): void {
+    this.#visited.push(stateName);
+  }
+
+  /**
+   * End the execution with the value its last state produced.
+   */
+  succeed(output: JSONValue, at: Date): void {
+    this.#status = "SUCCEEDED";
+    this.#output = output;
+    this.#stopDate = at;
+  }
+
+  /**
+   * End the execution with the error that stopped it.
+   *
+   * Nothing is thrown from here. An execution failing is as often the thing a
+   * test is asserting on as it is a fault, and advancing the clock past a
+   * failure elsewhere in the same test would otherwise raise from that
+   * caller's `advanceBy`.
+   */
+  fail(error: string, cause: string | undefined, at: Date): void {
+    this.#status = "FAILED";
+    this.#error = error;
+    this.#cause = cause;
+    this.#stopDate = at;
+  }
+}

--- a/src/service/stepfunctions/execution/sim-states-interpreter.iso.test.ts
+++ b/src/service/stepfunctions/execution/sim-states-interpreter.iso.test.ts
@@ -73,7 +73,7 @@ describe("Step Functions interpreter guards", () => {
       Type: "Pass",
       End: true,
       get Result(): never {
-        // eslint-disable-next-line no-throw-literal
+        // oxlint-disable-next-line typescript/only-throw-error
         throw "a bare string" as unknown as Error;
       },
     } as unknown as SimStatesState;
@@ -86,5 +86,22 @@ describe("Step Functions interpreter guards", () => {
 
     // Then the value is read as the cause.
     assertIdentical(execution.cause, "a bare string");
+  });
+
+  it("stops an execution whose states form a cycle", async () => {
+    // Given two states pointing at each other, which Amazon States Language
+    // allows and the parser cannot refuse.
+    const states = new Map<string, SimStatesState>([
+      ["A", { Type: "Pass", Next: "B" }],
+      ["B", { Type: "Pass", Next: "A" }],
+    ]);
+
+    // When it runs.
+    const execution = await runDefinition({ StartAt: "A", States: states });
+
+    // Then the walk stopped instead of never answering.
+    assertIdentical(execution.status, "FAILED");
+    assertIdentical(execution.error, "States.Runtime");
+    assertStringIncludes(execution.cause ?? "", "form a cycle");
   });
 });

--- a/src/service/stepfunctions/execution/sim-states-interpreter.iso.test.ts
+++ b/src/service/stepfunctions/execution/sim-states-interpreter.iso.test.ts
@@ -1,0 +1,90 @@
+import { assertIdentical, assertStringIncludes } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { BackgroundTasks } from "../../../util/background/background.js";
+import type { SimStatesDefinition } from "../definition/sim-states-definition.js";
+import type { SimStatesState } from "../definition/sim-states-state.js";
+import { SimStatesExecution } from "./sim-states-execution.js";
+import { SimStatesInterpreter } from "./sim-states-interpreter.js";
+
+/**
+ * Run a definition the parser would never have let through, to reach the
+ * interpreter's own guards.
+ */
+async function runDefinition(
+  definition: SimStatesDefinition,
+): Promise<SimStatesExecution> {
+  const background = new BackgroundTasks();
+  const execution = new SimStatesExecution({
+    arn: "arn:aws:states:eu-west-2:123456789012:execution:Enrolment:one",
+    name: "one",
+    stateMachineArn:
+      "arn:aws:states:eu-west-2:123456789012:stateMachine:Enrolment",
+    input: {},
+    startDate: background.now(),
+  });
+
+  await new SimStatesInterpreter({ definition, execution, background }).run();
+
+  return execution;
+}
+
+describe("Step Functions interpreter guards", () => {
+  it("fails an execution moving to a state that is not there", async () => {
+    // Given a definition whose transition names nothing, which the parser
+    // refuses and a hand-built definition can still carry.
+    const states = new Map<string, SimStatesState>([
+      ["Only", { Type: "Pass", Next: "Absent" }],
+    ]);
+
+    // When it runs.
+    const execution = await runDefinition({ StartAt: "Only", States: states });
+
+    // Then the execution failed rather than the walk raising.
+    assertIdentical(execution.status, "FAILED");
+    assertIdentical(execution.error, "States.Runtime");
+    assertStringIncludes(execution.cause ?? "", "Absent");
+  });
+
+  it("fails an execution on an error that carries no states error name", async () => {
+    // Given a Pass state whose Result getter raises something ordinary.
+    const raising = {
+      Type: "Pass",
+      End: true,
+      get Result(): never {
+        throw new Error("the definition was tampered with");
+      },
+    } as unknown as SimStatesState;
+
+    // When it runs.
+    const execution = await runDefinition({
+      StartAt: "Only",
+      States: new Map([["Only", raising]]),
+    });
+
+    // Then it is reported as a runtime failure carrying the message.
+    assertIdentical(execution.status, "FAILED");
+    assertIdentical(execution.error, "States.Runtime");
+    assertStringIncludes(execution.cause ?? "", "tampered with");
+  });
+
+  it("fails an execution on something raised that is not an Error", async () => {
+    // Given a state raising a bare value.
+    const raising = {
+      Type: "Pass",
+      End: true,
+      get Result(): never {
+        // eslint-disable-next-line no-throw-literal
+        throw "a bare string" as unknown as Error;
+      },
+    } as unknown as SimStatesState;
+
+    // When it runs.
+    const execution = await runDefinition({
+      StartAt: "Only",
+      States: new Map([["Only", raising]]),
+    });
+
+    // Then the value is read as the cause.
+    assertIdentical(execution.cause, "a bare string");
+  });
+});

--- a/src/service/stepfunctions/execution/sim-states-interpreter.ts
+++ b/src/service/stepfunctions/execution/sim-states-interpreter.ts
@@ -5,6 +5,17 @@ import { SimStepFunctionsError } from "../error/sim-step-functions.error.js";
 import type { SimStatesExecution } from "./sim-states-execution.js";
 import { runSimStatesState } from "./sim-states-run-state.js";
 
+/**
+ * How many state transitions one execution may make.
+ *
+ * Amazon States Language allows a cycle, so a definition can be valid and
+ * still never reach a terminal state. Real Step Functions stops such an
+ * execution when it runs out of execution history events, and this stands in
+ * for that limit. Without it the walk never returns and `StartExecution` never
+ * answers, which is the one failure a test tool must not have.
+ */
+const maximumTransitions = 25_000;
+
 interface SimStatesInterpreterProperties {
   readonly definition: SimStatesDefinition;
   readonly execution: SimStatesExecution;
@@ -40,7 +51,16 @@ export class SimStatesInterpreter {
     let current = this.#definition.StartAt;
     let value: JSONValue = this.#execution.input;
 
-    for (;;) {
+    for (let taken = 0; ; taken++) {
+      if (taken >= maximumTransitions) {
+        this.#fail(
+          "States.Runtime",
+          `The execution made ${String(maximumTransitions)} transitions ` +
+            "without reaching a terminal state. Its states form a cycle.",
+        );
+        return;
+      }
+
       const state = this.#definition.States.get(current);
 
       if (state === undefined) {

--- a/src/service/stepfunctions/execution/sim-states-interpreter.ts
+++ b/src/service/stepfunctions/execution/sim-states-interpreter.ts
@@ -1,0 +1,116 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import type { SimStatesDefinition } from "../definition/sim-states-definition.js";
+import { SimStepFunctionsError } from "../error/sim-step-functions.error.js";
+import type { SimStatesExecution } from "./sim-states-execution.js";
+import { runSimStatesState } from "./sim-states-run-state.js";
+
+interface SimStatesInterpreterProperties {
+  readonly definition: SimStatesDefinition;
+  readonly execution: SimStatesExecution;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * Walks one execution through its state machine.
+ *
+ * The walk is a loop over a map of states, which is all Amazon States Language
+ * asks for. Everything interesting happens either side of a state, in the
+ * data-flow fields.
+ */
+export class SimStatesInterpreter {
+  readonly #definition: SimStatesDefinition;
+  readonly #execution: SimStatesExecution;
+  readonly #background: BackgroundScheduler;
+
+  constructor(properties: SimStatesInterpreterProperties) {
+    this.#definition = properties.definition;
+    this.#execution = properties.execution;
+    this.#background = properties.background;
+  }
+
+  /**
+   * Run the execution to whichever end it reaches.
+   *
+   * A failure ends the execution and is recorded on it. Nothing raises out of
+   * here, since this runs where a caller advancing the clock would otherwise
+   * see the raise.
+   */
+  async run(): Promise<void> {
+    let current = this.#definition.StartAt;
+    let value: JSONValue = this.#execution.input;
+
+    for (;;) {
+      const state = this.#definition.States.get(current);
+
+      if (state === undefined) {
+        this.#fail(
+          "States.Runtime",
+          `The state ${current} is not one of this state machine's states.`,
+        );
+        return;
+      }
+
+      this.#execution.enter(current);
+      // One sequencing point per state. The states are a chain, so there is
+      // nothing here to run in parallel.
+      // oxlint-disable-next-line eslint/no-await-in-loop
+      await this.#background.sequence();
+
+      const outcome = this.#step(state, value);
+
+      if (outcome.kind !== "next") {
+        return;
+      }
+
+      value = outcome.output;
+      current = outcome.next;
+    }
+  }
+
+  /**
+   * Run one state, recording whatever ends the execution.
+   */
+  #step(
+    ...step: Parameters<typeof runSimStatesState>
+  ): ReturnType<typeof runSimStatesState> {
+    let outcome: ReturnType<typeof runSimStatesState>;
+
+    try {
+      outcome = runSimStatesState(...step);
+    } catch (error) {
+      outcome = this.#outcomeFrom(error);
+    }
+
+    if (outcome.kind === "succeed") {
+      this.#execution.succeed(outcome.output, this.#background.now());
+    } else if (outcome.kind === "fail") {
+      this.#fail(outcome.error, outcome.cause);
+    }
+
+    return outcome;
+  }
+
+  /**
+   * Read the Amazon States Language error name off whatever was raised.
+   */
+  #outcomeFrom(error: unknown): ReturnType<typeof runSimStatesState> {
+    if (error instanceof SimStepFunctionsError) {
+      return {
+        kind: "fail",
+        error: error.statesErrorName,
+        cause: error.message,
+      };
+    }
+
+    return {
+      kind: "fail",
+      error: "States.Runtime",
+      cause: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  #fail(error: string, cause: string | undefined): void {
+    this.#execution.fail(error, cause, this.#background.now());
+  }
+}

--- a/src/service/stepfunctions/execution/sim-states-run-state.ts
+++ b/src/service/stepfunctions/execution/sim-states-run-state.ts
@@ -1,0 +1,91 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import {
+  simStatesEffectiveInput,
+  simStatesEffectiveOutput,
+} from "../data/sim-states-data-flow.js";
+import type {
+  SimStatesFailState,
+  SimStatesPassState,
+  SimStatesState,
+  SimStatesSucceedState,
+} from "../definition/sim-states-state.js";
+
+/**
+ * The default a `Fail` state reports when it names no error.
+ */
+const unnamedFailError = "States.Unknown";
+
+/**
+ * What running one state did to the execution.
+ */
+export type SimStatesStateOutcome =
+  | { readonly kind: "next"; readonly output: JSONValue; readonly next: string }
+  | { readonly kind: "succeed"; readonly output: JSONValue }
+  | {
+      readonly kind: "fail";
+      readonly error: string;
+      readonly cause: string | undefined;
+    };
+
+/**
+ * Run one state and say what happened.
+ *
+ * A data-flow field raising is left to the caller, which reads the Amazon
+ * States Language error name off whatever came out.
+ */
+export function runSimStatesState(
+  state: SimStatesState,
+  input: JSONValue,
+): SimStatesStateOutcome {
+  if (state.Type === "Fail") {
+    return runFail(state);
+  }
+
+  if (state.Type === "Succeed") {
+    return runSucceed(state, input);
+  }
+
+  return runPass(state, input);
+}
+
+/**
+ * A `Pass` state, whose result is its `Result` or its effective input.
+ */
+function runPass(
+  state: SimStatesPassState,
+  input: JSONValue,
+): SimStatesStateOutcome {
+  const effective = simStatesEffectiveInput(input, state);
+  const result = state.Result === undefined ? effective : state.Result;
+  const output = simStatesEffectiveOutput(input, result, state);
+
+  return state.Next === undefined
+    ? { kind: "succeed", output }
+    : { kind: "next", output, next: state.Next };
+}
+
+/**
+ * A `Succeed` state, which ends the execution with what reaches it.
+ */
+function runSucceed(
+  state: SimStatesSucceedState,
+  input: JSONValue,
+): SimStatesStateOutcome {
+  const effective = simStatesEffectiveInput(input, state);
+
+  return {
+    kind: "succeed",
+    output: simStatesEffectiveOutput(effective, effective, state),
+  };
+}
+
+/**
+ * A `Fail` state, which ends the execution with the error it names.
+ */
+function runFail(state: SimStatesFailState): SimStatesStateOutcome {
+  return {
+    kind: "fail",
+    error: state.Error ?? unnamedFailError,
+    cause: state.Cause,
+  };
+}

--- a/src/service/stepfunctions/index.ts
+++ b/src/service/stepfunctions/index.ts
@@ -1,0 +1,36 @@
+export { SimStepFunctions } from "./sim-step-functions.js";
+export { SimStepFunctionsInspection } from "./sim-step-functions-inspection.js";
+export type { SimStepFunctionsRequestOptions } from "./command/sim-step-functions-request-options.js";
+export type * from "./command/sim-step-functions-command.types.js";
+export { SimStateMachine } from "./machine/sim-state-machine.js";
+export type { SimStateMachineType } from "./machine/sim-state-machine.js";
+export {
+  parseSimStateMachineArn,
+  simStateMachineArn,
+  simStatesExecutionArn,
+} from "./machine/sim-state-machine-arn.js";
+export type { SimStateMachineLocation } from "./machine/sim-state-machine-arn.js";
+export { SimStatesExecution } from "./execution/sim-states-execution.js";
+export type { SimStatesExecutionStatus } from "./execution/sim-states-execution.js";
+export type { SimStatesDefinition } from "./definition/sim-states-definition.js";
+export {
+  simStatesRunnableTypes,
+  simStatesStateTypes,
+} from "./definition/sim-states-state.js";
+export type {
+  SimStatesState,
+  SimStatesStateType,
+} from "./definition/sim-states-state.js";
+export {
+  SimStateMachineAlreadyExists,
+  SimStatesExecutionAlreadyExists,
+  SimStatesIntrinsicFailure,
+  SimStatesInvalidDefinition,
+  SimStatesInvalidRequest,
+  SimStatesPathError,
+  SimStatesPathMatchFailure,
+  SimStatesResourceNotFound,
+  SimStatesResultPathMatchFailure,
+  SimStatesUnsimulatedInput,
+  SimStepFunctionsError,
+} from "./error/sim-step-functions.error.js";

--- a/src/service/stepfunctions/machine/sim-state-machine-arn.iso.test.ts
+++ b/src/service/stepfunctions/machine/sim-state-machine-arn.iso.test.ts
@@ -1,0 +1,68 @@
+import {
+  assertIdentical,
+  assertObjectEquals,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  parseSimStateMachineArn,
+  simStateMachineArn,
+  simStatesExecutionArn,
+} from "./sim-state-machine-arn.js";
+
+const scope = {
+  regionName: "eu-west-2",
+  accountId: "123456789012",
+} as Parameters<typeof simStateMachineArn>[0];
+
+describe("Step Functions ARNs", () => {
+  it("builds a state machine ARN and reads it back", () => {
+    // Given a scope and a name.
+    // When an ARN is built and parsed.
+    const arn = simStateMachineArn(scope, "Enrolment");
+    const parsed = parseSimStateMachineArn(arn);
+
+    // Then it carries the Region, Account and name.
+    assertIdentical(
+      arn,
+      "arn:aws:states:eu-west-2:123456789012:stateMachine:Enrolment",
+    );
+    assertObjectEquals(parsed, {
+      regionName: "eu-west-2",
+      accountId: "123456789012",
+      name: "Enrolment",
+    });
+  });
+
+  it("separates an execution ARN's parts with colons", () => {
+    // Given a state machine name and an execution name.
+    // When the execution ARN is built.
+    const arn = simStatesExecutionArn(scope, "Enrolment", "one");
+
+    // Then both names are colon-separated parts, as real Step Functions writes
+    // them.
+    assertIdentical(
+      arn,
+      "arn:aws:states:eu-west-2:123456789012:execution:Enrolment:one",
+    );
+  });
+
+  it("reads nothing from a string that is not a state machine ARN", () => {
+    // Given strings that are not one.
+    const refused = [
+      "not-an-arn",
+      "arn:aws:states:eu-west-2:123456789012:execution:Enrolment:one",
+      "arn:aws:lambda:eu-west-2:123456789012:stateMachine:Enrolment",
+      "arn:aws-cn:states:eu-west-2:123456789012:stateMachine:Enrolment",
+      "arn:aws:states::123456789012:stateMachine:Enrolment",
+      "arn:aws:states:eu-west-2::stateMachine:Enrolment",
+      "arn:aws:states:eu-west-2:123456789012:stateMachine:",
+      "not:aws:states:eu-west-2:123456789012:stateMachine:Enrolment",
+    ];
+
+    // When each is parsed, nothing is read from any of them.
+    for (const value of refused) {
+      assertUndefined(parseSimStateMachineArn(value));
+    }
+  });
+});

--- a/src/service/stepfunctions/machine/sim-state-machine-arn.ts
+++ b/src/service/stepfunctions/machine/sim-state-machine-arn.ts
@@ -1,0 +1,78 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+
+const arnPartition = "aws";
+const arnService = "states";
+
+/**
+ * Where one state machine is, in the three facts its ARN carries.
+ */
+export interface SimStateMachineLocation {
+  readonly regionName: string;
+  readonly accountId: string;
+  readonly name: string;
+}
+
+/**
+ * The ARN of a state machine of a given name in an Account and Region.
+ */
+export function simStateMachineArn(
+  accountRegionScope: SimAwsAccountRegionScope,
+  name: string,
+): string {
+  const { regionName, accountId } = accountRegionScope;
+
+  return `arn:${arnPartition}:${arnService}:${regionName}:${accountId}:stateMachine:${name}`;
+}
+
+/**
+ * The ARN of one execution of a state machine.
+ *
+ * A `states` ARN separates its resource parts with colons rather than the
+ * slash most services use, so an execution ARN carries the state machine name
+ * and the execution name as two more colon-separated parts.
+ */
+export function simStatesExecutionArn(
+  accountRegionScope: SimAwsAccountRegionScope,
+  stateMachineName: string,
+  executionName: string,
+): string {
+  const { regionName, accountId } = accountRegionScope;
+
+  return `arn:${arnPartition}:${arnService}:${regionName}:${accountId}:execution:${stateMachineName}:${executionName}`;
+}
+
+/**
+ * Read a state machine ARN into the Region, Account and name it carries.
+ *
+ * Nothing is answered for a string that is not one. An ARN naming another
+ * Account or Region reaches nothing in this scope rather than having its name
+ * read out and looked up locally.
+ */
+export function parseSimStateMachineArn(
+  value: string,
+): SimStateMachineLocation | undefined {
+  const parts = value.split(":");
+
+  if (parts.length !== 7) {
+    return undefined;
+  }
+
+  const [prefix, partition, service, regionName, accountId, kind, name] = parts;
+
+  if (
+    prefix !== "arn" ||
+    partition !== arnPartition ||
+    service !== arnService ||
+    kind !== "stateMachine" ||
+    regionName === undefined ||
+    regionName === "" ||
+    accountId === undefined ||
+    accountId === "" ||
+    name === undefined ||
+    name === ""
+  ) {
+    return undefined;
+  }
+
+  return { regionName, accountId, name };
+}

--- a/src/service/stepfunctions/machine/sim-state-machine-commands.iso.test.ts
+++ b/src/service/stepfunctions/machine/sim-state-machine-commands.iso.test.ts
@@ -1,0 +1,193 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimStepFunctions } from "../sim-step-functions.js";
+
+const roleArn = "arn:aws:iam::123456789012:role/WorkflowRole";
+
+const passThrough = JSON.stringify({
+  StartAt: "Only",
+  States: { Only: { Type: "Pass", End: true } },
+});
+
+/**
+ * Create a state machine of a given name.
+ */
+async function givenAStateMachine(
+  stepFunctions: SimStepFunctions,
+  name: string,
+): Promise<string> {
+  const created = await stepFunctions.createStateMachine({
+    input: { name, roleArn, definition: passThrough },
+  });
+
+  return created.stateMachineArn;
+}
+
+describe("Simulated Step Functions state machines", () => {
+  it("creates a state machine reachable by the ARN it answers with", async () => {
+    // Given a simulated Step Functions.
+    const simAws = new SimAws();
+
+    // When a state machine is created and read back.
+    const arn = await givenAStateMachine(simAws.stepFunctions(), "Enrolment");
+    const described = await simAws
+      .stepFunctions()
+      .describeStateMachine({ input: { stateMachineArn: arn } });
+
+    // Then the ARN names it, and the definition comes back as it was sent.
+    assertStringIncludes(arn, ":stateMachine:Enrolment");
+    assertIdentical(described.name, "Enrolment");
+    assertIdentical(described.definition, passThrough);
+    assertIdentical(described.status, "ACTIVE");
+    assertIdentical(described.type, "STANDARD");
+  });
+
+  it("refuses a second state machine of the same name", async () => {
+    // Given a state machine that is already there.
+    const simAws = new SimAws();
+    await givenAStateMachine(simAws.stepFunctions(), "Enrolment");
+
+    // When another of that name is created.
+    const error = await assertThrowsErrorAsync(
+      async () => await givenAStateMachine(simAws.stepFunctions(), "Enrolment"),
+    );
+
+    // Then it is refused rather than answering with the one that is there.
+    assertStringIncludes(error.message, "already there");
+  });
+
+  it("lists state machines by name", async () => {
+    // Given three state machines created out of order.
+    const simAws = new SimAws();
+    await givenAStateMachine(simAws.stepFunctions(), "Reporting");
+    await givenAStateMachine(simAws.stepFunctions(), "Enrolment");
+    await givenAStateMachine(simAws.stepFunctions(), "Marking");
+
+    // When they are listed.
+    const listed = await simAws
+      .stepFunctions()
+      .listStateMachines({ input: {} });
+
+    // Then they come back in name order.
+    assertArrayLength(listed.stateMachines, 3);
+    assertIdentical(listed.stateMachines[0].name, "Enrolment");
+    assertIdentical(listed.stateMachines[2].name, "Reporting");
+  });
+
+  it("caps a listing at the maxResults it was given", async () => {
+    // Given two state machines.
+    const simAws = new SimAws();
+    await givenAStateMachine(simAws.stepFunctions(), "Enrolment");
+    await givenAStateMachine(simAws.stepFunctions(), "Marking");
+
+    // When one is asked for.
+    const listed = await simAws
+      .stepFunctions()
+      .listStateMachines({ input: { maxResults: 1 } });
+
+    // Then only one comes back.
+    assertArrayLength(listed.stateMachines, 1);
+  });
+
+  it("takes a new definition through UpdateStateMachine", async () => {
+    // Given a state machine that passes its input through.
+    const simAws = new SimAws();
+    const arn = await givenAStateMachine(simAws.stepFunctions(), "Enrolment");
+    const failing = JSON.stringify({
+      StartAt: "Only",
+      States: { Only: { Type: "Fail", Error: "Closed" } },
+    });
+
+    // When the definition is replaced and an execution runs.
+    await simAws.stepFunctions().updateStateMachine({
+      input: { stateMachineArn: arn, definition: failing },
+    });
+    const started = await simAws
+      .stepFunctions()
+      .startExecution({ input: { stateMachineArn: arn } });
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn: started.executionArn } });
+
+    // Then the execution ran the definition that replaced the first.
+    assertIdentical(described.error, "Closed");
+  });
+
+  it("leaves a state machine unchanged where an update carries only a role", async () => {
+    // Given a state machine.
+    const simAws = new SimAws();
+    const arn = await givenAStateMachine(simAws.stepFunctions(), "Enrolment");
+
+    // When only the role is changed.
+    await simAws.stepFunctions().updateStateMachine({
+      input: {
+        stateMachineArn: arn,
+        roleArn: "arn:aws:iam::123456789012:role/Another",
+      },
+    });
+    const described = await simAws
+      .stepFunctions()
+      .describeStateMachine({ input: { stateMachineArn: arn } });
+
+    // Then the definition is as it was and the role has moved.
+    assertIdentical(described.definition, passThrough);
+    assertStringIncludes(described.roleArn, "role/Another");
+  });
+
+  it("forgets a deleted state machine and its executions", async () => {
+    // Given a state machine that has run once.
+    const simAws = new SimAws();
+    const arn = await givenAStateMachine(simAws.stepFunctions(), "Enrolment");
+    const started = await simAws
+      .stepFunctions()
+      .startExecution({ input: { stateMachineArn: arn } });
+
+    // When it is deleted.
+    await simAws
+      .stepFunctions()
+      .deleteStateMachine({ input: { stateMachineArn: arn } });
+
+    // Then neither it nor its execution can be reached.
+    const machineError = await assertThrowsErrorAsync(
+      async () =>
+        await simAws
+          .stepFunctions()
+          .describeStateMachine({ input: { stateMachineArn: arn } }),
+    );
+    const executionError = await assertThrowsErrorAsync(
+      async () =>
+        await simAws
+          .stepFunctions()
+          .describeExecution({ input: { executionArn: started.executionArn } }),
+    );
+
+    assertStringIncludes(machineError.message, "not a simulated state machine");
+    assertStringIncludes(executionError.message, "not a simulated execution");
+  });
+
+  it("refuses a second execution of the same name", async () => {
+    // Given a state machine with a named execution.
+    const simAws = new SimAws();
+    const arn = await givenAStateMachine(simAws.stepFunctions(), "Enrolment");
+    await simAws
+      .stepFunctions()
+      .startExecution({ input: { stateMachineArn: arn, name: "first" } });
+
+    // When another of that name is started.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws
+          .stepFunctions()
+          .startExecution({ input: { stateMachineArn: arn, name: "first" } }),
+    );
+
+    // Then it is refused, which is what makes the name usable for idempotency.
+    assertStringIncludes(error.message, "already has an execution");
+  });
+});

--- a/src/service/stepfunctions/machine/sim-state-machine-commands.iso.test.ts
+++ b/src/service/stepfunctions/machine/sim-state-machine-commands.iso.test.ts
@@ -48,18 +48,65 @@ describe("Simulated Step Functions state machines", () => {
     assertIdentical(described.type, "STANDARD");
   });
 
-  it("refuses a second state machine of the same name", async () => {
+  it("answers a repeat CreateStateMachine with the one already there", async () => {
+    // Given a state machine that is already there.
+    const simAws = new SimAws();
+    const first = await givenAStateMachine(simAws.stepFunctions(), "Enrolment");
+
+    // When the same request is made again.
+    const second = await givenAStateMachine(
+      simAws.stepFunctions(),
+      "Enrolment",
+    );
+
+    // Then it answers with the same ARN, as real Step Functions does.
+    assertIdentical(second, first);
+  });
+
+  it("ignores a differing roleArn on a repeat CreateStateMachine", async () => {
+    // Given a state machine that is already there.
+    const simAws = new SimAws();
+    const first = await givenAStateMachine(simAws.stepFunctions(), "Enrolment");
+
+    // When the same name and definition arrive with another role.
+    const second = await simAws.stepFunctions().createStateMachine({
+      input: {
+        name: "Enrolment",
+        roleArn: "arn:aws:iam::123456789012:role/Another",
+        definition: passThrough,
+      },
+    });
+    const described = await simAws
+      .stepFunctions()
+      .describeStateMachine({ input: { stateMachineArn: first } });
+
+    // Then it is the same state machine and the role stayed as it was.
+    assertIdentical(second.stateMachineArn, first);
+    assertStringIncludes(described.roleArn, "role/WorkflowRole");
+  });
+
+  it("refuses a second state machine of the same name and another definition", async () => {
     // Given a state machine that is already there.
     const simAws = new SimAws();
     await givenAStateMachine(simAws.stepFunctions(), "Enrolment");
 
-    // When another of that name is created.
+    // When that name is used for a different definition.
     const error = await assertThrowsErrorAsync(
-      async () => await givenAStateMachine(simAws.stepFunctions(), "Enrolment"),
+      async () =>
+        await simAws.stepFunctions().createStateMachine({
+          input: {
+            name: "Enrolment",
+            roleArn,
+            definition: JSON.stringify({
+              StartAt: "Only",
+              States: { Only: { Type: "Succeed" } },
+            }),
+          },
+        }),
     );
 
-    // Then it is refused rather than answering with the one that is there.
-    assertStringIncludes(error.message, "already there");
+    // Then the idempotency check refuses it.
+    assertStringIncludes(error.message, "different definition or type");
   });
 
   it("lists state machines by name", async () => {

--- a/src/service/stepfunctions/machine/sim-state-machine-store.ts
+++ b/src/service/stepfunctions/machine/sim-state-machine-store.ts
@@ -1,0 +1,38 @@
+import type { SimStateMachine } from "./sim-state-machine.js";
+
+/**
+ * The state machines one simulated Step Functions holds.
+ *
+ * Kept by name as well as by ARN, since `CreateStateMachine` takes a name and
+ * every other command takes an ARN.
+ */
+export class SimStateMachineStore {
+  readonly #byArn = new Map<string, SimStateMachine>();
+
+  add(stateMachine: SimStateMachine): void {
+    this.#byArn.set(stateMachine.arn, stateMachine);
+  }
+
+  find(arn: string): SimStateMachine | undefined {
+    return this.#byArn.get(arn);
+  }
+
+  findByName(name: string): SimStateMachine | undefined {
+    return this.#byArn.values().find((machine) => machine.name === name);
+  }
+
+  remove(arn: string): void {
+    this.#byArn.delete(arn);
+  }
+
+  /**
+   * Every state machine, by name, which is the order real `ListStateMachines`
+   * answers in.
+   */
+  all(): readonly SimStateMachine[] {
+    return this.#byArn
+      .values()
+      .toArray()
+      .toSorted((one, other) => one.name.localeCompare(other.name));
+  }
+}

--- a/src/service/stepfunctions/machine/sim-state-machine.ts
+++ b/src/service/stepfunctions/machine/sim-state-machine.ts
@@ -28,7 +28,8 @@ interface SimStateMachineProperties {
 export class SimStateMachine {
   readonly arn: string;
   readonly name: string;
-  readonly creationDate: Date;
+
+  readonly #creationDate: Date;
 
   #roleArn: string;
   #definition: string;
@@ -38,11 +39,21 @@ export class SimStateMachine {
   constructor(properties: SimStateMachineProperties) {
     this.arn = properties.arn;
     this.name = properties.name;
-    this.creationDate = properties.creationDate;
+    this.#creationDate = new Date(properties.creationDate);
     this.#roleArn = properties.roleArn;
     this.#definition = properties.definition;
     this.#parsed = properties.parsed;
     this.#type = properties.type;
+  }
+
+  /**
+   * When this state machine was created.
+   *
+   * A copy, because a `Date` is mutable and this one is read back by every
+   * `DescribeStateMachine`.
+   */
+  get creationDate(): Date {
+    return new Date(this.#creationDate);
   }
 
   get roleArn(): string {

--- a/src/service/stepfunctions/machine/sim-state-machine.ts
+++ b/src/service/stepfunctions/machine/sim-state-machine.ts
@@ -1,0 +1,82 @@
+import type { SimStatesDefinition } from "../definition/sim-states-definition.js";
+
+/**
+ * The two kinds of state machine real Step Functions runs.
+ *
+ * Only `STANDARD` runs here. An `EXPRESS` state machine is accepted and runs
+ * the standard way, and the docs record that divergence.
+ */
+export type SimStateMachineType = "STANDARD" | "EXPRESS";
+
+interface SimStateMachineProperties {
+  readonly arn: string;
+  readonly name: string;
+  readonly roleArn: string;
+  readonly definition: string;
+  readonly parsed: SimStatesDefinition;
+  readonly type: SimStateMachineType;
+  readonly creationDate: Date;
+}
+
+/**
+ * One simulated state machine.
+ *
+ * The definition is held both as the string it arrived as and as the checked
+ * form an execution walks. `DescribeStateMachine` answers with the string, and
+ * a caller comparing it against what it deployed gets back what it sent.
+ */
+export class SimStateMachine {
+  readonly arn: string;
+  readonly name: string;
+  readonly creationDate: Date;
+
+  #roleArn: string;
+  #definition: string;
+  #parsed: SimStatesDefinition;
+  readonly #type: SimStateMachineType;
+
+  constructor(properties: SimStateMachineProperties) {
+    this.arn = properties.arn;
+    this.name = properties.name;
+    this.creationDate = properties.creationDate;
+    this.#roleArn = properties.roleArn;
+    this.#definition = properties.definition;
+    this.#parsed = properties.parsed;
+    this.#type = properties.type;
+  }
+
+  get roleArn(): string {
+    return this.#roleArn;
+  }
+
+  get definition(): string {
+    return this.#definition;
+  }
+
+  get parsedDefinition(): SimStatesDefinition {
+    return this.#parsed;
+  }
+
+  get type(): SimStateMachineType {
+    return this.#type;
+  }
+
+  /**
+   * Take a new definition or role.
+   *
+   * Real `UpdateStateMachine` leaves anything the request omits as it was, and
+   * an execution already running carries on with the definition it started on.
+   */
+  update(changes: {
+    readonly roleArn?: string | undefined;
+    readonly definition?: string | undefined;
+    readonly parsed?: SimStatesDefinition | undefined;
+  }): void {
+    this.#roleArn = changes.roleArn ?? this.#roleArn;
+
+    if (changes.definition !== undefined && changes.parsed !== undefined) {
+      this.#definition = changes.definition;
+      this.#parsed = changes.parsed;
+    }
+  }
+}

--- a/src/service/stepfunctions/machine/sim-states-name.ts
+++ b/src/service/stepfunctions/machine/sim-states-name.ts
@@ -1,0 +1,55 @@
+import { SimStatesInvalidName } from "../error/sim-step-functions.error.js";
+
+const maximumNameLength = 80;
+
+// Whitespace, brackets, wildcards and the special set real Step Functions
+// refuses in a name. Control characters are checked by code point below, since
+// a character class holding them reads as a mistake.
+const refusedCharacters = /[\s<>{}[\]?*"#%\\^|~`$&,;:/]/;
+
+/**
+ * Check a state machine or execution name against the rules real Step
+ * Functions holds them to.
+ *
+ * A name carrying a colon matters here beyond matching AWS. It would build an
+ * ARN with an extra colon-separated part, which the ARN parser then reads as
+ * something else entirely.
+ */
+export function checkSimStatesName(name: string, field: string): string {
+  if (name.length === 0 || name.length > maximumNameLength) {
+    throw new SimStatesInvalidName(
+      `${field} is ${String(name.length)} characters. A name is 1 to ` +
+        `${String(maximumNameLength)}.`,
+    );
+  }
+
+  if (refusedCharacters.test(name) || hasControlCharacter(name)) {
+    throw new SimStatesInvalidName(
+      `${field} carries a character Step Functions does not allow in a name. ` +
+        "Whitespace, brackets, wildcards, control characters and the set " +
+        '" # % \\ ^ | ~ ` $ & , ; : / are all refused.',
+    );
+  }
+
+  return name;
+}
+
+/**
+ * Whether a name holds a control character, a surrogate or a non-character.
+ */
+function hasControlCharacter(name: string): boolean {
+  for (const character of name) {
+    const code = character.codePointAt(0) ?? 0;
+
+    if (
+      code <= 0x1f ||
+      (code >= 0x7f && code <= 0x9f) ||
+      (code >= 0xd8_00 && code <= 0xdf_ff) ||
+      code >= 0xff_fe
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/src/service/stepfunctions/sdk/sim-step-functions-sdk-command-router.ts
+++ b/src/service/stepfunctions/sdk/sim-step-functions-sdk-command-router.ts
@@ -1,0 +1,90 @@
+import {
+  type SimSdkCommandRoute,
+  type SimSdkCommandRouter,
+  simSdkCallerOptions,
+} from "../../../sdk/index.js";
+import type * as simStatesCommands from "../command/sim-step-functions-command.types.js";
+import type { SimStepFunctions } from "../sim-step-functions.js";
+
+/**
+ * Routes intercepted SDK Commands to one scoped simulated Step Functions.
+ */
+export class SimStepFunctionsSdkCommandRouter implements SimSdkCommandRouter {
+  private readonly routes: ReadonlyMap<string, SimSdkCommandRoute>;
+
+  constructor(simStepFunctions: SimStepFunctions) {
+    this.routes = new Map<string, SimSdkCommandRoute>([
+      [
+        "CreateStateMachineCommand",
+        async (command, context): Promise<unknown> =>
+          await simStepFunctions.createStateMachine(
+            command as simStatesCommands.SimCreateStateMachineCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DescribeStateMachineCommand",
+        async (command, context): Promise<unknown> =>
+          await simStepFunctions.describeStateMachine(
+            command as simStatesCommands.SimDescribeStateMachineCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "UpdateStateMachineCommand",
+        async (command, context): Promise<unknown> =>
+          await simStepFunctions.updateStateMachine(
+            command as simStatesCommands.SimUpdateStateMachineCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteStateMachineCommand",
+        async (command, context): Promise<unknown> =>
+          await simStepFunctions.deleteStateMachine(
+            command as simStatesCommands.SimDeleteStateMachineCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListStateMachinesCommand",
+        async (command, context): Promise<unknown> =>
+          await simStepFunctions.listStateMachines(
+            command as simStatesCommands.SimListStateMachinesCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "StartExecutionCommand",
+        async (command, context): Promise<unknown> =>
+          await simStepFunctions.startExecution(
+            command as simStatesCommands.SimStartExecutionCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DescribeExecutionCommand",
+        async (command, context): Promise<unknown> =>
+          await simStepFunctions.describeExecution(
+            command as simStatesCommands.SimDescribeExecutionCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+    ]);
+  }
+
+  /**
+   * The SDK Command names simulated Step Functions can handle.
+   */
+  supportedCommandNames(): readonly string[] {
+    return this.routes.keys().toArray();
+  }
+
+  /**
+   * Get the route for an SDK Command name, if simulated Step Functions
+   * supports it.
+   */
+  route(commandName: string): SimSdkCommandRoute | undefined {
+    return this.routes.get(commandName);
+  }
+}

--- a/src/service/stepfunctions/sdk/sim-step-functions-sdk-routing.iso.test.ts
+++ b/src/service/stepfunctions/sdk/sim-step-functions-sdk-routing.iso.test.ts
@@ -1,0 +1,153 @@
+import {
+  CreateStateMachineCommand,
+  DeleteStateMachineCommand,
+  DescribeExecutionCommand,
+  DescribeStateMachineCommand,
+  ListStateMachinesCommand,
+  SFNClient,
+  StartExecutionCommand,
+  UpdateStateMachineCommand,
+} from "@aws-sdk/client-sfn";
+import {
+  assertArrayIncludesAll,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimSdk } from "../../../sdk/index.js";
+import { SimAws } from "../../aws/sim-aws.js";
+
+const definition = JSON.stringify({
+  StartAt: "Check",
+  States: {
+    Check: { Type: "Pass", Result: { eligible: true }, Next: "Done" },
+    Done: { Type: "Succeed" },
+  },
+});
+
+describe("Simulated Step Functions SDK interception", () => {
+  it("runs a state machine through an intercepted SFNClient", async () => {
+    // Given an intercepted client.
+    const simAws = new SimAws();
+    const client = new SFNClient({ region: "eu-west-2" });
+
+    using _intercepted = new SimSdk({ simAws }).intercept(client);
+
+    // When a state machine is created and run through the SDK.
+    const created = await client.send(
+      new CreateStateMachineCommand({
+        name: "Enrolment",
+        roleArn: "arn:aws:iam::123456789012:role/WorkflowRole",
+        definition,
+      }),
+    );
+
+    assertNonNullable(created.stateMachineArn);
+
+    const started = await client.send(
+      new StartExecutionCommand({
+        stateMachineArn: created.stateMachineArn,
+        input: '{"student":"Wei"}',
+      }),
+    );
+
+    assertNonNullable(started.executionArn);
+
+    const described = await client.send(
+      new DescribeExecutionCommand({ executionArn: started.executionArn }),
+    );
+
+    // Then the execution ran against the simulated service.
+    assertIdentical(described.status, "SUCCEEDED");
+    assertIdentical(described.output, '{"eligible":true}');
+  });
+
+  it("reads back through the simulator what the SDK created", async () => {
+    // Given a client in the simulation's own default Region, so the SDK and
+    // the accessor reach the same scoped service.
+    const simAws = new SimAws();
+    const client = new SFNClient({ region: simAws.defaultRegionName });
+
+    using _intercepted = new SimSdk({ simAws }).intercept(client);
+
+    await client.send(
+      new CreateStateMachineCommand({
+        name: "Enrolment",
+        roleArn: "arn:aws:iam::123456789012:role/WorkflowRole",
+        definition,
+      }),
+    );
+
+    // When it is listed through the SDK and found through the simulator.
+    const listed = await client.send(new ListStateMachinesCommand({}));
+
+    // Then both reach the same state machine.
+    assertArrayLength(listed.stateMachines ?? [], 1);
+    assertNonNullable(simAws.stepFunctions().findStateMachine("Enrolment"));
+  });
+
+  it("routes every state machine command it says it supports", async () => {
+    // Given an intercepted client.
+    const simAws = new SimAws();
+    const client = new SFNClient({ region: simAws.defaultRegionName });
+
+    using _intercepted = new SimSdk({ simAws }).intercept(client);
+
+    const created = await client.send(
+      new CreateStateMachineCommand({
+        name: "Enrolment",
+        roleArn: "arn:aws:iam::123456789012:role/WorkflowRole",
+        definition,
+      }),
+    );
+
+    assertNonNullable(created.stateMachineArn);
+
+    // When the rest of the state machine commands go through the SDK.
+    const described = await client.send(
+      new DescribeStateMachineCommand({
+        stateMachineArn: created.stateMachineArn,
+      }),
+    );
+    const updated = await client.send(
+      new UpdateStateMachineCommand({
+        stateMachineArn: created.stateMachineArn,
+        roleArn: "arn:aws:iam::123456789012:role/Another",
+      }),
+    );
+    await client.send(
+      new DeleteStateMachineCommand({
+        stateMachineArn: created.stateMachineArn,
+      }),
+    );
+    const listed = await client.send(new ListStateMachinesCommand({}));
+
+    // Then each answered, and the delete left nothing behind.
+    assertIdentical(described.name, "Enrolment");
+    assertNonNullable(updated.updateDate);
+    assertArrayLength(listed.stateMachines ?? [], 0);
+  });
+
+  it("names the commands it routes", () => {
+    // Given a simulated Step Functions.
+    const simAws = new SimAws();
+
+    // When its router is asked what it supports.
+    const supported = simAws
+      .stepFunctions()
+      .sdkCommandRouter()
+      .supportedCommandNames();
+
+    // Then every command this service handles is named.
+    assertArrayIncludesAll(supported, [
+      "CreateStateMachineCommand",
+      "DescribeStateMachineCommand",
+      "UpdateStateMachineCommand",
+      "DeleteStateMachineCommand",
+      "ListStateMachinesCommand",
+      "StartExecutionCommand",
+      "DescribeExecutionCommand",
+    ]);
+  });
+});

--- a/src/service/stepfunctions/sim-step-functions-inspection.ts
+++ b/src/service/stepfunctions/sim-step-functions-inspection.ts
@@ -1,0 +1,33 @@
+import type { SimStatesExecutionStore } from "./execution/sim-states-execution-store.js";
+
+/**
+ * What a test can read about the executions a simulated Step Functions has
+ * run.
+ *
+ * This is the simulator's own accessor rather than an AWS API.
+ * `GetExecutionHistory` answers the same question on real Step Functions, with
+ * an event stream that carries far more than a test usually asserts on.
+ */
+export class SimStepFunctionsInspection {
+  readonly #executions: SimStatesExecutionStore;
+
+  constructor(executions: SimStatesExecutionStore) {
+    this.#executions = executions;
+  }
+
+  /**
+   * The states one execution entered, in the order it entered them.
+   */
+  visitedStates(executionArn: string): readonly string[] {
+    return this.#executions.find(executionArn)?.visitedStates ?? [];
+  }
+
+  /**
+   * Every execution of one state machine, most recently started first.
+   */
+  executionsOf(stateMachineArn: string): readonly string[] {
+    return this.#executions
+      .forStateMachine(stateMachineArn)
+      .map((execution) => execution.arn);
+  }
+}

--- a/src/service/stepfunctions/sim-step-functions.iso.test.ts
+++ b/src/service/stepfunctions/sim-step-functions.iso.test.ts
@@ -1,0 +1,288 @@
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertObjectEquals,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../aws/sim-aws.js";
+import type { SimStepFunctions } from "./sim-step-functions.js";
+
+/**
+ * Create a state machine from a definition written as an object.
+ */
+async function givenAStateMachine(
+  stepFunctions: SimStepFunctions,
+  states: object,
+  startAt: string,
+): Promise<string> {
+  const created = await stepFunctions.createStateMachine({
+    input: {
+      name: "Enrolment",
+      roleArn: "arn:aws:iam::123456789012:role/WorkflowRole",
+      definition: JSON.stringify({ StartAt: startAt, States: states }),
+    },
+  });
+
+  return created.stateMachineArn;
+}
+
+describe("Simulated Step Functions executions", () => {
+  it("runs a Pass state machine to SUCCEEDED before the caller reads it", async () => {
+    // Given a state machine of one Pass state.
+    const simAws = new SimAws();
+    const stateMachineArn = await givenAStateMachine(
+      simAws.stepFunctions(),
+      { Only: { Type: "Pass", End: true } },
+      "Only",
+    );
+
+    // When an execution is started and read straight back.
+    const started = await simAws
+      .stepFunctions()
+      .startExecution({ input: { stateMachineArn, input: '{"term":3}' } });
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn: started.executionArn } });
+
+    // Then it has already finished, carrying its input through.
+    assertIdentical(described.status, "SUCCEEDED");
+    assertIdentical(described.output, '{"term":3}');
+  });
+
+  it("moves through the states its transitions name, in order", async () => {
+    // Given a state machine of three states in a chain.
+    const simAws = new SimAws();
+    const stateMachineArn = await givenAStateMachine(
+      simAws.stepFunctions(),
+      {
+        First: { Type: "Pass", Result: { step: 1 }, Next: "Second" },
+        Second: { Type: "Pass", ResultPath: "$.checked", Next: "Done" },
+        Done: { Type: "Succeed" },
+      },
+      "First",
+    );
+
+    // When an execution runs.
+    const started = await simAws
+      .stepFunctions()
+      .startExecution({ input: { stateMachineArn } });
+
+    // Then every state was entered, in the order the chain names.
+    assertArrayEquals(
+      simAws.stepFunctions().inspection().visitedStates(started.executionArn),
+      ["First", "Second", "Done"],
+    );
+  });
+
+  it("carries a Pass state's Result through its ResultPath", async () => {
+    // Given a Pass state writing a literal into its input.
+    const simAws = new SimAws();
+    const stateMachineArn = await givenAStateMachine(
+      simAws.stepFunctions(),
+      {
+        Only: {
+          Type: "Pass",
+          Result: { eligible: true },
+          ResultPath: "$.check",
+          End: true,
+        },
+      },
+      "Only",
+    );
+
+    // When an execution runs with an input.
+    const started = await simAws.stepFunctions().startExecution({
+      input: { stateMachineArn, input: '{"student":"Wei"}' },
+    });
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn: started.executionArn } });
+
+    // Then the result sits alongside the input it was given.
+    assertObjectEquals(JSON.parse(described.output ?? "null"), {
+      student: "Wei",
+      check: { eligible: true },
+    });
+  });
+
+  it("ends an execution at a Fail state with the error it names", async () => {
+    // Given a state machine that fails.
+    const simAws = new SimAws();
+    const stateMachineArn = await givenAStateMachine(
+      simAws.stepFunctions(),
+      {
+        Only: { Type: "Fail", Error: "NotEligible", Cause: "No place left" },
+      },
+      "Only",
+    );
+
+    // When an execution runs.
+    const started = await simAws
+      .stepFunctions()
+      .startExecution({ input: { stateMachineArn } });
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn: started.executionArn } });
+
+    // Then the failure is recorded on the execution rather than raised.
+    assertIdentical(described.status, "FAILED");
+    assertIdentical(described.error, "NotEligible");
+    assertIdentical(described.cause, "No place left");
+  });
+
+  it("records a data-flow failure with its Amazon States Language error name", async () => {
+    // Given a state reading a path its input has nothing at.
+    const simAws = new SimAws();
+    const stateMachineArn = await givenAStateMachine(
+      simAws.stepFunctions(),
+      { Only: { Type: "Pass", InputPath: "$.absent", End: true } },
+      "Only",
+    );
+
+    // When an execution runs.
+    const started = await simAws
+      .stepFunctions()
+      .startExecution({ input: { stateMachineArn, input: "{}" } });
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn: started.executionArn } });
+
+    // Then the execution failed with the name a Catch would match on.
+    assertIdentical(described.status, "FAILED");
+    assertIdentical(described.error, "States.ParameterPathFailure");
+  });
+
+  it("narrows a Succeed state's output with its OutputPath", async () => {
+    // Given a Succeed state reading one field.
+    const simAws = new SimAws();
+    const stateMachineArn = await givenAStateMachine(
+      simAws.stepFunctions(),
+      { Only: { Type: "Succeed", OutputPath: "$.student" } },
+      "Only",
+    );
+
+    // When an execution runs.
+    const started = await simAws.stepFunctions().startExecution({
+      input: { stateMachineArn, input: '{"student":"Wei","term":3}' },
+    });
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn: started.executionArn } });
+
+    // Then only the narrowed value comes out.
+    assertIdentical(described.output, '"Wei"');
+  });
+
+  it("gives an execution an empty object where the request carried no input", async () => {
+    // Given a state machine passing its input through.
+    const simAws = new SimAws();
+    const stateMachineArn = await givenAStateMachine(
+      simAws.stepFunctions(),
+      { Only: { Type: "Pass", End: true } },
+      "Only",
+    );
+
+    // When an execution is started with nothing.
+    const started = await simAws
+      .stepFunctions()
+      .startExecution({ input: { stateMachineArn } });
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn: started.executionArn } });
+
+    // Then it ran on an empty object.
+    assertIdentical(described.input, "{}");
+    assertIdentical(described.output, "{}");
+  });
+});
+
+describe("Simulated Step Functions execution inspection", () => {
+  it("lists a state machine's executions, most recently started first", async () => {
+    // Given a state machine that has run twice.
+    const simAws = new SimAws();
+    const stateMachineArn = await givenAStateMachine(
+      simAws.stepFunctions(),
+      { Only: { Type: "Pass", End: true } },
+      "Only",
+    );
+    const first = await simAws
+      .stepFunctions()
+      .startExecution({ input: { stateMachineArn, name: "first" } });
+    const second = await simAws
+      .stepFunctions()
+      .startExecution({ input: { stateMachineArn, name: "second" } });
+
+    // When its executions are listed.
+    const listed = simAws
+      .stepFunctions()
+      .inspection()
+      .executionsOf(stateMachineArn);
+
+    // Then the most recent comes first.
+    assertArrayEquals(listed, [second.executionArn, first.executionArn]);
+  });
+
+  it("reports nothing for an execution it has never run", () => {
+    // Given a simulated Step Functions holding nothing.
+    const simAws = new SimAws();
+
+    // When an unknown execution's states are asked for.
+    const visited = simAws
+      .stepFunctions()
+      .inspection()
+      .visitedStates("arn:aws:states:eu-west-2:123456789012:execution:A:one");
+
+    // Then it reports nothing rather than raising.
+    assertArrayEquals(visited, []);
+  });
+
+  it("reads back a definition's Comment", async () => {
+    // Given a state machine whose definition carries a comment.
+    const simAws = new SimAws();
+    const created = await simAws.stepFunctions().createStateMachine({
+      input: {
+        name: "Commented",
+        roleArn: "arn:aws:iam::123456789012:role/WorkflowRole",
+        definition: JSON.stringify({
+          Comment: "Enrols a student",
+          StartAt: "Only",
+          States: { Only: { Type: "Succeed" } },
+        }),
+      },
+    });
+
+    // When an execution runs.
+    const started = await simAws.stepFunctions().startExecution({
+      input: { stateMachineArn: created.stateMachineArn },
+    });
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn: started.executionArn } });
+
+    // Then the comment changed nothing about the run.
+    assertIdentical(described.status, "SUCCEEDED");
+  });
+
+  it("ends a Fail state with no Error under a states name of its own", async () => {
+    // Given a Fail state naming no error.
+    const simAws = new SimAws();
+    const stateMachineArn = await givenAStateMachine(
+      simAws.stepFunctions(),
+      { Only: { Type: "Fail" } },
+      "Only",
+    );
+
+    // When an execution runs.
+    const started = await simAws
+      .stepFunctions()
+      .startExecution({ input: { stateMachineArn } });
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn: started.executionArn } });
+
+    // Then it carries the unnamed default and no cause.
+    assertIdentical(described.error, "States.Unknown");
+    assertUndefined(described.cause);
+  });
+});

--- a/src/service/stepfunctions/sim-step-functions.ts
+++ b/src/service/stepfunctions/sim-step-functions.ts
@@ -1,0 +1,173 @@
+import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../util/background/background.js";
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
+import type * as simStatesCommands from "./command/sim-step-functions-command.types.js";
+import { SimStatesExecutionDescribe } from "./command/execution/sim-states-execution-describe.js";
+import { SimStatesExecutionStart } from "./command/execution/sim-states-execution-start.js";
+import { SimStateMachineCreate } from "./command/machine/sim-state-machine-create.js";
+import { SimStateMachineReads } from "./command/machine/sim-state-machine-reads.js";
+import { SimStateMachineWrites } from "./command/machine/sim-state-machine-writes.js";
+import type { SimStepFunctionsRequestOptions } from "./command/sim-step-functions-request-options.js";
+import { SimStatesExecutionStore } from "./execution/sim-states-execution-store.js";
+import type { SimStateMachine } from "./machine/sim-state-machine.js";
+import { SimStateMachineStore } from "./machine/sim-state-machine-store.js";
+import { SimStepFunctionsSdkCommandRouter } from "./sdk/sim-step-functions-sdk-command-router.js";
+import { SimStepFunctionsInspection } from "./sim-step-functions-inspection.js";
+
+interface SimStepFunctionsProperties {
+  readonly accountRegionScope?: SimAwsAccountRegionScope;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * Simulated Step Functions. Handles SDK commands. Emulates AWS behaviour and
+ * state.
+ *
+ * A state machine's definition is checked when it is created, so an execution
+ * walks a definition it can rely on. The state types this runs are `Pass`,
+ * `Succeed` and `Fail`, and a definition using any other is refused by name.
+ *
+ * An execution runs on the simulation's background scheduler rather than in
+ * the `StartExecution` call. An execution with nothing to wait for settles
+ * before the caller sees it. A failing execution records the failure and never
+ * raises out of the scheduler, following the way simulated EventBridge records
+ * a delivery it could not make.
+ */
+export class SimStepFunctions {
+  readonly #stateMachines = new SimStateMachineStore();
+  readonly #executions = new SimStatesExecutionStore();
+  readonly #machineReads: SimStateMachineReads;
+  readonly #machineWrites: SimStateMachineWrites;
+  readonly #machineCreate: SimStateMachineCreate;
+  readonly #executionStart: SimStatesExecutionStart;
+  readonly #executionDescribe: SimStatesExecutionDescribe;
+  readonly #background: BackgroundScheduler;
+  readonly #sdkRouter = new SimStepFunctionsSdkCommandRouter(this);
+  readonly #inspection = new SimStepFunctionsInspection(this.#executions);
+
+  constructor(properties: SimStepFunctionsProperties = {}) {
+    const {
+      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.#background = background;
+    this.#machineReads = new SimStateMachineReads(this.#stateMachines);
+    this.#machineWrites = new SimStateMachineWrites({
+      stateMachines: this.#stateMachines,
+      executions: this.#executions,
+      background,
+    });
+    this.#machineCreate = new SimStateMachineCreate({
+      stateMachines: this.#stateMachines,
+      accountRegionScope,
+      background,
+    });
+    this.#executionStart = new SimStatesExecutionStart({
+      stateMachines: this.#stateMachines,
+      executions: this.#executions,
+      accountRegionScope,
+      background,
+    });
+    this.#executionDescribe = new SimStatesExecutionDescribe(this.#executions);
+  }
+
+  /**
+   * Find a state machine by name.
+   *
+   * This is the simulator's own accessor, for tests seeding or inspecting
+   * state machines without going through a Command.
+   */
+  findStateMachine(name: string): SimStateMachine | undefined {
+    return this.#stateMachines.findByName(name);
+  }
+
+  /**
+   * What a test can read about the executions this service has run.
+   */
+  inspection(): SimStepFunctionsInspection {
+    return this.#inspection;
+  }
+
+  /** Handle a CreateStateMachine Command from the SDK. */
+  async createStateMachine(
+    command: simStatesCommands.SimCreateStateMachineCommand,
+    _options?: SimStepFunctionsRequestOptions,
+  ): Promise<simStatesCommands.SimCreateStateMachineCommandOutput> {
+    await this.#background.sequence();
+    return this.#machineCreate.handle(command);
+  }
+
+  /** Handle a DescribeStateMachine Command from the SDK. */
+  async describeStateMachine(
+    command: simStatesCommands.SimDescribeStateMachineCommand,
+    _options?: SimStepFunctionsRequestOptions,
+  ): Promise<simStatesCommands.SimDescribeStateMachineCommandOutput> {
+    await this.#background.sequence();
+    return this.#machineReads.describe(command);
+  }
+
+  /** Handle an UpdateStateMachine Command from the SDK. */
+  async updateStateMachine(
+    command: simStatesCommands.SimUpdateStateMachineCommand,
+    _options?: SimStepFunctionsRequestOptions,
+  ): Promise<simStatesCommands.SimUpdateStateMachineCommandOutput> {
+    await this.#background.sequence();
+    return this.#machineWrites.update(command);
+  }
+
+  /** Handle a DeleteStateMachine Command from the SDK. */
+  async deleteStateMachine(
+    command: simStatesCommands.SimDeleteStateMachineCommand,
+    _options?: SimStepFunctionsRequestOptions,
+  ): Promise<simStatesCommands.SimDeleteStateMachineCommandOutput> {
+    await this.#background.sequence();
+    return this.#machineWrites.delete(command);
+  }
+
+  /** Handle a ListStateMachines Command from the SDK. */
+  async listStateMachines(
+    command: simStatesCommands.SimListStateMachinesCommand,
+    _options?: SimStepFunctionsRequestOptions,
+  ): Promise<simStatesCommands.SimListStateMachinesCommandOutput> {
+    await this.#background.sequence();
+    return this.#machineReads.list(command);
+  }
+
+  /** Handle a StartExecution Command from the SDK. */
+  async startExecution(
+    command: simStatesCommands.SimStartExecutionCommand,
+    _options?: SimStepFunctionsRequestOptions,
+  ): Promise<simStatesCommands.SimStartExecutionCommandOutput> {
+    await this.#background.sequence();
+
+    const started = this.#executionStart.handle(command);
+
+    // The walk was scheduled rather than run. Yielding here lets an execution
+    // with nothing to wait for finish before the caller reads it back, which
+    // is what a test asserting straight after StartExecution expects.
+    await this.#background.sequence();
+
+    return started;
+  }
+
+  /** Handle a DescribeExecution Command from the SDK. */
+  async describeExecution(
+    command: simStatesCommands.SimDescribeExecutionCommand,
+    _options?: SimStepFunctionsRequestOptions,
+  ): Promise<simStatesCommands.SimDescribeExecutionCommandOutput> {
+    await this.#background.sequence();
+    return this.#executionDescribe.handle(command);
+  }
+
+  /**
+   * Get this service's SDK Command router for SDK client interception.
+   */
+  sdkCommandRouter(): SimSdkCommandRouter {
+    return this.#sdkRouter;
+  }
+}


### PR DESCRIPTION
A state machine is held in a template as data, and no unit test runs it. This adds `simAws.stepFunctions()`, the second pull request against #918, built on the data-flow layer that landed in #924.

## What runs

- **The service.** `CreateStateMachine`, `DescribeStateMachine`, `UpdateStateMachine`, `DeleteStateMachine`, `ListStateMachines`, `StartExecution` and `DescribeExecution`, through the accessor and through an intercepted `SFNClient`.
- **Three state types.** `Pass`, `Succeed` and `Fail`, with the five data-flow fields applying around each one. A definition using `Task`, `Choice`, `Wait`, `Parallel` or `Map` is refused when the state machine is created, naming the state and its type.
- **Definition checking at creation.** A `Next` naming a state that is not there, a state carrying neither `Next` nor `End`, a `Fail` carrying `InputPath`, a `Type` Amazon States Language does not define. Each is refused where real Step Functions refuses it, so an execution walks a definition it can rely on.
- **An inspection accessor** reporting the states an execution went through, and a state machine's executions.

## Three decisions worth a look

**`StartExecution` settles before it answers.** Real Step Functions answers before the execution has run, so a caller there sees `RUNNING` first. The interpreter here runs inline until it reaches something that has to wait on the clock, which for now is never. That spares every test a wait for work already done, and it is the shape `Wait` needs later: the walk stops at the `Wait`, leaves the execution `RUNNING`, and `advanceBy` moves it on. The alternative, scheduling the whole walk through `background.schedule`, puts it behind a `setTimeout` that no microtask yield reaches.

**A failing execution is recorded, never raised.** This follows the carve-out simulated time already makes for delivery, where EventBridge records a failure rather than throwing it into whichever caller happened to be advancing the clock. An execution failing is as often the thing under test as it is a fault.

**Every failure carries its Amazon States Language error name.** `States.ParameterPathFailure`, `States.Runtime` and the rest are read off the error and recorded on the execution. #920's `Retry` and `Catch` match on exactly that, so the wiring is in place before it is needed.

## Note on the file layout

There are more small files here than the shape of the code suggests. FTA scores density rather than length, so extracting code from a file can raise its score: `sim-state-machine-writes.ts` went **up** from 51.7 to 53.6 on one split before coming down when `create` moved out with its token mass. The command classes ended up split along read/write lines, which is the Kinesis layout anyway.

## Still to come on #918

`Choice` and `Wait` next, then `Task` with Lambda and IAM authorization. #919, #920, #921 and #922 all sit on top.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated AWS Step Functions support for creating, updating, listing, describing, and deleting state machines.
  * Added execution start and status inspection, including outputs, failures, visited states, and execution history.
  * Supports `Pass`, `Succeed`, and `Fail` states with data-flow handling, Standard and Express machine types, and AWS SDK command interception.
* **Bug Fixes**
  * Preserved falsy values when inserting data into arrays.
* **Documentation**
  * Added Step Functions documentation and runnable usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->