### PR TITLE
feat: invoke a Lambda function from a Task state

### DIFF
--- a/docs/services/stepfunctions/README.md
+++ b/docs/services/stepfunctions/README.md
@@ -8,12 +8,14 @@ Types for simulated Step Functions are imported from the `@kensio/yulin/stepfunc
 
 ## What runs today
 
-Five state types run. `Pass`, `Succeed`, `Fail`, `Choice` and `Wait`. A definition using any other
-is refused when the state machine is created, naming the state and its type. `Task`, `Parallel` and
-`Map` are on the way.
+Six state types run. `Pass`, `Task`, `Succeed`, `Fail`, `Choice` and `Wait`. A definition using
+`Parallel` or `Map` is refused when the state machine is created, naming the state and its type.
 
 The data-flow fields run in full. `InputPath`, `Parameters`, `ResultSelector`, `ResultPath` and
 `OutputPath` apply in that order, reading Reference Paths and the intrinsic functions.
+
+A `Task` state invokes a simulated Lambda function. Every other `Resource` is refused when the state
+machine is created, naming what the definition asked for.
 
 ## Running a state machine
 
@@ -108,6 +110,172 @@ A failing execution is recorded on the execution, and the call returns as it wou
 succeeded. Simulated EventBridge treats an undeliverable event the same way. An execution failing is
 as often the thing under test as it is a fault, and raising it would fail an unrelated `advanceBy`
 elsewhere in the same test.
+
+## Invoking a Lambda function
+
+A `Task` state invokes a simulated Lambda function, through either of the two `Resource` forms CDK's
+`LambdaInvoke` emits.
+
+`arn:aws:states:::lambda:invoke` is the integration Step Functions optimises. The state is talking to
+the Lambda API, so its `Parameters` are an `Invoke` request (`FunctionName` names the function and
+`Payload` carries what it is sent) and its result is an `Invoke` response, with the handler's answer
+under `Payload`.
+
+A function ARN sends the state's own input to the handler and answers with what the handler
+returned. CDK writes this form for `payloadResponseOnly`.
+
+```typescript sim-step-functions-task
+/**
+ * A workflow whose Task states invoke simulated Lambda functions.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateFunctionCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "check-enrolment",
+    Role: "arn:aws:iam::123456789012:role/FunctionRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: { term: number }) => ({
+        eligible: event.term > 1,
+      })),
+    },
+  }),
+);
+
+const enrol = await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "enrol-student",
+    Role: "arn:aws:iam::123456789012:role/FunctionRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: { student: string }) => ({
+        enrolled: event.student,
+      })),
+    },
+  }),
+);
+
+// The execution assumes this role, and invokes both functions as it.
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "WorkflowRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "states.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "WorkflowRole",
+    PolicyName: "InvokeEnrolmentFunctions",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "lambda:InvokeFunction",
+        Resource: "*",
+      },
+    }),
+  }),
+);
+
+const created = await simAws.stepFunctions().createStateMachine({
+  input: {
+    name: "Enrolment",
+    roleArn: role.Role.Arn,
+    definition: JSON.stringify({
+      StartAt: "Check",
+      States: {
+        Check: {
+          Type: "Task",
+          Resource: "arn:aws:states:::lambda:invoke",
+          Parameters: { FunctionName: "check-enrolment", "Payload.$": "$" },
+          ResultSelector: { "eligible.$": "$.Payload.eligible" },
+          ResultPath: "$.outcome",
+          Next: "Eligible",
+        },
+        Eligible: {
+          Type: "Choice",
+          Choices: [
+            {
+              Variable: "$.outcome.eligible",
+              BooleanEquals: true,
+              Next: "Enrol",
+            },
+          ],
+          Default: "Decline",
+        },
+        Enrol: { Type: "Task", Resource: enrol.FunctionArn, End: true },
+        Decline: { Type: "Fail", Error: "NotEligible" },
+      },
+    }),
+  },
+});
+
+const started = await simAws.stepFunctions().startExecution({
+  input: {
+    stateMachineArn: created.stateMachineArn,
+    input: JSON.stringify({ student: "Wei", term: 3 }),
+  },
+});
+
+const described = await simAws
+  .stepFunctions()
+  .describeExecution({ input: { executionArn: started.executionArn } });
+
+console.log(described.output); // {"enrolled":"Wei"}
+```
+
+The five data-flow fields apply around a task the way they apply around a `Pass` state.
+`InputPath` and `Parameters` build what the task is sent, and `ResultSelector`, `ResultPath` and
+`OutputPath` shape what comes back. `ResultPath` reads the state's raw input. `Check` above keeps
+the student it was given, alongside the one field its `ResultSelector` picked out of the response.
+
+A handler runs on the simulation's clock. A timestamp a handler stamps and a `TimestampPath` a later
+`Wait` state reads agree.
+
+`FunctionName` takes a function name or a function ARN, as the Lambda API does. A name alone is a
+function in the state machine's own Account and Region, and an ARN can name one in another. A
+qualified ARN invokes the version an alias points at.
+
+### The execution role
+
+The execution assumes the state machine's `RoleArn` and invokes the function as that role. The role
+needs two things. Its trust policy admits `states.amazonaws.com`, and one of its policies allows
+`lambda:InvokeFunction` on the function. A role missing either fails the task with
+`States.TaskFailed`, saying which of the two it was.
+
+The function's own resource policy is not consulted. A task arrives as an assumed role, and a role
+in the same Account needs only its own identity policy. An EventBridge rule works the other way
+round, arriving as a service principal that the function's resource policy admits.
+
+### When a task fails
+
+A handler that raises fails the task, and the Amazon States Language error name follows the
+`Resource` form that invoked it:
+
+- Through `arn:aws:states:::lambda:invoke` the failure is `States.TaskFailed`.
+- Through a function ARN it is the handler's own error type. An error named `NotEligible` fails the
+  task as `NotEligible`.
+
+`Retry` and `Catch` match on that name. Neither runs here yet. A task that fails ends the execution,
+and `DescribeExecution` carries the error name and the handler's message.
+
+Anything else that stops a task from running fails it with `States.TaskFailed`. A function that is
+not there, a role that cannot be assumed, and a role that may not invoke are the three of them, and
+the cause says which one it was.
 
 ## Branching on the input
 
@@ -375,7 +543,8 @@ raise. A path that would have selected the wrong node fails, and no state is ans
 data. A dotted field name is held to the JsonPath `member-name-shorthand` rule. `$.a-b` is refused,
 and `$['a-b']` is the way to write it.
 
-`$$`, the context object, arrives with the `Task` state.
+`$$`, the context object, is unsimulated. A path reading it fails the state with
+`States.QueryEvaluationError`, saying that only paths rooted at `$` are read.
 
 ## Intrinsic functions
 
@@ -404,6 +573,11 @@ A test asserting on the output of a state machine that used one could only asser
   `States.Format` alone, so `States.Format` is where `\{` is resolved. An escaped brace reaching
   another intrinsic arrives as it was written.
 - **`GetExecutionHistory` is unsimulated.** The inspection accessor answers the same question.
+- **A task's `Invoke` response carries three fields.** `ExecutedVersion`, `Payload` and
+  `StatusCode`. Real Step Functions adds `SdkHttpMetadata` and `SdkResponseMetadata`, which describe
+  a call over a network there was none of here.
+- **A failed task's `Cause` is the handler's message.** Real Step Functions writes the JSON error
+  document Lambda answered with, holding `errorMessage`, `errorType` and a stack trace.
 - **A cycle in the states fails the execution** after 25,000 transitions, with `States.Runtime`. Real
   Step Functions stops one when it runs out of execution history events.
 
@@ -427,8 +601,9 @@ two and is what this follows.
 
 ## Still to come
 
-- `Task`, `Parallel` and `Map` states.
-- `Retry` and `Catch`.
-- Service integrations, task tokens and activities.
+- `Parallel` and `Map` states.
+- `Retry` and `Catch`, and the `TimeoutSeconds` and `HeartbeatSeconds` a `Task` state takes. A
+  definition carrying one of them is refused, naming the field.
+- Service integrations beyond Lambda, task tokens and activities.
+- The context object, `$$`.
 - JSONata as a query language, and the `Assign` variables that go with it.
-- IAM authorization of what a state machine's role may do.

--- a/docs/services/stepfunctions/sim-step-functions-task.example.ts
+++ b/docs/services/stepfunctions/sim-step-functions-task.example.ts
@@ -1,0 +1,111 @@
+/**
+ * A workflow whose Task states invoke simulated Lambda functions.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateFunctionCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "check-enrolment",
+    Role: "arn:aws:iam::123456789012:role/FunctionRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: { term: number }) => ({
+        eligible: event.term > 1,
+      })),
+    },
+  }),
+);
+
+const enrol = await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "enrol-student",
+    Role: "arn:aws:iam::123456789012:role/FunctionRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: { student: string }) => ({
+        enrolled: event.student,
+      })),
+    },
+  }),
+);
+
+// The execution assumes this role, and invokes both functions as it.
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "WorkflowRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "states.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "WorkflowRole",
+    PolicyName: "InvokeEnrolmentFunctions",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "lambda:InvokeFunction",
+        Resource: "*",
+      },
+    }),
+  }),
+);
+
+const created = await simAws.stepFunctions().createStateMachine({
+  input: {
+    name: "Enrolment",
+    roleArn: role.Role.Arn,
+    definition: JSON.stringify({
+      StartAt: "Check",
+      States: {
+        Check: {
+          Type: "Task",
+          Resource: "arn:aws:states:::lambda:invoke",
+          Parameters: { FunctionName: "check-enrolment", "Payload.$": "$" },
+          ResultSelector: { "eligible.$": "$.Payload.eligible" },
+          ResultPath: "$.outcome",
+          Next: "Eligible",
+        },
+        Eligible: {
+          Type: "Choice",
+          Choices: [
+            {
+              Variable: "$.outcome.eligible",
+              BooleanEquals: true,
+              Next: "Enrol",
+            },
+          ],
+          Default: "Decline",
+        },
+        Enrol: { Type: "Task", Resource: enrol.FunctionArn, End: true },
+        Decline: { Type: "Fail", Error: "NotEligible" },
+      },
+    }),
+  },
+});
+
+const started = await simAws.stepFunctions().startExecution({
+  input: {
+    stateMachineArn: created.stateMachineArn,
+    input: JSON.stringify({ student: "Wei", term: 3 }),
+  },
+});
+
+const described = await simAws
+  .stepFunctions()
+  .describeExecution({ input: { executionArn: started.executionArn } });
+
+console.log(described.output); // {"enrolled":"Wei"}

--- a/docs/time/README.md
+++ b/docs/time/README.md
@@ -146,6 +146,9 @@ failed delivery to nobody, and one rejected delivery would otherwise fail an unr
 `advanceBy(...)` elsewhere in the same test. Read the failures from `eventBridge().deliveryFailures`
 and `scheduler().deliveryFailures`.
 
+A Step Functions execution works the same way. A state that fails while the clock is being advanced
+is recorded on the execution, and `DescribeExecution` reports it once the advance has returned.
+
 Several parts of the simulator schedule work on the clock. Advancing time does more than change what
 timestamps and expiry checks see. A scheduled EventBridge rule fires, an EventBridge Scheduler
 schedule invokes its target, a DynamoDB item passes its time to live, a Secrets Manager deletion

--- a/src/service/aws/factory/sim-aws-account-region-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-account-region-service-builder.ts
@@ -8,6 +8,7 @@ import {
   simAwsEventBridgeDeliveryTargets,
   simAwsRekognitionImages,
   simAwsSchedulerDeliveryTargets,
+  simAwsStatesTaskTargets,
 } from "./sim-aws-cross-account-collaborators.js";
 import { SimCloudFormation } from "../../cloudformation/index.js";
 import { SimCloudWatch } from "../../cloudwatch/index.js";
@@ -27,6 +28,7 @@ import { SimRekognition } from "../../rekognition/index.js";
 import { SimS3 } from "../../s3/sim-s3.js";
 import { SimScheduler } from "../../scheduler/index.js";
 import { SimSesV2 } from "../../ses/index.js";
+import { SimStepFunctions } from "../../stepfunctions/index.js";
 import { simAwsEcsCollaborators } from "./sim-aws-ecs-collaborators.js";
 import { simAwsLambdaCollaborators } from "./sim-aws-lambda-collaborators.js";
 import { simAwsS3NotificationDestinations } from "./sim-aws-s3-notification-destinations.js";
@@ -257,6 +259,22 @@ export class SimAwsAccountRegionServiceBuilder {
       ...this.scoped(scope),
       deliveryEndpoints: endpoints,
       messageLog: this.messageLog,
+    });
+  }
+
+  /**
+   * Create simulated Step Functions for an Account Region scope.
+   *
+   * State machines are Region-scoped on real AWS: a state machine ARN names
+   * the Region, and one cannot be reached from another. A `Task` state
+   * invokes a function in any Account and Region of the simulation, as a real
+   * execution does, so the functions it can reach come from the whole
+   * simulation rather than from this scope.
+   */
+  createStepFunctions(scope: SimAwsAccountRegionContainer): SimStepFunctions {
+    return new SimStepFunctions({
+      ...this.scoped(scope),
+      taskTargets: simAwsStatesTaskTargets(this.simAws, scope),
     });
   }
 

--- a/src/service/aws/factory/sim-aws-cross-account-collaborators.ts
+++ b/src/service/aws/factory/sim-aws-cross-account-collaborators.ts
@@ -4,6 +4,7 @@ import { SimCognitoHttpApiJwtIssuerKeys } from "../../apigatewayv2/api/authorize
 import { SimAwsEventBridgeDeliveryTargets } from "../../eventbridge/delivery/sim-aws-event-bridge-delivery-targets.js";
 import { SimAwsRekognitionImageObjects } from "../../rekognition/image/s3/sim-aws-rekognition-image-objects.js";
 import { SimAwsSchedulerDeliveryTargets } from "../../scheduler/delivery/sim-aws-scheduler-delivery-targets.js";
+import { SimAwsStatesTaskTargets } from "../../stepfunctions/task/sim-aws-states-task-targets.js";
 import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-scope.js";
 import type { SimAws } from "../sim-aws.js";
 import type { SimAwsScopedServiceRegistries } from "./sim-aws-scoped-service-registries.js";
@@ -72,6 +73,24 @@ export function simAwsSchedulerDeliveryTargets(
   simAws: SimAws,
 ): SimAwsSchedulerDeliveryTargets {
   return new SimAwsSchedulerDeliveryTargets({ simAws });
+}
+
+/**
+ * Everywhere a simulated state machine's `Task` state can invoke.
+ *
+ * An execution assumes its state machine's role in that role's own Account and
+ * reaches the function in the function's, which need not be the same one, so
+ * this reads the whole simulation rather than one scope. A `Task` state naming
+ * a function by name alone means one in the state machine's own scope.
+ */
+export function simAwsStatesTaskTargets(
+  simAws: SimAws,
+  scope: SimAwsAccountRegionContainer,
+): SimAwsStatesTaskTargets {
+  return new SimAwsStatesTaskTargets({
+    simAws,
+    accountRegionScope: scope.accountRegionScope,
+  });
 }
 
 /**

--- a/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
@@ -3,7 +3,6 @@ import { SimBedrock } from "../../bedrock/index.js";
 import { SimDynamoDb as SimDynamoDatabase } from "../../dynamodb/index.js";
 import { SimFirehose } from "../../firehose/index.js";
 import { SimKinesis } from "../../kinesis/index.js";
-import { SimStepFunctions } from "../../stepfunctions/index.js";
 import { SimSecretsManager } from "../../secretsmanager/index.js";
 import { SimSqs } from "../../sqs/index.js";
 import { SimSsm } from "../../ssm/index.js";
@@ -70,16 +69,6 @@ export class SimAwsSelfContainedServiceBuilder {
    */
   createKinesis(scope: SimAwsAccountRegionContainer): SimKinesis {
     return new SimKinesis(this.scoped(scope));
-  }
-
-  /**
-   * Create simulated Step Functions for an Account Region scope.
-   *
-   * State machines are Region-scoped on real AWS: a state machine ARN names
-   * the Region, and one cannot be reached from another.
-   */
-  createStepFunctions(scope: SimAwsAccountRegionContainer): SimStepFunctions {
-    return new SimStepFunctions(this.scoped(scope));
   }
 
   /**

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -245,7 +245,7 @@ export class SimAwsServiceFactory {
 
   /** Create simulated Step Functions for an Account Region scope. */
   createStepFunctions(scope: SimAwsAccountRegionContainer): SimStepFunctions {
-    return this.selfContainedServices.createStepFunctions(scope);
+    return this.accountRegionServices.createStepFunctions(scope);
   }
 
   /** Create simulated Lambda for an Account Region scope. */

--- a/src/service/cloudformation/resource/cfn/stepfunctions/sim-cfn-step-functions-resource-error.ts
+++ b/src/service/cloudformation/resource/cfn/stepfunctions/sim-cfn-step-functions-resource-error.ts
@@ -58,7 +58,7 @@ export function simCfnStepFunctionsSkippedResourceError(
  * Every Resource type here goes through the ordinary Step Functions commands,
  * so what a template may ask for is decided once, by simulated Step Functions,
  * rather than again in the CloudFormation layer. What that leaves out is where
- * the request came from. A deployment failing with `The state Check is a Task
+ * the request came from. A deployment failing with `The state Fan is a Parallel
  * state` says which state but not which Resource declared it, and a template
  * can hold several.
  *

--- a/src/service/stepfunctions/command/execution/sim-states-execution-start.ts
+++ b/src/service/stepfunctions/command/execution/sim-states-execution-start.ts
@@ -5,6 +5,7 @@ import type { SimStatesExecutionStore } from "../../execution/sim-states-executi
 import { SimStatesInterpreter } from "../../execution/sim-states-interpreter.js";
 import { simStatesExecutionArn } from "../../machine/sim-state-machine-arn.js";
 import type { SimStateMachineStore } from "../../machine/sim-state-machine-store.js";
+import type { SimStatesTaskTargets } from "../../task/sim-states-task-invocation.js";
 import { requireSimStateMachine } from "../machine/sim-state-machine-lookup.js";
 import type {
   SimStartExecutionCommand,
@@ -19,6 +20,7 @@ interface SimStatesExecutionStartProperties {
   readonly executions: SimStatesExecutionStore;
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly background: BackgroundScheduler;
+  readonly tasks: SimStatesTaskTargets;
 }
 
 /**
@@ -29,12 +31,14 @@ export class SimStatesExecutionStart {
   readonly #executions: SimStatesExecutionStore;
   readonly #accountRegionScope: SimAwsAccountRegionScope;
   readonly #background: BackgroundScheduler;
+  readonly #tasks: SimStatesTaskTargets;
 
   constructor(properties: SimStatesExecutionStartProperties) {
     this.#stateMachines = properties.stateMachines;
     this.#executions = properties.executions;
     this.#accountRegionScope = properties.accountRegionScope;
     this.#background = properties.background;
+    this.#tasks = properties.tasks;
   }
 
   /**
@@ -93,6 +97,8 @@ export class SimStatesExecutionStart {
       definition: stateMachine.parsedDefinition,
       execution,
       background: this.#background,
+      tasks: this.#tasks,
+      roleArn: stateMachine.roleArn,
     }).run();
 
     return { executionArn: execution.arn, startDate };

--- a/src/service/stepfunctions/definition/sim-states-state-fields.ts
+++ b/src/service/stepfunctions/definition/sim-states-state-fields.ts
@@ -1,0 +1,67 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { SimStatesInvalidDefinition } from "../error/sim-step-functions.error.js";
+
+// Real Step Functions gives a Fail state no input or output processing at all,
+// and gives a Succeed state only the two paths.
+const stateFieldsRefused = new Map<string, readonly string[]>([
+  [
+    "Fail",
+    ["InputPath", "OutputPath", "Parameters", "ResultPath", "ResultSelector"],
+  ],
+  ["Succeed", ["Parameters", "ResultPath", "ResultSelector"]],
+  // A Choice state and a Wait state produce no result of their own, so they
+  // carry the two paths and nothing that reshapes a result.
+  ["Choice", ["Parameters", "ResultPath", "ResultSelector"]],
+  ["Wait", ["Parameters", "ResultPath", "ResultSelector"]],
+]);
+
+/**
+ * Refuse the fields a state's type does not have.
+ *
+ * A definition carrying one of these would behave differently here than it
+ * does on AWS, where the field is simply not part of the state.
+ */
+export function checkSimStatesRefusedFields(
+  name: string,
+  type: string,
+  state: Record<string, JSONValue>,
+): void {
+  const refused = stateFieldsRefused.get(type) ?? [];
+  const present = refused.filter((field) => Object.hasOwn(state, field));
+
+  if (present.length > 0) {
+    throw new SimStatesInvalidDefinition(
+      `The ${type} state ${name} carries ${present.join(", ")}, which a ` +
+        `${type} state does not have.`,
+    );
+  }
+}
+
+/**
+ * Check the two fields that say what happens after a state.
+ *
+ * This runs on the state as it was written, before it is read as one of the
+ * state types. Once it has been, `End` is a boolean as far as the compiler is
+ * concerned, and a definition carrying `"true"` would be taken at its word.
+ */
+export function checkSimStatesTransitionFields(
+  name: string,
+  state: Record<string, JSONValue>,
+): void {
+  const end = state["End"];
+
+  if (end !== undefined && typeof end !== "boolean") {
+    throw new SimStatesInvalidDefinition(
+      `The state ${name} has an End that is not a boolean. Only true ends an ` +
+        "execution there.",
+    );
+  }
+
+  const next = state["Next"];
+
+  if (next !== undefined && typeof next !== "string") {
+    throw new SimStatesInvalidDefinition(
+      `The state ${name} has a Next that is not a state name.`,
+    );
+  }
+}

--- a/src/service/stepfunctions/definition/sim-states-state-parse.ts
+++ b/src/service/stepfunctions/definition/sim-states-state-parse.ts
@@ -8,27 +8,20 @@ import {
   SimStatesInvalidDefinition,
   SimStatesUnsimulatedInput,
 } from "../error/sim-step-functions.error.js";
+import { checkSimStatesTaskFields } from "../task/sim-states-task-fields.js";
+import { parseSimStatesTaskResource } from "../task/sim-states-task-resource.js";
 import { checkSimStatesWaitFields } from "../wait/sim-states-wait-fields.js";
+import {
+  checkSimStatesRefusedFields,
+  checkSimStatesTransitionFields,
+} from "./sim-states-state-fields.js";
 import {
   type SimStatesChoiceState,
   type SimStatesState,
+  type SimStatesTaskState,
   simStatesRunnableTypes,
   simStatesStateTypes,
 } from "./sim-states-state.js";
-
-// Real Step Functions gives a Fail state no input or output processing at all,
-// and gives a Succeed state only the two paths.
-const stateFieldsRefused = new Map<string, readonly string[]>([
-  [
-    "Fail",
-    ["InputPath", "OutputPath", "Parameters", "ResultPath", "ResultSelector"],
-  ],
-  ["Succeed", ["Parameters", "ResultPath", "ResultSelector"]],
-  // A Choice state and a Wait state produce no result of their own, so they
-  // carry the two paths and nothing that reshapes a result.
-  ["Choice", ["Parameters", "ResultPath", "ResultSelector"]],
-  ["Wait", ["Parameters", "ResultPath", "ResultSelector"]],
-]);
 
 /**
  * Check one state's type, and the fields that type is allowed.
@@ -61,11 +54,15 @@ export function parseSimStatesState(
     );
   }
 
-  checkRefusedFields(name, type, state);
-  checkTransitionFields(name, state);
+  checkSimStatesRefusedFields(name, type, state);
+  checkSimStatesTransitionFields(name, state);
 
   if (type === "Choice") {
     return readChoiceState(name, state);
+  }
+
+  if (type === "Task") {
+    return readTaskState(name, state);
   }
 
   if (type === "Wait") {
@@ -94,52 +91,19 @@ function readChoiceState(
 }
 
 /**
- * Refuse the fields a state's type does not have.
+ * Read a `Task` state, whose `Resource` is read as the state is.
  *
- * A definition carrying one of these would behave differently here than it
- * does on AWS, where the field is simply not part of the state.
+ * The target becomes the object the state invokes through, so a `Task` state
+ * that runs has already had its `Resource` and its `Parameters` read.
  */
-function checkRefusedFields(
-  name: string,
-  type: string,
-  state: Record<string, JSONValue>,
-): void {
-  const refused = stateFieldsRefused.get(type) ?? [];
-  const present = refused.filter((field) => Object.hasOwn(state, field));
-
-  if (present.length > 0) {
-    throw new SimStatesInvalidDefinition(
-      `The ${type} state ${name} carries ${present.join(", ")}, which a ` +
-        `${type} state does not have.`,
-    );
-  }
-}
-
-/**
- * Check the two fields that say what happens after a state.
- *
- * This runs on the state as it was written, before it is read as one of the
- * state types. Once it has been, `End` is a boolean as far as the compiler is
- * concerned, and a definition carrying `"true"` would be taken at its word.
- */
-function checkTransitionFields(
+function readTaskState(
   name: string,
   state: Record<string, JSONValue>,
-): void {
-  const end = state["End"];
+): SimStatesTaskState {
+  checkSimStatesTaskFields(name, state);
 
-  if (end !== undefined && typeof end !== "boolean") {
-    throw new SimStatesInvalidDefinition(
-      `The state ${name} has an End that is not a boolean. Only true ends an ` +
-        "execution there.",
-    );
-  }
-
-  const next = state["Next"];
-
-  if (next !== undefined && typeof next !== "string") {
-    throw new SimStatesInvalidDefinition(
-      `The state ${name} has a Next that is not a state name.`,
-    );
-  }
+  return {
+    ...(state as unknown as SimStatesTaskState),
+    target: parseSimStatesTaskResource(name, state),
+  };
 }

--- a/src/service/stepfunctions/definition/sim-states-state-refusals.iso.test.ts
+++ b/src/service/stepfunctions/definition/sim-states-state-refusals.iso.test.ts
@@ -39,14 +39,14 @@ describe("Step Functions state refusals", () => {
   it("refuses a state type this simulator does not run yet, by name", () => {
     // Given the state types still to come.
     // When each is read, each names itself and what does run.
-    for (const type of ["Task", "Parallel", "Map"]) {
+    for (const type of ["Parallel", "Map"]) {
       const refusal = refusalFor({
         StartAt: "Only",
         States: { Only: { Type: type, End: true } },
       });
 
       assertStringIncludes(refusal, `is a ${type} state`);
-      assertStringIncludes(refusal, "Pass, Succeed, Fail, Choice, Wait");
+      assertStringIncludes(refusal, "Pass, Succeed, Fail, Task, Choice, Wait");
     }
   });
 

--- a/src/service/stepfunctions/definition/sim-states-state.ts
+++ b/src/service/stepfunctions/definition/sim-states-state.ts
@@ -1,6 +1,7 @@
 import type { JSONValue } from "../../../util/type-guard/json.js";
 import type { SimStatesChoiceRule } from "../choice/sim-states-choice-rule.js";
 import type { SimStatesDataFlowFields } from "../data/sim-states-data-flow.js";
+import type { SimStatesTaskTarget } from "../task/sim-states-task-target.js";
 
 /**
  * Every state type Amazon States Language defines.
@@ -28,6 +29,7 @@ export const simStatesRunnableTypes = [
   "Pass",
   "Succeed",
   "Fail",
+  "Task",
   "Choice",
   "Wait",
 ] as const;
@@ -49,6 +51,19 @@ interface SimStatesCommonState extends SimStatesDataFlowFields {
 export interface SimStatesPassState extends SimStatesCommonState {
   readonly Type: "Pass";
   readonly Result?: JSONValue;
+}
+
+/**
+ * A `Task` state, which does work outside the state machine.
+ *
+ * `Resource` is held as it was written, and `target` is what it named. The
+ * `Resource` is read when the definition is read, so one this simulator cannot
+ * reach is refused there rather than when an execution arrives at the state.
+ */
+export interface SimStatesTaskState extends SimStatesCommonState {
+  readonly Type: "Task";
+  readonly Resource: string;
+  readonly target: SimStatesTaskTarget;
 }
 
 /**
@@ -104,6 +119,7 @@ export interface SimStatesFailState {
 
 export type SimStatesState =
   | SimStatesPassState
+  | SimStatesTaskState
   | SimStatesSucceedState
   | SimStatesFailState
   | SimStatesChoiceState

--- a/src/service/stepfunctions/error/sim-step-functions.error.ts
+++ b/src/service/stepfunctions/error/sim-step-functions.error.ts
@@ -77,6 +77,36 @@ export class SimStatesNoChoiceMatched extends SimStepFunctionsError {
 }
 
 /**
+ * A `Task` state that could not do its work.
+ *
+ * The task itself failed rather than the handler it reached: the function was
+ * not there, the execution role could not be assumed, or the role is not
+ * allowed to invoke it. Real Step Functions names each of these after the
+ * failure a task had, and this is the name a `Retry` or a `Catch` matches.
+ */
+export class SimStatesTaskFailure extends SimStepFunctionsError {
+  public override readonly name = "SimStatesTaskFailure";
+
+  constructor(message: string) {
+    super(message, "States.TaskFailed");
+  }
+}
+
+/**
+ * A handler that raised, reported under its own error type.
+ *
+ * A `Task` state whose `Resource` is a function ARN is talking to the function
+ * rather than to the Lambda API, and the error name it fails with is the one
+ * the handler raised. `NotEligible` thrown in a handler is `NotEligible` here.
+ *
+ * The error type the handler raised under is the states error name, so it is
+ * given where this is raised rather than fixed by the class.
+ */
+export class SimStatesTaskHandlerFailure extends SimStepFunctionsError {
+  public override readonly name = "SimStatesTaskHandlerFailure";
+}
+
+/**
  * A state that could not run on the data it was given.
  *
  * A `Choice` rule comparing a field that is not there, or a `Wait` reading a

--- a/src/service/stepfunctions/execution/sim-states-interpreter.iso.test.ts
+++ b/src/service/stepfunctions/execution/sim-states-interpreter.iso.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "vitest";
 import { BackgroundTasks } from "../../../util/background/background.js";
 import type { SimStatesDefinition } from "../definition/sim-states-definition.js";
 import type { SimStatesState } from "../definition/sim-states-state.js";
+import { SimStatesNoTaskTargets } from "../task/sim-states-no-task-targets.js";
 import { SimStatesExecution } from "./sim-states-execution.js";
 import { SimStatesInterpreter } from "./sim-states-interpreter.js";
 
@@ -23,7 +24,13 @@ async function runDefinition(
     startDate: background.now(),
   });
 
-  await new SimStatesInterpreter({ definition, execution, background }).run();
+  await new SimStatesInterpreter({
+    definition,
+    execution,
+    background,
+    tasks: new SimStatesNoTaskTargets(),
+    roleArn: "arn:aws:iam::123456789012:role/WorkflowRole",
+  }).run();
 
   return execution;
 }

--- a/src/service/stepfunctions/execution/sim-states-interpreter.ts
+++ b/src/service/stepfunctions/execution/sim-states-interpreter.ts
@@ -2,15 +2,15 @@ import type { BackgroundScheduler } from "../../../util/background/background.js
 import type { JSONValue } from "../../../util/type-guard/json.js";
 import type { SimStatesDefinition } from "../definition/sim-states-definition.js";
 import type { SimStatesState } from "../definition/sim-states-state.js";
+import type { SimStatesTaskTargets } from "../task/sim-states-task-invocation.js";
 import type { SimStatesExecution } from "./sim-states-execution.js";
 import {
   simStatesCycleFailure,
-  simStatesFailureFrom,
   simStatesMaximumTransitions,
   simStatesUnknownStateFailure,
 } from "./sim-states-failure.js";
-import { runSimStatesState } from "./sim-states-run-state.js";
 import { SimStatesSettlement } from "./sim-states-settlement.js";
+import { SimStatesStateRunner } from "./sim-states-state-runner.js";
 import type {
   SimStatesMoveOnOutcome,
   SimStatesNextOutcome,
@@ -21,6 +21,16 @@ interface SimStatesInterpreterProperties {
   readonly definition: SimStatesDefinition;
   readonly execution: SimStatesExecution;
   readonly background: BackgroundScheduler;
+
+  /**
+   * Where a `Task` state does its work.
+   */
+  readonly tasks: SimStatesTaskTargets;
+
+  /**
+   * The state machine's execution role, which a task assumes.
+   */
+  readonly roleArn: string;
 }
 
 /**
@@ -38,6 +48,7 @@ export class SimStatesInterpreter {
   readonly #definition: SimStatesDefinition;
   readonly #execution: SimStatesExecution;
   readonly #background: BackgroundScheduler;
+  readonly #runner: SimStatesStateRunner;
   readonly #settlement: SimStatesSettlement;
 
   /**
@@ -49,6 +60,11 @@ export class SimStatesInterpreter {
     this.#definition = properties.definition;
     this.#execution = properties.execution;
     this.#background = properties.background;
+    this.#runner = new SimStatesStateRunner({
+      background: properties.background,
+      tasks: properties.tasks,
+      roleArn: properties.roleArn,
+    });
     this.#settlement = new SimStatesSettlement({
       execution: properties.execution,
       background: properties.background,
@@ -86,7 +102,12 @@ export class SimStatesInterpreter {
       // oxlint-disable-next-line eslint/no-await-in-loop
       await this.#background.sequence();
 
-      const carrying = this.#resolve(this.#step(state, carried, current));
+      const carrying = this.#resolve(
+        // One state at a time, since each one's input is what the state
+        // before it produced.
+        // oxlint-disable-next-line eslint/no-await-in-loop
+        await this.#runner.run(state, carried, current),
+      );
 
       if (carrying === undefined) {
         return;
@@ -154,23 +175,5 @@ export class SimStatesInterpreter {
     });
 
     return undefined;
-  }
-
-  /**
-   * Run one state, reading a failure off whatever it raised.
-   */
-  #step(
-    state: SimStatesState,
-    input: JSONValue,
-    stateName: string,
-  ): SimStatesStateOutcome {
-    try {
-      return runSimStatesState(state, input, {
-        stateName,
-        now: this.#background.now(),
-      });
-    } catch (error) {
-      return simStatesFailureFrom(error);
-    }
   }
 }

--- a/src/service/stepfunctions/execution/sim-states-run-state.ts
+++ b/src/service/stepfunctions/execution/sim-states-run-state.ts
@@ -10,6 +10,7 @@ import type {
   SimStatesSucceedState,
 } from "../definition/sim-states-state.js";
 import { runSimStatesChoice } from "./sim-states-run-choice.js";
+import { runSimStatesTask } from "./sim-states-run-task.js";
 import { runSimStatesWait } from "./sim-states-run-wait.js";
 import type {
   SimStatesStateContext,
@@ -26,12 +27,20 @@ const unnamedFailError = "States.Unknown";
  *
  * A data-flow field raising is left to the caller, which reads the Amazon
  * States Language error name off whatever came out.
+ *
+ * This waits on the work a `Task` state does. Every other state type answers
+ * without waiting for anything. A `Wait` state pauses the walk rather than
+ * blocking it, and answers by saying what it is waiting for.
  */
-export function runSimStatesState(
+export async function runSimStatesState(
   state: SimStatesState,
   input: JSONValue,
   context: SimStatesStateContext,
-): SimStatesStateOutcome {
+): Promise<SimStatesStateOutcome> {
+  if (state.Type === "Task") {
+    return await runSimStatesTask(state, input, context);
+  }
+
   if (state.Type === "Fail") {
     return runFail(state);
   }

--- a/src/service/stepfunctions/execution/sim-states-run-task.ts
+++ b/src/service/stepfunctions/execution/sim-states-run-task.ts
@@ -1,0 +1,38 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import {
+  simStatesEffectiveInput,
+  simStatesEffectiveOutput,
+} from "../data/sim-states-data-flow.js";
+import type { SimStatesTaskState } from "../definition/sim-states-state.js";
+import type {
+  SimStatesStateContext,
+  SimStatesStateOutcome,
+} from "./sim-states-state-outcome.js";
+
+/**
+ * A `Task` state, which does its work outside the state machine.
+ *
+ * The data-flow fields apply around the work the way they do around any other
+ * state. `InputPath` and `Parameters` build what the task is sent, and
+ * `ResultSelector`, `ResultPath` and `OutputPath` shape what comes back.
+ * `ResultPath` reads the state's raw input, so a task can put its result
+ * beside the input it was given.
+ */
+export async function runSimStatesTask(
+  state: SimStatesTaskState,
+  input: JSONValue,
+  context: SimStatesStateContext,
+): Promise<SimStatesStateOutcome> {
+  const result = await context.tasks.invoke({
+    stateName: context.stateName,
+    target: state.target,
+    payload: simStatesEffectiveInput(input, state),
+    roleArn: context.roleArn,
+  });
+
+  const output = simStatesEffectiveOutput(input, result, state);
+
+  return state.Next === undefined
+    ? { kind: "succeed", output }
+    : { kind: "next", output, next: state.Next };
+}

--- a/src/service/stepfunctions/execution/sim-states-state-outcome.ts
+++ b/src/service/stepfunctions/execution/sim-states-state-outcome.ts
@@ -1,4 +1,5 @@
 import type { JSONValue } from "../../../util/type-guard/json.js";
+import type { SimStatesTaskTargets } from "../task/sim-states-task-invocation.js";
 
 /**
  * What a state leaves the execution to do once it has run.
@@ -41,4 +42,14 @@ export type SimStatesStateOutcome =
 export interface SimStatesStateContext {
   readonly stateName: string;
   readonly now: Date;
+
+  /**
+   * Where a `Task` state does its work.
+   */
+  readonly tasks: SimStatesTaskTargets;
+
+  /**
+   * The state machine's execution role, which a task assumes.
+   */
+  readonly roleArn: string;
 }

--- a/src/service/stepfunctions/execution/sim-states-state-runner.ts
+++ b/src/service/stepfunctions/execution/sim-states-state-runner.ts
@@ -1,0 +1,52 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import type { SimStatesState } from "../definition/sim-states-state.js";
+import type { SimStatesTaskTargets } from "../task/sim-states-task-invocation.js";
+import { simStatesFailureFrom } from "./sim-states-failure.js";
+import { runSimStatesState } from "./sim-states-run-state.js";
+import type { SimStatesStateOutcome } from "./sim-states-state-outcome.js";
+
+interface SimStatesStateRunnerProperties {
+  readonly background: BackgroundScheduler;
+  readonly tasks: SimStatesTaskTargets;
+  readonly roleArn: string;
+}
+
+/**
+ * Runs one state of an execution, and never raises.
+ *
+ * What a state knows about the execution it is running in is gathered here,
+ * and so is reading the Amazon States Language error name off whatever a state
+ * raised. Both leave the interpreter with the walk alone.
+ */
+export class SimStatesStateRunner {
+  readonly #background: BackgroundScheduler;
+  readonly #tasks: SimStatesTaskTargets;
+  readonly #roleArn: string;
+
+  constructor(properties: SimStatesStateRunnerProperties) {
+    this.#background = properties.background;
+    this.#tasks = properties.tasks;
+    this.#roleArn = properties.roleArn;
+  }
+
+  /**
+   * Run one state and say what happened, failure included.
+   */
+  async run(
+    state: SimStatesState,
+    input: JSONValue,
+    stateName: string,
+  ): Promise<SimStatesStateOutcome> {
+    try {
+      return await runSimStatesState(state, input, {
+        stateName,
+        now: this.#background.now(),
+        tasks: this.#tasks,
+        roleArn: this.#roleArn,
+      });
+    } catch (error) {
+      return simStatesFailureFrom(error);
+    }
+  }
+}

--- a/src/service/stepfunctions/index.ts
+++ b/src/service/stepfunctions/index.ts
@@ -21,6 +21,7 @@ export type {
   SimStatesChoiceState,
   SimStatesState,
   SimStatesStateType,
+  SimStatesTaskState,
   SimStatesWaitState,
 } from "./definition/sim-states-state.js";
 export { SimStatesChoiceRule } from "./choice/sim-states-choice-rule.js";
@@ -36,6 +37,8 @@ export {
   SimStatesResourceNotFound,
   SimStatesResultPathMatchFailure,
   SimStatesRuntimeFailure,
+  SimStatesTaskFailure,
+  SimStatesTaskHandlerFailure,
   SimStatesUnsimulatedInput,
   SimStepFunctionsError,
 } from "./error/sim-step-functions.error.js";

--- a/src/service/stepfunctions/sim-step-functions-task.iso.test.ts
+++ b/src/service/stepfunctions/sim-step-functions-task.iso.test.ts
@@ -1,0 +1,300 @@
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertNonNullable,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { statesExecutionRoleFactory } from "../../../test/stepfunctions/states-execution-role.factory.js";
+import { statesMachineFactory } from "../../../test/stepfunctions/states-machine.factory.js";
+import { statesTaskFunctionFactory } from "../../../test/stepfunctions/states-task-function.factory.js";
+import { SimFixedClock } from "../../util/clock/sim-clock.js";
+import type { JSONValue } from "../../util/type-guard/json.js";
+import { SimAws } from "../aws/sim-aws.js";
+import type { SimDescribeExecutionCommandOutput } from "./command/execution/execution.command.js";
+
+describe("Simulated Step Functions Task states", () => {
+  /**
+   * Start an execution and read back how it ended.
+   */
+  async function runExecution(
+    simAws: SimAws,
+    stateMachineArn: string,
+    input: JSONValue,
+  ): Promise<SimDescribeExecutionCommandOutput> {
+    const started = await simAws.stepFunctions().startExecution({
+      input: { stateMachineArn, input: JSON.stringify(input) },
+    });
+
+    return await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn: started.executionArn } });
+  }
+
+  it("invokes a function through the Lambda integration", async () => {
+    // Given a function answering what it was sent, and a state machine
+    // invoking it the way CDK's LambdaInvoke writes one.
+    const simAws = new SimAws();
+    await statesTaskFunctionFactory.make(
+      { handler: (event: unknown) => ({ eligible: true, sent: event }) },
+      simAws,
+    );
+    const roleArn = await statesExecutionRoleFactory.make({}, simAws);
+    const stateMachineArn = await statesMachineFactory.make(
+      {
+        roleArn,
+        startAt: "Check",
+        states: {
+          Check: {
+            Type: "Task",
+            Resource: "arn:aws:states:::lambda:invoke",
+            Parameters: {
+              FunctionName: "check-enrolment",
+              "Payload.$": "$",
+            },
+            End: true,
+          },
+        },
+      },
+      simAws,
+    );
+
+    // When an execution runs.
+    const described = await runExecution(simAws, stateMachineArn, {
+      student: "Wei",
+    });
+
+    // Then the handler was sent what Parameters built, and the state answered
+    // with the Invoke response around what the handler answered.
+    assertIdentical(described.status, "SUCCEEDED");
+    assertIdentical(
+      described.output,
+      '{"ExecutedVersion":"$LATEST","Payload":{"eligible":true,' +
+        '"sent":{"student":"Wei"}},"StatusCode":200}',
+    );
+  });
+
+  it("invokes a function through its own ARN, with nothing around the answer", async () => {
+    // Given a state machine whose Resource is the function ARN, which is what
+    // CDK writes for payloadResponseOnly.
+    const simAws = new SimAws();
+    const enrol = await statesTaskFunctionFactory.make(
+      {
+        functionName: "enrol-student",
+        handler: (event: { student: string }) => ({
+          enrolled: event.student,
+        }),
+      },
+      simAws,
+    );
+    const roleArn = await statesExecutionRoleFactory.make({}, simAws);
+    const stateMachineArn = await statesMachineFactory.make(
+      {
+        roleArn,
+        startAt: "Enrol",
+        states: { Enrol: { Type: "Task", Resource: enrol.arn, End: true } },
+      },
+      simAws,
+    );
+
+    // When an execution runs.
+    const described = await runExecution(simAws, stateMachineArn, {
+      student: "Wei",
+    });
+
+    // Then the state's own input reached the handler, and what the handler
+    // answered is the execution's output.
+    assertIdentical(described.status, "SUCCEEDED");
+    assertIdentical(described.output, '{"enrolled":"Wei"}');
+  });
+
+  it("shapes a task result with ResultSelector and ResultPath", async () => {
+    // Given a task narrowing the Invoke response and writing it beside the
+    // input it was given.
+    const simAws = new SimAws();
+    await statesTaskFunctionFactory.make(
+      { handler: () => ({ eligible: true, checkedBy: "admissions" }) },
+      simAws,
+    );
+    const roleArn = await statesExecutionRoleFactory.make({}, simAws);
+    const stateMachineArn = await statesMachineFactory.make(
+      {
+        roleArn,
+        startAt: "Check",
+        states: {
+          Check: {
+            Type: "Task",
+            Resource: "arn:aws:states:::lambda:invoke",
+            Parameters: { FunctionName: "check-enrolment", "Payload.$": "$" },
+            ResultSelector: { "eligible.$": "$.Payload.eligible" },
+            ResultPath: "$.outcome",
+            Next: "Done",
+          },
+          Done: { Type: "Succeed" },
+        },
+      },
+      simAws,
+    );
+
+    // When an execution runs.
+    const described = await runExecution(simAws, stateMachineArn, {
+      student: "Wei",
+    });
+
+    // Then the execution carries its input and the field the selector kept.
+    assertIdentical(
+      described.output,
+      '{"student":"Wei","outcome":{"eligible":true}}',
+    );
+  });
+
+  it("narrows what the next state receives with OutputPath", async () => {
+    // Given a task whose result is written into the input and then narrowed
+    // back down to the field the state after it works on.
+    const simAws = new SimAws();
+    await statesTaskFunctionFactory.make(
+      { handler: () => ({ eligible: true }) },
+      simAws,
+    );
+    const enrol = await statesTaskFunctionFactory.make(
+      {
+        functionName: "enrol-student",
+        handler: (event: unknown) => ({ enrolled: event }),
+      },
+      simAws,
+    );
+    const roleArn = await statesExecutionRoleFactory.make({}, simAws);
+    const stateMachineArn = await statesMachineFactory.make(
+      {
+        roleArn,
+        startAt: "Check",
+        states: {
+          Check: {
+            Type: "Task",
+            Resource: "arn:aws:states:::lambda:invoke",
+            Parameters: { FunctionName: "check-enrolment", "Payload.$": "$" },
+            ResultPath: "$.outcome",
+            OutputPath: "$.outcome.Payload",
+            Next: "Enrol",
+          },
+          Enrol: { Type: "Task", Resource: enrol.arn, End: true },
+        },
+      },
+      simAws,
+    );
+
+    // When an execution runs.
+    const described = await runExecution(simAws, stateMachineArn, {
+      student: "Wei",
+    });
+
+    // Then the second task was handed the narrowed value alone, with the
+    // student the execution started with left behind.
+    assertIdentical(described.output, '{"enrolled":{"eligible":true}}');
+  });
+
+  it("runs a handler on the same clock a later Wait reads", async () => {
+    // Given a handler stamping the time, and a Wait holding the execution
+    // until an hour after the stamp.
+    const simAws = new SimAws({
+      clock: new SimFixedClock(new Date("2026-07-26T09:00:00.000Z")),
+    });
+    const stamp = await statesTaskFunctionFactory.make(
+      {
+        functionName: "stamp-enrolment",
+        handler: () => ({
+          due: new Date(Date.now() + 3_600_000).toISOString(),
+        }),
+      },
+      simAws,
+    );
+    const roleArn = await statesExecutionRoleFactory.make({}, simAws);
+    const stateMachineArn = await statesMachineFactory.make(
+      {
+        roleArn,
+        startAt: "Stamp",
+        states: {
+          Stamp: { Type: "Task", Resource: stamp.arn, Next: "Hold" },
+          Hold: { Type: "Wait", TimestampPath: "$.due", Next: "Done" },
+          Done: { Type: "Succeed" },
+        },
+      },
+      simAws,
+    );
+
+    // When the execution runs and simulated time moves past the stamp.
+    const started = await simAws
+      .stepFunctions()
+      .startExecution({ input: { stateMachineArn } });
+    const waiting = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn: started.executionArn } });
+
+    await simAws.clock().advanceBy({ hours: 2 });
+
+    const settled = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn: started.executionArn } });
+
+    // Then the handler read the simulation's clock rather than the host's, so
+    // the wait it stamped is an hour after the execution started.
+    assertIdentical(waiting.status, "RUNNING");
+    assertIdentical(settled.status, "SUCCEEDED");
+    assertIdentical(
+      settled.stopDate?.toISOString(),
+      "2026-07-26T10:00:00.000Z",
+    );
+    assertNonNullable(settled.output, "The execution has an output");
+  });
+
+  it("visits the states of a workflow that branches on a task result", async () => {
+    // Given the workflow the issue describes: a task, a choice on what it
+    // answered, and a second task.
+    const simAws = new SimAws();
+    await statesTaskFunctionFactory.make(
+      { handler: () => ({ eligible: true }) },
+      simAws,
+    );
+    const enrol = await statesTaskFunctionFactory.make(
+      { functionName: "enrol-student", handler: () => ({ enrolled: true }) },
+      simAws,
+    );
+    const roleArn = await statesExecutionRoleFactory.make({}, simAws);
+    const stateMachineArn = await statesMachineFactory.make(
+      {
+        roleArn,
+        startAt: "Check",
+        states: {
+          Check: {
+            Type: "Task",
+            Resource: "arn:aws:states:::lambda:invoke",
+            Parameters: { FunctionName: "check-enrolment", "Payload.$": "$" },
+            ResultSelector: { "eligible.$": "$.Payload.eligible" },
+            Next: "Eligible",
+          },
+          Eligible: {
+            Type: "Choice",
+            Choices: [
+              { Variable: "$.eligible", BooleanEquals: true, Next: "Enrol" },
+            ],
+            Default: "Decline",
+          },
+          Enrol: { Type: "Task", Resource: enrol.arn, End: true },
+          Decline: { Type: "Fail", Error: "NotEligible" },
+        },
+      },
+      simAws,
+    );
+
+    // When an execution runs.
+    const started = await simAws.stepFunctions().startExecution({
+      input: { stateMachineArn, input: '{"student":"Wei"}' },
+    });
+
+    // Then it took the branch the task's answer chose.
+    assertArrayEquals(
+      simAws.stepFunctions().inspection().visitedStates(started.executionArn),
+      ["Check", "Eligible", "Enrol"],
+    );
+  });
+});

--- a/src/service/stepfunctions/sim-step-functions.ts
+++ b/src/service/stepfunctions/sim-step-functions.ts
@@ -16,11 +16,19 @@ import { SimStatesExecutionStore } from "./execution/sim-states-execution-store.
 import type { SimStateMachine } from "./machine/sim-state-machine.js";
 import { SimStateMachineStore } from "./machine/sim-state-machine-store.js";
 import { SimStepFunctionsSdkCommandRouter } from "./sdk/sim-step-functions-sdk-command-router.js";
+import { SimStatesNoTaskTargets } from "./task/sim-states-no-task-targets.js";
+import type { SimStatesTaskTargets } from "./task/sim-states-task-invocation.js";
 import { SimStepFunctionsInspection } from "./sim-step-functions-inspection.js";
 
 interface SimStepFunctionsProperties {
   readonly accountRegionScope?: SimAwsAccountRegionScope;
   readonly background?: BackgroundScheduler;
+
+  /**
+   * Where a `Task` state does its work. A simulated Step Functions built on
+   * its own has nowhere to invoke, and says so at the first task.
+   */
+  readonly taskTargets?: SimStatesTaskTargets;
 }
 
 /**
@@ -29,7 +37,8 @@ interface SimStepFunctionsProperties {
  *
  * A state machine's definition is checked when it is created, so an execution
  * walks a definition it can rely on. The state types this runs are `Pass`,
- * `Succeed` and `Fail`, and a definition using any other is refused by name.
+ * `Task`, `Choice`, `Wait`, `Succeed` and `Fail`, and a definition using any
+ * other is refused by name.
  *
  * An execution runs on the simulation's background scheduler rather than in
  * the `StartExecution` call. An execution with nothing to wait for settles
@@ -53,6 +62,7 @@ export class SimStepFunctions {
     const {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
       background = new BackgroundTasks(),
+      taskTargets = new SimStatesNoTaskTargets(),
     } = properties;
 
     this.#background = background;
@@ -72,6 +82,7 @@ export class SimStepFunctions {
       executions: this.#executions,
       accountRegionScope,
       background,
+      tasks: taskTargets,
     });
     this.#executionDescribe = new SimStatesExecutionDescribe(this.#executions);
   }

--- a/src/service/stepfunctions/task/sim-aws-states-task-targets.ts
+++ b/src/service/stepfunctions/task/sim-aws-states-task-targets.ts
@@ -1,0 +1,75 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import {
+  assumeSimStatesExecutionRole,
+  simStatesExecutionRoleTarget,
+} from "./sim-states-execution-role.js";
+import { simStatesFunctionLocation } from "./sim-states-function-location.js";
+import { SimStatesTaskFunction } from "./sim-states-task-function.js";
+import type {
+  SimStatesTaskInvocation,
+  SimStatesTaskTargets,
+} from "./sim-states-task-invocation.js";
+
+interface SimAwsStatesTaskTargetsProperties {
+  readonly simAws: SimAws;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * Everywhere the state machines of one simulated AWS instance can invoke.
+ *
+ * The function is looked up when a task runs, never when this is built:
+ * reaching another service while this one is being constructed is a cycle with
+ * no bottom to it.
+ *
+ * A function in another Account or Region is allowed, since a real execution
+ * invokes across both, and it is the function's own Account that decides
+ * whether the execution role may.
+ */
+export class SimAwsStatesTaskTargets implements SimStatesTaskTargets {
+  readonly #simAws: SimAws;
+  readonly #accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimAwsStatesTaskTargetsProperties) {
+    this.#simAws = properties.simAws;
+    this.#accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Assume the state machine's execution role, then invoke the function as
+   * that role.
+   *
+   * The role is assumed in its own Account, and the function is reached in the
+   * function's, which are not necessarily the same one.
+   */
+  async invoke(invocation: SimStatesTaskInvocation): Promise<JSONValue> {
+    const { stateName, target } = invocation;
+    const call = target.call(invocation.payload, stateName);
+    const where = simStatesFunctionLocation(
+      call.functionNameOrArn,
+      this.#accountRegionScope,
+      stateName,
+    );
+    const role = simStatesExecutionRoleTarget(invocation.roleArn, stateName);
+    const iam = this.#simAws
+      .accountRegionScope(role.accountId, where.regionName)
+      .iam();
+
+    const caller = await assumeSimStatesExecutionRole(role, iam);
+    const scope = this.#simAws.accountRegionScope(
+      where.accountId,
+      where.regionName,
+    );
+
+    return await new SimStatesTaskFunction({ scope }).invoke({
+      stateName,
+      target,
+      reference: where.reference,
+      named: call.functionNameOrArn,
+      payload: call.payload,
+      caller,
+    });
+  }
+}

--- a/src/service/stepfunctions/task/sim-states-execution-role.ts
+++ b/src/service/stepfunctions/task/sim-states-execution-role.ts
@@ -1,0 +1,81 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimIam } from "../../iam/sim-iam.js";
+import {
+  assumeSimServiceRole,
+  type SimServiceRoleRefusals,
+  type SimServiceRoleTarget,
+  simServiceRoleTarget,
+} from "../../sts/service-role/sim-service-role.js";
+import { SimStatesTaskFailure } from "../error/sim-step-functions.error.js";
+
+/**
+ * The service principal a state machine's execution role trusts.
+ */
+export const simStatesServicePrincipal = "states.amazonaws.com";
+
+/**
+ * The session name this gives the role an execution assumes.
+ *
+ * Nothing in the simulation reads it apart from the principal ARN a policy
+ * condition could match on.
+ */
+const sessionName = "StatesExecution";
+
+/**
+ * Read the Account and name out of a state machine's `RoleArn`.
+ *
+ * `CreateStateMachine` takes the role ARN as it is written, so a value that is
+ * not a role ARN at all is found here, at the first task that needs it.
+ */
+export function simStatesExecutionRoleTarget(
+  roleArn: string,
+  stateName: string,
+): SimServiceRoleTarget {
+  try {
+    return simServiceRoleTarget(roleArn);
+  } catch {
+    throw new SimStatesTaskFailure(
+      `The state machine's RoleArn is ${roleArn}, which is not an IAM role ` +
+        `ARN, so the Task state ${stateName} had no role to assume.`,
+    );
+  }
+}
+
+/**
+ * What a state machine says when it could not assume its execution role.
+ */
+const refusals: SimServiceRoleRefusals = {
+  missingRole: (target) =>
+    new SimStatesTaskFailure(
+      `${target.roleArn} is not a simulated IAM role, so the execution ` +
+        "could not assume it to do its task.",
+    ),
+  untrustedRole: (target, servicePrincipal) =>
+    new SimStatesTaskFailure(
+      `The trust policy of ${target.roleArn} does not allow ` +
+        `${servicePrincipal} to assume it, so the execution could not do ` +
+        "its task. Add it to the role's AssumeRolePolicyDocument.",
+    ),
+};
+
+/**
+ * Assume a state machine's execution role, and answer with the caller it
+ * makes.
+ *
+ * A task reaches a function as a session of this role, and the role's own
+ * policies decide what it may do. That is the difference from an EventBridge
+ * rule, which reaches a function as a service principal and is admitted by the
+ * function's resource policy.
+ */
+export async function assumeSimStatesExecutionRole(
+  target: SimServiceRoleTarget,
+  iam: SimIam,
+): Promise<SimAwsCaller> {
+  return await assumeSimServiceRole({
+    target,
+    servicePrincipal: simStatesServicePrincipal,
+    sessionName,
+    iam,
+    refusals,
+  });
+}

--- a/src/service/stepfunctions/task/sim-states-function-arn-target.ts
+++ b/src/service/stepfunctions/task/sim-states-function-arn-target.ts
@@ -1,0 +1,55 @@
+import { functionErrorDocument } from "../../lambda/command/invoke/invoke-payload.js";
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { SimStatesTaskHandlerFailure } from "../error/sim-step-functions.error.js";
+import {
+  type SimStatesTaskCall,
+  SimStatesTaskTarget,
+} from "./sim-states-task-target.js";
+
+interface SimStatesFunctionArnTargetProperties {
+  readonly functionArn: string;
+}
+
+/**
+ * A `Task` state whose `Resource` is a function ARN.
+ *
+ * The state is talking to the function rather than to the Lambda API, so what
+ * it sends is its own input and what it gets back is what the handler
+ * answered. CDK's `LambdaInvoke` emits this form for `payloadResponseOnly`.
+ */
+export class SimStatesFunctionArnTarget extends SimStatesTaskTarget {
+  readonly #functionArn: string;
+
+  constructor(properties: SimStatesFunctionArnTargetProperties) {
+    super();
+    this.#functionArn = properties.functionArn;
+  }
+
+  /**
+   * Send the state's own input to the function the `Resource` named.
+   */
+  override call(payload: JSONValue): SimStatesTaskCall {
+    return { functionNameOrArn: this.#functionArn, payload };
+  }
+
+  /**
+   * Answer with what the handler answered, with nothing around it.
+   */
+  override answer(result: JSONValue): JSONValue {
+    return result;
+  }
+
+  /**
+   * A handler raising fails the task under the handler's own error type, which
+   * is the name a `Retry` or a `Catch` on this form matches.
+   */
+  override handlerFailure(error: unknown, stateName: string): Error {
+    const document = functionErrorDocument(error);
+
+    return new SimStatesTaskHandlerFailure(
+      `The function the Task state ${stateName} invoked raised ` +
+        `${document.errorType}: ${document.errorMessage}`,
+      document.errorType,
+    );
+  }
+}

--- a/src/service/stepfunctions/task/sim-states-function-location.ts
+++ b/src/service/stepfunctions/task/sim-states-function-location.ts
@@ -1,0 +1,52 @@
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { AwsRegionName } from "../../aws/sim-aws-region.js";
+import { parseSimLambdaFunctionArn } from "../../lambda/function/sim-lambda-function-arn-parts.js";
+import {
+  type SimLambdaFunctionReference,
+  simLambdaFunctionReferenceOf,
+} from "../../lambda/function/sim-lambda-function-reference.js";
+import { SimStatesTaskFailure } from "../error/sim-step-functions.error.js";
+
+/**
+ * Where a function a `Task` state named is, and what it is called there.
+ */
+export interface SimStatesFunctionLocation {
+  readonly accountId: SimAwsAccountId;
+  readonly regionName: AwsRegionName;
+  readonly reference: SimLambdaFunctionReference;
+}
+
+/**
+ * Work out where the function a task named lives.
+ *
+ * An ARN carries its own Account and Region. A bare name, which the Lambda API
+ * takes as well, is a function of the state machine's own Account and Region.
+ */
+export function simStatesFunctionLocation(
+  functionNameOrArn: string,
+  scope: SimAwsAccountRegionScope,
+  stateName: string,
+): SimStatesFunctionLocation {
+  if (!functionNameOrArn.startsWith("arn:")) {
+    return {
+      ...scope,
+      reference: simLambdaFunctionReferenceOf(functionNameOrArn),
+    };
+  }
+
+  const parts = parseSimLambdaFunctionArn(functionNameOrArn);
+
+  if (parts === undefined) {
+    throw new SimStatesTaskFailure(
+      `The Task state ${stateName} invokes ${functionNameOrArn}, which is ` +
+        "not the ARN of a Lambda function.",
+    );
+  }
+
+  return {
+    accountId: parts.accountId,
+    regionName: parts.regionName,
+    reference: { functionName: parts.functionName, qualifier: parts.qualifier },
+  };
+}

--- a/src/service/stepfunctions/task/sim-states-lambda-invoke-target.ts
+++ b/src/service/stepfunctions/task/sim-states-lambda-invoke-target.ts
@@ -1,0 +1,86 @@
+import { functionErrorDocument } from "../../lambda/command/invoke/invoke-payload.js";
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { isRecord } from "../../../util/type-guard/record.js";
+import {
+  SimStatesRuntimeFailure,
+  SimStatesTaskFailure,
+} from "../error/sim-step-functions.error.js";
+import {
+  type SimStatesTaskCall,
+  SimStatesTaskTarget,
+} from "./sim-states-task-target.js";
+
+/**
+ * The `Resource` of the Lambda integration Step Functions optimises.
+ */
+export const simStatesLambdaInvokeResource = "arn:aws:states:::lambda:invoke";
+
+/**
+ * The two fields of the invocation this integration takes.
+ */
+export const simStatesLambdaInvokeParameters = [
+  "FunctionName",
+  "Payload",
+] as const;
+
+/**
+ * A `Task` state invoking a function through `arn:aws:states:::lambda:invoke`.
+ *
+ * The state is talking to the Lambda API rather than to the function, so its
+ * `Parameters` are an `Invoke` request and its result is an `Invoke` response.
+ * That is the form CDK's `LambdaInvoke` emits by default.
+ */
+export class SimStatesLambdaInvokeTarget extends SimStatesTaskTarget {
+  /**
+   * Read the `Invoke` request the state's `Parameters` built.
+   */
+  override call(payload: JSONValue, stateName: string): SimStatesTaskCall {
+    if (!isRecord(payload)) {
+      throw new SimStatesRuntimeFailure(
+        `The Task state ${stateName} built no Invoke request. Its ` +
+          "Parameters name the function to invoke.",
+      );
+    }
+
+    const functionName = payload["FunctionName"];
+
+    if (typeof functionName !== "string") {
+      throw new SimStatesRuntimeFailure(
+        `The Task state ${stateName} has a FunctionName that is not the ` +
+          "name or ARN of a function.",
+      );
+    }
+
+    return {
+      functionNameOrArn: functionName,
+      // A request carrying no Payload invokes the function with an empty
+      // event, as an Invoke carrying no payload does.
+      payload: payload["Payload"] ?? {},
+    };
+  }
+
+  /**
+   * Answer the way the Lambda API answers an `Invoke`.
+   */
+  override answer(result: JSONValue, executedVersion: string): JSONValue {
+    return {
+      ExecutedVersion: executedVersion,
+      Payload: result,
+      StatusCode: 200,
+    };
+  }
+
+  /**
+   * A handler raising fails the task under the name Step Functions gives a
+   * task that failed, which is what a `Retry` or a `Catch` on this integration
+   * matches.
+   */
+  override handlerFailure(error: unknown, stateName: string): Error {
+    const document = functionErrorDocument(error);
+
+    return new SimStatesTaskFailure(
+      `The function the Task state ${stateName} invoked raised ` +
+        `${document.errorType}: ${document.errorMessage}`,
+    );
+  }
+}

--- a/src/service/stepfunctions/task/sim-states-no-task-targets.ts
+++ b/src/service/stepfunctions/task/sim-states-no-task-targets.ts
@@ -1,0 +1,28 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { SimStatesTaskFailure } from "../error/sim-step-functions.error.js";
+import type {
+  SimStatesTaskInvocation,
+  SimStatesTaskTargets,
+} from "./sim-states-task-invocation.js";
+
+/**
+ * What a simulated Step Functions built on its own can invoke, which is
+ * nothing.
+ *
+ * A Lambda function in another simulated service is only reachable through
+ * SimAws, so a `SimStepFunctions` constructed directly has nowhere to send a
+ * task. Every task fails saying so, rather than quietly succeeding: a state
+ * machine that appears to have invoked a function that was never reachable is
+ * the worst of the possible answers.
+ */
+export class SimStatesNoTaskTargets implements SimStatesTaskTargets {
+  invoke(invocation: SimStatesTaskInvocation): Promise<JSONValue> {
+    return Promise.reject(
+      new SimStatesTaskFailure(
+        `This simulated Step Functions has no functions to invoke, so the ` +
+          `Task state ${invocation.stateName} did nothing. Reach Step ` +
+          "Functions through SimAws for a state machine that invokes one.",
+      ),
+    );
+  }
+}

--- a/src/service/stepfunctions/task/sim-states-task-answers.iso.test.ts
+++ b/src/service/stepfunctions/task/sim-states-task-answers.iso.test.ts
@@ -1,0 +1,105 @@
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { statesExecutionRoleFactory } from "../../../../test/stepfunctions/states-execution-role.factory.js";
+import { statesMachineFactory } from "../../../../test/stepfunctions/states-machine.factory.js";
+import { statesTaskFunctionFactory } from "../../../../test/stepfunctions/states-task-function.factory.js";
+import type { JSONObject } from "../../../util/type-guard/json.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimDescribeExecutionCommandOutput } from "../command/execution/execution.command.js";
+import { SimStatesLambdaInvokeTarget } from "./sim-states-lambda-invoke-target.js";
+
+describe("What a Task state answers with", () => {
+  /**
+   * Run a state machine of one task and read back how the execution ended.
+   */
+  async function runTask(
+    simAws: SimAws,
+    roleArn: string,
+    task: JSONObject,
+  ): Promise<SimDescribeExecutionCommandOutput> {
+    const stateMachineArn = await statesMachineFactory.make(
+      { roleArn, startAt: "Check", states: { Check: task } },
+      simAws,
+    );
+    const started = await simAws
+      .stepFunctions()
+      .startExecution({ input: { stateMachineArn } });
+
+    return await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn: started.executionArn } });
+  }
+
+  it("carries null where a handler answers with nothing", async () => {
+    // Given a function whose handler returns nothing, as one doing its work
+    // for the side effect does.
+    const simAws = new SimAws();
+    const record = await statesTaskFunctionFactory.make(
+      { functionName: "record-enrolment", handler: () => undefined },
+      simAws,
+    );
+    const roleArn = await statesExecutionRoleFactory.make({}, simAws);
+
+    // When an execution invokes it through its ARN.
+    const described = await runTask(simAws, roleArn, {
+      Type: "Task",
+      Resource: record.arn,
+      End: true,
+    });
+
+    // Then the execution carries the null a real invocation would answer.
+    assertIdentical(described.status, "SUCCEEDED");
+    assertIdentical(described.output, "null");
+  });
+
+  it("fails a task whose handler answers with something that is not JSON", async () => {
+    // Given a handler answering with an object that refers to itself.
+    const simAws = new SimAws();
+    const check = await statesTaskFunctionFactory.make(
+      {
+        handler: () => {
+          const answer: Record<string, unknown> = {};
+          answer["itself"] = answer;
+
+          return answer;
+        },
+      },
+      simAws,
+    );
+    const roleArn = await statesExecutionRoleFactory.make({}, simAws);
+
+    // When an execution reaches the task.
+    const described = await runTask(simAws, roleArn, {
+      Type: "Task",
+      Resource: check.arn,
+      End: true,
+    });
+
+    // Then the task failed rather than the walk raising.
+    assertIdentical(described.error, "States.TaskFailed");
+    assertStringIncludes(described.cause ?? "", "not JSON");
+  });
+
+  it("refuses an Invoke request that names no function at all", () => {
+    // Given requests the definition parser would never have let through, to
+    // reach the integration's own guards.
+    const target = new SimStatesLambdaInvokeTarget();
+
+    // When the state's Parameters built something that is not a request.
+    // Then it says what an invocation needs.
+    assertStringIncludes(
+      assertThrowsError(() => target.call("check-enrolment", "Check")).message,
+      "built no Invoke request",
+    );
+    assertStringIncludes(
+      assertThrowsError(() => target.call({ FunctionName: 3 }, "Check"))
+        .message,
+      "not the name or ARN of a function",
+    );
+  });
+});

--- a/src/service/stepfunctions/task/sim-states-task-failures.iso.test.ts
+++ b/src/service/stepfunctions/task/sim-states-task-failures.iso.test.ts
@@ -1,0 +1,209 @@
+import { assertIdentical, assertStringIncludes } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { statesExecutionRoleFactory } from "../../../../test/stepfunctions/states-execution-role.factory.js";
+import { statesMachineFactory } from "../../../../test/stepfunctions/states-machine.factory.js";
+import { statesTaskFunctionFactory } from "../../../../test/stepfunctions/states-task-function.factory.js";
+import type { JSONObject } from "../../../util/type-guard/json.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimDescribeExecutionCommandOutput } from "../command/execution/execution.command.js";
+
+describe("Simulated Step Functions Task failures", () => {
+  /**
+   * An error of a handler's own, as a workflow's own failures are written.
+   */
+  class NotEligible extends Error {
+    public override readonly name = "NotEligible";
+  }
+
+  /**
+   * Run a state machine of one task and read back how the execution ended.
+   */
+  async function runTask(
+    simAws: SimAws,
+    roleArn: string,
+    task: JSONObject,
+  ): Promise<SimDescribeExecutionCommandOutput> {
+    const stateMachineArn = await statesMachineFactory.make(
+      { roleArn, startAt: "Check", states: { Check: task } },
+      simAws,
+    );
+    const started = await simAws
+      .stepFunctions()
+      .startExecution({ input: { stateMachineArn, input: '{"term":3}' } });
+
+    return await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn: started.executionArn } });
+  }
+
+  /**
+   * The task the tests below run, which invokes a function that is there.
+   */
+  const invokeCheck = {
+    Type: "Task",
+    Resource: "arn:aws:states:::lambda:invoke",
+    Parameters: { FunctionName: "check-enrolment", "Payload.$": "$" },
+    End: true,
+  };
+
+  it("fails a task whose role may not invoke the function", async () => {
+    // Given a role that may read a bucket and nothing else.
+    const simAws = new SimAws();
+    await statesTaskFunctionFactory.make({}, simAws);
+    const roleArn = await statesExecutionRoleFactory.make(
+      {
+        statements: [
+          { Effect: "Allow", Action: "s3:GetObject", Resource: "*" },
+        ],
+      },
+      simAws,
+    );
+
+    // When an execution reaches the task.
+    const described = await runTask(simAws, roleArn, invokeCheck);
+
+    // Then the task failed, naming the action the role is missing.
+    assertIdentical(described.status, "FAILED");
+    assertIdentical(described.error, "States.TaskFailed");
+    assertStringIncludes(described.cause ?? "", "lambda:InvokeFunction");
+  });
+
+  it("fails a task whose role does not trust Step Functions", async () => {
+    // Given a role a Lambda function would assume rather than an execution.
+    const simAws = new SimAws();
+    await statesTaskFunctionFactory.make({}, simAws);
+    const roleArn = await statesExecutionRoleFactory.make(
+      { trusts: "lambda.amazonaws.com" },
+      simAws,
+    );
+
+    // When an execution reaches the task.
+    const described = await runTask(simAws, roleArn, invokeCheck);
+
+    // Then the execution could not assume the role at all.
+    assertIdentical(described.error, "States.TaskFailed");
+    assertStringIncludes(described.cause ?? "", "AssumeRolePolicyDocument");
+  });
+
+  it("fails a task whose role is not there", async () => {
+    // Given a state machine naming a role nothing created.
+    const simAws = new SimAws();
+    await statesTaskFunctionFactory.make({}, simAws);
+
+    // When an execution reaches the task.
+    const described = await runTask(
+      simAws,
+      "arn:aws:iam::123456789012:role/AbsentRole",
+      invokeCheck,
+    );
+
+    // Then the task failed, naming the role.
+    assertIdentical(described.error, "States.TaskFailed");
+    assertStringIncludes(described.cause ?? "", "AbsentRole");
+  });
+
+  it("fails a task naming a function that is not there", async () => {
+    // Given a state machine invoking a function nothing created.
+    const simAws = new SimAws();
+    const roleArn = await statesExecutionRoleFactory.make({}, simAws);
+
+    // When an execution reaches the task.
+    const described = await runTask(simAws, roleArn, invokeCheck);
+
+    // Then the task failed, naming what it was asked to invoke.
+    assertIdentical(described.error, "States.TaskFailed");
+    assertStringIncludes(described.cause ?? "", "check-enrolment");
+  });
+
+  it("reports a handler that raises as a task failure", async () => {
+    // Given a function that raises, invoked through the Lambda integration.
+    const simAws = new SimAws();
+    await statesTaskFunctionFactory.make(
+      {
+        handler: () => {
+          throw new Error("the enrolment service is down");
+        },
+      },
+      simAws,
+    );
+    const roleArn = await statesExecutionRoleFactory.make({}, simAws);
+
+    // When an execution reaches the task.
+    const described = await runTask(simAws, roleArn, invokeCheck);
+
+    // Then the execution failed under the name Step Functions gives a task
+    // that failed, carrying what the handler said.
+    assertIdentical(described.error, "States.TaskFailed");
+    assertStringIncludes(
+      described.cause ?? "",
+      "the enrolment service is down",
+    );
+  });
+
+  it("reports a handler raising through a function ARN under its own error type", async () => {
+    // Given a function raising an error of its own, invoked through its ARN.
+    const simAws = new SimAws();
+    const check = await statesTaskFunctionFactory.make(
+      {
+        handler: () => {
+          throw new NotEligible("no place left");
+        },
+      },
+      simAws,
+    );
+    const roleArn = await statesExecutionRoleFactory.make({}, simAws);
+
+    // When an execution reaches the task.
+    const described = await runTask(simAws, roleArn, {
+      Type: "Task",
+      Resource: check.arn,
+      End: true,
+    });
+
+    // Then the execution failed under the handler's own error type, which is
+    // the name a Retry or a Catch on this form matches.
+    assertIdentical(described.error, "NotEligible");
+    assertStringIncludes(described.cause ?? "", "no place left");
+  });
+
+  it("records a task failing after a Wait rather than raising from the clock", async () => {
+    // Given a workflow that waits and then invokes a function that raises.
+    const simAws = new SimAws();
+    await statesTaskFunctionFactory.make(
+      {
+        handler: () => {
+          throw new Error("the enrolment service is down");
+        },
+      },
+      simAws,
+    );
+    const roleArn = await statesExecutionRoleFactory.make({}, simAws);
+    const stateMachineArn = await statesMachineFactory.make(
+      {
+        roleArn,
+        startAt: "Hold",
+        states: {
+          Hold: { Type: "Wait", Seconds: 300, Next: "Check" },
+          Check: invokeCheck,
+        },
+      },
+      simAws,
+    );
+    const started = await simAws
+      .stepFunctions()
+      .startExecution({ input: { stateMachineArn } });
+
+    // When simulated time moves past the wait.
+    await simAws.clock().advanceBy({ minutes: 6 });
+
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn: started.executionArn } });
+
+    // Then advancing the clock returned as it would for an execution that
+    // succeeded, and the failure is read off the execution.
+    assertIdentical(described.status, "FAILED");
+    assertIdentical(described.error, "States.TaskFailed");
+  });
+});

--- a/src/service/stepfunctions/task/sim-states-task-fields.ts
+++ b/src/service/stepfunctions/task/sim-states-task-fields.ts
@@ -1,0 +1,39 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { SimStatesUnsimulatedInput } from "../error/sim-step-functions.error.js";
+
+/**
+ * The fields of a `Task` state this simulator has no implementation for.
+ */
+export const simStatesTaskFieldsUnsimulated = [
+  "Retry",
+  "Catch",
+  "TimeoutSeconds",
+  "TimeoutSecondsPath",
+  "HeartbeatSeconds",
+  "HeartbeatSecondsPath",
+  "Credentials",
+] as const;
+
+/**
+ * Refuse the fields of a `Task` state this simulator does not run.
+ *
+ * A definition carrying one of them would behave differently here than it does
+ * on AWS. A task that failed would end the execution rather than being retried,
+ * and a task that ran long would answer rather than time out.
+ */
+export function checkSimStatesTaskFields(
+  stateName: string,
+  state: Record<string, JSONValue>,
+): void {
+  const present = simStatesTaskFieldsUnsimulated.filter((field) =>
+    Object.hasOwn(state, field),
+  );
+
+  if (present.length > 0) {
+    throw new SimStatesUnsimulatedInput(
+      `The Task state ${stateName} carries ${present.join(", ")}, which this ` +
+        "simulator does not run yet. A task that fails ends the execution, " +
+        "and a task that runs long runs to whatever its handler answers.",
+    );
+  }
+}

--- a/src/service/stepfunctions/task/sim-states-task-function.ts
+++ b/src/service/stepfunctions/task/sim-states-task-function.ts
@@ -1,0 +1,149 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountRegionContainer } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimLambdaFunction } from "../../lambda/function/sim-lambda-function.js";
+import type { SimLambdaFunctionReference } from "../../lambda/function/sim-lambda-function-reference.js";
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { SimStatesTaskFailure } from "../error/sim-step-functions.error.js";
+import type { SimStatesTaskTarget } from "./sim-states-task-target.js";
+
+/**
+ * The action an execution needs to invoke a function.
+ */
+const invokeAction = "lambda:InvokeFunction";
+
+interface SimStatesTaskFunctionProperties {
+  readonly scope: SimAwsAccountRegionContainer;
+}
+
+/**
+ * One `Task` state's invocation of a function.
+ */
+export interface SimStatesTaskFunctionRequest {
+  readonly stateName: string;
+  readonly target: SimStatesTaskTarget;
+  readonly reference: SimLambdaFunctionReference;
+
+  /**
+   * What the state named the function, which is what its messages say.
+   */
+  readonly named: string;
+
+  readonly payload: JSONValue;
+  readonly caller: SimAwsCaller;
+}
+
+/**
+ * A Lambda function a `Task` state invokes, in the Account and Region the
+ * function is in.
+ *
+ * The function is resolved on every task rather than when the state machine
+ * was created, so an alias moved to another version moves what runs and a
+ * permission taken away stops the task.
+ */
+export class SimStatesTaskFunction {
+  readonly #scope: SimAwsAccountRegionContainer;
+
+  constructor(properties: SimStatesTaskFunctionProperties) {
+    this.#scope = properties.scope;
+  }
+
+  /**
+   * Invoke the function as the execution role, if the role may.
+   */
+  async invoke(request: SimStatesTaskFunctionRequest): Promise<JSONValue> {
+    const found = this.#scope
+      .lambda()
+      .getSimFunctionTarget(
+        request.reference.functionName,
+        request.reference.qualifier,
+      );
+
+    if (found === undefined) {
+      throw new SimStatesTaskFailure(
+        `The Task state ${request.stateName} invokes ${request.named}, ` +
+          "which is not a simulated Lambda function.",
+      );
+    }
+
+    this.authorize(request, found.resource.arn);
+
+    const result = await this.run(request, found.simFunction);
+
+    return request.target.answer(result, found.simFunction.version);
+  }
+
+  /**
+   * Ask the function's own Account whether the execution role may invoke it.
+   *
+   * The function's resource policy is not consulted, which is the difference
+   * from an EventBridge rule target. The task arrives as an assumed role
+   * rather than as a service principal, and a role in the same Account needs
+   * only its own identity policy.
+   */
+  private authorize(
+    request: SimStatesTaskFunctionRequest,
+    functionArn: string,
+  ): void {
+    const decision = this.#scope.iam().authorize({
+      action: invokeAction,
+      resource: functionArn,
+      caller: request.caller,
+    });
+
+    if (decision.isDenied) {
+      throw new SimStatesTaskFailure(
+        `The Task state ${request.stateName} is not allowed to ` +
+          `${invokeAction} on ${functionArn}. Grant it in a policy on the ` +
+          "state machine's execution role.",
+      );
+    }
+  }
+
+  /**
+   * Run the handler, and read a task failure off it raising.
+   *
+   * Invoked directly rather than through an `Invoke` command, because a
+   * handler failure has to reach the task rather than being answered as an
+   * error payload the state would take for a result.
+   */
+  private async run(
+    request: SimStatesTaskFunctionRequest,
+    simFunction: SimLambdaFunction,
+  ): Promise<JSONValue> {
+    let result: unknown;
+
+    try {
+      result = await simFunction.invoke(request.payload);
+    } catch (error) {
+      throw request.target.handlerFailure(error, request.stateName);
+    }
+
+    return readTaskResult(result, request.stateName);
+  }
+}
+
+/**
+ * Read what the handler answered as the JSON the execution carries on with.
+ *
+ * The answer crosses the same JSON serialisation a real invocation's payload
+ * does, so a `Date` a handler returns reaches the next state as the string it
+ * would there, and a handler answering with nothing answers `null`.
+ */
+function readTaskResult(result: unknown, stateName: string): JSONValue {
+  if (result === undefined) {
+    return null;
+  }
+
+  let serialised: string;
+
+  try {
+    serialised = JSON.stringify(result);
+  } catch {
+    throw new SimStatesTaskFailure(
+      `The function the Task state ${stateName} invoked answered with ` +
+        "something that is not JSON.",
+    );
+  }
+
+  return JSON.parse(serialised) as JSONValue;
+}

--- a/src/service/stepfunctions/task/sim-states-task-invocation.ts
+++ b/src/service/stepfunctions/task/sim-states-task-invocation.ts
@@ -1,0 +1,32 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import type { SimStatesTaskTarget } from "./sim-states-task-target.js";
+
+/**
+ * One `Task` state's invocation, as the state leaves it.
+ */
+export interface SimStatesTaskInvocation {
+  readonly stateName: string;
+  readonly target: SimStatesTaskTarget;
+
+  /**
+   * What the state's `InputPath` and `Parameters` produced.
+   */
+  readonly payload: JSONValue;
+
+  /**
+   * The state machine's execution role, which the execution assumes to do the
+   * work.
+   */
+  readonly roleArn: string;
+}
+
+/**
+ * Where a `Task` state's work is done.
+ *
+ * A state machine reaches a function through this rather than holding one, so
+ * a `SimStepFunctions` built on its own has somewhere to say that there is
+ * nothing to reach.
+ */
+export interface SimStatesTaskTargets {
+  invoke(invocation: SimStatesTaskInvocation): Promise<JSONValue>;
+}

--- a/src/service/stepfunctions/task/sim-states-task-refusals.iso.test.ts
+++ b/src/service/stepfunctions/task/sim-states-task-refusals.iso.test.ts
@@ -1,0 +1,131 @@
+import { assertStringIncludes, assertThrowsError } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { parseSimStatesDefinition } from "../definition/sim-states-definition-parse.js";
+
+describe("Step Functions Task state refusals", () => {
+  /**
+   * Read a definition of one Task state, and answer with why it was refused.
+   */
+  function refusalForTask(task: object): string {
+    return assertThrowsError(() =>
+      parseSimStatesDefinition(
+        JSON.stringify({ StartAt: "Check", States: { Check: task } }),
+      ),
+    ).message;
+  }
+
+  it("refuses a Resource that is not a Lambda invoke, naming it", () => {
+    // Given the service integrations this simulator has no implementation for.
+    // When each is read, each names what the definition asked for.
+    for (const resource of [
+      "arn:aws:states:::sns:publish",
+      "arn:aws:states:::dynamodb:putItem",
+      "arn:aws:states:::lambda:invoke.waitForTaskToken",
+      "arn:aws:sqs:eu-west-2:123456789012:enrolments",
+    ]) {
+      const refusal = refusalForTask({
+        Type: "Task",
+        Resource: resource,
+        End: true,
+      });
+
+      assertStringIncludes(refusal, resource);
+      assertStringIncludes(refusal, "arn:aws:states:::lambda:invoke");
+    }
+  });
+
+  it("refuses a Task state that says nothing about what it does", () => {
+    // Given a Task state with no Resource.
+    // When it is read, it is refused.
+    assertStringIncludes(
+      refusalForTask({ Type: "Task", End: true }),
+      "has no Resource",
+    );
+  });
+
+  it("refuses the Task fields this simulator does not run, by name", () => {
+    // Given the fields that would change what a task does.
+    // When each is read, each is named.
+    assertStringIncludes(
+      refusalForTask({
+        Type: "Task",
+        Resource: "arn:aws:states:::lambda:invoke",
+        Parameters: { FunctionName: "check-enrolment" },
+        Retry: [{ ErrorEquals: ["States.TaskFailed"], MaxAttempts: 2 }],
+        End: true,
+      }),
+      "carries Retry",
+    );
+    assertStringIncludes(
+      refusalForTask({
+        Type: "Task",
+        Resource: "arn:aws:states:::lambda:invoke",
+        Parameters: { FunctionName: "check-enrolment" },
+        TimeoutSeconds: 30,
+        End: true,
+      }),
+      "carries TimeoutSeconds",
+    );
+  });
+
+  it("refuses an invocation that names no function to invoke", () => {
+    // Given the Lambda integration without the Parameters it takes.
+    // When each is read, each says what is missing.
+    assertStringIncludes(
+      refusalForTask({
+        Type: "Task",
+        Resource: "arn:aws:states:::lambda:invoke",
+        End: true,
+      }),
+      "carries no Parameters",
+    );
+    assertStringIncludes(
+      refusalForTask({
+        Type: "Task",
+        Resource: "arn:aws:states:::lambda:invoke",
+        Parameters: { "Payload.$": "$" },
+        End: true,
+      }),
+      "carry no FunctionName",
+    );
+  });
+
+  it("refuses the fields of an Invoke this simulator does not make", () => {
+    // Given an invocation asking for something other than a plain call.
+    // When it is read, it names the field.
+    assertStringIncludes(
+      refusalForTask({
+        Type: "Task",
+        Resource: "arn:aws:states:::lambda:invoke",
+        Parameters: {
+          FunctionName: "check-enrolment",
+          InvocationType: "Event",
+        },
+        End: true,
+      }),
+      "carry InvocationType",
+    );
+  });
+
+  it("reads a function named by a path as naming the function", () => {
+    // Given an invocation reading its function name out of the input, which is
+    // the same field written the other way.
+    const definition = parseSimStatesDefinition(
+      JSON.stringify({
+        StartAt: "Check",
+        States: {
+          Check: {
+            Type: "Task",
+            Resource: "arn:aws:states:::lambda:invoke",
+            Parameters: { "FunctionName.$": "$.checker", "Payload.$": "$" },
+            End: true,
+          },
+        },
+      }),
+    );
+
+    // When the definition is read, the state is one this simulator runs.
+    assertStringIncludes(definition.StartAt, "Check");
+  });
+});

--- a/src/service/stepfunctions/task/sim-states-task-resource.ts
+++ b/src/service/stepfunctions/task/sim-states-task-resource.ts
@@ -1,0 +1,102 @@
+import { parseSimLambdaFunctionArn } from "../../lambda/function/sim-lambda-function-arn-parts.js";
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { isRecord } from "../../../util/type-guard/record.js";
+import {
+  SimStatesInvalidDefinition,
+  SimStatesUnsimulatedInput,
+} from "../error/sim-step-functions.error.js";
+import { SimStatesFunctionArnTarget } from "./sim-states-function-arn-target.js";
+import {
+  SimStatesLambdaInvokeTarget,
+  simStatesLambdaInvokeParameters,
+  simStatesLambdaInvokeResource,
+} from "./sim-states-lambda-invoke-target.js";
+import type { SimStatesTaskTarget } from "./sim-states-task-target.js";
+
+/**
+ * Read what a `Task` state's `Resource` names.
+ *
+ * This runs when the state machine is created, so a `Resource` this simulator
+ * cannot reach is refused there rather than when an execution arrives at the
+ * state. The service integrations beyond Lambda are refused here by name, and
+ * are where each of them will be added.
+ */
+export function parseSimStatesTaskResource(
+  stateName: string,
+  state: Record<string, JSONValue>,
+): SimStatesTaskTarget {
+  const resource = state["Resource"];
+
+  if (typeof resource !== "string" || resource === "") {
+    throw new SimStatesInvalidDefinition(
+      `The Task state ${stateName} has no Resource saying what it does.`,
+    );
+  }
+
+  if (resource === simStatesLambdaInvokeResource) {
+    checkInvokeParameters(stateName, state["Parameters"]);
+
+    return new SimStatesLambdaInvokeTarget();
+  }
+
+  if (parseSimLambdaFunctionArn(resource) !== undefined) {
+    return new SimStatesFunctionArnTarget({ functionArn: resource });
+  }
+
+  throw new SimStatesUnsimulatedInput(
+    `The Task state ${stateName} has a Resource of ${resource}, which this ` +
+      "simulator does not run. A Task state invokes a simulated Lambda " +
+      `function, through ${simStatesLambdaInvokeResource} or through a ` +
+      "function ARN.",
+  );
+}
+
+/**
+ * Check the `Invoke` request the state's `Parameters` build.
+ *
+ * The field naming the function is required, as it is on real Step Functions,
+ * and the fields of an `Invoke` this does not make are refused by name.
+ */
+function checkInvokeParameters(
+  stateName: string,
+  parameters: JSONValue | undefined,
+): void {
+  if (!isRecord(parameters)) {
+    throw new SimStatesInvalidDefinition(
+      `The Task state ${stateName} invokes a function and carries no ` +
+        "Parameters. A Parameters naming the function to invoke is what " +
+        `${simStatesLambdaInvokeResource} takes.`,
+    );
+  }
+
+  const fields = Object.keys(parameters).map(fieldName);
+
+  if (!fields.includes("FunctionName")) {
+    throw new SimStatesInvalidDefinition(
+      `The Parameters of the Task state ${stateName} carry no FunctionName ` +
+        "naming the function to invoke.",
+    );
+  }
+
+  const beyond = fields.filter(
+    (field) => !simStatesLambdaInvokeParameters.includes(field as never),
+  );
+
+  if (beyond.length > 0) {
+    throw new SimStatesUnsimulatedInput(
+      `The Parameters of the Task state ${stateName} carry ` +
+        `${beyond.join(", ")}. This simulator invokes a function with ` +
+        `${simStatesLambdaInvokeParameters.join(" and ")}.`,
+    );
+  }
+}
+
+/**
+ * The field one Payload Template key stands for.
+ *
+ * A key ending in `.$` holds a path to read rather than a value, and both
+ * spellings name the same field of the request.
+ */
+function fieldName(key: string): string {
+  return key.endsWith(".$") ? key.slice(0, -2) : key;
+}

--- a/src/service/stepfunctions/task/sim-states-task-target.ts
+++ b/src/service/stepfunctions/task/sim-states-task-target.ts
@@ -1,0 +1,40 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+
+/**
+ * The function one `Task` state invocation names, and what it sends.
+ */
+export interface SimStatesTaskCall {
+  readonly functionNameOrArn: string;
+  readonly payload: JSONValue;
+}
+
+/**
+ * What a `Task` state's `Resource` named.
+ *
+ * The two forms a `Task` state invokes a function through differ in three
+ * places, and this is each of them: which function the state is talking to,
+ * what the state gets back, and what a handler raising is called. Everything
+ * between those, from assuming the execution role to running the handler, is
+ * the same for both.
+ */
+export abstract class SimStatesTaskTarget {
+  /**
+   * The function to invoke and the payload to send it, read from what the
+   * state's data-flow fields produced.
+   */
+  abstract call(payload: JSONValue, stateName: string): SimStatesTaskCall;
+
+  /**
+   * The result the state produces from what the handler answered.
+   */
+  abstract answer(result: JSONValue, executedVersion: string): JSONValue;
+
+  /**
+   * What a handler raising fails the task with.
+   *
+   * The Amazon States Language error name is read here rather than where the
+   * failure is recorded, because the two forms report a handler error
+   * differently and `Retry` and `Catch` match on exactly that name.
+   */
+  abstract handlerFailure(error: unknown, stateName: string): Error;
+}

--- a/src/service/stepfunctions/task/sim-states-task-targets.iso.test.ts
+++ b/src/service/stepfunctions/task/sim-states-task-targets.iso.test.ts
@@ -1,0 +1,179 @@
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simLambdaAliasedFunction } from "../../../../test/lambda/alias-fixture.js";
+import { statesExecutionRoleFactory } from "../../../../test/stepfunctions/states-execution-role.factory.js";
+import { statesMachineFactory } from "../../../../test/stepfunctions/states-machine.factory.js";
+import { statesTaskFunctionFactory } from "../../../../test/stepfunctions/states-task-function.factory.js";
+import type { JSONObject } from "../../../util/type-guard/json.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimDescribeExecutionCommandOutput } from "../command/execution/execution.command.js";
+import { SimStepFunctions } from "../sim-step-functions.js";
+
+describe("Where a Task state invokes", () => {
+  /**
+   * Run a state machine of one task and read back how the execution ended.
+   */
+  async function runTask(
+    simAws: SimAws,
+    roleArn: string,
+    task: JSONObject,
+    input = '{"term":3}',
+  ): Promise<SimDescribeExecutionCommandOutput> {
+    const stateMachineArn = await statesMachineFactory.make(
+      { roleArn, startAt: "Check", states: { Check: task } },
+      simAws,
+    );
+    const started = await simAws
+      .stepFunctions()
+      .startExecution({ input: { stateMachineArn, input } });
+
+    return await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn: started.executionArn } });
+  }
+
+  it("invokes a function in another Region of the same Account", async () => {
+    // Given a function in a Region the state machine is not in.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    const check = await statesTaskFunctionFactory.make(
+      { handler: () => ({ eligible: true }), regionName: "us-east-1" },
+      simAws,
+    );
+    const roleArn = await statesExecutionRoleFactory.make({}, simAws);
+
+    // When an execution invokes it by ARN.
+    const described = await runTask(simAws, roleArn, {
+      Type: "Task",
+      Resource: check.arn,
+      End: true,
+    });
+
+    // Then the ARN found the function in its own Region.
+    assertIdentical(described.status, "SUCCEEDED");
+    assertIdentical(described.output, '{"eligible":true}');
+  });
+
+  it("reads a function named by a path as the function to invoke", async () => {
+    // Given an invocation reading which function to call out of its input.
+    const simAws = new SimAws();
+    await statesTaskFunctionFactory.make(
+      { handler: () => ({ eligible: true }) },
+      simAws,
+    );
+    const roleArn = await statesExecutionRoleFactory.make({}, simAws);
+
+    // When an execution carries the name.
+    const described = await runTask(
+      simAws,
+      roleArn,
+      {
+        Type: "Task",
+        Resource: "arn:aws:states:::lambda:invoke",
+        Parameters: { "FunctionName.$": "$.checker" },
+        End: true,
+      },
+      '{"checker":"check-enrolment"}',
+    );
+
+    // Then the function the input named is the one that ran.
+    assertIdentical(described.status, "SUCCEEDED");
+    assertStringIncludes(described.output ?? "", '"eligible":true');
+  });
+
+  it("fails a task whose FunctionName is not a function", async () => {
+    // Given an invocation naming a queue.
+    const simAws = new SimAws();
+    const roleArn = await statesExecutionRoleFactory.make({}, simAws);
+
+    // When an execution reaches the task.
+    const described = await runTask(simAws, roleArn, {
+      Type: "Task",
+      Resource: "arn:aws:states:::lambda:invoke",
+      Parameters: {
+        FunctionName: "arn:aws:sqs:eu-west-2:123456789012:enrolments",
+      },
+      End: true,
+    });
+
+    // Then the task failed rather than looking for a function of that name.
+    assertIdentical(described.error, "States.TaskFailed");
+    assertStringIncludes(described.cause ?? "", "not the ARN of a Lambda");
+  });
+
+  it("fails a task whose state machine has no role to assume", async () => {
+    // Given a state machine created with something that is not a role ARN.
+    const simAws = new SimAws();
+    await statesTaskFunctionFactory.make({}, simAws);
+
+    // When an execution reaches the task.
+    const described = await runTask(simAws, "WorkflowRole", {
+      Type: "Task",
+      Resource: "arn:aws:states:::lambda:invoke",
+      Parameters: { FunctionName: "check-enrolment" },
+      End: true,
+    });
+
+    // Then the task failed, saying what the RoleArn was.
+    assertIdentical(described.error, "States.TaskFailed");
+    assertStringIncludes(described.cause ?? "", "not an IAM role ARN");
+  });
+
+  it("fails a task on a simulated Step Functions built on its own", async () => {
+    // Given a service with no simulation around it to reach a function in.
+    const stepFunctions = new SimStepFunctions();
+    const created = await stepFunctions.createStateMachine({
+      input: {
+        name: "Enrolment",
+        roleArn: "arn:aws:iam::123456789012:role/WorkflowRole",
+        definition: JSON.stringify({
+          StartAt: "Check",
+          States: {
+            Check: {
+              Type: "Task",
+              Resource: "arn:aws:states:::lambda:invoke",
+              Parameters: { FunctionName: "check-enrolment" },
+              End: true,
+            },
+          },
+        }),
+      },
+    });
+
+    // When an execution reaches the task.
+    const started = await stepFunctions.startExecution({
+      input: { stateMachineArn: created.stateMachineArn },
+    });
+    const described = await stepFunctions.describeExecution({
+      input: { executionArn: started.executionArn },
+    });
+
+    // Then it says there was nowhere to invoke, rather than answering as if
+    // the function had run.
+    assertIdentical(described.error, "States.TaskFailed");
+    assertStringIncludes(described.cause ?? "", "no functions to invoke");
+  });
+
+  it("invokes the version an alias points at", async () => {
+    // Given a function with a published version behind an alias, which is what
+    // CDK writes when a workflow invokes an alias.
+    const simAws = new SimAws();
+    const check = await simLambdaAliasedFunction(simAws, "check-enrolment");
+    const roleArn = await statesExecutionRoleFactory.make({}, simAws);
+
+    // When a task names the alias ARN.
+    const described = await runTask(simAws, roleArn, {
+      Type: "Task",
+      Resource: check.aliasArn,
+      End: true,
+    });
+
+    // Then the version the alias points at ran, rather than $LATEST.
+    assertIdentical(described.status, "SUCCEEDED");
+    assertArrayEquals(check.ranAs, [check.version]);
+  });
+});

--- a/test/stepfunctions/states-execution-role.factory.ts
+++ b/test/stepfunctions/states-execution-role.factory.ts
@@ -1,0 +1,86 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { AsyncMappedFactory } from "@kensio/part-factory";
+
+import type { SimAws } from "../../src/service/aws/sim-aws.js";
+import { simIamPolicyDocumentFactory } from "../../src/service/iam/policy/sim-iam-policy-document.factory.js";
+import type { SimIamPolicyDocumentStatement } from "../../src/service/iam/policy/sim-iam-policy.js";
+
+/**
+ * What a state machine asks for when it wants a role to run its tasks as.
+ */
+export interface StatesExecutionRoleInput {
+  readonly roleName: string;
+
+  /**
+   * What the role is allowed. A role given none has no policy at all, which is
+   * how a state machine that may invoke nothing is written.
+   */
+  readonly statements: readonly SimIamPolicyDocumentStatement[];
+
+  /**
+   * The service principal the trust policy admits.
+   */
+  readonly trusts: string;
+}
+
+/**
+ * Creates an execution role a simulated state machine assumes to do its work,
+ * allowed the statements it is given and nothing else.
+ *
+ * ```typescript
+ * const roleArn = await statesExecutionRoleFactory.make({}, simAws);
+ * ```
+ *
+ * The default allows `lambda:InvokeFunction` on anything, because a test about
+ * what a state machine does is not usually a test about which functions its
+ * role may invoke. A test that is says so:
+ *
+ * ```typescript
+ * const roleArn = await statesExecutionRoleFactory.make(
+ *   { statements: [] },
+ *   simAws,
+ * );
+ * ```
+ */
+export const statesExecutionRoleFactory = new AsyncMappedFactory<
+  StatesExecutionRoleInput,
+  string,
+  SimAws
+>(
+  () => ({
+    roleName: "WorkflowRole",
+    statements: [
+      { Effect: "Allow", Action: "lambda:InvokeFunction", Resource: "*" },
+    ],
+    trusts: "states.amazonaws.com",
+  }),
+  async (input, simAws) => {
+    const simIam = simAws.iam();
+
+    const created = await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: input.roleName,
+        AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Principal: { Service: input.trusts },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+
+    if (input.statements.length > 0) {
+      await simIam.putRolePolicy(
+        new PutRolePolicyCommand({
+          RoleName: input.roleName,
+          PolicyName: `${input.roleName}Policy`,
+          PolicyDocument: simIamPolicyDocumentFactory.make({
+            Statement: input.statements,
+          }),
+        }),
+      );
+    }
+
+    return created.Role.Arn;
+  },
+);

--- a/test/stepfunctions/states-machine.factory.ts
+++ b/test/stepfunctions/states-machine.factory.ts
@@ -1,0 +1,62 @@
+import { AsyncMappedFactory } from "@kensio/part-factory";
+
+import type { SimAws } from "../../src/service/aws/sim-aws.js";
+import type { JSONObject } from "../../src/util/type-guard/json.js";
+
+/**
+ * What a test asks for when it wants a state machine to run.
+ */
+export interface StatesMachineInput {
+  readonly name: string;
+  readonly roleArn: string;
+  readonly startAt: string;
+
+  /**
+   * The states, written as Amazon States Language.
+   */
+  readonly states: JSONObject;
+}
+
+/**
+ * Creates a state machine and answers with its ARN.
+ *
+ * ```typescript
+ * const stateMachineArn = await statesMachineFactory.make(
+ *   {
+ *     roleArn,
+ *     startAt: "Check",
+ *     states: { Check: { Type: "Succeed" } },
+ *   },
+ *   simAws,
+ * );
+ * ```
+ *
+ * The definition is written as an object and serialised here, since a test
+ * reads a state machine more easily than it reads a JSON string.
+ */
+export const statesMachineFactory = new AsyncMappedFactory<
+  StatesMachineInput,
+  string,
+  SimAws
+>(
+  () => ({
+    name: "Enrolment",
+    roleArn: "arn:aws:iam::123456789012:role/WorkflowRole",
+    startAt: "Check",
+    states: { Check: { Type: "Succeed" } },
+  }),
+  async (input, simAws) => {
+    const created = await simAws.stepFunctions().createStateMachine({
+      input: {
+        name: input.name,
+        roleArn: input.roleArn,
+        definition: JSON.stringify({
+          StartAt: input.startAt,
+          States: input.states,
+        }),
+      },
+    });
+
+    return created.stateMachineArn;
+  },
+);

--- a/test/stepfunctions/states-task-function.factory.ts
+++ b/test/stepfunctions/states-task-function.factory.ts
@@ -1,0 +1,73 @@
+import { CreateFunctionCommand } from "@aws-sdk/client-lambda";
+import { AsyncMappedFactory } from "@kensio/part-factory";
+import { assertNonNullable } from "@kensio/smartass";
+
+import type { SimAws } from "../../src/service/aws/sim-aws.js";
+import type { AwsRegionName } from "../../src/service/aws/sim-aws-region.js";
+import { makeLambdaZipFileInput } from "../../src/service/lambda/function/code/lambda-zip-file-input.js";
+import type { SimLambdaFunction } from "../../src/service/lambda/function/sim-lambda-function.js";
+import type { SimLambdaHandler } from "../../src/service/lambda/function/sim-lambda-handler.type.js";
+
+/**
+ * What a `Task` state test asks for when it wants a function to invoke.
+ */
+export interface StatesTaskFunctionInput {
+  readonly functionName: string;
+
+  /**
+   * The handler, which runs in this process and reads the simulation's clock.
+   */
+  readonly handler: SimLambdaHandler;
+
+  /**
+   * The Region the function lives in, which is the default one unless a test
+   * is about a task reaching across Regions.
+   */
+  readonly regionName: AwsRegionName | undefined;
+}
+
+/**
+ * Creates a simulated Lambda function for a `Task` state to invoke, answering
+ * with the function so a test can read its ARN.
+ *
+ * ```typescript
+ * const check = await statesTaskFunctionFactory.make(
+ *   { functionName: "check-enrolment", handler: () => ({ eligible: true }) },
+ *   simAws,
+ * );
+ * ```
+ *
+ * The function is active by the time this answers, so a state machine can
+ * invoke it straight away.
+ */
+export const statesTaskFunctionFactory = new AsyncMappedFactory<
+  StatesTaskFunctionInput,
+  SimLambdaFunction,
+  SimAws
+>(
+  () => ({
+    functionName: "check-enrolment",
+    handler: (event: unknown): unknown => event,
+    regionName: undefined,
+  }),
+  async (input, simAws) => {
+    const simLambda = simAws.region(input.regionName).lambda();
+
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: input.functionName,
+        Role: "arn:aws:iam::123456789012:role/FunctionRole",
+        Code: { ZipFile: makeLambdaZipFileInput(input.handler) },
+      }),
+    );
+
+    // Creation schedules activation, and a caller asking for a function is
+    // asking for one a task can invoke.
+    await simAws.backgroundTasksComplete();
+
+    const created = simLambda.getSimFunctionByName(input.functionName);
+    assertNonNullable(created, `Simulated Lambda holds ${input.functionName}`);
+
+    return created;
+  },
+);


### PR DESCRIPTION
A `Task` state invokes a simulated Lambda function, through
`arn:aws:states:::lambda:invoke` and through a bare function ARN. The first
answers with the `Invoke` response and the second with the payload alone, the
two forms CDK's `LambdaInvoke` emits. The execution assumes the state
machine's `RoleArn` and authorizes `lambda:InvokeFunction` through simulated
IAM. A role that does not trust `states.amazonaws.com`, or that may not invoke
the function, fails the task with `States.TaskFailed`. A handler that raises
fails the task under `States.TaskFailed` through the integration, and under its
own error type through a function ARN. A `Resource` that is not a Lambda
invoke, and the `Retry`, `Catch` and timeout fields, are refused when the state
machine is created, naming what the definition asked for.

This unblocks the outstanding test noted on
https://github.com/KensioSoftware/yulin/issues/919, which joins a Lambda ARN
into a `Task` state. It is left for that issue rather than done here. The
CloudFormation factory stays where it is, under
`src/service/cloudformation/resource/cfn/stepfunctions/`, for the same reason.

Resolves https://github.com/KensioSoftware/yulin/issues/918
