### PR TITLE
feat: run Choice and Wait states

### DIFF
--- a/docs/services/stepfunctions/README.md
+++ b/docs/services/stepfunctions/README.md
@@ -194,9 +194,9 @@ on its own counts as a string.
 
 ## Waiting on the clock
 
-A `Wait` state holds the execution until an instant on the simulation's clock. `StartExecution`
-answers with the execution `RUNNING`, and moving simulated time past the instant runs the rest of
-it.
+A `Wait` state holds the execution until an instant on the simulation's clock. Where that instant is
+still ahead, `StartExecution` answers with the execution `RUNNING`, and moving simulated time past it
+runs the rest of the execution.
 
 ```typescript sim-step-functions-wait
 /**
@@ -249,10 +249,12 @@ console.log(settled.stopDate); // 2026-07-26T09:05:00.000Z
 Under a frozen clock the execution stays `RUNNING` for as long as the test leaves it there.
 Simulated time moves only when the test moves it, and a slow test holds the state it set up.
 
-A `Wait` state carries exactly one of `Seconds`, `SecondsPath`, `Timestamp` and `TimestampPath`. The
-two paths are read out of the state's input as it runs. A path holding something other than a whole
-number of seconds, or something other than an RFC3339 instant, fails the execution with
-`States.Runtime`. An instant already behind the clock lets the execution carry straight on.
+A `Wait` state carries exactly one of `Seconds`, `SecondsPath`, `Timestamp` and `TimestampPath`. A
+wait runs from 0 to 99,999,999 seconds, which is the range Step Functions takes, and a `Timestamp` is
+held to RFC3339 (so `2026-02-30T00:00:00Z` is refused rather than read as the second of March). The
+two paths are read out of the state's input as it runs, and a path holding a value outside either
+range fails the execution with `States.Runtime`. An instant already behind the clock lets the
+execution carry straight on.
 
 The execution stops at the instant it was waiting for, and `DescribeExecution` reports that as its
 `stopDate`. A failure after a wait is recorded on the execution, and `advanceBy` returns as it would

--- a/docs/services/stepfunctions/README.md
+++ b/docs/services/stepfunctions/README.md
@@ -8,8 +8,8 @@ Types for simulated Step Functions are imported from the `@kensio/yulin/stepfunc
 
 ## What runs today
 
-Three state types run. `Pass`, `Succeed` and `Fail`. A definition using any other is refused when the
-state machine is created, naming the state and its type. `Task`, `Choice`, `Wait`, `Parallel` and
+Five state types run. `Pass`, `Succeed`, `Fail`, `Choice` and `Wait`. A definition using any other
+is refused when the state machine is created, naming the state and its type. `Task`, `Parallel` and
 `Map` are on the way.
 
 The data-flow fields run in full. `InputPath`, `Parameters`, `ResultSelector`, `ResultPath` and
@@ -109,6 +109,154 @@ succeeded. Simulated EventBridge treats an undeliverable event the same way. An 
 as often the thing under test as it is a fault, and raising it would fail an unrelated `advanceBy`
 elsewhere in the same test.
 
+## Branching on the input
+
+A `Choice` state takes the first rule its input matches, and its `Default` where none of them do.
+
+```typescript sim-step-functions-choice
+/**
+ * Branching on an execution's data with a Choice state.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const created = await simAws.stepFunctions().createStateMachine({
+  input: {
+    name: "Enrolment",
+    roleArn: "arn:aws:iam::123456789012:role/WorkflowRole",
+    definition: JSON.stringify({
+      StartAt: "Eligible",
+      States: {
+        Eligible: {
+          Type: "Choice",
+          Choices: [
+            {
+              And: [
+                { Variable: "$.term", IsPresent: true },
+                { Variable: "$.term", NumericGreaterThanEquals: 2 },
+              ],
+              Next: "Enrol",
+            },
+          ],
+          Default: "Decline",
+        },
+        Enrol: { Type: "Pass", Result: { enrolled: true }, End: true },
+        Decline: { Type: "Fail", Error: "NotEligible" },
+      },
+    }),
+  },
+});
+
+const started = await simAws.stepFunctions().startExecution({
+  input: {
+    stateMachineArn: created.stateMachineArn,
+    input: JSON.stringify({ student: "Wei", term: 3 }),
+  },
+});
+
+console.log(
+  simAws.stepFunctions().inspection().visitedStates(started.executionArn),
+); // [ 'Eligible', 'Enrol' ]
+
+const described = await simAws
+  .stepFunctions()
+  .describeExecution({ input: { executionArn: started.executionArn } });
+
+console.log(described.output); // {"enrolled":true}
+```
+
+The comparators are the ones Amazon States Language defines. Strings compare with `StringEquals`,
+`StringLessThan`, `StringGreaterThan`, `StringLessThanEquals`, `StringGreaterThanEquals` and
+`StringMatches`. The same five orderings appear under `Numeric` and under `Timestamp`, and a boolean
+compares with `BooleanEquals`. Every one of them has a `Path` twin, such as
+`NumericGreaterThanPath`, which takes a Reference Path and reads its operand from the state's own
+input. The data tests are `IsPresent`, `IsNull`, `IsBoolean`, `IsNumeric`, `IsString` and
+`IsTimestamp`. Rules combine with `And`, `Or` and `Not`.
+
+`StringMatches` takes `*` as a wildcard spanning any run of characters. A backslash escapes the
+character after it, so `Star\*` matches the literal name `Star*`.
+
+Two things fail an execution at a `Choice` state, both the way real Step Functions fails one:
+
+- A state matching no rule with no `Default` to fall back on fails with `States.NoChoiceMatched`.
+- A comparator whose `Variable` selects nothing fails with `States.Runtime`. Guard a field that may
+  be absent with `IsPresent` at the front of an `And`, as the example above does. The rules under an
+  `And` are tested in the order they were written and stop at the first one that fails. The data
+  tests answer for an absent field on their own.
+
+A comparison of two different types answers false. A `StringEquals` rule tested against a number
+falls through to the next rule. Timestamps are read as RFC3339 (`2026-07-26T09:00:00Z`), so a date
+on its own counts as a string.
+
+## Waiting on the clock
+
+A `Wait` state holds the execution until an instant on the simulation's clock. `StartExecution`
+answers with the execution `RUNNING`, and moving simulated time past the instant runs the rest of
+it.
+
+```typescript sim-step-functions-wait
+/**
+ * Holding an execution at a Wait state, then moving time past it.
+ */
+
+import { SimAws, SimFixedClock } from "@kensio/yulin";
+
+const simAws = new SimAws({
+  clock: new SimFixedClock(new Date("2026-07-26T09:00:00.000Z")),
+});
+
+const created = await simAws.stepFunctions().createStateMachine({
+  input: {
+    name: "Enrolment",
+    roleArn: "arn:aws:iam::123456789012:role/WorkflowRole",
+    definition: JSON.stringify({
+      StartAt: "Settle",
+      States: {
+        Settle: { Type: "Wait", Seconds: 300, Next: "Confirm" },
+        Confirm: { Type: "Pass", Result: { confirmed: true }, End: true },
+      },
+    }),
+  },
+});
+
+const started = await simAws.stepFunctions().startExecution({
+  input: {
+    stateMachineArn: created.stateMachineArn,
+    input: JSON.stringify({ student: "Wei" }),
+  },
+});
+
+const waiting = await simAws
+  .stepFunctions()
+  .describeExecution({ input: { executionArn: started.executionArn } });
+
+console.log(waiting.status); // RUNNING
+
+await simAws.clock().advanceBy({ minutes: 6 });
+
+const settled = await simAws
+  .stepFunctions()
+  .describeExecution({ input: { executionArn: started.executionArn } });
+
+console.log(settled.status); // SUCCEEDED
+console.log(settled.stopDate); // 2026-07-26T09:05:00.000Z
+```
+
+Under a frozen clock the execution stays `RUNNING` for as long as the test leaves it there.
+Simulated time moves only when the test moves it, and a slow test holds the state it set up.
+
+A `Wait` state carries exactly one of `Seconds`, `SecondsPath`, `Timestamp` and `TimestampPath`. The
+two paths are read out of the state's input as it runs. A path holding something other than a whole
+number of seconds, or something other than an RFC3339 instant, fails the execution with
+`States.Runtime`. An instant already behind the clock lets the execution carry straight on.
+
+The execution stops at the instant it was waiting for, and `DescribeExecution` reports that as its
+`stopDate`. A failure after a wait is recorded on the execution, and `advanceBy` returns as it would
+for one that succeeded. [Simulated time](../../time/ "Simulated time docs") covers what else
+advancing the clock runs.
+
 ## Through an intercepted SDK client
 
 An `SFNClient` handed to `SimSdk` reaches the same simulated service:
@@ -173,18 +321,19 @@ A test asserting on the output of a state machine that used one could only asser
 
 ## Where this differs from real Step Functions
 
-- **`StartExecution` settles before it answers.** Real Step Functions answers before the execution
-  has run, and a caller there sees `RUNNING` first. An execution here has finished by the time the
-  caller reads it back. That spares every test a wait for work that is already done.
+- **`StartExecution` runs the execution as far as it goes before it answers.** Real Step Functions
+  answers before the execution has run, and a caller there sees `RUNNING` first. An execution here
+  with nothing to wait for has finished by the time the caller reads it back, and one held at a
+  `Wait` state reads as `RUNNING`. That spares every test a wait for work that is already done.
 - **An `EXPRESS` state machine runs the standard way.** The type is carried and read back, and
   `StartSyncExecution` is unsimulated.
 - **An unnamed execution is named by a counter.** Real Step Functions uses a UUID. A counter means a
   simulation answers the same way twice. The counter steps over any name a caller has already used.
-- **A running execution is not yet idempotent by name.** Real `StartExecution` answers a repeat of a
-  running Standard execution carrying the same name and input with that execution's own response.
-  Every execution here finishes before `StartExecution` answers, so there is never a running one to
-  match, and a repeated name raises `ExecutionAlreadyExists`. This arrives with the `Wait` state.
-  Reusing a name 90 days after an execution closes is unsimulated as well.
+- **A name is taken for good.** Real Step Functions frees an execution name 90 days after the
+  execution closes. A name here stays taken for the life of the simulation, which no test runs long
+  enough to notice. `StartExecution` is idempotent while an execution is still running, as it is on
+  AWS. A repeat carrying the same name and input answers with the execution already there, and one
+  carrying different input raises `ExecutionAlreadyExists`.
 - **A brace escape outside `States.Format` keeps its backslash.** A brace is a placeholder to
   `States.Format` alone, so `States.Format` is where `\{` is resolved. An escaped brace reaching
   another intrinsic arrives as it was written.
@@ -201,7 +350,7 @@ two and is what this follows.
 
 ## Still to come
 
-- `Task`, `Choice`, `Wait`, `Parallel` and `Map` states.
+- `Task`, `Parallel` and `Map` states.
 - `Retry` and `Catch`.
 - Service integrations, task tokens and activities.
 - `AWS::StepFunctions::StateMachine` CloudFormation resources.

--- a/docs/services/stepfunctions/README.md
+++ b/docs/services/stepfunctions/README.md
@@ -170,13 +170,15 @@ console.log(described.output); // {"enrolled":true}
 The comparators are the ones Amazon States Language defines. Strings compare with `StringEquals`,
 `StringLessThan`, `StringGreaterThan`, `StringLessThanEquals`, `StringGreaterThanEquals` and
 `StringMatches`. The same five orderings appear under `Numeric` and under `Timestamp`, and a boolean
-compares with `BooleanEquals`. Every one of them has a `Path` twin, such as
-`NumericGreaterThanPath`, which takes a Reference Path and reads its operand from the state's own
-input. The data tests are `IsPresent`, `IsNull`, `IsBoolean`, `IsNumeric`, `IsString` and
-`IsTimestamp`. Rules combine with `And`, `Or` and `Not`.
+compares with `BooleanEquals`. Each of those has a `Path` twin, such as `NumericGreaterThanPath`,
+which takes a Reference Path and reads its operand from the state's own input. The data tests are
+`IsPresent`, `IsNull`, `IsBoolean`, `IsNumeric`, `IsString` and `IsTimestamp`. Rules combine with
+`And`, `Or` and `Not`.
 
 `StringMatches` takes `*` as a wildcard spanning any run of characters. A backslash escapes the
-character after it, so `Star\*` matches the literal name `Star*`.
+character after it, so `Star\*` matches the literal name `Star*`. Amazon States Language gives
+`StringMatches` no `Path` twin, and `StringMatchesPath` is refused here as a comparator it does not
+define.
 
 Two things fail an execution at a `Choice` state, both the way real Step Functions fails one:
 

--- a/docs/services/stepfunctions/sim-step-functions-choice.example.ts
+++ b/docs/services/stepfunctions/sim-step-functions-choice.example.ts
@@ -1,0 +1,51 @@
+/**
+ * Branching on an execution's data with a Choice state.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const created = await simAws.stepFunctions().createStateMachine({
+  input: {
+    name: "Enrolment",
+    roleArn: "arn:aws:iam::123456789012:role/WorkflowRole",
+    definition: JSON.stringify({
+      StartAt: "Eligible",
+      States: {
+        Eligible: {
+          Type: "Choice",
+          Choices: [
+            {
+              And: [
+                { Variable: "$.term", IsPresent: true },
+                { Variable: "$.term", NumericGreaterThanEquals: 2 },
+              ],
+              Next: "Enrol",
+            },
+          ],
+          Default: "Decline",
+        },
+        Enrol: { Type: "Pass", Result: { enrolled: true }, End: true },
+        Decline: { Type: "Fail", Error: "NotEligible" },
+      },
+    }),
+  },
+});
+
+const started = await simAws.stepFunctions().startExecution({
+  input: {
+    stateMachineArn: created.stateMachineArn,
+    input: JSON.stringify({ student: "Wei", term: 3 }),
+  },
+});
+
+console.log(
+  simAws.stepFunctions().inspection().visitedStates(started.executionArn),
+); // [ 'Eligible', 'Enrol' ]
+
+const described = await simAws
+  .stepFunctions()
+  .describeExecution({ input: { executionArn: started.executionArn } });
+
+console.log(described.output); // {"enrolled":true}

--- a/docs/services/stepfunctions/sim-step-functions-wait.example.ts
+++ b/docs/services/stepfunctions/sim-step-functions-wait.example.ts
@@ -1,0 +1,45 @@
+/**
+ * Holding an execution at a Wait state, then moving time past it.
+ */
+
+import { SimAws, SimFixedClock } from "@kensio/yulin";
+
+const simAws = new SimAws({
+  clock: new SimFixedClock(new Date("2026-07-26T09:00:00.000Z")),
+});
+
+const created = await simAws.stepFunctions().createStateMachine({
+  input: {
+    name: "Enrolment",
+    roleArn: "arn:aws:iam::123456789012:role/WorkflowRole",
+    definition: JSON.stringify({
+      StartAt: "Settle",
+      States: {
+        Settle: { Type: "Wait", Seconds: 300, Next: "Confirm" },
+        Confirm: { Type: "Pass", Result: { confirmed: true }, End: true },
+      },
+    }),
+  },
+});
+
+const started = await simAws.stepFunctions().startExecution({
+  input: {
+    stateMachineArn: created.stateMachineArn,
+    input: JSON.stringify({ student: "Wei" }),
+  },
+});
+
+const waiting = await simAws
+  .stepFunctions()
+  .describeExecution({ input: { executionArn: started.executionArn } });
+
+console.log(waiting.status); // RUNNING
+
+await simAws.clock().advanceBy({ minutes: 6 });
+
+const settled = await simAws
+  .stepFunctions()
+  .describeExecution({ input: { executionArn: started.executionArn } });
+
+console.log(settled.status); // SUCCEEDED
+console.log(settled.stopDate); // 2026-07-26T09:05:00.000Z

--- a/docs/time/README.md
+++ b/docs/time/README.md
@@ -149,8 +149,9 @@ and `scheduler().deliveryFailures`.
 Several parts of the simulator schedule work on the clock. Advancing time does more than change what
 timestamps and expiry checks see. A scheduled EventBridge rule fires, an EventBridge Scheduler
 schedule invokes its target, a DynamoDB item passes its time to live, a Secrets Manager deletion
-falls due, and a Lambda event source mapping polls again. Each of those runs at its own due instant
-inside the interval, in the order they fall due.
+falls due, a Step Functions execution moves on from a `Wait` state, and a Lambda event source
+mapping polls again. Each of those runs at its own due instant inside the interval, in the order
+they fall due.
 
 ## Time inside a simulated Lambda handler
 

--- a/src/service/stepfunctions/choice/sim-states-choice-group-test.ts
+++ b/src/service/stepfunctions/choice/sim-states-choice-group-test.ts
@@ -1,0 +1,52 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import type { SimStatesChoiceTest } from "./sim-states-choice-test.js";
+
+/**
+ * An `And`, which holds where every test it carries does.
+ */
+export class SimStatesAllTest implements SimStatesChoiceTest {
+  readonly #tests: readonly SimStatesChoiceTest[];
+
+  constructor(tests: readonly SimStatesChoiceTest[]) {
+    this.#tests = tests;
+  }
+
+  /**
+   * The tests are made in the order they were written, and stop at the first
+   * one that does not hold. That is what lets an `IsPresent` guard a
+   * comparison of the same field further along the same `And`.
+   */
+  holds(input: JSONValue): boolean {
+    return this.#tests.every((test) => test.holds(input));
+  }
+}
+
+/**
+ * An `Or`, which holds where any test it carries does.
+ */
+export class SimStatesAnyTest implements SimStatesChoiceTest {
+  readonly #tests: readonly SimStatesChoiceTest[];
+
+  constructor(tests: readonly SimStatesChoiceTest[]) {
+    this.#tests = tests;
+  }
+
+  holds(input: JSONValue): boolean {
+    return this.#tests.some((test) => test.holds(input));
+  }
+}
+
+/**
+ * A `Not`, which holds where the test it carries does not.
+ */
+export class SimStatesNotTest implements SimStatesChoiceTest {
+  readonly #test: SimStatesChoiceTest;
+
+  constructor(test: SimStatesChoiceTest) {
+    this.#test = test;
+  }
+
+  holds(input: JSONValue): boolean {
+    return !this.#test.holds(input);
+  }
+}

--- a/src/service/stepfunctions/choice/sim-states-choice-operand.ts
+++ b/src/service/stepfunctions/choice/sim-states-choice-operand.ts
@@ -1,0 +1,56 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { selectSimStatesPath } from "../data/sim-states-path-segment.js";
+import type { SimStatesPathSegment } from "../data/sim-states-path-segment.js";
+import { SimStatesRuntimeFailure } from "../error/sim-step-functions.error.js";
+
+/**
+ * The value one side of a comparison is made against.
+ */
+export interface SimStatesChoiceOperand {
+  valueIn(input: JSONValue): JSONValue;
+}
+
+/**
+ * An operand the definition wrote out, as in `NumericEquals: 3`.
+ */
+export class SimStatesLiteralOperand implements SimStatesChoiceOperand {
+  readonly #value: JSONValue;
+
+  constructor(value: JSONValue) {
+    this.#value = value;
+  }
+
+  valueIn(): JSONValue {
+    return this.#value;
+  }
+}
+
+/**
+ * An operand read from the state's input, as in `NumericEqualsPath: "$.want"`.
+ *
+ * A path selecting nothing fails the execution. The comparison has no value to
+ * make, and answering false would read as a rule that was tested and did not
+ * match.
+ */
+export class SimStatesPathOperand implements SimStatesChoiceOperand {
+  readonly #path: string;
+  readonly #segments: readonly SimStatesPathSegment[];
+
+  constructor(path: string, segments: readonly SimStatesPathSegment[]) {
+    this.#path = path;
+    this.#segments = segments;
+  }
+
+  valueIn(input: JSONValue): JSONValue {
+    const value = selectSimStatesPath(input, this.#segments);
+
+    if (value === undefined) {
+      throw new SimStatesRuntimeFailure(
+        `A Choice rule reads its operand from ${this.#path}, which selects ` +
+          "nothing in the state's input.",
+      );
+    }
+
+    return value;
+  }
+}

--- a/src/service/stepfunctions/choice/sim-states-choice-parse.ts
+++ b/src/service/stepfunctions/choice/sim-states-choice-parse.ts
@@ -1,0 +1,68 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { SimStatesInvalidDefinition } from "../error/sim-step-functions.error.js";
+import { SimStatesChoiceRule } from "./sim-states-choice-rule.js";
+import { asSimStatesRuleRecord } from "./sim-states-choice-rule-record.js";
+import { parseSimStatesChoiceTest } from "./sim-states-choice-test-parse.js";
+
+/**
+ * Read a `Choice` state's rules, refusing anything this cannot test.
+ *
+ * The rules are read when the state machine is created, so a `Choice` state
+ * that runs is one whose comparators, paths and operand types are already
+ * known to be good.
+ */
+export function parseSimStatesChoices(
+  stateName: string,
+  state: Record<string, JSONValue>,
+): readonly SimStatesChoiceRule[] {
+  const declared = state["Choices"];
+
+  if (!Array.isArray(declared) || declared.length === 0) {
+    throw new SimStatesInvalidDefinition(
+      `The Choice state ${stateName} carries no Choices. A Choice state ` +
+        "needs at least one rule saying where the execution goes.",
+    );
+  }
+
+  return declared.map((rule) => parseRule(stateName, rule));
+}
+
+/**
+ * Check a `Choice` state's `Default`, the state it goes to when no rule holds.
+ */
+export function checkSimStatesChoiceDefault(
+  stateName: string,
+  state: Record<string, JSONValue>,
+): void {
+  const fallback = state["Default"];
+
+  if (fallback === undefined) {
+    return;
+  }
+
+  if (typeof fallback !== "string") {
+    throw new SimStatesInvalidDefinition(
+      `The Choice state ${stateName} has a Default that is not a state name.`,
+    );
+  }
+}
+
+/**
+ * Read one top-level rule, which names where a match goes next.
+ */
+function parseRule(stateName: string, rule: JSONValue): SimStatesChoiceRule {
+  const record = asSimStatesRuleRecord(stateName, rule);
+  const next = record["Next"];
+
+  if (typeof next !== "string") {
+    throw new SimStatesInvalidDefinition(
+      `A rule in the Choice state ${stateName} has no Next naming the state ` +
+        "a match goes to.",
+    );
+  }
+
+  return new SimStatesChoiceRule(
+    parseSimStatesChoiceTest(stateName, record),
+    next,
+  );
+}

--- a/src/service/stepfunctions/choice/sim-states-choice-refusals.iso.test.ts
+++ b/src/service/stepfunctions/choice/sim-states-choice-refusals.iso.test.ts
@@ -69,11 +69,20 @@ describe("Step Functions Choice refusals", () => {
   });
 
   it("refuses a comparator Amazon States Language does not define", () => {
-    // Given a rule testing with something invented.
-    // When it is read, it is refused by name.
+    // Given a rule testing with something invented, and one asking for the
+    // Path twin StringMatches has not got.
+    // When each is read, each is refused by name.
     assertStringIncludes(
       refusalForRule({ Variable: "$.term", NumericAbout: 3, Next: "Enrol" }),
       "NumericAbout",
+    );
+    assertStringIncludes(
+      refusalForRule({
+        Variable: "$.key",
+        StringMatchesPath: "$.pattern",
+        Next: "Enrol",
+      }),
+      "StringMatchesPath",
     );
   });
 

--- a/src/service/stepfunctions/choice/sim-states-choice-refusals.iso.test.ts
+++ b/src/service/stepfunctions/choice/sim-states-choice-refusals.iso.test.ts
@@ -1,0 +1,214 @@
+import { assertStringIncludes, assertThrowsError } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import type { JSONObject, JSONValue } from "../../../util/type-guard/json.js";
+import { parseSimStatesDefinition } from "../definition/sim-states-definition-parse.js";
+
+describe("Step Functions Choice refusals", () => {
+  /**
+   * Read a definition whose Choice state is expected to be refused, and answer
+   * with why.
+   */
+  function refusalFor(choice: JSONObject): string {
+    return assertThrowsError(() =>
+      parseSimStatesDefinition(
+        JSON.stringify({
+          StartAt: "Eligible",
+          States: {
+            Eligible: { Type: "Choice", ...choice },
+            Enrol: { Type: "Succeed" },
+          },
+        }),
+      ),
+    ).message;
+  }
+
+  /**
+   * The same, for a Choice state carrying one rule.
+   */
+  function refusalForRule(rule: JSONValue): string {
+    return refusalFor({ Choices: [rule] });
+  }
+
+  it("refuses a Choice state with nothing to choose between", () => {
+    // Given Choices that are missing, empty, or not an array at all.
+    // When each is read, each is refused.
+    assertStringIncludes(refusalFor({}), "carries no Choices");
+    assertStringIncludes(refusalFor({ Choices: [] }), "carries no Choices");
+    assertStringIncludes(
+      refusalFor({ Choices: "Enrol" }),
+      "carries no Choices",
+    );
+  });
+
+  it("refuses a rule that does not say where a match goes", () => {
+    // Given a rule with no Next, and one that is not an object.
+    // When each is read, each is refused.
+    assertStringIncludes(
+      refusalForRule({ Variable: "$.term", NumericEquals: 3 }),
+      "has no Next",
+    );
+    assertStringIncludes(refusalForRule("Enrol"), "is not an object");
+  });
+
+  it("refuses a rule that tests nothing, or more than one thing", () => {
+    // Given a rule with no comparator and one with two.
+    // When each is read, each names what it found.
+    assertStringIncludes(
+      refusalForRule({ Variable: "$.term", Next: "Enrol" }),
+      "tests nothing",
+    );
+    assertStringIncludes(
+      refusalForRule({
+        Variable: "$.term",
+        NumericEquals: 3,
+        NumericLessThan: 4,
+        Next: "Enrol",
+      }),
+      "NumericEquals, NumericLessThan",
+    );
+  });
+
+  it("refuses a comparator Amazon States Language does not define", () => {
+    // Given a rule testing with something invented.
+    // When it is read, it is refused by name.
+    assertStringIncludes(
+      refusalForRule({ Variable: "$.term", NumericAbout: 3, Next: "Enrol" }),
+      "NumericAbout",
+    );
+  });
+
+  it("refuses a comparison with no Variable to compare", () => {
+    // Given a comparator with nothing to read.
+    // When it is read, it is refused.
+    assertStringIncludes(
+      refusalForRule({ NumericEquals: 3, Next: "Enrol" }),
+      "has no Variable",
+    );
+  });
+
+  it("refuses an operand that is not the kind the comparator compares", () => {
+    // Given comparators written with the wrong kind of operand.
+    // When each is read, each names the kind it takes.
+    assertStringIncludes(
+      refusalForRule({ Variable: "$.term", NumericEquals: "3", Next: "Enrol" }),
+      "NumericEquals takes a number",
+    );
+    assertStringIncludes(
+      refusalForRule({ Variable: "$.term", IsPresent: "yes", Next: "Enrol" }),
+      "IsPresent takes a boolean",
+    );
+    assertStringIncludes(
+      refusalForRule({
+        Variable: "$.score",
+        NumericEqualsPath: 3,
+        Next: "Enrol",
+      }),
+      "NumericEqualsPath takes a string",
+    );
+  });
+
+  it("refuses a path outside the subset this reads", () => {
+    // Given a rule reading a wildcard path.
+    // When it is read, the path itself is refused.
+    assertStringIncludes(
+      refusalForRule({
+        Variable: "$.terms[*]",
+        IsPresent: true,
+        Next: "Enrol",
+      }),
+      "wildcards",
+    );
+  });
+
+  it("refuses an And or an Or holding no rules", () => {
+    // Given a boolean operator with nothing under it.
+    // When each is read, each is refused.
+    assertStringIncludes(
+      refusalForRule({ And: [], Next: "Enrol" }),
+      "non-empty array of rules",
+    );
+    assertStringIncludes(
+      refusalForRule({ Or: "$.term", Next: "Enrol" }),
+      "non-empty array of rules",
+    );
+  });
+
+  it("refuses a nested rule that says where the execution goes", () => {
+    // Given a rule inside an And carrying its own Next.
+    // When it is read, it is refused rather than ignored.
+    assertStringIncludes(
+      refusalForRule({
+        And: [{ Variable: "$.term", NumericEquals: 3, Next: "Enrol" }],
+        Next: "Enrol",
+      }),
+      "Only the rule at the top",
+    );
+  });
+
+  it("refuses a boolean operator carrying a Variable of its own", () => {
+    // Given an And that names a variable as well as the rules under it.
+    // When it is read, it is refused.
+    assertStringIncludes(
+      refusalForRule({
+        Variable: "$.term",
+        And: [{ Variable: "$.term", NumericEquals: 3 }],
+        Next: "Enrol",
+      }),
+      "carries a Variable",
+    );
+  });
+
+  it("refuses a transition naming a state that is not there", () => {
+    // Given a rule and a Default pointing at states the machine has not got.
+    // When each is read, each is refused when the state machine is created.
+    assertStringIncludes(
+      refusalForRule({ Variable: "$.term", NumericEquals: 3, Next: "Absent" }),
+      "moves to Absent",
+    );
+    assertStringIncludes(
+      refusalFor({
+        Choices: [{ Variable: "$.term", NumericEquals: 3, Next: "Enrol" }],
+        Default: "Absent",
+      }),
+      "Default of Absent",
+    );
+  });
+
+  it("refuses a Default that is not a state name", () => {
+    // Given a Default written as something else.
+    // When it is read, it is refused.
+    assertStringIncludes(
+      refusalFor({
+        Choices: [{ Variable: "$.term", NumericEquals: 3, Next: "Enrol" }],
+        Default: 3,
+      }),
+      "Default that is not a state name",
+    );
+  });
+
+  it("refuses a Choice state carrying Next or End of its own", () => {
+    // Given a Choice state written as though it moved on like a Pass state.
+    // When each is read, each is refused.
+    for (const transition of [{ Next: "Enrol" }, { End: true }]) {
+      assertStringIncludes(
+        refusalFor({
+          Choices: [{ Variable: "$.term", NumericEquals: 3, Next: "Enrol" }],
+          ...transition,
+        }),
+        "moves on through its Choices and its Default",
+      );
+    }
+  });
+
+  it("refuses the data-flow fields a Choice state does not have", () => {
+    // Given a Choice state carrying a ResultPath.
+    // When it is read, it is refused by field name.
+    assertStringIncludes(
+      refusalFor({
+        Choices: [{ Variable: "$.term", NumericEquals: 3, Next: "Enrol" }],
+        ResultPath: "$.check",
+      }),
+      "The Choice state Eligible carries ResultPath",
+    );
+  });
+});

--- a/src/service/stepfunctions/choice/sim-states-choice-rule-record.ts
+++ b/src/service/stepfunctions/choice/sim-states-choice-rule-record.ts
@@ -1,0 +1,52 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { isRecord } from "../../../util/type-guard/record.js";
+import { SimStatesInvalidDefinition } from "../error/sim-step-functions.error.js";
+
+// What a rule carries besides the test it makes.
+const ruleFields = new Set(["Variable", "Next", "Comment"]);
+
+/**
+ * Find the field naming what a rule tests.
+ */
+export function readSimStatesRuleOperator(
+  stateName: string,
+  record: Record<string, JSONValue>,
+): string {
+  const operators = Object.keys(record).filter(
+    (field) => !ruleFields.has(field),
+  );
+  const [operator] = operators;
+
+  if (operator === undefined) {
+    throw new SimStatesInvalidDefinition(
+      `A rule in the Choice state ${stateName} tests nothing. A rule carries ` +
+        "one comparator, or an And, an Or or a Not.",
+    );
+  }
+
+  if (operators.length > 1) {
+    throw new SimStatesInvalidDefinition(
+      `A rule in the Choice state ${stateName} carries ` +
+        `${operators.join(", ")}. A rule carries one comparator, or an And, ` +
+        "an Or or a Not.",
+    );
+  }
+
+  return operator;
+}
+
+/**
+ * Read one rule as the object it has to be.
+ */
+export function asSimStatesRuleRecord(
+  stateName: string,
+  rule: JSONValue | undefined,
+): Record<string, JSONValue> {
+  if (!isRecord(rule)) {
+    throw new SimStatesInvalidDefinition(
+      `A rule in the Choice state ${stateName} is not an object.`,
+    );
+  }
+
+  return rule;
+}

--- a/src/service/stepfunctions/choice/sim-states-choice-rule.ts
+++ b/src/service/stepfunctions/choice/sim-states-choice-rule.ts
@@ -1,0 +1,23 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import type { SimStatesChoiceTest } from "./sim-states-choice-test.js";
+
+/**
+ * One rule in a `Choice` state's `Choices`, and the state a match moves to.
+ */
+export class SimStatesChoiceRule {
+  readonly next: string;
+
+  readonly #test: SimStatesChoiceTest;
+
+  constructor(test: SimStatesChoiceTest, next: string) {
+    this.#test = test;
+    this.next = next;
+  }
+
+  /**
+   * Whether this rule's test holds for the state's effective input.
+   */
+  matches(input: JSONValue): boolean {
+    return this.#test.holds(input);
+  }
+}

--- a/src/service/stepfunctions/choice/sim-states-choice-test-parse.ts
+++ b/src/service/stepfunctions/choice/sim-states-choice-test-parse.ts
@@ -1,0 +1,121 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { SimStatesInvalidDefinition } from "../error/sim-step-functions.error.js";
+import {
+  SimStatesAllTest,
+  SimStatesAnyTest,
+  SimStatesNotTest,
+} from "./sim-states-choice-group-test.js";
+import {
+  asSimStatesRuleRecord,
+  readSimStatesRuleOperator,
+} from "./sim-states-choice-rule-record.js";
+import type { SimStatesChoiceTest } from "./sim-states-choice-test.js";
+import { parseSimStatesComparisonTest } from "./sim-states-comparison-parse.js";
+import { findSimStatesComparison } from "./sim-states-comparisons.js";
+
+const booleanOperators = new Set(["And", "Or", "Not"]);
+
+/**
+ * Read a rule nested inside an `And`, an `Or` or a `Not`.
+ *
+ * Only a top-level rule says where the execution goes, so a nested one
+ * carrying `Next` is refused rather than quietly ignored.
+ */
+function parseNestedTest(
+  stateName: string,
+  operator: string,
+  rule: JSONValue | undefined,
+): SimStatesChoiceTest {
+  const record = asSimStatesRuleRecord(stateName, rule);
+
+  if (Object.hasOwn(record, "Next")) {
+    throw new SimStatesInvalidDefinition(
+      `A rule inside the ${operator} of the Choice state ${stateName} ` +
+        "carries Next. Only the rule at the top of a Choices entry says " +
+        "where the execution goes.",
+    );
+  }
+
+  return parseSimStatesChoiceTest(stateName, record);
+}
+
+/**
+ * Read the one test a rule makes.
+ */
+export function parseSimStatesChoiceTest(
+  stateName: string,
+  record: Record<string, JSONValue>,
+): SimStatesChoiceTest {
+  const operator = readSimStatesRuleOperator(stateName, record);
+  // The operator was read off this record's own keys, so it holds a value.
+  // oxlint-disable-next-line security/detect-object-injection
+  const written = record[operator] as JSONValue;
+
+  if (booleanOperators.has(operator)) {
+    checkNoVariable(stateName, operator, record);
+
+    return parseBooleanTest(stateName, operator, written);
+  }
+
+  const comparison = findSimStatesComparison(operator);
+
+  if (comparison === undefined) {
+    throw new SimStatesInvalidDefinition(
+      `A rule in the Choice state ${stateName} tests with ${operator}, which ` +
+        "is not a comparator Amazon States Language defines.",
+    );
+  }
+
+  return parseSimStatesComparisonTest({
+    stateName,
+    record,
+    comparison,
+    written,
+  });
+}
+
+/**
+ * Read an `And`, an `Or` or a `Not` and the rules it holds.
+ */
+function parseBooleanTest(
+  stateName: string,
+  operator: string,
+  written: JSONValue | undefined,
+): SimStatesChoiceTest {
+  if (operator === "Not") {
+    return new SimStatesNotTest(parseNestedTest(stateName, operator, written));
+  }
+
+  if (!Array.isArray(written) || written.length === 0) {
+    throw new SimStatesInvalidDefinition(
+      `The ${operator} in a rule of the Choice state ${stateName} is not a ` +
+        "non-empty array of rules.",
+    );
+  }
+
+  const tests = written.map((nested) =>
+    parseNestedTest(stateName, operator, nested),
+  );
+
+  if (operator === "And") {
+    return new SimStatesAllTest(tests);
+  }
+
+  return new SimStatesAnyTest(tests);
+}
+
+/**
+ * An `And`, an `Or` or a `Not` tests rules rather than a value of its own.
+ */
+function checkNoVariable(
+  stateName: string,
+  operator: string,
+  record: Record<string, JSONValue>,
+): void {
+  if (Object.hasOwn(record, "Variable")) {
+    throw new SimStatesInvalidDefinition(
+      `The ${operator} in a rule of the Choice state ${stateName} carries a ` +
+        "Variable. The rules it holds carry their own.",
+    );
+  }
+}

--- a/src/service/stepfunctions/choice/sim-states-choice-test.ts
+++ b/src/service/stepfunctions/choice/sim-states-choice-test.ts
@@ -1,0 +1,58 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { selectSimStatesPath } from "../data/sim-states-path-segment.js";
+import type { SimStatesPathSegment } from "../data/sim-states-path-segment.js";
+import { SimStatesRuntimeFailure } from "../error/sim-step-functions.error.js";
+import type { SimStatesChoiceOperand } from "./sim-states-choice-operand.js";
+import type { SimStatesComparison } from "./sim-states-comparison.js";
+
+/**
+ * One test a `Choice` rule makes against the state's input.
+ */
+export interface SimStatesChoiceTest {
+  holds(input: JSONValue): boolean;
+}
+
+interface SimStatesVariableTestProperties {
+  readonly path: string;
+  readonly segments: readonly SimStatesPathSegment[];
+  readonly comparison: SimStatesComparison;
+  readonly operand: SimStatesChoiceOperand;
+}
+
+/**
+ * A comparison of the value at a `Variable` path against an operand.
+ */
+export class SimStatesVariableTest implements SimStatesChoiceTest {
+  readonly #path: string;
+  readonly #segments: readonly SimStatesPathSegment[];
+  readonly #comparison: SimStatesComparison;
+  readonly #operand: SimStatesChoiceOperand;
+
+  constructor(properties: SimStatesVariableTestProperties) {
+    this.#path = properties.path;
+    this.#segments = properties.segments;
+    this.#comparison = properties.comparison;
+    this.#operand = properties.operand;
+  }
+
+  /**
+   * Compare, failing the execution where the field being compared is absent.
+   *
+   * Real Step Functions fails a `Choice` state whose `Variable` selects
+   * nothing, which is why `IsPresent` exists. The data-test comparators answer
+   * for an absent field of their own accord.
+   */
+  holds(input: JSONValue): boolean {
+    const value = selectSimStatesPath(input, this.#segments);
+
+    if (value === undefined && this.#comparison.needsValue) {
+      throw new SimStatesRuntimeFailure(
+        `A Choice rule compares ${this.#path} with ` +
+          `${this.#comparison.name}, and the state's input holds nothing ` +
+          "there. Test it with IsPresent first where it may be absent.",
+      );
+    }
+
+    return this.#comparison.holds(value, this.#operand.valueIn(input));
+  }
+}

--- a/src/service/stepfunctions/choice/sim-states-choice.iso.test.ts
+++ b/src/service/stepfunctions/choice/sim-states-choice.iso.test.ts
@@ -1,0 +1,312 @@
+import {
+  assertFalse,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsError,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import type { JSONObject, JSONValue } from "../../../util/type-guard/json.js";
+import { parseSimStatesChoices } from "./sim-states-choice-parse.js";
+
+describe("Step Functions Choice comparators", () => {
+  /**
+   * Whether one rule, read the way a definition is read, matches an input.
+   */
+  function matches(rule: JSONObject, input: JSONValue): boolean {
+    const [only] = parseSimStatesChoices("Eligible", {
+      Choices: [{ ...rule, Next: "Enrol" }],
+    });
+
+    assertNonNullable(only);
+
+    return only.matches(input);
+  }
+
+  it("compares strings by equality and by order", () => {
+    // Given a student's name in the state's input.
+    const input = { student: "Wei" };
+
+    // When rules compare it as a string.
+    // Then each answers the way JavaScript orders strings.
+    assertTrue(matches({ Variable: "$.student", StringEquals: "Wei" }, input));
+    assertFalse(matches({ Variable: "$.student", StringEquals: "Li" }, input));
+    assertTrue(
+      matches({ Variable: "$.student", StringGreaterThan: "A" }, input),
+    );
+    assertTrue(matches({ Variable: "$.student", StringLessThan: "Z" }, input));
+    assertTrue(
+      matches({ Variable: "$.student", StringLessThanEquals: "Wei" }, input),
+    );
+    assertTrue(
+      matches({ Variable: "$.student", StringGreaterThanEquals: "Wei" }, input),
+    );
+    assertFalse(
+      matches({ Variable: "$.term", StringEquals: "3" }, { term: 3 }),
+    );
+  });
+
+  it("matches a string against a pattern, honouring its escapes", () => {
+    // Given a log path and a name holding a literal asterisk.
+    // When StringMatches rules are applied to them.
+    // Then the wildcard spans anything and an escaped asterisk does not.
+    assertTrue(
+      matches(
+        { Variable: "$.key", StringMatches: "logs/*/2026-*.json" },
+        { key: "logs/enrolment/2026-07.json" },
+      ),
+    );
+    assertFalse(
+      matches(
+        { Variable: "$.key", StringMatches: "logs/*.json" },
+        { key: "logs/enrolment.txt" },
+      ),
+    );
+    assertTrue(
+      matches(
+        { Variable: "$.name", StringMatches: String.raw`Star\*` },
+        { name: "Star*" },
+      ),
+    );
+    assertFalse(
+      matches(
+        { Variable: "$.name", StringMatches: String.raw`Star\*` },
+        { name: "Starling" },
+      ),
+    );
+    assertFalse(
+      matches({ Variable: "$.term", StringMatches: "3*" }, { term: 3 }),
+    );
+  });
+
+  it("compares numbers, and answers false for a value of another type", () => {
+    // Given a term number and a term written as a string.
+    // When numeric rules compare them.
+    // Then only the number compares, and the string simply does not match.
+    assertTrue(matches({ Variable: "$.term", NumericEquals: 3 }, { term: 3 }));
+    assertTrue(
+      matches({ Variable: "$.term", NumericGreaterThan: 2 }, { term: 3 }),
+    );
+    assertFalse(
+      matches({ Variable: "$.term", NumericLessThan: 3 }, { term: 3 }),
+    );
+    assertTrue(
+      matches({ Variable: "$.term", NumericLessThanEquals: 3 }, { term: 3 }),
+    );
+    assertTrue(
+      matches({ Variable: "$.term", NumericGreaterThanEquals: 3 }, { term: 3 }),
+    );
+    assertFalse(
+      matches({ Variable: "$.term", NumericEquals: 3 }, { term: "3" }),
+    );
+  });
+
+  it("compares booleans by identity", () => {
+    // Given an eligibility flag.
+    // When boolean rules compare it.
+    // Then only the same boolean matches, and a truthy string does not.
+    assertTrue(
+      matches(
+        { Variable: "$.eligible", BooleanEquals: true },
+        { eligible: true },
+      ),
+    );
+    assertFalse(
+      matches(
+        { Variable: "$.eligible", BooleanEquals: true },
+        { eligible: false },
+      ),
+    );
+    assertFalse(
+      matches(
+        { Variable: "$.eligible", BooleanEquals: true },
+        { eligible: "true" },
+      ),
+    );
+  });
+
+  it("compares timestamps as instants rather than as strings", () => {
+    // Given a deadline written in a different zone from the one compared with.
+    const input = { closesAt: "2026-07-26T11:00:00+02:00" };
+
+    // When timestamp rules compare it.
+    // Then the comparison is on the instant, and a date alone is not one.
+    assertTrue(
+      matches(
+        { Variable: "$.closesAt", TimestampEquals: "2026-07-26T09:00:00Z" },
+        input,
+      ),
+    );
+    assertTrue(
+      matches(
+        { Variable: "$.closesAt", TimestampLessThan: "2026-07-26T10:00:00Z" },
+        input,
+      ),
+    );
+    assertTrue(
+      matches(
+        {
+          Variable: "$.closesAt",
+          TimestampGreaterThanEquals: "2026-07-26T09:00:00Z",
+        },
+        input,
+      ),
+    );
+    assertFalse(
+      matches(
+        {
+          Variable: "$.closesAt",
+          TimestampGreaterThan: "2026-07-26T09:00:00Z",
+        },
+        input,
+      ),
+    );
+    assertFalse(
+      matches(
+        { Variable: "$.closesAt", TimestampEquals: "2026-07-26T09:00:00Z" },
+        { closesAt: "2026-07-26" },
+      ),
+    );
+    assertFalse(
+      matches(
+        { Variable: "$.closesAt", IsTimestamp: true },
+        {
+          closesAt: "2026-13-45T09:00:00Z",
+        },
+      ),
+    );
+  });
+
+  it("compares two places in the same input through a Path comparator", () => {
+    // Given a score and the score it has to beat, both on the input.
+    const input = { score: 71, pass: 70, grade: "B", wanted: "B" };
+
+    // When Path comparators compare them.
+    // Then each reads its operand from the input rather than the definition.
+    assertTrue(
+      matches({ Variable: "$.score", NumericGreaterThanPath: "$.pass" }, input),
+    );
+    assertFalse(
+      matches({ Variable: "$.score", NumericLessThanPath: "$.pass" }, input),
+    );
+    assertTrue(
+      matches({ Variable: "$.grade", StringEqualsPath: "$.wanted" }, input),
+    );
+  });
+
+  it("tests what a field holds, and whether it is there at all", () => {
+    // Given an input holding a null, a number and a timestamp.
+    const input = {
+      cancelled: null,
+      term: 3,
+      student: "Wei",
+      closesAt: "2026-07-26T09:00:00Z",
+      enrolled: false,
+    };
+
+    // When the data-test comparators are applied.
+    // Then each answers for what is there, and for what is not.
+    assertTrue(matches({ Variable: "$.term", IsPresent: true }, input));
+    assertTrue(matches({ Variable: "$.absent", IsPresent: false }, input));
+    assertFalse(matches({ Variable: "$.absent", IsPresent: true }, input));
+    assertTrue(matches({ Variable: "$.cancelled", IsNull: true }, input));
+    assertFalse(matches({ Variable: "$.term", IsNull: true }, input));
+    assertTrue(matches({ Variable: "$.enrolled", IsBoolean: true }, input));
+    assertTrue(matches({ Variable: "$.term", IsNumeric: true }, input));
+    assertTrue(matches({ Variable: "$.student", IsString: true }, input));
+    assertTrue(matches({ Variable: "$.closesAt", IsTimestamp: true }, input));
+    assertFalse(matches({ Variable: "$.student", IsTimestamp: true }, input));
+  });
+
+  it("combines rules with And, Or and Not", () => {
+    // Given a student in their third term.
+    const input = { student: "Wei", term: 3 };
+
+    // When rules are combined.
+    // Then And needs both, Or needs either, and Not inverts.
+    assertTrue(
+      matches(
+        {
+          And: [
+            { Variable: "$.term", NumericGreaterThanEquals: 2 },
+            { Variable: "$.student", StringEquals: "Wei" },
+          ],
+        },
+        input,
+      ),
+    );
+    assertFalse(
+      matches(
+        {
+          And: [
+            { Variable: "$.term", NumericGreaterThanEquals: 2 },
+            { Variable: "$.student", StringEquals: "Li" },
+          ],
+        },
+        input,
+      ),
+    );
+    assertTrue(
+      matches(
+        {
+          Or: [
+            { Variable: "$.student", StringEquals: "Li" },
+            { Variable: "$.term", NumericEquals: 3 },
+          ],
+        },
+        input,
+      ),
+    );
+    assertTrue(
+      matches({ Not: { Variable: "$.term", NumericEquals: 4 } }, input),
+    );
+  });
+
+  it("guards a comparison of a field that may be absent, in that order", () => {
+    // Given an input with no term on it at all.
+    const input = { student: "Wei" };
+
+    // When an And tests IsPresent before comparing the same field.
+    const guarded = matches(
+      {
+        And: [
+          { Variable: "$.term", IsPresent: true },
+          { Variable: "$.term", NumericEquals: 3 },
+        ],
+      },
+      input,
+    );
+
+    // Then the rule answers false, rather than the comparison failing on a
+    // field that is not there.
+    assertFalse(guarded);
+  });
+
+  it("fails the state where the field being compared is not there", () => {
+    // Given a comparison of a field the input does not hold.
+    // When the rule is tested.
+    const failure = assertThrowsError(() =>
+      matches({ Variable: "$.term", NumericEquals: 3 }, { student: "Wei" }),
+    );
+
+    // Then it fails the way real Step Functions does, naming the path.
+    assertStringIncludes(failure.message, "$.term");
+    assertStringIncludes(failure.message, "IsPresent");
+  });
+
+  it("fails the state where a Path comparator's operand is not there", () => {
+    // Given a comparison reading its operand from a path holding nothing.
+    // When the rule is tested.
+    const failure = assertThrowsError(() =>
+      matches(
+        { Variable: "$.score", NumericGreaterThanPath: "$.pass" },
+        {
+          score: 71,
+        },
+      ),
+    );
+
+    // Then the state fails rather than the rule quietly not matching.
+    assertStringIncludes(failure.message, "$.pass");
+  });
+});

--- a/src/service/stepfunctions/choice/sim-states-choice.iso.test.ts
+++ b/src/service/stepfunctions/choice/sim-states-choice.iso.test.ts
@@ -170,9 +170,21 @@ describe("Step Functions Choice comparators", () => {
     assertFalse(
       matches(
         { Variable: "$.closesAt", IsTimestamp: true },
-        {
-          closesAt: "2026-13-45T09:00:00Z",
-        },
+        { closesAt: "2026-13-45T09:00:00Z" },
+      ),
+    );
+    assertFalse(
+      matches(
+        { Variable: "$.closesAt", IsTimestamp: true },
+        // The thirtieth of February, which JavaScript's own parser reads as
+        // the second of March.
+        { closesAt: "2026-02-30T00:00:00Z" },
+      ),
+    );
+    assertTrue(
+      matches(
+        { Variable: "$.closesAt", IsTimestamp: true },
+        { closesAt: "2024-02-29T00:00:00Z" },
       ),
     );
   });

--- a/src/service/stepfunctions/choice/sim-states-comparison-families.ts
+++ b/src/service/stepfunctions/choice/sim-states-comparison-families.ts
@@ -1,0 +1,88 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import {
+  SimStatesComparison,
+  type SimStatesOperandType,
+} from "./sim-states-comparison.js";
+
+/**
+ * Read a JSON value as a string, or as nothing where it is not one.
+ */
+export function readString(value: JSONValue | undefined): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  return value;
+}
+
+/**
+ * Read a JSON value as a number, or as nothing where it is not one.
+ */
+export function readNumber(value: JSONValue | undefined): number | undefined {
+  if (typeof value !== "number") {
+    return undefined;
+  }
+
+  return value;
+}
+
+/**
+ * The five ordering comparators over one JSON type.
+ *
+ * A value of the wrong type on either side answers false rather than failing.
+ * `StringEquals` against a number is a comparison that does not hold, and a
+ * rule the input does not match is the ordinary case in a `Choice` state.
+ */
+export function orderedComparisons<T>(
+  prefix: string,
+  operandType: SimStatesOperandType,
+  read: (value: JSONValue | undefined) => T | undefined,
+): SimStatesComparison[] {
+  const comparison = (
+    suffix: string,
+    holds: (left: T, right: T) => boolean,
+  ): SimStatesComparison =>
+    new SimStatesComparison({
+      name: `${prefix}${suffix}`,
+      operandType,
+      needsValue: true,
+      operandIsPath: false,
+      holds: (variable, operand): boolean => {
+        const left = read(variable);
+        const right = read(operand);
+
+        if (left === undefined || right === undefined) {
+          return false;
+        }
+
+        return holds(left, right);
+      },
+    });
+
+  return [
+    comparison("Equals", (left, right) => left === right),
+    comparison("LessThan", (left, right) => left < right),
+    comparison("GreaterThan", (left, right) => left > right),
+    comparison("LessThanEquals", (left, right) => left <= right),
+    comparison("GreaterThanEquals", (left, right) => left >= right),
+  ];
+}
+
+/**
+ * One data-test comparator, such as `IsString`.
+ *
+ * These are the comparators that answer for a `Variable` selecting nothing,
+ * which is what makes `IsPresent` usable as the first test in an `And`.
+ */
+export function dataTest(
+  name: string,
+  describes: (variable: JSONValue | undefined) => boolean,
+): SimStatesComparison {
+  return new SimStatesComparison({
+    name,
+    operandType: "boolean",
+    needsValue: false,
+    operandIsPath: false,
+    holds: (variable, operand): boolean => describes(variable) === operand,
+  });
+}

--- a/src/service/stepfunctions/choice/sim-states-comparison-parse.ts
+++ b/src/service/stepfunctions/choice/sim-states-comparison-parse.ts
@@ -1,0 +1,82 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { parseSimStatesReferencePath } from "../data/sim-states-reference-path.js";
+import { SimStatesInvalidDefinition } from "../error/sim-step-functions.error.js";
+import {
+  type SimStatesChoiceOperand,
+  SimStatesLiteralOperand,
+  SimStatesPathOperand,
+} from "./sim-states-choice-operand.js";
+import {
+  type SimStatesChoiceTest,
+  SimStatesVariableTest,
+} from "./sim-states-choice-test.js";
+import type { SimStatesComparison } from "./sim-states-comparison.js";
+
+interface SimStatesComparisonTestProperties {
+  readonly stateName: string;
+  readonly record: Record<string, JSONValue>;
+  readonly comparison: SimStatesComparison;
+  readonly written: JSONValue;
+}
+
+/**
+ * Read a comparison of the value at a `Variable` path against an operand.
+ */
+export function parseSimStatesComparisonTest(
+  properties: SimStatesComparisonTestProperties,
+): SimStatesChoiceTest {
+  const { stateName, record, comparison, written } = properties;
+  const variable = record["Variable"];
+
+  if (typeof variable !== "string") {
+    throw new SimStatesInvalidDefinition(
+      `A ${comparison.name} rule in the Choice state ${stateName} has no ` +
+        "Variable naming the value to compare.",
+    );
+  }
+
+  checkOperandType(stateName, comparison, written);
+
+  return new SimStatesVariableTest({
+    path: variable,
+    segments: parseSimStatesReferencePath(variable),
+    comparison,
+    operand: readOperand(comparison, written),
+  });
+}
+
+/**
+ * Read a comparator's operand, either as written or as a path to read it from.
+ */
+function readOperand(
+  comparison: SimStatesComparison,
+  written: JSONValue,
+): SimStatesChoiceOperand {
+  if (typeof written === "string" && comparison.operandIsPath) {
+    return new SimStatesPathOperand(
+      written,
+      parseSimStatesReferencePath(written),
+    );
+  }
+
+  return new SimStatesLiteralOperand(written);
+}
+
+/**
+ * Check that a comparator's operand is the kind of value it compares.
+ */
+function checkOperandType(
+  stateName: string,
+  comparison: SimStatesComparison,
+  written: JSONValue,
+): void {
+  if (typeof written === comparison.operandType) {
+    return;
+  }
+
+  throw new SimStatesInvalidDefinition(
+    `A ${comparison.name} rule in the Choice state ${stateName} compares ` +
+      `against ${JSON.stringify(written)}, and ${comparison.name} takes a ` +
+      `${comparison.operandType}.`,
+  );
+}

--- a/src/service/stepfunctions/choice/sim-states-comparison.ts
+++ b/src/service/stepfunctions/choice/sim-states-comparison.ts
@@ -1,0 +1,74 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+
+/**
+ * What the definition writes as a comparator's operand.
+ */
+export type SimStatesOperandType = "string" | "number" | "boolean";
+
+interface SimStatesComparisonProperties {
+  readonly name: string;
+  readonly operandType: SimStatesOperandType;
+  readonly needsValue: boolean;
+  readonly operandIsPath: boolean;
+  readonly holds: SimStatesComparisonHolds;
+}
+
+export type SimStatesComparisonHolds = (
+  variable: JSONValue | undefined,
+  operand: JSONValue,
+) => boolean;
+
+/**
+ * One `Choice` comparator, such as `NumericGreaterThan`.
+ *
+ * A comparator knows what its operand has to be, so a definition writing the
+ * wrong kind is refused when the state machine is created rather than
+ * answering false at every rule it appears in.
+ */
+export class SimStatesComparison {
+  readonly name: string;
+  readonly operandType: SimStatesOperandType;
+  /**
+   * Whether the rule's `Variable` has to select something.
+   *
+   * The data-test comparators, `IsPresent` and its siblings, are the ones that
+   * answer for a field that is not there. Every other comparator fails the
+   * execution instead, as real Step Functions does.
+   */
+  readonly needsValue: boolean;
+  /** Whether the operand is a Reference Path into the state's input. */
+  readonly operandIsPath: boolean;
+
+  readonly #holds: SimStatesComparisonHolds;
+
+  constructor(properties: SimStatesComparisonProperties) {
+    this.name = properties.name;
+    this.operandType = properties.operandType;
+    this.needsValue = properties.needsValue;
+    this.operandIsPath = properties.operandIsPath;
+    this.#holds = properties.holds;
+  }
+
+  /**
+   * Whether the value at the rule's `Variable` compares as the rule asks.
+   */
+  holds(variable: JSONValue | undefined, operand: JSONValue): boolean {
+    return this.#holds(variable, operand);
+  }
+
+  /**
+   * The same comparator with its operand read from the state's input.
+   *
+   * Every comparator taking an operand has a `Path` twin, which compares two
+   * places in the same document instead of a place and a literal.
+   */
+  readingItsOperandFromAPath(): SimStatesComparison {
+    return new SimStatesComparison({
+      name: `${this.name}Path`,
+      operandType: "string",
+      needsValue: this.needsValue,
+      operandIsPath: true,
+      holds: this.#holds,
+    });
+  }
+}

--- a/src/service/stepfunctions/choice/sim-states-comparisons.ts
+++ b/src/service/stepfunctions/choice/sim-states-comparisons.ts
@@ -1,0 +1,71 @@
+import { readSimStatesTimestamp } from "../data/sim-states-timestamp.js";
+import { SimStatesComparison } from "./sim-states-comparison.js";
+import {
+  dataTest,
+  orderedComparisons,
+  readNumber,
+  readString,
+} from "./sim-states-comparison-families.js";
+import { simStatesGlobMatches } from "./sim-states-glob.js";
+
+/**
+ * Every comparator a `Choice` rule can be written with.
+ */
+function allComparisons(): SimStatesComparison[] {
+  const compared = [
+    ...orderedComparisons("String", "string", readString),
+    ...orderedComparisons("Numeric", "number", readNumber),
+    ...orderedComparisons("Timestamp", "string", readSimStatesTimestamp),
+    new SimStatesComparison({
+      name: "BooleanEquals",
+      operandType: "boolean",
+      needsValue: true,
+      operandIsPath: false,
+      holds: (variable, operand): boolean =>
+        typeof variable === "boolean" && variable === operand,
+    }),
+    new SimStatesComparison({
+      name: "StringMatches",
+      operandType: "string",
+      needsValue: true,
+      operandIsPath: false,
+      holds: (variable, operand): boolean => {
+        const value = readString(variable);
+        const pattern = readString(operand);
+
+        if (value === undefined || pattern === undefined) {
+          return false;
+        }
+
+        return simStatesGlobMatches(pattern, value);
+      },
+    }),
+  ];
+
+  return [
+    ...compared,
+    ...compared.map((comparison) => comparison.readingItsOperandFromAPath()),
+    dataTest("IsPresent", (variable) => variable !== undefined),
+    dataTest("IsNull", (variable) => variable === null),
+    dataTest("IsBoolean", (variable) => typeof variable === "boolean"),
+    dataTest("IsNumeric", (variable) => typeof variable === "number"),
+    dataTest("IsString", (variable) => typeof variable === "string"),
+    dataTest(
+      "IsTimestamp",
+      (variable) => readSimStatesTimestamp(variable) !== undefined,
+    ),
+  ];
+}
+
+const comparisons = new Map<string, SimStatesComparison>(
+  allComparisons().map((comparison) => [comparison.name, comparison]),
+);
+
+/**
+ * The comparator of a name, or nothing where no comparator has it.
+ */
+export function findSimStatesComparison(
+  name: string,
+): SimStatesComparison | undefined {
+  return comparisons.get(name);
+}

--- a/src/service/stepfunctions/choice/sim-states-comparisons.ts
+++ b/src/service/stepfunctions/choice/sim-states-comparisons.ts
@@ -9,42 +9,55 @@ import {
 import { simStatesGlobMatches } from "./sim-states-glob.js";
 
 /**
+ * `StringMatches`, which is the one comparator taking a wildcard pattern.
+ *
+ * Amazon States Language gives it no `Path` twin, so neither does this.
+ */
+const stringMatches = new SimStatesComparison({
+  name: "StringMatches",
+  operandType: "string",
+  needsValue: true,
+  operandIsPath: false,
+  holds: (variable, operand): boolean => {
+    const value = readString(variable);
+    const pattern = readString(operand);
+
+    if (value === undefined || pattern === undefined) {
+      return false;
+    }
+
+    return simStatesGlobMatches(pattern, value);
+  },
+});
+
+const booleanEquals = new SimStatesComparison({
+  name: "BooleanEquals",
+  operandType: "boolean",
+  needsValue: true,
+  operandIsPath: false,
+  holds: (variable, operand): boolean =>
+    typeof variable === "boolean" && variable === operand,
+});
+
+/**
  * Every comparator a `Choice` rule can be written with.
+ *
+ * Each comparator taking an operand has a `Path` twin reading that operand
+ * from the state's input. The data tests take a boolean the definition writes
+ * out, and have none.
  */
 function allComparisons(): SimStatesComparison[] {
   const compared = [
     ...orderedComparisons("String", "string", readString),
     ...orderedComparisons("Numeric", "number", readNumber),
     ...orderedComparisons("Timestamp", "string", readSimStatesTimestamp),
-    new SimStatesComparison({
-      name: "BooleanEquals",
-      operandType: "boolean",
-      needsValue: true,
-      operandIsPath: false,
-      holds: (variable, operand): boolean =>
-        typeof variable === "boolean" && variable === operand,
-    }),
-    new SimStatesComparison({
-      name: "StringMatches",
-      operandType: "string",
-      needsValue: true,
-      operandIsPath: false,
-      holds: (variable, operand): boolean => {
-        const value = readString(variable);
-        const pattern = readString(operand);
-
-        if (value === undefined || pattern === undefined) {
-          return false;
-        }
-
-        return simStatesGlobMatches(pattern, value);
-      },
-    }),
+    booleanEquals,
   ];
 
   return [
     ...compared,
     ...compared.map((comparison) => comparison.readingItsOperandFromAPath()),
+    stringMatches,
     dataTest("IsPresent", (variable) => variable !== undefined),
     dataTest("IsNull", (variable) => variable === null),
     dataTest("IsBoolean", (variable) => typeof variable === "boolean"),

--- a/src/service/stepfunctions/choice/sim-states-glob.ts
+++ b/src/service/stepfunctions/choice/sim-states-glob.ts
@@ -1,0 +1,96 @@
+/**
+ * One step of a pattern, either the wildcard or a character to match.
+ */
+type SimStatesGlobToken =
+  | { readonly wildcard: true }
+  | { readonly char: string };
+
+const wildcard: SimStatesGlobToken = { wildcard: true };
+
+/**
+ * Whether a string matches a `StringMatches` pattern.
+ *
+ * The pattern language is the one Amazon States Language defines for
+ * `StringMatches`. `*` stands for any run of characters, and a backslash
+ * escapes the character after it, so `\*` is a literal asterisk and `\\` a
+ * literal backslash.
+ *
+ * The match is done by walking both strings. A pattern comes out of a state
+ * machine definition, and turning one into a regular expression would put the
+ * definition's author in charge of how long the match takes.
+ */
+export function simStatesGlobMatches(pattern: string, value: string): boolean {
+  return matchTokens(readGlobTokens(pattern), value);
+}
+
+/**
+ * Split a pattern into the steps it is made of, resolving its escapes.
+ */
+function readGlobTokens(pattern: string): readonly SimStatesGlobToken[] {
+  const tokens: SimStatesGlobToken[] = [];
+
+  for (let index = 0; index < pattern.length; index++) {
+    const character = pattern.charAt(index);
+
+    if (character === "\\" && index + 1 < pattern.length) {
+      index += 1;
+      tokens.push({ char: pattern.charAt(index) });
+      continue;
+    }
+
+    if (character === "*") {
+      tokens.push(wildcard);
+      continue;
+    }
+
+    // A trailing backslash escapes nothing and stands for itself.
+    tokens.push({ char: character });
+  }
+
+  return tokens;
+}
+
+/**
+ * Match the tokens against a value, backtracking to the last wildcard.
+ *
+ * Each wildcard remembers where it started matching. Where the rest of the
+ * pattern then fails, that wildcard takes one more character and the match
+ * carries on from there, which is the whole of the backtracking this pattern
+ * language needs.
+ */
+function matchTokens(
+  tokens: readonly SimStatesGlobToken[],
+  value: string,
+): boolean {
+  let token = 0;
+  let character = 0;
+  let lastWildcard = -1;
+  let resumeAt = 0;
+
+  while (character < value.length) {
+    const current = tokens.at(token);
+
+    if (current !== undefined && "wildcard" in current) {
+      lastWildcard = token;
+      resumeAt = character;
+      token += 1;
+      continue;
+    }
+
+    if (current !== undefined && current.char === value.charAt(character)) {
+      token += 1;
+      character += 1;
+      continue;
+    }
+
+    if (lastWildcard === -1) {
+      return false;
+    }
+
+    token = lastWildcard + 1;
+    resumeAt += 1;
+    character = resumeAt;
+  }
+
+  return tokens.slice(token).every((rest) => "wildcard" in rest);
+}

--- a/src/service/stepfunctions/command/execution/sim-states-execution-repeat.ts
+++ b/src/service/stepfunctions/command/execution/sim-states-execution-repeat.ts
@@ -1,0 +1,32 @@
+import { SimStatesExecutionAlreadyExists } from "../../error/sim-step-functions.error.js";
+import type { SimStatesExecution } from "../../execution/sim-states-execution.js";
+import type { SimStartExecutionCommandOutput } from "./execution.command.js";
+import { readSimStatesExecutionInput } from "./sim-states-execution-view.js";
+
+/**
+ * Answer a start that names an execution already there.
+ *
+ * `StartExecution` on a Standard workflow is idempotent. A repeat naming an
+ * execution that is still running, and carrying the same input, answers with
+ * that execution's own response. A repeat naming one that has finished, or
+ * carrying different input, is a name collision.
+ */
+export function answerSimStatesRepeatedStart(
+  already: SimStatesExecution,
+  stateMachineName: string,
+  input: string | undefined,
+): SimStartExecutionCommandOutput {
+  const sameInput =
+    JSON.stringify(already.input) ===
+    JSON.stringify(readSimStatesExecutionInput(input));
+
+  if (sameInput && already.status === "RUNNING") {
+    return { executionArn: already.arn, startDate: already.startDate };
+  }
+
+  throw new SimStatesExecutionAlreadyExists(
+    `${stateMachineName} already has an execution called ${already.name}. ` +
+      "A repeat is answered with the execution already there only while it " +
+      "is still running on the same input.",
+  );
+}

--- a/src/service/stepfunctions/command/execution/sim-states-execution-start.ts
+++ b/src/service/stepfunctions/command/execution/sim-states-execution-start.ts
@@ -1,6 +1,5 @@
 import type { BackgroundScheduler } from "../../../../util/background/background.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
-import { SimStatesExecutionAlreadyExists } from "../../error/sim-step-functions.error.js";
 import { SimStatesExecution } from "../../execution/sim-states-execution.js";
 import type { SimStatesExecutionStore } from "../../execution/sim-states-execution-store.js";
 import { SimStatesInterpreter } from "../../execution/sim-states-interpreter.js";
@@ -12,6 +11,7 @@ import type {
   SimStartExecutionCommandOutput,
 } from "./execution.command.js";
 import { chooseSimStatesExecutionName } from "./sim-states-execution-name.js";
+import { answerSimStatesRepeatedStart } from "./sim-states-execution-repeat.js";
 import { readSimStatesExecutionInput } from "./sim-states-execution-view.js";
 
 interface SimStatesExecutionStartProperties {
@@ -65,10 +65,13 @@ export class SimStatesExecutionStart {
       name,
     );
 
-    if (this.#executions.hasName(stateMachine.arn, executionName)) {
-      throw new SimStatesExecutionAlreadyExists(
-        `${stateMachine.name} already has an execution called ${executionName}.`,
-      );
+    const already = this.#executions.findByName(
+      stateMachine.arn,
+      executionName,
+    );
+
+    if (already !== undefined) {
+      return answerSimStatesRepeatedStart(already, stateMachine.name, input);
     }
 
     const startDate = this.#background.now();

--- a/src/service/stepfunctions/data/sim-states-timestamp-fields.ts
+++ b/src/service/stepfunctions/data/sim-states-timestamp-fields.ts
@@ -1,0 +1,65 @@
+const monthLengths = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+const februaryInALeapYear = 29;
+
+/**
+ * Whether the fields a timestamp was written with name a real instant.
+ *
+ * A pattern can only say how many digits each field has. JavaScript's own
+ * parser rolls a day past the end of its month into the next one, so
+ * `2026-02-30T00:00:00Z` would otherwise be read as the second of March, and
+ * `2024-02-29T24:00:00Z` as midnight the next day.
+ */
+export function simStatesTimestampFieldsHold(
+  fields: readonly (string | undefined)[],
+): boolean {
+  const [
+    year = 0,
+    month = 0,
+    day = 0,
+    hour = 0,
+    minute = 0,
+    second = 0,
+    offsetHour = 0,
+    offsetMinute = 0,
+  ] = fields.map(readField);
+
+  return (
+    isWithin(month, 1, 12) &&
+    isWithin(day, 1, daysInMonth(year, month)) &&
+    isWithin(hour, 0, 23) &&
+    isWithin(minute, 0, 59) &&
+    isWithin(second, 0, 59) &&
+    isWithin(offsetHour, 0, 23) &&
+    isWithin(offsetMinute, 0, 59)
+  );
+}
+
+/**
+ * Read one field, taking one the timestamp left out as a zero.
+ *
+ * A timestamp written in UTC carries no offset, and no offset is no hours and
+ * no minutes away from it.
+ */
+function readField(written: string | undefined): number {
+  return Number(written ?? 0);
+}
+
+function isWithin(value: number, least: number, most: number): boolean {
+  return value >= least && value <= most;
+}
+
+/**
+ * How many days a month has, counting the leap day where the year has one.
+ */
+function daysInMonth(year: number, month: number): number {
+  if (month === 2 && isALeapYear(year)) {
+    return februaryInALeapYear;
+  }
+
+  return monthLengths.at(month - 1) ?? 0;
+}
+
+function isALeapYear(year: number): boolean {
+  return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+}

--- a/src/service/stepfunctions/data/sim-states-timestamp.ts
+++ b/src/service/stepfunctions/data/sim-states-timestamp.ts
@@ -1,4 +1,5 @@
 import type { JSONValue } from "../../../util/type-guard/json.js";
+import { simStatesTimestampFieldsHold } from "./sim-states-timestamp-fields.js";
 
 // RFC3339, which is the timestamp format Amazon States Language names. The
 // looser formats Date.parse accepts are left out, so a plain "2026-07-26" is
@@ -6,7 +7,7 @@ import type { JSONValue } from "../../../util/type-guard/json.js";
 // guessing at midnight in some zone.
 const rfc3339 =
   // oxlint-disable-next-line security/detect-unsafe-regex -- no nested quantifier.
-  /^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[Zz]|[+-]\d{2}:\d{2})$/;
+  /^(\d{4})-(\d{2})-(\d{2})[Tt](\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:[Zz]|[+-](\d{2}):(\d{2}))$/;
 
 /**
  * Read a JSON value as an RFC3339 timestamp, in milliseconds since the epoch.
@@ -18,15 +19,15 @@ const rfc3339 =
 export function readSimStatesTimestamp(
   value: JSONValue | undefined,
 ): number | undefined {
-  if (typeof value !== "string" || !rfc3339.test(value)) {
+  if (typeof value !== "string") {
     return undefined;
   }
 
-  const milliseconds = Date.parse(value);
+  const written = rfc3339.exec(value);
 
-  if (Number.isNaN(milliseconds)) {
+  if (written === null || !simStatesTimestampFieldsHold(written.slice(1))) {
     return undefined;
   }
 
-  return milliseconds;
+  return Date.parse(value);
 }

--- a/src/service/stepfunctions/data/sim-states-timestamp.ts
+++ b/src/service/stepfunctions/data/sim-states-timestamp.ts
@@ -1,0 +1,32 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+
+// RFC3339, which is the timestamp format Amazon States Language names. The
+// looser formats Date.parse accepts are left out, so a plain "2026-07-26" is
+// not a timestamp here and a comparison against one answers false rather than
+// guessing at midnight in some zone.
+const rfc3339 =
+  // oxlint-disable-next-line security/detect-unsafe-regex -- no nested quantifier.
+  /^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[Zz]|[+-]\d{2}:\d{2})$/;
+
+/**
+ * Read a JSON value as an RFC3339 timestamp, in milliseconds since the epoch.
+ *
+ * Answers undefined for anything that is not one, which is what lets a
+ * timestamp comparison and `IsTimestamp` tell a timestamp from a string that
+ * merely looks like a date.
+ */
+export function readSimStatesTimestamp(
+  value: JSONValue | undefined,
+): number | undefined {
+  if (typeof value !== "string" || !rfc3339.test(value)) {
+    return undefined;
+  }
+
+  const milliseconds = Date.parse(value);
+
+  if (Number.isNaN(milliseconds)) {
+    return undefined;
+  }
+
+  return milliseconds;
+}

--- a/src/service/stepfunctions/definition/sim-states-definition-refusals.iso.test.ts
+++ b/src/service/stepfunctions/definition/sim-states-definition-refusals.iso.test.ts
@@ -108,4 +108,16 @@ describe("Step Functions definition refusals", () => {
       "End that is not a boolean",
     );
   });
+
+  it("refuses a Next that is not a state name", () => {
+    // Given a Pass state whose Next is a number.
+    // When it is read, it is refused as it was written.
+    assertStringIncludes(
+      refusalFor({
+        StartAt: "Only",
+        States: { Only: { Type: "Pass", Next: 2 } },
+      }),
+      "Next that is not a state name",
+    );
+  });
 });

--- a/src/service/stepfunctions/definition/sim-states-state-parse.ts
+++ b/src/service/stepfunctions/definition/sim-states-state-parse.ts
@@ -1,10 +1,16 @@
 import type { JSONValue } from "../../../util/type-guard/json.js";
 import { isRecord } from "../../../util/type-guard/record.js";
 import {
+  checkSimStatesChoiceDefault,
+  parseSimStatesChoices,
+} from "../choice/sim-states-choice-parse.js";
+import {
   SimStatesInvalidDefinition,
   SimStatesUnsimulatedInput,
 } from "../error/sim-step-functions.error.js";
+import { checkSimStatesWaitFields } from "../wait/sim-states-wait-fields.js";
 import {
+  type SimStatesChoiceState,
   type SimStatesState,
   simStatesRunnableTypes,
   simStatesStateTypes,
@@ -18,6 +24,10 @@ const stateFieldsRefused = new Map<string, readonly string[]>([
     ["InputPath", "OutputPath", "Parameters", "ResultPath", "ResultSelector"],
   ],
   ["Succeed", ["Parameters", "ResultPath", "ResultSelector"]],
+  // A Choice state and a Wait state produce no result of their own, so they
+  // carry the two paths and nothing that reshapes a result.
+  ["Choice", ["Parameters", "ResultPath", "ResultSelector"]],
+  ["Wait", ["Parameters", "ResultPath", "ResultSelector"]],
 ]);
 
 /**
@@ -54,7 +64,33 @@ export function parseSimStatesState(
   checkRefusedFields(name, type, state);
   checkTransitionFields(name, state);
 
+  if (type === "Choice") {
+    return readChoiceState(name, state);
+  }
+
+  if (type === "Wait") {
+    checkSimStatesWaitFields(name, state);
+  }
+
   return state as unknown as SimStatesState;
+}
+
+/**
+ * Read a `Choice` state, whose rules are checked and built as it is read.
+ *
+ * The rules become the objects the state tests its input with, so a `Choice`
+ * state that runs has already had its comparators, paths and operands read.
+ */
+function readChoiceState(
+  name: string,
+  state: Record<string, JSONValue>,
+): SimStatesChoiceState {
+  checkSimStatesChoiceDefault(name, state);
+
+  return {
+    ...(state as unknown as SimStatesChoiceState),
+    Choices: parseSimStatesChoices(name, state),
+  };
 }
 
 /**

--- a/src/service/stepfunctions/definition/sim-states-state-refusals.iso.test.ts
+++ b/src/service/stepfunctions/definition/sim-states-state-refusals.iso.test.ts
@@ -39,14 +39,14 @@ describe("Step Functions state refusals", () => {
   it("refuses a state type this simulator does not run yet, by name", () => {
     // Given the state types still to come.
     // When each is read, each names itself and what does run.
-    for (const type of ["Task", "Choice", "Wait", "Parallel", "Map"]) {
+    for (const type of ["Task", "Parallel", "Map"]) {
       const refusal = refusalFor({
         StartAt: "Only",
         States: { Only: { Type: type, End: true } },
       });
 
       assertStringIncludes(refusal, `is a ${type} state`);
-      assertStringIncludes(refusal, "Pass, Succeed, Fail");
+      assertStringIncludes(refusal, "Pass, Succeed, Fail, Choice, Wait");
     }
   });
 

--- a/src/service/stepfunctions/definition/sim-states-state.ts
+++ b/src/service/stepfunctions/definition/sim-states-state.ts
@@ -1,4 +1,5 @@
 import type { JSONValue } from "../../../util/type-guard/json.js";
+import type { SimStatesChoiceRule } from "../choice/sim-states-choice-rule.js";
 import type { SimStatesDataFlowFields } from "../data/sim-states-data-flow.js";
 
 /**
@@ -23,7 +24,13 @@ export type SimStatesStateType = (typeof simStatesStateTypes)[number];
 /**
  * The state types this simulator runs.
  */
-export const simStatesRunnableTypes = ["Pass", "Succeed", "Fail"] as const;
+export const simStatesRunnableTypes = [
+  "Pass",
+  "Succeed",
+  "Fail",
+  "Choice",
+  "Wait",
+] as const;
 
 export type SimStatesRunnableType = (typeof simStatesRunnableTypes)[number];
 
@@ -52,6 +59,37 @@ export interface SimStatesSucceedState extends SimStatesCommonState {
 }
 
 /**
+ * A `Choice` state, which picks where the execution goes by testing its input.
+ *
+ * A `Choice` state has no result of its own, so it carries the two paths and
+ * none of the other data-flow fields.
+ */
+export interface SimStatesChoiceState {
+  readonly Type: "Choice";
+  readonly Comment?: string;
+  readonly InputPath?: string | null;
+  readonly OutputPath?: string | null;
+  readonly Choices: readonly SimStatesChoiceRule[];
+  readonly Default?: string;
+}
+
+/**
+ * A `Wait` state, which holds the execution until an instant on the clock.
+ */
+export interface SimStatesWaitState {
+  readonly Type: "Wait";
+  readonly Comment?: string;
+  readonly InputPath?: string | null;
+  readonly OutputPath?: string | null;
+  readonly Next?: string;
+  readonly End?: boolean;
+  readonly Seconds?: number;
+  readonly SecondsPath?: string;
+  readonly Timestamp?: string;
+  readonly TimestampPath?: string;
+}
+
+/**
  * A `Fail` state, which ends an execution with an error.
  *
  * Real Step Functions gives `Fail` no input or output processing, so the
@@ -67,7 +105,9 @@ export interface SimStatesFailState {
 export type SimStatesState =
   | SimStatesPassState
   | SimStatesSucceedState
-  | SimStatesFailState;
+  | SimStatesFailState
+  | SimStatesChoiceState
+  | SimStatesWaitState;
 
 /**
  * Whether a state ends the execution when it is reached.

--- a/src/service/stepfunctions/definition/sim-states-transitions.ts
+++ b/src/service/stepfunctions/definition/sim-states-transitions.ts
@@ -1,5 +1,6 @@
 import { SimStatesInvalidDefinition } from "../error/sim-step-functions.error.js";
 import {
+  type SimStatesChoiceState,
   type SimStatesState,
   isSimStatesTerminal,
 } from "./sim-states-state.js";
@@ -17,6 +18,11 @@ export function checkSimStatesTransitions(
   for (const [name, state] of states) {
     if (isSimStatesTerminal(state)) {
       checkTerminal(name, state);
+      continue;
+    }
+
+    if (state.Type === "Choice") {
+      checkChoice(name, state, states);
       continue;
     }
 
@@ -68,6 +74,44 @@ function checkTransition(
     throw new SimStatesInvalidDefinition(
       `The state ${name} moves to ${next}, which is not one of this state ` +
         "machine's states.",
+    );
+  }
+}
+
+/**
+ * A `Choice` state moves on through its rules rather than through `Next`.
+ *
+ * Amazon States Language gives a `Choice` state neither `Next` nor `End` of
+ * its own. Every rule names where a match goes, and `Default` names where the
+ * execution goes when no rule holds.
+ */
+function checkChoice(
+  name: string,
+  state: SimStatesChoiceState,
+  states: ReadonlyMap<string, SimStatesState>,
+): void {
+  for (const field of ["Next", "End"]) {
+    if (Object.hasOwn(state, field)) {
+      throw new SimStatesInvalidDefinition(
+        `The Choice state ${name} carries ${field}. A Choice state moves on ` +
+          "through its Choices and its Default, and carries neither.",
+      );
+    }
+  }
+
+  for (const rule of state.Choices) {
+    if (!states.has(rule.next)) {
+      throw new SimStatesInvalidDefinition(
+        `A rule in the Choice state ${name} moves to ${rule.next}, which is ` +
+          "not one of this state machine's states.",
+      );
+    }
+  }
+
+  if (state.Default !== undefined && !states.has(state.Default)) {
+    throw new SimStatesInvalidDefinition(
+      `The Choice state ${name} has a Default of ${state.Default}, which is ` +
+        "not one of this state machine's states.",
     );
   }
 }

--- a/src/service/stepfunctions/error/sim-step-functions.error.ts
+++ b/src/service/stepfunctions/error/sim-step-functions.error.ts
@@ -66,6 +66,32 @@ export class SimStatesIntrinsicFailure extends SimStepFunctionsError {
 }
 
 /**
+ * A `Choice` state none of whose rules matched, where it carries no `Default`.
+ */
+export class SimStatesNoChoiceMatched extends SimStepFunctionsError {
+  public override readonly name = "SimStatesNoChoiceMatched";
+
+  constructor(message: string) {
+    super(message, "States.NoChoiceMatched");
+  }
+}
+
+/**
+ * A state that could not run on the data it was given.
+ *
+ * A `Choice` rule comparing a field that is not there, or a `Wait` reading a
+ * duration from a path holding something else. Real Step Functions fails the
+ * execution with `States.Runtime` for both.
+ */
+export class SimStatesRuntimeFailure extends SimStepFunctionsError {
+  public override readonly name = "SimStatesRuntimeFailure";
+
+  constructor(message: string) {
+    super(message, "States.Runtime");
+  }
+}
+
+/**
  * A state machine definition that Amazon States Language itself refuses.
  *
  * A malformed definition, a state type that does not exist, a transition to a

--- a/src/service/stepfunctions/execution/sim-states-execution-store.ts
+++ b/src/service/stepfunctions/execution/sim-states-execution-store.ts
@@ -30,19 +30,29 @@ export class SimStatesExecutionStore {
   }
 
   /**
-   * Whether one state machine already has an execution of this name.
+   * One state machine's execution of a name, where it has one.
    *
-   * Real Step Functions refuses a second execution of the same name within 90
-   * days, which is what makes a name usable for idempotency.
+   * Real Step Functions keeps a name taken for 90 days after the execution
+   * closes, which is what makes a name usable for idempotency.
    */
-  hasName(stateMachineArn: string, name: string): boolean {
+  findByName(
+    stateMachineArn: string,
+    name: string,
+  ): SimStatesExecution | undefined {
     return this.#byArn
       .values()
-      .some(
+      .find(
         (execution) =>
           execution.stateMachineArn === stateMachineArn &&
           execution.name === name,
       );
+  }
+
+  /**
+   * Whether one state machine already has an execution of this name.
+   */
+  hasName(stateMachineArn: string, name: string): boolean {
+    return this.findByName(stateMachineArn, name) !== undefined;
   }
 
   /**

--- a/src/service/stepfunctions/execution/sim-states-failure.ts
+++ b/src/service/stepfunctions/execution/sim-states-failure.ts
@@ -1,0 +1,58 @@
+import { SimStepFunctionsError } from "../error/sim-step-functions.error.js";
+import type { SimStatesSettledOutcome } from "./sim-states-state-outcome.js";
+
+/**
+ * Read the Amazon States Language error name off whatever was raised.
+ */
+export function simStatesFailureFrom(error: unknown): SimStatesSettledOutcome {
+  if (error instanceof SimStepFunctionsError) {
+    return {
+      kind: "fail",
+      error: error.statesErrorName,
+      cause: error.message,
+    };
+  }
+
+  return {
+    kind: "fail",
+    error: "States.Runtime",
+    cause: error instanceof Error ? error.message : String(error),
+  };
+}
+
+/**
+ * How many state transitions one execution may make.
+ *
+ * Amazon States Language allows a cycle, so a definition can be valid and
+ * still never reach a terminal state. Real Step Functions stops such an
+ * execution when it runs out of execution history events, and this stands in
+ * for that limit. Without it the walk never returns and `StartExecution` never
+ * answers, which is the one failure a test tool must not have.
+ */
+export const simStatesMaximumTransitions = 25_000;
+
+/**
+ * The failure an execution whose states form a cycle ends with.
+ */
+export function simStatesCycleFailure(): SimStatesSettledOutcome {
+  return {
+    kind: "fail",
+    error: "States.Runtime",
+    cause:
+      `The execution made ${String(simStatesMaximumTransitions)} ` +
+      "transitions without reaching a terminal state. Its states form a cycle.",
+  };
+}
+
+/**
+ * The failure a transition naming no state ends the execution with.
+ */
+export function simStatesUnknownStateFailure(
+  name: string,
+): SimStatesSettledOutcome {
+  return {
+    kind: "fail",
+    error: "States.Runtime",
+    cause: `The state ${name} is not one of this state machine's states.`,
+  };
+}

--- a/src/service/stepfunctions/execution/sim-states-interpreter.ts
+++ b/src/service/stepfunctions/execution/sim-states-interpreter.ts
@@ -1,20 +1,21 @@
 import type { BackgroundScheduler } from "../../../util/background/background.js";
 import type { JSONValue } from "../../../util/type-guard/json.js";
 import type { SimStatesDefinition } from "../definition/sim-states-definition.js";
-import { SimStepFunctionsError } from "../error/sim-step-functions.error.js";
+import type { SimStatesState } from "../definition/sim-states-state.js";
 import type { SimStatesExecution } from "./sim-states-execution.js";
+import {
+  simStatesCycleFailure,
+  simStatesFailureFrom,
+  simStatesMaximumTransitions,
+  simStatesUnknownStateFailure,
+} from "./sim-states-failure.js";
 import { runSimStatesState } from "./sim-states-run-state.js";
-
-/**
- * How many state transitions one execution may make.
- *
- * Amazon States Language allows a cycle, so a definition can be valid and
- * still never reach a terminal state. Real Step Functions stops such an
- * execution when it runs out of execution history events, and this stands in
- * for that limit. Without it the walk never returns and `StartExecution` never
- * answers, which is the one failure a test tool must not have.
- */
-const maximumTransitions = 25_000;
+import { SimStatesSettlement } from "./sim-states-settlement.js";
+import type {
+  SimStatesMoveOnOutcome,
+  SimStatesNextOutcome,
+  SimStatesStateOutcome,
+} from "./sim-states-state-outcome.js";
 
 interface SimStatesInterpreterProperties {
   readonly definition: SimStatesDefinition;
@@ -28,46 +29,54 @@ interface SimStatesInterpreterProperties {
  * The walk is a loop over a map of states, which is all Amazon States Language
  * asks for. Everything interesting happens either side of a state, in the
  * data-flow fields.
+ *
+ * A `Wait` state pauses the walk rather than blocking it. The rest of it is
+ * scheduled on the simulation's clock, so the execution stays `RUNNING` until
+ * something moves simulated time to the instant it is waiting for.
  */
 export class SimStatesInterpreter {
   readonly #definition: SimStatesDefinition;
   readonly #execution: SimStatesExecution;
   readonly #background: BackgroundScheduler;
+  readonly #settlement: SimStatesSettlement;
+
+  /**
+   * Transitions made so far, counted across the pauses a `Wait` state makes.
+   */
+  #taken = 0;
 
   constructor(properties: SimStatesInterpreterProperties) {
     this.#definition = properties.definition;
     this.#execution = properties.execution;
     this.#background = properties.background;
+    this.#settlement = new SimStatesSettlement({
+      execution: properties.execution,
+      background: properties.background,
+    });
   }
 
   /**
-   * Run the execution to whichever end it reaches.
+   * Run the execution as far as it goes without waiting on the clock.
    *
    * A failure ends the execution and is recorded on it. Nothing raises out of
    * here, since this runs where a caller advancing the clock would otherwise
    * see the raise.
    */
   async run(): Promise<void> {
-    let current = this.#definition.StartAt;
-    let value: JSONValue = this.#execution.input;
+    await this.#walk(this.#definition.StartAt, this.#execution.input);
+  }
 
-    for (let taken = 0; ; taken++) {
-      if (taken >= maximumTransitions) {
-        this.#fail(
-          "States.Runtime",
-          `The execution made ${String(maximumTransitions)} transitions ` +
-            "without reaching a terminal state. Its states form a cycle.",
-        );
-        return;
-      }
+  /**
+   * Walk from one state until the execution ends or a `Wait` pauses it.
+   */
+  async #walk(from: string, value: JSONValue): Promise<void> {
+    let current = from;
+    let carried = value;
 
-      const state = this.#definition.States.get(current);
+    for (;;) {
+      const state = this.#nextState(current);
 
       if (state === undefined) {
-        this.#fail(
-          "States.Runtime",
-          `The state ${current} is not one of this state machine's states.`,
-        );
         return;
       }
 
@@ -77,60 +86,91 @@ export class SimStatesInterpreter {
       // oxlint-disable-next-line eslint/no-await-in-loop
       await this.#background.sequence();
 
-      const outcome = this.#step(state, value);
+      const carrying = this.#resolve(this.#step(state, carried, current));
 
-      if (outcome.kind !== "next") {
+      if (carrying === undefined) {
         return;
       }
 
-      value = outcome.output;
-      current = outcome.next;
+      carried = carrying.output;
+      current = carrying.next;
     }
   }
 
   /**
-   * Run one state, recording whatever ends the execution.
+   * The state a name stands for, failing the execution where there is none.
+   */
+  #nextState(current: string): SimStatesState | undefined {
+    if (this.#taken++ >= simStatesMaximumTransitions) {
+      this.#settlement.settle(simStatesCycleFailure());
+      return undefined;
+    }
+
+    const state = this.#definition.States.get(current);
+
+    if (state === undefined) {
+      this.#settlement.settle(simStatesUnknownStateFailure(current));
+    }
+
+    return state;
+  }
+
+  /**
+   * Settle what a state left to do, or schedule the rest of the walk.
+   *
+   * Answers with the outcome the walk carries on from, and with nothing where
+   * the execution has ended or is waiting on the clock.
+   */
+  #resolve(outcome: SimStatesStateOutcome): SimStatesNextOutcome | undefined {
+    if (outcome.kind === "wait") {
+      return this.#wait(outcome.until, outcome.resume);
+    }
+
+    return this.#settlement.settle(outcome);
+  }
+
+  /**
+   * Hold the execution until the clock reaches an instant.
+   *
+   * An instant already reached holds nothing up, and the walk carries straight
+   * on. Anything later is scheduled, and the execution is left `RUNNING` until
+   * simulated time gets there. Under a frozen clock that is for as long as the
+   * test leaves it.
+   */
+  #wait(
+    until: Date,
+    resume: SimStatesMoveOnOutcome,
+  ): SimStatesNextOutcome | undefined {
+    if (until.getTime() <= this.#background.now().getTime()) {
+      return this.#settlement.settle(resume);
+    }
+
+    this.#background.scheduleAt(until, async () => {
+      const carrying = this.#settlement.settle(resume);
+
+      if (carrying !== undefined) {
+        await this.#walk(carrying.next, carrying.output);
+      }
+    });
+
+    return undefined;
+  }
+
+  /**
+   * Run one state, reading a failure off whatever it raised.
    */
   #step(
-    ...step: Parameters<typeof runSimStatesState>
-  ): ReturnType<typeof runSimStatesState> {
-    let outcome: ReturnType<typeof runSimStatesState>;
-
+    state: SimStatesState,
+    input: JSONValue,
+    stateName: string,
+  ): SimStatesStateOutcome {
     try {
-      outcome = runSimStatesState(...step);
+      return runSimStatesState(state, input, {
+        stateName,
+        now: this.#background.now(),
+      });
     } catch (error) {
-      outcome = this.#outcomeFrom(error);
+      return simStatesFailureFrom(error);
     }
-
-    if (outcome.kind === "succeed") {
-      this.#execution.succeed(outcome.output, this.#background.now());
-    } else if (outcome.kind === "fail") {
-      this.#fail(outcome.error, outcome.cause);
-    }
-
-    return outcome;
-  }
-
-  /**
-   * Read the Amazon States Language error name off whatever was raised.
-   */
-  #outcomeFrom(error: unknown): ReturnType<typeof runSimStatesState> {
-    if (error instanceof SimStepFunctionsError) {
-      return {
-        kind: "fail",
-        error: error.statesErrorName,
-        cause: error.message,
-      };
-    }
-
-    return {
-      kind: "fail",
-      error: "States.Runtime",
-      cause: error instanceof Error ? error.message : String(error),
-    };
-  }
-
-  #fail(error: string, cause: string | undefined): void {
-    this.#execution.fail(error, cause, this.#background.now());
   }
 }

--- a/src/service/stepfunctions/execution/sim-states-run-choice.ts
+++ b/src/service/stepfunctions/execution/sim-states-run-choice.ts
@@ -1,0 +1,41 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import {
+  simStatesEffectiveInput,
+  simStatesEffectiveOutput,
+} from "../data/sim-states-data-flow.js";
+import type { SimStatesChoiceState } from "../definition/sim-states-state.js";
+import { SimStatesNoChoiceMatched } from "../error/sim-step-functions.error.js";
+import type {
+  SimStatesStateContext,
+  SimStatesStateOutcome,
+} from "./sim-states-state-outcome.js";
+
+/**
+ * A `Choice` state, which takes the first rule its input matches.
+ *
+ * The rules are tested in the order they were written, which is what lets a
+ * definition put its narrower rule first. A `Choice` state produces no result,
+ * so what it passes on is its own input.
+ */
+export function runSimStatesChoice(
+  state: SimStatesChoiceState,
+  input: JSONValue,
+  context: SimStatesStateContext,
+): SimStatesStateOutcome {
+  const effective = simStatesEffectiveInput(input, state);
+  const matched = state.Choices.find((rule) => rule.matches(effective));
+  const next = matched?.next ?? state.Default;
+
+  if (next === undefined) {
+    throw new SimStatesNoChoiceMatched(
+      `The Choice state ${context.stateName} matched none of its rules and ` +
+        "carries no Default to fall back on.",
+    );
+  }
+
+  return {
+    kind: "next",
+    output: simStatesEffectiveOutput(effective, effective, state),
+    next,
+  };
+}

--- a/src/service/stepfunctions/execution/sim-states-run-state.ts
+++ b/src/service/stepfunctions/execution/sim-states-run-state.ts
@@ -9,23 +9,17 @@ import type {
   SimStatesState,
   SimStatesSucceedState,
 } from "../definition/sim-states-state.js";
+import { runSimStatesChoice } from "./sim-states-run-choice.js";
+import { runSimStatesWait } from "./sim-states-run-wait.js";
+import type {
+  SimStatesStateContext,
+  SimStatesStateOutcome,
+} from "./sim-states-state-outcome.js";
 
 /**
  * The default a `Fail` state reports when it names no error.
  */
 const unnamedFailError = "States.Unknown";
-
-/**
- * What running one state did to the execution.
- */
-export type SimStatesStateOutcome =
-  | { readonly kind: "next"; readonly output: JSONValue; readonly next: string }
-  | { readonly kind: "succeed"; readonly output: JSONValue }
-  | {
-      readonly kind: "fail";
-      readonly error: string;
-      readonly cause: string | undefined;
-    };
 
 /**
  * Run one state and say what happened.
@@ -36,6 +30,7 @@ export type SimStatesStateOutcome =
 export function runSimStatesState(
   state: SimStatesState,
   input: JSONValue,
+  context: SimStatesStateContext,
 ): SimStatesStateOutcome {
   if (state.Type === "Fail") {
     return runFail(state);
@@ -43,6 +38,14 @@ export function runSimStatesState(
 
   if (state.Type === "Succeed") {
     return runSucceed(state, input);
+  }
+
+  if (state.Type === "Choice") {
+    return runSimStatesChoice(state, input, context);
+  }
+
+  if (state.Type === "Wait") {
+    return runSimStatesWait(state, input, context);
   }
 
   return runPass(state, input);

--- a/src/service/stepfunctions/execution/sim-states-run-wait.ts
+++ b/src/service/stepfunctions/execution/sim-states-run-wait.ts
@@ -1,0 +1,37 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import {
+  simStatesEffectiveInput,
+  simStatesEffectiveOutput,
+} from "../data/sim-states-data-flow.js";
+import type { SimStatesWaitState } from "../definition/sim-states-state.js";
+import { simStatesWaitDue } from "../wait/sim-states-wait-due.js";
+import type {
+  SimStatesMoveOnOutcome,
+  SimStatesStateContext,
+  SimStatesStateOutcome,
+} from "./sim-states-state-outcome.js";
+
+/**
+ * A `Wait` state, which holds the execution until an instant on the clock.
+ *
+ * Like a `Choice` state it produces no result. What it passes on once the wait
+ * is over is its own input.
+ */
+export function runSimStatesWait(
+  state: SimStatesWaitState,
+  input: JSONValue,
+  context: SimStatesStateContext,
+): SimStatesStateOutcome {
+  const effective = simStatesEffectiveInput(input, state);
+  const output = simStatesEffectiveOutput(effective, effective, state);
+  const resume: SimStatesMoveOnOutcome =
+    state.Next === undefined
+      ? { kind: "succeed", output }
+      : { kind: "next", output, next: state.Next };
+
+  return {
+    kind: "wait",
+    until: simStatesWaitDue(state, effective, context.now),
+    resume,
+  };
+}

--- a/src/service/stepfunctions/execution/sim-states-settlement.ts
+++ b/src/service/stepfunctions/execution/sim-states-settlement.ts
@@ -1,0 +1,49 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimStatesExecution } from "./sim-states-execution.js";
+import type {
+  SimStatesNextOutcome,
+  SimStatesSettledOutcome,
+} from "./sim-states-state-outcome.js";
+
+interface SimStatesSettlementProperties {
+  readonly execution: SimStatesExecution;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * Records on one execution whatever its states leave it as.
+ *
+ * The interpreter walks the states and this holds what the walk did, which
+ * keeps the recording in one place for the walk and for a `Wait` state
+ * carrying on later.
+ */
+export class SimStatesSettlement {
+  readonly #execution: SimStatesExecution;
+  readonly #background: BackgroundScheduler;
+
+  constructor(properties: SimStatesSettlementProperties) {
+    this.#execution = properties.execution;
+    this.#background = properties.background;
+  }
+
+  /**
+   * Record what a state's outcome ended the execution with.
+   *
+   * Answers with the outcome the walk carries on from, and with nothing where
+   * the execution has ended.
+   */
+  settle(outcome: SimStatesSettledOutcome): SimStatesNextOutcome | undefined {
+    if (outcome.kind === "next") {
+      return outcome;
+    }
+
+    if (outcome.kind === "succeed") {
+      this.#execution.succeed(outcome.output, this.#background.now());
+      return undefined;
+    }
+
+    this.#execution.fail(outcome.error, outcome.cause, this.#background.now());
+
+    return undefined;
+  }
+}

--- a/src/service/stepfunctions/execution/sim-states-state-outcome.ts
+++ b/src/service/stepfunctions/execution/sim-states-state-outcome.ts
@@ -1,0 +1,44 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+
+/**
+ * What a state leaves the execution to do once it has run.
+ */
+export interface SimStatesNextOutcome {
+  readonly kind: "next";
+  readonly output: JSONValue;
+  readonly next: string;
+}
+
+export type SimStatesMoveOnOutcome =
+  | SimStatesNextOutcome
+  | { readonly kind: "succeed"; readonly output: JSONValue };
+
+/**
+ * What running one state did to the execution.
+ *
+ * A `wait` outcome carries what the execution does once the clock reaches the
+ * instant, which is either the next state or the end of the execution.
+ */
+export type SimStatesSettledOutcome =
+  | SimStatesMoveOnOutcome
+  | {
+      readonly kind: "fail";
+      readonly error: string;
+      readonly cause: string | undefined;
+    };
+
+export type SimStatesStateOutcome =
+  | SimStatesSettledOutcome
+  | {
+      readonly kind: "wait";
+      readonly until: Date;
+      readonly resume: SimStatesMoveOnOutcome;
+    };
+
+/**
+ * What a state knows about the execution it is running in.
+ */
+export interface SimStatesStateContext {
+  readonly stateName: string;
+  readonly now: Date;
+}

--- a/src/service/stepfunctions/index.ts
+++ b/src/service/stepfunctions/index.ts
@@ -18,19 +18,24 @@ export {
   simStatesStateTypes,
 } from "./definition/sim-states-state.js";
 export type {
+  SimStatesChoiceState,
   SimStatesState,
   SimStatesStateType,
+  SimStatesWaitState,
 } from "./definition/sim-states-state.js";
+export { SimStatesChoiceRule } from "./choice/sim-states-choice-rule.js";
 export {
   SimStateMachineAlreadyExists,
   SimStatesExecutionAlreadyExists,
   SimStatesIntrinsicFailure,
   SimStatesInvalidDefinition,
   SimStatesInvalidRequest,
+  SimStatesNoChoiceMatched,
   SimStatesPathError,
   SimStatesPathMatchFailure,
   SimStatesResourceNotFound,
   SimStatesResultPathMatchFailure,
+  SimStatesRuntimeFailure,
   SimStatesUnsimulatedInput,
   SimStepFunctionsError,
 } from "./error/sim-step-functions.error.js";

--- a/src/service/stepfunctions/sim-step-functions-choice.iso.test.ts
+++ b/src/service/stepfunctions/sim-step-functions-choice.iso.test.ts
@@ -1,0 +1,189 @@
+import { assertArrayEquals, assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../aws/sim-aws.js";
+import type { SimStepFunctions } from "./sim-step-functions.js";
+
+describe("Simulated Step Functions Choice states", () => {
+  /**
+   * Create a state machine from a definition written as an object.
+   */
+  async function givenAStateMachine(
+    stepFunctions: SimStepFunctions,
+    states: object,
+  ): Promise<string> {
+    const created = await stepFunctions.createStateMachine({
+      input: {
+        name: "Enrolment",
+        roleArn: "arn:aws:iam::123456789012:role/WorkflowRole",
+        definition: JSON.stringify({ StartAt: "Eligible", States: states }),
+      },
+    });
+
+    return created.stateMachineArn;
+  }
+
+  /**
+   * A state machine that branches on the term a student is in.
+   */
+  function branchingStates(fallback: object): object {
+    return {
+      Eligible: {
+        Type: "Choice",
+        Choices: [
+          {
+            And: [
+              { Variable: "$.term", IsPresent: true },
+              { Variable: "$.term", NumericGreaterThanEquals: 2 },
+            ],
+            Next: "Enrol",
+          },
+          { Variable: "$.student", StringEquals: "Wei", Next: "Enrol" },
+        ],
+        ...fallback,
+      },
+      Enrol: { Type: "Pass", Result: { enrolled: true }, End: true },
+      Decline: { Type: "Fail", Error: "NotEligible" },
+    };
+  }
+
+  it("takes the branch the first matching rule names", async () => {
+    // Given a state machine branching on the term a student is in.
+    const simAws = new SimAws();
+    const stateMachineArn = await givenAStateMachine(
+      simAws.stepFunctions(),
+      branchingStates({ Default: "Decline" }),
+    );
+
+    // When an execution runs on an input the first rule matches.
+    const started = await simAws.stepFunctions().startExecution({
+      input: { stateMachineArn, input: '{"student":"Li","term":3}' },
+    });
+
+    // Then it went to the state that rule names.
+    assertArrayEquals(
+      simAws.stepFunctions().inspection().visitedStates(started.executionArn),
+      ["Eligible", "Enrol"],
+    );
+  });
+
+  it("takes a later rule where the earlier one does not match", async () => {
+    // Given the same state machine, and a student in their first term.
+    const simAws = new SimAws();
+    const stateMachineArn = await givenAStateMachine(
+      simAws.stepFunctions(),
+      branchingStates({ Default: "Decline" }),
+    );
+
+    // When an execution runs on an input only the second rule matches.
+    const started = await simAws.stepFunctions().startExecution({
+      input: { stateMachineArn, input: '{"student":"Wei","term":1}' },
+    });
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn: started.executionArn } });
+
+    // Then the second rule took it, and the execution succeeded.
+    assertIdentical(described.status, "SUCCEEDED");
+    assertIdentical(described.output, '{"enrolled":true}');
+  });
+
+  it("takes the Default where no rule matches", async () => {
+    // Given the same state machine, with a Default to fall back on.
+    const simAws = new SimAws();
+    const stateMachineArn = await givenAStateMachine(
+      simAws.stepFunctions(),
+      branchingStates({ Default: "Decline" }),
+    );
+
+    // When an execution runs on an input no rule matches.
+    const started = await simAws.stepFunctions().startExecution({
+      input: { stateMachineArn, input: '{"student":"Li","term":1}' },
+    });
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn: started.executionArn } });
+
+    // Then it went to the Default and failed there.
+    assertIdentical(described.status, "FAILED");
+    assertIdentical(described.error, "NotEligible");
+  });
+
+  it("fails an execution that matches nothing and has no Default", async () => {
+    // Given a Choice state with no Default.
+    const simAws = new SimAws();
+    const stateMachineArn = await givenAStateMachine(
+      simAws.stepFunctions(),
+      branchingStates({}),
+    );
+
+    // When an execution runs on an input no rule matches.
+    const started = await simAws.stepFunctions().startExecution({
+      input: { stateMachineArn, input: '{"student":"Li","term":1}' },
+    });
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn: started.executionArn } });
+
+    // Then the execution failed with the name Amazon States Language gives it.
+    assertIdentical(described.status, "FAILED");
+    assertIdentical(described.error, "States.NoChoiceMatched");
+  });
+
+  it("tests the input its InputPath narrowed, and passes on its OutputPath", async () => {
+    // Given a Choice state reading one part of its input and passing on
+    // another.
+    const simAws = new SimAws();
+    const stateMachineArn = await givenAStateMachine(simAws.stepFunctions(), {
+      Eligible: {
+        Type: "Choice",
+        InputPath: "$.enrolment",
+        OutputPath: "$.student",
+        Choices: [{ Variable: "$.term", NumericEquals: 3, Next: "Enrol" }],
+        Default: "Decline",
+      },
+      Enrol: { Type: "Succeed" },
+      Decline: { Type: "Fail", Error: "NotEligible" },
+    });
+
+    // When an execution runs on an input holding both.
+    const started = await simAws.stepFunctions().startExecution({
+      input: {
+        stateMachineArn,
+        input: '{"enrolment":{"term":3,"student":"Wei"}}',
+      },
+    });
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn: started.executionArn } });
+
+    // Then the rule was tested against the narrowed input, and what came out
+    // was narrowed again on the way to the next state.
+    assertIdentical(described.status, "SUCCEEDED");
+    assertIdentical(described.output, '"Wei"');
+  });
+
+  it("fails an execution comparing a field its input has not got", async () => {
+    // Given a rule comparing a field with no IsPresent guarding it.
+    const simAws = new SimAws();
+    const stateMachineArn = await givenAStateMachine(simAws.stepFunctions(), {
+      Eligible: {
+        Type: "Choice",
+        Choices: [{ Variable: "$.term", NumericEquals: 3, Next: "Enrol" }],
+        Default: "Enrol",
+      },
+      Enrol: { Type: "Succeed" },
+    });
+
+    // When an execution runs on an input without it.
+    const started = await simAws.stepFunctions().startExecution({
+      input: { stateMachineArn, input: '{"student":"Wei"}' },
+    });
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn: started.executionArn } });
+
+    // Then the execution failed rather than falling through to the Default.
+    assertIdentical(described.status, "FAILED");
+    assertIdentical(described.error, "States.Runtime");
+  });
+});

--- a/src/service/stepfunctions/sim-step-functions-wait.iso.test.ts
+++ b/src/service/stepfunctions/sim-step-functions-wait.iso.test.ts
@@ -1,0 +1,263 @@
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimFixedClock } from "../../util/clock/sim-clock.js";
+import { SimAws } from "../aws/sim-aws.js";
+
+describe("Simulated Step Functions Wait states", () => {
+  const startedAt = "2026-07-26T09:00:00.000Z";
+
+  /**
+   * A simulation whose clock stands at a known instant, holding a state
+   * machine written as an object.
+   */
+  async function givenAStateMachine(
+    states: object,
+  ): Promise<{ readonly simAws: SimAws; readonly stateMachineArn: string }> {
+    const simAws = new SimAws({
+      clock: new SimFixedClock(new Date(startedAt)),
+    });
+    const created = await simAws.stepFunctions().createStateMachine({
+      input: {
+        name: "Enrolment",
+        roleArn: "arn:aws:iam::123456789012:role/WorkflowRole",
+        definition: JSON.stringify({ StartAt: "Hold", States: states }),
+      },
+    });
+
+    return { simAws, stateMachineArn: created.stateMachineArn };
+  }
+
+  it("holds an execution RUNNING for as long as the clock stands still", async () => {
+    // Given a state machine waiting five minutes.
+    const { simAws, stateMachineArn } = await givenAStateMachine({
+      Hold: { Type: "Wait", Seconds: 300, Next: "Done" },
+      Done: { Type: "Succeed" },
+    });
+
+    // When an execution is started and read back twice under a frozen clock.
+    const started = await simAws
+      .stepFunctions()
+      .startExecution({ input: { stateMachineArn, input: '{"term":3}' } });
+    const first = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn: started.executionArn } });
+    const second = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn: started.executionArn } });
+
+    // Then it is still waiting, however long the test itself takes.
+    assertIdentical(first.status, "RUNNING");
+    assertIdentical(second.status, "RUNNING");
+    assertArrayEquals(
+      simAws.stepFunctions().inspection().visitedStates(started.executionArn),
+      ["Hold"],
+    );
+  });
+
+  it("runs the rest of the execution once time reaches the wait", async () => {
+    // Given the same state machine, with an execution waiting on it.
+    const { simAws, stateMachineArn } = await givenAStateMachine({
+      Hold: { Type: "Wait", Seconds: 300, Next: "Done" },
+      Done: { Type: "Pass", Result: { enrolled: true }, End: true },
+    });
+    const started = await simAws
+      .stepFunctions()
+      .startExecution({ input: { stateMachineArn, input: '{"term":3}' } });
+
+    // When simulated time passes the instant it is waiting for.
+    await simAws.clock().advanceBy({ minutes: 6 });
+
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn: started.executionArn } });
+
+    // Then the execution finished, and it stopped at the instant the wait was
+    // over rather than at the instant the clock reached.
+    assertIdentical(described.status, "SUCCEEDED");
+    assertIdentical(described.output, '{"enrolled":true}');
+    assertIdentical(
+      described.stopDate?.toISOString(),
+      "2026-07-26T09:05:00.000Z",
+    );
+  });
+
+  it("waits again where the execution reaches a second Wait", async () => {
+    // Given a state machine waiting twice, reading the second wait from its
+    // input.
+    const { simAws, stateMachineArn } = await givenAStateMachine({
+      Hold: { Type: "Wait", Seconds: 60, Next: "HoldAgain" },
+      HoldAgain: { Type: "Wait", SecondsPath: "$.again", Next: "Done" },
+      Done: { Type: "Succeed" },
+    });
+    const started = await simAws
+      .stepFunctions()
+      .startExecution({ input: { stateMachineArn, input: '{"again":600}' } });
+
+    // When time passes the first wait but not the second.
+    await simAws.clock().advanceBy({ minutes: 2 });
+
+    const between = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn: started.executionArn } });
+
+    // Then it is waiting again, and moves on once time reaches that one too.
+    assertIdentical(between.status, "RUNNING");
+    assertArrayEquals(
+      simAws.stepFunctions().inspection().visitedStates(started.executionArn),
+      ["Hold", "HoldAgain"],
+    );
+
+    await simAws.clock().advanceBy({ minutes: 10 });
+
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn: started.executionArn } });
+
+    assertIdentical(described.status, "SUCCEEDED");
+  });
+
+  it("leaves advanceBy returning normally where the execution then fails", async () => {
+    // Given a state machine that waits and then fails.
+    const { simAws, stateMachineArn } = await givenAStateMachine({
+      Hold: { Type: "Wait", Timestamp: "2026-07-26T10:00:00Z", Next: "Give" },
+      Give: { Type: "Fail", Error: "NoPlaceLeft", Cause: "The term is full" },
+    });
+    const started = await simAws
+      .stepFunctions()
+      .startExecution({ input: { stateMachineArn } });
+
+    // When time passes the instant it is waiting for.
+    await simAws.clock().advanceBy({ hours: 2 });
+
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn: started.executionArn } });
+
+    // Then advancing the clock returned as it would for an execution that
+    // succeeded, and the failure is on the execution.
+    assertIdentical(described.status, "FAILED");
+    assertIdentical(described.error, "NoPlaceLeft");
+    assertIdentical(described.cause, "The term is full");
+  });
+
+  it("holds nothing up where the instant waited for has already passed", async () => {
+    // Given a Wait state whose Timestamp is behind the clock.
+    const { simAws, stateMachineArn } = await givenAStateMachine({
+      Hold: {
+        Type: "Wait",
+        TimestampPath: "$.closesAt",
+        Next: "Done",
+      },
+      Done: { Type: "Succeed" },
+    });
+
+    // When an execution runs.
+    const started = await simAws.stepFunctions().startExecution({
+      input: {
+        stateMachineArn,
+        input: '{"closesAt":"2026-07-26T08:00:00Z"}',
+      },
+    });
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn: started.executionArn } });
+
+    // Then it finished in the StartExecution call, with nothing to wait for.
+    assertIdentical(described.status, "SUCCEEDED");
+  });
+
+  it("ends the execution at a Wait state that carries End", async () => {
+    // Given a Wait state that is the last state in the machine.
+    const { simAws, stateMachineArn } = await givenAStateMachine({
+      Hold: { Type: "Wait", Seconds: 30, End: true },
+    });
+    const started = await simAws
+      .stepFunctions()
+      .startExecution({ input: { stateMachineArn, input: '{"term":3}' } });
+
+    // When time passes the wait.
+    await simAws.clock().advanceBy({ minutes: 1 });
+
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn: started.executionArn } });
+
+    // Then the execution ended there, carrying what reached the Wait state.
+    assertIdentical(described.status, "SUCCEEDED");
+    assertIdentical(described.output, '{"term":3}');
+  });
+
+  it("fails an execution whose wait path holds no duration", async () => {
+    // Given a Wait state reading its duration from the input.
+    const { simAws, stateMachineArn } = await givenAStateMachine({
+      Hold: { Type: "Wait", SecondsPath: "$.after", Next: "Done" },
+      Done: { Type: "Succeed" },
+    });
+
+    // When an execution runs on an input holding something else there.
+    const started = await simAws.stepFunctions().startExecution({
+      input: { stateMachineArn, input: '{"after":"soon"}' },
+    });
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn: started.executionArn } });
+
+    // Then the execution failed rather than waiting for an instant it could
+    // not work out.
+    assertIdentical(described.status, "FAILED");
+    assertIdentical(described.error, "States.Runtime");
+  });
+
+  it("answers a repeated start with the execution already running", async () => {
+    // Given a named execution that is waiting on the clock.
+    const { simAws, stateMachineArn } = await givenAStateMachine({
+      Hold: { Type: "Wait", Seconds: 300, Next: "Done" },
+      Done: { Type: "Succeed" },
+    });
+    const first = await simAws.stepFunctions().startExecution({
+      input: { stateMachineArn, name: "enrol-wei", input: '{"term":3}' },
+    });
+
+    // When the same start is made again.
+    const second = await simAws.stepFunctions().startExecution({
+      input: { stateMachineArn, name: "enrol-wei", input: '{"term":3}' },
+    });
+
+    // Then it answers with the execution already there rather than starting a
+    // second one.
+    assertIdentical(second.executionArn, first.executionArn);
+    assertArrayEquals(
+      simAws.stepFunctions().inspection().executionsOf(stateMachineArn),
+      [first.executionArn],
+    );
+  });
+
+  it("refuses a repeated start that carries different input", async () => {
+    // Given a named execution that is waiting on the clock.
+    const { simAws, stateMachineArn } = await givenAStateMachine({
+      Hold: { Type: "Wait", Seconds: 300, Next: "Done" },
+      Done: { Type: "Succeed" },
+    });
+
+    await simAws.stepFunctions().startExecution({
+      input: { stateMachineArn, name: "enrol-wei", input: '{"term":3}' },
+    });
+
+    // When a start of the same name carries something else.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.stepFunctions().startExecution({
+          input: { stateMachineArn, name: "enrol-wei", input: '{"term":1}' },
+        }),
+    );
+
+    // Then the name is taken, rather than the running execution being handed
+    // back for input it never ran on.
+    assertStringIncludes(error.message, "already has an execution");
+  });
+});

--- a/src/service/stepfunctions/wait/sim-states-wait-due.iso.test.ts
+++ b/src/service/stepfunctions/wait/sim-states-wait-due.iso.test.ts
@@ -75,6 +75,17 @@ describe("Step Functions Wait due instants", () => {
     assertStringIncludes(failure.message, '"30"');
   });
 
+  it("fails where the input holds a wait longer than one Step Functions takes", () => {
+    // Given an input holding more seconds than a Wait state can wait for.
+    // When the due instant is worked out.
+    const failure = assertThrowsError(() =>
+      dueFor({ SecondsPath: "$.after" }, { after: 100_000_000 }),
+    );
+
+    // Then the state fails, naming the range a wait falls in.
+    assertStringIncludes(failure.message, "between 0 and 99999999");
+  });
+
   it("fails where the input holds no instant to wait for", () => {
     // Given an input holding a date rather than a timestamp.
     // When the due instant is worked out.

--- a/src/service/stepfunctions/wait/sim-states-wait-due.iso.test.ts
+++ b/src/service/stepfunctions/wait/sim-states-wait-due.iso.test.ts
@@ -1,0 +1,98 @@
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import type { SimStatesWaitState } from "../definition/sim-states-state.js";
+import { simStatesWaitDue } from "./sim-states-wait-due.js";
+
+describe("Step Functions Wait due instants", () => {
+  const now = new Date("2026-07-26T09:00:00.000Z");
+
+  /**
+   * The instant a Wait state written this way waits for.
+   */
+  function dueFor(
+    waits: Partial<SimStatesWaitState>,
+    input: JSONValue,
+  ): string {
+    const state: SimStatesWaitState = { Type: "Wait", End: true, ...waits };
+
+    return simStatesWaitDue(state, input, now).toISOString();
+  }
+
+  it("waits a number of seconds from the instant it is reached", () => {
+    // Given a Wait state carrying Seconds.
+    // When its due instant is worked out.
+    // Then it is that many seconds on from now.
+    assertIdentical(dueFor({ Seconds: 90 }, {}), "2026-07-26T09:01:30.000Z");
+  });
+
+  it("waits until the instant a Timestamp names", () => {
+    // Given a Wait state carrying a Timestamp in another zone.
+    // When its due instant is worked out.
+    // Then it is that instant, wherever the definition wrote it from.
+    assertIdentical(
+      dueFor({ Timestamp: "2026-07-26T12:00:00+02:00" }, {}),
+      "2026-07-26T10:00:00.000Z",
+    );
+  });
+
+  it("reads the seconds to wait out of the state's input", () => {
+    // Given a Wait state reading SecondsPath.
+    // When its due instant is worked out against an input holding a number.
+    // Then it waits for what the input said.
+    assertIdentical(
+      dueFor({ SecondsPath: "$.retry.after" }, { retry: { after: 30 } }),
+      "2026-07-26T09:00:30.000Z",
+    );
+  });
+
+  it("reads the instant to wait for out of the state's input", () => {
+    // Given a Wait state reading TimestampPath.
+    // When its due instant is worked out.
+    // Then it is the instant the input holds.
+    assertIdentical(
+      dueFor(
+        { TimestampPath: "$.closesAt" },
+        { closesAt: "2026-07-26T17:30:00Z" },
+      ),
+      "2026-07-26T17:30:00.000Z",
+    );
+  });
+
+  it("fails where the input holds no number of seconds to wait", () => {
+    // Given an input holding something else where SecondsPath reads.
+    // When the due instant is worked out.
+    const failure = assertThrowsError(() =>
+      dueFor({ SecondsPath: "$.after" }, { after: "30" }),
+    );
+
+    // Then the state fails, naming the path and what was there.
+    assertStringIncludes(failure.message, "SecondsPath $.after");
+    assertStringIncludes(failure.message, '"30"');
+  });
+
+  it("fails where the input holds no instant to wait for", () => {
+    // Given an input holding a date rather than a timestamp.
+    // When the due instant is worked out.
+    const failure = assertThrowsError(() =>
+      dueFor({ TimestampPath: "$.closesAt" }, { closesAt: "2026-07-26" }),
+    );
+
+    // Then the state fails, naming what an instant has to look like.
+    assertStringIncludes(failure.message, "RFC3339");
+  });
+
+  it("fails a Wait state carrying nothing to wait for", () => {
+    // Given a state the definition parser would have refused, hand-built the
+    // way an execution could still reach one.
+    // When its due instant is worked out.
+    const failure = assertThrowsError(() => dueFor({}, {}));
+
+    // Then it fails rather than waiting for an instant nothing named.
+    assertStringIncludes(failure.message, "nothing says how long it waits");
+  });
+});

--- a/src/service/stepfunctions/wait/sim-states-wait-due.ts
+++ b/src/service/stepfunctions/wait/sim-states-wait-due.ts
@@ -1,0 +1,95 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { selectSimStatesPath } from "../data/sim-states-path-segment.js";
+import { parseSimStatesReferencePath } from "../data/sim-states-reference-path.js";
+import { readSimStatesTimestamp } from "../data/sim-states-timestamp.js";
+import type { SimStatesWaitState } from "../definition/sim-states-state.js";
+import { SimStatesRuntimeFailure } from "../error/sim-step-functions.error.js";
+import { simStatesWaitFields } from "./sim-states-wait-fields.js";
+
+const millisecondsInASecond = 1000;
+
+/**
+ * The instant a `Wait` state waits for.
+ *
+ * The two literal fields are known from the definition. The two path fields
+ * are read out of the state's effective input, and a path holding the wrong
+ * kind of value fails the execution the way real Step Functions does.
+ */
+export function simStatesWaitDue(
+  state: SimStatesWaitState,
+  input: JSONValue,
+  now: Date,
+): Date {
+  if (state.Seconds !== undefined) {
+    return afterSeconds(now, state.Seconds, "Seconds");
+  }
+
+  if (state.Timestamp !== undefined) {
+    return atTimestamp(state.Timestamp, "Timestamp");
+  }
+
+  if (state.SecondsPath !== undefined) {
+    return afterSeconds(
+      now,
+      valueAt(state.SecondsPath, input),
+      `SecondsPath ${state.SecondsPath}`,
+    );
+  }
+
+  if (state.TimestampPath !== undefined) {
+    return atTimestamp(
+      valueAt(state.TimestampPath, input),
+      `TimestampPath ${state.TimestampPath}`,
+    );
+  }
+
+  throw new SimStatesRuntimeFailure(
+    `A Wait state carries none of ${simStatesWaitFields.join(", ")}, so ` +
+      "nothing says how long it waits.",
+  );
+}
+
+/**
+ * The instant a number of seconds from now.
+ */
+function afterSeconds(
+  now: Date,
+  seconds: JSONValue | undefined,
+  source: string,
+): Date {
+  if (
+    typeof seconds !== "number" ||
+    !Number.isSafeInteger(seconds) ||
+    seconds < 0
+  ) {
+    throw new SimStatesRuntimeFailure(
+      `A Wait state reads ${source}, which holds ${JSON.stringify(seconds)} ` +
+        "rather than a whole number of seconds to wait.",
+    );
+  }
+
+  return new Date(now.getTime() + seconds * millisecondsInASecond);
+}
+
+/**
+ * The instant a timestamp names.
+ */
+function atTimestamp(timestamp: JSONValue | undefined, source: string): Date {
+  const milliseconds = readSimStatesTimestamp(timestamp);
+
+  if (milliseconds === undefined) {
+    throw new SimStatesRuntimeFailure(
+      `A Wait state reads ${source}, which holds ` +
+        `${JSON.stringify(timestamp)} rather than an RFC3339 instant.`,
+    );
+  }
+
+  return new Date(milliseconds);
+}
+
+/**
+ * What one of the two paths selects in the state's input.
+ */
+function valueAt(path: string, input: JSONValue): JSONValue | undefined {
+  return selectSimStatesPath(input, parseSimStatesReferencePath(path));
+}

--- a/src/service/stepfunctions/wait/sim-states-wait-due.ts
+++ b/src/service/stepfunctions/wait/sim-states-wait-due.ts
@@ -4,7 +4,10 @@ import { parseSimStatesReferencePath } from "../data/sim-states-reference-path.j
 import { readSimStatesTimestamp } from "../data/sim-states-timestamp.js";
 import type { SimStatesWaitState } from "../definition/sim-states-state.js";
 import { SimStatesRuntimeFailure } from "../error/sim-step-functions.error.js";
-import { simStatesWaitFields } from "./sim-states-wait-fields.js";
+import {
+  simStatesMaximumWaitSeconds,
+  simStatesWaitFields,
+} from "./sim-states-wait-fields.js";
 
 const millisecondsInASecond = 1000;
 
@@ -57,18 +60,27 @@ function afterSeconds(
   seconds: JSONValue | undefined,
   source: string,
 ): Date {
-  if (
-    typeof seconds !== "number" ||
-    !Number.isSafeInteger(seconds) ||
-    seconds < 0
-  ) {
+  if (!isAWaitInSeconds(seconds)) {
     throw new SimStatesRuntimeFailure(
       `A Wait state reads ${source}, which holds ${JSON.stringify(seconds)} ` +
-        "rather than a whole number of seconds to wait.",
+        "rather than a whole number of seconds between 0 and " +
+        `${String(simStatesMaximumWaitSeconds)}.`,
     );
   }
 
   return new Date(now.getTime() + seconds * millisecondsInASecond);
+}
+
+/**
+ * Whether a value is a length of time a `Wait` state can wait for.
+ */
+function isAWaitInSeconds(seconds: JSONValue | undefined): seconds is number {
+  return (
+    typeof seconds === "number" &&
+    Number.isSafeInteger(seconds) &&
+    seconds >= 0 &&
+    seconds <= simStatesMaximumWaitSeconds
+  );
 }
 
 /**

--- a/src/service/stepfunctions/wait/sim-states-wait-fields.ts
+++ b/src/service/stepfunctions/wait/sim-states-wait-fields.ts
@@ -6,6 +6,11 @@ import { SimStatesInvalidDefinition } from "../error/sim-step-functions.error.js
 /**
  * The four ways a `Wait` state says how long to wait.
  */
+/**
+ * The longest wait Step Functions takes, which is a little over three years.
+ */
+export const simStatesMaximumWaitSeconds = 99_999_999;
+
 export const simStatesWaitFields = [
   "Seconds",
   "SecondsPath",
@@ -80,7 +85,7 @@ function checkField(
 }
 
 /**
- * `Seconds` is a whole number of seconds, and never a negative one.
+ * `Seconds` is a whole number of seconds within the range a wait takes.
  */
 function checkSeconds(stateName: string, written: JSONValue | undefined): void {
   if (typeof written !== "number" || !Number.isSafeInteger(written)) {
@@ -93,6 +98,13 @@ function checkSeconds(stateName: string, written: JSONValue | undefined): void {
     throw new SimStatesInvalidDefinition(
       `The Wait state ${stateName} waits for ${String(written)} seconds. A ` +
         "wait does not run backwards.",
+    );
+  }
+
+  if (written > simStatesMaximumWaitSeconds) {
+    throw new SimStatesInvalidDefinition(
+      `The Wait state ${stateName} waits for ${String(written)} seconds. ` +
+        `Step Functions waits ${String(simStatesMaximumWaitSeconds)} at most.`,
     );
   }
 }

--- a/src/service/stepfunctions/wait/sim-states-wait-fields.ts
+++ b/src/service/stepfunctions/wait/sim-states-wait-fields.ts
@@ -1,0 +1,113 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { parseSimStatesReferencePath } from "../data/sim-states-reference-path.js";
+import { readSimStatesTimestamp } from "../data/sim-states-timestamp.js";
+import { SimStatesInvalidDefinition } from "../error/sim-step-functions.error.js";
+
+/**
+ * The four ways a `Wait` state says how long to wait.
+ */
+export const simStatesWaitFields = [
+  "Seconds",
+  "SecondsPath",
+  "Timestamp",
+  "TimestampPath",
+] as const;
+
+/**
+ * Check what a `Wait` state waits for.
+ *
+ * A `Wait` state carries exactly one of the four fields. Real Step Functions
+ * refuses a definition carrying none or more than one when the state machine
+ * is created, and so does this.
+ */
+export function checkSimStatesWaitFields(
+  stateName: string,
+  state: Record<string, JSONValue>,
+): void {
+  const present = simStatesWaitFields.filter((field) =>
+    Object.hasOwn(state, field),
+  );
+  const [field] = present;
+
+  if (field === undefined) {
+    throw new SimStatesInvalidDefinition(
+      `The Wait state ${stateName} carries none of ` +
+        `${simStatesWaitFields.join(", ")}. A Wait state carries exactly one.`,
+    );
+  }
+
+  if (present.length > 1) {
+    throw new SimStatesInvalidDefinition(
+      `The Wait state ${stateName} carries ${present.join(", ")}. A Wait ` +
+        "state carries exactly one of them.",
+    );
+  }
+
+  // The field was found among this state's own keys.
+  // oxlint-disable-next-line security/detect-object-injection
+  checkField(stateName, field, state[field]);
+}
+
+/**
+ * Check the one field the state carries.
+ *
+ * The two paths are checked as far as their syntax here. What they select is
+ * only known once the state runs.
+ */
+function checkField(
+  stateName: string,
+  field: string,
+  written: JSONValue | undefined,
+): void {
+  if (field === "Seconds") {
+    checkSeconds(stateName, written);
+    return;
+  }
+
+  if (field === "Timestamp") {
+    checkTimestamp(stateName, written);
+    return;
+  }
+
+  if (typeof written !== "string") {
+    throw new SimStatesInvalidDefinition(
+      `The Wait state ${stateName} has a ${field} that is not a Reference ` +
+        "Path.",
+    );
+  }
+
+  parseSimStatesReferencePath(written);
+}
+
+/**
+ * `Seconds` is a whole number of seconds, and never a negative one.
+ */
+function checkSeconds(stateName: string, written: JSONValue | undefined): void {
+  if (typeof written !== "number" || !Number.isSafeInteger(written)) {
+    throw new SimStatesInvalidDefinition(
+      `The Wait state ${stateName} has a Seconds that is not a whole number.`,
+    );
+  }
+
+  if (written < 0) {
+    throw new SimStatesInvalidDefinition(
+      `The Wait state ${stateName} waits for ${String(written)} seconds. A ` +
+        "wait does not run backwards.",
+    );
+  }
+}
+
+/**
+ * `Timestamp` is an instant, written the way Amazon States Language writes one.
+ */
+function checkTimestamp(
+  stateName: string,
+  written: JSONValue | undefined,
+): void {
+  if (readSimStatesTimestamp(written) === undefined) {
+    throw new SimStatesInvalidDefinition(
+      `The Wait state ${stateName} has a Timestamp that is not an RFC3339 ` +
+        "instant, such as 2026-07-26T09:00:00Z.",
+    );
+  }
+}

--- a/src/service/stepfunctions/wait/sim-states-wait-refusals.iso.test.ts
+++ b/src/service/stepfunctions/wait/sim-states-wait-refusals.iso.test.ts
@@ -1,0 +1,87 @@
+import { assertStringIncludes, assertThrowsError } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import type { JSONObject } from "../../../util/type-guard/json.js";
+import { parseSimStatesDefinition } from "../definition/sim-states-definition-parse.js";
+
+describe("Step Functions Wait refusals", () => {
+  /**
+   * Read a definition whose Wait state is expected to be refused, and answer
+   * with why.
+   */
+  function refusalFor(wait: JSONObject): string {
+    return assertThrowsError(() =>
+      parseSimStatesDefinition(
+        JSON.stringify({
+          StartAt: "Hold",
+          States: { Hold: { Type: "Wait", End: true, ...wait } },
+        }),
+      ),
+    ).message;
+  }
+
+  it("refuses a Wait state that does not say how long to wait", () => {
+    // Given a Wait state carrying none of the four fields.
+    // When it is read, it names them.
+    assertStringIncludes(
+      refusalFor({}),
+      "carries none of Seconds, SecondsPath, Timestamp, TimestampPath",
+    );
+  });
+
+  it("refuses a Wait state carrying more than one of them", () => {
+    // Given a Wait state carrying both a duration and an instant.
+    // When it is read, it names what it found.
+    assertStringIncludes(
+      refusalFor({ Seconds: 30, Timestamp: "2026-07-26T09:00:00Z" }),
+      "carries Seconds, Timestamp",
+    );
+  });
+
+  it("refuses a Seconds that is not a whole number of seconds", () => {
+    // Given a Seconds written as a string, and one written as a fraction.
+    // When each is read, each is refused.
+    assertStringIncludes(refusalFor({ Seconds: "30" }), "not a whole number");
+    assertStringIncludes(refusalFor({ Seconds: 1.5 }), "not a whole number");
+  });
+
+  it("refuses a wait that runs backwards", () => {
+    // Given a negative Seconds.
+    // When it is read, it is refused.
+    assertStringIncludes(
+      refusalFor({ Seconds: -30 }),
+      "A wait does not run backwards",
+    );
+  });
+
+  it("refuses a Timestamp that is not an instant", () => {
+    // Given a Timestamp written as a date, with no time or zone on it.
+    // When it is read, it is refused with an example of one that works.
+    assertStringIncludes(
+      refusalFor({ Timestamp: "2026-07-26" }),
+      "2026-07-26T09:00:00Z",
+    );
+  });
+
+  it("refuses a wait path that is not a Reference Path", () => {
+    // Given a SecondsPath written as a number, and a TimestampPath using a
+    // wildcard.
+    // When each is read, each is refused.
+    assertStringIncludes(
+      refusalFor({ SecondsPath: 30 }),
+      "has a SecondsPath that is not a Reference Path",
+    );
+    assertStringIncludes(
+      refusalFor({ TimestampPath: "$.closesAt[*]" }),
+      "wildcards",
+    );
+  });
+
+  it("refuses the data-flow fields a Wait state does not have", () => {
+    // Given a Wait state carrying a ResultSelector.
+    // When it is read, it is refused by field name.
+    assertStringIncludes(
+      refusalFor({ Seconds: 30, ResultSelector: { held: true } }),
+      "The Wait state Hold carries ResultSelector",
+    );
+  });
+});

--- a/src/service/stepfunctions/wait/sim-states-wait-refusals.iso.test.ts
+++ b/src/service/stepfunctions/wait/sim-states-wait-refusals.iso.test.ts
@@ -53,12 +53,31 @@ describe("Step Functions Wait refusals", () => {
     );
   });
 
+  it("refuses a wait longer than Step Functions takes", () => {
+    // Given a Seconds a little past the hundred million Step Functions takes.
+    // When it is read, it is refused with the limit in the message.
+    assertStringIncludes(
+      refusalFor({ Seconds: 100_000_000 }),
+      "Step Functions waits 99999999 at most",
+    );
+  });
+
   it("refuses a Timestamp that is not an instant", () => {
     // Given a Timestamp written as a date, with no time or zone on it.
     // When it is read, it is refused with an example of one that works.
     assertStringIncludes(
       refusalFor({ Timestamp: "2026-07-26" }),
       "2026-07-26T09:00:00Z",
+    );
+  });
+
+  it("refuses a Timestamp naming a day its month has not got", () => {
+    // Given the thirtieth of February, which JavaScript's own parser reads as
+    // the second of March.
+    // When it is read, it is refused rather than rolled over.
+    assertStringIncludes(
+      refusalFor({ Timestamp: "2026-02-30T00:00:00Z" }),
+      "RFC3339",
     );
   });
 


### PR DESCRIPTION
A `Choice` state takes the first rule its input matches, with the string, numeric, boolean and timestamp comparators, their `Path` twins, the data tests, `And`, `Or`, `Not` and `Default`. A `Choice` state matching nothing with no `Default` fails the execution with `States.NoChoiceMatched`, and a comparator whose `Variable` selects nothing fails it with `States.Runtime`, both the way real Step Functions fails one. A `Wait` state schedules the rest of the execution on the simulated clock through `scheduleAt`, so `StartExecution` answers with the execution `RUNNING` and advancing time past the instant runs the rest of it. Under a frozen clock the execution waits for as long as the test leaves it there. Both state types are checked when the state machine is created, and `Task`, `Parallel` and `Map` are still refused by name. `StartExecution` is idempotent while an execution is running now that a `Wait` state gives it one to match.

Part of https://github.com/KensioSoftware/yulin/issues/918, which `Task` finishes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Step Functions `Choice` states, including comparisons, logical rules, default branches, and input/output paths.
  * Added support for `Wait` states using durations, timestamps, or input paths.
  * Executions can pause and resume when simulated time advances.
  * Added clear runtime failures for unmatched choices, invalid waits, unknown states, and excessive transition cycles.
  * Repeated starts with the same name and input now return the existing running execution.

* **Documentation**
  * Added usage examples and expanded Step Functions and simulated-time guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->