### PR TITLE
feat: throttle an HTTP API stage and route

### DIFF
--- a/docs/services/apigatewayv2/README.md
+++ b/docs/services/apigatewayv2/README.md
@@ -527,6 +527,158 @@ A request reaching an API with no stage for it, and no `$default` stage, is a 40
 on a `$default` match. `StageVariables` set on the stage arrive as `event.stageVariables`, and are
 left out the same way when the stage has none.
 
+## Throttling a stage and a route
+
+A stage holds a token bucket for every route it serves. `DefaultRouteSettings` sets the rate and the
+burst those buckets start with, and a `RouteSettings` entry keyed by route key overrides them for the
+route it names. `ThrottlingRateLimit` is requests per second, and `ThrottlingBurstLimit` is how many
+requests a route will take at once.
+
+A request that finds an empty bucket is answered 429 with `{"message":"Too Many Requests"}`. The
+route's authorizer and its integration are both skipped.
+
+The buckets refill against the simulated clock. Freeze it, spend a route's burst, assert on the 429,
+then move a second on and watch the route serve again.
+
+```typescript sim-apigatewayv2-throttling
+/**
+ * Throttling a simulated HTTP API stage and one of its routes.
+ */
+
+import {
+  CreateApiCommand,
+  CreateIntegrationCommand,
+  CreateRouteCommand,
+  CreateStageCommand,
+} from "@aws-sdk/client-apigatewayv2";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+const { FunctionArn } = await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "users",
+    Role: "arn:aws:iam::111111111111:role/UsersRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput(() => ({
+        statusCode: 200,
+        headers: { "content-type": "text/plain" },
+        body: "ok",
+      })),
+    },
+  }),
+);
+
+const apiGateway = simAws.apiGatewayV2();
+
+const { ApiId, ApiEndpoint } = await apiGateway.createApi(
+  new CreateApiCommand({ Name: "users", ProtocolType: "HTTP" }),
+);
+
+const { IntegrationId } = await apiGateway.createIntegration(
+  new CreateIntegrationCommand({
+    ApiId,
+    IntegrationType: "AWS_PROXY",
+    IntegrationUri: FunctionArn,
+    PayloadFormatVersion: "2.0",
+  }),
+);
+
+for (const RouteKey of ["POST /user/password-reset", "GET /user/profile"]) {
+  await apiGateway.createRoute(
+    new CreateRouteCommand({
+      ApiId,
+      RouteKey,
+      Target: `integrations/${IntegrationId}`,
+    }),
+  );
+}
+
+await apiGateway.createStage(
+  new CreateStageCommand({
+    ApiId,
+    StageName: "$default",
+    AutoDeploy: true,
+    DefaultRouteSettings: { ThrottlingRateLimit: 10, ThrottlingBurstLimit: 5 },
+    RouteSettings: {
+      "POST /user/password-reset": {
+        ThrottlingRateLimit: 1,
+        ThrottlingBurstLimit: 2,
+      },
+    },
+  }),
+);
+
+await simAws.lambda().addPermission(
+  new AddPermissionCommand({
+    FunctionName: "users",
+    StatementId: "api-gateway-invoke",
+    Action: "lambda:InvokeFunction",
+    Principal: "apigateway.amazonaws.com",
+    SourceArn: `arn:aws:execute-api:us-east-1:888888888888:${ApiId}/*/*`,
+  }),
+);
+
+const srv = await serveSimAws({ simAws });
+
+// Stop simulated time. A bucket now refills only when this example moves it.
+simAws.clock().freeze();
+
+const passwordReset = async (): Promise<Response> =>
+  await fetch(srv.localUrl(`${ApiEndpoint}/user/password-reset`), {
+    method: "POST",
+  });
+
+const first = await passwordReset();
+const second = await passwordReset();
+const third = await passwordReset();
+
+console.log(first.status, second.status, third.status);
+console.log(await third.text());
+
+// Another route, drawing on the stage default and a bucket of its own.
+const profile = await fetch(srv.localUrl(`${ApiEndpoint}/user/profile`));
+console.log(profile.status);
+
+// One second at a rate limit of one is one token back.
+await simAws.clock().advanceBy({ seconds: 1 });
+const afterASecond = await passwordReset();
+console.log(afterASecond.status);
+
+await srv.close();
+```
+
+The burst of two is served, the third password reset is refused, and the profile route is untouched
+by any of it:
+
+```text
+200 200 429
+{"message":"Too Many Requests"}
+200
+200
+```
+
+Every client of a route draws on the same bucket. Two callers sending one request each spend two
+tokens between them. A WAFv2 `RateBasedStatement` counts each client on its own (see
+[Rate limiting](../wafv2/#rate-limiting)), and a stack often carries both.
+
+A route is throttled here only where the settings reaching it name both limits. Naming one alone
+leaves the other at the account limit on real AWS. Account limits are outside this simulation, and a
+route configured that way is served unthrottled.
+
+`GetStages` answers with the settings a stage was created with. `AWS::ApiGatewayV2::Stage` deploys
+both properties as well (see [CloudFormation](#cloudformation)). The three members of `RouteSettings`
+that say nothing about throttling, `DetailedMetricsEnabled`, `LoggingLevel` and `DataTraceEnabled`,
+are refused by `CreateStage`. A template carrying one deploys, and the member it named is recorded on
+`stack.ignoredProperties`.
+
 ## Protecting a route with a Cognito user pool
 
 A JWT authorizer verifies a signed token before the integration is invoked. `CreateAuthorizerCommand`
@@ -1976,7 +2128,8 @@ parts behaves differently to the template. The simulated properties are:
   `AuthorizerResultTtlInSeconds`
 - `Integration`: `ApiId`, `IntegrationType`, `IntegrationUri`, `PayloadFormatVersion`, `Description`
 - `Route`: `ApiId`, `RouteKey`, `Target`, `AuthorizationType`, `AuthorizerId`, `AuthorizationScopes`
-- `Stage`: `ApiId`, `StageName`, `AutoDeploy`, `StageVariables`, `Description`
+- `Stage`: `ApiId`, `StageName`, `AutoDeploy`, `StageVariables`, `Description`,
+  `DefaultRouteSettings`, `RouteSettings`
 
 CDK's `HttpIamAuthorizer` deploys too. It emits no `AWS::ApiGatewayV2::Authorizer` and no
 `AuthorizerId`, only `AuthorizationType: "AWS_IAM"` on the `Route`, and the deployed route then
@@ -2106,6 +2259,8 @@ the simulation without being given one. See the
   to hold one per route
 - `CreateStage`, `GetStages` and `DeleteStage` for the `$default` stage and for named stages served
   under their own path segment, including stage variables
+- `DefaultRouteSettings` and `RouteSettings` throttling, with a token bucket per route refilling
+  against the simulated clock and a 429 for the requests past it
 - Serving the generated endpoint through `serveSimAws`, invoking the integrated function with a
   payload format 2.0 event and turning its result back into an HTTP response
 - The invoke permission of an integration's function and of an authorizer's, each evaluated against
@@ -2136,8 +2291,9 @@ Current documented limitations:
 - Deployments are outside the simulation, so `CreateStage` requires `AutoDeploy: true`. A stage
   without it serves whichever Deployment it was given, which on real AWS is nothing until one is
   created.
-- `RouteSettings`, `DefaultRouteSettings` and `AccessLogSettings` on a stage are refused, as is any
-  other option `CreateStage` takes and this one lacks.
+- `AccessLogSettings` on a stage is refused, as is any other option `CreateStage` takes and this one
+  lacks. `RouteSettings` and `DefaultRouteSettings` are taken, and only their throttling members are
+  read. `DetailedMetricsEnabled`, `LoggingLevel` and `DataTraceEnabled` are refused by name.
 - `AWS_PROXY` is the only integration type, and its URI must name a Lambda function ARN, written
   either as that ARN or as the
   `arn:aws:apigateway:<region>:lambda:path/2015-03-31/functions/<function-arn>/invocations` form.
@@ -2288,7 +2444,10 @@ Current documented limitations:
   for a REST API, not against a gap here.
 - A stack update replaces a changed resource of these types rather than updating it in place, as it
   does for any other type. See the [CloudFormation limitations](../cloudformation/#limitations).
-- Access logging, throttling, usage plans and API keys are outside the simulation.
+- Access logging, usage plans and API keys are outside the simulation. Stage and route
+  throttling is simulated (see [Throttling a stage and a route](#throttling-a-stage-and-a-route)).
+  The account-level rate and burst limits are not. A stage that names no limit throttles nothing,
+  and a settings entry naming one limit alone leaves that route unthrottled.
 - The response an API Gateway endpoint returns itself uses a lower-case `message` field, as a real
   HTTP API does. A Lambda Function URL uses `Message` for the same thing, so the two cannot be
   swapped.

--- a/docs/services/apigatewayv2/sim-apigatewayv2-throttling.example.ts
+++ b/docs/services/apigatewayv2/sim-apigatewayv2-throttling.example.ts
@@ -1,0 +1,112 @@
+/**
+ * Throttling a simulated HTTP API stage and one of its routes.
+ */
+
+import {
+  CreateApiCommand,
+  CreateIntegrationCommand,
+  CreateRouteCommand,
+  CreateStageCommand,
+} from "@aws-sdk/client-apigatewayv2";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+const { FunctionArn } = await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "users",
+    Role: "arn:aws:iam::111111111111:role/UsersRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput(() => ({
+        statusCode: 200,
+        headers: { "content-type": "text/plain" },
+        body: "ok",
+      })),
+    },
+  }),
+);
+
+const apiGateway = simAws.apiGatewayV2();
+
+const { ApiId, ApiEndpoint } = await apiGateway.createApi(
+  new CreateApiCommand({ Name: "users", ProtocolType: "HTTP" }),
+);
+
+const { IntegrationId } = await apiGateway.createIntegration(
+  new CreateIntegrationCommand({
+    ApiId,
+    IntegrationType: "AWS_PROXY",
+    IntegrationUri: FunctionArn,
+    PayloadFormatVersion: "2.0",
+  }),
+);
+
+for (const RouteKey of ["POST /user/password-reset", "GET /user/profile"]) {
+  await apiGateway.createRoute(
+    new CreateRouteCommand({
+      ApiId,
+      RouteKey,
+      Target: `integrations/${IntegrationId}`,
+    }),
+  );
+}
+
+await apiGateway.createStage(
+  new CreateStageCommand({
+    ApiId,
+    StageName: "$default",
+    AutoDeploy: true,
+    DefaultRouteSettings: { ThrottlingRateLimit: 10, ThrottlingBurstLimit: 5 },
+    RouteSettings: {
+      "POST /user/password-reset": {
+        ThrottlingRateLimit: 1,
+        ThrottlingBurstLimit: 2,
+      },
+    },
+  }),
+);
+
+await simAws.lambda().addPermission(
+  new AddPermissionCommand({
+    FunctionName: "users",
+    StatementId: "api-gateway-invoke",
+    Action: "lambda:InvokeFunction",
+    Principal: "apigateway.amazonaws.com",
+    SourceArn: `arn:aws:execute-api:us-east-1:888888888888:${ApiId}/*/*`,
+  }),
+);
+
+const srv = await serveSimAws({ simAws });
+
+// Stop simulated time. A bucket now refills only when this example moves it.
+simAws.clock().freeze();
+
+const passwordReset = async (): Promise<Response> =>
+  await fetch(srv.localUrl(`${ApiEndpoint}/user/password-reset`), {
+    method: "POST",
+  });
+
+const first = await passwordReset();
+const second = await passwordReset();
+const third = await passwordReset();
+
+console.log(first.status, second.status, third.status);
+console.log(await third.text());
+
+// Another route, drawing on the stage default and a bucket of its own.
+const profile = await fetch(srv.localUrl(`${ApiEndpoint}/user/profile`));
+console.log(profile.status);
+
+// One second at a rate limit of one is one token back.
+await simAws.clock().advanceBy({ seconds: 1 });
+const afterASecond = await passwordReset();
+console.log(afterASecond.status);
+
+await srv.close();

--- a/src/service/apigatewayv2/api/sim-http-api-lambda-proxy.factory.ts
+++ b/src/service/apigatewayv2/api/sim-http-api-lambda-proxy.factory.ts
@@ -6,6 +6,10 @@ import { simApiGatewayServicePrincipal } from "../../apigateway/sim-api-gateway-
 import { DEFAULT_SIM_AWS_ACCOUNT_ID } from "../../aws/sim-aws-account.js";
 import type { SimAws } from "../../aws/sim-aws.js";
 import { makeLambdaZipFileInput } from "../../lambda/function/code/lambda-zip-file-input.js";
+import type {
+  SimHttpApiRouteSettings,
+  SimHttpApiRouteSettingsMap,
+} from "./stage/settings/sim-http-api-route-settings.type.js";
 import type { SimHttpApi } from "./sim-http-api.js";
 import {
   simHttpApiProxyAuthorization,
@@ -51,6 +55,10 @@ export interface SimHttpApiLambdaProxyInput {
   readonly stageNames: readonly string[];
   /** The variables every one of those stages carries. */
   readonly stageVariables: Readonly<Record<string, string>>;
+  /** The throttle every one of those stages applies to any route. */
+  readonly defaultRouteSettings: SimHttpApiRouteSettings | undefined;
+  /** The throttles those stages apply to the route keys they name. */
+  readonly routeSettings: SimHttpApiRouteSettingsMap | undefined;
   /**
    * Whether the function grants the API permission to invoke it, which it
    * needs before any route serves anything.
@@ -103,6 +111,8 @@ export const simHttpApiLambdaProxyFactory = new AsyncMappedFactory<
     authorizationScopes: [],
     stageNames: ["$default"],
     stageVariables: {},
+    defaultRouteSettings: undefined,
+    routeSettings: undefined,
     invokePermission: true,
   }),
   async (input, simAws) => {
@@ -181,6 +191,8 @@ export const simHttpApiLambdaProxyFactory = new AsyncMappedFactory<
             StageName: stageName,
             AutoDeploy: true,
             StageVariables: input.stageVariables,
+            DefaultRouteSettings: input.defaultRouteSettings,
+            RouteSettings: input.routeSettings,
           },
         }),
       ),

--- a/src/service/apigatewayv2/api/stage/settings/sim-http-api-route-settings.type.ts
+++ b/src/service/apigatewayv2/api/stage/settings/sim-http-api-route-settings.type.ts
@@ -1,0 +1,27 @@
+/**
+ * The throttling half of one route's settings, which is what a stage's
+ * `DefaultRouteSettings` and each entry of its `RouteSettings` carry.
+ *
+ * `ThrottlingRateLimit` is requests per second and `ThrottlingBurstLimit` is
+ * how many requests the route may take at once. The members that say nothing
+ * about throttling are not simulated. They are left out of this type too.
+ */
+export interface SimHttpApiRouteSettings {
+  readonly ThrottlingRateLimit?: number | undefined;
+  readonly ThrottlingBurstLimit?: number | undefined;
+}
+
+/**
+ * A stage's `RouteSettings`, keyed by the route key each entry applies to.
+ */
+export type SimHttpApiRouteSettingsMap = Readonly<
+  Record<string, SimHttpApiRouteSettings>
+>;
+
+/**
+ * What a stage reports of the route settings it was created with.
+ */
+export interface SimHttpApiRouteSettingsView {
+  DefaultRouteSettings?: SimHttpApiRouteSettings;
+  RouteSettings?: SimHttpApiRouteSettingsMap;
+}

--- a/src/service/apigatewayv2/api/stage/settings/sim-http-api-stage-route-settings.ts
+++ b/src/service/apigatewayv2/api/stage/settings/sim-http-api-stage-route-settings.ts
@@ -1,0 +1,101 @@
+import type { SimClock } from "../../../../../util/clock/sim-clock.js";
+import type {
+  SimHttpApiRouteSettings,
+  SimHttpApiRouteSettingsMap,
+  SimHttpApiRouteSettingsView,
+} from "./sim-http-api-route-settings.type.js";
+import { SimHttpApiTokenBucket } from "./sim-http-api-token-bucket.js";
+
+interface SimHttpApiStageRouteSettingsProperties {
+  readonly clock: SimClock;
+  readonly defaultRouteSettings?: SimHttpApiRouteSettings | undefined;
+  readonly routeSettings?: SimHttpApiRouteSettingsMap | undefined;
+}
+
+/**
+ * The route settings one stage was created with, and the token buckets its
+ * throttle is evaluated from.
+ *
+ * Each route key has a bucket of its own. Two routes falling back to
+ * `DefaultRouteSettings` are throttled apart from each other, and a
+ * `RouteSettings` entry throttles only the route key it names. Every client of
+ * a route draws on that one bucket. A WAF rate-based rule counts each client
+ * separately, which is the other question a stack often asks.
+ *
+ * A route is throttled only where the settings reaching it name both limits.
+ * Naming one alone leaves the other at the account limit on real AWS. Account
+ * limits are outside this simulation, and a route configured that way serves
+ * unthrottled.
+ */
+export class SimHttpApiStageRouteSettings {
+  readonly #clock: SimClock;
+  readonly #defaultRouteSettings?: SimHttpApiRouteSettings | undefined;
+  readonly #routeSettings: ReadonlyMap<string, SimHttpApiRouteSettings>;
+  readonly #buckets = new Map<string, SimHttpApiTokenBucket | undefined>();
+
+  constructor(properties: SimHttpApiStageRouteSettingsProperties) {
+    this.#clock = properties.clock;
+    this.#defaultRouteSettings = properties.defaultRouteSettings;
+    this.#routeSettings = new Map(
+      Object.entries(properties.routeSettings ?? {}),
+    );
+  }
+
+  /**
+   * Take one token for a request to a route key, and answer whether the
+   * route's throttle had one to give.
+   *
+   * A route key nothing throttles is always admitted, and takes nothing.
+   */
+  admits(routeKey: string): boolean {
+    const bucket = this.#bucketFor(routeKey);
+
+    return bucket === undefined || bucket.take();
+  }
+
+  /**
+   * What CreateStage and GetStages report of these settings.
+   */
+  view(): SimHttpApiRouteSettingsView {
+    const view: SimHttpApiRouteSettingsView = {};
+
+    if (this.#defaultRouteSettings !== undefined) {
+      view.DefaultRouteSettings = { ...this.#defaultRouteSettings };
+    }
+
+    if (this.#routeSettings.size > 0) {
+      view.RouteSettings = Object.fromEntries(this.#routeSettings);
+    }
+
+    return view;
+  }
+
+  /**
+   * The bucket a route key draws on, made the first time the route is asked
+   * about so that it starts full at the request that found it.
+   */
+  #bucketFor(routeKey: string): SimHttpApiTokenBucket | undefined {
+    if (!this.#buckets.has(routeKey)) {
+      this.#buckets.set(routeKey, this.#newBucket(routeKey));
+    }
+
+    return this.#buckets.get(routeKey);
+  }
+
+  #newBucket(routeKey: string): SimHttpApiTokenBucket | undefined {
+    const settings =
+      this.#routeSettings.get(routeKey) ?? this.#defaultRouteSettings;
+    const rateLimit = settings?.ThrottlingRateLimit;
+    const burstLimit = settings?.ThrottlingBurstLimit;
+
+    if (rateLimit === undefined || burstLimit === undefined) {
+      return undefined;
+    }
+
+    return new SimHttpApiTokenBucket({
+      clock: this.#clock,
+      rateLimit,
+      burstLimit,
+    });
+  }
+}

--- a/src/service/apigatewayv2/api/stage/settings/sim-http-api-token-bucket.ts
+++ b/src/service/apigatewayv2/api/stage/settings/sim-http-api-token-bucket.ts
@@ -1,0 +1,70 @@
+import type { SimClock } from "../../../../../util/clock/sim-clock.js";
+
+const millisecondsPerSecond = 1000;
+
+interface SimHttpApiTokenBucketProperties {
+  readonly clock: SimClock;
+  /** Tokens added per second, which is `ThrottlingRateLimit`. */
+  readonly rateLimit: number;
+  /** How many tokens the bucket holds, which is `ThrottlingBurstLimit`. */
+  readonly burstLimit: number;
+}
+
+/**
+ * The token bucket one throttled route is served from.
+ *
+ * The bucket starts full. A route whose burst is five serves five requests
+ * before the rate matters. Each request takes a token, and tokens come back at
+ * the rate limit, up to the burst limit.
+ *
+ * Refilling is a function of the simulated clock. A frozen clock holds the
+ * bucket where it is, and a test moves the clock to fill it. Every client of
+ * the route draws on this one bucket.
+ */
+export class SimHttpApiTokenBucket {
+  readonly #clock: SimClock;
+  readonly #rateLimit: number;
+  readonly #burstLimit: number;
+  #tokens: number;
+  #filledAt: number;
+
+  constructor(properties: SimHttpApiTokenBucketProperties) {
+    this.#clock = properties.clock;
+    this.#rateLimit = properties.rateLimit;
+    this.#burstLimit = properties.burstLimit;
+    this.#tokens = properties.burstLimit;
+    this.#filledAt = properties.clock.now().getTime();
+  }
+
+  /**
+   * Take one token for a request, and answer whether there was one to take.
+   */
+  take(): boolean {
+    this.#refill();
+
+    if (this.#tokens < 1) {
+      return false;
+    }
+
+    this.#tokens -= 1;
+
+    return true;
+  }
+
+  /**
+   * Add whatever has accrued since the bucket was last read.
+   *
+   * A clock that has gone backwards, which a test setting an earlier instant
+   * can do, adds nothing rather than taking tokens away.
+   */
+  #refill(): void {
+    const now = this.#clock.now().getTime();
+    const elapsed = Math.max(0, now - this.#filledAt) / millisecondsPerSecond;
+
+    this.#filledAt = now;
+    this.#tokens = Math.min(
+      this.#burstLimit,
+      this.#tokens + elapsed * this.#rateLimit,
+    );
+  }
+}

--- a/src/service/apigatewayv2/api/stage/sim-http-api-stage.ts
+++ b/src/service/apigatewayv2/api/stage/sim-http-api-stage.ts
@@ -1,3 +1,6 @@
+import type { SimHttpApiRouteSettingsView } from "./settings/sim-http-api-route-settings.type.js";
+import type { SimHttpApiStageRouteSettings } from "./settings/sim-http-api-stage-route-settings.js";
+
 /**
  * The default stage, which is served at the root of the API endpoint rather
  * than under a stage-name path segment. It is the only stage simulated so far.
@@ -10,12 +13,13 @@ interface SimHttpApiStageProperties {
   readonly stageVariables?: Readonly<Record<string, string>> | undefined;
   readonly description?: string | undefined;
   readonly createdDate: Date;
+  readonly routeSettings?: SimHttpApiStageRouteSettings | undefined;
 }
 
 /**
  * Minimal structural stage view, as the Create and Get commands return.
  */
-export interface SimHttpApiStageView {
+export interface SimHttpApiStageView extends SimHttpApiRouteSettingsView {
   StageName: string;
   AutoDeploy: boolean;
   CreatedDate: Date;
@@ -37,12 +41,29 @@ export class SimHttpApiStage {
   public readonly description?: string | undefined;
   public readonly createdDate: Date;
 
+  /**
+   * The throttle this stage serves its routes at, or undefined for a stage
+   * that was given no route settings and so throttles nothing.
+   */
+  public readonly routeSettings?: SimHttpApiStageRouteSettings | undefined;
+
   constructor(properties: SimHttpApiStageProperties) {
     this.stageName = properties.stageName;
     this.autoDeploy = properties.autoDeploy;
     this.stageVariables = properties.stageVariables ?? {};
     this.description = properties.description;
     this.createdDate = properties.createdDate;
+    this.routeSettings = properties.routeSettings;
+  }
+
+  /**
+   * Whether this stage's throttle serves one more request to a route key now.
+   *
+   * Asking takes a token. A request that is admitted has already paid for
+   * itself, and a refused one has taken nothing.
+   */
+  admits(routeKey: string): boolean {
+    return this.routeSettings?.admits(routeKey) ?? true;
   }
 
   /**
@@ -56,6 +77,7 @@ export class SimHttpApiStage {
       StageName: this.stageName,
       AutoDeploy: this.autoDeploy,
       CreatedDate: new Date(this.createdDate),
+      ...this.routeSettings?.view(),
     };
 
     if (Object.keys(this.stageVariables).length > 0) {

--- a/src/service/apigatewayv2/cfn/sim-cfn-http-api-deploy.iso.test.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-http-api-deploy.iso.test.ts
@@ -213,4 +213,48 @@ describe("API Gateway v2 CloudFormation deployment", () => {
     assertIdentical(response.status, 200);
     assertIdentical(await response.text(), "GET /orders {}");
   });
+
+  it("throttles a deployed stage's route at the limits it declares", async () => {
+    // Given a template whose stage throttles one route harder than the rest
+    const simAws = simAwsInEuWest2();
+    const stack = await deployHttpApi(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        handlerSource: routeReportingHandler,
+        routeKeys: ["GET /orders", "POST /orders"],
+        stageProperties: {
+          DefaultRouteSettings: {
+            ThrottlingRateLimit: 10,
+            ThrottlingBurstLimit: 5,
+          },
+          RouteSettings: {
+            "POST /orders": {
+              ThrottlingRateLimit: 1,
+              ThrottlingBurstLimit: 1,
+            },
+          },
+        },
+      }),
+    );
+
+    // When the throttled route is used twice over
+    const apiEndpoint = stack.outputs.get("ApiEndpoint")?.value;
+    assertTypeString(apiEndpoint);
+    simAws.clock().freeze();
+    const http = new SimAwsHttp({ simAws });
+    const served = await http.fetch(localUrl(apiEndpoint, "/orders"), {
+      method: "POST",
+    });
+    const refused = await http.fetch(localUrl(apiEndpoint, "/orders"), {
+      method: "POST",
+    });
+
+    // Then the deployed limits are the ones the stage serves at, and the route
+    // on the stage default is untouched by the other route's burst
+    assertIdentical(served.status, 200);
+    assertIdentical(refused.status, 429);
+
+    const other = await http.fetch(localUrl(apiEndpoint, "/orders"));
+    assertIdentical(other.status, 200);
+  });
 });

--- a/src/service/apigatewayv2/cfn/sim-cfn-http-api-validation.iso.test.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-http-api-validation.iso.test.ts
@@ -1,5 +1,6 @@
 import {
   assertFalse,
+  assertIdentical,
   assertNonNullable,
   assertStringIncludes,
   assertTrue,
@@ -161,7 +162,7 @@ describe("API Gateway v2 CloudFormation validation", () => {
   });
 
   it("creates a stage without a property outside the simulated set", async () => {
-    // Given a stage asking for throttling settings
+    // Given a stage asking for access logging
     const simAws = simAwsInEuWest2();
 
     // When the template is deployed
@@ -169,12 +170,12 @@ describe("API Gateway v2 CloudFormation validation", () => {
       simAws,
       simCfnHttpApiTemplateFactory.make({
         stageProperties: {
-          DefaultRouteSettings: { ThrottlingBurstLimit: 10 },
+          AccessLogSettings: { Format: "$context.requestId" },
         },
       }),
     );
 
-    // Then the stage is created throttling nothing, and the record names the
+    // Then the stage is created logging nothing, and the record names the
     // Resource type, the logical ID, the property and what is simulated
     assertTrue(stack.getResource("Stage")?.deployed);
 
@@ -183,13 +184,45 @@ describe("API Gateway v2 CloudFormation validation", () => {
     assertStringIncludes(reason, "Stage");
     assertStringIncludes(
       reason,
-      "AWS::ApiGatewayV2::Stage property DefaultRouteSettings is not " +
-        "simulated",
+      "AWS::ApiGatewayV2::Stage property AccessLogSettings is not simulated",
     );
     assertStringIncludes(
       reason,
       "The simulated properties are ApiId, StageName, AutoDeploy, " +
-        "StageVariables, Description.",
+        "StageVariables, Description, DefaultRouteSettings, RouteSettings.",
+    );
+  });
+
+  it("creates a stage without a route setting outside throttling", async () => {
+    // Given a stage throttling a route and asking to log it as well
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const stack = await deployHttpApi(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        stageProperties: {
+          RouteSettings: {
+            "GET /orders": {
+              ThrottlingRateLimit: 10,
+              ThrottlingBurstLimit: 5,
+              LoggingLevel: "INFO",
+            },
+          },
+        },
+      }),
+    );
+
+    // Then the throttle is deployed and only the logging is recorded, named by
+    // the entry of the template it was written on
+    assertTrue(stack.getResource("Stage")?.deployed);
+
+    const [ignored] = stack.ignoredProperties;
+    assertNonNullable(ignored);
+    assertIdentical(ignored.path, "RouteSettings.GET /orders.LoggingLevel");
+    assertStringIncludes(
+      ignored.reason,
+      "AWS::ApiGatewayV2::Stage route setting LoggingLevel is not simulated",
     );
   });
 

--- a/src/service/apigatewayv2/cfn/stage/sim-cfn-http-api-route-settings-properties.ts
+++ b/src/service/apigatewayv2/cfn/stage/sim-cfn-http-api-route-settings-properties.ts
@@ -1,0 +1,122 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type {
+  SimHttpApiRouteSettings,
+  SimHttpApiRouteSettingsMap,
+} from "../../api/stage/settings/sim-http-api-route-settings.type.js";
+import type { SimCfnApiGatewayV2PropertyParser } from "../sim-cfn-api-gateway-v2-property-parser.js";
+
+/**
+ * The route settings members this simulation deploys. The rest are metrics and
+ * logging, and are recorded against the Resource rather than acted on.
+ */
+const simulatedMembers = ["ThrottlingRateLimit", "ThrottlingBurstLimit"];
+
+interface SimCfnHttpApiRouteSettingsPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly propertyParser: SimCfnApiGatewayV2PropertyParser;
+}
+
+/**
+ * Reads the route settings of an AWS::ApiGatewayV2::Stage.
+ *
+ * `DefaultRouteSettings` is one of these and `RouteSettings` is a map of them
+ * keyed by route key. A member outside the throttling pair is recorded by the
+ * path it was written at. The stage still deploys, and the record says which
+ * entry of the template it deployed without.
+ */
+export class SimCfnHttpApiRouteSettingsProperties {
+  readonly #resource: SimCfnResource;
+  readonly #propertyParser: SimCfnApiGatewayV2PropertyParser;
+
+  constructor(properties: SimCfnHttpApiRouteSettingsPropertiesProperties) {
+    this.#resource = properties.resource;
+    this.#propertyParser = properties.propertyParser;
+  }
+
+  /**
+   * Read one route settings object, such as `DefaultRouteSettings`.
+   */
+  settings(
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): SimHttpApiRouteSettings | undefined {
+    const record = this.#propertyParser.optionalRecord(
+      this.#resource,
+      value,
+      label,
+    );
+
+    if (record === undefined) {
+      return undefined;
+    }
+
+    this.#recordUnsimulated(record, label);
+
+    const rate = this.#limit(record["ThrottlingRateLimit"], label, "Rate");
+    const burst = this.#limit(record["ThrottlingBurstLimit"], label, "Burst");
+
+    // A limit the template left out is left out here too. A stage reports the
+    // settings it was written with.
+    return {
+      ...(rate !== undefined && { ThrottlingRateLimit: rate }),
+      ...(burst !== undefined && { ThrottlingBurstLimit: burst }),
+    };
+  }
+
+  /**
+   * Read the `RouteSettings` map, keyed by the route key each entry throttles.
+   */
+  settingsMap(
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): SimHttpApiRouteSettingsMap | undefined {
+    const record = this.#propertyParser.optionalRecord(
+      this.#resource,
+      value,
+      label,
+    );
+
+    if (record === undefined) {
+      return undefined;
+    }
+
+    return Object.fromEntries(
+      Object.entries(record).map(([routeKey, settings]) => [
+        routeKey,
+        this.settings(settings, `${label}.${routeKey}`) ?? {},
+      ]),
+    );
+  }
+
+  #limit(
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+    limit: string,
+  ): number | undefined {
+    return this.#propertyParser.optionalNumber(
+      this.#resource,
+      value,
+      `${label}.Throttling${limit}Limit`,
+    );
+  }
+
+  #recordUnsimulated(
+    record: Readonly<Record<string, SimCfnTemplateValue>>,
+    label: string,
+  ): void {
+    for (const member of Object.keys(record)) {
+      if (simulatedMembers.includes(member)) {
+        continue;
+      }
+
+      this.#resource.ignoreProperty(
+        `${label}.${member}`,
+        `AWS::ApiGatewayV2::Stage route setting ${member} is not simulated, ` +
+          `so the stage is created without it and behaves differently here ` +
+          `than on AWS. The simulated route settings are ` +
+          `${simulatedMembers.join(", ")}.`,
+      );
+    }
+  }
+}

--- a/src/service/apigatewayv2/cfn/stage/sim-cfn-http-api-stage-properties.ts
+++ b/src/service/apigatewayv2/cfn/stage/sim-cfn-http-api-stage-properties.ts
@@ -2,14 +2,15 @@ import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-re
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimCreateStageCommandInput } from "../../command/stage/stage.command.js";
 import { SimCfnApiGatewayV2PropertyParser } from "../sim-cfn-api-gateway-v2-property-parser.js";
+import { SimCfnHttpApiRouteSettingsProperties } from "./sim-cfn-http-api-route-settings-properties.js";
 
 /**
  * The AWS::ApiGatewayV2::Stage properties this simulation deploys.
  *
- * `DeploymentId`, `AccessLogSettings`, `RouteSettings`, `DefaultRouteSettings`
- * and `Tags` are left out, so a template carrying one is refused by name. None
- * of them is modelled, and a stage that looked throttled or logged to the
- * template and did neither when serving is the failure worth avoiding.
+ * `DeploymentId`, `AccessLogSettings` and `Tags` are left out, so a template
+ * carrying one is recorded and the stage is created without it. None of them
+ * is modelled, and a stage that looked logged to the template and logged
+ * nothing when serving is the failure worth recording.
  */
 const simulatedProperties = [
   "ApiId",
@@ -17,6 +18,8 @@ const simulatedProperties = [
   "AutoDeploy",
   "StageVariables",
   "Description",
+  "DefaultRouteSettings",
+  "RouteSettings",
 ];
 
 interface SimCfnHttpApiStagePropertiesProperties {
@@ -36,9 +39,15 @@ export class SimCfnHttpApiStageProperties {
     simulated: simulatedProperties,
   });
 
+  private readonly routeSettingsParser: SimCfnHttpApiRouteSettingsProperties;
+
   constructor(properties: SimCfnHttpApiStagePropertiesProperties) {
     this.resource = properties.resource;
     this.properties = properties.properties;
+    this.routeSettingsParser = new SimCfnHttpApiRouteSettingsProperties({
+      resource: this.resource,
+      propertyParser: this.propertyParser,
+    });
 
     this.propertyParser.ignoreUnsimulated(this.resource, this.properties);
   }
@@ -71,7 +80,8 @@ export class SimCfnHttpApiStageProperties {
    *
    * `AutoDeploy` is passed through as the template wrote it, so a stage that
    * does not deploy itself is refused by CreateStage with the reason it is
-   * refused.
+   * refused. The route settings arrive holding only their throttling members.
+   * The ones CreateStage would refuse never reach it from a template.
    */
   createStageInput(): SimCreateStageCommandInput {
     return {
@@ -91,6 +101,14 @@ export class SimCfnHttpApiStageProperties {
         this.resource,
         this.properties["Description"],
         "Description",
+      ),
+      DefaultRouteSettings: this.routeSettingsParser.settings(
+        this.properties["DefaultRouteSettings"],
+        "DefaultRouteSettings",
+      ),
+      RouteSettings: this.routeSettingsParser.settingsMap(
+        this.properties["RouteSettings"],
+        "RouteSettings",
       ),
     };
   }

--- a/src/service/apigatewayv2/command/sim-api-gateway-v2-unsimulated-input.ts
+++ b/src/service/apigatewayv2/command/sim-api-gateway-v2-unsimulated-input.ts
@@ -19,16 +19,25 @@ export class SimApiGatewayV2UnsimulatedInput {
 
   /**
    * Refuse every supplied input that is not one of the accepted options.
+   *
+   * An option nested inside another, such as one member of a stage's
+   * `DefaultRouteSettings`, is refused by the same accepted set. `within` names
+   * the path it was written at, and the message then points at the member the
+   * caller wrote.
    */
-  refuseUnaccepted(input: object, accepted: readonly string[]): void {
+  refuseUnaccepted(
+    input: object,
+    accepted: readonly string[],
+    within = "",
+  ): void {
     for (const [option, value] of Object.entries(input)) {
       if (value === undefined || accepted.includes(option)) {
         continue;
       }
 
       throw new SimApiGatewayV2BadRequest(
-        `${this.operation} ${option} is not simulated: it would be ignored ` +
-          `here and applied on real AWS`,
+        `${this.operation} ${within}${option} is not simulated: it would be ` +
+          `ignored here and applied on real AWS`,
       );
     }
   }

--- a/src/service/apigatewayv2/command/stage/sim-http-api-stage-commands.iso.test.ts
+++ b/src/service/apigatewayv2/command/stage/sim-http-api-stage-commands.iso.test.ts
@@ -3,7 +3,7 @@ import {
   CreateStageCommand,
   GetStagesCommand,
 } from "@aws-sdk/client-apigatewayv2";
-import { assertIdentical, assertTrue } from "@kensio/smartass";
+import { assertIdentical, assertTrue, assertUndefined } from "@kensio/smartass";
 import { describe, expect, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
@@ -204,5 +204,99 @@ describe("Sim API Gateway v2 stage commands", () => {
           new CreateStageCommand({ ApiId: apiId, StageName: "$default" }),
         ),
     ).rejects.toThrow(SimApiGatewayV2BadRequest);
+  });
+  it("keeps the route settings a stage was created with", async () => {
+    // Given an API
+    const simAws = new SimAws();
+    const { ApiId: apiId } = await simAws
+      .apiGatewayV2()
+      .createApi(
+        new CreateApiCommand({ Name: "orders", ProtocolType: "HTTP" }),
+      );
+
+    // When a stage is created with a stage default and a route of its own
+    const created = await simAws.apiGatewayV2().createStage(
+      new CreateStageCommand({
+        ApiId: apiId,
+        StageName: "$default",
+        AutoDeploy: true,
+        DefaultRouteSettings: {
+          ThrottlingRateLimit: 10,
+          ThrottlingBurstLimit: 5,
+        },
+        RouteSettings: {
+          "POST /user/password-reset": {
+            ThrottlingRateLimit: 1,
+            ThrottlingBurstLimit: 2,
+          },
+        },
+      }),
+    );
+
+    // Then both are reported back, by the create and by the list
+    expect(created.DefaultRouteSettings).toStrictEqual({
+      ThrottlingRateLimit: 10,
+      ThrottlingBurstLimit: 5,
+    });
+
+    const { Items: items } = await simAws
+      .apiGatewayV2()
+      .getStages(new GetStagesCommand({ ApiId: apiId }));
+    expect(items[0]?.RouteSettings).toStrictEqual({
+      "POST /user/password-reset": {
+        ThrottlingRateLimit: 1,
+        ThrottlingBurstLimit: 2,
+      },
+    });
+  });
+
+  it("reports no route settings for a stage created without any", async () => {
+    // Given an API with a stage that names no limits
+    const simAws = new SimAws();
+    const { ApiId: apiId } = await simAws
+      .apiGatewayV2()
+      .createApi(
+        new CreateApiCommand({ Name: "orders", ProtocolType: "HTTP" }),
+      );
+
+    // When the stage is created
+    const created = await simAws.apiGatewayV2().createStage(
+      new CreateStageCommand({
+        ApiId: apiId,
+        StageName: "$default",
+        AutoDeploy: true,
+      }),
+    );
+
+    // Then neither settings property is reported, as AWS reports none for a
+    // stage that throttles at the account limits
+    assertUndefined(created.DefaultRouteSettings);
+    assertUndefined(created.RouteSettings);
+  });
+
+  it("refuses a route setting that is not about throttling", async () => {
+    // Given an API
+    const simAws = new SimAws();
+    const { ApiId: apiId } = await simAws
+      .apiGatewayV2()
+      .createApi(
+        new CreateApiCommand({ Name: "orders", ProtocolType: "HTTP" }),
+      );
+
+    // When a stage asks for request logging alongside its throttle
+    const stage = new CreateStageCommand({
+      ApiId: apiId,
+      StageName: "$default",
+      AutoDeploy: true,
+      RouteSettings: {
+        "POST /orders": { ThrottlingRateLimit: 1, LoggingLevel: "INFO" },
+      },
+    });
+
+    // Then the member that is not simulated is refused by the path it was
+    // written at, rather than logging nothing while the throttle works
+    await expect(simAws.apiGatewayV2().createStage(stage)).rejects.toThrow(
+      /RouteSettings 'POST \/orders' LoggingLevel is not simulated/,
+    );
   });
 });

--- a/src/service/apigatewayv2/command/stage/sim-http-api-stage-commands.ts
+++ b/src/service/apigatewayv2/command/stage/sim-http-api-stage-commands.ts
@@ -4,6 +4,7 @@ import { SimApiGatewayV2NotFound } from "../../error/sim-api-gateway-v2.error.js
 import type { SimApiGatewayV2RequestOptions } from "../sim-api-gateway-v2-request-options.js";
 import { SimApiGatewayV2UnsimulatedInput } from "../sim-api-gateway-v2-unsimulated-input.js";
 import type { SimHttpApiAccess } from "../sim-http-api-access.js";
+import { simHttpApiStageRouteSettings } from "./sim-http-api-stage-route-settings-input.js";
 import { SimHttpApiStageRules } from "./sim-http-api-stage-rules.js";
 import type {
   SimCreateStageCommand,
@@ -22,6 +23,8 @@ const acceptedCreateStageOptions = [
   "AutoDeploy",
   "StageVariables",
   "Description",
+  "DefaultRouteSettings",
+  "RouteSettings",
 ];
 
 interface SimHttpApiStageCommandsProperties {
@@ -57,6 +60,10 @@ export class SimHttpApiStageCommands {
       unsimulated.require("StageName", input.StageName),
     );
     this.rules.requireAutoDeploy(input.AutoDeploy);
+    const routeSettings = simHttpApiStageRouteSettings(input, {
+      unsimulated,
+      clock: this.clock,
+    });
 
     const httpApi = this.access.api({
       method: "POST",
@@ -72,6 +79,7 @@ export class SimHttpApiStageCommands {
       stageVariables: input.StageVariables,
       description: input.Description,
       createdDate: this.clock.now(),
+      routeSettings,
     });
     httpApi.stages.add(stage);
 

--- a/src/service/apigatewayv2/command/stage/sim-http-api-stage-route-settings-input.ts
+++ b/src/service/apigatewayv2/command/stage/sim-http-api-stage-route-settings-input.ts
@@ -1,0 +1,57 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import { SimHttpApiStageRouteSettings } from "../../api/stage/settings/sim-http-api-stage-route-settings.js";
+import type { SimApiGatewayV2UnsimulatedInput } from "../sim-api-gateway-v2-unsimulated-input.js";
+import type { SimCreateStageCommandInput } from "./stage.command.js";
+
+/**
+ * The route settings members this simulation acts on. `DetailedMetricsEnabled`,
+ * `LoggingLevel` and `DataTraceEnabled` are metrics and logging rather than
+ * throttling, and nothing here reads any of them.
+ */
+const acceptedRouteSettings = ["ThrottlingRateLimit", "ThrottlingBurstLimit"];
+
+interface SimHttpApiStageRouteSettingsInputProperties {
+  readonly unsimulated: SimApiGatewayV2UnsimulatedInput;
+  readonly clock: SimClock;
+}
+
+/**
+ * Reads the throttling a CreateStage input asks for.
+ *
+ * Both `DefaultRouteSettings` and every entry of `RouteSettings` are checked
+ * member by member. A stage asking for logging is refused by the member that
+ * asks for it.
+ */
+export function simHttpApiStageRouteSettings(
+  input: SimCreateStageCommandInput,
+  properties: SimHttpApiStageRouteSettingsInputProperties,
+): SimHttpApiStageRouteSettings | undefined {
+  const { DefaultRouteSettings: defaults, RouteSettings: byRouteKey } = input;
+  const { unsimulated } = properties;
+
+  unsimulated.refuseUnaccepted(
+    defaults ?? {},
+    acceptedRouteSettings,
+    "DefaultRouteSettings.",
+  );
+
+  const perRoute = Object.entries(byRouteKey ?? {});
+
+  for (const [routeKey, settings] of perRoute) {
+    unsimulated.refuseUnaccepted(
+      settings,
+      acceptedRouteSettings,
+      `RouteSettings '${routeKey}' `,
+    );
+  }
+
+  if (defaults === undefined && byRouteKey === undefined) {
+    return undefined;
+  }
+
+  return new SimHttpApiStageRouteSettings({
+    clock: properties.clock,
+    defaultRouteSettings: defaults,
+    routeSettings: byRouteKey,
+  });
+}

--- a/src/service/apigatewayv2/command/stage/stage.command.ts
+++ b/src/service/apigatewayv2/command/stage/stage.command.ts
@@ -1,4 +1,8 @@
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type {
+  SimHttpApiRouteSettings,
+  SimHttpApiRouteSettingsMap,
+} from "../../api/stage/settings/sim-http-api-route-settings.type.js";
 import type { SimHttpApiStageView } from "../../api/stage/sim-http-api-stage.js";
 
 /**
@@ -16,6 +20,8 @@ export interface SimCreateStageCommandInput {
   readonly AutoDeploy?: boolean | undefined;
   readonly StageVariables?: Readonly<Record<string, string>> | undefined;
   readonly Description?: string | undefined;
+  readonly DefaultRouteSettings?: SimHttpApiRouteSettings | undefined;
+  readonly RouteSettings?: SimHttpApiRouteSettingsMap | undefined;
 }
 
 export interface SimCreateStageCommandOutput extends SimHttpApiStageView {

--- a/src/service/apigatewayv2/index.ts
+++ b/src/service/apigatewayv2/index.ts
@@ -80,6 +80,13 @@ export {
   SimHttpApiStage,
   type SimHttpApiStageView,
 } from "./api/stage/sim-http-api-stage.js";
+export type {
+  SimHttpApiRouteSettings,
+  SimHttpApiRouteSettingsMap,
+  SimHttpApiRouteSettingsView,
+} from "./api/stage/settings/sim-http-api-route-settings.type.js";
+export { SimHttpApiStageRouteSettings } from "./api/stage/settings/sim-http-api-stage-route-settings.js";
+export { SimHttpApiTokenBucket } from "./api/stage/settings/sim-http-api-token-bucket.js";
 export {
   SimApiGatewayV2BadRequest,
   SimApiGatewayV2Conflict,

--- a/src/service/apigatewayv2/serve/sim-api-gateway-v2-controller.ts
+++ b/src/service/apigatewayv2/serve/sim-api-gateway-v2-controller.ts
@@ -24,7 +24,10 @@ interface SimApiGatewayV2ServiceControllerProperties {
  * format 2.0 event. The function runs as its execution Role, as it does for
  * any other invocation.
  *
- * A route that authorizes anybody is checked before any of that: a JWT route's
+ * The stage's throttle comes before any of that. A route whose bucket is empty
+ * is answered 429, and neither its authorizer nor its integration runs.
+ *
+ * A route that authorizes anybody is checked next: a JWT route's
  * token has to verify and meet the route's scopes, an `AWS_IAM` route's caller
  * has to be allowed `execute-api:Invoke` on the route, and a `CUSTOM` route's
  * Lambda authorizer has to allow the request, or the request is refused and the
@@ -91,7 +94,14 @@ export class SimApiGatewayV2ServiceController implements SimAwsServiceController
       return this.errorResponse.notFound();
     }
 
-    // The client's own authorization comes first: a request with no
+    // The stage's throttle is asked before the route's authorizer. A flood of
+    // requests to a throttled route invokes neither. AWS publishes no order
+    // between the two.
+    if (!match.stage.admits(match.route.routeKey)) {
+      return this.errorResponse.tooManyRequests();
+    }
+
+    // The client's own authorization comes next: a request with no
     // credentials is refused whether or not the integration behind the route
     // would work.
     const authorization = await this.routeAuthorizer.authorize({

--- a/src/service/apigatewayv2/serve/sim-api-gateway-v2-error-response.ts
+++ b/src/service/apigatewayv2/serve/sim-api-gateway-v2-error-response.ts
@@ -46,6 +46,17 @@ export class SimApiGatewayV2ErrorResponse {
   }
 
   /**
+   * The route's throttle had no token left for the request.
+   *
+   * The stage's `DefaultRouteSettings` and `RouteSettings` set the rate and
+   * the burst each route is served at, and every client of a route draws on
+   * the one bucket. A client can be refused over traffic it did not send.
+   */
+  tooManyRequests(): Response {
+    return this.jsonResponse(429, "Too Many Requests");
+  }
+
+  /**
    * The integration failed to handle the request.
    */
   internalServerError(): Response {

--- a/src/service/apigatewayv2/serve/sim-http-api-throttling.iso.test.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-throttling.iso.test.ts
@@ -1,0 +1,192 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simHttpApiLambdaProxyFactory } from "../api/sim-http-api-lambda-proxy.factory.js";
+import type { SimHttpApiRouteSettingsMap } from "../api/stage/settings/sim-http-api-route-settings.type.js";
+import type { SimHttpApi } from "../api/sim-http-api.js";
+
+/** The route a stage throttles harder than the rest of its API. */
+const passwordReset = "POST /user/password-reset";
+
+/** The route the rest of the API's traffic goes to. */
+const profile = "GET /user/profile";
+
+/** The two routes every API here serves. */
+const routeKeys = [passwordReset, profile];
+
+/** A `RouteSettings` naming the password reset route and nothing else. */
+const perRoute: SimHttpApiRouteSettingsMap = {
+  [passwordReset]: { ThrottlingRateLimit: 1, ThrottlingBurstLimit: 2 },
+};
+
+/**
+ * Send one request to a route of an API, as a named client.
+ *
+ * The throttle reads nothing about the client, and the header is here so a
+ * test can say which client sent what. A stage bucket is shared, and who sent
+ * a request makes no difference to whether it is served.
+ */
+async function request(
+  simAws: SimAws,
+  api: SimHttpApi,
+  routeKey: string,
+  client = "one",
+): Promise<Response> {
+  const [method = "GET", path = "/"] = routeKey.split(" ", 2);
+
+  return await new SimAwsHttp({ simAws }).fetch(
+    new SimAwsLocalUrl({ input: `${api.apiEndpoint}${path}` }).toString(),
+    { method, headers: { "x-client": client } },
+  );
+}
+
+/**
+ * An API whose stage throttles, with the clock stopped so only what a test
+ * asks for moves it.
+ */
+async function throttledApi(
+  simAws: SimAws,
+  input: Parameters<typeof simHttpApiLambdaProxyFactory.make>[0],
+): Promise<SimHttpApi> {
+  const api = await simHttpApiLambdaProxyFactory.make(
+    { routeKeys, ...input },
+    simAws,
+  );
+  simAws.clock().freeze();
+
+  return api;
+}
+
+/**
+ * The status one request to a route gets back.
+ */
+async function status(
+  simAws: SimAws,
+  api: SimHttpApi,
+  routeKey: string,
+): Promise<number> {
+  const response = await request(simAws, api, routeKey);
+
+  return response.status;
+}
+
+describe("Throttling a sim HTTP API stage", () => {
+  it("answers a request past the route's burst with 429", async () => {
+    // Given a stage allowing two password resets at once and one a second
+    const simAws = new SimAws();
+    const api = await throttledApi(simAws, { routeSettings: perRoute });
+
+    // When three arrive with no time between them
+    const responses = [
+      await request(simAws, api, passwordReset),
+      await request(simAws, api, passwordReset),
+      await request(simAws, api, passwordReset),
+    ];
+
+    // Then the burst is served and the request past it is refused, with the
+    // lower-case message an HTTP API answers throttled requests with
+    expect(responses.map((response) => response.status)).toStrictEqual([
+      200, 200, 429,
+    ]);
+    expect(await responses[2]?.json()).toStrictEqual({
+      message: "Too Many Requests",
+    });
+  });
+
+  it("refills the bucket as the simulated clock moves on", async () => {
+    // Given a route that has run out of tokens
+    const simAws = new SimAws();
+    const api = await throttledApi(simAws, { routeSettings: perRoute });
+    await request(simAws, api, passwordReset);
+    await request(simAws, api, passwordReset);
+    assertIdentical(await status(simAws, api, passwordReset), 429);
+
+    // When a second passes, which is one token at the route's rate limit
+    await simAws.clock().advanceBy({ seconds: 1 });
+
+    // Then the next request is served, and the one after it is not, because
+    // the second refilled one token rather than the whole burst
+    assertIdentical(await status(simAws, api, passwordReset), 200);
+    assertIdentical(await status(simAws, api, passwordReset), 429);
+  });
+
+  it("gives a route named in RouteSettings the limit it names", async () => {
+    // Given a stage whose default is generous and whose password reset route
+    // is not
+    const simAws = new SimAws();
+    const api = await throttledApi(simAws, {
+      defaultRouteSettings: {
+        ThrottlingRateLimit: 10,
+        ThrottlingBurstLimit: 5,
+      },
+      routeSettings: perRoute,
+    });
+
+    // When the password reset route is used past its own burst
+    await request(simAws, api, passwordReset);
+    await request(simAws, api, passwordReset);
+    const refused = await request(simAws, api, passwordReset);
+
+    // Then it is refused by the entry that names it, while the route drawing
+    // on the stage default is served from a bucket of its own
+    assertIdentical(refused.status, 429);
+    assertIdentical(await status(simAws, api, profile), 200);
+  });
+
+  it("throttles a route on the stage default when nothing names it", async () => {
+    // Given a stage default of one request at a time and no entry for any
+    // route
+    const simAws = new SimAws();
+    const api = await throttledApi(simAws, {
+      defaultRouteSettings: { ThrottlingRateLimit: 1, ThrottlingBurstLimit: 1 },
+    });
+
+    // When one route is used twice
+    const served = await request(simAws, api, profile);
+    const refused = await request(simAws, api, profile);
+
+    // Then the second is refused on the stage default
+    assertIdentical(served.status, 200);
+    assertIdentical(refused.status, 429);
+  });
+
+  it("counts every client against the one bucket", async () => {
+    // Given a stage allowing two password resets at once
+    const simAws = new SimAws();
+    const api = await throttledApi(simAws, { routeSettings: perRoute });
+
+    // When two clients send one each, and then one of them sends another
+    const first = await request(simAws, api, passwordReset, "one");
+    const second = await request(simAws, api, passwordReset, "two");
+    const third = await request(simAws, api, passwordReset, "two");
+
+    // Then the third is refused, because a stage throttle is one bucket for
+    // the route rather than one per client, which is what a WAF rate-based
+    // rule counts instead
+    expect([first.status, second.status, third.status]).toStrictEqual([
+      200, 200, 429,
+    ]);
+  });
+
+  it("serves everything when the stage names no limits", async () => {
+    // Given a stage created without route settings
+    const simAws = new SimAws();
+    const api = await throttledApi(simAws, {});
+
+    // When the same route is used many times over
+    const responses = await Promise.all(
+      Array.from({ length: 20 }, async () =>
+        request(simAws, api, passwordReset),
+      ),
+    );
+
+    // Then nothing is throttled, as nothing was throttled before a stage could
+    // ask for it
+    expect(responses.map((response) => response.status)).toStrictEqual(
+      Array.from({ length: 20 }, () => 200),
+    );
+  });
+});


### PR DESCRIPTION
A simulated HTTP API stage now holds a token bucket for each route it serves. `DefaultRouteSettings`
sets the rate and burst every route starts with, and a `RouteSettings` entry keyed by route key
overrides them for the route it names. A request finding an empty bucket is answered 429 with the
lower-case `message` body an HTTP API sends, and neither the route's authorizer nor its integration
runs. The buckets refill against the simulated clock, and a test can spend a burst, assert the
refusal and then move a second on. Every client of a route draws on the one bucket, which is what
separates a stage throttle from the WAFv2 `RateBasedStatement` already simulated. `CreateStage`
takes both properties, `GetStages` answers with what it was given, `AWS::ApiGatewayV2::Stage`
deploys both, and the three members of `RouteSettings` that say nothing about throttling are
refused by `CreateStage` and recorded on `stack.ignoredProperties` by a template.

Resolves #945