### PR TITLE
fix: resolve a dynamic reference built by Fn::Join

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -930,8 +930,11 @@ exports published in that Region.
 ## Dynamic references
 
 A `{{resolve:...}}` dynamic reference reads a value from another service while a resource is being
-created. It is written into the template as ordinary text, so it can sit inside a longer string and
-inside `Fn::Sub`.
+created. It is written into the template as ordinary text, so it can sit inside a longer string.
+
+`Fn::Sub` and `Fn::Join` resolve first, and the reference is read from the string they built. CDK
+writes that shape whenever a secret sits in the same stack as the resource reading it (the secret's
+ARN arrives as a `Ref`).
 
 `{{resolve:ssm:name}}` and `{{resolve:ssm:name:3}}` read a simulated SSM parameter. See
 [reading a parameter with a dynamic reference](../ssm/README.md#reading-a-parameter-with-a-dynamic-reference)

--- a/src/service/cloudformation/template/node/fn/join/sim-cfn-fn-join-dynamic-reference.iso.test.ts
+++ b/src/service/cloudformation/template/node/fn/join/sim-cfn-fn-join-dynamic-reference.iso.test.ts
@@ -1,0 +1,169 @@
+import { assertIdentical, assertNonNullable } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../../aws/sim-aws.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../value/sim-cfn-template-value.js";
+
+/**
+ * Read one property back out of the simulation.
+ *
+ * The value under test is deployed as a Parameter's value, so whatever the
+ * reference resolved to is whatever the Parameter ended up holding.
+ */
+function readingParameter(
+  value: SimCfnTemplateValue,
+): SimCfnTemplateValueRecord {
+  return {
+    Type: "AWS::SSM::Parameter",
+    Properties: { Name: "/myapp/read", Type: "String", Value: value },
+  };
+}
+
+async function deploy(
+  simAws: SimAws,
+  resources: SimCfnTemplateValueRecord,
+  parameters?: Record<string, string>,
+): Promise<void> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "app-stack",
+    template: {
+      Parameters:
+        parameters === undefined
+          ? undefined
+          : Object.fromEntries(
+              Object.keys(parameters).map((name) => [name, { Type: "String" }]),
+            ),
+      Resources: resources,
+    },
+    parameters,
+  });
+  await stack.waitForDeployComplete();
+}
+
+function readValue(simAws: SimAws): string {
+  const parameter = simAws.ssm().findParameter("/myapp/read");
+  assertNonNullable(parameter, "the deployed parameter");
+
+  return parameter.currentVersion.value.value;
+}
+
+describe("CloudFormation Fn::Join assembling a dynamic reference", () => {
+  it("resolves a secretsmanager reference built around a Ref to a secret in the same Stack", async () => {
+    // Given a secret whose name the template never wrote, so that reading it
+    // has to go through a Ref, as CDK writes it.
+    const simAws = new SimAws();
+
+    // When a Resource reads that secret through a reference assembled by
+    // Fn::Join.
+    await deploy(simAws, {
+      OriginSecret: {
+        Type: "AWS::SecretsManager::Secret",
+        Properties: { SecretString: JSON.stringify({ current: "hunter2" }) },
+      },
+      Read: readingParameter({
+        "Fn::Join": [
+          "",
+          [
+            "{{resolve:secretsmanager:",
+            { Ref: "OriginSecret" },
+            ":SecretString:current::}}",
+          ],
+        ],
+      }),
+    });
+
+    // Then the property holds the secret's value rather than the reference.
+    assertIdentical(readValue(simAws), "hunter2");
+  });
+
+  it("resolves an ssm reference built around a Ref to a Parameter in the same Stack", async () => {
+    // Given a Parameter another Resource reads by Ref.
+    const simAws = new SimAws();
+
+    // When the reference reading it is assembled by Fn::Join.
+    await deploy(simAws, {
+      HostParameter: {
+        Type: "AWS::SSM::Parameter",
+        Properties: {
+          Name: "/myapp/host",
+          Type: "String",
+          Value: "db.example.com",
+        },
+      },
+      Read: readingParameter({
+        "Fn::Join": ["", ["{{resolve:ssm:", { Ref: "HostParameter" }, "}}"]],
+      }),
+    });
+
+    // Then the property holds the Parameter's value.
+    assertIdentical(readValue(simAws), "db.example.com");
+  });
+
+  it("keeps the text a joined reference sits inside", async () => {
+    // Given a Parameter holding a host name.
+    const simAws = new SimAws();
+
+    // When the assembled reference is joined into a longer value.
+    await deploy(simAws, {
+      HostParameter: {
+        Type: "AWS::SSM::Parameter",
+        Properties: {
+          Name: "/myapp/host",
+          Type: "String",
+          Value: "db.example.com",
+        },
+      },
+      Read: readingParameter({
+        "Fn::Join": [
+          "",
+          [
+            "https://",
+            "{{resolve:ssm:",
+            { Ref: "HostParameter" },
+            "}}",
+            "/health",
+          ],
+        ],
+      }),
+    });
+
+    // Then only the reference is replaced.
+    assertIdentical(readValue(simAws), "https://db.example.com/health");
+  });
+
+  it("resolves a reference assembled before any Resource exists", async () => {
+    // Given a secret the Stack does not declare, named by a Stack Parameter.
+    const simAws = new SimAws();
+    await simAws.secretsManager().createSecret({
+      input: {
+        Name: "db-credentials",
+        SecretString: JSON.stringify({ password: "hunter2" }),
+      },
+    });
+
+    // When the reference is assembled out of literals and that Parameter, so
+    // the join finishes on the up-front template pass.
+    await deploy(
+      simAws,
+      {
+        Read: readingParameter({
+          "Fn::Join": [
+            "",
+            [
+              "{{resolve:secretsmanager:",
+              { Ref: "SecretName" },
+              ":SecretString:password::}}",
+            ],
+          ],
+        }),
+      },
+      { SecretName: "db-credentials" },
+    );
+
+    // Then the property still holds the secret's value.
+    assertIdentical(readValue(simAws), "hunter2");
+  });
+});

--- a/src/service/cloudformation/template/node/fn/join/sim-cfn-fn-join.ts
+++ b/src/service/cloudformation/template/node/fn/join/sim-cfn-fn-join.ts
@@ -27,6 +27,13 @@ export class SimCfnFnJoin extends SimCfnNode {
    * during the up-front pass before Resources exist), this node re-emits
    * itself in template form. A later resolution pass can finish it once the
    * referenced Resources are available.
+   *
+   * A dynamic reference can be assembled out of the joined values, as CDK
+   * writes one whenever the secret it reads sits in the same Stack: the
+   * opening `{{resolve:secretsmanager:`, a `Ref` to the secret, and the
+   * trailing segments. No single value holds a whole reference, so the
+   * reference is read from the finished string, as `Fn::Sub` reads one built
+   * out of its variables.
    */
   resolve(context: SimCfnResolveContext): SimCfnTemplateValue {
     const resolved = this.values.map((value) =>
@@ -34,7 +41,9 @@ export class SimCfnFnJoin extends SimCfnNode {
     );
 
     if (resolved.every((value): value is string => typeof value === "string")) {
-      return resolved.join(this.delimiter);
+      const joined = resolved.join(this.delimiter);
+
+      return context.dynamicReferences?.substitute(joined) ?? joined;
     }
 
     return { "Fn::Join": [this.delimiter, resolved] };


### PR DESCRIPTION
Dynamic references were substituted as each string literal resolved, before `Fn::Join` had joined the fragments. No single fragment held a whole reference, and the joined string was never scanned. The property reached its service configurator holding the reference as its text. `Fn::Join` now reads a reference out of the string it built, as `Fn::Sub` already does. CDK writes that shape whenever a secret sits in the same stack as the resource reading it (the secret's ARN arrives as a `Ref`).

Resolves #952