### PR TITLE
feat: deploy AWS::KinesisFirehose::DeliveryStream

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -3253,6 +3253,7 @@ The resource types it creates are:
 - `AWS::Events::EventBus` and `AWS::Events::Rule`, with the rule's inline `Targets`
 - `AWS::IAM::Role`, `AWS::IAM::User`, `AWS::IAM::ManagedPolicy` and `AWS::IAM::Policy`
 - `AWS::Kinesis::Stream`
+- `AWS::KinesisFirehose::DeliveryStream`
 - `AWS::KMS::Key` and `AWS::KMS::Alias`
 - `AWS::Lambda::Function`, `AWS::Lambda::Url` and `AWS::Lambda::Permission`
 - `AWS::Logs::LogGroup`

--- a/docs/services/firehose/README.md
+++ b/docs/services/firehose/README.md
@@ -599,6 +599,9 @@ const { Contents } = await simAws
 console.log(Contents?.[0]?.Key);
 ```
 
+Both S3 destination properties are read, and a template declaring both is refused, the same as a
+`CreateDeliveryStream` request carrying both.
+
 The Bucket and the Role are named by ARN. A stack declaring all three deploys a delivery stream that
 writes into the Bucket beside it, as the Role beside it, and a Role without `s3:PutObject` fails the
 delivery the same way one created through `CreateDeliveryStream` does. Deleting the stack deletes the
@@ -750,9 +753,10 @@ operations.
   `IcebergDestinationConfiguration` and `SnowflakeDestinationConfiguration` are each refused by name
   at `CreateDeliveryStream`. A delivery stream created against one of them would take records and
   drop them, and a test asserting on an empty Bucket would blame the code under test.
-  `S3DestinationConfiguration` and `ExtendedS3DestinationConfiguration` are both read, and the
-  extended one wins where a request carries both. Either way the delivery stream describes back
-  through `ExtendedS3DestinationDescription`, which is the shape carrying every field read here.
+  `S3DestinationConfiguration` and `ExtendedS3DestinationConfiguration` are both read, and a
+  request carrying both is refused with `InvalidArgumentException`, the way real Firehose refuses a
+  request naming more than one destination. Either way the delivery stream describes back through
+  `ExtendedS3DestinationDescription`, which is the shape carrying every field read here.
   `S3DestinationDescription` is always absent.
 - **`DirectPut` and `KinesisStreamAsSource` are the two sources.** Every other
   `DeliveryStreamType`, such as `MSKAsSource` and `DatabaseAsSource`, is refused by name. A source

--- a/docs/services/firehose/README.md
+++ b/docs/services/firehose/README.md
@@ -616,7 +616,10 @@ simulation has no behaviour for go the same way, including `ProcessingConfigurat
 
 A delivery stream this simulation cannot deliver for is skipped and recorded in
 `stack.skippedResources`, and the rest of the stack deploys. That covers a destination other than
-S3, and a `DeliveryStreamType` of `KinesisStreamAsSource`.
+S3, a `DeliveryStreamType` of `KinesisStreamAsSource`, and a source property naming somewhere the
+records cannot come from, such as `MSKSourceConfiguration` or `DatabaseSourceConfiguration`. The
+source property is what the skip is decided on, because a template that leaves `DeliveryStreamType`
+out gets `DirectPut` by default.
 
 ## SDK interception
 
@@ -761,8 +764,9 @@ operations.
   failure goes to `getSourceFailures()`.
 - **A source stream keeps the shards it was created with.** Simulated Kinesis does not reshard, so
   the shards a delivery stream opens when it is created are the ones it reads for its life.
-- **A delivery stream a template cannot deploy is skipped.** A destination other than S3, and a
-  source outside the two simulated, leave the Resource in `stack.skippedResources` while the rest
+- **A delivery stream a template cannot deploy is skipped.** A destination other than S3, a source
+  outside the two simulated, and a source property such as `MSKSourceConfiguration` or
+  `DatabaseSourceConfiguration`, each leave the Resource in `stack.skippedResources` while the rest
   of the stack deploys. See [deploying from CloudFormation](#deploying-from-cloudformation).
 - **A delivery stream is `ACTIVE` as soon as it exists.** Real Firehose reports `CREATING` for a
   minute or so, and a status a test has to poll through earns its keep only where something is

--- a/docs/services/firehose/README.md
+++ b/docs/services/firehose/README.md
@@ -496,6 +496,128 @@ stream ARN, the Role it read as and the error. `wasRefused` separates an IAM den
 delivery that broke some other way. A denial is recorded quietly, since removing `s3:PutObject` is
 what a test checking the denial does. Anything else is also warned about on the console.
 
+## Deploying from CloudFormation
+
+`AWS::KinesisFirehose::DeliveryStream` deploys a delivery stream. `DeliveryStreamName`,
+`DeliveryStreamType`, `ExtendedS3DestinationConfiguration`, `S3DestinationConfiguration` and `Tags`
+are read. A `Ref` gives the delivery stream name and `Fn::GetAtt` on `Arn` gives the ARN, the way
+real CloudFormation publishes them.
+
+A CDK `DeliveryStream` with an `S3Bucket` destination synthesizes that resource, along with the
+delivery Role and its policy. A CDK project reaches a simulated delivery stream by deploying its
+synthesized template, and nothing here has to be written by hand.
+
+```typescript sim-firehose-cloudformation
+/**
+ * Deploying a delivery stream from a template and putting a record onto it.
+ */
+
+import { PutRecordCommand } from "@aws-sdk/client-firehose";
+import { ListObjectsV2Command } from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Resources: {
+      OrderArchive: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: "order-archive" },
+      },
+      DeliveryRole: {
+        Type: "AWS::IAM::Role",
+        Properties: {
+          AssumeRolePolicyDocument: {
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Principal: { Service: "firehose.amazonaws.com" },
+                Action: "sts:AssumeRole",
+              },
+            ],
+          },
+          Policies: [
+            {
+              PolicyName: "ArchiveOrders",
+              PolicyDocument: {
+                Version: "2012-10-17",
+                Statement: [
+                  {
+                    Effect: "Allow",
+                    Action: "s3:PutObject",
+                    Resource: "arn:aws:s3:::order-archive/*",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      OrderEvents: {
+        Type: "AWS::KinesisFirehose::DeliveryStream",
+        Properties: {
+          DeliveryStreamName: "order-events",
+          DeliveryStreamType: "DirectPut",
+          ExtendedS3DestinationConfiguration: {
+            BucketARN: { "Fn::GetAtt": ["OrderArchive", "Arn"] },
+            RoleARN: { "Fn::GetAtt": ["DeliveryRole", "Arn"] },
+            Prefix: "orders/",
+            BufferingHints: { IntervalInSeconds: 60, SizeInMBs: 1 },
+          },
+        },
+      },
+    },
+    Outputs: {
+      DeliveryStreamArn: { Value: { "Fn::GetAtt": ["OrderEvents", "Arn"] } },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+// arn:aws:firehose:us-east-1:<account>:deliverystream/order-events
+console.log(stack.outputs.get("DeliveryStreamArn")?.value);
+
+await simAws.firehose().putRecord(
+  new PutRecordCommand({
+    DeliveryStreamName: "order-events",
+    Record: { Data: new TextEncoder().encode('{"id":"order-1"}\n') },
+  }),
+);
+
+await simAws.clock().advanceBy({ minutes: 2 });
+
+const { Contents } = await simAws
+  .s3()
+  .listObjectsV2(new ListObjectsV2Command({ Bucket: "order-archive" }));
+
+// orders/2026/08/22/13/order-events-1-2026-08-22-13-51-01-92076704-cf4a-...
+console.log(Contents?.[0]?.Key);
+```
+
+The Bucket and the Role are named by ARN. A stack declaring all three deploys a delivery stream that
+writes into the Bucket beside it, as the Role beside it, and a Role without `s3:PutObject` fails the
+delivery the same way one created through `CreateDeliveryStream` does. Deleting the stack deletes the
+delivery stream.
+
+A delivery stream the template does not name is named after the stack and the logical ID, as real
+CloudFormation names one. The name is trimmed to the 64 characters Firehose allows.
+
+`DeliveryStreamEncryptionConfigurationInput` and `DirectPutSourceConfiguration` are recorded against
+the resource as unsimulated, and the delivery stream deploys anyway. The destination properties this
+simulation has no behaviour for go the same way, including `ProcessingConfiguration`,
+`DynamicPartitioningConfiguration`, `DataFormatConversionConfiguration`, `CompressionFormat` and the
+`CloudWatchLoggingOptions` CDK writes into every destination. They are all in
+`stack.ignoredProperties`.
+
+A delivery stream this simulation cannot deliver for is skipped and recorded in
+`stack.skippedResources`, and the rest of the stack deploys. That covers a destination other than
+S3, and a `DeliveryStreamType` of `KinesisStreamAsSource`.
+
 ## SDK interception
 
 `SimSdk` intercepts a `FirehoseClient`, so application code that constructs its own client reaches
@@ -639,9 +761,9 @@ operations.
   failure goes to `getSourceFailures()`.
 - **A source stream keeps the shards it was created with.** Simulated Kinesis does not reshard, so
   the shards a delivery stream opens when it is created are the ones it reads for its life.
-- **`AWS::KinesisFirehose::DeliveryStream` is skipped on deploy.** It is a Resource type outside
-  the simulation, so it is skipped and the rest of the stack deploys. Deploying one is
-  [issue 933](https://github.com/KensioSoftware/yulin/issues/933).
+- **A delivery stream a template cannot deploy is skipped.** A destination other than S3, and a
+  source outside the two simulated, leave the Resource in `stack.skippedResources` while the rest
+  of the stack deploys. See [deploying from CloudFormation](#deploying-from-cloudformation).
 - **A delivery stream is `ACTIVE` as soon as it exists.** Real Firehose reports `CREATING` for a
   minute or so, and a status a test has to poll through earns its keep only where something is
   being brought up. `DELETING` is absent for the same reason.
@@ -667,6 +789,6 @@ operations.
   record of a batch for throughput limits and internal faults, and both are absent here. The
   per-record response shape is still what a consumer of the response reads.
 - **Tags are accepted and never listed.** `TagDeliveryStream`, `ListTagsForDeliveryStream` and
-  `UntagDeliveryStream` are absent.
+  `UntagDeliveryStream` are absent. The `Tags` a template declares go the same way.
 - **A delivery stream cannot be reconfigured.** `UpdateDestination` is absent. The version in an
   Object key stays at `1` for the life of the delivery stream.

--- a/docs/services/firehose/README.md
+++ b/docs/services/firehose/README.md
@@ -499,9 +499,9 @@ what a test checking the denial does. Anything else is also warned about on the 
 ## Deploying from CloudFormation
 
 `AWS::KinesisFirehose::DeliveryStream` deploys a delivery stream. `DeliveryStreamName`,
-`DeliveryStreamType`, `ExtendedS3DestinationConfiguration`, `S3DestinationConfiguration` and `Tags`
-are read. A `Ref` gives the delivery stream name and `Fn::GetAtt` on `Arn` gives the ARN, the way
-real CloudFormation publishes them.
+`DeliveryStreamType`, `ExtendedS3DestinationConfiguration`, `S3DestinationConfiguration`,
+`KinesisStreamSourceConfiguration` and `Tags` are read. A `Ref` gives the delivery stream name and
+`Fn::GetAtt` on `Arn` gives the ARN, the way real CloudFormation publishes them.
 
 A CDK `DeliveryStream` with an `S3Bucket` destination synthesizes that resource, along with the
 delivery Role and its policy. A CDK project reaches a simulated delivery stream by deploying its
@@ -617,12 +617,15 @@ simulation has no behaviour for go the same way, including `ProcessingConfigurat
 `CloudWatchLoggingOptions` CDK writes into every destination. They are all in
 `stack.ignoredProperties`.
 
+A `DeliveryStreamType` of `KinesisStreamAsSource` deploys as well. The
+`KinesisStreamSourceConfiguration` names the stream by ARN and the Role to read it as, and a stack
+declaring the stream beside the delivery stream archives what a producer puts on it.
+
 A delivery stream this simulation cannot deliver for is skipped and recorded in
 `stack.skippedResources`, and the rest of the stack deploys. That covers a destination other than
-S3, a `DeliveryStreamType` of `KinesisStreamAsSource`, and a source property naming somewhere the
-records cannot come from, such as `MSKSourceConfiguration` or `DatabaseSourceConfiguration`. The
-source property is what the skip is decided on, because a template that leaves `DeliveryStreamType`
-out gets `DirectPut` by default.
+S3, and a source property naming somewhere the records cannot come from, such as
+`MSKSourceConfiguration` or `DatabaseSourceConfiguration`. The source property is what the skip is
+decided on, because a template that leaves `DeliveryStreamType` out gets `DirectPut` by default.
 
 ## SDK interception
 

--- a/docs/services/firehose/sim-firehose-cloudformation.example.ts
+++ b/docs/services/firehose/sim-firehose-cloudformation.example.ts
@@ -1,0 +1,89 @@
+/**
+ * Deploying a delivery stream from a template and putting a record onto it.
+ */
+
+import { PutRecordCommand } from "@aws-sdk/client-firehose";
+import { ListObjectsV2Command } from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Resources: {
+      OrderArchive: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: "order-archive" },
+      },
+      DeliveryRole: {
+        Type: "AWS::IAM::Role",
+        Properties: {
+          AssumeRolePolicyDocument: {
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Principal: { Service: "firehose.amazonaws.com" },
+                Action: "sts:AssumeRole",
+              },
+            ],
+          },
+          Policies: [
+            {
+              PolicyName: "ArchiveOrders",
+              PolicyDocument: {
+                Version: "2012-10-17",
+                Statement: [
+                  {
+                    Effect: "Allow",
+                    Action: "s3:PutObject",
+                    Resource: "arn:aws:s3:::order-archive/*",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      OrderEvents: {
+        Type: "AWS::KinesisFirehose::DeliveryStream",
+        Properties: {
+          DeliveryStreamName: "order-events",
+          DeliveryStreamType: "DirectPut",
+          ExtendedS3DestinationConfiguration: {
+            BucketARN: { "Fn::GetAtt": ["OrderArchive", "Arn"] },
+            RoleARN: { "Fn::GetAtt": ["DeliveryRole", "Arn"] },
+            Prefix: "orders/",
+            BufferingHints: { IntervalInSeconds: 60, SizeInMBs: 1 },
+          },
+        },
+      },
+    },
+    Outputs: {
+      DeliveryStreamArn: { Value: { "Fn::GetAtt": ["OrderEvents", "Arn"] } },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+// arn:aws:firehose:us-east-1:<account>:deliverystream/order-events
+console.log(stack.outputs.get("DeliveryStreamArn")?.value);
+
+await simAws.firehose().putRecord(
+  new PutRecordCommand({
+    DeliveryStreamName: "order-events",
+    Record: { Data: new TextEncoder().encode('{"id":"order-1"}\n') },
+  }),
+);
+
+await simAws.clock().advanceBy({ minutes: 2 });
+
+const { Contents } = await simAws
+  .s3()
+  .listObjectsV2(new ListObjectsV2Command({ Bucket: "order-archive" }));
+
+// orders/2026/08/22/13/order-events-1-2026-08-22-13-51-01-92076704-cf4a-...
+console.log(Contents?.[0]?.Key);

--- a/src/service/cloudformation/cdk/firehose/sim-cdk-firehose-delivery-stream.loc.test.ts
+++ b/src/service/cloudformation/cdk/firehose/sim-cdk-firehose-delivery-stream.loc.test.ts
@@ -1,0 +1,109 @@
+import { PutRecordCommand } from "@aws-sdk/client-firehose";
+import { ListObjectsV2Command } from "@aws-sdk/client-s3";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertStringStartsWith,
+  assertTypeString,
+} from "@kensio/smartass";
+import path from "node:path";
+import { describe, it } from "vitest";
+
+/**
+ * Slower local integration test. Calls the real CDK CLI to synth the output
+ * template file to pass to sim CloudFormation, so the template under test is
+ * one CDK actually produced rather than one written by hand.
+ */
+import { SimAws } from "../../../aws/sim-aws.js";
+import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+
+const accountIdOneOnes = "111111111111";
+
+describe("Sim CDK Firehose delivery stream deployment local integration", () => {
+  it("deploys a CDK delivery stream that archives into its Bucket", async () => {
+    // Given a CDK stack with a Bucket and an unnamed delivery stream writing
+    // into it, which is the whole of what a CDK project declares here. CDK
+    // synthesizes the delivery Role, its policy and the extended S3
+    // destination around those two lines.
+    const cdkProject = new TestCdkProject();
+    await cdkProject.writeCdkAppFile(
+      `
+import * as cdk from "aws-cdk-lib/core";
+import * as firehose from "aws-cdk-lib/aws-kinesisfirehose";
+import * as s3 from "aws-cdk-lib/aws-s3";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "111111111111", region: "eu-west-2" },
+});
+
+const orderArchive = new s3.Bucket(stack, "OrderArchive", {
+  bucketName: "cdk-order-archive",
+});
+
+const orderEvents = new firehose.DeliveryStream(stack, "OrderEvents", {
+  destination: new firehose.S3Bucket(orderArchive, {
+    dataOutputPrefix: "orders/",
+    bufferingInterval: cdk.Duration.seconds(60),
+    bufferingSize: cdk.Size.mebibytes(1),
+  }),
+});
+
+new cdk.CfnOutput(stack, "OrderEventsName", {
+  value: orderEvents.deliveryStreamName,
+});
+
+new cdk.CfnOutput(stack, "OrderEventsArn", {
+  value: orderEvents.deliveryStreamArn,
+});
+
+app.synth();
+      `,
+    );
+
+    // And we synth the CDK template.
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When we deploy the synthesized template into the account and region the
+    // CDK app declares, with no hand-editing of the
+    // AWS::KinesisFirehose::DeliveryStream Resource CDK emits.
+    const simAws = new SimAws();
+    const scoped = simAws.account(accountIdOneOnes).region("eu-west-2");
+    const stack = await scoped
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // Then the name CDK output carries is the deployed delivery stream, named
+    // after the stack and the logical ID because the template did not name it.
+    const deliveryStreamName = stack.outputs.get("OrderEventsName")?.value;
+    assertTypeString(deliveryStreamName);
+    assertStringStartsWith(deliveryStreamName, "TestStack-OrderEvents");
+    assertIdentical(
+      stack.outputs.get("OrderEventsArn")?.value,
+      `arn:aws:firehose:eu-west-2:${accountIdOneOnes}:deliverystream/${
+        deliveryStreamName
+      }`,
+    );
+
+    // And a record put onto it reaches the deployed Bucket, under the prefix
+    // the CDK destination declared, once the buffering interval passes.
+    await scoped.firehose().putRecord(
+      new PutRecordCommand({
+        DeliveryStreamName: deliveryStreamName,
+        Record: { Data: new TextEncoder().encode('{"id":"order-1"}\n') },
+      }),
+    );
+
+    await simAws.clock().advanceBy({ minutes: 2 });
+
+    const { Contents } = await scoped
+      .s3()
+      .listObjectsV2(new ListObjectsV2Command({ Bucket: "cdk-order-archive" }));
+
+    assertArrayLength(Contents ?? [], 1);
+    assertStringStartsWith(Contents?.[0]?.Key ?? "", "orders/");
+  });
+});

--- a/src/service/cloudformation/resource/cfn/firehose/sim-firehose-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/firehose/sim-firehose-cfn-value-adapter.ts
@@ -1,0 +1,25 @@
+import { firehoseDeliveryStreamResourceType } from "../../../../firehose/cfn/sim-cfn-firehose-resource-types.js";
+import { SimFirehoseDeliveryStream } from "../../../../firehose/stream/sim-firehose-delivery-stream.js";
+import type {
+  SimCfnResourceValueAdapterProperties,
+  SimCfnServiceValueAdapter,
+} from "../sim-cfn-resource-value-adapter.js";
+import { SimFirehoseDeliveryStreamCfn } from "./sim-firehose-delivery-stream-cfn.js";
+
+/**
+ * The CloudFormation-facing value adapter for a simulated Firehose Resource.
+ */
+export function firehoseValueAdapter(
+  properties: SimCfnResourceValueAdapterProperties,
+): SimCfnServiceValueAdapter {
+  const { type, simResource } = properties;
+
+  if (
+    type === firehoseDeliveryStreamResourceType &&
+    simResource instanceof SimFirehoseDeliveryStream
+  ) {
+    return new SimFirehoseDeliveryStreamCfn(simResource);
+  }
+
+  return undefined;
+}

--- a/src/service/cloudformation/resource/cfn/firehose/sim-firehose-delivery-stream-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/firehose/sim-firehose-delivery-stream-cfn.ts
@@ -1,0 +1,41 @@
+import { assertDefined } from "../../../../../util/type-guard/defined.js";
+import type { SimFirehoseDeliveryStream } from "../../../../firehose/stream/sim-firehose-delivery-stream.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+/**
+ * CloudFormation-facing values for a simulated Firehose delivery stream.
+ */
+export class SimFirehoseDeliveryStreamCfn implements SimCfnResourceValueAdapter {
+  readonly #deliveryStream: SimFirehoseDeliveryStream;
+
+  constructor(deliveryStream: SimFirehoseDeliveryStream) {
+    this.#deliveryStream = deliveryStream;
+  }
+
+  /**
+   * A Ref to an AWS::KinesisFirehose::DeliveryStream returns the delivery
+   * stream name.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.#deliveryStream.name;
+  }
+
+  /**
+   * The one attribute the Resource publishes, which is the delivery stream ARN.
+   *
+   * That is what a grant names, so a template allowing a producer to put
+   * records reads it.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    const value =
+      attributeName === "Arn" ? this.#deliveryStream.arn : undefined;
+
+    assertDefined(
+      value,
+      `Unsupported AWS::KinesisFirehose::DeliveryStream attribute ${attributeName}`,
+    );
+
+    return value;
+  }
+}

--- a/src/service/cloudformation/resource/cfn/sim-cfn-service-value-adapters.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-service-value-adapters.ts
@@ -10,6 +10,7 @@ import { logsValueAdapter } from "./logs/sim-logs-cfn-value-adapter.js";
 import { ecsValueAdapter } from "./ecs/sim-ecs-cfn-value-adapter.js";
 import { elbV2ValueAdapter } from "./elasticloadbalancingv2/sim-elbv2-cfn-value-adapter.js";
 import { eventBridgeValueAdapter } from "./events/sim-event-bridge-cfn-value-adapter.js";
+import { firehoseValueAdapter } from "./firehose/sim-firehose-cfn-value-adapter.js";
 import { iamValueAdapter } from "./iam/sim-iam-cfn-value-adapter.js";
 import { kinesisValueAdapter } from "./kinesis/sim-kinesis-cfn-value-adapter.js";
 import { kmsValueAdapter } from "./kms/sim-kms-cfn-value-adapter.js";
@@ -54,6 +55,7 @@ export const simCfnServiceValueAdapters: readonly ((
   ecsValueAdapter,
   elbV2ValueAdapter,
   eventBridgeValueAdapter,
+  firehoseValueAdapter,
   iamValueAdapter,
   kinesisValueAdapter,
   kmsValueAdapter,

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
@@ -96,6 +96,11 @@ export const simCfnServiceResourceFactories: ReadonlyMap<
       scopedAws.kinesis().cfnResourceFactory(),
   ],
   [
+    "KinesisFirehose",
+    (scopedAws): SimCfnServiceResourceFactory =>
+      scopedAws.firehose().cfnResourceFactory(),
+  ],
+  [
     "KMS",
     (scopedAws): SimCfnServiceResourceFactory =>
       scopedAws.kms().cfnResourceFactory(),

--- a/src/service/firehose/README.md
+++ b/src/service/firehose/README.md
@@ -148,6 +148,11 @@ delivery stream a template deployed is therefore the same thing an SDK caller wo
 a name, a Bucket ARN or a set of buffering hints is allowed is decided by simulated Firehose, at the
 command that reads it.
 
+`simCfnFirehoseSource` classifies the source before the command sees it. A `*SourceConfiguration`
+property other than the Kinesis one and the DirectPut throughput hint skips the Resource.
+`DeliveryStreamType` is no help there, since a template that leaves it out gets `DirectPut` by
+default and the source property is what says where the records come from.
+
 `simCfnFirehoseResourceCreation` decides what a refusal does to the Stack.
 `SimFirehoseUnsimulatedDestination` and `SimFirehoseUnsimulatedSource` become an
 `Unsupported sim Firehose CloudFormation Resource` error, which sim CloudFormation records as a skip

--- a/src/service/firehose/README.md
+++ b/src/service/firehose/README.md
@@ -137,14 +137,35 @@ Every Firehose operation names its delivery stream by name, and nothing here rea
 Compare `simKinesisRefLookupName`. It exists because a Kinesis request can name its stream either
 way.
 
+## CloudFormation
+
+`cfn/` creates a delivery stream from an `AWS::KinesisFirehose::DeliveryStream` Resource, and
+deletes it when the Stack comes down. `SimFirehoseCfnResourceFactory` dispatches on the Resource
+type name, and `SimCfnFirehoseDeliveryStreamCreator` goes through `CreateDeliveryStream` itself. A
+delivery stream a template deployed is therefore the same thing an SDK caller would have got.
+
+`SimCfnFirehoseDeliveryStreamProperties` reads the shape of the template and nothing else. Whether
+a name, a Bucket ARN or a set of buffering hints is allowed is decided by simulated Firehose, at the
+command that reads it.
+
+`simCfnFirehoseResourceCreation` decides what a refusal does to the Stack.
+`SimFirehoseUnsimulatedDestination` and `SimFirehoseUnsimulatedSource` become an
+`Unsupported sim Firehose CloudFormation Resource` error, which sim CloudFormation records as a skip
+and steps over. Every other `SimFirehoseError` fails the Resource, naming it, because a delivery
+stream the template got wrong is a template to fix.
+
+The `Ref` and `Fn::GetAtt` values live under
+`src/service/cloudformation/resource/cfn/firehose/`, as every service's do.
+
+`sim-cfn-firehose-delivery-stream-template.factory.ts` builds the Bucket, the delivery Role and the
+delivery stream a test deploys. Its default is what CDK synthesizes for a `DeliveryStream` with an
+`S3Bucket` destination.
+
 ## What is left out
 
 `sdk/sim-firehose-sdk-command-router.ts` names the six commands this service handles. Anything else
 an intercepted client sends is refused with `SimSdkUnsupportedCommandError`, which covers
 `UpdateDestination`, encryption and the tag operations.
-
-There is no `cfn/` here. `AWS::KinesisFirehose::DeliveryStream` is skipped on deploy, and issue 933
-is where it is added.
 
 Enhanced fan-out is left out on the source side. A delivery stream reads through `GetRecords`, which
 is the shared throughput path every stream has, and simulated Kinesis has nothing else. Resharding is

--- a/src/service/firehose/README.md
+++ b/src/service/firehose/README.md
@@ -47,7 +47,9 @@ which are bytes and milliseconds. The bounds Firehose allows are checked when a 
 created. A request asking for a buffer Firehose would refuse is refused here, at the same call.
 
 `simFirehoseDestinationOf` picks the destination a request declared. A destination outside the
-simulation is refused by name, with `SimFirehoseUnsimulatedDestination`. A delivery stream created
+simulation is refused by name, with `SimFirehoseUnsimulatedDestination`. A request carrying both
+S3 destinations is refused too, since Firehose takes one destination and the two are one
+destination declared twice. A delivery stream created
 against Redshift or OpenSearch would take records and drop them, and a test asserting on an empty
 Bucket would blame the code under test.
 
@@ -147,6 +149,11 @@ delivery stream a template deployed is therefore the same thing an SDK caller wo
 `SimCfnFirehoseDeliveryStreamProperties` reads the shape of the template and nothing else. Whether
 a name, a Bucket ARN or a set of buffering hints is allowed is decided by simulated Firehose, at the
 command that reads it.
+
+The CloudFormation layer reads the destinations a template declared and hands them all over
+without choosing between them. Which destinations a delivery stream may have is decided by
+`simFirehoseDestinationOf`, so the template door and the SDK door answer the same request the same
+way.
 
 `simCfnFirehoseSource` classifies the source before the command sees it. A `*SourceConfiguration`
 property other than the Kinesis one and the DirectPut throughput hint skips the Resource.

--- a/src/service/firehose/cfn/delivery-stream/sim-cfn-firehose-delivery-stream-creator.ts
+++ b/src/service/firehose/cfn/delivery-stream/sim-cfn-firehose-delivery-stream-creator.ts
@@ -1,0 +1,69 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimFirehose } from "../../sim-firehose.js";
+import type { SimFirehoseDeliveryStream } from "../../stream/sim-firehose-delivery-stream.js";
+import { simCfnFirehoseResourceCreation } from "../sim-cfn-firehose-resource-error.js";
+import { firehoseDeliveryStreamResourceType } from "../sim-cfn-firehose-resource-types.js";
+import { SimCfnFirehoseDeliveryStreamProperties } from "./sim-cfn-firehose-delivery-stream-properties.js";
+
+interface SimCfnFirehoseDeliveryStreamCreatorProperties {
+  readonly firehose: SimFirehose;
+}
+
+/**
+ * Creates simulated delivery streams from
+ * AWS::KinesisFirehose::DeliveryStream Resources.
+ *
+ * The delivery stream goes through the ordinary CreateDeliveryStream command
+ * rather than being constructed directly, so a delivery stream a template
+ * deployed is the same thing an SDK caller would have got: the same name
+ * validation, the same buffering bounds, the same refusals for what this
+ * simulation does not model.
+ *
+ * The Bucket and the Role are named by ARN, and both are resolved by the
+ * CloudFormation engine before this sees them. A delivery stream deployed
+ * alongside the Bucket it writes into therefore writes into that Bucket, and
+ * writes as the Role the template declared.
+ */
+export class SimCfnFirehoseDeliveryStreamCreator {
+  private readonly firehose: SimFirehose;
+
+  constructor(properties: SimCfnFirehoseDeliveryStreamCreatorProperties) {
+    this.firehose = properties.firehose;
+  }
+
+  /**
+   * Create a delivery stream from an AWS::KinesisFirehose::DeliveryStream
+   * Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimFirehoseDeliveryStream> {
+    return await simCfnFirehoseResourceCreation(
+      firehoseDeliveryStreamResourceType,
+      resource.logicalId,
+      async () => {
+        const streamProperties = new SimCfnFirehoseDeliveryStreamProperties({
+          resource,
+          properties,
+        });
+        const input = streamProperties.createInput();
+
+        await this.firehose.createDeliveryStream({ input });
+
+        const deliveryStream = this.firehose.findDeliveryStream(
+          streamProperties.name(),
+        );
+        assertDefined(
+          deliveryStream,
+          `sim Firehose delivery stream ${streamProperties.name()} after ` +
+            `CloudFormation creation`,
+        );
+
+        return deliveryStream;
+      },
+    );
+  }
+}

--- a/src/service/firehose/cfn/delivery-stream/sim-cfn-firehose-delivery-stream-name.ts
+++ b/src/service/firehose/cfn/delivery-stream/sim-cfn-firehose-delivery-stream-name.ts
@@ -1,0 +1,36 @@
+import { SimCfnGeneratedResourceName } from "../../../cloudformation/resource/name/sim-cfn-generated-resource-name.js";
+
+const maximumNameLength = 64;
+
+interface SimCfnFirehoseDeliveryStreamNameProperties {
+  readonly stackName: string | undefined;
+  readonly logicalId: string;
+}
+
+/**
+ * The name CloudFormation gives a delivery stream whose template does not name
+ * it.
+ *
+ * A delivery stream name is at most 64 characters, so a long stack name and
+ * logical ID together are trimmed to fit. How a generated name is put together
+ * and trimmed is the same for every service, and lives in
+ * {@link SimCfnGeneratedResourceName}.
+ */
+export class SimCfnFirehoseDeliveryStreamName {
+  private readonly generated: SimCfnGeneratedResourceName;
+
+  constructor(properties: SimCfnFirehoseDeliveryStreamNameProperties) {
+    this.generated = new SimCfnGeneratedResourceName({
+      stackName: properties.stackName,
+      logicalId: properties.logicalId,
+      maximumLength: maximumNameLength,
+    });
+  }
+
+  /**
+   * The generated delivery stream name.
+   */
+  get value(): string {
+    return this.generated.value;
+  }
+}

--- a/src/service/firehose/cfn/delivery-stream/sim-cfn-firehose-delivery-stream-properties.ts
+++ b/src/service/firehose/cfn/delivery-stream/sim-cfn-firehose-delivery-stream-properties.ts
@@ -1,0 +1,128 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCreateDeliveryStreamCommandInput } from "../../command/stream/stream.command.js";
+import { simCfnFirehoseDeliveryStreamPropertyError } from "../sim-cfn-firehose-resource-error.js";
+import { SimCfnFirehoseDeliveryStreamName } from "./sim-cfn-firehose-delivery-stream-name.js";
+import {
+  deliveryStreamNamePropertyName,
+  deliveryStreamTypePropertyName,
+  kinesisStreamSourcePropertyName,
+  tagsPropertyName,
+  unsimulatedPropertyReasons,
+} from "./sim-cfn-firehose-delivery-stream-property-names.js";
+import { simCfnFirehoseDestination } from "./sim-cfn-firehose-destination-choice.js";
+import { simCfnFirehoseTags } from "./sim-cfn-firehose-tags.js";
+
+interface SimCfnFirehoseDeliveryStreamPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::KinesisFirehose::DeliveryStream CloudFormation properties into the
+ * shape CreateDeliveryStream takes.
+ *
+ * What a template may ask for is decided by simulated Firehose rather than
+ * here, so a name, a Bucket ARN or buffering hints it will not take are refused
+ * by the command that reads them. What this reads is the shape: a property that
+ * has to be a string, a number or a record is checked for being one, since a
+ * template that put an object where a name goes has made a mistake
+ * CreateDeliveryStream cannot explain.
+ *
+ * `KinesisStreamSourceConfiguration` goes through as the template wrote it, so
+ * where a delivery stream reads from is decided in one place.
+ */
+export class SimCfnFirehoseDeliveryStreamProperties {
+  private readonly resource: SimCfnResource;
+  private readonly properties: ReadonlyMap<string, SimCfnTemplateValue>;
+
+  constructor(properties: SimCfnFirehoseDeliveryStreamPropertiesProperties) {
+    this.resource = properties.resource;
+    this.properties = new Map(Object.entries(properties.properties));
+
+    this.recordUnsimulated();
+  }
+
+  /**
+   * The delivery stream name.
+   *
+   * An unnamed delivery stream is named after the stack and the logical ID, as
+   * real CloudFormation names one.
+   */
+  name(): string {
+    const name = this.properties.get(deliveryStreamNamePropertyName);
+
+    if (name === undefined) {
+      return new SimCfnFirehoseDeliveryStreamName({
+        stackName: this.resource.stackName,
+        logicalId: this.resource.logicalId,
+      }).value;
+    }
+
+    if (typeof name !== "string") {
+      throw this.error(`${deliveryStreamNamePropertyName} must be a string`);
+    }
+
+    return name;
+  }
+
+  /**
+   * The whole request, as CreateDeliveryStream takes it.
+   */
+  createInput(): SimCreateDeliveryStreamCommandInput {
+    const type = this.deliveryStreamType();
+    const source = this.properties.get(kinesisStreamSourcePropertyName);
+    const tags = simCfnFirehoseTags(
+      this.resource,
+      this.properties.get(tagsPropertyName),
+    );
+
+    return {
+      DeliveryStreamName: this.name(),
+      ...(type !== undefined && { DeliveryStreamType: type }),
+      ...(source !== undefined && {
+        KinesisStreamSourceConfiguration: source,
+      }),
+      ...(tags !== undefined && { Tags: tags }),
+      ...simCfnFirehoseDestination(this.resource, this.properties),
+    };
+  }
+
+  /**
+   * Where the delivery stream reads its records from, when the template says.
+   */
+  private deliveryStreamType(): string | undefined {
+    const type = this.properties.get(deliveryStreamTypePropertyName);
+
+    if (type === undefined) {
+      return undefined;
+    }
+
+    if (typeof type !== "string") {
+      throw this.error(`${deliveryStreamTypePropertyName} must be a string`);
+    }
+
+    return type;
+  }
+
+  /**
+   * Record the properties this simulation gives no behaviour to.
+   */
+  private recordUnsimulated(): void {
+    for (const [name, reason] of unsimulatedPropertyReasons) {
+      if (this.properties.has(name)) {
+        this.resource.ignoreProperty(name, reason);
+      }
+    }
+  }
+
+  private error(reason: string): Error {
+    return simCfnFirehoseDeliveryStreamPropertyError(
+      this.resource.logicalId,
+      reason,
+    );
+  }
+}

--- a/src/service/firehose/cfn/delivery-stream/sim-cfn-firehose-delivery-stream-properties.ts
+++ b/src/service/firehose/cfn/delivery-stream/sim-cfn-firehose-delivery-stream-properties.ts
@@ -9,11 +9,11 @@ import { SimCfnFirehoseDeliveryStreamName } from "./sim-cfn-firehose-delivery-st
 import {
   deliveryStreamNamePropertyName,
   deliveryStreamTypePropertyName,
-  kinesisStreamSourcePropertyName,
   tagsPropertyName,
   unsimulatedPropertyReasons,
 } from "./sim-cfn-firehose-delivery-stream-property-names.js";
 import { simCfnFirehoseDestination } from "./sim-cfn-firehose-destination-choice.js";
+import { simCfnFirehoseSource } from "./sim-cfn-firehose-source-choice.js";
 import { simCfnFirehoseTags } from "./sim-cfn-firehose-tags.js";
 
 interface SimCfnFirehoseDeliveryStreamPropertiesProperties {
@@ -74,7 +74,7 @@ export class SimCfnFirehoseDeliveryStreamProperties {
    */
   createInput(): SimCreateDeliveryStreamCommandInput {
     const type = this.deliveryStreamType();
-    const source = this.properties.get(kinesisStreamSourcePropertyName);
+    const source = simCfnFirehoseSource(this.resource, this.properties);
     const tags = simCfnFirehoseTags(
       this.resource,
       this.properties.get(tagsPropertyName),

--- a/src/service/firehose/cfn/delivery-stream/sim-cfn-firehose-delivery-stream-property-names.ts
+++ b/src/service/firehose/cfn/delivery-stream/sim-cfn-firehose-delivery-stream-property-names.ts
@@ -1,0 +1,109 @@
+/**
+ * The AWS::KinesisFirehose::DeliveryStream properties this simulation acts on.
+ */
+export const deliveryStreamNamePropertyName = "DeliveryStreamName";
+
+export const deliveryStreamTypePropertyName = "DeliveryStreamType";
+
+export const kinesisStreamSourcePropertyName =
+  "KinesisStreamSourceConfiguration";
+
+export const extendedS3DestinationPropertyName =
+  "ExtendedS3DestinationConfiguration";
+
+export const s3DestinationPropertyName = "S3DestinationConfiguration";
+
+export const tagsPropertyName = "Tags";
+
+/**
+ * The suffix every Firehose destination configuration property ends in.
+ */
+export const destinationPropertySuffix = "DestinationConfiguration";
+
+/**
+ * The two destination properties this simulation delivers to. Everything else
+ * ending in {@link destinationPropertySuffix} is a destination outside the
+ * simulation, found by the suffix so one AWS adds later needs no change here.
+ */
+export const simulatedDestinationPropertyNames: ReadonlySet<string> = new Set([
+  extendedS3DestinationPropertyName,
+  s3DestinationPropertyName,
+]);
+
+/**
+ * Real AWS::KinesisFirehose::DeliveryStream properties this simulation does not
+ * model, and why.
+ *
+ * Each is recorded against the Resource rather than refused, so a template
+ * carrying one still deploys a delivery stream and the omission is somewhere a
+ * test can find it.
+ */
+export const unsimulatedPropertyReasons: ReadonlyMap<string, string> = new Map([
+  [
+    "DeliveryStreamEncryptionConfigurationInput",
+    "server-side encryption is not simulated, and every delivered Object " +
+      "holds the bytes that were put",
+  ],
+  [
+    "DirectPutSourceConfiguration",
+    "throughput is unlimited in the simulation, so a throughput hint has " +
+      "nothing to act on",
+  ],
+]);
+
+/**
+ * S3 destination properties this simulation does not model, and why.
+ *
+ * The path recorded against the Resource is the destination property these sit
+ * under, then the name, so a reader can find the one the template wrote.
+ */
+export const unsimulatedDestinationPropertyReasons: ReadonlyMap<
+  string,
+  string
+> = new Map([
+  [
+    "ProcessingConfiguration",
+    "record transformation through a Lambda is not simulated, and records " +
+      "are delivered as they were put",
+  ],
+  [
+    "DynamicPartitioningConfiguration",
+    "dynamic partitioning reads record content, and a record's bytes are " +
+      "carried here without being read",
+  ],
+  [
+    "DataFormatConversionConfiguration",
+    "Parquet and ORC conversion is not simulated, and every delivered " +
+      "Object holds the bytes that were put",
+  ],
+  [
+    "CompressionFormat",
+    "compression is not simulated, and every destination reports " +
+      "UNCOMPRESSED",
+  ],
+  [
+    "EncryptionConfiguration",
+    "Objects are delivered unencrypted, and no key is ever asked for",
+  ],
+  [
+    "CloudWatchLoggingOptions",
+    "delivery is not logged to CloudWatch Logs, and a failed delivery is " +
+      "read back through getDeliveryFailures()",
+  ],
+  ["RetryOptions", "a failed delivery is recorded once rather than retried"],
+  ["S3BackupMode", "the source record backup destination is not simulated"],
+  [
+    "S3BackupConfiguration",
+    "the source record backup destination is not simulated",
+  ],
+  [
+    "FileExtension",
+    "the Object key is built the way real Firehose builds it, with no " +
+      "extension on the end",
+  ],
+  [
+    "CustomTimeZone",
+    "the date path in an Object key is UTC, as it is on real Firehose by " +
+      "default",
+  ],
+]);

--- a/src/service/firehose/cfn/delivery-stream/sim-cfn-firehose-delivery-stream-property-names.ts
+++ b/src/service/firehose/cfn/delivery-stream/sim-cfn-firehose-delivery-stream-property-names.ts
@@ -8,6 +8,8 @@ export const deliveryStreamTypePropertyName = "DeliveryStreamType";
 export const kinesisStreamSourcePropertyName =
   "KinesisStreamSourceConfiguration";
 
+export const directPutSourcePropertyName = "DirectPutSourceConfiguration";
+
 export const extendedS3DestinationPropertyName =
   "ExtendedS3DestinationConfiguration";
 
@@ -19,6 +21,25 @@ export const tagsPropertyName = "Tags";
  * The suffix every Firehose destination configuration property ends in.
  */
 export const destinationPropertySuffix = "DestinationConfiguration";
+
+/**
+ * The suffix every Firehose source configuration property ends in.
+ */
+export const sourcePropertySuffix = "SourceConfiguration";
+
+/**
+ * The two source properties this simulation has an answer for.
+ *
+ * `KinesisStreamSourceConfiguration` goes through to CreateDeliveryStream, and
+ * `DirectPutSourceConfiguration` is a throughput hint on a delivery stream that
+ * is already taking direct puts. Everything else ending in
+ * {@link sourcePropertySuffix} reads from somewhere outside the simulation,
+ * found by the suffix so a source AWS adds later needs no change here.
+ */
+export const readSourcePropertyNames: ReadonlySet<string> = new Set([
+  kinesisStreamSourcePropertyName,
+  directPutSourcePropertyName,
+]);
 
 /**
  * The two destination properties this simulation delivers to. Everything else
@@ -45,7 +66,7 @@ export const unsimulatedPropertyReasons: ReadonlyMap<string, string> = new Map([
       "holds the bytes that were put",
   ],
   [
-    "DirectPutSourceConfiguration",
+    directPutSourcePropertyName,
     "throughput is unlimited in the simulation, so a throughput hint has " +
       "nothing to act on",
   ],

--- a/src/service/firehose/cfn/delivery-stream/sim-cfn-firehose-destination-choice.ts
+++ b/src/service/firehose/cfn/delivery-stream/sim-cfn-firehose-destination-choice.ts
@@ -1,0 +1,78 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimFirehoseDestinationInput } from "../../destination/sim-firehose-destination-choice.js";
+import { SimFirehoseUnsimulatedDestination } from "../../error/sim-firehose.error.js";
+import { SimCfnFirehoseS3Destination } from "./sim-cfn-firehose-s3-destination.js";
+import {
+  destinationPropertySuffix,
+  extendedS3DestinationPropertyName,
+  s3DestinationPropertyName,
+  simulatedDestinationPropertyNames,
+} from "./sim-cfn-firehose-delivery-stream-property-names.js";
+
+/**
+ * The destination a delivery stream Resource writes to.
+ *
+ * A destination outside the simulation is refused first, in the words
+ * CreateDeliveryStream refuses it in, which is what skips the Resource. That is
+ * the order the destination model works in too, so a template carrying both an
+ * S3 destination and a Redshift one is refused rather than half deployed.
+ *
+ * The extended destination wins over the plain one, as it does on real
+ * Firehose. A template declaring neither is left alone here, and
+ * CreateDeliveryStream refuses it, as real CloudFormation refuses it.
+ */
+export function simCfnFirehoseDestination(
+  resource: SimCfnResource,
+  properties: ReadonlyMap<string, SimCfnTemplateValue>,
+): SimFirehoseDestinationInput {
+  const unsimulated = properties
+    .keys()
+    .find(
+      (name) =>
+        name.endsWith(destinationPropertySuffix) &&
+        !simulatedDestinationPropertyNames.has(name),
+    );
+
+  if (unsimulated !== undefined) {
+    throw new SimFirehoseUnsimulatedDestination(unsimulated);
+  }
+
+  const extended = properties.get(extendedS3DestinationPropertyName);
+
+  if (extended !== undefined) {
+    return {
+      ExtendedS3DestinationConfiguration: read(
+        resource,
+        extendedS3DestinationPropertyName,
+        extended,
+      ),
+    };
+  }
+
+  const plain = properties.get(s3DestinationPropertyName);
+
+  if (plain === undefined) {
+    return {};
+  }
+
+  return {
+    S3DestinationConfiguration: read(
+      resource,
+      s3DestinationPropertyName,
+      plain,
+    ),
+  };
+}
+
+function read(
+  resource: SimCfnResource,
+  propertyName: string,
+  value: SimCfnTemplateValue,
+): ReturnType<SimCfnFirehoseS3Destination["input"]> {
+  return new SimCfnFirehoseS3Destination({
+    resource,
+    propertyName,
+    value,
+  }).input();
+}

--- a/src/service/firehose/cfn/delivery-stream/sim-cfn-firehose-destination-choice.ts
+++ b/src/service/firehose/cfn/delivery-stream/sim-cfn-firehose-destination-choice.ts
@@ -11,16 +11,18 @@ import {
 } from "./sim-cfn-firehose-delivery-stream-property-names.js";
 
 /**
- * The destination a delivery stream Resource writes to.
+ * The destinations a delivery stream Resource declared.
  *
  * A destination outside the simulation is refused first, in the words
  * CreateDeliveryStream refuses it in, which is what skips the Resource. That is
  * the order the destination model works in too, so a template carrying both an
  * S3 destination and a Redshift one is refused rather than half deployed.
  *
- * The extended destination wins over the plain one, as it does on real
- * Firehose. A template declaring neither is left alone here, and
- * CreateDeliveryStream refuses it, as real CloudFormation refuses it.
+ * Both S3 destinations go through where a template declares both, and
+ * CreateDeliveryStream refuses the pair. Which destinations a delivery stream
+ * may have is decided in one place, by simulated Firehose, so the template door
+ * and the SDK door answer the same request the same way. A template declaring
+ * no destination goes through in the same way.
  */
 export function simCfnFirehoseDestination(
   resource: SimCfnResource,
@@ -39,29 +41,23 @@ export function simCfnFirehoseDestination(
   }
 
   const extended = properties.get(extendedS3DestinationPropertyName);
+  const plain = properties.get(s3DestinationPropertyName);
 
-  if (extended !== undefined) {
-    return {
+  return {
+    ...(extended !== undefined && {
       ExtendedS3DestinationConfiguration: read(
         resource,
         extendedS3DestinationPropertyName,
         extended,
       ),
-    };
-  }
-
-  const plain = properties.get(s3DestinationPropertyName);
-
-  if (plain === undefined) {
-    return {};
-  }
-
-  return {
-    S3DestinationConfiguration: read(
-      resource,
-      s3DestinationPropertyName,
-      plain,
-    ),
+    }),
+    ...(plain !== undefined && {
+      S3DestinationConfiguration: read(
+        resource,
+        s3DestinationPropertyName,
+        plain,
+      ),
+    }),
   };
 }
 

--- a/src/service/firehose/cfn/delivery-stream/sim-cfn-firehose-s3-destination.ts
+++ b/src/service/firehose/cfn/delivery-stream/sim-cfn-firehose-s3-destination.ts
@@ -1,0 +1,144 @@
+import { isRecord } from "../../../../util/type-guard/record.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimFirehoseBufferingHintsInput } from "../../destination/sim-firehose-buffering-hints.js";
+import type { SimFirehoseS3DestinationInput } from "../../destination/sim-firehose-s3-destination.js";
+import { simCfnFirehoseResourceError } from "../sim-cfn-firehose-resource-error.js";
+import { firehoseDeliveryStreamResourceType } from "../sim-cfn-firehose-resource-types.js";
+import { unsimulatedDestinationPropertyReasons } from "./sim-cfn-firehose-delivery-stream-property-names.js";
+
+interface SimCfnFirehoseS3DestinationProperties {
+  readonly resource: SimCfnResource;
+  readonly propertyName: string;
+  readonly value: SimCfnTemplateValue;
+}
+
+/**
+ * Reads an S3 destination configuration out of a template.
+ *
+ * What the destination may say is decided by simulated Firehose, so a Bucket
+ * ARN naming an Object or buffering hints outside the range Firehose allows are
+ * refused by the command that reads them. What this reads is the shape: a field
+ * that has to be a string or a number is checked for being one, since a
+ * template that put an object where a Bucket ARN goes has made a mistake
+ * CreateDeliveryStream cannot explain.
+ *
+ * The extended and the plain configuration arrive in the same shape. Every
+ * field read here is on both, and CDK synthesizes the extended one.
+ */
+export class SimCfnFirehoseS3Destination {
+  private readonly resource: SimCfnResource;
+  private readonly propertyName: string;
+  private readonly fields: ReadonlyMap<string, SimCfnTemplateValue>;
+
+  constructor(properties: SimCfnFirehoseS3DestinationProperties) {
+    this.resource = properties.resource;
+    this.propertyName = properties.propertyName;
+
+    if (!isRecord(properties.value)) {
+      throw this.propertyError(`${properties.propertyName} must be an object`);
+    }
+
+    this.fields = new Map(Object.entries(properties.value));
+
+    this.recordUnsimulated();
+  }
+
+  /**
+   * The destination as CreateDeliveryStream takes it.
+   */
+  input(): SimFirehoseS3DestinationInput {
+    const bucketArn = this.optionalString("BucketARN");
+    const roleArn = this.optionalString("RoleARN");
+    const prefix = this.optionalString("Prefix");
+    const errorOutputPrefix = this.optionalString("ErrorOutputPrefix");
+    const bufferingHints = this.bufferingHints();
+
+    return {
+      ...(bucketArn !== undefined && { BucketARN: bucketArn }),
+      ...(roleArn !== undefined && { RoleARN: roleArn }),
+      ...(prefix !== undefined && { Prefix: prefix }),
+      ...(errorOutputPrefix !== undefined && {
+        ErrorOutputPrefix: errorOutputPrefix,
+      }),
+      ...(bufferingHints !== undefined && { BufferingHints: bufferingHints }),
+    };
+  }
+
+  /**
+   * When the buffer is delivered, as the template declares it.
+   */
+  private bufferingHints(): SimFirehoseBufferingHintsInput | undefined {
+    const hints = this.fields.get("BufferingHints");
+
+    if (hints === undefined) {
+      return undefined;
+    }
+
+    if (!isRecord(hints)) {
+      throw this.propertyError(
+        `${this.propertyName}.BufferingHints must be an object`,
+      );
+    }
+
+    const size = hints["SizeInMBs"];
+    const interval = hints["IntervalInSeconds"];
+
+    return {
+      ...(size !== undefined && {
+        SizeInMBs: this.hintNumber(size, "SizeInMBs"),
+      }),
+      ...(interval !== undefined && {
+        IntervalInSeconds: this.hintNumber(interval, "IntervalInSeconds"),
+      }),
+    };
+  }
+
+  private hintNumber(value: unknown, field: string): number {
+    if (typeof value !== "number") {
+      throw this.propertyError(
+        `${this.propertyName}.BufferingHints.${field} must be a number`,
+      );
+    }
+
+    return value;
+  }
+
+  /**
+   * A field that has to be a string, when the template carries one.
+   */
+  private optionalString(field: string): string | undefined {
+    const value = this.fields.get(field);
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value !== "string") {
+      throw this.propertyError(
+        `${this.propertyName}.${field} must be a string`,
+      );
+    }
+
+    return value;
+  }
+
+  /**
+   * Record the destination fields this simulation gives no behaviour to.
+   */
+  private recordUnsimulated(): void {
+    for (const [field, reason] of unsimulatedDestinationPropertyReasons) {
+      if (this.fields.has(field)) {
+        this.resource.ignoreProperty(`${this.propertyName}.${field}`, reason);
+      }
+    }
+  }
+
+  private propertyError(reason: string): Error {
+    return simCfnFirehoseResourceError(
+      firehoseDeliveryStreamResourceType,
+      this.resource.logicalId,
+      reason,
+    );
+  }
+}

--- a/src/service/firehose/cfn/delivery-stream/sim-cfn-firehose-source-choice.ts
+++ b/src/service/firehose/cfn/delivery-stream/sim-cfn-firehose-source-choice.ts
@@ -1,6 +1,11 @@
+import { isRecord } from "../../../../util/type-guard/record.js";
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
-import { simCfnFirehoseUnsupportedResourceError } from "../sim-cfn-firehose-resource-error.js";
+import type { SimFirehoseKinesisSourceInput } from "../../source/sim-firehose-source-choice.js";
+import {
+  simCfnFirehoseDeliveryStreamPropertyError,
+  simCfnFirehoseUnsupportedResourceError,
+} from "../sim-cfn-firehose-resource-error.js";
 import {
   kinesisStreamSourcePropertyName,
   readSourcePropertyNames,
@@ -10,20 +15,21 @@ import {
 /**
  * The source configuration a delivery stream Resource reads from.
  *
- * A source outside the simulation skips the Resource, naming the property the
- * template wrote. A delivery stream reading from MSK or from a database would
- * take nothing and deliver nothing, and `DeliveryStreamType` is no help in
- * finding it: the property is what says where the records come from, and a
- * template that leaves the type out gets `DirectPut` by default, on real
+ * A source property outside the simulation skips the Resource, naming the
+ * property the template wrote. A delivery stream reading from MSK or from a
+ * database would take nothing and deliver nothing, and `DeliveryStreamType` is
+ * no help in finding it. The property is what says where the records come from,
+ * and a template that leaves the type out gets `DirectPut` by default, on real
  * CloudFormation as well as here.
  *
- * `KinesisStreamSourceConfiguration` goes through to CreateDeliveryStream, so
- * where a delivery stream reads from is decided in one place.
+ * What the Kinesis configuration may say is decided by simulated Firehose, at
+ * the command that reads it. A stream in another account or region and a
+ * missing `RoleARN` are both refused there.
  */
 export function simCfnFirehoseSource(
   resource: SimCfnResource,
   properties: ReadonlyMap<string, SimCfnTemplateValue>,
-): SimCfnTemplateValue | undefined {
+): SimFirehoseKinesisSourceInput | undefined {
   const unsimulated = properties
     .keys()
     .find(
@@ -36,9 +42,55 @@ export function simCfnFirehoseSource(
     throw simCfnFirehoseUnsupportedResourceError(
       resource.logicalId,
       `simulated Firehose takes records through PutRecord and PutRecordBatch, ` +
-        `and this delivery stream declares ${unsimulated}`,
+        `or reads them off a simulated Kinesis stream, and this delivery ` +
+        `stream declares ${unsimulated}`,
     );
   }
 
-  return properties.get(kinesisStreamSourcePropertyName);
+  const source = properties.get(kinesisStreamSourcePropertyName);
+
+  if (source === undefined) {
+    return undefined;
+  }
+
+  if (!isRecord(source)) {
+    throw error(
+      resource,
+      `${kinesisStreamSourcePropertyName} must be an object`,
+    );
+  }
+
+  const streamArn = source["KinesisStreamARN"];
+  const roleArn = source["RoleARN"];
+
+  return {
+    ...(streamArn !== undefined && {
+      KinesisStreamARN: sourceString(resource, streamArn, "KinesisStreamARN"),
+    }),
+    ...(roleArn !== undefined && {
+      RoleARN: sourceString(resource, roleArn, "RoleARN"),
+    }),
+  };
+}
+
+/**
+ * A source field that has to be a string.
+ */
+function sourceString(
+  resource: SimCfnResource,
+  value: unknown,
+  field: string,
+): string {
+  if (typeof value !== "string") {
+    throw error(
+      resource,
+      `${kinesisStreamSourcePropertyName}.${field} must be a string`,
+    );
+  }
+
+  return value;
+}
+
+function error(resource: SimCfnResource, reason: string): Error {
+  return simCfnFirehoseDeliveryStreamPropertyError(resource.logicalId, reason);
 }

--- a/src/service/firehose/cfn/delivery-stream/sim-cfn-firehose-source-choice.ts
+++ b/src/service/firehose/cfn/delivery-stream/sim-cfn-firehose-source-choice.ts
@@ -1,0 +1,44 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { simCfnFirehoseUnsupportedResourceError } from "../sim-cfn-firehose-resource-error.js";
+import {
+  kinesisStreamSourcePropertyName,
+  readSourcePropertyNames,
+  sourcePropertySuffix,
+} from "./sim-cfn-firehose-delivery-stream-property-names.js";
+
+/**
+ * The source configuration a delivery stream Resource reads from.
+ *
+ * A source outside the simulation skips the Resource, naming the property the
+ * template wrote. A delivery stream reading from MSK or from a database would
+ * take nothing and deliver nothing, and `DeliveryStreamType` is no help in
+ * finding it: the property is what says where the records come from, and a
+ * template that leaves the type out gets `DirectPut` by default, on real
+ * CloudFormation as well as here.
+ *
+ * `KinesisStreamSourceConfiguration` goes through to CreateDeliveryStream, so
+ * where a delivery stream reads from is decided in one place.
+ */
+export function simCfnFirehoseSource(
+  resource: SimCfnResource,
+  properties: ReadonlyMap<string, SimCfnTemplateValue>,
+): SimCfnTemplateValue | undefined {
+  const unsimulated = properties
+    .keys()
+    .find(
+      (name) =>
+        name.endsWith(sourcePropertySuffix) &&
+        !readSourcePropertyNames.has(name),
+    );
+
+  if (unsimulated !== undefined) {
+    throw simCfnFirehoseUnsupportedResourceError(
+      resource.logicalId,
+      `simulated Firehose takes records through PutRecord and PutRecordBatch, ` +
+        `and this delivery stream declares ${unsimulated}`,
+    );
+  }
+
+  return properties.get(kinesisStreamSourcePropertyName);
+}

--- a/src/service/firehose/cfn/delivery-stream/sim-cfn-firehose-tags.ts
+++ b/src/service/firehose/cfn/delivery-stream/sim-cfn-firehose-tags.ts
@@ -1,0 +1,52 @@
+import { isRecord } from "../../../../util/type-guard/record.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimFirehoseTag } from "../../command/stream/stream.command.js";
+import { simCfnFirehoseDeliveryStreamPropertyError } from "../sim-cfn-firehose-resource-error.js";
+import { tagsPropertyName } from "./sim-cfn-firehose-delivery-stream-property-names.js";
+
+/**
+ * The tags a delivery stream Resource is created with.
+ *
+ * A simulated delivery stream takes them and does not list them back, the same
+ * as one created through the SDK.
+ */
+export function simCfnFirehoseTags(
+  resource: SimCfnResource,
+  tags: SimCfnTemplateValue | undefined,
+): readonly SimFirehoseTag[] | undefined {
+  if (tags === undefined) {
+    return undefined;
+  }
+
+  if (!Array.isArray(tags)) {
+    throw error(resource, `${tagsPropertyName} must be a list`);
+  }
+
+  return tags.map((tag) => tagOf(resource, tag));
+}
+
+/**
+ * One tag, as the key and value a template wrote it as.
+ */
+function tagOf(
+  resource: SimCfnResource,
+  tag: SimCfnTemplateValue,
+): SimFirehoseTag {
+  if (
+    !isRecord(tag) ||
+    typeof tag["Key"] !== "string" ||
+    typeof tag["Value"] !== "string"
+  ) {
+    throw error(
+      resource,
+      `${tagsPropertyName} entries must each carry a string Key and Value`,
+    );
+  }
+
+  return { Key: tag["Key"], Value: tag["Value"] };
+}
+
+function error(resource: SimCfnResource, reason: string): Error {
+  return simCfnFirehoseDeliveryStreamPropertyError(resource.logicalId, reason);
+}

--- a/src/service/firehose/cfn/sim-cfn-firehose-archive.resources.ts
+++ b/src/service/firehose/cfn/sim-cfn-firehose-archive.resources.ts
@@ -1,0 +1,66 @@
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+/**
+ * The Bucket every delivery stream template here archives into.
+ */
+export const orderArchiveBucketName = "order-archive";
+
+/**
+ * The S3 actions real Firehose requires a delivery Role to be allowed before it
+ * will write a buffer.
+ */
+export const firehoseDeliveryActions: readonly string[] = [
+  "s3:AbortMultipartUpload",
+  "s3:GetBucketLocation",
+  "s3:GetObject",
+  "s3:ListBucket",
+  "s3:ListBucketMultipartUploads",
+  "s3:PutObject",
+];
+
+/**
+ * The Bucket the delivery stream writes into.
+ */
+export const orderArchiveBucket: SimCfnTemplateValueRecord = {
+  Type: "AWS::S3::Bucket",
+  Properties: { BucketName: orderArchiveBucketName },
+};
+
+/**
+ * The Role the delivery writes as, allowed the S3 actions given.
+ */
+export function orderArchiveDeliveryRole(
+  allowedActions: readonly string[],
+): SimCfnTemplateValueRecord {
+  return {
+    Type: "AWS::IAM::Role",
+    Properties: {
+      RoleName: "OrderArchiveDeliveryRole",
+      AssumeRolePolicyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Principal: { Service: "firehose.amazonaws.com" },
+            Action: "sts:AssumeRole",
+          },
+        ],
+      },
+      Policies: [
+        {
+          PolicyName: "ArchiveOrders",
+          PolicyDocument: {
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Action: [...allowedActions],
+                Resource: `arn:aws:s3:::${orderArchiveBucketName}/*`,
+              },
+            ],
+          },
+        },
+      ],
+    },
+  };
+}

--- a/src/service/firehose/cfn/sim-cfn-firehose-archive.resources.ts
+++ b/src/service/firehose/cfn/sim-cfn-firehose-archive.resources.ts
@@ -19,6 +19,17 @@ export const firehoseDeliveryActions: readonly string[] = [
 ];
 
 /**
+ * The Kinesis actions real Firehose requires a source Role to be allowed before
+ * it will read a stream.
+ */
+const sourceActions: readonly string[] = [
+  "kinesis:DescribeStream",
+  "kinesis:GetRecords",
+  "kinesis:GetShardIterator",
+  "kinesis:ListShards",
+];
+
+/**
  * The Bucket the delivery stream writes into.
  */
 export const orderArchiveBucket: SimCfnTemplateValueRecord = {
@@ -64,3 +75,84 @@ export function orderArchiveDeliveryRole(
     },
   };
 }
+
+/**
+ * The stream a Kinesis-sourced delivery stream reads.
+ */
+export function orderSourceStream(
+  streamName: string,
+): SimCfnTemplateValueRecord {
+  return {
+    Type: "AWS::Kinesis::Stream",
+    Properties: { Name: streamName, ShardCount: 1 },
+  };
+}
+
+/**
+ * The Role a Kinesis-sourced delivery stream reads its stream as.
+ */
+export function orderSourceRole(): SimCfnTemplateValueRecord {
+  return {
+    Type: "AWS::IAM::Role",
+    Properties: {
+      RoleName: "OrderStreamSourceRole",
+      AssumeRolePolicyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Principal: { Service: "firehose.amazonaws.com" },
+            Action: "sts:AssumeRole",
+          },
+        ],
+      },
+      Policies: [
+        {
+          PolicyName: "ReadOrders",
+          PolicyDocument: {
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Action: [...sourceActions],
+                Resource: { "Fn::GetAtt": ["OrderStream", "Arn"] },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  };
+}
+
+/**
+ * The destination CDK synthesizes for a `DeliveryStream` with an `S3Bucket`,
+ * reading the Bucket and the Role off the Resources beside it.
+ *
+ * A test states this as its destination and changes what it is about, which is
+ * how a template a CDK project would have produced stays the starting point.
+ */
+export const cdkS3Destination: SimCfnTemplateValueRecord = {
+  BucketARN: { "Fn::GetAtt": ["OrderArchive", "Arn"] },
+  RoleARN: { "Fn::GetAtt": ["DeliveryRole", "Arn"] },
+  Prefix: "orders/",
+  BufferingHints: { IntervalInSeconds: 60, SizeInMBs: 1 },
+};
+
+/**
+ * The source CDK synthesizes for a `DeliveryStream` with a `KinesisStreamSource`,
+ * reading the stream and the Role off the Resources beside it.
+ */
+export const cdkKinesisSource: SimCfnTemplateValueRecord = {
+  KinesisStreamARN: { "Fn::GetAtt": ["OrderStream", "Arn"] },
+  RoleARN: { "Fn::GetAtt": ["SourceRole", "Arn"] },
+};
+
+/**
+ * The delivery stream a test that states no properties of its own gets.
+ */
+export const cdkDeliveryStreamProperties: SimCfnTemplateValueRecord = {
+  DeliveryStreamName: "order-events",
+  DeliveryStreamType: "DirectPut",
+  ExtendedS3DestinationConfiguration: cdkS3Destination,
+};

--- a/src/service/firehose/cfn/sim-cfn-firehose-delivery-stream-skips.iso.test.ts
+++ b/src/service/firehose/cfn/sim-cfn-firehose-delivery-stream-skips.iso.test.ts
@@ -192,59 +192,6 @@ describe("What a deployed AWS::KinesisFirehose::DeliveryStream leaves out", () =
     );
   });
 
-  it("skips a delivery stream reading from a Kinesis stream", async () => {
-    // Given a template declaring a delivery stream whose source is a Kinesis
-    // stream, which simulated Firehose does not yet read from.
-    const simAws = new SimAws();
-
-    // When it is deployed.
-    const stack = await deploy(simAws, {
-      DeliveryStreamName: "order-events",
-      DeliveryStreamType: "KinesisStreamAsSource",
-      KinesisStreamSourceConfiguration: {
-        KinesisStreamARN: `arn:aws:kinesis:${simAws.defaultRegionName}:${simAws.defaultAccountId}:stream/orders`,
-        RoleARN: { "Fn::GetAtt": ["DeliveryRole", "Arn"] },
-      },
-      ExtendedS3DestinationConfiguration: cdkS3Destination,
-    });
-
-    // Then the delivery stream was not created, and the rest of the stack was.
-    assertUndefined(simAws.firehose().findDeliveryStream("order-events"));
-    assertIdentical(stack.status, "CREATE_COMPLETE");
-    assertArrayLength(stack.skippedResources, 1);
-    assertStringIncludes(
-      stack.skippedResources[0].skippedReason ?? "",
-      "reading from a Kinesis stream",
-    );
-  });
-
-  it("skips a delivery stream reading from a source outside the simulation", async () => {
-    // Given a template declaring an MSK source and no DeliveryStreamType,
-    // which leaves the type at the DirectPut default while the records would
-    // come from somewhere this simulation cannot read.
-    const simAws = new SimAws();
-
-    // When it is deployed.
-    const stack = await deploy(simAws, {
-      DeliveryStreamName: "order-events",
-      MSKSourceConfiguration: {
-        MSKClusterARN: `arn:aws:kafka:${simAws.defaultRegionName}:${simAws.defaultAccountId}:cluster/orders/abc`,
-        TopicName: "orders",
-      },
-      ExtendedS3DestinationConfiguration: cdkS3Destination,
-    });
-
-    // Then the delivery stream was not created, the rest of the stack was, and
-    // the skip names the source property the template wrote.
-    assertUndefined(simAws.firehose().findDeliveryStream("order-events"));
-    assertIdentical(stack.status, "CREATE_COMPLETE");
-    assertArrayLength(stack.skippedResources, 1);
-    assertStringIncludes(
-      stack.skippedResources[0].skippedReason ?? "",
-      "MSKSourceConfiguration",
-    );
-  });
-
   it("takes tags without listing them back", async () => {
     // Given a template tagging its delivery stream.
     const simAws = new SimAws();

--- a/src/service/firehose/cfn/sim-cfn-firehose-delivery-stream-skips.iso.test.ts
+++ b/src/service/firehose/cfn/sim-cfn-firehose-delivery-stream-skips.iso.test.ts
@@ -1,0 +1,240 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnDeployedStack } from "../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import {
+  cdkS3Destination,
+  simCfnFirehoseDeliveryStreamTemplateFactory,
+} from "./sim-cfn-firehose-delivery-stream-template.factory.js";
+
+describe("What a deployed AWS::KinesisFirehose::DeliveryStream leaves out", () => {
+  /**
+   * Deploy a delivery stream declared with the given properties.
+   */
+  async function deploy(
+    simAws: SimAws,
+    deliveryStreamProperties: SimCfnTemplateValueRecord,
+  ): Promise<SimCfnDeployedStack> {
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: simCfnFirehoseDeliveryStreamTemplateFactory.make({
+        deliveryStreamProperties,
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    return stack;
+  }
+
+  /**
+   * The reasons recorded against the Resource for one property path.
+   */
+  function ignoredReasons(
+    stack: SimCfnDeployedStack,
+    path: string,
+  ): readonly string[] {
+    return stack.resources
+      .flatMap((resource) => [...resource.ignoredProperties])
+      .filter((property) => property.path === path)
+      .map((property) => property.reason);
+  }
+
+  it("records encryption as unsimulated and deploys the delivery stream", async () => {
+    // Given a template asking for a delivery stream encrypted with a KMS key.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await deploy(simAws, {
+      DeliveryStreamName: "order-events",
+      DeliveryStreamEncryptionConfigurationInput: {
+        KeyType: "AWS_OWNED_CMK",
+      },
+      ExtendedS3DestinationConfiguration: cdkS3Destination,
+    });
+
+    // Then the delivery stream is there, and the property it could not act on
+    // is recorded where a test can find it rather than failing the stack.
+    assertIdentical(
+      simAws.firehose().findDeliveryStream("order-events")?.name,
+      "order-events",
+    );
+
+    const reasons = ignoredReasons(
+      stack,
+      "DeliveryStreamEncryptionConfigurationInput",
+    );
+    assertArrayLength(reasons, 1);
+    assertStringIncludes(reasons[0], "encryption is not simulated");
+  });
+
+  it("records the destination properties it delivers without", async () => {
+    // Given the destination CDK synthesizes, which always logs to CloudWatch,
+    // alongside a transformation and a partitioning this simulation has no
+    // behaviour for.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await deploy(simAws, {
+      DeliveryStreamName: "order-events",
+      ExtendedS3DestinationConfiguration: {
+        ...cdkS3Destination,
+        CloudWatchLoggingOptions: {
+          Enabled: true,
+          LogGroupName: "orders",
+          LogStreamName: "S3Destination",
+        },
+        ProcessingConfiguration: { Enabled: false },
+        CompressionFormat: "GZIP",
+      },
+    });
+
+    // Then each is recorded under the destination it was written in, and the
+    // delivery stream is deployed anyway.
+    assertIdentical(
+      simAws.firehose().findDeliveryStream("order-events")?.name,
+      "order-events",
+    );
+    assertArrayLength(
+      ignoredReasons(
+        stack,
+        "ExtendedS3DestinationConfiguration.CloudWatchLoggingOptions",
+      ),
+      1,
+    );
+    assertArrayLength(
+      ignoredReasons(
+        stack,
+        "ExtendedS3DestinationConfiguration.ProcessingConfiguration",
+      ),
+      1,
+    );
+    assertStringIncludes(
+      ignoredReasons(
+        stack,
+        "ExtendedS3DestinationConfiguration.CompressionFormat",
+      )[0] ?? "",
+      "UNCOMPRESSED",
+    );
+  });
+
+  it("deploys a plain S3DestinationConfiguration", async () => {
+    // Given a template declaring the plain destination rather than the
+    // extended one CDK synthesizes.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    await deploy(simAws, {
+      DeliveryStreamName: "order-events",
+      S3DestinationConfiguration: cdkS3Destination,
+    });
+
+    // Then the delivery stream is there, since every field this simulation
+    // reads is on both forms.
+    assertIdentical(
+      simAws.firehose().findDeliveryStream("order-events")?.destination.prefix,
+      "orders/",
+    );
+  });
+
+  it("gives a destination declaring no buffering the Firehose defaults", async () => {
+    // Given a destination naming a Bucket and a Role and nothing else, which
+    // is the least CloudFormation accepts.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    await deploy(simAws, {
+      DeliveryStreamName: "order-events",
+      ExtendedS3DestinationConfiguration: {
+        BucketARN: { "Fn::GetAtt": ["OrderArchive", "Arn"] },
+        RoleARN: { "Fn::GetAtt": ["DeliveryRole", "Arn"] },
+      },
+    });
+
+    // Then the delivery stream buffers the way real Firehose buffers one that
+    // was told nothing. That is 5 MB or 300 seconds.
+    const hints = simAws.firehose().findDeliveryStream("order-events")
+      ?.destination.bufferingHints;
+    assertNonNullable(hints);
+    assertIdentical(hints.sizeInMegabytes, 5);
+    assertIdentical(hints.intervalInSeconds, 300);
+  });
+
+  it("skips a delivery stream whose destination is outside the simulation", async () => {
+    // Given a template whose only destination is Redshift.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await deploy(simAws, {
+      DeliveryStreamName: "order-events",
+      RedshiftDestinationConfiguration: {
+        ClusterJDBCURL:
+          "jdbc:redshift://orders.eu-west-2.redshift.amazonaws.com:5439/orders",
+        RoleARN: { "Fn::GetAtt": ["DeliveryRole", "Arn"] },
+      },
+    });
+
+    // Then the delivery stream was not created, the rest of the stack was, and
+    // the skip says which destination it could not deliver to.
+    assertUndefined(simAws.firehose().findDeliveryStream("order-events"));
+    assertIdentical(stack.status, "CREATE_COMPLETE");
+    assertArrayLength(stack.skippedResources, 1);
+    assertStringIncludes(
+      stack.skippedResources[0].skippedReason ?? "",
+      "RedshiftDestinationConfiguration",
+    );
+  });
+
+  it("skips a delivery stream reading from a Kinesis stream", async () => {
+    // Given a template declaring a delivery stream whose source is a Kinesis
+    // stream, which simulated Firehose does not yet read from.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await deploy(simAws, {
+      DeliveryStreamName: "order-events",
+      DeliveryStreamType: "KinesisStreamAsSource",
+      KinesisStreamSourceConfiguration: {
+        KinesisStreamARN: `arn:aws:kinesis:${simAws.defaultRegionName}:${simAws.defaultAccountId}:stream/orders`,
+        RoleARN: { "Fn::GetAtt": ["DeliveryRole", "Arn"] },
+      },
+      ExtendedS3DestinationConfiguration: cdkS3Destination,
+    });
+
+    // Then the delivery stream was not created, and the rest of the stack was.
+    assertUndefined(simAws.firehose().findDeliveryStream("order-events"));
+    assertIdentical(stack.status, "CREATE_COMPLETE");
+    assertArrayLength(stack.skippedResources, 1);
+    assertStringIncludes(
+      stack.skippedResources[0].skippedReason ?? "",
+      "reading from a Kinesis stream",
+    );
+  });
+
+  it("takes tags without listing them back", async () => {
+    // Given a template tagging its delivery stream.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    await deploy(simAws, {
+      DeliveryStreamName: "order-events",
+      Tags: [{ Key: "team", Value: "orders" }],
+      ExtendedS3DestinationConfiguration: cdkS3Destination,
+    });
+
+    // Then the delivery stream is there. Tags go the same way through a
+    // template as through CreateDeliveryStream, which is accepted and never
+    // listed back.
+    assertIdentical(
+      simAws.firehose().findDeliveryStream("order-events")?.name,
+      "order-events",
+    );
+  });
+});

--- a/src/service/firehose/cfn/sim-cfn-firehose-delivery-stream-skips.iso.test.ts
+++ b/src/service/firehose/cfn/sim-cfn-firehose-delivery-stream-skips.iso.test.ts
@@ -218,6 +218,33 @@ describe("What a deployed AWS::KinesisFirehose::DeliveryStream leaves out", () =
     );
   });
 
+  it("skips a delivery stream reading from a source outside the simulation", async () => {
+    // Given a template declaring an MSK source and no DeliveryStreamType,
+    // which leaves the type at the DirectPut default while the records would
+    // come from somewhere this simulation cannot read.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await deploy(simAws, {
+      DeliveryStreamName: "order-events",
+      MSKSourceConfiguration: {
+        MSKClusterARN: `arn:aws:kafka:${simAws.defaultRegionName}:${simAws.defaultAccountId}:cluster/orders/abc`,
+        TopicName: "orders",
+      },
+      ExtendedS3DestinationConfiguration: cdkS3Destination,
+    });
+
+    // Then the delivery stream was not created, the rest of the stack was, and
+    // the skip names the source property the template wrote.
+    assertUndefined(simAws.firehose().findDeliveryStream("order-events"));
+    assertIdentical(stack.status, "CREATE_COMPLETE");
+    assertArrayLength(stack.skippedResources, 1);
+    assertStringIncludes(
+      stack.skippedResources[0].skippedReason ?? "",
+      "MSKSourceConfiguration",
+    );
+  });
+
   it("takes tags without listing them back", async () => {
     // Given a template tagging its delivery stream.
     const simAws = new SimAws();

--- a/src/service/firehose/cfn/sim-cfn-firehose-delivery-stream-template.factory.ts
+++ b/src/service/firehose/cfn/sim-cfn-firehose-delivery-stream-template.factory.ts
@@ -1,0 +1,115 @@
+import { MappedFactory } from "@kensio/part-factory";
+
+import type { CfnTemplateBodyRecord } from "../../cloudformation/template/sim-cfn-template.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import {
+  firehoseDeliveryActions,
+  orderArchiveBucket,
+  orderArchiveDeliveryRole,
+} from "./sim-cfn-firehose-archive.resources.js";
+
+export { orderArchiveBucketName } from "./sim-cfn-firehose-archive.resources.js";
+
+/**
+ * The destination CDK synthesizes for a `DeliveryStream` with an `S3Bucket`,
+ * reading the Bucket and the Role off the Resources beside it.
+ *
+ * A test states this as its destination and changes what it is about, which is
+ * how a template a CDK project would have produced stays the starting point.
+ */
+export const cdkS3Destination: SimCfnTemplateValueRecord = {
+  BucketARN: { "Fn::GetAtt": ["OrderArchive", "Arn"] },
+  RoleARN: { "Fn::GetAtt": ["DeliveryRole", "Arn"] },
+  Prefix: "orders/",
+  BufferingHints: { IntervalInSeconds: 60, SizeInMBs: 1 },
+};
+
+/**
+ * The delivery stream a test that states no properties of its own gets.
+ */
+const cdkDeliveryStreamProperties: SimCfnTemplateValueRecord = {
+  DeliveryStreamName: "order-events",
+  DeliveryStreamType: "DirectPut",
+  ExtendedS3DestinationConfiguration: cdkS3Destination,
+};
+
+/**
+ * What a test asks for when it wants a stack holding a delivery stream.
+ */
+export interface SimCfnFirehoseDeliveryStreamTemplateInput {
+  /**
+   * The Properties the AWS::KinesisFirehose::DeliveryStream Resource carries.
+   *
+   * Left empty, the delivery stream is the one CDK synthesizes. A test that
+   * states them replaces them outright, since the factory merges its defaults
+   * into whatever it is given and a default stated here would put back the very
+   * property a test about a missing one is leaving out.
+   */
+  readonly deliveryStreamProperties: SimCfnTemplateValueRecord;
+
+  /**
+   * The S3 actions the delivery Role is allowed.
+   *
+   * Left empty, it is allowed the ones real Firehose asks a delivery Role for.
+   * Narrowing them is how a test checks what a Role that cannot write does.
+   */
+  readonly allowedActions: readonly string[];
+}
+
+/**
+ * Builds a stack holding a Bucket, a delivery Role and a delivery stream
+ * writing into the one as the other.
+ *
+ * ```typescript
+ * const stack = await simAws.cloudFormation().deployTemplate({
+ *   stackName: "orders-stack",
+ *   template: simCfnFirehoseDeliveryStreamTemplateFactory.make(),
+ * });
+ * ```
+ *
+ * The Bucket and the Role are read by ARN through `Fn::GetAtt`, which is what
+ * CDK synthesizes, so a deployment that resolved either wrongly delivers
+ * nowhere. The Outputs read the delivery stream both ways CloudFormation
+ * publishes it.
+ */
+export const simCfnFirehoseDeliveryStreamTemplateFactory = new MappedFactory<
+  SimCfnFirehoseDeliveryStreamTemplateInput,
+  CfnTemplateBodyRecord
+>(
+  () => ({ deliveryStreamProperties: {}, allowedActions: [] }),
+  (input) => ({
+    Resources: {
+      OrderArchive: orderArchiveBucket,
+      DeliveryRole: orderArchiveDeliveryRole(allowedActions(input)),
+      OrderEvents: {
+        Type: "AWS::KinesisFirehose::DeliveryStream",
+        Properties: deliveryStreamProperties(input),
+      },
+    },
+    Outputs: {
+      StreamRef: { Value: { Ref: "OrderEvents" } },
+      StreamArn: { Value: { "Fn::GetAtt": ["OrderEvents", "Arn"] } },
+      RoleArn: { Value: { "Fn::GetAtt": ["DeliveryRole", "Arn"] } },
+    },
+  }),
+);
+
+function allowedActions(
+  input: SimCfnFirehoseDeliveryStreamTemplateInput,
+): readonly string[] {
+  if (input.allowedActions.length > 0) {
+    return input.allowedActions;
+  }
+
+  return firehoseDeliveryActions;
+}
+
+function deliveryStreamProperties(
+  input: SimCfnFirehoseDeliveryStreamTemplateInput,
+): SimCfnTemplateValueRecord {
+  if (Object.keys(input.deliveryStreamProperties).length > 0) {
+    return input.deliveryStreamProperties;
+  }
+
+  return cdkDeliveryStreamProperties;
+}

--- a/src/service/firehose/cfn/sim-cfn-firehose-delivery-stream-template.factory.ts
+++ b/src/service/firehose/cfn/sim-cfn-firehose-delivery-stream-template.factory.ts
@@ -3,35 +3,19 @@ import { MappedFactory } from "@kensio/part-factory";
 import type { CfnTemplateBodyRecord } from "../../cloudformation/template/sim-cfn-template.js";
 import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
 import {
+  cdkDeliveryStreamProperties,
   firehoseDeliveryActions,
   orderArchiveBucket,
   orderArchiveDeliveryRole,
+  orderSourceRole,
+  orderSourceStream,
 } from "./sim-cfn-firehose-archive.resources.js";
 
-export { orderArchiveBucketName } from "./sim-cfn-firehose-archive.resources.js";
-
-/**
- * The destination CDK synthesizes for a `DeliveryStream` with an `S3Bucket`,
- * reading the Bucket and the Role off the Resources beside it.
- *
- * A test states this as its destination and changes what it is about, which is
- * how a template a CDK project would have produced stays the starting point.
- */
-export const cdkS3Destination: SimCfnTemplateValueRecord = {
-  BucketARN: { "Fn::GetAtt": ["OrderArchive", "Arn"] },
-  RoleARN: { "Fn::GetAtt": ["DeliveryRole", "Arn"] },
-  Prefix: "orders/",
-  BufferingHints: { IntervalInSeconds: 60, SizeInMBs: 1 },
-};
-
-/**
- * The delivery stream a test that states no properties of its own gets.
- */
-const cdkDeliveryStreamProperties: SimCfnTemplateValueRecord = {
-  DeliveryStreamName: "order-events",
-  DeliveryStreamType: "DirectPut",
-  ExtendedS3DestinationConfiguration: cdkS3Destination,
-};
+export {
+  cdkKinesisSource,
+  cdkS3Destination,
+  orderArchiveBucketName,
+} from "./sim-cfn-firehose-archive.resources.js";
 
 /**
  * What a test asks for when it wants a stack holding a delivery stream.
@@ -54,6 +38,15 @@ export interface SimCfnFirehoseDeliveryStreamTemplateInput {
    * Narrowing them is how a test checks what a Role that cannot write does.
    */
   readonly allowedActions: readonly string[];
+
+  /**
+   * The stream a Kinesis-sourced delivery stream reads.
+   *
+   * Left empty, the stack holds no stream and no source Role, which is what a
+   * `DirectPut` delivery stream wants. Naming one adds both, and
+   * `cdkKinesisSource` is the configuration that reads them.
+   */
+  readonly sourceStreamName: string;
 }
 
 /**
@@ -76,11 +69,16 @@ export const simCfnFirehoseDeliveryStreamTemplateFactory = new MappedFactory<
   SimCfnFirehoseDeliveryStreamTemplateInput,
   CfnTemplateBodyRecord
 >(
-  () => ({ deliveryStreamProperties: {}, allowedActions: [] }),
+  () => ({
+    deliveryStreamProperties: {},
+    allowedActions: [],
+    sourceStreamName: "",
+  }),
   (input) => ({
     Resources: {
       OrderArchive: orderArchiveBucket,
       DeliveryRole: orderArchiveDeliveryRole(allowedActions(input)),
+      ...sourceResources(input),
       OrderEvents: {
         Type: "AWS::KinesisFirehose::DeliveryStream",
         Properties: deliveryStreamProperties(input),
@@ -93,6 +91,23 @@ export const simCfnFirehoseDeliveryStreamTemplateFactory = new MappedFactory<
     },
   }),
 );
+
+/**
+ * The stream and the Role a Kinesis-sourced delivery stream reads, for a stack
+ * that names one.
+ */
+function sourceResources(
+  input: SimCfnFirehoseDeliveryStreamTemplateInput,
+): SimCfnTemplateValueRecord {
+  if (input.sourceStreamName === "") {
+    return {};
+  }
+
+  return {
+    OrderStream: orderSourceStream(input.sourceStreamName),
+    SourceRole: orderSourceRole(),
+  };
+}
 
 function allowedActions(
   input: SimCfnFirehoseDeliveryStreamTemplateInput,

--- a/src/service/firehose/cfn/sim-cfn-firehose-delivery-stream.iso.test.ts
+++ b/src/service/firehose/cfn/sim-cfn-firehose-delivery-stream.iso.test.ts
@@ -1,0 +1,203 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  deliveredObjectBody,
+  deliveredObjectKeys,
+} from "../../../../test/firehose/firehose-delivery-fixture.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimFirehoseResourceNotFoundException } from "../error/sim-firehose.error.js";
+import {
+  cdkS3Destination,
+  orderArchiveBucketName,
+  simCfnFirehoseDeliveryStreamTemplateFactory,
+} from "./sim-cfn-firehose-delivery-stream-template.factory.js";
+
+describe("deployed AWS::KinesisFirehose::DeliveryStream Resources", () => {
+  /**
+   * Put one order event onto a deployed delivery stream.
+   */
+  async function putOrderEvent(simAws: SimAws, name: string): Promise<void> {
+    await simAws.firehose().putRecord({
+      input: {
+        DeliveryStreamName: name,
+        Record: { Data: new TextEncoder().encode('{"id":"order-1"}\n') },
+      },
+    });
+  }
+
+  it("delivers a record put onto a deployed delivery stream", async () => {
+    // Given a stack holding a Bucket, a delivery Role and the delivery stream
+    // CDK synthesizes for an S3Bucket destination.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: simCfnFirehoseDeliveryStreamTemplateFactory.make(),
+    });
+    await stack.waitForDeployComplete();
+
+    // When a record is put onto the deployed delivery stream and the buffering
+    // interval passes.
+    await putOrderEvent(simAws, "order-events");
+    await simAws.clock().advanceBy({ minutes: 2 });
+
+    // Then it is in the deployed Bucket, which means the Bucket ARN the
+    // template read off the Bucket beside it resolved to that Bucket.
+    const keys = await deliveredObjectKeys(simAws, orderArchiveBucketName);
+    assertArrayLength(keys, 1);
+    assertIdentical(
+      await deliveredObjectBody(simAws, orderArchiveBucketName, keys[0]),
+      '{"id":"order-1"}\n',
+    );
+  });
+
+  it("answers a Ref with the name and Arn with the delivery stream ARN", async () => {
+    // Given a template reading its delivery stream both ways.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: simCfnFirehoseDeliveryStreamTemplateFactory.make(),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the Ref is the name and the attribute is the ARN, which is the way
+    // round real CloudFormation publishes them.
+    assertIdentical(stack.outputs.get("StreamRef")?.value, "order-events");
+    assertIdentical(
+      stack.outputs.get("StreamArn")?.value,
+      `arn:aws:firehose:${simAws.defaultRegionName}:` +
+        `${simAws.defaultAccountId}:deliverystream/order-events`,
+    );
+  });
+
+  it("names an unnamed delivery stream after the stack and the logical ID", async () => {
+    // Given a template that names no delivery stream.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: simCfnFirehoseDeliveryStreamTemplateFactory.make({
+        deliveryStreamProperties: {
+          ExtendedS3DestinationConfiguration: cdkS3Destination,
+        },
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then CloudFormation named it, as real CloudFormation names one.
+    assertIdentical(
+      stack.outputs.get("StreamRef")?.value,
+      "orders-stack-OrderEvents",
+    );
+    assertIdentical(
+      simAws.firehose().findDeliveryStream("orders-stack-OrderEvents")?.name,
+      "orders-stack-OrderEvents",
+    );
+  });
+
+  it("buffers and prefixes the way the destination declared", async () => {
+    // Given a template declaring a prefix and both buffering bounds.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: simCfnFirehoseDeliveryStreamTemplateFactory.make({
+        deliveryStreamProperties: {
+          DeliveryStreamName: "order-events",
+          ExtendedS3DestinationConfiguration: {
+            ...cdkS3Destination,
+            Prefix: "orders/archive/",
+            BufferingHints: { IntervalInSeconds: 120, SizeInMBs: 3 },
+          },
+        },
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // When the deployed delivery stream is described.
+    const described = await simAws.firehose().describeDeliveryStream({
+      input: { DeliveryStreamName: "order-events" },
+    });
+    const destination =
+      described.DeliveryStreamDescription.Destinations[0]
+        ?.ExtendedS3DestinationDescription;
+    assertNonNullable(destination);
+
+    // Then it carries the prefix and the two bounds the template declared.
+    assertIdentical(destination.Prefix, "orders/archive/");
+    assertIdentical(destination.BufferingHints.IntervalInSeconds, 120);
+    assertIdentical(destination.BufferingHints.SizeInMBs, 3);
+
+    // And a record put onto it lands under that prefix.
+    await putOrderEvent(simAws, "order-events");
+    await simAws.clock().advanceBy({ minutes: 3 });
+
+    const [key] = await deliveredObjectKeys(simAws, orderArchiveBucketName);
+    assertStringIncludes(key ?? "", "orders/archive/");
+  });
+
+  it("writes as the Role the template named", async () => {
+    // Given a stack whose delivery Role may read the Bucket and may not write
+    // to it.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: simCfnFirehoseDeliveryStreamTemplateFactory.make({
+        allowedActions: ["s3:GetObject", "s3:ListBucket"],
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // When a record is put onto the delivery stream and the interval passes.
+    await putOrderEvent(simAws, "order-events");
+    await simAws.clock().advanceBy({ minutes: 2 });
+
+    // Then nothing reached the Bucket, and the delivery was refused as that
+    // Role rather than as anyone else.
+    assertArrayLength(
+      await deliveredObjectKeys(simAws, orderArchiveBucketName),
+      0,
+    );
+
+    const failures = simAws.firehose().getDeliveryFailures();
+    assertArrayLength(failures, 1);
+    assertTrue(failures[0].wasRefused);
+    assertIdentical(failures[0].roleArn, stack.outputs.get("RoleArn")?.value);
+  });
+
+  it("deletes the delivery stream when the stack is deleted", async () => {
+    // Given a deployed delivery stream.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: simCfnFirehoseDeliveryStreamTemplateFactory.make(),
+    });
+    await stack.waitForDeployComplete();
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then the delivery stream has gone with it, and the Resource says so.
+    assertIdentical(
+      stack.getResource("OrderEvents")?.status,
+      "DELETE_COMPLETE",
+    );
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.firehose().describeDeliveryStream({
+        input: { DeliveryStreamName: "order-events" },
+      });
+    });
+    assertInstanceOf(error, SimFirehoseResourceNotFoundException);
+  });
+});

--- a/src/service/firehose/cfn/sim-cfn-firehose-delivery-stream.iso.test.ts
+++ b/src/service/firehose/cfn/sim-cfn-firehose-delivery-stream.iso.test.ts
@@ -16,6 +16,7 @@ import {
 import { SimAws } from "../../aws/sim-aws.js";
 import { SimFirehoseResourceNotFoundException } from "../error/sim-firehose.error.js";
 import {
+  cdkKinesisSource,
   cdkS3Destination,
   orderArchiveBucketName,
   simCfnFirehoseDeliveryStreamTemplateFactory,
@@ -51,6 +52,45 @@ describe("deployed AWS::KinesisFirehose::DeliveryStream Resources", () => {
 
     // Then it is in the deployed Bucket, which means the Bucket ARN the
     // template read off the Bucket beside it resolved to that Bucket.
+    const keys = await deliveredObjectKeys(simAws, orderArchiveBucketName);
+    assertArrayLength(keys, 1);
+    assertIdentical(
+      await deliveredObjectBody(simAws, orderArchiveBucketName, keys[0]),
+      '{"id":"order-1"}\n',
+    );
+  });
+
+  it("delivers from the Kinesis stream the template named as its source", async () => {
+    // Given a stack holding a Kinesis stream, a source Role, a Bucket, a
+    // delivery Role and a delivery stream reading the one into the other.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: simCfnFirehoseDeliveryStreamTemplateFactory.make({
+        sourceStreamName: "orders",
+        deliveryStreamProperties: {
+          DeliveryStreamName: "order-events",
+          DeliveryStreamType: "KinesisStreamAsSource",
+          KinesisStreamSourceConfiguration: cdkKinesisSource,
+          ExtendedS3DestinationConfiguration: cdkS3Destination,
+        },
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // When a record is put onto the deployed stream and the buffering interval
+    // passes.
+    await simAws.kinesis().putRecord({
+      input: {
+        StreamName: "orders",
+        PartitionKey: "order-1",
+        Data: new TextEncoder().encode('{"id":"order-1"}\n'),
+      },
+    });
+    await simAws.clock().advanceBy({ minutes: 2 });
+
+    // Then it reached the deployed Bucket, which means the delivery stream
+    // opened the stream the template named and read it as the Role beside it.
     const keys = await deliveredObjectKeys(simAws, orderArchiveBucketName);
     assertArrayLength(keys, 1);
     assertIdentical(

--- a/src/service/firehose/cfn/sim-cfn-firehose-resource-deleter.ts
+++ b/src/service/firehose/cfn/sim-cfn-firehose-resource-deleter.ts
@@ -1,0 +1,47 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimFirehose } from "../sim-firehose.js";
+import type { SimFirehoseDeliveryStream } from "../stream/sim-firehose-delivery-stream.js";
+import { firehoseDeliveryStreamResourceTypeName } from "./sim-cfn-firehose-resource-types.js";
+
+interface SimCfnFirehoseResourceDeleterProperties {
+  readonly firehose: SimFirehose;
+}
+
+/**
+ * Deletes the simulated Firehose resources a CloudFormation Stack created.
+ */
+export class SimCfnFirehoseResourceDeleter {
+  private readonly firehose: SimFirehose;
+
+  constructor(properties: SimCfnFirehoseResourceDeleterProperties) {
+    this.firehose = properties.firehose;
+  }
+
+  /**
+   * Delete a simulated Firehose resource created from a CloudFormation
+   * Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+  ): Promise<void> {
+    if (resourceTypeName !== firehoseDeliveryStreamResourceTypeName) {
+      throw new Error(
+        `Unsupported sim Firehose CloudFormation Resource ${resourceTypeName} deletion`,
+      );
+    }
+
+    const deliveryStream = resource.simResource as
+      | SimFirehoseDeliveryStream
+      | undefined;
+    assertDefined(
+      deliveryStream,
+      `sim Firehose delivery stream for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    await this.firehose.deleteDeliveryStream({
+      input: { DeliveryStreamName: deliveryStream.name },
+    });
+  }
+}

--- a/src/service/firehose/cfn/sim-cfn-firehose-resource-error.ts
+++ b/src/service/firehose/cfn/sim-cfn-firehose-resource-error.ts
@@ -1,0 +1,118 @@
+import {
+  SimFirehoseError,
+  SimFirehoseUnsimulatedDestination,
+  SimFirehoseUnsimulatedSource,
+} from "../error/sim-firehose.error.js";
+import { firehoseDeliveryStreamResourceType } from "./sim-cfn-firehose-resource-types.js";
+
+/**
+ * Build the error a Resource of a simulated Firehose type is refused with.
+ *
+ * The wording is deliberate. Sim CloudFormation reads an error saying a
+ * Resource is unsupported as one to record and step over, and stepping over a
+ * delivery stream that cannot be created as the template asked for it is the
+ * wrong answer where the template asked for something Firehose itself would
+ * refuse: the Stack would look deployed while nothing could be put anywhere. So
+ * a refusal here says the Resource is invalid.
+ */
+export function simCfnFirehoseResourceError(
+  resourceType: string,
+  logicalId: string,
+  reason: string,
+  cause?: unknown,
+): Error {
+  return new Error(`Invalid ${resourceType} Resource ${logicalId}: ${reason}`, {
+    cause,
+  });
+}
+
+/**
+ * Build the error a Resource outside the simulation is skipped with.
+ *
+ * The "Unsupported sim ... CloudFormation" wording is what marks the Resource
+ * as skipped rather than failing the Stack, so the rest of the template still
+ * deploys around it.
+ */
+export function simCfnFirehoseUnsupportedResourceError(
+  logicalId: string,
+  reason: string,
+  cause?: unknown,
+): Error {
+  return new Error(
+    `Unsupported sim Firehose CloudFormation Resource ${logicalId}: ${reason}`,
+    { cause },
+  );
+}
+
+/**
+ * Run the simulated Firehose commands one Resource is made of, naming the
+ * Resource in whatever they refuse.
+ *
+ * Every Resource type here goes through the ordinary Firehose commands, so what
+ * a template may ask for is decided once, by simulated Firehose, rather than
+ * again in the CloudFormation layer. What that leaves out is where the request
+ * came from: a deployment failing with `DeliveryStreamName order/events may
+ * hold only letters` says nothing about which Resource asked for it.
+ *
+ * The two refusals naming something outside the simulation are turned into
+ * skips instead. A delivery stream writing to Redshift or reading a Kinesis
+ * stream is a delivery stream this simulator has no behaviour for, and dropping
+ * it is the smallest thing that can be dropped: the Stack still deploys, and
+ * `stack.skippedResources` says what is missing. Only Firehose's own errors are
+ * touched, so a refusal the CloudFormation layer decided keeps the wording it
+ * was written with.
+ */
+export async function simCfnFirehoseResourceCreation<T>(
+  resourceType: string,
+  logicalId: string,
+  create: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await create();
+  } catch (error) {
+    if (isUnsimulatedFirehoseFeature(error)) {
+      throw simCfnFirehoseUnsupportedResourceError(
+        logicalId,
+        error.message,
+        error,
+      );
+    }
+
+    if (error instanceof SimFirehoseError) {
+      throw simCfnFirehoseResourceError(
+        resourceType,
+        logicalId,
+        error.message,
+        error,
+      );
+    }
+
+    throw error;
+  }
+}
+
+/**
+ * Whether a refusal says the delivery stream is outside the simulation, rather
+ * than that the template got it wrong.
+ */
+function isUnsimulatedFirehoseFeature(error: unknown): error is Error {
+  return (
+    error instanceof SimFirehoseUnsimulatedDestination ||
+    error instanceof SimFirehoseUnsimulatedSource
+  );
+}
+
+/**
+ * Build the error one AWS::KinesisFirehose::DeliveryStream Resource's
+ * properties are refused with.
+ */
+export function simCfnFirehoseDeliveryStreamPropertyError(
+  logicalId: string,
+  reason: string,
+): Error {
+  return simCfnFirehoseResourceError(
+    firehoseDeliveryStreamResourceType,
+    logicalId,
+    reason,
+  );
+}

--- a/src/service/firehose/cfn/sim-cfn-firehose-resource-refusals.iso.test.ts
+++ b/src/service/firehose/cfn/sim-cfn-firehose-resource-refusals.iso.test.ts
@@ -1,0 +1,248 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnDeployedResource } from "../../cloudformation/resource/sim-cfn-deployed-resource.type.js";
+import type { SimCfnDeployedStack } from "../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
+import {
+  deployedResourceObject,
+  deployedStackObject,
+} from "../../cloudformation/stack/sim-cfn-stack.fixture.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import { simCfnFirehoseResourceCreation } from "./sim-cfn-firehose-resource-error.js";
+import {
+  cdkS3Destination,
+  simCfnFirehoseDeliveryStreamTemplateFactory,
+} from "./sim-cfn-firehose-delivery-stream-template.factory.js";
+
+describe("What a deployed AWS::KinesisFirehose::DeliveryStream refuses", () => {
+  /**
+   * Deploy a delivery stream declared with the given properties, giving back
+   * whatever the deployment was refused with.
+   */
+  async function refusalFrom(
+    deliveryStreamProperties: SimCfnTemplateValueRecord,
+  ): Promise<Error> {
+    const simAws = new SimAws();
+
+    return await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: simCfnFirehoseDeliveryStreamTemplateFactory.make({
+          deliveryStreamProperties,
+        }),
+      });
+      await stack.waitForDeployComplete();
+    });
+  }
+
+  /**
+   * A deployed delivery stream, the stack that holds it and the simulation it
+   * is in.
+   */
+  async function deployedDeliveryStream(): Promise<{
+    readonly simAws: SimAws;
+    readonly stack: SimCfnDeployedStack;
+    readonly resource: SimCfnDeployedResource;
+  }> {
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: simCfnFirehoseDeliveryStreamTemplateFactory.make(),
+    });
+    await stack.waitForDeployComplete();
+
+    const resource = stack.getResource("OrderEvents");
+    assertNonNullable(resource);
+
+    return { simAws, stack, resource };
+  }
+
+  it("refuses a delivery stream name Firehose would not accept", async () => {
+    // When a template declares a delivery stream with a slash in its name.
+    const error = await refusalFrom({
+      DeliveryStreamName: "orders/live",
+      ExtendedS3DestinationConfiguration: cdkS3Destination,
+    });
+
+    // Then the deployment is refused rather than deploying a delivery stream
+    // nothing could reach by the name the template used, with the Resource
+    // named so the template can be found.
+    assertStringIncludes(error.message, "OrderEvents");
+    assertStringIncludes(error.message, "letters, digits");
+  });
+
+  it("refuses buffering hints Firehose would not accept", async () => {
+    // When a template asks to buffer for longer than Firehose ever holds one.
+    const error = await refusalFrom({
+      DeliveryStreamName: "order-events",
+      ExtendedS3DestinationConfiguration: {
+        ...cdkS3Destination,
+        BufferingHints: { IntervalInSeconds: 1000 },
+      },
+    });
+
+    // Then the deployment is refused in the words CreateDeliveryStream refuses
+    // it in.
+    assertStringIncludes(error.message, "IntervalInSeconds");
+  });
+
+  it("refuses a destination naming no Bucket", async () => {
+    // When a template names an Object rather than a Bucket.
+    const error = await refusalFrom({
+      DeliveryStreamName: "order-events",
+      ExtendedS3DestinationConfiguration: {
+        ...cdkS3Destination,
+        BucketARN: "arn:aws:s3:::order-archive/orders",
+      },
+    });
+
+    // Then the deployment is refused.
+    assertStringIncludes(error.message, "does not name a Bucket");
+  });
+
+  it("refuses a delivery stream declaring no destination", async () => {
+    // When a template declares a delivery stream and nowhere to write it.
+    const error = await refusalFrom({ DeliveryStreamName: "order-events" });
+
+    // Then the deployment is refused, as real CloudFormation refuses it, since
+    // there is nothing here for a test to assert against.
+    assertStringIncludes(error.message, "declares no destination");
+  });
+
+  it("refuses a property whose shape the template got wrong", async () => {
+    // Given templates that put the wrong kind of value in each place.
+    const wrongShapes: readonly (readonly [
+      SimCfnTemplateValueRecord,
+      string,
+    ])[] = [
+      [
+        { DeliveryStreamName: 7, ExtendedS3DestinationConfiguration: {} },
+        "DeliveryStreamName must be a string",
+      ],
+      [
+        {
+          DeliveryStreamType: 7,
+          ExtendedS3DestinationConfiguration: cdkS3Destination,
+        },
+        "DeliveryStreamType must be a string",
+      ],
+      [
+        { ExtendedS3DestinationConfiguration: "order-archive" },
+        "ExtendedS3DestinationConfiguration must be an object",
+      ],
+      [
+        { ExtendedS3DestinationConfiguration: { BucketARN: 7 } },
+        "ExtendedS3DestinationConfiguration.BucketARN must be a string",
+      ],
+      [
+        {
+          ExtendedS3DestinationConfiguration: {
+            ...cdkS3Destination,
+            BufferingHints: 60,
+          },
+        },
+        "ExtendedS3DestinationConfiguration.BufferingHints must be an object",
+      ],
+      [
+        {
+          ExtendedS3DestinationConfiguration: {
+            ...cdkS3Destination,
+            BufferingHints: { IntervalInSeconds: "a minute" },
+          },
+        },
+        "BufferingHints.IntervalInSeconds must be a number",
+      ],
+      [
+        {
+          Tags: { team: "orders" },
+          ExtendedS3DestinationConfiguration: cdkS3Destination,
+        },
+        "Tags must be a list",
+      ],
+      [
+        {
+          Tags: [{ Key: "team" }],
+          ExtendedS3DestinationConfiguration: cdkS3Destination,
+        },
+        "Tags entries must each carry a string Key and Value",
+      ],
+    ];
+
+    // When each is deployed.
+    // Then each is refused saying which property is wrong, rather than
+    // reaching CreateDeliveryStream with something it cannot explain.
+    for (const [properties, expected] of wrongShapes) {
+      // oxlint-disable-next-line no-await-in-loop
+      const error = await refusalFrom(properties);
+      assertStringIncludes(error.message, expected);
+    }
+  });
+
+  it("refuses creating a Firehose Resource type it does not simulate", async () => {
+    // Given a deployed delivery stream, and the factory that made it.
+    const { simAws, stack, resource } = await deployedDeliveryStream();
+
+    // When the factory is asked for a delivery stream's tags.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .firehose()
+        .cfnResourceFactory()
+        .create("Tags", deployedResourceObject(resource), {
+          simAws,
+          resources: deployedStackObject(stack).resourceMap,
+        });
+    });
+
+    // Then it says so, which sim CloudFormation records and steps over.
+    assertStringIncludes(
+      error.message,
+      "Unsupported sim Firehose CloudFormation Resource Tags",
+    );
+  });
+
+  it("refuses deleting a Firehose Resource type it never creates", async () => {
+    // Given a deployed delivery stream, and the factory that made it.
+    const { simAws, stack, resource } = await deployedDeliveryStream();
+
+    // When the factory is asked to delete something else.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .firehose()
+        .cfnResourceFactory()
+        .delete("Tags", deployedResourceObject(resource), {
+          simAws,
+          resources: deployedStackObject(stack).resourceMap,
+        });
+    });
+
+    // Then it says so.
+    assertStringIncludes(
+      error.message,
+      "Unsupported sim Firehose CloudFormation Resource Tags deletion",
+    );
+  });
+
+  it("passes through an error that did not come from simulated Firehose", async () => {
+    // Given a creation that fails for a reason of its own.
+    const thrown = new TypeError("the template reader broke");
+
+    // When it runs inside the wrapper that renames Firehose refusals.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simCfnFirehoseResourceCreation(
+        "AWS::KinesisFirehose::DeliveryStream",
+        "OrderEvents",
+        () => Promise.reject(thrown),
+      );
+    });
+
+    // Then it comes back as it was, since only Firehose's own refusals are
+    // reworded to name the Resource.
+    assertIdentical(error, thrown);
+  });
+});

--- a/src/service/firehose/cfn/sim-cfn-firehose-resource-refusals.iso.test.ts
+++ b/src/service/firehose/cfn/sim-cfn-firehose-resource-refusals.iso.test.ts
@@ -115,6 +115,21 @@ describe("What a deployed AWS::KinesisFirehose::DeliveryStream refuses", () => {
     assertStringIncludes(error.message, "declares no destination");
   });
 
+  it("refuses a template declaring both S3 destinations", async () => {
+    // When a template declares the same destination twice, in the extended
+    // form and the plain one.
+    const error = await refusalFrom({
+      DeliveryStreamName: "order-events",
+      ExtendedS3DestinationConfiguration: cdkS3Destination,
+      S3DestinationConfiguration: cdkS3Destination,
+    });
+
+    // Then the deployment is refused, as real CloudFormation refuses a
+    // Resource naming more than one destination.
+    assertStringIncludes(error.message, "OrderEvents");
+    assertStringIncludes(error.message, "one destination");
+  });
+
   it("refuses a property whose shape the template got wrong", async () => {
     // Given templates that put the wrong kind of value in each place.
     const wrongShapes: readonly (readonly [

--- a/src/service/firehose/cfn/sim-cfn-firehose-resource-types.ts
+++ b/src/service/firehose/cfn/sim-cfn-firehose-resource-types.ts
@@ -1,0 +1,15 @@
+/**
+ * The CloudFormation Resource types simulated Firehose creates.
+ *
+ * Named here rather than spelled out where they are used, because each one is
+ * written twice: once by the factory dispatching on it, and once by the
+ * refusals that quote it back to whoever wrote the template.
+ */
+export const firehoseDeliveryStreamResourceType =
+  "AWS::KinesisFirehose::DeliveryStream";
+
+/**
+ * The Resource type name the factory dispatches on, which is the last part of
+ * the full type.
+ */
+export const firehoseDeliveryStreamResourceTypeName = "DeliveryStream";

--- a/src/service/firehose/cfn/sim-firehose-cfn-resource-factory.ts
+++ b/src/service/firehose/cfn/sim-firehose-cfn-resource-factory.ts
@@ -1,0 +1,66 @@
+import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCloudFormationResourceDeleteContext } from "../../cloudformation/resource/sim-cfn-resource.type.js";
+import type { SimFirehose } from "../sim-firehose.js";
+import { SimCfnFirehoseDeliveryStreamCreator } from "./delivery-stream/sim-cfn-firehose-delivery-stream-creator.js";
+import { SimCfnFirehoseResourceDeleter } from "./sim-cfn-firehose-resource-deleter.js";
+import { firehoseDeliveryStreamResourceTypeName } from "./sim-cfn-firehose-resource-types.js";
+
+interface SimFirehoseCfnResourceFactoryProperties {
+  readonly firehose: SimFirehose;
+}
+
+/**
+ * CloudFormation Resource factory for simulated Firehose resources.
+ */
+export class SimFirehoseCfnResourceFactory implements SimCfnServiceResourceFactory {
+  private readonly deliveryStreamCreator: SimCfnFirehoseDeliveryStreamCreator;
+  private readonly deleter: SimCfnFirehoseResourceDeleter;
+
+  constructor(properties: SimFirehoseCfnResourceFactoryProperties) {
+    this.deliveryStreamCreator = new SimCfnFirehoseDeliveryStreamCreator({
+      firehose: properties.firehose,
+    });
+    this.deleter = new SimCfnFirehoseResourceDeleter({
+      firehose: properties.firehose,
+    });
+  }
+
+  /**
+   * Create a simulated Firehose resource from a CloudFormation Resource.
+   *
+   * The delivery stream is the one AWS::KinesisFirehose::* Resource type this
+   * simulation models.
+   */
+  async create(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<object | undefined> {
+    if (resourceTypeName !== firehoseDeliveryStreamResourceTypeName) {
+      throw new Error(
+        `Unsupported sim Firehose CloudFormation Resource ${resourceTypeName}`,
+      );
+    }
+
+    return await this.deliveryStreamCreator.create(
+      resource,
+      context.resolvedProperties ?? resource.properties,
+    );
+  }
+
+  /**
+   * Delete a simulated Firehose resource created from a CloudFormation
+   * Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    _context: SimCloudFormationResourceDeleteContext,
+  ): Promise<void> {
+    await this.deleter.delete(resourceTypeName, resource);
+  }
+}

--- a/src/service/firehose/destination/sim-firehose-destination-choice.ts
+++ b/src/service/firehose/destination/sim-firehose-destination-choice.ts
@@ -48,9 +48,10 @@ export interface SimFirehoseDestinationInput {
 /**
  * The S3 destination a request declared, or a refusal saying why there is none.
  *
- * The extended configuration wins where a request carries both, as it does on
- * real Firehose. A CDK `DeliveryStream` with an `S3Bucket` destination
- * synthesizes the extended form.
+ * A request carrying both S3 configurations is refused. Firehose takes one
+ * destination, and the two are one destination declared twice. A CDK
+ * `DeliveryStream` with an `S3Bucket` destination synthesizes the extended
+ * form.
  *
  * A destination outside the simulation is refused rather than ignored. A
  * delivery stream created against one would take records and drop them, and a
@@ -70,9 +71,19 @@ export function simFirehoseDestinationOf(
     throw new SimFirehoseUnsimulatedDestination(unsimulated[0]);
   }
 
-  const s3 =
-    input.ExtendedS3DestinationConfiguration ??
-    input.S3DestinationConfiguration;
+  const extended = input.ExtendedS3DestinationConfiguration;
+  const plain = input.S3DestinationConfiguration;
+
+  if (extended !== undefined && plain !== undefined) {
+    throw new SimFirehoseInvalidArgumentException(
+      "The delivery stream declares both ExtendedS3DestinationConfiguration " +
+        "and S3DestinationConfiguration. Firehose takes one destination. " +
+        "Declare the extended one, which carries every field the plain one " +
+        "does.",
+    );
+  }
+
+  const s3 = extended ?? plain;
 
   if (s3 === undefined) {
     throw new SimFirehoseInvalidArgumentException(

--- a/src/service/firehose/destination/sim-firehose-destination-refusals.iso.test.ts
+++ b/src/service/firehose/destination/sim-firehose-destination-refusals.iso.test.ts
@@ -72,4 +72,19 @@ describe("What a simulated Firehose delivery stream refuses to be", () => {
     assertInstanceOf(error, SimFirehoseInvalidArgumentException);
     assertStringIncludes(error.message, "no destination");
   });
+
+  it("refuses a delivery stream declaring both S3 destinations", async () => {
+    // Given a delivery stream declaring the same destination twice, in the
+    // extended form and the plain one.
+    const error = await refusalOf({
+      DeliveryStreamName: "order-events",
+      ExtendedS3DestinationConfiguration: validS3Destination,
+      S3DestinationConfiguration: validS3Destination,
+    });
+
+    // Then it is refused, as real Firehose refuses a request naming more than
+    // one destination.
+    assertInstanceOf(error, SimFirehoseInvalidArgumentException);
+    assertStringIncludes(error.message, "one destination");
+  });
 });

--- a/src/service/firehose/destination/sim-firehose-destination-refusals.iso.test.ts
+++ b/src/service/firehose/destination/sim-firehose-destination-refusals.iso.test.ts
@@ -14,6 +14,11 @@ import {
   SimFirehoseUnsimulatedDestination,
 } from "../error/sim-firehose.error.js";
 
+const validS3Destination = {
+  BucketARN: "arn:aws:s3:::order-archive",
+  RoleARN: "arn:aws:iam::888888888888:role/OrderArchiveRole",
+};
+
 /**
  * Try to create a delivery stream, and hand back what refused it.
  */

--- a/src/service/firehose/sim-firehose.ts
+++ b/src/service/firehose/sim-firehose.ts
@@ -12,6 +12,7 @@ import {
 import type * as simFirehoseCommands from "./command/sim-firehose-command.types.js";
 import { SimFirehoseCommands } from "./command/sim-firehose-commands.js";
 import type { SimFirehoseRequestOptions } from "./command/sim-firehose-request-options.js";
+import { SimFirehoseCfnResourceFactory } from "./cfn/sim-firehose-cfn-resource-factory.js";
 import type { SimFirehoseDeliveryFailure } from "./delivery/sim-firehose-delivery-failures.js";
 import { SimFirehoseFailures } from "./failure/sim-firehose-failures.js";
 import type { SimFirehoseObjectDestination } from "./delivery/sim-firehose-object-writer.js";
@@ -70,6 +71,9 @@ export class SimFirehose {
   private readonly commands: SimFirehoseCommands;
   private readonly background: BackgroundScheduler;
   private readonly sdkRouter = new SimFirehoseSdkCommandRouter(this);
+  private readonly cfnFactory = new SimFirehoseCfnResourceFactory({
+    firehose: this,
+  });
 
   constructor(properties: SimFirehoseProperties) {
     const {
@@ -188,5 +192,12 @@ export class SimFirehose {
    */
   sdkCommandRouter(): SimSdkCommandRouter {
     return this.sdkRouter;
+  }
+
+  /**
+   * Get this service's CloudFormation Resource factory.
+   */
+  cfnResourceFactory(): SimFirehoseCfnResourceFactory {
+    return this.cfnFactory;
   }
 }


### PR DESCRIPTION
An `AWS::KinesisFirehose::DeliveryStream` Resource now deploys a simulated delivery stream through `CreateDeliveryStream`, and the stack teardown deletes it. `DeliveryStreamName`, `DeliveryStreamType`, the two S3 destination configurations, `KinesisStreamSourceConfiguration` and `Tags` are read. A `Ref` gives the delivery stream name and `Fn::GetAtt` on `Arn` gives the ARN, and a template naming no delivery stream deploys under a generated name. Properties outside the simulation are recorded against the Resource and the delivery stream deploys anyway, and a delivery stream this simulator cannot deliver for is skipped and recorded while the rest of the stack deploys.

A `DeliveryStreamType` of `KinesisStreamAsSource` deploys and delivers, on top of [#938](https://github.com/KensioSoftware/yulin/pull/938). A source property such as `MSKSourceConfiguration` skips the Resource on the property rather than on `DeliveryStreamType`, since a template that leaves the type out gets `DirectPut` by default and would otherwise deploy a `DirectPut` delivery stream that read nothing.

Two changes fall outside the CloudFormation layer, both to simulated Firehose itself. A `CreateDeliveryStream` request carrying both `ExtendedS3DestinationConfiguration` and `S3DestinationConfiguration` used to create a delivery stream from the extended one and drop the other. Real Firehose takes one destination and refuses a request naming more than one, so that pair is now refused with `InvalidArgumentException`, and the CloudFormation layer hands both over without choosing between them. `SimFirehose` also gains a `cfnResourceFactory()` accessor, matching every other simulated service.

Resolves https://github.com/KensioSoftware/yulin/issues/933