### PR TITLE
feat: deliver Firehose records into an S3 bucket

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ behaviour and includes example code that can be copied into tests or local devel
 - [Elastic Load Balancing](./services/elbv2/ "Simulated Application Load Balancer usage docs")
 - [EventBridge](./services/eventbridge/ "Simulated EventBridge usage docs")
 - [IAM](./services/iam/ "Simulated IAM usage docs")
+- [Kinesis Data Firehose](./services/firehose/ "Simulated Kinesis Data Firehose usage docs")
 - [Kinesis Data Streams](./services/kinesis/ "Simulated Kinesis Data Streams usage docs")
 - [KMS](./services/kms/ "Simulated KMS usage docs")
 - [Lambda](./services/lambda/ "Simulated Lambda usage docs")

--- a/docs/services/firehose/README.md
+++ b/docs/services/firehose/README.md
@@ -1,0 +1,520 @@
+# Simulated Kinesis Data Firehose
+
+Yulin includes a simulated Kinesis Data Firehose for tests and local development. A delivery stream
+takes records, buffers them, and writes them into a simulated S3 Bucket under the key format real
+Firehose uses. A test can put an event and assert on the Object it landed in, without an AWS account
+and without waiting five minutes for a buffer to flush.
+
+Firehose specific types are imported from the `@kensio/yulin/firehose` subpath.
+
+## Putting a record and finding the Object
+
+`simAws.firehose()` gives the service for the default account and region. A delivery stream needs a
+Bucket to write into and a Role to write as, so both exist before it does. Advancing the clock past
+the buffering interval is what delivers the buffer.
+
+```typescript sim-firehose-put-and-deliver
+/**
+ * Putting an order event on a delivery stream and finding it in the Bucket.
+ */
+
+import {
+  CreateDeliveryStreamCommand,
+  PutRecordCommand,
+} from "@aws-sdk/client-firehose";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateBucketCommand, ListObjectsV2Command } from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws
+  .s3()
+  .createBucket(new CreateBucketCommand({ Bucket: "order-archive" }));
+
+const { Role } = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "OrderArchiveRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "firehose.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "OrderArchiveRole",
+    PolicyName: "ArchiveOrders",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "s3:PutObject",
+        Resource: "arn:aws:s3:::order-archive/*",
+      },
+    }),
+  }),
+);
+
+await simAws.firehose().createDeliveryStream(
+  new CreateDeliveryStreamCommand({
+    DeliveryStreamName: "order-events",
+    ExtendedS3DestinationConfiguration: {
+      BucketARN: "arn:aws:s3:::order-archive",
+      RoleARN: Role.Arn,
+      BufferingHints: { IntervalInSeconds: 60 },
+    },
+  }),
+);
+
+const orderEvent = `${JSON.stringify({ id: "order-1" })}\n`;
+
+await simAws.firehose().putRecord(
+  new PutRecordCommand({
+    DeliveryStreamName: "order-events",
+    Record: { Data: new TextEncoder().encode(orderEvent) },
+  }),
+);
+
+await simAws.clock().advanceBy({ seconds: 61 });
+
+const { Contents } = await simAws
+  .s3()
+  .listObjectsV2(new ListObjectsV2Command({ Bucket: "order-archive" }));
+
+// 2026/08/22/13/order-events-1-2026-08-22-13-51-01-92076704-cf4a-...
+console.log(Contents?.[0]?.Key);
+```
+
+The put is answered straight away with a record id. The Bucket stays empty until the buffer is
+delivered. That delay is what a Firehose pipeline is built around.
+
+## Buffering
+
+A delivery stream holds its records until the buffer passes `SizeInMBs` or `IntervalInSeconds`,
+whichever comes first. Everything in one buffer arrives as one Object, with the records concatenated
+end to end. A producer that wants lines puts the newline on the end of each record. The example
+below does exactly that.
+
+`IntervalInSeconds` runs from the first record of a buffer. The default is 300 seconds and the
+default size is 5 MB, as they are on real Firehose.
+
+```typescript sim-firehose-buffering
+/**
+ * Three records inside one buffering window, and the single Object they land
+ * in.
+ */
+
+import { text } from "node:stream/consumers";
+
+import {
+  CreateDeliveryStreamCommand,
+  PutRecordBatchCommand,
+} from "@aws-sdk/client-firehose";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateBucketCommand,
+  GetObjectCommand,
+  ListObjectsV2Command,
+} from "@aws-sdk/client-s3";
+import { assertNonNullable } from "@kensio/smartass";
+
+import { SimAws } from "@kensio/yulin";
+
+/**
+ * A Bucket, a delivery Role allowed the S3 actions given, and a delivery
+ * stream writing into the one as the other.
+ */
+async function makeOrderArchive(
+  simAws: SimAws,
+  actions: readonly string[] = ["s3:PutObject"],
+): Promise<void> {
+  await simAws
+    .s3()
+    .createBucket(new CreateBucketCommand({ Bucket: "order-archive" }));
+
+  const { Role } = await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "OrderArchiveRole",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { Service: "firehose.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "OrderArchiveRole",
+      PolicyName: "ArchiveOrders",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Action: actions,
+          Resource: "arn:aws:s3:::order-archive/*",
+        },
+      }),
+    }),
+  );
+
+  await simAws.firehose().createDeliveryStream(
+    new CreateDeliveryStreamCommand({
+      DeliveryStreamName: "order-events",
+      ExtendedS3DestinationConfiguration: {
+        BucketARN: "arn:aws:s3:::order-archive",
+        RoleARN: Role.Arn,
+        BufferingHints: { IntervalInSeconds: 60 },
+      },
+    }),
+  );
+}
+
+const simAws = new SimAws();
+
+await makeOrderArchive(simAws);
+
+await simAws.firehose().putRecordBatch(
+  new PutRecordBatchCommand({
+    DeliveryStreamName: "order-events",
+    Records: ["order-1", "order-2", "order-3"].map((id) => ({
+      Data: new TextEncoder().encode(`${JSON.stringify({ id })}\n`),
+    })),
+  }),
+);
+
+await simAws.clock().advanceBy({ minutes: 2 });
+
+const { Contents } = await simAws
+  .s3()
+  .listObjectsV2(new ListObjectsV2Command({ Bucket: "order-archive" }));
+
+// 1
+console.log(Contents?.length);
+
+const object = await simAws.s3().getObject(
+  new GetObjectCommand({
+    Bucket: "order-archive",
+    Key: Contents?.[0]?.Key,
+  }),
+);
+
+assertNonNullable(object.Body, "The delivered Object has a body");
+
+// {"id":"order-1"}
+// {"id":"order-2"}
+// {"id":"order-3"}
+console.log(await text(object.Body));
+```
+
+A buffer that fills before its interval is delivered on the size instead. That delivery happens on
+the background scheduler, the way real Firehose answers the producer before it writes anything.
+`simAws.backgroundTasksComplete()` is what a test waits on for it.
+
+## The Object key
+
+The key is the `Prefix`, then the UTC date path, then the delivery stream name, its version, the
+delivery time and a random string:
+
+```
+<Prefix>YYYY/MM/DD/HH/<delivery-stream-name>-<version>-YYYY-MM-DD-HH-MM-SS-<random>
+```
+
+A delivery stream with no `Prefix` gets the bare date path. The version is `1` and stays there,
+since a delivery stream's configuration is fixed once it is created.
+
+Simulated time is what the date path and the timestamp come from. A test that sets the clock to a
+known instant knows the prefix its Objects are under, and can list them.
+
+## Permissions
+
+Every Firehose operation authorizes against the `firehose:` action of the same name, on the ARN of
+the delivery stream it names. `ListDeliveryStreams` names none, and authorizes against `*`.
+
+The delivery itself is a separate request, made as the delivery stream's `RoleARN`. The caller who
+put the record needs no S3 permission at all, and a Role that cannot write to the Bucket fails the
+delivery. Real
+Firehose answered that `PutRecord` minutes earlier, and what became of the buffer reaches the
+producer through CloudWatch. The simulator keeps the failure for a test to read instead.
+
+```typescript sim-firehose-permissions
+/**
+ * A delivery Role that cannot write to the Bucket, and where the failure shows
+ * up.
+ */
+
+import {
+  CreateDeliveryStreamCommand,
+  PutRecordCommand,
+} from "@aws-sdk/client-firehose";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateBucketCommand, ListObjectsV2Command } from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+
+/**
+ * A Bucket, a delivery Role allowed the S3 actions given, and a delivery
+ * stream writing into the one as the other.
+ */
+async function makeOrderArchive(
+  simAws: SimAws,
+  actions: readonly string[] = ["s3:PutObject"],
+): Promise<void> {
+  await simAws
+    .s3()
+    .createBucket(new CreateBucketCommand({ Bucket: "order-archive" }));
+
+  const { Role } = await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "OrderArchiveRole",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { Service: "firehose.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "OrderArchiveRole",
+      PolicyName: "ArchiveOrders",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Action: actions,
+          Resource: "arn:aws:s3:::order-archive/*",
+        },
+      }),
+    }),
+  );
+
+  await simAws.firehose().createDeliveryStream(
+    new CreateDeliveryStreamCommand({
+      DeliveryStreamName: "order-events",
+      ExtendedS3DestinationConfiguration: {
+        BucketARN: "arn:aws:s3:::order-archive",
+        RoleARN: Role.Arn,
+        BufferingHints: { IntervalInSeconds: 60 },
+      },
+    }),
+  );
+}
+
+const simAws = new SimAws();
+
+// The Role may read the Bucket, and it may not write to it.
+await makeOrderArchive(simAws, ["s3:GetObject", "s3:ListBucket"]);
+
+await simAws.firehose().putRecord(
+  new PutRecordCommand({
+    DeliveryStreamName: "order-events",
+    Record: { Data: new TextEncoder().encode("one\n") },
+  }),
+);
+
+await simAws.clock().advanceBy({ minutes: 2 });
+
+const { Contents } = await simAws
+  .s3()
+  .listObjectsV2(new ListObjectsV2Command({ Bucket: "order-archive" }));
+
+// 0
+console.log(Contents?.length ?? 0);
+
+const [failure] = simAws.firehose().getDeliveryFailures();
+
+// order-events could not write 1 record to order-archive
+console.log(
+  `${failure?.deliveryStreamName} could not write ` +
+    `${failure?.recordCount} record to ${failure?.bucketName}`,
+);
+
+// true
+console.log(failure?.wasRefused);
+```
+
+A failure carries the delivery stream, the Bucket, the key it tried, how many records were in the
+buffer, the Role it wrote as and the error itself. `wasRefused` separates an IAM denial from a
+delivery that broke some other way. A denial is recorded quietly, since removing `s3:PutObject` is
+what a test checking the denial does. Anything else is also warned about on the console.
+
+## SDK interception
+
+`SimSdk` intercepts a `FirehoseClient`, so application code that constructs its own client reaches
+the simulation without being handed one.
+
+```typescript sim-firehose-sdk-interception
+/**
+ * Application code sending to its own FirehoseClient, answered by the
+ * simulation.
+ */
+
+import {
+  CreateDeliveryStreamCommand,
+  FirehoseClient,
+  PutRecordCommand,
+} from "@aws-sdk/client-firehose";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateBucketCommand,
+  ListObjectsV2Command,
+  S3Client,
+} from "@aws-sdk/client-s3";
+
+import type { SimAws } from "@kensio/yulin";
+import { SimSdk } from "@kensio/yulin/sdk";
+
+/**
+ * A Bucket, a delivery Role allowed the S3 actions given, and a delivery
+ * stream writing into the one as the other.
+ */
+async function makeOrderArchive(
+  simAws: SimAws,
+  actions: readonly string[] = ["s3:PutObject"],
+): Promise<void> {
+  await simAws
+    .s3()
+    .createBucket(new CreateBucketCommand({ Bucket: "order-archive" }));
+
+  const { Role } = await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "OrderArchiveRole",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { Service: "firehose.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "OrderArchiveRole",
+      PolicyName: "ArchiveOrders",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Action: actions,
+          Resource: "arn:aws:s3:::order-archive/*",
+        },
+      }),
+    }),
+  );
+
+  await simAws.firehose().createDeliveryStream(
+    new CreateDeliveryStreamCommand({
+      DeliveryStreamName: "order-events",
+      ExtendedS3DestinationConfiguration: {
+        BucketARN: "arn:aws:s3:::order-archive",
+        RoleARN: Role.Arn,
+        BufferingHints: { IntervalInSeconds: 60 },
+      },
+    }),
+  );
+}
+
+using simSdk = new SimSdk();
+
+simSdk.intercept(FirehoseClient);
+simSdk.intercept(S3Client);
+
+await makeOrderArchive(simSdk.simAws);
+
+const firehose = new FirehoseClient({ region: "us-east-1" });
+const s3 = new S3Client({ region: "us-east-1" });
+
+await firehose.send(
+  new PutRecordCommand({
+    DeliveryStreamName: "order-events",
+    Record: { Data: new TextEncoder().encode("one\n") },
+  }),
+);
+
+await simSdk.simAws.clock().advanceBy({ minutes: 2 });
+
+const { Contents } = await s3.send(
+  new ListObjectsV2Command({ Bucket: "order-archive" }),
+);
+
+// 1
+console.log(Contents?.length);
+```
+
+## Supported commands
+
+| Command                  | Notes                                                                      |
+| ------------------------ | -------------------------------------------------------------------------- |
+| `CreateDeliveryStream`   | A name already in use raises `ResourceInUseException`.                     |
+| `DeleteDeliveryStream`   | The name is free again at once. Whatever was buffered goes with it.        |
+| `ListDeliveryStreams`    | Sorted by name, paged with `Limit` and `ExclusiveStartDeliveryStreamName`. |
+| `DescribeDeliveryStream` | Reports the one destination as an `ExtendedS3DestinationDescription`.      |
+| `PutRecord`              | Records up to 1,000 KiB.                                                   |
+| `PutRecordBatch`         | Up to 500 records and 4 MiB. `FailedPutCount` is always zero.              |
+
+Anything else refuses on send with `SimSdkUnsupportedCommandError`, which covers
+`UpdateDestination`, `StartDeliveryStreamEncryption`, `StopDeliveryStreamEncryption` and the tag
+operations.
+
+## Divergences and limitations
+
+- **S3 is the only destination.** `RedshiftDestinationConfiguration`,
+  `ElasticsearchDestinationConfiguration`, the two OpenSearch ones,
+  `SplunkDestinationConfiguration`, `HttpEndpointDestinationConfiguration`,
+  `IcebergDestinationConfiguration` and `SnowflakeDestinationConfiguration` are each refused by name
+  at `CreateDeliveryStream`. A delivery stream created against one of them would take records and
+  drop them, and a test asserting on an empty Bucket would blame the code under test.
+  `S3DestinationConfiguration` and `ExtendedS3DestinationConfiguration` are both read, and the
+  extended one wins where a request carries both.
+- **`DirectPut` is the only source.** A `DeliveryStreamType` of `KinesisStreamAsSource` is refused,
+  along with any `KinesisStreamSourceConfiguration`. Reading a simulated Kinesis stream is
+  [issue 932](https://github.com/KensioSoftware/yulin/issues/932).
+- **`AWS::KinesisFirehose::DeliveryStream` is skipped on deploy.** It is a Resource type outside
+  the simulation, so it is skipped and the rest of the stack deploys. Deploying one is
+  [issue 933](https://github.com/KensioSoftware/yulin/issues/933).
+- **A delivery stream is `ACTIVE` as soon as it exists.** Real Firehose reports `CREATING` for a
+  minute or so, and a status a test has to poll through earns its keep only where something is
+  being brought up. `DELETING` is absent for the same reason.
+- **Record transformation is absent.** `ProcessingConfiguration` invoking a Lambda over the buffer
+  is a second delivery path, and it is ignored. A delivery stream declaring one delivers the records
+  as they were put.
+- **Dynamic partitioning is absent.** `DynamicPartitioningConfiguration` derives a partition key
+  from record content through jq or a Lambda. A record's bytes are carried here and never read.
+- **Every Object holds the bytes that were put.** GZIP, Snappy, ZIP, Parquet and ORC all change the
+  bytes in the Object while leaving what a test is checking alone, so `CompressionFormat` and
+  `DataFormatConversionConfiguration` are left out. Every destination reports `UNCOMPRESSED`.
+- **The error output path is unused.** `ErrorOutputPrefix` is read and reported back by
+  `DescribeDeliveryStream`. Writing under it takes a record that failed its own transformation or
+  its own conversion, and both of those are absent.
+- **Server-side encryption is absent.** `DeliveryStreamEncryptionConfigurationInput` is ignored, and
+  `Encrypted` is false on every put.
+- **A failed delivery is recorded once.** Real Firehose retries for `DurationInSeconds` and then
+  writes the buffer under the error output prefix. `RetryOptions` is accepted and unused, and a
+  buffer that failed goes straight to `getDeliveryFailures()`.
+- **Throughput is unlimited.** Real Firehose takes a fixed number of records and bytes a second per
+  delivery stream, and refuses past that with `ServiceUnavailableException`. Nothing here counts.
+  `FailedPutCount` on `PutRecordBatch` is always zero for the same reason. Real Firehose fails one
+  record of a batch for throughput limits and internal faults, and both are absent here. The
+  per-record response shape is still what a consumer of the response reads.
+- **Tags are accepted and never listed.** `TagDeliveryStream`, `ListTagsForDeliveryStream` and
+  `UntagDeliveryStream` are absent.
+- **A delivery stream cannot be reconfigured.** `UpdateDestination` is absent. The version in an
+  Object key stays at `1` for the life of the delivery stream.

--- a/docs/services/firehose/README.md
+++ b/docs/services/firehose/README.md
@@ -483,7 +483,9 @@ operations.
   at `CreateDeliveryStream`. A delivery stream created against one of them would take records and
   drop them, and a test asserting on an empty Bucket would blame the code under test.
   `S3DestinationConfiguration` and `ExtendedS3DestinationConfiguration` are both read, and the
-  extended one wins where a request carries both.
+  extended one wins where a request carries both. Either way the delivery stream describes back
+  through `ExtendedS3DestinationDescription`, which is the shape carrying every field read here.
+  `S3DestinationDescription` is always absent.
 - **`DirectPut` is the only source.** A `DeliveryStreamType` of `KinesisStreamAsSource` is refused,
   along with any `KinesisStreamSourceConfiguration`. Reading a simulated Kinesis stream is
   [issue 932](https://github.com/KensioSoftware/yulin/issues/932).

--- a/docs/services/firehose/sim-firehose-buffering.example.ts
+++ b/docs/services/firehose/sim-firehose-buffering.example.ts
@@ -1,0 +1,109 @@
+/**
+ * Three records inside one buffering window, and the single Object they land
+ * in.
+ */
+
+import { text } from "node:stream/consumers";
+
+import {
+  CreateDeliveryStreamCommand,
+  PutRecordBatchCommand,
+} from "@aws-sdk/client-firehose";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateBucketCommand,
+  GetObjectCommand,
+  ListObjectsV2Command,
+} from "@aws-sdk/client-s3";
+import { assertNonNullable } from "@kensio/smartass";
+
+import { SimAws } from "@kensio/yulin";
+
+/**
+ * A Bucket, a delivery Role allowed the S3 actions given, and a delivery
+ * stream writing into the one as the other.
+ */
+async function makeOrderArchive(
+  simAws: SimAws,
+  actions: readonly string[] = ["s3:PutObject"],
+): Promise<void> {
+  await simAws
+    .s3()
+    .createBucket(new CreateBucketCommand({ Bucket: "order-archive" }));
+
+  const { Role } = await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "OrderArchiveRole",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { Service: "firehose.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "OrderArchiveRole",
+      PolicyName: "ArchiveOrders",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Action: actions,
+          Resource: "arn:aws:s3:::order-archive/*",
+        },
+      }),
+    }),
+  );
+
+  await simAws.firehose().createDeliveryStream(
+    new CreateDeliveryStreamCommand({
+      DeliveryStreamName: "order-events",
+      ExtendedS3DestinationConfiguration: {
+        BucketARN: "arn:aws:s3:::order-archive",
+        RoleARN: Role.Arn,
+        BufferingHints: { IntervalInSeconds: 60 },
+      },
+    }),
+  );
+}
+
+const simAws = new SimAws();
+
+await makeOrderArchive(simAws);
+
+await simAws.firehose().putRecordBatch(
+  new PutRecordBatchCommand({
+    DeliveryStreamName: "order-events",
+    Records: ["order-1", "order-2", "order-3"].map((id) => ({
+      Data: new TextEncoder().encode(`${JSON.stringify({ id })}\n`),
+    })),
+  }),
+);
+
+await simAws.clock().advanceBy({ minutes: 2 });
+
+const { Contents } = await simAws
+  .s3()
+  .listObjectsV2(new ListObjectsV2Command({ Bucket: "order-archive" }));
+
+// 1
+console.log(Contents?.length);
+
+const object = await simAws.s3().getObject(
+  new GetObjectCommand({
+    Bucket: "order-archive",
+    Key: Contents?.[0]?.Key,
+  }),
+);
+
+assertNonNullable(object.Body, "The delivered Object has a body");
+
+// {"id":"order-1"}
+// {"id":"order-2"}
+// {"id":"order-3"}
+console.log(await text(object.Body));

--- a/docs/services/firehose/sim-firehose-permissions.example.ts
+++ b/docs/services/firehose/sim-firehose-permissions.example.ts
@@ -1,0 +1,98 @@
+/**
+ * A delivery Role that cannot write to the Bucket, and where the failure shows
+ * up.
+ */
+
+import {
+  CreateDeliveryStreamCommand,
+  PutRecordCommand,
+} from "@aws-sdk/client-firehose";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateBucketCommand, ListObjectsV2Command } from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+
+/**
+ * A Bucket, a delivery Role allowed the S3 actions given, and a delivery
+ * stream writing into the one as the other.
+ */
+async function makeOrderArchive(
+  simAws: SimAws,
+  actions: readonly string[] = ["s3:PutObject"],
+): Promise<void> {
+  await simAws
+    .s3()
+    .createBucket(new CreateBucketCommand({ Bucket: "order-archive" }));
+
+  const { Role } = await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "OrderArchiveRole",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { Service: "firehose.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "OrderArchiveRole",
+      PolicyName: "ArchiveOrders",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Action: actions,
+          Resource: "arn:aws:s3:::order-archive/*",
+        },
+      }),
+    }),
+  );
+
+  await simAws.firehose().createDeliveryStream(
+    new CreateDeliveryStreamCommand({
+      DeliveryStreamName: "order-events",
+      ExtendedS3DestinationConfiguration: {
+        BucketARN: "arn:aws:s3:::order-archive",
+        RoleARN: Role.Arn,
+        BufferingHints: { IntervalInSeconds: 60 },
+      },
+    }),
+  );
+}
+
+const simAws = new SimAws();
+
+// The Role may read the Bucket, and it may not write to it.
+await makeOrderArchive(simAws, ["s3:GetObject", "s3:ListBucket"]);
+
+await simAws.firehose().putRecord(
+  new PutRecordCommand({
+    DeliveryStreamName: "order-events",
+    Record: { Data: new TextEncoder().encode("one\n") },
+  }),
+);
+
+await simAws.clock().advanceBy({ minutes: 2 });
+
+const { Contents } = await simAws
+  .s3()
+  .listObjectsV2(new ListObjectsV2Command({ Bucket: "order-archive" }));
+
+// 0
+console.log(Contents?.length ?? 0);
+
+const [failure] = simAws.firehose().getDeliveryFailures();
+
+// order-events could not write 1 record to order-archive
+console.log(
+  `${failure?.deliveryStreamName} could not write ` +
+    `${failure?.recordCount} record to ${failure?.bucketName}`,
+);
+
+// true
+console.log(failure?.wasRefused);

--- a/docs/services/firehose/sim-firehose-put-and-deliver.example.ts
+++ b/docs/services/firehose/sim-firehose-put-and-deliver.example.ts
@@ -1,0 +1,76 @@
+/**
+ * Putting an order event on a delivery stream and finding it in the Bucket.
+ */
+
+import {
+  CreateDeliveryStreamCommand,
+  PutRecordCommand,
+} from "@aws-sdk/client-firehose";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateBucketCommand, ListObjectsV2Command } from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws
+  .s3()
+  .createBucket(new CreateBucketCommand({ Bucket: "order-archive" }));
+
+const { Role } = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "OrderArchiveRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "firehose.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "OrderArchiveRole",
+    PolicyName: "ArchiveOrders",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "s3:PutObject",
+        Resource: "arn:aws:s3:::order-archive/*",
+      },
+    }),
+  }),
+);
+
+await simAws.firehose().createDeliveryStream(
+  new CreateDeliveryStreamCommand({
+    DeliveryStreamName: "order-events",
+    ExtendedS3DestinationConfiguration: {
+      BucketARN: "arn:aws:s3:::order-archive",
+      RoleARN: Role.Arn,
+      BufferingHints: { IntervalInSeconds: 60 },
+    },
+  }),
+);
+
+const orderEvent = `${JSON.stringify({ id: "order-1" })}\n`;
+
+await simAws.firehose().putRecord(
+  new PutRecordCommand({
+    DeliveryStreamName: "order-events",
+    Record: { Data: new TextEncoder().encode(orderEvent) },
+  }),
+);
+
+await simAws.clock().advanceBy({ seconds: 61 });
+
+const { Contents } = await simAws
+  .s3()
+  .listObjectsV2(new ListObjectsV2Command({ Bucket: "order-archive" }));
+
+// 2026/08/22/13/order-events-1-2026-08-22-13-51-01-92076704-cf4a-...
+console.log(Contents?.[0]?.Key);

--- a/docs/services/firehose/sim-firehose-sdk-interception.example.ts
+++ b/docs/services/firehose/sim-firehose-sdk-interception.example.ts
@@ -1,0 +1,98 @@
+/**
+ * Application code sending to its own FirehoseClient, answered by the
+ * simulation.
+ */
+
+import {
+  CreateDeliveryStreamCommand,
+  FirehoseClient,
+  PutRecordCommand,
+} from "@aws-sdk/client-firehose";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateBucketCommand,
+  ListObjectsV2Command,
+  S3Client,
+} from "@aws-sdk/client-s3";
+
+import type { SimAws } from "@kensio/yulin";
+import { SimSdk } from "@kensio/yulin/sdk";
+
+/**
+ * A Bucket, a delivery Role allowed the S3 actions given, and a delivery
+ * stream writing into the one as the other.
+ */
+async function makeOrderArchive(
+  simAws: SimAws,
+  actions: readonly string[] = ["s3:PutObject"],
+): Promise<void> {
+  await simAws
+    .s3()
+    .createBucket(new CreateBucketCommand({ Bucket: "order-archive" }));
+
+  const { Role } = await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "OrderArchiveRole",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { Service: "firehose.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "OrderArchiveRole",
+      PolicyName: "ArchiveOrders",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Action: actions,
+          Resource: "arn:aws:s3:::order-archive/*",
+        },
+      }),
+    }),
+  );
+
+  await simAws.firehose().createDeliveryStream(
+    new CreateDeliveryStreamCommand({
+      DeliveryStreamName: "order-events",
+      ExtendedS3DestinationConfiguration: {
+        BucketARN: "arn:aws:s3:::order-archive",
+        RoleARN: Role.Arn,
+        BufferingHints: { IntervalInSeconds: 60 },
+      },
+    }),
+  );
+}
+
+using simSdk = new SimSdk();
+
+simSdk.intercept(FirehoseClient);
+simSdk.intercept(S3Client);
+
+await makeOrderArchive(simSdk.simAws);
+
+const firehose = new FirehoseClient({ region: "us-east-1" });
+const s3 = new S3Client({ region: "us-east-1" });
+
+await firehose.send(
+  new PutRecordCommand({
+    DeliveryStreamName: "order-events",
+    Record: { Data: new TextEncoder().encode("one\n") },
+  }),
+);
+
+await simSdk.simAws.clock().advanceBy({ minutes: 2 });
+
+const { Contents } = await s3.send(
+  new ListObjectsV2Command({ Bucket: "order-archive" }),
+);
+
+// 1
+console.log(Contents?.length);

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -18,6 +18,7 @@
       "@kensio/yulin/dynamodb": ["../src/service/dynamodb/index.ts"],
       "@kensio/yulin/elbv2": ["../src/service/elbv2/index.ts"],
       "@kensio/yulin/eslint": ["../src/config/eslint/index.ts"],
+      "@kensio/yulin/firehose": ["../src/service/firehose/index.ts"],
       "@kensio/yulin/iam": ["../src/service/iam/index.ts"],
       "@kensio/yulin/kinesis": ["../src/service/kinesis/index.ts"],
       "@kensio/yulin/kms": ["../src/service/kms/index.ts"],

--- a/package.json
+++ b/package.json
@@ -99,6 +99,10 @@
       "import": "./dist/config/eslint/index.js",
       "types": "./dist/config/eslint/index.d.ts"
     },
+    "./firehose": {
+      "import": "./dist/service/firehose/index.js",
+      "types": "./dist/service/firehose/index.d.ts"
+    },
     "./eventbridge": {
       "import": "./dist/service/eventbridge/index.js",
       "types": "./dist/service/eventbridge/index.d.ts"
@@ -217,6 +221,7 @@
     "@aws-sdk/client-ecs": "^3.1101.0",
     "@aws-sdk/client-elastic-load-balancing-v2": "^3.1109.0",
     "@aws-sdk/client-eventbridge": "^3.1109.0",
+    "@aws-sdk/client-firehose": "^3.1115.0",
     "@aws-sdk/client-iam": "^3.1101.0",
     "@aws-sdk/client-kinesis": "^3.1115.0",
     "@aws-sdk/client-kms": "^3.1101.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       '@aws-sdk/client-eventbridge':
         specifier: ^3.1109.0
         version: 3.1110.0
+      '@aws-sdk/client-firehose':
+        specifier: ^3.1115.0
+        version: 3.1115.0
       '@aws-sdk/client-iam':
         specifier: ^3.1101.0
         version: 3.1110.0
@@ -353,6 +356,10 @@ packages:
 
   '@aws-sdk/client-eventbridge@3.1110.0':
     resolution: {integrity: sha512-ajLRxMZVak1rGzhqtS/u8Mdfuo6Nj6YivR2vMHMXgejFf+6mOauFc6XInLcvUc1NwwFJHhrGTGMTuxbo9QCz9g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-firehose@3.1115.0':
+    resolution: {integrity: sha512-tgK3cwUN6LBOLZBZygICRJ4XkUvOhp3Nzd99Nz7NqsUnOgqSCtvMv5j+zJKG/eiEUDv7CeTUTkWRCEdyFZmFlQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-iam@3.1110.0':
@@ -3814,6 +3821,17 @@ snapshots:
       '@aws-sdk/core': 3.977.8
       '@aws-sdk/credential-provider-node': 3.972.80
       '@aws-sdk/signature-v4-multi-region': 3.996.45
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/client-firehose@3.1115.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/credential-provider-node': 3.972.80
       '@aws-sdk/types': 3.974.4
       '@smithy/core': 3.33.2
       '@smithy/fetch-http-handler': 5.7.2

--- a/src/sdk/router/resolve-sim-sdk-command-router.ts
+++ b/src/sdk/router/resolve-sim-sdk-command-router.ts
@@ -82,6 +82,10 @@ const scopedRouters: ReadonlyMap<string, SimSdkScopedRouter> = new Map<
   ],
   ["IAM", (scoped): SimSdkCommandRouter => scoped.iam().sdkCommandRouter()],
   [
+    "Firehose",
+    (scoped): SimSdkCommandRouter => scoped.firehose().sdkCommandRouter(),
+  ],
+  [
     "Kinesis",
     (scoped): SimSdkCommandRouter => scoped.kinesis().sdkCommandRouter(),
   ],

--- a/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
@@ -1,6 +1,7 @@
 import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-scope.js";
 import { SimBedrock } from "../../bedrock/index.js";
 import { SimDynamoDb as SimDynamoDatabase } from "../../dynamodb/index.js";
+import { SimFirehose } from "../../firehose/index.js";
 import { SimKinesis } from "../../kinesis/index.js";
 import { SimSecretsManager } from "../../secretsmanager/index.js";
 import { SimSqs } from "../../sqs/index.js";
@@ -48,6 +49,16 @@ export class SimAwsSelfContainedServiceBuilder {
   /** Create simulated DynamoDB for an Account Region scope. */
   createDynamoDb(scope: SimAwsAccountRegionContainer): SimDynamoDatabase {
     return new SimDynamoDatabase(this.scoped(scope));
+  }
+
+  /**
+   * Create simulated Kinesis Data Firehose for an Account Region scope.
+   *
+   * Delivery streams are Region-scoped on real AWS, and a delivery stream
+   * writes into a Bucket through that same scope's simulated S3.
+   */
+  createFirehose(scope: SimAwsAccountRegionContainer): SimFirehose {
+    return new SimFirehose({ ...this.scoped(scope), s3: scope.s3() });
   }
 
   /**

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -24,6 +24,7 @@ import type { SimScheduler } from "../../scheduler/index.js";
 import type { SimElbV2 } from "../../elbv2/index.js";
 import type { SimIam } from "../../iam/index.js";
 import { SimIamRegistry } from "../../iam/registry/sim-iam-registry.js";
+import type { SimFirehose } from "../../firehose/index.js";
 import type { SimKinesis } from "../../kinesis/index.js";
 import type { SimKms } from "../../kms/index.js";
 import type { SimLambda } from "../../lambda/index.js";
@@ -229,6 +230,11 @@ export class SimAwsServiceFactory {
   /** Create simulated KMS for an Account Region scope. */
   createKms(scope: SimAwsAccountRegionContainer): SimKms {
     return this.registeredServices.createKms(scope);
+  }
+
+  /** Create simulated Kinesis Data Firehose for an Account Region scope. */
+  createFirehose(scope: SimAwsAccountRegionContainer): SimFirehose {
+    return this.selfContainedServices.createFirehose(scope);
   }
 
   /** Create simulated Kinesis Data Streams for an Account Region scope. */

--- a/src/service/aws/sim-aws-account-region-scope.ts
+++ b/src/service/aws/sim-aws-account-region-scope.ts
@@ -30,6 +30,7 @@ import type { SimApiGateway } from "../apigateway/index.js";
 import type { SimApiGatewayV2 } from "../apigatewayv2/index.js";
 import type { SimElbV2 } from "../elbv2/index.js";
 import type { SimIam } from "../iam/index.js";
+import type { SimFirehose } from "../firehose/index.js";
 import type { SimKinesis } from "../kinesis/index.js";
 import type { SimKms } from "../kms/index.js";
 import type { SimLambda } from "../lambda/index.js";
@@ -194,6 +195,13 @@ export class SimAwsAccountRegionContainer {
   /** Get simulated IAM for this account. */
   iam(): SimIam {
     return this.memo.getOrCreate("iam", () => this.factory.createIam(this));
+  }
+
+  /** Get simulated Kinesis Data Firehose for this account and region. */
+  firehose(): SimFirehose {
+    return this.memo.getOrCreate("firehose", () =>
+      this.factory.createFirehose(this),
+    );
   }
 
   /** Get simulated Kinesis Data Streams for this account and region. */

--- a/src/service/aws/sim-aws-account.ts
+++ b/src/service/aws/sim-aws-account.ts
@@ -13,6 +13,7 @@ import type { SimCloudFormation } from "../cloudformation/index.js";
 import type { SimAcm } from "../acm/sim-acm.js";
 import type { SimRoute53 } from "../route53/index.js";
 import type { SimIam } from "../iam/index.js";
+import type { SimFirehose } from "../firehose/index.js";
 import type { SimKinesis } from "../kinesis/index.js";
 import type { SimKms } from "../kms/index.js";
 import type { SimLambda } from "../lambda/index.js";
@@ -121,6 +122,13 @@ export class SimAwsAccount {
    */
   iam(): SimIam {
     return this.region().iam();
+  }
+
+  /**
+   * Get simulated Kinesis Data Firehose for this Account's default Region.
+   */
+  firehose(): SimFirehose {
+    return this.region().firehose();
   }
 
   /**

--- a/src/service/aws/sim-aws-region.ts
+++ b/src/service/aws/sim-aws-region.ts
@@ -11,6 +11,7 @@ import type {
 import { SimAws } from "./sim-aws.js";
 import type { SimCloudFormation } from "../cloudformation/index.js";
 import type { SimAcm } from "../acm/sim-acm.js";
+import type { SimFirehose } from "../firehose/index.js";
 import type { SimKinesis } from "../kinesis/index.js";
 import type { SimKms } from "../kms/index.js";
 import type { SimLambda } from "../lambda/index.js";
@@ -168,6 +169,13 @@ export class SimAwsRegion {
    */
   dynamoDbStreams(): SimDynamoDbStreams {
     return this.account().dynamoDbStreams();
+  }
+
+  /**
+   * Get simulated Kinesis Data Firehose for this Region's default Account.
+   */
+  firehose(): SimFirehose {
+    return this.account().firehose();
   }
 
   /**

--- a/src/service/aws/sim-aws-service-accessors.ts
+++ b/src/service/aws/sim-aws-service-accessors.ts
@@ -16,6 +16,7 @@ import type { SimEcr } from "../ecr/index.js";
 import type { SimEcs } from "../ecs/index.js";
 import type { SimElbV2 } from "../elbv2/index.js";
 import type { SimIam } from "../iam/index.js";
+import type { SimFirehose } from "../firehose/index.js";
 import type { SimKinesis } from "../kinesis/index.js";
 import type { SimKms } from "../kms/index.js";
 import type { SimLambda } from "../lambda/index.js";
@@ -137,6 +138,11 @@ export abstract class SimAwsServiceAccessors {
   /** Get simulated IAM in the default Account scope. */
   iam(): SimIam {
     return this.defaultAccountRegionScope().iam();
+  }
+
+  /** Get simulated Kinesis Data Firehose in the default Account Region scope. */
+  firehose(): SimFirehose {
+    return this.defaultAccountRegionScope().firehose();
   }
 
   /** Get simulated Kinesis Data Streams in the default Account Region scope. */

--- a/src/service/aws/sim-aws.iso.test.ts
+++ b/src/service/aws/sim-aws.iso.test.ts
@@ -113,6 +113,15 @@ describe("SimAws", () => {
     assertIdentical(simAws.account().region().personalizeEvents(), events);
   });
 
+  it("returns the same Firehose from every scope", () => {
+    const simAws = new SimAws();
+    const firehose = simAws.firehose();
+
+    assertIdentical(simAws.account().firehose(), firehose);
+    assertIdentical(simAws.region().firehose(), firehose);
+    assertIdentical(simAws.account().region().firehose(), firehose);
+  });
+
   it("returns the same Kinesis from every scope", () => {
     const simAws = new SimAws();
     const kinesis = simAws.kinesis();

--- a/src/service/firehose/README.md
+++ b/src/service/firehose/README.md
@@ -1,0 +1,103 @@
+# Simulated Kinesis Data Firehose implementation
+
+This directory holds the simulated Kinesis Data Firehose service. S3 is the only destination and
+`DirectPut` the only source.
+
+A delivery stream is a destination and a buffer. Records go on through `PutRecord`, wait until the
+buffer passes one of its two bounds, and leave as one S3 Object.
+
+## Entry points
+
+- `sim-firehose.ts` is the in-memory service object for one Account and Region scope.
+- `index.ts` exports the public API for `@kensio/yulin/firehose`.
+
+A `SimFirehose` owns a `SimFirehoseDeliveryStreamStore` holding its delivery streams, and a
+`SimFirehoseDeliveryFailures` holding the buffers it could not write. The simulator is scoped to an
+Account and Region because real delivery streams are. A delivery stream ARN names the Region, and a
+delivery stream name is unique within one Account and Region.
+
+This one is built with a collaborator, unlike most of the self-contained services. It takes the
+simulated S3 of its own scope as a `SimFirehoseObjectDestination`. That interface names the one
+operation delivery needs, and `SimS3` implements it structurally.
+
+## Delivery stream model
+
+Delivery stream state lives under `stream/`, and what it delivers to under `destination/`.
+
+`SimFirehoseDeliveryStream` is the stored resource. It holds its name, its ARN, its destination and
+its buffer.
+
+`SimFirehoseS3Destination` is a parsed `ExtendedS3DestinationConfiguration`. The Bucket is held by
+name as well as by ARN, because a `PutObject` names a Bucket. An S3 Bucket ARN carries no Account
+and no Region, and the name is all it has to give.
+
+`SimFirehoseBufferingHints` holds the two bounds in the units the buffer and the scheduler work in,
+which are bytes and milliseconds. The bounds Firehose allows are checked when a delivery stream is
+created. A request asking for a buffer Firehose would refuse is refused here, at the same call.
+
+`simFirehoseDestinationOf` picks the destination a request declared. A destination outside the
+simulation is refused by name, with `SimFirehoseUnsimulatedDestination`. A delivery stream created
+against Redshift or OpenSearch would take records and drop them, and a test asserting on an empty
+Bucket would blame the code under test.
+
+## Delivery
+
+The delivery path lives under `delivery/`, and it is the part with no counterpart elsewhere in the
+simulation.
+
+`SimFirehoseBuffer` accumulates the records a delivery stream has taken. `take()` empties it into
+the bytes one Object holds, concatenated with no separator between them. That is what real Firehose
+writes. Taking and emptying happen together so that a record put while a delivery is under way joins
+the next buffer.
+
+`SimFirehoseDelivery` decides when a buffer is written. The size bound is checked as each record
+arrives. The interval bound is a task on `background.scheduleAt`, so advancing simulated time past
+the interval is what dispatches it. The task is scheduled when a record lands on an empty buffer.
+The interval then runs from the first record of a buffer, as real Firehose measures it. A buffer
+that fills first cancels that task and delivers on the background scheduler, since real Firehose
+answers the producer before it writes anything.
+
+Two size deliveries can be scheduled before either runs. `SimFirehoseObjectWriter` checks for an
+empty buffer because of that, since the second finds what the first already took.
+
+`SimFirehoseObjectWriter` makes the `PutObject`, as the delivery stream's `RoleARN`. Simulated IAM
+then applies to the write exactly as `s3:PutObject` authorization applies on real AWS, and the
+caller who put the record needs no S3 permission at all. A write that failed is recorded on
+`SimFirehoseDeliveryFailures` and swallowed. Real Firehose answered the `PutRecord` minutes earlier,
+and there is no caller left to raise at.
+
+`simFirehoseObjectKey` builds the key, from the prefix, the UTC date path, the delivery stream name,
+its version, the delivery instant and a random string. The instant comes from the scheduler's clock.
+A test that sets the clock therefore knows the prefix its Objects are under.
+
+## Commands
+
+Command handlers live under `command/`, grouped by what they act on: `stream/` creates, lists,
+describes and deletes, and `record/` puts.
+
+`SimFirehoseDeliveryStreamAccess` is how every operation but `ListDeliveryStreams` and
+`CreateDeliveryStream` reaches its delivery stream. It authorizes the action against the delivery
+stream's ARN and then looks the delivery stream up, in that order, because that is the order real
+IAM works in. A caller with no permission is refused for a delivery stream that was never created,
+and hears the same refusal either way.
+
+Every Firehose operation names its delivery stream by name, and nothing here reads an ARN back.
+Compare `simKinesisRefLookupName`. It exists because a Kinesis request can name its stream either
+way.
+
+## What is left out
+
+`sdk/sim-firehose-sdk-command-router.ts` names the six commands this service handles. Anything else
+an intercepted client sends is refused with `SimSdkUnsupportedCommandError`, which covers
+`UpdateDestination`, encryption and the tag operations.
+
+There is no `cfn/` here. `AWS::KinesisFirehose::DeliveryStream` is skipped on deploy, and issue 933
+is where it is added.
+
+`DeliveryStreamType` of `KinesisStreamAsSource` is refused with `SimFirehoseUnsimulatedSource`.
+Issue 932 is where a delivery stream reading a simulated Kinesis stream is added. It wants a poller
+of its own, because the one under `src/service/lambda/event-source/poll/kinesis/` is bound to a
+function and a mapping.
+
+`docs/services/firehose/README.md` is the user-facing page, and its **Divergences and limitations**
+section is the full list.

--- a/src/service/firehose/command/authorize/sim-firehose-authorizer.ts
+++ b/src/service/firehose/command/authorize/sim-firehose-authorizer.ts
@@ -1,0 +1,73 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+
+interface SimFirehoseAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * Applies simulated IAM authorization to Firehose requests.
+ *
+ * AWS maps each Firehose API operation to the `firehose:` action of the same
+ * name, and the resource is the ARN of the delivery stream the operation names.
+ * ListDeliveryStreams is the exception. It names no delivery stream, so it
+ * authorizes against `*`.
+ */
+export class SimFirehoseAuthorizer {
+  private readonly iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: SimFirehoseAuthorizerProperties) {
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Ensure the caller may perform an action on a delivery stream, named by its
+   * ARN.
+   *
+   * The delivery stream need not exist. Real IAM evaluates a request before the
+   * service handles it, so a caller with no permission is refused whether or
+   * not the delivery stream is there. That also keeps an unauthorized caller
+   * from finding out which delivery stream names are taken.
+   */
+  authorizeDeliveryStream(
+    action: string,
+    deliveryStreamArn: string,
+    caller?: SimAwsCaller,
+  ): SimAwsResolvedCaller {
+    return this.authorizeResource(action, deliveryStreamArn, caller);
+  }
+
+  /**
+   * Ensure the caller may perform an action naming no particular delivery
+   * stream.
+   *
+   * Authorization applies to the whole operation. A denied caller receives
+   * AccessDenied rather than an empty or filtered listing.
+   */
+  authorizeAnyDeliveryStream(
+    action: string,
+    caller?: SimAwsCaller,
+  ): SimAwsResolvedCaller {
+    return this.authorizeResource(action, "*", caller);
+  }
+
+  private authorizeResource(
+    action: string,
+    resource: string,
+    caller: SimAwsCaller | undefined,
+  ): SimAwsResolvedCaller {
+    const decision = this.iam.authorize({ action, resource, caller });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action,
+        resource,
+      });
+    }
+
+    return decision.caller;
+  }
+}

--- a/src/service/firehose/command/authorize/sim-firehose-iam.iso.test.ts
+++ b/src/service/firehose/command/authorize/sim-firehose-iam.iso.test.ts
@@ -1,0 +1,248 @@
+import {
+  CreateDeliveryStreamCommand,
+  DeleteDeliveryStreamCommand,
+  DescribeDeliveryStreamCommand,
+  ListDeliveryStreamsCommand,
+  PutRecordBatchCommand,
+  PutRecordCommand,
+} from "@aws-sdk/client-firehose";
+import { CreateBucketCommand } from "@aws-sdk/client-s3";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simIamRoleWithPolicyFactory } from "../../../iam/role/sim-iam-role-with-policy.factory.js";
+import { simFirehoseDeliveryStreamFactory } from "../../stream/sim-firehose-delivery-stream.factory.js";
+
+/**
+ * A simulated AWS with a Bucket, a delivery stream, and a caller allowed the
+ * actions it is given on the resource it is given.
+ */
+async function simAwsWithCaller(
+  actions: readonly string[],
+  resource = "*",
+): Promise<{ simAws: SimAws; caller: SimAwsCaller }> {
+  const simAws = new SimAws();
+
+  await simAws
+    .s3()
+    .createBucket(new CreateBucketCommand({ Bucket: "order-archive" }));
+  await simFirehoseDeliveryStreamFactory.make({}, simAws);
+
+  const role = await simIamRoleWithPolicyFactory.make(
+    {
+      roleName: "OrderProducerRole",
+      policyName: "ProduceOrders",
+      actions,
+      resource,
+    },
+    simAws,
+  );
+
+  return { simAws, caller: { kind: "arn", arn: role.Arn } };
+}
+
+describe("Simulated Firehose IAM authorization", () => {
+  it("allows a put by a caller allowed it on that delivery stream", async () => {
+    // Given a caller allowed firehose:PutRecord on the delivery stream.
+    const { simAws, caller } = await simAwsWithCaller(
+      ["firehose:PutRecord"],
+      `arn:aws:firehose:us-east-1:${new SimAws().defaultAccountId}:deliverystream/order-events`,
+    );
+
+    // When it puts a record.
+    const output = await simAws.firehose().putRecord(
+      new PutRecordCommand({
+        DeliveryStreamName: "order-events",
+        Record: { Data: new Uint8Array([1]) },
+      }),
+      { caller },
+    );
+
+    // Then the put was taken.
+    assertStringIncludes(output.RecordId, "-");
+  });
+
+  it("refuses a put by a caller allowed it on another delivery stream", async () => {
+    // Given a caller allowed firehose:PutRecord on a different delivery
+    // stream.
+    const { simAws, caller } = await simAwsWithCaller(
+      ["firehose:PutRecord"],
+      "arn:aws:firehose:us-east-1:888888888888:deliverystream/other-events",
+    );
+
+    // When it puts a record onto ours.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.firehose().putRecord(
+        new PutRecordCommand({
+          DeliveryStreamName: "order-events",
+          Record: { Data: new Uint8Array([1]) },
+        }),
+        { caller },
+      );
+    });
+
+    // Then IAM refuses it, naming the action and the delivery stream.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertStringIncludes(error.message, "firehose:PutRecord");
+    assertStringIncludes(error.message, "deliverystream/order-events");
+  });
+
+  it("refuses a caller before it finds out the delivery stream is missing", async () => {
+    // Given a caller allowed nothing.
+    const { simAws, caller } = await simAwsWithCaller([]);
+
+    // When it describes a delivery stream that is not there.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.firehose().describeDeliveryStream(
+        new DescribeDeliveryStreamCommand({
+          DeliveryStreamName: "never-existed",
+        }),
+        { caller },
+      );
+    });
+
+    // Then it is refused rather than told the delivery stream is missing,
+    // which is the order real IAM works in.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.name, "AccessDenied");
+  });
+
+  it("authorizes a listing against every delivery stream", async () => {
+    // Given a caller allowed firehose:ListDeliveryStreams on one delivery
+    // stream rather than on all of them.
+    const { simAws, caller } = await simAwsWithCaller(
+      ["firehose:ListDeliveryStreams"],
+      "arn:aws:firehose:us-east-1:888888888888:deliverystream/order-events",
+    );
+
+    // When it lists.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .firehose()
+        .listDeliveryStreams(new ListDeliveryStreamsCommand({}), { caller });
+    });
+
+    // Then it is refused. The action names no delivery stream, so a policy
+    // scoped to one does not reach it.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertStringIncludes(error.message, "firehose:ListDeliveryStreams");
+  });
+
+  it("lists for a caller allowed the action on every delivery stream", async () => {
+    // Given a caller allowed firehose:ListDeliveryStreams on all of them.
+    const { simAws, caller } = await simAwsWithCaller([
+      "firehose:ListDeliveryStreams",
+    ]);
+
+    // When it lists.
+    const listed = await simAws
+      .firehose()
+      .listDeliveryStreams(new ListDeliveryStreamsCommand({}), { caller });
+
+    // Then the listing is not filtered by what it may reach.
+    assertArrayLength(listed.DeliveryStreamNames, 1);
+  });
+
+  it("refuses each operation the caller was not allowed", async () => {
+    // Given a caller allowed nothing.
+    const { simAws, caller } = await simAwsWithCaller([]);
+    const firehose = simAws.firehose();
+
+    // When each of the remaining operations is tried.
+    const refusals = await Promise.all(
+      [
+        async (): Promise<unknown> =>
+          await firehose.createDeliveryStream(
+            new CreateDeliveryStreamCommand({
+              DeliveryStreamName: "other-events",
+              ExtendedS3DestinationConfiguration: {
+                BucketARN: "arn:aws:s3:::order-archive",
+                RoleARN: "arn:aws:iam::888888888888:role/Other",
+              },
+            }),
+            { caller },
+          ),
+        async (): Promise<unknown> =>
+          await firehose.deleteDeliveryStream(
+            new DeleteDeliveryStreamCommand({
+              DeliveryStreamName: "order-events",
+            }),
+            { caller },
+          ),
+        async (): Promise<unknown> =>
+          await firehose.putRecordBatch(
+            new PutRecordBatchCommand({
+              DeliveryStreamName: "order-events",
+              Records: [{ Data: new Uint8Array([1]) }],
+            }),
+            { caller },
+          ),
+      ].map(async (operation) => await assertThrowsErrorAsync(operation)),
+    );
+
+    // Then every one of them is refused, naming its own action.
+    assertStringIncludes(
+      refusals[0]?.message ?? "",
+      "firehose:CreateDeliveryStream",
+    );
+    assertStringIncludes(
+      refusals[1]?.message ?? "",
+      "firehose:DeleteDeliveryStream",
+    );
+    assertStringIncludes(refusals[2]?.message ?? "", "firehose:PutRecordBatch");
+  });
+
+  it("authorizes a creation against the ARN the delivery stream will have", async () => {
+    // Given a caller allowed firehose:CreateDeliveryStream on one name only.
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "order-archive" }));
+
+    const role = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "OrderAdminRole",
+        policyName: "AdministerOrders",
+        actions: ["firehose:CreateDeliveryStream"],
+        resource: `arn:aws:firehose:${simAws.defaultRegionName}:${simAws.defaultAccountId}:deliverystream/order-events`,
+      },
+      simAws,
+    );
+    const caller: SimAwsCaller = { kind: "arn", arn: role.Arn };
+    const destination = {
+      BucketARN: "arn:aws:s3:::order-archive",
+      RoleARN: "arn:aws:iam::888888888888:role/OrderArchiveRole",
+    };
+
+    // When it creates that one, and then another.
+    await simAws.firehose().createDeliveryStream(
+      new CreateDeliveryStreamCommand({
+        DeliveryStreamName: "order-events",
+        ExtendedS3DestinationConfiguration: destination,
+      }),
+      { caller },
+    );
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.firehose().createDeliveryStream(
+        new CreateDeliveryStreamCommand({
+          DeliveryStreamName: "other-events",
+          ExtendedS3DestinationConfiguration: destination,
+        }),
+        { caller },
+      );
+    });
+
+    // Then the allowed name was created and the other refused.
+    assertStringIncludes(error.message, "deliverystream/other-events");
+  });
+});

--- a/src/service/firehose/command/record/record.command.ts
+++ b/src/service/firehose/command/record/record.command.ts
@@ -1,0 +1,62 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * One record as a put request carries it.
+ */
+export interface SimFirehoseRecordInput {
+  readonly Data?: Uint8Array | undefined;
+}
+
+/**
+ * Minimal structural sim Firehose PutRecord command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/firehose/command/PutRecordCommand/
+ */
+export interface SimPutRecordCommand {
+  readonly input: SimPutRecordCommandInput;
+}
+
+export interface SimPutRecordCommandInput {
+  readonly DeliveryStreamName?: string | undefined;
+  readonly Record?: SimFirehoseRecordInput | undefined;
+}
+
+export interface SimPutRecordCommandOutput {
+  readonly RecordId: string;
+  readonly Encrypted: boolean;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Firehose PutRecordBatch command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/firehose/command/PutRecordBatchCommand/
+ */
+export interface SimPutRecordBatchCommand {
+  readonly input: SimPutRecordBatchCommandInput;
+}
+
+export interface SimPutRecordBatchCommandInput {
+  readonly DeliveryStreamName?: string | undefined;
+  readonly Records?: readonly SimFirehoseRecordInput[] | undefined;
+}
+
+/**
+ * What became of one record a PutRecordBatch request carried.
+ *
+ * A record the delivery stream took carries the id it was given. One it refused
+ * carries an error code and message instead, which is how real Firehose reports
+ * a record it dropped while accepting the rest of the batch.
+ */
+export interface SimFirehosePutRecordBatchResponseEntry {
+  readonly RecordId?: string | undefined;
+  readonly ErrorCode?: string | undefined;
+  readonly ErrorMessage?: string | undefined;
+}
+
+export interface SimPutRecordBatchCommandOutput {
+  readonly FailedPutCount: number;
+  readonly Encrypted: boolean;
+  readonly RequestResponses: readonly SimFirehosePutRecordBatchResponseEntry[];
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/firehose/command/record/sim-firehose-put-commands.ts
+++ b/src/service/firehose/command/record/sim-firehose-put-commands.ts
@@ -1,0 +1,95 @@
+import { randomUUID } from "node:crypto";
+import type { SimFirehoseDelivery } from "../../delivery/sim-firehose-delivery.js";
+import type { SimFirehoseDeliveryStreamAccess } from "../sim-firehose-delivery-stream-access.js";
+import type { SimFirehoseRequestOptions } from "../sim-firehose-request-options.js";
+import {
+  simFirehoseBatchData,
+  simFirehoseRecordData,
+} from "./sim-firehose-record-data.js";
+import type {
+  SimFirehosePutRecordBatchResponseEntry,
+  SimPutRecordBatchCommand,
+  SimPutRecordBatchCommandOutput,
+  SimPutRecordCommand,
+  SimPutRecordCommandOutput,
+} from "./record.command.js";
+
+interface SimFirehosePutCommandsProperties {
+  readonly access: SimFirehoseDeliveryStreamAccess;
+  readonly delivery: SimFirehoseDelivery;
+}
+
+/**
+ * The commands that put records onto a delivery stream.
+ *
+ * A record is taken onto the delivery stream's buffer and the request is
+ * answered. The Object it will land in is written later, when the buffer passes
+ * one of its two bounds.
+ *
+ * `Encrypted` is always false. Server side encryption changes nothing a test
+ * can see, so `DeliveryStreamEncryptionConfigurationInput` is left unsimulated
+ * and no delivery stream reports itself encrypted.
+ */
+export class SimFirehosePutCommands {
+  private readonly access: SimFirehoseDeliveryStreamAccess;
+  private readonly delivery: SimFirehoseDelivery;
+
+  constructor(properties: SimFirehosePutCommandsProperties) {
+    this.access = properties.access;
+    this.delivery = properties.delivery;
+  }
+
+  /**
+   * Put one record onto a delivery stream.
+   */
+  putRecord(
+    command: SimPutRecordCommand,
+    options?: SimFirehoseRequestOptions,
+  ): SimPutRecordCommandOutput {
+    const deliveryStream = this.access.require(
+      "firehose:PutRecord",
+      command.input.DeliveryStreamName,
+      options,
+    );
+
+    this.delivery.accept(
+      deliveryStream,
+      simFirehoseRecordData(command.input.Record),
+    );
+
+    return { $metadata: {}, RecordId: randomUUID(), Encrypted: false };
+  }
+
+  /**
+   * Put a batch of records onto a delivery stream.
+   *
+   * Every record in a batch this simulation accepted is taken. Real Firehose
+   * can fail some of a batch under throttling, and nothing here throttles, so
+   * `FailedPutCount` is always zero and every response entry carries a record
+   * id.
+   */
+  putRecordBatch(
+    command: SimPutRecordBatchCommand,
+    options?: SimFirehoseRequestOptions,
+  ): SimPutRecordBatchCommandOutput {
+    const deliveryStream = this.access.require(
+      "firehose:PutRecordBatch",
+      command.input.DeliveryStreamName,
+      options,
+    );
+    const data = simFirehoseBatchData(command.input.Records);
+    const responses: SimFirehosePutRecordBatchResponseEntry[] = [];
+
+    for (const record of data) {
+      this.delivery.accept(deliveryStream, record);
+      responses.push({ RecordId: randomUUID() });
+    }
+
+    return {
+      $metadata: {},
+      FailedPutCount: 0,
+      Encrypted: false,
+      RequestResponses: responses,
+    };
+  }
+}

--- a/src/service/firehose/command/record/sim-firehose-put-validation.iso.test.ts
+++ b/src/service/firehose/command/record/sim-firehose-put-validation.iso.test.ts
@@ -1,0 +1,187 @@
+import {
+  PutRecordBatchCommand,
+  PutRecordCommand,
+} from "@aws-sdk/client-firehose";
+import { CreateBucketCommand } from "@aws-sdk/client-s3";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUuidV4,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimFirehoseInvalidArgumentException } from "../../error/sim-firehose.error.js";
+import { simFirehoseDeliveryStreamFactory } from "../../stream/sim-firehose-delivery-stream.factory.js";
+
+/**
+ * A simulated AWS with a Bucket and a delivery stream writing into it.
+ */
+async function simAwsWithDeliveryStream(): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simAws
+    .s3()
+    .createBucket(new CreateBucketCommand({ Bucket: "order-archive" }));
+  await simFirehoseDeliveryStreamFactory.make({}, simAws);
+
+  return simAws;
+}
+
+describe("What a simulated Firehose put takes", () => {
+  it("answers a put with a record id", async () => {
+    // Given a delivery stream.
+    const simAws = await simAwsWithDeliveryStream();
+
+    // When a record is put.
+    const output = await simAws.firehose().putRecord(
+      new PutRecordCommand({
+        DeliveryStreamName: "order-events",
+        Record: { Data: new TextEncoder().encode("one") },
+      }),
+    );
+
+    // Then the record has an id, and the delivery stream is not encrypted.
+    assertUuidV4(output.RecordId);
+    assertFalse(output.Encrypted);
+  });
+
+  it("answers a batch with one id per record", async () => {
+    // Given a delivery stream.
+    const simAws = await simAwsWithDeliveryStream();
+
+    // When three records are put in one request.
+    const output = await simAws.firehose().putRecordBatch(
+      new PutRecordBatchCommand({
+        DeliveryStreamName: "order-events",
+        Records: [{ Data: new Uint8Array([1]) }, { Data: new Uint8Array([2]) }],
+      }),
+    );
+
+    // Then every one of them was taken. Nothing here throttles, so no record
+    // in an accepted batch fails.
+    assertIdentical(output.FailedPutCount, 0);
+    assertArrayLength(output.RequestResponses, 2);
+
+    const [first] = output.RequestResponses;
+    assertNonNullable(first, "The first record has a response entry");
+    assertUuidV4(first.RecordId);
+  });
+
+  it("refuses a record carrying no data", async () => {
+    const simAws = await simAwsWithDeliveryStream();
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .firehose()
+        .putRecord({ input: { DeliveryStreamName: "order-events" } });
+    });
+
+    assertInstanceOf(error, SimFirehoseInvalidArgumentException);
+    assertStringIncludes(error.message, "no Data");
+  });
+
+  it("refuses a record over the size Firehose takes", async () => {
+    const simAws = await simAwsWithDeliveryStream();
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.firehose().putRecord(
+        new PutRecordCommand({
+          DeliveryStreamName: "order-events",
+          Record: { Data: new Uint8Array(1000 * 1024 + 1) },
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimFirehoseInvalidArgumentException);
+    assertStringIncludes(error.message, "1024000 bytes");
+  });
+
+  it("names the record a batch was refused for", async () => {
+    const simAws = await simAwsWithDeliveryStream();
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.firehose().putRecordBatch(
+        new PutRecordBatchCommand({
+          DeliveryStreamName: "order-events",
+          Records: [{ Data: new Uint8Array([1]) }, { Data: undefined }],
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimFirehoseInvalidArgumentException);
+    assertStringIncludes(error.message, "at index 1");
+  });
+
+  it("refuses an empty batch", async () => {
+    const simAws = await simAwsWithDeliveryStream();
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.firehose().putRecordBatch(
+        new PutRecordBatchCommand({
+          DeliveryStreamName: "order-events",
+          Records: [],
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimFirehoseInvalidArgumentException);
+    assertStringIncludes(error.message, "at least one record");
+  });
+
+  it("refuses a batch over the record count Firehose takes", async () => {
+    const simAws = await simAwsWithDeliveryStream();
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.firehose().putRecordBatch(
+        new PutRecordBatchCommand({
+          DeliveryStreamName: "order-events",
+          Records: Array.from({ length: 501 }, () => ({
+            Data: new Uint8Array([1]),
+          })),
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimFirehoseInvalidArgumentException);
+    assertStringIncludes(error.message, "501 records");
+  });
+
+  it("refuses a batch over the size Firehose takes", async () => {
+    const simAws = await simAwsWithDeliveryStream();
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.firehose().putRecordBatch(
+        new PutRecordBatchCommand({
+          DeliveryStreamName: "order-events",
+          Records: Array.from({ length: 5 }, () => ({
+            Data: new Uint8Array(1000 * 1024),
+          })),
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimFirehoseInvalidArgumentException);
+    assertStringIncludes(error.message, "over the 4194304");
+  });
+
+  it("refuses a put onto a delivery stream that is not there", async () => {
+    const simAws = new SimAws();
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.firehose().putRecord(
+        new PutRecordCommand({
+          DeliveryStreamName: "order-events",
+          Record: { Data: new Uint8Array([1]) },
+        }),
+      );
+    });
+
+    assertIdentical(error.name, "ResourceNotFoundException");
+  });
+});

--- a/src/service/firehose/command/record/sim-firehose-record-data.ts
+++ b/src/service/firehose/command/record/sim-firehose-record-data.ts
@@ -1,0 +1,83 @@
+import { SimFirehoseInvalidArgumentException } from "../../error/sim-firehose.error.js";
+import type { SimFirehoseRecordInput } from "./record.command.js";
+
+/**
+ * The largest record real Firehose takes, before base64 encoding.
+ */
+const maxRecordBytes = 1000 * 1024;
+
+/**
+ * The most records one PutRecordBatch request may carry.
+ */
+export const maxBatchRecords = 500;
+
+/**
+ * The largest PutRecordBatch request real Firehose takes.
+ */
+const maxBatchBytes = 4 * 1024 * 1024;
+
+/**
+ * Read the bytes one record carries, or refuse it.
+ *
+ * The `position` names where the record was, so a refusal on a batch says which
+ * record it was about.
+ */
+export function simFirehoseRecordData(
+  record: SimFirehoseRecordInput | undefined,
+  position?: number,
+): Uint8Array {
+  const where = position === undefined ? "" : ` at index ${String(position)}`;
+
+  if (record?.Data === undefined) {
+    throw new SimFirehoseInvalidArgumentException(
+      `The record${where} carries no Data`,
+    );
+  }
+
+  if (record.Data.byteLength > maxRecordBytes) {
+    throw new SimFirehoseInvalidArgumentException(
+      `The record${where} is ${String(record.Data.byteLength)} bytes, over ` +
+        `the ${String(maxRecordBytes)} bytes Firehose takes`,
+    );
+  }
+
+  return record.Data;
+}
+
+/**
+ * Read the bytes a batch of records carries, or refuse the batch.
+ *
+ * Real Firehose measures the whole request against its own limit as well as
+ * each record against theirs, and refuses the request rather than dropping the
+ * records that would not fit.
+ */
+export function simFirehoseBatchData(
+  records: readonly SimFirehoseRecordInput[] | undefined,
+): readonly Uint8Array[] {
+  if (records === undefined || records.length === 0) {
+    throw new SimFirehoseInvalidArgumentException(
+      "A PutRecordBatch request has to carry at least one record",
+    );
+  }
+
+  if (records.length > maxBatchRecords) {
+    throw new SimFirehoseInvalidArgumentException(
+      `A PutRecordBatch request carries ${String(records.length)} records, ` +
+        `over the ${String(maxBatchRecords)} Firehose takes`,
+    );
+  }
+
+  const data = records.map((record, position) =>
+    simFirehoseRecordData(record, position),
+  );
+  const bytes = data.reduce((total, record) => total + record.byteLength, 0);
+
+  if (bytes > maxBatchBytes) {
+    throw new SimFirehoseInvalidArgumentException(
+      `A PutRecordBatch request carries ${String(bytes)} bytes, over the ` +
+        `${String(maxBatchBytes)} Firehose takes`,
+    );
+  }
+
+  return data;
+}

--- a/src/service/firehose/command/sim-firehose-command.types.ts
+++ b/src/service/firehose/command/sim-firehose-command.types.ts
@@ -1,0 +1,32 @@
+/**
+ * The sim Firehose Command types, gathered for the service facade.
+ */
+export type {
+  SimCreateDeliveryStreamCommand,
+  SimCreateDeliveryStreamCommandInput,
+  SimCreateDeliveryStreamCommandOutput,
+  SimDeleteDeliveryStreamCommand,
+  SimDeleteDeliveryStreamCommandInput,
+  SimDeleteDeliveryStreamCommandOutput,
+  SimDescribeDeliveryStreamCommand,
+  SimDescribeDeliveryStreamCommandInput,
+  SimDescribeDeliveryStreamCommandOutput,
+  SimFirehoseBufferingHintsOutput,
+  SimFirehoseDeliveryStreamDescription,
+  SimFirehoseDestinationDescription,
+  SimFirehoseExtendedS3DestinationDescription,
+  SimFirehoseTag,
+  SimListDeliveryStreamsCommand,
+  SimListDeliveryStreamsCommandInput,
+  SimListDeliveryStreamsCommandOutput,
+} from "./stream/stream.command.js";
+export type {
+  SimFirehosePutRecordBatchResponseEntry,
+  SimFirehoseRecordInput,
+  SimPutRecordBatchCommand,
+  SimPutRecordBatchCommandInput,
+  SimPutRecordBatchCommandOutput,
+  SimPutRecordCommand,
+  SimPutRecordCommandInput,
+  SimPutRecordCommandOutput,
+} from "./record/record.command.js";

--- a/src/service/firehose/command/sim-firehose-commands.ts
+++ b/src/service/firehose/command/sim-firehose-commands.ts
@@ -1,0 +1,67 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimFirehoseDelivery } from "../delivery/sim-firehose-delivery.js";
+import type { SimFirehoseDeliveryFailures } from "../delivery/sim-firehose-delivery-failures.js";
+import {
+  type SimFirehoseObjectDestination,
+  SimFirehoseObjectWriter,
+} from "../delivery/sim-firehose-object-writer.js";
+import type { SimFirehoseDeliveryStreamStore } from "../stream/sim-firehose-delivery-stream-store.js";
+import { SimFirehoseAuthorizer } from "./authorize/sim-firehose-authorizer.js";
+import { SimFirehosePutCommands } from "./record/sim-firehose-put-commands.js";
+import { SimFirehoseDeliveryStreamAccess } from "./sim-firehose-delivery-stream-access.js";
+import { SimFirehoseCreateDeliveryStream } from "./stream/sim-firehose-create-delivery-stream.js";
+import { SimFirehoseStreamCommands } from "./stream/sim-firehose-stream-commands.js";
+
+interface SimFirehoseCommandsProperties {
+  readonly deliveryStreams: SimFirehoseDeliveryStreamStore;
+  readonly failures: SimFirehoseDeliveryFailures;
+  readonly s3: SimFirehoseObjectDestination;
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly background: BackgroundScheduler;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * Every command handler one simulated Firehose scope delegates to.
+ *
+ * The wiring lives here rather than in the facade so that `SimFirehose` stays
+ * what it is meant to be: state and delegation. Which handler shares which
+ * collaborator is a fact about the handlers, not about the service object in
+ * front of them.
+ */
+export class SimFirehoseCommands {
+  public readonly creation: SimFirehoseCreateDeliveryStream;
+  public readonly deliveryStreams: SimFirehoseStreamCommands;
+  public readonly puts: SimFirehosePutCommands;
+
+  constructor(properties: SimFirehoseCommandsProperties) {
+    const { deliveryStreams, background, accountRegionScope } = properties;
+    const access = new SimFirehoseDeliveryStreamAccess({
+      deliveryStreams,
+      authorizer: new SimFirehoseAuthorizer({ iam: properties.iam }),
+      accountRegionScope,
+    });
+    const delivery = new SimFirehoseDelivery({
+      background,
+      writer: new SimFirehoseObjectWriter({
+        s3: properties.s3,
+        failures: properties.failures,
+      }),
+    });
+
+    this.creation = new SimFirehoseCreateDeliveryStream({
+      deliveryStreams,
+      access,
+      accountRegionScope,
+      background,
+    });
+    this.deliveryStreams = new SimFirehoseStreamCommands({
+      deliveryStreams,
+      access,
+      delivery,
+    });
+    this.puts = new SimFirehosePutCommands({ access, delivery });
+  }
+}

--- a/src/service/firehose/command/sim-firehose-delivery-stream-access.ts
+++ b/src/service/firehose/command/sim-firehose-delivery-stream-access.ts
@@ -1,0 +1,95 @@
+import type { SimAwsResolvedCaller } from "../../aws/caller/sim-aws-caller-resolver.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { SimFirehoseInvalidArgumentException } from "../error/sim-firehose.error.js";
+import { simFirehoseDeliveryStreamArn } from "../stream/sim-firehose-delivery-stream-arn.js";
+import type { SimFirehoseDeliveryStream } from "../stream/sim-firehose-delivery-stream.js";
+import type { SimFirehoseDeliveryStreamStore } from "../stream/sim-firehose-delivery-stream-store.js";
+import type { SimFirehoseAuthorizer } from "./authorize/sim-firehose-authorizer.js";
+import type { SimFirehoseRequestOptions } from "./sim-firehose-request-options.js";
+
+interface SimFirehoseDeliveryStreamAccessProperties {
+  readonly deliveryStreams: SimFirehoseDeliveryStreamStore;
+  readonly authorizer: SimFirehoseAuthorizer;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * How a request reaches the delivery stream it names.
+ *
+ * Every operation but ListDeliveryStreams and CreateDeliveryStream starts the
+ * same way: authorize the action against the ARN the named delivery stream
+ * would have, then require the delivery stream to be there.
+ *
+ * Authorizing before the lookup is what real IAM does. It is why a caller with
+ * no permission is refused for a delivery stream that does not exist, rather
+ * than being told the delivery stream is missing.
+ */
+export class SimFirehoseDeliveryStreamAccess {
+  private readonly deliveryStreams: SimFirehoseDeliveryStreamStore;
+  private readonly authorizer: SimFirehoseAuthorizer;
+  private readonly scope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimFirehoseDeliveryStreamAccessProperties) {
+    this.deliveryStreams = properties.deliveryStreams;
+    this.authorizer = properties.authorizer;
+    this.scope = properties.accountRegionScope;
+  }
+
+  /**
+   * Ensure the caller may perform an action on the delivery stream of a given
+   * name.
+   *
+   * The delivery stream need not exist, which is what CreateDeliveryStream
+   * needs. It authorizes against the ARN the delivery stream is about to have.
+   */
+  authorizeName(
+    action: string,
+    name: string,
+    options?: SimFirehoseRequestOptions,
+  ): SimAwsResolvedCaller {
+    return this.authorizer.authorizeDeliveryStream(
+      action,
+      simFirehoseDeliveryStreamArn(this.scope, name),
+      options?.caller,
+    );
+  }
+
+  /**
+   * Ensure the caller may perform an action naming no particular delivery
+   * stream.
+   */
+  authorizeAny(
+    action: string,
+    options?: SimFirehoseRequestOptions,
+  ): SimAwsResolvedCaller {
+    return this.authorizer.authorizeAnyDeliveryStream(action, options?.caller);
+  }
+
+  /**
+   * Resolve the delivery stream a request names, authorizing the action first.
+   */
+  require(
+    action: string,
+    name: string | undefined,
+    options?: SimFirehoseRequestOptions,
+  ): SimFirehoseDeliveryStream {
+    const named = requiredName(name);
+
+    this.authorizeName(action, named, options);
+
+    return this.deliveryStreams.require(named);
+  }
+}
+
+/**
+ * The delivery stream name a request carried, refusing one that named none.
+ */
+function requiredName(name: string | undefined): string {
+  if (name === undefined || name === "") {
+    throw new SimFirehoseInvalidArgumentException(
+      "A request has to name a delivery stream by DeliveryStreamName",
+    );
+  }
+
+  return name;
+}

--- a/src/service/firehose/command/sim-firehose-request-options.ts
+++ b/src/service/firehose/command/sim-firehose-request-options.ts
@@ -1,0 +1,12 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+
+/**
+ * What a Firehose request carries besides its command input.
+ */
+export interface SimFirehoseRequestOptions {
+  /**
+   * Who is making the request. An omitted caller is the Account root, as it is
+   * everywhere else in the simulation.
+   */
+  readonly caller?: SimAwsCaller;
+}

--- a/src/service/firehose/command/stream/sim-firehose-create-delivery-stream.ts
+++ b/src/service/firehose/command/stream/sim-firehose-create-delivery-stream.ts
@@ -1,0 +1,102 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import { simFirehoseDestinationOf } from "../../destination/sim-firehose-destination-choice.js";
+import {
+  SimFirehoseResourceInUseException,
+  SimFirehoseUnsimulatedSource,
+} from "../../error/sim-firehose.error.js";
+import { simFirehoseDeliveryStreamArn } from "../../stream/sim-firehose-delivery-stream-arn.js";
+import { requireSimFirehoseDeliveryStreamName } from "../../stream/sim-firehose-delivery-stream-name.js";
+import { SimFirehoseDeliveryStream } from "../../stream/sim-firehose-delivery-stream.js";
+import type { SimFirehoseDeliveryStreamStore } from "../../stream/sim-firehose-delivery-stream-store.js";
+import type { SimFirehoseDeliveryStreamAccess } from "../sim-firehose-delivery-stream-access.js";
+import type { SimFirehoseRequestOptions } from "../sim-firehose-request-options.js";
+import type {
+  SimCreateDeliveryStreamCommand,
+  SimCreateDeliveryStreamCommandInput,
+  SimCreateDeliveryStreamCommandOutput,
+} from "./stream.command.js";
+
+interface SimFirehoseCreateDeliveryStreamProperties {
+  readonly deliveryStreams: SimFirehoseDeliveryStreamStore;
+  readonly access: SimFirehoseDeliveryStreamAccess;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * Creates a delivery stream.
+ *
+ * The delivery stream is ACTIVE by the time this answers. Real Firehose spends
+ * a minute or so in CREATING, and a test that had to wait it out would be
+ * waiting on nothing.
+ */
+export class SimFirehoseCreateDeliveryStream {
+  private readonly deliveryStreams: SimFirehoseDeliveryStreamStore;
+  private readonly access: SimFirehoseDeliveryStreamAccess;
+  private readonly scope: SimAwsAccountRegionScope;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: SimFirehoseCreateDeliveryStreamProperties) {
+    this.deliveryStreams = properties.deliveryStreams;
+    this.access = properties.access;
+    this.scope = properties.accountRegionScope;
+    this.background = properties.background;
+  }
+
+  /**
+   * Handle a CreateDeliveryStream request.
+   *
+   * The destination is read before the name is taken, so a request naming a
+   * destination this simulation cannot deliver to leaves nothing behind.
+   */
+  handle(
+    command: SimCreateDeliveryStreamCommand,
+    options?: SimFirehoseRequestOptions,
+  ): SimCreateDeliveryStreamCommandOutput {
+    const { input } = command;
+    const name = requireSimFirehoseDeliveryStreamName(input.DeliveryStreamName);
+
+    this.access.authorizeName("firehose:CreateDeliveryStream", name, options);
+    requireDirectPutSource(input);
+
+    if (this.deliveryStreams.find(name) !== undefined) {
+      throw new SimFirehoseResourceInUseException(
+        `Firehose already holds a delivery stream named ${name} under this ` +
+          `account and region`,
+      );
+    }
+
+    const arn = simFirehoseDeliveryStreamArn(this.scope, name);
+
+    this.deliveryStreams.add(
+      new SimFirehoseDeliveryStream({
+        name,
+        arn,
+        destination: simFirehoseDestinationOf(input),
+        createdAt: this.background.now(),
+      }),
+    );
+
+    return { $metadata: {}, DeliveryStreamARN: arn };
+  }
+}
+
+/**
+ * Refuse a delivery stream that would read from somewhere this simulation
+ * cannot read from.
+ *
+ * An omitted `DeliveryStreamType` is `DirectPut` on real Firehose too.
+ */
+function requireDirectPutSource(
+  input: SimCreateDeliveryStreamCommandInput,
+): void {
+  const type = input.DeliveryStreamType ?? "DirectPut";
+
+  if (
+    type !== "DirectPut" ||
+    input.KinesisStreamSourceConfiguration !== undefined
+  ) {
+    throw new SimFirehoseUnsimulatedSource();
+  }
+}

--- a/src/service/firehose/command/stream/sim-firehose-delivery-stream-lifecycle.iso.test.ts
+++ b/src/service/firehose/command/stream/sim-firehose-delivery-stream-lifecycle.iso.test.ts
@@ -1,0 +1,271 @@
+/* oxlint-disable typescript/no-deprecated -- Firehose's
+ * S3DestinationConfiguration is deprecated in favour of the extended one, and
+ * a delivery stream declared the older way still has to work. */
+
+import {
+  CreateDeliveryStreamCommand,
+  DeleteDeliveryStreamCommand,
+  DescribeDeliveryStreamCommand,
+  ListDeliveryStreamsCommand,
+} from "@aws-sdk/client-firehose";
+import { CreateBucketCommand } from "@aws-sdk/client-s3";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimFirehoseInvalidArgumentException,
+  SimFirehoseResourceInUseException,
+  SimFirehoseResourceNotFoundException,
+} from "../../error/sim-firehose.error.js";
+import { simFirehoseDeliveryStreamFactory } from "../../stream/sim-firehose-delivery-stream.factory.js";
+
+/**
+ * A simulated AWS with a Bucket for a delivery stream to write into.
+ */
+async function simAwsWithBucket(): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simAws
+    .s3()
+    .createBucket(new CreateBucketCommand({ Bucket: "order-archive" }));
+
+  return simAws;
+}
+
+describe("Simulated Firehose delivery stream lifecycle", () => {
+  it("lists and describes a delivery stream it created", async () => {
+    // Given a simulated AWS with a Bucket and no delivery streams.
+    const simAws = await simAwsWithBucket();
+
+    // When a delivery stream is created against that Bucket.
+    const created = await simAws.firehose().createDeliveryStream(
+      new CreateDeliveryStreamCommand({
+        DeliveryStreamName: "order-events",
+        ExtendedS3DestinationConfiguration: {
+          BucketARN: "arn:aws:s3:::order-archive",
+          RoleARN: "arn:aws:iam::888888888888:role/OrderArchiveRole",
+          Prefix: "orders/",
+          BufferingHints: { SizeInMBs: 8, IntervalInSeconds: 120 },
+        },
+      }),
+    );
+
+    // Then it answers with the ARN, and the delivery stream lists and
+    // describes.
+    assertIdentical(
+      created.DeliveryStreamARN,
+      `arn:aws:firehose:${simAws.defaultRegionName}:${simAws.defaultAccountId}:deliverystream/order-events`,
+    );
+
+    const listed = await simAws
+      .firehose()
+      .listDeliveryStreams(new ListDeliveryStreamsCommand({}));
+    assertArrayEquals(listed.DeliveryStreamNames, ["order-events"]);
+    assertFalse(listed.HasMoreDeliveryStreams);
+
+    const { DeliveryStreamDescription } = await simAws
+      .firehose()
+      .describeDeliveryStream(
+        new DescribeDeliveryStreamCommand({
+          DeliveryStreamName: "order-events",
+        }),
+      );
+    assertIdentical(DeliveryStreamDescription.DeliveryStreamStatus, "ACTIVE");
+    assertIdentical(DeliveryStreamDescription.DeliveryStreamType, "DirectPut");
+    assertIdentical(DeliveryStreamDescription.VersionId, "1");
+    assertFalse(DeliveryStreamDescription.HasMoreDestinations);
+
+    const [destination] = DeliveryStreamDescription.Destinations;
+    assertNonNullable(destination, "The delivery stream has a destination");
+    assertIdentical(destination.DestinationId, "destinationId-000000000001");
+
+    const s3 = destination.ExtendedS3DestinationDescription;
+    assertIdentical(s3.BucketARN, "arn:aws:s3:::order-archive");
+    assertIdentical(s3.Prefix, "orders/");
+    assertIdentical(s3.CompressionFormat, "UNCOMPRESSED");
+    assertIdentical(s3.BufferingHints.SizeInMBs, 8);
+    assertIdentical(s3.BufferingHints.IntervalInSeconds, 120);
+  });
+
+  it("gives a delivery stream the buffering Firehose defaults to", async () => {
+    // Given a delivery stream declaring no buffering hints.
+    const simAws = await simAwsWithBucket();
+    await simAws.firehose().createDeliveryStream(
+      new CreateDeliveryStreamCommand({
+        DeliveryStreamName: "order-events",
+        ExtendedS3DestinationConfiguration: {
+          BucketARN: "arn:aws:s3:::order-archive",
+          RoleARN: "arn:aws:iam::888888888888:role/OrderArchiveRole",
+        },
+      }),
+    );
+
+    // Then it buffers five megabytes or five minutes, and its prefix is the
+    // bare date path.
+    const { DeliveryStreamDescription } = await simAws
+      .firehose()
+      .describeDeliveryStream(
+        new DescribeDeliveryStreamCommand({
+          DeliveryStreamName: "order-events",
+        }),
+      );
+    const [destination] = DeliveryStreamDescription.Destinations;
+    assertNonNullable(destination, "The delivery stream has a destination");
+
+    const s3 = destination.ExtendedS3DestinationDescription;
+    assertIdentical(s3.BufferingHints.SizeInMBs, 5);
+    assertIdentical(s3.BufferingHints.IntervalInSeconds, 300);
+    assertIdentical(s3.Prefix, "");
+  });
+
+  it("takes the plain S3 destination configuration as well", async () => {
+    // Given a delivery stream declared with the older configuration shape.
+    const simAws = await simAwsWithBucket();
+
+    // When it is created.
+    await simAws.firehose().createDeliveryStream(
+      new CreateDeliveryStreamCommand({
+        DeliveryStreamName: "order-events",
+        S3DestinationConfiguration: {
+          BucketARN: "arn:aws:s3:::order-archive",
+          RoleARN: "arn:aws:iam::888888888888:role/OrderArchiveRole",
+          Prefix: "legacy/",
+        },
+      }),
+    );
+
+    // Then it describes the same way an extended one does.
+    const { DeliveryStreamDescription } = await simAws
+      .firehose()
+      .describeDeliveryStream(
+        new DescribeDeliveryStreamCommand({
+          DeliveryStreamName: "order-events",
+        }),
+      );
+    const [destination] = DeliveryStreamDescription.Destinations;
+    assertNonNullable(destination, "The delivery stream has a destination");
+    assertIdentical(
+      destination.ExtendedS3DestinationDescription.Prefix,
+      "legacy/",
+    );
+  });
+
+  it("refuses a second delivery stream under a name it holds", async () => {
+    // Given a delivery stream.
+    const simAws = await simAwsWithBucket();
+    await simFirehoseDeliveryStreamFactory.make({}, simAws);
+
+    // When another is created under the same name.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simFirehoseDeliveryStreamFactory.make({}, simAws);
+    });
+
+    // Then it is refused the way real Firehose refuses one.
+    assertInstanceOf(error, SimFirehoseResourceInUseException);
+    assertIdentical(error.name, "ResourceInUseException");
+    assertStringIncludes(error.message, "order-events");
+  });
+
+  it("frees the name when a delivery stream is deleted", async () => {
+    // Given a delivery stream.
+    const simAws = await simAwsWithBucket();
+    await simFirehoseDeliveryStreamFactory.make({}, simAws);
+
+    // When it is deleted.
+    await simAws.firehose().deleteDeliveryStream(
+      new DeleteDeliveryStreamCommand({
+        DeliveryStreamName: "order-events",
+      }),
+    );
+
+    // Then describing it raises, and the name can be taken again.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.firehose().describeDeliveryStream(
+        new DescribeDeliveryStreamCommand({
+          DeliveryStreamName: "order-events",
+        }),
+      );
+    });
+    assertInstanceOf(error, SimFirehoseResourceNotFoundException);
+    assertIdentical(error.name, "ResourceNotFoundException");
+
+    await simFirehoseDeliveryStreamFactory.make({}, simAws);
+    assertTrue(
+      simAws.firehose().findDeliveryStream("order-events") !== undefined,
+    );
+  });
+
+  it("pages a listing by name", async () => {
+    // Given three delivery streams.
+    const simAws = await simAwsWithBucket();
+    for (const name of ["orders-c", "orders-a", "orders-b"]) {
+      // oxlint-disable-next-line no-await-in-loop
+      await simFirehoseDeliveryStreamFactory.make(
+        { deliveryStreamName: name },
+        simAws,
+      );
+    }
+
+    // When a page of two is asked for.
+    const first = await simAws
+      .firehose()
+      .listDeliveryStreams(new ListDeliveryStreamsCommand({ Limit: 2 }));
+
+    // Then it holds the first two by name, and says there are more.
+    assertArrayEquals(first.DeliveryStreamNames, ["orders-a", "orders-b"]);
+    assertTrue(first.HasMoreDeliveryStreams);
+
+    // When the next page carries on from the last name.
+    const second = await simAws.firehose().listDeliveryStreams(
+      new ListDeliveryStreamsCommand({
+        Limit: 2,
+        ExclusiveStartDeliveryStreamName: "orders-b",
+      }),
+    );
+
+    // Then it holds the rest.
+    assertArrayEquals(second.DeliveryStreamNames, ["orders-c"]);
+    assertFalse(second.HasMoreDeliveryStreams);
+  });
+
+  it("lists nothing for a delivery stream type nothing has", async () => {
+    // Given a DirectPut delivery stream, which is the only type simulated.
+    const simAws = await simAwsWithBucket();
+    await simFirehoseDeliveryStreamFactory.make({}, simAws);
+
+    // When a listing asks for Kinesis-sourced delivery streams.
+    const listed = await simAws.firehose().listDeliveryStreams(
+      new ListDeliveryStreamsCommand({
+        DeliveryStreamType: "KinesisStreamAsSource",
+      }),
+    );
+
+    // Then nothing matches.
+    assertArrayLength(listed.DeliveryStreamNames, 0);
+  });
+
+  it("refuses a request naming no delivery stream", async () => {
+    // Given a simulated AWS.
+    const simAws = await simAwsWithBucket();
+
+    // When a describe names none.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.firehose().describeDeliveryStream({ input: {} });
+    });
+
+    // Then it is refused as a malformed request.
+    assertInstanceOf(error, SimFirehoseInvalidArgumentException);
+    assertStringIncludes(error.message, "DeliveryStreamName");
+  });
+});

--- a/src/service/firehose/command/stream/sim-firehose-delivery-stream-page.ts
+++ b/src/service/firehose/command/stream/sim-firehose-delivery-stream-page.ts
@@ -1,0 +1,32 @@
+import type { SimFirehoseDeliveryStream } from "../../stream/sim-firehose-delivery-stream.js";
+
+/**
+ * A page of delivery streams cut out of a listing walked in name order.
+ *
+ * Firehose pages by naming the delivery stream to start after, so a page is
+ * whatever follows that name up to the limit.
+ *
+ * The start is the first name after the one given rather than the position of
+ * that name itself. A continuation name whose delivery stream has since been
+ * deleted then lands where it belongs in the order. Searching for an exact
+ * match would fail to find it and quietly start again from the beginning,
+ * which is a repeated first page and a paging loop that never ends.
+ */
+export class SimFirehoseDeliveryStreamPage {
+  public readonly items: readonly SimFirehoseDeliveryStream[];
+  public readonly hasMore: boolean;
+
+  constructor(
+    all: readonly SimFirehoseDeliveryStream[],
+    after: string | undefined,
+    limit: number,
+  ) {
+    const remaining =
+      after === undefined
+        ? all
+        : all.filter((deliveryStream) => deliveryStream.name > after);
+
+    this.items = remaining.slice(0, limit);
+    this.hasMore = remaining.length > this.items.length;
+  }
+}

--- a/src/service/firehose/command/stream/sim-firehose-stream-commands.ts
+++ b/src/service/firehose/command/stream/sim-firehose-stream-commands.ts
@@ -1,0 +1,119 @@
+import type { SimFirehoseDelivery } from "../../delivery/sim-firehose-delivery.js";
+import type { SimFirehoseDeliveryStreamStore } from "../../stream/sim-firehose-delivery-stream-store.js";
+import type { SimFirehoseDeliveryStreamAccess } from "../sim-firehose-delivery-stream-access.js";
+import type { SimFirehoseRequestOptions } from "../sim-firehose-request-options.js";
+import { SimFirehoseDeliveryStreamPage } from "./sim-firehose-delivery-stream-page.js";
+import { deliveryStreamDescription } from "./sim-firehose-stream-descriptions.js";
+import type {
+  SimDeleteDeliveryStreamCommand,
+  SimDeleteDeliveryStreamCommandOutput,
+  SimDescribeDeliveryStreamCommand,
+  SimDescribeDeliveryStreamCommandOutput,
+  SimListDeliveryStreamsCommand,
+  SimListDeliveryStreamsCommandOutput,
+} from "./stream.command.js";
+
+/**
+ * How many delivery streams ListDeliveryStreams reports when a request asks for
+ * no limit.
+ */
+const defaultListLimit = 10;
+
+interface SimFirehoseStreamCommandsProperties {
+  readonly deliveryStreams: SimFirehoseDeliveryStreamStore;
+  readonly access: SimFirehoseDeliveryStreamAccess;
+  readonly delivery: SimFirehoseDelivery;
+}
+
+/**
+ * The commands that list, describe and delete delivery streams.
+ */
+export class SimFirehoseStreamCommands {
+  private readonly deliveryStreams: SimFirehoseDeliveryStreamStore;
+  private readonly access: SimFirehoseDeliveryStreamAccess;
+  private readonly delivery: SimFirehoseDelivery;
+
+  constructor(properties: SimFirehoseStreamCommandsProperties) {
+    this.deliveryStreams = properties.deliveryStreams;
+    this.access = properties.access;
+    this.delivery = properties.delivery;
+  }
+
+  /**
+   * List the delivery streams in this scope, by name.
+   *
+   * Real Firehose gives this action no delivery stream level permission, so it
+   * authorizes against every delivery stream in the Account and Region and does
+   * not filter the list by what the caller can reach.
+   *
+   * `DeliveryStreamType` filters the list on real Firehose. `DirectPut` is the
+   * only type a simulated delivery stream has, so asking for
+   * `KinesisStreamAsSource` lists nothing.
+   */
+  listDeliveryStreams(
+    command: SimListDeliveryStreamsCommand,
+    options?: SimFirehoseRequestOptions,
+  ): SimListDeliveryStreamsCommandOutput {
+    this.access.authorizeAny("firehose:ListDeliveryStreams", options);
+
+    const { input } = command;
+    const matching = this.deliveryStreams.all.filter(
+      (deliveryStream) =>
+        input.DeliveryStreamType === undefined ||
+        input.DeliveryStreamType === deliveryStream.deliveryStreamType,
+    );
+    const page = new SimFirehoseDeliveryStreamPage(
+      matching,
+      input.ExclusiveStartDeliveryStreamName,
+      input.Limit ?? defaultListLimit,
+    );
+
+    return {
+      $metadata: {},
+      DeliveryStreamNames: page.items.map((stream) => stream.name),
+      HasMoreDeliveryStreams: page.hasMore,
+    };
+  }
+
+  /**
+   * Describe a delivery stream and its destination.
+   */
+  describeDeliveryStream(
+    command: SimDescribeDeliveryStreamCommand,
+    options?: SimFirehoseRequestOptions,
+  ): SimDescribeDeliveryStreamCommandOutput {
+    const deliveryStream = this.access.require(
+      "firehose:DescribeDeliveryStream",
+      command.input.DeliveryStreamName,
+      options,
+    );
+
+    return {
+      $metadata: {},
+      DeliveryStreamDescription: deliveryStreamDescription(deliveryStream),
+    };
+  }
+
+  /**
+   * Delete a delivery stream.
+   *
+   * Whatever it was holding goes with it. Real Firehose delivers the buffer
+   * first, and an Object landing after the delivery stream naming it has gone
+   * is nothing a test could expect.
+   */
+  deleteDeliveryStream(
+    command: SimDeleteDeliveryStreamCommand,
+    options?: SimFirehoseRequestOptions,
+  ): SimDeleteDeliveryStreamCommandOutput {
+    const deliveryStream = this.access.require(
+      "firehose:DeleteDeliveryStream",
+      command.input.DeliveryStreamName,
+      options,
+    );
+
+    this.delivery.forget(deliveryStream);
+    this.deliveryStreams.remove(deliveryStream);
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/firehose/command/stream/sim-firehose-stream-descriptions.ts
+++ b/src/service/firehose/command/stream/sim-firehose-stream-descriptions.ts
@@ -1,0 +1,61 @@
+import type { SimFirehoseDeliveryStream } from "../../stream/sim-firehose-delivery-stream.js";
+import type {
+  SimFirehoseDeliveryStreamDescription,
+  SimFirehoseDestinationDescription,
+} from "./stream.command.js";
+
+/**
+ * The id real Firehose gives a delivery stream's first destination.
+ *
+ * A delivery stream has one destination, so every simulated delivery stream
+ * reports this one.
+ */
+const firstDestinationId = "destinationId-000000000001";
+
+/**
+ * The compression every simulated delivery stream reports.
+ *
+ * GZIP, Snappy and ZIP all change the bytes in the Object without changing what
+ * a test is checking, so nothing here compresses a buffer.
+ */
+const uncompressed = "UNCOMPRESSED";
+
+/**
+ * One delivery stream, as DescribeDeliveryStream reports it.
+ */
+export function deliveryStreamDescription(
+  deliveryStream: SimFirehoseDeliveryStream,
+): SimFirehoseDeliveryStreamDescription {
+  return {
+    DeliveryStreamName: deliveryStream.name,
+    DeliveryStreamARN: deliveryStream.arn,
+    DeliveryStreamStatus: deliveryStream.status,
+    DeliveryStreamType: deliveryStream.deliveryStreamType,
+    VersionId: deliveryStream.versionId,
+    CreateTimestamp: deliveryStream.createdAt,
+    Destinations: [destinationDescription(deliveryStream)],
+    HasMoreDestinations: false,
+  };
+}
+
+function destinationDescription(
+  deliveryStream: SimFirehoseDeliveryStream,
+): SimFirehoseDestinationDescription {
+  const { destination } = deliveryStream;
+  const { bufferingHints } = destination;
+
+  return {
+    DestinationId: firstDestinationId,
+    ExtendedS3DestinationDescription: {
+      RoleARN: destination.roleArn,
+      BucketARN: destination.bucketArn,
+      Prefix: destination.prefix,
+      ErrorOutputPrefix: destination.errorOutputPrefix,
+      BufferingHints: {
+        SizeInMBs: bufferingHints.sizeInMegabytes,
+        IntervalInSeconds: bufferingHints.intervalInSeconds,
+      },
+      CompressionFormat: uncompressed,
+    },
+  };
+}

--- a/src/service/firehose/command/stream/stream.command.ts
+++ b/src/service/firehose/command/stream/stream.command.ts
@@ -1,0 +1,134 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimFirehoseDestinationInput } from "../../destination/sim-firehose-destination-choice.js";
+
+/**
+ * One tag as a CreateDeliveryStream request carries it.
+ */
+export interface SimFirehoseTag {
+  readonly Key?: string | undefined;
+  readonly Value?: string | undefined;
+}
+
+/**
+ * Minimal structural sim Firehose CreateDeliveryStream command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/firehose/command/CreateDeliveryStreamCommand/
+ */
+export interface SimCreateDeliveryStreamCommand {
+  readonly input: SimCreateDeliveryStreamCommandInput;
+}
+
+export interface SimCreateDeliveryStreamCommandInput extends SimFirehoseDestinationInput {
+  readonly DeliveryStreamName?: string | undefined;
+  readonly DeliveryStreamType?: string | undefined;
+  readonly KinesisStreamSourceConfiguration?: unknown;
+  readonly DeliveryStreamEncryptionConfigurationInput?: unknown;
+  readonly Tags?: readonly SimFirehoseTag[] | undefined;
+}
+
+export interface SimCreateDeliveryStreamCommandOutput {
+  readonly DeliveryStreamARN: string;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Firehose DeleteDeliveryStream command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/firehose/command/DeleteDeliveryStreamCommand/
+ */
+export interface SimDeleteDeliveryStreamCommand {
+  readonly input: SimDeleteDeliveryStreamCommandInput;
+}
+
+export interface SimDeleteDeliveryStreamCommandInput {
+  readonly DeliveryStreamName?: string | undefined;
+  readonly AllowForceDelete?: boolean | undefined;
+}
+
+export interface SimDeleteDeliveryStreamCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Firehose ListDeliveryStreams command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/firehose/command/ListDeliveryStreamsCommand/
+ */
+export interface SimListDeliveryStreamsCommand {
+  readonly input: SimListDeliveryStreamsCommandInput;
+}
+
+export interface SimListDeliveryStreamsCommandInput {
+  readonly Limit?: number | undefined;
+  readonly DeliveryStreamType?: string | undefined;
+  readonly ExclusiveStartDeliveryStreamName?: string | undefined;
+}
+
+export interface SimListDeliveryStreamsCommandOutput {
+  readonly DeliveryStreamNames: readonly string[];
+  readonly HasMoreDeliveryStreams: boolean;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * How a delivery stream reports its buffering, as DescribeDeliveryStream gives
+ * it back.
+ */
+export interface SimFirehoseBufferingHintsOutput {
+  readonly SizeInMBs: number;
+  readonly IntervalInSeconds: number;
+}
+
+/**
+ * One S3 destination, as DescribeDeliveryStream reports it.
+ */
+export interface SimFirehoseExtendedS3DestinationDescription {
+  readonly RoleARN: string;
+  readonly BucketARN: string;
+  readonly Prefix: string;
+  readonly ErrorOutputPrefix?: string | undefined;
+  readonly BufferingHints: SimFirehoseBufferingHintsOutput;
+  readonly CompressionFormat: string;
+}
+
+/**
+ * One destination of a delivery stream, as DescribeDeliveryStream reports it.
+ */
+export interface SimFirehoseDestinationDescription {
+  readonly DestinationId: string;
+  readonly ExtendedS3DestinationDescription: SimFirehoseExtendedS3DestinationDescription;
+}
+
+/**
+ * One delivery stream, as DescribeDeliveryStream reports it.
+ */
+export interface SimFirehoseDeliveryStreamDescription {
+  readonly DeliveryStreamName: string;
+  readonly DeliveryStreamARN: string;
+  readonly DeliveryStreamStatus: string;
+  readonly DeliveryStreamType: string;
+  readonly VersionId: string;
+  readonly CreateTimestamp: Date;
+  readonly Destinations: readonly SimFirehoseDestinationDescription[];
+  readonly HasMoreDestinations: boolean;
+}
+
+/**
+ * Minimal structural sim Firehose DescribeDeliveryStream command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/firehose/command/DescribeDeliveryStreamCommand/
+ */
+export interface SimDescribeDeliveryStreamCommand {
+  readonly input: SimDescribeDeliveryStreamCommandInput;
+}
+
+export interface SimDescribeDeliveryStreamCommandInput {
+  readonly DeliveryStreamName?: string | undefined;
+  readonly Limit?: number | undefined;
+  readonly ExclusiveStartDestinationId?: string | undefined;
+}
+
+export interface SimDescribeDeliveryStreamCommandOutput {
+  readonly DeliveryStreamDescription: SimFirehoseDeliveryStreamDescription;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/firehose/delivery/sim-firehose-buffer.ts
+++ b/src/service/firehose/delivery/sim-firehose-buffer.ts
@@ -1,0 +1,62 @@
+/**
+ * What one delivery stream has taken and not yet delivered.
+ *
+ * Firehose delivers a buffer as one S3 Object holding the records concatenated,
+ * with no separator between them. A producer that wants its records to arrive
+ * as lines puts the newline on the end of each record itself, which is what
+ * every Firehose to S3 pipeline does.
+ */
+export class SimFirehoseBuffer {
+  private records: Uint8Array[] = [];
+  private bytes = 0;
+
+  /**
+   * How many bytes the buffer is holding.
+   */
+  get byteLength(): number {
+    return this.bytes;
+  }
+
+  /**
+   * How many records the buffer is holding.
+   */
+  get recordCount(): number {
+    return this.records.length;
+  }
+
+  /**
+   * Whether there is anything here to deliver.
+   */
+  get isEmpty(): boolean {
+    return this.records.length === 0;
+  }
+
+  /**
+   * Take a record onto the buffer.
+   */
+  add(data: Uint8Array): void {
+    this.records.push(data);
+    this.bytes += data.byteLength;
+  }
+
+  /**
+   * Empty the buffer into the bytes one Object holds.
+   *
+   * Taking and emptying happen together so that a record put while a delivery
+   * is under way joins the next buffer rather than being delivered twice.
+   */
+  take(): Uint8Array {
+    const object = new Uint8Array(this.bytes);
+    let offset = 0;
+
+    for (const record of this.records) {
+      object.set(record, offset);
+      offset += record.byteLength;
+    }
+
+    this.records = [];
+    this.bytes = 0;
+
+    return object;
+  }
+}

--- a/src/service/firehose/delivery/sim-firehose-delivery-failures.ts
+++ b/src/service/firehose/delivery/sim-firehose-delivery-failures.ts
@@ -1,0 +1,110 @@
+import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
+
+interface SimFirehoseDeliveryFailureProperties {
+  readonly deliveryStreamName: string;
+  readonly bucketName: string;
+  readonly objectKey: string;
+  readonly recordCount: number;
+  readonly roleArn: string;
+  readonly error: unknown;
+}
+
+/**
+ * One buffer a delivery stream could not write.
+ */
+export class SimFirehoseDeliveryFailure {
+  public readonly deliveryStreamName: string;
+  public readonly bucketName: string;
+  public readonly objectKey: string;
+  public readonly recordCount: number;
+  public readonly roleArn: string;
+  public readonly error: unknown;
+
+  constructor(properties: SimFirehoseDeliveryFailureProperties) {
+    this.deliveryStreamName = properties.deliveryStreamName;
+    this.bucketName = properties.bucketName;
+    this.objectKey = properties.objectKey;
+    this.recordCount = properties.recordCount;
+    this.roleArn = properties.roleArn;
+    this.error = properties.error;
+  }
+
+  /**
+   * Whether IAM refused the write rather than the write going wrong.
+   */
+  get wasRefused(): boolean {
+    return this.error instanceof SimIamAccessDenied;
+  }
+
+  /**
+   * What went wrong, in one line.
+   */
+  get reason(): string {
+    return this.error instanceof Error
+      ? this.error.message
+      : String(this.error);
+  }
+}
+
+/**
+ * What became of the buffers a simulated Firehose scope could not deliver.
+ *
+ * Real Firehose answers a `PutRecord` long before the buffer that record joined
+ * is delivered. A delivery that fails minutes later reaches the producer
+ * through CloudWatch and the error output prefix, and neither of those is
+ * simulated. Every failure is kept here for a test to read.
+ *
+ * A refusal is warned about, and an IAM denial is recorded quietly. Removing
+ * `s3:PutObject` from the delivery role is what a test checking the denial
+ * does, and that test should not have to read a warning about the thing it
+ * asked for. Compare SimS3NotificationFailures, which draws the same line for
+ * the same reason.
+ */
+export class SimFirehoseDeliveryFailures {
+  private readonly failures: SimFirehoseDeliveryFailure[] = [];
+  private readonly warned = new Set<string>();
+
+  /**
+   * Every buffer this scope could not deliver, oldest first.
+   */
+  get all(): readonly SimFirehoseDeliveryFailure[] {
+    return this.failures;
+  }
+
+  /**
+   * Record a buffer that did not reach its Bucket.
+   */
+  record(failure: SimFirehoseDeliveryFailure): void {
+    this.failures.push(failure);
+
+    if (failure.wasRefused) {
+      return;
+    }
+
+    this.warn(failure);
+  }
+
+  /**
+   * Warn about a delivery that failed, once per delivery stream and cause.
+   *
+   * Warnings go to the console because that is where a test runner surfaces
+   * them next to the failing expectation they explain. The simulator has no
+   * logger of its own to route them through.
+   */
+  private warn(failure: SimFirehoseDeliveryFailure): void {
+    const key = `${failure.deliveryStreamName}:${failure.reason}`;
+
+    if (this.warned.has(key)) {
+      return;
+    }
+
+    this.warned.add(key);
+
+    // oxlint-disable-next-line no-console
+    console.warn(
+      `Simulated Kinesis Data Firehose delivery stream ` +
+        `${failure.deliveryStreamName} could not write to ` +
+        `s3://${failure.bucketName}/${failure.objectKey}: ${failure.reason}`,
+    );
+  }
+}

--- a/src/service/firehose/delivery/sim-firehose-delivery-permissions.iso.test.ts
+++ b/src/service/firehose/delivery/sim-firehose-delivery-permissions.iso.test.ts
@@ -1,0 +1,179 @@
+import { PutRecordCommand } from "@aws-sdk/client-firehose";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it, vi } from "vitest";
+
+import {
+  deliveredObjectKeys,
+  makeFirehoseDelivery,
+} from "../../../../test/firehose/firehose-delivery-fixture.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
+import { simIamRoleWithPolicyFactory } from "../../iam/role/sim-iam-role-with-policy.factory.js";
+import { simFirehoseDeliveryStreamFactory } from "../stream/sim-firehose-delivery-stream.factory.js";
+
+/**
+ * Put one order onto the delivery stream and let the buffering interval pass.
+ */
+async function putAndDeliver(simAws: SimAws): Promise<void> {
+  await simAws.firehose().putRecord(
+    new PutRecordCommand({
+      DeliveryStreamName: "order-events",
+      Record: { Data: new TextEncoder().encode('{"id":"order-1"}\n') },
+    }),
+  );
+  await simAws.clock().advanceBy({ minutes: 2 });
+}
+
+describe("The Role a simulated Firehose delivery writes as", () => {
+  it("fails the delivery when the Role cannot write to the Bucket", async () => {
+    // Given a delivery stream whose Role may read the Bucket and not write to
+    // it.
+    const simAws = new SimAws();
+    const { bucketName, roleArn } = await makeFirehoseDelivery(simAws, {
+      actions: ["s3:GetObject", "s3:ListBucket"],
+    });
+
+    // When a record is put and the buffering interval passes.
+    await putAndDeliver(simAws);
+
+    // Then nothing was written, and the delivery is on the simulator's list of
+    // failures with the Role and the key it tried.
+    assertArrayLength(await deliveredObjectKeys(simAws, bucketName), 0);
+
+    const failures = simAws.firehose().getDeliveryFailures();
+    assertArrayLength(failures, 1);
+
+    const [failure] = failures;
+    assertNonNullable(failure, "The delivery failed and was recorded");
+    assertIdentical(failure.deliveryStreamName, "order-events");
+    assertIdentical(failure.bucketName, bucketName);
+    assertIdentical(failure.roleArn, roleArn);
+    assertIdentical(failure.recordCount, 1);
+    assertInstanceOf(failure.error, SimIamAccessDenied);
+    assertTrue(failure.wasRefused);
+    assertStringIncludes(failure.reason, "s3:PutObject");
+  });
+
+  it("answers the producer either way", async () => {
+    // Given a delivery stream whose Role cannot write to the Bucket.
+    const simAws = new SimAws();
+    await makeFirehoseDelivery(simAws, { actions: ["s3:GetObject"] });
+
+    // When a record is put.
+    const output = await simAws.firehose().putRecord(
+      new PutRecordCommand({
+        DeliveryStreamName: "order-events",
+        Record: { Data: new TextEncoder().encode("one\n") },
+      }),
+    );
+
+    // Then the put was answered with a record id. Real Firehose answers long
+    // before it writes the buffer that record joined, and tells the producer
+    // nothing about what became of it.
+    assertStringIncludes(output.RecordId, "-");
+
+    await simAws.clock().advanceBy({ minutes: 2 });
+    assertArrayLength(simAws.firehose().getDeliveryFailures(), 1);
+  });
+
+  it("records one failure per buffer that did not land", async () => {
+    // Given a delivery stream whose Role cannot write to the Bucket.
+    const simAws = new SimAws();
+    await makeFirehoseDelivery(simAws, { actions: ["s3:GetObject"] });
+
+    // When two buffering intervals each take a record.
+    await putAndDeliver(simAws);
+    await putAndDeliver(simAws);
+
+    // Then each buffer failed on its own.
+    assertArrayLength(simAws.firehose().getDeliveryFailures(), 2);
+  });
+
+  it("delivers as the Role rather than as the caller who put the record", async () => {
+    // Given a delivery stream whose Role may write to the Bucket, and a caller
+    // who may put records and nothing else.
+    const simAws = new SimAws();
+    const { bucketName } = await makeFirehoseDelivery(simAws);
+    const producer = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "OrderProducerRole",
+        policyName: "ProduceOrders",
+        actions: ["firehose:PutRecord"],
+        resource: "*",
+      },
+      simAws,
+    );
+
+    // When that caller puts a record and the interval passes.
+    await simAws.firehose().putRecord(
+      new PutRecordCommand({
+        DeliveryStreamName: "order-events",
+        Record: { Data: new TextEncoder().encode("one\n") },
+      }),
+      { caller: { kind: "arn", arn: producer.Arn } },
+    );
+    await simAws.clock().advanceBy({ minutes: 2 });
+
+    // Then the Object landed. The producer has no S3 permission at all, and
+    // the delivery is the delivery stream's Role rather than theirs.
+    assertArrayLength(await deliveredObjectKeys(simAws, bucketName), 1);
+  });
+
+  it("warns about a delivery that failed for anything but a refusal", async () => {
+    // Given a delivery stream pointing at a Bucket nothing created.
+    const simAws = new SimAws();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    await simFirehoseDeliveryStreamFactory.make(
+      { bucketName: "never-created" },
+      simAws,
+    );
+
+    // When two records are put and delivered in separate buffers.
+    await putAndDeliver(simAws);
+    await putAndDeliver(simAws);
+
+    // Then both failures are recorded, neither is a refusal, and the console
+    // was warned once. A Bucket that is not there is a broken simulation
+    // rather than a modelled outcome, and a test that never reads the failures
+    // should still hear about it.
+    const failures = simAws.firehose().getDeliveryFailures();
+    assertArrayLength(failures, 2);
+
+    const [failure] = failures;
+    assertNonNullable(failure, "The delivery failed and was recorded");
+    assertFalse(failure.wasRefused);
+    assertArrayLength(warn.mock.calls, 1);
+
+    const [warning] = warn.mock.calls;
+    assertNonNullable(warning, "The failed delivery was warned about");
+    assertStringIncludes(String(warning[0]), "s3://never-created/");
+  });
+
+  it("reports a failure that was not an Error at all", async () => {
+    // Given a delivery stream whose destination throws something that is not
+    // an Error, which is what a broken collaborator does.
+    const simAws = new SimAws();
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    await simFirehoseDeliveryStreamFactory.make({}, simAws);
+    vi.spyOn(simAws.s3(), "putObject").mockRejectedValue("no bucket for you");
+
+    // When a record is put and delivered.
+    await putAndDeliver(simAws);
+
+    // Then the failure reads back as the string it was thrown as.
+    const failures = simAws.firehose().getDeliveryFailures();
+    assertArrayLength(failures, 1);
+
+    const [failure] = failures;
+    assertNonNullable(failure, "The delivery failed and was recorded");
+    assertIdentical(failure.reason, "no bucket for you");
+  });
+});

--- a/src/service/firehose/delivery/sim-firehose-delivery.ts
+++ b/src/service/firehose/delivery/sim-firehose-delivery.ts
@@ -1,0 +1,105 @@
+import type {
+  BackgroundScheduler,
+  BackgroundTask,
+} from "../../../util/background/background.js";
+import type { SimFirehoseDeliveryStream } from "../stream/sim-firehose-delivery-stream.js";
+import type { SimFirehoseObjectWriter } from "./sim-firehose-object-writer.js";
+
+interface SimFirehoseDeliveryProperties {
+  readonly background: BackgroundScheduler;
+  readonly writer: SimFirehoseObjectWriter;
+}
+
+/**
+ * When each delivery stream's buffer is written out.
+ *
+ * Firehose delivers a buffer once it passes either of its two bounds. The size
+ * bound is checked as each record arrives. The interval bound is a task
+ * scheduled on the clock for the instant the buffer is due, which is why
+ * advancing simulated time past the interval is what makes a delivery happen.
+ *
+ * The due task is scheduled when a record lands on an empty buffer, so the
+ * interval runs from the first record of a buffer rather than from the last.
+ * That is the window real Firehose measures.
+ */
+export class SimFirehoseDelivery {
+  private readonly background: BackgroundScheduler;
+  private readonly writer: SimFirehoseObjectWriter;
+  private readonly due = new Map<SimFirehoseDeliveryStream, BackgroundTask>();
+
+  constructor(properties: SimFirehoseDeliveryProperties) {
+    this.background = properties.background;
+    this.writer = properties.writer;
+  }
+
+  /**
+   * Take a record onto a delivery stream's buffer, and deliver if it is full.
+   *
+   * A size delivery happens on the background scheduler rather than inside the
+   * put, as real Firehose answers the producer before it writes anything.
+   * `simAws.backgroundTasksComplete()` is what waits for it.
+   */
+  accept(deliveryStream: SimFirehoseDeliveryStream, data: Uint8Array): void {
+    const wasEmpty = deliveryStream.buffer.isEmpty;
+
+    deliveryStream.buffer.add(data);
+
+    if (deliveryStream.isBufferFull) {
+      this.cancelDue(deliveryStream);
+      this.background.schedule(async () => {
+        await this.deliver(deliveryStream);
+      });
+
+      return;
+    }
+
+    if (wasEmpty) {
+      this.scheduleDue(deliveryStream);
+    }
+  }
+
+  /**
+   * Stop a deleted delivery stream delivering.
+   *
+   * Real Firehose delivers whatever a deleted delivery stream was holding
+   * before it goes. Nothing here does, because the Object would land after the
+   * delivery stream it names has gone and a test would have no way to expect
+   * it.
+   */
+  forget(deliveryStream: SimFirehoseDeliveryStream): void {
+    this.cancelDue(deliveryStream);
+    deliveryStream.buffer.take();
+  }
+
+  private scheduleDue(deliveryStream: SimFirehoseDeliveryStream): void {
+    const task = async (): Promise<void> => {
+      await this.deliver(deliveryStream);
+    };
+    const dueTime = new Date(
+      this.background.now().getTime() +
+        deliveryStream.destination.bufferingHints.intervalInMilliseconds,
+    );
+
+    this.due.set(deliveryStream, task);
+    this.background.scheduleAt(dueTime, task);
+  }
+
+  private cancelDue(deliveryStream: SimFirehoseDeliveryStream): void {
+    const task = this.due.get(deliveryStream);
+
+    if (task === undefined) {
+      return;
+    }
+
+    this.due.delete(deliveryStream);
+    this.background.cancelScheduled(task);
+  }
+
+  private async deliver(
+    deliveryStream: SimFirehoseDeliveryStream,
+  ): Promise<void> {
+    this.due.delete(deliveryStream);
+
+    await this.writer.write(deliveryStream, this.background.now());
+  }
+}

--- a/src/service/firehose/delivery/sim-firehose-object-key.ts
+++ b/src/service/firehose/delivery/sim-firehose-object-key.ts
@@ -1,0 +1,41 @@
+import { randomUUID } from "node:crypto";
+
+/**
+ * What one delivered Object's key is built from.
+ */
+export interface SimFirehoseObjectKeyParts {
+  readonly prefix: string;
+  readonly deliveryStreamName: string;
+  readonly versionId: string;
+  readonly deliveredAt: Date;
+}
+
+/**
+ * The key Firehose writes one buffer under.
+ *
+ * Real Firehose builds it as `<Prefix>YYYY/MM/DD/HH/` followed by the delivery
+ * stream name, its version, the delivery time and a random string. The date
+ * path is UTC, and it is what makes listing one hour of a Bucket cheap.
+ *
+ * A delivery stream with no `Prefix` gets the bare date path, the default real
+ * Firehose applies.
+ */
+export function simFirehoseObjectKey(parts: SimFirehoseObjectKeyParts): string {
+  const { prefix, deliveryStreamName, versionId, deliveredAt } = parts;
+  const year = String(deliveredAt.getUTCFullYear());
+  const month = padded(deliveredAt.getUTCMonth() + 1);
+  const day = padded(deliveredAt.getUTCDate());
+  const hour = padded(deliveredAt.getUTCHours());
+  const minute = padded(deliveredAt.getUTCMinutes());
+  const second = padded(deliveredAt.getUTCSeconds());
+  const stamp = `${year}-${month}-${day}-${hour}-${minute}-${second}`;
+
+  return (
+    `${prefix}${year}/${month}/${day}/${hour}/` +
+    `${deliveryStreamName}-${versionId}-${stamp}-${randomUUID()}`
+  );
+}
+
+function padded(value: number): string {
+  return String(value).padStart(2, "0");
+}

--- a/src/service/firehose/delivery/sim-firehose-object-writer.ts
+++ b/src/service/firehose/delivery/sim-firehose-object-writer.ts
@@ -1,0 +1,90 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimFirehoseDeliveryStream } from "../stream/sim-firehose-delivery-stream.js";
+import {
+  SimFirehoseDeliveryFailure,
+  type SimFirehoseDeliveryFailures,
+} from "./sim-firehose-delivery-failures.js";
+import { simFirehoseObjectKey } from "./sim-firehose-object-key.js";
+
+/**
+ * The narrow slice of simulated S3 that Firehose delivery needs.
+ *
+ * `SimS3` structurally implements this interface.
+ */
+export interface SimFirehoseObjectDestination {
+  putObject(
+    command: { input: { Bucket: string; Key: string; Body: Uint8Array } },
+    options?: { caller: SimAwsCaller },
+  ): Promise<unknown>;
+}
+
+interface SimFirehoseObjectWriterProperties {
+  readonly s3: SimFirehoseObjectDestination;
+  readonly failures: SimFirehoseDeliveryFailures;
+}
+
+/**
+ * Writes one delivery stream's buffer into its destination Bucket.
+ *
+ * The write goes through the simulated S3 PutObject as the delivery stream's
+ * `RoleARN`, so simulated IAM applies to it exactly as `s3:PutObject`
+ * authorization applies on real AWS. A role that cannot write to the Bucket
+ * fails the delivery here.
+ *
+ * A failed delivery is recorded and swallowed. Real Firehose has already
+ * answered the `PutRecord` that put the record in this buffer, and there is no
+ * caller left to raise at.
+ */
+export class SimFirehoseObjectWriter {
+  private readonly s3: SimFirehoseObjectDestination;
+  private readonly failures: SimFirehoseDeliveryFailures;
+
+  constructor(properties: SimFirehoseObjectWriterProperties) {
+    this.s3 = properties.s3;
+    this.failures = properties.failures;
+  }
+
+  /**
+   * Write whatever a delivery stream is holding, under a key stamped with the
+   * instant it was delivered.
+   *
+   * An empty buffer is nothing to write. Real Firehose delivers no Object for
+   * an interval in which no record arrived.
+   */
+  async write(
+    deliveryStream: SimFirehoseDeliveryStream,
+    deliveredAt: Date,
+  ): Promise<void> {
+    if (deliveryStream.buffer.isEmpty) {
+      return;
+    }
+
+    const { destination, name } = deliveryStream;
+    const recordCount = deliveryStream.buffer.recordCount;
+    const body = deliveryStream.buffer.take();
+    const key = simFirehoseObjectKey({
+      prefix: destination.prefix,
+      deliveryStreamName: name,
+      versionId: deliveryStream.versionId,
+      deliveredAt,
+    });
+
+    try {
+      await this.s3.putObject(
+        { input: { Bucket: destination.bucketName, Key: key, Body: body } },
+        { caller: { kind: "arn", arn: destination.roleArn } },
+      );
+    } catch (error) {
+      this.failures.record(
+        new SimFirehoseDeliveryFailure({
+          deliveryStreamName: name,
+          bucketName: destination.bucketName,
+          objectKey: key,
+          recordCount,
+          roleArn: destination.roleArn,
+          error,
+        }),
+      );
+    }
+  }
+}

--- a/src/service/firehose/delivery/sim-firehose-s3-delivery.iso.test.ts
+++ b/src/service/firehose/delivery/sim-firehose-s3-delivery.iso.test.ts
@@ -1,0 +1,254 @@
+import {
+  PutRecordBatchCommand,
+  PutRecordCommand,
+} from "@aws-sdk/client-firehose";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringLength,
+  assertStringStartsWith,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  deliveredObjectBody,
+  deliveredObjectKeys,
+  makeFirehoseDelivery,
+} from "../../../../test/firehose/firehose-delivery-fixture.js";
+import { SimAws } from "../../aws/sim-aws.js";
+
+/**
+ * The bytes of one JSON line, the way a Firehose producer writes one.
+ */
+function orderLine(id: string): Uint8Array {
+  return new TextEncoder().encode(`${JSON.stringify({ id })}\n`);
+}
+
+/**
+ * Assert an Object key is the one Firehose would have written.
+ */
+function assertKeyMatches(key: string | undefined, pattern: RegExp): void {
+  assertNonNullable(key, "An Object was delivered under a key");
+  assertTrue(
+    pattern.test(key),
+    `Expected the delivered key ${key} to match ${pattern.source}`,
+  );
+}
+
+describe("Delivering simulated Firehose records into S3", () => {
+  it("writes a record to the Bucket once the buffering interval passes", async () => {
+    // Given a delivery stream buffering for a minute into a Bucket.
+    const simAws = new SimAws();
+    const { bucketName } = await makeFirehoseDelivery(simAws, {
+      intervalInSeconds: 60,
+    });
+
+    // When a record is put and the interval has yet to pass.
+    await simAws.firehose().putRecord(
+      new PutRecordCommand({
+        DeliveryStreamName: "order-events",
+        Record: { Data: orderLine("order-1") },
+      }),
+    );
+    await simAws.clock().advanceBy({ seconds: 30 });
+
+    // Then nothing has been delivered yet.
+    assertArrayLength(await deliveredObjectKeys(simAws, bucketName), 0);
+
+    // When the clock passes the interval.
+    await simAws.clock().advanceBy({ seconds: 31 });
+
+    // Then the record is in the Bucket, under a key carrying the UTC date path
+    // and the delivery stream name.
+    const keys = await deliveredObjectKeys(simAws, bucketName);
+    assertArrayLength(keys, 1);
+    assertKeyMatches(
+      keys[0],
+      /^\d{4}\/\d{2}\/\d{2}\/\d{2}\/order-events-1-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-[\da-f-]{36}$/,
+    );
+  });
+
+  it("delivers records buffered together as one Object", async () => {
+    // Given a delivery stream buffering for a minute.
+    const simAws = new SimAws();
+    const { bucketName } = await makeFirehoseDelivery(simAws);
+    const firehose = simAws.firehose();
+
+    // When three records are put inside one buffering window.
+    await firehose.putRecord(
+      new PutRecordCommand({
+        DeliveryStreamName: "order-events",
+        Record: { Data: orderLine("order-1") },
+      }),
+    );
+    await firehose.putRecordBatch(
+      new PutRecordBatchCommand({
+        DeliveryStreamName: "order-events",
+        Records: [
+          { Data: orderLine("order-2") },
+          { Data: orderLine("order-3") },
+        ],
+      }),
+    );
+    await simAws.clock().advanceBy({ minutes: 2 });
+
+    // Then one Object holds all three, concatenated in the order they were put.
+    const keys = await deliveredObjectKeys(simAws, bucketName);
+    assertArrayLength(keys, 1);
+
+    assertIdentical(
+      await deliveredObjectBody(simAws, bucketName, keys[0]),
+      '{"id":"order-1"}\n{"id":"order-2"}\n{"id":"order-3"}\n',
+    );
+  });
+
+  it("puts the declared prefix in front of the date path", async () => {
+    // Given a delivery stream with a Prefix.
+    const simAws = new SimAws();
+    const { bucketName } = await makeFirehoseDelivery(simAws, {
+      prefix: "orders/raw/",
+    });
+
+    // When a record is put and the interval passes.
+    await simAws.firehose().putRecord(
+      new PutRecordCommand({
+        DeliveryStreamName: "order-events",
+        Record: { Data: orderLine("order-1") },
+      }),
+    );
+    await simAws.clock().advanceBy({ minutes: 2 });
+
+    // Then the key starts with the prefix, and the date path follows it.
+    const keys = await deliveredObjectKeys(simAws, bucketName);
+    assertArrayLength(keys, 1);
+    assertStringStartsWith(keys[0], "orders/raw/");
+    assertKeyMatches(keys[0], /^orders\/raw\/\d{4}\/\d{2}\/\d{2}\/\d{2}\//);
+  });
+
+  it("starts a new buffer after one is delivered", async () => {
+    // Given a delivery stream that has already delivered a buffer.
+    const simAws = new SimAws();
+    const { bucketName } = await makeFirehoseDelivery(simAws);
+    const firehose = simAws.firehose();
+
+    await firehose.putRecord(
+      new PutRecordCommand({
+        DeliveryStreamName: "order-events",
+        Record: { Data: orderLine("order-1") },
+      }),
+    );
+    await simAws.clock().advanceBy({ minutes: 2 });
+
+    // When another record is put and another interval passes.
+    await firehose.putRecord(
+      new PutRecordCommand({
+        DeliveryStreamName: "order-events",
+        Record: { Data: orderLine("order-2") },
+      }),
+    );
+    await simAws.clock().advanceBy({ minutes: 2 });
+
+    // Then it arrives as a second Object holding only itself.
+    const keys = await deliveredObjectKeys(simAws, bucketName);
+    assertArrayLength(keys, 2);
+
+    assertIdentical(
+      await deliveredObjectBody(simAws, bucketName, keys[1]),
+      '{"id":"order-2"}\n',
+    );
+  });
+
+  it("delivers nothing for an interval that took no records", async () => {
+    // Given a delivery stream nothing has been put onto.
+    const simAws = new SimAws();
+    const { bucketName } = await makeFirehoseDelivery(simAws);
+
+    // When several buffering intervals pass.
+    await simAws.clock().advanceBy({ minutes: 10 });
+
+    // Then no Object was written. Real Firehose writes one per buffer, and an
+    // empty interval is no buffer.
+    assertArrayLength(await deliveredObjectKeys(simAws, bucketName), 0);
+  });
+
+  it("delivers a full buffer without waiting for the interval", async () => {
+    // Given a delivery stream whose buffer delivers at one megabyte, and an
+    // interval far longer than the test will run for.
+    const simAws = new SimAws();
+    const { bucketName } = await makeFirehoseDelivery(simAws, {
+      sizeInMegabytes: 1,
+      intervalInSeconds: 900,
+    });
+
+    // When more than a megabyte is put onto it, in records under the size
+    // limit Firehose puts on one.
+    await simAws.firehose().putRecordBatch(
+      new PutRecordBatchCommand({
+        DeliveryStreamName: "order-events",
+        Records: [
+          { Data: new Uint8Array(600_000) },
+          { Data: new Uint8Array(600_000) },
+        ],
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the buffer was delivered on the size bound, with the clock standing
+    // still.
+    assertArrayLength(await deliveredObjectKeys(simAws, bucketName), 1);
+  });
+
+  it("stops delivering once the delivery stream is deleted", async () => {
+    // Given a delivery stream holding a record it has yet to deliver.
+    const simAws = new SimAws();
+    const { bucketName } = await makeFirehoseDelivery(simAws);
+    const firehose = simAws.firehose();
+
+    await firehose.putRecord(
+      new PutRecordCommand({
+        DeliveryStreamName: "order-events",
+        Record: { Data: orderLine("order-1") },
+      }),
+    );
+
+    // When the delivery stream is deleted before the interval passes.
+    await firehose.deleteDeliveryStream({
+      input: { DeliveryStreamName: "order-events" },
+    });
+    await simAws.clock().advanceBy({ minutes: 10 });
+
+    // Then nothing was written. An Object naming a delivery stream that has
+    // gone is nothing a test could expect.
+    assertArrayLength(await deliveredObjectKeys(simAws, bucketName), 0);
+  });
+
+  it("writes one Object when two records each fill the buffer", async () => {
+    // Given a delivery stream whose buffer delivers at one megabyte.
+    const simAws = new SimAws();
+    const { bucketName } = await makeFirehoseDelivery(simAws, {
+      sizeInMegabytes: 1,
+      intervalInSeconds: 900,
+    });
+    const firehose = simAws.firehose();
+    const megabyte = new Uint8Array(1000 * 1024);
+
+    // When two records that each fill it are put before either delivery runs.
+    await firehose.putRecordBatch(
+      new PutRecordBatchCommand({
+        DeliveryStreamName: "order-events",
+        Records: [{ Data: megabyte }, { Data: megabyte }, { Data: megabyte }],
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then one Object holds all of it. The second delivery found the buffer
+    // the first had already taken, and wrote nothing rather than an empty
+    // Object.
+    const keys = await deliveredObjectKeys(simAws, bucketName);
+    assertArrayLength(keys, 1);
+    const body = await deliveredObjectBody(simAws, bucketName, keys[0]);
+    assertStringLength(body, 3 * 1000 * 1024);
+  });
+});

--- a/src/service/firehose/destination/sim-firehose-buffering-hints.ts
+++ b/src/service/firehose/destination/sim-firehose-buffering-hints.ts
@@ -1,0 +1,83 @@
+import { SimFirehoseInvalidArgumentException } from "../error/sim-firehose.error.js";
+
+const bytesPerMegabyte = 1024 * 1024;
+
+const millisecondsPerSecond = 1000;
+
+const defaultSizeInMegabytes = 5;
+
+const minimumSizeInMegabytes = 1;
+
+const maximumSizeInMegabytes = 128;
+
+const defaultIntervalInSeconds = 300;
+
+const minimumIntervalInSeconds = 0;
+
+const maximumIntervalInSeconds = 900;
+
+/**
+ * How a request declares when a buffer should be delivered.
+ */
+export interface SimFirehoseBufferingHintsInput {
+  readonly SizeInMBs?: number | undefined;
+  readonly IntervalInSeconds?: number | undefined;
+}
+
+/**
+ * When a delivery stream's buffer is delivered, in the two bounds Firehose
+ * applies to every buffer.
+ *
+ * Whichever bound is reached first is what delivers the buffer. The size is
+ * held in bytes and the interval in milliseconds, since those are the units the
+ * buffer and the scheduler work in.
+ */
+export class SimFirehoseBufferingHints {
+  public readonly sizeInMegabytes: number;
+  public readonly intervalInSeconds: number;
+
+  constructor(input: SimFirehoseBufferingHintsInput = {}) {
+    this.sizeInMegabytes = requireInRange(
+      "SizeInMBs",
+      input.SizeInMBs ?? defaultSizeInMegabytes,
+      minimumSizeInMegabytes,
+      maximumSizeInMegabytes,
+    );
+    this.intervalInSeconds = requireInRange(
+      "IntervalInSeconds",
+      input.IntervalInSeconds ?? defaultIntervalInSeconds,
+      minimumIntervalInSeconds,
+      maximumIntervalInSeconds,
+    );
+  }
+
+  /**
+   * The buffer size that delivers, in bytes.
+   */
+  get sizeInBytes(): number {
+    return this.sizeInMegabytes * bytesPerMegabyte;
+  }
+
+  /**
+   * How long a buffer waits before it delivers, in milliseconds.
+   */
+  get intervalInMilliseconds(): number {
+    return this.intervalInSeconds * millisecondsPerSecond;
+  }
+}
+
+function requireInRange(
+  field: string,
+  value: number,
+  minimum: number,
+  maximum: number,
+): number {
+  if (!Number.isSafeInteger(value) || value < minimum || value > maximum) {
+    throw new SimFirehoseInvalidArgumentException(
+      `BufferingHints ${field} must be a whole number between ${String(minimum)} ` +
+        `and ${String(maximum)}, and is ${String(value)}`,
+    );
+  }
+
+  return value;
+}

--- a/src/service/firehose/destination/sim-firehose-destination-choice.ts
+++ b/src/service/firehose/destination/sim-firehose-destination-choice.ts
@@ -1,0 +1,85 @@
+import {
+  SimFirehoseInvalidArgumentException,
+  SimFirehoseUnsimulatedDestination,
+} from "../error/sim-firehose.error.js";
+import {
+  SimFirehoseS3Destination,
+  type SimFirehoseS3DestinationInput,
+} from "./sim-firehose-s3-destination.js";
+
+/**
+ * The suffix every Firehose destination configuration field ends in.
+ */
+const destinationSuffix = "DestinationConfiguration";
+
+/**
+ * The two destination fields this simulation delivers to.
+ */
+const simulatedDestinations = new Set([
+  "ExtendedS3DestinationConfiguration",
+  "S3DestinationConfiguration",
+]);
+
+/**
+ * The destination configurations a CreateDeliveryStream request can carry.
+ *
+ * Only the two S3 ones are read. The rest are here so a request naming one
+ * type checks, and they are found at run time by the suffix every destination
+ * field shares. A destination AWS adds later is refused by name without this
+ * file having heard of it.
+ */
+export interface SimFirehoseDestinationInput {
+  readonly ExtendedS3DestinationConfiguration?:
+    | SimFirehoseS3DestinationInput
+    | undefined;
+  readonly S3DestinationConfiguration?:
+    | SimFirehoseS3DestinationInput
+    | undefined;
+  readonly RedshiftDestinationConfiguration?: unknown;
+  readonly ElasticsearchDestinationConfiguration?: unknown;
+  readonly AmazonopensearchserviceDestinationConfiguration?: unknown;
+  readonly AmazonOpenSearchServerlessDestinationConfiguration?: unknown;
+  readonly SplunkDestinationConfiguration?: unknown;
+  readonly HttpEndpointDestinationConfiguration?: unknown;
+  readonly IcebergDestinationConfiguration?: unknown;
+  readonly SnowflakeDestinationConfiguration?: unknown;
+}
+
+/**
+ * The S3 destination a request declared, or a refusal saying why there is none.
+ *
+ * The extended configuration wins where a request carries both, as it does on
+ * real Firehose. A CDK `DeliveryStream` with an `S3Bucket` destination
+ * synthesizes the extended form.
+ *
+ * A destination outside the simulation is refused rather than ignored. A
+ * delivery stream created against one would take records and drop them, and a
+ * test asserting on an empty Bucket would blame the code under test.
+ */
+export function simFirehoseDestinationOf(
+  input: SimFirehoseDestinationInput,
+): SimFirehoseS3Destination {
+  const unsimulated = Object.entries(input).find(
+    ([field, value]) =>
+      value !== undefined &&
+      field.endsWith(destinationSuffix) &&
+      !simulatedDestinations.has(field),
+  );
+
+  if (unsimulated !== undefined) {
+    throw new SimFirehoseUnsimulatedDestination(unsimulated[0]);
+  }
+
+  const s3 =
+    input.ExtendedS3DestinationConfiguration ??
+    input.S3DestinationConfiguration;
+
+  if (s3 === undefined) {
+    throw new SimFirehoseInvalidArgumentException(
+      "The delivery stream declares no destination. Declare an " +
+        "ExtendedS3DestinationConfiguration naming a simulated Bucket.",
+    );
+  }
+
+  return new SimFirehoseS3Destination(s3);
+}

--- a/src/service/firehose/destination/sim-firehose-destination-refusals.iso.test.ts
+++ b/src/service/firehose/destination/sim-firehose-destination-refusals.iso.test.ts
@@ -1,0 +1,99 @@
+import { CreateBucketCommand } from "@aws-sdk/client-s3";
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCreateDeliveryStreamCommandInput } from "../command/stream/stream.command.js";
+import {
+  SimFirehoseInvalidArgumentException,
+  SimFirehoseUnsimulatedDestination,
+  SimFirehoseUnsimulatedSource,
+} from "../error/sim-firehose.error.js";
+
+const validS3Destination = {
+  BucketARN: "arn:aws:s3:::order-archive",
+  RoleARN: "arn:aws:iam::888888888888:role/OrderArchiveRole",
+};
+
+/**
+ * Try to create a delivery stream, and hand back what refused it.
+ */
+async function refusalOf(
+  input: SimCreateDeliveryStreamCommandInput,
+): Promise<Error> {
+  const simAws = new SimAws();
+
+  await simAws
+    .s3()
+    .createBucket(new CreateBucketCommand({ Bucket: "order-archive" }));
+
+  const error = await assertThrowsErrorAsync(async () => {
+    await simAws.firehose().createDeliveryStream({ input });
+  });
+
+  assertUndefined(simAws.firehose().findDeliveryStream("order-events"));
+
+  return error;
+}
+
+describe("What a simulated Firehose delivery stream refuses to be", () => {
+  it("refuses a destination other than S3, by name", async () => {
+    // Given a delivery stream declared against Redshift.
+    // When it is created.
+    const error = await refusalOf({
+      DeliveryStreamName: "order-events",
+      RedshiftDestinationConfiguration: {
+        RoleARN: "arn:aws:iam::888888888888:role/OrderArchiveRole",
+      },
+    });
+
+    // Then the refusal names the destination, so a test knows what Yulin will
+    // not do rather than watching an empty Bucket.
+    assertInstanceOf(error, SimFirehoseUnsimulatedDestination);
+    assertStringIncludes(error.message, "RedshiftDestinationConfiguration");
+    assertStringIncludes(error.message, "S3 only");
+  });
+
+  it("refuses an OpenSearch destination the same way", async () => {
+    const error = await refusalOf({
+      DeliveryStreamName: "order-events",
+      AmazonopensearchserviceDestinationConfiguration: { IndexName: "orders" },
+    });
+
+    assertInstanceOf(error, SimFirehoseUnsimulatedDestination);
+    assertStringIncludes(
+      error.message,
+      "AmazonopensearchserviceDestinationConfiguration",
+    );
+  });
+
+  it("refuses a delivery stream declaring no destination", async () => {
+    const error = await refusalOf({ DeliveryStreamName: "order-events" });
+
+    assertInstanceOf(error, SimFirehoseInvalidArgumentException);
+    assertStringIncludes(error.message, "no destination");
+  });
+
+  it("refuses a Kinesis stream as the source", async () => {
+    // Given a delivery stream that would read from a Kinesis stream.
+    const error = await refusalOf({
+      DeliveryStreamName: "order-events",
+      DeliveryStreamType: "KinesisStreamAsSource",
+      KinesisStreamSourceConfiguration: {
+        KinesisStreamARN:
+          "arn:aws:kinesis:us-east-1:888888888888:stream/orders",
+        RoleARN: "arn:aws:iam::888888888888:role/OrderArchiveRole",
+      },
+      ExtendedS3DestinationConfiguration: validS3Destination,
+    });
+
+    // Then it says so, rather than taking nothing and delivering nothing.
+    assertInstanceOf(error, SimFirehoseUnsimulatedSource);
+    assertStringIncludes(error.message, "DirectPut");
+  });
+});

--- a/src/service/firehose/destination/sim-firehose-s3-destination-refusals.iso.test.ts
+++ b/src/service/firehose/destination/sim-firehose-s3-destination-refusals.iso.test.ts
@@ -1,0 +1,145 @@
+import { CreateBucketCommand } from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCreateDeliveryStreamCommandInput } from "../command/stream/stream.command.js";
+import type { SimFirehoseS3DestinationInput } from "./sim-firehose-s3-destination.js";
+
+const bucketArn = "arn:aws:s3:::order-archive";
+
+const roleArn = "arn:aws:iam::888888888888:role/OrderArchiveRole";
+
+const validDestination = { BucketARN: bucketArn, RoleARN: roleArn };
+
+/**
+ * Try to create a delivery stream, and hand back the message that refused it.
+ *
+ * Every refusal here is an `InvalidArgumentException`, and what a test cares
+ * about is which field it named.
+ */
+async function refusalOf(
+  input: SimCreateDeliveryStreamCommandInput,
+): Promise<string> {
+  const simAws = new SimAws();
+
+  await simAws
+    .s3()
+    .createBucket(new CreateBucketCommand({ Bucket: "order-archive" }));
+
+  const error = await assertThrowsErrorAsync(async () => {
+    await simAws.firehose().createDeliveryStream({ input });
+  });
+
+  assertIdentical(error.name, "InvalidArgumentException");
+  assertUndefined(simAws.firehose().findDeliveryStream("order-events"));
+
+  return error.message;
+}
+
+/**
+ * Try to create a delivery stream against a destination, under a valid name.
+ */
+async function destinationRefusal(
+  destination: SimFirehoseS3DestinationInput,
+): Promise<string> {
+  return await refusalOf({
+    DeliveryStreamName: "order-events",
+    ExtendedS3DestinationConfiguration: destination,
+  });
+}
+
+describe("What a simulated Firehose S3 destination refuses", () => {
+  it("refuses a BucketARN that names no Bucket", async () => {
+    // Given an Object ARN, which carries a key after the Bucket name.
+    assertStringIncludes(
+      await destinationRefusal({
+        BucketARN: `${bucketArn}/orders`,
+        RoleARN: roleArn,
+      }),
+      "does not name a Bucket",
+    );
+
+    // And a bare Bucket name, which is no ARN at all.
+    assertStringIncludes(
+      await destinationRefusal({
+        BucketARN: "order-archive",
+        RoleARN: roleArn,
+      }),
+      "does not name a Bucket",
+    );
+  });
+
+  it("refuses a destination missing its Role", async () => {
+    // Given a destination with no RoleARN, and one with an empty string.
+    assertStringIncludes(
+      await destinationRefusal({ BucketARN: bucketArn }),
+      "RoleARN",
+    );
+    assertStringIncludes(
+      await destinationRefusal({ BucketARN: bucketArn, RoleARN: "" }),
+      "RoleARN",
+    );
+  });
+
+  it("refuses a destination missing its Bucket", async () => {
+    // Given a destination with no BucketARN, and one with an empty string.
+    assertStringIncludes(
+      await destinationRefusal({ RoleARN: roleArn }),
+      "BucketARN",
+    );
+    assertStringIncludes(
+      await destinationRefusal({ BucketARN: "", RoleARN: roleArn }),
+      "BucketARN",
+    );
+  });
+
+  it("refuses buffering outside the bounds Firehose allows", async () => {
+    // Given buffering hints asking for more than the largest buffer, and for
+    // longer than the longest Firehose waits.
+    assertStringIncludes(
+      await destinationRefusal({
+        ...validDestination,
+        BufferingHints: { SizeInMBs: 129 },
+      }),
+      "SizeInMBs",
+    );
+    assertStringIncludes(
+      await destinationRefusal({
+        ...validDestination,
+        BufferingHints: { IntervalInSeconds: 901 },
+      }),
+      "IntervalInSeconds",
+    );
+  });
+
+  it("refuses a delivery stream name Firehose would not take", async () => {
+    // Given a name carrying a character Firehose will not accept, one longer
+    // than it allows, and a request naming none at all.
+    assertStringIncludes(
+      await refusalOf({
+        DeliveryStreamName: "order events",
+        ExtendedS3DestinationConfiguration: validDestination,
+      }),
+      "letters, digits",
+    );
+    assertStringIncludes(
+      await refusalOf({
+        DeliveryStreamName: "a".repeat(65),
+        ExtendedS3DestinationConfiguration: validDestination,
+      }),
+      "64",
+    );
+    assertStringIncludes(
+      await refusalOf({
+        ExtendedS3DestinationConfiguration: validDestination,
+      }),
+      "DeliveryStreamName is required",
+    );
+  });
+});

--- a/src/service/firehose/destination/sim-firehose-s3-destination.ts
+++ b/src/service/firehose/destination/sim-firehose-s3-destination.ts
@@ -1,0 +1,83 @@
+import { SimFirehoseInvalidArgumentException } from "../error/sim-firehose.error.js";
+import {
+  SimFirehoseBufferingHints,
+  type SimFirehoseBufferingHintsInput,
+} from "./sim-firehose-buffering-hints.js";
+
+const bucketArnPrefix = "arn:aws:s3:::";
+
+/**
+ * An S3 destination as a CreateDeliveryStream request carries it.
+ *
+ * Both the extended and the plain form arrive in this shape. The extended one
+ * carries more fields, and every one this simulation reads is on both.
+ */
+export interface SimFirehoseS3DestinationInput {
+  readonly BucketARN?: string | undefined;
+  readonly RoleARN?: string | undefined;
+  readonly Prefix?: string | undefined;
+  readonly ErrorOutputPrefix?: string | undefined;
+  readonly BufferingHints?: SimFirehoseBufferingHintsInput | undefined;
+  readonly CompressionFormat?: string | undefined;
+}
+
+/**
+ * Where one delivery stream writes its buffers, and as whom.
+ *
+ * The Bucket is held by name rather than by ARN because a PutObject names a
+ * Bucket. An S3 Bucket ARN carries no Account and no Region, so the name is all
+ * the ARN has to give.
+ */
+export class SimFirehoseS3Destination {
+  public readonly bucketName: string;
+  public readonly bucketArn: string;
+  public readonly roleArn: string;
+  public readonly prefix: string;
+  public readonly errorOutputPrefix: string | undefined;
+  public readonly bufferingHints: SimFirehoseBufferingHints;
+
+  constructor(input: SimFirehoseS3DestinationInput) {
+    this.bucketArn = requireBucketArn(input.BucketARN);
+    this.bucketName = this.bucketArn.slice(bucketArnPrefix.length);
+    this.roleArn = requireRoleArn(input.RoleARN);
+    this.prefix = input.Prefix ?? "";
+    this.errorOutputPrefix = input.ErrorOutputPrefix;
+    this.bufferingHints = new SimFirehoseBufferingHints(input.BufferingHints);
+  }
+}
+
+/**
+ * Read the Bucket ARN a destination names, or refuse it.
+ *
+ * A Bucket ARN with a key after the Bucket name is an Object ARN, and a
+ * destination naming one has named something Firehose cannot write a buffer to.
+ */
+function requireBucketArn(value: string | undefined): string {
+  if (value === undefined || value === "") {
+    throw new SimFirehoseInvalidArgumentException(
+      "The S3 destination configuration is missing BucketARN",
+    );
+  }
+
+  const name = value.startsWith(bucketArnPrefix)
+    ? value.slice(bucketArnPrefix.length)
+    : "";
+
+  if (name === "" || name.includes("/")) {
+    throw new SimFirehoseInvalidArgumentException(
+      `The S3 destination BucketARN ${value} does not name a Bucket`,
+    );
+  }
+
+  return value;
+}
+
+function requireRoleArn(value: string | undefined): string {
+  if (value === undefined || value === "") {
+    throw new SimFirehoseInvalidArgumentException(
+      "The S3 destination configuration is missing RoleARN",
+    );
+  }
+
+  return value;
+}

--- a/src/service/firehose/error/sim-firehose.error.ts
+++ b/src/service/firehose/error/sim-firehose.error.ts
@@ -1,0 +1,105 @@
+/**
+ * Minimal metadata shape for simulated Firehose errors.
+ */
+export interface SimFirehoseErrorMetadata {
+  readonly httpStatusCode?: number;
+}
+
+/**
+ * Base class for simulated Kinesis Data Firehose errors.
+ */
+export class SimFirehoseError extends Error {
+  constructor(
+    message: string,
+    public readonly $metadata: SimFirehoseErrorMetadata = {},
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Simulated Firehose InvalidArgumentException error.
+ *
+ * Real Firehose reports a malformed request this way: a delivery stream name it
+ * will not accept, a record over the size limit, a batch over the record count,
+ * or buffering hints outside the range it allows.
+ */
+export class SimFirehoseInvalidArgumentException extends SimFirehoseError {
+  public override readonly name = "InvalidArgumentException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated Firehose ResourceNotFoundException error.
+ *
+ * Real Firehose reports a delivery stream it does not hold this way, whichever
+ * operation asked for it.
+ */
+export class SimFirehoseResourceNotFoundException extends SimFirehoseError {
+  public override readonly name = "ResourceNotFoundException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated Firehose ResourceInUseException error.
+ *
+ * Real Firehose refuses a second delivery stream under a name it already holds.
+ */
+export class SimFirehoseResourceInUseException extends SimFirehoseError {
+  public override readonly name = "ResourceInUseException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated Firehose UnsimulatedDestination error.
+ *
+ * This has no counterpart on real Firehose. Yulin simulates the S3 destination
+ * and refuses the rest by name at CreateDeliveryStream, where a test can see
+ * which destination it asked for. A delivery stream created against Redshift or
+ * OpenSearch would take records and drop them, and a test asserting on an
+ * empty bucket would blame the code under test.
+ */
+export class SimFirehoseUnsimulatedDestination extends SimFirehoseError {
+  public override readonly name = "SimFirehoseUnsimulatedDestination";
+
+  constructor(destination: string) {
+    super(
+      `Simulated Kinesis Data Firehose delivers to S3 only, and this delivery ` +
+        `stream declares ${destination}. Declare an ` +
+        `ExtendedS3DestinationConfiguration instead, or leave this delivery ` +
+        `stream out of the simulation.`,
+      { httpStatusCode: 400 },
+    );
+  }
+}
+
+/**
+ * Simulated Firehose UnsimulatedSource error.
+ *
+ * This has no counterpart on real Firehose. `DirectPut` is the only source
+ * simulated, and a delivery stream reading from a Kinesis stream would take
+ * nothing and deliver nothing. Refusing at CreateDeliveryStream says so where
+ * the request that asked for it is.
+ */
+export class SimFirehoseUnsimulatedSource extends SimFirehoseError {
+  public override readonly name = "SimFirehoseUnsimulatedSource";
+
+  constructor() {
+    super(
+      "Simulated Kinesis Data Firehose takes records through PutRecord and " +
+        "PutRecordBatch only. A delivery stream reading from a Kinesis " +
+        "stream is not simulated, so leave DeliveryStreamType at DirectPut " +
+        "and put the records the delivery stream should see.",
+      { httpStatusCode: 400 },
+    );
+  }
+}

--- a/src/service/firehose/index.ts
+++ b/src/service/firehose/index.ts
@@ -1,0 +1,20 @@
+export { SimFirehose } from "./sim-firehose.js";
+export type { SimFirehoseRequestOptions } from "./command/sim-firehose-request-options.js";
+export type * from "./command/sim-firehose-command.types.js";
+export { SimFirehoseDeliveryStream } from "./stream/sim-firehose-delivery-stream.js";
+export type {
+  SimFirehoseDeliveryStreamStatus,
+  SimFirehoseDeliveryStreamType,
+} from "./stream/sim-firehose-delivery-stream.js";
+export { simFirehoseDeliveryStreamArn } from "./stream/sim-firehose-delivery-stream-arn.js";
+export { SimFirehoseBufferingHints } from "./destination/sim-firehose-buffering-hints.js";
+export { SimFirehoseS3Destination } from "./destination/sim-firehose-s3-destination.js";
+export { SimFirehoseDeliveryFailure } from "./delivery/sim-firehose-delivery-failures.js";
+export {
+  SimFirehoseError,
+  SimFirehoseInvalidArgumentException,
+  SimFirehoseResourceInUseException,
+  SimFirehoseResourceNotFoundException,
+  SimFirehoseUnsimulatedDestination,
+  SimFirehoseUnsimulatedSource,
+} from "./error/sim-firehose.error.js";

--- a/src/service/firehose/sdk/sim-firehose-sdk-command-router.ts
+++ b/src/service/firehose/sdk/sim-firehose-sdk-command-router.ts
@@ -1,0 +1,81 @@
+import {
+  simSdkCallerOptions,
+  type SimSdkCommandRoute,
+  type SimSdkCommandRouter,
+} from "../../../sdk/index.js";
+import type * as simFirehoseCommands from "../command/sim-firehose-command.types.js";
+import type { SimFirehose } from "../sim-firehose.js";
+
+/**
+ * Routes intercepted SDK Commands to one scoped simulated Firehose.
+ */
+export class SimFirehoseSdkCommandRouter implements SimSdkCommandRouter {
+  private readonly routes: ReadonlyMap<string, SimSdkCommandRoute>;
+
+  constructor(simFirehose: SimFirehose) {
+    this.routes = new Map<string, SimSdkCommandRoute>([
+      [
+        "CreateDeliveryStreamCommand",
+        async (command, context): Promise<unknown> =>
+          await simFirehose.createDeliveryStream(
+            command as simFirehoseCommands.SimCreateDeliveryStreamCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteDeliveryStreamCommand",
+        async (command, context): Promise<unknown> =>
+          await simFirehose.deleteDeliveryStream(
+            command as simFirehoseCommands.SimDeleteDeliveryStreamCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListDeliveryStreamsCommand",
+        async (command, context): Promise<unknown> =>
+          await simFirehose.listDeliveryStreams(
+            command as simFirehoseCommands.SimListDeliveryStreamsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DescribeDeliveryStreamCommand",
+        async (command, context): Promise<unknown> =>
+          await simFirehose.describeDeliveryStream(
+            command as simFirehoseCommands.SimDescribeDeliveryStreamCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "PutRecordCommand",
+        async (command, context): Promise<unknown> =>
+          await simFirehose.putRecord(
+            command as simFirehoseCommands.SimPutRecordCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "PutRecordBatchCommand",
+        async (command, context): Promise<unknown> =>
+          await simFirehose.putRecordBatch(
+            command as simFirehoseCommands.SimPutRecordBatchCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+    ]);
+  }
+
+  /**
+   * The SDK Command names simulated Firehose can handle.
+   */
+  supportedCommandNames(): readonly string[] {
+    return this.routes.keys().toArray();
+  }
+
+  /**
+   * Get the route for an SDK Command name, if simulated Firehose supports it.
+   */
+  route(commandName: string): SimSdkCommandRoute | undefined {
+    return this.routes.get(commandName);
+  }
+}

--- a/src/service/firehose/sdk/sim-firehose-sdk-routing.iso.test.ts
+++ b/src/service/firehose/sdk/sim-firehose-sdk-routing.iso.test.ts
@@ -1,0 +1,133 @@
+import {
+  CreateDeliveryStreamCommand,
+  DeleteDeliveryStreamCommand,
+  DescribeDeliveryStreamCommand,
+  FirehoseClient,
+  ListDeliveryStreamsCommand,
+  PutRecordBatchCommand,
+  PutRecordCommand,
+} from "@aws-sdk/client-firehose";
+import { CreateBucketCommand, S3Client } from "@aws-sdk/client-s3";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  deliveredObjectKeys,
+  firehoseDeliveryActions,
+} from "../../../../test/firehose/firehose-delivery-fixture.js";
+import { SimSdk } from "../../../sdk/index.js";
+import { simIamRoleWithPolicyFactory } from "../../iam/role/sim-iam-role-with-policy.factory.js";
+
+const orderArchive = {
+  BucketARN: "arn:aws:s3:::order-archive",
+  RoleARN: "arn:aws:iam::888888888888:role/OrderArchiveRole",
+  BufferingHints: { IntervalInSeconds: 60 },
+};
+
+describe("Firehose SDK interception", () => {
+  it("carries a record from an intercepted client into a simulated Bucket", async () => {
+    // Given intercepted Firehose and S3 clients, and a Bucket to deliver into.
+    using simSdk = new SimSdk();
+    simSdk.intercept(FirehoseClient);
+    simSdk.intercept(S3Client);
+
+    const firehose = new FirehoseClient({ region: "us-east-1" });
+    const s3 = new S3Client({ region: "us-east-1" });
+
+    await s3.send(new CreateBucketCommand({ Bucket: "order-archive" }));
+
+    const role = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "OrderArchiveRole",
+        policyName: "ArchiveOrders",
+        actions: firehoseDeliveryActions,
+        resource: "arn:aws:s3:::order-archive/*",
+      },
+      simSdk.simAws,
+    );
+
+    // When ordinary SDK code creates a delivery stream and puts a record.
+    await firehose.send(
+      new CreateDeliveryStreamCommand({
+        DeliveryStreamName: "order-events",
+        ExtendedS3DestinationConfiguration: {
+          ...orderArchive,
+          RoleARN: role.Arn,
+        },
+      }),
+    );
+    await firehose.send(
+      new PutRecordCommand({
+        DeliveryStreamName: "order-events",
+        Record: { Data: new TextEncoder().encode('{"id":"order-1"}\n') },
+      }),
+    );
+    await simSdk.simAws.clock().advanceBy({ minutes: 2 });
+
+    // Then the Object is in the Bucket, with nothing touching the network.
+    assertArrayLength(
+      await deliveredObjectKeys(simSdk.simAws, "order-archive"),
+      1,
+    );
+  });
+
+  it("routes every delivery stream command an intercepted client sends", async () => {
+    // Given an intercepted Firehose client holding one delivery stream.
+    using simSdk = new SimSdk();
+    simSdk.intercept(FirehoseClient);
+
+    const firehose = new FirehoseClient({ region: "us-east-1" });
+    await firehose.send(
+      new CreateDeliveryStreamCommand({
+        DeliveryStreamName: "order-events",
+        ExtendedS3DestinationConfiguration: orderArchive,
+      }),
+    );
+
+    // When ordinary SDK code lists, describes, puts a batch and deletes.
+    const listed = await firehose.send(new ListDeliveryStreamsCommand({}));
+    const described = await firehose.send(
+      new DescribeDeliveryStreamCommand({
+        DeliveryStreamName: "order-events",
+      }),
+    );
+    const batch = await firehose.send(
+      new PutRecordBatchCommand({
+        DeliveryStreamName: "order-events",
+        Records: [{ Data: new Uint8Array([1]) }],
+      }),
+    );
+    await firehose.send(
+      new DeleteDeliveryStreamCommand({ DeliveryStreamName: "order-events" }),
+    );
+
+    // Then each answered from the simulated delivery stream, and nothing is
+    // left to list.
+    assertIdentical(listed.DeliveryStreamNames?.[0], "order-events");
+    assertIdentical(
+      described.DeliveryStreamDescription?.DeliveryStreamStatus,
+      "ACTIVE",
+    );
+    assertIdentical(batch.FailedPutCount, 0);
+
+    const after = await firehose.send(new ListDeliveryStreamsCommand({}));
+    assertArrayLength(after.DeliveryStreamNames ?? [], 0);
+  });
+
+  it("names the commands it can handle", () => {
+    // Given a simulated Firehose.
+    using simSdk = new SimSdk();
+
+    // When its SDK router is asked what it handles.
+    const supported = simSdk.simAws.firehose().sdkCommandRouter();
+
+    // Then every command this service simulates is named, and one it does not
+    // is absent.
+    assertArrayLength(supported.supportedCommandNames(), 6);
+    assertUndefined(supported.route("UpdateDestinationCommand"));
+  });
+});

--- a/src/service/firehose/sim-firehose.ts
+++ b/src/service/firehose/sim-firehose.ts
@@ -1,0 +1,158 @@
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../util/background/background.js";
+import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type * as simFirehoseCommands from "./command/sim-firehose-command.types.js";
+import { SimFirehoseCommands } from "./command/sim-firehose-commands.js";
+import type { SimFirehoseRequestOptions } from "./command/sim-firehose-request-options.js";
+import {
+  type SimFirehoseDeliveryFailure,
+  SimFirehoseDeliveryFailures,
+} from "./delivery/sim-firehose-delivery-failures.js";
+import type { SimFirehoseObjectDestination } from "./delivery/sim-firehose-object-writer.js";
+import { SimFirehoseSdkCommandRouter } from "./sdk/sim-firehose-sdk-command-router.js";
+import type { SimFirehoseDeliveryStream } from "./stream/sim-firehose-delivery-stream.js";
+import { SimFirehoseDeliveryStreamStore } from "./stream/sim-firehose-delivery-stream-store.js";
+
+interface SimFirehoseProperties {
+  readonly accountRegionScope?: SimAwsAccountRegionScope;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+  readonly s3: SimFirehoseObjectDestination;
+}
+
+/**
+ * Simulated Kinesis Data Firehose. Handles SDK commands. Emulates AWS behaviour
+ * and state.
+ *
+ * Delivery streams are scoped to an Account and Region, as they are on real
+ * AWS. A delivery stream name is unique within one of those scopes, and its ARN
+ * names the Region.
+ *
+ * A delivery stream is a destination and a buffer. Records arrive through
+ * PutRecord and PutRecordBatch, wait in the buffer until it passes its size or
+ * its interval, and leave as one S3 Object written as the delivery stream's
+ * `RoleARN`. Advancing simulated time past the interval is what makes a test's
+ * records land in the Bucket.
+ *
+ * S3 is the only destination simulated, and `DirectPut` the only source. The
+ * rest are refused by name at CreateDeliveryStream.
+ */
+export class SimFirehose {
+  private readonly deliveryStreams = new SimFirehoseDeliveryStreamStore();
+  private readonly failures = new SimFirehoseDeliveryFailures();
+  private readonly commands: SimFirehoseCommands;
+  private readonly background: BackgroundScheduler;
+  private readonly sdkRouter = new SimFirehoseSdkCommandRouter(this);
+
+  constructor(properties: SimFirehoseProperties) {
+    const {
+      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.background = background;
+    this.commands = new SimFirehoseCommands({
+      deliveryStreams: this.deliveryStreams,
+      failures: this.failures,
+      s3: properties.s3,
+      iam,
+      background,
+      accountRegionScope,
+    });
+  }
+
+  /**
+   * Find a delivery stream by name.
+   *
+   * This is the simulator's own accessor, for tests seeding or inspecting
+   * delivery stream state without going through a Command and its
+   * authorization.
+   */
+  findDeliveryStream(name: string): SimFirehoseDeliveryStream | undefined {
+    return this.deliveryStreams.find(name);
+  }
+
+  /**
+   * Get the buffers this Firehose could not write, which is the only place a
+   * delivery role missing `s3:PutObject` shows up.
+   *
+   * Real Firehose has answered the `PutRecord` long before it writes the buffer
+   * that record joined, so the caller who put it hears nothing either way.
+   */
+  getDeliveryFailures(): readonly SimFirehoseDeliveryFailure[] {
+    return this.failures.all;
+  }
+
+  /** Handle a CreateDeliveryStream Command from the SDK. */
+  async createDeliveryStream(
+    command: simFirehoseCommands.SimCreateDeliveryStreamCommand,
+    options?: SimFirehoseRequestOptions,
+  ): Promise<simFirehoseCommands.SimCreateDeliveryStreamCommandOutput> {
+    await this.background.sequence();
+    return this.commands.creation.handle(command, options);
+  }
+
+  /** Handle a DeleteDeliveryStream Command from the SDK. */
+  async deleteDeliveryStream(
+    command: simFirehoseCommands.SimDeleteDeliveryStreamCommand,
+    options?: SimFirehoseRequestOptions,
+  ): Promise<simFirehoseCommands.SimDeleteDeliveryStreamCommandOutput> {
+    await this.background.sequence();
+    return this.commands.deliveryStreams.deleteDeliveryStream(command, options);
+  }
+
+  /** Handle a ListDeliveryStreams Command from the SDK. */
+  async listDeliveryStreams(
+    command: simFirehoseCommands.SimListDeliveryStreamsCommand,
+    options?: SimFirehoseRequestOptions,
+  ): Promise<simFirehoseCommands.SimListDeliveryStreamsCommandOutput> {
+    await this.background.sequence();
+    return this.commands.deliveryStreams.listDeliveryStreams(command, options);
+  }
+
+  /** Handle a DescribeDeliveryStream Command from the SDK. */
+  async describeDeliveryStream(
+    command: simFirehoseCommands.SimDescribeDeliveryStreamCommand,
+    options?: SimFirehoseRequestOptions,
+  ): Promise<simFirehoseCommands.SimDescribeDeliveryStreamCommandOutput> {
+    await this.background.sequence();
+    return this.commands.deliveryStreams.describeDeliveryStream(
+      command,
+      options,
+    );
+  }
+
+  /** Handle a PutRecord Command from the SDK. */
+  async putRecord(
+    command: simFirehoseCommands.SimPutRecordCommand,
+    options?: SimFirehoseRequestOptions,
+  ): Promise<simFirehoseCommands.SimPutRecordCommandOutput> {
+    await this.background.sequence();
+    return this.commands.puts.putRecord(command, options);
+  }
+
+  /** Handle a PutRecordBatch Command from the SDK. */
+  async putRecordBatch(
+    command: simFirehoseCommands.SimPutRecordBatchCommand,
+    options?: SimFirehoseRequestOptions,
+  ): Promise<simFirehoseCommands.SimPutRecordBatchCommandOutput> {
+    await this.background.sequence();
+    return this.commands.puts.putRecordBatch(command, options);
+  }
+
+  /**
+   * Get this service's SDK Command router for SDK client interception.
+   */
+  sdkCommandRouter(): SimSdkCommandRouter {
+    return this.sdkRouter;
+  }
+}

--- a/src/service/firehose/stream/sim-firehose-delivery-stream-arn.ts
+++ b/src/service/firehose/stream/sim-firehose-delivery-stream-arn.ts
@@ -1,0 +1,17 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+
+/**
+ * The ARN of a delivery stream of a given name in an Account and Region.
+ *
+ * Every Firehose operation names its delivery stream by name, so nothing here
+ * reads an ARN back. This builds the resource an action authorizes against, and
+ * the ARN CreateDeliveryStream answers with.
+ */
+export function simFirehoseDeliveryStreamArn(
+  accountRegionScope: SimAwsAccountRegionScope,
+  name: string,
+): string {
+  const { regionName, accountId } = accountRegionScope;
+
+  return `arn:aws:firehose:${regionName}:${accountId}:deliverystream/${name}`;
+}

--- a/src/service/firehose/stream/sim-firehose-delivery-stream-name.ts
+++ b/src/service/firehose/stream/sim-firehose-delivery-stream-name.ts
@@ -1,0 +1,38 @@
+import { SimFirehoseInvalidArgumentException } from "../error/sim-firehose.error.js";
+
+const maxNameLength = 64;
+
+const namePattern = /^[\w.-]+$/;
+
+/**
+ * Check a delivery stream name the way real Firehose does, or refuse it.
+ *
+ * The name is the whole of a delivery stream's identity in one Account and
+ * Region, and it is the resource part of the ARN. Firehose accepts letters,
+ * digits, underscores, hyphens and dots, up to 64 characters.
+ */
+export function requireSimFirehoseDeliveryStreamName(
+  name: string | undefined,
+): string {
+  if (name === undefined || name === "") {
+    throw new SimFirehoseInvalidArgumentException(
+      "DeliveryStreamName is required",
+    );
+  }
+
+  if (name.length > maxNameLength) {
+    throw new SimFirehoseInvalidArgumentException(
+      `DeliveryStreamName ${name} is longer than the ${maxNameLength} ` +
+        `characters Firehose allows`,
+    );
+  }
+
+  if (!namePattern.test(name)) {
+    throw new SimFirehoseInvalidArgumentException(
+      `DeliveryStreamName ${name} may hold only letters, digits, underscores, ` +
+        `hyphens and dots`,
+    );
+  }
+
+  return name;
+}

--- a/src/service/firehose/stream/sim-firehose-delivery-stream-store.ts
+++ b/src/service/firehose/stream/sim-firehose-delivery-stream-store.ts
@@ -1,0 +1,68 @@
+import { SimFirehoseResourceNotFoundException } from "../error/sim-firehose.error.js";
+import type { SimFirehoseDeliveryStream } from "./sim-firehose-delivery-stream.js";
+
+/**
+ * The delivery streams of one simulated Firehose scope.
+ *
+ * They are keyed by name, which is the whole of their identity. The name is the
+ * resource part of the ARN, and it is unique within one Account and Region.
+ *
+ * A deleted delivery stream's name is freed straight away, as real Firehose
+ * frees one.
+ */
+export class SimFirehoseDeliveryStreamStore {
+  private readonly deliveryStreams = new Map<
+    string,
+    SimFirehoseDeliveryStream
+  >();
+
+  /**
+   * Every delivery stream in this scope, in name order.
+   *
+   * ListDeliveryStreams pages by name and reports them sorted, so the order a
+   * page is cut out of has to be the order the paging parameter walks.
+   */
+  get all(): readonly SimFirehoseDeliveryStream[] {
+    return this.deliveryStreams
+      .values()
+      .toArray()
+      .toSorted((left, right) => left.name.localeCompare(right.name));
+  }
+
+  /**
+   * Store a newly created delivery stream.
+   */
+  add(deliveryStream: SimFirehoseDeliveryStream): void {
+    this.deliveryStreams.set(deliveryStream.name, deliveryStream);
+  }
+
+  /**
+   * Find a delivery stream by name.
+   */
+  find(name: string): SimFirehoseDeliveryStream | undefined {
+    return this.deliveryStreams.get(name);
+  }
+
+  /**
+   * Resolve a delivery stream by name, or refuse.
+   */
+  require(name: string): SimFirehoseDeliveryStream {
+    const found = this.find(name);
+
+    if (found === undefined) {
+      throw new SimFirehoseResourceNotFoundException(
+        `Firehose cannot find the delivery stream ${name} under this account ` +
+          `and region`,
+      );
+    }
+
+    return found;
+  }
+
+  /**
+   * Forget a deleted delivery stream.
+   */
+  remove(deliveryStream: SimFirehoseDeliveryStream): void {
+    this.deliveryStreams.delete(deliveryStream.name);
+  }
+}

--- a/src/service/firehose/stream/sim-firehose-delivery-stream.factory.ts
+++ b/src/service/firehose/stream/sim-firehose-delivery-stream.factory.ts
@@ -1,0 +1,90 @@
+import { AsyncMappedFactory } from "@kensio/part-factory";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimFirehoseDeliveryStream } from "./sim-firehose-delivery-stream.js";
+
+/**
+ * What a test asks for when it wants a delivery stream to put records onto.
+ *
+ * The Bucket has to be there already, since a delivery stream is one entity and
+ * its destination is another. `test/firehose/firehose-delivery-fixture.ts`
+ * makes both together for the tests that want the whole path.
+ */
+export interface SimFirehoseDeliveryStreamInput {
+  readonly deliveryStreamName: string;
+  readonly bucketName: string;
+  readonly prefix: string;
+  readonly intervalInSeconds: number;
+  readonly sizeInMegabytes: number;
+
+  /**
+   * The Role the delivery writes as.
+   *
+   * A delivery stream made without one writes as the Account root, which IAM
+   * allows everything. A test about the delivery Role passes one from
+   * `simIamRoleWithPolicyFactory`.
+   */
+  readonly roleArn: string | undefined;
+}
+
+/**
+ * Creates a delivery stream through CreateDeliveryStream.
+ *
+ * The delivery stream went through the ordinary command, so it is the delivery
+ * stream an application would have rather than one built around the commands,
+ * and it is ACTIVE by the time this answers.
+ *
+ * ```typescript
+ * const deliveryStream = await simFirehoseDeliveryStreamFactory.make(
+ *   { bucketName: "order-archive", intervalInSeconds: 60 },
+ *   simAws,
+ * );
+ * ```
+ */
+export const simFirehoseDeliveryStreamFactory = new AsyncMappedFactory<
+  SimFirehoseDeliveryStreamInput,
+  SimFirehoseDeliveryStream,
+  SimAws
+>(
+  () => ({
+    deliveryStreamName: "order-events",
+    bucketName: "order-archive",
+    prefix: "",
+    intervalInSeconds: 60,
+    sizeInMegabytes: 5,
+    roleArn: undefined,
+  }),
+  async (input, simAws) => {
+    const firehose = simAws.firehose();
+
+    await firehose.createDeliveryStream({
+      input: {
+        DeliveryStreamName: input.deliveryStreamName,
+        ExtendedS3DestinationConfiguration: {
+          BucketARN: `arn:aws:s3:::${input.bucketName}`,
+          RoleARN:
+            input.roleArn ?? `arn:aws:iam::${simAws.defaultAccountId}:root`,
+          Prefix: input.prefix,
+          BufferingHints: {
+            IntervalInSeconds: input.intervalInSeconds,
+            SizeInMBs: input.sizeInMegabytes,
+          },
+        },
+      },
+    });
+
+    // A name CreateDeliveryStream accepted is a delivery stream the store
+    // holds, so this is only missing if something is wrong with the simulator
+    // itself.
+    const deliveryStream = firehose.findDeliveryStream(
+      input.deliveryStreamName,
+    );
+    assertDefined(
+      deliveryStream,
+      `Simulated Firehose created the delivery stream ` +
+        `${input.deliveryStreamName} and then did not hold it`,
+    );
+
+    return deliveryStream;
+  },
+);

--- a/src/service/firehose/stream/sim-firehose-delivery-stream.ts
+++ b/src/service/firehose/stream/sim-firehose-delivery-stream.ts
@@ -1,0 +1,65 @@
+import { SimFirehoseBuffer } from "../delivery/sim-firehose-buffer.js";
+import type { SimFirehoseS3Destination } from "../destination/sim-firehose-s3-destination.js";
+
+/**
+ * The states a delivery stream reports.
+ *
+ * A simulated delivery stream is ACTIVE from the moment CreateDeliveryStream
+ * answers. Real Firehose spends a minute or so in CREATING, and a test that had
+ * to wait it out would be waiting on nothing.
+ */
+export type SimFirehoseDeliveryStreamStatus = "ACTIVE";
+
+/**
+ * How a delivery stream gets its records.
+ *
+ * `DirectPut` is the only source simulated. A delivery stream reading from a
+ * Kinesis stream is a separate job.
+ */
+export type SimFirehoseDeliveryStreamType = "DirectPut";
+
+interface SimFirehoseDeliveryStreamProperties {
+  readonly name: string;
+  readonly arn: string;
+  readonly destination: SimFirehoseS3Destination;
+  readonly createdAt: Date;
+}
+
+/**
+ * One delivery stream, and what it has taken but not yet delivered.
+ *
+ * A delivery stream is a destination and a buffer. Records arrive through
+ * PutRecord, wait in the buffer until it passes one of its two bounds, and
+ * leave as one S3 Object.
+ *
+ * The version is the `1` in a delivered Object's key. Real Firehose moves it on
+ * with every configuration change, and nothing here changes a delivery stream's
+ * configuration, so it stays at 1 for the life of the delivery stream.
+ */
+export class SimFirehoseDeliveryStream {
+  public readonly name: string;
+  public readonly arn: string;
+  public readonly destination: SimFirehoseS3Destination;
+  public readonly createdAt: Date;
+  public readonly buffer = new SimFirehoseBuffer();
+  public readonly versionId = "1";
+  public readonly status: SimFirehoseDeliveryStreamStatus = "ACTIVE";
+  public readonly deliveryStreamType: SimFirehoseDeliveryStreamType =
+    "DirectPut";
+
+  constructor(properties: SimFirehoseDeliveryStreamProperties) {
+    this.name = properties.name;
+    this.arn = properties.arn;
+    this.destination = properties.destination;
+    this.createdAt = properties.createdAt;
+  }
+
+  /**
+   * Whether the buffer has reached the size that delivers it.
+   */
+  get isBufferFull(): boolean {
+    return (
+      this.buffer.byteLength >= this.destination.bufferingHints.sizeInBytes
+    );
+  }
+}

--- a/test/firehose/firehose-delivery-fixture.ts
+++ b/test/firehose/firehose-delivery-fixture.ts
@@ -1,0 +1,130 @@
+/**
+ * The parts a Firehose delivery test needs before it can say anything about
+ * what lands in a Bucket: a destination Bucket, a Role allowed to write to it,
+ * and a delivery stream pointing at both.
+ *
+ * Each of the three is an entity factory of its own. This is where they are put
+ * together, because a delivery stream whose Bucket is absent delivers nothing
+ * and no test wants that as its Given.
+ */
+
+import {
+  CreateBucketCommand,
+  GetObjectCommand,
+  ListObjectsV2Command,
+} from "@aws-sdk/client-s3";
+import { assertNonNullable } from "@kensio/smartass";
+import { assertDefined } from "../../src/util/type-guard/defined.js";
+import { simS3BodyToBuffer } from "../../src/service/s3/storage/s3-body-buffer.js";
+import type { SimAws } from "../../src/service/aws/sim-aws.js";
+import { simIamRoleWithPolicyFactory } from "../../src/service/iam/role/sim-iam-role-with-policy.factory.js";
+import { simFirehoseDeliveryStreamFactory } from "../../src/service/firehose/stream/sim-firehose-delivery-stream.factory.js";
+import type { SimFirehoseDeliveryStream } from "../../src/service/firehose/stream/sim-firehose-delivery-stream.js";
+
+/**
+ * The S3 action real Firehose requires a delivery Role to be allowed before it
+ * will write a buffer.
+ */
+export const firehoseDeliveryActions: readonly string[] = [
+  "s3:AbortMultipartUpload",
+  "s3:GetBucketLocation",
+  "s3:GetObject",
+  "s3:ListBucket",
+  "s3:ListBucketMultipartUploads",
+  "s3:PutObject",
+];
+
+/**
+ * What a delivery fixture leaves a test holding.
+ */
+export interface FirehoseDelivery {
+  readonly deliveryStream: SimFirehoseDeliveryStream;
+  readonly bucketName: string;
+  readonly roleArn: string;
+}
+
+interface FirehoseDeliveryOptions {
+  readonly bucketName?: string;
+  readonly prefix?: string;
+  readonly intervalInSeconds?: number;
+  readonly sizeInMegabytes?: number;
+  readonly actions?: readonly string[];
+}
+
+/**
+ * Make a Bucket, a delivery Role and a delivery stream writing into the one as
+ * the other.
+ *
+ * The Role is allowed the actions real Firehose asks a delivery Role for.
+ * Narrowing them is how a test checks what a Role that cannot write does.
+ */
+export async function makeFirehoseDelivery(
+  simAws: SimAws,
+  options: FirehoseDeliveryOptions = {},
+): Promise<FirehoseDelivery> {
+  const bucketName = options.bucketName ?? "order-archive";
+
+  await simAws
+    .s3()
+    .createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+
+  const role = await simIamRoleWithPolicyFactory.make(
+    {
+      roleName: "OrderArchiveDeliveryRole",
+      policyName: "ArchiveOrders",
+      actions: options.actions ?? firehoseDeliveryActions,
+      resource: `arn:aws:s3:::${bucketName}/*`,
+    },
+    simAws,
+  );
+
+  assertDefined(role.Arn, "Simulated IAM created a Role with no ARN");
+
+  const deliveryStream = await simFirehoseDeliveryStreamFactory.make(
+    {
+      bucketName,
+      roleArn: role.Arn,
+      prefix: options.prefix ?? "",
+      intervalInSeconds: options.intervalInSeconds ?? 60,
+      sizeInMegabytes: options.sizeInMegabytes ?? 5,
+    },
+    simAws,
+  );
+
+  return { deliveryStream, bucketName, roleArn: role.Arn };
+}
+
+/**
+ * Every Object key in a Bucket, in the order S3 lists them.
+ */
+export async function deliveredObjectKeys(
+  simAws: SimAws,
+  bucketName: string,
+): Promise<readonly string[]> {
+  const listing = await simAws
+    .s3()
+    .listObjectsV2(new ListObjectsV2Command({ Bucket: bucketName }));
+
+  return (listing.Contents ?? []).map((object) => object.Key ?? "");
+}
+
+/**
+ * The bytes of one delivered Object, as text.
+ */
+export async function deliveredObjectBody(
+  simAws: SimAws,
+  bucketName: string,
+  key: string | undefined,
+): Promise<string> {
+  assertDefined(key, "A delivered Object was expected under a key");
+
+  const read = await simAws
+    .s3()
+    .getObject(new GetObjectCommand({ Bucket: bucketName, Key: key }));
+
+  assertNonNullable(read.Body, `The Object at ${key} has a body`);
+
+  const bytes = await simS3BodyToBuffer(read.Body);
+
+  return bytes.toString("utf8");
+}


### PR DESCRIPTION
A delivery stream takes records through PutRecord and PutRecordBatch, buffers them until the buffer
passes its size or its interval, and writes them into a simulated S3 Bucket as its RoleARN.
Advancing the simulated clock past the interval is what delivers a buffer, and the object key
follows the real Firehose format of prefix, UTC date path, delivery stream name, version, timestamp
and a random string. S3 is the only destination and DirectPut the only source, and the rest are
refused by name at CreateDeliveryStream. A buffer the delivery Role could not write is kept on
simAws.firehose().getDeliveryFailures(), since real Firehose answered the put minutes earlier and
tells the producer nothing.
