### PR TITLE
feat: deploy AWS::StepFunctions::StateMachine

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -3263,6 +3263,7 @@ The resource types it creates are:
 - `AWS::SecretsManager::Secret`
 - `AWS::SQS::Queue`
 - `AWS::SSM::Parameter`
+- `AWS::StepFunctions::StateMachine`
 - selected CDK custom resources: `Custom::CDKBucketDeployment` and `Custom::S3BucketNotifications`
 
 Each service's own docs describe what its resource types support.

--- a/docs/services/stepfunctions/README.md
+++ b/docs/services/stepfunctions/README.md
@@ -305,8 +305,10 @@ console.log(started.executionArn);
 ## Deploying one from CloudFormation
 
 A template declaring `AWS::StepFunctions::StateMachine` creates a state machine. It goes through the
-ordinary `CreateStateMachine` command. A template and an SDK caller reach the same state machine, and
-a definition this simulator will not run is refused in the same words either way.
+ordinary `CreateStateMachine` command, and a template and an SDK caller reach the same state machine.
+A definition Amazon States Language itself refuses fails the Resource, in the words
+`CreateStateMachine` refuses it in. A definition this simulator has no implementation for takes the
+skip described at the end of this section.
 
 CDK synthesizes the Resource from `stepfunctions.StateMachine`. Deploy the synthesized assembly and
 the workflow is there to start an execution against.

--- a/docs/services/stepfunctions/README.md
+++ b/docs/services/stepfunctions/README.md
@@ -302,6 +302,66 @@ const started = await client.send(
 console.log(started.executionArn);
 ```
 
+## Deploying one from CloudFormation
+
+A template declaring `AWS::StepFunctions::StateMachine` creates a state machine. It goes through the
+ordinary `CreateStateMachine` command. A template and an SDK caller reach the same state machine, and
+a definition this simulator will not run is refused in the same words either way.
+
+CDK synthesizes the Resource from `stepfunctions.StateMachine`. Deploy the synthesized assembly and
+the workflow is there to start an execution against.
+
+```typescript sim-step-functions-cloudformation
+/**
+ * Running an execution against a state machine a CDK app deployed.
+ */
+
+import path from "node:path";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+// The CDK app holds `new sfn.StateMachine(stack, "Workflow", {
+//   stateMachineName: "Enrolment",
+//   definitionBody: sfn.DefinitionBody.fromChainable(record.next(done)),
+// })`.
+await simAws.cloudFormation().deployCdkOut(path.join(process.cwd(), "cdk.out"));
+
+const workflow = simAws.stepFunctions().findStateMachine("Enrolment");
+
+if (workflow === undefined) throw new Error("No Enrolment state machine");
+
+const started = await simAws.stepFunctions().startExecution({
+  input: {
+    stateMachineArn: workflow.arn,
+    input: JSON.stringify({ student: "Wei" }),
+  },
+});
+
+const described = await simAws
+  .stepFunctions()
+  .describeExecution({ input: { executionArn: started.executionArn } });
+
+console.log(described.status); // SUCCEEDED
+```
+
+The definition is read once the template intrinsics have resolved. CDK writes `DefinitionString` as
+an `Fn::Join` over the ARNs of the resources the workflow reaches, and the joined string is the
+Amazon States Language the interpreter reads. A template can write the same document as template
+data under `Definition`. `DefinitionSubstitutions` replaces every `${Key}` in the definition before
+it is read.
+
+`StateMachineName`, `RoleArn` and `StateMachineType` are carried across. A state machine the
+template does not name is named after the stack and the logical ID (`enrolment-Workflow`), the way
+CloudFormation names one. `Ref` answers with the ARN and `Fn::GetAtt` answers `Arn` and `Name`. Real
+CloudFormation publishes this one that way round too. Deleting the stack deletes the state machine.
+
+A definition holding a state type this simulator does not run drops that one state machine. The
+reason lands on `stack.skippedResources` and the rest of the stack deploys. The whole state machine
+goes. A state machine missing one state runs wrong, and a test watching it run wrong is worse off
+than a test watching it be absent.
+
 ## Reference Paths
 
 The path subset read here is the one Amazon States Language itself uses. A document root, a child by
@@ -345,6 +405,17 @@ A test asserting on the output of a state machine that used one could only asser
 - **A cycle in the states fails the execution** after 25,000 transitions, with `States.Runtime`. Real
   Step Functions stops one when it runs out of execution history events.
 
+- **A state machine carries no tags.** `Tags` on the CloudFormation Resource is recorded on
+  `stack.ignoredProperties` and the state machine is created without them. `ListTagsForResource`,
+  `TagResource` and `UntagResource` are unsimulated. `LoggingConfiguration`,
+  `TracingConfiguration` and `EncryptionConfiguration` are recorded the same way.
+- **`DefinitionS3Location` is unsimulated.** CDK reaches for it once a definition passes the
+  template size limit, and for `DefinitionBody.fromFile`. The state machine is dropped and the
+  reason recorded, and the rest of the stack deploys.
+- **`AWS::StepFunctions::StateMachineVersion` and `AWS::StepFunctions::StateMachineAlias` are
+  unsupported.** Every execution runs the definition the state machine currently holds, so there is
+  nothing for a published version or an alias to point at.
+
 `CreateStateMachine` is idempotent, as it is on AWS. A second request carrying the same name,
 definition and type answers with the state machine already there, and one carrying a different
 definition raises `StateMachineAlreadyExists`. A differing `roleArn` is ignored. The AWS API
@@ -357,6 +428,5 @@ two and is what this follows.
 - `Task`, `Parallel` and `Map` states.
 - `Retry` and `Catch`.
 - Service integrations, task tokens and activities.
-- `AWS::StepFunctions::StateMachine` CloudFormation resources.
 - JSONata as a query language, and the `Assign` variables that go with it.
 - IAM authorization of what a state machine's role may do.

--- a/docs/services/stepfunctions/sim-step-functions-cloudformation.example.ts
+++ b/docs/services/stepfunctions/sim-step-functions-cloudformation.example.ts
@@ -1,0 +1,32 @@
+/**
+ * Running an execution against a state machine a CDK app deployed.
+ */
+
+import path from "node:path";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+// The CDK app holds `new sfn.StateMachine(stack, "Workflow", {
+//   stateMachineName: "Enrolment",
+//   definitionBody: sfn.DefinitionBody.fromChainable(record.next(done)),
+// })`.
+await simAws.cloudFormation().deployCdkOut(path.join(process.cwd(), "cdk.out"));
+
+const workflow = simAws.stepFunctions().findStateMachine("Enrolment");
+
+if (workflow === undefined) throw new Error("No Enrolment state machine");
+
+const started = await simAws.stepFunctions().startExecution({
+  input: {
+    stateMachineArn: workflow.arn,
+    input: JSON.stringify({ student: "Wei" }),
+  },
+});
+
+const described = await simAws
+  .stepFunctions()
+  .describeExecution({ input: { executionArn: started.executionArn } });
+
+console.log(described.status); // SUCCEEDED

--- a/src/service/cloudformation/cdk/stepfunctions/sim-cdk-state-machine.loc.test.ts
+++ b/src/service/cloudformation/cdk/stepfunctions/sim-cdk-state-machine.loc.test.ts
@@ -1,0 +1,97 @@
+import {
+  assertIdentical,
+  assertStringStartsWith,
+  assertTypeString,
+} from "@kensio/smartass";
+import path from "node:path";
+import { describe, it } from "vitest";
+
+/**
+ * Slower local integration test. Calls the real CDK CLI to synth the output
+ * template file to pass to sim CloudFormation, so the template under test is
+ * one CDK actually produced rather than one written by hand.
+ */
+import { SimAws } from "../../../aws/sim-aws.js";
+import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+
+const accountIdOneOnes = "111111111111";
+
+describe("Sim CDK Step Functions StateMachine deployment local integration", () => {
+  it("runs an execution against a state machine CDK synthesized", async () => {
+    // Given a CDK stack holding an unnamed state machine, chained from the
+    // constructs rather than written as Amazon States Language.
+    const cdkProject = new TestCdkProject();
+    await cdkProject.writeCdkAppFile(`
+import * as cdk from "aws-cdk-lib/core";
+import * as sfn from "aws-cdk-lib/aws-stepfunctions";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "111111111111", region: "eu-west-2" },
+});
+
+const record = new sfn.Pass(stack, "Record", {
+  result: sfn.Result.fromObject({ enrolled: true }),
+  resultPath: "$.outcome",
+});
+
+const workflow = new sfn.StateMachine(stack, "Workflow", {
+  definitionBody: sfn.DefinitionBody.fromChainable(
+    record.next(new sfn.Succeed(stack, "Done")),
+  ),
+});
+
+new cdk.CfnOutput(stack, "WorkflowArn", { value: workflow.stateMachineArn });
+new cdk.CfnOutput(stack, "WorkflowName", { value: workflow.stateMachineName });
+
+app.synth();
+    `);
+
+    // And we synth the CDK template.
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When we deploy the synthesized template into the account and region the
+    // CDK app declares, with no hand-editing of the
+    // AWS::StepFunctions::StateMachine Resource CDK emits.
+    const simAws = new SimAws();
+    const scoped = simAws.account(accountIdOneOnes).region("eu-west-2");
+    const stack = await scoped
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // Then the state machine is named after the stack and the logical ID,
+    // because the CDK construct did not name it.
+    const stateMachineName = stack.outputs.get("WorkflowName")?.value;
+    assertTypeString(stateMachineName);
+    assertStringStartsWith(stateMachineName, "TestStack-Workflow");
+
+    // And the ARN CDK reads as a Ref is the one the state machine answers to.
+    const stateMachineArn = stack.outputs.get("WorkflowArn")?.value;
+    assertTypeString(stateMachineArn);
+
+    const described = await scoped
+      .stepFunctions()
+      .describeStateMachine({ input: { stateMachineArn } });
+    assertIdentical(described.name, stateMachineName);
+    assertIdentical(described.type, "STANDARD");
+
+    // And an execution walks the chain the constructs were wired into.
+    const started = await scoped.stepFunctions().startExecution({
+      input: { stateMachineArn, input: JSON.stringify({ student: "Wei" }) },
+    });
+    const execution = await scoped
+      .stepFunctions()
+      .describeExecution({ input: { executionArn: started.executionArn } });
+
+    assertIdentical(execution.status, "SUCCEEDED");
+    assertIdentical(
+      execution.output,
+      JSON.stringify({ student: "Wei", outcome: { enrolled: true } }),
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/service/cloudformation/resource/cfn/sim-cfn-service-value-adapters.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-service-value-adapters.ts
@@ -23,6 +23,7 @@ import { sesValueAdapter } from "./ses/sim-ses-cfn-value-adapter.js";
 import { snsValueAdapter } from "./sns/sim-sns-cfn-value-adapter.js";
 import { sqsValueAdapter } from "./sqs/sim-sqs-cfn-value-adapter.js";
 import { ssmValueAdapter } from "./ssm/sim-ssm-cfn-value-adapter.js";
+import { stepFunctionsValueAdapter } from "./stepfunctions/sim-step-functions-cfn-value-adapter.js";
 import { wafV2ValueAdapter } from "./wafv2/sim-wafv2-cfn-value-adapter.js";
 import type {
   SimCfnResourceValueAdapterProperties,
@@ -66,5 +67,6 @@ export const simCfnServiceValueAdapters: readonly ((
   snsValueAdapter,
   sqsValueAdapter,
   ssmValueAdapter,
+  stepFunctionsValueAdapter,
   wafV2ValueAdapter,
 ];

--- a/src/service/cloudformation/resource/cfn/stepfunctions/sim-cfn-state-machine-creator.ts
+++ b/src/service/cloudformation/resource/cfn/stepfunctions/sim-cfn-state-machine-creator.ts
@@ -1,0 +1,70 @@
+import { assertDefined } from "../../../../../util/type-guard/defined.js";
+import type { SimStateMachine } from "../../../../stepfunctions/machine/sim-state-machine.js";
+import type { SimStepFunctions } from "../../../../stepfunctions/sim-step-functions.js";
+import type { SimCfnResource } from "../../sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../template/value/sim-cfn-template-value.js";
+import { SimCfnStateMachineProperties } from "./sim-cfn-state-machine-properties.js";
+import { simCfnStepFunctionsResourceCommand } from "./sim-cfn-step-functions-resource-error.js";
+import { stateMachineResourceType } from "./sim-cfn-step-functions-resource-types.js";
+
+interface SimCfnStateMachineCreatorProperties {
+  readonly stepFunctions: SimStepFunctions;
+}
+
+/**
+ * Creates simulated state machines from AWS::StepFunctions::StateMachine
+ * Resources.
+ *
+ * The state machine goes through the ordinary CreateStateMachine command
+ * rather than being constructed directly, so one a template deployed is the
+ * same thing an SDK caller would have got. The name rules, the definition
+ * checks and the refusals for what this simulation does not run are all the
+ * same either way.
+ */
+export class SimCfnStateMachineCreator {
+  readonly #stepFunctions: SimStepFunctions;
+
+  constructor(properties: SimCfnStateMachineCreatorProperties) {
+    this.#stepFunctions = properties.stepFunctions;
+  }
+
+  /**
+   * Create a state machine from an AWS::StepFunctions::StateMachine Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimStateMachine> {
+    const stateMachineProperties = new SimCfnStateMachineProperties({
+      resource,
+      properties,
+    });
+    const name = stateMachineProperties.name();
+    const roleArn = stateMachineProperties.roleArn();
+    const type = stateMachineProperties.type();
+    const definition = stateMachineProperties.definition();
+
+    return await simCfnStepFunctionsResourceCommand(
+      stateMachineResourceType,
+      resource.logicalId,
+      async () => {
+        await this.#stepFunctions.createStateMachine({
+          input: {
+            name,
+            definition,
+            roleArn,
+            ...(type !== undefined && { type }),
+          },
+        });
+
+        const stateMachine = this.#stepFunctions.findStateMachine(name);
+        assertDefined(
+          stateMachine,
+          `sim state machine ${name} after CloudFormation creation`,
+        );
+
+        return stateMachine;
+      },
+    );
+  }
+}

--- a/src/service/cloudformation/resource/cfn/stepfunctions/sim-cfn-state-machine-definition.ts
+++ b/src/service/cloudformation/resource/cfn/stepfunctions/sim-cfn-state-machine-definition.ts
@@ -1,0 +1,133 @@
+import { isRecord } from "../../../../../util/type-guard/record.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import {
+  simCfnStepFunctionsResourceError,
+  simCfnStepFunctionsSkippedResourceError,
+} from "./sim-cfn-step-functions-resource-error.js";
+import {
+  definitionPropertyName,
+  definitionS3LocationPropertyName,
+  definitionStringPropertyName,
+  definitionSubstitutionsPropertyName,
+} from "./sim-cfn-state-machine-property-names.js";
+import { SimCfnStateMachineSubstitutions } from "./sim-cfn-state-machine-substitutions.js";
+import { stateMachineResourceType } from "./sim-cfn-step-functions-resource-types.js";
+
+interface SimCfnStateMachineDefinitionProperties {
+  readonly logicalId: string;
+  readonly properties: ReadonlyMap<string, SimCfnTemplateValue>;
+}
+
+/**
+ * Reads the Amazon States Language a state machine Resource carries.
+ *
+ * A template writes the definition one of three ways. `DefinitionString` holds
+ * it as a string. CDK emits that form, as an `Fn::Join` over the ARNs of the
+ * Resources the workflow reaches, and the join has resolved by the time this
+ * reads it. `Definition` holds the same document as template data, the form a
+ * hand-written YAML template tends to use. `DefinitionS3Location` points at an
+ * object in a bucket, and this simulation does not fetch one.
+ */
+export class SimCfnStateMachineDefinition {
+  readonly #logicalId: string;
+  readonly #properties: ReadonlyMap<string, SimCfnTemplateValue>;
+
+  constructor(properties: SimCfnStateMachineDefinitionProperties) {
+    this.#logicalId = properties.logicalId;
+    this.#properties = properties.properties;
+  }
+
+  /**
+   * The definition to create the state machine from, with any substitutions
+   * applied.
+   */
+  value(): string {
+    return new SimCfnStateMachineSubstitutions({
+      logicalId: this.#logicalId,
+      declared: this.#properties.get(definitionSubstitutionsPropertyName),
+    }).applyTo(this.declared());
+  }
+
+  /**
+   * The definition as the template wrote it, before substitution.
+   */
+  private declared(): string {
+    const definitionString = this.#properties.get(definitionStringPropertyName);
+    const definition = this.#properties.get(definitionPropertyName);
+
+    if (definitionString !== undefined && definition !== undefined) {
+      throw this.definitionError(
+        `${definitionStringPropertyName} and ${definitionPropertyName} are ` +
+          "two ways of writing the same thing, and a Resource carries one",
+      );
+    }
+
+    if (definitionString !== undefined) {
+      return this.readDefinitionString(definitionString);
+    }
+
+    if (definition !== undefined) {
+      return this.readDefinition(definition);
+    }
+
+    return this.missingDefinition();
+  }
+
+  /**
+   * The string form, which an `Fn::Join` resolves to.
+   */
+  private readDefinitionString(definitionString: SimCfnTemplateValue): string {
+    if (typeof definitionString !== "string") {
+      throw this.definitionError(
+        `${definitionStringPropertyName} must be a string`,
+      );
+    }
+
+    return definitionString;
+  }
+
+  /**
+   * The object form, holding the same document as template data.
+   */
+  private readDefinition(definition: SimCfnTemplateValue): string {
+    if (!isRecord(definition)) {
+      throw this.definitionError(`${definitionPropertyName} must be an object`);
+    }
+
+    return JSON.stringify(definition);
+  }
+
+  /**
+   * What a Resource carrying no definition this simulation reads is refused
+   * with.
+   *
+   * A definition in S3 is skipped and the Resource carries on being reported.
+   * The asset is published by the CDK bootstrap machinery this simulator has
+   * no part in, so a template pointing at one is asking for something absent.
+   * A Resource written wrongly is a different thing, and fails.
+   */
+  private missingDefinition(): never {
+    if (this.#properties.has(definitionS3LocationPropertyName)) {
+      throw simCfnStepFunctionsSkippedResourceError(
+        stateMachineResourceType,
+        this.#logicalId,
+        `${definitionS3LocationPropertyName} points at an object in a bucket, ` +
+          "which this simulation does not fetch a definition from",
+      );
+    }
+
+    throw this.definitionError(
+      `a state machine needs a ${definitionStringPropertyName} or a ${
+        definitionPropertyName
+      }`,
+    );
+  }
+
+  private definitionError(reason: string): Error {
+    return simCfnStepFunctionsResourceError(
+      stateMachineResourceType,
+      this.#logicalId,
+      reason,
+    );
+  }
+}

--- a/src/service/cloudformation/resource/cfn/stepfunctions/sim-cfn-state-machine-definitions.iso.test.ts
+++ b/src/service/cloudformation/resource/cfn/stepfunctions/sim-cfn-state-machine-definitions.iso.test.ts
@@ -1,0 +1,153 @@
+import { assertIdentical, assertTypeString } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../../template/sim-cfn-template.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+
+describe("AWS::StepFunctions::StateMachine definitions", () => {
+  const roleArn = "arn:aws:iam::123456789012:role/EnrolmentWorkflowRole";
+
+  /**
+   * A stack holding a queue and a workflow that carries the queue's ARN
+   * through to its output.
+   *
+   * The queue is there to put a Resource ARN in the definition, which is what
+   * makes the intrinsics worth resolving before the definition is read.
+   */
+  function workflowTemplate(
+    definitionProperties: Record<string, SimCfnTemplateValue>,
+  ): CfnTemplateBodyRecord {
+    return {
+      Resources: {
+        OrdersQueue: { Type: "AWS::SQS::Queue", Properties: {} },
+        Workflow: {
+          Type: "AWS::StepFunctions::StateMachine",
+          Properties: {
+            StateMachineName: "Enrolment",
+            RoleArn: roleArn,
+            ...definitionProperties,
+          },
+        },
+      },
+      Outputs: {
+        WorkflowArn: { Value: { "Fn::GetAtt": ["Workflow", "Arn"] } },
+        QueueArn: { Value: { "Fn::GetAtt": ["OrdersQueue", "Arn"] } },
+      },
+    };
+  }
+
+  /**
+   * Deploy a template and run one execution against the state machine in it.
+   */
+  async function runWorkflow(
+    template: CfnTemplateBodyRecord,
+  ): Promise<{ readonly output: string; readonly queueArn: string }> {
+    const simAws = new SimAws();
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplate({ stackName: "enrolment", template });
+    await stack.waitForDeployComplete();
+
+    const stateMachineArn = stack.outputs.get("WorkflowArn")?.value;
+    assertTypeString(stateMachineArn);
+    const queueArn = stack.outputs.get("QueueArn")?.value;
+    assertTypeString(queueArn);
+
+    const started = await simAws
+      .stepFunctions()
+      .startExecution({ input: { stateMachineArn } });
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn: started.executionArn } });
+
+    assertIdentical(described.status, "SUCCEEDED");
+
+    return { output: described.output ?? "", queueArn };
+  }
+
+  it("reads a DefinitionString written as an Fn::Join over a Resource", async () => {
+    // Given a definition built the way CDK builds one, as an Fn::Join with a
+    // Resource attribute in the middle of it.
+    const template = workflowTemplate({
+      DefinitionString: {
+        "Fn::Join": [
+          "",
+          [
+            '{"StartAt":"Record","States":{"Record":{"Type":"Pass","Result":{"queue":"',
+            { "Fn::GetAtt": ["OrdersQueue", "Arn"] },
+            '"},"End":true}}}',
+          ],
+        ],
+      },
+    });
+
+    // When the stack is deployed and an execution is run.
+    const { output, queueArn } = await runWorkflow(template);
+
+    // Then the execution ran the joined definition, carrying the ARN the
+    // intrinsics resolved to.
+    assertIdentical(output, JSON.stringify({ queue: queueArn }));
+  });
+
+  it("reads a Definition written as template data", async () => {
+    // Given the same workflow written as an object rather than as a string,
+    // which is the form a hand-written template tends to use.
+    const template = workflowTemplate({
+      Definition: {
+        StartAt: "Record",
+        States: {
+          Record: {
+            Type: "Pass",
+            Result: { queue: { "Fn::GetAtt": ["OrdersQueue", "Arn"] } },
+            End: true,
+          },
+        },
+      },
+    });
+
+    // When the stack is deployed and an execution is run.
+    const { output, queueArn } = await runWorkflow(template);
+
+    // Then the definition was read as Amazon States Language directly, with
+    // its intrinsics resolved the same way.
+    assertIdentical(output, JSON.stringify({ queue: queueArn }));
+  });
+
+  /**
+   * A substitution placeholder, written the way a template writes one.
+   */
+  function placeholder(key: string): string {
+    return `\${${key}}`;
+  }
+
+  it("puts DefinitionSubstitutions into the definition", async () => {
+    // Given a definition holding a placeholder, and a substitution naming the
+    // queue it stands for.
+    const template = workflowTemplate({
+      DefinitionString: JSON.stringify({
+        StartAt: "Record",
+        States: {
+          Record: {
+            Type: "Pass",
+            Result: {
+              queue: placeholder("OrdersQueueArn"),
+              attempts: placeholder("Attempts"),
+            },
+            End: true,
+          },
+        },
+      }),
+      DefinitionSubstitutions: {
+        OrdersQueueArn: { "Fn::GetAtt": ["OrdersQueue", "Arn"] },
+        Attempts: 3,
+      },
+    });
+
+    // When the stack is deployed and an execution is run.
+    const { output, queueArn } = await runWorkflow(template);
+
+    // Then every placeholder was replaced before the definition was read.
+    assertIdentical(output, JSON.stringify({ queue: queueArn, attempts: "3" }));
+  });
+});

--- a/src/service/cloudformation/resource/cfn/stepfunctions/sim-cfn-state-machine-name.ts
+++ b/src/service/cloudformation/resource/cfn/stepfunctions/sim-cfn-state-machine-name.ts
@@ -1,0 +1,36 @@
+import { SimCfnGeneratedResourceName } from "../../name/sim-cfn-generated-resource-name.js";
+
+const maximumNameLength = 80;
+
+interface SimCfnStateMachineNameProperties {
+  readonly stackName: string | undefined;
+  readonly logicalId: string;
+}
+
+/**
+ * The name CloudFormation gives a state machine whose template does not name
+ * it.
+ *
+ * A state machine name is at most 80 characters, so a long stack name and
+ * logical ID together are trimmed to fit. How a generated name is put together
+ * and trimmed is the same for every service, and lives in
+ * {@link SimCfnGeneratedResourceName}.
+ */
+export class SimCfnStateMachineName {
+  readonly #generated: SimCfnGeneratedResourceName;
+
+  constructor(properties: SimCfnStateMachineNameProperties) {
+    this.#generated = new SimCfnGeneratedResourceName({
+      stackName: properties.stackName,
+      logicalId: properties.logicalId,
+      maximumLength: maximumNameLength,
+    });
+  }
+
+  /**
+   * The generated state machine name.
+   */
+  get value(): string {
+    return this.#generated.value;
+  }
+}

--- a/src/service/cloudformation/resource/cfn/stepfunctions/sim-cfn-state-machine-properties.ts
+++ b/src/service/cloudformation/resource/cfn/stepfunctions/sim-cfn-state-machine-properties.ts
@@ -1,0 +1,136 @@
+import type { SimCfnResource } from "../../sim-cfn-resource.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../template/value/sim-cfn-template-value.js";
+import { SimCfnStateMachineDefinition } from "./sim-cfn-state-machine-definition.js";
+import { SimCfnStateMachineName } from "./sim-cfn-state-machine-name.js";
+import {
+  roleArnPropertyName,
+  stateMachineNamePropertyName,
+  stateMachineTypePropertyName,
+  unsimulatedPropertyReasons,
+} from "./sim-cfn-state-machine-property-names.js";
+import { simCfnStepFunctionsResourceError } from "./sim-cfn-step-functions-resource-error.js";
+import { stateMachineResourceType } from "./sim-cfn-step-functions-resource-types.js";
+
+interface SimCfnStateMachinePropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::StepFunctions::StateMachine CloudFormation properties into the
+ * shapes the Step Functions commands take.
+ *
+ * What a definition may hold is decided by simulated Step Functions rather
+ * than here, so a state type it does not run is refused by the command that
+ * reads it. What this reads is the shape. A property that has to be a string
+ * or an object is checked for being one, since a template that put an object
+ * where a role ARN goes has made a mistake CreateStateMachine cannot explain.
+ */
+export class SimCfnStateMachineProperties {
+  readonly #resource: SimCfnResource;
+  readonly #properties: ReadonlyMap<string, SimCfnTemplateValue>;
+
+  constructor(properties: SimCfnStateMachinePropertiesProperties) {
+    this.#resource = properties.resource;
+    this.#properties = new Map(Object.entries(properties.properties));
+
+    this.recordUnsimulated();
+  }
+
+  /**
+   * The state machine name.
+   *
+   * An unnamed state machine is named after the stack and the logical ID, as
+   * real CloudFormation names one.
+   */
+  name(): string {
+    const name = this.#properties.get(stateMachineNamePropertyName);
+
+    if (name === undefined) {
+      return new SimCfnStateMachineName({
+        stackName: this.#resource.stackName,
+        logicalId: this.#resource.logicalId,
+      }).value;
+    }
+
+    return this.string(stateMachineNamePropertyName, name);
+  }
+
+  /**
+   * The Role an execution runs as.
+   *
+   * Required on the real Resource, and required by `CreateStateMachine`, so a
+   * template leaving it out is refused rather than given one.
+   */
+  roleArn(): string {
+    const roleArn = this.#properties.get(roleArnPropertyName);
+
+    if (roleArn === undefined) {
+      throw this.propertyError(
+        `a state machine needs a ${roleArnPropertyName}`,
+      );
+    }
+
+    return this.string(roleArnPropertyName, roleArn);
+  }
+
+  /**
+   * Whether the state machine is STANDARD or EXPRESS, when the template says.
+   *
+   * Which of the two it is, is decided by `CreateStateMachine`, so a template
+   * asking for a third thing is refused in the words that command refuses it
+   * in.
+   */
+  type(): string | undefined {
+    const type = this.#properties.get(stateMachineTypePropertyName);
+
+    if (type === undefined) {
+      return undefined;
+    }
+
+    return this.string(stateMachineTypePropertyName, type);
+  }
+
+  /**
+   * The Amazon States Language the state machine runs.
+   */
+  definition(): string {
+    return new SimCfnStateMachineDefinition({
+      logicalId: this.#resource.logicalId,
+      properties: this.#properties,
+    }).value();
+  }
+
+  /**
+   * A property that has to be a string.
+   */
+  private string(name: string, value: SimCfnTemplateValue): string {
+    if (typeof value !== "string") {
+      throw this.propertyError(`${name} must be a string`);
+    }
+
+    return value;
+  }
+
+  /**
+   * Record the properties this simulation gives no behaviour to.
+   */
+  private recordUnsimulated(): void {
+    for (const [name, reason] of unsimulatedPropertyReasons) {
+      if (this.#properties.has(name)) {
+        this.#resource.ignoreProperty(name, reason);
+      }
+    }
+  }
+
+  private propertyError(reason: string): Error {
+    return simCfnStepFunctionsResourceError(
+      stateMachineResourceType,
+      this.#resource.logicalId,
+      reason,
+    );
+  }
+}

--- a/src/service/cloudformation/resource/cfn/stepfunctions/sim-cfn-state-machine-property-names.ts
+++ b/src/service/cloudformation/resource/cfn/stepfunctions/sim-cfn-state-machine-property-names.ts
@@ -1,0 +1,44 @@
+/**
+ * The AWS::StepFunctions::StateMachine properties this simulation acts on.
+ */
+export const stateMachineNamePropertyName = "StateMachineName";
+
+export const roleArnPropertyName = "RoleArn";
+
+export const stateMachineTypePropertyName = "StateMachineType";
+
+export const definitionStringPropertyName = "DefinitionString";
+
+export const definitionPropertyName = "Definition";
+
+export const definitionSubstitutionsPropertyName = "DefinitionSubstitutions";
+
+export const definitionS3LocationPropertyName = "DefinitionS3Location";
+
+export const tagsPropertyName = "Tags";
+
+/**
+ * Real AWS::StepFunctions::StateMachine properties this simulation does not
+ * model, and why.
+ *
+ * Each is recorded against the Resource rather than refused, so a template
+ * carrying one still deploys a state machine that runs, and the omission is
+ * somewhere a test can find it.
+ */
+export const unsimulatedPropertyReasons: ReadonlyMap<string, string> = new Map([
+  [
+    tagsPropertyName,
+    "simulated Step Functions holds no tags on a state machine, and " +
+      "ListTagsForResource is unsimulated",
+  ],
+  [
+    "LoggingConfiguration",
+    "an execution writes no log events, so there is nothing for a log level " +
+      "or a destination to decide",
+  ],
+  ["TracingConfiguration", "X-Ray is not simulated"],
+  [
+    "EncryptionConfiguration",
+    "a definition is held as it was written, and no key is ever asked for",
+  ],
+]);

--- a/src/service/cloudformation/resource/cfn/stepfunctions/sim-cfn-state-machine-property-refusals.iso.test.ts
+++ b/src/service/cloudformation/resource/cfn/stepfunctions/sim-cfn-state-machine-property-refusals.iso.test.ts
@@ -1,0 +1,142 @@
+import {
+  assertStringIncludes,
+  assertThrowsError,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../aws/sim-aws.js";
+import { SimStateMachine } from "../../../../stepfunctions/machine/sim-state-machine.js";
+import type { SimCfnTemplateValueRecord } from "../../../template/value/sim-cfn-template-value.js";
+import { SimStateMachineCfn } from "./sim-state-machine-cfn.js";
+
+describe("What an AWS::StepFunctions::StateMachine Resource shape refuses", () => {
+  const roleArn = "arn:aws:iam::123456789012:role/EnrolmentWorkflowRole";
+
+  const done = { StartAt: "Done", States: { Done: { Type: "Succeed" } } };
+
+  /**
+   * Deploy a workflow declared with the given properties, giving back whatever
+   * the deployment was refused with.
+   */
+  async function refusalFrom(
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<Error> {
+    const simAws = new SimAws();
+
+    return await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "enrolment",
+        template: {
+          Resources: {
+            Workflow: {
+              Type: "AWS::StepFunctions::StateMachine",
+              Properties: { RoleArn: roleArn, ...properties },
+            },
+          },
+        },
+      });
+      await stack.waitForDeployComplete();
+    });
+  }
+
+  it("refuses a DefinitionString that is not a string", async () => {
+    // When a template writes the string form as a number.
+    const error = await refusalFrom({ DefinitionString: 42 });
+
+    // Then the deployment is refused, saying which property is wrong.
+    assertStringIncludes(error.message, "DefinitionString must be a string");
+  });
+
+  it("refuses a Definition that is not an object", async () => {
+    // When a template writes the object form as a string.
+    const error = await refusalFrom({ Definition: JSON.stringify(done) });
+
+    // Then the deployment is refused rather than the string being read as ASL,
+    // since the two properties are written differently on purpose.
+    assertStringIncludes(error.message, "Definition must be an object");
+  });
+
+  it("refuses a StateMachineName that is not a string", async () => {
+    // When a template writes a name as a list.
+    const error = await refusalFrom({
+      StateMachineName: ["Enrolment"],
+      Definition: done,
+    });
+
+    // Then the deployment is refused.
+    assertStringIncludes(error.message, "StateMachineName must be a string");
+  });
+
+  it("refuses a RoleArn that is not a string", async () => {
+    // When a template writes the Role as an object.
+    const error = await refusalFrom({
+      RoleArn: { Ref: "WorkflowRole" },
+      Definition: done,
+    });
+
+    // Then the deployment is refused. An unresolved Ref arrives here as the
+    // object it was written as, which is the shape this catches.
+    assertStringIncludes(error.message, "RoleArn must be a string");
+  });
+
+  it("refuses a StateMachineType that is not a string", async () => {
+    // When a template writes the type as a number.
+    const error = await refusalFrom({ StateMachineType: 1, Definition: done });
+
+    // Then the deployment is refused.
+    assertStringIncludes(error.message, "StateMachineType must be a string");
+  });
+
+  it("refuses DefinitionSubstitutions that are not an object", async () => {
+    // When a template writes the substitutions as a list of pairs.
+    const error = await refusalFrom({
+      DefinitionString: JSON.stringify(done),
+      DefinitionSubstitutions: [{ Key: "Queue", Value: "orders" }],
+    });
+
+    // Then the deployment is refused.
+    assertStringIncludes(
+      error.message,
+      "DefinitionSubstitutions must be an object",
+    );
+  });
+
+  it("refuses a substitution value a definition could not hold as text", async () => {
+    // When a substitution stands for a whole object.
+    const error = await refusalFrom({
+      DefinitionString: JSON.stringify(done),
+      DefinitionSubstitutions: { Queue: { Arn: "arn:aws:sqs:::orders" } },
+    });
+
+    // Then the deployment is refused rather than the definition being given
+    // something stringified into it.
+    assertStringIncludes(
+      error.message,
+      "DefinitionSubstitutions.Queue must be a string, a number or a boolean",
+    );
+  });
+
+  it("refuses an attribute the Resource does not publish", () => {
+    // Given a deployed state machine's CloudFormation-facing values.
+    const values = new SimStateMachineCfn(
+      new SimStateMachine({
+        arn: "arn:aws:states:eu-west-2:111111111111:stateMachine:Enrolment",
+        name: "Enrolment",
+        roleArn,
+        definition: JSON.stringify(done),
+        parsed: { StartAt: "Done", States: new Map() },
+        type: "STANDARD",
+        creationDate: new Date(0),
+      }),
+    );
+
+    // When a template reads an attribute the Resource has no value for.
+    const error = assertThrowsError(() =>
+      values.attributeValue("StateMachineRevisionId"),
+    );
+
+    // Then it is refused by name rather than answered with a stand-in.
+    assertStringIncludes(error.message, "StateMachineRevisionId");
+  });
+});

--- a/src/service/cloudformation/resource/cfn/stepfunctions/sim-cfn-state-machine-refusals.iso.test.ts
+++ b/src/service/cloudformation/resource/cfn/stepfunctions/sim-cfn-state-machine-refusals.iso.test.ts
@@ -1,0 +1,259 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../../template/sim-cfn-template.js";
+import type { SimCfnTemplateValueRecord } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnDeployedStack } from "../../../stack/sim-cfn-deployed-stack.type.js";
+
+describe("What a deployed AWS::StepFunctions::StateMachine refuses", () => {
+  const roleArn = "arn:aws:iam::123456789012:role/EnrolmentWorkflowRole";
+
+  /**
+   * A stack holding a queue beside the workflow, so a dropped state machine
+   * can be told apart from a stack that did not deploy.
+   */
+  function template(
+    resources: SimCfnTemplateValueRecord,
+  ): CfnTemplateBodyRecord {
+    return {
+      Resources: {
+        OrdersQueue: { Type: "AWS::SQS::Queue", Properties: {} },
+        ...resources,
+      },
+    };
+  }
+
+  function workflowTemplate(
+    properties: SimCfnTemplateValueRecord,
+  ): CfnTemplateBodyRecord {
+    return template({
+      Workflow: {
+        Type: "AWS::StepFunctions::StateMachine",
+        Properties: properties,
+      },
+    });
+  }
+
+  /**
+   * Deploy a template, giving back whatever the deployment was refused with.
+   */
+  async function refusalFrom(body: CfnTemplateBodyRecord): Promise<Error> {
+    const simAws = new SimAws();
+
+    return await assertThrowsErrorAsync(async () => {
+      const stack = await simAws
+        .cloudFormation()
+        .deployTemplate({ stackName: "enrolment", template: body });
+      await stack.waitForDeployComplete();
+    });
+  }
+
+  /**
+   * Deploy a template that is expected to complete, whatever it had to drop.
+   */
+  async function deploy(
+    body: CfnTemplateBodyRecord,
+  ): Promise<{ readonly simAws: SimAws; readonly stack: SimCfnDeployedStack }> {
+    const simAws = new SimAws();
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplate({ stackName: "enrolment", template: body });
+    await stack.waitForDeployComplete();
+
+    return { simAws, stack };
+  }
+
+  it("drops a state machine using a state the interpreter does not run", async () => {
+    // Given a workflow holding a Wait state, which this simulator has no
+    // implementation for yet.
+    const body = workflowTemplate({
+      StateMachineName: "Enrolment",
+      RoleArn: roleArn,
+      DefinitionString: JSON.stringify({
+        StartAt: "Pause",
+        States: {
+          Pause: { Type: "Wait", Seconds: 5, Next: "Done" },
+          Done: { Type: "Succeed" },
+        },
+      }),
+    });
+
+    // When the stack is deployed.
+    const { simAws, stack } = await deploy(body);
+
+    // Then that one state machine is dropped, with the reason on the Stack,
+    // and everything else in the stack still deployed.
+    assertUndefined(simAws.stepFunctions().findStateMachine("Enrolment"));
+    assertArrayLength(stack.skippedResources, 1);
+
+    const skipped = stack.skippedResources[0];
+    assertNonNullable(skipped);
+    assertTrue(skipped.skipped);
+    assertIdentical(skipped.logicalId, "Workflow");
+    assertStringIncludes(skipped.skippedReason ?? "", "is a Wait state");
+    assertIdentical(
+      stack.getResource("OrdersQueue")?.status,
+      "CREATE_COMPLETE",
+    );
+  });
+
+  it("drops a state machine whose definition is an object in a bucket", async () => {
+    // Given a definition CDK published as an asset, which this simulation does
+    // not fetch.
+    const body = workflowTemplate({
+      StateMachineName: "Enrolment",
+      RoleArn: roleArn,
+      DefinitionS3Location: { Bucket: "assets", Key: "workflow.asl.json" },
+    });
+
+    // When the stack is deployed.
+    const { simAws, stack } = await deploy(body);
+
+    // Then the state machine is dropped and recorded, rather than deployed
+    // without the definition it was meant to run.
+    assertUndefined(simAws.stepFunctions().findStateMachine("Enrolment"));
+    assertStringIncludes(
+      stack.skippedResources[0]?.skippedReason ?? "",
+      "DefinitionS3Location",
+    );
+  });
+
+  it("drops a version or an alias of a state machine", async () => {
+    // Given a template publishing a version of its workflow and pointing an
+    // alias at it, neither of which this simulation models.
+    const body = template({
+      Version: {
+        Type: "AWS::StepFunctions::StateMachineVersion",
+        Properties: { StateMachineArn: "arn:aws:states:::stateMachine:Any" },
+      },
+      Live: {
+        Type: "AWS::StepFunctions::StateMachineAlias",
+        Properties: { Name: "live" },
+      },
+    });
+
+    // When the stack is deployed.
+    const { stack } = await deploy(body);
+
+    // Then both are recorded as unsupported and stepped over.
+    const reasons = stack.skippedResources.map(
+      (resource) => resource.skippedReason,
+    );
+    assertIdentical(
+      reasons.join("\n"),
+      "Unsupported sim StepFunctions CloudFormation Resource StateMachineVersion\n" +
+        "Unsupported sim StepFunctions CloudFormation Resource StateMachineAlias",
+    );
+  });
+
+  it("refuses a definition Amazon States Language itself refuses", async () => {
+    // When a template starts its workflow at a state it does not declare.
+    const error = await refusalFrom(
+      workflowTemplate({
+        StateMachineName: "Enrolment",
+        RoleArn: roleArn,
+        DefinitionString: JSON.stringify({
+          StartAt: "Missing",
+          States: { Done: { Type: "Succeed" } },
+        }),
+      }),
+    );
+
+    // Then the deployment is refused in the words CreateStateMachine refuses
+    // it in, with the Resource named so the template can be found.
+    assertStringIncludes(error.message, "Workflow");
+    assertStringIncludes(error.message, "StartAt names Missing");
+  });
+
+  it("refuses a state machine name Step Functions would not accept", async () => {
+    // When a template names its workflow with a character Step Functions
+    // refuses.
+    const error = await refusalFrom(
+      workflowTemplate({
+        StateMachineName: "Enrolment/Live",
+        RoleArn: roleArn,
+        DefinitionString: JSON.stringify({
+          StartAt: "Done",
+          States: { Done: { Type: "Succeed" } },
+        }),
+      }),
+    );
+
+    // Then the deployment is refused rather than deploying a state machine
+    // nothing could reach by the name the template used.
+    assertStringIncludes(error.message, "does not allow in a name");
+  });
+
+  it("refuses a state machine carrying no definition", async () => {
+    // When a template declares a workflow with nothing to run.
+    const error = await refusalFrom(
+      workflowTemplate({ StateMachineName: "Enrolment", RoleArn: roleArn }),
+    );
+
+    // Then the deployment is refused, as real CloudFormation refuses it.
+    assertStringIncludes(
+      error.message,
+      "a state machine needs a DefinitionString or a Definition",
+    );
+  });
+
+  it("refuses a state machine carrying both forms of definition", async () => {
+    // When a template writes the definition twice, once each way.
+    const done = { StartAt: "Done", States: { Done: { Type: "Succeed" } } };
+    const error = await refusalFrom(
+      workflowTemplate({
+        StateMachineName: "Enrolment",
+        RoleArn: roleArn,
+        DefinitionString: JSON.stringify(done),
+        Definition: done,
+      }),
+    );
+
+    // Then the deployment is refused rather than one of them being picked.
+    assertStringIncludes(error.message, "two ways of writing the same thing");
+  });
+
+  it("refuses a state machine with no Role to run as", async () => {
+    // When a template leaves out the RoleArn the Resource requires.
+    const error = await refusalFrom(
+      workflowTemplate({
+        StateMachineName: "Enrolment",
+        DefinitionString: JSON.stringify({
+          StartAt: "Done",
+          States: { Done: { Type: "Succeed" } },
+        }),
+      }),
+    );
+
+    // Then the deployment is refused rather than a Role being invented.
+    assertStringIncludes(error.message, "a state machine needs a RoleArn");
+  });
+
+  it("refuses a state machine type Step Functions does not have", async () => {
+    // When a template asks for a third kind of state machine.
+    const error = await refusalFrom(
+      workflowTemplate({
+        StateMachineName: "Enrolment",
+        RoleArn: roleArn,
+        StateMachineType: "SYNCHRONOUS",
+        DefinitionString: JSON.stringify({
+          StartAt: "Done",
+          States: { Done: { Type: "Succeed" } },
+        }),
+      }),
+    );
+
+    // Then the deployment is refused in the words CreateStateMachine refuses
+    // it in.
+    assertStringIncludes(error.message, "It is STANDARD or EXPRESS");
+  });
+});

--- a/src/service/cloudformation/resource/cfn/stepfunctions/sim-cfn-state-machine-refusals.iso.test.ts
+++ b/src/service/cloudformation/resource/cfn/stepfunctions/sim-cfn-state-machine-refusals.iso.test.ts
@@ -10,6 +10,10 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../../../aws/sim-aws.js";
+import {
+  simStatesRunnableTypes,
+  simStatesStateTypes,
+} from "../../../../stepfunctions/definition/sim-states-state.js";
 import type { CfnTemplateBodyRecord } from "../../../template/sim-cfn-template.js";
 import type { SimCfnTemplateValueRecord } from "../../../template/value/sim-cfn-template-value.js";
 import type { SimCfnDeployedStack } from "../../../stack/sim-cfn-deployed-stack.type.js";
@@ -72,16 +76,34 @@ describe("What a deployed AWS::StepFunctions::StateMachine refuses", () => {
     return { simAws, stack };
   }
 
+  /**
+   * A state type Amazon States Language defines and this simulator has no
+   * implementation for.
+   *
+   * Read from Step Functions' own two lists rather than named here. The
+   * interpreter keeps taking state types on, and a test naming one starts
+   * failing the day that one lands.
+   */
+  function unrunStateType(): string {
+    const type = simStatesStateTypes.find(
+      (candidate) => !simStatesRunnableTypes.includes(candidate as never),
+    );
+    assertNonNullable(type);
+
+    return type;
+  }
+
   it("drops a state machine using a state the interpreter does not run", async () => {
-    // Given a workflow holding a Wait state, which this simulator has no
+    // Given a workflow holding a state type this simulator has no
     // implementation for yet.
+    const stateType = unrunStateType();
     const body = workflowTemplate({
       StateMachineName: "Enrolment",
       RoleArn: roleArn,
       DefinitionString: JSON.stringify({
-        StartAt: "Pause",
+        StartAt: "Step",
         States: {
-          Pause: { Type: "Wait", Seconds: 5, Next: "Done" },
+          Step: { Type: stateType, Next: "Done" },
           Done: { Type: "Succeed" },
         },
       }),
@@ -99,7 +121,10 @@ describe("What a deployed AWS::StepFunctions::StateMachine refuses", () => {
     assertNonNullable(skipped);
     assertTrue(skipped.skipped);
     assertIdentical(skipped.logicalId, "Workflow");
-    assertStringIncludes(skipped.skippedReason ?? "", "is a Wait state");
+    assertStringIncludes(
+      skipped.skippedReason ?? "",
+      `is a ${stateType} state`,
+    );
     assertIdentical(
       stack.getResource("OrdersQueue")?.status,
       "CREATE_COMPLETE",

--- a/src/service/cloudformation/resource/cfn/stepfunctions/sim-cfn-state-machine-substitutions.ts
+++ b/src/service/cloudformation/resource/cfn/stepfunctions/sim-cfn-state-machine-substitutions.ts
@@ -1,0 +1,80 @@
+import { isRecord } from "../../../../../util/type-guard/record.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import { simCfnStepFunctionsResourceError } from "./sim-cfn-step-functions-resource-error.js";
+import { definitionSubstitutionsPropertyName } from "./sim-cfn-state-machine-property-names.js";
+import { stateMachineResourceType } from "./sim-cfn-step-functions-resource-types.js";
+
+interface SimCfnStateMachineSubstitutionsProperties {
+  readonly logicalId: string;
+  readonly declared: SimCfnTemplateValue | undefined;
+}
+
+/**
+ * Applies `DefinitionSubstitutions` to a state machine definition.
+ *
+ * Each entry replaces every `${Key}` in the definition with its value, which is
+ * how real Step Functions reads them. The values arrive already resolved, so a
+ * substitution holding a `Ref` is the ARN by the time it lands here.
+ */
+export class SimCfnStateMachineSubstitutions {
+  readonly #logicalId: string;
+  readonly #declared: SimCfnTemplateValue | undefined;
+
+  constructor(properties: SimCfnStateMachineSubstitutionsProperties) {
+    this.#logicalId = properties.logicalId;
+    this.#declared = properties.declared;
+  }
+
+  /**
+   * The definition with every placeholder replaced.
+   */
+  applyTo(definition: string): string {
+    let substituted = definition;
+
+    for (const [key, value] of this.entries()) {
+      substituted = substituted.split(`\${${key}}`).join(this.text(key, value));
+    }
+
+    return substituted;
+  }
+
+  /**
+   * The substitutions the template declared, as key and value pairs.
+   */
+  private entries(): readonly (readonly [string, SimCfnTemplateValue])[] {
+    if (this.#declared === undefined) {
+      return [];
+    }
+
+    if (!isRecord(this.#declared)) {
+      throw this.error(
+        `${definitionSubstitutionsPropertyName} must be an object`,
+      );
+    }
+
+    return Object.entries(this.#declared);
+  }
+
+  /**
+   * One substitution value, which has to be something a definition can hold as
+   * text.
+   */
+  private text(key: string, value: SimCfnTemplateValue): string {
+    if (value === null || typeof value === "object") {
+      throw this.error(
+        `${definitionSubstitutionsPropertyName}.${key} must be a string, a ` +
+          "number or a boolean",
+      );
+    }
+
+    return String(value);
+  }
+
+  private error(reason: string): Error {
+    return simCfnStepFunctionsResourceError(
+      stateMachineResourceType,
+      this.#logicalId,
+      reason,
+    );
+  }
+}

--- a/src/service/cloudformation/resource/cfn/stepfunctions/sim-cfn-state-machine.iso.test.ts
+++ b/src/service/cloudformation/resource/cfn/stepfunctions/sim-cfn-state-machine.iso.test.ts
@@ -167,8 +167,8 @@ describe("deployed AWS::StepFunctions::StateMachine Resources", () => {
   });
 
   it("records the properties it deployed the state machine without", async () => {
-    // Given a template asking for logging, tracing and tags, none of which
-    // this simulation gives a state machine any behaviour for.
+    // Given a template asking for tags, logging, tracing and encryption, none
+    // of which this simulation gives a state machine any behaviour for.
     const simAws = new SimAws();
 
     // When it is deployed.
@@ -178,8 +178,10 @@ describe("deployed AWS::StepFunctions::StateMachine Resources", () => {
         StateMachineName: "Enrolment",
         RoleArn: roleArn,
         DefinitionString: JSON.stringify(passChain),
-        TracingConfiguration: { Enabled: true },
         Tags: [{ Key: "team", Value: "enrolment" }],
+        LoggingConfiguration: { Level: "ALL" },
+        TracingConfiguration: { Enabled: true },
+        EncryptionConfiguration: { Type: "AWS_OWNED_KEY" },
       }),
     });
     await stack.waitForDeployComplete();
@@ -194,7 +196,10 @@ describe("deployed AWS::StepFunctions::StateMachine Resources", () => {
     const ignoredPaths = stack.ignoredProperties.map(
       (property) => property.path,
     );
-    assertIdentical(ignoredPaths.join(", "), "Tags, TracingConfiguration");
+    assertIdentical(
+      ignoredPaths.join(", "),
+      "Tags, LoggingConfiguration, TracingConfiguration, EncryptionConfiguration",
+    );
   });
 
   it("deletes the state machine when the stack is deleted", async () => {

--- a/src/service/cloudformation/resource/cfn/stepfunctions/sim-cfn-state-machine.iso.test.ts
+++ b/src/service/cloudformation/resource/cfn/stepfunctions/sim-cfn-state-machine.iso.test.ts
@@ -1,0 +1,230 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+  assertTypeString,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../aws/sim-aws.js";
+import { SimStatesResourceNotFound } from "../../../../stepfunctions/error/sim-step-functions.error.js";
+import type { CfnTemplateBodyRecord } from "../../../template/sim-cfn-template.js";
+import type { SimCfnTemplateValueRecord } from "../../../template/value/sim-cfn-template-value.js";
+
+describe("deployed AWS::StepFunctions::StateMachine Resources", () => {
+  const roleArn = "arn:aws:iam::123456789012:role/EnrolmentWorkflowRole";
+
+  /**
+   * A workflow of the state types the interpreter runs today.
+   */
+  const passChain = {
+    StartAt: "Record",
+    States: {
+      Record: {
+        Type: "Pass",
+        Result: { enrolled: true },
+        ResultPath: "$.outcome",
+        Next: "Done",
+      },
+      Done: { Type: "Succeed" },
+    },
+  };
+
+  /**
+   * A stack holding one state machine, and outputs reading it every way the
+   * Resource publishes.
+   */
+  function workflowTemplate(
+    properties: SimCfnTemplateValueRecord,
+  ): CfnTemplateBodyRecord {
+    return {
+      Resources: {
+        Workflow: {
+          Type: "AWS::StepFunctions::StateMachine",
+          Properties: properties,
+        },
+      },
+      Outputs: {
+        WorkflowRef: { Value: { Ref: "Workflow" } },
+        WorkflowArn: { Value: { "Fn::GetAtt": ["Workflow", "Arn"] } },
+        WorkflowName: { Value: { "Fn::GetAtt": ["Workflow", "Name"] } },
+      },
+    };
+  }
+
+  it("runs an execution against a state machine a template deployed", async () => {
+    // Given a template declaring a workflow of the states the interpreter
+    // runs.
+    const simAws = new SimAws();
+
+    // When it is deployed and an execution is started against it.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "enrolment",
+      template: workflowTemplate({
+        StateMachineName: "Enrolment",
+        RoleArn: roleArn,
+        DefinitionString: JSON.stringify(passChain),
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    const stateMachineArn = stack.outputs.get("WorkflowArn")?.value;
+    assertTypeString(stateMachineArn);
+
+    const started = await simAws.stepFunctions().startExecution({
+      input: { stateMachineArn, input: JSON.stringify({ student: "Wei" }) },
+    });
+
+    // Then the execution walked the definition the template carried, to the
+    // end.
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn: started.executionArn } });
+
+    assertIdentical(described.status, "SUCCEEDED");
+    assertIdentical(
+      described.output,
+      JSON.stringify({ student: "Wei", outcome: { enrolled: true } }),
+    );
+  });
+
+  it("answers a Ref with the ARN and the attributes with the ARN and name", async () => {
+    // Given a template reading its state machine every way the Resource
+    // publishes.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "enrolment",
+      template: workflowTemplate({
+        StateMachineName: "Enrolment",
+        RoleArn: roleArn,
+        DefinitionString: JSON.stringify(passChain),
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the Ref is the ARN, which is the way round real CloudFormation
+    // publishes this one, and the attributes are the ARN and the name.
+    const expectedArn = `arn:aws:states:${simAws.defaultRegionName}:${simAws.defaultAccountId}:stateMachine:Enrolment`;
+
+    assertIdentical(stack.outputs.get("WorkflowRef")?.value, expectedArn);
+    assertIdentical(stack.outputs.get("WorkflowArn")?.value, expectedArn);
+    assertIdentical(stack.outputs.get("WorkflowName")?.value, "Enrolment");
+  });
+
+  it("names an unnamed state machine after the stack and the logical ID", async () => {
+    // Given a template that names no state machine, which is what CDK emits
+    // for a StateMachine with no stateMachineName.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "enrolment",
+      template: workflowTemplate({
+        RoleArn: roleArn,
+        DefinitionString: JSON.stringify(passChain),
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then CloudFormation named it, as real CloudFormation does.
+    assertIdentical(
+      stack.outputs.get("WorkflowName")?.value,
+      "enrolment-Workflow",
+    );
+  });
+
+  it("carries the role and the type across to the state machine", async () => {
+    // Given a template declaring an express workflow running as a named Role.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "enrolment",
+      template: workflowTemplate({
+        StateMachineName: "Enrolment",
+        RoleArn: roleArn,
+        StateMachineType: "EXPRESS",
+        DefinitionString: JSON.stringify(passChain),
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then DescribeStateMachine answers with both, along with the definition
+    // as the template wrote it.
+    const stateMachineArn = stack.outputs.get("WorkflowArn")?.value;
+    assertTypeString(stateMachineArn);
+
+    const described = await simAws
+      .stepFunctions()
+      .describeStateMachine({ input: { stateMachineArn } });
+
+    assertIdentical(described.roleArn, roleArn);
+    assertIdentical(described.type, "EXPRESS");
+    assertIdentical(described.definition, JSON.stringify(passChain));
+  });
+
+  it("records the properties it deployed the state machine without", async () => {
+    // Given a template asking for logging, tracing and tags, none of which
+    // this simulation gives a state machine any behaviour for.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "enrolment",
+      template: workflowTemplate({
+        StateMachineName: "Enrolment",
+        RoleArn: roleArn,
+        DefinitionString: JSON.stringify(passChain),
+        TracingConfiguration: { Enabled: true },
+        Tags: [{ Key: "team", Value: "enrolment" }],
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the state machine is there, and what it was created without is
+    // recorded where a test can find it rather than failing the stack.
+    assertIdentical(
+      simAws.stepFunctions().findStateMachine("Enrolment")?.name,
+      "Enrolment",
+    );
+
+    const ignoredPaths = stack.ignoredProperties.map(
+      (property) => property.path,
+    );
+    assertIdentical(ignoredPaths.join(", "), "Tags, TracingConfiguration");
+  });
+
+  it("deletes the state machine when the stack is deleted", async () => {
+    // Given a deployed state machine.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "enrolment",
+      template: workflowTemplate({
+        StateMachineName: "Enrolment",
+        RoleArn: roleArn,
+        DefinitionString: JSON.stringify(passChain),
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    const stateMachineArn = stack.outputs.get("WorkflowArn")?.value;
+    assertTypeString(stateMachineArn);
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then the state machine has gone with it, and the Resource says so.
+    assertIdentical(stack.getResource("Workflow")?.status, "DELETE_COMPLETE");
+    assertUndefined(simAws.stepFunctions().findStateMachine("Enrolment"));
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .stepFunctions()
+        .describeStateMachine({ input: { stateMachineArn } });
+    });
+    assertInstanceOf(error, SimStatesResourceNotFound);
+  });
+});

--- a/src/service/cloudformation/resource/cfn/stepfunctions/sim-cfn-step-functions-resource-deleter.ts
+++ b/src/service/cloudformation/resource/cfn/stepfunctions/sim-cfn-step-functions-resource-deleter.ts
@@ -1,0 +1,47 @@
+import { assertDefined } from "../../../../../util/type-guard/defined.js";
+import type { SimStateMachine } from "../../../../stepfunctions/machine/sim-state-machine.js";
+import type { SimStepFunctions } from "../../../../stepfunctions/sim-step-functions.js";
+import type { SimCfnResource } from "../../sim-cfn-resource.js";
+import { stateMachineResourceTypeName } from "./sim-cfn-step-functions-resource-types.js";
+
+interface SimCfnStepFunctionsResourceDeleterProperties {
+  readonly stepFunctions: SimStepFunctions;
+}
+
+/**
+ * Deletes the simulated Step Functions resources a CloudFormation Stack
+ * created.
+ */
+export class SimCfnStepFunctionsResourceDeleter {
+  readonly #stepFunctions: SimStepFunctions;
+
+  constructor(properties: SimCfnStepFunctionsResourceDeleterProperties) {
+    this.#stepFunctions = properties.stepFunctions;
+  }
+
+  /**
+   * Delete a simulated Step Functions resource created from a CloudFormation
+   * Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+  ): Promise<void> {
+    if (resourceTypeName !== stateMachineResourceTypeName) {
+      throw new Error(
+        `Unsupported sim StepFunctions CloudFormation Resource ` +
+          `${resourceTypeName} deletion`,
+      );
+    }
+
+    const stateMachine = resource.simResource as SimStateMachine | undefined;
+    assertDefined(
+      stateMachine,
+      `sim state machine for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    await this.#stepFunctions.deleteStateMachine({
+      input: { stateMachineArn: stateMachine.arn },
+    });
+  }
+}

--- a/src/service/cloudformation/resource/cfn/stepfunctions/sim-cfn-step-functions-resource-error.ts
+++ b/src/service/cloudformation/resource/cfn/stepfunctions/sim-cfn-step-functions-resource-error.ts
@@ -1,0 +1,97 @@
+import {
+  SimStatesUnsimulatedInput,
+  SimStepFunctionsError,
+} from "../../../../stepfunctions/error/sim-step-functions.error.js";
+
+/**
+ * Build the error a Resource of a simulated Step Functions type is refused
+ * with.
+ *
+ * Sim CloudFormation fails a Stack on this one, so it is kept for a Resource
+ * nothing coherent could be deployed from. A template carrying no definition
+ * at all, a definition Amazon States Language itself refuses, a name Step
+ * Functions will not take. Real CloudFormation fails those too. A definition
+ * this simulator cannot run is a different thing and takes the skip below.
+ */
+export function simCfnStepFunctionsResourceError(
+  resourceType: string,
+  logicalId: string,
+  reason: string,
+  cause?: unknown,
+): Error {
+  return new Error(`Invalid ${resourceType} Resource ${logicalId}: ${reason}`, {
+    cause,
+  });
+}
+
+/**
+ * Build the error a Resource carrying something the interpreter cannot run is
+ * skipped with.
+ *
+ * The "Unsupported sim ... CloudFormation" wording is what sim CloudFormation
+ * reads as a Resource to record and step over, so the Resource lands on
+ * `stack.skippedResources` carrying the reason Step Functions gave, and the
+ * rest of the template deploys.
+ *
+ * A state machine missing one state runs wrong, and a test watching it run
+ * wrong is worse off than one watching it be absent. So the whole state
+ * machine goes rather than the state, and the Stack around it is no business
+ * of one workflow.
+ */
+export function simCfnStepFunctionsSkippedResourceError(
+  resourceType: string,
+  logicalId: string,
+  reason: string,
+  cause?: unknown,
+): Error {
+  return new Error(
+    `Unsupported sim StepFunctions CloudFormation ${resourceType} Resource ` +
+      `${logicalId}: ${reason}`,
+    { cause },
+  );
+}
+
+/**
+ * Run the simulated Step Functions commands one Resource is made of, naming
+ * the Resource in whatever they refuse.
+ *
+ * Every Resource type here goes through the ordinary Step Functions commands,
+ * so what a template may ask for is decided once, by simulated Step Functions,
+ * rather than again in the CloudFormation layer. What that leaves out is where
+ * the request came from. A deployment failing with `The state Check is a Task
+ * state` says which state but not which Resource declared it, and a template
+ * can hold several.
+ *
+ * The two kinds of refusal part company here. A definition Amazon States
+ * Language refuses is a failed Resource, and one it accepts that this
+ * simulator cannot run is a skipped one.
+ */
+export async function simCfnStepFunctionsResourceCommand<T>(
+  resourceType: string,
+  logicalId: string,
+  run: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await run();
+  } catch (error) {
+    if (error instanceof SimStatesUnsimulatedInput) {
+      throw simCfnStepFunctionsSkippedResourceError(
+        resourceType,
+        logicalId,
+        error.message,
+        error,
+      );
+    }
+
+    if (error instanceof SimStepFunctionsError) {
+      throw simCfnStepFunctionsResourceError(
+        resourceType,
+        logicalId,
+        error.message,
+        error,
+      );
+    }
+
+    throw error;
+  }
+}

--- a/src/service/cloudformation/resource/cfn/stepfunctions/sim-cfn-step-functions-resource-types.ts
+++ b/src/service/cloudformation/resource/cfn/stepfunctions/sim-cfn-step-functions-resource-types.ts
@@ -1,0 +1,10 @@
+/**
+ * The CloudFormation Resource types simulated Step Functions creates.
+ *
+ * Named here rather than spelled out where they are used, because each one is
+ * written twice, once by the factory dispatching on it and once by the
+ * refusals that quote it back to whoever wrote the template.
+ */
+export const stateMachineResourceType = "AWS::StepFunctions::StateMachine";
+
+export const stateMachineResourceTypeName = "StateMachine";

--- a/src/service/cloudformation/resource/cfn/stepfunctions/sim-state-machine-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/stepfunctions/sim-state-machine-cfn.ts
@@ -1,0 +1,48 @@
+import { assertDefined } from "../../../../../util/type-guard/defined.js";
+import type { SimStateMachine } from "../../../../stepfunctions/machine/sim-state-machine.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+/**
+ * CloudFormation-facing values for a simulated state machine.
+ */
+export class SimStateMachineCfn implements SimCfnResourceValueAdapter {
+  readonly #stateMachine: SimStateMachine;
+
+  constructor(stateMachine: SimStateMachine) {
+    this.#stateMachine = stateMachine;
+  }
+
+  /**
+   * A Ref to an AWS::StepFunctions::StateMachine returns the ARN.
+   *
+   * The other way round from most Resources, and the way round real
+   * CloudFormation publishes this one. It is also what CDK reads for
+   * `stateMachineArn`, so a grant or an environment variable pointing at a
+   * workflow resolves.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.#stateMachine.arn;
+  }
+
+  /**
+   * The two attributes the Resource publishes, which are the ARN and the name.
+   *
+   * `StateMachineRevisionId` is left out. A revision is what a published
+   * version is cut from, and neither is simulated.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    const values = new Map([
+      ["Arn", this.#stateMachine.arn],
+      ["Name", this.#stateMachine.name],
+    ]);
+    const value = values.get(attributeName);
+
+    assertDefined(
+      value,
+      `Unsupported AWS::StepFunctions::StateMachine attribute ${attributeName}`,
+    );
+
+    return value;
+  }
+}

--- a/src/service/cloudformation/resource/cfn/stepfunctions/sim-step-functions-cfn-resource-factory.iso.test.ts
+++ b/src/service/cloudformation/resource/cfn/stepfunctions/sim-step-functions-cfn-resource-factory.iso.test.ts
@@ -1,0 +1,96 @@
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../aws/sim-aws.js";
+import { SimCfnResource } from "../../sim-cfn-resource.js";
+import { simCfnStepFunctionsResourceCommand } from "./sim-cfn-step-functions-resource-error.js";
+import { SimStepFunctionsCfnResourceFactory } from "./sim-step-functions-cfn-resource-factory.js";
+
+describe("What the simulated Step Functions CloudFormation factory refuses", () => {
+  /**
+   * The factory, and a Resource for it to be asked about.
+   */
+  function factoryAndResource(type: string): {
+    readonly simAws: SimAws;
+    readonly factory: SimStepFunctionsCfnResourceFactory;
+    readonly resource: SimCfnResource;
+  } {
+    const simAws = new SimAws();
+
+    return {
+      simAws,
+      factory: new SimStepFunctionsCfnResourceFactory({
+        stepFunctions: simAws.stepFunctions(),
+      }),
+      resource: new SimCfnResource({
+        logicalId: "Live",
+        stackName: "enrolment",
+        template: { Type: `AWS::StepFunctions::${type}` },
+      }),
+    };
+  }
+
+  it("refuses creating a Step Functions Resource type it does not simulate", async () => {
+    // Given the factory, and an alias pointing at a published version.
+    const { simAws, factory, resource } =
+      factoryAndResource("StateMachineAlias");
+
+    // When the factory is asked for it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await factory.create("StateMachineAlias", resource, {
+        simAws,
+        resources: new Map(),
+      });
+    });
+
+    // Then it says so, which sim CloudFormation records and steps over.
+    assertStringIncludes(
+      error.message,
+      "Unsupported sim StepFunctions CloudFormation Resource StateMachineAlias",
+    );
+  });
+
+  it("refuses deleting a Step Functions Resource type it never creates", async () => {
+    // Given the factory, and a published version.
+    const { simAws, factory, resource } = factoryAndResource(
+      "StateMachineVersion",
+    );
+
+    // When the factory is asked to delete it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await factory.delete("StateMachineVersion", resource, {
+        simAws,
+        resources: new Map(),
+      });
+    });
+
+    // Then it says so.
+    assertStringIncludes(
+      error.message,
+      "Unsupported sim StepFunctions CloudFormation Resource " +
+        "StateMachineVersion deletion",
+    );
+  });
+
+  it("passes through an error that did not come from simulated Step Functions", async () => {
+    // Given a creation that fails for a reason of its own.
+    const thrown = new TypeError("the template reader broke");
+
+    // When it runs inside the wrapper that renames Step Functions refusals.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simCfnStepFunctionsResourceCommand(
+        "AWS::StepFunctions::StateMachine",
+        "Workflow",
+        () => Promise.reject(thrown),
+      );
+    });
+
+    // Then it comes back as it was, since only Step Functions' own refusals
+    // are reworded to name the Resource.
+    assertIdentical(error, thrown);
+  });
+});

--- a/src/service/cloudformation/resource/cfn/stepfunctions/sim-step-functions-cfn-resource-factory.ts
+++ b/src/service/cloudformation/resource/cfn/stepfunctions/sim-step-functions-cfn-resource-factory.ts
@@ -1,0 +1,70 @@
+import type { SimStepFunctions } from "../../../../stepfunctions/sim-step-functions.js";
+import type { SimCfnServiceResourceFactory } from "../../factory/sim-cfn-resource-factory.type.js";
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+  SimCloudFormationResourceDeleteContext,
+} from "../../sim-cfn-resource.js";
+import { SimCfnStateMachineCreator } from "./sim-cfn-state-machine-creator.js";
+import { SimCfnStepFunctionsResourceDeleter } from "./sim-cfn-step-functions-resource-deleter.js";
+import { stateMachineResourceTypeName } from "./sim-cfn-step-functions-resource-types.js";
+
+interface SimStepFunctionsCfnResourceFactoryProperties {
+  readonly stepFunctions: SimStepFunctions;
+}
+
+/**
+ * CloudFormation Resource factory for simulated Step Functions resources.
+ */
+export class SimStepFunctionsCfnResourceFactory implements SimCfnServiceResourceFactory {
+  readonly #stateMachineCreator: SimCfnStateMachineCreator;
+  readonly #deleter: SimCfnStepFunctionsResourceDeleter;
+
+  constructor(properties: SimStepFunctionsCfnResourceFactoryProperties) {
+    this.#stateMachineCreator = new SimCfnStateMachineCreator({
+      stepFunctions: properties.stepFunctions,
+    });
+    this.#deleter = new SimCfnStepFunctionsResourceDeleter({
+      stepFunctions: properties.stepFunctions,
+    });
+  }
+
+  /**
+   * Create a simulated Step Functions resource from a CloudFormation Resource.
+   *
+   * The state machine is the one AWS::StepFunctions::* Resource type this
+   * simulation models. `StateMachineVersion` publishes an immutable copy of a
+   * definition and `StateMachineAlias` routes executions between versions, and
+   * neither has anything to act on while every execution runs the definition
+   * the state machine currently holds. Both are reported as unsupported and
+   * skipped rather than quietly treated as deployed.
+   */
+  async create(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<object | undefined> {
+    if (resourceTypeName !== stateMachineResourceTypeName) {
+      throw new Error(
+        `Unsupported sim StepFunctions CloudFormation Resource ${resourceTypeName}`,
+      );
+    }
+
+    return await this.#stateMachineCreator.create(
+      resource,
+      context.resolvedProperties ?? resource.properties,
+    );
+  }
+
+  /**
+   * Delete a simulated Step Functions resource created from a CloudFormation
+   * Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    _context: SimCloudFormationResourceDeleteContext,
+  ): Promise<void> {
+    await this.#deleter.delete(resourceTypeName, resource);
+  }
+}

--- a/src/service/cloudformation/resource/cfn/stepfunctions/sim-step-functions-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/stepfunctions/sim-step-functions-cfn-value-adapter.ts
@@ -1,0 +1,26 @@
+import { SimStateMachine } from "../../../../stepfunctions/machine/sim-state-machine.js";
+import type {
+  SimCfnResourceValueAdapterProperties,
+  SimCfnServiceValueAdapter,
+} from "../sim-cfn-resource-value-adapter.js";
+import { SimStateMachineCfn } from "./sim-state-machine-cfn.js";
+import { stateMachineResourceType } from "./sim-cfn-step-functions-resource-types.js";
+
+/**
+ * The CloudFormation-facing value adapter for a simulated Step Functions
+ * Resource.
+ */
+export function stepFunctionsValueAdapter(
+  properties: SimCfnResourceValueAdapterProperties,
+): SimCfnServiceValueAdapter {
+  const { type, simResource } = properties;
+
+  if (
+    type === stateMachineResourceType &&
+    simResource instanceof SimStateMachine
+  ) {
+    return new SimStateMachineCfn(simResource);
+  }
+
+  return undefined;
+}

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
@@ -1,6 +1,7 @@
 import type { SimAwsAccountRegionContainer } from "../../../../aws/sim-aws-account-region-scope.js";
 import type { SimCfnServiceResourceFactory } from "../../factory/sim-cfn-resource-factory.type.js";
 import { SimCfnCfnResourceFactory } from "../../factory/sim-cfn-cfn-resource-factory.js";
+import { SimStepFunctionsCfnResourceFactory } from "../../cfn/stepfunctions/sim-step-functions-cfn-resource-factory.js";
 
 /**
  * How one simulated service hands over its CloudFormation Resource factory,
@@ -158,6 +159,13 @@ export const simCfnServiceResourceFactories: ReadonlyMap<
     "SSM",
     (scopedAws): SimCfnServiceResourceFactory =>
       scopedAws.ssm().cfnResourceFactory(),
+  ],
+  [
+    "StepFunctions",
+    (scopedAws): SimCfnServiceResourceFactory =>
+      new SimStepFunctionsCfnResourceFactory({
+        stepFunctions: scopedAws.stepFunctions(),
+      }),
   ],
   [
     "WAFv2",


### PR DESCRIPTION
A template declaring AWS::StepFunctions::StateMachine now creates a state machine, and a CDK app synthesizing one deploys and runs an execution against it. The definition is read once the template intrinsics have resolved. The Fn::Join CDK writes DefinitionString as arrives with real ARNs in it, the object Definition form is read as Amazon States Language directly, and DefinitionSubstitutions are applied before either is read. StateMachineName, RoleArn and StateMachineType go through the ordinary CreateStateMachine command. A template and an SDK caller reach the same state machine, and a definition Step Functions will not take is refused in the words that command refuses it in. An unnamed state machine is named after the stack and the logical ID. Ref answers the ARN, Fn::GetAtt answers Arn and Name, and deleting the stack deletes the state machine. A definition holding a state type the interpreter does not run drops that one state machine and records the reason on the stack, and the rest of the stack still deploys. StateMachineVersion and StateMachineAlias are refused as unsupported, and Tags, LoggingConfiguration, TracingConfiguration and EncryptionConfiguration are recorded against the Resource as unsimulated.

Three parts of #919 are outstanding.

- **A Task the execution invokes.** The Fn::Join over a Ref is covered, with a queue ARN joined into a Pass state, and an execution reads the resolved ARN out of its output. Joining a Lambda ARN into a Task state needs the Task slice of #918, which has not landed. The rest of that acceptance criterion is tested.
- **DefinitionBody.fromFile.** It synthesizes to DefinitionS3Location, which #919 puts out of scope. That state machine is dropped and the reason recorded rather than deployed without the definition it was meant to run. The object Definition form is covered.
- **Tags.** Simulated Step Functions holds no tags on a state machine and has no ListTagsForResource, so there is nowhere to carry them to. The property is recorded on stack.ignoredProperties and the state machine is created without them.

One note on placement. The factory sits under src/service/cloudformation/resource/cfn/stepfunctions/ rather than src/service/stepfunctions/cfn/ where the other services keep theirs, to stay clear of the interpreter work still in flight on #918. Moving it once that lands is a rename and a factory-map edit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for deploying and simulating Step Functions state machines through CloudFormation.
  * Supports state machine definitions, substitutions, generated names, references, attributes, execution, and deletion.
  * Added an executable deployment and execution example.

* **Documentation**
  * Documented CloudFormation and CDK support, supported properties, limitations, versions, aliases, and S3 definitions.

* **Bug Fixes**
  * Added validation and clear handling for invalid or unsupported state machine configurations.

* **Tests**
  * Added comprehensive integration coverage for deployment, execution, references, substitutions, errors, skipped resources, and deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->