### PR TITLE
feat: throttle a REST API stage and method

### DIFF
--- a/docs/services/apigateway/README.md
+++ b/docs/services/apigateway/README.md
@@ -352,6 +352,125 @@ supplied as `AWS:SourceArn`, in the form
 granted for one method therefore leaves the others closed. CDK wildcards the stage, method and path segments,
 which admits every method of the API.
 
+## Throttling a stage and a method
+
+A stage holds a token bucket for every method it serves. A method setting is addressed by
+`{resourcePath}/{httpMethod}`, which is how API Gateway addresses one, and the entry keyed with a
+resource path of `/*` and a method of `*` is the stage default. `throttlingRateLimit` is requests per
+second, and `throttlingBurstLimit` is how many requests a method will take at once.
+
+A request that finds an empty bucket is answered 429 with `{"message":"Too Many Requests"}`. The
+method's authorizer and its integration are both skipped.
+
+The buckets refill against the simulated clock. Freeze it, spend a method's burst, assert on the 429,
+then move a second on and watch the method serve again.
+
+```typescript sim-apigateway-throttling
+/**
+ * Throttling a REST API stage and one of its methods.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import { simRestApiLambdaProxyFactory } from "@kensio/yulin/apigateway";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+const restApi = await simRestApiLambdaProxyFactory.make(
+  {
+    resourcePaths: ["/password-reset", "/profile"],
+    httpMethod: "POST",
+    methodSettings: {
+      "/*/*": { throttlingRateLimit: 10, throttlingBurstLimit: 5 },
+      "/password-reset/POST": {
+        throttlingRateLimit: 1,
+        throttlingBurstLimit: 2,
+      },
+    },
+    handler: () => ({ statusCode: 200, body: "ok" }),
+  },
+  simAws,
+);
+
+const srv = await serveSimAws({ simAws });
+
+// Stop simulated time. A bucket now refills only when this example moves it.
+simAws.clock().freeze();
+
+const passwordReset = async (): Promise<Response> =>
+  await fetch(srv.localUrl(`${restApi.invokeUrl("prod")}/password-reset`), {
+    method: "POST",
+  });
+
+const first = await passwordReset();
+const second = await passwordReset();
+const third = await passwordReset();
+
+console.log(first.status, second.status, third.status);
+console.log(await third.text());
+
+// Another method, drawing on the stage default and a bucket of its own.
+const profile = await fetch(
+  srv.localUrl(`${restApi.invokeUrl("prod")}/profile`),
+  { method: "POST" },
+);
+console.log(profile.status);
+
+// One second at a rate limit of one is one token back.
+await simAws.clock().advanceBy({ seconds: 1 });
+const afterASecond = await passwordReset();
+console.log(afterASecond.status);
+
+await srv.close();
+```
+
+The burst of two is served, the third password reset is refused, and the profile method is untouched
+by any of it:
+
+```text
+200 200 429
+{"message":"Too Many Requests"}
+200
+200
+```
+
+A template writes the same thing as a list, with each entry naming the method it applies to:
+
+```yaml
+ProdStage:
+  Type: AWS::ApiGateway::Stage
+  Properties:
+    RestApiId: !Ref Api
+    DeploymentId: !Ref Deployment
+    StageName: prod
+    MethodSettings:
+      - ResourcePath: "/*"
+        HttpMethod: "*"
+        ThrottlingRateLimit: 10
+        ThrottlingBurstLimit: 5
+      - ResourcePath: "/password-reset"
+        HttpMethod: POST
+        ThrottlingRateLimit: 1
+        ThrottlingBurstLimit: 2
+```
+
+Every client of a method draws on the same bucket. Two callers sending one request each spend two
+tokens between them. A WAFv2 `RateBasedStatement` counts each client on its own (see
+[Rate limiting](../wafv2/#rate-limiting)), and a stack often carries both.
+
+A method is throttled here only where the settings reaching it name both limits. Naming one alone
+leaves the other at the account limit on real AWS. Account limits are outside this simulation, and a
+method configured that way is served unthrottled.
+
+The `httpMethod` half of a key is the one the method was declared with. A resource declaring `ANY`
+is named `ANY`, whatever method the client sent.
+
+Real `CreateStage` carries no method settings. AWS sets them with `UpdateStage` patch operations,
+which are outside this simulation, or from an `AWS::ApiGateway::Stage`. The `methodSettings` input
+above is this simulator's own, so that a test can throttle a stage without a template, and the SDK's
+`CreateStageCommand` declares no such member. `GetStage` reports the settings the way AWS reports
+them.
+
 ## Authorizing a method
 
 A method is open unless it names an authorizer. `CreateAuthorizerCommand` creates one, and
@@ -1625,7 +1744,10 @@ behaves differently to the template. The simulated properties are:
 - A method's `Integration` block: `Type`, `IntegrationHttpMethod`, `Uri`
 - `Authorizer`: `RestApiId`, `Name`, `Type`, `AuthorizerUri`, `ProviderARNs`, `IdentitySource`
 - `Deployment`: `RestApiId`, `Description`, `StageName`
-- `Stage`: `RestApiId`, `DeploymentId`, `StageName`, `Description`, `Variables`
+- `Stage`: `RestApiId`, `DeploymentId`, `StageName`, `Description`, `Variables`,
+  `MethodSettings`
+- A stage's `MethodSettings` entries: `ResourcePath`, `HttpMethod`, `ThrottlingRateLimit`,
+  `ThrottlingBurstLimit`
 
 A `Body` on the `RestApi` is an inline OpenAPI document declaring the API's resources, methods and
 integrations. It goes through `ImportRestApi`, the same translator an SDK caller importing a
@@ -1735,7 +1857,12 @@ and behave differently deployed. The refusals worth knowing about:
 - **Integration types.** Only `AWS_PROXY` with a Lambda function URI is simulated. `MOCK`, `HTTP`,
   `HTTP_PROXY` and the non-proxy `AWS` type each answer a request from somewhere this cannot reach.
 - **API keys and usage plans.** `apiKeyRequired: true` is refused, because a method requiring a key
-  here would answer requests real AWS rejects.
+  here would answer requests real AWS rejects. A usage plan holds a per-key quota and is its own
+  feature. Stage throttling is simulated, and is a bucket shared by every client. See
+  [Throttling a stage and a method](#throttling-a-stage-and-a-method).
+- **Method settings outside throttling.** `cachingEnabled`, `metricsEnabled`, `loggingLevel` and
+  `dataTraceEnabled` are refused by `CreateStage`. A template carrying one deploys, and the member it
+  named is recorded on `stack.ignoredProperties`.
 - **Paging.** Every list command answers in full, and `limit` or `position` is refused.
 - **Endpoint types, request validators, models, mapping templates and WAF.** All refused.
 - **Updates.** `UpdateRestApi` replaces `/name` and `/description`. Any other patch path is refused.
@@ -1778,6 +1905,8 @@ and `Stage`, including the template CDK synthesizes from a `RestApi` or a `Lambd
   API Gateway matches a token against before verifying it, is outside this.
 - Binary media types negotiated by `Accept`, CORS preflight and gateway responses are outside this.
   A response body is still base64 decoded when the handler says `isBase64Encoded`.
+- The account-level rate and burst limits are outside this. A stage that names no limit throttles
+  nothing, and a method setting naming one limit alone leaves that method unthrottled.
 - WebSocket APIs are outside this and outside the v2 service.
 - Only OpenAPI 3.0.x is imported. `ImportRestApi` and `PutRestApi` refuse a `swagger: "2.0"`
   document and an `openapi: "3.1.0"` one by version. A `Body` carrying a Swagger 2.0 document is

--- a/docs/services/apigateway/sim-apigateway-throttling.example.ts
+++ b/docs/services/apigateway/sim-apigateway-throttling.example.ts
@@ -1,0 +1,56 @@
+/**
+ * Throttling a REST API stage and one of its methods.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import { simRestApiLambdaProxyFactory } from "@kensio/yulin/apigateway";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+const restApi = await simRestApiLambdaProxyFactory.make(
+  {
+    resourcePaths: ["/password-reset", "/profile"],
+    httpMethod: "POST",
+    methodSettings: {
+      "/*/*": { throttlingRateLimit: 10, throttlingBurstLimit: 5 },
+      "/password-reset/POST": {
+        throttlingRateLimit: 1,
+        throttlingBurstLimit: 2,
+      },
+    },
+    handler: () => ({ statusCode: 200, body: "ok" }),
+  },
+  simAws,
+);
+
+const srv = await serveSimAws({ simAws });
+
+// Stop simulated time. A bucket now refills only when this example moves it.
+simAws.clock().freeze();
+
+const passwordReset = async (): Promise<Response> =>
+  await fetch(srv.localUrl(`${restApi.invokeUrl("prod")}/password-reset`), {
+    method: "POST",
+  });
+
+const first = await passwordReset();
+const second = await passwordReset();
+const third = await passwordReset();
+
+console.log(first.status, second.status, third.status);
+console.log(await third.text());
+
+// Another method, drawing on the stage default and a bucket of its own.
+const profile = await fetch(
+  srv.localUrl(`${restApi.invokeUrl("prod")}/profile`),
+  { method: "POST" },
+);
+console.log(profile.status);
+
+// One second at a rate limit of one is one token back.
+await simAws.clock().advanceBy({ seconds: 1 });
+const afterASecond = await passwordReset();
+console.log(afterASecond.status);
+
+await srv.close();

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export {
 } from "./util/clock/sim-clock.js";
 export { SimControllableClock } from "./util/clock/sim-controllable-clock.js";
 export { SimClockControl } from "./util/clock/sim-clock-control.js";
+export { SimTokenBucket } from "./util/throttle/sim-token-bucket.js";
 export {
   SimDuration,
   type SimDurationInput,

--- a/src/service/apigateway/api/sim-rest-api-lambda-proxy.factory.ts
+++ b/src/service/apigateway/api/sim-rest-api-lambda-proxy.factory.ts
@@ -14,11 +14,16 @@ import {
   simRestApiProxyFunction,
 } from "./sim-rest-api-proxy-function.js";
 import type { SimRestApi } from "./sim-rest-api.js";
+import {
+  simRestApiProxyStage,
+  type SimRestApiProxyStageInput,
+} from "./sim-rest-api-proxy-stage.js";
 
 /**
  * What a test asks for when it wants a REST API that serves something.
  */
-export interface SimRestApiLambdaProxyInput extends SimRestApiProxyAuthorizerInput {
+export interface SimRestApiLambdaProxyInput
+  extends SimRestApiProxyAuthorizerInput, SimRestApiProxyStageInput {
   readonly apiName: string;
   readonly functionName: string;
   /** The function code every method of the API hands its requests to. */
@@ -31,10 +36,6 @@ export interface SimRestApiLambdaProxyInput extends SimRestApiProxyAuthorizerInp
   readonly resourcePaths: readonly string[];
   /** The HTTP method declared on each of those resources. */
   readonly httpMethod: string;
-  /** The stage the API is deployed to, which every request goes through. */
-  readonly stageName: string;
-  /** The variables that stage carries. */
-  readonly stageVariables: Readonly<Record<string, string>>;
   /**
    * Whether the function grants the API permission to invoke it, which it
    * needs before any method serves anything.
@@ -99,6 +100,7 @@ export const simRestApiLambdaProxyFactory = new AsyncMappedFactory<
     httpMethod: "ANY",
     stageName: "prod",
     stageVariables: {},
+    methodSettings: undefined,
     invokePermission: true,
   }),
   async (input, simAws) => {
@@ -128,13 +130,7 @@ export const simRestApiLambdaProxyFactory = new AsyncMappedFactory<
       await simRestApiInvokePermission(simAws, input, restApiId);
     }
 
-    await apiGateway.createDeployment({
-      input: {
-        restApiId,
-        stageName: input.stageName,
-        variables: input.stageVariables,
-      },
-    });
+    await simRestApiProxyStage(apiGateway, input, restApiId);
 
     // An id CreateRestApi allocated is an API the store holds, so this is only
     // missing if something is wrong with the simulator itself.

--- a/src/service/apigateway/api/sim-rest-api-proxy-stage.ts
+++ b/src/service/apigateway/api/sim-rest-api-proxy-stage.ts
@@ -1,0 +1,51 @@
+import type { SimApiGateway } from "../sim-api-gateway.js";
+import type { SimRestApiMethodSettingsMap } from "./stage/settings/sim-rest-api-method-settings.type.js";
+
+export interface SimRestApiProxyStageInput {
+  /** The stage the API is deployed to, which every request goes through. */
+  readonly stageName: string;
+  /** The variables that stage carries. */
+  readonly stageVariables: Readonly<Record<string, string>>;
+  /**
+   * The throttle that stage serves its methods at, keyed as CreateStage keys
+   * one.
+   */
+  readonly methodSettings: SimRestApiMethodSettingsMap | undefined;
+}
+
+/**
+ * Deploy a test's REST API and publish it to the stage the test asked for.
+ *
+ * A deployment publishes its own stage in one call, which is the shorter path
+ * and the one most of these tests take. A stage carrying method settings is
+ * created by CreateStage instead, since a deployment carries none.
+ */
+export async function simRestApiProxyStage(
+  apiGateway: SimApiGateway,
+  input: SimRestApiProxyStageInput,
+  restApiId: string,
+): Promise<void> {
+  const { methodSettings, stageName, stageVariables } = input;
+  const throttled = methodSettings !== undefined;
+  const deployment = await apiGateway.createDeployment({
+    input: {
+      restApiId,
+      stageName: throttled ? undefined : stageName,
+      variables: throttled ? undefined : stageVariables,
+    },
+  });
+
+  if (!throttled) {
+    return;
+  }
+
+  await apiGateway.createStage({
+    input: {
+      restApiId,
+      stageName,
+      deploymentId: deployment.id,
+      variables: stageVariables,
+      methodSettings,
+    },
+  });
+}

--- a/src/service/apigateway/api/stage/settings/sim-rest-api-method-settings.type.ts
+++ b/src/service/apigateway/api/stage/settings/sim-rest-api-method-settings.type.ts
@@ -1,0 +1,21 @@
+/**
+ * The throttling half of one method's settings, as an entry of a stage's
+ * `methodSettings` carries it.
+ *
+ * `throttlingRateLimit` is requests per second and `throttlingBurstLimit` is
+ * how many requests the method may take at once. The members that say nothing
+ * about throttling are not simulated. They are left out of this type too.
+ */
+export interface SimRestApiMethodSettings {
+  readonly throttlingRateLimit?: number | undefined;
+  readonly throttlingBurstLimit?: number | undefined;
+}
+
+/**
+ * A stage's `methodSettings`, keyed `{resourcePath}/{httpMethod}`, which is
+ * how real API Gateway keys them. A resource path of `/` followed by a star,
+ * with a star for the method, is the stage default.
+ */
+export type SimRestApiMethodSettingsMap = Readonly<
+  Record<string, SimRestApiMethodSettings>
+>;

--- a/src/service/apigateway/api/stage/settings/sim-rest-api-stage-method-settings.ts
+++ b/src/service/apigateway/api/stage/settings/sim-rest-api-stage-method-settings.ts
@@ -1,0 +1,99 @@
+import type { SimClock } from "../../../../../util/clock/sim-clock.js";
+import { SimTokenBucket } from "../../../../../util/throttle/sim-token-bucket.js";
+import type {
+  SimRestApiMethodSettings,
+  SimRestApiMethodSettingsMap,
+} from "./sim-rest-api-method-settings.type.js";
+
+/**
+ * The key every method of the stage falls back to, which real API Gateway
+ * writes as a resource path of `/` and a star, then a star for the method.
+ */
+const stageDefaultKey = "/*/*";
+
+interface SimRestApiStageMethodSettingsProperties {
+  readonly clock: SimClock;
+  readonly methodSettings?: SimRestApiMethodSettingsMap | undefined;
+}
+
+/**
+ * The method settings one stage was created with, and the token buckets its
+ * throttle is evaluated from.
+ *
+ * A setting is addressed by `{resourcePath}/{httpMethod}`, the way real API
+ * Gateway addresses one. The resource path is the template the method is
+ * declared at, such as `/orders/{orderId}`, and the HTTP method is the one the
+ * method was declared with, so a resource declaring `ANY` is named `ANY` here.
+ *
+ * Each method gets a bucket of its own. Two methods on the stage default are
+ * throttled apart from each other, and a named entry throttles only the method
+ * it names. Every client of a method draws on that one bucket. A WAF
+ * rate-based rule counts each client separately, which is the other question a
+ * stack often asks.
+ *
+ * A method is throttled only where the settings reaching it name both limits.
+ * Naming one alone leaves the other at the account limit on real AWS. Account
+ * limits are outside this simulation, and a method configured that way serves
+ * unthrottled.
+ */
+export class SimRestApiStageMethodSettings {
+  readonly #clock: SimClock;
+  readonly #methodSettings: ReadonlyMap<string, SimRestApiMethodSettings>;
+  readonly #buckets = new Map<string, SimTokenBucket | undefined>();
+
+  constructor(properties: SimRestApiStageMethodSettingsProperties) {
+    this.#clock = properties.clock;
+    this.#methodSettings = new Map(
+      Object.entries(properties.methodSettings ?? {}),
+    );
+  }
+
+  /**
+   * Take one token for a request to a method, and answer whether the method's
+   * throttle had one to give.
+   *
+   * A method nothing throttles is always admitted, and takes nothing.
+   */
+  admits(resourcePath: string, httpMethod: string): boolean {
+    const bucket = this.#bucketFor(`${resourcePath}/${httpMethod}`);
+
+    return bucket === undefined || bucket.take();
+  }
+
+  /**
+   * What CreateStage and GetStage report of these settings.
+   */
+  view(): SimRestApiMethodSettingsMap | undefined {
+    if (this.#methodSettings.size === 0) {
+      return undefined;
+    }
+
+    return Object.fromEntries(this.#methodSettings);
+  }
+
+  /**
+   * The bucket a method key draws on, made the first time the method is asked
+   * about so that it starts full at the request that found it.
+   */
+  #bucketFor(key: string): SimTokenBucket | undefined {
+    if (!this.#buckets.has(key)) {
+      this.#buckets.set(key, this.#newBucket(key));
+    }
+
+    return this.#buckets.get(key);
+  }
+
+  #newBucket(key: string): SimTokenBucket | undefined {
+    const settings =
+      this.#methodSettings.get(key) ??
+      this.#methodSettings.get(stageDefaultKey);
+    const rateLimit = settings?.throttlingRateLimit;
+    const burstLimit = settings?.throttlingBurstLimit;
+
+    if (rateLimit === undefined || burstLimit === undefined) {
+      return undefined;
+    }
+
+    return new SimTokenBucket({ clock: this.#clock, rateLimit, burstLimit });
+  }
+}

--- a/src/service/apigateway/api/stage/sim-rest-api-stage.ts
+++ b/src/service/apigateway/api/stage/sim-rest-api-stage.ts
@@ -1,4 +1,6 @@
 import type { SimRestApiDeploymentId } from "../deployment/sim-rest-api-deployment.js";
+import type { SimRestApiMethodSettingsMap } from "./settings/sim-rest-api-method-settings.type.js";
+import type { SimRestApiStageMethodSettings } from "./settings/sim-rest-api-stage-method-settings.js";
 
 interface SimRestApiStageProperties {
   readonly stageName: string;
@@ -6,6 +8,7 @@ interface SimRestApiStageProperties {
   readonly createdDate: Date;
   readonly variables?: Readonly<Record<string, string>> | undefined;
   readonly description?: string | undefined;
+  readonly methodSettings?: SimRestApiStageMethodSettings | undefined;
 }
 
 /**
@@ -18,6 +21,7 @@ export interface SimRestApiStageView {
   lastUpdatedDate: Date;
   variables?: Record<string, string>;
   description?: string;
+  methodSettings?: SimRestApiMethodSettingsMap;
 }
 
 /**
@@ -43,6 +47,15 @@ export class SimRestApiStage {
   public deploymentId: SimRestApiDeploymentId;
   public lastUpdatedDate: Date;
 
+  /**
+   * The throttle this stage serves its methods at, or undefined for a stage
+   * that was given no method settings and so throttles nothing.
+   *
+   * A redeployment leaves it alone, the way it leaves the stage name and
+   * everything else addressed through the stage alone.
+   */
+  public readonly methodSettings?: SimRestApiStageMethodSettings | undefined;
+
   constructor(properties: SimRestApiStageProperties) {
     this.stageName = properties.stageName;
     this.deploymentId = properties.deploymentId;
@@ -50,6 +63,17 @@ export class SimRestApiStage {
     this.lastUpdatedDate = properties.createdDate;
     this.variables = properties.variables ?? {};
     this.description = properties.description;
+    this.methodSettings = properties.methodSettings;
+  }
+
+  /**
+   * Whether this stage's throttle serves one more request to a method now.
+   *
+   * Asking takes a token. A request that is admitted has already paid for
+   * itself, and a refused one has taken nothing.
+   */
+  admits(resourcePath: string, httpMethod: string): boolean {
+    return this.methodSettings?.admits(resourcePath, httpMethod) ?? true;
   }
 
   /**
@@ -80,6 +104,12 @@ export class SimRestApiStage {
 
     if (this.description !== undefined) {
       view.description = this.description;
+    }
+
+    const methodSettings = this.methodSettings?.view();
+
+    if (methodSettings !== undefined) {
+      view.methodSettings = methodSettings;
     }
 
     return view;

--- a/src/service/apigateway/cfn/sim-cfn-rest-api-properties.iso.test.ts
+++ b/src/service/apigateway/cfn/sim-cfn-rest-api-properties.iso.test.ts
@@ -208,7 +208,8 @@ describe("API Gateway REST API CloudFormation properties left out", () => {
   });
 
   it("records the settings a stage was created without", async () => {
-    // Given a stage asking for throttling and access logs
+    // Given a stage asking for tracing and for a method setting outside
+    // throttling
     const simAws = simAwsInEuWest2();
 
     // When the template is deployed
@@ -216,23 +217,34 @@ describe("API Gateway REST API CloudFormation properties left out", () => {
       simAws,
       simCfnRestApiTemplateFactory.make({
         stageProperties: {
-          MethodSettings: [{ HttpMethod: "*", ThrottlingBurstLimit: 10 }],
           TracingEnabled: true,
+          MethodSettings: [
+            {
+              ResourcePath: "/*",
+              HttpMethod: "*",
+              ThrottlingBurstLimit: 10,
+              MetricsEnabled: true,
+            },
+          ],
         },
       }),
     );
 
     // Then the stage serves the API and both are reported, since a stage that
-    // looked throttled to the template and was not is the failure to avoid
+    // looked traced to the template and was not is the failure to avoid
     const apiId = stack.getResource("Api")?.refValue;
     assertTypeString(apiId);
     assertNonNullable(
       simAws.apiGateway().findRestApi(apiId)?.stages.find("prod"),
     );
     expect(stack.ignoredProperties.map((entry) => entry.path)).toStrictEqual([
-      "MethodSettings",
       "TracingEnabled",
+      "MethodSettings[0].MetricsEnabled",
     ]);
+    assertStringIncludes(
+      stack.ignoredProperties[1]?.reason ?? "",
+      "AWS::ApiGateway::Stage MethodSettings property MetricsEnabled is not simulated",
+    );
   });
 });
 

--- a/src/service/apigateway/cfn/sim-cfn-rest-api-throttling.iso.test.ts
+++ b/src/service/apigateway/cfn/sim-cfn-rest-api-throttling.iso.test.ts
@@ -1,0 +1,72 @@
+import { assertIdentical, assertTypeString } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  deployRestApi,
+  simAwsInEuWest2,
+} from "../../../../test/apigateway/cfn-deploy.js";
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import { simCfnRestApiTemplateFactory } from "./sim-cfn-rest-api-template.factory.js";
+
+/** A handler that answers whatever reaches it. */
+const handlerSource = `
+exports.handler = async () => ({ statusCode: 200, body: "ok" });
+`;
+
+function localUrl(apiUrl: string, path: string): string {
+  return new SimAwsLocalUrl({ input: `${apiUrl}${path}` }).toString();
+}
+
+describe("Throttling a deployed sim REST API stage", () => {
+  it("throttles a deployed stage's method at the limits it declares", async () => {
+    // Given a template whose stage throttles one method harder than the rest
+    const simAws = simAwsInEuWest2();
+    const stack = await deployRestApi(
+      simAws,
+      simCfnRestApiTemplateFactory.make({
+        handlerSource,
+        methods: [
+          { httpMethod: "GET", path: ["orders"] },
+          { httpMethod: "POST", path: ["orders"] },
+        ],
+        stageProperties: {
+          MethodSettings: [
+            {
+              ResourcePath: "/*",
+              HttpMethod: "*",
+              ThrottlingRateLimit: 10,
+              ThrottlingBurstLimit: 5,
+            },
+            {
+              ResourcePath: "/orders",
+              HttpMethod: "POST",
+              ThrottlingRateLimit: 1,
+              ThrottlingBurstLimit: 1,
+            },
+          ],
+        },
+      }),
+    );
+
+    // When the throttled method is used twice over
+    const apiUrl = stack.outputs.get("ApiUrl")?.value;
+    assertTypeString(apiUrl);
+    simAws.clock().freeze();
+    const http = new SimAwsHttp({ simAws });
+    const served = await http.fetch(localUrl(apiUrl, "orders"), {
+      method: "POST",
+    });
+    const refused = await http.fetch(localUrl(apiUrl, "orders"), {
+      method: "POST",
+    });
+
+    // Then the deployed limits are the ones the stage serves at, and the
+    // method on the stage default is untouched by the other method's burst
+    assertIdentical(served.status, 200);
+    assertIdentical(refused.status, 429);
+
+    const other = await http.fetch(localUrl(apiUrl, "orders"));
+    assertIdentical(other.status, 200);
+  });
+});

--- a/src/service/apigateway/cfn/stage/sim-cfn-rest-api-method-settings-properties.ts
+++ b/src/service/apigateway/cfn/stage/sim-cfn-rest-api-method-settings-properties.ts
@@ -1,0 +1,116 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type {
+  SimRestApiMethodSettings,
+  SimRestApiMethodSettingsMap,
+} from "../../api/stage/settings/sim-rest-api-method-settings.type.js";
+import { SimCfnApiGatewayPropertyParser } from "../sim-cfn-api-gateway-property-parser.js";
+
+/**
+ * The properties of a stage's `MethodSettings` entries this simulation
+ * deploys. The rest are caching, metrics and logging, so a template carrying
+ * one has it recorded against the stage.
+ */
+const simulatedProperties = [
+  "ResourcePath",
+  "HttpMethod",
+  "ThrottlingRateLimit",
+  "ThrottlingBurstLimit",
+];
+
+interface SimCfnRestApiMethodSettingsPropertiesProperties {
+  readonly resource: SimCfnResource;
+}
+
+/**
+ * Reads the `MethodSettings` of an AWS::ApiGateway::Stage.
+ *
+ * A template writes a list, and each entry names the method it applies to with
+ * `ResourcePath` and `HttpMethod`. CreateStage takes the same settings as a
+ * map keyed `{resourcePath}/{httpMethod}`, which is what this builds.
+ */
+export class SimCfnRestApiMethodSettingsProperties {
+  private readonly resource: SimCfnResource;
+  private readonly parser = new SimCfnApiGatewayPropertyParser({
+    resourceType: "AWS::ApiGateway::Stage MethodSettings",
+    simulated: simulatedProperties,
+  });
+
+  constructor(properties: SimCfnRestApiMethodSettingsPropertiesProperties) {
+    this.resource = properties.resource;
+  }
+
+  /**
+   * Read the `MethodSettings` list into the map CreateStage takes.
+   */
+  methodSettings(
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): SimRestApiMethodSettingsMap | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (!Array.isArray(value)) {
+      throw this.parser.invalidPropertyError(
+        this.resource,
+        label,
+        "a list of method settings",
+      );
+    }
+
+    return Object.fromEntries(
+      value.map((entry, index) => this.entry(entry, `${label}[${index}]`)),
+    );
+  }
+
+  /**
+   * One entry of the list, as the key it applies to and what it sets there.
+   *
+   * Both halves of the key are required, as they are on real CloudFormation.
+   * The stage default is the entry naming the resource path `/` with a star,
+   * and the method as a star. A limit the template left out is left out here
+   * too, and a stage reports the settings it was written with.
+   */
+  private entry(
+    value: SimCfnTemplateValue,
+    label: string,
+  ): [string, SimRestApiMethodSettings] {
+    const { resource, parser } = this;
+    const record = parser.optionalRecord(resource, value, label) ?? {};
+
+    parser.ignoreUnsimulated(resource, record, `${label}.`);
+
+    const path = `${label}.`;
+    const rate = parser.optionalNumber(
+      resource,
+      record["ThrottlingRateLimit"],
+      `${path}ThrottlingRateLimit`,
+    );
+    const burst = parser.optionalNumber(
+      resource,
+      record["ThrottlingBurstLimit"],
+      `${path}ThrottlingBurstLimit`,
+    );
+    const key = [
+      parser.requiredString(
+        resource,
+        record["ResourcePath"],
+        `${path}ResourcePath`,
+      ),
+      parser.requiredString(
+        resource,
+        record["HttpMethod"],
+        `${path}HttpMethod`,
+      ),
+    ].join("/");
+
+    return [
+      key,
+      {
+        ...(rate !== undefined && { throttlingRateLimit: rate }),
+        ...(burst !== undefined && { throttlingBurstLimit: burst }),
+      },
+    ];
+  }
+}

--- a/src/service/apigateway/cfn/stage/sim-cfn-rest-api-stage-properties.ts
+++ b/src/service/apigateway/cfn/stage/sim-cfn-rest-api-stage-properties.ts
@@ -2,16 +2,17 @@ import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-re
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimCreateStageCommandInput } from "../../command/stage/stage.command.js";
 import { SimCfnApiGatewayPropertyParser } from "../sim-cfn-api-gateway-property-parser.js";
+import { SimCfnRestApiMethodSettingsProperties } from "./sim-cfn-rest-api-method-settings-properties.js";
 
 /**
  * The AWS::ApiGateway::Stage properties this simulation deploys.
  *
- * `MethodSettings`, `AccessLogSetting`, `CanarySetting`, `CacheClusterEnabled`,
+ * `AccessLogSetting`, `CanarySetting`, `CacheClusterEnabled`,
  * `CacheClusterSize`, `ClientCertificateId`, `DocumentationVersion`,
  * `TracingEnabled` and `Tags` are left out, so a template carrying one has it
  * recorded against the Resource. None of them is modelled, and a stage that
- * looked throttled or logged to the template and did neither when serving is
- * the failure worth avoiding.
+ * looked logged to the template and logged nothing when serving is the failure
+ * worth recording.
  */
 const simulatedProperties = [
   "RestApiId",
@@ -19,6 +20,7 @@ const simulatedProperties = [
   "StageName",
   "Description",
   "Variables",
+  "MethodSettings",
 ];
 
 interface SimCfnRestApiStagePropertiesProperties {
@@ -38,9 +40,14 @@ export class SimCfnRestApiStageProperties {
     simulated: simulatedProperties,
   });
 
+  private readonly methodSettingsParser: SimCfnRestApiMethodSettingsProperties;
+
   constructor(properties: SimCfnRestApiStagePropertiesProperties) {
     this.resource = properties.resource;
     this.properties = properties.properties;
+    this.methodSettingsParser = new SimCfnRestApiMethodSettingsProperties({
+      resource: this.resource,
+    });
 
     this.propertyParser.ignoreUnsimulated(this.resource, this.properties);
   }
@@ -75,7 +82,9 @@ export class SimCfnRestApiStageProperties {
    * `DeploymentId` is the `Ref` to the AWS::ApiGateway::Deployment this stage
    * serves. A deployment id naming nothing on the API is refused by
    * CreateStage, which is what stops a `Ref` to a Resource this simulation
-   * skipped from publishing a stage that serves nothing.
+   * skipped from publishing a stage that serves nothing. `MethodSettings`
+   * arrives holding only its throttling members, so the ones CreateStage would
+   * refuse never reach it from a template.
    */
   createStageInput(): SimCreateStageCommandInput {
     return {
@@ -95,6 +104,10 @@ export class SimCfnRestApiStageProperties {
         this.resource,
         this.properties["Variables"],
         "Variables",
+      ),
+      methodSettings: this.methodSettingsParser.methodSettings(
+        this.properties["MethodSettings"],
+        "MethodSettings",
       ),
     };
   }

--- a/src/service/apigateway/command/sim-api-gateway-unsimulated-input.ts
+++ b/src/service/apigateway/command/sim-api-gateway-unsimulated-input.ts
@@ -19,16 +19,25 @@ export class SimApiGatewayUnsimulatedInput {
 
   /**
    * Refuse every supplied input that is not one of the accepted options.
+   *
+   * An option nested inside another, such as one member of a stage's
+   * `methodSettings`, is refused by the same accepted set. `within` names the
+   * path it was written at, and the message then points at the member the
+   * caller wrote.
    */
-  refuseUnaccepted(input: object, accepted: readonly string[]): void {
+  refuseUnaccepted(
+    input: object,
+    accepted: readonly string[],
+    within = "",
+  ): void {
     for (const [option, value] of Object.entries(input)) {
       if (value === undefined || accepted.includes(option)) {
         continue;
       }
 
       throw new SimApiGatewayBadRequest(
-        `${this.operation} ${option} is not simulated: it would be ignored ` +
-          `here and applied on real AWS`,
+        `${this.operation} ${within}${option} is not simulated: it would be ` +
+          `ignored here and applied on real AWS`,
       );
     }
   }

--- a/src/service/apigateway/command/stage/sim-rest-api-stage-commands.iso.test.ts
+++ b/src/service/apigateway/command/stage/sim-rest-api-stage-commands.iso.test.ts
@@ -15,6 +15,7 @@ import { describe, expect, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
 import {
+  SimApiGatewayBadRequest,
   SimApiGatewayConflict,
   SimApiGatewayNotFound,
 } from "../../error/sim-api-gateway.error.js";
@@ -255,5 +256,118 @@ describe("Sim API Gateway REST API deployment and stage commands", () => {
     // Then it is refused
     await expect(deleted).rejects.toThrow(SimApiGatewayNotFound);
     await expect(deleted).rejects.toThrow("Invalid stage identifier");
+  });
+
+  it("keeps the method settings a stage was created with", async () => {
+    // Given a REST API with a deployment nothing serves yet
+    const simAws = new SimAws();
+    const restApiId = await givenRestApi(simAws.apiGateway());
+    const deployment = await simAws
+      .apiGateway()
+      .createDeployment(new CreateDeploymentCommand({ restApiId }));
+
+    // When a stage is created with a stage default and a method of its own.
+    // The settings are sent as a plain input, since real CreateStage carries
+    // no method settings and the SDK command declares no such member.
+    const created = await simAws.apiGateway().createStage({
+      input: {
+        restApiId,
+        stageName: "prod",
+        deploymentId: deployment.id,
+        methodSettings: {
+          "/*/*": { throttlingRateLimit: 10, throttlingBurstLimit: 5 },
+          "/password-reset/POST": {
+            throttlingRateLimit: 1,
+            throttlingBurstLimit: 2,
+          },
+        },
+      },
+    });
+
+    // Then both are reported back, by the create and by the get
+    expect(created.methodSettings?.["/*/*"]).toStrictEqual({
+      throttlingRateLimit: 10,
+      throttlingBurstLimit: 5,
+    });
+
+    const stage = await simAws
+      .apiGateway()
+      .getStage(new GetStageCommand({ restApiId, stageName: "prod" }));
+    expect(stage.methodSettings?.["/password-reset/POST"]).toStrictEqual({
+      throttlingRateLimit: 1,
+      throttlingBurstLimit: 2,
+    });
+  });
+
+  it("reports no method settings for a stage created without any", async () => {
+    // Given a REST API published to a stage that names no limits
+    const simAws = new SimAws();
+    const restApiId = await givenRestApi(simAws.apiGateway());
+    await simAws
+      .apiGateway()
+      .createDeployment(
+        new CreateDeploymentCommand({ restApiId, stageName: "prod" }),
+      );
+
+    // When the stage is read back
+    const stage = await simAws
+      .apiGateway()
+      .getStage(new GetStageCommand({ restApiId, stageName: "prod" }));
+
+    // Then nothing is reported, as AWS reports none for a stage that throttles
+    // at the account limits
+    assertUndefined(stage.methodSettings);
+  });
+
+  it("refuses a method setting that is not about throttling", async () => {
+    // Given a REST API with a deployment
+    const simAws = new SimAws();
+    const restApiId = await givenRestApi(simAws.apiGateway());
+    const deployment = await simAws
+      .apiGateway()
+      .createDeployment(new CreateDeploymentCommand({ restApiId }));
+
+    // When a stage asks for request logging alongside its throttle
+    const stage = {
+      input: {
+        restApiId,
+        stageName: "prod",
+        deploymentId: deployment.id,
+        methodSettings: {
+          "/orders/GET": { throttlingRateLimit: 1, loggingLevel: "INFO" },
+        },
+      },
+    };
+
+    // Then the member that is not simulated is refused by the path it was
+    // written at, rather than logging nothing while the throttle works
+    await expect(simAws.apiGateway().createStage(stage)).rejects.toThrow(
+      /methodSettings '\/orders\/GET' loggingLevel is not simulated/,
+    );
+  });
+
+  it("refuses a method settings key that names no method", async () => {
+    // Given a REST API with a deployment
+    const simAws = new SimAws();
+    const restApiId = await givenRestApi(simAws.apiGateway());
+    const deployment = await simAws
+      .apiGateway()
+      .createDeployment(new CreateDeploymentCommand({ restApiId }));
+
+    // When a key is written as something other than a resource path and an
+    // HTTP method
+    const stage = {
+      input: {
+        restApiId,
+        stageName: "prod",
+        deploymentId: deployment.id,
+        methodSettings: { orders: { throttlingRateLimit: 1 } },
+      },
+    };
+
+    // Then it is refused, because API Gateway would find no method under it
+    await expect(simAws.apiGateway().createStage(stage)).rejects.toThrow(
+      SimApiGatewayBadRequest,
+    );
   });
 });

--- a/src/service/apigateway/command/stage/sim-rest-api-stage-commands.ts
+++ b/src/service/apigateway/command/stage/sim-rest-api-stage-commands.ts
@@ -2,6 +2,7 @@ import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import type { SimApiGatewayRequestOptions } from "../sim-api-gateway-request-options.js";
 import { SimApiGatewayUnsimulatedInput } from "../sim-api-gateway-unsimulated-input.js";
 import type { SimRestApiAccess } from "../sim-rest-api-access.js";
+import { simRestApiStageMethodSettings } from "./sim-rest-api-stage-method-settings-input.js";
 import { SimRestApiStagePublisher } from "./sim-rest-api-stage-publisher.js";
 import { SimRestApiStageRules } from "./sim-rest-api-stage-rules.js";
 import type {
@@ -23,6 +24,7 @@ const acceptedCreateOptions = [
   "deploymentId",
   "description",
   "variables",
+  "methodSettings",
 ];
 
 interface SimRestApiStageCommandsProperties {
@@ -59,6 +61,7 @@ export class SimRestApiStageCommands {
     const restApiId = unsimulated.require("restApiId", input.restApiId);
     const stageName = unsimulated.require("stageName", input.stageName);
     const named = unsimulated.require("deploymentId", input.deploymentId);
+    const methodSettings = simRestApiStageMethodSettings(input, unsimulated);
 
     const restApi = this.access.api({
       method: "POST",
@@ -72,6 +75,7 @@ export class SimRestApiStageCommands {
       deploymentId,
       description: input.description,
       variables: input.variables,
+      methodSettings,
     });
 
     return { ...stage.view(), $metadata: {} };

--- a/src/service/apigateway/command/stage/sim-rest-api-stage-method-settings-input.ts
+++ b/src/service/apigateway/command/stage/sim-rest-api-stage-method-settings-input.ts
@@ -1,0 +1,59 @@
+import type { SimRestApiMethodSettingsMap } from "../../api/stage/settings/sim-rest-api-method-settings.type.js";
+import { SimApiGatewayBadRequest } from "../../error/sim-api-gateway.error.js";
+import type { SimApiGatewayUnsimulatedInput } from "../sim-api-gateway-unsimulated-input.js";
+import type { SimCreateStageCommandInput } from "./stage.command.js";
+
+/**
+ * The method setting members this simulation acts on. `cachingEnabled`,
+ * `metricsEnabled`, `loggingLevel` and `dataTraceEnabled` are caching, metrics
+ * and logging, and nothing here reads any of them.
+ */
+const acceptedMethodSettings = ["throttlingRateLimit", "throttlingBurstLimit"];
+
+/**
+ * Read the throttling a CreateStage input asks for.
+ *
+ * An entry is keyed `{resourcePath}/{httpMethod}`, which is how API Gateway
+ * keys the settings it reports, and the entry keyed with two stars is the
+ * stage default. Real CreateStage carries no method settings at all. AWS takes
+ * them through UpdateStage patch operations, which are outside this
+ * simulation, and through the `MethodSettings` of an AWS::ApiGateway::Stage.
+ * This input is here so that a test can throttle a stage without a template.
+ *
+ * Every entry is checked member by member. A stage asking for request logging
+ * is refused by the member that asks for it.
+ */
+export function simRestApiStageMethodSettings(
+  input: SimCreateStageCommandInput,
+  unsimulated: SimApiGatewayUnsimulatedInput,
+): SimRestApiMethodSettingsMap | undefined {
+  const { methodSettings } = input;
+  const perMethod = Object.entries(methodSettings ?? {});
+
+  for (const [key, settings] of perMethod) {
+    requireMethodKey(key);
+    unsimulated.refuseUnaccepted(
+      settings,
+      acceptedMethodSettings,
+      `methodSettings '${key}' `,
+    );
+  }
+
+  return methodSettings;
+}
+
+/**
+ * Refuse a key that is not a resource path followed by an HTTP method.
+ */
+function requireMethodKey(key: string): void {
+  if (key.startsWith("/") && key.lastIndexOf("/") > 0) {
+    return;
+  }
+
+  throw new SimApiGatewayBadRequest(
+    `CreateStage methodSettings key '${key}' is not a method: a key is a ` +
+      `resource path and an HTTP method, such as '/orders/GET', and the ` +
+      `stage default is the resource path '/*' and the method '*' joined ` +
+      `the same way`,
+  );
+}

--- a/src/service/apigateway/command/stage/sim-rest-api-stage-publisher.ts
+++ b/src/service/apigateway/command/stage/sim-rest-api-stage-publisher.ts
@@ -1,5 +1,7 @@
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import type { SimRestApiDeploymentId } from "../../api/deployment/sim-rest-api-deployment.js";
+import type { SimRestApiMethodSettingsMap } from "../../api/stage/settings/sim-rest-api-method-settings.type.js";
+import { SimRestApiStageMethodSettings } from "../../api/stage/settings/sim-rest-api-stage-method-settings.js";
 import { SimRestApiStage } from "../../api/stage/sim-rest-api-stage.js";
 import type { SimRestApi } from "../../api/sim-rest-api.js";
 import { SimRestApiStageRules } from "./sim-rest-api-stage-rules.js";
@@ -16,6 +18,7 @@ export interface SimRestApiStageInput {
   readonly deploymentId: SimRestApiDeploymentId;
   readonly description?: string | undefined;
   readonly variables?: Readonly<Record<string, string>> | undefined;
+  readonly methodSettings?: SimRestApiMethodSettingsMap | undefined;
 }
 
 /**
@@ -61,6 +64,25 @@ export class SimRestApiStagePublisher {
     return existing;
   }
 
+  /**
+   * The throttle a new stage serves at, or undefined for a stage that named no
+   * method settings.
+   *
+   * The buckets are a function of the same clock the stage is stamped with.
+   */
+  private throttle(
+    input: SimRestApiStageInput,
+  ): SimRestApiStageMethodSettings | undefined {
+    if (input.methodSettings === undefined) {
+      return undefined;
+    }
+
+    return new SimRestApiStageMethodSettings({
+      clock: this.clock,
+      methodSettings: input.methodSettings,
+    });
+  }
+
   private added(
     restApi: SimRestApi,
     input: SimRestApiStageInput,
@@ -68,6 +90,7 @@ export class SimRestApiStagePublisher {
     const stage = new SimRestApiStage({
       ...input,
       createdDate: this.clock.now(),
+      methodSettings: this.throttle(input),
     });
     restApi.stages.add(stage);
 

--- a/src/service/apigateway/command/stage/stage.command.ts
+++ b/src/service/apigateway/command/stage/stage.command.ts
@@ -1,5 +1,6 @@
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
 import type { SimRestApiDeploymentView } from "../../api/deployment/sim-rest-api-deployment.js";
+import type { SimRestApiMethodSettingsMap } from "../../api/stage/settings/sim-rest-api-method-settings.type.js";
 import type { SimRestApiStageView } from "../../api/stage/sim-rest-api-stage.js";
 
 /**
@@ -38,6 +39,16 @@ export interface SimCreateStageCommandInput {
   readonly deploymentId?: string | undefined;
   readonly description?: string | undefined;
   readonly variables?: Readonly<Record<string, string>> | undefined;
+  /**
+   * The throttle of each method, keyed `{resourcePath}/{httpMethod}`, with the
+   * key of two stars as the stage default.
+   *
+   * Real CreateStage takes no such member. API Gateway sets these through
+   * UpdateStage patch operations, which are outside this simulation, and
+   * through the `MethodSettings` of an AWS::ApiGateway::Stage. This is here so
+   * that a test can throttle a stage without a template.
+   */
+  readonly methodSettings?: SimRestApiMethodSettingsMap | undefined;
 }
 
 export interface SimCreateStageCommandOutput extends SimRestApiStageView {

--- a/src/service/apigateway/index.ts
+++ b/src/service/apigateway/index.ts
@@ -110,6 +110,11 @@ export {
   type SimRestApiStageView,
 } from "./api/stage/sim-rest-api-stage.js";
 export { SimRestApiStageStore } from "./api/stage/sim-rest-api-stage-store.js";
+export type {
+  SimRestApiMethodSettings,
+  SimRestApiMethodSettingsMap,
+} from "./api/stage/settings/sim-rest-api-method-settings.type.js";
+export { SimRestApiStageMethodSettings } from "./api/stage/settings/sim-rest-api-stage-method-settings.js";
 export {
   SimApiGatewayBadRequest,
   SimApiGatewayConflict,

--- a/src/service/apigateway/serve/sim-api-gateway-controller.ts
+++ b/src/service/apigateway/serve/sim-api-gateway-controller.ts
@@ -29,7 +29,10 @@ interface SimApiGatewayServiceControllerProperties {
  * simulated Lambda function with a payload format 1.0 event. The function runs
  * as its execution Role, as it does for any other invocation.
  *
- * A method that authorizes anybody is checked before any of that. An `AWS_IAM`
+ * The stage's throttle comes before any of that. A method whose bucket is
+ * empty is answered 429, and neither its authorizer nor its integration runs.
+ *
+ * A method that authorizes anybody is checked next. An `AWS_IAM`
  * method's caller has to be allowed `execute-api:Invoke` on the method, and a
  * `CUSTOM` method's Lambda authorizer has to allow the request, or the request
  * is refused and the integration is never invoked. Whether the API may invoke a
@@ -108,6 +111,13 @@ export class SimApiGatewayServiceController implements SimAwsServiceController {
 
     if (!isSimRestApiMatch(match)) {
       return this.missResponse(match);
+    }
+
+    // The stage's throttle is asked before the method's authorizer. A flood of
+    // requests to a throttled method invokes neither. AWS publishes no order
+    // between the two.
+    if (!match.stage.admits(match.resource.path, match.method.httpMethod)) {
+      return this.errorResponse.tooManyRequests();
     }
 
     // The client's own authorization comes next: a request with no

--- a/src/service/apigateway/serve/sim-api-gateway-error-response.ts
+++ b/src/service/apigateway/serve/sim-api-gateway-error-response.ts
@@ -59,6 +59,17 @@ export class SimApiGatewayErrorResponse {
   }
 
   /**
+   * The method's throttle had no token left for the request.
+   *
+   * The stage's `MethodSettings` set the rate and the burst each method is
+   * served at, and every client of a method draws on the one bucket. A client
+   * can be refused over traffic it did not send.
+   */
+  tooManyRequests(): Response {
+    return this.jsonResponse(429, "Too Many Requests");
+  }
+
+  /**
    * The method's authorizer could not answer at all.
    */
   internalServerError(): Response {

--- a/src/service/apigateway/serve/sim-rest-api-throttling.iso.test.ts
+++ b/src/service/apigateway/serve/sim-rest-api-throttling.iso.test.ts
@@ -1,0 +1,205 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simRestApiLambdaProxyFactory } from "../api/sim-rest-api-lambda-proxy.factory.js";
+import type { SimRestApiMethodSettingsMap } from "../api/stage/settings/sim-rest-api-method-settings.type.js";
+import type { SimRestApi } from "../api/sim-rest-api.js";
+
+/** The resource a stage throttles harder than the rest of its API. */
+const passwordReset = "/password-reset";
+
+/** The resource the rest of the API's traffic goes to. */
+const profile = "/profile";
+
+/** Both resources declare this method, so both are keyed by it. */
+const httpMethod = "POST";
+
+/** Method settings naming the password reset method and nothing else. */
+const perMethod: SimRestApiMethodSettingsMap = {
+  [`${passwordReset}/${httpMethod}`]: {
+    throttlingRateLimit: 1,
+    throttlingBurstLimit: 2,
+  },
+};
+
+/** The stage default, which real API Gateway keys with two stars. */
+const stageDefault = "/*/*";
+
+/**
+ * Send one request to a resource of an API, as a named client.
+ *
+ * The throttle reads nothing about the client, and the header is here so a
+ * test can say which client sent what. A stage bucket is shared, and who sent
+ * a request makes no difference to whether it is served.
+ */
+async function request(
+  simAws: SimAws,
+  restApi: SimRestApi,
+  path: string,
+  client = "one",
+): Promise<Response> {
+  const url = new SimAwsLocalUrl({
+    input: `${restApi.invokeUrl("prod")}${path}`,
+  }).toString();
+
+  return await new SimAwsHttp({ simAws }).fetch(url, {
+    method: httpMethod,
+    headers: { "x-client": client },
+  });
+}
+
+/**
+ * The status one request to a resource gets back.
+ */
+async function status(
+  simAws: SimAws,
+  restApi: SimRestApi,
+  path: string,
+): Promise<number> {
+  const response = await request(simAws, restApi, path);
+
+  return response.status;
+}
+
+/**
+ * An API whose stage throttles, with the clock stopped so only what a test
+ * asks for moves it.
+ */
+async function throttledApi(
+  simAws: SimAws,
+  methodSettings: SimRestApiMethodSettingsMap,
+): Promise<SimRestApi> {
+  const restApi = await simRestApiLambdaProxyFactory.make(
+    {
+      resourcePaths: [passwordReset, profile],
+      httpMethod,
+      methodSettings,
+      handler: () => ({ statusCode: 200, body: "ok" }),
+    },
+    simAws,
+  );
+  simAws.clock().freeze();
+
+  return restApi;
+}
+
+describe("Throttling a sim REST API stage", () => {
+  it("answers a request past the method's burst with 429", async () => {
+    // Given a stage allowing two password resets at once and one a second
+    const simAws = new SimAws();
+    const restApi = await throttledApi(simAws, perMethod);
+
+    // When three arrive with no time between them
+    const responses = [
+      await request(simAws, restApi, passwordReset),
+      await request(simAws, restApi, passwordReset),
+      await request(simAws, restApi, passwordReset),
+    ];
+
+    // Then the burst is served and the request past it is refused, with the
+    // `message` body a REST API answers with
+    expect(responses.map((response) => response.status)).toStrictEqual([
+      200, 200, 429,
+    ]);
+    expect(await responses[2]?.json()).toStrictEqual({
+      message: "Too Many Requests",
+    });
+  });
+
+  it("refills the bucket as the simulated clock moves on", async () => {
+    // Given a method that has run out of tokens
+    const simAws = new SimAws();
+    const restApi = await throttledApi(simAws, perMethod);
+    await request(simAws, restApi, passwordReset);
+    await request(simAws, restApi, passwordReset);
+    assertIdentical(await status(simAws, restApi, passwordReset), 429);
+
+    // When a second passes, which is one token at the method's rate limit
+    await simAws.clock().advanceBy({ seconds: 1 });
+
+    // Then the next request is served, and the one after it is not, because
+    // the second refilled one token rather than the whole burst
+    assertIdentical(await status(simAws, restApi, passwordReset), 200);
+    assertIdentical(await status(simAws, restApi, passwordReset), 429);
+  });
+
+  it("gives a method named in MethodSettings the limit it names", async () => {
+    // Given a stage whose default is generous and whose password reset method
+    // is not
+    const simAws = new SimAws();
+    const restApi = await throttledApi(simAws, {
+      [stageDefault]: { throttlingRateLimit: 10, throttlingBurstLimit: 5 },
+      ...perMethod,
+    });
+
+    // When the password reset method is used past its own burst
+    await request(simAws, restApi, passwordReset);
+    await request(simAws, restApi, passwordReset);
+
+    // Then it is refused by the entry that names it, while the method drawing
+    // on the stage default is served from a bucket of its own
+    assertIdentical(await status(simAws, restApi, passwordReset), 429);
+    assertIdentical(await status(simAws, restApi, profile), 200);
+  });
+
+  it("throttles a method on the stage default when nothing names it", async () => {
+    // Given a stage default of one request at a time and no entry for any
+    // method
+    const simAws = new SimAws();
+    const restApi = await throttledApi(simAws, {
+      [stageDefault]: { throttlingRateLimit: 1, throttlingBurstLimit: 1 },
+    });
+
+    // When one method is used twice
+    const served = await status(simAws, restApi, profile);
+    const refused = await status(simAws, restApi, profile);
+
+    // Then the second is refused on the stage default
+    assertIdentical(served, 200);
+    assertIdentical(refused, 429);
+  });
+
+  it("counts every client against the one bucket", async () => {
+    // Given a stage allowing two password resets at once
+    const simAws = new SimAws();
+    const restApi = await throttledApi(simAws, perMethod);
+
+    // When two clients send one each, and then one of them sends another
+    const first = await request(simAws, restApi, passwordReset, "one");
+    const second = await request(simAws, restApi, passwordReset, "two");
+    const third = await request(simAws, restApi, passwordReset, "two");
+
+    // Then the third is refused, because a stage throttle is one bucket for
+    // the method, where a WAF rate-based rule counts each client on its own
+    expect([first.status, second.status, third.status]).toStrictEqual([
+      200, 200, 429,
+    ]);
+  });
+
+  it("serves everything when the stage names no limits", async () => {
+    // Given a stage created without method settings
+    const simAws = new SimAws();
+    const restApi = await simRestApiLambdaProxyFactory.make(
+      {
+        resourcePaths: [passwordReset],
+        httpMethod,
+        handler: () => ({ statusCode: 200, body: "ok" }),
+      },
+      simAws,
+    );
+
+    // When the same method is used many times over
+    const statuses = await Promise.all(
+      Array.from({ length: 20 }, async () =>
+        status(simAws, restApi, passwordReset),
+      ),
+    );
+
+    // Then nothing is throttled, as nothing was throttled before a stage could
+    // ask for it
+    expect(statuses).toStrictEqual(Array.from({ length: 20 }, () => 200));
+  });
+});

--- a/src/service/apigatewayv2/api/stage/settings/sim-http-api-stage-route-settings.ts
+++ b/src/service/apigatewayv2/api/stage/settings/sim-http-api-stage-route-settings.ts
@@ -4,7 +4,7 @@ import type {
   SimHttpApiRouteSettingsMap,
   SimHttpApiRouteSettingsView,
 } from "./sim-http-api-route-settings.type.js";
-import { SimHttpApiTokenBucket } from "./sim-http-api-token-bucket.js";
+import { SimTokenBucket } from "../../../../../util/throttle/sim-token-bucket.js";
 
 interface SimHttpApiStageRouteSettingsProperties {
   readonly clock: SimClock;
@@ -31,7 +31,7 @@ export class SimHttpApiStageRouteSettings {
   readonly #clock: SimClock;
   readonly #defaultRouteSettings?: SimHttpApiRouteSettings | undefined;
   readonly #routeSettings: ReadonlyMap<string, SimHttpApiRouteSettings>;
-  readonly #buckets = new Map<string, SimHttpApiTokenBucket | undefined>();
+  readonly #buckets = new Map<string, SimTokenBucket | undefined>();
 
   constructor(properties: SimHttpApiStageRouteSettingsProperties) {
     this.#clock = properties.clock;
@@ -74,7 +74,7 @@ export class SimHttpApiStageRouteSettings {
    * The bucket a route key draws on, made the first time the route is asked
    * about so that it starts full at the request that found it.
    */
-  #bucketFor(routeKey: string): SimHttpApiTokenBucket | undefined {
+  #bucketFor(routeKey: string): SimTokenBucket | undefined {
     if (!this.#buckets.has(routeKey)) {
       this.#buckets.set(routeKey, this.#newBucket(routeKey));
     }
@@ -82,7 +82,7 @@ export class SimHttpApiStageRouteSettings {
     return this.#buckets.get(routeKey);
   }
 
-  #newBucket(routeKey: string): SimHttpApiTokenBucket | undefined {
+  #newBucket(routeKey: string): SimTokenBucket | undefined {
     const settings =
       this.#routeSettings.get(routeKey) ?? this.#defaultRouteSettings;
     const rateLimit = settings?.ThrottlingRateLimit;
@@ -92,7 +92,7 @@ export class SimHttpApiStageRouteSettings {
       return undefined;
     }
 
-    return new SimHttpApiTokenBucket({
+    return new SimTokenBucket({
       clock: this.#clock,
       rateLimit,
       burstLimit,

--- a/src/service/apigatewayv2/index.ts
+++ b/src/service/apigatewayv2/index.ts
@@ -86,7 +86,6 @@ export type {
   SimHttpApiRouteSettingsView,
 } from "./api/stage/settings/sim-http-api-route-settings.type.js";
 export { SimHttpApiStageRouteSettings } from "./api/stage/settings/sim-http-api-stage-route-settings.js";
-export { SimHttpApiTokenBucket } from "./api/stage/settings/sim-http-api-token-bucket.js";
 export {
   SimApiGatewayV2BadRequest,
   SimApiGatewayV2Conflict,

--- a/src/util/throttle/sim-token-bucket.ts
+++ b/src/util/throttle/sim-token-bucket.ts
@@ -1,34 +1,37 @@
-import type { SimClock } from "../../../../../util/clock/sim-clock.js";
+import type { SimClock } from "../clock/sim-clock.js";
 
 const millisecondsPerSecond = 1000;
 
-interface SimHttpApiTokenBucketProperties {
+interface SimTokenBucketProperties {
   readonly clock: SimClock;
-  /** Tokens added per second, which is `ThrottlingRateLimit`. */
+  /** Tokens added per second, which is the throttling rate limit. */
   readonly rateLimit: number;
-  /** How many tokens the bucket holds, which is `ThrottlingBurstLimit`. */
+  /** How many tokens the bucket holds, which is the throttling burst limit. */
   readonly burstLimit: number;
 }
 
 /**
- * The token bucket one throttled route is served from.
+ * The token bucket one throttled thing is served from.
  *
- * The bucket starts full. A route whose burst is five serves five requests
- * before the rate matters. Each request takes a token, and tokens come back at
- * the rate limit, up to the burst limit.
+ * The bucket starts full. A burst of five buys five requests before the rate
+ * matters. Each request takes a token, and tokens come back at the rate limit,
+ * up to the burst limit.
  *
  * Refilling is a function of the simulated clock. A frozen clock holds the
- * bucket where it is, and a test moves the clock to fill it. Every client of
- * the route draws on this one bucket.
+ * bucket where it is, and a test moves the clock to fill it.
+ *
+ * An API Gateway stage throttle is what this is here for. An HTTP API's routes
+ * and a REST API's methods are both served from one of these each, and every
+ * client of one draws on that same bucket.
  */
-export class SimHttpApiTokenBucket {
+export class SimTokenBucket {
   readonly #clock: SimClock;
   readonly #rateLimit: number;
   readonly #burstLimit: number;
   #tokens: number;
   #filledAt: number;
 
-  constructor(properties: SimHttpApiTokenBucketProperties) {
+  constructor(properties: SimTokenBucketProperties) {
     this.#clock = properties.clock;
     this.#rateLimit = properties.rateLimit;
     this.#burstLimit = properties.burstLimit;


### PR DESCRIPTION
A simulated REST API stage now holds a token bucket for each method it serves. A method setting is
addressed by `{resourcePath}/{httpMethod}`, which is how API Gateway addresses one, and the entry
keyed with two stars is the stage default. A request finding an empty bucket is answered 429 with
the `message` body a REST API sends, and neither the method's authorizer nor its integration runs.
The buckets refill against the simulated clock, and a test can spend a burst, assert the refusal and
then move a second on. Every client of a method draws on the one bucket, which is what separates a
stage throttle from the WAFv2 `RateBasedStatement` already simulated.

`AWS::ApiGateway::Stage` deploys `MethodSettings`, reading each entry into that map and recording
the members outside throttling under the entry they were written on. The property leaves
`stack.ignoredProperties`.

One divergence from the issue, worth flagging: real `CreateStage` carries no method settings at all.
AWS sets them with `UpdateStage` patch operations, which are outside this simulation, or from a
template. The `methodSettings` input is therefore this simulator's own, so a test can throttle a
stage without a template, and the SDK's `CreateStageCommand` declares no such member, so those tests
send the input directly. `GetStage` reports the settings the way AWS reports them. This is stated in
the docs and in the input type.

The token bucket #950 added for the HTTP API stage throttle moves to `src/util/throttle`, where both
services take it from.

Resolves #946