### PR TITLE
fix: run a Lambda with the AWS runtime variables

### DIFF
--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -2600,14 +2600,15 @@ pass because your shell or CI environment had the right variable set. Two functi
 same variable name with different values each see their own, including when their invocations
 overlap.
 
-A function that declares none is the exception, and keeps reading the test process's environment
-with the AWS-provided variables laid over it. That is where the configuration of an in-process
-handler comes from when nothing declares it. Declaring the variables on the function keeps the test
-explicit about where they came from.
-
 The same applies to zip-packaged code in the vm runtime and to functions deployed from an
 `AWS::Lambda::Function` template with an `Environment` property, including ones backed by an
 [executable binding](#executable-bindings).
+
+A function backed by a real in-process handler and declaring no variables at all is the exception.
+It keeps reading the test process's environment, with the AWS-provided variables laid over it, since
+that is where such a handler's configuration comes from when nothing declares it. Declaring the
+variables on the function keeps the test explicit about where they came from. Zip-packaged code in
+the vm runtime gets the function's own variables either way, and never the test process's.
 
 This is also how a function reaches something outside the simulation, such as a Redis or a
 Postgres. See [non-AWS dependencies](../../non-aws-dependencies/README.md).

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -2594,10 +2594,16 @@ if (invokeOutput.Payload === undefined) throw new Error("No invoke Payload");
 console.log(Buffer.from(invokeOutput.Payload).toString());
 ```
 
-Each function gets only the variables it declares. Variables that happen to be set in the process
-running your tests stay invisible to it, and a function cannot accidentally pass because your
-shell or CI environment had the right variable set. Two functions declaring the same variable name
-with different values each see their own, including when their invocations overlap.
+A function that declares variables gets only those and the AWS-provided ones. Variables that happen
+to be set in the process running your tests stay invisible to it, and a function cannot accidentally
+pass because your shell or CI environment had the right variable set. Two functions declaring the
+same variable name with different values each see their own, including when their invocations
+overlap.
+
+A function that declares none is the exception, and keeps reading the test process's environment
+with the AWS-provided variables laid over it. That is where the configuration of an in-process
+handler comes from when nothing declares it. Declaring the variables on the function keeps the test
+explicit about where they came from.
 
 The same applies to zip-packaged code in the vm runtime and to functions deployed from an
 `AWS::Lambda::Function` template with an `Environment` property, including ones backed by an

--- a/src/service/apigatewayv2/serve/sim-http-api-lambda-authorizer.iso.test.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-lambda-authorizer.iso.test.ts
@@ -115,6 +115,32 @@ describe("Authorizing a sim HTTP API route with a Lambda REQUEST authorizer", ()
     });
   });
 
+  it("runs its authorizer with the Lambda runtime environment", async () => {
+    // Given an authorizer reading the variables an AWS SDK client in it
+    // would, and passing them on for the handler to report
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    const api = await protectedApi(simAws, {
+      handler: () => ({
+        isAuthorized: true,
+        context: {
+          region: process.env["AWS_REGION"],
+          functionName: process.env["AWS_LAMBDA_FUNCTION_NAME"],
+        },
+      }),
+    });
+
+    // When the route is called
+    const response = await get(simAws, api, { cookie: goodCookie });
+
+    // Then the authorizer ran with its own function's environment, the way
+    // the integration behind it does
+    assertIdentical(response.status, 200);
+    assertObjectMatches(await response.json(), {
+      region: "eu-west-2",
+      functionName: "session-authorizer",
+    });
+  });
+
   it("refuses a request its authorizer says no to, without invoking the integration", async () => {
     // Given a route behind that authorizer, and a handler counting its runs
     const simAws = new SimAws();

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -248,9 +248,17 @@ current invocation's variables while one is set, and to the untouched host envir
 otherwise. The store follows the invocation across `await` points and keeps concurrent invocations
 apart, which swapping and restoring `process.env` around the handler call could not.
 
+Every invocation of an in-process handler runs with the AWS-provided runtime variables, whatever the
+function declared, because a real Lambda invocation always has them and an AWS SDK client built in
+the handler reads its Region and its credentials from them. A function declaring nothing of its own
+keeps the host process environment underneath them, read per invocation
+(`SimLambdaEnvironment.runVariables`). Taking that away would take away everything the test process
+set, which is where an in-process handler's configuration comes from when the function declares
+none. A function declaring variables runs with only its own, as a deployed one does.
+
 This is the only place the simulator patches a process global, so it is deliberately narrow. The
-patch is only installed when a function, or a simulated ECS container, actually declares variables,
-it is inert whenever no invocation is running, and it is never removed, since removing it would be unsafe while another
+patch is installed on the first invocation that needs it, it is inert whenever no invocation is
+running, and it is never removed, since removing it would be unsafe while another
 invocation is in flight and buys nothing. It lives under `util/` rather than here because simulated
 ECS applies a container's environment variables through the same object: two patches would each
 install a getter, and the second would capture whatever the first was reporting as its host

--- a/src/service/lambda/function/environment/sim-lambda-environment.ts
+++ b/src/service/lambda/function/environment/sim-lambda-environment.ts
@@ -1,4 +1,5 @@
 import { simProcessEnvironment } from "../../../../util/process/sim-process-environment.js";
+import { SimLambdaHostBackedVariables } from "./sim-lambda-host-backed-variables.js";
 import {
   type SimLambdaEnvironmentDetails,
   simLambdaRuntimeVariables,
@@ -19,6 +20,12 @@ interface SimLambdaEnvironmentProperties extends SimLambdaEnvironmentDetails {
 export class SimLambdaEnvironment {
   private readonly details: SimLambdaEnvironmentDetails;
   private readonly declared: ReadonlyMap<string, string>;
+
+  /**
+   * The environment a function declaring nothing of its own runs with, which
+   * keeps the host process environment underneath the AWS-provided variables.
+   */
+  private readonly hostBacked = new SimLambdaHostBackedVariables();
 
   /**
    * The merged variables, built once and then reused.
@@ -93,7 +100,11 @@ export class SimLambdaEnvironment {
    * instead, and is unaffected either way.
    */
   async runWith<T>(run: () => Promise<T>): Promise<T> {
-    return await simProcessEnvironment.run(this.runVariables(), run);
+    if (this.hasDeclaredVariables) {
+      return await simProcessEnvironment.run(this.variables(), run);
+    }
+
+    return await this.hostBacked.runWith(this.variables(), run);
   }
 
   /**
@@ -105,23 +116,5 @@ export class SimLambdaEnvironment {
       ...Object.fromEntries(this.declared),
     };
     return this.#variables;
-  }
-
-  /**
-   * The variables one invocation runs with.
-   *
-   * The host variables are read for each invocation rather than merged once,
-   * so a variable the test process sets between two invocations reaches the
-   * second of them.
-   */
-  private runVariables(): Record<string, string> {
-    if (this.hasDeclaredVariables) {
-      return this.variables();
-    }
-
-    return {
-      ...simProcessEnvironment.definedHostVariables(),
-      ...this.variables(),
-    };
   }
 }

--- a/src/service/lambda/function/environment/sim-lambda-environment.ts
+++ b/src/service/lambda/function/environment/sim-lambda-environment.ts
@@ -1,15 +1,8 @@
 import { simProcessEnvironment } from "../../../../util/process/sim-process-environment.js";
-import { simLambdaExecutionCredentials } from "./sim-lambda-execution-credentials.js";
-
-/**
- * The function details the AWS-provided runtime environment variables are
- * built from.
- */
-export interface SimLambdaEnvironmentDetails {
-  readonly functionName: string;
-  readonly regionName: string;
-  readonly memorySizeMb: number;
-}
+import {
+  type SimLambdaEnvironmentDetails,
+  simLambdaRuntimeVariables,
+} from "./sim-lambda-runtime-variables.js";
 
 interface SimLambdaEnvironmentProperties extends SimLambdaEnvironmentDetails {
   readonly declaredVariables?: ReadonlyMap<string, string> | undefined;
@@ -46,8 +39,9 @@ export class SimLambdaEnvironment {
   /**
    * Whether any variables were declared for this function.
    *
-   * A function with no declared variables needs no environment of its own, so
-   * callers can leave the host process environment alone entirely.
+   * A function with no declared variables runs with the host process
+   * environment under the AWS-provided runtime variables, and reports no
+   * Environment in its configuration.
    */
   get hasDeclaredVariables(): boolean {
     return this.declared.size > 0;
@@ -84,18 +78,22 @@ export class SimLambdaEnvironment {
   /**
    * Run function code with this environment applied to process.env.
    *
-   * A function that declares nothing is left reading the host process
-   * environment, exactly as before: there is nothing of its own to give it,
-   * so there is no reason to touch process.env at all. Zip code running in a
-   * vm context takes its variables from the sandbox instead, and is
-   * unaffected either way.
+   * Every invocation runs with the AWS-provided runtime variables, as every
+   * real Lambda invocation does, whatever the function declared. An AWS SDK
+   * client built inside the handler reads its Region from AWS_REGION there,
+   * and reads credentials the invocation is already attributed to.
+   *
+   * A function that declares nothing of its own keeps the host process
+   * environment underneath them. Taking that away would take away everything
+   * the test process set, which is where an in-process handler's
+   * configuration comes from when the function declares none. A function
+   * declaring variables gets only its own, as before.
+   *
+   * Zip code running in a vm context takes its variables from the sandbox
+   * instead, and is unaffected either way.
    */
   async runWith<T>(run: () => Promise<T>): Promise<T> {
-    if (!this.hasDeclaredVariables) {
-      return await run();
-    }
-
-    return await simProcessEnvironment.run(this.variables(), run);
+    return await simProcessEnvironment.run(this.runVariables(), run);
   }
 
   /**
@@ -103,27 +101,27 @@ export class SimLambdaEnvironment {
    */
   variables(): Record<string, string> {
     this.#variables ??= {
-      ...this.runtimeVariables(),
+      ...simLambdaRuntimeVariables(this.details),
       ...Object.fromEntries(this.declared),
     };
     return this.#variables;
   }
 
   /**
-   * The AWS-like standard runtime environment variables.
+   * The variables one invocation runs with.
+   *
+   * The host variables are read for each invocation rather than merged once,
+   * so a variable the test process sets between two invocations reaches the
+   * second of them.
    */
-  private runtimeVariables(): Record<string, string> {
-    const { functionName, regionName, memorySizeMb } = this.details;
-    // Built from entries rather than an object literal because AWS
-    // environment variable names are not code identifier names, and the
-    // project's naming rules treat object literal keys as if they were.
-    return Object.fromEntries([
-      ["AWS_REGION", regionName],
-      ["AWS_DEFAULT_REGION", regionName],
-      ["AWS_LAMBDA_FUNCTION_NAME", functionName],
-      ["AWS_LAMBDA_FUNCTION_MEMORY_SIZE", String(memorySizeMb)],
-      ["AWS_LAMBDA_FUNCTION_VERSION", "$LATEST"],
-      ...simLambdaExecutionCredentials,
-    ]);
+  private runVariables(): Record<string, string> {
+    if (this.hasDeclaredVariables) {
+      return this.variables();
+    }
+
+    return {
+      ...simProcessEnvironment.definedHostVariables(),
+      ...this.variables(),
+    };
   }
 }

--- a/src/service/lambda/function/environment/sim-lambda-function-environment.iso.test.ts
+++ b/src/service/lambda/function/environment/sim-lambda-function-environment.iso.test.ts
@@ -143,6 +143,34 @@ describe("sim Lambda in-process handler environment", () => {
     }
   });
 
+  it("keeps a write by a function declaring nothing for its next invocation", async () => {
+    // Given a function declaring nothing, whose handler writes a variable
+    // the first time it runs, as function code caching something would.
+    const simLambda = new SimAws().lambda();
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: greeterRoleArn,
+        Code: {
+          ZipFile: makeLambdaZipFileInput(() => {
+            const before = process.env["YULIN_TEST_WARM"] ?? null;
+            process.env["YULIN_TEST_WARM"] = "written";
+            return { before };
+          }),
+        },
+      }),
+    );
+    assertObjectEquals(await invoke(simLambda, "greeter"), { before: null });
+
+    // When it is invoked again.
+    const result = await invoke(simLambda, "greeter");
+
+    // Then the second invocation reads the first one's write, as a warm
+    // execution environment does, and the host process never saw it.
+    assertObjectEquals(result, { before: "written" });
+    assertUndefined(process.env["YULIN_TEST_WARM"]);
+  });
+
   it("hides host process variables the function does not declare", async () => {
     // Given a variable set on the host process running the tests.
     process.env["YULIN_TEST_HOST_ONLY"] = "host value";

--- a/src/service/lambda/function/environment/sim-lambda-function-environment.iso.test.ts
+++ b/src/service/lambda/function/environment/sim-lambda-function-environment.iso.test.ts
@@ -82,6 +82,67 @@ describe("sim Lambda in-process handler environment", () => {
     });
   });
 
+  it("gives a function declaring nothing the AWS runtime variables", async () => {
+    // Given a function with no Environment of its own.
+    const simAws = new SimAws();
+    const simLambda = simAws.lambda();
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: greeterRoleArn,
+        Code: {
+          ZipFile: makeLambdaZipFileInput(() => ({
+            region: process.env["AWS_REGION"],
+            functionName: process.env["AWS_LAMBDA_FUNCTION_NAME"],
+            accessKeyId: process.env["AWS_ACCESS_KEY_ID"],
+          })),
+        },
+      }),
+    );
+
+    // When it is invoked.
+    const result = await invoke(simLambda, "greeter");
+
+    // Then it runs with the AWS-provided runtime variables, as a real Lambda
+    // function does whether or not it declares any of its own. An SDK client
+    // built in the handler resolves its Region from them.
+    assertObjectEquals(result, {
+      region: simAws.defaultRegionName,
+      functionName: "greeter",
+      accessKeyId: "ASIAYULINSIMULATED00",
+    });
+  });
+
+  it("reads a host variable set between two invocations", async () => {
+    // Given a function declaring nothing, invoked once already.
+    const simLambda = new SimAws().lambda();
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: greeterRoleArn,
+        Code: {
+          ZipFile: makeLambdaZipFileInput(() => ({
+            late: process.env["YULIN_TEST_LATE"] ?? null,
+          })),
+        },
+      }),
+    );
+    assertObjectEquals(await invoke(simLambda, "greeter"), { late: null });
+
+    // When the test process sets a variable and invokes it again.
+    process.env["YULIN_TEST_LATE"] = "late value";
+
+    try {
+      const result = await invoke(simLambda, "greeter");
+
+      // Then the handler reads what the test process set now, rather than
+      // the host environment as it stood at the first invocation.
+      assertObjectEquals(result, { late: "late value" });
+    } finally {
+      delete process.env["YULIN_TEST_LATE"];
+    }
+  });
+
   it("hides host process variables the function does not declare", async () => {
     // Given a variable set on the host process running the tests.
     process.env["YULIN_TEST_HOST_ONLY"] = "host value";

--- a/src/service/lambda/function/environment/sim-lambda-host-backed-variables.ts
+++ b/src/service/lambda/function/environment/sim-lambda-host-backed-variables.ts
@@ -1,0 +1,58 @@
+import { simProcessEnvironment } from "../../../../util/process/sim-process-environment.js";
+
+/**
+ * The environment of a function that declares no variables of its own.
+ *
+ * It is the host process environment with the AWS-provided runtime variables
+ * laid over it. The host variables are read for each invocation rather than
+ * merged once, so a variable the test process sets between two invocations
+ * reaches the second of them.
+ *
+ * What the handler itself wrote is kept and laid over both, which is the warm
+ * execution environment semantics a function declaring variables gets from
+ * reusing one object. A name the handler wrote and the host also sets is the
+ * handler's, until the function is replaced.
+ */
+export class SimLambdaHostBackedVariables {
+  private readonly written = new Map<string, string>();
+
+  /**
+   * Run function code with these variables as its process.env.
+   */
+  async runWith<T>(
+    functionVariables: Record<string, string>,
+    run: () => Promise<T>,
+  ): Promise<T> {
+    const merged = {
+      ...simProcessEnvironment.definedHostVariables(),
+      ...functionVariables,
+      ...Object.fromEntries(this.written),
+    };
+    const variables = { ...merged };
+
+    try {
+      return await simProcessEnvironment.run(variables, run);
+    } finally {
+      this.recordWrites(merged, variables);
+    }
+  }
+
+  /**
+   * Keep what the handler wrote for the next invocation.
+   *
+   * A name the handler removed is left out. The next invocation reads it from
+   * the host process again, the way a name it never touched is read.
+   */
+  private recordWrites(
+    merged: Record<string, string>,
+    variables: Record<string, string>,
+  ): void {
+    const before = new Map(Object.entries(merged));
+
+    for (const [name, value] of Object.entries(variables)) {
+      if (before.get(name) !== value) {
+        this.written.set(name, value);
+      }
+    }
+  }
+}

--- a/src/service/lambda/function/environment/sim-lambda-runtime-variables.ts
+++ b/src/service/lambda/function/environment/sim-lambda-runtime-variables.ts
@@ -1,0 +1,36 @@
+import { simLambdaExecutionCredentials } from "./sim-lambda-execution-credentials.js";
+
+/**
+ * The function details the AWS-provided runtime environment variables are
+ * built from.
+ */
+export interface SimLambdaEnvironmentDetails {
+  readonly functionName: string;
+  readonly regionName: string;
+  readonly memorySizeMb: number;
+}
+
+/**
+ * The AWS-like standard runtime environment variables a function runs with.
+ *
+ * Real Lambda provides these to every invocation, whatever the function's
+ * configuration declares, and an AWS SDK client built in the handler reads
+ * its Region and its credentials from them.
+ */
+export function simLambdaRuntimeVariables(
+  details: SimLambdaEnvironmentDetails,
+): Record<string, string> {
+  const { functionName, regionName, memorySizeMb } = details;
+
+  // Built from entries rather than an object literal because AWS environment
+  // variable names are not code identifier names, and the project's naming
+  // rules treat object literal keys as if they were.
+  return Object.fromEntries([
+    ["AWS_REGION", regionName],
+    ["AWS_DEFAULT_REGION", regionName],
+    ["AWS_LAMBDA_FUNCTION_NAME", functionName],
+    ["AWS_LAMBDA_FUNCTION_MEMORY_SIZE", String(memorySizeMb)],
+    ["AWS_LAMBDA_FUNCTION_VERSION", "$LATEST"],
+    ...simLambdaExecutionCredentials,
+  ]);
+}

--- a/src/util/process/sim-process-environment.ts
+++ b/src/util/process/sim-process-environment.ts
@@ -51,6 +51,26 @@ class SimProcessEnvironment {
   }
 
   /**
+   * The host process environment in the shape a run's variables are held in.
+   *
+   * A run's store holds string values only, which is what process.env holds
+   * once Node.js has read it. The declared type allows undefined, so the
+   * names holding one are dropped rather than carried into a run as the
+   * string "undefined".
+   */
+  definedHostVariables(): Record<string, string> {
+    const defined: [string, string][] = [];
+
+    for (const [name, value] of Object.entries(this.hostEnvironment)) {
+      if (value !== undefined) {
+        defined.push([name, value]);
+      }
+    }
+
+    return Object.fromEntries(defined);
+  }
+
+  /**
    * Redefine process.env as an accessor backed by the run store.
    *
    * process.env is a plain configurable data property on process, so it can


### PR DESCRIPTION
A simulated Lambda function ran with the AWS-provided runtime variables only when it declared environment variables of its own. A function declaring none read the host process environment untouched, leaving `AWS_REGION`, the function name and the execution credentials all absent, so an AWS SDK client built inside the handler had no Region to resolve. This turned up under an HTTP API `REQUEST` authorizer, which commonly declares nothing while the route handler behind it declares plenty. Every invocation now runs with the runtime variables, and a function declaring nothing keeps the host environment underneath them, read per invocation, so whatever the test process set still reaches it.

Resolves https://github.com/KensioSoftware/yulin/issues/951

- [x] Conventional commit message, used as the title
- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Lambda functions now receive AWS-provided runtime environment variables during every invocation.
  - Functions without declared variables retain the host environment, refreshed between invocations.
  - Lambda authorizers pass configured runtime variables through to downstream handlers.

- **Documentation**
  - Updated Lambda environment documentation to clarify variable inheritance and runtime behavior.

- **Tests**
  - Added coverage for runtime variables, host-environment updates, and authorizer behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->