### PR TITLE
feat: feed a delivery stream from a Kinesis stream

### DIFF
--- a/docs/services/firehose/README.md
+++ b/docs/services/firehose/README.md
@@ -604,14 +604,14 @@ console.log(Contents?.length);
 
 ## Supported commands
 
-| Command                  | Notes                                                                      |
-| ------------------------ | -------------------------------------------------------------------------- |
-| `CreateDeliveryStream`   | A name already in use raises `ResourceInUseException`.                     |
-| `DeleteDeliveryStream`   | The name is free again at once. Whatever was buffered goes with it.        |
-| `ListDeliveryStreams`    | Sorted by name, paged with `Limit` and `ExclusiveStartDeliveryStreamName`. |
-| `DescribeDeliveryStream` | Reports the one destination, and a Kinesis source under `Source`.          |
-| `PutRecord`              | Records up to 1,000 KiB. Refused on a Kinesis-sourced delivery stream.     |
-| `PutRecordBatch`         | Up to 500 records and 4 MiB. `FailedPutCount` is always zero.              |
+| Command                  | Notes                                                                                                   |
+| ------------------------ | ------------------------------------------------------------------------------------------------------- |
+| `CreateDeliveryStream`   | A name already in use raises `ResourceInUseException`.                                                  |
+| `DeleteDeliveryStream`   | The name is free again at once. Whatever was buffered goes with it.                                     |
+| `ListDeliveryStreams`    | Sorted by name, paged with `Limit` and `ExclusiveStartDeliveryStreamName`.                              |
+| `DescribeDeliveryStream` | Reports the one destination, and a Kinesis source under `Source`.                                       |
+| `PutRecord`              | Records up to 1,000 KiB. Refused on a Kinesis-sourced delivery stream.                                  |
+| `PutRecordBatch`         | Up to 500 records and 4 MiB, and refused on a Kinesis-sourced one too. `FailedPutCount` is always zero. |
 
 Anything else refuses on send with `SimSdkUnsupportedCommandError`, which covers
 `UpdateDestination`, `StartDeliveryStreamEncryption`, `StopDeliveryStreamEncryption` and the tag

--- a/docs/services/firehose/README.md
+++ b/docs/services/firehose/README.md
@@ -2,8 +2,9 @@
 
 Yulin includes a simulated Kinesis Data Firehose for tests and local development. A delivery stream
 takes records, buffers them, and writes them into a simulated S3 Bucket under the key format real
-Firehose uses. A test can put an event and assert on the Object it landed in, without an AWS account
-and without waiting five minutes for a buffer to flush.
+Firehose uses. The records come from `PutRecord` or off a simulated Kinesis stream. A test can put an
+event and assert on the Object it landed in, without an AWS account and without waiting five minutes
+for a buffer to flush.
 
 Firehose specific types are imported from the `@kensio/yulin/firehose` subpath.
 
@@ -236,6 +237,142 @@ since a delivery stream's configuration is fixed once it is created.
 Simulated time is what the date path and the timestamp come from. A test that sets the clock to a
 known instant knows the prefix its Objects are under, and can list them.
 
+## Reading from a Kinesis stream
+
+A delivery stream can take its records off a simulated Kinesis stream instead. Create it with a
+`DeliveryStreamType` of `KinesisStreamAsSource` and a `KinesisStreamSourceConfiguration` naming the
+stream and the Role to read it as. Records put on the stream from then on are buffered and delivered
+the way put records are.
+
+```typescript sim-firehose-kinesis-source
+/**
+ * An order event put on a Kinesis stream, and the Object the delivery stream
+ * reading that stream wrote it into.
+ */
+
+import { CreateDeliveryStreamCommand } from "@aws-sdk/client-firehose";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateStreamCommand,
+  DescribeStreamSummaryCommand,
+  PutRecordCommand,
+} from "@aws-sdk/client-kinesis";
+import { CreateBucketCommand, ListObjectsV2Command } from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws
+  .s3()
+  .createBucket(new CreateBucketCommand({ Bucket: "order-archive" }));
+
+await simAws
+  .kinesis()
+  .createStream(
+    new CreateStreamCommand({ StreamName: "orders", ShardCount: 2 }),
+  );
+
+const { StreamDescriptionSummary } = await simAws
+  .kinesis()
+  .describeStreamSummary(
+    new DescribeStreamSummaryCommand({ StreamName: "orders" }),
+  );
+
+const { Role } = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "OrderArchiveRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "firehose.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "OrderArchiveRole",
+    PolicyName: "ArchiveOrders",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Action: "s3:PutObject",
+          Resource: "arn:aws:s3:::order-archive/*",
+        },
+        {
+          Effect: "Allow",
+          Action: [
+            "kinesis:DescribeStream",
+            "kinesis:GetShardIterator",
+            "kinesis:GetRecords",
+          ],
+          Resource: StreamDescriptionSummary.StreamARN,
+        },
+      ],
+    }),
+  }),
+);
+
+await simAws.firehose().createDeliveryStream(
+  new CreateDeliveryStreamCommand({
+    DeliveryStreamName: "order-events",
+    DeliveryStreamType: "KinesisStreamAsSource",
+    KinesisStreamSourceConfiguration: {
+      KinesisStreamARN: StreamDescriptionSummary.StreamARN,
+      RoleARN: Role.Arn,
+    },
+    ExtendedS3DestinationConfiguration: {
+      BucketARN: "arn:aws:s3:::order-archive",
+      RoleARN: Role.Arn,
+      BufferingHints: { IntervalInSeconds: 60 },
+    },
+  }),
+);
+
+const orderEvent = `${JSON.stringify({ id: "order-1" })}\n`;
+
+await simAws.kinesis().putRecord(
+  new PutRecordCommand({
+    StreamName: "orders",
+    PartitionKey: "order-1",
+    Data: new TextEncoder().encode(orderEvent),
+  }),
+);
+
+await simAws.clock().advanceBy({ seconds: 60 });
+
+const { Contents } = await simAws
+  .s3()
+  .listObjectsV2(new ListObjectsV2Command({ Bucket: "order-archive" }));
+
+// 1
+console.log(Contents?.length);
+```
+
+Every shard of the stream is read, so records spread across partition keys all arrive. The Object
+holds the record data as it was put on the stream. Firehose delivers those bytes and nothing else
+about the Kinesis record.
+
+Reading starts at the end of the stream when the delivery stream is created. Real Firehose starts
+there too. A record put before that stays on the stream for whatever else is reading it.
+
+The read happens on the clock. A record put on the stream is read when simulated time next moves, so
+one `advanceBy` past the buffering interval covers both halves. `simAws.backgroundTasksComplete()`
+does not move simulated time and leaves the record on the stream.
+
+`DescribeDeliveryStream` reports the stream, the Role and the instant reading started under
+`Source.KinesisStreamSourceDescription`. `PutRecord` and `PutRecordBatch` on a delivery stream with a
+Kinesis source raise `InvalidArgumentException`, as they do on real Firehose. Put the record onto the
+stream instead.
+
+Deleting the delivery stream stops it reading. Records put afterwards stay on the stream.
+
 ## Permissions
 
 Every Firehose operation authorizes against the `firehose:` action of the same name, on the ARN of
@@ -348,8 +485,14 @@ console.log(
 console.log(failure?.wasRefused);
 ```
 
+The source `RoleARN` is a second Role, and reading is authorized against it in the same way. A Role
+that cannot read the stream stops the delivery stream reading, and the failure goes to
+`getSourceFailures()`. There is one of those per delivery stream at most. The Role is refused every
+time it asks, and going round again would record the same refusal for as long as the simulation ran.
+
 A failure carries the delivery stream, the Bucket, the key it tried, how many records were in the
-buffer, the Role it wrote as and the error itself. `wasRefused` separates an IAM denial from a
+buffer, the Role it wrote as and the error itself. A source failure carries the delivery stream, the
+stream ARN, the Role it read as and the error. `wasRefused` separates an IAM denial from a
 delivery that broke some other way. A denial is recorded quietly, since removing `s3:PutObject` is
 what a test checking the denial does. Anything else is also warned about on the console.
 
@@ -466,8 +609,8 @@ console.log(Contents?.length);
 | `CreateDeliveryStream`   | A name already in use raises `ResourceInUseException`.                     |
 | `DeleteDeliveryStream`   | The name is free again at once. Whatever was buffered goes with it.        |
 | `ListDeliveryStreams`    | Sorted by name, paged with `Limit` and `ExclusiveStartDeliveryStreamName`. |
-| `DescribeDeliveryStream` | Reports the one destination as an `ExtendedS3DestinationDescription`.      |
-| `PutRecord`              | Records up to 1,000 KiB.                                                   |
+| `DescribeDeliveryStream` | Reports the one destination, and a Kinesis source under `Source`.          |
+| `PutRecord`              | Records up to 1,000 KiB. Refused on a Kinesis-sourced delivery stream.     |
 | `PutRecordBatch`         | Up to 500 records and 4 MiB. `FailedPutCount` is always zero.              |
 
 Anything else refuses on send with `SimSdkUnsupportedCommandError`, which covers
@@ -486,9 +629,16 @@ operations.
   extended one wins where a request carries both. Either way the delivery stream describes back
   through `ExtendedS3DestinationDescription`, which is the shape carrying every field read here.
   `S3DestinationDescription` is always absent.
-- **`DirectPut` is the only source.** A `DeliveryStreamType` of `KinesisStreamAsSource` is refused,
-  along with any `KinesisStreamSourceConfiguration`. Reading a simulated Kinesis stream is
-  [issue 932](https://github.com/KensioSoftware/yulin/issues/932).
+- **`DirectPut` and `KinesisStreamAsSource` are the two sources.** Every other
+  `DeliveryStreamType`, such as `MSKAsSource` and `DatabaseAsSource`, is refused by name. A source
+  stream in another account or region is refused as well, since a simulated Firehose reads the
+  simulated Kinesis of its own scope.
+- **A source stream is read through `GetRecords`.** Enhanced fan-out is absent from simulated
+  Kinesis as well. `RetryOptions` on the destination is read and stored, and nothing here fails a
+  read in a way that would use it. A read that fails stops the delivery stream instead, and the
+  failure goes to `getSourceFailures()`.
+- **A source stream keeps the shards it was created with.** Simulated Kinesis does not reshard, so
+  the shards a delivery stream opens when it is created are the ones it reads for its life.
 - **`AWS::KinesisFirehose::DeliveryStream` is skipped on deploy.** It is a Resource type outside
   the simulation, so it is skipped and the rest of the stack deploys. Deploying one is
   [issue 933](https://github.com/KensioSoftware/yulin/issues/933).

--- a/docs/services/firehose/sim-firehose-kinesis-source.example.ts
+++ b/docs/services/firehose/sim-firehose-kinesis-source.example.ts
@@ -1,0 +1,108 @@
+/**
+ * An order event put on a Kinesis stream, and the Object the delivery stream
+ * reading that stream wrote it into.
+ */
+
+import { CreateDeliveryStreamCommand } from "@aws-sdk/client-firehose";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateStreamCommand,
+  DescribeStreamSummaryCommand,
+  PutRecordCommand,
+} from "@aws-sdk/client-kinesis";
+import { CreateBucketCommand, ListObjectsV2Command } from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws
+  .s3()
+  .createBucket(new CreateBucketCommand({ Bucket: "order-archive" }));
+
+await simAws
+  .kinesis()
+  .createStream(
+    new CreateStreamCommand({ StreamName: "orders", ShardCount: 2 }),
+  );
+
+const { StreamDescriptionSummary } = await simAws
+  .kinesis()
+  .describeStreamSummary(
+    new DescribeStreamSummaryCommand({ StreamName: "orders" }),
+  );
+
+const { Role } = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "OrderArchiveRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "firehose.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "OrderArchiveRole",
+    PolicyName: "ArchiveOrders",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Action: "s3:PutObject",
+          Resource: "arn:aws:s3:::order-archive/*",
+        },
+        {
+          Effect: "Allow",
+          Action: [
+            "kinesis:DescribeStream",
+            "kinesis:GetShardIterator",
+            "kinesis:GetRecords",
+          ],
+          Resource: StreamDescriptionSummary.StreamARN,
+        },
+      ],
+    }),
+  }),
+);
+
+await simAws.firehose().createDeliveryStream(
+  new CreateDeliveryStreamCommand({
+    DeliveryStreamName: "order-events",
+    DeliveryStreamType: "KinesisStreamAsSource",
+    KinesisStreamSourceConfiguration: {
+      KinesisStreamARN: StreamDescriptionSummary.StreamARN,
+      RoleARN: Role.Arn,
+    },
+    ExtendedS3DestinationConfiguration: {
+      BucketARN: "arn:aws:s3:::order-archive",
+      RoleARN: Role.Arn,
+      BufferingHints: { IntervalInSeconds: 60 },
+    },
+  }),
+);
+
+const orderEvent = `${JSON.stringify({ id: "order-1" })}\n`;
+
+await simAws.kinesis().putRecord(
+  new PutRecordCommand({
+    StreamName: "orders",
+    PartitionKey: "order-1",
+    Data: new TextEncoder().encode(orderEvent),
+  }),
+);
+
+await simAws.clock().advanceBy({ seconds: 60 });
+
+const { Contents } = await simAws
+  .s3()
+  .listObjectsV2(new ListObjectsV2Command({ Bucket: "order-archive" }));
+
+// 1
+console.log(Contents?.length);

--- a/docs/services/kinesis/README.md
+++ b/docs/services/kinesis/README.md
@@ -213,6 +213,12 @@ polls a stream and invokes a function with the records it reads. Every shard is 
 of its own, as real Lambda reads one, and the function's execution role is what the polling is done
 as.
 
+## Feeding a Firehose delivery stream
+
+A [Firehose delivery stream](../firehose/#reading-from-a-kinesis-stream "Simulated Firehose Kinesis source docs")
+can read a stream and buffer what it reads into an S3 Bucket. It reads every shard as its source
+`RoleARN`, starting at the end of the stream when the delivery stream is created.
+
 ## Deploying a stream
 
 `AWS::Kinesis::Stream` creates a simulated stream, which is what a CDK `Stream` synthesizes. The
@@ -441,6 +447,8 @@ Anything else refuses on send with `SimSdkUnsupportedCommandError`.
   out, and no response carries an `EncryptionType`.
 - **Tags are kept and never listed.** A stream created with `Tags` holds them, readable through
   `findStream`. `AddTagsToStream`, `ListTagsForStream` and `RemoveTagsFromStream` are absent.
-- **Kinesis Data Firehose is a separate service and is absent.** So is Kinesis Video Streams.
+- **Kinesis Data Firehose is a separate service.** It has a simulation of its own under
+  `simAws.firehose()`, and a delivery stream there can read a stream here. Kinesis Video Streams is
+  absent.
 - **`AWS::DynamoDB::Table` `KinesisStreamSpecification` stays unsimulated.** A table does not publish
   its changes into a stream here.

--- a/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
@@ -55,11 +55,16 @@ export class SimAwsSelfContainedServiceBuilder {
   /**
    * Create simulated Kinesis Data Firehose for an Account Region scope.
    *
-   * Delivery streams are Region-scoped on real AWS, and a delivery stream
-   * writes into a Bucket through that same scope's simulated S3.
+   * Delivery streams are Region-scoped on real AWS. A delivery stream writes
+   * into a Bucket through that same scope's simulated S3, and reads a source
+   * stream through that same scope's simulated Kinesis.
    */
   createFirehose(scope: SimAwsAccountRegionContainer): SimFirehose {
-    return new SimFirehose({ ...this.scoped(scope), s3: scope.s3() });
+    return new SimFirehose({
+      ...this.scoped(scope),
+      s3: scope.s3(),
+      kinesis: scope.kinesis(),
+    });
   }
 
   /**

--- a/src/service/firehose/README.md
+++ b/src/service/firehose/README.md
@@ -1,31 +1,42 @@
 # Simulated Kinesis Data Firehose implementation
 
-This directory holds the simulated Kinesis Data Firehose service. S3 is the only destination and
-`DirectPut` the only source.
+This directory holds the simulated Kinesis Data Firehose service. S3 is the only destination.
 
-A delivery stream is a destination and a buffer. Records go on through `PutRecord`, wait until the
-buffer passes one of its two bounds, and leave as one S3 Object.
+A delivery stream is a source, a destination and a buffer. Records arrive from where the source says
+they do, wait until the buffer passes one of its two bounds, and leave as one S3 Object. A
+`DirectPut` delivery stream takes them from `PutRecord`. A `KinesisStreamAsSource` one reads them off
+a simulated Kinesis stream.
 
 ## Entry points
 
 - `sim-firehose.ts` is the in-memory service object for one Account and Region scope.
 - `index.ts` exports the public API for `@kensio/yulin/firehose`.
 
-A `SimFirehose` owns a `SimFirehoseDeliveryStreamStore` holding its delivery streams, and a
-`SimFirehoseDeliveryFailures` holding the buffers it could not write. The simulator is scoped to an
-Account and Region because real delivery streams are. A delivery stream ARN names the Region, and a
-delivery stream name is unique within one Account and Region.
+A `SimFirehose` owns a `SimFirehoseDeliveryStreamStore` holding its delivery streams, and two
+`SimFirehoseFailures` lists holding the buffers it could not write and the source streams it stopped
+reading. The simulator is scoped to an Account and Region because real delivery streams are. A
+delivery stream ARN names the Region, and a delivery stream name is unique within one Account and
+Region.
 
-This one is built with a collaborator, unlike most of the self-contained services. It takes the
-simulated S3 of its own scope as a `SimFirehoseObjectDestination`. That interface names the one
-operation delivery needs, and `SimS3` implements it structurally.
+This one is built with collaborators, unlike most of the self-contained services. It takes the
+simulated S3 of its own scope as a `SimFirehoseObjectDestination`, and the simulated Kinesis of that
+scope as a `SimFirehoseRecordSource`. Each interface names the operations one half of the delivery
+stream needs, and `SimS3` and `SimKinesis` implement them structurally. A `SimFirehose` built with no
+Kinesis falls back to `SimFirehoseNoRecordSource`, which refuses every read and says how to reach a
+stream.
+
+Both failure lists are the same `SimFirehoseFailures` under `failure/`, holding a
+`SimFirehoseDeliveryFailure` or a `SimFirehoseSourceFailure`. A refusal is recorded quietly and
+anything else is warned about once, which is the line `SimS3NotificationFailures` draws for the same
+reason. Taking `s3:PutObject` or `kinesis:GetRecords` off a Role is what a test checking the refusal
+does.
 
 ## Delivery stream model
 
 Delivery stream state lives under `stream/`, and what it delivers to under `destination/`.
 
-`SimFirehoseDeliveryStream` is the stored resource. It holds its name, its ARN, its destination and
-its buffer.
+`SimFirehoseDeliveryStream` is the stored resource. It holds its name, its ARN, its source, its
+destination and its buffer.
 
 `SimFirehoseS3Destination` is a parsed `ExtendedS3DestinationConfiguration`. The Bucket is held by
 name as well as by ARN, because a `PutObject` names a Bucket. An S3 Bucket ARN carries no Account
@@ -39,6 +50,43 @@ created. A request asking for a buffer Firehose would refuse is refused here, at
 simulation is refused by name, with `SimFirehoseUnsimulatedDestination`. A delivery stream created
 against Redshift or OpenSearch would take records and drop them, and a test asserting on an empty
 Bucket would blame the code under test.
+
+## Source
+
+Where a delivery stream's records come from lives under `source/`, and how it reads them under
+`source/read/`.
+
+`simFirehoseSourceOf` reads the source a request declared, the way `simFirehoseDestinationOf` reads
+the destination. It answers with a `SimFirehoseDirectPutSource` or a `SimFirehoseKinesisSource`, and
+the delivery stream reports its `DeliveryStreamType` from whichever it holds. Both answer
+`requirePut`, so a put refuses on the one that reads a stream without a handler asking which kind it
+has.
+
+A source stream in another Account or Region is refused with `SimFirehoseUnsimulatedSource`. This
+Firehose reads the simulated Kinesis of its own scope, and a foreign ARN reaches nothing.
+
+`SimFirehoseSourceReading` holds one `SimFirehoseSourceReader` per delivery stream that reads. The
+reader is started before CreateDeliveryStream answers, and it opens every shard at the end of the
+stream through `SimFirehoseSourceShards`. The place has to be taken then. A `LATEST` iterator stands
+after the newest record on the shard when the iterator was made, so opening the shards at the first
+read would step over the record that woke the delivery stream up.
+
+`SimFirehoseSourcePoll` decides when the reader reads. Simulated Kinesis says when a record has been
+put, through the same `streamActivity` a Lambda event source mapping watches, and the reader
+schedules a read on the clock for the instant the simulation currently reads. Advancing time then
+moves records from the stream into the buffer, and the same advance can carry that buffer past its
+interval. A read scheduled off the clock would happen after the advance instead, leaving a test to
+advance twice for one record.
+
+Compare `src/service/lambda/event-source/poll/kinesis/`, which reads the same streams the same way
+for a function. What a mapping does with a batch is most of that code. A batch belongs to one shard,
+the function answers for it, and a failure sends the mapping back to a record it named. A delivery
+stream answers for nothing. It buffers what every shard gave it and delivers on a bound, so the
+checkpoint, the retry backoff and the per-shard poller have no counterpart here.
+
+A read that fails stops the delivery stream reading and goes on `SimFirehoseSourceFailures`. The Role
+is refused every time it asks, and going round again would record the same refusal for as long as the
+simulation ran.
 
 ## Delivery
 
@@ -75,6 +123,10 @@ A test that sets the clock therefore knows the prefix its Objects are under.
 Command handlers live under `command/`, grouped by what they act on: `stream/` creates, lists,
 describes and deletes, and `record/` puts.
 
+`SimFirehosePutCommands` asks the delivery stream's source to take the put before it takes it. Real
+Firehose refuses `PutRecord` and `PutRecordBatch` on a delivery stream with a Kinesis source, since
+the records it delivers are the ones on its stream.
+
 `SimFirehoseDeliveryStreamAccess` is how every operation but `ListDeliveryStreams` and
 `CreateDeliveryStream` reaches its delivery stream. It authorizes the action against the delivery
 stream's ARN and then looks the delivery stream up, in that order, because that is the order real
@@ -94,10 +146,9 @@ an intercepted client sends is refused with `SimSdkUnsupportedCommandError`, whi
 There is no `cfn/` here. `AWS::KinesisFirehose::DeliveryStream` is skipped on deploy, and issue 933
 is where it is added.
 
-`DeliveryStreamType` of `KinesisStreamAsSource` is refused with `SimFirehoseUnsimulatedSource`.
-Issue 932 is where a delivery stream reading a simulated Kinesis stream is added. It wants a poller
-of its own, because the one under `src/service/lambda/event-source/poll/kinesis/` is bound to a
-function and a mapping.
+Enhanced fan-out is left out on the source side. A delivery stream reads through `GetRecords`, which
+is the shared throughput path every stream has, and simulated Kinesis has nothing else. Resharding is
+left out with it.
 
 `docs/services/firehose/README.md` is the user-facing page, and its **Divergences and limitations**
 section is the full list.

--- a/src/service/firehose/command/record/sim-firehose-put-commands.ts
+++ b/src/service/firehose/command/record/sim-firehose-put-commands.ts
@@ -29,6 +29,10 @@ interface SimFirehosePutCommandsProperties {
  * `Encrypted` is always false. Server side encryption changes nothing a test
  * can see, so `DeliveryStreamEncryptionConfigurationInput` is left unsimulated
  * and no delivery stream reports itself encrypted.
+ *
+ * A delivery stream reading a Kinesis stream takes neither put. Its records
+ * come off the stream, and real Firehose refuses a producer trying to put one
+ * on it directly.
  */
 export class SimFirehosePutCommands {
   private readonly access: SimFirehoseDeliveryStreamAccess;
@@ -51,6 +55,8 @@ export class SimFirehosePutCommands {
       command.input.DeliveryStreamName,
       options,
     );
+
+    deliveryStream.source.requirePut("PutRecord", deliveryStream.name);
 
     this.delivery.accept(
       deliveryStream,
@@ -77,6 +83,8 @@ export class SimFirehosePutCommands {
       command.input.DeliveryStreamName,
       options,
     );
+
+    deliveryStream.source.requirePut("PutRecordBatch", deliveryStream.name);
     const data = simFirehoseBatchData(command.input.Records);
     const responses: SimFirehosePutRecordBatchResponseEntry[] = [];
 

--- a/src/service/firehose/command/sim-firehose-commands.ts
+++ b/src/service/firehose/command/sim-firehose-commands.ts
@@ -7,6 +7,9 @@ import {
   type SimFirehoseObjectDestination,
   SimFirehoseObjectWriter,
 } from "../delivery/sim-firehose-object-writer.js";
+import type { SimFirehoseRecordSource } from "../source/sim-firehose-record-source.js";
+import type { SimFirehoseSourceFailures } from "../source/sim-firehose-source-failures.js";
+import { SimFirehoseSourceReading } from "../source/read/sim-firehose-source-reading.js";
 import type { SimFirehoseDeliveryStreamStore } from "../stream/sim-firehose-delivery-stream-store.js";
 import { SimFirehoseAuthorizer } from "./authorize/sim-firehose-authorizer.js";
 import { SimFirehosePutCommands } from "./record/sim-firehose-put-commands.js";
@@ -17,7 +20,9 @@ import { SimFirehoseStreamCommands } from "./stream/sim-firehose-stream-commands
 interface SimFirehoseCommandsProperties {
   readonly deliveryStreams: SimFirehoseDeliveryStreamStore;
   readonly failures: SimFirehoseDeliveryFailures;
+  readonly sourceFailures: SimFirehoseSourceFailures;
   readonly s3: SimFirehoseObjectDestination;
+  readonly kinesis: SimFirehoseRecordSource;
   readonly iam: SimIamInterServiceAuthZ;
   readonly background: BackgroundScheduler;
   readonly accountRegionScope: SimAwsAccountRegionScope;
@@ -51,16 +56,25 @@ export class SimFirehoseCommands {
       }),
     });
 
+    const sourceReading = new SimFirehoseSourceReading({
+      records: properties.kinesis,
+      failures: properties.sourceFailures,
+      delivery,
+      background,
+    });
+
     this.creation = new SimFirehoseCreateDeliveryStream({
       deliveryStreams,
       access,
       accountRegionScope,
       background,
+      sourceReading,
     });
     this.deliveryStreams = new SimFirehoseStreamCommands({
       deliveryStreams,
       access,
       delivery,
+      sourceReading,
     });
     this.puts = new SimFirehosePutCommands({ access, delivery });
   }

--- a/src/service/firehose/command/stream/sim-firehose-create-delivery-stream.ts
+++ b/src/service/firehose/command/stream/sim-firehose-create-delivery-stream.ts
@@ -1,10 +1,9 @@
 import type { BackgroundScheduler } from "../../../../util/background/background.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import { simFirehoseDestinationOf } from "../../destination/sim-firehose-destination-choice.js";
-import {
-  SimFirehoseResourceInUseException,
-  SimFirehoseUnsimulatedSource,
-} from "../../error/sim-firehose.error.js";
+import { SimFirehoseResourceInUseException } from "../../error/sim-firehose.error.js";
+import { simFirehoseSourceOf } from "../../source/sim-firehose-source-choice.js";
+import type { SimFirehoseSourceReading } from "../../source/read/sim-firehose-source-reading.js";
 import { simFirehoseDeliveryStreamArn } from "../../stream/sim-firehose-delivery-stream-arn.js";
 import { requireSimFirehoseDeliveryStreamName } from "../../stream/sim-firehose-delivery-stream-name.js";
 import { SimFirehoseDeliveryStream } from "../../stream/sim-firehose-delivery-stream.js";
@@ -13,7 +12,6 @@ import type { SimFirehoseDeliveryStreamAccess } from "../sim-firehose-delivery-s
 import type { SimFirehoseRequestOptions } from "../sim-firehose-request-options.js";
 import type {
   SimCreateDeliveryStreamCommand,
-  SimCreateDeliveryStreamCommandInput,
   SimCreateDeliveryStreamCommandOutput,
 } from "./stream.command.js";
 
@@ -22,6 +20,7 @@ interface SimFirehoseCreateDeliveryStreamProperties {
   readonly access: SimFirehoseDeliveryStreamAccess;
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly background: BackgroundScheduler;
+  readonly sourceReading: SimFirehoseSourceReading;
 }
 
 /**
@@ -36,67 +35,66 @@ export class SimFirehoseCreateDeliveryStream {
   private readonly access: SimFirehoseDeliveryStreamAccess;
   private readonly scope: SimAwsAccountRegionScope;
   private readonly background: BackgroundScheduler;
+  private readonly sourceReading: SimFirehoseSourceReading;
 
   constructor(properties: SimFirehoseCreateDeliveryStreamProperties) {
     this.deliveryStreams = properties.deliveryStreams;
     this.access = properties.access;
     this.scope = properties.accountRegionScope;
     this.background = properties.background;
+    this.sourceReading = properties.sourceReading;
   }
 
   /**
    * Handle a CreateDeliveryStream request.
    *
-   * The destination is read before the name is taken, so a request naming a
-   * destination this simulation cannot deliver to leaves nothing behind.
+   * The source and the destination are read before the delivery stream is
+   * stored, so a request naming somewhere this simulation cannot read or
+   * deliver leaves nothing behind.
+   *
+   * A Kinesis-sourced delivery stream is reading its stream by the time this
+   * answers, so a record put the moment it exists is one it sees. A source it
+   * could not open stops the delivery and is recorded on the simulator, since
+   * that is what real Firehose does with a Role that cannot read: the delivery
+   * stream is created either way.
    */
-  handle(
+  async handle(
     command: SimCreateDeliveryStreamCommand,
     options?: SimFirehoseRequestOptions,
-  ): SimCreateDeliveryStreamCommandOutput {
+  ): Promise<SimCreateDeliveryStreamCommandOutput> {
     const { input } = command;
     const name = requireSimFirehoseDeliveryStreamName(input.DeliveryStreamName);
 
     this.access.authorizeName("firehose:CreateDeliveryStream", name, options);
-    requireDirectPutSource(input);
+    this.requireNameFree(name);
 
+    const createdAt = this.background.now();
+    const source = simFirehoseSourceOf(input, this.scope, createdAt);
+    const arn = simFirehoseDeliveryStreamArn(this.scope, name);
+    const deliveryStream = new SimFirehoseDeliveryStream({
+      name,
+      arn,
+      destination: simFirehoseDestinationOf(input),
+      source,
+      createdAt,
+    });
+
+    this.deliveryStreams.add(deliveryStream);
+
+    await this.sourceReading.start(deliveryStream);
+
+    return { $metadata: {}, DeliveryStreamARN: arn };
+  }
+
+  /**
+   * Refuse a name this scope already holds a delivery stream under.
+   */
+  private requireNameFree(name: string): void {
     if (this.deliveryStreams.find(name) !== undefined) {
       throw new SimFirehoseResourceInUseException(
         `Firehose already holds a delivery stream named ${name} under this ` +
           `account and region`,
       );
     }
-
-    const arn = simFirehoseDeliveryStreamArn(this.scope, name);
-
-    this.deliveryStreams.add(
-      new SimFirehoseDeliveryStream({
-        name,
-        arn,
-        destination: simFirehoseDestinationOf(input),
-        createdAt: this.background.now(),
-      }),
-    );
-
-    return { $metadata: {}, DeliveryStreamARN: arn };
-  }
-}
-
-/**
- * Refuse a delivery stream that would read from somewhere this simulation
- * cannot read from.
- *
- * An omitted `DeliveryStreamType` is `DirectPut` on real Firehose too.
- */
-function requireDirectPutSource(
-  input: SimCreateDeliveryStreamCommandInput,
-): void {
-  const type = input.DeliveryStreamType ?? "DirectPut";
-
-  if (
-    type !== "DirectPut" ||
-    input.KinesisStreamSourceConfiguration !== undefined
-  ) {
-    throw new SimFirehoseUnsimulatedSource();
   }
 }

--- a/src/service/firehose/command/stream/sim-firehose-delivery-stream-lifecycle.iso.test.ts
+++ b/src/service/firehose/command/stream/sim-firehose-delivery-stream-lifecycle.iso.test.ts
@@ -240,7 +240,7 @@ describe("Simulated Firehose delivery stream lifecycle", () => {
   });
 
   it("lists nothing for a delivery stream type nothing has", async () => {
-    // Given a DirectPut delivery stream, which is the only type simulated.
+    // Given a DirectPut delivery stream, and nothing reading a stream.
     const simAws = await simAwsWithBucket();
     await simFirehoseDeliveryStreamFactory.make({}, simAws);
 

--- a/src/service/firehose/command/stream/sim-firehose-stream-commands.ts
+++ b/src/service/firehose/command/stream/sim-firehose-stream-commands.ts
@@ -1,4 +1,5 @@
 import type { SimFirehoseDelivery } from "../../delivery/sim-firehose-delivery.js";
+import type { SimFirehoseSourceReading } from "../../source/read/sim-firehose-source-reading.js";
 import type { SimFirehoseDeliveryStreamStore } from "../../stream/sim-firehose-delivery-stream-store.js";
 import type { SimFirehoseDeliveryStreamAccess } from "../sim-firehose-delivery-stream-access.js";
 import type { SimFirehoseRequestOptions } from "../sim-firehose-request-options.js";
@@ -23,6 +24,7 @@ interface SimFirehoseStreamCommandsProperties {
   readonly deliveryStreams: SimFirehoseDeliveryStreamStore;
   readonly access: SimFirehoseDeliveryStreamAccess;
   readonly delivery: SimFirehoseDelivery;
+  readonly sourceReading: SimFirehoseSourceReading;
 }
 
 /**
@@ -32,11 +34,13 @@ export class SimFirehoseStreamCommands {
   private readonly deliveryStreams: SimFirehoseDeliveryStreamStore;
   private readonly access: SimFirehoseDeliveryStreamAccess;
   private readonly delivery: SimFirehoseDelivery;
+  private readonly sourceReading: SimFirehoseSourceReading;
 
   constructor(properties: SimFirehoseStreamCommandsProperties) {
     this.deliveryStreams = properties.deliveryStreams;
     this.access = properties.access;
     this.delivery = properties.delivery;
+    this.sourceReading = properties.sourceReading;
   }
 
   /**
@@ -46,9 +50,8 @@ export class SimFirehoseStreamCommands {
    * authorizes against every delivery stream in the Account and Region and does
    * not filter the list by what the caller can reach.
    *
-   * `DeliveryStreamType` filters the list on real Firehose. `DirectPut` is the
-   * only type a simulated delivery stream has, so asking for
-   * `KinesisStreamAsSource` lists nothing.
+   * `DeliveryStreamType` filters the list on real Firehose, and it filters
+   * here on the type each delivery stream was created with.
    */
   listDeliveryStreams(
     command: SimListDeliveryStreamsCommand,
@@ -100,6 +103,9 @@ export class SimFirehoseStreamCommands {
    * Whatever it was holding goes with it. Real Firehose delivers the buffer
    * first, and an Object landing after the delivery stream naming it has gone
    * is nothing a test could expect.
+   *
+   * A delivery stream reading a Kinesis stream stops reading it here. Its place
+   * on the stream goes with it, and records put afterwards stay on the stream.
    */
   deleteDeliveryStream(
     command: SimDeleteDeliveryStreamCommand,
@@ -111,6 +117,7 @@ export class SimFirehoseStreamCommands {
       options,
     );
 
+    this.sourceReading.forget(deliveryStream);
     this.delivery.forget(deliveryStream);
     this.deliveryStreams.remove(deliveryStream);
 

--- a/src/service/firehose/command/stream/sim-firehose-stream-descriptions.ts
+++ b/src/service/firehose/command/stream/sim-firehose-stream-descriptions.ts
@@ -1,7 +1,9 @@
+import type { SimFirehoseSource } from "../../source/sim-firehose-source.js";
 import type { SimFirehoseDeliveryStream } from "../../stream/sim-firehose-delivery-stream.js";
 import type {
   SimFirehoseDeliveryStreamDescription,
   SimFirehoseDestinationDescription,
+  SimFirehoseSourceDescription,
 } from "./stream.command.js";
 
 /**
@@ -33,8 +35,34 @@ export function deliveryStreamDescription(
     DeliveryStreamType: deliveryStream.deliveryStreamType,
     VersionId: deliveryStream.versionId,
     CreateTimestamp: deliveryStream.createdAt,
+    ...sourceDescription(deliveryStream.source),
     Destinations: [destinationDescription(deliveryStream)],
     HasMoreDestinations: false,
+  };
+}
+
+/**
+ * Where a delivery stream reads from, for the ones that read.
+ *
+ * A `DirectPut` delivery stream carries no `Source` at all, which is what real
+ * Firehose reports for one, so this answers with nothing to spread rather than
+ * with an absent field.
+ */
+function sourceDescription(source: SimFirehoseSource): {
+  Source?: SimFirehoseSourceDescription;
+} {
+  if (source.kind !== "kinesis-stream") {
+    return {};
+  }
+
+  return {
+    Source: {
+      KinesisStreamSourceDescription: {
+        KinesisStreamARN: source.streamArn.value,
+        RoleARN: source.roleArn,
+        DeliveryStartTimestamp: source.startedAt,
+      },
+    },
   };
 }
 

--- a/src/service/firehose/command/stream/stream.command.ts
+++ b/src/service/firehose/command/stream/stream.command.ts
@@ -1,5 +1,6 @@
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
 import type { SimFirehoseDestinationInput } from "../../destination/sim-firehose-destination-choice.js";
+import type { SimFirehoseSourceInput } from "../../source/sim-firehose-source-choice.js";
 
 /**
  * One tag as a CreateDeliveryStream request carries it.
@@ -18,10 +19,9 @@ export interface SimCreateDeliveryStreamCommand {
   readonly input: SimCreateDeliveryStreamCommandInput;
 }
 
-export interface SimCreateDeliveryStreamCommandInput extends SimFirehoseDestinationInput {
+export interface SimCreateDeliveryStreamCommandInput
+  extends SimFirehoseDestinationInput, SimFirehoseSourceInput {
   readonly DeliveryStreamName?: string | undefined;
-  readonly DeliveryStreamType?: string | undefined;
-  readonly KinesisStreamSourceConfiguration?: unknown;
   readonly DeliveryStreamEncryptionConfigurationInput?: unknown;
   readonly Tags?: readonly SimFirehoseTag[] | undefined;
 }
@@ -100,6 +100,27 @@ export interface SimFirehoseDestinationDescription {
 }
 
 /**
+ * The Kinesis stream a delivery stream reads, as DescribeDeliveryStream reports
+ * it.
+ */
+export interface SimFirehoseKinesisStreamSourceDescription {
+  readonly KinesisStreamARN: string;
+  readonly RoleARN: string;
+  readonly DeliveryStartTimestamp: Date;
+}
+
+/**
+ * Where a delivery stream's records come from, as DescribeDeliveryStream
+ * reports it.
+ *
+ * A `DirectPut` delivery stream reports no source at all, as it does on real
+ * Firehose. Nothing put the records there but the producer.
+ */
+export interface SimFirehoseSourceDescription {
+  readonly KinesisStreamSourceDescription: SimFirehoseKinesisStreamSourceDescription;
+}
+
+/**
  * One delivery stream, as DescribeDeliveryStream reports it.
  */
 export interface SimFirehoseDeliveryStreamDescription {
@@ -109,6 +130,7 @@ export interface SimFirehoseDeliveryStreamDescription {
   readonly DeliveryStreamType: string;
   readonly VersionId: string;
   readonly CreateTimestamp: Date;
+  readonly Source?: SimFirehoseSourceDescription | undefined;
   readonly Destinations: readonly SimFirehoseDestinationDescription[];
   readonly HasMoreDestinations: boolean;
 }

--- a/src/service/firehose/delivery/sim-firehose-delivery-failures.ts
+++ b/src/service/firehose/delivery/sim-firehose-delivery-failures.ts
@@ -1,4 +1,5 @@
-import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
+import { SimFirehoseFailure } from "../failure/sim-firehose-failure.js";
+import type { SimFirehoseFailures } from "../failure/sim-firehose-failures.js";
 
 interface SimFirehoseDeliveryFailureProperties {
   readonly deliveryStreamName: string;
@@ -12,99 +13,37 @@ interface SimFirehoseDeliveryFailureProperties {
 /**
  * One buffer a delivery stream could not write.
  */
-export class SimFirehoseDeliveryFailure {
-  public readonly deliveryStreamName: string;
+export class SimFirehoseDeliveryFailure extends SimFirehoseFailure {
   public readonly bucketName: string;
   public readonly objectKey: string;
   public readonly recordCount: number;
-  public readonly roleArn: string;
-  public readonly error: unknown;
 
   constructor(properties: SimFirehoseDeliveryFailureProperties) {
-    this.deliveryStreamName = properties.deliveryStreamName;
+    super(properties);
     this.bucketName = properties.bucketName;
     this.objectKey = properties.objectKey;
     this.recordCount = properties.recordCount;
-    this.roleArn = properties.roleArn;
-    this.error = properties.error;
   }
 
   /**
-   * Whether IAM refused the write rather than the write going wrong.
+   * How a buffer that did not reach its Bucket reads on the console.
    */
-  get wasRefused(): boolean {
-    return this.error instanceof SimIamAccessDenied;
-  }
-
-  /**
-   * What went wrong, in one line.
-   */
-  get reason(): string {
-    return this.error instanceof Error
-      ? this.error.message
-      : String(this.error);
+  override get warning(): string {
+    return (
+      `Simulated Kinesis Data Firehose delivery stream ` +
+      `${this.deliveryStreamName} could not write to ` +
+      `s3://${this.bucketName}/${this.objectKey}: ${this.reason}`
+    );
   }
 }
 
 /**
- * What became of the buffers a simulated Firehose scope could not deliver.
+ * The buffers a simulated Firehose scope could not deliver.
  *
  * Real Firehose answers a `PutRecord` long before the buffer that record joined
  * is delivered. A delivery that fails minutes later reaches the producer
  * through CloudWatch and the error output prefix, and neither of those is
  * simulated. Every failure is kept here for a test to read.
- *
- * A refusal is warned about, and an IAM denial is recorded quietly. Removing
- * `s3:PutObject` from the delivery role is what a test checking the denial
- * does, and that test should not have to read a warning about the thing it
- * asked for. Compare SimS3NotificationFailures, which draws the same line for
- * the same reason.
  */
-export class SimFirehoseDeliveryFailures {
-  private readonly failures: SimFirehoseDeliveryFailure[] = [];
-  private readonly warned = new Set<string>();
-
-  /**
-   * Every buffer this scope could not deliver, oldest first.
-   */
-  get all(): readonly SimFirehoseDeliveryFailure[] {
-    return this.failures;
-  }
-
-  /**
-   * Record a buffer that did not reach its Bucket.
-   */
-  record(failure: SimFirehoseDeliveryFailure): void {
-    this.failures.push(failure);
-
-    if (failure.wasRefused) {
-      return;
-    }
-
-    this.warn(failure);
-  }
-
-  /**
-   * Warn about a delivery that failed, once per delivery stream and cause.
-   *
-   * Warnings go to the console because that is where a test runner surfaces
-   * them next to the failing expectation they explain. The simulator has no
-   * logger of its own to route them through.
-   */
-  private warn(failure: SimFirehoseDeliveryFailure): void {
-    const key = `${failure.deliveryStreamName}:${failure.reason}`;
-
-    if (this.warned.has(key)) {
-      return;
-    }
-
-    this.warned.add(key);
-
-    // oxlint-disable-next-line no-console
-    console.warn(
-      `Simulated Kinesis Data Firehose delivery stream ` +
-        `${failure.deliveryStreamName} could not write to ` +
-        `s3://${failure.bucketName}/${failure.objectKey}: ${failure.reason}`,
-    );
-  }
-}
+export type SimFirehoseDeliveryFailures =
+  SimFirehoseFailures<SimFirehoseDeliveryFailure>;

--- a/src/service/firehose/destination/sim-firehose-destination-refusals.iso.test.ts
+++ b/src/service/firehose/destination/sim-firehose-destination-refusals.iso.test.ts
@@ -12,13 +12,7 @@ import type { SimCreateDeliveryStreamCommandInput } from "../command/stream/stre
 import {
   SimFirehoseInvalidArgumentException,
   SimFirehoseUnsimulatedDestination,
-  SimFirehoseUnsimulatedSource,
 } from "../error/sim-firehose.error.js";
-
-const validS3Destination = {
-  BucketARN: "arn:aws:s3:::order-archive",
-  RoleARN: "arn:aws:iam::888888888888:role/OrderArchiveRole",
-};
 
 /**
  * Try to create a delivery stream, and hand back what refused it.
@@ -77,23 +71,5 @@ describe("What a simulated Firehose delivery stream refuses to be", () => {
 
     assertInstanceOf(error, SimFirehoseInvalidArgumentException);
     assertStringIncludes(error.message, "no destination");
-  });
-
-  it("refuses a Kinesis stream as the source", async () => {
-    // Given a delivery stream that would read from a Kinesis stream.
-    const error = await refusalOf({
-      DeliveryStreamName: "order-events",
-      DeliveryStreamType: "KinesisStreamAsSource",
-      KinesisStreamSourceConfiguration: {
-        KinesisStreamARN:
-          "arn:aws:kinesis:us-east-1:888888888888:stream/orders",
-        RoleARN: "arn:aws:iam::888888888888:role/OrderArchiveRole",
-      },
-      ExtendedS3DestinationConfiguration: validS3Destination,
-    });
-
-    // Then it says so, rather than taking nothing and delivering nothing.
-    assertInstanceOf(error, SimFirehoseUnsimulatedSource);
-    assertStringIncludes(error.message, "DirectPut");
   });
 });

--- a/src/service/firehose/error/sim-firehose.error.ts
+++ b/src/service/firehose/error/sim-firehose.error.ts
@@ -85,21 +85,15 @@ export class SimFirehoseUnsimulatedDestination extends SimFirehoseError {
 /**
  * Simulated Firehose UnsimulatedSource error.
  *
- * This has no counterpart on real Firehose. `DirectPut` is the only source
- * simulated, and a delivery stream reading from a Kinesis stream would take
- * nothing and deliver nothing. Refusing at CreateDeliveryStream says so where
- * the request that asked for it is.
+ * This has no counterpart on real Firehose. A delivery stream takes records put
+ * on it, or reads them off a simulated Kinesis stream in its own Account and
+ * Region. A source outside that would take nothing and deliver nothing, so it
+ * is refused at CreateDeliveryStream, where the request that asked for it is.
  */
 export class SimFirehoseUnsimulatedSource extends SimFirehoseError {
   public override readonly name = "SimFirehoseUnsimulatedSource";
 
-  constructor() {
-    super(
-      "Simulated Kinesis Data Firehose takes records through PutRecord and " +
-        "PutRecordBatch only. A delivery stream reading from a Kinesis " +
-        "stream is not simulated, so leave DeliveryStreamType at DirectPut " +
-        "and put the records the delivery stream should see.",
-      { httpStatusCode: 400 },
-    );
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
   }
 }

--- a/src/service/firehose/failure/sim-firehose-failure.ts
+++ b/src/service/firehose/failure/sim-firehose-failure.ts
@@ -1,0 +1,55 @@
+import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
+
+interface SimFirehoseFailureProperties {
+  readonly deliveryStreamName: string;
+  readonly roleArn: string;
+  readonly error: unknown;
+}
+
+/**
+ * Something a delivery stream could not do, kept where a test can read it.
+ *
+ * A delivery stream works out of sight of the caller. Real Firehose answered
+ * the producer minutes before it wrote the buffer that record joined, and it
+ * reads its source stream with no caller in front of it at all. What went wrong
+ * reaches a real operator through CloudWatch, which is not simulated, so it is
+ * kept on the simulator instead.
+ *
+ * The Role is on every failure because it is the usual cause: the delivery
+ * Role that cannot write to the Bucket, or the source Role that cannot read the
+ * stream.
+ */
+export abstract class SimFirehoseFailure {
+  public readonly deliveryStreamName: string;
+  public readonly roleArn: string;
+  public readonly error: unknown;
+
+  constructor(properties: SimFirehoseFailureProperties) {
+    this.deliveryStreamName = properties.deliveryStreamName;
+    this.roleArn = properties.roleArn;
+    this.error = properties.error;
+  }
+
+  /**
+   * Whether IAM refused this rather than it going wrong.
+   */
+  get wasRefused(): boolean {
+    return this.error instanceof SimIamAccessDenied;
+  }
+
+  /**
+   * What went wrong, in one line.
+   */
+  get reason(): string {
+    if (this.error instanceof Error) {
+      return this.error.message;
+    }
+
+    return String(this.error);
+  }
+
+  /**
+   * How this failure reads on the console, for the ones worth warning about.
+   */
+  abstract get warning(): string;
+}

--- a/src/service/firehose/failure/sim-firehose-failures.ts
+++ b/src/service/firehose/failure/sim-firehose-failures.ts
@@ -1,0 +1,56 @@
+import type { SimFirehoseFailure } from "./sim-firehose-failure.js";
+
+/**
+ * What became of the work a simulated Firehose scope could not do.
+ *
+ * A refusal is recorded quietly and anything else is warned about. Taking a
+ * permission off a Role is what a test checking the refusal does, and that test
+ * should not have to read a warning about the thing it asked for. Anything else
+ * is a broken simulation, and a test that never reads this list should still
+ * hear about it. Compare SimS3NotificationFailures, which draws the same line
+ * for the same reason.
+ *
+ * Warnings go to the console because that is where a test runner surfaces them
+ * next to the failing expectation they explain. The simulator has no logger of
+ * its own to route them through.
+ */
+export class SimFirehoseFailures<TFailure extends SimFirehoseFailure> {
+  private readonly failures: TFailure[] = [];
+  private readonly warned = new Set<string>();
+
+  /**
+   * Every failure of this kind in this scope, oldest first.
+   */
+  get all(): readonly TFailure[] {
+    return this.failures;
+  }
+
+  /**
+   * Record something that did not happen.
+   */
+  record(failure: TFailure): void {
+    this.failures.push(failure);
+
+    if (failure.wasRefused) {
+      return;
+    }
+
+    this.warn(failure);
+  }
+
+  /**
+   * Warn about a failure once per delivery stream and cause.
+   */
+  private warn(failure: TFailure): void {
+    const key = `${failure.deliveryStreamName}:${failure.reason}`;
+
+    if (this.warned.has(key)) {
+      return;
+    }
+
+    this.warned.add(key);
+
+    // oxlint-disable-next-line no-console
+    console.warn(failure.warning);
+  }
+}

--- a/src/service/firehose/index.ts
+++ b/src/service/firehose/index.ts
@@ -2,14 +2,23 @@ export { SimFirehose } from "./sim-firehose.js";
 export type { SimFirehoseRequestOptions } from "./command/sim-firehose-request-options.js";
 export type * from "./command/sim-firehose-command.types.js";
 export { SimFirehoseDeliveryStream } from "./stream/sim-firehose-delivery-stream.js";
+export type { SimFirehoseDeliveryStreamStatus } from "./stream/sim-firehose-delivery-stream.js";
+export {
+  SimFirehoseDirectPutSource,
+  SimFirehoseKinesisSource,
+} from "./source/sim-firehose-source.js";
 export type {
-  SimFirehoseDeliveryStreamStatus,
   SimFirehoseDeliveryStreamType,
-} from "./stream/sim-firehose-delivery-stream.js";
+  SimFirehoseSource,
+} from "./source/sim-firehose-source.js";
+export { SimFirehoseKinesisSourceArn } from "./source/sim-firehose-kinesis-source-arn.js";
+export type { SimFirehoseRecordSource } from "./source/sim-firehose-record-source.js";
 export { simFirehoseDeliveryStreamArn } from "./stream/sim-firehose-delivery-stream-arn.js";
 export { SimFirehoseBufferingHints } from "./destination/sim-firehose-buffering-hints.js";
 export { SimFirehoseS3Destination } from "./destination/sim-firehose-s3-destination.js";
 export { SimFirehoseDeliveryFailure } from "./delivery/sim-firehose-delivery-failures.js";
+export { SimFirehoseSourceFailure } from "./source/sim-firehose-source-failures.js";
+export { SimFirehoseFailure } from "./failure/sim-firehose-failure.js";
 export {
   SimFirehoseError,
   SimFirehoseInvalidArgumentException,

--- a/src/service/firehose/sim-firehose.ts
+++ b/src/service/firehose/sim-firehose.ts
@@ -12,11 +12,14 @@ import {
 import type * as simFirehoseCommands from "./command/sim-firehose-command.types.js";
 import { SimFirehoseCommands } from "./command/sim-firehose-commands.js";
 import type { SimFirehoseRequestOptions } from "./command/sim-firehose-request-options.js";
-import {
-  type SimFirehoseDeliveryFailure,
-  SimFirehoseDeliveryFailures,
-} from "./delivery/sim-firehose-delivery-failures.js";
+import type { SimFirehoseDeliveryFailure } from "./delivery/sim-firehose-delivery-failures.js";
+import { SimFirehoseFailures } from "./failure/sim-firehose-failures.js";
 import type { SimFirehoseObjectDestination } from "./delivery/sim-firehose-object-writer.js";
+import {
+  SimFirehoseNoRecordSource,
+  type SimFirehoseRecordSource,
+} from "./source/sim-firehose-record-source.js";
+import type { SimFirehoseSourceFailure } from "./source/sim-firehose-source-failures.js";
 import { SimFirehoseSdkCommandRouter } from "./sdk/sim-firehose-sdk-command-router.js";
 import type { SimFirehoseDeliveryStream } from "./stream/sim-firehose-delivery-stream.js";
 import { SimFirehoseDeliveryStreamStore } from "./stream/sim-firehose-delivery-stream-store.js";
@@ -26,6 +29,14 @@ interface SimFirehoseProperties {
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
   readonly s3: SimFirehoseObjectDestination;
+
+  /**
+   * The simulated Kinesis a delivery stream reads a source stream from.
+   *
+   * A SimFirehose built without one delivers whatever is put on it, and refuses
+   * to read for a delivery stream created with a Kinesis source.
+   */
+  readonly kinesis?: SimFirehoseRecordSource;
 }
 
 /**
@@ -42,12 +53,20 @@ interface SimFirehoseProperties {
  * `RoleARN`. Advancing simulated time past the interval is what makes a test's
  * records land in the Bucket.
  *
- * S3 is the only destination simulated, and `DirectPut` the only source. The
- * rest are refused by name at CreateDeliveryStream.
+ * A delivery stream can read its records off a simulated Kinesis stream
+ * instead, as the source `RoleARN`. It starts at the end of the stream, so
+ * records put before it was created stay behind it, and it takes no puts of its
+ * own.
+ *
+ * S3 is the only destination simulated. The rest are refused by name at
+ * CreateDeliveryStream.
  */
 export class SimFirehose {
   private readonly deliveryStreams = new SimFirehoseDeliveryStreamStore();
-  private readonly failures = new SimFirehoseDeliveryFailures();
+  private readonly failures =
+    new SimFirehoseFailures<SimFirehoseDeliveryFailure>();
+  private readonly sourceFailures =
+    new SimFirehoseFailures<SimFirehoseSourceFailure>();
   private readonly commands: SimFirehoseCommands;
   private readonly background: BackgroundScheduler;
   private readonly sdkRouter = new SimFirehoseSdkCommandRouter(this);
@@ -57,13 +76,16 @@ export class SimFirehose {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
       iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
+      kinesis = new SimFirehoseNoRecordSource(),
     } = properties;
 
     this.background = background;
     this.commands = new SimFirehoseCommands({
       deliveryStreams: this.deliveryStreams,
       failures: this.failures,
+      sourceFailures: this.sourceFailures,
       s3: properties.s3,
+      kinesis,
       iam,
       background,
       accountRegionScope,
@@ -90,6 +112,18 @@ export class SimFirehose {
    */
   getDeliveryFailures(): readonly SimFirehoseDeliveryFailure[] {
     return this.failures.all;
+  }
+
+  /**
+   * Get the source streams this Firehose stopped reading, which is where a
+   * source Role that cannot read its Kinesis stream shows up.
+   *
+   * A delivery stream reads with no caller in front of it, so a read it was
+   * refused reaches a test here rather than through the request that put the
+   * record.
+   */
+  getSourceFailures(): readonly SimFirehoseSourceFailure[] {
+    return this.sourceFailures.all;
   }
 
   /** Handle a CreateDeliveryStream Command from the SDK. */

--- a/src/service/firehose/source/read/sim-firehose-source-poll.ts
+++ b/src/service/firehose/source/read/sim-firehose-source-poll.ts
@@ -1,0 +1,63 @@
+import type {
+  BackgroundScheduler,
+  BackgroundTask,
+} from "../../../../util/background/background.js";
+
+interface SimFirehoseSourcePollProperties {
+  readonly background: BackgroundScheduler;
+  readonly read: BackgroundTask;
+}
+
+/**
+ * When one delivery stream reads its source stream next.
+ *
+ * The read is scheduled on the clock, for the instant the simulation currently
+ * reads. Advancing time is then what moves records from the stream into the
+ * buffer, and the same advance can carry that buffer past its interval. A read
+ * scheduled off the clock would happen after the advance instead, leaving a
+ * test to advance twice for one record.
+ *
+ * A read already waiting to happen is left alone. A stream taking a record a
+ * second would otherwise queue a read for each of them, and the first would
+ * have read them all.
+ */
+export class SimFirehoseSourcePoll {
+  private readonly background: BackgroundScheduler;
+  private readonly task: BackgroundTask;
+
+  private scheduled = false;
+  private stopped = false;
+
+  constructor(properties: SimFirehoseSourcePollProperties) {
+    this.background = properties.background;
+    this.task = async (): Promise<void> => {
+      this.scheduled = false;
+
+      await properties.read();
+    };
+  }
+
+  /**
+   * Read once simulated time next moves.
+   */
+  soon(): void {
+    if (this.stopped || this.scheduled) {
+      return;
+    }
+
+    this.scheduled = true;
+    this.background.scheduleAt(this.background.now(), this.task);
+  }
+
+  /**
+   * Give up whatever read was waiting on the clock, and take no more.
+   *
+   * Both halves matter. A read already queued would otherwise wait for a
+   * delivery stream that has gone, and a delivery stream that stopped part way
+   * through a read goes on to ask for another.
+   */
+  stop(): void {
+    this.stopped = true;
+    this.background.cancelScheduled(this.task);
+  }
+}

--- a/src/service/firehose/source/read/sim-firehose-source-reader.ts
+++ b/src/service/firehose/source/read/sim-firehose-source-reader.ts
@@ -1,0 +1,131 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimFirehoseDelivery } from "../../delivery/sim-firehose-delivery.js";
+import type { SimFirehoseFailures } from "../../failure/sim-firehose-failures.js";
+import type { SimFirehoseDeliveryStream } from "../../stream/sim-firehose-delivery-stream.js";
+import type {
+  SimFirehoseRecordSource,
+  SimFirehoseSourceActivity,
+  SimFirehoseSourceWatcher,
+} from "../sim-firehose-record-source.js";
+import { SimFirehoseSourceFailure } from "../sim-firehose-source-failures.js";
+import type { SimFirehoseKinesisSource } from "../sim-firehose-source.js";
+import { SimFirehoseSourcePoll } from "./sim-firehose-source-poll.js";
+import { SimFirehoseSourceShards } from "./sim-firehose-source-shards.js";
+
+interface SimFirehoseSourceReaderProperties {
+  readonly deliveryStream: SimFirehoseDeliveryStream;
+  readonly source: SimFirehoseKinesisSource;
+  readonly records: SimFirehoseRecordSource;
+  readonly delivery: SimFirehoseDelivery;
+  readonly failures: SimFirehoseFailures<SimFirehoseSourceFailure>;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * One delivery stream reading every shard of its source stream.
+ *
+ * The read happens on the clock. A record put onto the stream schedules a read
+ * for the instant the simulation currently reads, so advancing time is what
+ * moves records from the stream into the delivery stream's buffer, and the same
+ * advance can then carry the buffer past its interval. Real Firehose reads
+ * continuously, and nothing in this simulation runs continuously.
+ *
+ * Every call to the stream is made as the source Role. A Role that cannot read
+ * stops the delivery, and the failure is kept for a test to read: real Firehose
+ * has no caller in front of it here to raise at.
+ */
+export class SimFirehoseSourceReader implements SimFirehoseSourceWatcher {
+  private readonly properties: SimFirehoseSourceReaderProperties;
+  private readonly activity: SimFirehoseSourceActivity;
+  private readonly poll: SimFirehoseSourcePoll;
+
+  private shards = new SimFirehoseSourceShards([]);
+
+  constructor(properties: SimFirehoseSourceReaderProperties) {
+    this.properties = properties;
+    this.activity = properties.records.streamActivity();
+    this.poll = new SimFirehoseSourcePoll({
+      background: properties.background,
+      read: async (): Promise<void> => {
+        await this.take();
+      },
+    });
+  }
+
+  /**
+   * Open every shard of the source stream at its end, and watch for records.
+   *
+   * The shards are found before CreateDeliveryStream answers, rather than at
+   * the first read. Both calls are made as the source Role, and a record put
+   * the moment the delivery stream exists has to land behind a place that was
+   * already taken.
+   */
+  async start(): Promise<void> {
+    const { records, source } = this.properties;
+    const streamArn = source.streamArn.value;
+
+    try {
+      this.shards = await SimFirehoseSourceShards.atLatestOf(
+        records,
+        streamArn,
+        source.caller,
+      );
+    } catch (error) {
+      this.failed(error);
+
+      return;
+    }
+
+    this.activity.watch(streamArn, this);
+  }
+
+  /**
+   * Read the stream once simulated time next moves.
+   */
+  recordsAvailable(): void {
+    this.poll.soon();
+  }
+
+  /**
+   * Stop reading, and give up whatever read was waiting on the clock.
+   */
+  stop(): void {
+    this.poll.stop();
+    this.activity.unwatch(this.properties.source.streamArn.value, this);
+  }
+
+  /**
+   * Read the stream, and take what came back onto the buffer.
+   */
+  private async take(): Promise<void> {
+    const { delivery, deliveryStream } = this.properties;
+
+    try {
+      const read = await this.shards.read();
+
+      for (const record of read.records) {
+        delivery.accept(deliveryStream, record.Data);
+      }
+
+      // A read that filled the request has left records behind it, so the
+      // delivery stream goes round again rather than waiting for the next put.
+      if (read.filled) {
+        this.poll.soon();
+      }
+    } catch (error) {
+      this.failed(error);
+    }
+  }
+
+  /**
+   * Give up on the source stream, and say why.
+   */
+  private failed(error: unknown): void {
+    const { deliveryStream, source, failures } = this.properties;
+
+    this.stop();
+    failures.record(
+      SimFirehoseSourceFailure.of(deliveryStream.name, source, error),
+    );
+  }
+}

--- a/src/service/firehose/source/read/sim-firehose-source-reading.ts
+++ b/src/service/firehose/source/read/sim-firehose-source-reading.ts
@@ -1,0 +1,73 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimFirehoseDelivery } from "../../delivery/sim-firehose-delivery.js";
+import type { SimFirehoseFailures } from "../../failure/sim-firehose-failures.js";
+import type { SimFirehoseDeliveryStream } from "../../stream/sim-firehose-delivery-stream.js";
+import type { SimFirehoseRecordSource } from "../sim-firehose-record-source.js";
+import type { SimFirehoseSourceFailure } from "../sim-firehose-source-failures.js";
+import { SimFirehoseSourceReader } from "./sim-firehose-source-reader.js";
+
+interface SimFirehoseSourceReadingProperties {
+  readonly records: SimFirehoseRecordSource;
+  readonly delivery: SimFirehoseDelivery;
+  readonly failures: SimFirehoseFailures<SimFirehoseSourceFailure>;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * Which delivery streams of one simulated Firehose scope are reading a stream.
+ *
+ * A `DirectPut` delivery stream reads nothing, so it has no reader here. The
+ * readers are held by delivery stream so that deleting one stops it: a delivery
+ * stream that has gone still has an iterator on its source, and leaving it
+ * would go on buffering records for a destination nothing can deliver to.
+ */
+export class SimFirehoseSourceReading {
+  private readonly properties: SimFirehoseSourceReadingProperties;
+  private readonly readers = new Map<
+    SimFirehoseDeliveryStream,
+    SimFirehoseSourceReader
+  >();
+
+  constructor(properties: SimFirehoseSourceReadingProperties) {
+    this.properties = properties;
+  }
+
+  /**
+   * Start a newly created delivery stream reading its source.
+   *
+   * This answers once the source stream has been opened, so a record put the
+   * moment CreateDeliveryStream answers lands in front of the delivery stream
+   * rather than behind it.
+   */
+  async start(deliveryStream: SimFirehoseDeliveryStream): Promise<void> {
+    const { source } = deliveryStream;
+
+    if (source.kind !== "kinesis-stream") {
+      return;
+    }
+
+    const reader = new SimFirehoseSourceReader({
+      ...this.properties,
+      deliveryStream,
+      source,
+    });
+
+    this.readers.set(deliveryStream, reader);
+
+    await reader.start();
+  }
+
+  /**
+   * Stop a deleted delivery stream reading.
+   */
+  forget(deliveryStream: SimFirehoseDeliveryStream): void {
+    const reader = this.readers.get(deliveryStream);
+
+    if (reader === undefined) {
+      return;
+    }
+
+    this.readers.delete(deliveryStream);
+    reader.stop();
+  }
+}

--- a/src/service/firehose/source/read/sim-firehose-source-shard-ids.ts
+++ b/src/service/firehose/source/read/sim-firehose-source-shard-ids.ts
@@ -1,0 +1,83 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimFirehoseError } from "../../error/sim-firehose.error.js";
+import type {
+  SimFirehoseRecordSource,
+  SimFirehoseSourceShardDescription,
+} from "../sim-firehose-record-source.js";
+
+/**
+ * How many shards one DescribeStream page asks for.
+ *
+ * The stream is walked to the end rather than read one page deep, so a delivery
+ * stream on a stream with more shards than a page holds still reads all of
+ * them.
+ */
+const shardPageSize = 100;
+
+/**
+ * Every shard of the stream a delivery stream reads, in the order the stream
+ * reports them.
+ *
+ * This is a DescribeStream call, which is also how a delivery stream finds out
+ * whether the stream it names is there at all. Real Firehose needs the same
+ * permission for the same reason.
+ */
+export async function simFirehoseSourceShardIds(
+  records: SimFirehoseRecordSource,
+  streamArn: string,
+  caller: SimAwsCaller,
+): Promise<readonly string[]> {
+  const shardIds: string[] = [];
+  let after: string | undefined;
+
+  do {
+    // oxlint-disable-next-line no-await-in-loop
+    const described = await records.describeStream(
+      {
+        input: {
+          StreamARN: streamArn,
+          Limit: shardPageSize,
+          ...(after !== undefined && { ExclusiveStartShardId: after }),
+        },
+      },
+      { caller },
+    );
+    const page = described.StreamDescription;
+
+    shardIds.push(...namedShardsOf(page.Shards, streamArn));
+    after = page.HasMoreShards === true ? shardIds.at(-1) : undefined;
+  } while (after !== undefined);
+
+  if (shardIds.length === 0) {
+    throw new SimFirehoseError(
+      `Stream ${streamArn} reports no shards to read records from`,
+    );
+  }
+
+  return shardIds;
+}
+
+/**
+ * The identifiers a page of shards carries.
+ *
+ * A shard with no identifier is one nothing can ask for a place on, so it is
+ * refused here rather than skipped: a delivery stream quietly reading fewer
+ * shards than the stream has would drop records with nothing to point at.
+ */
+function namedShardsOf(
+  shards: readonly SimFirehoseSourceShardDescription[] | undefined,
+  streamArn: string,
+): readonly string[] {
+  return (shards ?? []).map((shard) => {
+    const { ShardId } = shard;
+
+    if (ShardId === undefined || ShardId === "") {
+      throw new SimFirehoseError(
+        `Stream ${streamArn} reports a shard with no ShardId, which nothing ` +
+          "can read from",
+      );
+    }
+
+    return ShardId;
+  });
+}

--- a/src/service/firehose/source/read/sim-firehose-source-shard.ts
+++ b/src/service/firehose/source/read/sim-firehose-source-shard.ts
@@ -1,0 +1,77 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type {
+  SimFirehoseRecordSource,
+  SimFirehoseSourceRecord,
+} from "../sim-firehose-record-source.js";
+
+interface SimFirehoseSourceShardProperties {
+  readonly records: SimFirehoseRecordSource;
+  readonly caller: SimAwsCaller;
+  readonly iterator: string;
+}
+
+interface SimFirehoseSourceShardOpening {
+  readonly records: SimFirehoseRecordSource;
+  readonly streamArn: string;
+  readonly shardId: string;
+  readonly caller: SimAwsCaller;
+}
+
+/**
+ * One shard of the stream a delivery stream reads, and the place it has
+ * reached on it.
+ *
+ * The place is an iterator rather than a sequence number, which is what a read
+ * hands back and what the next read carries.
+ */
+export class SimFirehoseSourceShard {
+  private readonly records: SimFirehoseRecordSource;
+  private readonly caller: SimAwsCaller;
+  private iterator: string;
+
+  private constructor(properties: SimFirehoseSourceShardProperties) {
+    this.records = properties.records;
+    this.caller = properties.caller;
+    this.iterator = properties.iterator;
+  }
+
+  /**
+   * Open a shard at the end of the stream, as the source Role.
+   *
+   * The iterator is taken now rather than at the first read. LATEST means
+   * "after the newest record on the shard when the iterator was made", so
+   * leaving it until something has been put would step over the record that
+   * woke the delivery stream up.
+   */
+  static async atLatest(
+    opening: SimFirehoseSourceShardOpening,
+  ): Promise<SimFirehoseSourceShard> {
+    const { records, streamArn, shardId, caller } = opening;
+    const opened = await records.getShardIterator(
+      {
+        input: {
+          StreamARN: streamArn,
+          ShardId: shardId,
+          ShardIteratorType: "LATEST",
+        },
+      },
+      { caller },
+    );
+
+    return new this({ records, caller, iterator: opened.ShardIterator });
+  }
+
+  /**
+   * Read up to a limit of records from where the last read left off.
+   */
+  async read(limit: number): Promise<readonly SimFirehoseSourceRecord[]> {
+    const read = await this.records.getRecords(
+      { input: { ShardIterator: this.iterator, Limit: limit } },
+      { caller: this.caller },
+    );
+
+    this.iterator = read.NextShardIterator;
+
+    return read.Records;
+  }
+}

--- a/src/service/firehose/source/read/sim-firehose-source-shards.ts
+++ b/src/service/firehose/source/read/sim-firehose-source-shards.ts
@@ -1,0 +1,89 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type {
+  SimFirehoseRecordSource,
+  SimFirehoseSourceRecord,
+} from "../sim-firehose-record-source.js";
+import { SimFirehoseSourceShard } from "./sim-firehose-source-shard.js";
+import { simFirehoseSourceShardIds } from "./sim-firehose-source-shard-ids.js";
+
+/**
+ * How many records one read of a shard asks for, which is the most one
+ * GetRecords call hands back.
+ */
+const shardReadLimit = 10_000;
+
+/**
+ * What one read across every shard came back with.
+ *
+ * `filled` says a shard handed back everything it was asked for, which means
+ * there are records behind what came back.
+ */
+export interface SimFirehoseSourceRead {
+  readonly records: readonly SimFirehoseSourceRecord[];
+  readonly filled: boolean;
+}
+
+/**
+ * Every shard of the stream one delivery stream reads.
+ *
+ * A Kinesis stream has as many shards as it was created with, and nothing here
+ * reshards, so they are found once and kept. All of them are read, because a
+ * delivery stream delivers the whole stream rather than part of it.
+ */
+export class SimFirehoseSourceShards {
+  private readonly shards: readonly SimFirehoseSourceShard[];
+
+  /**
+   * Hold the shards given, which is none for a delivery stream that has yet to
+   * open its stream.
+   */
+  constructor(shards: readonly SimFirehoseSourceShard[]) {
+    this.shards = shards;
+  }
+
+  /**
+   * Find every shard of a stream and open each at the end of it, as the source
+   * Role.
+   */
+  static async atLatestOf(
+    records: SimFirehoseRecordSource,
+    streamArn: string,
+    caller: SimAwsCaller,
+  ): Promise<SimFirehoseSourceShards> {
+    const shardIds = await simFirehoseSourceShardIds(
+      records,
+      streamArn,
+      caller,
+    );
+    const shards = await Promise.all(
+      shardIds.map(async (shardId) =>
+        SimFirehoseSourceShard.atLatest({
+          records,
+          streamArn,
+          shardId,
+          caller,
+        }),
+      ),
+    );
+
+    return new this(shards);
+  }
+
+  /**
+   * Read every shard, in the order the stream reported them.
+   *
+   * Real Firehose reads its shards in parallel too, and the order records from
+   * different shards land in one Object is nothing it promises. Reporting them
+   * shard by shard is what keeps a simulated delivery deterministic.
+   */
+  async read(): Promise<SimFirehoseSourceRead> {
+    const reads = await Promise.all(
+      this.shards.map(async (shard) => await shard.read(shardReadLimit)),
+    );
+
+    return {
+      records: reads.flat(),
+      filled: reads.some((records) => records.length === shardReadLimit),
+    };
+  }
+}

--- a/src/service/firehose/source/sim-firehose-kinesis-source-arn.ts
+++ b/src/service/firehose/source/sim-firehose-kinesis-source-arn.ts
@@ -1,0 +1,74 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { SimFirehoseInvalidArgumentException } from "../error/sim-firehose.error.js";
+
+/**
+ * A Kinesis stream ARN carries the stream name after a `stream/` separator, and
+ * a stream name holds no colon and no slash, so the ARN is read in one piece.
+ *
+ * The name is anchored to the end because a consumer ARN carries the consumer
+ * name and its creation time after the stream name. Enhanced fan-out is
+ * unsimulated, and a source naming a consumer has to be refused rather than
+ * read as though it named the stream.
+ */
+const streamArnPattern =
+  /^arn:aws:kinesis:(?<region>[a-z0-9-]+):(?<account>\d{12}):stream\/(?<stream>[\w.-]{1,128})$/u;
+
+/**
+ * The Kinesis stream ARN a delivery stream reads from.
+ *
+ * Everything the read needs comes out of it: the ARN the Kinesis calls name,
+ * and the Account and Region, which decide whether this simulated Firehose can
+ * reach the stream at all.
+ */
+export class SimFirehoseKinesisSourceArn {
+  /**
+   * How an ARN naming a source stream is written, for a refusal to say what it
+   * wanted instead.
+   */
+  static readonly arnShape =
+    "A Kinesis stream ARN is " +
+    "arn:aws:kinesis:<region>:<account-id>:stream/<stream-name>";
+
+  public readonly value: string;
+  public readonly regionName: string;
+  public readonly accountId: string;
+  public readonly streamName: string;
+
+  private constructor(value: string, parts: Record<string, string>) {
+    this.value = value;
+    this.regionName = parts["region"] ?? "";
+    this.accountId = parts["account"] ?? "";
+    this.streamName = parts["stream"] ?? "";
+  }
+
+  /**
+   * Read a stream ARN, refusing one that is not a stream ARN at all.
+   */
+  static of(value: string | undefined): SimFirehoseKinesisSourceArn {
+    if (value === undefined || value === "") {
+      throw new SimFirehoseInvalidArgumentException(
+        "The KinesisStreamSourceConfiguration is missing KinesisStreamARN",
+      );
+    }
+
+    const parts = streamArnPattern.exec(value)?.groups;
+
+    if (parts === undefined) {
+      throw new SimFirehoseInvalidArgumentException(
+        `The source KinesisStreamARN ${value} does not name a Kinesis ` +
+          `stream. ${this.arnShape}`,
+      );
+    }
+
+    return new this(value, parts);
+  }
+
+  /**
+   * Whether this stream is in an Account and Region.
+   */
+  isIn(scope: SimAwsAccountRegionScope): boolean {
+    return (
+      this.accountId === scope.accountId && this.regionName === scope.regionName
+    );
+  }
+}

--- a/src/service/firehose/source/sim-firehose-kinesis-source-refusals.iso.test.ts
+++ b/src/service/firehose/source/sim-firehose-kinesis-source-refusals.iso.test.ts
@@ -1,0 +1,233 @@
+import {
+  ListDeliveryStreamsCommand,
+  PutRecordBatchCommand,
+  PutRecordCommand,
+} from "@aws-sdk/client-firehose";
+import {
+  assertArrayEquals,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { makeFirehoseDeliveryDestination } from "../../../../test/firehose/firehose-delivery-fixture.js";
+import { makeFirehoseKinesisSource } from "../../../../test/firehose/firehose-kinesis-source-fixture.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import {
+  SimFirehoseInvalidArgumentException,
+  SimFirehoseUnsimulatedSource,
+} from "../error/sim-firehose.error.js";
+import { simFirehoseDeliveryStreamFactory } from "../stream/sim-firehose-delivery-stream.factory.js";
+import type { SimCreateDeliveryStreamCommandInput } from "../command/stream/stream.command.js";
+
+describe("What a simulated Firehose delivery stream refuses to read", () => {
+  /**
+   * Create a delivery stream against a Bucket that exists, and answer with
+   * what the request was refused with.
+   */
+  async function refusalOf(
+    input: Omit<SimCreateDeliveryStreamCommandInput, "DeliveryStreamName">,
+  ): Promise<Error> {
+    const simAws = new SimAws();
+    const { bucketName, roleArn } =
+      await makeFirehoseDeliveryDestination(simAws);
+
+    return await assertThrowsErrorAsync(async () => {
+      await simAws.firehose().createDeliveryStream({
+        input: {
+          DeliveryStreamName: "order-events",
+          ExtendedS3DestinationConfiguration: {
+            BucketARN: `arn:aws:s3:::${bucketName}`,
+            RoleARN: roleArn,
+          },
+          ...input,
+        },
+      });
+    });
+  }
+
+  /**
+   * A source configuration naming a stream ARN, as a request carries it.
+   */
+  function sourceConfiguration(
+    streamArn: string,
+  ): SimCreateDeliveryStreamCommandInput {
+    return {
+      DeliveryStreamType: "KinesisStreamAsSource",
+      KinesisStreamSourceConfiguration: {
+        KinesisStreamARN: streamArn,
+        RoleARN: "arn:aws:iam::888888888888:role/OrderStreamSourceRole",
+      },
+    };
+  }
+
+  it("refuses a source stream in another region", async () => {
+    // Given a delivery stream that would read a stream in another region.
+    const error = await refusalOf(
+      sourceConfiguration(
+        "arn:aws:kinesis:eu-west-2:888888888888:stream/orders",
+      ),
+    );
+
+    // Then it says so. A simulated Firehose reads the simulated Kinesis of its
+    // own scope, and nothing else is there to read.
+    assertInstanceOf(error, SimFirehoseUnsimulatedSource);
+    assertStringIncludes(error.message, "eu-west-2");
+  });
+
+  it("refuses a source stream in another account", async () => {
+    // Given a delivery stream that would read another account's stream.
+    const error = await refusalOf(
+      sourceConfiguration(
+        "arn:aws:kinesis:us-east-1:111111111111:stream/orders",
+      ),
+    );
+
+    // Then it is refused the same way.
+    assertInstanceOf(error, SimFirehoseUnsimulatedSource);
+    assertStringIncludes(error.message, "111111111111");
+  });
+
+  it("refuses a source that is not a stream ARN", async () => {
+    // Given a source naming a stream consumer rather than the stream.
+    const error = await refusalOf(
+      sourceConfiguration(
+        "arn:aws:kinesis:us-east-1:888888888888:stream/orders/consumer/archive:1",
+      ),
+    );
+
+    // Then it is refused as a malformed request, and told the shape it wanted.
+    assertInstanceOf(error, SimFirehoseInvalidArgumentException);
+    assertStringIncludes(error.message, "arn:aws:kinesis:<region>");
+  });
+
+  it("refuses a source configuration naming no stream", async () => {
+    // Given a source configuration with no KinesisStreamARN.
+    const error = await refusalOf({
+      DeliveryStreamType: "KinesisStreamAsSource",
+      KinesisStreamSourceConfiguration: {
+        RoleARN: "arn:aws:iam::888888888888:role/OrderStreamSourceRole",
+      },
+    });
+
+    // Then it says which field is missing.
+    assertInstanceOf(error, SimFirehoseInvalidArgumentException);
+    assertStringIncludes(error.message, "KinesisStreamARN");
+  });
+
+  it("refuses a source configuration naming no Role", async () => {
+    // Given a source configuration with no RoleARN.
+    const error = await refusalOf({
+      DeliveryStreamType: "KinesisStreamAsSource",
+      KinesisStreamSourceConfiguration: {
+        KinesisStreamARN:
+          "arn:aws:kinesis:us-east-1:888888888888:stream/orders",
+      },
+    });
+
+    // Then it says which field is missing. The read is made as that Role, and
+    // there is nothing to make it as.
+    assertInstanceOf(error, SimFirehoseInvalidArgumentException);
+    assertStringIncludes(error.message, "RoleARN");
+  });
+
+  it("refuses a Kinesis-sourced delivery stream naming no source", async () => {
+    // Given a delivery stream of that type carrying no configuration.
+    const error = await refusalOf({
+      DeliveryStreamType: "KinesisStreamAsSource",
+    });
+
+    // Then it says what it wanted, rather than reading nothing.
+    assertInstanceOf(error, SimFirehoseInvalidArgumentException);
+    assertStringIncludes(error.message, "KinesisStreamSourceConfiguration");
+  });
+
+  it("refuses a source configuration on a DirectPut delivery stream", async () => {
+    // Given a delivery stream that takes puts and names a stream as well.
+    const error = await refusalOf({
+      KinesisStreamSourceConfiguration: {
+        KinesisStreamARN:
+          "arn:aws:kinesis:us-east-1:888888888888:stream/orders",
+        RoleARN: "arn:aws:iam::888888888888:role/OrderStreamSourceRole",
+      },
+    });
+
+    // Then it is refused rather than taken as one or the other.
+    assertInstanceOf(error, SimFirehoseInvalidArgumentException);
+    assertStringIncludes(error.message, "KinesisStreamAsSource");
+  });
+
+  it("refuses a source outside the simulation by name", async () => {
+    // Given a delivery stream reading an MSK cluster.
+    const error = await refusalOf({ DeliveryStreamType: "MSKAsSource" });
+
+    // Then it says which type it was asked for. A delivery stream reading a
+    // cluster nothing simulates would take nothing and deliver nothing.
+    assertInstanceOf(error, SimFirehoseUnsimulatedSource);
+    assertStringIncludes(error.message, "MSKAsSource");
+  });
+
+  it("refuses a record put onto a delivery stream that reads a stream", async () => {
+    // Given a delivery stream reading a Kinesis stream.
+    const simAws = new SimAws();
+    const { deliveryStream, streamArn } =
+      await makeFirehoseKinesisSource(simAws);
+
+    // When a producer puts a record onto the delivery stream itself.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.firehose().putRecord(
+        new PutRecordCommand({
+          DeliveryStreamName: deliveryStream.name,
+          Record: { Data: new TextEncoder().encode("one\n") },
+        }),
+      );
+    });
+
+    // Then it is refused, and pointed at the stream the records come from.
+    assertInstanceOf(error, SimFirehoseInvalidArgumentException);
+    assertStringIncludes(error.message, "PutRecord");
+    assertStringIncludes(error.message, streamArn);
+  });
+
+  it("refuses a batch put onto a delivery stream that reads a stream", async () => {
+    // Given a delivery stream reading a Kinesis stream.
+    const simAws = new SimAws();
+    const { deliveryStream } = await makeFirehoseKinesisSource(simAws);
+
+    // When a producer puts a batch onto the delivery stream itself.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.firehose().putRecordBatch(
+        new PutRecordBatchCommand({
+          DeliveryStreamName: deliveryStream.name,
+          Records: [{ Data: new TextEncoder().encode("one\n") }],
+        }),
+      );
+    });
+
+    // Then it is refused the same way.
+    assertInstanceOf(error, SimFirehoseInvalidArgumentException);
+    assertStringIncludes(error.message, "PutRecordBatch");
+  });
+
+  it("lists delivery streams by the source they read", async () => {
+    // Given one delivery stream of each type.
+    const simAws = new SimAws();
+    const { deliveryStream, bucketName } =
+      await makeFirehoseKinesisSource(simAws);
+    await simFirehoseDeliveryStreamFactory.make(
+      { deliveryStreamName: "direct-orders", bucketName },
+      simAws,
+    );
+
+    // When a listing asks for the ones reading a Kinesis stream.
+    const listed = await simAws.firehose().listDeliveryStreams(
+      new ListDeliveryStreamsCommand({
+        DeliveryStreamType: "KinesisStreamAsSource",
+      }),
+    );
+
+    // Then only that one is listed.
+    assertArrayEquals(listed.DeliveryStreamNames, [deliveryStream.name]);
+  });
+});

--- a/src/service/firehose/source/sim-firehose-kinesis-source.iso.test.ts
+++ b/src/service/firehose/source/sim-firehose-kinesis-source.iso.test.ts
@@ -1,0 +1,273 @@
+import { DescribeDeliveryStreamCommand } from "@aws-sdk/client-firehose";
+import { PutRecordCommand, PutRecordsCommand } from "@aws-sdk/client-kinesis";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  deliveredObjectBody,
+  deliveredObjectKeys,
+  makeFirehoseDelivery,
+  makeFirehoseDeliveryDestination,
+} from "../../../../test/firehose/firehose-delivery-fixture.js";
+import { makeFirehoseKinesisSource } from "../../../../test/firehose/firehose-kinesis-source-fixture.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simKinesisStreamFactory } from "../../kinesis/stream/sim-kinesis-stream.factory.js";
+import { simFirehoseDeliveryStreamFactory } from "../stream/sim-firehose-delivery-stream.factory.js";
+
+/**
+ * The bytes of one JSON line, the way a producer writes one onto a stream.
+ */
+function orderLine(id: string): Uint8Array {
+  return new TextEncoder().encode(`${JSON.stringify({ id })}\n`);
+}
+
+describe("A simulated Firehose delivery stream reading a Kinesis stream", () => {
+  /**
+   * One batch of orders to put on a stream, each under its own partition key.
+   */
+  function orderBatch(
+    batch: number,
+    size: number,
+  ): { PartitionKey: string; Data: Uint8Array }[] {
+    return Array.from({ length: size }, (_unused, index) => ({
+      PartitionKey: `order-${batch}-${index}`,
+      Data: orderLine(`order-${batch}-${index}`),
+    }));
+  }
+
+  /**
+   * Put one order onto a stream, under its own partition key.
+   */
+  async function putOrder(
+    simAws: SimAws,
+    streamName: string,
+    id: string,
+  ): Promise<void> {
+    await simAws.kinesis().putRecord(
+      new PutRecordCommand({
+        StreamName: streamName,
+        PartitionKey: id,
+        Data: orderLine(id),
+      }),
+    );
+  }
+
+  it("delivers a record put on the stream after it was created", async () => {
+    // Given a delivery stream reading a stream, buffering for a minute.
+    const simAws = new SimAws();
+    const { bucketName, streamName } = await makeFirehoseKinesisSource(simAws, {
+      intervalInSeconds: 60,
+    });
+
+    // When a record is put onto the stream and the interval passes.
+    await putOrder(simAws, streamName, "order-1");
+    await simAws.clock().advanceBy({ seconds: 60 });
+
+    // Then it is in the Bucket, holding the bytes that were put on the stream.
+    const keys = await deliveredObjectKeys(simAws, bucketName);
+    assertArrayLength(keys, 1);
+    assertIdentical(
+      await deliveredObjectBody(simAws, bucketName, keys[0]),
+      '{"id":"order-1"}\n',
+    );
+  });
+
+  it("leaves a record put before it was created where it is", async () => {
+    // Given a stream that already holds a record, and a delivery stream
+    // created after it was put.
+    const simAws = new SimAws();
+    const stream = await simKinesisStreamFactory.make({}, simAws);
+    await putOrder(simAws, stream.name, "order-1");
+
+    const { bucketName, roleArn } =
+      await makeFirehoseDeliveryDestination(simAws);
+    await simFirehoseDeliveryStreamFactory.make(
+      { bucketName, roleArn, sourceStreamArn: stream.arn },
+      simAws,
+    );
+
+    // When another record is put and the buffering interval passes.
+    await putOrder(simAws, stream.name, "order-2");
+    await simAws.clock().advanceBy({ minutes: 2 });
+
+    // Then only the record put afterwards was delivered. Real Firehose starts
+    // at the end of the stream, and what was already on it stays there.
+    const keys = await deliveredObjectKeys(simAws, bucketName);
+    assertArrayLength(keys, 1);
+    assertIdentical(
+      await deliveredObjectBody(simAws, bucketName, keys[0]),
+      '{"id":"order-2"}\n',
+    );
+  });
+
+  it("reads every shard of the stream", async () => {
+    // Given a delivery stream reading a stream of four shards.
+    const simAws = new SimAws();
+    const { bucketName, streamName } = await makeFirehoseKinesisSource(simAws, {
+      shardCount: 4,
+    });
+
+    // When records whose partition keys spread across the shards are put.
+    await simAws.kinesis().putRecords(
+      new PutRecordsCommand({
+        StreamName: streamName,
+        Records: ["a", "b", "c", "d", "e", "f", "g", "h"].map((key) => ({
+          PartitionKey: key,
+          Data: orderLine(key),
+        })),
+      }),
+    );
+    await simAws.clock().advanceBy({ minutes: 2 });
+
+    // Then all of them arrived, whichever shard they landed on.
+    const keys = await deliveredObjectKeys(simAws, bucketName);
+    assertArrayLength(keys, 1);
+
+    const body = await deliveredObjectBody(simAws, bucketName, keys[0]);
+
+    for (const key of ["a", "b", "c", "d", "e", "f", "g", "h"]) {
+      assertStringIncludes(body, `{"id":"${key}"}`);
+    }
+  });
+
+  it("buffers what it reads across intervals", async () => {
+    // Given a delivery stream reading a stream, buffering for a minute.
+    const simAws = new SimAws();
+    const { bucketName, streamName } = await makeFirehoseKinesisSource(simAws, {
+      intervalInSeconds: 60,
+    });
+    // When a record is put in each of two intervals.
+    await putOrder(simAws, streamName, "order-1");
+    await simAws.clock().advanceBy({ seconds: 90 });
+
+    await putOrder(simAws, streamName, "order-2");
+    await simAws.clock().advanceBy({ seconds: 90 });
+
+    // Then each interval delivered its own Object.
+    const keys = await deliveredObjectKeys(simAws, bucketName);
+    assertArrayLength(keys, 2);
+    assertIdentical(
+      await deliveredObjectBody(simAws, bucketName, keys[1]),
+      '{"id":"order-2"}\n',
+    );
+  });
+
+  it("stops reading once the delivery stream is deleted", async () => {
+    // Given a delivery stream reading a stream.
+    const simAws = new SimAws();
+    const { bucketName, streamName, deliveryStream } =
+      await makeFirehoseKinesisSource(simAws);
+
+    // When it is deleted, and a record is put on the stream afterwards.
+    await simAws.firehose().deleteDeliveryStream({
+      input: { DeliveryStreamName: deliveryStream.name },
+    });
+    await putOrder(simAws, streamName, "order-1");
+    await simAws.clock().advanceBy({ minutes: 10 });
+
+    // Then nothing was read and nothing was written. The record stays on the
+    // stream for whatever else is reading it.
+    assertArrayLength(await deliveredObjectKeys(simAws, bucketName), 0);
+  });
+
+  it("reports the stream it reads and the Role it reads as", async () => {
+    // Given a delivery stream reading a stream.
+    const simAws = new SimAws();
+    const { deliveryStream, streamArn, sourceRoleArn } =
+      await makeFirehoseKinesisSource(simAws);
+
+    // When it is described.
+    const described = await simAws.firehose().describeDeliveryStream(
+      new DescribeDeliveryStreamCommand({
+        DeliveryStreamName: deliveryStream.name,
+      }),
+    );
+
+    // Then the source names the stream, the Role and when reading started.
+    const description = described.DeliveryStreamDescription;
+    assertIdentical(description.DeliveryStreamType, "KinesisStreamAsSource");
+
+    const source = description.Source?.KinesisStreamSourceDescription;
+    assertNonNullable(source, "The delivery stream reports its source");
+    assertIdentical(source.KinesisStreamARN, streamArn);
+    assertIdentical(source.RoleARN, sourceRoleArn);
+    assertIdentical(
+      source.DeliveryStartTimestamp.getTime(),
+      deliveryStream.createdAt.getTime(),
+    );
+  });
+
+  it("reports no source for a delivery stream that takes puts", async () => {
+    // Given a DirectPut delivery stream.
+    const simAws = new SimAws();
+    const { deliveryStream } = await makeFirehoseDelivery(simAws);
+
+    // When it is described.
+    const described = await simAws.firehose().describeDeliveryStream(
+      new DescribeDeliveryStreamCommand({
+        DeliveryStreamName: deliveryStream.name,
+      }),
+    );
+
+    // Then it reports no source at all, which is what real Firehose reports
+    // for a delivery stream nothing reads for.
+    assertUndefined(described.DeliveryStreamDescription.Source);
+  });
+
+  it("reads once for records put before it got to them", async () => {
+    // Given a delivery stream reading a stream, buffering for a minute.
+    const simAws = new SimAws();
+    const { bucketName, streamName } = await makeFirehoseKinesisSource(simAws, {
+      intervalInSeconds: 60,
+    });
+    // When two records are put before simulated time moves at all.
+    await putOrder(simAws, streamName, "order-1");
+    await putOrder(simAws, streamName, "order-2");
+    await simAws.clock().advanceBy({ seconds: 60 });
+
+    // Then one read took both, and both are in the same Object. The second
+    // record arrived while a read was already waiting to happen.
+    const keys = await deliveredObjectKeys(simAws, bucketName);
+    assertArrayLength(keys, 1);
+    assertIdentical(
+      await deliveredObjectBody(simAws, bucketName, keys[0]),
+      '{"id":"order-1"}\n{"id":"order-2"}\n',
+    );
+  });
+
+  it("reads on past the most one call hands back", async () => {
+    // Given a delivery stream reading a stream, and more records than one
+    // GetRecords call answers with, which is ten thousand.
+    const simAws = new SimAws();
+    const { bucketName, streamName } = await makeFirehoseKinesisSource(simAws);
+    const batchSize = 500;
+    const batchCount = 21;
+
+    // When every one of them is put onto the stream and the interval passes.
+    await Promise.all(
+      Array.from({ length: batchCount }, async (_unused, batch) =>
+        simAws.kinesis().putRecords(
+          new PutRecordsCommand({
+            StreamName: streamName,
+            Records: orderBatch(batch, batchSize),
+          }),
+        ),
+      ),
+    );
+    await simAws.clock().advanceBy({ minutes: 2 });
+
+    // Then every record arrived. A read that filled the request went round
+    // again rather than waiting for the next put.
+    const keys = await deliveredObjectKeys(simAws, bucketName);
+    assertArrayLength(keys, 1);
+
+    const body = await deliveredObjectBody(simAws, bucketName, keys[0]);
+    assertArrayLength(body.trimEnd().split("\n"), batchSize * batchCount);
+  });
+});

--- a/src/service/firehose/source/sim-firehose-kinesis-source.iso.test.ts
+++ b/src/service/firehose/source/sim-firehose-kinesis-source.iso.test.ts
@@ -20,14 +20,14 @@ import { SimAws } from "../../aws/sim-aws.js";
 import { simKinesisStreamFactory } from "../../kinesis/stream/sim-kinesis-stream.factory.js";
 import { simFirehoseDeliveryStreamFactory } from "../stream/sim-firehose-delivery-stream.factory.js";
 
-/**
- * The bytes of one JSON line, the way a producer writes one onto a stream.
- */
-function orderLine(id: string): Uint8Array {
-  return new TextEncoder().encode(`${JSON.stringify({ id })}\n`);
-}
-
 describe("A simulated Firehose delivery stream reading a Kinesis stream", () => {
+  /**
+   * The bytes of one JSON line, the way a producer writes one onto a stream.
+   */
+  function orderLine(id: string): Uint8Array {
+    return new TextEncoder().encode(`${JSON.stringify({ id })}\n`);
+  }
+
   /**
    * One batch of orders to put on a stream, each under its own partition key.
    */

--- a/src/service/firehose/source/sim-firehose-no-record-source.iso.test.ts
+++ b/src/service/firehose/source/sim-firehose-no-record-source.iso.test.ts
@@ -54,6 +54,9 @@ describe("A simulated Firehose with no simulated Kinesis to read", () => {
     const streamArn = "arn:aws:kinesis:us-east-1:888888888888:stream/orders";
 
     // When each of the three reads is made.
+    const shards = await assertThrowsErrorAsync(async () => {
+      await records.describeStream({ input: { StreamARN: streamArn } });
+    });
     const iterator = await assertThrowsErrorAsync(async () => {
       await records.getShardIterator({ input: { StreamARN: streamArn } });
     });
@@ -62,7 +65,9 @@ describe("A simulated Firehose with no simulated Kinesis to read", () => {
     });
 
     // Then each refuses on its own, rather than one refusing and the next
-    // handing back nothing.
+    // handing back nothing. Finding the shards is the one a delivery stream
+    // hits, since it is the read it starts with.
+    assertStringIncludes(shards.message, streamArn);
     assertStringIncludes(iterator.message, streamArn);
     assertStringIncludes(read.message, "no simulated Kinesis");
   });

--- a/src/service/firehose/source/sim-firehose-no-record-source.iso.test.ts
+++ b/src/service/firehose/source/sim-firehose-no-record-source.iso.test.ts
@@ -1,0 +1,88 @@
+import {
+  assertArrayLength,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it, vi } from "vitest";
+
+import { simAwsAccountRegionScopeFactory } from "../../aws/sim-aws-account-region-scope.factory.js";
+import { SimS3 } from "../../s3/sim-s3.js";
+import { SimFirehose } from "../sim-firehose.js";
+import { SimFirehoseNoRecordSource } from "./sim-firehose-record-source.js";
+
+describe("A simulated Firehose with no simulated Kinesis to read", () => {
+  it("says so when a delivery stream is created against a stream", async () => {
+    // Given a SimFirehose built on its own, with somewhere to deliver and
+    // nothing to read.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const accountRegionScope = simAwsAccountRegionScopeFactory.make();
+    const firehose = new SimFirehose({ accountRegionScope, s3: new SimS3() });
+    const { accountId, regionName } = accountRegionScope;
+
+    // When a delivery stream is created against a Kinesis stream.
+    await firehose.createDeliveryStream({
+      input: {
+        DeliveryStreamName: "order-events",
+        DeliveryStreamType: "KinesisStreamAsSource",
+        KinesisStreamSourceConfiguration: {
+          KinesisStreamARN: `arn:aws:kinesis:${regionName}:${accountId}:stream/orders`,
+          RoleARN: `arn:aws:iam::${accountId}:role/OrderStreamSourceRole`,
+        },
+        ExtendedS3DestinationConfiguration: {
+          BucketARN: "arn:aws:s3:::order-archive",
+          RoleARN: `arn:aws:iam::${accountId}:role/OrderArchiveDeliveryRole`,
+        },
+      },
+    });
+
+    // Then the delivery stream was created, and the failure says how to reach
+    // a stream rather than leaving the delivery stream quietly reading
+    // nothing.
+    const failures = firehose.getSourceFailures();
+    assertArrayLength(failures, 1);
+
+    const [failure] = failures;
+    assertNonNullable(failure, "The read failed and was recorded");
+    assertStringIncludes(failure.reason, "no simulated Kinesis");
+    assertArrayLength(warn.mock.calls, 1);
+  });
+
+  it("refuses every read it is asked for", async () => {
+    // Given the record source a SimFirehose falls back to.
+    const records = new SimFirehoseNoRecordSource();
+    const streamArn = "arn:aws:kinesis:us-east-1:888888888888:stream/orders";
+
+    // When each of the three reads is made.
+    const iterator = await assertThrowsErrorAsync(async () => {
+      await records.getShardIterator({ input: { StreamARN: streamArn } });
+    });
+    const read = await assertThrowsErrorAsync(async () => {
+      await records.getRecords();
+    });
+
+    // Then each refuses on its own, rather than one refusing and the next
+    // handing back nothing.
+    assertStringIncludes(iterator.message, streamArn);
+    assertStringIncludes(read.message, "no simulated Kinesis");
+  });
+
+  it("watches nothing", () => {
+    // Given the record source a SimFirehose falls back to, and something that
+    // would like to hear about records.
+    const activity = new SimFirehoseNoRecordSource().streamActivity();
+    const watcher = { recordsAvailable: () => undefined };
+
+    // When a stream is watched and then unwatched.
+    activity.watch(
+      "arn:aws:kinesis:us-east-1:888888888888:stream/orders",
+      watcher,
+    );
+    activity.unwatch(
+      "arn:aws:kinesis:us-east-1:888888888888:stream/orders",
+      watcher,
+    );
+
+    // Then neither did anything. There is no stream to hear from.
+  });
+});

--- a/src/service/firehose/source/sim-firehose-record-source.ts
+++ b/src/service/firehose/source/sim-firehose-record-source.ts
@@ -1,0 +1,165 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import { SimFirehoseError } from "../error/sim-firehose.error.js";
+
+/**
+ * What a Firehose read of a stream carries besides its command input.
+ *
+ * Every read is made as the source `RoleARN`, so simulated IAM decides it the
+ * way real IAM decides a real Firehose read.
+ */
+export interface SimFirehoseSourceCallerOptions {
+  readonly caller: SimAwsCaller;
+}
+
+/**
+ * One shard of a stream, as DescribeStream reports it.
+ */
+export interface SimFirehoseSourceShardDescription {
+  readonly ShardId?: string | undefined;
+}
+
+/**
+ * A stream, as DescribeStream reports it.
+ */
+export interface SimFirehoseSourceStreamDescription {
+  readonly Shards?: readonly SimFirehoseSourceShardDescription[] | undefined;
+  readonly HasMoreShards?: boolean | undefined;
+}
+
+/**
+ * One record as a stream hands it to a delivery stream.
+ *
+ * The bytes are the whole of it. A Kinesis-sourced delivery stream writes the
+ * record's data into the Object and nothing else about the record, which is
+ * why the sequence number and the partition key are absent here.
+ */
+export interface SimFirehoseSourceRecord {
+  readonly Data: Uint8Array;
+}
+
+/**
+ * Something outside Firehose waiting for records on a stream.
+ */
+export interface SimFirehoseSourceWatcher {
+  /**
+   * A record has been put, and can be read now.
+   */
+  recordsAvailable(): void;
+}
+
+/**
+ * The part of simulated Kinesis that says when a record has been put.
+ */
+export interface SimFirehoseSourceActivity {
+  watch(streamArn: string, watcher: SimFirehoseSourceWatcher): void;
+  unwatch(streamArn: string, watcher: SimFirehoseSourceWatcher): void;
+}
+
+/**
+ * The narrow slice of simulated Kinesis a delivery stream reads through.
+ *
+ * These are the SDK operations a real Firehose performs, in the order it
+ * performs them: find the shards, ask for a place at the end of one, then read
+ * from there. Going through the commands rather than through a reader of
+ * Yulin's own is what makes each call authorize as the source Role.
+ *
+ * `SimKinesis` structurally implements this interface.
+ */
+export interface SimFirehoseRecordSource {
+  describeStream(
+    command: {
+      input: {
+        StreamARN: string;
+        Limit?: number;
+        ExclusiveStartShardId?: string;
+      };
+    },
+    options?: SimFirehoseSourceCallerOptions,
+  ): Promise<{ StreamDescription: SimFirehoseSourceStreamDescription }>;
+
+  getShardIterator(
+    command: {
+      input: { StreamARN: string; ShardId: string; ShardIteratorType: string };
+    },
+    options?: SimFirehoseSourceCallerOptions,
+  ): Promise<{ ShardIterator: string }>;
+
+  getRecords(
+    command: { input: { ShardIterator: string; Limit: number } },
+    options?: SimFirehoseSourceCallerOptions,
+  ): Promise<{
+    Records: readonly SimFirehoseSourceRecord[];
+    NextShardIterator: string;
+  }>;
+
+  streamActivity(): SimFirehoseSourceActivity;
+}
+
+/**
+ * The record source used when no simulated Kinesis is wired up, such as for a
+ * standalone SimFirehose constructed outside SimAws.
+ *
+ * Every read refuses, so a delivery stream created against a Kinesis stream
+ * says why it takes nothing rather than quietly taking nothing.
+ */
+export class SimFirehoseNoRecordSource
+  implements SimFirehoseRecordSource, SimFirehoseSourceActivity
+{
+  /**
+   * Refuse to look at a stream, explaining how to reach one.
+   */
+  describeStream(command: {
+    input: { StreamARN: string };
+  }): Promise<{ StreamDescription: SimFirehoseSourceStreamDescription }> {
+    return Promise.reject(this.noStreams(command.input.StreamARN));
+  }
+
+  /**
+   * Refuse to take a place on a shard, explaining how to reach a stream.
+   */
+  getShardIterator(command: {
+    input: { StreamARN: string };
+  }): Promise<{ ShardIterator: string }> {
+    return Promise.reject(this.noStreams(command.input.StreamARN));
+  }
+
+  /**
+   * Refuse to read: there was never a place to read from.
+   */
+  getRecords(): Promise<{
+    Records: readonly SimFirehoseSourceRecord[];
+    NextShardIterator: string;
+  }> {
+    return Promise.reject(this.noStreams("a stream"));
+  }
+
+  /**
+   * Answer with the activity of a simulation holding no streams, which is
+   * this: nothing here ever has records to read.
+   */
+  streamActivity(): SimFirehoseSourceActivity {
+    return this;
+  }
+
+  /**
+   * Watch nothing: there is no stream to watch.
+   */
+  watch(): void {
+    //
+  }
+
+  /**
+   * Stop watching nothing.
+   */
+  unwatch(): void {
+    //
+  }
+
+  private noStreams(streamArn: string): SimFirehoseError {
+    return new SimFirehoseError(
+      `Cannot read ${streamArn}: this SimFirehose has no simulated Kinesis ` +
+        "to read. Create the delivery stream through SimAws, or construct " +
+        "SimFirehose with a kinesis to read from.",
+    );
+  }
+}

--- a/src/service/firehose/source/sim-firehose-source-choice.ts
+++ b/src/service/firehose/source/sim-firehose-source-choice.ts
@@ -1,0 +1,128 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import {
+  SimFirehoseInvalidArgumentException,
+  SimFirehoseUnsimulatedSource,
+} from "../error/sim-firehose.error.js";
+import { SimFirehoseKinesisSourceArn } from "./sim-firehose-kinesis-source-arn.js";
+import {
+  SimFirehoseDirectPutSource,
+  SimFirehoseKinesisSource,
+  type SimFirehoseSource,
+} from "./sim-firehose-source.js";
+
+/**
+ * The Kinesis stream a CreateDeliveryStream request reads from.
+ */
+export interface SimFirehoseKinesisSourceInput {
+  readonly KinesisStreamARN?: string | undefined;
+  readonly RoleARN?: string | undefined;
+}
+
+/**
+ * The source fields a CreateDeliveryStream request can carry.
+ */
+export interface SimFirehoseSourceInput {
+  readonly DeliveryStreamType?: string | undefined;
+  readonly KinesisStreamSourceConfiguration?:
+    | SimFirehoseKinesisSourceInput
+    | undefined;
+}
+
+/**
+ * The source a request declared, or a refusal saying why there is none.
+ *
+ * An omitted `DeliveryStreamType` is `DirectPut`, as it is on real Firehose. A
+ * type outside the two simulated is refused by name rather than taken as
+ * `DirectPut`, since a delivery stream reading an MSK cluster or a database
+ * would take nothing and deliver nothing.
+ */
+export function simFirehoseSourceOf(
+  input: SimFirehoseSourceInput,
+  scope: SimAwsAccountRegionScope,
+  startedAt: Date,
+): SimFirehoseSource {
+  const type = input.DeliveryStreamType ?? "DirectPut";
+
+  if (type === "KinesisStreamAsSource") {
+    return kinesisSource(requiredSourceConfiguration(input), scope, startedAt);
+  }
+
+  if (type !== "DirectPut") {
+    throw new SimFirehoseUnsimulatedSource(
+      `Simulated Kinesis Data Firehose takes records through PutRecord and ` +
+        `PutRecordBatch, or reads them off a simulated Kinesis stream, and ` +
+        `this delivery stream declares a DeliveryStreamType of ${type}.`,
+    );
+  }
+
+  if (input.KinesisStreamSourceConfiguration !== undefined) {
+    throw new SimFirehoseInvalidArgumentException(
+      "A KinesisStreamSourceConfiguration goes with a DeliveryStreamType of " +
+        "KinesisStreamAsSource, and this delivery stream is DirectPut",
+    );
+  }
+
+  return new SimFirehoseDirectPutSource();
+}
+
+/**
+ * The configuration a Kinesis-sourced delivery stream has to carry.
+ */
+function requiredSourceConfiguration(
+  input: SimFirehoseSourceInput,
+): SimFirehoseKinesisSourceInput {
+  const configuration = input.KinesisStreamSourceConfiguration;
+
+  if (configuration === undefined) {
+    throw new SimFirehoseInvalidArgumentException(
+      "A delivery stream of type KinesisStreamAsSource has to declare the " +
+        "stream it reads in a KinesisStreamSourceConfiguration",
+    );
+  }
+
+  return configuration;
+}
+
+/**
+ * The Kinesis stream a delivery stream reads, and the Role it reads as.
+ *
+ * A stream in another Account or Region is refused. This simulated Firehose
+ * reads the simulated Kinesis of its own scope, and treating a foreign ARN as
+ * local would let a test pass while the real delivery stream read nothing.
+ */
+function kinesisSource(
+  configuration: SimFirehoseKinesisSourceInput,
+  scope: SimAwsAccountRegionScope,
+  startedAt: Date,
+): SimFirehoseKinesisSource {
+  const streamArn = SimFirehoseKinesisSourceArn.of(
+    configuration.KinesisStreamARN,
+  );
+
+  if (!streamArn.isIn(scope)) {
+    throw new SimFirehoseUnsimulatedSource(
+      `Simulated Kinesis Data Firehose reads a source stream in its own ` +
+        `account and region, which is ${scope.accountId} in ` +
+        `${scope.regionName}, and ${streamArn.value} names another.`,
+    );
+  }
+
+  return new SimFirehoseKinesisSource({
+    streamArn,
+    roleArn: requiredRoleArn(configuration.RoleARN),
+    startedAt,
+  });
+}
+
+/**
+ * The Role a Kinesis-sourced delivery stream reads as.
+ */
+function requiredRoleArn(value: string | undefined): string {
+  if (value === undefined || value === "") {
+    throw new SimFirehoseInvalidArgumentException(
+      "The KinesisStreamSourceConfiguration is missing RoleARN",
+    );
+  }
+
+  return value;
+}

--- a/src/service/firehose/source/sim-firehose-source-failures.ts
+++ b/src/service/firehose/source/sim-firehose-source-failures.ts
@@ -1,0 +1,59 @@
+import { SimFirehoseFailure } from "../failure/sim-firehose-failure.js";
+import type { SimFirehoseFailures } from "../failure/sim-firehose-failures.js";
+import type { SimFirehoseKinesisSource } from "./sim-firehose-source.js";
+
+interface SimFirehoseSourceFailureProperties {
+  readonly deliveryStreamName: string;
+  readonly streamArn: string;
+  readonly roleArn: string;
+  readonly error: unknown;
+}
+
+/**
+ * A source stream a delivery stream stopped reading.
+ *
+ * There is one of these per delivery stream at most. A read that fails stops
+ * the delivery: the Role is refused every time it asks, and going round again
+ * would record the same refusal for as long as the simulation ran.
+ */
+export class SimFirehoseSourceFailure extends SimFirehoseFailure {
+  public readonly streamArn: string;
+
+  constructor(properties: SimFirehoseSourceFailureProperties) {
+    super(properties);
+    this.streamArn = properties.streamArn;
+  }
+
+  /**
+   * The failure of one delivery stream's read of the source it holds.
+   */
+  static of(
+    deliveryStreamName: string,
+    source: SimFirehoseKinesisSource,
+    error: unknown,
+  ): SimFirehoseSourceFailure {
+    return new this({
+      deliveryStreamName,
+      streamArn: source.streamArn.value,
+      roleArn: source.roleArn,
+      error,
+    });
+  }
+
+  /**
+   * How a stream that could not be read reads on the console.
+   */
+  override get warning(): string {
+    return `Simulated Kinesis Data Firehose delivery stream ${this.deliveryStreamName} stopped reading ${this.streamArn}: ${this.reason}`;
+  }
+}
+
+/**
+ * The source streams a simulated Firehose scope stopped reading.
+ *
+ * Real Firehose has no caller in front of it while it reads, and what stops the
+ * read reaches an operator through CloudWatch, which is not simulated. Every
+ * failure is kept here for a test to read.
+ */
+export type SimFirehoseSourceFailures =
+  SimFirehoseFailures<SimFirehoseSourceFailure>;

--- a/src/service/firehose/source/sim-firehose-source-permissions.iso.test.ts
+++ b/src/service/firehose/source/sim-firehose-source-permissions.iso.test.ts
@@ -1,0 +1,159 @@
+import { PutRecordCommand } from "@aws-sdk/client-kinesis";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it, vi } from "vitest";
+
+import {
+  deliveredObjectKeys,
+  makeFirehoseDeliveryDestination,
+} from "../../../../test/firehose/firehose-delivery-fixture.js";
+import { makeFirehoseKinesisSource } from "../../../../test/firehose/firehose-kinesis-source-fixture.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
+import { simFirehoseDeliveryStreamFactory } from "../stream/sim-firehose-delivery-stream.factory.js";
+
+describe("The Role a simulated Firehose delivery stream reads its source as", () => {
+  /**
+   * Put one order onto the source stream and let the buffering interval pass.
+   */
+  async function putAndDeliver(
+    simAws: SimAws,
+    streamName: string,
+  ): Promise<void> {
+    await simAws.kinesis().putRecord(
+      new PutRecordCommand({
+        StreamName: streamName,
+        PartitionKey: "order-1",
+        Data: new TextEncoder().encode('{"id":"order-1"}\n'),
+      }),
+    );
+    await simAws.clock().advanceBy({ minutes: 2 });
+  }
+
+  it("stops the delivery when the Role cannot read the stream", async () => {
+    // Given a delivery stream whose source Role may describe the stream and
+    // not read it.
+    const simAws = new SimAws();
+    const { bucketName, streamName, streamArn, sourceRoleArn } =
+      await makeFirehoseKinesisSource(simAws, {
+        sourceActions: ["kinesis:DescribeStream", "kinesis:GetShardIterator"],
+      });
+
+    // When a record is put on the stream and the interval passes.
+    await putAndDeliver(simAws, streamName);
+
+    // Then nothing was delivered, and the simulator holds the refusal with the
+    // stream and the Role it was reading as.
+    assertArrayLength(await deliveredObjectKeys(simAws, bucketName), 0);
+
+    const failures = simAws.firehose().getSourceFailures();
+    assertArrayLength(failures, 1);
+
+    const [failure] = failures;
+    assertNonNullable(failure, "The read failed and was recorded");
+    assertIdentical(failure.deliveryStreamName, "order-events");
+    assertIdentical(failure.streamArn, streamArn);
+    assertIdentical(failure.roleArn, sourceRoleArn);
+    assertInstanceOf(failure.error, SimIamAccessDenied);
+    assertTrue(failure.wasRefused);
+    assertStringIncludes(failure.reason, "kinesis:GetRecords");
+  });
+
+  it("stops before it starts when the Role cannot find the shards", async () => {
+    // Given a delivery stream whose source Role may do nothing on the stream.
+    const simAws = new SimAws();
+    const { streamName } = await makeFirehoseKinesisSource(simAws, {
+      sourceActions: ["kinesis:ListStreams"],
+    });
+
+    // Then the delivery stream was created, and the refusal is already
+    // recorded: finding the shards is a DescribeStream call made as the Role
+    // before CreateDeliveryStream answers.
+    const failures = simAws.firehose().getSourceFailures();
+    assertArrayLength(failures, 1);
+    assertStringIncludes(failures[0].reason, "kinesis:DescribeStream");
+
+    // When a record is put and the interval passes.
+    await putAndDeliver(simAws, streamName);
+
+    // Then it stayed at one failure. A delivery stream that gave up on its
+    // source does not go round again.
+    assertArrayLength(simAws.firehose().getSourceFailures(), 1);
+  });
+
+  it("records one failure and stops for a Role refused mid-stream", async () => {
+    // Given a delivery stream reading a stream, whose source Role loses its
+    // read permission after it started.
+    const simAws = new SimAws();
+    const { streamName } = await makeFirehoseKinesisSource(simAws);
+
+    await simAws.iam().deleteRolePolicy({
+      input: {
+        RoleName: "OrderStreamSourceRole",
+        PolicyName: "ReadOrders",
+      },
+    });
+
+    // When two records are put in separate intervals.
+    await putAndDeliver(simAws, streamName);
+    await putAndDeliver(simAws, streamName);
+
+    // Then it gave up on the first refusal rather than recording one per put.
+    assertArrayLength(simAws.firehose().getSourceFailures(), 1);
+  });
+
+  it("warns about a source stream that is not there", async () => {
+    // Given a delivery stream reading a stream nothing created.
+    const simAws = new SimAws();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const { bucketName, roleArn } =
+      await makeFirehoseDeliveryDestination(simAws);
+
+    await simFirehoseDeliveryStreamFactory.make(
+      {
+        bucketName,
+        roleArn,
+        sourceStreamArn: "arn:aws:kinesis:us-east-1:888888888888:stream/absent",
+      },
+      simAws,
+    );
+
+    // Then the failure was recorded, it is not a refusal, and the console was
+    // warned. A stream that is not there is a broken simulation rather than a
+    // modelled outcome, and a test that never reads the failures should still
+    // hear about it.
+    const failures = simAws.firehose().getSourceFailures();
+    assertArrayLength(failures, 1);
+
+    const [failure] = failures;
+    assertNonNullable(failure, "The read failed and was recorded");
+    assertFalse(failure.wasRefused);
+    assertArrayLength(warn.mock.calls, 1);
+
+    const [warning] = warn.mock.calls;
+    assertNonNullable(warning, "The failed read was warned about");
+    assertStringIncludes(String(warning[0]), "stream/absent");
+  });
+
+  it("reads as the Role rather than as whoever created the delivery stream", async () => {
+    // Given a delivery stream whose source Role may read the stream, created
+    // by a caller who has no Kinesis permission at all.
+    const simAws = new SimAws();
+    const { bucketName, streamName } = await makeFirehoseKinesisSource(simAws);
+
+    // When a record is put and the interval passes.
+    await putAndDeliver(simAws, streamName);
+
+    // Then it arrived. The read is the delivery stream's own, made as its
+    // source Role.
+    assertArrayLength(await deliveredObjectKeys(simAws, bucketName), 1);
+    assertArrayLength(simAws.firehose().getSourceFailures(), 0);
+  });
+});

--- a/src/service/firehose/source/sim-firehose-source.ts
+++ b/src/service/firehose/source/sim-firehose-source.ts
@@ -1,0 +1,91 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import { SimFirehoseInvalidArgumentException } from "../error/sim-firehose.error.js";
+import type { SimFirehoseKinesisSourceArn } from "./sim-firehose-kinesis-source-arn.js";
+
+/**
+ * How a delivery stream gets its records.
+ *
+ * `DirectPut` takes them from PutRecord and PutRecordBatch.
+ * `KinesisStreamAsSource` reads them off a Kinesis stream, and a delivery
+ * stream reading one takes no puts at all.
+ */
+export type SimFirehoseDeliveryStreamType =
+  | "DirectPut"
+  | "KinesisStreamAsSource";
+
+/**
+ * A delivery stream that takes the records a producer puts on it.
+ */
+export class SimFirehoseDirectPutSource {
+  public readonly kind = "direct-put" as const;
+  public readonly deliveryStreamType = "DirectPut" as const;
+
+  /**
+   * Take a put, which is where this delivery stream's records come from.
+   */
+  requirePut(): void {
+    //
+  }
+}
+
+interface SimFirehoseKinesisSourceProperties {
+  readonly streamArn: SimFirehoseKinesisSourceArn;
+  readonly roleArn: string;
+  readonly startedAt: Date;
+}
+
+/**
+ * A delivery stream that reads the records off a Kinesis stream.
+ *
+ * The Role is the one the reading is done as, so simulated IAM decides whether
+ * this delivery stream may read its source exactly as it decides whether the
+ * delivery Role may write the Bucket.
+ *
+ * Reading starts at the end of the stream, which is where real Firehose starts
+ * when the delivery stream is created. The instant it started is what
+ * DescribeDeliveryStream reports as `DeliveryStartTimestamp`, and records put
+ * before it stay behind the delivery stream.
+ */
+export class SimFirehoseKinesisSource {
+  public readonly kind = "kinesis-stream" as const;
+  public readonly deliveryStreamType = "KinesisStreamAsSource" as const;
+  public readonly streamArn: SimFirehoseKinesisSourceArn;
+  public readonly roleArn: string;
+  public readonly startedAt: Date;
+
+  constructor(properties: SimFirehoseKinesisSourceProperties) {
+    this.streamArn = properties.streamArn;
+    this.roleArn = properties.roleArn;
+    this.startedAt = properties.startedAt;
+  }
+
+  /**
+   * The Role every read of this stream is made as.
+   */
+  get caller(): SimAwsCaller {
+    return { kind: "arn", arn: this.roleArn };
+  }
+
+  /**
+   * Refuse a put, as real Firehose refuses one on a delivery stream with a
+   * Kinesis source.
+   *
+   * The records it delivers are the ones on its stream, and a producer putting
+   * one here would be putting it somewhere the delivery stream never reads.
+   */
+  requirePut(operation: string, deliveryStreamName: string): void {
+    throw new SimFirehoseInvalidArgumentException(
+      `${operation} is not supported for the delivery stream ` +
+        `${deliveryStreamName}, which reads its records from ` +
+        `${this.streamArn.value}. Put the record onto that Kinesis stream ` +
+        `instead.`,
+    );
+  }
+}
+
+/**
+ * Where one delivery stream's records come from.
+ */
+export type SimFirehoseSource =
+  | SimFirehoseDirectPutSource
+  | SimFirehoseKinesisSource;

--- a/src/service/firehose/stream/sim-firehose-delivery-stream.factory.ts
+++ b/src/service/firehose/stream/sim-firehose-delivery-stream.factory.ts
@@ -25,6 +25,21 @@ export interface SimFirehoseDeliveryStreamInput {
    * `simIamRoleWithPolicyFactory`.
    */
   readonly roleArn: string | undefined;
+
+  /**
+   * The Kinesis stream the delivery stream reads, for the tests that want one.
+   *
+   * A delivery stream made without it is `DirectPut`, which is what most tests
+   * want. Naming a stream makes it `KinesisStreamAsSource`, and the stream has
+   * to be there already: it is one entity and the delivery stream is another.
+   */
+  readonly sourceStreamArn: string | undefined;
+
+  /**
+   * The Role the source stream is read as, which the Account root stands in
+   * for when a test is not about the source Role.
+   */
+  readonly sourceRoleArn: string | undefined;
 }
 
 /**
@@ -40,6 +55,9 @@ export interface SimFirehoseDeliveryStreamInput {
  *   simAws,
  * );
  * ```
+ *
+ * A delivery stream reading a Kinesis stream is the same call naming the
+ * stream, which has to be there already.
  */
 export const simFirehoseDeliveryStreamFactory = new AsyncMappedFactory<
   SimFirehoseDeliveryStreamInput,
@@ -53,17 +71,26 @@ export const simFirehoseDeliveryStreamFactory = new AsyncMappedFactory<
     intervalInSeconds: 60,
     sizeInMegabytes: 5,
     roleArn: undefined,
+    sourceStreamArn: undefined,
+    sourceRoleArn: undefined,
   }),
   async (input, simAws) => {
     const firehose = simAws.firehose();
+    const accountRoot = `arn:aws:iam::${simAws.defaultAccountId}:root`;
 
     await firehose.createDeliveryStream({
       input: {
         DeliveryStreamName: input.deliveryStreamName,
+        ...(input.sourceStreamArn !== undefined && {
+          DeliveryStreamType: "KinesisStreamAsSource",
+          KinesisStreamSourceConfiguration: {
+            KinesisStreamARN: input.sourceStreamArn,
+            RoleARN: input.sourceRoleArn ?? accountRoot,
+          },
+        }),
         ExtendedS3DestinationConfiguration: {
           BucketARN: `arn:aws:s3:::${input.bucketName}`,
-          RoleARN:
-            input.roleArn ?? `arn:aws:iam::${simAws.defaultAccountId}:root`,
+          RoleARN: input.roleArn ?? accountRoot,
           Prefix: input.prefix,
           BufferingHints: {
             IntervalInSeconds: input.intervalInSeconds,

--- a/src/service/firehose/stream/sim-firehose-delivery-stream.ts
+++ b/src/service/firehose/stream/sim-firehose-delivery-stream.ts
@@ -1,5 +1,9 @@
 import { SimFirehoseBuffer } from "../delivery/sim-firehose-buffer.js";
 import type { SimFirehoseS3Destination } from "../destination/sim-firehose-s3-destination.js";
+import type {
+  SimFirehoseDeliveryStreamType,
+  SimFirehoseSource,
+} from "../source/sim-firehose-source.js";
 
 /**
  * The states a delivery stream reports.
@@ -10,27 +14,20 @@ import type { SimFirehoseS3Destination } from "../destination/sim-firehose-s3-de
  */
 export type SimFirehoseDeliveryStreamStatus = "ACTIVE";
 
-/**
- * How a delivery stream gets its records.
- *
- * `DirectPut` is the only source simulated. A delivery stream reading from a
- * Kinesis stream is a separate job.
- */
-export type SimFirehoseDeliveryStreamType = "DirectPut";
-
 interface SimFirehoseDeliveryStreamProperties {
   readonly name: string;
   readonly arn: string;
   readonly destination: SimFirehoseS3Destination;
+  readonly source: SimFirehoseSource;
   readonly createdAt: Date;
 }
 
 /**
  * One delivery stream, and what it has taken but not yet delivered.
  *
- * A delivery stream is a destination and a buffer. Records arrive through
- * PutRecord, wait in the buffer until it passes one of its two bounds, and
- * leave as one S3 Object.
+ * A delivery stream is a source, a destination and a buffer. Records arrive
+ * from where the source says they do, wait in the buffer until it passes one of
+ * its two bounds, and leave as one S3 Object.
  *
  * The version is the `1` in a delivered Object's key. Real Firehose moves it on
  * with every configuration change, and nothing here changes a delivery stream's
@@ -40,18 +37,25 @@ export class SimFirehoseDeliveryStream {
   public readonly name: string;
   public readonly arn: string;
   public readonly destination: SimFirehoseS3Destination;
+  public readonly source: SimFirehoseSource;
   public readonly createdAt: Date;
   public readonly buffer = new SimFirehoseBuffer();
   public readonly versionId = "1";
   public readonly status: SimFirehoseDeliveryStreamStatus = "ACTIVE";
-  public readonly deliveryStreamType: SimFirehoseDeliveryStreamType =
-    "DirectPut";
 
   constructor(properties: SimFirehoseDeliveryStreamProperties) {
     this.name = properties.name;
     this.arn = properties.arn;
     this.destination = properties.destination;
+    this.source = properties.source;
     this.createdAt = properties.createdAt;
+  }
+
+  /**
+   * Where this delivery stream gets its records, as it reports it.
+   */
+  get deliveryStreamType(): SimFirehoseDeliveryStreamType {
+    return this.source.deliveryStreamType;
   }
 
   /**

--- a/test/firehose/firehose-delivery-fixture.ts
+++ b/test/firehose/firehose-delivery-fixture.ts
@@ -35,12 +35,19 @@ export const firehoseDeliveryActions: readonly string[] = [
 ];
 
 /**
- * What a delivery fixture leaves a test holding.
+ * A Bucket and a Role allowed to write into it, which is what a delivery
+ * stream needs before it can deliver anything.
  */
-export interface FirehoseDelivery {
-  readonly deliveryStream: SimFirehoseDeliveryStream;
+export interface FirehoseDeliveryDestination {
   readonly bucketName: string;
   readonly roleArn: string;
+}
+
+/**
+ * What a delivery fixture leaves a test holding.
+ */
+export interface FirehoseDelivery extends FirehoseDeliveryDestination {
+  readonly deliveryStream: SimFirehoseDeliveryStream;
 }
 
 interface FirehoseDeliveryOptions {
@@ -52,16 +59,18 @@ interface FirehoseDeliveryOptions {
 }
 
 /**
- * Make a Bucket, a delivery Role and a delivery stream writing into the one as
- * the other.
+ * Make a Bucket and a delivery Role allowed to write into it.
  *
  * The Role is allowed the actions real Firehose asks a delivery Role for.
  * Narrowing them is how a test checks what a Role that cannot write does.
+ *
+ * This is the half a delivery stream reading a Kinesis stream needs as well,
+ * which is why it is on its own.
  */
-export async function makeFirehoseDelivery(
+export async function makeFirehoseDeliveryDestination(
   simAws: SimAws,
   options: FirehoseDeliveryOptions = {},
-): Promise<FirehoseDelivery> {
+): Promise<FirehoseDeliveryDestination> {
   const bucketName = options.bucketName ?? "order-archive";
 
   await simAws
@@ -80,10 +89,26 @@ export async function makeFirehoseDelivery(
 
   assertDefined(role.Arn, "Simulated IAM created a Role with no ARN");
 
+  return { bucketName, roleArn: role.Arn };
+}
+
+/**
+ * Make a Bucket, a delivery Role and a delivery stream writing into the one as
+ * the other.
+ */
+export async function makeFirehoseDelivery(
+  simAws: SimAws,
+  options: FirehoseDeliveryOptions = {},
+): Promise<FirehoseDelivery> {
+  const { bucketName, roleArn } = await makeFirehoseDeliveryDestination(
+    simAws,
+    options,
+  );
+
   const deliveryStream = await simFirehoseDeliveryStreamFactory.make(
     {
       bucketName,
-      roleArn: role.Arn,
+      roleArn,
       prefix: options.prefix ?? "",
       intervalInSeconds: options.intervalInSeconds ?? 60,
       sizeInMegabytes: options.sizeInMegabytes ?? 5,
@@ -91,7 +116,7 @@ export async function makeFirehoseDelivery(
     simAws,
   );
 
-  return { deliveryStream, bucketName, roleArn: role.Arn };
+  return { deliveryStream, bucketName, roleArn };
 }
 
 /**

--- a/test/firehose/firehose-kinesis-source-fixture.ts
+++ b/test/firehose/firehose-kinesis-source-fixture.ts
@@ -1,0 +1,101 @@
+/**
+ * The parts a Firehose Kinesis source test needs before it can say anything
+ * about what lands in a Bucket: a stream to read, a Role allowed to read it,
+ * and a delivery stream reading the one as the other into a Bucket it can
+ * write.
+ *
+ * Each of those is an entity factory of its own, and the delivery half is
+ * already put together by `makeFirehoseDelivery`. This is where the source is
+ * put on top, because a delivery stream whose stream is absent reads nothing
+ * and no test wants that as its Given.
+ */
+
+import { assertDefined } from "../../src/util/type-guard/defined.js";
+import type { SimAws } from "../../src/service/aws/sim-aws.js";
+import { simIamRoleWithPolicyFactory } from "../../src/service/iam/role/sim-iam-role-with-policy.factory.js";
+import { simKinesisStreamFactory } from "../../src/service/kinesis/stream/sim-kinesis-stream.factory.js";
+import { simFirehoseDeliveryStreamFactory } from "../../src/service/firehose/stream/sim-firehose-delivery-stream.factory.js";
+import type { SimFirehoseDeliveryStream } from "../../src/service/firehose/stream/sim-firehose-delivery-stream.js";
+import { makeFirehoseDeliveryDestination } from "./firehose-delivery-fixture.js";
+
+/**
+ * The Kinesis actions real Firehose requires a source Role to be allowed
+ * before it will read a stream.
+ */
+export const firehoseSourceActions: readonly string[] = [
+  "kinesis:DescribeStream",
+  "kinesis:GetRecords",
+  "kinesis:GetShardIterator",
+  "kinesis:ListShards",
+];
+
+/**
+ * What a Kinesis source fixture leaves a test holding.
+ */
+export interface FirehoseKinesisSource {
+  readonly deliveryStream: SimFirehoseDeliveryStream;
+  readonly streamName: string;
+  readonly streamArn: string;
+  readonly bucketName: string;
+  readonly sourceRoleArn: string;
+}
+
+interface FirehoseKinesisSourceOptions {
+  readonly streamName?: string;
+  readonly shardCount?: number;
+  readonly intervalInSeconds?: number;
+  readonly sourceActions?: readonly string[];
+}
+
+/**
+ * Make a stream, a source Role and a delivery stream reading the one as the
+ * other into an Object destination that works.
+ *
+ * The Role is allowed the actions real Firehose asks a source Role for.
+ * Narrowing them is how a test checks what a Role that cannot read does.
+ */
+export async function makeFirehoseKinesisSource(
+  simAws: SimAws,
+  options: FirehoseKinesisSourceOptions = {},
+): Promise<FirehoseKinesisSource> {
+  const streamName = options.streamName ?? "orders";
+  const stream = await simKinesisStreamFactory.make(
+    { streamName, shardCount: options.shardCount ?? 1 },
+    simAws,
+  );
+
+  const role = await simIamRoleWithPolicyFactory.make(
+    {
+      roleName: "OrderStreamSourceRole",
+      policyName: "ReadOrders",
+      actions: options.sourceActions ?? firehoseSourceActions,
+      resource: stream.arn,
+    },
+    simAws,
+  );
+
+  assertDefined(role.Arn, "Simulated IAM created a Role with no ARN");
+
+  const { bucketName, roleArn } = await makeFirehoseDeliveryDestination(simAws);
+
+  const deliveryStream = await simFirehoseDeliveryStreamFactory.make(
+    {
+      bucketName,
+      roleArn,
+      sourceStreamArn: stream.arn,
+      sourceRoleArn: role.Arn,
+      ...(options.intervalInSeconds !== undefined && {
+        intervalInSeconds: options.intervalInSeconds,
+      }),
+    },
+    simAws,
+  );
+
+  return {
+    deliveryStream,
+    streamName,
+    streamArn: stream.arn,
+    bucketName,
+    sourceRoleArn: role.Arn,
+  };
+}


### PR DESCRIPTION
A delivery stream created with a KinesisStreamSourceConfiguration reads every
shard of a simulated Kinesis stream as its source RoleARN, and buffers what it
reads for the S3 destination. The shards are opened at the end of the stream
before CreateDeliveryStream answers, leaving records put earlier where they are.
The read itself happens on the clock, so one advance past the buffering interval
covers both halves. DescribeDeliveryStream reports the source, both puts are
refused on a delivery stream that reads one, and a source Role that cannot read
stops the delivery and shows up on getSourceFailures().

Resolves https://github.com/KensioSoftware/yulin/issues/932

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Firehose delivery streams can now read records from simulated Kinesis streams and deliver them to S3.
  * Supports shard coverage, buffering, start-at-tail behavior, simulated-time polling, and source metadata.
  * Source and delivery failures are tracked separately and exposed for inspection.
  * Added validation for stream configuration, IAM permissions, account/region scope, and unsupported operations.

* **Documentation**
  * Added setup guidance, limitations, permissions details, and a complete Kinesis-to-S3 example.

* **Bug Fixes**
  * Deleting a Kinesis-backed delivery stream now stops its source reading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->