### PR TITLE
feat: retry and catch a failing task

### DIFF
--- a/docs/services/stepfunctions/README.md
+++ b/docs/services/stepfunctions/README.md
@@ -17,6 +17,9 @@ The data-flow fields run in full. `InputPath`, `Parameters`, `ResultSelector`, `
 A `Task` state invokes a simulated Lambda function. Every other `Resource` is refused when the state
 machine is created, naming what the definition asked for.
 
+A `Task` state's `Retry` and `Catch` both run, on the simulation's clock, along with the
+`TimeoutSeconds` and `HeartbeatSeconds` it takes.
+
 ## Running a state machine
 
 ```typescript sim-step-functions-run
@@ -270,12 +273,197 @@ A handler that raises fails the task, and the Amazon States Language error name 
 - Through a function ARN it is the handler's own error type. An error named `NotEligible` fails the
   task as `NotEligible`.
 
-`Retry` and `Catch` match on that name. Neither runs here yet. A task that fails ends the execution,
-and `DescribeExecution` carries the error name and the handler's message.
+`Retry` and `Catch` match on that name, and the next section covers both. A task that carries
+neither ends the execution, and `DescribeExecution` carries the error name and the handler's
+message.
 
 Anything else that stops a task from running fails it with `States.TaskFailed`. A function that is
 not there, a role that cannot be assumed, and a role that may not invoke are the three of them, and
 the cause says which one it was.
+
+## Retrying and catching a failure
+
+A `Task` state's `Retry` runs a failing task again on the simulation's clock. Its `Catch` sends a
+failure that survived the retries to another state. Both match on the Amazon States Language error
+name, and both are read when the state machine is created.
+
+Each attempt is scheduled at its own instant, and the execution reads as `RUNNING` in between. One
+`advanceBy` covering the whole backoff runs every attempt in it, because an attempt the advance
+schedules is itself due by the time the advance gets there. A test advances once and then asserts.
+
+```typescript sim-step-functions-retry
+/**
+ * Retrying a failing task on the clock, and catching what the retries leave.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateFunctionCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws, SimFixedClock } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws({
+  clock: new SimFixedClock(new Date("2026-07-26T09:00:00.000Z")),
+});
+
+// The enrolment service is down for the whole of this run.
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "check-enrolment",
+    Role: "arn:aws:iam::123456789012:role/FunctionRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput(() => {
+        throw new Error("the enrolment service is down");
+      }),
+    },
+  }),
+);
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "WorkflowRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "states.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "WorkflowRole",
+    PolicyName: "InvokeEnrolmentFunctions",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "lambda:InvokeFunction",
+        Resource: "*",
+      },
+    }),
+  }),
+);
+
+const created = await simAws.stepFunctions().createStateMachine({
+  input: {
+    name: "Enrolment",
+    roleArn: role.Role.Arn,
+    definition: JSON.stringify({
+      StartAt: "Check",
+      States: {
+        Check: {
+          Type: "Task",
+          Resource: "arn:aws:states:::lambda:invoke",
+          Parameters: { FunctionName: "check-enrolment", "Payload.$": "$" },
+          Retry: [
+            {
+              ErrorEquals: ["States.TaskFailed"],
+              IntervalSeconds: 2,
+              MaxAttempts: 2,
+            },
+          ],
+          Catch: [
+            {
+              ErrorEquals: ["States.ALL"],
+              Next: "Compensate",
+              ResultPath: "$.error",
+            },
+          ],
+          Next: "Enrol",
+        },
+        Enrol: { Type: "Pass", Result: { enrolled: true }, End: true },
+        Compensate: { Type: "Pass", End: true },
+      },
+    }),
+  },
+});
+
+const started = await simAws.stepFunctions().startExecution({
+  input: {
+    stateMachineArn: created.stateMachineArn,
+    input: JSON.stringify({ student: "Wei" }),
+  },
+});
+
+const waiting = await simAws
+  .stepFunctions()
+  .describeExecution({ input: { executionArn: started.executionArn } });
+
+console.log(waiting.status); // RUNNING
+
+// The attempts fall at 0, 2 and 6 seconds. One advance covers all three.
+await simAws.clock().advanceBy({ seconds: 10 });
+
+const described = await simAws
+  .stepFunctions()
+  .describeExecution({ input: { executionArn: started.executionArn } });
+
+console.log(described.status); // SUCCEEDED
+console.log(described.stopDate); // 2026-07-26T09:00:06.000Z
+
+// {"student":"Wei","error":{"Error":"States.TaskFailed","Cause":"The function
+//  the Task state Check invoked raised Error: the enrolment service is down"}}
+console.log(described.output);
+
+// [ { stateName: 'Check', error: 'States.TaskFailed' },
+//   { stateName: 'Check', error: 'States.TaskFailed' },
+//   { stateName: 'Check', error: 'States.TaskFailed' },
+//   { stateName: 'Compensate' } ]
+console.log(simAws.stepFunctions().inspection().attempts(started.executionArn));
+```
+
+### Matching an error
+
+`ErrorEquals` names the errors an entry handles. The retriers are tried first and the catchers after
+them, each in the order it was written, and the first entry naming the error takes it. `States.ALL`
+matches anything. Amazon States Language holds that one to an entry of its own written last, and a
+definition breaking either rule is refused when the state machine is created.
+
+Which name a task fails under follows the `Resource` that invoked it, as the section above
+describes. A handler raising through `arn:aws:states:::lambda:invoke` is `States.TaskFailed`, and
+through a function ARN it is the handler's own error type.
+
+`States.Runtime` is left alone by both. Real Step Functions ends an execution on that one whatever a
+`Retry` or a `Catch` names, and a catcher on `States.ALL` passes over it.
+
+### How long a retry waits
+
+The wait starts at `IntervalSeconds` (1 second by default) and is multiplied by `BackoffRate` (2.0)
+for every retry already taken. `MaxDelaySeconds` caps it. `MaxAttempts` (3) counts retries. A
+retrier left on all four defaults runs a task four times, at 0, 1, 3 and 7 seconds.
+
+Each retrier keeps its own count, the way Amazon States Language keeps it. A task failing one way
+and then another spends one attempt from each of the two retriers that name them. A retrier with no
+attempts left hands the failure to the catchers, and a failure no catcher names ends the execution.
+
+`JitterStrategy` is refused when the state machine is created. Jitter varies the wait between
+attempts, and a test advancing a clock over that wait needs it fixed.
+
+### Where the error lands
+
+A catcher's `Next` names the state a caught failure goes to. Its `ResultPath` says where the error
+output sits in that state's input, and the error output holds `Error` and `Cause` (the two the
+example above prints). `ResultPath` reads the raw input of the state that failed. Writing it to
+`$.error` keeps the data the task was given and puts the error beside it. A catcher carrying no
+`ResultPath` passes the error output on by itself, and one carrying `null` passes the input on
+untouched.
+
+### How long a task waits
+
+`TimeoutSeconds` and `HeartbeatSeconds` say how long a `Task` state waits for its work. A task still
+going when simulated time reaches either one fails with `States.Timeout`, and the shorter of the two
+fires. The failure goes to the state's `Catch` like any other. The deadline covers the state with
+its retries in it, and a task that reaches the deadline gives up where it stands.
+
+### Counting the attempts
+
+`visitedStates` says which states an execution reached. `attempts` says how many runs each of those
+states took, and what each run failed with. A test asserting that a task ran three times counts the
+rows.
 
 ## Branching on the input
 
@@ -578,6 +766,15 @@ A test asserting on the output of a state machine that used one could only asser
   a call over a network there was none of here.
 - **A failed task's `Cause` is the handler's message.** Real Step Functions writes the JSON error
   document Lambda answered with, holding `errorMessage`, `errorType` and a stack trace.
+- **A task's timeout covers the whole state.** Real Step Functions gives every attempt its own
+  `TimeoutSeconds`. An attempt here takes no simulated time by itself, and a per-attempt deadline
+  would never be reached. The deadline runs from the instant the execution entered the state, and a
+  task that reaches it goes to its `Catch` without another attempt.
+- **Nothing sends a heartbeat.** `HeartbeatSeconds` behaves as a second, shorter `TimeoutSeconds`.
+  Activities and task tokens are unsimulated, and there is no worker to send one from.
+- **`TimeoutSecondsPath` and `HeartbeatSecondsPath` are unsimulated.** The two literal fields say
+  the same thing in the definition. A `Task` state carrying either path is refused when the state
+  machine is created.
 - **A cycle in the states fails the execution** after 25,000 transitions, with `States.Runtime`. Real
   Step Functions stops one when it runs out of execution history events.
 
@@ -601,9 +798,7 @@ two and is what this follows.
 
 ## Still to come
 
-- `Parallel` and `Map` states.
-- `Retry` and `Catch`, and the `TimeoutSeconds` and `HeartbeatSeconds` a `Task` state takes. A
-  definition carrying one of them is refused, naming the field.
+- `Parallel` and `Map` states, and the `Retry` and `Catch` those two take.
 - Service integrations beyond Lambda, task tokens and activities.
 - The context object, `$$`.
 - JSONata as a query language, and the `Assign` variables that go with it.

--- a/docs/services/stepfunctions/sim-step-functions-retry.example.ts
+++ b/docs/services/stepfunctions/sim-step-functions-retry.example.ts
@@ -1,0 +1,122 @@
+/**
+ * Retrying a failing task on the clock, and catching what the retries leave.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateFunctionCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws, SimFixedClock } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws({
+  clock: new SimFixedClock(new Date("2026-07-26T09:00:00.000Z")),
+});
+
+// The enrolment service is down for the whole of this run.
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "check-enrolment",
+    Role: "arn:aws:iam::123456789012:role/FunctionRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput(() => {
+        throw new Error("the enrolment service is down");
+      }),
+    },
+  }),
+);
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "WorkflowRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "states.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "WorkflowRole",
+    PolicyName: "InvokeEnrolmentFunctions",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "lambda:InvokeFunction",
+        Resource: "*",
+      },
+    }),
+  }),
+);
+
+const created = await simAws.stepFunctions().createStateMachine({
+  input: {
+    name: "Enrolment",
+    roleArn: role.Role.Arn,
+    definition: JSON.stringify({
+      StartAt: "Check",
+      States: {
+        Check: {
+          Type: "Task",
+          Resource: "arn:aws:states:::lambda:invoke",
+          Parameters: { FunctionName: "check-enrolment", "Payload.$": "$" },
+          Retry: [
+            {
+              ErrorEquals: ["States.TaskFailed"],
+              IntervalSeconds: 2,
+              MaxAttempts: 2,
+            },
+          ],
+          Catch: [
+            {
+              ErrorEquals: ["States.ALL"],
+              Next: "Compensate",
+              ResultPath: "$.error",
+            },
+          ],
+          Next: "Enrol",
+        },
+        Enrol: { Type: "Pass", Result: { enrolled: true }, End: true },
+        Compensate: { Type: "Pass", End: true },
+      },
+    }),
+  },
+});
+
+const started = await simAws.stepFunctions().startExecution({
+  input: {
+    stateMachineArn: created.stateMachineArn,
+    input: JSON.stringify({ student: "Wei" }),
+  },
+});
+
+const waiting = await simAws
+  .stepFunctions()
+  .describeExecution({ input: { executionArn: started.executionArn } });
+
+console.log(waiting.status); // RUNNING
+
+// The attempts fall at 0, 2 and 6 seconds. One advance covers all three.
+await simAws.clock().advanceBy({ seconds: 10 });
+
+const described = await simAws
+  .stepFunctions()
+  .describeExecution({ input: { executionArn: started.executionArn } });
+
+console.log(described.status); // SUCCEEDED
+console.log(described.stopDate); // 2026-07-26T09:00:06.000Z
+
+// {"student":"Wei","error":{"Error":"States.TaskFailed","Cause":"The function
+//  the Task state Check invoked raised Error: the enrolment service is down"}}
+console.log(described.output);
+
+// [ { stateName: 'Check', error: 'States.TaskFailed' },
+//   { stateName: 'Check', error: 'States.TaskFailed' },
+//   { stateName: 'Check', error: 'States.TaskFailed' },
+//   { stateName: 'Compensate' } ]
+console.log(simAws.stepFunctions().inspection().attempts(started.executionArn));

--- a/src/service/stepfunctions/definition/sim-states-state-parse.ts
+++ b/src/service/stepfunctions/definition/sim-states-state-parse.ts
@@ -8,6 +8,8 @@ import {
   SimStatesInvalidDefinition,
   SimStatesUnsimulatedInput,
 } from "../error/sim-step-functions.error.js";
+import { parseSimStatesCatchers } from "../retry/sim-states-catch-parse.js";
+import { parseSimStatesRetriers } from "../retry/sim-states-retry-parse.js";
 import { checkSimStatesTaskFields } from "../task/sim-states-task-fields.js";
 import { parseSimStatesTaskResource } from "../task/sim-states-task-resource.js";
 import { checkSimStatesWaitFields } from "../wait/sim-states-wait-fields.js";
@@ -94,7 +96,9 @@ function readChoiceState(
  * Read a `Task` state, whose `Resource` is read as the state is.
  *
  * The target becomes the object the state invokes through, so a `Task` state
- * that runs has already had its `Resource` and its `Parameters` read.
+ * that runs has already had its `Resource` and its `Parameters` read. Its
+ * `Retry` and `Catch` are read the same way, leaving the intervals, the
+ * attempt counts and the paths known before an execution reaches the state.
  */
 function readTaskState(
   name: string,
@@ -102,8 +106,13 @@ function readTaskState(
 ): SimStatesTaskState {
   checkSimStatesTaskFields(name, state);
 
+  const retriers = parseSimStatesRetriers(name, state);
+  const catchers = parseSimStatesCatchers(name, state);
+
   return {
     ...(state as unknown as SimStatesTaskState),
     target: parseSimStatesTaskResource(name, state),
+    ...(retriers !== undefined && { Retry: retriers }),
+    ...(catchers !== undefined && { Catch: catchers }),
   };
 }

--- a/src/service/stepfunctions/definition/sim-states-state.ts
+++ b/src/service/stepfunctions/definition/sim-states-state.ts
@@ -1,6 +1,7 @@
 import type { JSONValue } from "../../../util/type-guard/json.js";
 import type { SimStatesChoiceRule } from "../choice/sim-states-choice-rule.js";
 import type { SimStatesDataFlowFields } from "../data/sim-states-data-flow.js";
+import type { SimStatesTaskHandling } from "../retry/sim-states-task-handling.js";
 import type { SimStatesTaskTarget } from "../task/sim-states-task-target.js";
 
 /**
@@ -59,8 +60,11 @@ export interface SimStatesPassState extends SimStatesCommonState {
  * `Resource` is held as it was written, and `target` is what it named. The
  * `Resource` is read when the definition is read, so one this simulator cannot
  * reach is refused there rather than when an execution arrives at the state.
+ * `Retry` and `Catch` are read there too, and arrive here as the retriers and
+ * catchers a failing task is handled by.
  */
-export interface SimStatesTaskState extends SimStatesCommonState {
+export interface SimStatesTaskState
+  extends SimStatesCommonState, SimStatesTaskHandling {
   readonly Type: "Task";
   readonly Resource: string;
   readonly target: SimStatesTaskTarget;

--- a/src/service/stepfunctions/definition/sim-states-transitions.ts
+++ b/src/service/stepfunctions/definition/sim-states-transitions.ts
@@ -16,6 +16,8 @@ export function checkSimStatesTransitions(
   states: ReadonlyMap<string, SimStatesState>,
 ): void {
   for (const [name, state] of states) {
+    checkCatchers(name, state, states);
+
     if (isSimStatesTerminal(state)) {
       checkTerminal(name, state);
       continue;
@@ -39,6 +41,30 @@ function checkTerminal(name: string, state: SimStatesState): void {
       throw new SimStatesInvalidDefinition(
         `The ${state.Type} state ${name} carries ${field}. A ${state.Type} ` +
           "state ends the execution and carries neither.",
+      );
+    }
+  }
+}
+
+/**
+ * A catcher moves the execution on as well, to the state it names.
+ */
+function checkCatchers(
+  name: string,
+  state: SimStatesState,
+  states: ReadonlyMap<string, SimStatesState>,
+): void {
+  if (state.Type !== "Task") {
+    return;
+  }
+
+  const catchers = state.Catch ?? [];
+
+  for (const catcher of catchers) {
+    if (!states.has(catcher.Next)) {
+      throw new SimStatesInvalidDefinition(
+        `A catcher in the Task state ${name} moves to ${catcher.Next}, ` +
+          "which is not one of this state machine's states.",
       );
     }
   }

--- a/src/service/stepfunctions/execution/sim-states-attempt.ts
+++ b/src/service/stepfunctions/execution/sim-states-attempt.ts
@@ -1,0 +1,16 @@
+/**
+ * One run of one state, as an execution made it.
+ *
+ * A state a `Retry` ran again appears once per attempt, in the order the
+ * attempts were made, so a test can count how many times a task ran and read
+ * what each run failed with.
+ */
+export interface SimStatesAttempt {
+  readonly stateName: string;
+
+  /**
+   * The Amazon States Language error name the attempt failed with, where it
+   * failed. An attempt that did its work carries none.
+   */
+  readonly error?: string;
+}

--- a/src/service/stepfunctions/execution/sim-states-execution.ts
+++ b/src/service/stepfunctions/execution/sim-states-execution.ts
@@ -1,4 +1,5 @@
 import type { JSONValue } from "../../../util/type-guard/json.js";
+import type { SimStatesAttempt } from "./sim-states-attempt.js";
 
 export type SimStatesExecutionStatus =
   | "RUNNING"
@@ -19,8 +20,9 @@ interface SimStatesExecutionProperties {
  * One run of a state machine.
  *
  * An execution holds what it has done as well as where it got to, because the
- * states it visited are what a test asserts on. Real Step Functions keeps the
- * same record and answers it through `GetExecutionHistory`.
+ * states it visited and the attempts it made at them are what a test asserts
+ * on. Real Step Functions keeps the same record and answers it through
+ * `GetExecutionHistory`.
  */
 export class SimStatesExecution {
   readonly arn: string;
@@ -35,6 +37,7 @@ export class SimStatesExecution {
   #cause: string | undefined;
   #stopDate: Date | undefined;
   readonly #visited: string[] = [];
+  readonly #attempts: SimStatesAttempt[] = [];
 
   constructor(properties: SimStatesExecutionProperties) {
     this.arn = properties.arn;
@@ -72,10 +75,29 @@ export class SimStatesExecution {
   }
 
   /**
+   * Every run of a state this execution made, in the order it made them.
+   *
+   * A state entered once and retried twice is three attempts and one visit.
+   */
+  get attempts(): readonly SimStatesAttempt[] {
+    return [...this.#attempts];
+  }
+
+  /**
    * Record that the execution has entered a state.
    */
   enter(stateName: string): void {
     this.#visited.push(stateName);
+  }
+
+  /**
+   * Record that the execution ran a state, and what that run failed with.
+   */
+  attempt(stateName: string, error: string | undefined): void {
+    this.#attempts.push({
+      stateName,
+      ...(error !== undefined && { error }),
+    });
   }
 
   /**

--- a/src/service/stepfunctions/execution/sim-states-interpreter.ts
+++ b/src/service/stepfunctions/execution/sim-states-interpreter.ts
@@ -10,12 +10,8 @@ import {
   simStatesUnknownStateFailure,
 } from "./sim-states-failure.js";
 import { SimStatesSettlement } from "./sim-states-settlement.js";
+import { SimStatesStateAttempts } from "./sim-states-state-attempts.js";
 import { SimStatesStateRunner } from "./sim-states-state-runner.js";
-import type {
-  SimStatesMoveOnOutcome,
-  SimStatesNextOutcome,
-  SimStatesStateOutcome,
-} from "./sim-states-state-outcome.js";
 
 interface SimStatesInterpreterProperties {
   readonly definition: SimStatesDefinition;
@@ -42,17 +38,19 @@ interface SimStatesInterpreterProperties {
  *
  * A `Wait` state pauses the walk rather than blocking it. The rest of it is
  * scheduled on the simulation's clock, so the execution stays `RUNNING` until
- * something moves simulated time to the instant it is waiting for.
+ * something moves simulated time to the instant it is waiting for. A `Retry`
+ * pauses it the same way, with the next attempt at the state standing in for
+ * the state after it.
  */
 export class SimStatesInterpreter {
   readonly #definition: SimStatesDefinition;
   readonly #execution: SimStatesExecution;
   readonly #background: BackgroundScheduler;
-  readonly #runner: SimStatesStateRunner;
   readonly #settlement: SimStatesSettlement;
+  readonly #attempts: SimStatesStateAttempts;
 
   /**
-   * Transitions made so far, counted across the pauses a `Wait` state makes.
+   * Transitions made so far, counted across every pause the clock makes.
    */
   #taken = 0;
 
@@ -60,14 +58,22 @@ export class SimStatesInterpreter {
     this.#definition = properties.definition;
     this.#execution = properties.execution;
     this.#background = properties.background;
-    this.#runner = new SimStatesStateRunner({
-      background: properties.background,
-      tasks: properties.tasks,
-      roleArn: properties.roleArn,
-    });
     this.#settlement = new SimStatesSettlement({
       execution: properties.execution,
       background: properties.background,
+    });
+    this.#attempts = new SimStatesStateAttempts({
+      runner: new SimStatesStateRunner({
+        execution: properties.execution,
+        background: properties.background,
+        tasks: properties.tasks,
+        roleArn: properties.roleArn,
+      }),
+      settlement: this.#settlement,
+      background: properties.background,
+      walkOn: async (outcome): Promise<void> => {
+        await this.#walk(outcome.next, outcome.output);
+      },
     });
   }
 
@@ -83,7 +89,7 @@ export class SimStatesInterpreter {
   }
 
   /**
-   * Walk from one state until the execution ends or a `Wait` pauses it.
+   * Walk from one state until the execution ends or the clock pauses it.
    */
   async #walk(from: string, value: JSONValue): Promise<void> {
     let current = from;
@@ -102,12 +108,14 @@ export class SimStatesInterpreter {
       // oxlint-disable-next-line eslint/no-await-in-loop
       await this.#background.sequence();
 
-      const carrying = this.#resolve(
-        // One state at a time, since each one's input is what the state
-        // before it produced.
-        // oxlint-disable-next-line eslint/no-await-in-loop
-        await this.#runner.run(state, carried, current),
-      );
+      // One state at a time, since each one's input is what the state before
+      // it produced.
+      // oxlint-disable-next-line eslint/no-await-in-loop
+      const carrying = await this.#attempts.run({
+        name: current,
+        state,
+        input: carried,
+      });
 
       if (carrying === undefined) {
         return;
@@ -134,46 +142,5 @@ export class SimStatesInterpreter {
     }
 
     return state;
-  }
-
-  /**
-   * Settle what a state left to do, or schedule the rest of the walk.
-   *
-   * Answers with the outcome the walk carries on from, and with nothing where
-   * the execution has ended or is waiting on the clock.
-   */
-  #resolve(outcome: SimStatesStateOutcome): SimStatesNextOutcome | undefined {
-    if (outcome.kind === "wait") {
-      return this.#wait(outcome.until, outcome.resume);
-    }
-
-    return this.#settlement.settle(outcome);
-  }
-
-  /**
-   * Hold the execution until the clock reaches an instant.
-   *
-   * An instant already reached holds nothing up, and the walk carries straight
-   * on. Anything later is scheduled, and the execution is left `RUNNING` until
-   * simulated time gets there. Under a frozen clock that is for as long as the
-   * test leaves it.
-   */
-  #wait(
-    until: Date,
-    resume: SimStatesMoveOnOutcome,
-  ): SimStatesNextOutcome | undefined {
-    if (until.getTime() <= this.#background.now().getTime()) {
-      return this.#settlement.settle(resume);
-    }
-
-    this.#background.scheduleAt(until, async () => {
-      const carrying = this.#settlement.settle(resume);
-
-      if (carrying !== undefined) {
-        await this.#walk(carrying.next, carrying.output);
-      }
-    });
-
-    return undefined;
   }
 }

--- a/src/service/stepfunctions/execution/sim-states-state-attempts.ts
+++ b/src/service/stepfunctions/execution/sim-states-state-attempts.ts
@@ -1,0 +1,156 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import {
+  type SimStatesAttemptState,
+  simStatesFirstAttempt,
+} from "../retry/sim-states-attempt-state.js";
+import type { SimStatesSettlement } from "./sim-states-settlement.js";
+import type { SimStatesStateRunner } from "./sim-states-state-runner.js";
+import type {
+  SimStatesNextOutcome,
+  SimStatesWaitOutcome,
+} from "./sim-states-state-outcome.js";
+import type {
+  SimStatesStateEntry,
+  SimStatesWalkOn,
+} from "./sim-states-walk.js";
+
+/**
+ * The rest of one state's work, once the clock reaches what held it up.
+ */
+type SimStatesPausedWork = () => Promise<SimStatesNextOutcome | undefined>;
+
+interface SimStatesStateAttemptsProperties {
+  readonly runner: SimStatesStateRunner;
+  readonly settlement: SimStatesSettlement;
+  readonly background: BackgroundScheduler;
+
+  /**
+   * How the walk carries on from a state the clock held up.
+   */
+  readonly walkOn: SimStatesWalkOn;
+}
+
+/**
+ * Runs the attempts one state takes, and puts the ones it waits for on the
+ * clock.
+ *
+ * A `Wait` state and a `Retry` both hold the execution `RUNNING` until an
+ * instant, and both carry on from where they left off once the clock gets
+ * there. That is one job, and it is this one. The interpreter is left walking
+ * states.
+ */
+export class SimStatesStateAttempts {
+  readonly #settlement: SimStatesSettlement;
+  readonly #background: BackgroundScheduler;
+  readonly #runner: SimStatesStateRunner;
+  readonly #walkOn: SimStatesWalkOn;
+
+  constructor(properties: SimStatesStateAttemptsProperties) {
+    this.#runner = properties.runner;
+    this.#settlement = properties.settlement;
+    this.#background = properties.background;
+    this.#walkOn = properties.walkOn;
+  }
+
+  /**
+   * Run one state until it moves the walk on, ends the execution, or leaves it
+   * waiting on the clock.
+   *
+   * Answers with the outcome the walk carries on from, and with nothing where
+   * the execution has ended or is waiting.
+   */
+  async run(
+    entry: SimStatesStateEntry,
+  ): Promise<SimStatesNextOutcome | undefined> {
+    return await this.#from(
+      entry,
+      simStatesFirstAttempt(entry.state, this.#background.now()),
+    );
+  }
+
+  /**
+   * Run the attempts a state has left, from the one it is up to.
+   *
+   * An attempt due at an instant the clock has already reached holds nothing
+   * up, so those run round this loop instead of through the scheduler.
+   */
+  async #from(
+    entry: SimStatesStateEntry,
+    from: SimStatesAttemptState,
+  ): Promise<SimStatesNextOutcome | undefined> {
+    let attempt = from;
+
+    for (;;) {
+      // One attempt at a time, since each one is only made because the one
+      // before it failed.
+      // oxlint-disable-next-line eslint/no-await-in-loop
+      const outcome = await this.#runner.run(
+        entry.state,
+        entry.input,
+        entry.name,
+        attempt,
+      );
+
+      if (outcome.kind === "wait") {
+        return this.#waited(outcome);
+      }
+
+      if (outcome.kind !== "retry") {
+        return this.#settlement.settle(outcome);
+      }
+
+      if (this.#reached(outcome.until)) {
+        attempt = outcome.attempt;
+        continue;
+      }
+
+      this.#pause(outcome.until, async () =>
+        this.#from(entry, outcome.attempt),
+      );
+
+      return undefined;
+    }
+  }
+
+  /**
+   * Hold the execution until the clock reaches what a `Wait` state waits for.
+   *
+   * An instant already reached holds nothing up, and the walk carries straight
+   * on. Under a frozen clock anything later waits for as long as the test
+   * leaves it.
+   */
+  #waited(outcome: SimStatesWaitOutcome): SimStatesNextOutcome | undefined {
+    if (this.#reached(outcome.until)) {
+      return this.#settlement.settle(outcome.resume);
+    }
+
+    this.#pause(outcome.until, () =>
+      Promise.resolve(this.#settlement.settle(outcome.resume)),
+    );
+
+    return undefined;
+  }
+
+  /**
+   * Put the rest of one state's work on the clock, and the walk after it.
+   *
+   * One advance covering a whole backoff runs every attempt in it, because
+   * work this schedules is itself due by the time the advance reaches it.
+   */
+  #pause(until: Date, rest: SimStatesPausedWork): void {
+    this.#background.scheduleAt(until, async () => {
+      const carrying = await rest();
+
+      if (carrying !== undefined) {
+        await this.#walkOn(carrying);
+      }
+    });
+  }
+
+  /**
+   * Whether simulated time has got to an instant.
+   */
+  #reached(instant: Date): boolean {
+    return instant.getTime() <= this.#background.now().getTime();
+  }
+}

--- a/src/service/stepfunctions/execution/sim-states-state-outcome.ts
+++ b/src/service/stepfunctions/execution/sim-states-state-outcome.ts
@@ -1,4 +1,5 @@
 import type { JSONValue } from "../../../util/type-guard/json.js";
+import type { SimStatesAttemptState } from "../retry/sim-states-attempt-state.js";
 import type { SimStatesTaskTargets } from "../task/sim-states-task-invocation.js";
 
 /**
@@ -14,27 +15,44 @@ export type SimStatesMoveOnOutcome =
   | SimStatesNextOutcome
   | { readonly kind: "succeed"; readonly output: JSONValue };
 
+export interface SimStatesFailOutcome {
+  readonly kind: "fail";
+  readonly error: string;
+  readonly cause: string | undefined;
+}
+
 /**
- * What running one state did to the execution.
- *
- * A `wait` outcome carries what the execution does once the clock reaches the
- * instant, which is either the next state or the end of the execution.
+ * What running one state did to the execution, where it is over and done with.
  */
 export type SimStatesSettledOutcome =
   | SimStatesMoveOnOutcome
-  | {
-      readonly kind: "fail";
-      readonly error: string;
-      readonly cause: string | undefined;
-    };
+  | SimStatesFailOutcome;
+
+/**
+ * A state that failed and is being tried again at an instant on the clock.
+ *
+ * The attempt state goes with it, so the attempt the clock releases knows what
+ * has already been tried.
+ */
+export interface SimStatesRetryOutcome {
+  readonly kind: "retry";
+  readonly until: Date;
+  readonly attempt: SimStatesAttemptState;
+}
+
+/**
+ * A `Wait` state, holding the execution until an instant on the clock.
+ */
+export interface SimStatesWaitOutcome {
+  readonly kind: "wait";
+  readonly until: Date;
+  readonly resume: SimStatesMoveOnOutcome;
+}
 
 export type SimStatesStateOutcome =
   | SimStatesSettledOutcome
-  | {
-      readonly kind: "wait";
-      readonly until: Date;
-      readonly resume: SimStatesMoveOnOutcome;
-    };
+  | SimStatesRetryOutcome
+  | SimStatesWaitOutcome;
 
 /**
  * What a state knows about the execution it is running in.

--- a/src/service/stepfunctions/execution/sim-states-state-runner.ts
+++ b/src/service/stepfunctions/execution/sim-states-state-runner.ts
@@ -1,49 +1,117 @@
 import type { BackgroundScheduler } from "../../../util/background/background.js";
 import type { JSONValue } from "../../../util/type-guard/json.js";
 import type { SimStatesState } from "../definition/sim-states-state.js";
+import type { SimStatesAttemptState } from "../retry/sim-states-attempt-state.js";
+import { simStatesRecover } from "../retry/sim-states-recover.js";
+import { simStatesTimedOut } from "../retry/sim-states-task-deadline.js";
 import type { SimStatesTaskTargets } from "../task/sim-states-task-invocation.js";
+import type { SimStatesExecution } from "./sim-states-execution.js";
 import { simStatesFailureFrom } from "./sim-states-failure.js";
 import { runSimStatesState } from "./sim-states-run-state.js";
 import type { SimStatesStateOutcome } from "./sim-states-state-outcome.js";
 
 interface SimStatesStateRunnerProperties {
+  readonly execution: SimStatesExecution;
   readonly background: BackgroundScheduler;
   readonly tasks: SimStatesTaskTargets;
   readonly roleArn: string;
 }
 
 /**
- * Runs one state of an execution, and never raises.
+ * Runs one attempt at one state of an execution, and never raises.
  *
  * What a state knows about the execution it is running in is gathered here,
  * and so is reading the Amazon States Language error name off whatever a state
- * raised. Both leave the interpreter with the walk alone.
+ * raised. What a `Task` state's `Retry` and `Catch` make of that name is read
+ * here too, so a state that failed answers with what the execution does about
+ * it. All three leave the interpreter with the walk alone.
  */
 export class SimStatesStateRunner {
+  readonly #execution: SimStatesExecution;
   readonly #background: BackgroundScheduler;
   readonly #tasks: SimStatesTaskTargets;
   readonly #roleArn: string;
 
   constructor(properties: SimStatesStateRunnerProperties) {
+    this.#execution = properties.execution;
     this.#background = properties.background;
     this.#tasks = properties.tasks;
     this.#roleArn = properties.roleArn;
   }
 
   /**
-   * Run one state and say what happened, failure included.
+   * Run one attempt at a state and say what happened, failure included.
    */
   async run(
     state: SimStatesState,
     input: JSONValue,
     stateName: string,
+    attempt: SimStatesAttemptState,
   ): Promise<SimStatesStateOutcome> {
+    const ran = await this.#ran(state, input, stateName, attempt);
+
+    this.#execution.attempt(
+      stateName,
+      ran.kind === "fail" ? ran.error : undefined,
+    );
+
+    return this.#recovered(state, input, ran, attempt);
+  }
+
+  /**
+   * Run the state itself, or give up on it where its deadline has passed.
+   */
+  async #ran(
+    state: SimStatesState,
+    input: JSONValue,
+    stateName: string,
+    attempt: SimStatesAttemptState,
+  ): Promise<SimStatesStateOutcome> {
+    const overdue = simStatesTimedOut(
+      stateName,
+      attempt,
+      this.#background.now(),
+    );
+
+    if (overdue !== undefined) {
+      return overdue;
+    }
+
     try {
       return await runSimStatesState(state, input, {
         stateName,
         now: this.#background.now(),
         tasks: this.#tasks,
         roleArn: this.#roleArn,
+      });
+    } catch (error) {
+      return simStatesFailureFrom(error);
+    }
+  }
+
+  /**
+   * What the state's own `Retry` and `Catch` make of a failure.
+   *
+   * A catcher whose `ResultPath` has nowhere to write fails the execution the
+   * way any other data-flow field that cannot be applied does.
+   */
+  #recovered(
+    state: SimStatesState,
+    input: JSONValue,
+    ran: SimStatesStateOutcome,
+    attempt: SimStatesAttemptState,
+  ): SimStatesStateOutcome {
+    if (ran.kind !== "fail" || state.Type !== "Task") {
+      return ran;
+    }
+
+    try {
+      return simStatesRecover({
+        handling: state,
+        input,
+        failure: ran,
+        attempt,
+        now: this.#background.now(),
       });
     } catch (error) {
       return simStatesFailureFrom(error);

--- a/src/service/stepfunctions/execution/sim-states-walk.ts
+++ b/src/service/stepfunctions/execution/sim-states-walk.ts
@@ -1,0 +1,17 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import type { SimStatesState } from "../definition/sim-states-state.js";
+import type { SimStatesNextOutcome } from "./sim-states-state-outcome.js";
+
+/**
+ * One entry to one state, as the walk reaches it.
+ */
+export interface SimStatesStateEntry {
+  readonly name: string;
+  readonly state: SimStatesState;
+  readonly input: JSONValue;
+}
+
+/**
+ * How the rest of the walk carries on from a state the clock held up.
+ */
+export type SimStatesWalkOn = (outcome: SimStatesNextOutcome) => Promise<void>;

--- a/src/service/stepfunctions/index.ts
+++ b/src/service/stepfunctions/index.ts
@@ -12,6 +12,7 @@ export {
 export type { SimStateMachineLocation } from "./machine/sim-state-machine-arn.js";
 export { SimStatesExecution } from "./execution/sim-states-execution.js";
 export type { SimStatesExecutionStatus } from "./execution/sim-states-execution.js";
+export type { SimStatesAttempt } from "./execution/sim-states-attempt.js";
 export type { SimStatesDefinition } from "./definition/sim-states-definition.js";
 export {
   simStatesRunnableTypes,
@@ -25,6 +26,9 @@ export type {
   SimStatesWaitState,
 } from "./definition/sim-states-state.js";
 export { SimStatesChoiceRule } from "./choice/sim-states-choice-rule.js";
+export type { SimStatesCatcher } from "./retry/sim-states-catcher.js";
+export type { SimStatesRetrier } from "./retry/sim-states-retrier.js";
+export type { SimStatesTaskHandling } from "./retry/sim-states-task-handling.js";
 export {
   SimStateMachineAlreadyExists,
   SimStatesExecutionAlreadyExists,

--- a/src/service/stepfunctions/retry/sim-states-attempt-state.ts
+++ b/src/service/stepfunctions/retry/sim-states-attempt-state.ts
@@ -1,0 +1,60 @@
+import type { SimStatesState } from "../definition/sim-states-state.js";
+import {
+  type SimStatesTaskDeadline,
+  simStatesTaskDeadline,
+} from "./sim-states-task-deadline.js";
+
+/**
+ * What one entry to a state has tried so far.
+ *
+ * A retry carries this to the attempt it schedules, so the attempt knows how
+ * long the next wait is and when the state gives up. `taken` counts the
+ * retries each retrier has taken, since Amazon States Language counts them per
+ * retrier rather than per state.
+ */
+export interface SimStatesAttemptState {
+  readonly taken: readonly number[];
+  readonly deadline: SimStatesTaskDeadline | undefined;
+}
+
+/**
+ * The first attempt at a state, which has tried nothing yet.
+ *
+ * Only a `Task` state carries the fields that give it a deadline. Every other
+ * state runs once and answers.
+ */
+export function simStatesFirstAttempt(
+  state: SimStatesState,
+  now: Date,
+): SimStatesAttemptState {
+  return {
+    taken: [],
+    deadline: simStatesTaskDeadline(state.Type === "Task" ? state : {}, now),
+  };
+}
+
+/**
+ * How many retries one retrier has taken.
+ */
+export function simStatesRetriesTaken(
+  attempt: SimStatesAttemptState,
+  index: number,
+): number {
+  return attempt.taken.at(index) ?? 0;
+}
+
+/**
+ * The same attempt state with one more retry counted against a retrier.
+ */
+export function simStatesRetryTaken(
+  attempt: SimStatesAttemptState,
+  index: number,
+): SimStatesAttemptState {
+  return {
+    ...attempt,
+    taken: Array.from(
+      { length: Math.max(attempt.taken.length, index + 1) },
+      (_, at) => (attempt.taken.at(at) ?? 0) + (at === index ? 1 : 0),
+    ),
+  };
+}

--- a/src/service/stepfunctions/retry/sim-states-catch-outcome.ts
+++ b/src/service/stepfunctions/retry/sim-states-catch-outcome.ts
@@ -1,0 +1,41 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import type {
+  SimStatesFailOutcome,
+  SimStatesNextOutcome,
+} from "../execution/sim-states-state-outcome.js";
+import {
+  type SimStatesCatcher,
+  simStatesCaughtOutput,
+  simStatesErrorOutput,
+} from "./sim-states-catcher.js";
+import { simStatesErrorMatches } from "./sim-states-error-name.js";
+
+/**
+ * Where a catcher sends a failure it matches, carrying the error output.
+ *
+ * The catchers are tried in the order they were written and the first one
+ * naming the error takes it. A failure none of them names is left as it was.
+ */
+export function simStatesCatchOutcome(
+  catchers: readonly SimStatesCatcher[],
+  failure: SimStatesFailOutcome,
+  input: JSONValue,
+): SimStatesNextOutcome | undefined {
+  const catcher = catchers.find((entry) =>
+    simStatesErrorMatches(entry.ErrorEquals, failure.error),
+  );
+
+  if (catcher === undefined) {
+    return undefined;
+  }
+
+  return {
+    kind: "next",
+    next: catcher.Next,
+    output: simStatesCaughtOutput(
+      catcher,
+      input,
+      simStatesErrorOutput(failure.error, failure.cause),
+    ),
+  };
+}

--- a/src/service/stepfunctions/retry/sim-states-catch-parse.ts
+++ b/src/service/stepfunctions/retry/sim-states-catch-parse.ts
@@ -1,0 +1,77 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { parseSimStatesReferencePath } from "../data/sim-states-reference-path.js";
+import { SimStatesInvalidDefinition } from "../error/sim-step-functions.error.js";
+import type { SimStatesCatcher } from "./sim-states-catcher.js";
+import {
+  type SimStatesHandlerEntry,
+  readSimStatesHandlers,
+} from "./sim-states-error-equals.js";
+
+/**
+ * Read a `Task` state's `Catch`, refusing anything this cannot run.
+ *
+ * A catcher's `Next` is checked against the state machine's own states once
+ * every state has been read, alongside the other transitions. Answers with
+ * nothing where the state carries no `Catch`.
+ */
+export function parseSimStatesCatchers(
+  stateName: string,
+  state: Record<string, JSONValue>,
+): readonly SimStatesCatcher[] | undefined {
+  return readSimStatesHandlers(stateName, state, "Catch", "catcher")?.map(
+    (entry) => readCatcher(stateName, entry),
+  );
+}
+
+/**
+ * Read one catcher, which names where a failure it matches goes.
+ */
+function readCatcher(
+  stateName: string,
+  entry: SimStatesHandlerEntry,
+): SimStatesCatcher {
+  const next = entry.written["Next"];
+
+  if (typeof next !== "string") {
+    throw new SimStatesInvalidDefinition(
+      `A catcher in the Task state ${stateName} has no Next naming the ` +
+        "state a caught failure goes to.",
+    );
+  }
+
+  return {
+    ErrorEquals: entry.ErrorEquals,
+    Next: next,
+    ...resultPath(stateName, entry.written["ResultPath"]),
+  };
+}
+
+/**
+ * Read a catcher's `ResultPath`, which is where the error lands.
+ *
+ * The path is checked as far as its syntax here. Whether the input it is
+ * written into can hold it is only known once a failure is caught.
+ */
+function resultPath(
+  stateName: string,
+  written: JSONValue | undefined,
+): { ResultPath?: string | null } {
+  if (written === undefined) {
+    return {};
+  }
+
+  if (written === null) {
+    return { ResultPath: null };
+  }
+
+  if (typeof written !== "string") {
+    throw new SimStatesInvalidDefinition(
+      `A catcher in the Task state ${stateName} has a ResultPath that is ` +
+        "neither a Reference Path nor null.",
+    );
+  }
+
+  parseSimStatesReferencePath(written);
+
+  return { ResultPath: written };
+}

--- a/src/service/stepfunctions/retry/sim-states-catcher.ts
+++ b/src/service/stepfunctions/retry/sim-states-catcher.ts
@@ -1,0 +1,60 @@
+import type { JSONObject, JSONValue } from "../../../util/type-guard/json.js";
+import { parseSimStatesReferencePath } from "../data/sim-states-reference-path.js";
+import { insertAtSimStatesPath } from "../data/sim-states-result-path.js";
+
+/**
+ * One entry in a `Task` state's `Catch`.
+ *
+ * `Next` is where a caught failure sends the execution, and `ResultPath` says
+ * where in the state's input the error goes. A catcher left without one
+ * replaces the input with the error, which is what a `ResultPath` of `$` does.
+ */
+export interface SimStatesCatcher {
+  readonly ErrorEquals: readonly string[];
+  readonly Next: string;
+  readonly ResultPath?: string | null;
+}
+
+/**
+ * What a caught failure looks like to the state it is sent to.
+ *
+ * Amazon States Language calls this the error output, and it holds the error
+ * name and whatever the failure said about itself.
+ */
+export function simStatesErrorOutput(
+  error: string,
+  cause: string | undefined,
+): JSONObject {
+  return {
+    Error: error,
+    ...(cause !== undefined && { Cause: cause }),
+  };
+}
+
+/**
+ * The input the state a catcher names is given.
+ *
+ * `ResultPath` reads the raw input of the state that failed, so a catcher can
+ * put the error beside the data the task was working on. A `ResultPath` of
+ * `null` discards the error and passes the input on as it was.
+ */
+export function simStatesCaughtOutput(
+  catcher: SimStatesCatcher,
+  input: JSONValue,
+  error: JSONObject,
+): JSONValue {
+  if (catcher.ResultPath === null) {
+    return input;
+  }
+
+  if (catcher.ResultPath === undefined) {
+    return error;
+  }
+
+  return insertAtSimStatesPath(
+    input,
+    parseSimStatesReferencePath(catcher.ResultPath),
+    error,
+    catcher.ResultPath,
+  );
+}

--- a/src/service/stepfunctions/retry/sim-states-error-equals.ts
+++ b/src/service/stepfunctions/retry/sim-states-error-equals.ts
@@ -1,0 +1,129 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { isRecord } from "../../../util/type-guard/record.js";
+import { SimStatesInvalidDefinition } from "../error/sim-step-functions.error.js";
+import { simStatesAllErrors } from "./sim-states-error-name.js";
+
+/**
+ * One entry of a `Retry` or a `Catch`, as it was written.
+ */
+export interface SimStatesHandlerEntry {
+  readonly ErrorEquals: readonly string[];
+  readonly written: Record<string, JSONValue>;
+}
+
+/**
+ * Read the entries of a state's `Retry` or `Catch`.
+ *
+ * Both fields are an ordered array of entries, and both say what they handle
+ * the same way. What each entry then does with a match is what tells them
+ * apart, so that is read by the caller.
+ *
+ * Answers with nothing where the state carries neither field.
+ */
+export function readSimStatesHandlers(
+  stateName: string,
+  state: Record<string, JSONValue>,
+  field: "Retry" | "Catch",
+  noun: string,
+): readonly SimStatesHandlerEntry[] | undefined {
+  // The field is one of the two this reads.
+  // oxlint-disable-next-line security/detect-object-injection
+  const declared = state[field];
+
+  if (declared === undefined) {
+    return undefined;
+  }
+
+  if (!Array.isArray(declared)) {
+    throw new SimStatesInvalidDefinition(
+      `The ${field} of the Task state ${stateName} is not an array of ` +
+        `${noun}s.`,
+    );
+  }
+
+  const entries = declared.map((entry) =>
+    readEntry(stateName, field, noun, entry),
+  );
+
+  checkAllErrorsLast(stateName, field, noun, entries);
+
+  return entries;
+}
+
+/**
+ * Read one entry, whose `ErrorEquals` says what it handles.
+ */
+function readEntry(
+  stateName: string,
+  field: string,
+  noun: string,
+  entry: JSONValue,
+): SimStatesHandlerEntry {
+  if (!isRecord(entry)) {
+    throw new SimStatesInvalidDefinition(
+      `A ${noun} in the ${field} of the Task state ${stateName} is not an ` +
+        "object.",
+    );
+  }
+
+  const declared = entry["ErrorEquals"];
+  const named = Array.isArray(declared)
+    ? declared.filter((error) => typeof error === "string")
+    : [];
+
+  if (
+    !Array.isArray(declared) ||
+    named.length !== declared.length ||
+    named.length === 0
+  ) {
+    throw new SimStatesInvalidDefinition(
+      `A ${noun} in the ${field} of the Task state ${stateName} has no ` +
+        "ErrorEquals naming the errors it handles.",
+    );
+  }
+
+  checkAllErrorsAlone(stateName, field, noun, named);
+
+  return { ErrorEquals: named, written: entry };
+}
+
+/**
+ * `States.ALL` matches anything, so it names nothing alongside it.
+ */
+function checkAllErrorsAlone(
+  stateName: string,
+  field: string,
+  noun: string,
+  named: readonly string[],
+): void {
+  if (named.includes(simStatesAllErrors) && named.length > 1) {
+    throw new SimStatesInvalidDefinition(
+      `A ${noun} in the ${field} of the Task state ${stateName} names ` +
+        `${simStatesAllErrors} alongside ${named.filter((error) => error !== simStatesAllErrors).join(", ")}. ` +
+        `${simStatesAllErrors} matches anything, so it stands on its own.`,
+    );
+  }
+}
+
+/**
+ * `States.ALL` comes last, since nothing written after it could ever match.
+ */
+function checkAllErrorsLast(
+  stateName: string,
+  field: string,
+  noun: string,
+  entries: readonly SimStatesHandlerEntry[],
+): void {
+  const at = entries.findIndex((entry) =>
+    entry.ErrorEquals.includes(simStatesAllErrors),
+  );
+
+  if (at !== -1 && at < entries.length - 1) {
+    throw new SimStatesInvalidDefinition(
+      `The ${field} of the Task state ${stateName} names ` +
+        `${simStatesAllErrors} in a ${noun} that is not the last one. ` +
+        `${simStatesAllErrors} matches anything, so nothing after it could ` +
+        "ever be reached.",
+    );
+  }
+}

--- a/src/service/stepfunctions/retry/sim-states-error-name.ts
+++ b/src/service/stepfunctions/retry/sim-states-error-name.ts
@@ -1,0 +1,38 @@
+/**
+ * The name that matches whatever a state failed with.
+ */
+export const simStatesAllErrors = "States.ALL";
+
+/**
+ * The failure a task runs past its `TimeoutSeconds` or `HeartbeatSeconds` with.
+ */
+export const simStatesTimeoutError = "States.Timeout";
+
+/**
+ * The failure a state that could not run on the data it was given ends with.
+ *
+ * Real Step Functions neither retries nor catches this one, whatever a retrier
+ * names, and neither does this.
+ */
+export const simStatesRuntimeError = "States.Runtime";
+
+/**
+ * Whether one retrier's or catcher's `ErrorEquals` names an error.
+ *
+ * Amazon States Language matches on the error name alone, so a catcher naming
+ * `States.TaskFailed` catches a task that failed and leaves everything else to
+ * the catcher after it. `States.ALL` matches anything, apart from the one error
+ * nothing matches.
+ */
+export function simStatesErrorMatches(
+  errorEquals: readonly string[],
+  error: string,
+): boolean {
+  if (error === simStatesRuntimeError) {
+    return false;
+  }
+
+  return errorEquals.some(
+    (named) => named === simStatesAllErrors || named === error,
+  );
+}

--- a/src/service/stepfunctions/retry/sim-states-recover.ts
+++ b/src/service/stepfunctions/retry/sim-states-recover.ts
@@ -1,0 +1,53 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import type {
+  SimStatesFailOutcome,
+  SimStatesStateOutcome,
+} from "../execution/sim-states-state-outcome.js";
+import type { SimStatesAttemptState } from "./sim-states-attempt-state.js";
+import { simStatesCatchOutcome } from "./sim-states-catch-outcome.js";
+import { simStatesTimeoutError } from "./sim-states-error-name.js";
+import { simStatesRetryOutcome } from "./sim-states-retry-outcome.js";
+import type { SimStatesTaskHandling } from "./sim-states-task-handling.js";
+
+interface SimStatesRecoverProperties {
+  /**
+   * The `Retry` and `Catch` of the state that failed.
+   */
+  readonly handling: SimStatesTaskHandling;
+
+  /**
+   * The raw input the state was given, which is what a catcher's `ResultPath`
+   * writes the error into.
+   */
+  readonly input: JSONValue;
+
+  readonly failure: SimStatesFailOutcome;
+  readonly attempt: SimStatesAttemptState;
+  readonly now: Date;
+}
+
+/**
+ * What a state's `Retry` and `Catch` make of a failure.
+ *
+ * The retriers are tried first and the catchers after them. A failure neither
+ * retried nor caught is left as it was, and ends the execution.
+ *
+ * A task that ran out of time skips the retriers. The deadline covers the
+ * state and not one attempt at it, and another attempt would find the clock
+ * past it again.
+ */
+export function simStatesRecover(
+  properties: SimStatesRecoverProperties,
+): SimStatesStateOutcome {
+  const { attempt, failure, handling, input, now } = properties;
+  const retry =
+    failure.error === simStatesTimeoutError
+      ? undefined
+      : simStatesRetryOutcome(handling.Retry ?? [], failure, attempt, now);
+
+  return (
+    retry ??
+    simStatesCatchOutcome(handling.Catch ?? [], failure, input) ??
+    failure
+  );
+}

--- a/src/service/stepfunctions/retry/sim-states-retrier.ts
+++ b/src/service/stepfunctions/retry/sim-states-retrier.ts
@@ -1,0 +1,50 @@
+/**
+ * One entry in a `Task` state's `Retry`.
+ *
+ * The four fields that shape the wait are optional, and the defaults below are
+ * the ones Amazon States Language gives them.
+ */
+export interface SimStatesRetrier {
+  readonly ErrorEquals: readonly string[];
+  readonly IntervalSeconds?: number;
+  readonly MaxAttempts?: number;
+  readonly BackoffRate?: number;
+  readonly MaxDelaySeconds?: number;
+}
+
+/**
+ * What a retrier means where it says nothing.
+ *
+ * `MaxAttempts` counts retries rather than runs, so the default lets a task run
+ * four times: once, and then three more.
+ */
+export const simStatesRetryIntervalSeconds = 1;
+export const simStatesRetryMaxAttempts = 3;
+export const simStatesRetryBackoffRate = 2;
+
+/**
+ * How many retries one retrier allows.
+ */
+export function simStatesRetriesAllowed(retrier: SimStatesRetrier): number {
+  return retrier.MaxAttempts ?? simStatesRetryMaxAttempts;
+}
+
+/**
+ * How long to wait before the next retry this retrier takes.
+ *
+ * The wait grows by `BackoffRate` for each retry already taken, so the first
+ * one waits `IntervalSeconds` and each one after it waits longer.
+ * `MaxDelaySeconds` caps how long that can get.
+ */
+export function simStatesRetryDelaySeconds(
+  retrier: SimStatesRetrier,
+  taken: number,
+): number {
+  const interval = retrier.IntervalSeconds ?? simStatesRetryIntervalSeconds;
+  const backoff = retrier.BackoffRate ?? simStatesRetryBackoffRate;
+  const delay = interval * backoff ** taken;
+
+  return retrier.MaxDelaySeconds === undefined
+    ? delay
+    : Math.min(delay, retrier.MaxDelaySeconds);
+}

--- a/src/service/stepfunctions/retry/sim-states-retry-outcome.ts
+++ b/src/service/stepfunctions/retry/sim-states-retry-outcome.ts
@@ -1,0 +1,75 @@
+import type {
+  SimStatesFailOutcome,
+  SimStatesRetryOutcome,
+} from "../execution/sim-states-state-outcome.js";
+import {
+  type SimStatesAttemptState,
+  simStatesRetriesTaken,
+  simStatesRetryTaken,
+} from "./sim-states-attempt-state.js";
+import { simStatesErrorMatches } from "./sim-states-error-name.js";
+import {
+  type SimStatesRetrier,
+  simStatesRetriesAllowed,
+  simStatesRetryDelaySeconds,
+} from "./sim-states-retrier.js";
+
+const millisecondsInASecond = 1000;
+
+/**
+ * The next attempt a retrier asks for, where one matches and has attempts left.
+ *
+ * The retriers are tried in the order they were written and the first one
+ * naming the error takes it. Each keeps its own count, the way Amazon States
+ * Language counts them.
+ */
+export function simStatesRetryOutcome(
+  retriers: readonly SimStatesRetrier[],
+  failure: SimStatesFailOutcome,
+  attempt: SimStatesAttemptState,
+  now: Date,
+): SimStatesRetryOutcome | undefined {
+  const matched = retriers
+    .map((retrier, index) => ({ retrier, index }))
+    .find(({ retrier }) =>
+      simStatesErrorMatches(retrier.ErrorEquals, failure.error),
+    );
+
+  if (matched === undefined) {
+    return undefined;
+  }
+
+  const { retrier, index } = matched;
+  const taken = simStatesRetriesTaken(attempt, index);
+
+  if (taken >= simStatesRetriesAllowed(retrier)) {
+    return undefined;
+  }
+
+  return {
+    kind: "retry",
+    until: dueAt(retrier, taken, attempt, now),
+    attempt: simStatesRetryTaken(attempt, index),
+  };
+}
+
+/**
+ * When the next attempt runs.
+ *
+ * A wait running past the state's deadline is cut short at it. The task gives
+ * up when it said it would, and not at the attempt it never made.
+ */
+function dueAt(
+  retrier: SimStatesRetrier,
+  taken: number,
+  attempt: SimStatesAttemptState,
+  now: Date,
+): Date {
+  const delay = simStatesRetryDelaySeconds(retrier, taken);
+  const due = new Date(now.getTime() + delay * millisecondsInASecond);
+  const { deadline } = attempt;
+
+  return deadline !== undefined && deadline.at.getTime() < due.getTime()
+    ? deadline.at
+    : due;
+}

--- a/src/service/stepfunctions/retry/sim-states-retry-parse.ts
+++ b/src/service/stepfunctions/retry/sim-states-retry-parse.ts
@@ -1,0 +1,120 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import {
+  SimStatesInvalidDefinition,
+  SimStatesUnsimulatedInput,
+} from "../error/sim-step-functions.error.js";
+import { simStatesMaximumWaitSeconds } from "../wait/sim-states-wait-fields.js";
+import {
+  type SimStatesHandlerEntry,
+  readSimStatesHandlers,
+} from "./sim-states-error-equals.js";
+import type { SimStatesRetrier } from "./sim-states-retrier.js";
+
+/**
+ * The field of a retrier this simulator has no implementation for.
+ *
+ * Jitter spreads retries over the interval rather than taking all of it, and a
+ * simulated retry is one a test asserts a clock advance against. An interval
+ * that varies is one such a test cannot be written for.
+ */
+const jitterField = "JitterStrategy";
+
+/**
+ * Read a `Task` state's `Retry`, refusing anything this cannot run.
+ *
+ * The retriers are read when the state machine is created, so a `Task` state
+ * that runs is one whose intervals and attempt counts are already known to be
+ * good. Answers with nothing where the state carries no `Retry`.
+ */
+export function parseSimStatesRetriers(
+  stateName: string,
+  state: Record<string, JSONValue>,
+): readonly SimStatesRetrier[] | undefined {
+  return readSimStatesHandlers(stateName, state, "Retry", "retrier")?.map(
+    (entry) => readRetrier(stateName, entry),
+  );
+}
+
+/**
+ * Read one retrier's `ErrorEquals` and the four fields that shape its wait.
+ */
+function readRetrier(
+  stateName: string,
+  entry: SimStatesHandlerEntry,
+): SimStatesRetrier {
+  const { written } = entry;
+
+  if (Object.hasOwn(written, jitterField)) {
+    throw new SimStatesUnsimulatedInput(
+      `A retrier in the Task state ${stateName} carries ${jitterField}, ` +
+        "which this simulator does not run. Jitter makes the wait between " +
+        "attempts vary, and a test advancing a clock over that wait needs it " +
+        "not to.",
+    );
+  }
+
+  return {
+    ErrorEquals: entry.ErrorEquals,
+    ...wholeNumber(stateName, written, "IntervalSeconds", 1),
+    ...wholeNumber(stateName, written, "MaxDelaySeconds", 1),
+    ...wholeNumber(stateName, written, "MaxAttempts", 0),
+    ...backoffRate(stateName, written),
+  };
+}
+
+/**
+ * Read one of the three whole-number fields, where the retrier carries it.
+ */
+function wholeNumber(
+  stateName: string,
+  written: Record<string, JSONValue>,
+  field: "IntervalSeconds" | "MaxDelaySeconds" | "MaxAttempts",
+  least: number,
+): Record<string, number> {
+  // The field is one of the three named above.
+  // oxlint-disable-next-line security/detect-object-injection
+  const value = written[field];
+
+  if (value === undefined) {
+    return {};
+  }
+
+  if (
+    typeof value !== "number" ||
+    !Number.isSafeInteger(value) ||
+    value < least ||
+    value > simStatesMaximumWaitSeconds
+  ) {
+    throw new SimStatesInvalidDefinition(
+      `A retrier in the Task state ${stateName} has a ${field} of ` +
+        `${JSON.stringify(value)}. It is a whole number from ` +
+        `${String(least)} to ${String(simStatesMaximumWaitSeconds)}.`,
+    );
+  }
+
+  return { [field]: value };
+}
+
+/**
+ * Read `BackoffRate`, which multiplies the wait for each retry already taken.
+ */
+function backoffRate(
+  stateName: string,
+  written: Record<string, JSONValue>,
+): Record<string, number> {
+  const value = written["BackoffRate"];
+
+  if (value === undefined) {
+    return {};
+  }
+
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 1) {
+    throw new SimStatesInvalidDefinition(
+      `A retrier in the Task state ${stateName} has a BackoffRate of ` +
+        `${JSON.stringify(value)}. It is at least 1, since a wait that ` +
+        "shrank would retry faster the longer a failure went on.",
+    );
+  }
+
+  return { BackoffRate: value };
+}

--- a/src/service/stepfunctions/retry/sim-states-retry-refusals.iso.test.ts
+++ b/src/service/stepfunctions/retry/sim-states-retry-refusals.iso.test.ts
@@ -1,0 +1,164 @@
+import { assertStringIncludes, assertThrowsError } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import type { JSONObject } from "../../../util/type-guard/json.js";
+import { parseSimStatesDefinition } from "../definition/sim-states-definition-parse.js";
+
+describe("Step Functions Retry and Catch refusals", () => {
+  /**
+   * Read a definition whose one task carries the fields under test, and answer
+   * with why it was refused.
+   */
+  function refusalFor(fields: JSONObject): string {
+    return assertThrowsError(() =>
+      parseSimStatesDefinition(
+        JSON.stringify({
+          StartAt: "Check",
+          States: {
+            Check: {
+              Type: "Task",
+              Resource: "arn:aws:states:::lambda:invoke",
+              Parameters: { FunctionName: "check-enrolment" },
+              End: true,
+              ...fields,
+            },
+            Compensate: { Type: "Succeed" },
+          },
+        }),
+      ),
+    ).message;
+  }
+
+  it("refuses a Retry that is not an array of retriers", () => {
+    // Given a Retry written as one retrier rather than a list of them.
+    // When it is read, it says what the field is.
+    assertStringIncludes(
+      refusalFor({ Retry: { ErrorEquals: ["States.ALL"] } }),
+      "is not an array of retriers",
+    );
+    assertStringIncludes(
+      refusalFor({ Retry: ["States.ALL"] }),
+      "is not an object",
+    );
+  });
+
+  it("refuses an entry that says nothing about what it handles", () => {
+    // Given retriers and catchers whose ErrorEquals is missing or empty.
+    // When each is read, each names the field it needs.
+    assertStringIncludes(
+      refusalFor({ Retry: [{ IntervalSeconds: 2 }] }),
+      "has no ErrorEquals",
+    );
+    assertStringIncludes(
+      refusalFor({ Catch: [{ ErrorEquals: [], Next: "Compensate" }] }),
+      "has no ErrorEquals",
+    );
+  });
+
+  it("refuses States.ALL named alongside another error", () => {
+    // Given a retrier naming the wildcard and something the wildcard covers.
+    // When it is read, it says why the pair makes no sense.
+    assertStringIncludes(
+      refusalFor({
+        Retry: [{ ErrorEquals: ["States.TaskFailed", "States.ALL"] }],
+      }),
+      "stands on its own",
+    );
+  });
+
+  it("refuses States.ALL written ahead of another entry", () => {
+    // Given a catcher after one that already matches anything.
+    // When it is read, it says the one after it is unreachable.
+    assertStringIncludes(
+      refusalFor({
+        Catch: [
+          { ErrorEquals: ["States.ALL"], Next: "Compensate" },
+          { ErrorEquals: ["States.Timeout"], Next: "Compensate" },
+        ],
+      }),
+      "could ever be reached",
+    );
+  });
+
+  it("refuses the retrier field this simulator does not run", () => {
+    // Given a retrier asking for jitter.
+    // When it is read, it says why the interval has to be predictable.
+    assertStringIncludes(
+      refusalFor({
+        Retry: [{ ErrorEquals: ["States.ALL"], JitterStrategy: "FULL" }],
+      }),
+      "JitterStrategy",
+    );
+  });
+
+  it("refuses the numbers of a retrier that are outside what it takes", () => {
+    // Given each of the four numbers written as something a wait cannot be.
+    // When each is read, each names the field and its range.
+    for (const retrier of [
+      { IntervalSeconds: 0 },
+      { IntervalSeconds: 1.5 },
+      { MaxAttempts: -1 },
+      { MaxDelaySeconds: "20" },
+      { BackoffRate: 0.5 },
+    ]) {
+      assertStringIncludes(
+        refusalFor({ Retry: [{ ErrorEquals: ["States.ALL"], ...retrier }] }),
+        "A retrier in the Task state Check has a",
+      );
+    }
+  });
+
+  it("refuses a catcher that says nothing about where a failure goes", () => {
+    // Given a catcher with no Next, and one naming a state that is not there.
+    // When each is read, each says which it was.
+    assertStringIncludes(
+      refusalFor({ Catch: [{ ErrorEquals: ["States.ALL"] }] }),
+      "has no Next",
+    );
+    assertStringIncludes(
+      refusalFor({
+        Catch: [{ ErrorEquals: ["States.ALL"], Next: "Elsewhere" }],
+      }),
+      "not one of this state machine's states",
+    );
+  });
+
+  it("refuses a catcher whose ResultPath is not a Reference Path", () => {
+    // Given a ResultPath written as something else, and one written as a path
+    // this simulator does not read.
+    // When each is read, each is refused.
+    assertStringIncludes(
+      refusalFor({
+        Catch: [
+          { ErrorEquals: ["States.ALL"], Next: "Compensate", ResultPath: 3 },
+        ],
+      }),
+      "neither a Reference Path nor null",
+    );
+    assertStringIncludes(
+      refusalFor({
+        Catch: [
+          {
+            ErrorEquals: ["States.ALL"],
+            Next: "Compensate",
+            ResultPath: "$.errors[*]",
+          },
+        ],
+      }),
+      "$.errors[*]",
+    );
+  });
+
+  it("refuses a timeout that is not a whole number of seconds", () => {
+    // Given each of the two timeout fields written as something else.
+    // When each is read, each names the field and its range.
+    assertStringIncludes(
+      refusalFor({ TimeoutSeconds: 0 }),
+      "has a TimeoutSeconds of 0",
+    );
+    assertStringIncludes(
+      refusalFor({ HeartbeatSeconds: "30" }),
+      'has a HeartbeatSeconds of "30"',
+    );
+  });
+});

--- a/src/service/stepfunctions/retry/sim-states-task-deadline.ts
+++ b/src/service/stepfunctions/retry/sim-states-task-deadline.ts
@@ -1,0 +1,121 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { SimStatesInvalidDefinition } from "../error/sim-step-functions.error.js";
+import type { SimStatesFailOutcome } from "../execution/sim-states-state-outcome.js";
+import { simStatesMaximumWaitSeconds } from "../wait/sim-states-wait-fields.js";
+import type { SimStatesAttemptState } from "./sim-states-attempt-state.js";
+import { simStatesTimeoutError } from "./sim-states-error-name.js";
+
+const millisecondsInASecond = 1000;
+
+/**
+ * The two fields that say how long a `Task` state waits for its work.
+ */
+export const simStatesTaskTimeoutFields = [
+  "TimeoutSeconds",
+  "HeartbeatSeconds",
+] as const;
+
+/**
+ * How long a `Task` state waits before it gives up.
+ */
+export interface SimStatesTaskTimeouts {
+  readonly TimeoutSeconds?: number;
+  readonly HeartbeatSeconds?: number;
+}
+
+/**
+ * When a `Task` state stops waiting, and which field said so.
+ */
+export interface SimStatesTaskDeadline {
+  readonly at: Date;
+  readonly field: string;
+  readonly seconds: number;
+}
+
+/**
+ * The instant a `Task` state entered now gives up at.
+ *
+ * A state carrying both fields gives up at whichever comes first, and one
+ * carrying neither waits as long as its work takes. The deadline covers the
+ * state rather than one attempt at it, so the retries a task takes run against
+ * the same one.
+ */
+export function simStatesTaskDeadline(
+  timeouts: SimStatesTaskTimeouts,
+  now: Date,
+): SimStatesTaskDeadline | undefined {
+  const soonest = [
+    ...(timeouts.TimeoutSeconds === undefined
+      ? []
+      : [{ field: "TimeoutSeconds", seconds: timeouts.TimeoutSeconds }]),
+    ...(timeouts.HeartbeatSeconds === undefined
+      ? []
+      : [{ field: "HeartbeatSeconds", seconds: timeouts.HeartbeatSeconds }]),
+  ].toSorted((one, other) => one.seconds - other.seconds)[0];
+
+  if (soonest === undefined) {
+    return undefined;
+  }
+
+  return {
+    ...soonest,
+    at: new Date(now.getTime() + soonest.seconds * millisecondsInASecond),
+  };
+}
+
+/**
+ * The failure a task that has run past its deadline ends with.
+ *
+ * Answers with nothing while the clock is still inside it, which is every
+ * attempt at a state carrying neither timeout field.
+ */
+export function simStatesTimedOut(
+  stateName: string,
+  attempt: SimStatesAttemptState,
+  now: Date,
+): SimStatesFailOutcome | undefined {
+  const { deadline } = attempt;
+
+  if (deadline === undefined || now.getTime() < deadline.at.getTime()) {
+    return undefined;
+  }
+
+  return {
+    kind: "fail",
+    error: simStatesTimeoutError,
+    cause:
+      `The Task state ${stateName} ran past the ` +
+      `${String(deadline.seconds)} seconds its ${deadline.field} allows.`,
+  };
+}
+
+/**
+ * Check what a `Task` state's two timeout fields hold.
+ */
+export function checkSimStatesTaskTimeouts(
+  stateName: string,
+  state: Record<string, JSONValue>,
+): void {
+  for (const field of simStatesTaskTimeoutFields) {
+    // The field is one of the two named above.
+    // oxlint-disable-next-line security/detect-object-injection
+    const written = state[field];
+
+    if (written === undefined) {
+      continue;
+    }
+
+    if (
+      typeof written !== "number" ||
+      !Number.isSafeInteger(written) ||
+      written < 1 ||
+      written > simStatesMaximumWaitSeconds
+    ) {
+      throw new SimStatesInvalidDefinition(
+        `The Task state ${stateName} has a ${field} of ` +
+          `${JSON.stringify(written)}. It is a whole number of seconds from ` +
+          `1 to ${String(simStatesMaximumWaitSeconds)}.`,
+      );
+    }
+  }
+}

--- a/src/service/stepfunctions/retry/sim-states-task-handling.ts
+++ b/src/service/stepfunctions/retry/sim-states-task-handling.ts
@@ -1,0 +1,15 @@
+import type { SimStatesCatcher } from "./sim-states-catcher.js";
+import type { SimStatesRetrier } from "./sim-states-retrier.js";
+import type { SimStatesTaskTimeouts } from "./sim-states-task-deadline.js";
+
+/**
+ * What a `Task` state says about failing and about running long.
+ *
+ * The four fields sit together because they are read together: a task that
+ * fails is retried, then caught, and a task still going at its deadline fails
+ * whatever it was doing.
+ */
+export interface SimStatesTaskHandling extends SimStatesTaskTimeouts {
+  readonly Retry?: readonly SimStatesRetrier[];
+  readonly Catch?: readonly SimStatesCatcher[];
+}

--- a/src/service/stepfunctions/sim-step-functions-catch.iso.test.ts
+++ b/src/service/stepfunctions/sim-step-functions-catch.iso.test.ts
@@ -1,0 +1,269 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertObjectEquals,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { statesFlakyHandlerFactory } from "../../../test/stepfunctions/states-flaky-handler.factory.js";
+import { statesTaskExecutionFactory } from "../../../test/stepfunctions/states-task-execution.factory.js";
+import { statesTaskFunctionFactory } from "../../../test/stepfunctions/states-task-function.factory.js";
+import type { JSONObject } from "../../util/type-guard/json.js";
+import { SimAws } from "../aws/sim-aws.js";
+import type { SimDescribeExecutionCommandOutput } from "./command/execution/execution.command.js";
+
+describe("Simulated Step Functions Catch", () => {
+  /**
+   * An error of a workflow's own, as one a Catch names is written.
+   */
+  class NotEligible extends Error {
+    public override readonly name = "NotEligible";
+  }
+
+  /**
+   * The states a caught failure can be sent to, either of which ends the
+   * execution with what reaches it.
+   */
+  const compensating: JSONObject = {
+    Compensate: { Type: "Pass", End: true },
+    Decline: { Type: "Pass", Result: { declined: true }, End: true },
+  };
+
+  /**
+   * Run a workflow whose first state is the task under test, and read back how
+   * the execution ended.
+   */
+  async function runWorkflow(
+    simAws: SimAws,
+    task: JSONObject,
+    input = '{"student":"Wei"}',
+  ): Promise<{
+    readonly described: SimDescribeExecutionCommandOutput;
+    readonly executionArn: string;
+  }> {
+    const executionArn = await statesTaskExecutionFactory.make(
+      { task, states: compensating, input },
+      simAws,
+    );
+
+    return {
+      described: await simAws
+        .stepFunctions()
+        .describeExecution({ input: { executionArn } }),
+      executionArn,
+    };
+  }
+
+  /**
+   * A simulation holding a function that always raises.
+   */
+  async function givenAFailingFunction(): Promise<SimAws> {
+    const simAws = new SimAws();
+
+    await statesTaskFunctionFactory.make(
+      { handler: statesFlakyHandlerFactory.make({ failures: 10 }) },
+      simAws,
+    );
+
+    return simAws;
+  }
+
+  /**
+   * The task the tests below run, which invokes that function.
+   */
+  function invokeCheck(caught: JSONObject[]): JSONObject {
+    return {
+      Type: "Task",
+      Resource: "arn:aws:states:::lambda:invoke",
+      Parameters: { FunctionName: "check-enrolment", "Payload.$": "$" },
+      Catch: caught,
+      End: true,
+    };
+  }
+
+  it("sends a caught failure on, writing the error into the input", async () => {
+    // Given a workflow whose task compensates for its own failure.
+    const simAws = await givenAFailingFunction();
+
+    // When the task fails.
+    const { described, executionArn } = await runWorkflow(
+      simAws,
+      invokeCheck([
+        {
+          ErrorEquals: ["States.ALL"],
+          Next: "Compensate",
+          ResultPath: "$.error",
+        },
+      ]),
+    );
+
+    // Then the execution went on to the compensating branch, carrying the
+    // error beside the data the task was given.
+    assertIdentical(described.status, "SUCCEEDED");
+    assertObjectEquals(JSON.parse(described.output ?? "null") as unknown, {
+      student: "Wei",
+      error: {
+        Error: "States.TaskFailed",
+        Cause:
+          "The function the Task state Check invoked raised Error: the " +
+          "enrolment service is down",
+      },
+    });
+    assertObjectEquals(
+      simAws.stepFunctions().inspection().visitedStates(executionArn),
+      ["Check", "Compensate"],
+    );
+  });
+
+  it("catches a task whose retrier has run out of attempts", async () => {
+    // Given a task that is retried once and caught after that.
+    const simAws = await givenAFailingFunction();
+    const executionArn = await statesTaskExecutionFactory.make(
+      {
+        task: {
+          ...invokeCheck([{ ErrorEquals: ["States.ALL"], Next: "Compensate" }]),
+          Retry: [
+            {
+              ErrorEquals: ["States.TaskFailed"],
+              IntervalSeconds: 5,
+              MaxAttempts: 1,
+            },
+          ],
+        },
+        states: compensating,
+      },
+      simAws,
+    );
+
+    // When the clock passes the one retry it had.
+    await simAws.clock().advanceBy({ seconds: 10 });
+
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn } });
+
+    // Then the retries were spent first and the catcher took what was left.
+    assertIdentical(described.status, "SUCCEEDED");
+    assertArrayLength(
+      simAws.stepFunctions().inspection().attempts(executionArn),
+      3,
+    );
+    assertObjectEquals(
+      simAws.stepFunctions().inspection().visitedStates(executionArn),
+      ["Check", "Compensate"],
+    );
+  });
+
+  it("takes the first catcher that names the error", async () => {
+    // Given a function raising an error of the workflow's own, invoked
+    // through its ARN so the error keeps its name.
+    const simAws = new SimAws();
+    const check = await statesTaskFunctionFactory.make(
+      {
+        handler: statesFlakyHandlerFactory.make({
+          failures: 10,
+          raises: (): Error => new NotEligible("no place left"),
+        }),
+      },
+      simAws,
+    );
+
+    // When the task fails.
+    const { described } = await runWorkflow(simAws, {
+      Type: "Task",
+      Resource: check.arn,
+      Catch: [
+        { ErrorEquals: ["NotEligible"], Next: "Decline", ResultPath: null },
+        { ErrorEquals: ["States.ALL"], Next: "Compensate" },
+      ],
+      End: true,
+    });
+
+    // Then the catcher naming the handler's own error took it, and its
+    // ResultPath of null passed the input on as it was.
+    assertIdentical(described.status, "SUCCEEDED");
+    assertIdentical(described.output, '{"declined":true}');
+  });
+
+  it("replaces the input with the error where a catcher has no ResultPath", async () => {
+    // Given a catcher written without one.
+    const simAws = await givenAFailingFunction();
+
+    // When the task fails.
+    const { described } = await runWorkflow(
+      simAws,
+      invokeCheck([{ ErrorEquals: ["States.TaskFailed"], Next: "Compensate" }]),
+    );
+
+    // Then the state it goes to is given the error alone, which is what a
+    // ResultPath of $ does.
+    assertIdentical(described.status, "SUCCEEDED");
+    assertObjectEquals(
+      Object.keys(JSON.parse(described.output ?? "null") as object),
+      ["Error", "Cause"],
+    );
+  });
+
+  it("leaves a failure no catcher names to the execution", async () => {
+    // Given a catcher naming something else.
+    const simAws = await givenAFailingFunction();
+
+    // When the task fails.
+    const { described } = await runWorkflow(
+      simAws,
+      invokeCheck([
+        { ErrorEquals: ["ThrottlingException"], Next: "Compensate" },
+      ]),
+    );
+
+    // Then the execution ended at the task.
+    assertIdentical(described.status, "FAILED");
+    assertIdentical(described.error, "States.TaskFailed");
+  });
+
+  it("leaves a States.Runtime failure uncaught, whatever States.ALL says", async () => {
+    // Given a task reading the function to invoke out of its input, and an
+    // input holding a number there.
+    const simAws = await givenAFailingFunction();
+
+    // When the task cannot work out what to invoke.
+    const { described } = await runWorkflow(
+      simAws,
+      {
+        Type: "Task",
+        Resource: "arn:aws:states:::lambda:invoke",
+        Parameters: { "FunctionName.$": "$.checker", "Payload.$": "$" },
+        Catch: [{ ErrorEquals: ["States.ALL"], Next: "Compensate" }],
+        End: true,
+      },
+      '{"checker":42}',
+    );
+
+    // Then the execution failed rather than compensating. Real Step Functions
+    // neither retries nor catches this one.
+    assertIdentical(described.status, "FAILED");
+    assertIdentical(described.error, "States.Runtime");
+  });
+
+  it("fails the execution where a catcher's ResultPath has nowhere to write", async () => {
+    // Given a catcher writing the error into a field of a string.
+    const simAws = await givenAFailingFunction();
+
+    // When the task fails on an input the path cannot be written into.
+    const { described } = await runWorkflow(
+      simAws,
+      invokeCheck([
+        {
+          ErrorEquals: ["States.ALL"],
+          Next: "Compensate",
+          ResultPath: "$.student.error",
+        },
+      ]),
+    );
+
+    // Then the execution failed the way any other path that cannot be applied
+    // fails one, rather than the failure being swallowed.
+    assertIdentical(described.status, "FAILED");
+    assertIdentical(described.error, "States.ResultPathMatchFailure");
+  });
+});

--- a/src/service/stepfunctions/sim-step-functions-inspection.ts
+++ b/src/service/stepfunctions/sim-step-functions-inspection.ts
@@ -1,3 +1,4 @@
+import type { SimStatesAttempt } from "./execution/sim-states-attempt.js";
 import type { SimStatesExecutionStore } from "./execution/sim-states-execution-store.js";
 
 /**
@@ -20,6 +21,17 @@ export class SimStepFunctionsInspection {
    */
   visitedStates(executionArn: string): readonly string[] {
     return this.#executions.find(executionArn)?.visitedStates ?? [];
+  }
+
+  /**
+   * Every run of a state one execution made, in the order it made them.
+   *
+   * A state a `Retry` ran again appears once per attempt, so this says how many
+   * times a task ran where `visitedStates` says only that the execution reached
+   * it. Each attempt carries the error name it failed with, where it failed.
+   */
+  attempts(executionArn: string): readonly SimStatesAttempt[] {
+    return this.#executions.find(executionArn)?.attempts ?? [];
   }
 
   /**

--- a/src/service/stepfunctions/sim-step-functions-retry-matching.iso.test.ts
+++ b/src/service/stepfunctions/sim-step-functions-retry-matching.iso.test.ts
@@ -1,0 +1,205 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertObjectEquals,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { statesFlakyHandlerFactory } from "../../../test/stepfunctions/states-flaky-handler.factory.js";
+import { statesTaskExecutionFactory } from "../../../test/stepfunctions/states-task-execution.factory.js";
+import { statesTaskFunctionFactory } from "../../../test/stepfunctions/states-task-function.factory.js";
+import { SimFixedClock } from "../../util/clock/sim-clock.js";
+import type { JSONObject } from "../../util/type-guard/json.js";
+import { SimAws } from "../aws/sim-aws.js";
+
+describe("Which retrier takes a failing task", () => {
+  /**
+   * Two failures a workflow tells apart, as its own errors are written.
+   */
+  class Throttled extends Error {
+    public override readonly name = "Throttled";
+  }
+
+  class Unavailable extends Error {
+    public override readonly name = "Unavailable";
+  }
+
+  /**
+   * A simulation whose clock stands still, holding a function that raises a
+   * number of times before it answers.
+   */
+  async function givenAFlakyFunction(failures: number): Promise<SimAws> {
+    const simAws = new SimAws({
+      clock: new SimFixedClock(new Date("2026-07-26T09:00:00.000Z")),
+    });
+
+    await statesTaskFunctionFactory.make(
+      { handler: statesFlakyHandlerFactory.make({ failures }) },
+      simAws,
+    );
+
+    return simAws;
+  }
+
+  /**
+   * The task the tests below run, which invokes the flaky function.
+   */
+  function invokeCheck(retry: JSONObject[]): JSONObject {
+    return {
+      Type: "Task",
+      Resource: "arn:aws:states:::lambda:invoke",
+      Parameters: { FunctionName: "check-enrolment", "Payload.$": "$" },
+      Retry: retry,
+      End: true,
+    };
+  }
+
+  it("fails the execution once a retrier runs out of attempts", async () => {
+    // Given a function that never comes good, retried twice.
+    const simAws = await givenAFlakyFunction(10);
+    const executionArn = await statesTaskExecutionFactory.make(
+      {
+        task: invokeCheck([
+          {
+            ErrorEquals: ["States.TaskFailed"],
+            IntervalSeconds: 2,
+            MaxAttempts: 2,
+          },
+        ]),
+      },
+      simAws,
+    );
+
+    // When the clock passes every attempt it had left.
+    await simAws.clock().advanceBy({ minutes: 1 });
+
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn } });
+
+    // Then advancing the clock returned as it would for an execution that
+    // succeeded, and the failure is read off the execution.
+    assertIdentical(described.status, "FAILED");
+    assertIdentical(described.error, "States.TaskFailed");
+    assertArrayLength(
+      simAws.stepFunctions().inspection().attempts(executionArn),
+      3,
+    );
+  });
+
+  it("leaves a failure no retrier names to the execution", async () => {
+    // Given a retrier that names a throttled write, and a task that failed
+    // for another reason.
+    const simAws = await givenAFlakyFunction(10);
+    const executionArn = await statesTaskExecutionFactory.make(
+      {
+        task: invokeCheck([
+          { ErrorEquals: ["ThrottlingException"], IntervalSeconds: 2 },
+        ]),
+      },
+      simAws,
+    );
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn } });
+
+    // Then the task ran once and the execution ended there.
+    assertIdentical(described.status, "FAILED");
+    assertIdentical(described.error, "States.TaskFailed");
+    assertArrayLength(
+      simAws.stepFunctions().inspection().attempts(executionArn),
+      1,
+    );
+  });
+
+  it("takes the first retrier that names the error", async () => {
+    // Given a retrier that does not match ahead of one that does.
+    const simAws = await givenAFlakyFunction(1);
+    const executionArn = await statesTaskExecutionFactory.make(
+      {
+        task: invokeCheck([
+          { ErrorEquals: ["ThrottlingException"], IntervalSeconds: 300 },
+          { ErrorEquals: ["States.ALL"], IntervalSeconds: 2 },
+        ]),
+      },
+      simAws,
+    );
+
+    // When the clock passes the second retrier's interval alone.
+    await simAws.clock().advanceBy({ seconds: 3 });
+
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn } });
+
+    // Then the retry waited the two seconds the matching retrier asked for
+    // rather than the five minutes of the one above it.
+    assertIdentical(described.status, "SUCCEEDED");
+    assertIdentical(
+      described.stopDate?.toISOString(),
+      "2026-07-26T09:00:02.000Z",
+    );
+  });
+
+  it("counts a retrier's attempts against that retrier alone", async () => {
+    // Given a task that fails one way and then another, each named by its own
+    // retrier. The function ARN form reports a handler's error type, so the
+    // two failures reach the retriers under different names.
+    const simAws = new SimAws({
+      clock: new SimFixedClock(new Date("2026-07-26T09:00:00.000Z")),
+    });
+    const check = await statesTaskFunctionFactory.make(
+      {
+        handler: statesFlakyHandlerFactory.make({
+          failures: 2,
+          raises: (call): Error =>
+            call === 1
+              ? new Throttled("the enrolment service is busy")
+              : new Unavailable("the enrolment service is down"),
+        }),
+      },
+      simAws,
+    );
+    const executionArn = await statesTaskExecutionFactory.make(
+      {
+        task: {
+          Type: "Task",
+          Resource: check.arn,
+          Retry: [
+            { ErrorEquals: ["Throttled"], IntervalSeconds: 2, MaxAttempts: 1 },
+            {
+              ErrorEquals: ["Unavailable"],
+              IntervalSeconds: 4,
+              MaxAttempts: 1,
+            },
+          ],
+          End: true,
+        },
+      },
+      simAws,
+    );
+
+    // When the clock passes both waits.
+    await simAws.clock().advanceBy({ minutes: 1 });
+
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn } });
+
+    // Then each retrier spent its own single attempt, so the task ran three
+    // times: two seconds after the first failure and four after the second.
+    assertIdentical(described.status, "SUCCEEDED");
+    assertIdentical(
+      described.stopDate?.toISOString(),
+      "2026-07-26T09:00:06.000Z",
+    );
+    assertObjectEquals(
+      simAws.stepFunctions().inspection().attempts(executionArn),
+      [
+        { stateName: "Check", error: "Throttled" },
+        { stateName: "Check", error: "Unavailable" },
+        { stateName: "Check" },
+      ],
+    );
+  });
+});

--- a/src/service/stepfunctions/sim-step-functions-retry.iso.test.ts
+++ b/src/service/stepfunctions/sim-step-functions-retry.iso.test.ts
@@ -1,0 +1,180 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertObjectEquals,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { statesFlakyHandlerFactory } from "../../../test/stepfunctions/states-flaky-handler.factory.js";
+import { statesTaskExecutionFactory } from "../../../test/stepfunctions/states-task-execution.factory.js";
+import { statesTaskFunctionFactory } from "../../../test/stepfunctions/states-task-function.factory.js";
+import { SimFixedClock } from "../../util/clock/sim-clock.js";
+import type { JSONObject } from "../../util/type-guard/json.js";
+import { SimAws } from "../aws/sim-aws.js";
+
+describe("Simulated Step Functions Retry on the clock", () => {
+  /**
+   * A simulation whose clock stands still, holding a function that raises a
+   * number of times before it answers.
+   */
+  async function givenAFlakyFunction(failures: number): Promise<SimAws> {
+    const simAws = new SimAws({
+      clock: new SimFixedClock(new Date("2026-07-26T09:00:00.000Z")),
+    });
+
+    await statesTaskFunctionFactory.make(
+      { handler: statesFlakyHandlerFactory.make({ failures }) },
+      simAws,
+    );
+
+    return simAws;
+  }
+
+  /**
+   * The task the tests below run, which invokes the flaky function.
+   */
+  function invokeCheck(retry: JSONObject[]): JSONObject {
+    return {
+      Type: "Task",
+      Resource: "arn:aws:states:::lambda:invoke",
+      Parameters: { FunctionName: "check-enrolment", "Payload.$": "$" },
+      Retry: retry,
+      End: true,
+    };
+  }
+
+  it("runs a task again until it answers, and records every attempt", async () => {
+    // Given a function that raises twice and then answers.
+    const simAws = await givenAFlakyFunction(2);
+    const executionArn = await statesTaskExecutionFactory.make(
+      {
+        task: invokeCheck([
+          { ErrorEquals: ["States.TaskFailed"], IntervalSeconds: 2 },
+        ]),
+      },
+      simAws,
+    );
+
+    // When one advance covers the whole backoff.
+    await simAws.clock().advanceBy({ seconds: 10 });
+
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn } });
+
+    // Then the execution succeeded on the third attempt, which ran six
+    // seconds in: two for the first retry and four for the second.
+    assertIdentical(described.status, "SUCCEEDED");
+    assertIdentical(
+      described.stopDate?.toISOString(),
+      "2026-07-26T09:00:06.000Z",
+    );
+    assertObjectEquals(
+      simAws.stepFunctions().inspection().attempts(executionArn),
+      [
+        { stateName: "Check", error: "States.TaskFailed" },
+        { stateName: "Check", error: "States.TaskFailed" },
+        { stateName: "Check" },
+      ],
+    );
+  });
+
+  it("retries on the defaults where a retrier names only the error", async () => {
+    // Given a retrier written as Amazon States Language allows the shortest
+    // one to be, which waits a second and doubles from there.
+    const simAws = await givenAFlakyFunction(2);
+    const executionArn = await statesTaskExecutionFactory.make(
+      { task: invokeCheck([{ ErrorEquals: ["States.TaskFailed"] }]) },
+      simAws,
+    );
+
+    // When the clock passes both waits.
+    await simAws.clock().advanceBy({ seconds: 10 });
+
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn } });
+
+    // Then the third attempt ran three seconds in: one for the first retry
+    // and two for the second.
+    assertIdentical(described.status, "SUCCEEDED");
+    assertIdentical(
+      described.stopDate?.toISOString(),
+      "2026-07-26T09:00:03.000Z",
+    );
+  });
+
+  it("leaves the execution RUNNING between one attempt and the next", async () => {
+    // Given a workflow whose second retry falls six seconds in.
+    const simAws = await givenAFlakyFunction(2);
+    const executionArn = await statesTaskExecutionFactory.make(
+      {
+        task: invokeCheck([
+          { ErrorEquals: ["States.TaskFailed"], IntervalSeconds: 2 },
+        ]),
+      },
+      simAws,
+    );
+
+    // When the clock stops partway through the backoff.
+    await simAws.clock().advanceBy({ seconds: 3 });
+
+    const between = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn } });
+
+    // Then the execution is waiting for the attempt it has not reached, in a
+    // state it entered once.
+    assertIdentical(between.status, "RUNNING");
+    assertArrayLength(
+      simAws.stepFunctions().inspection().attempts(executionArn),
+      2,
+    );
+    assertObjectEquals(
+      simAws.stepFunctions().inspection().visitedStates(executionArn),
+      ["Check"],
+    );
+
+    // And the rest of the backoff finishes it.
+    await simAws.clock().advanceBy({ seconds: 5 });
+
+    const settled = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn } });
+
+    assertIdentical(settled.status, "SUCCEEDED");
+  });
+
+  it("caps the wait between attempts at MaxDelaySeconds", async () => {
+    // Given a retrier whose backoff would reach a hundred seconds untouched.
+    const simAws = await givenAFlakyFunction(2);
+    const executionArn = await statesTaskExecutionFactory.make(
+      {
+        task: invokeCheck([
+          {
+            ErrorEquals: ["States.ALL"],
+            IntervalSeconds: 10,
+            BackoffRate: 10,
+            MaxDelaySeconds: 20,
+          },
+        ]),
+      },
+      simAws,
+    );
+
+    // When the clock passes the whole backoff.
+    await simAws.clock().advanceBy({ minutes: 5 });
+
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn } });
+
+    // Then the second wait was the cap rather than the hundred seconds the
+    // rate asked for, so the third attempt ran thirty seconds in.
+    assertIdentical(described.status, "SUCCEEDED");
+    assertIdentical(
+      described.stopDate?.toISOString(),
+      "2026-07-26T09:00:30.000Z",
+    );
+  });
+});

--- a/src/service/stepfunctions/sim-step-functions-task-timeout.iso.test.ts
+++ b/src/service/stepfunctions/sim-step-functions-task-timeout.iso.test.ts
@@ -1,0 +1,174 @@
+import {
+  assertIdentical,
+  assertObjectEquals,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { statesFlakyHandlerFactory } from "../../../test/stepfunctions/states-flaky-handler.factory.js";
+import { statesTaskExecutionFactory } from "../../../test/stepfunctions/states-task-execution.factory.js";
+import { statesTaskFunctionFactory } from "../../../test/stepfunctions/states-task-function.factory.js";
+import { SimFixedClock } from "../../util/clock/sim-clock.js";
+import type { JSONObject } from "../../util/type-guard/json.js";
+import { SimAws } from "../aws/sim-aws.js";
+import type { SimDescribeExecutionCommandOutput } from "./command/execution/execution.command.js";
+
+describe("How long a Task state waits", () => {
+  const startedAt = "2026-07-26T09:00:00.000Z";
+
+  /**
+   * A simulation whose clock stands still, holding a function that raises a
+   * number of times before it answers.
+   */
+  async function givenAFlakyFunction(failures: number): Promise<SimAws> {
+    const simAws = new SimAws({
+      clock: new SimFixedClock(new Date(startedAt)),
+    });
+
+    await statesTaskFunctionFactory.make(
+      { handler: statesFlakyHandlerFactory.make({ failures }) },
+      simAws,
+    );
+
+    return simAws;
+  }
+
+  /**
+   * Run a workflow of one task, then move the clock well past everything the
+   * task could be waiting for.
+   */
+  async function runPastTheDeadline(
+    failures: number,
+    task: JSONObject,
+  ): Promise<SimDescribeExecutionCommandOutput> {
+    const simAws = await givenAFlakyFunction(failures);
+    const executionArn = await statesTaskExecutionFactory.make(
+      { task },
+      simAws,
+    );
+
+    await simAws.clock().advanceBy({ minutes: 5 });
+
+    return await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn } });
+  }
+
+  /**
+   * The task the tests below run, retried often enough to outlast a deadline.
+   */
+  function invokeCheck(waiting: JSONObject): JSONObject {
+    return {
+      Type: "Task",
+      Resource: "arn:aws:states:::lambda:invoke",
+      Parameters: { FunctionName: "check-enrolment", "Payload.$": "$" },
+      Retry: [
+        { ErrorEquals: ["States.ALL"], IntervalSeconds: 10, BackoffRate: 1 },
+      ],
+      ...waiting,
+      End: true,
+    };
+  }
+
+  it("gives up on a task that has run past its TimeoutSeconds", async () => {
+    // Given a task retried every ten seconds, allowed fifteen in all.
+    // When the clock passes that.
+    const described = await runPastTheDeadline(
+      10,
+      invokeCheck({
+        TimeoutSeconds: 15,
+      }),
+    );
+
+    // Then the task gave up at the instant it said it would, rather than at
+    // the attempt due after it.
+    assertIdentical(described.status, "FAILED");
+    assertIdentical(described.error, "States.Timeout");
+    assertIdentical(
+      described.stopDate?.toISOString(),
+      "2026-07-26T09:00:15.000Z",
+    );
+    assertStringIncludes(described.cause ?? "", "TimeoutSeconds");
+  });
+
+  it("gives up on a task nothing has sent a heartbeat for", async () => {
+    // Given a task carrying both fields, the heartbeat being the shorter.
+    // When the clock passes that.
+    const described = await runPastTheDeadline(
+      10,
+      invokeCheck({
+        TimeoutSeconds: 60,
+        HeartbeatSeconds: 25,
+      }),
+    );
+
+    // Then it gave up at whichever of the two came first, and says which.
+    assertIdentical(described.error, "States.Timeout");
+    assertIdentical(
+      described.stopDate?.toISOString(),
+      "2026-07-26T09:00:25.000Z",
+    );
+    assertStringIncludes(described.cause ?? "", "HeartbeatSeconds");
+  });
+
+  it("sends a timed out task to its Catch", async () => {
+    // Given a task that compensates for running long.
+    const simAws = await givenAFlakyFunction(10);
+    const executionArn = await statesTaskExecutionFactory.make(
+      {
+        task: {
+          ...invokeCheck({ TimeoutSeconds: 15 }),
+          Catch: [
+            {
+              ErrorEquals: ["States.Timeout"],
+              Next: "Compensate",
+              ResultPath: "$.error",
+            },
+          ],
+        },
+        states: { Compensate: { Type: "Pass", End: true } },
+      },
+      simAws,
+    );
+
+    // When the clock passes the deadline.
+    await simAws.clock().advanceBy({ minutes: 5 });
+
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn } });
+
+    // Then the catcher took it, and the retrier did not start the task again
+    // after the attempt that found the deadline behind it.
+    assertIdentical(described.status, "SUCCEEDED");
+    assertStringIncludes(described.output ?? "", '"Error":"States.Timeout"');
+    assertObjectEquals(
+      simAws.stepFunctions().inspection().attempts(executionArn),
+      [
+        { stateName: "Check", error: "States.TaskFailed" },
+        { stateName: "Check", error: "States.TaskFailed" },
+        { stateName: "Check", error: "States.Timeout" },
+        { stateName: "Compensate" },
+      ],
+    );
+  });
+
+  it("leaves a task that answers inside its deadline alone", async () => {
+    // Given a task that fails once and answers on the retry, well inside the
+    // minute it is allowed.
+    // When the clock passes that retry.
+    const described = await runPastTheDeadline(
+      1,
+      invokeCheck({
+        TimeoutSeconds: 60,
+      }),
+    );
+
+    // Then the deadline had nothing to do with how the task ended.
+    assertIdentical(described.status, "SUCCEEDED");
+    assertIdentical(
+      described.stopDate?.toISOString(),
+      "2026-07-26T09:00:10.000Z",
+    );
+  });
+});

--- a/src/service/stepfunctions/task/sim-states-task-fields.ts
+++ b/src/service/stepfunctions/task/sim-states-task-fields.ts
@@ -1,25 +1,23 @@
 import type { JSONValue } from "../../../util/type-guard/json.js";
 import { SimStatesUnsimulatedInput } from "../error/sim-step-functions.error.js";
+import { checkSimStatesTaskTimeouts } from "../retry/sim-states-task-deadline.js";
 
 /**
  * The fields of a `Task` state this simulator has no implementation for.
  */
 export const simStatesTaskFieldsUnsimulated = [
-  "Retry",
-  "Catch",
-  "TimeoutSeconds",
   "TimeoutSecondsPath",
-  "HeartbeatSeconds",
   "HeartbeatSecondsPath",
   "Credentials",
 ] as const;
 
 /**
- * Refuse the fields of a `Task` state this simulator does not run.
+ * Check the fields of a `Task` state that are not about what it invokes.
  *
- * A definition carrying one of them would behave differently here than it does
- * on AWS. A task that failed would end the execution rather than being retried,
- * and a task that ran long would answer rather than time out.
+ * The two fields that read a timeout out of the input are refused. A definition
+ * carrying one of them would behave differently here than it does on AWS: the
+ * task would run to whatever its handler answered rather than giving up when
+ * the input said to.
  */
 export function checkSimStatesTaskFields(
   stateName: string,
@@ -32,8 +30,10 @@ export function checkSimStatesTaskFields(
   if (present.length > 0) {
     throw new SimStatesUnsimulatedInput(
       `The Task state ${stateName} carries ${present.join(", ")}, which this ` +
-        "simulator does not run yet. A task that fails ends the execution, " +
-        "and a task that runs long runs to whatever its handler answers.",
+        "simulator does not run yet. TimeoutSeconds and HeartbeatSeconds " +
+        "say the same thing in the definition rather than in the input.",
     );
   }
+
+  checkSimStatesTaskTimeouts(stateName, state);
 }

--- a/src/service/stepfunctions/task/sim-states-task-refusals.iso.test.ts
+++ b/src/service/stepfunctions/task/sim-states-task-refusals.iso.test.ts
@@ -52,20 +52,20 @@ describe("Step Functions Task state refusals", () => {
         Type: "Task",
         Resource: "arn:aws:states:::lambda:invoke",
         Parameters: { FunctionName: "check-enrolment" },
-        Retry: [{ ErrorEquals: ["States.TaskFailed"], MaxAttempts: 2 }],
+        TimeoutSecondsPath: "$.allowed",
         End: true,
       }),
-      "carries Retry",
+      "carries TimeoutSecondsPath",
     );
     assertStringIncludes(
       refusalForTask({
         Type: "Task",
         Resource: "arn:aws:states:::lambda:invoke",
         Parameters: { FunctionName: "check-enrolment" },
-        TimeoutSeconds: 30,
+        Credentials: { RoleArn: "arn:aws:iam::123456789012:role/Other" },
         End: true,
       }),
-      "carries TimeoutSeconds",
+      "carries Credentials",
     );
   });
 

--- a/test/stepfunctions/states-flaky-handler.factory.ts
+++ b/test/stepfunctions/states-flaky-handler.factory.ts
@@ -1,0 +1,60 @@
+import { MappedFactory } from "@kensio/part-factory";
+
+import type { SimLambdaHandler } from "../../src/service/lambda/function/sim-lambda-handler.type.js";
+
+/**
+ * What a `Retry` test asks for when it wants a function that fails and then
+ * comes good.
+ */
+export interface StatesFlakyHandlerInput {
+  /**
+   * How many of the first calls raise. A handler given more failures than the
+   * retriers allow attempts never answers at all.
+   */
+  readonly failures: number;
+
+  /**
+   * What one of those calls raises, given which call it is counting from one.
+   * A function failing two ways in turn is written here.
+   */
+  readonly raises: (call: number) => Error;
+
+  /**
+   * What the first call that does not raise answers with.
+   */
+  readonly answers: unknown;
+}
+
+/**
+ * Creates a Lambda handler that raises a number of times before it answers.
+ *
+ * ```typescript
+ * const handler = statesFlakyHandlerFactory.make({ failures: 2 });
+ * ```
+ *
+ * Each handler counts its own calls, so two tests sharing this factory are not
+ * sharing a count.
+ */
+export const statesFlakyHandlerFactory = new MappedFactory<
+  StatesFlakyHandlerInput,
+  SimLambdaHandler
+>(
+  () => ({
+    failures: 1,
+    raises: (): Error => new Error("the enrolment service is down"),
+    answers: { eligible: true },
+  }),
+  (input) => {
+    let called = 0;
+
+    return (): unknown => {
+      called += 1;
+
+      if (called <= input.failures) {
+        throw input.raises(called);
+      }
+
+      return input.answers;
+    };
+  },
+);

--- a/test/stepfunctions/states-task-execution.factory.ts
+++ b/test/stepfunctions/states-task-execution.factory.ts
@@ -1,0 +1,68 @@
+import { AsyncMappedFactory } from "@kensio/part-factory";
+
+import type { SimAws } from "../../src/service/aws/sim-aws.js";
+import type { JSONObject } from "../../src/util/type-guard/json.js";
+import { statesExecutionRoleFactory } from "./states-execution-role.factory.js";
+import { statesMachineFactory } from "./states-machine.factory.js";
+
+/**
+ * What a `Task` state test asks for when it wants an execution of a workflow
+ * built around one task.
+ */
+export interface StatesTaskExecutionInput {
+  /**
+   * The task, which the execution starts at under the name `Check`.
+   */
+  readonly task: JSONObject;
+
+  /**
+   * The states the task can move on to, written as Amazon States Language.
+   */
+  readonly states: JSONObject;
+
+  /**
+   * The execution input, as the JSON string `StartExecution` takes.
+   */
+  readonly input: string;
+}
+
+/**
+ * Creates a state machine of one task, starts an execution of it, and answers
+ * with the execution ARN.
+ *
+ * ```typescript
+ * const executionArn = await statesTaskExecutionFactory.make(
+ *   { task: { Type: "Task", Resource: check.arn, End: true } },
+ *   simAws,
+ * );
+ * ```
+ *
+ * The execution role is one that may invoke anything, since a test about what
+ * a task does when it fails is not a test about what its role is allowed.
+ */
+export const statesTaskExecutionFactory = new AsyncMappedFactory<
+  StatesTaskExecutionInput,
+  string,
+  SimAws
+>(
+  () => ({
+    task: { Type: "Succeed" },
+    states: {},
+    input: '{"student":"Wei"}',
+  }),
+  async (input, simAws) => {
+    const stateMachineArn = await statesMachineFactory.make(
+      {
+        roleArn: await statesExecutionRoleFactory.make({}, simAws),
+        startAt: "Check",
+        states: { Check: input.task, ...input.states },
+      },
+      simAws,
+    );
+    const started = await simAws
+      .stepFunctions()
+      .startExecution({ input: { stateMachineArn, input: input.input } });
+
+    return started.executionArn;
+  },
+);


### PR DESCRIPTION
A `Task` state's `Retry` runs a failing task again on the simulation's clock,
and its `Catch` sends a failure the retries did not fix to another state. Each
attempt is scheduled at its own instant and the execution reads as `RUNNING`
between them, so one `advanceBy` covering the backoff walks every attempt in
it. `ErrorEquals`, `IntervalSeconds`, `MaxAttempts`, `BackoffRate` and
`MaxDelaySeconds` are all read, retriers and catchers are tried in the order
they were written, and `States.ALL` matches anything. A catcher's `ResultPath`
writes `Error` and `Cause` into the state's input. `TimeoutSeconds` and
`HeartbeatSeconds` fail a task with `States.Timeout` once simulated time
reaches the deadline, which covers the state with its retries in it. The
inspection accessor gained `attempts`, which reports every run of every state
and the error each one ended with.

Two departures from real Step Functions are documented in the README. The
timeout covers the whole state rather than each attempt, because an attempt
here takes no simulated time by itself and a per-attempt deadline would never
be reached. `JitterStrategy` is refused, since a test advancing a clock over a
backoff needs the interval fixed. `Retry` and `Catch` on `Parallel` and `Map`
are left to https://github.com/KensioSoftware/yulin/issues/921.

Resolves https://github.com/KensioSoftware/yulin/issues/920
