### PR TITLE
feat: send a CloudFront Origin's custom headers to the Origin

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -575,6 +575,161 @@ Three things follow from the request never leaving the process:
   therefore refuses the request. [Origin access controls](#origin-access-controls) covers the
   Function URL that admits the Distribution and nothing else.
 
+## Custom headers on an Origin
+
+CloudFront adds an Origin's custom headers to every request it sends that Origin. An origin that
+answers only requests carrying a header nothing else knows is how AWS documents
+[restricting a custom origin to CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-overview.html#forward-custom-headers-restrict-access),
+and a sim Distribution sends them the same way.
+
+The CloudFront API and CloudFormation name the field differently, and both spellings are accepted
+here. The API has `CustomHeaders` inside an `Origin`, and `AWS::CloudFront::Distribution` has
+`OriginCustomHeaders`, as the two differ over the viewer certificate ARN.
+
+```typescript sim-cloudfront-origin-custom-headers
+/**
+ * An HTTP API answering only the requests that came through the Distribution.
+ */
+
+import {
+  CreateApiCommand,
+  CreateIntegrationCommand,
+  CreateRouteCommand,
+  CreateStageCommand,
+} from "@aws-sdk/client-apigatewayv2";
+import { CreateDistributionCommand } from "@aws-sdk/client-cloudfront";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const originSecret = "5d6e2b0c6f564c1e9d5b2f1a5b8c9d70";
+
+// A function serving the API, which reads the secret off every request.
+const { FunctionArn } = await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "profile",
+    Role: "arn:aws:iam::111111111111:role/ProfileRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput(
+        (event: { headers: Record<string, string> }) =>
+          event.headers["x-origin-secret"] === originSecret
+            ? { name: "Ada" }
+            : { message: "Forbidden" },
+      ),
+    },
+  }),
+);
+
+const apiGateway = simAws.apiGatewayV2();
+
+const { ApiId, ApiEndpoint } = await apiGateway.createApi(
+  new CreateApiCommand({ Name: "profile", ProtocolType: "HTTP" }),
+);
+
+const { IntegrationId } = await apiGateway.createIntegration(
+  new CreateIntegrationCommand({
+    ApiId,
+    IntegrationType: "AWS_PROXY",
+    IntegrationUri: FunctionArn,
+    PayloadFormatVersion: "2.0",
+  }),
+);
+
+await apiGateway.createRoute(
+  new CreateRouteCommand({
+    ApiId,
+    RouteKey: "GET /user/profile",
+    Target: `integrations/${IntegrationId}`,
+  }),
+);
+
+await apiGateway.createStage(
+  new CreateStageCommand({ ApiId, StageName: "$default", AutoDeploy: true }),
+);
+
+await simAws.lambda().addPermission(
+  new AddPermissionCommand({
+    FunctionName: "profile",
+    StatementId: "api-gateway-invoke",
+    Action: "lambda:InvokeFunction",
+    Principal: "apigateway.amazonaws.com",
+    SourceArn: `arn:aws:execute-api:us-east-1:888888888888:${ApiId}/*/*`,
+  }),
+);
+
+// A Distribution that sends the secret with every request to that Origin.
+const distributionCreation = await simAws.cloudFront().createDistribution(
+  new CreateDistributionCommand({
+    DistributionConfig: {
+      CallerReference: "user-site",
+      Comment: "User API CDN",
+      Enabled: true,
+      Origins: {
+        Quantity: 1,
+        Items: [
+          {
+            Id: "api-origin",
+            DomainName: new URL(ApiEndpoint).hostname,
+            CustomOriginConfig: {
+              HTTPPort: 80,
+              HTTPSPort: 443,
+              OriginProtocolPolicy: "https-only",
+            },
+            CustomHeaders: {
+              Quantity: 1,
+              Items: [
+                { HeaderName: "x-origin-secret", HeaderValue: originSecret },
+              ],
+            },
+          },
+        ],
+      },
+      DefaultCacheBehavior: {
+        TargetOriginId: "api-origin",
+        ViewerProtocolPolicy: "allow-all",
+      },
+    },
+  }),
+);
+
+const distroHostname = distributionCreation.Distribution!.DomainName!;
+const srv = await serveSimAws({ simAws });
+
+try {
+  const throughCdn = await fetch(
+    srv.localUrl(`http://${distroHostname}/user/profile`),
+  );
+  const direct = await fetch(srv.localUrl(`${ApiEndpoint}/user/profile`));
+
+  // {"name":"Ada"}
+  console.log(await throughCdn.text());
+  // {"message":"Forbidden"}
+  console.log(await direct.text());
+} finally {
+  await srv.close();
+}
+```
+
+Two rules follow CloudFront's own:
+
+- A header the viewer already sent is overwritten with the Origin's value, whatever case the viewer
+  wrote it in. A viewer cannot reach the origin with a guessed secret by sending the header through
+  the Distribution.
+- A header name CloudFront refuses to add fails the Distribution at create and fails the Stack at
+  deploy, naming the header. The
+  [denied names](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/add-origin-custom-headers.html#add-origin-custom-headers-denylist)
+  run from `Cache-Control` to `X-Real-Ip`, along with anything beginning `X-Amz-` or `X-Edge-`.
+
+An S3 Origin takes the headers and reaches nothing with them. Sim CloudFront reads a Bucket through
+`GetObject` and builds no HTTP request for a header to travel on, and real S3 ignores a header it
+has no use for.
+
 ## Viewer certificates
 
 A Distribution with alternate domain names needs an ACM certificate, and CloudFront accepts only
@@ -1979,6 +2134,7 @@ Sim CloudFront currently supports:
 - Key value stores, through both the CloudFront client and the key value store data client
 - S3 Origins backed by sim S3 Buckets, reading them as the Bucket policy allows
 - Custom Origins reaching sim HTTP APIs and sim Lambda Function URLs in process
+- `CustomHeaders` and `OriginCustomHeaders` on an Origin, for an origin that admits only CloudFront
 - CloudFront Distribution hostnames such as `distro123.cloudfront.net`
 - Default cache Behavior and path-based cache Behaviors
 - `DefaultRootObject` and `CustomErrorResponses`, for static sites and single-page apps

--- a/docs/services/cloudfront/sim-cloudfront-origin-custom-headers.example.ts
+++ b/docs/services/cloudfront/sim-cloudfront-origin-custom-headers.example.ts
@@ -1,0 +1,127 @@
+/**
+ * An HTTP API answering only the requests that came through the Distribution.
+ */
+
+import {
+  CreateApiCommand,
+  CreateIntegrationCommand,
+  CreateRouteCommand,
+  CreateStageCommand,
+} from "@aws-sdk/client-apigatewayv2";
+import { CreateDistributionCommand } from "@aws-sdk/client-cloudfront";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const originSecret = "5d6e2b0c6f564c1e9d5b2f1a5b8c9d70";
+
+// A function serving the API, which reads the secret off every request.
+const { FunctionArn } = await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "profile",
+    Role: "arn:aws:iam::111111111111:role/ProfileRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput(
+        (event: { headers: Record<string, string> }) =>
+          event.headers["x-origin-secret"] === originSecret
+            ? { name: "Ada" }
+            : { message: "Forbidden" },
+      ),
+    },
+  }),
+);
+
+const apiGateway = simAws.apiGatewayV2();
+
+const { ApiId, ApiEndpoint } = await apiGateway.createApi(
+  new CreateApiCommand({ Name: "profile", ProtocolType: "HTTP" }),
+);
+
+const { IntegrationId } = await apiGateway.createIntegration(
+  new CreateIntegrationCommand({
+    ApiId,
+    IntegrationType: "AWS_PROXY",
+    IntegrationUri: FunctionArn,
+    PayloadFormatVersion: "2.0",
+  }),
+);
+
+await apiGateway.createRoute(
+  new CreateRouteCommand({
+    ApiId,
+    RouteKey: "GET /user/profile",
+    Target: `integrations/${IntegrationId}`,
+  }),
+);
+
+await apiGateway.createStage(
+  new CreateStageCommand({ ApiId, StageName: "$default", AutoDeploy: true }),
+);
+
+await simAws.lambda().addPermission(
+  new AddPermissionCommand({
+    FunctionName: "profile",
+    StatementId: "api-gateway-invoke",
+    Action: "lambda:InvokeFunction",
+    Principal: "apigateway.amazonaws.com",
+    SourceArn: `arn:aws:execute-api:us-east-1:888888888888:${ApiId}/*/*`,
+  }),
+);
+
+// A Distribution that sends the secret with every request to that Origin.
+const distributionCreation = await simAws.cloudFront().createDistribution(
+  new CreateDistributionCommand({
+    DistributionConfig: {
+      CallerReference: "user-site",
+      Comment: "User API CDN",
+      Enabled: true,
+      Origins: {
+        Quantity: 1,
+        Items: [
+          {
+            Id: "api-origin",
+            DomainName: new URL(ApiEndpoint).hostname,
+            CustomOriginConfig: {
+              HTTPPort: 80,
+              HTTPSPort: 443,
+              OriginProtocolPolicy: "https-only",
+            },
+            CustomHeaders: {
+              Quantity: 1,
+              Items: [
+                { HeaderName: "x-origin-secret", HeaderValue: originSecret },
+              ],
+            },
+          },
+        ],
+      },
+      DefaultCacheBehavior: {
+        TargetOriginId: "api-origin",
+        ViewerProtocolPolicy: "allow-all",
+      },
+    },
+  }),
+);
+
+const distroHostname = distributionCreation.Distribution!.DomainName!;
+const srv = await serveSimAws({ simAws });
+
+try {
+  const throughCdn = await fetch(
+    srv.localUrl(`http://${distroHostname}/user/profile`),
+  );
+  const direct = await fetch(srv.localUrl(`${ApiEndpoint}/user/profile`));
+
+  // {"name":"Ada"}
+  console.log(await throughCdn.text());
+  // {"message":"Forbidden"}
+  console.log(await direct.text());
+} finally {
+  await srv.close();
+}

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-custom-headers.iso.test.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-custom-headers.iso.test.ts
@@ -1,0 +1,81 @@
+import { assertIdentical, assertInstanceOf } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsHttp } from "../../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../../serve/http/url/sim-aws-local-url.js";
+import type { SimPayload2Event } from "../../../../serve/payload-2/sim-payload-2-event.type.js";
+import { simHttpApiLambdaProxyFactory } from "../../../apigatewayv2/api/sim-http-api-lambda-proxy.factory.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
+
+describe("CloudFormation CloudFront Distribution Origin custom headers", () => {
+  it("sends a template's OriginCustomHeaders on to the Origin", async () => {
+    // Given an HTTP API that admits a request carrying a secret header, which
+    // is how AWS documents restricting a custom origin to CloudFront.
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        routeKeys: ["GET /things"],
+        handler: (event: SimPayload2Event): unknown =>
+          event.headers["x-origin-secret"] === "shibboleth"
+            ? { things: ["kettle"] }
+            : { message: "Forbidden" },
+      },
+      simAws,
+    );
+
+    // When a template declares a Distribution fronting that API and writes the
+    // secret as an Origin custom header.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "api-distribution-stack",
+      template: {
+        Resources: {
+          ApiDistribution: {
+            Type: "AWS::CloudFront::Distribution",
+            Properties: {
+              DistributionConfig: {
+                Enabled: true,
+                Origins: [
+                  {
+                    Id: "ApiOrigin",
+                    DomainName: new URL(api.apiEndpoint).hostname,
+                    CustomOriginConfig: { OriginProtocolPolicy: "https-only" },
+                    OriginCustomHeaders: [
+                      {
+                        HeaderName: "x-origin-secret",
+                        HeaderValue: "shibboleth",
+                      },
+                    ],
+                  },
+                ],
+                DefaultCacheBehavior: {
+                  TargetOriginId: "ApiOrigin",
+                  ViewerProtocolPolicy: "redirect-to-https",
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    // Then the Distribution's requests carry it and the API admits them, while
+    // a request sent to the API endpoint direct is refused.
+    const resource = stack.getResource("ApiDistribution");
+    assertInstanceOf(resource?.simResource, SimCloudFrontDistribution);
+
+    const simAwsHttp = new SimAwsHttp({ simAws });
+    const distributionId = resource.simResource.distributionId.toLowerCase();
+    const throughDistribution = await simAwsHttp.fetch(
+      new SimAwsLocalUrl({
+        input: `https://${distributionId}.cloudfront.net/things`,
+      }).toString(),
+    );
+    const direct = await simAwsHttp.fetch(
+      new SimAwsLocalUrl({ input: `${api.apiEndpoint}/things` }).toString(),
+    );
+
+    assertIdentical(await throughDistribution.text(), '{"things":["kettle"]}');
+    assertIdentical(await direct.text(), '{"message":"Forbidden"}');
+  });
+});

--- a/src/service/cloudfront/command/create-distribution/create-distribution.command.ts
+++ b/src/service/cloudfront/command/create-distribution/create-distribution.command.ts
@@ -123,6 +123,33 @@ export interface SimCloudFrontOriginConfig {
   readonly OriginAccessControlId?: string | undefined;
   readonly S3OriginConfig?: SimCloudFrontS3OriginConfig | undefined;
   readonly CustomOriginConfig?: object | undefined;
+  /**
+   * The headers CloudFront adds to a request it sends to this Origin.
+   *
+   * The CloudFront API and CloudFormation name this field differently. The API
+   * has `CustomHeaders` and `AWS::CloudFront::Distribution` has
+   * `OriginCustomHeaders`, as they differ over `ACMCertificateArn` and
+   * `AcmCertificateArn`. Both spellings are accepted so a template and an SDK
+   * call reach the simulator the same way.
+   */
+  readonly CustomHeaders?: SimCloudFrontOriginCustomHeaders | undefined;
+  readonly OriginCustomHeaders?: SimCloudFrontOriginCustomHeaders | undefined;
+}
+
+/**
+ * Minimal structural sim CloudFront Origin custom header list.
+ */
+export interface SimCloudFrontOriginCustomHeaders {
+  readonly Quantity?: number | undefined;
+  readonly Items?: readonly SimCloudFrontOriginCustomHeader[] | undefined;
+}
+
+/**
+ * Minimal structural sim CloudFront Origin custom header.
+ */
+export interface SimCloudFrontOriginCustomHeader {
+  readonly HeaderName?: string | undefined;
+  readonly HeaderValue?: string | undefined;
 }
 
 /**

--- a/src/service/cloudfront/command/create-distribution/sim-cf-distro-config-normalizer.ts
+++ b/src/service/cloudfront/command/create-distribution/sim-cf-distro-config-normalizer.ts
@@ -6,12 +6,11 @@ import type {
   SimCloudFrontFunctionAssociation,
   SimCloudFrontOriginConfig,
 } from "./create-distribution.command.js";
-import { isRecord } from "../../../../util/type-guard/record.js";
-import { assertConsistentQuantity } from "../sim-cf-list-quantity.js";
-
-interface SimCloudFrontConfigList<T> {
-  readonly Items?: readonly T[] | undefined;
-}
+import {
+  normalizeSimCfList,
+  normalizeSimCfListItems,
+} from "./sim-cf-normalize-list.js";
+import { normalizeSimCfOrigin } from "./sim-cf-normalize-origin.js";
 
 type SimCloudFrontBehaviorConfig =
   | SimCloudFrontDefaultCacheBehaviorConfig
@@ -34,29 +33,20 @@ export class SimCloudFrontDistributionConfigNormalizer {
    * Normalize known list-like DistributionConfig fields.
    */
   normalize(): SimCloudFrontDistributionConfig {
-    const distributionConfig = this.distributionConfig as Record<
-      string,
-      object
-    >;
-    const cacheBehaviors = this.normalizeList<SimCloudFrontCacheBehaviorConfig>(
-      "CacheBehaviors",
-      distributionConfig["CacheBehaviors"],
-    );
+    const config = this.distributionConfig as Record<string, object>;
 
     return {
       ...this.distributionConfig,
-      Aliases: this.normalizeList<string>(
-        "Aliases",
-        distributionConfig["Aliases"],
-      ),
-      Origins: this.normalizeList<SimCloudFrontOriginConfig>(
+      Aliases: normalizeSimCfList<string>("Aliases", config["Aliases"]),
+      Origins: normalizeSimCfListItems<SimCloudFrontOriginConfig>(
         "Origins",
-        distributionConfig["Origins"],
+        config["Origins"],
+        normalizeSimCfOrigin,
       ),
       CustomErrorResponses:
-        this.normalizeList<SimCloudFrontCustomErrorResponseConfig>(
+        normalizeSimCfList<SimCloudFrontCustomErrorResponseConfig>(
           "CustomErrorResponses",
-          distributionConfig["CustomErrorResponses"],
+          config["CustomErrorResponses"],
         ),
       DefaultCacheBehavior:
         this.distributionConfig.DefaultCacheBehavior === undefined
@@ -64,15 +54,11 @@ export class SimCloudFrontDistributionConfigNormalizer {
           : this.normalizeCacheBehavior(
               this.distributionConfig.DefaultCacheBehavior,
             ),
-      CacheBehaviors:
-        cacheBehaviors === undefined
-          ? undefined
-          : {
-              ...cacheBehaviors,
-              Items: cacheBehaviors.Items?.map((cacheBehavior) =>
-                this.normalizeCacheBehavior(cacheBehavior),
-              ),
-            },
+      CacheBehaviors: normalizeSimCfListItems<SimCloudFrontCacheBehaviorConfig>(
+        "CacheBehaviors",
+        config["CacheBehaviors"],
+        (behavior) => this.normalizeCacheBehavior(behavior),
+      ),
     };
   }
 
@@ -84,40 +70,10 @@ export class SimCloudFrontDistributionConfigNormalizer {
     return {
       ...cacheBehavior,
       FunctionAssociations:
-        this.normalizeList<SimCloudFrontFunctionAssociation>(
+        normalizeSimCfList<SimCloudFrontFunctionAssociation>(
           "FunctionAssociations",
           cacheBehaviorRecord["FunctionAssociations"],
         ),
     };
-  }
-
-  private normalizeList<T>(
-    listName: string,
-    value: unknown,
-  ): SimCloudFrontConfigList<T> | undefined {
-    if (value === undefined) {
-      return undefined;
-    }
-
-    assertConsistentQuantity(listName, value);
-
-    if (Array.isArray(value)) {
-      return {
-        Items: value as readonly T[],
-      };
-    }
-
-    if (isRecord(value)) {
-      return {
-        ...value,
-        // Keep downstream for..of iteration safe when Items is malformed.
-        Items: Array.isArray(value["Items"])
-          ? (value["Items"] as readonly T[])
-          : undefined,
-      };
-    }
-
-    /* v8 ignore next -- defensive fallback */
-    return undefined;
   }
 }

--- a/src/service/cloudfront/command/create-distribution/sim-cf-normalize-list.ts
+++ b/src/service/cloudfront/command/create-distribution/sim-cf-normalize-list.ts
@@ -1,0 +1,59 @@
+import { isRecord } from "../../../../util/type-guard/record.js";
+import { assertConsistentQuantity } from "../sim-cf-list-quantity.js";
+
+/**
+ * A CloudFront list, once normalized to the shape the simulator reads.
+ */
+export interface SimCloudFrontConfigList<T> {
+  readonly Items?: readonly T[] | undefined;
+}
+
+/**
+ * Normalize one of the list-like shapes a CloudFront config arrives in.
+ *
+ * The CloudFront API writes a list as `{ Quantity, Items }` and CloudFormation
+ * writes the same list as a plain array. Both arrive here and leave as the
+ * pair, so everything downstream reads one shape.
+ */
+export function normalizeSimCfList<T>(
+  listName: string,
+  value: unknown,
+): SimCloudFrontConfigList<T> | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  assertConsistentQuantity(listName, value);
+
+  if (Array.isArray(value)) {
+    return { Items: value as readonly T[] };
+  }
+
+  if (isRecord(value)) {
+    return {
+      ...value,
+      // Keep downstream for..of iteration safe when Items is malformed.
+      Items: Array.isArray(value["Items"])
+        ? (value["Items"] as readonly T[])
+        : undefined,
+    };
+  }
+
+  /* v8 ignore next -- defensive fallback */
+  return undefined;
+}
+
+/**
+ * Normalize a list and every item in it.
+ */
+export function normalizeSimCfListItems<T>(
+  listName: string,
+  value: unknown,
+  normalizeItem: (item: T) => T,
+): SimCloudFrontConfigList<T> | undefined {
+  const list = normalizeSimCfList<T>(listName, value);
+
+  return list === undefined
+    ? undefined
+    : { ...list, Items: list.Items?.map(normalizeItem) };
+}

--- a/src/service/cloudfront/command/create-distribution/sim-cf-normalize-origin.ts
+++ b/src/service/cloudfront/command/create-distribution/sim-cf-normalize-origin.ts
@@ -1,0 +1,30 @@
+import type {
+  SimCloudFrontOriginConfig,
+  SimCloudFrontOriginCustomHeader,
+} from "./create-distribution.command.js";
+import { normalizeSimCfList } from "./sim-cf-normalize-list.js";
+
+/**
+ * Normalize the custom header list on an Origin.
+ *
+ * The CloudFront API and CloudFormation name the field differently, so both
+ * names are normalized here and whichever one the caller wrote reaches the
+ * Origin the same way.
+ */
+export function normalizeSimCfOrigin(
+  origin: SimCloudFrontOriginConfig,
+): SimCloudFrontOriginConfig {
+  const originRecord = origin as Record<string, object>;
+
+  return {
+    ...origin,
+    CustomHeaders: normalizeSimCfList<SimCloudFrontOriginCustomHeader>(
+      "CustomHeaders",
+      originRecord["CustomHeaders"],
+    ),
+    OriginCustomHeaders: normalizeSimCfList<SimCloudFrontOriginCustomHeader>(
+      "OriginCustomHeaders",
+      originRecord["OriginCustomHeaders"],
+    ),
+  };
+}

--- a/src/service/cloudfront/distribution/configurator/sim-cloud-front-origin-configurator.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cloud-front-origin-configurator.ts
@@ -12,6 +12,7 @@ import type { SimCloudFrontOriginAccessControl } from "../../origin-access-contr
 import type { SimCloudFrontOriginAccessControlRegistry } from "../../origin-access-control/sim-cf-origin-access-control-registry.js";
 import { assertSimCfOacOriginType } from "../../origin-access-control/sim-cf-oac-origin-type.js";
 import { SimCloudFrontInvalidOriginAccessControl } from "../../error/sim-cloudfront.error.js";
+import { simCfOriginCustomHeaders } from "../../origin/sim-cf-origin-custom-headers.js";
 
 /**
  * Applies Origin configuration to a sim CloudFront Distribution.
@@ -44,6 +45,12 @@ export class SimCloudFrontOriginConfigurator {
       origin.Id,
       origin.OriginAccessControlId,
     );
+    // Read for both Origin kinds, since CloudFront refuses a header name it
+    // cannot add whichever kind the Origin turns out to be. Only a custom
+    // Origin goes on to carry them. An S3 Origin here reads its Bucket through
+    // GetObject and builds no request for a header to travel on, and real S3
+    // ignores a header it has no use for either way.
+    const customHeaders = simCfOriginCustomHeaders(origin.Id, origin);
 
     if (origin.S3OriginConfig !== undefined) {
       assertNoSimCfS3OriginAccessIdentity(origin.Id, origin.S3OriginConfig);
@@ -84,6 +91,7 @@ export class SimCloudFrontOriginConfigurator {
           domainName: origin.DomainName,
           originPath: origin.OriginPath,
           dispatcher: this.customOriginDispatcher,
+          customHeaders,
           ...(originAccessControl !== undefined && { originAccessControl }),
         }),
       );

--- a/src/service/cloudfront/origin/custom/sim-cf-custom-origin-request.ts
+++ b/src/service/cloudfront/origin/custom/sim-cf-custom-origin-request.ts
@@ -6,6 +6,10 @@ interface SimCfCustomOriginRequestProperties {
   readonly originPath: string;
   readonly request: Request;
   /**
+   * The Origin's own custom headers, keyed by lower-case header name.
+   */
+  readonly customHeaders?: Readonly<Record<string, string>> | undefined;
+  /**
    * Headers stating who the Origin request is from and what its signature
    * covers, which an Origin whose origin access control signs carries and an
    * anonymous one does not.
@@ -46,6 +50,15 @@ export function simCfCustomOriginRequest(
   // had them stripped already; one reaching a controller in process has not,
   // and either way an unsigned Origin should state nothing.
   stripSimAwsControlHeaders(headers);
+
+  // A viewer sending a header the Origin also configures has its value
+  // replaced, as CloudFront replaces it. That is what stops a viewer spoofing
+  // a header the origin trusts by sending it through the Distribution.
+  const customHeaders = Object.entries(properties.customHeaders ?? {});
+
+  for (const [name, value] of customHeaders) {
+    headers.set(name, value);
+  }
 
   const signingHeaders = Object.entries(properties.signingHeaders ?? {});
 

--- a/src/service/cloudfront/origin/custom/sim-cloudfront-custom-origin.ts
+++ b/src/service/cloudfront/origin/custom/sim-cloudfront-custom-origin.ts
@@ -11,6 +11,11 @@ interface SimCloudFrontCustomOriginProperties {
   readonly originPath?: string | undefined;
   readonly dispatcher: SimCfCustomOriginDispatcher;
   readonly originAccessControl?: SimCloudFrontOriginAccessControl | undefined;
+  /**
+   * The headers CloudFront adds to every request it sends to this Origin,
+   * keyed by lower-case header name.
+   */
+  readonly customHeaders?: Readonly<Record<string, string>> | undefined;
 }
 
 /**
@@ -40,6 +45,7 @@ export class SimCloudFrontCustomOrigin implements SimCloudFrontOrigin {
   private readonly originPath: string;
   private readonly dispatcher: SimCfCustomOriginDispatcher;
   private readonly signer: SimCfCustomOriginSigner;
+  private readonly customHeaders: Readonly<Record<string, string>>;
 
   constructor(properties: SimCloudFrontCustomOriginProperties) {
     this.originId = properties.originId;
@@ -48,6 +54,7 @@ export class SimCloudFrontCustomOrigin implements SimCloudFrontOrigin {
     this.dispatcher = properties.dispatcher;
     this.originAccessControl = properties.originAccessControl;
     this.signer = new SimCfCustomOriginSigner(properties.originAccessControl);
+    this.customHeaders = properties.customHeaders ?? {};
   }
 
   /**
@@ -62,6 +69,7 @@ export class SimCloudFrontCustomOrigin implements SimCloudFrontOrigin {
       domainName: this.domainName,
       originPath: this.originPath,
       request: request.req,
+      customHeaders: this.customHeaders,
       signingHeaders: this.signer.forRequest(request),
     });
 

--- a/src/service/cloudfront/origin/sim-cf-origin-custom-headers.iso.test.ts
+++ b/src/service/cloudfront/origin/sim-cf-origin-custom-headers.iso.test.ts
@@ -1,0 +1,358 @@
+import { CreateDistributionCommand } from "@aws-sdk/client-cloudfront";
+import {
+  CreateBucketCommand,
+  PutBucketPolicyCommand,
+  PutObjectCommand,
+  PutPublicAccessBlockCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import type { SimPayload2Event } from "../../../serve/payload-2/sim-payload-2-event.type.js";
+import { simHttpApiLambdaProxyFactory } from "../../apigatewayv2/api/sim-http-api-lambda-proxy.factory.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import {
+  SimCloudFrontInconsistentQuantities,
+  SimCloudFrontInvalidArgument,
+} from "../error/sim-cloudfront.error.js";
+
+/**
+ * An HTTP API answering with the headers its request arrived with, which is
+ * what an origin checking for a custom header reads.
+ */
+async function apiEchoingHeaders(simAws: SimAws): Promise<string> {
+  const api = await simHttpApiLambdaProxyFactory.make(
+    {
+      routeKeys: ["GET /headers"],
+      handler: (event: SimPayload2Event): unknown => event.headers,
+    },
+    simAws,
+  );
+
+  return new URL(api.apiEndpoint).hostname;
+}
+
+/**
+ * Create a Distribution fronting `originDomain` with the Origin properties
+ * given, and answer its hostname.
+ */
+async function distributionFronting(
+  simAws: SimAws,
+  originDomain: string,
+  originProperties: object,
+): Promise<string> {
+  const creation = await simAws.cloudFront().createDistribution(
+    new CreateDistributionCommand({
+      DistributionConfig: {
+        CallerReference: "custom-header-distribution",
+        Comment: "Custom header Distribution",
+        Enabled: true,
+        Origins: {
+          Quantity: 1,
+          Items: [
+            {
+              Id: "api",
+              DomainName: originDomain,
+              CustomOriginConfig: {
+                HTTPPort: 80,
+                HTTPSPort: 443,
+                OriginProtocolPolicy: "https-only",
+              },
+              ...originProperties,
+            },
+          ],
+        },
+        DefaultCacheBehavior: {
+          TargetOriginId: "api",
+          ViewerProtocolPolicy: "redirect-to-https",
+        },
+      },
+    }),
+  );
+
+  return `${creation.Distribution?.Id?.toLowerCase() ?? ""}.cloudfront.net`;
+}
+
+/**
+ * Send a request through a Distribution and read the headers the Origin saw.
+ */
+async function headersAtOrigin(
+  simAws: SimAws,
+  distributionHostname: string,
+  viewerHeaders: Record<string, string> = {},
+): Promise<Record<string, string>> {
+  const response = await new SimAwsHttp({ simAws }).fetch(
+    new SimAwsLocalUrl({
+      input: `https://${distributionHostname}/headers`,
+    }).toString(),
+    { headers: viewerHeaders },
+  );
+
+  return (await response.json()) as Record<string, string>;
+}
+
+describe("sim CloudFront Origin custom headers", () => {
+  it("adds the headers an Origin was created with to the Origin request", async () => {
+    // Given an Origin carrying a secret its origin checks for
+    const simAws = new SimAws();
+    const originDomain = await apiEchoingHeaders(simAws);
+
+    // When a request is served through the Distribution
+    const distributionHostname = await distributionFronting(
+      simAws,
+      originDomain,
+      {
+        CustomHeaders: {
+          Quantity: 2,
+          Items: [
+            { HeaderName: "X-Origin-Secret", HeaderValue: "shibboleth" },
+            { HeaderName: "X-From-Cdn", HeaderValue: "yes" },
+          ],
+        },
+      },
+    );
+    const headers = await headersAtOrigin(simAws, distributionHostname);
+
+    // Then the Origin sees both of them
+    assertIdentical(headers["x-origin-secret"], "shibboleth");
+    assertIdentical(headers["x-from-cdn"], "yes");
+  });
+
+  it("adds the headers a template writes as OriginCustomHeaders", async () => {
+    // Given the CloudFormation spelling of the property, as a plain array
+    const simAws = new SimAws();
+    const originDomain = await apiEchoingHeaders(simAws);
+
+    // When a request is served through the Distribution
+    const distributionHostname = await distributionFronting(
+      simAws,
+      originDomain,
+      {
+        OriginCustomHeaders: [
+          { HeaderName: "X-Origin-Secret", HeaderValue: "shibboleth" },
+        ],
+      },
+    );
+    const headers = await headersAtOrigin(simAws, distributionHostname);
+
+    // Then the Origin sees the header, as it does for the API spelling
+    assertIdentical(headers["x-origin-secret"], "shibboleth");
+  });
+
+  it("replaces a viewer's own copy of a configured header", async () => {
+    // Given a viewer sending the header the Origin trusts, in another case
+    const simAws = new SimAws();
+    const originDomain = await apiEchoingHeaders(simAws);
+
+    // When the request is served through the Distribution
+    const distributionHostname = await distributionFronting(
+      simAws,
+      originDomain,
+      {
+        CustomHeaders: {
+          Quantity: 1,
+          Items: [{ HeaderName: "X-Origin-Secret", HeaderValue: "shibboleth" }],
+        },
+      },
+    );
+    const headers = await headersAtOrigin(simAws, distributionHostname, {
+      "X-ORIGIN-SECRET": "guessed",
+    });
+
+    // Then the Origin's value replaces the viewer's, which is what stops a
+    // viewer spoofing the header through the Distribution
+    assertIdentical(headers["x-origin-secret"], "shibboleth");
+  });
+
+  it("sends nothing extra to an Origin with no custom headers", async () => {
+    // Given an Origin configured without any
+    const simAws = new SimAws();
+    const originDomain = await apiEchoingHeaders(simAws);
+
+    // When a request is served through the Distribution
+    const distributionHostname = await distributionFronting(
+      simAws,
+      originDomain,
+      {},
+    );
+    const headers = await headersAtOrigin(simAws, distributionHostname);
+
+    // Then the Origin sees no secret
+    assertUndefined(headers["x-origin-secret"]);
+  });
+
+  it("refuses a header name CloudFront will not add", async () => {
+    // Given an Origin asking for a header on CloudFront's denylist
+    const simAws = new SimAws();
+    const originDomain = await apiEchoingHeaders(simAws);
+
+    // When the Distribution is created
+    const error = await assertThrowsErrorAsync(async () =>
+      distributionFronting(simAws, originDomain, {
+        CustomHeaders: {
+          Quantity: 1,
+          Items: [
+            { HeaderName: "Host", HeaderValue: "elsewhere.example.test" },
+          ],
+        },
+      }),
+    );
+
+    // Then it is refused, naming the header
+    assertInstanceOf(error, SimCloudFrontInvalidArgument);
+    assertIdentical(
+      error.message,
+      "Sim CloudFront Origin api custom header Host is one CloudFront " +
+        "refuses to add to an Origin request. See https://docs.aws.amazon.com/" +
+        "AmazonCloudFront/latest/DeveloperGuide/add-origin-custom-headers.html",
+    );
+  });
+
+  it("refuses a header name on a denied prefix", async () => {
+    // Given an Origin asking for a header CloudFront reserves by prefix
+    const simAws = new SimAws();
+    const originDomain = await apiEchoingHeaders(simAws);
+
+    // When the Distribution is created
+    const error = await assertThrowsErrorAsync(async () =>
+      distributionFronting(simAws, originDomain, {
+        OriginCustomHeaders: [
+          { HeaderName: "X-Amz-Content-Sha256", HeaderValue: "0" },
+        ],
+      }),
+    );
+
+    // Then it is refused, as one named on the denylist is
+    assertInstanceOf(error, SimCloudFrontInvalidArgument);
+  });
+
+  it("refuses a custom header with no name", async () => {
+    // Given a header written with a value and no name
+    const simAws = new SimAws();
+    const originDomain = await apiEchoingHeaders(simAws);
+
+    // When the Distribution is created
+    const error = await assertThrowsErrorAsync(async () =>
+      distributionFronting(simAws, originDomain, {
+        OriginCustomHeaders: [{ HeaderValue: "shibboleth" }],
+      }),
+    );
+
+    // Then it is refused, naming the Origin
+    assertInstanceOf(error, SimCloudFrontInvalidArgument);
+    assertIdentical(
+      error.message,
+      "Sim CloudFront Origin api has a custom header with no HeaderName",
+    );
+  });
+
+  it("refuses a custom header list whose Quantity disagrees with its Items", async () => {
+    // Given a count that does not match the headers written under it
+    const simAws = new SimAws();
+    const originDomain = await apiEchoingHeaders(simAws);
+
+    // When the Distribution is created
+    const error = await assertThrowsErrorAsync(async () =>
+      distributionFronting(simAws, originDomain, {
+        CustomHeaders: {
+          Quantity: 2,
+          Items: [{ HeaderName: "X-Origin-Secret", HeaderValue: "shibboleth" }],
+        },
+      }),
+    );
+
+    // Then it is refused, as any CloudFront list with a wrong count is
+    assertInstanceOf(error, SimCloudFrontInconsistentQuantities);
+    assertIdentical(
+      error.message,
+      "CloudFront CustomHeaders has Quantity 2 and 1 Items",
+    );
+  });
+
+  it("takes a header on an S3 Origin and serves the Bucket without it", async () => {
+    // Given an S3 Origin carrying a custom header. It reads its Bucket through
+    // GetObject and builds no request for a header to travel on.
+    const simAws = new SimAws();
+    const simS3 = simAws.s3();
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "assets.example.test" }),
+    );
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "assets.example.test",
+        Key: "index.html",
+        Body: "<h1>Kettle</h1>",
+      }),
+    );
+    await simS3.putPublicAccessBlock(
+      new PutPublicAccessBlockCommand({
+        Bucket: "assets.example.test",
+        PublicAccessBlockConfiguration: { BlockPublicPolicy: false },
+      }),
+    );
+    await simS3.putBucketPolicy(
+      new PutBucketPolicyCommand({
+        Bucket: "assets.example.test",
+        Policy: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: "*",
+            Action: "s3:GetObject",
+            Resource: "arn:aws:s3:::assets.example.test/*",
+          },
+        }),
+      }),
+    );
+
+    // When a request is served through the Distribution
+    const creation = await simAws.cloudFront().createDistribution(
+      new CreateDistributionCommand({
+        DistributionConfig: {
+          CallerReference: "s3-custom-header-distribution",
+          Comment: "S3 custom header Distribution",
+          Enabled: true,
+          Origins: {
+            Quantity: 1,
+            Items: [
+              {
+                Id: "assets",
+                DomainName: "assets.example.test.s3.amazonaws.com",
+                S3OriginConfig: { OriginAccessIdentity: "" },
+                CustomHeaders: {
+                  Quantity: 1,
+                  Items: [
+                    {
+                      HeaderName: "X-Origin-Secret",
+                      HeaderValue: "shibboleth",
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          DefaultCacheBehavior: {
+            TargetOriginId: "assets",
+            ViewerProtocolPolicy: "redirect-to-https",
+          },
+        },
+      }),
+    );
+    const distributionHostname = `${creation.Distribution?.Id?.toLowerCase() ?? ""}.cloudfront.net`;
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      new SimAwsLocalUrl({
+        input: `https://${distributionHostname}/index.html`,
+      }).toString(),
+    );
+
+    // Then the Object is served, and the header reached nothing
+    assertIdentical(await response.text(), "<h1>Kettle</h1>");
+  });
+});

--- a/src/service/cloudfront/origin/sim-cf-origin-custom-headers.ts
+++ b/src/service/cloudfront/origin/sim-cf-origin-custom-headers.ts
@@ -1,0 +1,97 @@
+import type { SimCloudFrontOriginConfig } from "../command/create-distribution/create-distribution.command.js";
+import { SimCloudFrontInvalidArgument } from "../error/sim-cloudfront.error.js";
+
+/**
+ * The header names CloudFront refuses to add to an Origin request.
+ *
+ * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/add-origin-custom-headers.html
+ */
+const deniedHeaderNames = new Set([
+  "cache-control",
+  "connection",
+  "content-length",
+  "cookie",
+  "host",
+  "if-match",
+  "if-modified-since",
+  "if-none-match",
+  "if-range",
+  "if-unmodified-since",
+  "max-forwards",
+  "pragma",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "proxy-connection",
+  "range",
+  "request-range",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+  "via",
+  "x-real-ip",
+]);
+
+/**
+ * The header name prefixes CloudFront refuses alongside the names above.
+ */
+const deniedHeaderPrefixes = ["x-amz-", "x-edge-"];
+
+/**
+ * Read the custom headers an Origin was configured with.
+ *
+ * CloudFront adds these to every request it sends to the Origin, which is how
+ * an origin tells a request that came through the Distribution from one that
+ * reached it directly. A header name CloudFront refuses to add fails here, as
+ * CloudFront fails the Distribution over one.
+ *
+ * The header names are lower-cased on the way in. HTTP header names are
+ * case-insensitive, and lower-casing them here is what makes a configured
+ * header overwrite a viewer header written in another case.
+ */
+export function simCfOriginCustomHeaders(
+  originId: string,
+  origin: SimCloudFrontOriginConfig,
+): Readonly<Record<string, string>> {
+  const items = (origin.CustomHeaders ?? origin.OriginCustomHeaders)?.Items;
+
+  if (items === undefined) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    items.map((item) => [
+      assertHeaderName(originId, item.HeaderName),
+      item.HeaderValue ?? "",
+    ]),
+  );
+}
+
+/**
+ * Refuse a header name CloudFront has no way to add.
+ */
+function assertHeaderName(
+  originId: string,
+  headerName: string | undefined,
+): string {
+  if (headerName === undefined || headerName.length === 0) {
+    throw new SimCloudFrontInvalidArgument(
+      `Sim CloudFront Origin ${originId} has a custom header with no HeaderName`,
+    );
+  }
+
+  const name = headerName.toLowerCase();
+
+  if (
+    deniedHeaderNames.has(name) ||
+    deniedHeaderPrefixes.some((prefix) => name.startsWith(prefix))
+  ) {
+    throw new SimCloudFrontInvalidArgument(
+      `Sim CloudFront Origin ${originId} custom header ${headerName} is one ` +
+        `CloudFront refuses to add to an Origin request. See ` +
+        `https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/add-origin-custom-headers.html`,
+    );
+  }
+
+  return name;
+}


### PR DESCRIPTION
A simulated Distribution dropped the custom headers its Origin was configured with, so an origin that admits only requests carrying a secret header refused every request under simulation while working in the account. A custom Origin request now carries them, under the API's `CustomHeaders` and CloudFormation's `OriginCustomHeaders` alike, replacing a viewer's own copy of a configured header as CloudFront replaces it. A header name CloudFront refuses to add fails the Distribution at create and the Stack at deploy, naming the header. An S3 Origin takes the headers and reaches nothing with them, as real S3 ignores a header it has no use for.

Resolves #944